### PR TITLE
Use LLVM intrinsics for memcpy/memmove in codegen

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -415,14 +415,38 @@ static void init_runtime(compile_t* c)
   type = LLVMFunctionType(c->i32, NULL, 0, true);
   c->personality = LLVMAddFunction(c->module, "pony_personality_v0", type);
 
-  // i8* memcpy(...)
-  type = LLVMFunctionType(c->void_ptr, NULL, 0, true);
-  value = LLVMAddFunction(c->module, "memcpy", type);
+  // void llvm.memcpy.*(i8*, i8*, i32/64, i32, i1)
+  params[0] = c->void_ptr;
+  params[1] = c->void_ptr;
+  params[3] = c->i32;
+  params[4] = c->i1;
+  if(target_is_ilp32(c->opt->triple))
+  {
+    params[2] = c->i32;
+    type = LLVMFunctionType(c->void_type, params, 5, false);
+    value = LLVMAddFunction(c->module, "llvm.memcpy.p0i8.p0i8.i32", type);
+  } else {
+    params[2] = c->i64;
+    type = LLVMFunctionType(c->void_type, params, 5, false);
+    value = LLVMAddFunction(c->module, "llvm.memcpy.p0i8.p0i8.i64", type);
+  }
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 
-  // i8* memmove(...)
-  type = LLVMFunctionType(c->void_ptr, NULL, 0, true);
-  value = LLVMAddFunction(c->module, "memmove", type);
+  // void llvm.memmove.*(i8*, i8*, i32/64, i32, i1)
+  params[0] = c->void_ptr;
+  params[1] = c->void_ptr;
+  params[3] = c->i32;
+  params[4] = c->i1;
+  if(target_is_ilp32(c->opt->triple))
+  {
+    params[2] = c->i32;
+    type = LLVMFunctionType(c->void_type, params, 5, false);
+    value = LLVMAddFunction(c->module, "llvm.memmove.p0i8.p0i8.i32", type);
+  } else {
+    params[2] = c->i64;
+    type = LLVMFunctionType(c->void_type, params, 5, false);
+    value = LLVMAddFunction(c->module, "llvm.memmove.p0i8.p0i8.i64", type);
+  }
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
 }
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -543,10 +543,12 @@ class MergeRealloc : public FunctionPass
 {
 public:
   static char ID;
+  compile_t* c;
   Module* module;
 
   MergeRealloc() : FunctionPass(ID)
   {
+    c = the_compiler;
     module = NULL;
   }
 
@@ -796,11 +798,12 @@ public:
       int_size = ConstantInt::get(builder.getInt32Ty(), size);
     } else {
       alloc_fn = module->getFunction("pony_alloc_large");
-#ifdef PLATFORM_IS_ILP32
-      int_size = ConstantInt::get(builder.getInt32Ty(), size);
-#else
-      int_size = ConstantInt::get(builder.getInt64Ty(), size);
-#endif
+      if(target_is_ilp32(c->opt->triple))
+      {
+        int_size = ConstantInt::get(builder.getInt32Ty(), size);
+      } else {
+        int_size = ConstantInt::get(builder.getInt64Ty(), size);
+      }
     }
 
     Value* args[2];


### PR DESCRIPTION
LLVM optimises calls to its intrinsics better than calls to standard libc functions.