### PR TITLE
Fix detection of llvmconfig39 in Makefile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to the Pony compiler and standard library will be documented
 ## [unreleased] - unreleased
 
 ### Fixed
+
 - Output of `ponyc --version` shows C compiler used to build pony (issue #1245)
+- Makefile detects `llvmconfig39` in addition to `llvm-config-3.9` (#1379)
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,10 @@ ifndef LLVM_CONFIG
     LLVM_CONFIG = llvm-config-3.6
     LLVM_LINK = llvm-link-3.6
     LLVM_OPT = opt-3.6
+  else ifneq (,$(shell which llvm-config39 2> /dev/null))
+    LLVM_CONFIG = llvm-config39
+    LLVM_LINK = llvm-link39
+    LLVM_OPT = opt39
   else ifneq (,$(shell which llvm-config38 2> /dev/null))
     LLVM_CONFIG = llvm-config38
     LLVM_LINK = llvm-link38


### PR DESCRIPTION
This PR fixes detection of `llvmconfig39` in the `Makefile`.

Previously, only `llvm-config-3.9` was being detected.