### PR TITLE
Add DTrace/SystemTap scheduling probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- Extra DTrace/SystemTap probes concerning scheduling.
+
 ### Changed
 
 ## [0.9.0] - 2016-11-11

--- a/examples/dtrace/scheduling.d
+++ b/examples/dtrace/scheduling.d
@@ -1,0 +1,40 @@
+#!/usr/bin/env dtrace -x aggsortkey -x aggsortkeypos=1 -s
+
+#pragma D option quiet
+
+pony$target:::cpu-nanosleep
+{
+  @timer["Nanosleep (ns)"] = sum(arg0)
+}
+
+pony$target:::actor-scheduled
+{
+  @counter["Actor Scheduled", arg1] = count();
+}
+
+pony$target:::actor-descheduled
+{
+  @counter["Actor De-Scheduled", arg1] = count();
+}
+
+pony$target:::actor-msg-run
+{
+  @counter["Actor Messages", arg1] = count();
+}
+
+pony$target:::work-steal-successful
+{
+  @work["Successful Work Stealing", arg0] = count();
+}
+
+pony$target:::work-steal-failure
+{
+  @work["Failed Work Stealing", arg0] = count();
+}
+
+END
+{
+  printa(@counter);
+  printa(@work);
+  printa(@timer);
+}

--- a/examples/systemtap/scheduling.stp
+++ b/examples/systemtap/scheduling.stp
@@ -1,0 +1,55 @@
+global actor_scheduled, actor_descheduled, messages_ran, cpu_sleep, steal_successful, steal_failure
+
+probe process.mark("cpu-nanosleep")
+{
+	cpu_sleep <<< $arg1
+}
+
+probe process.mark("actor-scheduled")
+{
+	actor_scheduled[$arg2]++
+}
+
+probe process.mark("actor-descheduled")
+{
+	actor_descheduled[$arg2]++
+}
+
+probe process.mark("actor-msg-run")
+{
+	messages_ran[$arg2]++
+}
+
+probe process.mark("work-steal-successful")
+{
+	scheduler = $arg1
+	steal_successful <<< scheduler
+}
+
+probe process.mark("work-steal-failure")
+{
+	scheduler = $arg1
+	steal_failure <<< scheduler
+}
+
+probe end
+{
+	println();
+	foreach (actor+ in messages_ran)
+		printf("Actor %d ran %d messages\n", actor, messages_ran[actor]);
+
+	println();
+	foreach (actor+ in actor_scheduled)
+		printf("Actor %d scheduled %d times\n", actor, actor_scheduled[actor]);
+
+	println();
+	foreach (actor+ in actor_descheduled)
+		printf("Actor %d descheduled %d times\n", actor, actor_descheduled[actor]);
+
+	println();
+	printf("Successful work theft: %d\n", @count(steal_successful));
+	printf("Failed work stealing attempts: %d\n", @count(steal_failure));
+
+	println();
+	printf("Total time spent in nanosleep: %d seconds\n", @sum(cpu_sleep)/1000000000);
+}

--- a/src/common/dtrace.h
+++ b/src/common/dtrace.h
@@ -6,7 +6,7 @@
 #include "dtrace_probes.h"
 
 #define DTRACE_ENABLED(name)                         \
-  PONY_##name##_enabled()
+  PONY_##name##_ENABLED()
 #define DTRACE0(name)                                \
   PONY_##name()
 #define DTRACE1(name, a0)                            \

