### PR TITLE
Refactor atomic operations usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,59 +11,119 @@ sudo: required
 matrix:
   include:
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=debug
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=release
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.8.0"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=debug
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
       env:
         - LLVM_VERSION="3.8.0"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.6"
         - config=debug
+        - CC1=clang-3.6
+        - CXX1=clang++-3.6
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.6"
         - config=release
+        - CC1=clang-3.6
+        - CXX1=clang++-3.6
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
+        - CC1=clang-3.7
+        - CXX1=clang++-3.7
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
+        - CC1=clang-3.7
+        - CXX1=clang++-3.7
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.8"
         - config=debug
+        - CC1=clang-3.8
+        - CXX1=clang++-3.8
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
+        - CC1=clang-3.8
+        - CXX1=clang++-3.8
 
 rvm:
   - 2.2.3
@@ -108,7 +168,7 @@ install:
     fi;
 
 script:
-  - make test
+  - make CC=$CC1 CXX=$CXX1 test
 
 notifications:
   email:

--- a/src/common/atomics.h
+++ b/src/common/atomics.h
@@ -1,135 +1,29 @@
 #ifndef PLATFORM_ATOMICS_H
 #define PLATFORM_ATOMICS_H
 
-/** Intrinsics for atomic memory operations.
- *
- * This file provides cross-platform atomic instructions. It is based on the
- * FreeBSD stdatomic.h, the Clang stdatomic.h, and the GCC stdatomic.h. It
- * does not replicate the correct stdatomic.h interface because it doesn't
- * appear to be possible to do so when using MSVC on Windows.
- *
- * The Clang __c11_atomic_* operations are not used, because there are cases
- * (such as pagemap) where some operations on a type need to be atomic and
- * some non-atomic. Requiring an _Atomic(T) type prevents this.
- */
+// C and C++ atomics are incompatible and MSVC has no support of C atomics.
+// This header provides a workaround.
 
-#if defined(PLATFORM_IS_CLANG_OR_GCC)
-  #if defined(__clang__)
-    #define PONY_CLANG (__clang_major__ * 100) + __clang_minor__
-    #if defined(__apple_build_version__) && (PONY_CLANG >= 601)
-      #define __GNUC_ATOMICS
-    #elif !defined(__apple_build_version__) && (PONY_CLANG >= 306)
-      #define __GNUC_ATOMICS
-    #else
-      #define __SYNC_ATOMICS
-    #endif
-  #elif __GNUC_PREREQ(4, 7)
-    #define __GNUC_ATOMICS
-  #elif defined(__GNUC__)
-    #define __SYNC_ATOMICS
-  #else
-    #error "Please use clang >= 3.5 or gcc >= 4.7"
-  #endif
-#elif defined(PLATFORM_IS_VISUAL_STUDIO)
-  #define __MSVC_ATOMICS
-#endif
+#ifdef __cplusplus
+#  include <atomic>
+#  define ATOMIC_TYPE(T) std::atomic<T>
+using std::memory_order_relaxed;
+using std::memory_order_consume;
+using std::memory_order_acquire;
+using std::memory_order_release;
+using std::memory_order_acq_rel;
+using std::memory_order_seq_cst;
 
