### PR TITLE
hashmap: Add new putindex function and make everything use it

### DIFF
--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -63,7 +63,8 @@ const char* stringtab_len(const char* string, size_t len)
     return NULL;
 
   stringtab_entry_t key = {string, len, 0};
-  stringtab_entry_t* n = strtable_get(&table, &key);
+  size_t index = HASHMAP_UNKNOWN;
+  stringtab_entry_t* n = strtable_get(&table, &key, &index);
 
   if(n != NULL)
     return n->str;
@@ -77,7 +78,9 @@ const char* stringtab_len(const char* string, size_t len)
   n->len = len;
   n->buf_size = len + 1;
 
-  strtable_put(&table, n);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  strtable_putindex(&table, n, index);
   return n->str;
 }
 
@@ -88,7 +91,8 @@ const char* stringtab_consume(const char* string, size_t buf_size)
 
   size_t len = strlen(string);
   stringtab_entry_t key = {string, len, 0};
-  stringtab_entry_t* n = strtable_get(&table, &key);
+  size_t index = HASHMAP_UNKNOWN;
+  stringtab_entry_t* n = strtable_get(&table, &key, &index);
 
   if(n != NULL)
   {
@@ -101,7 +105,9 @@ const char* stringtab_consume(const char* string, size_t buf_size)
   n->len = len;
   n->buf_size = buf_size;
 
-  strtable_put(&table, n);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  strtable_putindex(&table, n, index);
   return n->str;
 }
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -1001,10 +1001,11 @@ void codegen_local_lifetime_start(compile_t* c, const char* name)
 
   compile_local_t k;
   k.name = name;
