### PR TITLE
Fix copy bounds for String.clone (avoid segfault for trimmed strings).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Memory copy bounds for `String.clone` (issue #1289).
 
 ### Added
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -477,7 +477,7 @@ actor Main
     """
     let len = _size
     let str = recover String(len) end
-    _ptr._copy_to(str._ptr._unsafe(), len + 1)
+    _ptr._copy_to(str._ptr._unsafe(), len)
     str._size = len
     str._set(len, 0)
     str

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -424,6 +424,7 @@ class iso _TestStringTrimInPlace is UnitTest
     let copy: String ref = orig.clone()
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
+    h.assert_eq[String box](expected, copy.clone()) // safe to clone
 
 
 class iso _TestStringIsNullTerminated is UnitTest


### PR DESCRIPTION
This PR fixes copy bounds for `String.clone` (avoiding a possible segfault for trimmed strings).

We are calling `_set(len, 0)` to set the null terminator on the new
string, so there is no reason to copy `len + 1` bytes from the original
string pointer. In fact, for trimmed strings this may not be safe -
in some situations, `len + 1` bytes may end in a chunk of memory that
we don't actually own, causing a segmentation fault.