### PR TITLE
Force constructor inlining when stack-allocating objects

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -32,6 +32,7 @@ void LLVMSetInaccessibleMemOrArgMemOnly(LLVMValueRef fun);
 #endif
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
+void LLVMSetMetadataStr(LLVMValueRef val, const char* str, LLVMValueRef node);
 
 // Intrinsics.
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -382,6 +382,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     i++;
   }
 
+  bool is_new_call = false;
+
   // Generate the receiver. Must be done after the arguments because the args
   // could change things in the receiver expression that must be accounted for.
   if(call_needs_receiver(postfix, t))
@@ -406,6 +408,7 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
         } else {
           args[0] = gencall_alloc(c, t);
         }
+        is_new_call = true;
         break;
       }
 
@@ -453,10 +456,22 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     if(ast_canerror(ast) && (c->frame->invoke_target != NULL))
       r = invoke_fun(c, func, args, i, "", true);
     else
+    {
       r = codegen_call(c, func, args, i);
+      if(is_new_call)
+      {
+        LLVMValueRef md = LLVMMDNodeInContext(c->context, NULL, 0);
+        LLVMSetMetadataStr(r, "pony.newcall", md);
+      }
+    }
 
     codegen_debugloc(c, NULL);
   }
+
+  // Class constructors return void, expression result is the receiver.
+  if(((ast_id(postfix) == TK_NEWREF) || (ast_id(postfix) == TK_NEWBEREF)) &&
+     (t->underlying == TK_CLASS))
+    r = args[0];
 
   ponyint_pool_free_size(buf_size, args);
   ponyint_pool_free_size(buf_size, params);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -116,7 +116,8 @@ static void gen_main(compile_t* c, reach_type_t* t_main,
   env_args[1] = args[0];
   env_args[2] = LLVMBuildBitCast(c->builder, args[1], c->void_ptr, "");
   env_args[3] = LLVMBuildBitCast(c->builder, args[2], c->void_ptr, "");
-  LLVMValueRef env = codegen_call(c, m->func, env_args, 4);
+  codegen_call(c, m->func, env_args, 4);
+  LLVMValueRef env = env_args[0];
 
   // Run primitive initialisers using the main actor's heap.
   primitive_call(c, c->str__init);

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -62,7 +62,7 @@ static void name_params(compile_t* c, reach_type_t* t, reach_method_t* m,
   }
 }
 
-static void make_signature(reach_type_t* t, reach_method_t* m)
+static void make_signature(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
   // Count the parameters, including the receiver.
   size_t count = m->param_count + 1;
@@ -76,9 +76,13 @@ static void make_signature(reach_type_t* t, reach_method_t* m)
   for(size_t i = 0; i < m->param_count; i++)
     tparams[i + 1] = m->params[i].type->use_type;
 
-  // Generate the function type.
-  m->func_type = LLVMFunctionType(m->result->use_type, tparams, (int)count,
-    false);
+  // Generate the function type. Class constructors return void to avoid
+  // clobbering nocapture information.
+  if((ast_id(m->r_fun) == TK_NEW) && (t->underlying == TK_CLASS))
+    m->func_type = LLVMFunctionType(c->void_type, tparams, (int)count, false);
+  else
+    m->func_type = LLVMFunctionType(m->result->use_type, tparams, (int)count,
+      false);
 
   ponyint_pool_free_size(tparam_size, tparams);
 }
@@ -134,7 +138,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
   switch(ast_id(m->r_fun))
   {
     case TK_NEW:
-      handler = (t->underlying == TK_ACTOR) && !m->forwarding;
+      handler = t->underlying == TK_ACTOR;
       break;
 
     case TK_BE:
@@ -144,7 +148,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     default: {}
   }
 
