### PR TITLE
Disable cache for LLVM for AppVeyor build (#1444)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -116,8 +116,8 @@ deploy:
         configuration: Release
     publish: true
 
-cache: # cache rebuild change 1
-  - 'C:\LLVM-%llvm%-pony\ -> .appveyor.yml'
+cache:
+  # - 'C:\LLVM-%llvm%-pony\ -> .appveyor.yml'
   - C:\premake5.exe -> .appveyor.yml
   - C:\ponyc-windows-libs\ -> .appveyor.yml
 


### PR DESCRIPTION
This PR disables the AppVeyor build cache for LLVM.  Experiments in changing the directory name (#1458) did not work; it seems that something is corrupting the build cache for LLVM.