### PR TITLE
remove None entries in persistent/Map

### DIFF
--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -92,7 +92,7 @@ class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
     end
 
 type _MapEntry[K: (mut.Hashable val & Equatable[K] val), V: Any val]
-  is (_MapNode[K, V] | Array[_Leaf[K, V]] val | _Leaf[K, V] | None)
+  is (_MapNode[K, V] | Array[_Leaf[K, V]] val | _Leaf[K, V])
 
 class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
   let entries: Array[_MapEntry[K, V]] val
@@ -103,9 +103,9 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
   new val empty(l: U8) =>
     entries = recover val
       match l
-      | 6 => Array[_MapEntry[K, V]].init(None, 4)
+      | 6 => Array[_MapEntry[K, V]](4)
       else
-        Array[_MapEntry[K, V]].init(None, 32)
+        Array[_MapEntry[K, V]](32)
       end
     end
     nodemap = 0


### PR DESCRIPTION
This PR just removes the option for entries to be None since the compression has made it obsolete.