### PR TITLE
Performance enhancements for JSON printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - pony_alloc_msg_size runtime function
 - `net/WriteBuffer`
 - `serialise` package.
-- optional parameter in json objects, arrays, and doc to turn off pretty printing
+- optional parameter in json objects, arrays, and doc to turn on pretty printing
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - pony_alloc_msg_size runtime function
 - `net/WriteBuffer`
 - `serialise` package.
+- optional parameter in json objects, arrays, and doc to turn off pretty printing
 
 ### Changed
 

--- a/packages/json/doc.pony
+++ b/packages/json/doc.pony
@@ -21,7 +21,7 @@ class JsonDoc
     """
     data = None
 
-  fun string(pretty_print: Bool = true): String =>
+  fun string(pretty_print: Bool = false): String =>
     """
     Generate string representation of this document.
     """

--- a/packages/json/doc.pony
+++ b/packages/json/doc.pony
@@ -21,11 +21,11 @@ class JsonDoc
     """
     data = None
 
-  fun string(): String =>
+  fun string(pretty_print: Bool = true): String =>
     """
     Generate string representation of this document.
     """
-    _JsonPrint._string(data, "")
+    _JsonPrint._string(data, "", pretty_print)
 
   fun ref parse(source: String) ? =>
     """

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -39,7 +39,7 @@ class JsonArray
       end
 
       if pretty_print then
-        text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent)
+        text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent, true)
       else
         text = text + if text.size() > 0 then " " else "" end
           + _JsonPrint._string(i, elem_indent, false)
@@ -87,7 +87,7 @@ class JsonObject
 
       if pretty_print then
         text = text + "\n" + elem_indent + "\"" + i._1 + "\": " +
-          _JsonPrint._string(i._2, elem_indent)
+          _JsonPrint._string(i._2, elem_indent, true)
       else
         text = text + if text.size() > 0 then " " else "" end
           + "\"" + i._1 + "\": " +

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -22,7 +22,7 @@ class JsonArray
     """
     data = data'
 
-  fun string(indent: String = ""): String =>
+  fun string(indent: String = "", pretty_print: Bool = true): String =>
     """
     Generate string representation of this array.
     """
@@ -38,9 +38,19 @@ class JsonArray
         text = text + ","
       end
 
-      text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent)
+      if pretty_print then
+        text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent)
+      else
+        text = text + if text.size() > 0 then " " else "" end
+          + _JsonPrint._string(i, elem_indent, false)
+      end
     end
-    "[" + text + "\n" + indent + "]"
+    if pretty_print then
+      "[" + text + "\n" + indent + "]"
+    else
+      "[" + text + "]"
+    end
+
 
 
 class JsonObject
