### PR TITLE
Convert functions to constructors in numeric primitives

### DIFF
--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -7,22 +7,22 @@ primitive F32 is FloatingPoint[F32]
 
   new from_bits(i: U32) => compile_intrinsic
   fun bits(): U32 => compile_intrinsic
-  fun tag from[B: (Number & Real[B] val)](a: B): F32 => a.f32()
+  new from[B: (Number & Real[B] val)](a: B) => a.f32()
 
-  fun tag min_value(): F32 =>
+  new min_value() =>
     """
     Minimum positive value representable at full precision (ie a normalised
     number).
     """
     from_bits(0x00800000)
 
-  fun tag max_value(): F32 =>
+  new max_value() =>
     """
     Maximum positive value representable.
     """
     from_bits(0x7F7FFFFF)
 
-  fun tag epsilon(): F32 =>
+  new epsilon() =>
     """
     Minimum positive value such that (1 + epsilon) != 1.
     """
@@ -169,22 +169,22 @@ primitive F64 is FloatingPoint[F64]
 
   new from_bits(i: U64) => compile_intrinsic
   fun bits(): U64 => compile_intrinsic
-  fun tag from[B: (Number & Real[B] val)](a: B): F64 => a.f64()
+  new from[B: (Number & Real[B] val)](a: B) => a.f64()
 
-  fun tag min_value(): F64 =>
+  new min_value() =>
     """
     Minimum positive value representable at full precision (ie a normalised
     number).
     """
     from_bits(0x0010_0000_0000_0000)
 
-  fun tag max_value(): F64 =>
+  new max_value() =>
     """
     Maximum positive value representable.
     """
     from_bits(0x7FEF_FFFF_FFFF_FFFF)
 
-  fun tag epsilon(): F64 =>
+  new epsilon() =>
     """
     Minimum positive value such that (1 + epsilon) != 1.
     """

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -22,9 +22,9 @@ trait val Real[A: Real[A] val] is
   (Stringable & _ArithmeticConvertible & Comparable[A])
   new val create(value: A)
 
-  fun tag from[B: (Number & Real[B] val)](a: B): A
-  fun tag min_value(): A
-  fun tag max_value(): A
+  new val from[B: (Number & Real[B] val)](a: B)
+  new val min_value()
+  new val max_value()
 
   fun add(y: A): A => this + y
   fun sub(y: A): A => this - y
@@ -89,7 +89,7 @@ trait val _UnsignedInteger[A: _UnsignedInteger[A] val] is Integer[A]
     _ToString._u64(u64(), false, fmt)
 
 trait val FloatingPoint[A: FloatingPoint[A] val] is Real[A]
-  fun tag epsilon(): A
+  new val epsilon()
   fun tag radix(): U8
   fun tag precision2(): U8
   fun tag precision10(): U8

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -1,9 +1,9 @@
 primitive I8 is _SignedInteger[I8, U8]
   new create(value: I8 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): I8 => a.i8()
+  new from[A: (Number & Real[A] val)](a: A) => a.i8()
 
-  fun tag min_value(): I8 => -0x80
-  fun tag max_value(): I8 => 0x7F
+  new min_value() => -0x80
+  new max_value() => 0x7F
 
   fun abs(): U8 => if this < 0 then (-this).u8() else this.u8() end
   fun bswap(): I8 => this
@@ -24,10 +24,10 @@ primitive I8 is _SignedInteger[I8, U8]
 
 primitive I16 is _SignedInteger[I16, U16]
   new create(value: I16 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): I16 => a.i16()
+  new from[A: (Number & Real[A] val)](a: A) => a.i16()
 
-  fun tag min_value(): I16 => -0x8000
-  fun tag max_value(): I16 => 0x7FFF
+  new min_value() => -0x8000
+  new max_value() => 0x7FFF
 
   fun abs(): U16 => if this < 0 then (-this).u16() else this.u16() end
   fun bswap(): I16 => @"llvm.bswap.i16"[I16](this)
@@ -48,10 +48,10 @@ primitive I16 is _SignedInteger[I16, U16]
 
 primitive I32 is _SignedInteger[I32, U32]
   new create(value: I32 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): I32 => a.i32()
+  new from[A: (Number & Real[A] val)](a: A) => a.i32()
 
-  fun tag min_value(): I32 => -0x8000_0000
-  fun tag max_value(): I32 => 0x7FFF_FFFF
+  new min_value() => -0x8000_0000
+  new max_value() => 0x7FFF_FFFF
 
   fun abs(): U32 => if this < 0 then (-this).u32() else this.u32() end
   fun bswap(): I32 => @"llvm.bswap.i32"[I32](this)
@@ -72,10 +72,10 @@ primitive I32 is _SignedInteger[I32, U32]
 
 primitive I64 is _SignedInteger[I64, U64]
   new create(value: I64 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): I64 => a.i64()
+  new from[A: (Number & Real[A] val)](a: A) => a.i64()
 
-  fun tag min_value(): I64 => -0x8000_0000_0000_0000
-  fun tag max_value(): I64 => 0x7FFF_FFFF_FFFF_FFFF
+  new min_value() => -0x8000_0000_0000_0000
+  new max_value() => 0x7FFF_FFFF_FFFF_FFFF
 
   fun abs(): U64 => if this < 0 then (-this).u64() else this.u64() end
   fun bswap(): I64 => @"llvm.bswap.i64"[I64](this)
@@ -96,16 +96,16 @@ primitive I64 is _SignedInteger[I64, U64]
 
 primitive ILong is _SignedInteger[ILong, ULong]
   new create(value: ILong = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): ILong => a.ilong()
