### PR TITLE
Add fallthrough comments to keep GCC >= 7.x happy.

### DIFF
--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -43,12 +43,12 @@ static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
 
   switch(len & 7)
   {
-    case 7: b |= ((uint64_t)in[6]) << 48;
-    case 6: b |= ((uint64_t)in[5]) << 40;
-    case 5: b |= ((uint64_t)in[4]) << 32;
-    case 4: b |= ((uint64_t)in[3]) << 24;
-    case 3: b |= ((uint64_t)in[2]) << 16;
-    case 2: b |= ((uint64_t)in[1]) << 8;
+    case 7: b |= ((uint64_t)in[6]) << 48; // -fallthrough
+    case 6: b |= ((uint64_t)in[5]) << 40; // -fallthrough
+    case 5: b |= ((uint64_t)in[4]) << 32; // -fallthrough
+    case 4: b |= ((uint64_t)in[3]) << 24; // -fallthrough
+    case 3: b |= ((uint64_t)in[2]) << 16; // -fallthrough
+    case 2: b |= ((uint64_t)in[1]) << 8;  // -fallthrough
     case 1: b |= ((uint64_t)in[0]);
   }
 


### PR DESCRIPTION
This PR adds fallthrough comments to keep GCC >= 7.x happy.

Resolves #1581.