### PR TITLE
Fixed error message when no type arguments are given (issue #1396)

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -89,7 +89,7 @@ static bool check_type_params(pass_opt_t* opt, ast_t** astp)
   if(ast_id(typeparams) == TK_NONE)
     return true;
 
-  BUILD(typeargs, typeparams, NODE(TK_TYPEARGS));
+  BUILD(typeargs, ast_parent(lhs), NODE(TK_TYPEARGS));
 
   if(!reify_defaults(typeparams, typeargs, true, opt))
   {


### PR DESCRIPTION
This PR resolves #1396 by passing the funref ast node to `reify_defaults` so that it may be used in error reporting in the case that no type arguments are given.