### PR TITLE
Check syntax in lambdas

### DIFF
--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -4,6 +4,7 @@
 #include "../ast/printbuf.h"
 #include "../pass/pass.h"
 #include "../pass/expr.h"
+#include "../pass/syntax.h"
 #include "../type/alias.h"
 #include "../type/sanitise.h"
 #include <assert.h>
@@ -167,5 +168,8 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   printbuf_free(buf);
 
   // Catch up passes
+  if(ast_visit(astp, pass_syntax, NULL, opt, PASS_SYNTAX) != AST_OK)
+    return false;
+
   return ast_passes_subtree(astp, opt, PASS_EXPR);
 }


### PR DESCRIPTION
The `pass_syntax` compiler pass was skipping lambda functions because
the child nodes of the lambda function are all intially flagged as
AST_FLAG_PRESERVE when `pass_syntax` is run in `module_passes`; this
flag is removed in a later step. This fix calls `pass_syntax` again
after the flag is removed in order to catch any issues that were
missed on the first call to `pass_syntax`.

Fixes issue #981.