### PR TITLE
Fix annoying, constant CHANGELOG merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 pony.g export-ignore
 .gitattributes export-ignore  
 .gitignore export-ignore
+CHANGELOG.md merge=union


### PR DESCRIPTION
Git being a non-semantic tool can't tell when changes to the same
line are additive or exclusive. This really comes to the fore for
us with the CHANGELOG.md file where multiple people will be adding
entries at the same time. The default for git it is assume they
are exclusive changes. Usually, this is the correct assumption,
however with the CHANGELOG.md, it is not.

This commit changes merges of CHANGELOG.md to use the "union"
merge strategy. It is described in the Git book as:

Instead of leaving conflicts in the file, resolve conflicts favouring
our (or their or both) side of the lines.

You can read more about git merge strategies at:

https://git-scm.com/docs/git-merge-file