### PR TITLE
Changed lambda literal syntax to be more concise (issue #1391)

### DIFF
--- a/examples/lambda/lambda.pony
+++ b/examples/lambda/lambda.pony
@@ -5,15 +5,15 @@ Simple example of creating and calling a lambda function.
 actor Main
   new create(env: Env) =>
     // First let's pass an add function.
-    let x = f(lambda(a: U32, b: U32): U32 => a + b end, 6)
+    let x = f({(a: U32, b: U32): U32 => a + b }, 6)
     env.out.print("Add: " + x.string())
 
     // Now a multiply.
-    let y = f(lambda(a: U32, b: U32): U32 => a * b end, 6)
+    let y = f({(a: U32, b: U32): U32 => a * b }, 6)
     env.out.print("Mult: " + y.string())
 
     // And finally a lambda that raises an error.
-    let z = f(lambda(a: U32, b: U32): U32 ? => error end, 6)
+    let z = f({(a: U32, b: U32): U32 ? => error }, 6)
     env.out.print("Error: " + z.string())
 
   fun f(fn: {(U32, U32): U32 ?} val, x: U32): U32 =>

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -374,7 +374,7 @@ class Array[A] is Seq[A]
 
   fun find(value: A!, offset: USize = 0, nth: USize = 0,
     predicate: {(box->A!, box->A!): Bool} val =
-      lambda(l: box->A!, r: box->A!): Bool => l is r end): USize ?
+      {(l: box->A!, r: box->A!): Bool => l is r }): USize ?
   =>
     """
     Find the `nth` appearance of `value` from the beginning of the array,
@@ -403,7 +403,7 @@ class Array[A] is Seq[A]
     error
 
   fun contains(value: A!, predicate: {(box->A!, box->A!): Bool} val =
-    lambda(l: box->A!, r: box->A!): Bool => l is r end): Bool =>
+    {(l: box->A!, r: box->A!): Bool => l is r }): Bool =>
     """
     Returns true if the array contains `value`, false otherwise.
     """
@@ -420,7 +420,7 @@ class Array[A] is Seq[A]
 
   fun rfind(value: A!, offset: USize = -1, nth: USize = 0,
     predicate: {(box->A!, box->A!): Bool} val =
-      lambda(l: box->A!, r: box->A!): Bool => l is r end): USize ?
+      {(l: box->A!, r: box->A!): Bool => l is r }): USize ?
   =>
     """
     Find the `nth` appearance of `value` from the end of the array, starting at

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -162,7 +162,7 @@ class iso _TestStringToBool is UnitTest
     h.assert_eq[Bool](true, "true".bool())
     h.assert_eq[Bool](true, "TRUE".bool())
 
-    h.assert_error(lambda()? => "bogus".bool() end)
+    h.assert_error({()? => "bogus".bool() })
 
 
 class iso _TestStringToFloat is UnitTest
@@ -191,9 +191,9 @@ class iso _TestStringToU8 is UnitTest
     h.assert_eq[U8](123, "0123".u8())
     h.assert_eq[U8](89, "089".u8())
 
-    h.assert_error(lambda()? => "300".u8() end, "U8 300")
-    h.assert_error(lambda()? => "30L".u8() end, "U8 30L")
-    h.assert_error(lambda()? => "-10".u8() end, "U8 -10")
+    h.assert_error({()? => "300".u8() }, "U8 300")
+    h.assert_error({()? => "30L".u8() }, "U8 30L")
+    h.assert_error({()? => "-10".u8() }, "U8 -10")
 
     h.assert_eq[U8](16, "0x10".u8())
     h.assert_eq[U8](31, "0x1F".u8())
@@ -203,10 +203,10 @@ class iso _TestStringToU8 is UnitTest
     h.assert_eq[U8](2, "0B10".u8())
     h.assert_eq[U8](0x8A, "0b1000_1010".u8())
 
-    h.assert_error(lambda()? => "1F".u8() end, "U8 1F")
-    h.assert_error(lambda()? => "0x".u8() end, "U8 0x")
-    h.assert_error(lambda()? => "0b3".u8() end, "U8 0b3")
-    h.assert_error(lambda()? => "0d4".u8() end, "U8 0d4")
+    h.assert_error({()? => "1F".u8() }, "U8 1F")
+    h.assert_error({()? => "0x".u8() }, "U8 0x")
+    h.assert_error({()? => "0b3".u8() }, "U8 0b3")
+    h.assert_error({()? => "0d4".u8() }, "U8 0d4")
 
 
 class iso _TestStringToI8 is UnitTest
@@ -222,8 +222,8 @@ class iso _TestStringToI8 is UnitTest
     h.assert_eq[I8](89, "089".i8())
     h.assert_eq[I8](-10, "-10".i8())
 
-    h.assert_error(lambda()? => "200".i8() end, "I8 200")
-    h.assert_error(lambda()? => "30L".i8() end, "I8 30L")
+    h.assert_error({()? => "200".i8() }, "I8 200")
+    h.assert_error({()? => "30L".i8() }, "I8 30L")
 
     h.assert_eq[I8](16, "0x10".i8())
     h.assert_eq[I8](31, "0x1F".i8())
@@ -234,10 +234,10 @@ class iso _TestStringToI8 is UnitTest
     h.assert_eq[I8](0x4A, "0b100_1010".i8())
     h.assert_eq[I8](-0x4A, "-0b100_1010".i8())
 
-    h.assert_error(lambda()? => "1F".i8() end, "U8 1F")
-    h.assert_error(lambda()? => "0x".i8() end, "U8 0x")
-    h.assert_error(lambda()? => "0b3".i8() end, "U8 0b3")
-    h.assert_error(lambda()? => "0d4".i8() end, "U8 0d4")
+    h.assert_error({()? => "1F".i8() }, "U8 1F")
+    h.assert_error({()? => "0x".i8() }, "U8 0x")
+    h.assert_error({()? => "0b3".i8() }, "U8 0b3")
+    h.assert_error({()? => "0d4".i8() }, "U8 0d4")
 
 
 class iso _TestStringToIntLarge is UnitTest
@@ -249,45 +249,45 @@ class iso _TestStringToIntLarge is UnitTest
   fun apply(h: TestHelper) ? =>
     h.assert_eq[U16](0, "0".u16())
     h.assert_eq[U16](123, "123".u16())
-    h.assert_error(lambda()? => "-10".u16() end, "U16 -10")
-    h.assert_error(lambda()? => "65536".u16() end, "U16 65536")
-    h.assert_error(lambda()? => "30L".u16() end, "U16 30L")
+    h.assert_error({()? => "-10".u16() }, "U16 -10")
+    h.assert_error({()? => "65536".u16() }, "U16 65536")
+    h.assert_error({()? => "30L".u16() }, "U16 30L")
 
     h.assert_eq[I16](0, "0".i16())
     h.assert_eq[I16](123, "123".i16())
     h.assert_eq[I16](-10, "-10".i16())
-    h.assert_error(lambda()? => "65536".i16() end, "I16 65536")
-    h.assert_error(lambda()? => "30L".i16() end, "I16 30L")
+    h.assert_error({()? => "65536".i16() }, "I16 65536")
+    h.assert_error({()? => "30L".i16() }, "I16 30L")
 
     h.assert_eq[U32](0, "0".u32())
     h.assert_eq[U32](123, "123".u32())
-    h.assert_error(lambda()? => "-10".u32() end, "U32 -10")
-    h.assert_error(lambda()? => "30L".u32() end, "U32 30L")
+    h.assert_error({()? => "-10".u32() }, "U32 -10")
+    h.assert_error({()? => "30L".u32() }, "U32 30L")
 
     h.assert_eq[I32](0, "0".i32())
     h.assert_eq[I32](123, "123".i32())
     h.assert_eq[I32](-10, "-10".i32())
-    h.assert_error(lambda()? => "30L".i32() end, "I32 30L")
+    h.assert_error({()? => "30L".i32() }, "I32 30L")
 
     h.assert_eq[U64](0, "0".u64())
     h.assert_eq[U64](123, "123".u64())
-    h.assert_error(lambda()? => "-10".u64() end, "U64 -10")
-    h.assert_error(lambda()? => "30L".u64() end, "U64 30L")
+    h.assert_error({()? => "-10".u64() }, "U64 -10")
+    h.assert_error({()? => "30L".u64() }, "U64 30L")
 
     h.assert_eq[I64](0, "0".i64())
     h.assert_eq[I64](123, "123".i64())
     h.assert_eq[I64](-10, "-10".i64())
-    h.assert_error(lambda()? => "30L".i64() end, "I64 30L")
+    h.assert_error({()? => "30L".i64() }, "I64 30L")
 
     h.assert_eq[U128](0, "0".u128())
     h.assert_eq[U128](123, "123".u128())
-    h.assert_error(lambda()? => "-10".u128() end, "U128 -10")
-    h.assert_error(lambda()? => "30L".u128() end, "U128 30L")
+    h.assert_error({()? => "-10".u128() }, "U128 -10")
+    h.assert_error({()? => "30L".u128() }, "U128 30L")
 
     h.assert_eq[I128](0, "0".i128())
     h.assert_eq[I128](123, "123".i128())
     h.assert_eq[I128](-10, "-10".i128())
-    h.assert_error(lambda()? => "30L".i128() end, "I128 30L")
+    h.assert_error({()? => "30L".i128() }, "I128 30L")
 
 
 class iso _TestStringLstrip is UnitTest
@@ -933,7 +933,7 @@ class iso _TestArrayInsert is UnitTest
     c.insert(2, "four")
     h.assert_array_eq[String](["one", "three", "four"], c)
 
