### PR TITLE
Add more ponytest TestHelper convenience methods for async tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - TCPConnection.expect
 - TCPConnectionNotify.sentv
 - HashMap.get_or_else
+- ponytest TestHelper.expect_action, complete_action, and fail_action
+- ponytest TestHelper.dispose_when_done
 
 ### Changed
 

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -76,12 +76,10 @@ class iso _TestBuffer is UnitTest
     h.assert_eq[String](b.line(), "hi!")
 
 class _TestPing is UDPNotify
-  let _mgr: _TestBroadcastMgr
   let _h: TestHelper
   let _ip: IPAddress
 
-  new create(mgr: _TestBroadcastMgr, h: TestHelper, ip: IPAddress) =>
-    _mgr = mgr
+  new create(h: TestHelper, ip: IPAddress) =>
     _h = h
 
     _ip = try
@@ -108,120 +106,92 @@ class _TestPing is UDPNotify
       ip
     end
 
+  fun ref not_listening(sock: UDPSocket ref) =>
+    _h.fail_action("ping listen")
+
   fun ref listening(sock: UDPSocket ref) =>
+    _h.complete_action("ping listen")
+
     sock.set_broadcast(true)
     sock.write("ping!", _ip)
 
-  fun ref not_listening(sock: UDPSocket ref) =>
-    _mgr.fail("Ping: not listening")
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress) =>
+    _h.complete_action("ping receive")
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
-  =>
     let s = String.append(consume data)
     _h.assert_eq[String box](s, "pong!")
-    _mgr.succeed()
+    _h.complete(true)
 
 class _TestPong is UDPNotify
-  let _mgr: _TestBroadcastMgr
   let _h: TestHelper
 
-  new create(mgr: _TestBroadcastMgr, h: TestHelper) =>
-    _mgr = mgr
+  new create(h: TestHelper) =>
     _h = h
 
-  fun ref listening(sock: UDPSocket ref) =>
-    sock.set_broadcast(true)
-    _mgr.pong_listening(sock.local_address())
-
   fun ref not_listening(sock: UDPSocket ref) =>
-    _mgr.fail("Pong: not listening")
+    _h.fail_action("pong listen")
+
+  fun ref listening(sock: UDPSocket ref) =>
+    _h.complete_action("pong listen")
+
+    sock.set_broadcast(true)
+    let ip = sock.local_address()
+
+    try
+      let auth = _h.env.root as AmbientAuth
+      let h = _h
+      if ip.ip4() then
+        _h.dispose_when_done(
+          UDPSocket.ip4(auth, recover _TestPing(h, ip) end))
+      else
+        _h.dispose_when_done(
+          UDPSocket.ip6(auth, recover _TestPing(h, ip) end))
+      end
+    else
+      _h.fail_action("ping create")
+    end
 
   fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
   =>
+    _h.complete_action("pong receive")
+
     let s = String.append(consume data)
     _h.assert_eq[String box](s, "ping!")
     sock.writev(
       recover val [[U8('p'), U8('o'), U8('n'), U8('g'), U8('!')]] end,
       from)
 
-actor _TestBroadcastMgr
-  let _h: TestHelper
-  var _pong: (UDPSocket | None) = None
-  var _ping: (UDPSocket | None) = None
-  var _fail: Bool = false
-
-  new create(h: TestHelper) =>
-    _h = h
-
-    try
-      _pong = UDPSocket(h.env.root as AmbientAuth,
-        recover _TestPong(this, h) end)
-    else
-      _h.fail("could not create Pong")
-      _h.complete(false)
-    end
-
-  be succeed() =>
-    if not _fail then
-      try (_pong as UDPSocket).dispose() end
-      try (_ping as UDPSocket).dispose() end
-      _h.complete(true)
-    end
-
-  be fail(msg: String) =>
-    if not _fail then
-      _fail = true
-      try (_pong as UDPSocket).dispose() end
-      try (_ping as UDPSocket).dispose() end
-      _h.fail(msg)
-      _h.complete(false)
-    end
-
-  be pong_listening(ip: IPAddress) =>
-    if not _fail then
-      let h = _h
-
-      try
-        if ip.ip4() then
-          _ping = UDPSocket.ip4(h.env.root as AmbientAuth,
-            recover _TestPing(this, h, ip) end)
-        else
-          _ping = UDPSocket.ip6(h.env.root as AmbientAuth,
-            recover _TestPing(this, h, ip) end)
-        end
-      else
-        _h.fail("could not create Ping")
-        _h.complete(false)
-      end
-    end
-
 class iso _TestBroadcast is UnitTest
   """
   Test broadcasting with UDP.
   """
