### PR TITLE
Remove llvm.invariant.start from code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 - Make sure all scheduler threads are pinned to CPU cores; on Linux/FreeBSD this wasn't the case for the main thread.
 - Account for both hyperthreading and NUMA locality when assigning scheduler threads to cores on Linux.
+- Stop generating `llvm.invariant.start` intrinsic. It was causing various problems in code generation.
 
 ### Added
 - `--ponypinasio` runtime option for pinning asio thread to a cpu core.

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -39,7 +39,6 @@ LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);
 LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32);
 LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module);
 LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module);
-LLVMValueRef LLVMInvariantStart(LLVMModuleRef module);
 
 #define GEN_NOVALUE ((LLVMValueRef)1)
 

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -902,23 +902,3 @@ void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr)
   args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
   LLVMBuildCall(c->builder, func, args, 2, "");
 }
-
-void gencall_invariant_start(compile_t* c, LLVMValueRef ptr)
-{
-  LLVMValueRef func = LLVMInvariantStart(c->module);
-  LLVMTypeRef type = LLVMGetElementType(LLVMTypeOf(ptr));
-  size_t size = (size_t)LLVMABISizeOfType(c->target_data, type);
-
-  LLVMValueRef args[2];
-  // Check if we were passed a Pony Pointer. If so, the object is variable
-  // sized.
-  if(LLVMTypeOf(ptr) == c->void_ptr)
-  {
-    args[0] = LLVMConstInt(c->i64, -1, true);
-    args[1] = ptr;
-  } else {
-    args[0] = LLVMConstInt(c->i64, size, false);
-    args[1] = LLVMBuildBitCast(c->builder, ptr, c->void_ptr, "");
-  }
-  LLVMBuildCall(c->builder, func, args, 2, "");
-}

--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -36,8 +36,6 @@ void gencall_lifetime_start(compile_t* c, LLVMValueRef ptr);
 
 void gencall_lifetime_end(compile_t* c, LLVMValueRef ptr);
 
-void gencall_invariant_start(compile_t* c, LLVMValueRef ptr);
-
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -196,14 +196,6 @@ static void pointer_apply(compile_t* c, void* data, token_id cap)
       LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
   }
 
-  ast_t* typearg = ast_child(ast_childidx(t->ast, 2));
-  if(cap == TK_VAL || ((ast_id(typearg) == TK_NOMINAL) &&
-    (cap_single(typearg) == TK_VAL)))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(result)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, result);
-  }
-
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 }
@@ -225,13 +217,6 @@ static void pointer_update(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
     LLVMPointerType(t_elem->use_type, 0), "");
   LLVMValueRef loc = LLVMBuildInBoundsGEP(c->builder, elem_ptr, &index, 1, "");
   LLVMValueRef result = LLVMBuildLoad(c->builder, loc, "");
-
-  ast_t* typearg = ast_child(ast_childidx(t->ast, 2));
-  if((ast_id(typearg) == TK_NOMINAL) && (cap_single(typearg) == TK_VAL))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(result)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, result);
-  }
 
   LLVMBuildStore(c->builder, LLVMGetParam(m->func, 2), loc);
 
@@ -330,13 +315,6 @@ static void pointer_delete(compile_t* c, reach_type_t* t, reach_type_t* t_elem)
   LLVMValueRef elem_ptr = LLVMBuildBitCast(c->builder, ptr,
     LLVMPointerType(t_elem->use_type, 0), "");
   LLVMValueRef result = LLVMBuildLoad(c->builder, elem_ptr, "");
-
-  ast_t* typearg = ast_child(ast_childidx(t->ast, 2));
-  if((ast_id(typearg) == TK_NOMINAL) && (cap_single(typearg) == TK_VAL))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(result)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, result);
-  }
 
   LLVMValueRef src = LLVMBuildInBoundsGEP(c->builder, elem_ptr, &n, 1, "");
   src = LLVMBuildBitCast(c->builder, src, t->use_type, "");
@@ -536,11 +514,6 @@ static void maybe_apply(compile_t* c, void* data, token_id cap)
 
   LLVMPositionBuilderAtEnd(c->builder, is_false);
   result = LLVMBuildBitCast(c->builder, result, t_elem->use_type, "");
-
-  ast_t* typearg = ast_child(ast_childidx(t->ast, 2));
-  if(cap == TK_VAL || ((ast_id(typearg) == TK_NOMINAL) &&
-    (cap_single(typearg) == TK_VAL)))
-    gencall_invariant_start(c, result);
 
   LLVMBuildRet(c->builder, result);
 

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -104,14 +104,6 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
     LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
   }
 
-  ast_t* f_type = ast_type(ast);
-
-  if((ast_id(f_type) == TK_NOMINAL) && (cap_single(f_type) == TK_VAL))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(field)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, field);
-  }
-
   return field;
 }
 
@@ -121,14 +113,6 @@ LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast)
 
   if(field == NULL)
     return NULL;
-
-  ast_t* f_type = ast_type(ast);
-
-  if((ast_id(f_type) == TK_NOMINAL) && (cap_single(f_type) == TK_VAL))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(field)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, field);
-  }
 
   return field;
 }
@@ -243,14 +227,6 @@ LLVMValueRef gen_localload(compile_t* c, ast_t* ast)
     LLVMValueRef metadata = LLVMMDNodeInContext(c->context, NULL, 0);
     const char id[] = "invariant.load";
     LLVMSetMetadata(local, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
-  }
-
-  ast_t* l_type = ast_type(ast);
-
-  if((ast_id(l_type) == TK_NOMINAL) && (cap_single(l_type) == TK_VAL))
-  {
-    if(LLVMGetTypeKind(LLVMTypeOf(local)) == LLVMPointerTypeKind)
-      gencall_invariant_start(c, local);
   }
 
   return local;

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -180,10 +180,3 @@ LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module)
 
   return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_end, {}));
 }
-
-LLVMValueRef LLVMInvariantStart(LLVMModuleRef module)
-{
-  Module* m = unwrap(module);
-
-  return wrap(Intrinsic::getDeclaration(m, Intrinsic::invariant_start, {}));
-}


### PR DESCRIPTION
This intrinsic is causing problems in generated code.

Closes #1186.