### PR TITLE
Use geometric growth when reserving space for new length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `Hashmap.concat` now returns `this` rather than `None`
 - Only allow single, internal underscores in numeric literals.
 - `ponyc --version` now includes the build type (debug/release) in its output.
+- Strings now grow and shrink geometrically.
 
 ## [0.2.1] - 2015-10-06
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -207,7 +207,13 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     null terminator.
     """
     if _alloc <= len then
-      _alloc = len.min(len.max_value() - 1) + 1
+      let max = len.max_value() - 1
+      let min_alloc = len + 1
+      if min_alloc < (max / 2) then
+        _alloc = min_alloc.next_pow2()
+      else
+        _alloc = min_alloc.min(max)
+      end
       _ptr = _ptr._realloc(_alloc)
     end
     this
@@ -235,6 +241,9 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     """
     Truncates the string at the minimum of len and space. Ensures there is a
     null terminator. Does not check for null terminators inside the string.
+
+    Note that in Pony, memory is reclaimed only when an actor dies and so an
+    attempt to shrink the allocation here would be futile.
     """
     _size = len.min(_alloc - 1)
     _set(_size, 0)

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -208,8 +208,8 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     """
     if _alloc <= len then
       let max = len.max_value() - 1
-      let min_alloc = len + 1
-      if min_alloc < (max / 2) then
+      let min_alloc = len.min(max) + 1
+      if min_alloc <= (max / 2) then
         _alloc = min_alloc.next_pow2()
       else
         _alloc = min_alloc.min(max)

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -242,8 +242,7 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
     Truncates the string at the minimum of len and space. Ensures there is a
     null terminator. Does not check for null terminators inside the string.
 
-    Note that in Pony, memory is reclaimed only when an actor dies and so an
-    attempt to shrink the allocation here would be futile.
+    Note that memory is not freed by this operation.
     """
     _size = len.min(_alloc - 1)
     _set(_size, 0)


### PR DESCRIPTION
This change reduces the following program from 12.5 secs to 9.5 secs runtime on my machine and memory usage with about 60%.
```pony
use "collections"

actor Main
  var _env: Env

  new create(env: Env) =>
    _env = env
    _start_benchmark()

  fun _start_benchmark() =>
    for j in Range(0, 1000) do
      _run_test()
    end

  be _run_test() =>
    let s = String

    for i in Range(0, 100000) do
      s.append(I8(0).string())
    end

    for i in Range(0, 100000) do
      s.truncate(100000 - i - 1)
    end
```