### PR TITLE
Memory leak when iso send is resent as val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Compiler crash on type alias of a lambda type.
 - Late detection of errors silently emitted in lexer/parser.
 - Compiler crash when handling invalid lambda return types
+- Memory leak fixed when something sent as iso is then sent as val.
 
 ### Added
 

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -47,7 +47,6 @@ static bool viewref_cmp(viewref_t* a, viewref_t* b)
 
 static void viewref_free(viewref_t* vref)
 {
-  // TODO: view_free(vref->view) ?
   POOL_FREE(viewref_t, vref);
 }
 

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -22,7 +22,6 @@ static object_t* object_alloc(void* address, uint32_t mark)
   obj->address = address;
   obj->final = NULL;
   obj->rc = 0;
-  obj->reachable = true;
   obj->immutable = false;
 
   // a new object is unmarked
@@ -91,12 +90,8 @@ size_t ponyint_objectmap_sweep(objectmap_t* map)
 
     if(obj->rc > 0)
     {
-      // Keep track of whether or not the object was reachable.
       chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
-      obj->reachable = ponyint_heap_ismarked(chunk, p);
-
-      if(!obj->reachable)
-        ponyint_heap_mark_shallow(chunk, p);
+      ponyint_heap_mark_shallow(chunk, p);
     } else {
       if(obj->final != NULL)
       {

--- a/src/libponyrt/gc/objectmap.h
+++ b/src/libponyrt/gc/objectmap.h
@@ -12,7 +12,6 @@ typedef struct object_t
   pony_final_fn final;
   size_t rc;
   uint32_t mark;
-  bool reachable;
   bool immutable;
 } object_t;
 


### PR DESCRIPTION
Previously, something resent as immutable was fully traced. This
was to protect against a premature free on release when the object
was not reachable by the owner. However, it resulted in an off-by-
one error in the RC and a memory leak.

Now, objects resent as immutable need not be fully traced, which is
a performance optimisation as well as removing the memory leak. As
a result, reachability on locally owned objects that have been sent
in messages is no longer tracked, so a release message can't result
in an immediate free (a gc cycle has to happen).