### PR TITLE
Improved error for array indexing with brackets

### DIFF
--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1125,21 +1125,12 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 
     case TK_VALUEFORMALARG:
     case TK_VALUEFORMALPARAM:
-    {
-      ast_t* array = ast_child(ast_child(
-        ast_parent(ast_parent(ast_parent(ast)))));
-
-      if(array != NULL && !strcmp(ast_get_print(array), "array")) {
-        ast_error(options->check.errors, ast_parent(ast),
-          "array indexing is not done with square brackets, "
-          "try using parentheses");
-      } else {
-        ast_error(options->check.errors, ast,
-          "Value formal parameters not yet supported");
-      }
+      ast_error(options->check.errors, ast,
+        "Value formal parameters not yet supported. "
+        "Note that many functions including array indexing use the apply "
+        "method raher than square brackets");
       r = AST_ERROR;
       break;
-    }
     
     case TK_CONSTANT:
       ast_error(options->check.errors, ast,

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1126,12 +1126,13 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_VALUEFORMALARG:
     case TK_VALUEFORMALPARAM:
       ast_error(options->check.errors, ast,
-        "Value formal parameters not yet supported. "
+        "Value formal parameters not yet supported");
+      ast_error_continue(options->check.errors, ast_parent(ast), 
         "Note that many functions including array indexing use the apply "
-        "method raher than square brackets");
+        "method rather than square brackets");
       r = AST_ERROR;
       break;
-    
+
     case TK_CONSTANT:
       ast_error(options->check.errors, ast,
         "Compile time expressions not yet supported");

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1125,11 +1125,22 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 
     case TK_VALUEFORMALARG:
     case TK_VALUEFORMALPARAM:
-      ast_error(options->check.errors, ast,
-        "Value formal parameters not yet supported");
+    {
+      ast_t* array = ast_child(ast_child(
+        ast_parent(ast_parent(ast_parent(ast)))));
+
+      if(array != NULL && !strcmp(ast_get_print(array), "array")) {
+        ast_error(options->check.errors, ast_parent(ast),
+          "array indexing is not done with square brackets, "
+          "try using parentheses");
+      } else {
+        ast_error(options->check.errors, ast,
+          "Value formal parameters not yet supported");
+      }
       r = AST_ERROR;
       break;
-
+    }
+    
     case TK_CONSTANT:
       ast_error(options->check.errors, ast,
         "Compile time expressions not yet supported");

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -341,7 +341,5 @@ TEST_F(BadPonyTest, IndexArrayWithBrackets)
         "let xs = [as I64: 1, 2, 3]\n"
         "xs[1]";
 
-  TEST_ERRORS_1(src, "Value formal parameters not yet supported. "
-            "Note that many functions including array indexing use the apply "
-            "method raher than square brackets");
+  TEST_ERRORS_1(src, "Value formal parameters not yet supported");
 }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -341,6 +341,7 @@ TEST_F(BadPonyTest, IndexArrayWithBrackets)
         "let xs = [as I64: 1, 2, 3]\n"
         "xs[1]";
 
-  TEST_ERRORS_1(src, "array indexing is not done with square brackets, "
-    "try using parentheses");
+  TEST_ERRORS_1(src, "Value formal parameters not yet supported. "
+            "Note that many functions including array indexing use the apply "
+            "method raher than square brackets");
 }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -331,3 +331,16 @@ TEST_F(BadPonyTest, AssignToFieldOfIso)
     "right side must be a subtype of left side"
     );
 }
+
+TEST_F(BadPonyTest, IndexArrayWithBrackets)
+{
+  // From issue #1493
+  const char* src =
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let xs = [as I64: 1, 2, 3]\n"
+        "xs[1]";
+
+  TEST_ERRORS_1(src, "array indexing is not done with square brackets, "
+    "try using parentheses");
+}


### PR DESCRIPTION
This PR resolves #1493  by improving the error message for indexing into an array with square brackets like `some_array[1]` as you would in many other languages. Previously the error was `Value formal parameters not yet supported`.