### PR TITLE
Make Map.upsert and Map.update much faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix issue with creating hex and octal strings if precision was specified.
 - Correctly parses Windows 10 SDK versions, and includes new UCRT library when linking with Windows 10 SDK.
 - Performance of Array.append and Array.concat (no unnecessary calls to push).
+- Performance of Map.upsert and Map.update (don't replace existing keys)
 
 ### Added
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -101,8 +101,8 @@ class HashMap[K, V, H: HashFunction[K] val]
 
     try
       if found then
-        let prev = (_array(i) = _MapEmpty) as (_, V^)
-        _array(i) = (consume key, f(consume prev, consume value))
+        (let pkey, let pvalue) = (_array(i) = _MapEmpty) as (K^, V^)
+        _array(i) = (consume pkey, f(consume pvalue, consume value))
       else
         _array(i) = (consume key, consume value)
         _size = _size + 1

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -63,7 +63,8 @@ class HashMap[K, V, H: HashFunction[K] val]
     try
       (let i, _) = _search(key)
 
-      match _array(i) = (consume key, consume value)
+      let pkey = (_array(i) = _MapEmpty) as (K^, _)
+      match _array(i) = (consume pkey, consume value)
       | (_, let v: V) =>
         return consume v
       else

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -61,10 +61,14 @@ class HashMap[K, V, H: HashFunction[K] val]
     returns None. If there was no previous value, this may trigger a resize.
     """
     try
-      (let i, _) = _search(key)
+      (let i, let found) = _search(key)
 
-      let pkey = (_array(i) = _MapEmpty) as (K^, _)
-      match _array(i) = (consume pkey, consume value)
+      let k = if found then
+        _array(i) as (K^, _)
+      else
+        consume key
+      end
+      match _array(i) = (consume k, consume value)
       | (_, let v: V) =>
         return consume v
       else


### PR DESCRIPTION
Both Map.upsert and Map.update were replacing the key with the new key value. This has
a rather drastic performance impact. In testing on my machine, this change results in up
to a 10x performance improvement. At minimum I saw 4x performance improvement from
both of these changes.