### PR TITLE
Call notifier when expect is called

### DIFF
--- a/packages/net/tcpconnection.pony
+++ b/packages/net/tcpconnection.pony
@@ -162,7 +162,7 @@ actor TCPConnection
     if called in the `sent` notifier callback.
     """
     if not _in_sent then
-      _expect = qty
+      _expect = _notify.expect(this, qty)
       _read_buf_size()
     end
 

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -320,6 +320,7 @@ class iso _TestTCPExpect is UnitTest
   fun ref apply(h: TestHelper) =>
     h.expect_action("client receive")
     h.expect_action("server receive")
+    h.expect_action("expect received")
 
     _TestTCP(h)(_TestTCPExpectNotify(h, false), _TestTCPExpectNotify(h, true))
 
@@ -345,6 +346,10 @@ class _TestTCPExpectNotify is TCPConnectionNotify
     _h.complete_action("client connect")
     conn.set_nodelay(true)
     conn.expect(_expect)
+
+  fun ref expect(conn: TCPConnection ref, qty: USize): USize =>
+    _h.complete_action("expect received")
+    qty
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
     if _frame then


### PR DESCRIPTION
TCPNotify has a method you can override to change
expect value when expect is called, however,
prior to this the notifier was never called by
TCPConnection resulting in lots of intersting issues
if you were relying on that to be called.