### PR TITLE
Stop generating LLVM invariant.load metadatas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Incorrect build number generated on Windows when building from non-git directory.
+- Stop generating `llvm.invariant.load` for fields of `val` references.
 
 ### Added
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -187,13 +187,6 @@ static void pointer_apply(compile_t* c, void* data, token_id cap)
   LLVMValueRef loc = LLVMBuildInBoundsGEP(c->builder, elem_ptr, &index, 1, "");
   LLVMValueRef result = LLVMBuildLoad(c->builder, loc, "");
 
-  if(cap == TK_VAL)
-  {
-      LLVMValueRef metadata = LLVMMDNodeInContext(c->context, NULL, 0);
-      const char id[] = "invariant.load";
-      LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
-  }
-
   LLVMBuildRet(c->builder, result);
   codegen_finishfun(c);
 }

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -93,12 +93,6 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   if(ast_id(l_type) != TK_TUPLETYPE)
   {
     field = LLVMBuildLoad(c->builder, field, "");
-    if(cap_single(l_type) == TK_VAL)
-    {
-      LLVMValueRef metadata = LLVMMDNodeInContext(c->context, NULL, 0);
-      const char id[] = "invariant.load";
-      LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
-    }
     LLVMValueRef metadata = tbaa_metadata_for_type(c, l_type);
     const char id[] = "tbaa";
     LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);


### PR DESCRIPTION
The semantics can be wrong if an object allocated in a loop is turned into a stack allocation.