### PR TITLE
Slightly more efficient work stealing

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -228,9 +228,9 @@ static pony_actor_t* steal(scheduler_t* sched, pony_actor_t* prev)
     scheduler_t* victim = choose_victim(sched);
 
     if(victim == NULL)
-      victim = sched;
-
-    actor = pop_global(victim);
+      actor = (pony_actor_t*)ponyint_mpmcq_pop_bailout_immediate(&inject);
+    else
+      actor = pop_global(victim);
 
     if(actor != NULL)
     {


### PR DESCRIPTION
In the case where choose_victim returns NULL, we set the
scheduler trying to do stealing as the victim. This caused
it to check the inject queue and then its own queue for work.
The latter check is pointless. We are doing work stealing
because our queue is empty.

This commit switches to only checking the inject queue if
we are "stealing from ourselves".