### PR TITLE
Allow the use of a LLVM bitcode file for libponyrt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `DoNotOptimise` primitive
 - `compact` method for `Array` and `String`
 - `String.push_utf32()` method.
+- Allow the use of a LLVM bitcode file for the runtime instead of a static library.
 
 ### Changed
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -28,6 +28,7 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
 void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size);
 #endif
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
+LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
 
 #define GEN_NOVALUE ((LLVMValueRef)1)
 
@@ -155,6 +156,8 @@ typedef struct compile_t
 
   compile_frame_t* frame;
 } compile_t;
+
+bool codegen_merge_runtime_bitcode(compile_t* c);
 
 bool codegen_init(pass_opt_t* opt);
 

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -52,10 +52,11 @@ LLVMDIBuilderRef LLVMNewDIBuilder(LLVMModuleRef m)
 {
 #if PONY_LLVM >= 307
   Module* pm = unwrap(m);
-  unsigned version = DEBUG_METADATA_VERSION;
+  unsigned dwarf = dwarf::DWARF_VERSION;
+  unsigned debug_info = DEBUG_METADATA_VERSION;
 
-  pm->addModuleFlag(Module::Warning, "Dwarf Version", version);
-  pm->addModuleFlag(Module::Error, "Debug Info Version", version);
+  pm->addModuleFlag(Module::Warning, "Dwarf Version", dwarf);
+  pm->addModuleFlag(Module::Warning, "Debug Info Version", debug_info);
 
   return wrap(new DIBuilder(*pm));
 #else

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -189,6 +189,13 @@ static bool link_exe(compile_t* c, ast_t* program,
 {
   errors_t* errors = c->opt->check.errors;
 
+  const char* ponyrt = c->opt->runtimebc ? "" :
+#if defined(PLATFORM_IS_WINDOWS)
+    "ponyrt.lib";
+#else
+    "-lponyrt";
+#endif
+
 #if defined(PLATFORM_IS_MACOSX)
   char* arch = strchr(c->opt->triple, '-');
 
@@ -216,8 +223,8 @@ static bool link_exe(compile_t* c, ast_t* program,
   // Avoid incorrect ld, eg from macports.
   snprintf(ld_cmd, ld_len,
     "/usr/bin/ld -execute -no_pie -dead_strip -arch %.*s "
-    "-macosx_version_min 10.8 -o %s %s %s -lponyrt -lSystem",
-    (int)arch_len, c->opt->triple, file_exe, file_o, lib_args
+    "-macosx_version_min 10.8 -o %s %s %s %s -lSystem",
+    (int)arch_len, c->opt->triple, file_exe, file_o, lib_args, ponyrt
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
@@ -274,12 +281,12 @@ static bool link_exe(compile_t* c, ast_t* program,
 #ifdef PLATFORM_IS_LINUX
     "-fuse-ld=gold "
 #endif
-    "%s %s -lponyrt -lpthread "
+    "%s %s %s -lpthread "
 #ifdef PLATFORM_IS_LINUX
     "-ldl "
 #endif
     "-lm",
-    file_exe, file_o, lib_args
+    file_exe, file_o, lib_args, ponyrt
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)
@@ -323,8 +330,8 @@ static bool link_exe(compile_t* c, ast_t* program,
       "%s "
       "/LIBPATH:\"%s\" "
       "/LIBPATH:\"%s\" "
-      "%s kernel32.lib msvcrt.lib Ws2_32.lib vcruntime.lib legacy_stdio_definitions.lib ponyrt.lib \"",
-      vcvars.link, file_exe, file_o, vcvars.kernel32, vcvars.msvcrt, lib_args
+      "%s kernel32.lib msvcrt.lib Ws2_32.lib vcruntime.lib legacy_stdio_definitions.lib %s \"",
+      vcvars.link, file_exe, file_o, vcvars.kernel32, vcvars.msvcrt, lib_args, ponyrt
     );
 
     if (num_written < ld_len)
@@ -404,8 +411,20 @@ bool genexe(compile_t* c, ast_t* program)
 
   gen_main(c, t_main, t_env);
 
-  if(!genopt(c))
+  if(!genopt(c, true))
     return false;
+
+  if(c->opt->runtimebc)
+  {
+    if(!codegen_merge_runtime_bitcode(c))
+      return false;
+
+    // Rerun the optimiser without the Pony-specific optimisation passes.
+    // Inlining runtime functions can screw up these passes so we can't
+    // run the optimiser only once after merging.
+    if(!genopt(c, false))
+      return false;
+  }
 
   const char* file_o = genobj(c);
 

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -175,8 +175,20 @@ bool genlib(compile_t* c, ast_t* program)
     )
     return false;
 
-  if(!genopt(c))
+  if(!genopt(c, true))
     return false;
+
+  if(c->opt->runtimebc)
+  {
+    if(!codegen_merge_runtime_bitcode(c))
+      return false;
+
+    // Rerun the optimiser without the Pony-specific optimisation passes.
+    // Inlining runtime functions can screw up these passes so we can't
+    // run the optimiser only once after merging.
+    if(!genopt(c, false))
+      return false;
+  }
 
   const char* file_o = genobj(c);
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -842,7 +842,7 @@ static void addMergeReallocPass(const PassManagerBuilder& pmb,
     pm.add(new MergeRealloc());
 }
 
-static void optimise(compile_t* c)
+static void optimise(compile_t* c, bool pony_specific)
 {
   the_compiler = c;
 
@@ -898,12 +898,15 @@ static void optimise(compile_t* c)
   pmb.LoadCombine = true;
   pmb.MergeFunctions = true;
 
-  pmb.addExtension(PassManagerBuilder::EP_Peephole,
-    addMergeReallocPass);
-  pmb.addExtension(PassManagerBuilder::EP_Peephole,
-    addHeapToStackPass);
-  pmb.addExtension(PassManagerBuilder::EP_ScalarOptimizerLate,
-    addDispatchPonyCtxPass);
+  if(pony_specific)
+  {
+    pmb.addExtension(PassManagerBuilder::EP_Peephole,
+      addMergeReallocPass);
+    pmb.addExtension(PassManagerBuilder::EP_Peephole,
+      addHeapToStackPass);
+    pmb.addExtension(PassManagerBuilder::EP_ScalarOptimizerLate,
+      addDispatchPonyCtxPass);
+  }
 
   pmb.populateFunctionPassManager(fpm);
 
@@ -952,13 +955,13 @@ static void optimise(compile_t* c)
     lpm.run(*m);
 }
 
-bool genopt(compile_t* c)
+bool genopt(compile_t* c, bool pony_specific)
 {
   errors_t* errors = c->opt->check.errors;
 
   // Finalise the debug info.
   LLVMDIBuilderFinalize(c->di);
-  optimise(c);
+  optimise(c, pony_specific);
 
   if(c->opt->verify)
   {

--- a/src/libponyc/codegen/genopt.h
+++ b/src/libponyc/codegen/genopt.h
@@ -6,7 +6,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool genopt(compile_t* c);
+bool genopt(compile_t* c, bool pony_specific);
 bool target_is_linux(char* triple);
 bool target_is_freebsd(char* triple);
 bool target_is_macosx(char* triple);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -10,6 +10,10 @@
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Linker/Linker.h>
+#include <llvm/Support/SourceMgr.h>
 
 #if PONY_LLVM < 307
 #include <llvm/Support/Host.h>
@@ -93,4 +97,18 @@ LLVMValueRef LLVMConstNaN(LLVMTypeRef type)
 #endif
 
   return wrap(nan);
+}
+
+#if PONY_LLVM < 308
+static LLVMContext* unwrap(LLVMContextRef ctx)
+{
+  return reinterpret_cast<LLVMContext*>(ctx);
+}
+#endif
+
+LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file)
+{
+  SMDiagnostic diag;
+
+  return wrap(parseIRFile(file, diag, *unwrap(ctx)).release());
 }

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -184,6 +184,7 @@ typedef struct pass_opt_t
   pass_id program_pass;
   bool release;
   bool library;
+  bool runtimebc;
   bool pic;
   bool ieee_math;
   bool print_stats;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -138,10 +138,7 @@ static bool parse_source_code(ast_t* package, const char* src,
 }
 
 
-// Cat together the 2 given path fragments into the given buffer.
-// The first path fragment may be absolute, relative or NULL
-static void path_cat(const char* part1, const char* part2,
-  char result[FILENAME_MAX])
+void path_cat(const char* part1, const char* part2, char result[FILENAME_MAX])
 {
   size_t len1 = 0;
   size_t lensep = 0;

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -11,6 +11,12 @@ PONY_EXTERN_C_BEGIN
 typedef struct package_t package_t;
 
 /**
+ * Cat together the 2 given path fragments into the given buffer.
+ * The first path fragment may be absolute, relative or NULL
+ */
+void path_cat(const char* part1, const char* part2, char result[FILENAME_MAX]);
+
+/**
  * Initialises the search directories. This is composed of a "packages"
  * directory relative to the executable, plus a collection of directories
  * specified in the PONYPATH environment variable.

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -27,6 +27,8 @@ enum
   OPT_PATHS,
   OPT_OUTPUT,
   OPT_LIBRARY,
+  OPT_RUNTIMEBC,
+  OPT_PIC,
   OPT_DOCS,
 
   OPT_SAFE,
@@ -50,7 +52,6 @@ enum
   OPT_BNF,
   OPT_ANTLR,
   OPT_ANTLRRAW,
-  OPT_PIC,
   OPT_EXTFUN
 };
 
@@ -63,19 +64,21 @@ static opt_arg_t args[] =
   {"path", 'p', OPT_ARG_REQUIRED, OPT_PATHS},
   {"output", 'o', OPT_ARG_REQUIRED, OPT_OUTPUT},
   {"library", 'l', OPT_ARG_NONE, OPT_LIBRARY},
+  {"runtimebc", '\0', OPT_ARG_NONE, OPT_RUNTIMEBC},
+  {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   {"docs", 'g', OPT_ARG_NONE, OPT_DOCS},
 
-  {"safe", 0, OPT_ARG_OPTIONAL, OPT_SAFE},
-  {"ieee-math", 0, OPT_ARG_NONE, OPT_IEEEMATH},
-  {"cpu", 0, OPT_ARG_REQUIRED, OPT_CPU},
-  {"features", 0, OPT_ARG_REQUIRED, OPT_FEATURES},
-  {"triple", 0, OPT_ARG_REQUIRED, OPT_TRIPLE},
-  {"stats", 0, OPT_ARG_NONE, OPT_STATS},
+  {"safe", '\0', OPT_ARG_OPTIONAL, OPT_SAFE},
+  {"ieee-math", '\0', OPT_ARG_NONE, OPT_IEEEMATH},
+  {"cpu", '\0', OPT_ARG_REQUIRED, OPT_CPU},
+  {"features", '\0', OPT_ARG_REQUIRED, OPT_FEATURES},
+  {"triple", '\0', OPT_ARG_REQUIRED, OPT_TRIPLE},
+  {"stats", '\0', OPT_ARG_NONE, OPT_STATS},
 
   {"verbose", 'V', OPT_ARG_REQUIRED, OPT_VERBOSE},
   {"pass", 'r', OPT_ARG_REQUIRED, OPT_PASSES},
   {"ast", 'a', OPT_ARG_NONE, OPT_AST},
-  {"astpackage", 0, OPT_ARG_NONE, OPT_ASTPACKAGE},
+  {"astpackage", '\0', OPT_ARG_NONE, OPT_ASTPACKAGE},
   {"trace", 't', OPT_ARG_NONE, OPT_TRACE},
   {"width", 'w', OPT_ARG_REQUIRED, OPT_WIDTH},
   {"immerr", '\0', OPT_ARG_NONE, OPT_IMMERR},
@@ -86,7 +89,6 @@ static opt_arg_t args[] =
   {"bnf", '\0', OPT_ARG_NONE, OPT_BNF},
   {"antlr", '\0', OPT_ARG_NONE, OPT_ANTLR},
   {"antlrraw", '\0', OPT_ARG_NONE, OPT_ANTLRRAW},
-  {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
   OPT_ARGS_FINISH
 };
@@ -109,6 +111,7 @@ static void usage()
     "  --output, -o    Write output to this directory.\n"
     "    =path         Defaults to the current directory.\n"
     "  --library, -l   Generate a C-API compatible static library.\n"
+    "  --runtimebc     Compile with the LLVM bitcode file for the runtime.\n"
     "  --pic           Compile using position independent code.\n"
     "  --docs, -g      Generate code documentation.\n"
     "\n"
@@ -265,8 +268,9 @@ int main(int argc, char* argv[])
       case OPT_STRIP: opt.strip_debug = true; break;
       case OPT_PATHS: package_add_paths(s.arg_val, &opt); break;
       case OPT_OUTPUT: opt.output = s.arg_val; break;
-      case OPT_PIC: opt.pic = true; break;
       case OPT_LIBRARY: opt.library = true; break;
+      case OPT_RUNTIMEBC: opt.runtimebc = true; break;
+      case OPT_PIC: opt.pic = true; break;
       case OPT_DOCS: opt.docs = true; break;
 
       case OPT_SAFE:


### PR DESCRIPTION
As discussed (briefly) on the dev mailing list a while back.

This change adds a compiler flag (`--runtimebc`) to use a bitcode file instead of a static library for libponyrt. The bitcode file can be built alongside the compiler by passing `runtime-bitcode=yes` to the Makefile. Building the bitcode file requires Clang.

Using a bitcode file allows to run the optimiser on the user and runtime code at the same time, which enables very aggressive interprocedural optimisations. Because of restrictions caused by some optimisation passes, the optimiser is executed twice, one time before and one time after merging the runtime module. Compilation times can get really high so this option is mainly recommended for final release builds.

This change also fixes two bugs as a side effect:

- Set the correct Dwarf version for debugging.
- Keep an external linkage for Pony functions used as function pointers in FFI calls.