### PR TITLE
Deserialise boxed machine words correctly

### DIFF
--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -15,6 +15,7 @@ actor Main is TestList
     test(_TestSimple)
     test(_TestArrays)
     test(_TestFailures)
+    test(_TestBoxedMachineWord)
 
 class _MachineWords
   var bool1: Bool = true
@@ -209,3 +210,24 @@ class iso _TestFailures is UnitTest
       lambda()(serialise)? =>
         Serialised(serialise, _HasActor)
       end)
+
+class _BoxedWord
+  var f: Any val = U32(3)
+
+class iso _TestBoxedMachineWord is UnitTest
+  """
+  Test serialising boxed machine words.
+  """
+  fun name(): String => "serialise/BoxedMachineWord"
+
+  fun apply(h: TestHelper) ? =>
+    let ambient = h.env.root as AmbientAuth
+    let serialise = SerialiseAuth(ambient)
+    let deserialise = DeserialiseAuth(ambient)
+
+    let x: _BoxedWord = _BoxedWord
+    x.f = U64(7)
+    let sx = Serialised(serialise, x)
+    let y = sx(deserialise) as _BoxedWord
+    h.assert_true(x isnt y)
+    h.assert_true((y.f as U64) == 7)

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -151,6 +151,7 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
 
   switch(t->underlying)
   {
+    case TK_PRIMITIVE:
     case TK_CLASS:
     {
       gendeserialise_typeid(c, t, object);
@@ -312,7 +313,7 @@ bool genserialise(compile_t* c, reach_type_t* t)
 
   make_serialise(c, t);
 
-  if(t->underlying != TK_PRIMITIVE)
+  if((t->underlying != TK_PRIMITIVE) || (t->primitive != NULL))
     make_deserialise(c, t);
 
   return true;

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -600,6 +600,18 @@ void ponyint_gc_handlestack(pony_ctx_t* ctx)
   }
 }
 
+void ponyint_gc_discardstack(pony_ctx_t* ctx)
+{
+  pony_trace_fn f;
+  void *p;
+
+  while(ctx->stack != NULL)
+  {
+    ctx->stack = ponyint_gcstack_pop(ctx->stack, (void**)&f);
+    ctx->stack = ponyint_gcstack_pop(ctx->stack, &p);
+  }
+}
+
 void ponyint_gc_sweep(pony_ctx_t* ctx, gc_t* gc)
 {
   gc->finalisers -= ponyint_objectmap_sweep(&gc->local);

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -57,6 +57,8 @@ void ponyint_gc_markimmutable(pony_ctx_t* ctx, gc_t* gc);
 
 void ponyint_gc_handlestack(pony_ctx_t* ctx);
 
+void ponyint_gc_discardstack(pony_ctx_t* ctx);
+
 void ponyint_gc_sweep(pony_ctx_t* ctx, gc_t* gc);
 
 void ponyint_gc_sendacquire(pony_ctx_t* ctx);


### PR DESCRIPTION
Previously, the descriptor wasn't being set correctly. It was still
the type ID, not the pointer to the descriptor.

This change also fixes an error where an aborted serialisation or
deserialisation left junk in the context that could cause a future
serialisation or deserialisation to fail unexpectedly.