-#ifdef __CLANG_ATOMICS
-
-#define _atomic_load(PTR, ORDER) \
-  __c11_atomic_load(PTR, ORDER)
-
-#define _atomic_store(PTR, VAL, ORDER) \
-  __c11_atomic_store(PTR, VAL, ORDER)
-
-#define _atomic_exchange(PTR, VAL, ORDER) \
-  __c11_atomic_exchange(PTR, VAL, ORDER)
-
-#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
-  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, SUCC, FAIL)
-
-#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
-  __c11_atomic_compare_exchange_strong(PTR, EXPP, VAL, SUCC, FAIL)
-
-#define _atomic_add(PTR, VAL, ORDER) \
-  (__c11_atomic_fetch_add(PTR, VAL, ORDER))
-
-#endif
-
-#ifdef __GNUC_ATOMICS
-
-#define _atomic_load(PTR, ORDER) \
-  __atomic_load_n(PTR, ORDER)
-
-#define _atomic_store(PTR, VAL, ORDER) \
-  __atomic_store_n(PTR, VAL, ORDER)
-
-#define _atomic_exchange(PTR, VAL, ORDER) \
-  __atomic_exchange_n(PTR, VAL, ORDER)
-
-#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
-  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, SUCC, FAIL)
-
-#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
-  __atomic_compare_exchange_n(PTR, EXPP, VAL, 0, SUCC, FAIL)
-
-#define _atomic_add(PTR, VAL, ORDER) \
-  (__atomic_fetch_add(PTR, VAL, ORDER))
-
-#endif
-
-#ifdef __SYNC_ATOMICS
-
-#define _atomic_load(PTR, ORDER) \
-  (*(PTR))
-
-#define _atomic_store(PTR, VAL, ORDER) \
-  (*(PTR) = VAL)
-
-#define _atomic_exchange(PTR, VAL, ORDER) \
-  __sync_lock_test_and_set(PTR, VAL);
-
-#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
-  (*(EXPP) == \
-    (*(EXPP) = __sync_val_compare_and_swap(PTR, *(EXPP), VAL)))
-
-#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
-  (*(EXPP) == \
-    (*(EXPP) = __sync_val_compare_and_swap(PTR, *(EXPP), VAL)))
-
-#define _atomic_add(PTR, VAL, ORDER) \
-  (__sync_fetch_and_add(PTR, VAL))
-
-#endif
-
-#ifdef __MSVC_ATOMICS
-
-#pragma intrinsic(_InterlockedExchangePointer)
-#pragma intrinsic(_InterlockedCompareExchangePointer)
-#pragma intrinsic(_InterlockedCompareExchange128)
-
-#define _atomic_load(PTR, ORDER) \
-  (*(PTR))
-
-#define _atomic_store(PTR, VAL, ORDER) \
-  (*(PTR) = VAL)
-
-#define _atomic_exchange(PTR, VAL, ORDER) \
-  (_InterlockedExchangePointer((PVOID volatile*)PTR, VAL))
-
-#define _atomic_cas(PTR, EXPP, VAL, SUCC, FAIL) \
-  (*(EXPP) == \
-    (*((PVOID*)(EXPP)) = \
-      _InterlockedCompareExchangePointer( \
-        (PVOID volatile*)PTR, VAL, *(EXPP))))
-
-#define _atomic_dwcas(PTR, EXPP, VAL, SUCC, FAIL) \
-  (_InterlockedCompareExchange128( \
-    (LONGLONG volatile*)PTR, VAL.high, VAL.low, (LONGLONG*)EXPP))
-
-#define _atomic_add(PTR, VAL, ORDER) \
-  (InterlockedAdd64((LONGLONG volatile*)PTR, VAL) - VAL)
-
+using std::atomic_load_explicit;
+using std::atomic_store_explicit;
+using std::atomic_exchange_explicit;
+using std::atomic_compare_exchange_weak_explicit;
+using std::atomic_compare_exchange_strong_explicit;
+using std::atomic_fetch_add_explicit;
+using std::atomic_fetch_sub_explicit;
+#else
+#  include <stdatomic.h>
+#  define ATOMIC_TYPE(T) T _Atomic
 #endif
 
 #endif

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -270,14 +270,6 @@ inline uint64_t __pony_ffsl(uint64_t x)
             __builtin_choose_expr(COND, THEN, ELSE)
 #endif
 
-#if defined(PLATFORM_IS_ILP32)
-typedef int64_t dw_t;
-#elif defined(PLATFORM_IS_VISUAL_STUDIO)
-typedef struct dw_t { uint64_t low; int64_t high; } dw_t;
-#else
-typedef __int128_t dw_t;
-#endif
-
 #include "atomics.h"
 #include "threads.h"
 #include "paths.h"

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -147,7 +147,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   }
 
   // If we have been scheduled, the head will not be marked as empty.
-  pony_msg_t* head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
+  pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_acquire);
 
   while((msg = ponyint_messageq_pop(&actor->q)) != NULL)
   {
@@ -206,10 +206,10 @@ void ponyint_actor_destroy(pony_actor_t* actor)
   // as empty. Otherwise, it may spuriously see that tail and head are not
   // the same and fail to mark the queue as empty, resulting in it getting
   // rescheduled.
-  pony_msg_t* head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
+  pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_acquire);
 
   while(((uintptr_t)head & (uintptr_t)1) != (uintptr_t)1)
