### PR TITLE
Check local compatibility for intersection types

### DIFF
--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -67,6 +67,11 @@ bool frame_push(typecheck_t* t, ast_t* ast)
       t->frame->type = ast;
       break;
 
+    case TK_PROVIDES:
+      pop = push_frame(t);
+      t->frame->provides = ast;
+      break;
+
     case TK_NEW:
     case TK_BE:
     case TK_FUN:

--- a/src/libponyc/ast/frame.h
+++ b/src/libponyc/ast/frame.h
@@ -11,6 +11,7 @@ typedef struct typecheck_frame_t
   ast_t* module;
   ast_t* type;
   ast_t* constraint;
+  ast_t* provides;
   ast_t* method;
   ast_t* def_arg;
   ast_t* method_body;

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -27,8 +27,6 @@ static void cap_aliasing(token_id* cap, token_id* eph)
       switch(*cap)
       {
         case TK_ISO:
-        case TK_CAP_SEND:
-        case TK_CAP_ANY:
           // Alias as tag.
           *cap = TK_TAG;
           break;
@@ -36,6 +34,17 @@ static void cap_aliasing(token_id* cap, token_id* eph)
         case TK_TRN:
           // Alias as box.
           *cap = TK_BOX;
+          break;
+
+        case TK_CAP_SEND:
+          // Alias as share.
+          *cap = TK_CAP_SHARE;
+          break;
+
+        case TK_CAP_ANY:
+          // TODO: should not be tag
+          // Alias as tag.
+          *cap = TK_TAG;
           break;
 
         case TK_ISO_BIND:
@@ -48,6 +57,11 @@ static void cap_aliasing(token_id* cap, token_id* eph)
 
         case TK_CAP_SEND_BIND:
           *cap = TK_CAP_SHARE_BIND;
+          break;
+
+        case TK_CAP_ANY_BIND:
+          // TODO: should not be tag
+          *cap = TK_TAG_BIND;
           break;
 
         default: {}

--- a/src/libponyc/type/compattype.c
+++ b/src/libponyc/type/compattype.c
@@ -1,0 +1,321 @@
+#include "compattype.h"
+#include "cap.h"
+#include "viewpoint.h"
+#include <assert.h>
+
+static bool is_nominal_compat_nominal(ast_t* a, ast_t* b)
+{
+  // k1 ~ k2
+  // ---
+  // N1 k1 ~ N2 k2
+  AST_GET_CHILDREN(a, a_pkg, a_id, a_typeparams, a_cap, a_eph);
+  AST_GET_CHILDREN(b, b_pkg, b_id, b_typeparams, b_cap, b_eph);
+
+  return is_cap_compat_cap(ast_id(a_cap), ast_id(a_eph),
+    ast_id(b_cap), ast_id(b_eph));
+}
+
+static bool is_nominal_compat_typeparam(ast_t* a, ast_t* b)
+{
+  // k1 ~ k2
+  // ---
+  // N1 k1 ~ A2 k2
+  AST_GET_CHILDREN(a, a_pkg, a_id, a_typeparams, a_cap, a_eph);
+  AST_GET_CHILDREN(b, b_id, b_cap, b_eph);
+
+  return is_cap_compat_cap(ast_id(a_cap), ast_id(a_eph),
+    ast_id(b_cap), ast_id(b_eph));
+}
+
+static bool is_typeparam_compat_typeparam(ast_t* a, ast_t* b)
+{
+  // k1 ~ k2
+  // ---
+  // A1 k1 ~ A2 k2
+  AST_GET_CHILDREN(a, a_id, a_cap, a_eph);
+  AST_GET_CHILDREN(b, b_id, b_cap, b_eph);
+
+  return is_cap_compat_cap(ast_id(a_cap), ast_id(a_eph),
+    ast_id(b_cap), ast_id(b_eph));
+}
+
+static bool is_arrow_compat_nominal(ast_t* a, ast_t* b)
+{
+  // lowerbound(T1->T2) ~ N k
+  // ---
+  // T1->T2 ~ N k
+  ast_t* a_lower = viewpoint_lower(a);
+
+  if(a == NULL)
+    return false;
+
+  bool ok = is_compat_type(a_lower, b);
+  ast_free_unattached(a_lower);
+  return ok;
+}
+
+static bool is_arrow_compat_typeparam(ast_t* a, ast_t* b)
+{
+  // forall k' in k . T1->T2 {A k |-> A k'} ~ A k'
+  // ---
+  // T1->T2 ~ A k
+  ast_t* r_a = viewpoint_reifytypeparam(a, b);
+  ast_t* r_b = viewpoint_reifytypeparam(b, b);
+
+  if(r_a != NULL)
+  {
+    bool ok = is_compat_type(r_a, r_b);
+    ast_free_unattached(r_a);
+    ast_free_unattached(r_b);
+    return ok;
+  }
+
+  // lowerbound(T1->T2) ~ A k
+  // ---
+  // T1->T2 ~ A k
+  return is_arrow_compat_nominal(a, b);
+}
+
+static bool is_arrow_compat_arrow(ast_t* a, ast_t* b)
+{
+  // S = this | A {#read, #send, #share, #any}
+  // K = N k | A {iso, trn, ref, val, box, tag} | K->K | (empty)
+  // L = S | K
+  // T = N k | A k | L->T
+  //
+  // forall K' in S . K->S->T1 {S |-> K'} ~ T2 {S |-> K'}
+  // ---
+  // K->S->T1 ~ T2
+  ast_t* r_a;
+  ast_t* r_b;
+
+  if(viewpoint_reifypair(a, b, &r_a, &r_b))
+  {
+    bool ok = is_compat_type(r_a, r_b);
+    ast_free_unattached(r_a);
+    ast_free_unattached(r_b);
+    return ok;
+  }
+
+  // No elements need reification.
+  //
+  // lowerbound(T1->T2) ~ lowerbound(T3->T4)
+  // ---
+  // T1->T2 ~ T3->T4
+  r_a = viewpoint_lower(a);
+
+  if(r_a == NULL)
+    return false;
+
+  r_b = viewpoint_lower(b);
+
+  if(r_b == NULL)
+  {
+    ast_free_unattached(r_a);
+    return false;
+  }
+
+  bool ok = is_compat_type(r_a, r_b);
+  ast_free_unattached(r_a);
+  ast_free_unattached(r_b);
+  return ok;
+}
+
+static bool is_union_compat_x(ast_t* a, ast_t* b)
+{
+  // T1 ~ T3 or T2 ~ T3
+  // ---
+  // (T1 | T2) ~ T3
+  for(ast_t* child = ast_child(a);
+    child != NULL;
+    child = ast_sibling(child))
+  {
+    if(is_compat_type(child, b))
+      return true;
+  }
+
+  return false;
+}
+
+static bool is_isect_compat_x(ast_t* a, ast_t* b)
+{
+  // T1 ~ T3
+  // T2 ~ T3
+  // ---
+  // (T1 & T2) ~ T3
+  for(ast_t* child = ast_child(a);
+    child != NULL;
+    child = ast_sibling(child))
+  {
+    if(!is_compat_type(child, b))
+      return false;
+  }
+
+  return true;
+}
+
+static bool is_tuple_compat_tuple(ast_t* a, ast_t* b)
+{
+  // T1 ~ T3
+  // T2 ~ T4
+  // ---
+  // (T1, T2) ~ (T3, T4)
+  ast_t* a_child = ast_child(a);
+  ast_t* b_child = ast_child(b);
+
+  while((a_child != NULL) && (b_child != NULL))
+  {
+    if(!is_compat_type(a_child, b_child))
+      return false;
+
+    a_child = ast_sibling(a_child);
+    b_child = ast_sibling(b_child);
+  }
+
+  return (a_child == NULL) && (b_child == NULL);
+}
+
+static bool is_tuple_compat_x(ast_t* a, ast_t* b)
+{
+  switch(ast_id(b))
+  {
+    case TK_UNIONTYPE:
+      return is_union_compat_x(b, a);
+
+    case TK_ISECTTYPE:
+      return is_isect_compat_x(b, a);
+
+    case TK_TUPLETYPE:
+      return is_tuple_compat_tuple(b, a);
+
+    case TK_NOMINAL:
+      return false;
+
+    case TK_TYPEPARAMREF:
+      return false;
+
+    case TK_ARROW:
+      return false;
+
+    default: {}
+  }
+
+  assert(0);
+  return false;
+}
+
+static bool is_nominal_compat_x(ast_t* a, ast_t* b)
+{
+  switch(ast_id(b))
+  {
+    case TK_UNIONTYPE:
+      return is_union_compat_x(b, a);
+
+    case TK_ISECTTYPE:
+      return is_isect_compat_x(b, a);
+
+    case TK_TUPLETYPE:
+      return is_tuple_compat_x(b, a);
+
+    case TK_NOMINAL:
+      return is_nominal_compat_nominal(a, b);
+
+    case TK_TYPEPARAMREF:
+      return is_nominal_compat_typeparam(a, b);
+
+    case TK_ARROW:
+      return is_arrow_compat_nominal(b, a);
+
+    default: {}
+  }
+
+  assert(0);
+  return false;
+}
+
+static bool is_typeparam_compat_x(ast_t* a, ast_t* b)
+{
+  switch(ast_id(b))
+  {
+    case TK_UNIONTYPE:
+      return is_union_compat_x(b, a);
+
+    case TK_ISECTTYPE:
+      return is_isect_compat_x(b, a);
+
+    case TK_TUPLETYPE:
+      return is_tuple_compat_x(b, a);
+
+    case TK_NOMINAL:
+      return is_nominal_compat_typeparam(b, a);
+
+    case TK_TYPEPARAMREF:
+      return is_typeparam_compat_typeparam(a, b);
+
+    case TK_ARROW:
+      return is_arrow_compat_typeparam(b, a);
+
+    default: {}
+  }
+
+  assert(0);
+  return false;
+}
+
+static bool is_arrow_compat_x(ast_t* a, ast_t* b)
+{
+  switch(ast_id(b))
+  {
+    case TK_UNIONTYPE:
+      return is_union_compat_x(b, a);
+
+    case TK_ISECTTYPE:
+      return is_isect_compat_x(b, a);
+
+    case TK_TUPLETYPE:
+      return is_tuple_compat_x(b, a);
+
+    case TK_NOMINAL:
+      return is_arrow_compat_nominal(a, b);
+
+    case TK_TYPEPARAMREF:
+      return is_arrow_compat_typeparam(a, b);
+
+    case TK_ARROW:
+      return is_arrow_compat_arrow(a, b);
+
+    default: {}
+  }
+
+  assert(0);
+  return false;
+}
+
+bool is_compat_type(ast_t* a, ast_t* b)
+{
+  switch(ast_id(a))
+  {
+    case TK_UNIONTYPE:
+      return is_union_compat_x(a, b);
+
+    case TK_ISECTTYPE:
+      return is_isect_compat_x(a, b);
+
+    case TK_TUPLETYPE:
+      return is_tuple_compat_x(a, b);
+
+    case TK_NOMINAL:
+      return is_nominal_compat_x(a, b);
+
+    case TK_TYPEPARAMREF:
+      return is_typeparam_compat_x(a, b);
+
+    case TK_ARROW:
+      return is_arrow_compat_x(a, b);
+
+    default: {}
+  }
+
+  assert(0);
+  return false;
+}

--- a/src/libponyc/type/compattype.h
+++ b/src/libponyc/type/compattype.h
@@ -1,0 +1,23 @@
+#ifndef COMPATTYPE_H
+#define COMPATTYPE_H
+
+#include <platform.h>
+#include "../ast/ast.h"
+
+PONY_EXTERN_C_BEGIN
+
+/**
+ * Returns true if these types are locally compatible, false otherwise. This
+ * does not examine subtyping at all: it checks purely for rcap local
+ * compatibility.
+ *
+ * This is used to check for valid intesection types, since intersection types
+ * represent two separate ways to view an object. Even though those views are
+ * encapsulated in a single reference, the views must still be locally
+ * compatible.
+ */
+bool is_compat_type(ast_t* a, ast_t* b);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/type/matchtype.h
+++ b/src/libponyc/type/matchtype.h
@@ -38,12 +38,6 @@ typedef enum
  */
 matchtype_t is_matchtype(ast_t* operand, ast_t* pattern);
 
-/**
- * Returns false if some instantiation of sub would deny a matchtype with
- * super. This is used to prevent intersection types from violating refcaps.
- */
-bool accept_subtype(ast_t* sub, ast_t* super);
-
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -495,7 +495,7 @@ static bool is_union_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
     {
       if(errors != NULL)
       {
-        ast_error_frame(errors, sub,
+        ast_error_frame(errors, child,
           "not every element of %s is a subtype of %s",
           ast_print_type(sub), ast_print_type(super));
       }
@@ -539,7 +539,6 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
       ast_t* super_def = (ast_t*)ast_data(super);
 
       // TODO: can satisfy the interface in aggregate
-      // Must still account for accept_subtype
       // (T1 & T2) <: I k
       if(ast_id(super_def) == TK_INTERFACE)
       {
@@ -551,46 +550,24 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
     default: {}
   }
 
-  // T1 <: T3
-  // T2 <: T3 or accept_subtype(T2, T3)
+  // T1 <: T3 or T2 <: T3
   // ---
   // (T1 & T2) <: T3
-
-  bool ok = false;
-  bool accept = true;
-
-  // TODO: if (T1 <: T3) and (T2 <: T3), no need to check accept_subtype
-  // works already except for (T1 & T2) <: (T3 & T4)
-  // because is_isect_sub_isect breaks that down
-
   for(ast_t* child = ast_child(sub);
     child != NULL;
     child = ast_sibling(child))
   {
     if(is_subtype(child, super, NULL))
-    {
-      ok = true;
-    } else if(!accept_subtype(child, super)) {
-      accept_subtype(child, super);
-
-      if(errors != NULL)
-      {
-        ast_error_frame(errors, child,
-          "%s prevents %s from being a subtype of %s",
-          ast_print_type(child), ast_print_type(sub), ast_print_type(super));
-      }
-
-      accept = false;
-    }
+      return true;
   }
 
-  if(!ok && errors != NULL)
+  if(errors != NULL)
   {
     ast_error_frame(errors, sub, "no element of %s is a subtype of %s",
       ast_print_type(sub), ast_print_type(super));
   }
 
-  return ok && accept;
+  return false;
 }
 
 static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
@@ -1199,7 +1176,7 @@ static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super,
 static bool is_arrow_sub_typeparam(ast_t* sub, ast_t* super,
   errorframe_t* errors)
 {
-  // forall k' in k . upperbound(T1->T2 {A k |-> A k'}) <: A k'
+  // forall k' in k . T1->T2 {A k |-> A k'} <: A k'
   // ---
   // T1->T2 <: A k
   ast_t* r_sub = viewpoint_reifytypeparam(sub, super);
@@ -1213,28 +1190,8 @@ static bool is_arrow_sub_typeparam(ast_t* sub, ast_t* super,
     return ok;
   }
 
-  // If there is only a single instantiation, calculate the upper bounds.
-  //
-  // upperbound(T1->T2) <: A k
-  // ---
-  // T1->T2 <: A k
-  ast_t* sub_upper = viewpoint_upper(sub);
-
-  if(sub_upper == NULL)
-  {
-    if(errors != NULL)
-    {
-      ast_error_frame(errors, sub,
-        "%s is not a subtype of %s: the subtype has no upper bounds",
-        ast_print_type(sub), ast_print_type(super));
-    }
-
-    return false;
-  }
-
-  bool ok = is_subtype(sub_upper, super, errors);
-  ast_free_unattached(sub_upper);
-  return ok;
+  // If there is only a single instantiation, treat as a nominal type.
+  return is_arrow_sub_nominal(sub, super, errors);
 }
 
 static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
@@ -1247,62 +1204,15 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
   // forall K' in S . K->S->T1 {S |-> K'} <: T2 {S |-> K'}
   // ---
   // K->S->T1 <: T2
-  ast_t* sub_test = sub;
+  ast_t* r_sub;
+  ast_t* r_super;
 
-  // Find the first left side that needs reification.
-  while(ast_id(sub_test) == TK_ARROW)
+  if(viewpoint_reifypair(sub, super, &r_sub, &r_super))
   {
-    AST_GET_CHILDREN(sub_test, left, right);
-
-    switch(ast_id(left))
-    {
-      case TK_THISTYPE:
-      {
-        // Reify on both sides and test subtyping again.
-        ast_t* r_sub = viewpoint_reifythis(sub);
-        ast_t* r_super = viewpoint_reifythis(super);
-        bool ok = is_subtype(r_sub, r_super, errors);
-        ast_free_unattached(r_sub);
-        ast_free_unattached(r_super);
-        return ok;
-      }
-
-      case TK_TYPEPARAMREF:
-      {
-        ast_t* r_sub = viewpoint_reifytypeparam(sub, left);
-
-        if(r_sub == NULL)
-          break;
-
-        // Reify on both sides and test subtyping again.
-        ast_t* r_super = viewpoint_reifytypeparam(super, left);
-        bool ok = is_subtype(r_sub, r_super, errors);
-        ast_free_unattached(r_sub);
-        ast_free_unattached(r_super);
-        return ok;
-      }
-
-      default: {}
-    }
-
-    sub_test = right;
-  }
-
-  if(ast_id(sub_test) == TK_TYPEPARAMREF)
-  {
-    // forall k' in k . K->A k' <: T1->T2 {A k |-> A k'}
-    // ---
-    // K->A k <: T1->T2
-    ast_t* r_sub = viewpoint_reifytypeparam(sub, sub_test);
-    ast_t* r_super = viewpoint_reifytypeparam(super, sub_test);
-
-    if(r_sub != NULL)
-    {
-      bool ok = is_subtype(r_sub, r_super, errors);
-      ast_free_unattached(r_sub);
-      ast_free_unattached(r_super);
-      return ok;
-    }
+    bool ok = is_subtype(r_sub, r_super, errors);
+    ast_free_unattached(r_sub);
+    ast_free_unattached(r_super);
+    return ok;
   }
 
   // No elements need reification.

--- a/src/libponyc/type/viewpoint.h
+++ b/src/libponyc/type/viewpoint.h
@@ -45,6 +45,13 @@ ast_t* viewpoint_reifytypeparam(ast_t* type, ast_t* typeparamref);
  */
 ast_t* viewpoint_reifythis(ast_t* type);
 
+/**
+ * Reifies a pair of arrow types into tuples. Returns true if r_a and r_b are
+ * set to new reified tuples. Returns false if no further pairwise reification
+ * is possible. The caller is responsible for freeing *r_a and *r_b.
+ */
+bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -323,8 +323,8 @@ TEST_F(MatchTypeTest, Capabilities)
     "    t1refort2val: (T1 ref | T2 val),\n"
     "    t1valort2ref: (T1 val | T2 ref),\n"
     "    t1refandt2ref: (T1 ref & T2 ref),\n"
-    "    t1refandt2val: (T1 ref & T2 val),\n"
-    "    t1valandt2ref: (T1 val & T2 ref))";
+    "    t1refandt2box: (T1 ref & T2 box),\n"
+    "    t1valandt2box: (T1 val & T2 box))";
 
   TEST_COMPILE(src);
 
@@ -381,9 +381,9 @@ TEST_F(MatchTypeTest, Capabilities)
   ASSERT_EQ(MATCHTYPE_ACCEPT,
     is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2ref")));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2ref")));
