### PR TITLE
CPU pinning enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Performance of Map.upsert and Map.update (don't replace existing keys)
 - Segmentation fault from allocating zero-sized struct.
 - Segmentation fault from serialising zero-sized array.
+- Make sure all scheduler threads are pinned to CPU cores; on Linux/FreeBSD this wasn't the case for the main thread.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - `from_iso_array` constructor on `String`.
 - `Sort` primitive
 - PonyBench package
+- `--ponypinasio` runtime option for pinning asio thread to a cpu core.
 
 ### Changed
 

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -14,6 +14,7 @@ struct asio_base_t
 };
 
 static asio_base_t running_base;
+static uint32_t asio_cpu;
 
 /** Start an asynchronous I/O event mechanism.
  *
@@ -30,15 +31,16 @@ asio_backend_t* ponyint_asio_get_backend()
   return running_base.backend;
 }
 
-void ponyint_asio_init()
+void ponyint_asio_init(uint32_t cpu)
 {
+  asio_cpu = cpu;
   running_base.backend = ponyint_asio_backend_init();
 }
 
 bool ponyint_asio_start()
 {
-  if(!pony_thread_create(&running_base.tid, ponyint_asio_backend_dispatch, -1,
-    running_base.backend))
+  if(!pony_thread_create(&running_base.tid, ponyint_asio_backend_dispatch,
+    asio_cpu, running_base.backend))
     return false;
 
   return true;

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -50,7 +50,7 @@ typedef struct asio_base_t asio_base_t;
 asio_backend_t* ponyint_asio_backend_init();
 
 /// Call this when the scheduler is initialised.
-void ponyint_asio_init();
+void ponyint_asio_init(uint32_t cpu);
 
 /// Call this when the scheduler runs its threads.
 bool ponyint_asio_start();

--- a/src/libponyrt/sched/cpu.h
+++ b/src/libponyrt/sched/cpu.h
@@ -10,7 +10,7 @@ PONY_EXTERN_C_BEGIN
 
 uint32_t ponyint_cpu_count();
 
-void ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler);
+uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler, bool pinasio);
 
 void ponyint_cpu_affinity(uint32_t cpu);
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -381,7 +381,7 @@ static void ponyint_sched_shutdown()
   ponyint_mpmcq_destroy(&inject);
 }
 
-pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield)
+pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pinasio)
 {
   use_yield = !noyield;
 
@@ -394,7 +394,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield)
     scheduler_count * sizeof(scheduler_t));
   memset(scheduler, 0, scheduler_count * sizeof(scheduler_t));
 
-  ponyint_cpu_assign(scheduler_count, scheduler);
+  uint32_t asio_cpu = ponyint_cpu_assign(scheduler_count, scheduler, pinasio);
 
   for(uint32_t i = 0; i < scheduler_count; i++)
   {
@@ -406,7 +406,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield)
 
   this_scheduler = &scheduler[0];
   ponyint_mpmcq_init(&inject);
-  ponyint_asio_init();
+  ponyint_asio_init(asio_cpu);
 
   return &scheduler[0].ctx;
 }

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -312,10 +312,7 @@ static void ponyint_sched_shutdown()
 {
   uint32_t start;
 
-  if(scheduler[0].tid == pony_thread_self())
-    start = 1;
-  else
-    start = 0;
+  start = 0;
 
   for(uint32_t i = start; i < scheduler_count; i++)
     pony_thread_join(scheduler[i].tid);
@@ -423,15 +420,11 @@ bool ponyint_sched_start(bool library)
 
   detect_quiescence = !library;
 
-  uint32_t start;
+  uint32_t start = 0;
 
   if(library)
   {
-    start = 0;
     pony_register_thread();
-  } else {
-    start = 1;
-    scheduler[0].tid = pony_thread_self();
   }
 
   for(uint32_t i = start; i < scheduler_count; i++)
@@ -443,7 +436,6 @@ bool ponyint_sched_start(bool library)
 
   if(!library)
   {
-    run_thread(&scheduler[0]);
     ponyint_sched_shutdown();
   }
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -75,7 +75,7 @@ struct scheduler_t
   messageq_t mq;
 };
 
-pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield);
+pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pinasio);
 
 bool ponyint_sched_start(bool library);
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -18,6 +18,7 @@ typedef struct options_t
   double gc_factor;
   bool noyield;
   bool noblock;
+  bool pinasio;
 } options_t;
 
 // global data
@@ -32,7 +33,8 @@ enum
   OPT_GCINITIAL,
   OPT_GCFACTOR,
   OPT_NOYIELD,
-  OPT_NOBLOCK
+  OPT_NOBLOCK,
+  OPT_PINASIO
 };
 
 static opt_arg_t args[] =
@@ -45,6 +47,7 @@ static opt_arg_t args[] =
   {"ponygcfactor", 0, OPT_ARG_REQUIRED, OPT_GCFACTOR},
   {"ponynoyield", 0, OPT_ARG_NONE, OPT_NOYIELD},
   {"ponynoblock", 0, OPT_ARG_NONE, OPT_NOBLOCK},
+  {"ponypinasio", 0, OPT_ARG_NONE, OPT_PINASIO},
 
   OPT_ARGS_FINISH
 };
@@ -67,6 +70,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_GCFACTOR: opt->gc_factor = atof(s.arg_val); break;
       case OPT_NOYIELD: opt->noyield = true; break;
       case OPT_NOBLOCK: opt->noblock = true; break;
+      case OPT_PINASIO: opt->pinasio = true; break;
 
       default: exit(-1);
     }
@@ -99,7 +103,7 @@ int pony_init(int argc, char** argv)
   ponyint_actor_setnoblock(opt.noblock);
 
   pony_exitcode(0);
-  pony_ctx_t* ctx = ponyint_sched_init(opt.threads, opt.noyield);
+  pony_ctx_t* ctx = ponyint_sched_init(opt.threads, opt.noyield, opt.pinasio);
   ponyint_cycle_create(ctx,
     opt.cd_min_deferred, opt.cd_max_deferred, opt.cd_conf_group);
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -189,6 +189,8 @@ static void usage()
     "                  point value. Defaults to 2.0.\n"
     "  --ponynoyield   Do not yield the CPU when no work is available.\n"
     "  --ponynoblock   Do not send block messages to the cycle detector.\n"
+    "  --ponypinasio   Pin the ASIO thread to a CPU the way Scheduler\n"
+    "                  threads are pinned to CPUs.\n"
     );
 }
 


### PR DESCRIPTION
* Currently, the main/initial scheduler thread when not running in
  library mode is not pinned to a CPU core on Linux/FreeBSD and it
  is also not assigned to the most appropriate stack space for
  NUMA efficiency. This PR changes behavior so the main thread
  is not used as a scheduler thread any longer and instead starts
  up another scheduler thread which is properly CPU pinned and
  NUMA space aligned ensuring that all scheduler threads are
  appropriately CPU pinned and NUMA space aligned.
* Add `--ponypinasio` runtime option for cpu pinning asio thread
* Behavior when the option is not specified is same as always which
  is that the asio thread is not pinned to a cpu core/numa node
  and can be moved from one core to another by the OS scheduler.
* When the option is specified, the asio thread is pinned to
  a cpu core/numa node. This is unrelated to the number of scheulder
  threads and the assumption is that this is an advanced runtime
  feature that an oprator with appropriate knowledge and desire
  can use in concert with `--ponythreads` to ensure thread pinning
  and isolation for a pony application.

Validated on linux via use of `ps` to confirm threads were running on the right CPUs. Not sure how to validate on OS X because I'm not sure how to view thread CPU assignment there. Didn't validate on Windows but, in theory, there shouldn't be any issues.

Thanks to @sylvanc for guidance on how to implement the changes.