### PR TITLE
Allow _final as a field name

### DIFF
--- a/src/libponyc/pass/finalisers.c
+++ b/src/libponyc/pass/finalisers.c
@@ -196,12 +196,16 @@ static bool entity_finaliser(pass_opt_t* opt, ast_t* entity, const char* final)
   if(ast == NULL)
     return true;
 
+  if(ast_id(ast) != TK_FUN)
+    return true;
+
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body);
   int r = check_body_send(body, true);
 
   if((r & FINAL_CAN_SEND) != 0)
   {
-    ast_error(opt->check.errors, ast, "_final cannot create actors or send messages");
+    ast_error(opt->check.errors, ast,
+      "_final cannot create actors or send messages");
     show_send(opt, body);
     return false;
   }
@@ -209,7 +213,8 @@ static bool entity_finaliser(pass_opt_t* opt, ast_t* entity, const char* final)
   return true;
 }
 
-static bool module_finalisers(pass_opt_t* opt, ast_t* module, const char* final)
+static bool module_finalisers(pass_opt_t* opt, ast_t* module,
+  const char* final)
 {
   ast_t* entity = ast_child(module);
   bool ok = true;

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -503,8 +503,19 @@ static void add_special(reach_t* r, reach_type_t* t, ast_t* type,
 
   if(find != NULL)
   {
-    reachable_method(r, t->ast, special, NULL, opt);
-    ast_free_unattached(find);
+    switch(ast_id(find))
+    {
+      case TK_NEW:
+      case TK_FUN:
+      case TK_BE:
+      {
+        reachable_method(r, t->ast, special, NULL, opt);
+        ast_free_unattached(find);
+        break;
+      }
+
+      default: {}
+    }
   }
 }
 


### PR DESCRIPTION
A _final field is now allowed. A _final method must still be a fun
rather than a new or a be, and must have the correct signature for
a finaliser, to avoid a situation where a programmer believes they
have written a finaliser, but the compiler doesn't recognise it and
so the runtime doesn't call it.