### PR TITLE
Do not fail if no error in union type matching

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -335,6 +335,7 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
     {
       if(ast_id(match_type) == TK_UNIONTYPE) {
         token_id cap = ast_id(ast_childidx(ast_child(match_type), 3));
+        bool has_specific_error = false;
         for(size_t i=1; i<ast_childcount(match_type); i++) {
           if(ast_id(ast_childidx(ast_childidx(match_type, i), 3)) != cap) {
             ast_error(opt->check.errors, match_expr, 
@@ -342,7 +343,14 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
               "capabilities");
             ast_error_continue(opt->check.errors, match_type, "match type: %s",
               ast_print_type(operand_type));
+            has_specific_error = true;
           }
+        }
+
+        if(!has_specific_error) {
+          ast_error(opt->check.errors, match_type,
+            "this capture type has a mismatch in reference capabilities, "
+            "which can't be differentiated at runtime");
         }
       } else {
         ast_error(opt->check.errors, pattern,

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -412,3 +412,18 @@ TEST_F(BadPonyTest, RefCapViolationViaCapAnyTypeParameter)
 
   TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
 }
+
+TEST_F(BadPonyTest, UnionTypeErrorWhichCausedAbortDueToMissingError)
+{
+  const char* src =
+    "class A\n"
+    "class B\n"
+    "type C is (A | B)\n"
+
+    "class D\n"
+      "fun apply(c: C val) =>\n"
+        "match c | let a:A => let b = a end";
+
+  TEST_ERRORS_1(src, "this capture type has a mismatch in reference "
+                "capabilities, which can't be differentiated at runtime");
+}


### PR DESCRIPTION
So, again I was writing some dumb code and got an assertion back from the compiler, and I boiled it down to this:

```pony
class A
class B
type C is (A | B)

class D
  fun apply(c: C val) =>
    match c | let a:A => let b = a end
```

There are cases where we could get MATCHTYPE_DENY back from is_matchtype, but no error is set.  This causes an assertion failure later, in pass/expr.c, as we've marked the return as a failure but haven't set any errors.

Again, I suspect this is not the right way to solve this.  I'm guessing this doesn't match because of the `C val` and expr/match.c lines 337-345 doesn't notice because the ast isn't the right shape.  If this is confirmed to be the case, I'll rework this to properly catch this (presumably with the same error message as is already there).