### PR TITLE
Add time.Nanos primitive with utility functions for time conversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - --verbose,-V option for compiler informational messages.
 - Logger package
 - `ArrayValues.rewind()` method.
+- Nanos primitive in time package.
 
 ### Changed
 

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -71,3 +71,4 @@ actor Main is TestList
     end
 
     strings.Main.make().tests(test)
+    time.Main.make().tests(test)

--- a/packages/time/nanos.pony
+++ b/packages/time/nanos.pony
@@ -1,0 +1,23 @@
+
+primitive Nanos
+  """
+  Collection of utility functions for converting various durations of time
+  to nanoseconds, for passing to other functions in the time package.
+  """
+  fun from_seconds(t: U64): U64 =>
+    t * 1_000_000_000
+
+  fun from_millis(t: U64): U64 =>
+    t * 1_000_000
+
+  fun from_micros(t: U64): U64 =>
+    t * 1_000
+
+  fun from_seconds_f(t: F64): U64 =>
+    (t * 1_000_000_000).trunc().u64()
+
+  fun from_millis_f(t: F64): U64 =>
+    (t * 1_000_000).trunc().u64()
+
+  fun from_micros_f(t: F64): U64 =>
+    (t * 1_000).trunc().u64()

--- a/packages/time/test.pony
+++ b/packages/time/test.pony
@@ -1,0 +1,20 @@
+use "ponytest"
+
+actor Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestNanos)
+
+class iso _TestNanos is UnitTest
+  fun name(): String => "time/Nanos"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[U64](5_000_000_000, Nanos.from_seconds(5))
+    h.assert_eq[U64](5_000_000, Nanos.from_millis(5))
+    h.assert_eq[U64](5_000, Nanos.from_micros(5))
+
+    h.assert_eq[U64](1_230_000_000, Nanos.from_seconds_f(1.23))
+    h.assert_eq[U64](1_230_000, Nanos.from_millis_f(1.23))
+    h.assert_eq[U64](1_230, Nanos.from_micros_f(1.23))


### PR DESCRIPTION
This PR adds the `time.Duration` primitive with utility functions for converting various durations of time to nanoseconds, for passing to other functions in the `time` package.

This was discussed in #547.

Note that the first set of functions takes a `U64`, which should be fast for inlining, but there is a second set of functions for the case where you want to pass a `F64`, which I also imagine might be quite common ("timeout after 1.5 seconds" somehow seems more direct than "timeout after 1500 milliseconds").  I wanted to do this with a type parameter, but it looked like there wasn't a good way to do this while preserving the efficiency of the `U64` versions of the functions (let me know if there is a clever trick for this).