### PR TITLE
Handle various possible names for LLVM tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,20 +142,36 @@ endif
 ifndef LLVM_CONFIG
   ifneq (,$(shell which llvm-config-3.8 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.8
+    LLVM_LINK = llvm-link-3.8
+    LLVM_OPT = opt-3.8
   else ifneq (,$(shell which llvm-config-3.7 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.7
+    LLVM_LINK = llvm-link-3.7
+    LLVM_OPT = opt-3.7
   else ifneq (,$(shell which llvm-config-3.6 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.6
+    LLVM_LINK = llvm-link-3.6
+    LLVM_OPT = opt-3.6
   else ifneq (,$(shell which llvm-config38 2> /dev/null))
     LLVM_CONFIG = llvm-config38
+    LLVM_LINK = llvm-link38
+    LLVM_OPT = opt38
   else ifneq (,$(shell which llvm-config37 2> /dev/null))
     LLVM_CONFIG = llvm-config37
+    LLVM_LINK = llvm-link37
+    LLVM_OPT = opt37
   else ifneq (,$(shell which llvm-config36 2> /dev/null))
     LLVM_CONFIG = llvm-config36
+    LLVM_LINK = llvm-link36
+    LLVM_OPT = opt36
   else ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
     LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm/bin/opt
   else ifneq (,$(shell which llvm-config 2> /dev/null))
     LLVM_CONFIG = llvm-config
+    LLVM_LINK = llvm-link
+    LLVM_OPT = opt
   endif
 endif
 
@@ -480,9 +496,9 @@ $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
   ifeq ($(runtime-bitcode),yes)
 $($(1))/libponyrt.bc: $(depends) $(bcfiles)
 	@echo 'Generating bitcode for libponyrt'
-	$(SILENT)llvm-link -o $$@ $(bcfiles)
+	$(SILENT)$(LLVM_LINK) -o $$@ $(bcfiles)
     ifeq ($(config),release)
-	$(SILENT)opt -O3 -o $$@ $$@
+	$(SILENT)$(LLVM_OPT) -O3 -o $$@ $$@
     endif
 libponyrt: $($(1))/libponyrt.bc $($(1))/libponyrt.$(LIB_EXT)
   else


### PR DESCRIPTION
I used the naming convention detected for `llvm-config` but I don't know if it is consistent for every tool and LLVM installation. Please add a comment if your LLVM isn't handled here.