### PR TITLE
Alias lambda capture types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Crashing gc bug from using `get` instead of `getorput` in `gc_markactor`.
 - Add -rpath to the link command for library paths
 - Simplify contains() method on HashMap.
+- Lambda captures use the alias of the expression type.
 
 ### Added
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -292,12 +292,8 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
-      ast_error_frame(&frame, param, "parameter type: %s",
-        ast_print_type(p_type));
-      ast_error_frame(&frame, arg, "argument type: %s", ast_print_type(a_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
-
       ast_free_unattached(a_type);
       return false;
     }
@@ -617,7 +613,8 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
   if(is_typecheck_error(type))
     return false;
 
-  token_id apply_cap = partial_application_cap(opt, type, receiver, positional);
+  token_id apply_cap = partial_application_cap(opt, type, receiver,
+    positional);
   AST_GET_CHILDREN(type, cap, type_params, target_params, result);
 
   token_id can_error = ast_canerror(lhs) ? TK_QUESTION : TK_NONE;

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -62,10 +62,6 @@ static ast_result_t declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
-      ast_error_frame(&frame, param, "parameter type: %s",
-        ast_print_type(p_type));
-      ast_error_frame(&frame, arg, "argument type: %s",
-        ast_print_type(a_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
       return AST_ERROR;

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -4,6 +4,7 @@
 #include "../ast/printbuf.h"
 #include "../pass/pass.h"
 #include "../pass/expr.h"
+#include "../type/alias.h"
 #include "../type/sanitise.h"
 #include <assert.h>
 
@@ -49,23 +50,15 @@ static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
 
     BUILD(capture_rhs, id_node, NODE(TK_REFERENCE, ID(name)));
 
-    type = ast_type(def);
+    type = alias(ast_type(def));
     value = capture_rhs;
-  }
-  else
-  {
-    // Expression capture
-    if(ast_id(type) == TK_NONE)
-    {
-      // No type specified, use type of the captured expression
-      type = ast_type(value);
-    }
-    else
-    {
-      // Type given, infer literals
-      if(!coerce_literals(&value, type, opt))
-        return NULL;
-    }
+  } else if(ast_id(type) == TK_NONE) {
+    // No type specified, use type of the captured expression
+    type = alias(ast_type(value));
+  } else {
+    // Type given, infer literals
+    if(!coerce_literals(&value, type, opt))
+      return NULL;
   }
 
   if(is_typecheck_error(type))


### PR DESCRIPTION
When building a lambda capture and not specifying a type, the
captured type should be the alias of the captured expression.