### PR TITLE
Fix SSLConnection bugs caused by missing sentv method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Memory copy bounds for `String.clone` (issue #1289).
 - Security issues in `ProcessMonitor` (issue #1180)
+- `SSLConnection` bugs due to missing `sentv` notify method (issue #1282)
 
 ### Added
 

--- a/packages/net/ssl/ssl_connection.pony
+++ b/packages/net/ssl/ssl_connection.pony
@@ -51,6 +51,8 @@ class SSLConnection is TCPConnectionNotify
     if _connected then
       try
         _ssl.write(data)
+      else
+        return ""
       end
     else
       _pending.push(data)
@@ -58,6 +60,13 @@ class SSLConnection is TCPConnectionNotify
 
     _poll(conn)
     ""
+
+  fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter =>
+    for bytes in data.values() do
+      sent(conn, bytes)
+    end
+
+  recover val Array[ByteSeq] end
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso) =>
     """


### PR DESCRIPTION
Prior to cfe579f252be8b9f6b48c5731e88b5c25213fb89, code
using SSLConnection would work correctly. With the
aforementioned change, by default, if you supplied no
`sentv` notifier method, the `sent` method code was applied.
However, this was done via `error` being triggered and was
quite slow for all code.

When the fix for that performance issue went in, I missed
that SSLConnection needed to have a `sentv` added that
replicated the old behavior.

Resolves #1282