-  var _mgr: (_TestBroadcastMgr | None) = None
-
   fun name(): String => "net/Broadcast"
 
   fun ref apply(h: TestHelper) =>
-    _mgr = _TestBroadcastMgr(h)
-    h.long_test(2_000_000_000) // 2 second timeout
+    h.expect_action("pong create")
+    h.expect_action("pong listen")
+    h.expect_action("ping create")
+    h.expect_action("ping listen")
+    h.expect_action("pong receive")
+    h.expect_action("ping receive")
 
-  fun timed_out(t: TestHelper) =>
     try
-      (_mgr as _TestBroadcastMgr).fail("timeout")
+      let auth = h.env.root as AmbientAuth
+      h.dispose_when_done(UDPSocket(auth, recover _TestPong(h) end))
+    else
+      h.fail_action("pong create")
     end
 
+    h.long_test(2_000_000_000) // 2 second timeout
+
 class _TestTCPExpectNotify is TCPConnectionNotify
-  let _mgr: _TestMgrTCPExpect
   let _h: TestHelper
   let _server: Bool
   var _expect: USize = 4
   var _frame: Bool = true
 
-  new iso create(mgr: _TestMgrTCPExpect, h: TestHelper, server: Bool) =>
+  new iso create(h: TestHelper, server: Bool) =>
     _server = server
-    _mgr = mgr
     _h = h
 
   fun ref accepted(conn: TCPConnection ref) =>
@@ -229,12 +199,13 @@ class _TestTCPExpectNotify is TCPConnectionNotify
     conn.expect(_expect)
     _send(conn, "hi there")
 
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("client connect")
+
   fun ref connected(conn: TCPConnection ref) =>
+    _h.complete_action("client connect")
     conn.set_nodelay(true)
     conn.expect(_expect)
-
-  fun ref connect_failed(conn: TCPConnection ref) =>
-    _mgr.fail("couldn't connect")
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
     if _frame then
@@ -248,9 +219,10 @@ class _TestTCPExpectNotify is TCPConnectionNotify
       _h.assert_eq[USize](_expect, data.size())
 
       if _server then
+        _h.complete_action("server receive")
         _h.assert_eq[String](String.from_array(data), "goodbye")
-        _mgr.succeed()
       else
+        _h.complete_action("client receive")
         _h.assert_eq[String](String.from_array(data), "hi there")
         _send(conn, "goodbye")
       end
@@ -276,211 +248,163 @@ class _TestTCPExpectNotify is TCPConnectionNotify
     conn.write(consume buf)
 
 class _TestTCPExpectListen is TCPListenNotify
-  let _mgr: _TestMgrTCPExpect
   let _h: TestHelper
 
-  new iso create(mgr: _TestMgrTCPExpect, h: TestHelper) =>
-    _mgr = mgr
+  new iso create(h: TestHelper) =>
     _h = h
-
-  fun ref listening(listen: TCPListener ref) =>
-    _mgr.listening(listen.local_address())
 
   fun ref not_listening(listen: TCPListener ref) =>
-    _mgr.fail("not listening")
+    _h.fail_action("server listen")
 
-  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
-    _TestTCPExpectNotify(_mgr, _h, true)
+  fun ref listening(listen: TCPListener ref) =>
+    _h.complete_action("server listen")
 
-interface tag _TestMgr
-  be succeed()
-  be fail(msg: String)
-
-actor _TestMgrNone is _TestMgr
-  be succeed() => None
-  be fail(msg: String) => None
-
-actor _TestMgrTCPExpect
-  let _h: TestHelper
-  var _listen: (TCPListener | None) = None
-  var _connect: (TCPConnection | None) = None
-  var _fail: Bool = false
-
-  new create(h: TestHelper) =>
-    _h = h
+    let h = _h
+    let ip = listen.local_address()
 
     try
