### PR TITLE
Refactor error handling to carry state explicitly (not globally).

### DIFF
--- a/src/common/vcvars.h
+++ b/src/common/vcvars.h
@@ -1,6 +1,8 @@
 #ifndef PLATFORM_VCVARS_H
 #define PLATFORM_VCVARS_H
 
+typedef struct errors_t errors_t;
+
 typedef struct vcvars_t
 {
   char link[MAX_PATH];
@@ -9,6 +11,6 @@ typedef struct vcvars_t
   char msvcrt[MAX_PATH];
 } vcvars_t;
 
-bool vcvars_get(vcvars_t* vcvars);
+bool vcvars_get(vcvars_t* vcvars, errors_t* errors);
 
 #endif

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -113,7 +113,8 @@ void ast_consolidate_branches(ast_t* ast, size_t count);
 bool ast_canmerge(ast_t* dst, ast_t* src);
 bool ast_merge(ast_t* dst, ast_t* src);
 bool ast_within_scope(ast_t* outer, ast_t* inner, const char* name);
-bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner);
+bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner,
+  errorframe_t* errorf);
 void ast_clear(ast_t* ast);
 void ast_clear_local(ast_t* ast);
 
@@ -137,8 +138,10 @@ void ast_fprintverbose(FILE* fp, ast_t* ast);
 const char* ast_print_type(ast_t* type);
 void ast_setwidth(size_t w);
 
-void ast_error(ast_t* ast, const char* fmt, ...)
-  __attribute__((format(printf, 2, 3)));
+void ast_error(errors_t* errors, ast_t* ast, const char* fmt, ...)
+  __attribute__((format(printf, 3, 4)));
+void ast_error_continue(errors_t* errors, ast_t* ast, const char* fmt, ...)
+  __attribute__((format(printf, 3, 4)));
 void ast_error_frame(errorframe_t* frame, ast_t* ast, const char* fmt, ...)
   __attribute__((format(printf, 3, 4)));
 

--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -1,5 +1,6 @@
 #include "frame.h"
 #include "ast.h"
+#include "error.h"
 #include "../../libponyrt/mem/pool.h"
 #include <string.h>
 #include <assert.h>

