### PR TITLE
Fix #948 for Mac OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ ifdef destdir
   endif
 endif
 
+ifeq ($(OSTYPE),osx)
+  symlink.flags = -sf
+else
+  symlink.flags = -srf
+endif
+
 prefix ?= /usr/local
 destdir ?= $(prefix)/lib/pony/$(tag)
 
@@ -496,10 +502,10 @@ ifeq ($$(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
 	@mkdir -p $(prefix)/include
-	$(SILENT)ln -srf $(destdir)/bin/ponyc $(prefix)/bin/ponyc
-	$(SILENT)ln -srf $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
-	$(SILENT)ln -srf $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
-	$(SILENT)ln -srf $(destdir)/include/pony.h $(prefix)/include/pony.h
+	$(SILENT)ln $(symlink.flags) $(destdir)/bin/ponyc $(prefix)/bin/ponyc
+	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a
+	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
+	$(SILENT)ln $(symlink.flags) $(destdir)/include/pony.h $(prefix)/include/pony.h
 endif
 endef
 


### PR DESCRIPTION
`/bin/ln` on mac does not support the `-r` option.

Fix #948