@@ -59,7 +69,7 @@ class JsonObject
     """
     data = data'
 
-  fun string(indent: String = ""): String =>
+  fun string(indent: String = "", pretty_print: Bool = true): String =>
     """
     Generate string representation of this object.
     """
@@ -75,7 +85,17 @@ class JsonObject
         text = text + ","
       end
 
-      text = text + "\n" + elem_indent + "\"" + i._1 + "\": " +
-        _JsonPrint._string(i._2, elem_indent)
+      if pretty_print then
+        text = text + "\n" + elem_indent + "\"" + i._1 + "\": " +
+          _JsonPrint._string(i._2, elem_indent)
+      else
+        text = text + if text.size() > 0 then " " else "" end
+          + "\"" + i._1 + "\": " +
+          _JsonPrint._string(i._2, elem_indent, false)
+      end
     end
-    "{" + text + "\n" + indent + "}"
+    if pretty_print then
+      "{" + text + "\n" + indent + "}"
+    else
+      "{" + text + "}"
+    end

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -30,26 +30,31 @@ class JsonArray
       return "[]"
     end
 
-    var text = ""
+    var text = recover String end
     let elem_indent = indent + "  "
 
+    text.append("[")
+
     for i in data.values() do
-      if text.size() > 0 then
-        text = text + ","
+      if text.size() > 1 then
+        text.append(",")
       end
 
       if pretty_print then
-        text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent, true)
-      else
-        text = text + _JsonPrint._string(i, elem_indent, false)
+        text.append("\n")
+        text.append(elem_indent)
       end
-    end
-    if pretty_print then
-      "[" + text + "\n" + indent + "]"
-    else
-      "[" + text + "]"
+
+      text.append(_JsonPrint._string(i, elem_indent, pretty_print))
     end
 
+    if pretty_print then
+      text.append("\n")
+      text.append(indent)
+    end
+
+    text.append("]")
+    text
 
 
 class JsonObject
@@ -76,24 +81,36 @@ class JsonObject
       return "{}"
     end
 
-    var text = ""
+    var text = recover String end
     let elem_indent = indent + "  "
 
+    text.append("{")
+
     for i in data.pairs() do
-      if text.size() > 0 then
-        text = text + ","
+      if text.size() > 1 then
+        text.append(",")
       end
 
       if pretty_print then
-        text = text + "\n" + elem_indent + "\"" + i._1 + "\": " +
-          _JsonPrint._string(i._2, elem_indent, true)
-      else
-        text = text + "\"" + i._1 + "\":" +
-          _JsonPrint._string(i._2, elem_indent, false)
+        text.append("\n")
+        text.append(elem_indent)
       end
+
+      text.append("\"")
+      text.append(i._1)
+      text.append("\":")
+
+      if pretty_print then
+        text.append(" ")
+      end
+
+      text.append(_JsonPrint._string(i._2, elem_indent, pretty_print))
     end
+
     if pretty_print then
-      "{" + text + "\n" + indent + "}"
-    else
-      "{" + text + "}"
+      text.append("\n")
+      text.append(indent)
     end
+
+    text.append("}")
+    text

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -30,7 +30,7 @@ class JsonArray
       return "[]"
     end
 
-    var text = recover String end
+    var text = recover String(256) end
     let elem_indent = indent + "  "
 
     text.append("[")
@@ -81,7 +81,7 @@ class JsonObject
       return "{}"
     end
 
-    var text = recover String end
+    var text = recover String(256) end
     let elem_indent = indent + "  "
 
     text.append("{")

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -41,8 +41,7 @@ class JsonArray
       if pretty_print then
         text = text + "\n" + elem_indent + _JsonPrint._string(i, elem_indent, true)
       else
-        text = text + if text.size() > 0 then " " else "" end
-          + _JsonPrint._string(i, elem_indent, false)
+        text = text + _JsonPrint._string(i, elem_indent, false)
       end
     end
     if pretty_print then
@@ -89,8 +88,7 @@ class JsonObject
         text = text + "\n" + elem_indent + "\"" + i._1 + "\": " +
           _JsonPrint._string(i._2, elem_indent, true)
       else
-        text = text + if text.size() > 0 then " " else "" end
-          + "\"" + i._1 + "\": " +
+        text = text + "\"" + i._1 + "\":" +
           _JsonPrint._string(i._2, elem_indent, false)
       end
     end

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -22,7 +22,7 @@ class JsonArray
     """
     data = data'
 
-  fun string(indent: String = "", pretty_print: Bool = true): String =>
+  fun string(indent: String = "", pretty_print: Bool = false): String =>
     """
     Generate string representation of this array.
     """
@@ -69,7 +69,7 @@ class JsonObject
     """
     data = data'
 
-  fun string(indent: String = "", pretty_print: Bool = true): String =>
+  fun string(indent: String = "", pretty_print: Bool = false): String =>
     """
     Generate string representation of this object.
     """

--- a/packages/json/print.pony
+++ b/packages/json/print.pony
@@ -1,6 +1,6 @@
 primitive _JsonPrint
   fun _string(d: box->JsonType, indent: String,
-    pretty_print: Bool = true): String
+    pretty_print: Bool = false): String
   =>
     """
     Generate string representation of the given data.

--- a/packages/json/print.pony
+++ b/packages/json/print.pony
@@ -1,5 +1,7 @@
 primitive _JsonPrint
-  fun _string(d: box->JsonType, indent: String): String =>
+  fun _string(d: box->JsonType, indent: String,
+    pretty_print: Bool = true): String
+  =>
     """
     Generate string representation of the given data.
     """
@@ -8,8 +10,8 @@ primitive _JsonPrint
     | let x: Bool => x.string()
     | let x: None => "null"
     | let x: String => _escaped_string(x)
-    | let x: JsonArray box => x.string(indent)
-    | let x: JsonObject box => x.string(indent)
+    | let x: JsonArray box => x.string(indent, pretty_print)
+    | let x: JsonObject box => x.string(indent, pretty_print)
     | let x: F64 =>
       // Make sure our printed floats can be distinguished from integers
       let basic = x.string()

