### PR TITLE
Add ASIO one shot support when using epoll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ All notable changes to the Pony compiler and standard library will be documented
     - allow_tls_v1
     - allow_tls_v1_1
     - allow_tls_v1_2
+- TCP sockets on Linux now use Epoll One Shot
 
 ## [0.10.0] - 2016-12-12
 

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -37,3 +37,5 @@ primitive AsioEvent
   fun timer(): U32 => 1 << 2
   fun signal(): U32 => 1 << 3
   fun read_write(): U32 => read() or write()
+  fun oneshot(): U32 => 1 << 8
+  fun read_write_oneshot(): U32 => read() or write() or oneshot()

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -26,6 +26,7 @@ enum
   ASIO_WRITE = 1 << 1,
   ASIO_TIMER = 1 << 2,
   ASIO_SIGNAL = 1 << 3,
+  ASIO_ONESHOT = 1 << 8,
   ASIO_DESTROYED = (uint32_t)-1
 };
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -568,8 +568,13 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
     return false;
   }
 
+#ifdef PLATFORM_IS_LINUX
+  // Create an event and subscribe it.
+  pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0, true);
+#else
   // Create an event and subscribe it.
   pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE, 0, true);
+#endif
 #endif
 
   return true;


### PR DESCRIPTION
Using asio one shot can be much more efficient than the current edge
polling. We started using at Sendence with TCPConnection and saw a
large drop in the number of events being sent to TCPConnection
instances. This in turn lead to performance improvements.

This commit contains support in the linux asio code, as well as
the linux tcp socket code to use one shot.

Support for OSX/FreeBSD can be added as kqueue supports the same
fundamental options.