### PR TITLE
Strengthen numeric literal type inference tests

### DIFF
--- a/test/libponyc/literal_inference.cc
+++ b/test/libponyc/literal_inference.cc
@@ -81,7 +81,7 @@ class LiteralTest : public PassTest
 
 // First the limitations.
 
-TEST_F(LiteralTest, CantInfer_Is)
+TEST_F(LiteralTest, CantInfer_Op_IsLiterals)
 {
   const char* src =
     "class Foo\n"
@@ -93,7 +93,7 @@ TEST_F(LiteralTest, CantInfer_Is)
 }
 
 
-TEST_F(LiteralTest, CantInfer_Isnt)
+TEST_F(LiteralTest, CantInfer_Op_IsntLiterals)
 {
   const char* src =
     "class Foo\n"
@@ -105,7 +105,7 @@ TEST_F(LiteralTest, CantInfer_Isnt)
 }
 
 
-TEST_F(LiteralTest, CantInfer_Is_Expr)
+TEST_F(LiteralTest, CantInfer_Op_ExprIsLiteral)
 {
   const char* src =
     "class Foo\n"
@@ -137,7 +137,7 @@ TEST_F(LiteralTest, CantInfer_Op_FloatAndInt )
 }
 
 
-TEST_F(LiteralTest, CantInfer_Op_FloatAndInt_Float )
+TEST_F(LiteralTest, CantInfer_Op_FloatAndIntReturningFloat )
 {
   const char* src =
     "class Foo12b\n"
@@ -147,7 +147,7 @@ TEST_F(LiteralTest, CantInfer_Op_FloatAndInt_Float )
 }
 
 
-TEST_F(LiteralTest, CantInfer_Op_IntAndFloat_Float )
+TEST_F(LiteralTest, CantInfer_Op_IntAndFloatReturningFloat )
 {
   const char* src =
     "class Foo13b\n"
@@ -157,7 +157,7 @@ TEST_F(LiteralTest, CantInfer_Op_IntAndFloat_Float )
 }
 
 
-TEST_F(LiteralTest, CantInfer_Op_Equals )
+TEST_F(LiteralTest, CantInfer_Op_EqualsLiterals )
 {
   const char* src =
     "class Foo14b\n"
@@ -301,7 +301,7 @@ TEST_F(LiteralTest, CantInfer_Array_UnambiguousUnion )
 }
 
 
-TEST_F(LiteralTest, CantInfer_Control_LiteralMatch )
+TEST_F(LiteralTest, CantInfer_Match_LiteralMatchValue )
 {
   const char* src =    
     "class Foo10c\n"
@@ -314,7 +314,7 @@ TEST_F(LiteralTest, CantInfer_Control_LiteralMatch )
 }
 
 
-TEST_F(LiteralTest, CantInfer_Control_InvalidMatchElse)
+TEST_F(LiteralTest, CantInfer_Match_InvalidElse)
 {
   const char* src =    
     "class Foo11c\n"
@@ -330,7 +330,7 @@ TEST_F(LiteralTest, CantInfer_Control_InvalidMatchElse)
 }
 
 
-TEST_F(LiteralTest, CantInfer_Control_UnusedLiteral)
+TEST_F(LiteralTest, CantInfer_Literal_Unused)
 {
   const char* src =    
     "class Foo12c\n"
@@ -340,7 +340,7 @@ TEST_F(LiteralTest, CantInfer_Control_UnusedLiteral)
 }
     
 
-TEST_F(LiteralTest, CantInfer_Control_InvalidWhileReturnValue)
+TEST_F(LiteralTest, CantInfer_While_InvalidReturnValue)
 {
   const char* src =
     "class Foo13c\n"
@@ -355,7 +355,7 @@ TEST_F(LiteralTest, CantInfer_Control_InvalidWhileReturnValue)
 }
     
 
-TEST_F(LiteralTest, CantInfer_Control_InvalidWhileElseValue )
+TEST_F(LiteralTest, CantInfer_While_InvalidElseValue )
 {
   const char* src =
     "class Foo14c\n"
@@ -476,7 +476,7 @@ TEST_F(LiteralTest, Let_NestedTuple)
 }
 
 
