### PR TITLE
Change error message for erroring behaviour bodies

### DIFF
--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -251,8 +251,18 @@ bool verify_fun(pass_opt_t* opt, ast_t* ast)
     // If the function is not marked as partial, it must never raise an error.
     if(ast_canerror(body))
     {
-      ast_error(opt->check.errors, can_error, "function signature is not "
-        "marked as partial but the function body can raise an error");
+      if(ast_id(ast) == TK_BE)
+      {
+        ast_error(opt->check.errors, can_error, "a behaviour must handle any "
+          "potential error");
+      } else if((ast_id(ast) == TK_NEW) &&
+        (ast_id(opt->check.frame->type) == TK_ACTOR)) {
+        ast_error(opt->check.errors, can_error, "an actor constructor must "
+          "handle any potential error");
+      } else {
+        ast_error(opt->check.errors, can_error, "function signature is not "
+          "marked as partial but the function body can raise an error");
+      }
       show_partiality(opt, body);
       return false;
     }

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -374,6 +374,26 @@ TEST_F(VerifyTest, NonPartialFunctionError)
     "function body can raise an error");
 }
 
+TEST_F(VerifyTest, ErroringBehaviourError)
+{
+  const char* src =
+    "actor Foo\n"
+    "  be apply() =>\n"
+    "    error";
+
+  TEST_ERRORS_1(src, "a behaviour must handle any potential error");
+}
+
+TEST_F(VerifyTest, ErroringActorConstructorError)
+{
+  const char* src =
+    "actor Foo\n"
+    "  new create() =>\n"
+    "    error";
+
+  TEST_ERRORS_1(src, "an actor constructor must handle any potential error");
+}
+
 TEST_F(VerifyTest, TraitPartialFunctionNoError)
 {
   const char* src =


### PR DESCRIPTION
The previous error message said that a function must be partial in order to raise an error. This was confusing for behaviours (which can't be partial) and the error message has been changed to "a behaviour must handle any potential error".