### PR TITLE
Fix type system hole introduced by fee5e5c

### DIFF
--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -719,6 +719,25 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
             ast_t* parent = ast_parent(ast);
             if(ast_id(parent) != TK_DOT)
               type = set_cap_and_ephemeral(type, TK_TAG, TK_NONE);
+
+            if(ast_id(ast) == TK_VARREF)
+            {
+              ast_t* current = ast;
+              while(ast_id(parent) != TK_RECOVER && ast_id(parent) != TK_ASSIGN)
+              {
+                current = parent;
+                parent = ast_parent(parent);
+              }
+              if(ast_id(parent) == TK_ASSIGN && ast_child(parent) != current)
+              {
+                ast_error(opt->check.errors, ast, "can't access a non-sendable "
+                  "local defined outside of a recover expression from within "
+                  "that recover epression");
+                ast_error_continue(opt->check.errors, parent, "this would be "
+                  "possible if the local wasn't assigned to");
+                return false;
+              }
+            }
           }
         }
       }

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -520,3 +520,18 @@ TEST_F(RecoverTest, CantRecover_TupleInUnionInnerLift)
 
   TEST_ERRORS_1(src, "right side must be a subtype of left side");
 }
+
+TEST_F(RecoverTest, CantAccess_NonSendableLocalAssigned)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    var a: String ref = String\n"
+    "    recover\n"
+    "      let b: String ref = String\n"
+    "      a = b\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
+    "left side must be something that can be assigned to");
+}


### PR DESCRIPTION
After the aforementioned change, non-sendable locals could be assigned to inside of recover expressions, violating the isolation boundary of recover.

No changelog entry since the bug isn't in a released version.