### PR TITLE
Use $CC as the linker in ponyc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- On Linux and FreeBSD, ponyc now uses $CC as the linker if the environment variable is defined.
+
 ## [0.3.2] - 2016-09-18
 
 ### Fixed


### PR DESCRIPTION
The priority order for the linker is now

1. The argument of the `--linker` flag
2. The value of `$CC`
3. The compiler used to build ponyc

If the last option is used, a warning is issued to make the user aware of that default behaviour.

This change only affects Linux and FreeBSD since Windows and OSX call the system linker directly.

Closes #1218.