### PR TITLE
Standardize publicly linked function names in libponyrt.

### DIFF
--- a/packages/assert/assert.pony
+++ b/packages/assert/assert.pony
@@ -16,7 +16,7 @@ primitive Fact
   fun apply(test: Bool, msg: String = "") ? =>
     if not test then
       if msg.size() > 0 then
-        @fprintf[I32](@os_stderr[Pointer[U8]](), "%s\n".cstring(),
+        @fprintf[I32](@pony_os_stderr[Pointer[U8]](), "%s\n".cstring(),
           msg.cstring())
       end
       error

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -83,7 +83,7 @@ class Array[A] is Seq[A]
     the array.
     """
     if _alloc < len then
-      _alloc = len.max(8).next_pow2()
+      _alloc = len.max(8).ponyint_next_pow2()
       _ptr = _ptr._realloc(_alloc)
     end
     this

--- a/packages/builtin/env.pony
+++ b/packages/builtin/env.pony
@@ -19,9 +19,9 @@ class val Env
     actor is created.
     """
     root = AmbientAuth._create()
-    @os_stdout_setup[None]()
+    @pony_os_stdout_setup[None]()
 
-    input = Stdin._create(@os_stdin_setup[Bool]())
+    input = Stdin._create(@pony_os_stdin_setup[Bool]())
     out = StdStream._out()
     err = StdStream._err()
 

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -1,7 +1,7 @@
-use @asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
+use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
   flags: U32, nsec: U64, noisy: Bool)
-use @asio_event_unsubscribe[None](event: AsioEventID)
-use @asio_event_destroy[None](event: AsioEventID)
+use @pony_asio_event_unsubscribe[None](event: AsioEventID)
+use @pony_asio_event_destroy[None](event: AsioEventID)
 
 interface StdinNotify
   """
@@ -59,13 +59,13 @@ actor Stdin
     if notify is None then
       if _use_event and not _event.is_null() then
         // Unsubscribe the event.
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
         _event = AsioEvent.none()
       end
     elseif _notify is None then
       if _use_event then
         // Create a new event.
-        _event = @asio_event_create(this, 0, AsioEvent.read(), 0, true)
+        _event = @pony_asio_event_create(this, 0, AsioEvent.read(), 0, true)
       else
         // Start the read loop.
         _loop_read()
@@ -88,7 +88,7 @@ actor Stdin
     When the event fires, read from stdin.
     """
     if AsioEvent.disposable(flags) then
-      @asio_event_destroy(event)
+      @pony_asio_event_destroy(event)
     elseif (_event is event) and AsioEvent.readable(flags) then
       _read()
     end
@@ -113,7 +113,7 @@ actor Stdin
         var data = recover Array[U8].undefined(len) end
         var again: Bool = false
 
-        len = @os_stdin_read[USize](data.cstring(), data.space(),
+        len = @pony_os_stdin_read[USize](data.cstring(), data.space(),
           addressof again)
 
         match len
@@ -132,7 +132,7 @@ actor Stdin
         notify(consume data)
 
         if not again then
-          // Not allowed to call os_stdin_read again yet, exit loop.
+          // Not allowed to call pony_os_stdin_read again yet, exit loop.
           return true
         end
 
@@ -158,6 +158,6 @@ actor Stdin
       Close the event.
       """
       if not _event.is_null() then
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
         _event = AsioEvent.none()
       end

--- a/packages/builtin/stdstream.pony
+++ b/packages/builtin/stdstream.pony
@@ -48,13 +48,13 @@ actor StdStream
     """
     Create an async stream for stdout.
     """
-    _stream = @os_stdout[Pointer[None]]()
+    _stream = @pony_os_stdout[Pointer[None]]()
 
   new _err() =>
     """
     Create an async stream for stderr.
     """
-    _stream = @os_stderr[Pointer[None]]()
+    _stream = @pony_os_stderr[Pointer[None]]()
 
   be print(data: ByteSeq) =>
     """
@@ -90,4 +90,4 @@ actor StdStream
     """
     Write the bytes without explicitly flushing.
     """
-    @os_std_write[None](_stream, data.cstring(), data.size())
+    @pony_os_std_write[None](_stream, data.cstring(), data.size())

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -1161,7 +1161,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     end
 
   fun hash(): U64 =>
-    @hash_block[U64](_ptr, _size)
+    @ponyint_hash_block[U64](_ptr, _size)
 
   fun string(fmt: FormatSettings = FormatSettingsDefault): String iso^
   =>

--- a/packages/builtin/uint.pony
+++ b/packages/builtin/uint.pony
@@ -5,7 +5,7 @@ primitive U8 is _UnsignedInteger[U8]
   fun tag min_value(): U8 => 0
   fun tag max_value(): U8 => 0xFF
 
-  fun next_pow2(): U8 =>
+  fun ponyint_next_pow2(): U8 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -35,7 +35,7 @@ primitive U16 is _UnsignedInteger[U16]
   fun tag min_value(): U16 => 0
   fun tag max_value(): U16 => 0xFFFF
 
-  fun next_pow2(): U16 =>
+  fun ponyint_next_pow2(): U16 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -66,7 +66,7 @@ primitive U32 is _UnsignedInteger[U32]
   fun tag min_value(): U32 => 0
   fun tag max_value(): U32 => 0xFFFF_FFFF
 
-  fun next_pow2(): U32 =>
+  fun ponyint_next_pow2(): U32 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -98,7 +98,7 @@ primitive U64 is _UnsignedInteger[U64]
   fun tag min_value(): U64 => 0
   fun tag max_value(): U64 => 0xFFFF_FFFF_FFFF_FFFF
 
-  fun next_pow2(): U64 =>
+  fun ponyint_next_pow2(): U64 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -137,7 +137,7 @@ primitive ULong is _UnsignedInteger[ULong]
       0xFFFF_FFFF_FFFF_FFFF
     end
 
-  fun next_pow2(): ULong =>
+  fun ponyint_next_pow2(): ULong =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -219,7 +219,7 @@ primitive USize is _UnsignedInteger[USize]
       0xFFFF_FFFF_FFFF_FFFF
     end
 
-  fun next_pow2(): USize =>
+  fun ponyint_next_pow2(): USize =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -295,7 +295,7 @@ primitive U128 is _UnsignedInteger[U128]
   fun tag min_value(): U128 => 0
   fun tag max_value(): U128 => 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
-  fun next_pow2(): U128 =>
+  fun ponyint_next_pow2(): U128 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)

--- a/packages/collections/hashfun.pony
+++ b/packages/collections/hashfun.pony
@@ -57,7 +57,7 @@ primitive HashByteSeq
   Hash and equality functions for arbitrary ByteSeq.
   """
   fun hash(x: ByteSeq): U64 =>
-    @hash_block[U64](x.cstring(), x.size())
+    @ponyint_hash_block[U64](x.cstring(), x.size())
 
   fun eq(x: ByteSeq, y: ByteSeq): Bool =>
     if x.size() == y.size() then

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -27,7 +27,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     resize. Defaults to 6.
     """
     let len = (prealloc * 4) / 3
-    let n = len.next_pow2().max(8)
+    let n = len.ponyint_next_pow2().max(8)
     _array = _array.create(n)
 
     for i in Range(0, n) do
@@ -174,7 +174,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     """
     Minimise the memory used for the map.
     """
-    _resize(((_size * 4) / 3).next_pow2().max(8))
+    _resize(((_size * 4) / 3).ponyint_next_pow2().max(8))
     this
 
   fun clone[H2: HashFunction[this->K!] val = H]():

--- a/packages/collections/ringbuffer.pony
+++ b/packages/collections/ringbuffer.pony
@@ -11,7 +11,7 @@ class RingBuffer[A]
     Create a ring buffer with a fixed size. The size will be rounded up to the
     next power of 2.
     """
-    let n = len.max(2).next_pow2()
+    let n = len.max(2).ponyint_next_pow2()
     _mod = n - 1
     _array = Array[A](n)
 

--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -48,8 +48,8 @@ primitive Debug
 
   fun _stream(stream: DebugStream): Pointer[U8] ? =>
     match stream
-    | DebugOut => @os_stdout[Pointer[U8]]()
-    | DebugErr => @os_stderr[Pointer[U8]]()
+    | DebugOut => @pony_os_stdout[Pointer[U8]]()
+    | DebugErr => @pony_os_stderr[Pointer[U8]]()
     else
       error
     end

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -1,12 +1,12 @@
 use "time"
 
-use @o_rdonly[I32]()
-use @o_rdwr[I32]()
-use @o_creat[I32]()
-use @o_trunc[I32]()
-use @o_directory[I32]()
-use @o_cloexec[I32]()
-use @at_removedir[I32]()
+use @ponyint_o_rdonly[I32]()
+use @ponyint_o_rdwr[I32]()
+use @ponyint_o_creat[I32]()
+use @ponyint_o_trunc[I32]()
+use @ponyint_o_directory[I32]()
+use @ponyint_o_cloexec[I32]()
+use @ponyint_at_removedir[I32]()
 use @unlinkat[I32](fd: I32, target: Pointer[U8] tag, flags: I32)
 
 primitive _DirectoryHandle
@@ -46,7 +46,7 @@ class Directory
 
     ifdef posix then
       _fd = @open[I32](from.path.cstring(),
-        @o_rdonly() or @o_directory() or @o_cloexec())
+        @ponyint_o_rdonly() or @ponyint_o_directory() or @ponyint_o_cloexec())
 
       if _fd == -1 then
         error
@@ -90,7 +90,8 @@ class Directory
 
         let h = ifdef linux or freebsd then
           let fd = @openat[I32](fd', ".".cstring(),
-            @o_rdonly() or @o_directory() or @o_cloexec())
+            @ponyint_o_rdonly() or @ponyint_o_directory() or
+            @ponyint_o_cloexec())
           @fdopendir[Pointer[_DirectoryHandle]](fd)
         else
           @opendir[Pointer[_DirectoryHandle]](path'.cstring())
@@ -101,14 +102,14 @@ class Directory
         end
 
         while true do
-          let p = @unix_readdir[Pointer[U8] iso^](h)
+          let p = @ponyint_unix_readdir[Pointer[U8] iso^](h)
           if p.is_null() then break end
           list.push(recover String.from_cstring(consume p) end)
         end
 
         @closedir[I32](h)
       elseif windows then
-        var find = @windows_find_data[Pointer[_DirectoryEntry]]()
+        var find = @ponyint_windows_find_data[Pointer[_DirectoryEntry]]()
         let search = path' + "\\*"
         let h = @FindFirstFileA[Pointer[_DirectoryHandle]](
           search.cstring(), find)
@@ -118,7 +119,7 @@ class Directory
         end
 
         repeat
-          let p = @windows_readdir[Pointer[U8] iso^](find)
+          let p = @ponyint_windows_readdir[Pointer[U8] iso^](find)
 
           if not p.is_null() then
             list.push(recover String.from_cstring(consume p) end)
@@ -147,7 +148,7 @@ class Directory
 
     ifdef linux or freebsd then
       let fd' = @openat[I32](_fd, target.cstring(),
-        @o_rdonly() or @o_directory() or @o_cloexec())
+        @ponyint_o_rdonly() or @ponyint_o_directory() or @ponyint_o_cloexec())
       _relative(path', fd')
     else
       recover create(path') end
@@ -210,7 +211,8 @@ class Directory
 
     ifdef linux or freebsd then
       let fd' = @openat[I32](_fd, target.cstring(),
-        @o_rdwr() or @o_creat() or @o_cloexec(), I32(0x1B6))
+        @ponyint_o_rdwr() or @ponyint_o_creat() or @ponyint_o_cloexec(),
+        I32(0x1B6))
       recover File._descriptor(fd', path') end
     else
       recover File(path') end
@@ -231,7 +233,7 @@ class Directory
 
     ifdef linux or freebsd then
       let fd' = @openat[I32](_fd, target.cstring(),
-        @o_rdonly() or @o_cloexec(), I32(0x1B6))
+        @ponyint_o_rdonly() or @ponyint_o_cloexec(), I32(0x1B6))
       recover File._descriptor(fd', path') end
     else
       recover File(path') end
@@ -427,7 +429,7 @@ class Directory
             end
           end
 
-          @unlinkat(_fd, target.cstring(), @at_removedir()) == 0
+          @unlinkat(_fd, target.cstring(), @ponyint_at_removedir()) == 0
         else
           @unlinkat(_fd, target.cstring(), 0) == 0
         end

--- a/packages/files/fileinfo.pony
+++ b/packages/files/fileinfo.pony
@@ -38,7 +38,7 @@ class val FileInfo
 
     filepath = from
 
-    if not @os_stat[Bool](filepath.path.cstring(), this) then
+    if not @pony_os_stat[Bool](filepath.path.cstring(), this) then
       error
     end
 
@@ -53,7 +53,7 @@ class val FileInfo
 
     filepath = path
 
-    if not @os_fstat[Bool](fd, path.path.cstring(), this) then
+    if not @pony_os_fstat[Bool](fd, path.path.cstring(), this) then
       error
     end
 
@@ -64,6 +64,6 @@ class val FileInfo
 
     filepath = path
 
-    if not @os_fstatat[Bool](fd, from.cstring(), this) then
+    if not @pony_os_fstatat[Bool](fd, from.cstring(), this) then
       error
     end

--- a/packages/files/filepath.pony
+++ b/packages/files/filepath.pony
@@ -164,7 +164,7 @@ class val FilePath
         end
 
         if r != 0 then
-          if @os_errno[I32]() != @os_eexist[I32]() then
+          if @pony_os_errno[I32]() != @pony_os_eexist[I32]() then
             return false
           end
 

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -202,7 +202,7 @@ primitive Path
     Returns the program's working directory. Setting the working directory is
     not supported, as it is not concurrency-safe.
     """
-    recover String.from_cstring(@os_cwd[Pointer[U8]]()) end
+    recover String.from_cstring(@pony_os_cwd[Pointer[U8]]()) end
 
   fun abs(path: String): String =>
     """
@@ -480,7 +480,7 @@ primitive Path
     Return the equivalent canonical absolute path. Raise an error if there
     isn't one.
     """
-    var cstring = @os_realpath[Pointer[U8] iso^](path.cstring())
+    var cstring = @pony_os_realpath[Pointer[U8] iso^](path.cstring())
 
     if cstring.is_null() then
       error

--- a/packages/net/dns.pony
+++ b/packages/net/dns.pony
@@ -36,13 +36,13 @@ primitive DNS
     """
     Returns true if the host is a literal IPv4 address.
     """
-    @os_host_ip4[Bool](host.cstring())
+    @pony_os_host_ip4[Bool](host.cstring())
 
   fun is_ip6(host: String): Bool =>
     """
     Returns true if the host is a literal IPv6 address.
     """
-    @os_host_ip6[Bool](host.cstring())
+    @pony_os_host_ip6[Bool](host.cstring())
 
   fun _resolve(family: U32, host: String, service: String):
     Array[IPAddress] iso^
@@ -51,7 +51,7 @@ primitive DNS
     Turns an addrinfo pointer into an array of addresses.
     """
     var list = recover Array[IPAddress] end
-    var result = @os_addrinfo[Pointer[U8]](
+    var result = @pony_os_addrinfo[Pointer[U8]](
       family, host.cstring(), service.cstring())
 
     if not result.is_null() then
@@ -59,9 +59,9 @@ primitive DNS
 
       while not addr.is_null() do
         let ip = recover IPAddress end
-        @os_getaddr[None](addr, ip)
+        @pony_os_getaddr[None](addr, ip)
         list.push(consume ip)
-        addr = @os_nextaddr[Pointer[U8]](addr)
+        addr = @pony_os_nextaddr[Pointer[U8]](addr)
       end
 
       @freeaddrinfo[None](result)

--- a/packages/net/ipaddress.pony
+++ b/packages/net/ipaddress.pony
@@ -19,13 +19,13 @@ class val IPAddress
     """
     Returns true for an IPv4 address.
     """
-    @os_ipv4[Bool](this)
+    @pony_os_ipv4[Bool](this)
 
   fun ip6(): Bool =>
     """
     Returns true for an IPv6 address.
     """
-    @os_ipv6[Bool](this)
+    @pony_os_ipv6[Bool](this)
 
   fun name(reversedns: Bool = false, servicename: Bool = false):
     (String, String) ?
@@ -36,8 +36,8 @@ class val IPAddress
     var host: Pointer[U8] iso = recover Pointer[U8] end
     var serv: Pointer[U8] iso = recover Pointer[U8] end
 
-    if not @os_nameinfo[Bool](this, addressof host, addressof serv, reversedns,
-      servicename) then
+    if not @pony_os_nameinfo[Bool](this, addressof host, addressof serv,
+      reversedns, servicename) then
       error
     end
 

--- a/packages/net/ssl/sslinit.pony
+++ b/packages/net/ssl/sslinit.pony
@@ -11,5 +11,5 @@ primitive _SSLInit
   fun _init(env: Env) =>
     @SSL_load_error_strings[None]()
     @SSL_library_init[I32]()
-    let cb = @os_ssl_multithreading[Pointer[U8]](@CRYPTO_num_locks[I32]())
+    let cb = @ponyint_ssl_multithreading[Pointer[U8]](@CRYPTO_num_locks[I32]())
     @CRYPTO_set_locking_callback[None](cb)

--- a/packages/net/ssl/x509.pony
+++ b/packages/net/ssl/x509.pony
@@ -103,7 +103,7 @@ primitive X509
             // Build a String from the ASN1 data.
             let data = @ASN1_STRING_data[Pointer[U8]](value)
             let len = @ASN1_STRING_length[I32](value)
-            String.from_cstring(@os_ip_string[Pointer[U8]](data, len))
+            String.from_cstring(@pony_os_ip_string[Pointer[U8]](data, len))
           end)
       end
 

--- a/packages/net/tcplistener.pony
+++ b/packages/net/tcplistener.pony
@@ -18,8 +18,9 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp[AsioEventID](this, host.cstring(), service.cstring())
-    _fd = @asio_event_fd(_event)
+    _event = @pony_os_listen_tcp[AsioEventID](this, host.cstring(),
+      service.cstring())
+    _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
   new ip4(notify: TCPListenNotify iso, host: String = "",
@@ -30,9 +31,9 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp4[AsioEventID](this, host.cstring(),
+    _event = @pony_os_listen_tcp4[AsioEventID](this, host.cstring(),
       service.cstring())
-    _fd = @asio_event_fd(_event)
+    _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
   new ip6(notify: TCPListenNotify iso, host: String = "",
@@ -43,9 +44,9 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @os_listen_tcp6[AsioEventID](this, host.cstring(),
+    _event = @pony_os_listen_tcp6[AsioEventID](this, host.cstring(),
       service.cstring())
-    _fd = @asio_event_fd(_event)
+    _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
   be set_notify(notify: TCPListenNotify iso) =>
@@ -65,7 +66,7 @@ actor TCPListener
     Return the bound IP address.
     """
     let ip = recover IPAddress end
-    @os_sockname[Bool](_fd, ip)
+    @pony_os_sockname[Bool](_fd, ip)
     ip
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
@@ -81,7 +82,7 @@ actor TCPListener
     end
 
     if AsioEvent.disposable(flags) then
-      @asio_event_destroy(_event)
+      @pony_asio_event_destroy(_event)
       _event = AsioEvent.none()
     end
 
@@ -104,13 +105,13 @@ actor TCPListener
     ifdef windows then
       if ns == -1 then
         // Unsubscribe when we get an invalid socket in the event.
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
         return
       end
 
       if ns > 0 then
         if _closed then
-          @os_closesocket[None](ns)
+          @pony_os_socket_close[None](ns)
           return
         end
 
@@ -119,7 +120,7 @@ actor TCPListener
 
       // Queue an accept if we're not at the limit.
       if (_limit == 0) or (_count < _limit) then
-        @os_accept[U32](_event)
+        @pony_os_accept[U32](_event)
       else
         _paused = true
       end
@@ -129,7 +130,7 @@ actor TCPListener
       end
 
       while (_limit == 0) or (_count < _limit) do
-        var fd = @os_accept[U32](_event)
+        var fd = @pony_os_accept[U32](_event)
 
         match fd
         | -1 =>
@@ -154,7 +155,7 @@ actor TCPListener
       TCPConnection._accept(this, _notify.connected(this), ns)
       _count = _count + 1
     else
-      @os_closesocket[None](ns)
+      @pony_os_socket_close[None](ns)
     end
 
   fun ref _notify_listening() =>
@@ -179,12 +180,12 @@ actor TCPListener
     _closed = true
 
     if not _event.is_null() then
-      @os_closesocket[None](_fd)
+      @pony_os_socket_close[None](_fd)
       _fd = -1
 
       // When not on windows, the unsubscribe is done immediately.
       ifdef not windows then
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
       end
 
       _notify.closed(this)

--- a/packages/signals/signalhandler.pony
+++ b/packages/signals/signalhandler.pony
@@ -1,7 +1,7 @@
-use @asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
+use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
   flags: U32, nsec: U64, noisy: Bool)
-use @asio_event_unsubscribe[None](event: AsioEventID)
-use @asio_event_destroy[None](event: AsioEventID)
+use @pony_asio_event_unsubscribe[None](event: AsioEventID)
+use @pony_asio_event_destroy[None](event: AsioEventID)
 
 actor SignalHandler
   """
@@ -17,7 +17,8 @@ actor SignalHandler
     """
     _notify = consume notify
     _sig = sig
-    _event = @asio_event_create(this, 0, AsioEvent.signal(), sig.u64(), false)
+    _event =
+      @pony_asio_event_create(this, 0, AsioEvent.signal(), sig.u64(), false)
 
   be raise() =>
     """
@@ -37,7 +38,7 @@ actor SignalHandler
     destroyed.
     """
     if AsioEvent.disposable(flags) then
-      @asio_event_destroy(event)
+      @pony_asio_event_destroy(event)
     elseif event is _event then
       if not _notify(arg) then
         _dispose()
@@ -49,7 +50,7 @@ actor SignalHandler
     Dispose of the AsioEventID.
     """
     if not _event.is_null() then
-      @asio_event_unsubscribe(_event)
+      @pony_asio_event_unsubscribe(_event)
       _event = AsioEvent.none()
       _notify.dispose()
     end

--- a/packages/time/date.pony
+++ b/packages/time/date.pony
@@ -18,13 +18,13 @@ class Date
     """
     Create a date from a POSIX time.
     """
-    @os_gmtime[None](this, seconds, nanoseconds)
+    @ponyint_gmtime[None](this, seconds, nanoseconds)
 
   fun time(): I64 =>
     """
     Return a POSIX time. Treats the date as UTC.
     """
-    @os_timegm[I64](this)
+    @ponyint_timegm[I64](this)
 
   fun ref normal(): Date^ =>
     """
@@ -33,7 +33,7 @@ class Date
     eg. adding 1000 to hours to advance the time by 1000 hours, and then
     normalising the date.
     """
-    @os_gmtime[None](this, time(), nsec)
+    @ponyint_gmtime[None](this, time(), nsec)
     this
 
   fun format(fmt: String): String =>
@@ -41,5 +41,5 @@ class Date
     Format the time as for strftime.
     """
     recover
-      String.from_cstring(@os_formattime[Pointer[U8]](this, fmt.cstring()))
+      String.from_cstring(@ponyint_formattime[Pointer[U8]](this, fmt.cstring()))
     end

--- a/packages/time/timers.pony
+++ b/packages/time/timers.pony
@@ -1,10 +1,10 @@
 use "collections"
 
-use @asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
+use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
   flags: U32, nsec: U64, noisy: Bool)
-use @asio_event_setnsec[U32](event: AsioEventID, nsec: U64)
-use @asio_event_unsubscribe[None](event: AsioEventID)
-use @asio_event_destroy[None](event: AsioEventID)
+use @pony_asio_event_setnsec[U32](event: AsioEventID, nsec: U64)
+use @pony_asio_event_unsubscribe[None](event: AsioEventID)
+use @pony_asio_event_destroy[None](event: AsioEventID)
 
 actor Timers
   """
@@ -52,7 +52,7 @@ actor Timers
 
       if (_map.size() == 0) and (not _event.is_null()) then
         // Unsubscribe an existing event.
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
         _event = AsioEvent.none()
       end
     end
@@ -67,7 +67,7 @@ actor Timers
     _map.clear()
 
     if not _event.is_null() then
-      @asio_event_unsubscribe(_event)
+      @pony_asio_event_unsubscribe(_event)
       _event = AsioEvent.none()
     end
 
@@ -76,7 +76,7 @@ actor Timers
     When the event fires, advance the timing wheels.
     """
     if AsioEvent.disposable(flags) then
-      @asio_event_destroy(event)
+      @pony_asio_event_destroy(event)
     elseif event is _event then
       _advance()
     end
