### PR TITLE
Can't use a struct as a type argument

### DIFF
--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -565,6 +565,11 @@ LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* type)
 
   switch(ast_id(def))
   {
+    case TK_STRUCT:
+      // The type system has ensured that at this stage the operand must be
+      // the pattern type.
+      return LLVMConstInt(c->i1, 1, false);
+
     case TK_INTERFACE:
     case TK_TRAIT:
       return gendesc_istrait(c, desc, type);

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -188,16 +188,39 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
 
   while(typeparam != NULL)
   {
-    if(ast_id(typearg) == TK_TYPEPARAMREF)
+    switch(ast_id(typearg))
     {
-      ast_t* def = (ast_t*)ast_data(typearg);
-
-      if(def == typeparam)
+      case TK_NOMINAL:
       {
-        typeparam = ast_sibling(typeparam);
-        typearg = ast_sibling(typearg);
-        continue;
+        ast_t* def = (ast_t*)ast_data(typearg);
+
+        if(ast_id(def) == TK_STRUCT)
+        {
+          if(report_errors)
+          {
+            ast_error(opt->check.errors, typearg,
+              "a struct cannot be used as a type argument");
+          }
+
+          return false;
+        }
+        break;
       }
+
+      case TK_TYPEPARAMREF:
+      {
+        ast_t* def = (ast_t*)ast_data(typearg);
+
+        if(def == typeparam)
+        {
+          typeparam = ast_sibling(typeparam);
+          typearg = ast_sibling(typearg);
+          continue;
+        }
+        break;
+      }
+
+      default: {}
     }
 
     // Reify the constraint.


### PR DESCRIPTION
A struct exists to mirror the C struct ABI. As a result, it has no
type descriptor, so no runtime type information is available for a
struct. As a result, an instance of a struct cannot be used in a
type where runtime type information may be requested.

* A struct can't be a subtype of a trait or interface
* A struct can't be a subtype of a union or intersection
* A struct can't be a type argument
* A struct can't be a pattern unless it always matches