### PR TITLE
Removed unneeded errors from ProcessError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Changed
 
 - `Stringable` interface no longer involves formatting (issue #1285)
+- Remove unused error types from ProcessError (issue #1293)
 
 ## [0.4.0] - 2016-09-26
 

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -243,12 +243,8 @@ class _ProcessClient is ProcessNotify
     match err
     | ExecveError   => _h.fail("ProcessError: ExecveError")
     | PipeError     => _h.fail("ProcessError: PipeError")
-    | Dup2Error     => _h.fail("ProcessError: Dup2Error")
     | ForkError     => _h.fail("ProcessError: ForkError")
-    | FcntlError    => _h.fail("ProcessError: FcntlError")
     | WaitpidError  => _h.fail("ProcessError: WaitpidError")
-    | CloseError    => _h.fail("ProcessError: CloseError")
-    | ReadError     => _h.fail("ProcessError: ReadError")
     | WriteError    => _h.fail("ProcessError: WriteError")
     | KillError     => _h.fail("ProcessError: KillError")
     | Unsupported   => _h.fail("ProcessError: Unsupported")

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -64,14 +64,11 @@ class ProcessClient is ProcessNotify
     match err
     | ExecveError   => _env.out.print("ProcessError: ExecveError")
     | PipeError     => _env.out.print("ProcessError: PipeError")
-    | Dup2Error     => _env.out.print("ProcessError: Dup2Error")
     | ForkError     => _env.out.print("ProcessError: ForkError")
-    | FcntlError    => _env.out.print("ProcessError: FcntlError")
     | WaitpidError  => _env.out.print("ProcessError: WaitpidError")
-    | CloseError    => _env.out.print("ProcessError: CloseError")
-    | ReadError     => _env.out.print("ProcessError: ReadError")
     | WriteError    => _env.out.print("ProcessError: WriteError")
     | KillError     => _env.out.print("ProcessError: KillError")
+    | CapError      => _env.out.print("ProcessError: CapError")
     | Unsupported   => _env.out.print("ProcessError: Unsupported")
     else
       _env.out.print("Unknown ProcessError!")
@@ -144,12 +141,8 @@ primitive _ONONBLOCK
 
 primitive ExecveError
 primitive PipeError
-primitive Dup2Error
 primitive ForkError
-primitive FcntlError
 primitive WaitpidError
-primitive CloseError
-primitive ReadError
 primitive WriteError
 primitive KillError
 primitive Unsupported // we throw this on non POSIX systems
@@ -157,13 +150,9 @@ primitive CapError
 
 type ProcessError is
   ( ExecveError
-  | CloseError
-  | Dup2Error
-  | FcntlError
   | ForkError
   | KillError
   | PipeError
-  | ReadError
   | Unsupported
   | WaitpidError
   | WriteError


### PR DESCRIPTION
There are several errors in ProcessError that are unused in the
ProcessMonitor. This commit removed unused errors with the
exception of ExecveError which is being used in #1180.

This PR fixes #1291.