### PR TITLE
Set symbol linkage type to private by default

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -473,6 +473,11 @@ static void init_module(compile_t* c, ast_t* program, pass_opt_t* opt)
   else
     c->callconv = LLVMFastCallConv;
 
+  if(!c->opt->release || c->opt->library || c->opt->extfun)
+    c->linkage = LLVMExternalLinkage;
+  else
+    c->linkage = LLVMPrivateLinkage;
+
   c->context = LLVMContextCreate();
   c->machine = make_machine(opt);
   c->target_data = LLVMGetTargetMachineData(c->machine);
@@ -602,9 +607,10 @@ bool codegen(ast_t* program, pass_opt_t* opt)
 
 LLVMValueRef codegen_addfun(compile_t* c, const char* name, LLVMTypeRef type)
 {
-  // Add the function and set the calling convention.
+  // Add the function and set the calling convention and the linkage type.
   LLVMValueRef fun = LLVMAddFunction(c->module, name, type);
   LLVMSetFunctionCallConv(fun, c->callconv);
+  LLVMSetLinkage(fun, c->linkage);
 
   LLVMValueRef arg = LLVMGetFirstParam(fun);
   uint32_t i = 1;

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -109,6 +109,7 @@ typedef struct compile_t
   const char* str__event_notify;
 
   LLVMCallConv callconv;
+  LLVMLinkage linkage;
   LLVMContextRef context;
   LLVMTargetMachineRef machine;
   LLVMTargetDataRef target_data;

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -195,7 +195,7 @@ static LLVMValueRef make_trait_list(compile_t* c, reach_type_t* t,
   LLVMTypeRef list_type = LLVMArrayType(c->i32, count);
   LLVMValueRef global = LLVMAddGlobal(c->module, list_type, name);
   LLVMSetGlobalConstant(global, true);
-  LLVMSetLinkage(global, LLVMInternalLinkage);
+  LLVMSetLinkage(global, LLVMPrivateLinkage);
   LLVMSetInitializer(global, trait_array);
 
   ponyint_pool_free_size(tid_size, tid);
@@ -275,7 +275,7 @@ static LLVMValueRef make_field_list(compile_t* c, reach_type_t* t)
   const char* name = genname_fieldlist(t->name);
   LLVMValueRef global = LLVMAddGlobal(c->module, field_type, name);
   LLVMSetGlobalConstant(global, true);
-  LLVMSetLinkage(global, LLVMInternalLinkage);
+  LLVMSetLinkage(global, LLVMPrivateLinkage);
   LLVMSetInitializer(global, field_array);
 
   ponyint_pool_free_size(buf_size, list);
@@ -398,7 +398,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
 
   t->desc = LLVMAddGlobal(c->module, t->desc_type, desc_name);
   LLVMSetGlobalConstant(t->desc, true);
-  LLVMSetLinkage(t->desc, LLVMInternalLinkage);
+  LLVMSetLinkage(t->desc, LLVMPrivateLinkage);
 }
 
 void gendesc_init(compile_t* c, reach_type_t* t)

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -185,9 +185,11 @@ static void make_prototype(compile_t* c, reach_type_t* t,
 
   if(n->name == c->str__final)
   {
-    // Store the finaliser and use the C calling convention.
+    // Store the finaliser and use the C calling convention and an external
+    // linkage.
     t->final_fn = m->func;
     LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
+    LLVMSetLinkage(m->func, LLVMExternalLinkage);
   }
 }
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -522,6 +522,7 @@ void genprim_array_trace(compile_t* c, reach_type_t* t)
 {
   codegen_startfun(c, t->trace_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->trace_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->trace_fn, LLVMExternalLinkage);
   LLVMValueRef ctx = LLVMGetParam(t->trace_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->trace_fn, 1);
 
@@ -548,6 +549,7 @@ void genprim_array_serialise_trace(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->serialise_trace_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->serialise_trace_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->serialise_trace_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->serialise_trace_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_trace_fn, 1);
@@ -588,6 +590,7 @@ void genprim_array_serialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->serialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->serialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->serialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_fn, 1);
@@ -718,6 +721,7 @@ void genprim_array_deserialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->deserialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->deserialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->deserialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->deserialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->deserialise_fn, 1);
@@ -798,6 +802,7 @@ void genprim_string_serialise_trace(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->serialise_trace_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->serialise_trace_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->serialise_trace_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->serialise_trace_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_trace_fn, 1);
@@ -829,6 +834,7 @@ void genprim_string_serialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->serialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->serialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->serialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_fn, 1);
@@ -908,6 +914,7 @@ void genprim_string_deserialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->deserialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->deserialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->deserialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->deserialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->deserialise_fn, 1);

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -325,7 +325,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
   LLVMValueRef str = LLVMConstStringInContext(c->context, name, (int)len,
     false);
   LLVMValueRef g_str = LLVMAddGlobal(c->module, LLVMTypeOf(str), "");
