### PR TITLE
Enable LTO by default for OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ matrix:
       env:
         - LLVM_CONFIG="llvm-config-3.6"
         - config=release
+        - lto=no
         - CC1=clang-3.6
         - CXX1=clang++-3.6
     - os: osx
@@ -110,6 +111,7 @@ matrix:
       env:
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
+        - lto=no
         - CC1=clang-3.7
         - CXX1=clang++-3.7
     - os: osx
@@ -122,6 +124,7 @@ matrix:
       env:
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
+        - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 - The `setversion` and `release` commands have been removed from `Makefile`.
+- LTO is again enabled by default on OSX
 
 ## [0.3.1] - 2016-09-14
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,13 @@ else
   endif
 endif
 
+ifndef lto
+  ifeq ($(UNAME_S),Darwin)
+  	# turn lto on for OSX if user hasn't specified a value
+   	lto := yes
+   endif
+endif
+
 ifdef LTO_PLUGIN
   lto := yes
 endif
@@ -438,7 +445,7 @@ define CONFIGURE_COMPILER
     compiler := $(CC)
     flags := $(ALL_CFLAGS) $(CFLAGS)
   endif
-  
+
   ifeq ($(suffix $(1)),.bc)
     compiler := $(CC)
     flags := $(ALL_CFLAGS) $(CFLAGS)


### PR DESCRIPTION
Commit #1207 turned off LTO as a default. Subsequent
testing by Sendence found a ~ 10% performance
degradation for some operations with the change.

The change was made in order to get the Travis CI
builds working. Not a wonderful trade-off. This change
turns LTO back on by default on OSX and fixes our
Travis issue.

Eventually, Travis should have a compiler that doesn't
have issue with LTO and we can remove the Travis portion
of this.

This fixes issue #1223.