### PR TITLE
Fix typo in reference to __clang_major__ in atomics.h.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Compiling ponyrt with Clang versions >= 3.3, < 3.6.
+
 ### Added
 
 - DTrace and SystemTap support - `use=dtrace`

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -55,7 +55,7 @@ using std::atomic_fetch_sub_explicit;
 #      include <stdatomic.h>
 #    endif
 #    define PONY_ATOMIC(T) T _Atomic
-#  elif __clang_major >= 3 && __clang_minor__ >= 3
+#  elif __clang_major__ >= 3 && __clang_minor__ >= 3
 // Valid on x86 and ARM given our uses of atomics.
 #    define PONY_ATOMIC(T) T
 #    define PONY_ATOMIC_BUILTINS


### PR DESCRIPTION
This PR fixes a small typo in reference to `__clang_major__` in `atomics.h`.

The typo was referencing this "magic define" without the two trailing underscores.  This was causing all Clangs `< 3.6` to be seen as `< 3.3`.