### PR TITLE
Regarding Issue 380: Added writebuffer.pony in net package;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Logger package
 - `ArrayValues.rewind()` method.
 - Nanos primitive in time package.
+- An initial implementation of WriteBuffer inside the net package
 
 ### Changed
 

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -18,25 +18,23 @@ class iso _TestWriteBuffer is UnitTest
   fun apply(h: TestHelper) ? =>
     let test_val_i64: I64 = 0xEAD_BEEF_FEED_FACE
     let test_val_u64: U64 = 0xDEADBEEFFEEDFACE
-    let wb: WriteBuffer = WriteBuffer(recover Array[U8] end)
-    wb.i64(test_val_i64)
-    wb.u64(test_val_u64)
+    let wb: WriteBuffer = WriteBuffer()
+    wb.i64_be(test_val_i64).u64_be(test_val_u64)
     h.assert_eq[USize](wb.current_size(), USize(8 * 2))
     wb.new_packet()
-    wb.i64(test_val_i64)
-    wb.u64(test_val_u64)
+    wb.i64_le(test_val_i64).u64_le(test_val_u64)
     h.assert_eq[USize](wb.current_size(), USize(8 * 2))
-    wb.take_buffer()
     let b = Buffer
     for x in wb.take_buffer().values() do
-      match consume x
-      | let x': Array[U8] iso => b.append(consume x')
+      match (consume x)
+      | let x': Array[U8] val => b.append(consume x')
+      | let x': String val => b.append(x'.array())
       end
     end
     h.assert_eq[I64](b.i64_be(), test_val_i64)
     h.assert_eq[U64](b.u64_be(), test_val_u64)
-    h.assert_eq[I64](b.i64_be(), test_val_i64)
-    h.assert_eq[U64](b.u64_be(), test_val_u64)
+    h.assert_eq[I64](b.i64_le(), test_val_i64)
+    h.assert_eq[U64](b.u64_le(), test_val_u64)
 
 class iso _TestBuffer is UnitTest
   """

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -16,52 +16,27 @@ class iso _TestWriteBuffer is UnitTest
   fun name(): String => "net/WriteBuffer"
 
   fun apply(h: TestHelper) ? =>
-    let bsize: USize = 1024
-    let test_val1: I64 = 0xEAD_BEEF_FEED_FACE
-    let test_val2: U64 = 0xDEADBEEFFEEDFACE
-    // Calling write_number with I64/U64 should test all cases(?!)
-    let x_be = recover val
-      let wb = WriteBuffer(bsize)
-      try
-        h.assert_eq[USize](wb.available(), bsize)
-        wb.write_number(test_val1)
-        // Using 8 here for the lack of a better way to get the size of an I64!
-        h.assert_eq[USize](wb.available(), bsize-8)
-        wb.write_number(test_val2)
-        h.assert_eq[USize](wb.available(), bsize-(8*2))
-      else
-        error
-      end
-
-      let data: Array[U8] iso = recover Array[U8].undefined(0) end
-      wb.get_data(consume data)
-    end
-
-    let x_le = recover val
-      let wb = WriteBuffer(bsize, true)
-      try
-        h.assert_eq[USize](wb.available(), bsize)
-        wb.write_number(test_val1)
-        h.assert_eq[USize](wb.available(), bsize-8)
-        wb.write_number(test_val2)
-        h.assert_eq[USize](wb.available(), bsize-(8*2))
-      else
-        error
-      end
-
-      let data: Array[U8] iso = recover Array[U8].undefined(0) end
-      wb.get_data(consume data)
-    end
-
+    let test_val_i64: I64 = 0xEAD_BEEF_FEED_FACE
+    let test_val_u64: U64 = 0xDEADBEEFFEEDFACE
+    let wb: WriteBuffer = WriteBuffer(recover Array[U8] end)
+    wb.i64(test_val_i64)
+    wb.u64(test_val_u64)
+    h.assert_eq[USize](wb.current_size(), USize(8 * 2))
+    wb.new_packet()
+    wb.i64(test_val_i64)
+    wb.u64(test_val_u64)
+    h.assert_eq[USize](wb.current_size(), USize(8 * 2))
+    wb.take_buffer()
     let b = Buffer
-    b.append(x_be)
-    b.append(x_le)
-
-    h.assert_eq[I64](b.i64_be(), test_val1)
-    h.assert_eq[U64](b.u64_be(), test_val2)
-    b.skip(bsize-(8*2))
-    h.assert_eq[I64](b.i64_le(), test_val1)
-    h.assert_eq[U64](b.u64_le(), test_val2)
+    for x in wb.take_buffer().values() do
+      match consume x
+      | let x': Array[U8] iso => b.append(consume x')
+      end
+    end
+    h.assert_eq[I64](b.i64_be(), test_val_i64)
+    h.assert_eq[U64](b.u64_be(), test_val_u64)
+    h.assert_eq[I64](b.i64_be(), test_val_i64)
+    h.assert_eq[U64](b.u64_be(), test_val_u64)
 
 class iso _TestBuffer is UnitTest
   """

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -18,12 +18,26 @@ class iso _TestWriteBuffer is UnitTest
   fun apply(h: TestHelper) ? =>
     let test_val_i64: I64 = 0xEAD_BEEF_FEED_FACE
     let test_val_u64: U64 = 0xDEADBEEFFEEDFACE
