### PR TITLE
Parse incoming HTTP request bodies correctly in payloadbuilder

### DIFF
--- a/packages/net/http/payloadbuilder.pony
+++ b/packages/net/http/payloadbuilder.pony
@@ -189,7 +189,7 @@ class _PayloadBuilder
           if
             (_payload.status == 204) or
             (_payload.status == 304) or
-            (_payload.status < 200)
+            ((_payload.status > 0) and (_payload.status < 200))
           then
             _state = _PayloadReady
           elseif _chunked then


### PR DESCRIPTION
When writing a server and receiving a new request, _payload.status is 0. This
condition was being hit accidentally, preventing the body from being read.