### PR TITLE
Tidy up big atomic operations

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -275,14 +275,6 @@ inline uint64_t __pony_clzl(uint64_t x)
  *
  */
 #ifdef PLATFORM_IS_VISUAL_STUDIO
-#  define __pony_spec_align__(IDENT, BYTES) \
-              __declspec(align(BYTES)) IDENT
-#elif defined(PLATFORM_IS_CLANG_OR_GCC)
-#  define __pony_spec_align__(IDENT, BYTES) \
-              IDENT __attribute__((aligned (BYTES)))
-#endif
-
-#ifdef PLATFORM_IS_VISUAL_STUDIO
 #  define __pony_spec_malloc__(FUNC) \
             __declspec(restrict) FUNC
 #elif defined(PLATFORM_IS_CLANG_OR_GCC)

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -1,7 +1,7 @@
 #ifndef PONY_DETAIL_ATOMICS_H
 #define PONY_DETAIL_ATOMICS_H
 
-#if !defined(ARMV2) && !defined(__arm__) && !defined(__aarch64__) && \
+#if !defined(__ARM_ARCH_2__) && !defined(__arm__) && !defined(__aarch64__) && \
  !defined(__i386__) && !defined(_M_IX86) && !defined(_X86_) && \
  !defined(__amd64__) && !defined(__x86_64__) && !defined(_M_X64) && \
  !defined(_M_AMD64)
@@ -67,60 +67,146 @@ using std::atomic_thread_fence;
 #  error "Unsupported compiler"
 #endif
 
-#if defined(PONY_ATOMIC_BUILTINS) && defined(PONY_WANT_ATOMIC_DEFS)
-#  define memory_order_relaxed __ATOMIC_RELAXED
-#  define memory_order_consume __ATOMIC_CONSUME
-#  define memory_order_acquire __ATOMIC_ACQUIRE
-#  define memory_order_release __ATOMIC_RELEASE
-#  define memory_order_acq_rel __ATOMIC_ACQ_REL
-#  define memory_order_seq_cst __ATOMIC_SEQ_CST
+#ifdef _MSC_VER
+namespace ponyint_atomics
+{
+  template <typename T>
+  struct aba_protected_t
+  {
+    static_assert(sizeof(T) <= sizeof(void*), "");
+    T object;
+    uintptr_t counter;
+  };
+}
+#  define PONY_ABA_PROTECTED_DECLARE(T)
+#  define PONY_ABA_PROTECTED(T) ponyint_atomics::aba_protected_t<T>
+#else
+#  if defined(__LP64__) || defined(_WIN64)
+#    define PONY_DOUBLEWORD __int128_t
+#  else
+#    define PONY_DOUBLEWORD int64_t
+#  endif
+#  define PONY_ABA_PROTECTED_DECLARE(T) \
+    typedef union \
+    { \
+      struct \
+      { \
+        _Static_assert(sizeof(T) <= sizeof(void*), ""); \
+        T object; \
+        uintptr_t counter; \
+      }; \
+      PONY_DOUBLEWORD raw; \
+    } aba_protected_T;
+#  define PONY_ABA_PROTECTED(T) aba_protected_T
+#endif
 
-#  define atomic_load_explicit(PTR, MO) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_load_n(PTR, MO); \
-    })
+// Big atomic objects (larger than machine word size) aren't consistently
+// implemented on the compilers we support. We add our own implementation to
+// make sure the objects are correctly defined and aligned.
+#define PONY_ATOMIC_ABA_PROTECTED(T) alignas(16) PONY_ABA_PROTECTED(T)
 
-#  define atomic_store_explicit(PTR, VAL, MO) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_store_n(PTR, VAL, MO); \
-    })
+#ifdef PONY_WANT_ATOMIC_DEFS
+#  ifdef _MSC_VER
+#    pragma intrinsic(_InterlockedCompareExchange128)
 
