### PR TITLE
String.compare() bug and unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Pony-as-library support, particularly pony_register_thread().
 - Bug in `HashMap._search`.
 - Crashing gc bug caused by "force freeing" objects with finalizers.
+- Bug in `String.compare`.
 
 ### Added
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -965,7 +965,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     """
     Lexically compare two strings.
     """
-    compare_sub(that, _size)
+    compare_sub(that, _size.max(that._size))
 
   fun compare_sub(that: String box, n: USize, offset: ISize = 0,
     that_offset: ISize = 0, ignore_case: Bool = false): Compare

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -509,6 +509,13 @@ class iso _TestStringCompare is UnitTest
   fun name(): String => "builtin/String.compare"
 
   fun apply(h: TestHelper) =>
+    h.assert_eq[Compare](Equal, "foo".compare("foo"))
+    h.assert_eq[Compare](Greater, "foo".compare("bar"))
+    h.assert_eq[Compare](Less, "bar".compare("foo"))
+    
+    h.assert_eq[Compare](Less, "bc".compare("abc"))
+    h.assert_eq[Compare](Greater, "abc".compare("bc"))
+
     h.assert_eq[Compare](Equal, "foo".compare_sub("foo", 3))
     h.assert_eq[Compare](Greater, "foo".compare_sub("bar", 3))
     h.assert_eq[Compare](Less, "bar".compare_sub("foo", 3))


### PR DESCRIPTION
This fixes the bug described in #638. I also added some unit tests for the function, as there was none.