### PR TITLE
Removes duplicate long test calls from net/_test.pony

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -340,8 +340,6 @@ class iso _TestTCPMute is UnitTest
     _TestTCP(h)(_TestTCPMuteSendNotify(h),
       _TestTCPMuteReceiveNotify(h))
 
-    h.long_test(2_000_000_000)
-
   fun timed_out(h: TestHelper) =>
     h.complete(true)
 
@@ -418,8 +416,6 @@ class iso _TestTCPUnmute is UnitTest
     _TestTCP(h)(_TestTCPMuteSendNotify(h),
       _TestTCPUnmuteReceiveNotify(h))
 
-    h.long_test(2_000_000_000)
-
 class _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
   """
   Notifier to test that after muting and unmuting a connection, we get data
@@ -468,8 +464,6 @@ class iso _TestTCPThrottle is UnitTest
 
     _TestTCP(h)(_TestTCPThrottleSendNotify(h),
       _TestTCPThrottleReceiveNotify(h))
-
-    h.long_test(10_000_000_000)
 
 class _TestTCPThrottleReceiveNotify is TCPConnectionNotify
   """


### PR DESCRIPTION
Previously, when I added mute and throttle related tests, I
inadvertently had each set up two long tests as I didn't realize
that `_TestTCP` was setting up a long test.

This change removes the extra `long_test` calls.