### PR TITLE
force vs2015 to not mangle serialise function names

### DIFF
--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -6,8 +6,8 @@
 
 #define HIGH_BIT ((size_t)1 << ((sizeof(size_t) * 8) - 1))
 
-extern size_t __DescTableSize;
-extern pony_type_t* __DescTable;
+extern "C" size_t __DescTableSize;
+extern "C" pony_type_t* __DescTable;
 
 typedef struct
 {

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -6,8 +6,12 @@
 
 #define HIGH_BIT ((size_t)1 << ((sizeof(size_t) * 8) - 1))
 
-extern "C" size_t __DescTableSize;
-extern "C" pony_type_t* __DescTable;
+PONY_EXTERN_C_BEGIN
+
+extern size_t __DescTableSize;
+extern pony_type_t* __DescTable;
+
+PONY_EXTERN_C_END
 
 typedef struct
 {

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -14,6 +14,15 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
+void pony_serialise(pony_ctx_t* ctx, void* p, void* out);
+size_t pony_serialise_offset(pony_ctx_t* ctx, void* p);
+void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size);
+
+void* pony_deserialise(pony_ctx_t* ctx, void* in);
+void* pony_deserialise_block(pony_ctx_t* ctx, uintptr_t offset, size_t size);
+void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,
+  uintptr_t offset);
+
 PONY_EXTERN_C_END
 
 #endif


### PR DESCRIPTION
VS2015, for some reason I cannot discover, is mangling the function names in serialise.c, which causes link errors when ponyc is linking on Windows.  This change declares the functions as extern "C" so the exported names are not mangled.