### PR TITLE
Avoid unnecessary synchronisation in the inject queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fixed error message when no type arguments are given (issue #1396) (PR #1397)
 - Fixed compiler assert failure when constructor is called on type intersection (issue #1398) (PR #1401)
 - Fix compiler assert fail on circular type inference error (issue #1334) (PR #1339)
+- Performance problem in the scheduler queue when running with many threads (issue #1404)
 
 ### Added
 

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -103,3 +103,16 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
   POOL_FREE(mpmcq_node_t, tail);
   return data;
 }
+
+void* ponyint_mpmcq_pop_bailout_immediate(mpmcq_t* q)
+{
+  mpmcq_node_t* head = atomic_load_explicit(&q->head, memory_order_relaxed);
+  mpmcq_node_t* tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
+
+  // If we believe the queue is empty, bailout immediately without taking a
+  // ticket to avoid unnecessary contention.
+  if(head == tail)
+    return NULL;
+
+  return ponyint_mpmcq_pop(q);
+}

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -29,6 +29,8 @@ void ponyint_mpmcq_push_single(mpmcq_t* q, void* data);
 
 void* ponyint_mpmcq_pop(mpmcq_t* q);
 
+void* ponyint_mpmcq_pop_bailout_immediate(mpmcq_t* q);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -53,7 +53,10 @@ static void push(scheduler_t* sched, pony_actor_t* actor)
  */
 static pony_actor_t* pop_global(scheduler_t* sched)
 {
-  pony_actor_t* actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
+  // The global queue is empty most of the time. We use pop_bailout_immediate
+  // to avoid unnecessary synchronisation in that common case.
+  pony_actor_t* actor =
+    (pony_actor_t*)ponyint_mpmcq_pop_bailout_immediate(&inject);
 
   if(actor != NULL)
     return actor;


### PR DESCRIPTION
This fixes a huge performance problem when running with many threads. The inject queue is empty most of the time, but all schedulers will regularly try to pop from it. This change removes the synchronisation operations if the queue is empty.