### PR TITLE
Add TCP backpressure hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- TCP read and write backpressure hooks in `TCPConnection (issue #1311)
+
 ### Changed
 
 ## [0.6.0] - 2016-10-20

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -8,6 +8,11 @@ actor Main is TestList
     test(_TestBroadcast)
     test(_TestTCPWritev)
     test(_TestTCPExpect)
+    test(_TestTCPMute)
+    test(_TestTCPUnmute)
+    ifdef not windows then
+      test(_TestTCPThrottle)
+    end
 
 class _TestPing is UDPNotify
   let _h: TestHelper
@@ -301,3 +306,210 @@ class _TestTCPWritevNotifyServer is TCPConnectionNotify
       _h.assert_eq[String](expected, consume buffer)
       _h.complete_action("server receive")
     end
+
+class iso _TestTCPMute is UnitTest
+  """
+  Test that the `mute` behavior stops us from reading incoming data. The
+  test assumes that send/recv works correctly and that the absence of
+  data received is because we muted the connection.
+
+  Test works as follows:
+
+  Once an incoming connection is established, we set mute on it and then
+  verify that within a 2 second long test that received is not called on
+  our notifier. A timeout is considering passing and received being called
+  is grounds for a failure.
+  """
+  fun name(): String => "net/TCPMute"
+  fun label(): String => "tcpmute"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver accepted")
+    h.expect_action("sender connected")
+    h.expect_action("receiver muted")
+    h.expect_action("receiver asks for data")
+    h.expect_action("sender sent data")
+
+    _TestTCP(h)(_TestTCPMuteSendNotify(h),
+      _TestTCPMuteReceiveNotify(h))
+
+    h.long_test(2_000_000_000)
+
+  fun timed_out(h: TestHelper) =>
+    h.complete(true)
+
+class _TestTCPMuteReceiveNotify is TCPConnectionNotify
+  """
+  Notifier to fail a test if we receive data after muting the connection.
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    _h.complete_action("receiver accepted")
+    conn.mute()
+    _h.complete_action("receiver muted")
+    conn.write("send me some data that i won't ever read")
+    _h.complete_action("receiver asks for data")
+    _h.dispose_when_done(conn)
+
+  fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
+    _h.complete(false)
+
+class _TestTCPMuteSendNotify is TCPConnectionNotify
+  """
+  Notifier that sends data back when it receives any. Used in conjunction with
+  the mute receiver to verify that after muting, we don't get any data on
+  to the `received` notifier on the muted connection. We only send in response
+  to data from the receiver to make sure we don't end up failing due to race
+  condition where the senders sends data on connect before the receiver has
+  executed its mute statement.
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: TCPConnection ref) =>
+    _h.complete_action("sender connected")
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("sender connected")
+
+   fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
+     conn.write("it's sad that you won't ever read this")
+     _h.complete_action("sender sent data")
+
+class iso _TestTCPUnmute is UnitTest
+  """
+  Test that the `unmute` behavior will allow a connection to start reading
+  incoming data again. The test assumes that `mute` works correctly and that
+  after muting, `unmute` successfully reset the mute state rather than `mute`
+  being broken and never actually muting the connection.
+
+  Test works as follows:
+
+  Once an incoming connection is established, we set mute on it, request
+  that data be sent to us and then unmute the connection such that we should
+  receive the return data.
+  """
+  fun name(): String => "net/TCPUnmute"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver accepted")
+    h.expect_action("sender connected")
+    h.expect_action("receiver muted")
+    h.expect_action("receiver asks for data")
+    h.expect_action("receiver unmuted")
+    h.expect_action("sender sent data")
+
+    _TestTCP(h)(_TestTCPMuteSendNotify(h),
+      _TestTCPUnmuteReceiveNotify(h))
+
+    h.long_test(2_000_000_000)
+
+class _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
+  """
+  Notifier to test that after muting and unmuting a connection, we get data
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    _h.complete_action("receiver accepted")
+    conn.mute()
+    _h.complete_action("receiver muted")
+    conn.write("send me some data that i won't ever read")
+    _h.complete_action("receiver asks for data")
+    conn.unmute()
+    _h.complete_action("receiver unmuted")
+
+  fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
+    _h.complete(true)
+
+class iso _TestTCPThrottle is UnitTest
+  """
+  Test that when we experience backpressure when sending that the `throttled`
+  method is called on our `TCPConnectionNotify` instance.
+
+  We do this by starting up a server connection, muting it immediately and then
+  sending data to it which should trigger a throttling to happen. We don't
+  start sending data til after the receiver has muted itself and sent the
+  sender data. This verifies that muting has been completed before any data is
+  sent as part of testing throttling.
+
+  This test assumes that muting functionality is working correctly.
+  """
+  fun name(): String => "net/TCPThrottle"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver accepted")
+    h.expect_action("sender connected")
+    h.expect_action("receiver muted")
+    h.expect_action("receiver asks for data")
+    h.expect_action("sender sent data")
+    h.expect_action("sender throttled")
+
+    _TestTCP(h)(_TestTCPThrottleSendNotify(h),
+      _TestTCPThrottleReceiveNotify(h))
+
+    h.long_test(10_000_000_000)
+
+class _TestTCPThrottleReceiveNotify is TCPConnectionNotify
+  """
+  Notifier to that mutes itself on startup. We then send data to it in order
+  to trigger backpressure on the sender.
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    _h.complete_action("receiver accepted")
+    conn.mute()
+    _h.complete_action("receiver muted")
+    conn.write("send me some data that i won't ever read")
+    _h.complete_action("receiver asks for data")
+    _h.dispose_when_done(conn)
+
+class _TestTCPThrottleSendNotify is TCPConnectionNotify
+  """
+  Notifier that sends data back when it receives any. Used in conjunction with
+  the mute receiver to verify that after muting, we don't get any data on
+  to the `received` notifier on the muted connection. We only send in response
+  to data from the receiver to make sure we don't end up failing due to race
+  condition where the senders sends data on connect before the receiver has
+  executed its mute statement.
+  """
+  let _h: TestHelper
+  var _throttled_yet: Bool = false
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: TCPConnection ref) =>
+    _h.complete_action("sender connected")
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("sender connected")
+
+  fun ref received(conn: TCPConnection ref, data: Array[U8] val) =>
+    conn.write("it's sad that you won't ever read this")
+    _h.complete_action("sender sent data")
+
+  fun ref throttled(conn: TCPConnection ref) =>
+    _throttled_yet = true
+    _h.complete_action("sender throttled")
+    _h.complete(true)
+
+  fun ref sent(conn: TCPConnection ref, data: ByteSeq): ByteSeq =>
+    if not _throttled_yet then
+      conn.write("this is more data that you won't ever read")
+    end
+    data

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -39,6 +39,112 @@ actor TCPConnection
           recover MyTCPConnectionNotify(env.out) end, "", "8989")
       end
   ```
