### PR TITLE
Implement HMAC for crypto package

### DIFF
--- a/packages/crypto/_test.pony
+++ b/packages/crypto/_test.pony
@@ -15,6 +15,7 @@ actor Main is TestList
     test(_TestSHA384)
     test(_TestSHA512)
     test(_TestDigest)
+    test(_TestHMAC)
 
 class iso _TestConstantTimeCompare is UnitTest
   fun name(): String => "crypto/ConstantTimeCompare"
@@ -119,3 +120,14 @@ class iso _TestDigest is UnitTest
     h.assert_eq[String](
       "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
       ToHexString(d'.final()))
+
+class iso _TestHMAC is UnitTest
+  fun name(): String => "crypto/Hmac"
+
+  fun apply(h: TestHelper) ? =>
+    let data = "Lücíllé: Bût... yøü sáîd hé wås âlrîght.\nDr. Físhmån: Yés. Hé's løst hîs léft hånd, sø hé's gøîng tø bé åll rîght"
+    let hmac = HMAC("SHA256", "qShkcwN92rsM9nHfdnP4ugcVU2iI7iM/trovs01ZWok", data)
+    h.assert_eq[String](
+      "a13984b929a07912e4e21c5720876a8e150d6f67f854437206e7f86547248396",
+      ToHexString(hmac)
+    )

--- a/packages/crypto/hmac.pony
+++ b/packages/crypto/hmac.pony
@@ -1,0 +1,48 @@
+use "path:/usr/local/opt/libressl/lib" if osx
+use "lib:crypto" if not windows
+use "lib:libcrypto-32" if windows
+
+primitive HMAC
+  """
+  Produces the authentication code for the input byte sequence using given key.
+  First argument accepts a name of digest algorithm. Currently supported algorithms are:
+
+    * ``MD5``
+    * ``RIPEMD160``
+    * ``SHA1``
+    * ``SHA224``
+    * ``SHA256``
+    * ``SHA384``
+    * ``SHA512``
+
+  ```pony
+  use "crypto"
+
+  actor Main
+    new create(env: Env) =>
+      env.out.print(ToHexString(HMAC("SHA1", "secret", "Hello, world")))
+      // => c671e00ea137e7a4bea30ae0d4969e7408a0f0f2
+  ```
+  """
+  fun tag apply(digest: String, key: ByteSeq, input: ByteSeq): Array[U8] val ? =>
+    recover
+      (let md, var size: U32) =
+        match(digest)
+          | "MD5" => (@EVP_md5[Pointer[_EVPMD]](), 16)
+          | "RIPEMD160" => (@EVP_ripemd160[Pointer[_EVPMD]](), 20)
+          | "SHA1" => (@EVP_sha1[Pointer[_EVPMD]](), 20)
+          | "SHA224" => (@EVP_sha224[Pointer[_EVPMD]](), 28)
+          | "SHA256" => (@EVP_sha256[Pointer[_EVPMD]](), 32)
+          | "SHA384" => (@EVP_sha384[Pointer[_EVPMD]](), 48)
+          | "SHA512" => (@EVP_sha512[Pointer[_EVPMD]](), 64)
+        else
+          error
+        end
+      let hash = @pony_alloc[Pointer[U8]](
+        @pony_ctx[Pointer[None] iso](),
+        size.usize()
+      )
+      @HMAC[Pointer[U8]](md, key.cpointer(), key.size(),
+        input.cpointer(), input.size(), hash, addressof size)
+      Array[U8].from_cpointer(hash, size.usize())
+    end


### PR DESCRIPTION
Motivation
----------
HMAC is pretty important part of crypto primitives and have to be exposed in `crypto` package. For example to implement SCRAM SASL authentication mechanism.

Modification
------------
New primitive has been added into `crypto` package, and has interface similar to hash functions. It accepts name of the digest, the key and the whole message to authenticate. Unfortunately, it is not easy to expose chunked interface like it was done in `Digest` class, because OpenSSL 1.0.2j (pretty widespread at the moment) does not allow to instantiate HMAC context, i.e. does not have `HMAC_CTX_new()` function yet.