### PR TITLE
Add subtypes to unions/isects in the reach pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Compiler assertion failure during type checking
 - Runtime memory allocator bug
 - Compiler crash on tuple sending generation (issue #1546)
+- Compiler crash due to incorrect subtype assignment (issue #1474)
 
 ### Added
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -370,8 +370,12 @@ static void add_types_to_trait(reach_t* r, reach_type_t* t,
   size_t i = HASHMAP_BEGIN;
   reach_type_t* t2;
 
-  ast_t* def = (ast_t*)ast_data(t->ast);
-  bool interface = ast_id(def) == TK_INTERFACE;
+  bool interface = false;
+  if(ast_id(t->ast) == TK_NOMINAL)
+  {
+    ast_t* def = (ast_t*)ast_data(t->ast);
+    interface = ast_id(def) == TK_INTERFACE;
+  }
 
   while((t2 = reach_types_next(&r->types, &i)) != NULL)
   {
@@ -397,7 +401,8 @@ static void add_types_to_trait(reach_t* r, reach_type_t* t,
         {
           reach_type_cache_put(&t->subtypes, t2);
           reach_type_cache_put(&t2->subtypes, t);
-          add_methods_to_type(r, t, t2, opt);
+          if(ast_id(t->ast) == TK_NOMINAL)
+            add_methods_to_type(r, t, t2, opt);
         }
         break;
 
@@ -414,24 +419,38 @@ static void add_traits_to_type(reach_t* r, reach_type_t* t,
 
   while((t2 = reach_types_next(&r->types, &i)) != NULL)
   {
-    if(ast_id(t2->ast) != TK_NOMINAL)
-      continue;
-
-    ast_t* def = (ast_t*)ast_data(t2->ast);
-
-    switch(ast_id(def))
+    if(ast_id(t2->ast) == TK_NOMINAL)
     {
-      case TK_INTERFACE:
-      case TK_TRAIT:
-        if(is_subtype(t->ast, t2->ast, NULL, opt))
-        {
-          reach_type_cache_put(&t->subtypes, t2);
-          reach_type_cache_put(&t2->subtypes, t);
-          add_methods_to_type(r, t2, t, opt);
-        }
-        break;
+      ast_t* def = (ast_t*)ast_data(t2->ast);
 
-      default: {}
+      switch(ast_id(def))
+      {
+        case TK_INTERFACE:
+        case TK_TRAIT:
+          if(is_subtype(t->ast, t2->ast, NULL, opt))
+          {
+            reach_type_cache_put(&t->subtypes, t2);
+            reach_type_cache_put(&t2->subtypes, t);
+            add_methods_to_type(r, t2, t, opt);
+          }
+          break;
+
+        default: {}
+      }
+    } else {
+      switch(ast_id(t2->ast))
+      {
+        case TK_UNIONTYPE:
+        case TK_ISECTTYPE:
+          if(is_subtype(t->ast, t2->ast, NULL, opt))
+          {
+            reach_type_cache_put(&t->subtypes, t2);
+            reach_type_cache_put(&t2->subtypes, t);
+          }
+          break;
+
+        default: {}
+      }
     }
   }
 }
@@ -555,6 +574,8 @@ static reach_type_t* add_isect_or_union(reach_t* r, ast_t* type,
   t = add_reach_type(r, type);
   t->underlying = ast_id(t->ast);
   t->type_id = r->next_type_id++;
+
+  add_types_to_trait(r, t, opt);
 
   ast_t* child = ast_child(type);
 

--- a/test/libponyc/reach.cc
+++ b/test/libponyc/reach.cc
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <reach/reach.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "reach"))
+
+
+class ReachTest : public PassTest
+{};
+
+
+TEST_F(ReachTest, IsectHasSubtypes)
+{
+  const char* src =
+    "trait TA\n"
+    "  fun a() => None\n"
+
+    "trait TB\n"
+    "  fun b() => None\n"
+
+    "actor Main is (TA & TB)\n"
+    "  new create(env: Env) =>\n"
+    "    let ab: (TA & TB) = this\n"
+    "    ab.a()\n"
+    "    ab.b()";
+
+  TEST_COMPILE(src);
+
+  ast_t* ab_ast = type_of("ab");
+  ASSERT_NE(ab_ast, (void*)NULL);
+
+  reach_t* reach = compile->reach;
+  reach_type_t* ab_reach = reach_type(reach, ab_ast);
+  ASSERT_NE(ab_reach, (void*)NULL);
+
+  size_t i = HASHMAP_BEGIN;
+  reach_type_t* subtype;
+
+  bool found = false;
+  while((subtype = reach_type_cache_next(&ab_reach->subtypes, &i)) != NULL)
+  {
+    if(subtype->name == stringtab("Main"))
+    {
+      found = true;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(found);
+}


### PR DESCRIPTION
This change ensures that unions and intersections pick up their subtypes during the reachability analysis.

Closes #1474.