### PR TITLE
Do not silently ignore paths containing parens on Windows (#1059)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Compiler bug where `as` operator with a lambda literal caused seg fault.
 - String.read_int failure on lowest number in the range of signed integers.
 - Regex incorrect of len variable when PCRE2_ERROR_NOMEMORY is encountered.
+- No longer silently ignores lib paths containing parens on Windows.
 
 ### Added
 

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -75,12 +75,18 @@ uint32_t program_assign_pkg_id(ast_t* ast)
   return data->next_package_id++;
 }
 
+#if defined(PLATFORM_IS_WINDOWS)
+#define INVALID_LOCATOR_CHARS "\t\r\n\"'`;$|&<>%*?[]{}"
+#else
+#define INVALID_LOCATOR_CHARS "\t\r\n\"'`;$|&<>%*?[]{}()"
+#endif
+
 static const char* quoted_locator(pass_opt_t* opt, ast_t* use,
   const char* locator)
 {
   assert(locator != NULL);
 
-  if(strpbrk(locator, "\t\r\n\"'`;$|&<>%*?[]{}()") != NULL)
+  if(strpbrk(locator, INVALID_LOCATOR_CHARS) != NULL)
   {
     if(use != NULL)
       ast_error(opt->check.errors, use, "use URI contains invalid characters");


### PR DESCRIPTION
This PR fixes a bug on Windows (#1059) where library paths (among others) are silently ignored if they contain parentheses, which are legal in Windows filenames.