### PR TITLE
Handle multiple constructor calls in heap2stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Account for both hyperthreading and NUMA locality when assigning scheduler threads to cores on Linux.
 - Stop generating `llvm.invariant.start` intrinsic. It was causing various problems in code generation.
 - Buffer overflow triggerable by very long `ponyc` filename (issue #1177).
+- Assertion failure in optimisation passes.
 
 ### Added
 - `--ponypinasio` runtime option for pinning asio thread to a cpu core.

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -456,13 +456,12 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     if(ast_canerror(ast) && (c->frame->invoke_target != NULL))
       r = invoke_fun(c, func, args, i, "", true);
     else
-    {
       r = codegen_call(c, func, args, i);
-      if(is_new_call)
-      {
-        LLVMValueRef md = LLVMMDNodeInContext(c->context, NULL, 0);
-        LLVMSetMetadataStr(r, "pony.newcall", md);
-      }
+
+    if(is_new_call)
+    {
+      LLVMValueRef md = LLVMMDNodeInContext(c->context, NULL, 0);
+      LLVMSetMetadataStr(r, "pony.newcall", md);
     }
 
     codegen_debugloc(c, NULL);


### PR DESCRIPTION
This can happen because of embedded fields and other passes merging function calls.

Closes #1191.