### PR TITLE
Rename TK_BORROWED to TK_ALIASED in the compiler

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -109,7 +109,7 @@ static const lextoken_t symbols[] =
   { "|", TK_PIPE },
   { "&", TK_ISECTTYPE },
   { "^", TK_EPHEMERAL },
-  { "!", TK_BORROWED },
+  { "!", TK_ALIASED },
 
   { "?", TK_QUESTION },
   { "-", TK_UNARY_MINUS },
@@ -206,7 +206,7 @@ static const lextoken_t keywords[] =
   { "$noseq", TK_TEST_NO_SEQ },
   { "$scope", TK_TEST_SEQ_SCOPE },
   { "$try_no_check", TK_TEST_TRY_NO_CHECK },
-  { "$borrowed", TK_TEST_BORROWED },
+  { "$aliased", TK_TEST_ALIASED },
   { "$updatearg", TK_TEST_UPDATEARG },
   { "$extra", TK_TEST_EXTRA },
   { "$ifdefand", TK_IFDEFAND },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -155,7 +155,7 @@ DEF(gencap);
     TK_CAP_ALIAS, TK_CAP_ANY);
   DONE();
 
-// ID [DOT ID] [typeargs] [CAP] [EPHEMERAL | BORROWED]
+// ID [DOT ID] [typeargs] [CAP] [EPHEMERAL | ALIASED]
 DEF(nominal);
   AST_NODE(TK_NOMINAL);
   TOKEN("name", TK_ID);
@@ -166,7 +166,7 @@ DEF(nominal);
   );
   OPT RULE("type arguments", typeargs);
   OPT RULE("capability", cap, gencap);
-  OPT TOKEN(NULL, TK_EPHEMERAL, TK_BORROWED);
+  OPT TOKEN(NULL, TK_EPHEMERAL, TK_ALIASED);
   DONE();
 
 // PIPE type
@@ -225,7 +225,7 @@ DEF(typelist);
   DONE();
 
 // LBRACE [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [typelist] RPAREN
-// [COLON type] [QUESTION] RBRACE [CAP] [EPHEMERAL | BORROWED]
+// [COLON type] [QUESTION] RBRACE [CAP] [EPHEMERAL | ALIASED]
 DEF(lambdatype);
   AST_NODE(TK_LAMBDATYPE);
   SKIP(NULL, TK_LBRACE);
@@ -239,7 +239,7 @@ DEF(lambdatype);
   OPT TOKEN(NULL, TK_QUESTION);
   SKIP(NULL, TK_RBRACE);
   OPT RULE("capability", cap, gencap);
-  OPT TOKEN(NULL, TK_EPHEMERAL, TK_BORROWED);
+  OPT TOKEN(NULL, TK_EPHEMERAL, TK_ALIASED);
   DONE();
 
 // (thistype | cap | typeexpr | nominal | lambdatype)
@@ -824,18 +824,18 @@ DEF(recover);
   TERMINATE("recover expression", TK_END);
   DONE();
 
-// $BORROWED
-DEF(test_borrowed);
+// $ALIASED
+DEF(test_aliased);
   PRINT_INLINE();
-  TOKEN(NULL, TK_TEST_BORROWED);
-  MAP_ID(TK_TEST_BORROWED, TK_BORROWED);
+  TOKEN(NULL, TK_TEST_ALIASED);
+  MAP_ID(TK_TEST_ALIASED, TK_ALIASED);
   DONE();
 
-// CONSUME [cap | test_borrowed] term
+// CONSUME [cap | test_aliased] term
 DEF(consume);
   PRINT_INLINE();
   TOKEN("consume", TK_CONSUME);
-  OPT RULE("capability", cap, test_borrowed);
+  OPT RULE("capability", cap, test_aliased);
   RULE("expression", term);
   DONE();
 
@@ -899,7 +899,7 @@ DEF(nextterm);
 //     (CASE
 //       (LET $1 type)
 //       NONE
-//       (SEQ (CONSUME BORROWED $1))))
+//       (SEQ (CONSUME ALIASED $1))))
 //   (SEQ ERROR))
 DEF(asop);
   PRINT_INLINE();

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -81,7 +81,7 @@ typedef enum token_id
   TK_PIPE,
   TK_ISECTTYPE,
   TK_EPHEMERAL,
