### PR TITLE
Don't "force free" memory of objects with finalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Interface subtyping takes receiver capabilities into account.
 - Pony-as-library support, particularly pony_register_thread().
 - Bug in `HashMap._search`.
+- Crashing gc bug caused by "force freeing" objects with finalizers.
 
 ### Added
 

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -483,7 +483,7 @@ bool ponyint_gc_release(gc_t* gc, actorref_t* aref)
     assert(obj_local->rc >= obj->rc);
     obj_local->rc -= obj->rc;
 
-    if(obj_local->rc == 0)
+    if((obj_local->rc == 0) && (obj_local->final == NULL))
     {
       // The local rc for this object has dropped to zero. We keep track of
       // whether or not the object was reachable. If we go to 0 rc and it


### PR DESCRIPTION
Magically GC code exists that will attempt to
"force free" data that is not referenced in the
allocating actors working set when release messages
arrive.

It shouldn't do this for anything with a finalizer.

It would be bad. BOOM! bad if that was to happen.