-    h.assert_error(lambda()? => ["one", "three"].insert(3, "invalid") end)
+    h.assert_error({()? => ["one", "three"].insert(3, "invalid") })
 
 class iso _TestArrayValuesRewind is UnitTest
   """
@@ -975,41 +975,41 @@ class iso _TestArrayFind is UnitTest
     h.assert_eq[USize](1, a.find(1))
     h.assert_eq[USize](5, a.find(1 where offset = 3))
     h.assert_eq[USize](5, a.find(1 where nth = 1))
-    h.assert_error(lambda()(a)? => a.find(6) end)
+    h.assert_error({()(a)? => a.find(6) })
     h.assert_eq[USize](2, a.find(1 where
-      predicate = lambda(l: ISize, r: ISize): Bool => l > r end))
+      predicate = {(l: ISize, r: ISize): Bool => l > r }))
     h.assert_eq[USize](0, a.find(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end))
+      predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }))
     h.assert_eq[USize](3, a.find(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
-      nth = 1))
-    h.assert_error(lambda()(a)? => a.find(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
-      nth = 2) end)
+      predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }, nth = 1))
+    h.assert_error({()(a)? =>
+      a.find(0 where
+        predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }, nth = 2)
+    })
 
     h.assert_eq[USize](5, a.rfind(1))
     h.assert_eq[USize](1, a.rfind(1 where offset = 3))
     h.assert_eq[USize](1, a.rfind(1 where nth = 1))
-    h.assert_error(lambda()(a)? => a.rfind(6) end)
+    h.assert_error({()(a)? => a.rfind(6) })
     h.assert_eq[USize](4, a.rfind(1 where
-      predicate = lambda(l: ISize, r: ISize): Bool => l > r end))
+      predicate = {(l: ISize, r: ISize): Bool => l > r }))
     h.assert_eq[USize](3, a.rfind(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end))
+      predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }))
     h.assert_eq[USize](0, a.rfind(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
-      nth = 1))
-    h.assert_error(lambda()(a)? => a.rfind(0 where
-      predicate = lambda(l: ISize, r: ISize): Bool => (l % 3) == r end,
-      nth = 2) end)
+      predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }, nth = 1))
+    h.assert_error({()(a)? =>
+      a.rfind(0 where
+        predicate = {(l: ISize, r: ISize): Bool => (l % 3) == r }, nth = 2)
+    })
 
     var b = Array[_FindTestCls]
     let c = _FindTestCls
     b.push(c)
-    h.assert_error(lambda()(b)? => b.find(_FindTestCls) end)
+    h.assert_error({()(b)? => b.find(_FindTestCls) })
     h.assert_eq[USize](0, b.find(c))
     h.assert_eq[USize](0, b.find(_FindTestCls where
-      predicate = lambda(l: _FindTestCls box, r: _FindTestCls box): Bool =>
-        l == r end))
+      predicate = {(l: _FindTestCls box, r: _FindTestCls box): Bool => l == r }
+    ))
 
 
 class iso _TestMath128 is UnitTest
@@ -1236,7 +1236,7 @@ class iso _TestMaybePointer is UnitTest
     let a = MaybePointer[_TestStruct].none()
     h.assert_true(a.is_none())
 
-    h.assert_error(lambda()(a)? => let from_a = a() end)
+    h.assert_error({()(a)? => let from_a = a() })
 
     let s = _TestStruct
     s.i = 7

--- a/packages/bureaucracy/_test.pony
+++ b/packages/bureaucracy/_test.pony
@@ -31,12 +31,9 @@ class iso _TestRegistrar is UnitTest
     let r = Registrar
     r("test") = _TestDisposable(h)
 
-    r[_TestDisposable]("test").next[None](
-      recover
-        lambda(value: _TestDisposable)(h) =>
-          value.dispose()
-        end
-      end)
+    r[_TestDisposable]("test").next[None]({(value: _TestDisposable)(h) =>
+      value.dispose()
+    } iso)
 
 actor _TestDisposable
   let _h: TestHelper

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -147,7 +147,7 @@ class iso _TestMapUpsert is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let x: Map[U32, U64] = Map[U32,U64]
-    let f = lambda(x: U64, y: U64): U64 => x + y end
+    let f = {(x: U64, y: U64): U64 => x + y }
     x.upsert(1, 5, f)
     h.assert_eq[U64](5, x(1))
     x.upsert(1, 3, f)
@@ -160,7 +160,7 @@ class iso _TestMapUpsert is UnitTest
     h.assert_eq[U64](15, x(1))
 
     let x2: Map[U32, String] = Map[U32,String]
-    let g = lambda(x: String, y: String): String => x + ", " + y end
+    let g = {(x: String, y: String): String => x + ", " + y }
     x2.upsert(1, "1", g)
     h.assert_eq[String]("1", x2(1))
     x2.upsert(1, "2", g)
@@ -176,7 +176,7 @@ class iso _TestMapUpsert is UnitTest
     let prealloc: USize = 6
     let expected_initial_size: USize = (prealloc * 4) / 3
     let x3: Map[U32, U64] = Map[U32,U64](prealloc)
-    let f' = lambda(x: U64, y: U64): U64 => x + y end
+    let f' = {(x: U64, y: U64): U64 => x + y }
     h.assert_eq[USize](expected_initial_size, x3.space())
     h.assert_eq[U64](1, x3.upsert(1, 1, f'))
     h.assert_eq[U64](1, x3.upsert(2, 1, f'))
@@ -202,15 +202,15 @@ class iso _TestRing is UnitTest
 
     a.push(4).push(5)
 
-    h.assert_error(lambda()(a)? => a(0) end, "Read ring 0")
-    h.assert_error(lambda()(a)? => a(1) end, "Read ring 1")
+    h.assert_error({()(a)? => a(0) }, "Read ring 0")
+    h.assert_error({()(a)? => a(1) }, "Read ring 1")
 
     h.assert_eq[U64](a(2), 2)
     h.assert_eq[U64](a(3), 3)
     h.assert_eq[U64](a(4), 4)
     h.assert_eq[U64](a(5), 5)
 
-    h.assert_error(lambda()(a)? => a(6) end, "Read ring 6")
+    h.assert_error({()(a)? => a(6) }, "Read ring 6")
 
 class iso _TestListsMap is UnitTest
   fun name(): String => "collections/Lists/map()"
@@ -219,7 +219,7 @@ class iso _TestListsMap is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2)
 
-    let f = lambda(a: U32): U32 => a * 2 end
+    let f = {(a: U32): U32 => a * 2 }
     let c = a.map[U32](f)
 
     h.assert_eq[USize](c.size(), 3)
@@ -234,7 +234,7 @@ class iso _TestListsFlatMap is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2)
 
-    let f = lambda(a: U32): List[U32] => List[U32].push(a).push(a * 2) end
+    let f = {(a: U32): List[U32] => List[U32].push(a).push(a * 2) }
     let c = a.flat_map[U32](f)
 
     h.assert_eq[USize](c.size(), 6)
@@ -252,7 +252,7 @@ class iso _TestListsFilter is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let f = lambda(a: U32): Bool => a > 1 end
+    let f = {(a: U32): Bool => a > 1 }
     let b = a.filter(f)
 
     h.assert_eq[USize](b.size(), 2)
@@ -266,12 +266,12 @@ class iso _TestListsFold is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let f = lambda(acc: U32, x: U32): U32 => acc + x end
+    let f = {(acc: U32, x: U32): U32 => acc + x }
     let value = a.fold[U32](f, 0)
 
     h.assert_eq[U32](value, 6)
 
-    let g = lambda(acc: List[U32], x: U32): List[U32] => acc.push(x * 2) end
+    let g = {(acc: List[U32], x: U32): List[U32] => acc.push(x * 2) }
     let resList = a.fold[List[U32]](g, List[U32])
 
     h.assert_eq[USize](resList.size(), 4)
@@ -287,9 +287,9 @@ class iso _TestListsEvery is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let f = lambda(x: U32): Bool => x < 4 end
-    let g = lambda(x: U32): Bool => x < 3 end
-    let z = lambda(x: U32): Bool => x < 0 end
+    let f = {(x: U32): Bool => x < 4 }
+    let g = {(x: U32): Bool => x < 3 }
+    let z = {(x: U32): Bool => x < 0 }
     let lessThan4 = a.every(f)
     let lessThan3 = a.every(g)
     let lessThan0 = a.every(z)
@@ -309,9 +309,9 @@ class iso _TestListsExists is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let f = lambda(x: U32): Bool => x > 2 end
-    let g = lambda(x: U32): Bool => x >= 0 end
-    let z = lambda(x: U32): Bool => x < 0 end
+    let f = {(x: U32): Bool => x > 2 }
+    let g = {(x: U32): Bool => x >= 0 }
+    let z = {(x: U32): Bool => x < 0 }
     let gt2 = a.exists(f)
     let gte0 = a.exists(g)
     let lt0 = a.exists(z)
@@ -331,7 +331,7 @@ class iso _TestListsPartition is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3)
 
-    let isEven = lambda(x: U32): Bool => (x % 2) == 0 end
+    let isEven = {(x: U32): Bool => (x % 2) == 0 }
     (let evens, let odds) = a.partition(isEven)
 
     h.assert_eq[USize](evens.size(), 2)
@@ -417,10 +417,10 @@ class iso _TestListsTakeWhile is UnitTest
     let a = List[U32]
     a.push(0).push(1).push(2).push(3).push(4)
 
-    let f = lambda(x: U32): Bool => x < 5 end
-    let g = lambda(x: U32): Bool => x < 4 end
-    let y = lambda(x: U32): Bool => x < 1 end
-    let z = lambda(x: U32): Bool => x < 0 end
+    let f = {(x: U32): Bool => x < 5 }
+    let g = {(x: U32): Bool => x < 4 }
+    let y = {(x: U32): Bool => x < 1 }
+    let z = {(x: U32): Bool => x < 0 }
     let b = a.take_while(f)
     let c = a.take_while(g)
     let d = a.take_while(y)

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -91,13 +91,13 @@ class HashMap[K, V, H: HashFunction[K] val]
     add 4 to the current value for key "test", which let's say is currently 2.
     We call
 
-    m.upsert("test", 4, lambda(x: I64, y: I64): I64 => x - y end)
+    m.upsert("test", 4, {(x: I64, y: I64): I64 => x - y })
 
     This changes the value associated with "test" to -2.
 
     If we have not yet added the key "new-key" to the map and we call
 
-    m.upsert("new-key", 4, lambda(x: I64, y: I64): I64 => x - y end)
+    m.upsert("new-key", 4, {(x: I64, y: I64): I64 => x - y })
 
     then "new-key" is added to the map with a value of -4.
 

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -75,11 +75,11 @@ class iso _TestListApply is UnitTest
     h.assert_eq[U32](l1(0), 1)
     h.assert_eq[U32](l1(1), 2)
     h.assert_eq[U32](l1(2), 3)
-    h.assert_error(lambda()(l1)? => l1(3) end)
-    h.assert_error(lambda()(l1)? => l1(4) end)
+    h.assert_error({()(l1)? => l1(3) })
+    h.assert_error({()(l1)? => l1(4) })
 
     let l2 = Lists[U32].empty()
-    h.assert_error(lambda()(l2)? => l2(0) end)
+    h.assert_error({()(l2)? => l2(0) })
 
 class iso _TestListValues is UnitTest
   fun name(): String => "collections/persistent/List/values()"
@@ -125,7 +125,7 @@ class iso _TestListMap is UnitTest
   fun name(): String => "collections/persistent/Lists/map()"
 
   fun apply(h: TestHelper) ? =>
-    let l5 = Lists[U32]([1, 2, 3]).map[U32](lambda(x: U32): U32 => x * 2 end)
+    let l5 = Lists[U32]([1, 2, 3]).map[U32]({(x: U32): U32 => x * 2 })
     h.assert_true(Lists[U32].eq(l5, Lists[U32]([2,4,6])))
 
     true
@@ -134,7 +134,7 @@ class iso _TestListFlatMap is UnitTest
   fun name(): String => "collections/persistent/Lists/flat_map()"
 
   fun apply(h: TestHelper) ? =>
-    let f = lambda(x: U32): List[U32] => Lists[U32]([x - 1, x, x + 1]) end
+    let f = {(x: U32): List[U32] => Lists[U32]([x - 1, x, x + 1]) }
     let l6 = Lists[U32]([2, 5, 8]).flat_map[U32](f)
     h.assert_true(Lists[U32].eq(l6, Lists[U32]([1,2,3,4,5,6,7,8,9])))
 
@@ -144,7 +144,7 @@ class iso _TestListFilter is UnitTest
   fun name(): String => "collections/persistent/Lists/filter()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
+    let is_even = {(x: U32): Bool => (x % 2) == 0 }
     let l7 = Lists[U32]([1,2,3,4,5,6,7,8]).filter(is_even)
     h.assert_true(Lists[U32].eq(l7, Lists[U32]([2,4,6,8])))
 
@@ -154,12 +154,12 @@ class iso _TestListFold is UnitTest
   fun name(): String => "collections/persistent/Lists/fold()"
 
   fun apply(h: TestHelper) ? =>
-    let add = lambda(acc: U32, x: U32): U32 => acc + x end
+    let add = {(acc: U32, x: U32): U32 => acc + x }
     let value = Lists[U32]([1,2,3]).fold[U32](add, 0)
     h.assert_eq[U32](value, 6)
 
     let doubleAndPrepend =
-      lambda(acc: List[U32], x: U32): List[U32] => acc.prepend(x * 2) end
+      {(acc: List[U32], x: U32): List[U32] => acc.prepend(x * 2) }
     let l8 =
       Lists[U32]([1,2,3]).fold[List[U32]](doubleAndPrepend, Lists[U32].empty())
     h.assert_true(Lists[U32].eq(l8, Lists[U32]([6,4,2])))
@@ -170,7 +170,7 @@ class iso _TestListEveryExists is UnitTest
   fun name(): String => "collections/persistent/Lists/every()exists()"
 
   fun apply(h: TestHelper) =>
-    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
+    let is_even = {(x: U32): Bool => (x % 2) == 0 }
     let l9 = Lists[U32]([4,2,10])
     let l10 = Lists[U32]([1,1,3])
     let l11 = Lists[U32]([1,1,2])
@@ -193,7 +193,7 @@ class iso _TestListPartition is UnitTest
   fun name(): String => "collections/persistent/Lists/partition()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
+    let is_even = {(x: U32): Bool => (x % 2) == 0 }
     let l = Lists[U32]([1,2,3,4,5,6])
     (let hits, let misses) = l.partition(is_even)
     h.assert_true(Lists[U32].eq(hits, Lists[U32]([2,4,6])))
@@ -217,7 +217,7 @@ class iso _TestListDropWhile is UnitTest
   fun name(): String => "collections/persistent/List/drop_while()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
+    let is_even = {(x: U32): Bool => (x % 2) == 0 }
     let l = Lists[U32]([4,2,6,1,3,4,6])
     let empty = Lists[U32].empty()
     h.assert_true(Lists[U32].eq(l.drop_while(is_even), Lists[U32]([1,3,4,6])))
@@ -240,7 +240,7 @@ class iso _TestListTakeWhile is UnitTest
   fun name(): String => "collections/persistent/List/take_while()"
 
   fun apply(h: TestHelper) ? =>
-    let is_even = lambda(x: U32): Bool => (x % 2) == 0 end
+    let is_even = {(x: U32): Bool => (x % 2) == 0 }
     let l = Lists[U32]([4,2,6,1,3,4,6])
     let empty = Lists[U32].empty()
     h.assert_true(Lists[U32].eq(l.take_while(is_even), Lists[U32]([4,2,6])))
@@ -253,7 +253,7 @@ class iso _TestMap is UnitTest
 
   fun apply(h: TestHelper) =>
     let m1: Map[String,U32] = Maps.empty[String,U32]()
-    h.assert_error(lambda()(m1)? => m1("a") end)
+    h.assert_error({()(m1)? => m1("a") })
     let s1 = m1.size()
     h.assert_eq[USize](s1, 0)
 
@@ -281,17 +281,17 @@ class iso _TestMap is UnitTest
       h.assert_eq[U32](m7("b"), 3)
       h.assert_eq[U32](m7("a"), 10)
       let m8 = m7.remove("a")
-      h.assert_error(lambda()(m8 = m8)? => m8("a") end)
+      h.assert_error({()(m8 = m8)? => m8("a") })
       h.assert_eq[U32](m8("b"), 3)
       h.assert_eq[U32](m8("d"), 4)
       h.assert_eq[U32](m8("e"), 5)
       let m9 = m7.remove("e")
-      h.assert_error(lambda()(m9 = m9)? => m9("e") end)
+      h.assert_error({()(m9 = m9)? => m9("e") })
       h.assert_eq[U32](m9("b"), 3)
       h.assert_eq[U32](m9("d"), 4)
       let m10 = m9.remove("b").remove("d")
-      h.assert_error(lambda()(m10 = m10)? => m10("b") end)
-      h.assert_error(lambda()(m10 = m10)? => m10("d") end)
+      h.assert_error({()(m10 = m10)? => m10("b") })
+      h.assert_error({()(m10 = m10)? => m10("d") })
     else
       h.complete(false)
     end

--- a/packages/collections/persistent/list.pony
+++ b/packages/collections/persistent/list.pony
@@ -21,7 +21,7 @@ h.assert_eq[U32](l4_head, 1)
 h.assert_true(Lists[U32].eq(l4, Lists[U32]([1, 2, 3])))
 h.assert_true(Lists[U32].eq(l4_tail, Lists[U32]([2, 3])))
 
-let doubled = l4.map[U32](lambda(x: U32): U32 => x * 2 end)
+let doubled = l4.map[U32]({(x: U32): U32 => x * 2 })
 
 h.assert_true(Lists[U32].eq(doubled, Lists[U32]([2, 4, 6])))
 

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -58,7 +58,7 @@ class iso _TestWalk is UnitTest
       h, ["a/1", "a/2", "b", "c/3", "c/4", "d/5", "d/6"])
     try
       top.walk(
-        lambda(dir: FilePath, entries: Array[String] ref)(p = top.path, h) =>
+        {(dir: FilePath, entries: Array[String] ref)(p = top.path, h) =>
           if dir.path == p then
             h.assert_array_eq_unordered[String](["b", "c", "a", "d"], entries)
           elseif dir.path.at("a", -1) then
@@ -70,7 +70,7 @@ class iso _TestWalk is UnitTest
           else
             h.fail("Unexpected dir: " + dir.path)
           end
-        end)
+        })
     then
       h.assert_true(top.remove())
     end

--- a/packages/glob/_test.pony
+++ b/packages/glob/_test.pony
@@ -140,20 +140,18 @@ class iso _TestIGlob is UnitTest
   fun apply(h: TestHelper) ? =>
     let top = _FileHelper.make_files(h, ["a/1", "a/2", "b", "c/1", "c/4"])
     try
-      Glob.iglob(
-        top, "*/1",
-        lambda(f: FilePath, matches: Array[String])(top, h) =>
-          try
-            match matches(0)
-            | "a" => h.assert_eq[String](Path.rel(top.path, f.path), "a/1")
-            | "c" => h.assert_eq[String](Path.rel(top.path, f.path), "c/1")
-            else
-              error
-            end
+      Glob.iglob(top, "*/1", {(f: FilePath, matches: Array[String])(top, h) =>
+        try
+          match matches(0)
+          | "a" => h.assert_eq[String](Path.rel(top.path, f.path), "a/1")
+          | "c" => h.assert_eq[String](Path.rel(top.path, f.path), "c/1")
           else
-              h.fail("Unexpected match: " + f.path)
+            error
           end
-        end)
+        else
+            h.fail("Unexpected match: " + f.path)
+        end
+      })
     then
       h.assert_true(top.remove())
     end

--- a/packages/glob/glob.pony
+++ b/packages/glob/glob.pony
@@ -149,9 +149,9 @@ primitive Glob
     let res = recover ref Array[FilePath] end
     iglob(
       root_path, pattern,
-      lambda ref(path: FilePath, match_groups: Array[String])(res) =>
+      {ref(path: FilePath, match_groups: Array[String])(res) =>
         res.push(path)
-      end)
+      })
     res
 
   fun _apply_glob_to_walk(

--- a/packages/itertools/_test.pony
+++ b/packages/itertools/_test.pony
@@ -204,7 +204,7 @@ class iso _TestMapFn is UnitTest
     let expected = ["ab", "bb", "cb"]
     let actual = Array[String]
 
-    let fn = lambda (x: String): String => x + "b" end
+    let fn = {(x: String): String => x + "b" }
     for x in MapFn[String, String](input.values(), fn) do
       actual.push(x)
     end
@@ -221,7 +221,7 @@ class iso _TestFilter is UnitTest
     let expected = ["c", "f", "g"]
     let actual = Array[String]
 
-    let fn1 = lambda (x: String): Bool => x.size() == 1 end
+    let fn1 = {(x: String): Bool => x.size() == 1 }
     for x in Filter[String](input1.values(), fn1) do
       actual.push(x)
     end
@@ -229,7 +229,7 @@ class iso _TestFilter is UnitTest
     h.assert_array_eq[String](actual, expected)
     actual.clear()
 
-    let fn2 = lambda (x: String): Bool => x.size() == 1 end
+    let fn2 = {(x: String): Bool => x.size() == 1 }
     for x in Filter[String](input2.values(), fn2) do
       actual.push(x)
     end
@@ -237,7 +237,7 @@ class iso _TestFilter is UnitTest
     h.assert_array_eq[String](actual, expected)
     actual.clear()
 
-    let fn3 = lambda (x: String): Bool => x.size() == 1 end
+    let fn3 = {(x: String): Bool => x.size() == 1 }
     for x in Filter[String](input3.values(), fn3) do
       actual.push(x)
     end
@@ -249,7 +249,7 @@ class iso _TestIterAll is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let input = [as I64: 1, 3, 6, 7, 9]
-    let is_positive = lambda(n: I64): Bool => n > 0 end
+    let is_positive = {(n: I64): Bool => n > 0 }
     h.assert_true(Iter[I64](input.values()).all(is_positive))
     input(2) = -6
     h.assert_false(Iter[I64](input.values()).all(is_positive))
@@ -259,7 +259,7 @@ class iso _TestIterAny is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let input = [as I64: -1, -3, 6, -7, -9]
-    let is_positive = lambda(n: I64): Bool => n > 0 end
+    let is_positive = {(n: I64): Bool => n > 0 }
     h.assert_true(Iter[I64](input.values()).any(is_positive))
     input(2) = -6
     h.assert_false(Iter[I64](input.values()).any(is_positive))
@@ -340,7 +340,7 @@ class iso _TestIterFilter is UnitTest
     let expected = ["c", "f", "g"]
     let actual = Array[String]
 
-    let fn1 = lambda (x: String): Bool => x.size() == 1 end
+    let fn1 = {(x: String): Bool => x.size() == 1 }
     for x in Iter[String](input1.values()).filter(fn1) do
       actual.push(x)
     end
@@ -348,7 +348,7 @@ class iso _TestIterFilter is UnitTest
     h.assert_array_eq[String](actual, expected)
     actual.clear()
 
-    let fn2 = lambda (x: String): Bool => x.size() == 1 end
+    let fn2 = {(x: String): Bool => x.size() == 1 }
     for x in Iter[String](input2.values()).filter(fn2) do
       actual.push(x)
     end
@@ -356,7 +356,7 @@ class iso _TestIterFilter is UnitTest
     h.assert_array_eq[String](actual, expected)
     actual.clear()
 
-    let fn3 = lambda (x: String): Bool => x.size() == 1 end
+    let fn3 = {(x: String): Bool => x.size() == 1 }
     for x in Iter[String](input3.values()).filter(fn3) do
       actual.push(x)
     end
@@ -368,40 +368,40 @@ class iso _TestIterFind is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let input = [as I64: 1, 2, 3, -4, 5]
-    h.assert_error(lambda()(input) ? =>
-      Iter[I64](input.values()).find(lambda(x: I64): Bool => x == 0 end)
-    end)
-    let ltzero = lambda(x: I64): Bool => x < 0 end
+    h.assert_error({()(input) ? =>
+      Iter[I64](input.values()).find({(x: I64): Bool => x == 0 })
+    })
+    let ltzero = {(x: I64): Bool => x < 0 }
     h.assert_eq[I64](
       -4,
       Iter[I64](input.values()).find(ltzero))
-    h.assert_error(lambda()(input, ltzero) ? =>
+    h.assert_error({()(input, ltzero) ? =>
       Iter[I64](input.values()).find(ltzero, 2)
-    end)
+    })
     h.assert_eq[I64](
       5,
-      Iter[I64](input.values()).find(lambda(x: I64): Bool => x > 0 end, 4))
+      Iter[I64](input.values()).find({(x: I64): Bool => x > 0 }, 4))
 
 class iso _TestIterFold is UnitTest
   fun name(): String => "itertools/Iter.fold"
 
   fun apply(h: TestHelper) ? =>
     let ns = [as I64: 1, 2, 3, 4, 5, 6]
-    let fn = lambda(sum: I64, n: I64): I64 => sum + n end
+    let fn = {(sum: I64, n: I64): I64 => sum + n }
     let sum = Iter[I64](ns.values()).fold[I64](fn, 0)
     h.assert_eq[I64](sum, 21)
 
-    let err = lambda(acc: I64, x: I64): I64 ? => error end
-    h.assert_error(lambda()(ns, err) ? =>
+    let err = {(acc: I64, x: I64): I64 ? => error }
+    h.assert_error({()(ns, err) ? =>
       Iter[I64](ns.values()).fold[I64](err, 0)
-    end)
+    })
 
 class iso _TestIterLast is UnitTest
   fun name(): String => "itertools/Iter.last"
 
   fun apply(h: TestHelper) ? =>
     let input1 = Array[I64]
-    h.assert_error(lambda()(input1) ? => Iter[I64](input1.values()).last() end)
+    h.assert_error({()(input1) ? => Iter[I64](input1.values()).last() })
     let input2 =[as I64: 1]
     h.assert_eq[I64](
       1,
@@ -423,7 +423,7 @@ class iso _TestIterMap is UnitTest
     let expected = ["ab", "bb", "cb"]
     let actual = Array[String]
 
-    let fn = lambda (x: String): String => x + "b" end
+    let fn = { (x: String): String => x + "b" }
     for x in Iter[String](input.values()).map[String](fn) do
       actual.push(x)
     end
@@ -444,7 +444,7 @@ class iso _TestIterNth is UnitTest
     h.assert_eq[USize](
       3,
       Iter[USize](input.values()).nth(3))
-    h.assert_error(lambda()(input) ? => Iter[USize](input.values()).nth(4) end)
+    h.assert_error({()(input) ? => Iter[USize](input.values()).nth(4) })
 
 class iso _TestIterRun is UnitTest
   fun name(): String => "itertools/Iter.run"
@@ -460,23 +460,22 @@ class iso _TestIterRun is UnitTest
     h.long_test(100_000_000)
     
     Iter[I64](xs.values())
-      .map[None](lambda(x: I64)(h) => h.complete_action(x.string()) end)
+      .map[None]({(x: I64)(h) => h.complete_action(x.string()) })
       .run()
 
     Iter[I64](object ref is Iterator[I64]
       fun ref has_next(): Bool => true
       fun ref next(): I64 ? => error
-    end)
-      .run(lambda()(h) => h.complete_action("error") end)
+    end).run({()(h) => h.complete_action("error") })
 
 class iso _TestIterSkip is UnitTest
   fun name(): String => "itertools/Iter.skip"
 
   fun apply(h: TestHelper) ? =>
     let input = [as I64: 1]
-    h.assert_error(lambda()(input) ? =>
+    h.assert_error({()(input) ? =>
       Iter[I64](input.values()).skip(1).next()
-    end)
+    })
     input.push(2)
     h.assert_eq[I64](
       2,
@@ -493,14 +492,10 @@ class iso _TestIterSkipWhile is UnitTest
     let input = [as I64: -1, 0, 1, 2, 3]
     h.assert_eq[I64](
       1,
-      Iter[I64](input.values()).skip_while(lambda(x: I64): Bool =>
-        x <= 0
-      end).next())
+      Iter[I64](input.values()).skip_while({(x: I64): Bool => x <= 0 }).next())
     h.assert_eq[I64](
       -1,
-      Iter[I64](input.values()).skip_while(lambda(x: I64): Bool =>
-        x < -2
-      end).next())
+      Iter[I64](input.values()).skip_while({(x: I64): Bool => x < -2 }).next())
 
 class iso _TestIterTake is UnitTest
   fun name(): String => "itertools/Iter.take"
@@ -524,15 +519,15 @@ class iso _TestIterTakeWhile is UnitTest
     let input = [as I64: -1, 0, 1, 2, 3]
     h.assert_array_eq[I64](
       [as I64: -1, 0],
-      Iter[I64](input.values()).take_while(lambda(x: I64): Bool => x < 1 end)
+      Iter[I64](input.values()).take_while({(x: I64): Bool => x < 1 })
         .collect(Array[I64]))
     h.assert_array_eq[I64](
       input,
-      Iter[I64](input.values()).take_while(lambda(x: I64): Bool => x < 4 end)
+      Iter[I64](input.values()).take_while({(x: I64): Bool => x < 4 })
         .collect(Array[I64]))
     h.assert_array_eq[I64](
       Array[I64],
-      Iter[I64](input.values()).take_while(lambda(x: I64): Bool ? => error end)
+      Iter[I64](input.values()).take_while({(x: I64): Bool ? => error })
         .collect(Array[I64]))
 
 class iso _TestIterZip is UnitTest

--- a/packages/itertools/filter.pony
+++ b/packages/itertools/filter.pony
@@ -14,7 +14,7 @@ class Filter[A] is Iterator[A]
 
   actor Main
     new create(env: Env) =>
-      let fn = lambda (s: String): Bool => x.size() > 3 end
+      let fn = {(s: String): Bool => x.size() > 3 }
       for x in Filter[String](env.args.slice(1).values(), fn) do
         env.out.print(x)
       end

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -40,13 +40,13 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 2, 4, 6].values())
-      .all(lambda(x: I64): Bool => (x % 2) == 0 end)
+      .all({(x: I64): Bool => (x % 2) == 0 })
     ```
     `true`
 
     ```pony
     Iter[I64]([as I64: 2, 3, 4].values())
-      .all(lambda(x: I64): Bool => (x % 2) == 0 end)
+      .all({(x: I64): Bool => (x % 2) == 0 })
     ```
     `false`
     """
