### PR TITLE
Adaptive per-actor scheduler batch sizes

### DIFF
--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -24,6 +24,7 @@ typedef struct pony_actor_t
   messageq_t q;
   pony_msg_t* continuation;
   uint8_t flags;
+  size_t batch;
 
   // keep things accessed by other actors on a separate cache line
   __pony_spec_align__(heap_t heap, 64); // 52/104 bytes

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -12,8 +12,6 @@
 #include <stdio.h>
 #include <assert.h>
 
-#define SCHED_BATCH 100
-
 static DECLARE_THREAD_FN(run_thread);
 
 typedef enum
@@ -287,7 +285,7 @@ static void run(scheduler_t* sched)
     }
 
     // Run the current actor and get the next actor.
-    bool reschedule = ponyint_actor_run(&sched->ctx, actor, SCHED_BATCH);
+    bool reschedule = ponyint_actor_run(&sched->ctx, actor, actor->batch);
     pony_actor_t* next = pop_global(sched);
 
     if(reschedule)


### PR DESCRIPTION
This is extracted from the integrated runtime back pressure work that
is ongoing.

Prior to this change, scheduler batch sizes are fixed. Each actor
can process up to a hundred application messages before giving up
the scheduler. While processing those messages, they can also process
an unlimited number of non-application messages (such as gc release
messages, gc acquire).

With this change, all messages count towards our batch size. This leads
to a better balance between actors as GC messages are no longer an
unaccounted for hidden cost. To account for differences in workload
of different actors, we allow actors to grab a larger amount of
scheduler time by having varying batch sizes:

Each time an actor runs through its complete batch size, we increase
the actor's batch size for the next run. If we process significantly
fewer messages than our batch size, we lower our batch size some.

We've found at Sendence that this leads to a smoother, more stable
application experience.