### PR TITLE
Fix names of test `timed_out` callback functions.

### DIFF
--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -188,7 +188,7 @@ class iso _TestBroadcast is UnitTest
     _mgr = _TestBroadcastMgr(h)
     h.long_test(2_000_000_000) // 2 second timeout
 
-  fun timedout(t: TestHelper) =>
+  fun timed_out(t: TestHelper) =>
     try
       (_mgr as _TestBroadcastMgr).fail("timeout")
     end

--- a/packages/signals/test.pony
+++ b/packages/signals/test.pony
@@ -28,7 +28,7 @@ class iso _TestSignalINT is UnitTest
     _signal = signal
     h.long_test(2_000_000_000) // 2 second timeout
 
-  fun timedout(h: TestHelper) =>
+  fun timed_out(h: TestHelper) =>
     try
       (_signal as SignalHandler).dispose()
     end


### PR DESCRIPTION
This PR fixes the names of test `timed_out` callback functions.

The name of this test case callback function was changed from `timedout` to `timed_out` in b88f6da, but that commit forgot to also change the these callback function implementations, so they were implementing functions with the wrong (old) name.

Because they were using the wrong name, when a test timed out and [the test runner called `timed_out`](https://github.com/ponylang/ponyc/blob/ff4b7d6f4c843c3eb30d8862c9445814c0465e93/packages/ponytest/runner.pony#L155) to clean up assets, it deferred to [the default implementation that does nothing](https://github.com/ponylang/ponyc/blob/ff4b7d6f4c843c3eb30d8862c9445814c0465e93/packages/ponytest/unit.pony#L27-L35).  Consequently, the assets were never cleaned up, and in the case of the `net/Broadcast` test mentioned in #602, the test would simply hang because UDP sockets were still left open, waiting for input.

This only fixes behavior of internal pony stdlib tests, so I think there's no need for a changelog entry (user programs are not affected).
