### PR TITLE
Add tests for Path methods

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -8,6 +8,12 @@ actor Main is TestList
     test(_TestMkdtemp)
     test(_TestWalk)
     test(_TestDirectoryOpen)
+    test(_TestPathJoin)
+    test(_TestPathRel)
+    test(_TestPathSplit)
+    test(_TestPathDir)
+    test(_TestPathExt)
+    test(_TestPathVolume)
 
 primitive _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath? =>
@@ -79,4 +85,95 @@ class iso _TestDirectoryOpen is UnitTest
       h.assert_false(file.valid())
     then
       h.assert_true(tmp.remove())
+    end
+
+
+class iso _TestPathJoin is UnitTest
+  fun name(): String => "files/Path.join"
+  fun apply(h: TestHelper) =>
+    let path1 = "//foo/bar///"
+    let path2 = "foo/./bar"
+    let path3 = "foo/../foo"
+    let path4 = "///foo///dir///base.ext"
+
+    var res1 = Path.join(path1, path2)
+    var res2 = Path.join(res1, path3)
+    var res3 = Path.join(res2, path4)
+
+    ifdef windows then
+      h.assert_eq[String](res1, "\\foo\\bar\\foo\\bar")
+      h.assert_eq[String](res2, "\\foo\\bar\\foo\\bar\\foo")
+      h.assert_eq[String](res3, "\\foo\\dir\\base.ext")
+    else
+      h.assert_eq[String](res1, "/foo/bar/foo/bar")
+      h.assert_eq[String](res2, "/foo/bar/foo/bar/foo")
+      h.assert_eq[String](res3, "/foo/dir/base.ext")
+    end
+
+
+class iso _TestPathRel is UnitTest
+  fun name(): String => "files/Path.rel"
+  fun apply(h: TestHelper) ? =>
+    let res = Path.rel("foo/bar", "foo/bar/baz")
+    h.assert_eq[String](res, "baz")
+
+
+class iso _TestPathSplit is UnitTest
+  fun name(): String => "files/Path.split"
+  fun apply(h: TestHelper) =>
+    var path = "/foo/bar/dir"
+  //  var path = "/foo/bar/dir/" // waiting for String.rfind fix
+    let expect = [
+  //    ("/foo/bar/dir", ""), // waiting for String.rfind fix
+      ("/foo/bar", "dir"),
+      ("/foo", "bar"),
+      (".", "foo"),
+      ("", ".")
+    ]
+
+    for parts in expect.values() do
+      let res = Path.split(path)
+      h.assert_eq[String](res._1, parts._1)
+      h.assert_eq[String](res._2, parts._2)
+      path = parts._1
+    end
+
+
+class iso _TestPathDir is UnitTest
+  fun name(): String => "files/Path.dir"
+  fun apply(h: TestHelper) =>
+    let res1 = Path.dir("/foo/bar/dir/base.ext")
+//    let res2 = Path.dir("/foo/bar/dir/") // waiting for String.rfind fix
+
+    ifdef windows then
+      h.assert_eq[String](res1, "\\foo\\bar\\dir")
+//      h.assert_eq[String](res2, "\\foo\\bar\\dir") // waiting for String.rfind
+    else
+      h.assert_eq[String](res1, "/foo/bar/dir")
+//      h.assert_eq[String](res2, "/foo/bar/dir") // waiting for String.rfind
+    end
+
+
+class iso _TestPathExt is UnitTest
+  fun name(): String => "files/Path.ext"
+  fun apply(h: TestHelper) =>
+    let res1 = Path.ext("/foo/bar/dir/base.ext")
+//    let res2 = Path.ext("/foo/bar/dir/base.ext/") // waiting for String.rfind
+
+    h.assert_eq[String](res1, "ext")
+//    h.assert_eq[String](res2, "") // waiting for String.rfind fix
+
+
+class iso _TestPathVolume is UnitTest
+  fun name(): String => "files/Path.volume"
+  fun apply(h: TestHelper) =>
+    let res1 = Path.volume("C:\\foo")
+    let res2 = Path.volume("\\foo")
+
+    ifdef windows then
+      h.assert_eq[String](res1, "C:")
+      h.assert_eq[String](res2, "")
+    else
+      h.assert_eq[String](res1, "")
+      h.assert_eq[String](res2, "")
     end

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -8,6 +8,7 @@ actor Main is TestList
     test(_TestMkdtemp)
     test(_TestWalk)
     test(_TestDirectoryOpen)
