### PR TITLE
Make persistent map more general

### DIFF
--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -1,12 +1,12 @@
 use mut = "collections"
 
-type _MapCollisions[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+type _MapCollisions[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   is Array[_MapLeaf[K, V]] val
 
-type _MapEntry[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+type _MapEntry[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   is (_MapNode[K, V] | _MapCollisions[K, V] | _MapLeaf[K, V])
 
-class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class val _MapNode[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   let _entries: Array[_MapEntry[K, V]] val
   let _nodemap: U32
   let _datamap: U32
@@ -30,7 +30,7 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
     _datamap = dm
     _level = l
 
-  fun val apply(hash: U32, key: K): val->V ? =>
+  fun val apply(hash: U32, key: K): V ? =>
     let idx = _mask(hash, _level)
     let i = _array_index(_nodemap, _datamap, idx)
     if i == -1 then error end
@@ -169,7 +169,7 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K] val), V: Any val]
 
   fun entries(): Array[_MapEntry[K, V]] val => _entries
 
-class val _MapLeaf[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class val _MapLeaf[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   let hash: U32
   let key: K
   let value: V

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -9,7 +9,7 @@ primitive Maps
     Map[K, V]._empty()
 
   fun val from[K: (mut.Hashable val & Equatable[K]), V: Any #share]
-  (pairs: Array[(K, V)]): Map[K, V] ? =>
+  (pairs: Array[(K, val->V)]): Map[K, V] ? =>
     """
     Return a map containing the provided key-value pairs.
     """
@@ -48,7 +48,7 @@ class val Map[K: (mut.Hashable val & Equatable[K]), V: Any #share]
     _root = r
     _size = s
 
-  fun val apply(k: K): V ? =>
+  fun val apply(k: K): val->V ? =>
     """
     Attempt to get the value corresponding to k.
     """
@@ -60,7 +60,7 @@ class val Map[K: (mut.Hashable val & Equatable[K]), V: Any #share]
     """
     _size
 
-  fun val update(key: K, value: V): Map[K, V] ? =>
+  fun val update(key: K, value: val->V): Map[K, V] ? =>
     """
     Update the value associated with the provided key.
     """
@@ -75,7 +75,7 @@ class val Map[K: (mut.Hashable val & Equatable[K]), V: Any #share]
     """
     _create(_root.remove(k.hash().u32(), k), _size-1)
 
-  fun val get_or_else(k: K, alt: V): V =>
+  fun val get_or_else(k: K, alt: val->V): val->V =>
     """
     Get the value associated with provided key if present. Otherwise,
     return the provided alternate value.
@@ -122,7 +122,7 @@ class MapValues[K: (mut.Hashable val & Equatable[K]), V: Any #share]
 
   fun has_next(): Bool => _pairs.has_next()
 
-  fun ref next(): V ? => _pairs.next()._2
+  fun ref next(): val->V ? => _pairs.next()._2
 
 class MapPairs[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   embed _path: Array[_MapNode[K, V]]
@@ -140,7 +140,7 @@ class MapPairs[K: (mut.Hashable val & Equatable[K]), V: Any #share]
 
   fun has_next(): Bool => _i < _size
 
-  fun ref next(): (K, V) ? =>
+  fun ref next(): (K, val->V) ? =>
     (let n, let i) = _cur()
     if i >= n.entries().size() then
       _backup()

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -1,15 +1,15 @@
 use mut = "collections"
 
 primitive Maps
-  fun val empty[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+  fun val empty[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   (): Map[K, V] =>
     """
     Return an empty map.
     """
     Map[K, V]._empty()
 
-  fun val from[K: (mut.Hashable val & Equatable[K] val), V: Any val]
-  (pairs: Array[(K, val->V)]): Map[K, V] ? =>
+  fun val from[K: (mut.Hashable val & Equatable[K]), V: Any #share]
+  (pairs: Array[(K, V)]): Map[K, V] ? =>
     """
     Return a map containing the provided key-value pairs.
     """
@@ -19,7 +19,7 @@ primitive Maps
     end
     m
 
-class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class val Map[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   """
   A persistent map based on the Compressed Hash Array Mapped Prefix-tree from
   'Optimizing Hash-Array Mapped Tries for Fast and Lean Immutable JVM
@@ -48,7 +48,7 @@ class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
     _root = r
     _size = s
 
-  fun val apply(k: K): val->V ? =>
+  fun val apply(k: K): V ? =>
     """
     Attempt to get the value corresponding to k.
     """
@@ -75,7 +75,7 @@ class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
     """
     _create(_root.remove(k.hash().u32(), k), _size-1)
 
-  fun val get_or_else(k: K, alt: val->V): val->V =>
+  fun val get_or_else(k: K, alt: V): V =>
     """
     Get the value associated with provided key if present. Otherwise,
     return the provided alternate value.
@@ -106,7 +106,7 @@ class val Map[K: (mut.Hashable val & Equatable[K] val), V: Any val]
 
   fun _root_node(): _MapNode[K, V] => _root
 
-class MapKeys[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class MapKeys[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   embed _pairs: MapPairs[K, V]
 
   new create(m: Map[K, V]) => _pairs = MapPairs[K, V](m)
@@ -115,7 +115,7 @@ class MapKeys[K: (mut.Hashable val & Equatable[K] val), V: Any val]
 
   fun ref next(): K ? => _pairs.next()._1
 
-class MapValues[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class MapValues[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   embed _pairs: MapPairs[K, V]
 
   new create(m: Map[K, V]) => _pairs = MapPairs[K, V](m)
@@ -124,7 +124,7 @@ class MapValues[K: (mut.Hashable val & Equatable[K] val), V: Any val]
 
   fun ref next(): V ? => _pairs.next()._2
 
-class MapPairs[K: (mut.Hashable val & Equatable[K] val), V: Any val]
+class MapPairs[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   embed _path: Array[_MapNode[K, V]]
   embed _idxs: Array[USize]
   var _i: USize = 0


### PR DESCRIPTION
This PR simply make the persistent Map more general by allowing the value to be `Any #share` rather than `Any val`.