### PR TITLE
Add `from()` method to HashSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `ArrayValues.rewind()` method.
 - Nanos primitive in time package.
 - Persistent package, with List and Map
+- `from()` method on HashSet
 
 ### Changed
 

--- a/packages/collections/set.pony
+++ b/packages/collections/set.pony
@@ -15,6 +15,15 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     _map = _map.create(prealloc)
 
+  new from(items: Array[A^]) =>
+    """
+    Create a set from an array of values.
+    """
+    _map = _map.create(items.size())
+    for item in items.values() do
+      set(consume item)
+    end
+
   fun size(): USize =>
     """
     The number of items in the set.

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -22,6 +22,7 @@ actor Main is TestList
     test(_TestListsTakeWhile)
     test(_TestListsContains)
     test(_TestListsReverse)
+    test(_TestHashSetFrom)
     test(_TestHashSetContains)
 
 class iso _TestList is UnitTest
@@ -427,6 +428,22 @@ class iso _TestListsReverse is UnitTest
     h.assert_eq[U32](b(0), 2)
     h.assert_eq[U32](b(1), 1)
     h.assert_eq[U32](b(2), 0)
+
+class iso _TestHashSetFrom is UnitTest
+  fun name(): String => "collections/HashSet/from()"
+
+  fun apply(h: TestHelper) =>
+    let a = Set[U32].from([1, 2, 3, 4, 5, 5, 6])
+
+    let not_found_fail = "contains did not find expected element in HashSet"
+
+    h.assert_eq[USize](6, a.size())
+    h.assert_true(a.contains(1), not_found_fail)
+    h.assert_true(a.contains(2), not_found_fail)
+    h.assert_true(a.contains(3), not_found_fail)
+    h.assert_true(a.contains(4), not_found_fail)
+    h.assert_true(a.contains(5), not_found_fail)
+    h.assert_true(a.contains(6), not_found_fail)
 
 class iso _TestHashSetContains is UnitTest
   fun name(): String => "collections/HashSet/contains()"


### PR DESCRIPTION
This commit adds a `from()` constructor to HashSet. It takes an array
of values as an argument, and adds the values to the
HashSet. Duplicate values in the array are ignored, which is
consistent with calling `set()` with a duplicate value.