### PR TITLE
String.from_array should copy _size bytes

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -37,7 +37,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     else
       _alloc = _size + 1
       _ptr = Pointer[U8]._alloc(_alloc)
-      data._cstring()._copy_to(_ptr, _alloc)
+      data._cstring()._copy_to(_ptr, _size)
       _set(_size, 0)
     end
 


### PR DESCRIPTION
Previously, it was copying _alloc bytes from the array, when the
array did not have _alloc bytes available. This would often succeed
due to an extra byte being read not causing a problem. However, for
a zero-length array or an array aligned right on a page boundary,
this would segfault.

Copying _size bytes always works, even for a zero-length array.