+    test(_TestPathClean)
     test(_TestPathJoin)
     test(_TestPathRel)
     test(_TestPathSplit)
@@ -88,6 +89,27 @@ class iso _TestDirectoryOpen is UnitTest
     end
 
 
+class iso _TestPathClean is UnitTest
+  fun name(): String => "files/Path.clean"
+  fun apply(h: TestHelper) =>
+    let res1 = Path.clean("//foo/bar///")
+    let res2 = Path.clean("foo/./bar")
+    let res3 = Path.clean("foo/../foo")
+    let res4 = Path.clean("///foo///bar///base.ext")
+
+    ifdef windows then
+      h.assert_eq[String](res1, "\\foo\\bar")
+      h.assert_eq[String](res2, "foo\\bar")
+      h.assert_eq[String](res3, "foo")
+      h.assert_eq[String](res4, "\\foo\\bar\\base.ext")
+    else
+      h.assert_eq[String](res1, "/foo/bar")
+      h.assert_eq[String](res2, "foo/bar")
+      h.assert_eq[String](res3, "foo")
+      h.assert_eq[String](res4, "/foo/bar/base.ext")
+    end
+
+
 class iso _TestPathJoin is UnitTest
   fun name(): String => "files/Path.join"
   fun apply(h: TestHelper) =>
@@ -96,9 +118,9 @@ class iso _TestPathJoin is UnitTest
     let path3 = "foo/../foo"
     let path4 = "///foo///dir///base.ext"
 
-    var res1 = Path.join(path1, path2)
-    var res2 = Path.join(res1, path3)
-    var res3 = Path.join(res2, path4)
+    let res1 = Path.join(path1, path2)
+    let res2 = Path.join(res1, path3)
+    let res3 = Path.join(res2, path4)
 
     ifdef windows then
       h.assert_eq[String](res1, "\\foo\\bar\\foo\\bar")

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -143,10 +143,9 @@ class iso _TestPathRel is UnitTest
 class iso _TestPathSplit is UnitTest
   fun name(): String => "files/Path.split"
   fun apply(h: TestHelper) =>