@@ -107,15 +107,15 @@ actor Timers
     if _event.is_null() then
       if nsec != -1 then
         // Create a new event.
-        _event = @asio_event_create(this, 0, AsioEvent.timer(), nsec, true)
+        _event = @pony_asio_event_create(this, 0, AsioEvent.timer(), nsec, true)
       end
     else
       if nsec != -1 then
         // Update an existing event.
-        @asio_event_setnsec(_event, nsec)
+        @pony_asio_event_setnsec(_event, nsec)
       else
         // Unsubscribe an existing event.
-        @asio_event_unsubscribe(_event)
+        @pony_asio_event_unsubscribe(_event)
         _event = AsioEvent.none()
       end
     end

--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -29,13 +29,13 @@ typedef uint32_t(__stdcall *thread_fn) (void* arg);
 #endif
 
 #if defined(PLATFORM_IS_LINUX)
-void pony_numa_init();
+void ponyint_numa_init();
 
-uint32_t pony_numa_cores();
+uint32_t ponyint_numa_cores();
 
-void pony_numa_core_list(uint32_t* list);
+void ponyint_numa_core_list(uint32_t* list);
 
-uint32_t pony_numa_node_of_cpu(uint32_t cpu);
+uint32_t ponyint_numa_node_of_cpu(uint32_t cpu);
 #endif
 
 bool pony_thread_create(pony_thread_id_t* thread, thread_fn start, uint32_t cpu,

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -320,11 +320,11 @@ static void append_to_token(lexer_t* lexer, char c)
   if(lexer->buflen >= lexer->alloc)
   {
     size_t new_len = (lexer->alloc > 0) ? lexer->alloc << 1 : 64;
-    char* new_buf = (char*)pool_alloc_size(new_len);
+    char* new_buf = (char*)ponyint_pool_alloc_size(new_len);
     memcpy(new_buf, lexer->buffer, lexer->alloc);
 
     if(lexer->alloc > 0)
-      pool_free_size(lexer->alloc, lexer->buffer);
+      ponyint_pool_free_size(lexer->alloc, lexer->buffer);
 
     lexer->buffer = new_buf;
     lexer->alloc = new_len;
@@ -1179,7 +1179,7 @@ void lexer_close(lexer_t* lexer)
     return;
 
   if(lexer->buffer != NULL)
-    pool_free_size(lexer->alloc, lexer->buffer);
+    ponyint_pool_free_size(lexer->alloc, lexer->buffer);
 
   POOL_FREE(lexer_t, lexer);
 }

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -30,7 +30,7 @@ source_t* source_open(const char* file)
 
   source_t* source = POOL_ALLOC(source_t);
   source->file = stringtab(file);
-  source->m = (char*)pool_alloc_size(size);
+  source->m = (char*)ponyint_pool_alloc_size(size);
   source->len = size;
 
   ssize_t read = fread(source->m, sizeof(char), size, fp);
@@ -38,7 +38,7 @@ source_t* source_open(const char* file)
   if(read < size)
   {
     errorf(file, "failed to read entire file");
-    pool_free_size(source->len, source->m);
+    ponyint_pool_free_size(source->len, source->m);
     POOL_FREE(source_t, source);
     fclose(fp);
     return NULL;
@@ -54,7 +54,7 @@ source_t* source_open_string(const char* source_code)
   source_t* source = POOL_ALLOC(source_t);
   source->file = NULL;
   source->len = strlen(source_code);
-  source->m = (char*)pool_alloc_size(source->len);
+  source->m = (char*)ponyint_pool_alloc_size(source->len);
 
   memcpy(source->m, source_code, source->len);
 
@@ -68,7 +68,7 @@ void source_close(source_t* source)
     return;
 
   if(source->m != NULL)
-    pool_free_size(source->len, source->m);
+    ponyint_pool_free_size(source->len, source->m);
 
   POOL_FREE(source_t, source);
 }

--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -12,7 +12,7 @@ static bool ptr_cmp(const char* a, const char* b)
   return a == b;
 }
 