@@ -67,13 +67,13 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 2, 4, 6].values())
-      .any(lambda(x: I64): Bool => (x % 2) == 1 end)
+      .any({(x: I64): Bool => (x % 2) == 1 })
     ```
     `false`
 
     ```pony
     Iter[I64]([as I64: 2, 3, 4].values())
-      .any(lambda(x: I64): Bool => (x % 2) == 1 end)
+      .any({(x: I64): Bool => (x % 2) == 1 })
     ```
     `true`
     """
@@ -195,7 +195,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3, 4, 5, 6].values())
-      .filter(lambda(x: I64): Bool => (x % 2) == 0 end)
+      .filter({(x: I64): Bool => (x % 2) == 0 })
     ```
     `2 4 6`
     """
@@ -254,13 +254,13 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3].values())
-      .find(lambda(x: I64): Bool => (x % 2) == 0 end)
+      .find({(x: I64): Bool => (x % 2) == 0 })
     ```
     `2`
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3, 4].values())
-      .find(lambda(x: I64): Bool => (x % 2) == 0 end, 2)
+      .find({(x: I64): Bool => (x % 2) == 0 }, 2)
     ```
     `4`
     """
@@ -284,7 +284,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3].values())
-      .fold[I64](lambda(x: I64, sum: I64): I64 => sum + x end, 0)
+      .fold[I64]({(x: I64, sum: I64): I64 => sum + x }, 0)
     ```
     `6`
     """
@@ -320,7 +320,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3].values())
-      .map[I64](lambda(x: I64): I64 => x * x end)
+      .map[I64]({(x: I64): I64 => x * x })
     ```
     `1 4 9`
     """
@@ -362,7 +362,7 @@ class Iter[A] is Iterator[A]
     end
     _iter.next()
 
-  fun ref run(on_error: {()} box = lambda() => None end) =>
+  fun ref run(on_error: {()} box = {() => None }) =>
     """
     Iterate through the values of the iterator without a for loop. The
     function `on_error` will be called if the iterator's `has_next` method
