### PR TITLE
Improve performance of power of 2 computations

### DIFF
--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -6,11 +6,8 @@ primitive U8 is _UnsignedInteger[U8]
   new max_value() => 0xFF
 
   fun next_pow2(): U8 =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U8 => this
   fun bswap(): U8 => this
@@ -36,12 +33,8 @@ primitive U16 is _UnsignedInteger[U16]
   new max_value() => 0xFFFF
 
   fun next_pow2(): U16 =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U16 => this
   fun bswap(): U16 => @"llvm.bswap.i16"[U16](this)
@@ -67,13 +60,8 @@ primitive U32 is _UnsignedInteger[U32]
   new max_value() => 0xFFFF_FFFF
 
   fun next_pow2(): U32 =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x = x or (x >> 16)
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U32 => this
   fun bswap(): U32 => @"llvm.bswap.i32"[U32](this)
@@ -99,14 +87,8 @@ primitive U64 is _UnsignedInteger[U64]
   new max_value() => 0xFFFF_FFFF_FFFF_FFFF
 
   fun next_pow2(): U64 =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x = x or (x >> 16)
-    x = x or (x >> 32)
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U64 => this
   fun bswap(): U64 => @"llvm.bswap.i64"[U64](this)
@@ -138,18 +120,8 @@ primitive ULong is _UnsignedInteger[ULong]
     end
 
   fun next_pow2(): ULong =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x = x or (x >> 16)
-
-    ifdef lp64 then
-      x = x or (x >> 32)
-    end
-
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): ULong => this
 
@@ -220,18 +192,8 @@ primitive USize is _UnsignedInteger[USize]
     end
 
   fun next_pow2(): USize =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x = x or (x >> 16)
-
-    ifdef llp64 or lp64 then
-      x = x or (x >> 32)
-    end
-
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): USize => this
 
@@ -296,15 +258,8 @@ primitive U128 is _UnsignedInteger[U128]
   new max_value() => 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
   fun next_pow2(): U128 =>
-    var x = this - 1
-    x = x or (x >> 1)
-    x = x or (x >> 2)
-    x = x or (x >> 4)
-    x = x or (x >> 8)
-    x = x or (x >> 16)
-    x = x or (x >> 32)
-    x = x or (x >> 64)
-    x + 1
+    let x = (this - 1).clz()
+    1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U128 => this
   fun bswap(): U128 => @"llvm.bswap.i128"[U128](this)

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -53,6 +53,7 @@ actor Main is TestList
     test(_TestMath128)
     test(_TestDivMod)
     test(_TestAddc)
+    test(_TestNextPow2)
     test(_TestMaybePointer)
     test(_TestValtrace)
     test(_TestCCallback)
@@ -1178,6 +1179,48 @@ class iso _TestAddc is UnitTest
     h.assert_eq[A](expected._1, actual._1)
     h.assert_eq[Bool](expected._2, actual._2)
 
+
+class iso _TestNextPow2 is UnitTest
+  """
+  Test power of 2 computations.
+  """
+  fun name(): String => "builtin/NextPow2"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[U8](32, U8(17).next_pow2())
+    h.assert_eq[U8](16, U8(16).next_pow2())
+    h.assert_eq[U8](1, U8(0).next_pow2())
+    h.assert_eq[U8](1, U8.max_value().next_pow2())
+
+    h.assert_eq[U16](32, U16(17).next_pow2())
+    h.assert_eq[U16](16, U16(16).next_pow2())
+    h.assert_eq[U16](1, U16(0).next_pow2())
+    h.assert_eq[U16](1, U16.max_value().next_pow2())
+
+    h.assert_eq[U32](32, U32(17).next_pow2())
+    h.assert_eq[U32](16, U32(16).next_pow2())
+    h.assert_eq[U32](1, U32(0).next_pow2())
+    h.assert_eq[U32](1, U32.max_value().next_pow2())
+
+    h.assert_eq[U64](32, U64(17).next_pow2())
+    h.assert_eq[U64](16, U64(16).next_pow2())
+    h.assert_eq[U64](1, U64(0).next_pow2())
+    h.assert_eq[U64](1, U64.max_value().next_pow2())
+
+    h.assert_eq[ULong](32, ULong(17).next_pow2())
+    h.assert_eq[ULong](16, ULong(16).next_pow2())
+    h.assert_eq[ULong](1, ULong(0).next_pow2())
+    h.assert_eq[ULong](1, ULong.max_value().next_pow2())
+
+    h.assert_eq[USize](32, USize(17).next_pow2())
+    h.assert_eq[USize](16, USize(16).next_pow2())
+    h.assert_eq[USize](1, USize(0).next_pow2())
+    h.assert_eq[USize](1, USize.max_value().next_pow2())
+
+    h.assert_eq[U128](32, U128(17).next_pow2())
+    h.assert_eq[U128](16, U128(16).next_pow2())
+    h.assert_eq[U128](1, U128(0).next_pow2())
+    h.assert_eq[U128](1, U128.max_value().next_pow2())
 
 struct _TestStruct
   var i: U32 = 0

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -217,6 +217,8 @@ inline int snprintf(char* str, size_t size, const char* format, ...)
 #  define __pony_popcount(X) __builtin_popcount((X))
 #  define __pony_ffs(X) __builtin_ffs((X))
 #  define __pony_ffsl(X) __builtin_ffsl((X))
+#  define __pony_clz(X) __builtin_clz((X))
+#  define __pony_clzl(X) __builtin_clzl((X))
 #else
 #  include <intrin.h>
 #  define __pony_popcount(X) __popcnt((X))
@@ -233,6 +235,20 @@ inline uint64_t __pony_ffsl(uint64_t x)
   DWORD i = 0;
   _BitScanForward64(&i, x);
   return i + 1;
+}
+
+inline uint32_t __pony_clz(uint32_t x)
+{
+  DWORD i = 0;
+  _BitScanReverse(&i, x);
+  return 31 - i;
+}
+
+inline uint64_t __pony_clzl(uint64_t x)
+{
+  DWORD i = 0;
+  _BitScanReverse64(&i, x);
+  return 63 - i;
 }
 
 #endif


### PR DESCRIPTION
We now use the count-leading-zeros compiler builtins, which lower to hardware instructions on modern platforms. This change yields consistent performance gains on x86. ARM wasn't benchmarked but similar
results are expected.

The benchmark program can be found [here](https://gist.github.com/Praetonus/0e0ddb03c70c3cec72c14c5f22a0305a).