### PR TITLE
Make IPAddress equatable

### DIFF
--- a/packages/net/ip_address.pony
+++ b/packages/net/ip_address.pony
@@ -1,4 +1,4 @@
-class val IPAddress
+class val IPAddress is Equatable[IPAddress]
   """
   Represents an IPv4 or IPv6 address. The family field indicates the address
   type. The addr field is either the IPv4 address or the IPv6 flow info. The
@@ -44,3 +44,13 @@ class val IPAddress
 
     (recover String.from_cstring(consume host) end,
       recover String.from_cstring(consume serv) end)
+
+  fun eq(that: IPAddress box): Bool =>
+    if ip4() then
+      this.addr == that.addr
+    else
+      (this.addr1 == that.addr1) and
+      (this.addr2 == that.addr2) and
+      (this.addr3 == that.addr3) and
+      (this.addr4 == that.addr4)
+    end


### PR DESCRIPTION
Makes IPAddresses comparable based on the address itself, not
port, family, etc. This is probably the right and expected thing.
However it could be argued that all fields of IPAddress should be
used with comparison.

We are using at Sendence to compare, "is this IP for a local or
remote address" which is in turn used to decide whether to turn
on TCP_NODELAY (on Linux, using TCP_NODELAY on local addresses
has a negative impact on our performance/stability. Using it
on remote addresses helps our performance/stability).

This change has raised the question for me, should IPAddress
be broken up into smaller classes? For example, the address
127.0.0.1: I should be able to compare that to 192.168.20.1
and see they are different. However, if I compare 127.0.0.1
port 80 to 127.0.0.1 port 90, am I asking for the address to
be compared or the address and the port? Given this class is
named IPAddress, I would expect just the 127.0.0.1 to be
used for comparison however if it was IPAddressAndPort, I
would have a different expectation.

I think this eq is a fine starting place and that there is
discussion to be had around this.