### PR TITLE
Update builtin package documentation

### DIFF
--- a/packages/builtin/builtin.pony
+++ b/packages/builtin/builtin.pony
@@ -1,0 +1,12 @@
+"""
+# Builtin package
+
+The builtin package is home to the following standard library members:
+
+1. Types the compiler needs to know exist, such as None.
+2. Types with "magic" internal workings that must be supplied directly by the
+compiler, such as U32.
+3. Any types needed by others in builtin.
+
+The public types that are defined in this package will always be in scope for every Pony source file. For details on specific packages, see their individual entity entries.
+"""

--- a/packages/builtin/builtin.pony
+++ b/packages/builtin/builtin.pony
@@ -8,5 +8,7 @@ The builtin package is home to the following standard library members:
 compiler, such as U32.
 3. Any types needed by others in builtin.
 
-The public types that are defined in this package will always be in scope for every Pony source file. For details on specific packages, see their individual entity entries.
+The public types that are defined in this package will always be in scope for
+every Pony source file. For details on specific packages, see their individual
+entity entries.
 """

--- a/packages/builtin/platform.pony
+++ b/packages/builtin/platform.pony
@@ -1,9 +1,3 @@
-"""
-# Builtin package
-
-The builtin package is home to standard library members that require compiler
-support. For details on specific packages, see their individual entity entries.
-"""
 primitive Platform
   fun freebsd(): Bool => compile_intrinsic
   fun linux(): Bool => compile_intrinsic


### PR DESCRIPTION
This PR moves the builtin package documentation which was previously in `platform.pony` into a separate file `builtin.pony` and updates it to include the rules defined in #286.