+
+  ## Backpressure support
+
+  ### Write
+
+  The TCP protocol has built-in backpressure support. This is generally
+  experienced as the outgoing write buffer becoming full and being unable
+  to write all requested data to the socket. In `TCPConnection`, this is
+  hidden from the programmer. When this occurs, `TCPConnection` will buffer
+  the extra data until such time as it is able to be sent. Left unchecked,
+  this could result in uncontrolled queuing. To address this,
+  `TCPConnectionNotify` implements two methods `throttled` and `unthrottled`
+  that are called when backpressure is applied and released.
+
+  Upon receiving a `throttled` notification, your application has two choices
+  on how to handle it. One is to inform any actors sending the connection to
+  stop sending data. For example, you might construct your application like:
+
+  ```pony
+  // Here we have a TCPConnectionNotify that upon construction
+  // is given a tag to a "Coordinator". Any actors that want to
+  // "publish" to this connection should register with the
+  // coordinator. This allows the notifier to inform the coordinator
+  // that backpressure has been applied and then it in turn can
+  // notify senders who could then pause sending.
+
+  class SlowDown is TCPConnectionNotify
+    let _coordinator: Coordinator
+
+    new create(coordinator: Coordinator) =>
+      _coordinator = coordinator
+
+    fun ref throttled(connection: TCPConnection ref) =>
+      _coordinator.throttled(this)
+
+    fun ref unthrottled(connection: TCPConnection ref) =>
+      _coordinator.unthrottled(this)
+
+  actor Coordinator
+    var _senders: List[Any tag] = _senders.create()
+
+    be register(sender: Any tag) =>
+      _senders.push(sender)
+
+    be throttled(connection: TCPConnection) =>
+      for sender in _senders.values() do
+        sender.pause_sending_to(connection)
+      end
+
+     be unthrottled(connection: TCPConnection) =>
+      for sender in _senders.values() do
+        sender.resume_sending_to(connection)
+      end
+  ```
+
+  Or if you want, you could handle backpressure by shedding load, that is,
+  dropping the extra data rather than carrying out the send. This might look
+  like:
+
+  ```pony
+  class ThrowItAway is TCPConnectionNotify
+    var _throttled = false
+
+    fun ref sent(conn: TCPConnection ref, data: ByteSeq): ByteSeq =>
+      if not _throttled then
+        data
+      else
+        ""
+      end
+
+  fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter =>
+    if not _throttled then
+      data
+    else
+      Array[String]
+    end
+
+    fun ref throttled(connection: TCPConnection ref) =>
+      _throttled = true
+
+    fun ref unthrottled(connection: TCPConnection ref) =>
+      _throttled = false
+  ```
+
+  In general, unless you have a very specific use case, we strongly advise that
+  you don't implement a load shedding scheme where you drop data.
+
+  ### Read
+
+  If your application is unable to keep up with data being sent to it over
+  a `TCPConnection` you can use the builtin read backpressure support to
+  pause reading the socket which will in turn start to exert backpressure on
+  the corresponding writer on the other end of that socket.
+
+  The `mute` behavior allow any other actors in your application to request
+  the cessation of additional reads until such time as `unmute` is called.
+  Please note that this cessation is not guaranteed to happen immediately as
+  it is the result of an asynchronous behavior call and as such will have to
+  wait for existing messages in the `TCPConnection`'s mailbox to be handled.
+
+  On non-windows platforms, your `TCPConnection` will not notice if the
+  other end of the connection closes until you unmute it. Unix type systems
+  like FreeBSD, Linux and OSX learn about a closed connection upon read. On
+  these platforms, you **must** call `unmute` on a muted connection to have
+  it close. Without calling `unmute` the `TCPConnection` actor will never
+  exit.
   """
   var _listen: (TCPListener | None) = None
   var _notify: TCPConnectionNotify
@@ -60,6 +166,8 @@ actor TCPConnection
 
   var _read_len: USize = 0
   var _expect: USize = 0
+
+  var _muted: Bool = false
 
   new create(auth: TCPConnectionAuth, notify: TCPConnectionNotify iso,
     host: String, service: String, from: String = "", init_size: USize = 64,
@@ -153,6 +261,19 @@ actor TCPConnection
 
       _in_sent = false
     end
+
+  be mute() =>
+    """
+    Temporarily suspend reading off this TCPConnection until such time as
+    `unmute` is called.
+    """
+    _muted = true
+
+  be unmute() =>
+    """
+    Start reading off this TCPConnection again after having been muted.
+    """
+    _muted = false
 
   be set_notify(notify: TCPConnectionNotify iso) =>
     """
