### PR TITLE
Stop leaking memory during serialization (issue #1413)

### DIFF
--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -164,7 +164,7 @@ void pony_serialise(pony_ctx_t* ctx, void* p, void* out)
   ponyint_array_t* r = (ponyint_array_t*)out;
   r->size = ctx->serialise_size;
   r->alloc = r->size;
-  r->ptr = (char*)ponyint_pool_alloc_size(r->size);
+  r->ptr = (char*)pony_alloc(ctx, r->size);
 
   size_t i = HASHMAP_BEGIN;
   serialise_t* s;


### PR DESCRIPTION
Prior to this commit, serializing a pony object would leak memory.
By using "pool alloc" rather than "pony alloc", we were directly
allocating memory that would need to be manually freed. What we
wanted to do was use "pony alloc" so that the GC would track
usage of the memory and free it when needed.