--- a/src/libponyc/ast/frame.h
+++ b/src/libponyc/ast/frame.h
@@ -5,6 +5,8 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct errors_t errors_t;
+
 typedef struct typecheck_frame_t
 {
   ast_t* package;
@@ -46,6 +48,7 @@ typedef struct typecheck_t
 {
   typecheck_frame_t* frame;
   typecheck_stats_t stats;
+  errors_t* errors;
 } typecheck_t;
 
 bool frame_push(typecheck_t* t, ast_t* ast);

--- a/src/libponyc/ast/id.c
+++ b/src/libponyc/ast/id.c
@@ -3,7 +3,7 @@
 #include "id_internal.h"
 
 
-bool check_id(ast_t* id_node, const char* desc, int spec)
+bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec)
 {
   assert(id_node != NULL);
   assert(ast_id(id_node) == TK_ID);
@@ -28,7 +28,8 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
 
     if((spec & ALLOW_LEADING_UNDERSCORE) == 0)
     {
-      ast_error(id_node, "%s name \"%s\" cannot start with underscores", desc,
+      ast_error(opt->check.errors, id_node,
+        "%s name \"%s\" cannot start with underscores", desc,
         ast_name(id_node));
       return false;
     }
@@ -36,15 +37,15 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
 
   if((spec & START_LOWER) != 0 && (*name < 'a' || *name > 'z'))
   {
-    ast_error(id_node, "%s name \"%s\" must start a-z or _(a-z)", desc,
-      ast_name(id_node));
+    ast_error(opt->check.errors, id_node,
+      "%s name \"%s\" must start a-z or _(a-z)", desc, ast_name(id_node));
     return false;
   }
 
   if((spec & START_UPPER) != 0 && (*name < 'A' || *name > 'Z'))
   {
-    ast_error(id_node, "%s name \"%s\" must start A-Z or _(A-Z)", desc,
-      ast_name(id_node));
+    ast_error(opt->check.errors, id_node,
+      "%s name \"%s\" must start A-Z or _(A-Z)", desc, ast_name(id_node));
     return false;
   }
 
@@ -55,15 +56,16 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
     {
       if((spec & ALLOW_UNDERSCORE) == 0)
       {
-        ast_error(id_node, "%s name \"%s\" cannot contain underscores", desc,
-          ast_name(id_node));
+        ast_error(opt->check.errors, id_node,
+          "%s name \"%s\" cannot contain underscores", desc, ast_name(id_node));
         return false;
       }
 
       if(prev == '_')
       {
-        ast_error(id_node, "%s name \"%s\" cannot contain double underscores",
-          desc, ast_name(id_node));
+        ast_error(opt->check.errors, id_node,
+          "%s name \"%s\" cannot contain double underscores", desc,
+          ast_name(id_node));
         return false;
       }
     }
@@ -76,8 +78,8 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
   // Check for ending with _
   if(prev == '_')
   {
-    ast_error(id_node, "%s name \"%s\" cannot end with underscores", desc,
-      ast_name(id_node));
+    ast_error(opt->check.errors, id_node,
+      "%s name \"%s\" cannot end with underscores", desc, ast_name(id_node));
     return false;
   }
 
@@ -89,8 +91,8 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
 
   if((spec & ALLOW_TICK) == 0)
   {
-    ast_error(id_node, "%s name \"%s\" cannot contain prime (')", desc,
-      ast_name(id_node));
+    ast_error(opt->check.errors, id_node,
+      "%s name \"%s\" cannot contain prime (')", desc, ast_name(id_node));
     return false;
   }
 
@@ -98,7 +100,7 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
   {
     if(*name != '\'')
     {
-      ast_error(id_node,
+      ast_error(opt->check.errors, id_node,
         "prime(') can only appear at the end of %s name \"%s\"", desc,
         ast_name(id_node));
       return false;
@@ -109,52 +111,52 @@ bool check_id(ast_t* id_node, const char* desc, int spec)
 }
 
 
-bool check_id_type(ast_t* id_node, const char* entity_desc)
+bool check_id_type(pass_opt_t* opt, ast_t* id_node, const char* entity_desc)
 {
   // _?[A-Z][A-Za-z0-9]*
-  return check_id(id_node, entity_desc,
+  return check_id(opt, id_node, entity_desc,
     START_UPPER | ALLOW_LEADING_UNDERSCORE);
 }
 
-bool check_id_type_param(ast_t* id_node)
+bool check_id_type_param(pass_opt_t* opt, ast_t* id_node)
 {
   // [A-Z][A-Za-z0-9]*
-  return check_id(id_node, "type parameter",
+  return check_id(opt, id_node, "type parameter",
     START_UPPER);
 }
 
-bool check_id_package(ast_t* id_node)
+bool check_id_package(pass_opt_t* opt, ast_t* id_node)
 {
   // [a-z][A-Za-z0-9_]* (and no double or trailing underscores)
-  return check_id(id_node, "package",
+  return check_id(opt, id_node, "package",
     START_LOWER | ALLOW_UNDERSCORE);
 }
 
-bool check_id_field(ast_t* id_node)
+bool check_id_field(pass_opt_t* opt, ast_t* id_node)
 {
   // _?[a-z][A-Za-z0-9_]* (and no double or trailing underscores)
-  return check_id(id_node, "field",
+  return check_id(opt, id_node, "field",
     START_LOWER | ALLOW_LEADING_UNDERSCORE | ALLOW_UNDERSCORE | ALLOW_TICK);
 }
 
-bool check_id_method(ast_t* id_node)
+bool check_id_method(pass_opt_t* opt, ast_t* id_node)
 {
   // _?[a-z][A-Za-z0-9_]* (and no double or trailing underscores)
-  return check_id(id_node, "method",
+  return check_id(opt, id_node, "method",
     START_LOWER | ALLOW_LEADING_UNDERSCORE | ALLOW_UNDERSCORE);
 }
 
-bool check_id_param(ast_t* id_node)
+bool check_id_param(pass_opt_t* opt, ast_t* id_node)
 {
   // [a-z][A-Za-z0-9_]*'* (and no double or trailing underscores)
-  return check_id(id_node, "parameter",
+  return check_id(opt, id_node, "parameter",
     START_LOWER | ALLOW_UNDERSCORE | ALLOW_TICK);
 }
 
-bool check_id_local(ast_t* id_node)
+bool check_id_local(pass_opt_t* opt, ast_t* id_node)
 {
   // [a-z][A-Za-z0-9_]*'* (and no double or trailing underscores)
-  return check_id(id_node, "local variable",
+  return check_id(opt, id_node, "local variable",
     START_LOWER | ALLOW_UNDERSCORE | ALLOW_TICK);
 }
 

--- a/src/libponyc/ast/id.h
+++ b/src/libponyc/ast/id.h
@@ -3,36 +3,37 @@
 
 #include <platform.h>
 #include "ast.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
 /// Check that the name in the given ID node is valid for an entity.
 /// If name is illegal an error will be generated.
-bool check_id_type(ast_t* id_node, const char* entity_desc);
+bool check_id_type(pass_opt_t* opt, ast_t* id_node, const char* entity_desc);
 
 /// Check that the name in the given ID node is valid for a type parameter.
 /// If name is illegal an error will be generated.
-bool check_id_type_param(ast_t* id_node);
+bool check_id_type_param(pass_opt_t* opt, ast_t* id_node);
 
 /// Check that the name in the given ID node is valid for a package.
 /// If name is illegal an error will be generated.
-bool check_id_package(ast_t* id_node);
+bool check_id_package(pass_opt_t* opt, ast_t* id_node);
 
 /// Check that the name in the given ID node is valid for a field.
 /// If name is illegal an error will be generated.
-bool check_id_field(ast_t* id_node);
+bool check_id_field(pass_opt_t* opt, ast_t* id_node);
 
 /// Check that the name in the given ID node is valid for a method.
 /// If name is illegal an error will be generated.
-bool check_id_method(ast_t* id_node);
+bool check_id_method(pass_opt_t* opt, ast_t* id_node);
 
 /// Check that the name in the given ID node is valid for a parameter.
 /// If name is illegal an error will be generated.
-bool check_id_param(ast_t* id_node);
+bool check_id_param(pass_opt_t* opt, ast_t* id_node);
 
 /// Check that the name in the given ID node is valid for a local.
 /// If name is illegal an error will be generated.
-bool check_id_local(ast_t* id_node);
+bool check_id_local(pass_opt_t* opt, ast_t* id_node);
 
 /// Report whether the given id name is a type name
 bool is_name_type(const char* name);

--- a/src/libponyc/ast/id_internal.h
+++ b/src/libponyc/ast/id_internal.h
@@ -5,6 +5,7 @@
 
 #include <platform.h>
 #include "ast.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -20,7 +21,7 @@ PONY_EXTERN_C_BEGIN
  * If name is illegal an error will be generated.
  * The spec is supplied as a set of the above #defined flags.
  */
- bool check_id(ast_t* id_node, const char* desc, int spec);
+ bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -1,3 +1,4 @@
+#include "error.h"
 #include "lexer.h"
 #include "lexint.h"
 #include "token.h"
@@ -13,6 +14,7 @@
 struct lexer_t
 {
   source_t* source;
+  errors_t* errors;
 
   // Information about next unused character in file
   size_t ptr;
@@ -297,7 +299,7 @@ static void lex_error_at(lexer_t* lexer, size_t line, size_t pos,
 {
   va_list ap;
   va_start(ap, fmt);
-  errorv(lexer->source, line, pos, fmt, ap);
+  errorv(lexer->errors, lexer->source, line, pos, fmt, ap);
   va_end(ap);
 }
 
@@ -307,7 +309,8 @@ static void lex_error(lexer_t* lexer, const char* fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  errorv(lexer->source, lexer->token_line, lexer->token_pos, fmt, ap);
+  errorv(lexer->errors, lexer->source, lexer->token_line, lexer->token_pos,
+    fmt, ap);
   va_end(ap);
 }
 
@@ -1160,7 +1163,7 @@ static token_t* symbol(lexer_t* lexer)
 }
 
 
-lexer_t* lexer_open(source_t* source)
+lexer_t* lexer_open(source_t* source, errors_t* errors)
 {
   assert(source != NULL);
 
@@ -1168,6 +1171,7 @@ lexer_t* lexer_open(source_t* source)
   memset(lexer, 0, sizeof(lexer_t));
 
   lexer->source = source;
+  lexer->errors = errors;
   lexer->len = source->len;
   lexer->line = 1;
   lexer->pos = 1;

--- a/src/libponyc/ast/lexer.h
+++ b/src/libponyc/ast/lexer.h
@@ -9,6 +9,7 @@
 PONY_EXTERN_C_BEGIN
 
 typedef struct lexer_t lexer_t;
+typedef struct errors_t errors_t;
 
 /** Allow test symbols to be generated in all lexers.
  * Should only be used for unit tests.
@@ -19,7 +20,7 @@ void lexer_allow_test_symbols();
  * The created lexer must be freed later with lexer_close().
  * Never returns NULL.
  */
-lexer_t* lexer_open(source_t* source);
+lexer_t* lexer_open(source_t* source, errors_t* errors);
 
 /** Free a previously opened lexer.
  * The lexer argument may be NULL.

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -1068,9 +1068,10 @@ DEF(module);
 #ifdef PARSER
 
 // external API
-bool pass_parse(ast_t* package, source_t* source)
+bool pass_parse(ast_t* package, source_t* source, errors_t* errors)
 {
-  return parse(package, source, module, "class, actor, primitive or trait");
+  return parse(package, source, module, "class, actor, primitive or trait",
+    errors);
 }
 
 #endif

--- a/src/libponyc/ast/parser.h
+++ b/src/libponyc/ast/parser.h
@@ -4,6 +4,6 @@
 #include "ast.h"
 #include "source.h"
 
-bool pass_parse(ast_t* package, source_t* source);
+bool pass_parse(ast_t* package, source_t* source, errors_t* errors);
 
 #endif

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -137,8 +137,8 @@ void parse_trace(bool enable);
  * The given source is attached to the resulting AST on success and closed on
  * failure.
  */
-bool parse(ast_t* package, source_t* source, rule_t start,
-  const char* expected);
+bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
+  errors_t* errors);
 
 
 /* The API for parser rules starts here */

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -6,13 +6,13 @@
 #include <string.h>
 #include <stdio.h>
 
-source_t* source_open(const char* file)
+source_t* source_open(const char* file, const char** error_msgp)
 {
   FILE* fp = fopen(file, "rb");
 
   if(fp == NULL)
   {
-    errorf(file, "can't open file");
+    *error_msgp = "can't open file";
     return NULL;
   }
 
@@ -21,7 +21,7 @@ source_t* source_open(const char* file)
 
   if(size < 0)
   {
-    errorf(file, "can't determine length of file");
+    *error_msgp = "can't determine length of file";
     fclose(fp);
     return NULL;
   }
@@ -37,7 +37,7 @@ source_t* source_open(const char* file)
 
   if(read < size)
   {
-    errorf(file, "failed to read entire file");
+    *error_msgp = "failed to read entire file";
     ponyint_pool_free_size(source->len, source->m);
     POOL_FREE(source_t, source);
     fclose(fp);

--- a/src/libponyc/ast/source.h
+++ b/src/libponyc/ast/source.h
@@ -17,7 +17,7 @@ typedef struct source_t
  * Returns the opened source which must be closed later,
  * NULL on failure.
  */
-source_t* source_open(const char* file);
+source_t* source_open(const char* file, const char** error_msgp);
 
 /** Create a source based on the given string of code.
  * Intended for testing purposes only.

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -270,7 +270,7 @@ bool symtab_merge_public(symtab_t* dst, symtab_t* src)
   return true;
 }
 
-bool symtab_check_all_defined(symtab_t* symtab)
+bool symtab_check_all_defined(symtab_t* symtab, errors_t* errors)
 {
   bool r = true;
   size_t i = HASHMAP_BEGIN;
@@ -282,7 +282,7 @@ bool symtab_check_all_defined(symtab_t* symtab)
     // this scope
     if(sym->def != NULL && sym->status == SYM_UNDEFINED)
     {
-      ast_error(sym->def,
+      ast_error(errors, sym->def,
         "Local variable %s is not assigned a value in all code paths", sym->name);
       r = false;
     }

--- a/src/libponyc/ast/symtab.h
+++ b/src/libponyc/ast/symtab.h
@@ -7,6 +7,7 @@
 PONY_EXTERN_C_BEGIN
 
 typedef struct ast_t ast_t;
+typedef struct errors_t errors_t;
 
 typedef enum
 {
@@ -58,7 +59,7 @@ bool symtab_can_merge_public(symtab_t* dst, symtab_t* src);
 
 bool symtab_merge_public(symtab_t* dst, symtab_t* src);
 
-bool symtab_check_all_defined(symtab_t* symtab);
+bool symtab_check_all_defined(symtab_t* symtab, errors_t* errors);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -4,7 +4,6 @@
 #include <platform.h>
 
 #include "lexint.h"
-#include "error.h"
 #include "source.h"
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/libponyc/ast/treecheck.h
+++ b/src/libponyc/ast/treecheck.h
@@ -6,12 +6,9 @@
 
 PONY_EXTERN_C_BEGIN
 
-// Enable or disable tree checking
-void enable_check_tree(bool enable);
-
 // Check that the given AST is well formed.
 // Does nothing in release builds of the compiler.
-void check_tree(ast_t* tree);
+void check_tree(ast_t* tree, errors_t* errors);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -41,8 +41,7 @@ DEFINE_HASHMAP(compile_locals, compile_locals_t, compile_local_t,
 
 static void fatal_error(const char* reason)
 {
-  printf("%s\n", reason);
-  print_errors();
+  printf("LLVM fatal error: %s\n", reason);
 }
 
 static compile_frame_t* push_frame(compile_t* c)
@@ -74,7 +73,7 @@ static LLVMTargetMachineRef make_machine(pass_opt_t* opt)
 
   if(LLVMGetTargetFromTriple(opt->triple, &target, &err) != 0)
   {
-    errorf(NULL, "couldn't create target: %s", err);
+    errorf(opt->check.errors, NULL, "couldn't create target: %s", err);
     LLVMDisposeMessage(err);
     return NULL;
   }
@@ -90,7 +89,7 @@ static LLVMTargetMachineRef make_machine(pass_opt_t* opt)
 
   if(machine == NULL)
   {
-    errorf(NULL, "couldn't create target machine");
+    errorf(opt->check.errors, NULL, "couldn't create target machine");
     return NULL;
   }
 
@@ -769,7 +768,7 @@ LLVMValueRef codegen_call(compile_t* c, LLVMValueRef fun, LLVMValueRef* args,
   return result;
 }
 
-const char* suffix_filename(const char* dir, const char* prefix,
+const char* suffix_filename(compile_t* c, const char* dir, const char* prefix,
   const char* file, const char* extension)
 {
   // Copy to a string with space for a suffix.
@@ -806,7 +805,7 @@ const char* suffix_filename(const char* dir, const char* prefix,
 
   if(suffix >= 100)
   {
-    errorf(NULL, "couldn't pick an unused file name");
+    errorf(c->opt->check.errors, NULL, "couldn't pick an unused file name");
     ponyint_pool_free_size(len, filename);
     return NULL;
   }

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -193,7 +193,7 @@ LLVMBasicBlockRef codegen_block(compile_t* c, const char* name);
 LLVMValueRef codegen_call(compile_t* c, LLVMValueRef fun, LLVMValueRef* args,
   size_t count);
 
-const char* suffix_filename(const char* dir, const char* prefix,
+const char* suffix_filename(compile_t* c, const char* dir, const char* prefix,
   const char* file, const char* extension);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -104,7 +104,7 @@ static LLVMValueRef special_case_platform(compile_t* c, ast_t* ast)
   if(os_is_target(method_name, c->opt->release, &is_target, c->opt))
     return LLVMConstInt(c->i1, is_target ? 1 : 0, false);
 
-  ast_error(ast, "unknown Platform setting");
+  ast_error(c->opt->check.errors, ast, "unknown Platform setting");
   return NULL;
 }
 

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -155,19 +155,20 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_COMPILE_INTRINSIC:
-      ast_error(ast, "unimplemented compile intrinsic");
+      ast_error(c->opt->check.errors, ast, "unimplemented compile intrinsic");
       return NULL;
 
     case TK_COMPILE_ERROR:
     {
       ast_t* reason_seq = ast_child(ast);
       ast_t* reason = ast_child(reason_seq);
-      ast_error(ast, "compile error: %s", ast_name(reason));
+      ast_error(c->opt->check.errors, ast, "compile error: %s",
+        ast_name(reason));
       return NULL;
     }
 
     default:
-      ast_error(ast, "not implemented (codegen unknown)");
+      ast_error(c->opt->check.errors, ast, "not implemented (codegen unknown)");
       return NULL;
   }
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -545,7 +545,7 @@ static bool static_value(compile_t* c, LLVMValueRef value, ast_t* type,
   // Get the type of the right-hand side of the pattern's eq() function.
   ast_t* param_type = eq_param_type(c, pattern);
 
-  if(!is_subtype(type, param_type, NULL))
+  if(!is_subtype(type, param_type, NULL, c->opt))
   {
     // Switch to dynamic value checking.
     assert(LLVMTypeOf(value) == c->object_ptr);
@@ -566,7 +566,7 @@ static bool static_capture(compile_t* c, LLVMValueRef value, ast_t* type,
   if(gen_localdecl(c, pattern) == NULL)
     return false;
 
-  if(!is_subtype(type, pattern_type, NULL))
+  if(!is_subtype(type, pattern_type, NULL, c->opt))
   {
     // Switch to dynamic capture.
     assert(LLVMTypeOf(value) == c->object_ptr);
@@ -722,7 +722,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
     ast_t* pattern_type = ast_type(pattern);
     bool ok = true;
 
-    if(is_matchtype(match_type, pattern_type) != MATCHTYPE_ACCEPT)
+    if(is_matchtype(match_type, pattern_type, c->opt) != MATCHTYPE_ACCEPT)
     {
       // If there's no possible match, jump directly to the next block.
       LLVMBuildBr(c->builder, next_block);

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -107,7 +107,7 @@ LLVMValueRef make_divmod(compile_t* c, ast_t* left, ast_t* right,
     (LLVMConstIntGetSExtValue(r_value) == 0)
     )
   {
-    ast_error(right, "constant divide or mod by zero");
+    ast_error(c->opt->check.errors, right, "constant divide or mod by zero");
     return NULL;
   }
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -913,13 +913,15 @@ void genprim_reachable_init(compile_t* c, ast_t* program)
 
             if(finit != NULL)
             {
-              reach(c->reachable, &c->next_type_id, type, c->str__init, NULL);
+              reach(c->reachable, &c->next_type_id, type, c->str__init, NULL,
+                c->opt);
               ast_free_unattached(finit);
             }
 
             if(ffinal != NULL)
             {
-              reach(c->reachable, &c->next_type_id, type, c->str__final, NULL);
+              reach(c->reachable, &c->next_type_id, type, c->str__final, NULL,
+                c->opt);
               ast_free_unattached(ffinal);
             }
 

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -498,7 +498,7 @@ static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
   LLVMBasicBlockRef is_true = codegen_block(c, "");
   LLVMBasicBlockRef is_false = codegen_block(c, "");
 
-  if(!is_subtype(orig, tuple, NULL))
+  if(!is_subtype(orig, tuple, NULL, c->opt))
   {
     LLVMValueRef dynamic_count = gendesc_fieldcount(c, desc);
     LLVMValueRef static_count = LLVMConstInt(c->i32, cardinality, false);
@@ -613,11 +613,11 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
   {
     // We are a tuple element. Our type is in the correct position in the
     // tuple, everything else is TK_DONTCARE.
-    if(is_matchtype(orig, tuple) != MATCHTYPE_ACCEPT)
+    if(is_matchtype(orig, tuple, c->opt) != MATCHTYPE_ACCEPT)
       return;
   } else {
     // We aren't a tuple element.
-    if(is_matchtype(orig, type) != MATCHTYPE_ACCEPT)
+    if(is_matchtype(orig, type, c->opt) != MATCHTYPE_ACCEPT)
       return;
   }
 

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -32,7 +32,7 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
 
     if(is_control_type(c_type))
     {
-      ast_error(ele,
+      ast_error(opt->check.errors, ele,
         "can't use an expression without a value in an array constructor");
       ast_free_unattached(type);
       return false;
@@ -50,7 +50,7 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
       c_type = ast_type(ele); // May have changed due to literals
 
       errorframe_t info = NULL;
-      if(!is_subtype(c_type, type, &info))
+      if(!is_subtype(c_type, type, &info, opt))
       {
         errorframe_t frame = NULL;
         ast_error_frame(&frame, ele,
@@ -60,7 +60,7 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
         ast_error_frame(&frame, c_type, "element type: %s",
           ast_print_type(c_type));
         errorframe_append(&frame, &info);
-        errorframe_report(&frame);
+        errorframe_report(&frame, opt->check.errors);
         return false;
       }
     }
@@ -74,7 +74,7 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
         return true;
       }
 
-      type = type_union(type, c_type);
+      type = type_union(opt, type, c_type);
     }
   }
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -74,7 +74,7 @@ bool is_this_incomplete(typecheck_t* t, ast_t* ast)
   return false;
 }
 
-static bool check_type_params(ast_t** astp)
+static bool check_type_params(pass_opt_t* opt, ast_t** astp)
 {
   ast_t* lhs = *astp;
   ast_t* type = ast_type(lhs);
@@ -90,19 +90,19 @@ static bool check_type_params(ast_t** astp)
 
   BUILD(typeargs, typeparams, NODE(TK_TYPEARGS));
 
-  if(!reify_defaults(typeparams, typeargs, true))
+  if(!reify_defaults(typeparams, typeargs, true, opt))
   {
     ast_free_unattached(typeargs);
     return false;
   }
 
-  if(!check_constraints(lhs, typeparams, typeargs, true))
+  if(!check_constraints(lhs, typeparams, typeargs, true, opt))
   {
     ast_free_unattached(typeargs);
     return false;
   }
 
-  type = reify(type, typeparams, typeargs);
+  type = reify(type, typeparams, typeargs, opt);
   typeparams = ast_childidx(type, 1);
   ast_replace(&typeparams, ast_from(typeparams, TK_NONE));
 
@@ -112,7 +112,8 @@ static bool check_type_params(ast_t** astp)
   return true;
 }
 
-static bool extend_positional_args(ast_t* params, ast_t* positional)
+static bool extend_positional_args(pass_opt_t* opt, ast_t* params,
+  ast_t* positional)
 {
   // Fill out the positional args to be as long as the param list.
   size_t param_len = ast_childcount(params);
@@ -120,7 +121,7 @@ static bool extend_positional_args(ast_t* params, ast_t* positional)
 
   if(arg_len > param_len)
   {
-    ast_error(positional, "too many arguments");
+    ast_error(opt->check.errors, positional, "too many arguments");
     return false;
   }
 
@@ -134,7 +135,7 @@ static bool extend_positional_args(ast_t* params, ast_t* positional)
   return true;
 }
 
-static bool apply_named_args(ast_t* params, ast_t* positional,
+static bool apply_named_args(pass_opt_t* opt, ast_t* params, ast_t* positional,
   ast_t* namedargs)
 {
   ast_t* namedarg = ast_pop(namedargs);
@@ -161,12 +162,12 @@ static bool apply_named_args(ast_t* params, ast_t* positional,
     {
       if(ast_id(namedarg) == TK_UPDATEARG)
       {
-        ast_error(arg_id,
+        ast_error(opt->check.errors, arg_id,
           "cannot use sugar, update() has no parameter named \"value\"");
         return false;
       }
 
-      ast_error(arg_id, "not a parameter name");
+      ast_error(opt->check.errors, arg_id, "not a parameter name");
       return false;
     }
 
@@ -174,8 +175,10 @@ static bool apply_named_args(ast_t* params, ast_t* positional,
 
     if(ast_id(arg_replace) != TK_NONE)
     {
-      ast_error(arg_id, "named argument is already supplied");
-      ast_error(arg_replace, "supplied argument is here");
+      ast_error(opt->check.errors, arg_id,
+        "named argument is already supplied");
+      ast_error_continue(opt->check.errors, arg_replace,
+        "supplied argument is here");
       return false;
     }
 
@@ -198,7 +201,7 @@ static bool apply_default_arg(pass_opt_t* opt, ast_t* param, ast_t* arg)
 
   if(ast_id(def_arg) == TK_NONE)
   {
-    ast_error(arg, "not enough arguments");
+    ast_error(opt->check.errors, arg, "not enough arguments");
     return false;
   }
 
@@ -261,7 +264,8 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
 
     if(is_control_type(arg_type))
     {
-      ast_error(arg, "can't use a control expression in an argument");
+      ast_error(opt->check.errors, arg,
+        "can't use a control expression in an argument");
       return false;
     }
 
@@ -284,7 +288,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     }
 
     errorframe_t info = NULL;
-    if(!is_subtype(a_type, p_type, &info))
+    if(!is_subtype(a_type, p_type, &info, opt))
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
@@ -292,7 +296,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
         ast_print_type(p_type));
       ast_error_frame(&frame, arg, "argument type: %s", ast_print_type(a_type));
       errorframe_append(&frame, &info);
-      errorframe_report(&frame);
+      errorframe_report(&frame, opt->check.errors);
 
       ast_free_unattached(a_type);
       return false;
@@ -339,7 +343,7 @@ static bool auto_recover_call(ast_t* ast, ast_t* receiver_type,
   return true;
 }
 
-static bool check_receiver_cap(ast_t* ast, bool incomplete)
+static bool check_receiver_cap(pass_opt_t* opt, ast_t* ast, bool incomplete)
 {
   AST_GET_CHILDREN(ast, positional, namedargs, lhs);
 
@@ -406,7 +410,7 @@ static bool check_receiver_cap(ast_t* ast, bool incomplete)
   }
 
   errorframe_t info = NULL;
-  bool ok = is_subtype(a_type, t_type, &info);
+  bool ok = is_subtype(a_type, t_type, &info, opt);
 
   if(!ok)
   {
@@ -419,14 +423,14 @@ static bool check_receiver_cap(ast_t* ast, bool incomplete)
     ast_error_frame(&frame, cap,
       "target type: %s", ast_print_type(t_type));
 
-    if(!can_recover && cap_recover && is_subtype(r_type, t_type, NULL))
+    if(!can_recover && cap_recover && is_subtype(r_type, t_type, NULL, opt))
     {
       ast_error_frame(&frame, ast,
         "this would be possible if the arguments and return value "
         "were all sendable");
     }
 
-    if(incomplete && is_subtype(r_type, t_type, NULL))
+    if(incomplete && is_subtype(r_type, t_type, NULL, opt))
     {
       ast_error_frame(&frame, ast,
         "this would be possible if all the fields of 'this' were assigned to "
@@ -434,7 +438,7 @@ static bool check_receiver_cap(ast_t* ast, bool incomplete)
     }
 
     errorframe_append(&frame, &info);
-    errorframe_report(&frame);
+    errorframe_report(&frame, opt->check.errors);
   }
 
   if(a_type != r_type)
@@ -449,7 +453,7 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
 {
   AST_GET_CHILDREN(ast, positional, namedargs, lhs);
 
-  if(!check_type_params(&lhs))
+  if(!check_type_params(opt, &lhs))
     return false;
 
   ast_t* type = ast_type(lhs);
@@ -459,10 +463,10 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
 
   AST_GET_CHILDREN(type, cap, typeparams, params, result);
 
-  if(!extend_positional_args(params, positional))
+  if(!extend_positional_args(opt, params, positional))
     return false;
 
-  if(!apply_named_args(params, positional, namedargs))
+  if(!apply_named_args(opt, params, positional, namedargs))
     return false;
 
   bool incomplete = is_this_incomplete(&opt->check, ast);
@@ -474,7 +478,7 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
   {
     case TK_FUNREF:
     case TK_FUNAPP:
-      if(!check_receiver_cap(ast, incomplete))
+      if(!check_receiver_cap(opt, ast, incomplete))
         return false;
       break;
 
@@ -518,8 +522,8 @@ static bool method_call(pass_opt_t* opt, ast_t* ast)
   return false;
 }
 
-static token_id partial_application_cap(ast_t* ftype, ast_t* receiver,
-  ast_t* positional)
+static token_id partial_application_cap(pass_opt_t* opt, ast_t* ftype,
+  ast_t* receiver, ast_t* positional)
 {
   // Check if the apply method in the generated object literal can accept a box
   // receiver. If not, it must be a ref receiver. It can accept a box receiver
@@ -530,7 +534,7 @@ static token_id partial_application_cap(ast_t* ftype, ast_t* receiver,
   ast_t* view_type = viewpoint_type(ast_from(type, TK_BOX), type);
   ast_t* need_type = set_cap_and_ephemeral(type, ast_id(cap), TK_NONE);
 
-  bool ok = is_subtype(view_type, need_type, NULL);
+  bool ok = is_subtype(view_type, need_type, NULL, opt);
   ast_free_unattached(view_type);
   ast_free_unattached(need_type);
 
@@ -548,7 +552,7 @@ static token_id partial_application_cap(ast_t* ftype, ast_t* receiver,
       view_type = viewpoint_type(ast_from(type, TK_BOX), type);
       need_type = ast_childidx(param, 1);
 
-      ok = is_subtype(view_type, need_type, NULL);
+      ok = is_subtype(view_type, need_type, NULL, opt);
       ast_free_unattached(view_type);
       ast_free_unattached(need_type);
 
@@ -613,7 +617,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
   if(is_typecheck_error(type))
     return false;
 
-  token_id apply_cap = partial_application_cap(type, receiver, positional);
+  token_id apply_cap = partial_application_cap(opt, type, receiver, positional);
   AST_GET_CHILDREN(type, cap, type_params, target_params, result);
 
   token_id can_error = ast_canerror(lhs) ? TK_QUESTION : TK_NONE;

--- a/src/libponyc/expr/control.h
+++ b/src/libponyc/expr/control.h
@@ -12,12 +12,12 @@ bool expr_if(pass_opt_t* opt, ast_t* ast);
 bool expr_while(pass_opt_t* opt, ast_t* ast);
 bool expr_repeat(pass_opt_t* opt, ast_t* ast);
 bool expr_try(pass_opt_t* opt, ast_t* ast);
-bool expr_recover(ast_t* ast);
-bool expr_break(typecheck_t* t, ast_t* ast);
-bool expr_continue(typecheck_t* t, ast_t* ast);
+bool expr_recover(pass_opt_t* opt, ast_t* ast);
+bool expr_break(pass_opt_t* opt, ast_t* ast);
+bool expr_continue(pass_opt_t* opt, ast_t* ast);
 bool expr_return(pass_opt_t* opt, ast_t* ast);
-bool expr_error(ast_t* ast);
-bool expr_compile_error(ast_t* ast);
+bool expr_error(pass_opt_t* opt, ast_t* ast);
+bool expr_compile_error(pass_opt_t* opt, ast_t* ast);
 bool expr_location(pass_opt_t* opt, ast_t* ast);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -32,8 +32,8 @@ static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
 
     if(def == NULL)
     {
-      ast_error(id_node, "cannot capture \"%s\", variable not defined",
-        name);
+      ast_error(opt->check.errors, id_node,
+        "cannot capture \"%s\", variable not defined", name);
       return NULL;
     }
 
@@ -42,8 +42,8 @@ static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
     if(def_id != TK_ID && def_id != TK_FVAR && def_id != TK_FLET &&
       def_id != TK_PARAM)
     {
-      ast_error(id_node, "cannot capture \"%s\", can only capture fields, "
-        "parameters and local variables", name);
+      ast_error(opt->check.errors, id_node, "cannot capture \"%s\", can only "
+        "capture fields, parameters and local variables", name);
       return NULL;
     }
 

--- a/src/libponyc/expr/match.h
+++ b/src/libponyc/expr/match.h
@@ -8,9 +8,9 @@
 PONY_EXTERN_C_BEGIN
 
 bool expr_match(pass_opt_t* opt, ast_t* ast);
-bool expr_cases(ast_t* ast);
+bool expr_cases(pass_opt_t* opt, ast_t* ast);
 bool expr_case(pass_opt_t* opt, ast_t* ast);
-bool expr_match_capture(ast_t* ast);
+bool expr_match_capture(pass_opt_t* opt, ast_t* ast);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/expr/operator.h
+++ b/src/libponyc/expr/operator.h
@@ -9,7 +9,7 @@ PONY_EXTERN_C_BEGIN
 
 bool expr_identity(pass_opt_t* opt, ast_t* ast);
 bool expr_assign(pass_opt_t* opt, ast_t* ast);
-bool expr_consume(typecheck_t* t, ast_t* ast);
+bool expr_consume(pass_opt_t* opt, ast_t* ast);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -22,14 +22,16 @@
  * Make sure the definition of something occurs before its use. This is for
  * both fields and local variable.
  */
-static bool def_before_use(ast_t* def, ast_t* use, const char* name)
+static bool def_before_use(pass_opt_t* opt, ast_t* def, ast_t* use, const char* name)
 {
   if((ast_line(def) > ast_line(use)) ||
      ((ast_line(def) == ast_line(use)) &&
       (ast_pos(def) > ast_pos(use))))
   {
-    ast_error(use, "declaration of '%s' appears after use", name);
-    ast_error(def, "declaration of '%s' appears here", name);
+    ast_error(opt->check.errors, use,
+      "declaration of '%s' appears after use", name);
+    ast_error_continue(opt->check.errors, def,
+      "declaration of '%s' appears here", name);
     return false;
   }
 
@@ -111,14 +113,16 @@ static bool valid_reference(pass_opt_t* opt, ast_t* ast, ast_t* type,
       if(is_assigned_to(ast, true))
         return true;
 
-      ast_error(ast, "can't use a consumed local in an expression");
+      ast_error(opt->check.errors, ast,
+        "can't use a consumed local in an expression");
       return false;
 
     case SYM_UNDEFINED:
       if(is_assigned_to(ast, true))
         return true;
 
-      ast_error(ast, "can't use an undefined variable in an expression");
+      ast_error(opt->check.errors, ast,
+        "can't use an undefined variable in an expression");
       return false;
 
     default: {}
@@ -150,7 +154,7 @@ bool expr_field(pass_opt_t* opt, ast_t* ast)
     init_type = alias(init_type);
 
     errorframe_t info = NULL;
-    if(!is_subtype(init_type, type, &info))
+    if(!is_subtype(init_type, type, &info, opt))
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, init,
@@ -160,7 +164,7 @@ bool expr_field(pass_opt_t* opt, ast_t* ast)
       ast_error_frame(&frame, init, "default argument type: %s",
         ast_print_type(init_type));
       errorframe_append(&frame, &info);
-      errorframe_report(&frame);
+      errorframe_report(&frame, opt->check.errors);
       ast_free_unattached(init_type);
       return false;
     }
@@ -191,7 +195,8 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
 
     if(upper == NULL)
     {
-      ast_error(ast, "can't read a field through %s", ast_print_type(l_type));
+      ast_error(opt->check.errors, ast, "can't read a field through %s",
+        ast_print_type(l_type));
       return false;
     }
 
@@ -426,10 +431,10 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
     const char* alt_name = suggest_alt_name(ast, name);
 
     if(alt_name == NULL)
-      ast_error(ast, "can't find declaration of '%s'", name);
+      ast_error(opt->check.errors, ast, "can't find declaration of '%s'", name);
     else
-      ast_error(ast, "can't find declaration of '%s', did you mean '%s'?",
-        name, alt_name);
+      ast_error(opt->check.errors, ast,
+        "can't find declaration of '%s', did you mean '%s'?", name, alt_name);
 
     return false;
   }
@@ -441,7 +446,8 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
       // Only allowed if in a TK_DOT with a type.
       if(ast_id(ast_parent(ast)) != TK_DOT)
       {
-        ast_error(ast, "a package can only appear as a prefix to a type");
+        ast_error(opt->check.errors, ast,
+          "a package can only appear as a prefix to a type");
         return false;
       }
 
@@ -474,7 +480,7 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
     case TK_EMBED:
     {
       // Transform to "this.f".
-      if(!def_before_use(def, ast, name))
+      if(!def_before_use(opt, def, ast, name))
         return false;
 
       ast_t* dot = ast_from(ast, TK_DOT);
@@ -495,11 +501,12 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
     {
       if(t->frame->def_arg != NULL)
       {
-        ast_error(ast, "can't reference a parameter in a default argument");
+        ast_error(opt->check.errors, ast,
+          "can't reference a parameter in a default argument");
         return false;
       }
 
-      if(!def_before_use(def, ast, name))
+      if(!def_before_use(opt, def, ast, name))
         return false;
 
       ast_t* type = ast_type(def);
@@ -512,9 +519,8 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
 
       if(!sendable(type) && (t->frame->recover != NULL))
       {
-        ast_error(ast,
-          "can't access a non-sendable parameter from inside a recover "
-          "expression");
+        ast_error(opt->check.errors, ast, "can't access a non-sendable "
+          "parameter from inside a recover expression");
         return false;
       }
 
@@ -551,14 +557,15 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
 
     case TK_ID:
     {
-      if(!def_before_use(def, ast, name))
+      if(!def_before_use(opt, def, ast, name))
         return false;
 
       ast_t* type = ast_type(def);
 
       if(type != NULL && ast_id(type) == TK_INFERTYPE)
       {
-        ast_error(ast, "cannot infer type of %s\n", ast_nice_name(def));
+        ast_error(opt->check.errors, ast, "cannot infer type of %s\n",
+          ast_nice_name(def));
         ast_settype(def, ast_from(def, TK_ERRORTYPE));
         ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
         return false;
@@ -596,8 +603,9 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
 
           if(t->frame->recover != def_recover)
           {
-            ast_error(ast, "can't access a non-sendable local defined outside "
-              "of a recover expression from within that recover expression");
+            ast_error(opt->check.errors, ast, "can't access a non-sendable "
+              "local defined outside of a recover expression from within "
+              "that recover expression");
             return false;
           }
         }
@@ -621,7 +629,7 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
   return false;
 }
 
-bool expr_local(ast_t* ast)
+bool expr_local(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   assert(ast_type(ast) != NULL);
@@ -634,7 +642,8 @@ bool expr_local(ast_t* ast)
     // No type specified, infer it later
     if(!is_assigned_to(ast, false))
     {
-      ast_error(ast, "locals must specify a type or be assigned a value");
+      ast_error(opt->check.errors, ast,
+        "locals must specify a type or be assigned a value");
       return false;
     }
   }
@@ -643,7 +652,8 @@ bool expr_local(ast_t* ast)
     // Let, check we have a value assigned
     if(!is_assigned_to(ast, false))
     {
-      ast_error(ast, "can't declare a let local without assigning to it");
+      ast_error(opt->check.errors, ast,
+        "can't declare a let local without assigning to it");
       return false;
     }
   }
@@ -672,7 +682,8 @@ bool expr_addressof(pass_opt_t* opt, ast_t* ast)
 
   if(!ok)
   {
-    ast_error(ast, "the & operator can only be used for FFI arguments");
+    ast_error(opt->check.errors, ast,
+      "the & operator can only be used for FFI arguments");
     return false;
   }
 
@@ -687,23 +698,28 @@ bool expr_addressof(pass_opt_t* opt, ast_t* ast)
       break;
 
     case TK_FLETREF:
-      ast_error(ast, "can't take the address of a let field");
+      ast_error(opt->check.errors, ast,
+        "can't take the address of a let field");
       return false;
 
     case TK_EMBEDREF:
-      ast_error(ast, "can't take the address of an embed field");
+      ast_error(opt->check.errors, ast,
+        "can't take the address of an embed field");
       return false;
 
     case TK_LETREF:
-      ast_error(ast, "can't take the address of a let local");
+      ast_error(opt->check.errors, ast,
+        "can't take the address of a let local");
       return false;
 
     case TK_PARAMREF:
-      ast_error(ast, "can't take the address of a function parameter");
+      ast_error(opt->check.errors, ast,
+        "can't take the address of a function parameter");
       return false;
 
     default:
-      ast_error(ast, "can only take the address of a local, field or method");
+      ast_error(opt->check.errors, ast,
+        "can only take the address of a local, field or method");
       return false;
   }
 
@@ -745,7 +761,8 @@ bool expr_identityof(pass_opt_t* opt, ast_t* ast)
       break;
 
     default:
-      ast_error(ast, "identity must be for a field, local, parameter or this");
+      ast_error(opt->check.errors, ast,
+        "identity must be for a field, local, parameter or this");
       return false;
   }
 
@@ -755,7 +772,7 @@ bool expr_identityof(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-bool expr_dontcare(ast_t* ast)
+bool expr_dontcare(pass_opt_t* opt, ast_t* ast)
 {
   // We are a tuple element. That tuple must either be a pattern or the LHS
   // of an assignment. It can be embedded in other tuples, which may appear
@@ -804,8 +821,8 @@ bool expr_dontcare(ast_t* ast)
     }
   }
 
-  ast_error(ast, "the don't care token can only appear in a tuple, either on "
-    "the LHS of an assignment or in a pattern");
+  ast_error(opt->check.errors, ast, "the don't care token can only appear "
+    "in a tuple, either on the LHS of an assignment or in a pattern");
   return false;
 }
 
@@ -815,7 +832,8 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
 
   if(t->frame->def_arg != NULL)
   {
-    ast_error(ast, "can't reference 'this' in a default argument");
+    ast_error(opt->check.errors, ast,
+      "can't reference 'this' in a default argument");
     return false;
   }
 
@@ -824,7 +842,8 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
 
   if(status == SYM_CONSUMED)
   {
-    ast_error(ast, "can't use a consumed 'this' in an expression");
+    ast_error(opt->check.errors, ast,
+      "can't use a consumed 'this' in an expression");
     return false;
   }
 
@@ -870,7 +889,7 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
   {
     if(!expr_nominal(opt, &typearg))
     {
-      ast_error(ast, "couldn't create a type for 'this'");
+      ast_error(opt->check.errors, ast, "couldn't create a type for 'this'");
       ast_free(type);
       return false;
     }
@@ -880,7 +899,7 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
 
   if(!expr_nominal(opt, &nominal))
   {
-    ast_error(ast, "couldn't create a type for 'this'");
+    ast_error(opt->check.errors, ast, "couldn't create a type for 'this'");
     ast_free(type);
     return false;
   }
@@ -894,7 +913,7 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-bool expr_tuple(ast_t* ast)
+bool expr_tuple(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* child = ast_child(ast);
   ast_t* type;
@@ -914,7 +933,8 @@ bool expr_tuple(ast_t* ast)
 
       if(is_control_type(c_type))
       {
-        ast_error(child, "a tuple can't contain a control flow expression");
+        ast_error(opt->check.errors, child,
+          "a tuple can't contain a control flow expression");
         return false;
       }
 
@@ -947,7 +967,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
   switch(ast_id(ast))
   {
     case TK_TYPEPARAMREF:
-      return flatten_typeparamref(ast) == AST_OK;
+      return flatten_typeparamref(opt, ast) == AST_OK;
 
     case TK_NOMINAL:
       break;
@@ -971,7 +991,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
   ast_t* typeparams = ast_childidx(def, 1);
   ast_t* typeargs = ast_childidx(ast, 2);
 
-  if(!reify_defaults(typeparams, typeargs, true))
+  if(!reify_defaults(typeparams, typeargs, true, opt))
     return false;
 
   if(!strcmp(name, "MaybePointer"))
@@ -1003,7 +1023,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
 
     if(!ok)
     {
-      ast_error(ast,
+      ast_error(opt->check.errors, ast,
         "%s is not allowed: the type argument to MaybePointer must be a struct",
         ast_print_type(ast));
 
@@ -1011,10 +1031,10 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
     }
   }
 
-  return check_constraints(typeargs, typeparams, typeargs, true);
+  return check_constraints(typeargs, typeparams, typeargs, true, opt);
 }
 
-static bool show_partiality(ast_t* ast)
+static bool show_partiality(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* child = ast_child(ast);
   bool found = false;
@@ -1022,7 +1042,7 @@ static bool show_partiality(ast_t* ast)
   while(child != NULL)
   {
     if(ast_canerror(child))
-      found |= show_partiality(child);
+      found |= show_partiality(opt, child);
 
     child = ast_sibling(child);
   }
@@ -1032,14 +1052,14 @@ static bool show_partiality(ast_t* ast)
 
   if(ast_canerror(ast))
   {
-    ast_error(ast, "an error can be raised here");
+    ast_error(opt->check.errors, ast, "an error can be raised here");
     return true;
   }
 
   return false;
 }
 
-static bool check_fields_defined(ast_t* ast)
+static bool check_fields_defined(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast_id(ast) == TK_NEW);
 
@@ -1061,7 +1081,8 @@ static bool check_fields_defined(ast_t* ast)
 
         if((def != member) || (status != SYM_DEFINED))
         {
-          ast_error(def, "field left undefined in constructor");
+          ast_error(opt->check.errors, def,
+            "field left undefined in constructor");
           result = false;
         }
 
@@ -1075,12 +1096,13 @@ static bool check_fields_defined(ast_t* ast)
   }
 
   if(!result)
-    ast_error(ast, "constructor with undefined fields is here");
+    ast_error(opt->check.errors, ast,
+      "constructor with undefined fields is here");
 
   return result;
 }
 
-static bool check_return_type(ast_t* ast)
+static bool check_return_type(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, type, can_error, body);
   ast_t* body_type = ast_type(body);
@@ -1104,8 +1126,8 @@ static bool check_return_type(ast_t* ast)
   bool ok = true;
 
   errorframe_t info = NULL;
-  if(!is_subtype(body_type, type, &info) ||
-    !is_subtype(a_body_type, a_type, &info))
+  if(!is_subtype(body_type, type, &info, opt) ||
+    !is_subtype(a_body_type, a_type, &info, opt))
   {
     errorframe_t frame = NULL;
     ast_t* last = ast_childlast(body);
@@ -1115,7 +1137,7 @@ static bool check_return_type(ast_t* ast)
     ast_error_frame(&frame, body_type, "function body type: %s",
       ast_print_type(body_type));
     errorframe_append(&frame, &info);
-    errorframe_report(&frame);
+    errorframe_report(&frame, opt->check.errors);
     ok = false;
   }
 
@@ -1124,12 +1146,12 @@ static bool check_return_type(ast_t* ast)
   return ok;
 }
 
-static bool check_main_create(typecheck_t* t, ast_t* ast)
+static bool check_main_create(pass_opt_t* opt, ast_t* ast)
 {
-  if(ast_id(t->frame->type) != TK_ACTOR)
+  if(ast_id(opt->check.frame->type) != TK_ACTOR)
     return true;
 
-  ast_t* type_id = ast_child(t->frame->type);
+  ast_t* type_id = ast_child(opt->check.frame->type);
 
   if(strcmp(ast_name(type_id), "Main"))
     return true;
@@ -1143,14 +1165,14 @@ static bool check_main_create(typecheck_t* t, ast_t* ast)
 
   if(ast_id(typeparams) != TK_NONE)
   {
-    ast_error(typeparams,
+    ast_error(opt->check.errors, typeparams,
       "the create constructor of a Main actor must not be polymorphic");
     ok = false;
   }
 
   if(ast_childcount(params) != 1)
   {
-    ast_error(params,
+    ast_error(opt->check.errors, params,
       "the create constructor of a Main actor must take a single Env "
       "parameter");
     ok = false;
@@ -1164,7 +1186,7 @@ static bool check_main_create(typecheck_t* t, ast_t* ast)
 
     if(!is_env(p_type))
     {
-      ast_error(p_type, "must be of type Env");
+      ast_error(opt->check.errors, p_type, "must be of type Env");
       ok = false;
     }
   }
@@ -1172,9 +1194,9 @@ static bool check_main_create(typecheck_t* t, ast_t* ast)
   return ok;
 }
 
-static bool check_primitive_init(typecheck_t* t, ast_t* ast)
+static bool check_primitive_init(pass_opt_t* opt, ast_t* ast)
 {
-  if(ast_id(t->frame->type) != TK_PRIMITIVE)
+  if(ast_id(opt->check.frame->type) != TK_PRIMITIVE)
     return true;
 
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error);
@@ -1184,52 +1206,57 @@ static bool check_primitive_init(typecheck_t* t, ast_t* ast)
 
   bool ok = true;
 
-  if(ast_id(ast_childidx(t->frame->type, 1)) != TK_NONE)
+  if(ast_id(ast_childidx(opt->check.frame->type, 1)) != TK_NONE)
   {
-    ast_error(ast, "a primitive with type parameters cannot have an _init");
+    ast_error(opt->check.errors, ast,
+      "a primitive with type parameters cannot have an _init");
     ok = false;
   }
 
   if(ast_id(ast) != TK_FUN)
   {
-    ast_error(ast, "a primitive _init must be a function");
+    ast_error(opt->check.errors, ast, "a primitive _init must be a function");
     ok = false;
   }
 
   if(ast_id(cap) != TK_BOX)
   {
-    ast_error(cap, "a primitive _init must be box");
+    ast_error(opt->check.errors, cap, "a primitive _init must be box");
     ok = false;
   }
 
   if(ast_id(typeparams) != TK_NONE)
   {
-    ast_error(typeparams, "a primitive _init must not be polymorphic");
+    ast_error(opt->check.errors, typeparams,
+      "a primitive _init must not be polymorphic");
     ok = false;
   }
 
   if(ast_childcount(params) != 0)
   {
-    ast_error(params, "a primitive _init must take no parameters");
+    ast_error(opt->check.errors, params,
+      "a primitive _init must take no parameters");
     ok = false;
   }
 
   if(!is_none(result))
   {
-    ast_error(result, "a primitive _init must return None");
+    ast_error(opt->check.errors, result,
+      "a primitive _init must return None");
     ok = false;
   }
 
   if(ast_id(can_error) != TK_NONE)
   {
-    ast_error(can_error, "a primitive _init cannot raise an error");
+    ast_error(opt->check.errors, can_error,
+      "a primitive _init cannot raise an error");
     ok = false;
   }
 
   return ok;
 }
 
-static bool check_finaliser(typecheck_t* t, ast_t* ast)
+static bool check_finaliser(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body);
 
@@ -1238,46 +1265,47 @@ static bool check_finaliser(typecheck_t* t, ast_t* ast)
 
   bool ok = true;
 
-  if((ast_id(t->frame->type) == TK_PRIMITIVE) &&
-    (ast_id(ast_childidx(t->frame->type, 1)) != TK_NONE))
+  if((ast_id(opt->check.frame->type) == TK_PRIMITIVE) &&
+    (ast_id(ast_childidx(opt->check.frame->type, 1)) != TK_NONE))
   {
-    ast_error(ast, "a primitive with type parameters cannot have a _final");
+    ast_error(opt->check.errors, ast,
+      "a primitive with type parameters cannot have a _final");
     ok = false;
   }
 
   if(ast_id(ast) != TK_FUN)
   {
-    ast_error(ast, "_final must be a function");
+    ast_error(opt->check.errors, ast, "_final must be a function");
     ok = false;
   }
 
   if(ast_id(cap) != TK_BOX)
   {
-    ast_error(cap, "_final must be box");
+    ast_error(opt->check.errors, cap, "_final must be box");
     ok = false;
   }
 
   if(ast_id(typeparams) != TK_NONE)
   {
-    ast_error(typeparams, "_final must not be polymorphic");
+    ast_error(opt->check.errors, typeparams, "_final must not be polymorphic");
     ok = false;
   }
 
   if(ast_childcount(params) != 0)
   {
-    ast_error(params, "_final must not have parameters");
+    ast_error(opt->check.errors, params, "_final must not have parameters");
     ok = false;
   }
 
   if(!is_none(result))
   {
-    ast_error(result, "_final must return None");
+    ast_error(opt->check.errors, result, "_final must return None");
     ok = false;
   }
 
   if(ast_id(can_error) != TK_NONE)
   {
-    ast_error(can_error, "_final cannot raise an error");
+    ast_error(opt->check.errors, can_error, "_final cannot raise an error");
     ok = false;
   }
 
@@ -1312,7 +1340,7 @@ bool expr_fun(pass_opt_t* opt, ast_t* ast)
     if(body_type == NULL)
     {
       // An error has already occurred.
-      assert(get_error_count() > 0);
+      assert(errors_get_count(t->errors) > 0);
       return false;
     }
 
@@ -1320,20 +1348,22 @@ bool expr_fun(pass_opt_t* opt, ast_t* ast)
       !ast_canerror(body) &&
       (ast_id(body_type) != TK_COMPILE_INTRINSIC))
     {
-      ast_error(can_error, "function body is not partial but the function is");
+      ast_error(opt->check.errors, can_error,
+        "function body is not partial but the function is");
       return false;
     }
   } else {
     // If not a partial function, check that we can't error.
     if(ast_canerror(body))
     {
-      ast_error(can_error, "function body is partial but the function is not");
-      show_partiality(body);
+      ast_error(opt->check.errors, can_error,
+        "function body is partial but the function is not");
+      show_partiality(opt, body);
       return false;
     }
   }
 
-  if(!check_primitive_init(t, ast) || !check_finaliser(t, ast))
+  if(!check_primitive_init(opt, ast) || !check_finaliser(opt, ast))
     return false;
 
   switch(ast_id(ast))
@@ -1344,21 +1374,21 @@ bool expr_fun(pass_opt_t* opt, ast_t* ast)
 
       if(is_machine_word(type))
       {
-        if(!check_return_type(ast))
+        if(!check_return_type(opt, ast))
          ok = false;
       }
 
-      if(!check_fields_defined(ast))
+      if(!check_fields_defined(opt, ast))
         ok = false;
 
-      if(!check_main_create(t, ast))
+      if(!check_main_create(opt, ast))
         ok = false;
 
       return ok;
     }
 
     case TK_FUN:
-      return check_return_type(ast);
+      return check_return_type(opt, ast);
 
     default: {}
   }
@@ -1366,8 +1396,9 @@ bool expr_fun(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-bool expr_compile_intrinsic(ast_t* ast)
+bool expr_compile_intrinsic(pass_opt_t* opt, ast_t* ast)
 {
+  (void)opt;
   ast_settype(ast, ast_from(ast, TK_COMPILE_INTRINSIC));
   return true;
 }

--- a/src/libponyc/expr/reference.h
+++ b/src/libponyc/expr/reference.h
@@ -12,15 +12,15 @@ bool expr_field(pass_opt_t* opt, ast_t* ast);
 bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid);
 bool expr_typeref(pass_opt_t* opt, ast_t** astp);
 bool expr_reference(pass_opt_t* opt, ast_t** astp);
-bool expr_local(ast_t* ast);
+bool expr_local(pass_opt_t* opt, ast_t* ast);
 bool expr_addressof(pass_opt_t* opt, ast_t* ast);
 bool expr_identityof(pass_opt_t* opt, ast_t* ast);
-bool expr_dontcare(ast_t* ast);
+bool expr_dontcare(pass_opt_t* opt, ast_t* ast);
 bool expr_this(pass_opt_t* opt, ast_t* ast);
-bool expr_tuple(ast_t* ast);
+bool expr_tuple(pass_opt_t* opt, ast_t* ast);
 bool expr_nominal(pass_opt_t* opt, ast_t** astp);
 bool expr_fun(pass_opt_t* opt, ast_t* ast);
-bool expr_compile_intrinsic(ast_t* ast);
+bool expr_compile_intrinsic(pass_opt_t* opt, ast_t* ast);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pass/casemethod.h
+++ b/src/libponyc/pass/casemethod.h
@@ -3,12 +3,12 @@
 
 #include <platform.h>
 #include "../ast/ast.h"
-#include "../ast/frame.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
 // Sugar any case methods in the given entity.
-ast_result_t sugar_case_methods(typecheck_t* t, ast_t* entity);
+ast_result_t sugar_case_methods(pass_opt_t* opt, ast_t* entity);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -38,6 +38,7 @@ typedef struct docgen_t
   const char* sub_dir;
   size_t base_dir_buf_len;
   size_t sub_dir_buf_len;
+  errors_t* errors;
 } docgen_t;
 
 
@@ -249,7 +250,8 @@ static FILE* doc_open_file(docgen_t* docgen, bool in_sub_dir,
   FILE* file = fopen(buffer, "w");
 
   if(file == NULL)
-    errorf(NULL, "Could not write documentation to file %s", buffer);
+    errorf(docgen->errors, NULL,
+      "Could not write documentation to file %s", buffer);
 
   ponyint_pool_free_size(buf_len, buffer);
   return file;
@@ -1090,6 +1092,8 @@ void generate_docs(ast_t* program, pass_opt_t* options)
     return;
 
   docgen_t docgen;
+  docgen.errors = options->check.errors;
+
   doc_setup_dirs(&docgen, program, options);
 
   // Open the index and home files

--- a/src/libponyc/pass/finalisers.h
+++ b/src/libponyc/pass/finalisers.h
@@ -7,7 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool pass_finalisers(ast_t* program);
+bool pass_finalisers(ast_t* program, pass_opt_t* options);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -7,7 +7,7 @@
 #include "../type/typeparam.h"
 #include <assert.h>
 
-static ast_result_t flatten_union(ast_t** astp)
+static ast_result_t flatten_union(pass_opt_t* opt, ast_t** astp)
 {
   ast_t* ast = *astp;
 
@@ -17,7 +17,7 @@ static ast_result_t flatten_union(ast_t** astp)
 
   AST_EXTRACT_CHILDREN(ast, left, right);
 
-  ast_t* r_ast = type_union(left, right);
+  ast_t* r_ast = type_union(opt, left, right);
   ast_replace(astp, r_ast);
   ast_free_unattached(left);
   ast_free_unattached(right);
@@ -44,7 +44,7 @@ static void flatten_isect_element(ast_t* type, ast_t* elem)
   ast_free_unattached(elem);
 }
 
-static ast_result_t flatten_isect(typecheck_t* t, ast_t* ast)
+static ast_result_t flatten_isect(pass_opt_t* opt, ast_t* ast)
 {
   // Flatten intersections without testing subtyping. This is to preserve any
   // type guarantees that an element in the intersection might make.
@@ -54,14 +54,14 @@ static ast_result_t flatten_isect(typecheck_t* t, ast_t* ast)
 
   AST_EXTRACT_CHILDREN(ast, left, right);
 
-  if((t->frame->constraint == NULL) &&
-    (t->frame->provides == NULL) &&
+  if((opt->check.frame->constraint == NULL) &&
+    (opt->check.frame->provides == NULL) &&
     !is_compat_type(left, right))
   {
     ast_add(ast, right);
     ast_add(ast, left);
 
-    ast_error(ast,
+    ast_error(opt->check.errors, ast,
       "intersection types cannot include reference capabilities that are not "
       "locally compatible");
     return AST_ERROR;
@@ -73,13 +73,14 @@ static ast_result_t flatten_isect(typecheck_t* t, ast_t* ast)
   return AST_OK;
 }
 
-ast_result_t flatten_typeparamref(ast_t* ast)
+ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, id, cap, eph);
 
   if(ast_id(cap) != TK_NONE)
   {
-    ast_error(cap, "can't specify a capability on a type parameter");
+    ast_error(opt->check.errors, cap,
+      "can't specify a capability on a type parameter");
     return AST_ERROR;
   }
 
@@ -87,20 +88,22 @@ ast_result_t flatten_typeparamref(ast_t* ast)
   return AST_OK;
 }
 
-static ast_result_t flatten_noconstraint(typecheck_t* t, ast_t* ast)
+static ast_result_t flatten_noconstraint(pass_opt_t* opt, ast_t* ast)
 {
-  if(t->frame->constraint != NULL)
+  if(opt->check.frame->constraint != NULL)
   {
     switch(ast_id(ast))
     {
       case TK_TUPLETYPE:
-        ast_error(ast, "tuple types can't be used as constraints");
+        ast_error(opt->check.errors, ast,
+          "tuple types can't be used as constraints");
         return AST_ERROR;
 
       case TK_ARROW:
-        if(t->frame->method == NULL)
+        if(opt->check.frame->method == NULL)
         {
-          ast_error(ast, "arrow types can't be used as type constraints");
+          ast_error(opt->check.errors, ast,
+            "arrow types can't be used as type constraints");
           return AST_ERROR;
         }
         break;
@@ -112,7 +115,7 @@ static ast_result_t flatten_noconstraint(typecheck_t* t, ast_t* ast)
   return AST_OK;
 }
 
-static ast_result_t flatten_sendable_params(ast_t* params)
+static ast_result_t flatten_sendable_params(pass_opt_t* opt, ast_t* params)
 {
   ast_t* param = ast_child(params);
   ast_result_t r = AST_OK;
@@ -123,7 +126,8 @@ static ast_result_t flatten_sendable_params(ast_t* params)
 
     if(!sendable(type))
     {
-      ast_error(type, "this parameter must be sendable (iso, val or tag)");
+      ast_error(opt->check.errors, type,
+        "this parameter must be sendable (iso, val or tag)");
       r = AST_ERROR;
     }
 
@@ -133,7 +137,7 @@ static ast_result_t flatten_sendable_params(ast_t* params)
   return r;
 }
 
-static ast_result_t flatten_constructor(ast_t* ast)
+static ast_result_t flatten_constructor(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body,
     docstring);
@@ -143,7 +147,7 @@ static ast_result_t flatten_constructor(ast_t* ast)
     case TK_ISO:
     case TK_TRN:
     case TK_VAL:
-      return flatten_sendable_params(params);
+      return flatten_sendable_params(opt, params);
 
     default: {}
   }
@@ -151,17 +155,17 @@ static ast_result_t flatten_constructor(ast_t* ast)
   return AST_OK;
 }
 
-static ast_result_t flatten_async(ast_t* ast)
+static ast_result_t flatten_async(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body,
     docstring);
 
-  return flatten_sendable_params(params);
+  return flatten_sendable_params(opt, params);
 }
 
 // Process the given provides type
-static bool flatten_provided_type(ast_t* provides_type, ast_t* error_at,
-  ast_t* list_parent, ast_t** list_end)
+static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
+  ast_t* error_at, ast_t* list_parent, ast_t** list_end)
 {
   assert(error_at != NULL);
   assert(provides_type != NULL);
@@ -175,7 +179,7 @@ static bool flatten_provided_type(ast_t* provides_type, ast_t* error_at,
       // Flatten all children
       for(ast_t* p = ast_child(provides_type); p != NULL; p = ast_sibling(p))
       {
-        if(!flatten_provided_type(p, error_at, list_parent, list_end))
+        if(!flatten_provided_type(opt, p, error_at, list_parent, list_end))
           return false;
       }
 
@@ -189,8 +193,10 @@ static bool flatten_provided_type(ast_t* provides_type, ast_t* error_at,
 
       if(ast_id(def) != TK_TRAIT && ast_id(def) != TK_INTERFACE)
       {
-        ast_error(error_at, "can only provide traits and interfaces");
-        ast_error(provides_type, "invalid type here");
+        ast_error(opt->check.errors, error_at,
+          "can only provide traits and interfaces");
+        ast_error_continue(opt->check.errors, provides_type,
+          "invalid type here");
         return false;
       }
 
@@ -202,16 +208,17 @@ static bool flatten_provided_type(ast_t* provides_type, ast_t* error_at,
     }
 
     default:
-      ast_error(error_at,
+      ast_error(opt->check.errors, error_at,
         "provides type may only be an intersect of traits and interfaces");
-      ast_error(provides_type, "invalid type here");
+      ast_error_continue(opt->check.errors, provides_type, "invalid type here");
       return false;
   }
 }
 
 // Flatten a provides type into a list, checking all types are traits or
 // interfaces
-static ast_result_t flatten_provides_list(ast_t* provider, int index)
+static ast_result_t flatten_provides_list(pass_opt_t* opt, ast_t* provider,
+  int index)
 {
   assert(provider != NULL);
 
@@ -223,7 +230,7 @@ static ast_result_t flatten_provides_list(ast_t* provider, int index)
   ast_t* list = ast_from(provides, TK_PROVIDES);
   ast_t* list_end = NULL;
 
-  if(!flatten_provided_type(provides, provider, list, &list_end))
+  if(!flatten_provided_type(opt, provides, provider, list, &list_end))
   {
     ast_free(list);
     return AST_ERROR;
@@ -235,26 +242,25 @@ static ast_result_t flatten_provides_list(ast_t* provider, int index)
 
 ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
 {
-  typecheck_t* t = &options->check;
   ast_t* ast = *astp;
 
   switch(ast_id(ast))
   {
     case TK_UNIONTYPE:
-      return flatten_union(astp);
+      return flatten_union(options, astp);
 
     case TK_ISECTTYPE:
-      return flatten_isect(t, ast);
+      return flatten_isect(options, ast);
 
     case TK_NEW:
     {
-      switch(ast_id(t->frame->type))
+      switch(ast_id(options->check.frame->type))
       {
         case TK_CLASS:
-          return flatten_constructor(ast);
+          return flatten_constructor(options, ast);
 
         case TK_ACTOR:
-          return flatten_async(ast);
+          return flatten_async(options, ast);
 
         default: {}
       }
@@ -262,18 +268,18 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
     }
 
     case TK_BE:
-      return flatten_async(ast);
+      return flatten_async(options, ast);
 
     case TK_TUPLETYPE:
     case TK_ARROW:
-      return flatten_noconstraint(t, ast);
+      return flatten_noconstraint(options, ast);
 
     case TK_TYPEPARAMREF:
-      return flatten_typeparamref(ast);
+      return flatten_typeparamref(options, ast);
 
     case TK_FVAR:
     case TK_FLET:
-      return flatten_provides_list(ast, 3);
+      return flatten_provides_list(options, ast, 3);
 
     case TK_EMBED:
     {
@@ -304,17 +310,18 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
 
       if(!ok)
       {
-        ast_error(type, "embedded fields must be classes or structs");
+        ast_error(options->check.errors, type,
+          "embedded fields must be classes or structs");
         return AST_ERROR;
       }
 
       if(cap_single(type) == TK_TAG)
       {
-        ast_error(type, "embedded fields cannot be tag");
+        ast_error(options->check.errors, type, "embedded fields cannot be tag");
         return AST_ERROR;
       }
 
-      return flatten_provides_list(ast, 3);
+      return flatten_provides_list(options, ast, 3);
     }
 
     case TK_ACTOR:
@@ -323,10 +330,10 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
     case TK_PRIMITIVE:
     case TK_TRAIT:
     case TK_INTERFACE:
-      return flatten_provides_list(ast, 3);
+      return flatten_provides_list(options, ast, 3);
 
     case TK_OBJECT:
-      return flatten_provides_list(ast, 0);
+      return flatten_provides_list(options, ast, 0);
 
     default: {}
   }

--- a/src/libponyc/pass/flatten.h
+++ b/src/libponyc/pass/flatten.h
@@ -7,7 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-ast_result_t flatten_typeparamref(ast_t* ast);
+ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast);
 
 ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options);
 

--- a/src/libponyc/pass/import.c
+++ b/src/libponyc/pass/import.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 
-static bool import_use(ast_t* ast)
+static bool import_use(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
 
@@ -54,21 +54,23 @@ static bool import_use(ast_t* ast)
       // Symbol clash.
       if(is_builtin)
       {
-        ast_error(existing, "type name clashes with builtin type");
-        ast_error(sym->def, "builtin type here");
+        ast_error(opt->check.errors, existing,
+          "type name clashes with builtin type");
+        ast_error_continue(opt->check.errors, sym->def, "builtin type here");
       }
       else
       {
         if(ok)
         {
           // Only print the "use" as an error once.
-          ast_error(ast, "can't use '%s' without alias, clashing symbols",
-            uri);
+          ast_error(opt->check.errors, ast,
+            "can't use '%s' without alias, clashing symbols", uri);
         }
 
-        ast_error(existing, "existing type name clashes with type from '%s'",
-          uri);
-        ast_error(sym->def, "clash trying to use this type");
+        ast_error(opt->check.errors, existing,
+          "existing type name clashes with type from '%s'", uri);
+        ast_error_continue(opt->check.errors, sym->def,
+          "clash trying to use this type");
       }
 
       ok = false;
@@ -98,7 +100,7 @@ ast_result_t pass_import(ast_t** astp, pass_opt_t* options)
       return AST_OK;
 
     case TK_USE:
-      if(!import_use(ast))
+      if(!import_use(options, ast))
         return AST_FATAL;
       break;
 

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -6,7 +6,8 @@
 #include "../pkg/package.h"
 #include <assert.h>
 
-static bool names_applycap(ast_t* ast, ast_t* cap, ast_t* ephemeral)
+static bool names_applycap(pass_opt_t* opt, ast_t* ast, ast_t* cap,
+  ast_t* ephemeral)
 {
   switch(ast_id(ast))
   {
@@ -20,7 +21,7 @@ static bool names_applycap(ast_t* ast, ast_t* cap, ast_t* ephemeral)
         child != NULL;
         child = ast_sibling(child))
       {
-        names_applycap(child, cap, ephemeral);
+        names_applycap(opt, child, cap, ephemeral);
       }
 
       return true;
@@ -32,7 +33,7 @@ static bool names_applycap(ast_t* ast, ast_t* cap, ast_t* ephemeral)
 
       if(ast_id(cap) != TK_NONE)
       {
-        ast_error(cap,
+        ast_error(opt->check.errors, cap,
           "can't specify a capability for an alias to a type parameter");
         return false;
       }
@@ -57,7 +58,7 @@ static bool names_applycap(ast_t* ast, ast_t* cap, ast_t* ephemeral)
     }
 
     case TK_ARROW:
-      return names_applycap(ast_childidx(ast, 1), cap, ephemeral);
+      return names_applycap(opt, ast_childidx(ast, 1), cap, ephemeral);
 
     default: {}
   }
@@ -78,7 +79,7 @@ static bool names_resolvealias(pass_opt_t* opt, ast_t* def, ast_t** type)
       break;
 
     case AST_FLAG_RECURSE_1:
-      ast_error(def, "type aliases can't be recursive");
+      ast_error(opt->check.errors, def, "type aliases can't be recursive");
       ast_clearflag(def, AST_FLAG_RECURSE_1);
       ast_setflag(def, AST_FLAG_ERROR_1);
       return false;
@@ -130,7 +131,7 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
   if(!names_resolvealias(opt, def, &alias))
     return false;
 
-  if(!reify_defaults(typeparams, typeargs, true))
+  if(!reify_defaults(typeparams, typeargs, true, opt))
     return false;
 
   if(!names_typeargs(opt, typeargs))
@@ -138,18 +139,18 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
 
   if(expr)
   {
-    if(!check_constraints(typeargs, typeparams, typeargs, true))
+    if(!check_constraints(typeargs, typeparams, typeargs, true, opt))
       return false;
   }
 
   // Reify the alias.
-  ast_t* r_alias = reify(alias, typeparams, typeargs);
+  ast_t* r_alias = reify(alias, typeparams, typeargs, opt);
 
   if(r_alias == NULL)
     return false;
 
   // Apply our cap and ephemeral to the result.
-  if(!names_applycap(r_alias, cap, eph))
+  if(!names_applycap(opt, r_alias, cap, eph))
   {
     ast_free_unattached(r_alias);
     return false;
@@ -164,7 +165,7 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
   return true;
 }
 
-static bool names_typeparam(ast_t** astp, ast_t* def)
+static bool names_typeparam(pass_opt_t* opt, ast_t** astp, ast_t* def)
 {
   ast_t* ast = *astp;
   AST_GET_CHILDREN(ast, package, id, typeargs, cap, ephemeral);
@@ -172,7 +173,8 @@ static bool names_typeparam(ast_t** astp, ast_t* def)
 
   if(ast_id(typeargs) != TK_NONE)
   {
-    ast_error(typeargs, "can't qualify a type parameter with type arguments");
+    ast_error(opt->check.errors, typeargs,
+      "can't qualify a type parameter with type arguments");
     return false;
   }
 
@@ -218,7 +220,7 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
   // Store our definition for later use.
   ast_setdata(ast, def);
 
-  if(!reify_defaults(typeparams, typeargs, true))
+  if(!reify_defaults(typeparams, typeargs, true, opt))
     return false;
 
   if(!names_typeargs(opt, typeargs))
@@ -227,7 +229,7 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
   return true;
 }
 
-static ast_t* get_package_scope(ast_t* scope, ast_t* ast)
+static ast_t* get_package_scope(pass_opt_t* opt, ast_t* scope, ast_t* ast)
 {
   assert(ast_id(ast) == TK_NOMINAL);
   ast_t* package_id = ast_child(ast);
@@ -244,7 +246,7 @@ static ast_t* get_package_scope(ast_t* scope, ast_t* ast)
 
     if((scope == NULL) || (ast_id(scope) != TK_PACKAGE))
     {
-      ast_error(package_id, "can't find package '%s'", name);
+      ast_error(opt->check.errors, package_id, "can't find package '%s'", name);
       return NULL;
     }
   }
@@ -252,7 +254,7 @@ static ast_t* get_package_scope(ast_t* scope, ast_t* ast)
   return scope;
 }
 
-ast_t* names_def(ast_t* ast)
+ast_t* names_def(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* def = (ast_t*)ast_data(ast);
 
@@ -260,7 +262,7 @@ ast_t* names_def(ast_t* ast)
     return def;
 
   AST_GET_CHILDREN(ast, package_id, type_id, typeparams, cap, eph);
-  ast_t* scope = get_package_scope(ast, ast);
+  ast_t* scope = get_package_scope(opt, ast, ast);
 
   return ast_get(scope, ast_name(type_id), NULL);
 }
@@ -281,7 +283,7 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
   if(ast_id(cap) == TK_NONE)
     t->stats.default_caps_count++;
 
-  ast_t* r_scope = get_package_scope(scope, ast);
+  ast_t* r_scope = get_package_scope(opt, scope, ast);
 
   if(r_scope == NULL)
     return false;
@@ -296,13 +298,15 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
 
   if(def == NULL)
   {
-    ast_error(type_id, "can't find definition of '%s'", name);
+    ast_error(opt->check.errors, type_id,
+      "can't find definition of '%s'", name);
     r = false;
   } else {
     // Check for a private type.
     if(!local_package && is_name_private(name))
     {
-      ast_error(type_id, "can't access a private type from another package");
+      ast_error(opt->check.errors, type_id,
+        "can't access a private type from another package");
       r = false;
     }
 
@@ -313,7 +317,7 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
         break;
 
       case TK_TYPEPARAM:
-        r = names_typeparam(astp, def);
+        r = names_typeparam(opt, astp, def);
         break;
 
       case TK_INTERFACE:
@@ -326,7 +330,8 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
         break;
 
       default:
-        ast_error(type_id, "definition of '%s' is not a type", name);
+        ast_error(opt->check.errors, type_id,
+          "definition of '%s' is not a type", name);
         r = false;
         break;
     }
@@ -335,7 +340,7 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
   return r;
 }
 
-static bool names_arrow(ast_t** astp)
+static bool names_arrow(pass_opt_t* opt, ast_t** astp)
 {
   AST_GET_CHILDREN(*astp, left, right);
 
@@ -358,7 +363,7 @@ static bool names_arrow(ast_t** astp)
     default: {}
   }
 
-  ast_error(left,
+  ast_error(opt->check.errors, left,
     "only 'this', refcaps, and type parameters can be viewpoints");
   return false;
 }
@@ -375,7 +380,7 @@ ast_result_t pass_names(ast_t** astp, pass_opt_t* options)
       break;
 
     case TK_ARROW:
-      if(!names_arrow(astp))
+      if(!names_arrow(options, astp))
         return AST_ERROR;
       break;
 

--- a/src/libponyc/pass/names.h
+++ b/src/libponyc/pass/names.h
@@ -7,7 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-ast_t* names_def(ast_t* ast);
+ast_t* names_def(pass_opt_t* opt, ast_t* ast);
 
 bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr);
 

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -191,6 +191,7 @@ typedef struct pass_opt_t
   bool verify;
   bool strip_debug;
   bool print_filenames;
+  bool check_tree;
   bool docs;
   verbosity_level verbosity;
   const char* output;

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -129,7 +129,8 @@ static bool is_expr_infix(token_id id)
 
 
 // Check whether the given node is a valid provides type
-static bool check_provides_type(ast_t* type, const char* description)
+static bool check_provides_type(pass_opt_t* opt, ast_t* type,
+  const char* description)
 {
   assert(type != NULL);
   assert(description != NULL);
@@ -142,13 +143,15 @@ static bool check_provides_type(ast_t* type, const char* description)
 
       if(ast_id(cap) != TK_NONE)
       {
-        ast_error(cap, "can't specify a capability in a provides type");
+        ast_error(opt->check.errors, cap,
+          "can't specify a capability in a provides type");
         return false;
       }
 
       if(ast_id(ephemeral) != TK_NONE)
       {
-        ast_error(ephemeral, "can't specify ephemeral in a provides type");
+        ast_error(opt->check.errors, ephemeral,
+          "can't specify ephemeral in a provides type");
         return false;
       }
 
@@ -160,14 +163,14 @@ static bool check_provides_type(ast_t* type, const char* description)
       // Check all our children are also legal
       for(ast_t* p = ast_child(type); p != NULL; p = ast_sibling(p))
       {
-        if(!check_provides_type(p, description))
+        if(!check_provides_type(opt, p, description))
           return false;
       }
 
       return true;
 
     default:
-      ast_error(type, "invalid %s type. Can only be "
+      ast_error(opt->check.errors, type, "invalid %s type. Can only be "
         "interfaces, traits and intersects of those.", description);
       return false;
   }
@@ -175,8 +178,8 @@ static bool check_provides_type(ast_t* type, const char* description)
 
 
 // Check permission for one specific element of a method or entity
-static bool check_permission(const permission_def_t* def, int element,
-  ast_t* actual, const char* context, ast_t* report_at)
+static bool check_permission(pass_opt_t* opt, const permission_def_t* def,
+  int element, ast_t* actual, const char* context, ast_t* report_at)
 {
   assert(def != NULL);
   assert(actual != NULL);
@@ -188,13 +191,15 @@ static bool check_permission(const permission_def_t* def, int element,
 
   if(permission == 'N' && ast_id(actual) != TK_NONE)
   {
-    ast_error(actual, "%s cannot specify %s", def->desc, context);
+    ast_error(opt->check.errors, actual, "%s cannot specify %s",
+      def->desc, context);
     return false;
   }
 
   if(permission == 'Y' && ast_id(actual) == TK_NONE)
   {
-    ast_error(report_at, "%s must specify %s", def->desc, context);
+    ast_error(opt->check.errors, report_at, "%s must specify %s",
+      def->desc, context);
     return false;
   }
 
@@ -203,7 +208,7 @@ static bool check_permission(const permission_def_t* def, int element,
 
 
 // Check whether the given method has any illegal parts
-static bool check_method(ast_t* ast, int method_def_index)
+static bool check_method(pass_opt_t* opt, ast_t* ast, int method_def_index)
 {
   assert(ast != NULL);
   assert(method_def_index >= 0 && method_def_index < DEF_METHOD_COUNT);
@@ -213,33 +218,34 @@ static bool check_method(ast_t* ast, int method_def_index)
 
   if(def->permissions == NULL)
   {
-    ast_error(ast, "%ss are not allowed", def->desc);
+    ast_error(opt->check.errors, ast, "%ss are not allowed", def->desc);
     return false;
   }
 
   AST_GET_CHILDREN(ast, cap, id, type_params, params, return_type,
     error, body, docstring);
 
-  if(!check_permission(def, METHOD_CAP, cap, "receiver capability", cap))
+  if(!check_permission(opt, def, METHOD_CAP, cap, "receiver capability", cap))
     r = false;
 
-  if(!check_id_method(id))
+  if(!check_id_method(opt, id))
     r = false;
 
-  if(!check_permission(def, METHOD_RETURN, return_type, "return type", ast))
+  if(!check_permission(opt, def, METHOD_RETURN, return_type, "return type",
+    ast))
     r = false;
 
-  if(!check_permission(def, METHOD_ERROR, error, "?", ast))
+  if(!check_permission(opt, def, METHOD_ERROR, error, "?", ast))
     r = false;
 
-  if(!check_permission(def, METHOD_BODY, body, "body", ast))
+  if(!check_permission(opt, def, METHOD_BODY, body, "body", ast))
     r = false;
 
   if(ast_id(docstring) == TK_STRING)
   {
     if(ast_id(body) != TK_NONE)
     {
-      ast_error(docstring,
+      ast_error(opt->check.errors, docstring,
         "methods with bodies must put docstrings in the body");
       r = false;
     }
@@ -250,7 +256,7 @@ static bool check_method(ast_t* ast, int method_def_index)
 
 
 // Check whether the given entity members are legal in their entity
-static bool check_members(ast_t* members, int entity_def_index)
+static bool check_members(pass_opt_t* opt, ast_t* members, int entity_def_index)
 {
   assert(members != NULL);
   assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
@@ -269,35 +275,36 @@ static bool check_members(ast_t* members, int entity_def_index)
       {
         if(def->permissions[ENTITY_FIELD] == 'N')
         {
-          ast_error(member, "Can't have fields in %s", def->desc);
+          ast_error(opt->check.errors, member,
+            "Can't have fields in %s", def->desc);
           r = false;
         }
 
-        if(!check_id_field(ast_child(member)))
+        if(!check_id_field(opt, ast_child(member)))
           r = false;
 
         ast_t* delegate_type = ast_childidx(member, 3);
         if(ast_id(delegate_type) != TK_NONE &&
-          !check_provides_type(delegate_type, "delegate"))
+          !check_provides_type(opt, delegate_type, "delegate"))
           r = false;
         break;
       }
 
       case TK_NEW:
-        if(!check_method(member, entity_def_index + DEF_NEW))
+        if(!check_method(opt, member, entity_def_index + DEF_NEW))
           r = false;
         break;
 
       case TK_BE:
       {
-        if(!check_method(member, entity_def_index + DEF_BE))
+        if(!check_method(opt, member, entity_def_index + DEF_BE))
           r = false;
         break;
       }
 
       case TK_FUN:
       {
-        if(!check_method(member, entity_def_index + DEF_FUN))
+        if(!check_method(opt, member, entity_def_index + DEF_FUN))
           r = false;
         break;
       }
@@ -316,7 +323,8 @@ static bool check_members(ast_t* members, int entity_def_index)
 
 
 // Check whether the given entity has illegal parts
-static ast_result_t syntax_entity(ast_t* ast, int entity_def_index)
+static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
+  int entity_def_index)
 {
   assert(ast != NULL);
   assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
@@ -328,24 +336,26 @@ static ast_result_t syntax_entity(ast_t* ast, int entity_def_index)
   // Check if we're called Main
   if(def->permissions[ENTITY_MAIN] == 'N' && ast_name(id) == stringtab("Main"))
   {
-    ast_error(ast, "Main must be an actor");
+    ast_error(opt->check.errors, ast, "Main must be an actor");
     r = AST_ERROR;
   }
 
-  if(!check_id_type(id, def->desc))
+  if(!check_id_type(opt, id, def->desc))
     r = AST_ERROR;
 
-  if(!check_permission(def, ENTITY_CAP, defcap, "default capability", defcap))
+  if(!check_permission(opt, def, ENTITY_CAP, defcap, "default capability",
+    defcap))
     r = AST_ERROR;
 
-  if(!check_permission(def, ENTITY_C_API, c_api, "C api", c_api))
+  if(!check_permission(opt, def, ENTITY_C_API, c_api, "C api", c_api))
     r = AST_ERROR;
 
   if(ast_id(c_api) == TK_AT)
   {
     if(ast_id(typeparams) != TK_NONE)
     {
-      ast_error(typeparams, "generic actor cannot specify C api");
+      ast_error(opt->check.errors, typeparams,
+        "generic actor cannot specify C api");
       r = AST_ERROR;
     }
   }
@@ -354,7 +364,7 @@ static ast_result_t syntax_entity(ast_t* ast, int entity_def_index)
   {
     // Check referenced traits
     if(ast_id(provides) != TK_NONE &&
-      !check_provides_type(provides, "provides"))
+      !check_provides_type(opt, provides, "provides"))
       r = AST_ERROR;
   }
   else
@@ -362,20 +372,21 @@ static ast_result_t syntax_entity(ast_t* ast, int entity_def_index)
     // Check for a type alias
     if(ast_id(provides) == TK_NONE)
     {
-      ast_error(provides, "a type alias must specify a type");
+      ast_error(opt->check.errors, provides,
+        "a type alias must specify a type");
       r = AST_ERROR;
     }
   }
 
   // Check for illegal members
-  if(!check_members(members, entity_def_index))
+  if(!check_members(opt, members, entity_def_index))
     r = AST_ERROR;
 
   return r;
 }
 
 
-static ast_result_t syntax_thistype(typecheck_t* t, ast_t* ast)
+static ast_result_t syntax_thistype(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   ast_t* parent = ast_parent(ast);
@@ -384,13 +395,15 @@ static ast_result_t syntax_thistype(typecheck_t* t, ast_t* ast)
 
   if(ast_id(parent) != TK_ARROW)
   {
-    ast_error(ast, "in a type, 'this' can only be used as a viewpoint");
+    ast_error(opt->check.errors, ast,
+      "in a type, 'this' can only be used as a viewpoint");
     r = AST_ERROR;
   }
 
-  if(t->frame->method == NULL)
+  if(opt->check.frame->method == NULL)
   {
-    ast_error(ast, "can only use 'this' for a viewpoint in a method");
+    ast_error(opt->check.errors, ast,
+      "can only use 'this' for a viewpoint in a method");
     r = AST_ERROR;
   }
 
@@ -398,7 +411,7 @@ static ast_result_t syntax_thistype(typecheck_t* t, ast_t* ast)
 }
 
 
-static ast_result_t syntax_arrowtype(ast_t* ast)
+static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
@@ -406,7 +419,8 @@ static ast_result_t syntax_arrowtype(ast_t* ast)
   switch(ast_id(right))
   {
     case TK_THISTYPE:
-      ast_error(ast, "'this' cannot appear to the right of a viewpoint");
+      ast_error(opt->check.errors, ast,
+        "'this' cannot appear to the right of a viewpoint");
       return AST_ERROR;
 
     case TK_ISO:
@@ -415,7 +429,8 @@ static ast_result_t syntax_arrowtype(ast_t* ast)
     case TK_VAL:
     case TK_BOX:
     case TK_TAG:
-      ast_error(ast, "refcaps cannot appear to the right of a viewpoint");
+      ast_error(opt->check.errors, ast,
+        "refcaps cannot appear to the right of a viewpoint");
       return AST_ERROR;
 
     default: {}
@@ -425,7 +440,7 @@ static ast_result_t syntax_arrowtype(ast_t* ast)
 }
 
 
-static ast_result_t syntax_match(ast_t* ast)
+static ast_result_t syntax_match(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
 
@@ -446,7 +461,8 @@ static ast_result_t syntax_match(ast_t* ast)
 
   if(ast_id(body) == TK_NONE)
   {
-    ast_error(case_ast, "Last case in match must have a body");
+    ast_error(opt->check.errors,
+      case_ast, "Last case in match must have a body");
     return AST_ERROR;
   }
 
@@ -454,7 +470,8 @@ static ast_result_t syntax_match(ast_t* ast)
 }
 
 
-static ast_result_t syntax_ffi(ast_t* ast, bool return_optional)
+static ast_result_t syntax_ffi(pass_opt_t* opt, ast_t* ast,
+  bool return_optional)
 {
   assert(ast != NULL);
   AST_GET_CHILDREN(ast, id, typeargs, args, named_args);
@@ -465,7 +482,8 @@ static ast_result_t syntax_ffi(ast_t* ast, bool return_optional)
   if((ast_child(typeargs) == NULL && !return_optional) ||
     ast_childidx(typeargs, 1) != NULL)
   {
-    ast_error(typeargs, "FFIs must specify a single return type");
+    ast_error(opt->check.errors, typeargs,
+      "FFIs must specify a single return type");
     r = AST_ERROR;
   }
 
@@ -478,7 +496,8 @@ static ast_result_t syntax_ffi(ast_t* ast, bool return_optional)
 
       if(ast_id(def_val) != TK_NONE)
       {
-        ast_error(def_val, "FFIs parameters cannot have default values");
+        ast_error(opt->check.errors, def_val,
+          "FFIs parameters cannot have default values");
         r = AST_ERROR;
       }
     }
@@ -486,7 +505,7 @@ static ast_result_t syntax_ffi(ast_t* ast, bool return_optional)
 
   if(ast_id(named_args) != TK_NONE)
   {
-    ast_error(typeargs, "FFIs cannot take named arguments");
+    ast_error(opt->check.errors, typeargs, "FFIs cannot take named arguments");
     r = AST_ERROR;
   }
 
@@ -494,7 +513,7 @@ static ast_result_t syntax_ffi(ast_t* ast, bool return_optional)
 }
 
 
-static ast_result_t syntax_ellipsis(ast_t* ast)
+static ast_result_t syntax_ellipsis(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   ast_result_t r = AST_OK;
@@ -504,13 +523,14 @@ static ast_result_t syntax_ellipsis(ast_t* ast)
 
   if(ast_id(fn) != TK_FFIDECL)
   {
-    ast_error(ast, "... may only appear in FFI declarations");
+    ast_error(opt->check.errors, ast,
+      "... may only appear in FFI declarations");
     r = AST_ERROR;
   }
 
   if(ast_sibling(ast) != NULL)
   {
-    ast_error(ast, "... must be the last parameter");
+    ast_error(opt->check.errors, ast, "... must be the last parameter");
     r = AST_ERROR;
   }
 
@@ -518,7 +538,7 @@ static ast_result_t syntax_ellipsis(ast_t* ast)
 }
 
 
-static ast_result_t syntax_infix_expr(ast_t* ast)
+static ast_result_t syntax_infix_expr(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
@@ -537,7 +557,7 @@ static ast_result_t syntax_infix_expr(ast_t* ast)
 
   if(left_clash || right_clash)
   {
-    ast_error(ast,
+    ast_error(opt->check.errors, ast,
       "Operator precedence is not supported. Parentheses required.");
     return AST_ERROR;
   }
@@ -546,7 +566,7 @@ static ast_result_t syntax_infix_expr(ast_t* ast)
 }
 
 
-static ast_result_t syntax_consume(ast_t* ast)
+static ast_result_t syntax_consume(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, cap, term);
 
@@ -559,12 +579,13 @@ static ast_result_t syntax_consume(ast_t* ast)
     default: {}
   }
 
-  ast_error(term, "Consume expressions must specify a single identifier");
+  ast_error(opt->check.errors, term,
+    "Consume expressions must specify a single identifier");
   return AST_ERROR;
 }
 
 
-static ast_result_t syntax_return(pass_opt_t* options, ast_t* ast,
+static ast_result_t syntax_return(pass_opt_t* opt, ast_t* ast,
   size_t max_value_count)
 {
   assert(ast != NULL);
@@ -575,30 +596,31 @@ static ast_result_t syntax_return(pass_opt_t* options, ast_t* ast,
 
   if(value_count > max_value_count)
   {
-    ast_error(ast_childidx(value_seq, max_value_count), "Unreachable code");
+    ast_error(opt->check.errors,
+      ast_childidx(value_seq, max_value_count), "Unreachable code");
     return AST_ERROR;
   }
 
   if(ast_id(ast) == TK_RETURN)
   {
-    if(options->check.frame->method_body == NULL)
+    if(opt->check.frame->method_body == NULL)
     {
-      ast_error(ast, "return must occur in a method body");
+      ast_error(opt->check.errors, ast, "return must occur in a method body");
       return AST_ERROR;
     }
 
     if(value_count > 0)
     {
-      if(ast_id(options->check.frame->method) == TK_NEW)
+      if(ast_id(opt->check.frame->method) == TK_NEW)
       {
-        ast_error(ast,
+        ast_error(opt->check.errors, ast,
           "A return in a constructor must not have an expression");
         return AST_ERROR;
       }
 
-      if(ast_id(options->check.frame->method) == TK_BE)
+      if(ast_id(opt->check.frame->method) == TK_BE)
       {
-        ast_error(ast,
+        ast_error(opt->check.errors, ast,
           "A return in a behaviour must not have an expression");
         return AST_ERROR;
       }
@@ -609,15 +631,15 @@ static ast_result_t syntax_return(pass_opt_t* options, ast_t* ast,
 }
 
 
-static ast_result_t syntax_semi(ast_t* ast)
+static ast_result_t syntax_semi(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast_parent(ast) != NULL);
   assert(ast_id(ast_parent(ast)) == TK_SEQ);
 
   if(ast_checkflag(ast, AST_FLAG_BAD_SEMI))
   {
-    ast_error(ast, "Unexpected semicolon, only use to separate expressions on"
-      " the same line");
+    ast_error(opt->check.errors, ast, "Unexpected semicolon, only use to "
+      "separate expressions on the same line");
     return AST_ERROR;
   }
 
@@ -625,20 +647,20 @@ static ast_result_t syntax_semi(ast_t* ast)
 }
 
 
-static ast_result_t syntax_local(ast_t* ast)
+static ast_result_t syntax_local(pass_opt_t* opt, ast_t* ast)
 {
-  if(!check_id_local(ast_child(ast)))
+  if(!check_id_local(opt, ast_child(ast)))
     return AST_ERROR;
 
   return AST_OK;
 }
 
 
-static ast_result_t syntax_embed(ast_t* ast)
+static ast_result_t syntax_embed(pass_opt_t* opt, ast_t* ast)
 {
   if(ast_id(ast_parent(ast)) != TK_MEMBERS)
   {
-    ast_error(ast, "Local variables cannot be embedded");
+    ast_error(opt->check.errors, ast, "Local variables cannot be embedded");
     return AST_ERROR;
   }
 
@@ -646,9 +668,10 @@ static ast_result_t syntax_embed(ast_t* ast)
 }
 
 
-static ast_result_t syntax_type_param(ast_t* ast)
+static ast_result_t syntax_type_param(pass_opt_t* opt, ast_t* ast)
 {
-  if(!check_id_type_param(ast_child(ast)))
+
+  if(!check_id_type_param(opt, ast_child(ast)))
     return AST_ERROR;
 
   return AST_OK;
@@ -667,7 +690,7 @@ static const char* _illegal_flags[] =
 // Check the given ast is a valid ifdef condition.
 // The context parameter is for error messages and should be a literal string
 // such as "ifdef condition" or "use guard".
-static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* options)
+static bool syntax_ifdef_cond(pass_opt_t* opt, ast_t* ast, const char* context)
 {
   assert(ast != NULL);
   assert(context != NULL);
@@ -694,7 +717,7 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
 
       bool r = true;
       bool result;
-      if(os_is_target(lower_case, true, &result, options))
+      if(os_is_target(lower_case, true, &result, opt))
         r = false;
 
       for(int i = 0; _illegal_flags[i] != NULL; i++)
@@ -705,7 +728,8 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
 
       if(!r)
       {
-        ast_error(ast, "\"%s\" is not a valid user build flag\n", name);
+        ast_error(opt->check.errors, ast,
+          "\"%s\" is not a valid user build flag\n", name);
         return false;
       }
 
@@ -717,9 +741,10 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
     {
       const char* name = ast_name(ast_child(ast));
       bool result;
-      if(!os_is_target(name, true, &result, options))
+      if(!os_is_target(name, true, &result, opt))
       {
-        ast_error(ast, "\"%s\" is not a valid platform flag\n", name);
+        ast_error(opt->check.errors, ast,
+          "\"%s\" is not a valid platform flag\n", name);
         return false;
       }
 
@@ -730,20 +755,21 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
     case TK_SEQ:
       if(ast_childcount(ast) != 1)
       {
-        ast_error(ast, "Sequence not allowed in %s", context);
+        ast_error(opt->check.errors, ast,
+          "Sequence not allowed in %s", context);
         return false;
       }
 
       break;
 
     default:
-      ast_error(ast, "Invalid %s", context);
+      ast_error(opt->check.errors, ast, "Invalid %s", context);
       return false;
   }
 
   for(ast_t* p = ast_child(ast); p != NULL; p = ast_sibling(p))
   {
-    if(!syntax_ifdef_cond(p, context, options))
+    if(!syntax_ifdef_cond(opt, p, context))
       return false;
   }
 
@@ -751,40 +777,40 @@ static bool syntax_ifdef_cond(ast_t* ast, const char* context, pass_opt_t* optio
 }
 
 
-static ast_result_t syntax_ifdef(ast_t* ast, pass_opt_t* options)
+static ast_result_t syntax_ifdef(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
 
-  if(!syntax_ifdef_cond(ast_child(ast), "ifdef condition", options))
+  if(!syntax_ifdef_cond(opt, ast_child(ast), "ifdef condition"))
     return AST_ERROR;
 
   return AST_OK;
 }
 
 
-static ast_result_t syntax_use(ast_t* ast, pass_opt_t* options)
+static ast_result_t syntax_use(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
   AST_GET_CHILDREN(ast, id, url, guard);
 
-  if(ast_id(id) != TK_NONE && !check_id_package(id))
+  if(ast_id(id) != TK_NONE && !check_id_package(opt, id))
     return AST_ERROR;
 
-  if(ast_id(guard) != TK_NONE && !syntax_ifdef_cond(guard, "use guard", options))
+  if(ast_id(guard) != TK_NONE && !syntax_ifdef_cond(opt, guard, "use guard"))
     return AST_ERROR;
 
   return AST_OK;
 }
 
 
-static ast_result_t syntax_lambda_capture(ast_t* ast)
+static ast_result_t syntax_lambda_capture(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, name, type, value);
 
   if(ast_id(type) != TK_NONE && ast_id(value) == TK_NONE)
   {
-    ast_error(ast, "value missing for lambda expression capture (cannot "
-      "specify type without value)");
+    ast_error(opt->check.errors, ast, "value missing for lambda expression "
+      "capture (cannot specify type without value)");
     return AST_ERROR;
   }
 
@@ -792,7 +818,7 @@ static ast_result_t syntax_lambda_capture(ast_t* ast)
 }
 
 
-static ast_result_t syntax_compile_intrinsic(ast_t* ast)
+static ast_result_t syntax_compile_intrinsic(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* parent = ast_parent(ast);
   assert(ast_id(parent) == TK_SEQ);
@@ -808,7 +834,8 @@ static ast_result_t syntax_compile_intrinsic(ast_t* ast)
       break;
 
     default:
-      ast_error(ast, "a compile intrinsic must be a method body");
+      ast_error(opt->check.errors, ast,
+        "a compile intrinsic must be a method body");
       return AST_ERROR;
   }
 
@@ -823,7 +850,8 @@ static ast_result_t syntax_compile_intrinsic(ast_t* ast)
 
   if(child != ast || ast_sibling(child) != NULL || ast_id(value) != TK_NONE)
   {
-    ast_error(ast, "a compile intrinsic must be the entire body");
+    ast_error(opt->check.errors, ast,
+      "a compile intrinsic must be the entire body");
     return AST_ERROR;
   }
 
@@ -831,14 +859,14 @@ static ast_result_t syntax_compile_intrinsic(ast_t* ast)
 }
 
 
-static ast_result_t syntax_compile_error(ast_t* ast)
+static ast_result_t syntax_compile_error(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* parent = ast_parent(ast);
   assert(ast_id(parent) == TK_SEQ);
 
   if(ast_id(ast_parent(parent)) != TK_IFDEF)
   {
-    ast_error(ast, "a compile error must be in an ifdef");
+    ast_error(opt->check.errors, ast, "a compile error must be in an ifdef");
     return AST_ERROR;
   }
 
@@ -849,7 +877,7 @@ static ast_result_t syntax_compile_error(ast_t* ast)
   if(ast_id(reason_seq) != TK_SEQ ||
     ast_id(ast_child(reason_seq)) != TK_STRING)
   {
-    ast_error(ast,
+    ast_error(opt->check.errors, ast,
       "a compile error must have a string literal reason for the error");
     return AST_ERROR;
   }
@@ -859,7 +887,8 @@ static ast_result_t syntax_compile_error(ast_t* ast)
   if((child != ast) || (ast_sibling(child) != NULL) ||
     (ast_childcount(reason_seq) != 1))
   {
-    ast_error(ast, "a compile error must be the entire ifdef clause");
+    ast_error(opt->check.errors, ast,
+      "a compile error must be the entire ifdef clause");
     return AST_ERROR;
   }
 
@@ -867,7 +896,7 @@ static ast_result_t syntax_compile_error(ast_t* ast)
 }
 
 
-static ast_result_t syntax_cap(ast_t* ast)
+static ast_result_t syntax_cap(pass_opt_t* opt, ast_t* ast)
 {
   switch(ast_id(ast_parent(ast)))
   {
@@ -893,17 +922,18 @@ static ast_result_t syntax_cap(ast_t* ast)
     default: {}
   }
 
-  ast_error(ast, "a type cannot be only a capability");
+  ast_error(opt->check.errors, ast, "a type cannot be only a capability");
   return AST_ERROR;
 }
 
 
-static ast_result_t syntax_cap_set(typecheck_t* t, ast_t* ast)
+static ast_result_t syntax_cap_set(pass_opt_t* opt, ast_t* ast)
 {
   // Cap sets can only appear in type parameter constraints.
-  if(t->frame->constraint == NULL)
+  if(opt->check.frame->constraint == NULL)
   {
-    ast_error(ast, "a capability set can only appear in a type constraint");
+    ast_error(opt->check.errors, ast,
+      "a capability set can only appear in a type constraint");
     return AST_ERROR;
   }
 
@@ -913,8 +943,6 @@ static ast_result_t syntax_cap_set(typecheck_t* t, ast_t* ast)
 
 ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 {
-  typecheck_t* t = &options->check;
-
   assert(astp != NULL);
   ast_t* ast = *astp;
   assert(ast != NULL);
@@ -924,59 +952,61 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 
   switch(id)
   {
-    case TK_SEMI:       r = syntax_semi(ast); break;
-    case TK_TYPE:       r = syntax_entity(ast, DEF_TYPEALIAS); break;
-    case TK_PRIMITIVE:  r = syntax_entity(ast, DEF_PRIMITIVE); break;
-    case TK_STRUCT:     r = syntax_entity(ast, DEF_STRUCT); break;
-    case TK_CLASS:      r = syntax_entity(ast, DEF_CLASS); break;
-    case TK_ACTOR:      r = syntax_entity(ast, DEF_ACTOR); break;
-    case TK_TRAIT:      r = syntax_entity(ast, DEF_TRAIT); break;
-    case TK_INTERFACE:  r = syntax_entity(ast, DEF_INTERFACE); break;
-    case TK_THISTYPE:   r = syntax_thistype(t, ast); break;
-    case TK_ARROW:      r = syntax_arrowtype(ast); break;
-    case TK_MATCH:      r = syntax_match(ast); break;
-    case TK_FFIDECL:    r = syntax_ffi(ast, false); break;
-    case TK_FFICALL:    r = syntax_ffi(ast, true); break;
-    case TK_ELLIPSIS:   r = syntax_ellipsis(ast); break;
-    case TK_CONSUME:    r = syntax_consume(ast); break;
+    case TK_SEMI:       r = syntax_semi(options, ast); break;
+    case TK_TYPE:       r = syntax_entity(options, ast, DEF_TYPEALIAS); break;
+    case TK_PRIMITIVE:  r = syntax_entity(options, ast, DEF_PRIMITIVE); break;
+    case TK_STRUCT:     r = syntax_entity(options, ast, DEF_STRUCT); break;
+    case TK_CLASS:      r = syntax_entity(options, ast, DEF_CLASS); break;
+    case TK_ACTOR:      r = syntax_entity(options, ast, DEF_ACTOR); break;
+    case TK_TRAIT:      r = syntax_entity(options, ast, DEF_TRAIT); break;
+    case TK_INTERFACE:  r = syntax_entity(options, ast, DEF_INTERFACE); break;
+    case TK_THISTYPE:   r = syntax_thistype(options, ast); break;
+    case TK_ARROW:      r = syntax_arrowtype(options, ast); break;
+    case TK_MATCH:      r = syntax_match(options, ast); break;
+    case TK_FFIDECL:    r = syntax_ffi(options, ast, false); break;
+    case TK_FFICALL:    r = syntax_ffi(options, ast, true); break;
+    case TK_ELLIPSIS:   r = syntax_ellipsis(options, ast); break;
+    case TK_CONSUME:    r = syntax_consume(options, ast); break;
     case TK_RETURN:
     case TK_BREAK:      r = syntax_return(options, ast, 1); break;
     case TK_CONTINUE:
     case TK_ERROR:      r = syntax_return(options, ast, 0); break;
     case TK_LET:
-    case TK_VAR:        r = syntax_local(ast); break;
-    case TK_EMBED:      r = syntax_embed(ast); break;
-    case TK_TYPEPARAM:  r = syntax_type_param(ast); break;
-    case TK_IFDEF:      r = syntax_ifdef(ast, options); break;
-    case TK_USE:        r = syntax_use(ast, options); break;
+    case TK_VAR:        r = syntax_local(options, ast); break;
+    case TK_EMBED:      r = syntax_embed(options, ast); break;
+    case TK_TYPEPARAM:  r = syntax_type_param(options, ast); break;
+    case TK_IFDEF:      r = syntax_ifdef(options, ast); break;
+    case TK_USE:        r = syntax_use(options, ast); break;
     case TK_LAMBDACAPTURE:
-                        r = syntax_lambda_capture(ast); break;
+                        r = syntax_lambda_capture(options, ast); break;
     case TK_COMPILE_INTRINSIC:
-                        r = syntax_compile_intrinsic(ast); break;
+                        r = syntax_compile_intrinsic(options, ast); break;
     case TK_COMPILE_ERROR:
-                        r = syntax_compile_error(ast); break;
+                        r = syntax_compile_error(options, ast); break;
 
     case TK_ISO:
     case TK_TRN:
     case TK_REF:
     case TK_VAL:
     case TK_BOX:
-    case TK_TAG:        r = syntax_cap(ast); break;
+    case TK_TAG:        r = syntax_cap(options, ast); break;
 
     case TK_CAP_READ:
     case TK_CAP_SEND:
     case TK_CAP_SHARE:
     case TK_CAP_ALIAS:
-    case TK_CAP_ANY:    r = syntax_cap_set(t, ast); break;
+    case TK_CAP_ANY:    r = syntax_cap_set(options, ast); break;
 
     case TK_VALUEFORMALARG:
     case TK_VALUEFORMALPARAM:
-      ast_error(ast, "Value formal parameters not yet supported");
+      ast_error(options->check.errors, ast,
+        "Value formal parameters not yet supported");
       r = AST_ERROR;
       break;
 
     case TK_CONSTANT:
-      ast_error(ast, "Compile time expressions not yet supported");
+      ast_error(options->check.errors, ast,
+        "Compile time expressions not yet supported");
       r = AST_ERROR;
       break;
 
@@ -984,11 +1014,11 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
   }
 
   if(is_expr_infix(id))
-    r = syntax_infix_expr(ast);
+    r = syntax_infix_expr(options, ast);
 
   if(ast_checkflag(ast, AST_FLAG_MISSING_SEMI))
   {
-    ast_error(ast,
+    ast_error(options->check.errors, ast,
       "Use a semi colon to separate expressions on the same line");
     r = AST_ERROR;
   }

--- a/src/libponyc/pkg/ifdef.h
+++ b/src/libponyc/pkg/ifdef.h
@@ -12,17 +12,18 @@ PONY_EXTERN_C_BEGIN
 // Includes replacing TK_*s with ifdef specific versions.
 // Returns: true on success, false if condition can nver be true (does not
 // report error for this).
-bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* options);
+bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* opt);
 
 // Evaluate the given ifdef or use guard condition for our build target.
 // Returns: value of given condition.
-bool ifdef_cond_eval(ast_t* ast, pass_opt_t* options);
+bool ifdef_cond_eval(ast_t* ast, pass_opt_t* opt);
 
 // Find the FFI declaration for the given FFI call, if any.
 // Returns: true on success, false on failure.
 // On success out_decl contains the relevant declaration, or NULL if there
 // isn't one.
-bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl, pass_opt_t* options);
+bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl,
+  pass_opt_t* opt);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -95,42 +95,46 @@ static const char* find_magic_package(const char* path)
 // Attempt to parse the specified source file and add it to the given AST
 // @return true on success, false on error
 static bool parse_source_file(ast_t* package, const char* file_path,
-  pass_opt_t* options)
+  pass_opt_t* opt)
 {
   assert(package != NULL);
   assert(file_path != NULL);
-  assert(options != NULL);
+  assert(opt != NULL);
 
-  if(options->print_filenames)
+  if(opt->print_filenames)
     printf("Opening %s\n", file_path);
 
-  source_t* source = source_open(file_path);
+  const char* error_msg = NULL;
+  source_t* source = source_open(file_path, &error_msg);
 
   if(source == NULL)
   {
-    errorf(file_path, "couldn't open file %s", file_path);
+    if(error_msg == NULL)
+      error_msg = "couldn't open file";
+
+    errorf(opt->check.errors, file_path, "%s %s", error_msg, file_path);
     return false;
   }
 
-  return module_passes(package, options, source);
+  return module_passes(package, opt, source);
 }
 
 
 // Attempt to parse the specified source code and add it to the given AST
 // @return true on success, false on error
 static bool parse_source_code(ast_t* package, const char* src,
-  pass_opt_t* options)
+  pass_opt_t* opt)
 {
   assert(src != NULL);
-  assert(options != NULL);
+  assert(opt != NULL);
 
-  if(options->print_filenames)
+  if(opt->print_filenames)
     printf("Opening magic source\n");
 
   source_t* source = source_open_string(src);
   assert(source != NULL);
 
-  return module_passes(package, options, source);
+  return module_passes(package, opt, source);
 }
 
 
@@ -171,19 +175,20 @@ static void path_cat(const char* part1, const char* part2,
 // the given package AST
 // @return true on success, false on error
 static bool parse_files_in_dir(ast_t* package, const char* dir_path,
-  pass_opt_t* options)
+  pass_opt_t* opt)
 {
   PONY_ERRNO err = 0;
   PONY_DIR* dir = pony_opendir(dir_path, &err);
+  errors_t* errors = opt->check.errors;
 
   if(dir == NULL)
   {
     switch(err)
     {
-      case EACCES:  errorf(dir_path, "permission denied"); break;
-      case ENOENT:  errorf(dir_path, "does not exist");    break;
-      case ENOTDIR: errorf(dir_path, "not a directory");   break;
-      default:      errorf(dir_path, "unknown error");     break;
+      case EACCES:  errorf(errors, dir_path, "permission denied"); break;
+      case ENOENT:  errorf(errors, dir_path, "does not exist");    break;
+      case ENOTDIR: errorf(errors, dir_path, "not a directory");   break;
+      default:      errorf(errors, dir_path, "unknown error");     break;
     }
 
     return false;
@@ -207,7 +212,7 @@ static bool parse_files_in_dir(ast_t* package, const char* dir_path,
     {
       char fullpath[FILENAME_MAX];
       path_cat(dir_path, name, fullpath);
-      r &= parse_source_file(package, fullpath, options);
+      r &= parse_source_file(package, fullpath, opt);
     }
   }
 
@@ -360,7 +365,6 @@ static const char* find_path(ast_t* from, const char* path,
     }
   }
 
-  errorf(path, "couldn't locate this path");
   return NULL;
 }
 
@@ -554,10 +558,11 @@ static bool add_safe(const char* path)
 
 // Determine the absolute path of the directory the current executable is in
 // and add it to our search path
-static void add_exec_dir()
+static void add_exec_dir(pass_opt_t* opt)
 {
   char path[FILENAME_MAX];
   bool success;
+  errors_t* errors = opt->check.errors;
 
 #ifdef PLATFORM_IS_WINDOWS
   // Specified size *includes* nul terminator
@@ -596,7 +601,7 @@ static void add_exec_dir()
 
   if(!success)
   {
-    errorf(NULL, "Error determining executable path");
+    errorf(errors, NULL, "Error determining executable path");
     return;
   }
 
@@ -605,7 +610,7 @@ static void add_exec_dir()
 
   if(p == NULL)
   {
-    errorf(NULL, "Error determining executable path (%s)", path);
+    errorf(errors, NULL, "Error determining executable path (%s)", path);
     return;
   }
 
@@ -640,13 +645,13 @@ static void add_exec_dir()
 }
 
 
-bool package_init()
+bool package_init(pass_opt_t* opt)
 {
   // package_add_paths for command line paths has already been done. Here, we
   // append the paths from an optional environment variable, and then the paths
   // that are relative to the compiler location on disk.
-  package_add_paths(getenv("PONYPATH"));
-  add_exec_dir();
+  package_add_paths(getenv("PONYPATH"), opt);
+  add_exec_dir(opt);
 
   // Finally we add OS specific paths.
 #ifdef PLATFORM_IS_POSIX_BASED
@@ -685,7 +690,7 @@ strlist_t* package_paths()
 }
 
 
-static bool handle_path_list(const char* paths, path_fn f)
+static bool handle_path_list(const char* paths, path_fn f, pass_opt_t* opt)
 {
   if(paths == NULL)
     return true;
@@ -709,7 +714,7 @@ static bool handle_path_list(const char* paths, path_fn f)
 
     if(len >= FILENAME_MAX)
     {
-      errorf(NULL, "Path too long in %s", paths);
+      errorf(opt->check.errors, NULL, "Path too long in %s", paths);
     } else {
       char path[FILENAME_MAX];
 
@@ -727,16 +732,16 @@ static bool handle_path_list(const char* paths, path_fn f)
   return ok;
 }
 
-void package_add_paths(const char* paths)
+void package_add_paths(const char* paths, pass_opt_t* opt)
 {
-  handle_path_list(paths, add_path);
+  handle_path_list(paths, add_path, opt);
 }
 
 
-bool package_add_safe(const char* paths)
+bool package_add_safe(const char* paths, pass_opt_t* opt)
 {
   add_safe("builtin");
-  return handle_path_list(paths, add_safe);
+  return handle_path_list(paths, add_safe, opt);
 }
 
 
@@ -771,16 +776,16 @@ void package_suppress_build_message()
 }
 
 
-ast_t* program_load(const char* path, pass_opt_t* options)
+ast_t* program_load(const char* path, pass_opt_t* opt)
 {
   ast_t* program = ast_blank(TK_PROGRAM);
   ast_scope(program);
 
-  options->program_pass = PASS_PARSE;
+  opt->program_pass = PASS_PARSE;
 
   // Always load builtin package first, then the specified one.
-  if(package_load(program, stringtab("builtin"), options) == NULL ||
-    package_load(program, path, options) == NULL)
+  if(package_load(program, stringtab("builtin"), opt) == NULL ||
+    package_load(program, path, opt) == NULL)
   {
     ast_free(program);
     return NULL;
@@ -790,7 +795,7 @@ ast_t* program_load(const char* path, pass_opt_t* options)
   ast_t* builtin = ast_pop(program);
   ast_append(program, builtin);
 
-  if(!ast_passes_program(program, options))
+  if(!ast_passes_program(program, opt))
   {
     ast_free(program);
     return NULL;
@@ -800,7 +805,7 @@ ast_t* program_load(const char* path, pass_opt_t* options)
 }
 
 
-ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options)
+ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt)
 {
   assert(from != NULL);
 
@@ -816,7 +821,10 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options)
     full_path = find_path(from, path, &is_relative);
 
     if(full_path == NULL)
+    {
+      errorf(opt->check.errors, path, "couldn't locate this path");
       return NULL;
+    }
 
     if((from != program) && is_relative)
     {
@@ -849,27 +857,28 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options)
   package = create_package(program, full_path, qualified_name);
 
   if(report_build) {
-    PONY_LOG(options, VERBOSITY_INFO, ("Building %s -> %s\n", path, full_path));
+    PONY_LOG(opt, VERBOSITY_INFO, ("Building %s -> %s\n", path, full_path));
   }
 
   if(magic != NULL)
   {
-    if(!parse_source_code(package, magic, options))
+    if(!parse_source_code(package, magic, opt))
       return NULL;
   }
   else
   {
-    if(!parse_files_in_dir(package, full_path, options))
+    if(!parse_files_in_dir(package, full_path, opt))
       return NULL;
   }
 
   if(ast_child(package) == NULL)
   {
-    ast_error(package, "no source files in package '%s'", path);
+    ast_error(opt->check.errors, package,
+      "no source files in package '%s'", path);
     return NULL;
   }
 
-  if(!ast_passes_subtree(&package, options, options->program_pass))
+  if(!ast_passes_subtree(&package, opt, opt->program_pass))
   {
     // If these passes failed, don't run future passes.
     ast_setflag(package, AST_FLAG_PRESERVE);

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -15,7 +15,7 @@ typedef struct package_t package_t;
  * directory relative to the executable, plus a collection of directories
  * specified in the PONYPATH environment variable.
  */
-bool package_init();
+bool package_init(pass_opt_t* opt);
 
 /**
  * Gets the list of search paths.
@@ -28,7 +28,7 @@ strlist_t* package_paths();
  * Path list is semicolon (;) separated on Windows and colon (:) separated on
  * Linux and MacOS.
  */
-void package_add_paths(const char* paths);
+void package_add_paths(const char* paths, pass_opt_t* opt);
 
 /**
  * Appends a list of paths to the list of packages allowed to do C FFI.
@@ -36,7 +36,7 @@ void package_add_paths(const char* paths);
  * Linux and MacOS.
  * If this is never called, all packages are allowed to do C FFI.
  */
-bool package_add_safe(const char* paths);
+bool package_add_safe(const char* paths, pass_opt_t* opt);
 
 /**
  * Add a magic package. When the package with the specified path is requested
@@ -60,12 +60,12 @@ void package_suppress_build_message();
 /**
  * Load a program. The path specifies the package that represents the program.
  */
-ast_t* program_load(const char* path, pass_opt_t* options);
+ast_t* program_load(const char* path, pass_opt_t* opt);
 
 /**
  * Load a package. Used by program_load() and when handling 'use' statements.
  */
-ast_t* package_load(ast_t* from, const char* path, pass_opt_t* options);
+ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt);
 
 /**
  * Free the package_t that is set as the ast_data of a package node.

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -75,14 +75,15 @@ uint32_t program_assign_pkg_id(ast_t* ast)
   return data->next_package_id++;
 }
 
-static const char* quoted_locator(ast_t* use, const char* locator)
+static const char* quoted_locator(pass_opt_t* opt, ast_t* use,
+  const char* locator)
 {
   assert(locator != NULL);
 
   if(strpbrk(locator, "\t\r\n\"'`;$|&<>%*?[]{}()") != NULL)
   {
     if(use != NULL)
-      ast_error(use, "use URI contains invalid characters");
+      ast_error(opt->check.errors, use, "use URI contains invalid characters");
 
     return NULL;
   }
@@ -102,9 +103,8 @@ bool use_library(ast_t* use, const char* locator, ast_t* name,
   pass_opt_t* options)
 {
   (void)name;
-  (void)options;
 
-  const char* libname = quoted_locator(use, locator);
+  const char* libname = quoted_locator(options, use, locator);
 
   if(libname == NULL)
     return false;
@@ -126,9 +126,8 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
   pass_opt_t* options)
 {
   (void)name;
-  (void)options;
 
-  const char* libpath = quoted_locator(use, locator);
+  const char* libpath = quoted_locator(options, use, locator);
 
   if(libpath == NULL)
     return false;
@@ -145,7 +144,7 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 }
 
 
-void program_lib_build_args(ast_t* program,
+void program_lib_build_args(ast_t* program, pass_opt_t* opt,
   const char* path_preamble, const char* rpath_preamble,
   const char* global_preamble, const char* global_postamble,
   const char* lib_premable, const char* lib_postamble)
@@ -186,7 +185,7 @@ void program_lib_build_args(ast_t* program,
   // Library paths from the command line and environment variable.
   for(strlist_t* p = package_paths(); p != NULL; p = strlist_next(p))
   {
-    const char* libpath = quoted_locator(NULL, strlist_data(p));
+    const char* libpath = quoted_locator(opt, NULL, strlist_data(p));
 
     if(libpath == NULL)
       continue;

--- a/src/libponyc/pkg/program.h
+++ b/src/libponyc/pkg/program.h
@@ -30,7 +30,7 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 /** Build the required linker arguments based on the libraries we're using.
  * Once this has been called no more calls to use_library() are permitted.
  */
-void program_lib_build_args(ast_t* program,
+void program_lib_build_args(ast_t* program, pass_opt_t* opt,
   const char* path_preamble, const char* rpath_preamble,
   const char* global_preamble, const char* global_postamble,
   const char* lib_premable, const char* lib_postamble);

--- a/src/libponyc/ponyc.c
+++ b/src/libponyc/ponyc.c
@@ -3,21 +3,20 @@
 #include "codegen/codegen.h"
 #include "pkg/package.h"
 
-bool ponyc_init(pass_opt_t *options)
+bool ponyc_init(pass_opt_t* options)
 {
   if (!codegen_init(options))
     return false;
 
-  if (!package_init())
+  if (!package_init(options))
     return false;
 
   return true;
 }
 
-void ponyc_shutdown(pass_opt_t *options)
+void ponyc_shutdown(pass_opt_t* options)
 {
-  print_errors();
-  free_errors();
+  errors_print(options->check.errors);
   package_done();
   codegen_shutdown(options);
   stringtab_done();

--- a/src/libponyc/ponyc.h
+++ b/src/libponyc/ponyc.h
@@ -6,8 +6,8 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool ponyc_init(pass_opt_t *options);
-void ponyc_shutdown(pass_opt_t *options);
+bool ponyc_init(pass_opt_t* options);
+void ponyc_shutdown(pass_opt_t* options);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -102,7 +102,7 @@ void reach_free(reachable_types_t* r);
  * typeargs can be NULL if there are none.
  */
 void reach(reachable_types_t* r, uint32_t* next_type_id, ast_t* type,
-  const char* name, ast_t* typeargs);
+  const char* name, ast_t* typeargs, pass_opt_t* opt);
 
 reachable_type_t* reach_type(reachable_types_t* r, ast_t* type);
 

--- a/src/libponyc/type/assemble.h
+++ b/src/libponyc/type/assemble.h
@@ -34,17 +34,18 @@ ast_t* type_sugar(ast_t* from, const char* package, const char* name);
 /**
 * Add a branch type to a control structure type.
 */
-ast_t* control_type_add_branch(ast_t* control_type, ast_t* branch);
+ast_t* control_type_add_branch(pass_opt_t* opt, ast_t* control_type,
+  ast_t* branch);
 
 /**
  * Build a type that is the union of these two types.
  */
-ast_t* type_union(ast_t* l_type, ast_t* r_type);
+ast_t* type_union(pass_opt_t* opt, ast_t* l_type, ast_t* r_type);
 
 /**
  * Build a type that is the intersection of these two types.
  */
-ast_t* type_isect(ast_t* l_type, ast_t* r_type);
+ast_t* type_isect(pass_opt_t* opt, ast_t* l_type, ast_t* r_type);
 
 /**
  * Build a type to describe the current class/actor.

--- a/src/libponyc/type/matchtype.h
+++ b/src/libponyc/type/matchtype.h
@@ -3,6 +3,7 @@
 
 #include <platform.h>
 #include "../ast/ast.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -36,7 +37,7 @@ typedef enum
  *
  * Return REJECT if no such type can exist.
  */
-matchtype_t is_matchtype(ast_t* operand, ast_t* pattern);
+matchtype_t is_matchtype(ast_t* operand, ast_t* pattern, pass_opt_t* opt);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -3,15 +3,17 @@
 
 #include <platform.h>
 #include "../ast/ast.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
-bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors);
+bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
+  pass_opt_t* opt);
 
-ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs);
+ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt);
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
-  bool report_errors);
+  bool report_errors, pass_opt_t* opt);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -11,12 +11,14 @@
 #include "../expr/literal.h"
 #include <assert.h>
 
-static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errors);
-static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors);
+static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
+  pass_opt_t* opt);
+static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt);
 
 static __pony_thread_local ast_t* subtype_assume;
 
-static bool exact_nominal(ast_t* a, ast_t* b)
+static bool exact_nominal(ast_t* a, ast_t* b, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(a, a_pkg, a_id, a_typeargs, a_cap, a_eph);
   AST_GET_CHILDREN(b, b_pkg, b_id, b_typeargs, b_cap, b_eph);
@@ -28,10 +30,10 @@ static bool exact_nominal(ast_t* a, ast_t* b)
     (a_def == b_def) &&
     (ast_id(a_cap) == ast_id(b_cap)) &&
     (ast_id(a_eph) == ast_id(b_eph)) &&
-    is_eq_typeargs(a, b, false);
+    is_eq_typeargs(a, b, false, opt);
 }
 
-static bool push_assume(ast_t* sub, ast_t* super)
+static bool push_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
 {
   // Returns true if we have already assumed sub is a subtype of super.
   if(subtype_assume != NULL)
@@ -42,8 +44,8 @@ static bool push_assume(ast_t* sub, ast_t* super)
     {
       AST_GET_CHILDREN(assumption, assume_sub, assume_super);
 
-      if(exact_nominal(sub, assume_sub) &&
-        exact_nominal(super, assume_super))
+      if(exact_nominal(sub, assume_sub, opt) &&
+        exact_nominal(super, assume_super, opt))
         return true;
 
       assumption = ast_sibling(assumption);
@@ -69,8 +71,10 @@ static void pop_assume()
   }
 }
 
-static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
+  (void)opt;
   ast_t* sub_cap = cap_fetch(sub);
   ast_t* sub_eph = ast_sibling(sub_cap);
   ast_t* super_cap = cap_fetch(super);
@@ -79,9 +83,9 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, errorframe_t* errors)
   if(!is_cap_sub_cap(ast_id(sub_cap), ast_id(sub_eph),
     ast_id(super_cap), ast_id(super_eph)))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: %s%s is not a subtype of %s%s",
         ast_print_type(sub), ast_print_type(super),
         ast_print_type(sub_cap), ast_print_type(sub_eph),
@@ -94,7 +98,8 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, errorframe_t* errors)
   return true;
 }
 
-static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errors)
+static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   assert(ast_id(a) == TK_NOMINAL);
   assert(ast_id(b) == TK_NOMINAL);
