### PR TITLE
Add documentation for the `net` package.

### DIFF
--- a/packages/net/net.pony
+++ b/packages/net/net.pony
@@ -1,0 +1,7 @@
+"""
+# Net package
+
+The Net package provides support for creating UDP and TCP clients and
+servers, reading and writing network data, and establishing UDP and
+TCP connections.
+"""

--- a/packages/net/tcpconnection.pony
+++ b/packages/net/tcpconnection.pony
@@ -11,6 +11,31 @@ type TCPConnectionAuth is (AmbientAuth | NetAuth | TCPAuth | TCPConnectAuth)
 actor TCPConnection
   """
   A TCP connection. When connecting, the Happy Eyeballs algorithm is used.
+
+  The following code creates a client that connects to port 8989 of
+  the local host, writes "hello world", and listens for a response,
+  which it then prints.
+
+  ```
+  use "net"
+
+  class MyTCPConnectionNotify is TCPConnectionNotify
+    let _out: OutStream
+    new create(out: OutStream) =>
+      _out = out
+    fun ref connected(conn: TCPConnection ref) =>
+      conn.write("hello world")
+    fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
+      _out.print("GOT:" + String.from_array(consume data))
+      conn.close()
+
+  actor Main
+    new create(env: Env) =>
+      try
+        TCPConnection(env.root as AmbientAuth,
+          recover MyTCPConnectionNotify(env.out) end, "", "8989")
+      end
+  ```
   """
   var _listen: (TCPListener | None) = None
   var _notify: TCPConnectionNotify

--- a/packages/net/tcplistener.pony
+++ b/packages/net/tcplistener.pony
@@ -3,6 +3,28 @@ type TCPListenerAuth is (AmbientAuth | NetAuth | TCPAuth | TCPListenAuth)
 actor TCPListener
   """
   Listens for new network connections.
+
+  The following program creates an echo server that listens for
+  connections on port 8989 and echoes back any data it receives.
+
+  ```
+  use "net"
+
+  class MyTCPConnectionNotify is TCPConnectionNotify
+    fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
+      conn.write(String.from_array(consume data))
+
+  class MyTCPListenNotify is TCPListenNotify
+    fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
+      MyTCPConnectionNotify
+
+  actor Main
+    new create(env: Env) =>
+      try
+        TCPListener(env.root as AmbientAuth,
+          recover MyTCPListenNotify end, "", "8989")
+      end
+  ```
   """
   var _notify: TCPListenNotify
   var _fd: U32

--- a/packages/net/tcpnotify.pony
+++ b/packages/net/tcpnotify.pony
@@ -1,6 +1,9 @@
 interface TCPConnectionNotify
   """
   Notifications for TCP connections.
+
+  For an example of using this class please see the documentation for the
+  `TCPConnection` and `TCPListener` actors.
   """
   fun ref accepted(conn: TCPConnection ref) =>
     """
@@ -78,6 +81,9 @@ interface TCPConnectionNotify
 interface TCPListenNotify
   """
   Notifications for TCP listeners.
+
+  For an example of using this class, please see the documentation for the
+  `TCPListener` actor.
   """
   fun ref listening(listen: TCPListener ref) =>
     """

--- a/packages/net/udpnotify.pony
+++ b/packages/net/udpnotify.pony
@@ -1,4 +1,10 @@
 interface UDPNotify
+  """
+  Notifications for UDP connections.
+
+  For an example of using this class please see the documentatoin for the
+  `UDPSocket` actor.
+  """
   fun ref listening(sock: UDPSocket ref) =>
     """
     Called when the socket has been bound to an address.


### PR DESCRIPTION
The documentation for the `net` package was sparse. This commit adds
package-level documenation and adds example code for UDPSocket,
TCPListener, and TCPConnection. It also adds notes to the document
strings for supporting classes indicating that examples of their use
can be found in other places.