### PR TITLE
Fix lstrip, rstrip, and split so they don't call pony_throw

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -324,12 +324,16 @@ class Array[A] is Seq[A]
     """
     Returns true if the array contains `value`, false otherwise.
     """
-    try
-      find(value, 0, 0, predicate)
-      true
-    else
-      false
+    var i = USize(0)
+
+    while i < _size do
+      if predicate(_ptr._apply(i), value) then
+        return true
+      end
+
+      i = i + 1
     end
+    false
 
   fun rfind(value: A!, offset: USize = -1, nth: USize = 0,
     predicate: {(box->A!, box->A!): Bool} val =

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -840,9 +840,8 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
         while i < _size do
           (let c, let len) = utf32(i.isize())
 
-          try
+          if chars.contains(c) then
             // If we find a delimeter, add the current string to the array.
-            chars.find(c)
             occur = occur + 1
 
             if (n > 0) and (occur >= n) then
@@ -898,7 +897,10 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
         try
           match utf32(i.isize())
           | (0xFFFD, 1) => None
-          | (let c: U32, _) => chars.find(c)
+          | (let c: U32, _) =>
+            if not chars.contains(c) then
+              break
+            end
           end
         else
           break
@@ -926,7 +928,9 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
       while i < _size do
         try
           (let c, let len) = utf32(i.isize())
-          chars.find(c)
+          if not chars.contains(c) then
+            break
+          end
           i = i + len.usize()
         else
           break


### PR DESCRIPTION
lstrip, rstrip, and split were relying on Array.find(), which was causing them to unnecessarily call pony_throw.  This change fixes that.  I've updated Array.contains() so it doesn't need to call pony_throw and rely on that instead.