### PR TITLE
Allow element to be inserted at the end of array

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -115,7 +115,7 @@ class Array[A] is Seq[A]
     An out of bounds index raises an error.
     The array is returned to allow call chaining.
     """
-    if i < _size then
+    if i <= _size then
       reserve(_size + 1)
       _ptr._offset(i)._insert(1, _size - i)
       _ptr._update(i, consume value)

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -35,6 +35,7 @@ actor Main is TestList
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArraySlice)
+    test(_TestArrayInsert)
     test(_TestMath128)
     test(_TestDivMod)
     test(_TestMaybe)
@@ -558,6 +559,31 @@ class iso _TestArraySlice is UnitTest
     h.assert_eq[String]("five", e(0))
     h.assert_eq[String]("three", e(1))
     h.assert_eq[String]("one", e(2))
+
+
+class iso _TestArrayInsert is UnitTest
+  """
+  Test inserting new element into array
+  """
+  fun name(): String => "builtin/Array.insert"
+
+  fun apply(h: TestHelper) ? =>
+    let a = _iso_array(["one", "three"])
+    a.insert(0, "zero")
+    h.assert_array_eq[String](["zero", "one", "three"], consume a)
+
+    let b = _iso_array(["one", "three"])
+    b.insert(1, "two")
+    h.assert_array_eq[String](["one", "two", "three"], consume b)
+
+    let c = _iso_array(["one", "three"])
+    c.insert(2, "four")
+    h.assert_array_eq[String](["one", "three", "four"], consume c)
+
+  fun _iso_array(elements: Array[String]): Array[String] iso^ =>
+    let array = recover Array[String] end
+    for element in elements.values() do array.push(element) end
+    consume array
 
 
 class iso _TestMath128 is UnitTest


### PR DESCRIPTION
Element can be inserted at the very beginning or between existing
array elements. To insert at the very end, however, requires `push()`
to be used. Allowing insertions at the very end makes `insert()`
consistent and `Array` easier to use.