### PR TITLE
Handle invalid types in is_x_subtype_x functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Performance of Map.upsert and Map.update (don't replace existing keys)
 - Segmentation fault from allocating zero-sized struct.
 - Segmentation fault from serialising zero-sized array.
+- Assertion failure from type-checking in invalid programs.
 
 ### Added
 

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -646,6 +646,11 @@ static bool is_tuple_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
     case TK_ARROW:
       return is_tuple_sub_single(sub, super, errorf, opt);
 
+    case TK_FUNTYPE:
+    case TK_INFERTYPE:
+    case TK_ERRORTYPE:
+      return false;
+
     default: {}
   }
 
@@ -1045,6 +1050,11 @@ static bool is_nominal_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
     case TK_ARROW:
       return is_nominal_sub_arrow(sub, super, errorf, opt);
 
+    case TK_FUNTYPE:
+    case TK_INFERTYPE:
+    case TK_ERRORTYPE:
+      return false;
+
     default: {}
   }
 
@@ -1160,6 +1170,11 @@ static bool is_typeparam_base_sub_x(ast_t* sub, ast_t* super,
 
     case TK_ARROW:
       return is_typeparam_sub_arrow(sub, super, errorf, opt);
+
+    case TK_FUNTYPE:
+    case TK_INFERTYPE:
+    case TK_ERRORTYPE:
+      return false;
 
     default: {}
   }
@@ -1327,6 +1342,11 @@ static bool is_arrow_sub_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
 
     case TK_ARROW:
       return is_arrow_sub_arrow(sub, super, errorf, opt);
+
+    case TK_FUNTYPE:
+    case TK_INFERTYPE:
+    case TK_ERRORTYPE:
+      return false;
 
     default: {}
   }


### PR DESCRIPTION
This fix prevents an assertion failure that may occur if a program contains errors.

Closes #1163.