### PR TITLE
Add string representations for TK_FORMALVALUE* tokens.

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -236,9 +236,11 @@ static const lextoken_t abstract[] =
 
   { "typeparams", TK_TYPEPARAMS },
   { "typeparam", TK_TYPEPARAM },
+  { "valueformalparam", TK_VALUEFORMALPARAM },
   { "params", TK_PARAMS },
   { "param", TK_PARAM },
   { "typeargs", TK_TYPEARGS },
+  { "valueformalarg", TK_VALUEFORMALARG },
   { "positionalargs", TK_POSITIONALARGS },
   { "namedargs", TK_NAMEDARGS },
   { "namedarg", TK_NAMEDARG },


### PR DESCRIPTION
This PR adds string representations for the `TK_FORMALVALUEARG` and `TK_FORMALVALUEPARAM` tokens, which were previously missing.