### PR TITLE
add verbosity level as a command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Timeouts for PonyTest long tests.
 - contains() method on HashMap
 - Support for empty sections in ini parsing.
+- --verbose,-V option for compiler informational messages.
 
 ### Changed
 
@@ -157,7 +158,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - ANSI terminal handling on all platforms, including Windows.
 - The lexer now allows underscore characters in numeric literals. This allows long numeric literals to be broken up for human readability.
 - "Did you mean?" support when the compiler doesn't recognise a name but something similar is in scope.
-- Garbage collection and cycle detection parameters can now be set from the command line. 
+- Garbage collection and cycle detection parameters can now be set from the command line.
 - Added a FileStream wrapper to the file package.
 
 ### Fixed

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -524,6 +524,8 @@ void codegen_shutdown(pass_opt_t* opt)
 
 bool codegen(ast_t* program, pass_opt_t* opt)
 {
+  PONY_LOG(opt, VERBOSITY_INFO, ("Generating\n"));
+
   pony_mkdir(opt->output);
 
   compile_t c;

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -207,7 +207,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   }
 
   const char* file_exe = suffix_filename(c->opt->output, "", c->filename, "");
-  printf("Linking %s\n", file_exe);
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Linking %s\n", file_exe));
 
   program_lib_build_args(program, "-L", "", "", "-l", "");
   const char* lib_args = program_lib_args(program);
@@ -223,6 +223,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     "-macosx_version_min 10.8 -o %s %s %s -lponyrt -lSystem",
     (int)arch_len, c->opt->triple, file_exe, file_o, lib_args
     );
+
+  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
 
   if(system(ld_cmd) != 0)
   {
@@ -251,7 +253,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
 #elif defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_FREEBSD)
   const char* file_exe = suffix_filename(c->opt->output, "", c->filename, "");
-  printf("Linking %s\n", file_exe);
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Linking %s\n", file_exe));
 
   program_lib_build_args(program, "-L", "-Wl,--start-group ",
     "-Wl,--end-group ", "-l", "");
@@ -280,6 +282,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     file_exe, file_o, lib_args
     );
 
+  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
+
   if(system(ld_cmd) != 0)
   {
     errorf(NULL, "unable to link: %s", ld_cmd);
@@ -299,7 +303,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   const char* file_exe = suffix_filename(c->opt->output, "", c->filename,
     ".exe");
-  printf("Linking %s\n", file_exe);
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Linking %s\n", file_exe));
 
   program_lib_build_args(program, "/LIBPATH:", "", "", "", ".lib");
   const char* lib_args = program_lib_args(program);
@@ -317,6 +321,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     "%s ponyrt.lib kernel32.lib msvcrt.lib Ws2_32.lib \"",
     vcvars.link, file_exe, file_o, vcvars.kernel32, vcvars.msvcrt, lib_args
     );
