### PR TITLE
Allow user to set custom chunk_size for Stdin notifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `ArrayValues.rewind()` method.
 - Nanos primitive in time package.
 - Persistent package, with List and Map
+- Custom chunk size for Stdin.
 
 ### Changed
 


### PR DESCRIPTION
This PR adds a chunk_size argument to Stdin.apply, allowing the user to set a custom size for chunks reported to the notifier.