### PR TITLE
Store command history in Readline example

### DIFF
--- a/examples/readline/main.pony
+++ b/examples/readline/main.pony
@@ -17,6 +17,16 @@ class Handler is ReadlineNotify
       _i = _i + 1
       prompt(_i.string() + " > ")
     end
+    _update_commands(line)
+
+  fun ref _update_commands(line: String) =>
+    for command in _commands.values() do
+      if command.at(line, 0) then
+        return
+      end
+    end
+
+    _commands.push(line)
 
   fun ref tab(line: String): Seq[String] box =>
     let r = Array[String]


### PR DESCRIPTION
Having a fixed command set isn't particularly realistic.
Modified the readline example to record commands entered
so they can be part of command history for completion.