### PR TITLE
Must normalize "IFDEF" node before evaluating

### DIFF
--- a/src/libponyc/pkg/use.c
+++ b/src/libponyc/pkg/use.c
@@ -133,7 +133,7 @@ static bool uri_command(pass_opt_t* opt, ast_t* ast, ast_t* uri, ast_t* alias,
     return false;
   }
 
-  if(!ifdef_cond_eval(guard, opt))
+  if(ifdef_cond_normalise(&guard, opt) && !ifdef_cond_eval(guard, opt))
     return true;
 
   assert(handlers[index].handler != NULL);


### PR DESCRIPTION
I ran into this error because I had a source file that began with:
```pony
2use "ponytest" // sic
```