-DEFINE_LIST(strlist, const char, ptr_cmp, NULL);
+DEFINE_LIST(strlist, strlist_t, const char, ptr_cmp, NULL);
 
 typedef struct stringtab_entry_t
 {
@@ -23,7 +23,7 @@ typedef struct stringtab_entry_t
 
 static size_t stringtab_hash(stringtab_entry_t* a)
 {
-  return (size_t)hash_block(a->str, a->len);
+  return (size_t)ponyint_hash_block(a->str, a->len);
 }
 
 static bool stringtab_cmp(stringtab_entry_t* a, stringtab_entry_t* b)
@@ -33,13 +33,14 @@ static bool stringtab_cmp(stringtab_entry_t* a, stringtab_entry_t* b)
 
 static void stringtab_free(stringtab_entry_t* a)
 {
-  pool_free_size(a->buf_size, (char*)a->str);
+  ponyint_pool_free_size(a->buf_size, (char*)a->str);
   POOL_FREE(stringtab_entry_t, a);
 }
 
-DECLARE_HASHMAP(strtable, stringtab_entry_t);
-DEFINE_HASHMAP(strtable, stringtab_entry_t, stringtab_hash, stringtab_cmp,
-  pool_alloc_size, pool_free_size, stringtab_free);
+DECLARE_HASHMAP(strtable, strtable_t, stringtab_entry_t);
+DEFINE_HASHMAP(strtable, strtable_t, stringtab_entry_t, stringtab_hash,
+  stringtab_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
+  stringtab_free);
 
 static strtable_t table;
 
@@ -67,7 +68,7 @@ const char* stringtab_len(const char* string, size_t len)
   if(n != NULL)
     return n->str;
 
-  char* dst = (char*)pool_alloc_size(len + 1);
+  char* dst = (char*)ponyint_pool_alloc_size(len + 1);
   memcpy(dst, string, len);
   dst[len] = '\0';
 
@@ -91,7 +92,7 @@ const char* stringtab_consume(const char* string, size_t buf_size)
 
   if(n != NULL)
   {
-    pool_free_size(buf_size, (void*)string);
+    ponyint_pool_free_size(buf_size, (void*)string);
     return n->str;
   }
 

--- a/src/libponyc/ast/stringtab.h
+++ b/src/libponyc/ast/stringtab.h
@@ -6,13 +6,13 @@
 
 PONY_EXTERN_C_BEGIN
 
-DECLARE_LIST(strlist, const char);
+DECLARE_LIST(strlist, strlist_t, const char);
 
 void stringtab_init();
 const char* stringtab(const char* string);
 const char* stringtab_len(const char* string, size_t len);
 
-// Must be called with a string allocated by pool_alloc_size, which the
+// Must be called with a string allocated by ponyint_pool_alloc_size, which the
 // function takes control of. The function is responsible for freeing this
 // string and it must not be accessed again after the call returns.
 const char* stringtab_consume(const char* string, size_t buf_size);

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -10,7 +10,7 @@
 
 static size_t sym_hash(symbol_t* sym)
 {
-  return hash_ptr(sym->name);
+  return ponyint_hash_ptr(sym->name);
 }
 
 static bool sym_cmp(symbol_t* a, symbol_t* b)
@@ -33,7 +33,7 @@ static void sym_free(symbol_t* sym)
 static const char* name_without_case(const char* name)
 {
   size_t len = strlen(name) + 1;
-  char* buf = (char*)pool_alloc_size(len);
+  char* buf = (char*)ponyint_pool_alloc_size(len);
 
   if(is_type_name(name))
   {
@@ -47,8 +47,8 @@ static const char* name_without_case(const char* name)
   return stringtab_consume(buf, len);
 }
 
-DEFINE_HASHMAP(symtab, symbol_t, sym_hash, sym_cmp, pool_alloc_size,
-  pool_free_size, sym_free);
+DEFINE_HASHMAP(symtab, symtab_t, symbol_t, sym_hash, sym_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, sym_free);
 
 bool is_type_name(const char* name)
 {

--- a/src/libponyc/ast/symtab.h
+++ b/src/libponyc/ast/symtab.h
@@ -27,7 +27,7 @@ typedef struct symbol_t
   size_t branch_count;
 } symbol_t;
 
-DECLARE_HASHMAP(symtab, symbol_t);
+DECLARE_HASHMAP(symtab, symtab_t, symbol_t);
 
 bool is_type_name(const char* name);
 

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -63,7 +63,7 @@ void token_free(token_t* token)
     return;
 
   if(token->printed != NULL)
-    pool_free_size(64, token->printed);
+    ponyint_pool_free_size(64, token->printed);
 
   POOL_FREE(token_t, token);
 }
@@ -125,7 +125,7 @@ const char* token_print(token_t* token)
 
     case TK_INT:
       if (token->printed == NULL)
-        token->printed = (char*)pool_alloc_size(64);
+        token->printed = (char*)ponyint_pool_alloc_size(64);
 
       snprintf(token->printed, 64, "%llu",
         (unsigned long long)token->integer.low);
@@ -134,7 +134,7 @@ const char* token_print(token_t* token)
     case TK_FLOAT:
     {
       if(token->printed == NULL)
-        token->printed = (char*)pool_alloc_size(64);
+        token->printed = (char*)ponyint_pool_alloc_size(64);
 
       int r = snprintf(token->printed, 64, "%g", token->real);
 
@@ -156,7 +156,7 @@ const char* token_print(token_t* token)
     return p;
 
   if(token->printed == NULL)
-    token->printed = (char*)pool_alloc_size(64);
+    token->printed = (char*)ponyint_pool_alloc_size(64);
 
   snprintf(token->printed, 64, "Unknown_token_%d", token->id);
   return token->printed;

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -21,7 +21,7 @@ struct compile_local_t
 
 static size_t compile_local_hash(compile_local_t* p)
 {
-  return hash_ptr(p->name);
+  return ponyint_hash_ptr(p->name);
 }
 
 static bool compile_local_cmp(compile_local_t* a, compile_local_t* b)
@@ -34,8 +34,9 @@ static void compile_local_free(compile_local_t* p)
   POOL_FREE(compile_local_t, p);
 }
 
-DEFINE_HASHMAP(compile_locals, compile_local_t, compile_local_hash,
-  compile_local_cmp, pool_alloc_size, pool_free_size, compile_local_free);
+DEFINE_HASHMAP(compile_locals, compile_locals_t, compile_local_t,
+  compile_local_hash, compile_local_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, compile_local_free);
 
 static void fatal_error(const char* reason)
 {
@@ -231,10 +232,10 @@ static void init_runtime(compile_t* c)
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
 
-  // void pony_destroy($object*)
+  // void ponyint_destroy($object*)
   params[0] = c->object_ptr;
   type = LLVMFunctionType(c->void_type, params, 1, false);
-  value = LLVMAddFunction(c->module, "pony_destroy", type);
+  value = LLVMAddFunction(c->module, "ponyint_destroy", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   //LLVMSetReturnNoAlias(value);
 
@@ -749,7 +750,7 @@ const char* suffix_filename(const char* dir, const char* prefix,
   // Copy to a string with space for a suffix.
   size_t len = strlen(dir) + strlen(prefix) + strlen(file) + strlen(extension)
     + 4;
-  char* filename = (char*)pool_alloc_size(len);
+  char* filename = (char*)ponyint_pool_alloc_size(len);
 
   // Start with no suffix.
 #ifdef PLATFORM_IS_WINDOWS
@@ -781,7 +782,7 @@ const char* suffix_filename(const char* dir, const char* prefix,
   if(suffix >= 100)
   {
     errorf(NULL, "couldn't pick an unused file name");
-    pool_free_size(len, filename);
+    ponyint_pool_free_size(len, filename);
     return NULL;
   }
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -37,7 +37,7 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
 #define GEN_NOTNEEDED (LLVMConstInt(c->i1, 1, false))
 
 typedef struct compile_local_t compile_local_t;
-DECLARE_HASHMAP(compile_locals, compile_local_t);
+DECLARE_HASHMAP(compile_locals, compile_locals_t, compile_local_t);
 
 typedef struct compile_frame_t
 {

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -312,8 +312,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   size_t count = ast_childcount(positional) + 1;
   size_t buf_size = count * sizeof(void*);
 
-  LLVMValueRef* args = (LLVMValueRef*)pool_alloc_size(buf_size);
-  LLVMTypeRef* params = (LLVMTypeRef*)pool_alloc_size(buf_size);
+  LLVMValueRef* args = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
+  LLVMTypeRef* params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
   LLVMGetParamTypes(f_type, params);
 
   ast_t* arg = ast_child(positional);
@@ -325,8 +325,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
 
     if(value == NULL)
     {
-      pool_free_size(buf_size, args);
-      pool_free_size(buf_size, params);
+      ponyint_pool_free_size(buf_size, args);
+      ponyint_pool_free_size(buf_size, params);
       return NULL;
     }
 
@@ -392,8 +392,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       r = codegen_call(c, func, args, i);
   }
 
-  pool_free_size(buf_size, args);
-  pool_free_size(buf_size, params);
+  ponyint_pool_free_size(buf_size, args);
+  ponyint_pool_free_size(buf_size, params);
   return r;
 }
 
@@ -479,7 +479,7 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
 
   int count = (int)ast_childcount(args);
   size_t buf_size = count * sizeof(LLVMTypeRef);
-  LLVMTypeRef* f_params = (LLVMTypeRef*)pool_alloc_size(buf_size);
+  LLVMTypeRef* f_params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
   count = 0;
 
   ast_t* arg = ast_child(args);
@@ -513,10 +513,10 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
       // elements.
       unsigned int count = LLVMCountStructElementTypes(g->use_type);
       size_t buf_size = count * sizeof(LLVMTypeRef);
-      LLVMTypeRef* e_types = (LLVMTypeRef*)pool_alloc_size(buf_size);
+      LLVMTypeRef* e_types = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
       LLVMGetStructElementTypes(g->use_type, e_types);
       r_type = LLVMStructTypeInContext(c->context, e_types, count, false);
-      pool_free_size(buf_size, e_types);
+      ponyint_pool_free_size(buf_size, e_types);
     } else {
       r_type = g->use_type;
     }
@@ -528,7 +528,7 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
       LLVMAddFunctionAttr(func, LLVMNoUnwindAttribute);
   }
 
-  pool_free_size(buf_size, f_params);
+  ponyint_pool_free_size(buf_size, f_params);
   return func;
 }
 
@@ -576,7 +576,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
   // Generate the arguments.
   int count = (int)ast_childcount(args);
   size_t buf_size = count * sizeof(LLVMValueRef);
-  LLVMValueRef* f_args = (LLVMValueRef*)pool_alloc_size(buf_size);
+  LLVMValueRef* f_args = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
 
   LLVMTypeRef f_type = LLVMGetElementType(LLVMTypeOf(func));
   LLVMTypeRef* f_params = NULL;
@@ -584,7 +584,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
 
   if(!vararg)
   {
-    f_params = (LLVMTypeRef*)pool_alloc_size(buf_size);
+    f_params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
     LLVMGetParamTypes(f_type, f_params);
   }
 
@@ -604,7 +604,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
 
     if(f_args[i] == NULL)
     {
-      pool_free_size(buf_size, f_args);
+      ponyint_pool_free_size(buf_size, f_args);
       return NULL;
     }
 
@@ -620,10 +620,10 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
   else
     result = LLVMBuildCall(c->builder, func, f_args, count, "");
 
-  pool_free_size(buf_size, f_args);
+  ponyint_pool_free_size(buf_size, f_args);
 
   if(!vararg)
-    pool_free_size(buf_size, f_params);
+    ponyint_pool_free_size(buf_size, f_params);
 
   // Special case a None return value, which is used for void functions.
   if(is_none(type))
@@ -702,7 +702,7 @@ LLVMValueRef gencall_allocstruct(compile_t* c, gentype_t* g)
   {
     if(size <= HEAP_MAX)
     {
-      uint32_t index = heap_index(size);
+      uint32_t index = ponyint_heap_index(size);
       args[1] = LLVMConstInt(c->i32, index, false);
       result = gencall_runtime(c, "pony_alloc_small", args, 2, "");
     } else {

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -39,7 +39,7 @@ static LLVMValueRef make_unbox_function(compile_t* c, gentype_t* g,
 
   // Leave space for a receiver if it's a constructor vtable entry.
   size_t buf_size = (count + 1) * sizeof(LLVMTypeRef);
-  LLVMTypeRef* params = (LLVMTypeRef*)pool_alloc_size(buf_size);
+  LLVMTypeRef* params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
   LLVMGetParamTypes(f_type, params);
   LLVMTypeRef ret_type = LLVMGetReturnType(f_type);
 
@@ -67,7 +67,7 @@ static LLVMValueRef make_unbox_function(compile_t* c, gentype_t* g,
   LLVMValueRef primitive_ptr = LLVMBuildStructGEP(c->builder, this_ptr, 1, "");
   LLVMValueRef primitive = LLVMBuildLoad(c->builder, primitive_ptr, "");
 
-  LLVMValueRef* args = (LLVMValueRef*)pool_alloc_size(buf_size);
+  LLVMValueRef* args = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
 
   if(t != TK_NEW)
   {
@@ -87,8 +87,8 @@ static LLVMValueRef make_unbox_function(compile_t* c, gentype_t* g,
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
-  pool_free_size(buf_size, params);
-  pool_free_size(buf_size, args);
+  ponyint_pool_free_size(buf_size, params);
+  ponyint_pool_free_size(buf_size, args);
   return LLVMConstBitCast(unbox_fun, c->void_ptr);
 }
 
@@ -150,7 +150,7 @@ static uint32_t trait_count(compile_t* c, gentype_t* g,
 
       // Sort the trait identifiers.
       size_t tid_size = count * sizeof(uint32_t);
-      uint32_t* tid = (uint32_t*)pool_alloc_size(tid_size);
+      uint32_t* tid = (uint32_t*)ponyint_pool_alloc_size(tid_size);
 
       size_t i = HASHMAP_BEGIN;
       size_t index = 0;
@@ -167,7 +167,7 @@ static uint32_t trait_count(compile_t* c, gentype_t* g,
         *list = tid;
         *list_size = tid_size;
       } else {
-        pool_free_size(tid_size, tid);
+        ponyint_pool_free_size(tid_size, tid);
       }
 
       return count;
@@ -193,7 +193,7 @@ static LLVMValueRef make_trait_list(compile_t* c, gentype_t* g,
 
   // Create a constant array of trait identifiers.
   size_t list_size = count * sizeof(LLVMValueRef);
-  LLVMValueRef* list = (LLVMValueRef*)pool_alloc_size(list_size);
+  LLVMValueRef* list = (LLVMValueRef*)ponyint_pool_alloc_size(list_size);
 
   for(uint32_t i = 0; i < count; i++)
     list[i] = LLVMConstInt(c->i32, tid[i], false);
@@ -208,8 +208,8 @@ static LLVMValueRef make_trait_list(compile_t* c, gentype_t* g,
   LLVMSetLinkage(global, LLVMInternalLinkage);
   LLVMSetInitializer(global, trait_array);
 
-  pool_free_size(tid_size, tid);
-  pool_free_size(list_size, list);
+  ponyint_pool_free_size(tid_size, tid);
+  ponyint_pool_free_size(list_size, list);
 
   *final_count = count;
   return global;
@@ -255,7 +255,7 @@ static LLVMValueRef make_field_list(compile_t* c, gentype_t* g)
 
   // Create a constant array of field descriptors.
   size_t buf_size = count * sizeof(LLVMValueRef);
-  LLVMValueRef* list = (LLVMValueRef*)pool_alloc_size(buf_size);
+  LLVMValueRef* list = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
 
   for(int i = 0; i < count; i++)
   {
@@ -289,7 +289,7 @@ static LLVMValueRef make_field_list(compile_t* c, gentype_t* g)
   LLVMSetLinkage(global, LLVMInternalLinkage);
   LLVMSetInitializer(global, field_array);
 
-  pool_free_size(buf_size, list);
+  ponyint_pool_free_size(buf_size, list);
   return global;
 }
 
@@ -301,7 +301,7 @@ static LLVMValueRef make_vtable(compile_t* c, gentype_t* g)
     return LLVMConstArray(c->void_ptr, NULL, 0);
 
   size_t buf_size = vtable_size * sizeof(LLVMValueRef);
-  LLVMValueRef* vtable = (LLVMValueRef*)pool_alloc_size(buf_size);
+  LLVMValueRef* vtable = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
   memset(vtable, 0, buf_size);
 
   reachable_type_t* t = reach_type(c->reachable, g->type_name);
@@ -348,7 +348,7 @@ static LLVMValueRef make_vtable(compile_t* c, gentype_t* g)
   }
 
   LLVMValueRef r = LLVMConstArray(c->void_ptr, vtable, vtable_size);
-  pool_free_size(buf_size, vtable);
+  ponyint_pool_free_size(buf_size, vtable);
   return r;
 }
 

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -164,7 +164,7 @@ static void gen_main(compile_t* c, gentype_t* main_g, gentype_t* env_g)
   uint32_t index = genfun_vtable_index(c, main_g, stringtab("create"), NULL);
 
   size_t msg_size = (size_t)LLVMABISizeOfType(c->target_data, msg_type);
-  args[0] = LLVMConstInt(c->i32, pool_index(msg_size), false);
+  args[0] = LLVMConstInt(c->i32, ponyint_pool_index(msg_size), false);
   args[1] = LLVMConstInt(c->i32, index, false);
   LLVMValueRef msg = gencall_runtime(c, "pony_alloc_msg", args, 2, "");
   LLVMValueRef msg_ptr = LLVMBuildBitCast(c->builder, msg, msg_type_ptr, "");
@@ -204,7 +204,7 @@ static void gen_main(compile_t* c, gentype_t* main_g, gentype_t* env_g)
     LLVMValueRef final_actor = create_main(c, main_g, ctx);
     primitive_call(c, stringtab("_final"), NULL);
     args[0] = final_actor;
-    gencall_runtime(c, "pony_destroy", args, 1, "");
+    gencall_runtime(c, "ponyint_destroy", args, 1, "");
   }
 
   // Return the runtime exit code.
@@ -237,7 +237,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   size_t arch_len = arch - c->opt->triple;
   size_t ld_len = 128 + arch_len + strlen(file_exe) + strlen(file_o) +
     strlen(lib_args);
-  char* ld_cmd = (char*)pool_alloc_size(ld_len);
+  char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
   // Avoid incorrect ld, eg from macports.
   snprintf(ld_cmd, ld_len,
@@ -249,16 +249,16 @@ static bool link_exe(compile_t* c, ast_t* program,
   if(system(ld_cmd) != 0)
   {
     errorf(NULL, "unable to link: %s", ld_cmd);
-    pool_free_size(ld_len, ld_cmd);
+    ponyint_pool_free_size(ld_len, ld_cmd);
     return false;
   }
 
-  pool_free_size(ld_len, ld_cmd);
+  ponyint_pool_free_size(ld_len, ld_cmd);
 
   if(!c->opt->strip_debug)
   {
     size_t dsym_len = 16 + strlen(file_exe);
-    char* dsym_cmd = (char*)pool_alloc_size(dsym_len);
+    char* dsym_cmd = (char*)ponyint_pool_alloc_size(dsym_len);
 
     snprintf(dsym_cmd, dsym_len, "rm -rf %s.dSYM", file_exe);
     system(dsym_cmd);
@@ -268,7 +268,7 @@ static bool link_exe(compile_t* c, ast_t* program,
     if(system(dsym_cmd) != 0)
       errorf(NULL, "unable to create dsym");
 
-    pool_free_size(dsym_len, dsym_cmd);
+    ponyint_pool_free_size(dsym_len, dsym_cmd);
   }
 
 #elif defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_FREEBSD)
@@ -280,7 +280,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* lib_args = program_lib_args(program);
 
   size_t ld_len = 512 + strlen(file_exe) + strlen(file_o) + strlen(lib_args);
-  char* ld_cmd = (char*)pool_alloc_size(ld_len);
+  char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
   snprintf(ld_cmd, ld_len, PONY_COMPILER " -o %s -O3 -march=" PONY_ARCH " "
 #ifndef PLATFORM_IS_ILP32
@@ -305,11 +305,11 @@ static bool link_exe(compile_t* c, ast_t* program,
   if(system(ld_cmd) != 0)
   {
     errorf(NULL, "unable to link: %s", ld_cmd);
-    pool_free_size(ld_len, ld_cmd);
+    ponyint_pool_free_size(ld_len, ld_cmd);
     return false;
   }
 
-  pool_free_size(ld_len, ld_cmd);
+  ponyint_pool_free_size(ld_len, ld_cmd);
 #elif defined(PLATFORM_IS_WINDOWS)
   vcvars_t vcvars;
 
@@ -328,7 +328,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   size_t ld_len = 256 + strlen(file_exe) + strlen(file_o) +
     strlen(vcvars.kernel32) + strlen(vcvars.msvcrt) + strlen(lib_args);
-  char* ld_cmd = (char*)pool_alloc_size(ld_len);
+  char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
   snprintf(ld_cmd, ld_len,
     "cmd /C \"\"%s\" /DEBUG /NOLOGO /MACHINE:X64 "
@@ -343,11 +343,11 @@ static bool link_exe(compile_t* c, ast_t* program,
   if(system(ld_cmd) == -1)
   {
     errorf(NULL, "unable to link: %s", ld_cmd);
-    pool_free_size(ld_len, ld_cmd);
+    ponyint_pool_free_size(ld_len, ld_cmd);
     return false;
   }
 
-  pool_free_size(ld_len, ld_cmd);
+  ponyint_pool_free_size(ld_len, ld_cmd);
 #endif
 
   return true;

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -197,7 +197,7 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
 
   int count = LLVMCountStructElementTypes(l_type);
   size_t buf_size = count * sizeof(LLVMTypeRef);
-  LLVMTypeRef* elements = (LLVMTypeRef*)pool_alloc_size(buf_size);
+  LLVMTypeRef* elements = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
   LLVMGetStructElementTypes(l_type, elements);
 
   LLVMValueRef result = LLVMGetUndef(l_type);
@@ -213,7 +213,7 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
 
     if(cast_value == NULL)
     {
-      pool_free_size(buf_size, elements);
+      ponyint_pool_free_size(buf_size, elements);
       return NULL;
     }
 
@@ -222,7 +222,7 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
     i++;
   }
 
-  pool_free_size(buf_size, elements);
+  ponyint_pool_free_size(buf_size, elements);
   return result;
 }
 

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -106,7 +106,7 @@ static void print_params(compile_t* c, printbuf_t* buf, ast_t* params)
     const char* name = ast_name(id);
     size_t len = strlen(name) + 1;
     size_t buf_size = len;
-    char* buffer = (char*)pool_alloc_size(buf_size);
+    char* buffer = (char*)ponyint_pool_alloc_size(buf_size);
     memcpy(buffer, name, len);
 
     len--;
@@ -117,7 +117,7 @@ static void print_params(compile_t* c, printbuf_t* buf, ast_t* params)
     printbuf(buf, " %s", buffer);
 
     param = ast_sibling(param);
-    pool_free_size(buf_size, buffer);
+    ponyint_pool_free_size(buf_size, buffer);
   }
 }
 

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -158,7 +158,7 @@ static bool link_lib(compile_t* c, const char* file_o)
   printf("Archiving %s\n", file_lib);
 
   size_t len = 32 + strlen(file_lib) + strlen(file_o);
-  char* cmd = (char*)pool_alloc_size(len);
+  char* cmd = (char*)ponyint_pool_alloc_size(len);
 
 #if defined(PLATFORM_IS_MACOSX)
   snprintf(cmd, len, "/usr/bin/ar -rcs %s %s", file_lib, file_o);
@@ -169,11 +169,11 @@ static bool link_lib(compile_t* c, const char* file_o)
   if(system(cmd) != 0)
   {
     errorf(NULL, "unable to link: %s", cmd);
-    pool_free_size(len, cmd);
+    ponyint_pool_free_size(len, cmd);
     return false;
   }
 
-  pool_free_size(len, cmd);
+  ponyint_pool_free_size(len, cmd);
 #elif defined(PLATFORM_IS_WINDOWS)
   const char* file_lib = suffix_filename(c->opt->output, "", c->filename,
     ".lib");
@@ -188,7 +188,7 @@ static bool link_lib(compile_t* c, const char* file_o)
   }
 
   size_t len = 128 + strlen(file_lib) + strlen(file_o);
-  char* cmd = (char*)pool_alloc_size(len);
+  char* cmd = (char*)ponyint_pool_alloc_size(len);
 
   snprintf(cmd, len, "cmd /C \"\"%s\" /NOLOGO /OUT:%s %s\"", vcvars.ar,
     file_lib, file_o);
@@ -196,11 +196,11 @@ static bool link_lib(compile_t* c, const char* file_o)
   if(system(cmd) == -1)
   {
     errorf(NULL, "unable to link: %s", cmd);
-    pool_free_size(len, cmd);
+    ponyint_pool_free_size(len, cmd);
     return false;
   }
 
-  pool_free_size(len, cmd);
+  ponyint_pool_free_size(len, cmd);
 #endif
 
   return true;

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -108,7 +108,7 @@ static const char* build_name(const char* a, const char* b, ast_t* elements,
     len += strlen(cap_str) + 1;
   }
 
-  char* name = (char*)pool_alloc_size(len);
+  char* name = (char*)ponyint_pool_alloc_size(len);
 
   if(a != NULL)
     strcpy(name, a);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -449,7 +449,7 @@ static bool make_struct(compile_t* c, gentype_t* g)
     extra++;
 
   size_t buf_size = (g->field_count + extra) * sizeof(LLVMTypeRef);
-  LLVMTypeRef* elements = (LLVMTypeRef*)pool_alloc_size(buf_size);
+  LLVMTypeRef* elements = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
 
   // Create the type descriptor as element 0.
   if(extra > 0)
@@ -478,7 +478,7 @@ static bool make_struct(compile_t* c, gentype_t* g)
 
     if(!ok)
     {
-      pool_free_size(buf_size, elements);
+      ponyint_pool_free_size(buf_size, elements);
       return false;
     }
   }
@@ -497,7 +497,7 @@ static bool make_struct(compile_t* c, gentype_t* g)
   if(g->underlying == TK_TUPLETYPE)
     make_box_type(c, g);
 
-  pool_free_size(buf_size, elements);
+  ponyint_pool_free_size(buf_size, elements);
   return true;
 }
 

--- a/src/libponyc/debug/symbols.cc
+++ b/src/libponyc/debug/symbols.cc
@@ -59,9 +59,9 @@ static size_t symbol_hash(debug_sym_t* symbol);
 static bool symbol_cmp(debug_sym_t* a, debug_sym_t* b);
 static void symbol_free(debug_sym_t* symbol);
 
-DECLARE_HASHMAP(symbolmap, debug_sym_t);
-DEFINE_HASHMAP(symbolmap, debug_sym_t, symbol_hash, symbol_cmp,
-  pool_alloc_size, pool_free_size, symbol_free);
+DECLARE_HASHMAP(symbolmap, symbolmap_t, debug_sym_t);
+DEFINE_HASHMAP(symbolmap, symbolmap_t, debug_sym_t, symbol_hash, symbol_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, symbol_free);
 
 struct symbols_t
 {
@@ -78,7 +78,7 @@ struct symbols_t
 
 static size_t symbol_hash(debug_sym_t* symbol)
 {
-  return hash_ptr(symbol->name);
+  return ponyint_hash_ptr(symbol->name);
 }
 
 static bool symbol_cmp(debug_sym_t* a, debug_sym_t* b)

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -380,7 +380,7 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
   else
   {
     // Try with a leading underscore
-    char* buf = (char*)pool_alloc_size(name_len + 2);
+    char* buf = (char*)ponyint_pool_alloc_size(name_len + 2);
     buf[0] = '_';
     strncpy(buf + 1, name, name_len + 1);
     const char* try_name = stringtab_consume(buf, name_len + 2);

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -132,8 +132,8 @@ static void doc_list_add_named(ast_list_t* list, ast_t* ast, size_t id_index,
 
 // Cat together the given strings into a newly allocated buffer.
 // Any unneeded strings should be passed as "", not NULL.
-// The returned buffer must be freed with pool_free_size() when no longer
-// needed.
+// The returned buffer must be freed with ponyint_pool_free_size() when
+// no longer needed.
 // The out_buf_size parameter returns the size of the buffer (which is needed
 // for freeing), not the length of the string.
 static char* doc_cat(const char* a, const char* b, const char* c,
@@ -153,7 +153,7 @@ static char* doc_cat(const char* a, const char* b, const char* c,
   size_t e_len = strlen(e);
   size_t buf_len = a_len + b_len + c_len + d_len + e_len + 1;
 
-  char* buffer = (char*)pool_alloc_size(buf_len);
+  char* buffer = (char*)ponyint_pool_alloc_size(buf_len);
   char *p = buffer;
 
   if(a_len > 0) { memcpy(p, a, a_len); p += a_len; }
@@ -181,7 +181,7 @@ static char* doc_cat(const char* a, const char* b, const char* c,
 // Write the TQFN for the given type to a new buffer.
 // By default the type name is taken from the given AST, however this can be
 // overridden by the type_name parameter. Pass NULL to use the default.
-// The returned buffer must be freed using pool_free_size when no longer
+// The returned buffer must be freed using ponyint_pool_free_size when no longer
 // needed. Note that the size reported is the size of the buffer and includes a
 // terminator.
 static char* write_tqfn(ast_t* type, const char* type_name, size_t* out_size)
@@ -243,7 +243,7 @@ static FILE* doc_open_file(docgen_t* docgen, bool in_sub_dir,
   if(file == NULL)
     errorf(NULL, "Could not write documentation to file %s", buffer);
 
-  pool_free_size(buf_len, buffer);
+  ponyint_pool_free_size(buf_len, buffer);
   return file;
 }
 
@@ -303,7 +303,7 @@ static void doc_type(docgen_t* docgen, ast_t* type)
 
       // Links are of the form: [text](target)
       fprintf(docgen->type_file, "[%s](%s)", ast_name(id), tqfn);
-      pool_free_size(link_len, tqfn);
+      ponyint_pool_free_size(link_len, tqfn);
 
       doc_type_list(docgen, tparams, "\\[", ", ", "\\]");
 
@@ -619,7 +619,7 @@ static void doc_entity(docgen_t* docgen, ast_t* ast, ast_t* package)
   fprintf(docgen->index_file, "  - %s %s: \"%s.md\"\n",
     ast_get_print(ast), name, tqfn);
 
-  pool_free_size(tqfn_len, tqfn);
+  ponyint_pool_free_size(tqfn_len, tqfn);
 
   // Now we can write the actual documentation for the entity
   fprintf(docgen->type_file, "%s %s", ast_get_print(ast), name);
@@ -737,7 +737,7 @@ static void doc_package_home(docgen_t* docgen, ast_t* package,
       package_qualified_name(package));
   }
 
-  pool_free_size(tqfn_len, tqfn);
+  ponyint_pool_free_size(tqfn_len, tqfn);
 
   fclose(docgen->type_file);
   docgen->type_file = NULL;
@@ -847,7 +847,7 @@ static void doc_rm_star(const char* path)
 #else
       remove(buf);
 #endif
-      pool_free_size(buf_len, buf);
+      ponyint_pool_free_size(buf_len, buf);
     }
   }
 
@@ -934,8 +934,8 @@ void generate_docs(ast_t* program, pass_opt_t* options)
    fclose(docgen.home_file);
 
   if(docgen.base_dir != NULL)
-    pool_free_size(docgen.base_dir_buf_len, (void*)docgen.base_dir);
+    ponyint_pool_free_size(docgen.base_dir_buf_len, (void*)docgen.base_dir);
 
   if(docgen.sub_dir != NULL)
-    pool_free_size(docgen.sub_dir_buf_len, (void*)docgen.sub_dir);
+    ponyint_pool_free_size(docgen.sub_dir_buf_len, (void*)docgen.sub_dir);
 }

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1078,7 +1078,7 @@ static ast_result_t sugar_ffi(ast_t* ast)
   }
 
   // Prefix '@' to the name
-  char* new_name = (char*)pool_alloc_size(len + 2);
+  char* new_name = (char*)ponyint_pool_alloc_size(len + 2);
   new_name[0] = '@';
   memcpy(new_name + 1, name, len);
   new_name[len + 1] = '\0';

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -687,7 +687,7 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
 
       // Create an all lower case version of the name for comparisons.
       size_t len = strlen(name) + 1;
-      char* lower_case = (char*)pool_alloc_size(len);
+      char* lower_case = (char*)ponyint_pool_alloc_size(len);
 
       for(size_t i = 0; i < len; i++)
         lower_case[i] = (char)tolower(name[i]);
@@ -701,7 +701,7 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
         if(strcmp(lower_case, _illegal_flags[i]) == 0)
           r = false;
 
-      pool_free_size(len, lower_case);
+      ponyint_pool_free_size(len, lower_case);
 
       if(!r)
       {

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -72,7 +72,7 @@ typedef struct flag_t
 static size_t flag_hash(flag_t* flag)
 {
   assert(flag != NULL);
-  return hash_ptr(flag->name);
+  return ponyint_hash_ptr(flag->name);
 }
 
 static bool flag_cmp(flag_t* a, flag_t* b)
@@ -98,9 +98,9 @@ static void flag_free(flag_t* flag)
   POOL_FREE(flag_t, flag);
 }
 
-DECLARE_HASHMAP(flagtab, flag_t);
-DEFINE_HASHMAP(flagtab, flag_t, flag_hash, flag_cmp, pool_alloc_size,
-  pool_free_size, flag_free);
+DECLARE_HASHMAP(flagtab, flagtab_t, flag_t);
+DEFINE_HASHMAP(flagtab, flagtab_t, flag_t, flag_hash, flag_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, flag_free);
 
 
 struct buildflagset_t
@@ -145,7 +145,7 @@ void buildflagset_free(buildflagset_t* set)
     POOL_FREE(flagtab_t, set->flags);
 
     if(set->buffer_size > 0)
-      pool_free_size(set->buffer_size, set->text_buffer);
+      ponyint_pool_free_size(set->buffer_size, set->text_buffer);
 
     POOL_FREE(buildflagset_t, set);
   }
@@ -486,9 +486,9 @@ const char* buildflagset_print(buildflagset_t* set)
   {
     // Buffer we have isn't big enough, make it bigger then go round again.
     if(set->buffer_size > 0)
-      pool_free_size(set->buffer_size, set->text_buffer);
+      ponyint_pool_free_size(set->buffer_size, set->text_buffer);
 
-    set->text_buffer = (char*)pool_alloc_size(size_needed);
+    set->text_buffer = (char*)ponyint_pool_alloc_size(size_needed);
     set->buffer_size = size_needed;
     set->text_buffer[0] = '\0';
     buildflagset_print(set);

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -369,7 +369,7 @@ static const char* id_to_string(const char* prefix, size_t id)
 
   size_t len = strlen(prefix);
   size_t buf_size = len + 32;
-  char* buffer = (char*)pool_alloc_size(buf_size);
+  char* buffer = (char*)ponyint_pool_alloc_size(buf_size);
   snprintf(buffer, buf_size, "%s$" __zu, prefix, id);
   return stringtab_consume(buffer, buf_size);
 }
@@ -406,7 +406,7 @@ static const char* string_to_symbol(const char* string)
 
   size_t len = strlen(string);
   size_t buf_size = len + prefix + 1;
-  char* buf = (char*)pool_alloc_size(buf_size);
+  char* buf = (char*)ponyint_pool_alloc_size(buf_size);
   memcpy(buf + prefix, string, len + 1);
 
   if(prefix)
@@ -438,7 +438,7 @@ static const char* symbol_suffix(const char* symbol, size_t suffix)
 {
   size_t len = strlen(symbol);
   size_t buf_size = len + 32;
-  char* buf = (char*)pool_alloc_size(buf_size);
+  char* buf = (char*)ponyint_pool_alloc_size(buf_size);
   snprintf(buf, buf_size, "%s" __zu, symbol, suffix);
 
   return stringtab_consume(buf, buf_size);
@@ -828,7 +828,7 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options)
         size_t base_name_len = strlen(base_name);
         size_t path_len = strlen(path);
         size_t len = base_name_len + path_len + 2;
-        char* q_name = (char*)pool_alloc_size(len);
+        char* q_name = (char*)ponyint_pool_alloc_size(len);
         memcpy(q_name, base_name, base_name_len);
         q_name[base_name_len] = '/';
         memcpy(q_name + base_name_len + 1, path, path_len);

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -88,7 +88,7 @@ static const char* quoted_locator(ast_t* use, const char* locator)
   }
 
   size_t len = strlen(locator);
-  char* quoted = (char*)pool_alloc_size(len + 3);
+  char* quoted = (char*)ponyint_pool_alloc_size(len + 3);
   quoted[0] = '"';
   memcpy(quoted + 1, locator, len);
   quoted[len + 1] = '"';

--- a/src/libponyc/platform/paths.c
+++ b/src/libponyc/platform/paths.c
@@ -104,7 +104,7 @@ void pony_mkdir(const char* path)
   // Copy the given path into a new buffer, one directory at a time, creating
   // each as we go
   size_t path_len = strlen(path);
-  char* buf = (char*)pool_alloc_size(path_len + 1); // + 1 for terminator
+  char* buf = (char*)ponyint_pool_alloc_size(path_len + 1); // +1 for terminator
 
   for(size_t i = 0; i < path_len; i++)
   {
@@ -134,5 +134,5 @@ void pony_mkdir(const char* path)
   mkdir(path, 0777);
 #endif
 
-  pool_free_size(path_len + 1, buf);
+  ponyint_pool_free_size(path_len + 1, buf);
 }

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -58,7 +58,7 @@ static bool query_registry(HKEY key, bool query_subkeys, query_callback_fn fn,
 
   HKEY node;
   DWORD size = largest_subkey;
-  char* name = (char*)pool_alloc_size(largest_subkey);
+  char* name = (char*)ponyint_pool_alloc_size(largest_subkey);
   bool r = true;
 
   for(DWORD i = 0; i < sub_keys; ++i)
@@ -76,7 +76,7 @@ static bool query_registry(HKEY key, bool query_subkeys, query_callback_fn fn,
     size = largest_subkey;
   }
 
-  pool_free_size(largest_subkey, name);
+  ponyint_pool_free_size(largest_subkey, name);
   return true;
 }
 

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -86,7 +86,7 @@ typedef struct name_record_t
 // We keep our name records in a hash map
 static size_t name_record_hash(name_record_t* p)
 {
-  return hash_ptr(p->name);
+  return ponyint_hash_ptr(p->name);
 }
 
 static bool name_record_cmp(name_record_t* a, name_record_t* b)
@@ -96,13 +96,14 @@ static bool name_record_cmp(name_record_t* a, name_record_t* b)
 
 static void name_record_free(name_record_t* p)
 {
-  pool_free_size(p->typemap_size * sizeof(uint64_t), p->type_map);
+  ponyint_pool_free_size(p->typemap_size * sizeof(uint64_t), p->type_map);
   POOL_FREE(name_record_t, p);
 }
 
-DECLARE_HASHMAP(name_records, name_record_t);
-DEFINE_HASHMAP(name_records, name_record_t, name_record_hash, name_record_cmp,
-  pool_alloc_size, pool_free_size, name_record_free);
+DECLARE_HASHMAP(name_records, name_records_t, name_record_t);
+DEFINE_HASHMAP(name_records, name_records_t, name_record_t, name_record_hash,
+  name_record_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
+  name_record_free);
 
 
 typedef struct colour_record_t
@@ -189,7 +190,7 @@ static name_record_t* add_name(painter_t* painter, const char* name)
   n->name = name;
   n->colour = UNASSIGNED_COLOUR;
   n->typemap_size = painter->typemap_size;
-  n->type_map = (uint64_t*)pool_alloc_size(map_byte_count);
+  n->type_map = (uint64_t*)ponyint_pool_alloc_size(map_byte_count);
   memset(n->type_map, 0, map_byte_count);
 
   name_records_put(&painter->names, n);
@@ -206,7 +207,7 @@ static colour_record_t* add_colour(painter_t* painter)
 
   colour_record_t* n = POOL_ALLOC(colour_record_t);
   n->colour = painter->colour_count;
-  n->type_map = (uint64_t*)pool_alloc_size(map_byte_count);
+  n->type_map = (uint64_t*)ponyint_pool_alloc_size(map_byte_count);
   n->next = NULL;
   memset(n->type_map, 0, map_byte_count);
 
@@ -400,7 +401,7 @@ static void painter_tidy(painter_t* painter)
   while(c != NULL)
   {
     colour_record_t* next = c->next;
-    pool_free_size(map_byte_count, c->type_map);
+    ponyint_pool_free_size(map_byte_count, c->type_map);
     POOL_FREE(sizeof(colour_record_t), c);
     c = next;
   }

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -10,8 +10,10 @@
 #include <string.h>
 #include <assert.h>
 
-DECLARE_STACK(reachable_method_stack, reachable_method_t);
-DEFINE_STACK(reachable_method_stack, reachable_method_t);
+DECLARE_STACK(reachable_method_stack, reachable_method_stack_t,
+  reachable_method_t);
+DEFINE_STACK(reachable_method_stack, reachable_method_stack_t,
+  reachable_method_t);
 
 static reachable_type_t* add_type(reachable_method_stack_t** s,
   reachable_types_t* r, uint32_t* next_type_id, ast_t* type);
@@ -25,7 +27,7 @@ static void reachable_expr(reachable_method_stack_t** s,
 
 static size_t reachable_method_hash(reachable_method_t* m)
 {
-  return hash_ptr(m->name);
+  return ponyint_hash_ptr(m->name);
 }
 
 static bool reachable_method_cmp(reachable_method_t* a, reachable_method_t* b)
@@ -40,13 +42,13 @@ static void reachable_method_free(reachable_method_t* m)
   POOL_FREE(reachable_method_t, m);
 }
 
-DEFINE_HASHMAP(reachable_methods, reachable_method_t, reachable_method_hash,
-  reachable_method_cmp, pool_alloc_size, pool_free_size, reachable_method_free
-  );
+DEFINE_HASHMAP(reachable_methods, reachable_methods_t, reachable_method_t,
+  reachable_method_hash, reachable_method_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, reachable_method_free);
 
 static size_t reachable_method_name_hash(reachable_method_name_t* m)
 {
-  return hash_ptr(m->name);
+  return ponyint_hash_ptr(m->name);
 }
 
 static bool reachable_method_name_cmp(reachable_method_name_t* a,
@@ -61,13 +63,14 @@ static void reachable_method_name_free(reachable_method_name_t* m)
   POOL_FREE(reachable_method_name_t, m);
 }
 
-DEFINE_HASHMAP(reachable_method_names, reachable_method_name_t,
-  reachable_method_name_hash, reachable_method_name_cmp, pool_alloc_size,
-  pool_free_size, reachable_method_name_free);
+DEFINE_HASHMAP(reachable_method_names, reachable_method_names_t,
+  reachable_method_name_t, reachable_method_name_hash,
+  reachable_method_name_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
+  reachable_method_name_free);
 
 static size_t reachable_type_hash(reachable_type_t* t)
 {
-  return hash_ptr(t->name);
+  return ponyint_hash_ptr(t->name);
 }
 
 static bool reachable_type_cmp(reachable_type_t* a, reachable_type_t* b)
@@ -83,11 +86,13 @@ static void reachable_type_free(reachable_type_t* t)
   POOL_FREE(reachable_type_t, t);
 }
 
-DEFINE_HASHMAP(reachable_types, reachable_type_t, reachable_type_hash,
-  reachable_type_cmp, pool_alloc_size, pool_free_size, reachable_type_free);
+DEFINE_HASHMAP(reachable_types, reachable_types_t, reachable_type_t,
+  reachable_type_hash, reachable_type_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, reachable_type_free);
 
-DEFINE_HASHMAP(reachable_type_cache, reachable_type_t, reachable_type_hash,
-  reachable_type_cmp, pool_alloc_size, pool_free_size, NULL);
+DEFINE_HASHMAP(reachable_type_cache, reachable_type_cache_t, reachable_type_t,
+  reachable_type_hash, reachable_type_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, NULL);
 
 static void add_rmethod(reachable_method_stack_t** s,
   reachable_type_t* t, reachable_method_name_t* n, ast_t* typeargs)

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -11,10 +11,13 @@ typedef struct reachable_method_t reachable_method_t;
 typedef struct reachable_method_name_t reachable_method_name_t;
 typedef struct reachable_type_t reachable_type_t;
 
-DECLARE_HASHMAP(reachable_methods, reachable_method_t);
-DECLARE_HASHMAP(reachable_method_names, reachable_method_name_t);
-DECLARE_HASHMAP(reachable_types, reachable_type_t);
-DECLARE_HASHMAP(reachable_type_cache, reachable_type_t);
+DECLARE_HASHMAP(reachable_methods, reachable_methods_t,
+  reachable_method_t);
+DECLARE_HASHMAP(reachable_method_names, reachable_method_names_t,
+  reachable_method_name_t);
+DECLARE_HASHMAP(reachable_types, reachable_types_t, reachable_type_t);
+DECLARE_HASHMAP(reachable_type_cache, reachable_type_cache_t,
+  reachable_type_t);
 
 struct reachable_method_t
 {

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -30,29 +30,25 @@ typedef struct pony_actor_t
   gc_t gc; // 44/80 bytes
 } pony_actor_t;
 
-bool actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch);
+bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch);
 
-void actor_destroy(pony_actor_t* actor);
+void ponyint_actor_destroy(pony_actor_t* actor);
 
-gc_t* actor_gc(pony_actor_t* actor);
+gc_t* ponyint_actor_gc(pony_actor_t* actor);
 
-heap_t* actor_heap(pony_actor_t* actor);
+heap_t* ponyint_actor_heap(pony_actor_t* actor);
 
-bool actor_pendingdestroy(pony_actor_t* actor);
+bool ponyint_actor_pendingdestroy(pony_actor_t* actor);
 
-void actor_setpendingdestroy(pony_actor_t* actor);
+void ponyint_actor_setpendingdestroy(pony_actor_t* actor);
 
-void actor_final(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_actor_final(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void actor_sendrelease(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_actor_sendrelease(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void actor_setsystem(pony_actor_t* actor);
+void ponyint_actor_setsystem(pony_actor_t* actor);
 
-pony_actor_t* actor_next(pony_actor_t* actor);
-
-void actor_setnext(pony_actor_t* actor, pony_actor_t* next);
-
-void pony_destroy(pony_actor_t* actor);
+void ponyint_destroy(pony_actor_t* actor);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -5,7 +5,7 @@
 
 #ifndef NDEBUG
 
-size_t messageq_size_debug(messageq_t* q)
+static size_t messageq_size_debug(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
   size_t count = 0;
@@ -21,7 +21,7 @@ size_t messageq_size_debug(messageq_t* q)
 
 #endif
 
-void messageq_init(messageq_t* q)
+void ponyint_messageq_init(messageq_t* q)
 {
   pony_msg_t* stub = POOL_ALLOC(pony_msg_t);
   stub->size = POOL_INDEX(sizeof(pony_msg_t));
@@ -35,17 +35,17 @@ void messageq_init(messageq_t* q)
 #endif
 }
 
-void messageq_destroy(messageq_t* q)
+void ponyint_messageq_destroy(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
   assert(((uintptr_t)q->head & ~(uintptr_t)1) == (uintptr_t)tail);
 
-  pool_free(tail->size, tail);
+  ponyint_pool_free(tail->size, tail);
   q->head = NULL;
   q->tail = NULL;
 }
 
-bool messageq_push(messageq_t* q, pony_msg_t* m)
+bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m)
 {
   m->next = NULL;
 
@@ -59,7 +59,7 @@ bool messageq_push(messageq_t* q, pony_msg_t* m)
   return was_empty;
 }
 
-pony_msg_t* messageq_pop(messageq_t* q)
+pony_msg_t* ponyint_messageq_pop(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = _atomic_load(&tail->next);
@@ -67,13 +67,13 @@ pony_msg_t* messageq_pop(messageq_t* q)
   if(next != NULL)
   {
     q->tail = next;
-    pool_free(tail->size, tail);
+    ponyint_pool_free(tail->size, tail);
   }
 
   return next;
 }
 
-bool messageq_markempty(messageq_t* q)
+bool ponyint_messageq_markempty(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* head = _atomic_load(&q->head);

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -12,15 +12,15 @@ typedef struct messageq_t
   pony_msg_t* tail;
 } messageq_t;
 
-void messageq_init(messageq_t* q);
+void ponyint_messageq_init(messageq_t* q);
 
-void messageq_destroy(messageq_t* q);
+void ponyint_messageq_destroy(messageq_t* q);
 
-bool messageq_push(messageq_t* q, pony_msg_t* m);
+bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m);
 
-pony_msg_t* messageq_pop(messageq_t* q);
+pony_msg_t* ponyint_messageq_pop(messageq_t* q);
 
-bool messageq_markempty(messageq_t* q);
+bool ponyint_messageq_markempty(messageq_t* q);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -25,33 +25,33 @@ static asio_base_t running_base;
  *  not need to maintain a thread pool. Instead, I/O is processed in the
  *  context of the owning actor.
  */
-asio_backend_t* asio_get_backend()
+asio_backend_t* ponyint_asio_get_backend()
 {
   return running_base.backend;
 }
 
-void asio_init()
+void ponyint_asio_init()
 {
-  running_base.backend = asio_backend_init();
+  running_base.backend = ponyint_asio_backend_init();
 }
 
-bool asio_start()
+bool ponyint_asio_start()
 {
-  if(!pony_thread_create(&running_base.tid, asio_backend_dispatch, -1,
+  if(!pony_thread_create(&running_base.tid, ponyint_asio_backend_dispatch, -1,
     running_base.backend))
     return false;
 
   return true;
 }
 
-bool asio_stop()
+bool ponyint_asio_stop()
 {
   if(_atomic_load(&running_base.noisy_count) > 0)
     return false;
 
   if(running_base.backend != NULL)
   {
-    asio_backend_terminate(running_base.backend);
+    ponyint_asio_backend_final(running_base.backend);
     pony_thread_join(running_base.tid);
 
     running_base.backend = NULL;
@@ -61,12 +61,12 @@ bool asio_stop()
   return true;
 }
 
-void asio_noisy_add()
+void ponyint_asio_noisy_add()
 {
   _atomic_add(&running_base.noisy_count, 1);
 }
 
-void asio_noisy_remove()
+void ponyint_asio_noisy_remove()
 {
   _atomic_add(&running_base.noisy_count, -1);
 }

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -47,13 +47,13 @@ typedef struct asio_base_t asio_base_t;
 /** Initializes an ASIO backend.
  *
  */
-asio_backend_t* asio_backend_init();
+asio_backend_t* ponyint_asio_backend_init();
 
 /// Call this when the scheduler is initialised.
-void asio_init();
+void ponyint_asio_init();
 
 /// Call this when the scheduler runs its threads.
-bool asio_start();
+bool ponyint_asio_start();
 
 /** Returns the underlying mechanism for I/O event notification of the running
  * ASIO base.
@@ -65,7 +65,7 @@ bool asio_start();
  *
  * If there is no current running backend, one will be started.
  */
-asio_backend_t* asio_get_backend();
+asio_backend_t* ponyint_asio_get_backend();
 
 /** Attempts to stop an asynchronous event mechanism.
  *
@@ -75,15 +75,15 @@ asio_backend_t* asio_get_backend();
  * Subscribers need to release their interest in an I/O resource before we can
  * shut down.
  */
-bool asio_stop();
+bool ponyint_asio_stop();
 
 /** Add a noisy event subscription.
  */
-void asio_noisy_add();
+void ponyint_asio_noisy_add();
 
 /** Remove a noisy event subscription.
  */
-void asio_noisy_remove();
+void ponyint_asio_noisy_remove();
 
 /** Destroys an ASIO backend.
  *
@@ -92,7 +92,7 @@ void asio_noisy_remove();
  * Destroying a backend causes the dispatch loop to be exited, such that the
  * ASIO thread can terminate.
  */
-void asio_backend_terminate(asio_backend_t* backend);
+void ponyint_asio_backend_final(asio_backend_t* backend);
 
 /** Entry point for the ASIO thread.
  *
@@ -102,14 +102,14 @@ void asio_backend_terminate(asio_backend_t* backend);
  * The return code of the ASIO thread is not of interest. Therefore, the ASIO
  * thread is detached an does not need to be joined.
  */
-DECLARE_THREAD_FN(asio_backend_dispatch);
+DECLARE_THREAD_FN(ponyint_asio_backend_dispatch);
 
 
 #ifdef ASIO_USE_IOCP
 
 // Resume waiting on stdin after a read.
 // Should only be called from stdfd.c.
-void iocp_resume_stdin();
+void ponyint_iocp_resume_stdin();
 
 #endif
 

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -5,8 +5,8 @@
 #include <string.h>
 #include <assert.h>
 
-asio_event_t* asio_event_create(pony_actor_t* owner, int fd, uint32_t flags,
-  uint64_t nsec, bool noisy)
+asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
+  uint32_t flags, uint64_t nsec, bool noisy)
 {
   if((flags == ASIO_DISPOSABLE) || (flags == ASIO_DESTROYED))
     return NULL;
@@ -33,11 +33,11 @@ asio_event_t* asio_event_create(pony_actor_t* owner, int fd, uint32_t flags,
   pony_traceactor(ctx, owner);
   pony_send_done(ctx);
 
-  asio_event_subscribe(ev);
+  pony_asio_event_subscribe(ev);
   return ev;
 }
 
-void asio_event_destroy(asio_event_t* ev)
+void pony_asio_event_destroy(asio_event_t* ev)
 {
   if((ev == NULL) || (ev->magic != ev) || (ev->flags != ASIO_DISPOSABLE))
   {
@@ -57,7 +57,7 @@ void asio_event_destroy(asio_event_t* ev)
   POOL_FREE(asio_event_t, ev);
 }
 
-int asio_event_fd(asio_event_t* ev)
+int pony_asio_event_fd(asio_event_t* ev)
 {
   if(ev == NULL)
     return -1;
@@ -65,7 +65,7 @@ int asio_event_fd(asio_event_t* ev)
   return ev->fd;
 }
 
-uint64_t asio_event_nsec(asio_event_t* ev)
+uint64_t pony_asio_event_nsec(asio_event_t* ev)
 {
   if(ev == NULL)
     return 0;
@@ -73,7 +73,7 @@ uint64_t asio_event_nsec(asio_event_t* ev)
   return ev->nsec;
 }
 
-void asio_event_send(asio_event_t* ev, uint32_t flags, uint32_t arg)
+void pony_asio_event_send(asio_event_t* ev, uint32_t flags, uint32_t arg)
 {
   asio_msg_t* m = (asio_msg_t*)pony_alloc_msg(POOL_INDEX(sizeof(asio_msg_t)),
     ev->msg_id);

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -40,19 +40,19 @@ typedef struct asio_msg_t
  *  An event is noisy, if it should prevent the runtime system from terminating
  *  based on quiescence.
  */
-asio_event_t* asio_event_create(pony_actor_t* owner, int fd, uint32_t flags,
-  uint64_t nsec, bool noisy);
+asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
+  uint32_t flags, uint64_t nsec, bool noisy);
 
 /** Deallocates an ASIO event.
  */
-void asio_event_destroy(asio_event_t* ev);
+void pony_asio_event_destroy(asio_event_t* ev);
 
-int asio_event_fd(asio_event_t* ev);
+int pony_asio_event_fd(asio_event_t* ev);
 
-uint64_t asio_event_nsec(asio_event_t* ev);
+uint64_t pony_asio_event_nsec(asio_event_t* ev);
 
 /// Send a triggered event.
-void asio_event_send(asio_event_t* ev, uint32_t flags, uint32_t arg);
+void pony_asio_event_send(asio_event_t* ev, uint32_t flags, uint32_t arg);
 
 /* Subscribe and unsubscribe are implemented in the corresponding I/O
  * mechanism. Files epoll.c, kqueue.c, ...
@@ -63,20 +63,20 @@ void asio_event_send(asio_event_t* ev, uint32_t flags, uint32_t arg);
  *  Subscriptions are not incremental. Registering an event multiple times will
  *  overwrite the previous event filter mask.
  */
-void asio_event_subscribe(asio_event_t* ev);
+void pony_asio_event_subscribe(asio_event_t* ev);
 
 /** Update an event.
  *
  * Used for timers.
  */
-void asio_event_setnsec(asio_event_t* ev, uint64_t nsec);
+void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec);
 
 /** Unsubscribe an event.
  *
  *  After a call to unsubscribe, the caller will not receive any further event
  *  notifications for I/O events on the corresponding resource.
  */
-void asio_event_unsubscribe(asio_event_t* ev);
+void pony_asio_event_unsubscribe(asio_event_t* ev);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -65,26 +65,26 @@ static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
   return v0 ^ v1 ^ v2 ^ v3;
 }
 
-uint64_t hash_block(const void* p, size_t len)
+uint64_t ponyint_hash_block(const void* p, size_t len)
 {
   return siphash24(the_key, (const char*)p, len);
 }
 
-uint64_t hash_str(const char* str)
+uint64_t ponyint_hash_str(const char* str)
 {
   return siphash24(the_key, str, strlen(str));
 }
 
-size_t hash_ptr(const void* p)
+size_t ponyint_hash_ptr(const void* p)
 {
 #ifdef PLATFORM_IS_ILP32
-  return hash_int32((uintptr_t)p);
+  return ponyint_hash_int32((uintptr_t)p);
 #else
-  return hash_int64((uintptr_t)p);
+  return ponyint_hash_int64((uintptr_t)p);
 #endif
 }
 
-uint64_t hash_int64(uint64_t key)
+uint64_t ponyint_hash_int64(uint64_t key)
 {
   key = ~key + (key << 21);
   key = key ^ (key >> 24);
@@ -97,7 +97,7 @@ uint64_t hash_int64(uint64_t key)
   return key;
 }
 
-uint32_t hash_int32(uint32_t key)
+uint32_t ponyint_hash_int32(uint32_t key)
 {
   key = ~key + (key << 15);
   key = key ^ (key >> 12);
@@ -108,16 +108,16 @@ uint32_t hash_int32(uint32_t key)
   return key;
 }
 
-size_t hash_size(size_t key)
+size_t ponyint_hash_size(size_t key)
 {
 #ifdef PLATFORM_IS_ILP32
-  return hash_int32(key);
+  return ponyint_hash_int32(key);
 #else
-  return hash_int64(key);
+  return ponyint_hash_int64(key);
 #endif
 }
 
-size_t next_pow2(size_t i)
+size_t ponyint_next_pow2(size_t i)
 {
   i--;
 

--- a/src/libponyrt/ds/fun.h
+++ b/src/libponyrt/ds/fun.h
@@ -20,19 +20,19 @@ typedef void (*free_fn)(void* data);
 
 typedef void (*free_size_fn)(size_t size, void* data);
 
-uint64_t hash_block(const void* p, size_t len);
+uint64_t ponyint_hash_block(const void* p, size_t len);
 
-uint64_t hash_str(const char* str);
+uint64_t ponyint_hash_str(const char* str);
 
-size_t hash_ptr(const void* p);
+size_t ponyint_hash_ptr(const void* p);
 
-uint64_t hash_int64(uint64_t key);
+uint64_t ponyint_hash_int64(uint64_t key);
 
-uint32_t hash_int32(uint32_t key);
+uint32_t ponyint_hash_int32(uint32_t key);
 
-size_t hash_size(size_t key);
+size_t ponyint_hash_size(size_t key);
 
-size_t next_pow2(size_t i);
+size_t ponyint_next_pow2(size_t i);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/ds/hash.c
+++ b/src/libponyrt/ds/hash.c
@@ -65,14 +65,14 @@ static void resize(hashmap_t* map, hash_fn hash, cmp_fn cmp, alloc_fn alloc,
     curr = b[i];
 
     if(valid(curr))
-      hashmap_put(map, curr, hash, cmp, alloc, fr);
+      ponyint_hashmap_put(map, curr, hash, cmp, alloc, fr);
   }
 
   if((fr != NULL) && (b != NULL))
     fr(s * sizeof(void*), b);
 }
 
-void hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc)
+void ponyint_hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc)
 {
   if(size > 0)
   {
@@ -82,7 +82,7 @@ void hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc)
     if(size < 8)
       size = 8;
     else
-      size = next_pow2(size);
+      size = ponyint_next_pow2(size);
   }
 
   map->count = 0;
@@ -97,7 +97,7 @@ void hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc)
   }
 }
 
-void hashmap_destroy(hashmap_t* map, free_size_fn fr, free_fn free_elem)
+void ponyint_hashmap_destroy(hashmap_t* map, free_size_fn fr, free_fn free_elem)
 {
   if(free_elem != NULL)
   {
@@ -120,7 +120,7 @@ void hashmap_destroy(hashmap_t* map, free_size_fn fr, free_fn free_elem)
   map->buckets = NULL;
 }
 
-void* hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp)
+void* ponyint_hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp)
 {
   if(map->count == 0)
     return NULL;
@@ -129,11 +129,11 @@ void* hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp)
   return search(map, &pos, key, hash, cmp);
 }
 
