### PR TITLE
Add more type-based alias analysis metadatas

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -139,6 +139,8 @@ typedef struct compile_t
   LLVMDIBuilderRef di;
   LLVMMetadataRef di_unit;
   LLVMValueRef tbaa_root;
+  LLVMValueRef tbaa_descriptor;
+  LLVMValueRef tbaa_descptr;
 
   LLVMTypeRef void_type;
   LLVMTypeRef ibool;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -232,7 +232,9 @@ static void set_descriptor(compile_t* c, reach_type_t* t, LLVMValueRef value)
     return;
 
   LLVMValueRef desc_ptr = LLVMBuildStructGEP(c->builder, value, 0, "");
-  LLVMBuildStore(c->builder, t->desc, desc_ptr);
+  LLVMValueRef store = LLVMBuildStore(c->builder, t->desc, desc_ptr);
+  const char id[] = "tbaa";
+  LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), c->tbaa_descptr);
 }
 
 static void set_method_external_nominal(reach_type_t* t, const char* name)

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -20,6 +20,8 @@ void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
 
 LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
 
+LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name);
+
 bool gentypes(compile_t* c);
 
 PONY_EXTERN_C_END


### PR DESCRIPTION
We now generate metadatas for load and stores on

- Pony `Pointer`s
- Boxed values
- Type descriptors and descriptor pointers

The TBAA tree now looks like this (see 3beb8c5 for details on the types subtrees).

```text
  root
   |
   |--- type subtrees (including Pointer)
   |
   |--- boxed types (separate metadata for each type)
   |
   |--- any type descriptor (unique metadata with immutability)
   |
   |--- any descriptor pointer (unique metadata)
```