### PR TITLE
Set the right dereferenceable value for pony_create

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -247,7 +247,8 @@ static void init_runtime(compile_t* c)
   value = LLVMAddFunction(c->module, "pony_create", type);
   LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
   LLVMSetReturnNoAlias(value);
-  LLVMSetDereferenceable(value, 0, PONY_ACTOR_PAD_SIZE);
+  LLVMSetDereferenceable(value, 0, PONY_ACTOR_PAD_SIZE +
+    (target_is_ilp32(c->opt->triple) ? 4 : 8));
 
   // void ponyint_destroy(__object*)
   params[0] = c->object_ptr;


### PR DESCRIPTION
The size of the descriptor pointer wasn't included in the previous value.