@@ -295,6 +416,13 @@ actor TCPConnection
           // Add an IOCP write.
           @pony_os_send[USize](_event, data.cpointer(), data.size()) ?
           _pending.push((data, 0))
+
+          if _pending.size() > 32 then
+            // If more than 32 asynchronous writes are scheduled, apply
+            // backpressure. The choice of 32 is rather arbitrary an
+            // probably needs tuning
+            _apply_backpressure()
+          end
         end
       else
         if _writeable then
@@ -306,7 +434,7 @@ actor TCPConnection
             if len < data.size() then
               // Send any remaining data later.
               _pending.push((data, len))
-              _writeable = false
+              _apply_backpressure()
             end
           else
             // Non-graceful shutdown on error.
@@ -349,6 +477,13 @@ actor TCPConnection
           end
         end
       end
+
+      if _pending.size() < 16 then
+        // If fewer than 16 asynchronous writes are scheduled, remove
+        // backpressure. The choice of 16 is rather arbitrary and probably
+        // needs to be tuned.
+        _release_backpressure()
+      end
     end
 
   fun ref _pending_writes() =>
@@ -373,6 +508,10 @@ actor TCPConnection
           else
             // This chunk has been fully sent.
             _pending.shift()
+
+            if _pending.size() == 0 then
+              _release_backpressure()
+            end
           end
         else
           // Non-graceful shutdown on error.
