### PR TITLE
Add more LLVM attributes to allocators

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -7,6 +7,7 @@
 #include "gencall.h"
 #include "genopt.h"
 #include "../pkg/package.h"
+#include "../../libponyrt/mem/heap.h"
 #include "../../libponyrt/mem/pool.h"
 
 #include <platform.h>
@@ -246,6 +247,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_create", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+  LLVMSetDereferenceable(value, 0, PONY_ACTOR_PAD_SIZE);
 
   // void ponyint_destroy(__object*)
   params[0] = c->object_ptr;
@@ -268,6 +270,9 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_alloc", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+#if PONY_LLVM >= 307
+  LLVMSetDereferenceableOrNull(value, 0, HEAP_MIN);
+#endif
 
   // i8* pony_alloc_small(i8*, i32)
   params[0] = c->void_ptr;
@@ -276,6 +281,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_alloc_small", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+  LLVMSetDereferenceable(value, 0, HEAP_MIN);
 
   // i8* pony_alloc_large(i8*, intptr)
   params[0] = c->void_ptr;
@@ -284,6 +290,7 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_alloc_large", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+  LLVMSetDereferenceable(value, 0, HEAP_MAX + 1);
 
   // i8* pony_realloc(i8*, i8*, intptr)
   params[0] = c->void_ptr;
@@ -293,6 +300,9 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_realloc", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+#if PONY_LLVM >= 307
+  LLVMSetDereferenceableOrNull(value, 0, HEAP_MIN);
+#endif
 
   // i8* pony_alloc_final(i8*, intptr, c->final_fn)
   params[0] = c->void_ptr;
@@ -302,6 +312,9 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_alloc_final", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
+#if PONY_LLVM >= 307
+  LLVMSetDereferenceableOrNull(value, 0, HEAP_MIN);
+#endif
 
   // $message* pony_alloc_msg(i32, i32)
   params[0] = c->i32;

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -24,6 +24,9 @@ char* LLVMGetHostCPUName();
 void LLVMSetUnsafeAlgebra(LLVMValueRef inst);
 void LLVMSetReturnNoAlias(LLVMValueRef fun);
 void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
+#if PONY_LLVM >= 307
+void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size);
+#endif
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 
 #define GEN_NOVALUE ((LLVMValueRef)1)

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -518,6 +518,13 @@ static bool genfun_allocator(compile_t* c, reach_type_t* t)
   const char* funname = genname_alloc(t->name);
   LLVMTypeRef ftype = LLVMFunctionType(t->use_type, NULL, 0, false);
   LLVMValueRef fun = codegen_addfun(c, funname, ftype);
+  if(t->underlying != TK_PRIMITIVE)
+  {
+    LLVMSetReturnNoAlias(fun);
+    LLVMTypeRef elem = LLVMGetElementType(t->use_type);
+    size_t size = (size_t)LLVMABISizeOfType(c->target_data, elem);
+    LLVMSetDereferenceable(fun, 0, size);
+  }
   codegen_startfun(c, fun, NULL, NULL);
 
   LLVMValueRef result;

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -107,6 +107,11 @@ static void pointer_alloc(compile_t* c, reach_type_t* t,
   size_t size = (size_t)LLVMABISizeOfType(c->target_data, t_elem->use_type);
   LLVMValueRef l_size = LLVMConstInt(c->intptr, size, false);
 
+  LLVMSetReturnNoAlias(m->func);
+#if PONY_LLVM >= 307
+  LLVMSetDereferenceableOrNull(m->func, 0, size);
+#endif
+
   LLVMValueRef len = LLVMGetParam(m->func, 1);
   LLVMValueRef args[2];
   args[0] = codegen_ctx(c);
@@ -132,6 +137,11 @@ static void pointer_realloc(compile_t* c, reach_type_t* t,
   // Set up a constant integer for the allocation size.
   size_t size = (size_t)LLVMABISizeOfType(c->target_data, t_elem->use_type);
   LLVMValueRef l_size = LLVMConstInt(c->intptr, size, false);
+
+  LLVMSetReturnNoAlias(m->func);
+#if PONY_LLVM >= 307
+  LLVMSetDereferenceableOrNull(m->func, 0, size);
+#endif
 
   LLVMValueRef args[3];
   args[0] = codegen_ctx(c);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -49,6 +49,18 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size)
   f->addAttributes(i, AttributeSet::get(f->getContext(), i, attr));
 }
 
+#if PONY_LLVM >= 307
+void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size)
+{
+  Function* f = unwrap<Function>(fun);
+
+  AttrBuilder attr;
+  attr.addDereferenceableOrNullAttr(size);
+
+  f->addAttributes(i, AttributeSet::get(f->getContext(), i, attr));
+}
+#endif
+
 #if PONY_LLVM < 307
 static fltSemantics const* float_semantics(Type* t)
 {


### PR DESCRIPTION
Add `noalias` to every allocation function and `dereferenceable` or `dereferenceable_or_null` depending on the function.