### PR TITLE
Add pony_alloc_msg_size runtime function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - copysign and infinite for floating point numbers
 - contains() method on Array
 - GC tracing with acquire/release semantics.
+- pony_alloc_msg_size runtime function
 
 ### Changed
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -131,7 +131,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
     msg = actor->continuation;
     actor->continuation = msg->next;
     bool ret = handle_message(ctx, actor, msg);
-    ponyint_pool_free(msg->size, msg);
+    ponyint_pool_free(msg->index, msg);
 
     if(ret)
     {
@@ -295,13 +295,18 @@ void ponyint_destroy(pony_actor_t* actor)
   ponyint_actor_destroy(actor);
 }
 
-pony_msg_t* pony_alloc_msg(uint32_t size, uint32_t id)
+pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id)
 {
-  pony_msg_t* msg = (pony_msg_t*)ponyint_pool_alloc(size);
-  msg->size = size;
+  pony_msg_t* msg = (pony_msg_t*)ponyint_pool_alloc(index);
+  msg->index = index;
   msg->id = id;
 
   return msg;
+}
+
+pony_msg_t* pony_alloc_msg_size(size_t size, uint32_t id)
+{
+  return pony_alloc_msg((uint32_t)ponyint_pool_index(size), id);
 }
 
 void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* m)

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -24,7 +24,7 @@ static size_t messageq_size_debug(messageq_t* q)
 void ponyint_messageq_init(messageq_t* q)
 {
   pony_msg_t* stub = POOL_ALLOC(pony_msg_t);
-  stub->size = POOL_INDEX(sizeof(pony_msg_t));
+  stub->index = POOL_INDEX(sizeof(pony_msg_t));
   stub->next = NULL;
 
   q->head = (pony_msg_t*)((uintptr_t)stub | 1);
@@ -40,7 +40,7 @@ void ponyint_messageq_destroy(messageq_t* q)
   pony_msg_t* tail = q->tail;
   assert(((uintptr_t)q->head & ~(uintptr_t)1) == (uintptr_t)tail);
 
-  ponyint_pool_free(tail->size, tail);
+  ponyint_pool_free(tail->index, tail);
   q->head = NULL;
   q->tail = NULL;
 }
@@ -67,7 +67,7 @@ pony_msg_t* ponyint_messageq_pop(messageq_t* q)
   if(next != NULL)
   {
     q->tail = next;
-    ponyint_pool_free(tail->size, tail);
+    ponyint_pool_free(tail->index, tail);
   }
 
   return next;

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -35,7 +35,7 @@ typedef struct pony_ctx_t pony_ctx_t;
  */
 typedef struct pony_msg_t
 {
-  uint32_t size;
+  uint32_t index;
   uint32_t id;
   struct pony_msg_t* volatile next;
 } pony_msg_t;
@@ -126,8 +126,11 @@ pony_ctx_t* pony_ctx();
 ATTRIBUTE_MALLOC(pony_actor_t* pony_create(pony_ctx_t* ctx,
   pony_type_t* type));
 
-/// Allocates a message and sets up the header. The size is a POOL_INDEX.
-pony_msg_t* pony_alloc_msg(uint32_t size, uint32_t id);
+/// Allocates a message and sets up the header. The index is a POOL_INDEX.
+pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id);
+
+/// Allocates a message and sets up the header. The size is in bytes.
+pony_msg_t* pony_alloc_msg_size(size_t size, uint32_t id);
 
 /// Sends a message to an actor.
 void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* m);


### PR DESCRIPTION
As discussed in #796.

I also renamed some index variables misleadingly named `size` to keep things clear.