### PR TITLE
Improve efficiency of muted TCPConnection on non Windows platforms

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -274,6 +274,7 @@ actor TCPConnection
     Start reading off this TCPConnection again after having been muted.
     """
     _muted = false
+    _pending_reads()
 
   be set_notify(notify: TCPConnectionNotify iso) =>
     """
@@ -589,7 +590,6 @@ actor TCPConnection
 
         while _readable and not _shutdown_peer do
           if _muted then
-            _read_again()
             return
           end
 


### PR DESCRIPTION
Prior to this commit, if we were in TCPConnection's _pending_reads
and encountered discovered that the connection was muted, we would
call read_again to requeue another read and would then return.

This results in a lot of extra, unneeded work. Until the connection
is unmuted, there's no point to calling read_again, we'll just keep
repeating the same cycle over and over again; pointlessly putting
messages on the TCPConnection's queue.

With the commit, we now return from _pending_reads when discovering
that the connection is muted without calling read_again. Instead,
when we unmute the connection, we will then immediately call
_pending_reads to start processing any unhandled data.

There is probably a similar improvement that can be made on Windows,
however, I'm not a Windows programmer, barely know IOCP at all and
am more likely to break the Windows TCP implementation than I am
improve it therefore, this commit only applies to non Windows platforms.