### PR TITLE
Use LLVM i8 for Bool instead of i1

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -155,6 +155,7 @@ static void init_runtime(compile_t* c)
   LLVMValueRef value;
 
   c->void_type = LLVMVoidTypeInContext(c->context);
+  c->ibool = LLVMInt8TypeInContext(c->context);
   c->i1 = LLVMInt1TypeInContext(c->context);
   c->i8 = LLVMInt8TypeInContext(c->context);
   c->i16 = LLVMInt16TypeInContext(c->context);

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -27,7 +27,7 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
 
 #define GEN_NOVALUE ((LLVMValueRef)1)
 
-#define GEN_NOTNEEDED (LLVMConstInt(c->i1, 1, false))
+#define GEN_NOTNEEDED (LLVMConstInt(c->ibool, 0, false))
 
 typedef struct compile_local_t compile_local_t;
 DECLARE_HASHMAP(compile_locals, compile_locals_t, compile_local_t);
@@ -117,6 +117,7 @@ typedef struct compile_t
   LLVMMetadataRef di_unit;
 
   LLVMTypeRef void_type;
+  LLVMTypeRef ibool;
   LLVMTypeRef i1;
   LLVMTypeRef i8;
   LLVMTypeRef i16;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -103,7 +103,7 @@ static LLVMValueRef special_case_platform(compile_t* c, ast_t* ast)
   bool is_target;
 
   if(os_is_target(method_name, c->opt->release, &is_target, c->opt))
-    return LLVMConstInt(c->i1, is_target ? 1 : 0, false);
+    return LLVMConstInt(c->ibool, is_target ? 1 : 0, false);
 
   ast_error(c->opt->check.errors, ast, "unknown Platform setting");
   return NULL;

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -69,7 +69,8 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   if(!is_control_type(type))
     post_block = codegen_block(c, "if_post");
 
-  LLVMBuildCondBr(c->builder, c_value, then_block, else_block);
+  LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
+  LLVMBuildCondBr(c->builder, test, then_block, else_block);
 
   // Left branch.
   LLVMPositionBuilderAtEnd(c->builder, then_block);
@@ -192,7 +193,8 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   if(i_value == NULL)
     return NULL;
 
-  LLVMBuildCondBr(c->builder, i_value, body_block, else_block);
+  LLVMValueRef test = LLVMBuildTrunc(c->builder, i_value, c->i1, "");
+  LLVMBuildCondBr(c->builder, test, body_block, else_block);
 
   // Body.
   LLVMPositionBuilderAtEnd(c->builder, body_block);
@@ -218,7 +220,8 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
       return NULL;
 
     body_from = LLVMGetInsertBlock(c->builder);
-    LLVMBuildCondBr(c->builder, c_value, body_block, post_block);
+    LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
+    LLVMBuildCondBr(c->builder, test, body_block, post_block);
   }
 
   // Don't need loop status for the else block.
@@ -323,7 +326,8 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
       return NULL;
 
     body_from = LLVMGetInsertBlock(c->builder);
-    LLVMBuildCondBr(c->builder, c_value, post_block, body_block);
+    LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
+    LLVMBuildCondBr(c->builder, test, post_block, body_block);
   }
 
   // cond block
@@ -331,7 +335,9 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   // or to the else block.
   LLVMPositionBuilderAtEnd(c->builder, cond_block);
   LLVMValueRef i_value = gen_expr(c, cond);
-  LLVMBuildCondBr(c->builder, i_value, else_block, body_block);
+
+  LLVMValueRef test = LLVMBuildTrunc(c->builder, i_value, c->i1, "");
+  LLVMBuildCondBr(c->builder, test, else_block, body_block);
 
   // Don't need loop status for the else block.
   codegen_poploop(c);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -115,11 +115,11 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_TRUE:
-      ret = LLVMConstInt(c->i1, 1, false);
+      ret = LLVMConstInt(c->ibool, 1, false);
       break;
 
     case TK_FALSE:
-      ret = LLVMConstInt(c->i1, 0, false);
+      ret = LLVMConstInt(c->ibool, 0, false);
       break;
 
     case TK_INT:

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -3,6 +3,9 @@
 #include "genexpr.h"
 #include <assert.h>
 
