### PR TITLE
Performance fix in the runtime actor schedule

### DIFF
--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -9,13 +9,17 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct mpmcq_node_t mpmcq_node_t;
 
+typedef struct mpmcq_dwcas_t
+{
+  uintptr_t aba;
+  mpmcq_node_t* node;
+} mpmcq_dwcas_t;
+
 __pony_spec_align__(
   typedef struct mpmcq_t
   {
     PONY_ATOMIC(mpmcq_node_t*) head;
-    PONY_ATOMIC(mpmcq_node_t*) tail;
-    PONY_ATOMIC(size_t) ticket;
-    PONY_ATOMIC(size_t) waiting_for;
+    PONY_ATOMIC(mpmcq_dwcas_t) tail;
   } mpmcq_t, 64
 );
 
@@ -28,8 +32,6 @@ void ponyint_mpmcq_push(mpmcq_t* q, void* data);
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data);
 
 void* ponyint_mpmcq_pop(mpmcq_t* q);
-
-void* ponyint_mpmcq_pop_bailout_immediate(mpmcq_t* q);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -54,10 +54,7 @@ static void push(scheduler_t* sched, pony_actor_t* actor)
  */
 static pony_actor_t* pop_global(scheduler_t* sched)
 {
-  // The global queue is empty most of the time. We use pop_bailout_immediate
-  // to avoid unnecessary synchronisation in that common case.
-  pony_actor_t* actor =
-    (pony_actor_t*)ponyint_mpmcq_pop_bailout_immediate(&inject);
+  pony_actor_t* actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
 
   if(actor != NULL)
     return actor;
@@ -228,7 +225,7 @@ static pony_actor_t* steal(scheduler_t* sched, pony_actor_t* prev)
     scheduler_t* victim = choose_victim(sched);
 
     if(victim == NULL)
-      actor = (pony_actor_t*)ponyint_mpmcq_pop_bailout_immediate(&inject);
+      actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
     else
       actor = pop_global(victim);
 


### PR DESCRIPTION
The original testing for performance impact of the ticketing
algo change was done at Sendence. At the time, we didn't see
any impact. However, we weren't looking in the right place.

We have since found that the ticketing algo under some workloads
can result in very long pauses (up to a second) getting a ticket.
Further, we regularly see pauses while waiting to get a ticket
measured in the 100's of micro-seconds.

This commit reverts to the prior double word cas algo that we
found has far better performance characteristics in the "bad"
scenarios we found and the same or slightly better characteristics
under normal circumstances.

The reversion includes the work in a later commit to support GCC
4.7.

It does not include the VALGRIND awareness that was added later.
I'm not sure where to put that in, as such, I left it out.

There was a change in heap that went along with the original
ticketing algo change. That is not included as part of this commit
as we at Sendence didn't switch that and thus are unsure if it
should be switched or what the impact would be.