### PR TITLE
Drop dynamic LTO detection in the build system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - Bug in `String.compare` and `String.compare_sub`.
 - Crashing gc bug from using `get` instead of `getorput` in `gc_markactor`.
 - Add -rpath to the link command for library paths
-- Do not enable LTO if LLVMgold isn't found on Linux in release builds.
 - Simplify contains() method on HashMap.
 
 ### Added
@@ -58,6 +57,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Replaced '&' with 'addressof' for taking address in FFI calls.
 - @jemc: use half-open ranges for String operations.
 - Improved TCPConnection with a dynamically size of buffers
+- Drop dynamic LTO detection in the build system.
 
 ## [0.2.1] - 2015-10-06
 

--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,9 @@ else
 
   ifeq ($(UNAME_S),Linux)
     OSTYPE = linux
-    lto := no
-
-    ifdef LTO
-      lto := yes
-    endif
 
     ifneq (,$(shell which gcc-ar 2> /dev/null))
       AR = gcc-ar
-      ifndef LTO
-        LTO := $(shell whereis LLVMgold.so | sed s/LLVMgold://)
-        ifeq (,$(LTO))
-          lto := no
-        else
-          lto := yes
-        endif
-      endif
     endif
   endif
 
@@ -36,8 +23,11 @@ else
   ifeq ($(UNAME_S),FreeBSD)
     OSTYPE = freebsd
     CXX = c++
-    lto := no
   endif
+endif
+
+ifdef LTO_PLUGIN
+  lto := yes
 endif
 
 # Default settings (silent debug build).
@@ -125,11 +115,11 @@ ifeq ($(config),release)
     BUILD_FLAGS += -flto -DPONY_USE_LTO
     LINKER_FLAGS += -flto
 
-    ifdef LTO
-      AR_FLAGS += --plugin $(LTO)
+    ifdef LTO_PLUGIN
+      AR_FLAGS += --plugin $(LTO_PLUGIN)
     endif
 
-    ifeq ($(OSTYPE),linux)
+    ifneq (,$(filter $(OSTYPE),linux freebsd))
       LINKER_FLAGS += -fuse-linker-plugin -fuse-ld=gold
     endif
   endif

--- a/README.md
+++ b/README.md
@@ -241,3 +241,24 @@ Now you can run the pony compiler and tests:
 > build\release\ponyc.exe -d -s packages\stdlib
 > .\stdlib
 ```
+
+## Building with link-time optimisation (LTO)
+
+You can enable LTO when building the compiler in release mode. There are
+slight differences between platforms so you'll need to do a manual setup.
+LTO is enabled by setting `lto` to `yes` in the build command line:
+
+```bash
+$ make config=release lto=yes
+```
+
+If the build fails, you have to specify the LTO plugin for your compiler
+in the `LTO_PLUGIN` variable. For example:
+
+```bash
+$ make config=release LTO_PLUGIN=/usr/lib/LLVMgold.so
+```
+
+Refer to your compiler documentation for the plugin to use in your case.
+
+LTO is enabled by default on OSX.


### PR DESCRIPTION
As discussed in #690. I also renamed the Makefile variable `LTO` to `LTO_PLUGIN` to clarify its role and to avoid confusion with `lto` in lowercase.