-TEST_F(LiteralTest, Let_TupleOfGeneric_FirstOnly)
+TEST_F(LiteralTest, Let_TupleOfGeneric)
 {
   const char* src =
     "class Foo[A: U8, B: U32]\n"
@@ -490,7 +490,7 @@ TEST_F(LiteralTest, Let_TupleOfGeneric_FirstOnly)
 }
 
 
-TEST_F(LiteralTest, Let_TupleOfGeneric_FirstAndSecond)
+TEST_F(LiteralTest, Let_TupleOfGenericOfGeneric)
 {
   const char* src =
     "class Foo[A: U8, B: U32]\n"
@@ -517,7 +517,7 @@ TEST_F(LiteralTest, Parameter_Simple)
 }
 
 
-TEST_F(LiteralTest, Parameter_Second)
+TEST_F(LiteralTest, Parameter_SecondParameter)
 {
   const char* src =
     "class Foo1a\n"
@@ -739,7 +739,7 @@ TEST_F(LiteralTest, Array_ParameterOfArrayOfUnion)
 }
 
 
-TEST_F(LiteralTest, Binary_SimpleMul)
+TEST_F(LiteralTest, Op_MulLiterals)
 {
   const char* src =
     "class Foo1b\n"
@@ -752,7 +752,7 @@ TEST_F(LiteralTest, Binary_SimpleMul)
 }
 
 
-TEST_F(LiteralTest, Binary_SimpleXor)
+TEST_F(LiteralTest, Op_XorLiterals)
 {
   const char* src =
     "class Foo2b\n"
@@ -765,7 +765,7 @@ TEST_F(LiteralTest, Binary_SimpleXor)
 }
 
 
-TEST_F(LiteralTest, Binary_VarOr)
+TEST_F(LiteralTest, Op_VarOrLiteral)
 {
   const char* src =
     "class Foo2ba\n"
@@ -777,7 +777,31 @@ TEST_F(LiteralTest, Binary_VarOr)
 }
 
 
-TEST_F(LiteralTest, Binary_ParameterOfTupleOfBinary)
+TEST_F(LiteralTest, Op_VarEqualsLiteral)
+{
+  const char* src =
+    "class Foo4b\n"
+    "  fun test(y: I32): Bool => y == 79\n";
+
+  TEST_COMPILE(src);
+
+  DO(check_type("I32", TK_NOMINAL, numeric_literal(79)));
+}
+
+
+TEST_F(LiteralTest, Op_LiteralEqualsVar)
+{
+  const char* src =
+    "class Foo5b\n"
+    "  fun test(y: I32): Bool => 79 == y\n";
+
+  TEST_COMPILE(src);
+
+  DO(check_type("I32", TK_NOMINAL, numeric_literal(79)));
+}
+
+
+TEST_F(LiteralTest, Op_ParameterOfTupleOfAnd)
 {
   const char* src =
     "class Foo3b\n"
@@ -791,31 +815,7 @@ TEST_F(LiteralTest, Binary_ParameterOfTupleOfBinary)
 }
 
 
-TEST_F(LiteralTest, Binary_VarLhsEquals)
-{
-  const char* src =
-    "class Foo4b\n"
-    "  fun test(y: I32): Bool => y == 79\n";
-
-  TEST_COMPILE(src);
-
-  DO(check_type("I32", TK_NOMINAL, numeric_literal(79)));
-}
-
-
-TEST_F(LiteralTest, Binary_VarRhsEquals)
-{
-  const char* src =
-    "class Foo5b\n"
-    "  fun test(y: I32): Bool => 79 == y\n";
-
-  TEST_COMPILE(src);
-
-  DO(check_type("I32", TK_NOMINAL, numeric_literal(79)));
-}
-
-
-TEST_F(LiteralTest, Control_If)
+TEST_F(LiteralTest, If_Simple)
 {
   const char* src =
    "class Foo1c\n"
@@ -829,7 +829,7 @@ TEST_F(LiteralTest, Control_If)
 }
 
 
-TEST_F(LiteralTest, Control_MatchResult)
+TEST_F(LiteralTest, Match_ResultInt)
 {
   const char* src =
     "class Foo2c\n"
@@ -849,7 +849,7 @@ TEST_F(LiteralTest, Control_MatchResult)
 }
 
 