--- a/packages/json/tests.pony
+++ b/packages/json/tests.pony
@@ -22,6 +22,9 @@ actor Main is TestList
     test(_TestPrintArray)
     test(_TestPrintObject)
 
+    test(_TestNoPrettyPrintArray)
+    test(_TestNoPrettyPrintObject)
+
     test(_TestParsePrint)
 
 
@@ -505,6 +508,43 @@ class iso _TestPrintArray is UnitTest
       doc.string())
 
 
+class iso _TestNoPrettyPrintArray is UnitTest
+  """
+  Test Json none-pretty printing of arrays.
+  """
+  fun name(): String => "JSON/nopprint.array"
+
+  fun apply(h: TestHelper) =>
+    let doc: JsonDoc = JsonDoc
+    let array: JsonArray = JsonArray
+
+    doc.data = array
+    h.assert_eq[String]("[]", doc.string(false))
+
+    array.data.clear()
+    array.data.push(true)
+    h.assert_eq[String]("[true]", doc.string(false))
+
+    array.data.clear()
+    array.data.push(true)
+    array.data.push(false)
+    h.assert_eq[String]("[true, false]", doc.string(false))
+
+    array.data.clear()
+    array.data.push(true)
+    array.data.push(I64(13))
+    array.data.push(None)
+    h.assert_eq[String]("[true, 13, null]", doc.string(false))
+
+    array.data.clear()
+    array.data.push(true)
+    var nested: JsonArray = JsonArray
+    nested.data.push(I64(52))
+    nested.data.push(None)
+    array.data.push(nested)
+    h.assert_eq[String]("[true, [52, null]]",
+      doc.string(false))
+
 class iso _TestPrintObject is UnitTest
   """
   Test Json printing of objects.
@@ -532,6 +572,32 @@ class iso _TestPrintObject is UnitTest
     // We don't test with more fields in the object because we don't know what
     // order they will be printed in
 
+class iso _TestNoPrettyPrintObject is UnitTest
+  """
+  Test Json none-pretty printing of objects.
+  """
+  fun name(): String => "JSON/nopprint.object"
+
+  fun apply(h: TestHelper) =>
+    let doc: JsonDoc = JsonDoc
+    let obj: JsonObject = JsonObject
+
+    doc.data = obj
+    h.assert_eq[String]("{}", doc.string(false))
+
+    obj.data.clear()
+    obj.data("foo") = true
+    h.assert_eq[String]("{\"foo\": true}", doc.string(false))
+
+    obj.data.clear()
+    obj.data("a") = true
+    obj.data("b") = I64(3)
+    let s = doc.string(false)
+    h.assert_true((s == "{\"a\": true, \"b\": 3}") or
+      (s == "{\"b\": false, \"a\": true}"))
+
+    // We don't test with more fields in the object because we don't know what
+    // order they will be printed in
 
 class iso _TestParsePrint is UnitTest
   """

--- a/packages/json/tests.pony
+++ b/packages/json/tests.pony
@@ -593,7 +593,6 @@ class iso _TestNoPrettyPrintObject is UnitTest
     obj.data("a") = true
     obj.data("b") = I64(3)
     let s = doc.string(false)
-    @printf[None]("%s\n".cstring(), s.cstring())
     h.assert_true((s == "{\"a\":true,\"b\":3}") or
       (s == "{\"b\":3,\"a\":true}"))
 

--- a/packages/json/tests.pony
+++ b/packages/json/tests.pony
@@ -481,22 +481,22 @@ class iso _TestPrintArray is UnitTest
     let array: JsonArray = JsonArray
 
     doc.data = array
-    h.assert_eq[String]("[]", doc.string())
+    h.assert_eq[String]("[]", doc.string(true))
 
     array.data.clear()
     array.data.push(true)
-    h.assert_eq[String]("[\n  true\n]", doc.string())
+    h.assert_eq[String]("[\n  true\n]", doc.string(true))
 
     array.data.clear()
     array.data.push(true)
     array.data.push(false)
-    h.assert_eq[String]("[\n  true,\n  false\n]", doc.string())
+    h.assert_eq[String]("[\n  true,\n  false\n]", doc.string(true))
 
     array.data.clear()
     array.data.push(true)
     array.data.push(I64(13))
     array.data.push(None)
-    h.assert_eq[String]("[\n  true,\n  13,\n  null\n]", doc.string())
+    h.assert_eq[String]("[\n  true,\n  13,\n  null\n]", doc.string(true))
 
     array.data.clear()
     array.data.push(true)
