### PR TITLE
Serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - GC tracing with acquire/release semantics.
 - pony_alloc_msg_size runtime function
 - `net/WriteBuffer`
+- `serialise` package.
 
 ### Changed
 

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -74,7 +74,7 @@ class Array[A] is Seq[A]
     the array.
     """
     if _alloc < len then
-      _alloc = len.max(8).ponyint_next_pow2()
+      _alloc = len
       _ptr = _ptr._realloc(_alloc)
     end
     this
@@ -85,11 +85,7 @@ class Array[A] is Seq[A]
     Resize to len elements, populating previously empty elements with random
     memory. This is only allowed for an array of numbers.
     """
-    if _alloc < len then
-      _ptr = _ptr._realloc(len)
-    end
-
-    _alloc = len
+    reserve(len)
     _size = len
     this
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -38,6 +38,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
       _alloc = _size + 1
       _ptr = Pointer[U8]._alloc(_alloc)
       data._cstring()._copy_to(_ptr, _alloc)
+      _set(_size, 0)
     end
 
   new from_cstring(str: Pointer[U8], len: USize = 0) =>

--- a/packages/builtin/uint.pony
+++ b/packages/builtin/uint.pony
@@ -5,7 +5,7 @@ primitive U8 is _UnsignedInteger[U8]
   fun tag min_value(): U8 => 0
   fun tag max_value(): U8 => 0xFF
 
-  fun ponyint_next_pow2(): U8 =>
+  fun next_pow2(): U8 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -35,7 +35,7 @@ primitive U16 is _UnsignedInteger[U16]
   fun tag min_value(): U16 => 0
   fun tag max_value(): U16 => 0xFFFF
 
-  fun ponyint_next_pow2(): U16 =>
+  fun next_pow2(): U16 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -66,7 +66,7 @@ primitive U32 is _UnsignedInteger[U32]
   fun tag min_value(): U32 => 0
   fun tag max_value(): U32 => 0xFFFF_FFFF
 
-  fun ponyint_next_pow2(): U32 =>
+  fun next_pow2(): U32 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -98,7 +98,7 @@ primitive U64 is _UnsignedInteger[U64]
   fun tag min_value(): U64 => 0
   fun tag max_value(): U64 => 0xFFFF_FFFF_FFFF_FFFF
 
-  fun ponyint_next_pow2(): U64 =>
+  fun next_pow2(): U64 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -137,7 +137,7 @@ primitive ULong is _UnsignedInteger[ULong]
       0xFFFF_FFFF_FFFF_FFFF
     end
 
-  fun ponyint_next_pow2(): ULong =>
+  fun next_pow2(): ULong =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -219,7 +219,7 @@ primitive USize is _UnsignedInteger[USize]
       0xFFFF_FFFF_FFFF_FFFF
     end
 
-  fun ponyint_next_pow2(): USize =>
+  fun next_pow2(): USize =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -295,7 +295,7 @@ primitive U128 is _UnsignedInteger[U128]
   fun tag min_value(): U128 => 0
   fun tag max_value(): U128 => 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
-  fun ponyint_next_pow2(): U128 =>
+  fun next_pow2(): U128 =>
     var x = this - 1
     x = x or (x >> 1)
     x = x or (x >> 2)
@@ -315,7 +315,7 @@ primitive U128 is _UnsignedInteger[U128]
   fun min(y: U128): U128 => if this < y then this else y end
   fun max(y: U128): U128 => if this > y then this else y end
   fun hash(): U64 => ((this >> 64).u64() xor this.u64()).hash()
-    
+
   fun string(
     fmt: FormatSettings[FormatInt, PrefixNumber] = FormatDefaultNumber)
     : String iso^

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -27,7 +27,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     resize. Defaults to 6.
     """
     let len = (prealloc * 4) / 3
-    let n = len.ponyint_next_pow2().max(8)
+    let n = len.max(8).next_pow2()
     _array = _array.init(_MapEmpty, n)
 
   fun size(): USize =>
@@ -188,7 +188,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     """
     Minimise the memory used for the map.
     """
-    _resize(((_size * 4) / 3).ponyint_next_pow2().max(8))
+    _resize(((_size * 4) / 3).next_pow2().max(8))
     this
 
   fun clone[H2: HashFunction[this->K!] val = H]():

--- a/packages/collections/ringbuffer.pony
+++ b/packages/collections/ringbuffer.pony
@@ -11,7 +11,7 @@ class RingBuffer[A]
     Create a ring buffer with a fixed size. The size will be rounded up to the
     next power of 2.
     """
-    let n = len.max(2).ponyint_next_pow2()
+    let n = len.max(2).next_pow2()
     _mod = n - 1
     _array = Array[A](n)
 

--- a/packages/net/tcpconnection.pony
+++ b/packages/net/tcpconnection.pony
@@ -405,7 +405,7 @@ actor TCPConnection
         @pony_os_recv[USize](
           _event,
           _read_buf.cstring().usize() + _read_len,
-          _read_buf.space() - _read_len) ?
+          _read_buf.size() - _read_len) ?
       else
         _hard_close()
       end
@@ -426,7 +426,7 @@ actor TCPConnection
           let len = @pony_os_recv[USize](
             _event,
             _read_buf.cstring().usize() + _read_len,
-            _read_buf.space() - _read_len) ?
+            _read_buf.size() - _read_len) ?
 
           match len
           | 0 =>

--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -1,0 +1,84 @@
+"""
+# Serialise package
+
+This package provides support for serialising and deserialising arbitrary data
+structures.
+"""
+
+primitive SerialiseAuth
+  """
+  This is a capability that allows the holder to serialise objects. It does not
+  allow the holder to examine serialised data or to deserialise objects.
+  """
+  new create(auth: AmbientAuth) =>
+    None
+
+primitive DeserialiseAuth
+  """
+  This is a capability token that allows the holder to deserialise objects. It
+  does not allow the holder to serialise objects or examine serialised.
+  """
+  new create(auth: AmbientAuth) =>
+    None
+
+primitive OutputSerialisedAuth
+  """
+  This is a capability token that allows the holder to examine serialised data.
+  This should only be provided to types that need to write serialised data to
+  some output stream, such as a file or socket. A type with the SerialiseAuth
+  capability should usually not also have OutputSerialisedAuth, as the
+  combination gives the holder the ability to examine the bitwise contents of
+  any object it has a reference to.
+  """
+  new create(auth: AmbientAuth) =>
+    None
+
+primitive InputSerialisedAuth
+  """
+  This is a capability token that allows the holder to treat data arbitrary
+  bytes as serialised data. This is the most dangerous capability, as currently
+  it is possible for a malformed chunk of data to crash your program if it is
+  deserialised.
+  """
+  new create(auth: AmbientAuth) =>
+    None
+
+class val Serialised
+  """
+  This represents serialised data. How it can be used depends on the other
+  capabilities a caller holds.
+  """
+  let _data: Array[U8] val
+
+  new create(auth: SerialiseAuth, data: Any box) ? =>
+    """
+    A caller with SerialiseAuth can create serialised data from any object.
+    """
+    let r = recover Array[U8] end
+    @pony_serialise[None](@pony_ctx[Pointer[None]](), data, r) ?
+    _data = consume r
+
+  new input(auth: InputSerialisedAuth, data: Array[U8] val) =>
+    """
+    A caller with InputSerialisedAuth can create serialised data from any
+    arbitrary set of bytes. It is the caller's responsibility to ensure that
+    the data is in fact well-formed serialised data. This is currently the most
+    dangerous method, as there is currently no way to check validity at
+    runtime.
+    """
+    _data = data
+
+  fun apply(auth: DeserialiseAuth): Any iso^ ? =>
+    """
+    A caller with DeserialiseAuth can create an object graph from serialised
+    data.
+    """
+    @pony_deserialise[Any iso^](@pony_ctx[Pointer[None]](), _data) ?
+
+  fun output(auth: OutputSerialisedAuth): Array[U8] val =>
+    """
+    A caller with OutputSerialisedAuth can gain access to the underlying bytes
+    that contain the serialised data. This can be used to write those bytes to,
+    for example, a file or socket.
+    """
+    _data

--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -3,6 +3,23 @@
 
 This package provides support for serialising and deserialising arbitrary data
 structures.
