### PR TITLE
Improve Map.get_or_else performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Map.get_or_else performance
 
+- Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Map.get_or_else performance
 
+- Back pressure notifications now given when encountered while sending data during `TCPConnection` pending writes
 - Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ All notable changes to the Pony compiler and standard library will be documented
     - allow_tls_v1
     - allow_tls_v1_1
     - allow_tls_v1_2
+- TCP sockets on Linux now use Epoll One Shot
 
 ## [0.10.0] - 2016-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Map.get_or_else performance
+
 ### Added
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
-- Map.get_or_else performance
-
 - Back pressure notifications now given when encountered while sending data during `TCPConnection` pending writes
 - Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
 - Map.get_or_else performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Back pressure notifications now given when encountered while sending data during `TCPConnection` pending writes
 - Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
+- Map.get_or_else performance
 
 ### Added
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -60,80 +60,12 @@ All releases should have a corresponding issue in the [ponyc repo](https://githu
 
 ## Releasing
 
-For the duration of this document, we will pretend the "golden commit" version is `8a8ee28`, the version is `0.3.1`, and our release date is 2016-01-15. Any place you see those values, please substitute your own version.
+For the duration of this document, we will pretend the "golden commit" version is `8a8ee28` and the version is `0.3.1`. Any place you see those values, please substitute your own version.
 
-### Update the GitHub issue
 
-Leave a comment on the GitHub issue for this release to let everyone know that you are starting.
+With that in mind, run the release script:
 
-### Update VERSION and CHANGELOG
-
-* git checkout master
-* git pull
-* git checkout -b release-0.3.1 8a8ee28
-
-#### Update the VERSION
-
-In the root of the ponyc repo is a file called `VERSION`. You should update the version number therein to your version number, for example: `0.3.1`.
-
-#### Update the CHANGELOG
-
-We maintain all changes in our CHANGELOG. At the time we do a release, we need to "roll" the CHANGELOG from one version to another. Open up CHANGELOG.md and you will see a series of changes that are in this commit under a section that says:
-
-`## [unreleased] - unreleased`
-
-This should be changed to:
-
-`## [0.3.1] - 2016-01-15`
-
-**If any of the sections, "Added", "Fixed" or "Changed" is empty, delete it.**
-
-### Commit your CHANGELOG and VERSION updates
-
-* git add CHANGELOG.md VERSION
-* git commit -m "Prep for 0.3.1 release"
-
-### Merge into release
-
-* git checkout release
-* git merge release-0.3.1
-
-### Tag the release
-
-* git tag 0.3.1
-
-### Push to the release branch
-
-* git push origin
-* git push origin 0.3.1
-
-### Update CHANGELOG for new entries
-
-We are in a slightly precarious state here, someone might have merged since we started and updated the CHANGELOG on master. Verify that hasn't happened then merge your change to CHANGELOG into master.
-
-* git checkout master
-* git merge release-0.3.1
-
-Now add a new "unreleased" section to the change log. Above the `## [0.3.1] - 2016-01-15` add the following:
-
-```
-## [unreleased] - unreleased
-
-### Fixed
-
-### Added
-
-### Changed
-
-```
-
-If anything was merged into the CHANGELOG since versioned it, move the new additions to the appropriate section of the new "unreleased" section. 
-
-### Commit CHANGELOG and push to master.
-
-* git add CHANGELOG.md
-* git commit -m "Add unreleased section to CHANGELOG post 0.3.1 release prep"
-* git push
+- bash release.sh 0.3.1 8a8ee28
 
 ### Update the GitHub issue
 

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -37,3 +37,5 @@ primitive AsioEvent
   fun timer(): U32 => 1 << 2
   fun signal(): U32 => 1 << 3
   fun read_write(): U32 => read() or write()
+  fun oneshot(): U32 => 1 << 8
+  fun read_write_oneshot(): U32 => read() or write() or oneshot()

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -174,8 +174,16 @@ class HashMap[K, V, H: HashFunction[K] val]
     Get the value associated with provided key if present. Otherwise,
     return the provided alternate value.
     """
-    try
-      apply(key)
+    (let i, let found) = _search(key)
+
+    if found then
+      try
+        _array(i) as (_, this->V)
+      else
+        // This should never happen as we have already
+        // proven that _array(i) exists
+        consume alt
+      end
     else
       consume alt
     end

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -513,7 +513,7 @@ actor TCPConnection
           if (len + offset) < data.size() then
             // Send remaining data later.
             node() = (data, offset + len)
-            _writeable = false
+            _apply_backpressure()
           else
             // This chunk has been fully sent.
             _pending.shift()

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -281,6 +281,7 @@ actor TCPConnection
     Start reading off this TCPConnection again after having been muted.
     """
     _muted = false
+    _pending_reads()
 
   be set_notify(notify: TCPConnectionNotify iso) =>
     """
@@ -597,7 +598,6 @@ actor TCPConnection
 
         while _readable and not _shutdown_peer do
           if _muted then
-            _read_again()
             return
           end
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+release_date=`date +%Y-%m-%d`
+
+verify_args() {
+  echo "Cutting a release for version $version with commit $commit"
+  while true; do
+    read -p "Is this correct (y/n)?" yn
+    case $yn in
+      [Yy]* ) break;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer y or n.";;
+    esac
+  done
+}
+
+update_version() {
+  > VERSION
+  echo $version >> VERSION
+  echo "VERSION set to $version"
+}
+
+update_changelog() {
+  # cut out empty "Fixed", "Added", or "Changed" sections
+  remove_empty_sections
+  
+  local match='## \[unreleased\] \- unreleased'
+  local heading="## [$version] - $release_date"
+  sed -i "/$match/c $heading" CHANGELOG.md
+}
+
+remove_empty_sections() {
+  for section in "Fixed" "Added" "Changed"; do
+    # check if first non-whitespace character after section heading is '-'
+    local str_after=`sed "1,/### $section/d" <CHANGELOG.md`
+    local first_word=`echo $str_after | head -n1 | cut -d " " -f1`
+    if [ $first_word != "-" ]; then
+      echo "Removing empty CHANGELOG section: $section"
+      sed -i "0,/### $section/{//d;}" CHANGELOG.md
+    fi
+  done
+}
+
+add_changelog_unreleased_section() {
+  echo "Adding unreleased section to CHANGELOG"
+  local replace='## [unreleased] - unreleased\n\n### Fixed\n\n### Added\n\n### Changed\n'
+  sed -i "/## \[$version\] \- $release_date/i $replace" CHANGELOG.md
+}
+
+
+if [ $# -le 2 ]; then
+  echo "version and commit arguments required"
+fi
+
+set -eu
+version=$1
+commit=$2
+
+verify_args
+
+# create version release branch
+git checkout master
+git pull
+git checkout -b release-$version $commit
+
+# update VERSION and CHANGELOG
+update_version
+update_changelog
+
+# commit VERSION and CHANGELOG updates
+git add CHANGELOG.md VERSION
+git commit -m "Prep for $version release"
+
+# merge into release
+git checkout release
+git merge release-$version
+
+# tag release
+git tag $version
+
+# push to release branch
+git push origin release
+git push origin $version
+
+# update CHANGELOG for new entries
+git checkout master
+git merge release-$version
+add_changelog_unreleased_section
+
+# commit changelog and push to master
+git add CHANGELOG.md
+git commit -m "Add unreleased section to CHANGELOG post $version release prep"
+git push origin master

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -26,6 +26,7 @@ enum
   ASIO_WRITE = 1 << 1,
   ASIO_TIMER = 1 << 2,
   ASIO_SIGNAL = 1 << 3,
+  ASIO_ONESHOT = 1 << 8,
   ASIO_DESTROYED = (uint32_t)-1
 };
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -568,8 +568,13 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
     return false;
   }
 
+#ifdef PLATFORM_IS_LINUX
+  // Create an event and subscribe it.
+  pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0, true);
+#else
   // Create an event and subscribe it.
   pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE, 0, true);
+#endif
 #endif
 
   return true;


### PR DESCRIPTION
Avoid paying the cost of an `error` call. This has little impact
in non-hot code paths but is a huge performance boost when `get_or_else`
is called often.