### PR TITLE
Add tests for the finaliser compiler pass and improve error reporting.

### DIFF
--- a/src/libponyc/pass/finalisers.c
+++ b/src/libponyc/pass/finalisers.c
@@ -30,9 +30,10 @@ static void show_send(pass_opt_t* opt, ast_t* ast)
   if(ast_id(ast) == TK_CALL)
   {
     if(ast_cansend(ast))
-      ast_error(opt->check.errors, ast, "a message can be sent here");
+      ast_error_continue(opt->check.errors, ast, "a message can be sent here");
     else if(ast_mightsend(ast))
-      ast_error(opt->check.errors, ast, "a message might be sent here");
+      ast_error_continue(opt->check.errors, ast,
+        "a message might be sent here");
   }
 }
 

--- a/test/libponyc/finalisers.cc
+++ b/test/libponyc/finalisers.cc
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "finalisers"))
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "finalisers", errs)); }
+
+
+class FinalisersTest : public PassTest
+{};
+
+
+TEST_F(FinalisersTest, FinalCanCreatePrimitive)
+{
+  const char* src =
+    "primitive Prim\n"
+    "primitive Foo\n"
+    "  fun _final() =>\n"
+    "    Prim";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(FinalisersTest, FinalCannotCreateActor)
+{
+  const char* src =
+    "actor Actor\n"
+    "primitive Foo\n"
+    "  fun _final() =>\n"
+    "    Actor";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}
+
+TEST_F(FinalisersTest, FinalCannotCreateActorInBranch)
+{
+  const char* src =
+    "actor Actor\n"
+    "primitive Foo\n"
+    "  fun _final() =>\n"
+    "    if false then None else Actor end";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}
+
+TEST_F(FinalisersTest, FinalCannotCreateActorInTryBlock)
+{
+  const char* src =
+    "actor Actor\n"
+    "primitive Foo\n"
+    "  fun _final() =>\n"
+    "    try Actor; error end";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}
+
+TEST_F(FinalisersTest, FinalCannotCallBehaviour)
+{
+  const char* src =
+    "actor Actor\n"
+    "  be apply() => None\n"
+    "class Foo\n"
+    "  let a: Actor = Actor\n"
+    "  fun _final() =>\n"
+    "    a()";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}
+
+TEST_F(FinalisersTest, FinalCannotCallBehaviourInBranch)
+{
+  const char* src =
+    "actor Actor\n"
+    "  be apply() => None\n"
+    "class Foo\n"
+    "  let a: Actor = Actor\n"
+    "  fun _final() =>\n"
+    "    if true then a() end";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}
+
+TEST_F(FinalisersTest, FinalCannotCallBehaviourInTryElseBlock)
+{
+  const char* src =
+    "actor Actor\n"
+    "  be apply() => None\n"
+    "class Foo\n"
+    "  let a: Actor = Actor\n"
+    "  fun _final() =>\n"
+    "    try error else a() end";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}


### PR DESCRIPTION
This PR simply adds some tests for the `finaliser` compiler pass for some error reporting that was previously untested (and thus vulnerable to regression).

It also makes a minor fix to the way errors are reported in the finaliser pass, using the `ast_error_continue` function for error messages that add more information to the current error.  This avoids the additional information lines from being reported as additional errors, and makes it easier for the user to see what was going on.  The `ast_error_continue` function did not exist at the original time this code was written, or it would have been used from the start.

No changelog entry should be necessary, as this doesn't really change anything a user should care about.