### PR TITLE
Use primitives for capabilities-secure networking

### DIFF
--- a/examples/echo/echo.pony
+++ b/examples/echo/echo.pony
@@ -2,7 +2,11 @@ use "net"
 
 actor Main
   new create(env: Env) =>
-    TCPListener(Listener(env.out))
+    try
+      TCPListener(env.root as AmbientAuth, Listener(env.out))
+    else
+      env.out.print("unable to use the network")
+    end
 
 class Listener is TCPListenNotify
   let _out: OutStream

--- a/examples/files/files.pony
+++ b/examples/files/files.pony
@@ -5,7 +5,9 @@ actor Main
     let caps = recover val FileCaps.set(FileRead).set(FileStat) end
 
     try
-      with file = OpenFile(FilePath(env.root, env.args(1), caps)) as File do
+      with file = OpenFile(
+        FilePath(env.root as AmbientAuth, env.args(1), caps)) as File
+      do
         env.out.print(file.path.path)
         for line in file.lines() do
           env.out.print(line)

--- a/examples/httpserver/httpserver.pony
+++ b/examples/httpserver/httpserver.pony
@@ -4,12 +4,18 @@ actor Main
   new create(env: Env) =>
     let service = try env.args(1) else "50000" end
     let limit = try env.args(2).usize() else 100 end
-    Server(Info(env), Handle, CommonLog(env.out) where service = service,
-      limit = limit)
-    // Server(Info(env), Handle, ContentsLog(env.out) where service = service,
-    //   limit = limit)
-    // Server(Info(env), Handle, DiscardLog where service = service,
-    //   limit = limit)
+
+    try
+      let auth = env.root as AmbientAuth
+      Server(auth, Info(env), Handle, CommonLog(env.out)
+        where service = service, limit = limit, reversedns = auth)
+      // Server(auth, Info(env), Handle, ContentsLog(env.out)
+      //   where service = service, limit = limit)
+      // Server(auth, Info(env), Handle, DiscardLog
+      //   where service = service, limit = limit)
+    else
+      env.out.print("unable to use network")
+    end
 
 class Info
   let _env: Env

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -152,7 +152,7 @@ actor Main
       | ("chunks", let arg: I64) => chunks = arg.usize()
       | ("width", let arg: I64) => width = arg.usize()
       | ("output", let arg: String) =>
-        outfile = try File(FilePath(env.root, arg)) end
+        outfile = try File(FilePath(env.root as AmbientAuth, arg)) end
       | let err: ParseError => err.report(env.out) ; usage(env) ; error
       end
     end

--- a/examples/net/net.pony
+++ b/examples/net/net.pony
@@ -22,5 +22,10 @@ actor Main
       1
     end
 
-    TCPListener(recover Listener(env, ssl, limit) end)
-    UDPSocket(recover Pong(env) end)
+    try
+      let auth = env.root as AmbientAuth
+      TCPListener(auth, recover Listener(env, ssl, limit) end)
+      UDPSocket(auth, recover Pong(env) end)
+    else
+      env.out.print("unable to use the network")
+    end

--- a/examples/net/pong.pony
+++ b/examples/net/pong.pony
@@ -13,11 +13,12 @@ class Pong is UDPNotify
       _env.out.print("Pong: listening on " + host + ":" + service)
 
       let env = _env
+      let auth = env.root as AmbientAuth
 
       if ip.ip4() then
-        UDPSocket.ip4(recover Ping(env, ip) end)
+        UDPSocket.ip4(auth, recover Ping(env, ip) end)
       elseif ip.ip6() then
-        UDPSocket.ip6(recover Ping(env, ip) end)
+        UDPSocket.ip6(auth, recover Ping(env, ip) end)
       else
         error
       end

--- a/minimal-cases/issue-629/629.pony
+++ b/minimal-cases/issue-629/629.pony
@@ -23,8 +23,12 @@ actor Tester
       let ctx = SSLContext.set_client_verify(false)
       let ssl = ctx.client()
 
