### PR TITLE
Fix F32.sqrt and F64.sqrt

### DIFF
--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -3,6 +3,8 @@ primitive F32 is FloatingPoint[F32]
   new pi() => 3.14159265358979323846
   new e() => 2.71828182845904523536
 
+  new _nan() => compile_intrinsic
+
   new from_bits(i: U32) => compile_intrinsic
   fun bits(): U32 => compile_intrinsic
   fun tag from[B: (Number & Real[B] val)](a: B): F32 => a.f32()
@@ -123,7 +125,13 @@ primitive F32 is FloatingPoint[F32]
       @"llvm.powi.f32"[F32](this, y)
     end
 
-  fun sqrt(): F32 => @"llvm.sqrt.f32"[F32](this)
+  fun sqrt(): F32 =>
+    if this < 0.0 then
+      _nan()
+    else
+      @"llvm.sqrt.f32"[F32](this)
+    end
+
   fun cbrt(): F32 => @cbrtf[F32](this)
   fun exp(): F32 => @"llvm.exp.f32"[F32](this)
   fun exp2(): F32 => @"llvm.exp2.f32"[F32](this)
@@ -156,6 +164,8 @@ primitive F64 is FloatingPoint[F64]
   new create(value: F64 = 0) => value
   new pi() => 3.14159265358979323846
   new e() => 2.71828182845904523536
+
+  new _nan() => compile_intrinsic
 
   new from_bits(i: U64) => compile_intrinsic
   fun bits(): U64 => compile_intrinsic
@@ -277,7 +287,13 @@ primitive F64 is FloatingPoint[F64]
       @"llvm.powi.f64"[F64](this, y)
     end
 
-  fun sqrt(): F64 => @"llvm.sqrt.f64"[F64](this)
+  fun sqrt(): F64 =>
+    if this < 0.0 then
+      _nan()
+    else
+      @"llvm.sqrt.f64"[F64](this)
+    end
+
   fun cbrt(): F64 => @cbrt[F64](this)
   fun exp(): F64 => @"llvm.exp.f64"[F64](this)
   fun exp2(): F64 => @"llvm.exp2.f64"[F64](this)

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -24,6 +24,7 @@ char* LLVMGetHostCPUName();
 void LLVMSetUnsafeAlgebra(LLVMValueRef inst);
 void LLVMSetReturnNoAlias(LLVMValueRef fun);
 void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
+LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 
 #define GEN_NOVALUE ((LLVMValueRef)1)
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -1257,6 +1257,16 @@ static void number_conversions(compile_t* c)
   }
 }
 
+static void f32__nan(compile_t* c, reach_type_t* t)
+{
+  FIND_METHOD("_nan");
+  start_function(c, m, c->f32, &c->f32, 1);
+
+  LLVMValueRef result = LLVMConstNaN(c->f32);
+  LLVMBuildRet(c->builder, result);
+  codegen_finishfun(c);
+}
+
 static void f32_from_bits(compile_t* c, reach_type_t* t)
 {
   FIND_METHOD("from_bits");
@@ -1283,6 +1293,16 @@ static void f32_bits(compile_t* c, reach_type_t* t)
   codegen_finishfun(c);
 
   BOX_FUNCTION();
+}
+
+static void f64__nan(compile_t* c, reach_type_t* t)
+{
+  FIND_METHOD("_nan");
+  start_function(c, m, c->f64, &c->f64, 1);
+
+  LLVMValueRef result = LLVMConstNaN(c->f64);
+  LLVMBuildRet(c->builder, result);
+  codegen_finishfun(c);
 }
 
 static void f64_from_bits(compile_t* c, reach_type_t* t)
@@ -1313,18 +1333,20 @@ static void f64_bits(compile_t* c, reach_type_t* t)
   BOX_FUNCTION();
 }
 
-static void fp_as_bits(compile_t* c)
+static void fp_intrinsics(compile_t* c)
 {
   reach_type_t* t;
 
   if((t = reach_type_name(c->reach, "F32")) != NULL)
   {
+    f32__nan(c, t);
     f32_from_bits(c, t);
     f32_bits(c, t);
   }
 
   if((t = reach_type_name(c->reach, "F64")) != NULL)
   {
+    f64__nan(c, t);
     f64_from_bits(c, t);
     f64_bits(c, t);
   }
@@ -1385,7 +1407,7 @@ static void make_rdtscp(compile_t* c)
 void genprim_builtins(compile_t* c)
 {
   number_conversions(c);
-  fp_as_bits(c);
+  fp_intrinsics(c);
   make_cpuid(c);
   make_rdtscp(c);
 }

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -8,6 +8,7 @@
 #  pragma warning(disable:4141)
 #endif
 
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 
 #if PONY_LLVM < 307
@@ -46,4 +47,38 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size)
   attr.addDereferenceableAttr(size);
 
   f->addAttributes(i, AttributeSet::get(f->getContext(), i, attr));
+}
+
+#if PONY_LLVM < 307
+static fltSemantics const* float_semantics(Type* t)
+{
+  if (t->isHalfTy())
+    return &APFloat::IEEEhalf;
+  if (t->isFloatTy())
+    return &APFloat::IEEEsingle;
+  if (t->isDoubleTy())
+    return &APFloat::IEEEdouble;
+  if (t->isX86_FP80Ty())
+    return &APFloat::x87DoubleExtended;
+  if (t->isFP128Ty())
+    return &APFloat::IEEEquad;
+
+  assert(t->isPPC_FP128Ty() && "Unknown FP format");
+  return &APFloat::PPCDoubleDouble;
+}
+#endif
+
+LLVMValueRef LLVMConstNaN(LLVMTypeRef type)
+{
+  Type* t = unwrap<Type>(type);
+
+#if PONY_LLVM >= 307
+  Value* nan = ConstantFP::getNaN(t);
+#else
+  fltSemantics const& sem = *float_semantics(t->getScalarType());
+  APFloat flt = APFloat::getNaN(sem, false, 0);
+  Value* nan = ConstantFP::get(t->getContext(), flt);
+#endif
+
+  return wrap(nan);
 }


### PR DESCRIPTION
The LLVM sqrt intrinsic has undefined behaviour for negative arguments. We now check the argument and return NaN if it is below 0.