### PR TITLE
Add infinite function for floating point numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - HashMap.get_or_else
 - ponytest TestHelper.expect_action, complete_action, and fail_action
 - ponytest TestHelper.dispose_when_done
-- copysign for floating point numbers
+- copysign and infinite for floating point numbers
 
 ### Changed
 

--- a/packages/builtin/arithmetic.pony
+++ b/packages/builtin/arithmetic.pony
@@ -105,6 +105,7 @@ trait val FloatingPoint[A: FloatingPoint[A] val] is Real[A]
   fun trunc(): A
 
   fun finite(): Bool
+  fun infinite(): Bool
   fun nan(): Bool
 
   fun ldexp(x: A, exponent: I32): A

--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -86,6 +86,14 @@ primitive F32 is FloatingPoint[F32]
     // True if exponent is not all 1s
     (bits() and 0x7F800000) != 0x7F800000
 
+  fun infinite(): Bool =>
+    """
+    Check whether this number is +/-infinity
+    """
+    // True if exponent is all 1s and mantissa is 0
+    ((bits() and 0x7F800000) == 0x7F800000) and  // exp
+    ((bits() and 0x007FFFFF) == 0)  // mantissa
+
   fun nan(): Bool =>
     """
     Check whether this number is NaN.
@@ -231,6 +239,14 @@ primitive F64 is FloatingPoint[F64]
     """
     // True if exponent is not all 1s
     (bits() and 0x7FF0_0000_0000_0000) != 0x7FF0_0000_0000_0000
+
+  fun infinite(): Bool =>
+    """
+    Check whether this number is +/-infinity
+    """
+    // True if exponent is all 1s and mantissa is 0
+    ((bits() and 0x7FF0_0000_0000_0000) == 0x7FF0_0000_0000_0000) and  // exp
+    ((bits() and 0x000F_FFFF_FFFF_FFFF) == 0)  // mantissa
 
   fun nan(): Bool =>
     """

--- a/packages/builtin_test/test.pony
+++ b/packages/builtin_test/test.pony
@@ -387,22 +387,27 @@ class iso _TestSpecialValuesF32 is UnitTest
   fun apply(h: TestHelper) =>
     // 1
     h.assert_true(F32(1.0).finite())
+    h.assert_false(F32(1.0).infinite())
     h.assert_false(F32(1.0).nan())
 
     // -1
     h.assert_true(F32(-1.0).finite())
+    h.assert_false(F32(-1.0).infinite())
     h.assert_false(F32(-1.0).nan())
 
     // Infinity
     h.assert_false(F32(1.0 / 0.0).finite())
+    h.assert_true(F32(1.0 / 0.0).infinite())
     h.assert_false(F32(1.0 / 0.0).nan())
 
     // - infinity
     h.assert_false(F32(-1.0 / 0.0).finite())
+    h.assert_true(F32(-1.0 / 0.0).infinite())
     h.assert_false(F32(-1.0 / 0.0).nan())
 
     // NaN
     h.assert_false(F32(0.0 / 0.0).finite())
+    h.assert_false(F32(0.0 / 0.0).infinite())
     h.assert_true(F32(0.0 / 0.0).nan())
 
 
@@ -415,22 +420,27 @@ class iso _TestSpecialValuesF64 is UnitTest
   fun apply(h: TestHelper) =>
     // 1
     h.assert_true(F64(1.0).finite())
+    h.assert_false(F64(1.0).infinite())
     h.assert_false(F64(1.0).nan())
 
     // -1
     h.assert_true(F64(-1.0).finite())
+    h.assert_false(F64(-1.0).infinite())
     h.assert_false(F64(-1.0).nan())
 
     // Infinity
     h.assert_false(F64(1.0 / 0.0).finite())
+    h.assert_true(F64(1.0 / 0.0).infinite())
     h.assert_false(F64(1.0 / 0.0).nan())
 
     // - infinity
     h.assert_false(F64(-1.0 / 0.0).finite())
+    h.assert_true(F64(-1.0 / 0.0).infinite())
     h.assert_false(F64(-1.0 / 0.0).nan())
 
     // NaN
     h.assert_false(F64(0.0 / 0.0).finite())
+    h.assert_false(F64(0.0 / 0.0).infinite())
     h.assert_true(F64(0.0 / 0.0).nan())
 
 


### PR DESCRIPTION
I think having this function could be good because using `finite` and `nan` to check infinity can add complexity to the code and is quite obscure to people unfamiliar with floating point numbers.