### PR TITLE
Whitespace fixes in Pony code style.

### DIFF
--- a/examples/delegates/main.pony
+++ b/examples/delegates/main.pony
@@ -4,37 +4,37 @@ Demonstrate the basic use of delegates in pony
 use "time"
 
 trait Wombat
-  fun box battle_call() : String val =>
+  fun box battle_call(): String val =>
     "Huzzah!"
 
 class SimpleWombat is Wombat
 
 class KungFuWombat is Wombat
-  fun box battle_call() : String val =>
+  fun box battle_call(): String val =>
     "Bonzai!"
 
 trait Drone
-  fun box battle_call() : String val =>
+  fun box battle_call(): String val =>
     "Beep Boop!"
 
-class DroneWombat is ( Drone & Wombat)
-  fun box battle_call() : String val =>
+class DroneWombat is (Drone & Wombat)
+  fun box battle_call(): String val =>
     "Beep boop Huzzah!"
 
 actor Main is Wombat
-  let wombatness : Wombat delegate Wombat
+  let wombatness: Wombat delegate Wombat
 
-  new create(env : Env) =>
+  new create(env: Env) =>
     let x = Time.nanos() % 3
 
-    wombatness = match x
-    | 0 => SimpleWombat
-    | 1 => DroneWombat
-    | 2 => KungFuWombat
-    else
-      SimpleWombat
-    end
+    wombatness =
+      match x
+      | 0 => SimpleWombat
+      | 1 => DroneWombat
+      | 2 => KungFuWombat
+      else
+        SimpleWombat
+      end
 
     env.out.print("Welcome to Wombat Combat!")
     env.out.print("Battle cry: " + this.battle_call())
-

--- a/examples/echo/echo.pony
+++ b/examples/echo/echo.pony
@@ -29,7 +29,7 @@ class Listener is TCPListenNotify
     _out.print("couldn't listen")
     listen.close()
 
-  fun ref connected(listen: TCPListener ref) : TCPConnectionNotify iso^ =>
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
     Server(_out)
 
 class Server is TCPConnectionNotify

--- a/examples/mixed/main.pony
+++ b/examples/mixed/main.pony
@@ -20,7 +20,7 @@ actor Worker
         false
       end
 
-  fun ref factorize(bigint: U64) : Array[U64] =>
+  fun ref factorize(bigint: U64): Array[U64] =>
     var factors = Array[U64](2)
 
     if bigint <= 3 then
@@ -81,7 +81,7 @@ actor Ring
       Worker(_env)
     end
 
