### PR TITLE
Simplify HashMap.contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Crashing gc bug from using `get` instead of `getorput` in `gc_markactor`.
 - Add -rpath to the link command for library paths
 - Do not enable LTO if LLVMgold isn't found on Linux in release builds.
+- Simplify contains() method on HashMap.
 
 ### Added
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -123,12 +123,8 @@ class HashMap[K, V, H: HashFunction[K] val]
     """
     Checks whether the map contains the key k
     """
-    try
-      apply(k)
-      true
-    else
-      false
-    end
+    (_, let found) = _search(k)
+    found
 
   fun ref concat(iter: Iterator[(K^, V^)]) =>
     """

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -82,6 +82,9 @@ class iso _TestMap is UnitTest
     (a("5") = 5) as None
     (a("6") = 6) as None
 
+    h.assert_true(a.contains("0"), "contains did not find expected element in HashMap")
+    h.assert_false(a.contains("7"), "contains found unexpected element in HashMap")
+
     h.assert_eq[U32](1, (a("1") = 11) as U32)
     h.assert_eq[U32](11, (a("1") = 1) as U32)
 


### PR DESCRIPTION
Hashmap.contains was calling apply within a try...else...end. This change
cuts out the middleman, just calling _search.

Fixes #678