### PR TITLE
Add sentv method to TCPConnectionNotify.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Custom chunk size for Stdin.
 - Itertools package
 - TCPConnection.expect
+- TCPConnectionNotify.sentv
 
 ### Changed
 

--- a/packages/net/tcpconnection.pony
+++ b/packages/net/tcpconnection.pony
@@ -115,8 +115,14 @@ actor TCPConnection
     """
     if not _closed then
       _in_sent = true
-      for bytes in data.values() do
-        try write_final(_notify.sent(this, bytes)) end
+      try
+        for bytes in _notify.sentv(this, data).values() do
+          write_final(bytes)
+        end
+      else
+        for bytes in data.values() do
+          try write_final(_notify.sent(this, bytes)) end
+        end
       end
       _in_sent = false
     end

--- a/packages/net/tcpnotify.pony
+++ b/packages/net/tcpnotify.pony
@@ -46,6 +46,15 @@ interface TCPConnectionNotify
     """
     data
 
+  fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter ? =>
+    """
+    Called when multiple chunks of data are sent to the connection in a single
+    call. This gives the notifier an opportunity to modify the sent data chunks
+    before they are written. The notifier can raise an error to defer to using
+    multiple calls of the sent method instead of one call to this one.
+    """
+    error
+
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
     """
     Called when new data is received on the connection.


### PR DESCRIPTION
This PR adds the `sentv` method to `TCPConnectionNotify`.

This gives the `TCPConnectionNotify` object the option to treat `writev` calls differently from `write` calls, for protocols where this affects the final encoding of the bytes.  For example, this feature will be used in the [`pony-zmq`](https://github.com/jemc/pony-zmq) redesign, where it is vital to making CURVE encryption work with no intermediate actor.