@@ -106,25 +111,25 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errors)
 
   while((a_arg != NULL) && (b_arg != NULL))
   {
-    if(!is_eqtype(a_arg, b_arg, errors))
+    if(!is_eqtype(a_arg, b_arg, errorf, opt))
       ret = false;
 
     a_arg = ast_sibling(a_arg);
     b_arg = ast_sibling(b_arg);
   }
 
-  if(!ret && errors != NULL)
+  if(!ret && errorf != NULL)
   {
-    ast_error_frame(errors, a, "%s has different type arguments than %s",
+    ast_error_frame(errorf, a, "%s has different type arguments than %s",
       ast_print_type(a), ast_print_type(b));
   }
 
   // Make sure we had the same number of typeargs.
   if((a_arg != NULL) || (b_arg != NULL))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, a,
+      ast_error_frame(errorf, a,
         "%s has a different number of type arguments than %s",
         ast_print_type(a), ast_print_type(b));
     }
@@ -135,14 +140,14 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errors)
   return ret;
 }
 
-static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errorf)
 {
   // If either result type is a machine word, the other must be as well.
   if(is_machine_word(sub) && !is_machine_word(super))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub, "%s is a machine word and %s is not",
+      ast_error_frame(errorf, sub, "%s is a machine word and %s is not",
         ast_print_type(sub), ast_print_type(super));
     }
 
