### PR TITLE
Duplicate fewer AST nodes during reification

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -102,7 +102,7 @@ static bool check_type_params(pass_opt_t* opt, ast_t** astp)
     return false;
   }
 
-  type = reify(type, typeparams, typeargs, opt);
+  type = reify(type, typeparams, typeargs, opt, true);
   typeparams = ast_childidx(type, 1);
   ast_replace(&typeparams, ast_from(typeparams, TK_NONE));
 

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -514,7 +514,7 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
       if(!check_constraints(left, typeparams, right, true, opt))
         return false;
 
-      type = reify(type, typeparams, right, opt);
+      type = reify(type, typeparams, right, opt, true);
       typeparams = ast_childidx(type, 1);
       ast_replace(&typeparams, ast_from(typeparams, TK_NONE));
 

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -144,7 +144,7 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
   }
 
   // Reify the alias.
-  ast_t* r_alias = reify(alias, typeparams, typeargs, opt);
+  ast_t* r_alias = reify(alias, typeparams, typeargs, opt, true);
 
   if(r_alias == NULL)
     return false;

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -269,7 +269,7 @@ static ast_t* reify_provides_type(ast_t* method, ast_t* trait_ref,
   if(!reify_defaults(type_params, type_args, true, opt))
     return NULL;
 
-  ast_t* reified = reify(method, type_params, type_args, opt);
+  ast_t* reified = reify(method, type_params, type_args, opt, true);
 
   if(reified == NULL)
     return NULL;

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -323,9 +323,7 @@ static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
     AST_GET_CHILDREN(fun, cap, id, typeparams, params, result, can_error,
       body);
 
-    ast_t* r_fun = reify(fun, typeparams, typeargs, opt);
-    ast_free_unattached(fun);
-    fun = r_fun;
+    fun = reify(fun, typeparams, typeargs, opt, false);
   }
 
   m->r_fun = fun;
@@ -483,7 +481,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
 
         t->fields[index].embed = ast_id(member) == TK_EMBED;
         t->fields[index].ast = reify(ast_type(member), typeparams, typeargs,
-          opt);
+          opt, true);
         ast_setpos(t->fields[index].ast, NULL, ast_line(name), ast_pos(name));
         t->fields[index].type = add_type(r, type, opt);
 

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -159,9 +159,7 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
 
   ast_t* typeargs = ast_childidx(type, 2);
   ast_t* r_find = viewpoint_replacethis(find, orig);
-  ast_t* rr_find = reify(r_find, typeparams, typeargs, opt);
-  ast_free_unattached(r_find);
-  return rr_find;
+  return reify(r_find, typeparams, typeargs, opt, false);
 }
 
 static ast_t* lookup_typeparam(pass_opt_t* opt, ast_t* from, ast_t* orig,

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -10,7 +10,11 @@ PONY_EXTERN_C_BEGIN
 bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   pass_opt_t* opt);
 
-ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt);
+ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt,
+  bool duplicate);
+
+ast_t* reify_method_def(ast_t* ast, ast_t* typeparams, ast_t* typeargs,
+  pass_opt_t* opt);
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
   bool report_errors, pass_opt_t* opt);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -394,7 +394,7 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
       super_typeparam = ast_sibling(super_typeparam);
     }
 
-    r_sub = reify(sub, sub_typeparams, typeargs, opt);
+    r_sub = reify(sub, sub_typeparams, typeargs, opt, true);
     ast_free_unattached(typeargs);
   }
 
@@ -720,7 +720,8 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
     ast_t* sub_member = ast_get(sub_def, ast_name(super_member_id), NULL);
 
     // If we don't provide a method, we aren't a subtype.
-    if(sub_member == NULL)
+    if((sub_member == NULL) || (ast_id(sub_member) != TK_FUN &&
+      ast_id(sub_member) != TK_BE && ast_id(sub_member) != TK_NEW))
     {
       if(errorf != NULL)
       {
@@ -736,11 +737,12 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
     }
 
     // Reify the method on the subtype.
-    ast_t* r_sub_member = reify(sub_member, sub_typeparams, sub_typeargs, opt);
+    ast_t* r_sub_member = reify_method_def(sub_member, sub_typeparams,
+      sub_typeargs, opt);
     assert(r_sub_member != NULL);
 
     // Reify the method on the supertype.
-    ast_t* r_super_member = reify(super_member, super_typeparams,
+    ast_t* r_super_member = reify_method_def(super_member, super_typeparams,
       super_typeargs, opt);
     assert(r_super_member != NULL);
 
@@ -812,7 +814,7 @@ static bool nominal_provides_trait(ast_t* type, ast_t* trait,
   while(child != NULL)
   {
     // Reify the child with our typeargs.
-    ast_t* r_child = reify(child, typeparams, typeargs, opt);
+    ast_t* r_child = reify(child, typeparams, typeargs, opt, true);
     assert(r_child != NULL);
 
     // Use the cap and ephemerality of the trait.


### PR DESCRIPTION
This change avoids unnecessary duplications of AST nodes. Compilation times are reduced, mainly for the reachability pass.

Closes #1062.