### PR TITLE
Generate trace correctly for tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Improve efficiency of muted TCPConnection on non Windows platforms (PR #1477)
 - Compiler assertion failure during type checking
 - Runtime memory allocator bug
+- Compiler crash on tuple sending generation (issue #1546)
 
 ### Added
 

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -476,7 +476,7 @@ static void trace_tuple(compile_t* c, LLVMValueRef ctx, LLVMValueRef value,
   int i = 0;
 
   // We're a tuple, determined statically.
-  if(dst_type != NULL)
+  if((dst_type != NULL) && (ast_id(dst_type) == TK_TUPLETYPE))
   {
     ast_t* src_child = ast_child(src_type);
     ast_t* dst_child = ast_child(dst_type);


### PR DESCRIPTION
This change fixes a code generator crash on generating behaviour calls with tuples as arguments.

Closes #1546.