### PR TITLE
Use more accurate LLVM parameter attributes

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -621,11 +621,12 @@ void genfun_param_attrs(reach_type_t* t, reach_method_t* m, LLVMValueRef fun)
           case TK_REF:
             break;
           case TK_VAL:
-          case TK_BOX:
+          case TK_TAG:
+            LLVMAddAttribute(param, LLVMNoAliasAttribute);
             LLVMAddAttribute(param, LLVMReadOnlyAttribute);
             break;
-          case TK_TAG:
-            LLVMAddAttribute(param, LLVMReadNoneAttribute);
+          case TK_BOX:
+            LLVMAddAttribute(param, LLVMReadOnlyAttribute);
             break;
           default:
             assert(0);


### PR DESCRIPTION
Follows bbacbe1 (Set LLVM parameter attributes according to refcaps).

- Set `tag` parameters to `noalias readonly` instead of `readnone`. A `tag` can be dereferenced by a match expression to access the type descriptor so `readnone` isn't safe.
- Add `noalias` to `val` parameters in addition to `readonly`. Only read-only pointers to `val` objects can exist and read-only pointers never alias between each other in LLVM.