### PR TITLE
Set null terminator in String.from_iso_array (issue #1435)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -73,6 +73,9 @@ actor Main
     _size = data.size()
     _alloc = data.space()
     _ptr = (consume data).cpointer()._unsafe()
+    if _alloc > _size then
+      _set(_size, 0)
+    end
 
   new from_cpointer(str: Pointer[U8], len: USize, alloc: USize = 0) =>
     """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -41,6 +41,7 @@ actor Main is TestList
     test(_TestStringUTF32)
     test(_TestStringRFind)
     test(_TestStringFromArray)
+    test(_TestStringFromIsoArray)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -786,6 +787,23 @@ class iso _TestStringFromArray is UnitTest
     h.assert_eq[String](s_no_null, "foo")
     h.assert_eq[USize](s_no_null.size(), 3)
 
+
+class iso _TestStringFromIsoArray is UnitTest
+  fun name(): String => "builtin/String.from_iso_array"
+
+  fun apply(h: TestHelper) =>
+    let s = String.from_iso_array(recover ['f', 'o', 'o'] end)
+    h.assert_eq[String](s, "foo")
+    h.assert_eq[USize](s.size(), 3)
+    h.assert_true((s.space() == 3) or s.is_null_terminated())
+/*
+    let s2 = String.from_iso_array(recover
+      ['1', '1', '1', '1', '1', '1', '1', '1']
+    end)
+    h.assert_eq[String](s, "11111111")
+    h.assert_eq[USize](s.size(), 8)
+    h.assert_true((s.space() == 8) or s.is_null_terminated())
+*/
 
 class iso _TestArrayAppend is UnitTest
   fun name(): String => "builtin/Array.append"

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -792,7 +792,7 @@ class iso _TestStringFromIsoArray is UnitTest
   fun name(): String => "builtin/String.from_iso_array"
 
   fun apply(h: TestHelper) =>
-    let s = String.from_iso_array(recover ['f', 'o', 'o'] end)
+    let s = recover val String.from_iso_array(recover ['f', 'o', 'o'] end) end
     h.assert_eq[String](s, "foo")
     h.assert_eq[USize](s.size(), 3)
     h.assert_true((s.space() == 3) or s.is_null_terminated())


### PR DESCRIPTION
When the `Array[U8]` passed to `String.from_iso_array` has pre-allocated
space, the first pre-allocated byte (the one at the `_size` index) should
be set to `0` in order to be compliant with how `is_null_terminated`
does its check. This PR sets that byte in such a case.

Fixes #1435