### PR TITLE
Primitive _init now takes no arguments

### DIFF
--- a/packages/net/ssl/sslinit.pony
+++ b/packages/net/ssl/sslinit.pony
@@ -8,7 +8,7 @@ primitive _SSLInit
   """
   This initialises SSL when the program begins.
   """
-  fun _init(env: Env) =>
+  fun _init() =>
     @SSL_load_error_strings[None]()
     @SSL_library_init[I32]()
     let cb = @ponyint_ssl_multithreading[Pointer[U8]](@CRYPTO_num_locks[I32]())

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -38,13 +38,8 @@ static bool need_primitive_call(compile_t* c, const char* method)
   return false;
 }
 
-static void primitive_call(compile_t* c, const char* method, LLVMValueRef arg)
+static void primitive_call(compile_t* c, const char* method)
 {
-  size_t count = 1;
-
-  if(arg != NULL)
-    count++;
-
   size_t i = HASHMAP_BEGIN;
   reachable_type_t* t;
 
@@ -58,11 +53,7 @@ static void primitive_call(compile_t* c, const char* method, LLVMValueRef arg)
     if(m == NULL)
       continue;
 
-    LLVMValueRef args[2];
-    args[0] = t->instance;
-    args[1] = arg;
-
-    codegen_call(c, m->func, args, count);
+    codegen_call(c, m->func, &t->instance, 1);
   }
 }
 
@@ -127,7 +118,7 @@ static void gen_main(compile_t* c, reachable_type_t* t_main,
   LLVMSetInstructionCallConv(env, c->callconv);
 
   // Run primitive initialisers using the main actor's heap.
-  primitive_call(c, c->str__init, env);
+  primitive_call(c, c->str__init);
 
   // Create a type for the message.
   LLVMTypeRef f_params[4];
@@ -180,7 +171,7 @@ static void gen_main(compile_t* c, reachable_type_t* t_main,
   if(need_primitive_call(c, c->str__final))
   {
     LLVMValueRef final_actor = create_main(c, t_main, ctx);
-    primitive_call(c, c->str__final, NULL);
+    primitive_call(c, c->str__final);
     args[0] = final_actor;
     gencall_runtime(c, "ponyint_destroy", args, 1, "");
   }

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -1208,23 +1208,10 @@ static bool check_primitive_init(typecheck_t* t, ast_t* ast)
     ok = false;
   }
 
-  if(ast_childcount(params) != 1)
+  if(ast_childcount(params) != 0)
   {
-    ast_error(params, "a primitive _init must take a single Env parameter");
+    ast_error(params, "a primitive _init must take no parameters");
     ok = false;
-  }
-
-  ast_t* param = ast_child(params);
-
-  if(param != NULL)
-  {
-    ast_t* p_type = ast_childidx(param, 1);
-
-    if(!is_env(p_type))
-    {
-      ast_error(p_type, "must be of type Env");
-      ok = false;
-    }
   }
 
   if(!is_none(result))

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -10,7 +10,11 @@
 static ast_result_t flatten_union(ast_t** astp)
 {
   ast_t* ast = *astp;
-  assert(ast_childcount(ast) == 2);
+
+  // If there are more than 2 children, this has already been flattened.
+  if(ast_childcount(ast) > 2)
+    return AST_OK;
+
   AST_EXTRACT_CHILDREN(ast, left, right);
 
   ast_t* r_ast = type_union(left, right);
@@ -44,7 +48,10 @@ static ast_result_t flatten_isect(typecheck_t* t, ast_t* ast)
 {
   // Flatten intersections without testing subtyping. This is to preserve any
   // type guarantees that an element in the intersection might make.
-  assert(ast_childcount(ast) == 2);
+  // If there are more than 2 children, this has already been flattened.
+  if(ast_childcount(ast) > 2)
+    return AST_OK;
+
   AST_EXTRACT_CHILDREN(ast, left, right);
 
   if((t->frame->constraint == NULL) &&


### PR DESCRIPTION
As pointed out by @dckc, primitive _init taking an Env as an
argument gives ambient authority to any package declaring a
primitive with an _init function. Since these functions are
meant primarily for initialising FFI libraries, access to Env
isn't needed. If a use case appears where some part of Env is
needed, this can be revisited.