-  LLVMSetLinkage(g_str, LLVMInternalLinkage);
+  LLVMSetLinkage(g_str, LLVMPrivateLinkage);
   LLVMSetInitializer(g_str, str);
   LLVMSetGlobalConstant(g_str, true);
   LLVMValueRef str_ptr = LLVMConstInBoundsGEP(g_str, args, 2);
@@ -341,7 +341,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
   LLVMValueRef g_inst = LLVMAddGlobal(c->module, t->structure, "");
   LLVMSetInitializer(g_inst, inst);
   LLVMSetGlobalConstant(g_inst, true);
-  LLVMSetLinkage(g_inst, LLVMInternalLinkage);
+  LLVMSetLinkage(g_inst, LLVMPrivateLinkage);
 
   return g_inst;
 }

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -123,6 +123,7 @@ static void make_serialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->serialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->serialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->serialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->serialise_fn, 1);
@@ -227,6 +228,7 @@ static void make_deserialise(compile_t* c, reach_type_t* t)
 
   codegen_startfun(c, t->deserialise_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->deserialise_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->deserialise_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->deserialise_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->deserialise_fn, 1);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -246,7 +246,7 @@ static void make_global_instance(compile_t* c, reach_type_t* t)
   t->instance = LLVMAddGlobal(c->module, t->structure, inst_name);
   LLVMSetInitializer(t->instance, value);
   LLVMSetGlobalConstant(t->instance, true);
-  LLVMSetLinkage(t->instance, LLVMInternalLinkage);
+  LLVMSetLinkage(t->instance, LLVMPrivateLinkage);
 }
 
 static void make_dispatch(compile_t* c, reach_type_t* t)
@@ -259,6 +259,7 @@ static void make_dispatch(compile_t* c, reach_type_t* t)
   const char* dispatch_name = genname_dispatch(t->name);
   t->dispatch_fn = codegen_addfun(c, dispatch_name, c->dispatch_type);
   LLVMSetFunctionCallConv(t->dispatch_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->dispatch_fn, LLVMExternalLinkage);
   codegen_startfun(c, t->dispatch_fn, NULL, NULL);
 
   LLVMBasicBlockRef unreachable = codegen_block(c, "unreachable");
@@ -533,6 +534,7 @@ static bool make_trace(compile_t* c, reach_type_t* t)
   // Generate the trace function.
   codegen_startfun(c, t->trace_fn, NULL, NULL);
   LLVMSetFunctionCallConv(t->trace_fn, LLVMCCallConv);
+  LLVMSetLinkage(t->trace_fn, LLVMExternalLinkage);
 
   LLVMValueRef ctx = LLVMGetParam(t->trace_fn, 0);
   LLVMValueRef arg = LLVMGetParam(t->trace_fn, 1);

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -188,6 +188,7 @@ typedef struct pass_opt_t
   bool ieee_math;
   bool print_stats;
   bool verify;
+  bool extfun;
   bool strip_debug;
   bool print_filenames;
   bool check_tree;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -50,7 +50,8 @@ enum
   OPT_BNF,
   OPT_ANTLR,
   OPT_ANTLRRAW,
-  OPT_PIC
+  OPT_PIC,
+  OPT_EXTFUN
 };
 
 static opt_arg_t args[] =
@@ -86,6 +87,7 @@ static opt_arg_t args[] =
   {"antlr", '\0', OPT_ARG_NONE, OPT_ANTLR},
   {"antlrraw", '\0', OPT_ARG_NONE, OPT_ANTLRRAW},
   {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
+  {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
   OPT_ARGS_FINISH
 };
 
@@ -155,6 +157,7 @@ static void usage()
     "    =columns      Defaults to the terminal width.\n"
     "  --immerr        Report errors immediately rather than deferring.\n"
     "  --verify        Verify LLVM IR.\n"
+    "  --extfun        Set function default linkage to external.\n"
     "  --files         Print source file names as each is processed.\n"
     "  --bnf           Print out the Pony grammar as human readable BNF.\n"
     "  --antlr         Print out the Pony grammar as an ANTLR file.\n"
@@ -283,6 +286,7 @@ int main(int argc, char* argv[])
       case OPT_WIDTH: ast_setwidth(atoi(s.arg_val)); break;
       case OPT_IMMERR: errors_set_immediate(opt.check.errors, true); break;
       case OPT_VERIFY: opt.verify = true; break;
+      case OPT_EXTFUN: opt.extfun = true; break;
       case OPT_FILENAMES: opt.print_filenames = true; break;
       case OPT_CHECKTREE: opt.check_tree = true; break;
 


### PR DESCRIPTION
This is advised in LLVM's "[Performance tips for frontend authors](http://llvm.org/docs/Frontend/PerformanceTips.html)".

Functions called from the runtime (finalisers and trace functions) are still generated with an external linkage.

This is only enabled in optimised builds of standalone programs and can be disabled with the new `--extfun` compiler flag.

I've observed a 10% to 30% decrease in executable sizes with this change.