### PR TITLE
Paramaterize Array.find/rfind on a comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - @jemc: use half-open ranges for String operations.
 - Improved TCPConnection with a dynamically size of buffers
 - Drop dynamic LTO detection in the build system.
+- Parameterized Array.find and Array.rfind with a comparator.
 
 ## [0.2.1] - 2015-10-06
 

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -276,16 +276,24 @@ class Array[A] is Seq[A]
 
     this
 
-  fun find(value: A!, offset: USize = 0, nth: USize = 0): USize ? =>
+  fun find(value: A!, offset: USize = 0, nth: USize = 0,
+    predicate: {(box->A!,box->A!): Bool} val =
+      lambda (l:box->A!,r:box->A!):Bool => l is r end): USize ?
+  =>
     """
-    Find the n-th appearance of value in the array, by identity. Return the
-    index, or raise an error if value isn't present.
+    Find the `nth` appearance of `value` from the beginning of the array,
+    starting at `offset` and examining higher indices, and using the supplied
+    `predicate` for comparisons. Returns the index of the value, or raise an
+    error if the value isn't present.
+
+    By default, the search starts at the first element of the array, returns the
+    first instance of `value` found, and uses object identity for comparison.
     """
     var i = offset
     var n = USize(0)
 
     while i < _size do
-      if _ptr._apply(i) is value then
+      if predicate(_ptr._apply(i), value) then
         if n == nth then
           return i
         end
@@ -298,16 +306,25 @@ class Array[A] is Seq[A]
 
     error
 
-  fun rfind(value: A!, offset: USize = -1, nth: USize = 0): USize ? =>
+  fun rfind(value: A!, offset: USize = -1, nth: USize = 0,
+    predicate: {(box->A!, box->A!): Bool} val =
+      lambda (l: box->A!, r: box->A!): Bool => l is r end): USize ?
+  =>
     """
-    As find, but search backwards in the array.
+    Find the `nth` appearance of `value` from the end of the array, starting at
+    `offset` and examining lower indices, and using the supplied `predicate` for
+    comparisons. Returns the index of the value, or raise an error if the value
+    isn't present.
+
+    By default, the search starts at the last element of the array, returns the
+    first instance of `value` found, and uses object identity for comparison.
     """
     if _size > 0 then
       var i = if offset >= _size then _size - 1 else offset end
       var n = USize(0)
 
       repeat
-        if _ptr._apply(i) is value then
+        if predicate(_ptr._apply(i), value) then
           if n == nth then
             return i
           end

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -277,8 +277,8 @@ class Array[A] is Seq[A]
     this
 
   fun find(value: A!, offset: USize = 0, nth: USize = 0,
-    predicate: {(box->A!,box->A!): Bool} val =
-      lambda (l:box->A!,r:box->A!):Bool => l is r end): USize ?
+    predicate: {(box->A!, box->A!): Bool} val =
+      lambda(l: box->A!, r: box->A!): Bool => l is r end): USize ?
   =>
     """
     Find the `nth` appearance of `value` from the beginning of the array,
@@ -308,7 +308,7 @@ class Array[A] is Seq[A]
 
   fun rfind(value: A!, offset: USize = -1, nth: USize = 0,
     predicate: {(box->A!, box->A!): Bool} val =
-      lambda (l: box->A!, r: box->A!): Bool => l is r end): USize ?
+      lambda(l: box->A!, r: box->A!): Bool => l is r end): USize ?
   =>
     """
     Find the `nth` appearance of `value` from the end of the array, starting at

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -38,6 +38,7 @@ actor Main is TestList
     test(_TestArraySlice)
     test(_TestArrayInsert)
     test(_TestArrayValuesRewind)
+    test(_TestArrayFind)
     test(_TestMath128)
     test(_TestDivMod)
     test(_TestMaybePointer)
@@ -654,6 +655,57 @@ class iso _TestArrayValuesRewind is UnitTest
     h.assert_eq[U32](3, av.next())
     h.assert_eq[U32](4, av.next())
     h.assert_eq[Bool](false, av.has_next())
