### PR TITLE
Generating tuple return value with tuple bodies

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -356,7 +356,7 @@ static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
     // cast even if the body type is not a tuple.
     ast_t* body_type = ast_type(body);
 
-    if(ast_id(result) == TK_TUPLETYPE)
+    if((ast_id(result) == TK_TUPLETYPE) && (ast_id(body_type) != TK_TUPLETYPE))
       body_type = result;
 
     LLVMValueRef ret = gen_assign_cast(c, r_type, value, body_type);


### PR DESCRIPTION
Previously, this line of code always switch to the return type for
gen_assign_cast if the return type was a tuple. This is needed in
order to codegen the right LLVM return type. However, if the body
type is also a tuple, then the body type, rather than the result
type, should be passed to gen_assign_cast so that the correct
boxed type can be chosen by gen_box if necessary.