### PR TITLE
Updated LLVM install instructions for Linux

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,33 @@
+version: 1.0.{build}
+image: Visual Studio 2013
+configuration:
+  - Debug
+  - Release
+clone_depth: 1
+clone_folder: C:\projects\ponyc
+install:
+  - ps: |
+      cd C:\
+      $premakeInstalled = Test-Path C:\premake5.exe
+      $llvmInstalled = Test-Path C:\LLVM
+      if(-Not $premakeInstalled)
+      {
+        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha8/premake-5.0.0-alpha8-windows.zip -OutFile C:\premake5.zip
+        7z x C:\premake5.zip
+        del C:\premake5.zip
+      }
+      if(-Not $llvmInstalled)
+      {
+        wget http://releases.ponylang.org/llvm/llvm37-final-x86_64-windows-release.zip -OutFile C:\llvm37.zip
+        7z x C:\llvm37.zip
+        del C:\llvm37.zip
+      }
+      $env:path += ";C:\LLVM\bin"
+      cd C:\projects\ponyc
+      C:\premake5.exe --with-tests --to=work/vs2013 vs2013
+cache:
+  - C:\LLVM\ -> .appveyor.yml
+  - C:\premake5.exe -> .appveyor.yml
+build:
+  project: work\vs2013\ponyc.sln
+  verbosity: minimal

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You will need to build from source.
 
 First, install LLVM using your package manager. You may need to install zlib, ncurses, pcre2, and ssl as well. Instructions for some specific distributions follow.
 
-APT packages for LLVM 3.7, 3.8 and 3.9, for Debian and Ubuntu, are provided by the LLVM build server.
+APT packages for LLVM 3.7 and 3.8, for Debian and Ubuntu, are provided by the LLVM build server.
 
 Please follow the instructions at http://llvm.org/apt/ for installing the GPG keys and packages for your distribution.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Getting help 
