### PR TITLE
Fix changelog for 0.3.0 to remote PRs merged after the release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to the Pony compiler and standard library will be documented
 ## [unreleased] - unreleased
 
 ### Fixed
+- Make sure all scheduler threads are pinned to CPU cores; on Linux/FreeBSD this wasn't the case for the main thread.
 
 ### Added
+- `--ponypinasio` runtime option for pinning asio thread to a cpu core.
 
 ### Changed
 
@@ -59,7 +61,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - Performance of Map.upsert and Map.update (don't replace existing keys)
 - Segmentation fault from allocating zero-sized struct.
 - Segmentation fault from serialising zero-sized array.
-- Make sure all scheduler threads are pinned to CPU cores; on Linux/FreeBSD this wasn't the case for the main thread.
 - Assertion failure from type-checking in invalid programs.
 - Make the offset parameter of String.rfind inclusive of the given index.
 
@@ -114,7 +115,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - `from_iso_array` constructor on `String`.
 - `Sort` primitive
 - PonyBench package
-- `--ponypinasio` runtime option for pinning asio thread to a cpu core.
 
 ### Changed
 


### PR DESCRIPTION
This PR moves the changelog entries for PR#1168 from `0.3.0` to `unreleased` since the PR was merged after the release was made.

The two additional PRs that were merged after the release was made are PR#1174 and PR#1166. These PRs didn't include changelog entries so there were no corresponding changelog entry changes required for them but it is probably a good idea to add changelog entries for them into the `unreleased` section.