### PR TITLE
Fix compiler crash on "exotic" recursive type alias.

### DIFF
--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -376,12 +376,12 @@ ast_result_t pass_names(ast_t** astp, pass_opt_t* options)
   {
     case TK_NOMINAL:
       if(!names_nominal(options, *astp, astp, false))
-        return AST_ERROR;
+        return AST_FATAL;
       break;
 
     case TK_ARROW:
       if(!names_arrow(options, astp))
-        return AST_ERROR;
+        return AST_FATAL;
       break;
 
     default: {}

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -170,3 +170,15 @@ TEST_F(BadPonyTest, ExportedActorWithVariadicReturnTypeContainingNone)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(BadPonyTest, TypeAliasRecursionThroughTypeParameterInTuple)
+{
+  // From issue #901
+  const char* src =
+    "type Foo is (Map[Foo, Foo], None)\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_ERRORS_1(src, "type aliases can't be recursive");
+}


### PR DESCRIPTION
This PR fixes #901 by setting name resolution pass errors to be fatal.

This stops some more exotic forms of type alias recursion (such as
when a type aliases a union or tuple, where one of the elements has
the type alias as a type parameter), by not allowing the compiler
to continue after it has detected a recursion.

A possible downside of this change is that *all* name resolution
pass errors will be treated as fatal, meaning that users may no
longer see parallel name resolution pass errors in the output.
In practice, this is probably not a big deal, and its easier than
the alternative of trying to complicate the codebase by differentiating
between type alias recursion and other name resolution pass errors.

Resolves #901.