### PR TITLE
Include case method docstrings in doc output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Concatenate docstrings from case methods (issue #575).
+
 ### Added
 
 ### Changed

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -301,6 +301,7 @@ void token_set_int(token_t* token, lexint_t* value)
   token->integer = *value;
 }
 
+
 void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos)
 {
   assert(token != NULL);


### PR DESCRIPTION
This PR adds code to concatenate the docstrings of individual case methods into the generated wrapper function (#575).  It grabs the text of each method's parameters and prepends it to the docstrings.

Is OK to change the ID of an AST node as I do in casemethod.c:819ff?  I don't think this should leak, since I've checked that the string is empty.

## Example:

    fun my_case_func(p: Array[USize] iso, q: USize) =>
      """
      This case takes an array of integers and another integer.
      """
      None
  
    fun my_case_func(p: String, q: U32) =>
      """
      This takes a string and an integer.
      """
      None

becomes

### my_case_func

`my_case_func(p: Array[USize] iso, q: USize)`: This case takes an array of integers and another integer.



`my_case_func(p: String, q: U32)`: This takes a string and an integer.



```pony
fun box my_case_func(
  p: (Array[USize val] iso | String val),
  q: (USize val | U32 val))
: None val
```
#### Parameters

*   p: ([Array](builtin-Array)\[[USize](builtin-USize) val\] iso | [String](builtin-String) val)
*   q: ([USize](builtin-USize) val | [U32](builtin-U32) val)

#### Returns

* [None](builtin-None) val
