### PR TITLE
Print default values in documentation

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -540,11 +540,23 @@ static void doc_params(docgen_t* docgen, ast_t* params)
     const char* name = ast_name(id);
     assert(name != NULL);
 
-    if(ast_id(def_val) != TK_NONE)
-      fprintf(docgen->type_file, "optional ");
-
     fprintf(docgen->type_file, "%s: ", name);
     doc_type(docgen, type);
+
+    // if we have a default value, add it to the documentation
+    if(ast_id(def_val) != TK_NONE)
+    {
+      switch(ast_id(def_val))
+      {
+        case TK_STRING:
+          fprintf(docgen->type_file, "= \"%s\"", ast_get_print(def_val));
+          break;
+
+        default:
+          fprintf(docgen->type_file, " = %s", ast_get_print(def_val));
+          break;
+      }
+    }
   }
 
   fprintf(docgen->type_file, ")");


### PR DESCRIPTION
Before this commit, we printed "optional" next to parameters
that came with default values. Nice, but not as useful as
knowing what that value is.

This change should had "straight forward" defaults. If the default
is a complex expression, it will probably render like shit and per
this discussion: https://pony.groups.io/g/dev/thread/724212#15,
we'll need to revisit and improve that printing. However, this commit
should work for just about everything that is currently in the
stdlib.

Closes #682