### PR TITLE
Thread pinning on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 work/
 output/
 _ReSharper.*
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 - Make sure all scheduler threads are pinned to CPU cores; on Linux/FreeBSD this wasn't the case for the main thread.
+- Account for both hyperthreading and NUMA locality when assigning scheduler threads to cores on Linux.
 
 ### Added
 - `--ponypinasio` runtime option for pinning asio thread to a cpu core.
+- `--ponynopin` runtime option for not pinning any threads at all.
 
 ### Changed
 

--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -29,17 +29,20 @@ typedef uint32_t(__stdcall *thread_fn) (void* arg);
 #endif
 
 #if defined(PLATFORM_IS_LINUX)
-void ponyint_numa_init();
+#include <sched.h>
+
+bool ponyint_numa_init();
 
 uint32_t ponyint_numa_cores();
 
-void ponyint_numa_core_list(uint32_t* list);
+uint32_t ponyint_numa_core_list(cpu_set_t* hw_cpus, cpu_set_t* ht_cpus,
+  uint32_t* list);
 
 uint32_t ponyint_numa_node_of_cpu(uint32_t cpu);
 #endif
 
-bool pony_thread_create(pony_thread_id_t* thread, thread_fn start, uint32_t cpu,
-  void* arg);
+bool pony_thread_create(pony_thread_id_t* thread, thread_fn start,
+  uint32_t cpu, void* arg);
 
 bool pony_thread_join(pony_thread_id_t thread);
 

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -132,7 +132,7 @@ uint32_t ponyint_numa_core_list(cpu_set_t* hw_cpus, cpu_set_t* ht_cpus,
   uint32_t* list)
 {
   if(!use_numa)
-    return;
+    return 0;
 
   // Create an ordered list of cpus. Physical CPUs grouped by NUMA node come
   // first, followed by hyperthreaded CPUs grouped by NUMA node.

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -91,17 +91,17 @@ void ponyint_cpu_init()
   cpu_set_t hw_cpus;
   cpu_set_t ht_cpus;
 
-  sched_getaffinity(0, sizeof(cpu_set_t), &mask);
+  sched_getaffinity(0, sizeof(cpu_set_t), &all_cpus);
   CPU_ZERO(&hw_cpus);
   CPU_ZERO(&ht_cpus);
 
-  avail_cpu_count = CPU_COUNT(&mask);
+  avail_cpu_count = CPU_COUNT(&all_cpus);
   uint32_t index = 0;
   uint32_t found = 0;
 
   while(found < avail_cpu_count)
   {
-    if(CPU_ISSET(index, &mask))
+    if(CPU_ISSET(index, &all_cpus))
     {
       if(cpu_physical(index))
         CPU_SET(index, &hw_cpus);

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -155,7 +155,7 @@ void ponyint_cpu_init()
       ptr = info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)malloc(len);
       continue;
     } else {
-      return 0;
+      return;
     }
   }
 

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -185,9 +185,20 @@ uint32_t ponyint_cpu_count()
 }
 
 uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
