### PR TITLE
Avoid hard wraps in markdown files.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,17 +2,11 @@
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to creating a positive environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -33,105 +27,47 @@ advances
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at coc@ponylang.org. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at coc@ponylang.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/
 
 # Social Rules
 
-In addition to having a code of conduct as an anti-harassment policy, we have a 
-small set of [social rules](https://www.recurse.com/manual#sub-sec-social-rules) 
-we follow. We (the project maintainers) lifted these rules from the 
-[Recurse Center](https://www.recurse.com). We've seen these rules in effect
-in other environments. We'd like Pony community to share a similar positive
-environment. These rules are intended to be lightweight, and to make more
-explicit certain social norms that  are normally implicit. Most of our social
-rules really boil down to “don't be a  jerk“ or “don't be annoying.” Of course,
-almost nobody sets out to be a jerk or annoying, so telling people not to be
-jerks isn't a very productive strategy.
+In addition to having a code of conduct as an anti-harassment policy, we have a small set of [social rules](https://www.recurse.com/manual#sub-sec-social-rules) we follow. We (the project maintainers) lifted these rules from the [Recurse Center](https://www.recurse.com). We've seen these rules in effect in other environments. We'd like Pony community to share a similar positive environment. These rules are intended to be lightweight, and to make more explicit certain social norms that  are normally implicit. Most of our social rules really boil down to “don't be a  jerk“ or “don't be annoying.” Of course, almost nobody sets out to be a jerk or annoying, so telling people not to be jerks isn't a very productive strategy.
 
-Unlike the anti-harassment policy, violation of the social rules will not result 
-in expulsion from the Pony community or a strong warning from project
-maintainers. Rather, they are designed to provide some lightweight social 
-structure for community members to use when interacting with each other.
+Unlike the anti-harassment policy, violation of the social rules will not result in expulsion from the Pony community or a strong warning from project maintainers. Rather, they are designed to provide some lightweight social structure for community members to use when interacting with each other.
 
-## No feigning surprise. 
+## No feigning surprise.
 
-The first rule means you shouldn't act surprised when people say they don't know 
-something. This applies to both technical things ("What?! I can't believe you 
-don't know what the stack is!") and non-technical things ("You don't know who 
-RMS is?!"). Feigning surprise has absolutely no social or educational benefit: 
-When people feign surprise, it's usually to make them feel better about 
-themselves and others feel worse. And even when that's not the intention, it's 
-almost always the effect.
+The first rule means you shouldn't act surprised when people say they don't know something. This applies to both technical things ("What?! I can't believe you don't know what the stack is!") and non-technical things ("You don't know who RMS is?!"). Feigning surprise has absolutely no social or educational benefit: When people feign surprise, it's usually to make them feel better about themselves and others feel worse. And even when that's not the intention, it's almost always the effect.
 
 ## No well-actually's
 
-A well-actually happens when someone says something that's almost - but not 
-entirely - correct, and you say, "well, actually…" and then give a minor 
-correction. This is especially annoying when the correction has no bearing on 
-the actual conversation. This doesn't mean we aren't about truth-seeking or 
-that we don't care about being precise. Almost all well-actually's in our 
-experience are about grandstanding, not truth-seeking.
+A well-actually happens when someone says something that's almost - but not entirely - correct, and you say, "well, actually…" and then give a minor correction. This is especially annoying when the correction has no bearing on the actual conversation. This doesn't mean we aren't about truth-seeking or that we don't care about being precise. Almost all well-actually's in our experience are about grandstanding, not truth-seeking.
 
 ## No subtle -isms
 
-Our last social rule bans subtle racism, sexism, homophobia, transphobia, and 
-other kinds of bias. This one is different from the rest, because it covers a 
-class of behaviors instead of one very specific pattern.
+Our last social rule bans subtle racism, sexism, homophobia, transphobia, and other kinds of bias. This one is different from the rest, because it covers a class of behaviors instead of one very specific pattern.
 
-Subtle -isms are small things that make others feel uncomfortable, things that 
-we all sometimes do by mistake. For example, saying "It's so easy my 
-grandmother could do it" is a subtle -ism. Like the other three social rules, 
-this one is often accidentally broken. Like the other three, it's not a big deal 
-to mess up – you just apologize and move on.
+Subtle -isms are small things that make others feel uncomfortable, things that we all sometimes do by mistake. For example, saying "It's so easy my grandmother could do it" is a subtle -ism. Like the other three social rules, this one is often accidentally broken. Like the other three, it's not a big deal to mess up – you just apologize and move on.
 
-If you see a subtle -ism in the Pony community , you can point it out to the
-relevant person, either publicly or privately, or you can ask one of the project
-maintainers to say something. After this, we ask that all further discussion 
-move off of public channels. If you are a third party, and you don't see what 
-could be biased about the comment that was made, feel free to talk to the 
-project maintainers. Please don't say, "Comment X wasn't homophobic!" Similarly,
-please don't pile on to someone who made a mistake. The "subtle" in 
-"subtle -isms" means that it's probably not obvious to everyone right away what 
-was wrong with the comment.
+If you see a subtle -ism in the Pony community , you can point it out to the relevant person, either publicly or privately, or you can ask one of the project maintainers to say something. After this, we ask that all further discussion move off of public channels. If you are a third party, and you don't see what could be biased about the comment that was made, feel free to talk to the project maintainers. Please don't say, "Comment X wasn't homophobic!" Similarly,please don't pile on to someone who made a mistake. The "subtle" in "subtle -isms" means that it's probably not obvious to everyone right away what was wrong with the comment.
 
-If you have any questions about any part of the code of conduct or social rules, 
-please feel free to reach out to any of the project maintainers.
-
+If you have any questions about any part of the code of conduct or social rules, please feel free to reach out to any of the project maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,7 @@ Contributing
 
 It's good to hear that you want to contribute to Pony!
 
-First of all please [search existing issues][complete-issue-list]. Apart from bug reports you will
-find feature requests and work currently in progress too. If you cannot find a suitable issue —
-[create a new one][new-issue]. Potential pull requests are no exception. Before you start working,
-let's have a discussion and agree on the solution and scope.
+First of all please [search existing issues][complete-issue-list]. Apart from bug reports you will find feature requests and work currently in progress too. If you cannot find a suitable issue — [create a new one][new-issue]. Potential pull requests are no exception. Before you start working, let's have a discussion and agree on the solution and scope.
 
 Each of [bug report](#bug-report), [feature request](#feature-request) or [pull request](#pull-request)
 has to cover different aspects described below.
@@ -21,42 +18,35 @@ Provide the following details:
   - actual results and
   - environment details: at least operating system and compiler version (`ponyc -v`).
 
-If possible, try to isolate the problem and provide just enough code to demonstrate it. Add any
-related information which might help to fix the issue.
+If possible, try to isolate the problem and provide just enough code to demonstrate it. Add any related information which might help to fix the issue.
 
 Feature request
 ---------------
-Define a context and a problem the feature solves. List potential use cases and give some code
-examples.
+Define a context and a problem the feature solves. List potential use cases and give some code examples.
 
 Pull request
 ------------
 Provide the same information as you would for a [feature request](#feature-request).
 
-Before issuing a pull request we ask that you squash all your commits into a 
-single logical commit. While your PR is in review, we may ask for additional
-changes, please do not squash those commits while the review is underway. Once
-everything is good, we'll then ask you to further squash those commits before
-merging. We ask that you not squash while a review is underway as it can make it
-hard to follow what is going on. Additionally, we ask that you:
+Before issuing a pull request we ask that you squash all your commits into a single logical commit. While your PR is in review, we may ask for additional changes, please do not squash those commits while the review is underway. Once everything is good, we'll then ask you to further squash those commits before merging. We ask that you not squash while a review is underway as it can make it hard to follow what is going on. Additionally, we ask that you:
 
 * [Write a good commit message](http://chris.beams.io/posts/git-commit/)
 * Issue 1 Pull Request per feature. Don't lump unrelated changes together.
 
-If you aren't sure how to squash multiple commits into one, Steve Klabnik wrote
-[a handy guide](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request)
-that you can refer to. 
+If you aren't sure how to squash multiple commits into one, Steve Klabnik wrote [a handy guide](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request) that you can refer to.
 
-We keep a [CHANGELOG](CHANGELOG.md) of all software changes with behavioural 
-effects in ponyc. If your PR includes such changes (rather than say a
-documentation update), please make sure that as part of PR, you have also
-updated the CHANGELOG.
+We keep a [CHANGELOG](CHANGELOG.md) of all software changes with behavioural effects in ponyc. If your PR includes such changes (rather than say a documentation update), please make sure that as part of PR, you have also updated the CHANGELOG.
+
+Documentation Formatting
+---------------
+When contributing to documentation, try to keep the following style guidelines in mind:
+
+* Wherever possible, try to match the style of surrounding documentation.
+* Avoid hard-wrapping lines within paragraphs (using line breaks in the middle of or between sentences to make lines shorter than a certain length). Instead, turn on soft-wrapping in your editor and expect the documentation renderer to let the text flow to the width of the container.
 
 Code Formatting
 ---------------
-A few code formatting rules to be aware of if you are submitting changes. In
-general, take a look at the existing code and try to match that formatting
-style. A couple things that might not be immediately obvious.
+A few code formatting rules to be aware of if you are submitting changes. In general, take a look at the existing code and try to match that formatting style. A couple things that might not be immediately obvious.
 
 * Indentation
 
@@ -64,35 +54,19 @@ We indent using spaces not tabs. The unit of indentation is two spaces.
 
 * Watch your whitespace!
 
-Use an editor plugin to remove unused trailing whitespace. This includes both at
-the end of a line and at the end of a file. By the same token, remember to leave
-a single newline only line at the end of each file. It makes output files to the
-console much more pleasant.
+Use an editor plugin to remove unused trailing whitespace. This includes both at the end of a line and at the end of a file. By the same token, remember to leave a single newline only line at the end of each file. It makes output files to the console much more pleasant.
 
 * Line Length
 
-We all have different sized monitors. What might look good on yours might look
-like awful on another. Be kind and wrap all lines at 80 columns unless you
-have a good reason not to.
+We all have different sized monitors. What might look good on yours might look like awful on another. Be kind and wrap all lines at 80 columns unless you have a good reason not to.
 
 * Style
 
-*Variable and method names* -- Variable and method names should be
-lowercase and should have underscores between the words. Examples:
-`from_array`, `offset_to_index`.
+*Variable and method names* -- Variable and method names should be lowercase and should have underscores between the words. Examples: `from_array`, `offset_to_index`.
 
-*Class, type, interface, trait, and primitive names* -- Class, type,
-interface, trait, and primitive names should start with an uppercase
-letter and each word should be capitalized. Examples: `StringBytes`,
-`ErrorReason`, `ReadlineNotify`, `FloatingPoint` `UnrecognizedOption`.
+*Class, type, interface, trait, and primitive names* -- Class, type, interface, trait, and primitive names should start with an uppercase letter and each word should be capitalized. Examples: `StringBytes`, `ErrorReason`, `ReadlineNotify`, `FloatingPoint` `UnrecognizedOption`.
 
-*Breaking up parameter lists* -- A method signature may need to be
-split across several lines in order to follow the rule that the line
-length must be 80 characters or fewer. The accepted way to break up a
-parameter list is to indent all lines after the first line by 2
-spaces, and to place the `=>` on a line by itself at the same level of
-indentation as the `fun` or `be` at the beginning of the
-declaration. Example:
+*Breaking up parameter lists* -- A method signature may need to be split across several lines in order to follow the rule that the line length must be 80 characters or fewer. The accepted way to break up a parameter list is to indent all lines after the first line by 2 spaces, and to place the `=>` on a line by itself at the same level of indentation as the `fun` or `be` at the beginning of the declaration. Example:
 
 ```pony
   fun ref append(seq: (ReadSeq[A] & ReadElement[A^]), offset: USize = 0,
@@ -102,14 +76,7 @@ declaration. Example:
 
 * Reformatting code to meet standards
 
-Try to avoid doing it. A commit that changes the formatting for large chunks of
-a file makes for an ugly commit history when looking for important changes. This
-means, don't commit code that doesn't conform to coding standards in the first
-place. If you do reformat code, make sure it is either standalone reformatting
-with no logic changes or confined solely to code whose logic you touched. For
-example, changing the indentation in a file? Do not make logic changes along
-with it. Editing a line that has extra whitespace at the end? Feel free to
-remove it.
+Try to avoid doing it. A commit that changes the formatting for large chunks of a file makes for an ugly commit history when looking for important changes. This means, don't commit code that doesn't conform to coding standards in the first place. If you do reformat code, make sure it is either standalone reformatting with no logic changes or confined solely to code whose logic you touched. For example, changing the indentation in a file? Do not make logic changes along with it. Editing a line that has extra whitespace at the end? Feel free to remove it.
 
 [complete-issue-list]: //github.com/ponylang/ponyc/search?q=&type=Issues&utf8=%E2%9C%93
 [new-issue]: //github.com/ponylang/ponyc/issues/new

--- a/README.md
+++ b/README.md
@@ -23,28 +23,21 @@
 
 ## Using Docker
 
-Want to use the latest revision of Pony source, but don't want to build from 
-source yourself? You can run the `ponylang/ponyc` Docker container, which is 
-created from an automated build at each commit to master.
+Want to use the latest revision of Pony source, but don't want to build from source yourself? You can run the `ponylang/ponyc` Docker container, which is created from an automated build at each commit to master.
 
-You'll need to install Docker using 
-[the instructions here](https://docs.docker.com/engine/installation/). Then you 
-can pull the latest `ponylang/ponyc` image using this command:
+You'll need to install Docker using [the instructions here](https://docs.docker.com/engine/installation/). Then you can pull the latest `ponylang/ponyc` image using this command:
 
 ```bash
 docker pull ponylang/ponyc:latest
 ```
 
-Then you'll be able to run `ponyc` to compile a Pony program in a given 
-directory, running a command like this:
+Then you'll be able to run `ponyc` to compile a Pony program in a given directory, running a command like this:
 
 ```bash
 docker run -v /path/to/my-code:/src/main ponylang/ponyc
 ```
 
-Note that if your host doesn't match the docker container, you'll probably have 
-to run the resulting program inside the docker container as well, using a 
-command like this:
+Note that if your host doesn't match the docker container, you'll probably have to run the resulting program inside the docker container as well, using a command like this:
 
 ```bash
 docker run -v /path/to/my-code:/src/main ponylang/ponyc ./main
@@ -76,8 +69,7 @@ A live ebuild is also available in the
 
 ### Other distributions
 
-We're transitioning to a new binary release system. For now, please build from 
-source.
+We're transitioning to a new binary release system. For now, please build from source.
 
 ## Windows
 
@@ -85,31 +77,23 @@ You will need to build from source.
 
 # Building ponyc from source
 
-Pony requires LLVM 3.6, 3.7 or 3.8. Please note that **LLVM 3.7.0 does not 
-work**. If you are using LLVM 3.7.x, you need to use 3.7.1. If you are 
-using LLVM 3.6.x, make sure to use 3.6.2.
+Pony requires LLVM 3.6, 3.7 or 3.8. Please note that **LLVM 3.7.0 does not work**. If you are using LLVM 3.7.x, you need to use 3.7.1. If you are using LLVM 3.6.x, make sure to use 3.6.2.
 
 ## Building on Linux
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-First, install LLVM using your package manager. You may need to install zlib, 
-ncurses, pcre2, and ssl as well. Instructions for some specific distributions 
-follow.
+First, install LLVM using your package manager. You may need to install zlib, ncurses, pcre2, and ssl as well. Instructions for some specific distributions follow.
 
-APT packages for LLVM 3.7 and 3.8, for Debian and Ubuntu, are provided by the 
-LLVM build server.
+APT packages for LLVM 3.7 and 3.8, for Debian and Ubuntu, are provided by the LLVM build server.
 
-Please follow the instructions at http://llvm.org/apt/ for installing the GPG 
-keys and packages for your distribution.
+Please follow the instructions at http://llvm.org/apt/ for installing the GPG keys and packages for your distribution.
 
 #### Notes:
 
 On Ubuntu,
-```apt-get install llvm-dev``` installs LLVM-3.6.
+`apt-get install llvm-dev` installs LLVM-3.6.
 
-When installing the full set of LLVM packages, the ```apt-get install``` 
-instructions include the ```clang-modernize``` package. This should be changed 
-to ```clang-tidy``` due to a recent name change.
+When installing the full set of LLVM packages, the ```apt-get install``` instructions include the ```clang-modernize``` package. This should be changed to ```clang-tidy``` due to a recent name change.
 
 
 ### Debian Jessie
@@ -121,8 +105,7 @@ deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
 deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
 ```
 
-Install the LLVM toolchain public GPG key, update `apt` and install
-packages:
+Install the LLVM toolchain public GPG key, update `apt` and install packages:
 
 ```bash
 $ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
@@ -131,9 +114,7 @@ $ sudo apt-get install make gcc g++ git zlib1g-dev libncurses5-dev \
                        libssl-dev llvm-3.8-dev
 ```
 
-Debian Jessie and some other Linux distributions don't include pcre2 in their
-package manager. pcre2 is used by the Pony regex package. To download and
-build pcre2 from source:
+Debian Jessie and some other Linux distributions don't include pcre2 in their package manager. pcre2 is used by the Pony regex package. To download and build pcre2 from source:
 
 ```bash
 $ wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
@@ -158,9 +139,7 @@ $ sudo apt-get install build-essential git \
                        zlib1g-dev libncurses5-dev libssl-dev
 ```
 
-Ubuntu and some other Linux distributions don't include pcre2 in their
-package manager. pcre2 is used by the Pony regex package. To download and
-build pcre2 from source:
+Ubuntu and some other Linux distributions don't include pcre2 in their package manager. pcre2 is used by the Pony regex package. To download and build pcre2 from source:
 
 ```bash
 $ wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
@@ -196,9 +175,7 @@ $ gmake config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently
-produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not
-have this problem, and works fine with LLVM 3.7 and 3.8.
+Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not have this problem, and works fine with LLVM 3.7 and 3.8.
 
 ## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
@@ -226,28 +203,17 @@ $ ./build/release/ponyc examples/helloworld
 ## Building on Windows
 [![Windows](https://ci.appveyor.com/api/projects/status/kckam0f1a1o0ly2j?svg=true)](https://ci.appveyor.com/project/sylvanc/ponyc)
 
-The LLVM prebuilt binaries for Windows do NOT include the LLVM development
-tools and libraries. Instead, you will have to build and install LLVM 3.7 or
-3.8 from source. You will need to make sure that the path to LLVM/bin (location
-of llvm-config) is in your PATH variable.
+The LLVM prebuilt binaries for Windows do NOT include the LLVM development tools and libraries. Instead, you will have to build and install LLVM 3.7 or 3.8 from source. You will need to make sure that the path to LLVM/bin (location of llvm-config) is in your PATH variable.
 
-LLVM recommends using the GnuWin32 unix tools; your mileage may vary using
-MSYS or Cygwin.
+LLVM recommends using the GnuWin32 unix tools; your mileage may vary using MSYS or Cygwin.
 
-- Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/)
-  tool.
-- Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or
-  2.7).
+- Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/) tool.
+- Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or 2.7).
 - Install [CMake](https://cmake.org/download/).
-- Get the LLVM source (e.g. 3.7.1 is
-  at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
+- Get the LLVM source (e.g. 3.7.1 is at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
 - Make sure you have VS2015 with the C++ tools installed.
-- Generate LLVM VS2015 configuration with CMake. You can use the GUI to
-  configure and generate the VS projects; make sure you use the 64-bit
-  generator (**Visual Studio 14 2015 Win64**), and set the
-  `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
-- Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in
-  the LLVM solution in Release mode.
+- Generate LLVM VS2015 configuration with CMake. You can use the GUI to configure and generate the VS projects; make sure you use the 64-bit generator (**Visual Studio 14 2015 Win64**), and set the `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
+- Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in the LLVM solution in Release mode.
 
 Building Pony requires [Premake 5](https://premake.github.io).
 
@@ -257,16 +223,12 @@ Building Pony requires [Premake 5](https://premake.github.io).
   solution.
 - Build ponyc.sln in Release mode.
 
-In order to run the pony compiler, you'll need a few libraries in your
-environment (pcre2, libssl, libcrypto).
+In order to run the pony compiler, you'll need a few libraries in your environment (pcre2, libssl, libcrypto).
 
-There is a third-party utility that will get the libraries and set up your
-environment:
+There is a third-party utility that will get the libraries and set up your environment:
 
-- Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in
-  your PATH.
-- Open a **VS2015 x64 Native Tools Command Prompt** (things will not work
-  correctly otherwise!) and run:
+- Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in your PATH.
+- Open a **VS2015 x64 Native Tools Command Prompt** (things will not work correctly otherwise!) and run:
 
 ```
 > git clone git@github.com:kulibali/ponyc-windows-libs.git
@@ -287,16 +249,13 @@ Now you can run the pony compiler and tests:
 
 ## Building with link-time optimisation (LTO)
 
-You can enable LTO when building the compiler in release mode. There are
-slight differences between platforms so you'll need to do a manual setup.
-LTO is enabled by setting `lto` to `yes` in the build command line:
+You can enable LTO when building the compiler in release mode. There are slight differences between platforms so you'll need to do a manual setup. LTO is enabled by setting `lto` to `yes` in the build command line:
 
 ```bash
 $ make config=release lto=yes
 ```
 
-If the build fails, you have to specify the LTO plugin for your compiler
-in the `LTO_PLUGIN` variable. For example:
+If the build fails, you have to specify the LTO plugin for your compiler in the `LTO_PLUGIN` variable. For example:
 
 ```bash
 $ make config=release LTO_PLUGIN=/usr/lib/LLVMgold.so
@@ -309,7 +268,6 @@ LTO is enabled by default on OSX.
 
 ## VirtualBox
 
-Pony binaries can trigger illegal instruction errors under VirtualBox 4.x, for
-at least the x86_64 platform and possibly others.
+Pony binaries can trigger illegal instruction errors under VirtualBox 4.x, for at least the x86_64 platform and possibly others.
 
 Use VirtualBox 5.x to avoid possible problems.


### PR DESCRIPTION
This PR reformats markdown files to avoid hard wraps in favor of soft wrapping by our text editors and doc renderers.  It also makes this policy clear in `CONTRIBUTING.md`.

See some discussion here: https://github.com/ponylang/pony-for-x/pull/1#issuecomment-217628633