### PR TITLE
Use llvm.lifetime intrinsics

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -49,6 +49,7 @@ typedef struct compile_frame_t
   LLVMMetadataRef di_file;
   LLVMMetadataRef di_scope;
   bool is_function;
+  bool early_termination;
 
   struct compile_frame_t* prev;
 } compile_frame_t;
@@ -172,6 +173,12 @@ void codegen_finishfun(compile_t* c);
 void codegen_pushscope(compile_t* c, ast_t* ast);
 
 void codegen_popscope(compile_t* c);
+
+void codegen_local_lifetime_start(compile_t* c, const char* name);
+
+void codegen_local_lifetime_end(compile_t* c, const char* name);
+
+void codegen_scope_lifetime_end(compile_t* c);
 
 LLVMMetadataRef codegen_difile(compile_t* c);
 

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -765,3 +765,27 @@ void gencall_throw(compile_t* c)
 
   LLVMBuildUnreachable(c->builder);
 }
+
+void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr)
+{
+  LLVMValueRef func = LLVMGetNamedFunction(c->module, "llvm.lifetime.start");
+  LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
+  size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
+
+  LLVMValueRef args[2];
+  args[0] = LLVMConstInt(c->i64, size, false);
+  args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
+  LLVMBuildCall(c->builder, func, args, 2, "");
+}
+
+void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr)
+{
+  LLVMValueRef func = LLVMGetNamedFunction(c->module, "llvm.lifetime.end");
+  LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
+  size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
+
+  LLVMValueRef args[2];
+  args[0] = LLVMConstInt(c->i64, size, false);
+  args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
+  LLVMBuildCall(c->builder, func, args, 2, "");
+}

--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -26,6 +26,10 @@ LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t);
 
 void gencall_throw(compile_t* c);
 
+void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr);
+
+void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -413,6 +413,7 @@ LLVMValueRef gen_break(compile_t* c, ast_t* ast)
   }
 
   // Jump to the break target.
+  codegen_scope_lifetime_end(c);
   codegen_debugloc(c, ast);
   LLVMBuildBr(c->builder, target);
   codegen_debugloc(c, NULL);
@@ -425,6 +426,7 @@ LLVMValueRef gen_continue(compile_t* c, ast_t* ast)
   (void)ast;
 
   // Jump to the continue target.
+  codegen_scope_lifetime_end(c);
   codegen_debugloc(c, ast);
   LLVMBuildBr(c->builder, c->frame->continue_target);
   codegen_debugloc(c, NULL);
@@ -453,8 +455,10 @@ LLVMValueRef gen_return(compile_t* c, ast_t* ast)
   if(LLVMGetTypeKind(r_type) != LLVMVoidTypeKind)
   {
     LLVMValueRef ret = gen_assign_cast(c, r_type, value, ast_type(expr));
+    codegen_scope_lifetime_end(c);
     LLVMBuildRet(c->builder, ret);
   } else {
+    codegen_scope_lifetime_end(c);
     LLVMBuildRetVoid(c->builder);
   }
 
@@ -586,6 +590,7 @@ LLVMValueRef gen_error(compile_t* c, ast_t* ast)
   if((try_expr != NULL) && (clause == 1))
     gen_expr(c, ast_childidx(try_expr, 2));
 
+  codegen_scope_lifetime_end(c);
   codegen_debugloc(c, ast);
   gencall_throw(c);
   codegen_debugloc(c, NULL);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -75,8 +75,27 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_CONSUME:
-      ret = gen_expr(c, ast_childidx(ast, 1));
+    {
+      ast_t* ref = ast_childidx(ast, 1);
+      ret = gen_expr(c, ref);
+      switch(ast_id(ref))
+      {
+        case TK_LETREF:
+        case TK_VARREF:
+        {
+          const char* name = ast_name(ast_child(ref));
+          codegen_local_lifetime_end(c, name);
+          break;
+        }
+        case TK_THIS:
+        case TK_PARAMREF:
+          break;
+        default:
+          assert(0);
+          break;
+      }
       break;
+    }
 
     case TK_RECOVER:
       ret = gen_expr(c, ast_childidx(ast, 1));
@@ -173,7 +192,10 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
   }
 
   if(has_scope)
+  {
+    codegen_scope_lifetime_end(c);
     codegen_popscope(c);
+  }
 
   return ret;
 }

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -369,6 +369,7 @@ static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
     if(ret == NULL)
       return false;
 
+    codegen_scope_lifetime_end(c);
     codegen_debugloc(c, ast_childlast(body));
     LLVMBuildRet(c->builder, ret);
     codegen_debugloc(c, NULL);
@@ -395,6 +396,7 @@ static bool genfun_be(compile_t* c, reach_type_t* t, reach_method_t* m)
   if(value == NULL)
     return false;
 
+  codegen_scope_lifetime_end(c);
   if(value != GEN_NOVALUE)
     LLVMBuildRetVoid(c->builder);
 
@@ -438,6 +440,7 @@ static bool genfun_new(compile_t* c, reach_type_t* t, reach_method_t* m)
   if(t->primitive == NULL)
     value = LLVMGetParam(m->func, 0);
 
+  codegen_scope_lifetime_end(c);
   codegen_debugloc(c, ast_childlast(body));
   LLVMBuildRet(c->builder, value);
   codegen_debugloc(c, NULL);
@@ -463,6 +466,7 @@ static bool genfun_newbe(compile_t* c, reach_type_t* t, reach_method_t* m)
   if(value == NULL)
     return false;
 
+  codegen_scope_lifetime_end(c);
   LLVMBuildRetVoid(c->builder);
   codegen_finishfun(c);
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -656,6 +656,7 @@ static bool case_body(compile_t* c, ast_t* body,
     LLVMAddIncoming(phi, &body_value, &block, 1);
   }
 
+  codegen_scope_lifetime_end(c);
   LLVMBuildBr(c->builder, post_block);
   return true;
 }
@@ -752,6 +753,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
   LLVMPositionBuilderAtEnd(c->builder, else_block);
   codegen_pushscope(c, else_expr);
   bool ok = case_body(c, else_expr, post_block, phi, phi_type);
+  codegen_scope_lifetime_end(c);
   codegen_popscope(c);
 
   if(!ok)


### PR DESCRIPTION
Describing variables lifetime can help optimise the program (e.g. in register allocation).