### PR TITLE
Update from_array to prevent a copy (issue #1097)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -60,23 +60,11 @@ actor Main
 
   new val from_array(data: Array[U8] val) =>
     """
-    Create a string from an array, reusing the underlying data pointer if the
-    array is null terminated, or copying the data if it is not.
+    Create a string from an array, reusing the underlying data pointer.
     """
     _size = data.size()
-
-    if
-      (_size > 0) and
-      try (data(_size - 1) == 0) else false end
-    then
-      _alloc = data.space()
-      _ptr = data.cpointer()._unsafe()
-    else
-      _alloc = _size + 1
-      _ptr = Pointer[U8]._alloc(_alloc)
-      data._copy_to(_ptr, _size)
-      _set(_size, 0)
-    end
+    _alloc = data.space()
+    _ptr = data.cpointer()._unsafe()
 
   new iso from_iso_array(data: Array[U8] iso) =>
     """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -40,6 +40,7 @@ actor Main is TestList
     test(_TestStringReadInt)
     test(_TestStringUTF32)
     test(_TestStringRFind)
+    test(_TestStringFromArray)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -771,6 +772,19 @@ class iso _TestStringRFind is UnitTest
     h.assert_eq[ISize](s.rfind("-"), 12)
     h.assert_eq[ISize](s.rfind("-", -2), 8)
     h.assert_eq[ISize](s.rfind("-bar", 7), 4)
+
+
+class iso _TestStringFromArray is UnitTest
+  fun name(): String => "builtin/String.from_array"
+
+  fun apply(h: TestHelper) =>
+    let s_null = String.from_array(recover ['f', 'o', 'o', 0] end)
+    h.assert_eq[String](s_null, "foo\x00")
+    h.assert_eq[USize](s_null.size(), 4)
+
+    let s_no_null = String.from_array(recover ['f', 'o', 'o'] end)
+    h.assert_eq[String](s_no_null, "foo")
+    h.assert_eq[USize](s_no_null.size(), 3)
 
 
 class iso _TestArrayAppend is UnitTest


### PR DESCRIPTION
The `String.from_array` method previously was documented to only reuse
the underlying `Array[U8]` if it ended with a `0` byte, otherwise the
Array would be copied with the `0` added to the end. However, the
behavior was such that the no-copy version would make the trailing `0`
the last character of the String instead of a terminator, and changing
that behavior caused other issues.

Since pony Strings may now be non-null-terminated, the new behavior of
`.from_array` is to always use the entire underlying Array, without
regard to the presence of a trailing `0` byte.

The documentation is also updated and tests added.