### PR TITLE
Improve Map.get_or_else performance

### DIFF
--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -174,8 +174,16 @@ class HashMap[K, V, H: HashFunction[K] val]
     Get the value associated with provided key if present. Otherwise,
     return the provided alternate value.
     """
-    try
-      apply(key)
+    (let i, let found) = _search(key)
+
+    if found then
+      try
+        _array(i) as (_, this->V)
+      else
+        // This should never happen as we have already
+        // proven that _array(i) exists
+        consume alt
+      end
     else
       consume alt
     end


### PR DESCRIPTION
This commit introduces a change so that, when a key isn't found during
a `get_or_else` call, that we do not have an error thrown. Instead,
we do a search for the key directly rather than going through the
`apply` method that might throw said error.