### PR TITLE
Make version come from VERSION file, not git tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 ### Changed
-- The `prerelease` command has been removed from `Makefile`.
+- The `setversion` and `release` commands have been removed from `Makefile`.
 
 ## [0.3.1] - 2016-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to the Pony compiler and standard library will be documented
 ## [unreleased] - unreleased
 
 ### Fixed
+- The `ponyc` version is now consistently set from the VERSION file.
 
 ### Added
 
 ### Changed
+- The `prerelease` command has been removed from `Makefile`.
 
 ## [0.3.1] - 2016-09-14
 

--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,7 @@ else
   SILENT =
 endif
 
-ifneq ($(wildcard .git),)
-tag := $(shell git describe --tags --always)
-git := yes
-else
 tag := $(shell cat VERSION)
-git := no
-endif
 
 # package_name, _version, and _iteration can be overriden by Travis or AppVeyor
 package_base_version ?= $(tag)
@@ -644,13 +638,9 @@ test-ci: all
 	@./examples1
 	@rm examples1
 
-ifeq ($(git),yes)
-setversion:
-	@echo $(tag) > VERSION
-
 $(eval $(call EXPAND_RELEASE))
 
-release: prerelease setversion
+release: prerelease
 	$(SILENT)git add VERSION
 	$(SILENT)git commit -m "Releasing version $(tag)"
 	$(SILENT)git tag $(tag)

--- a/Makefile
+++ b/Makefile
@@ -543,32 +543,6 @@ endef
 
 $(foreach target,$(targets),$(eval $(call EXPAND_COMMAND,$(target))))
 
-define EXPAND_RELEASE
-$(eval branch := $(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'))
-ifneq ($(branch),master)
-prerelease:
-	$$(error "Releases not allowed on $(branch) branch.")
-else
-ifndef version
-prerelease:
-	$$(error "No version number specified.")
-else
-$(eval tag := $(version))
-$(eval unstaged := $(shell git status --porcelain 2>/dev/null | wc -l))
-ifneq ($(unstaged),0)
-prerelease:
-	$$(error "Detected unstaged changes. Release aborted")
-else
-prerelease: libponyc libponyrt ponyc
-	@while [ -z "$$$$CONTINUE" ]; do \
-	read -r -p "New version number: $(tag). Are you sure? [y/N]: " CONTINUE; \
-	done ; \
-	[ $$$$CONTINUE = "y" ] || [ $$$$CONTINUE = "Y" ] || (echo "Release aborted."; exit 1;)
-	@echo "Releasing ponyc v$(tag)."
-endif
-endif
-endif
-endef
 
 define EXPAND_INSTALL
 install: libponyc libponyrt ponyc
@@ -637,21 +611,6 @@ test-ci: all
 	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
 	@./examples1
 	@rm examples1
-
-$(eval $(call EXPAND_RELEASE))
-
-release: prerelease
-	$(SILENT)git add VERSION
-	$(SILENT)git commit -m "Releasing version $(tag)"
-	$(SILENT)git tag $(tag)
-	$(SILENT)git push
-	$(SILENT)git push --tags
-	$(SILENT)git checkout release
-	$(SILENT)git pull
-	$(SILENT)git merge master
-	$(SILENT)git push
-	$(SILENT)git checkout $(branch)
-endif
 
 # Note: linux only
 # FIXME: why is $(branch) empty?

--- a/premake5.lua
+++ b/premake5.lua
@@ -126,11 +126,7 @@
       buildoptions "/PROFILE"
 
     configuration "vs*"
-      local version, exitcode = os.outputof("git describe --tags --always")
-
-      if exitcode ~= 0 then
-        version = os.outputof("type VERSION")
-      end
+      local version = os.outputof("type VERSION")
 
       debugdir "."
       defines {


### PR DESCRIPTION
The version assigned when building was coming from `git describe --tags
--always` when `.git` was present, otherwise from `VERSION`. This can
get out of sync with `VERSION` if the git tags are not up to date.

This commit makes the `tag` variable come version come exclusively from
the `VERSION` file, which then is used to set the build version.

This rendered the `setversion` command, which used the `tag` variable
to set the `VERSION`, file recursive and nonsensical, so the
`setversion` command has been removed. The `git` variable was also
removed, since it was only use was for `setversion`.

The `setversion` was also removed from the `release` command.

This resolves issue #1220.