### PR TITLE
Use LLVM to detect CPU features by default if --features aren't specified.

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -861,6 +861,16 @@ bool codegen_init(pass_opt_t* opt)
   LLVMInitializeCodeGen(passreg);
   LLVMInitializeTarget(passreg);
 
+  if(opt->features != NULL)
+  {
+    opt->features = LLVMCreateMessage(opt->features);
+  } else {
+    if((opt->cpu == NULL) && (opt->triple == NULL))
+      opt->features = LLVMGetHostCPUFeatures();
+    else
+      opt->features = LLVMCreateMessage("");
+  }
+
   // Default triple, cpu and features.
   if(opt->triple != NULL)
   {
@@ -878,11 +888,6 @@ bool codegen_init(pass_opt_t* opt)
     opt->cpu = LLVMCreateMessage(opt->cpu);
   else
     opt->cpu = LLVMGetHostCPUName();
-
-  if(opt->features != NULL)
-    opt->features = LLVMCreateMessage(opt->features);
-  else
-    opt->features = LLVMCreateMessage("");
 
   return true;
 }

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -21,6 +21,7 @@ PONY_EXTERN_C_BEGIN
 
 // Missing from C API.
 char* LLVMGetHostCPUName();
+char* LLVMGetHostCPUFeatures();
 void LLVMSetUnsafeAlgebra(LLVMValueRef inst);
 void LLVMSetNoUnsignedWrap(LLVMValueRef inst);
 void LLVMSetNoSignedWrap(LLVMValueRef inst);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -33,6 +33,39 @@ char* LLVMGetHostCPUName()
   return strdup(sys::getHostCPUName().str().c_str());
 }
 
+char* LLVMGetHostCPUFeatures()
+{
+  StringMap<bool> features;
+  bool got_features = sys::getHostCPUFeatures(features);
+  assert(got_features);
+  (void)got_features;
+
+  // Calculate the size of buffer that will be needed to return all features.
+  size_t buf_size = 0;
+  for(auto it = features.begin(); it != features.end(); it++)
+    buf_size += (*it).getKey().str().length() + 2; // plus +/- char and ,/null
+
+  char* buf = (char*)malloc(buf_size);
+  assert(buf != NULL);
+  buf[0] = 0;
+
+  for(auto it = features.begin(); it != features.end();)
+  {
+    if((*it).getValue())
+      strcat(buf, "+");
+    else
+      strcat(buf, "-");
+
+    strcat(buf, (*it).getKey().str().c_str());
+
+    it++;
+    if(it != features.end())
+      strcat(buf, ",");
+  }
+
+  return buf;
+}
+
 void LLVMSetUnsafeAlgebra(LLVMValueRef inst)
 {
   unwrap<Instruction>(inst)->setHasUnsafeAlgebra(true);

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -125,6 +125,7 @@ static void usage()
     "    =name         Default is the host CPU.\n"
     "  --features      CPU features to enable or disable.\n"
     "    =+this,-that  Use + to enable, - to disable.\n"
+    "                  Defaults to detecting all CPU features from the host.\n"
     "  --triple        Set the target triple.\n"
     "    =name         Defaults to the host triple.\n"
     "  --stats         Print some compiler stats.\n"


### PR DESCRIPTION
This PR fixes #1176 using the proposed approach discussed in that ticket.

Specifically, if the user does not specify specific `--features` in the invocation, we use LLVM's `getHostCPUFeatures` function to get the list of features (and format them into the expected features string format).
