### PR TITLE
Add net/WriteBuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - contains() method on Array
 - GC tracing with acquire/release semantics.
 - pony_alloc_msg_size runtime function
+- `net/WriteBuffer`
 
 ### Changed
 
@@ -79,6 +80,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Parameterized Array.find and Array.rfind with a comparator.
 - `this->` adapted types check match on the upper bounds.
 - Renamed `identityof` to `digestof`.
+- Renamed `net/Buffer` to `net/ReadBuffer`
 
 ## [0.2.1] - 2015-10-06
 

--- a/packages/net/http/payloadbuilder.pony
+++ b/packages/net/http/payloadbuilder.pony
@@ -56,7 +56,7 @@ class _PayloadBuilder
     """
     _state
 
-  fun ref parse(buffer: Buffer) =>
+  fun ref parse(buffer: ReadBuffer) =>
     """
     Parse available data based on our state. _ResponseBody is not listed here.
     In that state, we wait for the connection to close and treat all pending
@@ -93,7 +93,7 @@ class _PayloadBuilder
 
     payload
 
-  fun ref closed(buffer: Buffer) =>
+  fun ref closed(buffer: ReadBuffer) =>
     """
     The connection has closed, which may signal that all remaining data is the
     payload body.
@@ -108,7 +108,7 @@ class _PayloadBuilder
       end
     end
 
-  fun ref _parse_request(buffer: Buffer) =>
+  fun ref _parse_request(buffer: ReadBuffer) =>
     """
     Look for: "<Method> <URL> <Proto>".
     """
@@ -130,7 +130,7 @@ class _PayloadBuilder
       end
     end
 
-  fun ref _parse_response(buffer: Buffer) =>
+  fun ref _parse_response(buffer: ReadBuffer) =>
     """
     Look for: "<Proto> <Code> <Description>".
     """
@@ -152,7 +152,7 @@ class _PayloadBuilder
       end
     end
 
-  fun ref _parse_headers(buffer: Buffer) =>
+  fun ref _parse_headers(buffer: ReadBuffer) =>
     """
     Look for: "<Key>:<Value>" or an empty line.
     """
@@ -212,7 +212,7 @@ class _PayloadBuilder
       end
     end
 
-  fun ref _parse_content_length(buffer: Buffer) =>
+  fun ref _parse_content_length(buffer: ReadBuffer) =>
     """
     Look for _content_length available bytes.
     """
@@ -222,7 +222,7 @@ class _PayloadBuilder
       _state = _PayloadReady
     end
 
-  fun ref _parse_chunk_start(buffer: Buffer) =>
+  fun ref _parse_chunk_start(buffer: ReadBuffer) =>
     """
     Look for the beginning of a chunk.
     """
@@ -245,7 +245,7 @@ class _PayloadBuilder
       end
     end
 
-  fun ref _parse_chunk(buffer: Buffer) =>
+  fun ref _parse_chunk(buffer: ReadBuffer) =>
     """
     Look for a chunk.
     """
@@ -256,7 +256,7 @@ class _PayloadBuilder
       parse(buffer)
     end
 
-  fun ref _parse_chunk_end(buffer: Buffer) =>
+  fun ref _parse_chunk_end(buffer: ReadBuffer) =>
     """
     Look for a blank line.
     """

--- a/packages/net/http/requestbuilder.pony
+++ b/packages/net/http/requestbuilder.pony
@@ -8,7 +8,7 @@ class _RequestBuilder is TCPConnectionNotify
   let _logger: Logger
   let _reversedns: (DNSLookupAuth | None)
   var _server: (_ServerConnection | None) = None
-  let _buffer: Buffer = Buffer
+  let _buffer: ReadBuffer = ReadBuffer
   let _builder: _PayloadBuilder = _PayloadBuilder.request()
 
   new iso create(handler: RequestHandler, logger: Logger,

--- a/packages/net/http/responsebuilder.pony
+++ b/packages/net/http/responsebuilder.pony
@@ -5,7 +5,7 @@ class _ResponseBuilder is TCPConnectionNotify
   This builds a response payload using received chunks of data.
   """
   let _client: _ClientConnection
