### PR TITLE
error on recover and uninferred types #358

### DIFF
--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -651,7 +651,9 @@ static void reachable_method(reachable_method_stack_t** s,
     }
 
     case TK_LITERAL:
-      assert(0&&"Known internal limitation. Not yet inferred literal type"); break;
+      ast_error(type, "Cannot yet infer type of literal (internal limitation). Add it with \"as TYPE\"");
+      print_errors();
+      exit(1);
     default:
       assert(0&&"Not yet inferred method type. Need NOMINAL, UNIONTYPE or ISECTTYPE");
   }

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -650,8 +650,10 @@ static void reachable_method(reachable_method_stack_t** s,
       break;
     }
 
+    case TK_LITERAL:
+      assert(0&&"Known internal limitation. Not yet inferred literal type"); break;
     default:
-      assert(0);
+      assert(0&&"Not yet inferred method type. Need NOMINAL, UNIONTYPE or ISECTTYPE");
   }
 }
 

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -371,6 +371,10 @@ ast_t* recover_type(ast_t* type, token_id cap)
       return r_type;
     }
 
+    case TK_LITERAL:
+      ast_error(type, "Cannot infer type of recover literal (internal limitation). Add it with \"as TYPE\"");
+      return type;
+
     case TK_FUNTYPE:
     case TK_INFERTYPE:
     case TK_ERRORTYPE:

--- a/test/libponyc/local_inference.cc
+++ b/test/libponyc/local_inference.cc
@@ -135,3 +135,13 @@ TEST_F(LocalInferTest, DeclAndNot)
 
   TEST_EQUIV(short_form, full_form);
 }
+
+TEST_F(LocalInferTest, RecoverLitExpr)
+{
+  const char* src =
+    "class C\n"
+    "  new create(offset: U64) =>\n"
+    "  let a:Array[I32] val = recover [1, 2, 3, 4] end";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/local_inference.cc
+++ b/test/libponyc/local_inference.cc
@@ -143,5 +143,7 @@ TEST_F(LocalInferTest, RecoverLitExpr)
     "  new create(offset: U64) =>\n"
     "  let a:Array[I32] val = recover [1, 2, 3, 4] end";
 
-  TEST_COMPILE(src);
+  // Cannot infer yet the recover literal, limitation GH #358
+  //TEST_COMPILE(src);
+  TEST_ERROR(src);
 }


### PR DESCRIPTION
throw expr error on recover literal

The recover expr did not yet infer its types. 
At least throw an error with a hint and do not assert. Improves GH #358