### PR TITLE
Create ZIP artifacts in Win64 AppVeyor builds and use versions from the repository

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: "{build}"
 
 image: Visual Studio 2015
 
@@ -57,11 +57,14 @@ install:
       $env:path += ";C:\ponyc-windows-libs\lib"
       cd C:\projects\ponyc
       C:\premake5.exe --with-tests --to=work/vs2015 vs2015
+  - ps: |
+      $file_version = (Get-Content "C:\projects\ponyc\VERSION")
+      Update-AppveyorBuild -Version "$file_version.${env:appveyor_build_number}"
 
 after_build:
   - ps: |
       cd C:\projects\ponyc
-      7z a -tzip "ponyc-win64-${env:appveyor_build_version}-${env:configuration}--llvm-${env:llvm}.zip" "packages\" "build\$env:configuration\ponyc.*" "build\$env:configuration\ponyrt.*"
+      7z a -tzip "ponyc-win64-${env:appveyor_build_version}-${env:configuration}-llvm-${env:llvm}.zip" "packages\" "build\$env:configuration\ponyc.*" "build\$env:configuration\ponyrt.*"
 
 artifacts:
   - path: 'ponyc-*.zip'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,6 +58,14 @@ install:
       cd C:\projects\ponyc
       C:\premake5.exe --with-tests --to=work/vs2015 vs2015
 
+after_build:
+  - ps: |
+      cd C:\projects\ponyc
+      7z a -tzip "ponyc-win64-${env:appveyor_build_version}-${env:configuration}--llvm-${env:llvm}.zip" "packages\" "build\$env:configuration\ponyc.*" "build\$env:configuration\ponyrt.*"
+
+artifacts:
+  - path: 'ponyc-*.zip'
+
 cache:
   - 'C:\LLVM-%llvm%\ -> .appveyor.yml'
   - C:\premake5.exe -> .appveyor.yml


### PR DESCRIPTION
One step forward...  (You can see it in action [here](https://ci.appveyor.com/project/killerswan/ponyc/build/1.0.23): the job for each configuration will build a uniquely named artifact which contains a minimum [I think] viable ponyc.)

~~Next on my list: to fix the numbering!~~ 😅 

@SeanTAllen @jemc 