### PR TITLE
Add foreigntypes package to hold FFI interop types

### DIFF
--- a/packages/foreigntypes/foreigntypes.pony
+++ b/packages/foreigntypes/foreigntypes.pony
@@ -1,0 +1,9 @@
+"""
+# ForeignTypes package
+
+The foreigntypes package is home to type definitions/aliases for foreign
+languages that Pony applications might interact with via FFI calls.
+
+In particular, it includes
+1. Posix standard types
+"""

--- a/packages/foreigntypes/posixerrors.pony
+++ b/packages/foreigntypes/posixerrors.pony
@@ -1,0 +1,12 @@
+// This file defines the standard Posix error to make FFI calls easier
+// to manage and more consistent.
+
+primitive EBADF
+  fun apply(): I32 => 9
+
+primitive EEXIST
+  fun apply(): I32 => 17
+
+primitive EACCES
+  fun apply(): I32 => 13
+

--- a/packages/foreigntypes/posixtypes.pony
+++ b/packages/foreigntypes/posixtypes.pony
@@ -1,0 +1,95 @@
+// This file defines the standard Posix type to make FFI calls easier
+// to manage and more consistent.
+
+type BlkCnt is I64 "blkcnt_t - Used for file block counts."
+
+// not consistent across OSX (always 32 bit int)/Linux (Long)
+type BlkSize is ILong "blksize_t - Used for block sizes."
+type OSXBlkSize is I32 "blksize_t - Used for block sizes. (OSX variant)"
+
+type Cc is U8 "cc_t - Type used for terminal special characters."
+
+// not consistent across OSX (Unsigned Long)/Linux (Long)
+type Clock is ILong "clock_t - Used for system times in clock ticks or CLOCKS_PER_SEC."
+type OSXClock is ULong "clock_t - Used for system times in clock ticks or CLOCKS_PER_SEC. (OSX variant)"
+
+// not defined on OSX
+type ClockId is I32 "clockid_t - Used for clock ID type in the clock and timer functions."
+
+// not consistent across OSX (always 32 bit int)/Linux (always 64 bit)
+type Dev is I64 "dev_t - Used for device IDs."
+type OSXDev is I32 "dev_t - Used for device IDs. (OSX variant)"
+
+// not consistent across OSX (always unsigned int)/Linux (always unsigned long)
+type FsBlkCnt is ULong "fsblkcnt_t - Used for file system block counts."
+type OSXFsBlkCnt is U32 "fsblkcnt_t - Used for file system block counts. (OSX variant)"
+
+// not consistent across OSX (always unsigned int)/Linux (always unsigned long)
+type FsFilCnt is ULong "fsfilcnt_t - Used for file system file counts."
+type OSXFsFilCnt is U32 "fsfilcnt_t - Used for file system file counts. (OSX variant)"
+
+type Gid is U32 "gid_t - Used for group IDs."
+
+type Id is U32 "id_t - Used as a general identifier; can be used to contain at least a pid_t, uid_t, or gid_t."
+
+type INo is U64 "ino_t - Used for file serial numbers."
+
+type Key is I32 "key_t - Used for XSI interprocess communication."
+
+// not consistent across OSX (always unsigned 16 bit int)/Linux (always unsigned int)
+type Mode is ULong "mode_t - Used for some file attributes."
+type OSXMode is U16 "mode_t - Used for some file attributes. (OSX variant)"
+
+type Mqd is I32 "mqd_t - Used for message queue descriptors."
+
+// not consistent across OSX (always unsigned int)/Linux (always unsigned Long)
+type Nfds is ULong "nfds_t - Integral type used for the number of file descriptors."
+type OSXNfds is U32 "nfds_t - Integral type used for the number of file descriptors. (OSX variant)"
+
+// not consistent across OSX (always unsigned 16 bit int)/Linux (unsigned Long)
+type NLink is ULong "nlink_t - Used for link counts."
+type OSXNLink is U16 "nlink_t - Used for link counts. (OSX variant)"
+
+type Off is I64 "off_t - Used for file sizes."
+
+type Pid is I32 "pid_t - Used for process IDs and process group IDs."
+
+// not defined on linux
+type PtrDiff is ISize "ptrdiff_t - Signed integral type of the result of subtracting two pointers."
+
+type RLim is I64 "rlim_t - Unsigned arithmetic type used for limit values, to which objects of type int and off_t can be cast without loss of value."
+
+type SigAtomic is I32 "sig_atomic_t - Integral type of an object that can be accessed as an atomic entity, even in the presence of asynchronous interrupts."
+
+type Size is USize "size_t - Used for sizes of objects."
+
+// not consistent across OSX (always unsigned long)/Linux (always unsigned int)
+type Speed is ULong "speed_t - Type used for terminal baud rates."
+
+type SSize is ISize "ssize_t - Used for a count of bytes or an error indication."
+
+// not consistent across OSX (always int)/Linux (always long)
+type SuSeconds is ILong "suseconds_t - Used for time in microseconds."
+
+// not consistent across OSX (always unsigned long)/Linux (always unsigned int)
+type TcFlag is U32 "tcflag_t - Type used for terminal modes."
+type OSXTcFlag is ULong "tcflag_t - Type used for terminal modes. (OSX variant)"
+
+type Time is ILong "time_t - Used for time in seconds."
+
+// not defined on OSX/void* on Linux
+type Timer is Pointer[None] "timer_t - Used for timer ID returned by timer_create()."
+
+type Uid is U32 "uid_t - Used for user IDs."
+
+type USeconds is U32 "useconds_t - Used for time in microseconds."
+
+type Wchar is I32 "wchar_t - Integral type whose range of values can represent distinct codes for all members of the largest extended character set specified by the supported locales."
+
+// not consistent across OSX (always unsigned 32 bit)/Linux (always unsigned long)
+type WCType is ULong "wctype_t - Scalar type which represents a character class descriptor."
+type OSXWCType is U32 "wctype_t - Scalar type which represents a character class descriptor. (OSX variant)"
+
+// not consistent across OSX (always signed 32 bit)/Linux (always unsigned 32 bit)
+type WInt is U32 "wint_t - An integral type capable of storing any valid value of wchar_t, or WEOF."
+type OSXWInt is I32 "wint_t - An integral type capable of storing any valid value of wchar_t, or WEOF. (OSX variant)"


