### PR TITLE
Expose `st_dev` and `st_ino` fields of stat structure

### DIFF
--- a/packages/files/file_info.pony
+++ b/packages/files/file_info.pony
@@ -16,7 +16,7 @@ class val FileInfo
 
   let mode: FileMode val = recover FileMode end
   let hard_links: U32 = 0
-  let device: U32 = 0
+  let device: U64 = 0
   let inode: U64 = 0
   let uid: U32 = 0
   let gid: U32 = 0

--- a/packages/files/file_info.pony
+++ b/packages/files/file_info.pony
@@ -3,6 +3,8 @@ class val FileInfo
   This contains file system metadata for a path. The times are in the same
   format as Time.now(), i.e. seconds and nanoseconds since the epoch.
 
+  The INODE is UNIX specific.  It will be zero on Windows.
+
   The UID and GID are UNIX-style user and group IDs. These will be zero on
   Windows. The change_time will actually be the file creation time on Windows.
 
@@ -14,6 +16,8 @@ class val FileInfo
 
   let mode: FileMode val = recover FileMode end
   let hard_links: U32 = 0
+  let device: U32 = 0
+  let inode: U64 = 0
   let uid: U32 = 0
   let gid: U32 = 0
   let size: USize = 0

--- a/src/libponyrt/lang/stat.c
+++ b/src/libponyrt/lang/stat.c
@@ -30,6 +30,8 @@ typedef struct pony_stat_t
   pony_mode_t* mode;
 
   uint32_t hard_links;
+  uint32_t device;
+  uint64_t inode;
   uint32_t uid;
   uint32_t gid;
   size_t size;
@@ -69,6 +71,8 @@ static void windows_stat(const char* path, pony_stat_t* p, struct __stat64* st,
   p->broken = false;
 
   p->hard_links = (uint32_t)st->st_nlink;
+  p->device = (uint32_t)st->st_dev;
+  p->inode = (uint64_t)st->st_ino;
   p->uid = st->st_uid;
   p->gid = st->st_gid;
   p->size = st->st_size;
@@ -113,6 +117,8 @@ static void unix_stat(pony_stat_t* p, struct stat* st)
 {
   // Report information other than size based on the symlink if there is one.
   p->hard_links = (uint32_t)st->st_nlink;
+  p->device = (uint32_t)st->st_dev;
+  p->inode = (uint64_t)st->st_ino;
   p->uid = st->st_uid;
   p->gid = st->st_gid;
 

--- a/src/libponyrt/lang/stat.c
+++ b/src/libponyrt/lang/stat.c
@@ -30,7 +30,7 @@ typedef struct pony_stat_t
   pony_mode_t* mode;
 
   uint32_t hard_links;
-  uint32_t device;
+  uint64_t device;
   uint64_t inode;
   uint32_t uid;
   uint32_t gid;
@@ -71,7 +71,7 @@ static void windows_stat(const char* path, pony_stat_t* p, struct __stat64* st,
   p->broken = false;
 
   p->hard_links = (uint32_t)st->st_nlink;
-  p->device = (uint32_t)st->st_dev;
+  p->device = (uint64_t)st->st_dev;
   p->inode = (uint64_t)st->st_ino;
   p->uid = st->st_uid;
   p->gid = st->st_gid;
@@ -117,7 +117,7 @@ static void unix_stat(pony_stat_t* p, struct stat* st)
 {
   // Report information other than size based on the symlink if there is one.
   p->hard_links = (uint32_t)st->st_nlink;
-  p->device = (uint32_t)st->st_dev;
+  p->device = (uint64_t)st->st_dev;
   p->inode = (uint64_t)st->st_ino;
   p->uid = st->st_uid;
   p->gid = st->st_gid;


### PR DESCRIPTION
Makes possible to access `device` and `inode` value from pony's FileInfo type
