### PR TITLE
Load program symbols dynamically in the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - TCP sockets on FreeBSD and MacOSX now use Kqueue one shot
 - All arithmetic and logic operations are now fully defined for every input by default (issue #993)
 - Removed compiler flag `--ieee-math`
+- The `pony_start` runtime function now takes a `language_features` boolean parameter indicating whether the Pony-specific runtime features (e.g. network or serialisation) should be initialised
 
 ## [0.10.0] - 2016-12-12
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -680,9 +680,10 @@ static void init_runtime(compile_t* c)
 #  endif
 #endif
 
-  // i32 pony_start(i32)
+  // i32 pony_start(i32, i32)
   params[0] = c->i32;
-  type = LLVMFunctionType(c->i32, params, 1, false);
+  params[1] = c->i32;
+  type = LLVMFunctionType(c->i32, params, 2, false);
   value = LLVMAddFunction(c->module, "pony_start", type);
 #if PONY_LLVM >= 309
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -468,11 +468,13 @@ void gendesc_table(compile_t* c)
   LLVMValueRef value = LLVMConstArray(c->descriptor_ptr, args, len);
   LLVMSetInitializer(table, value);
   LLVMSetGlobalConstant(table, true);
+  LLVMSetDLLStorageClass(table, LLVMDLLExportStorageClass);
 
   LLVMValueRef table_size = LLVMAddGlobal(c->module, c->intptr,
     "__DescTableSize");
   LLVMSetInitializer(table_size, LLVMConstInt(c->intptr, len, false));
   LLVMSetGlobalConstant(table_size, true);
+  LLVMSetDLLStorageClass(table_size, LLVMDLLExportStorageClass);
 
   ponyint_pool_free_size(size, args);
 }

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -9,6 +9,8 @@ typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
 
+bool ponyint_serialise_setup();
+
 void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -341,9 +341,12 @@ int pony_init(int argc, char** argv);
  * exit code of 0, and the runtime won't terminate until pony_stop() is
  * called. This allows further processing to be done on the current thread.
  *
+ * If language_features is false, the features of the runtime specific to the
+ * Pony language, such as network or serialisation, won't be initialised.
+ *
  * It is not safe to call this again before the runtime has terminated.
  */
-int pony_start(bool library);
+int pony_start(bool library, bool language_features);
 
 /**
  * Call this to create a pony_ctx_t for a non-scheduler thread. This has to be


### PR DESCRIPTION
The `__DescTable` and `__DescTableSize` defined by Pony programs and generated by the compiler are now accessed dynamically by the runtime (with `dlsym` on POSIX and `GetProcAddress` on Windows).

This change was made for two reasons:

- To avoid link errors from of compiler-generated symbols when using the runtime library directly in a C program.
- JIT compilation is being worked on for the compiler test framework. Since we'll want to run more than one JIT'ed programs in the test suite, the symbol addresses must be dynamic.

As part of this change, the `pony_start` runtime function now takes an additional parameter indicating whether the language-specific features of the Pony runtime should be intialised. This solves the first concern stated above by avoiding referencing the symbols.