### PR TITLE
Add option to elide extension in Path.base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- Path.base now provides option to omit the file extension from the result.
+
 ## [0.3.0] - 2016-08-26
 
 ### Fixed

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -200,18 +200,15 @@ class iso _TestPathBase is UnitTest
   fun name(): String => "files/Path.dir"
   fun apply(h: TestHelper) =>
 
-    ifdef windows then
-      let res1 = Path.base("\\dir\\base.ext")
-      let res2 = Path.base("\\dir\\")
-      h.assert_eq[String](res1, "base.ext")
-      h.assert_eq[String](res2, "")
-
+    (let p1, let p2) = ifdef windows then
+      ("\\dir\\base.ext", "\\dir\\")
     else
-      let res1 = Path.base("/dir/base.ext")
-      let res2 = Path.base("/dir/")
-      h.assert_eq[String](res1, "base.ext")
-      h.assert_eq[String](res2, "")
+      ("/dir/base.ext", "/dir/")
     end
+
+    h.assert_eq[String](Path.base(p1), "base.ext")
+    h.assert_eq[String](Path.base(p1, false), "base")
+    h.assert_eq[String](Path.base(p2), "")
 
 
 class iso _TestPathExt is UnitTest

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -321,15 +321,29 @@ primitive Path
       ("", path)
     end
 
-  fun base(path: String): String =>
+  fun base(path: String, with_ext: Bool = true): String =>
     """
     Return the path after the last separator, or the whole path if there is no
     separator.
+    If `with_ext` is `false`, the extension as defined by the `ext()` method
+    will be omitted from the result.
     """
-    try
+    let b = try
       path.trim(path.rfind(sep()).usize() + 1)
     else
       path
+    end
+
+    if with_ext then
+      b
+    else
+      let e_size = ext(b)
+
+      if e_size > 0 then
+        b.trim(0, b.size() - e_size - 1)
+      else
+        b
+      end
     end
 
   fun dir(path: String): String =>

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -337,7 +337,7 @@ primitive Path
     if with_ext then
       b
     else
-      let e_size = ext(b)
+      let e_size = ext(b).size()
 
       if e_size > 0 then
         b.trim(0, b.size() - e_size - 1)


### PR DESCRIPTION
This commit adds an optional `with_ext` method to `Path.base` in the
files package. The default retains the current behavior. If `false` is
passed, the extension is elided if present, as defined by the `ext()`
method.

Tests for `Path.base` are included in this commit.
