### PR TITLE
Add invariant informations in generated LLVM IR

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -431,33 +431,6 @@ static void init_runtime(compile_t* c)
   // i32 pony_personality_v0(...)
   type = LLVMFunctionType(c->i32, NULL, 0, true);
   c->personality = LLVMAddFunction(c->module, "pony_personality_v0", type);
-
-  // void llvm.memcpy.*(i8*, i8*, i32/64, i32, i1)
-  // void llvm.memmove.*(i8*, i8*, i32/64, i32, i1)
-  params[0] = c->void_ptr;
-  params[1] = c->void_ptr;
-  params[3] = c->i32;
-  params[4] = c->i1;
-  if(target_is_ilp32(c->opt->triple))
-  {
-    params[2] = c->i32;
-    type = LLVMFunctionType(c->void_type, params, 5, false);
-    LLVMAddFunction(c->module, "llvm.memcpy.p0i8.p0i8.i32", type);
-    LLVMAddFunction(c->module, "llvm.memmove.p0i8.p0i8.i32", type);
-  } else {
-    params[2] = c->i64;
-    type = LLVMFunctionType(c->void_type, params, 5, false);
-    LLVMAddFunction(c->module, "llvm.memcpy.p0i8.p0i8.i64", type);
-    LLVMAddFunction(c->module, "llvm.memmove.p0i8.p0i8.i64", type);
-  }
-
-  // void llvm.lifetime.start(i64, i8*)
-  // void llvm.lifetime.end(i64, i8*)
-  params[0] = c->i64;
-  params[1] = c->void_ptr;
-  type = LLVMFunctionType(c->void_type, params, 2, false);
-  LLVMAddFunction(c->module, "llvm.lifetime.start", type);
-  LLVMAddFunction(c->module, "llvm.lifetime.end", type);
 }
 
 static void init_module(compile_t* c, ast_t* program, pass_opt_t* opt)

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -30,6 +30,13 @@ void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size);
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
 
+// Intrinsics.
+LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);
+LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32);
+LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module);
+LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module);
+LLVMValueRef LLVMInvariantStart(LLVMModuleRef module);
+
 #define GEN_NOVALUE ((LLVMValueRef)1)
 
 #define GEN_NOTNEEDED (LLVMConstInt(c->ibool, 0, false))

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -832,9 +832,37 @@ void gencall_throw(compile_t* c)
   LLVMBuildUnreachable(c->builder);
 }
 
+void gencall_memcpy(compile_t* c, LLVMValueRef dst, LLVMValueRef src,
+  LLVMValueRef n)
+{
+  LLVMValueRef func = LLVMMemcpy(c->module, target_is_ilp32(c->opt->triple));
+
+  LLVMValueRef args[5];
+  args[0] = dst;
+  args[1] = src;
+  args[2] = n;
+  args[3] = LLVMConstInt(c->i32, 1, false);
+  args[4] = LLVMConstInt(c->i1, 0, false);
+  LLVMBuildCall(c->builder, func, args, 5, "");
+}
+
+void gencall_memmove(compile_t* c, LLVMValueRef dst, LLVMValueRef src,
+  LLVMValueRef n)
+{
+  LLVMValueRef func = LLVMMemmove(c->module, target_is_ilp32(c->opt->triple));
+
+  LLVMValueRef args[5];
+  args[0] = dst;
+  args[1] = src;
+  args[2] = n;
+  args[3] = LLVMConstInt(c->i32, 1, false);
+  args[4] = LLVMConstInt(c->i1, 0, false);
+  LLVMBuildCall(c->builder, func, args, 5, "");
+}
+
 void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr)
 {
-  LLVMValueRef func = LLVMGetNamedFunction(c->module, "llvm.lifetime.start");
+  LLVMValueRef func = LLVMLifetimeStart(c->module);
   LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
   size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
 
@@ -846,12 +874,32 @@ void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr)
 
 void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr)
 {
-  LLVMValueRef func = LLVMGetNamedFunction(c->module, "llvm.lifetime.end");
+  LLVMValueRef func = LLVMLifetimeEnd(c->module);
   LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
   size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
 
   LLVMValueRef args[2];
   args[0] = LLVMConstInt(c->i64, size, false);
   args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
+  LLVMBuildCall(c->builder, func, args, 2, "");
+}
+
+void gencall_invariant_start(compile_t* c, LLVMValueRef ptr)
+{
+  LLVMValueRef func = LLVMInvariantStart(c->module);
+  LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
+  size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
+
+  LLVMValueRef args[2];
+  // Check if we were passed a Pony Pointer. If so, the object is variable
+  // sized.
+  if(LLVMTypeOf(ptr) == c->void_ptr)
+  {
+    args[0] = LLVMConstInt(c->i64, -1, true);
+    args[1] = ptr;
+  } else {
+    args[0] = LLVMConstInt(c->i64, size, false);
+    args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
+  }
   LLVMBuildCall(c->builder, func, args, 2, "");
 }

