### PR TITLE
Change File class to use low level and vectored i/o functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
   -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
   -DBUILD_COMPILER=\"$(compiler_version)\" \
-  -DPONY_BUILD_CONFIG=\"$(config)\"
+  -DPONY_BUILD_CONFIG=\"$(config)\" \
+  -D_FILE_OFFSET_BITS=64
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -63,11 +63,11 @@ class Array[A] is Seq[A]
     """
     _ptr._offset(from_offset)._copy_to(ptr._offset(to_offset), copy_len)
 
-  fun cpointer(): Pointer[A] tag =>
+  fun cpointer(offset: USize = 0): Pointer[A] tag =>
     """
     Return the underlying C-style pointer.
     """
-    _ptr
+    _ptr._offset(offset)
 
   fun size(): USize =>
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -198,11 +198,11 @@ actor Main
     """
     _ptr._offset(from_offset)._copy_to(ptr._offset(to_offset), copy_len)
 
-  fun cpointer(): Pointer[U8] tag =>
+  fun cpointer(offset: USize = 0): Pointer[U8] tag =>
     """
     Returns a C compatible pointer to the underlying string allocation.
     """
-    _ptr
+    _ptr._offset(offset)
 
   fun cstring(): Pointer[U8] tag =>
     """

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -1,4 +1,23 @@
-primitive _FileHandle
+use @_read[I32](fd: I32, buffer: Pointer[None], bytes_to_read: I32) if windows
+use @read[ISize](fd: I32, buffer: Pointer[None], bytes_to_read: USize) if not windows
+use @_write[I32](fd: I32, buffer: Pointer[None], bytes_to_send: I32) if windows
+use @writev[ISize](fd: I32, buffer: Pointer[None], num_to_send: I32) if not windows
+use @_lseeki64[I64](fd: I32, offset: I64, base: I32) if windows
+use @lseek64[I64](fd: I32, offset: I64, base: I32) if linux
+use @lseek[I64](fd: I32, offset: I64, base: I32) if not windows and not linux
+use @FlushFileBuffers[Bool](file_handle: Pointer[None]) if windows
+use @_get_osfhandle[Pointer[None]](fd: I32) if windows
+use @fsync[I32](fd: I32) if not windows
+use @fdatasync[I32](fd: I32) if not windows
+use @_chsize_s[I32](fd: I32, len: I64) if windows
+use @ftruncate64[I32](fd: I32, len: I64) if linux
+use @ftruncate[I32](fd: I32, len: I64) if not windows and not linux
+use @_close[I32](fd: I32) if windows
+use @close[I32](fd: I32) if not windows
+use @pony_os_writev_max[I32]()
+use @pony_os_errno[I32]()
+
+use "collections"
 
 primitive FileOK
 primitive FileError
@@ -15,7 +34,7 @@ primitive _EEXIST
 
 primitive _EACCES
   fun apply(): I32 => 13
-    
+
 type FileErrNo is
   ( FileOK
   | FileError
@@ -60,10 +79,14 @@ class File
   """
   let path: FilePath
   let writeable: Bool
+  let _newline: String = "\n"
+  var _unsynced_data: Bool = false
+  var _unsynced_metadata: Bool = false
   var _fd: I32
-  var _handle: Pointer[_FileHandle]
   var _last_line_length: USize = 256
   var _errno: FileErrNo = FileOK
