### PR TITLE
Add terminal resize notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `String.push_utf32()` method.
 - Allow the use of a LLVM bitcode file for the runtime instead of a static library.
 - add iterators to persistent/Map (`keys()`, `values()`, and `pairs()`)
+- add notification of terminal resize
 
 ### Changed
 

--- a/packages/term/ansi_notify.pony
+++ b/packages/term/ansi_notify.pony
@@ -41,5 +41,8 @@ interface ANSINotify
   fun ref prompt(term: ANSITerm ref, value: String) =>
     None
 
+  fun ref size(rows: U16, cols: U16) =>
+    None
+
   fun ref closed() =>
     None

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -193,7 +193,6 @@ actor ANSITerm
     """
     Pass the window size to the notifier.
     """
-
     let ws: _TermSize = _TermSize
     ifdef posix then
       @ioctl[I32](0, _TIOCGWINSZ(), ws) // do error handling

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -24,8 +24,10 @@ type _EscapeState is
 
 class _TermResizeNotify is SignalNotify
   let _term: ANSITerm tag
+
   new create(term: ANSITerm tag) =>
     _term = term
+
   fun apply(times: U32): Bool =>
     _term.size()
     true

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -1,4 +1,12 @@
 use "time"
+use "signals"
+use @ioctl[I32](fx: I32, cmd: ULong, ...) if posix
+
+struct _TermSize
+  var row: U16 = 0
+  var col: U16 = 0
+  var xpixel: U16 = 0
+  var ypixel: U16 = 0
 
 primitive _EscapeNone
 primitive _EscapeStart
@@ -13,6 +21,24 @@ type _EscapeState is
   | _EscapeCSI
   | _EscapeMod
   )
+
+class _TermResizeNotify is SignalNotify
+  let _term: ANSITerm tag
+  new create(term: ANSITerm tag) =>
+    _term = term
+  fun apply(times: U32): Bool =>
+    _term.size()
+    true
+
+primitive _TIOCGWINSZ
+  fun apply(): ULong =>
+    ifdef linux then
+      21523
+    elseif osx or freebsd then
+      1074295912
+    else
+      0
+    end
 
 actor ANSITerm
   """
@@ -37,6 +63,10 @@ actor ANSITerm
     _timers = timers
     _notify = consume notify
     _source = source
+
+    SignalHandler(recover _TermResizeNotify(this) end, Sig.winch())
+
+    _size()
 
   be apply(data: Array[U8] iso) =>
     """
@@ -153,6 +183,20 @@ actor ANSITerm
     Pass a prompt along to the notifier.
     """
     _notify.prompt(this, value)
+
+  be size() =>
+    _size()
+
+  fun ref _size() =>
+    """
+    Pass the window size to the notifier.
+    """
+
+    let ws: _TermSize = _TermSize
+    ifdef posix then
+      @ioctl[I32](0, _TIOCGWINSZ(), ws) // do error handling
+      _notify.size(ws.row, ws.col)
+    end
 
   be dispose() =>
     """


### PR DESCRIPTION
This change:
* creates a signal handler for the window size change signal
* sends a notification to the terminal notification object when the terminal is
  first created and when the signal is received
A call to `ioctl` is used to retrieve the window size.