### PR TITLE
Performance improvement in subtype checking.

### DIFF
--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -232,8 +232,8 @@ static ast_t* lookup_union(pass_opt_t* opt, ast_t* from, ast_t* type,
           {
             // If we don't have a result yet, use this one.
             result = r;
-          } else if(!is_subtype(r, result, pframe, opt)) {
-            if(is_subtype(result, r, pframe, opt))
+          } else if(!is_subtype_fun(r, result, pframe, opt)) {
+            if(is_subtype_fun(result, r, pframe, opt))
             {
               // Use the supertype function. Require the most specific
               // arguments and return the least specific result.
@@ -302,8 +302,8 @@ static ast_t* lookup_isect(pass_opt_t* opt, ast_t* from, ast_t* type,
           {
             // If we don't have a result yet, use this one.
             result = r;
-          } else if(!is_subtype(result, r, NULL, opt)) {
-            if(is_subtype(r, result, NULL, opt))
+          } else if(!is_subtype_fun(result, r, NULL, opt)) {
+            if(is_subtype_fun(r, result, NULL, opt))
             {
               // Use the subtype function. Require the least specific
               // arguments and return the most specific result.

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -15,6 +15,9 @@ bool is_sub_cap_and_ephemeral(ast_t* sub, ast_t* super);
 bool is_subtype(ast_t* sub, ast_t* super, errorframe_t* errorf,
   pass_opt_t* opt);
 
+bool is_subtype_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
+  pass_opt_t* opt);
+
 bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt);
 
 bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,


### PR DESCRIPTION
In subtype checking we now avoid some costly allocation operations
associated with viewpoint adaptation and reification by checking
first if the type could be a subtype of the other if caps were ignored.
If not, then there's no point in moving forward with comparisons
that take the cap into account, but require costly allocations.

Reduces compile time drastically for programs requiring a lot of type
unions to be flattened, where those types involve viewpoint adaptation.
For the real-world package under test, compile time was reduced by 23x.
For comparison, standard library test compile time was not affected by this change.