### PR TITLE
Default to persistent connection for HTTP/1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Use the nice name for types when generating documentation.
 - Compiler crash when generating C library for the exported actors containing functions with variadic return type contatining None
 - AST Printing of string literals with quote characters.
+- HTTP/1.1 connections are now persistent by default.
 
 ### Added
 

--- a/packages/net/http/serverconnection.pony
+++ b/packages/net/http/serverconnection.pony
@@ -119,7 +119,7 @@ actor _ServerConnection
       let keepalive = try
         request("Connection") != "close"
       else
-        false
+        request.proto != "HTTP/1.0"
       end
 
       _dispatched.shift()


### PR DESCRIPTION
In HTTP 1.1, all connections are considered persistent unless declared otherwise.