### PR TITLE
Add ASIO one shot support when using kqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ All notable changes to the Pony compiler and standard library will be documented
     - allow_tls_v1_2
 - TCP sockets on Linux now use Epoll One Shot
 - Non-sendable locals and parameters are now seen as `tag` inside of recover expressions instead of being inaccessible.
+- TCP sockets on FreeBSD and MacOSX now use Kqueue one shot
 
 ## [0.10.0] - 2016-12-12
 

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -229,7 +229,7 @@ actor TCPConnection
     _notify = consume notify
     _connect_count = 0
     _fd = fd
-    ifdef linux then
+    ifdef not windows then
       _event = @pony_asio_event_create(this, fd,
         AsioEvent.read_write_oneshot(), 0, true)
     else
@@ -748,9 +748,7 @@ actor TCPConnection
   fun ref _apply_backpressure() =>
     ifdef not windows then
       _writeable = false
-      ifdef linux then
-        _resubscribe_event()
-      end
+      _resubscribe_event()
     end
 
     _notify.throttled(this)
@@ -759,7 +757,7 @@ actor TCPConnection
     _notify.unthrottled(this)
 
   fun ref _resubscribe_event() =>
-    ifdef linux then
+    ifdef not windows then
       let flags = if not _readable and not _writeable then
         AsioEvent.read_write_oneshot()
       elseif not _readable then

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -568,7 +568,7 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
     return false;
   }
 
-#ifdef PLATFORM_IS_LINUX
+#ifndef PLATFORM_IS_WINDOWS
   // Create an event and subscribe it.
   pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0, true);
 #else


### PR DESCRIPTION
When using EV_ONESHOT, after the user retrieves the event from the kqueue, it is deleted. This way, when the `pony_asio_event_resubscribe` is called, we need to recreate the events.