-    let wb: WriteBuffer = WriteBuffer()
+    let wb: WriteBuffer = WriteBuffer
     wb.i64_be(test_val_i64).u64_be(test_val_u64)
     h.assert_eq[USize](wb.current_size(), USize(8 * 2))
     wb.new_packet()
     wb.i64_le(test_val_i64).u64_le(test_val_u64)
     h.assert_eq[USize](wb.current_size(), USize(8 * 2))
+    let test_vector: Array[U8] val = recover val [as U8:
+      0x42,
+      0xDE, 0xAD,
+      0xAD, 0xDE,
+      0xDE, 0xAD, 0xBE, 0xEF,
+      0xEF, 0xBE, 0xAD, 0xDE,
+      0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED, 0xFA, 0xCE,
+      0xCE, 0xFA, 0xED, 0xFE, 0xEF, 0xBE, 0xAD, 0xDE,
+      0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED, 0xFA, 0xCE,
+      0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED, 0xFA, 0xCE,
+      0xCE, 0xFA, 0xED, 0xFE, 0xEF, 0xBE, 0xAD, 0xDE,
+      0xCE, 0xFA, 0xED, 0xFE, 0xEF, 0xBE, 0xAD, 0xDE
+      ] end
+    wb.add_byte_seq(test_vector)
     let b = Buffer
     for x in wb.take_buffer().values() do
       match (consume x)
@@ -35,6 +49,9 @@ class iso _TestWriteBuffer is UnitTest
     h.assert_eq[U64](b.u64_be(), test_val_u64)
     h.assert_eq[I64](b.i64_le(), test_val_i64)
     h.assert_eq[U64](b.u64_le(), test_val_u64)
+    for x in test_vector.values() do
+      h.assert_eq[U8](b.u8(), x)
+    end
 
 class iso _TestBuffer is UnitTest
   """

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -3,29 +3,23 @@ use "collections"
 class WriteBuffer
   """
   * A List[ByteSeq] maintained as WriteBuffer.
-  * _current keeps track of the current packet of type `ByteSeq iso`
+  * _current keeps track of the current packet `ByteSeq iso`
     into which the user is writing
   * _buffer is returned on take_buffer() as a ByteSeqIter
   * The current packet is written into _buffer on call the new_packet()
   """
   var _buffer: List[ByteSeq] iso
-  var _current: ByteSeq iso
+  var _current: Array[U8] iso
   var _current_size: USize
   var _little_endian: Bool
-  var _seq_type: ByteSeq
 
-  new create(seq_type: ByteSeq, little_endian: Bool = false) =>
+  new create(little_endian: Bool = false) =>
     """
     Create the buffer
     Create _current depending on the seq_type requested by the user
     """
     _buffer = recover List[ByteSeq] end
-    _seq_type = seq_type
-    _current =
-      match seq_type
-      | String => recover String end
-      else recover Array[U8] end
-      end
+    _current = recover Array[U8] end
     _current_size = 0
     _little_endian = little_endian
 
@@ -34,12 +28,9 @@ class WriteBuffer
     * Archives the current packet into _buffer and ensures future
       writes goto a new packet
     * Destructive read of _current and push it onto buffer.
-    * Potentially, will have a default argument that will decide whether
-      to have an Array[U8] or String as the next packet in the buffer
     * This is chainable
     """
-    var x = _current = recover Array[U8 val] end
-    _buffer.push(consume x)
+    _buffer.push(_current = recover Array[U8] end)
     _current_size = 0
     this
 
@@ -50,8 +41,7 @@ class WriteBuffer
     if (_current_size > 0) then
       new_packet()
     end
-    var x = _buffer = recover List[ByteSeq] end
-    consume x
+    _buffer = recover List[ByteSeq] end
 
   fun current_size(): USize =>
     """
@@ -59,32 +49,60 @@ class WriteBuffer
     """
     _current_size
 
