### PR TITLE
Fix incorrect use of the `len` variable in regex package replace func…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Runtime crash when Main.create is a function instead of a constructor.
 - Compiler bug where `as` operator with a lambda literal caused seg fault.
 - String.read_int failure on lowest number in the range of signed integers.
+- Regex incorrect of len variable when PCRE2_ERROR_NOMEMORY is encountered.
 
 ### Added
 

--- a/packages/regex/regex.pony
+++ b/packages/regex/regex.pony
@@ -129,7 +129,7 @@ class Regex
         addressof len)
 
       if rc == -48 then
-        len = len * 2
+        len = out.space() * 2
         out.reserve(len)
         len = out.space()
       end


### PR DESCRIPTION
…tion

* In `regex.pony` line 132, we rely on the `len` variable when
  `PCRE2_ERROR_NOMEMORY` has been encountered by PCRE2. This is not
  correct because we pass the pointer to `len` to `pcre2_substitute_8`
  and it modifies the value (see: http://vcs.pcre.org/pcre2/code/tags/pcre2-10.21/src/pcre2_substitute.c?revision=476&view=markup
  line 242) so that it is not usable for our purposes any longer.