### PR TITLE
Restrict mutable tuple recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Compiling ponyrt with Clang versions >= 3.3, < 3.6.
+- Restrict mutable tuple recovery to maintain reference capability security (issue #1123)
 
 ### Added
 

--- a/src/libponyc/type/alias.h
+++ b/src/libponyc/type/alias.h
@@ -19,6 +19,8 @@ ast_t* recover_type(ast_t* type, token_id cap);
 
 bool sendable(ast_t* type);
 
+bool immutable_or_opaque(ast_t* type);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -1076,6 +1076,22 @@ bool cap_sendable(token_id cap)
   return false;
 }
 
+bool cap_immutable_or_opaque(token_id cap)
+{
+  switch(cap)
+  {
+    case TK_VAL:
+    case TK_BOX:
+    case TK_TAG:
+    case TK_CAP_SHARE:
+      return true;
+
+    default: {}
+  }
+
+  return false;
+}
+
 bool cap_safetowrite(token_id into, token_id cap)
 {
   switch(into)

--- a/src/libponyc/type/cap.h
+++ b/src/libponyc/type/cap.h
@@ -77,6 +77,8 @@ bool cap_view_lower(token_id left_cap, token_id left_eph,
 
 bool cap_sendable(token_id cap);
 
+bool cap_immutable_or_opaque(token_id cap);
+
 bool cap_safetowrite(token_id into, token_id cap);
 
 PONY_EXTERN_C_END

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -375,3 +375,70 @@ TEST_F(RecoverTest, CantDoPartialApplication_RefWithLowerToTag)
 
   TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
 }
+
+TEST_F(RecoverTest, CanRecover_TupleMutableAlias)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    let x: (Foo, Foo) = recover\n"
+    "      let y: Foo = Foo\n"
+    "      (y, y)\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantRecover_TupleMutableLift)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    let x: (Foo iso, Foo iso) = recover\n"
+    "      let y: Foo = Foo\n"
+    "      (y, y)\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+TEST_F(RecoverTest, CanRecover_TupleMutableToImmutable)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    let x: (Foo val, Foo val) = recover val\n"
+    "      let y: Foo = Foo\n"
+    "      (y, y)\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CanRecover_TupleInUnionNoInnerLift)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    let x: (Foo iso | (Foo, Foo)) = recover\n"
+    "      let y: Foo = Foo\n"
+    "      let z: (Foo | (Foo, Foo)) = (y, y)\n"
+    "      z\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantRecover_TupleInUnionInnerLift)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    let x: (Foo iso | (Foo iso, Foo iso)) = recover\n"
+    "      let y: Foo = Foo\n"
+    "      let z: (Foo | (Foo, Foo)) = (y, y)\n"
+    "      z\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}


### PR DESCRIPTION
This is a fix for #1123. Recovery of tuples is now completely forbidden. We could allow some tuples and rcap combinations while keeping it safe but I'm not sure if it would be a good thing.

EDIT by @jemc: This PR now allows some tuple recovery, while disallowing the problematic combinations.