-      _listen = TCPListener(h.env.root as AmbientAuth,
-        _TestTCPExpectListen(this, h))
+      let auth = h.env.root as AmbientAuth
+      (let host, let service) = ip.name()
+      _h.dispose_when_done(TCPConnection.ip4(auth,
+        _TestTCPExpectNotify(h, false), host, service))
+      _h.complete_action("client create")
     else
-      _h.fail("could not create TCP.expect listener")
-      _h.complete(false)
+      _h.fail_action("client create")
     end
 
-  be succeed() =>
-    if not _fail then
-      try (_listen as TCPListener).dispose() end
-      try (_connect as TCPConnection).dispose() end
-      _h.complete(true)
-    end
-
-  be fail(msg: String) =>
-    if not _fail then
-      _fail = true
-      try (_listen as TCPListener).dispose() end
-      try (_connect as TCPConnection).dispose() end
-      _h.fail(msg)
-      _h.complete(false)
-    end
-
-  be listening(ip: IPAddress) =>
-    if not _fail then
-      let h = _h
-
-      try
-        (let host, let service) = ip.name()
-        _connect = TCPConnection.ip4(h.env.root as AmbientAuth,
-          _TestTCPExpectNotify(this, h, false), host, service)
-      else
-        _h.fail("could not create TCP.expect connection")
-        _h.complete(false)
-      end
-    end
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
+    _h.complete_action("server accept")
+    _TestTCPExpectNotify(_h, true)
 
 class iso _TestTCPExpect is UnitTest
   """
   Test expecting framed data with TCP.
   """
-  var _mgr: _TestMgr = _TestMgrNone
-
   fun name(): String => "net/TCP.expect"
 
   fun ref apply(h: TestHelper) =>
-    _mgr = _TestMgrTCPExpect(h)
+    h.expect_action("server create")
+    h.expect_action("server listen")
+    h.expect_action("client create")
+    h.expect_action("client connect")
+    h.expect_action("server accept")
+    h.expect_action("client receive")
+    h.expect_action("server receive")
+
+    try
+      let auth = h.env.root as AmbientAuth
+      h.dispose_when_done(TCPListener(auth, _TestTCPExpectListen(h)))
+      h.complete_action("server create")
+    else
+      h.fail_action("server create")
+    end
+
     h.long_test(2_000_000_000)
 
-  fun timed_out(t: TestHelper) =>
-    _mgr.fail("timeout")
-
-actor _TestMgrTCPWritev
+class _TestTCPWritevListenNotify is TCPListenNotify
   let _h: TestHelper
-  let _auth: TCPAuth
-  let _disposables: Array[DisposableActor] = _disposables.create()
-  var _disposed: Bool = false
 
-  new create(h: TestHelper, auth: TCPAuth) =>
+  new iso create(h: TestHelper) =>
     _h = h
-    _auth = auth
-    dispose_later(TCPListener(auth, _listen_notify()))
 
-  be dispose_later(d: DisposableActor) =>
-    if _disposed then
-      d.dispose()
-    else
-      _disposables.push(d)
-    end
+  fun ref not_listening(listen: TCPListener ref) =>
+    _h.fail_action("server listen")
 
-  be dispose() =>
-    for d in _disposables.values() do d.dispose() end
-    _disposed = true
+  fun ref listening(listen: TCPListener ref) =>
+    _h.complete_action("server listen")
 
-  be succeed() =>
-    _h.complete(true)
-    dispose()
+    let ip = listen.local_address()
 
-  be fail(msg: String) =>
-    _h.fail(msg)
-    _h.complete(false)
-    dispose()
-
-  be listening(ip: IPAddress) =>
     try
+      let auth = _h.env.root as AmbientAuth
       (let host, let service) = ip.name()
-      let conn = TCPConnection.ip4(_auth, _conn_notify(false), host, service)
-      dispose_later(conn)
+      _h.dispose_when_done(
+        TCPConnection.ip4(auth, _TestTCPWritevNotify(_h, false), host, service))
+      _h.complete_action("client create")
+    else
+      _h.fail_action("client create")
     end
 
