### PR TITLE
AST annotations (RFC 27)

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -22,7 +22,7 @@ use_ffi
   ;
 
 class_def
-  : ('type' | 'interface' | 'trait' | 'primitive' | 'struct' | 'class' | 'actor') '@'? cap? ID typeparams? ('is' type)? STRING? members
+  : ('type' | 'interface' | 'trait' | 'primitive' | 'struct' | 'class' | 'actor') ('\' ID (',' ID)* '\')? '@'? cap? ID typeparams? ('is' type)? STRING? members
   ;
 
 members
@@ -34,7 +34,11 @@ field
   ;
 
 method
-  : ('fun' | 'be' | 'new') cap? ID typeparams? ('(' | LPAREN_NEW) params? ')' (':' type)? '?'? STRING? ('if' rawseq)? ('=>' rawseq)?
+  : ('fun' | 'be' | 'new') ('\' ID (',' ID)* '\')? cap? ID typeparams? ('(' | LPAREN_NEW) params? ')' (':' type)? '?'? STRING? ('if' rawseq)? ('=>' rawseq)?
+  ;
+
+annotatedrawseq
+  : ('\' ID (',' ID)* '\')? (exprseq | jump)
   ;
 
 rawseq
@@ -84,30 +88,30 @@ binop
   ;
 
 nextterm
-  : 'if' rawseq 'then' rawseq (elseif | ('else' rawseq))? 'end'
-  | 'ifdef' infix 'then' rawseq (elseifdef | ('else' rawseq))? 'end'
-  | 'match' rawseq caseexpr* ('else' rawseq)? 'end'
-  | 'while' rawseq 'do' rawseq ('else' rawseq)? 'end'
-  | 'repeat' rawseq 'until' rawseq ('else' rawseq)? 'end'
-  | 'for' idseq 'in' rawseq 'do' rawseq ('else' rawseq)? 'end'
-  | 'with' (withelem (',' withelem)*) 'do' rawseq ('else' rawseq)? 'end'
-  | 'try' rawseq ('else' rawseq)? ('then' rawseq)? 'end'
-  | 'recover' cap? rawseq 'end'
+  : 'if' ('\' ID (',' ID)* '\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
+  | 'ifdef' ('\' ID (',' ID)* '\')? infix 'then' rawseq (elseifdef | ('else' annotatedrawseq))? 'end'
+  | 'match' ('\' ID (',' ID)* '\')? rawseq caseexpr* ('else' annotatedrawseq)? 'end'
+  | 'while' ('\' ID (',' ID)* '\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'repeat' ('\' ID (',' ID)* '\')? rawseq 'until' rawseq ('else' annotatedrawseq)? 'end'
+  | 'for' ('\' ID (',' ID)* '\')? idseq 'in' rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'with' ('\' ID (',' ID)* '\')? (withelem (',' withelem)*) 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'try' ('\' ID (',' ID)* '\')? rawseq ('else' annotatedrawseq)? ('then' annotatedrawseq)? 'end'
+  | 'recover' ('\' ID (',' ID)* '\')? cap? rawseq 'end'
   | 'consume' cap? term
   | nextpattern
   | '#' postfix
   ;
 
 term
-  : 'if' rawseq 'then' rawseq (elseif | ('else' rawseq))? 'end'
-  | 'ifdef' infix 'then' rawseq (elseifdef | ('else' rawseq))? 'end'
-  | 'match' rawseq caseexpr* ('else' rawseq)? 'end'
-  | 'while' rawseq 'do' rawseq ('else' rawseq)? 'end'
-  | 'repeat' rawseq 'until' rawseq ('else' rawseq)? 'end'
-  | 'for' idseq 'in' rawseq 'do' rawseq ('else' rawseq)? 'end'
-  | 'with' (withelem (',' withelem)*) 'do' rawseq ('else' rawseq)? 'end'
-  | 'try' rawseq ('else' rawseq)? ('then' rawseq)? 'end'
-  | 'recover' cap? rawseq 'end'
+  : 'if' ('\' ID (',' ID)* '\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
+  | 'ifdef' ('\' ID (',' ID)* '\')? infix 'then' rawseq (elseifdef | ('else' annotatedrawseq))? 'end'
+  | 'match' ('\' ID (',' ID)* '\')? rawseq caseexpr* ('else' annotatedrawseq)? 'end'
+  | 'while' ('\' ID (',' ID)* '\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'repeat' ('\' ID (',' ID)* '\')? rawseq 'until' rawseq ('else' annotatedrawseq)? 'end'
+  | 'for' ('\' ID (',' ID)* '\')? idseq 'in' rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'with' ('\' ID (',' ID)* '\')? (withelem (',' withelem)*) 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'try' ('\' ID (',' ID)* '\')? rawseq ('else' annotatedrawseq)? ('then' annotatedrawseq)? 'end'
+  | 'recover' ('\' ID (',' ID)* '\')? cap? rawseq 'end'
   | 'consume' cap? term
   | pattern
   | '#' postfix
@@ -118,15 +122,15 @@ withelem
   ;
 
 caseexpr
-  : '|' pattern? ('if' rawseq)? ('=>' rawseq)?
+  : '|' ('\' ID (',' ID)* '\')? pattern? ('if' rawseq)? ('=>' rawseq)?
   ;
 
 elseifdef
-  : 'elseif' infix 'then' rawseq (elseifdef | ('else' rawseq))?
+  : 'elseif' ('\' ID (',' ID)* '\')? infix 'then' rawseq (elseifdef | ('else' annotatedrawseq))?
   ;
 
 elseif
-  : 'elseif' rawseq 'then' rawseq (elseif | ('else' rawseq))?
+  : 'elseif' ('\' ID (',' ID)* '\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))?
   ;
 
 idseq
@@ -190,9 +194,9 @@ nextatom
   | literal
   | LPAREN_NEW (rawseq | '_') tuple? ')'
   | LSQUARE_NEW ('as' type ':')? rawseq (',' rawseq)* ']'
-  | 'object' cap? ('is' type)? members 'end'
-  | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
-  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | 'object' ('\' ID (',' ID)* '\')? cap? ('is' type)? members 'end'
+  | '{' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | 'lambda' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;
@@ -203,9 +207,9 @@ atom
   | literal
   | ('(' | LPAREN_NEW) (rawseq | '_') tuple? ')'
   | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq (',' rawseq)* ']'
-  | 'object' cap? ('is' type)? members 'end'
-  | '{' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
-  | 'lambda' cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | 'object' ('\' ID (',' ID)* '\')? cap? ('is' type)? members 'end'
+  | '{' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | 'lambda' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -53,6 +53,7 @@ struct ast_t
   struct ast_t* child;
   struct ast_t* sibling;
   struct ast_t* type;
+  struct ast_t* annotation;
   uint32_t flags;
 };
 
@@ -67,7 +68,16 @@ static const char in[] = "  ";
 static const size_t in_len = 2;
 static size_t width = 80;
 
-static void print(FILE* fp, ast_t* ast, size_t indent, bool type);
+enum print_special
+{
+  NOT_SPECIAL,
+  SPECIAL_TYPE,
+  SPECIAL_ANNOTATION
+};
+
+static const char special_char[] = {'(', ')', '[', ']', '\\', '\\'};
+
+static void print(FILE* fp, ast_t* ast, size_t indent, enum print_special kind);
 
 
 static void print_token(FILE* fp, token_t* token)
@@ -92,12 +102,13 @@ static void print_token(FILE* fp, token_t* token)
   }
 }
 
-static size_t length(ast_t* ast, size_t indent, bool type)
+static size_t length(ast_t* ast, size_t indent, enum print_special kind)
 {
   size_t len = (indent * in_len) + strlen(token_print(ast->t));
   ast_t* child = ast->child;
 
-  if(type || (child != NULL) || (ast->type != NULL))
+  if((kind != NOT_SPECIAL) || (child != NULL) || (ast->type != NULL) ||
+    (ast->annotation) != NULL)
     len += 2;
 
   switch(token_get_id(ast->t))
@@ -112,59 +123,72 @@ static size_t length(ast_t* ast, size_t indent, bool type)
 
   while(child != NULL)
   {
-    len += 1 + length(child, 0, false);
+    len += 1 + length(child, 0, NOT_SPECIAL);
     child = child->sibling;
   }
 
   if(ast->type != NULL)
-    len += 1 + length(ast->type, 0, true);
+    len += 1 + length(ast->type, 0, SPECIAL_TYPE);
+
+  if(ast->annotation != NULL)
+    len += 1 + length(ast->annotation, 0, SPECIAL_ANNOTATION);
 
   return len;
 }
 
-static void print_compact(FILE* fp, ast_t* ast, size_t indent, bool type)
+static void print_compact(FILE* fp, ast_t* ast, size_t indent,
+  enum print_special kind)
 {
   for(size_t i = 0; i < indent; i++)
     fprintf(fp, in);
 
   ast_t* child = ast->child;
-  bool parens = type || (child != NULL) || (ast->type != NULL);
+  bool parens = (kind != NOT_SPECIAL) || (child != NULL) ||
+    (ast->type != NULL) || (ast->annotation != NULL);
 
   if(parens)
-    fprintf(fp, type ? "[" : "(");
+    fputc(special_char[kind * 2], fp);
 
   print_token(fp, ast->t);
 
   if(ast->symtab != NULL)
     fprintf(fp, ":scope");
 
+  if(ast->annotation != NULL)
+  {
+    fprintf(fp, " ");
+    print_compact(fp, ast->annotation, 0, SPECIAL_ANNOTATION);
+  }
+
   while(child != NULL)
   {
     fprintf(fp, " ");
-    print_compact(fp, child, 0, false);
+    print_compact(fp, child, 0, NOT_SPECIAL);
     child = child->sibling;
   }
 
   if(ast->type != NULL)
   {
     fprintf(fp, " ");
-    print_compact(fp, ast->type, 0, true);
+    print_compact(fp, ast->type, 0, SPECIAL_TYPE);
   }
 
   if(parens)
-    fprintf(fp, type ? "]" : ")");
+    fputc(special_char[(kind * 2) + 1], fp);
 }
 
-static void print_extended(FILE* fp, ast_t* ast, size_t indent, bool type)
+static void print_extended(FILE* fp, ast_t* ast, size_t indent,
+  enum print_special kind)
 {
   for(size_t i = 0; i < indent; i++)
     fprintf(fp, in);
 
   ast_t* child = ast->child;
-  bool parens = type || (child != NULL) || (ast->type != NULL);
+  bool parens = (kind != NOT_SPECIAL) || (child != NULL) ||
+    (ast->type != NULL) || (ast->annotation != NULL);
 
   if(parens)
-    fprintf(fp, type ? "[" : "(");
+    fputc(special_char[kind * 2], fp);
 
   print_token(fp, ast->t);
 
@@ -173,34 +197,39 @@ static void print_extended(FILE* fp, ast_t* ast, size_t indent, bool type)
 
   fprintf(fp, "\n");
 
+  if(ast->annotation != NULL)
+    print(fp, ast->annotation, indent + 1, SPECIAL_ANNOTATION);
+
   while(child != NULL)
   {
-    print(fp, child, indent + 1, false);
+    print(fp, child, indent + 1, NOT_SPECIAL);
     child = child->sibling;
   }
 
   if(ast->type != NULL)
-    print(fp, ast->type, indent + 1, true);
+    print(fp, ast->type, indent + 1, SPECIAL_TYPE);
 
-  if(parens || type)
+  if(parens)
   {
     for(size_t i = 0; i < indent; i++)
       fprintf(fp, in);
 
-    fprintf(fp, type ? "]" : ")");
+    fputc(special_char[(kind * 2) + 1], fp);
   }
 }
 
-static void print_verbose(FILE* fp, ast_t* ast, size_t indent, bool type)
+static void print_verbose(FILE* fp, ast_t* ast, size_t indent,
+  enum print_special kind)
 {
   for(size_t i = 0; i < indent; i++)
     fprintf(fp, in);
 
   ast_t* child = ast->child;
-  bool parens = type || (child != NULL) || (ast->type != NULL);
+  bool parens = (kind != NOT_SPECIAL) || (child != NULL) ||
+    (ast->type != NULL) || (ast->annotation != NULL);
 
   if(parens)
-    fprintf(fp, type ? "[" : "(");
+    fputc(special_char[kind * 2], fp);
 
   print_token(fp, ast->t);
   fprintf(fp, ":%p,%0x", ast, ast->flags);
@@ -223,32 +252,35 @@ static void print_verbose(FILE* fp, ast_t* ast, size_t indent, bool type)
 
   fprintf(fp, "\n");
 
+  if(ast->annotation != NULL)
+    print_verbose(fp, ast->annotation, indent + 1, SPECIAL_ANNOTATION);
+
   while(child != NULL)
   {
-    print_verbose(fp, child, indent + 1, false);
+    print_verbose(fp, child, indent + 1, NOT_SPECIAL);
     child = child->sibling;
   }
 
   if(ast->type != NULL)
-    print_verbose(fp, ast->type, indent + 1, true);
+    print_verbose(fp, ast->type, indent + 1, SPECIAL_TYPE);
 
-  if(parens || type)
+  if(parens)
   {
     for(size_t i = 0; i < indent; i++)
       fprintf(fp, in);
 
-    fprintf(fp, type ? "]\n" : ")\n");
+    fprintf(fp, "%c\n", special_char[(kind * 2) + 1]);
   }
 }
 
-static void print(FILE* fp, ast_t* ast, size_t indent, bool type)
+static void print(FILE* fp, ast_t* ast, size_t indent, enum print_special kind)
 {
-  size_t len = length(ast, indent, type);
+  size_t len = length(ast, indent, kind);
 
   if(len < width)
-    print_compact(fp, ast, indent, type);
+    print_compact(fp, ast, indent, kind);
   else
-    print_extended(fp, ast, indent, type);
+    print_extended(fp, ast, indent, kind);
 
   fprintf(fp, "\n");
 }
@@ -304,6 +336,7 @@ static ast_t* duplicate(ast_t* parent, ast_t* ast)
 
   n->child = duplicate(n, ast->child);
   n->type = duplicate(n, ast->type);
+  n->annotation = duplicate(n, ast->annotation);
 
   if(ast->symtab != NULL)
     n->symtab = symtab_dup(ast->symtab);
@@ -618,6 +651,57 @@ void ast_settype(ast_t* ast, ast_t* type)
   }
 
   ast->type = type;
+}
+
+ast_t* ast_annotation(ast_t* ast)
+{
+  assert(ast != NULL);
+  return ast->annotation;
+}
+
+void ast_setannotation(ast_t* ast, ast_t* annotation)
+{
+  assert(ast != NULL);
+
+  if(ast->annotation == annotation)
+    return;
+
+  ast_free(ast->annotation);
+
+  assert((annotation == NULL) || !hasparent(annotation));
+
+  ast->annotation = annotation;
+}
+
+ast_t* ast_consumeannotation(ast_t* ast)
+{
+  assert(ast != NULL);
+
+  ast_t* annotation = ast->annotation;
+  ast->annotation = NULL;
+
+  return annotation;
+}
+
+bool ast_has_annotation(ast_t* ast, const char* name)
+{
+  assert(ast != NULL);
+
+  ast_t* annotation = ast->annotation;
+
+  if((annotation != NULL) && (ast_id(annotation) == TK_BACKSLASH))
+  {
+    const char* strtab_name = stringtab(name);
+    ast_t* elem = ast_child(annotation);
+    while(elem != NULL)
+    {
+      if(ast_name(elem) == strtab_name)
+        return true;
+      elem = ast_sibling(elem);
+    }
+  }
+
+  return false;
 }
 
 void ast_erase(ast_t* ast)
@@ -1198,6 +1282,7 @@ void ast_free(ast_t* ast)
   }
 
   ast_free(ast->type);
+  ast_free(ast->annotation);
 
   switch(token_get_id(ast->t))
   {
@@ -1243,7 +1328,7 @@ void ast_fprint(FILE* fp, ast_t* ast)
   if(ast == NULL)
     return;
 
-  print(fp, ast, 0, false);
+  print(fp, ast, 0, NOT_SPECIAL);
   fprintf(fp, "\n");
 }
 
@@ -1252,7 +1337,7 @@ void ast_fprintverbose(FILE* fp, ast_t* ast)
   if(ast == NULL)
     return;
 
-  print_verbose(fp, ast, 0, false);
+  print_verbose(fp, ast, 0, NOT_SPECIAL);
 }
 
 static void print_type(printbuf_t* buffer, ast_t* type);

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -90,6 +90,10 @@ double ast_float(ast_t* ast);
 lexint_t* ast_int(ast_t* ast);
 ast_t* ast_type(ast_t* ast);
 void ast_settype(ast_t* ast, ast_t* type);
+ast_t* ast_annotation(ast_t* ast);
+void ast_setannotation(ast_t* ast, ast_t* annotation);
+ast_t* ast_consumeannotation(ast_t* ast);
+bool ast_has_annotation(ast_t* ast, const char* name);
 void ast_erase(ast_t* ast);
 
 ast_t* ast_nearest(ast_t* ast, token_id id);

--- a/src/libponyc/ast/astbuild.h
+++ b/src/libponyc/ast/astbuild.h
@@ -120,5 +120,7 @@
 /// Set the data field of the enclosing node
 #define DATA(target) ast_setdata(parent, (void*)(target));
 
+/// Set the annotation of the enclosing node
+#define ANNOTATE(target) ast_setannotation(parent, target);
 
 #endif

--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -814,6 +814,8 @@ static void bnf_mark_used_rules(bnf_t* tree)
     bnf_rule_set(p, tokens); \
   }
 
+#define ANNOTATE(rule) OPT RULE("annotations", rule)
+
 #define DONE()  }
 
 

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -62,6 +62,8 @@ static const lextoken_t symbols[] =
 
   { ".>", TK_CHAIN },
 
+  { "\\", TK_BACKSLASH },
+
   { "{", TK_LBRACE },
   { "}", TK_RBRACE },
   { "(", TK_LPAREN },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -16,6 +16,8 @@
 DECL(type);
 DECL(rawseq);
 DECL(seq);
+DECL(annotatedrawseq);
+DECL(annotatedseq);
 DECL(exprseq);
 DECL(nextexprseq);
 DECL(assignment);
@@ -292,10 +294,20 @@ DEF(positional);
   WHILE(TK_COMMA, RULE("argument", rawseq));
   DONE();
 
-// OBJECT [CAP] [IS type] members END
+// '\' ID {COMMA ID} '\'
+DEF(annotations);
+  PRINT_INLINE();
+  TOKEN(NULL, TK_BACKSLASH);
+  TOKEN("annotation", TK_ID);
+  WHILE(TK_COMMA, TOKEN("annotation", TK_ID));
+  TERMINATE("annotations", TK_BACKSLASH);
+  DONE();
+
+// OBJECT [annotations] [CAP] [IS type] members END
 DEF(object);
   PRINT_INLINE();
   TOKEN(NULL, TK_OBJECT);
+  ANNOTATE(annotations);
   OPT RULE("capability", cap);
   IF(TK_IS, RULE("provided type", provides));
   RULE("object member", members);
@@ -320,11 +332,12 @@ DEF(lambdacaptures);
   SKIP(NULL, TK_RPAREN);
   DONE();
 
-// LAMBDA [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params] RPAREN
-// [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq END
+// LAMBDA [annotations] [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params]
+// RPAREN [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq END
 DEF(oldlambda);
   PRINT_INLINE();
   TOKEN(NULL, TK_LAMBDA);
+  ANNOTATE(annotations);
   OPT RULE("receiver capability", cap);
   OPT TOKEN("function name", TK_ID);
   OPT RULE("type parameters", typeparams);
@@ -344,12 +357,13 @@ DEF(oldlambda);
   SET_CHILD_FLAG(7, AST_FLAG_PRESERVE); // Body
   DONE();
 
-// LBRACE [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params] RPAREN
-// [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq RBRACE [CAP]
+// LBRACE [annotations] [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params]
+// RPAREN [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq RBRACE [CAP]
 DEF(lambda);
   PRINT_INLINE();
   AST_NODE(TK_LAMBDA);
   SKIP(NULL, TK_LBRACE);
+  ANNOTATE(annotations);
   OPT RULE("receiver capability", cap);
   OPT TOKEN("function name", TK_ID);
   OPT RULE("type parameters", typeparams);
@@ -597,28 +611,30 @@ DEF(idseq);
   RULE("variable name", idseqsingle, dontcare, idseqmulti);
   DONE();
 
-// ELSE seq
+// ELSE annotatedseq
 DEF(elseclause);
   PRINT_INLINE();
   SKIP(NULL, TK_ELSE);
-  RULE("else value", seq);
+  RULE("else value", annotatedseq);
   DONE();
 
-// ELSEIF rawseq THEN seq [elseif | (ELSE seq)]
+// ELSEIF [annotations] rawseq THEN seq [elseif | (ELSE seq)]
 DEF(elseif);
   AST_NODE(TK_IF);
   SCOPE();
   SKIP(NULL, TK_ELSEIF);
+  ANNOTATE(annotations);
   RULE("condition expression", rawseq);
   SKIP(NULL, TK_THEN);
   RULE("then value", seq);
   OPT RULE("else clause", elseif, elseclause);
   DONE();
 
-// IF rawseq THEN seq [elseif | (ELSE seq)] END
+// IF [annotations] rawseq THEN seq [elseif | elseclause] END
 DEF(cond);
   PRINT_INLINE();
   TOKEN(NULL, TK_IF);
+  ANNOTATE(annotations);
   SCOPE();
   RULE("condition expression", rawseq);
   SKIP(NULL, TK_THEN);
@@ -627,11 +643,12 @@ DEF(cond);
   TERMINATE("if expression", TK_END);
   DONE();
 
-// ELSEIF infix [$EXTRA infix] THEN seq [elseifdef | (ELSE seq)]
+// ELSEIF [annotations] infix [$EXTRA infix] THEN seq [elseifdef | elseclause]
 DEF(elseifdef);
   AST_NODE(TK_IFDEF);
   SCOPE();
   SKIP(NULL, TK_ELSEIF);
+  ANNOTATE(annotations);
   RULE("condition expression", infix);
   IF(TK_TEST_EXTRA, RULE("else condition", infix));
   SKIP(NULL, TK_THEN);
@@ -642,10 +659,12 @@ DEF(elseifdef);
   REORDER(0, 2, 3, 1);
   DONE();
 
-// IFDEF infix [$EXTRA infix] THEN seq [elseifdef | (ELSE seq)] END
+// IFDEF [annotations] infix [$EXTRA infix] THEN seq [elseifdef | elseclause]
+// END
 DEF(ifdef);
   PRINT_INLINE();
   TOKEN(NULL, TK_IFDEF);
+  ANNOTATE(annotations);
   SCOPE();
   RULE("condition expression", infix);
   IF(TK_TEST_EXTRA, RULE("else condition", infix));
@@ -658,11 +677,12 @@ DEF(ifdef);
   REORDER(0, 2, 3, 1);
   DONE();
 
-// PIPE [infix] [WHERE rawseq] [ARROW rawseq]
+// PIPE [annotations] [infix] [WHERE rawseq] [ARROW rawseq]
 DEF(caseexpr);
   AST_NODE(TK_CASE);
   SCOPE();
   SKIP(NULL, TK_PIPE);
+  ANNOTATE(annotations);
   OPT RULE("case pattern", pattern);
   IF(TK_IF, RULE("guard expression", rawseq));
   IF(TK_DBLARROW, RULE("case body", rawseq));
@@ -676,42 +696,45 @@ DEF(cases);
   SEQ("cases", caseexpr);
   DONE();
 
-// MATCH rawseq cases [ELSE seq] END
+// MATCH [annotations] rawseq cases [ELSE annotatedseq] END
 DEF(match);
   PRINT_INLINE();
   TOKEN(NULL, TK_MATCH);
+  ANNOTATE(annotations);
   SCOPE();
   RULE("match expression", rawseq);
   RULE("cases", cases);
-  IF(TK_ELSE, RULE("else clause", seq));
+  IF(TK_ELSE, RULE("else clause", annotatedseq));
   TERMINATE("match expression", TK_END);
   DONE();
 
-// WHILE rawseq DO seq [ELSE seq] END
+// WHILE [annotations] rawseq DO seq [ELSE annotatedseq] END
 DEF(whileloop);
   PRINT_INLINE();
   TOKEN(NULL, TK_WHILE);
+  ANNOTATE(annotations);
   SCOPE();
   RULE("condition expression", rawseq);
   SKIP(NULL, TK_DO);
   RULE("while body", seq);
-  IF(TK_ELSE, RULE("else clause", seq));
+  IF(TK_ELSE, RULE("else clause", annotatedseq));
   TERMINATE("while loop", TK_END);
   DONE();
 
-// REPEAT seq UNTIL seq [ELSE seq] END
+// REPEAT [annotations] seq UNTIL seq [ELSE annotatedseq] END
 DEF(repeat);
   PRINT_INLINE();
   TOKEN(NULL, TK_REPEAT);
+  ANNOTATE(annotations);
   SCOPE();
   RULE("repeat body", seq);
   SKIP(NULL, TK_UNTIL);
   RULE("condition expression", rawseq);
-  IF(TK_ELSE, RULE("else clause", seq));
+  IF(TK_ELSE, RULE("else clause", annotatedseq));
   TERMINATE("repeat loop", TK_END);
   DONE();
 
-// FOR idseq IN rawseq DO rawseq [ELSE seq] END
+// FOR [annotations] idseq IN rawseq DO rawseq [ELSE annotatedseq] END
 // =>
 // (SEQ
 //   (ASSIGN (LET $1) iterator)
@@ -721,12 +744,13 @@ DEF(repeat);
 DEF(forloop);
   PRINT_INLINE();
   TOKEN(NULL, TK_FOR);
+  ANNOTATE(annotations);
   RULE("iterator name", idseq);
   SKIP(NULL, TK_IN);
   RULE("iterator", rawseq);
   SKIP(NULL, TK_DO);
   RULE("for body", rawseq);
-  IF(TK_ELSE, RULE("else clause", seq));
+  IF(TK_ELSE, RULE("else clause", annotatedseq));
   TERMINATE("for loop", TK_END);
   DONE();
 
@@ -746,7 +770,7 @@ DEF(withexpr);
   WHILE(TK_COMMA, RULE("with expression", withelem));
   DONE();
 
-// WITH withexpr DO rawseq [ELSE rawseq] END
+// WITH [annotations] withexpr DO rawseq [ELSE annotatedrawseq] END
 // =>
 // (SEQ
 //   (ASSIGN (LET $1 initialiser))*
@@ -759,38 +783,42 @@ DEF(withexpr);
 DEF(with);
   PRINT_INLINE();
   TOKEN(NULL, TK_WITH);
+  ANNOTATE(annotations);
   RULE("with expression", withexpr);
   SKIP(NULL, TK_DO);
   RULE("with body", rawseq);
-  IF(TK_ELSE, RULE("else clause", rawseq));
+  IF(TK_ELSE, RULE("else clause", annotatedrawseq));
   TERMINATE("with expression", TK_END);
   DONE();
 
-// TRY seq [ELSE seq] [THEN seq] END
+// TRY [annotations] seq [ELSE annotatedseq] [THEN annotatedseq] END
 DEF(try_block);
   PRINT_INLINE();
   TOKEN(NULL, TK_TRY);
+  ANNOTATE(annotations);
   RULE("try body", seq);
-  IF(TK_ELSE, RULE("try else body", seq));
-  IF(TK_THEN, RULE("try then body", seq));
+  IF(TK_ELSE, RULE("try else body", annotatedseq));
+  IF(TK_THEN, RULE("try then body", annotatedseq));
   TERMINATE("try expression", TK_END);
   DONE();
 
-// $TRY_NO_CHECK seq [ELSE seq] [THEN seq] END
+// $TRY_NO_CHECK [annotations] seq [ELSE annotatedseq] [THEN annotatedseq] END
 DEF(test_try_block);
   PRINT_INLINE();
   TOKEN(NULL, TK_TEST_TRY_NO_CHECK);
+  ANNOTATE(annotations);
   MAP_ID(TK_TEST_TRY_NO_CHECK, TK_TRY_NO_CHECK);
   RULE("try body", seq);
-  IF(TK_ELSE, RULE("try else body", seq));
-  IF(TK_THEN, RULE("try then body", seq));
+  IF(TK_ELSE, RULE("try else body", annotatedseq));
+  IF(TK_THEN, RULE("try then body", annotatedseq));
   TERMINATE("try expression", TK_END);
   DONE();
 
-// RECOVER [CAP] rawseq END
+// RECOVER [annotations] [CAP] rawseq END
 DEF(recover);
   PRINT_INLINE();
   TOKEN(NULL, TK_RECOVER);
+  ANNOTATE(annotations)
   OPT RULE("capability", cap);
   RULE("recover body", seq);
   TERMINATE("recover expression", TK_END);
@@ -987,10 +1015,24 @@ DEF(seq);
   SCOPE();
   DONE();
 
-// (FUN | BE | NEW) [CAP] ID [typeparams] (LPAREN | LPAREN_NEW) [params]
-// RPAREN [COLON type] [QUESTION] [ARROW rawseq]
+// [annotations] (exprseq | jump)
+DEF(annotatedrawseq);
+  AST_NODE(TK_SEQ);
+  ANNOTATE(annotations);
+  RULE("value", exprseq, jump);
+  DONE();
+
+// annotatedrawseq
+DEF(annotatedseq);
+  RULE("value", annotatedrawseq);
+  SCOPE();
+  DONE();
+
+// (FUN | BE | NEW) [annotations] [CAP] ID [typeparams] (LPAREN | LPAREN_NEW)
+// [params] RPAREN [COLON type] [QUESTION] [ARROW rawseq]
 DEF(method);
   TOKEN(NULL, TK_FUN, TK_BE, TK_NEW);
+  ANNOTATE(annotations);
   SCOPE();
   OPT RULE("capability", cap);
   TOKEN("method name", TK_ID);
@@ -1030,13 +1072,14 @@ DEF(members);
   SEQ("method", method);
   DONE();
 
-// (TYPE | INTERFACE | TRAIT | PRIMITIVE | STRUCT | CLASS | ACTOR) [AT] ID
-// [typeparams] [CAP] [IS type] [STRING] members
+// (TYPE | INTERFACE | TRAIT | PRIMITIVE | STRUCT | CLASS | ACTOR) [annotations]
+// [AT] ID [typeparams] [CAP] [IS type] [STRING] members
 DEF(class_def);
   RESTART(TK_TYPE, TK_INTERFACE, TK_TRAIT, TK_PRIMITIVE, TK_STRUCT, TK_CLASS,
     TK_ACTOR);
   TOKEN("entity", TK_TYPE, TK_INTERFACE, TK_TRAIT, TK_PRIMITIVE, TK_STRUCT,
     TK_CLASS, TK_ACTOR);
+  ANNOTATE(annotations);
   SCOPE();
   OPT TOKEN(NULL, TK_AT);
   OPT RULE("capability", cap);

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -101,7 +101,7 @@ static void syntax_error(parser_t* parser, const char* expected,
 
 // Standard build functions
 
-void default_builder(rule_state_t* state, ast_t* new_ast)
+static void default_builder(rule_state_t* state, ast_t* new_ast)
 {
   assert(state != NULL);
   assert(new_ast != NULL);
@@ -151,6 +151,15 @@ void infix_reverse_builder(rule_state_t* state, ast_t* new_ast)
   state->ast = new_ast;
 
   // state->last_child is actually still valid, so leave it
+}
+
+
+static void annotation_builder(rule_state_t* state, ast_t* new_ast)
+{
+  assert(state != NULL);
+  assert(new_ast != NULL);
+
+  ast_setannotation(state->ast, new_ast);
 }
 
 
@@ -472,7 +481,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
  *    NULL to propogate a restarted error.
  */
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
-  const rule_t* rule_set, bool* out_found)
+  const rule_t* rule_set, bool* out_found, bool annotate)
 {
   assert(parser != NULL);
   assert(state != NULL);
@@ -492,9 +501,9 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
       (rule_set[1] == NULL) ? "" : "s", desc);
   }
 
+  builder_fn_t build_fn = annotate ? annotation_builder : default_builder;
   for(const rule_t* p = rule_set; *p != NULL; p++)
   {
-    builder_fn_t build_fn = default_builder;
     ast_t* rule_ast = (*p)(parser, &build_fn, desc);
 
     if(rule_ast == PARSE_ERROR)

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -119,7 +119,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
   bool* out_found);
 
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
-  const rule_t* rule_set, bool* out_found);
+  const rule_t* rule_set, bool* out_found, bool annotate);
 
 void parse_set_next_flags(parser_t* parser, uint32_t flags);
 
@@ -316,7 +316,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
 #define RULE(desc, ...) \
   { \
     static const rule_t rule_set[] = { __VA_ARGS__, NULL }; \
-    ast_t* r = parse_rule_set(parser, &state, desc, rule_set, NULL); \
+    ast_t* r = parse_rule_set(parser, &state, desc, rule_set, NULL, false); \
     if(r != PARSE_OK) return r; \
   }
 
@@ -400,7 +400,8 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     while(found) \
     { \
       state.deflt_id = TK_EOF; \
-      ast_t* r = parse_rule_set(parser, &state, desc, rule_set, &found); \
+      ast_t* r = parse_rule_set(parser, &state, desc, rule_set, &found, \
+        false); \
       if(r != PARSE_OK) return r; \
     } \
   }
@@ -470,6 +471,21 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     body; \
     state.ast = ast; \
     state.last_child = NULL; \
+  }
+
+
+/** Annotate the current AST with another AST node from an arbitrary rule.
+ *
+ * Example:
+ *    ANNOTATE(annotations)
+ */
+#define ANNOTATE(rule) \
+  { \
+    state.deflt_id = TK_EOF; \
+    static const rule_t rule_set[] = { rule, NULL }; \
+    ast_t* r = parse_rule_set(parser, &state, "annotations", rule_set, NULL, \
+      true); \
+    if(r != PARSE_OK) return r; \
   }
 
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -35,6 +35,7 @@ typedef enum token_id
   TK_RPAREN,
   TK_LSQUARE,
   TK_RSQUARE,
+  TK_BACKSLASH,
 
   TK_COMMA,
   TK_ARROW,

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -94,6 +94,7 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
 
   AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
     ret_type, raises, body, reference_cap);
+  ast_t* annotation = ast_consumeannotation(ast);
 
   ast_t* members = ast_from(ast, TK_MEMBERS);
   ast_t* last_member = NULL;
@@ -130,6 +131,7 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
   // Make the apply function
   BUILD(apply, ast,
     NODE(TK_FUN, AST_SCOPE
+      ANNOTATE(annotation)
       TREE(receiver_cap)
       ID(fn_name)
       TREE(t_params)

--- a/test/libponyc/annotations.cc
+++ b/test/libponyc/annotations.cc
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+#include "util.h"
+
+
+#define TEST_COMPILE(src, pass) DO(test_compile(src, pass))
+#define TEST_ERROR(src) DO(test_error(src, "syntax"))
+
+class AnnotationsTest : public PassTest
+{};
+
+
+TEST_F(AnnotationsTest, AnnotateTypes)
+{
+  const char* src =
+    "actor \\a, b\\ A\n"
+	"class \\a, b\\ C\n"
+    "primitive \\a, b\\ P\n"
+    "struct \\a, b\\ S\n"
+    "interface \\a, b\\ I\n"
+    "trait \\a, b\\ T";
+
+  TEST_COMPILE(src, "syntax");
+}
+
+TEST_F(AnnotationsTest, AnnotateMethods)
+{   
+  const char* src =
+	"actor A\n"
+    "  new \\a, b\\ create() => None\n"
+    "  be \\a, b\\ apply() => None\n"
+	"  fun \\a, b\\ apply() => None";
+
+  TEST_COMPILE(src, "syntax");
+}
+
+TEST_F(AnnotationsTest, AnnotateCompoundExpr)
+{
+  const char* src =
+    "class C\n"
+    "  fun apply() =>\n"
+	"    if \\a, b\\ foo then\n"
+	"      None\n"
+	"    elseif \\a, b\\ bar then\n"
+	"      None\n"
+	"    else \\a, b\\ \n"
+	"      None\n"
+	"    end\n"
+
+	"    ifdef \\a, b\\ \"foo\" then\n"
+	"      None\n"
+	"    elseif \\a, b\\ \"bar\" then\n"
+	"      None\n"
+	"    else \\a, b\\ \n"
+	"      None\n"
+	"    end\n"
+
+    "    while \\a, b\\ foo do\n"
+    "      None\n"
+    "    else \\a, b\\ \n"
+    "      None\n"
+    "    end\n"
+
+	"    repeat \\a, b\\ \n"
+	"      None\n"
+	"    until foo end\n"
+
+	"    match \\a, b\\ x\n"
+	"    | \\a, b\\ foo => None\n"
+	"    else \\a, b\\ \n"
+	"      None\n"
+	"    end\n"
+
+	"    try \\a, b\\ \n"
+	"      None\n"
+	"    else \\a, b\\ \n"
+	"      None\n"
+	"    then \\a, b\\ \n"
+	"      None\n"
+	"    end\n"
+
+	"    recover \\a, b\\ foo end";
+
+  TEST_COMPILE(src, "syntax");
+}
+
+TEST_F(AnnotationsTest, UnterminatedAnnotationError)
+{
+  const char* src =
+    "class \\a C";
+
+  TEST_ERROR(src);
+}
+
+TEST_F(AnnotationsTest, InvalidAnnotationError)
+{
+  const char* src =
+    "class \\0a\\ C";
+
+  TEST_ERROR(src);
+}
+
+TEST_F(AnnotationsTest, AnnotationsArePresent)
+{
+  const char* src =
+	"class \\a, b\\ C";
+
+  TEST_COMPILE(src, "scope");
+
+  ast_t* ast = lookup_type("C");
+  
+  ast = ast_annotation(ast);
+
+  ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_BACKSLASH));
+  ast = ast_child(ast);
+
+  ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ID) &&
+    (ast_name(ast) == stringtab("a")));
+  ast = ast_sibling(ast);
+
+  ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ID) &&
+    (ast_name(ast) == stringtab("b")));
+}
+
+TEST_F(AnnotationsTest, AnnotateSugar)
+{
+  const char* src =
+    "class C\n"
+    "  fun test_for() =>\n"
+    "    for \\a\\ i in x do\n"
+    "      None\n"
+    "    else \\b\\ \n"
+    "      None\n"
+    "    end\n"
+
+	"  fun test_with() =>\n"
+	"    with \\a\\ x = 42 do\n"
+	"      None\n"
+	"    else \\b\\ \n"
+	"      None\n"
+	"    end\n"
+
+	"  fun test_object() =>\n"
+	"    object \\a\\ \n"
+	"      fun \\b\\ apply() => None\n"
+	"    end";
+
+  TEST_COMPILE(src, "scope");
+
+  ast_t* c_type = lookup_type("C");
+
+  // Get the sugared `while` node.
+  ast_t* ast = lookup_in(c_type, "test_for");
+  ast = ast_childidx(ast_child(ast_childidx(ast, 6)), 1);
+
+  ASSERT_TRUE(ast_has_annotation(ast, "a"));
+  ASSERT_FALSE(ast_has_annotation(ast, "b"));
+  ASSERT_TRUE(ast_has_annotation(ast_childidx(ast, 2), "b"));
+
+  // Get the sugared `try` node.
+  ast = lookup_in(c_type, "test_with");
+  ast = ast_childidx(ast_child(ast_childidx(ast, 6)), 1);
+
+  ASSERT_TRUE(ast_has_annotation(ast, "a"));
+  ASSERT_FALSE(ast_has_annotation(ast, "b"));
+  ASSERT_TRUE(ast_has_annotation(ast_childidx(ast, 1), "b"));
+
+  // Get the type of the object literal.
+  ast = lookup_type("$1$2");
+
+  ASSERT_TRUE(ast_has_annotation(ast, "a"));
+  ast = lookup_in(ast, "apply");
+
+  ASSERT_TRUE(ast_has_annotation(ast, "b"));
+}
+
+TEST_F(AnnotationsTest, AnnotateLambda)
+{
+  const char* src =
+    "class C\n"
+    "  fun apply() =>\n"
+    "    {\\a\\() => None }";
+
+  TEST_COMPILE(src, "expr");
+
+  // Get the type of the lambda.
+  ast_t* ast = lookup_type("$1$0");
+
+  ASSERT_FALSE(ast_has_annotation(ast, "a"));
+  ast = lookup_in(ast, "apply");
+
+  ASSERT_TRUE(ast_has_annotation(ast, "a"));
+}


### PR DESCRIPTION
Scoping keywords can now be annotated with arbitrary Pony identifiers. The current format for annotations is `\foo, bar\`. In the actual implementation, any grammar rule can easily be used as an annotation if we need that flexibility in the future.

Closes #1442.