### PR TITLE
Add cross compiling functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ endif
 # Default settings (silent debug build).
 config ?= debug
 arch ?= native
+bits ?= $(shell getconf LONG_BIT)
 
 ifndef verbose
   SILENT = @
@@ -67,16 +68,16 @@ prefix ?= /usr/local
 destdir ?= $(prefix)/lib/pony/$(tag)
 
 LIB_EXT ?= a
-BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
+BUILD_FLAGS = -m$(bits) -march=$(arch) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
-LINKER_FLAGS = -march=$(arch)
+LINKER_FLAGS = -m$(bits) -march=$(arch)
 AR_FLAGS = -rcs
-ALL_CFLAGS = -std=gnu11 -fexceptions \
+ALL_CFLAGS = -m$(bits) -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\"
-ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
+ALL_CXXFLAGS = -m$(bits) -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.
-BITS := $(shell getconf LONG_BIT)
+BITS := $(bits)
 
 ifeq ($(BITS),64)
 	BUILD_FLAGS += -mcx16

--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,13 @@ prefix ?= /usr/local
 destdir ?= $(prefix)/lib/pony/$(tag)
 
 LIB_EXT ?= a
-BUILD_FLAGS = -m$(bits) -march=$(arch) -Werror -Wconversion \
+BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
-LINKER_FLAGS = -m$(bits) -march=$(arch)
+LINKER_FLAGS = -march=$(arch)
 AR_FLAGS = -rcs
-ALL_CFLAGS = -m$(bits) -std=gnu11 -fexceptions \
+ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\"
-ALL_CXXFLAGS = -m$(bits) -std=gnu++11 -fno-rtti
+ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.
 BITS := $(bits)

--- a/src/libponyc/ast/lexint.c
+++ b/src/libponyc/ast/lexint.c
@@ -196,7 +196,7 @@ void lexint_char(lexint_t* i, int c)
 
 bool lexint_accum(lexint_t* i, uint64_t digit, uint64_t base)
 {
-#if !defined(PLATFORM_IS_ILP32) && !defined(PLATFORM_IS_WINDOWS)
+#ifdef USE_NATIVE128
   NATIVE(v1, i);
   __uint128_t v2 = v1 * base;
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -504,6 +504,7 @@ void codegen_shutdown(pass_opt_t* opt)
   LLVMDisposeMessage(opt->cpu);
   LLVMDisposeMessage(opt->features);
 
+  LLVMResetFatalErrorHandler();
   LLVMShutdown();
 }
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -452,6 +452,7 @@ bool codegen_init(pass_opt_t* opt)
   LLVMInitializeNativeTarget();
   LLVMInitializeAllTargets();
   LLVMInitializeAllTargetMCs();
+  LLVMInitializeAllTargetInfos();
   LLVMInitializeAllAsmPrinters();
   LLVMInitializeAllAsmParsers();
   LLVMEnablePrettyStackTrace();

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -5,6 +5,7 @@
 #include "gendesc.h"
 #include "genfun.h"
 #include "genname.h"
+#include "genopt.h"
 #include "../pkg/platformfuns.h"
 #include "../type/subtype.h"
 #include "../ast/stringtab.h"
@@ -109,7 +110,7 @@ static LLVMValueRef special_case_platform(compile_t* c, ast_t* ast)
   const char* method_name = ast_name(method);
   bool is_target;
 
-  if(os_is_target(method_name, c->opt->release, &is_target))
+  if(os_is_target(method_name, c->opt->release, &is_target, c->opt))
     return LLVMConstInt(c->i1, is_target ? 1 : 0, false);
 
   ast_error(ast, "unknown Platform setting");
@@ -160,8 +161,7 @@ static bool special_case_call(compile_t* c, ast_t* ast, LLVMValueRef* value)
 
   if((name == c->str_I128) || (name == c->str_U128))
   {
-    bool native128;
-    os_is_target(OS_NATIVE128_NAME, c->opt->release, &native128);
+    bool native128 = target_is_native128(c->opt->triple);
     return special_case_operator(c, ast, value, false, native128);
   }
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -7,6 +7,7 @@
 #endif
 
 #include "genopt.h"
+#include <string.h>
 
 #include <llvm/IR/Module.h>
 #include <llvm/IR/DataLayout.h>
@@ -514,7 +515,8 @@ static void optimise(compile_t* c)
 
   pmb.populateFunctionPassManager(fpm);
 
-#ifdef PLATFORM_IS_ARM
+  if(target_is_arm(c->opt->triple))
+  {
   // On ARM, without this, trace functions are being loaded with a double
   // indirection with a debug binary. An ldr r0, [LABEL] is done, loading
   // the trace function address, but then ldr r2, [r0] is done to move the
@@ -522,15 +524,17 @@ static void optimise(compile_t* c)
   // gives a garbage trace function. In release mode, a different path is used
   // and this error doesn't happen. Forcing an OptLevel of 1 for the MPM
   // results in the alternate (working) asm being used for a debug build.
-  if(!c->opt->release)
-    pmb.OptLevel = 1;
-#endif
+    if(!c->opt->release)
+      pmb.OptLevel = 1;
+  }
+
   pmb.populateModulePassManager(mpm);
 
-#ifdef PLATFORM_IS_ARM
-  if(!c->opt->release)
-    pmb.OptLevel = 0;
-#endif
+  if(target_is_arm(c->opt->triple))
+  {
+    if(!c->opt->release)
+      pmb.OptLevel = 0;
+  }
 
   pmb.populateLTOPassManager(lpm);
 
