### PR TITLE
Have HashMap.concat return `this` rather than `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Renamed `identityof` to `digestof`.
 - Renamed `net/Buffer` to `net/ReadBuffer`
 - Print compiler error and info messages to stderr instead of stdout.
+- `Hashmap.concat` now returns `this` rather than `None`
 
 ## [0.2.1] - 2015-10-06
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -137,13 +137,14 @@ class HashMap[K, V, H: HashFunction[K] val]
     (_, let found) = _search(k)
     found
 
-  fun ref concat(iter: Iterator[(K^, V^)]) =>
+  fun ref concat(iter: Iterator[(K^, V^)]): HashMap[K, V, H]^ =>
     """
     Add K, V pairs from the iterator to the map.
     """
     for (k, v) in iter do
       this(consume k) = consume v
     end
+    this
 
   fun add[H2: HashFunction[this->K!] val = H](key: this->K!, value: this->V!):
     HashMap[this->K!, this->V!, H2]^


### PR DESCRIPTION
Allows for code such as:

```pony
Map[String, String].concat([
  ("hi", "there"),
  ("sailor", "boy")].values())
```