### PR TITLE
Change TCPConnection to use vectored i/o functions

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -63,11 +63,11 @@ class Array[A] is Seq[A]
     """
     _ptr._offset(from_offset)._copy_to(ptr._offset(to_offset), copy_len)
 
-  fun cpointer(): Pointer[A] tag =>
+  fun cpointer(offset: USize = 0): Pointer[A] tag =>
     """
     Return the underlying C-style pointer.
     """
-    _ptr
+    _ptr._offset(offset)
 
   fun size(): USize =>
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -198,11 +198,11 @@ actor Main
     """
     _ptr._offset(from_offset)._copy_to(ptr._offset(to_offset), copy_len)
 
-  fun cpointer(): Pointer[U8] tag =>
+  fun cpointer(offset: USize = 0): Pointer[U8] tag =>
     """
     Returns a C compatible pointer to the underlying string allocation.
     """
-    _ptr
+    _ptr._offset(offset)
 
   fun cstring(): Pointer[U8] tag =>
     """

--- a/src/libponyrt/lang/io.c
+++ b/src/libponyrt/lang/io.c
@@ -1,0 +1,21 @@
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+#include <platform.h>
+
+PONY_EXTERN_C_BEGIN
+
+#if defined(PLATFORM_IS_POSIX_BASED)
+#include <limits.h>
+#endif
+
+PONY_API int pony_os_writev_max()
+{
+#if defined(PLATFORM_IS_POSIX_BASED)
+  return IOV_MAX;
+#else
+  return 1;
+#endif
+}
+
+PONY_EXTERN_C_END


### PR DESCRIPTION
The motivation behind this is to improve performance of network
i/o operations. Vectored I/O is more efficient because it offloads
the combining of multiple user buffers into a single buffer for
sending to the network hardware when possible.

------------

This change required getting the pointer to a specific element in an `array` like PR #1598 and it should become a no-op for whichever PR is merged second. In order to get that offset as cleanly and safely as possible the change in commit 34d71201339c7254b4723c68ff687aaf52efe274 was introduced. The commit message for the change is:

>Prior to this change getting an offset for a pointer into an
`array` or a `string` required doing pointer arithmetic after
geting the pointer to the start. This is problematic because
in most cases we want the pointer to a specific entry in the
`array` or `string`. Doing pointer arithmetic to calculate the
pointer to a specific entry is non-trivial because it requires
one to know the size of each array entry in order to do the
pointer math correctly.
>
>This change makes it easy and safe to get the pointer to a
specific entry by giving an optional `offset` argument to
`cpointer` in `array` and `string` and letting Pony handle
the appropriate pointer math prior to returning the pointer
to the appropriate element.

----------

I don't believe this requires an `rfc` because it doesn't break the existing interface due to being able to default the new argument. However, if I'm wrong and this does require an `rfc`, please let me know and I'll follow the appropriate procedure.

------

This PR also adds `src/libponyrt/lang/io.c` like PR #1598 and it should become a no-op for whichever PR is merged second.