### PR TITLE
Sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - add notification of terminal resize
 - `trim` and `trim_in_place` methods for `Array` and `String`.
 - `is_null_terminated` and `null_terminated` methods for `String`.
+- `Sort` primitive
 
 ### Changed
 

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -488,7 +488,7 @@ class iso _TestHashSetContains is UnitTest
 class iso _TestSort is UnitTest
   fun name(): String => "collections/Sort"
 
-  fun apply(h: TestHelper) ? =>
+  fun apply(h: TestHelper) =>
     test_sort[USize](h,
       [23, 26, 31, 41, 53, 58, 59, 84, 93, 97],
       [31, 41, 59, 26, 53, 58, 97, 93, 23, 84])
@@ -506,5 +506,5 @@ class iso _TestSort is UnitTest
     h: TestHelper,
     sorted: Array[A],
     unsorted: Array[A]
-  ) ? =>
-    h.assert_array_eq[A](sorted, Sort[A](unsorted))
+  ) =>
+    h.assert_array_eq[A](sorted, Sort[Array[A], A](unsorted))

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -24,6 +24,7 @@ actor Main is TestList
     test(_TestListsContains)
     test(_TestListsReverse)
     test(_TestHashSetContains)
+    test(_TestSort)
 
 class iso _TestList is UnitTest
   fun name(): String => "collections/List"
@@ -483,3 +484,27 @@ class iso _TestHashSetContains is UnitTest
     // And resetting an element should cause it to be found again
     a.set(0)
     h.assert_true(a.contains(0), not_found_fail)
+
+class iso _TestSort is UnitTest
+  fun name(): String => "collections/Sort"
+
+  fun apply(h: TestHelper) ? =>
+    test_sort[USize](h,
+      [23, 26, 31, 41, 53, 58, 59, 84, 93, 97],
+      [31, 41, 59, 26, 53, 58, 97, 93, 23, 84])
+    test_sort[I64](h,
+      [-5467984, -784, 0, 0, 42, 59, 74, 238, 905, 959, 7586, 7586, 9845],
+      [74, 59, 238, -784, 9845, 959, 905, 0, 0, 42, 7586, -5467984, 7586])
+    test_sort[F64](h,
+      [-959.7485, -784.0, 2.3, 7.8, 7.8, 59.0, 74.3, 238.2, 905, 9845.768],
+      [74.3, 59.0, 238.2, -784.0, 2.3, 9845.768, -959.7485, 905, 7.8, 7.8])
+    test_sort[String](h,
+      ["", "%*&^*&^&", "***", "Hello", "bar", "f00", "foo", "foo"],
+      ["", "Hello", "foo", "bar", "foo", "f00", "%*&^*&^&", "***"])
+
+  fun test_sort[A: (Comparable[A] val & Stringable)](
+    h: TestHelper,
+    sorted: Array[A],
+    unsorted: Array[A]
+  ) ? =>
+    h.assert_array_eq[A](sorted, Sort[A](unsorted))

