### PR TITLE
Display llvm version in --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Path.base now provides option to omit the file extension from the result.
 - Map.upsert returns value for upserted key rather than `this`.
+- `ponyc --version` now includes llvm version in its output.
 
 ## [0.3.0] - 2016-08-26
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
 LINKER_FLAGS = -march=$(arch)
 AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
-  -DPONY_VERSION=\"$(tag)\" -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
+  -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
+  -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
   -DPONY_BUILD_CONFIG=\"$(config)\"
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
@@ -202,6 +203,8 @@ endif
 ifndef LLVM_CONFIG
   $(error No LLVM installation found!)
 endif
+
+llvm_version = $(shell $(LLVM_CONFIG) --version)
 
 ifeq ($(runtime-bitcode),yes)
   ifeq (,$(shell $(CC) -v 2>&1 | grep clang))

--- a/premake5.lua
+++ b/premake5.lua
@@ -86,21 +86,25 @@
     }
 
     configuration "Debug"
+      local llvm_version = string.gsub(llvm_config("--version"), "\n", "")
       targetdir "build/debug"
       objdir "build/debug/obj"
       defines "DEBUG"
       defines "PONY_BUILD_CONFIG=\"debug\""
+      defines { "LLVM_VERSION=\"".. llvm_version .. "\"" }
       flags { "Symbols" }
 
     configuration "Release"
       targetdir "build/release"
       objdir "build/release/obj"
       defines "PONY_BUILD_CONFIG=\"release\""
+      defines { "LLVM_VERSION=\"" .. llvm_config("--version") .. "\"" }
 
     configuration "Profile"
       targetdir "build/profile"
       objdir "build/profile/obj"
       defines "PONY_BUILD_CONFIG=\"profile\""
+      defines { "LLVM_VERSION=\"" .. llvm_config("--version") .. "\"" }
 
     configuration "Release or Profile"
       defines "NDEBUG"

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -273,7 +273,8 @@ int main(int argc, char* argv[])
     switch(id)
     {
       case OPT_VERSION:
-        printf("%s [%s]\n", PONY_VERSION, PONY_BUILD_CONFIG);
+        printf("%s [%s] (llvm %s)\n", PONY_VERSION, PONY_BUILD_CONFIG,
+          LLVM_VERSION);
         return 0;
 
       case OPT_DEBUG: opt.release = false; break;


### PR DESCRIPTION
- It's an important piece of information in bug reports
- It's not trivial to find.
  - Multiple llvm versions are installed on some systems
  - I had to read the Makefile when I was asked (#901, #1186)

Maybe this change requires a further discussion (What if some tools rely on the output of --version? Is it better to add another option, say --debug-info containing more informations? ...)