### PR TITLE
Correctly add prefixes for hex and octal strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - String.read_int failure on lowest number in the range of signed integers.
 - Regex incorrect of len variable when PCRE2_ERROR_NOMEMORY is encountered.
 - No longer silently ignores lib paths containing parens on Windows.
+- Fix issue with creating hex and octal strings if precision was specified.
 
 ### Added
 

--- a/packages/builtin/format_settings.pony
+++ b/packages/builtin/format_settings.pony
@@ -306,8 +306,8 @@ primitive _ToString
         end
       end
 
-      s.append(typestring)
       _extend_digits(s, prec')
+      s.append(typestring)
       s.append(prestring)
       _pad(s, width', align', fill')
       s
@@ -344,8 +344,8 @@ primitive _ToString
         end
       end
 
-      s.append(typestring)
       _extend_digits(s, prec')
+      s.append(typestring)
       s.append(prestring)
       _pad(s, width', align', fill')
       s

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -48,6 +48,7 @@ actor Main is TestList
     test(_TestMaybePointer)
     test(_TestValtrace)
     test(_TestCCallback)
+    test(_TestFormatSettingsInt)
 
 
 class iso _TestAbs is UnitTest
@@ -1051,3 +1052,96 @@ class iso _TestCCallback is UnitTest
     let cb: Callback = Callback
     let r = @pony_test_callback[I32](cb, addressof cb.apply, I32(3))
     h.assert_eq[I32](6, r)
+
+class iso _TestFormatSettingsInt is UnitTest
+  """
+  Test format settings
+  """
+  fun name(): String => "builtin/FormatSettingsInt"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("00010", U64(10)
+      .string(FormatSettingsInt.set_precision(5)))
+    h.assert_eq[String]("0x0000A", U64(10)
+      .string(FormatSettingsInt.set_precision(5).set_format(FormatHex)))
+    h.assert_eq[String]("0000A", U64(10)
+      .string(FormatSettingsInt.set_precision(5).set_format(FormatHexBare)))
+    h.assert_eq[String]("0x0000a", U64(10)
+      .string(FormatSettingsInt.set_precision(5).set_format(FormatHexSmall)))
+    h.assert_eq[String]("0000a", U64(10)
+      .string(FormatSettingsInt.set_precision(5)
+      .set_format(FormatHexSmallBare)))
+    h.assert_eq[String](" 0x0000A", U64(10)
+      .string(FormatSettingsInt.set_precision(5).set_format(FormatHex)
+      .set_width(8)))
+    h.assert_eq[String]("0x0000A ", U64(10)
+      .string(FormatSettingsInt.set_precision(5).set_format(FormatHex)
+      .set_width(8).set_align(AlignLeft)))
+    h.assert_eq[String]("   0000a", U64(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)))
+    h.assert_eq[String]("0000a   ", U64(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)
+      .set_align(AlignLeft)))
+
+    h.assert_eq[String]("-00010", I64(-10).string(FormatSettingsInt
+      .set_precision(5)))
+    h.assert_eq[String]("-0x0000A", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex)))
+    h.assert_eq[String]("-0000A", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexBare)))
+    h.assert_eq[String]("-0x0000a", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmall)))
+    h.assert_eq[String]("-0000a", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare)))
+    h.assert_eq[String]("-0x0000A", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)))
+    h.assert_eq[String]("-0x0000A", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)
+      .set_align(AlignLeft)))
+    h.assert_eq[String]("  -0000a", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)))
+    h.assert_eq[String]("-0000a  ", I64(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)
+      .set_align(AlignLeft)))
+
+    h.assert_eq[String]("00010", U128(10).string(FormatSettingsInt
+      .set_precision(5)))
+    h.assert_eq[String]("0x0000A", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex)))
+    h.assert_eq[String]("0000A", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexBare)))
+    h.assert_eq[String]("0x0000a", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmall)))
+    h.assert_eq[String]("0000a", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare)))
+    h.assert_eq[String](" 0x0000A", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)))
+    h.assert_eq[String]("0x0000A ", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)
+      .set_align(AlignLeft)))
+    h.assert_eq[String]("   0000a", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)))
+    h.assert_eq[String]("0000a   ", U128(10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)
+      .set_align(AlignLeft)))
+
+    h.assert_eq[String]("-00010", I128(-10).string(FormatSettingsInt
+      .set_precision(5)))
+    h.assert_eq[String]("-0x0000A", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex)))
+    h.assert_eq[String]("-0000A", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexBare)))
+    h.assert_eq[String]("-0x0000a", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmall)))
+    h.assert_eq[String]("-0000a", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare)))
+    h.assert_eq[String]("-0x0000A", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)))
+    h.assert_eq[String]("-0x0000A", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHex).set_width(8)
+      .set_align(AlignLeft)))
+    h.assert_eq[String]("  -0000a", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)))
+    h.assert_eq[String]("-0000a  ", I128(-10).string(FormatSettingsInt
+      .set_precision(5).set_format(FormatHexSmallBare).set_width(8)
+      .set_align(AlignLeft)))


### PR DESCRIPTION
If a number was converted to a string with either a hex or octal
representation, and a precision was specified, then the resulting
string had `0`s before the hex or octal prefix. For example, `10`,
when converted to hex with a precision of 5, resulted in "00000xA";
the expected result is "0x0000A".

This is now fixed. The fix involved rearranging the way the string was
generated so that the prefix is added after extending the digits (the
string is constructed backwards and then reversed). A test has also
been added that uses different formatting options to format a string
and then checks the results.

Closes #1093