### PR TITLE
tweak to Windows premake file to avoid manually setting project char sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,6 @@ Building Pony requires [Premake 5](https://premake.github.io).
 - Get the [PonyC source](https://github.com/ponylang/ponyc).
 - Run `premake5.exe --with-tests --to=..\vs vs2015` to generate the PonyC
   solution.
-- Change the **Character Set** property of each project in the PonyC solution
-  to **Not Set**.
 - Build ponyc.sln in Release mode.
 
 In order to run the pony compiler, you'll need a few libraries in your 

--- a/premake5.lua
+++ b/premake5.lua
@@ -178,6 +178,7 @@
       }
       excludes { "src/libponyc/**.cc" }
     configuration "vs*"
+      characterset "MBCS"
       defines {
         "PONY_USE_BIGINT"
       }
@@ -201,6 +202,7 @@
         "-std=gnu11"
       }
     configuration "vs*"
+      characterset "MBCS"
       cppforce { "src/libponyrt/**.c" }
     configuration "*"
 
@@ -218,6 +220,7 @@
     configuration "gmake"
       buildoptions "-std=gnu11"
     configuration "vs*"
+      characterset "MBCS"
       cppforce { "src/ponyc/**.c" }
     configuration "*"
       link_libponyc()
@@ -232,6 +235,8 @@ if ( _OPTIONS["with-tests"] or _OPTIONS["run-tests"] ) then
       buildoptions {
         "-std=gnu++11"
       }
+    configuration "vs*"
+      characterset "MBCS"
     configuration "*"
 
     includedirs {
@@ -256,6 +261,7 @@ if ( _OPTIONS["with-tests"] or _OPTIONS["run-tests"] ) then
       "test/libponyc/**.cc"
     }
     configuration "vs*"
+      characterset "MBCS"
       defines { "PONY_USE_BIGINT" }
     configuration "*"
       link_libponyc()
@@ -270,6 +276,8 @@ if ( _OPTIONS["with-tests"] or _OPTIONS["run-tests"] ) then
       "src/libponyrt"
     }
     files { "test/libponyrt/**.cc" }
+    configuration "vs*"
+      characterset "MBCS"
 end
 
   if _ACTION == "clean" then


### PR DESCRIPTION
This patch adds a character set option to the Windows premake definition file so you don't have to change your projects' character sets manually.