### PR TITLE
Rename FloatingPoint min_value to min_normalised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Runtime function `pony_send_next`. This function can help optimise some message sending scenarios.
+- Floating point `min_normalised`. The function returns the smallest normalised positive number, as `min_value` used to do (issue #1351)
 
 ### Changed
+
+- Floating point `min_value` now returns the smallest negative number instead of the smallest normalised positive number (issue #1351)
 
 ## [0.7.0] - 2016-10-22
 

--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -11,16 +11,22 @@ primitive F32 is FloatingPoint[F32]
 
   new min_value() =>
     """
-    Minimum positive value representable at full precision (ie a normalised
-    number).
+    Minimum negative value representable.
     """
-    from_bits(0x00800000)
+    from_bits(0xFF7FFFFF)
 
   new max_value() =>
     """
     Maximum positive value representable.
     """
     from_bits(0x7F7FFFFF)
+
+  new min_normalised() =>
+    """
+    Minimum positive value representable at full precision (ie a normalised
+    number).
+    """
+    from_bits(0x00800000)
 
   new epsilon() =>
     """
@@ -173,16 +179,22 @@ primitive F64 is FloatingPoint[F64]
 
   new min_value() =>
     """
-    Minimum positive value representable at full precision (ie a normalised
-    number).
+    Minimum negative value representable.
     """
-    from_bits(0x0010_0000_0000_0000)
+    from_bits(0xFFEF_FFFF_FFFF_FFFF)
 
   new max_value() =>
     """
     Maximum positive value representable.
     """
     from_bits(0x7FEF_FFFF_FFFF_FFFF)
+
+  new min_normalised() =>
+    """
+    Minimum positive value representable at full precision (ie a normalised
+    number).
+    """
+    from_bits(0x0010_0000_0000_0000)
 
   new epsilon() =>
     """

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -83,6 +83,7 @@ trait val _UnsignedInteger[A: _UnsignedInteger[A] val] is Integer[A]
     _ToString._u64(u64(), false)
 
 trait val FloatingPoint[A: FloatingPoint[A] val] is Real[A]
+  new val min_normalised()
   new val epsilon()
   fun tag radix(): U8
   fun tag precision2(): U8


### PR DESCRIPTION
`min_value` was previously returning the smallest normalised positive number, which wasn't consistent with `min_value` on integers. `min_value` now returns the smallest negative number, and a `min_normalised` function returning the smallest normalised positive number has been added.

Closes #1351.