### PR TITLE
 Add support for arbitrary expressions as default values in documentation

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -721,7 +721,7 @@ const char* ast_get_print(ast_t* ast)
 
 char* ast_string_escape(ast_t* ast)
 {
-  assert(ast != NULL && ast_id(ast) == TK_STRING);
+  pony_assert(ast != NULL && ast_id(ast) == TK_STRING);
   return token_print_escaped(ast->t);
 }
 

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -719,6 +719,12 @@ const char* ast_get_print(ast_t* ast)
   return token_print(ast->t);
 }
 
+char* ast_string_escape(ast_t* ast)
+{
+  assert(ast != NULL && ast_id(ast) == TK_STRING);
+  return token_print_escaped(ast->t);
+}
+
 const char* ast_name(ast_t* ast)
 {
   pony_assert(ast != NULL);

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -91,6 +91,7 @@ void ast_resetpass(ast_t *ast, uint32_t flag);
 const char* ast_get_print(ast_t* ast);
 const char* ast_name(ast_t* ast);
 const char* ast_nice_name(ast_t* ast);
+char* ast_string_escape(ast_t* ast);
 size_t ast_name_len(ast_t* ast);
 void ast_set_name(ast_t* ast, const char* name);
 double ast_float(ast_t* ast);

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -254,6 +254,7 @@ char* token_print_escaped(token_t* token)
   return escaped;
 }
 
+
 const char* token_id_desc(token_id id)
 {
   switch(id)

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -254,7 +254,6 @@ char* token_print_escaped(token_t* token)
   return escaped;
 }
 
-
 const char* token_id_desc(token_id id)
 {
   switch(id)


### PR DESCRIPTION
This fixes an issue where a recover-expression would get printed
as simply "recover", leaving out both the actual expression as well
as the "end" token.

The `doc_expression` function writes out an expression provided
as an AST node to the provided document.

This closes #1262.
