### PR TITLE
Change appveyor.yml to rebuild the build cache (#1444)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -115,7 +115,7 @@ deploy:
         configuration: Release
     publish: true
 
-cache:
+cache: # cache rebuild change 1
   - 'C:\LLVM-%llvm%\ -> .appveyor.yml'
   - C:\premake5.exe -> .appveyor.yml
   - C:\ponyc-windows-libs\ -> .appveyor.yml


### PR DESCRIPTION
This PR adds a comment to .appveyor.yml in order to invalidate the AppVeyor build cache to see if the cached LLVM is bad.

Please do not merge unless the AppVeyor build actually works.