+  embed _pending_writev: Array[USize] = _pending_writev.create()
+  var _pending_writev_total: USize = 0
 
   new create(from: FilePath) =>
     """
@@ -74,36 +97,33 @@ class File
     path = from
     writeable = true
     _fd = -1
-    _handle = Pointer[_FileHandle]
 
     if not from.caps(FileRead) or not from.caps(FileWrite) then
       _errno = FileError
     else
-      var mode = "x"
-      if not from.exists() then
-        if not from.caps(FileCreate) then
+      var flags: I32 = @ponyint_o_rdwr()
+      let mode = FileMode._os() // default file permissions
+      if not path.exists() then
+        if not path.caps(FileCreate) then
           _errno = FileError
         else
-          mode = "w+b"
+          flags = flags or @ponyint_o_creat() or @ponyint_o_trunc()
         end
-      else
-        mode = "r+b"
       end
 
-      if mode != "x" then
-        _handle = @fopen[Pointer[_FileHandle]](
-          path.path.cstring(), mode.cstring())
+      _fd = ifdef windows then
+        @_open[I32](path.path.cstring(), flags, mode.i32())
+      else
+        @open[I32](path.path.cstring(), flags, mode)
+      end
 
-        if _handle.is_null() then
-          _errno = _get_error()
+      if _fd == -1 then
+        _errno = _get_error()
+      else
+        try
+          _FileDes.set_rights(_fd, path, writeable)
         else
-          _fd = _get_fd(_handle)
-
-          try
-            _FileDes.set_rights(_fd, path, writeable)
-          else
-            _errno = FileError
-          end
+          _errno = FileError
         end
       end
     end
@@ -116,12 +136,11 @@ class File
     path = from
     writeable = false
     _fd = -1
-    _handle = Pointer[_FileHandle]
 
     if
-      not from.caps(FileRead) or
+      not path.caps(FileRead) or
       try
-        let info' = FileInfo(from)
+        let info' = FileInfo(path)
         info'.directory or info'.pipe
       else
         true
@@ -129,14 +148,15 @@ class File
     then
       _errno = FileError
     else
-      _handle = @fopen[Pointer[_FileHandle]](
-        from.path.cstring(), "rb".cstring())
+      _fd = ifdef windows then
+        @_open[I32](path.path.cstring(), @ponyint_o_rdwr())
+      else
+        @open[I32](path.path.cstring(), @ponyint_o_rdwr())
+      end
 
-      if _handle.is_null() then
+      if _fd == -1 then
         _errno = FileError
       else
-        _fd = _get_fd(_handle)
-
         try
           _FileDes.set_rights(_fd, path, writeable)
         else
@@ -157,17 +177,6 @@ class File
     writeable = from.caps(FileRead)
     _fd = fd
 
-    if writeable then
-      _handle = @fdopen[Pointer[_FileHandle]](fd, "r+b".cstring())
-    else
-      _handle = @fdopen[Pointer[_FileHandle]](fd, "rb".cstring())
-    end
-
-    if _handle.is_null() then
-      _errno = _get_error()
-      error
-    end
-
     _FileDes.set_rights(_fd, path, writeable)
 
   fun errno(): FileErrNo =>
@@ -181,29 +190,13 @@ class File
     Clears the last error code set for this File.
     Clears the error indicator for the stream.
     """
-    if not _handle.is_null() then
-      @clearerr[None](_handle)
-    end
     _errno = FileOK
-
-  fun get_stream_error(): FileErrNo =>
-    """
-    Checks for errors after File stream operations.
-    Retrieves errno if ferror is true.
-    """
-    if @feof[I32](_handle) != 0 then
-      return FileEOF
-    end
-    if @ferror[I32](_handle) != 0 then
-      return _get_error()
-    end
-    FileOK
 
   fun _get_error(): FileErrNo =>
     """
     Fetch errno from the OS.
     """
-    let os_errno = @pony_os_errno[I32]()
+    let os_errno = @pony_os_errno()
     match os_errno
     | _EBADF() => return FileBadFileNumber
     | _EEXIST() => return FileExists
@@ -212,33 +205,24 @@ class File
       return FileError
     end
 
-    
+
   fun valid(): Bool =>
     """
     Returns true if the file is currently open.
     """
-    not _handle.is_null()
-
-  fun get_fd(): I32 ? =>
-    """
-    Returns the underlying file descriptor.
-    Raises an error if the file is not currently open.
-    """
-    if _handle.is_null() then
-      error
-    end
-
-    _fd
+    not _fd == -1
 
   fun ref line(): String iso^ ? =>
     """
     Returns a line as a String. The newline is not included in the string. If
-    there is no more data, this raises an error.
+    there is no more data, this raises an error. If there is a file error,
+    this raises an error.
     """
-    if _handle.is_null() then
+    if _fd == -1 then
       error
     end
 
+    let bytes_to_read: USize = 1
     var offset: USize = 0
     var len = _last_line_length
     var result = recover String end
@@ -247,29 +231,36 @@ class File
     while not done do
       result.reserve(len)
 
