### PR TITLE
Fix message sending of boxed types through interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Runtime memory allocator bug
 - Compiler crash on tuple sending generation (issue #1546)
 - Compiler crash due to incorrect subtype assignment (issue #1474)
+- Incorrect code generation when sending certain types of messages (issue #1594)
 
 ### Added
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -601,6 +601,7 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
   t = add_reach_type(r, type);
   t->underlying = TK_TUPLETYPE;
   t->type_id = r->next_type_id++;
+  t->can_be_boxed = true;
 
   t->field_count = (uint32_t)ast_childcount(t->ast);
   t->fields = (reach_field_t*)calloc(t->field_count,
@@ -679,6 +680,9 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
 
   if(t->type_id == (uint32_t)-1)
     t->type_id = r->next_type_id++;
+
+  if(is_machine_word(type))
+    t->can_be_boxed = true;
 
   if(ast_id(def) != TK_PRIMITIVE)
     return t;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -90,6 +90,7 @@ struct reach_type_t
   uint32_t type_id;
   size_t abi_size;
   uint32_t vtable_size;
+  bool can_be_boxed;
 
   LLVMTypeRef structure;
   LLVMTypeRef structure_ptr;


### PR DESCRIPTION
Previously, a message send was inlined in the caller when every possible instantiation of the method was a behaviour. This logic turned out to be incorrect when sending a message through an interface, with the interface expecting an unboxed value as a parameter and one of the subtypes expecting a boxed value. This change suppresses the inlining of message sends when such a case arises.