### PR TITLE
Add `insert_if_absent` method to Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,4 +393,3 @@ gcc -march=none
 ```
 
 This will result in an error message plus a listing off all architecture types acceptable on your platform.
-

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -124,6 +124,14 @@ class iso _TestMap is UnitTest
     h.assert_eq[USize](0, b.size())
     h.assert_eq[USize](8, b.space())
 
+    let c = Map[String, U32]
+    c.insert_if_absent("a", 1)
+    h.assert_eq[U32](1, c("a"))
+    c.insert_if_absent("a", 2)
+    h.assert_eq[U32](1, c("a"))
+    h.assert_eq[U32](0, c.insert_if_absent("0", 0))
+    h.assert_eq[U32](0, c.insert_if_absent("0", 1))
+
 class iso _TestMapRemove is UnitTest
   fun name(): String => "collections/Map.remove"
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -150,6 +150,41 @@ class HashMap[K, V, H: HashFunction[K] val]
       error
     end
 
+  fun ref insert_if_absent(key: K, value: V): V ? =>
+    """
+    Set a value in the map if the key doesn't already exist in the Map.
+    Saves an extra lookup when doing a pattern like:
+
+    ```pony
+    if not my_map.contains(my_key) then
+      my_map(my_key) = my_value
+    end
+    ```
+
+    Returns the value, the same as `insert`, allowing 'insert_if_absent'
+    to be used as a drop-in replacement for `insert`.
+    """
+    try
+      (let i, let found) = _search(key)
+      let key' = key
+
+      if not found then
+        _array(i) = (consume key, consume value)
+
+        _size = _size + 1
+
+        if (_size * 4) > (_array.size() * 3) then
+          _resize(_array.size() * 2)
+          return this(key')
+        end
+      end
+
+      _array(i) as (_, V)
+    else
+      // This is unreachable, since index will never be out-of-bounds.
+      error
+    end
+
   fun ref remove(key: box->K!): (K^, V^) ? =>
     """
     Delete a value from the map and return it. Raises an error if there was no


### PR DESCRIPTION
Allows for a speed improvement by saving a Map lookup when using
this pattern:

```pony
if not my_map.contains(my_key) then
  my_map(my_key) = my_value
end
```