--- a/packages/collections/sort.pony
+++ b/packages/collections/sort.pony
@@ -1,15 +1,15 @@
-primitive Sort[A: Comparable[A] val]
+primitive Sort[A: Seq[B] ref, B: Comparable[B] #read]
   """
   Implementation of dual-pivot quicksort.
   """
-  fun apply(a: Seq[A]): Seq[A]^ ? =>
+  fun apply(a: A): A^ =>
     """
     Sort the given seq.
     """
-    _sort(a, 0, a.size().isize()-1)
+    try _sort(a, 0, a.size().isize()-1) end
     a
 
-  fun _sort(a: Seq[A], lo: ISize, hi: ISize) ? =>
+  fun _sort(a: A, lo: ISize, hi: ISize) ? =>
     if hi <= lo then return end
     // choose outermost elements as pivots
     if a(lo.usize()) > a(hi.usize()) then _swap(a, lo, hi) end
@@ -41,7 +41,5 @@ primitive Sort[A: Comparable[A] val]
     _sort(a, l+1, g-1)
     _sort(a, g+1, hi)
 
-  fun _swap(a: Seq[A], i: ISize, j: ISize) ? =>
-    let tmp = a(i.usize())
-    a(i.usize()) = a(j.usize())
-    a(j.usize()) = tmp
+  fun _swap(a: A, i: ISize, j: ISize) ? =>
+    a(j.usize()) = a(i.usize()) = a(j.usize())

--- a/packages/collections/sort.pony
+++ b/packages/collections/sort.pony
@@ -1,0 +1,34 @@
+primitive Sort[A: Comparable[A] val]
+  """
+  Implementation of a 3-way partition QuickSort.
+  """
+  fun apply(a: Seq[A]): Seq[A]^ ? =>
+    """
+    Sort the given seq.
+    """
+    _sort(a, 0, a.size())
+    a
+
+  fun _sort(a: Seq[A], start: USize, stop: USize) ? =>
+    if (stop - start) < 2 then return end
+    let key = a(start + ((stop - start) / 2))
+    (var e, var u, var g) = (start, start, stop)
+    while u < g do
+      if a(u) < key then
+        _swap(a, u, e)
+        e = e + 1
+        u = u + 1
+      elseif a(u) == key then
+        u = u + 1
+      else
+        g = g - 1
+        _swap(a, u, g)
+      end
+    end
+    _sort(a, start, e)
+    _sort(a, g, stop)
+
+  fun _swap(a: Seq[A], i: USize, j: USize) ? =>
+    let tmp = a(i)
+    a(i) = a(j)
+    a(j) = tmp

--- a/packages/collections/sort.pony
+++ b/packages/collections/sort.pony
@@ -1,34 +1,47 @@
 primitive Sort[A: Comparable[A] val]
   """
-  Implementation of a 3-way partition QuickSort.
+  Implementation of dual-pivot quicksort.
   """
   fun apply(a: Seq[A]): Seq[A]^ ? =>
     """
     Sort the given seq.
     """
-    _sort(a, 0, a.size())
+    _sort(a, 0, a.size().isize()-1)
     a
 
-  fun _sort(a: Seq[A], start: USize, stop: USize) ? =>
-    if (stop - start) < 2 then return end
-    let key = a(start + ((stop - start) / 2))
-    (var e, var u, var g) = (start, start, stop)
-    while u < g do
-      if a(u) < key then
-        _swap(a, u, e)
-        e = e + 1
-        u = u + 1
-      elseif a(u) == key then
-        u = u + 1
-      else
-        g = g - 1
-        _swap(a, u, g)
+  fun _sort(a: Seq[A], lo: ISize, hi: ISize) ? =>
+    if hi <= lo then return end
+    // choose outermost elements as pivots
+    if a(lo.usize()) > a(hi.usize()) then _swap(a, lo, hi) end
+    (var p, var q) = (a(lo.usize()), a(hi.usize()))
+    // partition according to invariant
+    (var l, var g) = (lo+1, hi-1)
+    var k = l
+    while k <= g do
+      if a(k.usize()) < p then
+        _swap(a, k, l)
+        l = l+1
+      elseif a(k.usize()) >= q then
+        while (a(g.usize()) > q) and (k < g) do g = g-1 end
+        _swap(a, k, g)
+        g = g-1
+        if a(k.usize()) < p then
+          _swap(a, k, l)
+          l = l+1
+        end
       end
+      k = k+1
     end
-    _sort(a, start, e)
-    _sort(a, g, stop)
+    (l, g) = (l-1, g+1)
+    // swap pivots to final positions
+    _swap(a, lo, l)
+    _swap(a, hi, g)
+    // recursively sort 3 partitions
+    _sort(a, lo, l-1)
+    _sort(a, l+1, g-1)
+    _sort(a, g+1, hi)
 
-  fun _swap(a: Seq[A], i: USize, j: USize) ? =>
-    let tmp = a(i)
-    a(i) = a(j)
-    a(j) = tmp
+  fun _swap(a: Seq[A], i: ISize, j: ISize) ? =>
+    let tmp = a(i.usize())
+    a(i.usize()) = a(j.usize())
+    a(j.usize()) = tmp


### PR DESCRIPTION
Add a `Sort` primitive to the collections package that uses Yaroslavskiy's algorithm (the dual-pivot QuickSort that is used in Java 7).