### PR TITLE
Handle build number failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ## [unreleased] - unreleased
 
 ### Fixed
+- Incorrect build number generated on Windows when building from non-git directory.
 
 ### Added
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -127,7 +127,11 @@
 
     configuration "vs*"
       local version = os.outputof("type VERSION")
-      version = version .. "-" .. os.outputof("git rev-parse --short HEAD")
+
+      local build, exitcode = os.outputof("git rev-parse --short HEAD")
+      if exitcode == 0 then
+        version = version .. "-" .. build
+      end
 
       debugdir "."
       defines {


### PR DESCRIPTION
Hopefully handles the error case correctly when fetching build number on Windows for #1237