@@ -573,3 +577,85 @@ bool genopt(compile_t* c)
 
   return true;
 }
+
+bool target_is_linux(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isOSLinux();
+}
+
+bool target_is_freebsd(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isOSFreeBSD();
+}
+
+bool target_is_macosx(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isMacOSX();
+}
+
+bool target_is_windows(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isOSWindows();
+}
+
+bool target_is_posix(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isMacOSX() || triple.isOSFreeBSD() || triple.isOSLinux();
+}
+
+bool target_is_x86(char* t)
+{
+  Triple triple = Triple(t);
+
+  const char* arch = Triple::getArchTypePrefix(triple.getArch());
+
+  return !strcmp("x86", arch);
+}
+
+bool target_is_arm(char* t)
+{
+  Triple triple = Triple(t);
+
+  const char* arch = Triple::getArchTypePrefix(triple.getArch());
+
+  return !strcmp("arm", arch);
+}
+
+bool target_is_lp64(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isArch64Bit() && !triple.isOSWindows();
+}
+
+bool target_is_llp64(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isArch64Bit() && triple.isOSWindows();
+}
+
+bool target_is_ilp32(char* t)
+{
+  Triple triple = Triple(t);
+
+  return triple.isArch32Bit();
+}
+
+bool target_is_native128(char* t)
+{
+  Triple triple = Triple(t);
+
+  return !triple.isArch32Bit() && !triple.isKnownWindowsMSVCEnvironment();
+}
+

--- a/src/libponyc/codegen/genopt.h
+++ b/src/libponyc/codegen/genopt.h
@@ -7,6 +7,18 @@
 PONY_EXTERN_C_BEGIN
 
 bool genopt(compile_t* c);
+bool target_is_linux(char* triple);
+bool target_is_freebsd(char* triple);
+bool target_is_macosx(char* triple);
+bool target_is_windows(char* triple);
+bool target_is_posix(char* triple);
+bool target_is_x86(char* triple);
+bool target_is_arm(char* triple);
+bool target_is_lp64(char* triple);
+bool target_is_llp64(char* triple);
+bool target_is_ilp32(char* triple);
+bool target_is_native128(char* triple);
+
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -550,96 +550,90 @@ static void number_conversions(compile_t* c)
 
   num_conv_t* conv;
 
-  if(ilp32)
+  num_conv_t ilp32_conv[] =
   {
-    num_conv_t my_conv[] =
-    {
-      {"I8", "i8", c->i8, 8, true, false},
-      {"I16", "i16", c->i16, 16, true, false},
-      {"I32", "i32", c->i32, 32, true, false},
-      {"I64", "i64", c->i64, 64, true, false},
+    {"I8", "i8", c->i8, 8, true, false},
+    {"I16", "i16", c->i16, 16, true, false},
+    {"I32", "i32", c->i32, 32, true, false},
+    {"I64", "i64", c->i64, 64, true, false},
 
-      {"U8", "u8", c->i8, 8, false, false},
-      {"U16", "u16", c->i16, 16, false, false},
-      {"U32", "u32", c->i32, 32, false, false},
-      {"U64", "u64", c->i64, 64, false, false},
-      {"I128", "i128", c->i128, 128, true, false},
-      {"U128", "u128", c->i128, 128, false, false},
+    {"U8", "u8", c->i8, 8, false, false},
+    {"U16", "u16", c->i16, 16, false, false},
+    {"U32", "u32", c->i32, 32, false, false},
+    {"U64", "u64", c->i64, 64, false, false},
+    {"I128", "i128", c->i128, 128, true, false},
+    {"U128", "u128", c->i128, 128, false, false},
 
-      {"ILong", "ilong", c->i32, 32, true, false},
-      {"ULong", "ulong", c->i32, 32, false, false},
-      {"ISize", "isize", c->i32, 32, true, false},
-      {"USize", "usize", c->i32, 32, false, false},
+    {"ILong", "ilong", c->i32, 32, true, false},
+    {"ULong", "ulong", c->i32, 32, false, false},
+    {"ISize", "isize", c->i32, 32, true, false},
+    {"USize", "usize", c->i32, 32, false, false},
 
-      {"F32", "f32", c->f32, 32, false, true},
-      {"F64", "f64", c->f64, 64, false, true},
+    {"F32", "f32", c->f32, 32, false, true},
+    {"F64", "f64", c->f64, 64, false, true},
 
-      {NULL, NULL, NULL, false, false, false}
-    };
+    {NULL, NULL, NULL, false, false, false}
+  };
 
