### PR TITLE
Makes NetAddress comparable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Readline interpret C-d on empty line as EOF (PR #1504)
 - AST annotations (RFC 27) (PR #1485)
 - Unsafe mathematic and logic operations. Can be faster but can have undefined results for some inputs (issue #993)
+- Equality comparison for NetAddress (PR #1569)
+- Host address comparison for NetAddress (PR #1569)
 
 ### Changed
 

--- a/packages/net/net_address.pony
+++ b/packages/net/net_address.pony
@@ -1,4 +1,4 @@
-class val NetAddress
+class val NetAddress is Equatable[NetAddress]
   """
   Represents an IPv4 or IPv6 address. The family field indicates the address
   type. The addr field is either the IPv4 address or the IPv6 flow info. The
@@ -44,3 +44,20 @@ class val NetAddress
 
     (recover String.from_cstring(consume host) end,
       recover String.from_cstring(consume serv) end)
+
+  fun eq(that: NetAddress box): Bool =>
+    (this.length == that.length) and
+    (this.family == that.family) and
+    (this.port == that.port) and
+    (host_eq(that)) and
+    (this.scope == that.scope)
+
+  fun host_eq(that: NetAddress box): Bool =>
+    if ip4() then
+      this.addr == that.addr
+    else
+      (this.addr1 == that.addr1) and
+      (this.addr2 == that.addr2) and
+      (this.addr3 == that.addr3) and
+      (this.addr4 == that.addr4)
+    end


### PR DESCRIPTION
Provides two types of equality.

1: "basic equality"

Compares all the fields of NetAddress to see if they are equal. This
is the comparison if we use `==` or `eq`.

2: "address equality"

Compares based on the ip address portion of NetAddress. Does not
take port, family, length or scope into account. We are using
"address equality" at Sendence to compare, "is this IP for a local
or remote address" which is in turn used to decide whether to turn
on TCP_NODELAY (on Linux, using TCP_NODELAY on local addresses has
a negative impact on our performance/stability. Using it on
remote addresses helps our performance/stability).