### PR TITLE
Always call finalisers for embedded fields

### DIFF
--- a/minimal-cases/finalisers/finalisers.pony
+++ b/minimal-cases/finalisers/finalisers.pony
@@ -5,7 +5,13 @@ primitive PrimitiveInitFinal
   fun _final() =>
     @printf[I32]("primitive final\n".cstring())
 
+class EmbedFinal
+  fun _final() =>
+    @printf[I32]("embed final\n".cstring())
+
 class ClassFinal
+  embed f: EmbedFinal = EmbedFinal
+
   fun _final() =>
     @printf[I32]("class final\n".cstring())
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -962,6 +962,14 @@ static void reachable_method(reach_t* r, ast_t* type, const char* name,
 
   if((n->id == TK_FUN) && ((n->cap == TK_BOX) || (n->cap == TK_TAG)))
   {
+    if(name == stringtab("_final"))
+    {
+      // If the method is a finaliser, don't mark the ref and val versions as
+      // reachable.
+      assert(n->cap == TK_BOX);
+      return;
+    }
+
     // TODO: if it doesn't use this-> in a constructor, we could reuse the
     // function, which means always reuse in a fun tag
     bool subordinate = (n->cap == TK_TAG);


### PR DESCRIPTION
Previously, finalisers of embedded fields would never be called due to embedded fields being transparent to the runtime. This change adds calls to the adequate finalisers in parent objects' finalisers when said parents contain embedded fields.

Closes #1551.