-    conv = my_conv;
-  }
+  num_conv_t lp64_conv[] =
+  {
+    {"I8", "i8", c->i8, 8, true, false},
+    {"I16", "i16", c->i16, 16, true, false},
+    {"I32", "i32", c->i32, 32, true, false},
+    {"I64", "i64", c->i64, 64, true, false},
+
+    {"U8", "u8", c->i8, 8, false, false},
+    {"U16", "u16", c->i16, 16, false, false},
+    {"U32", "u32", c->i32, 32, false, false},
+    {"U64", "u64", c->i64, 64, false, false},
+    {"I128", "i128", c->i128, 128, true, false},
+    {"U128", "u128", c->i128, 128, false, false},
+
+    {"ILong", "ilong", c->i64, 64, true, false},
+    {"ULong", "ulong", c->i64, 64, false, false},
+    {"ISize", "isize", c->i64, 64, true, false},
+    {"USize", "usize", c->i64, 64, false, false},
+
+    {"F32", "f32", c->f32, 32, false, true},
+    {"F64", "f64", c->f64, 64, false, true},
+
+    {NULL, NULL, NULL, false, false, false}
+  };
+
+  num_conv_t llp64_conv[] =
+  {
+    {"I8", "i8", c->i8, 8, true, false},
+    {"I16", "i16", c->i16, 16, true, false},
+    {"I32", "i32", c->i32, 32, true, false},
+    {"I64", "i64", c->i64, 64, true, false},
+
+    {"U8", "u8", c->i8, 8, false, false},
+    {"U16", "u16", c->i16, 16, false, false},
+    {"U32", "u32", c->i32, 32, false, false},
+    {"U64", "u64", c->i64, 64, false, false},
+    {"I128", "i128", c->i128, 128, true, false},
+    {"U128", "u128", c->i128, 128, false, false},
+
+    {"ILong", "ilong", c->i32, 32, true, false},
+    {"ULong", "ulong", c->i32, 32, false, false},
+    {"ISize", "isize", c->i64, 64, true, false},
+    {"USize", "usize", c->i64, 64, false, false},
+
+    {"F32", "f32", c->f32, 32, false, true},
+    {"F64", "f64", c->f64, 64, false, true},
+
+    {NULL, NULL, NULL, false, false, false}
+  };
+
+  if(ilp32)
+    conv = ilp32_conv;
 
   if(lp64)
-  {
-    num_conv_t my_conv[] =
-    {
-      {"I8", "i8", c->i8, 8, true, false},
-      {"I16", "i16", c->i16, 16, true, false},
-      {"I32", "i32", c->i32, 32, true, false},
-      {"I64", "i64", c->i64, 64, true, false},
-
-      {"U8", "u8", c->i8, 8, false, false},
-      {"U16", "u16", c->i16, 16, false, false},
-      {"U32", "u32", c->i32, 32, false, false},
-      {"U64", "u64", c->i64, 64, false, false},
-      {"I128", "i128", c->i128, 128, true, false},
-      {"U128", "u128", c->i128, 128, false, false},
-
-      {"ILong", "ilong", c->i64, 64, true, false},
-      {"ULong", "ulong", c->i64, 64, false, false},
-      {"ISize", "isize", c->i64, 64, true, false},
-      {"USize", "usize", c->i64, 64, false, false},
-
-      {"F32", "f32", c->f32, 32, false, true},
-      {"F64", "f64", c->f64, 64, false, true},
-
-      {NULL, NULL, NULL, false, false, false}
-    };
-
-    conv = my_conv;
-  }
-
+    conv = lp64_conv;
 
   if(llp64)
-  {
-    num_conv_t my_conv[] =
-    {
-      {"I8", "i8", c->i8, 8, true, false},
-      {"I16", "i16", c->i16, 16, true, false},
-      {"I32", "i32", c->i32, 32, true, false},
-      {"I64", "i64", c->i64, 64, true, false},
+    conv = llp64_conv;
 
-      {"U8", "u8", c->i8, 8, false, false},
-      {"U16", "u16", c->i16, 16, false, false},
-      {"U32", "u32", c->i32, 32, false, false},
-      {"U64", "u64", c->i64, 64, false, false},
-      {"I128", "i128", c->i128, 128, true, false},
-      {"U128", "u128", c->i128, 128, false, false},
-
-      {"ILong", "ilong", c->i32, 32, true, false},
-      {"ULong", "ulong", c->i32, 32, false, false},
-      {"ISize", "isize", c->i64, 64, true, false},
-      {"USize", "usize", c->i64, 64, false, false},
-
-      {"F32", "f32", c->f32, 32, false, true},
-      {"F64", "f64", c->f64, 64, false, true},
-
-      {NULL, NULL, NULL, false, false, false}
-    };
-
-    conv = my_conv;
-  }
 
   assert(conv != NULL);
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -4,10 +4,13 @@
 #include "genfun.h"
 #include "gencall.h"
 #include "gentrace.h"
+#include "genopt.h"
 #include "../pkg/platformfuns.h"
 #include "../pass/names.h"
 #include "../debug/dwarf.h"
 #include "../type/assemble.h"
