### PR TITLE
Avoid inhibiting too much optimisations in DoNotOptimise

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -28,7 +28,9 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
 void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size);
 #endif
 #if PONY_LLVM >= 308
+void LLVMSetCallInaccessibleMemOnly(LLVMValueRef inst);
 void LLVMSetInaccessibleMemOrArgMemOnly(LLVMValueRef fun);
+void LLVMSetCallInaccessibleMemOrArgMemOnly(LLVMValueRef inst);
 #endif
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -598,7 +598,11 @@ static void donotoptimise_apply(compile_t* c, reach_type_t* t,
     false);
   LLVMValueRef asmstr = LLVMConstInlineAsm(void_fn, "", "imr,~{memory}", true,
     false);
-  LLVMBuildCall(c->builder, asmstr, &obj, 1, "");
+  LLVMValueRef call = LLVMBuildCall(c->builder, asmstr, &obj, 1, "");
+  LLVMAddInstrAttribute(call, 1, LLVMReadOnlyAttribute);
+#if PONY_LLVM >= 308
+  LLVMSetCallInaccessibleMemOrArgMemOnly(call);
+#endif
 
   LLVMBuildRet(c->builder, m->result->instance);
   codegen_finishfun(c);
@@ -613,7 +617,12 @@ static void donotoptimise_observe(compile_t* c, reach_type_t* t, token_id cap)
   LLVMTypeRef void_fn = LLVMFunctionType(c->void_type, NULL, 0, false);
   LLVMValueRef asmstr = LLVMConstInlineAsm(void_fn, "", "~{memory}", true,
     false);
-  LLVMBuildCall(c->builder, asmstr, NULL, 0, "");
+  LLVMValueRef call = LLVMBuildCall(c->builder, asmstr, NULL, 0, "");
+#if PONY_LLVM >= 308
+  LLVMSetCallInaccessibleMemOnly(call);
+#else
+  (void)call;
+#endif
 
   LLVMBuildRet(c->builder, m->result->instance);
   codegen_finishfun(c);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -6,11 +6,13 @@
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
 #  pragma warning(disable:4141)
+#  pragma warning(disable:4291)
 #endif
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Linker/Linker.h>
@@ -67,9 +69,35 @@ void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size)
 #endif
 
 #if PONY_LLVM >= 308
+void LLVMSetCallInaccessibleMemOnly(LLVMValueRef inst)
+{
+  Instruction* i = unwrap<Instruction>(inst);
+  if(CallInst* c = dyn_cast<CallInst>(i))
+    c->addAttribute(AttributeSet::FunctionIndex,
+      Attribute::InaccessibleMemOnly);
+  else if(InvokeInst* c = dyn_cast<InvokeInst>(i))
+    c->addAttribute(AttributeSet::FunctionIndex,
+      Attribute::InaccessibleMemOnly);
+  else
+    assert(0);
+}
+
 void LLVMSetInaccessibleMemOrArgMemOnly(LLVMValueRef fun)
 {
   unwrap<Function>(fun)->setOnlyAccessesInaccessibleMemOrArgMem();
+}
+
+void LLVMSetCallInaccessibleMemOrArgMemOnly(LLVMValueRef inst)
+{
+  Instruction* i = unwrap<Instruction>(inst);
+  if(CallInst* c = dyn_cast<CallInst>(i))
+    c->addAttribute(AttributeSet::FunctionIndex,
+      Attribute::InaccessibleMemOrArgMemOnly);
+  else if(InvokeInst* c = dyn_cast<InvokeInst>(i))
+    c->addAttribute(AttributeSet::FunctionIndex,
+      Attribute::InaccessibleMemOrArgMemOnly);
+  else
+    assert(0);
 }
 #endif
 


### PR DESCRIPTION
DoNotOptimise now only affects objects passed as arguments to `apply`.