### PR TITLE
Allow only single, internal underscores in numeric literals (#765)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Renamed `net/Buffer` to `net/ReadBuffer`
 - Print compiler error and info messages to stderr instead of stdout.
 - `Hashmap.concat` now returns `this` rather than `None`
+- Only allow single, internal underscores in numeric literals.
 
 ## [0.2.1] - 2015-10-06
 

--- a/test/libponyc/lexer.cc
+++ b/test/libponyc/lexer.cc
@@ -696,7 +696,7 @@ TEST_F(LexerTest, IntDecimalWithTrailingSeparator)
 {
   const char* src = "12_3_45_";
 
-  expect(1, 1, TK_INT, "12345");
+  expect(1, 1, TK_LEX_ERROR, "LEX_ERROR");
   expect(1, 9, TK_EOF, "EOF");
   DO(test(src));
 }


### PR DESCRIPTION
Previously the lexer accepted `7___4_9__.6_` as a numeric literal. This
change reports an error for duplicated underscore and underscores
terminating the literal.

This fixes #765