### PR TITLE
added note about win10-sdk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Invoke-WebRequest -Uri https://dl.bintray.com/pony-language/ponyc-win/ponyc-VERS
 .\ponyc-VERSION\ponyc\bin\ponyc.exe --version
 ```
 
+The Windows 10 SDK is required in order to build programs with ponyc on windows. It can be downloaded here:
+https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
 
 ## Mac OS X using [Homebrew](http://brew.sh)
 


### PR DESCRIPTION
On windows, the Windows 10 SDK is required in order to link to the Universal Windows App C Runtime Library (ucrt.lib)