### PR TITLE
Allow for reserving of chunks in WriteBuffer

### DIFF
--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -33,7 +33,7 @@ class WriteBuffer
 
   ```
   use "net"
-  
+
   actor Main
     new create(env: Env) =>
       let wb = WriteBuffer
@@ -57,6 +57,13 @@ class WriteBuffer
   var _current: Array[U8] iso = recover Array[U8] end
   var _offset: USize = 0
   var _size: USize = 0
+
+  fun ref reserve_chunks(size': USize): WriteBuffer^ =>
+    """
+    Reserve space for size' chunks.
+    """
+    _chunks.reserve(size')
+    this
 
   fun ref reserve(size': USize): WriteBuffer^ =>
     """


### PR DESCRIPTION
When using the WriteBuffer, I find myself knowing
how many chunks I intend to use. With this change,
anyone in a similar situation can preallocate the
correct number of chunks for the buffer.

Note as this is currently written, this needs to be
reset after each call to done() as done() resets
chunks back to Array[ByteSeq].