### PR TITLE
Fix broken `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -719,7 +719,7 @@ stats:
 
 clean:
 	@rm -rf $(PONY_BUILD_DIR)
-	@rm src/common/dtrace_probes.h
+	@rm -f src/common/dtrace_probes.h
 	-@rmdir build 2>/dev/null ||:
 	@echo 'Repository cleaned ($(PONY_BUILD_DIR)).'
 


### PR DESCRIPTION
dtrace_probes.h won't always be present. Use `-f` to remove
if present and otherwise, don't error out.