-TEST_F(LiteralTest, Control_MatchResultFloat)
+TEST_F(LiteralTest, Match_ResultFloat)
 {
   const char* src =
     "class Foo3c\n"
@@ -869,7 +869,7 @@ TEST_F(LiteralTest, Control_MatchResultFloat)
 }
 
 
-TEST_F(LiteralTest, Control_MatchPatternTuple)
+TEST_F(LiteralTest, Match_PatternTuple)
 {
   const char* src =
     "class Foo4c\n"
@@ -890,7 +890,7 @@ TEST_F(LiteralTest, Control_MatchPatternTuple)
 }
 
 
-TEST_F(LiteralTest, Control_TryErrorOnlyBody)
+TEST_F(LiteralTest, Try_ErrorBodyElseLiteral)
 {
   const char* src =
     "class Foo5c\n"
@@ -902,7 +902,7 @@ TEST_F(LiteralTest, Control_TryErrorOnlyBody)
 }
 
 
-TEST_F(LiteralTest, Control_TryExpressionBody)
+TEST_F(LiteralTest, Try_ExpressionBody)
 {
   const char* src =
     "class Foo6c\n"
@@ -916,7 +916,7 @@ TEST_F(LiteralTest, Control_TryExpressionBody)
 }
 
 
-TEST_F(LiteralTest, Control_WhileBreakHasValue)
+TEST_F(LiteralTest, While_TupleResultBreakHasValue)
 {
   const char* src =
     "class Foo7c\n"
@@ -941,7 +941,7 @@ TEST_F(LiteralTest, Control_WhileBreakHasValue)
 }
 
 
-TEST_F(LiteralTest, Control_WhileBreakHasNoValue)
+TEST_F(LiteralTest, While_TupleResultBreakHasNoValue)
 {
   const char* src =
     "class Foo8c\n"
@@ -965,7 +965,7 @@ TEST_F(LiteralTest, Control_WhileBreakHasNoValue)
 }
 
 
-TEST_F(LiteralTest, Control_ForSimple)
+TEST_F(LiteralTest, For_Simple)
 {
   const char* src =
     "class Foo9c\n"

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -17,44 +17,52 @@ using std::string;
 
 
 static const char* _builtin =
-  "primitive U8 is Real[U8]\n"  // for literal inference tests
+  "primitive U8 is Real[U8]\n"
   "  new create() => 0\n"
-  "primitive I8\n"
+  "  fun mul(a: U8): U8 => 0\n"
+  "primitive I8 is Real[I8]"
   "  new create() => 0\n"
   "  fun neg():I8 => -this\n"
-  "primitive U16\n"
+  "primitive U16 is Real[U16]"
   "  new create() => 0\n"
-  "primitive I16\n"
+  "primitive I16 is Real[I16]"
   "  new create() => 0\n"
   "  fun neg():I16 => -this\n"
-  "primitive U32\n"
+  "  fun mul(a: I16): I16 => 0\n"
+  "primitive U32 is Real[U32]"
   "  new create() => 0\n"
-  "primitive I32\n"
+  "primitive I32 is Real[I32]"
   "  new create() => 0\n"
   "  fun neg():I32 => -this\n"
-  "primitive U64\n"
+  "primitive U64 is Real[U64]"
   "  new create() => 0\n"
-  "primitive I64\n"
+  "primitive I64 is Real[I64]"
   "  new create() => 0\n"
   "  fun neg():I64 => -this\n"
-  "primitive U128\n"
+  "  fun mul(a: I64): I64 => 0\n"  
+  "  fun op_or(a: I64): I64 => 0\n"
+  "  fun op_and(a: I64): I64 => 0\n"  
+  "  fun op_xor(a: I64): I64 => 0\n"
+  "primitive U128 is Real[U128]"
   "  new create() => 0\n"
-  "primitive I128\n"
+  "  fun mul(a: U128): U128 => 0\n"
+  "  fun div(a: U128): U128 => 0\n"
+  "primitive I128 is Real[I128]"
   "  new create() => 0\n"
   "  fun neg():I128 => -this\n"
-  "primitive ULong\n"
+  "primitive ULong is Real[ULong]"
   "  new create() => 0\n"
-  "primitive ILong\n"
+  "primitive ILong is Real[ILong]"
   "  new create() => 0\n"
   "  fun neg():ILong => -this\n"
-  "primitive USize\n"
+  "primitive USize is Real[USize]"
   "  new create() => 0\n"
-  "primitive ISize\n"
+  "primitive ISize is Real[ISize]"
   "  new create() => 0\n"
   "  fun neg():ISize => -this\n"
-  "primitive F32\n"
+  "primitive F32 is Real[F32]"
   "  new create() => 0\n"
-  "primitive F64\n"
+  "primitive F64 is Real[F64]"
   "  new create() => 0\n"
   "type Number is (Signed | Unsigned | Float)\n"
   "type Signed is (I8 | I16 | I32 | I64 | I128 | ILong | ISize)\n"
@@ -64,7 +72,21 @@ static const char* _builtin =
   "primitive None\n"
   "primitive Bool\n"
   "class val String\n"
-  "class Pointer[A]\n";
+  "class Pointer[A]\n"
+  "interface Seq[A]\n"
+  // Fake up arrays and iterators enough to allow tests to
+  // - create array literals
+  // - call .values() iterator in a for loop
+  "class Array[A] is Seq[A]\n"
+  "  new create(len: USize, alloc: USize = 0) => true\n"
+  "  fun ref push(value: A): Array[A]^ => this\n"
+  "  fun values(): Iterator[A] => object ref\n"
+  "    fun ref has_next(): Bool => false\n"
+  "    fun ref next(): A ? => error\n"
+  "  end\n"
+  "interface Iterator[A]\n"
+  "  fun ref has_next(): Bool\n"
+  "  fun ref next(): A ?\n";
 
 
 // Check whether the 2 given ASTs are identical
@@ -287,6 +309,13 @@ ast_t* PassTest::type_of(const char* name)
 }
 
 