+
+#include <assert.h>
 
 static void pointer_create(compile_t* c, gentype_t* g)
 {
@@ -540,45 +543,107 @@ typedef struct num_conv_t
 
 static void number_conversions(compile_t* c)
 {
-  num_conv_t conv[] =
+  bool ilp32 = target_is_ilp32(c->opt->triple);
+  bool llp64 = target_is_llp64(c->opt->triple);
+  bool lp64 = target_is_lp64(c->opt->triple);
+
+
+  num_conv_t* conv;
+
+  if(ilp32)
   {
-    {"I8", "i8", c->i8, 8, true, false},
-    {"I16", "i16", c->i16, 16, true, false},
-    {"I32", "i32", c->i32, 32, true, false},
-    {"I64", "i64", c->i64, 64, true, false},
+    num_conv_t my_conv[] =
+    {
+      {"I8", "i8", c->i8, 8, true, false},
+      {"I16", "i16", c->i16, 16, true, false},
+      {"I32", "i32", c->i32, 32, true, false},
+      {"I64", "i64", c->i64, 64, true, false},
 
-    {"U8", "u8", c->i8, 8, false, false},
-    {"U16", "u16", c->i16, 16, false, false},
-    {"U32", "u32", c->i32, 32, false, false},
-    {"U64", "u64", c->i64, 64, false, false},
-    {"I128", "i128", c->i128, 128, true, false},
-    {"U128", "u128", c->i128, 128, false, false},
+      {"U8", "u8", c->i8, 8, false, false},
+      {"U16", "u16", c->i16, 16, false, false},
+      {"U32", "u32", c->i32, 32, false, false},
+      {"U64", "u64", c->i64, 64, false, false},
+      {"I128", "i128", c->i128, 128, true, false},
+      {"U128", "u128", c->i128, 128, false, false},
 
-#if defined(PLATFORM_IS_ILP32)
-    {"ILong", "ilong", c->i32, 32, true, false},
-    {"ULong", "ulong", c->i32, 32, false, false},
-    {"ISize", "isize", c->i32, 32, true, false},
-    {"USize", "usize", c->i32, 32, false, false},
-#elif defined(PLATFORM_IS_LP64)
-    {"ILong", "ilong", c->i64, 64, true, false},
-    {"ULong", "ulong", c->i64, 64, false, false},
-    {"ISize", "isize", c->i64, 64, true, false},
-    {"USize", "usize", c->i64, 64, false, false},
-#elif defined(PLATFORM_IS_LLP64)
-    {"ILong", "ilong", c->i32, 32, true, false},
-    {"ULong", "ulong", c->i32, 32, false, false},
-    {"ISize", "isize", c->i64, 64, true, false},
-    {"USize", "usize", c->i64, 64, false, false},
-#endif
+      {"ILong", "ilong", c->i32, 32, true, false},
+      {"ULong", "ulong", c->i32, 32, false, false},
+      {"ISize", "isize", c->i32, 32, true, false},
+      {"USize", "usize", c->i32, 32, false, false},
 
-    {"F32", "f32", c->f32, 32, false, true},
-    {"F64", "f64", c->f64, 64, false, true},
+      {"F32", "f32", c->f32, 32, false, true},
+      {"F64", "f64", c->f64, 64, false, true},
 
-    {NULL, NULL, NULL, false, false, false}
-  };
+      {NULL, NULL, NULL, false, false, false}
+    };
 
-  bool native128;
-  os_is_target(OS_NATIVE128_NAME, c->opt->release, &native128);
+    conv = my_conv;
+  }
+
+  if(lp64)
+  {
+    num_conv_t my_conv[] =
+    {
+      {"I8", "i8", c->i8, 8, true, false},
+      {"I16", "i16", c->i16, 16, true, false},
+      {"I32", "i32", c->i32, 32, true, false},
+      {"I64", "i64", c->i64, 64, true, false},
+
+      {"U8", "u8", c->i8, 8, false, false},
+      {"U16", "u16", c->i16, 16, false, false},
+      {"U32", "u32", c->i32, 32, false, false},
+      {"U64", "u64", c->i64, 64, false, false},
+      {"I128", "i128", c->i128, 128, true, false},
+      {"U128", "u128", c->i128, 128, false, false},
+
+      {"ILong", "ilong", c->i64, 64, true, false},
+      {"ULong", "ulong", c->i64, 64, false, false},
+      {"ISize", "isize", c->i64, 64, true, false},
+      {"USize", "usize", c->i64, 64, false, false},
+
+      {"F32", "f32", c->f32, 32, false, true},
+      {"F64", "f64", c->f64, 64, false, true},
+
+      {NULL, NULL, NULL, false, false, false}
+    };
+
+    conv = my_conv;
+  }
+
+
+  if(llp64)
+  {
+    num_conv_t my_conv[] =
+    {
+      {"I8", "i8", c->i8, 8, true, false},
+      {"I16", "i16", c->i16, 16, true, false},
+      {"I32", "i32", c->i32, 32, true, false},
+      {"I64", "i64", c->i64, 64, true, false},
+
+      {"U8", "u8", c->i8, 8, false, false},
+      {"U16", "u16", c->i16, 16, false, false},
+      {"U32", "u32", c->i32, 32, false, false},
+      {"U64", "u64", c->i64, 64, false, false},
+      {"I128", "i128", c->i128, 128, true, false},
+      {"U128", "u128", c->i128, 128, false, false},
+
+      {"ILong", "ilong", c->i32, 32, true, false},
+      {"ULong", "ulong", c->i32, 32, false, false},
+      {"ISize", "isize", c->i64, 64, true, false},
+      {"USize", "usize", c->i64, 64, false, false},
+
+      {"F32", "f32", c->f32, 32, false, true},
+      {"F64", "f64", c->f64, 64, false, true},
+
+      {NULL, NULL, NULL, false, false, false}
+    };
+
+    conv = my_conv;
+  }
+
+  assert(conv != NULL);
+
+  bool native128 = target_is_native128(c->opt->triple);
 
   for(num_conv_t* from = conv; from->type_name != NULL; from++)
   {
@@ -690,51 +755,53 @@ static void fp_as_bits(compile_t* c)
 
 static void make_cpuid(compile_t* c)
 {
-#ifdef PLATFORM_IS_X86
-  LLVMTypeRef elems[4] = {c->i32, c->i32, c->i32, c->i32};
-  LLVMTypeRef r_type = LLVMStructTypeInContext(c->context, elems, 4, false);
-  LLVMTypeRef f_type = LLVMFunctionType(r_type, &c->i32, 1, false);
-  LLVMValueRef fun = codegen_addfun(c, "internal.x86.cpuid", f_type);
-  LLVMSetFunctionCallConv(fun, LLVMCCallConv);
-  codegen_startfun(c, fun, false);
+  if(target_is_x86(c->opt->triple))
+  {
+    LLVMTypeRef elems[4] = {c->i32, c->i32, c->i32, c->i32};
+    LLVMTypeRef r_type = LLVMStructTypeInContext(c->context, elems, 4, false);
+    LLVMTypeRef f_type = LLVMFunctionType(r_type, &c->i32, 1, false);
+    LLVMValueRef fun = codegen_addfun(c, "internal.x86.cpuid", f_type);
+    LLVMSetFunctionCallConv(fun, LLVMCCallConv);
+    codegen_startfun(c, fun, false);
 
-  LLVMValueRef cpuid = LLVMConstInlineAsm(f_type,
-    "cpuid", "={ax},={bx},={cx},={dx},{ax}", false, false);
-  LLVMValueRef zero = LLVMConstInt(c->i32, 0, false);
+    LLVMValueRef cpuid = LLVMConstInlineAsm(f_type,
+      "cpuid", "={ax},={bx},={cx},={dx},{ax}", false, false);
+    LLVMValueRef zero = LLVMConstInt(c->i32, 0, false);
 
-  LLVMValueRef result = LLVMBuildCall(c->builder, cpuid, &zero, 1, "");
-  LLVMBuildRet(c->builder, result);
+    LLVMValueRef result = LLVMBuildCall(c->builder, cpuid, &zero, 1, "");
+    LLVMBuildRet(c->builder, result);
 
-  codegen_finishfun(c);
-#else
-  (void)c;
-#endif
+    codegen_finishfun(c);
+  } else {
+    (void)c;
+  }
 }
 
 static void make_rdtscp(compile_t* c)
 {
-#ifdef PLATFORM_IS_X86
-  // i64 @llvm.x86.rdtscp(i8*)
-  LLVMTypeRef f_type = LLVMFunctionType(c->i64, &c->void_ptr, 1, false);
-  LLVMValueRef rdtscp = LLVMAddFunction(c->module, "llvm.x86.rdtscp", f_type);
+  if(target_is_x86(c->opt->triple))
+  {
+    // i64 @llvm.x86.rdtscp(i8*)
+    LLVMTypeRef f_type = LLVMFunctionType(c->i64, &c->void_ptr, 1, false);
+    LLVMValueRef rdtscp = LLVMAddFunction(c->module, "llvm.x86.rdtscp", f_type);
 
-  // i64 @internal.x86.rdtscp(i32*)
-  LLVMTypeRef i32_ptr = LLVMPointerType(c->i32, 0);
-  f_type = LLVMFunctionType(c->i64, &i32_ptr, 1, false);
-  LLVMValueRef fun = codegen_addfun(c, "internal.x86.rdtscp", f_type);
-  LLVMSetFunctionCallConv(fun, LLVMCCallConv);
-  codegen_startfun(c, fun, false);
+    // i64 @internal.x86.rdtscp(i32*)
+    LLVMTypeRef i32_ptr = LLVMPointerType(c->i32, 0);
+    f_type = LLVMFunctionType(c->i64, &i32_ptr, 1, false);
+    LLVMValueRef fun = codegen_addfun(c, "internal.x86.rdtscp", f_type);
+    LLVMSetFunctionCallConv(fun, LLVMCCallConv);
+    codegen_startfun(c, fun, false);
 
-  // Cast i32* to i8* and call the intrinsic.
-  LLVMValueRef arg = LLVMGetParam(fun, 0);
-  arg = LLVMBuildBitCast(c->builder, arg, c->void_ptr, "");
-  LLVMValueRef result = LLVMBuildCall(c->builder, rdtscp, &arg, 1, "");
-  LLVMBuildRet(c->builder, result);
+    // Cast i32* to i8* and call the intrinsic.
+    LLVMValueRef arg = LLVMGetParam(fun, 0);
+    arg = LLVMBuildBitCast(c->builder, arg, c->void_ptr, "");
+    LLVMValueRef result = LLVMBuildCall(c->builder, rdtscp, &arg, 1, "");
+    LLVMBuildRet(c->builder, result);
 
-  codegen_finishfun(c);
-#else
-  (void)c;
-#endif
+    codegen_finishfun(c);
+  } else {
+    (void)c;
+  }
 }
 
 void genprim_builtins(compile_t* c)

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -4,6 +4,7 @@
 #include "genprim.h"
 #include "gentrace.h"
 #include "genfun.h"
+#include "genopt.h"
 #include "../pkg/package.h"
 #include "../type/reify.h"
 #include "../type/subtype.h"
@@ -103,6 +104,10 @@ static bool setup_name(compile_t* c, ast_t* ast, gentype_t* g, bool prelim)
     const char* package = ast_name(pkg);
     const char* name = ast_name(id);
 
+    bool ilp32 = target_is_ilp32(c->opt->triple);
+    bool llp64 = target_is_llp64(c->opt->triple);
+    bool lp64 = target_is_lp64(c->opt->triple);
+
     if(package == c->str_builtin)
     {
       if(name == c->str_Bool)
@@ -127,34 +132,30 @@ static bool setup_name(compile_t* c, ast_t* ast, gentype_t* g, bool prelim)
         g->primitive = c->i128;
       else if(name == c->str_U128)
         g->primitive = c->i128;
-#if defined(PLATFORM_IS_ILP32)
-      else if(name == c->str_ILong)
+      else if(ilp32 && name == c->str_ILong)
         g->primitive = c->i32;
-      else if(name == c->str_ULong)
+      else if(ilp32 && name == c->str_ULong)
         g->primitive = c->i32;
-      else if(name == c->str_ISize)
+      else if(ilp32 && name == c->str_ISize)
         g->primitive = c->i32;
-      else if(name == c->str_USize)
+      else if(ilp32 && name == c->str_USize)
         g->primitive = c->i32;
-#elif defined(PLATFORM_IS_LP64)
-      else if(name == c->str_ILong)
+      else if(lp64 && name == c->str_ILong)
         g->primitive = c->i64;
-      else if(name == c->str_ULong)
+      else if(lp64 && name == c->str_ULong)
         g->primitive = c->i64;
-      else if(name == c->str_ISize)
+      else if(lp64 && name == c->str_ISize)
         g->primitive = c->i64;
-      else if(name == c->str_USize)
+      else if(lp64 && name == c->str_USize)
         g->primitive = c->i64;
-#elif defined(PLATFORM_IS_LLP64)
-      else if(name == c->str_ILong)
+      else if(llp64 && name == c->str_ILong)
         g->primitive = c->i32;
-      else if(name == c->str_ULong)
+      else if(llp64 && name == c->str_ULong)
         g->primitive = c->i32;
-      else if(name == c->str_ISize)
+      else if(llp64 && name == c->str_ISize)
         g->primitive = c->i64;
-      else if(name == c->str_USize)
+      else if(llp64 && name == c->str_USize)
         g->primitive = c->i64;
-#endif
       else if(name == c->str_F32)
         g->primitive = c->f32;
       else if(name == c->str_F64)

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -147,7 +147,7 @@ ast_result_t expr_ffi(pass_opt_t* opt, ast_t* ast)
   assert(name != NULL);
 
   ast_t* decl;
-  if(!ffi_get_decl(&opt->check, ast, &decl))
+  if(!ffi_get_decl(&opt->check, ast, &decl, opt))
     return AST_ERROR;
 
   if(decl != NULL)  // We have a declaration

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1022,7 +1022,7 @@ static ast_result_t sugar_ffi(ast_t* ast)
 }
 
 
-static ast_result_t sugar_ifdef(typecheck_t* t, ast_t* ast)
+static ast_result_t sugar_ifdef(typecheck_t* t, ast_t* ast, pass_opt_t* options)
 {
   assert(t != NULL);
   assert(ast != NULL);
@@ -1055,13 +1055,13 @@ static ast_result_t sugar_ifdef(typecheck_t* t, ast_t* ast)
 
   // Normalise condition so and, or and not nodes aren't sugared to function
   // calls.
-  if(!ifdef_cond_normalise(&cond))
+  if(!ifdef_cond_normalise(&cond, options))
   {
     ast_error(ast, "ifdef condition will never be true");
     return AST_ERROR;
   }
 
-  if(!ifdef_cond_normalise(&else_cond))
+  if(!ifdef_cond_normalise(&else_cond, options))
   {
     ast_error(ast, "ifdef condition is always true");
     return AST_ERROR;
@@ -1071,7 +1071,7 @@ static ast_result_t sugar_ifdef(typecheck_t* t, ast_t* ast)
 }
 
 
-static ast_result_t sugar_use(ast_t* ast)
+static ast_result_t sugar_use(ast_t* ast, pass_opt_t* options)
 {
   assert(ast != NULL);
 
@@ -1079,7 +1079,7 @@ static ast_result_t sugar_use(ast_t* ast)
   // calls.
   ast_t* guard = ast_childidx(ast, 2);
 
-  if(!ifdef_cond_normalise(&guard))
+  if(!ifdef_cond_normalise(&guard, options))
   {
     ast_error(ast, "use guard condition will never be true");
     return AST_ERROR;
@@ -1268,8 +1268,8 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_NOT:        return sugar_unop(astp, "op_not");
     case TK_FFIDECL:
     case TK_FFICALL:    return sugar_ffi(ast);
-    case TK_IFDEF:      return sugar_ifdef(t, ast);
-    case TK_USE:        return sugar_use(ast);
+    case TK_IFDEF:      return sugar_ifdef(t, ast, options);
+    case TK_USE:        return sugar_use(ast, options);
     case TK_SEMI:       return sugar_semi(options, astp);
     case TK_LET:        return sugar_let(t, ast);
     case TK_LAMBDATYPE: return sugar_lambdatype(options, astp);

--- a/src/libponyc/pkg/ifdef.h
+++ b/src/libponyc/pkg/ifdef.h
@@ -12,7 +12,7 @@ PONY_EXTERN_C_BEGIN
 // Includes replacing TK_*s with ifdef specific versions.
 // Returns: true on success, false if condition can nver be true (does not
 // report error for this).
-bool ifdef_cond_normalise(ast_t** astp);
+bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* options);
 
 // Evaluate the given ifdef or use guard condition for our build target.
 // Returns: value of given condition.
@@ -22,7 +22,7 @@ bool ifdef_cond_eval(ast_t* ast, pass_opt_t* options);
 // Returns: true on success, false on failure.
 // On success out_decl contains the relevant declaration, or NULL if there
 // isn't one.
-bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl);
+bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl, pass_opt_t* options);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -957,7 +957,7 @@ bool package_allow_ffi(typecheck_t* t)
 }
 
 
-void package_done(pass_opt_t* opt)
+void package_done(pass_opt_t* opt, bool handle_errors)
 {
   codegen_shutdown(opt);
 
@@ -969,8 +969,11 @@ void package_done(pass_opt_t* opt)
 
   package_clear_magic();
 
-  print_errors();
-  free_errors();
+  if(handle_errors)
+  {
+    print_errors();
+    free_errors();
+  }
 }
 
 

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -118,7 +118,7 @@ bool package_allow_ffi(typecheck_t* t);
 /**
  * Cleans up the list of search directories and shuts down the code generator.
  */
-void package_done(pass_opt_t* opt);
+void package_done(pass_opt_t* opt, bool handle_errors);
 
 bool is_path_absolute(const char* path);
 

--- a/src/libponyc/pkg/platformfuns.c
+++ b/src/libponyc/pkg/platformfuns.c
@@ -1,121 +1,79 @@
 #include "platformfuns.h"
+#include "../codegen/genopt.h"
 #include <assert.h>
 #include <string.h>
 
 
 // Report whether the named platform attribute is true
-bool os_is_target(const char* attribute, bool release, bool* out_is_target)
+bool os_is_target(const char* attribute, bool release, bool* out_is_target, pass_opt_t* options)
 {
   assert(attribute != NULL);
   assert(out_is_target != NULL);
+  assert(options != NULL);
 
   if(!strcmp(attribute, OS_FREEBSD_NAME))
   {
-#ifdef PLATFORM_IS_FREEBSD
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_freebsd(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_LINUX_NAME))
   {
-#ifdef PLATFORM_IS_LINUX
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_linux(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_MACOSX_NAME))
   {
-#ifdef PLATFORM_IS_MACOSX
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_macosx(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_WINDOWS_NAME))
   {
-#ifdef PLATFORM_IS_WINDOWS
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_windows(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_POSIX_NAME))
   {
-#ifdef PLATFORM_IS_POSIX_BASED
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_posix(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_X86_NAME))
   {
-#ifdef PLATFORM_IS_X86
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_x86(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_ARM_NAME))
   {
-#ifdef PLATFORM_IS_ARM
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_arm(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_LP64_NAME))
   {
-#ifdef PLATFORM_IS_LP64
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_lp64(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_LLP64_NAME))
   {
-#ifdef PLATFORM_IS_LLP64
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_llp64(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_ILP32_NAME))
   {
-#ifdef PLATFORM_IS_ILP32
-    *out_is_target = true;
-#else
-    *out_is_target = false;
-#endif
+    *out_is_target = target_is_ilp32(options->triple);
     return true;
   }
 
   if(!strcmp(attribute, OS_NATIVE128_NAME))
   {
-#if defined(PLATFORM_IS_ILP32) || defined(PLATFORM_IS_VISUAL_STUDIO)
-    *out_is_target = false;
-#else
-    *out_is_target = true;
-#endif
+    *out_is_target = target_is_native128(options->triple);
     return true;
   }
 

--- a/src/libponyc/pkg/platformfuns.h
+++ b/src/libponyc/pkg/platformfuns.h
@@ -2,6 +2,7 @@
 #define PLATFORMFUNS_H
 
 #include <platform.h>
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -23,7 +24,7 @@ PONY_EXTERN_C_BEGIN
  * @param out_is true if the specified attribute is set, false otherwise
  * @return true on success, false is specified attribute does not exist
  */
-bool os_is_target(const char* attribute, bool release, bool* out_is_target);
+bool os_is_target(const char* attribute, bool release, bool* out_is_target, pass_opt_t* options);
 
 PONY_EXTERN_C_END
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -326,7 +326,7 @@ int main(int argc, char* argv[])
   if(!ok && get_error_count() == 0)
     printf("Error: internal failure not reported\n");
 
-  package_done(&opt);
+  package_done(&opt, true);
   pass_opt_done(&opt);
   stringtab_done();
 

--- a/test/libponyc/program.cc
+++ b/test/libponyc/program.cc
@@ -24,7 +24,7 @@ TEST(ProgramTest, PackageID)
 }
 
 
-TEST(ProgramTest, DISABLED_NoLibs)
+TEST(ProgramTest, NoLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -36,7 +36,7 @@ TEST(ProgramTest, DISABLED_NoLibs)
 }
 
 
-TEST(ProgramTest, DISABLED_OneLib)
+TEST(ProgramTest, OneLib)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -52,7 +52,7 @@ TEST(ProgramTest, DISABLED_OneLib)
 }
 
 
