### PR TITLE
Rename IPAddress to NetAddress

### DIFF
--- a/examples/net/ping.pony
+++ b/examples/net/ping.pony
@@ -2,9 +2,9 @@ use "net"
 
 class Ping is UDPNotify
   let _env: Env
-  let _ip: IPAddress
+  let _ip: NetAddress
 
-  new create(env: Env, ip: IPAddress) =>
+  new create(env: Env, ip: NetAddress) =>
     _env = env
     _ip = ip
 
@@ -22,7 +22,7 @@ class Ping is UDPNotify
     _env.out.print("Ping: not listening")
     sock.dispose()
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
   =>
     try
       (let host, let service) = from.name()

--- a/examples/net/pong.pony
+++ b/examples/net/pong.pony
@@ -31,7 +31,7 @@ class Pong is UDPNotify
     _env.out.print("Pong: not listening")
     sock.dispose()
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
   =>
     try
       (let host, let service) = from.name()

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -16,9 +16,9 @@ actor Main is TestList
 
 class _TestPing is UDPNotify
   let _h: TestHelper
-  let _ip: IPAddress
+  let _ip: NetAddress
 
-  new create(h: TestHelper, ip: IPAddress) =>
+  new create(h: TestHelper, ip: NetAddress) =>
     _h = h
 
     _ip = try
@@ -54,7 +54,7 @@ class _TestPing is UDPNotify
     sock.set_broadcast(true)
     sock.write("ping!", _ip)
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress) =>
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress) =>
     _h.complete_action("ping receive")
 
     let s = String.>append(consume data)
@@ -90,7 +90,7 @@ class _TestPong is UDPNotify
       _h.fail_action("ping create")
     end
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
   =>
     _h.complete_action("pong receive")
 

--- a/packages/net/dns.pony
+++ b/packages/net/dns.pony
@@ -5,7 +5,7 @@ primitive DNS
   Helper functions for resolving DNS queries.
   """
   fun apply(auth: DNSLookupAuth, host: String, service: String)
-    : Array[IPAddress] iso^
+    : Array[NetAddress] iso^
   =>
     """
     Gets all IPv4 and IPv6 addresses for a host and service.
@@ -13,7 +13,7 @@ primitive DNS
     _resolve(auth, 0, host, service)
 
   fun ip4(auth: DNSLookupAuth, host: String, service: String)
-    : Array[IPAddress] iso^
+    : Array[NetAddress] iso^
   =>
     """
     Gets all IPv4 addresses for a host and service.
@@ -21,7 +21,7 @@ primitive DNS
     _resolve(auth, 1, host, service)
 
   fun ip6(auth: DNSLookupAuth, host: String, service: String)
-    : Array[IPAddress] iso^
+    : Array[NetAddress] iso^
   =>
     """
     Gets all IPv6 addresses for a host and service.
@@ -29,7 +29,7 @@ primitive DNS
     _resolve(auth, 2, host, service)
 
   fun broadcast_ip4(auth: DNSLookupAuth, service: String)
-    : Array[IPAddress] iso^
+    : Array[NetAddress] iso^
   =>
     """
     Link-local IP4 broadcast address.
@@ -37,7 +37,7 @@ primitive DNS
     ip4(auth, "255.255.255.255", service)
 
   fun broadcast_ip6(auth: DNSLookupAuth, service: String)
-    : Array[IPAddress] iso^
+    : Array[NetAddress] iso^
   =>
     """
     Link-local IP6 broadcast address.
@@ -57,12 +57,12 @@ primitive DNS
     @pony_os_host_ip6[Bool](host.cstring())
 
   fun _resolve(auth: DNSLookupAuth, family: U32, host: String,
-    service: String): Array[IPAddress] iso^
+    service: String): Array[NetAddress] iso^
   =>
     """
     Turns an addrinfo pointer into an array of addresses.
     """
-    var list = recover Array[IPAddress] end
+    var list = recover Array[NetAddress] end
     var result = @pony_os_addrinfo[Pointer[U8]](family,
       host.cstring(), service.cstring())
 
@@ -70,7 +70,7 @@ primitive DNS
       var addr = result
 
       while not addr.is_null() do
-        let ip = recover IPAddress end
+        let ip = recover NetAddress end
         @pony_os_getaddr[None](addr, ip)
         list.push(consume ip)
         addr = @pony_os_nextaddr[Pointer[U8]](addr)

--- a/packages/net/http/server.pony
+++ b/packages/net/http/server.pony
@@ -13,7 +13,7 @@ actor Server
   let _reversedns: (DNSLookupAuth | None)
   let _sslctx: (SSLContext | None)
   let _listen: TCPListener