+  size_t index = HASHMAP_UNKNOWN;
 
   while(frame != NULL)
   {
-    compile_local_t* p = compile_locals_get(&frame->locals, &k);
+    compile_local_t* p = compile_locals_get(&frame->locals, &k, &index);
 
     if(p != NULL && !p->alive)
     {
@@ -1026,10 +1027,11 @@ void codegen_local_lifetime_end(compile_t* c, const char* name)
 
   compile_local_t k;
   k.name = name;
+  size_t index = HASHMAP_UNKNOWN;
 
   while(frame != NULL)
   {
-    compile_local_t* p = compile_locals_get(&frame->locals, &k);
+    compile_local_t* p = compile_locals_get(&frame->locals, &k, &index);
 
     if(p != NULL && p->alive)
     {
@@ -1126,10 +1128,11 @@ LLVMValueRef codegen_getlocal(compile_t* c, const char* name)
 
   compile_local_t k;
   k.name = name;
+  size_t index = HASHMAP_UNKNOWN;
 
   while(frame != NULL)
   {
-    compile_local_t* p = compile_locals_get(&frame->locals, &k);
+    compile_local_t* p = compile_locals_get(&frame->locals, &k, &index);
 
     if(p != NULL)
       return p->alloca;

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -50,13 +50,16 @@ LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type)
   const char* name = genname_type_and_cap(type);
   tbaa_metadata_t k;
   k.name = name;
-  tbaa_metadata_t* md = tbaa_metadatas_get(c->tbaa_mds, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  tbaa_metadata_t* md = tbaa_metadatas_get(c->tbaa_mds, &k, &index);
   if(md != NULL)
     return md->metadata;
 
   md = POOL_ALLOC(tbaa_metadata_t);
   md->name = name;
-  tbaa_metadatas_put(c->tbaa_mds, md);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  tbaa_metadatas_putindex(c->tbaa_mds, md, index);
 
   LLVMValueRef params[3];
   params[0] = LLVMMDStringInContext(c->context, name, (unsigned)strlen(name));
@@ -86,13 +89,16 @@ LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name)
 {
   tbaa_metadata_t k;
   k.name = box_name;
-  tbaa_metadata_t* md = tbaa_metadatas_get(c->tbaa_mds, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  tbaa_metadata_t* md = tbaa_metadatas_get(c->tbaa_mds, &k, &index);
   if(md != NULL)
     return md->metadata;
 
   md = POOL_ALLOC(tbaa_metadata_t);
   md->name = box_name;
-  tbaa_metadatas_put(c->tbaa_mds, md);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  tbaa_metadatas_putindex(c->tbaa_mds, md, index);
 
   LLVMValueRef params[2];
   params[0] = LLVMMDStringInContext(c->context, box_name,

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -234,13 +234,16 @@ void buildflagset_add(buildflagset_t* set, const char* flag)
 
   // Just a normal flag.
   flag_t f1 = {flag, false};
-  flag_t* f2 = flagtab_get(set->flags, &f1);
+  size_t index = HASHMAP_UNKNOWN;
+  flag_t* f2 = flagtab_get(set->flags, &f1, &index);
 
   if(f2 != NULL)  // Flag already in our table.
     return;
 
   // Add flag to our table.
-  flagtab_put(set->flags, flag_dup(&f1));
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  flagtab_putindex(set->flags, flag_dup(&f1), index);
 }
 
 
@@ -403,7 +406,8 @@ bool buildflagset_get(buildflagset_t* set, const char* flag)
 
   // Just a normal flag.
   flag_t f1 = {flag, false};
-  flag_t* f2 = flagtab_get(set->flags, &f1);
+  size_t h_index = HASHMAP_UNKNOWN;
+  flag_t* f2 = flagtab_get(set->flags, &f1, &h_index);
 
   // Flag MUST have been added previously.
   assert(f2 != NULL);
@@ -515,13 +519,16 @@ bool define_build_flag(const char* name)
   }
 
   flag_t f1 = {stringtab(name), false};
-  flag_t* f2 = flagtab_get(_user_flags, &f1);
+  size_t index = HASHMAP_UNKNOWN;
+  flag_t* f2 = flagtab_get(_user_flags, &f1, &index);
 
   if(f2 != NULL)  // Flag already in our table.
     return false;
 
   // Add flag to our table.
-  flagtab_put(_user_flags, flag_dup(&f1));
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  flagtab_putindex(_user_flags, flag_dup(&f1), index);
   return true;
 }
 
@@ -535,7 +542,8 @@ bool is_build_flag_defined(const char* name)
     return false;
 
   flag_t f1 = { stringtab(name), false };
-  flag_t* f2 = flagtab_get(_user_flags, &f1);
+  size_t index = HASHMAP_UNKNOWN;
+  flag_t* f2 = flagtab_get(_user_flags, &f1, &index);
 
   return f2 != NULL;
 }

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -222,7 +222,8 @@ static colour_record_t* add_colour(painter_t* painter)
 static name_record_t* find_name(painter_t* painter, const char* name)
 {
   name_record_t n = { name, 0, 0, NULL };
-  return name_records_get(&painter->names, &n);
+  size_t index = HASHMAP_UNKNOWN;
+  return name_records_get(&painter->names, &n, &index);
 }
 
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -127,7 +127,8 @@ static reach_method_t* reach_rmethod(reach_method_name_t* n, const char* name)
 {
   reach_method_t k;
   k.name = name;
-  return reach_methods_get(&n->r_methods, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  return reach_methods_get(&n->r_methods, &k, &index);
 }
 
 static reach_method_name_t* add_method_name(reach_type_t* t, const char* name)
@@ -214,7 +215,8 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
   add_rmethod(r, t, n2, m->cap, m->typeargs, opt);
 
   // Add this mangling to the type if it isn't already there.
-  reach_method_t* mangled = reach_mangled_get(&n2->r_mangled, m);
+  size_t index = HASHMAP_UNKNOWN;
+  reach_method_t* mangled = reach_mangled_get(&n2->r_mangled, m, &index);
 
   if(mangled != NULL)
     return;
@@ -238,7 +240,9 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
   mangled->result = m->result;
 
   // Add to the mangled table only.
-  reach_mangled_put(&n2->r_mangled, mangled);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  reach_mangled_putindex(&n2->r_mangled, mangled, index);
 }
 
 static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
@@ -1030,14 +1034,16 @@ reach_type_t* reach_type(reach_t* r, ast_t* type)
 {
   reach_type_t k;
   k.name = genname_type(type);
-  return reach_types_get(&r->types, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  return reach_types_get(&r->types, &k, &index);
 }
 
 reach_type_t* reach_type_name(reach_t* r, const char* name)
 {
   reach_type_t k;
   k.name = stringtab(name);
-  return reach_types_get(&r->types, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  return reach_types_get(&r->types, &k, &index);
 }
 
 reach_method_t* reach_method(reach_type_t* t, token_id cap,
@@ -1077,7 +1083,8 @@ reach_method_name_t* reach_method_name(reach_type_t* t, const char* name)
 {
   reach_method_name_t k;
   k.name = name;
-  return reach_method_names_get(&t->methods, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  return reach_method_names_get(&t->methods, &k, &index);
 }
 
 uint32_t reach_vtable_index(reach_type_t* t, const char* name)

--- a/src/libponyrt/ds/hash.h
+++ b/src/libponyrt/ds/hash.h
@@ -11,6 +11,7 @@
 PONY_EXTERN_C_BEGIN
 
 #define HASHMAP_BEGIN ((size_t)-1)
+#define HASHMAP_UNKNOWN ((size_t)-1)
 
 /** Definition of a quadratic probing hash map.
  *
@@ -39,7 +40,7 @@ void ponyint_hashmap_destroy(hashmap_t* map, free_size_fn fr,
  *
  *  Returns a pointer to the element, or NULL.
  */
-void* ponyint_hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp);
+void* ponyint_hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp, size_t* index);
 
 /** Put a new element in a hash map.
  *
@@ -48,6 +49,15 @@ void* ponyint_hashmap_get(hashmap_t* map, void* key, hash_fn hash, cmp_fn cmp);
  */
 void* ponyint_hashmap_put(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
   alloc_fn alloc, free_size_fn fr);
+
+
+/** Put a new element in a hash map at a specific index.
+ *
+ *  If an element is already in the hash map at that position, the old
+ *  element is overwritten and returned to the caller.
+ */
+void* ponyint_hashmap_putindex(hashmap_t* map, void* entry, hash_fn hash, cmp_fn cmp,
+  alloc_fn alloc, free_size_fn fr, size_t index);
 
 /** Removes a given entry from a hash map.
  *
@@ -76,8 +86,9 @@ void* ponyint_hashmap_next(hashmap_t* map, size_t* i);
   typedef struct name_t { hashmap_t contents; } name_t; \
   void name##_init(name_t* map, size_t size); \
   void name##_destroy(name_t* map); \
-  type* name##_get(name_t* map, type* key); \
+  type* name##_get(name_t* map, type* key, size_t* index); \
   type* name##_put(name_t* map, type* entry); \
+  type* name##_putindex(name_t* map, type* entry, size_t index); \
   type* name##_remove(name_t* map, type* entry); \
   type* name##_removeindex(name_t* map, size_t index); \
   size_t name##_size(name_t* map); \
@@ -101,12 +112,12 @@ void* ponyint_hashmap_next(hashmap_t* map, size_t* i);
     name##_free_fn freef = free_elem; \
     ponyint_hashmap_destroy((hashmap_t*)map, fr, (free_fn)freef); \
   } \
-  type* name##_get(name_t* map, type* key) \
+  type* name##_get(name_t* map, type* key, size_t* index) \
   { \
     name##_hash_fn hashf = hash; \
     name##_cmp_fn cmpf = cmp; \
     return (type*)ponyint_hashmap_get((hashmap_t*)map, (void*)key, \
-      (hash_fn)hashf, (cmp_fn)cmpf); \
+      (hash_fn)hashf, (cmp_fn)cmpf, index); \
   } \
   type* name##_put(name_t* map, type* entry) \
   { \
@@ -114,6 +125,13 @@ void* ponyint_hashmap_next(hashmap_t* map, size_t* i);
     name##_cmp_fn cmpf = cmp; \
     return (type*)ponyint_hashmap_put((hashmap_t*)map, (void*)entry, \
       (hash_fn)hashf, (cmp_fn)cmpf, alloc, fr); \
+  } \
+  type* name##_putindex(name_t* map, type* entry, size_t index) \
+  { \
+    name##_hash_fn hashf = hash; \
+    name##_cmp_fn cmpf = cmp; \
+    return (type*)ponyint_hashmap_putindex((hashmap_t*)map, (void*)entry, \
+      (hash_fn)hashf, (cmp_fn)cmpf, alloc, fr, index); \
   } \
   type* name##_remove(name_t* map, type* entry) \
   { \

--- a/src/libponyrt/gc/actormap.c
+++ b/src/libponyrt/gc/actormap.c
@@ -31,7 +31,8 @@ static actorref_t* actorref_alloc(pony_actor_t* actor, uint32_t mark)
 
 object_t* ponyint_actorref_getobject(actorref_t* aref, void* address)
 {
-  return ponyint_objectmap_getobject(&aref->map, address);
+  size_t index = HASHMAP_UNKNOWN;
+  return ponyint_objectmap_getobject(&aref->map, address, &index);
 }
 
 object_t* ponyint_actorref_getorput(actorref_t* aref, void* address,
@@ -97,24 +98,25 @@ static void send_release(pony_ctx_t* ctx, actorref_t* aref)
   pony_sendp(ctx, aref->actor, ACTORMSG_RELEASE, aref);
 }
 
-actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor)
+actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor, size_t* index)
 {
   actorref_t key;
   key.actor = actor;
 
-  return ponyint_actormap_get(map, &key);
+  return ponyint_actormap_get(map, &key, index);
 }
 
 actorref_t* ponyint_actormap_getorput(actormap_t* map, pony_actor_t* actor,
   uint32_t mark)
 {
-  actorref_t* aref = ponyint_actormap_getactor(map, actor);
+  size_t index = HASHMAP_UNKNOWN;
+  actorref_t* aref = ponyint_actormap_getactor(map, actor, &index);
 
   if(aref != NULL)
     return aref;
 
   aref = actorref_alloc(actor, mark);
-  ponyint_actormap_put(map, aref);
+  ponyint_actormap_putindex(map, aref, index);
   return aref;
 }
 

--- a/src/libponyrt/gc/actormap.h
+++ b/src/libponyrt/gc/actormap.h
@@ -26,7 +26,7 @@ void ponyint_actorref_free(actorref_t* aref);
 
 DECLARE_HASHMAP(ponyint_actormap, actormap_t, actorref_t);
 
-actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor);
+actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor, size_t* index);
 
 actorref_t* ponyint_actormap_getorput(actormap_t* map, pony_actor_t* actor,
   uint32_t mark);

--- a/src/libponyrt/gc/delta.c
+++ b/src/libponyrt/gc/delta.c
@@ -38,6 +38,8 @@ DEFINE_HASHMAP(ponyint_deltamap, deltamap_t, delta_t, delta_hash, delta_cmp,
 deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
   size_t rc)
 {
+  size_t index = HASHMAP_UNKNOWN;
+
   if(map == NULL)
   {
     // allocate a new map with space for at least one element
@@ -46,7 +48,7 @@ deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
   } else {
     delta_t key;
     key.actor = actor;
-    delta_t* delta = ponyint_deltamap_get(map, &key);
+    delta_t* delta = ponyint_deltamap_get(map, &key, &index);
 
     if(delta != NULL)
     {
@@ -59,7 +61,16 @@ deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
   delta->actor = actor;
   delta->rc = rc;
 
-  ponyint_deltamap_put(map, delta);
+  if(index == HASHMAP_UNKNOWN)
+  {
+    // new map
+    ponyint_deltamap_put(map, delta);
+  } else {
+    // didn't find it in the map but index is where we can put the
+    // new one without another search
+    ponyint_deltamap_putindex(map, delta, index);
+  }
+
   return map;
 }
 

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -154,8 +154,9 @@ static void recv_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
   // get the object
+  size_t index = HASHMAP_UNKNOWN;
   gc_t* gc = ponyint_actor_gc(ctx->current);
-  object_t* obj = ponyint_objectmap_getobject(&gc->local, p);
+  object_t* obj = ponyint_objectmap_getobject(&gc->local, p, &index);
   assert(obj != NULL);
 
   if(obj->mark == gc->mark)
@@ -221,8 +222,9 @@ static void acquire_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 static void release_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
+  size_t index = HASHMAP_UNKNOWN;
   gc_t* gc = ponyint_actor_gc(ctx->current);
-  object_t* obj = ponyint_objectmap_getobject(&gc->local, p);
+  object_t* obj = ponyint_objectmap_getobject(&gc->local, p, &index);
   assert(obj != NULL);
 
   if(obj->mark == gc->mark)
@@ -653,11 +655,12 @@ bool ponyint_gc_release(gc_t* gc, actorref_t* aref)
   objectmap_t* map = &aref->map;
   size_t i = HASHMAP_BEGIN;
   object_t* obj;
+  size_t index = HASHMAP_UNKNOWN;
 
   while((obj = ponyint_objectmap_next(map, &i)) != NULL)
   {
     void* p = obj->address;
-    object_t* obj_local = ponyint_objectmap_getobject(&gc->local, p);
+    object_t* obj_local = ponyint_objectmap_getobject(&gc->local, p, &index);
 
     assert(obj_local->rc >= obj->rc);
     obj_local->rc -= obj->rc;

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -37,24 +37,25 @@ static void object_free(object_t* obj)
 DEFINE_HASHMAP(ponyint_objectmap, objectmap_t, object_t, object_hash,
   object_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size, object_free);
 
-object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address)
+object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address, size_t* index)
 {
   object_t obj;
   obj.address = address;
 
-  return ponyint_objectmap_get(map, &obj);
+  return ponyint_objectmap_get(map, &obj, index);
 }
 
 object_t* ponyint_objectmap_getorput(objectmap_t* map, void* address,
   uint32_t mark)
 {
-  object_t* obj = ponyint_objectmap_getobject(map, address);
+  size_t index = HASHMAP_UNKNOWN;
+  object_t* obj = ponyint_objectmap_getobject(map, address, &index);
 
   if(obj != NULL)
     return obj;
 
   obj = object_alloc(address, mark);
-  ponyint_objectmap_put(map, obj);
+  ponyint_objectmap_putindex(map, obj, index);
   return obj;
 }
 

--- a/src/libponyrt/gc/objectmap.h
+++ b/src/libponyrt/gc/objectmap.h
@@ -17,7 +17,7 @@ typedef struct object_t
 
 DECLARE_HASHMAP(ponyint_objectmap, objectmap_t, object_t);
 
-object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address);
+object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address, size_t* index);
 
 object_t* ponyint_objectmap_getorput(objectmap_t* map, void* address,
   uint32_t mark);

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -78,7 +78,8 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
   serialise_t k;
   k.key = (uintptr_t)p;
-  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k, &index);
 
   if(s != NULL)
   {
@@ -93,7 +94,9 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
     s->value = ctx->serialise_size;
     s->t = t;
 
-    ponyint_serialise_put(&ctx->serialise, s);
+    // didn't find it in the map but index is where we can put the
+    // new one without another search
+    ponyint_serialise_putindex(&ctx->serialise, s, index);
     ctx->serialise_size += t->size;
   }
 
@@ -118,7 +121,9 @@ void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size)
   // String and Array[A].
   serialise_t k;
   k.key = (uintptr_t)p;
-  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+  size_t index = HASHMAP_UNKNOWN;
+
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k, &index);
 
   if(s != NULL)
     return;
@@ -130,7 +135,9 @@ void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size)
   s->t = NULL;
   s->mutability = PONY_TRACE_OPAQUE;
 
-  ponyint_serialise_put(&ctx->serialise, s);
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  ponyint_serialise_putindex(&ctx->serialise, s, index);
   ctx->serialise_size += size;
 }
 
@@ -138,7 +145,8 @@ size_t pony_serialise_offset(pony_ctx_t* ctx, void* p)
 {
   serialise_t k;
   k.key = (uintptr_t)p;
-  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k, &index);
 
   // If we are in the map, return the offset.
   if(s != NULL)
@@ -200,7 +208,8 @@ void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,
   // Lookup the offset, return the associated object if there is one.
   serialise_t k;
   k.key = offset;
-  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k);
+  size_t index = HASHMAP_UNKNOWN;
+  serialise_t* s = ponyint_serialise_get(&ctx->serialise, &k, &index);
 
   if(s != NULL)
     return (void*)s->value;
@@ -239,7 +248,10 @@ void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,
   s = POOL_ALLOC(serialise_t);
   s->key = offset;
   s->value = (uintptr_t)object;
-  ponyint_serialise_put(&ctx->serialise, s);
+
+  // didn't find it in the map but index is where we can put the
+  // new one without another search
+  ponyint_serialise_putindex(&ctx->serialise, s, index);
 
   recurse(ctx, object, t->deserialise);
   return object;

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -69,7 +69,8 @@ protected:
   {
     reach_type_t t;
     t.name = stringtab(name);
-    reach_type_t* type = reach_types_get(&_set->types, &t);
+    size_t index = HASHMAP_UNKNOWN;
+    reach_type_t* type = reach_types_get(&_set->types, &t, &index);
     ASSERT_NE((void*)NULL, type);
 
     ASSERT_LE(min_expected, type->vtable_size);
@@ -88,7 +89,7 @@ protected:
       reach_method_t m2;
       memset(&m2, 0, sizeof(reach_method_t));
       m2.name = n->name;
-      reach_method_t* method = reach_methods_get(&n->r_methods, &m2);
+      reach_method_t* method = reach_methods_get(&n->r_methods, &m2, &index);
 
       assert(method != NULL);
 
@@ -103,6 +104,7 @@ protected:
     uint32_t* actual)
   {
     size_t i = HASHMAP_BEGIN;
+    size_t index = HASHMAP_UNKNOWN;
     reach_type_t* type;
     uint32_t colour = (uint32_t)-1;
 
@@ -110,14 +112,14 @@ protected:
     {
       reach_method_name_t m1;
       m1.name = stringtab(name);
-      reach_method_name_t* n = reach_method_names_get(&type->methods, &m1);
+      reach_method_name_t* n = reach_method_names_get(&type->methods, &m1, &index);
 
       if(n != NULL)
       {
         reach_method_t m2;
         memset(&m2, 0, sizeof(reach_method_t));
         m2.name = stringtab(name);
-        reach_method_t* method = reach_methods_get(&n->r_methods, &m2);
+        reach_method_t* method = reach_methods_get(&n->r_methods, &m2, &index);
 
         ASSERT_NE((void*)NULL, method);
 

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -138,10 +138,11 @@ TEST_F(HashMapTest, InsertAndRetrieve)
   hash_elem_t* e = get_element();
   e->key = 1;
   e->val = 42;
+  size_t index = HASHMAP_UNKNOWN;
 
   testmap_put(&_map, e);
 
-  hash_elem_t* n = testmap_get(&_map, e);
+  hash_elem_t* n = testmap_get(&_map, e, &index);
 
   ASSERT_EQ(e->val, n->val);
 }
@@ -153,13 +154,14 @@ TEST_F(HashMapTest, TryGetNonExistent)
 {
   hash_elem_t* e1 = get_element();
   hash_elem_t* e2 = get_element();
+  size_t index = HASHMAP_UNKNOWN;
 
   e1->key = 1;
   e2->key = 2;
 
   testmap_put(&_map, e1);
 
-  hash_elem_t* n = testmap_get(&_map, e2);
+  hash_elem_t* n = testmap_get(&_map, e2, &index);
 
   ASSERT_EQ(NULL, n);
 }
@@ -171,6 +173,7 @@ TEST_F(HashMapTest, ReplacingElementReturnsReplaced)
 {
   hash_elem_t* e1 = get_element();
   hash_elem_t* e2 = get_element();
+  size_t index = HASHMAP_UNKNOWN;
 
   e1->key = 1;
   e2->key = 1;
@@ -180,7 +183,7 @@ TEST_F(HashMapTest, ReplacingElementReturnsReplaced)
   hash_elem_t* n = testmap_put(&_map, e2);
   ASSERT_EQ(n, e1);
 
-  hash_elem_t* m = testmap_get(&_map, e2);
+  hash_elem_t* m = testmap_get(&_map, e2, &index);
   ASSERT_EQ(m, e2);
 }
 
@@ -196,6 +199,7 @@ TEST_F(HashMapTest, DeleteElement)
 
   e1->key = 1;
   e2->key = 2;
+  size_t index = HASHMAP_UNKNOWN;
 
   testmap_put(&_map, e1);
   testmap_put(&_map, e2);
@@ -211,7 +215,7 @@ TEST_F(HashMapTest, DeleteElement)
   ASSERT_EQ(n1, e1);
   ASSERT_EQ(l, (size_t)1);
 
-  hash_elem_t* n2 = testmap_get(&_map, e2);
+  hash_elem_t* n2 = testmap_get(&_map, e2, &index);
 
   ASSERT_EQ(n2, e2);
 }
@@ -261,6 +265,7 @@ TEST_F(HashMapTest, RemoveByIndex)
   put_elements(100);
 
   size_t i = HASHMAP_BEGIN;
+  size_t index = HASHMAP_UNKNOWN;
   hash_elem_t* p = NULL;
 
   while((curr = testmap_next(&_map, &i)) != NULL)
@@ -275,5 +280,51 @@ TEST_F(HashMapTest, RemoveByIndex)
   hash_elem_t* n = testmap_removeindex(&_map, i);
 
   ASSERT_EQ(n, p);
-  ASSERT_EQ(NULL, testmap_get(&_map, p));
+  ASSERT_EQ(NULL, testmap_get(&_map, p, &index));
 }
+
+/** An element not found can be put by index into
+ * an empty map and retrieved successfully.
+ */
+TEST_F(HashMapTest, EmptyPutByIndex)
+{
+  hash_elem_t* e = get_element();
+  e->key = 1000;
+  e->val = 42;
+  size_t index = HASHMAP_UNKNOWN;
+
+  hash_elem_t* n = testmap_get(&_map, e, &index);
+
+  ASSERT_EQ(NULL, n);
+  ASSERT_EQ(HASHMAP_UNKNOWN, index);
+
+  testmap_putindex(&_map, e, index);
+
+  hash_elem_t* m = testmap_get(&_map, e, &index);
+
+  ASSERT_EQ(e->val, m->val);
+}
+
+/** An element not found can be put by index into
+ * a non-empty map and retrieved successfully.
+ */
+TEST_F(HashMapTest, NotEmptyPutByIndex)
+{
+  put_elements(100);
+
+  hash_elem_t* e = get_element();
+  e->key = 1000;
+  e->val = 42;
+  size_t index = HASHMAP_UNKNOWN;
+
+  hash_elem_t* n = testmap_get(&_map, e, &index);
+
+  ASSERT_EQ(NULL, n);
+
+  testmap_putindex(&_map, e, index);
+
+  hash_elem_t* m = testmap_get(&_map, e, &index);
+
+  ASSERT_EQ(e->val, m->val);
+}
+


### PR DESCRIPTION
This change was motivated by profiling using linux `perf` and
`FlameGraphs` which revealed that `ponyint_objectmap_getorput`
was an expensive operation of which `search` in hashmap was taking
up almost all the processing time. The `FlameGraphs` also revealed
that `search` was being called twice by `ponyint_objectmap_getorput`,
once for `get` and again for `put` where the object wasn't found.
This change allows `ponyint_objectmap_getorput` to only do the `search`
once and reuse the `index` returned by `search` for the subsequent `put`
operation via the new `putindex` function. In addition to changing
`ponyint_objectmap_getorput`, this PR also changes all instances
where a `get` was followed by a subsequent `put` to reuse the `index`
from `search` via `putindex` for all hashmaps in the runtime and the
compiler.