### PR DESCRIPTION
NOTE: This PR has been updated to only include the `foreigntypes` package. See discussion thread on this PR for details.

-----------------

The motivation behind this is to improve performance to file i/o
operations. The C standard stdio functions do user space
buffering prior to sending the data to the OS kernel via a system
call. On most operating system, the OS kernel also does additional
buffering on top of the user level buffering by the C functions.
Unfortunately, if the C functions are buffering data, they prevent
the OS kernal from taking advantage of some potential performance
enhancements if they're available (namely Vectored I/O so the
OS can offload work to hardward and never has to combine multiple
user buffers into a single buffer for writing to disk).

The commit changes the File class to use low level i/o functions
that map to system calls on Linux and other posix based systems
and to C lib calls on Windows. On Posix based systems, the OS is
free to take advantage of performance offloading to hardware if
possible. On Windows, this change shouldn't have a negative
performance impact but doesn't give the same possible performance
benefits as on Posix based systems.

Other changes:

* Enable `_FILE_OFFSET_BITS=64` arg to compiler to ensure 32 bit
  linux builds get large file support enabled.
* Adds `datasync` to be able to call `fdatasync` instead of `fsync`
  as it can be appropriate in some situations. On Windows, `fsync`
  and `fdatasync` behave the same.
* Adds `queue` and `queuev` functions that are analogous to
  `write` and `writev` but queue/buffer data to be written
  instead of writing the data immediately. Additionally,
  these new functions provide the ability to interleave buffered
  data writing and unbuffered data writing where unbuffered data
  writing would force any buffered data to be written first.
* Changes `flush` to flush any queued/buffered data to disk
  because it is otherwise unnecessary since we're not buffering
  data in the C library via stdio any longer.
* A few additional tests have been added to validate things are
  working correctly.

Future work:
* Change `queue`/`queuev` to automatically flush data to disk once
  the # of queued items exceeds `IOV_MAX` for a single system call.
* Error handling in the File package might be possible to add now
  including having the various functions throw `error` on things
  that can't be recovered from.
* Possibly switch to async/nonblocking i/o for file writing with an
  actor as the intermediary (similar to the TCPConnection actor in
  the net package).

--------

Also added foreigntypes package to hold FFI interop types

The new package is to help with consistency of data types
mapping between Pony and FFI types. Initially includes types
related to the Posix standard.

Thanks to @sylvanc for help and feedback regarding this.

--------

The following is a great explanation of why `writev` is worth it (from https://bytes.com/topic/python/answers/39551-writev) in reference to python:
```
writelines applies to a general Python file object. writev applies only
to C file descriptors. Writev can't replace writelines, after all it
makes no sense to cStringIO, gzip files for these are not valid C file
descriptors. Generally, writelines works fine.

Now why would you want to use writev? Optimization on the C side.

Understand that when you do file I/O you have to either:

a) Copy all of the strings to a new memory location
b) Call write over and over again

Sometimes, when you do b), userspace libraries (fwrite) will "optimize"
by buffering and doing a) for you. But you cannot escape the fact that
so long as your write parameter takes a single string for each
invocation, the underlying libraries are forced to choose between the
two options above.

Writev is the vector version of write. Whereas write accepts a single
pointer and length parameter, writev accepts a *list* of pointers and
size parameters. It represents a strategy c) -- just hand the list to
operating system

I want to include it because POSIX has a single OS call that
conceptually maps pretty closely to writelines. writev can be faster
because you don't have to do memory copies to buffer data in one place
for it -- the OS will do that, and can sometimes delegate that chore to
the underlying network or scsi card.

If you are still scratching your head, just think of writev as a C-file
descriptor only optimization of writelines that offloads the memory copy
cost of buffering to the OS in hopes that it can pass the buck to the
hardware (and IIRC, BSD does handle this correctly ... it has zero copy
network code, think about how cool it is to think that your network card
is going to traverse your list for you with a little help from the
writev function.)
```