-  fun tag spawn_ring(env: Env, size: U32, pass': U32) : Ring =>
+  fun tag spawn_ring(env: Env, size: U32, pass': U32): Ring =>
     var next: Ring = this
 
     for i in Range[U32](0, size) do

--- a/examples/producer-consumer/consumer.pony
+++ b/examples/producer-consumer/consumer.pony
@@ -17,5 +17,3 @@ actor Consumer
   be consuming(product: Product) =>
     _out.print("**Consumer** Consuming product " + product.id.string())
     _quantity_to_consume = _quantity_to_consume -1
-
-

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -48,27 +48,27 @@ class StopWatch
   """
   A simple stopwatch class for performance micro-benchmarking
   """
-  var _s : U64 = 0
+  var _s: U64 = 0
 
-  fun ref start() : StopWatch =>
+  fun ref start(): StopWatch =>
     _s = Time.nanos()
     this
 
-  fun delta() : U64 =>
+  fun delta(): U64 =>
     Time.nanos() - _s
 
 actor LonelyPony
   """
   A simple manifestation of the lonely pony problem
   """
-  var _env : Env
-  let _sw : StopWatch = StopWatch
-  var _alive : Bool = true
-  var _debug : Bool = false
-  var _m : U64
-  var _n : U64
+  var _env: Env
+  let _sw: StopWatch = StopWatch
+  var _alive: Bool = true
+  var _debug: Bool = false
+  var _m: U64
+  var _n: U64
 
-  new create(env : Env, debug : Bool = false, n : U64 = 0) =>
+  new create(env: Env, debug: Bool = false, n: U64 = 0) =>
     _env = env
     _debug = debug
     _m = n
@@ -105,13 +105,13 @@ actor InterruptiblePony
   """
   An interruptible version that avoids the lonely pony problem
   """
-  var _env : Env
-  let _sw : StopWatch = StopWatch
-  var _alive : Bool = true
-  var _debug : Bool = false
-  var _n : U64
+  var _env: Env
+  let _sw: StopWatch = StopWatch
+  var _alive: Bool = true
+  var _debug: Bool = false
+  var _n: U64
 
-  new create(env : Env, debug : Bool, n : U64 = 0) =>
+  new create(env: Env, debug: Bool, n: U64 = 0) =>
     _env = env
     _debug = debug
     _n = n
@@ -152,11 +152,11 @@ actor InterruptiblePony
     this
 
 actor PunkDemo
-  var _env : Env
-  var _alive : Bool = false
-  var _current : U8 = 0
+  var _env: Env
+  var _alive: Bool = false
+  var _current: U8 = 0
 
-  new create(env : Env) =>
+  new create(env: Env) =>
     _env = env
 
   be inc() =>
@@ -184,15 +184,15 @@ actor PunkDemo
     end
 
 actor Main
-  var _env : Env
-  new create(env : Env) =>
+  var _env: Env
+  new create(env: Env) =>
     _env = env
 
-    var punk : Bool = false
-    var lonely : Bool = false
-    var perf : U64 = 0
-    var debug : Bool = false
-    var err : Bool = false
+    var punk: Bool = false
+    var lonely: Bool = false
+    var perf: U64 = 0
+    var debug: Bool = false
+    var err: Bool = false
 
     let options = Options(env.args) +
       ("punk", "p", None) +
@@ -205,7 +205,7 @@ actor Main
       match opt
       | ("punk", None) => punk = true
       | ("lonely", None) => lonely = true
-      | ("bench", let arg : I64) => perf = arg.u64()
+      | ("bench", let arg: I64) => perf = arg.u64()
       | ("debug", None) => debug = true
       else
         err = true

--- a/packages/net/tcp_connection_notify.pony
+++ b/packages/net/tcp_connection_notify.pony
@@ -98,4 +98,3 @@ interface TCPConnectionNotify
     `write` and `writev` again.
     """
     None
-

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -161,7 +161,7 @@ Test can have label. Labels are used to filter which tests are run, by setting
 command line argument `--label=[some custom label]`. It can be used to separate
 unit tests from integration tests.
 
-By default label is empty. You can set it up by overriding `label() : String`
+By default label is empty. You can set it up by overriding `label(): String`
 method in unit test.
 
 ```pony
@@ -170,7 +170,7 @@ use "ponytest"
 class iso _I8AddTest is UnitTest
   fun name(): String => "_I8AddTest"
   fun label(): String => "simple"
-  fun apply(h : TestHelper) =>
+  fun apply(h: TestHelper) =>
     h.assert_eq[I8](1, 1)
 
 ```
@@ -216,7 +216,7 @@ actor PonyTest
   var _finished: USize = 0
   var _any_found: Bool = false
   var _all_started: Bool = false
-  var _label : String = ""
+  var _label: String = ""
 
   new create(env: Env, list: TestList tag) =>
     """

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -326,4 +326,3 @@ class _ProcessClient is ProcessNotify
     _h.assert_eq[String box](_err, _d_stderr)
     _h.assert_eq[I32](_exit_code, child_exit_code)
     _h.complete(true)
-


### PR DESCRIPTION
Many of the examples were using whitespace in a way that was
inconsistent with the established normative code style for the
official codebase. This is particularly problematic, since
the examples are often the first place a user will go to learn
Pony and normative code style.