### PR TITLE
Make atomic memory orders explicit

### DIFF
--- a/src/common/atomics.h
+++ b/src/common/atomics.h
@@ -36,72 +36,68 @@
 
 #ifdef __CLANG_ATOMICS
 
-#define _atomic_load(PTR) \
-  __c11_atomic_load(PTR, __ATOMIC_ACQUIRE)
+#define _atomic_load(PTR, ORDER) \
+  __c11_atomic_load(PTR, ORDER)
 
-#define _atomic_store(PTR, VAL) \
-  __c11_atomic_store(PTR, VAL, __ATOMIC_RELEASE)
+#define _atomic_store(PTR, VAL, ORDER) \
+  __c11_atomic_store(PTR, VAL, ORDER)
 
-#define _atomic_exchange(PTR, VAL) \
-  __c11_atomic_exchange(PTR, VAL, __ATOMIC_RELAXED)
+#define _atomic_exchange(PTR, VAL, ORDER) \
+  __c11_atomic_exchange(PTR, VAL, ORDER)
 
-#define _atomic_cas(PTR, EXPP, VAL) \
-  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, \
-    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
+  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, SUCC, FAIL)
 
-#define _atomic_dwcas(PTR, EXPP, VAL) \
-  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, \
-    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
+  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, SUCC, FAIL)
 
-#define _atomic_add(PTR, VAL) \
-  (__c11_atomic_fetch_add(PTR, VAL, __ATOMIC_RELEASE))
+#define _atomic_add(PTR, VAL, ORDER) \
+  (__c11_atomic_fetch_add(PTR, VAL, ORDER))
 
 #endif
 
 #ifdef __GNUC_ATOMICS
 
-#define _atomic_load(PTR) \
-  __atomic_load_n(PTR, __ATOMIC_ACQUIRE)
+#define _atomic_load(PTR, ORDER) \
+  __atomic_load_n(PTR, ORDER)
 
-#define _atomic_store(PTR, VAL) \
-  __atomic_store_n(PTR, VAL, __ATOMIC_RELEASE)
+#define _atomic_store(PTR, VAL, ORDER) \
+  __atomic_store_n(PTR, VAL, ORDER)
 
-#define _atomic_exchange(PTR, VAL) \
-  __atomic_exchange_n(PTR, VAL, __ATOMIC_RELAXED)
+#define _atomic_exchange(PTR, VAL, ORDER) \
+  __atomic_exchange_n(PTR, VAL, ORDER)
 
-#define _atomic_cas(PTR, EXPP, VAL) \
-  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, \
-    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
+  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, SUCC, FAIL)
 
-#define _atomic_dwcas(PTR, EXPP, VAL) \
-  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, \
-    __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)
+#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
+  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, SUCC, FAIL)
 
-#define _atomic_add(PTR, VAL) \
-  (__atomic_fetch_add(PTR, VAL, __ATOMIC_RELEASE))
+#define _atomic_add(PTR, VAL, ORDER) \
+  (__atomic_fetch_add(PTR, VAL, ORDER))
 
 #endif
 
 #ifdef __SYNC_ATOMICS
 
-#define _atomic_load(PTR) \
+#define _atomic_load(PTR, ORDER) \
   (*(PTR))
 
-#define _atomic_store(PTR, VAL) \
+#define _atomic_store(PTR, VAL, ORDER) \
   (*(PTR) = VAL)
 
-#define _atomic_exchange(PTR, VAL) \
+#define _atomic_exchange(PTR, VAL, ORDER) \
   __sync_lock_test_and_set(PTR, VAL);
 
-#define _atomic_cas(PTR, EXPP, VAL) \
+#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
   (*(EXPP) == \
     (*(EXPP) = __sync_val_compare_and_swap(PTR, *(EXPP), VAL)))
 
-#define _atomic_dwcas(PTR, EXPP, VAL) \
+#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
   (*(EXPP) == \
     (*(EXPP) = __sync_val_compare_and_swap(PTR, *(EXPP), VAL)))
 
-#define _atomic_add(PTR, VAL) \
+#define _atomic_add(PTR, VAL, ORDER) \
   (__sync_fetch_and_add(PTR, VAL))
 
 #endif
