### PR TITLE
Identify additional test types as test types

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -414,16 +414,20 @@ static bool is_for_testing(const char* name, ast_t* list)
 
   if (strncmp(name, "_Test", 5) == 0) return true;
 
-  if(ast_id(list) == TK_NONE)
-    return false;
+  if(ast_id(list) == TK_NONE) return false;
 
   for(ast_t* p = ast_child(list); p != NULL; p = ast_sibling(p))
   {
-    if (ast_id(p) == TK_NOMINAL)
+    if(ast_id(p) == TK_NOMINAL)
     {
       ast_t* id = ast_childidx(p, 1);
 
-      if (strncmp(ast_name(id), "TestList", 8) == 0) return true;
+      if(strcmp(ast_name(id), "TestList") == 0) return true;
+      if(strcmp(ast_name(id), "UnitTest") == 0) return true;
+
+      ast_t* p_def = (ast_t*)ast_data(p);
+      ast_t* p_list = ast_childidx(p_def, 3);
+      return is_for_testing(ast_name(id), p_list);
     }
   }
 
@@ -648,8 +652,8 @@ static void doc_entity(docgen_t* docgen, ast_t* ast, ast_t* package)
 
   // Add to appropriate package types buffer
   printbuf_t* buffer = docgen->public_types;
-  if (is_for_testing(name, provides)) buffer = docgen->test_types;
-  else if (name[0] == '_') buffer = docgen->private_types;
+  if(is_for_testing(name, provides)) buffer = docgen->test_types;
+  else if(name[0] == '_') buffer = docgen->private_types;
   printbuf(buffer,
            "* [%s %s](%s.md)\n",
            ast_get_print(ast), name, tqfn);


### PR DESCRIPTION
Previous we were only checking a types provides list
which wouldn't identify tests when they were like

trait _TopTest is UnitTest
trait _RefinedTopTest is _TopTest

_RefinedTopTest would be listed as a private type rather than
as a test type. Logger and its _StringLogger test exposed this
flaw.