### PR TITLE
Add pony_send_next runtime function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- Runtime function `pony_send_next`. This function can help optimise some message sending scenarios.
+
 ### Changed
 
 ## [0.6.0] - 2016-10-20

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -85,6 +85,12 @@ void pony_release_done(pony_ctx_t* ctx)
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 
+void pony_send_next(pony_ctx_t* ctx)
+{
+  ponyint_gc_handlestack(ctx);
+  ponyint_gc_done(ponyint_actor_gc(ctx->current));
+}
+
 void pony_trace(pony_ctx_t* ctx, void* p)
 {
   ctx->trace_object(ctx, p, NULL, PONY_TRACE_OPAQUE);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -267,6 +267,17 @@ void pony_acquire_done(pony_ctx_t* ctx);
  */
 void pony_release_done(pony_ctx_t* ctx);
 
+/** Continue gc tracing with another message.
+ *
+ * When sending multiple messages following each other, you can use this
+ * function to trace the content of every message in one
+ * pony_gc_send/pony_send_done round instead of doing one pair of calls for each
+ * message. Call pony_send_next before tracing the content of a new message.
+ * Using this function can reduce the amount of gc-specific messages
+ * sent.
+ */
+void pony_send_next(pony_ctx_t* ctx);
+
 /** Identifiers for reference capabilities when tracing.
  *
  * At runtime, we need to identify if the object is logically mutable,


### PR DESCRIPTION
This new function allows switching to a new message when tracing message contents before sending. The two following code snippets are equivalent.

```c
pony_gc_send(ctx);                | pony_gc_send(ctx);
pony_trace(ctx, obj);             | pony_trace(ctx, obj);
pony_send_done();                 | pony_send_next(ctx);
pony_sendp(ctx, to, mid, obj);    | pony_trace(ctx, obj2);
pony_gc_send(ctx);                | pony_send_done();
pony_trace(ctx, obj2);            | pony_sendp(ctx, to, mid, obj);
pony_send_done();                 | pony_sendp(ctx, to2, mid2, obj2);
pony_sendp(ctx, to2, mid2, obj2); |
```

Using `pony_send_next` can reduce the amount of GC acquire messages that must be sent. Using the function never results in more work being performed.

An optimisation pass taking advantage of this function will be added to the compiler in the future.