### PR TITLE
Add Dockerfile for automated builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:jessie
+
+RUN echo 'deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main' \
+  | tee -a /etc/apt/sources.list \
+ && echo 'deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main' \
+  | tee -a /etc/apt/sources.list
+
+RUN apt-get update \
+ && apt-get install -y wget bzip2 make g++ git \
+                       zlib1g-dev libncurses5-dev libssl-dev
+
+RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+ && apt-get update \
+ && apt-get install -y llvm-3.8-dev
+
+RUN cd /tmp \
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr \
+ && make && make install \
+ && rm -rf /tmp/*
+
+WORKDIR /src/ponyc
+COPY Makefile LICENSE VERSION /src/ponyc/
+COPY src      /src/ponyc/src
+COPY lib      /src/ponyc/lib
+COPY test     /src/ponyc/test
+COPY packages /src/ponyc/packages
+
+RUN make config=release clean && make config=release && make install
+
+RUN mkdir /src/main
+WORKDIR   /src/main
+
+CMD ponyc

--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@
 
 # Installation
 
+## Using Docker
+
+Want to use the latest revision of Pony source, but don't want to build from source yourself? You can run the `ponylang/ponyc` Docker container, which is created from an automated build at each commit to master.
+
+You'll need to install Docker using [the instructions here](https://docs.docker.com/engine/installation/). Then you can pull the latest `ponylang/ponyc` image using this command:
+
+```bash
+docker pull ponylang/ponyc:latest
+```
+
+Then you'll be able to run `ponyc` to compile a Pony program in a given directory, running a command like this:
+
+```bash
+docker run -v /path/to/my-code:/src/main ponylang/ponyc
+```
+
+Note that if your host doesn't match the docker container, you'll probably have to run the resulting program inside the docker container as well, using a command like this:
+
+```bash
+docker run -v /path/to/my-code:/src/main ponylang/ponyc ./main
+```
+
 ## Mac OS X using [Homebrew](http://brew.sh)
 
 The homebrew version is currently woefully out of date. We are transitioning to


### PR DESCRIPTION
This PR adds a Dockerfile for automated builds.

This should be an easier way for some users to try the latest revision of ponyc master, without having to actually build from source.

Think of it like a kind of nightlies, but it actually happens on every commit and it's only in docker.