-      let r = ifdef linux then
-        @fgets_unlocked[Pointer[U8]](result.cstring().usize() + offset,
-          result.space() - offset, _handle)
+      let r = (ifdef windows then
+        @_read(_fd, result.cpointer(offset), bytes_to_read.i32())
       else
-        @fgets[Pointer[U8]](result.cstring().usize() + offset,
-          result.space() - offset, _handle)
+        @read(_fd, result.cpointer(offset), bytes_to_read)
+      end).isize()
+
+      if r < bytes_to_read.isize() then
+        _errno = if r == 0 then
+                   FileEOF
+                 else
+                   _get_error() // error
+                   error
+                 end
+      else
+        // truncate at offset in order to adjust size of string after ffi call
+        // and to avoid scanning full array via recalc
+        result.truncate(offset + 1)
       end
 
-      result.recalc()
-
-      if r.is_null() then
-        _errno = get_stream_error() // either EOF or error
-      end
-      
       done = try
-        r.is_null() or (result.at_offset(-1) == '\n')
+        (_errno is FileEOF) or (result.at_offset(offset.isize()) == '\n')
       else
         true
       end
 
-      if not done then
-        offset = result.size()
-        len = len * 2
+      if (not done) then
+        offset = offset + 1
+        if offset == len then
+          len = len * 2
+        end
       end
     end
 
@@ -278,8 +269,10 @@ class File
     end
 
     try
-      if result.at_offset(-1) == '\n' then
-        result.truncate(result.size() - 1)
+      if result.at_offset(offset.isize()) == '\n' then
+        // can't rely on result.size because recalc might find an errant
+        // null terminator in the uninitialized memory.
+        result.truncate(offset)
 
         if result.at_offset(-1) == '\r' then
           result.truncate(result.size() - 1)
@@ -294,20 +287,25 @@ class File
     """
     Returns up to len bytes.
     """
-    if not _handle.is_null() then
+    if _fd != -1 then
       let result = recover Array[U8].>undefined(len) end
 
-      let r = ifdef linux then
-        @fread_unlocked[USize](result.cpointer(), USize(1), len, _handle)
+      let r = (ifdef windows then
+        @_read(_fd, result.cpointer(), len.i32())
       else
-        @fread[USize](result.cpointer(), USize(1), len, _handle)
+        @read(_fd, result.cpointer(), len)
+      end).isize()
+
+      if r < len.isize() then
+        _errno = if r == 0 then
+                   FileEOF
+                 else
+                   _get_error() // error
+                 end
       end
 
-      if r < len then
-        _errno = get_stream_error() // EOF or error
-      end
-      
-      (consume result).>truncate(r)
+      result.truncate(r.usize())
+      result
     else
       recover Array[U8] end
     end