@@ -151,9 +156,9 @@ static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(is_machine_word(super) && !is_machine_word(sub))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub, "%s is a machine word and %s is not",
+      ast_error_frame(errorf, sub, "%s is a machine word and %s is not",
         ast_print_type(super), ast_print_type(sub));
     }
 
@@ -164,7 +169,7 @@ static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errors)
 }
 
 static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(sub, sub_cap, sub_id, sub_typeparams, sub_params,
     sub_result, sub_throws);
@@ -179,9 +184,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       // Covariant receiver.
       if(!is_cap_sub_cap(ast_id(sub_cap), TK_NONE, ast_id(super_cap), TK_NONE))
       {
-        if(errors != NULL)
+        if(errorf != NULL)
         {
-          ast_error_frame(errors, sub,
+          ast_error_frame(errorf, sub,
             "%s constructor is not a subtype of %s constructor",
             ast_print_type(sub_cap), ast_print_type(super_cap));
         }
@@ -190,11 +195,11 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       }
 
       // Covariant result.
-      if(!is_subtype(sub_result, super_result, errors))
+      if(!is_subtype(sub_result, super_result, errorf, opt))
       {
-        if(errors != NULL)
+        if(errorf != NULL)
         {
-          ast_error_frame(errors, sub,
+          ast_error_frame(errorf, sub,
             "constructor result %s is not a subtype of %s",
             ast_print_type(sub_result), ast_print_type(super_result));
         }
@@ -202,7 +207,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         return false;
       }
 
-      if(!check_machine_words(sub_result, super_result, errors))
+      if(!check_machine_words(sub_result, super_result, errorf))
         return false;
 
       break;
@@ -214,9 +219,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       // Contravariant receiver.
       if(!is_cap_sub_cap(ast_id(super_cap), TK_NONE, ast_id(sub_cap), TK_NONE))
       {
-        if(errors != NULL)
+        if(errorf != NULL)
         {
-          ast_error_frame(errors, sub,
+          ast_error_frame(errorf, sub,
             "%s method is not a subtype of %s method",
             ast_print_type(sub_cap), ast_print_type(super_cap));
         }
@@ -225,11 +230,11 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       }
 
       // Covariant result.
-      if(!is_subtype(sub_result, super_result, errors))
+      if(!is_subtype(sub_result, super_result, errorf, opt))
       {
-        if(errors != NULL)
+        if(errorf != NULL)
         {
-          ast_error_frame(errors, sub,
+          ast_error_frame(errorf, sub,
             "method result %s is not a subtype of %s",
             ast_print_type(sub_result), ast_print_type(super_result));
         }
@@ -237,7 +242,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         return false;
       }
 
-      if(!check_machine_words(sub_result, super_result, errors))
+      if(!check_machine_words(sub_result, super_result, errorf))
         return false;
 
       break;
@@ -255,11 +260,11 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
     ast_t* sub_constraint = ast_childidx(sub_typeparam, 1);
     ast_t* super_constraint = ast_childidx(super_typeparam, 1);
 
-    if(!is_subtype(super_constraint, sub_constraint, errors))
+    if(!is_subtype(super_constraint, sub_constraint, errorf, opt))
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub,
+        ast_error_frame(errorf, sub,
           "type parameter constraint %s is not a supertype of %s",
           ast_print_type(sub_constraint), ast_print_type(super_constraint));
       }
@@ -281,18 +286,18 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
     ast_t* super_type = ast_childidx(super_param, 1);
 
     // Contravariant: the super type must be a subtype of the sub type.
-    if(!is_subtype(super_type, sub_type, errors))
+    if(!is_subtype(super_type, sub_type, errorf, opt))
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub, "parameter %s is not a supertype of %s",
+        ast_error_frame(errorf, sub, "parameter %s is not a supertype of %s",
           ast_print_type(sub_type), ast_print_type(super_type));
       }
 
       return false;
     }
 
-    if(!check_machine_words(sub_type, super_type, errors))
+    if(!check_machine_words(sub_type, super_type, errorf))
       return false;
 
     sub_param = ast_sibling(sub_param);
@@ -303,9 +308,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
   if((ast_id(sub_throws) == TK_QUESTION) &&
     (ast_id(super_throws) != TK_QUESTION))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "a partial function is not a subtype of a total function");
     }
 