-  bool pinasio)
+  bool nopin, bool pinasio)
 {
   uint32_t asio_cpu = -1;
+
+  if(nopin)
+  {
+    for(uint32_t i = 0; i < count; i++)
+    {
+      scheduler[i].cpu = -1;
+      scheduler[i].node = 0;
+    }
+
+    return asio_cpu;
+  }
 
 #if defined(PLATFORM_IS_LINUX)
   for(uint32_t i = 0; i < count; i++)
@@ -240,9 +251,13 @@ uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
 
 void ponyint_cpu_affinity(uint32_t cpu)
 {
-#if defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_FREEBSD)
+  if(cpu == (uint32_t)-1)
+    return;
+
+#if defined(PLATFORM_IS_LINUX)
   // Affinity is handled when spawning the thread.
-  (void)cpu;
+#elif defined(PLATFORM_IS_FREEBSD)
+  // No pinning, since we cannot yet determine hyperthreads vs physical cores.
 #elif defined(PLATFORM_IS_MACOSX)
   thread_affinity_policy_data_t policy;
   policy.affinity_tag = cpu;

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -118,7 +118,7 @@ void ponyint_cpu_init()
 
   if(ponyint_numa_init())
   {
-    uint32_t numa_count = ponyint_numa_cores()
+    uint32_t numa_count = ponyint_numa_cores();
 
     if(avail_cpu_count > numa_count)
       avail_cpu_count = numa_count;

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -19,6 +19,11 @@
 #include "cpu.h"
 #include "../mem/pool.h"
 
+#if defined(PLATFORM_IS_LINUX)
+static uint32_t avail_cpu_count;
+static uint32_t* avail_cpu_list;
+#endif
+
 #if defined(PLATFORM_IS_MACOSX) || defined(PLATFORM_IS_FREEBSD)
 
 #include <sys/types.h>
@@ -32,6 +37,8 @@ static uint32_t property(const char* key)
   return value;
 }
 #endif
+
+static uint32_t hw_cpu_count;
 
 #if defined(PLATFORM_IS_LINUX)
 static bool cpu_physical(uint32_t cpu)
@@ -55,36 +62,86 @@ static bool cpu_physical(uint32_t cpu)
 
   return true;
 }
-#endif
 
-uint32_t ponyint_cpu_count()
+static uint32_t cpu_add_mask_to_list(uint32_t i, cpu_set_t* mask)
 {
-#if defined(PLATFORM_IS_LINUX)
-  uint32_t count = ponyint_numa_cores();
+  uint32_t count = CPU_COUNT(mask);
+  uint32_t index = 0;
+  uint32_t found = 0;
 
-  if(count > 0)
-    return count;
-
-  uint32_t max = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
-  count = 0;
-
-  for(uint32_t i = 0; i < max; i++)
+  while(found < count)
   {
-    if(cpu_physical(i))
-      count++;
+    if(CPU_ISSET(index, mask))
+    {
+      avail_cpu_list[i++] = index;
+      found++;
+    }
+
+    index++;
   }
 
-  return count;
+  return i;
+}
+#endif
+
+void ponyint_cpu_init()
+{
+#if defined(PLATFORM_IS_LINUX)
+  cpu_set_t all_cpus;
+  cpu_set_t hw_cpus;
+  cpu_set_t ht_cpus;
+
+  sched_getaffinity(0, sizeof(cpu_set_t), &mask);
+  CPU_ZERO(&hw_cpus);
+  CPU_ZERO(&ht_cpus);
+
+  avail_cpu_count = CPU_COUNT(&mask);
+  uint32_t index = 0;
+  uint32_t found = 0;
+
+  while(found < avail_cpu_count)
+  {
+    if(CPU_ISSET(index, &mask))
+    {
+      if(cpu_physical(index))
+        CPU_SET(index, &hw_cpus);
+      else
+        CPU_SET(index, &ht_cpus);
+
+      found++;
+    }
+
+    index++;
+  }
+
+  hw_cpu_count = CPU_COUNT(&hw_cpus);
+
+  if(ponyint_numa_init())
+  {
+    uint32_t numa_count = ponyint_numa_cores()
+
+    if(avail_cpu_count > numa_count)
+      avail_cpu_count = numa_count;
+
+    avail_cpu_list = (uint32_t*)malloc(avail_cpu_count * sizeof(uint32_t));
+    avail_cpu_count =
+      ponyint_numa_core_list(&hw_cpus, &ht_cpus, avail_cpu_list);
+  } else {
+    avail_cpu_list = (uint32_t*)malloc(avail_cpu_count * sizeof(uint32_t));
+
+    uint32_t i = 0;
+    i = cpu_add_mask_to_list(i, &hw_cpus);
+    i = cpu_add_mask_to_list(i, &ht_cpus);
+  }
 #elif defined(PLATFORM_IS_FREEBSD)
-  return property("hw.ncpu");
+  hw_cpu_count = property("hw.ncpu");
 #elif defined(PLATFORM_IS_MACOSX)
-  return property("hw.physicalcpu");
+  hw_cpu_count = property("hw.physicalcpu");
 #elif defined(PLATFORM_IS_WINDOWS)
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION info = NULL;
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION ptr = NULL;
   DWORD len = 0;
   DWORD offset = 0;
-  uint32_t count = 0;
 
   while(true)
   {
@@ -107,7 +164,7 @@ uint32_t ponyint_cpu_count()
     switch(info->Relationship)
     {
       case RelationProcessorCore:
-        count++;
+        hw_cpu_count++;
         break;
 
       default: {}
@@ -119,65 +176,49 @@ uint32_t ponyint_cpu_count()
 
   if(ptr != NULL)
     free(ptr);
-
-  return count;
 #endif
 }
 
-uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler, bool pinasio)
+uint32_t ponyint_cpu_count()
+{
+  return hw_cpu_count;
+}
+
+uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
+  bool pinasio)
 {
   uint32_t asio_cpu = -1;
 
 #if defined(PLATFORM_IS_LINUX)
-  uint32_t cpu_count = ponyint_numa_cores();
-
-  if(cpu_count > 0)
+  for(uint32_t i = 0; i < count; i++)
   {
-    uint32_t* list = ponyint_pool_alloc_size(cpu_count * sizeof(uint32_t));
-    ponyint_numa_core_list(list);
-
-    for(uint32_t i = 0; i < count; i++)
-    {
-      uint32_t cpu = list[i % cpu_count];
-      scheduler[i].cpu = cpu;
-      scheduler[i].node = ponyint_numa_node_of_cpu(cpu);
-    }
-
-    // If pinning asio thread to a core is requested override the default
-    // asio_cpu of -1
-    if(pinasio)
-      asio_cpu = list[count % cpu_count];
-
-    ponyint_pool_free_size(cpu_count * sizeof(uint32_t), list);
-
-    return asio_cpu;
+    uint32_t cpu = avail_cpu_list[i % avail_cpu_count];
+    scheduler[i].cpu = cpu;
+    scheduler[i].node = ponyint_numa_node_of_cpu(cpu);
   }
-
-  // Physical cores come first, so assign in sequence.
-  cpu_count = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
 
   // If pinning asio thread to a core is requested override the default
   // asio_cpu of -1
   if(pinasio)
-    asio_cpu = count % cpu_count;
+    asio_cpu = avail_cpu_list[count % avail_cpu_count];
 
-  for(uint32_t i = 0; i < count; i++)
-  {
-    scheduler[i].cpu = i % cpu_count;
-    scheduler[i].node = 0;
-  }
+  avail_cpu_count = 0;
+  free(avail_cpu_list);
+  avail_cpu_list = NULL;
+
+  return asio_cpu;
 #elif defined(PLATFORM_IS_FREEBSD)
-  // Spread across available cores.
-  uint32_t cpu_count = property("hw.ncpu");
+  // FreeBSD does not currently do thread pinning, as we can't yet determine
+  // which cores are hyperthreads.
 
   // If pinning asio thread to a core is requested override the default
   // asio_cpu of -1
   if(pinasio)
-    asio_cpu = count % cpu_count;
+    asio_cpu = count % hw_cpu_count;
 
   for(uint32_t i = 0; i < count; i++)
   {
-    scheduler[i].cpu = i % cpu_count;
+    scheduler[i].cpu = i % hw_cpu_count;
     scheduler[i].node = 0;
   }
 #else

--- a/src/libponyrt/sched/cpu.h
+++ b/src/libponyrt/sched/cpu.h
@@ -13,7 +13,7 @@ void ponyint_cpu_init();
 uint32_t ponyint_cpu_count();
 
 uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
-  bool pinasio);
+  bool nopin, bool pinasio);
 
 void ponyint_cpu_affinity(uint32_t cpu);
 

