### PR TITLE
support for PIC libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,12 +361,12 @@ define CONFIGURE_COMPILER
 
   ifeq ($(suffix $(1)),.cc)
     compiler := $(CXX)
-    flags := $(ALL_CXXFLAGS)
+    flags := $(ALL_CXXFLAGS) $(CXXFLAGS)
   endif
 
   ifeq ($(suffix $(1)),.c)
     compiler := $(CC)
-    flags := $(ALL_CFLAGS)
+    flags := $(ALL_CFLAGS) $(CFLAGS)
   endif
 endef
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -90,7 +90,7 @@ static LLVMTargetMachineRef make_machine(pass_opt_t* opt)
   LLVMCodeGenOptLevel opt_level =
     opt->release ? LLVMCodeGenLevelAggressive : LLVMCodeGenLevelNone;
 
-  LLVMRelocMode reloc = opt->library ? LLVMRelocPIC : LLVMRelocDefault;
+  LLVMRelocMode reloc = (opt->pic || opt->library) ? LLVMRelocPIC : LLVMRelocDefault;
 
   LLVMTargetMachineRef machine = LLVMCreateTargetMachine(target, opt->triple,
     opt->cpu, opt->features, opt_level, reloc, LLVMCodeModelDefault);

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -173,6 +173,7 @@ typedef struct pass_opt_t
   pass_id program_pass;
   bool release;
   bool library;
+  bool pic;
   bool ieee_math;
   bool print_stats;
   bool verify;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -47,7 +47,8 @@ enum
 
   OPT_BNF,
   OPT_ANTLR,
-  OPT_ANTLRRAW
+  OPT_ANTLRRAW,
+  OPT_PIC
 };
 
 static opt_arg_t args[] =
@@ -81,7 +82,7 @@ static opt_arg_t args[] =
   {"bnf", '\0', OPT_ARG_NONE, OPT_BNF},
   {"antlr", '\0', OPT_ARG_NONE, OPT_ANTLR},
   {"antlrraw", '\0', OPT_ARG_NONE, OPT_ANTLRRAW},
-
+  {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   OPT_ARGS_FINISH
 };
 
@@ -103,6 +104,7 @@ static void usage()
     "  --output, -o    Write output to this directory.\n"
     "    =path         Defaults to the current directory.\n"
     "  --library, -l   Generate a C-API compatible static library.\n"
+	"  --pic           Use PIC code regardless of libraries.\n"
     "  --docs, -g      Generate code documentation.\n"
     "\n"
     "Rarely needed options:\n"
@@ -248,6 +250,7 @@ int main(int argc, char* argv[])
       case OPT_STRIP: opt.strip_debug = true; break;
       case OPT_PATHS: package_add_paths(s.arg_val); break;
       case OPT_OUTPUT: opt.output = s.arg_val; break;
+	  case OPT_PIC: opt.pic = true; break;
       case OPT_LIBRARY: opt.library = true; break;
       case OPT_DOCS: opt.docs = true; break;
 


### PR DESCRIPTION
With hardened machines, many compile glibc with -fPIC. The effect of that is that on 64 bit machines, static libraries that haven't themselves been complied with -fPIC are _completely_ unusable. pony has static libs it links every program to, which need to be compiled -fPIC, or linking will fail. pony also uses LLVM to generate object files, which need to be set to produce PIC even for executables, otherwise you can't link the object files pony generates, when not compiling a library.

so, I had errors blocking any pony application from compiling, saying like
`error: ./test.o: requires dynamic R_X86_64_32 reloc against 'pony_personality_v0' which may overflow at runtime; recompile with -fPIC` 
or 
`/usr/bin/ld.gold: error: .../lib/pony/0.2.1-605-g37cd551/bin/../lib/libponyrt.a(fun.o): requires unsupported dynamic reloc 11; recompile with -fPIC` 
and I removed them by first applying this patch, then doing something like this:

```sh
$ cd $pony
$ make clean
$ make CFLAGS=-fPIC CXXFLAGS=-fPIC prefix=$prefix install
$ cd $project
$ $prefix/ponyc --pic .
```

might "slow" things down, but I dunno.