### PR TITLE
Print error and info messages to stderr instead of stdout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `this->` adapted types check match on the upper bounds.
 - Renamed `identityof` to `digestof`.
 - Renamed `net/Buffer` to `net/ReadBuffer`
+- Print compiler error and info messages to stderr instead of stdout.
 
 ## [0.2.1] - 2015-10-06
 

--- a/src/libponyc/ast/error.c
+++ b/src/libponyc/ast/error.c
@@ -40,7 +40,7 @@ errors_t* errors_alloc()
 {
   errors_t* errors = POOL_ALLOC(errors_t);
   memset(errors, 0, sizeof(errors_t));
-  errors->output_stream = stdout;
+  errors->output_stream = stderr;
   return errors;
 }
 

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -225,7 +225,7 @@ static void ditch_restart(parser_t* parser, rule_state_t* state)
   assert(state->restart != NULL);
 
   if(trace_enable)
-    printf("Rule %s: Attempting recovery:\n", state->fn_name);
+    fprintf(stderr, "Rule %s: Attempting recovery:\n", state->fn_name);
 
   while(true)
   {
@@ -237,7 +237,7 @@ static void ditch_restart(parser_t* parser, rule_state_t* state)
       {
         // Legal token found
         if(trace_enable)
-          printf("  recovered with %s\n", token_print(parser->token));
+          fprintf(stderr, "  recovered with %s\n", token_print(parser->token));
 
         return;
       }
@@ -245,7 +245,7 @@ static void ditch_restart(parser_t* parser, rule_state_t* state)
 
     // Current token is not in legal set, ditch it
     if(trace_enable)
-      printf("  ignoring %d %s %s\n", id, lexer_print(id),
+      fprintf(stderr, "  ignoring %d %s %s\n", id, lexer_print(id),
         token_print(parser->token));
 
     consume_token_no_ast(parser);
@@ -266,7 +266,7 @@ static ast_t* propogate_error(parser_t* parser, rule_state_t* state)
   if(state->restart == NULL)
   {
     if(trace_enable)
-      printf("Rule %s: Propogate failure\n", state->fn_name);
+      fprintf(stderr, "Rule %s: Propogate failure\n", state->fn_name);
 
     return PARSE_ERROR;
   }
@@ -298,7 +298,7 @@ static ast_t* handle_found(parser_t* parser, rule_state_t* state,
   {
     // First token / sub rule in rule was found
     if(trace_enable)
-      printf("Rule %s: Matched\n", state->fn_name);
+      fprintf(stderr, "Rule %s: Matched\n", state->fn_name);
 
     state->matched = true;
   }
@@ -347,7 +347,7 @@ static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
   {
     // Rule not matched
     if(trace_enable)
-      printf("Rule %s: Not matched\n", state->fn_name);
+      fprintf(stderr, "Rule %s: Not matched\n", state->fn_name);
 
     ast_free(state->ast);
     state->ast = NULL;
@@ -356,7 +356,7 @@ static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
 
   // Rule partially matched, error
   if(trace_enable)
-    printf("Rule %s: Error\n", state->fn_name);
+    fprintf(stderr, "Rule %s: Error\n", state->fn_name);
 
   syntax_error(parser, desc, state->ast, terminating);
   parser->failed = true;
@@ -406,7 +406,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
 
   if(trace_enable)
   {
-    printf("Rule %s: Looking for %s token%s %s. Found %s. ",
+    fprintf(stderr, "Rule %s: Looking for %s token%s %s. Found %s. ",
       state->fn_name,
       (state->deflt_id == TK_LEX_ERROR) ? "required" : "optional",
       (id_set[1] == TK_NONE) ? "" : "s", desc,
@@ -427,7 +427,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
         *out_found = is_newline;
 
       if(trace_enable)
-        printf("\\n %smatched\n", is_newline ? "" : "not ");
+        fprintf(stderr, "\\n %smatched\n", is_newline ? "" : "not ");
 
       state->deflt_id = TK_LEX_ERROR;
       return PARSE_OK;
@@ -437,7 +437,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
     {
       // Current token matches one in set
       if(trace_enable)
-        printf("Compatible\n");
+        fprintf(stderr, "Compatible\n");
 
       parser->last_matched = token_print(parser->token);
 
@@ -453,7 +453,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
 
   // Current token does not match any in current set
   if(trace_enable)
-    printf("Not compatible\n");
+    fprintf(stderr, "Not compatible\n");
 
   return handle_not_found(parser, state, desc, terminating, out_found);
 }
@@ -486,7 +486,7 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
 
   if(trace_enable)
   {
-    printf("Rule %s: Looking for %s rule%s \"%s\"\n",
+    fprintf(stderr, "Rule %s: Looking for %s rule%s \"%s\"\n",
       state->fn_name,
       (state->deflt_id == TK_LEX_ERROR) ? "required" : "optional",
       (rule_set[1] == NULL) ? "" : "s", desc);
@@ -541,7 +541,7 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
     ast_scope(state->ast);
 
   if(trace_enable)
-    printf("Rule %s: Complete\n", state->fn_name);
+    fprintf(stderr, "Rule %s: Complete\n", state->fn_name);
 
   if(state->restart == NULL)
     return state->ast;
@@ -550,8 +550,8 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
   token_id id = current_token_id(parser);
 
   if(trace_enable)
-    printf("Rule %s: Check restart set for next token %s\n", state->fn_name,
-      token_print(parser->token));
+    fprintf(stderr, "Rule %s: Check restart set for next token %s\n",
+      state->fn_name, token_print(parser->token));
 
   for(const token_id* p = state->restart; *p != TK_NONE; p++)
   {
@@ -559,7 +559,7 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
     {
       // Legal token found
       if(trace_enable)
-        printf("Rule %s: Restart check successful\n", state->fn_name);
+        fprintf(stderr, "Rule %s: Restart check successful\n", state->fn_name);
 
       return state->ast;
     }
@@ -567,7 +567,7 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
 
   // Next token is not in restart set, error
   if(trace_enable)
-    printf("Rule %s: Restart check error\n", state->fn_name);
+    fprintf(stderr, "Rule %s: Restart check error\n", state->fn_name);
 
   assert(parser->token != NULL);
   error(parser->errors, parser->source, token_line_number(parser->token),

--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -38,7 +38,7 @@ static void error_preamble(ast_t* ast)
 {
   assert(ast != NULL);
 
-  printf("Internal error: AST node %d (%s), ", ast_id(ast),
+  fprintf(stderr, "Internal error: AST node %d (%s), ", ast_id(ast),
     ast_get_print(ast));
 }
 
@@ -115,10 +115,10 @@ static bool check_children(ast_t* ast, check_state_t* state,
   if(state->child == NULL)
   {
     error_preamble(ast);
-    printf("found " __zu " child%s, expected more\n", state->child_index,
+    fprintf(stderr, "found " __zu " child%s, expected more\n", state->child_index,
       (state->child_index == 1) ? "" : "ren");
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif
@@ -126,10 +126,10 @@ static bool check_children(ast_t* ast, check_state_t* state,
   else
   {
     error_preamble(ast);
-    printf("child " __zu " has invalid id %d\n", state->child_index,
+    fprintf(stderr, "child " __zu " has invalid id %d\n", state->child_index,
       ast_id(state->child));
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif
@@ -157,9 +157,9 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     if(state->type == NULL)
     {
       error_preamble(ast);
-      printf("unexpected type\n");
+      fprintf(stderr, "unexpected type\n");
       ast_error(state->errors, ast, "Here");
-      ast_print(ast);
+      ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
       assert(false);
 #endif
@@ -174,9 +174,9 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     if(r == CHK_NOT_FOUND)
     {
       error_preamble(ast);
-      printf("type field has invalid id %d\n", ast_id(type_field));
+      fprintf(stderr, "type field has invalid id %d\n", ast_id(type_field));
       ast_error(state->errors, ast, "Here");
-      ast_print(ast);
+      ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
       assert(false);
 #endif
@@ -187,10 +187,10 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
   if(state->child != NULL)
   {
     error_preamble(ast);
-    printf("child " __zu " (id %d, %s) unexpected\n", state->child_index,
+    fprintf(stderr, "child " __zu " (id %d, %s) unexpected\n", state->child_index,
       ast_id(state->child), ast_get_print(state->child));
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif
@@ -200,9 +200,9 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
   if(ast_data(ast) != NULL && !state->has_data)
   {
     error_preamble(ast);
-    printf("unexpected data %p\n", ast_data(ast));
+    fprintf(stderr, "unexpected data %p\n", ast_data(ast));
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif
@@ -212,9 +212,9 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
   if(ast_has_scope(ast) && !state->is_scope)
   {
     error_preamble(ast);
-    printf("unexpected scope\n");
+    fprintf(stderr, "unexpected scope\n");
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif
@@ -224,9 +224,9 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
   if(!ast_has_scope(ast) && state->is_scope)
   {
     error_preamble(ast);
-    printf("expected scope not found\n");
+    fprintf(stderr, "expected scope not found\n");
     ast_error(state->errors, ast, "Here");
-    ast_print(ast);
+    ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
     assert(false);
 #endif

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -525,7 +525,8 @@ void codegen_shutdown(pass_opt_t* opt)
 
 bool codegen(ast_t* program, pass_opt_t* opt)
 {
-  PONY_LOG(opt, VERBOSITY_MINIMAL, ("Generating\n"));
+  if(opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Generating\n");
 
   pony_mkdir(opt->output);
 

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -202,7 +202,8 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* file_exe =
     suffix_filename(c, c->opt->output, "", c->filename, "");
 
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Linking %s\n", file_exe);
 
   program_lib_build_args(program, c->opt, "-L", NULL, "", "", "-l", "");
   const char* lib_args = program_lib_args(program);
@@ -219,7 +220,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     (int)arch_len, c->opt->triple, file_exe, file_o, lib_args
     );
 
-  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
+  if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
+    fprintf(stderr, "%s\n", ld_cmd);
 
   if(system(ld_cmd) != 0)
   {
@@ -250,7 +252,8 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* file_exe =
     suffix_filename(c, c->opt->output, "", c->filename, "");
 
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Linking %s\n", file_exe);
 
   program_lib_build_args(program, c->opt, "-L", "-Wl,-rpath,",
     "-Wl,--start-group ", "-Wl,--end-group ", "-l", "");
@@ -279,7 +282,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     file_exe, file_o, lib_args
     );
 
-  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
+  if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
+    fprintf(stderr, "%s\n", ld_cmd);
 
   if(system(ld_cmd) != 0)
   {
@@ -300,7 +304,8 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   const char* file_exe = suffix_filename(c, c->opt->output, "", c->filename,
     ".exe");
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Linking %s\n", file_exe));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Linking %s\n", file_exe);
 
   program_lib_build_args(program, c->opt,
     "/LIBPATH:", NULL, "", "", "", ".lib");
@@ -330,7 +335,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
   }
 
-  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", ld_cmd));
+  if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
+    fprintf(stderr, "%s\n", ld_cmd);
 
   if (system(ld_cmd) == -1)
   {
@@ -369,11 +375,13 @@ bool genexe(compile_t* c, ast_t* program)
   if(lookup(NULL, main_ast, main_ast, c->str_create) == NULL)
     return false;
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Reachability\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Reachability\n");
   reach(c->reach, main_ast, c->str_create, NULL, c->opt);
   reach(c->reach, env_ast, c->str__create, NULL, c->opt);
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Selector painting\n");
   paint(&c->reach->types);
 
   if(c->opt->verbosity >= VERBOSITY_ALL)

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -51,7 +51,8 @@ static bool reachable_actors(compile_t* c, ast_t* program)
 {
   errors_t* errors = c->opt->check.errors;
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Library reachability\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Library reachability\n");
 
   // Look for C-API actors in every package.
   bool found = false;
@@ -96,7 +97,8 @@ static bool reachable_actors(compile_t* c, ast_t* program)
     return false;
   }
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Selector painting\n");
   paint(&c->reach->types);
   return true;
 }
@@ -108,7 +110,8 @@ static bool link_lib(compile_t* c, const char* file_o)
 #if defined(PLATFORM_IS_POSIX_BASED)
   const char* file_lib = suffix_filename(c, c->opt->output, "lib", c->filename,
     ".a");
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Archiving %s\n", file_lib));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Archiving %s\n", file_lib);
 
   size_t len = 32 + strlen(file_lib) + strlen(file_o);
   char* cmd = (char*)ponyint_pool_alloc_size(len);
@@ -119,7 +122,8 @@ static bool link_lib(compile_t* c, const char* file_o)
   snprintf(cmd, len, "ar -rcs %s %s", file_lib, file_o);
 #endif
 
-  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", cmd));
+  if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
+    fprintf(stderr, "%s\n", cmd);
   if(system(cmd) != 0)
   {
     errorf(errors, NULL, "unable to link: %s", cmd);
@@ -131,7 +135,8 @@ static bool link_lib(compile_t* c, const char* file_o)
 #elif defined(PLATFORM_IS_WINDOWS)
   const char* file_lib = suffix_filename(c, c->opt->output, "", c->filename,
     ".lib");
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Archiving %s\n", file_lib));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Archiving %s\n", file_lib));
 
   vcvars_t vcvars;
 
@@ -147,7 +152,8 @@ static bool link_lib(compile_t* c, const char* file_o)
   snprintf(cmd, len, "cmd /C \"\"%s\" /NOLOGO /OUT:%s %s\"", vcvars.ar,
     file_lib, file_o);
 
-  PONY_LOG(c->opt, VERBOSITY_TOOL_INFO, ("%s\n", cmd));
+  if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
+    fprintf(stderr, "%s\n", cmd));
   if(system(cmd) == -1)
   {
     errorf(errors, NULL, "unable to link: %s", cmd);

--- a/src/libponyc/codegen/genobj.c
+++ b/src/libponyc/codegen/genobj.c
@@ -17,7 +17,8 @@ const char* genobj(compile_t* c)
   {
     const char* file_o = suffix_filename(c, c->opt->output, "", c->filename,
       ".ll");
-    PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Writing %s\n", file_o));
+    if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+      fprintf(stderr, "Writing %s\n", file_o);
 
     char* err;
 
@@ -35,7 +36,8 @@ const char* genobj(compile_t* c)
   {
     const char* file_o = suffix_filename(c, c->opt->output, "", c->filename,
       ".bc");
-    PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Writing %s\n", file_o));
+    if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+      fprintf(stderr, "Writing %s\n", file_o);
 
     if(LLVMWriteBitcodeToFile(c->module, file_o) != 0)
     {
@@ -62,7 +64,8 @@ const char* genobj(compile_t* c)
 #endif
   }
 
-  PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Writing %s\n", file_o));
+  if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+    fprintf(stderr, "Writing %s\n", file_o);
   char* err;
 
   if(LLVMTargetMachineEmitToFile(

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -519,7 +519,8 @@ static void optimise(compile_t* c)
 
   if(c->opt->release)
   {
-    PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Optimising\n"));
+    if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+      fprintf(stderr, "Optimising\n");
 
     pmb.OptLevel = 3;
     pmb.Inliner = createFunctionInliningPass(275);
@@ -591,7 +592,8 @@ bool genopt(compile_t* c)
 
   if(c->opt->verify)
   {
-    PONY_LOG(c->opt, VERBOSITY_MINIMAL, ("Verifying\n"));
+    if(c->opt->verbosity >= VERBOSITY_MINIMAL)
+      fprintf(stderr, "Verifying\n");
     
     char* msg = NULL;
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -574,7 +574,8 @@ bool gentypes(compile_t* c)
 
   genprim_builtins(c);
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Data prototypes\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Data prototypes\n");
   i = HASHMAP_BEGIN;
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
@@ -589,7 +590,8 @@ bool gentypes(compile_t* c)
     gentrace_prototype(c, t);
   }
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Data types\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Data types\n");
   i = HASHMAP_BEGIN;
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
@@ -600,7 +602,8 @@ bool gentypes(compile_t* c)
     make_global_instance(c, t);
   }
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Function prototypes\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Function prototypes\n");
   i = HASHMAP_BEGIN;
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
@@ -612,7 +615,8 @@ bool gentypes(compile_t* c)
       return false;
   }
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Functions\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Functions\n");
   i = HASHMAP_BEGIN;
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
@@ -621,7 +625,8 @@ bool gentypes(compile_t* c)
       return false;
   }
 
-  PONY_LOG(c->opt, VERBOSITY_INFO, (" Descriptors\n"));
+  if(c->opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, " Descriptors\n");
   i = HASHMAP_BEGIN;
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1072,7 +1072,8 @@ static void doc_setup_dirs(docgen_t* docgen, ast_t* program, pass_opt_t* opt)
   docgen->sub_dir = doc_cat(docgen->base_dir, "docs/", "", "", "",
     &docgen->sub_dir_buf_len);
 
-  PONY_LOG(opt, VERBOSITY_INFO, ("Writing docs to %s\n", docgen->base_dir));
+  if(opt->verbosity >= VERBOSITY_INFO)
+    fprintf(stderr, "Writing docs to %s\n", docgen->base_dir);
 
   // Create and clear out base directory
   pony_mkdir(docgen->base_dir);

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -105,7 +105,7 @@ void pass_opt_done(pass_opt_t* options)
 
   if(options->print_stats)
   {
-    printf(
+    fprintf(stderr,
       "\nStats:"
       "\n  Names: " __zu
       "\n  Default caps: " __zu
@@ -156,8 +156,8 @@ static bool visit_pass(ast_t** astp, pass_opt_t* options, pass_id last_pass,
     return false;
   }
 
-  //printf("Pass %s (last %s) on %s\n", pass_name(pass), pass_name(last_pass),
-  //  ast_get_print(*astp));
+  //fprintf(stderr, "Pass %s (last %s) on %s\n", pass_name(pass),
+  //  pass_name(last_pass), ast_get_print(*astp));
 
   if(ast_visit(astp, pre_fn, post_fn, options, pass) != AST_OK)
   {

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -154,9 +154,6 @@ typedef enum verbosity_level
   VERBOSITY_ALL       = 4
 } verbosity_level;
 
-#define PONY_LOG(opt, level, args) \
-        { if((opt)->verbosity >= (level)) { printf args ;} }
-
 typedef enum pass_id
 {
   PASS_PARSE,

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -99,7 +99,7 @@ static void cond_normalise(ast_t** astp)
       break;
 
     default:
-      ast_print(ast);
+      ast_fprint(stderr, ast);
       assert(0);
       break;
   }
@@ -156,7 +156,7 @@ static bool cond_eval(ast_t* ast, buildflagset_t* config, bool release,
     }
 
     default:
-      ast_print(ast);
+      ast_fprint(stderr, ast);
       assert(0);
       return false;
   }
@@ -196,7 +196,7 @@ static void find_flags_in_cond(ast_t* ast, buildflagset_t* config)
     }
 
     default:
-      ast_print(ast);
+      ast_fprint(stderr, ast);
       assert(0);
       break;
   }

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -857,7 +857,8 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt)
   package = create_package(program, full_path, qualified_name);
 
   if(report_build) {
-    PONY_LOG(opt, VERBOSITY_INFO, ("Building %s -> %s\n", path, full_path));
+    if(opt->verbosity >= VERBOSITY_INFO)
+      fprintf(stderr, "Building %s -> %s\n", path, full_path);
   }
 
   if(magic != NULL)

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -215,10 +215,10 @@ static bool compile_package(const char* path, pass_opt_t* opt,
     return false;
 
   if(print_program_ast)
-    ast_print(program);
+    ast_fprint(stderr, program);
 
   if(print_package_ast)
-    ast_print(ast_child(program));
+    ast_fprint(stderr, ast_child(program));
 
   bool ok = generate_passes(program, opt);
   ast_free(program);


### PR DESCRIPTION
Currently, all error and info and diagnostic output is logged to stdout.  This is a problem for dumping ASTs from earlier passes, which are also sent to stdout.  It seems more correct to dump AST output to stdout (as output of the program), and send all errors and info and out-of-band compiler messages to stderr.