### PR TITLE
Run tests sequentially

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -129,10 +129,10 @@ test_script:
   - C:\projects\ponyc\build\%CONFIGURATION%\testrt.exe
   - CALL "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\vcvars64.bat"
   - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s --verify packages/stdlib
-  - stdlib.exe
+  - stdlib.exe --sequential
   - del stdlib.exe
   - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ --verify packages/stdlib
-  - stdlib.exe
+  - stdlib.exe --sequential
   - del stdlib.exe
   - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s --verify examples
   - examples.exe

--- a/Makefile
+++ b/Makefile
@@ -624,7 +624,7 @@ test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
 	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib
-	@./stdlib
+	@./stdlib --sequential
 	@rm stdlib
 
 test-examples: all

--- a/Makefile
+++ b/Makefile
@@ -636,10 +636,10 @@ test-ci: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
 	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib
-	@./stdlib
+	@./stdlib --sequential
 	@rm stdlib
 	@$(PONY_BUILD_DIR)/ponyc --verify packages/stdlib
-	@./stdlib
+	@./stdlib --sequential
 	@rm stdlib
 	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
 	@./examples1


### PR DESCRIPTION
See if this solves our flakey test problem. My theory is that we have
failing tests because, we are running more tests and have more
contention on the scheduler so we are more likely to hit timeouts.

If flakey tests disappear when running sequentially then adding a
facility to exclude certain groups from tests would work well.
Something like:

run all tests except X, Y, Z "groups"
run X
run Y
run Z

This could be jammed into existing label and exclusion group support
but I think that address it head on via some new addition to PonyTest
would make sense.

This initial commit to test sequentiality is meant to:

* Verify that it doesn't take too long to run all our tests in a
sequential fashion
* Verify that running sequentially fixes our problem

If this commit doesn't increase CI times by too much, I'll merge it
and we can observe if it starts fixing the flakey test issue.
If it does, we can proceed from there.