-TEST(ProgramTest, DISABLED_OneLibWithAmbles)
+TEST(ProgramTest, OneLibWithAmbles)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -68,7 +68,7 @@ TEST(ProgramTest, DISABLED_OneLibWithAmbles)
 }
 
 
-TEST(ProgramTest, DISABLED_MultipleLibs)
+TEST(ProgramTest, MultipleLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -86,7 +86,7 @@ TEST(ProgramTest, DISABLED_MultipleLibs)
 }
 
 
-TEST(ProgramTest, DISABLED_MultipleLibsWithAmbles)
+TEST(ProgramTest, MultipleLibsWithAmbles)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -106,7 +106,7 @@ TEST(ProgramTest, DISABLED_MultipleLibsWithAmbles)
 }
 
 
-TEST(ProgramTest, DISABLED_RepeatedLibs)
+TEST(ProgramTest, RepeatedLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);

--- a/test/libponyc/program.cc
+++ b/test/libponyc/program.cc
@@ -24,7 +24,7 @@ TEST(ProgramTest, PackageID)
 }
 
 
-TEST(ProgramTest, NoLibs)
+TEST(ProgramTest, DISABLED_NoLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -36,7 +36,7 @@ TEST(ProgramTest, NoLibs)
 }
 
 
-TEST(ProgramTest, OneLib)
+TEST(ProgramTest, DISABLED_OneLib)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -52,7 +52,7 @@ TEST(ProgramTest, OneLib)
 }
 
 
