### PR TITLE
issue 870 - improving compile error message for class fields missing type declarations

### DIFF
--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -979,7 +979,7 @@ DEF(field);
   MAP_ID(TK_VAR, TK_FVAR);
   MAP_ID(TK_LET, TK_FLET);
   TOKEN("field name", TK_ID);
-  SKIP(NULL, TK_COLON);
+  SKIP("mandatory type declaration on field", TK_COLON);
   RULE("field type", type);
   IF(TK_DELEGATE, RULE("delegated type", provides));
   IF(TK_ASSIGN, RULE("field value", infix));


### PR DESCRIPTION
resolves #870 

Example:

```
[chris@heimdall ponyc]$ cat main.pony 
class Wombat
  let fur

[chris@heimdall ponyc]$ make && ./build/debug/ponyc
Building builtin -> /home/chris/devel/ponyc/packages/builtin
Building . -> /home/chris/devel/ponyc
Error:
/home/chris/devel/ponyc/main.pony:2:7: syntax error: expected mandatory type declaration on field after fur
  let fur
      ^
```