### PR TITLE
Fix "package:" scheme

### DIFF
--- a/src/libponyc/pkg/use.c
+++ b/src/libponyc/pkg/use.c
@@ -29,7 +29,7 @@ struct
   use_handler_t handler;
 } handlers[] =
 {
-  {"package:", 5, true, false, use_package},
+  {"package:", 8, true, false, use_package},
   {"lib:", 4, false, true, use_library},
   {"path:", 5, false, true, use_path},
 


### PR DESCRIPTION
Before this change, using "package:" scheme resulted in compilation
error due to incorrect scheme length in the handlers table.