+static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
+  ast_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value);
+
 static LLVMValueRef tuple_is(compile_t* c, ast_t* left_type, ast_t* right_type,
   LLVMValueRef l_value, LLVMValueRef r_value)
 {
@@ -58,8 +61,8 @@ static LLVMValueRef tuple_is(compile_t* c, ast_t* left_type, ast_t* right_type,
   return phi;
 }
 
-LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type, ast_t* right_type,
-  LLVMValueRef l_value, LLVMValueRef r_value)
+static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
+  ast_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value)
 {
   LLVMTypeRef l_type = LLVMTypeOf(l_value);
   LLVMTypeRef r_type = LLVMTypeOf(r_value);
@@ -131,8 +134,9 @@ LLVMValueRef gen_is(compile_t* c, ast_t* ast)
   codegen_debugloc(c, ast);
   LLVMValueRef result = gen_is_value(c, left_type, right_type,
     l_value, r_value);
+  LLVMValueRef value = LLVMBuildZExt(c->builder, result, c->ibool, "");
   codegen_debugloc(c, NULL);
-  return result;
+  return value;
 }
 
 LLVMValueRef gen_isnt(compile_t* c, ast_t* ast)

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -141,10 +141,21 @@ LLVMValueRef gen_is(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_isnt(compile_t* c, ast_t* ast)
 {
-  LLVMValueRef is = gen_is(c, ast);
+  AST_GET_CHILDREN(ast, left, right);
+  ast_t* left_type = ast_type(left);
+  ast_t* right_type = ast_type(right);
 
-  if(is == NULL)
+  LLVMValueRef l_value = gen_expr(c, left);
+  LLVMValueRef r_value = gen_expr(c, right);
+
+  if((l_value == NULL) || (r_value == NULL))
     return NULL;
 
-  return LLVMBuildNot(c->builder, is, "");
+  codegen_debugloc(c, ast);
+  LLVMValueRef result = gen_is_value(c, left_type, right_type,
+    l_value, r_value);
+  result = LLVMBuildNot(c->builder, result, "");
+  LLVMValueRef value = LLVMBuildZExt(c->builder, result, c->ibool, "");
+  codegen_debugloc(c, NULL);
+  return value;
 }

--- a/src/libponyc/codegen/genident.h
+++ b/src/libponyc/codegen/genident.h
@@ -6,9 +6,6 @@
 
 PONY_EXTERN_C_BEGIN
 
-LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type, ast_t* right_type,
-  LLVMValueRef l_value, LLVMValueRef r_value);
-
 LLVMValueRef gen_is(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_isnt(compile_t* c, ast_t* ast);

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -552,6 +552,23 @@ LLVMValueRef gen_not(compile_t* c, ast_t* ast)
   if(value == NULL)
     return NULL;
 
+  ast_t* type = ast_type(ast);
+
+  if(is_bool(type))
+  {
+    if(LLVMIsAConstantInt(value))
+    {
+      if(is_always_true(value))
+        return LLVMConstInt(c->ibool, 0, false);
+
+      return LLVMConstInt(c->ibool, 1, false);
+    }
+
+    LLVMValueRef test = LLVMBuildICmp(c->builder, LLVMIntEQ, value,
+      LLVMConstInt(c->ibool, 0, false), "");
+    return LLVMBuildZExt(c->builder, test, c->ibool, "");
+  }
+
   if(LLVMIsAConstantInt(value))
     return LLVMConstNot(value);
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -532,12 +532,7 @@ static void optimise(compile_t* c)
   pmb.LoopVectorize = true;
   pmb.SLPVectorize = true;
   pmb.RerollLoops = true;
-
-#if !defined(PLATFORM_IS_MACOSX)
-  // The LoadCombine optimisation can result in IR errors inside LLVM on OSX.
-  // These errors don't occur on Linux or Windows.
   pmb.LoadCombine = true;
-#endif
 
   pmb.addExtension(PassManagerBuilder::EP_LoopOptimizerEnd,
     addHeapToStackPass);
@@ -594,7 +589,7 @@ bool genopt(compile_t* c)
   {
     if(c->opt->verbosity >= VERBOSITY_MINIMAL)
       fprintf(stderr, "Verifying\n");
-    
+
     char* msg = NULL;
 
     if(LLVMVerifyModule(c->module, LLVMPrintMessageAction, &msg) != 0)

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -424,12 +424,13 @@ static void maybe_is_none(compile_t* c, reach_type_t* t)
 {
   // Returns true if the receiver is null.
   FIND_METHOD("is_none");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef receiver = LLVMGetParam(m->func, 0);
   LLVMValueRef test = LLVMBuildIsNull(c->builder, receiver, "");
+  LLVMValueRef value = LLVMBuildZExt(c->builder, test, c->ibool, "");
 
-  LLVMBuildRet(c->builder, test);
+  LLVMBuildRet(c->builder, value);
   codegen_finishfun(c);
 
   BOX_FUNCTION();
@@ -901,10 +902,10 @@ void genprim_string_deserialise(compile_t* c, reach_type_t* t)
 static void platform_freebsd(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("freebsd");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_freebsd(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_freebsd(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -914,10 +915,10 @@ static void platform_freebsd(compile_t* c, reach_type_t* t)
 static void platform_linux(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("linux");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_linux(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_linux(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -927,10 +928,10 @@ static void platform_linux(compile_t* c, reach_type_t* t)
 static void platform_osx(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("osx");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_macosx(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_macosx(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -940,10 +941,10 @@ static void platform_osx(compile_t* c, reach_type_t* t)
 static void platform_windows(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("windows");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_windows(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_windows(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -953,10 +954,10 @@ static void platform_windows(compile_t* c, reach_type_t* t)
 static void platform_x86(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("x86");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_x86(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_x86(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -966,10 +967,10 @@ static void platform_x86(compile_t* c, reach_type_t* t)
 static void platform_arm(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("arm");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_arm(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_arm(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -979,10 +980,10 @@ static void platform_arm(compile_t* c, reach_type_t* t)
 static void platform_lp64(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("lp64");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_lp64(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_lp64(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -992,10 +993,10 @@ static void platform_lp64(compile_t* c, reach_type_t* t)
 static void platform_llp64(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("llp64");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_llp64(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_llp64(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -1005,10 +1006,10 @@ static void platform_llp64(compile_t* c, reach_type_t* t)
 static void platform_ilp32(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("ilp32");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_ilp32(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_ilp32(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -1018,10 +1019,10 @@ static void platform_ilp32(compile_t* c, reach_type_t* t)
 static void platform_native128(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("native128");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
   LLVMValueRef result =
-    LLVMConstInt(c->i1, target_is_native128(c->opt->triple), false);
+    LLVMConstInt(c->ibool, target_is_native128(c->opt->triple), false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 
@@ -1031,9 +1032,9 @@ static void platform_native128(compile_t* c, reach_type_t* t)
 static void platform_debug(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("debug");
-  start_function(c, m, c->i1, &t->use_type, 1);
+  start_function(c, m, c->ibool, &t->use_type, 1);
 
-  LLVMValueRef result = LLVMConstInt(c->i1, !c->opt->release, false);
+  LLVMValueRef result = LLVMConstInt(c->ibool, !c->opt->release, false);
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -43,7 +43,7 @@ static bool make_opaque_struct(compile_t* c, reach_type_t* t)
       if(package == c->str_builtin)
       {
         if(name == c->str_Bool)
-          t->primitive = c->i1;
+          t->primitive = c->ibool;
         else if(name == c->str_I8)
           t->primitive = c->i8;
         else if(name == c->str_U8)


### PR DESCRIPTION
The LLVM load-combine pass can produce invalid results when
combining i1 loads. Previously, it was believed this only
happened on OSX, so the load-combine pass was disabled on OSX.
However, a Linux test case has been found.

The performance cost of disabling load-combine is high. Switching
to representing Bool as i8 instead of i1 has no runtime cost, and
may actually improve performance depending on how LLVM was storing
sequences of i8 in structures.

The load-combine pass is now re-enabled on all platforms.