### PR TITLE
Add String and Array trim and trim_in_place.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Allow the use of a LLVM bitcode file for the runtime instead of a static library.
 - add iterators to persistent/Map (`keys()`, `values()`, and `pairs()`)
 - add notification of terminal resize
+- `trim` and `trim_in_place` methods for `Array` and `String`.
+- `is_null_terminated` and `null_terminated` methods for `String`.
 
 ### Changed
 

--- a/packages/assert/assert.pony
+++ b/packages/assert/assert.pony
@@ -25,7 +25,7 @@ primitive Fact
     if not test then
       if msg.size() > 0 then
         @fprintf[I32](@pony_os_stderr[Pointer[U8]](), "%s\n".cstring(),
-          msg.cstring())
+          msg.null_terminated().cstring())
       end
       error
     end

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -28,6 +28,9 @@ actor Main is TestList
     test(_TestStringRemove)
     test(_TestStringSubstring)
     test(_TestStringCut)
+    test(_TestStringTrim)
+    test(_TestStringTrimInPlace)
+    test(_TestStringIsNullTerminated)
     test(_TestStringReplace)
     test(_TestStringSplit)
     test(_TestStringJoin)
@@ -39,6 +42,8 @@ actor Main is TestList
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArraySlice)
+    test(_TestArrayTrim)
+    test(_TestArrayTrimInPlace)
     test(_TestArrayInsert)
     test(_TestArrayValuesRewind)
     test(_TestArrayFind)
@@ -381,6 +386,56 @@ class iso _TestStringCut is UnitTest
     h.assert_eq[String]("01236", "0123456".cut(4, 6))
     h.assert_eq[String]("0123", "0123456".cut(4, 7))
     h.assert_eq[String]("0123", "0123456".cut(4))
+
+
+class iso _TestStringTrim is UnitTest
+  """
+  Test trimming part of a string.
+  """
+  fun name(): String => "builtin/String.trim"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("45", "0123456".trim(4, 6))
+    h.assert_eq[String]("456", "0123456".trim(4, 7))
+    h.assert_eq[String]("456", "0123456".trim(4))
+    h.assert_eq[String]("", "0123456".trim(4, 4))
+    h.assert_eq[String]("", "0123456".trim(4, 1))
+
+
+class iso _TestStringTrimInPlace is UnitTest
+  """
+  Test trimming part of a string in place.
+  """
+  fun name(): String => "builtin/String.trim_in_place"
+
+  fun apply(h: TestHelper) =>
+    case(h, "45", "0123456", 4, 6)
+    case(h, "456", "0123456", 4, 7)
+    case(h, "456", "0123456", 4)
+    case(h, "", "0123456", 4, 4)
+    case(h, "", "0123456", 4, 1)
+
+  fun case(h: TestHelper, expected: String, orig: String, from: USize,
+    to: USize = -1)
+  =>
+    let copy: String ref = orig.clone()
+    copy.trim_in_place(from, to)
+    h.assert_eq[String box](expected, copy)
+
+
+class iso _TestStringIsNullTerminated is UnitTest
+  """
+  Test checking if a string is null terminated.
+  """
+  fun name(): String => "builtin/String.is_null_terminated"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true("".is_null_terminated())
+    h.assert_true("0123456".is_null_terminated())
+    h.assert_true("0123456".trim(4, 7).is_null_terminated())
+    h.assert_false("0123456".trim(2, 4).is_null_terminated())
+    h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
+    h.assert_true("0123456".trim(2, 4).null_terminated().is_null_terminated())
 
 
 class iso _TestSpecialValuesF32 is UnitTest
@@ -745,6 +800,41 @@ class iso _TestArraySlice is UnitTest
     h.assert_eq[String]("three", e(1))
     h.assert_eq[String]("one", e(2))
 