@@ -317,21 +315,24 @@ class File
     Returns up to len bytes. The resulting string may have internal null
     characters.
     """
-    if not _handle.is_null() then
+    if _fd != -1 then
       let result = recover String(len) end
 
-      let r = ifdef linux then
-        @fread_unlocked[USize](result.cstring(), USize(1), result.space(),
-          _handle)
+      let r = (ifdef windows then
+        @_read(_fd, result.cpointer(), result.space().i32())
       else
-        @fread[USize](result.cstring(), USize(1), result.space(), _handle)
+        @read(_fd, result.cpointer(), result.space())
+      end).isize()
+
+      if r < len.isize() then
+        _errno = if r == 0 then
+                   FileEOF
+                 else
+                   _get_error() // error
+                 end
       end
 
-      if r < len then
-        _errno = get_stream_error() // EOF or error
-      end
-      
-      result.truncate(r)
+      result.truncate(r.usize())
       result
     else
       recover String end
@@ -341,66 +342,181 @@ class File
     """
     Same as write, buts adds a newline.
     """
-    write(data) and write("\n")
+    queue(data)
+    queue(_newline)
+
+    _pending_writes()
 
   fun ref printv(data: ByteSeqIter box): Bool =>
     """
     Print an iterable collection of ByteSeqs.
     """
     for bytes in data.values() do
-      if not print(bytes) then
-        return false
-      end
+      queue(bytes)
+      queue(_newline)
     end
-    true
+
+    _pending_writes()
 
   fun ref write(data: ByteSeq box): Bool =>
     """
     Returns false if the file wasn't opened with write permission.
     Returns false and closes the file if not all the bytes were written.
     """
-    if writeable and (not _handle.is_null()) then
-      let len = ifdef linux then
-        @fwrite_unlocked[USize](data.cpointer(), USize(1), data.size(), _handle)
-      else
-        @fwrite[USize](data.cpointer(), USize(1), data.size(), _handle)
-      end
+    queue(data)
 
-      if len == data.size() then
-        return true
-      end
-      // check error
-      _errno = get_stream_error()
-      // fwrite can't resume in case of error
-      dispose()
-    end
-    false
+    _pending_writes()
 
   fun ref writev(data: ByteSeqIter box): Bool =>
     """
     Write an iterable collection of ByteSeqs.
     """
     for bytes in data.values() do
-      if not write(bytes) then
-        return false
+      queue(bytes)
+    end
+
+    _pending_writes()
+
+  fun ref queue(data: ByteSeq box) =>
+    """
+    Queue data to be written
+    NOTE: Queue'd data will always be written before normal print/write
+    requested data
+    """
+    _pending_writev.>push(data.cpointer().usize()).>push(data.size())
+    _pending_writev_total = _pending_writev_total + data.size()
+
+  fun ref queuev(data: ByteSeqIter box) =>
+    """
+    Queue an iterable collection of ByteSeqs to be written
+    NOTE: Queue'd data will always be written before normal print/write
+    requested data
+    """
+    for bytes in data.values() do
+      queue(bytes)
+    end
+
+  fun ref flush(): Bool =>
+    """
+    Flush any queued data
+    """
+    _pending_writes()
+
+  fun ref _pending_writes(): Bool =>
+    """
+    Write pending data.
+    Returns false if the file wasn't opened with write permission.
+    Returns false and closes the file and discards all pending data
+    if not all the bytes were written.
+    Returns true if it sent all pending data.
+    """
+    try
+      (let result, let num_written, let new_pending_total) =
+        _write_to_disk()
+      _pending_writev_total = new_pending_total
+      if _pending_writev_total == 0 then
+        _pending_writev.clear()
+        _unsynced_data = true
+        _unsynced_metadata = true
+      else
+        if num_written > 0 then
+          _unsynced_data = true
+          _unsynced_metadata = true
+        end
+        for d in Range[USize](0, num_written, 1) do
+          _pending_writev.shift()
+          _pending_writev.shift()
+        end
+      end
+      return result
+    else
+      // TODO: error recovery? EINTR?
+
+      // check error
+      _errno = _get_error()
+
+      dispose()
+      return false
+    end
+
+  fun _write_to_disk(): (Bool, USize, USize) ? =>
+    """
+    Write pending data.
+    Returns false if the file wasn't opened with write permission.
+    Returns raises error if not all the bytes were written.
+    Returns true if it sent all pending data.
+    Returns num_processed and new pending_total also.
+    """
+    // TODO: Make writev_batch_size user configurable
+    let writev_batch_size = @pony_os_writev_max()
+    var num_to_send: I32 = 0
+    var num_sent: USize = 0
+    var bytes_to_send: USize = 0
+    var pending_total = _pending_writev_total
+    while writeable and (pending_total > 0)
+      and (_fd != -1) do
+      //determine number of bytes and buffers to send
+      if (_pending_writev.size().i32()/2) < writev_batch_size then
+        num_to_send = _pending_writev.size().i32()/2
+        bytes_to_send = pending_total
+      else
+        //have more buffers than a single writev can handle
+        //iterate over buffers being sent to add up total
+        num_to_send = writev_batch_size
+        bytes_to_send = 0
+        var counter: I32 = (num_sent.i32()*2) + 1
+        repeat
+          bytes_to_send = bytes_to_send + _pending_writev(counter.usize())
+          counter = counter + 2
+        until counter >= (num_to_send*2) end
+      end
+
+      // Write as much data as possible (vectored i/o).
+      // On Windows only write 1 buffer at a time.
+      var len = ifdef windows then
+        @_write(_fd, _pending_writev(num_sent*2),
+          bytes_to_send.i32()).isize()
+      else
+        @writev(_fd, _pending_writev.cpointer(num_sent*2),
+          num_to_send).isize()
+      end
+
+      if len < bytes_to_send.isize() then
+        error
+      else
+        // sent all data we requested in this batch
+        pending_total = pending_total - bytes_to_send
+        num_sent = num_sent + num_to_send.usize()
+
+        if pending_total == 0 then
+          return (true, num_sent, pending_total)
+        end
       end
     end
-    true
+
+    (false, num_sent, pending_total)
 
   fun ref position(): USize =>
     """
     Return the current cursor position in the file.
     """
-    if not _handle.is_null() then
+    if _fd != -1 then
+      let o: I64 = 0
+      let b: I32 = 1
       let r = ifdef windows then
-        @_ftelli64[U64](_handle).usize()
+        @_lseeki64(_fd, o, b)
       else
-        @ftell[USize](_handle)
+        ifdef linux then
+          @lseek64(_fd, o, b)
+        else
+          @lseek(_fd, o, b)
+        end
       end
+
       if r < 0 then
         _errno = _get_error()
       end
-      r
+      r.usize()
     else
       0
     end
@@ -412,7 +528,7 @@ class File
     let pos = position()
     _seek(0, 2)
     let len = position()
-    _seek(pos.isize(), 0)
+    _seek(pos.i64(), 0)
     len
 
   fun ref seek_start(offset: USize) =>
@@ -420,7 +536,7 @@ class File
     Set the cursor position relative to the start of the file.
     """
     if path.caps(FileSeek) then
