### PR TITLE
buffered - Added a string() method on Reader

### DIFF
--- a/packages/buffered/_test.pony
+++ b/packages/buffered/_test.pony
@@ -35,6 +35,8 @@ class iso _TestReader is UnitTest
     b.append(recover [as U8: 'h', 'i'] end)
     b.append(recover [as U8: '\n', 't', 'h', 'e'] end)
     b.append(recover [as U8: 'r', 'e', '\r', '\n'] end)
+    b.append(recover [as U8: 's', 't', 'r', '1', 0] end)
+    b.append(recover [as U8: 's', 't', 'r', '2', 0, 0, 'r'] end)
 
     // These expectations peek into the buffer without consuming bytes.
     h.assert_eq[U8](b.peek_u8(), 0x42)
@@ -63,6 +65,11 @@ class iso _TestReader is UnitTest
 
     h.assert_eq[String](b.line(), "hi")
     h.assert_eq[String](b.line(), "there")
+    h.assert_eq[String](b.string(), "str1")
+    h.assert_eq[String](b.string(), "str2")
+    h.assert_eq[String](b.string(), "")
+    h.assert_eq[U8](b.u8(), 'r')
+
 
     b.append(recover [as U8: 'h', 'i'] end)
 

--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -187,6 +187,15 @@ class Reader
 
     consume out
 
+  fun ref string(): String ? =>
+    """
+    Return a NULL terminated string. The ending NULL byte is consumed.
+    """
+    let len = _distance_of(0)
+    let result = block(len)
+    result.truncate(len - 1)
+    String.from_array(consume result)
+
   fun ref u8(): U8 ? =>
     """
     Get a U8. Raise an error if there isn't enough data.
@@ -534,6 +543,13 @@ class Reader
     Get the length of a pending line. Raise an error if there is no pending
     line.
     """
+    _distance_of('\n')
+
+  fun ref _distance_of(char: U8): USize ? =>
+    """
+    Return the relative offset of the first occurrence of a byte. Raise an 
+    error if the byte is not found.
+    """
     if _chunks.size() == 0 then
       error
     end
@@ -554,7 +570,7 @@ class Reader
       (var data, var offset) = node()
 
       try
-        let len = (_line_len + data.find('\n', offset) + 1) - offset
+        let len = (_line_len + data.find(char, offset) + 1) - offset
         _line_node = None
         _line_len = 0
         return len


### PR DESCRIPTION
Consume and return a null-terminated string.

Some protocols need this (e.g. https://www.postgresql.org/docs/current/static/protocol-message-formats.html ), I had to implement this by iterating over U8s which is far from optimal and not very user-friendly.

About the name of the function, I guess it's useless to make Reader
a Stringable, so I took the name. I can change this if needed.