### PR TITLE
Set correct source file for debug info

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -667,11 +667,8 @@ void codegen_pushscope(compile_t* c, ast_t* ast)
 
   if(frame->prev->di_scope != NULL)
   {
-    source_t* source = ast_source(ast);
-    LLVMMetadataRef file = LLVMDIBuilderCreateFile(c->di, source->file);
-
     frame->di_scope = LLVMDIBuilderCreateLexicalBlock(c->di,
-      frame->prev->di_scope, file,
+      frame->prev->di_scope, frame->di_file,
       (unsigned)ast_line(ast), (unsigned)ast_pos(ast));
   }
 }

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -169,7 +169,14 @@ static void make_debug_prototype(compile_t* c, reach_type_t* t)
 
 static void make_debug_info(compile_t* c, reach_type_t* t)
 {
-  source_t* source = ast_source(t->ast);
+  ast_t* def = (ast_t*)ast_data(t->ast);
+  source_t* source;
+
+  if(def != NULL)
+    source = ast_source(def);
+  else
+    source = ast_source(t->ast);
+
   t->di_file = LLVMDIBuilderCreateFile(c->di, source->file);
 
   switch(t->underlying)


### PR DESCRIPTION
In codegen_pushscope, use the existing frame->di_file rather than
trying to create a new one, as that can lead to incorrect results.

In make_debug_info, if the type being generated has a definition
(i.e. it is a nominal type), use the file the definition is in,
rather than whatever random source file the use-site AST node
happens to be in.