@@ -372,7 +372,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3].values())
-      .map[None](lambda(x: I64)(env) => env.out.print(x.string()) end)
+      .map[None]({(x: I64)(env) => env.out.print(x.string()) })
       .run()
     ```
     ```
@@ -418,7 +418,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3, 4, 5, 6].values())
-      .skip_while(lambda(x: I64): Bool => x < 4 end)
+      .skip_while({(x: I64): Bool => x < 4 })
     ```
     `4 5 6`
     """
@@ -478,7 +478,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3, 4, 5, 6].values())
-      .take_while(lambda(x: I64): Bool => x < 4 end)
+      .take_while({(x: I64): Bool => x < 4 })
     ```
     `1 2 3`
     """

--- a/packages/itertools/itertools.pony
+++ b/packages/itertools/itertools.pony
@@ -19,9 +19,9 @@ any odd numbers, and prints the rest.
 
 ```pony
 let xs = Iter[I64]([as I64: 1, 2, 3, 4, 5].values())
-  .map[I64](lambda(x: I64): I64 => x + 1 end)
-  .filter(lambda(x: I64): Bool => (x % 2) == 0 end)
-  .map[None](lambda(x: I64)(env) => env.out.print(x.string()) end)
+  .map[I64]({(x: I64): I64 => x + 1 })
+  .filter({(x: I64): Bool => (x % 2) == 0 })
+  .map[None]({(x: I64)(env) => env.out.print(x.string()) })
 ```
 
 This will result in an iterator that prints the numbers 2, 4, and 6. However,
@@ -41,9 +41,9 @@ for a loop. So the final code would be as follows:
 
 ```pony
 Iter[I64]([as I64: 1, 2, 3, 4, 5].values())
-  .map[I64](lambda(x: I64): I64 => x + 1 end)
-  .filter(lambda(x: I64): Bool => (x % 2) == 0 end)
-  .map[None](lambda(x: I64)(env) => env.out.print(x.string()) end)
+  .map[I64]({(x: I64): I64 => x + 1 })
+  .filter({(x: I64): Bool => (x % 2) == 0 })
+  .map[None]({(x: I64)(env) => env.out.print(x.string()) })
   .run()
 ```
 

--- a/packages/itertools/map_fn.pony
+++ b/packages/itertools/map_fn.pony
@@ -13,7 +13,7 @@ class MapFn[A, B] is Iterator[B]
 
   actor Main
     new create(env: Env) =>
-      let fn = lambda (s: String): I32 => try s.i32() * 2 else 0 end end
+      let fn = {(s: String): I32 => try s.i32() * 2 else 0 end }
       for x in MapFn[String, I32](env.args.slice(1).values(), fn) do
         env.out.print(x.string())
       end

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -41,9 +41,9 @@ class iso _TestParseBasic is UnitTest
     doc.parse(" true   ")
     h.assert_eq[Bool](true, doc.data as Bool)
 
-    h.assert_error(lambda()? => JsonDoc.parse("") end)
-    h.assert_error(lambda()? => JsonDoc.parse("   ") end)
-    h.assert_error(lambda()? => JsonDoc.parse("true true") end)
+    h.assert_error({()? => JsonDoc.parse("") })
+    h.assert_error({()? => JsonDoc.parse("   ") })
+    h.assert_error({()? => JsonDoc.parse("true true") })
 
 class iso _TestParseKeyword is UnitTest
   """