@@ -315,7 +320,8 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
   return true;
 }
 
-static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   token_id tsub = ast_id(sub);
   token_id tsuper = ast_id(super);
@@ -348,9 +354,9 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
   // Must have the same name.
   if(ast_name(sub_id) != ast_name(super_id))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "method %s is not a subtype of method %s: they have different names",
         ast_name(sub_id), ast_name(super_id));
     }
@@ -361,8 +367,8 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
   // A constructor can only be a subtype of a constructor.
   if(((tsub == TK_NEW) || (tsuper == TK_NEW)) && (tsub != tsuper))
   {
-    if(errors != NULL)
-      ast_error_frame(errors, sub,
+    if(errorf != NULL)
+      ast_error_frame(errorf, sub,
         "only a constructor can be a subtype of a constructor");
 
     return false;
@@ -371,8 +377,8 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
   // Must have the same number of type parameters.
   if(ast_childcount(sub_typeparams) != ast_childcount(super_typeparams))
   {
-    if(errors != NULL)
-      ast_error_frame(errors, sub,
+    if(errorf != NULL)
+      ast_error_frame(errorf, sub,
         "methods have a different number of type parameters");
 
     return false;
@@ -381,8 +387,8 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
   // Must have the same number of parameters.
   if(ast_childcount(sub_params) != ast_childcount(super_params))
   {
-    if(errors != NULL)
-      ast_error_frame(errors, sub,
+    if(errorf != NULL)
+      ast_error_frame(errorf, sub,
         "methods have a different number of parameters");
 
     return false;
@@ -411,11 +417,11 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
       super_typeparam = ast_sibling(super_typeparam);
     }
 
-    r_sub = reify(sub, sub_typeparams, typeargs);
+    r_sub = reify(sub, sub_typeparams, typeargs, opt);
     ast_free_unattached(typeargs);
   }
 
-  bool ok = is_reified_fun_sub_fun(r_sub, super, errors);
+  bool ok = is_reified_fun_sub_fun(r_sub, super, errorf, opt);
 
   if(r_sub != sub)
     ast_free_unattached(r_sub);
@@ -423,7 +429,8 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errors)
   return ok;
 }
 
-static bool is_x_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_x_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // T1 <: T2
   // T1 <: T3
@@ -433,11 +440,11 @@ static bool is_x_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
     child != NULL;
     child = ast_sibling(child))
   {
-    if(!is_subtype(sub, child, errors))
+    if(!is_subtype(sub, child, errorf, opt))
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub,
+        ast_error_frame(errorf, sub,
           "%s is not a subtype of every element of %s",
           ast_print_type(sub), ast_print_type(super));
       }
@@ -449,7 +456,8 @@ static bool is_x_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
   return true;
 }
 
