### PR TITLE
Add a data structure managing unattached ASTs

### DIFF
--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -196,6 +196,20 @@ void ast_extract_children(ast_t* parent, size_t child_count,
       children); \
   }
 
+typedef struct unattached_asts_t
+{
+  ast_t** storage;
+  size_t count;
+  size_t alloc;
+} unattached_asts_t;
+
+void unattached_asts_init(unattached_asts_t* asts);
+
+void unattached_asts_put(unattached_asts_t* asts, ast_t* ast);
+
+void unattached_asts_clear(unattached_asts_t* asts);
+
+void unattached_asts_destroy(unattached_asts_t* asts);
 
 #if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)
 }


### PR DESCRIPTION
This data structure will allow us to create ASTs on the fly, pass them to code expecting attached ASTs (i.e. not freeing them after use) and free them afterwards.

This is not used anywhere in the compiler yet but it will be used in upcoming bugfixes.