### PR TITLE
Verify generated LLVM IR when building tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,7 +71,7 @@ test_script:
   - C:\projects\ponyc\build\%CONFIGURATION%\testc.exe
   - C:\projects\ponyc\build\%CONFIGURATION%\testrt.exe
   - CALL "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
-  - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s packages/stdlib
+  - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s --verify packages/stdlib
   - stdlib.exe
   - del stdlib.exe
 

--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ uninstall:
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
-	@$(PONY_BUILD_DIR)/ponyc -d -s packages/stdlib
+	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib
 	@./stdlib
 	@rm stdlib
 


### PR DESCRIPTION
This will allow us to detect breaking changes to the code generator and get useful diagnostics in the CI.