@@ -112,26 +108,26 @@
 #pragma intrinsic(_InterlockedCompareExchangePointer)
 #pragma intrinsic(_InterlockedCompareExchange128)
 
-#define _atomic_load(PTR) \
+#define _atomic_load(PTR, ORDER) \
   (*(PTR))
 
-#define _atomic_store(PTR, VAL) \
+#define _atomic_store(PTR, VAL, ORDER) \
   (*(PTR) = VAL)
 
-#define _atomic_exchange(PTR, VAL) \
+#define _atomic_exchange(PTR, VAL, ORDER) \
   (_InterlockedExchangePointer((PVOID volatile*)PTR, VAL))
 
-#define _atomic_cas(PTR, EXPP, VAL) \
+#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
   (*(EXPP) == \
     (*((PVOID*)(EXPP)) = \
       _InterlockedCompareExchangePointer( \
         (PVOID volatile*)PTR, VAL, *(EXPP))))
 
-#define _atomic_dwcas(PTR, EXPP, VAL) \
+#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
   (_InterlockedCompareExchange128( \
     (LONGLONG volatile*)PTR, VAL.high, VAL.low, (LONGLONG*)EXPP))
 
-#define _atomic_add(PTR, VAL) \
+#define _atomic_add(PTR, VAL, ORDER) \
   (InterlockedAdd64((LONGLONG volatile*)PTR, VAL) - VAL)
 
 #endif

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -147,7 +147,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   }
 
   // If we have been scheduled, the head will not be marked as empty.
-  pony_msg_t* head = _atomic_load(&actor->q.head);
+  pony_msg_t* head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
 
   while((msg = ponyint_messageq_pop(&actor->q)) != NULL)
   {
@@ -206,10 +206,10 @@ void ponyint_actor_destroy(pony_actor_t* actor)
   // as empty. Otherwise, it may spuriously see that tail and head are not
   // the same and fail to mark the queue as empty, resulting in it getting
   // rescheduled.
-  pony_msg_t* head = _atomic_load(&actor->q.head);
+  pony_msg_t* head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
 
   while(((uintptr_t)head & (uintptr_t)1) != (uintptr_t)1)
-    head = _atomic_load(&actor->q.head);
+    head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
 
   ponyint_messageq_destroy(&actor->q);
   ponyint_gc_destroy(&actor->gc);

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -48,7 +48,7 @@ bool ponyint_asio_start()
 
 bool ponyint_asio_stop()
 {
-  if(_atomic_load(&running_base.noisy_count) > 0)
+  if(_atomic_load(&running_base.noisy_count, __ATOMIC_ACQUIRE) > 0)
     return false;
 
   if(running_base.backend != NULL)
@@ -65,10 +65,10 @@ bool ponyint_asio_stop()
 
 void ponyint_asio_noisy_add()
 {
-  _atomic_add(&running_base.noisy_count, 1);
+  _atomic_add(&running_base.noisy_count, 1, __ATOMIC_RELEASE);
 }
 
 void ponyint_asio_noisy_remove()
 {
-  _atomic_add(&running_base.noisy_count, -1);
+  _atomic_add(&running_base.noisy_count, -1, __ATOMIC_RELEASE);
 }

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -217,7 +217,8 @@ void pony_asio_event_subscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = NULL;
 
-    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, ev))
+    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, ev,
+      __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
     {
       signal(sig, signal_handler);
       ev->fd = eventfd(0, EFD_NONBLOCK);
@@ -275,7 +276,8 @@ void pony_asio_event_unsubscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = ev;
 
-    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, NULL))
+    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, NULL,
+      __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
     {
       signal(sig, SIG_DFL);
       close(ev->fd);

--- a/src/libponyrt/mem/pagemap.c
+++ b/src/libponyrt/mem/pagemap.c
@@ -87,7 +87,7 @@ void ponyint_pagemap_set(const void* m, void* v)
       memset(p, 0, level[i].size);
       void** prev = NULL;
 
-      if(!_atomic_cas(pv, &prev, p))
+      if(!_atomic_cas(pv, &prev, p, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
       {
         ponyint_pool_free(level[i].size_index, p);
         *pv = prev;

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -493,7 +493,8 @@ static void pool_push(pool_local_t* thread, pool_global_t* global)
   {
     p->central = cmp.node;
     xchg.aba = cmp.aba + 1;
-  } while(!_atomic_dwcas(&global->central, &cmp.dw, xchg.dw));
+  } while(!_atomic_dwcas(&global->central, &cmp.dw, xchg.dw, __ATOMIC_ACQ_REL,
+    __ATOMIC_ACQUIRE));
 }
 
 static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
@@ -511,7 +512,8 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
 
     xchg.node = next->central;
     xchg.aba = cmp.aba + 1;
-  } while(!_atomic_dwcas(&global->central, &cmp.dw, xchg.dw));
+  } while(!_atomic_dwcas(&global->central, &cmp.dw, xchg.dw, __ATOMIC_ACQ_REL,
+    __ATOMIC_ACQUIRE));
 
   pool_item_t* p = (pool_item_t*)next;
 

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -33,8 +33,9 @@ void ponyint_mpmcq_push(mpmcq_t* q, void* data)
   node->data = data;
   node->next = NULL;
 