+# Getting help
 
 * [Open an issue!](https://github.com/ponylang/ponyc/issues)
 * Use the [mailing list](mailto:pony+user@groups.io).
@@ -23,12 +23,12 @@
 
 ## Mac OS X using [Homebrew](http://brew.sh)
 
-The homebrew version is currently woefully out of date. We are transitioning to 
-a new release system that will keep homebrew up to date. For now, please build 
+The homebrew version is currently woefully out of date. We are transitioning to
+a new release system that will keep homebrew up to date. For now, please build
 from source.
 
 ```bash
-$ brew update 
+$ brew update
 $ brew install ponyc
 ```
 
@@ -41,8 +41,8 @@ layman -a stefantalpalaru
 emerge dev-lang/pony
 ```
 
-A live ebuild is also available in the 
-[overlay](https://github.com/stefantalpalaru/gentoo-overlay) 
+A live ebuild is also available in the
+[overlay](https://github.com/stefantalpalaru/gentoo-overlay)
 (dev-lang/pony-9999) and for Vim users there's app-vim/pony-syntax.
 
 ### Other distributions
@@ -55,12 +55,22 @@ You will need to build from source.
 
 # Building ponyc from source
 
-## Building on Linux 
+## Building on Linux
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-First, install LLVM 3.6.2, 3.7.1 or 3.8 using your package manager. You may 
-need to install zlib, ncurses, pcre2, and ssl as well. Instructions for some
-specific distributions follow.
+First, install LLVM using your package manager. You may need to install zlib, ncurses, pcre2, and ssl as well. Instructions for some specific distributions follow.
+
+APT packages for LLVM 3.7, 3.8 and 3.9, for Debian and Ubuntu, are provided by the LLVM build server.
+
+Please follow the instructions at http://llvm.org/apt/ for installing the GPG keys and packages for your distribution.
+
+#### Notes:
+
+On Ubuntu,
+```apt-get install llvm-dev``` installs LLVM-3.6.
+
+When installing the full set of LLVM packages, the ```apt-get install``` instructions include the ```clang-modernize``` package. This should be changed to ```clang-tidy``` due to a recent name change.
+
 
 ### Debian Jessie
 
@@ -101,14 +111,14 @@ $ make config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-### Ubuntu 15.10
+### Ubuntu (12.04, 14.04, 15.10, 16.04)
 
 ```bash
-$ sudo apt-get install build-essential git llvm-dev \
+$ sudo apt-get install build-essential git \
                        zlib1g-dev libncurses5-dev libssl-dev
 ```
 
-Ubuntu 15.10 and some other Linux distributions don't include pcre2 in their
+Ubuntu and some other Linux distributions don't include pcre2 in their
 package manager. pcre2 is used by the Pony regex package. To download and
 build pcre2 from source:
 
@@ -128,11 +138,6 @@ $ make config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-Please note that the LLVM 3.8 apt packages do not include debug symbols. As a 
-result, the `ponyc config=debug` build fails when using those packages. If you 
-need a debug compiler built with LLVM 3.8, you will need to build LLVM from 
-source.
-
 ## Building on FreeBSD
 
 First, install the required dependencies:
@@ -151,11 +156,11 @@ $ gmake config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently 
-produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not 
+Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently
+produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not
 have this problem, and works fine with LLVM 3.7 and 3.8.
 
-## Building on Mac OS X 
+## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
 You'll need llvm 3.6.2, 3.7.1, or 3.8 and the pcre2 library to build Pony.
@@ -178,30 +183,30 @@ $ make config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-## Building on Windows 
+## Building on Windows
 [![Windows](https://ci.appveyor.com/api/projects/status/kckam0f1a1o0ly2j?svg=true)](https://ci.appveyor.com/project/sylvanc/ponyc)
 
-The LLVM prebuilt binaries for Windows do NOT include the LLVM development 
-tools and libraries. Instead, you will have to build and install LLVM 3.7 or 
-3.8 from source. You will need to make sure that the path to LLVM/bin (location 
+The LLVM prebuilt binaries for Windows do NOT include the LLVM development
+tools and libraries. Instead, you will have to build and install LLVM 3.7 or
+3.8 from source. You will need to make sure that the path to LLVM/bin (location
 of llvm-config) is in your PATH variable.
 
-LLVM recommends using the GnuWin32 unix tools; your mileage may vary using 
+LLVM recommends using the GnuWin32 unix tools; your mileage may vary using
 MSYS or Cygwin.
 
-- Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/) 
+- Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/)
   tool.
-- Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or 
+- Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or
   2.7).
 - Install [CMake](https://cmake.org/download/).
-- Get the LLVM source (e.g. 3.7.1 is 
+- Get the LLVM source (e.g. 3.7.1 is
   at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
 - Make sure you have VS2015 with the C++ tools installed.
-- Generate LLVM VS2015 configuration with CMake. You can use the GUI to 
-  configure and generate the VS projects; make sure you use the 64-bit 
-  generator (**Visual Studio 14 2015 Win64**), and set the 
+- Generate LLVM VS2015 configuration with CMake. You can use the GUI to
+  configure and generate the VS projects; make sure you use the 64-bit
+  generator (**Visual Studio 14 2015 Win64**), and set the
   `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
-- Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in 
+- Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in
   the LLVM solution in Release mode.
 
 Building Pony requires [Premake 5](https://premake.github.io).
@@ -212,15 +217,15 @@ Building Pony requires [Premake 5](https://premake.github.io).
   solution.
 - Build ponyc.sln in Release mode.
 
-In order to run the pony compiler, you'll need a few libraries in your 
-environment (pcre2, libssl, libcrypto). 
+In order to run the pony compiler, you'll need a few libraries in your
+environment (pcre2, libssl, libcrypto).
 
-There is a third-party utility that will get the libraries and set up your 
+There is a third-party utility that will get the libraries and set up your
 environment:
 
-- Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in 
+- Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in
   your PATH.
-- Open a **VS2015 x64 Native Tools Command Prompt** (things will not work 
+- Open a **VS2015 x64 Native Tools Command Prompt** (things will not work
   correctly otherwise!) and run:
 
 ```

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -109,8 +109,6 @@ class iso _TestStringRunes is UnitTest
       h.assert_eq[U32](expect(i), result(i))
     end
 
-    true
-
 
 class iso _TestIntToString is UnitTest
   """

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -66,8 +66,6 @@ class iso _TestListsFrom is UnitTest
     let b = List[U32].from(Array[U32])
     h.assert_eq[USize](b.size(), 0)
 
-    true
-
 class iso _TestMap is UnitTest
   fun name(): String => "collections/Map"
 
@@ -181,8 +179,6 @@ class iso _TestListsMap is UnitTest
     h.assert_eq[U32](c(1), 2)
     h.assert_eq[U32](c(2), 4)
 
-    true
-
 class iso _TestListsFlatMap is UnitTest
   fun name(): String => "collections/Lists/flat_map()"
 
@@ -201,8 +197,6 @@ class iso _TestListsFlatMap is UnitTest
     h.assert_eq[U32](c(4), 2)
     h.assert_eq[U32](c(5), 4)
 
-    true
-
 class iso _TestListsFilter is UnitTest
   fun name(): String => "collections/Lists/filter()"
 
@@ -216,8 +210,6 @@ class iso _TestListsFilter is UnitTest
     h.assert_eq[USize](b.size(), 2)
     h.assert_eq[U32](b(0), 2)
     h.assert_eq[U32](b(1), 3)
-
-    true
 
 class iso _TestListsFold is UnitTest
   fun name(): String => "collections/Lists/fold()"
@@ -239,8 +231,6 @@ class iso _TestListsFold is UnitTest
     h.assert_eq[U32](resList(1), 2)
     h.assert_eq[U32](resList(2), 4)
     h.assert_eq[U32](resList(3), 6)
-
-    true
 
 class iso _TestListsEvery is UnitTest
   fun name(): String => "collections/Lists/every()"
@@ -264,8 +254,6 @@ class iso _TestListsEvery is UnitTest
     let empty = b.every(f)
     h.assert_eq[Bool](empty, true)
 
-    true
-
 class iso _TestListsExists is UnitTest
   fun name(): String => "collections/Lists/exists()"
 
@@ -287,8 +275,6 @@ class iso _TestListsExists is UnitTest
     let b = List[U32]
     let empty = b.exists(f)
     h.assert_eq[Bool](empty, false)
-
-    true
 
 class iso _TestListsPartition is UnitTest
   fun name(): String => "collections/Lists/partition()"
@@ -313,8 +299,6 @@ class iso _TestListsPartition is UnitTest
     h.assert_eq[USize](emptyEvens.size(), 0)
     h.assert_eq[USize](emptyOdds.size(), 0)
 
-    true
-
 class iso _TestListsDrop is UnitTest
   fun name(): String => "collections/Lists/drop()"
 
@@ -338,8 +322,6 @@ class iso _TestListsDrop is UnitTest
     let empty = List[U32]
     let l = empty.drop(3)
     h.assert_eq[USize](l.size(), 0)
-
-    true
 
 class iso _TestListsTake is UnitTest
   fun name(): String => "collections/Lists/take()"
@@ -380,8 +362,6 @@ class iso _TestListsTake is UnitTest
     let l = empty.take(3)
     h.assert_eq[USize](l.size(), 0)
 
-    true
-
 class iso _TestListsTakeWhile is UnitTest
   fun name(): String => "collections/Lists/take_while()"
 
@@ -417,8 +397,6 @@ class iso _TestListsTakeWhile is UnitTest
     let l = empty.take_while(g)
     h.assert_eq[USize](l.size(), 0)
 
-    true
-
 class iso _TestListsContains is UnitTest
   fun name(): String => "collections/Lists/contains()"
 
@@ -430,8 +408,6 @@ class iso _TestListsContains is UnitTest
     h.assert_eq[Bool](a.contains(1), true)
     h.assert_eq[Bool](a.contains(2), true)
     h.assert_eq[Bool](a.contains(3), false)
-
-    true
 
 class iso _TestListsReverse is UnitTest
   fun name(): String => "collections/Lists/reverse()"
@@ -451,8 +427,6 @@ class iso _TestListsReverse is UnitTest
     h.assert_eq[U32](b(0), 2)
     h.assert_eq[U32](b(1), 1)
     h.assert_eq[U32](b(2), 0)
-
-    true
 
 class iso _TestHashSetContains is UnitTest
   fun name(): String => "collections/HashSet/contains()"
@@ -478,5 +452,3 @@ class iso _TestHashSetContains is UnitTest
     // And resetting an element should cause it to be found again
     a.set(0)
     h.assert_true(a.contains(0), not_found_fail)
-
-    true

--- a/packages/net/ssl/sslinit.pony
+++ b/packages/net/ssl/sslinit.pony
@@ -8,7 +8,7 @@ primitive _SSLInit
   """
   This initialises SSL when the program begins.
   """
-  fun _init(env: Env) =>
+  fun _init() =>
     @SSL_load_error_strings[None]()
     @SSL_library_init[I32]()
     let cb = @ponyint_ssl_multithreading[Pointer[U8]](@CRYPTO_num_locks[I32]())

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -38,13 +38,8 @@ static bool need_primitive_call(compile_t* c, const char* method)
   return false;
 }
 
-static void primitive_call(compile_t* c, const char* method, LLVMValueRef arg)
+static void primitive_call(compile_t* c, const char* method)
 {
-  size_t count = 1;
-
-  if(arg != NULL)
-    count++;
-
   size_t i = HASHMAP_BEGIN;
   reachable_type_t* t;
 
@@ -58,11 +53,7 @@ static void primitive_call(compile_t* c, const char* method, LLVMValueRef arg)
     if(m == NULL)
       continue;
 
-    LLVMValueRef args[2];
-    args[0] = t->instance;
-    args[1] = arg;
-
-    codegen_call(c, m->func, args, count);
+    codegen_call(c, m->func, &t->instance, 1);
   }
 }
 
@@ -127,7 +118,7 @@ static void gen_main(compile_t* c, reachable_type_t* t_main,
   LLVMSetInstructionCallConv(env, c->callconv);
 
   // Run primitive initialisers using the main actor's heap.
-  primitive_call(c, c->str__init, env);
+  primitive_call(c, c->str__init);
 
   // Create a type for the message.
   LLVMTypeRef f_params[4];
@@ -180,7 +171,7 @@ static void gen_main(compile_t* c, reachable_type_t* t_main,
   if(need_primitive_call(c, c->str__final))
   {
     LLVMValueRef final_actor = create_main(c, t_main, ctx);
-    primitive_call(c, c->str__final, NULL);
+    primitive_call(c, c->str__final);
     args[0] = final_actor;
     gencall_runtime(c, "ponyint_destroy", args, 1, "");
   }

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -1208,23 +1208,10 @@ static bool check_primitive_init(typecheck_t* t, ast_t* ast)
     ok = false;
   }
 
-  if(ast_childcount(params) != 1)
+  if(ast_childcount(params) != 0)
   {
-    ast_error(params, "a primitive _init must take a single Env parameter");
+    ast_error(params, "a primitive _init must take no parameters");
     ok = false;
-  }
-
-  ast_t* param = ast_child(params);
-
-  if(param != NULL)
-  {
-    ast_t* p_type = ast_childidx(param, 1);
-
-    if(!is_env(p_type))
-    {
-      ast_error(p_type, "must be of type Env");
-      ok = false;
-    }
   }
 
   if(!is_none(result))


### PR DESCRIPTION
As discussed in Issue #649 I've changed the README.md file to update the LLVM install instructions for Linux using the recently updated builds in the LLVM APT repository.

I left the instructions for Debian unchanged since I haven't actually tested that, but I think they are probably exactly the same now as for Ubuntu and could be redundant.

I can submit a separate pull request for the instructions in the tutorial if these are ok.