### PR TITLE
Make codegen tests run smoothly

### DIFF
--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -297,7 +297,11 @@ static void make_debug_info(compile_t* c, reach_type_t* t)
   else
     source = ast_source(t->ast);
 
-  t->di_file = LLVMDIBuilderCreateFile(c->di, source->file);
+  const char* file = source->file;
+  if(file == NULL)
+    file = "";
+
+  t->di_file = LLVMDIBuilderCreateFile(c->di, file);
 
   switch(t->underlying)
   {

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -71,6 +71,7 @@ static const char* _builtin =
   "type Float is (F32 | F64)\n"
   "trait val Real[A: Real[A] val]\n"
   "class val Env\n"
+  "  let none: None = None\n"
   "primitive None\n"
   "primitive Bool\n"
   "class val String\n"
@@ -209,6 +210,7 @@ void PassTest::SetUp()
   _first_pkg_path = "prog";
   package_clear_magic();
   package_suppress_build_message();
+  opt.verbosity = VERBOSITY_QUIET;
 }
 
 


### PR DESCRIPTION
- Use a default file name for debug information when we compile from a string and have no input file name
- Make sure to reach `None` in the fake builtin package for the tests
- Set verbosity to quiet during tests