### PR TITLE
spelling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,7 +525,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Reduced memory pressure.
 - Scheduler steals when only the CD is on a scheduler thread queue.
 - use commands searches ../pony_packages recursively similar to Node.js
-- Readline uses a Promise to handle async reponses.
+- Readline uses a Promise to handle async responses.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else
   tag := $(shell cat VERSION)
 endif
 
-# package_name, _version, and _iteration can be overriden by Travis or AppVeyor
+# package_name, _version, and _iteration can be overridden by Travis or AppVeyor
 package_base_version ?= $(tag)
 package_iteration ?= "1"
 package_name ?= "ponyc-unknown"

--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -200,7 +200,7 @@ class HttpNotify is HTTPHandler
 
   fun ref chunk(data: ByteSeq val) =>
     """
-    Receive additional arbitary-length response body data.
+    Receive additional arbitrary-length response body data.
     """
     _main.have_body(data)
 

--- a/examples/systemtap/README.md
+++ b/examples/systemtap/README.md
@@ -46,7 +46,7 @@ SystemTap documentation can be found
 
     You need the `dtrace` commandline tool to generate header and object files
     that are needed in the compilation and linking of PonyC compiler. This is
-    requred on Linux systems. At the time of writing this the version of
+    required on Linux systems. At the time of writing this the version of
     SystemTap that these probes have been implemented and tested with is 2.6, on
     Debian 8 Stable. Later versions should work. Earlier versions might not work
     and must be tested independently. In debian based systems, SystemTap can be