-#  define atomic_exchange_explicit(PTR, VAL, MO) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_exchange_n(PTR, VAL, MO); \
-    })
+namespace ponyint_atomics
+{
+  template <typename T>
+  inline PONY_ABA_PROTECTED(T) big_load(PONY_ABA_PROTECTED(T)* ptr)
+  {
+    PONY_ABA_PROTECTED(T) ret = {NULL, 0};
+    _InterlockedCompareExchange128((LONGLONG*)ptr, 0, 0, (LONGLONG*)&ret);
+    return ret;
+  }
 
-#  define atomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_compare_exchange_n(PTR, EXP, DES, true, SUCC, FAIL); \
-    })
+  template <typename T>
+  inline void big_store(PONY_ABA_PROTECTED(T)* ptr, PONY_ABA_PROTECTED(T) val)
+  {
+    PONY_ABA_PROTECTED(T) tmp;
+    tmp.object = ptr->object;
+    tmp.counter = ptr->counter;
+    while(!_InterlockedCompareExchange128((LONGLONG*)ptr,
+      (LONGLONG)val.counter, (LONGLONG)val.object, (LONGLONG*)&tmp))
+    {}
+  }
+}
 
-#  define atomic_compare_exchange_strong_explicit(PTR, EXP, DES, SUCC, FAIL) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_compare_exchange_n(PTR, EXP, DES, false, SUCC, FAIL); \
-    })
+#    define bigatomic_load_explicit(PTR, MO) \
+      ponyint_atomics::big_load(PTR)
 
-#  define atomic_fetch_add_explicit(PTR, VAL, MO) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_fetch_add(PTR, VAL, MO); \
-    })
+#    define bigatomic_store_explicit(PTR, VAL, MO) \
+      ponyint_atomics::big_store(PTR, VAL)
 
-#  define atomic_fetch_sub_explicit(PTR, VAL, MO) \
-    ({ \
-      _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
-      __atomic_fetch_sub(PTR, VAL, MO); \
-    })
+#    define bigatomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
+      _InterlockedCompareExchange128((LONGLONG*)PTR, (LONGLONG)((DES).counter), \
+        (LONGLONG)((DES).object), (LONGLONG*)EXP)
+#  else
+#    define bigatomic_load_explicit(PTR, MO) \
+      (__typeof__(*(PTR)))__atomic_load_n(&(PTR)->raw, MO)
 
-#  define atomic_thread_fence(MO) \
-    __atomic_thread_fence(MO)
+#    define bigatomic_store_explicit(PTR, VAL, MO) \
+      __atomic_store_n(&(PTR)->raw, (VAL).raw, MO)
 
-#  undef PONY_ATOMIC_BUILTINS
+#    define bigatomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
+      __atomic_compare_exchange_n(&(PTR)->raw, &(EXP)->raw, (DES).raw, true, \
+        SUCC, FAIL)
+#  endif
+
+#  ifdef PONY_ATOMIC_BUILTINS
+#    define memory_order_relaxed __ATOMIC_RELAXED
+#    define memory_order_consume __ATOMIC_CONSUME
+#    define memory_order_acquire __ATOMIC_ACQUIRE
+#    define memory_order_release __ATOMIC_RELEASE
+#    define memory_order_acq_rel __ATOMIC_ACQ_REL
+#    define memory_order_seq_cst __ATOMIC_SEQ_CST
+
+#    define atomic_load_explicit(PTR, MO) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_load_n(PTR, MO); \
+      })
+
+#    define atomic_store_explicit(PTR, VAL, MO) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_store_n(PTR, VAL, MO); \
+      })
+
+#    define atomic_exchange_explicit(PTR, VAL, MO) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_exchange_n(PTR, VAL, MO); \
+      })
+
+#    define atomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_compare_exchange_n(PTR, EXP, DES, true, SUCC, FAIL); \
+      })
+
+#    define atomic_compare_exchange_strong_explicit(PTR, EXP, DES, SUCC, FAIL) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_compare_exchange_n(PTR, EXP, DES, false, SUCC, FAIL); \
+      })
+
+#    define atomic_fetch_add_explicit(PTR, VAL, MO) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_fetch_add(PTR, VAL, MO); \
+      })
+
+#    define atomic_fetch_sub_explicit(PTR, VAL, MO) \
+      ({ \
+        _Static_assert(sizeof(PTR) <= sizeof(void*), ""); \
+        __atomic_fetch_sub(PTR, VAL, MO); \
+      })
+
+#    define atomic_thread_fence(MO) \
+      __atomic_thread_fence(MO)
+
+#    undef PONY_ATOMIC_BUILTINS
+#  endif
 #endif
 
 #endif

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -7,6 +7,9 @@
 #include <pony.h>
 #include <stdint.h>
 #include <stdbool.h>
