### PR TITLE
Remove public/private output from entity documentation

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -627,8 +627,6 @@ static void doc_entity(docgen_t* docgen, ast_t* ast, ast_t* package)
   doc_type_list(docgen, provides, " is ", ", ", "");
   fprintf(docgen->type_file, "\n\n");
 
-  fprintf(docgen->type_file, "%s", (name[0] == '_') ? "Private" : "Public");
-
   const char* cap_text = doc_get_cap(cap);
   if(cap_text != NULL)
     fprintf(docgen->type_file, ", default capability %s", cap_text);


### PR DESCRIPTION
All we are doing is checking to see if the first character of the name is '_'.
This is standard Pony idiom and enforced by the compiler. We can expect
that anyone seeing '_name' knows that it is private and that 'name' is public.

The removed output added little value while cluttering up the documentation.