### PR TITLE
Add some tests for recover semantics.

### DIFF
--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -367,8 +367,11 @@ bool expr_recover(ast_t* ast)
 
   if(r_type == NULL)
   {
-    ast_error(ast, "can't recover to this capability");
-    ast_error(expr, "expression type is %s", ast_print_type(type));
+    errorframe_t frame = NULL;
+    ast_error_frame(&frame, ast, "can't recover to this capability");
+    ast_error_frame(&frame, expr, "expression type is %s",
+      ast_print_type(type));
+    errorframe_report(&frame);
     return false;
   }
 

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -1,0 +1,257 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_ERRORS_1(src, err1) DO(test_errors_1(src, "expr", err1));
+
+
+class RecoverTest : public PassTest
+{};
+
+
+TEST_F(RecoverTest, CanRecover_NewRefToIso)
+{
+  const char* src =
+    "class Class\n"
+    "  new ref create() => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Class iso =>\n"
+    "    recover iso Class end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CanRecover_NewRefToVal)
+{
+  const char* src =
+    "class Class\n"
+    "  new ref create() => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Class val =>\n"
+    "    recover val Class end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantRecover_NewValToIso)
+{
+  const char* src =
+    "class Class\n"
+    "  new val create() => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Class iso =>\n"
+    "    recover iso Class end";
+
+  TEST_ERRORS_1(src, "can't recover to this capability");
+}
+
+TEST_F(RecoverTest, CantRecover_NewTagToVal)
+{
+  const char* src =
+    "class Class\n"
+    "  new tag create() => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Class val =>\n"
+    "    recover val Class end";
+
+  TEST_ERRORS_1(src, "can't recover to this capability");
+}
+
+TEST_F(RecoverTest, CantAccess_LetLocalRef)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    let inner: Inner ref = Inner\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't access a non-sendable local defined outside");
+}
+
+TEST_F(RecoverTest, CanAccess_LetLocalVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    let inner: Inner val = Inner\n"
+    "    recover Wrap(inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CanAccess_LetLocalConsumedIso)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    let inner: Inner iso = Inner\n"
+    "    recover Wrap(consume inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantAccess_VarLocalRef)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    var inner: Inner ref = Inner\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't access a non-sendable local defined outside");
+}
+
+TEST_F(RecoverTest, CanAccess_VarLocalVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    var inner: Inner val = Inner\n"
+    "    recover Wrap(inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CanAccess_VarLocalConsumedIso)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    var inner: Inner iso = Inner\n"
+    "    recover Wrap(consume inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantAccess_ParamRef)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(inner: Inner ref): Wrap iso =>\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't access a non-sendable parameter");
+}
+
+TEST_F(RecoverTest, CanAccess_ParamVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(inner: Inner val): Wrap iso =>\n"
+    "    recover Wrap(inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CanAccess_ParamConsumedIso)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "primitive Prim\n"
+    "  fun apply(inner: Inner iso): Wrap iso =>\n"
+    "    recover Wrap(consume inner) end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantAccess_LetFieldVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  let inner: Inner val = Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't read a field through Class tag");
+}
+
+TEST_F(RecoverTest, CantAccess_VarFieldVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  var inner: Inner val = Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't read a field through Class tag");
+}
+
+TEST_F(RecoverTest, CantAccess_EmbedFieldVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  embed inner: Inner val = Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover Wrap(inner) end";
+
+  TEST_ERRORS_1(src, "can't read a field through Class tag");
+}
+
+TEST_F(RecoverTest, CantAccess_FunReturnVal)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  fun inner(): Inner val => Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover Wrap(inner()) end";
+
+  TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
+}

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -289,6 +289,18 @@ void PassTest::test_error(const char* src, const char* pass)
 }
 
 
+void PassTest::test_errors_1(const char* src, const char* pass,
+  const char* err1)
+{
+  DO(test_error(src, pass));
+
+  ASSERT_EQ(1, get_error_count());
+  errormsg_t* errors = get_errors();
+  EXPECT_TRUE(strstr(errors->msg, err1) != NULL)
+      << "Actual error: " << errors->msg;
+}
+
+
 void PassTest::test_equiv(const char* actual_src, const char* actual_pass,
   const char* expect_src, const char* expect_pass)
 {

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -60,6 +60,10 @@ protected:
   // Check that the given source fails when compiled to the specified pass
   void test_error(const char* src, const char* pass);
 
+  // Check that the given source fails when compiled to the specified pass,
+  // exactly N errors are produced, and the errors match expected text.
+  void test_errors_1(const char* src, const char* pass, const char* err1);
+
   // Check that the 2 given sources compile to give the same AST for the first
   // package
   void test_equiv(const char* actual_src, const char* actual_pass,


### PR DESCRIPTION
This PR adds some tests for the semantics of `recover ... end` blocks.

My next PR is going to be mucking around with auto-recover for #702, so I thought it would be a good idea to get some of the semantics of `recover` under test so I can be sure I'm not breaking anything important.

These tests may not cover 100% of what it means to `recover`, but it's a start.  We can always add more as we find missing coverage and/or regressions in the future.