### PR TITLE
Verbose reachability

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -376,6 +376,9 @@ bool genexe(compile_t* c, ast_t* program)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
   paint(c->reachable);
 
+  if(c->opt->verbosity >= VERBOSITY_ALL)
+    reach_dump(c->reachable);
+
   if(!gentypes(c))
     return false;
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -888,7 +888,7 @@ void reach_dump(reachable_types_t* r)
 
   while((t = reachable_types_next(r, &i)) != NULL)
   {
-    printf("  %s vtable size %d\n", t->name, t->vtable_size);
+    printf("  %s: %d\n", t->name, t->vtable_size);
     size_t j = HASHMAP_BEGIN;
     reachable_method_name_t* m;
 
@@ -898,9 +898,7 @@ void reach_dump(reachable_types_t* r)
       reachable_method_t* p;
 
       while((p = reachable_methods_next(&m->r_methods, &k)) != NULL)
-      {
-        printf("    %s vtable index %d (%p)\n", p->name, p->vtable_index, p);
-      }
+        printf("    %s: %d\n", p->name, p->vtable_index);
     }
   }
 }


### PR DESCRIPTION
When compiler verbosity is set to maximum (ie 4), print out a the
complete reachability analysis results, including vtable sizes and
vtable indices for all types and methods.