+  new from[A: (Number & Real[A] val)](a: A) => a.ilong()
 
-  fun tag min_value(): ILong =>
+  new min_value() =>
     ifdef ilp32 or llp64 then
       -0x8000_0000
     else
       -0x8000_0000_0000_0000
     end
 
-  fun tag max_value(): ILong =>
+  new max_value() =>
     ifdef ilp32 or llp64 then
       0x7FFF_FFFF
     else
@@ -169,16 +169,16 @@ primitive ILong is _SignedInteger[ILong, ULong]
 
 primitive ISize is _SignedInteger[ISize, USize]
   new create(value: ISize = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): ISize => a.isize()
+  new from[A: (Number & Real[A] val)](a: A) => a.isize()
 
-  fun tag min_value(): ISize =>
+  new min_value() =>
     ifdef ilp32 then
       -0x8000_0000
     else
       -0x8000_0000_0000_0000
     end
 
-  fun tag max_value(): ISize =>
+  new max_value() =>
     ifdef ilp32 then
       0x7FFF_FFFF
     else
@@ -242,10 +242,10 @@ primitive ISize is _SignedInteger[ISize, USize]
 
 primitive I128 is _SignedInteger[I128, U128]
   new create(value: I128 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): I128 => a.i128()
+  new from[A: (Number & Real[A] val)](a: A) => a.i128()
 
-  fun tag min_value(): I128 => -0x8000_0000_0000_0000_0000_0000_0000_0000
-  fun tag max_value(): I128 => 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+  new min_value() => -0x8000_0000_0000_0000_0000_0000_0000_0000
+  new max_value() => 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
   fun abs(): U128 => if this < 0 then (-this).u128() else this.u128() end
   fun bswap(): I128 => @"llvm.bswap.i128"[I128](this)

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -1,9 +1,9 @@
 primitive U8 is _UnsignedInteger[U8]
   new create(value: U8 = 0) => value
-  fun tag from[B: (Number & Real[B] val)](a: B): U8 => a.u8()
+  new from[B: (Number & Real[B] val)](a: B) => a.u8()
 
-  fun tag min_value(): U8 => 0
-  fun tag max_value(): U8 => 0xFF
+  new min_value() => 0
+  new max_value() => 0xFF
 
   fun next_pow2(): U8 =>
     var x = this - 1
@@ -30,10 +30,10 @@ primitive U8 is _UnsignedInteger[U8]
 
 primitive U16 is _UnsignedInteger[U16]
   new create(value: U16 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): U16 => a.u16()
+  new from[A: (Number & Real[A] val)](a: A) => a.u16()
 
-  fun tag min_value(): U16 => 0
-  fun tag max_value(): U16 => 0xFFFF
+  new min_value() => 0
+  new max_value() => 0xFFFF
 
   fun next_pow2(): U16 =>
     var x = this - 1
@@ -61,10 +61,10 @@ primitive U16 is _UnsignedInteger[U16]
 
 primitive U32 is _UnsignedInteger[U32]
   new create(value: U32 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): U32 => a.u32()
+  new from[A: (Number & Real[A] val)](a: A) => a.u32()
 
-  fun tag min_value(): U32 => 0
-  fun tag max_value(): U32 => 0xFFFF_FFFF
+  new min_value() => 0
+  new max_value() => 0xFFFF_FFFF
 
   fun next_pow2(): U32 =>
     var x = this - 1
@@ -93,10 +93,10 @@ primitive U32 is _UnsignedInteger[U32]
 
 primitive U64 is _UnsignedInteger[U64]
   new create(value: U64 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): U64 => a.u64()
+  new from[A: (Number & Real[A] val)](a: A) => a.u64()
 
-  fun tag min_value(): U64 => 0
-  fun tag max_value(): U64 => 0xFFFF_FFFF_FFFF_FFFF
+  new min_value() => 0
+  new max_value() => 0xFFFF_FFFF_FFFF_FFFF
 
   fun next_pow2(): U64 =>
     var x = this - 1
@@ -126,11 +126,11 @@ primitive U64 is _UnsignedInteger[U64]
 
 primitive ULong is _UnsignedInteger[ULong]
   new create(value: ULong = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): ULong => a.ulong()
+  new from[A: (Number & Real[A] val)](a: A) => a.ulong()
 
-  fun tag min_value(): ULong => 0
+  new min_value() => 0
 
-  fun tag max_value(): ULong =>
+  new max_value() =>
     ifdef ilp32 or llp64 then
       0xFFFF_FFFF
     else
@@ -208,11 +208,11 @@ primitive ULong is _UnsignedInteger[ULong]
 
 primitive USize is _UnsignedInteger[USize]
   new create(value: USize = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): USize => a.usize()
+  new from[A: (Number & Real[A] val)](a: A) => a.usize()
 
-  fun tag min_value(): USize => 0
+  new min_value() => 0
 
-  fun tag max_value(): USize =>
+  new max_value() =>
     ifdef ilp32 then
       0xFFFF_FFFF
     else
@@ -290,10 +290,10 @@ primitive USize is _UnsignedInteger[USize]
 
 primitive U128 is _UnsignedInteger[U128]
   new create(value: U128 = 0) => value
-  fun tag from[A: (Number & Real[A] val)](a: A): U128 => a.u128()
+  new from[A: (Number & Real[A] val)](a: A) => a.u128()
 
-  fun tag min_value(): U128 => 0
-  fun tag max_value(): U128 => 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+  new min_value() => 0
+  new max_value() => 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
   fun next_pow2(): U128 =>
     var x = this - 1


### PR DESCRIPTION
Also fixes a bug to allow said functions to be turned into constructors.

Closes #966.