### PR TITLE
Organize package entities by visibility and purpose

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1,5 +1,6 @@
 #include "docgen.h"
 #include "../ast/id.h"
+#include "../ast/printbuf.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/pool.h"
 #include <assert.h>
@@ -29,6 +30,9 @@ typedef struct docgen_t
   FILE* index_file;
   FILE* home_file;
   FILE* package_file;
+  printbuf_t* test_entities;
+  printbuf_t* public_entities;
+  printbuf_t* private_entities;
   FILE* type_file;
   const char* base_dir;
   const char* sub_dir;
@@ -403,6 +407,30 @@ static void doc_type_list(docgen_t* docgen, ast_t* list, const char* preamble,
   fprintf(docgen->type_file, "%s", postamble);
 }
 
+static bool is_for_testing(const char* name, ast_t* list)
+{
+  assert(name != NULL);
+  assert(list != NULL);
+
+  if (strncmp(name, "_Test", 5) == 0) return true;
+
+  if(ast_id(list) == TK_NONE)
+    return false;
+
+  for(ast_t* p = ast_child(list); p != NULL; p = ast_sibling(p))
+  {
+    if (ast_id(p) == TK_NOMINAL)
+    {
+      ast_t* id = ast_childidx(p, 1);
+
+      if (strncmp(ast_name(id), "TestList", 8) == 0) return true;
+    }
+  }
+
+  return false;
+}
+
+
 
 // Functions to handle everything else
 
@@ -593,6 +621,9 @@ static void doc_entity(docgen_t* docgen, ast_t* ast, ast_t* package)
   assert(docgen != NULL);
   assert(docgen->index_file != NULL);
   assert(docgen->package_file != NULL);
+  assert(docgen->test_entities != NULL);
+  assert(docgen->public_entities != NULL);
+  assert(docgen->private_entities != NULL);
   assert(docgen->type_file == NULL);
   assert(ast != NULL);
   assert(package != NULL);
@@ -615,8 +646,13 @@ static void doc_entity(docgen_t* docgen, ast_t* ast, ast_t* package)
   fprintf(docgen->index_file, "  - %s %s: \"%s.md\"\n",
     ast_get_print(ast), name, tqfn);
 
-  fprintf(docgen->package_file, "* [%s %s](%s.md)\n",
-    ast_get_print(ast), name, tqfn);
+  // Add to appropriate package entities buffer
+  printbuf_t* buffer = docgen->public_entities;
+  if (is_for_testing(name, provides)) buffer = docgen->test_entities;
+  else if (name[0] == '_') buffer = docgen->private_entities;
+  printbuf(buffer,
+           "* [%s %s](%s.md)\n",
+           ast_get_print(ast), name, tqfn);
 
   ponyint_pool_free_size(tqfn_len, tqfn);
 
@@ -709,6 +745,9 @@ static void doc_package_home(docgen_t* docgen,
   assert(docgen->index_file != NULL);
   assert(docgen->home_file != NULL);
   assert(docgen->package_file == NULL);
+  assert(docgen->test_entities == NULL);
+  assert(docgen->public_entities == NULL);
+  assert(docgen->private_entities == NULL);
   assert(docgen->type_file == NULL);
   assert(package != NULL);
   assert(ast_id(package) == TK_PACKAGE);
@@ -746,11 +785,11 @@ static void doc_package_home(docgen_t* docgen,
   }
 
 
-  // Add listing of subpackages and links
-  fprintf(docgen->type_file, "\n\n## Entities\n\n");
-
   ponyint_pool_free_size(tqfn_len, tqfn);
 
+  docgen->test_entities = printbuf_new();
+  docgen->public_entities = printbuf_new();
+  docgen->private_entities = printbuf_new();
   docgen->package_file = docgen->type_file;
   docgen->type_file = NULL;
 }
@@ -762,6 +801,9 @@ static void doc_package(docgen_t* docgen, ast_t* ast)
   assert(ast != NULL);
   assert(ast_id(ast) == TK_PACKAGE);
   assert(docgen->package_file == NULL);
+  assert(docgen->test_entities == NULL);
+  assert(docgen->public_entities == NULL);
+  assert(docgen->private_entities == NULL);
 
   ast_list_t types = { NULL, NULL, NULL };
   ast_t* package_doc = NULL;
@@ -800,8 +842,22 @@ static void doc_package(docgen_t* docgen, ast_t* ast)
   for(ast_list_t* p = types.next; p != NULL; p = p->next)
     doc_entity(docgen, p->ast, ast);
 
+  // Add listing of subpackages and links
+  fprintf(docgen->package_file, "\n\n## Public Entities\n\n");
+  fprintf(docgen->package_file, "%s", docgen->public_entities->m);
+  fprintf(docgen->package_file, "\n\n## Private Entities\n\n");
+  fprintf(docgen->package_file, "%s", docgen->private_entities->m);
+  fprintf(docgen->package_file, "\n\n## Test Entities\n\n");
+  fprintf(docgen->package_file, "%s", docgen->test_entities->m);
+
   fclose(docgen->package_file);
   docgen->package_file = NULL;
+  printbuf_free(docgen->test_entities);
+  printbuf_free(docgen->public_entities);
+  printbuf_free(docgen->private_entities);
+  docgen->test_entities = NULL;
+  docgen->public_entities = NULL;
+  docgen->private_entities = NULL;
 }
 
 
@@ -828,6 +884,9 @@ static void doc_packages(docgen_t* docgen, ast_t* ast)
 
   // Process packages
   docgen->package_file = NULL;
+  docgen->test_entities = NULL;
+  docgen->public_entities = NULL;
+  docgen->private_entities = NULL;
   doc_package(docgen, package_1);
 
   for(ast_list_t* p = packages.next; p != NULL; p = p->next)


### PR DESCRIPTION
Will organize into public and private for non-testing related
entities and into testing/non-testing entities.

Public Entities
Private Entities
Testing Entities

After talking to Sylvan, once this is accepted, I will
rename from 'entities' to 'types'