### PR TITLE
Enable LLVM 3.9 in Travis OSX builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,12 +116,14 @@ matrix:
         - CXX1=g++-5
     - os: osx
       env:
+        - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=debug
         - CC1=clang-3.6
         - CXX1=clang++-3.6
     - os: osx
       env:
+        - LLVM_VERSION="3.6.2"
         - LLVM_CONFIG="llvm-config-3.6"
         - config=release
         - lto=no
@@ -129,12 +131,14 @@ matrix:
         - CXX1=clang++-3.6
     - os: osx
       env:
+        - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
         - CC1=clang-3.7
         - CXX1=clang++-3.7
     - os: osx
       env:
+        - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
         - lto=no
@@ -142,30 +146,34 @@ matrix:
         - CXX1=clang++-3.7
     - os: osx
       env:
+        - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=debug
         - CC1=clang-3.8
         - CXX1=clang++-3.8
     - os: osx
       env:
+        - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
         - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
-    # LLVM 3.9 can be enabled for OSX once Homebrew supports it.
-    #- os: osx
-    #  env:
-    #    - LLVM_CONFIG="llvm-config-3.9"
-    #    - config=debug
-    #    - CC1=clang-3.9
-    #    - CXX1=clang++-3.9
-    #- os: osx
-    #  env:
-    #    - LLVM_CONFIG="llvm-config-3.9"
-    #    - config=release
-    #    - CC1=clang-3.9
-    #    - CXX1=clang++-3.9
+    - os: osx
+      env:
+        - LLVM_VERSION="3.9.0"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=debug
+        - CC1=clang-3.9
+        - CXX1=clang++-3.9
+    - os: osx
+      env:
+        - LLVM_VERSION="3.9.0"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=release
+        - lto=no
+        - CC1=clang-3.9
+        - CXX1=clang++-3.9
 
 
 rvm:
@@ -208,7 +216,28 @@ install:
     then
       brew update;
       brew install gmp; brew link --overwrite gmp;
-      brew install llvm36 llvm37 llvm38 pcre2 libressl;
+      if [ "${LLVM_VERSION}" = "3.6.2" ];
+      then
+        brew install llvm36;
+      fi;
+      if [ "${LLVM_VERSION}" = "3.7.1" ];
+      then
+        brew install llvm37;
+      fi;
+      if [ "${LLVM_VERSION}" = "3.8.1" ];
+      then
+        brew install llvm38;
+      fi;
+      if [ "${LLVM_VERSION}" = "3.9.0" ];
+      then
+        brew install llvm;
+        brew link --overwrite --force llvm;
+        mkdir llvmsym;
+        ln -s `which llvm-config` llvmsym/llvm-config-3.9;
+        ln -s `which clang++` llvmsym/clang++-3.9;
+        export PATH=llvmsym/:$PATH;
+      fi;
+      brew install pcre2 libressl;
     fi;
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Iter class methods `all`, `any`, `collect`, `count`, `find`, `last`, `nth`, `run`, `skip`, `skip_while`, `take`, `take_while` (issue #1370)
 - Output of `ponyc --version` shows C compiler used to build pony (issue #1245)
 - Makefile detects `llvmconfig39` in addition to `llvm-config-3.9` (#1379)
+- LLVM 3.9 support
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -662,6 +662,7 @@ test-examples: all
 	@rm examples1
 
 test-ci: all
+	@$(PONY_BUILD_DIR)/ponyc --version
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
 	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Pony requires one of the following versions of LLVM:
 - 3.6.2
 - 3.7.1
 - 3.8.1
-- 3.9.0 (unsupported on OSX at the moment)
+- 3.9.0
 
 Compiling Pony is only possible on x86 and ARM (either 32 or 64 bits).
 


### PR DESCRIPTION
Homebrew now supports LLVM 3.9.
