### PR TITLE
Correctly detect compile errors from arithmetic operations

### DIFF
--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -46,6 +46,7 @@ static bool special_case_operator(compile_t* c, ast_t* ast,
 
   ast_t* right = ast_child(positional);
   const char* name = ast_name(method);
+  bool special_case = true;
   *value = NULL;
 
   codegen_debugloc(c, ast);
@@ -90,9 +91,11 @@ static bool special_case_operator(compile_t* c, ast_t* ast,
     *value = gen_ge(c, left, right);
   else if(name == c->str_gt)
     *value = gen_gt(c, left, right);
+  else
+    special_case = false;
 
   codegen_debugloc(c, NULL);
-  return *value != NULL;
+  return special_case;
 }
 
 static LLVMValueRef special_case_platform(compile_t* c, ast_t* ast)


### PR DESCRIPTION
Previously in `special_case_operator`, a no-op and a failure were reported in the same way. This change ensures that we detect errors and that we don't proceed through the final stages of compilation.

This doesn't fix any program correctness issue. The only error that could be detected here is a division by 0 error which was reported even though compilation didn't stop and wasn't inhibiting the runtime check, because of the way the code generator is architectured.