### PR TITLE
Fix issue where SSL connection would not use notifier, but write directly

### DIFF
--- a/packages/net/ssl/ssl_connection.pony
+++ b/packages/net/ssl/ssl_connection.pony
@@ -135,6 +135,6 @@ class SSLConnection is TCPConnectionNotify
 
     try
       while _ssl.can_send() do
-        conn.write_final(_ssl.send())
+        _notify.sent(conn, _ssl.send())
       end
     end

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -136,7 +136,7 @@ actor TCPConnection
     """
     if not _closed then
       _in_sent = true
-      write_final(_notify.sent(this, data))
+      _write_final(_notify.sent(this, data))
       _in_sent = false
     end
 
@@ -148,7 +148,7 @@ actor TCPConnection
       _in_sent = true
 
       for bytes in _notify.sentv(this, data).values() do
-        write_final(bytes)
+        _write_final(bytes)
       end
 
       _in_sent = false
@@ -283,7 +283,7 @@ actor TCPConnection
     """
     _pending_reads()
 
-  fun ref write_final(data: ByteSeq) =>
+  fun ref _write_final(data: ByteSeq) =>
     """
     Write as much as possible to the socket. Set `_writeable` to `false` if not
     everything was written. On an error, close the connection. This is for


### PR DESCRIPTION
In this change, 'write_final' is turned into a private method to ensure that this
is prevented from happening in the future.

This closes issue #1268.