-  TK_BORROWED,
+  TK_ALIASED,
 
   TK_QUESTION,
   TK_UNARY_MINUS,
@@ -268,7 +268,7 @@ typedef enum token_id
   TK_TEST_NO_SEQ,
   TK_TEST_SEQ_SCOPE,
   TK_TEST_TRY_NO_CHECK,
-  TK_TEST_BORROWED,
+  TK_TEST_ALIASED,
   TK_TEST_UPDATEARG,
   TK_TEST_EXTRA
 } token_id;

--- a/src/libponyc/ast/treecheckdef.h
+++ b/src/libponyc/ast/treecheckdef.h
@@ -179,7 +179,7 @@ RULE(tuple,
 
 RULE(consume,
   HAS_TYPE(type)
-  CHILD(cap, borrowed, none)
+  CHILD(cap, aliased, none)
   CHILD(expr),
   TK_CONSUME);
 
@@ -433,7 +433,7 @@ RULE(lambda_type,
   CHILD(type, none) // Return type
   CHILD(question, none)
   CHILD(cap, gencap, none)  // Type reference cap
-  CHILD(borrowed, ephemeral, none),
+  CHILD(aliased, ephemeral, none),
   TK_LAMBDATYPE);
 
 RULE(type_list, ONE_OR_MORE(type), TK_PARAMS);
@@ -444,7 +444,7 @@ RULE(nominal,
   CHILD(id)       // Type
   CHILD(type_args, none)
   CHILD(cap, gencap, none)
-  CHILD(borrowed, ephemeral, none)
+  CHILD(aliased, ephemeral, none)
   OPTIONAL(id, none), // Original package specifier (for error reporting)
   TK_NOMINAL);
 
@@ -452,12 +452,12 @@ RULE(type_param_ref,
   HAS_DATA  // Definition of referred type parameter
   CHILD(id)
   CHILD(cap, gencap, none)
-  CHILD(borrowed, ephemeral, none),
+  CHILD(aliased, ephemeral, none),
   TK_TYPEPARAMREF);
 
 RULE(at, LEAF, TK_AT);
 RULE(bool_literal, HAS_TYPE(type), TK_TRUE, TK_FALSE);
-RULE(borrowed, LEAF, TK_BORROWED);
+RULE(aliased, LEAF, TK_ALIASED);
 RULE(cap, LEAF, TK_ISO, TK_TRN, TK_REF, TK_VAL, TK_BOX, TK_TAG);
 RULE(control_type, LEAF, TK_IF, TK_CASES, TK_COMPILE_INTRINSIC,
   TK_COMPILE_ERROR, TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR);

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -996,7 +996,7 @@ static void add_as_type(pass_opt_t* opt, ast_t* type, ast_t* pattern,
 
       BUILD(body_elem, body,
         NODE(TK_SEQ,
-          NODE(TK_CONSUME, NODE(TK_BORROWED) NODE(TK_REFERENCE, ID(name)))));
+          NODE(TK_CONSUME, NODE(TK_ALIASED) NODE(TK_REFERENCE, ID(name)))));
 
       ast_append(pattern, pattern_elem);
       ast_append(body, body_elem);

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -30,7 +30,7 @@ static ast_t* alias_single(ast_t* type)
         case TK_NONE:
           type = ast_dup(type);
           ephemeral = ast_sibling(cap_fetch(type));
-          ast_setid(ephemeral, TK_BORROWED);
+          ast_setid(ephemeral, TK_ALIASED);
           break;
 
         default: {}
@@ -39,7 +39,7 @@ static ast_t* alias_single(ast_t* type)
       return type;
     }
 
-    case TK_BORROWED:
+    case TK_ALIASED:
       return type;
 
     default: {}
@@ -150,8 +150,8 @@ static ast_t* consume_single(ast_t* type, token_id ccap)
       ast_setid(eph, TK_EPHEMERAL);
       break;
 
-    case TK_BORROWED:
-      if(ccap == TK_BORROWED)
+    case TK_ALIASED:
+      if(ccap == TK_ALIASED)
         ast_setid(eph, TK_NONE);
       break;
 
@@ -161,7 +161,7 @@ static ast_t* consume_single(ast_t* type, token_id ccap)
   switch(ccap)
   {
     case TK_NONE:
-    case TK_BORROWED:
+    case TK_ALIASED:
       ccap = tcap;
       break;
 

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -23,7 +23,7 @@ static void cap_aliasing(token_id* cap, token_id* eph)
       }
       break;
 