@@ -63,10 +63,10 @@ class iso _TestParseKeyword is UnitTest
     doc.parse("null")
     h.assert_eq[None](None, doc.data as None)
 
-    h.assert_error(lambda()? => JsonDoc.parse("tru e") end)
-    h.assert_error(lambda()? => JsonDoc.parse("truw") end)
-    h.assert_error(lambda()? => JsonDoc.parse("truez") end)
-    h.assert_error(lambda()? => JsonDoc.parse("TRUE") end)
+    h.assert_error({()? => JsonDoc.parse("tru e") })
+    h.assert_error({()? => JsonDoc.parse("truw") })
+    h.assert_error({()? => JsonDoc.parse("truez") })
+    h.assert_error({()? => JsonDoc.parse("TRUE") })
 
 class iso _TestParseNumber is UnitTest
   """
@@ -104,11 +104,11 @@ class iso _TestParseNumber is UnitTest
     doc.parse("1.23e3")
     h.assert_eq[F64](1230, doc.data as F64)
 
-    h.assert_error(lambda()? => JsonDoc.parse("0x4") end)
-    h.assert_error(lambda()? => JsonDoc.parse("+1") end)
-    h.assert_error(lambda()? => JsonDoc.parse("1.") end)
-    h.assert_error(lambda()? => JsonDoc.parse("1.-3") end)
-    h.assert_error(lambda()? => JsonDoc.parse("1e") end)
+    h.assert_error({()? => JsonDoc.parse("0x4") })
+    h.assert_error({()? => JsonDoc.parse("+1") })
+    h.assert_error({()? => JsonDoc.parse("1.") })
+    h.assert_error({()? => JsonDoc.parse("1.-3") })
+    h.assert_error({()? => JsonDoc.parse("1e") })
 
 class iso _TestParseString is UnitTest
   """
@@ -143,13 +143,13 @@ class iso _TestParseString is UnitTest
     doc.parse(""" "Foo\uD834\uDD1Ebar" """)
     h.assert_eq[String]("Foo\U01D11Ebar", doc.data as String)
 
