### PR TITLE
Add `ArrayValues.rewind()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Support for empty sections in ini parsing.
 - --verbose,-V option for compiler informational messages.
 - Logger package
+- `ArrayValues.rewind()` method.
 
 ### Changed
 

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -452,6 +452,10 @@ class ArrayValues[A, B: Array[A] #read] is Iterator[B->A]
   fun ref next(): B->A ? =>
     _array(_i = _i + 1)
 
+  fun ref rewind(): ArrayValues[A, B] =>
+    _i = 0
+    this
+  
 class ArrayPairs[A, B: Array[A] #read] is Iterator[(USize, B->A)]
   let _array: B
   var _i: USize

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -37,6 +37,7 @@ actor Main is TestList
     test(_TestSpecialValuesF64)
     test(_TestArraySlice)
     test(_TestArrayInsert)
+    test(_TestArrayValuesRewind)
     test(_TestMath128)
     test(_TestDivMod)
     test(_TestMaybePointer)
@@ -630,6 +631,29 @@ class iso _TestArrayInsert is UnitTest
 
     h.assert_error(lambda()? => ["one", "three"].insert(3, "invalid") end)
 
+class iso _TestArrayValuesRewind is UnitTest
+  """
+  Test rewinding an ArrayValues object
+  """
+  fun name(): String => "builtin/ArrayValues.rewind"
+
+  fun apply(h: TestHelper) ? =>
+    let av = [as U32: 1, 2, 3, 4].values()
+
+    h.assert_eq[U32](1, av.next())
+    h.assert_eq[U32](2, av.next())
+    h.assert_eq[U32](3, av.next())
+    h.assert_eq[U32](4, av.next())
+    h.assert_eq[Bool](false, av.has_next())
+
+    av.rewind()
+
+    h.assert_eq[Bool](true, av.has_next())
+    h.assert_eq[U32](1, av.next())
+    h.assert_eq[U32](2, av.next())
+    h.assert_eq[U32](3, av.next())
+    h.assert_eq[U32](4, av.next())
+    h.assert_eq[Bool](false, av.has_next())
 
 class iso _TestMath128 is UnitTest
   """


### PR DESCRIPTION
The `ArrayValues.rewind()` method "rewinds" so that subsequents calls
to `next()` return items starting from the first item in the array.

This came as a result of a conversation with Sylvan. There was a
situation where it made sense to have `rewind()` as part of
`ArrayValues`, but we didn't think it made sense to make it part of
the `Iterator` interface.