+
+class iso _TestArrayTrim is UnitTest
+  """
+  Test trimming part of a string.
+  """
+  fun name(): String => "builtin/Array.trim"
+
+  fun apply(h: TestHelper) =>
+    let orig: Array[U8] val = recover [0, 1, 2, 3, 4, 5, 6] end
+    h.assert_array_eq[U8]([as U8: 4, 5], orig.trim(4, 6))
+    h.assert_array_eq[U8]([as U8: 4, 5, 6], orig.trim(4, 7))
+    h.assert_array_eq[U8]([as U8: 4, 5, 6], orig.trim(4))
+    h.assert_array_eq[U8](Array[U8], orig.trim(4, 4))
+    h.assert_array_eq[U8](Array[U8], orig.trim(4, 1))
+
+
+class iso _TestArrayTrimInPlace is UnitTest
+  """
+  Test trimming part of a string in place.
+  """
+  fun name(): String => "builtin/Array.trim_in_place"
+
+  fun apply(h: TestHelper) =>
+    case(h, [4, 5], [0, 1, 2, 3, 4, 5, 6], 4, 6)
+    case(h, [4, 5, 6], [0, 1, 2, 3, 4, 5, 6], 4, 7)
+    case(h, [4, 5, 6], [0, 1, 2, 3, 4, 5, 6], 4)
+    case(h, Array[U8], [0, 1, 2, 3, 4, 5, 6], 4, 4)
+    case(h, Array[U8], [0, 1, 2, 3, 4, 5, 6], 4, 1)
+
+  fun case(h: TestHelper, expected: Array[U8], orig: Array[U8], from: USize,
+    to: USize = -1)
+  =>
+    let copy: Array[U8] ref = orig.clone()
+    copy.trim_in_place(from, to)
+    h.assert_array_eq[U8](expected, copy)
 
 class iso _TestArrayInsert is UnitTest
   """

--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -60,7 +60,8 @@ primitive Debug
   fun _print(msg: String, stream: DebugStream) =>
     ifdef debug then
       try
-        @fprintf[I32](_stream(stream), "%s\n".cstring(), msg.cstring())
+        @fprintf[I32](_stream(stream), "%s\n".cstring(),
+          msg.null_terminated().cstring())
       end
     end
 

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -45,7 +45,7 @@ class Directory
     path = from
 
     ifdef posix then
-      _fd = @open[I32](from.path.cstring(),
+      _fd = @open[I32](from.path.null_terminated().cstring(),
         @ponyint_o_rdonly() or @ponyint_o_directory() or @ponyint_o_cloexec())
 
       if _fd == -1 then
@@ -94,7 +94,7 @@ class Directory
             @ponyint_o_cloexec())
           @fdopendir[Pointer[_DirectoryHandle]](fd)
         else
-          @opendir[Pointer[_DirectoryHandle]](path'.cstring())
+          @opendir[Pointer[_DirectoryHandle]](path'.null_terminated().cstring())
         end
 
         if h.is_null() then
@@ -147,7 +147,7 @@ class Directory
     let path' = FilePath(path, target, path.caps)
 
     ifdef linux or freebsd then
-      let fd' = @openat[I32](_fd, target.cstring(),
+      let fd' = @openat[I32](_fd, target.null_terminated().cstring(),
         @ponyint_o_rdonly() or @ponyint_o_directory() or @ponyint_o_cloexec())
       _relative(path', fd')
     else
@@ -210,7 +210,7 @@ class Directory
     let path' = FilePath(path, target, path.caps)
 
     ifdef linux or freebsd then
-      let fd' = @openat[I32](_fd, target.cstring(),
+      let fd' = @openat[I32](_fd, target.null_terminated().cstring(),
         @ponyint_o_rdwr() or @ponyint_o_creat() or @ponyint_o_cloexec(),
         I32(0x1B6))
       recover File._descriptor(fd', path') end
@@ -232,7 +232,7 @@ class Directory
     let path' = FilePath(path, target, path.caps - FileWrite)
 
     ifdef linux or freebsd then
-      let fd' = @openat[I32](_fd, target.cstring(),
+      let fd' = @openat[I32](_fd, target.null_terminated().cstring(),
         @ponyint_o_rdonly() or @ponyint_o_cloexec(), I32(0x1B6))
       recover File._descriptor(fd', path') end
     else
@@ -307,7 +307,8 @@ class Directory
       let path' = FilePath(path, target, path.caps)
 
       ifdef linux or freebsd then
-        @fchmodat[I32](_fd, target.cstring(), mode._os(), I32(0)) == 0
+        0 == @fchmodat[I32](_fd, target.null_terminated().cstring(), mode._os(),
+          I32(0))
       else
         path'.chmod(mode)
       end
@@ -331,7 +332,8 @@ class Directory
       let path' = FilePath(path, target, path.caps)
 
       ifdef linux or freebsd then
-        @fchownat[I32](_fd, target.cstring(), uid, gid, I32(0)) == 0
+        0 == @fchownat[I32](_fd, target.null_terminated().cstring(), uid, gid,
+          I32(0))
       else
         path'.chown(uid, gid)
       end
@@ -366,7 +368,8 @@ class Directory
         var tv: (ILong, ILong, ILong, ILong) =
           (atime._1.ilong(), atime._2.ilong() / 1000,
             mtime._1.ilong(), mtime._2.ilong() / 1000)
-        @futimesat[I32](_fd, target.cstring(), addressof tv) == 0
+        0 == @futimesat[I32](_fd, target.null_terminated().cstring(),
+          addressof tv)
       else
         path'.set_time(atime, mtime)
       end
@@ -393,7 +396,8 @@ class Directory
       let path' = FilePath(path, link_name, path.caps)
 
       ifdef linux or freebsd then
-        @symlinkat[I32](source.path.cstring(), _fd, link_name.cstring()) == 0
+        0 == @symlinkat[I32](source.path.null_terminated().cstring(), _fd,
+          link_name.null_terminated().cstring())
       else
         source.symlink(path')
       end
@@ -429,9 +433,10 @@ class Directory
             end
           end
 
-          @unlinkat(_fd, target.cstring(), @ponyint_at_removedir()) == 0
+          0 == @unlinkat(_fd, target.null_terminated().cstring(),
+            @ponyint_at_removedir())
         else
-          @unlinkat(_fd, target.cstring(), 0) == 0
+          0 == @unlinkat(_fd, target.null_terminated().cstring(), 0)
         end
       else
         path'.remove()
@@ -460,7 +465,8 @@ class Directory
       let path'' = FilePath(to.path, target, to.path.caps)
 
       ifdef linux or freebsd then
-        @renameat[I32](_fd, source.cstring(), to._fd, target.cstring()) == 0
+        0 == @renameat[I32](_fd, source.null_terminated().cstring(), to._fd,
+          target.null_terminated().cstring())
       else
         path'.rename(path'')
       end

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -75,8 +75,8 @@ class File
       end
 
       if mode != "x" then
-        _handle = @fopen[Pointer[_FileHandle]](from.path.cstring(),
-          mode.cstring())
+        _handle = @fopen[Pointer[_FileHandle]](
+          path.path.null_terminated().cstring(), mode.cstring())
 
         if _handle.is_null() then
           _errno = FileError
@@ -113,8 +113,8 @@ class File
     then
       _errno = FileError
     else
-      _handle = @fopen[Pointer[_FileHandle]](from.path.cstring(),
-        "rb".cstring())
+      _handle = @fopen[Pointer[_FileHandle]](
+        from.path.null_terminated().cstring(), "rb".cstring())
 
       if _handle.is_null() then
         _errno = FileError

--- a/packages/files/file_info.pony
+++ b/packages/files/file_info.pony
@@ -38,7 +38,7 @@ class val FileInfo
 
     filepath = from
 
-    if not @pony_os_stat[Bool](filepath.path.cstring(), this) then
+    if not @pony_os_stat[Bool](from.path.null_terminated().cstring(), this) then
       error
     end
 
@@ -53,9 +53,9 @@ class val FileInfo
 
     filepath = path
 
-    if not @pony_os_fstat[Bool](fd, path.path.cstring(), this) then
-      error
-    end
+    let fstat =
+      @pony_os_fstat[Bool](fd, path.path.null_terminated().cstring(), this)
+    if not fstat then error end
 
   new val _relative(fd: I32, path: FilePath, from: String) ? =>
     if not path.caps(FileStat) or (fd == -1) then
@@ -64,6 +64,6 @@ class val FileInfo
 
     filepath = path
 
-    if not @pony_os_fstatat[Bool](fd, from.cstring(), this) then
-      error
-    end
+    let fstatat =
+      @pony_os_fstatat[Bool](fd, from.null_terminated().cstring(), this)
+    if not fstatat then error end

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -37,14 +37,14 @@ class val FilePath
         error
       end
 
-      path = Path.join(b.path, path')
+      path = Path.join(b.path, path').null_terminated()
       caps.intersect(b.caps)
 
       if not path.at(b.path, 0) then
         error
       end
     | let b: AmbientAuth =>
-      path = Path.abs(path')
+      path = Path.abs(path').null_terminated()
     else
       error
     end
@@ -79,13 +79,13 @@ class val FilePath
 
     caps.union(caps')
     caps.intersect(temp.caps)
-    path = temp.path
+    path = temp.path.null_terminated()
 
   new val _create(path': String, caps': FileCaps val) =>
     """
     Internal constructor.
     """
-    path = path'
+    path = path'.null_terminated()
     caps.union(caps')
 
   fun val join(path': String,
@@ -158,9 +158,9 @@ class val FilePath
 
       if element.size() > 0 then
         let r = ifdef windows then
-          @_mkdir[I32](element.cstring())
+          @_mkdir[I32](element.null_terminated().cstring())
         else
-          @mkdir[I32](element.cstring(), U32(0x1FF))
+          @mkdir[I32](element.null_terminated().cstring(), U32(0x1FF))
         end
 
         if r != 0 then
@@ -205,15 +205,15 @@ class val FilePath
 
       ifdef windows then
         if info.directory and not info.symlink then
-          @_rmdir[I32](path.cstring()) == 0
+          0 == @_rmdir[I32](path.null_terminated().cstring())
         else
-          @_unlink[I32](path.cstring()) == 0
+          0 == @_unlink[I32](path.null_terminated().cstring())
         end
       else
         if info.directory and not info.symlink then
-          @rmdir[I32](path.cstring()) == 0
+          0 == @rmdir[I32](path.null_terminated().cstring())
         else
-          @unlink[I32](path.cstring()) == 0
+          0 == @unlink[I32](path.null_terminated().cstring())
         end
       end
     else
@@ -228,7 +228,8 @@ class val FilePath
       return false
     end
 
-    @rename[I32](path.cstring(), new_path.path.cstring()) == 0
+    0 == @rename[I32](path.null_terminated().cstring(),
+      new_path.path.null_terminated().cstring())
 
   fun symlink(link_name: FilePath): Bool =>
     """
