### PR TITLE
Add -rpath to the link command for library paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Crashing gc bug caused by "force freeing" objects with finalizers.
 - Bug in `String.compare` and `String.compare_sub`.
 - Crashing gc bug from using `get` instead of `getorput` in `gc_markactor`.
+- Add -rpath to the link command for library paths
 
 ### Added
 

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -209,7 +209,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* file_exe = suffix_filename(c->opt->output, "", c->filename, "");
   PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
 
-  program_lib_build_args(program, "-L", "", "", "-l", "");
+  program_lib_build_args(program, "-L", NULL, "", "", "-l", "");
   const char* lib_args = program_lib_args(program);
 
   size_t arch_len = arch - c->opt->triple;
@@ -255,7 +255,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* file_exe = suffix_filename(c->opt->output, "", c->filename, "");
   PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
 
-  program_lib_build_args(program, "-L", "-Wl,--start-group ",
+  program_lib_build_args(program, "-L", "-Wl,-rpath,", "-Wl,--start-group ",
     "-Wl,--end-group ", "-l", "");
   const char* lib_args = program_lib_args(program);
 
@@ -305,7 +305,7 @@ static bool link_exe(compile_t* c, ast_t* program,
     ".exe");
   PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
 
-  program_lib_build_args(program, "/LIBPATH:", "", "", "", ".lib");
+  program_lib_build_args(program, "/LIBPATH:", NULL, "", "", "", ".lib");
   const char* lib_args = program_lib_args(program);
 
   size_t ld_len = 256 + strlen(file_exe) + strlen(file_o) +

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -145,7 +145,8 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 }
 
 
-void program_lib_build_args(ast_t* program, const char* path_preamble,
+void program_lib_build_args(ast_t* program,
+  const char* path_preamble, const char* rpath_preamble,
   const char* global_preamble, const char* global_postamble,
   const char* lib_premable, const char* lib_postamble)
 {
@@ -173,6 +174,13 @@ void program_lib_build_args(ast_t* program, const char* path_preamble,
     append_to_args(data, path_preamble);
     append_to_args(data, libpath);
     append_to_args(data, " ");
+
+    if(rpath_preamble != NULL)
+    {
+      append_to_args(data, rpath_preamble);
+      append_to_args(data, libpath);
+      append_to_args(data, " ");
+    }
   }
 
   // Library paths from the command line and environment variable.
@@ -186,6 +194,13 @@ void program_lib_build_args(ast_t* program, const char* path_preamble,
     append_to_args(data, path_preamble);
     append_to_args(data, libpath);
     append_to_args(data, " ");
+
+    if(rpath_preamble != NULL)
+    {
+      append_to_args(data, rpath_preamble);
+      append_to_args(data, libpath);
+      append_to_args(data, " ");
+    }
   }
 
   // Library names.

--- a/src/libponyc/pkg/program.h
+++ b/src/libponyc/pkg/program.h
@@ -30,7 +30,8 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 /** Build the required linker arguments based on the libraries we're using.
  * Once this has been called no more calls to use_library() are permitted.
  */
-void program_lib_build_args(ast_t* program, const char* path_preamble,
+void program_lib_build_args(ast_t* program,
+  const char* path_preamble, const char* rpath_preamble,
   const char* global_preamble, const char* global_postamble,
   const char* lib_premable, const char* lib_postamble);
 

--- a/test/libponyc/program.cc
+++ b/test/libponyc/program.cc
@@ -29,7 +29,7 @@ TEST(ProgramTest, NoLibs)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  program_lib_build_args(prog, "", "pre", "post", "", "");
+  program_lib_build_args(prog, "", "", "pre", "post", "", "");
   ASSERT_STREQ("prepost", program_lib_args(prog));
 
   ast_free(prog);
@@ -43,7 +43,7 @@ TEST(ProgramTest, OneLib)
 
   ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
 
-  program_lib_build_args(prog, "", "", "", "", "");
+  program_lib_build_args(prog, "", "", "", "", "", "");
 
   const char* expect = "\"foo\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -59,7 +59,7 @@ TEST(ProgramTest, OneLibWithAmbles)
 
   ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
 
-  program_lib_build_args(prog, "", "pre", "post", "lpre", "lpost");
+  program_lib_build_args(prog, "", "", "pre", "post", "lpre", "lpost");
 
   const char* expect = "prelpre\"foo\"lpost post";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -77,7 +77,7 @@ TEST(ProgramTest, MultipleLibs)
   ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
   ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
 
-  program_lib_build_args(prog, "", "", "", "", "");
+  program_lib_build_args(prog, "", "", "", "", "", "");
 
   const char* expect = "\"foo\" \"bar\" \"wombat\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -95,7 +95,7 @@ TEST(ProgramTest, MultipleLibsWithAmbles)
   ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
   ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
 
-  program_lib_build_args(prog, "", "pre", "post", "lpre", "lpost");
+  program_lib_build_args(prog, "", "", "pre", "post", "lpre", "lpost");
 
   const char* expect =
     "prelpre\"foo\"lpost lpre\"bar\"lpost lpre\"wombat\"lpost post";
@@ -117,7 +117,7 @@ TEST(ProgramTest, RepeatedLibs)
   ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
   ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
 
-  program_lib_build_args(prog, "", "" "", "", "", "");
+  program_lib_build_args(prog, "", "", "" "", "", "", "");
 
   const char* expect = "\"foo\" \"bar\" \"wombat\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -136,6 +136,22 @@ TEST(ProgramTest, BadLibName)
   ASSERT_FALSE(use_library(prog, "foo;bar", NULL, NULL));
   ASSERT_FALSE(use_library(prog, "foo$bar", NULL, NULL));
   //ASSERT_FALSE(use_library(prog, "foo\\bar", NULL, NULL));
+
+  ast_free(prog);
+}
+
+
+TEST(ProgramTest, LibPaths)
+{
+  ast_t* prog = ast_blank(TK_PROGRAM);
+  ASSERT_NE((void*)NULL, prog);
+
+  ASSERT_TRUE(use_path(prog, "foo", NULL, NULL));
+
+  program_lib_build_args(prog, "static", "dynamic", "", "", "", "");
+
+  const char* expect = "static\"foo\" dynamic\"foo\" ";
+  ASSERT_STREQ(expect, program_lib_args(prog));
 
   ast_free(prog);
 }


### PR DESCRIPTION
Add a new parameter, rpath_preamble, to program_lib_build_args
(libponyc/pkg/program.c). If this argument is non-null, then for
all library paths from the source code, command line, and PONYPATH
environment variable, add rpath_preamble plus the libpath to the string
used as a linker command line. For Linux and FreeBSD, modify the calls
to program_lib_build_args to use "-Wl,-rpath," as the rpath_preamble. For
Windows and Mac OS X, pass NULL as rpath_preamble.

Previously, if a dynamic library were in a non-standard location, the
library could not be found at run time.  The -rpath argument includes
the paths on the run time dynamic library search path, allowing dynamic
libraries to be found in non-standard locations.

The OS X linker appears to add the -L paths to the executable's search
path and I honestly have no idea what Windows does.

Fixes #651