### PR TITLE
Fix Travis OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,6 +164,7 @@ install:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];
     then
       brew update;
+      brew install gmp; brew link --overwrite gmp;
       brew install llvm36 llvm37 llvm38 pcre2 libressl;
     fi;
 


### PR DESCRIPTION
A change in Homebrew is breaking OSX builds.
This fix handles the problems we are now having
installing GMP. Specifically, we are hitting errors
were it can't be linked into /usr/local when
being installed as a dependency for various
llvm version. This ends up failing the llvm installs
and from that, the build.

This fixes by "manually" installing gmp and then
forcing the link overwrite.