### PR TITLE
use relative link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,10 +496,10 @@ ifeq ($$(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
 	@mkdir -p $(prefix)/include
-	$(SILENT)ln -sf $(destdir)/bin/ponyc $(prefix)/bin/ponyc
-	$(SILENT)ln -sf $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
-	$(SILENT)ln -sf $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
-	$(SILENT)ln -sf $(destdir)/include/pony.h $(prefix)/include/pony.h
+	$(SILENT)ln -srf $(destdir)/bin/ponyc $(prefix)/bin/ponyc
+	$(SILENT)ln -srf $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
+	$(SILENT)ln -srf $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
+	$(SILENT)ln -srf $(destdir)/include/pony.h $(prefix)/include/pony.h
 endif
 endef
 


### PR DESCRIPTION
switch to relative link for /bin/ponyc, /lib/libponyrt.a /lib/libponyc.a
and /include/pony.h (instead of absolute link). Ensure that installation using fakeroot (like
makepkg) don't create link to fakeroot directory