### PR TITLE
Improve delegate example code

### DIFF
--- a/examples/delegates/main.pony
+++ b/examples/delegates/main.pony
@@ -24,21 +24,16 @@ class DroneWombat is ( Drone & Wombat)
     "Beep boop Huzzah!"
 
 actor Main is Wombat
- let d : Wombat delegate Wombat = DroneWombat
- let k : Wombat delegate Wombat = KungFuWombat
+  let wombatness : Wombat delegate Wombat
 
   new create(env : Env) =>
-    let x = Time.nanos() % 4
+    let x = Time.nanos() % 3
 
-    let chosen_wombat = match x
+    wombatness = match x
     | 0 => SimpleWombat
-    | 1 => k
-    | 2 => d
-    else
-      this
+    | 1 => DroneWombat
+    | 2 => KungFuWombat
     end
     env.out.print("Welcome to Wombat Combat!")
-    env.out.print("Battle cry: " + chosen_wombat.battle_call())
+    env.out.print("Battle cry: " + this.battle_call())
 
-  fun box battle_call() : String val =>
-    "Bonzai! Beep boop! Huzzah!"


### PR DESCRIPTION
The old delegate example code didn't really demonstrate what a
delegate did, which was confusing for me when I initially started to
try to use delegates. It creates several objects, some of which are
used as delegates, but then calls those objects directly. To
demonstrate delegation, the delegate should be set to one of those
classes, and then the delegating object should be called to
demonstrate that it is delegating the call to the delegate. This
commit implements that behavior.