-void* hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
+void* ponyint_hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
   alloc_fn alloc, free_size_fn fr)
 {
   if(map->size == 0)
-    hashmap_init(map, 4, alloc);
+    ponyint_hashmap_init(map, 4, alloc);
 
   size_t pos;
   void* elem = search(map, &pos, entry, hash, cmp);
@@ -151,7 +151,8 @@ void* hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
   return elem;
 }
 
-void* hashmap_remove(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp)
+void* ponyint_hashmap_remove(hashmap_t* map, void* entry, hash_fn hash,
+  cmp_fn cmp)
 {
   if(map->count == 0)
     return NULL;
@@ -168,7 +169,7 @@ void* hashmap_remove(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp)
   return elem;
 }
 
-void* hashmap_removeindex(hashmap_t* map, size_t index)
+void* ponyint_hashmap_removeindex(hashmap_t* map, size_t index)
 {
   if(map->size <= index)
     return NULL;
@@ -183,7 +184,7 @@ void* hashmap_removeindex(hashmap_t* map, size_t index)
   return elem;
 }
 
-void* hashmap_next(hashmap_t* map, size_t* i)
+void* ponyint_hashmap_next(hashmap_t* map, size_t* i)
 {
   if(map->count == 0)
     return NULL;
@@ -208,7 +209,7 @@ void* hashmap_next(hashmap_t* map, size_t* i)
   return NULL;
 }
 
-size_t hashmap_size(hashmap_t* map)
+size_t ponyint_hashmap_size(hashmap_t* map)
 {
   return map->count;
 }

--- a/src/libponyrt/ds/hash.h
+++ b/src/libponyrt/ds/hash.h
@@ -27,110 +27,112 @@ typedef struct hashmap_t
  *
  *  This is a quadratic probing hash map.
  */
-void hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc);
+void ponyint_hashmap_init(hashmap_t* map, size_t size, alloc_fn alloc);
 
 /** Destroys a hash map.
  *
  */
-void hashmap_destroy(hashmap_t* map, free_size_fn fr, free_fn free_elem);
+void ponyint_hashmap_destroy(hashmap_t* map, free_size_fn fr,
+  free_fn free_elem);
 
 /** Retrieve an element from a hash map.
  *
  *  Returns a pointer to the element, or NULL.
  */
-void* hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp);
+void* ponyint_hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp);
 
 /** Put a new element in a hash map.
  *
  *  If the element (according to cmp_fn) is already in the hash map, the old
  *  element is overwritten and returned to the caller.
  */
-void* hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
+void* ponyint_hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
   alloc_fn alloc, free_size_fn fr);
 
 /** Removes a given entry from a hash map.
  *
  *  Returns the element removed (if any).
  */
-void* hashmap_remove(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp);
+void* ponyint_hashmap_remove(hashmap_t* map, void* entry, hash_fn hash,
+  cmp_fn cmp);
 
 /** Removes a given entry from a hash map by index.
  *
  *  Returns the element removed (if any).
  */
-void* hashmap_removeindex(hashmap_t* map, size_t index);
+void* ponyint_hashmap_removeindex(hashmap_t* map, size_t index);
 
 /** Get the number of elements in the map.
  */
-size_t hashmap_size(hashmap_t* map);
+size_t ponyint_hashmap_size(hashmap_t* map);
 
 /** Hashmap iterator.
  *
  *  Set i to HASHMAP_BEGIN, then call until this returns NULL.
  */
-void* hashmap_next(hashmap_t* map, size_t* i);
+void* ponyint_hashmap_next(hashmap_t* map, size_t* i);
 
-#define DECLARE_HASHMAP(name, type) \
-  typedef struct name##_t { hashmap_t contents; } name##_t; \
-  void name##_init(name##_t* map, size_t size); \
-  void name##_destroy(name##_t* map); \
-  type* name##_get(name##_t* map, type* key); \
-  type* name##_put(name##_t* map, type* entry); \
-  type* name##_remove(name##_t* map, type* entry); \
-  type* name##_removeindex(name##_t* map, size_t index); \
-  size_t name##_size(name##_t* map); \
-  type* name##_next(name##_t* map, size_t* i); \
+#define DECLARE_HASHMAP(name, name_t, type) \
+  typedef struct name_t { hashmap_t contents; } name_t; \
+  void name##_init(name_t* map, size_t size); \
+  void name##_destroy(name_t* map); \
+  type* name##_get(name_t* map, type* key); \
+  type* name##_put(name_t* map, type* entry); \
+  type* name##_remove(name_t* map, type* entry); \
+  type* name##_removeindex(name_t* map, size_t index); \
+  size_t name##_size(name_t* map); \
+  type* name##_next(name_t* map, size_t* i); \
   void name##_trace(void* map); \
 
