### PR TITLE
rename Maybe[A] to MaybePointer[A]

### DIFF
--- a/packages/builtin/maybe.pony
+++ b/packages/builtin/maybe.pony
@@ -1,30 +1,30 @@
-struct Maybe[A]
+struct MaybePointer[A]
   """
-  A Maybe[A] is used to encode a possibly-null type. It should _only_ be used
-  for structs that need to be passed to and from the C FFI.
+  A MaybePointer[A] is used to encode a possibly-null type. It should
+  _only_ be used for structs that need to be passed to and from the C FFI.
 
   An optional type for anything that isn't a struct should be encoded as a
   union type, for example (A | None).
   """
   new create(that: A) =>
     """
-    This re-encodes the type of `that` from A to Maybe[A], allowing `that` to
-    be assigned to a field or variable of type Maybe[A]. It doesn't allocate a
-    wrapper object: there is no containing object for `that`.
+    This re-encodes the type of `that` from A to MaybePointer[A], allowing
+    `that` to be assigned to a field or variable of type MaybePointer[A]. It
+    doesn't allocate a wrapper object: there is no containing object for `that`.
     """
     compile_intrinsic
 
   new none() =>
     """
-    This returns a null pointer typed as a Maybe[A].
+    This returns a null pointer typed as a MaybePointer[A].
     """
     compile_intrinsic
 
   fun apply(): this->A ? =>
     """
-    This re-encodes the type of `this` from Maybe[A] to A, allowing `this` to
-    be assigned to a field of variable of type A. If `this` is a null pointer,
-    an error is raised.
+    This re-encodes the type of `this` from MaybePointer[A] to A, allowing
+    `this` to be assigned to a field of variable of type A. If `this` is a null
+    pointer, an error is raised.
     """
     compile_intrinsic
 

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -39,7 +39,7 @@ actor Main is TestList
     test(_TestArrayInsert)
     test(_TestMath128)
     test(_TestDivMod)
-    test(_TestMaybe)
+    test(_TestMaybePointer)
     test(_TestValtrace)
 
 
@@ -719,14 +719,14 @@ class iso _TestDivMod is UnitTest
 struct _TestStruct
   var i: U32 = 0
 
-class iso _TestMaybe is UnitTest
+class iso _TestMaybePointer is UnitTest
   """
-  Test the Maybe type.
+  Test the MaybePointer type.
   """
-  fun name(): String => "builtin/Maybe"
+  fun name(): String => "builtin/MaybePointer"
 
   fun apply(h: TestHelper) ? =>
-    let a = Maybe[_TestStruct].none()
+    let a = MaybePointer[_TestStruct].none()
     h.assert_true(a.is_none())
 
     h.assert_error(lambda()(a)? => let from_a = a() end)
@@ -734,7 +734,7 @@ class iso _TestMaybe is UnitTest
     let s = _TestStruct
     s.i = 7
 
-    let b = Maybe[_TestStruct](s)
+    let b = MaybePointer[_TestStruct](s)
     h.assert_false(b.is_none())
 
     let from_b = b()

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -125,7 +125,7 @@ static void init_runtime(compile_t* c)
   c->str_F32 = stringtab("F32");
   c->str_F64 = stringtab("F64");
   c->str_Pointer = stringtab("Pointer");
-  c->str_Maybe = stringtab("Maybe");
+  c->str_Maybe = stringtab("MaybePointer");
   c->str_Array = stringtab("Array");
   c->str_Platform = stringtab("Platform");
 

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -19,7 +19,7 @@ static bool void_star_param(ast_t* param_type, ast_t* arg_type)
     return false;
 
   // Parameter type is Pointer[None]
-  // If the argument is Pointer[A], Maybe[A] or USize, allow it
+  // If the argument is Pointer[A], MaybePointer[A] or USize, allow it
   while(ast_id(arg_type) == TK_ARROW)
     arg_type = ast_childidx(arg_type, 1);
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -962,9 +962,9 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
   if(!reify_defaults(typeparams, typeargs, true))
     return false;
 
-  if(!strcmp(name, "Maybe"))
+  if(!strcmp(name, "MaybePointer"))
   {
-    // Maybe[A] must be bound to a struct.
+    // MaybePointer[A] must be bound to a struct.
     assert(ast_childcount(typeargs) == 1);
     ast_t* typeparam = ast_child(typeparams);
     ast_t* typearg = ast_child(typeargs);
@@ -992,7 +992,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
     if(!ok)
     {
       ast_error(ast,
-        "%s is not allowed: the type argument to Maybe must be a struct",
+        "%s is not allowed: the type argument to MaybePointer must be a struct",
         ast_print_type(ast));
 
       return false;

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1448,7 +1448,7 @@ bool is_pointer(ast_t* type)
 
 bool is_maybe(ast_t* type)
 {
-  return is_literal(type, "Maybe");
+  return is_literal(type, "MaybePointer");
 }
 
 bool is_none(ast_t* type)


### PR DESCRIPTION
This patch is for #567: it renames Maybe[A] to MaybePointer[A] in Pony code.  The tests pass on Linux.  I didn't rename any of the internal compiler functions (e.g. `is_maybe()`) -- should I do those as well?