### PR TITLE
Fix MPMCQ crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - `SSLConnection` ignoring the `sent` notifier method (issue #1268)
+- Runtime crash in the runtime scheduler queues (issue #1319)
 
 ### Added
 

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -478,7 +478,7 @@ static void pool_push(pool_local_t* thread, pool_global_t* global)
 
   cmp = atomic_load_explicit(&global->central, memory_order_acquire);
 
-  uintptr_t mask = UINTPTR_MAX ^ ((1 << POOL_MIN_BITS) - 1);
+  uintptr_t mask = UINTPTR_MAX ^ ((1 << (POOL_MIN_BITS - 1)) - 1);
 
   do
   {
@@ -500,7 +500,7 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
 
   cmp = atomic_load_explicit(&global->central, memory_order_acquire);
 
-  uintptr_t mask = UINTPTR_MAX ^ ((1 << POOL_MIN_BITS) - 1);
+  uintptr_t mask = UINTPTR_MAX ^ ((1 << (POOL_MIN_BITS - 1)) - 1);
 
   do
   {

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -64,7 +64,7 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
   cmp = atomic_load_explicit(&q->tail, memory_order_acquire);
 
   uintptr_t mask = UINTPTR_MAX ^
-    ((1 << (POOL_MIN_BITS + POOL_INDEX(sizeof(mpmcq_node_t*)))) - 1);
+    ((1 << (POOL_MIN_BITS + POOL_INDEX(sizeof(mpmcq_node_t)) - 1)) - 1);
 
   do
   {


### PR DESCRIPTION
We were using one bit too many for the ABA counter.

Closes #1319.