-  be assert_streq(expect: String, actual: String) =>
-    _h.assert_eq[String](expect, actual)
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
+    _h.complete_action("server accept")
+    _TestTCPWritevNotify(_h, true)
 
-  fun tag _listen_notify(): TCPListenNotify iso^ =>
-    object iso is TCPListenNotify
-      let _mgr: _TestMgrTCPWritev = this
+class _TestTCPWritevNotify is TCPConnectionNotify
+  let _h: TestHelper
+  let _server: Bool
+  var _buffer: String iso = recover iso String end
 
-      fun ref not_listening(listen: TCPListener ref) =>
-        _mgr.fail("not listening")
+  new iso create(h: TestHelper, server: Bool) =>
+    _h = h
+    _server = server
 
-      fun ref listening(listen: TCPListener ref) =>
-        _mgr.listening(listen.local_address())
-
-      fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
-        _mgr._conn_notify(true)
+  fun ref sent(conn: TCPConnection ref, data: ByteSeq): ByteSeq ? =>
+    if not _server then
+      _h.fail("TCPConnectionNotify.sent invoked on the client side, " +
+              "when the sentv success should have prevented it.")
     end
 
-  fun tag _conn_notify(server: Bool): TCPConnectionNotify iso^ =>
-    object iso is TCPConnectionNotify
-      let _mgr: _TestMgrTCPWritev = this
-      let _server: Bool = server
-      var _buffer: String iso = recover iso String end
+    let data_str = recover trn String.append(data) end
+    if data_str == "ignore me" then error end
 
-      fun ref sent(conn: TCPConnection ref, data: ByteSeq): ByteSeq ? =>
-        if not _server then
-          _mgr.fail("TCPConnectionNotify.sent invoked on the client side, " +
-                    "when the sentv success should have prevented it.")
-        end
+    if data_str == "replace me" then return ", hello" end
 
-        let data_str = recover trn String.append(data) end
-        if data_str == "ignore me" then error end
+    _h.assert_eq[String]("hello", consume data_str)
+    data
 
-        if data_str == "replace me" then return ", hello" end
+  fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter ?=>
+    if _server then error end
+    recover Array[ByteSeq].concat(data.values()).push(" (from client)") end
 
-        _mgr.assert_streq("hello", consume data_str)
-        data
+  fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
+    _buffer.append(consume data)
 
-      fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter ?=>
-        if _server then error end
-        recover Array[ByteSeq].concat(data.values()).push(" (from client)") end
+    let expected =
+      if _server
+      then "hello, hello (from client)"
+      else "hello, hello"
+      end
 
-      fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
-        _buffer.append(consume data)
+    if _buffer.size() >= expected.size() then
+      let buffer: String = _buffer = recover iso String end
+      _h.assert_eq[String](expected, consume buffer)
 
-        let expected =
-          if _server
-          then "hello, hello (from client)"
-          else "hello, hello"
-          end
-
-        if _buffer.size() >= expected.size() then
-          let buffer: String = _buffer = recover iso String end
-          _mgr.assert_streq(expected, consume buffer)
-
-          if _server
-          then conn.writev(recover ["hello", "ignore me", "replace me"] end)
-          else _mgr.succeed()
-          end
-        end
-
-      fun ref connected(conn: TCPConnection ref) =>
-        if not _server then
-          conn.writev(recover ["hello", ", hello"] end)
-        end
-
-      fun ref connect_failed(conn: TCPConnection ref) =>
-        _mgr.fail("connect failed")
+      if _server then
+        _h.complete_action("server receive")
+        conn.writev(recover ["hello", "ignore me", "replace me"] end)
+      else
+        _h.complete_action("client receive")
+      end
     end
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("client connect")
+
+  fun ref connected(conn: TCPConnection ref) =>
+    _h.complete_action("client connect")
+    conn.writev(recover ["hello", ", hello"] end)
 
 class iso _TestTCPWritev is UnitTest
   """
   Test writev (and sent/sentv notification).
   """
