### PR TITLE
Fix Travis CI Linux builds using LLVM binaries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,48 +7,38 @@ branches:
 dist: trusty
 sudo: required
 
-addons:
-  apt:
-    sources:
-      # - llvm-toolchain-trusty-3.7
-      # - llvm-toolchain-trusty-3.8
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
-      - llvm-3.6
-      - llvm-3.6-dev
-      # - llvm-3.7
-      # - llvm-3.7-dev
-      # - llvm-3.8
-      # - llvm-3.8-dev
-
 matrix:
   include:
     - os: linux
       env:
+        - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=debug
     - os: linux
       env:
+        - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=release
-    # - os: linux
-    #   env:
-    #     - LLVM_CONFIG="llvm-config-3.7"
-    #     - config=debug
-    # - os: linux
-    #   env:
-    #     - LLVM_CONFIG="llvm-config-3.7"
-    #     - config=release
-    # - os: linux
-    #   env:
-    #     - LLVM_CONFIG="llvm-config-3.8"
-    #     - config=release
-    # - os: linux
-    #   env:
-    #     - LLVM_CONFIG="llvm-config-3.8"
-    #     - config=release
+    - os: linux
+      env:
+        - LLVM_VERSION="3.7.1"
+        - LLVM_CONFIG="llvm-config-3.7"
+        - config=debug
+    - os: linux
+      env:
+        - LLVM_VERSION="3.7.1"
+        - LLVM_CONFIG="llvm-config-3.7"
+        - config=release
+    - os: linux
+      env:
+        - LLVM_VERSION="3.8.0"
+        - LLVM_CONFIG="llvm-config-3.8"
+        - config=debug
+    - os: linux
+      env:
+        - LLVM_VERSION="3.8.0"
+        - LLVM_CONFIG="llvm-config-3.8"
+        - config=release
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.6"
@@ -77,8 +67,11 @@ matrix:
 install:
   - if [ "${TRAVIS_OS_NAME}" = "linux" ];
     then
-      export CC="gcc-4.9";
-      export CXX="g++-4.9";
+      wget "http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz";
+      tar -xvf clang+llvm*;
+      cd clang+llvm* && sudo mkdir /tmp/llvm && sudo cp -r * /tmp/llvm/;
+      sudo ln -s /tmp/llvm/bin/llvm-config /usr/local/bin/${LLVM_CONFIG};
+      cd -;
       wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2;
       tar -xjvf pcre2-10.21.tar.bz2;
       cd pcre2-10.21 && ./configure --prefix=/usr && make && sudo make install;


### PR DESCRIPTION
We previously disabled Travis CI Linux builds for most versions of LLVM, because LLVM [turned off their apt repo](http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html) and we had to use only the LLVM available through the official Ubuntu repos.

EDIT: This PR was originally going to use docker to work around the problem, but I've amended it to take a non-docker approach.

This fixes the Travis CI Linux builds by using LLVM binaries (which are not turned off) instead of apt packages. 