### PR TITLE
fix persistent/Map size() method

### DIFF
--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -140,6 +140,7 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
       match e
       | let sn: _MapNode[K, V] => tot = tot + sn.size()
       | let l: _Leaf[K, V] => tot = tot + 1
+      | let cn: Array[_Leaf[K, V]] val => tot = tot + cn.size()
       end
     end
     tot

--- a/packages/collections/persistent/test.pony
+++ b/packages/collections/persistent/test.pony
@@ -307,8 +307,8 @@ class iso _TestMapVsMap is UnitTest
     let kvs = Array[(String,U64)]()
     let dice = Dice(MT)
     var count: USize = 0
-    let iterations: USize = 100000
-    let keys: U64 = 10000
+    let iterations: USize = 200000
+    let keys: U64 = 200000
 
     while(count < iterations) do
       let k0 = dice(1,keys).string()
@@ -333,6 +333,8 @@ class iso _TestMapVsMap is UnitTest
       h.assert_eq[Bool](_H.equal_map_u64_values(pmv, mmv), true)
       count = count + 1
     end
+
+    h.assert_eq[USize](m_map.size(), p_map.size())
 
     true
 


### PR DESCRIPTION
The updated test previously failed since collision nodes were not counted when adding up all the entries.