### PR TITLE
llvm 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,18 @@ else
   ifeq ($(UNAME_S),Darwin)
     OSTYPE = osx
     lto := yes
-    AR := /usr/bin/ar
+    ifneq (,$(shell which llvm-ar-mp-3.8 2> /dev/null))
+      AR := llvm-ar-mp-3.8
+      AR_FLAGS := rcs
+    else
+      ifneq (,$(shell which llvm-ar-3.8 2> /dev/null))
+        AR := llvm-ar-3.8
+        AR_FLAGS := rcs
+      else
+        AR := /usr/bin/ar
+	AR_FLAGS := -rcs
+      endif
+    endif
   endif
 
   ifeq ($(UNAME_S),FreeBSD)
@@ -79,7 +90,7 @@ LIB_EXT ?= a
 BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
 LINKER_FLAGS = -march=$(arch)
-AR_FLAGS = -rcs
+AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
   -DPONY_BUILD_CONFIG=\"$(config)\"
@@ -145,10 +156,18 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-  ifneq (,$(shell which llvm-config-3.8 2> /dev/null))
+  ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
+    LLVM_CONFIG = llvm-config-3.9
+    LLVM_LINK = llvm-link-3.9
+    LLVM_OPT = opt-3.9
+  else ifneq (,$(shell which llvm-config-3.8 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.8
     LLVM_LINK = llvm-link-3.8
     LLVM_OPT = opt-3.8
+  else ifneq (,$(shell which llvm-config-mp-3.8 2> /dev/null))
+    LLVM_CONFIG = llvm-config-mp-3.8
+    LLVM_LINK = llvm-link-mp-3.8
+    LLVM_OPT = opt-mp-3.8
   else ifneq (,$(shell which llvm-config-3.7 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.7
     LLVM_LINK = llvm-link-3.7

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -88,7 +88,12 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef d,
   unsigned lang, const char* file, const char* dir, const char* producer,
   int optimized)
 {
-#if PONY_LLVM >= 307
+#if PONY_LLVM >= 309
+  DIBuilder* pd = unwrap(d);
+
+  return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized,
+    StringRef(), 0, StringRef())); // use the defaults
+#elif PONY_LLVM >= 307
   DIBuilder* pd = unwrap(d);
 
   return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized,
@@ -149,7 +154,13 @@ LLVMMetadataRef LLVMDIBuilderCreateMethod(LLVMDIBuilderRef d,
 
   DISubprogram* di_method = pd->createMethod(unwrap<DIScope>(scope),
     name, linkage, unwrap<DIFile>(file), line, unwrap<DISubroutineType>(type),
-    false, true, 0, 0, nullptr, 0, optimized);
+    false, true, 0, 0,
+#if PONY_LLVM >= 309
+    0,
+#else
+    nullptr,
+#endif
+    0, optimized);
 
   f->setSubprogram(di_method);
   return wrap(di_method);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -221,11 +221,11 @@ static bool link_exe(compile_t* c, ast_t* program,
     strlen(lib_args);
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
-  // Avoid incorrect ld, eg from macports.
   snprintf(ld_cmd, ld_len,
-    "/usr/bin/ld -execute -no_pie -dead_strip -arch %.*s "
+    "ld -execute -no_pie -dead_strip -arch %.*s "
     "-macosx_version_min 10.8 -o %s %s %s %s -lSystem",
-    (int)arch_len, c->opt->triple, file_exe, file_o, lib_args, ponyrt
+           (int)arch_len, c->opt->triple, file_exe, file_o, lib_args,
+           ponyrt
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -220,12 +220,14 @@ static bool link_exe(compile_t* c, ast_t* program,
   size_t ld_len = 128 + arch_len + strlen(file_exe) + strlen(file_o) +
     strlen(lib_args);
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
+  const char* linker = c->opt->linker != NULL ? c->opt->linker
+                                              : "ld";
 
   snprintf(ld_cmd, ld_len,
-    "ld -execute -no_pie -dead_strip -arch %.*s "
+    "%s -execute -no_pie -dead_strip -arch %.*s "
     "-macosx_version_min 10.8 -o %s %s %s %s -lSystem",
-           (int)arch_len, c->opt->triple, file_exe, file_o, lib_args,
-           ponyrt
+           linker, (int)arch_len, c->opt->triple, file_exe, file_o,
+           lib_args, ponyrt
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -849,9 +849,15 @@ static void optimise(compile_t* c, bool pony_specific)
   Module* m = unwrap(c->module);
   TargetMachine* machine = reinterpret_cast<TargetMachine*>(c->machine);
 
+#if PONY_LLVM >= 309
+  llvm::legacy::PassManager lpm;
+  llvm::legacy::PassManager mpm;
+  llvm::legacy::FunctionPassManager fpm(m);
+#else
   PassManager lpm;
   PassManager mpm;
   FunctionPassManager fpm(m);
+#endif
 
 #if PONY_LLVM >= 307
   TargetLibraryInfoImpl *tl = new TargetLibraryInfoImpl(


### PR DESCRIPTION
I made it work, but the old LoadCombine bug on darwin is still present. See 9aca1e09c107ca770a2ba560747e3b61f8ca0e81

In this PR is also some old and new macports logic for --linker support and more llvm-config probing. The darwin system linker does not support the macports libLTO plugin.
