### PR TITLE
Add upsert method to Map for updating by combining current with new value

### DIFF
--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -76,6 +76,44 @@ class HashMap[K, V, H: HashFunction[K] val]
     end
     None
 
+  fun ref upsert(key: K, value: V, f: {(V, V): V^} box): HashMap[K, V, H]^ =>
+    """
+    Combines a provided value with the current value for the provided key
+    using the provided function. If the provided key has not been added to
+    the map yet, it sets its value to the provided value.
+
+    As a simple example, say we had a map with U64 values and we wanted to
+    add 4 to the current value for key "test", which let's say is currently 2.
+    We call
+
+    m.upsert("test", 4, lambda(x: U64, y: U64): U64 => x + y end)
+
+    This changes the value associated with "test" to 6.
+
+    If we have not yet added the key "new-key" to the map and we call
+
+    m.upsert("new-key", 4, lambda(x: U64, y: U64): U64 => x + y end)
+
+    then "new-key" is added to the map with a value of 4.
+    """
+
+    (let i, let found) = _search(key)
+
+    try
+      if found then
+        let prev = (_array(i) = _MapEmpty) as (_, V^)
+        _array(i) = (consume key, f(consume prev, consume value))
+      else
+        _array(i) = (consume key, consume value)
+        _size = _size + 1
+
+        if (_size * 4) > (_array.size() * 3) then
+          _resize(_array.size() * 2)
+        end
+      end
+    end
+    this
+
   fun ref insert(key: K, value: V): V ? =>
     """
     Set a value in the map. Returns the new value, allowing reuse.

--- a/packages/collections/test.pony
+++ b/packages/collections/test.pony
@@ -8,6 +8,7 @@ actor Main is TestList
     test(_TestList)
     test(_TestMap)
     test(_TestMapRemove)
+    test(_TestMapUpsert)
     test(_TestRing)
     test(_TestListsFrom)
     test(_TestListsMap)
@@ -139,6 +140,36 @@ class iso _TestMapRemove is UnitTest
 
     x(11) = "here"
     h.assert_eq[String](x(11), "here")
+
+class iso _TestMapUpsert is UnitTest
+  fun name(): String => "collections/Map.upsert"
+
+  fun apply(h: TestHelper) ? =>
+    let x: Map[U32, U64] = Map[U32,U64]
+    let f = lambda(x: U64, y: U64): U64 => x + y end
+    x.upsert(1, 5, f)
+    h.assert_eq[U64](5, x(1))
+    x.upsert(1, 3, f)
+    h.assert_eq[U64](8, x(1))
+    x.upsert(1, 4, f)
+    h.assert_eq[U64](12, x(1))
+    x.upsert(1, 2, f)
+    h.assert_eq[U64](14, x(1))
+    x.upsert(1, 1, f)
+    h.assert_eq[U64](15, x(1))
+
+    let x2: Map[U32, String] = Map[U32,String]
+    let g = lambda(x: String, y: String): String => x + ", " + y end
+    x2.upsert(1, "1", g)
+    h.assert_eq[String]("1", x2(1))
+    x2.upsert(1, "2", g)
+    h.assert_eq[String]("1, 2", x2(1))
+    x2.upsert(1, "3", g)
+    h.assert_eq[String]("1, 2, 3", x2(1))
+    x2.upsert(1, "abc", g)
+    h.assert_eq[String]("1, 2, 3, abc", x2(1))
+    x2.upsert(1, "def", g)
+    h.assert_eq[String]("1, 2, 3, abc, def", x2(1))
 
 class iso _TestRing is UnitTest
   fun name(): String => "collections/RingBuffer"


### PR DESCRIPTION
Map.upsert() combines a provided value with the current value for the provided key
using the provided function. If the provided key has not been added to
the map yet, it sets its value to the provided value. 

This avoids having to lookup the old value twice when you want to use the old value to calculate the new value.