### PR TITLE
Recurse when tracing an iso that has become a val

### DIFF
--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -357,6 +357,9 @@ static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->rc += GC_INC_MORE;
     obj->immutable = true;
     acquire_object(ctx, actor, p, true);
+
+    // Set the to PONY_TRACE_MUTABLE to force recursion.
+    mutability = PONY_TRACE_MUTABLE;
   } else if(obj->rc == 0) {
     // If we haven't seen this object, it's an object that is reached from
     // another immutable object we received, or it's a pointer to an embedded


### PR DESCRIPTION
Force `mutability` to trigger recursion.

DO NOT MERGE

I've been unable to reproduce #1118 locally. Can someone confirm that they can reproduce it, and that this change fixes it? Thanks!