-TEST(ProgramTest, OneLibWithAmbles)
+TEST(ProgramTest, DISABLED_OneLibWithAmbles)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -68,7 +68,7 @@ TEST(ProgramTest, OneLibWithAmbles)
 }
 
 
-TEST(ProgramTest, MultipleLibs)
+TEST(ProgramTest, DISABLED_MultipleLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -86,7 +86,7 @@ TEST(ProgramTest, MultipleLibs)
 }
 
 
-TEST(ProgramTest, MultipleLibsWithAmbles)
+TEST(ProgramTest, DISABLED_MultipleLibsWithAmbles)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
@@ -106,7 +106,7 @@ TEST(ProgramTest, MultipleLibsWithAmbles)
 }
 
 
-TEST(ProgramTest, RepeatedLibs)
+TEST(ProgramTest, DISABLED_RepeatedLibs)
 {
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -243,7 +243,6 @@ void PassTest::check_ast_same(ast_t* expect, ast_t* actual)
 
 void PassTest::test_compile(const char* src, const char* pass)
 {
-  package_add_magic("builtin", _builtin_src);
   DO(build_package(pass, src, _first_pkg_path, true, &program));
 
   package = ast_child(program);
@@ -253,7 +252,6 @@ void PassTest::test_compile(const char* src, const char* pass)
 
 void PassTest::test_error(const char* src, const char* pass)
 {
-  package_add_magic("builtin", _builtin_src);
   DO(build_package(pass, src, _first_pkg_path, false, &program));
 
   package = NULL;
@@ -325,17 +323,22 @@ void PassTest::build_package(const char* pass, const char* src,
   ASSERT_NE((void*)NULL, package_name);
   ASSERT_NE((void*)NULL, out_package);
 
-  lexer_allow_test_symbols();
-  package_add_magic(package_name, src);
-
-  free_errors();
-  package_suppress_build_message();
-
   pass_opt_t opt;
   pass_opt_init(&opt);
   package_init(&opt);
+
+  lexer_allow_test_symbols();
+
+  package_add_magic("builtin", _builtin_src);
+
+  package_add_magic(package_name, src);
+
+  package_suppress_build_message();
+
   limit_passes(&opt, pass);
   *out_package = program_load(stringtab(package_name), &opt);
+
+  package_done(&opt, false);
   pass_opt_done(&opt);
 
   if(check_good)
@@ -345,6 +348,7 @@ void PassTest::build_package(const char* pass, const char* src,
 
     ASSERT_NE((void*)NULL, *out_package);
   }
+
 }
 
 

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -332,6 +332,7 @@ void PassTest::build_package(const char* pass, const char* src,
 
   pass_opt_t opt;
   pass_opt_init(&opt);
+  package_init(&opt);
   limit_passes(&opt, pass);
   *out_package = program_load(stringtab(package_name), &opt);
   pass_opt_done(&opt);


### PR DESCRIPTION
This pull request adds cross compiling functionality to ponyc. It does not address cross linking and the usual gcc cross compile chain is required for linking.

See: https://github.com/dipinhora/rpxp for an example of use of the cross compiling features in a Linux X86_64 environment targeting a Linux Arm 32 bit environment.

* Update all code generation related bits (codegen, expr, ast, pass,
  pkg) in libponyc to dynamically check for target machine features
  (OS, architecture, etc) based on LLVM Triple.
* Adjust Makefile for building to 32 bit targets on 64 bit platforms.
* Update test/libponyc/util to call `package_init` in order to
  properly intialize compiler for dynamic targets to fix some failing
  tests.
* Disable some tests in test/libponyc/program.cc because they fail
  when run as part of the full test suite but pass when run without
  other tests in the test suite
  (`./build/debug/libponyc.tests --gtest_also_run_disabled_tests --gtest_filter=ProgramTest.*`).
  These tests can be fixed by adding a `package_done` to `test/libponyc/util.cc` via the following diff:
```
diff --git a/test/libponyc/util.cc b/test/libponyc/util.cc
index 2fa46a2..5e7aa4b 100644
--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -345,6 +345,8 @@ void PassTest::build_package(const char* pass, const char* src,
 
     ASSERT_NE((void*)NULL, *out_package);
   }
+^M
+  package_done(&opt);^M
 }
```
  but this causes other tests to fail. I've confirmed that these same tests fail if the package_init/package_done are added to Pony master also so the failures are not related to the cross compiling changes.

The changes to `src/libponyc/codegen/genprim.c` are a bit of a hack in relation to the `num_conv_t conv[]` declaration/assignment due to the duplication.
