### PR TITLE
Store the match pattern type in the case

### DIFF
--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -174,7 +174,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   if(!is_control_type(type))
   {
     // Start the post block so that a break can modify the phi node.
-    post_block = codegen_block(c, "match_post");
+    post_block = codegen_block(c, "while_post");
     LLVMPositionBuilderAtEnd(c->builder, post_block);
 
     if(needed)
@@ -292,7 +292,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   if(!is_control_type(type))
   {
     // Start the post block so that a break can modify the phi node.
-    post_block = codegen_block(c, "match_post");
+    post_block = codegen_block(c, "repeat_post");
     LLVMPositionBuilderAtEnd(c->builder, post_block);
 
     if(needed)

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -716,7 +716,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
     LLVMPositionBuilderAtEnd(c->builder, pattern_block);
     codegen_pushscope(c, the_case);
 
-    ast_t* pattern_type = ast_type(pattern);
+    ast_t* pattern_type = ast_type(the_case);
     bool ok = true;
 
     if(is_matchtype(match_type, pattern_type, c->opt) != MATCHTYPE_ACCEPT)


### PR DESCRIPTION
A structural equality pattern was being assigned the type of the
parameter instead of the receiver. This is fixed, and the the full
type of the match pattern is stored with the case for use in the
code generator.