### PR TITLE
Delay MPMCQ node freeing until the next pop by the same thread

### DIFF
--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -4,97 +4,106 @@
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
 
+#ifdef USE_VALGRIND
+#include <valgrind/helgrind.h>
+#endif
+
 typedef struct mpmcq_node_t mpmcq_node_t;
 
 struct mpmcq_node_t
 {
   PONY_ATOMIC(mpmcq_node_t*) next;
-  PONY_ATOMIC(void*) data;
+  void* data;
 };
 
-void ponyint_mpmcq_init(mpmcq_t* q)
+mpmcq_node_t* ponyint_mpmcq_node_alloc(void* data)
 {
   mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, NULL, memory_order_relaxed);
   atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  node->data = data;
 
-  mpmcq_dwcas_t tail;
-  tail.node = node;
+  return node;
+}
+
+void ponyint_mpmcq_node_free(mpmcq_node_t* node)
+{
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(node);
+#endif
+  POOL_FREE(mpmcq_node_t, node);
+}
+
+mpmcq_node_t* ponyint_mpmcq_init(mpmcq_t* q)
+{
+  mpmcq_node_t* node = ponyint_mpmcq_node_alloc(NULL);
 
   atomic_store_explicit(&q->head, node, memory_order_relaxed);
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+  atomic_store_explicit(&q->tail, node, memory_order_relaxed);
+
+  return node;
 }
 
 void ponyint_mpmcq_destroy(mpmcq_t* q)
 {
-  mpmcq_dwcas_t tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
-
-  POOL_FREE(mpmcq_node_t, tail.node);
-  tail.node = NULL;
-  q->head = NULL;
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+  // The stub node is freed by one of the schedulers.
+  atomic_store_explicit(&q->head, NULL, memory_order_relaxed);
+  atomic_store_explicit(&q->tail, NULL, memory_order_relaxed);
 }
 
 void ponyint_mpmcq_push(mpmcq_t* q, void* data)
 {
-  mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, data, memory_order_relaxed);
-  atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  mpmcq_node_t* node = ponyint_mpmcq_node_alloc(data);
 
   mpmcq_node_t* prev = atomic_exchange_explicit(&q->head, node,
     memory_order_relaxed);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+#endif
   atomic_store_explicit(&prev->next, node, memory_order_release);
 }
 
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
 {
-  mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, data, memory_order_relaxed);
-  atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  mpmcq_node_t* node = ponyint_mpmcq_node_alloc(data);
 
   // If we have a single producer, the swap of the head need not be atomic RMW.
   mpmcq_node_t* prev = atomic_load_explicit(&q->head, memory_order_relaxed);
   atomic_store_explicit(&q->head, node, memory_order_relaxed);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+#endif
   atomic_store_explicit(&prev->next, node, memory_order_release);
 }
 
-void* ponyint_mpmcq_pop(mpmcq_t* q)
+void* ponyint_mpmcq_pop(mpmcq_t* q, mpmcq_node_t** old_item)
 {
-  mpmcq_dwcas_t cmp, xchg;
+  mpmcq_node_t* tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
   mpmcq_node_t* next;
-
-  cmp = atomic_load_explicit(&q->tail, memory_order_acquire);
 
   do
   {
     // Get the next node rather than the tail. The tail is either a stub or has
     // already been consumed.
-    next = atomic_load_explicit(&cmp.node->next, memory_order_acquire);
+    next = atomic_load_explicit(&tail->next, memory_order_relaxed);
 
-    // Bailout if we have no next node.
     if(next == NULL)
       return NULL;
 
-    // Make the next node the tail, incrementing the aba counter. If this
-    // fails, cmp becomes the new tail and we retry the loop.
-    xchg.aba = cmp.aba + 1;
-    xchg.node = next;
-  } while(!atomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
-    memory_order_acq_rel, memory_order_acquire));
+  } while(!atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
+    memory_order_relaxed, memory_order_relaxed));
 
