### PR TITLE
Add a constructor for `Options` with a simple `String` array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Embedded fields can now be constructed from complex expressions containing constructors
 - Sendable members of non-sendable objects can be used in recover expressions in certain cases.
 - ProcessNotify functions are passed a reference to ProcessMonitor.
+- The constructor of `Options` doesn't require an `Env` anymore but just a simple `String` array.
 
 ## [0.2.1] - 2015-10-06
 

--- a/examples/gups_basic/main.pony
+++ b/examples/gups_basic/main.pony
@@ -58,7 +58,7 @@ actor Main
     end
 
   fun ref arguments() ? =>
-    var options = Options(_env)
+    var options = Options(_env.args)
 
     options
       .add("table", "t", I64Argument)

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -9,7 +9,7 @@ class Config
   var logactors: USize = 2
 
   fun ref apply(env: Env): Bool =>
-    var options = Options(env)
+    var options = Options(env.args)
 
     options
       .add("table", "t", I64Argument)

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -136,7 +136,7 @@ actor Main
       imaginary)
 
   fun ref arguments(env: Env) ? =>
-    let options = Options(env)
+    let options = Options(env.args)
 
     options
       .add("iterations", "i", I64Argument)

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -194,7 +194,7 @@ actor Main
     var debug : Bool = false
     var err : Bool = false
 
-    let options = Options(env) +
+    let options = Options(env.args) +
       ("punk", "p", None) +
       ("lonely", "l", None) +
       ("bench", "b", I64Argument) +
@@ -258,4 +258,3 @@ actor Main
 
       By Default, the actor will run quiet and interruptibly.
     """)
-

--- a/packages/options/_test.pony
+++ b/packages/options/_test.pony
@@ -11,12 +11,6 @@ actor Main is TestList
     test(_TestCombineShortArg)
     test(_TestArgLeadingDash)
 
-primitive TestOptions
-  fun from(renv: Env val, args: Array[String] val): Options =>
-    let env = recover val Env.create(renv.root, renv.input, renv.out, renv.err,
-      args, None) end
-    Options(env)
-
 class iso _TestLongOptions is UnitTest
   """
   Long options start with two leading dashes, and can be lone, have a following
@@ -25,8 +19,7 @@ class iso _TestLongOptions is UnitTest
   fun name(): String => "options/Options.longOptions"
 
   fun apply(h: TestHelper) =>
-    let options = TestOptions.from(h.env, recover ["--none", "--i64", "12345",
-      "--f64=67.890"] end)
+    let options = Options(["--none", "--i64", "12345", "--f64=67.890"])
     var none: Bool = false
     var i64: I64 = -1
     var f64: F64 = -1
@@ -54,8 +47,7 @@ class iso _TestShortOptions is UnitTest
   fun name(): String => "options/Options.shortOptions"
 
   fun apply(h: TestHelper) =>
-    let options = TestOptions.from(h.env, recover val ["-n", "-i", "12345",
-      "-f67.890"] end)
+    let options = Options(["-n", "-i", "12345", "-f67.890"])
     var none: Bool = false
     var i64: I64 = -1
     var f64: F64 = -1
@@ -84,7 +76,7 @@ class iso _TestCombineShortOptions is UnitTest
   fun name(): String => "options/Options.combineShort"
 
   fun apply(h: TestHelper) =>
-    let options = TestOptions.from(h.env, recover val ["-ab"] end)
+    let options = Options(["-ab"])
     var aaa: Bool = false
     var bbb: Bool = false
     options
@@ -107,8 +99,7 @@ class iso _TestCombineShortArg is UnitTest
   fun name(): String => "options/Options.combineShortArg"
 
   fun apply(h: TestHelper) =>
-    let options =
-      TestOptions.from(h.env, recover val ["-ab99", "-ac", "99"] end)
+    let options = Options(["-ab99", "-ac", "99"])
     var aaa: Bool = false
     var bbb: I64 = -1
     var ccc: I64 = -1
@@ -136,8 +127,7 @@ class iso _TestArgLeadingDash is UnitTest
   fun name(): String => "options/Options.testArgLeadingDash"
 
   fun apply(h: TestHelper) =>
-    let options =
-      TestOptions.from(h.env, recover val ["--aaa", "-2", "--bbb=-2"] end)
+    let options = Options(["--aaa", "-2", "--bbb=-2"])
     var aaa: I64 = -1
     var bbb: I64 = -1
     options

--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -25,7 +25,7 @@ actor Main
     _env.out.print("The Float is " + _a_float.string())
 
   fun ref arguments() ? =>
-    var options = Options(_env)
+    var options = Options(_env.args)
 
     options
       .add("string", "t", StringArgument)
@@ -93,11 +93,11 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
   var _index: USize = 0
   var _error: Bool = false
 
-  new create(env: Env, fatal: Bool = true) =>
-    _arguments = _arguments.create(env.args.size())
+  new create(args: Array[String] box, fatal: Bool = true) =>
+    _arguments = _arguments.create(args.size())
     _fatal = fatal
 
-    for arg in env.args.values() do
+    for arg in args.values() do
       _arguments.push(arg.clone())
     end
 


### PR DESCRIPTION
The unit tests has been simplified to use the new constructor, and so a new unit test has been added to still test the constructor with an `Env`.

Implemention notes:
- the two constructors have some duplicated lines, but I wasn't able to make one constructor call the other without having ponyc complain about uninitialized fields
- I am not at ease with miwing refcaps and generics, maybe the signature of the suggested new constructor could be improved