+#ifndef __cplusplus
+#  include <stdalign.h>
+#endif
 #include <platform.h>
 
 PONY_EXTERN_C_BEGIN
@@ -26,7 +29,7 @@ typedef struct pony_actor_t
   uint8_t flags;
 
   // keep things accessed by other actors on a separate cache line
-  __pony_spec_align__(heap_t heap, 64); // 52/104 bytes
+  alignas(64) heap_t heap; // 52/104 bytes
   gc_t gc; // 44/80 bytes
 } pony_actor_t;
 

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -4,6 +4,10 @@
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
 
+#ifdef USE_VALGRIND
+#include <valgrind/helgrind.h>
+#endif
+
 typedef struct mpmcq_node_t mpmcq_node_t;
 
 struct mpmcq_node_t
@@ -12,89 +16,151 @@ struct mpmcq_node_t
   PONY_ATOMIC(void*) data;
 };
 
-void ponyint_mpmcq_init(mpmcq_t* q)
+static mpmcq_node_t* node_alloc(void* data)
 {
   mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, NULL, memory_order_relaxed);
   atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  atomic_store_explicit(&node->data, data, memory_order_relaxed);
 
-  mpmcq_dwcas_t tail;
-  tail.node = node;
+  return node;
+}
+
+static void node_free(mpmcq_node_t* node)
+{
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(node);
+  ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(&node->data);
+#endif
+  POOL_FREE(mpmcq_node_t, node);
+}
+
+void ponyint_mpmcq_init(mpmcq_t* q)
+{
+  mpmcq_node_t* node = node_alloc(NULL);
 
   atomic_store_explicit(&q->head, node, memory_order_relaxed);
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+#ifdef PLATFORM_IS_X86
+  PONY_ABA_PROTECTED(mpmcq_node_t*) tail;
+  tail.object = node;
+  tail.counter = 0;
+  bigatomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+#else
+  atomic_store_explicit(&q->tail, node, memory_order_relaxed);
+#endif
 }
 
 void ponyint_mpmcq_destroy(mpmcq_t* q)
 {
-  mpmcq_dwcas_t tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
-
-  POOL_FREE(mpmcq_node_t, tail.node);
-  tail.node = NULL;
-  q->head = NULL;
-  atomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+  atomic_store_explicit(&q->head, NULL, memory_order_relaxed);
+#ifdef PLATFORM_IS_X86
+  PONY_ABA_PROTECTED(mpmcq_node_t*) tail = bigatomic_load_explicit(&q->tail,
+    memory_order_relaxed);
+  node_free(tail.object);
+  tail.object = NULL;
+  bigatomic_store_explicit(&q->tail, tail, memory_order_relaxed);
+#else
+  mpmcq_node_t* tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
+  node_free(tail);
+  atomic_store_explicit(&q->tail, NULL, memory_order_relaxed);
+#endif
 }
 
 void ponyint_mpmcq_push(mpmcq_t* q, void* data)
 {
-  mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, data, memory_order_relaxed);
-  atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  mpmcq_node_t* node = node_alloc(data);
 
   mpmcq_node_t* prev = atomic_exchange_explicit(&q->head, node,
     memory_order_relaxed);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+#endif
   atomic_store_explicit(&prev->next, node, memory_order_release);
 }
 
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data)
 {
-  mpmcq_node_t* node = POOL_ALLOC(mpmcq_node_t);
-  atomic_store_explicit(&node->data, data, memory_order_relaxed);
-  atomic_store_explicit(&node->next, NULL, memory_order_relaxed);
+  mpmcq_node_t* node = node_alloc(data);
 
   // If we have a single producer, the swap of the head need not be atomic RMW.
   mpmcq_node_t* prev = atomic_load_explicit(&q->head, memory_order_relaxed);
   atomic_store_explicit(&q->head, node, memory_order_relaxed);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+#endif
   atomic_store_explicit(&prev->next, node, memory_order_release);
 }
 
 void* ponyint_mpmcq_pop(mpmcq_t* q)
 {
-  mpmcq_dwcas_t cmp, xchg;
+#ifdef PLATFORM_IS_X86
+  PONY_ABA_PROTECTED(mpmcq_node_t*) cmp = bigatomic_load_explicit(&q->tail,
+    memory_order_relaxed);
+  PONY_ABA_PROTECTED(mpmcq_node_t*) xchg;
+  mpmcq_node_t* tail;
+#else
+  mpmcq_node_t* tail = atomic_load_explicit(&q->tail, memory_order_relaxed);
+#endif
   mpmcq_node_t* next;
-
-  cmp = atomic_load_explicit(&q->tail, memory_order_acquire);
 
   do
   {
+#ifdef PLATFORM_IS_X86
+    tail = cmp.object;
+#endif
     // Get the next node rather than the tail. The tail is either a stub or has
     // already been consumed.
-    next = atomic_load_explicit(&cmp.node->next, memory_order_acquire);
+    next = atomic_load_explicit(&tail->next, memory_order_relaxed);
 
-    // Bailout if we have no next node.
     if(next == NULL)
       return NULL;
 
-    // Make the next node the tail, incrementing the aba counter. If this
-    // fails, cmp becomes the new tail and we retry the loop.
-    xchg.aba = cmp.aba + 1;
-    xchg.node = next;
-  } while(!atomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
-    memory_order_acq_rel, memory_order_acquire));
+#ifdef PLATFORM_IS_X86
+    xchg.object = next;
+    xchg.counter = cmp.counter + 1;
+  } while(!bigatomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
+    memory_order_relaxed, memory_order_relaxed));
+#else
+  } while(!atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
+    memory_order_relaxed, memory_order_relaxed));
+#endif
 
