### PR TITLE
Fix and future-proof Path.clean separator removal

### DIFF
--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -174,8 +174,8 @@ primitive Path
     end
 
     try
-      if is_sep(s(-1)) then
-        s.delete(-1, 1)
+      if is_sep(s(s.size()-1)) then
+        s.delete(-1, sep().size())
       end
     end
 


### PR DESCRIPTION
Fixed invalid negative indexing on a string, and made the deletion of
the trailing separator future-proof by using the .size() of the
separator instead of the fixed value of 1.

----

Could have just included this with the `.join()` fix, since it's the same issue! 