### PR TITLE
Trace message contents in the sender context

### DIFF
--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -6,6 +6,9 @@
 
 PONY_EXTERN_C_BEGIN
 
+void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
+  ast_t* args_ast);
+
 LLVMValueRef gen_funptr(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_call(compile_t* c, ast_t* ast);

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -135,6 +135,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
 
   // Behaviours and actor constructors also have handler functions.
   bool handler = false;
+  bool only_needs_msg_type = false;
 
   switch(ast_id(m->r_fun))
   {
@@ -159,32 +160,52 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     case TK_ACTOR:
       break;
 
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    case TK_INTERFACE:
+    case TK_TRAIT:
+      only_needs_msg_type = true;
+      break;
+
     default:
+      assert(0);
       return;
   }
 
-  if(handler)
+  if(handler || only_needs_msg_type)
   {
-    // Generate the sender prototype.
-    const char* sender_name = genname_be(m->full_name);
-    m->func = codegen_addfun(c, sender_name, m->func_type);
-    genfun_param_attrs(c, t, m, m->func);
-
-    // Change the return type to void for the handler.
-    size_t count = LLVMCountParamTypes(m->func_type);
+    size_t count = LLVMCountParamTypes(m->func_type) + 2;
     size_t buf_size = count * sizeof(LLVMTypeRef);
     LLVMTypeRef* tparams = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
-    LLVMGetParamTypes(m->func_type, tparams);
+    LLVMGetParamTypes(m->func_type, &tparams[2]);
 
-    LLVMTypeRef handler_type = LLVMFunctionType(c->void_type, tparams,
-      (int)count, false);
+    if(!only_needs_msg_type)
+    {
+      // Generate the sender prototype.
+      const char* sender_name = genname_be(m->full_name);
+      m->func = codegen_addfun(c, sender_name, m->func_type);
+      genfun_param_attrs(c, t, m, m->func);
+
+      // Change the return type to void for the handler.
+      LLVMTypeRef handler_type = LLVMFunctionType(c->void_type, &tparams[2],
+        (int)count - 2, false);
+
+      // Generate the handler prototype.
+      m->func_handler = codegen_addfun(c, m->full_name, handler_type);
+      genfun_param_attrs(c, t, m, m->func_handler);
+      make_function_debug(c, t, m, m->func_handler);
+    }
+
+    // Generate the message type.
+    tparams[0] = c->i32;
+    tparams[1] = c->i32;
+    tparams[2] = c->void_ptr;
+
+    m->msg_type = LLVMStructTypeInContext(c->context, tparams, (int)count,
+      false);
+
     ponyint_pool_free_size(buf_size, tparams);
-
-    // Generate the handler prototype.
-    m->func_handler = codegen_addfun(c, m->full_name, handler_type);
-    genfun_param_attrs(c, t, m, m->func_handler);
-    make_function_debug(c, t, m, m->func_handler);
-  } else {
+  } else if(!handler) {
     // Generate the function prototype.
     m->func = codegen_addfun(c, m->full_name, m->func_type);
     genfun_param_attrs(c, t, m, m->func);
@@ -199,84 +220,6 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
     LLVMSetLinkage(m->func, LLVMExternalLinkage);
   }
-}
-
-static LLVMTypeRef send_message(compile_t* c, ast_t* params, LLVMValueRef to,
-  LLVMValueRef func, uint32_t index)
-{
-  // Get the parameter types.
-  LLVMTypeRef f_type = LLVMGetElementType(LLVMTypeOf(func));
-  int count = LLVMCountParamTypes(f_type) + 2;
-
-  size_t buf_size = count * sizeof(LLVMTypeRef);
-  LLVMTypeRef* f_params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
-  LLVMGetParamTypes(f_type, &f_params[2]);
-
-  // The first one becomes the message size, the second the message ID.
-  f_params[0] = c->i32;
-  f_params[1] = c->i32;
-  f_params[2] = c->void_ptr;
-  LLVMTypeRef msg_type = LLVMStructTypeInContext(c->context, f_params, count,
-    false);
-  LLVMTypeRef msg_type_ptr = LLVMPointerType(msg_type, 0);
-  ponyint_pool_free_size(buf_size, f_params);
-
-  // Allocate the message, setting its size and ID.
-  size_t msg_size = (size_t)LLVMABISizeOfType(c->target_data, msg_type);
-  LLVMValueRef args[3];
-
-  args[0] = LLVMConstInt(c->i32, ponyint_pool_index(msg_size), false);
-  args[1] = LLVMConstInt(c->i32, index, false);
-  LLVMValueRef msg = gencall_runtime(c, "pony_alloc_msg", args, 2, "");
-  LLVMValueRef msg_ptr = LLVMBuildBitCast(c->builder, msg, msg_type_ptr, "");
-
-  for(int i = 3; i < count; i++)
-  {
-    LLVMValueRef arg = LLVMGetParam(func, i - 2);
-    LLVMValueRef arg_ptr = LLVMBuildStructGEP(c->builder, msg_ptr, i, "");
-    LLVMBuildStore(c->builder, arg, arg_ptr);
-  }
-
-  // Trace while populating the message contents.
-  LLVMValueRef ctx = codegen_ctx(c);
-
-  ast_t* param = ast_child(params);
-  bool need_trace = false;
-
-  while(param != NULL)
-  {
-    if(gentrace_needed(ast_type(param)))
-    {
-      need_trace = true;
-      break;
-    }
-
-    param = ast_sibling(param);
-  }
-
-  if(need_trace)
-  {
-    gencall_runtime(c, "pony_gc_send", &ctx, 1, "");
-    param = ast_child(params);
-
-    for(int i = 3; i < count; i++)
-    {
-      LLVMValueRef arg = LLVMGetParam(func, i - 2);
-      gentrace(c, ctx, arg, ast_type(param));
-      param = ast_sibling(param);
-    }
-
-    gencall_runtime(c, "pony_send_done", &ctx, 1, "");
-  }
-
-  // Send the message.
-  args[0] = ctx;
-  args[1] = LLVMBuildBitCast(c->builder, to, c->object_ptr, "");
-  args[2] = msg;
-  gencall_runtime(c, "pony_sendv", args, 3, "");
-
-  // Return the type of the message.
-  return msg_type_ptr;
 }
 
 static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
