### PR TITLE
Automate release versioning

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -60,80 +60,12 @@ All releases should have a corresponding issue in the [ponyc repo](https://githu
 
 ## Releasing
 
-For the duration of this document, we will pretend the "golden commit" version is `8a8ee28`, the version is `0.3.1`, and our release date is 2016-01-15. Any place you see those values, please substitute your own version.
+For the duration of this document, we will pretend the "golden commit" version is `8a8ee28` and the version is `0.3.1`. Any place you see those values, please substitute your own version.
 
-### Update the GitHub issue
 
-Leave a comment on the GitHub issue for this release to let everyone know that you are starting.
+With that in mind, run the release script:
 
-### Update VERSION and CHANGELOG
-
-* git checkout master
-* git pull
-* git checkout -b release-0.3.1 8a8ee28
-
-#### Update the VERSION
-
-In the root of the ponyc repo is a file called `VERSION`. You should update the version number therein to your version number, for example: `0.3.1`.
-
-#### Update the CHANGELOG
-
-We maintain all changes in our CHANGELOG. At the time we do a release, we need to "roll" the CHANGELOG from one version to another. Open up CHANGELOG.md and you will see a series of changes that are in this commit under a section that says:
-
-`## [unreleased] - unreleased`
-
-This should be changed to:
-
-`## [0.3.1] - 2016-01-15`
-
-**If any of the sections, "Added", "Fixed" or "Changed" is empty, delete it.**
-
-### Commit your CHANGELOG and VERSION updates
-
-* git add CHANGELOG.md VERSION
-* git commit -m "Prep for 0.3.1 release"
-
-### Merge into release
-
-* git checkout release
-* git merge release-0.3.1
-
-### Tag the release
-
-* git tag 0.3.1
-
-### Push to the release branch
-
-* git push origin
-* git push origin 0.3.1
-
-### Update CHANGELOG for new entries
-
-We are in a slightly precarious state here, someone might have merged since we started and updated the CHANGELOG on master. Verify that hasn't happened then merge your change to CHANGELOG into master.
-
-* git checkout master
-* git merge release-0.3.1
-
-Now add a new "unreleased" section to the change log. Above the `## [0.3.1] - 2016-01-15` add the following:
-
-```
-## [unreleased] - unreleased
-
-### Fixed
-
-### Added
-
-### Changed
-
-```
-
-If anything was merged into the CHANGELOG since versioned it, move the new additions to the appropriate section of the new "unreleased" section. 
-
-### Commit CHANGELOG and push to master.
-
-* git add CHANGELOG.md
-* git commit -m "Add unreleased section to CHANGELOG post 0.3.1 release prep"
-* git push
+- bash release.sh 0.3.1 8a8ee28
 
 ### Update the GitHub issue
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+release_date=`date +%Y-%m-%d`
+
+verify_args() {
+  echo "Cutting a release for version $version with commit $commit"
+  while true; do
+    read -p "Is this correct (y/n)?" yn
+    case $yn in
+      [Yy]* ) break;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer y or n.";;
+    esac
+  done
+}
+
+update_version() {
+  > VERSION
+  echo $version >> VERSION
+  echo "VERSION set to $version"
+}
+
+update_changelog() {
+  # cut out empty "Fixed", "Added", or "Changed" sections
+  remove_empty_sections
+  
+  local match='## \[unreleased\] \- unreleased'
+  local heading="## [$version] - $release_date"
+  sed -i "/$match/c $heading" CHANGELOG.md
+}
+
+remove_empty_sections() {
+  for section in "Fixed" "Added" "Changed"; do
+    # check if first non-whitespace character after section heading is '-'
+    local str_after=`sed "1,/### $section/d" <CHANGELOG.md`
+    local first_word=`echo $str_after | head -n1 | cut -d " " -f1`
+    if [ $first_word != "-" ]; then
+      echo "Removing empty CHANGELOG section: $section"
+      sed -i "0,/### $section/{//d;}" CHANGELOG.md
+    fi
+  done
+}
+
+add_changelog_unreleased_section() {
+  echo "Adding unreleased section to CHANGELOG"
+  local replace='## [unreleased] - unreleased\n\n### Fixed\n\n### Added\n\n### Changed\n'
+  sed -i "/## \[$version\] \- $release_date/i $replace" CHANGELOG.md
+}
+
+
+if [ $# -le 2 ]; then
+  echo "version and commit arguments required"
+fi
+
+set -eu
+version=$1
+commit=$2
+
+verify_args
+
+# create version release branch
+git checkout master
+git pull
+git checkout -b release-$version $commit
+
+# update VERSION and CHANGELOG
+update_version
+update_changelog
+
+# commit VERSION and CHANGELOG updates
+git add CHANGELOG.md VERSION
+git commit -m "Prep for $version release"
+
+# merge into release
+git checkout release
+git merge release-$version
+
+# tag release
+git tag $version
+
+# push to release branch
+git push origin release
+git push origin $version
+
+# update CHANGELOG for new entries
+git checkout master
+git merge release-$version
+add_changelog_unreleased_section
+
+# commit changelog and push to master
+git add CHANGELOG.md
+git commit -m "Add unreleased section to CHANGELOG post $version release prep"
+git push origin master


### PR DESCRIPTION
This PR automates a large portion of the release process to reduce human error and move toward a fully automated release process. The script has been tested on my branch of ponyc with multiple changelogs and tags from past pony releases.