+
+class _FindTestCls
+  let i: ISize
+  new create(i': ISize = 0) => i = i'
+  fun eq(other: _FindTestCls box): Bool => i == other.i
+
+class iso _TestArrayFind is UnitTest
+  """
+  Test finding elements in an array.
+  """
+  fun name(): String => "builtin/Array.find"
+  fun apply(h: TestHelper) ? =>
+    let a: Array[ISize] = [0,1,2,3,4,1]
+    h.assert_eq[USize](1, a.find(1))
+    h.assert_eq[USize](5, a.find(1 where offset = 3))
+    h.assert_eq[USize](5, a.find(1 where nth = 1))
+    h.assert_error(lambda()(a)? => a.find(6) end)
+    h.assert_eq[USize](2, a.find(1 where
+      predicate = lambda (l:ISize,r:ISize): Bool => l > r end))
+    h.assert_eq[USize](0, a.find(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end))
+    h.assert_eq[USize](3, a.find(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      nth = 1))
+    h.assert_error(lambda()(a)? => a.find(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      nth = 2) end)
+    h.assert_eq[USize](5, a.rfind(1))
+    h.assert_eq[USize](1, a.rfind(1 where offset = 3))
+    h.assert_eq[USize](1, a.rfind(1 where nth = 1))
+    h.assert_error(lambda()(a)? => a.rfind(6) end)
+    h.assert_eq[USize](4, a.rfind(1 where
+      predicate = lambda (l:ISize,r:ISize): Bool => l > r end))
+    h.assert_eq[USize](3, a.rfind(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end))
+    h.assert_eq[USize](0, a.rfind(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      nth = 1))
+    h.assert_error(lambda()(a)? => a.rfind(0 where
+      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      nth = 2) end)
+
+    var b = Array[_FindTestCls]
+    let c = _FindTestCls
+    b.push(c)
+    h.assert_error(lambda()(b)? => b.find(_FindTestCls) end)
+    h.assert_eq[USize](0, b.find(c))
+    h.assert_eq[USize](0, b.find(_FindTestCls where
+      predicate = lambda (l:_FindTestCls box, r:_FindTestCls box): Bool =>
+        l == r end))
+
 
 class iso _TestMath128 is UnitTest
   """

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -666,35 +666,37 @@ class iso _TestArrayFind is UnitTest
   Test finding elements in an array.
   """
   fun name(): String => "builtin/Array.find"
+
   fun apply(h: TestHelper) ? =>
-    let a: Array[ISize] = [0,1,2,3,4,1]
+    let a: Array[ISize] = [0, 1, 2, 3, 4, 1]
     h.assert_eq[USize](1, a.find(1))
     h.assert_eq[USize](5, a.find(1 where offset = 3))
     h.assert_eq[USize](5, a.find(1 where nth = 1))
     h.assert_error(lambda()(a)? => a.find(6) end)
     h.assert_eq[USize](2, a.find(1 where
-      predicate = lambda (l:ISize,r:ISize): Bool => l > r end))
+      predicate = lambda(l: ISize, r: ISize): Bool => l > r end))
     h.assert_eq[USize](0, a.find(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end))
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end))
     h.assert_eq[USize](3, a.find(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
       nth = 1))
     h.assert_error(lambda()(a)? => a.find(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
       nth = 2) end)
+
     h.assert_eq[USize](5, a.rfind(1))
     h.assert_eq[USize](1, a.rfind(1 where offset = 3))
     h.assert_eq[USize](1, a.rfind(1 where nth = 1))
     h.assert_error(lambda()(a)? => a.rfind(6) end)
     h.assert_eq[USize](4, a.rfind(1 where
-      predicate = lambda (l:ISize,r:ISize): Bool => l > r end))
+      predicate = lambda(l: ISize, r: ISize): Bool => l > r end))
     h.assert_eq[USize](3, a.rfind(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end))
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end))
     h.assert_eq[USize](0, a.rfind(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
       nth = 1))
     h.assert_error(lambda()(a)? => a.rfind(0 where
-      predicate = lambda (l:ISize,r:ISize): Bool => (l % 3) == r end,
+      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
       nth = 2) end)
 
     var b = Array[_FindTestCls]
@@ -703,7 +705,7 @@ class iso _TestArrayFind is UnitTest
     h.assert_error(lambda()(b)? => b.find(_FindTestCls) end)
     h.assert_eq[USize](0, b.find(c))
     h.assert_eq[USize](0, b.find(_FindTestCls where
-      predicate = lambda (l:_FindTestCls box, r:_FindTestCls box): Bool =>
+      predicate = lambda(l: _FindTestCls box, r: _FindTestCls box): Bool =>
         l == r end))
 
 


### PR DESCRIPTION
Add a parameter `predicate` to the `find` and `rfind` methods of Array
that accepts a lambda returning Bool, which replaces the `is` test in
the methods. By default, to maintain current behavior, this predicate
is passed a lambda that uses an `is` test, but it can be replaced with
a test using equality or any other binary predicate.

Add tests for find and rfind.

Fixes #659