### PR TITLE
Correctly generate TBAA metadatas for box intrinsics

### DIFF
--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -40,7 +40,7 @@ static void start_function(compile_t* c, reach_type_t* t, reach_method_t* m,
 
 static void box_function(compile_t* c, generate_box_fn gen, void* gen_data)
 {
-  gen(c, gen_data, TK_NONE);
+  gen(c, gen_data, TK_BOX);
   gen(c, gen_data, TK_REF);
   gen(c, gen_data, TK_VAL);
 }


### PR DESCRIPTION
Looking up the function with `TK_NONE` instead of `TK_BOX` resulted in the wrong metadata being generated.