### PR TITLE
Switch to material theme for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,5 +97,7 @@ after_success:
       build/release/ponyc packages/stdlib --docs;
       cd stdlib-docs;
       sudo -H pip install mkdocs;
+      sudo -H pip install mkdocs-material;
+      sed -i '' 's/theme: readthedocs/theme: material/' mkdocs.yml
       mkdocs gh-deploy -v --clean --remote-name gh-token;
     fi;


### PR DESCRIPTION
There's numerous issues with the formatting in the readthedocs
theme. Material is far from perfect but it displays the docs
in a more readable format.

This is a short term fix on the way to a theme that works better
for the Pony standard library docs.