### PR TITLE
Make composite types print to mutable string

### DIFF
--- a/packages/json/_json_print.pony
+++ b/packages/json/_json_print.pony
@@ -1,33 +1,95 @@
 primitive _JsonPrint
-  fun _string(d: box->JsonType, indent: String,
-    pretty_print: Bool = false): String
+  fun _indent(
+    text: String iso, indent: String, level': USize): String iso^
+  =>
+    """
+    Add indentation to the text to the appropriate indent_level
+    """
+    var level = level'
+
+    text.push('\n')
+
+    while level != 0 do
+      text.append(indent)
+      level = level - 1
+    end
+
+    consume text
+
+  fun _string(d: box->JsonType, text': String iso, indent: String, level: USize,
+    pretty: Bool): String iso^
   =>
     """
     Generate string representation of the given data.
     """
+    var text = consume text'
+
     match d
-    | let x: I64 => x.string()
-    | let x: Bool => x.string()
-    | let x: None => "null"
-    | let x: String => _escaped_string(x)
-    | let x: JsonArray box => x.string(indent, pretty_print)
-    | let x: JsonObject box => x.string(indent, pretty_print)
+    | let x: Bool => text.append(x.string())
+    | let x: None => text.append("null")
+    | let x: String =>
+      text = _escaped_string(consume text, x)
+
+    | let x: JsonArray box =>
+      text = x._show(consume text, indent, level, pretty)
+
+    | let x: JsonObject box =>
+      text = x._show(consume text, indent, level, pretty)
+
+    | let x': I64 =>
+      var x = if x' < 0 then
+        text.push('-')
+        -x'
+      else
+        x'
+      end
+
+      if x == 0 then
+        text.push('0')
+      else
+        // Append the numbers in reverse order
+        var i = text.size()
+
+        while x != 0 do
+          text.push((x % 10).u8() or 48)
+          x = x / 10
+        end
+
+        var j = text.size() - 1
+
+        // Place the numbers back in the proper order
+        try
+          while i < j do
+            text(i) = text(j = j - 1) = text(i = i + 1)
+          end
+        end
+      end
+
     | let x: F64 =>
       // Make sure our printed floats can be distinguished from integers
       let basic = x.string()
-      if basic.count(".") == 0 then basic + ".0" else basic end
+
+      if basic.count(".") == 0 then
+        text.append(consume basic)
+        text.append(".0")
+      else
+        text.append(consume basic)
+      end
     else
       // Can never happen
       ""
     end
 
-  fun _escaped_string(s: String): String =>
+    text
+
+  fun _escaped_string(text: String iso, s: String): String iso^ =>
     """
     Generate a version of the given string with escapes for all non-printable
     and non-ASCII characters.
     """
-    var out = recover ref String end
     var i: USize = 0
+
+    text.push('"')
 
     try
       while i < s.size() do
@@ -35,36 +97,37 @@ primitive _JsonPrint
         i = i + count.usize()
 
         if c == '"' then
-          out.append("\\\"")
+          text.append("\\\"")
         elseif c == '\\' then
-          out.append("\\\\")
+          text.append("\\\\")
         elseif c == '\b' then
-          out.append("\\b")
+          text.append("\\b")
         elseif c == '\f' then
-          out.append("\\f")
+          text.append("\\f")
         elseif c == '\t' then
-          out.append("\\t")
+          text.append("\\t")
         elseif c == '\r' then
-          out.append("\\r")
+          text.append("\\r")
         elseif c == '\n' then
-          out.append("\\n")
+          text.append("\\n")
         elseif (c >= 0x20) and (c < 0x80) then
-          out.push(c.u8())
+          text.push(c.u8())
         elseif c < 0x10000 then
-          out.append("\\u")
+          text.append("\\u")
           let fmt = FormatSettingsInt.set_format(FormatHexBare).set_width(4)
             .set_fill('0')
-          out.append(c.string(fmt))
+          text.append(c.string(fmt))
         else
           let high = (((c - 0x10000) >> 10) and 0x3FF) + 0xD800
           let low = ((c - 0x10000) and 0x3FF) + 0xDC00
           let fmt = FormatSettingsInt.set_format(FormatHexBare).set_width(4)
-          out.append("\\u")
-          out.append(high.string(fmt))
-          out.append("\\u")
-          out.append(low.string(fmt))
+          text.append("\\u")
+          text.append(high.string(fmt))
+          text.append("\\u")
+          text.append(low.string(fmt))
         end
       end
     end
 
-    "\"" + out + "\""
+    text.push('"')
+    text

--- a/packages/json/_json_print.pony
+++ b/packages/json/_json_print.pony
@@ -1,7 +1,5 @@
 primitive _JsonPrint
-  fun _indent(
-    buf: String iso, indent: String, level': USize): String iso^
-  =>
+  fun _indent(buf: String iso, indent: String, level': USize): String iso^ =>
     """
     Add indentation to the buf to the appropriate indent_level
     """

--- a/packages/json/_json_print.pony
+++ b/packages/json/_json_print.pony
@@ -14,7 +14,7 @@ primitive _JsonPrint
       level = level - 1
     end
 
-    consume buf
+    buf
 
   fun _string(d: box->JsonType, buf': String iso, indent: String, level: USize,
     pretty: Bool): String iso^

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -468,22 +468,22 @@ class iso _TestPrintArray is UnitTest
     let array: JsonArray = JsonArray
 
     doc.data = array
-    h.assert_eq[String]("[]", doc.string(true))
+    h.assert_eq[String]("[]", doc.string("  ", true))
 
     array.data.clear()
     array.data.push(true)
-    h.assert_eq[String]("[\n  true\n]", doc.string(true))
+    h.assert_eq[String]("[\n  true\n]", doc.string("  ", true))
 
     array.data.clear()
     array.data.push(true)
     array.data.push(false)
-    h.assert_eq[String]("[\n  true,\n  false\n]", doc.string(true))
+    h.assert_eq[String]("[\n  true,\n  false\n]", doc.string("  ", true))
 
     array.data.clear()
     array.data.push(true)
     array.data.push(I64(13))
     array.data.push(None)
-    h.assert_eq[String]("[\n  true,\n  13,\n  null\n]", doc.string(true))
+    h.assert_eq[String]("[\n  true,\n  13,\n  null\n]", doc.string("  ", true))
 
     array.data.clear()
     array.data.push(true)
@@ -492,7 +492,7 @@ class iso _TestPrintArray is UnitTest
     nested.data.push(None)
     array.data.push(nested)
     h.assert_eq[String]("[\n  true,\n  [\n    52,\n    null\n  ]\n]",
-      doc.string(true))
+      doc.string("  ", true))
 
 class iso _TestNoPrettyPrintArray is UnitTest
   """
@@ -505,22 +505,22 @@ class iso _TestNoPrettyPrintArray is UnitTest
     let array: JsonArray = JsonArray
 
     doc.data = array
-    h.assert_eq[String]("[]", doc.string(false))
+    h.assert_eq[String]("[]", doc.string())
 
     array.data.clear()
     array.data.push(true)
-    h.assert_eq[String]("[true]", doc.string(false))
+    h.assert_eq[String]("[true]", doc.string())
 
     array.data.clear()
     array.data.push(true)
     array.data.push(false)
-    h.assert_eq[String]("[true,false]", doc.string(false))
+    h.assert_eq[String]("[true,false]", doc.string())
 
     array.data.clear()
     array.data.push(true)
     array.data.push(I64(13))
     array.data.push(None)
-    h.assert_eq[String]("[true,13,null]", doc.string(false))
+    h.assert_eq[String]("[true,13,null]", doc.string())
 
     array.data.clear()
     array.data.push(true)
@@ -529,7 +529,7 @@ class iso _TestNoPrettyPrintArray is UnitTest
     nested.data.push(None)
     array.data.push(nested)
     h.assert_eq[String]("[true,[52,null]]",
-      doc.string(false))
+      doc.string())
 
 class iso _TestPrintObject is UnitTest
   """
@@ -542,16 +542,16 @@ class iso _TestPrintObject is UnitTest
     let obj: JsonObject = JsonObject
 
     doc.data = obj
-    h.assert_eq[String]("{}", doc.string(true))
+    h.assert_eq[String]("{}", doc.string("  ", true))
 
     obj.data.clear()
     obj.data("foo") = true
-    h.assert_eq[String]("{\n  \"foo\": true\n}", doc.string(true))
+    h.assert_eq[String]("{\n  \"foo\": true\n}", doc.string("  ", true))
 
     obj.data.clear()
     obj.data("a") = true
     obj.data("b") = I64(3)
-    let s = doc.string(true)
+    let s = doc.string("  ", true)
     h.assert_true((s == "{\n  \"a\": true,\n  \"b\": 3\n}") or
       (s == "{\n  \"b\": false,\n  \"a\": true\n}"))
 
@@ -569,16 +569,16 @@ class iso _TestNoPrettyPrintObject is UnitTest
     let obj: JsonObject = JsonObject
 
     doc.data = obj
-    h.assert_eq[String]("{}", doc.string(false))
+    h.assert_eq[String]("{}", doc.string())
 
     obj.data.clear()
     obj.data("foo") = true
-    h.assert_eq[String]("{\"foo\":true}", doc.string(false))
+    h.assert_eq[String]("{\"foo\":true}", doc.string())
 
     obj.data.clear()
     obj.data("a") = true
     obj.data("b") = I64(3)
-    let s = doc.string(false)
+    let s = doc.string()
     h.assert_true((s == "{\"a\":true,\"b\":3}") or
       (s == "{\"b\":3,\"a\":true}"))
 
@@ -625,7 +625,7 @@ class iso _TestParsePrint is UnitTest
 
     let doc: JsonDoc = JsonDoc
     doc.parse(src)
-    let printed = doc.string(true)
+    let printed = doc.string("  ", true)
 
     // TODO: Sort out line endings on different platforms. For now normalise
     // before comparing

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -21,11 +21,15 @@ class JsonDoc
     """
     data = None
 
-  fun string(pretty_print: Bool = false): String =>
+  fun string(pretty_print: Bool = false, indent: String = "  "): String =>
     """
     Generate string representation of this document.
     """
-    _JsonPrint._string(data, "", pretty_print)
+    let text = _JsonPrint._string(
+      data, recover String(256) end, indent, 0, pretty_print
+    )
+    text.compact()
+    text
 
   fun ref parse(source: String) ? =>
     """

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -25,11 +25,11 @@ class JsonDoc
     """
     Generate string representation of this document.
     """
-    let text = _JsonPrint._string(
+    let buf = _JsonPrint._string(
       data, recover String(256) end, indent, 0, pretty_print
     )
-    text.compact()
-    text
+    buf.compact()
+    buf
 
   fun ref parse(source: String) ? =>
     """

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -25,9 +25,8 @@ class JsonDoc
     """
     Generate string representation of this document.
     """
-    let buf = _JsonPrint._string(
-      data, recover String(256) end, indent, 0, pretty_print
-    )
+    let buf = _JsonPrint._string(data, recover String(256) end, indent, 0,
+      pretty_print)
     buf.compact()
     buf
 

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -21,7 +21,7 @@ class JsonDoc
     """
     data = None
 
-  fun string(pretty_print: Bool = false, indent: String = "  "): String =>
+  fun string(indent: String = "", pretty_print: Bool = false): String =>
     """
     Generate string representation of this document.
     """

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -24,47 +24,47 @@ class JsonArray
     """
     Generate string representation of this array.
     """
-    let text = _show(recover String(256) end, indent, 0, pretty_print)
-    text.compact()
-    text
+    let buf = _show(recover String(256) end, indent, 0, pretty_print)
+    buf.compact()
+    buf
 
-  fun _show(text': String iso, indent: String = "", level: USize = 0,
+  fun _show(buf': String iso, indent: String = "", level: USize = 0,
     pretty: Bool = false): String iso^
   =>
     """
     Append the string representation of this array to the provided String.
     """
-    var text = consume text'
+    var buf = consume buf'
 
     if data.size() == 0 then
-      text.append("[]")
-      return text
+      buf.append("[]")
+      return buf
     end
 
-    text.push('[')
+    buf.push('[')
 
     var print_comma = false
 
     for v in data.values() do
       if print_comma then
-        text.push(',')
+        buf.push(',')
       else
         print_comma = true
       end
 
       if pretty then
-        text = _JsonPrint._indent(consume text, indent, level + 1)
+        buf = _JsonPrint._indent(consume buf, indent, level + 1)
       end
 
-      text = _JsonPrint._string(v, consume text, indent, level + 1, pretty)
+      buf = _JsonPrint._string(v, consume buf, indent, level + 1, pretty)
     end
 
     if pretty then
-      text = _JsonPrint._indent(consume text, indent, level)
+      buf = _JsonPrint._indent(consume buf, indent, level)
     end
 
-    text.push(']')
-    text
+    buf.push(']')
+    buf
 
 
 class JsonObject
@@ -87,53 +87,53 @@ class JsonObject
     """
     Generate string representation of this object.
     """
-    let text = _show(recover String(256) end, indent, 0, pretty_print)
-    text.compact()
-    text
+    let buf = _show(recover String(256) end, indent, 0, pretty_print)
+    buf.compact()
+    buf
 
-  fun _show(text': String iso, indent: String = "", level: USize = 0,
+  fun _show(buf': String iso, indent: String = "", level: USize = 0,
     pretty: Bool = false): String iso^
   =>
     """
     Append the string representation of this object to the provided String.
     """
-    var text = consume text'
+    var buf = consume buf'
 
     if data.size() == 0 then
-      text.append("{}")
-      return text
+      buf.append("{}")
+      return buf
     end
 
-    text.push('{')
+    buf.push('{')
 
     var print_comma = false
 
     for (k, v) in data.pairs() do
       if print_comma then
-        text.push(',')
+        buf.push(',')
       else
         print_comma = true
       end
 
       if pretty then
-        text = _JsonPrint._indent(consume text, indent, level + 1)
+        buf = _JsonPrint._indent(consume buf, indent, level + 1)
       end
 
-      text.push('"')
-      text.append(k)
+      buf.push('"')
+      buf.append(k)
 
       if pretty then
-        text.append("\": ")
+        buf.append("\": ")
       else
-        text.append("\":")
+        buf.append("\":")
       end
 
-      text = _JsonPrint._string(v, consume text, indent, level + 1, pretty)
+      buf = _JsonPrint._string(v, consume buf, indent, level + 1, pretty)
     end
 
     if pretty then
-      text = _JsonPrint._indent(consume text, indent, level)
+      buf = _JsonPrint._indent(consume buf, indent, level)
     end
 
-    text.push('}')
-    text
+    buf.push('}')
+    buf

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -28,8 +28,8 @@ class JsonArray
     buf.compact()
     buf
 
-  fun _show(buf': String iso, indent: String = "", level: USize = 0,
-    pretty: Bool = false): String iso^
+  fun _show(buf': String iso, indent: String = "", level: USize,
+    pretty: Bool): String iso^
   =>
     """
     Append the string representation of this array to the provided String.
@@ -91,8 +91,8 @@ class JsonObject
     buf.compact()
     buf
 
-  fun _show(buf': String iso, indent: String = "", level: USize = 0,
-    pretty: Bool = false): String iso^
+  fun _show(buf': String iso, indent: String = "", level: USize,
+    pretty: Bool): String iso^
   =>
     """
     Append the string representation of this object to the provided String.

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -24,34 +24,46 @@ class JsonArray
     """
     Generate string representation of this array.
     """
+    let text = _show(recover String(256) end, indent, 0, pretty_print)
+    text.compact()
+    text
+
+  fun _show(text': String iso, indent: String = "", level: USize = 0,
+    pretty: Bool = false): String iso^
+  =>
+    """
+    Append the string representation of this array to the provided String.
+    """
+    var text = consume text'
+
     if data.size() == 0 then
-      return "[]"
+      text.append("[]")
+      return text
     end
 
-    var text = recover String(256) end
-    let elem_indent = indent + "  "
+    text.push('[')
 
-    text.append("[")
+    var print_comma = false
 
-    for i in data.values() do
-      if text.size() > 1 then
-        text.append(",")
+    for v in data.values() do
+      if print_comma then
+        text.push(',')
+      else
+        print_comma = true
       end
 
-      if pretty_print then
-        text.append("\n")
-        text.append(elem_indent)
+      if pretty then
+        text = _JsonPrint._indent(consume text, indent, level + 1)
       end
 
-      text.append(_JsonPrint._string(i, elem_indent, pretty_print))
+      text = _JsonPrint._string(v, consume text, indent, level + 1, pretty)
     end
 
-    if pretty_print then
-      text.append("\n")
-      text.append(indent)
+    if pretty then
+      text = _JsonPrint._indent(consume text, indent, level)
     end
 
-    text.append("]")
+    text.push(']')
     text
 
 
@@ -75,40 +87,53 @@ class JsonObject
     """
     Generate string representation of this object.
     """
+    let text = _show(recover String(256) end, indent, 0, pretty_print)
+    text.compact()
+    text
+
+  fun _show(text': String iso, indent: String = "", level: USize = 0,
+    pretty: Bool = false): String iso^
+  =>
+    """
+    Append the string representation of this object to the provided String.
+    """
+    var text = consume text'
+
     if data.size() == 0 then
-      return "{}"
+      text.append("{}")
+      return text
     end
 
-    var text = recover String(256) end
-    let elem_indent = indent + "  "
+    text.push('{')
 
-    text.append("{")
+    var print_comma = false
 
-    for i in data.pairs() do
-      if text.size() > 1 then
-        text.append(",")
+    for (k, v) in data.pairs() do
+      if print_comma then
+        text.push(',')
+      else
+        print_comma = true
       end
 
-      if pretty_print then
-        text.append("\n")
-        text.append(elem_indent)
+      if pretty then
+        text = _JsonPrint._indent(consume text, indent, level + 1)
       end
 
-      text.append("\"")
-      text.append(i._1)
-      text.append("\":")
+      text.push('"')
+      text.append(k)
 
-      if pretty_print then
-        text.append(" ")
+      if pretty then
+        text.append("\": ")
+      else
+        text.append("\":")
       end
 
-      text.append(_JsonPrint._string(i._2, elem_indent, pretty_print))
+      text = _JsonPrint._string(v, consume text, indent, level + 1, pretty)
     end
 
-    if pretty_print then
-      text.append("\n")
-      text.append(indent)
+    if pretty then
+      text = _JsonPrint._indent(consume text, indent, level)
     end
 
-    text.append("}")
+    text.push('}')
     text


### PR DESCRIPTION
This commit adds a `_show` method to the `JsonArray` and `JsonObject` types.
This method is responsible for printing the string representation to a
string buffer that it receives as an argument. The method also receives
the desired indentation style, and the current level of indentation.

The indentation is managed by a new `_JsonPrint._indent` method, which
prints the leading newline and the indentation as many times as the
given level requires.

The `_JsonPrint._string` method has been updated to also receive the
buffer and will either pass the string representation of the primitive
to it, or will forward it to the `_show` method of `JsonArray` or
`JsonObject`.

This greatly reduces the amount of allocation that takes place.

The `I64` and `String` types in the `_JsonPrint` match expression have
also been altered to avoid unnecessary allocation. The `F64` still
requires an allocation at the moment.

When only a single byte is added to the buffer, `.push()` is used instead
of `.append()`.

Lastly, the `JsonDoc.string()` method now allows the user to pass the
desired indentation style.