### PR TITLE
Use an encapsulating reach_t structure

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -52,9 +52,8 @@ typedef struct compile_frame_t
 typedef struct compile_t
 {
   pass_opt_t* opt;
-  reachable_types_t* reachable;
+  reach_t* reachable;
   const char* filename;
-  uint32_t next_type_id;
 
   const char* str_builtin;
   const char* str_Bool;

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -22,7 +22,7 @@ static bool need_primitive_call(compile_t* c, const char* method)
   size_t i = HASHMAP_BEGIN;
   reachable_type_t* t;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(t->underlying != TK_PRIMITIVE)
       continue;
@@ -43,7 +43,7 @@ static void primitive_call(compile_t* c, const char* method)
   size_t i = HASHMAP_BEGIN;
   reachable_type_t* t;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(t->underlying != TK_PRIMITIVE)
       continue;
@@ -370,11 +370,11 @@ bool genexe(compile_t* c, ast_t* program)
     return false;
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Reachability\n"));
-  reach(c->reachable, &c->next_type_id, main_ast, c->str_create, NULL, c->opt);
-  reach(c->reachable, &c->next_type_id, env_ast, c->str__create, NULL, c->opt);
+  reach(c->reachable, main_ast, c->str_create, NULL, c->opt);
+  reach(c->reachable, env_ast, c->str__create, NULL, c->opt);
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
-  paint(c->reachable);
+  paint(&c->reachable->types);
 
   if(c->opt->verbosity >= VERBOSITY_ALL)
     reach_dump(c->reachable);

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -215,7 +215,7 @@ static void print_types(compile_t* c, FILE* fp, printbuf_t* buf)
   size_t i = HASHMAP_BEGIN;
   reachable_type_t* t;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     // Print the docstring if we have one.
     ast_t* def = (ast_t*)ast_data(t->ast);

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -33,8 +33,7 @@ static bool reachable_methods(compile_t* c, ast_t* ast)
 
         // Mark all non-polymorphic methods as reachable.
         if(ast_id(typeparams) == TK_NONE)
-          reach(c->reachable, &c->next_type_id, type, ast_name(m_id), NULL,
-            c->opt);
+          reach(c->reachable, type, ast_name(m_id), NULL, c->opt);
         break;
       }
 
@@ -98,7 +97,7 @@ static bool reachable_actors(compile_t* c, ast_t* program)
   }
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
-  paint(c->reachable);
+  paint(&c->reachable->types);
   return true;
 }
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -992,15 +992,13 @@ void genprim_reachable_init(compile_t* c, ast_t* program)
 
             if(finit != NULL)
             {
-              reach(c->reachable, &c->next_type_id, type, c->str__init, NULL,
-                c->opt);
+              reach(c->reachable, type, c->str__init, NULL, c->opt);
               ast_free_unattached(finit);
             }
 
             if(ffinal != NULL)
             {
-              reach(c->reachable, &c->next_type_id, type, c->str__final, NULL,
-                c->opt);
+              reach(c->reachable, type, c->str__final, NULL, c->opt);
               ast_free_unattached(ffinal);
             }
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -582,7 +582,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Data prototypes\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(!make_opaque_struct(c, t))
       return false;
@@ -597,7 +597,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Data types\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(!make_struct(c, t))
       return false;
@@ -608,7 +608,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Function prototypes\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     make_debug_final(c, t);
     make_pointer_methods(c, t);
@@ -620,7 +620,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Functions\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(!genfun_method_bodies(c, t))
       return false;
@@ -629,7 +629,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Descriptors\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(c->reachable, &i)) != NULL)
+  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
   {
     if(!make_trace(c, t))
       return false;

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -10,7 +10,7 @@
 class PaintTest: public testing::Test
 {
 protected:
-  reachable_types_t* _set;
+  reach_t* _set;
   reachable_type_t* _current_type;
 
   virtual void SetUp()
@@ -34,7 +34,7 @@ protected:
     reachable_type_cache_init(&_current_type->subtypes, 0);
     _current_type->vtable_size = 0;
 
-    reachable_types_put(_set, _current_type);
+    reachable_types_put(&_set->types, _current_type);
   }
 
   void add_method(const char* name)
@@ -58,7 +58,7 @@ protected:
 
   void do_paint()
   {
-    paint(_set);
+    paint(&_set->types);
   }
 
   void check_vtable_size(const char* name, uint32_t min_expected,
@@ -66,7 +66,7 @@ protected:
   {
     reachable_type_t t;
     t.name = stringtab(name);
-    reachable_type_t* type = reachable_types_get(_set, &t);
+    reachable_type_t* type = reachable_types_get(&_set->types, &t);
     ASSERT_NE((void*)NULL, type);
 
     ASSERT_LE(min_expected, type->vtable_size);
@@ -103,7 +103,7 @@ protected:
     reachable_type_t* type;
     uint32_t colour = (uint32_t)-1;
 
-    while((type = reachable_types_next(_set, &i)) != NULL)
+    while((type = reachable_types_next(&_set->types, &i)) != NULL)
     {
       reachable_method_name_t m1;
       m1.name = stringtab(name);


### PR DESCRIPTION
Rather than pass around a supporting stack and next type id, use
an encapsulating structure. This allows more supporting reachability
data structures without affecting every method signature.