### PR TITLE
Add -no-pie to linker flags if default-pic is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,11 @@ ifeq ($(OSTYPE),osx)
   ALL_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=10.8
 endif
 
+default_pie := $(shell $(CC) -v 2>&1 >/dev/null | grep enable-default-pie)
+ifneq ($(default_pie),)
+	ALL_CFLAGS += -DDEFAULT_PIE
+endif
+
 ifndef LLVM_CONFIG
   ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.9

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ endif
 
 default_pie := $(shell $(CC) -v 2>&1 >/dev/null | grep enable-default-pie)
 ifneq ($(default_pie),)
-	ALL_CFLAGS += -DDEFAULT_PIE
+  ALL_CFLAGS += -DDEFAULT_PIE
 endif
 
 ifndef LLVM_CONFIG

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -166,7 +166,8 @@ static bool link_exe(compile_t* c, ast_t* program,
 #if defined(PLATFORM_IS_WINDOWS)
     "libponyrt.lib";
 #elif defined(PLATFORM_IS_LINUX)
-    c->opt->pic ? "-lponyrt-pic" : "-lponyrt";
+    c->opt->pic ? "-lponyrt-pic" :
+      c->opt->nopie ? "-no-pie -lponyrt" : "-lponyrt";
 #else
     "-lponyrt";
 #endif

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -199,6 +199,7 @@ typedef struct pass_opt_t
   bool library;
   bool runtimebc;
   bool pic;
+  bool nopie;
   bool print_stats;
   bool verify;
   bool extfun;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -349,6 +349,11 @@ int main(int argc, char* argv[])
   opt.strip_debug = true;
 #endif
 
+#if defined(DEFAULT_PIE)
+  if(!opt.pic)
+    opt.nopie = true;
+#endif
+
   if(!ok)
   {
     errors_print(opt.check.errors);


### PR DESCRIPTION
This PR resolves #1484 by adding `-no-pie` to the linker flags if the C compiler has default-pie enabled and the `--pic` flag is not set.