-static bool is_x_sub_union(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_x_sub_union(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // TODO: a tuple may be a subtype of a union of tuples without being a
   // subtype of any one element of the union.
@@ -461,27 +469,28 @@ static bool is_x_sub_union(ast_t* sub, ast_t* super, errorframe_t* errors)
     child != NULL;
     child = ast_sibling(child))
   {
-    if(is_subtype(sub, child, NULL))
+    if(is_subtype(sub, child, NULL, opt))
       return true;
   }
 
-  if(errors != NULL)
+  if(errorf != NULL)
   {
     for(ast_t* child = ast_child(super);
       child != NULL;
       child = ast_sibling(child))
     {
-      is_subtype(sub, child, errors);
+      is_subtype(sub, child, errorf, opt);
     }
 
-    ast_error_frame(errors, sub, "%s is not a subtype of any element of %s",
+    ast_error_frame(errorf, sub, "%s is not a subtype of any element of %s",
       ast_print_type(sub), ast_print_type(super));
   }
 
   return false;
 }
 
-static bool is_union_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_union_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // T1 <: T3
   // T2 <: T3
@@ -491,11 +500,11 @@ static bool is_union_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
     child != NULL;
     child = ast_sibling(child))
   {
-    if(!is_subtype(child, super, errors))
+    if(!is_subtype(child, super, errorf, opt))
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, child,
+        ast_error_frame(errorf, child,
           "not every element of %s is a subtype of %s",
           ast_print_type(sub), ast_print_type(super));
       }
@@ -507,7 +516,8 @@ static bool is_union_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
   return true;
 }
 
-static bool is_isect_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_isect_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // (T1 & T2) <: T3
   // (T1 & T2) <: T4
@@ -517,7 +527,7 @@ static bool is_isect_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   while(super_child != NULL)
   {
-    if(!is_isect_sub_x(sub, super_child, errors))
+    if(!is_isect_sub_x(sub, super_child, errorf, opt))
       return false;
 
     super_child = ast_sibling(super_child);
@@ -526,13 +536,14 @@ static bool is_isect_sub_isect(ast_t* sub, ast_t* super, errorframe_t* errors)
   return true;
 }
 
-static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   switch(ast_id(super))
   {
     case TK_ISECTTYPE:
       // (T1 & T2) <: (T3 & T4)
-      return is_isect_sub_isect(sub, super, errors);
+      return is_isect_sub_isect(sub, super, errorf, opt);
 
     case TK_NOMINAL:
     {
@@ -542,7 +553,7 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
       // (T1 & T2) <: I k
       if(ast_id(super_def) == TK_INTERFACE)
       {
-        // return is_isect_sub_interface(sub, super, errors);
+        // return is_isect_sub_interface(sub, super, errorf);
       }
       break;
     }
@@ -557,20 +568,21 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
     child != NULL;
     child = ast_sibling(child))
   {
-    if(is_subtype(child, super, NULL))
+    if(is_subtype(child, super, NULL, opt))
       return true;
   }
 
-  if(errors != NULL)
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub, "no element of %s is a subtype of %s",
+    ast_error_frame(errorf, sub, "no element of %s is a subtype of %s",
       ast_print_type(sub), ast_print_type(super));
   }
 
   return false;
 }
 
-static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // T1 <: T3
   // T2 <: T4
@@ -578,9 +590,9 @@ static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
   // (T1, T2) <: (T3, T4)
   if(ast_childcount(sub) != ast_childcount(super))
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: they have a different number of elements",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -594,27 +606,29 @@ static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   while(sub_child != NULL)
   {
-    if(!is_subtype(sub_child, super_child, errors))
+    if(!is_subtype(sub_child, super_child, errorf, opt))
       ret = false;
 
     sub_child = ast_sibling(sub_child);
     super_child = ast_sibling(super_child);
   }
 
-  if(!ret && errors != NULL)
+  if(!ret && errorf != NULL)
   {
-    ast_error_frame(errors, sub, "%s is not a pairwise subtype of %s",
+    ast_error_frame(errorf, sub, "%s is not a pairwise subtype of %s",
       ast_print_type(sub), ast_print_type(super));
   }
 
   return ret;
 }
 
-static bool is_tuple_sub_single(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_tuple_sub_single(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
-  if(errors != NULL)
+  (void)opt;
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub,
+    ast_error_frame(errorf, sub,
       "%s is not a subytpe of %s: the subtype is a tuple",
       ast_print_type(sub), ast_print_type(super));
   }
@@ -622,11 +636,13 @@ static bool is_tuple_sub_single(ast_t* sub, ast_t* super, errorframe_t* errors)
   return false;
 }
 
-static bool is_single_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_single_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
-  if(errors != NULL)
+  (void)opt;
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub,
+    ast_error_frame(errorf, sub,
       "%s is not a subytpe of %s: the supertype is a tuple",
       ast_print_type(sub), ast_print_type(super));
   }
@@ -634,23 +650,24 @@ static bool is_single_sub_tuple(ast_t* sub, ast_t* super, errorframe_t* errors)
   return false;
 }
 
-static bool is_tuple_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_tuple_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   switch(ast_id(super))
   {
     case TK_UNIONTYPE:
-      return is_x_sub_union(sub, super, errors);
+      return is_x_sub_union(sub, super, errorf, opt);
 
     case TK_ISECTTYPE:
-      return is_x_sub_isect(sub, super, errors);
+      return is_x_sub_isect(sub, super, errorf, opt);
 
     case TK_TUPLETYPE:
-      return is_tuple_sub_tuple(sub, super, errors);
+      return is_tuple_sub_tuple(sub, super, errorf, opt);
 
     case TK_NOMINAL:
     case TK_TYPEPARAMREF:
     case TK_ARROW:
-      return is_tuple_sub_single(sub, super, errors);
+      return is_tuple_sub_single(sub, super, errorf, opt);
 
     default: {}
   }
@@ -660,7 +677,7 @@ static bool is_tuple_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
 }
 
 static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // N = C
   // k <: k'
@@ -672,26 +689,26 @@ static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
 
   if(sub_def != super_def)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub, "%s is not a subtype of %s",
+      ast_error_frame(errorf, sub, "%s is not a subtype of %s",
         ast_print_type(sub), ast_print_type(super));
     }
 
     return false;
   }
 
-  if(!is_eq_typeargs(sub, super, errors))
+  if(!is_eq_typeargs(sub, super, errorf, opt))
     ret = false;
 
-  if(!is_sub_cap_and_eph(sub, super, errors))
+  if(!is_sub_cap_and_eph(sub, super, errorf, opt))
     ret = false;
 
   return ret;
 }
 
 static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // implements(N, I)
   // k <: k'
@@ -701,7 +718,7 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
   ast_t* super_def = (ast_t*)ast_data(super);
 
   // Add an assumption: sub <: super
-  if(push_assume(sub, super))
+  if(push_assume(sub, super, opt))
     return true;
 
   bool ret = true;
@@ -711,16 +728,16 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
   {
     ret = false;
 
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: a struct can't be a subtype of an "
         "interface",
         ast_print_type(sub), ast_print_type(super));
     }
   }
 
-  if(!is_sub_cap_and_eph(sub, super, errors))
+  if(!is_sub_cap_and_eph(sub, super, errorf, opt))
     ret = false;
 
   ast_t* sub_typeargs = ast_childidx(sub, 2);
@@ -740,9 +757,9 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
     // If we don't provide a method, we aren't a subtype.
     if(sub_member == NULL)
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub,
+        ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: it has no method %s",
           ast_print_type(sub), ast_print_type(super),
           ast_name(super_member_id));
@@ -754,16 +771,16 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
     }
 
     // Reify the method on the subtype.
-    ast_t* r_sub_member = reify(sub_member, sub_typeparams, sub_typeargs);
+    ast_t* r_sub_member = reify(sub_member, sub_typeparams, sub_typeargs, opt);
     assert(r_sub_member != NULL);
 
     // Reify the method on the supertype.
     ast_t* r_super_member = reify(super_member, super_typeparams,
-      super_typeargs);
+      super_typeargs, opt);
     assert(r_super_member != NULL);
 
     // Check the reified methods.
-    bool ok = is_fun_sub_fun(r_sub_member, r_super_member, errors);
+    bool ok = is_fun_sub_fun(r_sub_member, r_super_member, errorf, opt);
     ast_free_unattached(r_sub_member);
     ast_free_unattached(r_super_member);
 
