### PR TITLE
Do not duplicate status code in HTTP response

### DIFF
--- a/packages/net/http/payload.pony
+++ b/packages/net/http/payload.pony
@@ -194,8 +194,6 @@ class iso Payload
 
     list.push(proto)
     list.push(" ")
-    list.push(status.string())
-    list.push(" ")
     list.push(method)
 
     if keepalive then


### PR DESCRIPTION
as documentation says, `method` already includes status code for response