### PR TITLE
Make Helgrind aware of atomic memory operations

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -11,6 +11,10 @@
 #include <assert.h>
 #include <dtrace.h>
 
+#ifdef USE_VALGRIND
+#include <valgrind/helgrind.h>
+#endif
+
 enum
 {
   FLAG_BLOCKED = 1 << 0,
@@ -209,6 +213,10 @@ void ponyint_actor_destroy(pony_actor_t* actor)
 
   while(((uintptr_t)head & (uintptr_t)1) != (uintptr_t)1)
     head = atomic_load_explicit(&actor->q.head, memory_order_acquire);
+
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&actor->q.head);
+#endif
 
   ponyint_messageq_destroy(&actor->q);
   ponyint_gc_destroy(&actor->gc);

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -14,6 +14,10 @@
 #include <signal.h>
 #include <stdbool.h>
 
+#ifdef USE_VALGRIND
+#include <valgrind/helgrind.h>
+#endif
+
 #define MAX_SIGNAL 128
 
 struct asio_backend_t
@@ -49,6 +53,10 @@ static void signal_handler(int sig)
   asio_backend_t* b = ponyint_asio_get_backend();
   asio_event_t* ev = atomic_load_explicit(&b->sighandlers[sig],
     memory_order_acquire);
+
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&b->sighandlers[sig]);
+#endif
 
   if(ev == NULL)
     return;
@@ -220,6 +228,9 @@ void pony_asio_event_subscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = NULL;
 
+#ifdef USE_VALGRIND
+    ANNOTATE_HAPPENS_BEFORE(&b->sighandlers[sig]);
+#endif
     if((sig < MAX_SIGNAL) &&
       atomic_compare_exchange_strong_explicit(&b->sighandlers[sig], &prev, ev,
       memory_order_release, memory_order_relaxed))
@@ -280,6 +291,9 @@ void pony_asio_event_unsubscribe(asio_event_t* ev)
     int sig = (int)ev->nsec;
     asio_event_t* prev = ev;
 
+#ifdef USE_VALGRIND
+    ANNOTATE_HAPPENS_BEFORE(&b->sighandlers[sig]);
+#endif
     if((sig < MAX_SIGNAL) &&
       atomic_compare_exchange_strong_explicit(&b->sighandlers[sig], &prev, NULL,
       memory_order_release, memory_order_relaxed))


### PR DESCRIPTION
By default, Helgrind doesn't know about the happens-before relationships introduced by atomic operations and can report subsequent normal operations as false positives. With this change, Helgrind should only report the atomic operations themselves, which also are false positives but Helgrind has no way to know that.