### PR TITLE
Use the new AttributeRef API for LLVM 3.9

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -22,15 +22,17 @@ PONY_EXTERN_C_BEGIN
 // Missing from C API.
 char* LLVMGetHostCPUName();
 void LLVMSetUnsafeAlgebra(LLVMValueRef inst);
+#if PONY_LLVM < 309
 void LLVMSetReturnNoAlias(LLVMValueRef fun);
 void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size);
-#if PONY_LLVM >= 307
+#  if PONY_LLVM >= 307
 void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size);
-#endif
-#if PONY_LLVM >= 308
+#  endif
+#  if PONY_LLVM >= 308
 void LLVMSetCallInaccessibleMemOnly(LLVMValueRef inst);
 void LLVMSetInaccessibleMemOrArgMemOnly(LLVMValueRef fun);
 void LLVMSetCallInaccessibleMemOrArgMemOnly(LLVMValueRef inst);
+#  endif
 #endif
 LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
@@ -41,6 +43,16 @@ LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);
 LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32);
 LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module);
 LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module);
+
+#if PONY_LLVM >= 309
+#define LLVM_DECLARE_ATTRIBUTEREF(decl, name, val) \
+  LLVMAttributeRef decl; \
+  { \
+    unsigned decl##_id = \
+      LLVMGetEnumAttributeKindForName(#name, sizeof(#name) - 1); \
+    decl = LLVMCreateEnumAttribute(c->context, decl##_id, val); \
+  }
+#endif
 
 #define GEN_NOVALUE ((LLVMValueRef)1)
 

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -619,7 +619,15 @@ static LLVMValueRef declare_ffi_vararg(compile_t* c, const char* f_name,
   LLVMValueRef func = LLVMAddFunction(c->module, f_name, f_type);
 
   if(!err)
+  {
+#if PONY_LLVM >= 309
+    LLVM_DECLARE_ATTRIBUTEREF(nounwind_attr, nounwind, 0);
+
+    LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex, nounwind_attr);
+#else
     LLVMAddFunctionAttr(func, LLVMNoUnwindAttribute);
+#endif
+  }
 
   return func;
 }
@@ -699,7 +707,15 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
   LLVMValueRef func = LLVMAddFunction(c->module, f_name, f_type);
 
   if(!err)
+  {
+#if PONY_LLVM >= 309
+    LLVM_DECLARE_ATTRIBUTEREF(nounwind_attr, nounwind, 0);
+
+    LLVMAddAttributeAtIndex(func, LLVMAttributeFunctionIndex, nounwind_attr);
+#else
     LLVMAddFunctionAttr(func, LLVMNoUnwindAttribute);
+#endif
+  }
 
   ponyint_pool_free_size(buf_size, f_params);
   return func;

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -7,7 +7,8 @@
 
 PONY_EXTERN_C_BEGIN
 
-void genfun_param_attrs(reach_type_t* t, reach_method_t* m, LLVMValueRef fun);
+void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
+  LLVMValueRef fun);
 
 bool genfun_method_sigs(compile_t* c, reach_type_t* t);
 

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -42,6 +42,7 @@ void LLVMSetUnsafeAlgebra(LLVMValueRef inst)
   unwrap<Instruction>(inst)->setHasUnsafeAlgebra(true);
 }
 
+#if PONY_LLVM < 309
 void LLVMSetReturnNoAlias(LLVMValueRef fun)
 {
   unwrap<Function>(fun)->setDoesNotAlias(0);
@@ -57,7 +58,7 @@ void LLVMSetDereferenceable(LLVMValueRef fun, uint32_t i, size_t size)
   f->addAttributes(i, AttributeSet::get(f->getContext(), i, attr));
 }
 
-#if PONY_LLVM >= 307
+#  if PONY_LLVM >= 307
 void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size)
 {
   Function* f = unwrap<Function>(fun);
@@ -67,9 +68,9 @@ void LLVMSetDereferenceableOrNull(LLVMValueRef fun, uint32_t i, size_t size)
 
   f->addAttributes(i, AttributeSet::get(f->getContext(), i, attr));
 }
-#endif
+#  endif
 
-#if PONY_LLVM >= 308
+#  if PONY_LLVM >= 308
 void LLVMSetCallInaccessibleMemOnly(LLVMValueRef inst)
 {
   Instruction* i = unwrap<Instruction>(inst);
@@ -100,6 +101,7 @@ void LLVMSetCallInaccessibleMemOrArgMemOnly(LLVMValueRef inst)
   else
     assert(0);
 }
+#  endif
 #endif
 
 #if PONY_LLVM < 307


### PR DESCRIPTION
The `LLVMAttribute` API is deprecated in LLVM 3.9 and is replaced by the `AttributeRef` API.