### PR TITLE
add Windows build details to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,58 @@ tools and libraries. Instead, you will have to build and install LLVM 3.7 or
 3.8 from source. You will need to make sure that the path to LLVM/bin (location 
 of llvm-config) is in your PATH variable.
 
-You will also need to build and install premake5 (not premake4) from source. We 
-need premake5 in order to support current versions of Visual Studio.
+LLVM recommends using the GnuWin32 unix tools; your mileage may vary using 
+MSYS or Cygwin.
 
-You may also need to install zlib and ncurses.
+- Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/) 
+  tool.
+- Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or 
+  2.7).
+- Install [CMake](https://cmake.org/download/).
+- Get the LLVM source (e.g. 3.7.1 is 
+  at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
+- Make sure you have VS2015 with the C++ tools installed.
+- Generate LLVM VS2015 configuration with CMake. You can use the GUI to 
+  configure and generate the VS projects; make sure you use the 64-bit 
+  generator (**Visual Studio 14 2015 Win64**), and set the 
+  `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
+- Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in 
+  the LLVM solution in Release mode.
+
+Building Pony requires [Premake 5](https://premake.github.io).
+
+- Get the [PreMake 5](https://premake.github.io/download.html#v5) executable.
+- Get the [PonyC source](https://github.com/ponylang/ponyc).
+- Run `premake5.exe --with-tests --to=..\vs vs2015` to generate the PonyC
+  solution.
+- Change the **Character Set** property of each project in the PonyC solution
+  to **Not Set**.
+- Build ponyc.sln in Release mode.
+
+In order to run the pony compiler, you'll need a few libraries in your 
+environment (pcre2, libssl, libcrypto). 
+
+There is a third-party utility that will get the libraries and set up your 
+environment:
+
+- Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in 
+  your PATH.
+- Open a **VS2015 x64 Native Tools Command Prompt** (things will not work 
+  correctly otherwise!) and run:
 
 ```
-$ premake5 vs2013
-$ Release build with Visual Studio (ponyc.sln)
-$ ./build/release/ponyc examples/helloworld
+> git clone git@github.com:kulibali/ponyc-windows-libs.git
+> cd ponyc-windows-libs
+> .\getlibs.bat
+> .\setenv.bat
+```
+
+Now you can run the pony compiler and tests:
+
+```
+> cd path_to_pony_source
+> build\release\testc.exe
+> build\release\testrt.exe
+> build\release\ponyc.exe -d -s packages\stdlib
+> .\stdlib
 ```

--- a/test/libponyrt/mem/heap.cc
+++ b/test/libponyrt/mem/heap.cc
@@ -8,7 +8,7 @@
 
 TEST(Heap, Init)
 {
-  pony_actor_t* actor = (pony_actor_t*)0xDEADBEEF;
+  pony_actor_t* actor = (pony_actor_t*)0xDEADBEEFDEADBEEF;
 
   heap_t heap;
   ponyint_heap_init(&heap);


### PR DESCRIPTION
After my premature tweet yesterday I can build PonyC and run the tests on Windows.  This PR contains a couple of code fixes, and an updated description of the steps I took in the README.

Note that to get the libraries I needed, I made a small utility that gets and builds libpcre2-8.lib and gets a binary of libssl-32.dll and libcrypto-32.dll from LibreSSL.  I mention this in my changes to the README; I hope that's OK.