### PR TITLE
Fix windows sdk lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Regex incorrect of len variable when PCRE2_ERROR_NOMEMORY is encountered.
 - No longer silently ignores lib paths containing parens on Windows.
 - Fix issue with creating hex and octal strings if precision was specified.
+- Correctly parses Windows 10 SDK versions, and includes new UCRT library when linking with Windows 10 SDK.
 
 ### Added
 

--- a/src/common/vcvars.h
+++ b/src/common/vcvars.h
@@ -8,7 +8,9 @@ typedef struct vcvars_t
   char link[MAX_PATH];
   char ar[MAX_PATH];
   char kernel32[MAX_PATH];
+  char ucrt[MAX_PATH];
   char msvcrt[MAX_PATH];
+  char default_libs[MAX_PATH];
 } vcvars_t;
 
 bool vcvars_get(vcvars_t* vcvars, errors_t* errors);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -318,6 +318,12 @@ static bool link_exe(compile_t* c, ast_t* program,
     "/LIBPATH:", NULL, "", "", "", ".lib");
   const char* lib_args = program_lib_args(program);
 
+  char ucrt_lib[MAX_PATH + 12];
+  if (strlen(vcvars.ucrt) > 0)
+    snprintf(ucrt_lib, MAX_PATH + 12, "/LIBPATH:\"%s\"", vcvars.ucrt);
+  else
+    ucrt_lib[0] = '\0';
+
   size_t ld_len = 256 + strlen(file_exe) + strlen(file_o) +
     strlen(vcvars.kernel32) + strlen(vcvars.msvcrt) + strlen(lib_args);
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
@@ -327,11 +333,12 @@ static bool link_exe(compile_t* c, ast_t* program,
     int num_written = snprintf(ld_cmd, ld_len,
       "cmd /C \"\"%s\" /DEBUG /NOLOGO /MACHINE:X64 "
       "/OUT:%s "
-      "%s "
+      "%s %s "
       "/LIBPATH:\"%s\" "
       "/LIBPATH:\"%s\" "
-      "%s kernel32.lib msvcrt.lib Ws2_32.lib vcruntime.lib legacy_stdio_definitions.lib %s \"",
-      vcvars.link, file_exe, file_o, vcvars.kernel32, vcvars.msvcrt, lib_args, ponyrt
+      "%s %s %s \"",
+      vcvars.link, file_exe, file_o, ucrt_lib, vcvars.kernel32, 
+      vcvars.msvcrt, lib_args, vcvars.default_libs, ponyrt
     );
 
     if (num_written < ld_len)


### PR DESCRIPTION
There was a bug in `vcvars.c` when parsing existing Windows 10 SDK version numbers.  This PR fixes that bug.

In addition, Windows 10 SDKs require linking with a new library called UCRT (https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/).  This PR adds this library to the default libs when linking with a Windows 10 SDK.