### PR TITLE
Set basic attributes on standard source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,12 @@
+[attr]pony text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=2
+
+*.c pony
+*.cc pony
+*.h pony
+*.pony pony
+
 pony.g export-ignore
-.gitattributes export-ignore  
+.gitattributes export-ignore
 .gitignore export-ignore
+
 CHANGELOG.md merge=union


### PR DESCRIPTION
Utilize git attibutes (https://git-scm.com/docs/gitattributes) to
make sure we have 2 space indent, no tabs for indent, no trailing
whitespace and lf as our line ending.