### PR TITLE
Don't violate reference capabilities when assigning via a field

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -532,12 +532,27 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
   // Inferring locals may have changed the left type.
   l_type = ast_type(left);
+  ast_t* fl_type = l_type;
+
+  switch(ast_id(left))
+  {
+    case TK_FVARREF:
+    case TK_FLETREF:
+    {
+      // Must be a subtype of the field type, not the viewpoint adapted type.
+      AST_GET_CHILDREN(left, origin, field);
+      fl_type = ast_type(field);
+      break;
+    }
+
+    default: {}
+  }
 
   // Assignment is based on the alias of the right hand side.
   ast_t* a_type = alias(r_type);
 
   errorframe_t info = NULL;
-  if(!is_subtype(a_type, l_type, &info, opt))
+  if(!is_subtype(a_type, fl_type, &info, opt))
   {
     errorframe_t frame = NULL;
     ast_error_frame(&frame, ast, "right side must be a subtype of left side");

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -308,3 +308,26 @@ TEST_F(BadPonyTest, CallConstructorOnTypeIntersection)
 
   TEST_ERRORS_1(src, "can't call a constructor on a type intersection");
 }
+
+TEST_F(BadPonyTest, AssignToFieldOfIso)
+{
+  // From issue #1469
+  const char* src =
+    "class Foo\n"
+    "  var x: String ref = String\n"
+    "  fun iso bar(): String iso^ =>\n"
+    "    let s = recover String end\n"
+    "    x = s\n"
+    "   consume s\n"
+
+    "  fun ref foo(): String iso^ =>\n"
+    "    let s = recover String end\n"
+    "    let y: Foo iso = Foo\n"
+    "    y.x = s\n"
+    "    consume s";
+
+  TEST_ERRORS_2(src,
+    "right side must be a subtype of left side",
+    "right side must be a subtype of left side"
+    );
+}


### PR DESCRIPTION
When assigning to a field, the incoming value must be a subtype of
the field type _without_ viewpoint adaptation.

This addresses #1469.