### PR TITLE
Use `-I` rather than `-isystem` for LLVM include directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Simplify contains() method on HashMap.
 - Lambda captures use the alias of the expression type.
 - Trace boxed primitives in union types.
+- Use `-I` rather than `-isystem` for LLVM include directory.
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ endif
 # (3) a list of include directories for a set of libraries
 # (4) a list of the libraries to link against
 llvm.ldflags := $(shell $(LLVM_CONFIG) --ldflags)
-llvm.include := -isystem $(shell $(LLVM_CONFIG) --includedir)
+llvm.include := -I $(shell $(LLVM_CONFIG) --includedir)
 llvm.libs    := $(shell $(LLVM_CONFIG) --libs) -lz -lncurses
 
 ifeq ($(OSTYPE), freebsd)


### PR DESCRIPTION
Building on Arch Linux, using gcc 6.1.1 and LLVM 3.7.1, fails with
the error:

    /usr/include/c++/6.1.1/cmath:45:23: fatal error: math.h: No such file or directory
     #include_next <math.h>

Replacing -isystem with -I alters the include file search path and avoids
the problem.

This fixes #797