### PR TITLE
Remove pointer/integer conversions in generated code

### DIFF
--- a/packages/builtin/pointer.pony
+++ b/packages/builtin/pointer.pony
@@ -78,19 +78,19 @@ struct Pointer[A]
     """
     Return true for a null pointer, false for anything else.
     """
-    usize() == 0
+    compile_intrinsic
 
   fun tag eq(that: Pointer[A] tag): Bool =>
     """
     Return true if this address is that address.
     """
-    usize() == that.usize()
+    compile_intrinsic
 
   fun tag lt(that: Pointer[A] tag): Bool =>
     """
     Return true if this address is less than that address.
     """
-    usize() < that.usize()
+    compile_intrinsic
 
   fun tag ne(that: Pointer[A] tag): Bool => not eq(that)
   fun tag le(that: Pointer[A] tag): Bool => lt(that) or eq(that)

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -107,8 +107,8 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
         return LLVMConstInt(c->i1, 0, false);
 
       // Pointers must be to the same address.
-      l_value = LLVMBuildPtrToInt(c->builder, l_value, c->intptr, "");
-      r_value = LLVMBuildPtrToInt(c->builder, r_value, c->intptr, "");
+      l_value = LLVMBuildBitCast(c->builder, l_value, c->object_ptr, "");
+      r_value = LLVMBuildBitCast(c->builder, r_value, c->object_ptr, "");
       return LLVMBuildICmp(c->builder, LLVMIntEQ, l_value, r_value, "");
     }
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -89,7 +89,7 @@ static bool check_tuple(compile_t* c, LLVMValueRef ptr, LLVMValueRef desc,
     // Load the object, load its descriptor, and continue from there.
     LLVMPositionBuilderAtEnd(c->builder, null_block);
     LLVMTypeRef ptr_type = LLVMPointerType(c->object_ptr, 0);
-    LLVMValueRef object_ptr = LLVMBuildIntToPtr(c->builder, field_ptr,
+    LLVMValueRef object_ptr = LLVMBuildBitCast(c->builder, field_ptr,
       ptr_type, "");
     LLVMValueRef object = LLVMBuildLoad(c->builder, object_ptr, "");
     LLVMValueRef object_desc = gendesc_fetch(c, object);
@@ -252,7 +252,7 @@ static bool dynamic_tuple_element(compile_t* c, LLVMValueRef ptr,
   // Load the object, load its descriptor, and continue from there.
   LLVMPositionBuilderAtEnd(c->builder, null_block);
   LLVMTypeRef ptr_type = LLVMPointerType(c->object_ptr, 0);
-  LLVMValueRef object_ptr = LLVMBuildIntToPtr(c->builder, field_ptr, ptr_type,
+  LLVMValueRef object_ptr = LLVMBuildBitCast(c->builder, field_ptr, ptr_type,
     "");
   LLVMValueRef object = LLVMBuildLoad(c->builder, object_ptr, "");
   LLVMValueRef object_desc = gendesc_fetch(c, object);
@@ -329,7 +329,7 @@ static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
   // load from ptr with a type based on the static type of the pattern.
   reach_type_t* t = reach_type(c->reach, param_type);
   LLVMTypeRef ptr_type = LLVMPointerType(t->use_type, 0);
-  ptr = LLVMBuildIntToPtr(c->builder, ptr, ptr_type, "");
+  ptr = LLVMBuildBitCast(c->builder, ptr, ptr_type, "");
   LLVMValueRef value = LLVMBuildLoad(c->builder, ptr, "");
 
   return check_value(c, pattern, param_type, value, next_block);
@@ -353,7 +353,7 @@ static bool dynamic_capture_ptr(compile_t* c, LLVMValueRef ptr,
   // We can load from ptr with a type based on the static type of the pattern.
   reach_type_t* t = reach_type(c->reach, pattern_type);
   LLVMTypeRef ptr_type = LLVMPointerType(t->use_type, 0);
-  ptr = LLVMBuildIntToPtr(c->builder, ptr, ptr_type, "");
+  ptr = LLVMBuildBitCast(c->builder, ptr, ptr_type, "");
   LLVMValueRef value = LLVMBuildLoad(c->builder, ptr, "");
 
   return gen_assign_value(c, pattern, value, pattern_type) != NULL;


### PR DESCRIPTION
- Use `getelementptr` instead of `ptrtoint`/`inttoptr` for pointer arithmetic to keep aliasing information.
- Directly compare pointers instead of converting to integers before comparison.