@@ -401,7 +540,7 @@ actor TCPConnection
 
       _read_len = _read_len + len.usize()
 
-      if _read_len >= _expect then
+      if (not _muted) and (_read_len >= _expect) then
         let data = _read_buf = recover Array[U8] end
         data.truncate(_read_len)
         _read_len = 0
@@ -440,15 +579,20 @@ actor TCPConnection
 
   fun ref _pending_reads() =>
     """
-    Read while data is available, guessing the next packet length as we go. If
-    we read 4 kb of data, send ourself a resume message and stop reading, to
-    avoid starving other actors.
+    Unless this connection is currently muted, read while data is available,
+    guessing the next packet length as we go. If we read 4 kb of data, send
+    ourself a resume message and stop reading, to avoid starving other actors.
     """
     ifdef not windows then
       try
         var sum: USize = 0
 
         while _readable and not _shutdown_peer do
+          if _muted then
+            _read_again()
+            return
+          end
+
           // Read as much data as possible.
           let len = @pony_os_recv[USize](
             _event,
@@ -504,9 +648,22 @@ actor TCPConnection
 
   fun ref close() =>
     """
-    Perform a graceful shutdown. Don't accept new writes, but don't finish
-    closing until we get a zero length read.
+    Attempt to perform a graceful shutdown. Don't accept new writes. If the
+    connection isn't muted then we won't finish closing until we get a zero
+    length read.  If the connection is muted, perform a hard close and
+    shut down immediately.
     """
+     ifdef windows then
+      _close()
+    else
+      if _muted then
+        _hard_close()
+      else
+       _close()
+     end
+    end
+
+  fun ref _close() =>
     _closed = true
     _try_shutdown()
 
@@ -573,3 +730,13 @@ actor TCPConnection
     _notify.closed(this)
 
     try (_listen as TCPListener)._conn_closed() end
+
+  fun ref _apply_backpressure() =>
+    ifdef not windows then
+      _writeable = false
+    end
+
+    _notify.throttled(this)
+
+  fun ref _release_backpressure() =>
+    _notify.unthrottled(this)

--- a/packages/net/tcp_connection_notify.pony
+++ b/packages/net/tcp_connection_notify.pony
@@ -77,3 +77,22 @@ interface TCPConnectionNotify
     Called when the connection is closed.
     """
     None
+
+  fun ref throttled(conn: TCPConnection ref) =>
+    """
+    Called when the connection starts experiencing TCP backpressure. You should
+    respond to this by pausing additional calls to `write` and `writev` until
+    you are informed that pressure has been released. Failure to respond to
+    the `throttled` notification will result in outgoing data queuing in the
+    connection and increasing memory usage.
+    """
+    None
+
+  fun ref unthrottled(conn: TCPConnection ref) =>
+    """
+    Called when the connection stops experiencing TCP backpressure. Upon
+    receiving this notification, you should feel free to start making calls to
+    `write` and `writev` again.
+    """
+    None
+


### PR DESCRIPTION
Implements RFC #17:
https://github.com/ponylang/rfcs/blob/master/text/0017-tcp-backpressure.md

TCP provides backpressure to signal to applications that they need to
slow down sending, however, currently Pony while itself being signaled
that backpressure is being applied, doesn't surface that to application
code. This means that even a well meaning, diligent programmer is unable
to respond to backpressure by slowing down.

Additionally, currently Pony applications that are TCP receivers can't
participate in this system as they have no way of preventing
TCPConnection from continuing to read all available data.

This commit add support for TCP backpressure to TCPConnection.