### PR TITLE
Use a store-release in ponyint_mpmc_push_single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Stop generating `llvm.invariant.start` intrinsic. It was causing various problems in code generation.
 - Buffer overflow triggerable by very long `ponyc` filename (issue #1177).
 - Assertion failure in optimisation passes.
+- Race condition in scheduler queues on weakly-ordered architectures.
 
 ### Added
 - `--ponypinasio` runtime option for pinning asio thread to a cpu core.

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -44,10 +44,10 @@ void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
   node->data = data;
   node->next = NULL;
 
-  // If we have a single producer, don't use an atomic instruction.
+  // If we have a single producer, operations on the head need not be atomic.
   mpmcq_node_t* prev = q->head;
   q->head = node;
-  prev->next = node;
+  _atomic_store(&prev->next, node, __ATOMIC_RELEASE);
 }
 
 void* ponyint_mpmcq_pop(mpmcq_t* q)


### PR DESCRIPTION
A memory barrier on both side of a concurrent operation is required when publishing data.

@pdtwonotes Can you try and see if it fixes #1000 for you?