### PR TITLE
return usize with size method

### DIFF
--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -51,7 +51,7 @@ class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
     """
     _root(k.hash().u32(), k)
 
-  fun val size(): U64 =>
+  fun val size(): USize =>
     """
     Return the amount of key-value pairs in the Map.
     """
@@ -134,8 +134,8 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
       error
     end
 
-  fun val size(): U64 =>
-    var tot: U64 = 0
+  fun val size(): USize =>
+    var tot: USize = 0
     for e in entries.values() do
       match e
       | let sn: _MapNode[K, V] => tot = tot + sn.size()

--- a/packages/collections/persistent/test.pony
+++ b/packages/collections/persistent/test.pony
@@ -223,7 +223,7 @@ class iso _TestMap is UnitTest
     let m1: Map[String,U32] = Maps.empty[String,U32]()
     h.assert_error(lambda()(m1)? => m1("a") end)
     let s1 = m1.size()
-    h.assert_eq[U64](s1, 0)
+    h.assert_eq[USize](s1, 0)
 
     try
       let m2 = m1.update("a", 5)


### PR DESCRIPTION
This should have been USize considering that other collections use USize as the return type for their size methods. It was an oversight on my part.