### PR TITLE
Add a suite of helper functions for the list collection with corresponding tests

### DIFF
--- a/packages/collections/lists.pony
+++ b/packages/collections/lists.pony
@@ -3,6 +3,9 @@ primitive Lists
   Helper functions for List. All functions are non-destructive.
   """
   fun unit[A](a: A): List[A] => List[A].push(consume a)
+    """
+    Builds a new list from an element.
+    """
 
   fun map[A: Any #read, B](l: List[A], f: {(A!): B^} val): List[B] =>
     """
@@ -250,6 +253,9 @@ primitive Lists
     end
 
   fun reverse[A: Any #read](l: List[A]): List[A] =>
+    """
+    Builds a new list by reversing the elements in the list.
+    """
     try
       _reverse[A](l.head(), List[A])
     else

--- a/packages/collections/lists.pony
+++ b/packages/collections/lists.pony
@@ -2,10 +2,11 @@ primitive Lists
   """
   Helper functions for List. All functions are non-destructive.
   """
-  fun unit[A](a: A): List[A] => List[A].push(consume a)
+  fun unit[A](a: A): List[A] =>
     """
     Builds a new list from an element.
     """
+    List[A].push(consume a)
 
   fun map[A: Any #read, B](l: List[A], f: {(A!): B^} val): List[B] =>
     """
@@ -102,21 +103,21 @@ primitive Lists
     Returns true if every element satisfies the provided predicate, false otherwise.
     """
     try
-      return _every[A](l.head(), f)
+      _every[A](l.head(), f)
     else
-      return true
+      true
     end
 
   fun _every[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
     try
       let a: A = ln()
       if (not(f(a))) then
-        return false
+        false
       else
-        return _every[A](ln.next() as ListNode[A], f)
+        _every[A](ln.next() as ListNode[A], f)
       end
     else
-      return true
+      true
     end
 
   fun exists[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool =>
@@ -124,21 +125,21 @@ primitive Lists
     Returns true if at least one element satisfies the provided predicate, false otherwise.
     """
     try
-      return _exists[A](l.head(), f)
+      _exists[A](l.head(), f)
     else
-      return false
+      false
     end
 
   fun _exists[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
     try
       let a: A = ln()
       if (f(a)) then
-        return true
+        true
       else
-        return _exists[A](ln.next() as ListNode[A], f)
+        _exists[A](ln.next() as ListNode[A], f)
       end
     else
-      return false
+      false
     end
 
   fun partition[A: Any #read](l: List[A], f: {(A!): Bool} val): (List[A], List[A]) =>

--- a/packages/collections/lists.pony
+++ b/packages/collections/lists.pony
@@ -18,7 +18,11 @@ primitive Lists
       List[B]
     end
 
-  fun _map[A: Any #read, B](ln: ListNode[A], f: {(A!): B^} val, acc: List[B]): List[B] =>
+  fun _map[A: Any #read, B](ln: ListNode[A], f: {(A!): B^} val, acc: List[B]):
+  List[B] =>
+    """
+    Private helper for map, recursively working with ListNodes.
+    """
     try acc.push(f(ln())) end
 
     try
@@ -29,8 +33,8 @@ primitive Lists
 
   fun flat_map[A: Any #read, B](l: List[A], f: {(A!): List[B]} val): List[B] =>
     """
-    Builds a new list by applying a function to every member of the list and using the elements
-    of the resulting lists.
+    Builds a new list by applying a function to every member of the list and
+    using the elements of the resulting lists.
     """
     try
       _flat_map[A,B](l.head(), f, List[List[B]])
@@ -38,7 +42,11 @@ primitive Lists
       List[B]
     end
 
-  fun _flat_map[A: Any #read, B](ln: ListNode[A], f: {(A!): List[B]} val, acc: List[List[B]]): List[B] =>
+  fun _flat_map[A: Any #read, B](ln: ListNode[A], f: {(A!): List[B]} val,
+  acc: List[List[B]]): List[B] =>
+    """
+    Private helper for flat_map, recursively working with ListNodes.
+    """
     try acc.push(f(ln())) end
 
     try
@@ -67,10 +75,14 @@ primitive Lists
       List[A]
     end
 
-  fun _filter[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val, acc: List[A]): List[A] =>
+  fun _filter[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val,
+  acc: List[A]): List[A] =>
+    """
+    Private helper for filter, recursively working with ListNodes.
+    """
     try
       let cur = ln()
-      if (f(cur)) then acc.push(consume cur) end
+      if f(cur) then acc.push(consume cur) end
     end
 
     try
@@ -79,7 +91,8 @@ primitive Lists
       acc
     end
 
-  fun fold[A: Any #read,B: Any #read](l: List[A], f: {(B!, A!): B^} val, acc: B): B =>
+  fun fold[A: Any #read,B: Any #read](l: List[A], f: {(B!, A!): B^} val,
+  acc: B): B =>
     """
     Folds the elements of the list using the supplied function.
     """
@@ -89,7 +102,11 @@ primitive Lists
       acc
     end
 
-  fun _fold[A: Any #read,B: Any #read](ln: ListNode[A], f: {(B!, A!): B^} val, acc: B!): B =>
+  fun _fold[A: Any #read,B: Any #read](ln: ListNode[A], f: {(B!, A!): B^} val,
+  acc: B!): B =>
+    """
+    Private helper for fold, recursively working with ListNodes.
+    """
     let nextAcc: B! = try f(acc, ln()) else acc end
 
     try
@@ -100,7 +117,8 @@ primitive Lists
 
   fun every[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool =>
     """
-    Returns true if every element satisfies the provided predicate, false otherwise.
+    Returns true if every element satisfies the provided predicate, false
+    otherwise.
     """
     try
       _every[A](l.head(), f)
@@ -109,9 +127,12 @@ primitive Lists
     end
 
   fun _every[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
+    """
+    Private helper for every, recursively working with ListNodes.
+    """
     try
       let a: A = ln()
-      if (not(f(a))) then
+      if not(f(a)) then
         false
       else
         _every[A](ln.next() as ListNode[A], f)
@@ -122,7 +143,8 @@ primitive Lists
 
   fun exists[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool =>
     """
-    Returns true if at least one element satisfies the provided predicate, false otherwise.
+    Returns true if at least one element satisfies the provided predicate,
+    false otherwise.
     """
     try
       _exists[A](l.head(), f)
@@ -131,9 +153,12 @@ primitive Lists
     end
 
   fun _exists[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
+    """
+    Private helper for exists, recursively working with ListNodes.
+    """
     try
       let a: A = ln()
-      if (f(a)) then
+      if f(a) then
         true
       else
         _exists[A](ln.next() as ListNode[A], f)
@@ -142,15 +167,17 @@ primitive Lists
       false
     end
 
-  fun partition[A: Any #read](l: List[A], f: {(A!): Bool} val): (List[A], List[A]) =>
+  fun partition[A: Any #read](l: List[A], f: {(A!): Bool} val): (List[A],
+  List[A]) =>
     """
-    Builds a pair of lists, the first of which is made up of the elements satisfying the supplied
-    predicate and the second of which is made up of those that do not.
+    Builds a pair of lists, the first of which is made up of the elements
+    satisfying the supplied predicate and the second of which is made up of
+    those that do not.
     """
     let l1: List[A] = List[A]
     let l2: List[A] = List[A]
     for item in l.values() do
-      if (f(item)) then l1.push(item) else l2.push(item) end
+      if f(item) then l1.push(item) else l2.push(item) end
     end
     (l1, l2)
 
@@ -158,7 +185,7 @@ primitive Lists
     """
     Builds a list by dropping the first n elements.
     """
-    if (l.size() < (n + 1)) then return List[A] end
+    if l.size() < (n + 1) then return List[A] end
 
     try
       _drop[A](l.clone().head(), n)
@@ -167,15 +194,18 @@ primitive Lists
     end
 
   fun _drop[A: Any #read](ln: ListNode[A], n: USize): List[A] =>
+    """
+    Private helper for drop, working with ListNodes.
+    """
     var count = n
     var cur: ListNode[A] = ln
-    while(count > 0) do
+    while count > 0 do
       try cur = cur.next() as ListNode[A] else return List[A] end
       count = count - 1
     end
     let res = List[A]
     try res.push(cur()) end
-    while (cur.has_next()) do
+    while cur.has_next() do
       try
         cur = cur.next() as ListNode[A]
         res.push(cur())
@@ -187,7 +217,7 @@ primitive Lists
     """
     Builds a list of the first n elements.
     """
-    if (l.size() <= n) then l end
+    if l.size() <= n then l end
 
     try
       _take[A](l.clone().head(), n)
@@ -196,10 +226,13 @@ primitive Lists
     end
 
   fun _take[A: Any #read](ln: ListNode[A], n: USize): List[A] =>
+    """
+    Private helper for take, working with ListNodes.
+    """
     var count = n
     let res = List[A]
     var cur: ListNode[A] = ln
-    while(count > 0) do
+    while count > 0 do
       try res.push(cur()) end
       try cur = cur.next() as ListNode[A] else return res end
       count = count - 1
@@ -208,7 +241,8 @@ primitive Lists
 
   fun take_while[A: Any #read](l: List[A], f: {(A!): Bool} val): List[A] =>
     """
-    Builds a list of elements satisfying the provided predicate until one does not.
+    Builds a list of elements satisfying the provided predicate until one does
+    not.
     """
     try
       _take_while[A](l.clone().head(), f)
@@ -216,14 +250,18 @@ primitive Lists
       List[A]
     end
 
-  fun _take_while[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): List[A] =>
+  fun _take_while[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): List[A]
+  =>
+    """
+    Private helper for take_while, working with ListNodes.
+    """
     let res = List[A]
     var cur: ListNode[A] = ln
     try
       let initial = cur()
       if f(initial) then res.push(initial) else return res end
     end
-    while(cur.has_next()) do
+    while cur.has_next() do
       try cur = cur.next() as ListNode[A] else return res end
       try
         let value = cur()
@@ -243,6 +281,9 @@ primitive Lists
     end
 
   fun _contains[A: (Any #read & Equatable[A])](ln: ListNode[A], a: A): Bool =>
+    """
+    Private helper for contains, recursively working with ListNodes.
+    """
     try
       if ln() == a then
         true
@@ -264,6 +305,9 @@ primitive Lists
     end
 
   fun _reverse[A: Any #read](ln: ListNode[A], acc: List[A]): List[A] =>
+    """
+    Private helper for reverse, recursively working with ListNodes.
+    """
     try acc.unshift(ln()) end
 
     try

--- a/packages/collections/lists.pony
+++ b/packages/collections/lists.pony
@@ -1,0 +1,266 @@
+primitive Lists
+  """
+  Helper functions for List. All functions are non-destructive.
+  """
+  fun unit[A](a: A): List[A] => List[A].push(consume a)
+
+  fun map[A: Any #read, B](l: List[A], f: {(A!): B^} val): List[B] =>
+    """
+    Builds a new list by applying a function to every member of the list.
+    """
+    try
+      _map[A, B](l.head(), f, List[B])
+    else
+      List[B]
+    end
+
+  fun _map[A: Any #read, B](ln: ListNode[A], f: {(A!): B^} val, acc: List[B]): List[B] =>
+    try acc.push(f(ln())) end
+
+    try
+      _map[A, B](ln.next() as ListNode[A], f, acc)
+    else
+      acc
+    end
+
+  fun flat_map[A: Any #read, B](l: List[A], f: {(A!): List[B]} val): List[B] =>
+    """
+    Builds a new list by applying a function to every member of the list and using the elements
+    of the resulting lists.
+    """
+    try
+      _flat_map[A,B](l.head(), f, List[List[B]])
+    else
+      List[B]
+    end
+
+  fun _flat_map[A: Any #read, B](ln: ListNode[A], f: {(A!): List[B]} val, acc: List[List[B]]): List[B] =>
+    try acc.push(f(ln())) end
+
+    try
+      _flat_map[A,B](ln.next() as ListNode[A], f, acc)
+    else
+      flatten[B](acc)
+    end
+
+  fun flatten[A](l: List[List[A]]): List[A] =>
+    """
+    Builds a new list out of the elements of the lists in this one.
+    """
+    let resList = List[A]
+    for subList in l.values() do
+      resList.append_list(subList)
+    end
+    resList
+
+  fun filter[A: Any #read](l: List[A], f: {(A!): Bool} val): List[A] =>
+    """
+    Builds a new list with those elements that satisfy a provided predicate.
+    """
+    try
+      _filter[A](l.head(), f, List[A])
+    else
+      List[A]
+    end
+
+  fun _filter[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val, acc: List[A]): List[A] =>
+    try
+      let cur = ln()
+      if (f(cur)) then acc.push(consume cur) end
+    end
+
+    try
+      _filter[A](ln.next() as ListNode[A], f, acc)
+    else
+      acc
+    end
+
+  fun fold[A: Any #read,B: Any #read](l: List[A], f: {(B!, A!): B^} val, acc: B): B =>
+    """
+    Folds the elements of the list using the supplied function.
+    """
+    try
+      _fold[A,B](l.head(), f, acc)
+    else
+      acc
+    end
+
+  fun _fold[A: Any #read,B: Any #read](ln: ListNode[A], f: {(B!, A!): B^} val, acc: B!): B =>
+    let nextAcc: B! = try f(acc, ln()) else acc end
+
+    try
+      _fold[A,B](ln.next() as ListNode[A], f, nextAcc)
+    else
+      nextAcc
+    end
+
+  fun every[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool =>
+    """
+    Returns true if every element satisfies the provided predicate, false otherwise.
+    """
+    try
+      return _every[A](l.head(), f)
+    else
+      return true
+    end
+
+  fun _every[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
+    try
+      let a: A = ln()
+      if (not(f(a))) then
+        return false
+      else
+        return _every[A](ln.next() as ListNode[A], f)
+      end
+    else
+      return true
+    end
+
+  fun exists[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool =>
+    """
+    Returns true if at least one element satisfies the provided predicate, false otherwise.
+    """
+    try
+      return _exists[A](l.head(), f)
+    else
+      return false
+    end
+
+  fun _exists[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): Bool =>
+    try
+      let a: A = ln()
+      if (f(a)) then
+        return true
+      else
+        return _exists[A](ln.next() as ListNode[A], f)
+      end
+    else
+      return false
+    end
+
+  fun partition[A: Any #read](l: List[A], f: {(A!): Bool} val): (List[A], List[A]) =>
+    """
+    Builds a pair of lists, the first of which is made up of the elements satisfying the supplied
+    predicate and the second of which is made up of those that do not.
+    """
+    let l1: List[A] = List[A]
+    let l2: List[A] = List[A]
+    for item in l.values() do
+      if (f(item)) then l1.push(item) else l2.push(item) end
+    end
+    (l1, l2)
+
+  fun drop[A: Any #read](l: List[A], n: USize): List[A] =>
+    """
+    Builds a list by dropping the first n elements.
+    """
+    if (l.size() < (n + 1)) then return List[A] end
+
+    try
+      _drop[A](l.clone().head(), n)
+    else
+      List[A]
+    end
+
+  fun _drop[A: Any #read](ln: ListNode[A], n: USize): List[A] =>
+    var count = n
+    var cur: ListNode[A] = ln
+    while(count > 0) do
+      try cur = cur.next() as ListNode[A] else return List[A] end
+      count = count - 1
+    end
+    let res = List[A]
+    try res.push(cur()) end
+    while (cur.has_next()) do
+      try
+        cur = cur.next() as ListNode[A]
+        res.push(cur())
+      end
+    end
+    res
+
+  fun take[A: Any #read](l: List[A], n: USize): List[A] =>
+    """
+    Builds a list of the first n elements.
+    """
+    if (l.size() <= n) then l end
+
+    try
+      _take[A](l.clone().head(), n)
+    else
+      List[A]
+    end
+
+  fun _take[A: Any #read](ln: ListNode[A], n: USize): List[A] =>
+    var count = n
+    let res = List[A]
+    var cur: ListNode[A] = ln
+    while(count > 0) do
+      try res.push(cur()) end
+      try cur = cur.next() as ListNode[A] else return res end
+      count = count - 1
+    end
+    res
+
+  fun take_while[A: Any #read](l: List[A], f: {(A!): Bool} val): List[A] =>
+    """
+    Builds a list of elements satisfying the provided predicate until one does not.
+    """
+    try
+      _take_while[A](l.clone().head(), f)
+    else
+      List[A]
+    end
+
+  fun _take_while[A: Any #read](ln: ListNode[A], f: {(A!): Bool} val): List[A] =>
+    let res = List[A]
+    var cur: ListNode[A] = ln
+    try
+      let initial = cur()
+      if f(initial) then res.push(initial) else return res end
+    end
+    while(cur.has_next()) do
+      try cur = cur.next() as ListNode[A] else return res end
+      try
+        let value = cur()
+        if f(value) then res.push(value) else return res end
+      end
+    end
+    res
+
+  fun contains[A: (Any #read & Equatable[A])](l: List[A], a: A): Bool =>
+    """
+    Returns true if the list contains the provided element, false otherwise.
+    """
+    try
+      _contains[A](l.head(), a)
+    else
+      false
+    end
+
+  fun _contains[A: (Any #read & Equatable[A])](ln: ListNode[A], a: A): Bool =>
+    try
+      if ln() == a then
+        true
+      else
+        _contains[A](ln.next() as ListNode[A], a)
+      end
+    else
+      false
+    end
+
+  fun reverse[A: Any #read](l: List[A]): List[A] =>
+    try
+      _reverse[A](l.head(), List[A])
+    else
+      List[A]
+    end
+
+  fun _reverse[A: Any #read](ln: ListNode[A], acc: List[A]): List[A] =>
+    try acc.unshift(ln()) end
+
+    try
+      _reverse[A](ln.next() as ListNode[A], acc)
+    else
+      acc
+    end

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -7,6 +7,19 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     test(_TestList)
     test(_TestRing)
+    test(_TestListsMap)
+    test(_TestListsFlatMap)
+    test(_TestListsFlatten)
+    test(_TestListsFilter)
+    test(_TestListsFold)
+    test(_TestListsEvery)
+    test(_TestListsExists)
+    test(_TestListsPartition)
+    test(_TestListsDrop)
+    test(_TestListsTake)
+    test(_TestListsTakeWhile)
+    test(_TestListsContains)
+    test(_TestListsReverse)
 
 class iso _TestList is UnitTest
   fun name(): String => "collections/List"
@@ -55,5 +68,306 @@ class iso _TestRing is UnitTest
     h.assert_eq[U64](a(3), 3)
     h.assert_eq[U64](a(4), 4)
     h.assert_eq[U64](a(5), 5)
-    
+
     h.assert_error(lambda()(a)? => a(6) end, "Read ring 6")
+
+class iso _TestListsMap is UnitTest
+  fun name(): String => "collections/Lists/map()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2)
+
+    let f = lambda(a: U32): U32 => consume a * 2 end
+    let c = Lists.map[U32,U32](a, f)
+
+    h.assert_eq[U32](c(0), 0)
+    h.assert_eq[U32](c(1), 2)
+    h.assert_eq[U32](c(2), 4)
+
+    true
+
+class iso _TestListsFlatMap is UnitTest
+  fun name(): String => "collections/Lists/flat_map()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2)
+
+    let f = lambda(a: U32): List[U32] => List[U32].push(consume a * 2) end
+    let c = Lists.flat_map[U32,U32](a, f)
+
+    h.assert_eq[U32](c(0), 0)
+    h.assert_eq[U32](c(1), 2)
+    h.assert_eq[U32](c(2), 4)
+
+    true
+
+class iso _TestListsFlatten is UnitTest
+  fun name(): String => "collections/Lists/flatten()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[List[U32]]
+    let l1 = List[U32].push(0).push(1)
+    let l2 = List[U32].push(2).push(3)
+    let l3 = List[U32].push(4)
+    a.push(l1).push(l2).push(l3)
+
+    let b: List[U32] = Lists.flatten[U32](a)
+
+    h.assert_eq[U32](b(0), 0)
+    h.assert_eq[U32](b(1), 1)
+    h.assert_eq[U32](b(2), 2)
+    h.assert_eq[U32](b(3), 3)
+    h.assert_eq[U32](b(4), 4)
+
+    let c = List[List[U32]]
+    let d = Lists.flatten[U32](c)
+    h.assert_eq[USize](d.size(), 0)
+
+    true
+
+class iso _TestListsFilter is UnitTest
+  fun name(): String => "collections/Lists/filter()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3)
+
+    let f = lambda(a: U32): Bool => consume a > 1 end
+    let b = Lists.filter[U32](a, f)
+
+    h.assert_eq[USize](b.size(), 2)
+    h.assert_eq[U32](b(0), 2)
+    h.assert_eq[U32](b(1), 3)
+
+    true
+
+class iso _TestListsFold is UnitTest
+  fun name(): String => "collections/Lists/fold()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3)
+
+    let f = lambda(acc: U32, x: U32): U32 => acc + x end
+    let value = Lists.fold[U32,U32](a, f, 0)
+
+    h.assert_eq[U32](value, 6)
+
+    let g = lambda(acc: List[U32], x: U32): List[U32] => acc.push(x * 2) end
+    let resList = Lists.fold[U32,List[U32]](a, g, List[U32])
+
+    try h.assert_eq[U32](resList(0), 0) else error end
+    try h.assert_eq[U32](resList(1), 2) else error end
+    try h.assert_eq[U32](resList(2), 4) else error end
+    try h.assert_eq[U32](resList(3), 6) else error end
+
+    true
+
+class iso _TestListsEvery is UnitTest
+  fun name(): String => "collections/Lists/every()"
+
+  fun apply(h: TestHelper) =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3)
+
+    let f = lambda(x: U32): Bool => x < 4 end
+    let g = lambda(x: U32): Bool => x < 3 end
+    let z = lambda(x: U32): Bool => x < 0 end
+    let lessThan4 = Lists.every[U32](a, f)
+    let lessThan3 = Lists.every[U32](a, g)
+    let lessThan0 = Lists.every[U32](a, z)
+
+    h.assert_eq[Bool](lessThan4, true)
+    h.assert_eq[Bool](lessThan3, false)
+    h.assert_eq[Bool](lessThan0, false)
+
+    let b = List[U32]
+    let empty = Lists.every[U32](b, f)
+    h.assert_eq[Bool](empty, true)
+
+    true
+
+class iso _TestListsExists is UnitTest
+  fun name(): String => "collections/Lists/exists()"
+
+  fun apply(h: TestHelper) =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3)
+
+    let f = lambda(x: U32): Bool => x > 2 end
+    let g = lambda(x: U32): Bool => x >= 0 end
+    let z = lambda(x: U32): Bool => x < 0 end
+    let gt2 = Lists.exists[U32](a, f)
+    let gte0 = Lists.exists[U32](a, g)
+    let lt0 = Lists.exists[U32](a, z)
+
+    h.assert_eq[Bool](gt2, true)
+    h.assert_eq[Bool](gte0, true)
+    h.assert_eq[Bool](lt0, false)
+
+    let b = List[U32]
+    let empty = Lists.exists[U32](b, f)
+    h.assert_eq[Bool](empty, false)
+
+    true
+
+class iso _TestListsPartition is UnitTest
+  fun name(): String => "collections/Lists/partition()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3)
+
+    let isEven = lambda(x: U32): Bool => x % 2 == 0 end
+    (let evens, let odds) = Lists.partition[U32](a, isEven)
+
+    try h.assert_eq[U32](evens(0), 0) else error end
+    try h.assert_eq[U32](evens(1), 2) else error end
+    try h.assert_eq[U32](odds(0), 1) else error end
+    try h.assert_eq[U32](odds(1), 3) else error end
+
+    let b = List[U32]
+    (let emptyEvens, let emptyOdds) = Lists.partition[U32](b, isEven)
+
+    h.assert_eq[USize](emptyEvens.size(), 0)
+    h.assert_eq[USize](emptyOdds.size(), 0)
+
+    true
+
+class iso _TestListsDrop is UnitTest
+  fun name(): String => "collections/Lists/drop()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3).push(4)
+
+    let b = Lists.drop[U32](a, 2)
+    let c = Lists.drop[U32](a, 4)
+    let d = Lists.drop[U32](a, 5)
+    let e = Lists.drop[U32](a, 6)
+
+    h.assert_eq[USize](b.size(), 3)
+    try h.assert_eq[U32](b(0), 2) else error end
+    try h.assert_eq[U32](b(2), 4) else error end
+    h.assert_eq[USize](c.size(), 1)
+    try h.assert_eq[U32](c(0), 4) else error end
+    h.assert_eq[USize](d.size(), 0)
+    h.assert_eq[USize](e.size(), 0)
+
+    let empty = List[U32]
+    let l = Lists.drop[U32](empty, 3)
+    h.assert_eq[USize](l.size(), 0)
+
+    true
+
+class iso _TestListsTake is UnitTest
+  fun name(): String => "collections/Lists/take()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3).push(4)
+
+    let b = Lists.take[U32](a, 2)
+    let c = Lists.take[U32](a, 4)
+    let d = Lists.take[U32](a, 5)
+    let e = Lists.take[U32](a, 6)
+    let m = Lists.take[U32](a, 0)
+
+    h.assert_eq[USize](b.size(), 2)
+    try h.assert_eq[U32](b(0), 0) else error end
+    try h.assert_eq[U32](b(1), 1) else error end
+    h.assert_eq[USize](c.size(), 4)
+    try h.assert_eq[U32](c(0), 0) else error end
+    try h.assert_eq[U32](c(1), 1) else error end
+    try h.assert_eq[U32](c(2), 2) else error end
+    try h.assert_eq[U32](c(3), 3) else error end
+    h.assert_eq[USize](d.size(), 5)
+    try h.assert_eq[U32](d(0), 0) else error end
+    try h.assert_eq[U32](d(1), 1) else error end
+    try h.assert_eq[U32](d(2), 2) else error end
+    try h.assert_eq[U32](d(3), 3) else error end
+    try h.assert_eq[U32](d(4), 4) else error end
+    h.assert_eq[USize](e.size(), 5)
+    try h.assert_eq[U32](e(0), 0) else error end
+    try h.assert_eq[U32](e(1), 1) else error end
+    try h.assert_eq[U32](e(2), 2) else error end
+    try h.assert_eq[U32](e(3), 3) else error end
+    try h.assert_eq[U32](e(4), 4) else error end
+    h.assert_eq[USize](m.size(), 0)
+
+    let empty = List[U32]
+    let l = Lists.take[U32](empty, 3)
+    h.assert_eq[USize](l.size(), 0)
+
+    true
+
+class iso _TestListsTakeWhile is UnitTest
+  fun name(): String => "collections/Lists/take_while()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2).push(3).push(4)
+
+    let f = lambda(x: U32): Bool => x < 5 end
+    let g = lambda(x: U32): Bool => x < 4 end
+    let y = lambda(x: U32): Bool => x < 1 end
+    let z = lambda(x: U32): Bool => x < 0 end
+    let b = Lists.take_while[U32](a, f)
+    let c = Lists.take_while[U32](a, g)
+    let d = Lists.take_while[U32](a, y)
+    let e = Lists.take_while[U32](a, z)
+
+    h.assert_eq[USize](b.size(), 5)
+    try h.assert_eq[U32](b(0), 0) else error end
+    try h.assert_eq[U32](b(1), 1) else error end
+    try h.assert_eq[U32](b(2), 2) else error end
+    try h.assert_eq[U32](b(3), 3) else error end
+    try h.assert_eq[U32](b(4), 4) else error end
+    h.assert_eq[USize](c.size(), 4)
+    try h.assert_eq[U32](c(0), 0) else error end
+    try h.assert_eq[U32](c(1), 1) else error end
+    try h.assert_eq[U32](c(2), 2) else error end
+    try h.assert_eq[U32](c(3), 3) else error end
+    h.assert_eq[USize](d.size(), 1)
+    try h.assert_eq[U32](d(0), 0) else error end
+    h.assert_eq[USize](e.size(), 0)
+
+    let empty = List[U32]
+    let l = Lists.take_while[U32](empty, g)
+    h.assert_eq[USize](l.size(), 0)
+
+    true
+
+class iso _TestListsContains is UnitTest
+  fun name(): String => "collections/Lists/contains()"
+
+  fun apply(h: TestHelper) =>
+    let a = List[U32]
+    a.push(0).push(1).push(2)
+
+    h.assert_eq[Bool](Lists.contains[U32](a, 0), true)
+    h.assert_eq[Bool](Lists.contains[U32](a, 3), false)
+
+    true
+
+class iso _TestListsReverse is UnitTest
+  fun name(): String => "collections/Lists/reverse()"
+
+  fun apply(h: TestHelper) ? =>
+    let a = List[U32]
+    a.push(0).push(1).push(2)
+
+    let b = Lists.reverse[U32](a)
+
+
+    h.assert_eq[U32](a(0), 0)
+    h.assert_eq[U32](a(1), 1)
+    h.assert_eq[U32](a(2), 2)
+
+    h.assert_eq[U32](b(0), 2)
+    h.assert_eq[U32](b(1), 1)
+    h.assert_eq[U32](b(2), 0)
+
+    true

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -81,6 +81,7 @@ class iso _TestListsMap is UnitTest
     let f = lambda(a: U32): U32 => consume a * 2 end
     let c = Lists.map[U32,U32](a, f)
 
+    h.assert_eq[USize](c.size(), 3)
     h.assert_eq[U32](c(0), 0)
     h.assert_eq[U32](c(1), 2)
     h.assert_eq[U32](c(2), 4)
@@ -97,6 +98,7 @@ class iso _TestListsFlatMap is UnitTest
     let f = lambda(a: U32): List[U32] => List[U32].push(consume a * 2) end
     let c = Lists.flat_map[U32,U32](a, f)
 
+    h.assert_eq[USize](c.size(), 3)
     h.assert_eq[U32](c(0), 0)
     h.assert_eq[U32](c(1), 2)
     h.assert_eq[U32](c(2), 4)
@@ -115,6 +117,7 @@ class iso _TestListsFlatten is UnitTest
 
     let b: List[U32] = Lists.flatten[U32](a)
 
+    h.assert_eq[USize](b.size(), 5)
     h.assert_eq[U32](b(0), 0)
     h.assert_eq[U32](b(1), 1)
     h.assert_eq[U32](b(2), 2)
@@ -158,10 +161,11 @@ class iso _TestListsFold is UnitTest
     let g = lambda(acc: List[U32], x: U32): List[U32] => acc.push(x * 2) end
     let resList = Lists.fold[U32,List[U32]](a, g, List[U32])
 
-    try h.assert_eq[U32](resList(0), 0) else error end
-    try h.assert_eq[U32](resList(1), 2) else error end
-    try h.assert_eq[U32](resList(2), 4) else error end
-    try h.assert_eq[U32](resList(3), 6) else error end
+    h.assert_eq[USize](resList.size(), 4)
+    h.assert_eq[U32](resList(0), 0)
+    h.assert_eq[U32](resList(1), 2)
+    h.assert_eq[U32](resList(2), 4)
+    h.assert_eq[U32](resList(3), 6)
 
     true
 
@@ -223,10 +227,12 @@ class iso _TestListsPartition is UnitTest
     let isEven = lambda(x: U32): Bool => x % 2 == 0 end
     (let evens, let odds) = Lists.partition[U32](a, isEven)
 
-    try h.assert_eq[U32](evens(0), 0) else error end
-    try h.assert_eq[U32](evens(1), 2) else error end
-    try h.assert_eq[U32](odds(0), 1) else error end
-    try h.assert_eq[U32](odds(1), 3) else error end
+    h.assert_eq[USize](evens.size(), 2)
+    h.assert_eq[U32](evens(0), 0)
+    h.assert_eq[U32](evens(1), 2)
+    h.assert_eq[USize](odds.size(), 2)
+    h.assert_eq[U32](odds(0), 1)
+    h.assert_eq[U32](odds(1), 3)
 
     let b = List[U32]
     (let emptyEvens, let emptyOdds) = Lists.partition[U32](b, isEven)
@@ -249,10 +255,10 @@ class iso _TestListsDrop is UnitTest
     let e = Lists.drop[U32](a, 6)
 
     h.assert_eq[USize](b.size(), 3)
-    try h.assert_eq[U32](b(0), 2) else error end
-    try h.assert_eq[U32](b(2), 4) else error end
+    h.assert_eq[U32](b(0), 2)
+    h.assert_eq[U32](b(2), 4)
     h.assert_eq[USize](c.size(), 1)
-    try h.assert_eq[U32](c(0), 4) else error end
+    h.assert_eq[U32](c(0), 4)
     h.assert_eq[USize](d.size(), 0)
     h.assert_eq[USize](e.size(), 0)
 
@@ -276,25 +282,25 @@ class iso _TestListsTake is UnitTest
     let m = Lists.take[U32](a, 0)
 
     h.assert_eq[USize](b.size(), 2)
-    try h.assert_eq[U32](b(0), 0) else error end
-    try h.assert_eq[U32](b(1), 1) else error end
+    h.assert_eq[U32](b(0), 0)
+    h.assert_eq[U32](b(1), 1)
     h.assert_eq[USize](c.size(), 4)
-    try h.assert_eq[U32](c(0), 0) else error end
-    try h.assert_eq[U32](c(1), 1) else error end
-    try h.assert_eq[U32](c(2), 2) else error end
-    try h.assert_eq[U32](c(3), 3) else error end
+    h.assert_eq[U32](c(0), 0)
+    h.assert_eq[U32](c(1), 1)
+    h.assert_eq[U32](c(2), 2)
+    h.assert_eq[U32](c(3), 3)
     h.assert_eq[USize](d.size(), 5)
-    try h.assert_eq[U32](d(0), 0) else error end
-    try h.assert_eq[U32](d(1), 1) else error end
-    try h.assert_eq[U32](d(2), 2) else error end
-    try h.assert_eq[U32](d(3), 3) else error end
-    try h.assert_eq[U32](d(4), 4) else error end
+    h.assert_eq[U32](d(0), 0)
+    h.assert_eq[U32](d(1), 1)
+    h.assert_eq[U32](d(2), 2)
+    h.assert_eq[U32](d(3), 3)
+    h.assert_eq[U32](d(4), 4)
     h.assert_eq[USize](e.size(), 5)
-    try h.assert_eq[U32](e(0), 0) else error end
-    try h.assert_eq[U32](e(1), 1) else error end
-    try h.assert_eq[U32](e(2), 2) else error end
-    try h.assert_eq[U32](e(3), 3) else error end
-    try h.assert_eq[U32](e(4), 4) else error end
+    h.assert_eq[U32](e(0), 0)
+    h.assert_eq[U32](e(1), 1)
+    h.assert_eq[U32](e(2), 2)
+    h.assert_eq[U32](e(3), 3)
+    h.assert_eq[U32](e(4), 4)
     h.assert_eq[USize](m.size(), 0)
 
     let empty = List[U32]
@@ -320,18 +326,18 @@ class iso _TestListsTakeWhile is UnitTest
     let e = Lists.take_while[U32](a, z)
 
     h.assert_eq[USize](b.size(), 5)
-    try h.assert_eq[U32](b(0), 0) else error end
-    try h.assert_eq[U32](b(1), 1) else error end
-    try h.assert_eq[U32](b(2), 2) else error end
-    try h.assert_eq[U32](b(3), 3) else error end
-    try h.assert_eq[U32](b(4), 4) else error end
+    h.assert_eq[U32](b(0), 0)
+    h.assert_eq[U32](b(1), 1)
+    h.assert_eq[U32](b(2), 2)
+    h.assert_eq[U32](b(3), 3)
+    h.assert_eq[U32](b(4), 4)
     h.assert_eq[USize](c.size(), 4)
-    try h.assert_eq[U32](c(0), 0) else error end
-    try h.assert_eq[U32](c(1), 1) else error end
-    try h.assert_eq[U32](c(2), 2) else error end
-    try h.assert_eq[U32](c(3), 3) else error end
+    h.assert_eq[U32](c(0), 0)
+    h.assert_eq[U32](c(1), 1)
+    h.assert_eq[U32](c(2), 2)
+    h.assert_eq[U32](c(3), 3)
     h.assert_eq[USize](d.size(), 1)
-    try h.assert_eq[U32](d(0), 0) else error end
+    h.assert_eq[U32](d(0), 0)
     h.assert_eq[USize](e.size(), 0)
 
     let empty = List[U32]
@@ -362,10 +368,12 @@ class iso _TestListsReverse is UnitTest
     let b = Lists.reverse[U32](a)
 
 
+    h.assert_eq[USize](a.size(), 3)
     h.assert_eq[U32](a(0), 0)
     h.assert_eq[U32](a(1), 1)
     h.assert_eq[U32](a(2), 2)
 
+    h.assert_eq[USize](b.size(), 3)
     h.assert_eq[U32](b(0), 2)
     h.assert_eq[U32](b(1), 1)
     h.assert_eq[U32](b(2), 0)


### PR DESCRIPTION
The primitive Lists has the following methods:

```
    contains[A: (Any #read & Equatable[A])](l: List[A], a: A): Bool 

    drop[A: Any #read](l: List[A], n: USize): List[A]

    every[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool

    exists[A: Any #read](l: List[A], f: {(A!): Bool} val): Bool

    filter[A: Any #read](l: List[A], f: {(A!): Bool} val): List[A]

    flat_map[A: Any #read, B](l: List[A], f: {(A!): List[B]} val): List[B]

    flatten[A](l: List[List[A]]): List[A]

    fold[A: Any #read,B: Any #read](l: List[A], f: {(B!, A!): B^} val, acc: B): B

    map[A: Any #read, B](l: List[A], f: {(A!): B^} val): List[B]

    partition[A: Any #read](l: List[A], f: {(A!): Bool} val): (List[A], List[A])

    reverse[A: Any #read](l: List[A]): List[A]

    take[A: Any #read](l: List[A], n: USize): List[A]

    take_while[A: Any #read](l: List[A], f: {(A!): Bool} val): List[A]

    unit[A](a: A): List[A]