### PR TITLE
Fix compiler crash on object literal with uninitialized fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Late detection of errors silently emitted in lexer/parser.
 - Compiler crash when handling invalid lambda return types
 - Memory leak fixed when something sent as iso is then sent as val.
+- Compiler crash when handling object literal with uninitialized fields.
 
 ### Added
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -140,3 +140,16 @@ TEST_F(BadPonyTest, InvalidMethodReturnType)
 
   TEST_ERRORS_1(src, "function return type: iso");
 }
+
+TEST_F(BadPonyTest, ObjectLiteralUninitializedField)
+{
+  // From issue #879
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    object\n"
+    "      let x: I32\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "object literal fields must be initialized");
+}


### PR DESCRIPTION
Resolves #879.