### PR TITLE
Correctly emit debugging info for Windows debug builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ waf-*
 waf3-*
 .lock-waf*
 tmp.eof
+src/.vs
+CppProperties.json
 build/
 work/
 output/

--- a/wscript
+++ b/wscript
@@ -88,10 +88,6 @@ def configure(ctx):
             'BUILD_COMPILER="msvc-' + MSVC_VERSION + '-x64"'
         ])
         ctx.env.append_value('LIBPATH', [ ctx.env.LLVM_DIR ])
-        ctx.env.TESTS_LINK_FLAGS = [
-            '/NXCOMPAT',
-            '/SUBSYSTEM:CONSOLE'
-        ]
 
         base_env = ctx.env.derive()
 
@@ -122,10 +118,13 @@ def configure(ctx):
             msvcDebugFlags = [
                 '/EHsc', '/MP', '/GS', '/W3', '/Zc:wchar_t', '/Zi',
                 '/Gm-', '/Od', '/Zc:inline', '/fp:precise', '/WX',
-                '/Zc:forScope', '/Gd', '/MD', '/FS'
+                '/Zc:forScope', '/Gd', '/MD', '/FS', '/DEBUG'
             ]
             ctx.env.append_value('CFLAGS', msvcDebugFlags)
             ctx.env.append_value('CXXFLAGS', msvcDebugFlags)
+            ctx.env.append_value('LINKFLAGS', [
+                '/NXCOMPAT', '/SUBSYSTEM:CONSOLE', '/DEBUG'
+            ])
 
             bldName = 'release-llvm-' + llvm_version
             ctx.setenv(bldName, env = bld_env)
@@ -140,6 +139,9 @@ def configure(ctx):
             ]
             ctx.env.append_value('CFLAGS', msvcReleaseFlags)
             ctx.env.append_value('CXXFLAGS', msvcReleaseFlags)
+            ctx.env.append_value('LINKFLAGS', [
+                '/NXCOMPAT', '/SUBSYSTEM:CONSOLE'
+            ])
 
 
 # specifies build targets
@@ -225,11 +227,11 @@ def build(ctx):
 
     # libponyc
     ctx(
-        features = 'c cxx cxxstlib seq',
-        target   = 'libponyc',
-        source   = ctx.path.ant_glob('src/libponyc/**/*.c') + \
+        features  = 'c cxx cxxstlib seq',
+        target    = 'libponyc',
+        source    = ctx.path.ant_glob('src/libponyc/**/*.c') + \
                     ctx.path.ant_glob('src/libponyc/**/*.cc'),
-        includes = [ 'src/common' ] + llvmIncludes + sslIncludes
+        includes  = [ 'src/common' ] + llvmIncludes + sslIncludes
     )
 
     # libponyrt
@@ -242,12 +244,12 @@ def build(ctx):
 
     # ponyc
     ctx(
-        features = 'c cxx cxxprogram seq',
-        target   = 'ponyc',
-        source   = ctx.path.ant_glob('src/ponyc/**/*.c'),
-        includes = [ 'src/common' ],
-        use      = [ 'libponyc', 'libponyrt' ],
-        lib      = llvmLibs + ctx.env.PONYC_EXTRA_LIBS
+        features  = 'c cxx cxxprogram seq',
+        target    = 'ponyc',
+        source    = ctx.path.ant_glob('src/ponyc/**/*.c'),
+        includes  = [ 'src/common' ],
+        use       = [ 'libponyc', 'libponyrt' ],
+        lib       = llvmLibs + ctx.env.PONYC_EXTRA_LIBS
     )
 
     # testc
@@ -257,8 +259,7 @@ def build(ctx):
         source    = ctx.path.ant_glob('test/libponyc/**/*.cc'),
         includes  = [ 'src/common', 'src/libponyc', 'lib/gtest' ] + llvmIncludes,
         use       = [ 'gtest', 'libponyc', 'libponyrt' ],
-        lib       = llvmLibs + ctx.env.PONYC_EXTRA_LIBS,
-        linkflags = ctx.env.TESTS_LINK_FLAGS
+        lib       = llvmLibs + ctx.env.PONYC_EXTRA_LIBS
     )
 
     # testrt
@@ -268,8 +269,7 @@ def build(ctx):
         source    = ctx.path.ant_glob('test/libponyrt/**/*.cc'),
         includes  = [ 'src/common', 'src/libponyrt', 'lib/gtest' ],
         use       = [ 'gtest', 'libponyrt' ],
-        lib       = ctx.env.PONYC_EXTRA_LIBS,
-        linkflags = ctx.env.TESTS_LINK_FLAGS
+        lib       = ctx.env.PONYC_EXTRA_LIBS
     )
 
     # stdlib tests


### PR DESCRIPTION
The new Windows build did not correctly include symbol information (*.pdb files) for debug builds.  This PR changes the build script to do this.  It also adds a couple of entries to the .gitignore to ignore files used for VS2017 "Open Folder" functionality.