### PR TITLE
Reserve chunks

### DIFF
--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -33,7 +33,7 @@ class WriteBuffer
 
   ```
   use "net"
-  
+
   actor Main
     new create(env: Env) =>
       let wb = WriteBuffer
@@ -57,6 +57,13 @@ class WriteBuffer
   var _current: Array[U8] iso = recover Array[U8] end
   var _offset: USize = 0
   var _size: USize = 0
+
+  fun ref reserve_chunks(size': USize): WriteBuffer^ =>
+    """
+    Reserve space for size' chunks.
+    """
+    _chunks.reserve(size')
+    this
 
   fun ref reserve(size': USize): WriteBuffer^ =>
     """

--- a/packages/net/writebuffer.pony
+++ b/packages/net/writebuffer.pony
@@ -61,6 +61,9 @@ class WriteBuffer
   fun ref reserve_chunks(size': USize): WriteBuffer^ =>
     """
     Reserve space for size' chunks.
+
+    This needs to be recalled after every call to `done`
+    as `done` resets the chunks.
     """
     _chunks.reserve(size')
     this


### PR DESCRIPTION
This adds a new reserve chunks method to WriteBuffer. When WriteBuffer was written, we missed a performance improvement. Many times when using a writebuffer, we know the number of elements we are writing ahead of time, by reserving those chunks, we can save on allocations and increase performance.
