### PR TITLE
Fixed compiler assert failure when constructor is called on type intersection (issue #1398)

### DIFF
--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -102,6 +102,22 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
       return constructor_type(opt, ast, cap, right, resultp);
     }
 
+    case TK_UNIONTYPE:
+    {
+      ast_error(opt->check.errors, ast,
+        "can't call a constructor on a type union: %s",
+        ast_print_type(type));
+      return false;
+    }
+
+    case TK_ISECTTYPE:
+    {
+      ast_error(opt->check.errors, ast,
+        "can't call a constructor on a type intersection: %s",
+        ast_print_type(type));
+      return false;
+    }
+
     default: {}
   }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -293,3 +293,18 @@ TEST_F(BadPonyTest, CircularTypeInfer)
   TEST_ERRORS_2(src, "cannot infer type of x",
                      "cannot infer type of y");
 }
+
+TEST_F(BadPonyTest, CallConstructorOnTypeIntersection)
+{
+  // From issue #1398
+  const char* src =
+    "interface Foo\n"
+
+    "type Isect is (None & Foo)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Isect.create()";
+
+  TEST_ERRORS_1(src, "can't call a constructor on a type intersection");
+}


### PR DESCRIPTION
This PR fixes a compiler assert failure when constructor is called on type intersection.

Resolves issue #1398.