### PR TITLE
Fix is_null_terminated reading arbitrary memory (issue #1425)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -373,7 +373,7 @@ actor Main
     which may be present earlier in the content of the string.
     If you need a null-terminated copy of this string, use the clone method.
     """
-    (_alloc > 0) and (_ptr._apply(_size) == 0)
+    (_alloc > 0) and (_alloc != _size) and (_ptr._apply(_size) == 0)
 
   fun utf32(offset: ISize): (U32, U8) ? =>
     """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -436,6 +436,13 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
     h.assert_false("0123456".trim(2, 4).is_null_terminated())
 
+    h.assert_false(String.from_iso_array(recover
+      ['a', 'b', 'c']
+    end).is_null_terminated())
+    h.assert_false(String.from_iso_array(recover
+      ['a', 'b', 'c', 0] // zero byte is not a terminator
+    end).is_null_terminated())
+
 
 class iso _TestSpecialValuesF32 is UnitTest
   """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -437,11 +437,9 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
     h.assert_false("0123456".trim(2, 4).is_null_terminated())
 
-/*
-    h.assert_false(String.from_iso_array(recover
+    h.assert_true(String.from_iso_array(recover
       ['a', 'b', 'c']
     end).is_null_terminated())
-*/
     h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] // power of two sized array
     end).is_null_terminated())

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -436,11 +436,8 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
     h.assert_false("0123456".trim(2, 4).is_null_terminated())
 
-    h.assert_false(String.from_iso_array(recover
+    h.assert_true(String.from_iso_array(recover
       ['a', 'b', 'c']
-    end).is_null_terminated())
-    h.assert_false(String.from_iso_array(recover
-      ['a', 'b', 'c', 0] // zero byte is not a terminator
     end).is_null_terminated())
     h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] // power of two sized array

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -442,6 +442,9 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c', 0] // zero byte is not a terminator
     end).is_null_terminated())
+    h.assert_false(String.from_iso_array(recover
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] // power of two sized array
+    end).is_null_terminated())
 
 
 class iso _TestSpecialValuesF32 is UnitTest

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -436,7 +436,7 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
     h.assert_false("0123456".trim(2, 4).is_null_terminated())
 
-    h.assert_true(String.from_iso_array(recover
+    h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c']
     end).is_null_terminated())
     h.assert_false(String.from_iso_array(recover

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -436,9 +436,11 @@ class iso _TestStringIsNullTerminated is UnitTest
     h.assert_true("0123456".trim(2, 4).clone().is_null_terminated())
     h.assert_false("0123456".trim(2, 4).is_null_terminated())
 
+/*
     h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c']
     end).is_null_terminated())
+*/
     h.assert_false(String.from_iso_array(recover
       ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] // power of two sized array
     end).is_null_terminated())


### PR DESCRIPTION
When `_alloc` is equal to `_size`, the `is_null_terminated` method will
point to arbitrary memory when checking for the `0` byte. This PR makes
that method first check that `_alloc != _size` before reading the
`_size` byte of the `Pointer[U8]`.

Fixes #1425