-  let _buffer: Buffer = Buffer
+  let _buffer: ReadBuffer = ReadBuffer
   let _builder: _PayloadBuilder = _PayloadBuilder.response()
 
   new iso create(client: _ClientConnection) =>

--- a/packages/net/readbuffer.pony
+++ b/packages/net/readbuffer.pony
@@ -1,6 +1,6 @@
 use "collections"
 
-class Buffer
+class ReadBuffer
   """
   Store network data and provide a parsing interface.
   """
@@ -15,7 +15,7 @@ class Buffer
     """
     _available
 
-  fun ref clear(): Buffer^ =>
+  fun ref clear(): ReadBuffer^ =>
     """
     Discard all pending data.
     """
@@ -23,7 +23,7 @@ class Buffer
     _available = 0
     this
 
-  fun ref append(data: Array[U8] val): Buffer^ =>
+  fun ref append(data: Array[U8] val): ReadBuffer^ =>
     """
     Add a chunk of data.
     """
@@ -31,7 +31,7 @@ class Buffer
     _chunks.push((data, 0))
     this
 
-  fun ref skip(n: USize): Buffer^ ? =>
+  fun ref skip(n: USize): ReadBuffer^ ? =>
     """
     Skip n bytes.
     """

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -5,19 +5,20 @@ actor Main is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    test(_TestBuffer)
+    test(_TestReadBuffer)
+    test(_TestWriteBuffer)
     test(_TestBroadcast)
     test(_TestTCPExpect)
     test(_TestTCPWritev)
 
-class iso _TestBuffer is UnitTest
+class iso _TestReadBuffer is UnitTest
   """
