### PR TITLE
Call `sent` on TCPConnectionNotify when using SSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- `SSLConnection` ignoring the `sent` notifier method (issue #1268)
+
 ### Added
 
 ### Changed

--- a/packages/net/ssl/ssl_connection.pony
+++ b/packages/net/ssl/ssl_connection.pony
@@ -48,14 +48,15 @@ class SSLConnection is TCPConnectionNotify
     Pass the data to the SSL session and check for both new application data
     and new destination data.
     """
+    let notified = _notify.sent(conn, data)
     if _connected then
       try
-        _ssl.write(data)
+        _ssl.write(notified)
       else
         return ""
       end
     else
-      _pending.push(data)
+      _pending.push(notified)
     end
 
     _poll(conn)


### PR DESCRIPTION
Before this commit, due to a bug in `SSLConnection`, `sent` on
a `TCPConnectionNotify` wouldn't be called.

Resolves #1268 