### PR TITLE
Fix exit call to use _exit instead which is safer for a chile process

### DIFF
--- a/packages/process/process-monitor.pony
+++ b/packages/process/process-monitor.pony
@@ -228,7 +228,7 @@ actor ProcessMonitor
       _dup2(_stdout_write, _STDOUTFILENO()) // redirect stdout
       _dup2(_stderr_write, _STDERRFILENO()) // redirect stderr
       if @execve[I32](path.cstring(), argp.cstring(), envp.cstring()) < 0 then
-        @exit[None](I32(-1))
+        @_exit[None](I32(-1))
       end
     end
       
@@ -269,7 +269,7 @@ actor ProcessMonitor
         if @pony_os_errno() == _EINTR() then
           continue
         else
-          @exit[None](I32(-1))
+          @_exit[None](I32(-1))
         end
       end
     end


### PR DESCRIPTION
In the child branch of a fork(), it is normally incorrect to use
exit(), because that can lead to stdio buffers being flushed
twice, and temporary files being unexpectedly removed.