-  Test adding to and reading from a Buffer.
+  Test adding to and reading from a ReadBuffer.
   """
-  fun name(): String => "net/Buffer"
+  fun name(): String => "net/ReadBuffer"
 
   fun apply(h: TestHelper) ? =>
-    let b = Buffer
+    let b = ReadBuffer
 
     b.append(recover [as U8:
       0x42,
@@ -36,6 +37,74 @@ class iso _TestBuffer is UnitTest
     b.append(recover [as U8: 'h', 'i'] end)
     b.append(recover [as U8: '\n', 't', 'h', 'e'] end)
     b.append(recover [as U8: 'r', 'e', '\r', '\n'] end)
+
+    // These expectations peek into the buffer without consuming bytes.
+    h.assert_eq[U8](b.peek_u8(), 0x42)
+    h.assert_eq[U16](b.peek_u16_be(1), 0xDEAD)
+    h.assert_eq[U16](b.peek_u16_le(3), 0xDEAD)
+    h.assert_eq[U32](b.peek_u32_be(5), 0xDEADBEEF)
+    h.assert_eq[U32](b.peek_u32_le(9), 0xDEADBEEF)
+    h.assert_eq[U64](b.peek_u64_be(13), 0xDEADBEEFFEEDFACE)
+    h.assert_eq[U64](b.peek_u64_le(21), 0xDEADBEEFFEEDFACE)
+    h.assert_eq[U128](b.peek_u128_be(29), 0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+    h.assert_eq[U128](b.peek_u128_le(45), 0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+
+    h.assert_eq[U8](b.peek_u8(61), 'h')
+    h.assert_eq[U8](b.peek_u8(62), 'i')
+
+    // These expectations consume bytes from the head of the buffer.
+    h.assert_eq[U8](b.u8(), 0x42)
+    h.assert_eq[U16](b.u16_be(), 0xDEAD)
+    h.assert_eq[U16](b.u16_le(), 0xDEAD)
+    h.assert_eq[U32](b.u32_be(), 0xDEADBEEF)
+    h.assert_eq[U32](b.u32_le(), 0xDEADBEEF)
+    h.assert_eq[U64](b.u64_be(), 0xDEADBEEFFEEDFACE)
+    h.assert_eq[U64](b.u64_le(), 0xDEADBEEFFEEDFACE)
+    h.assert_eq[U128](b.u128_be(), 0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+    h.assert_eq[U128](b.u128_le(), 0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+
+    h.assert_eq[String](b.line(), "hi")
+    h.assert_eq[String](b.line(), "there")
+
+    b.append(recover [as U8: 'h', 'i'] end)
+
+    try
+      b.line()
+      h.fail("shouldn't have a line")
+    end
+
+    b.append(recover [as U8: '!', '\n'] end)
+    h.assert_eq[String](b.line(), "hi!")
+
+class iso _TestWriteBuffer is UnitTest
+  """
+  Test writing to and reading from a WriteBuffer.
+  """
+  fun name(): String => "net/WriteBuffer"
+
+  fun apply(h: TestHelper) ? =>
+    let b = ReadBuffer
+    let wb: WriteBuffer ref = WriteBuffer
+
+    wb.u8(0x42)
+      .u16_be(0xDEAD)
+      .u16_le(0xDEAD)
+      .u32_be(0xDEADBEEF)
+      .u32_le(0xDEADBEEF)
+      .u64_be(0xDEADBEEFFEEDFACE)
+      .u64_le(0xDEADBEEFFEEDFACE)
+      .u128_be(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+      .u128_le(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+
+    wb.write(recover [as U8: 'h', 'i'] end)
+    wb.writev(recover [as Array[U8]: [as U8: '\n', 't', 'h', 'e'],
+                                     [as U8: 'r', 'e', '\r', '\n']] end)
+
+    for bs in wb.done().values() do
+      try
+        b.append(bs as Array[U8] val)
+      end
+    end
 
     // These expectations peek into the buffer without consuming bytes.
     h.assert_eq[U8](b.peek_u8(), 0x42)

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -1,0 +1,312 @@
+class WriteBuffer
+  """
+  A buffer for building messages.
+
+  `WriteBuffer` provides an way to create byte sequences using common
+  data encodings. The `WriteBuffer` manages the underlying arrays and
+  sizes. It is useful for encoding data to send over a network or
+  store in a file. Once a message has been built you can call `done()`
+  to get the message's `ByteSeq`s, and you can then reuse the
+  `WriteBuffer` for creating a new message.
+
+  For example, suppose we have a TCP-based network data protocol where
+  messages consist of the following:
+
+  * `message_length` - the number of bytes in the message as a
+    big-endian 32-bit integer
+  * `list_size` - the number of items in the following list of items
+    as a big-endian 32-bit integer
+  * zero or more items of the following data:
+    * a big-endian 64-bit floating point number
+    * a string that starts with a big-endian 32-bit integer that
+      specifies the length of the string, followed by a number of
+      bytes that represent the string
+
+  A message would be something like this:
+
+  ```
+  [message_length][list_size][float1][string1][float2][string2]...
+  ```
+
+  The following program uses a write buffer to encode an array of
+  tuples as a message of this type:
+
+  ```
+  use "net"
+  
+  actor Main
+    new create(env: Env) =>
+      let wb = WriteBuffer
+      let messages = [[(F32(3597.82), "Anderson"), (F32(-7979.3), "Graham")],
+                      [(F32(3.14159), "Hopper"), (F32(-83.83), "Jones")]]
+      for items in messages.values() do
+        wb.i32_be((items.size() / 2).i32())
+        for (f, s) in items.values() do
+          wb.f32_be(f)
+          wb.i32_be(s.size().i32())
+          wb.write(s.array())
+        end
+        let wb_msg = WriteBuffer
+        wb_msg.i32_be(wb.size().i32())
+        wb_msg.writev(wb.done())
+        env.out.writev(wb_msg.done())
+      end
+  ```
+  """
+  var _chunks: Array[ByteSeq] iso = recover Array[ByteSeq] end
+  var _current: Array[U8] iso = recover Array[U8] end
+  var _offset: USize = 0
+  var _size: USize = 0
+
+  fun ref reserve(size': USize): WriteBuffer^ =>
+    """
+    Reserve space for size additional bytes.
+    """
+    _current.undefined(_current.size() + size')
+    this
+
+  fun size(): USize =>
+    _size
+
+  fun ref u8(data: U8): WriteBuffer^ =>
+    """
+    Write a byte to the buffer.
+    """
+    _check(1)
+    _byte(data)
+    this
+
+  fun ref u16_le(data: U16): WriteBuffer^ =>
+    """
+    Write a U16 to the buffer in little-endian byte order.
+    """
+    _check(2)
+    _byte(data.u8())
+    _byte((data >> 8).u8())
+    this
+
+  fun ref u16_be(data: U16): WriteBuffer^ =>
+    """
+    Write a U16 to the buffer in big-endian byte order.
+    """
+    _check(2)
+    _byte((data >> 8).u8())
+    _byte(data.u8())
+    this
+
+  fun ref i16_le(data: I16): WriteBuffer^ =>
+    """
+    Write an I16 to the buffer in little-endian byte order.
+    """
+    u16_le(data.u16())
+
+  fun ref i16_be(data: I16): WriteBuffer^ =>
+    """
+    Write an I16 to the buffer in big-endian byte order.
+    """
+    u16_be(data.u16())
+
+  fun ref u32_le(data: U32): WriteBuffer^ =>
+    """
+    Write a U32 to the buffer in little-endian byte order.
+    """
+    _check(4)
+    _byte(data.u8())
+    _byte((data >> 8).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 24).u8())
+    this
+
+  fun ref u32_be(data: U32): WriteBuffer^ =>
+    """
+    Write a U32 to the buffer in big-endian byte order.
+    """
+    _check(4)
+    _byte((data >> 24).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 8).u8())
+    _byte(data.u8())
+    this
+
+  fun ref i32_le(data: I32): WriteBuffer^ =>
+    """
+    Write an I32 to the buffer in little-endian byte order.
+    """
+    u32_le(data.u32())
+
+  fun ref i32_be(data: I32): WriteBuffer^ =>
+    """
+    Write an I32 to the buffer in big-endian byte order.
+    """
+    u32_be(data.u32())
+
+  fun ref f32_le(data: F32): WriteBuffer^ =>
+    """
+    Write an F32 to the buffer in little-endian byte order.
+    """
+    u32_le(data.bits())
+
+  fun ref f32_be(data: F32): WriteBuffer^ =>
+    """
+    Write an F32 to the buffer in big-endian byte order.
+    """
+    u32_be(data.bits())
+
+  fun ref u64_le(data: U64): WriteBuffer^ =>
+    """
+    Write a U64 to the buffer in little-endian byte order.
+    """
+    _check(8)
+    _byte(data.u8())
+    _byte((data >> 8).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 24).u8())
+    _byte((data >> 32).u8())
+    _byte((data >> 40).u8())
+    _byte((data >> 48).u8())
+    _byte((data >> 56).u8())
+    this
+
+  fun ref u64_be(data: U64): WriteBuffer^ =>
+    """
+    Write a U64 to the buffer in big-endian byte order.
+    """
+    _check(8)
+    _byte((data >> 56).u8())
+    _byte((data >> 48).u8())
+    _byte((data >> 40).u8())
+    _byte((data >> 32).u8())
+    _byte((data >> 24).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 8).u8())
+    _byte(data.u8())
+    this
+
+  fun ref i64_le(data: I64): WriteBuffer^ =>
+    """
+    Write an I64 to the buffer in little-endian byte order.
+    """
+    u64_le(data.u64())
+
+  fun ref i64_be(data: I64): WriteBuffer^ =>
+    """
+    Write an I64 to the buffer in big-endian byte order.
+    """
+    u64_be(data.u64())
+
+  fun ref f64_le(data: F64): WriteBuffer^ =>
+    """
+    Write an F64 to the buffer in little-endian byte order.
+    """
+    u64_le(data.bits())
+
+  fun ref f64_be(data: F64): WriteBuffer^ =>
+    """
+    Write an F64 to the buffer in big-endian byte order.
+    """
+    u64_be(data.bits())
+
+  fun ref u128_le(data: U128): WriteBuffer^ =>
+    """
+    Write a U128 to the buffer in little-endian byte order.
+    """
+    _check(16)
+    _byte(data.u8())
+    _byte((data >> 8).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 24).u8())
+    _byte((data >> 32).u8())
+    _byte((data >> 40).u8())
+    _byte((data >> 48).u8())
+    _byte((data >> 56).u8())
+    _byte((data >> 64).u8())
+    _byte((data >> 72).u8())
+    _byte((data >> 80).u8())
+    _byte((data >> 88).u8())
+    _byte((data >> 96).u8())
+    _byte((data >> 104).u8())
+    _byte((data >> 112).u8())
+    _byte((data >> 120).u8())
+    this
+
+  fun ref u128_be(data: U128): WriteBuffer^ =>
+    """
+    Write a U128 to the buffer in big-endian byte order.
+    """
+    _check(16)
+    _byte((data >> 120).u8())
+    _byte((data >> 112).u8())
+    _byte((data >> 104).u8())
+    _byte((data >> 96).u8())
+    _byte((data >> 88).u8())
+    _byte((data >> 80).u8())
+    _byte((data >> 72).u8())
+    _byte((data >> 64).u8())
+    _byte((data >> 56).u8())
+    _byte((data >> 48).u8())
+    _byte((data >> 40).u8())
+    _byte((data >> 32).u8())
+    _byte((data >> 24).u8())
+    _byte((data >> 16).u8())
+    _byte((data >> 8).u8())
+    _byte(data.u8())
+    this
+
+  fun ref i128_le(data: I128): WriteBuffer^ =>
+    """
+    Write an I128 to the buffer in little-endian byte order.
+    """
+    u128_le(data.u128())
+
+  fun ref i128_be(data: I128): WriteBuffer^ =>
+    """
+    Write an I128 to the buffer in big-endian byte order.
+    """
+    u128_be(data.u128())
+
+  fun ref write(data: ByteSeq): WriteBuffer^ =>
+    """
+    Write a ByteSeq to the buffer.
+    """
+    _append_current()
+    _chunks.push(data)
+    _size = _size + data.size()
+    this
+
+  fun ref writev(data: ByteSeqIter): WriteBuffer^ =>
+    """
+    Write ByteSeqs to the buffer.
+    """
+    _append_current()
+    for chunk in data.values() do
+      _chunks.push(chunk)
+      _size = _size + chunk.size()
+    end
+    this
+
+  fun ref done(): Array[ByteSeq] iso^ =>
+    """
+    Return an array of buffered ByteSeqs and reset the WriteBuffer's buffer.
+    """
+    _append_current()
+    _size = 0
+    _chunks = recover Array[ByteSeq] end
+
+  fun ref _append_current() =>
+    if _offset > 0 then
+      _current.truncate(_offset)
+      _offset = 0
+      _chunks.push(_current = recover Array[U8] end)
+    end
+
+  fun ref _check(size': USize) =>
+    if (_current.size() - _offset) < size' then
+      _current.undefined(_offset + size')
+    end
+
+  fun ref _byte(data: U8) =>
+    try
+      _current(_offset) = data
+      _offset = _offset + 1
+      _size = _size + 1
+    end


### PR DESCRIPTION
The WriteBuffer provides a way to build messages using convenience
functions for common data encodings. It is complementary to the
ReadBuffer (formerly Buffer) which is used to extract information from
a message.

As part of this change I renamed Buffer to ReadBuffer to make its
purpose more clear.