### PR TITLE
Add `from_tuples()` and `from_array` to HashMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `ArrayValues.rewind()` method.
 - Nanos primitive in time package.
 - Persistent package, with List and Map
+- `from_tuples()` and `from_array()` methods on HashMap
 
 ### Changed
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -30,6 +30,31 @@ class HashMap[K, V, H: HashFunction[K] val]
     let n = len.ponyint_next_pow2().max(8)
     _array = _array.init(_MapEmpty, n)
 
+  new from_tuples(keys_values: Array[(K^, V^)]) ? =>
+    """
+    Create a map from an array of key/value pair tuples.
+    """  
+    let len = (keys_values.size() * 4) / 3
+    let n = len.ponyint_next_pow2().max(8)
+    _array = _array.init(_MapEmpty, n)
+    for (key, value) in keys_values.values() do
+      insert(consume key, consume value)
+    end
+
+  new from_array(keys_values: Array[(K^ | V^)]) ? =>
+    """
+    Create a map from an array of alternating keys and values. If the
+    array has an odd number of elements the last element will be
+    ignored.
+    """
+    let pairs_count = keys_values.size() / 2
+    let n = pairs_count.ponyint_next_pow2().max(8)
+    _array = _array.init(_MapEmpty, n)
+    let kv = keys_values.values()
+    for i in Range[USize](0, pairs_count) do
+      insert(keys_values(i * 2) as K^, keys_values((i * 2) + 1) as V^)
+    end
+
   fun size(): USize =>
     """
     The number of items in the map.

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -7,6 +7,8 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     test(_TestList)
     test(_TestMap)
+    test(_TestMapFromTuples)
+    test(_TestMapFromArray)
     test(_TestMapRemove)
     test(_TestRing)
     test(_TestListsFrom)
@@ -121,6 +123,28 @@ class iso _TestMap is UnitTest
     b.clear()
     h.assert_eq[USize](0, b.size())
     h.assert_eq[USize](8, b.space())
+
+class iso _TestMapFromTuples is UnitTest
+  fun name(): String => "collections/Map.from_tuples([(K, V)])"
+
+  fun apply(h: TestHelper) ? =>
+    let a = Map[String, U32].from_tuples([("a", 1),
+                                          ("b", 2)])
+
+    h.assert_eq[USize](2, a.size())
+    h.assert_eq[U32](1, a("a"))
+    h.assert_eq[U32](2, a("b"))
+    
+class iso _TestMapFromArray is UnitTest
+  fun name(): String => "collections/Map.from_array([K, V])"
+
+  fun apply(h: TestHelper) ? =>
+    let a = Map[String, U32].from_array(["a", 1,
+                                         "b", 2])
+
+    h.assert_eq[USize](2, a.size())
+    h.assert_eq[U32](1, a("a"))
+    h.assert_eq[U32](2, a("b"))
 
 class iso _TestMapRemove is UnitTest
   fun name(): String => "collections/Map.remove"


### PR DESCRIPTION
This commit adds the constructors `from_tuples()` and `from_array` to
the HashMap class. There are probably several arguments for having
convenience functions like this, but the primary motivation for this
was the question of whether or not Pony had sugar for creating
maps. In the interest of keeping sugar to a minimum I think this is
the next best thing.

`from_tuples()` creates a HashMap from an array of tuples of key/value
pairs.

`from_array()` creates a HashMap from an array of alternating keys and
values.