@@ -239,9 +240,11 @@ class val FilePath
     end
 
     ifdef windows then
-      @CreateSymbolicLink[U8](link_name.path.cstring(), path.cstring()) != 0
+      0 != @CreateSymbolicLink[U8](link_name.path.null_terminated().cstring(),
+        path.null_terminated().cstring())
     else
-      @symlink[I32](path.cstring(), link_name.path.cstring()) == 0
+      0 == @symlink[I32](path.null_terminated().cstring(),
+        link_name.path.null_terminated().cstring())
     end
 
   fun chmod(mode: FileMode box): Bool =>
@@ -255,9 +258,9 @@ class val FilePath
     let m = mode._os()
 
     ifdef windows then
-      @_chmod[I32](path.cstring(), m) == 0
+      0 == @_chmod[I32](path.null_terminated().cstring(), m)
     else
-      @chmod[I32](path.cstring(), m) == 0
+      0 == @chmod[I32](path.null_terminated().cstring(), m)
     end
 
   fun chown(uid: U32, gid: U32): Bool =>
@@ -268,7 +271,7 @@ class val FilePath
       false
     else
       if caps(FileChown) then
-        @chown[I32](path.cstring(), uid, gid) == 0
+        0 == @chown[I32](path.null_terminated().cstring(), uid, gid)
       else
         false
       end
