### PR TITLE
Make AppVeyor build cache use pony-specific name for LLVM directory

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ install:
   - ps: |
       cd C:\
       $premakeInstalled = Test-Path C:\premake5.exe
-      $llvmInstalled = Test-Path C:\LLVM-${env:llvm}
+      $llvmInstalled = Test-Path C:\LLVM-${env:llvm}-pony
       if(-Not $premakeInstalled)
       {
         wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-windows.zip -OutFile C:\premake5.zip
@@ -41,9 +41,10 @@ install:
       {
         wget "https://github.com/ponylang/ponyc-windows-llvm/releases/download/LLVM-Release-VS2015/LLVM-${env:llvm}-Release-VS2015.7z" -OutFile C:\LLVM.7z
         7z x C:\LLVM.7z
+        ren C:\LLVM-${env:llvm} C:\LLVM-${env:llvm}-pony
         del C:\LLVM.7z
       }
-      $env:path += ";C:\LLVM-${env:llvm}\bin"
+      $env:path += ";C:\LLVM-${env:llvm}-pony\bin"
   - ps: |
       cd C:\
       $libsInstalled = Test-Path C:\ponyc-windows-libs
@@ -116,7 +117,7 @@ deploy:
     publish: true
 
 cache: # cache rebuild change 1
-  - 'C:\LLVM-%llvm%\ -> .appveyor.yml'
+  - 'C:\LLVM-%llvm%-pony\ -> .appveyor.yml'
   - C:\premake5.exe -> .appveyor.yml
   - C:\ponyc-windows-libs\ -> .appveyor.yml
 
@@ -137,4 +138,3 @@ test_script:
   - C:\projects\ponyc\build\%CONFIGURATION%\ponyc.exe -V 3 -o C:\projects\ponyc\ -d -s --verify examples
   - examples.exe
   - del examples.exe
-


### PR DESCRIPTION
I have an unsubstantiated theory about #1444 that the cached directory for the LLVM libarary is being corrupted by being confused with a standard LLVM install that doesn't include llvm-config.exe.

This PR makes the AppVeyor build use a pony-specific name for the LLVM build directory in order to test this theory.