### PR TITLE
LLVM intrinsics with i1 in params or return type

### DIFF
--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -456,7 +456,7 @@ static LLVMValueRef declare_ffi_vararg(compile_t* c, const char* f_name,
 }
 
 static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
-  reach_type_t* t, ast_t* args, bool err)
+  reach_type_t* t, ast_t* args, bool err, bool intrinsic)
 {
   ast_t* last_arg = ast_childlast(args);
 
@@ -480,40 +480,97 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
     reach_type_t* pt = reach_type(c->reach, p_type);
     assert(pt != NULL);
 
-    f_params[count++] = pt->use_type;
+    // An intrinsic that takes a Bool should be i1, not ibool.
+    if(intrinsic && is_bool(pt->ast))
+      f_params[count++] = c->i1;
+    else
+      f_params[count++] = pt->use_type;
+
     arg = ast_sibling(arg);
   }
 
-  // We may have generated the function by generating a parameter type.
-  LLVMValueRef func = LLVMGetNamedFunction(c->module, f_name);
+  LLVMTypeRef r_type;
 
-  if(func == NULL)
+  if(t->underlying == TK_TUPLETYPE)
   {
-    LLVMTypeRef r_type;
+    // Can't use the named type. Build an unnamed type with the same
+    // elements.
+    unsigned int count = LLVMCountStructElementTypes(t->use_type);
+    size_t buf_size = count * sizeof(LLVMTypeRef);
+    LLVMTypeRef* e_types = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
+    LLVMGetStructElementTypes(t->use_type, e_types);
 
-    if(t->underlying == TK_TUPLETYPE)
+    if(intrinsic)
     {
-      // Can't use the named type. Build an unnamed type with the same
-      // elements.
-      unsigned int count = LLVMCountStructElementTypes(t->use_type);
-      size_t buf_size = count * sizeof(LLVMTypeRef);
-      LLVMTypeRef* e_types = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
-      LLVMGetStructElementTypes(t->use_type, e_types);
-      r_type = LLVMStructTypeInContext(c->context, e_types, count, false);
-      ponyint_pool_free_size(buf_size, e_types);
-    } else {
-      r_type = t->use_type;
+      ast_t* child = ast_child(t->ast);
+      size_t i = 0;
+
+      while(child != NULL)
+      {
+        // A Bool in an intrinsic tuple return type is an i1, not an ibool.
+        if(is_bool(child))
+          e_types[i] = c->i1;
+
+        child = ast_sibling(child);
+        i++;
+      }
     }
 
-    LLVMTypeRef f_type = LLVMFunctionType(r_type, f_params, count, false);
-    func = LLVMAddFunction(c->module, f_name, f_type);
-
-    if(!err)
-      LLVMAddFunctionAttr(func, LLVMNoUnwindAttribute);
+    r_type = LLVMStructTypeInContext(c->context, e_types, count, false);
+    ponyint_pool_free_size(buf_size, e_types);
+  } else {
+    // An intrinsic that returns a Bool returns an i1, not an ibool.
+    if(intrinsic && is_bool(t->ast))
+      r_type = c->i1;
+    else
+      r_type = t->use_type;
   }
+
+  LLVMTypeRef f_type = LLVMFunctionType(r_type, f_params, count, false);
+  LLVMValueRef func = LLVMAddFunction(c->module, f_name, f_type);
+
+  if(!err)
+    LLVMAddFunctionAttr(func, LLVMNoUnwindAttribute);
 
   ponyint_pool_free_size(buf_size, f_params);
   return func;
+}
+
+static LLVMValueRef cast_ffi_arg(compile_t* c, LLVMValueRef arg,
+  LLVMTypeRef param)
+{
+  if(arg == NULL)
+    return NULL;
+
+  LLVMTypeRef arg_type = LLVMTypeOf(arg);
+
+  if(param == c->i1)
+  {
+    // If the parameter is an i1, it must be from an LLVM intrinsic. In that
+    // case, the argument must be a Bool encoded as an ibool.
+    if(arg_type != c->ibool)
+      return NULL;
+
+    // Truncate the Bool's i8 representation to i1.
+    return LLVMBuildTrunc(c->builder, arg, c->i1, "");
+  }
+
+  switch(LLVMGetTypeKind(param))
+  {
+    case LLVMPointerTypeKind:
+    {
+      if(LLVMGetTypeKind(arg_type) == LLVMIntegerTypeKind)
+        arg = LLVMBuildIntToPtr(c->builder, arg, param, "");
+      else
+        arg = LLVMBuildBitCast(c->builder, arg, param, "");
+
+      break;
+    }
+
+    default: {}
+  }
+
+  return arg;
 }
 
 LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
@@ -542,10 +599,10 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
       // Define using the declared types.
       AST_GET_CHILDREN(decl, decl_id, decl_ret, decl_params, decl_err);
       err = (ast_id(decl_err) == TK_QUESTION);
-      func = declare_ffi(c, f_name, t, decl_params, err);
+      func = declare_ffi(c, f_name, t, decl_params, err, false);
     } else if(!strncmp(f_name, "llvm.", 5)) {
       // Intrinsic, so use the exact types we supply.
-      func = declare_ffi(c, f_name, t, args, err);
+      func = declare_ffi(c, f_name, t, args, err, true);
     } else {
       // Make it varargs.
       func = declare_ffi_vararg(c, f_name, t, err);
@@ -573,13 +630,8 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
   {
     f_args[i] = gen_expr(c, arg);
 
-    if(!vararg && (LLVMGetTypeKind(f_params[i]) == LLVMPointerTypeKind))
-    {
-      if(LLVMGetTypeKind(LLVMTypeOf(f_args[i])) == LLVMIntegerTypeKind)
-        f_args[i] = LLVMBuildIntToPtr(c->builder, f_args[i], f_params[i], "");
-      else
-        f_args[i] = LLVMBuildBitCast(c->builder, f_args[i], f_params[i], "");
-    }
+    if(!vararg)
+      f_args[i] = cast_ffi_arg(c, f_args[i], f_params[i]);
 
     if(f_args[i] == NULL)
     {

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -232,18 +232,28 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
     case LLVMHalfTypeKind:
     case LLVMFloatTypeKind:
     case LLVMDoubleTypeKind:
+    {
+      // This can occur if an LLVM intrinsic returns an i1 or a tuple that
+      // contains an i1. Extend the i1 to an ibool.
+      if((r_type == c->i1) && (l_type == c->ibool))
+        return LLVMBuildZExt(c->builder, r_value, l_type, "");
+
       assert(LLVMGetTypeKind(r_type) == LLVMPointerTypeKind);
       return gen_unbox(c, type, r_value);
+    }
 
     case LLVMPointerTypeKind:
+    {
       r_value = gen_box(c, type, r_value);
 
       if(r_value == NULL)
         return NULL;
 
       return LLVMBuildBitCast(c->builder, r_value, l_type, "");
+    }
 
     case LLVMStructTypeKind:
+    {
       if(LLVMGetTypeKind(r_type) == LLVMPointerTypeKind)
       {
         r_value = gen_unbox(c, type, r_value);
@@ -251,6 +261,7 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
       }
 
       return assign_to_tuple(c, l_type, r_value, type);
+    }
 
     default: {}
   }


### PR DESCRIPTION
Such intrinsics must correctly generate i1, not i8, now that Bool
is encoded as i8. Arguments passed in must be trunated, and results
returned must be zero-extended.