### PR TITLE
Fix Linux epoll event resubscribe performance and race condition.

### DIFF
--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -26,6 +26,8 @@ asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
   ev->flags = flags;
   ev->noisy = noisy;
   ev->nsec = nsec;
+  ev->writeable = false;
+  ev->readable = false;
 
   // The event is effectively being sent to another thread, so mark it here.
   pony_ctx_t* ctx = pony_ctx();
@@ -63,6 +65,34 @@ int pony_asio_event_fd(asio_event_t* ev)
     return -1;
 
   return ev->fd;
+}
+
+bool pony_asio_event_get_writeable(asio_event_t* ev)
+{
+  if(ev == NULL)
+    return false;
+
+  return ev->writeable;
+}
+
+void pony_asio_event_set_writeable(asio_event_t* ev, bool writeable)
+{
+  if(ev != NULL)
+    ev->writeable = writeable;
+}
+
+bool pony_asio_event_get_readable(asio_event_t* ev)
+{
+  if(ev == NULL)
+    return false;
+
+  return ev->readable;
+}
+
+void pony_asio_event_set_readable(asio_event_t* ev, bool readable)
+{
+  if(ev != NULL)
+    ev->readable = readable;
 }
 
 uint64_t pony_asio_event_nsec(asio_event_t* ev)

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -21,6 +21,18 @@ typedef struct asio_event_t
   uint32_t flags;       /* event filter flags */
   bool noisy;           /* prevents termination? */
   uint64_t nsec;        /* nanoseconds for timers */
+
+#ifdef PLATFORM_IS_LINUX
+  // automagically resubscribe to an event on an FD when another event is
+  // on the same FD is triggered
+  // This is only needed on linux where an event firing on an FD that has
+  // ONESHOT enabled will clear all events for the FD and not only the
+  // event that was fired.
+  bool auto_resub;      /* automagically resubscribe? */
+#endif
+
+  bool readable;        /* is fd readable? */
+  bool writeable;       /* is fd writeable? */
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE timer;         /* timer handle */
 #endif
@@ -77,6 +89,22 @@ void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec);
  *  notifications for I/O events on the corresponding resource.
  */
 void pony_asio_event_unsubscribe(asio_event_t* ev);
+
+/** Get whether FD is writeable or not
+ */
+bool pony_asio_event_get_writeable(asio_event_t* ev);
+
+/** Set whether FD is writeable or not
+ */
+void pony_asio_event_set_writeable(asio_event_t* ev, bool writeable);
+
+/** Get whether FD is readable or not
+ */
+bool pony_asio_event_get_readable(asio_event_t* ev);
+
+/** Get whether FD is readable or not
+ */
+void pony_asio_event_set_readable(asio_event_t* ev, bool readable);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -568,13 +568,8 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
     return false;
   }
 
-#ifndef PLATFORM_IS_WINDOWS
   // Create an event and subscribe it.
   pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0, true);
-#else
-  // Create an event and subscribe it.
-  pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE, 0, true);
-#endif
 #endif
 
   return true;


### PR DESCRIPTION
Prior to this change, if ONE_SHOT is enabled, linux epoll based
asio wouldn't be subscribed for certain events after another
event was fired on the same FD.

The specific scenario was the following:

* Register event E for READ/WRITE with ONE_SHOT.
* E fires for READ and a message is placed on the message queue
  for the TCPConnection actor.
* TCPConnection actor eventually gets to processing this message
  (after processing any other messages ahread of this one on the
  queue) and then goes through the work of `_event_notify`. At
  the end of `_event_notify`, `_resubscribe_event` is called and
  epoll is told to resubscribe for READ and/or WRITE events as
  required.

Normally, this wouldn't be an issue but the behavior we're seen
is that with ONE_SHOT, if a READ (or WRITE) event is fired, all
events for the FD are disabled. This means that in the above
scenario, when the READ event is fired, the WRITE is also
disabled along with the READ because of ONE_SHOT.

We could (and did) try adding a call to `_resubscribe_event` in
`_event_notify` before any processing is done to resubscribe
earlier but there were two problems with this. First, it still
meant that the other event was unsubscribed for the duration of
the time the asio event notification message was sitting on the
message queue of the TCPConnection actor. Second, it resulted in
a race condition and incorrect use of epoll where the TCPConnection
actor would ask epoll to resubscribe to either READ or WRITE when
the event had already fired and was waiting on the message queue.
For the READ event case, this is incorrect use of epoll because
the manual for epoll strongly indicates that when using ONE_SHOT
and Edge Triggering all data should be read from the socket before
it is resubcribed again.

The final design we settled upon is to move the readable/writeable
flags into the Event structure, split the resubscribe for READ
and WRITE events, and have epoll automagically resubscribe to the
untriggered event if ONE_SHOT is enabled. This ensures there are
no race conditions because the decision to resubscribe is based on
the the state of the readable/writeable flags on the event which is
always up to date based on the latest events that fired. It also
ensures that we resubscribe to the untriggered event as soon as
possible because the epoll asio thread takes care of it.

* The event now holds the readable/writeable flags.
* This is only safe because the asio thread will only
  write to those flags if there's a subscription for an event.
* In order to avoid two threads writing/reading to the new flags
  at the same time, the resubscribe for reads and writes has been
  split.
* Additionally, the epoll code will now automagically resubscribe
  to the un-triggered event in order to minimize the delay for when
  an event is triggered for ONE_SHOT code so it behaves the same
  as for kqueue ONE_SHOT where if an FD is subscribed with ONE_SHOT
  for both `read` and `write` events and a `read` event fires and
  is disabled because of ONE_SHOT, the `write` event is still left
  enabled. This also greatly simplifies where/when resubscribes
  need to occur in the TCPConnection actor.
* Update kqueue code to also split readable/writeable resubscribe.