--- a/src/libponyrt/sched/cpu.h
+++ b/src/libponyrt/sched/cpu.h
@@ -8,9 +8,12 @@
 
 PONY_EXTERN_C_BEGIN
 
+void ponyint_cpu_init();
+
 uint32_t ponyint_cpu_count();
 
-uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler, bool pinasio);
+uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
+  bool pinasio);
 
 void ponyint_cpu_affinity(uint32_t cpu);
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -381,7 +381,8 @@ static void ponyint_sched_shutdown()
   ponyint_mpmcq_destroy(&inject);
 }
 
-pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pinasio)
+pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
+  bool pinasio)
 {
   use_yield = !noyield;
 
@@ -394,7 +395,8 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pinasio)
     scheduler_count * sizeof(scheduler_t));
   memset(scheduler, 0, scheduler_count * sizeof(scheduler_t));
 
-  uint32_t asio_cpu = ponyint_cpu_assign(scheduler_count, scheduler, pinasio);
+  uint32_t asio_cpu = ponyint_cpu_assign(scheduler_count, scheduler, nopin,
+    pinasio);
 
   for(uint32_t i = 0; i < scheduler_count; i++)
   {

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -75,7 +75,8 @@ struct scheduler_t
   messageq_t mq;
 };
 
-pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pinasio);
+pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
+  bool pinasio);
 
 bool ponyint_sched_start(bool library);
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -19,6 +19,7 @@ typedef struct options_t
   double gc_factor;
   bool noyield;
   bool noblock;
