### PR TITLE
Use the nice name for types when generating documentation (#872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Compiler crash when handling invalid lambda return types
 - Memory leak fixed when something sent as iso is then sent as val.
 - Compiler crash when handling object literal with uninitialized fields.
+- Associate a nice name with function types based on the type of the function.
+- Use the nice name for types when generating documentation.
 
 ### Added
 

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -303,7 +303,9 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
     {
       AST_GET_CHILDREN(type, package, id, tparams, cap, ephemeral);
 
-      if(generate_links)
+      // Generate links only if directed to and if the type is not anonymous (as
+      // indicated by a name created by package_hygienic_id).
+      if(generate_links && *ast_name(id) != '$')
       {
         // Find type we reference so we can link to it
         ast_t* target = (ast_t*)ast_data(type);
@@ -313,14 +315,14 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
         char* tqfn = write_tqfn(target, NULL, &link_len);
 
         // Links are of the form: [text](target)
-        fprintf(docgen->type_file, "[%s](%s)", ast_name(id), tqfn);
+        fprintf(docgen->type_file, "[%s](%s)", ast_nice_name(id), tqfn);
         ponyint_pool_free_size(link_len, tqfn);
 
         doc_type_list(docgen, tparams, "\\[", ", ", "\\]", true);
       }
       else
       {
-        fprintf(docgen->type_file, "%s", ast_name(id));
+        fprintf(docgen->type_file, "%s", ast_nice_name(id));
         doc_type_list(docgen, tparams, "[", ", ", "]", false);
       }
 
@@ -349,7 +351,7 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
     case TK_TYPEPARAMREF:
     {
       AST_GET_CHILDREN(type, id, cap, ephemeral);
-      fprintf(docgen->type_file, "%s", ast_name(id));
+      fprintf(docgen->type_file, "%s", ast_nice_name(id));
 
       const char* cap_text = doc_get_cap(cap);
       if(cap_text != NULL)

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1233,7 +1233,12 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   collect_type_params(ast, &interface_t_params, NULL);
 
   printbuf_t* buf = printbuf_new();
-  printbuf(buf, "{(");
+
+  // Include the receiver capability if one is present.
+  if (ast_id(apply_cap) != TK_NONE)
+    printbuf(buf, "{%s(", ast_print_type(apply_cap));
+  else
+    printbuf(buf, "{(");
 
   // Convert parameter type list to a normal parameter list.
   int p_no = 1;
@@ -1270,6 +1275,9 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
 
   if(ast_id(apply_name) == TK_ID)
     fn_name = ast_name(apply_name);
+
+  // Attach the nice name to the original lambda.
+  ast_setdata(ast_childidx(ast, 1), (void*)stringtab(buf->m));
 
   // Create a new anonymous type.
   BUILD(def, ast,


### PR DESCRIPTION
In generated documentation, replace the use of hygienic, generated
names for anonymous function types with a nice name based on the type
of the function. Generated names have the form of `$0$1` and are less than useful.

This change associates a nice name with function types based on the
`{(ISize):ISize}` syntax and uses that name in generated documentation.
Additionally, this change adds the reference capability for the function
to the nice name, as in `{ref(ISize):ISize} ref`.

There were actually two (and a half) problems involved in this issue: 

* `doc_type` in docgen.c was using `ast_name` for anonymous function types; `ast_name` for lambdas is generated hygienically as *$M$N*. This was trivially fixed by using `ast_nice_name`.

* (The half-problem.) `doc_type` was generating a broken link for function types, referring to the desugared interface which never appears in the documentation. I fixed this by checking for the hygienic names when testing whether or not to generate links.

* `sugar_lambdatype` in sugar.c did not actually associate the nice name with the function type, only with the generated desugared interface. Plus, for added excitement, it generated the nice name *after* replacing the function type with the reference to the interface, after the comment, 

    // Fetch the interface type parameters after we replace the ast, so that if
    // we are an interface type parameter, we get ourselves as the constraint.

  Not wanting to mess with that, I poked the nice name into the function type ast after it was replaced.

As an added bonus, in the generated function type nice name, I added the reference capability for the function receiver.