### PR TITLE
Change internal mangling for complex types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fixed compiler assert failure when constructor is called on type intersection (issue #1398) (PR #1401)
 - Fix compiler assert fail on circular type inference error (issue #1334) (PR #1339)
 - Performance problem in the scheduler queue when running with many threads (issue #1404)
+- Invalid name mangling in generated C headers (issue #1377)
 
 ### Added
 

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -14,24 +14,24 @@ static void type_append(printbuf_t* buf, ast_t* type, bool first)
   {
     case TK_UNIONTYPE:
     {
-      // 3u_Arg1_Arg2_Arg3
-      printbuf(buf, "%du", ast_childcount(type));
+      // u3_Arg1_Arg2_Arg3
+      printbuf(buf, "u%d", ast_childcount(type));
       types_append(buf, type);
       return;
     }
 
     case TK_ISECTTYPE:
     {
-      // 3i_Arg1_Arg2_Arg3
-      printbuf(buf, "%di", ast_childcount(type));
+      // i3_Arg1_Arg2_Arg3
+      printbuf(buf, "i%d", ast_childcount(type));
       types_append(buf, type);
       return;
     }
 
     case TK_TUPLETYPE:
     {
-      // 3t_Arg1_Arg2_Arg3
-      printbuf(buf, "%dt", ast_childcount(type));
+      // t3_Arg1_Arg2_Arg3
+      printbuf(buf, "t%d", ast_childcount(type));
       types_append(buf, type);
       return;
     }


### PR DESCRIPTION
We now prefix the name with e.g. `t2` instead of `2t`. This change was made because identifiers can't start with numbers in C, and that rule was problematic for generated library headers.

-----

I haven't been able to come up with an ambiguous case with this new mangling, so I think the change is fine. But maybe I'm horribly wrong and there is something I've missed.