### PR TITLE
Disallow type parameter names shadowing other types.

### DIFF
--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -178,6 +178,15 @@ static bool names_typeparam(pass_opt_t* opt, ast_t** astp, ast_t* def)
     return false;
   }
 
+  if(ast_id(ast) == TK_NOMINAL) {
+    ast_t* module = ast_nearest(ast, TK_MODULE);
+    if(module && ast_get(module, ast_name(id), 0)) {
+      ast_error(opt->check.errors, def,
+                "type parameter shadows existing type");
+      return false;
+    }
+  }
+
   // Change to a typeparamref.
   REPLACE(astp,
     NODE(TK_TYPEPARAMREF,

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -338,3 +338,21 @@ TEST_F(BadPonyTest, MatchUnionOfDifferentCaps)
   TEST_ERRORS_1(src,
     "match type may not be a union of types with different capabilities");
 }
+
+TEST_F(BadPonyTest, ShadowingBuiltinTypeParameter)
+{
+  const char* src =
+    "class A[I8]\n"
+      "let b: U8 = 0";
+
+  TEST_ERRORS_1(src, "type parameter shadows existing type");
+}
+
+TEST_F(BadPonyTest, ShadowingTypeParameterInSameFile)
+{
+  const char* src =
+    "trait B\n"
+    "class A[B]";
+
+  TEST_ERRORS_1(src, "can't reuse name 'B'");
+}


### PR DESCRIPTION
(I'm opening this PR as is, but admittedly this is probably the wrong way to solve this, thus my explicit use of WIP in the commit message.  If I can get some guidance on the right way to fix this, I'd be more than happy to contribute a suitable fix, including a more detailed commit message.)

So, this started with me trying to do something stupid (and getting a segfault, on the release compiler), but boiled down, this is sufficient to cause an assert with a debug compiler:

```pony
class A[I8]
  let b: U8 = 0
```

What seems to happen is that if the type parameter for `A` is any of the types named in `_str_uif_types` in `libponyc/expr/literals.c`, when we then go to look up `U8` (which can be any _other_ type from that same set of builtin types) in `uifset_simple_type()`, the structure of the AST we get back is not what we expect (it's become a `TK_TYPEPARAMREF` thanks to the call to `names_nominal()` within `types_builtin()` and friends).  As a result `ast_childidx(uif, 3)` returns NULL and `ast_setid()` aborts (or goes on to segfault, in release mode).

I don't know enough about either Pony or the compiler to know what the correct behavior should be, but I imagine that having `I8` as a type parameter here should either be forbidden, or it should shadow `I8` throughout this definition, and not affect `uifset_simple_type()` at all.  It seems like other parts of the compiler do the right thing, and the presence of literal type inference causes the snafu, since changing 0 to `U8.min_value()` works fine.

Advice would be appreciated, even "go read this part of the code".