### PR TITLE
Check errors correctly for method chaining

### DIFF
--- a/src/libponyc/pass/finalisers.c
+++ b/src/libponyc/pass/finalisers.c
@@ -101,6 +101,7 @@ static int check_call_send(ast_t* ast, bool in_final)
   {
     case TK_NEWREF:
     case TK_FUNREF:
+    case TK_FUNCHAIN:
       // Qualified. Get the real receiver.
       receiver = ast_child(receiver);
       method = ast_sibling(receiver);

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -15,8 +15,10 @@ ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
     case TK_NEW:
     case TK_BE:           r = verify_fun(options, ast); break;
     case TK_FUNREF:
+    case TK_FUNCHAIN:
     case TK_NEWREF:       r = verify_function_call(options, ast); break;
     case TK_BEREF:
+    case TK_BECHAIN:
     case TK_NEWBEREF:     r = verify_behaviour_call(options, ast); break;
     case TK_FFICALL:      r = verify_ffi_call(options, ast); break;
     case TK_TRY:

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -780,6 +780,8 @@ static void reachable_fun(reach_t* r, ast_t* ast, pass_opt_t* opt)
     case TK_NEWBEREF:
     case TK_BEREF:
     case TK_FUNREF:
+    case TK_BECHAIN:
+    case TK_FUNCHAIN:
       typeargs = method;
       AST_GET_CHILDREN_NO_DECL(receiver, receiver, method);
       break;

--- a/src/libponyc/verify/call.c
+++ b/src/libponyc/verify/call.c
@@ -6,7 +6,8 @@
 
 static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_NEWREF));
+  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+    (ast_id(ast) == TK_NEWREF));
   AST_GET_CHILDREN(ast, receiver, method);
 
   // Receiver might be wrapped in another funref/newref
@@ -63,7 +64,8 @@ static bool check_partial_ffi_call(pass_opt_t* opt, ast_t* ast)
 
 bool verify_function_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_NEWREF));
+  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+    (ast_id(ast) == TK_NEWREF));
 
   ast_inheritflags(ast);
   ast_setmightsend(ast);
@@ -77,7 +79,8 @@ bool verify_function_call(pass_opt_t* opt, ast_t* ast)
 bool verify_behaviour_call(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
-  assert((ast_id(ast) == TK_BEREF) || (ast_id(ast) == TK_NEWBEREF));
+  assert((ast_id(ast) == TK_BEREF) || (ast_id(ast) == TK_BECHAIN) ||
+    (ast_id(ast) == TK_NEWBEREF));
 
   ast_inheritflags(ast);
   ast_setsend(ast);

--- a/test/libponyc/finalisers.cc
+++ b/test/libponyc/finalisers.cc
@@ -97,3 +97,16 @@ TEST_F(FinalisersTest, FinalCannotCallBehaviourInTryElseBlock)
 
   TEST_ERRORS_1(src, "_final cannot create actors or send messages");
 }
+
+TEST_F(FinalisersTest, FinalCannotCallChainedBehaviour)
+{
+  const char* src =
+    "actor Actor\n"
+    "  be apply() => None\n"
+    "class Foo\n"
+    "  let a: Actor = Actor\n"
+    "  fun _final() =>\n"
+    "    a.>apply()";
+
+  TEST_ERRORS_1(src, "_final cannot create actors or send messages");
+}

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -309,6 +309,17 @@ TEST_F(VerifyTest, TryCallCurriedPartialFunction)
   TEST_COMPILE(src);
 }
 
+TEST_F(VerifyTest, TryCallChainedPartialFunction)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun partial() ? => error\n"
+    "  fun apply() =>\n"
+    "    try this.>partial() end";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(VerifyTest, PartialFunctionNoError)
 {
   const char* src =


### PR DESCRIPTION
This fix covers partial method checking and message sending in finalisers.