### PR TITLE
Make Promises less restrictive

### DIFF
--- a/packages/ponybench/_auto_bench.pony
+++ b/packages/ponybench/_auto_bench.pony
@@ -1,7 +1,7 @@
 use "collections"
 use "promises"
 
-actor _AutoBench[A: Any #share]
+actor _AutoBench[A: Any #send]
   let _notify: _BenchNotify
   let _run: {(U64)} val
   let _auto_ops: _AutoOps
@@ -9,7 +9,7 @@ actor _AutoBench[A: Any #share]
   new create(
     notify: _BenchNotify,
     name: String,
-    f: ({(): A ?} val | {(): Promise[A] ?} val),
+    f: ({(): A^ ?} val | {(): Promise[A] ?} val),
     bench_time: U64 = 1_000_000_000,
     max_ops: U64 = 100_000_000
   ) =>
@@ -17,7 +17,7 @@ actor _AutoBench[A: Any #share]
     _run = recover
       lambda(ops: U64)(notify = this, name, f) =>
         match f
-        | let fn: {(): A ?} val =>
+        | let fn: {(): A^ ?} val =>
           _Bench[A](notify)(name, fn, ops)
         | let fn: {(): Promise[A] ?} val =>
           _BenchAsync[A](notify)(name, fn, ops)

--- a/packages/ponybench/_bench.pony
+++ b/packages/ponybench/_bench.pony
@@ -1,13 +1,13 @@
 use "collections"
 use "time"
 
-actor _Bench[A: Any #share]
+actor _Bench[A: Any #send]
   let _notify: _BenchNotify
 
   new create(notify: _BenchNotify) =>
     _notify = notify
 
-  be apply(name: String, f: {(): A ?} val, ops: U64) =>
+  be apply(name: String, f: {(): A^ ?} val, ops: U64) =>
     try
       @pony_triggergc[None](this)
       let start = Time.nanos()

--- a/packages/ponybench/_bench_async.pony
+++ b/packages/ponybench/_bench_async.pony
@@ -2,7 +2,7 @@ use "collections"
 use "promises"
 use "time"
 
-actor _BenchAsync[A: Any #share]
+actor _BenchAsync[A: Any #send]
   let _notify: _BenchNotify
 
   new create(notify: _BenchNotify) =>
@@ -15,9 +15,9 @@ actor _BenchAsync[A: Any #share]
       for i in Range[U64](0, ops) do
         let p = f()
         p.next[A](recover
-          lambda(a: A)(pn): A =>
+          lambda(a: A)(pn): A^ =>
             pn()
-            a
+            consume a
           end
         end)
       end

--- a/packages/ponybench/pony_bench.pony
+++ b/packages/ponybench/pony_bench.pony
@@ -75,7 +75,7 @@ actor PonyBench
   new create(env: Env) =>
     (_bs, _env) = (Array[(String, {()} val, String)], env)
 
-  be apply[A: Any #share](name: String, f: {(): A ?} val, ops: U64 = 0) =>
+  be apply[A: Any #send](name: String, f: {(): A^ ?} val, ops: U64 = 0) =>
     """
     Benchmark the function `f` by calling it repeatedly and output a simple
     average of the total run time over the amount of times `f` is called. This
@@ -97,7 +97,7 @@ actor PonyBench
     _bs.push((name, bf, ""))
     if _bs.size() < 2 then bf() end
 
-  be async[A: Any #share](
+  be async[A: Any #send](
     name: String,
     f: {(): Promise[A] ?} val,
     timeout: U64 = 0,
@@ -127,7 +127,7 @@ actor PonyBench
       try
         let p = f()
         p.next[A](recover
-          lambda(a: A)(ts, tt): A =>
+          lambda(a: A)(ts, tt): A^ =>
             ts.cancel(tt)
             a
           end

--- a/packages/promises/_then.pony
+++ b/packages/promises/_then.pony
@@ -1,4 +1,4 @@
-class _Then[A: Any #share, B: Any #share]
+class _Then[A: Any #send, B: Any #send]
   """
   A step in a promise pipeline.
   """
@@ -30,7 +30,7 @@ class _Then[A: Any #share, B: Any #share]
       _active = false
 
       try
-        _promise(_fulfill(value))
+        _promise(_fulfill(consume value))
       else
         _promise.reject()
       end
@@ -50,7 +50,7 @@ class _Then[A: Any #share, B: Any #share]
       end
     end
 
-interface _IThen[A: Any #share]
+interface _IThen[A: Any #send]
   """
   An interface representing an abstract Then. This allows for any Then that
   accepts an input of type A, regardless of the output type.

--- a/packages/promises/fulfill.pony
+++ b/packages/promises/fulfill.pony
@@ -1,28 +1,28 @@
 primitive _Pending
 primitive _Reject
 
-interface iso Fulfill[A: Any #share, B: Any #share]
+interface iso Fulfill[A: Any #send, B: Any #send]
   """
   A function from A to B that is called when a promise is fulfilled.
   """
-  fun ref apply(value: A): B ?
+  fun ref apply(value: A): B^ ?
 
-interface iso Reject[A: Any #share]
+interface iso Reject[A: Any #send]
   """
   A function on A that is called when a promise is rejected.
   """
-  fun ref apply(): A ?
+  fun ref apply(): A^ ?
 
-class iso FulfillIdentity[A: Any #share]
+class iso FulfillIdentity[A: Any #send]
   """
   An identity function for fulfilling promises.
   """
-  fun ref apply(value: A): A =>
+  fun ref apply(value: A): A^ =>
     consume value
 
-class iso RejectAlways[A: Any #share]
+class iso RejectAlways[A: Any #send]
   """
   A reject that always raises an error.
   """
-  fun ref apply(): A ? =>
+  fun ref apply(): A^ ? =>
     error


### PR DESCRIPTION
This PR changes `Promise[A: Any #share]` to `Promise[A: Any _#send]`, allowing iso values to be used. I don't think that this change requires an RFC since the use of promises has been extended rather than modified.