### PR TITLE
Added minimal tests for examples.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -525,6 +525,11 @@ test: all
 	@./stdlib
 	@rm stdlib
 
+test-examples: all
+	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
+	@./examples1
+	@rm examples1
+
 ifeq ($(git),yes)
 setversion:
 	@echo $(tag) > VERSION

--- a/examples/tests.pony
+++ b/examples/tests.pony
@@ -1,0 +1,44 @@
+"""
+Pony examples tests
+
+This package will eventually test all examples. At the moment we only
+use them to type check.
+"""
+
+use "ponytest"
+
+// Include all example packages here, even if they don't have tests, so
+// that the package loads and them and perform syntax and type checks
+
+// Commented packages are broken at the moment. We have to fix them and
+// then keep the tests green.
+use ex_circle = "examples/circle"
+use ex_counter = "examples/counter"
+// use ex_delegates = "examples/delegates"
+use ex_echo = "examples/echo"
+// use ex_ffi_struct = "examples/ffi-struct"
+use ex_files = "examples/files"
+use ex_gups_basic = "examples/gups_basic"
+use ex_gups_opt = "examples/gups_opt"
+use ex_helloworld = "examples/helloworld"
+use ex_httpget = "examples/httpget"
+use ex_httpserver = "examples/httpserver"
+use ex_ifdef = "examples/ifdef"
+use ex_lambda = "examples/lambda"
+use ex_mailbox = "examples/mailbox"
+use ex_mandelbrot = "examples/mandelbrot"
+use ex_mixed = "examples/mixed"
+use ex_n_body = "examples/n-body"
+use ex_net = "examples/net"
+use ex_printargs = "examples/printargs"
+use ex_producer_consumer = "examples/producer-consumer"
+use ex_readline = "examples/readline"
+use ex_ring = "examples/ring"
+use ex_spreader = "examples/spreader"
+use ex_timers = "examples/timers"
+// use ex_yield = "examples/yield"
+
+
+actor Main
+  new create(env: Env) =>
+    env.out.write("All examples compile!\n")

--- a/examples/tests.pony
+++ b/examples/tests.pony
@@ -8,13 +8,13 @@ use them to type check.
 use "ponytest"
 
 // Include all example packages here, even if they don't have tests, so
-// that the package loads and them and perform syntax and type checks
+// that we load them to perform syntax and type checks.
 
 // Commented packages are broken at the moment. We have to fix them and
 // then keep the tests green.
 use ex_circle = "examples/circle"
 use ex_counter = "examples/counter"
-// use ex_delegates = "examples/delegates"
+use ex_delegates = "examples/delegates"
 use ex_echo = "examples/echo"
 // use ex_ffi_struct = "examples/ffi-struct"
 use ex_files = "examples/files"
@@ -36,7 +36,7 @@ use ex_readline = "examples/readline"
 use ex_ring = "examples/ring"
 use ex_spreader = "examples/spreader"
 use ex_timers = "examples/timers"
-// use ex_yield = "examples/yield"
+use ex_yield = "examples/yield"
 
 
 actor Main


### PR DESCRIPTION
Currently the examples are not included in the CI process, this leads to
this kind of commit messages :

4eb42e2 Fix ffi example (#949) Was broken a while back.

I added a separate make target `test-examples`though I believe this
tests should be run with the full tests suite.

The package is minimal at the moment, it just tries to use all examples.
Unit tests should be added later, demonstrating some testing techniques.

Some example packages are commented at the moment as they don't build on
my laptop. I still have to figure out what is broken: the example or my
pony build chain.