### PR TITLE
Example of "from_iso_array" on String

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -41,6 +41,14 @@ class val String is (Seq[U8] & Comparable[String box] & Stringable)
       _set(_size, 0)
     end
 
+  new iso from_iso_array(data: Array[U8] iso) =>
+    """
+    Create a string from an array, reusing the underlying data pointer
+    """
+    _size = data.size()
+    _alloc = data.space()
+    _ptr = (consume data)._cstring()._unsafe()._offset(0)
+
   new from_cstring(str: Pointer[U8], len: USize = 0, alloc: USize = 0) =>
     """
     The cstring is not copied. This must be done only with C-FFI functions that


### PR DESCRIPTION
DO NOT MERGE

@jemc I am opening this up for conversation. I added this last night while performance hacking in a branch for our code. This had a large performance boost for us where we have a really common case of:

everything comes in over tcp and arrives as a `Array[U8] iso`. 

We need to turn into a `String` and make some changes like running `lower_in_place` and then eventually turn into vals. With the existing String api (we are running a little behind ponyc master), there was no way to zero copy from Array -> String and be able to have a mutable reference.

Thoughts on how this would play with trim et al?

Am I missing a way to do this already? If I'm not, how do we get this into ponyc stdlib as it can be very valuable when trying to get the best performance.