-  fun ref _byte(value: U8 val) : WriteBuffer =>
+  fun ref _byte(value: U8 val): WriteBuffer =>
     """
     Endless writes into _current
     Chainable
-    Potentially use the push depending on the result of a match on _current
     """
-    // match _seq_type
-    // | String => _current.push(value)
-    // | Array[U8] =>
-    // end
     _current.push(value)
     _current_size = _current_size + 1
     this
 
-  fun ref u8(value: U8) => _byte(value)
+  fun ref add_byte_seq(bytes: ByteSeq): WriteBuffer =>
+    if (_current_size > 0) then
+      new_packet()
+    end
+    _buffer.push(bytes)
+    new_packet()
 
-  fun ref i8(value: I8) => _byte(value.u8())
+  fun ref u8(value: U8): WriteBuffer =>
+    _byte(value)
 
-  fun ref u16(value: U16) => _byte((value>>8).u8()); _byte(value.u8())
+  fun ref i8(value: I8): WriteBuffer =>
+    _byte(value.u8())
 
-  fun ref i16(value: I16) => _byte((value>>8).u8()); _byte(value.u8())
+  fun ref u16_be(value: U16): WriteBuffer =>
+    _byte((value>>8).u8())._byte(value.u8())
 
-  fun ref u32(value: U32) => u16((value>>16).u16()); u16(value.u16())
+  fun ref i16_be(value: I16): WriteBuffer =>
+    u16_be(value.u16())
 
-  fun ref i32(value: I32) => u16((value>>16).u16()); u16(value.u16())
+  fun ref u32_be(value: U32): WriteBuffer =>
+    u16_be((value>>16).u16()).u16_be(value.u16())
 
-  fun ref u64(value: U64) => u32((value>>32).u32()); u32(value.u32())
+  fun ref i32_be(value: I32): WriteBuffer =>
+    u32_be(value.u32())
 
-  fun ref i64(value: I64) => u32((value>>32).u32()); u32(value.u32())
+  fun ref u64_be(value: U64): WriteBuffer =>
+    u32_be((value>>32).u32()).u32_be(value.u32())
+
+  fun ref i64_be(value: I64): WriteBuffer =>
+    u64_be(value.u64())
+
+  fun ref u16_le(value: U16): WriteBuffer =>
+    _byte(value.u8())._byte((value>>8).u8())
+
+  fun ref i16_le(value: I16): WriteBuffer =>
+    u16_le(value.u16())
+
+  fun ref u32_le(value: U32): WriteBuffer =>
+    u16_le(value.u16()).u16_le((value>>16).u16())
+
+  fun ref i32_le(value: I32): WriteBuffer =>
+    u32_le(value.u32())
+
+  fun ref u64_le(value: U64): WriteBuffer =>
+    u32_le(value.u32()).u32_le((value>>32).u32())
+
+  fun ref i64_le(value: I64): WriteBuffer =>
+    u64_le(value.u64())

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -2,68 +2,89 @@ use "collections"
 
 class WriteBuffer
   """
-  A simple constant sized byte buffer to push Numbers into.
-  The data container is iso in order to keep it sendable(?)
-  Potential upgrades:
-  1. Have a list of data buffers of preset size
-  2. Arguably, seperate functions for _be and _le
-  3. A better way to get data out of the buffer, without passing a new array?
+  * A List[ByteSeq] maintained as WriteBuffer.
+  * _current keeps track of the current packet of type `ByteSeq iso`
+    into which the user is writing
+  * _buffer is returned on take_buffer() as a ByteSeqIter
+  * The current packet is written into _buffer on call the new_packet()
   """
-  var data: Array[U8] iso
-  var _offset: USize
+  var _buffer: List[ByteSeq] iso
+  var _current: ByteSeq iso
+  var _current_size: USize
   var _little_endian: Bool
+  var _seq_type: ByteSeq
 
-  new create(size: USize, little_endian: Bool = false) =>
+  new create(seq_type: ByteSeq, little_endian: Bool = false) =>
     """
-    Allocate the buffer
+    Create the buffer
+    Create _current depending on the seq_type requested by the user
     """
-    data = recover Array[U8].undefined(size) end
-    _offset = 0
+    _buffer = recover List[ByteSeq] end
+    _seq_type = seq_type
+    _current =
+      match seq_type
+      | String => recover String end
+      else recover Array[U8] end
+      end
+    _current_size = 0
     _little_endian = little_endian
 
