### PR TITLE
Handle #any in chain_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Improve Map.get_or_else performance (PR #1482)
 - Back pressure notifications now given when encountered while sending data during `TCPConnection` pending writes
 - Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
+- Compiler assertion failure during type checking
 
 ### Added
 

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -456,7 +456,13 @@ ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call)
         case TK_CAP_ALIAS:
           // If the receiver type aliases as itself, it stays the same after
           // chaining.
-          return type;
+          return ast_dup(type);
+
+        case TK_CAP_ANY:
+          // If the receiver is #any, the call is on a tag method and we can
+          // chain as #any.
+          assert(fun_cap == TK_TAG);
+          return ast_dup(type);
 
         default: {}
       }


### PR DESCRIPTION
This fixes an assertion failure when chaining an `#any` receiver.

Because of other bugs in the implementation (namely #1328), non-tag methods can currently be called on an `#any` receiver. Another assertion has been added to prevent this case to silently pass.