### PR TITLE
On arch linux, you need --pic to compile with ponyc

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To build ponyc and compile helloworld:
 
 ```bash
 $ make config=release
-$ ./build/release/ponyc examples/helloworld
+$ ./build/release/ponyc --pic examples/helloworld
 ```
 
 ### Debian Jessie


### PR DESCRIPTION
When not using `--pic`, you may find the following errors:

```
/usr/bin/ld.gold: error: ./fb.o: requires dynamic R_X86_64_32 reloc against 'Array_String_val_Trace' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: ./fb.o: requires dynamic R_X86_64_32 reloc against 'pony_personality_v0' which may overflow at runtime; recompile with -fPIC
collect2: error: ld returned 1 exit status
Error:
unable to link: cc -o ./fb -O3 -march=x86-64 -mcx16 -fuse-ld=gold ./fb.o -L"/usr/lib/pony/0.2.1.20160513/bin/" -Wl,-rpath,"/usr/lib/pony/0.2.1.20160513/bin/" -L"/usr/lib/pony/0.2.1.20160513/bin/../packages" -Wl,-rpath,"/usr/lib/pony/0.2.1.20160513/bin/../packages" -L"/usr/local/lib" -Wl,-rpath,"/usr/local/lib" -Wl,--start-group -l"rt" -Wl,--end-group  -lponyrt -lpthread -ldl -lm
```