### PR TITLE
Run automated tests in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,17 +38,20 @@ install:
       $libsInstalled = Test-Path C:\ponyc-windows-libs
       if(-Not $libsInstalled)
       {
-        git clone https://github.com/kulibali/ponyc-windows-libs.git C:\ponyc-windows-libs
+        md C:\ponyc-windows-libs
         cd C:\ponyc-windows-libs
-        sed -i'.bak2' 's/echo off/echo on/g' getlibs.bat
-        sed -i'.bak3' 's/%PCRE2_SRC% wget/%PCRE2_SRC% curl -fsSL -o %PCRE2_SRC% /g' getlibs.bat
-        sed -i'.bak4' 's/wget/curl -fsSL -O /g' getlibs.bat
-        sed -i'.bak5' 's/pcre2-10.20/pcre2-10.21/g' getlibs.bat
-        sed -i'.bak6' 's/.tar.gz/.zip/g' getlibs.bat
-        sed -i'.bak7' 's@devenv .*@msbuild PCRE2.sln /t:pcre2-8 /p:Configuration=Release@g' getlibs.bat
-        sed -i'.bak8' 's/gunzip .*/unzip -o %PCRE2_SRC%/' getlibs.bat
-        sed -i'.bak9' 's@ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/%PCRE2_SRC%@https://sourceforge.net/projects/pcre/files/pcre2/10.21/%PCRE2_SRC%/download@g' getlibs.bat
-        C:\ponyc-windows-libs\getlibs.bat
+        md lib
+        svn co svn://vcs.exim.org/pcre2/code/tags/pcre2-10.21 pcre2
+        md pcre2.build
+        cd pcre2.build
+        cmake ..\pcre2 -G "Visual Studio 14 2015 Win64"
+        msbuild PCRE2.sln /t:pcre2-8 /p:Configuration=Release
+        copy Release\pcre2-8.lib ..\lib
+        cd ..
+        wget http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.1.4-windows.zip -OutFile libressl-2.1.4-windows.zip
+        unzip -o libressl-2.1.4-windows.zip
+        copy libressl-2.1.4-windows\x64\libssl-32.* lib
+        copy libressl-2.1.4-windows\x64\libcrypto-32.* lib
       }
       $env:LIB = "C:\ponyc-windows-libs\lib;" + $env:LIB
       $env:path += ";C:\ponyc-windows-libs\lib"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,20 @@
 version: 1.0.{build}
-image: Visual Studio 2013
+
+image: Visual Studio 2015
+
+environment:
+  matrix:
+  - llvm: 3.8.0
+  - llvm: 3.7.1
+
 configuration:
   - Debug
   - Release
-clone_depth: 1
+
+clone_depth: 100
+
 clone_folder: C:\projects\ponyc
+
 install:
   - ps: |
       cd C:\
@@ -12,22 +22,53 @@ install:
       $llvmInstalled = Test-Path C:\LLVM
       if(-Not $premakeInstalled)
       {
-        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha8/premake-5.0.0-alpha8-windows.zip -OutFile C:\premake5.zip
+        wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-windows.zip -OutFile C:\premake5.zip
         7z x C:\premake5.zip
         del C:\premake5.zip
       }
       if(-Not $llvmInstalled)
       {
-        wget http://releases.ponylang.org/llvm/llvm37-final-x86_64-windows-release.zip -OutFile C:\llvm37.zip
-        7z x C:\llvm37.zip
-        del C:\llvm37.zip
+        wget "https://github.com/dipinhora/ponyc-llvm/releases/download/LLVM-Release-VS2015/LLVM-${env:llvm}-Release-VS2015.7z" -OutFile C:\LLVM.7z
+        7z x C:\LLVM.7z
+        del C:\LLVM.7z
       }
-      $env:path += ";C:\LLVM\bin"
+      $env:path += ";C:\LLVM-${env:llvm}\bin"
+  - ps: |
+      cd C:\
+      $libsInstalled = Test-Path C:\ponyc-windows-libs
+      if(-Not $libsInstalled)
+      {
+        git clone https://github.com/kulibali/ponyc-windows-libs.git C:\ponyc-windows-libs
+        cd C:\ponyc-windows-libs
+        sed -i'.bak2' 's/echo off/echo on/g' getlibs.bat
+        sed -i'.bak3' 's/%PCRE2_SRC% wget/%PCRE2_SRC% curl -fsSL -o %PCRE2_SRC% /g' getlibs.bat
+        sed -i'.bak4' 's/wget/curl -fsSL -O /g' getlibs.bat
+        sed -i'.bak5' 's/pcre2-10.20/pcre2-10.21/g' getlibs.bat
+        sed -i'.bak6' 's/.tar.gz/.zip/g' getlibs.bat
+        sed -i'.bak7' 's@devenv .*@msbuild PCRE2.sln /t:pcre2-8 /p:Configuration=Release@g' getlibs.bat
+        sed -i'.bak8' 's/gunzip .*/unzip -o %PCRE2_SRC%/' getlibs.bat
+        sed -i'.bak9' 's@ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/%PCRE2_SRC%@https://sourceforge.net/projects/pcre/files/pcre2/10.21/%PCRE2_SRC%/download@g' getlibs.bat
+        C:\ponyc-windows-libs\getlibs.bat
+      }
+      $env:LIB = "C:\ponyc-windows-libs\lib;" + $env:LIB
+      $env:path += ";C:\ponyc-windows-libs\lib"
       cd C:\projects\ponyc
