### PR TITLE
Prevent `String.truncate` from chopping last byte

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -326,7 +326,13 @@ actor Main
 
     Note that memory is not freed by this operation.
     """
-    _size = len.min(_alloc - 1)
+    if len >= _alloc then
+      _size = len.min(_alloc)
+      reserve(_alloc + 1)
+    else
+      _size = len.min(_alloc - 1)
+    end
+
     _set(_size, 0)
 
     this

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -45,6 +45,7 @@ actor Main is TestList
     test(_TestStringFromIsoArray)
     test(_TestStringSpace)
     test(_TestStringRecalc)
+    test(_TestStringTruncate)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -914,6 +915,31 @@ class iso _TestStringRecalc is UnitTest
     h.assert_eq[USize](s3.size(), 1)
     h.assert_eq[USize](s3.space(), 7)
     h.assert_true(s3.is_null_terminated())
+
+
+class iso _TestStringTruncate is UnitTest
+  fun name(): String => "builtin/String.truncate"
+
+  fun apply(h: TestHelper) =>
+    let s = recover ref String.from_iso_array(recover
+      ['1', '1', '1', '1', '1', '1', '1', '1']
+    end) end
+    s.truncate(s.space())
+    h.assert_true(s.is_null_terminated())
+    h.assert_eq[String](s.clone(), "11111111")
+    h.assert_eq[USize](s.size(), 8)
+    h.assert_eq[USize](s.space(), 15) // created extra allocation for null
+
+    s.truncate(100)
+    h.assert_true(s.is_null_terminated())
+    h.assert_eq[USize](s.size(), 16) // sized up to _alloc
+    h.assert_eq[USize](s.space(), 31) // created extra allocation for null
+
+    s.truncate(3)
+    h.assert_true(s.is_null_terminated())
+    h.assert_eq[String](s.clone(), "111")
+    h.assert_eq[USize](s.size(), 3)
+    h.assert_eq[USize](s.space(), 31)
 
 
 class iso _TestArrayAppend is UnitTest


### PR DESCRIPTION
When `String.truncate` is called on a String where `_size` is
to `_alloc`, the last byte would be lost since it set the null
terminator without first checking.

Because the docs guarantee that the result is null terminated,
when the `len` passed to `truncate` is greater than or equal to
the `_alloc`, extra space is reserved to accommodate the null
terminator.

While this resolves the issue without changing documented behavior,
it has the undesirable effect that in this specific case, a call to
`truncate` can actually allocate, which may be surprising.

Fixes #1427