### PR TITLE
Method chaining (RFC #25)

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -172,6 +172,10 @@ call
   : '(' positional? named? ')'
   ;
 
+chain
+  : '.>' ID
+  ;
+
 tilde
   : '~' ID
   ;
@@ -330,6 +334,7 @@ antlr_1
 antlr_2
   : dot
   | tilde
+  | chain
   | typeargs
   | call
   ;
@@ -337,6 +342,7 @@ antlr_2
 antlr_3
   : dot
   | tilde
+  | chain
   | typeargs
   | call
   ;

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -60,6 +60,8 @@ static const lextoken_t symbols[] =
   { "<=", TK_LE },
   { ">=", TK_GE },
 
+  { ".>", TK_CHAIN },
+
   { "{", TK_LBRACE },
   { "}", TK_RBRACE },
   { "(", TK_LPAREN },
@@ -278,6 +280,8 @@ static const lextoken_t abstract[] =
   { "newapp", TK_NEWAPP },
   { "beapp", TK_BEAPP },
   { "funapp", TK_FUNAPP },
+  { "bechain", TK_BECHAIN },
+  { "funchain", TK_FUNCHAIN },
 
   { "\\n", TK_NEWLINE },
   {NULL, (token_id)0}

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -487,6 +487,13 @@ DEF(tilde);
   TOKEN("method name", TK_ID);
   DONE();
 
+// CHAIN ID
+DEF(chain);
+  INFIX_BUILD();
+  TOKEN(NULL, TK_CHAIN);
+  TOKEN("method name", TK_ID);
+  DONE();
+
 // typeargs
 DEF(qualify);
   INFIX_BUILD();
@@ -504,16 +511,16 @@ DEF(call);
   TERMINATE("call arguments", TK_RPAREN);
   DONE();
 
-// atom {dot | tilde | qualify | call}
+// atom {dot | tilde | chain | qualify | call}
 DEF(postfix);
   RULE("value", atom);
-  SEQ("postfix expression", dot, tilde, qualify, call);
+  SEQ("postfix expression", dot, tilde, chain, qualify, call);
   DONE();
 
-// atom {dot | tilde | qualify | call}
+// atom {dot | tilde | chain | qualify | call}
 DEF(nextpostfix);
   RULE("value", nextatom);
-  SEQ("postfix expression", dot, tilde, qualify, call);
+  SEQ("postfix expression", dot, tilde, chain, qualify, call);
   DONE();
 
 // (VAR | LET | EMBED | $LET) ID [COLON type]

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -41,6 +41,7 @@ typedef enum token_id
   TK_DBLARROW,
   TK_DOT,
   TK_TILDE,
+  TK_CHAIN,
   TK_COLON,
   TK_SEMI,
   TK_ASSIGN,
@@ -237,6 +238,8 @@ typedef enum token_id
   TK_NEWAPP,
   TK_BEAPP,
   TK_FUNAPP,
+  TK_BECHAIN,
+  TK_FUNCHAIN,
 
   // Pseudo tokens that never actually exist
   TK_NEWLINE,  // Used by parser macros

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -489,6 +489,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     case TK_NEWBEREF:
     case TK_BEREF:
     case TK_FUNREF:
+    case TK_BECHAIN:
+    case TK_FUNCHAIN:
       typeargs = method;
       AST_GET_CHILDREN_NO_DECL(receiver, receiver, method);
       break;
@@ -600,6 +602,8 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
 
       case TK_BEREF:
       case TK_FUNREF:
+      case TK_BECHAIN:
+      case TK_FUNCHAIN:
         args[0] = gen_expr(c, receiver);
         break;
 
@@ -698,6 +702,10 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   // Class constructors return void, expression result is the receiver.
   if(((ast_id(postfix) == TK_NEWREF) || (ast_id(postfix) == TK_NEWBEREF)) &&
      (t->underlying == TK_CLASS))
+    r = args[0];
+
+  // Chained methods forward their receiver.
+  if((ast_id(postfix) == TK_BECHAIN) || (ast_id(postfix) == TK_FUNCHAIN))
     r = args[0];
 
   ponyint_pool_free_size(buf_size, args);

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -844,7 +844,8 @@ static bool unify(ast_t* ast, pass_opt_t* opt, bool report_errors)
 bool literal_member_access(ast_t* ast, pass_opt_t* opt)
 {
   assert(ast != NULL);
-  assert(ast_id(ast) == TK_DOT || ast_id(ast) == TK_TILDE);
+  assert(ast_id(ast) == TK_DOT || ast_id(ast) == TK_TILDE ||
+    ast_id(ast) == TK_CHAIN);
 
   AST_GET_CHILDREN(ast, receiver, name_node);
 

--- a/src/libponyc/expr/postfix.h
+++ b/src/libponyc/expr/postfix.h
@@ -10,6 +10,7 @@ PONY_EXTERN_C_BEGIN
 bool expr_qualify(pass_opt_t* opt, ast_t** astp);
 bool expr_dot(pass_opt_t* opt, ast_t** astp);
 bool expr_tilde(pass_opt_t* opt, ast_t** astp);
+bool expr_chain(pass_opt_t* opt, ast_t** astp);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -93,6 +93,11 @@ bool is_result_needed(ast_t* ast)
       // Result of a behaviour isn't needed.
       return false;
 
+    case TK_BECHAIN:
+    case TK_FUNCHAIN:
+      // Result of a chained method isn't needed.
+      return false;
+
     default: {}
   }
 
@@ -258,6 +263,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_RECOVER:    r = expr_recover(options, ast); break;
     case TK_DOT:        r = expr_dot(options, astp); break;
     case TK_TILDE:      r = expr_tilde(options, astp); break;
+    case TK_CHAIN:      r = expr_chain(options, astp); break;
     case TK_QUALIFY:    r = expr_qualify(options, astp); break;
     case TK_CALL:       r = expr_call(options, astp); break;
     case TK_IFDEF:

--- a/src/libponyc/type/alias.h
+++ b/src/libponyc/type/alias.h
@@ -17,6 +17,8 @@ ast_t* consume_type(ast_t* type, token_id cap);
 
 ast_t* recover_type(ast_t* type, token_id cap);
 
+ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call);
+
 bool sendable(ast_t* type);
 
 bool immutable_or_opaque(ast_t* type);