--- a/lib/gbenchmark/.ycm_extra_conf.py
+++ b/lib/gbenchmark/.ycm_extra_conf.py
@@ -7,7 +7,7 @@ import ycm_core
 flags = [
 '-Wall',
 '-Werror',
-'-pendantic-errors',
+'-pedantic-errors',
 '-std=c++0x',
 '-fno-strict-aliasing',
 '-O3',

--- a/lib/gbenchmark/src/benchmark.cc
+++ b/lib/gbenchmark/src/benchmark.cc
@@ -81,7 +81,7 @@ DEFINE_string(benchmark_out_format, "json",
               "The format to use for file output. Valid values are "
               "'console', 'json', or 'csv'.");
 
-DEFINE_string(benchmark_out, "", "The file to write additonal output to");
+DEFINE_string(benchmark_out, "", "The file to write additional output to");
 
 DEFINE_string(benchmark_color, "auto",
               "Whether to use colors in the output.  Valid values: "
@@ -474,7 +474,7 @@ void RunBenchmarks(const std::vector<Benchmark::Instance>& benchmarks,
   context.cpu_scaling_enabled = CpuScalingEnabled();
   context.name_field_width = name_field_width;
 
-  // Keep track of runing times of all instances of current benchmark
+  // Keep track of running times of all instances of current benchmark
   std::vector<BenchmarkReporter::Run> complexity_reports;
 
   // We flush streams after invoking reporter methods that write to them. This

--- a/lib/gbenchmark/src/complexity.cc
+++ b/lib/gbenchmark/src/complexity.cc
@@ -66,10 +66,10 @@ std::string GetBigOString(BigO complexity) {
 
 // Find the coefficient for the high-order term in the running time, by
 // minimizing the sum of squares of relative error, for the fitting curve
-// given by the lambda expresion.
+// given by the lambda expression.
 //   - n             : Vector containing the size of the benchmark tests.
 //   - time          : Vector containing the times for the benchmark tests.
-//   - fitting_curve : lambda expresion (e.g. [](int n) {return n; };).
+//   - fitting_curve : lambda expression (e.g. [](int n) {return n; };).
 
 // For a deeper explanation on the algorithm logic, look the README file at
 // http://github.com/ismaelJimenez/Minimal-Cpp-Least-Squared-Fit

--- a/lib/gbenchmark/src/sysinfo.cc
+++ b/lib/gbenchmark/src/sysinfo.cc
@@ -174,7 +174,7 @@ void InitializeSystemInfo() {
     if (newline != nullptr) *newline = '\0';
 
     // When parsing the "cpu MHz" and "bogomips" (fallback) entries, we only
-    // accept postive values. Some environments (virtual machines) report zero,
+    // accept positive values. Some environments (virtual machines) report zero,
     // which would cause infinite looping in WallTime_Init.
     if (!saw_mhz && startsWithKey(line, "cpu MHz")) {
       const char* freqstr = strchr(line, ':');

--- a/lib/gtest/gtest/gtest.h
+++ b/lib/gtest/gtest/gtest.h
@@ -1255,7 +1255,7 @@ class GTEST_API_ UnitTest {
   internal::UnitTestImpl* impl() { return impl_; }
   const internal::UnitTestImpl* impl() const { return impl_; }
 
-  // These classes and funcions are friends as they need to access private
+  // These classes and functions are friends as they need to access private
   // members of UnitTest.
   friend class Test;
   friend class internal::AssertHelper;

--- a/lib/gtest/gtest/internal/gtest-filepath.h
+++ b/lib/gtest/gtest/internal/gtest-filepath.h
@@ -192,7 +192,7 @@ class GTEST_API_ FilePath {
 
   void Normalize();
 
-  // Returns a pointer to the last occurence of a valid path separator in
+  // Returns a pointer to the last occurrence of a valid path separator in
   // the FilePath. On Windows, for example, both '/' and '\' are valid path
   // separators. Returns NULL if no path separator was found.
   const char* FindLastPathSeparator() const;

--- a/lib/gtest/gtest/internal/gtest-port.h
+++ b/lib/gtest/gtest/internal/gtest-port.h
@@ -1047,7 +1047,7 @@ inline void FlushInfoLog() { fflush(NULL); }
 //
 // GTEST_CHECK_ is an all-mode assert. It aborts the program if the condition
 // is not satisfied.
-//  Synopsys:
+//  Synopsis:
 //    GTEST_CHECK_(boolean_condition);
 //     or
 //    GTEST_CHECK_(boolean_condition) << "Additional message";

--- a/lib/gtest/src/gtest-filepath.cc
+++ b/lib/gtest/src/gtest-filepath.cc
@@ -125,7 +125,7 @@ FilePath FilePath::RemoveExtension(const char* extension) const {
   return *this;
 }
 
-// Returns a pointer to the last occurence of a valid path separator in
+// Returns a pointer to the last occurrence of a valid path separator in
 // the FilePath. On Windows, for example, both '/' and '\' are valid path
 // separators. Returns NULL if no path separator was found.
 const char* FilePath::FindLastPathSeparator() const {

--- a/lib/gtest/src/gtest-printers.cc
+++ b/lib/gtest/src/gtest-printers.cc
@@ -119,7 +119,7 @@ namespace internal {
 // Depending on the value of a char (or wchar_t), we print it in one
 // of three formats:
 //   - as is if it's a printable ASCII (e.g. 'a', '2', ' '),
-//   - as a hexidecimal escape sequence (e.g. '\x7F'), or
+//   - as a hexadecimal escape sequence (e.g. '\x7F'), or
 //   - as a special escape sequence (e.g. '\r', '\n').
 enum CharFormat {
   kAsIs,
@@ -223,7 +223,7 @@ void PrintCharAndCodeTo(Char c, ostream* os) {
     return;
   *os << " (" << static_cast<int>(c);
 
-  // For more convenience, we print c's code again in hexidecimal,
+  // For more convenience, we print c's code again in hexadecimal,
   // unless c was already printed in the form '\x##' or the code is in
   // [1, 9].
   if (format == kHexEscape || (1 <= c && c <= 9)) {

--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -152,7 +152,7 @@ class Reader
 
   fun ref read_until(separator: U8): Array[U8] iso^ ? =>
     """
-    Find the first occurence of the separator and return the block of bytes
+    Find the first occurrence of the separator and return the block of bytes
     before its position. The separator is not included in the returned array,
     but it is removed from the buffer. To read a line of text, prefer line()
     that handles \n and \r\n.
@@ -540,7 +540,7 @@ class Reader
 
   fun ref _distance_of(byte: U8): USize ? =>
     """
-    Get the distance to the first occurence of the given byte
+    Get the distance to the first occurrence of the given byte
     """
     if _chunks.size() == 0 then
       error

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -505,7 +505,7 @@ actor Main
   fun find(s: String box, offset: ISize = 0, nth: USize = 0): ISize ? =>
     """
     Return the index of the n-th instance of s in the string starting from the
-    beginning. Raise an error if there is no n-th occurence of s or s is empty.
+    beginning. Raise an error if there is no n-th occurrence of s or s is empty.
     """
     var i = offset_to_index(offset)
     var steps = nth + 1
@@ -535,7 +535,7 @@ actor Main
     """
     Return the index of n-th instance of `s` in the string starting from the
     end. The `offset` represents the highest index to included in the search.
-    Raise an error if there is no n-th occurence of `s` or `s` is empty.
+    Raise an error if there is no n-th occurrence of `s` or `s` is empty.
     """
     var i = (offset_to_index(offset) + 1) - s._size
 
@@ -1004,7 +1004,7 @@ actor Main
           (let c, let len) = utf32(i.isize())
 
           if chars.contains(c) then
-            // If we find a delimeter, add the current string to the array.
+            // If we find a delimiter, add the current string to the array.
             occur = occur + 1
 
             if (n > 0) and (occur >= n) then

--- a/packages/itertools/itertools.pony
+++ b/packages/itertools/itertools.pony
@@ -25,7 +25,7 @@ let xs = Iter[I64]([as I64: 1, 2, 3, 4, 5].values())
 ```
 
 This will result in an iterator that prints the numbers 2, 4, and 6. However,
-due to the lazy nature of the map and filter, no iteration has actually occured
+due to the lazy nature of the map and filter, no iteration has actually occurred
 and nothing will be printed. One solution to this would be to loop over the
 resulting Iter as so:
 

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -55,7 +55,7 @@ class JsonDoc
 
   fun parse_report(): (USize /* line */, String /*message */) =>
     """
-    Give details of the error that occured last time we attempted to parse.
+    Give details of the error that occurred last time we attempted to parse.
     If parse was successful returns (0, "").
     """
     (_err_line, _err_msg)

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -283,7 +283,7 @@ actor PonyTest
     end
 
     // Group doesn't exist yet, make it.
-    // We only need one simultanous group, which we've already made. All new
+    // We only need one simultaneous group, which we've already made. All new
     // groups are exclusive.
     let g = _ExclusiveGroup
     _groups.push((name, g))

--- a/src/common/dtrace_probes.d
+++ b/src/common/dtrace_probes.d
@@ -95,7 +95,7 @@ provider pony {
   probe rt__end();
 
   /**
-   * Fired when a scheduler succesfully steals a job
+   * Fired when a scheduler successfully steals a job
    * @param scheduler is the scheduler that stole the job
    * @param victim is the victim that the scheduler stole from
    * @param actor is actor that was stolen from the victim

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -275,7 +275,7 @@ static ast_t* propogate_error(parser_t* parser, rule_state_t* state)
   if(state->restart == NULL)
   {
     if(trace_enable)
-      fprintf(stderr, "Rule %s: Propogate failure\n", state->fn_name);
+      fprintf(stderr, "Rule %s: Propagate failure\n", state->fn_name);
 
     return PARSE_ERROR;
   }
@@ -327,7 +327,7 @@ static ast_t* handle_found(parser_t* parser, rule_state_t* state,
 *
 * Returns:
  *    PARSE_OK if not error.
- *    PARSE_ERROR to propogate a lexer error.
+ *    PARSE_ERROR to propagate a lexer error.
  *    RULE_NOT_FOUND if current token is not is specified set.
 */
 static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
@@ -393,9 +393,9 @@ static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
  *
  * Returns:
  *    PARSE_OK on success.
- *    PARSE_ERROR to propogate a lexer error.
+ *    PARSE_ERROR to propagate a lexer error.
  *    RULE_NOT_FOUND if current token is not is specified set.
- *    NULL to propogate a restarted error.
+ *    NULL to propagate a restarted error.
  */
 ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
   const char* terminating, const token_id* id_set, bool make_ast,
@@ -476,9 +476,9 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
  *
  * Returns:
  *    PARSE_OK on success.
- *    PARSE_ERROR to propogate an error.
+ *    PARSE_ERROR to propagate an error.
  *    RULE_NOT_FOUND if no rules in given set can be matched.
- *    NULL to propogate a restarted error.
+ *    NULL to propagate a restarted error.
  */
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
   const rule_t* rule_set, bool* out_found, bool annotate)

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -32,7 +32,7 @@ PONY_EXTERN_C_BEGIN
  *
  * Each rule returns one of 4 things:
  * 1. PARSE_ERROR - indicates that an error occurred. Parse errors are
- *    propogated up to the caller without re-reporting them.
+ *    propagated up to the caller without re-reporting them.
  * 2. RULE_NOT_FOUND - indicates that the rule was not found. It is up to the
  *    caller whether this constitutes an error.
  * 3. An AST tree - generated from a successful rule parse. It is the caller's
@@ -102,7 +102,7 @@ typedef ast_t* (*rule_t)(parser_t* parser, builder_fn_t *out_builder,
 
 
 #define PARSE_OK        ((ast_t*)1)   // Requested parse successful
-#define PARSE_ERROR     ((ast_t*)2)   // A parse error has occured
+#define PARSE_ERROR     ((ast_t*)2)   // A parse error has occurred
 #define RULE_NOT_FOUND  ((ast_t*)3)   // Sub item was not found
 
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -343,7 +343,7 @@ size_t token_line_number(token_t* token);
 /// Report the position within the line that the given token was found at
 size_t token_line_position(token_t* token);
 
-/// Report whether debug info should be genreated.
+/// Report whether debug info should be generated.
 bool token_debug(token_t* token);
 
 

--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -95,7 +95,7 @@ static bool check_children(ast_t* ast, check_state_t* state,
     // See if next child is suitable
     check_res_t r = check_from_list(state->child, rules, errors);
 
-    if(r == CHK_ERROR)  // Propogate error
+    if(r == CHK_ERROR)  // Propagate error
       return false;
 
     if(r == CHK_NOT_FOUND)  // End of list
@@ -168,7 +168,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
 
     check_res_t r = state->type(type_field, errors);
 
-    if(r == CHK_ERROR)  // Propogate error
+    if(r == CHK_ERROR)  // Propagate error
       return CHK_ERROR;
 
     if(r == CHK_NOT_FOUND)

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -129,7 +129,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
     LLVMBuildBr(c->builder, post_block);
   }
 
-  // If both sides return, we return a sentinal value.
+  // If both sides return, we return a sentinel value.
   if(is_control_type(type))
     return GEN_NOVALUE;
 
@@ -578,7 +578,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
     LLVMBuildBr(c->builder, post_block);
   }
 
-  // If both sides return, we return a sentinal value.
+  // If both sides return, we return a sentinel value.
   if(is_control_type(type))
     return GEN_NOVALUE;
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -725,7 +725,7 @@ public:
     while(alloc_size == 0)
     {
       // replace is a LLVM null pointer here. We have to handle any realloc
-      // chain before losing call use informations.
+      // chain before losing call use information.
 
       CallInst* next_realloc = findRealloc(*last_realloc);
       if(next_realloc == NULL)

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -309,7 +309,7 @@ static int uifset_union(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
   {
     int r = uifset(opt, p, chain);
 
-    if(r == UIF_ERROR)  // Propogate errors
+    if(r == UIF_ERROR)  // Propagate errors
       return UIF_ERROR;
 
     bool child_valid = (r != UIF_NO_TYPES);
@@ -344,7 +344,7 @@ static int uifset_intersect(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
   {
     int r = uifset(opt, p, chain);
 
-    if(r == UIF_ERROR)  // Propogate errors
+    if(r == UIF_ERROR)  // Propagate errors
       return UIF_ERROR;
 
     if((r & UIF_CONSTRAINED) != 0)

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -244,7 +244,7 @@ static ast_t* find_infer_type(pass_opt_t* opt, ast_t* type, infer_path_t* path)
 
         if(t == NULL)
         {
-          // Propogate error
+          // Propagate error
           ast_free_unattached(u_type);
           return NULL;
         }
@@ -266,7 +266,7 @@ static ast_t* find_infer_type(pass_opt_t* opt, ast_t* type, infer_path_t* path)
 
         if(t == NULL)
         {
-          // Propogate error
+          // Propagate error
           ast_free_unattached(i_type);
           return NULL;
         }

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -192,7 +192,7 @@ bool module_passes(ast_t* package, pass_opt_t* options, source_t* source)
 }
 
 
-// Peform the AST passes on the given AST up to the speficied last pass
+// Peform the AST passes on the given AST up to the specified last pass
 static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
 {
   assert(astp != NULL);

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -109,7 +109,7 @@ TODO
 * Traits pass (AST)
 
 Adds methods inherited by entities from traits and interfaces, including
-handling default bodies. Only chnages AST by adding methods to types and bodies
+handling default bodies. Only changes AST by adding methods to types and bodies
 to previously bodiless methods.
 
 Uses the data field of various AST nodes:
@@ -150,7 +150,7 @@ Does not mutate the structure of the AST, but may set and use flags.
 
 * Finaliser pass (AST)
 
-Checks that any finalisers do not perfrom any restricted operations, such as
+Checks that any finalisers do not perform any restricted operations, such as
 creating actors or sending messages.
 
 Within finalisers uses the data field of the top body node and any TK_CALL
@@ -294,7 +294,7 @@ typedef ast_result_t(*ast_visit_t)(ast_t** astp, pass_opt_t* options);
 
 /** Perform the specified pass on the given AST.
  * The specified pass is stored in the AST and passes will not be repeated.
- * To surpress this check, and execute the given pass regardless, specify the
+ * To suppress this check, and execute the given pass regardless, specify the
  * pass as PASS_ALL. No pass will be recorded in the AST in this case.
  */
 ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -301,7 +301,7 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
 
   const char* name = ast_name(ast_childidx(basis_method, 1));
 
-  // Check behaviour compatability.
+  // Check behaviour compatibility.
   if(ast_id(basis_method) == TK_BE)
   {
     switch(ast_id(entity))

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -40,7 +40,7 @@ typedef struct asio_backend_t asio_backend_t;
 
 /** Opaque definition of an ASIO base.
  *
- * A base is a representation of the running instance of some I/O notifcation
+ * A base is a representation of the running instance of some I/O notification
  * mechanism.
  */
 typedef struct asio_base_t asio_base_t;

--- a/src/libponyrt/ds/hash.c
+++ b/src/libponyrt/ds/hash.c
@@ -372,7 +372,7 @@ static void shift_delete(hashmap_t* map, size_t index)
     ni_hash = map->buckets[next_pos].hash;
   }
 
-  // done shifting all required elements; set current postion as empty
+  // done shifting all required elements; set current position as empty
   // and decrement count
   map->buckets[pos].ptr = NULL;
   map->count--;

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -101,7 +101,7 @@ protected:
   // the previously loaded package
   ast_t* numeric_literal(uint64_t num);
 
-  // Run the compiled program. The program must have been successfuly compiled
+  // Run the compiled program. The program must have been successfully compiled
   // up to the ir pass before calling this function.
   bool run_program(int* exit_code);
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

the one in 
  lib/gbenchmark/.ycm_extra_conf.py
might be even a real catch. looks like an (now valid) gcc option.