+
+  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
 
   if(system(ld_cmd) == -1)
   {

--- a/src/libponyc/codegen/genobj.c
+++ b/src/libponyc/codegen/genobj.c
@@ -15,7 +15,8 @@ const char* genobj(compile_t* c)
   {
     const char* file_o = suffix_filename(c->opt->output, "", c->filename,
       ".ll");
-    printf("Writing %s\n", file_o);
+    PONY_LOG(c->opt, VERBOSITY_INFO, ("Writing %s\n", file_o));
+
     char* err;
 
     if(LLVMPrintModuleToFile(c->module, file_o, &err) != 0)
@@ -32,7 +33,7 @@ const char* genobj(compile_t* c)
   {
     const char* file_o = suffix_filename(c->opt->output, "", c->filename,
       ".bc");
-    printf("Writing %s\n", file_o);
+    PONY_LOG(c->opt, VERBOSITY_INFO, ("Writing %s\n", file_o));
 
     if(LLVMWriteBitcodeToFile(c->module, file_o) != 0)
     {
@@ -59,7 +60,7 @@ const char* genobj(compile_t* c)
 #endif
   }
 
-  printf("Writing %s\n", file_o);
+  PONY_LOG(c->opt, VERBOSITY_INFO, ("Writing %s\n", file_o));
   char* err;
 
   if(LLVMTargetMachineEmitToFile(

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -516,7 +516,8 @@ static void optimise(compile_t* c)
 
   if(c->opt->release)
   {
-    printf("Optimising\n");
+    PONY_LOG(c->opt, VERBOSITY_INFO, ("Optimising\n"));
+
     pmb.OptLevel = 3;
     pmb.Inliner = createFunctionInliningPass(275);
   } else {
@@ -585,7 +586,8 @@ bool genopt(compile_t* c)
 
   if(c->opt->verify)
   {
-    printf("Verifying\n");
+    PONY_LOG(c->opt,VERBOSITY_INFO, ("Verifying\n"));
+    
     char* msg = NULL;
 
     if(LLVMVerifyModule(c->module, LLVMPrintMessageAction, &msg) != 0)
@@ -682,4 +684,3 @@ bool target_is_native128(char* t)
 
   return !triple.isArch32Bit() && !triple.isKnownWindowsMSVCEnvironment();
 }
-

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -87,6 +87,7 @@ void pass_opt_init(pass_opt_t* options)
   // Start with an empty typechecker frame.
   memset(options, 0, sizeof(pass_opt_t));
   options->limit = PASS_ALL;
+  options->verbosity = VERBOSITY_DEFAULT;
   frame_push(&options->check, NULL);
 }
 

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -145,6 +145,18 @@ Within finalisers uses the data field of the top body node and any TK_CALL
 nodes as ast_send flags.
 */
 
+typedef enum verbosity_level
+{
+  VERBOSITY_QUIET     = 0,
+  VERBOSITY_DEFAULT   = 1,
+  VERBOSITY_INFO      = 2,
+  VERBOSITY_TOOL_INFO = 3,
+  VERBOSITY_ALL       = 4
+} verbosity_level;
+
+#define PONY_LOG(opt, level, args) \
+        { if((opt)->verbosity >= (level)) { printf args ;} }
+
 typedef enum pass_id
 {
   PASS_PARSE,
@@ -179,6 +191,7 @@ typedef struct pass_opt_t
   bool strip_debug;
   bool print_filenames;
   bool docs;
+  verbosity_level verbosity;
   const char* output;
 
   char* triple;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -851,8 +851,9 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options)
 
   package = create_package(program, full_path, qualified_name);
 
-  if(report_build)
-    printf("Building %s -> %s\n", path, full_path);
+  if(report_build) {
+    PONY_LOG(options, VERBOSITY_INFO, ("Building %s -> %s\n", path, full_path));
+  }
 
   if(magic != NULL)
   {

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -35,6 +35,7 @@ enum
   OPT_TRIPLE,
   OPT_STATS,
 
+  OPT_VERBOSE,
   OPT_PASSES,
   OPT_AST,
   OPT_ASTPACKAGE,
@@ -68,6 +69,7 @@ static opt_arg_t args[] =
   {"triple", 0, OPT_ARG_REQUIRED, OPT_TRIPLE},
   {"stats", 0, OPT_ARG_NONE, OPT_STATS},
 
+  {"verbose", 'V', OPT_ARG_REQUIRED, OPT_VERBOSE},
   {"pass", 'r', OPT_ARG_REQUIRED, OPT_PASSES},
   {"ast", 'a', OPT_ARG_NONE, OPT_AST},
   {"astpackage", 0, OPT_ARG_NONE, OPT_ASTPACKAGE},
@@ -118,6 +120,12 @@ static void usage()
     "  --stats         Print some compiler stats.\n"
     "\n"
     "Debugging options:\n"
+    "  --verbose, -V   Verbosity level.\n"
+    "    =0            Only print errors.\n"
+    "    =1            Print info on compiler stages.\n"
+    "    =2            More detailed compilation information.\n"
+    "    =3            External tool command lines.\n"
+    "    =4            Very low-level detail.\n"
     "  --pass, -r      Restrict phases.\n"
     "    =parse\n"
     "    =syntax\n"
@@ -274,6 +282,17 @@ int main(int argc, char* argv[])
       case OPT_BNF: print_grammar(false, true); return 0;
       case OPT_ANTLR: print_grammar(true, true); return 0;
       case OPT_ANTLRRAW: print_grammar(true, false); return 0;
+
+      case OPT_VERBOSE:
+        {
+          int v = atoi(s.arg_val);
+          if (v >= 0 && v <= 4) {
+            opt.verbosity = (verbosity_level)v;
+          } else {
+            ok = false;
+          }
+        }
+        break;
 
       case OPT_PASSES:
         if(!limit_passes(&opt, s.arg_val))


### PR DESCRIPTION
This patch adds a command-line argument (per #569) `--verbose=N`, where N is from 0 to 4.  Various things are printed for verbosity >= N:

- 0: only errors are printed
- 1: compilation stages, e.g. "Generating", "Linking"
- 2: optimization and package info, e.g. "Building stdlib\regex..."
- 3: external tool command lines, e.g. for linking
- 4: currently nothing...