--- a/test/libponyc/chain.cc
+++ b/test/libponyc/chain.cc
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
+
+class ChainTest : public PassTest
+{};
+
+
+TEST_F(ChainTest, Chain_AliasRefcap)
+{
+  const char* src =
+    "class C\n"
+    "  fun tag x() => None\n"
+
+    "  fun apply() =>\n"
+    "    let r: C ref = C\n"
+    "    let r2: C ref = r.>x()\n"
+    "    let v: C val = C\n"
+    "    let v2: C val = v.>x()\n"
+    "    let b: C box = C\n"
+    "    let b2: C box = b.>x()\n"
+    "    let t: C tag = C\n"
+    "    let t2: C tag = t.>x()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ChainTest, Chain_UniqueRefcap)
+{
+  const char* src =
+    "class C\n"
+    "  fun ref x() => None\n"
+
+    "  fun apply() =>\n"
+    "    let i: C iso = C\n"
+    "    let i2: C iso = i.>x()\n"
+    "    let t: C trn = C\n"
+    "    let t2: C trn = t.>x()";
+
+  TEST_ERRORS_2(src,
+    "right side must be a subtype of left side",
+    "right side must be a subtype of left side");
+}
+
+TEST_F(ChainTest, Chain_UniqueEphRecoverCall)
+{
+  const char* src =
+    "class C\n"
+    "  new iso create() => None\n"
+    "  new trn trn_create() => None\n"
+    "  fun ref x() => None\n"
+
+    "  fun apply() =>\n"
+    "    let i: C iso = C.>x()\n"
+    "    let t: C trn = C.trn_create().>x()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ChainTest, Chain_UniqueEphSubtypeMethodCap)
+{
+  const char* src =
+    "class C\n"
+    "  new iso create() => None\n"
+    "  new trn trn_create() => None\n"
+    "  fun tag x(c: C ref) => None\n"
+    "  fun box y(c: C ref) => None\n"
+
+    "  fun apply() =>\n"
+    "    let r: C ref = C\n"
+    "    let i: C iso = C.>x(r)\n"
+    "    let t: C trn = C.trn_create().>y(r)";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ChainTest, Chain_UniqueEphSameMethodCap)
+{
+  const char* src =
+    "class C\n"
+    "  new iso create() => None\n"
+    "  new trn trn_create() => None\n"
+    "  fun iso x() => None\n"
+    "  fun trn y() => None\n"
+
+    "  fun apply() =>\n"
+    "    let i: C iso = C.>x()\n"
+    "    let t: C trn = C.trn_create().>y()";
+
+  TEST_ERRORS_2(src,
+    "right side must be a subtype of left side",
+    "right side must be a subtype of left side");
+}
+
+TEST_F(ChainTest, Chain_UniqueEphNoRecoverCall)
+{
+  const char* src =
+    "class C\n"
+    "  new iso create() => None\n"
+    "  new trn trn_create() => None\n"
+    "  fun ref x(c: C ref) => None\n"
+
+    "  fun apply() =>\n"
+    "    let r: C ref = C\n"
+    "    let i: C iso = C.>x(r)\n"
+    "    let t: C trn = C.trn_create().>x(r)";
+
+  TEST_ERRORS_2(src,
+    "right side must be a subtype of left side",
+    "right side must be a subtype of left side");
+}


### PR DESCRIPTION
This change provides a way to chain calls on an object without depending on the method's API.

Closes #1409.