### PR TITLE
Branch prediction annotations (RFC 30)

### DIFF
--- a/src/libponyc/codegen/gencontrol.h
+++ b/src/libponyc/codegen/gencontrol.h
@@ -24,6 +24,21 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_error(compile_t* c, ast_t* ast);
 
+void attach_branchweights_metadata(LLVMContextRef ctx, LLVMValueRef branch,
+   unsigned int weights[], unsigned int count);
+
+void handle_branch_prediction_default(LLVMContextRef ctx, LLVMValueRef branch,
+  ast_t* ast);
+
+// Numbers from Clang's __builtin_expect()
+#if PONY_LLVM < 309
+#  define PONY_BRANCHWEIGHT_LIKELY 64
+#  define PONY_BRANCHWEIGHT_UNLIKELY 4
+#else
+#  define PONY_BRANCHWEIGHT_LIKELY 2000
+#  define PONY_BRANCHWEIGHT_UNLIKELY 1
+#endif
+
 PONY_EXTERN_C_END
 
 #endif


### PR DESCRIPTION
This change adds annotations to control structures allowing programmers to make the optimiser aware of the likelihood of a given condition.

Closes #1500.