+ast_t* PassTest::numeric_literal(uint64_t num)
+{
+  assert(program != NULL);
+  return numeric_literal_within(program, num);
+}
+
+
 ast_t* PassTest::lookup_in(ast_t* ast, const char* name)
 {
   assert(ast != NULL);
@@ -386,6 +415,30 @@ ast_t* PassTest::type_of_within(ast_t* ast, const char* name)
   for(ast_t* p = ast_child(ast); p != NULL; p = ast_sibling(p))
   {
     ast_t* r = type_of_within(p, name);
+
+    if(r != NULL)
+      return r;
+  }
+
+  // Not found.
+  return NULL;
+}
+
+
+ast_t* PassTest::numeric_literal_within(ast_t* ast, uint64_t num)
+{
+  assert(ast != NULL);
+
+  // Is this node the definition we're looking for?
+  if (ast_id(ast) == TK_INT && lexint_cmp64(ast_int(ast), num) == 0)
+  {
+    return ast;
+  }
+
+  // Check children.
+  for(ast_t* p = ast_child(ast); p != NULL; p = ast_sibling(p))
+  {
+    ast_t* r = numeric_literal_within(p, num);
 
     if(r != NULL)
       return r;

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -86,6 +86,10 @@ protected:
   // Returns: the AST of the named definition, NULL if not found.
   ast_t* lookup_member(const char* type_name, const char* member_name);
 
+  // Lookup the first instance of the given integer as a number literal in 
+  // the previously loaded package
+  ast_t* numeric_literal(uint64_t num);
+
 private:
   const char* _builtin_src;
   const char* _first_pkg_path;
@@ -100,6 +104,8 @@ private:
   // If there are multiple matches the first found will be returned.
   // Returns: type of specified name, NULL if none found.
   ast_t* type_of_within(ast_t* ast, const char* name);
+
+  ast_t* numeric_literal_within(ast_t* ast, uint64_t num);
 };
 
 


### PR DESCRIPTION
More tests for #570.

Move to finding literals directly by value rather than by crawling around from other constructs.

Add tests for inference in parameters, returning a value and using a returned value, type aliases, binary expressions, arrays, if, while, match, try and for. So, certainly not all constructs covered, but a fair proportion.

Tests for arrays and for required extending the faked up builtin types declared at the top of test/libpony/util.cc