@@ -290,10 +293,10 @@ class val FilePath
 
     ifdef windows then
       var tv: (I64, I64) = (atime._1, mtime._1)
-      @_utime64[I32](path.cstring(), addressof tv) == 0
+      0 == @_utime64[I32](path.null_terminated().cstring(), addressof tv)
     else
       var tv: (ILong, ILong, ILong, ILong) =
         (atime._1.ilong(), atime._2.ilong() / 1000,
           mtime._1.ilong(), mtime._2.ilong() / 1000)
-      @utimes[I32](path.cstring(), addressof tv) == 0
+      0 == @utimes[I32](path.null_terminated().cstring(), addressof tv)
     end

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -480,7 +480,8 @@ primitive Path
     Return the equivalent canonical absolute path. Raise an error if there
     isn't one.
     """
-    var cstring = @pony_os_realpath[Pointer[U8] iso^](path.cstring())
+    var cstring = @pony_os_realpath[Pointer[U8] iso^](
+      path.null_terminated().cstring())
 
     if cstring.is_null() then
       error

--- a/packages/net/dns.pony
+++ b/packages/net/dns.pony
@@ -48,13 +48,13 @@ primitive DNS
     """
     Returns true if the host is a literal IPv4 address.
     """
-    @pony_os_host_ip4[Bool](host.cstring())
+    @pony_os_host_ip4[Bool](host.null_terminated().cstring())
 
   fun is_ip6(host: String): Bool =>
     """
     Returns true if the host is a literal IPv6 address.
     """
-    @pony_os_host_ip6[Bool](host.cstring())
+    @pony_os_host_ip6[Bool](host.null_terminated().cstring())
 
   fun _resolve(auth: DNSLookupAuth, family: U32, host: String,
     service: String): Array[IPAddress] iso^
@@ -63,8 +63,8 @@ primitive DNS
     Turns an addrinfo pointer into an array of addresses.
     """
     var list = recover Array[IPAddress] end
