### PR TITLE
better #430 fix (missing match capture type asserted)

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -142,6 +142,11 @@ static bool is_valid_pattern(pass_opt_t* opt, ast_t* pattern)
 
         return false;
       }
+      if(ast_id(capture_type) == TK_NONE)
+      {
+        ast_error(pattern, "can't capture a type without a type declaration");
+        return false;
+      }
 
       // Set the pattern type to be the capture type.
       ast_settype(pattern, capture_type);

--- a/test/libponyc/parse_expr.cc
+++ b/test/libponyc/parse_expr.cc
@@ -4,7 +4,7 @@
 
 // Parsing tests regarding expressions
 
-#define TEST_AST(src, expect) DO(test_program_ast(src, "syntax", expect))
+#define TEST_AST(src, expect) DO(test_equiv(src,"syntax",expect,"syntax"))
 #define TEST_ERROR(src) DO(test_error(src, "syntax"))
 #define TEST_COMPILE(src) DO(test_compile(src, "syntax"))
 
@@ -244,4 +244,17 @@ TEST_F(ParseExprTest, CompileErrorNotAllowedOutsideIfdef)
     "    compile_error \"Reason\"";
 
   TEST_ERROR(src);
+}
+
+TEST_F(ParseExprTest, ExprErrorPatternCaptureType)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    let a: U8 = 'a'\n"
+    "    match a\n"
+    "    | let c => None\n"
+    "    end";
+
+  DO(test_error(src, "expr"));
 }


### PR DESCRIPTION
fix s_matchtype_operand_entity assert testcase

error on missing pattern capture type, and only there.
fixes #430
