### PR TITLE
check verbosity flag for compiler messages

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -369,11 +369,11 @@ bool genexe(compile_t* c, ast_t* program)
   if(lookup(NULL, main_ast, main_ast, c->str_create) == NULL)
     return false;
 
-  printf("Reachability\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Reachability\n"));
   reach(c->reachable, &c->next_type_id, main_ast, c->str_create, NULL);
   reach(c->reachable, &c->next_type_id, env_ast, c->str__create, NULL);
 
-  printf("Selector painting\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Selector painting\n"));
   paint(c->reachable);
 
   if(!gentypes(c))

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -49,7 +49,7 @@ static bool reachable_methods(compile_t* c, ast_t* ast)
 
 static bool reachable_actors(compile_t* c, ast_t* program)
 {
-  printf("Library reachability\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Library reachability\n"));
 
   // Look for C-API actors in every package.
   bool found = false;
@@ -94,7 +94,7 @@ static bool reachable_actors(compile_t* c, ast_t* program)
     return false;
   }
 
-  printf("Selector painting\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Selector painting\n"));
   paint(c->reachable);
   return true;
 }
@@ -104,7 +104,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 #if defined(PLATFORM_IS_POSIX_BASED)
   const char* file_lib = suffix_filename(c->opt->output, "lib", c->filename,
     ".a");
-  printf("Archiving %s\n", file_lib);
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Archiving %s\n", file_lib));
 
   size_t len = 32 + strlen(file_lib) + strlen(file_o);
   char* cmd = (char*)ponyint_pool_alloc_size(len);
@@ -115,6 +115,7 @@ static bool link_lib(compile_t* c, const char* file_o)
   snprintf(cmd, len, "ar -rcs %s %s", file_lib, file_o);
 #endif
 
+  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", cmd));
   if(system(cmd) != 0)
   {
     errorf(NULL, "unable to link: %s", cmd);
@@ -126,7 +127,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 #elif defined(PLATFORM_IS_WINDOWS)
   const char* file_lib = suffix_filename(c->opt->output, "", c->filename,
     ".lib");
-  printf("Archiving %s\n", file_lib);
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Archiving %s\n", file_lib));
 
   vcvars_t vcvars;
 
@@ -142,6 +143,7 @@ static bool link_lib(compile_t* c, const char* file_o)
   snprintf(cmd, len, "cmd /C \"\"%s\" /NOLOGO /OUT:%s %s\"", vcvars.ar,
     file_lib, file_o);
 
+  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", cmd));
   if(system(cmd) == -1)
   {
     errorf(NULL, "unable to link: %s", cmd);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -579,7 +579,7 @@ bool gentypes(compile_t* c)
 
   genprim_builtins(c);
 
-  printf("Data prototypes\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Data prototypes\n"));
   i = HASHMAP_BEGIN;
 
   while((t = reachable_types_next(c->reachable, &i)) != NULL)
@@ -594,7 +594,7 @@ bool gentypes(compile_t* c)
     gentrace_prototype(c, t);
   }
 
-  printf("Data types\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Data types\n"));
   i = HASHMAP_BEGIN;
 
   while((t = reachable_types_next(c->reachable, &i)) != NULL)
@@ -605,7 +605,7 @@ bool gentypes(compile_t* c)
     make_global_instance(c, t);
   }
 
-  printf("Function prototypes\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Function prototypes\n"));
   i = HASHMAP_BEGIN;
 
   while((t = reachable_types_next(c->reachable, &i)) != NULL)
@@ -617,7 +617,7 @@ bool gentypes(compile_t* c)
       return false;
   }
 
-  printf("Descriptors\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Descriptors\n"));
   i = HASHMAP_BEGIN;
 
   while((t = reachable_types_next(c->reachable, &i)) != NULL)
@@ -628,7 +628,7 @@ bool gentypes(compile_t* c)
     gendesc_init(c, t);
   }
 
-  printf("Functions\n");
+  PONY_LOG(c->opt, VERBOSITY_DEFAULT, ("Functions\n"));
   i = HASHMAP_BEGIN;
 
   while((t = reachable_types_next(c->reachable, &i)) != NULL)

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -958,7 +958,7 @@ static void doc_setup_dirs(docgen_t* docgen, ast_t* program, pass_opt_t* opt)
   docgen->sub_dir = doc_cat(docgen->base_dir, "docs/", "", "", "",
     &docgen->sub_dir_buf_len);
 
-  printf("Writing docs to %s\n", docgen->base_dir);
+  PONY_LOG(opt, VERBOSITY_DEFAULT, ("Writing docs to %s\n", docgen->base_dir));
 
   // Create and clear out base directory
   pony_mkdir(docgen->base_dir);


### PR DESCRIPTION
This PR updates compiler printf statements from the recent rewrite to use the new PONY_LOG macro, which checks the desired verbosity level.