### PR TITLE
Deprecate LLVM 3.6 OSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,21 +116,6 @@ matrix:
         - CXX1=g++-5
     - os: osx
       env:
-        - LLVM_VERSION="3.6.2"
-        - LLVM_CONFIG="llvm-config-3.6"
-        - config=debug
-        - CC1=clang-3.6
-        - CXX1=clang++-3.6
-    - os: osx
-      env:
-        - LLVM_VERSION="3.6.2"
-        - LLVM_CONFIG="llvm-config-3.6"
-        - config=release
-        - lto=no
-        - CC1=clang-3.6
-        - CXX1=clang++-3.6
-    - os: osx
-      env:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
@@ -216,10 +201,6 @@ install:
     then
       brew update;
       brew install gmp; brew link --overwrite gmp;
-      if [ "${LLVM_VERSION}" = "3.6.2" ];
-      then
-        brew install llvm36;
-      fi;
       if [ "${LLVM_VERSION}" = "3.7.1" ];
       then
         brew install llvm37;

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Please note that on 32-bit X86, using LLVM 3.7.1 or 3.8.1 on FreeBSD currently p
 ## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-You'll need llvm 3.6.2, 3.7.1, or 3.8.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install these dependencies.
+You'll need llvm 3.7.1 or 3.8.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install these dependencies.
 
 Installation via [homebrew](http://brew.sh):
 ```


### PR DESCRIPTION
No longer available via homebrew.