-    var path = "/foo/bar/dir"
-  //  var path = "/foo/bar/dir/" // waiting for String.rfind fix
+    var path = "/foo/bar/dir/"
     let expect = [
-  //    ("/foo/bar/dir", ""), // waiting for String.rfind fix
+      ("/foo/bar/dir", ""),
       ("/foo/bar", "dir"),
       ("/foo", "bar"),
       (".", "foo"),
@@ -165,14 +164,14 @@ class iso _TestPathDir is UnitTest
   fun name(): String => "files/Path.dir"
   fun apply(h: TestHelper) =>
     let res1 = Path.dir("/foo/bar/dir/base.ext")
-//    let res2 = Path.dir("/foo/bar/dir/") // waiting for String.rfind fix
+    let res2 = Path.dir("/foo/bar/dir/")
 
     ifdef windows then
       h.assert_eq[String](res1, "\\foo\\bar\\dir")
-//      h.assert_eq[String](res2, "\\foo\\bar\\dir") // waiting for String.rfind
+      h.assert_eq[String](res2, "\\foo\\bar\\dir")
     else
       h.assert_eq[String](res1, "/foo/bar/dir")
-//      h.assert_eq[String](res2, "/foo/bar/dir") // waiting for String.rfind
+      h.assert_eq[String](res2, "/foo/bar/dir")
     end
 
 
@@ -180,10 +179,10 @@ class iso _TestPathExt is UnitTest
   fun name(): String => "files/Path.ext"
   fun apply(h: TestHelper) =>
     let res1 = Path.ext("/foo/bar/dir/base.ext")
-//    let res2 = Path.ext("/foo/bar/dir/base.ext/") // waiting for String.rfind
+    let res2 = Path.ext("/foo/bar/dir/base.ext/")
 
     h.assert_eq[String](res1, "ext")
-//    h.assert_eq[String](res2, "") // waiting for String.rfind fix
+    h.assert_eq[String](res2, "")
 
 
 class iso _TestPathVolume is UnitTest

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -13,6 +13,7 @@ actor Main is TestList
     test(_TestPathRel)
     test(_TestPathSplit)
     test(_TestPathDir)
+    test(_TestPathBase)
     test(_TestPathExt)
     test(_TestPathVolume)
 
@@ -143,46 +144,93 @@ class iso _TestPathRel is UnitTest
 class iso _TestPathSplit is UnitTest
   fun name(): String => "files/Path.split"
   fun apply(h: TestHelper) =>
-    var path = "/foo/bar/dir/"
-    let expect = [
-      ("/foo/bar/dir", ""),
-      ("/foo/bar", "dir"),
-      ("/foo", "bar"),
-      (".", "foo"),
-      ("", ".")
-    ]
+    ifdef windows then
+      var path = "\\foo\\bar\\dir\\"
+      let expect = [
+        ("\\foo\\bar\\dir", ""),
+        ("\\foo\\bar", "dir"),
+        ("\\foo", "bar"),
+        (".", "foo"),
+        ("", ".")
+      ]
+      for parts in expect.values() do
+        let res = Path.split(path)
+        h.assert_eq[String](res._1, parts._1)
+        h.assert_eq[String](res._2, parts._2)
+        path = parts._1
+      end
 
-    for parts in expect.values() do
-      let res = Path.split(path)
-      h.assert_eq[String](res._1, parts._1)
-      h.assert_eq[String](res._2, parts._2)
-      path = parts._1
+    else
+      var path = "/foo/bar/dir/"
+      let expect = [
+        ("/foo/bar/dir", ""),
+        ("/foo/bar", "dir"),
+        ("/foo", "bar"),
+        (".", "foo"),
+        ("", ".")
+      ]
+      for parts in expect.values() do
+        let res = Path.split(path)
+        h.assert_eq[String](res._1, parts._1)
+        h.assert_eq[String](res._2, parts._2)
+        path = parts._1
+      end
     end
 
 
 class iso _TestPathDir is UnitTest
   fun name(): String => "files/Path.dir"
   fun apply(h: TestHelper) =>
-    let res1 = Path.dir("/foo/bar/dir/base.ext")
-    let res2 = Path.dir("/foo/bar/dir/")
 
     ifdef windows then
+      let res1 = Path.dir("\\foo\\bar\\dir\\base.ext")
+      let res2 = Path.dir("\\foo\\bar\\dir\\")
       h.assert_eq[String](res1, "\\foo\\bar\\dir")
       h.assert_eq[String](res2, "\\foo\\bar\\dir")
+
     else
+      let res1 = Path.dir("/foo/bar/dir/base.ext")
+      let res2 = Path.dir("/foo/bar/dir/")
       h.assert_eq[String](res1, "/foo/bar/dir")
       h.assert_eq[String](res2, "/foo/bar/dir")
+    end
+
+
+class iso _TestPathBase is UnitTest
+  fun name(): String => "files/Path.dir"
+  fun apply(h: TestHelper) =>
+
+    ifdef windows then
+      let res1 = Path.base("\\dir\\base.ext")
+      let res2 = Path.base("\\dir\\")
+      h.assert_eq[String](res1, "base.ext")
+      h.assert_eq[String](res2, "")
+
+    else
+      let res1 = Path.base("/dir/base.ext")
+      let res2 = Path.base("/dir/")
+      h.assert_eq[String](res1, "base.ext")
+      h.assert_eq[String](res2, "")
     end
 
 
 class iso _TestPathExt is UnitTest
   fun name(): String => "files/Path.ext"
   fun apply(h: TestHelper) =>
-    let res1 = Path.ext("/foo/bar/dir/base.ext")
-    let res2 = Path.ext("/foo/bar/dir/base.ext/")
+    ifdef windows then
+      let res1 = Path.ext("\\dir\\base.ext")
+      let res2 = Path.ext("\\dir\\base.ext\\")
 
-    h.assert_eq[String](res1, "ext")
-    h.assert_eq[String](res2, "")
+      h.assert_eq[String](res1, "ext")
+      h.assert_eq[String](res2, "")
+
+    else
+      let res1 = Path.ext("/dir/base.ext")
+      let res2 = Path.ext("/dir/base.ext/")
+
+      h.assert_eq[String](res1, "ext")
+      h.assert_eq[String](res2, "")
+    end
 
 
 class iso _TestPathVolume is UnitTest


### PR DESCRIPTION
Some tests are commented out because of `String.rfind` issue #1164. If that can be resolved first, I'll update this commit before it is merged.