-    h.assert_error(lambda()? => JsonDoc.parse(""" "Foo """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "Foo\z" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "\u" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "\u37" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "\u037g" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "\uD834" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse(""" "\uDD1E" """) end)
+    h.assert_error({()? => JsonDoc.parse(""" "Foo """) })
+    h.assert_error({()? => JsonDoc.parse(""" "Foo\z" """) })
+    h.assert_error({()? => JsonDoc.parse(""" "\u" """) })
+    h.assert_error({()? => JsonDoc.parse(""" "\u37" """) })
+    h.assert_error({()? => JsonDoc.parse(""" "\u037g" """) })
+    h.assert_error({()? => JsonDoc.parse(""" "\uD834" """) })
+    h.assert_error({()? => JsonDoc.parse(""" "\uDD1E" """) })
 
 class iso _TestParseArray is UnitTest
   """
@@ -195,13 +195,13 @@ class iso _TestParseArray is UnitTest
     h.assert_eq[None](None,
       ((doc.data as JsonArray).data(1) as JsonArray).data(1) as None)
 
-    h.assert_error(lambda()? => JsonDoc.parse("[true true]") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[,]") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[true,]") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[,true]") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[true") end)
-    h.assert_error(lambda()? => JsonDoc.parse("[true,") end)
+    h.assert_error({()? => JsonDoc.parse("[true true]") })
+    h.assert_error({()? => JsonDoc.parse("[,]") })
+    h.assert_error({()? => JsonDoc.parse("[true,]") })
+    h.assert_error({()? => JsonDoc.parse("[,true]") })
+    h.assert_error({()? => JsonDoc.parse("[") })
+    h.assert_error({()? => JsonDoc.parse("[true") })
+    h.assert_error({()? => JsonDoc.parse("[true,") })
 
 class iso _TestParseObject is UnitTest
   """
@@ -247,17 +247,17 @@ class iso _TestParseObject is UnitTest
     h.assert_eq[None](None,
       ((doc.data as JsonObject).data("b") as JsonObject).data("d") as None)
 
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a": 1 "b": 2}""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("{,}") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a": true,}""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{,"a": true}""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a" """) end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a": """) end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a": true""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a": true,""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{"a" true}""") end)
-    h.assert_error(lambda()? => JsonDoc.parse("""{:true}""") end)
+    h.assert_error({()? => JsonDoc.parse("""{"a": 1 "b": 2}""") })
+    h.assert_error({()? => JsonDoc.parse("{,}") })
+    h.assert_error({()? => JsonDoc.parse("""{"a": true,}""") })
+    h.assert_error({()? => JsonDoc.parse("""{,"a": true}""") })
+    h.assert_error({()? => JsonDoc.parse("""{""") })
+    h.assert_error({()? => JsonDoc.parse("""{"a" """) })
+    h.assert_error({()? => JsonDoc.parse("""{"a": """) })
+    h.assert_error({()? => JsonDoc.parse("""{"a": true""") })
+    h.assert_error({()? => JsonDoc.parse("""{"a": true,""") })
+    h.assert_error({()? => JsonDoc.parse("""{"a" true}""") })
+    h.assert_error({()? => JsonDoc.parse("""{:true}""") })
 
 class iso _TestParseRFC1 is UnitTest
   """

--- a/packages/logger/_test.pony
+++ b/packages/logger/_test.pony
@@ -77,7 +77,7 @@ class _TestObjectLogging is _LoggerTest[U64]
   =>
     Logger[U64](level',
       stream',
-      lambda(a: U64): String => a.string() end,
+      {(a: U64): String => a.string() },
       formatter')
 
   fun level(): LogLevel => Fine

--- a/packages/logger/logger.pony
+++ b/packages/logger/logger.pony
@@ -67,7 +67,7 @@ actor Main
   new create(env: Env) =>
     let logger = Logger[U64](Fine,
     env.out,
-    lambda(a: U64): String => a.string() end)
+    {(a: U64): String => a.string() })
 
     logger(Error) and logger.log(U64(42))
 ```
@@ -137,7 +137,7 @@ primitive StringLogger
     out: OutStream,
     formatter: LogFormatter = DefaultLogFormatter): Logger[String]
   =>
-    Logger[String](level, out, lambda(s: String): String => s end, formatter)
+    Logger[String](level, out, {(s: String): String => s }, formatter)
 
 interface val LogFormatter
   """

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -76,9 +76,9 @@ class iso _EncodeBad is UnitTest
   fun name(): String => "net/http/URLEncode.encode_bad"
 
   fun apply(h: TestHelper) =>
-    h.assert_error(lambda()? => URLEncode.encode("%2G", URLPartUser) end)
-    h.assert_error(lambda()? => URLEncode.encode("%xx", URLPartUser) end)
-    h.assert_error(lambda()? => URLEncode.encode("%2", URLPartUser) end)
+    h.assert_error({()? => URLEncode.encode("%2G", URLPartUser) })
+    h.assert_error({()? => URLEncode.encode("%xx", URLPartUser) })
+    h.assert_error({()? => URLEncode.encode("%2", URLPartUser) })
 
 class iso _EncodeIPv6 is UnitTest
   fun name(): String => "net/http/URLEncode.encode_ipv6"
@@ -86,11 +86,11 @@ class iso _EncodeIPv6 is UnitTest
   fun apply(h: TestHelper) ? =>
     // Allowed hex digits, '.' and ':' only, between '[' and ']'.
     h.assert_eq[String]("[1::A.B]", URLEncode.encode("[1::A.B]", URLPartHost))
-    h.assert_error(lambda()? => URLEncode.encode("[G]", URLPartHost) end)
-    h.assert_error(lambda()? => URLEncode.encode("[/]", URLPartHost) end)
-    h.assert_error(lambda()? => URLEncode.encode("[%32]", URLPartHost) end)
-    h.assert_error(lambda()? => URLEncode.encode("[1]2", URLPartHost) end)
-    h.assert_error(lambda()? => URLEncode.encode("[1", URLPartHost) end)
+    h.assert_error({()? => URLEncode.encode("[G]", URLPartHost) })
+    h.assert_error({()? => URLEncode.encode("[/]", URLPartHost) })
+    h.assert_error({()? => URLEncode.encode("[%32]", URLPartHost) })
+    h.assert_error({()? => URLEncode.encode("[1]2", URLPartHost) })
+    h.assert_error({()? => URLEncode.encode("[1", URLPartHost) })
     h.assert_eq[String]("1%5D", URLEncode.encode("1]", URLPartHost))
 
 class iso _EncodeClean is UnitTest
@@ -215,9 +215,9 @@ class iso _DecodeBad is UnitTest
   fun name(): String => "net/http/URLEncode.decode_bad"
 
   fun apply(h: TestHelper) =>
-    h.assert_error(lambda()? => URLEncode.decode("%2G") end)
-    h.assert_error(lambda()? => URLEncode.decode("%xx") end)
-    h.assert_error(lambda()? => URLEncode.decode("%2") end)
+    h.assert_error({()? => URLEncode.decode("%2G") })
+    h.assert_error({()? => URLEncode.decode("%xx") })
+    h.assert_error({()? => URLEncode.decode("%2") })
 
 class iso _BuildBasic is UnitTest
   fun name(): String => "net/http/URL.build_basic"
@@ -274,20 +274,25 @@ class iso _BuildBad is UnitTest
   fun name(): String => "net/http/URL.build_bad"
 
   fun apply(h: TestHelper) =>
-    h.assert_error(lambda()? =>
-      URL.build("htt_ps://user@host.name/path#fragment") end)
+    h.assert_error({()? =>
+      URL.build("htt_ps://user@host.name/path#fragment")
+    })
 
-    h.assert_error(lambda()? =>
-      URL.build("https://[11::24_]/path") end)
+    h.assert_error({()? =>
+      URL.build("https://[11::24_]/path")
+    })
 
-    h.assert_error(lambda()? =>
-      URL.build("https://[11::24/path") end)
+    h.assert_error({()? =>
+      URL.build("https://[11::24/path")
+    })
 
-    h.assert_error(lambda()? =>
-      URL.build("https://host%2Gname/path") end)
+    h.assert_error({()? =>
+      URL.build("https://host%2Gname/path")
+    })
 
-    h.assert_error(lambda()? =>
-      URL.build("https://hostname/path%") end)
+    h.assert_error({()? =>
+      URL.build("https://hostname/path%")
+    })
 
 class iso _BuildNoEncoding is UnitTest
   fun name(): String => "net/http/URL.build_no_encoding"
@@ -305,12 +310,14 @@ class iso _Valid is UnitTest
       "https", "user", "password", "host.name", 12345, "/path", "query",
       "fragment")
 
-    h.assert_error(lambda()? =>
-      URL.valid("http://rosettacode.org/wiki/Category[Pony]") end)
+    h.assert_error({()? =>
+      URL.valid("http://rosettacode.org/wiki/Category[Pony]")
+    })
 
-    h.assert_error(lambda()? =>
+    h.assert_error({()? =>
       URL.valid("https://en.wikipedia|org/wiki/Polymorphism_" +
-        "(computer_science)#Parametric_polymorphism") end)
+        "(computer_science)#Parametric_polymorphism")
+    })
 
     _Test(h, URL.valid("http://user@host"),
       "http", "user", "", "host", 80, "/", "", "")

--- a/packages/ponybench/_auto_bench.pony
+++ b/packages/ponybench/_auto_bench.pony
@@ -14,16 +14,14 @@ actor _AutoBench[A: Any #share]
     max_ops: U64 = 100_000_000
   ) =>
     _notify = notify
-    _run = recover
-      lambda(ops: U64)(notify = this, name, f) =>
-        match f
-        | let fn: {(): A ?} val =>
-          _Bench[A](notify)(name, fn, ops)
-        | let fn: {(): Promise[A] ?} val =>
-          _BenchAsync[A](notify)(name, fn, ops)
-        end
+    _run = {(ops: U64)(notify = this, name, f) =>
+      match f
+      | let fn: {(): A ?} val =>
+        _Bench[A](notify)(name, fn, ops)
+      | let fn: {(): Promise[A] ?} val =>
+        _BenchAsync[A](notify)(name, fn, ops)
       end
-    end
+    } val
     _auto_ops = _AutoOps(bench_time, max_ops)
 
   be apply(ops: U64 = 1) => _run(ops)

--- a/packages/ponybench/_bench_async.pony
+++ b/packages/ponybench/_bench_async.pony
@@ -14,12 +14,7 @@ actor _BenchAsync[A: Any #share]
       let pn = _PromiseNotify(_notify, name, ops)
       for i in Range[U64](0, ops) do
         let p = f()
-        p.next[A](recover
-          lambda(a: A)(pn): A =>
-            pn()
-            a
-          end
-        end)
+        p.next[A]({(a: A)(pn): A => pn(); a } iso)
       end
     else
       _notify._failure(name)

--- a/packages/promises/_test.pony
+++ b/packages/promises/_test.pony
@@ -18,18 +18,16 @@ class iso _TestPromise is UnitTest
   fun _test_fulfilled(h: TestHelper) =>
     h.expect_action("fulfilled")
     let p = Promise[String]
-    p.next[None](
-      recover lambda(s: String)(h) => h.complete_action(s) end end
-    )
+    p.next[None]({(s: String)(h) => h.complete_action(s) } iso)
     p("fulfilled")
 
   fun _test_rejected(h: TestHelper) =>
     h.expect_action("rejected")
     let p = Promise[String]
     p.next[String](
-      recover lambda(s: String)(h): String ? => error end end,
-      recover lambda()(h): String => "rejected" end end
+      {(s: String)(h): String ? => error } iso,
+      {()(h): String => "rejected" } iso
     ).next[None](
-      recover lambda(s: String)(h) => h.complete_action(s) end end
+      {(s: String)(h) => h.complete_action(s) } iso
     )
     p.reject()

--- a/packages/regex/_test.pony
+++ b/packages/regex/_test.pony
@@ -41,12 +41,12 @@ class iso _TestGroups is UnitTest
     let m2 = r("123.")
     h.assert_eq[String](m2(0), "123.")
     h.assert_eq[String](m2(1), "123")
-    h.assert_error(lambda()(m2 = m2)? => m2(2) end)
+    h.assert_error({()(m2 = m2)? => m2(2) })
     h.assert_array_eq[String](m2.groups(), ["123", ""])
 
     let m3 = r(".456")
     h.assert_eq[String](m3(0), ".456")
-    h.assert_error(lambda()(m3 = m3)? => m3(1) end)
+    h.assert_error({()(m3 = m3)? => m3(1) })
     h.assert_eq[String](m3(2), "456")
     h.assert_array_eq[String](m3.groups(), ["", "456"])
 
@@ -80,4 +80,4 @@ class iso _TestError is UnitTest
   fun name(): String => "regex/Regex.create/fails"
 
   fun apply(h: TestHelper) =>
-    h.assert_error(lambda()? => Regex("(\\d+") end)
+    h.assert_error({()? => Regex("(\\d+") })

--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -205,15 +205,13 @@ class iso _TestFailures is UnitTest
     let ambient = h.env.root as AmbientAuth
     let serialise = SerialiseAuth(ambient)
 
-    h.assert_error(
-      lambda()(serialise)? =>
-        Serialised(serialise, _HasPointer)
-      end)
+    h.assert_error({()(serialise)? =>
+      Serialised(serialise, _HasPointer)
+    })
 
-    h.assert_error(
-      lambda()(serialise)? =>
-        Serialised(serialise, _HasActor)
-      end)
+    h.assert_error({()(serialise)? =>
+      Serialised(serialise, _HasActor)
+    })
 
 class _BoxedWord
   var f: Any val = U32(3)

--- a/pony.g
+++ b/pony.g
@@ -187,7 +187,7 @@ nextatom
   | LPAREN_NEW (rawseq | '_') tuple? ')'
   | LSQUARE_NEW ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' cap? ('is' type)? members 'end'
-  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;
@@ -199,7 +199,7 @@ atom
   | ('(' | LPAREN_NEW) (rawseq | '_') tuple? ')'
   | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' cap? ('is' type)? members 'end'
-  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;

--- a/pony.g
+++ b/pony.g
@@ -188,6 +188,7 @@ nextatom
   | LSQUARE_NEW ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' cap? ('is' type)? members 'end'
   | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;
@@ -200,6 +201,7 @@ atom
   | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' cap? ('is' type)? members 'end'
   | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -347,6 +347,7 @@ DEF(oldlambda);
 // LBRACE [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params] RPAREN
 // [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq RBRACE [CAP]
 DEF(lambda);
+  PRINT_INLINE();
   AST_NODE(TK_LAMBDA);
   SKIP(NULL, TK_LBRACE);
   OPT RULE("receiver capability", cap);

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -322,10 +322,10 @@ DEF(lambdacaptures);
 
 // LAMBDA [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params] RPAREN
 // [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq END
-DEF(lambda);
+DEF(oldlambda);
   PRINT_INLINE();
   TOKEN(NULL, TK_LAMBDA);
-  OPT RULE("capability", cap);
+  OPT RULE("receiver capability", cap);
   OPT TOKEN("function name", TK_ID);
   OPT RULE("type parameters", typeparams);
   SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
@@ -337,6 +337,31 @@ DEF(lambda);
   SKIP(NULL, TK_DBLARROW);
   RULE("lambda body", rawseq);
   TERMINATE("lambda expression", TK_END);
+  AST_NODE(TK_QUESTION); // Reference capability - question indicates old syntax
+  SET_CHILD_FLAG(2, AST_FLAG_PRESERVE); // Type parameters
+  SET_CHILD_FLAG(3, AST_FLAG_PRESERVE); // Parameters
+  SET_CHILD_FLAG(5, AST_FLAG_PRESERVE); // Return type
+  SET_CHILD_FLAG(7, AST_FLAG_PRESERVE); // Body
+  DONE();
+
+// LBRACE [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params] RPAREN
+// [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq RBRACE [CAP]
+DEF(lambda);
+  AST_NODE(TK_LAMBDA);
+  SKIP(NULL, TK_LBRACE);
+  OPT RULE("receiver capability", cap);
+  OPT TOKEN("function name", TK_ID);
+  OPT RULE("type parameters", typeparams);
+  SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
+  OPT RULE("parameters", params);
+  SKIP(NULL, TK_RPAREN);
+  OPT RULE("captures", lambdacaptures);
+  IF(TK_COLON, RULE("return type", type));
+  OPT TOKEN(NULL, TK_QUESTION);
+  SKIP(NULL, TK_DBLARROW);
+  RULE("lambda body", rawseq);
+  TERMINATE("lambda expression", TK_RBRACE);
+  OPT RULE("reference capability", cap);
   SET_CHILD_FLAG(2, AST_FLAG_PRESERVE); // Type parameters
   SET_CHILD_FLAG(3, AST_FLAG_PRESERVE); // Parameters
   SET_CHILD_FLAG(5, AST_FLAG_PRESERVE); // Return type
@@ -438,13 +463,13 @@ DEF(ffi);
 // ref | this | literal | tuple | array | object | lambda | ffi | location
 DEF(atom);
   RULE("value", ref, thisliteral, literal, groupedexpr, array, object, lambda,
-    ffi, location);
+    oldlambda, ffi, location);
   DONE();
 
 // ref | this | literal | tuple | array | object | lambda | ffi | location
 DEF(nextatom);
   RULE("value", ref, thisliteral, literal, nextgroupedexpr, nextarray, object,
-    lambda, ffi, location);
+    lambda, oldlambda, ffi, location);
   DONE();
 
 // DOT ID

--- a/src/libponyc/ast/treecheckdef.h
+++ b/src/libponyc/ast/treecheckdef.h
@@ -330,14 +330,15 @@ RULE(try_expr,
 
 RULE(lambda,
   HAS_TYPE(type)
-  CHILD(cap, none)
+  CHILD(cap, none) // Receiver cap
   CHILD(id, none)
   CHILD(type_params, none)
   CHILD(params, none)
   CHILD(lambda_captures, none)
   CHILD(type, none) // Return
   CHILD(question, none)
-  CHILD(rawseq),
+  CHILD(rawseq)
+  CHILD(cap, none, question), // Type reference cap (? indicates old syntax)
   TK_LAMBDA);
 
 RULE(lambda_captures, ONE_OR_MORE(lambda_capture), TK_LAMBDACAPTURES);

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -523,7 +523,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
    *
    * Partial call is converted to:
    * ```pony
-   * lambda(b: B = b_default)($0 = recv, a = foo): R => $0.f[T2](a, consume b)
+   * {(b: B = b_default)($0 = recv, a = foo): R => $0.f[T2](a, consume b) }
    * ```
    */
 
@@ -675,7 +675,8 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
         NODE(TK_CALL,
           TREE(lambda_call_args)
           NONE  // Named args.
-          TREE(call_receiver)))));
+          TREE(call_receiver)))
+      NONE)); // Lambda reference capability.
 
   // Need to preserve various lambda children.
   ast_setflag(ast_childidx(*astp, 2), AST_FLAG_PRESERVE); // Type params.

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -92,8 +92,8 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   ast_t* ast = *astp;
   assert(ast != NULL);
 
-  AST_GET_CHILDREN(ast, cap, name, t_params, params, captures, ret_type,
-    raises, body);
+  AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
+    ret_type, raises, body, reference_cap);
 
   ast_t* members = ast_from(ast, TK_MEMBERS);
   ast_t* last_member = NULL;
@@ -130,7 +130,7 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   // Make the apply function
   BUILD(apply, ast,
     NODE(TK_FUN, AST_SCOPE
-      TREE(cap)
+      TREE(receiver_cap)
       ID(fn_name)
       TREE(t_params)
       TREE(params)
@@ -143,7 +143,7 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   ast_list_append(members, &last_member, apply);
 
   printbuf_t* buf = printbuf_new();
-  printbuf(buf, "lambda(");
+  printbuf(buf, "{(");
   bool first = true;
 
   for(ast_t* p = ast_child(params); p != NULL; p = ast_sibling(p))
@@ -164,12 +164,12 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   if(ast_id(raises) != TK_NONE)
     printbuf(buf, " ?");
 
-  printbuf(buf, " end");
+  printbuf(buf, "}");
 
   // Replace lambda with object literal
   REPLACE(astp,
     NODE(TK_OBJECT, DATA(stringtab(buf->m))
-      NONE
+      TREE(reference_cap)
       NONE  // Provides list
       TREE(members)));
 

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -935,9 +935,9 @@ static ast_result_t syntax_compile_error(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast_id(ast) == TK_LAMBDA);
-  AST_GET_CHILDREN(ast, cap, name, typeparams, params, captures, type,
-    can_error, body);
-  switch(ast_id(type))
+  AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
+    ret_type, raises, body, reference_cap);
+  switch(ast_id(ret_type))
   {
     case TK_ISO:
     case TK_TRN:
@@ -946,9 +946,9 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
     case TK_BOX:
     case TK_TAG:
     {
-      ast_error(opt->check.errors, type, "lambda return type: %s",
-        ast_print_type(type));
-      ast_error_continue(opt->check.errors, type, "lambda return type "
+      ast_error(opt->check.errors, ret_type, "lambda return type: %s",
+        ast_print_type(ret_type));
+      ast_error_continue(opt->check.errors, ret_type, "lambda return type "
         "cannot be capability");
       return AST_ERROR;
     }
@@ -965,6 +965,13 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
       return AST_ERROR;
     }
     capture = ast_sibling(capture);
+  }
+
+  if(ast_id(reference_cap) == TK_QUESTION)
+  {
+    ast_error(opt->check.errors, ast,
+      "lambda ... end is no longer supported syntax; use {...} for lambdas");
+    return AST_ERROR;
   }
 
   return AST_OK;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -126,7 +126,7 @@ TEST_F(BadPonyTest, InvalidLambdaReturnType)
   const char* src =
     "actor Main\n"
     "  new create(env: Env) =>\n"
-    "    lambda (): tag => this end\n";
+    "    {(): tag => this }\n";
 
   TEST_ERRORS_1(src, "lambda return type: tag");
 }
@@ -161,7 +161,7 @@ TEST_F(BadPonyTest, LambdaCaptureVariableBeforeDeclarationWithTypeInferenceExpre
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda()(x) => None end\n"
+    "    {()(x) => None }\n"
     "    let x = 0";
 
    TEST_ERRORS_1(src, "declaration of 'x' appears after use");

--- a/test/libponyc/parse_expr.cc
+++ b/test/libponyc/parse_expr.cc
@@ -7,6 +7,10 @@
 #define TEST_ERROR(src) DO(test_error(src, "syntax"))
 #define TEST_COMPILE(src) DO(test_compile(src, "syntax"))
 
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "syntax", errs)); }
+
 
 class ParseExprTest : public PassTest
 {};
@@ -90,7 +94,7 @@ TEST_F(ParseExprTest, Lambda)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda() => None end";
+    "    {() => None }";
 
   TEST_COMPILE(src);
 }
@@ -101,7 +105,7 @@ TEST_F(ParseExprTest, LambdaCap)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda iso() => None end";
+    "    {iso() => None }";
 
   TEST_COMPILE(src);
 }
@@ -112,7 +116,7 @@ TEST_F(ParseExprTest, LambdaCaptureVariable)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   TEST_COMPILE(src);
 }
@@ -123,7 +127,7 @@ TEST_F(ParseExprTest, LambdaCaptureExpression)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda()(x = y) => None end";
+    "    {()(x = y) => None }";
 
   TEST_COMPILE(src);
 }
@@ -134,7 +138,7 @@ TEST_F(ParseExprTest, LambdaCaptureExpressionAndType)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda()(x: T = y) => None end";
+    "    {()(x: T = y) => None }";
 
   TEST_COMPILE(src);
 }
@@ -145,9 +149,21 @@ TEST_F(ParseExprTest, LambdaCaptureTypeWithoutExpressionFail)
   const char* src =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda()(x: T) => None end";
+    "    {()(x: T) => None }";
 
   TEST_ERROR(src);
+}
+
+
+TEST_F(ParseExprTest, LambdaOldSyntax)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    lambda() => None end";
+
+  TEST_ERRORS_1(src,
+    "lambda ... end is no longer supported syntax; use {...} for lambdas");
 }
 
 

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -2709,7 +2709,7 @@ TEST_F(SugarTest, AsOperatorWithLambdaType)
   const char* short_form =
     "class Foo\n"
       "new create() =>\n"
-        "let x = lambda():U32 => 0 end\n"
+        "let x = {():U32 => 0 }\n"
         "try x as {():U32} val end";
 
   TEST_COMPILE(short_form);

--- a/test/libponyc/sugar_expr.cc
+++ b/test/libponyc/sugar_expr.cc
@@ -33,7 +33,7 @@ TEST_F(SugarExprTest, PartialMinimal)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x) => $1.f() end";
+    "    {box()($1 = x) => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -55,7 +55,7 @@ TEST_F(SugarExprTest, PartialReceiverCapability)
 
     "class Foo\n"
     "  fun f(x: T ref) =>\n"
-    "    lambda ref()($1 = x) => $1.f() end";
+    "    {ref()($1 = x) => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -117,10 +117,10 @@ TEST_F(SugarExprTest, PartialSomeArgs)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box(b: U32, d: U32)\n"
+    "    {box(b: U32, d: U32)\n"
     "      ($1 = x, a: U32 = (3), c: U32 = (4)) =>\n"
     "      $1.f(a, consume b, c, consume d)\n"
-    "    end";
+    "    }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -142,10 +142,10 @@ TEST_F(SugarExprTest, PartialAllArgs)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x, a: U32 = (1), b: U32 = (2), c: U32 = (3),\n"
+    "    {box()($1 = x, a: U32 = (1), b: U32 = (2), c: U32 = (3),\n"
     "      d: U32 = (4)) =>\n"
     "      $1.f(a, b, c, d)\n"
-    "    end";
+    "    }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -167,10 +167,10 @@ TEST_F(SugarExprTest, PartialDefaultArgs)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box(b: U32 = 2, d: U32 = 4)\n"
+    "    {box(b: U32 = 2, d: U32 = 4)\n"
     "      ($1 = x, a: U32 = (5), c: U32 = (6)) =>\n"
     "      $1.f(a, consume b, c, consume d)\n"
-    "    end";
+    "    }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -192,7 +192,7 @@ TEST_F(SugarExprTest, PartialResult)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x): U32 => $1.f() end";
+    "    {box()($1 = x): U32 => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -214,7 +214,7 @@ TEST_F(SugarExprTest, PartialBehaviour)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x): T tag => $1.f() end";
+    "    {box()($1 = x): T tag => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -236,7 +236,7 @@ TEST_F(SugarExprTest, PartialRaisesError)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x): U32 ? => $1.f() end";
+    "    {box()($1 = x): U32 ? => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -258,7 +258,7 @@ TEST_F(SugarExprTest, PartialParameterTypeParameters)
 
     "class Foo[A: T #read]\n"
     "  fun f(t: T box, a: A) =>\n"
-    "    lambda box()($1 = t, a: A = (a)) => $1.f(a) end";
+    "    {box()($1 = t, a: A = (a)) => $1.f(a) }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -280,7 +280,7 @@ TEST_F(SugarExprTest, PartialReceiverTypeParameters)
 
     "class Foo[A: T #read]\n"
     "  fun f(x: A) =>\n"
-    "    lambda box()($1 = x) => $1.f() end";
+    "    {box()($1 = x) => $1.f() }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -302,7 +302,7 @@ TEST_F(SugarExprTest, PartialFunctionTypeParameter)
 
     "class Foo\n"
     "  fun f(x: T) =>\n"
-    "    lambda box()($1 = x, a: U32 = (3)) => $1.f[U32](a) end";
+    "    {box()($1 = x, a: U32 = (3)) => $1.f[U32](a) }";
 
   TEST_EQUIV(short_form, full_form);
 }
@@ -315,7 +315,7 @@ TEST_F(SugarExprTest, LambdaMinimal)
   const char* short_form =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda() => None end";
+    "    {() => None }";
 
   const char* full_form =
     "class Foo\n"
@@ -339,7 +339,7 @@ TEST_F(SugarExprTest, LambdaFull)
 
     "class Foo\n"
     "  fun f(c: C val, d: D2 val) =>\n"
-    "    lambda iso (a: A, b: B)(c, _c = c, _d: D val = d): A => a end";
+    "    {ref(a: A, b: B)(c, _c = c, _d: D val = d): A => a } iso";
 
   const char* full_form =
     "trait A\n"
@@ -350,11 +350,11 @@ TEST_F(SugarExprTest, LambdaFull)
 
     "class Foo\n"
     "  fun f(c: C val, d: D2 val) =>\n"
-    "    object ref\n"
+    "    object iso\n"
     "      var c: C val = c\n"
     "      var _c: C val = c\n"
     "      var _d: D val = d\n"
-    "      fun iso apply(a: A, b: B): A => a\n"
+    "      fun ref apply(a: A, b: B): A => a\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -366,7 +366,7 @@ TEST_F(SugarExprTest, LambdaThrow)
   const char* short_form =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda() ? => error end";
+    "    {() ? => error }";
 
   const char* full_form =
     "class Foo\n"
@@ -386,7 +386,7 @@ TEST_F(SugarExprTest, LambdaWithTypeArgs)
 
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda[A: T]() => None end";
+    "    {[A: T]() => None }";
 
   const char* full_form =
     "trait T\n"
@@ -409,7 +409,7 @@ TEST_F(SugarExprTest, LambdaCaptureLocalLet)
     "class Foo\n"
     "  fun f() =>\n"
     "    let x: U32 = 4\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   const char* full_form =
     "trait T\n"
@@ -434,7 +434,7 @@ TEST_F(SugarExprTest, LambdaCaptureLocalVar)
     "class Foo\n"
     "  fun f() =>\n"
     "    var x: U32 = 4\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   const char* full_form =
     "trait T\n"
@@ -458,7 +458,7 @@ TEST_F(SugarExprTest, LambdaCaptureParameter)
 
     "class Foo\n"
     "  fun f(x: U32) =>\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   const char* full_form =
     "trait T\n"
@@ -482,7 +482,7 @@ TEST_F(SugarExprTest, LambdaCaptureFieldLet)
     "class Foo\n"
     "  let x: U32 = 4\n"
     "  fun f() =>\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   const char* full_form =
     "trait T\n"
@@ -507,7 +507,7 @@ TEST_F(SugarExprTest, LambdaCaptureFieldVar)
     "class Foo\n"
     "  var x: U32 = 4\n"
     "  fun f() =>\n"
-    "    lambda()(x) => None end";
+    "    {()(x) => None }";
 
   const char* full_form =
     "trait T\n"
@@ -529,7 +529,7 @@ TEST_F(SugarExprTest, LambdaNamed)
   const char* short_form =
     "class Foo\n"
     "  fun f() =>\n"
-    "    lambda bar() => None end";
+    "    {bar() => None }";
 
   const char* full_form =
     "class Foo\n"


### PR DESCRIPTION
This PR implements issue #1391 (RFC 24), changing the lambda syntax to be more concise, and more consistent with the "lambdatype" syntax, using curly braces as the bounds of the lambda.

Note that the implementation takes special care to give a convenient, comprehensible error message for the old lambda syntax, to try to make migration to the new syntax easier for people with existing codebases using the old syntax:

```
lambda ... end is no longer supported syntax; use {...} for lambdas
      lambda(s: String): String => s + " world" end
      ^
```