### PR TITLE
Fix intermittent process monitor test failures

### DIFF
--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -563,12 +563,13 @@ actor ProcessMonitor
         | _stdout_read =>
           if _read_len >= _expect then
             _notifier.stdout(this, consume data)
-            _read_len = 0
-            _read_buf_size()
           end
         | _stderr_read =>
           _notifier.stderr(this, consume data)
         end
+
+        _read_len = 0
+        _read_buf_size()
 
         sum = sum + len.usize()
         if sum > (1 << 12) then


### PR DESCRIPTION
Before this change, `_read_len` would not be reset to zero for the `stderr` case, meaning that the next chunk of data would be read into a wrong location.