### PR TITLE
reorganize compiler init and shutdown (#574)

### DIFF
--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -640,11 +640,8 @@ static void add_exec_dir()
 }
 
 
-bool package_init(pass_opt_t* opt)
+bool package_init()
 {
-  if(!codegen_init(opt))
-    return false;
-
   // package_add_paths for command line paths has already been done. Here, we
   // append the paths from an optional environment variable, and then the paths
   // that are relative to the compiler location on disk.
@@ -963,10 +960,8 @@ bool package_allow_ffi(typecheck_t* t)
 }
 
 
-void package_done(pass_opt_t* opt, bool handle_errors)
+void package_done()
 {
-  codegen_shutdown(opt);
-
   strlist_free(search);
   search = NULL;
 
@@ -974,12 +969,6 @@ void package_done(pass_opt_t* opt, bool handle_errors)
   safe = NULL;
 
   package_clear_magic();
-
-  if(handle_errors)
-  {
-    print_errors();
-    free_errors();
-  }
 }
 
 

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -15,7 +15,7 @@ typedef struct package_t package_t;
  * directory relative to the executable, plus a collection of directories
  * specified in the PONYPATH environment variable.
  */
-bool package_init(pass_opt_t* opt);
+bool package_init();
 
 /**
  * Gets the list of search paths.
@@ -116,9 +116,9 @@ const char* package_hygienic_id(typecheck_t* t);
 bool package_allow_ffi(typecheck_t* t);
 
 /**
- * Cleans up the list of search directories and shuts down the code generator.
+ * Cleans up the list of search directories.
  */
-void package_done(pass_opt_t* opt, bool handle_errors);
+void package_done();
 
 bool is_path_absolute(const char* path);
 

--- a/src/libponyc/ponyc.c
+++ b/src/libponyc/ponyc.c
@@ -1,0 +1,24 @@
+#include "ponyc.h"
+#include "ast/error.h"
+#include "codegen/codegen.h"
+#include "pkg/package.h"
+
+bool ponyc_init(pass_opt_t *options)
+{
+  if (!codegen_init(options))
+    return false;
+
+  if (!package_init())
+    return false;
+
+  return true;
+}
+
+void ponyc_shutdown(pass_opt_t *options)
+{
+  print_errors();
+  free_errors();
+  package_done();
+  codegen_shutdown(options);
+  stringtab_done();
+}

--- a/src/libponyc/ponyc.h
+++ b/src/libponyc/ponyc.h
@@ -1,0 +1,14 @@
+#ifndef PONYC_H
+#define PONYC_H
+
+#include <platform.h>
+#include "pass/pass.h"
+
+PONY_EXTERN_C_BEGIN
+
+bool ponyc_init(pass_opt_t *options);
+void ponyc_shutdown(pass_opt_t *options);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -1,3 +1,4 @@
+#include "../libponyc/ponyc.h"
 #include "../libponyc/ast/parserapi.h"
 #include "../libponyc/ast/bnfprint.h"
 #include "../libponyc/pkg/package.h"
@@ -333,7 +334,7 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  if(package_init(&opt))
+  if(ponyc_init(&opt))
   {
     if(argc == 1)
     {
@@ -348,9 +349,8 @@ int main(int argc, char* argv[])
   if(!ok && get_error_count() == 0)
     printf("Error: internal failure not reported\n");
 
-  package_done(&opt, true);
+  ponyc_shutdown(&opt);
   pass_opt_done(&opt);
-  stringtab_done();
 
   return ok ? 0 : -1;
 }

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
 #include <platform.h>
 
+#include <ponyc.h>
 #include <ast/ast.h>
 #include <ast/lexer.h>
 #include <ast/source.h>
 #include <ast/stringtab.h>
+#include <codegen/codegen.h>
 #include <pass/pass.h>
 #include <pkg/package.h>
 
@@ -330,7 +332,8 @@ void PassTest::build_package(const char* pass, const char* src,
 
   pass_opt_t opt;
   pass_opt_init(&opt);
-  package_init(&opt);
+  codegen_init(&opt);
+  package_init();
 
   lexer_allow_test_symbols();
 
@@ -343,7 +346,8 @@ void PassTest::build_package(const char* pass, const char* src,
   limit_passes(&opt, pass);
   *out_package = program_load(stringtab(package_name), &opt);
 
-  package_done(&opt, false);
+  package_done();
+  codegen_shutdown(&opt);
   pass_opt_done(&opt);
 
   if(check_good)
@@ -353,7 +357,6 @@ void PassTest::build_package(const char* pass, const char* src,
 
     ASSERT_NE((void*)NULL, *out_package);
   }
-
 }
 
 


### PR DESCRIPTION
This patch for #574 collects compiler init and shutdown functions in new functions ponyc_init() and ponyc_shutdown().

The test framework's PassTest::build_package() doesn't use them, as it seems to rely on some other things that I haven't investigated yet.