### PR TITLE
Added String.split_by, which uses a string delimiter (issue #1399)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -973,6 +973,33 @@ actor Main
     end
     this
 
+  fun split_by(delim: String, n: USize = USize.max_value()): Array[String] iso^ =>
+    """
+    Split the string into an array of strings that are delimited by `delim` in
+    the original string. If `n > 0`, then the split count is limited to n.
+
+    Adjacent delimiters result in a zero length entry in the array. For
+    example, `"1,,2".split(",") => ["1", "", "2"]`.
+
+    An empty delimiter results in an array that contains a single element equal
+    to the whole string.
+    """
+    let delim_size = ISize.from[USize](delim.size())
+    let total_size = ISize.from[USize](size())
+
+    let result = recover Array[String] end
+    var current = ISize(0)
+
+    while ((result.size() + 1) < n) and (current < total_size) do
+      try
+        let delim_start = find(delim where offset = current)
+        result.push(substring(current, delim_start))
+        current = delim_start + delim_size
+      else break end
+    end
+    result.push(substring(current))
+    consume result
+
   fun split(delim: String = " \t\v\f\r\n", n: USize = 0): Array[String] iso^ =>
     """
     Split the string into an array of strings. Any character in the delimiter

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -33,6 +33,7 @@ actor Main is TestList
     test(_TestStringIsNullTerminated)
     test(_TestStringReplace)
     test(_TestStringSplit)
+    test(_TestStringSplitBy)
     test(_TestStringJoin)
     test(_TestStringCount)
     test(_TestStringCompare)
@@ -536,6 +537,66 @@ class iso _TestStringSplit is UnitTest
     h.assert_eq[String](r(1), "2")
     h.assert_eq[String](r(2), "3  4")
 
+class iso _TestStringSplitBy is UnitTest
+  """
+  Test String.split_by
+  """
+  fun name(): String => "builtin/String.split_by"
+
+  fun apply(h: TestHelper) ? =>
+    var r = "opinion".split_by("pi")
+    h.assert_eq[USize](r.size(), 2)
+    h.assert_eq[String](r(0), "o")
+    h.assert_eq[String](r(1), "nion")
+
+    r = "opopgadget".split_by("op")
+    h.assert_eq[USize](r.size(), 3)
+    h.assert_eq[String](r(0), "")
+    h.assert_eq[String](r(1), "")
+    h.assert_eq[String](r(2), "gadget")
+
+    r = "simple spaces, with one trailing ".split_by(" ")
+    h.assert_eq[USize](r.size(), 6)
+    h.assert_eq[String](r(0), "simple")
+    h.assert_eq[String](r(1), "spaces,")
+    h.assert_eq[String](r(2), "with")
+    h.assert_eq[String](r(3), "one")
+    h.assert_eq[String](r(4), "trailing")
+    h.assert_eq[String](r(5), "")
+
+    r = " with more trailing  ".split_by(" ")
+    h.assert_eq[USize](r.size(), 6)
+    h.assert_eq[String](r(0), "")
+    h.assert_eq[String](r(1), "with")
+    h.assert_eq[String](r(2), "more")
+    h.assert_eq[String](r(3), "trailing")
+    h.assert_eq[String](r(4), "")
+    h.assert_eq[String](r(5), "")
+
+    r = "should not split this too much".split(" ", 3)
+    h.assert_eq[USize](r.size(), 3)
+    h.assert_eq[String](r(0), "should")
+    h.assert_eq[String](r(1), "not")
+    h.assert_eq[String](r(2), "split this too much")
+
+    let s = "this should not even be split"
+    r = s.split_by(" ", 0)
+    h.assert_eq[USize](r.size(), 1)
+    h.assert_eq[String](r(0), s)
+
+    r = s.split_by("")
+    h.assert_eq[USize](r.size(), 1)
+    h.assert_eq[String](r(0), s)
+
+    r = "make some ☃s and ☺ for the winter ☺".split_by("☃")
+    h.assert_eq[USize](r.size(), 2)
+    h.assert_eq[String](r(0), "make some ")
+    h.assert_eq[String](r(1), "s and ☺ for the winter ☺")
+
+    r = "try with trailing patternpatternpattern".split_by("pattern", 2)
+    h.assert_eq[USize](r.size(), 2)
+    h.assert_eq[String](r(0), "try with trailing ")
+    h.assert_eq[String](r(1), "patternpattern")
 
 class iso _TestStringJoin is UnitTest
   """


### PR DESCRIPTION
The signature is almost the same as `String.split`, we don't have any default value here. I'm not sure what'd make sense, `\n`, `' '`?

There are some users of `String.split` in the stdlib and this can't be a drop-in replacement for those. If it's acceptable we can replace the current String.split uses with a Regex or move the current logic under another name (tokenize?).