-    head = _atomic_load(&actor->q.head, __ATOMIC_ACQUIRE);
+    head = atomic_load_explicit(&actor->q.head, memory_order_acquire);
 
   ponyint_messageq_destroy(&actor->q);
   ponyint_gc_destroy(&actor->gc);

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -10,10 +10,10 @@ static size_t messageq_size_debug(messageq_t* q)
   pony_msg_t* tail = q->tail;
   size_t count = 0;
 
-  while(tail->next != NULL)
+  while(atomic_load_explicit(&tail->next, memory_order_relaxed) != NULL)
   {
     count++;
-    tail = tail->next;
+    tail = atomic_load_explicit(&tail->next, memory_order_relaxed);
   }
 
   return count;
@@ -25,9 +25,10 @@ void ponyint_messageq_init(messageq_t* q)
 {
   pony_msg_t* stub = POOL_ALLOC(pony_msg_t);
   stub->index = POOL_INDEX(sizeof(pony_msg_t));
-  stub->next = NULL;
+  atomic_store_explicit(&stub->next, NULL, memory_order_relaxed);
 
-  q->head = (pony_msg_t*)((uintptr_t)stub | 1);
+  atomic_store_explicit(&q->head, (pony_msg_t*)((uintptr_t)stub | 1),
+    memory_order_relaxed);
   q->tail = stub;
 
 #ifndef NDEBUG
@@ -38,24 +39,25 @@ void ponyint_messageq_init(messageq_t* q)
 void ponyint_messageq_destroy(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
-  assert(((uintptr_t)q->head & ~(uintptr_t)1) == (uintptr_t)tail);
+  assert((((uintptr_t)atomic_load_explicit(&q->head, memory_order_acquire) &
+    ~(uintptr_t)1)) == (uintptr_t)tail);
 
   ponyint_pool_free(tail->index, tail);
-  q->head = NULL;
+  atomic_store_explicit(&q->head, NULL, memory_order_relaxed);
   q->tail = NULL;
 }
 
 bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m)
 {
-  m->next = NULL;
+  atomic_store_explicit(&m->next, NULL, memory_order_relaxed);
 
-  pony_msg_t* prev = (pony_msg_t*)_atomic_exchange(&q->head, m,
-    __ATOMIC_RELAXED);
+  pony_msg_t* prev = atomic_exchange_explicit(&q->head, m,
+    memory_order_relaxed);
 
   bool was_empty = ((uintptr_t)prev & 1) != 0;
   prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
 
-  _atomic_store(&prev->next, m, __ATOMIC_RELEASE);
+  atomic_store_explicit(&prev->next, m, memory_order_release);
 
   return was_empty;
 }
