### PR TITLE
Fix unexpected message ordering in ProcessManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+* Unexpected message ordering in `ProcessManager` (issue #1265)
+
 ### Added
 
 ### Changed


### PR DESCRIPTION
So, imagine you are an intrepid Pony user on IRC.
Let's call you "polypus74". You have some code that
does something like this:

pm.writev(some_data)
pm.done_writing()

You reasonably expect that your data will be written
and then shutdown because you told it you were done
writing. Sadly, before this commit you would be wrong.
You might even go on IRC and ask folks about it. You
might in fact, point out what you think is the issue
to a core team member and be told you were wrong.
But, of course, you weren't wrong. Therefore, this is
hereby called "the polypus74 fix".

The issue is, that before this commit, writev calls
write which is itself a behavior. Because behaviors
run to completion we get something like this...

original behavior: enqueues writev
original behavior: enguques done_writing
process manager writev: enqueues write
process manager writev: enguques write again etc

The important part of this is that done_writing will
happen before the write calls. Not at all what
a user would expect.

The fix, as seen here, is to follow the same pattern
that TCPConnection does and make sure that we are
calling functions not behaviours in order to maintain
the expected ordering.

As a sidenote, we really need to use this as an example
in the tutorial about causal messaging and make sure
everyone understands what would happen here.

This original process monitor code made it through
multiple reviews with Sylvan as well as past every
committer. Ooops.