### PR TITLE
Only use -isystem for LLVM if the directory is not already on the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Simplify contains() method on HashMap.
 - Lambda captures use the alias of the expression type.
 - Trace boxed primitives in union types.
+- Use -isystem for LLVM include directory only if it is not in search path.
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,17 @@ endif
 # (3) a list of include directories for a set of libraries
 # (4) a list of the libraries to link against
 llvm.ldflags := $(shell $(LLVM_CONFIG) --ldflags)
-llvm.include := -isystem $(shell $(LLVM_CONFIG) --includedir)
+llvm.include.dir := $(shell $(LLVM_CONFIG) --includedir)
+include.paths := $(shell echo | cc -v -E - 2>&1)
+ifeq (,$(findstring $(llvm.include.dir),$(include.paths)))
+# LLVM include directory is not in the existing paths;
+# put it at the top of the system list
+llvm.include := -isystem $(llvm.include.dir)
+else
+# LLVM include directory is already on the existing paths;
+# do nothing
+llvm.include :=
+endif
 llvm.libs    := $(shell $(LLVM_CONFIG) --libs) -lz -lncurses
 
 ifeq ($(OSTYPE), freebsd)


### PR DESCRIPTION
Building on Arch Linux, using gcc 6.1.1 and LLVM 3.7.1, fails with
the error:

/usr/include/c++/6.1.1/cmath:45:23: fatal error: math.h: No such file or directory
 #include_next <math.h>

Avoiding the use of -isystem if the LLVM include directory is already
on the search path should avoid the problem.

This fixes #797