### PR TITLE
Optimise count zeros operations in the runtime

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -215,26 +215,26 @@ inline int snprintf(char* str, size_t size, const char* format, ...)
  */
 #ifdef PLATFORM_IS_CLANG_OR_GCC
 #  define __pony_popcount(X) __builtin_popcount((X))
-#  define __pony_ffs(X) __builtin_ffs((X))
-#  define __pony_ffsl(X) __builtin_ffsl((X))
+#  define __pony_ctz(X) __builtin_ctz((X))
+#  define __pony_ctzl(X) __builtin_ctzl((X))
 #  define __pony_clz(X) __builtin_clz((X))
 #  define __pony_clzl(X) __builtin_clzl((X))
 #else
 #  include <intrin.h>
 #  define __pony_popcount(X) __popcnt((X))
 
-inline uint32_t __pony_ffs(uint32_t x)
+inline uint32_t __pony_ctz(uint32_t x)
 {
   DWORD i = 0;
   _BitScanForward(&i, x);
-  return i + 1;
+  return i;
 }
 
-inline uint64_t __pony_ffsl(uint64_t x)
+inline uint64_t __pony_ctzl(uint64_t x)
 {
   DWORD i = 0;
   _BitScanForward64(&i, x);
-  return i + 1;
+  return i;
 }
 
 inline uint32_t __pony_clz(uint32_t x)

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -225,7 +225,7 @@ void* ponyint_heap_alloc_small(pony_actor_t* actor, heap_t* heap,
   {
     // Clear and use the first available slot.
     uint32_t slots = chunk->slots;
-    uint32_t bit = __pony_ffs(slots) - 1;
+    uint32_t bit = __pony_ctz(slots);
     slots &= ~(1 << bit);
 
     m = chunk->m + (bit << HEAP_MINBITS);

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -700,8 +700,7 @@ size_t ponyint_pool_index(size_t size)
   if(size > POOL_MAX)
     return POOL_COUNT;
 
-  size = ponyint_next_pow2(size);
-  return __pony_ffsl(size) - (POOL_MIN_BITS + 1);
+  return ((size_t)64 - __pony_clzl(size)) - POOL_MIN_BITS;
 }
 
 size_t ponyint_pool_size(size_t index)


### PR DESCRIPTION
This change replaces some bit counting operations in the runtime by more efficient ones.

- ponyint_heap_alloc_small: The slot search now uses CTZ instead of FFS. A slot mask with free slots isn't zero so this is safe.
- ponyint_pool_index: Now uses CLZ instead of rounding to next power of 2 followed by FFS. The size can't be zero on this code path so this is safe.

This results in less instructions being issued on both x86 and ARM.