-    var result = @pony_os_addrinfo[Pointer[U8]](
-      family, host.cstring(), service.cstring())
+    var result = @pony_os_addrinfo[Pointer[U8]](family,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
 
     if not result.is_null() then
       var addr = result

--- a/packages/net/ssl/ssl.pony
+++ b/packages/net/ssl/ssl.pony
@@ -53,7 +53,7 @@ class SSL
       not DNS.is_ip6(_hostname)
     then
       // SSL_set_tlsext_host_name
-      @SSL_ctrl(_ssl, 55, 0, _hostname.cstring())
+      @SSL_ctrl(_ssl, 55, 0, _hostname.null_terminated().cstring())
     end
 
     if server then

--- a/packages/net/ssl/ssl_context.pony
+++ b/packages/net/ssl/ssl_context.pony
@@ -62,11 +62,11 @@ class val SSLContext
       _ctx.is_null() or
       (cert.path.size() == 0) or
       (key.path.size() == 0) or
-      (@SSL_CTX_use_certificate_chain_file[I32](
-        _ctx, cert.path.cstring()) == 0) or
-      (@SSL_CTX_use_PrivateKey_file[I32](
-        _ctx, key.path.cstring(), I32(1)) == 0) or
-      (@SSL_CTX_check_private_key[I32](_ctx) == 0)
+      (0 == @SSL_CTX_use_certificate_chain_file[I32](
+        _ctx, cert.path.null_terminated().cstring())) or
+      (0 == @SSL_CTX_use_PrivateKey_file[I32](
+        _ctx, key.path.null_terminated().cstring(), I32(1))) or
+      (0 == @SSL_CTX_check_private_key[I32](_ctx))
     then
       error
     end
@@ -90,7 +90,7 @@ class val SSLContext
     if
       _ctx.is_null() or
       (f.is_null() and p.is_null()) or
-      (@SSL_CTX_load_verify_locations[I32](_ctx, f, p) == 0)
+      (0 == @SSL_CTX_load_verify_locations[I32](_ctx, f, p))
     then
       error
     end
@@ -103,7 +103,8 @@ class val SSLContext
     """
     if
       _ctx.is_null() or
-      (@SSL_CTX_set_cipher_list[I32](_ctx, ciphers.cstring()) == 0)
+      (0 == @SSL_CTX_set_cipher_list[I32](_ctx,
+        ciphers.null_terminated().cstring()))
     then
       error
     end

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -70,8 +70,9 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
-    _connect_count = @pony_os_connect_tcp[U32](this, host.cstring(),
-      service.cstring(), from.cstring())
+    _connect_count = @pony_os_connect_tcp[U32](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring(),
+      from.null_terminated().cstring())
     _notify_connecting()
 
   new ip4(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
@@ -85,8 +86,9 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
-    _connect_count = @pony_os_connect_tcp4[U32](this, host.cstring(),
-      service.cstring(), from.cstring())
+    _connect_count = @pony_os_connect_tcp4[U32](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring(),
+      from.null_terminated().cstring())
     _notify_connecting()
 
   new ip6(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
@@ -100,8 +102,9 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
-    _connect_count = @pony_os_connect_tcp6[U32](this, host.cstring(),
-      service.cstring(), from.cstring())
+    _connect_count = @pony_os_connect_tcp6[U32](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring(),
+      from.null_terminated().cstring())
     _notify_connecting()
 
   new _accept(listen: TCPListener, notify: TCPConnectionNotify iso, fd: U32,

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -45,8 +45,8 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @pony_os_listen_tcp[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_tcp[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _init_size = init_size
     _max_size = max_size
     _fd = @pony_asio_event_fd(_event)
@@ -61,8 +61,8 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @pony_os_listen_tcp4[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_tcp4[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _init_size = init_size
     _max_size = max_size
     _fd = @pony_asio_event_fd(_event)
@@ -77,8 +77,8 @@ actor TCPListener
     """
     _limit = limit
     _notify = consume notify
-    _event = @pony_os_listen_tcp6[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_tcp6[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _init_size = init_size
     _max_size = max_size
     _fd = @pony_asio_event_fd(_event)

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -74,8 +74,8 @@ actor UDPSocket
     Listens for both IPv4 and IPv6 datagrams.
     """
     _notify = consume notify
-    _event = @pony_os_listen_udp[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_udp[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
@@ -90,8 +90,8 @@ actor UDPSocket
     Listens for IPv4 datagrams.
     """
     _notify = consume notify
-    _event = @pony_os_listen_udp4[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_udp4[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
@@ -106,8 +106,8 @@ actor UDPSocket
     Listens for IPv6 datagrams.
     """
     _notify = consume notify
-    _event = @pony_os_listen_udp6[AsioEventID](this, host.cstring(),
-      service.cstring())
+    _event = @pony_os_listen_udp6[AsioEventID](this,
+      host.null_terminated().cstring(), service.null_terminated().cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
@@ -154,7 +154,7 @@ actor UDPSocket
     revert to allowing the OS to choose, call with an empty string.
     """
     if not _closed then
-      @pony_os_multicast_interface[None](_fd, from.cstring())
+      @pony_os_multicast_interface[None](_fd, from.null_terminated().cstring())
     end
 
   be set_multicast_loopback(loopback: Bool) =>
@@ -181,7 +181,8 @@ actor UDPSocket
     specific interface.
     """
     if not _closed then
-      @pony_os_multicast_join[None](_fd, group.cstring(), to.cstring())
+      @pony_os_multicast_join[None](_fd, group.null_terminated().cstring(),
+        to.null_terminated().cstring())
     end
 
   be multicast_leave(group: String, to: String = "") =>
@@ -191,7 +192,8 @@ actor UDPSocket
     previously added this group.
     """
     if not _closed then
-      @pony_os_multicast_leave[None](_fd, group.cstring(), to.cstring())
+      @pony_os_multicast_leave[None](_fd, group.null_terminated().cstring(),
+        to.null_terminated().cstring())
     end
 
   be dispose() =>

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -261,7 +261,9 @@ actor ProcessMonitor
       _dup2(_stdin_read, _STDINFILENO())    // redirect stdin
       _dup2(_stdout_write, _STDOUTFILENO()) // redirect stdout
       _dup2(_stderr_write, _STDERRFILENO()) // redirect stderr
-      if @execve[I32](path.cstring(), argp.cstring(), envp.cstring()) < 0 then
+      if 0 > @execve[I32](path.null_terminated().cstring(), argp.cstring(),
+        envp.cstring())
+      then
         @_exit[None](I32(-1))
       end
     end
@@ -286,7 +288,7 @@ actor ProcessMonitor
     """
     let argv = Array[Pointer[U8] tag](args.size() + 1)
     for s in args.values() do
-      argv.push(s.cstring())
+      argv.push(s.null_terminated().cstring())
     end
     argv.push(Pointer[U8]) // nullpointer to terminate list of args
     argv

--- a/packages/regex/regex.pony
+++ b/packages/regex/regex.pony
@@ -173,7 +173,8 @@ class Regex
     Returns the index of a named capture. Raises an error if the named capture
     does not exist.
     """
-    let rc = @pcre2_substring_number_from_name[I32](_pattern, name.cstring())
+    let rc = @pcre2_substring_number_from_name[I32](_pattern,
+      name.null_terminated().cstring())
 
     if rc < 0 then
       error

--- a/packages/time/date.pony
+++ b/packages/time/date.pony
@@ -41,5 +41,6 @@ class Date
     Format the time as for strftime.
     """
     recover
-      String.from_cstring(@ponyint_formattime[Pointer[U8]](this, fmt.cstring()))
+      String.from_cstring(@ponyint_formattime[Pointer[U8]](this,
+        fmt.null_terminated().cstring()))
     end


### PR DESCRIPTION
This PR implements part of https://github.com/ponylang/rfcs/pull/2 / https://github.com/ponylang/ponyc/issues/1023.

It implements `trim` and `trim_in_place`, but does not yet remove `truncate`, since `truncate` is part of the `Seq` interface and is thus a wider-reaching change than the RFC originally intended.

It adds `String.is_null_terminated` as per the RFC, but also adds `String.null_terminated`, which does the work of checking `is_null_terminated`, and calling `clone` if that check returns false.  This turned out to be much less cumbersome in practice for all of the FFI calls that need to ensure a null-terminated string.