### PR TITLE
Remove the "return this" idiom used for call chaining (RFC 29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,132 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Behaviour calls return None instead of their receiver (RFC 28) (PR #1460)
 - Update from_array to prevent a copy (issue #1097) (PR #1423)
+- Methods returning their receiver to allow call chaining have been changed to return either None or some useful value. Generalised method chaining implemented in version 0.9.0 should be used as a replacement. The full list of updated methods follows. No details means that the method now returns None.
+  - builtin.Seq
+    - reserve
+    - clear
+    - push
+    - unshift
+    - append
+    - concat
+    - truncate
+  - builtin.Array
+    - reserve
+    - compact
+    - undefined
+    - insert
+    - truncate
+    - trim_in_place
+    - copy_to
+    - remove
+    - clear
+    - push
+    - unshift
+    - append
+    - concat
+    - reverse_in_place
+  - builtin.String
+    - reserve
+    - compact
+    - recalc
+    - truncate
+    - trim_in_place
+    - delete
+    - lower_in_place
+    - upper_in_place
+    - reverse_in_place
+    - push
+    - unshift
+    - append
+    - concat
+    - clear
+    - insert_in_place
+    - insert_byte
+    - cut_in_place
+    - replace (returns the number of occurrences replaced)
+    - strip
+    - lstrip
+    - rstrip
+  - buffered.Reader
+    - clear
+    - append
+    - skip
+  - buffered.Writer
+    - reserve
+    - reserve_chunks
+    - number writing functions (e.g. u16_le)
+    - write
+    - writev
+  - capsicum.CapRights0
+    - set
+    - unset
+  - collections.Flag
+    - all
+    - clear
+    - set
+    - unset
+    - flip
+    - union
+    - intersect
+    - difference
+    - remove
+  - collections.ListNode
+    - prepend (returns whether the node was removed from another List)
+    - append (returns whether the node was removed from another List)
+    - remove
+  - collections.List
+    - reserve
+    - remove
+    - clear
+    - prepend_node
+    - append_node
+    - prepend_list
+    - append_list
+    - push
+    - unshift
+    - append
+    - concat
+    - truncate
+  - collections.Map
+    - concat
+    - compact
+    - clear
+  - collections.RingBuffer
+    - push (returns whether the collection was full)
+    - clear
+  - collections.Set
+    - clear
+    - set
+    - unset
+    - union
+    - intersect
+    - difference
+    - remove
+  - files.FileMode
+    - exec
+    - shared
+    - group
+    - private
+  - files.File
+    - seek_start
+    - seek_end
+    - seek
+    - flush
+    - sync
+  - time.Date
+    - normal
+  - net.http.Payload
+    - update (returns the old value)
+  - net.ssl.SSLContext
+    - set_cert
+    - set_authority
+    - set_ciphers
+    - set_client_verify
+    - set_server_verify
+    - set_verify_depth
+    - allow_tls_v1
+    - allow_tls_v1_1
+    - allow_tls_v1_2
 
 ## [0.9.0] - 2016-11-11
 

--- a/examples/files/files.pony
+++ b/examples/files/files.pony
@@ -2,7 +2,7 @@ use "files"
 
 actor Main
   new create(env: Env) =>
-    let caps = recover val FileCaps.set(FileRead).set(FileStat) end
+    let caps = recover val FileCaps.>set(FileRead).>set(FileStat) end
 
     try
       with file = OpenFile(

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -133,7 +133,7 @@ actor Updater
     _output = _output.create(updaters)
 
     let size = 1 << loglocal
-    _table = Array[U64].undefined(size)
+    _table = Array[U64].>undefined(size)
 
     var offset = index * size
 
@@ -222,7 +222,7 @@ primitive PolyRand
       return 1
     end
 
-    var m2 = Array[U64].undefined(64)
+    var m2 = Array[U64].>undefined(64)
     var temp = U64(1)
 
     try

--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -13,8 +13,8 @@ actor Main
     let sslctx = try
       recover
         SSLContext
-          .set_client_verify(true)
-          .set_authority(FilePath(env.root as AmbientAuth, "cacert.pem"))
+          .>set_client_verify(true)
+          .>set_authority(FilePath(env.root as AmbientAuth, "cacert.pem"))
       end
     end
 

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -12,8 +12,8 @@ actor Worker
         Array[U8]((y - x) * (width >> 3))
       end
 
-    let group_r = Array[F32].undefined(8)
-    let group_i = Array[F32].undefined(8)
+    let group_r = Array[F32].>undefined(8)
+    let group_i = Array[F32].>undefined(8)
 
     var row = x
 

--- a/examples/n-body/n-body.pony
+++ b/examples/n-body/n-body.pony
@@ -121,11 +121,11 @@ actor Main
 
     // Initial system
     system
-      .push(sun)
-      .push(Body.jupiter())
-      .push(Body.saturn())
-      .push(Body.uranus())
-      .push(Body.neptune())
+      .>push(sun)
+      .>push(Body.jupiter())
+      .>push(Body.saturn())
+      .>push(Body.uranus())
+      .>push(Body.neptune())
 
     offset_momentum()
     print_energy()

--- a/examples/net/listener.pony
+++ b/examples/net/listener.pony
@@ -19,12 +19,12 @@ class Listener is TCPListenNotify
         let auth = env.root as AmbientAuth
         recover
           SSLContext
-            .set_authority(FilePath(auth, "./test/pony/net/cert.pem"))
-            .set_cert(
+            .>set_authority(FilePath(auth, "./test/pony/net/cert.pem"))
+            .>set_cert(
               FilePath(auth, "./test/pony/net/cert.pem"),
               FilePath(auth, "./test/pony/net/key.pem"))
-            .set_client_verify(true)
-            .set_server_verify(true)
+            .>set_client_verify(true)
+            .>set_server_verify(true)
         end
       end
     end

--- a/packages/buffered/_test.pony
+++ b/packages/buffered/_test.pony
@@ -101,15 +101,15 @@ class iso _TestWriter is UnitTest
     let b = Reader
     let wb: Writer ref = Writer
 
-    wb.u8(0x42)
-      .u16_be(0xDEAD)
-      .u16_le(0xDEAD)
-      .u32_be(0xDEADBEEF)
-      .u32_le(0xDEADBEEF)
-      .u64_be(0xDEADBEEFFEEDFACE)
-      .u64_le(0xDEADBEEFFEEDFACE)
-      .u128_be(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
-      .u128_le(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+    wb.>u8(0x42)
+      .>u16_be(0xDEAD)
+      .>u16_le(0xDEAD)
+      .>u32_be(0xDEADBEEF)
+      .>u32_le(0xDEADBEEF)
+      .>u64_be(0xDEADBEEFFEEDFACE)
+      .>u64_le(0xDEADBEEFFEEDFACE)
+      .>u128_be(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
+      .>u128_le(0xDEADBEEFFEEDFACEDEADBEEFFEEDFACE)
 
     wb.write(recover [as U8: 'h', 'i'] end)
     wb.writev(recover [as Array[U8]: [as U8: '\n', 't', 'h', 'e'],

--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -72,23 +72,21 @@ class Reader
     """
     _available
 
-  fun ref clear(): Reader^ =>
+  fun ref clear() =>
     """
     Discard all pending data.
     """
     _chunks.clear()
     _available = 0
-    this
 
-  fun ref append(data: Array[U8] val): Reader^ =>
+  fun ref append(data: Array[U8] val) =>
     """
     Add a chunk of data.
     """
     _available = _available + data.size()
     _chunks.push((data, 0))
-    this
 
-  fun ref skip(n: USize): Reader^ ? =>
+  fun ref skip(n: USize) ? =>
     """
     Skip n bytes.
     """
@@ -110,7 +108,6 @@ class Reader
         _chunks.shift()
       end
 
-      this
     else
       error
     end
@@ -124,7 +121,7 @@ class Reader
     end
 
     _available = _available - len
-    var out = recover Array[U8].undefined(len) end
+    var out = recover Array[U8].>undefined(len) end
     var i = USize(0)
 
     while i < len do

--- a/packages/buffered/writer.pony
+++ b/packages/buffered/writer.pony
@@ -58,7 +58,7 @@ class Writer
   var _offset: USize = 0
   var _size: USize = 0
 
-  fun ref reserve_chunks(size': USize): Writer^ =>
+  fun ref reserve_chunks(size': USize) =>
     """
     Reserve space for size' chunks.
 
@@ -66,57 +66,52 @@ class Writer
     as `done` resets the chunks.
     """
     _chunks.reserve(size')
-    this
 
-  fun ref reserve(size': USize): Writer^ =>
+  fun ref reserve(size': USize) =>
     """
     Reserve space for size additional bytes.
     """
     _current.undefined(_current.size() + size')
-    this
 
   fun size(): USize =>
     _size
 
-  fun ref u8(data: U8): Writer^ =>
+  fun ref u8(data: U8) =>
     """
     Write a byte to the buffer.
     """
     _check(1)
     _byte(data)
-    this
 
-  fun ref u16_le(data: U16): Writer^ =>
+  fun ref u16_le(data: U16) =>
     """
     Write a U16 to the buffer in little-endian byte order.
     """
     _check(2)
     _byte(data.u8())
     _byte((data >> 8).u8())
-    this
 
-  fun ref u16_be(data: U16): Writer^ =>
+  fun ref u16_be(data: U16) =>
     """
     Write a U16 to the buffer in big-endian byte order.
     """
     _check(2)
     _byte((data >> 8).u8())
     _byte(data.u8())
-    this
 
-  fun ref i16_le(data: I16): Writer^ =>
+  fun ref i16_le(data: I16) =>
     """
     Write an I16 to the buffer in little-endian byte order.
     """
     u16_le(data.u16())
 
-  fun ref i16_be(data: I16): Writer^ =>
+  fun ref i16_be(data: I16) =>
     """
     Write an I16 to the buffer in big-endian byte order.
     """
     u16_be(data.u16())
 
-  fun ref u32_le(data: U32): Writer^ =>
+  fun ref u32_le(data: U32) =>
     """
     Write a U32 to the buffer in little-endian byte order.
     """
@@ -125,9 +120,8 @@ class Writer
     _byte((data >> 8).u8())
     _byte((data >> 16).u8())
     _byte((data >> 24).u8())
-    this
 
-  fun ref u32_be(data: U32): Writer^ =>
+  fun ref u32_be(data: U32) =>
     """
     Write a U32 to the buffer in big-endian byte order.
     """
@@ -136,33 +130,32 @@ class Writer
     _byte((data >> 16).u8())
     _byte((data >> 8).u8())
     _byte(data.u8())
-    this
 
-  fun ref i32_le(data: I32): Writer^ =>
+  fun ref i32_le(data: I32) =>
     """
     Write an I32 to the buffer in little-endian byte order.
     """
     u32_le(data.u32())
 
-  fun ref i32_be(data: I32): Writer^ =>
+  fun ref i32_be(data: I32) =>
     """
     Write an I32 to the buffer in big-endian byte order.
     """
     u32_be(data.u32())
 
-  fun ref f32_le(data: F32): Writer^ =>
+  fun ref f32_le(data: F32) =>
     """
     Write an F32 to the buffer in little-endian byte order.
     """
     u32_le(data.bits())
 
-  fun ref f32_be(data: F32): Writer^ =>
+  fun ref f32_be(data: F32) =>
     """
     Write an F32 to the buffer in big-endian byte order.
     """
     u32_be(data.bits())
 
-  fun ref u64_le(data: U64): Writer^ =>
+  fun ref u64_le(data: U64) =>
     """
     Write a U64 to the buffer in little-endian byte order.
     """
@@ -175,9 +168,8 @@ class Writer
     _byte((data >> 40).u8())
     _byte((data >> 48).u8())
     _byte((data >> 56).u8())
-    this
 
-  fun ref u64_be(data: U64): Writer^ =>
+  fun ref u64_be(data: U64) =>
     """
     Write a U64 to the buffer in big-endian byte order.
     """
@@ -190,33 +182,32 @@ class Writer
     _byte((data >> 16).u8())
     _byte((data >> 8).u8())
     _byte(data.u8())
-    this
 
-  fun ref i64_le(data: I64): Writer^ =>
+  fun ref i64_le(data: I64) =>
     """
     Write an I64 to the buffer in little-endian byte order.
     """
     u64_le(data.u64())
 
-  fun ref i64_be(data: I64): Writer^ =>
+  fun ref i64_be(data: I64) =>
     """
     Write an I64 to the buffer in big-endian byte order.
     """
     u64_be(data.u64())
 
-  fun ref f64_le(data: F64): Writer^ =>
+  fun ref f64_le(data: F64) =>
     """
     Write an F64 to the buffer in little-endian byte order.
     """
     u64_le(data.bits())
 
-  fun ref f64_be(data: F64): Writer^ =>
+  fun ref f64_be(data: F64) =>
     """
     Write an F64 to the buffer in big-endian byte order.
     """
     u64_be(data.bits())
 
-  fun ref u128_le(data: U128): Writer^ =>
+  fun ref u128_le(data: U128) =>
     """
     Write a U128 to the buffer in little-endian byte order.
     """
@@ -237,9 +228,8 @@ class Writer
     _byte((data >> 104).u8())
     _byte((data >> 112).u8())
     _byte((data >> 120).u8())
-    this
 
-  fun ref u128_be(data: U128): Writer^ =>
+  fun ref u128_be(data: U128) =>
     """
     Write a U128 to the buffer in big-endian byte order.
     """
@@ -260,30 +250,28 @@ class Writer
     _byte((data >> 16).u8())
     _byte((data >> 8).u8())
     _byte(data.u8())
-    this
 
-  fun ref i128_le(data: I128): Writer^ =>
+  fun ref i128_le(data: I128) =>
     """
     Write an I128 to the buffer in little-endian byte order.
     """
     u128_le(data.u128())
 
-  fun ref i128_be(data: I128): Writer^ =>
+  fun ref i128_be(data: I128) =>
     """
     Write an I128 to the buffer in big-endian byte order.
     """
     u128_be(data.u128())
 
-  fun ref write(data: ByteSeq): Writer^ =>
+  fun ref write(data: ByteSeq) =>
     """
     Write a ByteSeq to the buffer.
     """
     _append_current()
     _chunks.push(data)
     _size = _size + data.size()
-    this
 
-  fun ref writev(data: ByteSeqIter): Writer^ =>
+  fun ref writev(data: ByteSeqIter) =>
     """
     Write ByteSeqs to the buffer.
     """
@@ -292,7 +280,6 @@ class Writer
       _chunks.push(chunk)
       _size = _size + chunk.size()
     end
-    this
 
   fun ref done(): Array[ByteSeq] iso^ =>
     """

--- a/packages/builtin/_to_string.pony
+++ b/packages/builtin/_to_string.pony
@@ -22,7 +22,7 @@ primitive _ToString
       end
 
       if neg then s.push('-') end
-      s.reverse_in_place()
+      s.>reverse_in_place()
     end
 
   fun _u128(x: U128, neg: Bool): String iso^ =>
@@ -45,13 +45,13 @@ primitive _ToString
       end
 
       if neg then s.push('-') end
-      s.reverse_in_place()
+      s.>reverse_in_place()
     end
 
   fun _f64(x: F64): String iso^ =>
     recover
       var s = String(31)
-      var f = String(31).append("%g")
+      var f = String(31).>append("%g")
 
       ifdef windows then
         @_snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
@@ -59,5 +59,5 @@ primitive _ToString
         @snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
       end
 
-      s.recalc()
+      s.>recalc()
     end

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -81,7 +81,7 @@ class Array[A] is Seq[A]
     """
     _alloc
 
-  fun ref reserve(len: USize): Array[A]^ =>
+  fun ref reserve(len: USize) =>
     """
     Reserve space for len elements, including whatever elements are already in
     the array. Array space grows geometrically.
@@ -90,12 +90,11 @@ class Array[A] is Seq[A]
       _alloc = len.next_pow2().max(len).max(8)
       _ptr = _ptr._realloc(_alloc)
     end
-    this
 
-  fun ref compact(): Array[A]^ =>
+  fun ref compact() =>
     """
     Try to remove unused space, making it available for garbage collection. The
-    request may be ignored. The array is returned to allow call chaining.
+    request may be ignored.
     """
     if _size <= (512 / _ptr._element_size()) then
       if _size.next_pow2() != _alloc.next_pow2() then
@@ -108,17 +107,14 @@ class Array[A] is Seq[A]
       let old_ptr = _ptr = Pointer[A]._alloc(_alloc)
       _ptr._consume_from(consume old_ptr, _size)
     end
-    this
 
-  fun ref undefined[B: (A & Real[B] val & Number) = A](len: USize): Array[A]^
-  =>
+  fun ref undefined[B: (A & Real[B] val & Number) = A](len: USize) =>
     """
     Resize to len elements, populating previously empty elements with random
     memory. This is only allowed for an array of numbers.
     """
     reserve(len)
     _size = len
-    this
 
   fun apply(i: USize): this->A ? =>
     """
@@ -140,19 +136,17 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun ref insert(i: USize, value: A): Array[A]^ ? =>
+  fun ref insert(i: USize, value: A) ? =>
     """
     Insert an element into the array. Elements after this are moved up by one
     index, extending the array.
     An out of bounds index raises an error.
-    The array is returned to allow call chaining.
     """
     if i <= _size then
       reserve(_size + 1)
       _ptr._offset(i)._insert(1, _size - i)
       _ptr._update(i, consume value)
       _size = _size + 1
-      this
     else
       error
     end
@@ -171,20 +165,17 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun ref truncate(len: USize): Array[A]^ =>
+  fun ref truncate(len: USize) =>
     """
     Truncate an array to the given length, discarding excess elements. If the
     array is already smaller than len, do nothing.
-    The array is returned to allow call chaining.
     """
     _size = _size.min(len)
-    this
 
-  fun ref trim_in_place(from: USize = 0, to: USize = -1): Array[A]^ =>
+  fun ref trim_in_place(from: USize = 0, to: USize = -1) =>
     """
     Trim the array to a portion of itself, covering `from` until `to`.
     Unlike slice, the operation does not allocate a new array nor copy elements.
-    The same array is returned to allow call chaining.
     """
     let last = _size.min(to)
     let offset = last.min(from)
@@ -192,8 +183,6 @@ class Array[A] is Seq[A]
     _size = last - offset
     _alloc = _alloc - offset
     _ptr = if _size > 0 then _ptr._offset(offset) else _ptr.create() end
-
-    this
 
   fun val trim(from: USize = 0, to: USize = -1): Array[A] val =>
     """
@@ -216,11 +205,10 @@ class Array[A] is Seq[A]
     end
 
   fun copy_to(dst: Array[this->A!], src_idx: USize, dst_idx: USize,
-    len: USize): this->Array[A]^
+    len: USize)
   =>
     """
     Copy len elements from this(src_idx) to dst(dst_idx).
-    The array is returned to allow call chaining.
     """
     dst.reserve(dst_idx + len)
     _ptr._offset(src_idx)._copy_to(dst._ptr._offset(dst_idx), len)
@@ -228,37 +216,30 @@ class Array[A] is Seq[A]
     if dst._size < (dst_idx + len) then
       dst._size = dst_idx + len
     end
-    this
 
-  fun ref remove(i: USize, n: USize): Array[A]^ =>
+  fun ref remove(i: USize, n: USize) =>
     """
     Remove n elements from the array, beginning at index i.
-    The array is returned to allow call chaining.
     """
     if i < _size then
       let count = n.min(_size - i)
       _size = _size - count
       _ptr._offset(i)._delete(count, _size - i)
     end
-    this
 
-  fun ref clear(): Array[A]^ =>
+  fun ref clear() =>
     """
     Remove all elements from the array.
-    The array is returned to allow call chaining.
     """
     _size = 0
-    this
 
-  fun ref push(value: A): Array[A]^ =>
+  fun ref push(value: A) =>
     """
     Add an element to the end of the array.
-    The array is returned to allow call chaining.
     """
     reserve(_size + 1)
     _ptr._update(_size, consume value)
     _size = _size + 1
-    this
 
   fun ref pop(): A^ ? =>
     """
@@ -267,15 +248,13 @@ class Array[A] is Seq[A]
     """
     delete(_size - 1)
 
-  fun ref unshift(value: A): Array[A]^ =>
+  fun ref unshift(value: A) =>
     """
     Add an element to the beginning of the array.
-    The array is returned to allow call chaining.
     """
     try
       insert(0, consume value)
     end
-    this
 
   fun ref shift(): A^ ? =>
     """
@@ -285,14 +264,13 @@ class Array[A] is Seq[A]
     delete(0)
 
   fun ref append(seq: (ReadSeq[A] & ReadElement[A^]), offset: USize = 0,
-    len: USize = -1): Array[A]^
+    len: USize = -1)
   =>
     """
     Append the elements from a sequence, starting from the given offset.
-    The array is returned to allow call chaining.
     """
     if offset >= seq.size() then
-      return this
+      return
     end
 
     let copy_len = len.min(seq.size() - offset)
@@ -310,14 +288,10 @@ class Array[A] is Seq[A]
 
     _size = _size + n
 
-    this
-
-  fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1)
-    : Array[A]^
-  =>
+  fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1) =>
     """
     Add len iterated elements to the end of the array, starting from the given
-    offset. The array is returned to allow call chaining.
+    offset.
     """
 
     var n = USize(0)
@@ -327,7 +301,7 @@ class Array[A] is Seq[A]
         if iter.has_next() then
           iter.next()
         else
-          return this
+          return
         end
 
         n = n + 1
@@ -369,8 +343,6 @@ class Array[A] is Seq[A]
         end
       end
     end
-
-    this
 
   fun find(value: A!, offset: USize = 0, nth: USize = 0,
     predicate: {(box->A!, box->A!): Bool} val =
@@ -511,9 +483,9 @@ class Array[A] is Seq[A]
     The new array contains references to the same elements that the old array
     contains, the elements themselves are not copied.
     """
-    clone().reverse_in_place()
+    clone().>reverse_in_place()
 
-  fun ref reverse_in_place(): Array[A] ref^ =>
+  fun ref reverse_in_place() =>
     """
     Reverse the array in place.
     """
@@ -529,7 +501,6 @@ class Array[A] is Seq[A]
         j = j - 1
       end
     end
-    this
 
   fun keys(): ArrayKeys[A, this->Array[A]]^ =>
     """

--- a/packages/builtin/seq.pony
+++ b/packages/builtin/seq.pony
@@ -7,7 +7,7 @@ interface Seq[A]
     Create a sequence, reserving space for len elements.
     """
 
-  fun ref reserve(len: USize): Seq[A]^
+  fun ref reserve(len: USize)
     """
     Reserve space for len elements.
     """
@@ -29,12 +29,12 @@ interface Seq[A]
     Raises an error if the index is out of bounds.
     """
 
-  fun ref clear(): Seq[A]^
+  fun ref clear()
     """
     Removes all elements from the sequence.
     """
 
-  fun ref push(value: A): Seq[A]^
+  fun ref push(value: A)
     """
     Adds an element to the end of the sequence.
     """
@@ -44,7 +44,7 @@ interface Seq[A]
     Removes an element from the end of the sequence.
     """
 
-  fun ref unshift(value: A): Seq[A]^
+  fun ref unshift(value: A)
     """
     Adds an element to the beginning of the sequence.
     """
@@ -55,20 +55,19 @@ interface Seq[A]
     """
 
   fun ref append(seq: (ReadSeq[A] & ReadElement[A^]), offset: USize = 0,
-    len: USize = -1): Seq[A]^
+    len: USize = -1)
     """
     Add len elements to the end of the list, starting from the given
     offset.
     """
 
   fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1)
-    : Seq[A]^
     """
     Add len iterated elements to the end of the list, starting from the given
     offset.
     """
 
-  fun ref truncate(len: USize): Seq[A]^
+  fun ref truncate(len: USize)
     """
     Truncate the sequence to the given length, discarding excess elements.
     If the sequence is already smaller than len, do nothing.

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -113,7 +113,7 @@ actor Stdin
 
       while true do
         let chunk_size = _chunk_size
-        var data = recover Array[U8].undefined(chunk_size) end
+        var data = recover Array[U8].>undefined(chunk_size) end
         var again: Bool = false
 
         let len = @pony_os_stdin_read[USize](data.cpointer(), data.space(),

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -264,7 +264,7 @@ actor Main
     """
     if is_null_terminated() then _alloc - 1 else _alloc end
 
-  fun ref reserve(len: USize): String ref^ =>
+  fun ref reserve(len: USize) =>
     """
     Reserve space for len bytes. An additional byte will be reserved for the
     null terminator.
@@ -279,9 +279,8 @@ actor Main
       end
       _ptr = _ptr._realloc(_alloc)
     end
-    this
 
-  fun ref compact(): String ref^ =>
+  fun ref compact() =>
     """
     Try to remove unused space, making it available for garbage collection. The
     request may be ignored. The string is returned to allow call chaining.
@@ -299,9 +298,8 @@ actor Main
       _ptr._consume_from(consume old_ptr, _size)
       _set(_size, 0)
     end
-    this
 
-  fun ref recalc(): String ref^ =>
+  fun ref recalc() =>
     """
     Recalculates the string length. This is only needed if the string is
     changed via an FFI call. If a null terminator byte is not found within the
@@ -317,9 +315,7 @@ actor Main
       _size = s
     end
 
-    this
-
-  fun ref truncate(len: USize): String ref^ =>
+  fun ref truncate(len: USize) =>
     """
     Truncates the string at the minimum of len and space. Ensures there is a
     null terminator. Does not check for null terminators inside the string.
@@ -335,13 +331,10 @@ actor Main
 
     _set(_size, 0)
 
-    this
-
-  fun ref trim_in_place(from: USize = 0, to: USize = -1): String ref^ =>
+  fun ref trim_in_place(from: USize = 0, to: USize = -1) =>
     """
     Trim the string to a portion of itself, covering `from` until `to`.
     Unlike slice, the operation does not allocate a new string nor copy elements.
-    The same string is returned to allow call chaining.
     """
     let last = _size.min(to)
     let offset = last.min(from)
@@ -349,8 +342,6 @@ actor Main
     _size = last - offset
     _alloc = _alloc - offset
     _ptr = if _size > 0 then _ptr._offset(offset) else _ptr.create() end
-
-    this
 
   fun val trim(from: USize = 0, to: USize = -1): String val =>
     """
@@ -634,7 +625,7 @@ actor Main
       false
     end
 
-  fun ref delete(offset: ISize, len: USize = 1): String ref^ =>
+  fun ref delete(offset: ISize, len: USize = 1) =>
     """
     Delete len bytes at the supplied offset, compacting the string in place.
     """
@@ -646,7 +637,6 @@ actor Main
       _ptr._offset(i)._delete(n, _size - i)
       _set(_size, 0)
     end
-    this
 
   fun substring(from: ISize, to: ISize = ISize.max_value()): String iso^ =>
     """
@@ -675,7 +665,7 @@ actor Main
     s.lower_in_place()
     s
 
-  fun ref lower_in_place(): String ref^ =>
+  fun ref lower_in_place() =>
     """
     Transforms the string to lower case. Currently only knows ASCII case.
     """
@@ -690,7 +680,6 @@ actor Main
 
       i = i + 1
     end
-    this
 
   fun upper(): String iso^ =>
     """
@@ -701,7 +690,7 @@ actor Main
     s.upper_in_place()
     s
 
-  fun ref upper_in_place(): String ref^ =>
+  fun ref upper_in_place() =>
     """
     Transforms the string to upper case.
     """
@@ -716,7 +705,6 @@ actor Main
 
       i = i + 1
     end
-    this
 
   fun reverse(): String iso^ =>
     """
@@ -726,7 +714,7 @@ actor Main
     s.reverse_in_place()
     s
 
-  fun ref reverse_in_place(): String ref^ =>
+  fun ref reverse_in_place() =>
     """
     Reverses the byte order in the string. This needs to be changed to handle
     UTF-8 correctly.
@@ -743,9 +731,8 @@ actor Main
         j = j - 1
       end
     end
-    this
 
-  fun ref push(value: U8): String ref^ =>
+  fun ref push(value: U8) =>
     """
     Add a byte to the end of the string.
     """
@@ -753,7 +740,6 @@ actor Main
     _set(_size, value)
     _size = _size + 1
     _set(_size, 0)
-    this
 
   fun ref pop(): U8 ? =>
     """
@@ -766,7 +752,7 @@ actor Main
       error
     end
 
-  fun ref unshift(value: U8): String ref^ =>
+  fun ref unshift(value: U8) =>
     """
     Adds a byte to the beginning of the string.
     """
@@ -779,8 +765,6 @@ actor Main
       _set(0, 0)
       _size = 0
     end
-
-    this
 
   fun ref shift(): U8 ? =>
     """
@@ -795,14 +779,12 @@ actor Main
       error
     end
 
-  fun ref append(seq: ReadSeq[U8], offset: USize = 0, len: USize = -1)
-    : String ref^
-  =>
+  fun ref append(seq: ReadSeq[U8], offset: USize = 0, len: USize = -1) =>
     """
     Append the elements from a sequence, starting from the given offset.
     """
     if offset >= seq.size() then
-      return this
+      return
     end
 
     let copy_len = len.min(seq.size() - offset)
@@ -825,14 +807,10 @@ actor Main
       end
     end
 
-    this
-
-  fun ref concat(iter: Iterator[U8], offset: USize = 0, len: USize = -1)
-    : String ref^
-  =>
+  fun ref concat(iter: Iterator[U8], offset: USize = 0, len: USize = -1) =>
     """
     Add len iterated bytes to the end of the string, starting from the given
-    offset. The string is returned to allow call chaining.
+    offset.
     """
     try
       var n = USize(0)
@@ -841,7 +819,7 @@ actor Main
         if iter.has_next() then
           iter.next()
         else
-          return this
+          return
         end
 
         n = n + 1
@@ -853,20 +831,17 @@ actor Main
         if iter.has_next() then
           push(iter.next())
         else
-          return this
+          return
         end
       end
     end
 
-    this
-
-  fun ref clear(): String ref^ =>
+  fun ref clear() =>
     """
     Truncate the string to zero length.
     """
     _set(0, 0)
     _size = 0
-    this
 
   fun insert(offset: ISize, that: String): String iso^ =>
     """
@@ -877,7 +852,7 @@ actor Main
     s.insert_in_place(offset, that)
     s
 
-  fun ref insert_in_place(offset: ISize, that: String box): String ref^ =>
+  fun ref insert_in_place(offset: ISize, that: String box) =>
     """
     Inserts the given string at the given offset. Appends the string if the
     offset is out of bounds.
@@ -889,9 +864,8 @@ actor Main
     that._ptr._copy_to(_ptr._offset(index), that._size)
     _size = _size + that._size
     _set(_size, 0)
-    this
 
-  fun ref insert_byte(offset: ISize, value: U8): String ref^ =>
+  fun ref insert_byte(offset: ISize, value: U8) =>
     """
     Inserts a byte at the given offset. Appends if the offset is out of bounds.
     """
@@ -902,7 +876,6 @@ actor Main
     _set(index, value)
     _size = _size + 1
     _set(_size, 0)
-    this
 
   fun cut(from: ISize, to: ISize = ISize.max_value()): String iso^ =>
     """
@@ -913,8 +886,7 @@ actor Main
     s.cut_in_place(from, to)
     s
 
-  fun ref cut_in_place(from: ISize, to: ISize = ISize.max_value()): String ref^
-  =>
+  fun ref cut_in_place(from: ISize, to: ISize = ISize.max_value()) =>
     """
     Cuts the given range out of the string.
     Index range [`from` .. `to`) is half-open.
@@ -935,7 +907,6 @@ actor Main
       _size = _size - fragment_len
       _set(_size, 0)
     end
-    this
 
   fun ref remove(s: String box): USize =>
     """
@@ -954,12 +925,10 @@ actor Main
     end
     n
 
-  fun ref replace(from: String box, to: String box, n: USize = 0):
-    String ref^
-  =>
+  fun ref replace(from: String box, to: String box, n: USize = 0): USize =>
     """
     Replace up to n occurrences of `from` in `this` with `to`. If n is 0, all
-    occurrences will be replaced.
+    occurrences will be replaced. Returns the count of replaced occurrences.
     """
     let from_len = from.size().isize()
     let to_len = to.size().isize()
@@ -979,7 +948,7 @@ actor Main
         end
       end
     end
-    this
+    occur
 
   fun split_by(delim: String, n: USize = USize.max_value()): Array[String] iso^ =>
     """
@@ -1068,13 +1037,13 @@ actor Main
 
     consume result
 
-  fun ref strip(s: String box = " \t\v\f\r\n"): String ref^ =>
+  fun ref strip(s: String box = " \t\v\f\r\n") =>
     """
     Remove all leading and trailing characters from the string that are in s.
     """
-    lstrip(s).rstrip(s)
+    this.>lstrip(s).>rstrip(s)
 
-  fun ref rstrip(s: String box = " \t\v\f\r\n"): String ref^ =>
+  fun ref rstrip(s: String box = " \t\v\f\r\n") =>
     """
     Remove all trailing characters within the string that are in s. By default,
     trailing whitespace is removed.
@@ -1104,9 +1073,7 @@ actor Main
       truncate(i + 1)
     end
 
-    this
-
-  fun ref lstrip(s: String box = " \t\v\f\r\n"): String ref^ =>
+  fun ref lstrip(s: String box = " \t\v\f\r\n") =>
     """
     Remove all leading characters within the string that are in s. By default,
     leading whitespace is removed.
@@ -1135,8 +1102,6 @@ actor Main
         delete(0, i)
       end
     end
-
-    this
 
   fun iso _append(s: String box): String iso^ =>
     reserve(s._size + _size)

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -303,10 +303,10 @@ class iso _TestStringLstrip is UnitTest
   fun name(): String => "builtin/String.lstrip"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String](recover "foobar".clone().lstrip("foo") end, "bar")
-    h.assert_eq[String](recover "fooooooobar".clone().lstrip("foo") end, "bar")
-    h.assert_eq[String](recover "   foobar".clone().lstrip() end, "foobar")
-    h.assert_eq[String](recover "  foobar  ".clone().lstrip() end, "foobar  ")
+    h.assert_eq[String](recover "foobar".clone().>lstrip("foo") end, "bar")
+    h.assert_eq[String](recover "fooooooobar".clone().>lstrip("foo") end, "bar")
+    h.assert_eq[String](recover "   foobar".clone().>lstrip() end, "foobar")
+    h.assert_eq[String](recover "  foobar  ".clone().>lstrip() end, "foobar  ")
 
 
 class iso _TestStringRstrip is UnitTest
@@ -316,10 +316,10 @@ class iso _TestStringRstrip is UnitTest
   fun name(): String => "builtin/String.rstrip"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String](recover "foobar".clone().rstrip("bar") end, "foo")
-    h.assert_eq[String](recover "foobaaaaaar".clone().rstrip("bar") end, "foo")
-    h.assert_eq[String](recover "foobar  ".clone().rstrip() end, "foobar")
-    h.assert_eq[String](recover "  foobar  ".clone().rstrip() end, "  foobar")
+    h.assert_eq[String](recover "foobar".clone().>rstrip("bar") end, "foo")
+    h.assert_eq[String](recover "foobaaaaaar".clone().>rstrip("bar") end, "foo")
+    h.assert_eq[String](recover "foobar  ".clone().>rstrip() end, "foobar")
+    h.assert_eq[String](recover "  foobar  ".clone().>rstrip() end, "  foobar")
 
 
 class iso _TestStringStrip is UnitTest
@@ -329,10 +329,10 @@ class iso _TestStringStrip is UnitTest
   fun name(): String => "builtin/String.strip"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String](recover "  foobar  ".clone().strip() end, "foobar")
-    h.assert_eq[String](recover "barfoobar".clone().strip("bar") end, "foo")
-    h.assert_eq[String](recover "foobarfoo".clone().strip("foo") end, "bar")
-    h.assert_eq[String](recover "foobarfoo".clone().strip("bar") end,
+    h.assert_eq[String](recover "  foobar  ".clone().>strip() end, "foobar")
+    h.assert_eq[String](recover "barfoobar".clone().>strip("bar") end, "foo")
+    h.assert_eq[String](recover "foobarfoo".clone().>strip("foo") end, "bar")
+    h.assert_eq[String](recover "foobarfoo".clone().>strip("bar") end,
       "foobarfoo")
 
 
@@ -522,7 +522,7 @@ class iso _TestStringReplace is UnitTest
   fun name(): String => "builtin/String.replace"
 
   fun apply(h: TestHelper) =>
-    let s = String.append("this is a robbery, this is a stickup")
+    let s = String.>append("this is a robbery, this is a stickup")
     s.replace("is a", "is not a")
     h.assert_eq[String box](s, "this is not a robbery, this is not a stickup")
 

--- a/packages/builtin_test/_test_valtrace.pony
+++ b/packages/builtin_test/_test_valtrace.pony
@@ -18,7 +18,7 @@ actor _Valtrace
     Create a String iso, send it to a new actor.
     """
     @pony_triggergc[None](this)
-    let s = recover String.append("test") end
+    let s = recover String.>append("test") end
     _Valtrace.two(this, h, consume s)
 
   be two(a1: _Valtrace, h: TestHelper, s: String iso) =>

--- a/packages/capsicum/cap_rights.pony
+++ b/packages/capsicum/cap_rights.pony
@@ -57,17 +57,15 @@ class CapRights0
       @__cap_rights_get[I32](_version(), fd, addressof _r0)
     end
 
-  fun ref set(cap: U64): CapRights0^ =>
+  fun ref set(cap: U64) =>
     ifdef freebsd or "capsicum" then
       @__cap_rights_set[None](addressof _r0, cap, U64(0))
     end
-    this
 
-  fun ref unset(cap: U64): CapRights0^ =>
+  fun ref unset(cap: U64) =>
     ifdef freebsd or "capsicum" then
       @__cap_rights_clear[None](addressof _r0, cap, U64(0))
     end
-    this
 
   fun limit(fd: I32): Bool =>
     """

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -31,7 +31,7 @@ class iso _TestList is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2)
+    a.>push(0).>push(1).>push(2)
 
     let b = a.clone()
     h.assert_eq[USize](b.size(), 3)
@@ -193,14 +193,14 @@ class iso _TestRing is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = RingBuffer[U64](4)
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     h.assert_eq[U64](a(0), 0)
     h.assert_eq[U64](a(1), 1)
     h.assert_eq[U64](a(2), 2)
     h.assert_eq[U64](a(3), 3)
 
-    a.push(4).push(5)
+    a.>push(4).>push(5)
 
     h.assert_error({()(a)? => a(0) }, "Read ring 0")
     h.assert_error({()(a)? => a(1) }, "Read ring 1")
@@ -217,7 +217,7 @@ class iso _TestListsMap is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2)
+    a.>push(0).>push(1).>push(2)
 
     let f = {(a: U32): U32 => a * 2 }
     let c = a.map[U32](f)
@@ -232,9 +232,9 @@ class iso _TestListsFlatMap is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2)
+    a.>push(0).>push(1).>push(2)
 
-    let f = {(a: U32): List[U32] => List[U32].push(a).push(a * 2) }
+    let f = {(a: U32): List[U32] => List[U32].>push(a).>push(a * 2) }
     let c = a.flat_map[U32](f)
 
     h.assert_eq[USize](c.size(), 6)
@@ -250,7 +250,7 @@ class iso _TestListsFilter is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     let f = {(a: U32): Bool => a > 1 }
     let b = a.filter(f)
@@ -264,14 +264,14 @@ class iso _TestListsFold is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     let f = {(acc: U32, x: U32): U32 => acc + x }
     let value = a.fold[U32](f, 0)
 
     h.assert_eq[U32](value, 6)
 
-    let g = {(acc: List[U32], x: U32): List[U32] => acc.push(x * 2) }
+    let g = {(acc: List[U32], x: U32): List[U32] => acc.>push(x * 2) }
     let resList = a.fold[List[U32]](g, List[U32])
 
     h.assert_eq[USize](resList.size(), 4)
@@ -285,7 +285,7 @@ class iso _TestListsEvery is UnitTest
 
   fun apply(h: TestHelper) =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     let f = {(x: U32): Bool => x < 4 }
     let g = {(x: U32): Bool => x < 3 }
@@ -307,7 +307,7 @@ class iso _TestListsExists is UnitTest
 
   fun apply(h: TestHelper) =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     let f = {(x: U32): Bool => x > 2 }
     let g = {(x: U32): Bool => x >= 0 }
@@ -329,7 +329,7 @@ class iso _TestListsPartition is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3)
+    a.>push(0).>push(1).>push(2).>push(3)
 
     let isEven = {(x: U32): Bool => (x % 2) == 0 }
     (let evens, let odds) = a.partition(isEven)
@@ -352,7 +352,7 @@ class iso _TestListsDrop is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3).push(4)
+    a.>push(0).>push(1).>push(2).>push(3).>push(4)
 
     let b = a.drop(2)
     let c = a.drop(4)
@@ -376,7 +376,7 @@ class iso _TestListsTake is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3).push(4)
+    a.>push(0).>push(1).>push(2).>push(3).>push(4)
 
     let b = a.take(2)
     let c = a.take(4)
@@ -415,7 +415,7 @@ class iso _TestListsTakeWhile is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2).push(3).push(4)
+    a.>push(0).>push(1).>push(2).>push(3).>push(4)
 
     let f = {(x: U32): Bool => x < 5 }
     let g = {(x: U32): Bool => x < 4 }
@@ -450,7 +450,7 @@ class iso _TestListsContains is UnitTest
 
   fun apply(h: TestHelper) =>
     let a = List[U32]
-    a.push(0).push(1).push(2)
+    a.>push(0).>push(1).>push(2)
 
     h.assert_eq[Bool](a.contains(0), true)
     h.assert_eq[Bool](a.contains(1), true)
@@ -462,7 +462,7 @@ class iso _TestListsReverse is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let a = List[U32]
-    a.push(0).push(1).push(2)
+    a.>push(0).>push(1).>push(2)
 
     let b = a.reverse()
 
@@ -481,7 +481,7 @@ class iso _TestHashSetContains is UnitTest
 
   fun apply(h: TestHelper) =>
     let a = Set[U32]
-    a.set(0).set(1)
+    a.>set(0).>set(1)
 
     let not_found_fail = "contains did not find expected element in HashSet"
     let found_fail = "contains found unexpected element in HashSet"

--- a/packages/collections/flag.pony
+++ b/packages/collections/flag.pony
@@ -39,68 +39,59 @@ class Flags[A: Flag[B] val, B: (Unsigned & Integer[B] val) = U64] is
     """
     (_value and flag.value()) > 0
 
-  fun ref all(): Flags[A, B]^ =>
+  fun ref all() =>
     """
     Sets all bits, including undefined flags.
     """
     _value = -1
-    this
 
-  fun ref clear(): Flags[A, B]^ =>
+  fun ref clear() =>
     """
     Unsets all flags.
     """
     _value = 0
-    this
 
-  fun ref set(flag: A): Flags[A, B]^ =>
+  fun ref set(flag: A) =>
     """
     Sets the flag.
     """
     _value = _value or flag.value()
-    this
 
-  fun ref unset(flag: A): Flags[A, B]^ =>
+  fun ref unset(flag: A) =>
     """
     Unsets the flag.
     """
     _value = _value and not flag.value()
-    this
 
-  fun ref flip(flag: A): Flags[A, B]^ =>
+  fun ref flip(flag: A) =>
     """
     Sets the flag if it is unset, unsets the flag if it is set.
     """
     _value = _value xor flag.value()
-    this
 
-  fun ref union(that: Flags[A, B] box): Flags[A, B]^ =>
+  fun ref union(that: Flags[A, B] box) =>
     """
     The union of this and that.
     """
     _value = this._value or that._value
-    this
 
-  fun ref intersect(that: Flags[A, B] box): Flags[A, B]^ =>
+  fun ref intersect(that: Flags[A, B] box) =>
     """
     The intersection of this and that.
     """
     _value = this._value and that._value
-    this
 
-  fun ref difference(that: Flags[A, B] box): Flags[A, B]^ =>
+  fun ref difference(that: Flags[A, B] box) =>
     """
     The symmetric difference of this and that.
     """
     _value = this._value xor that._value
-    this
 
-  fun ref remove(that: Flags[A, B] box): Flags[A, B]^ =>
+  fun ref remove(that: Flags[A, B] box) =>
     """
     Unset flags that are set in that.
     """
     _value = this._value xor that._value
-    this
 
   fun add(flag: A): Flags[A, B] iso^ =>
     """

--- a/packages/collections/list.pony
+++ b/packages/collections/list.pony
@@ -26,11 +26,11 @@ class List[A] is Seq[A]
       push(consume value)
     end
 
-  fun ref reserve(len: USize): List[A]^ =>
+  fun ref reserve(len: USize) =>
     """
     Do nothing, but be compatible with Seq.
     """
-    this
+    None
 
   fun size(): USize =>
     """
@@ -70,21 +70,20 @@ class List[A] is Seq[A]
 
     node
 
-  fun ref remove(i: USize): List[A]^ ? =>
+  fun ref remove(i: USize): ListNode[A] ? =>
     """
     Remove the i-th node, raising an error if the index is out of bounds.
+    The removed node is returned.
     """
-    index(i).remove()
-    this
+    index(i).>remove()
 
-  fun ref clear(): List[A]^ =>
+  fun ref clear() =>
     """
     Empties the list.
     """
     _head = None
     _tail = None
     _size = 0
-    this
 
   fun head(): this->ListNode[A] ? =>
     """
@@ -98,7 +97,7 @@ class List[A] is Seq[A]
     """
     _tail as this->ListNode[A]
 
-  fun ref prepend_node(node: ListNode[A]): List[A]^ =>
+  fun ref prepend_node(node: ListNode[A]) =>
     """
     Adds a node to the head of the list.
     """
@@ -108,9 +107,8 @@ class List[A] is Seq[A]
     else
       _set_both(node)
     end
-    this
 
-  fun ref append_node(node: ListNode[A]): List[A]^ =>
+  fun ref append_node(node: ListNode[A]) =>
     """
     Adds a node to the tail of the list.
     """
@@ -120,9 +118,8 @@ class List[A] is Seq[A]
     else
       _set_both(node)
     end
-    this
 
-  fun ref append_list(that: List[A]): List[A]^ =>
+  fun ref append_list(that: List[A]) =>
     """
     Remove all nodes from that and append them to this.
     """
@@ -131,9 +128,8 @@ class List[A] is Seq[A]
         try append_node(that.head()) end
       end
     end
-    this
 
-  fun ref prepend_list(that: List[A]): List[A]^ =>
+  fun ref prepend_list(that: List[A]) =>
     """
     Remove all nodes from that and prepend them to this.
     """
@@ -142,9 +138,8 @@ class List[A] is Seq[A]
         try prepend_node(that.tail()) end
       end
     end
-    this
 
-  fun ref push(a: A): List[A]^ =>
+  fun ref push(a: A) =>
     """
     Adds a value to the tail of the list.
     """
@@ -154,9 +149,9 @@ class List[A] is Seq[A]
     """
     Removes a value from the tail of the list.
     """
-    tail().remove().pop()
+    tail().>remove().pop()
 
-  fun ref unshift(a: A): List[A]^ =>
+  fun ref unshift(a: A) =>
     """
     Adds a value to the head of the list.
     """
@@ -166,16 +161,16 @@ class List[A] is Seq[A]
     """
     Removes a value from the head of the list.
     """
-    head().remove().pop()
+    head().>remove().pop()
 
   fun ref append(seq: (ReadSeq[A] & ReadElement[A^]), offset: USize = 0,
-    len: USize = -1): List[A]^
+    len: USize = -1)
   =>
     """
     Append len elements from a sequence, starting from the given offset.
     """
     if offset >= seq.size() then
-      return this
+      return
     end
 
     let copy_len = len.min(seq.size() - offset)
@@ -191,11 +186,7 @@ class List[A] is Seq[A]
       end
     end
 
-    this
-
-  fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1)
-    : List[A]^
-  =>
+  fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1) =>
     """
     Add len iterated elements to the end of the list, starting from the given
     offset.
@@ -205,7 +196,7 @@ class List[A] is Seq[A]
         if iter.has_next() then
           iter.next()
         else
-          return this
+          return
         end
       end
 
@@ -213,14 +204,12 @@ class List[A] is Seq[A]
         if iter.has_next() then
           push(iter.next())
         else
-          return this
+          return
         end
       end
     end
 
-    this
-
-  fun ref truncate(len: USize): List[A]^ =>
+  fun ref truncate(len: USize) =>
     """
     Truncate the list to the given length, discarding excess elements.
     If the list is already smaller than len, do nothing.
@@ -230,8 +219,6 @@ class List[A] is Seq[A]
         pop()
       end
     end
-
-    this
 
   fun clone(): List[this->A!]^ =>
     """

--- a/packages/collections/list_node.pony
+++ b/packages/collections/list_node.pony
@@ -32,17 +32,21 @@ class ListNode[A]
     """
     (_item = None) as A^
 
-  fun ref prepend(that: ListNode[A]): ListNode[A]^ =>
+  fun ref prepend(that: ListNode[A]): Bool =>
     """
     Prepend a node to this one. If `that` is already in a list, it is removed
-    before it is prepended.
+    before it is prepended. Returns true if `that` was removed from another
+    list.
     """
     if (_prev is that) or (this is that) then
-      return this
+      return false
     end
+
+    var in_list = false
 
     match _list
     | let list': List[A] =>
+      in_list = that._list isnt None
       that.remove()
 
       match _prev
@@ -58,19 +62,23 @@ class ListNode[A]
       _prev = that
       list'._increment()
     end
-    this
+    in_list
 
-  fun ref append(that: ListNode[A]): ListNode[A]^ =>
+  fun ref append(that: ListNode[A]): Bool =>
     """
     Append a node to this one. If `that` is already in a list, it is removed
-    before it is appended.
+    before it is appended. Returns true if `that` was removed from another
+    list.
     """
     if (_next is that) or (this is that) then
-      return this
+      return false
     end
+
+    var in_list = false
 
     match _list
     | let list': List[A] =>
+      in_list = that._list isnt None
       that.remove()
 
       match _next
@@ -86,9 +94,9 @@ class ListNode[A]
       _next = that
       list'._increment()
     end
-    this
+    in_list
 
-  fun ref remove(): ListNode[A]^ =>
+  fun ref remove() =>
     """
     Remove a node from a list.
     """
@@ -120,7 +128,6 @@ class ListNode[A]
       list'._decrement()
       _list = None
     end
-    this
 
   fun has_prev(): Bool =>
     """

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -187,14 +187,13 @@ class HashMap[K, V, H: HashFunction[K] val]
     (_, let found) = _search(k)
     found
 
-  fun ref concat(iter: Iterator[(K^, V^)]): HashMap[K, V, H]^ =>
+  fun ref concat(iter: Iterator[(K^, V^)]) =>
     """
     Add K, V pairs from the iterator to the map.
     """
     for (k, v) in iter do
       this(consume k) = consume v
     end
-    this
 
   fun add[H2: HashFunction[this->K!] val = H](key: this->K!, value: this->V!):
     HashMap[this->K!, this->V!, H2]^
@@ -235,12 +234,11 @@ class HashMap[K, V, H: HashFunction[K] val]
     """
     _array(i) as (this->K, this->V)
 
-  fun ref compact(): HashMap[K, V, H]^ =>
+  fun ref compact() =>
     """
     Minimise the memory used for the map.
     """
     _resize(((_size * 4) / 3).next_pow2().max(8))
-    this
 
   fun clone[H2: HashFunction[this->K!] val = H]():
     HashMap[this->K!, this->V!, H2]^
@@ -256,7 +254,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     end
     r
 
-  fun ref clear(): HashMap[K, V, H]^ =>
+  fun ref clear() =>
     """
     Remove all entries.
     """
@@ -264,7 +262,6 @@ class HashMap[K, V, H: HashFunction[K] val]
     // Our default prealloc of 6 corresponds to an array alloc size of 8.
     let n: USize = 8
     _array = _array.init(_MapEmpty, n)
-    this
 
   fun _search(key: box->K!): (USize, Bool) =>
     """

--- a/packages/collections/ring_buffer.pony
+++ b/packages/collections/ring_buffer.pony
@@ -53,24 +53,26 @@ class RingBuffer[A]
 
     _array(i and _mod)
 
-  fun ref push(value: A): RingBuffer[A]^ =>
+  fun ref push(value: A): Bool =>
     """
     Add an element to the ring. If the ring is full, this will drop the oldest
-    element in the ring.
+    element in the ring. Returns true if an element was dropped.
     """
+    var full = false
+
     if _write < space() then
       _array.push(consume value)
     else
       try _array(_write and _mod) = consume value end
+      full = true
     end
 
     _write = _write + 1
-    this
+    full
 
-  fun ref clear(): RingBuffer[A]^ =>
+  fun ref clear() =>
     """
     Clear the queue.
     """
     _array.clear()
     _write = 0
-    this

--- a/packages/collections/set.pony
+++ b/packages/collections/set.pony
@@ -39,26 +39,23 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     _map.contains(value)
 
-  fun ref clear(): HashSet[A, H]^ =>
+  fun ref clear() =>
     """
     Remove all elements from the set.
     """
     _map.clear()
-    this
 
-  fun ref set(value: A): HashSet[A, H]^ =>
+  fun ref set(value: A) =>
     """
     Add a value to the set.
     """
     _map(value) = consume value
-    this
 
-  fun ref unset(value: box->A!): HashSet[A, H]^ =>
+  fun ref unset(value: box->A!) =>
     """
     Remove a value from the set.
     """
     try _map.remove(value) end
-    this
 
   fun ref extract(value: box->A!): A^ ? =>
     """
@@ -67,17 +64,16 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     _map.remove(value)._2
 
-  fun ref union(that: Iterator[A^]): HashSet[A, H]^ =>
+  fun ref union(that: Iterator[A^]) =>
     """
     Add everything in that to the set.
     """
     for value in that do
       set(consume value)
     end
-    this
 
   fun ref intersect[K: HashFunction[box->A!] val = H](
-    that: HashSet[box->A!, K]): HashSet[A, H]^
+    that: HashSet[box->A!, K])
   =>
     """
     Remove everything that isn't in that.
@@ -89,9 +85,8 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
         unset(value)
       end
     end
-    this
 
-  fun ref difference(that: Iterator[A^]): HashSet[A, H]^ =>
+  fun ref difference(that: Iterator[A^]) =>
     """
     Remove elements in this which are also in that. Add elements in that which
     are not in this.
@@ -103,16 +98,14 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
         set(consume value)
       end
     end
-    this
 
-  fun ref remove(that: Iterator[box->A!]): HashSet[A, H]^ =>
+  fun ref remove(that: Iterator[box->A!]) =>
     """
     Remove everything that is in that.
     """
     for value in that do
       unset(value)
     end
-    this
 
   fun add[K: HashFunction[this->A!] val = H](value: this->A!):
     HashSet[this->A!, K]^
@@ -120,7 +113,7 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     Add a value to the set.
     """
-    clone[K]().set(value)
+    clone[K]().>set(value)
 
   fun sub[K: HashFunction[this->A!] val = H](value: box->this->A!):
     HashSet[this->A!, K]^
@@ -128,7 +121,7 @@ class HashSet[A, H: HashFunction[A!] val] is Comparable[HashSet[A, H] box]
     """
     Remove a value from the set.
     """
-    clone[K]().unset(value)
+    clone[K]().>unset(value)
 
   fun op_or[K: HashFunction[this->A!] val = H](that: this->HashSet[A, H]):
     HashSet[this->A!, K]^

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -295,7 +295,7 @@ class File
     Returns up to len bytes.
     """
     if not _handle.is_null() then
-      let result = recover Array[U8].undefined(len) end
+      let result = recover Array[U8].>undefined(len) end
 
       let r = ifdef linux then
         @fread_unlocked[USize](result.cpointer(), USize(1), len, _handle)
@@ -305,10 +305,9 @@ class File
 
       if r < len then
         _errno = get_stream_error() // EOF or error
-      end 
+      end
       
-      result.truncate(r)
-      result
+      (consume result).>truncate(r)
     else
       recover Array[U8] end
     end
@@ -330,7 +329,7 @@ class File
 
       if r < len then
         _errno = get_stream_error() // EOF or error
-      end 
+      end
       
       result.truncate(r)
       result
@@ -416,34 +415,31 @@ class File
     _seek(pos.isize(), 0)
     len
 
-  fun ref seek_start(offset: USize): File =>
+  fun ref seek_start(offset: USize) =>
     """
     Set the cursor position relative to the start of the file.
     """
     if path.caps(FileSeek) then
       _seek(offset.isize(), 0)
     end
-    this
 
-  fun ref seek_end(offset: USize): File =>
+  fun ref seek_end(offset: USize) =>
     """
     Set the cursor position relative to the end of the file.
     """
     if path.caps(FileSeek) then
       _seek(-offset.isize(), 2)
     end
-    this
 
-  fun ref seek(offset: ISize): File =>
+  fun ref seek(offset: ISize) =>
     """
     Move the cursor position.
     """
     if path.caps(FileSeek) then
       _seek(offset, 1)
     end
-    this
 
-  fun ref flush(): File =>
+  fun ref flush() =>
     """
     Flush the file.
     """
@@ -457,9 +453,8 @@ class File
         _errno = _get_error()
       end
     end
-    this
 
-  fun ref sync(): File =>
+  fun ref sync() =>
     """
     Sync the file contents to physical storage.
     """
@@ -474,7 +469,6 @@ class File
         end
       end
     end
-    this
 
   fun ref set_length(len: USize): Bool =>
     """

--- a/packages/files/file_mode.pony
+++ b/packages/files/file_mode.pony
@@ -20,33 +20,30 @@ class FileMode
   var any_write: Bool = false
   var any_exec: Bool = false
 
-  fun ref exec(): FileMode =>
+  fun ref exec() =>
     """
     Set the executable flag for everyone.
     """
     owner_exec = true
     group_exec = true
     any_exec = true
-    this
 
-  fun ref shared(): FileMode =>
+  fun ref shared() =>
     """
     Set the write flag for everyone to the same as owner_write.
     """
     group_write = owner_write
     any_write = owner_write
-    this
 
-  fun ref group(): FileMode =>
+  fun ref group() =>
     """
     Clear all of the any-user flags.
     """
     any_read = false
     any_write = false
     any_exec = false
-    this
 
-  fun ref private(): FileMode =>
+  fun ref private() =>
     """
     Clear all of the group and any-user flags.
     """
@@ -56,7 +53,6 @@ class FileMode
     any_read = false
     any_write = false
     any_exec = false
-    this
 
   fun _os(): U32 =>
     """

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -16,7 +16,7 @@ class val FilePath
   let caps: FileCaps = FileCaps
 
   new val create(base: (FilePath | AmbientAuth), path': String,
-    caps': FileCaps val = recover val FileCaps.all() end) ?
+    caps': FileCaps val = recover val FileCaps.>all() end) ?
   =>
     """
     Create a new path. The caller must either provide the root capability or an
@@ -50,7 +50,7 @@ class val FilePath
     end
 
   new val mkdtemp(base: (FilePath | AmbientAuth), prefix: String = "",
-    caps': FileCaps val = recover val FileCaps.all() end) ?
+    caps': FileCaps val = recover val FileCaps.>all() end) ?
   =>
     """
     Create a temporary directory and returns a path to it. The directory's name
@@ -89,7 +89,7 @@ class val FilePath
     caps.union(caps')
 
   fun val join(path': String,
-    caps': FileCaps val = recover val FileCaps.all() end): FilePath ? =>
+    caps': FileCaps val = recover val FileCaps.>all() end): FilePath ? =>
     """
     Return a new path relative to this one.
     """

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -190,7 +190,7 @@ primitive Path
     Normalizes the case of path for the runtime platform.
     """
     if Platform.windows() then
-      recover val path.lower().replace("/", "\\") end
+      recover val path.lower().>replace("/", "\\") end
     elseif Platform.osx() then
       path.lower()
     else

--- a/packages/format/_format_float.pony
+++ b/packages/format/_format_float.pony
@@ -11,10 +11,10 @@ primitive _FormatFloat
 
     recover
       var s = String((prec' + 8).max(width.max(31)))
-      var f = String(31).append("%")
+      var f = String(31).>append("%")
 
       if width > 0 then f.append(width.string()) end
-      f.append(".").append(prec'.string())
+      f.>append(".").>append(prec'.string())
 
       match fmt
       | FormatExp => f.append("e")
@@ -33,5 +33,5 @@ primitive _FormatFloat
         @snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
       end
 
-      s.recalc()
+      s.>recalc()
     end

--- a/packages/format/format.pony
+++ b/packages/format/format.pony
@@ -48,7 +48,7 @@ primitive Format
         end
       end
 
-      s.recalc()
+      s.>recalc()
     end
 
   fun int[A: (Int & Integer[A])](x: A, fmt: FormatInt = FormatDefault,

--- a/packages/glob/glob.pony
+++ b/packages/glob/glob.pony
@@ -123,12 +123,12 @@ primitive Glob
               i = i + 1
             end
             let sub = recover ref pat.substring(i.isize(), j.isize()) end
-            res.append(sub.replace("\\","\\\\"))
+            res.append(sub.>replace("\\","\\\\"))
             res.append("])")
             i = j + 1
           end
         else
-          if alpha_num_regex != String(1).push(c) then
+          if alpha_num_regex != String(1).>push(c) then
             res.append("\\")
           end
           res.push(c)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -57,7 +57,7 @@ class _TestPing is UDPNotify
   fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress) =>
     _h.complete_action("ping receive")
 
-    let s = String.append(consume data)
+    let s = String.>append(consume data)
     _h.assert_eq[String box](s, "pong!")
     _h.complete(true)
 
@@ -94,7 +94,7 @@ class _TestPong is UDPNotify
   =>
     _h.complete_action("pong receive")
 
-    let s = String.append(consume data)
+    let s = String.>append(consume data)
     _h.assert_eq[String box](s, "ping!")
     sock.writev(
       recover val [[U8('p'), U8('o'), U8('n'), U8('g'), U8('!')]] end,
@@ -286,7 +286,7 @@ class _TestTCPWritevNotifyClient is TCPConnectionNotify
     _h = h
 
   fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter =>
-    recover Array[ByteSeq].concat(data.values()).push(" (from client)") end
+    recover Array[ByteSeq].>concat(data.values()).>push(" (from client)") end
 
   fun ref connected(conn: TCPConnection ref) =>
     _h.complete_action("client connect")

--- a/packages/net/http/_payload_builder.pony
+++ b/packages/net/http/_payload_builder.pony
@@ -164,8 +164,8 @@ class _PayloadBuilder
         if line.size() > 0 then
           try
             let i = line.find(":")
-            let key = recover val line.substring(0, i).strip() end
-            let value = recover val line.substring(i + 1).strip() end
+            let key = recover val line.substring(0, i).>strip() end
+            let value = recover val line.substring(i + 1).>strip() end
             _payload(key) = value
 
             match key.lower()

--- a/packages/net/http/client.pony
+++ b/packages/net/http/client.pony
@@ -22,7 +22,7 @@ actor Client
     _sslctx = try
       sslctx as SSLContext
     else
-      recover SSLContext.set_client_verify(false) end
+      recover SSLContext.>set_client_verify(false) end
     end
 
     _pipeline = pipeline

--- a/packages/net/http/payload.pony
+++ b/packages/net/http/payload.pony
@@ -56,7 +56,7 @@ class iso Payload
     """
     _headers(key)
 
-  fun ref update(key: String, value: String): Payload ref^ =>
+  fun ref update(key: String, value: String): (String | None) =>
     """
     Set a header. If we've already received the header, append the value as a
     comma separated list, as per RFC 2616 section 4.2.
@@ -64,8 +64,8 @@ class iso Payload
     match _headers(key) = value
     | let prev: String =>
       _headers(key) = prev + "," + value
+      prev
     end
-    this
 
   fun headers(): this->Map[String, String] =>
     """
@@ -91,12 +91,11 @@ class iso Payload
 
     len
 
-  fun ref add_chunk(data: ByteSeq): Payload ref^ =>
+  fun ref add_chunk(data: ByteSeq) =>
     """
     Add a chunk to the body.
     """
     _body.push(data)
-    this
 
   fun iso respond(response': Payload) =>
     """

--- a/packages/net/ssl/ssl.pony
+++ b/packages/net/ssl/ssl.pony
@@ -171,7 +171,7 @@ class SSL
     let len = @BIO_ctrl_pending[USize](_output)
     if len == 0 then error end
 
-    let buf = recover Array[U8].undefined(len) end
+    let buf = recover Array[U8].>undefined(len) end
     @BIO_read[I32](_output, buf.cpointer(), buf.size().u32())
     buf
 

--- a/packages/net/ssl/ssl_context.pony
+++ b/packages/net/ssl/ssl_context.pony
@@ -53,7 +53,7 @@ class val SSLContext
     let verify = _server_verify
     recover SSL._create(ctx, true, verify) end
 
-  fun ref set_cert(cert: FilePath, key: FilePath): SSLContext ref^ ? =>
+  fun ref set_cert(cert: FilePath, key: FilePath) ? =>
     """
     The cert file is a PEM certificate chain. The key file is a private key.
     Servers must set this. For clients, it is optional.
@@ -70,10 +70,9 @@ class val SSLContext
     then
       error
     end
-    this
 
   fun ref set_authority(file: (FilePath | None),
-    path: (FilePath | None) = None): SSLContext ref^ ?
+    path: (FilePath | None) = None) ?
   =>
     """
     Use a PEM file and/or a directory of PEM files to specify certificate
@@ -94,9 +93,8 @@ class val SSLContext
     then
       error
     end
-    this
 
-  fun ref set_ciphers(ciphers: String): SSLContext ref^ ? =>
+  fun ref set_ciphers(ciphers: String) ? =>
     """
     Set the accepted ciphers. This replaces the existing list. Raises an error
     if the cipher list is invalid.
@@ -108,32 +106,28 @@ class val SSLContext
     then
       error
     end
-    this
 
-  fun ref set_client_verify(state: Bool): SSLContext ref^ =>
+  fun ref set_client_verify(state: Bool) =>
     """
     Set to true to require verification. Defaults to true.
     """
     _client_verify = state
-    this
 
-  fun ref set_server_verify(state: Bool): SSLContext ref^ =>
+  fun ref set_server_verify(state: Bool) =>
     """
     Set to true to require verification. Defaults to false.
     """
     _server_verify = state
-    this
 
-  fun ref set_verify_depth(depth: U32): SSLContext ref^ =>
+  fun ref set_verify_depth(depth: U32) =>
     """
     Set the verify depth. Defaults to 6.
     """
     if not _ctx.is_null() then
       @SSL_CTX_set_verify_depth[None](_ctx, depth)
     end
-    this
 
-  fun ref allow_tls_v1(state: Bool): SSLContext ref^ =>
+  fun ref allow_tls_v1(state: Bool) =>
     """
     Allow TLS v1. Defaults to false.
     """
@@ -146,9 +140,8 @@ class val SSLContext
         @SSL_CTX_ctrl(_ctx, 32, 0x04000000, Pointer[None])
       end
     end
-    this
 
-  fun ref allow_tls_v1_1(state: Bool): SSLContext ref^ =>
+  fun ref allow_tls_v1_1(state: Bool) =>
     """
     Allow TLS v1.1. Defaults to false.
     """
@@ -161,9 +154,8 @@ class val SSLContext
         @SSL_CTX_ctrl(_ctx, 32, 0x10000000, Pointer[None])
       end
     end
-    this
 
-  fun ref allow_tls_v1_2(state: Bool): SSLContext ref^ =>
+  fun ref allow_tls_v1_2(state: Bool) =>
     """
     Allow TLS v1.2. Defaults to true.
     """
@@ -176,7 +168,6 @@ class val SSLContext
         @SSL_CTX_ctrl(_ctx, 32, 0x08000000, Pointer[None])
       end
     end
-    this
 
   fun ref dispose() =>
     """

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -177,7 +177,7 @@ actor TCPConnection
     Connect via IPv4 or IPv6. If `from` is a non-empty string, the connection
     will be made from the specified interface.
     """
-    _read_buf = recover Array[U8].undefined(init_size) end
+    _read_buf = recover Array[U8].>undefined(init_size) end
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
@@ -193,7 +193,7 @@ actor TCPConnection
     """
     Connect via IPv4.
     """
-    _read_buf = recover Array[U8].undefined(init_size) end
+    _read_buf = recover Array[U8].>undefined(init_size) end
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
@@ -209,7 +209,7 @@ actor TCPConnection
     """
     Connect via IPv6.
     """
-    _read_buf = recover Array[U8].undefined(init_size) end
+    _read_buf = recover Array[U8].>undefined(init_size) end
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
@@ -231,7 +231,7 @@ actor TCPConnection
     _event = @pony_asio_event_create(this, fd, AsioEvent.read_write(), 0, true)
     _connected = true
     _writeable = true
-    _read_buf = recover Array[U8].undefined(init_size) end
+    _read_buf = recover Array[U8].>undefined(init_size) end
     _next_size = init_size
     _max_size = max_size
 

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -79,7 +79,7 @@ actor UDPSocket
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
-    _read_buf = recover Array[U8].undefined(size) end
+    _read_buf = recover Array[U8].>undefined(size) end
     _notify_listening()
     _start_next_read()
 
@@ -95,7 +95,7 @@ actor UDPSocket
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
-    _read_buf = recover Array[U8].undefined(size) end
+    _read_buf = recover Array[U8].>undefined(size) end
     _notify_listening()
     _start_next_read()
 
@@ -111,7 +111,7 @@ actor UDPSocket
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname[Bool](_fd, _ip)
     _packet_size = size
-    _read_buf = recover Array[U8].undefined(size) end
+    _read_buf = recover Array[U8].>undefined(size) end
     _notify_listening()
     _start_next_read()
 
@@ -258,7 +258,7 @@ actor UDPSocket
 
         while _readable do
           let size = _packet_size
-          let data = _read_buf = recover Array[U8].undefined(size) end
+          let data = _read_buf = recover Array[U8].>undefined(size) end
           let from = recover IPAddress end
           let len = @pony_os_recvfrom[USize](_event, data.cpointer(),
             data.space(), from) ?
@@ -302,7 +302,7 @@ actor UDPSocket
 
       // Hand back read data
       let size = _packet_size
-      let data = _read_buf = recover Array[U8].undefined(size) end
+      let data = _read_buf = recover Array[U8].>undefined(size) end
       let from = _read_from = recover IPAddress end
       data.truncate(len.usize())
       _notify.received(this, consume data, consume from)

--- a/packages/options/options.pony
+++ b/packages/options/options.pony
@@ -129,7 +129,7 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
     if opt.has_argument() then
       // If 'matched' is non-empty, then the rest (without - or =) must be the
       // argument.
-      matched.lstrip("-").remove("=")
+      matched.>lstrip("-").>remove("=")
     end
 
     try

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -80,7 +80,7 @@ class iso _TestFileExecCapabilityIsRequired is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient("", "", 1, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/date",
-        recover val FileCaps.all().unset(FileExec) end)
+        recover val FileCaps.>all().>unset(FileExec) end)
       let args: Array[String] iso = recover Array[String](1) end
       args.push("date")
       let vars: Array[String] iso = recover Array[String](2) end

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -170,7 +170,7 @@ actor ProcessMonitor
   var _stderr_event: AsioEventID = AsioEvent.none()
 
   let _max_size: USize = 4096
-  var _read_buf: Array[U8] iso = recover Array[U8].undefined(_max_size) end
+  var _read_buf: Array[U8] iso = recover Array[U8].>undefined(_max_size) end
   var _read_len: USize = 0
   var _expect: USize = 0
 
@@ -575,7 +575,7 @@ actor ProcessMonitor
 
         _read_len = _read_len + len.usize()
 
-        let data = _read_buf = recover Array[U8].undefined(next) end
+        let data = _read_buf = recover Array[U8].>undefined(next) end
         data.truncate(_read_len)
 
         match fd

--- a/packages/time/date.pony
+++ b/packages/time/date.pony
@@ -26,7 +26,7 @@ class Date
     """
     @ponyint_timegm[I64](this)
 
-  fun ref normal(): Date^ =>
+  fun ref normal() =>
     """
     Normalise all the fields of the date. For example, if the hour is 24, it is
     set to 0 and the day is advanced. This allows fields to be changed naively,
@@ -34,7 +34,6 @@ class Date
     normalising the date.
     """
     @ponyint_gmtime[None](this, time(), nsec)
-    this
 
   fun format(fmt: String): String =>
     """

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -114,17 +114,17 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
 
   for(ast_t* ele = ast_childidx(ast, 1); ele != NULL; ele = ast_sibling(ele))
   {
-    BUILD(append_dot, ast, NODE(TK_DOT, TREE(*astp) ID("push")));
+    BUILD(append_chain, ast, NODE(TK_CHAIN, TREE(*astp) ID("push")));
 
     BUILD(append, ast,
       NODE(TK_CALL,
         NODE(TK_POSITIONALARGS, TREE(ele))
         NONE
-        TREE(append_dot)));
+        TREE(append_chain)));
 
     ast_replace(astp, append);
 
-    if(!expr_dot(opt, &append_dot) ||
+    if(!expr_chain(opt, &append_chain) ||
       !expr_call(opt, &append)
       )
       return false;


### PR DESCRIPTION
Methods in the standard library returning their receiver for call chaining have been updated to return either `None` or some useful value. Generalised chaining (as in RFC 25) should be used as a replacement for this idiom.

Closes #1457.