@@ -505,7 +505,7 @@ class iso _TestPrintArray is UnitTest
     nested.data.push(None)
     array.data.push(nested)
     h.assert_eq[String]("[\n  true,\n  [\n    52,\n    null\n  ]\n]",
-      doc.string())
+      doc.string(true))
 
 
 class iso _TestNoPrettyPrintArray is UnitTest
@@ -556,16 +556,16 @@ class iso _TestPrintObject is UnitTest
     let obj: JsonObject = JsonObject
 
     doc.data = obj
-    h.assert_eq[String]("{}", doc.string())
+    h.assert_eq[String]("{}", doc.string(true))
 
     obj.data.clear()
     obj.data("foo") = true
-    h.assert_eq[String]("{\n  \"foo\": true\n}", doc.string())
+    h.assert_eq[String]("{\n  \"foo\": true\n}", doc.string(true))
 
     obj.data.clear()
     obj.data("a") = true
     obj.data("b") = I64(3)
-    let s = doc.string()
+    let s = doc.string(true)
     h.assert_true((s == "{\n  \"a\": true,\n  \"b\": 3\n}") or
       (s == "{\n  \"b\": false,\n  \"a\": true\n}"))
 
@@ -639,7 +639,7 @@ class iso _TestParsePrint is UnitTest
 
     let doc: JsonDoc = JsonDoc
     doc.parse(src)
-    let printed = doc.string()
+    let printed = doc.string(true)
 
     // TODO: Sort out line endings on different platforms. For now normalise
     // before comparing

--- a/packages/json/tests.pony
+++ b/packages/json/tests.pony
@@ -528,13 +528,13 @@ class iso _TestNoPrettyPrintArray is UnitTest
     array.data.clear()
     array.data.push(true)
     array.data.push(false)
-    h.assert_eq[String]("[true, false]", doc.string(false))
+    h.assert_eq[String]("[true,false]", doc.string(false))
 
     array.data.clear()
     array.data.push(true)
     array.data.push(I64(13))
     array.data.push(None)
-    h.assert_eq[String]("[true, 13, null]", doc.string(false))
+    h.assert_eq[String]("[true,13,null]", doc.string(false))
 
     array.data.clear()
     array.data.push(true)
@@ -542,7 +542,7 @@ class iso _TestNoPrettyPrintArray is UnitTest
     nested.data.push(I64(52))
     nested.data.push(None)
     array.data.push(nested)
-    h.assert_eq[String]("[true, [52, null]]",
+    h.assert_eq[String]("[true,[52,null]]",
       doc.string(false))
 
 class iso _TestPrintObject is UnitTest
@@ -587,14 +587,15 @@ class iso _TestNoPrettyPrintObject is UnitTest
 
     obj.data.clear()
     obj.data("foo") = true
-    h.assert_eq[String]("{\"foo\": true}", doc.string(false))
+    h.assert_eq[String]("{\"foo\":true}", doc.string(false))
 
     obj.data.clear()
     obj.data("a") = true
     obj.data("b") = I64(3)
     let s = doc.string(false)
-    h.assert_true((s == "{\"a\": true, \"b\": 3}") or
-      (s == "{\"b\": 3, \"a\": true}"))
+    @printf[None]("%s\n".cstring(), s.cstring())
+    h.assert_true((s == "{\"a\":true,\"b\":3}") or
+      (s == "{\"b\":3,\"a\":true}"))
 
     // We don't test with more fields in the object because we don't know what
     // order they will be printed in

--- a/packages/json/tests.pony
+++ b/packages/json/tests.pony
@@ -594,7 +594,7 @@ class iso _TestNoPrettyPrintObject is UnitTest
     obj.data("b") = I64(3)
     let s = doc.string(false)
     h.assert_true((s == "{\"a\": true, \"b\": 3}") or
-      (s == "{\"b\": false, \"a\": true}"))
+      (s == "{\"b\": 3, \"a\": true}"))
 
     // We don't test with more fields in the object because we don't know what
     // order they will be printed in


### PR DESCRIPTION
Pretty printing JSON creates a slightly larger data structure than
a non-pretty printed version. When dealing with large aggregates,
this can result in large differences that can have a noticeable
impact on performance when sending over the network.

This change makes pretty printing optional in a way that maintains
compatibility with the existing API.