### PR TITLE
Fix compiler assert fail on circular type inference error (issue #1334)

### DIFF
--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -675,9 +675,6 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
 
       ast_t* type = ast_type(def);
 
-      if(is_typecheck_error(type))
-        return false;
-
       if(type != NULL && ast_id(type) == TK_INFERTYPE)
       {
         ast_error(opt->check.errors, ast, "cannot infer type of %s\n",
@@ -686,6 +683,9 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
         ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
         return false;
       }
+
+      if(is_typecheck_error(type))
+        return false;
 
       if(!valid_reference(opt, ast, type, status))
         return false;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -259,7 +259,9 @@ TEST_F(BadPonyTest, WithBlockTypeInference)
     "  new create(env: Env) =>\n"
     "    with x = 1 do None end";
 
-  TEST_ERRORS_1(src, "could not infer literal type, no valid types found");
+  TEST_ERRORS_3(src, "could not infer literal type, no valid types found",
+                     "cannot infer type of $1$0",
+                     "cannot infer type of x");
 }
 
 TEST_F(BadPonyTest, EmbedNestedTuple)
@@ -277,4 +279,17 @@ TEST_F(BadPonyTest, EmbedNestedTuple)
     "    (foo, x) = (Foo.get_foo(), 42)";
 
   TEST_ERRORS_1(src, "an embedded field must be assigned using a constructor");
+}
+
+TEST_F(BadPonyTest, CircularTypeInfer)
+{
+  // From issue #1334
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x = x.create()\n"
+    "    let y = y.create()";
+
+  TEST_ERRORS_2(src, "cannot infer type of x",
+                     "cannot infer type of y");
 }


### PR DESCRIPTION
This PR fixes a compiler assert fail on circular type inference error.

Resolves #1334.
