### PR TITLE
Fix issue 577 and add tests for String.count.

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -411,7 +411,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     end
 
     try
-      while k < j do
+      while k <= j do
         k = find(s, k) + s.size().isize()
         i = i + 1
       end

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -31,6 +31,7 @@ actor Main is TestList
     test(_TestStringReplace)
     test(_TestStringSplit)
     test(_TestStringJoin)
+    test(_TestStringCount)
     test(_TestStringCompare)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
@@ -479,6 +480,26 @@ class iso _TestStringJoin is UnitTest
     h.assert_eq[String](" ".join([as Stringable: U32(1), U32(4)]), "1 4")
     h.assert_eq[String](" ".join(Array[String]), "")
 
+
+class iso _TestStringCount is UnitTest
+  """
+  Test String.count
+  """
+  fun name(): String => "builtin/String.count"
+
+  fun apply(h: TestHelper) =>
+    let testString: String = "testString"
+    h.assert_eq[USize](testString.count(testString), 1)
+    h.assert_eq[USize](testString.count("testString"), 1)
+    h.assert_eq[USize]("testString".count(testString), 1)
+    h.assert_eq[USize]("".count("zomg"), 0)
+    h.assert_eq[USize]("zomg".count(""), 0)
+    h.assert_eq[USize]("azomg".count("zomg"), 1)
+    h.assert_eq[USize]("zomga".count("zomg"), 1)
+    h.assert_eq[USize]("atatat".count("at"), 3)
+    h.assert_eq[USize]("atatbat".count("at"), 3)
+    h.assert_eq[USize]("atata".count("ata"), 1)
+    h.assert_eq[USize]("tttt".count("tt"), 2)
 
 class iso _TestStringCompare is UnitTest
   """


### PR DESCRIPTION
String.count would fail to count the last instance of a substring in a string if the substring appeared twice at the end of the string. For example, "atat".count("at") would return 1 instead of 2.

The problem was caused because the loop that drives the search was terminated when the loop index was greater than or equal to the difference in length of the two strings being compared. Because of the way String.count used the String.find method, this was only a problem in situations where finding the second-to-last-string resulted in the index now being equal to the difference in length of the two strings being compared, causing the loop to terminate before finding the last occurrence of the substring.

The solution was to replace `k < j` with `k <= j` in the match search loop.

I added grey-box tests for String.count to prevent a regression on this issue and to excercise the code paths through the method.