+
+The API is designed to require capability tokens, as otherwise serialising
+would leak the bit patterns of all private information in a type (since the
+resulting Array[U8] could be examined.
+
+Deserialisation is fundamentally unsafe currently: there isn't yet a
+verification pass to check that the resulting object graph maintains a
+well-formed heap or that individual objects maintain any expected local
+invariants. However, if only "trusted" data (i.e. data produced by Pony
+serialisation from the same binary) is deserialised, it will always maintain a
+well-formed heap and all object invariants.
+
+Note that serialised data is not usable between different Pony binaries,
+possibly including recompilation of the same code. This is due to the use of
+type identifiers rather than a heavy-weight self-describing serialisation
+schema. This also means it isn't safe to deserialise something serialised by
+the same program compiled for a different platform.
 """
 
 primitive SerialiseAuth

--- a/packages/serialise/test.pony
+++ b/packages/serialise/test.pony
@@ -1,0 +1,167 @@
+use "ponytest"
+
+actor Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    /*
+    TODO:
+    arrays of classes
+    arrays of structs
+    arrays of tuples
+    arrays of union types
+    arrays of tags
+    no pointers
+    no actors
+    */
+    test(_TestSimple)
+    test(_TestArrays)
+
+class _MachineWords
+  var bool1: Bool = true
+  var bool2: Bool = false
+  var i8: I8 = 0x3
+  var i16: I16 = 0x7BCD
+  var i32: I32 = 0x12345678
+  var i64: I64 = 0x7EDCBA9876543210
+  var i128: I128 = 0x7EDCBA9876543210123456789ABCDEFE
+  var ilong: ILong = 1 << (ILong.bitwidth() - 1)
+  var isize: ISize = 1 << (ISize.bitwidth() - 1)
+  var f32: F32 = 1.2345e-13
+  var f64: F64 = 9.82643431e19
+
+  fun eq(that: _MachineWords box): Bool =>
+    (bool1 == that.bool1) and
+    (bool2 == that.bool2) and
+    (i8 == that.i8) and
+    (i16 == that.i16) and
+    (i32 == that.i32) and
+    (i64 == that.i64) and
+    (i128 == that.i128) and
+    (ilong == that.ilong) and
+    (isize == that.isize) and
+    (f32 == that.f32) and
+    (f64 == that.f64)
+
+class _StructWords
+  var u8: U8 = 0x3
+  var u16: U16 = 0xABCD
+  var u32: U32 = 0x12345678
+  var u64: U64 = 0xFEDCBA9876543210
+  var u128: U128 = 0xFEDCBA9876543210123456789ABCDEFE
+  var ulong: ULong = 1 << (ULong.bitwidth() - 1)
+  var usize: USize = 1 << (USize.bitwidth() - 1)
+
+  fun eq(that: _StructWords box): Bool =>
+    (u8 == that.u8) and
+    (u16 == that.u16) and
+    (u32 == that.u32) and
+    (u64 == that.u64) and
+    (u128 == that.u128) and
+    (ulong == that.ulong) and
+    (usize == that.usize)
+
+class _Simple
+  var words1: _MachineWords = _MachineWords
+  embed words2: _MachineWords = _MachineWords
+  var words3: _StructWords = _StructWords
+  embed words4: _StructWords = _StructWords
+  var words5: (Any ref | None) = _MachineWords
+  var words6: (Any ref | None) = None
+  var string: String = "hello"
+  var none: None = None
+  var fmt: FormatInt = FormatOctal
+  var tuple: (U64, String) = (99, "goodbye")
+  var tuple2: ((U64, String) | None) = (101, "awesome")
+  var a_tag: _MachineWords tag = words1
+  var a_ref: _MachineWords = words1
+
+  fun eq(that: _Simple): Bool =>
+    (words1 == that.words1) and
+    (words2 == that.words2) and
+    (words3 == that.words3) and
+    (words4 == that.words4) and
+    try
+      (words5 as _MachineWords box) == (that.words5 as _MachineWords box)
+    else
+      false
+    end and
+    (words6 is that.words6) and
+    (string == that.string) and
+    (none is that.none) and
+    (fmt is that.fmt) and
+    (tuple._1 == that.tuple._1) and
+    (tuple._2 == that.tuple._2) and
+    try
+      let x = tuple2 as (U64, String)
+      let y = that.tuple2 as (U64, String)
+      (x._1 == y._1) and (x._2 == y._2)
+    else
+      false
+    end and
+    (a_tag isnt that.a_tag) and
+    (a_tag is words1) and
+    (that.a_tag is that.words1) and
+    (a_ref == that.a_ref) and
+    (a_ref is words1) and
+    (that.a_ref is that.words1)
+
+class iso _TestSimple is UnitTest
+  """
+  Test serialising simple fields.
+  """
+  fun name(): String => "serialise/Simple"
+
+  fun apply(h: TestHelper) ? =>
+    let ambient = h.env.root as AmbientAuth
+    let serialise = SerialiseAuth(ambient)
+    let deserialise = DeserialiseAuth(ambient)
+
+    let x: _Simple = _Simple
+    let sx = Serialised(serialise, x)
+    let y = sx(deserialise) as _Simple
+    h.assert_true(x isnt y)
+    h.assert_true(x == y)
+
+class iso _TestArrays is UnitTest
+  """
+  Test serialising arrays.
+  """
+  fun name(): String => "serialise/Arrays"
+
+  fun apply(h: TestHelper) ? =>
+    let ambient = h.env.root as AmbientAuth
+    let serialise = SerialiseAuth(ambient)
+    let deserialise = DeserialiseAuth(ambient)
+
+    let x1: Array[U128] = [1, 2, 3]
+    var sx = Serialised(serialise, x1)
+    let y1 = sx(deserialise) as Array[U128]
+    h.assert_true(x1 isnt y1)
+    h.assert_array_eq[U128](x1, y1)
+
+    let x2: Array[Bool] = [true, false, true]
+    sx = Serialised(serialise, x2)
+    let y2 = sx(deserialise) as Array[Bool]
+    h.assert_true(x2 isnt y2)
+    h.assert_array_eq[Bool](x2, y2)
+
+    let x3: Array[U32] = [1, 2, 3]
+    sx = Serialised(serialise, x3)
+    let y3 = sx(deserialise) as Array[U32]
+    h.assert_true(x3 isnt y3)
+    h.assert_array_eq[U32](x3, y3)
+
+    let x4: Array[(U16, Bool)] = [(1, true), (2, false), (3, true)]
+    sx = Serialised(serialise, x4)
+    let y4 = sx(deserialise) as Array[(U16, Bool)]
+    h.assert_true(x4 isnt y4)
+
+    var i = USize(0)
+
+    while i < x4.size() do
+      h.assert_eq[U16](x4(i)._1, y4(i)._1)
+      h.assert_eq[Bool](x4(i)._2, y4(i)._2)
+      i = i + 1
+    end

--- a/packages/stdlib/test.pony
+++ b/packages/stdlib/test.pony
@@ -40,6 +40,7 @@ use strings = "strings"
 use term = "term"
 use time = "time"
 use itertools = "itertools"
+use serialise = "serialise"
 
 
 actor Main is TestList
@@ -69,7 +70,7 @@ actor Main is TestList
       // The process package currently only supports posix
       process.Main.make().tests(test)
     end
-    
+
     regex.Main.make().tests(test)
 
     ifdef not windows then
@@ -81,3 +82,4 @@ actor Main is TestList
     strings.Main.make().tests(test)
     time.Main.make().tests(test)
     itertools.Main.make().tests(test)
+    serialise.Main.make().tests(test)

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -189,6 +189,14 @@ static void init_runtime(compile_t* c)
   c->trace_type = LLVMFunctionType(c->void_type, params, 2, false);
   c->trace_fn = LLVMPointerType(c->trace_type, 0);
 
+  // serialise
+  // void (*)(i8*, __object*, i8*)
+  params[0] = c->void_ptr;
+  params[1] = c->object_ptr;
+  params[2] = c->void_ptr;
+  c->serialise_type = LLVMFunctionType(c->void_type, params, 3, false);
+  c->serialise_fn = LLVMPointerType(c->serialise_type, 0);
+
   // dispatch
   // void (*)(i8*, __object*, $message*)
   params[0] = c->void_ptr;

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -369,6 +369,13 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_serialise_offset", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
+  // i8* pony_deserialise_offset(i8*, __desc*, intptr)
+  params[0] = c->void_ptr;
+  params[1] = c->descriptor_ptr;
+  params[2] = c->intptr;
+  type = LLVMFunctionType(c->void_ptr, params, 3, false);
+  value = LLVMAddFunction(c->module, "pony_deserialise_offset", type);
+
   // i32 pony_init(i32, i8**)
   params[0] = c->i32;
   params[1] = LLVMPointerType(c->void_ptr, 0);

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -190,11 +190,12 @@ static void init_runtime(compile_t* c)
   c->trace_fn = LLVMPointerType(c->trace_type, 0);
 
   // serialise
-  // void (*)(i8*, __object*, i8*)
+  // void (*)(i8*, __object*, i8*, i32)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->void_ptr;
-  c->serialise_type = LLVMFunctionType(c->void_type, params, 3, false);
+  params[3] = c->i32;
+  c->serialise_type = LLVMFunctionType(c->void_type, params, 4, false);
   c->serialise_fn = LLVMPointerType(c->serialise_type, 0);
 
   // dispatch

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -151,7 +151,7 @@ static void init_runtime(compile_t* c)
   c->str__event_notify = stringtab("_event_notify");
 
   LLVMTypeRef type;
-  LLVMTypeRef params[4];
+  LLVMTypeRef params[5];
   LLVMValueRef value;
 
   c->void_type = LLVMVoidTypeInContext(c->context);
@@ -190,12 +190,13 @@ static void init_runtime(compile_t* c)
   c->trace_fn = LLVMPointerType(c->trace_type, 0);
 
   // serialise
-  // void (*)(i8*, __object*, i8*, i32)
+  // void (*)(i8*, __object*, i8*, intptr, i32)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->void_ptr;
-  params[3] = c->i32;
-  c->serialise_type = LLVMFunctionType(c->void_type, params, 4, false);
+  params[3] = c->intptr;
+  params[4] = c->i32;
+  c->serialise_type = LLVMFunctionType(c->void_type, params, 5, false);
   c->serialise_fn = LLVMPointerType(c->serialise_type, 0);
 
   // dispatch
@@ -355,16 +356,17 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_recv_done", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_serialise_size(i8*, intptr)
+  // void pony_serialise_reserve(i8*, i8*, intptr)
   params[0] = c->void_ptr;
-  params[1] = c->intptr;
-  type = LLVMFunctionType(c->void_type, params, 2, false);
-  value = LLVMAddFunction(c->module, "pony_serialise_size", type);
+  params[1] = c->void_ptr;
+  params[2] = c->intptr;
+  type = LLVMFunctionType(c->void_type, params, 3, false);
+  value = LLVMAddFunction(c->module, "pony_serialise_reserve", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // intptr pony_serialise_offset(i8*, __object*)
+  // intptr pony_serialise_offset(i8*, i8*)
   params[0] = c->void_ptr;
-  params[1] = c->object_ptr;
+  params[1] = c->void_ptr;
   type = LLVMFunctionType(c->intptr, params, 2, false);
   value = LLVMAddFunction(c->module, "pony_serialise_offset", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
@@ -375,6 +377,13 @@ static void init_runtime(compile_t* c)
   params[2] = c->intptr;
   type = LLVMFunctionType(c->void_ptr, params, 3, false);
   value = LLVMAddFunction(c->module, "pony_deserialise_offset", type);
+
+  // i8* pony_deserialise_block(i8*, intptr, intptr)
+  params[0] = c->void_ptr;
+  params[1] = c->intptr;
+  params[2] = c->intptr;
+  type = LLVMFunctionType(c->void_ptr, params, 3, false);
+  value = LLVMAddFunction(c->module, "pony_deserialise_block", type);
 
   // i32 pony_init(i32, i8**)
   params[0] = c->i32;

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -119,6 +119,7 @@ static void init_runtime(compile_t* c)
   c->str_Pointer = stringtab("Pointer");
   c->str_Maybe = stringtab("MaybePointer");
   c->str_Array = stringtab("Array");
+  c->str_String = stringtab("String");
   c->str_Platform = stringtab("Platform");
   c->str_Main = stringtab("Main");
   c->str_Env = stringtab("Env");
@@ -182,21 +183,21 @@ static void init_runtime(compile_t* c)
   LLVMStructSetBody(c->msg_type, params, 2, false);
 
   // trace
-  // void (*)(i8*, $object*)
+  // void (*)(i8*, __object*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   c->trace_type = LLVMFunctionType(c->void_type, params, 2, false);
   c->trace_fn = LLVMPointerType(c->trace_type, 0);
 
   // dispatch
-  // void (*)(i8*, $object*, $message*)
+  // void (*)(i8*, __object*, $message*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->msg_ptr;
   c->dispatch_type = LLVMFunctionType(c->void_type, params, 3, false);
   c->dispatch_fn = LLVMPointerType(c->dispatch_type, 0);
 
-  // void (*)($object*)
+  // void (*)(__object*)
   params[0] = c->object_ptr;
   c->final_fn = LLVMPointerType(
     LLVMFunctionType(c->void_type, params, 1, false), 0);
@@ -225,7 +226,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_ctx", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // $object* pony_create(i8*, $desc*)
+  // __object* pony_create(i8*, __Desc*)
   params[0] = c->void_ptr;
   params[1] = c->descriptor_ptr;
   type = LLVMFunctionType(c->object_ptr, params, 2, false);
@@ -233,13 +234,13 @@ static void init_runtime(compile_t* c)
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
 
-  // void ponyint_destroy($object*)
+  // void ponyint_destroy(__object*)
   params[0] = c->object_ptr;
   type = LLVMFunctionType(c->void_type, params, 1, false);
   value = LLVMAddFunction(c->module, "ponyint_destroy", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_sendv(i8*, $object*, $message*);
+  // void pony_sendv(i8*, __object*, $message*);
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->msg_ptr;
@@ -304,23 +305,23 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_trace", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_traceactor(i8*, $object*)
+  // void pony_traceactor(i8*, __object*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   type = LLVMFunctionType(c->void_type, params, 2, false);
   value = LLVMAddFunction(c->module, "pony_traceactor", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // i8* pony_traceobject(i8*, $object*, trace_fn, i32)
+  // i8* pony_traceobject(i8*, __object*, __Desc*, i32)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
-  params[2] = c->trace_fn;
+  params[2] = c->descriptor_ptr;
   params[3] = c->i32;
   type = LLVMFunctionType(c->void_ptr, params, 4, false);
   value = LLVMAddFunction(c->module, "pony_traceobject", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // i8* pony_traceunknown(i8*, $object*, i32)
+  // i8* pony_traceunknown(i8*, __object*, i32)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->i32;
@@ -328,7 +329,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_traceunknown", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_trace_tag_or_actor(i8*, $object*)
+  // void pony_trace_tag_or_actor(i8*, __object*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   type = LLVMFunctionType(c->void_type, params, 2, false);
@@ -366,7 +367,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_init", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_become(i8*, $object*)
+  // void pony_become(i8*, __object*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   type = LLVMFunctionType(c->void_type, params, 2, false);

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -354,6 +354,20 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_recv_done", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
+  // void pony_serialise_size(i8*, intptr)
+  params[0] = c->void_ptr;
+  params[1] = c->intptr;
+  type = LLVMFunctionType(c->void_type, params, 2, false);
+  value = LLVMAddFunction(c->module, "pony_serialise_size", type);
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+
+  // intptr pony_serialise_offset(i8*, __object*)
+  params[0] = c->void_ptr;
+  params[1] = c->object_ptr;
+  type = LLVMFunctionType(c->intptr, params, 2, false);
+  value = LLVMAddFunction(c->module, "pony_serialise_offset", type);
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+
   // i32 pony_init(i32, i8**)
   params[0] = c->i32;
   params[1] = LLVMPointerType(c->void_ptr, 0);

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -305,20 +305,13 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_trace", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // void pony_traceactor(i8*, __object*)
-  params[0] = c->void_ptr;
-  params[1] = c->object_ptr;
-  type = LLVMFunctionType(c->void_type, params, 2, false);
-  value = LLVMAddFunction(c->module, "pony_traceactor", type);
-  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
-
   // i8* pony_traceobject(i8*, __object*, __Desc*, i32)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->descriptor_ptr;
   params[3] = c->i32;
   type = LLVMFunctionType(c->void_ptr, params, 4, false);
-  value = LLVMAddFunction(c->module, "pony_traceobject", type);
+  value = LLVMAddFunction(c->module, "pony_traceknown", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
   // i8* pony_traceunknown(i8*, __object*, i32)
@@ -327,13 +320,6 @@ static void init_runtime(compile_t* c)
   params[2] = c->i32;
   type = LLVMFunctionType(c->void_ptr, params, 3, false);
   value = LLVMAddFunction(c->module, "pony_traceunknown", type);
-  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
-
-  // void pony_trace_tag_or_actor(i8*, __object*)
-  params[0] = c->void_ptr;
-  params[1] = c->object_ptr;
-  type = LLVMFunctionType(c->void_type, params, 2, false);
-  value = LLVMAddFunction(c->module, "pony_trace_tag_or_actor", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
   // void pony_gc_send(i8*)

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -138,6 +138,8 @@ typedef struct compile_t
   LLVMTypeRef actor_pad;
   LLVMTypeRef trace_type;
   LLVMTypeRef trace_fn;
+  LLVMTypeRef serialise_type;
+  LLVMTypeRef serialise_fn;
   LLVMTypeRef dispatch_type;
   LLVMTypeRef dispatch_fn;
   LLVMTypeRef final_fn;

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -76,6 +76,7 @@ typedef struct compile_t
   const char* str_Pointer;
   const char* str_Maybe;
   const char* str_Array;
+  const char* str_String;
   const char* str_Platform;
   const char* str_Main;
   const char* str_Env;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -657,9 +657,6 @@ LLVMValueRef gencall_alloc(compile_t* c, reach_type_t* t)
 LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t)
 {
   // We explicitly want a boxed version.
-  // Get the size of the structure.
-  size_t size = (size_t)LLVMABISizeOfType(c->target_data, t->structure);
-
   // Allocate the object.
   LLVMValueRef args[3];
   args[0] = codegen_ctx(c);
@@ -668,17 +665,17 @@ LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t)
 
   if(t->final_fn == NULL)
   {
-    if(size <= HEAP_MAX)
+    if(t->abi_size <= HEAP_MAX)
     {
-      uint32_t index = ponyint_heap_index(size);
+      uint32_t index = ponyint_heap_index(t->abi_size);
       args[1] = LLVMConstInt(c->i32, index, false);
       result = gencall_runtime(c, "pony_alloc_small", args, 2, "");
     } else {
-      args[1] = LLVMConstInt(c->intptr, size, false);
+      args[1] = LLVMConstInt(c->intptr, t->abi_size, false);
       result = gencall_runtime(c, "pony_alloc_large", args, 2, "");
     }
   } else {
-    args[1] = LLVMConstInt(c->intptr, size, false);
+    args[1] = LLVMConstInt(c->intptr, t->abi_size, false);
     args[2] = LLVMConstBitCast(t->final_fn, c->final_fn);
     result = gencall_runtime(c, "pony_alloc_final", args, 3, "");
   }

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -12,16 +12,17 @@
 #define DESC_FIELD_COUNT 3
 #define DESC_FIELD_OFFSET 4
 #define DESC_TRACE 5
-#define DESC_SERIALISE 6
-#define DESC_DESERIALISE 7
-#define DESC_DISPATCH 8
-#define DESC_FINALISE 9
-#define DESC_EVENT_NOTIFY 10
-#define DESC_TRAITS 11
-#define DESC_FIELDS 12
-#define DESC_VTABLE 13
+#define DESC_SERIALISE_TRACE 6
+#define DESC_SERIALISE 7
+#define DESC_DESERIALISE 8
+#define DESC_DISPATCH 9
+#define DESC_FINALISE 10
+#define DESC_EVENT_NOTIFY 11
+#define DESC_TRAITS 12
+#define DESC_FIELDS 13
+#define DESC_VTABLE 14
 
-#define DESC_LENGTH 14
+#define DESC_LENGTH 15
 
 static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
   reach_method_t* m)
@@ -331,6 +332,7 @@ void gendesc_basetype(compile_t* c, LLVMTypeRef desc_type)
   params[DESC_FIELD_COUNT] = c->i32;
   params[DESC_FIELD_OFFSET] = c->i32;
   params[DESC_TRACE] = c->trace_fn;
+  params[DESC_SERIALISE_TRACE] = c->trace_fn;
   params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
@@ -378,6 +380,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
   params[DESC_FIELD_COUNT] = c->i32;
   params[DESC_FIELD_OFFSET] = c->i32;
   params[DESC_TRACE] = c->trace_fn;
+  params[DESC_SERIALISE_TRACE] = c->trace_fn;
   params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
@@ -413,6 +416,8 @@ void gendesc_init(compile_t* c, reach_type_t* t)
   args[DESC_FIELD_COUNT] = make_field_count(c, t);
   args[DESC_FIELD_OFFSET] = make_field_offset(c, t);
   args[DESC_TRACE] = make_function_ptr(t->trace_fn, c->trace_fn);
+  args[DESC_SERIALISE_TRACE] = make_function_ptr(t->serialise_trace_fn,
+    c->trace_fn);
   args[DESC_SERIALISE] = make_function_ptr(t->serialise_fn, c->serialise_fn);
   args[DESC_DESERIALISE] = make_function_ptr(t->deserialise_fn, c->trace_fn);
   args[DESC_DISPATCH] = make_function_ptr(t->dispatch_fn, c->dispatch_fn);

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -398,14 +398,13 @@ void gendesc_init(compile_t* c, reach_type_t* t)
 
   // Initialise the global descriptor.
   uint32_t event_notify_index = reach_vtable_index(t, c->str__event_notify);
-  uint32_t size = (uint32_t)LLVMABISizeOfType(c->target_data, t->structure);
   uint32_t trait_count = 0;
   LLVMValueRef trait_list = make_trait_list(c, t, &trait_count);
 
   LLVMValueRef args[DESC_LENGTH];
 
   args[DESC_ID] = LLVMConstInt(c->i32, t->type_id, false);
-  args[DESC_SIZE] = LLVMConstInt(c->i32, size, false);
+  args[DESC_SIZE] = LLVMConstInt(c->i32, t->abi_size, false);
   args[DESC_TRAIT_COUNT] = LLVMConstInt(c->i32, trait_count, false);
   args[DESC_FIELD_COUNT] = make_field_count(c, t);
   args[DESC_FIELD_OFFSET] = make_field_offset(c, t);

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -216,7 +216,10 @@ static LLVMValueRef make_field_offset(compile_t* c, reach_type_t* t)
   if(t->field_count == 0)
     return LLVMConstInt(c->i32, 0, false);
 
-  int index = 1;
+  int index = 0;
+
+  if(t->underlying != TK_STRUCT)
+    index++;
 
   if(t->underlying == TK_ACTOR)
     index++;
@@ -347,6 +350,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
   {
     case TK_TUPLETYPE:
     case TK_PRIMITIVE:
+    case TK_STRUCT:
     case TK_CLASS:
     case TK_ACTOR:
       break;

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -331,7 +331,7 @@ void gendesc_basetype(compile_t* c, LLVMTypeRef desc_type)
   params[DESC_FIELD_COUNT] = c->i32;
   params[DESC_FIELD_OFFSET] = c->i32;
   params[DESC_TRACE] = c->trace_fn;
-  params[DESC_SERIALISE] = c->trace_fn;
+  params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
   params[DESC_FINALISE] = c->final_fn;
@@ -378,7 +378,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
   params[DESC_FIELD_COUNT] = c->i32;
   params[DESC_FIELD_OFFSET] = c->i32;
   params[DESC_TRACE] = c->trace_fn;
-  params[DESC_SERIALISE] = c->trace_fn;
+  params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
   params[DESC_FINALISE] = c->final_fn;
@@ -413,7 +413,7 @@ void gendesc_init(compile_t* c, reach_type_t* t)
   args[DESC_FIELD_COUNT] = make_field_count(c, t);
   args[DESC_FIELD_OFFSET] = make_field_offset(c, t);
   args[DESC_TRACE] = make_function_ptr(t->trace_fn, c->trace_fn);
-  args[DESC_SERIALISE] = make_function_ptr(t->serialise_fn, c->trace_fn);
+  args[DESC_SERIALISE] = make_function_ptr(t->serialise_fn, c->serialise_fn);
   args[DESC_DESERIALISE] = make_function_ptr(t->deserialise_fn, c->trace_fn);
   args[DESC_DISPATCH] = make_function_ptr(t->dispatch_fn, c->dispatch_fn);
   args[DESC_FINALISE] = make_function_ptr(t->final_fn, c->final_fn);

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -12,6 +12,8 @@ void gendesc_type(compile_t* c, reach_type_t* t);
 
 void gendesc_init(compile_t* c, reach_type_t* t);
 
+void gendesc_table(compile_t* c);
+
 LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object);
 
 LLVMValueRef gendesc_trace(compile_t* c, LLVMValueRef object);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -148,7 +148,7 @@ static void gen_main(compile_t* c, reach_type_t* t_main,
 
   args[0] = ctx;
   args[1] = LLVMBuildBitCast(c->builder, env, c->object_ptr, "");
-  args[2] = t_env->trace_fn;
+  args[2] = t_env->desc;
   args[3] = LLVMConstInt(c->i32, 1, false);
   gencall_runtime(c, "pony_traceobject", args, 4, "");
 
@@ -376,11 +376,11 @@ bool genexe(compile_t* c, ast_t* program)
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Selector painting\n"));
   paint(&c->reach->types);
 
-  if(c->opt->verbosity >= VERBOSITY_ALL)
-    reach_dump(c->reach);
-
   if(!gentypes(c))
     return false;
+
+  if(c->opt->verbosity >= VERBOSITY_ALL)
+    reach_dump(c->reach);
 
   reach_type_t* t_main = reach_type(c->reach, main_ast);
   reach_type_t* t_env = reach_type(c->reach, env_ast);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -148,9 +148,9 @@ static void gen_main(compile_t* c, reach_type_t* t_main,
 
   args[0] = ctx;
   args[1] = LLVMBuildBitCast(c->builder, env, c->object_ptr, "");
-  args[2] = t_env->desc;
-  args[3] = LLVMConstInt(c->i32, 1, false);
-  gencall_runtime(c, "pony_traceobject", args, 4, "");
+  args[2] = LLVMBuildBitCast(c->builder, t_env->desc, c->descriptor_ptr, "");
+  args[3] = LLVMConstInt(c->i32, PONY_TRACE_IMMUTABLE, false);
+  gencall_runtime(c, "pony_traceknown", args, 4, "");
 
   args[0] = ctx;
   gencall_runtime(c, "pony_send_done", args, 1, "");

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -125,6 +125,11 @@ const char* genname_trace(const char* type)
   return stringtab_two(type, "Trace");
 }
 
+const char* genname_serialise_trace(const char* type)
+{
+  return stringtab_two(type, "SerialiseTrace");
+}
+
 const char* genname_serialise(const char* type)
 {
   return stringtab_two(type, "Serialise");

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -16,6 +16,8 @@ const char* genname_fieldlist(const char* type);
 
 const char* genname_trace(const char* type);
 
+const char* genname_serialise_trace(const char* type);
+
 const char* genname_serialise(const char* type);
 
 const char* genname_deserialise(const char* type);

--- a/src/libponyc/codegen/genprim.h
+++ b/src/libponyc/codegen/genprim.h
@@ -17,9 +17,13 @@ void genprim_array_serialise_trace(compile_t* c, reach_type_t* t);
 
 void genprim_array_serialise(compile_t* c, reach_type_t* t);
 
+void genprim_array_deserialise(compile_t* c, reach_type_t* t);
+
 void genprim_string_serialise_trace(compile_t* c, reach_type_t* t);
 
 void genprim_string_serialise(compile_t* c, reach_type_t* t);
+
+void genprim_string_deserialise(compile_t* c, reach_type_t* t);
 
 void genprim_platform_methods(compile_t* c, reach_type_t* t);
 

--- a/src/libponyc/codegen/genprim.h
+++ b/src/libponyc/codegen/genprim.h
@@ -13,6 +13,14 @@ void genprim_maybe_methods(compile_t* c, reach_type_t* t);
 
 void genprim_array_trace(compile_t* c, reach_type_t* t);
 
+void genprim_array_serialise_trace(compile_t* c, reach_type_t* t);
+
+void genprim_array_serialise(compile_t* c, reach_type_t* t);
+
+void genprim_string_serialise_trace(compile_t* c, reach_type_t* t);
+
+void genprim_string_serialise(compile_t* c, reach_type_t* t);
+
 void genprim_platform_methods(compile_t* c, reach_type_t* t);
 
 void genprim_builtins(compile_t* c);

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -61,8 +61,6 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     default: {}
   }
 
-  // TODO: don't write fields if we are opaque
-
   for(uint32_t i = 0; i < t->field_count; i++)
   {
     LLVMValueRef field = LLVMBuildStructGEP(c->builder, object, i + extra, "");
@@ -90,10 +88,6 @@ static void make_serialise(compile_t* c, reach_type_t* t)
   LLVMValueRef ctx = LLVMGetParam(t->serialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_fn, 1);
   LLVMValueRef addr = LLVMGetParam(t->serialise_fn, 2);
-
-  // TODO: pass mutability in or not?
-  LLVMValueRef mutability = LLVMGetParam(t->serialise_fn, 3);
-  (void)mutability;
 
   LLVMValueRef object = LLVMBuildBitCast(c->builder, arg, t->structure_ptr,
     "");

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -57,27 +57,6 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
   }
 }
 
-static void make_serialise_size(compile_t* c, reach_type_t* t)
-{
-  // Generate the serialise_size function.
-  t->serialise_size_fn = codegen_addfun(c, genname_serialise(t->name),
-    c->trace_type);
-
-  codegen_startfun(c, t->serialise_size_fn, NULL, NULL);
-  LLVMSetFunctionCallConv(t->serialise_size_fn, LLVMCCallConv);
-
-  LLVMValueRef ctx = LLVMGetParam(t->serialise_size_fn, 0);
-  LLVMValueRef arg = LLVMGetParam(t->serialise_size_fn, 1);
-
-  LLVMValueRef object = LLVMBuildBitCast(c->builder, arg, t->structure_ptr,
-    "");
-
-  serialise_size(c, t, ctx, object);
-
-  LLVMBuildRetVoid(c->builder);
-  codegen_finishfun(c);
-}
-
 static void make_serialise(compile_t* c, reach_type_t* t)
 {
   // Generate the serialise function.
@@ -166,7 +145,6 @@ bool genserialise(compile_t* c, reach_type_t* t)
       return true;
   }
 
-  make_serialise_size(c, t);
   make_serialise(c, t);
   return true;
 }

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -144,7 +144,6 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
   LLVMValueRef object)
 {
   // The contents have already been copied.
-  LLVMTypeRef structure = t->structure;
   int extra = 0;
 
   switch(t->underlying)
@@ -172,8 +171,6 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
         gendeserialise_typeid(c, t, object);
         object = LLVMBuildStructGEP(c->builder, object, 1, "");
       }
-
-      structure = t->primitive;
       break;
     }
 

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -1,0 +1,172 @@
+#include "codegen.h"
+#include "genname.h"
+
+static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
+  LLVMValueRef object, LLVMValueRef offset)
+{
+  int extra = 0;
+
+  // Write the type id instead of the descriptor.
+  switch(t->underlying)
+  {
+    case TK_PRIMITIVE:
+    case TK_CLASS:
+    case TK_ACTOR:
+    {
+      LLVMValueRef type_id = LLVMConstInt(c->intptr, t->type_id, false);
+      LLVMValueRef loc = LLVMBuildIntToPtr(c->builder, offset,
+        LLVMPointerType(c->intptr, 0), "");
+      LLVMBuildStore(c->builder, type_id, loc);
+      extra++;
+      break;
+    }
+
+    default: {}
+  }
+
+  // Actors have a pad. Leave the memory untouched.
+  if(t->underlying == TK_ACTOR)
+    extra++;
+
+  for(uint32_t i = 0; i < t->field_count; i++)
+  {
+    LLVMValueRef field = LLVMBuildStructGEP(c->builder, object, i + extra, "");
+    reach_type_t* t_field = t->fields[i].type;
+    LLVMValueRef f_offset = LLVMBuildAdd(c->builder, offset,
+      LLVMConstInt(c->intptr,
+        LLVMOffsetOfElement(c->target_data, t->structure, i + extra), false),
+      "");
+
+    if(t->fields[i].embed || (t_field->underlying == TK_TUPLETYPE))
+    {
+      // Embedded field or tuple, serialise in place. Don't load from the
+      // StructGEP, as the StructGEP is already a pointer to the object.
+      serialise(c, t_field, ctx, field, f_offset);
+    } else if(t_field->primitive != NULL) {
+      // Machine word, write the bits to the buffer.
+      LLVMValueRef value = LLVMBuildLoad(c->builder, field, "");
+      LLVMValueRef loc = LLVMBuildIntToPtr(c->builder, f_offset,
+        LLVMPointerType(t_field->primitive, 0), "");
+      LLVMBuildStore(c->builder, value, loc);
+    } else {
+      // TODO: pointer
+      // lookup the pointer and get the offset, write that
+      LLVMValueRef value = LLVMBuildLoad(c->builder, field, "");
+      (void)value;
+    }
+  }
+}
+
+static void make_serialise_size(compile_t* c, reach_type_t* t)
+{
+  // Generate the serialise_size function.
+  t->serialise_size_fn = codegen_addfun(c, genname_serialise(t->name),
+    c->trace_type);
+
+  codegen_startfun(c, t->serialise_size_fn, NULL, NULL);
+  LLVMSetFunctionCallConv(t->serialise_size_fn, LLVMCCallConv);
+
+  LLVMValueRef ctx = LLVMGetParam(t->serialise_size_fn, 0);
+  LLVMValueRef arg = LLVMGetParam(t->serialise_size_fn, 1);
+
+  LLVMValueRef object = LLVMBuildBitCast(c->builder, arg, t->structure_ptr,
+    "");
+
+  serialise_size(c, t, ctx, object);
+
+  LLVMBuildRetVoid(c->builder);
+  codegen_finishfun(c);
+}
+
+static void make_serialise(compile_t* c, reach_type_t* t)
+{
+  // Generate the serialise function.
+  // TODO: different function signature
+  t->serialise_fn = codegen_addfun(c, genname_serialise(t->name),
+    c->trace_type);
+
+  codegen_startfun(c, t->serialise_fn, NULL, NULL);
+  LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
+
+  LLVMValueRef ctx = LLVMGetParam(t->serialise_fn, 0);
+  LLVMValueRef arg = LLVMGetParam(t->serialise_fn, 1);
+  LLVMValueRef addr = LLVMGetParam(t->serialise_fn, 2);
+
+  LLVMValueRef object = LLVMBuildBitCast(c->builder, arg, t->structure_ptr,
+    "");
+  LLVMValueRef offset = LLVMBuildPtrToInt(c->builder, addr, c->intptr, "");
+
+  serialise(c, t, ctx, object, offset);
+
+  LLVMBuildRetVoid(c->builder);
+  codegen_finishfun(c);
+}
+
+bool genserialise(compile_t* c, reach_type_t* t)
+{
+  switch(t->underlying)
+  {
+    case TK_TUPLETYPE:
+    case TK_PRIMITIVE:
+    case TK_ACTOR:
+      break;
+
+    case TK_STRUCT:
+    {
+      // Special case some serialise functions.
+      AST_GET_CHILDREN(t->ast, pkg, id);
+      const char* package = ast_name(pkg);
+      const char* name = ast_name(id);
+
+      if(package == c->str_builtin)
+      {
+        if(name == c->str_Maybe)
+        {
+          // TODO:
+          // genprim_maybe_serialise(c, t);
+          return true;
+        }
+
+        if(name == c->str_Pointer)
+        {
+          // TODO:
+          // genprim_pointer_serialise(c, t);
+          return true;
+        }
+      }
+      break;
+    }
+    case TK_CLASS:
+    {
+      // Special case some serialise functions.
+      AST_GET_CHILDREN(t->ast, pkg, id);
+      const char* package = ast_name(pkg);
+      const char* name = ast_name(id);
+
+      if(package == c->str_builtin)
+      {
+        if(name == c->str_Array)
+        {
+          // TODO:
+          // genprim_array_serialise(c, t);
+          return true;
+        }
+
+        if(name == c->str_String)
+        {
+          // TODO:
+          // genprim_string_serialise(c, t);
+          return true;
+        }
+      }
+      break;
+    }
+
+    default:
+      return true;
+  }
+
+  make_serialise_size(c, t);
+  make_serialise(c, t);
+  return true;
+}

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -6,6 +6,9 @@
 
 PONY_EXTERN_C_BEGIN
 
+void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
+  LLVMValueRef ctx, LLVMValueRef ptr, LLVMValueRef offset);
+
 void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
 
 bool genserialise(compile_t* c, reach_type_t* t);

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -11,6 +11,11 @@ void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
 
 void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
 
+void gendeserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
+
+void gendeserialise_element(compile_t* c, reach_type_t* t, bool embed,
+  LLVMValueRef ctx, LLVMValueRef ptr);
+
 bool genserialise(compile_t* c, reach_type_t* t);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -6,6 +6,8 @@
 
 PONY_EXTERN_C_BEGIN
 
+void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
+
 bool genserialise(compile_t* c, reach_type_t* t);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -1,0 +1,13 @@
+#ifndef CODEGEN_GENSERIALISE_H
+#define CODEGEN_GENSERIALISE_H
+
+#include <platform.h>
+#include "codegen.h"
+
+PONY_EXTERN_C_BEGIN
+
+bool genserialise(compile_t* c, reach_type_t* t);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -411,24 +411,14 @@ static void trace_known(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 {
   reach_type_t* t = reach_type(c->reach, type);
 
-  // If this type has no trace function, don't try to recurse in the runtime.
-  if(t->trace_fn != NULL)
-  {
-    // Cast the object to an object pointer.
-    LLVMValueRef args[4];
-    args[0] = ctx;
-    args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
-    args[2] = t->trace_fn;
-    args[3] = LLVMConstInt(c->i32, immutable, false);
+  // Cast the object to an object pointer.
+  LLVMValueRef args[4];
+  args[0] = ctx;
+  args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
+  args[2] = t->desc;
+  args[3] = LLVMConstInt(c->i32, immutable, false);
 
-    gencall_runtime(c, "pony_traceobject", args, 4, "");
-  } else {
-    // Cast the object to a void pointer.
-    LLVMValueRef args[2];
-    args[0] = ctx;
-    args[1] = LLVMBuildBitCast(c->builder, object, c->void_ptr, "");
-    gencall_runtime(c, "pony_trace", args, 2, "");
-  }
+  gencall_runtime(c, "pony_traceobject", args, 4, "");
 }
 
 static void trace_unknown(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
@@ -745,8 +735,7 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
   if(!need_trace)
     return;
 
-  const char* trace_name = genname_trace(t->name);
-  t->trace_fn = codegen_addfun(c, trace_name, c->trace_type);
+  t->trace_fn = codegen_addfun(c, genname_trace(t->name), c->trace_type);
 }
 
 void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -24,15 +24,14 @@
 typedef enum
 {
   TRACE_NONE,
-  TRACE_PRIMITIVE,
   TRACE_MAYBE,
-  TRACE_ACTOR,
-  TRACE_KNOWN_VAL,
-  TRACE_UNKNOWN_VAL,
-  TRACE_KNOWN,
-  TRACE_UNKNOWN,
-  TRACE_TAG,
-  TRACE_TAG_OR_ACTOR,
+  TRACE_PRIMITIVE,
+  TRACE_VAL_KNOWN,
+  TRACE_VAL_UNKNOWN,
+  TRACE_MUT_KNOWN,
+  TRACE_MUT_UNKNOWN,
+  TRACE_TAG_KNOWN,
+  TRACE_TAG_UNKNOWN,
   TRACE_DYNAMIC,
   TRACE_TUPLE
 } trace_t;
@@ -44,29 +43,22 @@ static trace_t trace_type(ast_t* type);
 
 static trace_t trace_union_primitive(trace_t a)
 {
-  assert(a >= TRACE_PRIMITIVE);
-
   switch(a)
   {
     case TRACE_PRIMITIVE:
       return TRACE_PRIMITIVE;
 
-    case TRACE_ACTOR:
-      return TRACE_TAG_OR_ACTOR;
+    case TRACE_MUT_KNOWN:
+    case TRACE_MUT_UNKNOWN:
+      return TRACE_MUT_UNKNOWN;
 
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-      return TRACE_UNKNOWN;
+    case TRACE_VAL_KNOWN:
+    case TRACE_VAL_UNKNOWN:
+      return TRACE_VAL_UNKNOWN;
 
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-      return TRACE_UNKNOWN_VAL;
-
-    case TRACE_TAG:
-      return TRACE_TAG;
-
-    case TRACE_TAG_OR_ACTOR:
-      return TRACE_TAG_OR_ACTOR;
+    case TRACE_TAG_KNOWN:
+    case TRACE_TAG_UNKNOWN:
+      return TRACE_TAG_UNKNOWN;
 
     case TRACE_DYNAMIC:
     case TRACE_TUPLE:
@@ -79,145 +71,67 @@ static trace_t trace_union_primitive(trace_t a)
   return TRACE_NONE;
 }
 
-static trace_t trace_union_actor(trace_t a)
+static trace_t trace_union_val(trace_t a)
 {
-  assert(a >= TRACE_ACTOR);
-
   switch(a)
   {
-    case TRACE_ACTOR:
-      return TRACE_ACTOR;
-
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-      return TRACE_UNKNOWN;
-
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-      return TRACE_UNKNOWN_VAL;
-
-    case TRACE_TAG:
-    case TRACE_TAG_OR_ACTOR:
-      return TRACE_TAG_OR_ACTOR;
-
-    case TRACE_DYNAMIC:
-    case TRACE_TUPLE:
-      return TRACE_DYNAMIC;
-
-    default: {}
-  }
-
-  assert(0);
-  return TRACE_NONE;
-}
-
-static trace_t trace_union_known_or_unknown(trace_t a)
-{
-  assert(a >= TRACE_KNOWN);
-
-  switch(a)
-  {
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-      return TRACE_UNKNOWN;
-
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-    case TRACE_TAG:
-    case TRACE_TAG_OR_ACTOR:
-    case TRACE_DYNAMIC:
-    case TRACE_TUPLE:
-      return TRACE_DYNAMIC;
-
-    default: {}
-  }
-
-  assert(0);
-  return TRACE_NONE;
-}
-
-static trace_t trace_union_known_or_unknown_val(trace_t a)
-{
-  assert(a >= TRACE_KNOWN_VAL);
-
-  switch(a)
-  {
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-      return TRACE_UNKNOWN_VAL;
-
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-    case TRACE_TAG:
-    case TRACE_TAG_OR_ACTOR:
-    case TRACE_DYNAMIC:
-    case TRACE_TUPLE:
-      return TRACE_DYNAMIC;
-
-    default: {}
-  }
-
-  assert(0);
-  return TRACE_NONE;
-}
-
-static trace_t trace_union_tag_or_actor(trace_t a)
-{
-  assert(a >= TRACE_TAG);
-
-  switch(a)
-  {
-    case TRACE_TAG:
-      return TRACE_TAG;
-
-    case TRACE_TAG_OR_ACTOR:
-      return TRACE_TAG_OR_ACTOR;
-
-    case TRACE_DYNAMIC:
-    case TRACE_TUPLE:
-      return TRACE_DYNAMIC;
-
-    default: {}
-  }
-
-  assert(0);
-  return TRACE_NONE;
-}
-
-static trace_t trace_type_combine(trace_t a, trace_t b)
-{
-  if(a > b)
-  {
-    trace_t tmp = a;
-    a = b;
-    b = tmp;
-  }
-
-  assert(a <= b);
-
-  switch(a)
-  {
-    case TRACE_NONE:
-      return b;
-
     case TRACE_PRIMITIVE:
-      return trace_union_primitive(b);
+    case TRACE_VAL_KNOWN:
+    case TRACE_VAL_UNKNOWN:
+      return TRACE_VAL_UNKNOWN;
 
-    case TRACE_ACTOR:
-      return trace_union_actor(b);
+    case TRACE_MUT_KNOWN:
+    case TRACE_MUT_UNKNOWN:
+    case TRACE_TAG_KNOWN:
+    case TRACE_TAG_UNKNOWN:
+    case TRACE_DYNAMIC:
+    case TRACE_TUPLE:
+      return TRACE_DYNAMIC;
 
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-      return trace_union_known_or_unknown(b);
+    default: {}
+  }
 
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-      return trace_union_known_or_unknown_val(b);
+  assert(0);
+  return TRACE_NONE;
+}
 
-    case TRACE_TAG:
-    case TRACE_TAG_OR_ACTOR:
-      return trace_union_tag_or_actor(b);
+static trace_t trace_union_mut(trace_t a)
+{
+  switch(a)
+  {
+    case TRACE_PRIMITIVE:
+    case TRACE_MUT_KNOWN:
+    case TRACE_MUT_UNKNOWN:
+      return TRACE_MUT_UNKNOWN;
 
+    case TRACE_VAL_KNOWN:
+    case TRACE_VAL_UNKNOWN:
+    case TRACE_TAG_KNOWN:
+    case TRACE_TAG_UNKNOWN:
+    case TRACE_DYNAMIC:
+    case TRACE_TUPLE:
+      return TRACE_DYNAMIC;
+
+    default: {}
+  }
+
+  assert(0);
+  return TRACE_NONE;
+}
+
+static trace_t trace_union_tag(trace_t a)
+{
+  switch(a)
+  {
+    case TRACE_PRIMITIVE:
+    case TRACE_TAG_KNOWN:
+    case TRACE_TAG_UNKNOWN:
+      return TRACE_TAG_UNKNOWN;
+
+    case TRACE_VAL_KNOWN:
+    case TRACE_VAL_UNKNOWN:
+    case TRACE_MUT_KNOWN:
+    case TRACE_MUT_UNKNOWN:
     case TRACE_DYNAMIC:
     case TRACE_TUPLE:
       return TRACE_DYNAMIC;
@@ -237,7 +151,42 @@ static trace_t trace_type_union(ast_t* type)
     child != NULL;
     child = ast_sibling(child))
   {
-    trace = trace_type_combine(trace, trace_type(child));
+    trace_t t = trace_type(child);
+
+    switch(trace)
+    {
+      case TRACE_NONE:
+        trace = t;
+        break;
+
+      case TRACE_MAYBE:
+        // Can't be in a union.
+        assert(0);
+        return TRACE_NONE;
+
+      case TRACE_PRIMITIVE:
+        trace = trace_union_primitive(t);
+        break;
+
+      case TRACE_MUT_KNOWN:
+      case TRACE_MUT_UNKNOWN:
+        trace = trace_union_mut(t);
+        break;
+
+      case TRACE_VAL_KNOWN:
+      case TRACE_VAL_UNKNOWN:
+        trace = trace_union_val(t);
+        break;
+
+      case TRACE_TAG_KNOWN:
+      case TRACE_TAG_UNKNOWN:
+        trace = trace_union_tag(t);
+        break;
+
+      case TRACE_DYNAMIC:
+      case TRACE_TUPLE:
+        return TRACE_DYNAMIC;
+    }
   }
 
   return trace;
@@ -256,23 +205,29 @@ static trace_t trace_type_isect(ast_t* type)
     switch(t)
     {
       case TRACE_NONE:
-      case TRACE_MAYBE: // Maybe, any refcap.
+      case TRACE_MAYBE:
         // Can't be in an isect.
         assert(0);
         return TRACE_NONE;
 
-      case TRACE_PRIMITIVE: // Primitive, any refcap.
-      case TRACE_ACTOR: // Actor, tag.
-      case TRACE_KNOWN_VAL:
-      case TRACE_KNOWN: // Class or struct, not tag.
-        return t;
+      case TRACE_PRIMITIVE:
+        return TRACE_PRIMITIVE;
 
-      case TRACE_UNKNOWN_VAL:
-      case TRACE_UNKNOWN: // Trait or interface, not tag.
-      case TRACE_TAG: // Class or struct, tag.
-      case TRACE_TAG_OR_ACTOR: // Trait or interface, tag.
-        if(trace > t)
-          trace = t;
+      case TRACE_VAL_KNOWN:
+      case TRACE_VAL_UNKNOWN:
+        trace = TRACE_VAL_UNKNOWN;
+        break;
+
+      case TRACE_MUT_KNOWN:
+      case TRACE_MUT_UNKNOWN:
+        if(trace != TRACE_VAL_UNKNOWN)
+          trace = TRACE_MUT_UNKNOWN;
+        break;
+
+      case TRACE_TAG_KNOWN:
+      case TRACE_TAG_UNKNOWN:
+        if((trace != TRACE_MUT_UNKNOWN) && (trace != TRACE_VAL_UNKNOWN))
+          trace = TRACE_TAG_UNKNOWN;
         break;
 
       case TRACE_DYNAMIC:
@@ -293,15 +248,15 @@ static trace_t trace_type_nominal(ast_t* type)
       switch(cap_single(type))
       {
         case TK_VAL:
-          return TRACE_UNKNOWN_VAL;
+          return TRACE_VAL_UNKNOWN;
 
         case TK_TAG:
-          return TRACE_TAG_OR_ACTOR;
+          return TRACE_TAG_UNKNOWN;
 
         default: {}
       }
 
-      return TRACE_UNKNOWN;
+      return TRACE_MUT_UNKNOWN;
 
     case TK_PRIMITIVE:
       return TRACE_PRIMITIVE;
@@ -314,18 +269,18 @@ static trace_t trace_type_nominal(ast_t* type)
       switch(cap_single(type))
       {
         case TK_VAL:
-          return TRACE_KNOWN_VAL;
+          return TRACE_VAL_KNOWN;
 
         case TK_TAG:
-          return TRACE_TAG;
+          return TRACE_TAG_KNOWN;
 
         default: {}
       }
 
-      return TRACE_KNOWN;
+      return TRACE_MUT_KNOWN;
 
     case TK_ACTOR:
-      return TRACE_ACTOR;
+      return TRACE_TAG_KNOWN;
 
     default: {}
   }
@@ -357,36 +312,6 @@ static trace_t trace_type(ast_t* type)
   return TRACE_DYNAMIC;
 }
 
-static void trace_tag(compile_t* c, LLVMValueRef ctx, LLVMValueRef object)
-{
-  // Cast the object to a void pointer.
-  LLVMValueRef args[2];
-  args[0] = ctx;
-  args[1] = LLVMBuildBitCast(c->builder, object, c->void_ptr, "");
-
-  gencall_runtime(c, "pony_trace", args, 2, "");
-}
-
-static void trace_tag_or_actor(compile_t* c, LLVMValueRef ctx,
-  LLVMValueRef object)
-{
-  // We're an object.
-  LLVMValueRef args[2];
-  args[0] = ctx;
-  args[1] = object;
-  gencall_runtime(c, "pony_trace_tag_or_actor", args, 2, "");
-}
-
-static void trace_actor(compile_t* c, LLVMValueRef ctx, LLVMValueRef object)
-{
-  // Cast the object to an object pointer.
-  LLVMValueRef args[2];
-  args[0] = ctx;
-  args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
-
-  gencall_runtime(c, "pony_traceactor", args, 2, "");
-}
-
 static void trace_maybe(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   ast_t* type)
 {
@@ -407,28 +332,26 @@ static void trace_maybe(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 }
 
 static void trace_known(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
-  ast_t* type, bool immutable)
+  ast_t* type, int mutability)
 {
   reach_type_t* t = reach_type(c->reach, type);
 
-  // Cast the object to an object pointer.
   LLVMValueRef args[4];
   args[0] = ctx;
   args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
-  args[2] = t->desc;
-  args[3] = LLVMConstInt(c->i32, immutable, false);
+  args[2] = LLVMBuildBitCast(c->builder, t->desc, c->descriptor_ptr, "");
+  args[3] = LLVMConstInt(c->i32, mutability, false);
 
-  gencall_runtime(c, "pony_traceobject", args, 4, "");
+  gencall_runtime(c, "pony_traceknown", args, 4, "");
 }
 
 static void trace_unknown(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
-  bool immutable)
+  int mutability)
 {
-  // We're an object.
   LLVMValueRef args[3];
   args[0] = ctx;
-  args[1] = object;
-  args[2] = LLVMConstInt(c->i32, immutable, false);
+  args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
+  args[2] = LLVMConstInt(c->i32, mutability, false);
 
   gencall_runtime(c, "pony_traceunknown", args, 3, "");
 }
@@ -464,7 +387,7 @@ static void trace_dynamic_union_or_isect(compile_t* c, LLVMValueRef ctx,
   }
 
   // No type matched. This may be a boxed primitive: trace it here.
-  trace_tag(c, ctx, object);
+  trace_unknown(c, ctx, object, PONY_TRACE_OPAQUE);
 }
 
 static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
@@ -518,13 +441,12 @@ static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
         // Skip this element.
         break;
 
-      case TRACE_ACTOR:
-      case TRACE_KNOWN:
-      case TRACE_UNKNOWN:
-      case TRACE_KNOWN_VAL:
-      case TRACE_UNKNOWN_VAL:
-      case TRACE_TAG:
-      case TRACE_TAG_OR_ACTOR:
+      case TRACE_MUT_KNOWN:
+      case TRACE_MUT_UNKNOWN:
+      case TRACE_VAL_KNOWN:
+      case TRACE_VAL_UNKNOWN:
+      case TRACE_TAG_KNOWN:
+      case TRACE_TAG_UNKNOWN:
       case TRACE_DYNAMIC:
       {
         // If we are (A, B), turn (_, _) into (A, _).
@@ -626,16 +548,14 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
   LLVMPositionBuilderAtEnd(c->builder, is_true);
   gentrace(c, ctx, object, type);
 
-  // If we have traced as known, unknown or actor, we're done with this
-  // element. Otherwise, continue tracing this as if the match had been
-  // unsuccessful.
+  // If we have traced as mut or val, we're done with this element. Otherwise,
+  // continue tracing this as if the match had been unsuccessful.
   switch(trace_type(type))
   {
-    case TRACE_KNOWN:
-    case TRACE_UNKNOWN:
-    case TRACE_KNOWN_VAL:
-    case TRACE_UNKNOWN_VAL:
-    case TRACE_ACTOR:
+    case TRACE_MUT_KNOWN:
+    case TRACE_MUT_UNKNOWN:
+    case TRACE_VAL_KNOWN:
+    case TRACE_VAL_UNKNOWN:
       LLVMBuildBr(c->builder, next_block);
       break;
 
@@ -662,7 +582,7 @@ static void trace_dynamic(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
     case TK_TUPLETYPE:
     {
       // This is a boxed tuple. Trace the box, then handle the elements.
-      trace_tag(c, ctx, object);
+      trace_unknown(c, ctx, object, PONY_TRACE_OPAQUE);
 
       LLVMValueRef desc = gendesc_fetch(c, object);
       LLVMValueRef ptr = gendesc_ptr_to_fields(c, object, desc);
@@ -753,32 +673,28 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)
       trace_maybe(c, ctx, value, type);
       return;
 
-    case TRACE_ACTOR:
-      trace_actor(c, ctx, value);
+    case TRACE_VAL_KNOWN:
+      trace_known(c, ctx, value, type, PONY_TRACE_IMMUTABLE);
       return;
 
-    case TRACE_KNOWN_VAL:
-      trace_known(c, ctx, value, type, true);
+    case TRACE_VAL_UNKNOWN:
+      trace_unknown(c, ctx, value, PONY_TRACE_IMMUTABLE);
       return;
 
-    case TRACE_UNKNOWN_VAL:
-      trace_unknown(c, ctx, value, true);
+    case TRACE_MUT_KNOWN:
+      trace_known(c, ctx, value, type, PONY_TRACE_MUTABLE);
       return;
 
-    case TRACE_KNOWN:
-      trace_known(c, ctx, value, type, false);
+    case TRACE_MUT_UNKNOWN:
+      trace_unknown(c, ctx, value, PONY_TRACE_MUTABLE);
       return;
 
-    case TRACE_UNKNOWN:
-      trace_unknown(c, ctx, value, false);
+    case TRACE_TAG_KNOWN:
+      trace_known(c, ctx, value, type, PONY_TRACE_OPAQUE);
       return;
 
-    case TRACE_TAG:
-      trace_tag(c, ctx, value);
-      return;
-
-    case TRACE_TAG_OR_ACTOR:
-      trace_tag_or_actor(c, ctx, value);
+    case TRACE_TAG_UNKNOWN:
+      trace_unknown(c, ctx, value, PONY_TRACE_OPAQUE);
       return;
 
     case TRACE_DYNAMIC:

--- a/src/libponyc/codegen/gentrace.h
+++ b/src/libponyc/codegen/gentrace.h
@@ -3,7 +3,6 @@
 
 #include <platform.h>
 #include "codegen.h"
-#include "gentype.h"
 
 PONY_EXTERN_C_BEGIN
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -351,10 +351,6 @@ static bool make_struct(compile_t* c, reach_type_t* t)
 
   LLVMStructSetBody(type, elements, t->field_count + extra, false);
   ponyint_pool_free_size(buf_size, elements);
-
-  // The ABI size for machine words and tuples is the boxed size.
-  t->abi_size = LLVMABISizeOfType(c->target_data, t->structure);
-
   return true;
 }
 
@@ -613,6 +609,10 @@ bool gentypes(compile_t* c)
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
+    // The ABI size for machine words and tuples is the boxed size.
+    if(t->structure != NULL)
+      t->abi_size = LLVMABISizeOfType(c->target_data, t->structure);
+
     make_debug_final(c, t);
     make_pointer_methods(c, t);
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -637,9 +637,8 @@ bool gentypes(compile_t* c)
     if(!make_trace(c, t))
       return false;
 
-    // TODO:
-    // if(!genserialise(c, t))
-    //   return false;
+    if(!genserialise(c, t))
+      return false;
 
     gendesc_init(c, t);
   }

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -593,6 +593,8 @@ bool gentypes(compile_t* c)
     gentrace_prototype(c, t);
   }
 
+  gendesc_table(c);
+
   PONY_LOG(c->opt, VERBOSITY_INFO, (" Data types\n"));
   i = HASHMAP_BEGIN;
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1082,9 +1082,12 @@ void reach_dump(reach_t* r)
 
   while((t = reach_types_next(&r->types, &i)) != NULL)
   {
-    printf("  %s: %s, %d\n", t->name, t->mangle, t->vtable_size);
+    printf("  %d: %s, %s\n", t->type_id, t->name, t->mangle);
     size_t j = HASHMAP_BEGIN;
     reach_method_name_t* n;
+
+    printf("    size: " __zu "\n", t->abi_size);
+    printf("    vtable: %d\n", t->vtable_size);
 
     while((n = reach_method_names_next(&t->methods, &j)) != NULL)
     {
@@ -1092,7 +1095,7 @@ void reach_dump(reach_t* r)
       reach_method_t* m;
 
       while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
-        printf("    %s: %d\n", m->mangled_name, m->vtable_index);
+        printf("      %d: %s\n", m->vtable_index, m->mangled_name);
     }
 
     j = HASHMAP_BEGIN;

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -516,6 +516,8 @@ static reach_type_t* add_reach_type(reach_t* r, ast_t* type)
   t->name = genname_type(type);
   t->mangle = "o";
   t->ast = set_cap_and_ephemeral(type, TK_REF, TK_NONE);
+  t->type_id = (uint32_t)-1;
+
   reach_method_names_init(&t->methods, 0);
   reach_type_cache_init(&t->subtypes, 0);
   reach_types_put(&r->types, t);
@@ -533,7 +535,7 @@ static reach_type_t* add_isect_or_union(reach_t* r, ast_t* type,
 
   t = add_reach_type(r, type);
   t->underlying = ast_id(t->ast);
-  t->type_id = ++r->next_type_id;
+  t->type_id = r->next_type_id++;
 
   ast_t* child = ast_child(type);
 
@@ -558,7 +560,7 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
 
   t = add_reach_type(r, type);
   t->underlying = TK_TUPLETYPE;
-  t->type_id = ++r->next_type_id;
+  t->type_id = r->next_type_id++;
 
   t->field_count = (uint32_t)ast_childcount(t->ast);
   t->fields = (reach_field_t*)calloc(t->field_count,
@@ -635,8 +637,8 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
     default: {}
   }
 
-  if(t->type_id == 0)
-    t->type_id = ++r->next_type_id;
+  if(t->type_id == (uint32_t)-1)
+    t->type_id = r->next_type_id++;
 
   if(ast_id(def) != TK_PRIMITIVE)
     return t;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -92,6 +92,7 @@ struct reach_type_t
   LLVMValueRef desc;
   LLVMValueRef instance;
   LLVMValueRef trace_fn;
+  LLVMValueRef serialise_trace_fn;
   LLVMValueRef serialise_fn;
   LLVMValueRef deserialise_fn;
   LLVMValueRef final_fn;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -80,6 +80,7 @@ struct reach_type_t
   reach_method_names_t methods;
   reach_type_cache_t subtypes;
   uint32_t type_id;
+  size_t abi_size;
   uint32_t vtable_size;
 
   LLVMTypeRef structure;
@@ -91,6 +92,7 @@ struct reach_type_t
   LLVMValueRef desc;
   LLVMValueRef instance;
   LLVMValueRef trace_fn;
+  LLVMValueRef serialise_size_fn;
   LLVMValueRef serialise_fn;
   LLVMValueRef deserialise_fn;
   LLVMValueRef final_fn;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -92,7 +92,6 @@ struct reach_type_t
   LLVMValueRef desc;
   LLVMValueRef instance;
   LLVMValueRef trace_fn;
-  LLVMValueRef serialise_size_fn;
   LLVMValueRef serialise_fn;
   LLVMValueRef deserialise_fn;
   LLVMValueRef final_fn;

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -30,7 +30,7 @@ asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
   // The event is effectively being sent to another thread, so mark it here.
   pony_ctx_t* ctx = pony_ctx();
   pony_gc_send(ctx);
-  pony_traceactor(ctx, owner);
+  pony_traceknown(ctx, owner, type, PONY_TRACE_OPAQUE);
   pony_send_done(ctx);
 
   pony_asio_event_subscribe(ev);
@@ -51,7 +51,7 @@ void pony_asio_event_destroy(asio_event_t* ev)
   // the asio thread.
   pony_ctx_t* ctx = pony_ctx();
   pony_gc_recv(ctx);
-  pony_traceactor(ctx, ev->owner);
+  pony_traceunknown(ctx, ev->owner, PONY_TRACE_OPAQUE);
   pony_recv_done(ctx);
 
   POOL_FREE(asio_event_t, ev);

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -830,6 +830,7 @@ static pony_type_t cycle_type =
   NULL,
   NULL,
   NULL,
+  NULL,
   cycle_dispatch,
   NULL,
   0,

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -829,6 +829,7 @@ static pony_type_t cycle_type =
   NULL,
   NULL,
   NULL,
+  NULL,
   cycle_dispatch,
   NULL,
   0,

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -122,8 +122,8 @@ static void acq_or_rel_remote_actor(pony_ctx_t* ctx, pony_actor_t* actor)
   aref->rc += 1;
 }
 
-static void send_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+static void send_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   object_t* obj = ponyint_objectmap_getorput(&gc->local, p, gc->mark);
@@ -138,15 +138,18 @@ static void send_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
   obj->rc++;
   obj->mark = gc->mark;
 
-  if(immutable)
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
 
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
-static void recv_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+static void recv_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   // get the object
   gc_t* gc = ponyint_actor_gc(ctx->current);
@@ -165,30 +168,33 @@ static void recv_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
   obj->mark = gc->mark;
   obj->reachable = true;
 
-  if(immutable)
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
 
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
 static void mark_local_object(pony_ctx_t* ctx, chunk_t* chunk, void* p,
-  pony_trace_fn f)
+  pony_type_t* t, int mutability)
 {
-  if(f != NULL)
+  if(mutability != PONY_TRACE_OPAQUE)
   {
     // Mark in our heap and recurse if it wasn't already marked.
     if(!ponyint_heap_mark(chunk, p))
-      recurse(ctx, p, f);
+      recurse(ctx, p, t->trace);
   } else {
-    // No recurse function, so do a shallow mark. If the same address is
-    // later marked with a recurse function, it will recurse.
+    // Do a shallow mark. If the same address is later marked as something that
+    // is not opaque, it will recurse.
     ponyint_heap_mark_shallow(chunk, p);
   }
 }
 
-static void acquire_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+static void acquire_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   object_t* obj = ponyint_objectmap_getorput(&gc->local, p, gc->mark);
@@ -201,16 +207,19 @@ static void acquire_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
 
   obj->rc++;
   obj->mark = gc->mark;
-  
-  if(immutable)
+
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
 
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
-static void release_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+static void release_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   object_t* obj = ponyint_objectmap_getobject(&gc->local, p);
@@ -224,16 +233,19 @@ static void release_local_object(pony_ctx_t* ctx, void* p, pony_trace_fn f,
 
   obj->rc--;
   obj->mark = gc->mark;
-  
-  if(immutable)
+
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
 
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
 static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
-  void* p, pony_trace_fn f, bool immutable)
+  void* p, pony_type_t* t, int mutability)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   actorref_t* aref = ponyint_actormap_getorput(&gc->foreign, actor, gc->mark);
@@ -248,7 +260,7 @@ static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
   // Mark the object.
   obj->mark = gc->mark;
 
-  if(immutable && !obj->immutable && (obj->rc > 0))
+  if((mutability == PONY_TRACE_IMMUTABLE) && !obj->immutable && (obj->rc > 0))
   {
     // If we received the object as not immutable (it's not marked as immutable
     // and it has an RC > 0), but we are now sending it as immutable, we need
@@ -259,15 +271,15 @@ static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->immutable = true;
     acquire_object(ctx, actor, p, true);
 
-    immutable = false;
+    mutability = PONY_TRACE_MUTABLE;
   } else if(obj->rc <= 1) {
     // If we haven't seen this object, it's an object that is reached from
     // another immutable object we received. Invent some references to this
     // object and acquire it. This object should either be immutable or a tag.
-    assert((obj->rc > 0) || immutable || (f == NULL));
+    assert((obj->rc > 0) || (mutability != PONY_TRACE_MUTABLE));
 
     // Add to the acquire message and decrement.
-    if(immutable)
+    if(mutability == PONY_TRACE_IMMUTABLE)
       obj->immutable = true;
 
     obj->rc += (GC_INC_MORE - 1);
@@ -277,12 +289,12 @@ static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->rc--;
   }
 
-  if(!immutable)
-    recurse(ctx, p, f);
+  if(mutability == PONY_TRACE_MUTABLE)
+    recurse(ctx, p, t->trace);
 }
 
 static void recv_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
-  void* p, pony_trace_fn f, bool immutable, chunk_t* chunk)
+  void* p, pony_type_t* t, int mutability, chunk_t* chunk)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   actorref_t* aref = ponyint_actormap_getorput(&gc->foreign, actor, gc->mark);
@@ -296,22 +308,27 @@ static void recv_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
 
   // If this is our first reference, add to our heap used size.
   if(obj->rc == 0)
+  {
     ponyint_heap_used(ponyint_actor_heap(ctx->current),
       ponyint_heap_size(chunk));
+  }
 
   // Inc, mark and recurse.
   obj->rc++;
   obj->mark = gc->mark;
 
-  if(immutable)
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
 
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
 static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
-  void* p, pony_trace_fn f, bool immutable, chunk_t* chunk)
+  void* p, pony_type_t* t, int mutability, chunk_t* chunk)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   actorref_t* aref = ponyint_actormap_getorput(&gc->foreign, actor, gc->mark);
@@ -330,7 +347,7 @@ static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
   ponyint_heap_used(ponyint_actor_heap(ctx->current),
     ponyint_heap_size(chunk));
 
-  if(immutable && !obj->immutable && (obj->rc > 0))
+  if((mutability == PONY_TRACE_IMMUTABLE) && !obj->immutable && (obj->rc > 0))
   {
     // If we received the object as not immutable (it's not marked as immutable
     // and it has an RC > 0), but we are now marking it as immutable, we need
@@ -341,26 +358,26 @@ static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->immutable = true;
     acquire_object(ctx, actor, p, true);
 
-    immutable = false;
+    mutability = PONY_TRACE_MUTABLE;
   } else if(obj->rc == 0) {
     // If we haven't seen this object, it's an object that is reached from
     // another immutable object we received. Invent some references to this
     // object and acquire it. This object should either be immutable or a tag.
-    assert(immutable || (f == NULL));
+    assert(mutability != PONY_TRACE_MUTABLE);
 
-    if(immutable)
+    if(mutability == PONY_TRACE_IMMUTABLE)
       obj->immutable = true;
 
     obj->rc += GC_INC_MORE;
     acquire_object(ctx, actor, p, obj->immutable);
   }
 
-  if(!immutable)
-    recurse(ctx, p, f);
+  if(mutability == PONY_TRACE_MUTABLE)
+    recurse(ctx, p, t->trace);
 }
 
 static void acq_or_rel_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
-  void* p, pony_trace_fn f, bool immutable)
+  void* p, pony_type_t* t, int mutability)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
   actorref_t* aref = ponyint_actormap_getorput(&ctx->acquire, actor, 0);
@@ -375,110 +392,119 @@ static void acq_or_rel_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
   obj->rc++;
   obj->mark = gc->mark;
 
-  if(immutable)
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
+  if(mutability == PONY_TRACE_IMMUTABLE)
     obj->immutable = true;
+
   if(!obj->immutable)
-    recurse(ctx, p, f);
+    recurse(ctx, p, t->trace);
 }
 
-void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
   {
-    recurse(ctx, p, f);
+    if(mutability != PONY_TRACE_OPAQUE)
+      recurse(ctx, p, t->trace);
     return;
   }
 
   pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
-    send_local_object(ctx, p, f, immutable);
+    send_local_object(ctx, p, t, mutability);
   else
-    send_remote_object(ctx, actor, p, f, immutable);
+    send_remote_object(ctx, actor, p, t, mutability);
 }
 
-void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
   {
-    recurse(ctx, p, f);
+    if(mutability != PONY_TRACE_OPAQUE)
+      recurse(ctx, p, t->trace);
     return;
   }
 
   pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
-    recv_local_object(ctx, p, f, immutable);
+    recv_local_object(ctx, p, t, mutability);
   else
-    recv_remote_object(ctx, actor, p, f, immutable, chunk);
+    recv_remote_object(ctx, actor, p, t, mutability, chunk);
 }
 
-void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
   {
-    recurse(ctx, p, f);
+    if(mutability != PONY_TRACE_OPAQUE)
+      recurse(ctx, p, t->trace);
     return;
   }
 
   pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
-    mark_local_object(ctx, chunk, p, f);
+    mark_local_object(ctx, chunk, p, t, mutability);
   else
-    mark_remote_object(ctx, actor, p, f, immutable, chunk);
+    mark_remote_object(ctx, actor, p, t, mutability, chunk);
 }
 
-void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
   {
-    recurse(ctx, p, f);
+    if(mutability != PONY_TRACE_OPAQUE)
+      recurse(ctx, p, t->trace);
     return;
   }
 
   pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
-    acquire_local_object(ctx, p, f, immutable);
+    acquire_local_object(ctx, p, t, mutability);
   else
-    acq_or_rel_remote_object(ctx, actor, p, f, immutable);
+    acq_or_rel_remote_object(ctx, actor, p, t, mutability);
 }
 
-void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
   {
-    recurse(ctx, p, f);
+    if(mutability != PONY_TRACE_OPAQUE)
+      recurse(ctx, p, t->trace);
     return;
   }
 
   pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
-    release_local_object(ctx, p, f, immutable);
+    release_local_object(ctx, p, t, mutability);
   else
-    acq_or_rel_remote_object(ctx, actor, p, f, immutable);
+    acq_or_rel_remote_object(ctx, actor, p, t, mutability);
 
 }
 
@@ -559,7 +585,7 @@ void ponyint_gc_markimmutable(pony_ctx_t* ctx, gc_t* gc)
       void* p = obj->address;
       chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
       pony_type_t* type = *(pony_type_t**)p;
-      mark_local_object(ctx, chunk, p, type->trace);
+      mark_local_object(ctx, chunk, p, type, PONY_TRACE_IMMUTABLE);
     }
   }
 }

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -26,20 +26,20 @@ typedef struct gc_t
 
 DECLARE_STACK(ponyint_gcstack, gcstack_t, void);
 
-void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
-void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
-void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
-void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
-void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
 void ponyint_gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor);
 

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -1,9 +1,12 @@
 #include "serialise.h"
 #include "../sched/scheduler.h"
+#include "../actor/actor.h"
+#include <assert.h>
 
 struct serialise_t
 {
   void* p;
+  pony_type_t* t;
   size_t offset;
 };
 
@@ -35,10 +38,14 @@ static void recurse(pony_ctx_t* ctx, void* p, void* f)
   }
 }
 
-void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_type_t* t,
+void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  (void)mutability;
+  if(t->serialise == NULL)
+  {
+    // TODO: actor, MaybePointer[A] or Pointer[A], raise an error?
+    return;
+  }
 
   serialise_t k;
   k.p = p;
@@ -49,30 +56,19 @@ void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
   s = POOL_ALLOC(serialise_t);
   s->p = p;
+  s->t = t;
   s->offset = ctx->serialise_size;
   ponyint_serialise_put(&ctx->serialise, s);
 
   ctx->serialise_size += t->size;
-  recurse(ctx, p, t->trace);
 
-  // do embedded objects need to show up?
-
-  // TODO: writing to the buffer
-  // allocate a single buffer that's large enough
-  // for each object in the map
-  // write the object to its position in the buffer
-  // * write the type ID instead of the descriptor
-  // * for each field
-  //   * if it's a machine word, write it
-  //   * if it's an embedded object, write it
-  //   * if it's an object, write its buffer position
-  //     * if it's not in the buffer, write an invalid position
-  //   * if it's a tuple, write each element
+  if(mutability != PONY_TRACE_OPAQUE)
+    recurse(ctx, p, t->trace);
 }
 
-void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor)
+void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor)
 {
-  // TODO: do nothing
+  // TODO: raise an error?
   // when writing to the buffer, write the global id
   //   global id might not fit
   //   write an invalid position that maps to a global id
@@ -80,4 +76,31 @@ void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor)
   // can't serialise the actor: can't look at its state
   (void)ctx;
   (void)actor;
+}
+
+void* pony_serialise(pony_ctx_t* ctx, void* p)
+{
+  assert(ctx->stack == NULL);
+  ctx->trace_object = ponyint_serialise_object;
+  ctx->trace_actor = ponyint_serialise_actor;
+
+  pony_traceunknown(ctx, p, PONY_TRACE_MUTABLE);
+
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
+
+  void* out = ponyint_pool_alloc_size(ctx->serialise_size);
+
+  size_t i = HASHMAP_BEGIN;
+  serialise_t* s;
+
+  while((s = ponyint_serialise_next(&ctx->serialise, &i)) != NULL)
+  {
+    // TODO:
+    s->t->serialise(ctx, s->p, out + s->offset);
+  }
+
+  ctx->serialise_size = 0;
+  ponyint_serialise_destroy(&ctx->serialise);
+  return out;
 }

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -1,0 +1,84 @@
+#include "serialise.h"
+#include "../sched/scheduler.h"
+
+struct serialise_t
+{
+  void* p;
+  size_t offset;
+};
+
+static size_t serialise_hash(serialise_t* p)
+{
+  return ponyint_hash_ptr(p->p);
+}
+
+static bool serialise_cmp(serialise_t* a, serialise_t* b)
+{
+  return a->p == b->p;
+}
+
+static void serialise_free(serialise_t* p)
+{
+  POOL_FREE(serialise_t, p);
+}
+
+DEFINE_HASHMAP(ponyint_serialise, ponyint_serialise_t,
+  serialise_t, serialise_hash, serialise_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, serialise_free);
+
+static void recurse(pony_ctx_t* ctx, void* p, void* f)
+{
+  if(f != NULL)
+  {
+    ctx->stack = ponyint_gcstack_push(ctx->stack, p);
+    ctx->stack = ponyint_gcstack_push(ctx->stack, f);
+  }
+}
+
+void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable)
+{
+  (void)immutable;
+
+  serialise_t k;
+  k.p = p;
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+
+  if(s != NULL)
+    return;
+
+  s = POOL_ALLOC(serialise_t);
+  s->p = p;
+  s->offset = ctx->serialise_size;
+  ponyint_serialise_put(&ctx->serialise, s);
+
+  pony_type_t* type = *(pony_type_t**)p;
+  ctx->serialise_size += type->size;
+  recurse(ctx, p, f);
+
+  // do embedded objects need to show up?
+
+  // TODO: writing to the buffer
+  // allocate a single buffer that's large enough
+  // for each object in the map
+  // write the object to its position in the buffer
+  // * write the type ID instead of the descriptor
+  // * for each field
+  //   * if it's a machine word, write it
+  //   * if it's an embedded object, write it
+  //   * if it's an object, write its buffer position
+  //     * if it's not in the buffer, write an invalid position
+  //   * if it's a tuple, write each element
+}
+
+void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor)
+{
+  // TODO: do nothing
+  // when writing to the buffer, write the global id
+  //   global id might not fit
+  //   write an invalid position that maps to a global id
+  // if it's not a pony internal thing for distribution, record an error?
+  // can't serialise the actor: can't look at its state
+  (void)ctx;
+  (void)actor;
+}

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -1,8 +1,13 @@
 #include "serialise.h"
 #include "../sched/scheduler.h"
-#include "../actor/actor.h"
 #include "../lang/lang.h"
+#include <string.h>
 #include <assert.h>
+
+#define HIGH_BIT ((size_t)1 << ((sizeof(size_t) * 8) - 1))
+
+extern size_t __DescTableSize;
+extern pony_type_t* __DescTable;
 
 typedef struct
 {
@@ -14,20 +19,20 @@ typedef struct
 
 struct serialise_t
 {
-  void* p;
+  uintptr_t key;
+  uintptr_t value;
   pony_type_t* t;
-  size_t offset;
   int mutability;
 };
 
 static size_t serialise_hash(serialise_t* p)
 {
-  return ponyint_hash_ptr(p->p);
+  return ponyint_hash_size(p->key);
 }
 
 static bool serialise_cmp(serialise_t* a, serialise_t* b)
 {
-  return a->p == b->p;
+  return a->key == b->key;
 }
 
 static void serialise_free(serialise_t* p)
@@ -60,7 +65,7 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   }
 
   serialise_t k;
-  k.p = p;
+  k.key = (uintptr_t)p;
   serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
 
   if(s != NULL)
@@ -72,9 +77,9 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   } else {
     // Put an entry in the map and reserve space.
     s = POOL_ALLOC(serialise_t);
-    s->p = p;
+    s->key = (uintptr_t)p;
+    s->value = ctx->serialise_size;
     s->t = t;
-    s->offset = ctx->serialise_size;
 
     ponyint_serialise_put(&ctx->serialise, s);
     ctx->serialise_size += t->size;
@@ -119,9 +124,7 @@ void pony_serialise(pony_ctx_t* ctx, void* p, void* out)
   ctx->serialise_size = 0;
 
   pony_traceunknown(ctx, p, PONY_TRACE_MUTABLE);
-
   ponyint_gc_handlestack(ctx);
-  ponyint_gc_done(ponyint_actor_gc(ctx->current));
 
   ponyint_array_t* r = (ponyint_array_t*)out;
   r->size = ctx->serialise_size;
@@ -132,7 +135,7 @@ void pony_serialise(pony_ctx_t* ctx, void* p, void* out)
   serialise_t* s;
 
   while((s = ponyint_serialise_next(&ctx->serialise, &i)) != NULL)
-    s->t->serialise(ctx, s->p, r->ptr + s->offset, s->mutability);
+    s->t->serialise(ctx, (void*)s->key, r->ptr + s->value, s->mutability);
 
   ctx->serialise_size = 0;
   ponyint_serialise_destroy(&ctx->serialise);
@@ -141,15 +144,91 @@ void pony_serialise(pony_ctx_t* ctx, void* p, void* out)
 size_t pony_serialise_offset(pony_ctx_t* ctx, void* p)
 {
   serialise_t k;
-  k.p = p;
+  k.key = (uintptr_t)p;
   serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
 
   // If we are in the map, return the offset.
   if(s != NULL)
-    return s->offset;
+    return s->value;
 
   // If we are not in the map, we are an untraced primitive. Return the type id
   // with the high bit set.
   pony_type_t* t = *(pony_type_t**)p;
-  return (size_t)t->id | ((size_t)1 << ((sizeof(size_t) * 8) - 1));
+  return (size_t)t->id | HIGH_BIT;
+}
+
+void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,
+  uintptr_t offset)
+{
+  // If the high bit of the offset is set, it is either an unserialised
+  // primitive, or an unserialised field in an opaque object.
+  if((offset & HIGH_BIT) != 0)
+  {
+    offset &= ~HIGH_BIT;
+
+    if(offset > __DescTableSize)
+      return NULL;
+
+    // Return the global instance, if there is one. It's ok to return null if
+    // there is no global instance, as this will then be an unserisalised
+    // field in an opaque object.
+    t = (&__DescTable)[offset];
+    return t->instance;
+  }
+
+  // Lookup the offset, return the associated object if there is one.
+  serialise_t k;
+  k.key = offset;
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+
+  if(s != NULL)
+    return (void*)s->value;
+
+  // If we haven't been passed a type descriptor, read one.
+  if(t == NULL)
+  {
+    // Make sure we have space to read a type id.
+    if((offset + sizeof(uintptr_t)) > ctx->serialise_size)
+      pony_throw();
+
+    // Turn the type id into a descriptor pointer.
+    uintptr_t id = *(uintptr_t*)((uintptr_t)ctx->serialise_buffer + offset);
+    t = (&__DescTable)[id];
+  }
+
+  // If it's a primitive, return the global instance.
+  if(t->instance != NULL)
+    return t->instance;
+
+  // Make sure we have space to read the object.
+  if((offset + t->size) > ctx->serialise_size)
+    pony_throw();
+
+  // Allocate the object, memcpy to it.
+  void* object = pony_alloc(ctx, t->size);
+  memcpy(object, (void*)((uintptr_t)ctx->serialise_buffer + offset), t->size);
+
+  // Store a mapping of offset to object.
+  s = POOL_ALLOC(serialise_t);
+  s->key = offset;
+  s->value = (uintptr_t)object;
+  ponyint_serialise_put(&ctx->serialise, s);
+
+  recurse(ctx, object, t->deserialise);
+  return object;
+}
+
+void* pony_deserialise(pony_ctx_t* ctx, void* in)
+{
+  // This can raise an error.
+  ponyint_array_t* r = (ponyint_array_t*)in;
+  ctx->serialise_buffer = r->ptr;
+  ctx->serialise_size = r->size;
+
+  void* object = pony_deserialise_offset(ctx, NULL, 0);
+  ponyint_gc_handlestack(ctx);
+
+  ctx->serialise_size = 0;
+  ponyint_serialise_destroy(&ctx->serialise);
+  return object;
 }

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -35,10 +35,10 @@ static void recurse(pony_ctx_t* ctx, void* p, void* f)
   }
 }
 
-void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable)
+void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability)
 {
-  (void)immutable;
+  (void)mutability;
 
   serialise_t k;
   k.p = p;
@@ -52,9 +52,8 @@ void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_trace_fn f,
   s->offset = ctx->serialise_size;
   ponyint_serialise_put(&ctx->serialise, s);
 
-  pony_type_t* type = *(pony_type_t**)p;
-  ctx->serialise_size += type->size;
-  recurse(ctx, p, f);
+  ctx->serialise_size += t->size;
+  recurse(ctx, p, t->trace);
 
   // do embedded objects need to show up?
 

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -144,8 +144,12 @@ size_t pony_serialise_offset(pony_ctx_t* ctx, void* p)
   k.p = p;
   serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
 
-  if(s == NULL)
-    pony_throw();
+  // If we are in the map, return the offset.
+  if(s != NULL)
+    return s->offset;
 
-  return s->offset;
+  // If we are not in the map, we are an untraced primitive. Return the type id
+  // with the high bit set.
+  pony_type_t* t = *(pony_type_t**)p;
+  return (size_t)t->id | ((size_t)1 << ((sizeof(size_t) * 8) - 1));
 }

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -9,10 +9,12 @@ typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
 
-void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_type_t* t,
+void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);
 
-void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
+
+void* pony_serialise(pony_ctx_t* ctx, void* p);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -1,0 +1,19 @@
+#ifndef gc_serialise_h
+#define gc_serialise_h
+
+#include "gc.h"
+
+PONY_EXTERN_C_BEGIN
+
+typedef struct serialise_t serialise_t;
+
+DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
+
+void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+  bool immutable);
+
+void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -14,8 +14,6 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void pony_serialise(pony_ctx_t* ctx, void* p, void* out);
-
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -14,7 +14,7 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-void* pony_serialise(pony_ctx_t* ctx, void* p);
+void pony_serialise(pony_ctx_t* ctx, void* p, void* out);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -9,8 +9,8 @@ typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
 
-void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_trace_fn f,
-  bool immutable);
+void ponyint_serialise_object_size(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  int mutability);
 
 void ponyint_serialise_actor_size(pony_ctx_t* ctx, pony_actor_t* actor);
 

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -92,6 +92,19 @@ void pony_release_done(pony_ctx_t* ctx)
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 
+void ponyint_serialise_size_begin(pony_ctx_t* ctx)
+{
+  assert(ctx->stack == NULL);
+  ctx->trace_object = ponyint_serialise_object_size;
+  ctx->trace_actor = ponyint_serialise_actor_size;
+}
+
+void ponyint_serialise_size_done(pony_ctx_t* ctx)
+{
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
+}
+
 void pony_trace(pony_ctx_t* ctx, void* p)
 {
   ctx->trace_object(ctx, p, NULL, false);

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -92,19 +92,6 @@ void pony_release_done(pony_ctx_t* ctx)
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 
-void ponyint_serialise_size_begin(pony_ctx_t* ctx)
-{
-  assert(ctx->stack == NULL);
-  ctx->trace_object = ponyint_serialise_object_size;
-  ctx->trace_actor = ponyint_serialise_actor_size;
-}
-
-void ponyint_serialise_size_done(pony_ctx_t* ctx)
-{
-  ponyint_gc_handlestack(ctx);
-  ponyint_gc_done(ponyint_actor_gc(ctx->current));
-}
-
 void pony_trace(pony_ctx_t* ctx, void* p)
 {
   ctx->trace_object(ctx, p, NULL, PONY_TRACE_OPAQUE);

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -107,39 +107,27 @@ void ponyint_serialise_size_done(pony_ctx_t* ctx)
 
 void pony_trace(pony_ctx_t* ctx, void* p)
 {
-  ctx->trace_object(ctx, p, NULL, false);
+  ctx->trace_object(ctx, p, NULL, PONY_TRACE_OPAQUE);
 }
 
-void pony_traceactor(pony_ctx_t* ctx, pony_actor_t* p)
+void pony_traceknown(pony_ctx_t* ctx, void* p, pony_type_t* t, int m)
 {
-  ctx->trace_actor(ctx, p);
-}
-
-void pony_traceobject(pony_ctx_t* ctx, void* p, pony_type_t* t, int immutable)
-{
-  ctx->trace_object(ctx, p, t, immutable != 0);
-}
-
-void pony_traceunknown(pony_ctx_t* ctx, void* p, int immutable)
-{
-  pony_type_t* type = *(pony_type_t**)p;
-
-  if(type->dispatch != NULL)
+  if(t->dispatch != NULL)
   {
     ctx->trace_actor(ctx, (pony_actor_t*)p);
   } else {
-    ctx->trace_object(ctx, p, type, immutable != 0);
+    ctx->trace_object(ctx, p, t, m);
   }
 }
 
-void pony_trace_tag_or_actor(pony_ctx_t* ctx, void* p)
+void pony_traceunknown(pony_ctx_t* ctx, void* p, int m)
 {
-  pony_type_t* type = *(pony_type_t**)p;
+  pony_type_t* t = *(pony_type_t**)p;
 
-  if(type->dispatch != NULL)
+  if(t->dispatch != NULL)
   {
     ctx->trace_actor(ctx, (pony_actor_t*)p);
   } else {
-    ctx->trace_object(ctx, p, NULL, false);
+    ctx->trace_object(ctx, p, t, m);
   }
 }

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -115,9 +115,9 @@ void pony_traceactor(pony_ctx_t* ctx, pony_actor_t* p)
   ctx->trace_actor(ctx, p);
 }
 
-void pony_traceobject(pony_ctx_t* ctx, void* p, pony_trace_fn f, int immutable)
+void pony_traceobject(pony_ctx_t* ctx, void* p, pony_type_t* t, int immutable)
 {
-  ctx->trace_object(ctx, p, f, immutable != 0);
+  ctx->trace_object(ctx, p, t, immutable != 0);
 }
 
 void pony_traceunknown(pony_ctx_t* ctx, void* p, int immutable)
@@ -128,7 +128,7 @@ void pony_traceunknown(pony_ctx_t* ctx, void* p, int immutable)
   {
     ctx->trace_actor(ctx, (pony_actor_t*)p);
   } else {
-    ctx->trace_object(ctx, p, type->trace, immutable != 0);
+    ctx->trace_object(ctx, p, type, immutable != 0);
   }
 }
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -67,7 +67,7 @@ typedef void (*pony_trace_fn)(pony_ctx_t* ctx, void* p);
  * executing context, the object being serialised, and an address to serialise
  * to.
  */
-typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr);
+typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr, int m);
 
 /** Dispatch function.
  *

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -67,7 +67,8 @@ typedef void (*pony_trace_fn)(pony_ctx_t* ctx, void* p);
  * executing context, the object being serialised, and an address to serialise
  * to.
  */
-typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr, int m);
+typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr,
+  size_t offset, int m);
 
 /** Dispatch function.
  *

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -276,7 +276,7 @@ void pony_traceactor(pony_ctx_t* ctx, pony_actor_t* p);
  * @param p The pointer being traced.
  * @param f The trace function for the object pointed to.
  */
-void pony_traceobject(pony_ctx_t* ctx, void* p, pony_trace_fn f, int immutable);
+void pony_traceobject(pony_ctx_t* ctx, void* p, pony_type_t* t, int immutable);
 
 /** Trace unknown.
  *

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -92,6 +92,7 @@ typedef const struct _pony_type_t
   uint32_t trait_count;
   uint32_t field_count;
   uint32_t field_offset;
+  void* instance;
   pony_trace_fn trace;
   pony_trace_fn serialise_trace;
   pony_serialise_fn serialise;

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -63,7 +63,7 @@ typedef void (*pony_trace_fn)(pony_ctx_t* ctx, void* p);
 
 /** Serialise function.
  *
- * Each type may supply a trace function. It is invoked with the currently
+ * Each type may supply a serialise function. It is invoked with the currently
  * executing context, the object being serialised, and an address to serialise
  * to.
  */
@@ -93,6 +93,7 @@ typedef const struct _pony_type_t
   uint32_t field_count;
   uint32_t field_offset;
   pony_trace_fn trace;
+  pony_trace_fn serialise_trace;
   pony_serialise_fn serialise;
   pony_trace_fn deserialise;
   pony_dispatch_fn dispatch;

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -61,6 +61,14 @@ typedef struct pony_msgp_t
  */
 typedef void (*pony_trace_fn)(pony_ctx_t* ctx, void* p);
 
+/** Serialise function.
+ *
+ * Each type may supply a trace function. It is invoked with the currently
+ * executing context, the object being serialised, and an address to serialise
+ * to.
+ */
+typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr);
+
 /** Dispatch function.
  *
  * Each actor has a dispatch function that is invoked when the actor handles
@@ -85,7 +93,7 @@ typedef const struct _pony_type_t
   uint32_t field_count;
   uint32_t field_offset;
   pony_trace_fn trace;
-  pony_trace_fn serialise;
+  pony_serialise_fn serialise;
   pony_trace_fn deserialise;
   pony_dispatch_fn dispatch;
   pony_final_fn final;

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -209,7 +209,7 @@ void pony_gc_send(pony_ctx_t* ctx);
 void pony_gc_recv(pony_ctx_t* ctx);
 
 /** Start gc tracing for acquiring.
- * 
+ *
  * Call this when acquiring objects. Then trace the objects you want to
  * acquire, then call pony_acquire_done. Acquired objects will not be GCed
  * until released even if they are not reachable from Pony code anymore.
@@ -223,7 +223,7 @@ void pony_gc_recv(pony_ctx_t* ctx);
 void pony_gc_acquire(pony_ctx_t* ctx);
 
 /** Start gc tracing for releasing.
- * 
+ *
  * Call this when releasing acquired objects. Then trace the objects you want
  * to release, then call pony_release_done. If an object was acquired multiple
  * times, it must be released as many times before being GCed.
@@ -243,29 +243,34 @@ void pony_send_done(pony_ctx_t* ctx);
 void pony_recv_done(pony_ctx_t* ctx);
 
 /** Finish gc tracing for acquiring.
- * 
+ *
  * Call this after tracing objects you want to acquire.
  */
 void pony_acquire_done(pony_ctx_t* ctx);
 
 /** Finish gc tracing for releasing.
- * 
+ *
  * Call this after tracing objects you want to release.
  */
 void pony_release_done(pony_ctx_t* ctx);
 
+/** Identifiers for reference capabilities when tracing.
+ *
+ * At runtime, we need to identify if the object is logically mutable,
+ * immutable, or opaque.
+ */
+enum
+{
+  PONY_TRACE_MUTABLE = 0,
+  PONY_TRACE_IMMUTABLE = 1,
+  PONY_TRACE_OPAQUE = 2
+};
+
 /** Trace memory
  *
- * Call this on allocated memory that contains no pointers to other allocated
- * memory. Also use this to mark tag aliases.
+ * Call this on allocated blocks of memory that do not have object headers.
  */
 void pony_trace(pony_ctx_t* ctx, void* p);
-
-/** Trace an actor
- *
- * This should be called for fields in an object that point to an actor.
- */
-void pony_traceactor(pony_ctx_t* ctx, pony_actor_t* p);
 
 /** Trace an object.
  *
@@ -274,23 +279,20 @@ void pony_traceactor(pony_ctx_t* ctx, pony_actor_t* p);
  *
  * @param ctx The current context.
  * @param p The pointer being traced.
- * @param f The trace function for the object pointed to.
+ * @param t The pony_type_t for the object pointed to.
+ * @param m Logical mutability of the object pointed to.
  */
-void pony_traceobject(pony_ctx_t* ctx, void* p, pony_type_t* t, int immutable);
+void pony_traceknown(pony_ctx_t* ctx, void* p, pony_type_t* t, int m);
 
 /** Trace unknown.
  *
- * This should be called for fields in an object with an unknown type, but
- * which are not tags.
- */
-void pony_traceunknown(pony_ctx_t* ctx, void* p, int immutable);
-
-/** Trace a tag or an actor
+ * This should be called for fields in an object with an unknown type.
  *
- * This should be called for fields in an object that might be an actor or
- * might be a tag.
+ * @param ctx The current context.
+ * @param p The pointer being traced.
+ * @param m Logical mutability of the object pointed to.
  */
-void pony_trace_tag_or_actor(pony_ctx_t* ctx, void* p);
+void pony_traceunknown(pony_ctx_t* ctx, void* p, int m);
 
 /** Initialize the runtime.
  *

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -11,7 +11,7 @@
 PONY_EXTERN_C_BEGIN
 
 typedef void (*trace_object_fn)(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  bool immutable);
+  int mutability);
 
 typedef void (*trace_actor_fn)(pony_ctx_t* ctx, pony_actor_t* actor);
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -27,6 +27,7 @@ typedef struct pony_ctx_t
   actormap_t acquire;
   bool finalising;
 
+  void* serialise_buffer;
   size_t serialise_size;
   ponyint_serialise_t serialise;
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -5,6 +5,7 @@
 #include <platform.h>
 #include "actor/messageq.h"
 #include "gc/gc.h"
+#include "gc/serialise.h"
 #include "mpmcq.h"
 
 PONY_EXTERN_C_BEGIN
@@ -25,6 +26,9 @@ typedef struct pony_ctx_t
   gcstack_t* stack;
   actormap_t acquire;
   bool finalising;
+
+  size_t serialise_size;
+  ponyint_serialise_t serialise;
 
 #ifdef USE_TELEMETRY
   size_t tsc;

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -10,7 +10,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-typedef void (*trace_object_fn)(pony_ctx_t* ctx, void* p, pony_trace_fn f,
+typedef void (*trace_object_fn)(pony_ctx_t* ctx, void* p, pony_type_t* t,
   bool immutable);
 
 typedef void (*trace_actor_fn)(pony_ctx_t* ctx, pony_actor_t* actor);


### PR DESCRIPTION
This adds compiler support for serialisation and deserialisation. The API is designed to require capability tokens, as otherwise serialising would leak the bit patterns of all private information in a type (since the resulting `Array[U8]` could be examined.

Deserialisation is fundamentally unsafe currently: there isn't yet a verification pass to check that the resulting object graph maintains a well-formed heap or that individual objects maintain any expected local invariants. However, if only "trusted" data (i.e. data produced by Pony serialisation from the same binary) is deserialised, it will always maintain a well-formed heap and all object invariants.

Note that serialised data is not usable between different Pony binaries, possibly including recompilation of the same code. This is due to the use of type identifiers rather than a heavy-weight self-describing serialisation schema.