-  ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2val")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2box")));
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2box")));
 }
 
 

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -282,9 +282,13 @@ TEST_F(SubTypeTest, IsSubTypeIntersect)
     "  fun z(c1: C1, c2: C2, c3: C3,\n"
     "    t1: T1, t2: T2, t3: T3,\n"
     "    t1and2: (T1 & T2),\n"
+    "    t3iso: T3 iso,\n"
     "    t3trn: T3 trn,\n"
     "    t1val: T1 val,\n"
-    "    t1and2val: (T1 ref & T2 val))";
+    "    t1isoand2iso: (T1 iso & T2 iso),\n"
+    "    t1trnand2trn: (T1 trn & T2 trn),\n"
+    "    t1valand2box: (T1 val & T2 box),\n"
+    "    t1refand2box: (T1 ref & T2 box))";
 
   TEST_COMPILE(src);
 
@@ -296,11 +300,22 @@ TEST_F(SubTypeTest, IsSubTypeIntersect)
   ASSERT_FALSE(is_subtype(type_of("t1and2"), type_of("c3"), NULL));
   ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1"), NULL));
   ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1and2val"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1and2val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1and2val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1and2val"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1and2val"), type_of("t1val"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1refand2box"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1refand2box"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1valand2box"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1refand2box"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1valand2box"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1valand2box"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t1refand2box"), type_of("t1"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("t1valand2box"), type_of("t1val"), NULL));