-      _conn = TCPConnection(SSLConnection(ResponseBuilder(_env, this), consume ssl),     "127.0.0.1", "8443".string())
-      (_conn as TCPConnection).write("GET /index.html HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+      _conn = TCPConnection(_env.root as AmbientAuth,
+        SSLConnection(ResponseBuilder(_env, this), consume ssl),
+        "127.0.0.1", "8443".string())
+
+      (_conn as TCPConnection).write(
+        "GET /index.html HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
     else
       _env.out.print("failed to connect")
     end

--- a/packages/files/filepath.pony
+++ b/packages/files/filepath.pony
@@ -15,7 +15,7 @@ class val FilePath
   let path: String
   let caps: FileCaps = FileCaps
 
-  new val create(base: (FilePath | AmbientAuth | None), path': String,
+  new val create(base: (FilePath | AmbientAuth), path': String,
     caps': FileCaps val = recover val FileCaps.all() end) ?
   =>
     """
@@ -49,7 +49,7 @@ class val FilePath
       error
     end
 
-  new val mkdtemp(base: (FilePath | AmbientAuth | None), prefix: String = "",
+  new val mkdtemp(base: (FilePath | AmbientAuth), prefix: String = "",
     caps': FileCaps val = recover val FileCaps.all() end) ?
   =>
     """

--- a/packages/files/test.pony
+++ b/packages/files/test.pony
@@ -11,7 +11,8 @@ actor Main is TestList
 
 primitive _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath? =>
-    let top = Directory(FilePath.mkdtemp(h.env.root, "tmp._FileHelper."))
+    let top = Directory(FilePath.mkdtemp(h.env.root as AmbientAuth,
+      "tmp._FileHelper."))
     for f in files.values() do
       try
         // Since we embed paths, we use the posix separator, even on Windows.
@@ -33,7 +34,7 @@ primitive _FileHelper
 class iso _TestMkdtemp is UnitTest
   fun name(): String => "files/FilePath.mkdtemp"
   fun apply(h: TestHelper) ? =>
-    let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestMkdtemp.")
+    let tmp = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp.TestMkdtemp.")
     try
       h.assert_true(FileInfo(tmp).directory)
     then
@@ -69,7 +70,7 @@ class iso _TestWalk is UnitTest
 class iso _TestDirectoryOpen is UnitTest
   fun name(): String => "files/File.open.directory"
   fun apply(h: TestHelper) ? =>
-    let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestDiropen.")
+    let tmp = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp.TestDiropen.")
 
     try
       h.assert_true(FileInfo(tmp).directory)

--- a/packages/glob/test.pony
+++ b/packages/glob/test.pony
@@ -53,7 +53,8 @@ actor Main is TestList
 
 primitive _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath? =>
-    let top = Directory(FilePath.mkdtemp(h.env.root, "tmp._FileHelper."))
+    let top = Directory(FilePath.mkdtemp(h.env.root as AmbientAuth,
+      "tmp._FileHelper."))
     for f in files.values() do
       try
         let dir_head = Path.split(f)

--- a/packages/net/auth.pony
+++ b/packages/net/auth.pony
@@ -1,0 +1,23 @@
+primitive NetAuth
+  new create(from: AmbientAuth) =>
+    None
+
+primitive DNSAuth
+  new create(from: (AmbientAuth | NetAuth)) =>
+    None
+
+primitive UDPAuth
+  new create(from: (AmbientAuth | NetAuth)) =>
+    None
+
+primitive TCPAuth
+  new create(from: (AmbientAuth | NetAuth)) =>
+    None
+
+primitive TCPListenAuth
+  new create(from: (AmbientAuth | NetAuth | TCPAuth)) =>
+    None
+
+primitive TCPConnectAuth
+  new create(from: (AmbientAuth | NetAuth | TCPAuth)) =>
+    None

--- a/packages/net/dns.pony
+++ b/packages/net/dns.pony
@@ -1,36 +1,48 @@
+type DNSLookupAuth is (AmbientAuth | NetAuth | DNSAuth)
+
 primitive DNS
   """
   Helper functions for resolving DNS queries.
   """
-  fun apply(host: String, service: String): Array[IPAddress] iso^ =>
+  fun apply(auth: DNSLookupAuth, host: String, service: String)
+    : Array[IPAddress] iso^
+  =>
     """
     Gets all IPv4 and IPv6 addresses for a host and service.
     """
-    _resolve(0, host, service)
+    _resolve(auth, 0, host, service)
 
-  fun ip4(host: String, service: String): Array[IPAddress] iso^ =>
+  fun ip4(auth: DNSLookupAuth, host: String, service: String)
+    : Array[IPAddress] iso^
+  =>
     """
     Gets all IPv4 addresses for a host and service.
     """
-    _resolve(1, host, service)
+    _resolve(auth, 1, host, service)
 
-  fun ip6(host: String, service: String): Array[IPAddress] iso^ =>
+  fun ip6(auth: DNSLookupAuth, host: String, service: String)
+    : Array[IPAddress] iso^
+  =>
     """
     Gets all IPv6 addresses for a host and service.
     """
-    _resolve(2, host, service)
+    _resolve(auth, 2, host, service)
 
-  fun broadcast_ip4(service: String): Array[IPAddress] iso^ =>
+  fun broadcast_ip4(auth: DNSLookupAuth, service: String)
+    : Array[IPAddress] iso^
+  =>
     """
     Link-local IP4 broadcast address.
     """
-    ip4("255.255.255.255", service)
+    ip4(auth, "255.255.255.255", service)
 
-  fun broadcast_ip6(service: String): Array[IPAddress] iso^ =>
+  fun broadcast_ip6(auth: DNSLookupAuth, service: String)
+    : Array[IPAddress] iso^
+  =>
     """
     Link-local IP6 broadcast address.
     """
-    ip6("FF02::1", service)
+    ip6(auth, "FF02::1", service)
 
   fun is_ip4(host: String): Bool =>
     """
@@ -44,8 +56,8 @@ primitive DNS
     """
     @pony_os_host_ip6[Bool](host.cstring())
 
-  fun _resolve(family: U32, host: String, service: String):
-    Array[IPAddress] iso^
+  fun _resolve(auth: DNSLookupAuth, family: U32, host: String,
+    service: String): Array[IPAddress] iso^
   =>
     """
     Turns an addrinfo pointer into an array of addresses.

--- a/packages/net/http/client.pony
+++ b/packages/net/http/client.pony
@@ -6,14 +6,19 @@ actor Client
   """
   Manages a collection of client connections.
   """
+  let _auth: TCPConnectionAuth
   let _sslctx: SSLContext
   let _pipeline: Bool
   let _clients: Map[_HostService, _ClientConnection] = _clients.create()
 
-  new create(sslctx: (SSLContext | None) = None, pipeline: Bool = true) =>
+  new create(auth: TCPConnectionAuth, sslctx: (SSLContext | None) = None,
+    pipeline: Bool = true)
+  =>
     """
     Create a client for the given host and service.
     """
+    _auth = auth
+
     _sslctx = try
       sslctx as SSLContext
     else
@@ -50,8 +55,10 @@ actor Client
       _clients(hs)
     else
       let client = match url.scheme
-      | "http" => _ClientConnection(hs.host, hs.service, None, _pipeline)
-      | "https" => _ClientConnection(hs.host, hs.service, _sslctx, _pipeline)
+      | "http" =>
+        _ClientConnection(_auth, hs.host, hs.service, None, _pipeline)
+      | "https" =>
+        _ClientConnection(_auth, hs.host, hs.service, _sslctx, _pipeline)
       else
         error
       end

--- a/packages/net/http/requestbuilder.pony
+++ b/packages/net/http/requestbuilder.pony
@@ -6,22 +6,31 @@ class _RequestBuilder is TCPConnectionNotify
   """
   let _handler: RequestHandler
   let _logger: Logger
+  let _reversedns: (DNSLookupAuth | None)
   var _server: (_ServerConnection | None) = None
   let _buffer: Buffer = Buffer
   let _builder: _PayloadBuilder = _PayloadBuilder.request()
 
-  new iso create(handler: RequestHandler, logger: Logger) =>
+  new iso create(handler: RequestHandler, logger: Logger,
+    reversedns: (DNSLookupAuth | None))
+  =>
     """
     The request builder needs to know how to handle requests.
     """
     _handler = handler
     _logger = logger
+    _reversedns = reversedns
 
   fun ref accepted(conn: TCPConnection ref) =>
     """
     Create a server connection to handle response ordering.
     """
-    (let host, let port) = try conn.remote_address().name() else ("-", "-") end
+    (let host, let port) = try
+      conn.remote_address().name(_reversedns)
+    else
+      ("-", "-")
+    end
+
     _server = _ServerConnection(_handler, _logger, conn, host)
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>

--- a/packages/net/http/serverlistener.pony
+++ b/packages/net/http/serverlistener.pony
@@ -9,9 +9,11 @@ class _ServerListener is TCPListenNotify
   let _sslctx: (SSLContext | None)
   let _handler: RequestHandler
   let _logger: Logger
+  let _reversedns: (DNSLookupAuth | None)
 
   new iso create(server: Server, sslctx: (SSLContext | None),
-    handler: RequestHandler, logger: Logger)
+    handler: RequestHandler, logger: Logger,
+    reversedns: (DNSLookupAuth | None))
   =>
     """
     Creates a new listening socket manager.
@@ -20,6 +22,7 @@ class _ServerListener is TCPListenNotify
     _sslctx = sslctx
     _handler = handler
     _logger = logger
+    _reversedns = reversedns
 
   fun ref listening(listen: TCPListener ref) =>
     """
@@ -46,7 +49,8 @@ class _ServerListener is TCPListenNotify
     try
       let ctx = _sslctx as SSLContext
       let ssl = ctx.server()
-      SSLConnection(_RequestBuilder(_handler, _logger), consume ssl)
+      SSLConnection(_RequestBuilder(_handler, _logger, _reversedns),
+        consume ssl)
     else
-      _RequestBuilder(_handler, _logger)
+      _RequestBuilder(_handler, _logger, _reversedns)
     end

--- a/packages/net/ipaddress.pony
+++ b/packages/net/ipaddress.pony
@@ -27,17 +27,18 @@ class val IPAddress
     """
     @pony_os_ipv6[Bool](this)
 
-  fun name(reversedns: Bool = false, servicename: Bool = false):
-    (String, String) ?
+  fun name(reversedns: (DNSLookupAuth | None) = None,
+    servicename: Bool = false): (String, String) ?
   =>
     """
     Return the host and service name.
     """
     var host: Pointer[U8] iso = recover Pointer[U8] end
     var serv: Pointer[U8] iso = recover Pointer[U8] end
+    let reverse = reversedns isnt None
 
     if not @pony_os_nameinfo[Bool](this, addressof host, addressof serv,
-      reversedns, servicename) then
+      reverse, servicename) then
       error
     end
 

--- a/packages/net/tcpconnection.pony
+++ b/packages/net/tcpconnection.pony
@@ -6,6 +6,8 @@ use @pony_asio_event_fd[U32](event: AsioEventID)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
+type TCPConnectionAuth is (AmbientAuth | NetAuth | TCPAuth | TCPConnectAuth)
+
 actor TCPConnection
   """
   A TCP connection. When connecting, the Happy Eyeballs algorithm is used.
@@ -24,8 +26,8 @@ actor TCPConnection
   let _pending: List[(ByteSeq, USize)] = _pending.create()
   var _read_buf: Array[U8] iso = recover Array[U8].undefined(64) end
 
-  new create(notify: TCPConnectionNotify iso, host: String, service: String,
-    from: String = "")
+  new create(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
+    host: String, service: String, from: String = "")
   =>
     """
     Connect via IPv4 or IPv6. If `from` is a non-empty string, the connection
@@ -36,8 +38,8 @@ actor TCPConnection
       service.cstring(), from.cstring())
     _notify_connecting()
 
-  new ip4(notify: TCPConnectionNotify iso, host: String, service: String,
-    from: String = "")
+  new ip4(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
+    host: String, service: String, from: String = "")
   =>
     """
     Connect via IPv4.
@@ -47,8 +49,8 @@ actor TCPConnection
       service.cstring(), from.cstring())
     _notify_connecting()
 
-  new ip6(notify: TCPConnectionNotify iso, host: String, service: String,
-    from: String = "")
+  new ip6(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
+    host: String, service: String, from: String = "")
   =>
     """
     Connect via IPv6.

--- a/packages/net/tcplistener.pony
+++ b/packages/net/tcplistener.pony
@@ -1,3 +1,5 @@
+type TCPListenerAuth is (AmbientAuth | NetAuth | TCPAuth | TCPListenAuth)
+
 actor TCPListener
   """
   Listens for new network connections.
@@ -10,8 +12,8 @@ actor TCPListener
   var _count: USize = 0
   var _paused: Bool = false
 
-  new create(notify: TCPListenNotify iso, host: String = "",
-    service: String = "0", limit: USize = 0)
+  new create(auth: TCPListenerAuth, notify: TCPListenNotify iso,
+    host: String = "", service: String = "0", limit: USize = 0)
   =>
     """
     Listens for both IPv4 and IPv6 connections.
@@ -23,8 +25,8 @@ actor TCPListener
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
-  new ip4(notify: TCPListenNotify iso, host: String = "",
-    service: String = "0", limit: USize = 0)
+  new ip4(auth: TCPListenerAuth, notify: TCPListenNotify iso,
+    host: String = "", service: String = "0", limit: USize = 0)
   =>
     """
     Listens for IPv4 connections.
@@ -36,8 +38,8 @@ actor TCPListener
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
-  new ip6(notify: TCPListenNotify iso, host: String = "",
-    service: String = "0", limit: USize = 0)
+  new ip6(auth: TCPListenerAuth, notify: TCPListenNotify iso,
+    host: String = "", service: String = "0", limit: USize = 0)
   =>
     """
     Listens for IPv6 connections.

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -83,19 +83,20 @@ class _TestPing is UDPNotify
     _h = h
 
     _ip = try
+      let auth = h.env.root as AmbientAuth
       (_, let service) = ip.name()
 
       let list = if ip.ip4() then
         ifdef freebsd then
-          DNS.ip4("", service)
+          DNS.ip4(auth, "", service)
         else
-          DNS.broadcast_ip4(service)
+          DNS.broadcast_ip4(auth, service)
         end
       else
         ifdef freebsd then
-          DNS.ip6("", service)
+          DNS.ip6(auth, "", service)
         else
-          DNS.broadcast_ip6(service)
+          DNS.broadcast_ip6(auth, service)
         end
       end
 
@@ -141,17 +142,24 @@ class _TestPong is UDPNotify
 
 actor _TestBroadcastMgr
   let _h: TestHelper
-  let _pong: UDPSocket
+  var _pong: (UDPSocket | None) = None
   var _ping: (UDPSocket | None) = None
   var _fail: Bool = false
 
   new create(h: TestHelper) =>
     _h = h
-    _pong = UDPSocket(recover _TestPong(this, h) end)
+
+    try
+      _pong = UDPSocket(h.env.root as AmbientAuth,
+        recover _TestPong(this, h) end)
+    else
+      _h.fail("could not create Pong")
+      _h.complete(false)
+    end
 
   be succeed() =>
     if not _fail then
-      _pong.dispose()
+      try (_pong as UDPSocket).dispose() end
       try (_ping as UDPSocket).dispose() end
       _h.complete(true)
     end
@@ -159,7 +167,7 @@ actor _TestBroadcastMgr
   be fail(msg: String) =>
     if not _fail then
       _fail = true
-      _pong.dispose()
+      try (_pong as UDPSocket).dispose() end
       try (_ping as UDPSocket).dispose() end
       _h.fail(msg)
       _h.complete(false)
@@ -169,10 +177,17 @@ actor _TestBroadcastMgr
     if not _fail then
       let h = _h
 
-      if ip.ip4() then
-        _ping = UDPSocket.ip4(recover _TestPing(this, h, ip) end)
+      try
+        if ip.ip4() then
+          _ping = UDPSocket.ip4(h.env.root as AmbientAuth,
+            recover _TestPing(this, h, ip) end)
+        else
+          _ping = UDPSocket.ip6(h.env.root as AmbientAuth,
+            recover _TestPing(this, h, ip) end)
+        end
       else
-        _ping = UDPSocket.ip6(recover _TestPing(this, h, ip) end)
+        _h.fail("could not create Ping")
+        _h.complete(false)
       end
     end
 

--- a/packages/net/udpsocket.pony
+++ b/packages/net/udpsocket.pony
@@ -1,5 +1,7 @@
 use "collections"
 
+type UDPSocketAuth is (AmbientAuth | NetAuth | UDPAuth)
+
 actor UDPSocket
   var _notify: UDPNotify
   var _fd: U32
@@ -11,8 +13,8 @@ actor UDPSocket
   var _read_from: IPAddress iso = IPAddress
   embed _ip: IPAddress = IPAddress
 
-  new create(notify: UDPNotify iso, host: String = "", service: String = "0",
-    size: USize = 1024)
+  new create(auth: UDPSocketAuth, notify: UDPNotify iso, host: String = "",
+    service: String = "0", size: USize = 1024)
   =>
     """
     Listens for both IPv4 and IPv6 datagrams.
@@ -26,8 +28,8 @@ actor UDPSocket
     _notify_listening()
     _start_next_read()
 
-  new ip4(notify: UDPNotify iso, host: String = "", service: String = "0",
-    size: USize = 1024)
+  new ip4(auth: UDPSocketAuth, notify: UDPNotify iso, host: String = "",
+    service: String = "0", size: USize = 1024)
   =>
     """
     Listens for IPv4 datagrams.
@@ -41,8 +43,8 @@ actor UDPSocket
     _notify_listening()
     _start_next_read()
 
-  new ip6(notify: UDPNotify iso, host: String = "", service: String = "0",
-    size: USize = 1024)
+  new ip6(auth: UDPSocketAuth, notify: UDPNotify iso, host: String = "",
+    service: String = "0", size: USize = 1024)
   =>
     """
     Listens for IPv6 datagrams.


### PR DESCRIPTION
This is based on @dckc 's work on capability-secure networking.
The idea is to use primitives as authorisation tokens, so that
higher level interfaces can be built that hold those primitives,
but can do additional validation. For example, an application
might want to limit the ports that can be listened on. To do so,
pass a class that can construct a TCPListener (by holding a
TCPListenerAuth token) but will only do so for a specified port
range.