### PR TITLE
Mark pony_ctx as readnone in LLVM IR

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -236,6 +236,7 @@ static void init_runtime(compile_t* c)
   type = LLVMFunctionType(c->void_ptr, NULL, 0, false);
   value = LLVMAddFunction(c->module, "pony_ctx", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+  LLVMAddFunctionAttr(value, LLVMReadNoneAttribute);
 
   // __object* pony_create(i8*, __Desc*)
   params[0] = c->void_ptr;


### PR DESCRIPTION
This avoids redundant calls in generated code after inlining. `pony_ctx` always returns the same pointer from within a single behaviour so this is safe.