### PR TITLE
Call primitive _init and _final through a global function

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -171,6 +171,8 @@ typedef struct compile_t
   LLVMValueRef tbaa_descriptor;
   LLVMValueRef tbaa_descptr;
   LLVMValueRef none_instance;
+  LLVMValueRef primitives_init;
+  LLVMValueRef primitives_final;
 
   LLVMTypeRef void_type;
   LLVMTypeRef ibool;

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -14,6 +14,8 @@ bool genfun_method_sigs(compile_t* c, reach_type_t* t);
 
 bool genfun_method_bodies(compile_t* c, reach_type_t* t);
 
+void genfun_primitive_calls(compile_t* c);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -282,6 +282,24 @@ bool genheader(compile_t* c)
     c->filename
     );
 
+  if(c->primitives_init != NULL)
+  {
+    fprintf(fp,
+      "void %s_primitives_init();\n"
+      "\n",
+      c->filename
+      );
+  }
+
+  if(c->primitives_final != NULL)
+  {
+    fprintf(fp,
+      "void %s_primitives_final();\n"
+      "\n",
+      c->filename
+      );
+  }
+
   printbuf_t* buf = printbuf_new();
   print_types(c, fp, buf);
   fwrite(buf->m, 1, buf->offset, fp);

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -186,3 +186,8 @@ const char* genname_unbox(const char* name)
 {
   return stringtab_two(name, "Unbox");
 }
+
+const char* genname_program_fn(const char* program, const char* name)
+{
+  return stringtab_two(program, name);
+}

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -38,6 +38,8 @@ const char* genname_box(const char* name);
 
 const char* genname_unbox(const char* name);
 
+const char* genname_program_fn(const char* program, const char* name);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -784,6 +784,8 @@ bool gentypes(compile_t* c)
       return false;
   }
 
+  genfun_primitive_calls(c);
+
   if(c->opt->verbosity >= VERBOSITY_INFO)
     fprintf(stderr, " Descriptors\n");
 


### PR DESCRIPTION
This new function is generated for both executables and libraries. In the latter case, it allows users to initialise and finalise primitives with a single function call.