### PR TITLE
Fix ffi example

### DIFF
--- a/examples/ffi-struct/struct.pony
+++ b/examples/ffi-struct/struct.pony
@@ -24,7 +24,7 @@ struct Outer
 
 actor Main
   new create(env: Env) =>
-    let s = Outer
+    let s: Outer = Outer
 
     // When passing a Pony struct in a FFI call, you get a pointer to a
     // C struct on the other side.


### PR DESCRIPTION
Was broken a while back. Reading a field on a class through
an iso (like Inner here on Outer) results in it being a tag.
Aka doesn't work. Explicitly make Outer a ref rather than an iso.