@@ -63,7 +65,7 @@ bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m)
 pony_msg_t* ponyint_messageq_pop(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
-  pony_msg_t* next = _atomic_load(&tail->next, __ATOMIC_ACQUIRE);
+  pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_acquire);
 
   if(next != NULL)
   {
@@ -77,7 +79,7 @@ pony_msg_t* ponyint_messageq_pop(messageq_t* q)
 bool ponyint_messageq_markempty(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
-  pony_msg_t* head = _atomic_load(&q->head, __ATOMIC_ACQUIRE);
+  pony_msg_t* head = atomic_load_explicit(&q->head, memory_order_acquire);
 
   if(((uintptr_t)head & 1) != 0)
     return true;
@@ -87,5 +89,6 @@ bool ponyint_messageq_markempty(messageq_t* q)
 
   head = (pony_msg_t*)((uintptr_t)head | 1);
 
-  return _atomic_cas(&q->head, &tail, head, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+  return atomic_compare_exchange_strong_explicit(&q->head, &tail, head,
+    memory_order_acq_rel, memory_order_acquire);
 }

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -8,7 +8,7 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct messageq_t
 {
-  pony_msg_t* volatile head;
+  ATOMIC_TYPE(pony_msg_t*) head;
   pony_msg_t* tail;
 } messageq_t;
 

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -10,7 +10,7 @@ struct asio_base_t
 {
   pony_thread_id_t tid;
   asio_backend_t* backend;
-  uint64_t volatile noisy_count;
+  ATOMIC_TYPE(uint64_t) noisy_count;
 };
 
 static asio_base_t running_base;
@@ -48,7 +48,7 @@ bool ponyint_asio_start()
 
 bool ponyint_asio_stop()
 {
-  if(_atomic_load(&running_base.noisy_count, __ATOMIC_ACQUIRE) > 0)
+  if(atomic_load_explicit(&running_base.noisy_count, memory_order_acquire) > 0)
     return false;
 
   if(running_base.backend != NULL)
@@ -65,10 +65,10 @@ bool ponyint_asio_stop()
 
 void ponyint_asio_noisy_add()
 {
-  _atomic_add(&running_base.noisy_count, 1, __ATOMIC_RELEASE);
+  atomic_fetch_add_explicit(&running_base.noisy_count, 1, memory_order_release);
 }
 
 void ponyint_asio_noisy_remove()
 {
-  _atomic_add(&running_base.noisy_count, -1, __ATOMIC_RELEASE);
+  atomic_fetch_sub_explicit(&running_base.noisy_count, 1, memory_order_release);
 }

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -19,8 +19,8 @@ struct asio_backend_t
   int epfd;
   int wakeup;    /* eventfd to break epoll loop */
   struct epoll_event events[MAX_EVENTS];
-  asio_event_t* sighandlers[MAX_SIGNAL];
-  bool terminate;
+  ATOMIC_TYPE(asio_event_t*) sighandlers[MAX_SIGNAL];
+  ATOMIC_TYPE(bool) terminate;
   messageq_t q;
 };
 
@@ -98,7 +98,7 @@ asio_backend_t* ponyint_asio_backend_init()
 
 void ponyint_asio_backend_final(asio_backend_t* b)
 {
-  b->terminate = true;
+  atomic_store_explicit(&b->terminate, true, memory_order_relaxed);
   eventfd_write(b->wakeup, 1);
 }
 
@@ -107,7 +107,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   pony_register_thread();
   asio_backend_t* b = arg;
 
-  while(!b->terminate)
+  while(!atomic_load_explicit(&b->terminate, memory_order_relaxed))
   {
     int event_cnt = epoll_wait(b->epfd, b->events, MAX_EVENTS, -1);
 
@@ -217,8 +217,9 @@ void pony_asio_event_subscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = NULL;
 
-    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, ev,
-      __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    if((sig < MAX_SIGNAL) &&
+      atomic_compare_exchange_strong_explicit(&b->sighandlers[sig], &prev, ev,
+      memory_order_acq_rel, memory_order_acquire))
     {
       signal(sig, signal_handler);
       ev->fd = eventfd(0, EFD_NONBLOCK);
@@ -276,8 +277,9 @@ void pony_asio_event_unsubscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = ev;
 
-    if((sig < MAX_SIGNAL) && _atomic_cas(&b->sighandlers[sig], &prev, NULL,
-      __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    if((sig < MAX_SIGNAL) &&
+      atomic_compare_exchange_strong_explicit(&b->sighandlers[sig], &prev, NULL,
+      memory_order_acq_rel, memory_order_acquire))
     {
       signal(sig, SIG_DFL);
       close(ev->fd);

--- a/src/libponyrt/mem/pagemap.c
+++ b/src/libponyrt/mem/pagemap.c
@@ -56,11 +56,11 @@ static const pagemap_level_t level[PAGEMAP_LEVELS] =
     POOL_INDEX((1 << L1_MASK) * sizeof(void*)) }
 };
 
-static void** root;
+ATOMIC_TYPE(static void**) root;
 
 void* ponyint_pagemap_get(const void* m)
 {
-  void** v = root;
+  void** v = atomic_load_explicit(&root, memory_order_acquire);
 
   for(int i = 0; i < PAGEMAP_LEVELS; i++)
   {
@@ -76,27 +76,31 @@ void* ponyint_pagemap_get(const void* m)
 
 void ponyint_pagemap_set(const void* m, void* v)
 {
-  void*** pv = &root;
+  ATOMIC_TYPE(void**)* pv = &root;
   void* p;
 
   for(int i = 0; i < PAGEMAP_LEVELS; i++)
   {
-    if(*pv == NULL)
+    void** pv_ld = atomic_load_explicit(pv, memory_order_acquire);
+    if(pv_ld == NULL)
     {
       p = ponyint_pool_alloc(level[i].size_index);
       memset(p, 0, level[i].size);
       void** prev = NULL;
 
-      if(!_atomic_cas(pv, &prev, p, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+      if(!atomic_compare_exchange_strong_explicit(pv, &prev, (void**)p,
+        memory_order_acq_rel, memory_order_acquire))
       {
         ponyint_pool_free(level[i].size_index, p);
-        *pv = prev;
+        pv_ld = prev;
+      } else {
+        pv_ld = (void**)p;
       }
     }
 
     uintptr_t ix = ((uintptr_t)m >> level[i].shift) & level[i].mask;
-    pv = (void***)&((*pv)[ix]);
+    pv = (ATOMIC_TYPE(void**)*)&(pv_ld[ix]);
   }
 
-  *pv = (void**)v;
+  atomic_store_explicit(pv, (void**)v, memory_order_release);
 }

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -6,7 +6,11 @@
 #include <stdbool.h>
 
 #if defined(__cplusplus)
+#  include <atomic>
+#  define ATOMIC_TYPE(T) std::atomic<T>
 extern "C" {
+#else
+#  define ATOMIC_TYPE(T) T _Atomic
 #endif
 
 #if defined(_MSC_VER)
@@ -37,7 +41,7 @@ typedef struct pony_msg_t
 {
   uint32_t index;
   uint32_t id;
-  struct pony_msg_t* volatile next;
+  ATOMIC_TYPE(struct pony_msg_t*) next;
 } pony_msg_t;
 
 /// Convenience message for sending an integer.

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -8,27 +8,17 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct mpmcq_node_t mpmcq_node_t;
 
-__pony_spec_align__(
-  typedef struct mpmcq_dwcas_t
-  {
-    union
-    {
-      struct
-      {
-        uintptr_t aba;
-        mpmcq_node_t* node;
-      };
-
-      dw_t dw;
-    };
-  } mpmcq_dwcas_t, 16
-);
+typedef struct mpmcq_dwcas_t
+{
+  uintptr_t aba;
+  mpmcq_node_t* node;
+} mpmcq_dwcas_t;
 
 __pony_spec_align__(
   typedef struct mpmcq_t
   {
-    mpmcq_node_t* volatile head;
-    mpmcq_dwcas_t tail;
+    ATOMIC_TYPE(mpmcq_node_t*) head;
+    ATOMIC_TYPE(mpmcq_dwcas_t) tail;
   } mpmcq_t, 64
 );
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -24,7 +24,7 @@ typedef struct options_t
 } options_t;
 
 // global data
-static int volatile exit_code;
+static ATOMIC_TYPE(int) exit_code;
 
 enum
 {
@@ -127,7 +127,7 @@ int pony_start(bool library)
   if(library)
     return 0;
 
-  return _atomic_load(&exit_code, __ATOMIC_ACQUIRE);
+  return atomic_load_explicit(&exit_code, memory_order_acquire);
 }
 
 int pony_stop()
@@ -135,10 +135,10 @@ int pony_stop()
   ponyint_sched_stop();
   ponyint_os_sockets_final();
 
-  return _atomic_load(&exit_code, __ATOMIC_ACQUIRE);
+  return atomic_load_explicit(&exit_code, memory_order_acquire);
 }
 
 void pony_exitcode(int code)
 {
-  _atomic_store(&exit_code, code, __ATOMIC_RELEASE);
+  atomic_store_explicit(&exit_code, code, memory_order_release);
 }


### PR DESCRIPTION
We now use standard C11 functions with `_Atomic` types. In addition, some atomic operations have been strengthened.

- In `pagemap`, loads of the data structure have been changed from plain loads to loads with acquire semantics to make sure the allocation of the data structure _happens-before_ its usage in other threads.
- Before entering the ABA protected CAS loops (`ponyint_mpmc_pop`, `pool_push` and `pool_pull`), we now load the whole ABA data structure in one atomic operation instead of loading each member separately. This ensures the shared data isn't modified between member loading and that the value seen is the last value in the modification order.
- Every access of a shared variable is now atomic. We use relaxed ordering whenever possible so there should be almost no overhead on most platforms.