-      _seek(offset.isize(), 0)
+      _seek(offset.i64(), 0)
     end
 
   fun ref seek_end(offset: USize) =>
@@ -428,7 +544,7 @@ class File
     Set the cursor position relative to the end of the file.
     """
     if path.caps(FileSeek) then
-      _seek(-offset.isize(), 2)
+      _seek(-offset.i64(), 2)
     end
 
   fun ref seek(offset: ISize) =>
@@ -436,57 +552,68 @@ class File
     Move the cursor position.
     """
     if path.caps(FileSeek) then
-      _seek(offset, 1)
-    end
-
-  fun ref flush() =>
-    """
-    Flush the file.
-    """
-    if not _handle.is_null() then
-      let r = ifdef linux then
-        @fflush_unlocked[I32](_handle)
-      else
-        @fflush[I32](_handle)
-      end
-      if r != 0 then
-        _errno = _get_error()
-      end
+      _seek(offset.i64(), 1)
     end
 
   fun ref sync() =>
     """
     Sync the file contents to physical storage.
     """
-    if path.caps(FileSync) and not _handle.is_null() then
+    if path.caps(FileSync) and (_fd != -1) then
       ifdef windows then
-        let h = @_get_osfhandle[U64](_fd)
-        @FlushFileBuffers[I32](h)
+        let r = @FlushFileBuffers(@_get_osfhandle(_fd))
+        if r == true then
+          _errno = FileError
+        end
       else
-        let r = @fsync[I32](_fd)
+        let r = @fsync(_fd)
         if r < 0 then
           _errno = _get_error()
         end
       end
     end
+    _unsynced_data = false
+    _unsynced_metadata = false
+
+  fun ref datasync() =>
+    """
+    Sync the file contents to physical storage.
+    """
+    if path.caps(FileSync) and (_fd != -1) then
+      ifdef windows then
+        let r = @FlushFileBuffers(@_get_osfhandle(_fd))
+        if r == true then
+          _errno = FileError
+        end
+      else
+        let r = @fdatasync(_fd)
+        if r < 0 then
+          _errno = _get_error()
+        end
+      end
+    end
+    _unsynced_data = false
 
   fun ref set_length(len: USize): Bool =>
     """
     Change the file size. If it is made larger, the new contents are undefined.
     """
-    if path.caps(FileTruncate) and writeable and (not _handle.is_null()) then
-      flush()
+    if path.caps(FileTruncate) and writeable and (_fd != -1) then
       let pos = position()
       let result = ifdef windows then
-        @_chsize_s[I32](_fd, len)
+        @_chsize_s(_fd, len.i64())
       else
-        @ftruncate[I32](_fd, len)
+        ifdef linux then
+          @ftruncate64(_fd, len.i64())
+        else
+          @ftruncate(_fd, len.i64())
+        end
       end
 
       if pos >= len then
         _seek(0, 2)
       end