+  ASSERT_TRUE(
+    is_subtype(type_of("t1isoand2iso"), type_of("t1refand2box"), NULL));
+  ASSERT_TRUE(
+    is_subtype(type_of("t1trnand2trn"), type_of("t1refand2box"), NULL));
+  ASSERT_TRUE(
+    is_subtype(type_of("t1isoand2iso"), type_of("t1valand2box"), NULL));
+  ASSERT_TRUE(
+    is_subtype(type_of("t1trnand2trn"), type_of("t1valand2box"), NULL));
 }
 
 
@@ -788,7 +803,7 @@ TEST_F(SubTypeTest, IsConcrete)
     "    i8: I8, i16: I16, i32: I32, isize: ISize, i64: I64, i128: I128,\n"
     "    f32: F32, f64: F64,\n"
     "    c1: C1, p1: P1, t1: T1,\n"
-    "    t1ornone: (T1 | None), t1andnone: (T1 & None),\n"
+    "    t1ornone: (T1 | None), t1andnone: (T1 val & None),\n"
     "    c1ort1: (C1 | T1), c1andt1: (C1 & T1))";
 
   TEST_COMPILE(src);


### PR DESCRIPTION
An intersection type represents multiple views on to the same
object. As such, every view in an intersection type must be
locally compatible with every other view. This check is introduced
in the flatten pass (and skipped for provides lists and constraints
as they do not represent actual object view). As a result, the
subtyping check for intersection types is simplified to the natural
form, i.e.:

  T1 <: T3 or T2 <: T3
  ---
  (T1 & T2) <: T3