### PR TITLE
Make space() check if string is null terminated (issue #1426)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -259,7 +259,7 @@ actor Main
     """
     Returns the space available for data, not including the null terminator.
     """
-    _alloc - 1
+    if _is_null_terminated() then _alloc - 1 else _alloc end
 
   fun ref reserve(len: USize): String ref^ =>
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -259,7 +259,7 @@ actor Main
     """
     Returns the space available for data, not including the null terminator.
     """
-    if _is_null_terminated() then _alloc - 1 else _alloc end
+    if is_null_terminated() then _alloc - 1 else _alloc end
 
   fun ref reserve(len: USize): String ref^ =>
     """


### PR DESCRIPTION
The `space()` method assumes that the string is null termianted, and so
it always returns `_alloc - 1`. When not null terminated, the space
should return the full `_alloc`.

This PR assumes PR #1429 is correct and has been merged.

Fixes #1426