### PR TITLE
Add a comment to the README requiring Visual Studio 2015 to run Pony on Windows (#1440).

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Invoke-WebRequest -Uri https://dl.bintray.com/pony-language/ponyc-win/ponyc-VERS
 .\ponyc-VERSION\ponyc\bin\ponyc.exe --version
 ```
 
-Windows 10 users will need to install the Windows 10 SDK in order to build programs with ponyc. It can be downloaded [from Microsoft](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).
+Windows users will need to install Visual Studio 2015 and the Windows 10 SDK in order to build programs with ponyc. It can be downloaded from Microsoft ([Visual Studio](https://www.visualstudio.com/vs/community/), [SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
 
 ## Mac OS X using [Homebrew](http://brew.sh)
 


### PR DESCRIPTION
Turns out the Windows 10 SDK doesn't include the linker; Visual Studio 2015 is required; [Microsoft says](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk):

    By installing this SDK, the latest Visual Studio 2015 release, and your IDE environment you will be able to access the new Windows 10 APIs.

This PR adds a comment to the README that VS2015 is required.
