### PR TITLE
Machine word autobox

### DIFF
--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -512,7 +512,7 @@ class iso _TestStringCompare is UnitTest
     h.assert_eq[Compare](Equal, "foo".compare("foo"))
     h.assert_eq[Compare](Greater, "foo".compare("bar"))
     h.assert_eq[Compare](Less, "bar".compare("foo"))
-    
+
     h.assert_eq[Compare](Less, "abc".compare("bc"))
 
     h.assert_eq[Compare](Equal, "foo".compare_sub("foo", 3))
@@ -820,6 +820,7 @@ class iso _TestDivMod is UnitTest
 
 struct _TestStruct
   var i: U32 = 0
+  new create() => None
 
 class iso _TestMaybePointer is UnitTest
   """

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -809,13 +809,24 @@ ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status)
   return NULL;
 }
 
-bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status)
+bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
+  bool allow_shadowing)
 {
   while(ast->symtab == NULL)
     ast = ast->parent;
 
-  return (ast_get_case(ast, name, NULL) == NULL)
-    && symtab_add(ast->symtab, name, value, status);
+  if(allow_shadowing)
+  {
+    // Only check the local scope.
+    if(symtab_find_case(ast->symtab, name, NULL) != NULL)
+      return false;
+  } else {
+    // Check the local scope and all parent scopes.
+    if(ast_get_case(ast, name, NULL) != NULL)
+      return false;
+  }
+
+  return symtab_add(ast->symtab, name, value, status);
 }
 
 void ast_setstatus(ast_t* ast, const char* name, sym_status_t status)

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -105,7 +105,8 @@ size_t ast_index(ast_t* ast);
 
 ast_t* ast_get(ast_t* ast, const char* name, sym_status_t* status);
 ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status);
-bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status);
+bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
+  bool allow_shadowing);
 void ast_setstatus(ast_t* ast, const char* name, sym_status_t status);
 void ast_inheritstatus(ast_t* dst, ast_t* src);
 void ast_inheritbranch(ast_t* dst, ast_t* src);

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -409,7 +409,7 @@ static void init_module(compile_t* c, ast_t* program, pass_opt_t* opt)
   if(builtin == NULL)
     builtin = package;
 
-  c->reachable = reach_new();
+  c->reach = reach_new();
 
   // The name of the first package is the name of the program.
   c->filename = package_filename(package);
@@ -458,7 +458,7 @@ static void codegen_cleanup(compile_t* c)
   LLVMDisposeModule(c->module);
   LLVMContextDispose(c->context);
   LLVMDisposeTargetMachine(c->machine);
-  reach_free(c->reachable);
+  reach_free(c->reach);
 }
 
 bool codegen_init(pass_opt_t* opt)

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -147,6 +147,7 @@ static void init_runtime(compile_t* c)
   c->str__create = stringtab("_create");
   c->str__init = stringtab("_init");
   c->str__final = stringtab("_final");
+  c->str__event_notify = stringtab("_event_notify");
 
   LLVMTypeRef type;
   LLVMTypeRef params[4];

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -168,7 +168,7 @@ static void init_runtime(compile_t* c)
   c->void_ptr = LLVMPointerType(c->i8, 0);
 
   // forward declare object
-  c->object_type = LLVMStructCreateNamed(c->context, "$object");
+  c->object_type = LLVMStructCreateNamed(c->context, "__object");
   c->object_ptr = LLVMPointerType(c->object_type, 0);
 
   // padding required in an actor between the descriptor and fields
@@ -177,7 +177,7 @@ static void init_runtime(compile_t* c)
   // message
   params[0] = c->i32; // size
   params[1] = c->i32; // id
-  c->msg_type = LLVMStructCreateNamed(c->context, "$message");
+  c->msg_type = LLVMStructCreateNamed(c->context, "__message");
   c->msg_ptr = LLVMPointerType(c->msg_type, 0);
   LLVMStructSetBody(c->msg_type, params, 2, false);
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -52,7 +52,7 @@ typedef struct compile_frame_t
 typedef struct compile_t
 {
   pass_opt_t* opt;
-  reach_t* reachable;
+  reach_t* reach;
   const char* filename;
 
   const char* str_builtin;

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -104,6 +104,7 @@ typedef struct compile_t
   const char* str__create;
   const char* str__init;
   const char* str__final;
+  const char* str__event_notify;
 
   LLVMCallConv callconv;
   LLVMContextRef context;

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -9,7 +9,7 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
   if(LLVMGetTypeKind(l_type) == LLVMPointerTypeKind)
     return value;
 
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
 
   if(l_type != t->primitive)
@@ -32,7 +32,7 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
   if(LLVMGetTypeKind(l_type) != LLVMPointerTypeKind)
     return object;
 
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
 
   if(t->primitive == NULL)

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -166,11 +166,11 @@ static bool special_case_call(compile_t* c, ast_t* ast, LLVMValueRef* value)
   return false;
 }
 
-static LLVMValueRef dispatch_function(compile_t* c, reachable_type_t* t,
+static LLVMValueRef dispatch_function(compile_t* c, reach_type_t* t,
   ast_t* type, LLVMValueRef l_value, const char* method_name, ast_t* typeargs)
 {
   token_id cap = cap_dispatch(type);
-  reachable_method_t* m = reach_method(t, cap, method_name, typeargs);
+  reach_method_t* m = reach_method(t, cap, method_name, typeargs);
   assert(m != NULL);
 
   switch(t->underlying)
@@ -203,7 +203,7 @@ static LLVMValueRef dispatch_function(compile_t* c, reachable_type_t* t,
   return NULL;
 }
 
-static bool call_needs_receiver(ast_t* postfix, reachable_type_t* t)
+static bool call_needs_receiver(ast_t* postfix, reach_type_t* t)
 {
   switch(ast_id(postfix))
   {
@@ -249,7 +249,7 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
 
   // Get the receiver type.
   ast_t* type = ast_type(receiver);
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
 
   return dispatch_function(c, t, type, value, ast_name(method), typeargs);
@@ -284,7 +284,7 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   // Get the receiver type.
   const char* method_name = ast_name(method);
   ast_t* type = ast_type(receiver);
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
 
   // Generate the arguments.
@@ -421,7 +421,7 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
 
   // Generate the receiver.
   LLVMValueRef l_value = gen_expr(c, pattern);
-  reachable_type_t* t = reach_type(c->reachable, pattern_type);
+  reach_type_t* t = reach_type(c->reach, pattern_type);
   assert(t != NULL);
 
   // Static or virtual dispatch.
@@ -444,7 +444,7 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
 }
 
 static LLVMValueRef declare_ffi_vararg(compile_t* c, const char* f_name,
-  reachable_type_t* t, bool err)
+  reach_type_t* t, bool err)
 {
   LLVMTypeRef f_type = LLVMFunctionType(t->use_type, NULL, 0, true);
   LLVMValueRef func = LLVMAddFunction(c->module, f_name, f_type);
@@ -456,7 +456,7 @@ static LLVMValueRef declare_ffi_vararg(compile_t* c, const char* f_name,
 }
 
 static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
-  reachable_type_t* t, ast_t* args, bool err)
+  reach_type_t* t, ast_t* args, bool err)
 {
   ast_t* last_arg = ast_childlast(args);
 
@@ -477,7 +477,7 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
     if(p_type == NULL)
       p_type = ast_childidx(arg, 1);
 
-    reachable_type_t* pt = reach_type(c->reachable, p_type);
+    reach_type_t* pt = reach_type(c->reach, p_type);
     assert(pt != NULL);
 
     f_params[count++] = pt->use_type;
@@ -526,7 +526,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
 
   // Get the return type.
   ast_t* type = ast_type(ast);
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
 
   // Get the function.
@@ -624,7 +624,7 @@ LLVMValueRef gencall_runtime(compile_t* c, const char *name,
   return LLVMBuildCall(c->builder, func, args, count, ret);
 }
 
-LLVMValueRef gencall_create(compile_t* c, reachable_type_t* t)
+LLVMValueRef gencall_create(compile_t* c, reach_type_t* t)
 {
   LLVMValueRef args[2];
   args[0] = codegen_ctx(c);
@@ -634,7 +634,7 @@ LLVMValueRef gencall_create(compile_t* c, reachable_type_t* t)
   return LLVMBuildBitCast(c->builder, result, t->use_type, "");
 }
 
-LLVMValueRef gencall_alloc(compile_t* c, reachable_type_t* t)
+LLVMValueRef gencall_alloc(compile_t* c, reach_type_t* t)
 {
   // Do nothing for primitives.
   if(t->primitive != NULL)
@@ -654,7 +654,7 @@ LLVMValueRef gencall_alloc(compile_t* c, reachable_type_t* t)
   return gencall_allocstruct(c, t);
 }
 
-LLVMValueRef gencall_allocstruct(compile_t* c, reachable_type_t* t)
+LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t)
 {
   // We explicitly want a boxed version.
   // Get the size of the structure.

--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -18,11 +18,11 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast);
 LLVMValueRef gencall_runtime(compile_t* c, const char *name,
   LLVMValueRef* args, int count, const char* ret);
 
-LLVMValueRef gencall_create(compile_t* c, reachable_type_t* t);
+LLVMValueRef gencall_create(compile_t* c, reach_type_t* t);
 
-LLVMValueRef gencall_alloc(compile_t* c, reachable_type_t* t);
+LLVMValueRef gencall_alloc(compile_t* c, reach_type_t* t);
 
-LLVMValueRef gencall_allocstruct(compile_t* c, reachable_type_t* t);
+LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t);
 
 void gencall_throw(compile_t* c);
 

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -37,10 +37,10 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   ast_t* right_type = ast_type(right);
 
   // We will have no type if both branches have return statements.
-  reachable_type_t* phi_type = NULL;
+  reach_type_t* phi_type = NULL;
 
   if(!is_control_type(type))
-    phi_type = reach_type(c->reachable, type);
+    phi_type = reach_type(c->reach, type);
 
   LLVMValueRef c_value = gen_expr(c, cond);
 
@@ -156,10 +156,10 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reachable_type_t* phi_type = NULL;
+  reach_type_t* phi_type = NULL;
 
   if(needed && !is_control_type(type))
-    phi_type = reach_type(c->reachable, type);
+    phi_type = reach_type(c->reach, type);
 
   LLVMBasicBlockRef init_block = codegen_block(c, "while_init");
   LLVMBasicBlockRef body_block = codegen_block(c, "while_body");
@@ -272,10 +272,10 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reachable_type_t* phi_type = NULL;
+  reach_type_t* phi_type = NULL;
 
   if(needed && !is_control_type(type))
-    phi_type = reach_type(c->reachable, type);
+    phi_type = reach_type(c->reach, type);
 
   LLVMBasicBlockRef body_block = codegen_block(c, "repeat_body");
   LLVMBasicBlockRef cond_block = codegen_block(c, "repeat_cond");
@@ -465,11 +465,11 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reachable_type_t* phi_type = NULL;
+  reach_type_t* phi_type = NULL;
 
   // We will have no type if both branches have return statements.
   if(!is_control_type(type))
-    phi_type = reach_type(c->reachable, type);
+    phi_type = reach_type(c->reach, type);
 
   LLVMBasicBlockRef block = LLVMGetInsertBlock(c->builder);
   LLVMBasicBlockRef else_block = codegen_block(c, "try_else");

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -397,7 +397,7 @@ void gendesc_init(compile_t* c, reach_type_t* t)
     return;
 
   // Initialise the global descriptor.
-  uint32_t event_notify_index = reach_vtable_index(t, "_event_notify");
+  uint32_t event_notify_index = reach_vtable_index(t, c->str__event_notify);
   uint32_t size = (uint32_t)LLVMABISizeOfType(c->target_data, t->structure);
   uint32_t trait_count = 0;
   LLVMValueRef trait_list = make_trait_list(c, t, &trait_count);

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -294,7 +294,7 @@ static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
     size_t j = HASHMAP_BEGIN;
     reach_method_t* m;
 
-    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
     {
       uint32_t index = m->vtable_index;
       assert(index != (uint32_t)-1);

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -23,8 +23,8 @@
 
 #define DESC_LENGTH 14
 
-static LLVMValueRef make_unbox_function(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m)
+static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
+  reach_method_t* m)
 {
   // Create a new unboxing function that forwards to the real function.
   LLVMTypeRef f_type = LLVMGetElementType(LLVMTypeOf(m->func));
@@ -122,7 +122,7 @@ static size_t unique_uint32(uint32_t* list, size_t len)
   return (++r) - list;
 }
 
-static uint32_t trait_count(reachable_type_t* t, uint32_t** list,
+static uint32_t trait_count(reach_type_t* t, uint32_t** list,
   size_t* list_size)
 {
   switch(t->underlying)
@@ -131,7 +131,7 @@ static uint32_t trait_count(reachable_type_t* t, uint32_t** list,
     case TK_CLASS:
     case TK_ACTOR:
     {
-      uint32_t count = (uint32_t)reachable_type_cache_size(&t->subtypes);
+      uint32_t count = (uint32_t)reach_type_cache_size(&t->subtypes);
 
       if(count == 0)
         return 0;
@@ -142,9 +142,9 @@ static uint32_t trait_count(reachable_type_t* t, uint32_t** list,
 
       size_t i = HASHMAP_BEGIN;
       size_t index = 0;
-      reachable_type_t* provide;
+      reach_type_t* provide;
 
-      while((provide = reachable_type_cache_next(&t->subtypes, &i)) != NULL)
+      while((provide = reach_type_cache_next(&t->subtypes, &i)) != NULL)
         tid[index++] = provide->type_id;
 
       qsort(tid, index, sizeof(uint32_t), cmp_uint32);
@@ -167,7 +167,7 @@ static uint32_t trait_count(reachable_type_t* t, uint32_t** list,
   return 0;
 }
 
-static LLVMValueRef make_trait_list(compile_t* c, reachable_type_t* t,
+static LLVMValueRef make_trait_list(compile_t* c, reach_type_t* t,
   uint32_t* final_count)
 {
   // The list is an array of integers.
@@ -203,7 +203,7 @@ static LLVMValueRef make_trait_list(compile_t* c, reachable_type_t* t,
   return global;
 }
 
-static LLVMValueRef make_field_count(compile_t* c, reachable_type_t* t)
+static LLVMValueRef make_field_count(compile_t* c, reach_type_t* t)
 {
   if(t->underlying != TK_TUPLETYPE)
     return LLVMConstInt(c->i32, 0, false);
@@ -211,7 +211,7 @@ static LLVMValueRef make_field_count(compile_t* c, reachable_type_t* t)
   return LLVMConstInt(c->i32, t->field_count, false);
 }
 
-static LLVMValueRef make_field_offset(compile_t* c, reachable_type_t* t)
+static LLVMValueRef make_field_offset(compile_t* c, reach_type_t* t)
 {
   if(t->field_count == 0)
     return LLVMConstInt(c->i32, 0, false);
@@ -225,7 +225,7 @@ static LLVMValueRef make_field_offset(compile_t* c, reachable_type_t* t)
     LLVMOffsetOfElement(c->target_data, t->structure, index), false);
 }
 
-static LLVMValueRef make_field_list(compile_t* c, reachable_type_t* t)
+static LLVMValueRef make_field_list(compile_t* c, reach_type_t* t)
 {
   // The list is an array of field descriptors.
   uint32_t count;
@@ -277,7 +277,7 @@ static LLVMValueRef make_field_list(compile_t* c, reachable_type_t* t)
   return global;
 }
 
-static LLVMValueRef make_vtable(compile_t* c, reachable_type_t* t)
+static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
 {
   if(t->vtable_size == 0)
     return LLVMConstArray(c->void_ptr, NULL, 0);
@@ -287,14 +287,14 @@ static LLVMValueRef make_vtable(compile_t* c, reachable_type_t* t)
   memset(vtable, 0, buf_size);
 
   size_t i = HASHMAP_BEGIN;
-  reachable_method_name_t* n;
+  reach_method_name_t* n;
 
-  while((n = reachable_method_names_next(&t->methods, &i)) != NULL)
+  while((n = reach_method_names_next(&t->methods, &i)) != NULL)
   {
     size_t j = HASHMAP_BEGIN;
-    reachable_method_t* m;
+    reach_method_t* m;
 
-    while((m = reachable_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
     {
       uint32_t index = m->vtable_index;
       assert(index != (uint32_t)-1);
@@ -341,7 +341,7 @@ void gendesc_basetype(compile_t* c, LLVMTypeRef desc_type)
   LLVMStructSetBody(desc_type, params, DESC_LENGTH, false);
 }
 
-void gendesc_type(compile_t* c, reachable_type_t* t)
+void gendesc_type(compile_t* c, reach_type_t* t)
 {
   switch(t->underlying)
   {
@@ -391,7 +391,7 @@ void gendesc_type(compile_t* c, reachable_type_t* t)
   LLVMSetLinkage(t->desc, LLVMInternalLinkage);
 }
 
-void gendesc_init(compile_t* c, reachable_type_t* t)
+void gendesc_init(compile_t* c, reach_type_t* t)
 {
   if(t->desc_type == NULL)
     return;
@@ -537,7 +537,7 @@ LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* type)
 LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
 {
   // Get the trait identifier.
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   assert(t != NULL);
   LLVMValueRef trait_id = LLVMConstInt(c->i32, t->type_id, false);
 
@@ -590,7 +590,7 @@ LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
 
 LLVMValueRef gendesc_isentity(compile_t* c, LLVMValueRef desc, ast_t* type)
 {
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   if(t == NULL)
     return GEN_NOVALUE;

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -8,9 +8,9 @@ PONY_EXTERN_C_BEGIN
 
 void gendesc_basetype(compile_t* c, LLVMTypeRef desc_type);
 
-void gendesc_type(compile_t* c, reachable_type_t* t);
+void gendesc_type(compile_t* c, reach_type_t* t);
 
-void gendesc_init(compile_t* c, reachable_type_t* t);
+void gendesc_init(compile_t* c, reach_type_t* t);
 
 LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object);
 

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -131,7 +131,7 @@ static void gen_main(compile_t* c, reach_type_t* t_main,
   LLVMTypeRef msg_type_ptr = LLVMPointerType(msg_type, 0);
 
   // Allocate the message, setting its size and ID.
-  uint32_t index = reach_vtable_index(t_main, "create");
+  uint32_t index = reach_vtable_index(t_main, c->str_create);
   size_t msg_size = (size_t)LLVMABISizeOfType(c->target_data, msg_type);
   args[0] = LLVMConstInt(c->i32, ponyint_pool_index(msg_size), false);
   args[1] = LLVMConstInt(c->i32, index, false);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -20,14 +20,14 @@
 static bool need_primitive_call(compile_t* c, const char* method)
 {
   size_t i = HASHMAP_BEGIN;
-  reachable_type_t* t;
+  reach_type_t* t;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(t->underlying != TK_PRIMITIVE)
       continue;
 
-    reachable_method_name_t* n = reach_method_name(t, method);
+    reach_method_name_t* n = reach_method_name(t, method);
 
     if(n == NULL)
       continue;
@@ -41,14 +41,14 @@ static bool need_primitive_call(compile_t* c, const char* method)
 static void primitive_call(compile_t* c, const char* method)
 {
   size_t i = HASHMAP_BEGIN;
-  reachable_type_t* t;
+  reach_type_t* t;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(t->underlying != TK_PRIMITIVE)
       continue;
 
-    reachable_method_t* m = reach_method(t, TK_NONE, method, NULL);
+    reach_method_t* m = reach_method(t, TK_NONE, method, NULL);
 
     if(m == NULL)
       continue;
@@ -60,7 +60,7 @@ static void primitive_call(compile_t* c, const char* method)
   }
 }
 
-static LLVMValueRef create_main(compile_t* c, reachable_type_t* t,
+static LLVMValueRef create_main(compile_t* c, reach_type_t* t,
   LLVMValueRef ctx)
 {
   // Create the main actor and become it.
@@ -76,8 +76,8 @@ static LLVMValueRef create_main(compile_t* c, reachable_type_t* t,
   return actor;
 }
 
-static void gen_main(compile_t* c, reachable_type_t* t_main,
-  reachable_type_t* t_env)
+static void gen_main(compile_t* c, reach_type_t* t_main,
+  reach_type_t* t_env)
 {
   LLVMTypeRef params[3];
   params[0] = c->i32;
@@ -108,7 +108,7 @@ static void gen_main(compile_t* c, reachable_type_t* t_main,
   LLVMValueRef main_actor = create_main(c, t_main, ctx);
 
   // Create an Env on the main actor's heap.
-  reachable_method_t* m = reach_method(t_env, TK_NONE, c->str__create, NULL);
+  reach_method_t* m = reach_method(t_env, TK_NONE, c->str__create, NULL);
 
   LLVMValueRef env_args[4];
   env_args[0] = gencall_alloc(c, t_env);
@@ -370,20 +370,20 @@ bool genexe(compile_t* c, ast_t* program)
     return false;
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Reachability\n"));
-  reach(c->reachable, main_ast, c->str_create, NULL, c->opt);
-  reach(c->reachable, env_ast, c->str__create, NULL, c->opt);
+  reach(c->reach, main_ast, c->str_create, NULL, c->opt);
+  reach(c->reach, env_ast, c->str__create, NULL, c->opt);
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
-  paint(&c->reachable->types);
+  paint(&c->reach->types);
 
   if(c->opt->verbosity >= VERBOSITY_ALL)
-    reach_dump(c->reachable);
+    reach_dump(c->reach);
 
   if(!gentypes(c))
     return false;
 
-  reachable_type_t* t_main = reach_type(c->reachable, main_ast);
-  reachable_type_t* t_env = reach_type(c->reachable, env_ast);
+  reach_type_t* t_main = reach_type(c->reach, main_ast);
+  reach_type_t* t_env = reach_type(c->reach, env_ast);
 
   if((t_main == NULL) || (t_env == NULL))
     return false;

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -14,8 +14,8 @@
 #include <string.h>
 #include <assert.h>
 
-static void name_param(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m, LLVMValueRef func, const char* name, unsigned index,
+static void name_param(compile_t* c, reach_type_t* t,
+  reach_method_t* m, LLVMValueRef func, const char* name, unsigned index,
   size_t line, size_t pos)
 {
   LLVMValueRef value = LLVMGetParam(func, index);
@@ -45,8 +45,8 @@ static void name_param(compile_t* c, reachable_type_t* t,
     LLVMGetInsertBlock(c->builder));
 }
 
-static void name_params(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m, ast_t* params, LLVMValueRef func)
+static void name_params(compile_t* c, reach_type_t* t, reach_method_t* m,
+  ast_t* params, LLVMValueRef func)
 {
   // Name the receiver 'this'.
   name_param(c, t, m, func, c->str_this, 0, ast_line(params), ast_pos(params));
@@ -62,7 +62,7 @@ static void name_params(compile_t* c, reachable_type_t* t,
   }
 }
 
-static void make_signature(reachable_type_t* t, reachable_method_t* m)
+static void make_signature(reach_type_t* t, reach_method_t* m)
 {
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
@@ -86,15 +86,15 @@ static void make_signature(reachable_type_t* t, reachable_method_t* m)
   ponyint_pool_free_size(tparam_size, tparams);
 }
 
-static void make_function_debug(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m, LLVMValueRef func)
+static void make_function_debug(compile_t* c, reach_type_t* t,
+  reach_method_t* m, LLVMValueRef func)
 {
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
 
   // Count the parameters, including the receiver and the result.
   size_t count = m->param_count + 2;
-  size_t md_size = count * sizeof(reachable_type_t*);
+  size_t md_size = count * sizeof(reach_type_t*);
   LLVMMetadataRef* md = (LLVMMetadataRef*)ponyint_pool_alloc_size(md_size);
 
   md[0] = m->result->di_type;
@@ -125,8 +125,8 @@ static void make_function_debug(compile_t* c, reachable_type_t* t,
   ponyint_pool_free_size(md_size, md);
 }
 
-static void make_prototype(compile_t* c, reachable_type_t* t,
-  reachable_method_name_t* n, reachable_method_t* m)
+static void make_prototype(compile_t* c, reach_type_t* t,
+  reach_method_name_t* n, reach_method_t* m)
 {
   if(m->intrinsic)
     return;
@@ -272,7 +272,7 @@ static LLVMTypeRef send_message(compile_t* c, ast_t* params, LLVMValueRef to,
   return msg_type_ptr;
 }
 
-static void add_dispatch_case(compile_t* c, reachable_type_t* t, ast_t* params,
+static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
   uint32_t index, LLVMValueRef handler, LLVMTypeRef type)
 {
   // Add a case to the dispatch function to handle this message.
@@ -335,8 +335,7 @@ static void add_dispatch_case(compile_t* c, reachable_type_t* t, ast_t* params,
   ponyint_pool_free_size(buf_size, args);
 }
 
-static bool genfun_fun(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m)
+static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
   assert(m->func != NULL);
 
@@ -377,8 +376,7 @@ static bool genfun_fun(compile_t* c, reachable_type_t* t,
   return true;
 }
 
-static bool genfun_be(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m)
+static bool genfun_be(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
   assert(m->func != NULL);
   assert(m->func_handler != NULL);
@@ -419,8 +417,7 @@ static bool genfun_be(compile_t* c, reachable_type_t* t,
   return true;
 }
 
-static bool genfun_new(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m)
+static bool genfun_new(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
   assert(m->func != NULL);
 
@@ -447,8 +444,7 @@ static bool genfun_new(compile_t* c, reachable_type_t* t,
   return true;
 }
 
-static bool genfun_newbe(compile_t* c, reachable_type_t* t,
-  reachable_method_t* m)
+static bool genfun_newbe(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
   assert(m->func != NULL);
   assert(m->func_handler != NULL);
@@ -490,9 +486,9 @@ static bool genfun_newbe(compile_t* c, reachable_type_t* t,
   return true;
 }
 
-static void copy_subordinate(reachable_method_t* m)
+static void copy_subordinate(reach_method_t* m)
 {
-  reachable_method_t* m2 = m->subordinate;
+  reach_method_t* m2 = m->subordinate;
 
   while(m2 != NULL)
   {
@@ -502,7 +498,7 @@ static void copy_subordinate(reachable_method_t* m)
   }
 }
 
-static bool genfun_allocator(compile_t* c, reachable_type_t* t)
+static bool genfun_allocator(compile_t* c, reach_type_t* t)
 {
   switch(t->underlying)
   {
@@ -551,17 +547,17 @@ static bool genfun_allocator(compile_t* c, reachable_type_t* t)
   return true;
 }
 
-bool genfun_method_sigs(compile_t* c, reachable_type_t* t)
+bool genfun_method_sigs(compile_t* c, reach_type_t* t)
 {
   size_t i = HASHMAP_BEGIN;
-  reachable_method_name_t* n;
+  reach_method_name_t* n;
 
-  while((n = reachable_method_names_next(&t->methods, &i)) != NULL)
+  while((n = reach_method_names_next(&t->methods, &i)) != NULL)
   {
     size_t j = HASHMAP_BEGIN;
-    reachable_method_t* m;
+    reach_method_t* m;
 
-    while((m = reachable_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
     {
       make_prototype(c, t, n, m);
       copy_subordinate(m);
@@ -574,7 +570,7 @@ bool genfun_method_sigs(compile_t* c, reachable_type_t* t)
   return true;
 }
 
-bool genfun_method_bodies(compile_t* c, reachable_type_t* t)
+bool genfun_method_bodies(compile_t* c, reach_type_t* t)
 {
   switch(t->underlying)
   {
@@ -589,14 +585,14 @@ bool genfun_method_bodies(compile_t* c, reachable_type_t* t)
   }
 
   size_t i = HASHMAP_BEGIN;
-  reachable_method_name_t* n;
+  reach_method_name_t* n;
 
-  while((n = reachable_method_names_next(&t->methods, &i)) != NULL)
+  while((n = reach_method_names_next(&t->methods, &i)) != NULL)
   {
     size_t j = HASHMAP_BEGIN;
-    reachable_method_t* m;
+    reach_method_t* m;
 
-    while((m = reachable_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
     {
       if(m->intrinsic)
         continue;

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -7,9 +7,9 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool genfun_method_sigs(compile_t* c, reachable_type_t* t);
+bool genfun_method_sigs(compile_t* c, reach_type_t* t);
 
-bool genfun_method_bodies(compile_t* c, reachable_type_t* t);
+bool genfun_method_bodies(compile_t* c, reach_type_t* t);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -148,8 +148,8 @@ static bool emit_fun(ast_t* fun)
   return true;
 }
 
-static void print_method(compile_t* c, printbuf_t* buf, reachable_type_t* t,
-  reachable_method_t* m)
+static void print_method(compile_t* c, printbuf_t* buf, reach_type_t* t,
+  reach_method_t* m)
 {
   if(!emit_fun(m->r_fun))
     return;
@@ -195,17 +195,17 @@ static void print_method(compile_t* c, printbuf_t* buf, reachable_type_t* t,
   printbuf(buf, ");\n\n");
 }
 
-static void print_methods(compile_t* c, reachable_type_t* t, printbuf_t* buf)
+static void print_methods(compile_t* c, reach_type_t* t, printbuf_t* buf)
 {
   size_t i = HASHMAP_BEGIN;
-  reachable_method_name_t* n;
+  reach_method_name_t* n;
 
-  while((n = reachable_method_names_next(&t->methods, &i)) != NULL)
+  while((n = reach_method_names_next(&t->methods, &i)) != NULL)
   {
     size_t j = HASHMAP_BEGIN;
-    reachable_method_t* m;
+    reach_method_t* m;
 
-    while((m = reachable_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
       print_method(c, buf, t, m);
   }
 }
@@ -213,9 +213,9 @@ static void print_methods(compile_t* c, reachable_type_t* t, printbuf_t* buf)
 static void print_types(compile_t* c, FILE* fp, printbuf_t* buf)
 {
   size_t i = HASHMAP_BEGIN;
-  reachable_type_t* t;
+  reach_type_t* t;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     // Print the docstring if we have one.
     ast_t* def = (ast_t*)ast_data(t->ast);

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -205,7 +205,7 @@ static void print_methods(compile_t* c, reach_type_t* t, printbuf_t* buf)
     size_t j = HASHMAP_BEGIN;
     reach_method_t* m;
 
-    while((m = reach_methods_next(&n->r_methods, &j)) != NULL)
+    while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
       print_method(c, buf, t, m);
   }
 }

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -33,7 +33,7 @@ static bool reachable_methods(compile_t* c, ast_t* ast)
 
         // Mark all non-polymorphic methods as reachable.
         if(ast_id(typeparams) == TK_NONE)
-          reach(c->reachable, type, ast_name(m_id), NULL, c->opt);
+          reach(c->reach, type, ast_name(m_id), NULL, c->opt);
         break;
       }
 
@@ -97,7 +97,7 @@ static bool reachable_actors(compile_t* c, ast_t* program)
   }
 
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
-  paint(&c->reachable->types);
+  paint(&c->reach->types);
   return true;
 }
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -210,7 +210,7 @@ static bool check_value(compile_t* c, ast_t* pattern, ast_t* param_type,
   if(l_value == NULL)
     return false;
 
-  reachable_type_t* t = reach_type(c->reachable, param_type);
+  reach_type_t* t = reach_type(c->reach, param_type);
   LLVMValueRef r_value = gen_assign_cast(c, t->use_type, value, param_type);
 
   if(r_value == NULL)
@@ -331,7 +331,7 @@ static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
   // it isn't a boxed primitive, as that would go through the other path, ie
   // dynamic_match_object(). We also know it isn't an unboxed tuple. We can
   // load from ptr with a type based on the static type of the pattern.
-  reachable_type_t* t = reach_type(c->reachable, param_type);
+  reach_type_t* t = reach_type(c->reach, param_type);
   LLVMTypeRef ptr_type = LLVMPointerType(t->use_type, 0);
   ptr = LLVMBuildIntToPtr(c->builder, ptr, ptr_type, "");
   LLVMValueRef value = LLVMBuildLoad(c->builder, ptr, "");
@@ -355,7 +355,7 @@ static bool dynamic_capture_ptr(compile_t* c, LLVMValueRef ptr,
   // it isn't a boxed primitive or tuple, as that would go through the other
   // path, ie dynamic_match_object(). We also know it isn't an unboxed tuple.
   // We can load from ptr with a type based on the static type of the pattern.
-  reachable_type_t* t = reach_type(c->reachable, pattern_type);
+  reach_type_t* t = reach_type(c->reach, pattern_type);
   LLVMTypeRef ptr_type = LLVMPointerType(t->use_type, 0);
   ptr = LLVMBuildIntToPtr(c->builder, ptr, ptr_type, "");
   LLVMValueRef value = LLVMBuildLoad(c->builder, ptr, "");
@@ -674,7 +674,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
 
   if(needed && !is_control_type(type))
   {
-    reachable_type_t* t_phi = reach_type(c->reachable, type);
+    reach_type_t* t_phi = reach_type(c->reach, type);
     phi_type = t_phi->use_type;
   }
 

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -159,12 +159,6 @@ const char* genname_fun(token_id cap, const char* name, ast_t* typeargs)
   return stringtab_buf(buf);
 }
 
-const char* genname_funlong(const char* type, const char* name)
-{
-  // pkg_Type[_Arg1_Arg2]_cap_name[_Arg1_Arg2]
-  return stringtab_two(type, name);
-}
-
 const char* genname_be(const char* name)
 {
   return stringtab_two(name, "_send");

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -6,219 +6,176 @@
 #include <string.h>
 #include <assert.h>
 
-static const char* build_name(const char* a, const char* b, ast_t* typeargs,
-  ast_t* cap, bool use_cap, bool function);
+static void types_append(printbuf_t* buf, ast_t* elements);
 
-static const char* nominal_name(ast_t* ast, bool use_cap)
-{
-  AST_GET_CHILDREN(ast, package, name, typeargs, cap, eph);
-
-  ast_t* def = (ast_t*)ast_data(ast);
-  ast_t* pkg = ast_nearest(def, TK_PACKAGE);
-
-  if(!use_cap)
-    cap = NULL;
-
-  return build_name(package_symbol(pkg), ast_name(name), typeargs, cap,
-    true, false);
-}
-
-static void name_append(char* name, const char* append)
-{
-  strcat(name, "_");
-  strcat(name, append);
-}
-
-static const char* element_name(ast_t* type, bool use_cap)
+static void type_append(printbuf_t* buf, ast_t* type, bool first)
 {
   switch(ast_id(type))
   {
     case TK_UNIONTYPE:
-      return build_name(NULL, "$union", type, NULL, true, false);
+    {
+      // 3u_Arg1_Arg2_Arg3
+      printbuf(buf, "%du", ast_childcount(type));
+      types_append(buf, type);
+      return;
+    }
 
     case TK_ISECTTYPE:
-      return build_name(NULL, "$isect", type, NULL, true, false);
+    {
+      // 3i_Arg1_Arg2_Arg3
+      printbuf(buf, "%di", ast_childcount(type));
+      types_append(buf, type);
+      return;
+    }
 
     case TK_TUPLETYPE:
-      return build_name(NULL, "$tuple", type, NULL, true, false);
+    {
+      // 3t_Arg1_Arg2_Arg3
+      printbuf(buf, "%dt", ast_childcount(type));
+      types_append(buf, type);
+      return;
+    }
 
     case TK_NOMINAL:
-      return nominal_name(type, use_cap);
+    {
+      // pkg_Type[_Arg1_Arg2]_cap
+      AST_GET_CHILDREN(type, package, name, typeargs, cap, eph);
+
+      ast_t* def = (ast_t*)ast_data(type);
+      ast_t* pkg = ast_nearest(def, TK_PACKAGE);
+      const char* pkg_name = package_symbol(pkg);
+
+      if(pkg_name != NULL)
+        printbuf(buf, "%s_", pkg_name);
+
+      printbuf(buf, "%s", ast_name(name));
+      types_append(buf, typeargs);
+
+      if(!first)
+        printbuf(buf, "_%s", ast_get_print(cap));
+
+      return;
+    }
 
     default: {}
   }
 
   assert(0);
-  return NULL;
 }
 
-static size_t elements_len(ast_t* elements, bool use_cap, bool function)
+static void types_append(printbuf_t* buf, ast_t* elements)
 {
-  if(elements == NULL)
-    return 0;
-
-  ast_t* element = ast_child(elements);
-  size_t len = 0;
-
-  if(function)
-    len++;
-
-  while(element != NULL)
-  {
-    const char* name = element_name(element, use_cap);
-    len += strlen(name) + 1;
-    element = ast_sibling(element);
-  }
-
-  return len;
-}
-
-static void elements_append(char* name, ast_t* elements, bool use_cap,
-  bool function)
-{
+  // _Arg1_Arg2
   if(elements == NULL)
     return;
 
-  if(function)
-    strcat(name, "_");
+  ast_t* elem = ast_child(elements);
 
-  ast_t* element = ast_child(elements);
-
-  while(element != NULL)
+  while(elem != NULL)
   {
-    name_append(name, element_name(element, use_cap));
-    element = ast_sibling(element);
+    printbuf(buf, "_");
+    type_append(buf, elem, false);
+    elem = ast_sibling(elem);
   }
 }
 
-static const char* build_name(const char* a, const char* b, ast_t* elements,
-  ast_t* cap, bool use_cap, bool function)
+static const char* stringtab_buf(printbuf_t* buf)
 {
-  size_t len = elements_len(elements, use_cap, function);
-  const char* cap_str = NULL;
+  const char* r = stringtab(buf->m);
+  printbuf_free(buf);
+  return r;
+}
 
-  if(a != NULL)
-    len += strlen(a) + 1;
+static const char* stringtab_two(const char* a, const char* b)
+{
+  if(a == NULL)
+    a = "_";
 
-  if(b != NULL)
-    len += strlen(b) + 1;
-
-  if(cap != NULL)
-  {
-    cap_str = ast_get_print(cap);
-    len += strlen(cap_str) + 1;
-  }
-
-  char* name = (char*)ponyint_pool_alloc_size(len);
-
-  if(a != NULL)
-    strcpy(name, a);
-
-  if(b != NULL)
-  {
-    if(a != NULL)
-      name_append(name, b);
-    else
-      strcpy(name, b);
-  }
-
-  elements_append(name, elements, use_cap, function);
-
-  if(cap != NULL)
-    name_append(name, cap_str);
-
-  return stringtab_consume(name, len);
+  assert(b != NULL);
+  printbuf_t* buf = printbuf_new();
+  printbuf(buf, "%s_%s", a, b);
+  return stringtab_buf(buf);
 }
 
 const char* genname_type(ast_t* ast)
 {
-  switch(ast_id(ast))
-  {
-    case TK_UNIONTYPE:
-      return build_name(NULL, "$union", ast, NULL, false, false);
-
-    case TK_ISECTTYPE:
-      return build_name(NULL, "$isect", ast, NULL, false, false);
-
-    case TK_TUPLETYPE:
-      return build_name(NULL, "$tuple", ast, NULL, false, false);
-
-    case TK_NOMINAL:
-      return nominal_name(ast, false);
-
-    default: {}
-  }
-
-  assert(0);
-  return NULL;
+  // package_Type[_Arg1_Arg2]
+  printbuf_t* buf = printbuf_new();
+  type_append(buf, ast, true);
+  return stringtab_buf(buf);
 }
 
 const char* genname_alloc(const char* type)
 {
-  return build_name(type, "Alloc", NULL, NULL, false, false);
+  return stringtab_two(type, "Alloc");
 }
 
 const char* genname_traitlist(const char* type)
 {
-  return build_name(type, "Traits", NULL, NULL, false, false);
+  return stringtab_two(type, "Traits");
 }
 
 const char* genname_fieldlist(const char* type)
 {
-  return build_name(type, "Fields", NULL, NULL, false, false);
+  return stringtab_two(type, "Fields");
 }
 
 const char* genname_trace(const char* type)
 {
-  return build_name(type, "Trace", NULL, NULL, false, false);
+  return stringtab_two(type, "Trace");
 }
 
 const char* genname_serialise(const char* type)
 {
-  return build_name(type, "Serialise", NULL, NULL, false, false);
+  return stringtab_two(type, "Serialise");
 }
 
 const char* genname_deserialise(const char* type)
 {
-  return build_name(type, "Deserialise", NULL, NULL, false, false);
+  return stringtab_two(type, "Deserialise");
 }
 
 const char* genname_dispatch(const char* type)
 {
-  return build_name(type, "Dispatch", NULL, NULL, false, false);
+  return stringtab_two(type, "Dispatch");
 }
 
 const char* genname_descriptor(const char* type)
 {
-  return build_name(type, "Desc", NULL, NULL, false, false);
+  return stringtab_two(type, "Desc");
 }
 
 const char* genname_instance(const char* type)
 {
-  return build_name(type, "Inst", NULL, NULL, false, false);
+  return stringtab_two(type, "Inst");
 }
 
 const char* genname_fun(token_id cap, const char* name, ast_t* typeargs)
 {
-  return build_name(lexer_print(cap), name, typeargs, NULL, false, true);
+  // cap_name[_Arg1_Arg2]
+  printbuf_t* buf = printbuf_new();
+  printbuf(buf, "%s_%s", lexer_print(cap), name);
+  types_append(buf, typeargs);
+  return stringtab_buf(buf);
 }
 
 const char* genname_funlong(const char* type, const char* name)
 {
-  return build_name(type, name, NULL, NULL, false, false);
+  // pkg_Type[_Arg1_Arg2]_cap_name[_Arg1_Arg2]
+  return stringtab_two(type, name);
 }
 
 const char* genname_be(const char* name)
 {
-  return build_name(name, "_send", NULL, NULL, false, false);
+  return stringtab_two(name, "_send");
 }
 
 const char* genname_box(const char* name)
 {
-  return build_name(name, "Box", NULL, NULL, false, false);
+  return stringtab_two(name, "Box");
 }
 
 const char* genname_unbox(const char* name)
 {
-  return build_name(name, "Unbox", NULL, NULL, false, false);
+  return stringtab_two(name, "Unbox");
 }

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -28,8 +28,6 @@ const char* genname_instance(const char* type);
 
 const char* genname_fun(token_id cap, const char* name, ast_t* typeargs);
 
-const char* genname_funlong(const char* type, const char* name);
-
 const char* genname_be(const char* name);
 
 const char* genname_box(const char* name);

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -12,14 +12,14 @@
 
 #define FIND_METHOD(name) \
   const char* strtab_name = stringtab(name); \
-  reachable_method_t* m = reach_method(t, TK_NONE, strtab_name, NULL); \
+  reach_method_t* m = reach_method(t, TK_NONE, strtab_name, NULL); \
   if(m == NULL) return; \
   m->intrinsic = true;
 
 #define BOX_FUNCTION() \
   box_function(t, m, strtab_name);
 
-static void start_function(compile_t* c, reachable_method_t* m,
+static void start_function(compile_t* c, reach_method_t* m,
   LLVMTypeRef result, LLVMTypeRef* params, unsigned count)
 {
   m->func_type = LLVMFunctionType(result, params, count, false);
@@ -27,13 +27,12 @@ static void start_function(compile_t* c, reachable_method_t* m,
   codegen_startfun(c, m->func, NULL, NULL);
 }
 
-static void box_function(reachable_type_t* t, reachable_method_t* m,
-  const char* name)
+static void box_function(reach_type_t* t, reach_method_t* m, const char* name)
 {
   if((m->cap != TK_BOX) && (m->cap != TK_TAG))
     return;
 
-  reachable_method_t* m_ref = reach_method(t, TK_REF, name, NULL);
+  reach_method_t* m_ref = reach_method(t, TK_REF, name, NULL);
 
   if(m_ref != NULL)
   {
@@ -42,7 +41,7 @@ static void box_function(reachable_type_t* t, reachable_method_t* m,
     m_ref->intrinsic = true;
   }
 
-  reachable_method_t* m_val = reach_method(t, TK_VAL, name, NULL);
+  reach_method_t* m_val = reach_method(t, TK_VAL, name, NULL);
 
   if(m_val != NULL)
   {
@@ -53,7 +52,7 @@ static void box_function(reachable_type_t* t, reachable_method_t* m,
 
   if(m->cap == TK_TAG)
   {
-    reachable_method_t* m_box = reach_method(t, TK_BOX, name, NULL);
+    reach_method_t* m_box = reach_method(t, TK_BOX, name, NULL);
 
     if(m_box != NULL)
     {
@@ -64,7 +63,7 @@ static void box_function(reachable_type_t* t, reachable_method_t* m,
   }
 }
 
-static void pointer_create(compile_t* c, reachable_type_t* t)
+static void pointer_create(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("create");
   start_function(c, m, t->use_type, &t->use_type, 1);
@@ -75,8 +74,8 @@ static void pointer_create(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void pointer_alloc(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_alloc(compile_t* c, reach_type_t* t,
+  reach_type_t* t_elem)
 {
   FIND_METHOD("_alloc");
 
@@ -101,8 +100,8 @@ static void pointer_alloc(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void pointer_realloc(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_realloc(compile_t* c, reach_type_t* t,
+  reach_type_t* t_elem)
 {
   FIND_METHOD("_realloc");
 
@@ -129,7 +128,7 @@ static void pointer_realloc(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void pointer_unsafe(compile_t* c, reachable_type_t* t)
+static void pointer_unsafe(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("_unsafe");
   start_function(c, m, t->use_type, &t->use_type, 1);
@@ -138,8 +137,7 @@ static void pointer_unsafe(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void pointer_apply(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_apply(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("_apply");
 
@@ -162,8 +160,7 @@ static void pointer_apply(compile_t* c, reachable_type_t* t,
   BOX_FUNCTION();
 }
 
-static void pointer_update(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_update(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("_update");
 
@@ -186,8 +183,7 @@ static void pointer_update(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void pointer_offset(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_offset(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("_offset");
 
@@ -215,8 +211,7 @@ static void pointer_offset(compile_t* c, reachable_type_t* t,
   BOX_FUNCTION();
 }
 
-static void pointer_insert(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_insert(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("_insert");
 
@@ -252,8 +247,7 @@ static void pointer_insert(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void pointer_delete(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_delete(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("_delete");
 
@@ -293,8 +287,8 @@ static void pointer_delete(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void pointer_copy_to(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void pointer_copy_to(compile_t* c, reach_type_t* t,
+  reach_type_t* t_elem)
 {
   FIND_METHOD("_copy_to");
 
@@ -327,7 +321,7 @@ static void pointer_copy_to(compile_t* c, reachable_type_t* t,
   BOX_FUNCTION();
 }
 
-static void pointer_usize(compile_t* c, reachable_type_t* t)
+static void pointer_usize(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("usize");
   start_function(c, m, c->intptr, &t->use_type, 1);
@@ -339,11 +333,11 @@ static void pointer_usize(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-void genprim_pointer_methods(compile_t* c, reachable_type_t* t)
+void genprim_pointer_methods(compile_t* c, reach_type_t* t)
 {
   ast_t* typeargs = ast_childidx(t->ast, 2);
   ast_t* typearg = ast_child(typeargs);
-  reachable_type_t* t_elem = reach_type(c->reachable, typearg);
+  reach_type_t* t_elem = reach_type(c->reach, typearg);
 
   pointer_create(c, t);
   pointer_alloc(c, t, t_elem);
@@ -359,8 +353,7 @@ void genprim_pointer_methods(compile_t* c, reachable_type_t* t)
   pointer_usize(c, t);
 }
 
-static void maybe_create(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void maybe_create(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   FIND_METHOD("create");
 
@@ -375,7 +368,7 @@ static void maybe_create(compile_t* c, reachable_type_t* t,
   codegen_finishfun(c);
 }
 
-static void maybe_none(compile_t* c, reachable_type_t* t)
+static void maybe_none(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("none");
   start_function(c, m, t->use_type, &t->use_type, 1);
@@ -384,8 +377,7 @@ static void maybe_none(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void maybe_apply(compile_t* c, reachable_type_t* t,
-  reachable_type_t* t_elem)
+static void maybe_apply(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
 {
   // Returns the receiver if it isn't null.
   FIND_METHOD("apply");
@@ -410,7 +402,7 @@ static void maybe_apply(compile_t* c, reachable_type_t* t,
   BOX_FUNCTION();
 }
 
-static void maybe_is_none(compile_t* c, reachable_type_t* t)
+static void maybe_is_none(compile_t* c, reach_type_t* t)
 {
   // Returns true if the receiver is null.
   FIND_METHOD("is_none");
@@ -425,11 +417,11 @@ static void maybe_is_none(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-void genprim_maybe_methods(compile_t* c, reachable_type_t* t)
+void genprim_maybe_methods(compile_t* c, reach_type_t* t)
 {
   ast_t* typeargs = ast_childidx(t->ast, 2);
   ast_t* typearg = ast_child(typeargs);
-  reachable_type_t* t_elem = reach_type(c->reachable, typearg);
+  reach_type_t* t_elem = reach_type(c->reach, typearg);
 
   maybe_create(c, t, t_elem);
   maybe_none(c, t);
@@ -437,7 +429,7 @@ void genprim_maybe_methods(compile_t* c, reachable_type_t* t)
   maybe_is_none(c, t);
 }
 
-void genprim_array_trace(compile_t* c, reachable_type_t* t)
+void genprim_array_trace(compile_t* c, reach_type_t* t)
 {
   // Get the type argument for the array. This will be used to generate the
   // per-element trace call.
@@ -468,7 +460,7 @@ void genprim_array_trace(compile_t* c, reachable_type_t* t)
     return;
   }
 
-  reachable_type_t* t_elem = reach_type(c->reachable, typearg);
+  reach_type_t* t_elem = reach_type(c->reach, typearg);
   pointer = LLVMBuildBitCast(c->builder, pointer,
     LLVMPointerType(t_elem->use_type, 0), "");
 
@@ -509,7 +501,7 @@ void genprim_array_trace(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void platform_freebsd(compile_t* c, reachable_type_t* t)
+static void platform_freebsd(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("freebsd");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -522,7 +514,7 @@ static void platform_freebsd(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_linux(compile_t* c, reachable_type_t* t)
+static void platform_linux(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("linux");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -535,7 +527,7 @@ static void platform_linux(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_osx(compile_t* c, reachable_type_t* t)
+static void platform_osx(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("osx");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -548,7 +540,7 @@ static void platform_osx(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_windows(compile_t* c, reachable_type_t* t)
+static void platform_windows(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("windows");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -561,7 +553,7 @@ static void platform_windows(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_x86(compile_t* c, reachable_type_t* t)
+static void platform_x86(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("x86");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -574,7 +566,7 @@ static void platform_x86(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_arm(compile_t* c, reachable_type_t* t)
+static void platform_arm(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("arm");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -587,7 +579,7 @@ static void platform_arm(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_lp64(compile_t* c, reachable_type_t* t)
+static void platform_lp64(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("lp64");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -600,7 +592,7 @@ static void platform_lp64(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_llp64(compile_t* c, reachable_type_t* t)
+static void platform_llp64(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("llp64");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -613,7 +605,7 @@ static void platform_llp64(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_ilp32(compile_t* c, reachable_type_t* t)
+static void platform_ilp32(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("ilp32");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -626,7 +618,7 @@ static void platform_ilp32(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_native128(compile_t* c, reachable_type_t* t)
+static void platform_native128(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("native128");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -639,7 +631,7 @@ static void platform_native128(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void platform_debug(compile_t* c, reachable_type_t* t)
+static void platform_debug(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("debug");
   start_function(c, m, c->i1, &t->use_type, 1);
@@ -651,7 +643,7 @@ static void platform_debug(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-void genprim_platform_methods(compile_t* c, reachable_type_t* t)
+void genprim_platform_methods(compile_t* c, reach_type_t* t)
 {
   platform_freebsd(c, t);
   platform_linux(c, t);
@@ -687,7 +679,7 @@ static void number_conversion(compile_t* c, num_conv_t* from, num_conv_t* to,
     return;
   }
 
-  reachable_type_t* t = reach_type_name(c->reachable, from->type_name);
+  reach_type_t* t = reach_type_name(c->reach, from->type_name);
 
   if(t == NULL)
     return;
@@ -831,7 +823,7 @@ static void number_conversions(compile_t* c)
   }
 }
 
-static void f32_from_bits(compile_t* c, reachable_type_t* t)
+static void f32_from_bits(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("from_bits");
 
@@ -846,7 +838,7 @@ static void f32_from_bits(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void f32_bits(compile_t* c, reachable_type_t* t)
+static void f32_bits(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("bits");
   start_function(c, m, c->i32, &c->f32, 1);
@@ -859,7 +851,7 @@ static void f32_bits(compile_t* c, reachable_type_t* t)
   BOX_FUNCTION();
 }
 
-static void f64_from_bits(compile_t* c, reachable_type_t* t)
+static void f64_from_bits(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("from_bits");
 
@@ -874,7 +866,7 @@ static void f64_from_bits(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static void f64_bits(compile_t* c, reachable_type_t* t)
+static void f64_bits(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("bits");
   start_function(c, m, c->i64, &c->f64, 1);
@@ -889,15 +881,15 @@ static void f64_bits(compile_t* c, reachable_type_t* t)
 
 static void fp_as_bits(compile_t* c)
 {
-  reachable_type_t* t;
+  reach_type_t* t;
 
-  if((t = reach_type_name(c->reachable, "F32")) != NULL)
+  if((t = reach_type_name(c->reach, "F32")) != NULL)
   {
     f32_from_bits(c, t);
     f32_bits(c, t);
   }
 
-  if((t = reach_type_name(c->reachable, "F64")) != NULL)
+  if((t = reach_type_name(c->reach, "F64")) != NULL)
   {
     f64_from_bits(c, t);
     f64_bits(c, t);
@@ -992,13 +984,13 @@ void genprim_reachable_init(compile_t* c, ast_t* program)
 
             if(finit != NULL)
             {
-              reach(c->reachable, type, c->str__init, NULL, c->opt);
+              reach(c->reach, type, c->str__init, NULL, c->opt);
               ast_free_unattached(finit);
             }
 
             if(ffinal != NULL)
             {
-              reach(c->reachable, type, c->str__final, NULL, c->opt);
+              reach(c->reach, type, c->str__final, NULL, c->opt);
               ast_free_unattached(ffinal);
             }
 

--- a/src/libponyc/codegen/genprim.h
+++ b/src/libponyc/codegen/genprim.h
@@ -7,13 +7,13 @@
 
 PONY_EXTERN_C_BEGIN
 
-void genprim_pointer_methods(compile_t* c, reachable_type_t* t);
+void genprim_pointer_methods(compile_t* c, reach_type_t* t);
 
-void genprim_maybe_methods(compile_t* c, reachable_type_t* t);
+void genprim_maybe_methods(compile_t* c, reach_type_t* t);
 
-void genprim_array_trace(compile_t* c, reachable_type_t* t);
+void genprim_array_trace(compile_t* c, reach_type_t* t);
 
-void genprim_platform_methods(compile_t* c, reachable_type_t* t);
+void genprim_platform_methods(compile_t* c, reach_type_t* t);
 
 void genprim_builtins(compile_t* c);
 

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -104,7 +104,7 @@ LLVMValueRef gen_tuple(compile_t* c, ast_t* ast)
   if(contains_dontcare(type))
     return GEN_NOTNEEDED;
 
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
   LLVMValueRef tuple = LLVMGetUndef(t->primitive);
   int i = 0;
 
@@ -142,7 +142,7 @@ LLVMValueRef gen_localdecl(compile_t* c, ast_t* ast)
   if(value != NULL)
     return GEN_NOVALUE;
 
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   // All alloca should happen in the entry block of a function.
   LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
@@ -286,7 +286,7 @@ LLVMValueRef gen_identity(compile_t* c, ast_t* ast)
 LLVMValueRef gen_int(compile_t* c, ast_t* ast)
 {
   ast_t* type = ast_type(ast);
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   lexint_t* value = ast_int(ast);
   LLVMValueRef vlow = LLVMConstInt(c->i128, value->low, false);
@@ -307,7 +307,7 @@ LLVMValueRef gen_int(compile_t* c, ast_t* ast)
 LLVMValueRef gen_float(compile_t* c, ast_t* ast)
 {
   ast_t* type = ast_type(ast);
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   return LLVMConstReal(t->primitive, ast_float(ast));
 }
@@ -330,7 +330,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
   LLVMSetGlobalConstant(g_str, true);
   LLVMValueRef str_ptr = LLVMConstInBoundsGEP(g_str, args, 2);
 
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   args[0] = t->desc;
   args[1] = LLVMConstInt(c->intptr, len, false);

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -324,7 +324,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
 
   LLVMValueRef str = LLVMConstStringInContext(c->context, name, (int)len,
     false);
-  LLVMValueRef g_str = LLVMAddGlobal(c->module, LLVMTypeOf(str), "$strval");
+  LLVMValueRef g_str = LLVMAddGlobal(c->module, LLVMTypeOf(str), "");
   LLVMSetLinkage(g_str, LLVMInternalLinkage);
   LLVMSetInitializer(g_str, str);
   LLVMSetGlobalConstant(g_str, true);
@@ -338,7 +338,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
   args[3] = str_ptr;
 
   LLVMValueRef inst = LLVMConstNamedStruct(t->structure, args, 4);
-  LLVMValueRef g_inst = LLVMAddGlobal(c->module, t->structure, "$string");
+  LLVMValueRef g_inst = LLVMAddGlobal(c->module, t->structure, "");
   LLVMSetInitializer(g_inst, inst);
   LLVMSetGlobalConstant(g_inst, true);
   LLVMSetLinkage(g_inst, LLVMInternalLinkage);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -409,7 +409,7 @@ static void trace_maybe(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 static void trace_known(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   ast_t* type, bool immutable)
 {
-  reachable_type_t* t = reach_type(c->reachable, type);
+  reach_type_t* t = reach_type(c->reach, type);
 
   // If this type has no trace function, don't try to recurse in the runtime.
   if(t->trace_fn != NULL)
@@ -716,7 +716,7 @@ bool gentrace_needed(ast_t* type)
   return true;
 }
 
-void gentrace_prototype(compile_t* c, reachable_type_t* t)
+void gentrace_prototype(compile_t* c, reach_type_t* t)
 {
   switch(t->underlying)
   {

--- a/src/libponyc/codegen/gentrace.h
+++ b/src/libponyc/codegen/gentrace.h
@@ -9,7 +9,7 @@ PONY_EXTERN_C_BEGIN
 
 bool gentrace_needed(ast_t* type);
 
-void gentrace_prototype(compile_t* c, reachable_type_t* t);
+void gentrace_prototype(compile_t* c, reach_type_t* t);
 
 void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type);
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <assert.h>
 
-static bool make_opaque_struct(compile_t* c, reachable_type_t* t)
+static bool make_opaque_struct(compile_t* c, reach_type_t* t)
 {
   switch(ast_id(t->ast))
   {
@@ -133,7 +133,7 @@ static bool make_opaque_struct(compile_t* c, reachable_type_t* t)
   return false;
 }
 
-static void make_debug_basic(compile_t* c, reachable_type_t* t)
+static void make_debug_basic(compile_t* c, reach_type_t* t)
 {
   uint64_t size = LLVMABISizeOfType(c->target_data, t->primitive);
   uint64_t align = LLVMABIAlignmentOfType(c->target_data, t->primitive);
@@ -154,7 +154,7 @@ static void make_debug_basic(compile_t* c, reachable_type_t* t)
     8 * size, 8 * align, encoding);
 }
 
-static void make_debug_prototype(compile_t* c, reachable_type_t* t)
+static void make_debug_prototype(compile_t* c, reach_type_t* t)
 {
   t->di_type = LLVMDIBuilderCreateReplaceableStruct(c->di,
     t->name, c->di_unit, t->di_file, (unsigned)ast_line(t->ast));
@@ -166,7 +166,7 @@ static void make_debug_prototype(compile_t* c, reachable_type_t* t)
   }
 }
 
-static void make_debug_info(compile_t* c, reachable_type_t* t)
+static void make_debug_info(compile_t* c, reach_type_t* t)
 {
   source_t* source = ast_source(t->ast);
   t->di_file = LLVMDIBuilderCreateFile(c->di, source->file);
@@ -202,7 +202,7 @@ static void make_debug_info(compile_t* c, reachable_type_t* t)
   assert(0);
 }
 
-static void make_box_type(compile_t* c, reachable_type_t* t)
+static void make_box_type(compile_t* c, reach_type_t* t)
 {
   if(t->primitive == NULL)
     return;
@@ -218,7 +218,7 @@ static void make_box_type(compile_t* c, reachable_type_t* t)
   t->structure_ptr = LLVMPointerType(t->structure, 0);
 }
 
-static void make_global_instance(compile_t* c, reachable_type_t* t)
+static void make_global_instance(compile_t* c, reach_type_t* t)
 {
   // Not a primitive type.
   if(t->underlying != TK_PRIMITIVE)
@@ -241,7 +241,7 @@ static void make_global_instance(compile_t* c, reachable_type_t* t)
   LLVMSetLinkage(t->instance, LLVMInternalLinkage);
 }
 
-static void make_dispatch(compile_t* c, reachable_type_t* t)
+static void make_dispatch(compile_t* c, reach_type_t* t)
 {
   // Do nothing if we're not an actor.
   if(t->underlying != TK_ACTOR)
@@ -270,7 +270,7 @@ static void make_dispatch(compile_t* c, reachable_type_t* t)
   codegen_finishfun(c);
 }
 
-static bool make_struct(compile_t* c, reachable_type_t* t)
+static bool make_struct(compile_t* c, reach_type_t* t)
 {
   LLVMTypeRef type;
   int extra = 0;
@@ -349,7 +349,7 @@ static bool make_struct(compile_t* c, reachable_type_t* t)
   return true;
 }
 
-static LLVMMetadataRef make_debug_field(compile_t* c, reachable_type_t* t,
+static LLVMMetadataRef make_debug_field(compile_t* c, reach_type_t* t,
   uint32_t i)
 {
   const char* name;
@@ -403,7 +403,7 @@ static LLVMMetadataRef make_debug_field(compile_t* c, reachable_type_t* t,
     (unsigned)ast_line(ast), 8 * size, 8 * align, 8 * offset, flags, di_type);
 }
 
-static void make_debug_fields(compile_t* c, reachable_type_t* t)
+static void make_debug_fields(compile_t* c, reach_type_t* t)
 {
   LLVMMetadataRef fields = NULL;
 
@@ -450,7 +450,7 @@ static void make_debug_fields(compile_t* c, reachable_type_t* t)
   }
 }
 
-static void make_debug_final(compile_t* c, reachable_type_t* t)
+static void make_debug_final(compile_t* c, reach_type_t* t)
 {
   switch(t->underlying)
   {
@@ -478,7 +478,7 @@ static void make_debug_final(compile_t* c, reachable_type_t* t)
   assert(0);
 }
 
-static void make_pointer_methods(compile_t* c, reachable_type_t* t)
+static void make_pointer_methods(compile_t* c, reach_type_t* t)
 {
   if(ast_id(t->ast) != TK_NOMINAL)
     return;
@@ -499,7 +499,7 @@ static void make_pointer_methods(compile_t* c, reachable_type_t* t)
   }
 }
 
-static bool make_trace(compile_t* c, reachable_type_t* t)
+static bool make_trace(compile_t* c, reach_type_t* t)
 {
   if(t->trace_fn == NULL)
     return true;
@@ -569,7 +569,7 @@ static bool make_trace(compile_t* c, reachable_type_t* t)
 
 bool gentypes(compile_t* c)
 {
-  reachable_type_t* t;
+  reach_type_t* t;
   size_t i;
 
   genprim_builtins(c);
@@ -577,7 +577,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Data prototypes\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(!make_opaque_struct(c, t))
       return false;
@@ -592,7 +592,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Data types\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(!make_struct(c, t))
       return false;
@@ -603,7 +603,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Function prototypes\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     make_debug_final(c, t);
     make_pointer_methods(c, t);
@@ -615,7 +615,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Functions\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(!genfun_method_bodies(c, t))
       return false;
@@ -624,7 +624,7 @@ bool gentypes(compile_t* c)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Descriptors\n"));
   i = HASHMAP_BEGIN;
 
-  while((t = reachable_types_next(&c->reachable->types, &i)) != NULL)
+  while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
     if(!make_trace(c, t))
       return false;

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -20,9 +20,6 @@ static bool make_opaque_struct(compile_t* c, reachable_type_t* t)
   {
     case TK_NOMINAL:
     {
-      ast_t* def = (ast_t*)ast_data(t->ast);
-      t->underlying = ast_id(def);
-
       switch(t->underlying)
       {
         case TK_INTERFACE:
@@ -118,7 +115,6 @@ static bool make_opaque_struct(compile_t* c, reachable_type_t* t)
     }
 
     case TK_TUPLETYPE:
-      t->underlying = TK_TUPLETYPE;
       t->primitive = LLVMStructCreateNamed(c->context, t->name);
       t->use_type = t->primitive;
       t->field_count = (uint32_t)ast_childcount(t->ast);
@@ -127,7 +123,6 @@ static bool make_opaque_struct(compile_t* c, reachable_type_t* t)
     case TK_UNIONTYPE:
     case TK_ISECTTYPE:
       // Just a raw object pointer.
-      t->underlying = ast_id(t->ast);
       t->use_type = c->object_ptr;
       return true;
 

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -427,10 +427,6 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   {
     errorframe_t frame = NULL;
     ast_error_frame(&frame, ast, "right side must be a subtype of left side");
-    ast_error_frame(&frame, a_type, "right side type: %s",
-      ast_print_type(a_type));
-    ast_error_frame(&frame, l_type, "left side type: %s",
-      ast_print_type(l_type));
     errorframe_append(&frame, &info);
     errorframe_report(&frame, opt->check.errors);
     ast_free_unattached(a_type);
@@ -458,8 +454,6 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
         break;
     }
 
-    ast_error(opt->check.errors, a_type, "right side type: %s",
-      ast_print_type(a_type));
     ast_free_unattached(a_type);
     return false;
   }

--- a/src/libponyc/expr/reference.h
+++ b/src/libponyc/expr/reference.h
@@ -8,6 +8,7 @@
 
 PONY_EXTERN_C_BEGIN
 
+bool expr_param(pass_opt_t* opt, ast_t* ast);
 bool expr_field(pass_opt_t* opt, ast_t* ast);
 bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid);
 bool expr_typeref(pass_opt_t* opt, ast_t** astp);

--- a/src/libponyc/expr/reference.h
+++ b/src/libponyc/expr/reference.h
@@ -8,6 +8,7 @@
 
 PONY_EXTERN_C_BEGIN
 
+bool expr_provides(pass_opt_t* opt, ast_t* ast);
 bool expr_param(pass_opt_t* opt, ast_t* ast);
 bool expr_field(pass_opt_t* opt, ast_t* ast);
 bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid);

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -201,8 +201,8 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_NOMINAL:    r = expr_nominal(options, astp); break;
     case TK_FVAR:
     case TK_FLET:
-    case TK_EMBED:
-    case TK_PARAM:      r = expr_field(options, ast); break;
+    case TK_EMBED:      r = expr_field(options, ast); break;
+    case TK_PARAM:      r = expr_param(options, ast); break;
     case TK_NEW:
     case TK_BE:
     case TK_FUN:        r = expr_fun(options, ast); break;

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -198,6 +198,12 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
 
   switch(ast_id(ast))
   {
+    case TK_PRIMITIVE:
+    case TK_STRUCT:
+    case TK_CLASS:
+    case TK_ACTOR:
+    case TK_TRAIT:
+    case TK_INTERFACE:  r = expr_provides(options, ast); break;
     case TK_NOMINAL:    r = expr_nominal(options, astp); break;
     case TK_FVAR:
     case TK_FLET:

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -61,13 +61,14 @@ static bool set_scope(pass_opt_t* opt, typecheck_t* t, ast_t* scope,
       return false;
   }
 
-  if(!ast_set(scope, s, value, status))
+  if(!ast_set(scope, s, value, status, false))
   {
     ast_t* prev = ast_get(scope, s, NULL);
     ast_t* prev_nocase = ast_get_case(scope, s, NULL);
 
     ast_error(opt->check.errors, name, "can't reuse name '%s'", s);
-    ast_error_continue(opt->check.errors, prev_nocase, "previous use of '%s'%s",
+    ast_error_continue(opt->check.errors, prev_nocase,
+      "previous use of '%s'%s",
       s, (prev == NULL) ? " differs only by case" : "");
 
     return false;

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -22,7 +22,17 @@ static ast_t* make_create(ast_t* ast)
   assert(ast != NULL);
 
   // Default constructors on classes can be iso, on actors they must be tag
-  token_id cap = (ast_id(ast) == TK_CLASS) ? TK_ISO : TK_NONE;
+  token_id cap = TK_NONE;
+
+  switch(ast_id(ast))
+  {
+    case TK_STRUCT:
+    case TK_CLASS:
+      cap = TK_ISO;
+      break;
+
+    default: {}
+  }
 
   BUILD(create, ast,
     NODE(TK_NEW, AST_SCOPE

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -813,26 +813,12 @@ static bool delegated_methods(ast_t* entity, pass_opt_t* opt)
         if(!trait_entity(trait, opt))
           return false;
 
-        errorframe_t err = NULL;
-        if(!is_subtype(f_type, trait_ref, &err, opt))
+        // Run through the methods of each delegated type.
+        for(ast_t* method = ast_child(ast_childidx(trait, 4));
+          method != NULL; method = ast_sibling(method))
         {
-          ast_error(opt->check.errors, trait_ref,
-            "field not a subtype of delegate");
-          ast_error_continue(opt->check.errors, f_type,
-            "field type: %s", ast_print_type(f_type));
-          ast_error_continue(opt->check.errors, trait_ref,
-            "delegate type: %s", ast_print_type(trait_ref));
-          r = false;
-        }
-        else
-        {
-          // Run through the methods of each delegated type.
-          for(ast_t* method = ast_child(ast_childidx(trait, 4));
-            method != NULL; method = ast_sibling(method))
-          {
-            if(!delegated_method(entity, method, field, trait_ref, opt))
-              r = false;
-          }
+          if(!delegated_method(entity, method, field, trait_ref, opt))
+            r = false;
         }
       }
     }

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -500,8 +500,8 @@ static ast_t* create_package(ast_t* program, const char* name,
 
   ast_scope(package);
   ast_append(program, package);
-  ast_set(program, pkg->path, package, SYM_NONE);
-  ast_set(program, pkg->id, package, SYM_NONE);
+  ast_set(program, pkg->path, package, SYM_NONE, false);
+  ast_set(program, pkg->id, package, SYM_NONE, false);
 
   if((safe != NULL) && (strlist_find(safe, pkg->path) == NULL))
     pkg->allow_ffi = false;

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -269,23 +269,22 @@ static void find_names_types_use(painter_t* painter, reach_types_t* types)
   size_t i = HASHMAP_BEGIN;
   size_t typemap_index = 0;
   uint64_t typemap_mask = 1;
-  reach_type_t* type;
+  reach_type_t* t;
 
-  while((type = reach_types_next(types, &i)) != NULL)
+  while((t = reach_types_next(types, &i)) != NULL)
   {
     assert(typemap_index < painter->typemap_size);
     size_t j = HASHMAP_BEGIN;
-    reach_method_name_t* mn;
+    reach_method_name_t* n;
 
-    while((mn = reach_method_names_next(&type->methods, &j)) != NULL)
+    while((n = reach_method_names_next(&t->methods, &j)) != NULL)
     {
       size_t k = HASHMAP_BEGIN;
-      reach_method_t* method;
+      reach_method_t* m;
 
-      while((method = reach_methods_next(&mn->r_methods, &k)) != NULL)
+      while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
-        const char* name = method->name;
-
+        const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
 
         if(name_rec == NULL)  // This is the first use of this name
@@ -347,34 +346,33 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
   assert(types != NULL);
 
   size_t i = HASHMAP_BEGIN;
-  reach_type_t* type;
+  reach_type_t* t;
 
   // Iterate over all types
-  while((type = reach_types_next(types, &i)) != NULL)
+  while((t = reach_types_next(types, &i)) != NULL)
   {
-    if(reach_method_names_size(&type->methods) == 0)
+    if(reach_method_names_size(&t->methods) == 0)
       continue;
 
     size_t j = HASHMAP_BEGIN;
-    reach_method_name_t* mn;
+    reach_method_name_t* n;
     uint32_t max_colour = 0;
 
     // Iterate over all method names in type
-    while((mn = reach_method_names_next(&type->methods, &j)) != NULL)
+    while((n = reach_method_names_next(&t->methods, &j)) != NULL)
     {
       size_t k = HASHMAP_BEGIN;
-      reach_method_t* method;
+      reach_method_t* m;
 
-      while((method = reach_methods_next(&mn->r_methods, &k)) != NULL)
+      while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
         // Store colour assigned to name in reachable types set
-        const char* name = method->name;
-
+        const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
         assert(name_rec != NULL);
 
         uint32_t colour = name_rec->colour;
-        method->vtable_index = colour;
+        m->vtable_index = colour;
 
         if(colour > max_colour)
           max_colour = colour;
@@ -382,7 +380,7 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
     }
 
     // Store vtable size for type
-    type->vtable_size = max_colour + 1;
+    t->vtable_size = max_colour + 1;
   }
 }
 

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -261,7 +261,7 @@ static void assign_name_to_colour(colour_record_t* colour, name_record_t* name)
 
 
 // Step 1
-static void find_names_types_use(painter_t* painter, reachable_types_t* types)
+static void find_names_types_use(painter_t* painter, reach_types_t* types)
 {
   assert(painter != NULL);
   assert(types != NULL);
@@ -269,20 +269,20 @@ static void find_names_types_use(painter_t* painter, reachable_types_t* types)
   size_t i = HASHMAP_BEGIN;
   size_t typemap_index = 0;
   uint64_t typemap_mask = 1;
-  reachable_type_t* type;
+  reach_type_t* type;
 
-  while((type = reachable_types_next(types, &i)) != NULL)
+  while((type = reach_types_next(types, &i)) != NULL)
   {
     assert(typemap_index < painter->typemap_size);
     size_t j = HASHMAP_BEGIN;
-    reachable_method_name_t* mn;
+    reach_method_name_t* mn;
 
-    while((mn = reachable_method_names_next(&type->methods, &j)) != NULL)
+    while((mn = reach_method_names_next(&type->methods, &j)) != NULL)
     {
       size_t k = HASHMAP_BEGIN;
-      reachable_method_t* method;
+      reach_method_t* method;
 
-      while((method = reachable_methods_next(&mn->r_methods, &k)) != NULL)
+      while((method = reach_methods_next(&mn->r_methods, &k)) != NULL)
       {
         const char* name = method->name;
 
@@ -341,31 +341,31 @@ static void assign_colours_to_names(painter_t* painter)
 
 
 // Step 5
-static void distribute_info(painter_t* painter, reachable_types_t* types)
+static void distribute_info(painter_t* painter, reach_types_t* types)
 {
   assert(painter != NULL);
   assert(types != NULL);
 
   size_t i = HASHMAP_BEGIN;
-  reachable_type_t* type;
+  reach_type_t* type;
 
   // Iterate over all types
-  while((type = reachable_types_next(types, &i)) != NULL)
+  while((type = reach_types_next(types, &i)) != NULL)
   {
-    if(reachable_method_names_size(&type->methods) == 0)
+    if(reach_method_names_size(&type->methods) == 0)
       continue;
 
     size_t j = HASHMAP_BEGIN;
-    reachable_method_name_t* mn;
+    reach_method_name_t* mn;
     uint32_t max_colour = 0;
 
     // Iterate over all method names in type
-    while((mn = reachable_method_names_next(&type->methods, &j)) != NULL)
+    while((mn = reach_method_names_next(&type->methods, &j)) != NULL)
     {
       size_t k = HASHMAP_BEGIN;
-      reachable_method_t* method;
+      reach_method_t* method;
 
-      while((method = reachable_methods_next(&mn->r_methods, &k)) != NULL)
+      while((method = reach_methods_next(&mn->r_methods, &k)) != NULL)
       {
         // Store colour assigned to name in reachable types set
         const char* name = method->name;
@@ -408,11 +408,11 @@ static void painter_tidy(painter_t* painter)
 }
 
 
-void paint(reachable_types_t* types)
+void paint(reach_types_t* types)
 {
   assert(types != NULL);
 
-  size_t type_count = reachable_types_size(types);
+  size_t type_count = reach_types_size(types);
 
   if(type_count == 0) // Nothing to paint
     return;

--- a/src/libponyc/reach/paint.h
+++ b/src/libponyc/reach/paint.h
@@ -10,7 +10,7 @@ PONY_EXTERN_C_BEGIN
  * reachable types. The resulting vtable indices and sizes are written back
  * into the given set.
  */
-void paint(reachable_types_t* types);
+void paint(reach_types_t* types);
 
 
 PONY_EXTERN_C_END

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -452,6 +452,7 @@ static reachable_type_t* add_isect_or_union(reach_t* r, ast_t* type,
     return t;
 
   t = add_reachable_type(r, type);
+  t->underlying = ast_id(t->ast);
   t->type_id = ++r->next_type_id;
 
   ast_t* child = ast_child(type);
@@ -476,6 +477,7 @@ static reachable_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
     return t;
 
   t = add_reachable_type(r, type);
+  t->underlying = TK_TUPLETYPE;
   t->type_id = ++r->next_type_id;
 
   t->field_count = (uint32_t)ast_childcount(t->ast);
@@ -509,6 +511,8 @@ static reachable_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
     return t;
 
   t = add_reachable_type(r, type);
+  ast_t* def = (ast_t*)ast_data(type);
+  t->underlying = ast_id(def);
 
   AST_GET_CHILDREN(type, pkg, id, typeparams);
   ast_t* typeparam = ast_child(typeparams);
@@ -518,8 +522,6 @@ static reachable_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
     add_type(r, typeparam, opt);
     typeparam = ast_sibling(typeparam);
   }
-
-  ast_t* def = (ast_t*)ast_data(type);
 
   switch(ast_id(def))
   {

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -483,10 +483,12 @@ static reachable_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
   t->field_count = (uint32_t)ast_childcount(t->ast);
   t->fields = (reachable_field_t*)calloc(t->field_count,
     sizeof(reachable_field_t));
+
   printbuf_t* mangle = printbuf_new();
-  size_t index = 0;
+  printbuf(mangle, "%d", t->field_count);
 
   ast_t* child = ast_child(type);
+  size_t index = 0;
 
   while(child != NULL)
   {

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -53,6 +53,7 @@ struct reach_method_t
 
 struct reach_method_name_t
 {
+  token_id id;
   token_id cap;
   const char* name;
   reach_methods_t r_methods;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -43,6 +43,9 @@ struct reach_method_t
   // Mark as true if the compiler supplies an implementation.
   bool intrinsic;
 
+  // Mark as true if the method is a forwarding method.
+  bool forwarding;
+
   // Linked list of instantiations that use the same func.
   reach_method_t* subordinate;
 

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -11,22 +11,22 @@
 
 PONY_EXTERN_C_BEGIN
 
-typedef struct reachable_method_t reachable_method_t;
-typedef struct reachable_method_name_t reachable_method_name_t;
-typedef struct reachable_field_t reachable_field_t;
-typedef struct reachable_type_t reachable_type_t;
+typedef struct reach_method_t reach_method_t;
+typedef struct reach_method_name_t reach_method_name_t;
+typedef struct reach_field_t reach_field_t;
+typedef struct reach_type_t reach_type_t;
 
-DECLARE_STACK(reachable_method_stack, reachable_method_stack_t,
-  reachable_method_t);
-DECLARE_HASHMAP(reachable_methods, reachable_methods_t,
-  reachable_method_t);
-DECLARE_HASHMAP(reachable_method_names, reachable_method_names_t,
-  reachable_method_name_t);
-DECLARE_HASHMAP(reachable_types, reachable_types_t, reachable_type_t);
-DECLARE_HASHMAP(reachable_type_cache, reachable_type_cache_t,
-  reachable_type_t);
+DECLARE_STACK(reach_method_stack, reach_method_stack_t,
+  reach_method_t);
+DECLARE_HASHMAP(reach_methods, reach_methods_t,
+  reach_method_t);
+DECLARE_HASHMAP(reach_method_names, reach_method_names_t,
+  reach_method_name_t);
+DECLARE_HASHMAP(reach_types, reach_types_t, reach_type_t);
+DECLARE_HASHMAP(reach_type_cache, reach_type_cache_t,
+  reach_type_t);
 
-struct reachable_method_t
+struct reach_method_t
 {
   const char* name;
   const char* full_name;
@@ -41,36 +41,36 @@ struct reachable_method_t
   LLVMMetadataRef di_method;
   LLVMMetadataRef di_file;
   bool intrinsic;
-  reachable_method_t* subordinate;
+  reach_method_t* subordinate;
 
   size_t param_count;
-  reachable_type_t** params;
-  reachable_type_t* result;
+  reach_type_t** params;
+  reach_type_t* result;
 };
 
-struct reachable_method_name_t
+struct reach_method_name_t
 {
   token_id cap;
   const char* name;
-  reachable_methods_t r_methods;
+  reach_methods_t r_methods;
 };
 
-struct reachable_field_t
+struct reach_field_t
 {
   ast_t* ast;
-  reachable_type_t* type;
+  reach_type_t* type;
   bool embed;
 };
 
-struct reachable_type_t
+struct reach_type_t
 {
   const char* name;
   const char* mangle;
   ast_t* ast;
   token_id underlying;
 
-  reachable_method_names_t methods;
-  reachable_type_cache_t subtypes;
+  reach_method_names_t methods;
+  reach_type_cache_t subtypes;
   uint32_t type_id;
   uint32_t vtable_size;
 
@@ -94,13 +94,13 @@ struct reachable_type_t
   LLVMMetadataRef di_type_embed;
 
   uint32_t field_count;
-  reachable_field_t* fields;
+  reach_field_t* fields;
 };
 
 typedef struct
 {
-  reachable_types_t types;
-  reachable_method_stack_t* stack;
+  reach_types_t types;
+  reach_method_stack_t* stack;
   uint32_t next_type_id;
 } reach_t;
 
@@ -118,17 +118,17 @@ void reach_free(reach_t* r);
 void reach(reach_t* r, ast_t* type, const char* name, ast_t* typeargs,
   pass_opt_t* opt);
 
-reachable_type_t* reach_type(reach_t* r, ast_t* type);
+reach_type_t* reach_type(reach_t* r, ast_t* type);
 
-reachable_type_t* reach_type_name(reach_t* r, const char* name);
+reach_type_t* reach_type_name(reach_t* r, const char* name);
 
-reachable_method_t* reach_method(reachable_type_t* t, token_id cap,
+reach_method_t* reach_method(reach_type_t* t, token_id cap,
   const char* name, ast_t* typeargs);
 
-reachable_method_name_t* reach_method_name(reachable_type_t* t,
+reach_method_name_t* reach_method_name(reach_type_t* t,
   const char* name);
 
-uint32_t reach_vtable_index(reachable_type_t* t, const char* name);
+uint32_t reach_vtable_index(reach_type_t* t, const char* name);
 
 void reach_dump(reach_t* r);
 

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -16,20 +16,19 @@ typedef struct reach_method_name_t reach_method_name_t;
 typedef struct reach_field_t reach_field_t;
 typedef struct reach_type_t reach_type_t;
 
-DECLARE_STACK(reach_method_stack, reach_method_stack_t,
-  reach_method_t);
-DECLARE_HASHMAP(reach_methods, reach_methods_t,
-  reach_method_t);
-DECLARE_HASHMAP(reach_method_names, reach_method_names_t,
-  reach_method_name_t);
+DECLARE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
+DECLARE_HASHMAP(reach_methods, reach_methods_t, reach_method_t);
+DECLARE_HASHMAP(reach_mangled, reach_mangled_t, reach_method_t);
+DECLARE_HASHMAP(reach_method_names, reach_method_names_t, reach_method_name_t);
 DECLARE_HASHMAP(reach_types, reach_types_t, reach_type_t);
-DECLARE_HASHMAP(reach_type_cache, reach_type_cache_t,
-  reach_type_t);
+DECLARE_HASHMAP(reach_type_cache, reach_type_cache_t, reach_type_t);
 
 struct reach_method_t
 {
   const char* name;
+  const char* mangled_name;
   const char* full_name;
+
   token_id cap;
   ast_t* typeargs;
   ast_t* r_fun;
@@ -40,7 +39,11 @@ struct reach_method_t
   LLVMValueRef func_handler;
   LLVMMetadataRef di_method;
   LLVMMetadataRef di_file;
+
+  // Mark as true if the compiler supplies an implementation.
   bool intrinsic;
+
+  // Linked list of instantiations that use the same func.
   reach_method_t* subordinate;
 
   size_t param_count;
@@ -53,6 +56,7 @@ struct reach_method_name_t
   token_id cap;
   const char* name;
   reach_methods_t r_methods;
+  reach_mangled_t r_mangled;
 };
 
 struct reach_field_t

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -65,6 +65,7 @@ struct reachable_field_t
 struct reachable_type_t
 {
   const char* name;
+  const char* mangle;
   ast_t* ast;
   token_id underlying;
 

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -763,7 +763,7 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
       if(errorf != NULL)
       {
         ast_error_frame(errorf, sub,
-          "%s is not a subtype of %s: it has no method %s",
+          "%s is not a subtype of %s: it has no method '%s'",
           ast_print_type(sub), ast_print_type(super),
           ast_name(super_member_id));
       }

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -145,37 +145,6 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
   return ret;
 }
 
-static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errorf)
-{
-  // TODO: working on this
-  return true;
-
-  // If either result type is a machine word, the other must be as well.
-  if(is_machine_word(sub) && !is_machine_word(super))
-  {
-    if(errorf != NULL)
-    {
-      ast_error_frame(errorf, sub, "%s is a machine word and %s is not",
-        ast_print_type(sub), ast_print_type(super));
-    }
-
-    return false;
-  }
-
-  if(is_machine_word(super) && !is_machine_word(sub))
-  {
-    if(errorf != NULL)
-    {
-      ast_error_frame(errorf, sub, "%s is a machine word and %s is not",
-        ast_print_type(super), ast_print_type(sub));
-    }
-
-    return false;
-  }
-
-  return true;
-}
-
 static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
   errorframe_t* errorf, pass_opt_t* opt)
 {
@@ -214,10 +183,6 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
 
         return false;
       }
-
-      if(!check_machine_words(sub_result, super_result, errorf))
-        return false;
-
       break;
     }
 
@@ -249,10 +214,6 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
 
         return false;
       }
-
-      if(!check_machine_words(sub_result, super_result, errorf))
-        return false;
-
       break;
     }
 
@@ -304,9 +265,6 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
 
       return false;
     }
-
-    if(!check_machine_words(sub_type, super_type, errorf))
-      return false;
 
     sub_param = ast_sibling(sub_param);
     super_param = ast_sibling(super_param);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -7,8 +7,8 @@
 #include "typeparam.h"
 #include "viewpoint.h"
 #include "../ast/astbuild.h"
-#include "../ast/stringtab.h"
 #include "../expr/literal.h"
+#include <string.h>
 #include <assert.h>
 
 static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
@@ -142,6 +142,9 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
 
 static bool check_machine_words(ast_t* sub, ast_t* super, errorframe_t* errorf)
 {
+  // TODO: working on this
+  return true;
+
   // If either result type is a machine word, the other must be as well.
   if(is_machine_word(sub) && !is_machine_word(super))
   {
@@ -1393,7 +1396,7 @@ bool is_literal(ast_t* type, const char* name)
     return false;
 
   // Don't have to check the package, since literals are all builtins.
-  return ast_name(ast_childidx(type, 1)) == stringtab(name);
+  return !strcmp(ast_name(ast_childidx(type, 1)), name);
 }
 
 bool is_pointer(ast_t* type)

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -17,6 +17,9 @@ bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errorf,
 
 bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt);
 
+bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,
+  pass_opt_t* opt);
+
 bool is_pointer(ast_t* type);
 
 bool is_maybe(ast_t* type);

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -39,21 +39,24 @@ protected:
 
   void add_method(const char* name)
   {
-    reach_method_name_t* mn = POOL_ALLOC(reach_method_name_t);
-    memset(mn, 0, sizeof(reach_method_name_t));
-    mn->name = stringtab(name);
-    reach_methods_init(&mn->r_methods, 0);
+    reach_method_name_t* n = POOL_ALLOC(reach_method_name_t);
+    memset(n, 0, sizeof(reach_method_name_t));
+    n->name = stringtab(name);
+    reach_methods_init(&n->r_methods, 0);
+    reach_mangled_init(&n->r_mangled, 0);
 
-    reach_method_names_put(&_current_type->methods, mn);
+    reach_method_names_put(&_current_type->methods, n);
 
     reach_method_t* method = POOL_ALLOC(reach_method_t);
     memset(method, 0, sizeof(reach_method_t));
     method->name = stringtab(name);
+    method->mangled_name = method->name;
     method->typeargs = NULL;
     method->r_fun = NULL;
     method->vtable_index = (uint32_t)-1;
 
-    reach_methods_put(&mn->r_methods, method);
+    reach_methods_put(&n->r_methods, method);
+    reach_mangled_put(&n->r_mangled, method);
   }
 
   void do_paint()
@@ -77,15 +80,15 @@ protected:
 
     // Find max colour
     size_t i = HASHMAP_BEGIN;
-    reach_method_name_t* mn;
+    reach_method_name_t* n;
     uint32_t max_colour = 0;
 
-    while((mn = reach_method_names_next(&type->methods, &i)) != NULL)
+    while((n = reach_method_names_next(&type->methods, &i)) != NULL)
     {
       reach_method_t m2;
       memset(&m2, 0, sizeof(reach_method_t));
-      m2.name = mn->name;
-      reach_method_t* method = reach_methods_get(&mn->r_methods, &m2);
+      m2.name = n->name;
+      reach_method_t* method = reach_methods_get(&n->r_methods, &m2);
 
       assert(method != NULL);
 
@@ -107,16 +110,14 @@ protected:
     {
       reach_method_name_t m1;
       m1.name = stringtab(name);
-      reach_method_name_t* mn =
-        reach_method_names_get(&type->methods, &m1);
+      reach_method_name_t* n = reach_method_names_get(&type->methods, &m1);
 
-      if(mn != NULL)
+      if(n != NULL)
       {
         reach_method_t m2;
         memset(&m2, 0, sizeof(reach_method_t));
         m2.name = stringtab(name);
-        reach_method_t* method =
-          reach_methods_get(&mn->r_methods, &m2);
+        reach_method_t* method = reach_methods_get(&n->r_methods, &m2);
 
         ASSERT_NE((void*)NULL, method);
 

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -11,7 +11,7 @@ class PaintTest: public testing::Test
 {
 protected:
   reach_t* _set;
-  reachable_type_t* _current_type;
+  reach_type_t* _current_type;
 
   virtual void SetUp()
   {
@@ -26,34 +26,34 @@ protected:
 
   void add_type(const char* name)
   {
-    _current_type = POOL_ALLOC(reachable_type_t);
-    memset(_current_type, 0, sizeof(reachable_type_t));
+    _current_type = POOL_ALLOC(reach_type_t);
+    memset(_current_type, 0, sizeof(reach_type_t));
     _current_type->name = stringtab(name);
     _current_type->ast = NULL;
-    reachable_method_names_init(&_current_type->methods, 0);
-    reachable_type_cache_init(&_current_type->subtypes, 0);
+    reach_method_names_init(&_current_type->methods, 0);
+    reach_type_cache_init(&_current_type->subtypes, 0);
     _current_type->vtable_size = 0;
 
-    reachable_types_put(&_set->types, _current_type);
+    reach_types_put(&_set->types, _current_type);
   }
 
   void add_method(const char* name)
   {
-    reachable_method_name_t* mn = POOL_ALLOC(reachable_method_name_t);
-    memset(mn, 0, sizeof(reachable_method_name_t));
+    reach_method_name_t* mn = POOL_ALLOC(reach_method_name_t);
+    memset(mn, 0, sizeof(reach_method_name_t));
     mn->name = stringtab(name);
-    reachable_methods_init(&mn->r_methods, 0);
+    reach_methods_init(&mn->r_methods, 0);
 
-    reachable_method_names_put(&_current_type->methods, mn);
+    reach_method_names_put(&_current_type->methods, mn);
 
-    reachable_method_t* method = POOL_ALLOC(reachable_method_t);
-    memset(method, 0, sizeof(reachable_method_t));
+    reach_method_t* method = POOL_ALLOC(reach_method_t);
+    memset(method, 0, sizeof(reach_method_t));
     method->name = stringtab(name);
     method->typeargs = NULL;
     method->r_fun = NULL;
     method->vtable_index = (uint32_t)-1;
 
-    reachable_methods_put(&mn->r_methods, method);
+    reach_methods_put(&mn->r_methods, method);
   }
 
   void do_paint()
@@ -64,9 +64,9 @@ protected:
   void check_vtable_size(const char* name, uint32_t min_expected,
     uint32_t max_expected, uint32_t* actual)
   {
-    reachable_type_t t;
+    reach_type_t t;
     t.name = stringtab(name);
-    reachable_type_t* type = reachable_types_get(&_set->types, &t);
+    reach_type_t* type = reach_types_get(&_set->types, &t);
     ASSERT_NE((void*)NULL, type);
 
     ASSERT_LE(min_expected, type->vtable_size);
@@ -77,15 +77,15 @@ protected:
 
     // Find max colour
     size_t i = HASHMAP_BEGIN;
-    reachable_method_name_t* mn;
+    reach_method_name_t* mn;
     uint32_t max_colour = 0;
 
-    while((mn = reachable_method_names_next(&type->methods, &i)) != NULL)
+    while((mn = reach_method_names_next(&type->methods, &i)) != NULL)
     {
-      reachable_method_t m2;
-      memset(&m2, 0, sizeof(reachable_method_t));
+      reach_method_t m2;
+      memset(&m2, 0, sizeof(reach_method_t));
       m2.name = mn->name;
-      reachable_method_t* method = reachable_methods_get(&mn->r_methods, &m2);
+      reach_method_t* method = reach_methods_get(&mn->r_methods, &m2);
 
       assert(method != NULL);
 
@@ -100,23 +100,23 @@ protected:
     uint32_t* actual)
   {
     size_t i = HASHMAP_BEGIN;
-    reachable_type_t* type;
+    reach_type_t* type;
     uint32_t colour = (uint32_t)-1;
 
-    while((type = reachable_types_next(&_set->types, &i)) != NULL)
+    while((type = reach_types_next(&_set->types, &i)) != NULL)
     {
-      reachable_method_name_t m1;
+      reach_method_name_t m1;
       m1.name = stringtab(name);
-      reachable_method_name_t* mn =
-        reachable_method_names_get(&type->methods, &m1);
+      reach_method_name_t* mn =
+        reach_method_names_get(&type->methods, &m1);
 
       if(mn != NULL)
       {
-        reachable_method_t m2;
-        memset(&m2, 0, sizeof(reachable_method_t));
+        reach_method_t m2;
+        memset(&m2, 0, sizeof(reach_method_t));
         m2.name = stringtab(name);
-        reachable_method_t* method =
-          reachable_methods_get(&mn->r_methods, &m2);
+        reach_method_t* method =
+          reach_methods_get(&mn->r_methods, &m2);
 
         ASSERT_NE((void*)NULL, method);
 

--- a/test/libponyc/sugar_traits.cc
+++ b/test/libponyc/sugar_traits.cc
@@ -6,8 +6,8 @@
 
 // Tests for sugar that is applied during the traits pass
 
-#define TEST_COMPILE(src) DO(test_compile(src, "traits"))
-#define TEST_ERROR(src) DO(test_error(src, "traits"))
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_ERROR(src) DO(test_error(src, "expr"))
 #define TEST_EQUIV(src, expect) DO(test_equiv(src, "traits", expect, "traits"))
 
 
@@ -58,7 +58,8 @@ TEST_F(SugarTraitTest, FieldDelegateTypeCanBeUnimplementedInterface)
     "  fun f()\n"
 
     "class Foo\n"
-    "  var bar: T delegate T";
+    "  var bar: T delegate T\n"
+    "  new create(bar': T) => bar = bar'";
 
   TEST_COMPILE(short_form);
 }
@@ -71,7 +72,8 @@ TEST_F(SugarTraitTest, FieldDelegateTypeCanBeUnimplementedTrait)
     "  fun f()\n"
 
     "class Foo\n"
-    "  var bar: T delegate T";
+    "  var bar: T delegate T\n"
+    "  new create(bar': T) => bar = bar'";
 
   TEST_COMPILE(short_form);
 }

--- a/test/libponyc/traits.cc
+++ b/test/libponyc/traits.cc
@@ -5,9 +5,9 @@
 
 #include "util.h"
 
-#define TEST_COMPILE(src) DO(test_compile(src, "traits"))
-#define TEST_ERROR(src) DO(test_error(src, "traits"))
-#define TEST_EQUIV(src, expect) DO(test_equiv(src, "traits", expect, "traits"))
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_ERROR(src) DO(test_error(src, "expr"))
+#define TEST_EQUIV(src, expect) DO(test_equiv(src, "expr", expect, "expr"))
 
 
 class TraitsTest : public PassTest
@@ -99,7 +99,7 @@ TEST_F(TraitsTest, TraitAndClassNamesDontClash)
     "  fun f(y: U32): U32 => y\n"
 
     "class C is T\n"
-    "  var y: Bool";
+    "  var y: Bool = false";
 
   TEST_COMPILE(src);
 }
@@ -112,7 +112,7 @@ TEST_F(TraitsTest, TraitMethodAndCLassFieldNamesDoClash)
     "  fun f()\n"
 
     "class C is T\n"
-    "  var f: Bool";
+    "  var f: Bool = false";
 
   TEST_ERROR(src);
 }


### PR DESCRIPTION
Machine words are subtypes of some traits and interfaces, but have a different binary representation from an object. Previously, the compiler attempted to detect when machine word representation would make method subtyping result in unusable representations (e.g. passing a 4 byte integer where a memory pointer was expected, etc.). This failed in the presence of complex generics.

This change instead allows machine words subtyping to work like any other types, and generates forwarding functions with mangled names that correctly autobox machine word types when (and only when) it is required.

This addresses #561 and #563.
