### PR TITLE
Update Dockerfile to use LLVM 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,11 @@ RUN apt-get update \
  && apt-get install -y make g++ git wget xz-utils \
                        zlib1g-dev libncurses5-dev libssl-dev \
                        libpcre2-dev \
- && rm -rf /var/lib/apt/lists/*
-
-RUN wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-RUN tar xf clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
-WORKDIR clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04
-RUN cp -r * /usr/local/
-RUN rm -rf /clang*
+ && rm -rf /var/lib/apt/lists/* \
+ && wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
+ && tar xf clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
+ && cp -r clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04/* /usr/local \
+ && rm -rf /clang*
 
 WORKDIR /src/ponyc
 COPY Makefile LICENSE VERSION /src/ponyc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM ubuntu:16.04
 
 RUN apt-get update \
- && apt-get install -y make g++ git \
+ && apt-get install -y make g++ git wget xz-utils \
                        zlib1g-dev libncurses5-dev libssl-dev \
-                       llvm-dev libpcre2-dev \
+                       libpcre2-dev \
  && rm -rf /var/lib/apt/lists/*
+
+RUN wget http://llvm.org/releases/3.9.0/clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+RUN tar xf clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+WORKDIR clang+llvm-3.9.0-x86_64-linux-gnu-ubuntu-16.04
+RUN cp -r * /usr/local/
+RUN rm -rf /clang*
 
 WORKDIR /src/ponyc
 COPY Makefile LICENSE VERSION /src/ponyc/
@@ -13,10 +19,11 @@ COPY lib      /src/ponyc/lib
 COPY test     /src/ponyc/test
 COPY packages /src/ponyc/packages
 
-RUN make config=release install \
+RUN make \
+ && make install \
  && rm -rf /src/ponyc/build
 
 RUN mkdir /src/main
-WORKDIR   /src/main
+WORKDIR /src/main
 
 CMD ponyc


### PR DESCRIPTION
The Dockerfile was using the apt package llvm-dev which installed llvm 3.8.0. This change will Install the prebuilt binary of llvm 3.9.0 instead.