-  // We'll return the data pointer from the next node.
-  void* data = atomic_load_explicit(&next->data, memory_order_acquire);
+  // Synchronise on tail->next.
+  atomic_thread_fence(memory_order_acquire);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&tail->next);
+#endif
 
-  // Since we will be freeing the old tail, we need to be sure no other
-  // consumer is still reading the old tail. To do this, we set the data
-  // pointer of our new tail to NULL, and we wait until the data pointer of
-  // the old tail is NULL.
-  atomic_store_explicit(&next->data, NULL, memory_order_release);
+  // Free the previous item popped from the queue by this thread. This mitigates
+  // the ABA problem on the compare_exchange by making sure the delay between
+  // popping a node and freeing that node is high compared to the CAS loop
+  // delay.
+  ponyint_mpmcq_node_free(*old_item);
+  *old_item = next;
 
-  while(atomic_load_explicit(&cmp.node->data, memory_order_acquire) != NULL)
-    ponyint_cpu_relax();
-
-  // Free the old tail. The new tail is the next node.
-  POOL_FREE(mpmcq_node_t, cmp.node);
-  return data;
+  return next->data;
 }

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -9,21 +9,19 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct mpmcq_node_t mpmcq_node_t;
 
-typedef struct mpmcq_dwcas_t
-{
-  uintptr_t aba;
-  mpmcq_node_t* node;
-} mpmcq_dwcas_t;
-
 __pony_spec_align__(
   typedef struct mpmcq_t
   {
     PONY_ATOMIC(mpmcq_node_t*) head;
-    PONY_ATOMIC(mpmcq_dwcas_t) tail;
+    PONY_ATOMIC(mpmcq_node_t*) tail;
   } mpmcq_t, 64
 );
 
-void ponyint_mpmcq_init(mpmcq_t* q);
+mpmcq_node_t* ponyint_mpmcq_node_alloc(void* data);
+
+void ponyint_mpmcq_node_free(mpmcq_node_t* node);
+
+mpmcq_node_t* ponyint_mpmcq_init(mpmcq_t* q);
 
 void ponyint_mpmcq_destroy(mpmcq_t* q);
 
@@ -31,7 +29,7 @@ void ponyint_mpmcq_push(mpmcq_t* q, void* data);
 
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data);
 
-void* ponyint_mpmcq_pop(mpmcq_t* q);
+void* ponyint_mpmcq_pop(mpmcq_t* q, mpmcq_node_t** old_item);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -43,6 +43,16 @@ struct scheduler_t
 
   // These are changed primarily by the owning scheduler thread.
   __pony_spec_align__(struct scheduler_t* last_victim, 64);
+  // Data used to mitigate the ABA problem when popping from the MPMC queues.
+  // We need less data on ARM because the ABA problem can't occur
+  // (compare_exchange is implemented with LoadLinked/StoreConditional
+  // instructions).
+#ifdef PLATFORM_IS_X86
+  mpmcq_node_t** sched_buffer_nodes;
+  mpmcq_node_t* inject_buffer_node;
+#else
+  mpmcq_node_t* sched_buffer_node;
+#endif
 
   pony_ctx_t ctx;
   uint32_t block_count;


### PR DESCRIPTION
This commit changes the memory management of the MPMC queue. Previously, a node was freed when the next item was popped by any thread. Now, a node will only be freed when the thread that popped it successfuly pops another node from the same queue. This mitigates the ABA problem by making sure the delay between popping a node and freeing that node is high compared to the delay of the CAS loop in
`ponyint_mpmcq_pop`. As a result, the ABA counter on the nodes is removed and the CAS loop operand is now a single pointer instead of a double memory word structure.

This change also introduces some memory overhead to hold the popped nodes. On x86, the space complexity is quadratic on the number of threads: each thread holds a node pointer per queue. On ARM, the complexity is linear on the number of threads: each thread holds a single node pointer that it will use for all queues. This is because the ABA problem can't occur on ARM thanks to the memory model, but the change still eliminates some synchronisation in `ponyint_mpmcq_pop`.