### PR TITLE
mkdocs: auto-scroll to current section

### DIFF
--- a/.docs/extra.js
+++ b/.docs/extra.js
@@ -1,0 +1,2 @@
+// https://github.com/mkdocs/mkdocs/issues/803
+$(document).ready(() => $('.wy-nav-side').scrollTop($('li.toctree-l1.current').offset().top - $('.wy-nav-side').offset().top - 80));

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,7 @@ after_success:
       build/release/ponyc packages/stdlib --docs;
       cd stdlib-docs;
       sudo -H pip install mkdocs;
+      cp ../.docs/extra.js docs/;
       sed -i '' 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' mkdocs.yml;
       mkdocs gh-deploy -v --clean --remote-name gh-token;
     fi;


### PR DESCRIPTION
Irregardless of which section was viewed, the navbar would be displayed _scrolled to the top_.   With this, it will scroll to the currently viewed section.

(The fix is adding a `$(document).ready()` to what was proposed in https://github.com/mkdocs/mkdocs/issues/803, because I found that this was needed to make it not fail. No JS expert, sorry.)

I've tried placing the file at its right place (`stdlib-docs/docs/`), but that directory apparently gets nuked by `ponyc ... --docs`, so it'll be copied there when it's needed.