-      
+
       if result == 0 then
         true
       else
@@ -539,47 +666,73 @@ class File
     """
     Close the file. Future operations will do nothing.
     """
-    if not _handle.is_null() then
-      @fclose[I32](_handle)
-      _handle = Pointer[_FileHandle]
+    if _fd != -1 then
+      if (_pending_writev_total > 0) and (_errno is FileOK) then
+        flush()
+      end
+      if _unsynced_data or _unsynced_metadata then
+        sync()
+      end
+      let r = ifdef windows then
+        @_close(_fd)
+      else
+        @close(_fd)
+      end
+      if r < 0 then
+        _errno = _get_error()
+      end
       _fd = -1
+
+      _pending_writev_total = 0
+      _pending_writev.clear()
     end
 
-  fun ref _seek(offset: ISize, base: I32) =>
+  fun ref _seek(offset: I64, base: I32) =>
     """
     Move the cursor position.
     """
-    if not _handle.is_null() then
-      ifdef windows then
-        @_fseeki64[I32](_handle, offset, base)
+    if _fd != -1 then
+      let r = ifdef windows then
+        @_lseeki64(_fd, offset, base)
       else
-        let r = @fseek[I32](_handle, offset, base)
-        if r < 0 then
-          _errno = _get_error()
+        ifdef linux then
+          @lseek64(_fd, offset, base)
+        else
+          @lseek(_fd, offset, base)
         end
       end
-    end
-
-  fun tag _get_fd(handle: Pointer[_FileHandle]): I32 =>
-    """
-    Get the file descriptor associated with the file handle.
-    """
-    if not handle.is_null() then
-      ifdef windows then
-        @_fileno[I32](handle)
-      else
-        @fileno[I32](handle)
+      if r < 0 then
+        _errno = _get_error()
       end
-    else
-      -1
     end
 
   fun _final() =>
     """
     Close the file.
     """
-    if not _handle.is_null() then
-      @fclose[I32](_handle)
+    if _fd != -1 then
+      if (_pending_writev_total > 0) and (_errno is FileOK) then
+        // attempt to write any buffered data
+        try
+          _write_to_disk()
+        end
+      end
+      if _unsynced_data or _unsynced_metadata then
+        // attempt to sync any un-synced data
+        if (path.caps.value() and FileSync.value()) > 0 then
+          ifdef windows then
+            @FlushFileBuffers(@_get_osfhandle(_fd))
+          else
+            @fsync(_fd)
+          end
+        end
+      end
+      // close file
+      ifdef windows then
+        @_close(_fd)
+      else
+        @close(_fd)
+      end
     end
 
 class FileLines is Iterator[String]

--- a/src/libponyrt/lang/directory.c
+++ b/src/libponyrt/lang/directory.c
@@ -6,6 +6,7 @@
 #if defined(PLATFORM_IS_WINDOWS)
 #include <direct.h>
 #include <errno.h>
+#include <fcntl.h>
 #elif defined(PLATFORM_IS_POSIX_BASED)
 #include <unistd.h>
 #include <stdio.h>
@@ -79,8 +80,6 @@ PONY_API const char* ponyint_windows_readdir(WIN32_FIND_DATA* find)
 
 #endif
 
