### PR TITLE
examples/httpserver: use case for POST body

### DIFF
--- a/examples/httpserver/httpserver.pony
+++ b/examples/httpserver/httpserver.pony
@@ -1,4 +1,5 @@
 use "net/http"
+use "crypto"
 
 actor Main
   new create(env: Env) =>
@@ -55,6 +56,15 @@ primitive Handle
     if request.url.fragment.size() > 0 then
       response.add_chunk("#")
       response.add_chunk(request.url.fragment)
+    end
+
+    if request.method == "POST" then
+      let digest = Digest.sha256()
+      for chunk in request.body().values() do
+        digest.append(chunk)
+      end
+      response.add_chunk(", sha256: ")
+      response.add_chunk(ToHexString(digest.final()))
     end
 
     (consume request).respond(consume response)


### PR DESCRIPTION
@SeanTAllen I'm trying to write simple web service, and stopped at reading the body in the HTTP request handler. In the handler I need to both get access to `.body()` and `.respond()`. How I would do that?

```
Building builtin -> .local/lib/pony/0.8.0-d9f75a8/packages/builtin
Building examples/httpserver -> examples/httpserver
Building net/http -> .local/lib/pony/0.8.0-d9f75a8/packages/net/http
Building collections -> .local/lib/pony/0.8.0-d9f75a8/packages/collections
Building ponytest -> .local/lib/pony/0.8.0-d9f75a8/packages/ponytest
Building time -> .local/lib/pony/0.8.0-d9f75a8/packages/time
Building net -> .local/lib/pony/0.8.0-d9f75a8/packages/net
Building net/ssl -> .local/lib/pony/0.8.0-d9f75a8/packages/net/ssl
Building files -> .local/lib/pony/0.8.0-d9f75a8/packages/files
Building capsicum -> .local/lib/pony/0.8.0-d9f75a8/packages/capsicum
Building buffered -> .local/lib/pony/0.8.0-d9f75a8/packages/buffered
Building crypto -> .local/lib/pony/0.8.0-d9f75a8/packages/crypto
Building format -> .local/lib/pony/0.8.0-d9f75a8/packages/format
Error:
examples/httpserver/httpserver.pony:63:41: receiver type is not a subtype of target type
      for chunk in request.body().values() do
                                        ^
    Info:
    examples/httpserver/httpserver.pony:63:32: receiver type: Array[(String val | Array[U8 val] val)] tag
          for chunk in request.body().values() do
                                   ^
    .local/lib/pony/0.8.0-d9f75a8/packages/builtin/array.pony:540:3: target type: Array[(String val | Array[U8 val] val)] box
      fun values(): ArrayValues[A, this->Array[A]]^ =>
      ^
    .local/lib/pony/0.8.0-d9f75a8/packages/net/http/payload.pony:76:21: Array[(String val | Array[U8 val] val)] tag is not a subtype of Array[(String val | Array[U8 val] val)] box: tag is not a subtype of box
      fun body(): this->Array[ByteSeq] =>
                        ^
```
