### PR TITLE
Use less bits for ABA protection in CAS loops

### DIFF
--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -16,21 +16,17 @@ void ponyint_mpmcq_init(mpmcq_t* q)
   atomic_store_explicit(&node->data, NULL, memory_order_relaxed);
   atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
 
-  mpmcq_dwcas_t tail;
-  tail.node = node;
-
   atomic_store_explicit(&q->head, node, memory_order_relaxed);
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+  atomic_store_explicit(&q->tail, node, memory_order_relaxed);
 }
 
 void ponyint_mpmcq_destroy(mpmcq_t* q)
 {
-  mpmcq_dwcas_t tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
+  mpmcq_node_t* tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
 
-  POOL_FREE(mpmcq_node_t, tail.node);
-  tail.node = NULL;
-  q->head = NULL;
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+  POOL_FREE(mpmcq_node_t, tail);
+  atomic_store_explicit(&q->head, NULL, memory_order_relaxed);
+  atomic_store_explicit(&q->tail, NULL, memory_order_relaxed);
 }
 
 void ponyint_mpmcq_push(mpmcq_t* q, void* data)
@@ -58,16 +54,26 @@ void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
 
 void* ponyint_mpmcq_pop(mpmcq_t* q)
 {
-  mpmcq_dwcas_t cmp, xchg;
+  mpmcq_node_t* cmp;
+  mpmcq_node_t* xchg;
   mpmcq_node_t* next;
+  mpmcq_node_t* tail;
 
   cmp = atomic_load_explicit(&q->tail, memory_order_acquire);
 
+  uintptr_t mask = UINTPTR_MAX ^
+    ((1 << (POOL_MIN_BITS + POOL_INDEX(sizeof(mpmcq_node_t*)))) - 1);
+
   do
   {
+    // We know the alignment boundary of the objects in the queue so we use the
+    // low bits for ABA protection.
+    uintptr_t aba = (uintptr_t)cmp & ~mask;
+    tail = (mpmcq_node_t*)((uintptr_t)cmp & mask);
+
     // Get the next node rather than the tail. The tail is either a stub or has
     // already been consumed.
-    next = atomic_load_explicit(&cmp.node->next, memory_order_acquire);
+    next = atomic_load_explicit(&tail->next, memory_order_acquire);
 
     // Bailout if we have no next node.
     if(next == NULL)
@@ -75,8 +81,7 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
 
     // Make the next node the tail, incrementing the aba counter. If this
     // fails, cmp becomes the new tail and we retry the loop.
-    xchg.aba = cmp.aba + 1;
-    xchg.node = next;
+    xchg = (mpmcq_node_t*)((uintptr_t)next | ((aba + 1) & ~mask));
   } while(!atomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
     memory_order_acq_rel, memory_order_acquire));
 
@@ -89,10 +94,10 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
   // the old tail is NULL.
   atomic_store_explicit(&next->data, NULL, memory_order_release);
 
-  while(atomic_load_explicit(&cmp.node->data, memory_order_acquire) != NULL)
+  while(atomic_load_explicit(&tail->data, memory_order_acquire) != NULL)
     ponyint_cpu_relax();
 
   // Free the old tail. The new tail is the next node.
-  POOL_FREE(mpmcq_node_t, cmp.node);
+  POOL_FREE(mpmcq_node_t, tail);
   return data;
 }

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -18,7 +18,7 @@ __pony_spec_align__(
   typedef struct mpmcq_t
   {
     ATOMIC_TYPE(mpmcq_node_t*) head;
-    ATOMIC_TYPE(mpmcq_dwcas_t) tail;
+    ATOMIC_TYPE(mpmcq_node_t*) tail;
   } mpmcq_t, 64
 );
 


### PR DESCRIPTION
The ABA bits are now the 5 (`POOL_MIN_BITS`) lowest bits of the pointers. I used a fixed number to avoid runtime computations, even though more bits are available in `pool_push` and `pool_pull` as the pool index goes up. I think 5 bits should be sufficient in every case.

I benchmarked this change on x86_64, the benchmark program can be found [here](https://gist.github.com/Praetonus/b4ceb633de887fb069e79e3ab1208efb) (it uses the [benchmark](https://github.com/google/benchmark) lib). The old version takes ~50ns per iteration while the new one takes ~30ns per iteration. I don't know how it would perform on ARM or other platforms but I expect similar ratios.