-  fun ref get_data(x: Array[U8] iso): Array[U8] iso^ =>
+  fun ref new_packet(): WriteBuffer =>
     """
-    Destructive read inorder to get an iso reference to data
+    * Archives the current packet into _buffer and ensures future
+      writes goto a new packet
+    * Destructive read of _current and push it onto buffer.
+    * Potentially, will have a default argument that will decide whether
+      to have an Array[U8] or String as the next packet in the buffer
+    * This is chainable
     """
-    var x': Array[U8] iso = data = consume x
-    consume x'
-
-  fun ref available(): USize =>
-    """
-    Number of bytes currently available
-    """
-    data.size() - _offset
-
-  fun ref _byte(value: U8) : WriteBuffer^ ? =>
-    """
-    Write a single byte into the buffer if space available else error
-    Update _offset
-    """
-    if _offset < data.size() then
-      data(_offset) = value
-      _offset = _offset + 1
-    else error end
+    var x = _current = recover Array[U8 val] end
+    _buffer.push(consume x)
+    _current_size = 0
     this
 
-  fun ref write_number(value: Number): WriteBuffer? =>
+  fun ref take_buffer(): ByteSeqIter =>
     """
-    Write the number to buffer based on endianness
+    Destructive read of existing _buffer and return as ByteSeqIter
     """
-    match (value, _little_endian)
-    | (let v: U8, _) => _byte(v)
-    | (let v: I8, _) => _byte(v.u8())
-    | (let v: U16, false) => _byte((v>>8).u8()); _byte(v.u8())
-    | (let v: I16, false) => _byte((v>>8).u8()); _byte(v.u8())
-    | (let v: U32, false) => write_number((v>>16).u16()); write_number(v.u16())
-    | (let v: I32, false) => write_number((v>>16).u16()); write_number(v.u16())
-    | (let v: U64, false) => write_number((v>>32).u32()); write_number(v.u32())
-    | (let v: I64, false) => write_number((v>>32).u32()); write_number(v.u32())
-    | (let v: U16, true) => _byte(v.u8()); _byte((v>>8).u8())
-    | (let v: I16, true) => _byte(v.u8()); _byte((v>>8).u8())
-    | (let v: U32, true) => write_number(v.u16()); write_number((v>>16).u16())
-    | (let v: I32, true) => write_number(v.u16()); write_number((v>>16).u16())
-    | (let v: U64, true) => write_number(v.u32()); write_number((v>>32).u32())
-    | (let v: I64, true) => write_number(v.u32()); write_number((v>>32).u32())
-    else
-      error
+    if (_current_size > 0) then
+      new_packet()
     end
