### PR TITLE
Add primitive to deal with EAGAIN and O_NONBLOCK values on Linux and OSX

### DIFF
--- a/packages/process/process-monitor.pony
+++ b/packages/process/process-monitor.pony
@@ -100,18 +100,26 @@ use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
       
-primitive _EINTR        fun apply(): I32 => 4
-primitive _EAGAIN       fun apply(): I32 => 35
-primitive _STDINFILENO  fun apply(): U32 => 0
-primitive _STDOUTFILENO fun apply(): U32 => 1
-primitive _STDERRFILENO fun apply(): U32 => 2
-primitive _ONONBLOCK    fun apply(): I32 => 4
-primitive _FSETFL       fun apply(): I32 => 4
-primitive _FGETFL       fun apply(): I32 => 3
-primitive _FSETFD       fun apply(): I32 => 2
-primitive _FGETFD       fun apply(): I32 => 1
-primitive _FDCLOEXEC    fun apply(): I32 => 1
-primitive _SIGTERM      fun apply(): I32 => 15
+primitive _EINTR          fun apply(): I32 => 4
+primitive _STDINFILENO    fun apply(): U32 => 0
+primitive _STDOUTFILENO   fun apply(): U32 => 1
+primitive _STDERRFILENO   fun apply(): U32 => 2
+primitive _FSETFL         fun apply(): I32 => 4
+primitive _FGETFL         fun apply(): I32 => 3
+primitive _FSETFD         fun apply(): I32 => 2
+primitive _FGETFD         fun apply(): I32 => 1
+primitive _FDCLOEXEC      fun apply(): I32 => 1
+primitive _SIGTERM        fun apply(): I32 => 15
+
+primitive _EAGAIN      fun apply(): I32 =>
+  ifdef freebsd or osx then 35
+  elseif linux then 11
+  else compile_error "no EAGAIN" end
+      
+primitive _ONONBLOCK   fun apply(): I32 =>
+  ifdef freebsd or osx then 4
+  elseif linux then 2048
+  else compile_error "no O_NONBLOCK" end
 
 primitive ExecveError
 primitive PipeError


### PR DESCRIPTION
- EAGAIN needs to return 11 on Linux and 35 on OSX and FreeBSD
- O_NONBLOCK needs to return 2048 on Linux and 4 on OSX and FreeBSD