### PR TITLE
Centralize checks for names being private, types, internal tests, and FFI declarations

### DIFF
--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -1,6 +1,7 @@
 #include "symtab.h"
 #include "stringtab.h"
 #include "ast.h"
+#include "../pass/names.h"
 #include "../../libponyrt/mem/pool.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -35,7 +36,7 @@ static const char* name_without_case(const char* name)
   size_t len = strlen(name) + 1;
   char* buf = (char*)ponyint_pool_alloc_size(len);
 
-  if(is_type_name(name))
+  if(is_name_type(name))
   {
     for(size_t i = 0; i < len; i++)
       buf[i] = (char)toupper(name[i]);
@@ -49,14 +50,6 @@ static const char* name_without_case(const char* name)
 
 DEFINE_HASHMAP(symtab, symtab_t, symbol_t, sym_hash, sym_cmp,
   ponyint_pool_alloc_size, ponyint_pool_free_size, sym_free);
-
-bool is_type_name(const char* name)
-{
-  if(*name == '_')
-    name++;
-
-  return (*name >= 'A') && (*name <= 'Z');
-}
 
 symtab_t* symtab_new()
 {
@@ -246,7 +239,7 @@ bool symtab_can_merge_public(symtab_t* dst, symtab_t* src)
 
   while((sym = symtab_next(src, &i)) != NULL)
   {
-    if((sym->name[0] == '_') ||
+    if(is_name_private(sym->name) ||
       (sym->status == SYM_NOCASE) ||
       !strcmp(sym->name, "Main"))
       continue;
@@ -265,7 +258,7 @@ bool symtab_merge_public(symtab_t* dst, symtab_t* src)
 
   while((sym = symtab_next(src, &i)) != NULL)
   {
-    if((sym->name[0] == '_') ||
+    if(is_name_private(sym->name) ||
       (sym->status == SYM_NOCASE) ||
       !strcmp(sym->name, "Main"))
       continue;

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -265,7 +265,7 @@ static bool make_tuple_index(ast_t** astp)
   ast_t* ast = *astp;
   const char* name = ast_name(ast);
 
-  if(name[0] != '_')
+  if(!is_name_private(name))
     return false;
 
   for(size_t i = 1; name[i] != '\0'; i++)

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -369,7 +369,7 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
 
   size_t name_len = strlen(name);
 
-  if(name[0] == '_')
+  if(is_name_private(name))
   {
     // Try without leading underscore
     const char* try_name = stringtab(name + 1);

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1,4 +1,5 @@
 #include "docgen.h"
+#include "../pass/names.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/pool.h"
 #include <assert.h>
@@ -113,16 +114,16 @@ static void doc_list_add_named(ast_list_t* list, ast_t* ast, size_t id_index,
   const char* name = ast_name(ast_childidx(ast, id_index));
   assert(name != NULL);
 
-  if(name[0] == '$')  // Ignore internally generated names
+  if(is_name_internal_test(name))  // Ignore internally generated names
     return;
 
-  if(name[0] == '_' && !allow_private)  // Ignore private
+  if(is_name_private(name) && !allow_private)  // Ignore private
     return;
 
-  if(name[0] != '_' && !allow_public)  // Ignore public
+  if(!is_name_private(name) && !allow_public)  // Ignore public
     return;
 
-  if(name[0] == '_')  // Ignore leading underscore for ordering
+  if(is_name_private(name))  // Ignore leading underscore for ordering
     name++;
 
   doc_list_add(list, ast, name);

--- a/src/libponyc/pass/import.c
+++ b/src/libponyc/pass/import.c
@@ -1,6 +1,7 @@
 #include "import.h"
 #include "../ast/ast.h"
 #include "../ast/symtab.h"
+#include "../pass/names.h"
 #include <assert.h>
 #include <string.h>
 
@@ -37,8 +38,8 @@ static bool import_use(ast_t* ast)
 
   while((sym = symtab_next(src_symtab, &i)) != NULL)
   {
-    if((sym->name[0] == '_') || // Public symbols only.
-      (sym->name[0] == '@') ||  // Don't merge FFI declarations.
+    if(is_name_private(sym->name) || // Public symbols only.
+      is_name_ffi(sym->name) ||  // Don't merge FFI declarations.
       (sym->status == SYM_NOCASE) ||
       (strcmp(sym->name, "Main") == 0))
       continue;

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -5,6 +5,29 @@
 #include "../pkg/package.h"
 #include <assert.h>
 
+bool is_name_private(const char* name)
+{
+  return name[0] == '_';
+}
+
+bool is_name_type(const char* name)
+{
+  if(*name == '_')
+    name++;
+    
+  return (*name >= 'A') && (*name <= 'Z');
+}
+
+bool is_name_ffi(const char* name)
+{
+  return name[0] == '@';
+}
+
+bool is_name_internal_test(const char* name)
+{
+  return name[0] == '$';
+}
+
 static bool names_applycap(ast_t* ast, ast_t* cap, ast_t* ephemeral)
 {
   switch(ast_id(ast))
@@ -236,7 +259,7 @@ static ast_t* get_package_scope(ast_t* scope, ast_t* ast)
   {
     const char* name = ast_name(package_id);
 
-    if(name[0] == '$')
+    if(is_name_internal_test(name))
       scope = ast_get(ast_nearest(scope, TK_PROGRAM), name, NULL);
     else
       scope = ast_get(scope, name, NULL);
@@ -299,7 +322,7 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
     r = false;
   } else {
     // Check for a private type.
-    if(!local_package && (name[0] == '_'))
+    if(!local_package && is_name_private(name))
     {
       ast_error(type_id, "can't access a private type from another package");
       r = false;

--- a/src/libponyc/pass/names.h
+++ b/src/libponyc/pass/names.h
@@ -9,6 +9,14 @@ PONY_EXTERN_C_BEGIN
 
 ast_t* names_def(ast_t* ast);
 
+bool is_name_private(const char* name);
+
+bool is_name_type(const char* name);
+
+bool is_name_ffi(const char* name);
+
+bool is_name_internal_test(const char* name);
+
 bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr);
 
 ast_result_t pass_names(ast_t** astp, pass_opt_t* options);

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1,5 +1,6 @@
 #include "sugar.h"
 #include "casemethod.h"
+#include "names.h"
 #include "../ast/astbuild.h"
 #include "../ast/id.h"
 #include "../ast/printbuf.h"
@@ -289,7 +290,7 @@ static ast_result_t check_params(ast_t* params)
       ast_error(p, "expected parameter name");
       result = AST_ERROR;
     }
-    else if(ast_name(id)[0] != '$' && !check_id_param(id))
+    else if(!is_name_internal_test(ast_name(id)) && !check_id_param(id))
     {
       result = AST_ERROR;
     }

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -6,6 +6,7 @@
 #include "../ast/token.h"
 #include "../pass/pass.h"
 #include "../pass/expr.h"
+#include "../pass/names.h"
 #include <string.h>
 #include <assert.h>
 
@@ -22,7 +23,7 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
   AST_GET_CHILDREN(def, type_id, typeparams);
   const char* type_name = ast_name(type_id);
 
-  if((type_name[0] == '_') && (from != NULL) && (opt != NULL))
+  if(is_name_private(type_name) && (from != NULL) && (opt != NULL))
   {
     if(ast_nearest(def, TK_PACKAGE) != t->frame->package)
     {
@@ -92,7 +93,7 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
     return NULL;
   }
 
-  if((name[0] == '_') && (from != NULL) && (opt != NULL))
+  if(is_name_private(name) && (from != NULL) && (opt != NULL))
   {
     switch(ast_id(find))
     {


### PR DESCRIPTION
This is my patch for #576.

I added the functions to `pass/names.h`/`pass/names.c` and included that header where needed. Was that the right place?

I wasn't sure if, or where, to add tests for these new functions.