+    var x = _buffer = recover List[ByteSeq] end
+    consume x
+
+  fun current_size(): USize =>
+    """
+    Size of current packet
+    """
+    _current_size
+
+  fun ref _byte(value: U8 val) : WriteBuffer =>
+    """
+    Endless writes into _current
+    Chainable
+    Potentially use the push depending on the result of a match on _current
+    """
+    // match _seq_type
+    // | String => _current.push(value)
+    // | Array[U8] =>
+    // end
+    _current.push(value)
+    _current_size = _current_size + 1
+    this
+
+  fun ref u8(value: U8) => _byte(value)
+
+  fun ref i8(value: I8) => _byte(value.u8())
+
+  fun ref u16(value: U16) => _byte((value>>8).u8()); _byte(value.u8())
+
+  fun ref i16(value: I16) => _byte((value>>8).u8()); _byte(value.u8())
+
+  fun ref u32(value: U32) => u16((value>>16).u16()); u16(value.u16())
+
+  fun ref i32(value: I32) => u16((value>>16).u16()); u16(value.u16())
+
+  fun ref u64(value: U64) => u32((value>>32).u32()); u32(value.u32())
+
+  fun ref i64(value: I64) => u32((value>>32).u32()); u32(value.u32())

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -1,0 +1,69 @@
+use "collections"
+
+class WriteBuffer
+  """
+  A simple constant sized byte buffer to push Numbers into.
+  The data container is iso in order to keep it sendable(?)
+  Potential upgrades:
+  1. Have a list of data buffers of preset size
+  2. Arguably, seperate functions for _be and _le
+  3. A better way to get data out of the buffer, without passing a new array?
+  """
+  var data: Array[U8] iso
+  var _offset: USize
+  var _little_endian: Bool
+
+  new create(size: USize, little_endian: Bool = false) =>
+    """
+    Allocate the buffer
+    """
+    data = recover Array[U8].undefined(size) end
+    _offset = 0
+    _little_endian = little_endian
+
+  fun ref get_data(x: Array[U8] iso): Array[U8] iso^ =>
+    """
+    Destructive read inorder to get an iso reference to data
+    """
+    var x': Array[U8] iso = data = consume x
+    consume x'
+
+  fun ref available(): USize =>
+    """
+    Number of bytes currently available
+    """
+    data.size() - _offset
+
+  fun ref _byte(value: U8) : WriteBuffer^ ? =>
+    """
+    Write a single byte into the buffer if space available else error
+    Update _offset
+    """
+    if _offset < data.size() then
+      data(_offset) = value
+      _offset = _offset + 1
+    else error end
+    this
+
+  fun ref write_number(value: Number): WriteBuffer? =>
+    """
+    Write the number to buffer based on endianness
+    """
+    match (value, _little_endian)
+    | (let v: U8, _) => _byte(v)
+    | (let v: I8, _) => _byte(v.u8())
+    | (let v: U16, false) => _byte((v>>8).u8()); _byte(v.u8())
+    | (let v: I16, false) => _byte((v>>8).u8()); _byte(v.u8())
+    | (let v: U32, false) => write_number((v>>16).u16()); write_number(v.u16())
+    | (let v: I32, false) => write_number((v>>16).u16()); write_number(v.u16())
+    | (let v: U64, false) => write_number((v>>32).u32()); write_number(v.u32())
+    | (let v: I64, false) => write_number((v>>32).u32()); write_number(v.u32())
+    | (let v: U16, true) => _byte(v.u8()); _byte((v>>8).u8())
+    | (let v: I16, true) => _byte(v.u8()); _byte((v>>8).u8())
+    | (let v: U32, true) => write_number(v.u16()); write_number((v>>16).u16())
+    | (let v: I32, true) => write_number(v.u16()); write_number((v>>16).u16())
+    | (let v: U64, true) => write_number(v.u32()); write_number((v>>32).u32())
+    | (let v: I64, true) => write_number(v.u32()); write_number((v>>32).u32())
+    else
+      error
+    end

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -3,12 +3,14 @@ use "collections"
 class WriteBuffer
   """
   * A List[ByteSeq] maintained as WriteBuffer.
-  * _current keeps track of the current packet `Array[U8] iso`
-    into which the user is writing.
+  * _current keeps track of the current packet `Array[U8] iso` into which the
+    user is writing.
   * _current can potentially keep track of `ByteSeq iso` if push is conforming
     between Array[U8] and String.
   * _buffer is returned on take_buffer() as a ByteSeqIter
   * The current packet is pushed into _buffer on a call to new_packet()
+  Example usage:
+
   """
   var _buffer: List[ByteSeq] iso
   var _current: Array[U8] iso
@@ -16,8 +18,7 @@ class WriteBuffer
 
   new create() =>
     """
-    Create the buffer
-    Create _current depending on the seq_type requested by the user
+    Create _buffer, _current and set _current_size to 0
     """
     _buffer = recover List[ByteSeq] end
     _current = recover Array[U8] end
@@ -25,10 +26,10 @@ class WriteBuffer
 
   fun ref new_packet(): WriteBuffer =>
     """
-    * Archives the current packet into _buffer and ensures future
-      writes goto a new packet
-    * Destructive read of _current and push it onto buffer.
-    * This is chainable
+    * Pushes _current into _buffer to ensure future writes go to a new packet
+    * Accomplishes this with a destructive read of _current while pushing
+      it onto _buffer.
+    * Chainable
     * Empty packets disallowed for now
     """
     if (_current_size > 0) then
@@ -39,14 +40,14 @@ class WriteBuffer
 
   fun ref take_buffer(): ByteSeqIter =>
     """
-    Destructive read of existing _buffer and returned as ByteSeqIter
+    Destructive read of existing _buffer which is returned as ByteSeqIter
     """
     if (_current_size > 0) then new_packet() end
     _buffer = recover List[ByteSeq] end
 
   fun current_size(): USize =>
     """
-    Size of current packet
+    Size of _current
     """
     _current_size
 


### PR DESCRIPTION
A first attempt to add a WriteBuffer within the net package.

At the moment, WriteBuffer maintains a constant sized Array[U8] that provides a capability for the user to write Number types into it. Allows the user to get hold of an iso reference to the array via a destructive read.

This implementation resulted from my use case and a discussion with @aturley.
A few things that are up for discussion:
1. Expand this implementation so that the buffer size is indefinite?
2. Provide separate methods for big-endian and little-endian?

Would love any feedback.

Updated test.pony in net package.