### PR TITLE
Fix appveyor LLVM caching issue.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ install:
   - ps: |
       cd C:\
       $premakeInstalled = Test-Path C:\premake5.exe
-      $llvmInstalled = Test-Path C:\LLVM
+      $llvmInstalled = Test-Path C:\LLVM-${env:llvm}
       if(-Not $premakeInstalled)
       {
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-windows.zip -OutFile C:\premake5.zip


### PR DESCRIPTION
This is a bugfix for PR #957 where it hangs if the LLVM cache is restored and causes the build to time out in Appveyor.