-  var _address: IPAddress
+  var _address: NetAddress
   var _dirty_routes: Bool = false
 
   new create(auth: TCPListenerAuth, notify: ServerNotify iso,
@@ -33,7 +33,7 @@ actor Server
     _listen = TCPListener(auth,
       _ServerListener(this, sslctx, _handler, _logger, _reversedns),
       host, service, limit)
-    _address = recover IPAddress end
+    _address = recover NetAddress end
 
   be set_handler(handler: RequestHandler) =>
     """
@@ -57,13 +57,13 @@ actor Server
     """
     _listen.dispose()
 
-  fun local_address(): IPAddress =>
+  fun local_address(): NetAddress =>
     """
     Returns the locally bound address.
     """
     _address
 
-  be _listening(address: IPAddress) =>
+  be _listening(address: NetAddress) =>
     """
     Called when we are listening.
     """

--- a/packages/net/net_address.pony
+++ b/packages/net/net_address.pony
@@ -1,4 +1,4 @@
-class val IPAddress
+class val NetAddress
   """
   Represents an IPv4 or IPv6 address. The family field indicates the address
   type. The addr field is either the IPv4 address or the IPv6 flow info. The

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -300,19 +300,19 @@ actor TCPConnection
     """
     close()
 
-  fun local_address(): IPAddress =>
+  fun local_address(): NetAddress =>
     """
     Return the local IP address.
     """
-    let ip = recover IPAddress end
+    let ip = recover NetAddress end
     @pony_os_sockname[Bool](_fd, ip)
     ip
 
-  fun remote_address(): IPAddress =>
+  fun remote_address(): NetAddress =>
     """
     Return the remote IP address.
     """
-    let ip = recover IPAddress end
+    let ip = recover NetAddress end
     @pony_os_peername[Bool](_fd, ip)
     ip
 

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -38,7 +38,7 @@ actor TCPListener
   var _max_size: USize
 
   new create(auth: TCPListenerAuth, notify: TCPListenNotify iso,
-    host: String = "", service: String = "0", limit: USize = 0, 
+    host: String = "", service: String = "0", limit: USize = 0,
     init_size: USize = 64, max_size: USize = 16384)
   =>
     """
@@ -54,7 +54,7 @@ actor TCPListener
     _notify_listening()
 
   new ip4(auth: TCPListenerAuth, notify: TCPListenNotify iso,
-    host: String = "", service: String = "0", limit: USize = 0, 
+    host: String = "", service: String = "0", limit: USize = 0,
     init_size: USize = 64, max_size: USize = 16384)
   =>
     """
@@ -70,7 +70,7 @@ actor TCPListener
     _notify_listening()
 
   new ip6(auth: TCPListenerAuth, notify: TCPListenNotify iso,
-    host: String = "", service: String = "0", limit: USize = 0, 
+    host: String = "", service: String = "0", limit: USize = 0,
     init_size: USize = 64, max_size: USize = 16384)
   =>
     """
@@ -97,11 +97,11 @@ actor TCPListener
     """
     close()
 
-  fun local_address(): IPAddress =>
+  fun local_address(): NetAddress =>
     """
     Return the bound IP address.
     """
-    let ip = recover IPAddress end
+    let ip = recover NetAddress end
     @pony_os_sockname[Bool](_fd, ip)
     ip
 

--- a/packages/net/udp_notify.pony
+++ b/packages/net/udp_notify.pony
@@ -17,7 +17,7 @@ interface UDPNotify
     """
     None
 
-  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+  fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
   =>
     """
     Called when new data is received on the socket.

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -18,7 +18,7 @@ actor UDPSocket
   use "net"
 
   class MyUDPNotify is UDPNotify
-    fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+    fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
     =>
       sock.write(consume data, from)
 
@@ -37,13 +37,13 @@ actor UDPSocket
 
   class MyUDPNotify is UDPNotify
     let _out: OutStream
-    let _destination: IPAddress
-    new create(out: OutStream, destination: IPAddress) =>
+    let _destination: NetAddress
+    new create(out: OutStream, destination: NetAddress) =>
       _out = out
       _destination = destination
     fun ref listening(sock: UDPSocket ref) =>
       sock.write("hello world", _destination)
-    fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: IPAddress)
+    fun ref received(sock: UDPSocket ref, data: Array[U8] iso, from: NetAddress)
     =>
       _out.print("GOT:" + String.from_array(consume data))
       sock.dispose()
@@ -64,8 +64,8 @@ actor UDPSocket
   var _closed: Bool = false
   var _packet_size: USize
   var _read_buf: Array[U8] iso
-  var _read_from: IPAddress iso = IPAddress
-  embed _ip: IPAddress = IPAddress
+  var _read_from: NetAddress iso = NetAddress
+  embed _ip: NetAddress = NetAddress
 
   new create(auth: UDPSocketAuth, notify: UDPNotify iso, host: String = "",
     service: String = "0", size: USize = 1024)
@@ -115,13 +115,13 @@ actor UDPSocket
     _notify_listening()
     _start_next_read()
 
-  be write(data: ByteSeq, to: IPAddress) =>
+  be write(data: ByteSeq, to: NetAddress) =>
     """
     Write a single sequence of bytes.
     """
     _write(data, to)
 
-  be writev(data: ByteSeqIter, to: IPAddress) =>
+  be writev(data: ByteSeqIter, to: NetAddress) =>
     """
     Write a sequence of sequences of bytes.
     """
@@ -204,7 +204,7 @@ actor UDPSocket
       _close()
     end
 
-  fun local_address(): IPAddress =>
+  fun local_address(): NetAddress =>
     """
     Return the bound IP address.
     """
@@ -259,7 +259,7 @@ actor UDPSocket
         while _readable do
           let size = _packet_size
           let data = _read_buf = recover Array[U8].>undefined(size) end
-          let from = recover IPAddress end
+          let from = recover NetAddress end
           let len = @pony_os_recvfrom[USize](_event, data.cpointer(),
             data.space(), from) ?
 
@@ -303,7 +303,7 @@ actor UDPSocket
       // Hand back read data
       let size = _packet_size
       let data = _read_buf = recover Array[U8].>undefined(size) end
-      let from = _read_from = recover IPAddress end
+      let from = _read_from = recover NetAddress end
       data.truncate(len.usize())
       _notify.received(this, consume data, consume from)
 
@@ -325,7 +325,7 @@ actor UDPSocket
       end
     end
 
-  fun ref _write(data: ByteSeq, to: IPAddress) =>
+  fun ref _write(data: ByteSeq, to: NetAddress) =>
     """
     Write the datagram to the socket.
     """


### PR DESCRIPTION
As was discussed in https://github.com/ponylang/ponyc/pull/1524,
IPAddress is poorly named as it doesn't represent just the IP address,
it incorporates additional information such as port, protocol etc.

This change renamed IPAddress to more applicable NetAddress.