-  mpmcq_node_t* prev = (mpmcq_node_t*)_atomic_exchange(&q->head, node);
-  _atomic_store(&prev->next, node);
+  mpmcq_node_t* prev = (mpmcq_node_t*)_atomic_exchange(&q->head, node,
+    __ATOMIC_RELAXED);
+  _atomic_store(&prev->next, node, __ATOMIC_RELEASE);
 }
 
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
@@ -61,7 +62,7 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
   {
     // Get the next node rather than the tail. The tail is either a stub or has
     // already been consumed.
-    next = _atomic_load(&cmp.node->next);
+    next = _atomic_load(&cmp.node->next, __ATOMIC_ACQUIRE);
 
     // Bailout if we have no next node.
     if(next == NULL)
@@ -71,18 +72,19 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
     // fails, cmp becomes the new tail and we retry the loop.
     xchg.aba = cmp.aba + 1;
     xchg.node = next;
-  } while(!_atomic_dwcas(&q->tail.dw, &cmp.dw, xchg.dw));
+  } while(!_atomic_dwcas(&q->tail.dw, &cmp.dw, xchg.dw, __ATOMIC_ACQ_REL,
+    __ATOMIC_ACQUIRE));
 
   // We'll return the data pointer from the next node.
-  void* data = _atomic_load(&next->data);
+  void* data = _atomic_load(&next->data, __ATOMIC_ACQUIRE);
 
   // Since we will be freeing the old tail, we need to be sure no other
   // consumer is still reading the old tail. To do this, we set the data
   // pointer of our new tail to NULL, and we wait until the data pointer of
   // the old tail is NULL.
-  _atomic_store(&next->data, NULL);
+  _atomic_store(&next->data, NULL, __ATOMIC_RELEASE);
 
-  while(_atomic_load(&cmp.node->data) != NULL)
+  while(_atomic_load(&cmp.node->data, __ATOMIC_ACQUIRE) != NULL)
     ponyint_cpu_relax();
 
   // Free the old tail. The new tail is the next node.

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -446,7 +446,7 @@ bool ponyint_sched_start(bool library)
 
 void ponyint_sched_stop()
 {
-  _atomic_store(&detect_quiescence, true);
+  _atomic_store(&detect_quiescence, true, __ATOMIC_RELEASE);
   ponyint_sched_shutdown();
 }
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -127,7 +127,7 @@ int pony_start(bool library)
   if(library)
     return 0;
 
-  return _atomic_load(&exit_code);
+  return _atomic_load(&exit_code, __ATOMIC_ACQUIRE);
 }
 
 int pony_stop()
@@ -135,10 +135,10 @@ int pony_stop()
   ponyint_sched_stop();
   ponyint_os_sockets_final();
 
-  return _atomic_load(&exit_code);
+  return _atomic_load(&exit_code, __ATOMIC_ACQUIRE);
 }
 
 void pony_exitcode(int code)
 {
-  _atomic_store(&exit_code, code);
+  _atomic_store(&exit_code, code, __ATOMIC_RELEASE);
 }


### PR DESCRIPTION
Having the memory order right next to the atomic operation really helps clarity. Additionally, we may want to use different memory orders for the same operation type.

No functional changes here.