--- a/src/common/dtrace_probes.d
+++ b/src/common/dtrace_probes.d
@@ -11,6 +11,33 @@ provider pony {
   probe actor__msg__send(uintptr_t scheduler, uint32_t id);
 
   /**
+   * Fired when a message is being run by an actor
+   * @param actor the actor running the message
+   * @param id the message id
+   */
+  probe actor__msg__run(uintptr_t scheduler, uintptr_t actor, uint32_t id);
+
+  /**
+   * Fired when actor is scheduled
+   * @param scheduler is the scheduler that scheduled the actor
+   * @param actor is the scheduled actor
+   */
+  probe actor__scheduled(uintptr_t scheduler, uintptr_t actor);
+
+  /**
+   * Fired when actor is descheduled
+   * @param scheduler is the scheduler that descheduled the actor
+   * @param actor is the descheduled actor
+   */
+  probe actor__descheduled(uintptr_t scheduler, uintptr_t actor);
+
+  /**
+   * Fired when cpu goes into nanosleep
+   * @param ns is nano seconds spent in sleep
+   */
+  probe cpu__nanosleep(uint64_t ns);
+
+  /**
    * Fired when the garbage collection function is ending
    */
   probe gc__end(uintptr_t scheduler);
@@ -41,8 +68,45 @@ provider pony {
   probe gc__start(uintptr_t scheduler);
 
   /**
+   * Fired when the garbage collection threshold is changed with a certain factor
+   * @param factor the factor with which the GC threshold is changed
+   */
+  probe gc__threshold(double factor);
+
+  /**
    * Fired when memory is allocated on the heap
    * @param size the size of the allocated memory
    */
   probe heap__alloc(uintptr_t scheduler, unsigned long size);
+
+  /**
+   * Fired when runtime initiates
+   */
+  probe rt__init();
+
+  /**
+   * Fired when runtime is initiated and the program starts
+   */
+  probe rt__start();
+
+  /**
+   * Fired when runtime shutdown is started
+   */
+  probe rt__end();
+
+  /**
+   * Fired when a scheduler succesfully steals a job
+   * @param scheduler is the scheduler that stole the job
+   * @param victim is the victim that the scheduler stole from
+   * @param actor is actor that was stolen from the victim
+   */
+  probe work__steal__successful(uintptr_t scheduler, uintptr_t victim, uintptr_t actor);
+
+  /**
+   * Fired when a scheduler fails to steal a job
+   * @param scheduler is the scheduler that attempted theft
+   * @param victim is the victim that the scheduler attempted to steal from
+   */
+  probe work__steal__failure(uintptr_t scheduler, uintptr_t victim);
+
 };

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -99,6 +99,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
         ponyint_cycle_unblock(ctx, actor);
       }
 
+      DTRACE3(ACTOR_MSG_RUN, (uintptr_t)ctx->scheduler, (uintptr_t)actor, msg->id);
       actor->type->dispatch(ctx, actor, msg);
       return true;
     }
@@ -312,7 +313,7 @@ pony_actor_t* pony_create(pony_ctx_t* ctx, pony_type_t* type)
 
 void ponyint_destroy(pony_actor_t* actor)
 {
-  // This destroy an actor immediately. If any other actor has a reference to
+  // This destroys an actor immediately. If any other actor has a reference to
   // this actor, the program will likely crash. The finaliser is not called.
   ponyint_actor_setpendingdestroy(actor);
   ponyint_actor_destroy(actor);

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 
 #include <platform.h>
+#include <dtrace.h>
 
 typedef struct chunk_t
 {
@@ -180,6 +181,7 @@ void ponyint_heap_setnextgcfactor(double factor)
   if(factor < 1.0)
     factor = 1.0;
 
+  DTRACE1(GC_THRESHOLD, factor);
   heap_nextgc_factor = factor;
 }
 

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 #endif
 #include <platform.h>
+#include <dtrace.h>
 
 #if defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_FREEBSD)
   #include <sched.h>
@@ -301,6 +302,7 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
     }
   }
 
+  DTRACE1(CPU_NANOSLEEP, ts.tv_nsec);
   nanosleep(&ts, NULL);
 #else
   Sleep(0);

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -7,6 +7,7 @@
 #include "../gc/cycle.h"
 #include "../lang/socket.h"
 #include "../options/options.h"
+#include <dtrace.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -89,6 +90,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
 
 int pony_init(int argc, char** argv)
 {
+  DTRACE0(RT_INIT);
   options_t opt;
   memset(&opt, 0, sizeof(options_t));
 


### PR DESCRIPTION
This pull request adds new probes to the DTrace/SystemTap implementation which are focused on the scheduling of actors. Using these probes you should be able to get a direct view of how different actors are scheduled.

The use of these probes has been shown in the scheduling scripts in the respective `dtrace` and `systemtap` folders in the `examples` directory.

Contribution by @mkdubik, @DarkLog1x and me.