### PR TITLE
Get compiler version at build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Link the correct version of `libponyrt` when compiling with `--pic` on Linux (issue #1359)
+- Output of `ponyc --version` shows C compiler used to build pony (issue #1245)
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
   -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
+  -DBUILD_COMPILER=\"$(compiler_version)\" \
   -DPONY_BUILD_CONFIG=\"$(config)\"
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
@@ -214,6 +215,8 @@ ifndef LLVM_CONFIG
 endif
 
 llvm_version := $(shell $(LLVM_CONFIG) --version)
+
+compiler_version := "$(shell $(CC) --version | sed -n 1p)"
 
 ifeq ($(runtime-bitcode),yes)
   ifeq (,$(shell $(CC) -v 2>&1 | grep clang))

--- a/premake5.lua
+++ b/premake5.lua
@@ -62,6 +62,32 @@
     return output
   end
 
+  function build_compiler()
+    local vcver = tonumber(os.getenv("_MSC_FULL_VER"))
+    if vcver == nil then
+      return "?"
+    end
+    local vcmaj = vcver / 10000000
+    local vcmin = (vcver % 10000000) / 1000000
+    local vcbld = vcver % 1000000
+    local vcday = tonumber(os.getenv("_MSC_BUILD"))
+    if vcday == nil then
+      return "?"
+    end
+
+    local osverstr = os.getenv("NTDDI_VERSION")
+    if osverstr == nil then
+      return "?"
+    end
+    local osver = tonumber(string.sub(osverstr, 3), 16)
+    local osmaj = osver / 10000000
+    local osmin = (osver % 10000000) / 100000
+    local osbld = osver % 100000
+
+    return string.format("VC++ %02d.%02d.%d.%d Windows %02d.%02d.%d",
+      vcmaj, vcmin, vcbld, vcday, osmaj, osmin, osbld)
+  end
+
   function testsuite()
     kind "ConsoleApp"
     language "C++"
@@ -95,6 +121,7 @@
       defines "DEBUG"
       defines "PONY_BUILD_CONFIG=\"debug\""
       defines { "LLVM_VERSION=\"".. llvm_version .. "\"" }
+      defines {"BUILD_COMPILER=\"" .. build_compiler() .. "\""}
       flags { "Symbols" }
 
     configuration "Release"
@@ -102,12 +129,14 @@
       objdir "build/release/obj"
       defines "PONY_BUILD_CONFIG=\"release\""
       defines { "LLVM_VERSION=\"" .. llvm_config("--version") .. "\"" }
+      defines {"BUILD_COMPILER=\"" .. build_compiler() .. "\""}
 
     configuration "Profile"
       targetdir "build/profile"
       objdir "build/profile/obj"
       defines "PONY_BUILD_CONFIG=\"profile\""
       defines { "LLVM_VERSION=\"" .. llvm_config("--version") .. "\"" }
+      defines {"BUILD_COMPILER=\"" .. build_compiler() .. "\""}
 
     configuration "Release or Profile"
       defines "NDEBUG"

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -249,57 +249,6 @@ static bool compile_package(const char* path, pass_opt_t* opt,
   return ok;
 }
 
-static char* compiler_version()
-{
-#ifdef PLATFORM_IS_WINDOWS
-  const int size = 128;
-  static char buff[size];
-  buff[0] = 0;
-
-# if defined(_MSC_FULL_VER) && defined(NTDDI_VERSION)
-  uint64_t vcver = _MSC_FULL_VER;
-  int vcmaj = (int)(vcver / 10000000);
-  int vcmin = (int)((vcver % 10000000) / 1000000);
-  int vcbld = (int)(vcver % 1000000);
-  int vcday = _MSC_BUILD;
-
-  uint64_t osver = NTDDI_VERSION;
-  int osmaj = (int)(osver / 10000000);
-  int osmin = (int)((osver % 10000000) / 100000);
-  int osbld = (int)(osver % 100000);
-
-  snprintf(buff, size,
-    "VC++ %02d.%02d.%d.%d Windows %02d.%02d.%d",
-    vcmaj, vcmin, vcbld, vcday,
-    osmaj, osmin, osbld);
-  return buff;
-# else
-  return "?";
-# endif
-#else
-  char* cc = PONY_COMPILER;
-  char* args = " --version";
-  size_t idx = ponyint_pool_index(strlen(cc) + strlen(args));
-  char* cmd = ponyint_pool_alloc(idx);
-  strcat(cmd, cc);
-  strcat(cmd, args);
-
-  FILE* fp = popen(cmd, "r");
-  ponyint_pool_free(idx, cmd);
-  if (fp == NULL)
-    return cc;
-
-  char buff[60];
-  char* info = fgets(buff, sizeof(buff), fp);
-  pclose(fp);
-  if (info == NULL)
-    return cc;
-
-  strtok(info, "\n");
-  return info;
-#endif
-}
-
 int main(int argc, char* argv[])
 {
   stringtab_init();
@@ -326,8 +275,8 @@ int main(int argc, char* argv[])
     switch(id)
     {
       case OPT_VERSION:
-        printf("%s [%s] (llvm %s) (%s)\n", PONY_VERSION, PONY_BUILD_CONFIG,
-          LLVM_VERSION, compiler_version());
+        printf("%s [%s]\ncompiled with: llvm %s -- %s\n", PONY_VERSION, PONY_BUILD_CONFIG,
+          LLVM_VERSION, BUILD_COMPILER);
         return 0;
 
       case OPT_DEBUG: opt.release = false; break;


### PR DESCRIPTION
This PR shows the c compiler used to build Pony for the `--version` output rather than getting the version at run time. resolves #1245 