### PR TITLE
Add the build type to ponyc -v output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Print compiler error and info messages to stderr instead of stdout.
 - `Hashmap.concat` now returns `this` rather than `None`
 - Only allow single, internal underscores in numeric literals.
+- `ponyc --version` now includes the build type (debug/release) in its output.
 
 ## [0.2.1] - 2015-10-06
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ LINKER_FLAGS = -march=$(arch)
 AR_FLAGS = -rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
-	-DPONY_BUILD_CONFIG=\"$(config)\"
+  -DPONY_BUILD_CONFIG=\"$(config)\"
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
 LINKER_FLAGS = -march=$(arch)
 AR_FLAGS = -rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
-  -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\"
+  -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
+	-DPONY_BUILD_CONFIG=\"$(config)\"
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.

--- a/premake5.lua
+++ b/premake5.lua
@@ -89,15 +89,18 @@
       targetdir "build/debug"
       objdir "build/debug/obj"
       defines "DEBUG"
+      defines "PONY_BUILD_CONFIG=\"debug\""
       flags { "Symbols" }
 
     configuration "Release"
       targetdir "build/release"
       objdir "build/release/obj"
+      defines "PONY_BUILD_CONFIG=\"release\""
 
     configuration "Profile"
       targetdir "build/profile"
       objdir "build/profile/obj"
+      defines "PONY_BUILD_CONFIG=\"profile\""
 
     configuration "Release or Profile"
       defines "NDEBUG"

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
     switch(id)
     {
       case OPT_VERSION:
-        printf("%s\n", PONY_VERSION);
+        printf("%s [%s]\n", PONY_VERSION, PONY_BUILD_CONFIG);
         return 0;
 
       case OPT_DEBUG: opt.release = false; break;


### PR DESCRIPTION
This adds the type of build after the version number when running `ponyc -v`.

e.g.

```
0.2.1-944-ga9585df [debug]
```