-    case TK_BORROWED:
+    case TK_ALIASED:
       switch(*cap)
       {
         case TK_ISO:

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -30,7 +30,7 @@ static void reify_typeparamref(ast_t** astp, ast_t* typeparam, ast_t* typearg)
     case TK_NONE:
       break;
 
-    case TK_BORROWED:
+    case TK_ALIASED:
       typearg = alias(typearg);
       break;
 

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -419,7 +419,7 @@ static bool apply_cap_to_single(ast_t* type, token_id tcap, token_id teph)
   switch(ast_id(eph))
   {
     case TK_EPHEMERAL:
-      if(teph == TK_BORROWED)
+      if(teph == TK_ALIASED)
         ast_setid(eph, TK_NONE);
       break;
 
@@ -427,7 +427,7 @@ static bool apply_cap_to_single(ast_t* type, token_id tcap, token_id teph)
       ast_setid(eph, teph);
       break;
 
-    case TK_BORROWED:
+    case TK_ALIASED:
       if(teph == TK_EPHEMERAL)
         ast_setid(eph, TK_NONE);
       break;

--- a/src/libponyc/type/viewpoint.c
+++ b/src/libponyc/type/viewpoint.c
@@ -363,7 +363,7 @@ static void replace_type(ast_t** astp, ast_t* target, ast_t* with)
               a_with = consume_type(with, TK_NONE);
               break;
 
-            case TK_BORROWED:
+            case TK_ALIASED:
               a_with = alias(with);
               break;
 

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -1362,7 +1362,7 @@ TEST_F(SugarTest, As)
     "  var create: U32\n"
     "  fun box f(a: (Foo | Bar)): Foo ? =>\n"
     "    match a\n"
-    "    | $let $1: Foo ref => consume $borrowed $1\n"
+    "    | $let $1: Foo ref => consume $aliased $1\n"
     "    else\n"
     "      error\n"
     "    end";
@@ -1386,7 +1386,7 @@ TEST_F(SugarTest, AsTuple)
     "  fun box f(a: (Foo, Bar)): (Foo, Bar) ? =>\n"
     "    match a\n"
     "    | ($let $1: Foo ref, $let $2: Bar ref) =>\n"
-    "      (consume $borrowed $1, consume $borrowed $2)\n"
+    "      (consume $aliased $1, consume $aliased $2)\n"
     "    else\n"
     "      error\n"
     "    end";
@@ -1410,8 +1410,8 @@ TEST_F(SugarTest, AsNestedTuple)
     "  fun box f(a: (Foo, (Bar, Baz))): (Foo, (Bar, Baz)) ? =>\n"
     "    match a\n"
     "    | ($let $1: Foo ref, ($let $2: Bar ref, $let $3: Baz ref)) =>\n"
-    "      (consume $borrowed $1,\n"
-    "        (consume $borrowed $2, consume $borrowed $3))\n"
+    "      (consume $aliased $1,\n"
+    "        (consume $aliased $2, consume $aliased $3))\n"
     "    else\n"
     "      error\n"
     "    end";
@@ -1446,7 +1446,7 @@ TEST_F(SugarTest, AsDontCare2Tuple)
     "  fun box f(a: (Foo, Bar)): Foo ? =>\n"
     "    match a\n"
     "    | ($let $1: Foo ref, _) =>\n"
-    "      consume $borrowed $1\n"
+    "      consume $aliased $1\n"
     "    else\n"
     "      error\n"
     "    end";
@@ -1470,7 +1470,7 @@ TEST_F(SugarTest, AsDontCareMultiTuple)
     "  fun box f(a: (Foo, Bar, Baz)): (Foo, Baz) ? =>\n"
     "    match a\n"
     "    | ($let $1: Foo ref, _, $let $2: Baz ref) =>\n"
-    "      (consume $borrowed $1, consume $borrowed $2)\n"
+    "      (consume $aliased $1, consume $aliased $2)\n"
     "    else\n"
     "      error\n"
     "    end";


### PR DESCRIPTION
The standard term in the tutorial for `!` is "aliased type". Using `TK_ALIASED` in the compiler is more consistent with this.