### PR TITLE
Disable LTO by default on OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Path.base now provides option to omit the file extension from the result.
 - Map.upsert returns value for upserted key rather than `this`.
 - `ponyc --version` now includes llvm version in its output.
+- LTO is now disabled by default on OSX.
 
 ## [0.3.0] - 2016-08-26
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ else
 
   ifeq ($(UNAME_S),Darwin)
     OSTYPE = osx
-    lto := yes
     ifneq (,$(shell which llvm-ar-mp-3.8 2> /dev/null))
       AR := llvm-ar-mp-3.8
       AR_FLAGS := rcs

--- a/README.md
+++ b/README.md
@@ -371,8 +371,6 @@ $ make config=release LTO_PLUGIN=/usr/lib/LLVMgold.so
 
 Refer to your compiler documentation for the plugin to use in your case.
 
-LTO is enabled by default on OSX.
-
 
 ## VirtualBox
 


### PR DESCRIPTION
This is a workaround for the CI failures of #1206 on OSX. The default compiler in Travis builds is too old and doesn't support the C features used in #1206. We have to use a more recent compiler, which introduces incompatiblities with libLTO.