-      C:\premake5.exe --with-tests --to=work/vs2013 vs2013
+      C:\premake5.exe --with-tests --to=work/vs2015 vs2015
+
 cache:
-  - C:\LLVM\ -> .appveyor.yml
+  - 'C:\LLVM-%llvm%\ -> .appveyor.yml'
   - C:\premake5.exe -> .appveyor.yml
+  - C:\ponyc-windows-libs\ -> .appveyor.yml
+
 build:
-  project: work\vs2013\ponyc.sln
+  project: work\vs2015\ponyc.sln
   verbosity: minimal
+
+test_script:
+  - C:\projects\ponyc\build\%CONFIGURATION%\testc.exe
+  - C:\projects\ponyc\build\%CONFIGURATION%\testrt.exe
+  - CALL "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
+  - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s packages/stdlib
+  - stdlib.exe
+  - del stdlib.exe
+

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,7 +28,7 @@ install:
       }
       if(-Not $llvmInstalled)
       {
-        wget "https://github.com/dipinhora/ponyc-llvm/releases/download/LLVM-Release-VS2015/LLVM-${env:llvm}-Release-VS2015.7z" -OutFile C:\LLVM.7z
+        wget "https://github.com/ponylang/ponyc-windows-llvm/releases/download/LLVM-Release-VS2015/LLVM-${env:llvm}-Release-VS2015.7z" -OutFile C:\LLVM.7z
         7z x C:\LLVM.7z
         del C:\LLVM.7z
       }

--- a/packages/net/test.pony
+++ b/packages/net/test.pony
@@ -8,8 +8,10 @@ actor Main is TestList
     test(_TestReadBuffer)
     test(_TestWriteBuffer)
     test(_TestBroadcast)
-    test(_TestTCPExpect)
-    test(_TestTCPWritev)
+    ifdef not windows then
+      test(_TestTCPExpect)
+      test(_TestTCPWritev)
+    end
 
 class iso _TestReadBuffer is UnitTest
   """

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -101,7 +101,7 @@ static void pick_vc_tools(HKEY key, char* name, search_t* p)
 {
   DWORD size = MAX_PATH;
 
-  RegGetValue(key, NULL, "InstallDir", RRF_RT_REG_SZ,
+  RegGetValue(key, NULL, "ProductDir", RRF_RT_REG_SZ,
     NULL, p->path, &size);
 }
 
@@ -203,7 +203,7 @@ static bool find_msvcrt_and_linker(vcvars_t* vcvars, errors_t* errors)
     PLATFORM_TOOLS_VERSION % 10);
 
   TCHAR reg_vs_install_path[MAX_PATH+1];
-  snprintf(reg_vs_install_path, MAX_PATH, "%s%s", REG_VS_INSTALL_PATH, vs.version);
+  snprintf(reg_vs_install_path, MAX_PATH, "%s%s\\Setup\\VC", REG_VS_INSTALL_PATH, vs.version);
 
   if(!find_registry_key(reg_vs_install_path, pick_vc_tools, false, &vs))
   {
@@ -212,12 +212,12 @@ static bool find_msvcrt_and_linker(vcvars_t* vcvars, errors_t* errors)
   }
 
   strcpy(vcvars->msvcrt, vs.path);
-  strcat(vcvars->msvcrt, "..\\..\\VC\\lib\\amd64");
+  strcat(vcvars->msvcrt, "lib\\amd64");
 
   // Find the linker and lib archiver relative to vs.path.
   return
-    find_executable(vs.path, "..\\..\\VC\\bin\\link.exe", vcvars->link, errors) &&
-    find_executable(vs.path, "..\\..\\VC\\bin\\lib.exe", vcvars->ar, errors);
+    find_executable(vs.path, "bin\\link.exe", vcvars->link, errors) &&
+    find_executable(vs.path, "bin\\lib.exe", vcvars->ar, errors);
 }
 
 bool vcvars_get(vcvars_t* vcvars, errors_t* errors)

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -150,7 +150,12 @@ static bool find_kernel32(vcvars_t* vcvars, errors_t* errors)
 
   strcpy(vcvars->kernel32, sdk.path);
   strcat(vcvars->kernel32, "Lib\\");
-  if(strcmp("v8.0", sdk.name) == 0)
+  if(strcmp("v7.1", sdk.name) == 0)
+  {
+    strcat(vcvars->kernel32 , "\\x64");
+    return true;
+  }
+  else if(strcmp("v8.0", sdk.name) == 0)
   {
     strcat(vcvars->kernel32 , "win8");
   }


### PR DESCRIPTION
This pull request enables running the normal ponyc automated tests (that run for linux/osx) on every commit in Appveyor for Windows builds.

See https://ci.appveyor.com/project/dipinhora/ponyc for a build run with Appveyor with these changes included. Currently a couple of tests fail so the build fails.

This pull request also includes changes to how the Visual Studio installation location is determined by ponyc for finding libraries and executables needed to include support for systems where only the command line Visual C++ Build Tools 2015 (https://blogs.msdn.microsoft.com/vcblog/2016/03/31/announcing-the-official-release-of-the-visual-c-build-tools-2015/) are installed but a full copy of Visual Studio isn't installed. This change should have no negative impact to normal Visual Studio installs (as confirmed by the Appveyor build referenced above) but it would be ideal if other Windows users such as @kulibali, @sblessing, or others are able to confirm.

Also, I am not 100% sure that the caching functionality in Appveyor is working correctly (although in theory it should be based on my understanding of the docs) with this so that might need tweaking to get functioning properly.