### PR TITLE
Fix Path.join invalid negative indexing on string

### DIFF
--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -55,7 +55,7 @@ primitive Path
       clean(next_path)
     else
       try
-        if is_sep(path(-1)) then
+        if is_sep(path(path.size()-1)) then
           if is_sep(next_path(0)) then
             return clean(path + next_path.substring(1))
           else


### PR DESCRIPTION
This is part of the failures in the PR for the `files.Path` tests.