### PR TITLE
Add acquire/release GC tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - ponytest TestHelper.dispose_when_done
 - copysign and infinite for floating point numbers
 - contains() method on Array
+- GC tracing with acquire/release semantics.
 
 ### Changed
 

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -35,11 +35,21 @@ void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
 void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
   bool immutable);
 
+void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
+
+void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
+
 void ponyint_gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_recvactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_markactor(pony_ctx_t* ctx, pony_actor_t* actor);
+
+void ponyint_gc_acquireactor(pony_ctx_t* ctx, pony_actor_t* actor);
+
+void ponyint_gc_releaseactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_createactor(pony_actor_t* current, pony_actor_t* actor);
 
@@ -52,6 +62,8 @@ void ponyint_gc_sweep(pony_ctx_t* ctx, gc_t* gc);
 void ponyint_gc_sendacquire(pony_ctx_t* ctx);
 
 void ponyint_gc_sendrelease(pony_ctx_t* ctx, gc_t* gc);
+
+void ponyint_gc_sendrelease_manual(pony_ctx_t* ctx);
 
 bool ponyint_gc_acquire(gc_t* gc, actorref_t* aref);
 

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -34,6 +34,20 @@ void ponyint_gc_mark(pony_ctx_t* ctx)
   ctx->trace_actor = ponyint_gc_markactor;
 }
 
+void pony_gc_acquire(pony_ctx_t* ctx)
+{
+  assert(ctx->stack == NULL);
+  ctx->trace_object = ponyint_gc_acquireobject;
+  ctx->trace_actor = ponyint_gc_acquireactor;
+}
+
+void pony_gc_release(pony_ctx_t* ctx)
+{
+  assert(ctx->stack == NULL);
+  ctx->trace_object = ponyint_gc_releaseobject;
+  ctx->trace_actor = ponyint_gc_releaseactor;
+}
+
 void pony_send_done(pony_ctx_t* ctx)
 {
   ponyint_gc_handlestack(ctx);
@@ -61,6 +75,20 @@ void ponyint_mark_done(pony_ctx_t* ctx)
   ponyint_gc_handlestack(ctx);
   ponyint_gc_sendacquire(ctx);
   ponyint_gc_sweep(ctx, ponyint_actor_gc(ctx->current));
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
+}
+
+void pony_acquire_done(pony_ctx_t* ctx)
+{
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_sendacquire(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
+}
+
+void pony_release_done(pony_ctx_t* ctx)
+{
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_sendrelease_manual(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -205,6 +205,28 @@ void pony_gc_send(pony_ctx_t* ctx);
  */
 void pony_gc_recv(pony_ctx_t* ctx);
 
+/** Start gc tracing for acquiring.
+ * 
+ * Call this when acquiring objects. Then trace the objects you want to
+ * acquire, then call pony_acquire_done. Acquired objects will not be GCed
+ * until released even if they are not reachable from Pony code anymore.
+ * Acquiring an object will also acquire all objects reachable from it as well
+ * as their respective owners. When adding or removing objects from an acquired
+ * object graph, you must acquire anything added and release anything removed.
+ * A given object (excluding actors) cannot be acquired more than once in a
+ * single pony_gc_acquire/pony_acquire_done round. The same restriction applies
+ * to release functions.
+ */
+void pony_gc_acquire(pony_ctx_t* ctx);
+
+/** Start gc tracing for releasing.
+ * 
+ * Call this when releasing acquired objects. Then trace the objects you want
+ * to release, then call pony_release_done. If an object was acquired multiple
+ * times, it must be released as many times before being GCed.
+ */
+void pony_gc_release(pony_ctx_t* ctx);
+
 /** Finish gc tracing for sending.
  *
  * Call this after tracing the GCable contents.
@@ -216,6 +238,18 @@ void pony_send_done(pony_ctx_t* ctx);
  * Call this after tracing the GCable contents.
  */
 void pony_recv_done(pony_ctx_t* ctx);
+
+/** Finish gc tracing for acquiring.
+ * 
+ * Call this after tracing objects you want to acquire.
+ */
+void pony_acquire_done(pony_ctx_t* ctx);
+
+/** Finish gc tracing for releasing.
+ * 
+ * Call this after tracing objects you want to release.
+ */
+void pony_release_done(pony_ctx_t* ctx);
 
 /** Trace memory
  *


### PR DESCRIPTION
As discussed in #675. Please do not merge yet.

This is the algorithm @sylvanc suggested. My implementation seems to work in all 4 cases (local acquire/local release, remote acquire/local release, local acquire/remote release and remote acquire/remote release) but there are some issues to resolve.

- What if the memory wasn't Pony-allocated? Should we assert or just let it crash?
- Currently, acquiring an object more than one time is possible and requires multiple releases to allow collection. Is this a problem?
- Should we have separate functions for local and remote like the other functions in `gc.c`?
- Do we need unit tests for this? Maybe as a separate PR?
- Are the function names right?
- Are the function parameters right?