### PR TITLE
fix llvm3.9 builds on windows

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -41,6 +41,9 @@
     for lib in string.gmatch(output, "-l(%S+)") do
       links { lib }
     end
+    for lib in string.gmatch(output, "lib.(%S+).lib") do
+      links { lib }
+    end
   end
 
   function llvm_config(opt)

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -42,6 +42,7 @@
 #  pragma warning(disable:4510)
 #  pragma warning(disable:4512)
 #  pragma warning(disable:4610)
+#  pragma warning(disable:4146)
 /** Disable warning about __declspec(restrict) not being used at function
  *  definition. According to the documentation, it should not matter.
  *  Also, using extern "C" does not remove this warning.

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -7,6 +7,7 @@
 #  pragma warning(disable:4624)
 #  pragma warning(disable:4141)
 #  pragma warning(disable:4291)
+#  pragma warning(disable:4146)
 #endif
 
 #include <llvm/IR/Constants.h>


### PR DESCRIPTION
Looks like LLVM 3.9 decided to change the output format of `llvm-config --libs`.  This PR changes the build script to account for this and supresses a warning from LLVM headers.