### PR TITLE
Check syntax in lambdas

### DIFF
--- a/packages/collections/persistent/test.pony
+++ b/packages/collections/persistent/test.pony
@@ -144,7 +144,7 @@ class iso _TestListFilter is UnitTest
   fun name(): String => "collections/persistent/Lists/filter()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => x % 2 == 0 end
+    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
     let l7 = Lists[U32]([1,2,3,4,5,6,7,8]).filter(is_even)
     h.assert_true(Lists[U32].eq(l7, Lists[U32]([2,4,6,8])))
 
@@ -170,7 +170,7 @@ class iso _TestListEveryExists is UnitTest
   fun name(): String => "collections/persistent/Lists/every()exists()"
 
   fun apply(h: TestHelper) =>
-    let is_even = lambda(x: U32): Bool => x % 2 == 0 end
+    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
     let l9 = Lists[U32]([4,2,10])
     let l10 = Lists[U32]([1,1,3])
     let l11 = Lists[U32]([1,1,2])
@@ -193,7 +193,7 @@ class iso _TestListPartition is UnitTest
   fun name(): String => "collections/persistent/Lists/partition()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => x % 2 == 0 end
+    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
     let l = Lists[U32]([1,2,3,4,5,6])
     (let hits, let misses) = l.partition(is_even)
     h.assert_true(Lists[U32].eq(hits, Lists[U32]([2,4,6])))
@@ -217,7 +217,7 @@ class iso _TestListDropWhile is UnitTest
   fun name(): String => "collections/persistent/List/drop_while()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => x % 2 == 0 end
+    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
     let l = Lists[U32]([4,2,6,1,3,4,6])
     let empty = Lists[U32].empty()
     h.assert_true(Lists[U32].eq(l.drop_while(is_even), Lists[U32]([1,3,4,6])))
@@ -240,7 +240,7 @@ class iso _TestListTakeWhile is UnitTest
   fun name(): String => "collections/persistent/List/take_while()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => x % 2 == 0 end
+    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
     let l = Lists[U32]([4,2,6,1,3,4,6])
     let empty = Lists[U32].empty()
     h.assert_true(Lists[U32].eq(l.take_while(is_even), Lists[U32]([4,2,6])))

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -283,7 +283,7 @@ class iso _TestListsPartition is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let isEven = lambda(x: U32): Bool => x % 2 == 0 end
+    let isEven = lambda(x: U32): Bool => (x % 2) == 0 end
     (let evens, let odds) = a.partition(isEven)
 
     h.assert_eq[USize](evens.size(), 2)

--- a/src/libponyc/ast/id.c
+++ b/src/libponyc/ast/id.c
@@ -16,8 +16,9 @@ bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec)
   // Ignore leading $, handled by lexer
   if(*name == '$')
   {
-    name++;
-    prev = '$';
+    // We assume this variable has been placed by someone or something who
+    // knows what they are doing
+    return true;
   }
 
   // Ignore leading _

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -4,6 +4,7 @@
 #include "../ast/printbuf.h"
 #include "../pass/pass.h"
 #include "../pass/expr.h"
+#include "../pass/syntax.h"
 #include "../type/alias.h"
 #include "../type/sanitise.h"
 #include <assert.h>
@@ -167,5 +168,8 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   printbuf_free(buf);
 
   // Catch up passes
+  if(ast_visit(astp, pass_syntax, NULL, opt, PASS_SYNTAX) != AST_OK)
+    return false;
+
   return ast_passes_subtree(astp, opt, PASS_EXPR);
 }


### PR DESCRIPTION
The pass_syntax compiler pass was skipping lambda functions because
the child nodes of the lambda function are all intially flagged as
AST_FLAG_PRESERVE when pass_syntax is run in module_passes; this
flag is removed in a later step. This fix calls pass_syntax again
after the flag is removed in order to catch any issues that were
missed on the first call to pass_syntax.

In order for this to work correctly, `check_id` was changed to allow
any identifier that starts with a "$" character. The reasoning is
that variables with these names are only used in hygienic variables
that are created by the compiler, and in certain tests. We don't want
to disallow them, so we assume that if you use them then you know what
you are doing. This has been discussed with @sylvanc.

Once this change was made the compiler spotted several errors in test
code which had been previously overlooked. These tests were also
changed as part of this fix.