@@ -771,9 +788,9 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
     {
       ret = false;
 
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub_member,
+        ast_error_frame(errorf, sub_member,
           "%s is not a subtype of %s: method %s has an incompatible signature",
           ast_print_type(sub), ast_print_type(super),
           ast_name(super_member_id));
@@ -788,7 +805,7 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
 }
 
 static bool nominal_provides_trait(ast_t* type, ast_t* trait,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // Get our typeparams and typeargs.
   ast_t* def = (ast_t*)ast_data(type);
@@ -806,12 +823,12 @@ static bool nominal_provides_trait(ast_t* type, ast_t* trait,
   while(child != NULL)
   {
     // Reify the child with our typeargs.
-    ast_t* r_child = reify(child, typeparams, typeargs);
+    ast_t* r_child = reify(child, typeparams, typeargs, opt);
     assert(r_child != NULL);
 
     // Use the cap and ephemerality of the trait.
     ast_t* rr_child = set_cap_and_ephemeral(r_child, tcap, teph);
-    bool is_sub = is_subtype(rr_child, trait, NULL);
+    bool is_sub = is_subtype(rr_child, trait, NULL, opt);
     ast_free_unattached(rr_child);
 
     if(r_child != child)
@@ -823,30 +840,31 @@ static bool nominal_provides_trait(ast_t* type, ast_t* trait,
     child = ast_sibling(child);
   }
 
-  if(errors != NULL)
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, type, "%s does not implement trait %s",
+    ast_error_frame(errorf, type, "%s does not implement trait %s",
       ast_print_type(type), ast_print_type(trait));
   }
 
   return false;
 }
 
-static bool is_entity_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_entity_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // implements(C, R)
   // k <: k'
   // ---
   // C k <: R k'
-  return nominal_provides_trait(sub, super, errors) &&
-    is_sub_cap_and_eph(sub, super, errors);
+  return nominal_provides_trait(sub, super, errorf, opt) &&
+    is_sub_cap_and_eph(sub, super, errorf, opt);
 }
 
-static bool is_struct_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_struct_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errorf)
 {
-  if(errors != NULL)
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub,
+    ast_error_frame(errorf, sub,
       "%s is a struct, so it cannot be a subtype of trait %s",
       ast_print_type(sub), ast_print_type(super));
   }
@@ -854,7 +872,8 @@ static bool is_struct_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errors)
   return false;
 }
 
-static bool is_trait_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_trait_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // R = R' or implements(R, R')
   // k <: k'
@@ -866,26 +885,26 @@ static bool is_trait_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(sub_def == super_def)
   {
-    if(!is_eq_typeargs(sub, super, errors))
+    if(!is_eq_typeargs(sub, super, errorf, opt))
       ret = false;
   }
-  else if(!nominal_provides_trait(sub, super, errors))
+  else if(!nominal_provides_trait(sub, super, errorf, opt))
   {
     ret = false;
   }
 
-  if(!is_sub_cap_and_eph(sub, super, errors))
+  if(!is_sub_cap_and_eph(sub, super, errorf, opt))
     ret = false;
 
   return ret;
 }
 
 static bool is_interface_sub_trait(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf)
 {
-  if(errors != NULL)
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub,
+    ast_error_frame(errorf, sub,
       "%s is an interface, so it cannot be a subtype of trait %s",
       ast_print_type(sub), ast_print_type(super));
   }
@@ -894,7 +913,7 @@ static bool is_interface_sub_trait(ast_t* sub, ast_t* super,
 }
 
 static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // N k <: I k'
   ast_t* sub_def = (ast_t*)ast_data(sub);
@@ -905,16 +924,16 @@ static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
     case TK_PRIMITIVE:
     case TK_CLASS:
     case TK_ACTOR:
-      return is_entity_sub_trait(sub, super, errors);
+      return is_entity_sub_trait(sub, super, errorf, opt);
 
     case TK_STRUCT:
-      return is_struct_sub_trait(sub, super, errors);
+      return is_struct_sub_trait(sub, super, errorf);
 
     case TK_TRAIT:
-      return is_trait_sub_trait(sub, super, errors);
+      return is_trait_sub_trait(sub, super, errorf, opt);
 
     case TK_INTERFACE:
-      return is_interface_sub_trait(sub, super, errors);
+      return is_interface_sub_trait(sub, super, errorf);
 
     default: {}
   }
@@ -924,7 +943,7 @@ static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
 }
 
 static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // N k <: N' k'
   ast_t* super_def = (ast_t*)ast_data(super);
@@ -935,13 +954,13 @@ static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
     case TK_STRUCT:
     case TK_CLASS:
     case TK_ACTOR:
-      return is_nominal_sub_entity(sub, super, errors);
+      return is_nominal_sub_entity(sub, super, errorf, opt);
 
     case TK_INTERFACE:
-      return is_nominal_sub_interface(sub, super, errors);
+      return is_nominal_sub_interface(sub, super, errorf, opt);
 
     case TK_TRAIT:
-      return is_nominal_sub_trait(sub, super, errors);
+      return is_nominal_sub_trait(sub, super, errorf, opt);
 
     default: {}
   }
@@ -951,7 +970,7 @@ static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
 }
 
 static bool is_nominal_sub_typeparam(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // N k <: lowerbound(A k')
   // ---
@@ -960,9 +979,9 @@ static bool is_nominal_sub_typeparam(ast_t* sub, ast_t* super,
 
   if(super_lower == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the type parameter has no lower bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -970,13 +989,13 @@ static bool is_nominal_sub_typeparam(ast_t* sub, ast_t* super,
     return false;
   }
 
-  bool ok = is_subtype(sub, super_lower, errors);
+  bool ok = is_subtype(sub, super_lower, errorf, opt);
   ast_free_unattached(super_lower);
   return ok;
 }
 
 static bool is_nominal_sub_arrow(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // N k <: lowerbound(T1->T2)
   // ---
@@ -985,9 +1004,9 @@ static bool is_nominal_sub_arrow(ast_t* sub, ast_t* super,
 
   if(super_lower == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -995,33 +1014,34 @@ static bool is_nominal_sub_arrow(ast_t* sub, ast_t* super,
     return false;
   }
 
-  bool ok = is_subtype(sub, super_lower, errors);
+  bool ok = is_subtype(sub, super_lower, errorf, opt);
   ast_free_unattached(super_lower);
   return ok;
 }
 
-static bool is_nominal_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_nominal_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // N k <: T
   switch(ast_id(super))
   {
     case TK_UNIONTYPE:
-      return is_x_sub_union(sub, super, errors);
+      return is_x_sub_union(sub, super, errorf, opt);
 
     case TK_ISECTTYPE:
-      return is_x_sub_isect(sub, super, errors);
+      return is_x_sub_isect(sub, super, errorf, opt);
 
     case TK_TUPLETYPE:
-      return is_single_sub_tuple(sub, super, errors);
+      return is_single_sub_tuple(sub, super, errorf, opt);
 
     case TK_NOMINAL:
-      return is_nominal_sub_nominal(sub, super, errors);
+      return is_nominal_sub_nominal(sub, super, errorf, opt);
 
     case TK_TYPEPARAMREF:
-      return is_nominal_sub_typeparam(sub, super, errors);
+      return is_nominal_sub_typeparam(sub, super, errorf, opt);
 
     case TK_ARROW:
-      return is_nominal_sub_arrow(sub, super, errors);
+      return is_nominal_sub_arrow(sub, super, errorf, opt);
 
     default: {}
   }
@@ -1031,11 +1051,12 @@ static bool is_nominal_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
 }
 
 static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // k <: k'
   // ---
   // A k <: A k'
+  (void)opt;
   ast_t* sub_def = (ast_t*)ast_data(sub);
   ast_t* super_def = (ast_t*)ast_data(super);
 
@@ -1051,9 +1072,9 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
     if(!is_cap_sub_cap_bound(ast_id(sub_cap), ast_id(sub_eph),
       ast_id(super_cap), ast_id(super_eph)))
     {
-      if(errors != NULL)
+      if(errorf != NULL)
       {
-        ast_error_frame(errors, sub,
+        ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: %s%s is not a subtype of %s%s",
           ast_print_type(sub), ast_print_type(super),
           ast_print_type(sub_cap), ast_print_type(sub_eph),
@@ -1066,9 +1087,9 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
     return true;
   }
 
-  if(errors != NULL)
+  if(errorf != NULL)
   {
-    ast_error_frame(errors, sub,
+    ast_error_frame(errorf, sub,
       "%s is not a subtype of %s: they are different type parameters",
       ast_print_type(sub), ast_print_type(super));
   }
@@ -1077,7 +1098,7 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
 }
 
 static bool is_typeparam_sub_arrow(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // forall k' in k . A k' <: lowerbound(T1->T2 {A k |-> A k'})
   // ---
@@ -1087,7 +1108,7 @@ static bool is_typeparam_sub_arrow(ast_t* sub, ast_t* super,
 
   if(r_sub != NULL)
   {
-    bool ok = is_subtype(r_sub, r_super, errors);
+    bool ok = is_subtype(r_sub, r_super, errorf, opt);
     ast_free_unattached(r_sub);
     ast_free_unattached(r_super);
     return ok;
@@ -1102,9 +1123,9 @@ static bool is_typeparam_sub_arrow(ast_t* sub, ast_t* super,
 
   if(super_lower == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -1112,31 +1133,31 @@ static bool is_typeparam_sub_arrow(ast_t* sub, ast_t* super,
     return false;
   }
 
-  bool ok = is_subtype(sub, super_lower, errors);
+  bool ok = is_subtype(sub, super_lower, errorf, opt);
   ast_free_unattached(super_lower);
   return ok;
 }
 
 static bool is_typeparam_base_sub_x(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   switch(ast_id(super))
   {
     case TK_UNIONTYPE:
-      return is_x_sub_union(sub, super, errors);
+      return is_x_sub_union(sub, super, errorf, opt);
 
     case TK_ISECTTYPE:
-      return is_x_sub_isect(sub, super, errors);
+      return is_x_sub_isect(sub, super, errorf, opt);
 
     case TK_TUPLETYPE:
     case TK_NOMINAL:
       return false;
 
     case TK_TYPEPARAMREF:
-      return is_typeparam_sub_typeparam(sub, super, errors);
+      return is_typeparam_sub_typeparam(sub, super, errorf, opt);
 
     case TK_ARROW:
-      return is_typeparam_sub_arrow(sub, super, errors);
+      return is_typeparam_sub_arrow(sub, super, errorf, opt);
 
     default: {}
   }
@@ -1145,9 +1166,10 @@ static bool is_typeparam_base_sub_x(ast_t* sub, ast_t* super,
   return false;
 }
 
-static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
-  if(is_typeparam_base_sub_x(sub, super, false))
+  if(is_typeparam_base_sub_x(sub, super, false, opt))
     return true;
 
   // upperbound(A k) <: T
@@ -1157,9 +1179,9 @@ static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(sub_upper == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no constraint",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -1167,13 +1189,13 @@ static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
     return false;
   }
 
-  bool ok = is_subtype(sub_upper, super, errors);
+  bool ok = is_subtype(sub_upper, super, errorf, opt);
   ast_free_unattached(sub_upper);
   return ok;
 }
 
-static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // upperbound(T1->T2) <: N k
   // ---
@@ -1182,9 +1204,9 @@ static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super,
 
   if(sub_upper == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no upper bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -1192,13 +1214,13 @@ static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super,
     return false;
   }
 
-  bool ok = is_subtype(sub_upper, super, errors);
+  bool ok = is_subtype(sub_upper, super, errorf, opt);
   ast_free_unattached(sub_upper);
   return ok;
 }
 
 static bool is_arrow_sub_typeparam(ast_t* sub, ast_t* super,
-  errorframe_t* errors)
+  errorframe_t* errorf, pass_opt_t* opt)
 {
   // forall k' in k . T1->T2 {A k |-> A k'} <: A k'
   // ---
@@ -1208,17 +1230,18 @@ static bool is_arrow_sub_typeparam(ast_t* sub, ast_t* super,
 
   if(r_sub != NULL)
   {
-    bool ok = is_subtype(r_sub, r_super, errors);
+    bool ok = is_subtype(r_sub, r_super, errorf, opt);
     ast_free_unattached(r_sub);
     ast_free_unattached(r_super);
     return ok;
   }
 
   // If there is only a single instantiation, treat as a nominal type.
-  return is_arrow_sub_nominal(sub, super, errors);
+  return is_arrow_sub_nominal(sub, super, errorf, opt);
 }
 
-static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   // S = this | A {#read, #send, #share, #any}
   // K = N k | A {iso, trn, ref, val, box, tag} | K->K | (empty)
@@ -1233,7 +1256,7 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(viewpoint_reifypair(sub, super, &r_sub, &r_super))
   {
-    bool ok = is_subtype(r_sub, r_super, errors);
+    bool ok = is_subtype(r_sub, r_super, errorf, opt);
     ast_free_unattached(r_sub);
     ast_free_unattached(r_super);
     return ok;
@@ -1250,9 +1273,9 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(sub_upper == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no upper bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -1262,9 +1285,9 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
 
   if(super_lower == NULL)
   {
-    if(errors != NULL)
+    if(errorf != NULL)
     {
-      ast_error_frame(errors, sub,
+      ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
         ast_print_type(sub), ast_print_type(super));
     }
@@ -1273,34 +1296,35 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, errorframe_t* errors)
   }
 
   if(ok)
-    ok = is_subtype(sub_upper, super_lower, errors);
+    ok = is_subtype(sub_upper, super_lower, errorf, opt);
 
   ast_free_unattached(sub_upper);
   ast_free_unattached(super_lower);
   return ok;
 }
 
-static bool is_arrow_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
+static bool is_arrow_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   switch(ast_id(super))
   {
     case TK_UNIONTYPE:
-      return is_x_sub_union(sub, super, errors);
+      return is_x_sub_union(sub, super, errorf, opt);
 
     case TK_ISECTTYPE:
-      return is_x_sub_isect(sub, super, errors);
+      return is_x_sub_isect(sub, super, errorf, opt);
 
     case TK_TUPLETYPE:
-      return is_single_sub_tuple(sub, super, errors);
+      return is_single_sub_tuple(sub, super, errorf, opt);
 
     case TK_NOMINAL:
-      return is_arrow_sub_nominal(sub, super, errors);
+      return is_arrow_sub_nominal(sub, super, errorf, opt);
 
     case TK_TYPEPARAMREF:
-      return is_arrow_sub_typeparam(sub, super, errors);
+      return is_arrow_sub_typeparam(sub, super, errorf, opt);
 
     case TK_ARROW:
-      return is_arrow_sub_arrow(sub, super, errors);
+      return is_arrow_sub_arrow(sub, super, errorf, opt);
 
     default: {}
   }
@@ -1309,7 +1333,8 @@ static bool is_arrow_sub_x(ast_t* sub, ast_t* super, errorframe_t* errors)
   return false;
 }
 
-bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errors)
+bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
   assert(sub != NULL);
   assert(super != NULL);
@@ -1320,22 +1345,22 @@ bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errors)
   switch(ast_id(sub))
   {
     case TK_UNIONTYPE:
-      return is_union_sub_x(sub, super, errors);
+      return is_union_sub_x(sub, super, errorf, opt);
 
     case TK_ISECTTYPE:
-      return is_isect_sub_x(sub, super, errors);
+      return is_isect_sub_x(sub, super, errorf, opt);
 
     case TK_TUPLETYPE:
-      return is_tuple_sub_x(sub, super, errors);
+      return is_tuple_sub_x(sub, super, errorf, opt);
 
     case TK_NOMINAL:
-      return is_nominal_sub_x(sub, super, errors);
+      return is_nominal_sub_x(sub, super, errorf, opt);
 
     case TK_TYPEPARAMREF:
-      return is_typeparam_sub_x(sub, super, errors);
+      return is_typeparam_sub_x(sub, super, errorf, opt);
 
     case TK_ARROW:
-      return is_arrow_sub_x(sub, super, errors);
+      return is_arrow_sub_x(sub, super, errorf, opt);
 
     case TK_FUNTYPE:
     case TK_INFERTYPE:
@@ -1345,7 +1370,7 @@ bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errors)
     case TK_NEW:
     case TK_BE:
     case TK_FUN:
-      return is_fun_sub_fun(sub, super, errors);
+      return is_fun_sub_fun(sub, super, errorf, opt);
 
     default: {}
   }
@@ -1354,9 +1379,9 @@ bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errors)
   return false;
 }
 
-bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errors)
+bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt)
 {
-  return is_subtype(a, b, errors) && is_subtype(b, a, errors);
+  return is_subtype(a, b, errorf, opt) && is_subtype(b, a, errorf, opt);
 }
 
 bool is_literal(ast_t* type, const char* name)

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -4,6 +4,7 @@
 #include <platform.h>
 #include "../ast/ast.h"
 #include "../ast/error.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -11,9 +12,10 @@ bool is_literal(ast_t* type, const char* name);
 
 bool is_sub_cap_and_ephemeral(ast_t* sub, ast_t* super);
 
-bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errors);
+bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt);
 
-bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errors);
+bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt);
 
 bool is_pointer(ast_t* type);
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -257,14 +257,14 @@ int main(int argc, char* argv[])
       case OPT_DEBUG: opt.release = false; break;
       case OPT_BUILDFLAG: define_build_flag(s.arg_val); break;
       case OPT_STRIP: opt.strip_debug = true; break;
-      case OPT_PATHS: package_add_paths(s.arg_val); break;
+      case OPT_PATHS: package_add_paths(s.arg_val, &opt); break;
       case OPT_OUTPUT: opt.output = s.arg_val; break;
       case OPT_PIC: opt.pic = true; break;
       case OPT_LIBRARY: opt.library = true; break;
       case OPT_DOCS: opt.docs = true; break;
 
       case OPT_SAFE:
-        if(!package_add_safe(s.arg_val))
+        if(!package_add_safe(s.arg_val, &opt))
           ok = false;
         break;
 
@@ -278,10 +278,10 @@ int main(int argc, char* argv[])
       case OPT_ASTPACKAGE: print_package_ast = true; break;
       case OPT_TRACE: parse_trace(true); break;
       case OPT_WIDTH: ast_setwidth(atoi(s.arg_val)); break;
-      case OPT_IMMERR: error_set_immediate(true); break;
+      case OPT_IMMERR: errors_set_immediate(opt.check.errors, true); break;
       case OPT_VERIFY: opt.verify = true; break;
       case OPT_FILENAMES: opt.print_filenames = true; break;
-      case OPT_CHECKTREE: enable_check_tree(true); break;
+      case OPT_CHECKTREE: opt.check_tree = true; break;
 
       case OPT_BNF: print_grammar(false, true); return 0;
       case OPT_ANTLR: print_grammar(true, true); return 0;
@@ -326,7 +326,7 @@ int main(int argc, char* argv[])
 
   if(!ok)
   {
-    print_errors();
+    errors_print(opt.check.errors);
 
     if(print_usage)
       usage();
@@ -346,7 +346,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  if(!ok && get_error_count() == 0)
+  if(!ok && errors_get_count(opt.check.errors) == 0)
     printf("Error: internal failure not reported\n");
 
   ponyc_shutdown(&opt);

--- a/test/libponyc/id.cc
+++ b/test/libponyc/id.cc
@@ -14,7 +14,12 @@ static void test_id(const char* id, bool expect_pass, int spec)
   ast_t* node = ast_blank(TK_ID);
   ast_set_name(node, id);
 
-  bool r = check_id(node, "test", spec);
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  bool r = check_id(&opt, node, "test", spec);
+
+  pass_opt_done(&opt);
 
   ast_free(node);
 

--- a/test/libponyc/lexer.cc
+++ b/test/libponyc/lexer.cc
@@ -34,8 +34,9 @@ protected:
   // Errors are checked with ASSERTs, call in ASSERT_NO_FATAL_FAILURE.
   void test(const char* src)
   {
+    errors_t* errors = errors_alloc();
     source_t* source = source_open_string(src);
-    lexer_t* lexer = lexer_open(source);
+    lexer_t* lexer = lexer_open(source, errors);
     token_id id = TK_LEX_ERROR;
     string actual;
 
@@ -63,6 +64,7 @@ protected:
 
     lexer_close(lexer);
     source_close(source);
+    errors_free(errors);
 
     ASSERT_STREQ(_expected.c_str(), actual.c_str());
   }

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -35,24 +35,29 @@ TEST_F(MatchTypeTest, SimpleTypes)
 
   TEST_COMPILE(src);
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1")));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("t1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1")));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c2"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1"), &opt));
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1")));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("t1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1"), &opt));
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("i1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1")));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t2"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1"), &opt));
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("i2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1")));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("i1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1"), &opt));
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1")));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("i2"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1"), &opt));
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t2"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1"), &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -89,29 +94,52 @@ TEST_F(MatchTypeTest, CompoundOperand)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // (C1 | C2)
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("t1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("t2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("i1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("i2")));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("t1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("t2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("i1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("i2"), &opt));
 
   // (C1 | T2)
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1ort2"), type_of("c2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t2")));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1ort2"), type_of("c2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t2"), &opt));
 
   // (T1 & T2)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("c3")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t3")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i2")));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("c3"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t3"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i2"), &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -148,29 +176,52 @@ TEST_F(MatchTypeTest, CompoundPattern)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // (C1 | C2)
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1or2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c2"), type_of("c1or2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1or2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1or2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1or2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1or2")));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1or2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c2"), type_of("c1or2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1or2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1or2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1or2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1or2"), &opt));
 
   // (C1 | T2)
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1ort2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1ort2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1ort2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("c1ort2")));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1ort2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1ort2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1ort2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("c1ort2"), &opt));
 
   // (T1 & T2)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c3"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t3"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("t1and2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i2"), type_of("t1and2")));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c3"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t3"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("t1and2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i2"), type_of("t1and2"), &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -205,41 +256,48 @@ TEST_F(MatchTypeTest, BothCompound)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // (C1 | C2) vs (T1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc2"), type_of("t1ort2")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc2"), type_of("t1ort2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("c1orc2")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("c1orc2"), &opt));
 
   // (C1 | C2) vs (C3 | T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("c3ort2")));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("c3ort2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c3ort2"), type_of("c1orc2")));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c3ort2"), type_of("c1orc2"), &opt));
 
   // (C1 | C2) vs (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("t1andt2")));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("t1andt2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("t1andt2"), type_of("c1orc2")));
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1andt2"), type_of("c1orc2"), &opt));
 
   // (C1 | C3) vs (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc3"), type_of("t1andt2")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc3"), type_of("t1andt2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("c1orc3")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("c1orc3"), &opt));
 
   // (T1 & T2) vs (T1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("t1ort2")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("t1ort2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("t1andt2")));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("t1andt2"), &opt));
 
   // (T1 & T2) vs (I1 & I2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("i1andi2")));
+    MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("t1andt2"), type_of("i1andi2"), &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1andi2"), type_of("t1andt2")));
+    MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("i1andi2"), type_of("t1andt2"), &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -268,11 +326,18 @@ TEST_F(MatchTypeTest, Tuples)
 
   TEST_COMPILE(src);
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c1c1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1c1"), type_of("c1")));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1c2"), type_of("t1t2")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c3"), type_of("t1t2")));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c1c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1c1"), type_of("c1"), &opt));
+
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1c2"), type_of("t1t2"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c3"), type_of("t1t2"), &opt));
 
   // We can't make types with don't cares in as the type of a parameter. Modify
   // t1t2 instead.
@@ -284,14 +349,16 @@ TEST_F(MatchTypeTest, Tuples)
   REPLACE(&elem2, NODE(TK_DONTCARE));
 
   // (T1, _)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, &opt));
 
   REPLACE(&elem1, NODE(TK_DONTCARE));
 
   // (_, _)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -328,62 +395,67 @@ TEST_F(MatchTypeTest, Capabilities)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // Classes
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1ref"), type_of("c1ref")));
+    is_matchtype(type_of("c1ref"), type_of("c1ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1ref"), type_of("c1val")));
+    is_matchtype(type_of("c1ref"), type_of("c1val"), &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1ref"), type_of("c1box")));
+    is_matchtype(type_of("c1ref"), type_of("c1box"), &opt));
 
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1val"), type_of("c1ref")));
+    is_matchtype(type_of("c1val"), type_of("c1ref"), &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1val"), type_of("c1val")));
+    is_matchtype(type_of("c1val"), type_of("c1val"), &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1val"), type_of("c1box")));
+    is_matchtype(type_of("c1val"), type_of("c1box"), &opt));
 
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1box"), type_of("c1ref")));
+    is_matchtype(type_of("c1box"), type_of("c1ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1box"), type_of("c1val")));
+    is_matchtype(type_of("c1box"), type_of("c1val"), &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1box"), type_of("c1box")));
+    is_matchtype(type_of("c1box"), type_of("c1box"), &opt));
 
   ASSERT_EQ(MATCHTYPE_REJECT,
-    is_matchtype(type_of("c1box"), type_of("c2ref")));
+    is_matchtype(type_of("c1box"), type_of("c2ref"), &opt));
 
   // Tuples
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2ref")));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1valc2ref")));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1valc2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2val")));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2val"), &opt));
 
   // Unions
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2ref")));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1valorc2ref")));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1valorc2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2val")));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2val"), &opt));
 
   // Intersect vs union
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2ref")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1valort2ref")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1valort2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2val")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2val"), &opt));
 
   // Intersects
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2ref")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2ref"), &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2box")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2box"), &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2box")));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2box"), &opt));
+
+  pass_opt_done(&opt);
 }
 
 
