### PR TITLE
Fix String.recalc method for cases where no null terminator is found (issue #1446)

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -304,18 +304,17 @@ actor Main
   fun ref recalc(): String ref^ =>
     """
     Recalculates the string length. This is only needed if the string is
-    changed via an FFI call. If the string is not null terminated at the
-    allocated length, a null is added.
+    changed via an FFI call. If a null terminator byte is not found within the
+    allocated length, the size will not be changed.
     """
-    _size = 0
+    var s: USize = 0
 
-    while (_size < _alloc) and (_ptr._apply(_size) > 0) do
-      _size = _size + 1
+    while (s < _alloc) and (_ptr._apply(s) > 0) do
+      s = s + 1
     end
 
-    if _size == _alloc then
-      _size = _size - 1
-      _set(_size, 0)
+    if s != _alloc then
+      _size = s
     end
 
     this

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -44,6 +44,7 @@ actor Main is TestList
     test(_TestStringFromArray)
     test(_TestStringFromIsoArray)
     test(_TestStringSpace)
+    test(_TestStringRecalc)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -885,6 +886,34 @@ class iso _TestStringSpace is UnitTest
     h.assert_eq[USize](s.size(), 8)
     h.assert_eq[USize](s.space(), 8)
     h.assert_false(s.is_null_terminated())
+
+
+class iso _TestStringRecalc is UnitTest
+  fun name(): String => "builtin/String.recalc"
+
+  fun apply(h: TestHelper) =>
+    let s: String ref = String.from_iso_array(recover
+      ['1', '1', '1', '1', '1', '1', '1', '1']
+    end)
+    s.recalc()
+    h.assert_eq[USize](s.size(), 8)
+    h.assert_eq[USize](s.space(), 8)
+    h.assert_false(s.is_null_terminated())
+
+    let s2: String ref = "foobar".clone()
+    s2.recalc()
+    h.assert_eq[USize](s2.size(), 6)
+    h.assert_eq[USize](s2.space(), 6)
+    h.assert_true(s2.is_null_terminated())
+
+    let s3: String ref = String.from_iso_array(recover
+      ['1', 0, 0, 0, 0, 0, 0, '1']
+    end)
+    s3.truncate(1)
+    s3.recalc()
+    h.assert_eq[USize](s3.size(), 1)
+    h.assert_eq[USize](s3.space(), 7)
+    h.assert_true(s3.is_null_terminated())
 
 
 class iso _TestArrayAppend is UnitTest


### PR DESCRIPTION
The `String.recalc` method would truncate the final byte in a string
where no null terminator was found. The behavior and documentation
has been changed so that in the case of no null terminator, the
`_size` of the string remains unchanged.

Fixes #1446