### PR TITLE
fixes for Windows compile

### DIFF
--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -8,6 +8,7 @@
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
+#  pragma warning(disable:4141)
 #endif
 
 #include <llvm/IR/DIBuilder.h>

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -5,6 +5,7 @@
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
+#  pragma warning(disable:4141)
 #endif
 
 #include "genopt.h"
@@ -192,7 +193,7 @@ public:
     {
       // Convert a heap index to a size.
       int_size = ConstantInt::get(builder.getInt64Ty(),
-        1 << (alloc_size + HEAP_MINBITS));
+        ((int64_t)1) << (alloc_size + HEAP_MINBITS));
     } else {
       if(alloc_size > 1024)
       {

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -5,6 +5,7 @@
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
+#  pragma warning(disable:4141)
 #endif
 
 #include <llvm/IR/Function.h>


### PR DESCRIPTION
This PR contains a few minor fixes for building on Windows with LLVM 3.8.

The LLVM headers contain a couple of redundant "inline" modifiers, which Visual C++ warns on.  Also, Visual C++ warns on "converting a 32-bit shift to 64 bits".