-  // We'll return the data pointer from the next node.
-  void* data = atomic_load_explicit(&next->data, memory_order_acquire);
+  // Synchronise on tail->next to ensure we see the write to next->data from
+  // the push. Also synchronise on next->data (see comment below).
+  // This is a standalone fence instead of a synchronised compare_exchange
+  // operation because the latter would result in unnecessary synchronisation
+  // on each loop iteration.
+#ifdef USE_VALGRID
+  atomic_thread_fence(memory_order_acquire);
+  ANNOTATE_HAPPENS_AFTER(&tail->next);
+  ANNOTATE_HAPPENS_BEFORE(&next->data);
+  atomic_thread_fence(memory_order_release);
+#else
+  atomic_thread_fence(memory_order_acq_rel);
+#endif
+
+  void* data = atomic_load_explicit(&next->data, memory_order_relaxed);
 
   // Since we will be freeing the old tail, we need to be sure no other
   // consumer is still reading the old tail. To do this, we set the data
   // pointer of our new tail to NULL, and we wait until the data pointer of
   // the old tail is NULL.
-  atomic_store_explicit(&next->data, NULL, memory_order_release);
+  // We synchronised on next->data to make sure all memory writes we've done
+  // will be visible from the thread that will free our tail when it starts
+  // freeing it.
+  atomic_store_explicit(&next->data, NULL, memory_order_relaxed);
 
-  while(atomic_load_explicit(&cmp.node->data, memory_order_acquire) != NULL)
+  while(atomic_load_explicit(&tail->data, memory_order_relaxed) != NULL)
     ponyint_cpu_relax();
 
-  // Free the old tail. The new tail is the next node.
-  POOL_FREE(mpmcq_node_t, cmp.node);
+  // Synchronise on tail->data to make sure we see every previous write to the
+  // old tail before freeing it. This is a standalone fence to avoid
+  // unnecessary synchronisation on each loop iteration.
+  atomic_thread_fence(memory_order_acquire);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&tail->data);
+#endif
+
+  node_free(tail);
+
   return data;
 }

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -1,6 +1,9 @@
 #ifndef sched_scheduler_h
 #define sched_scheduler_h
 
+#ifndef __cplusplus
+#  include <stdalign.h>
+#endif
 #include <pony.h>
 #include <platform.h>
 #include "actor/messageq.h"
@@ -42,7 +45,7 @@ struct scheduler_t
   bool asio_stopped;
 
   // These are changed primarily by the owning scheduler thread.
-  __pony_spec_align__(struct scheduler_t* last_victim, 64);
+  alignas(64) struct scheduler_t* last_victim;
 
   pony_ctx_t ctx;
   uint32_t block_count;


### PR DESCRIPTION
This change adds a cross-platform implementation for big atomics (2 machine words in size) used for ABA protection in the MPMC queue. The ABA structure is now declared and used via macros. This change also
restores support for GCC 4.7 and 4.8 and Clang 3.3 through 3.5, which was temporarily dropped in 81e727a.