### PR TITLE
Make `release` the default build type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 - The `setversion` and `release` commands have been removed from `Makefile`.
+- make now builds a `release` rather than `debug` build by default
 
 ## [0.3.1] - 2016-09-14
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ ifdef LTO_PLUGIN
   lto := yes
 endif
 
-# Default settings (silent debug build).
-config ?= debug
+# Default settings (silent release build).
+config ?= release
 arch ?= native
 bits ?= $(shell getconf LONG_BIT)
 
@@ -438,7 +438,7 @@ define CONFIGURE_COMPILER
     compiler := $(CC)
     flags := $(ALL_CFLAGS) $(CFLAGS)
   endif
-  
+
   ifeq ($(suffix $(1)),.bc)
     compiler := $(CC)
     flags := $(ALL_CFLAGS) $(CFLAGS)


### PR DESCRIPTION
Prior to this commit, the default when
running `make` was to create a debug
build. This is fine for pony developers
but pony first time users might be unaware.

Our stated guiding principle for defaults
is to use the best performing option that
wouldn't violate the principal of least
surprise. And so, this commit.