### PR TITLE
turn off appveyor build cache for all directories

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -116,10 +116,10 @@ deploy:
         configuration: Release
     publish: true
 
-cache:
-  # - 'C:\LLVM-%llvm%-pony\ -> .appveyor.yml'
-  - C:\premake5.exe -> .appveyor.yml
-  - C:\ponyc-windows-libs\ -> .appveyor.yml
+# cache:
+#   - 'C:\LLVM-%llvm%-pony\ -> .appveyor.yml'
+#   - C:\premake5.exe -> .appveyor.yml
+#   - C:\ponyc-windows-libs\ -> .appveyor.yml
 
 build:
   project: work\vs2015\ponyc.sln


### PR DESCRIPTION
It looks like the AppVeyor cache problem (#1444) is not just for LLVM.  This PR turns off build cacheing for everything.