### PR TITLE
added contains function to HashSet[A] with relevant tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Case functions.
 - Timeouts for PonyTest long tests.
 - contains() method on HashMap
+- contains() method on HashSet
 - Support for empty sections in ini parsing.
 - --verbose,-V option for compiler informational messages.
 - Logger package

--- a/packages/collections/set.pony
+++ b/packages/collections/set.pony
@@ -33,6 +33,12 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     _map(value)
 
+  fun contains(value: box->A!): Bool =>
+    """
+    Checks whether the set contains the value.
+    """
+    _map.contains(value)
+
   fun ref clear(): HashSet[A, H]^ =>
     """
     Remove all elements from the set.

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -22,6 +22,7 @@ actor Main is TestList
     test(_TestListsTakeWhile)
     test(_TestListsContains)
     test(_TestListsReverse)
+    test(_TestHashSetContains)
 
 class iso _TestList is UnitTest
   fun name(): String => "collections/List"
@@ -450,5 +451,32 @@ class iso _TestListsReverse is UnitTest
     h.assert_eq[U32](b(0), 2)
     h.assert_eq[U32](b(1), 1)
     h.assert_eq[U32](b(2), 0)
+
+    true
+
+class iso _TestHashSetContains is UnitTest
+  fun name(): String => "collections/HashSet/contains()"
+
+  fun apply(h: TestHelper) =>
+    let a = Set[U32]
+    a.set(0).set(1)
+
+    let not_found_fail = "contains did not find expected element in HashSet"
+    let found_fail = "contains found unexpected element in HashSet"
+
+    // Elements in set should be found
+    h.assert_true(a.contains(0), not_found_fail)
+    h.assert_true(a.contains(1), not_found_fail)
+
+    // Elements not in set should not be found
+    h.assert_false(a.contains(2), found_fail)
+
+    // Unsetting an element should cause it to not be found
+    a.unset(0)
+    h.assert_false(a.contains(0), found_fail)
+
+    // And resetting an element should cause it to be found again
+    a.set(0)
+    h.assert_true(a.contains(0), not_found_fail)
 
     true


### PR DESCRIPTION
Because often:
```pony
if my_set.contains(element) then
  do_something()
else
  do_something_else()
end
```
is clearer and more convenient than:
```pony
try my_set(element)
  do_something
else
  do_something_else()
end
```