### PR TITLE
Fix String.rfind failure and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Segmentation fault from allocating zero-sized struct.
 - Segmentation fault from serialising zero-sized array.
 - Assertion failure from type-checking in invalid programs.
+- Make the offset parameter of String.rfind inclusive of the given index.
 
 ### Added
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -513,10 +513,17 @@ actor Main
 
   fun rfind(s: String box, offset: ISize = -1, nth: USize = 0): ISize ? =>
     """
-    Return the index of n-th instance of s in the string starting from the end.
-    Raise an error if there is no n-th occurence of s or s is empty.
+    Return the index of n-th instance of `s` in the string starting from the
+    end. The `offset` represents the highest index to included in the search.
+    Raise an error if there is no n-th occurence of `s` or `s` is empty.
     """
-    var i = offset_to_index(offset) - s._size
+    // Avoid pointless looping
+    if s._size == 0 then
+      error
+    end
+
+    var i = (offset_to_index(offset) + 1) - s._size
+
     var steps = nth + 1
 
     while i < _size do

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -39,6 +39,7 @@ actor Main is TestList
     test(_TestStringContains)
     test(_TestStringReadInt)
     test(_TestStringUTF32)
+    test(_TestStringRFind)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -765,6 +766,16 @@ class iso _TestStringUTF32 is UnitTest
     h.assert_eq[U8](0x9C, s(2))
     h.assert_eq[U8](0x8E, s(3))
     h.assert_eq[U32](0x2070E, s.utf32(0)._1)
+
+
+class iso _TestStringRFind is UnitTest
+  fun name(): String => "builtin/String.rfind"
+
+  fun apply(h: TestHelper) ? =>
+    let s = "-foo-bar-baz-"
+    h.assert_eq[ISize](s.rfind("-"), 12)
+    h.assert_eq[ISize](s.rfind("-", -2), 8)
+    h.assert_eq[ISize](s.rfind("-bar", 7), 4)
 
 
 class iso _TestArrayAppend is UnitTest


### PR DESCRIPTION
Update docstring and optimize edge case

The `offset` parameter is now included in the docstring.

A search pattern that is an empty string would previously cycle through
the entire string, and always fail in the end. This is now checked
before the loops.

Resolves #1164