### PR TITLE
Add LLVM type-based alias analysis metadatas

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -6,6 +6,7 @@
 #include "gendesc.h"
 #include "gencall.h"
 #include "genopt.h"
+#include "gentype.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/heap.h"
 #include "../../libponyrt/mem/pool.h"
@@ -447,6 +448,8 @@ static void init_module(compile_t* c, ast_t* program, pass_opt_t* opt)
 
   c->reach = reach_new();
 
+  c->tbaa_mds = tbaa_metadatas_new();
+
   // The name of the first package is the name of the program.
   c->filename = package_filename(package);
 
@@ -542,6 +545,7 @@ static void codegen_cleanup(compile_t* c)
   LLVMDisposeModule(c->module);
   LLVMContextDispose(c->context);
   LLVMDisposeTargetMachine(c->machine);
+  tbaa_metadatas_free(c->tbaa_mds);
   reach_free(c->reach);
 }
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -44,6 +44,8 @@ LLVMValueRef LLVMInvariantStart(LLVMModuleRef module);
 typedef struct compile_local_t compile_local_t;
 DECLARE_HASHMAP(compile_locals, compile_locals_t, compile_local_t);
 
+typedef struct tbaa_metadatas_t tbaa_metadatas_t;
+
 typedef struct compile_frame_t
 {
   LLVMValueRef fun;
@@ -66,6 +68,7 @@ typedef struct compile_t
 {
   pass_opt_t* opt;
   reach_t* reach;
+  tbaa_metadatas_t* tbaa_mds;
   const char* filename;
 
   const char* str_builtin;
@@ -130,6 +133,7 @@ typedef struct compile_t
   LLVMBuilderRef builder;
   LLVMDIBuilderRef di;
   LLVMMetadataRef di_unit;
+  LLVMValueRef tbaa_root;
 
   LLVMTypeRef void_type;
   LLVMTypeRef ibool;

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -105,6 +105,14 @@ const char* genname_type(ast_t* ast)
   return stringtab_buf(buf);
 }
 
+const char* genname_type_and_cap(ast_t* ast)
+{
+  // package_Type[_Arg1_Arg2]_cap
+  printbuf_t* buf = printbuf_new();
+  type_append(buf, ast, false);
+  return stringtab_buf(buf);
+}
+
 const char* genname_alloc(const char* type)
 {
   return stringtab_two(type, "Alloc");

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -8,6 +8,8 @@ PONY_EXTERN_C_BEGIN
 
 const char* genname_type(ast_t* ast);
 
+const char* genname_type_and_cap(ast_t* ast);
+
 const char* genname_alloc(const char* type);
 
 const char* genname_traitlist(const char* type);

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -2,6 +2,7 @@
 #include "genexpr.h"
 #include "genname.h"
 #include "gencall.h"
+#include "gentype.h"
 #include "../expr/literal.h"
 #include "../type/cap.h"
 #include "../type/subtype.h"
@@ -98,6 +99,9 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
       const char id[] = "invariant.load";
       LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
     }
+    LLVMValueRef metadata = tbaa_metadata_for_type(c, l_type);
+    const char id[] = "tbaa";
+    LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
   }
 
   ast_t* f_type = ast_type(ast);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -8,12 +8,86 @@
 #include "genserialise.h"
 #include "../ast/id.h"
 #include "../pkg/package.h"
+#include "../type/cap.h"
 #include "../type/reify.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+
+static size_t tbaa_metadata_hash(tbaa_metadata_t* a)
+{
+  return ponyint_hash_ptr(a->name);
+}
+
+static bool tbaa_metadata_cmp(tbaa_metadata_t* a, tbaa_metadata_t* b)
+{
+  return a->name == b->name;
+}
+
+DEFINE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t,
+  tbaa_metadata_hash, tbaa_metadata_cmp, ponyint_pool_alloc_size,
+  ponyint_pool_free_size, NULL);
+
+tbaa_metadatas_t* tbaa_metadatas_new()
+{
+  tbaa_metadatas_t* tbaa_mds = POOL_ALLOC(tbaa_metadatas_t);
+  tbaa_metadatas_init(tbaa_mds, 64);
+  return tbaa_mds;
+}
+
+void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_mds)
+{
+  tbaa_metadatas_destroy(tbaa_mds);
+  POOL_FREE(tbaa_metadatas_t, tbaa_mds);
+}
+
+LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type)
+{
+  assert(ast_id(type) == TK_NOMINAL);
+
+  const char* name = genname_type_and_cap(type);
+  tbaa_metadata_t k;
+  k.name = name;
+  tbaa_metadata_t* md = tbaa_metadatas_get(c->tbaa_mds, &k);
+  if(md != NULL)
+    return md->metadata;
+
+  md = POOL_ALLOC(tbaa_metadata_t);
+  md->name = name;
+  tbaa_metadatas_put(c->tbaa_mds, md);
+
+  LLVMValueRef params[3];
+  params[0] = LLVMMDStringInContext(c->context, name, (unsigned)strlen(name));
+
+  token_id cap = cap_single(type);
+  switch(cap)
+  {
+    case TK_TRN:
+    case TK_REF:
+    {
+      ast_t* tcap = ast_childidx(type, 3);
+      ast_setid(tcap, TK_BOX);
+      params[1] = tbaa_metadata_for_type(c, type);
+      ast_setid(tcap, cap);
+      break;
+    }
+    default:
+      params[1] = c->tbaa_root;
+      break;
+  }
+
+  md->metadata = LLVMMDNodeInContext(c->context, params, 2);
+  return md->metadata;
+}
+
+static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
+{
+  const char str[] = "Pony TBAA";
+  LLVMValueRef mdstr = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
+  return LLVMMDNodeInContext(ctx, &mdstr, 1);
+}
 
 static bool make_opaque_struct(compile_t* c, reach_type_t* t)
 {
@@ -586,6 +660,8 @@ bool gentypes(compile_t* c)
 {
   reach_type_t* t;
   size_t i;
+
+  c->tbaa_root = make_tbaa_root(c->context);
 
   genprim_builtins(c);
 

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -6,6 +6,20 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct tbaa_metadata_t
+{
+  const char* name;
+  LLVMValueRef metadata;
+} tbaa_metadata_t;
+
+DECLARE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t);
+
+tbaa_metadatas_t* tbaa_metadatas_new();
+
+void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
+
+LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
+
 bool gentypes(compile_t* c);
 
 PONY_EXTERN_C_END


### PR DESCRIPTION
These metadatas make LLVM aware of the aliasing guarantees of the Pony type system. It will allow a more precise alias analysis, which will lead to better optimisations.

Metadatas are added on loads and stores of fields. Since fields of interfaces, union types, etc. are inaccessible, only base types are considered. Each type has its own subtree (objects of different types can never alias) which is arranged in the following way:

```text
                        ----R----
                       /    |    \
                     iso   box   val
                          /   \
                        ref   trn
```

In LLVM, an object of a given type can alias with objects of any child or parent type. The tree is a simple transposition of the reference capabilities rules. The only difference is `val` ; it isn't a child of `box` here because LLVM aliasing only cares about writes. `tag` is left out since it can neither be read from nor written to.