### PR TITLE
Fix #929 compiler bug where 'as' causes seg fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - AST Printing of string literals with quote characters.
 - HTTP/1.1 connections are now persistent by default.
 - Runtime crash when Main.create is a function instead of a constructor.
+- Compiler bug where `as` operator with a lambda literal caused seg fault.
 
 ### Added
 

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -211,6 +211,7 @@ ast_t* alias(ast_t* type)
       return r_type;
     }
 
+    case TK_LAMBDATYPE:
     case TK_FUNTYPE:
     case TK_INFERTYPE:
     case TK_ERRORTYPE:

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -2702,3 +2702,15 @@ TEST_F(SugarTest, CaseFunctionDefaultTypeParamClash)
 
   TEST_ERROR(short_form);
 }
+
+
+TEST_F(SugarTest, AsOperatorWithLambdaType)
+{
+  const char* short_form =
+    "class Foo\n"
+      "new create() =>\n"
+        "let x = lambda():U32 => 0 end\n"
+        "try x as {():U32} val end";
+
+  TEST_COMPILE(short_form);
+}


### PR DESCRIPTION
Fixes issue #929.

Please review. Just getting my toes wet in the compiler. Builds on Linux; do not have a Windows environment at the moment.

Does this need a test? If so, please advise as to its proper location.

The `alias()` function was missing the `TK_LAMBDATYPE`; this has been added.