### PR TITLE
Tighten an #if condition: LLVM 3.7.0 has a breaking change fixed in 3.7.1+

### DIFF
--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -506,7 +506,10 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   LLVMTypeRef lp_type = LLVMStructTypeInContext(c->context, lp_elements, 2,
     false);
 
-#if PONY_LLVM >= 307
+#if LLVM_VERSION_MAJOR == 3 && LLVM_VERSION_MINOR == 7 && LLVM_VERSION_PATCH == 0
+  // This backwards-incompatible API change to LLVMBuildLandingPad is only in
+  // LLVM 3.7.0. In 3.7.1 and all later versions, backward-compatibility was
+  // restored.
   assert((c->frame->fun != NULL) && "No function in current frame!");
   LLVMSetPersonalityFn(c->frame->fun, c->personality);
   LLVMValueRef landing = LLVMBuildLandingPad(c->builder, lp_type, 1, "");


### PR DESCRIPTION
`LLVMBuildLandingPad`'s API changed in a backwards-incompatible way for 3.7.0, but
was then restored in 3.7.1 and later. This change makes the condition for the
call to `LLVMBuildLandingPad` specific to LLVM 3.7.0; all other versions use the
original API.

Tested on LLVM 3.7.1 on 32-bit ARMv7 and 3.7.0 on x86_64, both Linux; all tests
passing.