-  make_signature(t, m);
+  make_signature(c, t, m);
 
   switch(t->underlying)
   {
@@ -450,7 +454,10 @@ static bool genfun_new(compile_t* c, reach_type_t* t, reach_method_t* m)
 
   codegen_scope_lifetime_end(c);
   codegen_debugloc(c, ast_childlast(body));
-  LLVMBuildRet(c->builder, value);
+  if(t->underlying == TK_CLASS)
+    LLVMBuildRetVoid(c->builder);
+  else
+    LLVMBuildRet(c->builder, value);
   codegen_debugloc(c, NULL);
 
   codegen_finishfun(c);

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1,11 +1,13 @@
 #ifdef _MSC_VER
 #  pragma warning(push)
-//because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
+// because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
 #  pragma warning(disable:4244)
 #  pragma warning(disable:4800)
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
 #  pragma warning(disable:4141)
+// LLVM claims DEBUG as a macro name. Conflicts with MSVC headers.
+#  pragma warning(disable:4005)
 #endif
 
 #include "genopt.h"
@@ -30,6 +32,7 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/ADT/SmallSet.h>
 
 #include "../../libponyrt/mem/heap.h"
@@ -196,8 +199,9 @@ public:
     }
 
     SmallVector<CallInst*, 4> tail;
+    Instruction* new_call = NULL;
 
-    if(!canStackAlloc(inst, dt, tail))
+    if(!canStackAlloc(inst, dt, tail, &new_call))
       return false;
 
     for(auto iter = tail.begin(), end = tail.end(); iter != end; ++iter)
@@ -213,6 +217,16 @@ public:
     inst->replaceAllUsesWith(replace);
     inst->eraseFromParent();
 
+    if(new_call != NULL)
+    {
+      // Force constructor inlining to see if fields can be stack-allocated.
+      InlineFunctionInfo ifi{};
+      InlineFunction(CallSite(new_call), ifi);
+
+      for(AllocaInst* inlined_alloca : ifi.StaticAllocas)
+        inlined_alloca->moveBefore(begin);
+    }
+
     print_transform(c, replace, "stack allocation");
     c->opt->check.stats.heap_alloc--;
     c->opt->check.stats.stack_alloc++;
@@ -221,7 +235,7 @@ public:
   }
 
   bool canStackAlloc(Instruction* alloc, DominatorTree& dt,
-    SmallVector<CallInst*, 4>& tail)
+    SmallVector<CallInst*, 4>& tail, Instruction** out_new_call)
   {
     // This is based on the pass in the LDC compiler.
     SmallVector<Use*, 16> work;
@@ -262,6 +276,12 @@ public:
               // Doesn't return any pointers, so it isn't captured.
               break;
             }
+          }
+
+          if(inst->getMetadata("pony.newcall") != NULL)
+          {
+            assert(*out_new_call == NULL);
+            *out_new_call = inst;
           }
 
           auto first = call.arg_begin();
@@ -849,7 +869,7 @@ static void optimise(compile_t* c, bool pony_specific)
   Module* m = unwrap(c->module);
   TargetMachine* machine = reinterpret_cast<TargetMachine*>(c->machine);
 
-#if PONY_LLVM >= 309
+#if PONY_LLVM >= 307
   llvm::legacy::PassManager lpm;
   llvm::legacy::PassManager mpm;
   llvm::legacy::FunctionPassManager fpm(m);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -121,6 +121,28 @@ LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file)
   return wrap(parseIRFile(file, diag, *unwrap(ctx)).release());
 }
 
+// From LLVM internals.
+static MDNode* extractMDNode(MetadataAsValue* mdv)
+{
+  Metadata* md = mdv->getMetadata();
+  assert(isa<MDNode>(md) || isa<ConstantAsMetadata>(md));
+
+  MDNode* n = dyn_cast<MDNode>(md);
+  if(n != NULL)
+    return n;
+
+  return MDNode::get(mdv->getContext(), md);
+}
+
+void LLVMSetMetadataStr(LLVMValueRef inst, const char* str, LLVMValueRef node)
+{
+  assert(node != NULL);
+
+  MDNode* n = extractMDNode(unwrap<MetadataAsValue>(node));
+
+  unwrap<Instruction>(inst)->setMetadata(str, n);
+}
+
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32)
 {
   Module* m = unwrap(module);


### PR DESCRIPTION
This is an improvement for the heap2stack optimisation pass, which replaces heap allocations by stack allocations when possible. This modification allows the optimiser to know that the parent object of a given field is stack-allocated, which gives it more information to stack-allocate the field itself.

In order to get correct nocapture info in LLVM, which greatly helps the analysis in heap2stack, class constructors in generated code now return `void` instead of their receiver.