### PR TITLE
Add LLVM 3.9 builds in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ branches:
 
 environment:
   matrix:
+  - llvm: 3.9.0
   - llvm: 3.8.0
   - llvm: 3.7.1
 
@@ -96,7 +97,7 @@ deploy:
     version: $(appveyor_build_version)
     on:
         branch: master
-        llvm: 3.8.0
+        llvm: 3.9.0
         configuration: Release
     publish: true
 
@@ -110,7 +111,7 @@ deploy:
     version: $(appveyor_build_version)
     on:
         branch: release
-        llvm: 3.8.0
+        llvm: 3.9.0
         configuration: Release
     publish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,32 @@ matrix:
         - config=release
         - CC1=gcc-5
         - CXX1=g++-5
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - LLVM_VERSION="3.9.0"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=debug
+        - CC1=gcc-5
+        - CXX1=g++-5
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - LLVM_VERSION="3.9.0"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=release
+        - CC1=gcc-5
+        - CXX1=g++-5
     - os: osx
       env:
         - LLVM_CONFIG="llvm-config-3.6"
@@ -127,6 +153,20 @@ matrix:
         - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
+    # LLVM 3.9 can be enabled for OSX once Homebrew supports it.
+    #- os: osx
+    #  env:
+    #    - LLVM_CONFIG="llvm-config-3.9"
+    #    - config=debug
+    #    - CC1=clang-3.9
+    #    - CXX1=clang++-3.9
+    #- os: osx
+    #  env:
+    #    - LLVM_CONFIG="llvm-config-3.9"
+    #    - config=release
+    #    - CC1=clang-3.9
+    #    - CXX1=clang++-3.9
+
 
 rvm:
   - 2.2.3
@@ -136,7 +176,7 @@ install:
   # prepare to deploy artifacts.
   - if [[
         "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
-        "$LLVM_VERSION" == "3.8.0" &&
+        "$LLVM_VERSION" == "3.9.0" &&
         "$config" == "release" &&
         "$TRAVIS_OS_NAME" == "linux" &&
         "$TRAVIS_PULL_REQUEST" == "false"
@@ -207,7 +247,7 @@ after_success:
   # For a master release build with the latest stable LLVM, upload docs.
   - if [[
         "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
-        "$LLVM_VERSION" == "3.8.0" &&
+        "$LLVM_VERSION" == "3.9.0" &&
         "$config" == "release" &&
         "$TRAVIS_OS_NAME" == "linux" &&
         "$TRAVIS_PULL_REQUEST" == "false" &&

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Pony requires one of the following versions of LLVM:
 - 3.6.2
 - 3.7.1
 - 3.8.1
+- 3.9.0 (unsupported on OSX at the moment)
 
 Compiling Pony is only possible on x86 and ARM (either 32 or 64 bits).
 

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -9,6 +9,7 @@
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
 #  pragma warning(disable:4141)
+#  pragma warning(disable:4146)
 #endif
 
 #include <llvm/IR/DIBuilder.h>

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -6,6 +6,7 @@
 #  pragma warning(disable:4267)
 #  pragma warning(disable:4624)
 #  pragma warning(disable:4141)
+#  pragma warning(disable:4146)
 // LLVM claims DEBUG as a macro name. Conflicts with MSVC headers.
 #  pragma warning(disable:4005)
 #endif


### PR DESCRIPTION
Before this can be merged, [ponyc-windows-llvm](https://github.com/ponylang/ponyc-windows-llvm) will have to be updated with LLVM 3.9 binaries. I don't have a Windows system at hand so I don't think I'll be able to do it.

The final release builds still use LLVM 3.8 until we're certain there are no regressions with LLVM 3.9.