-#define DEFINE_HASHMAP(name, type, hash, cmp, alloc, fr, free_elem) \
-  typedef struct name##_t name##_t; \
+#define DEFINE_HASHMAP(name, name_t, type, hash, cmp, alloc, fr, free_elem) \
+  typedef struct name_t name_t; \
   typedef size_t (*name##_hash_fn)(type* m); \
   typedef bool (*name##_cmp_fn)(type* a, type* b); \
   typedef void (*name##_free_fn)(type* a); \
-  typedef void (*name##_trace_fn)(void* a); \
+  typedef void (*name_trace_fn)(void* a); \
   \
-  void name##_init(name##_t* map, size_t size) \
+  void name##_init(name_t* map, size_t size) \
   { \
     alloc_fn allocf = alloc; \
-    hashmap_init((hashmap_t*)map, size, allocf); \
+    ponyint_hashmap_init((hashmap_t*)map, size, allocf); \
   } \
-  void name##_destroy(name##_t* map) \
+  void name##_destroy(name_t* map) \
   { \
     name##_free_fn freef = free_elem; \
-    hashmap_destroy((hashmap_t*)map, fr, (free_fn)freef); \
+    ponyint_hashmap_destroy((hashmap_t*)map, fr, (free_fn)freef); \
   } \
-  type* name##_get(name##_t* map, type* key) \
+  type* name##_get(name_t* map, type* key) \
   { \
     name##_hash_fn hashf = hash; \
     name##_cmp_fn cmpf = cmp; \
-    return (type*)hashmap_get((hashmap_t*)map, (void*)key, (hash_fn)hashf, \
-      (cmp_fn)cmpf); \
-  } \
-  type* name##_put(name##_t* map, type* entry) \
-  { \
-    name##_hash_fn hashf = hash; \
-    name##_cmp_fn cmpf = cmp; \
-    return (type*)hashmap_put((hashmap_t*)map, (void*)entry, (hash_fn)hashf, \
-      (cmp_fn)cmpf, alloc, fr); \
-  } \
-  type* name##_remove(name##_t* map, type* entry) \
-  { \
-    name##_hash_fn hashf = hash; \
-    name##_cmp_fn cmpf = cmp; \
-    return (type*)hashmap_remove((hashmap_t*) map, (void*)entry, \
+    return (type*)ponyint_hashmap_get((hashmap_t*)map, (void*)key, \
       (hash_fn)hashf, (cmp_fn)cmpf); \
   } \
-  type* name##_removeindex(name##_t* map, size_t index) \
+  type* name##_put(name_t* map, type* entry) \
   { \
-    return (type*)hashmap_removeindex((hashmap_t*) map, index); \
+    name##_hash_fn hashf = hash; \
+    name##_cmp_fn cmpf = cmp; \
+    return (type*)ponyint_hashmap_put((hashmap_t*)map, (void*)entry, \
+      (hash_fn)hashf, (cmp_fn)cmpf, alloc, fr); \
   } \
-  size_t name##_size(name##_t* map) \
+  type* name##_remove(name_t* map, type* entry) \
   { \
-    return hashmap_size((hashmap_t*)map); \
+    name##_hash_fn hashf = hash; \
+    name##_cmp_fn cmpf = cmp; \
+    return (type*)ponyint_hashmap_remove((hashmap_t*) map, (void*)entry, \
+      (hash_fn)hashf, (cmp_fn)cmpf); \
   } \
-  type* name##_next(name##_t* map, size_t* i) \
+  type* name##_removeindex(name_t* map, size_t index) \
   { \
-    return (type*)hashmap_next((hashmap_t*)map, i); \
+    return (type*)ponyint_hashmap_removeindex((hashmap_t*) map, index); \
+  } \
+  size_t name##_size(name_t* map) \
+  { \
+    return ponyint_hashmap_size((hashmap_t*)map); \
+  } \
+  type* name##_next(name_t* map, size_t* i) \
+  { \
+    return (type*)ponyint_hashmap_next((hashmap_t*)map, i); \
   } \
 
 #define HASHMAP_INIT {0, 0, NULL}

--- a/src/libponyrt/ds/list.c
+++ b/src/libponyrt/ds/list.c
@@ -9,7 +9,7 @@ typedef struct list_t
   struct list_t* next;
 } list_t;
 
-list_t* list_pop(list_t* list, void** data)
+list_t* ponyint_list_pop(list_t* list, void** data)
 {
   list_t* l = list;
   list = l->next;
@@ -19,7 +19,7 @@ list_t* list_pop(list_t* list, void** data)
   return list;
 }
 
-list_t* list_push(list_t* list, void* data)
+list_t* ponyint_list_push(list_t* list, void* data)
 {
   list_t* l = (list_t*)POOL_ALLOC(list_t);
   l->data = data;
@@ -28,7 +28,7 @@ list_t* list_push(list_t* list, void* data)
   return l;
 }
 
-list_t* list_append(list_t* list, void* data)
+list_t* ponyint_list_append(list_t* list, void* data)
 {
   list_t* l = (list_t*)POOL_ALLOC(list_t);
   l->data = data;
@@ -46,15 +46,15 @@ list_t* list_append(list_t* list, void* data)
   return list;
 }
 
-list_t* list_next(list_t* list)
+list_t* ponyint_list_next(list_t* list)
 {
   return list->next;
 }
 
-list_t* list_index(list_t* list, ssize_t index)
+list_t* ponyint_list_index(list_t* list, ssize_t index)
 {
   if(index < 0)
-    index = list_length(list) + index;
+    index = ponyint_list_length(list) + index;
 
   for(int i = 0; (list != NULL) && (i < index); i++)
     list = list->next;
@@ -62,12 +62,12 @@ list_t* list_index(list_t* list, ssize_t index)
   return list;
 }
 
-void* list_data(list_t* list)
+void* ponyint_list_data(list_t* list)
 {
   return list->data;
 }
 
-void* list_find(list_t* list, cmp_fn f, void* data)
+void* ponyint_list_find(list_t* list, cmp_fn f, void* data)
 {
   while(list != NULL)
   {
@@ -80,7 +80,7 @@ void* list_find(list_t* list, cmp_fn f, void* data)
   return NULL;
 }
 
-ssize_t list_findindex(list_t* list, cmp_fn f, void* data)
+ssize_t ponyint_list_findindex(list_t* list, cmp_fn f, void* data)
 {
   size_t index = 0;
 
@@ -96,11 +96,11 @@ ssize_t list_findindex(list_t* list, cmp_fn f, void* data)
   return -1;
 }
 
-bool list_subset(list_t* a, list_t* b, cmp_fn f)
+bool ponyint_list_subset(list_t* a, list_t* b, cmp_fn f)
 {
   while(a != NULL)
   {
-    if(list_find(b, f, a->data) == NULL)
+    if(ponyint_list_find(b, f, a->data) == NULL)
       return false;
 
     a = a->next;
@@ -109,7 +109,7 @@ bool list_subset(list_t* a, list_t* b, cmp_fn f)
   return true;
 }
 
-bool list_equals(list_t* a, list_t* b, cmp_fn f)
+bool ponyint_list_equals(list_t* a, list_t* b, cmp_fn f)
 {
   while(a != NULL)
   {
@@ -123,7 +123,7 @@ bool list_equals(list_t* a, list_t* b, cmp_fn f)
   return b == NULL;
 }
 
-list_t* list_map(list_t* list, map_fn f, void* arg)
+list_t* ponyint_list_map(list_t* list, map_fn f, void* arg)
 {
   list_t* to = NULL;
 
@@ -132,15 +132,15 @@ list_t* list_map(list_t* list, map_fn f, void* arg)
     void* result = f(list->data, (void*)arg);
 
     if(result != NULL)
-      to = list_push(to, result);
+      to = ponyint_list_push(to, result);
 
     list = list->next;
   }
 
-  return list_reverse(to);
+  return ponyint_list_reverse(to);
 }
 
-list_t* list_reverse(list_t* list)
+list_t* ponyint_list_reverse(list_t* list)
 {
   list_t* to = NULL;
 
@@ -155,7 +155,7 @@ list_t* list_reverse(list_t* list)
   return to;
 }
 
-size_t list_length(list_t* list)
+size_t ponyint_list_length(list_t* list)
 {
   size_t len = 0;
 
@@ -168,7 +168,7 @@ size_t list_length(list_t* list)
   return len;
 }
 
-void list_free(list_t* list, free_fn f)
+void ponyint_list_free(list_t* list, free_fn f)
 {
   list_t* next;
 

--- a/src/libponyrt/ds/list.h
+++ b/src/libponyrt/ds/list.h
@@ -10,117 +10,117 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct list_t list_t;
 
-list_t* list_pop(list_t* list, void** data);
+list_t* ponyint_list_pop(list_t* list, void** data);
 
-list_t* list_push(list_t* list, void* data);
+list_t* ponyint_list_push(list_t* list, void* data);
 
-list_t* list_append(list_t* list, void* data);
+list_t* ponyint_list_append(list_t* list, void* data);
 
-list_t* list_next(list_t* list);
+list_t* ponyint_list_next(list_t* list);
 
-list_t* list_index(list_t* list, ssize_t index);
+list_t* ponyint_list_index(list_t* list, ssize_t index);
 
-void* list_data(list_t* list);
+void* ponyint_list_data(list_t* list);
 
-void* list_find(list_t* list, cmp_fn f, void* data);
+void* ponyint_list_find(list_t* list, cmp_fn f, void* data);
 
-ssize_t list_findindex(list_t* list, cmp_fn f, void* data);
+ssize_t ponyint_list_findindex(list_t* list, cmp_fn f, void* data);
 
-bool list_subset(list_t* a, list_t* b, cmp_fn f);
+bool ponyint_list_subset(list_t* a, list_t* b, cmp_fn f);
 
-bool list_equals(list_t* a, list_t* b, cmp_fn f);
+bool ponyint_list_equals(list_t* a, list_t* b, cmp_fn f);
 
-list_t* list_map(list_t* list, map_fn f, void* arg);
+list_t* ponyint_list_map(list_t* list, map_fn f, void* arg);
 
-list_t* list_reverse(list_t* list);
+list_t* ponyint_list_reverse(list_t* list);
 
-size_t list_length(list_t* list);
+size_t ponyint_list_length(list_t* list);
 
-void list_free(list_t* list, free_fn f);
+void ponyint_list_free(list_t* list, free_fn f);
 
-#define DECLARE_LIST(name, elem) \
-  typedef struct name##_t name##_t; \
+#define DECLARE_LIST(name, name_t, elem) \
+  typedef struct name_t name_t; \
   typedef bool (*name##_cmp_fn)(elem* a, elem* b); \
   typedef elem* (*name##_map_fn)(elem* a, void* arg); \
   typedef void (*name##_free_fn)(elem* a); \
-  name##_t* name##_pop(name##_t* list, elem** data); \
-  name##_t* name##_push(name##_t* list, elem* data); \
-  name##_t* name##_append(name##_t* list, elem* data); \
-  name##_t* name##_next(name##_t* list); \
-  name##_t* name##_index(name##_t* list, ssize_t index); \
-  elem* name##_data(name##_t* list); \
-  elem* name##_find(name##_t* list, elem* data); \
-  ssize_t name##_findindex(name##_t* list, elem* data); \
-  bool name##_subset(name##_t* a, name##_t* b); \
-  bool name##_equals(name##_t* a, name##_t* b); \
-  name##_t* name##_map(name##_t* list, name##_map_fn f, void* arg); \
-  name##_t* name##_reverse(name##_t* list); \
-  size_t name##_length(name##_t* list); \
-  void name##_free(name##_t* list); \
+  name_t* name##_pop(name_t* list, elem** data); \
+  name_t* name##_push(name_t* list, elem* data); \
+  name_t* name##_append(name_t* list, elem* data); \
+  name_t* name##_next(name_t* list); \
+  name_t* name##_index(name_t* list, ssize_t index); \
+  elem* name##_data(name_t* list); \
+  elem* name##_find(name_t* list, elem* data); \
+  ssize_t name##_findindex(name_t* list, elem* data); \
+  bool name##_subset(name_t* a, name_t* b); \
+  bool name##_equals(name_t* a, name_t* b); \
+  name_t* name##_map(name_t* list, name##_map_fn f, void* arg); \
+  name_t* name##_reverse(name_t* list); \
+  size_t name##_length(name_t* list); \
+  void name##_free(name_t* list); \
 
-#define DEFINE_LIST(name, elem, cmpf, freef) \
-  struct name##_t {}; \
+#define DEFINE_LIST(name, name_t, elem, cmpf, freef) \
+  struct name_t {}; \
   \
-  name##_t* name##_pop(name##_t* list, elem** data) \
+  name_t* name##_pop(name_t* list, elem** data) \
   { \
-    return (name##_t*)list_pop((list_t*)list, (void**)data); \
+    return (name_t*)ponyint_list_pop((list_t*)list, (void**)data); \
   } \
-  name##_t* name##_push(name##_t* list, elem* data) \
+  name_t* name##_push(name_t* list, elem* data) \
   { \
-    return (name##_t*)list_push((list_t*)list, (void*)data); \
+    return (name_t*)ponyint_list_push((list_t*)list, (void*)data); \
   } \
-  name##_t* name##_append(name##_t* list, elem* data) \
+  name_t* name##_append(name_t* list, elem* data) \
   { \
-    return (name##_t*)list_append((list_t*)list, (void*)data); \
+    return (name_t*)ponyint_list_append((list_t*)list, (void*)data); \
   } \
-  name##_t* name##_next(name##_t* list) \
+  name_t* name##_next(name_t* list) \
   { \
-    return (name##_t*)list_next((list_t*)list); \
+    return (name_t*)ponyint_list_next((list_t*)list); \
   } \
-  name##_t* name##_index(name##_t* list, ssize_t index) \
+  name_t* name##_index(name_t* list, ssize_t index) \
   { \
-    return (name##_t*)list_index((list_t*)list, index); \
+    return (name_t*)ponyint_list_index((list_t*)list, index); \
   } \
-  elem* name##_data(name##_t* list) \
+  elem* name##_data(name_t* list) \
   { \
-    return (elem*)list_data((list_t*)list); \
+    return (elem*)ponyint_list_data((list_t*)list); \
   } \
-  elem* name##_find(name##_t* list, elem* data) \
-  { \
-    name##_cmp_fn cmp = cmpf; \
-    return (elem*)list_find((list_t*)list, (cmp_fn)cmp, (void*)data); \
-  } \
-  ssize_t name##_findindex(name##_t* list, elem* data) \
+  elem* name##_find(name_t* list, elem* data) \
   { \
     name##_cmp_fn cmp = cmpf; \
-    return list_findindex((list_t*)list, (cmp_fn)cmp, (void*)data); \
+    return (elem*)ponyint_list_find((list_t*)list, (cmp_fn)cmp, (void*)data); \
   } \
-  bool name##_subset(name##_t* a, name##_t* b) \
+  ssize_t name##_findindex(name_t* list, elem* data) \
   { \
     name##_cmp_fn cmp = cmpf; \
-    return list_subset((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
+    return ponyint_list_findindex((list_t*)list, (cmp_fn)cmp, (void*)data); \
   } \
-  bool name##_equals(name##_t* a, name##_t* b) \
+  bool name##_subset(name_t* a, name_t* b) \
   { \
     name##_cmp_fn cmp = cmpf; \
-    return list_equals((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
+    return ponyint_list_subset((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
   } \
-  name##_t* name##_map(name##_t* list, name##_map_fn f, void* arg) \
+  bool name##_equals(name_t* a, name_t* b) \
   { \
-    return (name##_t*)list_map((list_t*)list, (map_fn)f, arg); \
+    name##_cmp_fn cmp = cmpf; \
+    return ponyint_list_equals((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
   } \
-  name##_t* name##_reverse(name##_t* list) \
+  name_t* name##_map(name_t* list, name##_map_fn f, void* arg) \
   { \
-    return (name##_t*)list_reverse((list_t*)list); \
+    return (name_t*)ponyint_list_map((list_t*)list, (map_fn)f, arg); \
   } \
-  size_t name##_length(name##_t* list) \
+  name_t* name##_reverse(name_t* list) \
   { \
-    return list_length((list_t*)list); \
+    return (name_t*)ponyint_list_reverse((list_t*)list); \
   } \
-  void name##_free(name##_t* list) \
+  size_t name##_length(name_t* list) \
+  { \
+    return ponyint_list_length((list_t*)list); \
+  } \
+  void name##_free(name_t* list) \
   { \
     name##_free_fn free = freef; \
-    list_free((list_t*)list, (free_fn)free); \
+    ponyint_list_free((list_t*)list, (free_fn)free); \
   } \
 
 PONY_EXTERN_C_END

--- a/src/libponyrt/ds/stack.c
+++ b/src/libponyrt/ds/stack.c
@@ -12,7 +12,7 @@ static Stack* stack_new(Stack* prev, void* data)
   return stack;
 }
 
-Stack* stack_pop(Stack* stack, void** data)
+Stack* ponyint_stack_pop(Stack* stack, void** data)
 {
   assert(stack != NULL);
   assert(data != NULL);
@@ -30,7 +30,7 @@ Stack* stack_pop(Stack* stack, void** data)
   return stack;
 }
 
-Stack* stack_push(Stack* stack, void* data)
+Stack* ponyint_stack_push(Stack* stack, void* data)
 {
   if((stack != NULL) && (stack->index < STACK_COUNT))
   {

--- a/src/libponyrt/ds/stack.h
+++ b/src/libponyrt/ds/stack.h
@@ -14,25 +14,25 @@ typedef struct Stack
   struct Stack* prev;
 } Stack;
 
-Stack* stack_pop(Stack* stack, void** data);
+Stack* ponyint_stack_pop(Stack* stack, void** data);
 
-Stack* stack_push(Stack* list, void* data);
+Stack* ponyint_stack_push(Stack* list, void* data);
 
-#define DECLARE_STACK(name, elem) \
-  typedef struct name##_t name##_t; \
-  name##_t* name##_pop(name##_t* stack, elem** data); \
-  name##_t* name##_push(name##_t* stack, elem* data); \
+#define DECLARE_STACK(name, name_t, elem) \
+  typedef struct name_t name_t; \
+  name_t* name##_pop(name_t* stack, elem** data); \
+  name_t* name##_push(name_t* stack, elem* data); \
 
-#define DEFINE_STACK(name, elem) \
-  struct name##_t {}; \
+#define DEFINE_STACK(name, name_t, elem) \
+  struct name_t {}; \
   \
-  name##_t* name##_pop(name##_t* stack, elem** data) \
+  name_t* name##_pop(name_t* stack, elem** data) \
   { \
-    return (name##_t*)stack_pop((Stack*)stack, (void**)data); \
+    return (name_t*)ponyint_stack_pop((Stack*)stack, (void**)data); \
   } \
-  name##_t* name##_push(name##_t* stack, elem* data) \
+  name_t* name##_push(name_t* stack, elem* data) \
   { \
-    return (name##_t*)stack_push((Stack*)stack, data); \
+    return (name_t*)ponyint_stack_push((Stack*)stack, data); \
   } \
 
 PONY_EXTERN_C_END

--- a/src/libponyrt/gc/actormap.h
+++ b/src/libponyrt/gc/actormap.h
@@ -17,21 +17,22 @@ typedef struct actorref_t
   objectmap_t map;
 } actorref_t;
 
-object_t* actorref_getobject(actorref_t* aref, void* address);
+object_t* ponyint_actorref_getobject(actorref_t* aref, void* address);
 
-object_t* actorref_getorput(actorref_t* aref, void* address, uint32_t mark);
-
-void actorref_free(actorref_t* aref);
-
-DECLARE_HASHMAP(actormap, actorref_t);
-
-actorref_t* actormap_getactor(actormap_t* map, pony_actor_t* actor);
-
-actorref_t* actormap_getorput(actormap_t* map, pony_actor_t* actor,
+object_t* ponyint_actorref_getorput(actorref_t* aref, void* address,
   uint32_t mark);
 
-deltamap_t* actormap_sweep(pony_ctx_t* ctx, actormap_t* map, uint32_t mark,
-  deltamap_t* delta);
+void ponyint_actorref_free(actorref_t* aref);
+
+DECLARE_HASHMAP(ponyint_actormap, actormap_t, actorref_t);
+
+actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor);
+
+actorref_t* ponyint_actormap_getorput(actormap_t* map, pony_actor_t* actor,
+  uint32_t mark);
+
+deltamap_t* ponyint_actormap_sweep(pony_ctx_t* ctx, actormap_t* map,
+  uint32_t mark, deltamap_t* delta);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -37,7 +37,7 @@ typedef struct viewref_t
 
 static size_t viewref_hash(viewref_t* vref)
 {
-  return hash_ptr(vref->view);
+  return ponyint_hash_ptr(vref->view);
 }
 
 static bool viewref_cmp(viewref_t* a, viewref_t* b)
@@ -50,19 +50,19 @@ static void viewref_free(viewref_t* vref)
   POOL_FREE(viewref_t, vref);
 }
 
-DECLARE_STACK(viewrefstack, viewref_t);
-DEFINE_STACK(viewrefstack, viewref_t);
+DECLARE_STACK(ponyint_viewrefstack, viewrefstack_t, viewref_t);
+DEFINE_STACK(ponyint_viewrefstack, viewrefstack_t, viewref_t);
 
-DECLARE_HASHMAP(viewrefmap, viewref_t);
-DEFINE_HASHMAP(viewrefmap, viewref_t, viewref_hash, viewref_cmp,
-  pool_alloc_size, pool_free_size, viewref_free);
+DECLARE_HASHMAP(ponyint_viewrefmap, viewrefmap_t, viewref_t);
+DEFINE_HASHMAP(ponyint_viewrefmap, viewrefmap_t, viewref_t, viewref_hash,
+  viewref_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size, viewref_free);
 
 enum
 {
   COLOR_BLACK,
   COLOR_GREY,
   COLOR_WHITE
-} color_t;
+} ponyint_color_t;
 
 struct view_t
 {
@@ -79,7 +79,7 @@ struct view_t
 
 static size_t view_hash(view_t* view)
 {
-  return hash_ptr(view->actor);
+  return ponyint_hash_ptr(view->actor);
 }
 
 static bool view_cmp(view_t* a, view_t* b)
@@ -93,11 +93,11 @@ static void view_free(view_t* view)
 
   if(view->view_rc == 0)
   {
-    viewrefmap_destroy(&view->map);
+    ponyint_viewrefmap_destroy(&view->map);
 
     if(view->delta != NULL)
     {
-      deltamap_free(view->delta);
+      ponyint_deltamap_free(view->delta);
       view->delta = NULL;
     }
 
@@ -106,9 +106,9 @@ static void view_free(view_t* view)
 }
 
 // no element free for a viewmap. views are kept in many maps.
-DECLARE_HASHMAP(viewmap, view_t);
-DEFINE_HASHMAP(viewmap, view_t, view_hash, view_cmp, pool_alloc_size,
-  pool_free_size, NULL);
+DECLARE_HASHMAP(ponyint_viewmap, viewmap_t, view_t);
+DEFINE_HASHMAP(ponyint_viewmap, viewmap_t, view_t, view_hash, view_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, NULL);
 
 struct perceived_t
 {
@@ -120,7 +120,7 @@ struct perceived_t
 
 static size_t perceived_hash(perceived_t* per)
 {
-  return hash_size(per->token);
+  return ponyint_hash_size(per->token);
 }
 
 static bool perceived_cmp(perceived_t* a, perceived_t* b)
@@ -130,13 +130,14 @@ static bool perceived_cmp(perceived_t* a, perceived_t* b)
 
 static void perceived_free(perceived_t* per)
 {
-  viewmap_destroy(&per->map);
+  ponyint_viewmap_destroy(&per->map);
   POOL_FREE(perceived_t, per);
 }
 
-DECLARE_HASHMAP(perceivedmap, perceived_t);
-DEFINE_HASHMAP(perceivedmap, perceived_t, perceived_hash, perceived_cmp,
-  pool_alloc_size, pool_free_size, perceived_free);
+DECLARE_HASHMAP(ponyint_perceivedmap, perceivedmap_t, perceived_t);
+DEFINE_HASHMAP(ponyint_perceivedmap, perceivedmap_t, perceived_t,
+  perceived_hash, perceived_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, perceived_free);
 
 typedef struct detector_t
 {
@@ -168,7 +169,7 @@ static view_t* get_view(detector_t* d, pony_actor_t* actor, bool create)
   view_t key;
   key.actor = actor;
 
-  view_t* view = viewmap_get(&d->views, &key);
+  view_t* view = ponyint_viewmap_get(&d->views, &key);
 
   if((view == NULL) && create)
   {
@@ -177,7 +178,7 @@ static view_t* get_view(detector_t* d, pony_actor_t* actor, bool create)
     view->actor = actor;
     view->view_rc = 1;
 
-    viewmap_put(&d->views, view);
+    ponyint_viewmap_put(&d->views, view);
     d->created++;
   }
 
@@ -195,11 +196,11 @@ static void apply_delta(detector_t* d, view_t* view)
   size_t i = HASHMAP_BEGIN;
   delta_t* delta;
 
-  while((delta = deltamap_next(map, &i)) != NULL)
+  while((delta = ponyint_deltamap_next(map, &i)) != NULL)
   {
     // If rc is 0, we skip creating a view for the actor.
-    pony_actor_t* actor = delta_actor(delta);
-    size_t rc = delta_rc(delta);
+    pony_actor_t* actor = ponyint_delta_actor(delta);
+    size_t rc = ponyint_delta_rc(delta);
 
     // If the referenced actor has never blocked, we will insert a view_t
     // that has blocked set to false.
@@ -213,19 +214,19 @@ static void apply_delta(detector_t* d, view_t* view)
 
     if(rc > 0)
     {
-      viewref_t* ref = viewrefmap_get(&view->map, &key);
+      viewref_t* ref = ponyint_viewrefmap_get(&view->map, &key);
 
       if(ref == NULL)
       {
         ref = (viewref_t*)POOL_ALLOC(viewref_t);
         ref->view = find;
-        viewrefmap_put(&view->map, ref);
+        ponyint_viewrefmap_put(&view->map, ref);
         find->view_rc++;
       }
 
       ref->rc = rc;
     } else {
-      viewref_t* ref = viewrefmap_remove(&view->map, &key);
+      viewref_t* ref = ponyint_viewrefmap_remove(&view->map, &key);
 
       if(ref != NULL)
       {
@@ -235,7 +236,7 @@ static void apply_delta(detector_t* d, view_t* view)
     }
   }
 
-  deltamap_free(map);
+  ponyint_deltamap_free(map);
   view->delta = NULL;
 }
 
@@ -249,7 +250,7 @@ static bool mark_grey(detector_t* d, view_t* view, size_t rc)
 
   if(view->deferred)
   {
-    viewmap_remove(&d->deferred, view);
+    ponyint_viewmap_remove(&d->deferred, view);
     view->deferred = false;
   }
 
@@ -269,19 +270,19 @@ static void scan_grey(detector_t* d, view_t* view, size_t rc)
 {
   viewref_t* ref;
   viewref_t head = {view, rc};
-  viewrefstack_t* stack = viewrefstack_push(NULL, &head);
+  viewrefstack_t* stack = ponyint_viewrefstack_push(NULL, &head);
 
   while(stack != NULL)
   {
-    stack = viewrefstack_pop(stack, &ref);
+    stack = ponyint_viewrefstack_pop(stack, &ref);
 
     if(mark_grey(d, ref->view, ref->rc))
     {
       size_t i = HASHMAP_BEGIN;
       viewref_t* child;
 
-      while((child = viewrefmap_next(&ref->view->map, &i)) != NULL)
-        stack = viewrefstack_push(stack, child);
+      while((child = ponyint_viewrefmap_next(&ref->view->map, &i)) != NULL)
+        stack = ponyint_viewrefstack_push(stack, child);
     }
   }
 }
@@ -313,19 +314,19 @@ static int scan_black(view_t* view, size_t rc)
   int count = 0;
   viewref_t* ref;
   viewref_t head = {view, rc};
-  viewrefstack_t* stack = viewrefstack_push(NULL, &head);
+  viewrefstack_t* stack = ponyint_viewrefstack_push(NULL, &head);
 
   while(stack != NULL)
   {
-    stack = viewrefstack_pop(stack, &ref);
+    stack = ponyint_viewrefstack_pop(stack, &ref);
 
     if(mark_black(ref->view, ref->rc, &count))
     {
       size_t i = HASHMAP_BEGIN;
       viewref_t* child;
 
-      while((child = viewrefmap_next(&ref->view->map, &i)) != NULL)
-        stack = viewrefstack_push(stack, child);
+      while((child = ponyint_viewrefmap_next(&ref->view->map, &i)) != NULL)
+        stack = ponyint_viewrefstack_push(stack, child);
     }
   }
 
@@ -359,19 +360,19 @@ static int scan_white(view_t* view)
   int count = 0;
   viewref_t* ref;
   viewref_t head = {view, 0};
-  viewrefstack_t* stack = viewrefstack_push(NULL, &head);
+  viewrefstack_t* stack = ponyint_viewrefstack_push(NULL, &head);
 
   while(stack != NULL)
   {
-    stack = viewrefstack_pop(stack, &ref);
+    stack = ponyint_viewrefstack_pop(stack, &ref);
 
     if(mark_white(ref->view, &count))
     {
       size_t i = HASHMAP_BEGIN;
       viewref_t* child;
 
-      while((child = viewrefmap_next(&ref->view->map, &i)) != NULL)
-        stack = viewrefstack_push(stack, child);
+      while((child = ponyint_viewrefmap_next(&ref->view->map, &i)) != NULL)
+        stack = ponyint_viewrefstack_push(stack, child);
     }
   }
 
@@ -386,7 +387,7 @@ static bool collect_view(perceived_t* per, view_t* view, size_t rc, int* count)
     assert(view->perceived == NULL);
 
     view->perceived = per;
-    viewmap_put(&per->map, view);
+    ponyint_viewmap_put(&per->map, view);
   }
 
   return mark_black(view, rc, count);
@@ -398,19 +399,19 @@ static int collect_white(perceived_t* per, view_t* view, size_t rc)
   int count = 0;
   viewref_t* ref;
   viewref_t head = {view, rc};
-  viewrefstack_t* stack = viewrefstack_push(NULL, &head);
+  viewrefstack_t* stack = ponyint_viewrefstack_push(NULL, &head);
 
   while(stack != NULL)
   {
-    stack = viewrefstack_pop(stack, &ref);
+    stack = ponyint_viewrefstack_pop(stack, &ref);
 
     if(collect_view(per, ref->view, ref->rc, &count))
     {
       size_t i = HASHMAP_BEGIN;
       viewref_t* child;
 
-      while((child = viewrefmap_next(&ref->view->map, &i)) != NULL)
-        stack = viewrefstack_push(stack, child);
+      while((child = ponyint_viewrefmap_next(&ref->view->map, &i)) != NULL)
+        stack = ponyint_viewrefstack_push(stack, child);
     }
   }
 
@@ -423,7 +424,7 @@ static void send_conf(pony_ctx_t* ctx, detector_t* d, perceived_t* per)
   size_t count = 0;
   view_t* view;
 
-  while((view = viewmap_next(&per->map, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
   {
     pony_sendi(ctx, view->actor, ACTORMSG_CONF, per->token);
     count++;
@@ -452,14 +453,14 @@ static bool detect(pony_ctx_t* ctx, detector_t* d, view_t* view)
   per->token = d->next_token++;
   per->ack = 0;
   per->last_conf = HASHMAP_BEGIN;
-  viewmap_init(&per->map, count);
-  perceivedmap_put(&d->perceived, per);
+  ponyint_viewmap_init(&per->map, count);
+  ponyint_perceivedmap_put(&d->perceived, per);
 
   int count2 = collect_white(per, view, 0);
 
   (void)count2;
   assert(count2 == count);
-  assert(viewmap_size(&per->map) == (size_t)count);
+  assert(ponyint_viewmap_size(&per->map) == (size_t)count);
 
   send_conf(ctx, d, per);
   return true;
@@ -478,10 +479,10 @@ static void deferred(pony_ctx_t* ctx, detector_t* d)
   size_t i = HASHMAP_BEGIN;
   view_t* view;
 
-  while((view = viewmap_next(&d->deferred, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&d->deferred, &i)) != NULL)
   {
     assert(view->deferred == true);
-    viewmap_removeindex(&d->deferred, i);
+    ponyint_viewmap_removeindex(&d->deferred, i);
     view->deferred = false;
 
     if(!detect(ctx, d, view))
@@ -512,53 +513,53 @@ static void expire(detector_t* d, view_t* view)
   size_t i = HASHMAP_BEGIN;
   view_t* pview;
 
-  while((pview = viewmap_next(&per->map, &i)) != NULL)
+  while((pview = ponyint_viewmap_next(&per->map, &i)) != NULL)
     pview->perceived = NULL;
 
-  perceivedmap_remove(&d->perceived, per);
+  ponyint_perceivedmap_remove(&d->perceived, per);
   perceived_free(per);
   view->perceived = NULL;
 }
 
 static void collect(pony_ctx_t* ctx, detector_t* d, perceived_t* per)
 {
-  perceivedmap_remove(&d->perceived, per);
+  ponyint_perceivedmap_remove(&d->perceived, per);
 
   size_t i = HASHMAP_BEGIN;
   view_t* view;
 
   // mark actors in the cycle as pending destruction
-  while((view = viewmap_next(&per->map, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
   {
     assert(view->perceived == per);
 
     // remove from the deferred set
     if(view->deferred)
-      viewmap_remove(&d->deferred, view);
+      ponyint_viewmap_remove(&d->deferred, view);
 
     // invoke the actor's finalizer
-    actor_setpendingdestroy(view->actor);
-    actor_final(ctx, view->actor);
+    ponyint_actor_setpendingdestroy(view->actor);
+    ponyint_actor_final(ctx, view->actor);
   }
 
   // actors being collected that have references to actors that are not in
-  // the cycle now send gc_release messages to those actors
+  // the cycle now send ponyint_gc_release messages to those actors
   i = HASHMAP_BEGIN;
 
-  while((view = viewmap_next(&per->map, &i)) != NULL)
-    actor_sendrelease(ctx, view->actor);
+  while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
+    ponyint_actor_sendrelease(ctx, view->actor);
 
   // destroy the actor and free the view on the actor
   i = HASHMAP_BEGIN;
 
-  while((view = viewmap_next(&per->map, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
   {
-    actor_destroy(view->actor);
-    viewmap_remove(&d->views, view);
+    ponyint_actor_destroy(view->actor);
+    ponyint_viewmap_remove(&d->views, view);
     view_free(view);
   }
 
-  d->destroyed += viewmap_size(&per->map);
+  d->destroyed += ponyint_viewmap_size(&per->map);
 
   // free the perceived cycle
   perceived_free(per);
@@ -590,7 +591,7 @@ static void block(pony_ctx_t* ctx, detector_t* d, pony_actor_t* actor,
     // remove from the deferred set
     if(view->deferred)
     {
-      viewmap_remove(&d->deferred, view);
+      ponyint_viewmap_remove(&d->deferred, view);
       view->deferred = false;
     }
 
@@ -600,7 +601,7 @@ static void block(pony_ctx_t* ctx, detector_t* d, pony_actor_t* actor,
     // add to the deferred set
     if(!view->deferred)
     {
-      viewmap_put(&d->deferred, view);
+      ponyint_viewmap_put(&d->deferred, view);
       view->deferred = true;
     }
 
@@ -615,7 +616,7 @@ static void unblock(detector_t* d, pony_actor_t* actor)
   key.actor = actor;
 
   // we must be in the views, because we must have blocked in order to unblock
-  view_t* view = viewmap_get(&d->views, &key);
+  view_t* view = ponyint_viewmap_get(&d->views, &key);
   assert(view != NULL);
 
   // record that we're unblocked
@@ -624,7 +625,7 @@ static void unblock(detector_t* d, pony_actor_t* actor)
   // remove from the deferred set
   if(view->deferred)
   {
-    viewmap_remove(&d->deferred, view);
+    ponyint_viewmap_remove(&d->deferred, view);
     view->deferred = false;
   }
 
@@ -637,14 +638,14 @@ static void ack(pony_ctx_t* ctx, detector_t* d, size_t token)
   perceived_t key;
   key.token = token;
 
-  perceived_t* per = perceivedmap_get(&d->perceived, &key);
+  perceived_t* per = ponyint_perceivedmap_get(&d->perceived, &key);
 
   if(per == NULL)
     return;
 
   per->ack++;
 
-  if(per->ack == viewmap_size(&per->map))
+  if(per->ack == ponyint_viewmap_size(&per->map))
   {
     collect(ctx, d, per);
     return;
@@ -659,19 +660,19 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
   // Find block messages and invoke finalisers for those actors
   pony_msg_t* msg;
 
-  while((msg = messageq_pop(&self->q)) != NULL)
+  while((msg = ponyint_messageq_pop(&self->q)) != NULL)
   {
     if(msg->id == ACTORMSG_BLOCK)
     {
       block_msg_t* m = (block_msg_t*)msg;
 
       if(m->delta != NULL)
-        deltamap_free(m->delta);
+        ponyint_deltamap_free(m->delta);
 
-      if(!actor_pendingdestroy(m->actor))
+      if(!ponyint_actor_pendingdestroy(m->actor))
       {
-        actor_setpendingdestroy(m->actor);
-        actor_final(ctx, m->actor);
+        ponyint_actor_setpendingdestroy(m->actor);
+        ponyint_actor_final(ctx, m->actor);
       }
     }
   }
@@ -683,17 +684,17 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
   // Invoke the actor's finalizer. Note that system actors and unscheduled
   // actors will not necessarily be finalised. If the actor isn't marked as
   // blocked, it has already been destroyed.
-  while((view = viewmap_next(&d->views, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&d->views, &i)) != NULL)
   {
-    if(view->blocked && !actor_pendingdestroy(view->actor))
+    if(view->blocked && !ponyint_actor_pendingdestroy(view->actor))
     {
-      actor_setpendingdestroy(view->actor);
-      actor_final(ctx, view->actor);
+      ponyint_actor_setpendingdestroy(view->actor);
+      ponyint_actor_final(ctx, view->actor);
     }
   }
 
   // Terminate the scheduler.
-  scheduler_terminate();
+  ponyint_sched_terminate();
 }
 
 #ifndef NDEBUG
@@ -710,9 +711,9 @@ static void dump_view(view_t* view)
   viewref_t* p;
   actorref_t* aref;
 
-  while((p = viewrefmap_next(&view->map, &i)) != NULL)
+  while((p = ponyint_viewrefmap_next(&view->map, &i)) != NULL)
   {
-    aref = actormap_getactor(&view->actor->gc.foreign, p->view->actor);
+    aref = ponyint_actormap_getactor(&view->actor->gc.foreign, p->view->actor);
 
     if(aref != NULL)
     {
@@ -724,33 +725,34 @@ static void dump_view(view_t* view)
     }
   }
 
-  if(actormap_size(&view->actor->gc.foreign) != viewrefmap_size(&view->map))
+  if(ponyint_actormap_size(&view->actor->gc.foreign) != \
+    ponyint_viewrefmap_size(&view->map))
   {
     printf("\t--- ERROR\n");
 
     i = HASHMAP_BEGIN;
 
-    while((aref = actormap_next(&view->actor->gc.foreign, &i)) != NULL)
+    while((aref = ponyint_actormap_next(&view->actor->gc.foreign, &i)) != NULL)
     {
       printf("\t%p: " __zu "\n", aref->actor, aref->rc);
     }
   }
 }
 
-void dump_views()
+static void dump_views()
 {
   detector_t* d = (detector_t*)cycle_detector;
   size_t i = HASHMAP_BEGIN;
   view_t* view;
 
-  while((view = viewmap_next(&d->views, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&d->views, &i)) != NULL)
   {
     apply_delta(d, view);
     dump_view(view);
   }
 }
 
-void check_view(detector_t* d, view_t* view)
+static void check_view(detector_t* d, view_t* view)
 {
   if(view->perceived != NULL)
   {
@@ -765,13 +767,13 @@ void check_view(detector_t* d, view_t* view)
   printf("%p: %s\n", view->actor, count > 0 ? "COLLECTABLE" : "uncollectable");
 }
 
-void check_views()
+static void check_views()
 {
   detector_t* d = (detector_t*)cycle_detector;
   size_t i = HASHMAP_BEGIN;
   view_t* view;
 
-  while((view = viewmap_next(&d->views, &i)) != NULL)
+  while((view = ponyint_viewmap_next(&d->views, &i)) != NULL)
   {
     check_view(d, view);
   }
@@ -836,7 +838,7 @@ static pony_type_t cycle_type =
   NULL
 };
 
-void cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
+void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
   uint32_t max_deferred, uint32_t conf_group)
 {
   if(min_deferred > 30)
@@ -852,7 +854,7 @@ void cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
     conf_group = 30;
 
   cycle_detector = pony_create(ctx, &cycle_type);
-  actor_setsystem(cycle_detector);
+  ponyint_actor_setsystem(cycle_detector);
 
   detector_t* d = (detector_t*)cycle_detector;
   d->min_deferred = (size_t)1 << (size_t)min_deferred;
@@ -861,7 +863,7 @@ void cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
   d->next_deferred = min_deferred;
 }
 
-void cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
+void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
 {
   assert(ctx->current == actor);
   assert(&actor->gc == gc);
@@ -870,30 +872,30 @@ void cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
     POOL_INDEX(sizeof(block_msg_t)), ACTORMSG_BLOCK);
 
   m->actor = actor;
-  m->rc = gc_rc(gc);
-  m->delta = gc_delta(gc);
+  m->rc = ponyint_gc_rc(gc);
+  m->delta = ponyint_gc_delta(gc);
   assert(gc->delta == NULL);
 
   pony_sendv(ctx, cycle_detector, &m->msg);
 }
 
-void cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor)
+void ponyint_cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   pony_sendp(ctx, cycle_detector, ACTORMSG_UNBLOCK, actor);
 }
 
-void cycle_ack(pony_ctx_t* ctx, size_t token)
+void ponyint_cycle_ack(pony_ctx_t* ctx, size_t token)
 {
   pony_sendi(ctx, cycle_detector, ACTORMSG_ACK, token);
 }
 
-void cycle_terminate(pony_ctx_t* ctx)
+void ponyint_cycle_terminate(pony_ctx_t* ctx)
 {
   pony_become(ctx, cycle_detector);
   final(ctx, cycle_detector);
 }
 
-bool is_cycle(pony_actor_t* actor)
+bool ponyint_is_cycle(pony_actor_t* actor)
 {
   return actor == cycle_detector;
 }

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -9,18 +9,18 @@
 
 PONY_EXTERN_C_BEGIN
 
-void cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
+void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
   uint32_t max_deferred, uint32_t conf_group);
 
-void cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc);
+void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc);
 
-void cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void cycle_ack(pony_ctx_t* ctx, size_t token);
+void ponyint_cycle_ack(pony_ctx_t* ctx, size_t token);
 
-void cycle_terminate(pony_ctx_t* ctx);
+void ponyint_cycle_terminate(pony_ctx_t* ctx);
 
-bool is_cycle(pony_actor_t* actor);
+bool ponyint_is_cycle(pony_actor_t* actor);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/delta.c
+++ b/src/libponyrt/gc/delta.c
@@ -9,7 +9,7 @@ typedef struct delta_t
 
 static size_t delta_hash(delta_t* delta)
 {
-  return hash_ptr(delta->actor);
+  return ponyint_hash_ptr(delta->actor);
 }
 
 static bool delta_cmp(delta_t* a, delta_t* b)
@@ -22,30 +22,31 @@ static void delta_free(delta_t* delta)
   POOL_FREE(delta_t, delta);
 }
 
-pony_actor_t* delta_actor(delta_t* delta)
+pony_actor_t* ponyint_delta_actor(delta_t* delta)
 {
   return delta->actor;
 }
 
-size_t delta_rc(delta_t* delta)
+size_t ponyint_delta_rc(delta_t* delta)
 {
   return delta->rc;
 }
 
-DEFINE_HASHMAP(deltamap, delta_t, delta_hash, delta_cmp, pool_alloc_size,
-  pool_free_size, delta_free);
+DEFINE_HASHMAP(ponyint_deltamap, deltamap_t, delta_t, delta_hash, delta_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, delta_free);
 
-deltamap_t* deltamap_update(deltamap_t* map, pony_actor_t* actor, size_t rc)
+deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
+  size_t rc)
 {
   if(map == NULL)
   {
     // allocate a new map with space for at least one element
     map = (deltamap_t*)POOL_ALLOC(deltamap_t);
-    deltamap_init(map, 1);
+    ponyint_deltamap_init(map, 1);
   } else {
     delta_t key;
     key.actor = actor;
-    delta_t* delta = deltamap_get(map, &key);
+    delta_t* delta = ponyint_deltamap_get(map, &key);
 
     if(delta != NULL)
     {
@@ -58,12 +59,12 @@ deltamap_t* deltamap_update(deltamap_t* map, pony_actor_t* actor, size_t rc)
   delta->actor = actor;
   delta->rc = rc;
 
-  deltamap_put(map, delta);
+  ponyint_deltamap_put(map, delta);
   return map;
 }
 
-void deltamap_free(deltamap_t* map)
+void ponyint_deltamap_free(deltamap_t* map)
 {
-  deltamap_destroy(map);
+  ponyint_deltamap_destroy(map);
   POOL_FREE(deltamap_t, map);
 }

--- a/src/libponyrt/gc/delta.h
+++ b/src/libponyrt/gc/delta.h
@@ -9,15 +9,16 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct delta_t delta_t;
 
-pony_actor_t* delta_actor(delta_t* delta);
+pony_actor_t* ponyint_delta_actor(delta_t* delta);
 
-size_t delta_rc(delta_t* delta);
+size_t ponyint_delta_rc(delta_t* delta);
 
-DECLARE_HASHMAP(deltamap, delta_t);
+DECLARE_HASHMAP(ponyint_deltamap, deltamap_t, delta_t);
 
-deltamap_t* deltamap_update(deltamap_t* map, pony_actor_t* actor, size_t rc);
+deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
+  size_t rc);
 
-void deltamap_free(deltamap_t* map);
+void ponyint_deltamap_free(deltamap_t* map);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -24,47 +24,50 @@ typedef struct gc_t
   deltamap_t* delta;
 } gc_t;
 
-DECLARE_STACK(gcstack, void);
+DECLARE_STACK(ponyint_gcstack, gcstack_t, void);
 
-void gc_sendobject(pony_ctx_t* ctx, void* p, pony_trace_fn f, bool immutable);
+void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
 
-void gc_recvobject(pony_ctx_t* ctx, void* p, pony_trace_fn f, bool immutable);
+void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
 
-void gc_markobject(pony_ctx_t* ctx, void* p, pony_trace_fn f, bool immutable);
+void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
 
-void gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void gc_recvactor(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_gc_recvactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void gc_markactor(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_gc_markactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void gc_createactor(pony_actor_t* current, pony_actor_t* actor);
+void ponyint_gc_createactor(pony_actor_t* current, pony_actor_t* actor);
 
-void gc_markimmutable(pony_ctx_t* ctx, gc_t* gc);
+void ponyint_gc_markimmutable(pony_ctx_t* ctx, gc_t* gc);
 
-void gc_handlestack(pony_ctx_t* ctx);
+void ponyint_gc_handlestack(pony_ctx_t* ctx);
 
-void gc_sweep(pony_ctx_t* ctx, gc_t* gc);
+void ponyint_gc_sweep(pony_ctx_t* ctx, gc_t* gc);
 
-void gc_sendacquire(pony_ctx_t* ctx);
+void ponyint_gc_sendacquire(pony_ctx_t* ctx);
 
-void gc_sendrelease(pony_ctx_t* ctx, gc_t* gc);
+void ponyint_gc_sendrelease(pony_ctx_t* ctx, gc_t* gc);
 
-bool gc_acquire(gc_t* gc, actorref_t* aref);
+bool ponyint_gc_acquire(gc_t* gc, actorref_t* aref);
 
-bool gc_release(gc_t* gc, actorref_t* aref);
+bool ponyint_gc_release(gc_t* gc, actorref_t* aref);
 
-size_t gc_rc(gc_t* gc);
+size_t ponyint_gc_rc(gc_t* gc);
 
-deltamap_t* gc_delta(gc_t* gc);
+deltamap_t* ponyint_gc_delta(gc_t* gc);
 
-void gc_register_final(pony_ctx_t* ctx, void* p, pony_final_fn final);
+void ponyint_gc_register_final(pony_ctx_t* ctx, void* p, pony_final_fn final);
 
-void gc_final(pony_ctx_t* ctx, gc_t* gc);
+void ponyint_gc_final(pony_ctx_t* ctx, gc_t* gc);
 
-void gc_done(gc_t* gc);
+void ponyint_gc_done(gc_t* gc);
 
-void gc_destroy(gc_t* gc);
+void ponyint_gc_destroy(gc_t* gc);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -8,7 +8,7 @@
 
 static size_t object_hash(object_t* obj)
 {
-  return hash_ptr(obj->address);
+  return ponyint_hash_ptr(obj->address);
 }
 
 static bool object_cmp(object_t* a, object_t* b)
@@ -35,82 +35,83 @@ static void object_free(object_t* obj)
   POOL_FREE(object_t, obj);
 }
 
-DEFINE_HASHMAP(objectmap, object_t, object_hash, object_cmp, pool_alloc_size,
-  pool_free_size, object_free);
+DEFINE_HASHMAP(ponyint_objectmap, objectmap_t, object_t, object_hash,
+  object_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size, object_free);
 
-object_t* objectmap_getobject(objectmap_t* map, void* address)
+object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address)
 {
   object_t obj;
   obj.address = address;
 
-  return objectmap_get(map, &obj);
+  return ponyint_objectmap_get(map, &obj);
 }
 
-object_t* objectmap_getorput(objectmap_t* map, void* address, uint32_t mark)
+object_t* ponyint_objectmap_getorput(objectmap_t* map, void* address,
+  uint32_t mark)
 {
-  object_t* obj = objectmap_getobject(map, address);
+  object_t* obj = ponyint_objectmap_getobject(map, address);
 
   if(obj != NULL)
     return obj;
 
   obj = object_alloc(address, mark);
-  objectmap_put(map, obj);
+  ponyint_objectmap_put(map, obj);
   return obj;
 }
 
-object_t* objectmap_register_final(objectmap_t* map, void* address,
+object_t* ponyint_objectmap_register_final(objectmap_t* map, void* address,
   pony_final_fn final, uint32_t mark)
 {
-  object_t* obj = objectmap_getorput(map, address, mark);
+  object_t* obj = ponyint_objectmap_getorput(map, address, mark);
   obj->final = final;
   return obj;
 }
 
-void objectmap_final(objectmap_t* map)
+void ponyint_objectmap_final(objectmap_t* map)
 {
   size_t i = HASHMAP_BEGIN;
   object_t* obj;
 
-  while((obj = objectmap_next(map, &i)) != NULL)
+  while((obj = ponyint_objectmap_next(map, &i)) != NULL)
   {
     if(obj->final != NULL)
       obj->final(obj->address);
   }
 }
 
-size_t objectmap_sweep(objectmap_t* map)
+size_t ponyint_objectmap_sweep(objectmap_t* map)
 {
   size_t count = 0;
   size_t i = HASHMAP_BEGIN;
   object_t* obj;
 
-  while((obj = objectmap_next(map, &i)) != NULL)
+  while((obj = ponyint_objectmap_next(map, &i)) != NULL)
   {
     void* p = obj->address;
 
     if(obj->rc > 0)
     {
       // Keep track of whether or not the object was reachable.
-      chunk_t* chunk = (chunk_t*)pagemap_get(p);
-      obj->reachable = heap_ismarked(chunk, p);
+      chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+      obj->reachable = ponyint_heap_ismarked(chunk, p);
 
       if(!obj->reachable)
-        heap_mark_shallow(chunk, p);
+        ponyint_heap_mark_shallow(chunk, p);
     } else {
       if(obj->final != NULL)
       {
         // If we are not free in the heap, don't run the finaliser and don't
         // remove this entry from the object map.
-        chunk_t* chunk = (chunk_t*)pagemap_get(p);
+        chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
-        if(heap_ismarked(chunk, p))
+        if(ponyint_heap_ismarked(chunk, p))
           continue;
 
         obj->final(p);
         count++;
       }
 
-      objectmap_removeindex(map, i);
+      ponyint_objectmap_removeindex(map, i);
       object_free(obj);
     }
   }

--- a/src/libponyrt/gc/objectmap.h
+++ b/src/libponyrt/gc/objectmap.h
@@ -16,18 +16,19 @@ typedef struct object_t
   bool immutable;
 } object_t;
 
-DECLARE_HASHMAP(objectmap, object_t);
+DECLARE_HASHMAP(ponyint_objectmap, objectmap_t, object_t);
 
-object_t* objectmap_getobject(objectmap_t* map, void* address);
+object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address);
 
-object_t* objectmap_getorput(objectmap_t* map, void* address, uint32_t mark);
+object_t* ponyint_objectmap_getorput(objectmap_t* map, void* address,
+  uint32_t mark);
 
-object_t* objectmap_register_final(objectmap_t* map, void* address,
+object_t* ponyint_objectmap_register_final(objectmap_t* map, void* address,
   pony_final_fn final, uint32_t mark);
 
-void objectmap_final(objectmap_t* map);
+void ponyint_objectmap_final(objectmap_t* map);
 
-size_t objectmap_sweep(objectmap_t* map);
+size_t ponyint_objectmap_sweep(objectmap_t* map);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -8,60 +8,60 @@
 void pony_gc_send(pony_ctx_t* ctx)
 {
   assert(ctx->stack == NULL);
-  ctx->trace_object = gc_sendobject;
-  ctx->trace_actor = gc_sendactor;
+  ctx->trace_object = ponyint_gc_sendobject;
+  ctx->trace_actor = ponyint_gc_sendactor;
 
 #ifdef USE_TELEMETRY
-  ctx->tsc = cpu_tick();
+  ctx->tsc = ponyint_cpu_tick();
 #endif
 }
 
 void pony_gc_recv(pony_ctx_t* ctx)
 {
   assert(ctx->stack == NULL);
-  ctx->trace_object = gc_recvobject;
-  ctx->trace_actor = gc_recvactor;
+  ctx->trace_object = ponyint_gc_recvobject;
+  ctx->trace_actor = ponyint_gc_recvactor;
 
 #ifdef USE_TELEMETRY
-  ctx->tsc = cpu_tick();
+  ctx->tsc = ponyint_cpu_tick();
 #endif
 }
 
-void pony_gc_mark(pony_ctx_t* ctx)
+void ponyint_gc_mark(pony_ctx_t* ctx)
 {
   assert(ctx->stack == NULL);
-  ctx->trace_object = gc_markobject;
-  ctx->trace_actor = gc_markactor;
+  ctx->trace_object = ponyint_gc_markobject;
+  ctx->trace_actor = ponyint_gc_markactor;
 }
 
 void pony_send_done(pony_ctx_t* ctx)
 {
-  gc_handlestack(ctx);
-  gc_sendacquire(ctx);
-  gc_done(actor_gc(ctx->current));
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_sendacquire(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
 
 #ifdef USE_TELEMETRY
-  ctx->time_in_send_scan += (cpu_tick() - ctx->tsc);
+  ctx->time_in_send_scan += (ponyint_cpu_tick() - ctx->tsc);
 #endif
 }
 
 void pony_recv_done(pony_ctx_t* ctx)
 {
-  gc_handlestack(ctx);
-  gc_done(actor_gc(ctx->current));
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
 
 #ifdef USE_TELEMETRY
-  ctx->time_in_recv_scan += (cpu_tick() - ctx->tsc);
+  ctx->time_in_recv_scan += (ponyint_cpu_tick() - ctx->tsc);
 #endif
 }
 
-void pony_mark_done(pony_ctx_t* ctx)
+void ponyint_mark_done(pony_ctx_t* ctx)
 {
-  gc_markimmutable(ctx, actor_gc(ctx->current));
-  gc_handlestack(ctx);
-  gc_sendacquire(ctx);
-  gc_sweep(ctx, actor_gc(ctx->current));
-  gc_done(actor_gc(ctx->current));
+  ponyint_gc_markimmutable(ctx, ponyint_actor_gc(ctx->current));
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_sendacquire(ctx);
+  ponyint_gc_sweep(ctx, ponyint_actor_gc(ctx->current));
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 
 void pony_trace(pony_ctx_t* ctx, void* p)

--- a/src/libponyrt/gc/trace.h
+++ b/src/libponyrt/gc/trace.h
@@ -6,9 +6,9 @@
 
 PONY_EXTERN_C_BEGIN
 
-void pony_gc_mark(pony_ctx_t* ctx);
+void ponyint_gc_mark(pony_ctx_t* ctx);
 
-void pony_mark_done(pony_ctx_t* ctx);
+void ponyint_mark_done(pony_ctx_t* ctx);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/lang/directory.c
+++ b/src/libponyrt/lang/directory.c
@@ -15,12 +15,12 @@ PONY_EXTERN_C_BEGIN
 
 const char* cwd;
 
-int os_eexist()
+int pony_os_eexist()
 {
   return EEXIST;
 }
 
-int os_errno()
+int pony_os_errno()
 {
   return errno;
 }
@@ -36,7 +36,7 @@ static bool skip_entry(const char* entry, size_t len)
   return false;
 }
 
-char* os_cwd()
+char* pony_os_cwd()
 {
   if(cwd == NULL)
   {
@@ -59,12 +59,12 @@ char* os_cwd()
 
 #if defined(PLATFORM_IS_WINDOWS)
 
-WIN32_FIND_DATA* windows_find_data()
+WIN32_FIND_DATA* ponyint_windows_find_data()
 {
   return (WIN32_FIND_DATA*)malloc(sizeof(WIN32_FIND_DATA));
 }
 
-const char* windows_readdir(WIN32_FIND_DATA* find)
+const char* ponyint_windows_readdir(WIN32_FIND_DATA* find)
 {
   size_t len = strlen(find->cFileName) + 1;
 
@@ -81,44 +81,44 @@ const char* windows_readdir(WIN32_FIND_DATA* find)
 
 #if defined(PLATFORM_IS_POSIX_BASED)
 
-int o_rdonly()
+int ponyint_o_rdonly()
 {
   return O_RDONLY;
 }
 
-int o_rdwr()
+int ponyint_o_rdwr()
 {
   return O_RDWR;
 }
 
-int o_creat()
+int ponyint_o_creat()
 {
   return O_CREAT;
 }
 
-int o_trunc()
+int ponyint_o_trunc()
 {
   return O_TRUNC;
 }
 
-int o_directory()
+int ponyint_o_directory()
 {
   return O_DIRECTORY;
 }
 
-int o_cloexec()
+int ponyint_o_cloexec()
 {
   return O_CLOEXEC;
 }
 
 #if !defined(PLATFORM_IS_MACOSX)
-int at_removedir()
+int ponyint_at_removedir()
 {
   return AT_REMOVEDIR;
 }
 #endif
 
-const char* unix_readdir(DIR* dir)
+const char* ponyint_unix_readdir(DIR* dir)
 {
   struct dirent de;
   struct dirent* d;

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -216,7 +216,7 @@ static bool lsda_init(lsda_t* lsda, exception_context_t* context)
   return true;
 }
 
-bool lsda_scan(exception_context_t* context, uintptr_t* lp)
+bool ponyint_lsda_scan(exception_context_t* context, uintptr_t* lp)
 {
   lsda_t lsda;
 

--- a/src/libponyrt/lang/lsda.h
+++ b/src/libponyrt/lang/lsda.h
@@ -18,7 +18,7 @@ typedef struct _Unwind_Context exception_context_t;
 typedef DISPATCHER_CONTEXT exception_context_t;
 #endif
 
-bool lsda_scan(exception_context_t* context, uintptr_t* lp);
+bool ponyint_lsda_scan(exception_context_t* context, uintptr_t* lp);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/lang/paths.c
+++ b/src/libponyrt/lang/paths.c
@@ -5,7 +5,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-char* os_realpath(const char* path)
+char* pony_os_realpath(const char* path)
 {
 #ifdef PLATFORM_IS_WINDOWS
   char resolved[FILENAME_MAX];

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -72,7 +72,7 @@ _Unwind_Reason_Code pony_personality_v0(_Unwind_State state,
   {
     case _US_VIRTUAL_UNWIND_FRAME:
     {
-      if(!lsda_scan(context, &landing_pad))
+      if(!ponyint_lsda_scan(context, &landing_pad))
         return continue_unwind(exception, context);
 
       // Save r13.
@@ -128,7 +128,7 @@ _Unwind_Reason_Code pony_personality_v0(int version, _Unwind_Action actions,
   // The search phase sets up the landing pad.
   if(actions & _UA_SEARCH_PHASE)
   {
-    if(!lsda_scan(context, &landing_pad))
+    if(!ponyint_lsda_scan(context, &landing_pad))
       return _URC_CONTINUE_UNWIND;
 
     return _URC_HANDLER_FOUND;

--- a/src/libponyrt/lang/socket.h
+++ b/src/libponyrt/lang/socket.h
@@ -3,9 +3,9 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool os_socket_init();
+bool ponyint_os_sockets_init();
 
-void os_socket_shutdown();
+void ponyint_os_sockets_final();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/lang/ssl.c
+++ b/src/libponyrt/lang/ssl.c
@@ -10,7 +10,7 @@ static pthread_mutex_t* locks;
 PONY_EXTERN_C_BEGIN
 
 // Forward declaration to avoid C++ name mangling
-void* os_ssl_multithreading(uint32_t count);
+void* ponyint_ssl_multithreading(uint32_t count);
 
 PONY_EXTERN_C_END
 
@@ -36,7 +36,7 @@ static void locking_callback(int mode, int type, const char* file, int line)
   }
 }
 
-void* os_ssl_multithreading(uint32_t count)
+void* ponyint_ssl_multithreading(uint32_t count)
 {
 #if defined(PLATFORM_IS_WINDOWS)
   locks = (HANDLE*)malloc(count * sizeof(HANDLE*));

--- a/src/libponyrt/lang/stat.c
+++ b/src/libponyrt/lang/stat.c
@@ -49,7 +49,7 @@ typedef struct pony_stat_t
 
 #ifdef PLATFORM_IS_WINDOWS
 
-void filetime_to_ts(FILETIME* ft, int64_t* s, int64_t* ns)
+static void filetime_to_ts(FILETIME* ft, int64_t* s, int64_t* ns)
 {
   int64_t epoch = ((int64_t)ft->dwHighDateTime << 32) | ft->dwLowDateTime;
   epoch -= 116444736000000000;
@@ -166,7 +166,7 @@ static void unix_symlink(int r, pony_stat_t* p, struct stat* st)
 
 #endif
 
-bool os_fstatat(int fd, const char* path, pony_stat_t* p)
+bool pony_os_fstatat(int fd, const char* path, pony_stat_t* p)
 {
 #if defined(PLATFORM_IS_WINDOWS) || defined(PLATFORM_IS_MACOSX)
   (void)fd;
@@ -189,7 +189,7 @@ bool os_fstatat(int fd, const char* path, pony_stat_t* p)
 #endif
 }
 
-bool os_fstat(int fd, const char* path, pony_stat_t* p)
+bool pony_os_fstat(int fd, const char* path, pony_stat_t* p)
 {
 #if defined(PLATFORM_IS_WINDOWS)
   HANDLE h = (HANDLE)_get_osfhandle(fd);
@@ -219,7 +219,7 @@ bool os_fstat(int fd, const char* path, pony_stat_t* p)
 #endif
 }
 
-bool os_stat(const char* path, pony_stat_t* p)
+bool pony_os_stat(const char* path, pony_stat_t* p)
 {
 #if defined(PLATFORM_IS_WINDOWS)
   WIN32_FILE_ATTRIBUTE_DATA fa;

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -14,12 +14,12 @@
 
 PONY_EXTERN_C_BEGIN
 
-FILE* os_stdout()
+FILE* pony_os_stdout()
 {
   return stdout;
 }
 
-FILE* os_stderr()
+FILE* pony_os_stderr()
 {
   return stderr;
 }
@@ -367,7 +367,7 @@ static char ansi_parse(const char* buffer, size_t* pos, size_t len,
   return code;
 }
 
-void os_stdout_setup()
+void pony_os_stdout_setup()
 {
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE handle;
@@ -404,7 +404,7 @@ void os_stdout_setup()
 #endif
 }
 
-bool os_stdin_setup()
+bool pony_os_stdin_setup()
 {
   // Return true if reading stdin should be event based.
 #ifdef PLATFORM_IS_WINDOWS
@@ -436,7 +436,7 @@ bool os_stdin_setup()
 #endif
 }
 
-size_t os_stdin_read(char* buffer, size_t space, bool* out_again)
+size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
 {
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
@@ -484,7 +484,7 @@ size_t os_stdin_read(char* buffer, size_t space, bool* out_again)
   }
 
   if(len != 0)  // Start listening to stdin notifications again
-    iocp_resume_stdin();
+    ponyint_iocp_resume_stdin();
 
   *out_again = false;
   return len;
@@ -507,19 +507,19 @@ size_t os_stdin_read(char* buffer, size_t space, bool* out_again)
 #endif
 }
 
-bool os_fp_tty(FILE* fp)
+static bool fp_tty(FILE* fp)
 {
   return
     ((fp == stdout) && is_stdout_tty) ||
     ((fp == stderr) && is_stderr_tty);
 }
 
-void os_std_write(FILE* fp, char* buffer, size_t len)
+void pony_os_std_write(FILE* fp, char* buffer, size_t len)
 {
   if(len == 0)
     return;
 
-  if(!os_fp_tty(fp))
+  if(!fp_tty(fp))
   {
     // Find ANSI codes and strip them from the output.
     const size_t final = len - 1;

--- a/src/libponyrt/lang/time.c
+++ b/src/libponyrt/lang/time.c
@@ -47,7 +47,7 @@ static void tm_to_date(struct tm* tm, int nsec, date_t* date)
   date->day_of_year = tm->tm_yday;
 }
 
-int64_t os_timegm(date_t* date)
+int64_t ponyint_timegm(date_t* date)
 {
   struct tm tm;
   date_to_tm(date, &tm);
@@ -59,7 +59,7 @@ int64_t os_timegm(date_t* date)
 #endif
 }
 
-void os_gmtime(date_t* date, int64_t sec, int64_t nsec)
+void ponyint_gmtime(date_t* date, int64_t sec, int64_t nsec)
 {
   time_t overflow_sec = (time_t)(nsec / 1000000000);
   nsec -= (overflow_sec * 1000000000);
@@ -83,7 +83,7 @@ void os_gmtime(date_t* date, int64_t sec, int64_t nsec)
   tm_to_date(&tm, (int)nsec, date);
 }
 
-char* os_formattime(date_t* date, const char* fmt)
+char* ponyint_formattime(date_t* date, const char* fmt)
 {
   pony_ctx_t* ctx = pony_ctx();
   char* buffer;

--- a/src/libponyrt/lang/win_except.c
+++ b/src/libponyrt/lang/win_except.c
@@ -86,7 +86,7 @@ EXCEPTION_DISPOSITION pony_personality_v0(EXCEPTION_RECORD *ExcRecord,
   if(!(ExcRecord->ExceptionFlags  &
     (EXCEPTION_UNWINDING | EXCEPTION_EXIT_UNWIND)))
   {
-    if(!lsda_scan(DispatcherContext, &landing_pad))
+    if(!ponyint_lsda_scan(DispatcherContext, &landing_pad))
       return ExceptionContinueSearch;
 
     RtlUnwindEx(EstablisherFrame, (PVOID)landing_pad, ExcRecord,

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -13,7 +13,7 @@
 #include <mach/vm_statistics.h>
 #endif
 
-void* virtual_alloc(size_t bytes)
+void* ponyint_virt_alloc(size_t bytes)
 {
   void* p;
 
@@ -41,7 +41,7 @@ void* virtual_alloc(size_t bytes)
   return p;
 }
 
-void virtual_free(void* p, size_t bytes)
+void ponyint_virt_free(void* p, size_t bytes)
 {
 #if defined(PLATFORM_IS_WINDOWS)
   VirtualFree(p, 0, MEM_RELEASE);

--- a/src/libponyrt/mem/alloc.h
+++ b/src/libponyrt/mem/alloc.h
@@ -4,12 +4,12 @@
 /**
  * Allocates memory in the virtual address space.
  */
-void* virtual_alloc(size_t bytes);
+void* ponyint_virt_alloc(size_t bytes);
 
 /**
  * Deallocates a chunk of memory that was previously allocated with
- * virtual_alloc.
+ * ponyint_virt_alloc.
  */
-void virtual_free(void* p, size_t bytes);
+void ponyint_virt_free(void* p, size_t bytes);
 
 #endif

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -27,66 +27,67 @@ typedef struct heap_t
   size_t next_gc;
 } heap_t;
 
-uint32_t heap_index(size_t size);
+uint32_t ponyint_heap_index(size_t size);
 
-void heap_setinitialgc(size_t size);
+void ponyint_heap_setinitialgc(size_t size);
 
-void heap_setnextgcfactor(double factor);
+void ponyint_heap_setnextgcfactor(double factor);
 
-void heap_init(heap_t* heap);
+void ponyint_heap_init(heap_t* heap);
 
-void heap_destroy(heap_t* heap);
+void ponyint_heap_destroy(heap_t* heap);
 
 __pony_spec_malloc__(
-  void* heap_alloc(pony_actor_t* actor, heap_t* heap, size_t size)
+  void* ponyint_heap_alloc(pony_actor_t* actor, heap_t* heap, size_t size)
   );
 
 __pony_spec_malloc__(
-void* heap_alloc_small(pony_actor_t* actor, heap_t* heap,
+void* ponyint_heap_alloc_small(pony_actor_t* actor, heap_t* heap,
   uint32_t sizeclass)
   );
 
 __pony_spec_malloc__(
-void* heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size)
+void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size)
   );
 
-void* heap_realloc(pony_actor_t* actor, heap_t* heap, void* p, size_t size);
+void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
+  size_t size);
 
 /**
  * Adds to the used memory figure kept by the heap. This allows objects
  * received in messages to count towards the GC heuristic.
  */
-void heap_used(heap_t* heap, size_t size);
+void ponyint_heap_used(heap_t* heap, size_t size);
 
-bool heap_startgc(heap_t* heap);
+bool ponyint_heap_startgc(heap_t* heap);
 
 /**
  * Mark an address in a chunk. Returns true if it was already marked, or false
  * if you have just marked it.
  */
-bool heap_mark(chunk_t* chunk, void* p);
+bool ponyint_heap_mark(chunk_t* chunk, void* p);
 
 /**
- * Marks an address, but does not affect the return value of heap_mark() for
- * the same address, nor does it indicate previous mark status.
+ * Marks an address, but does not affect the return value of ponyint_heap_mark()
+ * for the same address, nor does it indicate previous mark status.
  */
-void heap_mark_shallow(chunk_t* chunk, void* p);
+void ponyint_heap_mark_shallow(chunk_t* chunk, void* p);
 
 /**
  * Returns true if the address is marked (allocated).
  */
-bool heap_ismarked(chunk_t* chunk, void* p);
+bool ponyint_heap_ismarked(chunk_t* chunk, void* p);
 
 /**
  * Forcibly free this address.
  */
-void heap_free(chunk_t* chunk, void* p);
+void ponyint_heap_free(chunk_t* chunk, void* p);
 
-void heap_endgc(heap_t* heap);
+void ponyint_heap_endgc(heap_t* heap);
 
-pony_actor_t* heap_owner(chunk_t* chunk);
+pony_actor_t* ponyint_heap_owner(chunk_t* chunk);
 
-size_t heap_size(chunk_t* chunk);
+size_t ponyint_heap_size(chunk_t* chunk);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/mem/pagemap.c
+++ b/src/libponyrt/mem/pagemap.c
@@ -58,7 +58,7 @@ static const pagemap_level_t level[PAGEMAP_LEVELS] =
 
 static void** root;
 
-void* pagemap_get(const void* m)
+void* ponyint_pagemap_get(const void* m)
 {
   void** v = root;
 
@@ -74,7 +74,7 @@ void* pagemap_get(const void* m)
   return v;
 }
 
-void pagemap_set(const void* m, void* v)
+void ponyint_pagemap_set(const void* m, void* v)
 {
   void*** pv = &root;
   void* p;
@@ -83,13 +83,13 @@ void pagemap_set(const void* m, void* v)
   {
     if(*pv == NULL)
     {
-      p = pool_alloc(level[i].size_index);
+      p = ponyint_pool_alloc(level[i].size_index);
       memset(p, 0, level[i].size);
       void** prev = NULL;
 
       if(!_atomic_cas(pv, &prev, p))
       {
-        pool_free(level[i].size_index, p);
+        ponyint_pool_free(level[i].size_index, p);
         *pv = prev;
       }
     }

--- a/src/libponyrt/mem/pagemap.h
+++ b/src/libponyrt/mem/pagemap.h
@@ -5,9 +5,9 @@
 
 PONY_EXTERN_C_BEGIN
 
-void* pagemap_get(const void* m);
+void* ponyint_pagemap_get(const void* m);
 
-void pagemap_set(const void* m, void* v);
+void ponyint_pagemap_set(const void* m, void* v);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/mem/pool.h
+++ b/src/libponyrt/mem/pool.h
@@ -12,17 +12,17 @@ PONY_EXTERN_C_BEGIN
 #define POOL_ALIGN_BITS 10
 #define POOL_ALIGN (1 << POOL_ALIGN_BITS)
 
-__pony_spec_malloc__(void* pool_alloc(size_t index));
-void pool_free(size_t index, void* p);
+__pony_spec_malloc__(void* ponyint_pool_alloc(size_t index));
+void ponyint_pool_free(size_t index, void* p);
 
-__pony_spec_malloc__(void* pool_alloc_size(size_t size));
-void pool_free_size(size_t size, void* p);
+__pony_spec_malloc__(void* ponyint_pool_alloc_size(size_t size));
+void ponyint_pool_free_size(size_t size, void* p);
 
-size_t pool_index(size_t size);
+size_t ponyint_pool_index(size_t size);
 
-size_t pool_size(size_t index);
+size_t ponyint_pool_size(size_t index);
 
-size_t pool_adjust_size(size_t size);
+size_t ponyint_pool_adjust_size(size_t size);
 
 #define POOL_INDEX(SIZE) \
   __pony_choose_expr(SIZE <= (1 << (POOL_MIN_BITS + 0)), 0, \
@@ -45,10 +45,10 @@ size_t pool_adjust_size(size_t size);
     ))))))))))))))))
 
 #define POOL_ALLOC(TYPE) \
-  (TYPE*) pool_alloc(POOL_INDEX(sizeof(TYPE)))
+  (TYPE*) ponyint_pool_alloc(POOL_INDEX(sizeof(TYPE)))
 
 #define POOL_FREE(TYPE, VALUE) \
-  pool_free(POOL_INDEX(sizeof(TYPE)), VALUE)
+  ponyint_pool_free(POOL_INDEX(sizeof(TYPE)), VALUE)
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -170,7 +170,8 @@ static int missing_argument(opt_state_t* s)
     return -2;
 }
 
-void opt_init(const opt_arg_t* args, opt_state_t* s, int* argc, char** argv)
+void ponyint_opt_init(const opt_arg_t* args, opt_state_t* s, int* argc,
+  char** argv)
 {
   s->argc = argc;
   s->argv = argv;
@@ -184,7 +185,7 @@ void opt_init(const opt_arg_t* args, opt_state_t* s, int* argc, char** argv)
   s->remove = 0;
 }
 
-int opt_next(opt_state_t* s)
+int ponyint_opt_next(opt_state_t* s)
 {
   s->arg_val = NULL;
   
@@ -204,7 +205,7 @@ int opt_next(opt_state_t* s)
   if(m == NULL)
   {
     s->opt_start += strlen(s->opt_start);
-    return opt_next(s);
+    return ponyint_opt_next(s);
   }
   else if(m == (opt_arg_t*)1)
   {

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -32,8 +32,9 @@ typedef struct opt_state_t
   int remove;
 } opt_state_t;
 
-void opt_init(const opt_arg_t* args, opt_state_t* s, int* argc, char** argv);
+void ponyint_opt_init(const opt_arg_t* args, opt_state_t* s, int* argc,
+  char** argv);
 
-int opt_next(opt_state_t* s);
+int ponyint_opt_next(opt_state_t* s);
 
 #endif

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -52,7 +52,7 @@ static bool use_numa = false;
   err += (_##sym == NULL); \
 }
 
-void pony_numa_init()
+void ponyint_numa_init()
 {
   void* lib = dlopen("libnuma.so.1", RTLD_LAZY);
   int err = 0;
@@ -86,7 +86,7 @@ void pony_numa_init()
   _numa_set_localalloc();
 }
 
-uint32_t pony_numa_cores()
+uint32_t ponyint_numa_cores()
 {
   if(use_numa)
     return _numa_num_task_cpus();
@@ -94,7 +94,7 @@ uint32_t pony_numa_cores()
   return 0;
 }
 
-void pony_numa_core_list(uint32_t* list)
+void ponyint_numa_core_list(uint32_t* list)
 {
   if(!use_numa)
     return;
@@ -128,7 +128,7 @@ void pony_numa_core_list(uint32_t* list)
   _numa_bitmask_free(cpu);
 }
 
-uint32_t pony_numa_node_of_cpu(uint32_t cpu)
+uint32_t ponyint_numa_node_of_cpu(uint32_t cpu)
 {
   if(use_numa)
     return _numa_node_of_cpu(cpu);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -194,20 +194,20 @@ void pony_triggergc(pony_actor_t* actor);
 /** Start gc tracing for sending.
  *
  * Call this before sending a message if it has anything in it that can be
- * GCed. Then trace all the GCable items, then call pony_gc_done.
+ * GCed. Then trace all the GCable items, then call pony_send_done.
  */
 void pony_gc_send(pony_ctx_t* ctx);
 
 /** Start gc tracing for receiving.
  *
  * Call this when receiving a message if it has anything in it that can be
- * GCed. Then trace all the GCable items, then call pony_gc_done.
+ * GCed. Then trace all the GCable items, then call pony_recv_done.
  */
 void pony_gc_recv(pony_ctx_t* ctx);
 
 /** Finish gc tracing for sending.
  *
- * Call this after tracing the GC-able contents.
+ * Call this after tracing the GCable contents.
  */
 void pony_send_done(pony_ctx_t* ctx);
 

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -57,10 +57,10 @@ static bool cpu_physical(uint32_t cpu)
 }
 #endif
 
-uint32_t cpu_count()
+uint32_t ponyint_cpu_count()
 {
 #if defined(PLATFORM_IS_LINUX)
-  uint32_t count = pony_numa_cores();
+  uint32_t count = ponyint_numa_cores();
 
   if(count > 0)
     return count;
@@ -124,24 +124,24 @@ uint32_t cpu_count()
 #endif
 }
 
-void cpu_assign(uint32_t count, scheduler_t* scheduler)
+void ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler)
 {
 #if defined(PLATFORM_IS_LINUX)
-  uint32_t cpu_count = pony_numa_cores();
+  uint32_t cpu_count = ponyint_numa_cores();
 
   if(cpu_count > 0)
   {
-    uint32_t* list = pool_alloc_size(cpu_count * sizeof(uint32_t));
-    pony_numa_core_list(list);
+    uint32_t* list = ponyint_pool_alloc_size(cpu_count * sizeof(uint32_t));
+    ponyint_numa_core_list(list);
 
     for(uint32_t i = 0; i < count; i++)
     {
       uint32_t cpu = list[i % cpu_count];
       scheduler[i].cpu = cpu;
-      scheduler[i].node = pony_numa_node_of_cpu(cpu);
+      scheduler[i].node = ponyint_numa_node_of_cpu(cpu);
     }
 
-    pool_free_size(cpu_count * sizeof(uint32_t), list);
+    ponyint_pool_free_size(cpu_count * sizeof(uint32_t), list);
     return;
   }
 
@@ -172,7 +172,7 @@ void cpu_assign(uint32_t count, scheduler_t* scheduler)
 #endif
 }
 
-void cpu_affinity(uint32_t cpu)
+void ponyint_cpu_affinity(uint32_t cpu)
 {
 #if defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_FREEBSD)
   // Affinity is handled when spawning the thread.
@@ -195,7 +195,7 @@ void cpu_affinity(uint32_t cpu)
 /**
  * Only nanosleep if sufficient cycles have elapsed.
  */
-void cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
+void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
 {
   // 10m cycles is about 3ms
   if((tsc2 - tsc) < 10000000)
@@ -226,7 +226,7 @@ void cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
 #endif
 }
 
-uint64_t cpu_tick()
+uint64_t ponyint_cpu_tick()
 {
 #if defined PLATFORM_IS_ARM
 # if defined(__APPLE__)

--- a/src/libponyrt/sched/cpu.h
+++ b/src/libponyrt/sched/cpu.h
@@ -8,15 +8,15 @@
 
 PONY_EXTERN_C_BEGIN
 
-uint32_t cpu_count();
+uint32_t ponyint_cpu_count();
 
-void cpu_assign(uint32_t count, scheduler_t* scheduler);
+void ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler);
 
-void cpu_affinity(uint32_t cpu);
+void ponyint_cpu_affinity(uint32_t cpu);
 
-void cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield);
+void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield);
 
-uint64_t cpu_tick();
+uint64_t ponyint_cpu_tick();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -9,7 +9,7 @@ struct mpmcq_node_t
   void* volatile data;
 };
 
-void mpmcq_init(mpmcq_t* q)
+void ponyint_mpmcq_init(mpmcq_t* q)
 {
   mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
   node->data = NULL;
@@ -19,14 +19,14 @@ void mpmcq_init(mpmcq_t* q)
   q->tail.node = node;
 }
 
-void mpmcq_destroy(mpmcq_t* q)
+void ponyint_mpmcq_destroy(mpmcq_t* q)
 {
   POOL_FREE(mpmcq_node_t, q->tail.node);
   q->head = NULL;
   q->tail.node = NULL;
 }
 
-void mpmcq_push(mpmcq_t* q, void* data)
+void ponyint_mpmcq_push(mpmcq_t* q, void* data)
 {
   mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
   node->data = data;
@@ -36,7 +36,7 @@ void mpmcq_push(mpmcq_t* q, void* data)
   _atomic_store(&prev->next, node);
 }
 
-void mpmcq_push_single(mpmcq_t* q, void* data)
+void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
 {
   mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
   node->data = data;
@@ -48,7 +48,7 @@ void mpmcq_push_single(mpmcq_t* q, void* data)
   prev->next = node;
 }
 
-void* mpmcq_pop(mpmcq_t* q)
+void* ponyint_mpmcq_pop(mpmcq_t* q)
 {
   mpmcq_dwcas_t cmp, xchg;
   mpmcq_node_t* next;

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -32,15 +32,15 @@ __pony_spec_align__(
   } mpmcq_t, 64
 );
 
-void mpmcq_init(mpmcq_t* q);
+void ponyint_mpmcq_init(mpmcq_t* q);
 
-void mpmcq_destroy(mpmcq_t* q);
+void ponyint_mpmcq_destroy(mpmcq_t* q);
 
-void mpmcq_push(mpmcq_t* q, void* data);
+void ponyint_mpmcq_push(mpmcq_t* q, void* data);
 
-void mpmcq_push_single(mpmcq_t* q, void* data);
+void ponyint_mpmcq_push_single(mpmcq_t* q, void* data);
 
-void* mpmcq_pop(mpmcq_t* q);
+void* ponyint_mpmcq_pop(mpmcq_t* q);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -70,17 +70,17 @@ struct scheduler_t
   messageq_t mq;
 };
 
-pony_ctx_t* scheduler_init(uint32_t threads, bool noyield);
+pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield);
 
-bool scheduler_start(bool library);
+bool ponyint_sched_start(bool library);
 
-void scheduler_stop();
+void ponyint_sched_stop();
 
-void scheduler_add(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor);
 
-uint32_t scheduler_cores();
+uint32_t ponyint_sched_cores();
 
-void scheduler_terminate();
+void ponyint_sched_terminate();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -49,9 +49,9 @@ static int parse_opts(int argc, char** argv, options_t* opt)
 {
   opt_state_t s;
   int id;
-  opt_init(args, &s, &argc, argv);
+  ponyint_opt_init(args, &s, &argc, argv);
 
-  while((id = opt_next(&s)) != -1)
+  while((id = ponyint_opt_next(&s)) != -1)
   {
     switch(id)
     {
@@ -86,15 +86,15 @@ int pony_init(int argc, char** argv)
   argc = parse_opts(argc, argv, &opt);
 
 #if defined(PLATFORM_IS_LINUX)
-  pony_numa_init();
+  ponyint_numa_init();
 #endif
 
-  heap_setinitialgc(opt.gc_initial);
-  heap_setnextgcfactor(opt.gc_factor);
+  ponyint_heap_setinitialgc(opt.gc_initial);
+  ponyint_heap_setnextgcfactor(opt.gc_factor);
 
   pony_exitcode(0);
-  pony_ctx_t* ctx = scheduler_init(opt.threads, opt.noyield);
-  cycle_create(ctx,
+  pony_ctx_t* ctx = ponyint_sched_init(opt.threads, opt.noyield);
+  ponyint_cycle_create(ctx,
     opt.cd_min_deferred, opt.cd_max_deferred, opt.cd_conf_group);
 
   return argc;
@@ -102,10 +102,10 @@ int pony_init(int argc, char** argv)
 
 int pony_start(bool library)
 {
-  if(!os_socket_init())
+  if(!ponyint_os_sockets_init())
     return -1;
 
-  if(!scheduler_start(library))
+  if(!ponyint_sched_start(library))
     return -1;
 
   if(library)
@@ -116,8 +116,8 @@ int pony_start(bool library)
 
 int pony_stop()
 {
-  scheduler_stop();
-  os_socket_shutdown();
+  ponyint_sched_stop();
+  ponyint_os_sockets_final();
 
   return _atomic_load(&exit_code);
 }

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -229,13 +229,13 @@ int main(int argc, char* argv[])
   bool print_package_ast = false;
 
   opt_state_t s;
-  opt_init(args, &s, &argc, argv);
+  ponyint_opt_init(args, &s, &argc, argv);
 
   bool ok = true;
   bool print_usage = false;
   int id;
 
-  while((id = opt_next(&s)) != -1)
+  while((id = ponyint_opt_next(&s)) != -1)
   {
     switch(id)
     {

--- a/test/libponyrt/ds/fun.cc
+++ b/test/libponyrt/ds/fun.cc
@@ -10,8 +10,8 @@ TEST(DsFunTest, HashSameIntGivesSameKey)
 {
   uint64_t i = 2701197231051989;
 
-  uint64_t key1 = hash_int64(i);
-  uint64_t key2 = hash_int64(i);
+  uint64_t key1 = ponyint_hash_int64(i);
+  uint64_t key2 = ponyint_hash_int64(i);
 
   ASSERT_EQ(key1, key2);
 }
@@ -23,8 +23,8 @@ TEST(DsFunTest, HashSameStringGivesSameKey)
 {
   const char* s = "Pony";
 
-  uint64_t key1 = hash_str(s);
-  uint64_t key2 = hash_str(s);
+  uint64_t key1 = ponyint_hash_str(s);
+  uint64_t key2 = ponyint_hash_str(s);
 
   ASSERT_EQ(key1, key2);
 }
@@ -36,8 +36,8 @@ TEST(DsFunTest, HashSamePointerGivesSameKey)
 {
   void* p = malloc(sizeof(void*));
 
-  uint64_t key2 = hash_ptr(p);
-  uint64_t key1 = hash_ptr(p);
+  uint64_t key2 = ponyint_hash_ptr(p);
+  uint64_t key1 = ponyint_hash_ptr(p);
 
   ASSERT_EQ(key1, key2);
 
@@ -49,13 +49,13 @@ TEST(DsFunTest, HashSamePointerGivesSameKey)
  */
 TEST(DsFunTest, NumbersToNextPow)
 {
-  ASSERT_EQ(4, (unsigned int)next_pow2(3));
-  ASSERT_EQ(8, (unsigned int)next_pow2(5));
-  ASSERT_EQ(16, (unsigned int)next_pow2(10));
-  ASSERT_EQ(32, (unsigned int)next_pow2(25));
-  ASSERT_EQ(64, (unsigned int)next_pow2(50));
-  ASSERT_EQ(128, (unsigned int)next_pow2(100));
-  ASSERT_EQ(256, (unsigned int)next_pow2(200));
+  ASSERT_EQ(4, (unsigned int)ponyint_next_pow2(3));
+  ASSERT_EQ(8, (unsigned int)ponyint_next_pow2(5));
+  ASSERT_EQ(16, (unsigned int)ponyint_next_pow2(10));
+  ASSERT_EQ(32, (unsigned int)ponyint_next_pow2(25));
+  ASSERT_EQ(64, (unsigned int)ponyint_next_pow2(50));
+  ASSERT_EQ(128, (unsigned int)ponyint_next_pow2(100));
+  ASSERT_EQ(256, (unsigned int)ponyint_next_pow2(200));
 }
 
 /** Powers of two are not rounded.
@@ -63,5 +63,5 @@ TEST(DsFunTest, NumbersToNextPow)
  */
 TEST(DsFunTest, PowersOfTwoAreNotRounded)
 {
-  ASSERT_EQ((size_t)128, next_pow2(128));
+  ASSERT_EQ((size_t)128, ponyint_next_pow2(128));
 }

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -12,7 +12,7 @@
 
 typedef struct elem_t elem_t;
 
-DECLARE_HASHMAP(testmap, elem_t);
+DECLARE_HASHMAP(testmap, testmap_t, elem_t);
 
 class HashMapTest: public testing::Test
 {
@@ -32,8 +32,9 @@ class HashMapTest: public testing::Test
     static void free_buckets(size_t size, void* p);
 };
 
-DEFINE_HASHMAP(testmap, elem_t, HashMapTest::hash_tst, HashMapTest::cmp_tst,
-  malloc, HashMapTest::free_buckets, HashMapTest::free_elem);
+DEFINE_HASHMAP(testmap, testmap_t, elem_t, HashMapTest::hash_tst,
+  HashMapTest::cmp_tst, malloc, HashMapTest::free_buckets,
+  HashMapTest::free_elem);
 
 struct elem_t
 {
@@ -71,7 +72,7 @@ elem_t* HashMapTest::get_element()
 
 size_t HashMapTest::hash_tst(elem_t* p)
 {
-  return hash_size(p->key);
+  return ponyint_hash_size(p->key);
 }
 
 bool HashMapTest::cmp_tst(elem_t* a, elem_t* b)

--- a/test/libponyrt/ds/list.cc
+++ b/test/libponyrt/ds/list.cc
@@ -7,7 +7,7 @@
 
 typedef struct elem_t elem_t;
 
-DECLARE_LIST(testlist, elem_t);
+DECLARE_LIST(testlist, testlist_t, elem_t);
 
 class ListTest: public testing::Test
 {
@@ -16,7 +16,7 @@ class ListTest: public testing::Test
     static bool compare(elem_t* a, elem_t* b);
 };
 
-DEFINE_LIST(testlist, elem_t, ListTest::compare, NULL);
+DEFINE_LIST(testlist, testlist_t, elem_t, ListTest::compare, NULL);
 
 struct elem_t
 {
@@ -35,7 +35,7 @@ elem_t* ListTest::times2(elem_t* e, void* arg)
   return e;
 }
 
-/** Calling list_append with NULL as argument
+/** Calling ponyint_list_append with NULL as argument
  *  returns a new list with a single element.
  */
 TEST_F(ListTest, InitializeList)
@@ -50,7 +50,7 @@ TEST_F(ListTest, InitializeList)
   testlist_free(list);
 }
 
-/** A call to list_length returns the number of elements
+/** A call to ponyint_list_length returns the number of elements
  *  until the end of the list is reached.
  */
 TEST_F(ListTest, ListLength)
@@ -68,7 +68,7 @@ TEST_F(ListTest, ListLength)
   testlist_free(list);
 }
 
-/** A call to list_append appends an element to
+/** A call to ponyint_list_append appends an element to
  *  the end of the list.
  *
  *  After pushing an element, the resulting
@@ -98,7 +98,7 @@ TEST_F(ListTest, AppendElement)
   testlist_free(list);
 }
 
-/** A call to list_push prepends an element to the list.
+/** A call to ponyint_list_push prepends an element to the list.
  *
  *  The pointer returned points to the new head.
  */
@@ -119,8 +119,8 @@ TEST_F(ListTest, PushElement)
   testlist_free(list);
 }
 
-/** A call to list_pop provides the head of the list.
- *  The second element prior to list_pop becomes the new head.
+/** A call to ponyint_list_pop provides the head of the list.
+ *  The second element prior to ponyint_list_pop becomes the new head.
  */
 TEST_F(ListTest, ListPop)
 {
@@ -145,7 +145,7 @@ TEST_F(ListTest, ListPop)
   testlist_free(list);
 }
 
-/** A call to list_index (with index > 0) advances
+/** A call to ponyint_list_index (with index > 0) advances
  *  the list pointer to the element at position
  *  "index" (starting from 0).
  */
@@ -165,7 +165,7 @@ TEST_F(ListTest, ListIndexAbsolute)
   testlist_free(list);
 }
 
-/** A call to list_index with a negative index
+/** A call to ponyint_list_index with a negative index
  *  allows to traverse the list relative to its end.
  */
 TEST_F(ListTest, ListIndexRelative)
@@ -188,10 +188,10 @@ TEST_F(ListTest, ListIndexRelative)
   testlist_free(list);
 }
 
-/** A call to list_find returns a matching element according
+/** A call to ponyint_list_find returns a matching element according
  *  to the provided compare function.
  *
- *  If an element is not in the list, list_find returns NULL.
+ *  If an element is not in the list, ponyint_list_find returns NULL.
  */
 TEST_F(ListTest, ListFind)
 {
@@ -215,7 +215,7 @@ TEST_F(ListTest, ListFind)
   testlist_free(list);
 }
 
-/** A call to list_findindex returns the position
+/** A call to ponyint_list_findindex returns the position
  *  of an element within the list, -1 otherwise.
  */
 TEST_F(ListTest, ListFindIndex)
@@ -289,7 +289,7 @@ TEST_F(ListTest, ListSubset)
   testlist_free(b);
 }
 
-/** A call to list_reverse the returns a pointer
+/** A call to ponyint_list_reverse the returns a pointer
  *  to a new list of reversed order.
  */
 TEST_F(ListTest, ListReverse)
@@ -319,7 +319,7 @@ TEST_F(ListTest, ListReverse)
   ASSERT_EQ(e, &e1);
 }
 
-/** A call to list_map invokes the provided map function
+/** A call to ponyint_list_map invokes the provided map function
  *  for each element within the list.
  */
 TEST_F(ListTest, ListMap)

--- a/test/libponyrt/mem/heap.cc
+++ b/test/libponyrt/mem/heap.cc
@@ -11,58 +11,58 @@ TEST(Heap, Init)
   pony_actor_t* actor = (pony_actor_t*)0xDEADBEEF;
 
   heap_t heap;
-  heap_init(&heap);
+  ponyint_heap_init(&heap);
 
-  void* p = heap_alloc(actor, &heap, 127);
+  void* p = ponyint_heap_alloc(actor, &heap, 127);
   ASSERT_EQ((size_t)128, heap.used);
 
-  chunk_t* chunk = (chunk_t*)pagemap_get(p);
-  ASSERT_EQ(actor, heap_owner(chunk));
+  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  ASSERT_EQ(actor, ponyint_heap_owner(chunk));
 
-  size_t size = heap_size(chunk);
+  size_t size = ponyint_heap_size(chunk);
   ASSERT_EQ(size, (size_t)128);
 
-  void* p2 = heap_alloc(actor, &heap, 99);
+  void* p2 = ponyint_heap_alloc(actor, &heap, 99);
   ASSERT_NE(p, p2);
   ASSERT_EQ((size_t)256, heap.used);
 
   heap.next_gc = 0;
-  heap_startgc(&heap);
-  heap_mark(chunk, p);
-  heap_endgc(&heap);
+  ponyint_heap_startgc(&heap);
+  ponyint_heap_mark(chunk, p);
+  ponyint_heap_endgc(&heap);
   ASSERT_EQ((size_t)128, heap.used);
 
-  void* p3 = heap_alloc(actor, &heap, 107);
+  void* p3 = ponyint_heap_alloc(actor, &heap, 107);
   ASSERT_EQ(p2, p3);
 
-  heap_used(&heap, 1024);
+  ponyint_heap_used(&heap, 1024);
   ASSERT_EQ((size_t)1280, heap.used);
 
   heap.next_gc = 0;
-  heap_startgc(&heap);
-  heap_mark_shallow(chunk, p3);
-  heap_endgc(&heap);
+  ponyint_heap_startgc(&heap);
+  ponyint_heap_mark_shallow(chunk, p3);
+  ponyint_heap_endgc(&heap);
   ASSERT_EQ((size_t)128, heap.used);
 
-  void* p4 = heap_alloc(actor, &heap, 67);
+  void* p4 = ponyint_heap_alloc(actor, &heap, 67);
   ASSERT_EQ(p, p4);
 
   size_t large_size = (1 << 15) - 7;
-  void* p5 = heap_alloc(actor, &heap, large_size);
-  chunk_t* chunk5 = (chunk_t*)pagemap_get(p5);
-  ASSERT_EQ(actor, heap_owner(chunk5));
+  void* p5 = ponyint_heap_alloc(actor, &heap, large_size);
+  chunk_t* chunk5 = (chunk_t*)ponyint_pagemap_get(p5);
+  ASSERT_EQ(actor, ponyint_heap_owner(chunk5));
 
-  size_t adjust_size = pool_adjust_size(large_size);
+  size_t adjust_size = ponyint_pool_adjust_size(large_size);
 
-  size_t size5 = heap_size(chunk5);
+  size_t size5 = ponyint_heap_size(chunk5);
   ASSERT_EQ(adjust_size, size5);
   ASSERT_EQ(256 + adjust_size, heap.used);
 
   heap.next_gc = 0;
-  heap_startgc(&heap);
-  heap_mark_shallow(chunk5, p5);
-  heap_endgc(&heap);
+  ponyint_heap_startgc(&heap);
+  ponyint_heap_mark_shallow(chunk5, p5);
+  ponyint_heap_endgc(&heap);
   ASSERT_EQ(adjust_size, heap.used);
 
-  heap_destroy(&heap);
+  ponyint_heap_destroy(&heap);
 }

--- a/test/libponyrt/mem/pagemap.cc
+++ b/test/libponyrt/mem/pagemap.cc
@@ -6,35 +6,35 @@
 
 TEST(Pagemap, UnmappedIsNull)
 {
-  ASSERT_EQ(NULL, pagemap_get((void*)0x0));
-  ASSERT_EQ(NULL, pagemap_get((void*)0x7623432D));
-  ASSERT_EQ(NULL, pagemap_get((void*)0xFFFFFFFFFFFFFFFF));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x0));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x7623432D));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0xFFFFFFFFFFFFFFFF));
 }
 
 TEST(Pagemap, SetAndUnset)
 {
   void* m = (void*)(44 << 12);
 
-  pagemap_set(m, m);
-  ASSERT_EQ(m, pagemap_get(m));
+  ponyint_pagemap_set(m, m);
+  ASSERT_EQ(m, ponyint_pagemap_get(m));
 
-  pagemap_set(m, NULL);
-  ASSERT_EQ(NULL, pagemap_get(m));
+  ponyint_pagemap_set(m, NULL);
+  ASSERT_EQ(NULL, ponyint_pagemap_get(m));
 }
 
 TEST(Pagemap, SubAddressing)
 {
   char* m = (char*)(99 << 12);
-  pagemap_set(m, m);
+  ponyint_pagemap_set(m, m);
 
   char* p = m;
   char* end = p + 1024;
 
   while(p < end)
   {
-    ASSERT_EQ(m, pagemap_get(p));
+    ASSERT_EQ(m, ponyint_pagemap_get(p));
     p += 64;
   }
 
-  ASSERT_EQ(NULL, pagemap_get(end));
+  ASSERT_EQ(NULL, ponyint_pagemap_get(end));
 }

--- a/test/libponyrt/mem/pool.cc
+++ b/test/libponyrt/mem/pool.cc
@@ -8,8 +8,8 @@ typedef char block_t[32];
 
 TEST(Pool, Fifo)
 {
-  void* p1 = pool_alloc(0);
-  pool_free(0, p1);
+  void* p1 = ponyint_pool_alloc(0);
+  ponyint_pool_free(0, p1);
 
   void* p2 = POOL_ALLOC(block_t);
   ASSERT_EQ(p1, p2);
@@ -18,16 +18,16 @@ TEST(Pool, Fifo)
 
 TEST(Pool, Size)
 {
-  void* p1 = pool_alloc(0);
-  pool_free(0, p1);
+  void* p1 = ponyint_pool_alloc(0);
+  ponyint_pool_free(0, p1);
 
-  void* p2 = pool_alloc_size(17);
+  void* p2 = ponyint_pool_alloc_size(17);
   ASSERT_EQ(p1, p2);
-  pool_free_size(17, p2);
+  ponyint_pool_free_size(17, p2);
 
-  void* p3 = pool_alloc(0);
+  void* p3 = ponyint_pool_alloc(0);
   ASSERT_EQ(p2, p3);
-  pool_free(0, p3);
+  ponyint_pool_free(0, p3);
 }
 
 TEST(Pool, ExceedBlock)
@@ -66,7 +66,7 @@ TEST(Pool, ExceedBlock)
 
 TEST(Pool, LargeAlloc)
 {
-  void* p = pool_alloc_size(1 << 20);
+  void* p = ponyint_pool_alloc_size(1 << 20);
   ASSERT_TRUE(p != NULL);
-  pool_free_size(1 << 20, p);
+  ponyint_pool_free_size(1 << 20, p);
 }


### PR DESCRIPTION
This PR standardizes all publicly linked function names exposed by libponyrt (to avoid colliding with names of functions in user programs linked with libponyrt).

Specifically, every exposed function is now prefixed with either:

* `pony_` - functions that the user may want to call, either from C or from Pony via FFI.
* `ponyint_` - functions exposed by the runtime library, but for internal use only and subject to change without notification.

Additionally, any internal functions that are not used anywhere outside the file that defines them, but weren't marked `static` are now marked `static`.

Resolves #444.