### PR TITLE
Always allow writing to `_` (dontcare)

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -135,13 +135,12 @@ elseif
 
 idseq
   : ID
-  | '_'
-  | ('(' | LPAREN_NEW) (idseq_in_seq | '_') (',' (idseq_in_seq | '_'))* ')'
+  | ('(' | LPAREN_NEW) idseq_in_seq (',' idseq_in_seq)* ')'
   ;
 
 idseq_in_seq
   : ID
-  | ('(' | LPAREN_NEW) (idseq_in_seq | '_') (',' (idseq_in_seq | '_'))* ')'
+  | ('(' | LPAREN_NEW) idseq_in_seq (',' idseq_in_seq)* ')'
   ;
 
 nextpattern
@@ -192,7 +191,7 @@ nextatom
   : ID
   | 'this'
   | literal
-  | LPAREN_NEW (rawseq | '_') tuple? ')'
+  | LPAREN_NEW rawseq tuple? ')'
   | LSQUARE_NEW ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' ('\' ID (',' ID)* '\')? cap? ('is' type)? members 'end'
   | '{' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
@@ -205,7 +204,7 @@ atom
   : ID
   | 'this'
   | literal
-  | ('(' | LPAREN_NEW) (rawseq | '_') tuple? ')'
+  | ('(' | LPAREN_NEW) rawseq tuple? ')'
   | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq (',' rawseq)* ']'
   | 'object' ('\' ID (',' ID)* '\')? cap? ('is' type)? members 'end'
   | '{' ('\' ID (',' ID)* '\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
@@ -215,7 +214,7 @@ atom
   ;
 
 tuple
-  : ',' (rawseq | '_') (',' (rawseq | '_'))*
+  : ',' rawseq (',' rawseq)*
   ;
 
 lambdacaptures
@@ -245,7 +244,7 @@ type
 atomtype
   : 'this'
   | cap
-  | ('(' | LPAREN_NEW) (infixtype | '_') tupletype? ')'
+  | ('(' | LPAREN_NEW) infixtype tupletype? ')'
   | nominal
   | lambdatype
   ;
@@ -255,7 +254,7 @@ lambdatype
   ;
 
 tupletype
-  : ',' (infixtype | '_') (',' (infixtype | '_'))*
+  : ',' infixtype (',' infixtype)*
   ;
 
 infixtype
@@ -322,7 +321,7 @@ literal
   ;
 
 param
-  : (parampattern | '_') (':' type)? ('=' infix)?
+  : parampattern (':' type)? ('=' infix)?
   ;
 
 antlr_0
@@ -379,7 +378,7 @@ Type:
 
 ID
   : LETTER (LETTER | DIGIT | '_' | '\'')*
-  | '_' (LETTER | DIGIT | '_' | '\'')+
+  | '_' (LETTER | DIGIT | '_' | '\'')*
   ;
 
 INT

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -1438,7 +1438,7 @@ static void print_type(printbuf_t* buffer, ast_t* type)
       printbuf(buffer, "this");
       break;
 
-    case TK_DONTCARE:
+    case TK_DONTCARETYPE:
       printbuf(buffer, "_");
       break;
 

--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -61,7 +61,7 @@ static const char* antlr_post =
   "// Lexer\n\n"
   "ID\n"
   "  : LETTER (LETTER | DIGIT | '_' | '\\'')*\n"
-  "  | '_' (LETTER | DIGIT | '_' | '\\'')+\n"
+  "  | '_' (LETTER | DIGIT | '_' | '\\'')*\n"
   "  ;\n\n"
   "INT\n"
   "  : DIGIT (DIGIT | '_')*\n"

--- a/src/libponyc/ast/id.c
+++ b/src/libponyc/ast/id.c
@@ -27,6 +27,17 @@ bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec)
     name++;
     prev = '_';
 
+    if(*name == '\0')
+    {
+      if((spec & ALLOW_DONTCARE) == 0)
+      {
+        ast_error(opt->check.errors, id_node,
+          "%s name cannot be \"%s\"", desc, ast_name(id_node));
+        return false;
+      }
+      return true;
+    }
+
     if((spec & ALLOW_LEADING_UNDERSCORE) == 0)
     {
       ast_error(opt->check.errors, id_node,
@@ -168,9 +179,9 @@ bool check_id_param(pass_opt_t* opt, ast_t* id_node)
 
 bool check_id_local(pass_opt_t* opt, ast_t* id_node)
 {
-  // [a-z][A-Za-z0-9_]*'* (and no double or trailing underscores)
+  // (_|[a-z][A-Za-z0-9_]*'*) (and no double or trailing underscores)
   return check_id(opt, id_node, "local variable",
-    START_LOWER | ALLOW_UNDERSCORE | ALLOW_TICK);
+    START_LOWER | ALLOW_UNDERSCORE | ALLOW_TICK | ALLOW_DONTCARE);
 }
 
 bool is_name_type(const char* name)
@@ -186,7 +197,8 @@ bool is_name_type(const char* name)
 
 bool is_name_private(const char* name)
 {
-  return name[0] == '_' || (is_name_internal_test(name) && name[1] == '_');
+  return ((name[0] == '_') && (name[1] != '\0')) ||
+    (is_name_internal_test(name) && (name[1] == '_'));
 }
 
 bool is_name_ffi(const char* name)
@@ -197,4 +209,9 @@ bool is_name_ffi(const char* name)
 bool is_name_internal_test(const char* name)
 {
   return name[0] == '$';
+}
+
+bool is_name_dontcare(const char* name)
+{
+  return (name[0] == '_') && (name[1] == '\0');
 }

--- a/src/libponyc/ast/id.h
+++ b/src/libponyc/ast/id.h
@@ -47,6 +47,9 @@ bool is_name_ffi(const char* name);
 // Report whether the given id name is for an internal test
 bool is_name_internal_test(const char* name);
 
+// Report whether the given id name is '_'
+bool is_name_dontcare(const char* name);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/ast/id_internal.h
+++ b/src/libponyc/ast/id_internal.h
@@ -15,6 +15,7 @@ PONY_EXTERN_C_BEGIN
 #define ALLOW_LEADING_UNDERSCORE  0x04
 #define ALLOW_UNDERSCORE          0x08
 #define ALLOW_TICK                0x10
+#define ALLOW_DONTCARE            0x20
 
 
 /* Check that the name in the given ID node meets the given spec.

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -106,7 +106,6 @@ static const lextoken_t symbols[] =
 
 static const lextoken_t keywords[] =
 {
-  { "_", TK_DONTCARE },
   { "compile_intrinsic", TK_COMPILE_INTRINSIC },
 
   { "use", TK_USE },
@@ -211,6 +210,7 @@ static const lextoken_t abstract[] =
   { "members", TK_MEMBERS },
   { "fvar", TK_FVAR },
   { "flet", TK_FLET },
+  { "dontcare", TK_DONTCARE },
   { "ffidecl", TK_FFIDECL },
   { "fficall", TK_FFICALL },
 
@@ -222,6 +222,7 @@ static const lextoken_t abstract[] =
   { "thistype", TK_THISTYPE },
   { "funtype", TK_FUNTYPE },
   { "lambdatype", TK_LAMBDATYPE },
+  { "dontcaretype", TK_DONTCARETYPE },
   { "infer", TK_INFERTYPE },
   { "errortype", TK_ERRORTYPE },
 
@@ -279,6 +280,7 @@ static const lextoken_t abstract[] =
   { "varref", TK_VARREF },
   { "letref", TK_LETREF },
   { "paramref", TK_PARAMREF },
+  { "dontcareref", TK_DONTCAREREF },
   { "newapp", TK_NEWAPP },
   { "beapp", TK_BEAPP },
   { "funapp", TK_FUNAPP },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -57,12 +57,6 @@ DECL(thisliteral);
 
 // Parse rules
 
-// DONTCARE
-DEF(dontcare);
-  PRINT_INLINE();
-  TOKEN(NULL, TK_DONTCARE);
-  DONE();
-
 // type
 DEF(provides);
   PRINT_INLINE();
@@ -70,10 +64,10 @@ DEF(provides);
   RULE("provided type", type);
   DONE();
 
-// (postfix | dontcare) [COLON type] [ASSIGN infix]
+// postfix [COLON type] [ASSIGN infix]
 DEF(param);
   AST_NODE(TK_PARAM);
-  RULE("name", parampattern, dontcare);
+  RULE("name", parampattern);
   IF(TK_COLON,
     RULE("parameter type", type);
     UNWRAP(0, TK_REFERENCE);
@@ -196,20 +190,20 @@ DEF(infixtype);
   SEQ("type", uniontype, isecttype);
   DONE();
 
-// COMMA (infixtype | dontcare) {COMMA (infixtype | dontcare)}
+// COMMA infixtype {COMMA infixtype}
 DEF(tupletype);
   INFIX_BUILD();
   TOKEN(NULL, TK_COMMA);
   MAP_ID(TK_COMMA, TK_TUPLETYPE);
-  RULE("type", infixtype, dontcare);
-  WHILE(TK_COMMA, RULE("type", infixtype, dontcare));
+  RULE("type", infixtype);
+  WHILE(TK_COMMA, RULE("type", infixtype));
   DONE();
 
-// (LPAREN | LPAREN_NEW) (infixtype | dontcare) [tupletype] RPAREN
+// (LPAREN | LPAREN_NEW) infixtype [tupletype] RPAREN
 DEF(groupedtype);
   PRINT_INLINE();
   SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
-  RULE("type", infixtype, dontcare);
+  RULE("type", infixtype);
   OPT_NO_DFLT RULE("type", tupletype);
   SKIP(NULL, TK_RPAREN);
   SET_FLAG(AST_FLAG_IN_PARENS);
@@ -413,30 +407,30 @@ DEF(nextarray);
   TERMINATE("array literal", TK_RSQUARE);
   DONE();
 
-// COMMA (rawseq | dontcare) {COMMA (rawseq | dontcare)}
+// COMMA rawseq {COMMA rawseq}
 DEF(tuple);
   INFIX_BUILD();
   TOKEN(NULL, TK_COMMA);
   MAP_ID(TK_COMMA, TK_TUPLE);
-  RULE("value", rawseq, dontcare);
-  WHILE(TK_COMMA, RULE("value", rawseq, dontcare));
+  RULE("value", rawseq);
+  WHILE(TK_COMMA, RULE("value", rawseq));
   DONE();
 
-// (LPAREN | LPAREN_NEW) (rawseq | dontcare) [tuple] RPAREN
+// (LPAREN | LPAREN_NEW) rawseq [tuple] RPAREN
 DEF(groupedexpr);
   PRINT_INLINE();
   SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
-  RULE("value", rawseq, dontcare);
+  RULE("value", rawseq);
   OPT_NO_DFLT RULE("value", tuple);
   SKIP(NULL, TK_RPAREN);
   SET_FLAG(AST_FLAG_IN_PARENS);
   DONE();
 
-// LPAREN_NEW (rawseq | dontcare) [tuple] RPAREN
+// LPAREN_NEW rawseq [tuple] RPAREN
 DEF(nextgroupedexpr);
   PRINT_INLINE();
   SKIP(NULL, TK_LPAREN_NEW);
-  RULE("value", rawseq, dontcare);
+  RULE("value", rawseq);
   OPT_NO_DFLT RULE("value", tuple);
   SKIP(NULL, TK_RPAREN);
   SET_FLAG(AST_FLAG_IN_PARENS);
@@ -587,8 +581,8 @@ DEF(idseqmulti);
   PRINT_INLINE();
   AST_NODE(TK_TUPLE);
   SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
-  RULE("variable name", idseq_in_seq, dontcare);
-  WHILE(TK_COMMA, RULE("variable name", idseq_in_seq, dontcare));
+  RULE("variable name", idseq_in_seq);
+  WHILE(TK_COMMA, RULE("variable name", idseq_in_seq));
   SKIP(NULL, TK_RPAREN);
   DONE();
 
@@ -606,9 +600,9 @@ DEF(idseq_in_seq);
   RULE("variable name", idseqsingle, idseqmulti);
   DONE();
 
-// ID | '_' | (LPAREN | LPAREN_NEW) idseq {COMMA idseq} RPAREN
+// ID | (LPAREN | LPAREN_NEW) idseq {COMMA idseq} RPAREN
 DEF(idseq);
-  RULE("variable name", idseqsingle, dontcare, idseqmulti);
+  RULE("variable name", idseqsingle, idseqmulti);
   DONE();
 
 // ELSE annotatedseq

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -73,7 +73,6 @@ typedef enum token_id
   TK_QUESTION,
   TK_UNARY_MINUS,
   TK_ELLIPSIS,
-  TK_DONTCARE,
   TK_CONSTANT,
 
   // Newline symbols, only used by lexer and parser
@@ -103,6 +102,7 @@ typedef enum token_id
   TK_VAR,
   TK_LET,
   TK_EMBED,
+  TK_DONTCARE,
   TK_NEW,
   TK_FUN,
   TK_BE,
@@ -192,6 +192,7 @@ typedef enum token_id
   TK_THISTYPE,
   TK_FUNTYPE,
   TK_LAMBDATYPE,
+  TK_DONTCARETYPE,
   TK_INFERTYPE,
   TK_ERRORTYPE,
 
@@ -221,6 +222,7 @@ typedef enum token_id
   TK_CASES,
   TK_CASE,
   TK_MATCH_CAPTURE,
+  TK_MATCH_DONTCARE,
 
   TK_REFERENCE,
   TK_PACKAGEREF,
@@ -236,6 +238,7 @@ typedef enum token_id
   TK_VARREF,
   TK_LETREF,
   TK_PARAMREF,
+  TK_DONTCAREREF,
   TK_NEWAPP,
   TK_BEAPP,
   TK_FUNAPP,

--- a/src/libponyc/ast/treecheckdef.h
+++ b/src/libponyc/ast/treecheckdef.h
@@ -171,7 +171,7 @@ RULE(asop,
 
 RULE(tuple,
   HAS_TYPE(type)
-  ONE_OR_MORE(rawseq, dont_care),
+  ONE_OR_MORE(rawseq),
   TK_TUPLE);
 
 RULE(consume,
@@ -319,7 +319,7 @@ RULE(match_case,
   CHILD(rawseq, none),  // Body
   TK_CASE);
 
-RULE(no_case_expr, HAS_TYPE(dont_care), TK_NONE);
+RULE(no_case_expr, HAS_TYPE(dontcare_type), TK_NONE);
 
 RULE(try_expr,
   HAS_TYPE(type)
@@ -403,8 +403,8 @@ RULE(local_ref,
 
 GROUP(type,
   type_infix, type_tuple, type_arrow, type_this, cap, nominal,
-  type_param_ref, dont_care, fun_type, error_type, lambda_type,
-  literal_type, opliteral_type, control_type, dont_care);
+  type_param_ref, dontcare_type, fun_type, error_type, lambda_type,
+  literal_type, opliteral_type, control_type);
 
 RULE(type_infix, ONE_OR_MORE(type), TK_UNIONTYPE, TK_ISECTTYPE);
 
@@ -458,7 +458,7 @@ RULE(borrowed, LEAF, TK_BORROWED);
 RULE(cap, LEAF, TK_ISO, TK_TRN, TK_REF, TK_VAL, TK_BOX, TK_TAG);
 RULE(control_type, LEAF, TK_IF, TK_CASES, TK_COMPILE_INTRINSIC,
   TK_COMPILE_ERROR, TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR);
-RULE(dont_care, HAS_TYPE(type), TK_DONTCARE);
+RULE(dontcare_type, LEAF, TK_DONTCARETYPE);
 RULE(ellipsis, LEAF, TK_ELLIPSIS);
 RULE(ephemeral, LEAF, TK_EPHEMERAL);
 RULE(error_type, LEAF, TK_ERRORTYPE);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -49,6 +49,12 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       ret = gen_localload(c, ast);
       break;
 
+    case TK_DONTCARE:
+    case TK_DONTCAREREF:
+    case TK_MATCH_DONTCARE:
+      ret = GEN_NOVALUE;
+      break;
+
     case TK_IF:
       ret = gen_if(c, ast);
       break;
@@ -167,10 +173,6 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
 
     case TK_DIGESTOF:
       ret = gen_digestof(c, ast);
-      break;
-
-    case TK_DONTCARE:
-      ret = GEN_NOVALUE;
       break;
 
     case TK_COMPILE_INTRINSIC:

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -120,7 +120,7 @@ LLVMValueRef gen_tuple(compile_t* c, ast_t* ast)
 
   ast_t* type = ast_type(ast);
 
-  // If we contain TK_DONTCARE, we have no usable value.
+  // If we contain '_', we have no usable value.
   if(contains_dontcare(type))
     return GEN_NOTNEEDED;
 

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -458,7 +458,7 @@ static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
   ast_t* dontcare = ast_from(type, TK_TUPLETYPE);
 
   for(size_t i = 0; i < cardinality; i++)
-    ast_append(dontcare, ast_from(type, TK_DONTCARE));
+    ast_append(dontcare, ast_from(type, TK_DONTCARETYPE));
 
   // Replace our type in the tuple type with the "don't care" type.
   bool in_tuple = (tuple != NULL);
@@ -588,7 +588,7 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
   if(tuple != NULL)
   {
     // We are a tuple element. Our type is in the correct position in the
-    // tuple, everything else is TK_DONTCARE.
+    // tuple, everything else is TK_DONTCARETYPE.
     if(is_matchtype(orig, tuple, c->opt) != MATCHTYPE_ACCEPT)
       return;
   } else {

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -423,7 +423,7 @@ static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 
       return uifset_simple_type(opt, type);
 
-    case TK_DONTCARE:
+    case TK_DONTCARETYPE:
     case TK_FUNTYPE:
       return UIF_NO_TYPES;
 

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -6,6 +6,7 @@
 #include "../type/alias.h"
 #include "../type/lookup.h"
 #include "../ast/stringtab.h"
+#include "../ast/id.h"
 #include "../pass/expr.h"
 #include "../pass/pass.h"
 #include <assert.h>
@@ -113,7 +114,7 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 {
   if(ast_id(pattern) == TK_NONE)
   {
-    ast_t* type = ast_from(pattern, TK_DONTCARE);
+    ast_t* type = ast_from(pattern, TK_DONTCARETYPE);
     ast_settype(pattern, type);
     return type;
   }
@@ -128,12 +129,10 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 
   switch(ast_id(pattern))
   {
-    case TK_DONTCARE:
+    case TK_DONTCAREREF:
     case TK_MATCH_CAPTURE:
-    {
-      // Return the capture type or don't care.
+    case TK_MATCH_DONTCARE:
       return ast_type(pattern);
-    }
 
     case TK_TUPLE:
     {
@@ -368,7 +367,11 @@ bool expr_match_capture(pass_opt_t* opt, ast_t* ast)
   (void)opt;
   assert(ast != NULL);
 
-  ast_t* type = ast_childidx(ast, 1);
+  AST_GET_CHILDREN(ast, id, type);
+
+  if(is_name_dontcare(ast_name(id)))
+    ast_setid(ast, TK_MATCH_DONTCARE);
+
   assert(type != NULL);
 
   // Capture type is as specified.

--- a/src/libponyc/expr/reference.h
+++ b/src/libponyc/expr/reference.h
@@ -17,7 +17,6 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp);
 bool expr_local(pass_opt_t* opt, ast_t* ast);
 bool expr_addressof(pass_opt_t* opt, ast_t* ast);
 bool expr_digestof(pass_opt_t* opt, ast_t* ast);
-bool expr_dontcare(pass_opt_t* opt, ast_t* ast);
 bool expr_this(pass_opt_t* opt, ast_t* ast);
 bool expr_tuple(pass_opt_t* opt, ast_t* ast);
 bool expr_nominal(pass_opt_t* opt, ast_t** astp);

--- a/src/libponyc/pass/casemethod.c
+++ b/src/libponyc/pass/casemethod.c
@@ -236,17 +236,9 @@ static bool param_without_type(ast_t* case_param, ast_t* pattern,
   // Add value to match pattern.
   ast_t* value_to_add = ast_dup(value);
 
-  if(ast_id(value_to_add) == TK_DONTCARE)
-  {
-    // Value is just `don't care`.
-    ast_append(pattern, value_to_add);
-  }
-  else
-  {
-    // Value in an expression, need a containing sequence.
-    BUILD(value_ast, value, NODE(TK_SEQ, TREE(value_to_add)));
-    ast_append(pattern, value_ast);
-  }
+  // Value in an expression, need a containing sequence.
+  BUILD(value_ast, value, NODE(TK_SEQ, TREE(value_to_add)));
+  ast_append(pattern, value_ast);
 
   return true;
 }

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -291,7 +291,6 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_LOCATION:   r = expr_location(options, ast); break;
     case TK_ADDRESS:    r = expr_addressof(options, ast); break;
     case TK_DIGESTOF:   r = expr_digestof(options, ast); break;
-    case TK_DONTCARE:   r = expr_dontcare(options, ast); break;
 
     case TK_LAMBDA:
       if(!expr_lambda(options, astp))

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -293,6 +293,14 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
 
   // Find our definition.
   const char* name = ast_name(type_id);
+
+  if(is_name_dontcare(name))
+  {
+    ast_error(opt->check.errors, type_id,
+      "can't use '_' as a type name");
+    return false;
+  }
+
   ast_t* def = ast_get(r_scope, name, NULL);
   bool r = true;
 

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -6,6 +6,7 @@
 #include "../ast/token.h"
 #include "../ast/stringtab.h"
 #include "../ast/astbuild.h"
+#include "../ast/id.h"
 #include <string.h>
 #include <assert.h>
 
@@ -17,6 +18,9 @@ static bool set_scope(pass_opt_t* opt, typecheck_t* t, ast_t* scope,
 {
   assert(ast_id(name) == TK_ID);
   const char* s = ast_name(name);
+
+  if(is_name_dontcare(s))
+    return true;
 
   sym_status_t status = SYM_NONE;
 

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -462,6 +462,48 @@ static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
 }
 
 
+static ast_result_t syntax_nominal(pass_opt_t* opt, ast_t* ast)
+{
+  assert(ast != NULL);
+  AST_GET_CHILDREN(ast, package, name, typeargs, cap, eph);
+
+  if(!is_name_dontcare(ast_name(name)))
+    return AST_OK;
+
+  ast_result_t r = AST_OK;
+
+  if(ast_id(package) != TK_NONE)
+  {
+    ast_error(opt->check.errors, package,
+      "'_' cannot be in a package");
+    r = AST_ERROR;
+  }
+
+  if(ast_id(typeargs) != TK_NONE)
+  {
+    ast_error(opt->check.errors, typeargs,
+      "'_' cannot have generic arguments");
+    r = AST_ERROR;
+  }
+
+  if(ast_id(cap) != TK_NONE)
+  {
+    ast_error(opt->check.errors, cap,
+      "'_' cannot specify capability");
+    r = AST_ERROR;
+  }
+
+  if(ast_id(eph) != TK_NONE)
+  {
+    ast_error(opt->check.errors, eph,
+      "'_' cannot specify capability modifier");
+    r = AST_ERROR;
+  }
+
+  return r;
+}
+
+
 static ast_result_t syntax_match(pass_opt_t* opt, ast_t* ast)
 {
   assert(ast != NULL);
@@ -1084,6 +1126,7 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_INTERFACE:  r = syntax_entity(options, ast, DEF_INTERFACE); break;
     case TK_THISTYPE:   r = syntax_thistype(options, ast); break;
     case TK_ARROW:      r = syntax_arrowtype(options, ast); break;
+    case TK_NOMINAL:    r = syntax_nominal(options, ast); break;
     case TK_MATCH:      r = syntax_match(options, ast); break;
     case TK_FFIDECL:    r = syntax_ffi(options, ast, false); break;
     case TK_FFICALL:    r = syntax_ffi(options, ast, true); break;

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -2,6 +2,7 @@
 #include "sugar.h"
 #include "../ast/token.h"
 #include "../ast/astbuild.h"
+#include "../ast/id.h"
 #include "../pkg/package.h"
 #include "../type/assemble.h"
 #include "../type/subtype.h"
@@ -954,7 +955,12 @@ static void local_types(ast_t* ast)
   assert(type != NULL);
 
   if(ast_id(type) == TK_NONE)
-    type = ast_from(id, TK_INFERTYPE);
+  {
+    if(is_name_dontcare(ast_name(id)))
+      type = ast_from(id, TK_DONTCARETYPE);
+    else
+      type = ast_from(id, TK_INFERTYPE);
+  }
 
   ast_settype(id, type);
   ast_settype(ast, type);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -735,11 +735,11 @@ static void reachable_pattern(reach_t* r, ast_t* ast, pass_opt_t* opt)
 {
   switch(ast_id(ast))
   {
-    case TK_DONTCARE:
     case TK_NONE:
       break;
 
     case TK_MATCH_CAPTURE:
+    case TK_MATCH_DONTCARE:
     {
       AST_GET_CHILDREN(ast, idseq, type);
       add_type(r, type, opt);
@@ -761,8 +761,11 @@ static void reachable_pattern(reach_t* r, ast_t* ast, pass_opt_t* opt)
 
     default:
     {
-      reachable_method(r, ast_type(ast), stringtab("eq"), NULL, opt);
-      reachable_expr(r, ast, opt);
+      if(ast_id(ast_type(ast)) != TK_DONTCARETYPE)
+      {
+        reachable_method(r, ast_type(ast), stringtab("eq"), NULL, opt);
+        reachable_expr(r, ast, opt);
+      }
       break;
     }
   }

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -273,7 +273,7 @@ ast_t* consume_type(ast_t* type, token_id cap)
 {
   switch(ast_id(type))
   {
-    case TK_DONTCARE:
+    case TK_DONTCARETYPE:
       return type;
 
     case TK_UNIONTYPE:

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -438,7 +438,7 @@ static matchtype_t is_x_match_arrow(ast_t* operand, ast_t* pattern,
 static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
   pass_opt_t* opt)
 {
-  if(ast_id(pattern) == TK_DONTCARE)
+  if(ast_id(pattern) == TK_DONTCARETYPE)
     return MATCHTYPE_ACCEPT;
 
   switch(ast_id(pattern))
@@ -460,9 +460,6 @@ static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
 
     case TK_ARROW:
       return is_x_match_arrow(operand, pattern, opt);
-
-    case TK_DONTCARE:
-      return MATCHTYPE_ACCEPT;
 
     case TK_FUNTYPE:
       return MATCHTYPE_DENY;

--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -60,6 +60,7 @@ bool safe_to_write(ast_t* ast, ast_t* type)
     case TK_LET:
     case TK_VARREF:
     case TK_DONTCARE:
+    case TK_DONTCAREREF:
       return true;
 
     case TK_FVARREF:

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1363,7 +1363,7 @@ bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errorf,
   assert(sub != NULL);
   assert(super != NULL);
 
-  if(ast_id(super) == TK_DONTCARE)
+  if(ast_id(super) == TK_DONTCARETYPE)
     return true;
 
   switch(ast_id(sub))
@@ -1749,7 +1749,7 @@ bool contains_dontcare(ast_t* ast)
 {
   switch(ast_id(ast))
   {
-    case TK_DONTCARE:
+    case TK_DONTCARETYPE:
       return true;
 
     case TK_TUPLETYPE:

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -36,20 +36,6 @@ class BadPonyTest : public PassTest
 
 // Cases from reported issues
 
-TEST_F(BadPonyTest, DontCareInFieldType)
-{
-  // From issue #207
-  const char* src =
-    "class Abc\n"
-    "  var _test1: (_)";
-
-  TEST_ERRORS_3(src,
-    "the don't care token can only appear in",
-    "field left undefined in constructor",
-    "constructor with undefined fields");
-}
-
-
 TEST_F(BadPonyTest, ClassInOtherClassProvidesList)
 {
   // From issue #218
@@ -82,20 +68,6 @@ TEST_F(BadPonyTest, TypeParamMissingForTypeInProvidesList)
     "    None";
 
   TEST_ERRORS_1(src, "not enough type arguments");
-}
-
-
-TEST_F(BadPonyTest, DontCareInIntLiteralType)
-{
-  // From issue #222
-  const char* src =
-    "actor Main\n"
-    "  new create(env: Env) =>\n"
-    "    let crashme: (_, I32) = (4, 4)";
-
-  TEST_ERRORS_2(src,
-    "the don't care token can only appear in",
-    "could not infer literal type, no valid types found");
 }
 
 TEST_F(BadPonyTest, TupleIndexIsZero)

--- a/test/libponyc/dontcare.cc
+++ b/test/libponyc/dontcare.cc
@@ -1,0 +1,149 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "all"))
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
+
+class DontcareTest : public PassTest
+{};
+
+
+TEST_F(DontcareTest, TypeCantBeDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  let x: _";
+
+  TEST_ERRORS_1(src, "can't use '_' as a type name");
+}
+
+
+TEST_F(DontcareTest, ComplexTypeCantBeDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  let x: (_ | None)";
+
+  TEST_ERRORS_1(src, "can't use '_' as a type name");
+}
+
+
+TEST_F(DontcareTest, CanAssignToDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    _ = None";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(DontcareTest, CanAssignToDontcareDeclInfer)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    let _ = None";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(DontcareTest, CanAssignToDontcareDeclWithType)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    let _: None = None";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(DontcareTest, CannotAssignFromDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    let x = _";
+
+  TEST_ERRORS_1(src, "can't read from '_'");
+}
+
+
+TEST_F(DontcareTest, CannotChainAssignDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    _ = _ = None";
+
+  TEST_ERRORS_1(src, "can't read from '_'");
+}
+
+
+TEST_F(DontcareTest, CannotCallMethodOnDontcare)
+{
+  const char* src =
+    "class C\n"
+    "  fun f() =>\n"
+    "    _.foo()";
+
+  TEST_ERRORS_1(src, "can't read from '_'");
+}
+
+
+TEST_F(DontcareTest, CanUseDontcareNamedCapture)
+{
+  const char* src =
+    "class C\n"
+    "  fun f(x: None) =>\n"
+    "    match x\n"
+    "    | let _: None => None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(DontcareTest, CannotUseDontcareNamedCaptureNoType)
+{
+  const char* src =
+    "class C\n"
+    "  fun f(x: None) =>\n"
+    "    match x\n"
+    "    | let _ => None\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "capture types cannot be inferred");
+}
+
+
+TEST_F(DontcareTest, CanUseDontcareInTupleLHS)
+{
+  const char* src =
+    "class C\n"
+    "  fun f(x: None) =>\n"
+    "    (let a, _) = (None, None)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(DontcareTest, CannotUseDontcareInTupleRHS)
+{
+  const char* src =
+    "class C\n"
+    "  fun f(x: None) =>\n"
+    "    (let a, let b) = (None, _)";
+
+  TEST_ERRORS_1(src, "can't read from '_'");
+}

--- a/test/libponyc/id.cc
+++ b/test/libponyc/id.cc
@@ -95,6 +95,7 @@ TEST_F(IdTest, ContainUnderscore)
   DO(test_id("_foo_bar", false, ALLOW_UNDERSCORE));
   DO(test_id("foo_bar", true, ALLOW_LEADING_UNDERSCORE | ALLOW_UNDERSCORE));
   DO(test_id("_foo_bar", true, ALLOW_LEADING_UNDERSCORE | ALLOW_UNDERSCORE));
+  DO(test_id("_", false, ALLOW_LEADING_UNDERSCORE | ALLOW_UNDERSCORE));
 }
 
 
@@ -168,6 +169,14 @@ TEST_F(IdTest, Prime)
 }
 
 
+TEST_F(IdTest, Dontcare)
+{
+  DO(test_id("_", true, ALLOW_DONTCARE));
+  DO(test_id("_", false, 0));
+  DO(test_id("__", false, ALLOW_DONTCARE));
+}
+
+
 TEST_F(IdTest, PrivateName)
 {
   ASSERT_TRUE(is_name_private("_foo"));
@@ -178,6 +187,7 @@ TEST_F(IdTest, PrivateName)
   ASSERT_FALSE(is_name_private("Foo"));
   ASSERT_FALSE(is_name_private("$foo"));
   ASSERT_FALSE(is_name_private("$Foo"));
+  ASSERT_FALSE(is_name_private("_"));
 }
 
 
@@ -191,6 +201,7 @@ TEST_F(IdTest, TypeName)
   ASSERT_FALSE(is_name_type("_foo"));
   ASSERT_FALSE(is_name_type("$foo"));
   ASSERT_FALSE(is_name_type("$_foo"));
+  ASSERT_FALSE(is_name_type("_"));
 }
 
 
@@ -211,4 +222,12 @@ TEST_F(IdTest, InternalTypeName)
   ASSERT_FALSE(is_name_internal_test("_foo"));
   ASSERT_FALSE(is_name_internal_test("Foo"));
   ASSERT_FALSE(is_name_internal_test("_Foo"));
+  ASSERT_FALSE(is_name_internal_test("_"));
+}
+
+
+TEST_F(IdTest, DontcareName)
+{
+  ASSERT_TRUE(is_name_dontcare("_"));
+  ASSERT_FALSE(is_name_dontcare("__"));
 }

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -346,13 +346,13 @@ TEST_F(MatchTypeTest, Tuples)
   assert(ast_id(elem1) == TK_NOMINAL);
   assert(ast_id(elem2) == TK_NOMINAL);
 
-  REPLACE(&elem2, NODE(TK_DONTCARE));
+  REPLACE(&elem2, NODE(TK_DONTCARETYPE));
 
   // (T1, _)
   ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, &opt));
 
-  REPLACE(&elem1, NODE(TK_DONTCARE));
+  REPLACE(&elem1, NODE(TK_DONTCARETYPE));
 
   // (_, _)
   ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));

--- a/test/libponyc/parse_entity.cc
+++ b/test/libponyc/parse_entity.cc
@@ -90,6 +90,13 @@ TEST_F(ParseEntityTest, ActorCannotBeGenericAndCApi)
 }
 
 
+TEST_F(ParseEntityTest, ActorCannotBeDontcare)
+{
+  const char* src = "actor _";
+
+  TEST_ERROR(src);
+}
+
 
 // Classes
 
@@ -141,6 +148,13 @@ TEST_F(ParseEntityTest, ClassCannotBeCApi)
   TEST_ERROR(src);
 }
 
+
+TEST_F(ParseEntityTest, ClassCannotBeDontcare)
+{
+  const char* src = "class _";
+
+  TEST_ERROR(src);
+}
 
 
 // Primitives
@@ -205,6 +219,14 @@ TEST_F(ParseEntityTest, PrimitiveCannotBeCApi)
 }
 
 
+TEST_F(ParseEntityTest, PrimitiveCannotBeDontcare)
+{
+  const char* src = "primitive _";
+
+  TEST_ERROR(src);
+}
+
+
 // Traits
 
 TEST_F(ParseEntityTest, TraitMinimal)
@@ -254,6 +276,14 @@ TEST_F(ParseEntityTest, TraitCannotHaveConstructor)
 TEST_F(ParseEntityTest, TraitCannotBeCApi)
 {
   const char* src = "trait @ Foo";
+
+  TEST_ERROR(src);
+}
+
+
+TEST_F(ParseEntityTest, TraitCannotBeDontcare)
+{
+  const char* src = "trait _";
 
   TEST_ERROR(src);
 }
@@ -313,6 +343,14 @@ TEST_F(ParseEntityTest, InterfaceCannotBeCApi)
 }
 
 
+TEST_F(ParseEntityTest, InterfaceCannotBeDontcare)
+{
+  const char* src = "interface _";
+
+  TEST_ERROR(src);
+}
+
+
 // Aliases
 
 TEST_F(ParseEntityTest, Alias)
@@ -326,6 +364,14 @@ TEST_F(ParseEntityTest, Alias)
 TEST_F(ParseEntityTest, AliasMustHaveType)
 {
   const char* src = "type Foo";
+
+  TEST_ERROR(src);
+}
+
+
+TEST_F(ParseEntityTest, AliasCannotBeDontcare)
+{
+  const char* src = "type _ is Foo";
 
   TEST_ERROR(src);
 }
@@ -413,6 +459,14 @@ TEST_F(ParseEntityTest, InterfaceFunctionCannotBeCCallable)
 }
 
 
+TEST_F(ParseEntityTest, FunctionCannotBeDontcare)
+{
+  const char* src = "class Foo fun _() => 3";
+
+  TEST_ERROR(src);
+}
+
+
 // Behaviours
 
 TEST_F(ParseEntityTest, Behaviour)
@@ -495,6 +549,14 @@ TEST_F(ParseEntityTest, InterfaceBehaviourCannotBeCCallable)
 }
 
 
+TEST_F(ParseEntityTest, BehaviourCannotBeDontcare)
+{
+  const char* src = "actor Foo be _() => 3";
+
+  TEST_ERROR(src);
+}
+
+
 // Constructors
 
 TEST_F(ParseEntityTest, ConstructorMinimal)
@@ -556,6 +618,14 @@ TEST_F(ParseEntityTest, ActorConstructorCannotBePartial)
 TEST_F(ParseEntityTest, ConstructorMustHaveBody)
 {
   const char* src = "class Foo new m()";
+
+  TEST_ERROR(src);
+}
+
+
+TEST_F(ParseEntityTest, ConstructorCannotBeDontcare)
+{
+  const char* src = "class Foo new _() => 3";
 
   TEST_ERROR(src);
 }
@@ -671,6 +741,15 @@ TEST_F(ParseEntityTest, FieldDelegateCannotHaveCapability)
 
     "class Foo\n"
     "  var bar: T delegate T1 ref";
+
+  TEST_ERROR(src);
+}
+
+
+TEST_F(ParseEntityTest, FieldCannotBeDontcare)
+{
+  const char* src =
+    "class Foo let _: None";
 
   TEST_ERROR(src);
 }
@@ -880,6 +959,15 @@ TEST_F(ParseEntityTest, OsNameCaseSensitiveInConditionWrong)
 {
   const char* src =
     "use \"foo\" if WINDOWS";
+
+  TEST_ERROR(src);
+}
+
+
+TEST_F(ParseEntityTest, UseUriCannotBeDontcare)
+{
+  const char* src =
+    "use _ = \"foo\"";
 
   TEST_ERROR(src);
 }

--- a/test/libponyc/scope.cc
+++ b/test/libponyc/scope.cc
@@ -283,6 +283,18 @@ TEST_F(ScopeTest, Package)
 }
 
 
+TEST_F(ScopeTest, CanShadowDontcare)
+{
+  const char* src =
+    "actor A\n"
+    "  fun foo() =>\n"
+    "    var _: None\n"
+    "    var _: None";
+
+  TEST_COMPILE(src);
+}
+
+
 /*
 TEST_F(ScopeTest, Use)
 {


### PR DESCRIPTION
`_` is now an identifier that is always valid to write to, but never to read from. It can also be shadowed freely.

Closes #876.