-  var _mgr: _TestMgr = _TestMgrNone
-
   fun name(): String => "net/TCP.writev"
 
-  fun ref apply(h: TestHelper) ? =>
-    let auth = TCPAuth(h.env.root as AmbientAuth)
-    _mgr = _TestMgrTCPWritev(h, auth)
-    h.long_test(2_000_000_000)
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("server create")
+    h.expect_action("server listen")
+    h.expect_action("client create")
+    h.expect_action("client connect")
+    h.expect_action("server accept")
+    h.expect_action("client receive")
+    h.expect_action("server receive")
 
-  fun timed_out(t: TestHelper) =>
-    _mgr.fail("timeout")
+    try
+      let auth = h.env.root as AmbientAuth
+      h.dispose_when_done(TCPListener(auth, _TestTCPWritevListenNotify(h)))
+      h.complete_action("server create")
+    else
+      h.fail_action("server create")
+    end
+
+    h.long_test(2_000_000_000)

--- a/packages/ponytest/helper.pony
+++ b/packages/ponytest/helper.pony
@@ -312,3 +312,52 @@ class val TestHelper
     Once this is called tear_down() may be called at any time.
     """
     _runner.complete(success)
+
+  fun expect_action(name: String) =>
+    """
+    Can be called in a long test to set up expectations for one or more actions
+    that, when all completed, will complete the test.
+
+    This pattern is useful for cases where you have multiple things that need
+    to happen to complete your test, but don't want to have to collect them
+    all yourself into a single actor that calls the complete method.
+
+    The order of calls to expect_action don't matter - the actions may be
+    completed in any other order to complete the test.
+    """
+    _runner.expect_action(name)
+
+  fun complete_action(name: String) =>
+    """
+    MUST be called for each action expectation that was set up in a long test
+    to fulfill the expectations. Any expectations that are still outstanding
+    when the long test timeout runs out will be printed by name when it fails.
+
+    Completing all outstanding actions is enough to finish the test. There's no
+    need to also call the complete method when the actions are finished.
+
+    Calling the complete method will finish the test immediately, without
+    waiting for any outstanding actions to be completed.
+    """
+    _runner.complete_action(name, true)
+
+  fun fail_action(name: String) =>
+    """
+    Call to fail an action, which will also cause the entire test to fail
+    immediately, without waiting the rest of the outstanding actions.
+
+    The name of the failed action will be included in the failure output.
+
+    Usually the action name should be an expected action set up by a call to
+    expect_action, but failing unexpected actions will also fail the test.
+    """
+    _runner.complete_action(name, false)
+
+  fun dispose_when_done(disposable: DisposableActor) =>
+    """
+    Pass a disposable actor to be disposed of when the test is complete.
+    The actor will be disposed no matter whether the test succeeds or fails.
+
+    If the test is already tearing down, the actor will be disposed immediately.
+    """
+    _runner.dispose_when_done(disposable)


### PR DESCRIPTION
Last week when I was working on some TCP tests in the `net` package (and my own tests in other packages), I noticed that it's quite onerous to write non-trivial async tests with `ponytest`. Particularly,

* When you have actors to be disposed of (like  when the test is over (even in a timeout or early fail), it required creating a separate "manager" actor to dispose of, and calling `fail` on the manager instead of `complete` on the `TestHelper` directly.  This feature (disposing of `DisposableActor`s when the test is over) can be built directly into the `TestHelper` and `TestRunner` and remove the need for these intermediate manager actors entirely.
* When you have a complex asynchronous test, you want to be able to test that it reaches various checkpoints (that I called "actions"). When all these actions are done, the test can be considered over, but without a centralized point of tracking, it can be hard to tell that all actions are met in order to call `complete` on the `TestHelper`.  This feature can also be built into the `TestHelper` and `TestRunner`, which serve as the centralized point of tracking.
  * Writing out expected and completed "actions" is also pretty self-documenting in terms of making the control flow of the test easier to understand.  Actions don't need to be completed in any specific order, but listing out the expected actions in a logical order can make it easier for a new reader to understand the tests.

This PR also tests/demonstrates these new features in the `net` tests.