@@ -312,7 +255,7 @@ static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
 
   while(param != NULL)
   {
-    if(gentrace_needed(ast_type(param)))
+    if(gentrace_needed(c, ast_type(param), NULL))
     {
       need_trace = true;
       break;
@@ -328,7 +271,7 @@ static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
 
     for(int i = 1; i < count; i++)
     {
-      gentrace(c, ctx, args[i], ast_type(param));
+      gentrace(c, ctx, args[i], ast_type(param), NULL);
       param = ast_sibling(param);
     }
 
@@ -409,17 +352,21 @@ static bool genfun_be(compile_t* c, reach_type_t* t, reach_method_t* m)
 
   // Generate the sender.
   codegen_startfun(c, m->func, NULL, NULL);
-  LLVMValueRef this_ptr = LLVMGetParam(m->func, 0);
+  size_t buf_size = (m->param_count + 1) * sizeof(LLVMValueRef);
+  LLVMValueRef* param_vals = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
+  LLVMGetParams(m->func, param_vals);
 
   // Send the arguments in a message to 'this'.
-  LLVMTypeRef msg_type_ptr = send_message(c, params, this_ptr, m->func,
-    m->vtable_index);
+  gen_send_message(c, m, param_vals, params);
 
   // Return 'this'.
-  LLVMBuildRet(c->builder, this_ptr);
+  LLVMBuildRet(c->builder, param_vals[0]);
   codegen_finishfun(c);
 
+  ponyint_pool_free_size(buf_size, param_vals);
+
   // Add the dispatch case.
+  LLVMTypeRef msg_type_ptr = LLVMPointerType(m->msg_type, 0);
   add_dispatch_case(c, t, params, m->vtable_index, m->func_handler,
     msg_type_ptr);
 
@@ -478,22 +425,23 @@ static bool genfun_newbe(compile_t* c, reach_type_t* t, reach_method_t* m)
   LLVMBuildRetVoid(c->builder);
   codegen_finishfun(c);
 
-  // Generate the sender.
+    // Generate the sender.
   codegen_startfun(c, m->func, NULL, NULL);
-  LLVMValueRef this_ptr = LLVMGetParam(m->func, 0);
+  size_t buf_size = (m->param_count + 1) * sizeof(LLVMValueRef);
+  LLVMValueRef* param_vals = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
+  LLVMGetParams(m->func, param_vals);
 
   // Send the arguments in a message to 'this'.
-  LLVMTypeRef msg_type_ptr = send_message(c, params, this_ptr, m->func,
-    m->vtable_index);
+  gen_send_message(c, m, param_vals, params);
 
   // Return 'this'.
-  codegen_debugloc(c, ast_childlast(body));
-  LLVMBuildRet(c->builder, this_ptr);
-  codegen_debugloc(c, NULL);
-
+  LLVMBuildRet(c->builder, param_vals[0]);
   codegen_finishfun(c);
 
+  ponyint_pool_free_size(buf_size, param_vals);
+
   // Add the dispatch case.
+  LLVMTypeRef msg_type_ptr = LLVMPointerType(m->msg_type, 0);
   add_dispatch_case(c, t, params, m->vtable_index, m->func_handler,
     msg_type_ptr);
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -669,7 +669,7 @@ static void trace_array_elements(compile_t* c, reach_type_t* t,
   ast_t* typeargs = ast_childidx(t->ast, 2);
   ast_t* typearg = ast_child(typeargs);
 
-  if(!gentrace_needed(typearg))
+  if(!gentrace_needed(c, typearg, NULL))
     return;
 
   reach_type_t* t_elem = reach_type(c->reach, typearg);
@@ -699,7 +699,7 @@ static void trace_array_elements(compile_t* c, reach_type_t* t,
   LLVMValueRef elem_ptr = LLVMBuildInBoundsGEP(c->builder, pointer, &phi, 1,
     "");
   LLVMValueRef elem = LLVMBuildLoad(c->builder, elem_ptr, "");
-  gentrace(c, ctx, elem, typearg);
+  gentrace(c, ctx, elem, typearg, NULL);
 
   // Add one to the phi node and branch back to the cond block.
   LLVMValueRef one = LLVMConstInt(c->intptr, 1, false);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -369,7 +369,7 @@ static void trace_maybe(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   LLVMBuildCondBr(c->builder, test, is_true, is_false);
 
   LLVMPositionBuilderAtEnd(c->builder, is_false);
-  gentrace(c, ctx, object, elem);
+  gentrace(c, ctx, object, elem, NULL);
   LLVMBuildBr(c->builder, is_true);
 
   LLVMPositionBuilderAtEnd(c->builder, is_true);
@@ -401,19 +401,35 @@ static void trace_unknown(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 }
 
 static void trace_tuple(compile_t* c, LLVMValueRef ctx, LLVMValueRef value,
-  ast_t* type)
+  ast_t* src_type, ast_t* dst_type)
 {
   int i = 0;
 
   // We're a tuple, determined statically.
-  for(ast_t* child = ast_child(type);
-    child != NULL;
-    child = ast_sibling(child))
+  if(dst_type != NULL)
   {
-    // Extract each element and trace it.
-    LLVMValueRef elem = LLVMBuildExtractValue(c->builder, value, i, "");
-    gentrace(c, ctx, elem, child);
-    i++;
+    ast_t* src_child = ast_child(src_type);
+    ast_t* dst_child = ast_child(dst_type);
+    while((src_child != NULL) && (dst_child != NULL))
+    {
+      // Extract each element and trace it.
+      LLVMValueRef elem = LLVMBuildExtractValue(c->builder, value, i, "");
+      gentrace(c, ctx, elem, src_child, dst_child);
+      i++;
+      src_child = ast_sibling(src_child);
+      dst_child = ast_sibling(dst_child);
+    }
+    assert(src_child == NULL && dst_child == NULL);
+  } else {
+    ast_t* src_child = ast_child(src_type);
+    while(src_child != NULL)
+    {
+      // Extract each element and trace it.
+      LLVMValueRef elem = LLVMBuildExtractValue(c->builder, value, i, "");
+      gentrace(c, ctx, elem, src_child, NULL);
+      i++;
+      src_child = ast_sibling(src_child);
+    }
   }
 }
 
@@ -567,7 +583,7 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
   if(ast_id(def) == TK_PRIMITIVE)
     return;
 
-  // If it's not possible to use match or as to extract this type from the
+  // If it's not possible to use match or to extract this type from the
   // original type, there's no need to trace as this type.
   if(tuple != NULL)
   {
@@ -591,7 +607,7 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
 
   // Trace as this type.
   LLVMPositionBuilderAtEnd(c->builder, is_true);
-  gentrace(c, ctx, object, type);
+  gentrace(c, ctx, object, type, NULL);
 
   // If we have traced as mut or val, we're done with this element. Otherwise,
   // continue tracing this as if the match had been unsuccessful.
@@ -643,26 +659,58 @@ static void trace_dynamic(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   }
 }
 
-bool gentrace_needed(ast_t* type)
+bool gentrace_needed(compile_t* c, ast_t* src_type, ast_t* dst_type)
 {
-  switch(trace_type(type))
+  switch(trace_type(src_type))
   {
     case TRACE_NONE:
       assert(0);
       return false;
 
     case TRACE_MACHINE_WORD:
+    {
+      if(dst_type == NULL)
+        return false;
+
+      reach_type_t* dst_rtype = reach_type(c->reach, dst_type);
+      switch(dst_rtype->underlying)
+      {
+        case TK_UNIONTYPE:
+        case TK_ISECTTYPE:
+        case TK_INTERFACE:
+        case TK_TRAIT:
+          return true;
+
+        default:
+          return false;
+      }
+    }
+
     case TRACE_PRIMITIVE:
       return false;
 
     case TRACE_TUPLE:
     {
-      for(ast_t* child = ast_child(type);
-        child != NULL;
-        child = ast_sibling(child))
+      if(dst_type != NULL)
       {
-        if(gentrace_needed(child))
-          return true;
+        ast_t* src_child = ast_child(src_type);
+        ast_t* dst_child = ast_child(dst_type);
+        while((src_child != NULL) && (dst_child != NULL))
+        {
+          if(gentrace_needed(c, src_child, dst_child))
+            return true;
+          src_child = ast_sibling(src_child);
+          dst_child = ast_sibling(dst_child);
+        }
+        assert(src_child == NULL && dst_child == NULL);
+      } else {
+        ast_t* src_child = ast_child(src_type);
+        while(src_child != NULL)
+        {
+          if(gentrace_needed(c, src_child, NULL))
+            return true;
+          src_child = ast_sibling(src_child);
+        }
       }
 
       return false;
@@ -691,7 +739,7 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
 
   for(uint32_t i = 0; i < t->field_count; i++)
   {
-    if(gentrace_needed(t->fields[i].ast))
+    if(gentrace_needed(c, t->fields[i].ast, NULL))
     {
       need_trace = true;
       break;
@@ -704,24 +752,44 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
   t->trace_fn = codegen_addfun(c, genname_trace(t->name), c->trace_type);
 }
 
-void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)
+void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value,
+  ast_t* src_type, ast_t* dst_type)
 {
-  switch(trace_type(type))
+  switch(trace_type(src_type))
   {
     case TRACE_NONE:
       assert(0);
       return;
 
     case TRACE_MACHINE_WORD:
+    {
+      if(dst_type == NULL)
+        return;
+
+      reach_type_t* dst_rtype = reach_type(c->reach, dst_type);
+      switch(dst_rtype->underlying)
+      {
+        case TK_UNIONTYPE:
+        case TK_ISECTTYPE:
+        case TK_INTERFACE:
+        case TK_TRAIT:
+          trace_known(c, ctx, value, src_type, PONY_TRACE_IMMUTABLE);
+          return;
+
+        default:
+          return;
+      }
+    }
+
     case TRACE_PRIMITIVE:
       return;
 
     case TRACE_MAYBE:
-      trace_maybe(c, ctx, value, type);
+      trace_maybe(c, ctx, value, src_type);
       return;
 
     case TRACE_VAL_KNOWN:
-      trace_known(c, ctx, value, type, PONY_TRACE_IMMUTABLE);
+      trace_known(c, ctx, value, src_type, PONY_TRACE_IMMUTABLE);
       return;
 
     case TRACE_VAL_UNKNOWN:
@@ -729,7 +797,7 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)
       return;
 
     case TRACE_MUT_KNOWN:
-      trace_known(c, ctx, value, type, PONY_TRACE_MUTABLE);
+      trace_known(c, ctx, value, src_type, PONY_TRACE_MUTABLE);
       return;
 
     case TRACE_MUT_UNKNOWN:
@@ -737,7 +805,7 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)
       return;
 
     case TRACE_TAG_KNOWN:
-      trace_known(c, ctx, value, type, PONY_TRACE_OPAQUE);
+      trace_known(c, ctx, value, src_type, PONY_TRACE_OPAQUE);
       return;
 
     case TRACE_TAG_UNKNOWN:
@@ -747,14 +815,17 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type)
     case TRACE_DYNAMIC:
     {
       LLVMBasicBlockRef next_block = codegen_block(c, "");
-      trace_dynamic(c, ctx, value, type, type, NULL, next_block);
+      if(dst_type == NULL)
+        trace_dynamic(c, ctx, value, src_type, src_type, NULL, next_block);
+      else
+        trace_dynamic(c, ctx, value, dst_type, dst_type, NULL, next_block);
       LLVMBuildBr(c->builder, next_block);
       LLVMPositionBuilderAtEnd(c->builder, next_block);
       return;
     }
 
     case TRACE_TUPLE:
-      trace_tuple(c, ctx, value, type);
+      trace_tuple(c, ctx, value, src_type, dst_type);
       return;
   }
 }

--- a/src/libponyc/codegen/gentrace.h
+++ b/src/libponyc/codegen/gentrace.h
@@ -6,11 +6,12 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool gentrace_needed(ast_t* type);
+bool gentrace_needed(compile_t* c, ast_t* src_type, ast_t* dst_type);
 
 void gentrace_prototype(compile_t* c, reach_type_t* t);
 
-void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value, ast_t* type);
+void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef value,
+  ast_t* src_type, ast_t* dst_type);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -675,7 +675,7 @@ static bool make_trace(compile_t* c, reach_type_t* t)
     {
       // Call the trace function indirectly depending on rcaps.
       LLVMValueRef value = LLVMBuildLoad(c->builder, field, "");
-      gentrace(c, ctx, value, t->fields[i].ast);
+      gentrace(c, ctx, value, t->fields[i].ast, NULL);
     } else {
       // Call the trace function directly without marking the field.
       LLVMValueRef trace_fn = t->fields[i].type->trace_fn;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -36,6 +36,7 @@ struct reach_method_t
   uint32_t vtable_index;
 
   LLVMTypeRef func_type;
+  LLVMTypeRef msg_type;
   LLVMValueRef func;
   LLVMValueRef func_handler;
   LLVMMetadataRef di_method;


### PR DESCRIPTION
This change inlines message tracing and sending in caller functions. It will allow tracing the most precise object type possible, for performance. If the call is made through an interface and it cannot be proven that it is a message send, a virtual call is made.