-#if defined(PLATFORM_IS_POSIX_BASED)
-
 PONY_API int ponyint_o_rdonly()
 {
   return O_RDONLY;
@@ -100,6 +99,8 @@ PONY_API int ponyint_o_trunc()
 {
   return O_TRUNC;
 }
+
+#if defined(PLATFORM_IS_POSIX_BASED)
 
 PONY_API int ponyint_o_directory()
 {

--- a/src/libponyrt/lang/io.c
+++ b/src/libponyrt/lang/io.c
@@ -1,0 +1,21 @@
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+#include <platform.h>
+
+PONY_EXTERN_C_BEGIN
+
+#if defined(PLATFORM_IS_POSIX_BASED)
+#include <limits.h>
+#endif
+
+PONY_API int pony_os_writev_max()
+{
+#if defined(PLATFORM_IS_POSIX_BASED)
+  return IOV_MAX;
+#else
+  return 1;
+#endif
+}
+
+PONY_EXTERN_C_END

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -185,9 +185,9 @@ bool ponyint_thread_create(pony_thread_id_t* thread, thread_fn start,
       if(getrlimit(RLIMIT_STACK, &limit) == 0)
       {
         int node = _numa_node_of_cpu(cpu);
-        void* stack = _numa_alloc_onnode(limit.rlim_cur, node);
+        void* stack = _numa_alloc_onnode((size_t)limit.rlim_cur, node);
         if (stack != NULL) {
-          pthread_attr_setstack(&attr, stack, limit.rlim_cur);
+          pthread_attr_setstack(&attr, stack, (size_t)limit.rlim_cur);
         }
       }
     }


### PR DESCRIPTION
The motivation behind this is to improve performance to file i/o
operations. The C standard stdio functions do user space
buffering prior to sending the data to the OS kernel via a system
call. On most operating system, the OS kernel also does additional
buffering on top of the user level buffering by the C functions.
Unfortunately, if the C functions are buffering data, they prevent
the OS kernal from taking advantage of some potential performance
enhancements if they're available (namely Vectored I/O so the
OS can offload work to hardward and never has to combine multiple
user buffers into a single buffer for writing to disk).

The commit changes the File class to use low level i/o functions
that map to system calls on Linux and other posix based systems
and to C lib calls on Windows. On Posix based systems, the OS is
free to take advantage of performance offloading to hardware if
possible. On Windows, this change shouldn't have a negative
performance impact but doesn't give the same possible performance
benefits as on Posix based systems.

Other changes:

* Enable `_FILE_OFFSET_BITS=64` arg to compiler to ensure 32 bit
  linux builds get large file support enabled.
* Adds `datasync` to be able to call `fdatasync` instead of `fsync`
  as it can be appropriate in some situations. On Windows, `fsync`
  and `fdatasync` behave the same.
* Adds `queue` and `queuev` functions that are analogous to
  `write` and `writev` but queue/buffer data to be written
  instead of writing the data immediately. Additionally,
  these new functions provide the ability to interleave buffered
  data writing and unbuffered data writing where unbuffered data
  writing would force any buffered data to be written first.
* Changes `flush` to flush any queued/buffered data to disk
  because it is otherwise unnecessary since we're not buffering
  data in the C library via stdio any longer.
* A few additional tests have been added to validate things are
  working correctly.

Future work:
* Change `queue`/`queuev` to automatically flush data to disk once
  the # of queued items exceeds `IOV_MAX` for a single system call.
* Error handling in the File package might be possible to add now
  including having the various functions throw `error` on things
  that can't be recovered from.
* Possibly switch to async/nonblocking i/o for file writing with an
  actor as the intermediary (similar to the TCPConnection actor in
  the net package).

--------

This change was split from PR #1575 because the `foreigntypes` package addition requires additional discussion.

--------

The following is a great explanation of why `writev` is worth it (from https://bytes.com/topic/python/answers/39551-writev) in reference to python:
```
writelines applies to a general Python file object. writev applies only
to C file descriptors. Writev can't replace writelines, after all it
makes no sense to cStringIO, gzip files for these are not valid C file
descriptors. Generally, writelines works fine.

Now why would you want to use writev? Optimization on the C side.

Understand that when you do file I/O you have to either:

a) Copy all of the strings to a new memory location
b) Call write over and over again

Sometimes, when you do b), userspace libraries (fwrite) will "optimize"
by buffering and doing a) for you. But you cannot escape the fact that
so long as your write parameter takes a single string for each
invocation, the underlying libraries are forced to choose between the
two options above.

Writev is the vector version of write. Whereas write accepts a single
pointer and length parameter, writev accepts a *list* of pointers and
size parameters. It represents a strategy c) -- just hand the list to
operating system

I want to include it because POSIX has a single OS call that
conceptually maps pretty closely to writelines. writev can be faster
because you don't have to do memory copies to buffer data in one place
for it -- the OS will do that, and can sometimes delegate that chore to
the underlying network or scsi card.

If you are still scratching your head, just think of writev as a C-file
descriptor only optimization of writelines that offloads the memory copy
cost of buffering to the OS in hopes that it can pass the buck to the
hardware (and IIRC, BSD does handle this correctly ... it has zero copy
network code, think about how cool it is to think that your network card
is going to traverse your list for you with a little help from the
writev function.)
```