### PR TITLE
Call lookup correctly when searching for Main.create

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -379,7 +379,7 @@ bool genexe(compile_t* c, ast_t* program)
   ast_t* main_ast = type_builtin(c->opt, main_def, main_actor);
   ast_t* env_ast = type_builtin(c->opt, main_def, env_class);
 
-  if(lookup(NULL, main_ast, main_ast, c->str_create) == NULL)
+  if(lookup(c->opt, main_ast, main_ast, c->str_create) == NULL)
     return false;
 
   if(c->opt->verbosity >= VERBOSITY_INFO)


### PR DESCRIPTION
Previously the `opt` parameter of the `lookup` function could be `NULL` because errors were carried in global state. Since the error state is now part of `pass_opt_t`, the `opt` parameter can be dereferenced when reporting errors and we must pass a valid `pass_opt_t*` to `lookup`.

Closes #1089.