### PR TITLE
Exposes socket connection error into pony level

### DIFF
--- a/packages/net/tcp_connection_notify.pony
+++ b/packages/net/tcp_connection_notify.pony
@@ -33,6 +33,13 @@ interface TCPConnectionNotify
     """
     None
 
+  fun ref connect_error(conn: TCPConnection ref, errnum: U32) =>
+    """
+    Extended version of `connect_failed` which exposes connection error.
+    `errnum` indicated errno value of failed connection.
+    """
+    this.connect_failed(conn)
+
   fun ref auth_failed(conn: TCPConnection ref) =>
     """
     A raw TCPConnection has no authentication mechanism. However, when

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -729,15 +729,14 @@ int pony_os_accept(asio_event_t* ev)
 }
 
 // Check this when a connection gets its first writeable event.
-bool pony_os_connected(int fd)
+// NOTE: error clears after the call
+int pony_os_socket_error(int fd)
 {
-  int val = 0;
-  socklen_t len = sizeof(int);
-
-  if(getsockopt((SOCKET)fd, SOL_SOCKET, SO_ERROR, (char*)&val, &len) == -1)
-    return false;
-
-  return val == 0;
+  int sockerr;
+  socklen_t errlen = sizeof(sockerr);
+  if(getsockopt((SOCKET)fd, SOL_SOCKET, SO_ERROR, &sockerr, &errlen))
+    return errno;
+  return sockerr;
 }
 
 static int address_family(int length)

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -734,8 +734,10 @@ int pony_os_socket_error(int fd)
 {
   int sockerr;
   socklen_t errlen = sizeof(sockerr);
-  if(getsockopt((SOCKET)fd, SOL_SOCKET, SO_ERROR, &sockerr, &errlen))
+
+  if(getsockopt((SOCKET)fd, SOL_SOCKET, SO_ERROR, (char*)&sockerr, &errlen))
     return errno;
+
   return sockerr;
 }
 


### PR DESCRIPTION
* net/tcp_connection_notify: added `connect_error` method -
  extended version of `connect_failed`