### PR TITLE
Add line breaks for bar separated lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - `Stringable` interface no longer involves formatting (issue #1285)
 - Remove unused error types from ProcessError (issue #1293)
+- HTML documentation for expanded union types now adds line breaks to improve readability (issue #1263)
 
 ## [0.4.0] - 2016-09-26
 


### PR DESCRIPTION
Bar separated lists were causing an ugly horizontal scrollbar in the docs. This commit fixes #1263 by including a new line every three list elements if the separator is a bar. The behavior is added as a boolean flag to the doc_type_list function to be easily applied to other lists if the need arises. A screenshot of the docs generated with this change is included below.

<img width="777" alt="screen shot 2016-10-08 at 10 46 11 pm" src="https://cloud.githubusercontent.com/assets/373621/19217447/552be624-8da9-11e6-886e-fe29b1b2ddcf.png">
