### PR TITLE
Array.clone should return an iso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- `Array.clone()` now correctly returns an iso reference.
+
 ### Added
 
 ### Changed

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -448,16 +448,16 @@ class Array[A] is Seq[A]
 
     error
 
-  fun clone(): Array[this->A!]^ =>
+  fun clone(): Array[this->A!] iso^ =>
     """
     Clone the array.
     The new array contains references to the same elements that the old array
     contains, the elements themselves are not cloned.
     """
-    let out = Array[this->A!](_size)
-    _ptr._copy_to(out._ptr, _size)
+    let out = recover Array[this->A!](_size) end
+    _ptr._copy_to(out._ptr._unsafe(), _size)
     out._size = _size
-    out
+    consume out
 
   fun slice(from: USize = 0, to: USize = -1, step: USize = 1)
     : Array[this->A!]^

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -43,6 +43,7 @@ actor Main is TestList
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
+    test(_TestArrayClone)
     test(_TestArrayConcat)
     test(_TestArraySlice)
     test(_TestArrayTrim)
@@ -807,6 +808,14 @@ class iso _TestArrayAppend is UnitTest
     h.assert_eq[String]("three", a(2))
     h.assert_eq[String]("five", a(3))
 
+class iso _TestArrayClone is UnitTest
+  fun name(): String => "builtin/Array.clone"
+
+  fun apply(h: TestHelper) =>
+    var a = ["one", "two", "three"]
+    var b: Array[String] val = a.clone()
+    a.append(b)
+    h.assert_eq[USize](a.size(), 6)
 
 class iso _TestArrayConcat is UnitTest
   fun name(): String => "builtin/Array.concat"


### PR DESCRIPTION
This is analogous to `String.clone` and allows for example cloning an `Array ref` and then make it sendable.

With this change, we can write a valid program such as:
```pony
actor Foo
  let _s: Array[String val]

  new create(s: Array[String val] iso) =>
    _s = consume s

actor Main
  var _s: Array[String val] = [""]

  new create(env:Env) =>
    let s = _s.clone()
    Foo.create(consume s)
```
Note that I added a test case for `Array.clone()` – it was missing.