### PR TITLE
Allow qualifying exponential notations to be lexed as integers.

### DIFF
--- a/test/libponyc/lexer.cc
+++ b/test/libponyc/lexer.cc
@@ -858,11 +858,11 @@ TEST_F(LexerTest, FloatDotOnly)
 }
 
 
-TEST_F(LexerTest, FloatEOnly)
+TEST_F(LexerTest, FloatEOnlyAsInt)
 {
   const char* src = "1e3";
 
-  expect(1, 1, TK_FLOAT, "1000.0");
+  expect(1, 1, TK_INT, "1000");
   expect(1, 4, TK_EOF, "EOF");
   DO(test(src));
 }
@@ -878,11 +878,11 @@ TEST_F(LexerTest, FloatNegativeE)
 }
 
 
-TEST_F(LexerTest, FloatPositiveE)
+TEST_F(LexerTest, FloatPositiveEAsInt)
 {
   const char* src = "1e+2";
 
-  expect(1, 1, TK_FLOAT, "100.0");
+  expect(1, 1, TK_INT, "100");
   expect(1, 5, TK_EOF, "EOF");
   DO(test(src));
 }
@@ -935,6 +935,26 @@ TEST_F(LexerTest, FloatIllegalExp)
   expect(1, 1, TK_LEX_ERROR, "LEX_ERROR");
   expect(1, 7, TK_ID, "fg");
   expect(1, 9, TK_EOF, "EOF");
+  DO(test(src));
+}
+
+
+TEST_F(LexerTest, FloatSmallNumberLargeEAsInt)
+{
+  const char* src = "1.234e4";
+
+  expect(1, 1, TK_INT, "12340");
+  expect(1, 8, TK_EOF, "EOF");
+  DO(test(src));
+}
+
+
+TEST_F(LexerTest, FloatLargeEAsFloat)
+{
+  const char* src = "1e40";
+
+  expect(1, 1, TK_FLOAT, "1e+40");
+  expect(1, 5, TK_EOF, "EOF");
   DO(test(src));
 }
 


### PR DESCRIPTION
This PR allows qualifying exponential notations to be lexed as integers.

Specifically, if the value after applying the exponent would not have any digits to the right of its decimal point, and would not overflow the `lexint_t` type (effectively, U128), then the exponential notation is lexed as `TK_INT`.  Otherwise, it is lexed as `TK_FLOAT` as before.

These qualifying exponential notation are lexed as `TK_INT`, but can be assigned to integer *or* floating point types, just like any other `TK_INT`.  So this shouldn't break any working code, it only expands the realm of numeric literals possible where an integer is expected.

Resolves #547.