### PR TITLE
Stop generating `llvm.invariant.load` intrinsic for "let" references.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 - The `ponyc` version is now consistently set from the VERSION file.
+- Stop generating `llvm.invariant.load` intrinsic for "let" references, as these don't necessarily match the semantics of that intrinsic.
 
 ### Added
 

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -93,7 +93,7 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   if(ast_id(l_type) != TK_TUPLETYPE)
   {
     field = LLVMBuildLoad(c->builder, field, "");
-    if((ast_id(ast) == TK_FLETREF) || (cap_single(l_type) == TK_VAL))
+    if(cap_single(l_type) == TK_VAL)
     {
       LLVMValueRef metadata = LLVMMDNodeInContext(c->context, NULL, 0);
       const char id[] = "invariant.load";
@@ -220,16 +220,7 @@ LLVMValueRef gen_localload(compile_t* c, ast_t* ast)
   if(local_ptr == NULL)
     return NULL;
 
-  LLVMValueRef local = LLVMBuildLoad(c->builder, local_ptr, "");
-
-  if(ast_id(ast) == TK_LETREF)
-  {
-    LLVMValueRef metadata = LLVMMDNodeInContext(c->context, NULL, 0);
-    const char id[] = "invariant.load";
-    LLVMSetMetadata(local, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
-  }
-
-  return local;
+  return LLVMBuildLoad(c->builder, local_ptr, "");
 }
 
 LLVMValueRef gen_addressof(compile_t* c, ast_t* ast)


### PR DESCRIPTION
Resolves #1222.

As we saw in issue #1222, the load invariant doesn't necessarily hold true
for let references in Pony. Particularly it doesn't seem to hold for `for`
loops, which are `let` in Pony semantics, but the value changes between
iterations of the loop, so the optimizer can't see them as invariant.

With more research it might be possible to exclude the `for` loop case
(and any other problematic cases) but for now the best course of action
is to remove it for all `let` references.