+  bool nopin;
   bool pinasio;
 } options_t;
 
@@ -35,6 +36,7 @@ enum
   OPT_GCFACTOR,
   OPT_NOYIELD,
   OPT_NOBLOCK,
+  OPT_NOPIN,
   OPT_PINASIO
 };
 
@@ -48,6 +50,7 @@ static opt_arg_t args[] =
   {"ponygcfactor", 0, OPT_ARG_REQUIRED, OPT_GCFACTOR},
   {"ponynoyield", 0, OPT_ARG_NONE, OPT_NOYIELD},
   {"ponynoblock", 0, OPT_ARG_NONE, OPT_NOBLOCK},
+  {"ponynopin", 0, OPT_ARG_NONE, OPT_NOPIN},
   {"ponypinasio", 0, OPT_ARG_NONE, OPT_PINASIO},
 
   OPT_ARGS_FINISH
@@ -71,6 +74,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_GCFACTOR: opt->gc_factor = atof(s.arg_val); break;
       case OPT_NOYIELD: opt->noyield = true; break;
       case OPT_NOBLOCK: opt->noblock = true; break;
+      case OPT_NOPIN: opt->nopin = true; break;
       case OPT_PINASIO: opt->pinasio = true; break;
 
       default: exit(-1);
@@ -102,7 +106,10 @@ int pony_init(int argc, char** argv)
   ponyint_actor_setnoblock(opt.noblock);
 
   pony_exitcode(0);
-  pony_ctx_t* ctx = ponyint_sched_init(opt.threads, opt.noyield, opt.pinasio);
+
+  pony_ctx_t* ctx = ponyint_sched_init(opt.threads, opt.noyield, opt.nopin,
+    opt.pinasio);
+
   ponyint_cycle_create(ctx,
     opt.cd_min_deferred, opt.cd_max_deferred, opt.cd_conf_group);
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -1,4 +1,5 @@
 #include "scheduler.h"
+#include "cpu.h"
 #include "../mem/heap.h"
 #include "../actor/actor.h"
 #include "../gc/cycle.h"
@@ -94,9 +95,7 @@ int pony_init(int argc, char** argv)
 
   argc = parse_opts(argc, argv, &opt);
 
-#if defined(PLATFORM_IS_LINUX)
-  ponyint_numa_init();
-#endif
+  ponyint_cpu_init();
 
   ponyint_heap_setinitialgc(opt.gc_initial);
   ponyint_heap_setnextgcfactor(opt.gc_factor);

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -189,7 +189,10 @@ static void usage()
     "                  point value. Defaults to 2.0.\n"
     "  --ponynoyield   Do not yield the CPU when no work is available.\n"
     "  --ponynoblock   Do not send block messages to the cycle detector.\n"
-    "  --ponypinasio   Pin the ASIO thread to a CPU the way Scheduler\n"
+    "  --ponynopin     Do not pin scheduler threads or the ASIO thread, even\n"
+    "                  if --ponypinasio is set.\n"
+    "                  threads are pinned to CPUs.\n"
+    "  --ponypinasio   Pin the ASIO thread to a CPU the way scheduler\n"
     "                  threads are pinned to CPUs.\n"
     );
 }


### PR DESCRIPTION
Correctly pay attention to taskset and cgroups by using
sched_getaffinity() to determine an initial CPU set.

When building the available CPU list, pay attention to
both the distinction between physical and hyperthreaded
cores and NUMA core grouping.

Add --ponynopin to disable all thread pinning.
