### PR TITLE
Do not enable LTO if LLVMgold isn't found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Bug in `String.compare` and `String.compare_sub`.
 - Crashing gc bug from using `get` instead of `getorput` in `gc_markactor`.
 - Add -rpath to the link command for library paths
+- Do not enable LTO if LLVMgold isn't found on Linux in release builds.
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,20 @@ else
     OSTYPE = linux
     lto := no
 
-    ifneq (,$(shell which gcc-ar 2> /dev/null))
-      AR = gcc-ar
+    ifdef LTO
       lto := yes
     endif
 
-    ifdef LTO
-      lto := yes
+    ifneq (,$(shell which gcc-ar 2> /dev/null))
+      AR = gcc-ar
+      ifndef LTO
+        LTO := $(shell whereis LLVMgold.so | sed s/LLVMgold://)
+        ifeq (,$(LTO))
+          lto := no
+        else
+          lto := yes
+        endif
+      endif
     endif
   endif
 


### PR DESCRIPTION
This is a fix for #648. I'm not a Makefile expert, so feel free to say if there is a better way to do it.