--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -26,9 +26,17 @@ LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t);
 
 void gencall_throw(compile_t* c);
 
+void gencall_memcpy(compile_t* c, LLVMValueRef dst, LLVMValueRef src,
+  LLVMValueRef n);
+
+void gencall_memmove(compile_t* c, LLVMValueRef dst, LLVMValueRef src,
+  LLVMValueRef n);
+
 void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr);
 
 void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr);
+
+void gencall_invariant_start(compile_t* c, LLVMValueRef ptr);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -31,7 +31,7 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_EMBEDREF:
-      ret = gen_fieldptr(c, ast);
+      ret = gen_fieldembed(c, ast);
       break;
 
     case TK_PARAMREF:

--- a/src/libponyc/codegen/genreference.h
+++ b/src/libponyc/codegen/genreference.h
@@ -14,6 +14,8 @@ LLVMValueRef gen_fieldptr(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast);
 
+LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast);
+
 LLVMValueRef gen_tuple(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_localdecl(compile_t* c, ast_t* ast);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -10,6 +10,7 @@
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Linker/Linker.h>
@@ -111,4 +112,49 @@ LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file)
   SMDiagnostic diag;
 
   return wrap(parseIRFile(file, diag, *unwrap(ctx)).release());
+}
+
+LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32)
+{
+  Module* m = unwrap(module);
+
+  Type* params[3];
+  params[0] = Type::getInt8PtrTy(m->getContext());
+  params[1] = params[0];
+  params[2] = Type::getIntNTy(m->getContext(), ilp32 ? 32 : 64);
+
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::memcpy, {params, 3}));
+}
+
+LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32)
+{
+  Module* m = unwrap(module);
+
+  Type* params[3];
+  params[0] = Type::getInt8PtrTy(m->getContext());
+  params[1] = params[0];
+  params[2] = Type::getIntNTy(m->getContext(), ilp32 ? 32 : 64);
+
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::memmove, {params, 3}));
+}
+
+LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module)
+{
+  Module* m = unwrap(module);
+
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_start, {}));
+}
+
+LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module)
+{
+  Module* m = unwrap(module);
+
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_end, {}));
+}
+
+LLVMValueRef LLVMInvariantStart(LLVMModuleRef module)
+{
+  Module* m = unwrap(module);
+
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::invariant_start, {}));
 }


### PR DESCRIPTION
Having these informations allows the optimiser to reason about object immutability and eliminate redundant reads from memory.

We now

- add the `invariant.load` metadata on loads from non-rebindable fields/locals (`let` binding or `val` parent object).
- use the `llvm.invariant.start` intrinsic when referencing immutable objects. `llvm.invariant.end` isn't used since an immutable Pony object can't become mutable.

As a part of this change, LLVM intrinsic declarations are now retreived through the `Intrinsic::getDeclaration` API instead of being declared by hand.