### PR TITLE
Recursively check control flow AST errors

### DIFF
--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -464,7 +464,17 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
   // return is always the last expression in a sequence
   assert(ast_sibling(ast) == NULL);
 
-  if(ast_parent(ast) == t->frame->method_body)
+  ast_t* parent = ast_parent(ast);
+  ast_t* current = ast;
+
+  while(ast_id(parent) == TK_SEQ)
+  {
+    assert(ast_childlast(parent) == current);
+    current = parent;
+    parent = ast_parent(parent);
+  }
+
+  if(current == t->frame->method_body)
   {
     ast_error(opt->check.errors, ast,
       "use return only to exit early from a method, not at the end");

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -623,6 +623,20 @@ static ast_result_t syntax_return(pass_opt_t* opt, ast_t* ast,
     return AST_ERROR;
   }
 
+  ast_t* parent = ast_parent(ast);
+  ast_t* current = ast;
+  while(ast_id(parent) == TK_SEQ)
+  {
+    if(ast_sibling(current) != NULL)
+    {
+      ast_error(opt->check.errors,
+        ast_sibling(current), "Unreachable code");
+      return AST_ERROR;
+    }
+    current = parent;
+    parent = ast_parent(parent);
+  }
+
   if(ast_id(ast) == TK_RETURN)
   {
     if(opt->check.frame->method_body == NULL)

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -205,3 +205,29 @@ TEST_F(BadPonyTest, MainActorFunCreate)
 
   TEST_ERRORS_1(src, "the create method of a Main actor must be a constructor");
 }
+
+TEST_F(BadPonyTest, ParenthesisedReturn)
+{
+  // From issue #1050
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    (return)";
+
+  TEST_ERRORS_1(src, "use return only to exit early from a method");
+}
+
+TEST_F(BadPonyTest, ParenthesisedReturn2)
+{
+  // From issue #1050
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo()\n"
+
+    "  fun foo(): U64 =>\n"
+    "    (return 0)\n"
+    "    2";
+
+  TEST_ERRORS_1(src, "Unreachable code");
+}


### PR DESCRIPTION
Previously, invalid uses of control flow statements were only checked on the AST node for the statement itself. We now check parent sequence nodes to catch errors if the statement is in parenthesis.

Closes #1050.