@@ -409,15 +481,26 @@ TEST_F(MatchTypeTest, TypeParams)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // Ref constraints
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("ac2"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("at2"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("at1"), type_of("c1")));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("at2"), type_of("t1")));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("ac2"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_REJECT, is_matchtype(type_of("at2"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("at1"), type_of("c1"), &opt));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("at2"), type_of("t1"), &opt));
 
   // Box constraint
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(type_of("at2box"), type_of("t1")));
+  ASSERT_EQ(
+    MATCHTYPE_DENY, is_matchtype(type_of("at2box"), type_of("t1"), &opt));
 
   // Union constraint
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1")));
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1"), &opt));
+
+  pass_opt_done(&opt);
 }

--- a/test/libponyc/program.cc
+++ b/test/libponyc/program.cc
@@ -29,7 +29,14 @@ TEST(ProgramTest, NoLibs)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  program_lib_build_args(prog, "", "", "pre", "post", "", "");
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  program_lib_build_args(prog, &opt, "", "", "pre", "post", "", "");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
   ASSERT_STREQ("prepost", program_lib_args(prog));
 
   ast_free(prog);
@@ -41,9 +48,16 @@ TEST(ProgramTest, OneLib)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "", "", "", "", "", "");
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "", "", "", "", "", "");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect = "\"foo\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -57,9 +71,16 @@ TEST(ProgramTest, OneLibWithAmbles)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "", "", "pre", "post", "lpre", "lpost");
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "", "", "pre", "post", "lpre", "lpost");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect = "prelpre\"foo\"lpost post";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -73,11 +94,18 @@ TEST(ProgramTest, MultipleLibs)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "", "", "", "", "", "");
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "bar", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "wombat", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "", "", "", "", "", "");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect = "\"foo\" \"bar\" \"wombat\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -91,11 +119,18 @@ TEST(ProgramTest, MultipleLibsWithAmbles)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "", "", "pre", "post", "lpre", "lpost");
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "bar", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "wombat", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "", "", "pre", "post", "lpre", "lpost");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect =
     "prelpre\"foo\"lpost lpre\"bar\"lpost lpre\"wombat\"lpost post";
@@ -111,13 +146,20 @@ TEST(ProgramTest, RepeatedLibs)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "bar", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "foo", NULL, NULL));
-  ASSERT_TRUE(use_library(prog, "wombat", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "", "", "" "", "", "", "");
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "bar", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "bar", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "foo", NULL, &opt));
+  ASSERT_TRUE(use_library(prog, "wombat", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "", "", "" "", "", "", "");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect = "\"foo\" \"bar\" \"wombat\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));
@@ -131,11 +173,17 @@ TEST(ProgramTest, BadLibName)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_FALSE(use_library(prog, "foo\nbar", NULL, NULL));
-  ASSERT_FALSE(use_library(prog, "foo\tbar", NULL, NULL));
-  ASSERT_FALSE(use_library(prog, "foo;bar", NULL, NULL));
-  ASSERT_FALSE(use_library(prog, "foo$bar", NULL, NULL));
-  //ASSERT_FALSE(use_library(prog, "foo\\bar", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_FALSE(use_library(prog, "foo\nbar", NULL, &opt));
+  ASSERT_FALSE(use_library(prog, "foo\tbar", NULL, &opt));
+  ASSERT_FALSE(use_library(prog, "foo;bar", NULL, &opt));
+  ASSERT_FALSE(use_library(prog, "foo$bar", NULL, &opt));
+  //ASSERT_FALSE(use_library(prog, "foo\\bar", NULL, &opt));
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 4);
+  pass_opt_done(&opt);
 
   ast_free(prog);
 }
@@ -146,9 +194,16 @@ TEST(ProgramTest, LibPaths)
   ast_t* prog = ast_blank(TK_PROGRAM);
   ASSERT_NE((void*)NULL, prog);
 
-  ASSERT_TRUE(use_path(prog, "foo", NULL, NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  program_lib_build_args(prog, "static", "dynamic", "", "", "", "");
+  ASSERT_TRUE(use_path(prog, "foo", NULL, &opt));
+
+  program_lib_build_args(prog, &opt, "static", "dynamic", "", "", "", "");
+
+  ASSERT_EQ(errors_get_count(opt.check.errors), 0);
+  errors_print(opt.check.errors);
+  pass_opt_done(&opt);
 
   const char* expect = "static\"foo\" dynamic\"foo\" ";
   ASSERT_STREQ(expect, program_lib_args(prog));

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -5,7 +5,10 @@
 
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
-#define TEST_ERRORS_1(src, err1) DO(test_errors_1(src, "expr", err1));
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
 
 
 class RecoverTest : public PassTest

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -35,12 +35,17 @@ TEST_F(SubTypeTest, IsSubTypeClassTrait)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t3"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t3"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t3"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t3"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -69,12 +74,17 @@ TEST_F(SubTypeTest, IsSubTypeClassInterface)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("i1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("i2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("i3"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i3"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("i1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("i2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("i3"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("i3"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -93,9 +103,14 @@ TEST_F(SubTypeTest, IsSubTypeClassClass)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("c1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("c2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c2"), type_of("c1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("c1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("c2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c2"), type_of("c1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -118,11 +133,16 @@ TEST_F(SubTypeTest, IsSubTypeTraitTrait)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("t1"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t3"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1b"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1b"), type_of("t1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("t1"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t3"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1b"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1b"), type_of("t1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -145,11 +165,16 @@ TEST_F(SubTypeTest, IsSubTypeInterfaceInterface)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("i1"), type_of("i1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("i1"), type_of("i3"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("i3"), type_of("i1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("i1"), type_of("i1b"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("i1b"), type_of("i1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("i1"), type_of("i1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("i1"), type_of("i3"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("i3"), type_of("i1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("i1"), type_of("i1b"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("i1b"), type_of("i1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -170,9 +195,14 @@ TEST_F(SubTypeTest, IsSubTypeTraitInterface)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("t1"), type_of("i1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("i2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("i1"), type_of("t1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("t1"), type_of("i1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("i2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("i1"), type_of("t1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -187,9 +217,14 @@ TEST_F(SubTypeTest, IsSubTypePrimitivePrimitive)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("p1"), type_of("p1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("p2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("p2"), type_of("p1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("p1"), type_of("p1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("p2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("p2"), type_of("p1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -212,10 +247,15 @@ TEST_F(SubTypeTest, IsSubTypePrimitiveTrait)
 
   TEST_COMPILE(src);
 
-  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("t2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("p2"), type_of("t1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("p2"), type_of("t2"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("p1"), type_of("t2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("p2"), type_of("t1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("p2"), type_of("t2"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -247,13 +287,18 @@ TEST_F(SubTypeTest, IsSubTypeUnion)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("c1or2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c2"), type_of("c1or2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c3"), type_of("c1or2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1or2"), type_of("c1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c1or2"), type_of("c1or2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("t1or2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1or2"), type_of("c1"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("c1or2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c2"), type_of("c1or2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c3"), type_of("c1or2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1or2"), type_of("c1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c1or2"), type_of("c1or2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("t1or2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1or2"), type_of("c1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -292,30 +337,35 @@ TEST_F(SubTypeTest, IsSubTypeIntersect)
 
   TEST_COMPILE(src);
 
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1and2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t1and2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3"), type_of("t1and2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t1and2"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t1and2"), type_of("t1and2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1and2"), type_of("c3"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1refand2box"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1refand2box"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1valand2box"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1refand2box"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1valand2box"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1valand2box"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t1refand2box"), type_of("t1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t1valand2box"), type_of("t1val"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1and2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t1and2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3"), type_of("t1and2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c3"), type_of("t1and2"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t1and2"), type_of("t1and2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1and2"), type_of("c3"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1val"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1valand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1valand2box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1valand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t1refand2box"), type_of("t1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t1valand2box"), type_of("t1val"), NULL, &opt));
   ASSERT_TRUE(
-    is_subtype(type_of("t1isoand2iso"), type_of("t1refand2box"), NULL));
+    is_subtype(type_of("t1isoand2iso"), type_of("t1refand2box"), NULL, &opt));
   ASSERT_TRUE(
-    is_subtype(type_of("t1trnand2trn"), type_of("t1refand2box"), NULL));
+    is_subtype(type_of("t1trnand2trn"), type_of("t1refand2box"), NULL, &opt));
   ASSERT_TRUE(
-    is_subtype(type_of("t1isoand2iso"), type_of("t1valand2box"), NULL));
+    is_subtype(type_of("t1isoand2iso"), type_of("t1valand2box"), NULL, &opt));
   ASSERT_TRUE(
-    is_subtype(type_of("t1trnand2trn"), type_of("t1valand2box"), NULL));
+    is_subtype(type_of("t1trnand2trn"), type_of("t1valand2box"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -338,12 +388,17 @@ TEST_F(SubTypeTest, IsSubTypeIntersectInterface)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // TODO: Fix this, intersect of non-independent and combinable types
   // (I1 & I2) <: I3
-  //ASSERT_TRUE(is_subtype(type_of("i1and2"), type_of("i3"), NULL));
+  //ASSERT_TRUE(is_subtype(type_of("i1and2"), type_of("i3"), NULL, &opt));
 
   // I3 <: (I1 & I2)
-  ASSERT_TRUE(is_subtype(type_of("i3"), type_of("i1and2"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("i3"), type_of("i1and2"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -360,11 +415,16 @@ TEST_F(SubTypeTest, IsSubTypeIntersectOfUnion)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("iofu"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("c1"), type_of("iofu"), NULL, &opt));
 
   // TODO: Fix this, intersect of non-independent and combinable types
   // ((C1 | C2) & (C1 | C3)) <: C1
-  //ASSERT_TRUE(is_subtype(type_of("iofu"), type_of("c1"), NULL));
+  //ASSERT_TRUE(is_subtype(type_of("iofu"), type_of("c1"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -389,12 +449,17 @@ TEST_F(SubTypeTest, IsSubTypeTuple)
 
   TEST_COMPILE(src);
 
-  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1t1"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1t1"), type_of("t1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("c1c2"), type_of("t1t2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1c2"), type_of("t2t1"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("t1t2"), type_of("t1t2"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("t1t2"), type_of("c1c2"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1t1"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1t1"), type_of("t1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("c1c2"), type_of("t1t2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1c2"), type_of("t2t1"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("t1t2"), type_of("t1t2"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t1t2"), type_of("c1c2"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -412,21 +477,26 @@ TEST_F(SubTypeTest, IsSubTypeUnionOfTuple)
 
   TEST_COMPILE(src);
 
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
   // C1 <!: ((C1 | C2), (C1 | C2))
-  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("tofu"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("c1"), type_of("tofu"), NULL, &opt));
 
   // ((C1, C1) | (C1, C2) | (C2, C1) | (C2, C2)) <: ((C1 | C2), (C1 | C2))
-  ASSERT_TRUE(is_subtype(type_of("uoft4"), type_of("tofu"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("uoft4"), type_of("tofu"), NULL, &opt));
 
   // ((C1, C1) | (C1, C2) | (C2, C1)) <: ((C1 | C2), (C1 | C2))
-  ASSERT_TRUE(is_subtype(type_of("uoft3"), type_of("tofu"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("uoft3"), type_of("tofu"), NULL, &opt));
 
   // TODO: Fix this, union of tuples vs tuple of unions
   // ((C1 | C2), (C1 | C2)) <: ((C1, C1) | (C1, C2) | (C2, C1) | (C2, C2))
-  //ASSERT_TRUE(is_subtype(type_of("tofu"), type_of("uoft4"), NULL));
+  //ASSERT_TRUE(is_subtype(type_of("tofu"), type_of("uoft4"), NULL, &opt));
 
   // ((C1 | C2), (C1 | C2)) <!: ((C1, C1) | (C1, C2) | (C2, C1))
-  ASSERT_FALSE(is_subtype(type_of("tofu"), type_of("uoft3"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("tofu"), type_of("uoft3"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -447,35 +517,40 @@ TEST_F(SubTypeTest, IsSubTypeCap)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1iso"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1ref"), type_of("t1iso"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1val"), type_of("t1iso"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1iso"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1iso"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1ref"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1ref"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1val"), type_of("t1ref"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1ref"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1ref"), NULL));
+  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1iso"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1ref"), type_of("t1iso"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1val"), type_of("t1iso"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1iso"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1iso"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1ref"), type_of("t1val"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1val"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1val"), NULL));
+  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1ref"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1ref"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1val"), type_of("t1ref"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1ref"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1ref"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1box"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1box"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1box"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1box"), type_of("t1box"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1box"), NULL));
+  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1val"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1ref"), type_of("t1val"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1val"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1val"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1val"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1tag"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1tag"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1tag"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1box"), type_of("t1tag"), NULL));
-  ASSERT_TRUE (is_subtype(type_of("c1tag"), type_of("t1tag"), NULL));
+  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1box"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1box"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1box"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1box"), type_of("t1box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1box"), NULL, &opt));
+
+  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1tag"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1tag"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1tag"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1box"), type_of("t1tag"), NULL, &opt));
+  ASSERT_TRUE (is_subtype(type_of("c1tag"), type_of("t1tag"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -508,28 +583,33 @@ TEST_F(SubTypeTest, IsEqType)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_eqtype(type_of("c1"), type_of("c1"), NULL));
-  ASSERT_TRUE(is_eqtype(type_of("c2"), type_of("c2"), NULL));
-  ASSERT_TRUE(is_eqtype(type_of("i1"), type_of("i1"), NULL));
-  ASSERT_TRUE(is_eqtype(type_of("i2"), type_of("i2"), NULL));
-  ASSERT_TRUE(is_eqtype(type_of("t1"), type_of("t1"), NULL));
-  ASSERT_TRUE(is_eqtype(type_of("t2"), type_of("t2"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("c2"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c2"), type_of("c1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("i2"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("i2"), type_of("i1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("t2"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("t2"), type_of("t1"), NULL));
+  ASSERT_TRUE(is_eqtype(type_of("c1"), type_of("c1"), NULL, &opt));
+  ASSERT_TRUE(is_eqtype(type_of("c2"), type_of("c2"), NULL, &opt));
+  ASSERT_TRUE(is_eqtype(type_of("i1"), type_of("i1"), NULL, &opt));
+  ASSERT_TRUE(is_eqtype(type_of("i2"), type_of("i2"), NULL, &opt));
+  ASSERT_TRUE(is_eqtype(type_of("t1"), type_of("t1"), NULL, &opt));
+  ASSERT_TRUE(is_eqtype(type_of("t2"), type_of("t2"), NULL, &opt));
 
-  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("i1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("c1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("t1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("c1"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("i1"), NULL));
+  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("c2"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c2"), type_of("c1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("i2"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("i2"), type_of("i1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("t2"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("t2"), type_of("t1"), NULL, &opt));
 
-  ASSERT_TRUE(is_eqtype(type_of("i1"), type_of("i1b"), NULL));
+  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("i1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("c1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("i1"), type_of("t1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("c1"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("t1"), type_of("i1"), NULL, &opt));
+
+  ASSERT_TRUE(is_eqtype(type_of("i1"), type_of("i1b"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -544,35 +624,40 @@ TEST_F(SubTypeTest, IsEqTypeCap)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE (is_eqtype(type_of("c1iso"), type_of("c1iso"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1iso"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1iso"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1iso"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1iso"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1ref"), NULL));
-  ASSERT_TRUE (is_eqtype(type_of("c1ref"), type_of("c1ref"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1ref"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1ref"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1ref"), NULL));
+  ASSERT_TRUE (is_eqtype(type_of("c1iso"), type_of("c1iso"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1iso"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1iso"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1iso"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1iso"), NULL, &opt));
 
-  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1val"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1val"), NULL));
-  ASSERT_TRUE (is_eqtype(type_of("c1val"), type_of("c1val"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1val"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1val"), NULL));
+  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1ref"), NULL, &opt));
+  ASSERT_TRUE (is_eqtype(type_of("c1ref"), type_of("c1ref"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1ref"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1ref"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1ref"), NULL, &opt));
 
-  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1box"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1box"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1box"), NULL));
-  ASSERT_TRUE (is_eqtype(type_of("c1box"), type_of("c1box"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1box"), NULL));
+  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1val"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1val"), NULL, &opt));
+  ASSERT_TRUE (is_eqtype(type_of("c1val"), type_of("c1val"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1val"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1val"), NULL, &opt));
 
-  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1tag"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1tag"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1tag"), NULL));
-  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1tag"), NULL));
-  ASSERT_TRUE (is_eqtype(type_of("c1tag"), type_of("c1tag"), NULL));
+  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1box"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1box"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1box"), NULL, &opt));
+  ASSERT_TRUE (is_eqtype(type_of("c1box"), type_of("c1box"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1tag"), type_of("c1box"), NULL, &opt));
+
+  ASSERT_FALSE(is_eqtype(type_of("c1iso"), type_of("c1tag"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1ref"), type_of("c1tag"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1val"), type_of("c1tag"), NULL, &opt));
+  ASSERT_FALSE(is_eqtype(type_of("c1box"), type_of("c1tag"), NULL, &opt));
+  ASSERT_TRUE (is_eqtype(type_of("c1tag"), type_of("c1tag"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -592,6 +677,9 @@ TEST_F(SubTypeTest, IsNone)
     "    union: (Bool | None), intersect: (Bool & None))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_TRUE(is_none(type_of("none")));
   ASSERT_FALSE(is_none(type_of("bool")));
@@ -614,6 +702,8 @@ TEST_F(SubTypeTest, IsNone)
   ASSERT_FALSE(is_none(type_of("t1")));
   ASSERT_FALSE(is_none(type_of("union")));
   ASSERT_FALSE(is_none(type_of("intersect")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -633,6 +723,9 @@ TEST_F(SubTypeTest, IsBool)
     "    union: (Bool | None), intersect: (Bool & None))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_FALSE(is_bool(type_of("none")));
   ASSERT_TRUE(is_bool(type_of("bool")));
@@ -655,6 +748,8 @@ TEST_F(SubTypeTest, IsBool)
   ASSERT_FALSE(is_bool(type_of("t1")));
   ASSERT_FALSE(is_bool(type_of("union")));
   ASSERT_FALSE(is_bool(type_of("intersect")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -675,6 +770,9 @@ TEST_F(SubTypeTest, IsFloat)
     "    f32or64: (F32 | F64), f32and64: (F32 & F64))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_FALSE(is_float(type_of("none")));
   ASSERT_FALSE(is_float(type_of("bool")));
@@ -699,6 +797,8 @@ TEST_F(SubTypeTest, IsFloat)
   ASSERT_FALSE(is_float(type_of("f32andnone")));
   ASSERT_FALSE(is_float(type_of("f32or64")));
   ASSERT_FALSE(is_float(type_of("f32and64")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -719,6 +819,9 @@ TEST_F(SubTypeTest, IsInteger)
     "    u8ori32: (U8 | I32), u8andi32: (U8 & I32))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_FALSE(is_integer(type_of("none")));
   ASSERT_FALSE(is_integer(type_of("bool")));
@@ -743,6 +846,8 @@ TEST_F(SubTypeTest, IsInteger)
   ASSERT_FALSE(is_integer(type_of("u8andnone")));
   ASSERT_FALSE(is_integer(type_of("u8ori32")));
   ASSERT_FALSE(is_integer(type_of("u8andi32")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -763,6 +868,9 @@ TEST_F(SubTypeTest, IsMachineWord)
     "    u8ori32: (U8 | I32), u8andi32: (U8 & I32))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_FALSE(is_machine_word(type_of("none")));
   ASSERT_TRUE(is_machine_word(type_of("bool")));
@@ -787,6 +895,8 @@ TEST_F(SubTypeTest, IsMachineWord)
   ASSERT_FALSE(is_machine_word(type_of("u8andnone")));
   ASSERT_FALSE(is_machine_word(type_of("u8ori32")));
   ASSERT_FALSE(is_machine_word(type_of("u8andi32")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -807,6 +917,9 @@ TEST_F(SubTypeTest, IsConcrete)
     "    c1ort1: (C1 | T1), c1andt1: (C1 & T1))";
 
   TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
   ASSERT_TRUE(is_concrete(type_of("none")));
   ASSERT_TRUE(is_concrete(type_of("bool")));
@@ -831,6 +944,8 @@ TEST_F(SubTypeTest, IsConcrete)
   ASSERT_TRUE(is_concrete(type_of("t1andnone")));
   ASSERT_FALSE(is_concrete(type_of("c1ort1")));
   ASSERT_TRUE(is_concrete(type_of("c1andt1")));
+
+  pass_opt_init(&opt);
 }
 
 
@@ -845,25 +960,30 @@ TEST_F(SubTypeTest, IsSubTypeArrow)
 
   TEST_COMPILE(src);
 
-  ASSERT_TRUE(is_subtype(type_of("a"), type_of("a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("a"), type_of("this_a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("a"), type_of("b_a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("a"), type_of("b_b_a"), NULL));
+  pass_opt_t opt;
+  pass_opt_init(&opt);
 
-  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("a"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("this_a"), type_of("this_a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("b_a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("b_b_a"), NULL));
+  ASSERT_TRUE(is_subtype(type_of("a"), type_of("a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("a"), type_of("this_a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("a"), type_of("b_a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("a"), type_of("b_b_a"), NULL, &opt));
 
-  ASSERT_FALSE(is_subtype(type_of("b_a"), type_of("a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("b_a"), type_of("this_a"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("b_a"), type_of("b_a"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("b_a"), type_of("b_b_a"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("a"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("this_a"), type_of("this_a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("b_a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("this_a"), type_of("b_b_a"), NULL, &opt));
 
-  ASSERT_FALSE(is_subtype(type_of("b_b_a"), type_of("a"), NULL));
-  ASSERT_FALSE(is_subtype(type_of("b_b_a"), type_of("this_a"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("b_b_a"), type_of("b_a"), NULL));
-  ASSERT_TRUE(is_subtype(type_of("b_b_a"), type_of("b_b_a"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("b_a"), type_of("a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("b_a"), type_of("this_a"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("b_a"), type_of("b_a"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("b_a"), type_of("b_b_a"), NULL, &opt));
 
-  ASSERT_TRUE(is_subtype(type_of("val_a"), type_of("box_a"), NULL));
+  ASSERT_FALSE(is_subtype(type_of("b_b_a"), type_of("a"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("b_b_a"), type_of("this_a"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("b_b_a"), type_of("b_a"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("b_b_a"), type_of("b_b_a"), NULL, &opt));
+
+  ASSERT_TRUE(is_subtype(type_of("val_a"), type_of("box_a"), NULL, &opt));
+
+  pass_opt_init(&opt);
 }

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -61,8 +61,10 @@ protected:
   void test_error(const char* src, const char* pass);
 
   // Check that the given source fails when compiled to the specified pass,
-  // exactly N errors are produced, and the errors match expected text.
-  void test_errors_1(const char* src, const char* pass, const char* err1);
+  // that a specific number of errors are produced, and that the errors match
+  // expected text, given as a NULL-terminated array of NULL-terminated strings.
+  void test_expected_errors(const char* src, const char* pass,
+    const char** errors);
 
   // Check that the 2 given sources compile to give the same AST for the first
   // package
@@ -101,7 +103,8 @@ private:
   // Attempt to compile the package with the specified name into a program.
   // Errors are checked with ASSERTs, call in ASSERT_NO_FATAL_FAILURE.
   void build_package(const char* pass, const char* src,
-    const char* package_name, bool check_good, ast_t** out_package);
+    const char* package_name, bool check_good, const char** expected_errors,
+    ast_t** out_package);
 
   // Find the type of the parameter, field or local variable with the specified
   // name in the given AST.


### PR DESCRIPTION
This is something I discussed with @sylvanc at the beginning of the week.

This PR gets rid of static global state in the error handling code in `libponyc`.  It replaces it by explicitly passing around this state in an `errors_t` object (often embedded in `pass_opt_t`).  Obviously, this affects code in a lot of places, so that's why the diff is so extensive.

While I was at it, I made it more succinct to declare error + info units, and converted many cases that were incorrectly reported as multiple errors to be reported as error + info units.

I also cleaned up some tests that were failing for the wrong reason in `bad_pony.cc` by fixing the cause and making the expected errors explicit.

I filed this PR now because it will make it easier for me to work on auto-recovery, where we want to cleanly suppress some errors when we test out whether auto-recovery is feasible, but don't want to show the errors if it fails.