### PR TITLE
Add custom assertion mechanism with backtrace printing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,6 +379,8 @@ ifneq (,$(filter $(OSTYPE), osx freebsd))
 endif
 
 # target specific build options
+libponyrt.buildoptions = -DPONY_NO_ASSERT
+
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS
@@ -397,6 +399,8 @@ libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
 libgbenchmark.buildoptions := -DHAVE_POSIX_REGEX
 
 ponyc.buildoptions = $(libponyc.buildoptions)
+
+ponyc.linkoptions += -rdynamic
 
 ifeq ($(OSTYPE), linux)
   libponyrt-pic.buildoptions += -fpic

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -28,6 +28,9 @@ using std::atomic_compare_exchange_strong_explicit;
 using std::atomic_fetch_add_explicit;
 using std::atomic_fetch_sub_explicit;
 using std::atomic_thread_fence;
+using std::atomic_flag_test_and_set_explicit;
+
+using std::atomic_flag;
 #  endif
 #elif defined(__GNUC__) && !defined(__clang__)
 #  include <features.h>
@@ -46,6 +49,8 @@ using std::atomic_thread_fence;
 #  elif __GNUC_PREREQ(4, 7)
 // Valid on x86 and ARM given our uses of atomics.
 #    define PONY_ATOMIC(T) T
+#    define atomic_flag bool
+#    define ATOMIC_FLAG_INIT false
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use GCC >= 4.7"
@@ -59,6 +64,8 @@ using std::atomic_thread_fence;
 #  elif __clang_major__ >= 3 && __clang_minor__ >= 3
 // Valid on x86 and ARM given our uses of atomics.
 #    define PONY_ATOMIC(T) T
+#    define atomic_flag bool
+#    define ATOMIC_FLAG_INIT false
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use Clang >= 3.3"
@@ -204,6 +211,9 @@ namespace ponyint_atomics
 
 #    define atomic_thread_fence(MO) \
       __atomic_thread_fence(MO)
+
+#    define atomic_flag_test_and_set_explicit(PTR, MO) \
+      __atomic_test_and_set(PTR, MO)
 
 #    undef PONY_ATOMIC_BUILTINS
 #  endif

--- a/src/common/ponyassert.h
+++ b/src/common/ponyassert.h
@@ -1,0 +1,21 @@
+#ifndef PLATFORM_PONYASSERT_H
+#define PLATFORM_PONYASSERT_H
+
+#include "platform.h"
+
+PONY_EXTERN_C_BEGIN
+
+#if defined(NDEBUG) && defined(PONY_NO_ASSERT)
+#  define pony_assert(expr) ((void)0)
+#else
+#  define pony_assert(expr) \
+    ((expr) ? (void)0 : \
+      ponyint_assert_fail(#expr, __FILE__, __LINE__, __func__))
+#endif
+
+void ponyint_assert_fail(const char* expr, const char* file, size_t line,
+  const char* func);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -8,11 +8,11 @@
 #include "../pkg/program.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 
 /* Every AST node has a parent field, which points to the parent node when
@@ -294,7 +294,7 @@ static bool hasparent(ast_t* ast)
 // Set both the parent and scope for the given node
 static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast->parent = parent;
   ast_clearflag(ast, AST_ORPHAN);
@@ -303,7 +303,7 @@ static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 // Set the scope for the given node, but set it no have no parent
 static void set_scope_no_parent(ast_t* ast, ast_t* scope)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast->parent = scope;
   ast_setflag(ast, AST_ORPHAN);
@@ -320,7 +320,7 @@ static ast_t* duplicate(ast_t* parent, ast_t* ast)
   if(ast == NULL)
     return NULL;
 
-  assert(ast_id(ast) != TK_PROGRAM && ast_id(ast) != TK_PACKAGE &&
+  pony_assert(ast_id(ast) != TK_PROGRAM && ast_id(ast) != TK_PACKAGE &&
     ast_id(ast) != TK_MODULE);
 
   ast_t* n = ast_token(token_dup(ast->t));
@@ -378,7 +378,7 @@ ast_t* ast_token(token_t* t)
 
 ast_t* ast_from(ast_t* ast, token_id id)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_t* new_ast = ast_token(token_dup_new_id(ast->t, id));
   set_scope_no_parent(new_ast, ast->parent);
   return new_ast;
@@ -400,7 +400,7 @@ ast_t* ast_from_string(ast_t* ast, const char* name)
 
 ast_t* ast_from_int(ast_t* ast, uint64_t value)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   token_t* t = token_dup(ast->t);
   token_set_id(t, TK_INT);
 
@@ -414,7 +414,7 @@ ast_t* ast_from_int(ast_t* ast, uint64_t value)
 
 ast_t* ast_from_float(ast_t* ast, double value)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   token_t* t = token_dup(ast->t);
   token_set_id(t, TK_FLOAT);
   token_set_float(t, value);
@@ -431,56 +431,56 @@ ast_t* ast_dup(ast_t* ast)
 
 void ast_scope(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast->symtab = symtab_new();
 }
 
 bool ast_has_scope(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return ast->symtab != NULL;
 }
 
 symtab_t* ast_get_symtab(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return ast->symtab;
 }
 
 ast_t* ast_setid(ast_t* ast, token_id id)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   token_set_id(ast->t, id);
   return ast;
 }
 
 void ast_setpos(ast_t* ast, source_t* source, size_t line, size_t pos)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   token_set_pos(ast->t, source, line, pos);
 }
 
 token_id ast_id(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_get_id(ast->t);
 }
 
 size_t ast_line(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_line_number(ast->t);
 }
 
 size_t ast_pos(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_line_position(ast->t);
 }
 
 source_t* ast_source(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_source(ast->t);
 }
 
@@ -494,7 +494,7 @@ void* ast_data(ast_t* ast)
 
 ast_t* ast_setdata(ast_t* ast, void* data)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast->data = data;
   return ast;
 }
@@ -536,7 +536,7 @@ void ast_clearmightsend(ast_t* ast)
 
 void ast_inheritflags(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   for(ast_t* child = ast->child; child != NULL; child = ast_sibling(child))
     ast_setflag(ast, child->flags & AST_INHERIT_FLAGS);
@@ -544,24 +544,24 @@ void ast_inheritflags(ast_t* ast)
 
 int ast_checkflag(ast_t* ast, uint32_t flag)
 {
-  assert(ast != NULL);
-  assert((flag & AST_ALL_FLAGS) == flag);
+  pony_assert(ast != NULL);
+  pony_assert((flag & AST_ALL_FLAGS) == flag);
 
   return ast->flags & flag;
 }
 
 void ast_setflag(ast_t* ast, uint32_t flag)
 {
-  assert(ast != NULL);
-  assert((flag & AST_ALL_FLAGS) == flag);
+  pony_assert(ast != NULL);
+  pony_assert((flag & AST_ALL_FLAGS) == flag);
 
   ast->flags |= flag;
 }
 
 void ast_clearflag(ast_t* ast, uint32_t flag)
 {
-  assert(ast != NULL);
-  assert((flag & AST_ALL_FLAGS) == flag);
+  pony_assert(ast != NULL);
+  pony_assert((flag & AST_ALL_FLAGS) == flag);
 
   ast->flags &= ~flag;
 }
@@ -580,21 +580,21 @@ void ast_resetpass(ast_t* ast)
 
 const char* ast_get_print(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_print(ast->t);
 }
 
 const char* ast_name(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_string(ast->t);
 }
 
 
 const char* ast_nice_name(ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_ID);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_ID);
 
   if(ast->data != NULL)
     return (const char*)ast->data;
@@ -605,37 +605,37 @@ const char* ast_nice_name(ast_t* ast)
 
 size_t ast_name_len(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_string_len(ast->t);
 }
 
 void ast_set_name(ast_t* ast, const char* name)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   token_set_string(ast->t, name, 0);
 }
 
 double ast_float(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_float(ast->t);
 }
 
 lexint_t* ast_int(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return token_int(ast->t);
 }
 
 ast_t* ast_type(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return ast->type;
 }
 
 void ast_settype(ast_t* ast, ast_t* type)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(ast->type == type)
     return;
@@ -655,27 +655,27 @@ void ast_settype(ast_t* ast, ast_t* type)
 
 ast_t* ast_annotation(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return ast->annotation;
 }
 
 void ast_setannotation(ast_t* ast, ast_t* annotation)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(ast->annotation == annotation)
     return;
 
   ast_free(ast->annotation);
 
-  assert((annotation == NULL) || !hasparent(annotation));
+  pony_assert((annotation == NULL) || !hasparent(annotation));
 
   ast->annotation = annotation;
 }
 
 ast_t* ast_consumeannotation(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* annotation = ast->annotation;
   ast->annotation = NULL;
@@ -685,7 +685,7 @@ ast_t* ast_consumeannotation(ast_t* ast)
 
 bool ast_has_annotation(ast_t* ast, const char* name)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* annotation = ast->annotation;
 
@@ -706,7 +706,7 @@ bool ast_has_annotation(ast_t* ast, const char* name)
 
 void ast_erase(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* child = ast->child;
 
@@ -764,13 +764,13 @@ ast_t* ast_parent(ast_t* ast)
 
 ast_t* ast_child(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   return ast->child;
 }
 
 ast_t* ast_childidx(ast_t* ast, size_t idx)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_t* child = ast->child;
 
   while((child != NULL) && (idx > 0))
@@ -817,8 +817,8 @@ ast_t* ast_sibling(ast_t* ast)
 
 ast_t* ast_previous(ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(hasparent(ast));
+  pony_assert(ast != NULL);
+  pony_assert(hasparent(ast));
 
   ast_t* last = NULL;
   ast_t* cur = ast->parent->child;
@@ -834,8 +834,8 @@ ast_t* ast_previous(ast_t* ast)
 
 size_t ast_index(ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(hasparent(ast));
+  pony_assert(ast != NULL);
+  pony_assert(hasparent(ast));
 
   ast_t* child = ast->parent->child;
   size_t idx = 0;
@@ -950,7 +950,7 @@ void ast_inheritbranch(ast_t* dst, ast_t* src)
 
 void ast_consolidate_branches(ast_t* ast, size_t count)
 {
-  assert(hasparent(ast));
+  pony_assert(hasparent(ast));
 
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
@@ -962,7 +962,7 @@ void ast_consolidate_branches(ast_t* ast, size_t count)
 
     if(sym->status == SYM_UNDEFINED)
     {
-      assert(sym->branch_count <= count);
+      pony_assert(sym->branch_count <= count);
 
       if((status == SYM_DEFINED) || (sym->branch_count == count))
       {
@@ -1086,9 +1086,9 @@ void ast_clear_local(ast_t* ast)
 
 ast_t* ast_add(ast_t* parent, ast_t* child)
 {
-  assert(parent != NULL);
-  assert(parent != child);
-  assert(parent->child != child);
+  pony_assert(parent != NULL);
+  pony_assert(parent != child);
+  pony_assert(parent->child != child);
 
   if(hasparent(child))
     child = ast_dup(child);
@@ -1101,15 +1101,15 @@ ast_t* ast_add(ast_t* parent, ast_t* child)
 
 ast_t* ast_add_sibling(ast_t* older_sibling, ast_t* new_sibling)
 {
-  assert(older_sibling != NULL);
-  assert(new_sibling != NULL);
-  assert(older_sibling != new_sibling);
-  assert(hasparent(older_sibling));
+  pony_assert(older_sibling != NULL);
+  pony_assert(new_sibling != NULL);
+  pony_assert(older_sibling != new_sibling);
+  pony_assert(hasparent(older_sibling));
 
   if(hasparent(new_sibling))
     new_sibling = ast_dup(new_sibling);
 
-  assert(new_sibling->sibling == NULL);
+  pony_assert(new_sibling->sibling == NULL);
 
   set_scope_and_parent(new_sibling, older_sibling->parent);
   new_sibling->sibling = older_sibling->sibling;
@@ -1133,9 +1133,9 @@ ast_t* ast_pop(ast_t* parent)
 
 ast_t* ast_append(ast_t* parent, ast_t* child)
 {
-  assert(parent != NULL);
-  assert(child != NULL);
-  assert(parent != child);
+  pony_assert(parent != NULL);
+  pony_assert(child != NULL);
+  pony_assert(parent != child);
 
   if(hasparent(child))
     child = ast_dup(child);
@@ -1159,21 +1159,21 @@ ast_t* ast_append(ast_t* parent, ast_t* child)
 
 ast_t* ast_list_append(ast_t* parent, ast_t** last_pointer, ast_t* new_child)
 {
-  assert(parent != NULL);
-  assert(last_pointer != NULL);
-  assert(new_child != NULL);
+  pony_assert(parent != NULL);
+  pony_assert(last_pointer != NULL);
+  pony_assert(new_child != NULL);
 
   if(*last_pointer == NULL)
   {
     // This is the first child for the parent
-    assert(parent->child == NULL);
+    pony_assert(parent->child == NULL);
     *last_pointer = ast_add(parent, new_child);
   }
   else
   {
     // This is not the first child, append to list
-    assert(parent->child != NULL);
-    assert((*last_pointer)->sibling == NULL);
+    pony_assert(parent->child != NULL);
+    pony_assert((*last_pointer)->sibling == NULL);
     *last_pointer = ast_add_sibling(*last_pointer, new_child);
   }
 
@@ -1182,8 +1182,8 @@ ast_t* ast_list_append(ast_t* parent, ast_t** last_pointer, ast_t* new_child)
 
 void ast_remove(ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(hasparent(ast));
+  pony_assert(ast != NULL);
+  pony_assert(hasparent(ast));
 
   ast_t* last = ast_previous(ast);
 
@@ -1199,11 +1199,11 @@ void ast_remove(ast_t* ast)
 
 void ast_swap(ast_t* prev, ast_t* next)
 {
-  assert(prev != NULL);
-  assert(prev != next);
+  pony_assert(prev != NULL);
+  pony_assert(prev != next);
 
   ast_t* parent = ast_parent(prev);
-  assert(parent != NULL);
+  pony_assert(parent != NULL);
 
   if(hasparent(next))
     next = ast_dup(next);
@@ -1246,9 +1246,9 @@ void ast_replace(ast_t** prev, ast_t* next)
 void ast_reorder_children(ast_t* ast, const size_t* new_order,
   ast_t** shuffle_space)
 {
-  assert(ast != NULL);
-  assert(new_order != NULL);
-  assert(shuffle_space != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(new_order != NULL);
+  pony_assert(shuffle_space != NULL);
 
   size_t count = ast_childcount(ast);
 
@@ -1258,9 +1258,9 @@ void ast_reorder_children(ast_t* ast, const size_t* new_order,
   for(size_t i = 0; i < count; i++)
   {
     size_t index = new_order[i];
-    assert(index < count);
+    pony_assert(index < count);
     ast_t* t = shuffle_space[index];
-    assert(t != NULL);
+    pony_assert(t != NULL);
     ast_append(ast, t);
     shuffle_space[index] = NULL;
   }
@@ -1498,9 +1498,9 @@ void ast_error_continue(errors_t* errors, ast_t* ast, const char* fmt, ...)
 
 void ast_error_frame(errorframe_t* frame, ast_t* ast, const char* fmt, ...)
 {
-  assert(frame != NULL);
-  assert(ast != NULL);
-  assert(fmt != NULL);
+  pony_assert(frame != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(fmt != NULL);
 
   va_list ap;
   va_start(ap, fmt);
@@ -1512,15 +1512,15 @@ void ast_error_frame(errorframe_t* frame, ast_t* ast, const char* fmt, ...)
 void ast_get_children(ast_t* parent, size_t child_count,
   ast_t*** out_children)
 {
-  assert(parent != NULL);
-  assert(child_count > 0);
-  assert(out_children != NULL);
+  pony_assert(parent != NULL);
+  pony_assert(child_count > 0);
+  pony_assert(out_children != NULL);
 
   ast_t* p = parent->child;
 
   for(size_t i = 0; i < child_count; i++)
   {
-    assert(p != NULL);
+    pony_assert(p != NULL);
 
     if(out_children[i] != NULL)
       *(out_children[i]) = p;
@@ -1532,16 +1532,16 @@ void ast_get_children(ast_t* parent, size_t child_count,
 void ast_extract_children(ast_t* parent, size_t child_count,
   ast_t*** out_children)
 {
-  assert(parent != NULL);
-  assert(child_count > 0);
-  assert(out_children != NULL);
+  pony_assert(parent != NULL);
+  pony_assert(child_count > 0);
+  pony_assert(out_children != NULL);
 
   ast_t* p = parent->child;
   ast_t* last_remaining_sibling = NULL;
 
   for(size_t i = 0; i < child_count; i++)
   {
-    assert(p != NULL);
+    pony_assert(p != NULL);
     ast_t* next = p->sibling;
 
     if(out_children[i] != NULL)

--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -4,8 +4,8 @@
 #include "ast.h"
 #include "token.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 
 /** This file contains the BNF printer, which prints out the Pony BNF in human
@@ -241,8 +241,8 @@ static bnf_t* bnf_copy(bnf_t* bnf, bnf_t** out_last_sibling)
 // New children go at the end of the child list.
 static bnf_t* bnf_add(bnf_t* bnf, bnf_t* parent)
 {
-  assert(bnf != NULL);
-  assert(parent != NULL);
+  pony_assert(bnf != NULL);
+  pony_assert(parent != NULL);
 
   if(parent->last_child == NULL)  // First node in list
     parent->child = bnf;
@@ -344,7 +344,7 @@ static void bnf_print(bnf_t* bnf, bool top_format)
       break;
 
     default:
-      assert(false);
+      pony_assert(false);
       break;
   }
 }
@@ -356,11 +356,11 @@ static void bnf_print(bnf_t* bnf, bool top_format)
 static void bnf_print_children(bnf_t* bnf, const char* separator,
   bool top_format, bool children_top_format)
 {
-  assert(bnf != NULL);
-  assert(separator != NULL);
+  pony_assert(bnf != NULL);
+  pony_assert(separator != NULL);
 
   bnf_t* child = bnf->child;
-  assert(child != NULL);
+  pony_assert(child != NULL);
 
   bool parens = !top_format && (child->sibling != NULL);
 
@@ -383,12 +383,12 @@ static void bnf_print_children(bnf_t* bnf, const char* separator,
 // Build a list of token references with the given node
 static void bnf_token_set(bnf_t* bnf, token_id* tokens, bool clean)
 {
-  assert(bnf != NULL);
+  pony_assert(bnf != NULL);
 
   for(int i = 0; tokens[i] != TK_NONE; i++)
   {
     bnf_t* p = bnf_add(bnf_create(BNF_TOKEN), bnf);
-    assert(p != NULL);
+    pony_assert(p != NULL);
 
     //token_id next = tokens[i + 1];
 
@@ -410,7 +410,7 @@ static void bnf_token_set(bnf_t* bnf, token_id* tokens, bool clean)
         p->name = lexer_print(tokens[i]);
         p->id = BNF_QUOTED_TOKEN;
 
-        assert(p->name != NULL);
+        pony_assert(p->name != NULL);
 
         if((clean && p->name[0] == '$') || tokens[i] == TK_NEWLINE)
         {
@@ -427,12 +427,12 @@ static void bnf_token_set(bnf_t* bnf, token_id* tokens, bool clean)
 // Build a list of rule references with the given node
 static void bnf_rule_set(bnf_t* bnf, const char** rules)
 {
-  assert(bnf != NULL);
+  pony_assert(bnf != NULL);
 
   for(int i = 0; rules[i] != NULL; i++)
   {
     bnf_t* p = bnf_add(bnf_create(BNF_RULE), bnf);
-    assert(p != NULL);
+    pony_assert(p != NULL);
     p->name = rules[i];
   }
 }
@@ -443,8 +443,8 @@ static void bnf_rule_set(bnf_t* bnf, const char** rules)
 // it and then free the child.
 static void bnf_use_child(bnf_t* bnf)
 {
-  assert(bnf != NULL);
-  assert(bnf->child != NULL);
+  pony_assert(bnf != NULL);
+  pony_assert(bnf->child != NULL);
 
   bnf_t* child = bnf->child;
 
@@ -462,8 +462,8 @@ static void bnf_use_child(bnf_t* bnf)
 // Find the rule with the specified name
 static bnf_t* bnf_find_def(bnf_t* tree, const char* name)
 {
-  assert(tree != NULL);
-  assert(name != NULL);
+  pony_assert(tree != NULL);
+  pony_assert(name != NULL);
 
   for(bnf_t* p = tree->child; p != NULL; p = p->sibling)
   {
@@ -472,7 +472,7 @@ static bnf_t* bnf_find_def(bnf_t* tree, const char* name)
   }
 
   // Not found, this is impossible if the parser compiles
-  assert(false);
+  pony_assert(false);
   return NULL;
 }
 
@@ -483,8 +483,8 @@ static bnf_t* bnf_find_def(bnf_t* tree, const char* name)
 // The out_changed variable is set to true when any simplifications occur.
 static void bnf_simplify_node(bnf_t* tree, bnf_t* bnf, bool *out_changed)
 {
-  assert(bnf != NULL);
-  assert(out_changed != NULL);
+  pony_assert(bnf != NULL);
+  pony_assert(out_changed != NULL);
 
   switch(bnf->id)
   {
@@ -568,10 +568,10 @@ static void bnf_simplify_node(bnf_t* tree, bnf_t* bnf, bool *out_changed)
         break;
 
       bnf_t* def = bnf_find_def(tree, bnf->name);
-      assert(def != NULL);
+      pony_assert(def != NULL);
 
       bnf_t* rule = def->child;
-      assert(rule != NULL);
+      pony_assert(rule != NULL);
 
       // We inline rules that are nevers, nops, single token / rule references
       // or have been explicitly marked to inline
@@ -588,7 +588,7 @@ static void bnf_simplify_node(bnf_t* tree, bnf_t* bnf, bool *out_changed)
 
         // Child of def should only ever have one child, so don't need to worry
         // about copying siblings
-        assert(rule->sibling == NULL);
+        pony_assert(rule->sibling == NULL);
 
         // Don't worry about simplifying children now, leave that til the next
         // iteration
@@ -610,7 +610,7 @@ static void bnf_simplify_node(bnf_t* tree, bnf_t* bnf, bool *out_changed)
 static void bnf_simplify_children(bnf_t* tree, bnf_t* parent, bool* out_never,
   bool* out_nop, bool *out_changed)
 {
-  assert(parent != NULL);
+  pony_assert(parent != NULL);
 
   if(out_never != NULL) *out_never = false;
   if(out_nop != NULL) *out_nop = false;
@@ -658,7 +658,7 @@ static void bnf_simplify_children(bnf_t* tree, bnf_t* parent, bool* out_never,
 // Simplify the given tree as far as possible
 static void bnf_simplify(bnf_t* tree)
 {
-  assert(tree != NULL);
+  pony_assert(tree != NULL);
 
   bool changed = true;
 
@@ -673,7 +673,7 @@ static void bnf_simplify(bnf_t* tree)
 // Add extra rules to get round the ANTLR interpreter bug
 static void bnf_avoid_antlr_bug(bnf_t* tree, bnf_t* bnf)
 {
-  assert(tree != NULL);
+  pony_assert(tree != NULL);
 
   if(bnf == NULL)
     return;
@@ -688,12 +688,12 @@ static void bnf_avoid_antlr_bug(bnf_t* tree, bnf_t* bnf)
     return;
 
   bnf_t* or_node = bnf->child;
-  assert(or_node != NULL);
+  pony_assert(or_node != NULL);
 
   if(or_node->id != BNF_OR)
     return;
 
-  assert(or_node->child != NULL);
+  pony_assert(or_node->child != NULL);
 
   bnf_t* second_child = or_node->child->sibling;
 
@@ -704,7 +704,7 @@ static void bnf_avoid_antlr_bug(bnf_t* tree, bnf_t* bnf)
   // This is the bug case. Move 'or' node into its own rule.
   int rule_no = tree->hack_count++;
 
-  assert(tree->last_child != NULL);
+  pony_assert(tree->last_child != NULL);
   bnf_t* new_rule = bnf_create(BNF_DEF);
   new_rule->hack_count = rule_no;
   new_rule->child = or_node;
@@ -722,8 +722,8 @@ static void bnf_avoid_antlr_bug(bnf_t* tree, bnf_t* bnf)
 // Mark rule definitions that are referenced from within the given subtree
 static void bnf_mark_refd_defs(bnf_t* tree, bnf_t* bnf)
 {
-  assert(tree != NULL);
-  assert(bnf != NULL);
+  pony_assert(tree != NULL);
+  pony_assert(bnf != NULL);
 
   for(bnf_t* p = bnf; p != NULL; p = p->sibling)
   {
@@ -733,7 +733,7 @@ static void bnf_mark_refd_defs(bnf_t* tree, bnf_t* bnf)
     if(p->id == BNF_RULE && p->name != NULL)
     {
       bnf_t* rule = bnf_find_def(tree, p->name);
-      assert(rule != NULL);
+      pony_assert(rule != NULL);
       rule->used = true;
     }
   }
@@ -871,7 +871,7 @@ static bnf_t* bnf_def(bool clean)
 void print_grammar(bool antlr, bool clean)
 {
   bnf_t* tree = bnf_def(clean);
-  assert(tree != NULL);
+  pony_assert(tree != NULL);
 
   bnf_simplify(tree);
 

--- a/src/libponyc/ast/error.c
+++ b/src/libponyc/ast/error.c
@@ -1,10 +1,10 @@
 #include "error.h"
 #include "stringtab.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #define LINE_LEN 1024
 
@@ -146,7 +146,7 @@ static void errors_push(errors_t* errors, errormsg_t* e)
 
 static void append_to_frame(errorframe_t* frame, errormsg_t* e)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
 
   if(*frame == NULL)
   {
@@ -262,14 +262,14 @@ void error_continue(errors_t* errors, source_t* source, size_t line, size_t pos,
 void errorframev(errorframe_t* frame, source_t* source, size_t line,
   size_t pos, const char* fmt, va_list ap)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
   append_to_frame(frame, make_errorv(source, line, pos, fmt, ap));
 }
 
 void errorframe(errorframe_t* frame, source_t* source, size_t line, size_t pos,
   const char* fmt, ...)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
 
   va_list ap;
   va_start(ap, fmt);
@@ -304,8 +304,8 @@ void errorf(errors_t* errors, const char* file, const char* fmt, ...)
 
 void errorframe_append(errorframe_t* first, errorframe_t* second)
 {
-  assert(first != NULL);
-  assert(second != NULL);
+  pony_assert(first != NULL);
+  pony_assert(second != NULL);
 
   append_to_frame(first, *second);
   *second = NULL;
@@ -313,13 +313,13 @@ void errorframe_append(errorframe_t* first, errorframe_t* second)
 
 bool errorframe_has_errors(errorframe_t* frame)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
   return frame != NULL;
 }
 
 void errorframe_report(errorframe_t* frame, errors_t* errors)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
 
   if(*frame != NULL)
     errors_push(errors, *frame);
@@ -329,7 +329,7 @@ void errorframe_report(errorframe_t* frame, errors_t* errors)
 
 void errorframe_discard(errorframe_t* frame)
 {
-  assert(frame != NULL);
+  pony_assert(frame != NULL);
 
   error_free(*frame);
   *frame = NULL;

--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -2,8 +2,8 @@
 #include "ast.h"
 #include "error.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static bool push_frame(typecheck_t* t)
 {
@@ -273,7 +273,7 @@ bool frame_push(typecheck_t* t, ast_t* ast)
 void frame_pop(typecheck_t* t)
 {
   typecheck_frame_t* f = t->frame;
-  assert(f != NULL);
+  pony_assert(f != NULL);
 
   t->frame = f->prev;
   POOL_FREE(typecheck_frame_t, f);

--- a/src/libponyc/ast/id.c
+++ b/src/libponyc/ast/id.c
@@ -1,16 +1,16 @@
-#include <assert.h>
+#include "ponyassert.h"
 #include "id.h"
 #include "id_internal.h"
 
 
 bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec)
 {
-  assert(id_node != NULL);
-  assert(ast_id(id_node) == TK_ID);
-  assert(desc != NULL);
+  pony_assert(id_node != NULL);
+  pony_assert(ast_id(id_node) == TK_ID);
+  pony_assert(desc != NULL);
 
   const char* name = ast_name(id_node);
-  assert(name != NULL);
+  pony_assert(name != NULL);
   char prev = '\0';
 
   // Ignore leading $, handled by lexer
@@ -111,7 +111,7 @@ bool check_id(pass_opt_t* opt, ast_t* id_node, const char* desc, int spec)
     return true;
 
   // Should only be ticks left
-  assert(*name == '\'');
+  pony_assert(*name == '\'');
 
   if((spec & ALLOW_TICK) == 0)
   {

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -4,11 +4,11 @@
 #include "token.h"
 #include "stringtab.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <math.h>
-#include <assert.h>
 
 
 struct lexer_t
@@ -384,7 +384,7 @@ static token_t* make_token_with_text(lexer_t* lexer, token_id id)
  */
 static void consume_chars(lexer_t* lexer, size_t count)
 {
-  assert(lexer->len >= count);
+  pony_assert(lexer->len >= count);
 
   if(count == 0)
     return;
@@ -754,7 +754,7 @@ static int escape(lexer_t* lexer, bool unicode_allowed, bool is_string)
 // Append the given value to the current token text, UTF-8 encoded
 static void append_utf8(lexer_t* lexer, int value)
 {
-  assert(value >= 0 && value <= 0x10FFFF);
+  pony_assert(value >= 0 && value <= 0x10FFFF);
 
   if(value <= 0x7F)
   {
@@ -955,7 +955,7 @@ static token_t* real(lexer_t* lexer, lexint_t* integral_value)
 
   uint32_t mantissa_digit_count = 0;
   char c = look(lexer);
-  assert(c == '.' || c == 'e' || c == 'E');
+  pony_assert(c == '.' || c == 'e' || c == 'E');
 
   if(c == '.')
   {
@@ -1208,7 +1208,7 @@ static token_t* symbol(lexer_t* lexer)
 
 lexer_t* lexer_open(source_t* source, errors_t* errors)
 {
-  assert(source != NULL);
+  pony_assert(source != NULL);
 
   lexer_t* lexer = POOL_ALLOC(lexer_t);
   memset(lexer, 0, sizeof(lexer_t));
@@ -1238,7 +1238,7 @@ void lexer_close(lexer_t* lexer)
 
 token_t* lexer_next(lexer_t* lexer)
 {
-  assert(lexer != NULL);
+  pony_assert(lexer != NULL);
 
   token_t* t = NULL;
 
@@ -1297,7 +1297,7 @@ token_t* lexer_next(lexer_t* lexer)
         else if(isalpha(c) || (c == '_'))
         {
           t = keyword(lexer, true);
-          assert(t != NULL);
+          pony_assert(t != NULL);
         }
         else
         {

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -1,7 +1,7 @@
 #include "parserapi.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
-#include <assert.h>
 #include <stdio.h>
 
 
@@ -68,9 +68,9 @@ static void consume_token_no_ast(parser_t* parser)
 static void syntax_error(parser_t* parser, const char* expected,
   ast_t* ast, const char* terminating)
 {
-  assert(parser != NULL);
-  assert(expected != NULL);
-  assert(parser->token != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(expected != NULL);
+  pony_assert(parser->token != NULL);
 
   if(parser->last_matched == NULL)
   {
@@ -87,7 +87,7 @@ static void syntax_error(parser_t* parser, const char* expected,
     }
     else
     {
-      assert(ast != NULL);
+      pony_assert(ast != NULL);
       ast_error(parser->errors, ast, "syntax error: unterminated %s",
         terminating);
       error_continue(parser->errors, parser->source,
@@ -103,8 +103,8 @@ static void syntax_error(parser_t* parser, const char* expected,
 
 static void default_builder(rule_state_t* state, ast_t* new_ast)
 {
-  assert(state != NULL);
-  assert(new_ast != NULL);
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL);
 
   // Existing AST goes at the top
 
@@ -131,8 +131,8 @@ static void default_builder(rule_state_t* state, ast_t* new_ast)
 
 void infix_builder(rule_state_t* state, ast_t* new_ast)
 {
-  assert(state != NULL);
-  assert(new_ast != NULL);
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL);
 
   // New AST goes at the top
   ast_add(new_ast, state->ast);
@@ -143,8 +143,8 @@ void infix_builder(rule_state_t* state, ast_t* new_ast)
 
 void infix_reverse_builder(rule_state_t* state, ast_t* new_ast)
 {
-  assert(state != NULL);
-  assert(new_ast != NULL);
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL);
 
   // New AST goes at the top, existing goes on the right
   ast_append(new_ast, state->ast);
@@ -156,8 +156,8 @@ void infix_reverse_builder(rule_state_t* state, ast_t* new_ast)
 
 static void annotation_builder(rule_state_t* state, ast_t* new_ast)
 {
-  assert(state != NULL);
-  assert(new_ast != NULL);
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL);
 
   ast_setannotation(state->ast, new_ast);
 }
@@ -168,8 +168,8 @@ static void annotation_builder(rule_state_t* state, ast_t* new_ast)
 // Process any deferred token we have
 static void process_deferred_ast(parser_t* parser, rule_state_t* state)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
 
   if(state->deferred)
   {
@@ -185,10 +185,10 @@ static void process_deferred_ast(parser_t* parser, rule_state_t* state)
 static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
   builder_fn_t build_fn)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
-  assert(new_ast != NULL && new_ast != PARSE_ERROR);
-  assert(build_fn != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
+  pony_assert(new_ast != NULL && new_ast != PARSE_ERROR);
+  pony_assert(build_fn != NULL);
 
   process_deferred_ast(parser, state);
 
@@ -209,7 +209,7 @@ static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
 // Add an AST node for the specified token, which may be deferred
 void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id)
 {
-  assert(parser->token != NULL);
+  pony_assert(parser->token != NULL);
 
   if(!state->matched && state->ast == NULL && !state->deferred)
   {
@@ -229,9 +229,9 @@ void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id)
 // The token set must be TK_NONE terminated
 static void ditch_restart(parser_t* parser, rule_state_t* state)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
-  assert(state->restart != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
+  pony_assert(state->restart != NULL);
 
   if(trace_enable)
     fprintf(stderr, "Rule %s: Attempting recovery:\n", state->fn_name);
@@ -265,8 +265,8 @@ static void ditch_restart(parser_t* parser, rule_state_t* state)
 // Propgate an error, handling AST tidy up and restart points
 static ast_t* propogate_error(parser_t* parser, rule_state_t* state)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
 
   ast_free(state->ast);
   state->ast = NULL;
@@ -297,8 +297,8 @@ static ast_t* propogate_error(parser_t* parser, rule_state_t* state)
 static ast_t* handle_found(parser_t* parser, rule_state_t* state,
   ast_t* new_ast, builder_fn_t build_fn, bool* out_found)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
 
   if(out_found != NULL)
     *out_found = true;
@@ -333,9 +333,9 @@ static ast_t* handle_found(parser_t* parser, rule_state_t* state,
 static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
   const char* desc, const char* terminating, bool* out_found)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
-  assert(desc != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
+  pony_assert(desc != NULL);
 
   if(out_found != NULL)
     *out_found = false;
@@ -401,9 +401,9 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
   const char* terminating, const token_id* id_set, bool make_ast,
   bool* out_found)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
-  assert(id_set != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
+  pony_assert(id_set != NULL);
 
   token_id id = current_token_id(parser);
 
@@ -427,7 +427,7 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
     // Match new line if the next token is the first on a line
     if(*p == TK_NEWLINE)
     {
-      assert(parser->token != NULL);
+      pony_assert(parser->token != NULL);
       size_t last_token_line = parser->last_token_line;
       size_t next_token_line = token_line_number(parser->token);
       bool is_newline = (next_token_line != last_token_line);
@@ -483,10 +483,10 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
   const rule_t* rule_set, bool* out_found, bool annotate)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
-  assert(desc != NULL);
-  assert(rule_set != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
+  pony_assert(desc != NULL);
+  pony_assert(rule_set != NULL);
 
   token_id id = current_token_id(parser);
 
@@ -525,7 +525,7 @@ ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
 // Set the data flags to use for the next token consumed from the source
 void parse_set_next_flags(parser_t* parser, uint32_t flags)
 {
-  assert(parser != NULL);
+  pony_assert(parser != NULL);
   parser->next_flags = flags;
 }
 
@@ -541,8 +541,8 @@ void parse_set_next_flags(parser_t* parser, uint32_t flags)
  */
 ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
 {
-  assert(parser != NULL);
-  assert(state != NULL);
+  pony_assert(parser != NULL);
+  pony_assert(state != NULL);
 
   process_deferred_ast(parser, state);
 
@@ -578,7 +578,7 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
   if(trace_enable)
     fprintf(stderr, "Rule %s: Restart check error\n", state->fn_name);
 
-  assert(parser->token != NULL);
+  pony_assert(parser->token != NULL);
   error(parser->errors, parser->source, token_line_number(parser->token),
     token_line_position(parser->token),
     "syntax error: unexpected token %s after %s", token_print(parser->token),
@@ -602,9 +602,9 @@ void parse_trace(bool enable)
 bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
   errors_t* errors)
 {
-  assert(package != NULL);
-  assert(source != NULL);
-  assert(expected != NULL);
+  pony_assert(package != NULL);
+  pony_assert(source != NULL);
+  pony_assert(expected != NULL);
 
   // Open the lexer
   lexer_t* lexer = lexer_open(source, errors);
@@ -658,8 +658,8 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     return false;
   }
 
-  assert(ast_id(ast) == TK_MODULE);
-  assert(ast_data(ast) == NULL);
+  pony_assert(ast_id(ast) == TK_MODULE);
+  pony_assert(ast_data(ast) == NULL);
   ast_setdata(ast, source);
   ast_add(package, ast);
   return true;

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -6,10 +6,10 @@
 #include "lexer.h"
 #include "ast.h"
 #include "token.h"
+#include "ponyassert.h"
 #include <stdbool.h>
 #include <limits.h>
 #include <stdio.h>
-#include <assert.h>
 
 PONY_EXTERN_C_BEGIN
 
@@ -449,7 +449,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
 #define REORDER(...) \
   { \
     static const size_t order[] = { __VA_ARGS__ }; \
-    assert(ast_childcount(state.ast) == (sizeof(order) / sizeof(size_t))); \
+    pony_assert(ast_childcount(state.ast) == (sizeof(order) / sizeof(size_t))); \
     static ast_t* shuffle[sizeof(order) / sizeof(size_t)]; \
     ast_reorder_children(state.ast, order, shuffle); \
     state.last_child = NULL; \

--- a/src/libponyc/ast/printbuf.c
+++ b/src/libponyc/ast/printbuf.c
@@ -1,8 +1,8 @@
 #include "printbuf.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 
 printbuf_t* printbuf_new()
 {
@@ -53,7 +53,7 @@ void printbuf(printbuf_t* buf, const char* fmt, ...)
     r = vsnprintf(buf->m + buf->offset, avail, fmt, ap);
     va_end(ap);
 
-    assert((r > 0) && ((size_t)r < buf->size));
+    pony_assert((r > 0) && ((size_t)r < buf->size));
   }
 
   buf->offset += r;

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -3,11 +3,11 @@
 #include "ast.h"
 #include "id.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
-#include <assert.h>
 
 static size_t sym_hash(symbol_t* sym)
 {

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -2,10 +2,10 @@
 #include "lexer.h"
 #include "stringtab.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 typedef struct token_t
 {
@@ -39,7 +39,7 @@ token_t* token_new(token_id id)
 
 token_t* token_dup(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   token_t* t = POOL_ALLOC(token_t);
   memcpy(t, token, sizeof(token_t));
   t->printed = NULL;
@@ -71,46 +71,46 @@ void token_free(token_t* token)
 
 token_id token_get_id(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   return token->id;
 }
 
 
 const char* token_string(token_t* token)
 {
-  assert(token != NULL);
-  assert(token->id == TK_STRING || token->id == TK_ID);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_STRING || token->id == TK_ID);
   return token->string;
 }
 
 
 size_t token_string_len(token_t* token)
 {
-  assert(token != NULL);
-  assert(token->id == TK_STRING || token->id == TK_ID);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_STRING || token->id == TK_ID);
   return token->str_length;
 }
 
 
 double token_float(token_t* token)
 {
-  assert(token != NULL);
-  assert(token->id == TK_FLOAT);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_FLOAT);
   return token->real;
 }
 
 
 lexint_t* token_int(token_t* token)
 {
-  assert(token != NULL);
-  assert(token->id == TK_INT);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_INT);
   return &token->integer;
 }
 
 
 const char* token_print(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
 
   switch(token->id)
   {
@@ -163,7 +163,7 @@ const char* token_print(token_t* token)
 
 char* token_print_escaped(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   const char* str = NULL;
   size_t str_len = 0;
 
@@ -244,21 +244,21 @@ const char* token_id_desc(token_id id)
 
 source_t* token_source(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   return token->source;
 }
 
 
 size_t token_line_number(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   return token->line;
 }
 
 
 size_t token_line_position(token_t* token)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   return token->pos;
 }
 
@@ -267,16 +267,16 @@ size_t token_line_position(token_t* token)
 
 void token_set_id(token_t* token, token_id id)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
   token->id = id;
 }
 
 
 void token_set_string(token_t* token, const char* value, size_t length)
 {
-  assert(token != NULL);
-  assert(token->id == TK_STRING || token->id == TK_ID);
-  assert(value != NULL);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_STRING || token->id == TK_ID);
+  pony_assert(value != NULL);
 
   if(length == 0)
     length = strlen(value);
@@ -288,23 +288,23 @@ void token_set_string(token_t* token, const char* value, size_t length)
 
 void token_set_float(token_t* token, double value)
 {
-  assert(token != NULL);
-  assert(token->id == TK_FLOAT);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_FLOAT);
   token->real = value;
 }
 
 
 void token_set_int(token_t* token, lexint_t* value)
 {
-  assert(token != NULL);
-  assert(token->id == TK_INT);
+  pony_assert(token != NULL);
+  pony_assert(token->id == TK_INT);
   token->integer = *value;
 }
 
 
 void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos)
 {
-  assert(token != NULL);
+  pony_assert(token != NULL);
 
   if(source != NULL)
     token->source = source;

--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -1,8 +1,8 @@
 #include "treecheck.h"
 #include "ast.h"
+#include "ponyassert.h"
 #include <stdbool.h>
 #include <stdio.h>
-#include <assert.h>
 
 
 // This define causes the tree checker to assert immediately on error, rather
@@ -36,7 +36,7 @@ typedef struct check_state_t
 // Print an error preamble for the given node.
 static void error_preamble(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   fprintf(stderr, "Internal error: AST node %d (%s), ", ast_id(ast),
     ast_get_print(ast));
@@ -47,7 +47,7 @@ static void error_preamble(ast_t* ast)
 // The id list must be TK_EOF terminated.
 static bool is_id_in_list(token_id id, const token_id* list)
 {
-  assert(list != NULL);
+  pony_assert(list != NULL);
 
   for(size_t i = 0; list[i] != TK_EOF; i++)
     if(list[i] == id)
@@ -62,8 +62,8 @@ static bool is_id_in_list(token_id id, const token_id* list)
 static check_res_t check_from_list(ast_t* ast, const check_fn_t *rules,
   errors_t* errors)
 {
-  assert(ast != NULL);
-  assert(rules != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(rules != NULL);
 
   // Check rules in given list
   for(const check_fn_t* p = rules; *p != NULL; p++)
@@ -84,9 +84,9 @@ static check_res_t check_from_list(ast_t* ast, const check_fn_t *rules,
 static bool check_children(ast_t* ast, check_state_t* state,
   const check_fn_t *rules, size_t min_count, size_t max_count, errors_t* errors)
 {
-  assert(ast != NULL);
-  assert(state != NULL);
-  assert(min_count <= max_count);
+  pony_assert(ast != NULL);
+  pony_assert(state != NULL);
+  pony_assert(min_count <= max_count);
 
   size_t found_count = 0;
 
@@ -120,7 +120,7 @@ static bool check_children(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
   }
   else
@@ -131,7 +131,7 @@ static bool check_children(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
   }
 
@@ -146,8 +146,8 @@ static bool check_children(ast_t* ast, check_state_t* state,
 static check_res_t check_extras(ast_t* ast, check_state_t* state,
   errors_t* errors)
 {
-  assert(ast != NULL);
-  assert(state != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(state != NULL);
 
 
   ast_t* type_field = ast_type(ast);
@@ -161,7 +161,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
       ast_error(state->errors, ast, "Here");
       ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-      assert(false);
+      pony_assert(false);
 #endif
       return CHK_ERROR;
     }
@@ -178,7 +178,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
       ast_error(state->errors, ast, "Here");
       ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-      assert(false);
+      pony_assert(false);
 #endif
       return CHK_ERROR;
     }
@@ -192,7 +192,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
     return CHK_ERROR;
   }
@@ -204,7 +204,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
     return CHK_ERROR;
   }
@@ -216,7 +216,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
     return CHK_ERROR;
   }
@@ -228,7 +228,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
     ast_error(state->errors, ast, "Here");
     ast_fprint(stderr, ast);
 #ifdef IMMEDIATE_FAIL
-    assert(false);
+    pony_assert(false);
 #endif
     return CHK_ERROR;
   }
@@ -307,9 +307,9 @@ void check_tree(ast_t* tree, errors_t* errors)
   (void)errors;
 #else
   // Only check tree in debug builds.
-  assert(tree != NULL);
+  pony_assert(tree != NULL);
   check_res_t r = check_root(tree, errors);
-  assert(r != CHK_ERROR);
+  pony_assert(r != CHK_ERROR);
 
   // Ignore CHK_NOT_FOUND, that means we weren't given a whole tree.
 #endif

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -13,13 +13,13 @@
 #include "../type/lookup.h"
 #include "../../libponyrt/mem/heap.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 
 #include <platform.h>
 #include <llvm-c/Initialization.h>
 #include <llvm-c/ExecutionEngine.h>
 #include <llvm-c/Linker.h>
 #include <string.h>
-#include <assert.h>
 
 struct compile_local_t
 {

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -2,7 +2,7 @@
 #include "gencall.h"
 #include "genname.h"
 #include "gentype.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
 {
@@ -12,7 +12,7 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
     return value;
 
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   if(l_type != t->primitive)
     return NULL;
@@ -40,7 +40,7 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
     return object;
 
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   if(t->primitive == NULL)
     return object;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -13,8 +13,8 @@
 #include "../ast/stringtab.h"
 #include "../../libponyrt/mem/pool.h"
 #include "../../libponyrt/mem/heap.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static LLVMValueRef invoke_fun(compile_t* c, LLVMValueRef fun,
   LLVMValueRef* args, int count, const char* ret, bool setcc)
@@ -227,7 +227,7 @@ static LLVMValueRef dispatch_function(compile_t* c, reach_type_t* t,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -303,7 +303,7 @@ static void set_method_external_interface(reach_type_t* t, const char* name)
 
 LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_BEREF));
+  pony_assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_BEREF));
   AST_GET_CHILDREN(ast, receiver, method);
   ast_t* typeargs = NULL;
 
@@ -325,7 +325,7 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
   // Get the receiver type.
   ast_t* type = ast_type(receiver);
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   const char* name = ast_name(method);
   token_id cap = cap_dispatch(type);
@@ -351,7 +351,7 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
         set_method_external_interface(t, name);
         break;
       default:
-        assert(0);
+        pony_assert(0);
         break;
     }
   }
@@ -446,7 +446,7 @@ static void tuple_indices_push(call_tuple_indices_t* ti, size_t idx)
 
 static size_t tuple_indices_pop(call_tuple_indices_t* ti)
 {
-  assert(ti->count > 0);
+  pony_assert(ti->count > 0);
 
   return ti->data[--ti->count];
 }
@@ -509,7 +509,7 @@ static bool can_inline_message_send(reach_type_t* t, reach_method_t* m,
       return false;
     }
 
-    assert(param_count == m_sub->param_count);
+    pony_assert(param_count == m_sub->param_count);
     for(size_t i = 0; i < param_count; i++)
     {
       // If the param is a boxable type for us and an unboxable type for one of
@@ -561,7 +561,7 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   const char* method_name = ast_name(method);
   ast_t* type = ast_type(receiver);
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   // Generate the arguments.
   size_t count = ast_childcount(positional) + 1;
@@ -667,7 +667,7 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
         return NULL;
     }
   } else {
@@ -828,7 +828,7 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
   // Generate the receiver.
   LLVMValueRef l_value = gen_expr(c, pattern);
   reach_type_t* t = reach_type(c->reach, pattern_type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   // Static or virtual dispatch.
   token_id cap = cap_dispatch(pattern_type);
@@ -893,7 +893,7 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
       p_type = ast_childidx(arg, 1);
 
     reach_type_t* pt = reach_type(c->reach, p_type);
-    assert(pt != NULL);
+    pony_assert(pt != NULL);
 
     // An intrinsic that takes a Bool should be i1, not ibool.
     if(intrinsic && is_bool(pt->ast))
@@ -1007,7 +1007,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
   // Get the return type.
   ast_t* type = ast_type(ast);
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   // Get the function.
   LLVMValueRef func = LLVMGetNamedFunction(c->module, f_name);

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -5,7 +5,7 @@
 #include "../pass/expr.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 LLVMValueRef gen_seq(compile_t* c, ast_t* ast)
@@ -549,7 +549,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   // This backwards-incompatible API change to LLVMBuildLandingPad is only in
   // LLVM 3.7.0. In 3.7.1 and all later versions, backward-compatibility was
   // restored.
-  assert((c->frame->fun != NULL) && "No function in current frame!");
+  pony_assert((c->frame->fun != NULL) && "No function in current frame!");
   LLVMSetPersonalityFn(c->frame->fun, c->personality);
   LLVMValueRef landing = LLVMBuildLandingPad(c->builder, lp_type, 1, "");
 #else

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -4,8 +4,8 @@
 #include "../type/reify.h"
 #include "../ast/stringtab.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #define DESC_ID 0
 #define DESC_SIZE 1
@@ -308,8 +308,8 @@ static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
     while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
     {
       uint32_t index = m->vtable_index;
-      assert(index != (uint32_t)-1);
-      assert(vtable[index] == NULL);
+      pony_assert(index != (uint32_t)-1);
+      pony_assert(vtable[index] == NULL);
 
       if(t->primitive != NULL)
         vtable[index] = make_unbox_function(c, t, m);
@@ -604,7 +604,7 @@ LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return GEN_NOVALUE;
 }
 
@@ -612,7 +612,7 @@ LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
 {
   // Get the trait identifier.
   reach_type_t* t = reach_type(c->reach, type);
-  assert(t != NULL);
+  pony_assert(t != NULL);
   LLVMValueRef trait_id = LLVMConstInt(c->i32, t->type_id, false);
 
   // Read the count and the trait list from the descriptor.

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -11,8 +11,8 @@
 #include "../type/assemble.h"
 #include "../type/lookup.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #ifdef PLATFORM_IS_POSIX_BASED
 #  include <unistd.h>

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -9,7 +9,7 @@
 #include "gencall.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
 {
@@ -97,7 +97,7 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
         case TK_PARAMREF:
           break;
         default:
-          assert(0);
+          pony_assert(0);
           break;
       }
       break;
@@ -209,7 +209,7 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
   LLVMValueRef r_value, ast_t* type)
 {
   // Cast each component.
-  assert(ast_id(type) == TK_TUPLETYPE);
+  pony_assert(ast_id(type) == TK_TUPLETYPE);
 
   int count = LLVMCountStructElementTypes(l_type);
   size_t buf_size = count * sizeof(LLVMTypeRef);
@@ -265,7 +265,7 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
       if((r_type == c->i1) && (l_type == c->ibool))
         return LLVMBuildZExt(c->builder, r_value, l_type, "");
 
-      assert(LLVMGetTypeKind(r_type) == LLVMPointerTypeKind);
+      pony_assert(LLVMGetTypeKind(r_type) == LLVMPointerTypeKind);
       return gen_unbox(c, type, r_value);
     }
 
@@ -284,7 +284,7 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
       if(LLVMGetTypeKind(r_type) == LLVMPointerTypeKind)
       {
         r_value = gen_unbox(c, type, r_value);
-        assert(LLVMGetTypeKind(LLVMTypeOf(r_value)) == LLVMStructTypeKind);
+        pony_assert(LLVMGetTypeKind(LLVMTypeOf(r_value)) == LLVMStructTypeKind);
       }
 
       return assign_to_tuple(c, l_type, r_value, type);
@@ -293,6 +293,6 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -13,8 +13,8 @@
 #include "../../libponyrt/ds/fun.h"
 #include "../../libponyrt/mem/pool.h"
 #include "../../libponyrt/mem/heap.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static void name_param(compile_t* c, reach_type_t* t,
   reach_method_t* m, LLVMValueRef func, const char* name, unsigned index,
@@ -169,7 +169,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return;
   }
 
@@ -221,7 +221,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
   {
     // Store the finaliser and use the C calling convention and an external
     // linkage.
-    assert(t->final_fn == NULL);
+    pony_assert(t->final_fn == NULL);
     t->final_fn = m->func;
     LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
     LLVMSetLinkage(m->func, LLVMExternalLinkage);
@@ -320,7 +320,7 @@ static void call_embed_finalisers(compile_t* c, reach_type_t* t,
 
 static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
-  assert(m->func != NULL);
+  pony_assert(m->func != NULL);
 
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
@@ -365,8 +365,8 @@ static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
 
 static bool genfun_be(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
-  assert(m->func != NULL);
-  assert(m->func_handler != NULL);
+  pony_assert(m->func != NULL);
+  pony_assert(m->func_handler != NULL);
 
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
@@ -411,7 +411,7 @@ static bool genfun_be(compile_t* c, reach_type_t* t, reach_method_t* m)
 
 static bool genfun_new(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
-  assert(m->func != NULL);
+  pony_assert(m->func != NULL);
 
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
@@ -442,8 +442,8 @@ static bool genfun_new(compile_t* c, reach_type_t* t, reach_method_t* m)
 
 static bool genfun_newbe(compile_t* c, reach_type_t* t, reach_method_t* m)
 {
-  assert(m->func != NULL);
-  assert(m->func_handler != NULL);
+  pony_assert(m->func != NULL);
+  pony_assert(m->func_handler != NULL);
 
   AST_GET_CHILDREN(m->r_fun, cap, id, typeparams, params, result, can_error,
     body);
@@ -553,7 +553,7 @@ static bool genfun_allocator(compile_t* c, reach_type_t* t)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -565,11 +565,11 @@ static bool genfun_allocator(compile_t* c, reach_type_t* t)
 static bool genfun_forward(compile_t* c, reach_type_t* t,
   reach_method_name_t* n,  reach_method_t* m)
 {
-  assert(m->func != NULL);
+  pony_assert(m->func != NULL);
 
   reach_method_t* m2 = reach_method(t, m->cap, n->name, m->typeargs);
-  assert(m2 != NULL);
-  assert(m2 != m);
+  pony_assert(m2 != NULL);
+  pony_assert(m2 != m);
 
   codegen_startfun(c, m->func, m->di_file, m->di_method);
 
@@ -656,7 +656,7 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
 #endif
             break;
           default:
-            assert(0);
+            pony_assert(0);
         }
       }
     }
@@ -744,7 +744,7 @@ bool genfun_method_bodies(compile_t* c, reach_type_t* t)
             break;
 
           default:
-            assert(0);
+            pony_assert(0);
             return false;
         }
       }

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -6,8 +6,8 @@
 #include "../type/reify.h"
 #include "../ast/printbuf.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static const char* c_type_name(compile_t* c, const char* name)
 {

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -1,7 +1,7 @@
 #include "genident.h"
 #include "gendesc.h"
 #include "genexpr.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
   ast_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value);
@@ -9,9 +9,9 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
 static LLVMValueRef tuple_is(compile_t* c, ast_t* left_type, ast_t* right_type,
   LLVMValueRef l_value, LLVMValueRef r_value)
 {
-  assert(ast_id(left_type) == TK_TUPLETYPE);
-  assert(ast_id(right_type) == TK_TUPLETYPE);
-  assert(ast_childcount(left_type) == ast_childcount(right_type));
+  pony_assert(ast_id(left_type) == TK_TUPLETYPE);
+  pony_assert(ast_id(right_type) == TK_TUPLETYPE);
+  pony_assert(ast_childcount(left_type) == ast_childcount(right_type));
 
   // Pairwise comparison.
   LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
@@ -115,7 +115,7 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -11,7 +11,7 @@
 #include "../type/alias.h"
 #include "../type/viewpoint.h"
 #include "../type/lookup.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 typedef enum
 {
@@ -231,7 +231,7 @@ static bool check_type(compile_t* c, LLVMValueRef ptr, LLVMValueRef desc,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -328,7 +328,7 @@ static bool dynamic_tuple_ptr(compile_t* c, LLVMValueRef ptr,
 
   for(int i = 0; pattern_child != NULL; i++)
   {
-    assert(ast_id(pattern_child) == TK_SEQ);
+    pony_assert(ast_id(pattern_child) == TK_SEQ);
 
     // Skip over the SEQ node.
     ast_t* pattern_expr = ast_child(pattern_child);
@@ -537,7 +537,7 @@ static bool static_tuple_from_tuple(compile_t* c, LLVMValueRef value,
   // The match expression is a tuple. The type checker will have made sure
   // it's the right cardinality and each element has a useful type relation
   // with the pattern.
-  assert(LLVMGetTypeKind(LLVMTypeOf(value)) == LLVMStructTypeKind);
+  pony_assert(LLVMGetTypeKind(LLVMTypeOf(value)) == LLVMStructTypeKind);
 
   // We have a static type.
   ast_t* type_child = ast_child(type);
@@ -546,7 +546,7 @@ static bool static_tuple_from_tuple(compile_t* c, LLVMValueRef value,
   // Destructure the tuple and continue pattern matching on each element.
   for(int i = 0; pattern_child != NULL; i++)
   {
-    assert(ast_id(pattern_child) == TK_SEQ);
+    pony_assert(ast_id(pattern_child) == TK_SEQ);
 
     // Skip over the SEQ node.
     ast_t* pattern_expr = ast_child(pattern_child);
@@ -559,7 +559,7 @@ static bool static_tuple_from_tuple(compile_t* c, LLVMValueRef value,
     pattern_child = ast_sibling(pattern_child);
   }
 
-  assert(type_child == NULL);
+  pony_assert(type_child == NULL);
   return true;
 }
 
@@ -601,7 +601,7 @@ static bool static_value(compile_t* c, LLVMValueRef value, ast_t* type,
   if(!is_subtype(type, param_type, NULL, c->opt))
   {
     // Switch to dynamic value checking.
-    assert(LLVMTypeOf(value) == c->object_ptr);
+    pony_assert(LLVMTypeOf(value) == c->object_ptr);
     LLVMValueRef desc = gendesc_fetch(c, value);
     return dynamic_value_object(c, value, desc, pattern, next_block);
   }
@@ -625,7 +625,7 @@ static bool static_capture(compile_t* c, LLVMValueRef value, ast_t* type,
   if(!is_subtype(type, pattern_type, NULL, c->opt))
   {
     // Switch to dynamic capture.
-    assert(LLVMTypeOf(value) == c->object_ptr);
+    pony_assert(LLVMTypeOf(value) == c->object_ptr);
     LLVMValueRef desc = gendesc_fetch(c, value);
     return dynamic_capture_object(c, value, desc, pattern, next_block);
   }
@@ -654,8 +654,8 @@ static bool static_match(compile_t* c, LLVMValueRef value, ast_t* type,
       // during type checking.
       ast_t* child = ast_child(pattern);
 
-      assert(child != NULL);
-      assert(ast_sibling(child) == NULL);
+      pony_assert(child != NULL);
+      pony_assert(ast_sibling(child) == NULL);
 
       // Pass on the element in the seq instead of the seq.
       return static_match(c, value, type, child, next_block);
@@ -664,8 +664,8 @@ static bool static_match(compile_t* c, LLVMValueRef value, ast_t* type,
     case TK_TUPLE:
     {
       // Tuples must have multiple elements, or they aren't tuples.
-      assert(ast_child(pattern) != NULL);
-      assert(ast_sibling(ast_child(pattern)) != NULL);
+      pony_assert(ast_child(pattern) != NULL);
+      pony_assert(ast_sibling(ast_child(pattern)) != NULL);
 
       // Destructure the match expression (or element thereof).
       return static_tuple(c, value, type, pattern, next_block);

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -3,8 +3,8 @@
 #include "../ast/stringtab.h"
 #include "../ast/lexer.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static void types_append(printbuf_t* buf, ast_t* elements);
 
@@ -60,7 +60,7 @@ static void type_append(printbuf_t* buf, ast_t* type, bool first)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
 }
 
 static void types_append(printbuf_t* buf, ast_t* elements)
@@ -91,7 +91,7 @@ static const char* stringtab_two(const char* a, const char* b)
   if(a == NULL)
     a = "_";
 
-  assert(b != NULL);
+  pony_assert(b != NULL);
   printbuf_t* buf = printbuf_new();
   printbuf(buf, "%s_%s", a, b);
   return stringtab_buf(buf);

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -6,7 +6,7 @@
 #include "gentype.h"
 #include "../pkg/platformfuns.h"
 #include "../type/subtype.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 typedef LLVMValueRef (*const_binop)(LLVMValueRef left, LLVMValueRef right);
 
@@ -396,7 +396,7 @@ static bool assign_tuple(compile_t* c, ast_t* left, ast_t* r_type,
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
     }
 
     if(expr != NULL)
@@ -415,7 +415,7 @@ static bool assign_tuple(compile_t* c, ast_t* left, ast_t* r_type,
     rtype_child = ast_sibling(rtype_child);
   }
 
-  assert(rtype_child == NULL);
+  pony_assert(rtype_child == NULL);
   return true;
 }
 
@@ -428,7 +428,7 @@ static LLVMValueRef assign_rvalue(compile_t* c, ast_t* left, ast_t* r_type,
       // The actual expression is inside a sequence node.
       while(ast_id(left) == TK_SEQ)
       {
-        assert(ast_childcount(left) == 1);
+        pony_assert(ast_childcount(left) == 1);
         left = ast_child(left);
       }
       return assign_rvalue(c, left, r_type, r_value);
@@ -509,7 +509,7 @@ static LLVMValueRef assign_rvalue(compile_t* c, ast_t* left, ast_t* r_type,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -650,7 +650,7 @@ LLVMValueRef gen_shl(compile_t* c, ast_t* left, ast_t* right, bool safe)
     return NULL;
 
   LLVMTypeRef l_type = LLVMTypeOf(l_value);
-  assert(LLVMGetTypeKind(l_type) == LLVMIntegerTypeKind);
+  pony_assert(LLVMGetTypeKind(l_type) == LLVMIntegerTypeKind);
   unsigned width = LLVMGetIntTypeWidth(l_type);
 
   if(LLVMIsConstant(r_value))
@@ -703,7 +703,7 @@ LLVMValueRef gen_shr(compile_t* c, ast_t* left, ast_t* right, bool safe)
     return NULL;
 
   LLVMTypeRef l_type = LLVMTypeOf(l_value);
-  assert(LLVMGetTypeKind(l_type) == LLVMIntegerTypeKind);
+  pony_assert(LLVMGetTypeKind(l_type) == LLVMIntegerTypeKind);
   unsigned width = LLVMGetIntTypeWidth(l_type);
 
   if(LLVMIsConstant(r_value))

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -31,6 +31,7 @@
 #include <llvm/ADT/SmallSet.h>
 
 #include "../../libponyrt/mem/heap.h"
+#include "ponyassert.h"
 
 #ifdef _MSC_VER
 #  pragma warning(pop)
@@ -467,7 +468,7 @@ public:
     if(name.size() < 10 || name.rfind("_Dispatch") != name.size() - 9)
       return false;
 
-    assert(f.arg_size() > 0);
+    pony_assert(f.arg_size() > 0);
 
     Value* ctx = &(*f.arg_begin());
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -10,8 +10,8 @@
 #include "../type/assemble.h"
 #include "../type/cap.h"
 #include "../../libponyrt/mem/heap.h"
+#include "ponyassert.h"
 
-#include <assert.h>
 #include <string.h>
 
 #define FIND_METHOD(name, cap) \
@@ -1707,7 +1707,7 @@ static void number_conversions(compile_t* c)
   else if(target_is_llp64(c->opt->triple))
     conv = llp64_conv;
 
-  assert(conv != NULL);
+  pony_assert(conv != NULL);
 
   void* data[3];
   data[2] = (void*)target_is_native128(c->opt->triple);

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -7,8 +7,8 @@
 #include "../type/cap.h"
 #include "../type/subtype.h"
 #include "../type/viewpoint.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 LLVMValueRef gen_this(compile_t* c, ast_t* ast)
 {
@@ -31,7 +31,7 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
   {
     case TK_NOMINAL:
     {
-      assert(ast_id(right) == TK_ID);
+      pony_assert(ast_id(right) == TK_ID);
 
       ast_t* def = (ast_t*)ast_data(l_type);
       ast_t* field = ast_get(def, ast_name(right), NULL);
@@ -48,7 +48,7 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
 
     case TK_TUPLETYPE:
     {
-      assert(ast_id(right) == TK_INT);
+      pony_assert(ast_id(right) == TK_INT);
       int index = (int)ast_int(right)->low;
 
       return LLVMBuildExtractValue(c->builder, l_value, index, "");
@@ -60,7 +60,7 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -87,7 +87,7 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   if(field == NULL)
     return NULL;
 
-  assert((ast_id(l_type) == TK_NOMINAL) || (ast_id(l_type) == TK_TUPLETYPE));
+  pony_assert((ast_id(l_type) == TK_NOMINAL) || (ast_id(l_type) == TK_TUPLETYPE));
 
   // Don't load if we're reading from a tuple.
   if(ast_id(l_type) != TK_TUPLETYPE)
@@ -202,7 +202,7 @@ LLVMValueRef gen_localptr(compile_t* c, ast_t* ast)
   const char* name = ast_name(id);
 
   LLVMValueRef value = codegen_getlocal(c, name);
-  assert(value != NULL);
+  pony_assert(value != NULL);
 
   return value;
 }
@@ -236,7 +236,7 @@ LLVMValueRef gen_addressof(compile_t* c, ast_t* ast)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -292,7 +292,7 @@ static LLVMValueRef gen_digestof_value(compile_t* c, LLVMValueRef value)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -6,7 +6,7 @@
 #include "../type/cap.h"
 #include "../type/matchtype.h"
 #include "../type/subtype.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 // Arranged from most specific to least specific.
 typedef enum
@@ -67,7 +67,7 @@ static trace_t trace_union_machine_word(trace_t a)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -98,7 +98,7 @@ static trace_t trace_union_primitive(trace_t a)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -123,7 +123,7 @@ static trace_t trace_union_val(trace_t a)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -148,7 +148,7 @@ static trace_t trace_union_mut(trace_t a)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -173,7 +173,7 @@ static trace_t trace_union_tag(trace_t a)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -195,7 +195,7 @@ static trace_t trace_type_union(ast_t* type)
 
       case TRACE_MAYBE:
         // Can't be in a union.
-        assert(0);
+        pony_assert(0);
         return TRACE_NONE;
 
       case TRACE_MACHINE_WORD:
@@ -227,7 +227,7 @@ static trace_t trace_type_union(ast_t* type)
 
       case TRACE_STATIC:
         // Can't happen here.
-        assert(0);
+        pony_assert(0);
         return TRACE_DYNAMIC;
     }
   }
@@ -250,7 +250,7 @@ static trace_t trace_type_isect(ast_t* type)
       case TRACE_NONE:
       case TRACE_MAYBE:
         // Can't be in an isect.
-        assert(0);
+        pony_assert(0);
         return TRACE_NONE;
 
       case TRACE_PRIMITIVE:
@@ -280,7 +280,7 @@ static trace_t trace_type_isect(ast_t* type)
 
       case TRACE_STATIC:
         // Can't happen here.
-        assert(0);
+        pony_assert(0);
         break;
     }
   }
@@ -339,7 +339,7 @@ static trace_t trace_type_nominal(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_NONE;
 }
 
@@ -362,7 +362,7 @@ static trace_t trace_type(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TRACE_DYNAMIC;
 }
 
@@ -453,11 +453,11 @@ static trace_t trace_type_dst_cap(trace_t src_trace, trace_t dst_trace,
 
     case TRACE_STATIC:
       // Can't happen here.
-      assert(0);
+      pony_assert(0);
       return src_trace;
 
     default:
-      assert(0);
+      pony_assert(0);
       return src_trace;
   }
 }
@@ -509,7 +509,7 @@ static void trace_unknown(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
   ast_t* tuple)
 {
-  assert(ast_id(type) == TK_NOMINAL);
+  pony_assert(ast_id(type) == TK_NOMINAL);
 
   ast_t* cap = cap_fetch(type);
 
@@ -559,7 +559,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
     }
   }
 
-  assert(ast_id(cap) == TK_TAG);
+  pony_assert(ast_id(cap) == TK_TAG);
 
   int ret = -1;
   if(is_matchtype(orig, type, opt) == MATCHTYPE_ACCEPT)
@@ -572,10 +572,10 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
 static void trace_static(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   ast_t* src_type, ast_t* dst_type)
 {
-  assert(ast_id(src_type) == TK_NOMINAL);
+  pony_assert(ast_id(src_type) == TK_NOMINAL);
 
   int mutability = trace_cap_nominal(c->opt, src_type, dst_type, NULL);
-  assert(mutability != -1);
+  pony_assert(mutability != -1);
 
   if(is_known(src_type))
     trace_known(c, ctx, object, src_type, mutability);
@@ -602,13 +602,13 @@ static void trace_tuple(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,
       src_child = ast_sibling(src_child);
       dst_child = ast_sibling(dst_child);
     }
-    assert(src_child == NULL && dst_child == NULL);
+    pony_assert(src_child == NULL && dst_child == NULL);
   } else {
     // This is a boxed tuple. Trace the box, then handle the elements.
     trace_unknown(c, ctx, dst_value, PONY_TRACE_OPAQUE);
 
     // Extract the elements from the original unboxed tuple.
-    assert(LLVMGetTypeKind(LLVMTypeOf(src_value)) == LLVMStructTypeKind);
+    pony_assert(LLVMGetTypeKind(LLVMTypeOf(src_value)) == LLVMStructTypeKind);
 
     ast_t* src_child = ast_child(src_type);
     while(src_child != NULL)
@@ -765,7 +765,7 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
   LLVMValueRef object, ast_t* type, ast_t* orig, ast_t* tuple,
   LLVMBasicBlockRef next_block)
 {
-  assert(ast_id(type) == TK_NOMINAL);
+  pony_assert(ast_id(type) == TK_NOMINAL);
 
   // Skip if a primitive.
   ast_t* def = (ast_t*)ast_data(type);
@@ -860,7 +860,7 @@ bool gentrace_needed(compile_t* c, ast_t* src_type, ast_t* dst_type)
   switch(trace_type(src_type))
   {
     case TRACE_NONE:
-      assert(0);
+      pony_assert(0);
       return false;
 
     case TRACE_MACHINE_WORD:
@@ -890,7 +890,7 @@ bool gentrace_needed(compile_t* c, ast_t* src_type, ast_t* dst_type)
           src_child = ast_sibling(src_child);
           dst_child = ast_sibling(dst_child);
         }
-        assert(src_child == NULL && dst_child == NULL);
+        pony_assert(src_child == NULL && dst_child == NULL);
       } else {
         // This is a boxed tuple. We'll have to trace the box anyway.
         return true;
@@ -949,7 +949,7 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,
   switch(trace_method)
   {
     case TRACE_NONE:
-      assert(0);
+      pony_assert(0);
       return;
 
     case TRACE_MACHINE_WORD:

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -12,9 +12,9 @@
 #include "../type/reify.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 static size_t tbaa_metadata_hash(tbaa_metadata_t* a)
 {
@@ -45,7 +45,7 @@ void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_mds)
 
 LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type)
 {
-  assert(ast_id(type) == TK_NOMINAL);
+  pony_assert(ast_id(type) == TK_NOMINAL);
 
   const char* name = genname_type_and_cap(type);
   tbaa_metadata_t k;
@@ -250,7 +250,7 @@ static bool make_opaque_struct(compile_t* c, reach_type_t* t)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -331,7 +331,7 @@ static void make_debug_info(compile_t* c, reach_type_t* t)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
 }
 
 static void make_box_type(compile_t* c, reach_type_t* t)
@@ -459,7 +459,7 @@ static bool make_struct(compile_t* c, reach_type_t* t)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -483,7 +483,7 @@ static bool make_struct(compile_t* c, reach_type_t* t)
 
     if(elements[i + extra] == NULL)
     {
-      assert(0);
+      pony_assert(0);
       return false;
     }
   }
@@ -619,7 +619,7 @@ static void make_debug_final(compile_t* c, reach_type_t* t)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
 }
 
 static void make_intrinsic_methods(compile_t* c, reach_type_t* t)
@@ -760,7 +760,7 @@ bool gentypes(compile_t* c)
   // Cache the instance of None, which is used as the return value for
   // behaviour calls.
   t = reach_type_name(c->reach, "None");
-  assert(t != NULL);
+  pony_assert(t != NULL);
   c->none_instance = t->instance;
 
   if(c->opt->verbosity >= VERBOSITY_INFO)

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include "codegen.h"
+#include "ponyassert.h"
 
 using namespace llvm;
 
@@ -37,7 +38,7 @@ char* LLVMGetHostCPUFeatures()
 {
   StringMap<bool> features;
   bool got_features = sys::getHostCPUFeatures(features);
-  assert(got_features);
+  pony_assert(got_features);
   (void)got_features;
 
   // Calculate the size of buffer that will be needed to return all features.
@@ -46,7 +47,7 @@ char* LLVMGetHostCPUFeatures()
     buf_size += (*it).getKey().str().length() + 2; // plus +/- char and ,/null
 
   char* buf = (char*)malloc(buf_size);
-  assert(buf != NULL);
+  pony_assert(buf != NULL);
   buf[0] = 0;
 
   for(auto it = features.begin(); it != features.end();)
@@ -123,7 +124,7 @@ void LLVMSetCallInaccessibleMemOnly(LLVMValueRef inst)
     c->addAttribute(AttributeSet::FunctionIndex,
       Attribute::InaccessibleMemOnly);
   else
-    assert(0);
+    pony_assert(0);
 }
 
 void LLVMSetInaccessibleMemOrArgMemOnly(LLVMValueRef fun)
@@ -141,7 +142,7 @@ void LLVMSetCallInaccessibleMemOrArgMemOnly(LLVMValueRef inst)
     c->addAttribute(AttributeSet::FunctionIndex,
       Attribute::InaccessibleMemOrArgMemOnly);
   else
-    assert(0);
+    pony_assert(0);
 }
 #  endif
 #endif
@@ -187,7 +188,7 @@ LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file)
 static MDNode* extractMDNode(MetadataAsValue* mdv)
 {
   Metadata* md = mdv->getMetadata();
-  assert(isa<MDNode>(md) || isa<ConstantAsMetadata>(md));
+  pony_assert(isa<MDNode>(md) || isa<ConstantAsMetadata>(md));
 
   MDNode* n = dyn_cast<MDNode>(md);
   if(n != NULL)
@@ -198,7 +199,7 @@ static MDNode* extractMDNode(MetadataAsValue* mdv)
 
 void LLVMSetMetadataStr(LLVMValueRef inst, const char* str, LLVMValueRef node)
 {
-  assert(node != NULL);
+  pony_assert(node != NULL);
 
   MDNode* n = extractMDNode(unwrap<MetadataAsValue>(node));
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -15,7 +15,7 @@
 #include "../type/sanitise.h"
 #include "../type/subtype.h"
 #include "../type/viewpoint.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool insert_apply(pass_opt_t* opt, ast_t** astp)
 {
@@ -84,7 +84,7 @@ static bool check_type_params(pass_opt_t* opt, ast_t** astp)
     return false;
 
   ast_t* typeparams = ast_childidx(type, 1);
-  assert(ast_id(type) == TK_FUNTYPE);
+  pony_assert(ast_id(type) == TK_FUNTYPE);
 
   if(ast_id(typeparams) == TK_NONE)
     return true;
@@ -302,7 +302,7 @@ static bool auto_recover_call(ast_t* ast, ast_t* receiver_type,
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       break;
   }
 
@@ -390,7 +390,7 @@ static bool check_receiver_cap(pass_opt_t* opt, ast_t* ast, bool* recovered)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
   }
 
   if(can_recover && cap_recover)
@@ -655,7 +655,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
 
   // LHS must be an application, possibly wrapped in another application
   // if the method had type parameters for qualification.
-  assert(ast_id(lhs) == TK_FUNAPP || ast_id(lhs) == TK_BEAPP ||
+  pony_assert(ast_id(lhs) == TK_FUNAPP || ast_id(lhs) == TK_BEAPP ||
     ast_id(lhs) == TK_NEWAPP);
   AST_GET_CHILDREN(lhs, receiver, method);
   ast_t* type_args = NULL;
@@ -668,12 +668,12 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
 
   // Look up the original method definition for this method call.
   ast_t* method_def = lookup(opt, lhs, ast_type(receiver), ast_name(method));
-  assert(ast_id(method_def) == TK_FUN || ast_id(method_def) == TK_BE ||
+  pony_assert(ast_id(method_def) == TK_FUN || ast_id(method_def) == TK_BE ||
     ast_id(method_def) == TK_NEW);
 
   // The TK_FUNTYPE of the LHS.
   ast_t* type = ast_type(lhs);
-  assert(ast_id(type) == TK_FUNTYPE);
+  pony_assert(ast_id(type) == TK_FUNTYPE);
 
   if(is_typecheck_error(type))
     return false;
@@ -702,7 +702,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
 
   while(given_arg != NULL)
   {
-    assert(target_param != NULL);
+    pony_assert(target_param != NULL);
     const char* target_p_name = ast_name(ast_child(target_param));
 
     if(ast_id(given_arg) == TK_NONE)
@@ -760,7 +760,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
     target_param = ast_sibling(target_param);
   }
 
-  assert(target_param == NULL);
+  pony_assert(target_param == NULL);
 
   // Build lambda expression.
   // `$0.f`

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -10,7 +10,7 @@
 #include "../type/assemble.h"
 #include "../type/subtype.h"
 #include "../type/alias.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 bool expr_seq(pass_opt_t* opt, ast_t* ast)
 {
@@ -80,7 +80,7 @@ bool expr_seq(pass_opt_t* opt, ast_t* ast)
 // an if.
 static bool resolve_ifdef(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // We turn the ifdef node into an if so that codegen doesn't need to know
   // about ifdefs at all.
@@ -386,7 +386,7 @@ bool expr_break(pass_opt_t* opt, ast_t* ast)
   }
 
   // break is always the last expression in a sequence
-  assert(ast_sibling(ast) == NULL);
+  pony_assert(ast_sibling(ast) == NULL);
 
   ast_settype(ast, ast_from(ast, TK_BREAK));
 
@@ -431,7 +431,7 @@ bool expr_continue(pass_opt_t* opt, ast_t* ast)
   }
 
   // continue is always the last expression in a sequence
-  assert(ast_sibling(ast) == NULL);
+  pony_assert(ast_sibling(ast) == NULL);
 
   ast_settype(ast, ast_from(ast, TK_CONTINUE));
   return true;
@@ -442,14 +442,14 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
   typecheck_t* t = &opt->check;
 
   // return is always the last expression in a sequence
-  assert(ast_sibling(ast) == NULL);
+  pony_assert(ast_sibling(ast) == NULL);
 
   ast_t* parent = ast_parent(ast);
   ast_t* current = ast;
 
   while(ast_id(parent) == TK_SEQ)
   {
-    assert(ast_childlast(parent) == current);
+    pony_assert(ast_childlast(parent) == current);
     current = parent;
     parent = ast_parent(parent);
   }
@@ -493,7 +493,7 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
       break;
 
     case TK_BE:
-      assert(is_none(body_type));
+      pony_assert(is_none(body_type));
       break;
 
     default:
@@ -532,7 +532,7 @@ bool expr_error(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
   // error is always the last expression in a sequence
-  assert(ast_sibling(ast) == NULL);
+  pony_assert(ast_sibling(ast) == NULL);
 
   ast_settype(ast, ast_from(ast, TK_ERROR));
   return true;
@@ -542,7 +542,7 @@ bool expr_compile_error(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
   // compile_error is always the last expression in a sequence
-  assert(ast_sibling(ast) == NULL);
+  pony_assert(ast_sibling(ast) == NULL);
 
   ast_settype(ast, ast_from(ast, TK_COMPILE_ERROR));
   return true;

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -2,12 +2,12 @@
 #include "literal.h"
 #include "../type/subtype.h"
 #include "../pkg/ifdef.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool void_star_param(ast_t* param_type, ast_t* arg_type)
 {
-  assert(param_type != NULL);
-  assert(arg_type != NULL);
+  pony_assert(param_type != NULL);
+  pony_assert(arg_type != NULL);
 
   if(!is_pointer(param_type))
     return false;
@@ -32,9 +32,9 @@ static bool void_star_param(ast_t* param_type, ast_t* arg_type)
 
 static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
 {
-  assert(call != NULL);
-  assert(decl != NULL);
-  assert(ast_id(decl) == TK_FFIDECL);
+  pony_assert(call != NULL);
+  pony_assert(decl != NULL);
+  pony_assert(ast_id(decl) == TK_FFIDECL);
 
   AST_GET_CHILDREN(call, call_name, call_ret_typeargs, args, named_args,
     call_error);
@@ -120,7 +120,7 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
 bool expr_ffi(pass_opt_t* opt, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, name, return_typeargs, args, namedargs, question);
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   ast_t* decl;
   if(!ffi_get_decl(&opt->check, ast, &decl, opt))

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -8,7 +8,7 @@
 #include "../pass/syntax.h"
 #include "../type/alias.h"
 #include "../type/sanitise.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 // Process the given capture and create the AST for the corresponding field.
@@ -16,7 +16,7 @@
 // Returns NULL on error.
 static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
 {
-  assert(capture != NULL);
+  pony_assert(capture != NULL);
 
   AST_GET_CHILDREN(capture, id_node, type, value);
   const char* name = ast_name(id_node);
@@ -29,7 +29,7 @@ static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
   if(ast_id(value) == TK_NONE)
   {
     // Variable capture
-    assert(ast_id(type) == TK_NONE);
+    pony_assert(ast_id(type) == TK_NONE);
 
     ast_t* def = ast_get(capture, name, NULL);
 
@@ -87,9 +87,9 @@ static ast_t* make_capture_field(pass_opt_t* opt, ast_t* capture)
 
 bool expr_lambda(pass_opt_t* opt, ast_t** astp)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
     ret_type, raises, body, reference_cap);

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -8,8 +8,8 @@
 #include "../type/reify.h"
 #include "../ast/token.h"
 #include "../ast/stringtab.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 
 #define UIF_ERROR       -1
@@ -145,7 +145,7 @@ static bool unify(ast_t* ast, pass_opt_t* options, bool report_errors);
 
 static void chain_init_head(lit_chain_t* head)
 {
-  assert(head != NULL);
+  pony_assert(head != NULL);
 
   head->cardinality = CHAIN_CARD_BASE;
   head->formal = NULL;
@@ -159,7 +159,7 @@ static void chain_init_head(lit_chain_t* head)
 
 static void chain_clear_cache(lit_chain_t* chain)
 {
-  assert(chain != NULL);
+  pony_assert(chain != NULL);
 
   while(chain->cardinality != CHAIN_CARD_BASE)
     chain = chain->next;
@@ -175,14 +175,14 @@ static void chain_clear_cache(lit_chain_t* chain)
 static void chain_add(lit_chain_t* chain, lit_chain_t* new_link,
   size_t cardinality)
 {
-  assert(new_link != NULL);
-  assert(cardinality != CHAIN_CARD_BASE);
+  pony_assert(new_link != NULL);
+  pony_assert(cardinality != CHAIN_CARD_BASE);
 
   new_link->cardinality = cardinality;
   new_link->index = 0;
 
-  assert(chain != NULL);
-  assert(chain->next != NULL);
+  pony_assert(chain != NULL);
+  pony_assert(chain->next != NULL);
   new_link->next = chain->next;
   chain->next = new_link;
 
@@ -192,10 +192,10 @@ static void chain_add(lit_chain_t* chain, lit_chain_t* new_link,
 
 static void chain_remove(lit_chain_t* old_tail)
 {
-  assert(old_tail != NULL);
-  assert(old_tail->next != NULL);
-  assert(old_tail->next->next != NULL);
-  assert(old_tail->next->next->cardinality == CHAIN_CARD_BASE);
+  pony_assert(old_tail != NULL);
+  pony_assert(old_tail->next != NULL);
+  pony_assert(old_tail->next->next != NULL);
+  pony_assert(old_tail->next->next->cardinality == CHAIN_CARD_BASE);
 
   old_tail->next = old_tail->next->next;
   chain_clear_cache(old_tail);
@@ -207,7 +207,7 @@ static void chain_remove(lit_chain_t* old_tail)
 // any formal parameters.
 static int uifset_simple_type(pass_opt_t* opt, ast_t* type)
 {
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   int set = 0;
 
@@ -231,17 +231,17 @@ static int uifset_simple_type(pass_opt_t* opt, ast_t* type)
 static int uifset_formal_param(pass_opt_t* opt, ast_t* type_param_ref,
   lit_chain_t* chain)
 {
-  assert(type_param_ref != NULL);
-  assert(ast_id(type_param_ref) == TK_TYPEPARAMREF);
+  pony_assert(type_param_ref != NULL);
+  pony_assert(ast_id(type_param_ref) == TK_TYPEPARAMREF);
 
   ast_t* type_param = (ast_t*)ast_data(type_param_ref);
 
-  assert(type_param != NULL);
-  assert(ast_id(type_param) == TK_TYPEPARAM);
-  assert(chain != NULL);
+  pony_assert(type_param != NULL);
+  pony_assert(ast_id(type_param) == TK_TYPEPARAM);
+  pony_assert(chain != NULL);
 
   ast_t* constraint = ast_childidx(type_param, 1);
-  assert(constraint != NULL);
+  pony_assert(constraint != NULL);
 
   // If the constraint is not a subtype of (Real[A] & Number) then there are no
   // legal types in the set
@@ -299,8 +299,8 @@ static int uifset_formal_param(pass_opt_t* opt, ast_t* type_param_ref,
 // Determine the UIF types that the given non-tuple union type may be
 static int uifset_union(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 {
-  assert(type != NULL);
-  assert(ast_id(type) == TK_UNIONTYPE);
+  pony_assert(type != NULL);
+  pony_assert(ast_id(type) == TK_UNIONTYPE);
 
   int uif_set = 0;
 
@@ -334,8 +334,8 @@ static int uifset_union(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 // Determine the UIF types that the given non-tuple intersection type may be
 static int uifset_intersect(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 {
-  assert(type != NULL);
-  assert(ast_id(type) == TK_ISECTTYPE);
+  pony_assert(type != NULL);
+  pony_assert(ast_id(type) == TK_ISECTTYPE);
 
   int uif_set = UIF_ALL_TYPES;
   int constraint = 0;
@@ -377,7 +377,7 @@ static int uifset_intersect(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 // Determine the UIF types that the given type may be
 static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 {
-  assert(chain != NULL);
+  pony_assert(chain != NULL);
 
   if(is_typecheck_error(type))
     return UIF_NO_TYPES;
@@ -392,7 +392,7 @@ static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 
     case TK_ARROW:
       // Since we don't care about capabilities we can just use the rhs
-      assert(ast_id(ast_childidx(type, 1)) == TK_NOMINAL);
+      pony_assert(ast_id(ast_childidx(type, 1)) == TK_NOMINAL);
       return uifset(opt, ast_childidx(type, 1), chain);
 
     case TK_TYPEPARAMREF:
@@ -414,7 +414,7 @@ static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
           return UIF_NO_TYPES;
 
         ast_t* type_args = ast_childidx(type, 2);
-        assert(ast_childcount(type_args) == 1);
+        pony_assert(ast_childcount(type_args) == 1);
         return uifset(opt, ast_child(type_args), chain->next);
       }
 
@@ -429,7 +429,7 @@ static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 
     default:
       ast_error(opt->check.errors, type, "Internal error: uif type, node %d", ast_id(type));
-      assert(0);
+      pony_assert(0);
       return UIF_ERROR;
   }
 }
@@ -439,8 +439,8 @@ static int uifset(pass_opt_t* opt, ast_t* type, lit_chain_t* chain)
 static bool uif_type(pass_opt_t* opt, ast_t* literal, ast_t* type,
   lit_chain_t* chain_head, bool report_errors)
 {
-  assert(chain_head != NULL);
-  assert(chain_head->cardinality == CHAIN_CARD_BASE);
+  pony_assert(chain_head != NULL);
+  pony_assert(chain_head->cardinality == CHAIN_CARD_BASE);
 
   chain_head->formal = NULL;
   int r = uifset(opt, type, chain_head->next);
@@ -457,14 +457,14 @@ static bool uif_type(pass_opt_t* opt, ast_t* literal, ast_t* type,
     return false;
   }
 
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   if((r & UIF_CONSTRAINED) != 0)
   {
     // Type is a formal parameter
-    assert(chain_head->formal != NULL);
-    assert(chain_head->name != NULL);
-    assert(chain_head->cached_uif_index < 0);
+    pony_assert(chain_head->formal != NULL);
+    pony_assert(chain_head->name != NULL);
+    pony_assert(chain_head->cached_uif_index < 0);
 
     BUILD(uif_type, type,
       NODE(TK_TYPEPARAMREF, DATA(chain_head->formal)
@@ -500,8 +500,8 @@ static bool uif_type_from_chain(pass_opt_t* opt, ast_t* literal,
   ast_t* target_type, lit_chain_t* chain, bool require_float,
   bool report_errors)
 {
-  assert(literal != NULL);
-  assert(chain != NULL);
+  pony_assert(literal != NULL);
+  pony_assert(chain != NULL);
 
   lit_chain_t* chain_head = chain;
   while(chain_head->cardinality != CHAIN_CARD_BASE)
@@ -546,7 +546,7 @@ static bool uif_type_from_chain(pass_opt_t* opt, ast_t* literal,
         // looser test if the literal is immediately negated.
         // We do not do this if the negation is not immediate, eg "-(128)".
         ast_t* parent = ast_parent(literal);
-        assert(parent != NULL);
+        pony_assert(parent != NULL);
         ast_t* parent_type = ast_type(parent);
 
         if(parent_type != NULL && ast_id(parent_type) == TK_OPERATORLITERAL &&
@@ -577,12 +577,12 @@ static bool uif_type_from_chain(pass_opt_t* opt, ast_t* literal,
 static bool coerce_group(ast_t** astp, ast_t* target_type, lit_chain_t* chain,
   size_t cardinality, pass_opt_t* options, bool report_errors)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* literal_expr = *astp;
-  assert(literal_expr != NULL);
-  assert(ast_id(literal_expr) == TK_TUPLE || ast_id(literal_expr) == TK_ARRAY);
-  assert(chain != NULL);
-  assert(cardinality != CHAIN_CARD_BASE);
+  pony_assert(literal_expr != NULL);
+  pony_assert(ast_id(literal_expr) == TK_TUPLE || ast_id(literal_expr) == TK_ARRAY);
+  pony_assert(chain != NULL);
+  pony_assert(cardinality != CHAIN_CARD_BASE);
 
   size_t i = 0;
   lit_chain_t link;
@@ -631,20 +631,20 @@ static bool coerce_group(ast_t** astp, ast_t* target_type, lit_chain_t* chain,
 static bool coerce_control_block(ast_t** astp, ast_t* target_type,
   lit_chain_t* chain, pass_opt_t* opt, bool report_errors)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* literal_expr = *astp;
-  assert(literal_expr != NULL);
+  pony_assert(literal_expr != NULL);
 
   ast_t* lit_type = ast_type(literal_expr);
-  assert(lit_type != NULL);
-  assert(ast_id(lit_type) == TK_LITERAL);
+  pony_assert(lit_type != NULL);
+  pony_assert(ast_id(lit_type) == TK_LITERAL);
   ast_t* block_type = ast_type(lit_type);
 
   for(ast_t* p = ast_child(lit_type); p != NULL; p = ast_sibling(p))
   {
-    assert(ast_id(p) == TK_LITERALBRANCH);
+    pony_assert(ast_id(p) == TK_LITERALBRANCH);
     ast_t* branch = (ast_t*)ast_data(p);
-    assert(branch != NULL);
+    pony_assert(branch != NULL);
 
     if(!coerce_literal_to_type(&branch, target_type, chain, opt,
       report_errors))
@@ -675,9 +675,9 @@ static bool coerce_control_block(ast_t** astp, ast_t* target_type,
 static bool coerce_literal_to_type(ast_t** astp, ast_t* target_type,
   lit_chain_t* chain, pass_opt_t* opt, bool report_errors)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* literal_expr = *astp;
-  assert(literal_expr != NULL);
+  pony_assert(literal_expr != NULL);
 
   ast_t* lit_type = ast_type(literal_expr);
 
@@ -776,7 +776,7 @@ static bool coerce_literal_to_type(ast_t** astp, ast_t* target_type,
     default:
       ast_error(opt->check.errors, literal_expr, "Internal error, coerce_literal_to_type node %s",
         ast_get_print(literal_expr));
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -789,9 +789,9 @@ static bool coerce_literal_to_type(ast_t** astp, ast_t* target_type,
 
 bool coerce_literals(ast_t** astp, ast_t* target_type, pass_opt_t* opt)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* literal_expr = *astp;
-  assert(literal_expr != NULL);
+  pony_assert(literal_expr != NULL);
 
   if(ast_id(literal_expr) == TK_NONE)
     return true;
@@ -814,7 +814,7 @@ bool coerce_literals(ast_t** astp, ast_t* target_type, pass_opt_t* opt)
 // Unify all the branches of the given AST to the same type
 static bool unify(ast_t* ast, pass_opt_t* opt, bool report_errors)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_t* type = ast_type(ast);
 
   if(is_typecheck_error(type))
@@ -823,7 +823,7 @@ static bool unify(ast_t* ast, pass_opt_t* opt, bool report_errors)
   if(!is_type_literal(type)) // Not literal, nothing to unify
     return true;
 
-  assert(type != NULL);
+  pony_assert(type != NULL);
   ast_t* non_literal = ast_type(type);
 
   if(non_literal != NULL)
@@ -843,8 +843,8 @@ static bool unify(ast_t* ast, pass_opt_t* opt, bool report_errors)
 
 bool literal_member_access(ast_t* ast, pass_opt_t* opt)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_DOT || ast_id(ast) == TK_TILDE ||
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_DOT || ast_id(ast) == TK_TILDE ||
     ast_id(ast) == TK_CHAIN);
 
   AST_GET_CHILDREN(ast, receiver, name_node);
@@ -862,7 +862,7 @@ bool literal_member_access(ast_t* ast, pass_opt_t* opt)
 
   // Receiver is a pure literal expression
   // Look up member name
-  assert(ast_id(name_node) == TK_ID);
+  pony_assert(ast_id(name_node) == TK_ID);
   const char* name = ast_name(name_node);
   lit_op_info_t* op = lookup_literal_op(name);
 
@@ -882,8 +882,8 @@ bool literal_member_access(ast_t* ast, pass_opt_t* opt)
 
 bool literal_call(ast_t* ast, pass_opt_t* opt)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_CALL);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_CALL);
 
   AST_GET_CHILDREN(ast, positional_args, named_args, receiver);
 
@@ -902,7 +902,7 @@ bool literal_call(ast_t* ast, pass_opt_t* opt)
     return true;
 
   lit_op_info_t* op = (lit_op_info_t*)ast_data(recv_type);
-  assert(op != NULL);
+  pony_assert(op != NULL);
 
   if(ast_childcount(named_args) != 0)
   {
@@ -947,8 +947,8 @@ bool literal_call(ast_t* ast, pass_opt_t* opt)
 
 bool literal_is(ast_t* ast, pass_opt_t* opt)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_IS || ast_id(ast) == TK_ISNT);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_IS || ast_id(ast) == TK_ISNT);
 
   AST_GET_CHILDREN(ast, left, right);
 
@@ -975,8 +975,8 @@ bool literal_is(ast_t* ast, pass_opt_t* opt)
   }
 
   // Both sides are literals, that's a problem.
-  assert(is_type_literal(l_type));
-  assert(is_type_literal(r_type));
+  pony_assert(is_type_literal(l_type));
+  pony_assert(is_type_literal(r_type));
   ast_error(opt->check.errors, ast, "Cannot infer type of operands");
   return false;
 }

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -9,11 +9,11 @@
 #include "../ast/id.h"
 #include "../pass/expr.h"
 #include "../pass/pass.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 bool expr_match(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_MATCH);
+  pony_assert(ast_id(ast) == TK_MATCH);
   AST_GET_CHILDREN(ast, expr, cases, else_clause);
 
   // A literal match expression should have been caught by the cases, but check
@@ -75,7 +75,7 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
 
 bool expr_cases(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_CASES);
+  pony_assert(ast_id(ast) == TK_CASES);
   ast_t* the_case = ast_child(ast);
 
   if(the_case == NULL)
@@ -268,8 +268,8 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 static bool infer_pattern_type(ast_t* pattern, ast_t* match_expr_type,
   pass_opt_t* opt)
 {
-  assert(pattern != NULL);
-  assert(match_expr_type != NULL);
+  pony_assert(pattern != NULL);
+  pony_assert(match_expr_type != NULL);
 
   if(is_type_literal(match_expr_type))
   {
@@ -283,8 +283,8 @@ static bool infer_pattern_type(ast_t* pattern, ast_t* match_expr_type,
 
 bool expr_case(pass_opt_t* opt, ast_t* ast)
 {
-  assert(opt != NULL);
-  assert(ast_id(ast) == TK_CASE);
+  pony_assert(opt != NULL);
+  pony_assert(ast_id(ast) == TK_CASE);
   AST_GET_CHILDREN(ast, pattern, guard, body);
 
   if((ast_id(pattern) == TK_NONE) && (ast_id(guard) == TK_NONE))
@@ -379,14 +379,14 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
 bool expr_match_capture(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, id, type);
 
   if(is_name_dontcare(ast_name(id)))
     ast_setid(ast, TK_MATCH_DONTCARE);
 
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   // Capture type is as specified.
   ast_settype(ast, type);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -10,11 +10,11 @@
 #include "../type/matchtype.h"
 #include "../type/safeto.h"
 #include "../type/subtype.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool assign_id(pass_opt_t* opt, ast_t* ast, bool let, bool need_value)
 {
-  assert(ast_id(ast) == TK_ID);
+  pony_assert(ast_id(ast) == TK_ID);
   const char* name = ast_name(ast);
 
   sym_status_t status;
@@ -77,7 +77,7 @@ static bool assign_id(pass_opt_t* opt, ast_t* ast, bool let, bool need_value)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -220,7 +220,7 @@ typedef enum infer_ret_t
 
 static ast_t* find_infer_type(pass_opt_t* opt, ast_t* type, infer_path_t* path)
 {
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   switch(ast_id(type))
   {
@@ -289,10 +289,10 @@ static ast_t* find_infer_type(pass_opt_t* opt, ast_t* type, infer_path_t* path)
 static infer_ret_t infer_local_inner(pass_opt_t* opt, ast_t* left,
   ast_t* r_type, infer_path_t* path)
 {
-  assert(left != NULL);
-  assert(r_type != NULL);
-  assert(path != NULL);
-  assert(path->root != NULL);
+  pony_assert(left != NULL);
+  pony_assert(r_type != NULL);
+  pony_assert(path != NULL);
+  pony_assert(path->root != NULL);
 
   infer_ret_t ret_val = INFER_NOP;
 
@@ -300,7 +300,7 @@ static infer_ret_t infer_local_inner(pass_opt_t* opt, ast_t* left,
   {
     case TK_SEQ:
     {
-      assert(ast_childcount(left) == 1);
+      pony_assert(ast_childcount(left) == 1);
       infer_ret_t r = infer_local_inner(opt, ast_child(left), r_type, path);
 
       if(r == INFER_OK) // Update seq type
@@ -342,7 +342,7 @@ static infer_ret_t infer_local_inner(pass_opt_t* opt, ast_t* left,
     case TK_LET:
     {
       ast_t* var_type = ast_type(left);
-      assert(var_type != NULL);
+      pony_assert(var_type != NULL);
 
       if(ast_id(var_type) != TK_INFERTYPE)  // No inferring needed
         return INFER_NOP;
@@ -364,7 +364,7 @@ static infer_ret_t infer_local_inner(pass_opt_t* opt, ast_t* left,
       // Add the type to the var / let AST as if it had been specified by the
       // user. Not really needed, but makes testing easier
       ast_t* speced_type = ast_childidx(left, 1);
-      assert(ast_id(speced_type) == TK_NONE);
+      pony_assert(ast_id(speced_type) == TK_NONE);
       ast_replace(&speced_type, a_type);
 
       ast_free_unattached(infer_type);
@@ -385,14 +385,14 @@ static bool infer_locals(pass_opt_t* opt, ast_t* left, ast_t* r_type)
   if(infer_local_inner(opt, left, r_type, &path_root) == INFER_ERROR)
     return false;
 
-  assert(path_root.next == NULL);
-  assert(path_root.root = &path_root);
+  pony_assert(path_root.next == NULL);
+  pony_assert(path_root.root = &path_root);
   return true;
 }
 
 static bool is_expr_constructor(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   switch(ast_id(ast))
   {
     case TK_CALL:
@@ -436,11 +436,11 @@ static bool is_expr_constructor(ast_t* ast)
 
 static bool tuple_contains_embed(ast_t* ast)
 {
-  assert(ast_id(ast) == TK_TUPLE);
+  pony_assert(ast_id(ast) == TK_TUPLE);
   ast_t* child = ast_child(ast);
   while(child != NULL)
   {
-    assert(ast_id(child) == TK_SEQ);
+    pony_assert(ast_id(child) == TK_SEQ);
     ast_t* member = ast_childlast(child);
     if(ast_id(member) == TK_EMBEDREF)
     {
@@ -474,7 +474,7 @@ static bool check_embed_construction(pass_opt_t* opt, ast_t* left, ast_t* right)
       ast_t* r_child = ast_child(right);
       while(l_child != NULL)
       {
-        assert((ast_id(l_child) == TK_SEQ) && (ast_id(r_child) == TK_SEQ));
+        pony_assert((ast_id(l_child) == TK_SEQ) && (ast_id(r_child) == TK_SEQ));
         ast_t* l_member = ast_childlast(l_child);
         ast_t* r_member = ast_childlast(r_child);
         if(!check_embed_construction(opt, l_member, r_member))
@@ -483,7 +483,7 @@ static bool check_embed_construction(pass_opt_t* opt, ast_t* left, ast_t* right)
         l_child = ast_sibling(l_child);
         r_child = ast_sibling(r_child);
       }
-      assert(r_child == NULL);
+      pony_assert(r_child == NULL);
     } else if(tuple_contains_embed(left)) {
       ast_error(opt->check.errors, left,
         "an embedded field must be assigned using a constructor");
@@ -498,7 +498,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 {
   // Left and right are swapped in the AST to make sure we type check the
   // right side before the left. Fetch them in the opposite order.
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, right, left);
   ast_t* l_type = ast_type(left);
@@ -583,7 +583,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
         break;
     }
 
@@ -604,7 +604,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
       if(fn != NULL)
       {
         ast_t* iso = ast_child(fn);
-        assert(iso != NULL);
+        pony_assert(iso != NULL);
         token_id iso_id = ast_id(iso);
 
         if(iso_id == TK_BOX || iso_id == TK_VAL || iso_id == TK_TAG)

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -10,9 +10,9 @@
 #include "../type/reify.h"
 #include "../type/assemble.h"
 #include "../type/lookup.h"
+#include "ponyassert.h"
 #include <string.h>
 #include <stdlib.h>
-#include <assert.h>
 
 static bool is_method_called(pass_opt_t* opt, ast_t* ast)
 {
@@ -75,7 +75,7 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
           return false;
 
         default:
-          assert(0);
+          pony_assert(0);
           return false;
       }
       return true;
@@ -121,7 +121,7 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -154,7 +154,7 @@ static bool method_access(pass_opt_t* opt, ast_t* ast, ast_t* method)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -171,8 +171,8 @@ static bool package_access(pass_opt_t* opt, ast_t** astp)
   ast_t* left = ast_child(ast);
   ast_t* right = ast_sibling(left);
 
-  assert(ast_id(left) == TK_PACKAGEREF);
-  assert(ast_id(right) == TK_ID);
+  pony_assert(ast_id(left) == TK_PACKAGEREF);
+  pony_assert(ast_id(right) == TK_ID);
 
   // Must be a type in a package.
   const char* package_name = ast_name(ast_child(left));
@@ -185,7 +185,7 @@ static bool package_access(pass_opt_t* opt, ast_t** astp)
     return false;
   }
 
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   const char* type_name = ast_name(right);
   ast_t* type = ast_get(package, type_name, NULL);
 
@@ -214,8 +214,8 @@ static bool type_access(pass_opt_t* opt, ast_t** astp)
   if(is_typecheck_error(type))
     return false;
 
-  assert(ast_id(left) == TK_TYPEREF);
-  assert(ast_id(right) == TK_ID);
+  pony_assert(ast_id(left) == TK_TYPEREF);
+  pony_assert(ast_id(right) == TK_ID);
 
   ast_t* find = lookup(opt, ast, type, ast_name(right));
 
@@ -273,7 +273,7 @@ static bool type_access(pass_opt_t* opt, ast_t** astp)
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       ret = false;
       break;
   }
@@ -340,7 +340,7 @@ static bool tuple_access(pass_opt_t* opt, ast_t* ast)
   }
 
   type = ast_childidx(type, right_idx);
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   ast_setid(ast, TK_FLETREF);
   ast_settype(ast, type);
@@ -351,7 +351,7 @@ static bool member_access(pass_opt_t* opt, ast_t* ast)
 {
   // Left is a postfix expression, right is an id.
   AST_GET_CHILDREN(ast, left, right);
-  assert(ast_id(right) == TK_ID);
+  pony_assert(ast_id(right) == TK_ID);
   ast_t* type = ast_type(left);
 
   if(is_typecheck_error(type))
@@ -394,7 +394,7 @@ static bool member_access(pass_opt_t* opt, ast_t* ast)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       ret = false;
       break;
   }
@@ -410,7 +410,7 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
   ast_t* ast = *astp;
   AST_GET_CHILDREN(ast, left, right);
   ast_t* type = ast_type(left);
-  assert(ast_id(right) == TK_TYPEARGS);
+  pony_assert(ast_id(right) == TK_TYPEARGS);
 
   if(is_typecheck_error(type))
     return false;
@@ -420,7 +420,7 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
     case TK_TYPEREF:
     {
       // Qualify the type.
-      assert(ast_id(type) == TK_NOMINAL);
+      pony_assert(ast_id(type) == TK_NOMINAL);
 
       // If the type isn't polymorphic or the type is already qualified,
       // sugar .apply().
@@ -456,7 +456,7 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
     case TK_FUNCHAIN:
     {
       // Qualify the function.
-      assert(ast_id(type) == TK_FUNTYPE);
+      pony_assert(ast_id(type) == TK_FUNTYPE);
       ast_t* typeparams = ast_childidx(type, 1);
 
       if(!reify_defaults(typeparams, right, true, opt))
@@ -520,7 +520,7 @@ static bool entity_access(pass_opt_t* opt, ast_t** astp)
     return true;
 
   type = ast_type(left); // Literal handling may have changed lhs type
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   if(ast_id(type) == TK_TUPLETYPE)
     return tuple_access(opt, ast);
@@ -578,7 +578,7 @@ bool expr_tilde(pass_opt_t* opt, ast_t** astp)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -620,6 +620,6 @@ bool expr_chain(pass_opt_t* opt, ast_t** astp)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -15,8 +15,8 @@
 #include "../ast/astbuild.h"
 #include "../ast/id.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 /**
  * Make sure the definition of something occurs before its use. This is for
@@ -128,7 +128,7 @@ static bool valid_reference(pass_opt_t* opt, ast_t* ast, ast_t* type,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -161,7 +161,7 @@ static bool check_provides(pass_opt_t* opt, ast_t* type, ast_t* provides,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -325,7 +325,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
 bool expr_typeref(pass_opt_t* opt, ast_t** astp)
 {
   ast_t* ast = *astp;
-  assert(ast_id(ast) == TK_TYPEREF);
+  pony_assert(ast_id(ast) == TK_TYPEREF);
   ast_t* type = ast_type(ast);
 
   if(is_typecheck_error(type))
@@ -382,7 +382,7 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
         if(is_typecheck_error(type))
           return false;
 
-        assert(ast_id(type) == TK_FUNTYPE);
+        pony_assert(ast_id(type) == TK_FUNTYPE);
         AST_GET_CHILDREN(type, cap, typeparams, params, result);
 
         if(ast_id(params) == TK_NONE)
@@ -466,8 +466,8 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
 
 static const char* suggest_alt_name(ast_t* ast, const char* name)
 {
-  assert(ast != NULL);
-  assert(name != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(name != NULL);
 
   size_t name_len = strlen(name);
 
@@ -500,7 +500,7 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
     if(ast_id(id) != TK_ID)
       id = ast_child(id);
 
-    assert(ast_id(id) == TK_ID);
+    pony_assert(ast_id(id) == TK_ID);
     const char* try_name = ast_name(id);
 
     if(ast_get(ast, try_name, NULL) != NULL)
@@ -768,7 +768,7 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
           break;
 
         default:
-          assert(0);
+          pony_assert(0);
           return false;
       }
 
@@ -820,17 +820,17 @@ bool expr_reference(pass_opt_t* opt, ast_t** astp)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
 bool expr_local(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(ast_type(ast) != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(ast_type(ast) != NULL);
 
   AST_GET_CHILDREN(ast, id, type);
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   bool is_dontcare = is_name_dontcare(ast_name(id));
 
@@ -993,7 +993,7 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
     return false;
   }
 
-  assert(status == SYM_NONE);
+  pony_assert(status == SYM_NONE);
   token_id cap = cap_for_this(t);
 
   if(!cap_sendable(cap) && (t->frame->recover != NULL))
@@ -1061,7 +1061,7 @@ bool expr_this(pass_opt_t* opt, ast_t* ast)
   if((ast_id(parent) == TK_DOT) && (ast_child(parent) == ast))
   {
     ast_t* right = ast_sibling(ast);
-    assert(ast_id(right) == TK_ID);
+    pony_assert(ast_id(right) == TK_ID);
     ast_t* find = lookup_try(opt, ast, nominal, ast_name(right));
 
     if(find != NULL)
@@ -1177,7 +1177,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
   if(is_maybe(ast))
   {
     // MaybePointer[A] must be bound to a struct.
-    assert(ast_childcount(typeargs) == 1);
+    pony_assert(ast_childcount(typeargs) == 1);
     ast_t* typeparam = ast_child(typeparams);
     ast_t* typearg = ast_child(typeargs);
     bool ok = false;
@@ -1219,7 +1219,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
 
 static bool check_fields_defined(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_NEW);
+  pony_assert(ast_id(ast) == TK_NEW);
 
   ast_t* members = ast_parent(ast);
   ast_t* member = ast_child(members);

--- a/src/libponyc/pass/casemethod.c
+++ b/src/libponyc/pass/casemethod.c
@@ -4,7 +4,7 @@
 #include "../ast/id.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <string.h>
 
 /* The following sugar handles case methods.
@@ -55,7 +55,7 @@ class C
 // Returns: created method, NULL on error.
 static ast_t* make_match_wrapper(ast_t* case_method, pass_opt_t* opt)
 {
-  assert(case_method != NULL);
+  pony_assert(case_method != NULL);
 
   if(ast_id(case_method) == TK_FUN)
     fun_defaults(case_method);
@@ -143,12 +143,12 @@ static ast_t* make_match_wrapper(ast_t* case_method, pass_opt_t* opt)
 static bool param_with_type(ast_t* case_param, ast_t* match_param,
   ast_t* pattern, pass_opt_t* opt)
 {
-  assert(case_param != NULL);
-  assert(match_param != NULL);
-  assert(pattern != NULL);
+  pony_assert(case_param != NULL);
+  pony_assert(match_param != NULL);
+  pony_assert(pattern != NULL);
 
   AST_GET_CHILDREN(case_param, case_id, case_type, case_def_arg);
-  assert(ast_id(case_type) != TK_NONE);
+  pony_assert(ast_id(case_type) != TK_NONE);
 
   if(ast_id(case_id) != TK_ID)
   {
@@ -159,7 +159,7 @@ static bool param_with_type(ast_t* case_param, ast_t* match_param,
   }
 
   AST_GET_CHILDREN(match_param, match_id, match_type, match_def_arg);
-  assert(ast_id(match_id) == TK_ID || ast_id(match_id) == TK_NONE);
+  pony_assert(ast_id(match_id) == TK_ID || ast_id(match_id) == TK_NONE);
 
   if(ast_id(match_id) == TK_NONE)
   {
@@ -220,11 +220,11 @@ static bool param_with_type(ast_t* case_param, ast_t* match_param,
 static bool param_without_type(ast_t* case_param, ast_t* pattern,
   pass_opt_t* opt)
 {
-  assert(case_param != NULL);
-  assert(pattern != NULL);
+  pony_assert(case_param != NULL);
+  pony_assert(pattern != NULL);
 
   AST_GET_CHILDREN(case_param, value, type, def_arg);
-  assert(ast_id(type) == TK_NONE);
+  pony_assert(ast_id(type) == TK_NONE);
 
   if(ast_id(def_arg) != TK_NONE)
   {
@@ -251,8 +251,8 @@ static bool param_without_type(ast_t* case_param, ast_t* pattern,
 static ast_t* process_params(ast_t* match_params, ast_t* case_params,
   pass_opt_t* opt)
 {
-  assert(match_params != NULL);
-  assert(case_params != NULL);
+  pony_assert(match_params != NULL);
+  pony_assert(case_params != NULL);
 
   bool ok = true;
   size_t count = 0;
@@ -297,7 +297,7 @@ static ast_t* process_params(ast_t* match_params, ast_t* case_params,
     return NULL;
   }
 
-  assert(count > 0);
+  pony_assert(count > 0);
   if(count == 1)
   {
     // Only one parameter, don't need a tuple pattern.
@@ -317,14 +317,14 @@ static ast_t* process_params(ast_t* match_params, ast_t* case_params,
 static ast_t* build_params(ast_t* match_params, ast_t* worker_params,
   ast_t* call_args, const char* name, pass_opt_t* opt)
 {
-  assert(match_params != NULL);
-  assert(worker_params != NULL);
-  assert(call_args != NULL);
-  assert(name != NULL);
-  assert(opt != NULL);
+  pony_assert(match_params != NULL);
+  pony_assert(worker_params != NULL);
+  pony_assert(call_args != NULL);
+  pony_assert(name != NULL);
+  pony_assert(opt != NULL);
 
   typecheck_t* t = &opt->check;
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   ast_t* match_operand = ast_from(match_params, TK_TUPLE);
   size_t count = 0;
@@ -337,7 +337,7 @@ static ast_t* build_params(ast_t* match_params, ast_t* worker_params,
 
     if(ast_id(id) == TK_NONE)
     {
-      assert(ast_id(type) == TK_NONE);
+      pony_assert(ast_id(type) == TK_NONE);
       ast_error(opt->check.errors, p,
         "name and type not specified for parameter " __zu
         " of case function %s",
@@ -383,7 +383,7 @@ static ast_t* build_params(ast_t* match_params, ast_t* worker_params,
     return NULL;
   }
 
-  assert(count > 0);
+  pony_assert(count > 0);
   if(count == 1)
   {
     // Only one parameter, don't need tuple in operand.
@@ -403,14 +403,14 @@ static ast_t* build_params(ast_t* match_params, ast_t* worker_params,
 static bool process_t_param(ast_t* case_param, ast_t* match_param,
   pass_opt_t* opt)
 {
-  assert(case_param != NULL);
-  assert(match_param != NULL);
+  pony_assert(case_param != NULL);
+  pony_assert(match_param != NULL);
 
   AST_GET_CHILDREN(case_param, case_id, case_constraint, case_def_type);
-  assert(ast_id(case_id) == TK_ID);
+  pony_assert(ast_id(case_id) == TK_ID);
 
   AST_GET_CHILDREN(match_param, match_id, match_constraint, match_def_type);
-  assert(ast_id(match_id) == TK_ID || ast_id(match_id) == TK_NONE);
+  pony_assert(ast_id(match_id) == TK_ID || ast_id(match_id) == TK_NONE);
 
   if(ast_id(match_id) == TK_NONE)
   {
@@ -476,8 +476,8 @@ static bool process_t_param(ast_t* case_param, ast_t* match_param,
 static bool process_t_params(ast_t* match_params, ast_t* case_params,
   pass_opt_t* opt)
 {
-  assert(match_params != NULL);
-  assert(case_params != NULL);
+  pony_assert(match_params != NULL);
+  pony_assert(case_params != NULL);
 
   bool ok = true;
   ast_t* case_param = ast_child(case_params);
@@ -511,13 +511,13 @@ static bool process_t_params(ast_t* match_params, ast_t* case_params,
 static void build_t_params(ast_t* match_t_params,
   ast_t* worker_t_params)
 {
-  assert(match_t_params != NULL);
-  assert(worker_t_params != NULL);
+  pony_assert(match_t_params != NULL);
+  pony_assert(worker_t_params != NULL);
 
   for(ast_t* p = ast_child(match_t_params); p != NULL; p = ast_sibling(p))
   {
     AST_GET_CHILDREN(p, id, constraint, def_type);
-    assert(ast_id(id) == TK_ID);
+    pony_assert(ast_id(id) == TK_ID);
 
     // Add type parameter name to worker call list.
     BUILD(type, p, NODE(TK_NOMINAL, NONE TREE(id) NONE NONE NONE));
@@ -641,8 +641,8 @@ static void add_docstring(ast_t* id, ast_t* match_docstring,
 static ast_t* add_case_method(ast_t* match_method, ast_t* case_method,
   pass_opt_t* opt)
 {
-  assert(match_method != NULL);
-  assert(case_method != NULL);
+  pony_assert(match_method != NULL);
+  pony_assert(case_method != NULL);
 
   // We need default capabality and return value if not provided explicitly.
   if(ast_id(case_method) == TK_FUN)
@@ -740,13 +740,13 @@ static ast_t* add_case_method(ast_t* match_method, ast_t* case_method,
 static bool sugar_case_method(ast_t* first_case_method, ast_t* members,
   const char* name, pass_opt_t* opt)
 {
-  assert(first_case_method != NULL);
-  assert(members != NULL);
-  assert(name != NULL);
-  assert(opt != NULL);
+  pony_assert(first_case_method != NULL);
+  pony_assert(members != NULL);
+  pony_assert(name != NULL);
+  pony_assert(opt != NULL);
 
   typecheck_t* t = &opt->check;
-  assert(t != NULL);
+  pony_assert(t != NULL);
 
   ast_t* wrapper = make_match_wrapper(first_case_method, opt);
 
@@ -803,8 +803,8 @@ static bool sugar_case_method(ast_t* first_case_method, ast_t* members,
   ast_t* wrapper_body = ast_childidx(wrapper, 6);
   ast_t* wrapper_call;
   ast_t* call_t_args = ast_from(wrapper, TK_NONE);
-  assert(ast_id(wrapper_body) == TK_SEQ);
-  assert(ast_childcount(wrapper_body) == 0);
+  pony_assert(ast_id(wrapper_body) == TK_SEQ);
+  pony_assert(ast_childcount(wrapper_body) == 0);
 
   build_t_params(ast_childidx(wrapper, 2), call_t_args);
 
@@ -873,8 +873,8 @@ static bool sugar_case_method(ast_t* first_case_method, ast_t* members,
 // Sugar any case methods in the given entity.
 ast_result_t sugar_case_methods(pass_opt_t* opt, ast_t* entity)
 {
-  assert(opt != NULL);
-  assert(entity != NULL);
+  pony_assert(opt != NULL);
+  pony_assert(entity != NULL);
 
   ast_result_t result = AST_OK;
   ast_t* members = ast_childidx(entity, 4);

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -3,7 +3,7 @@
 #include "../ast/printbuf.h"
 #include "../pkg/package.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -59,7 +59,7 @@ typedef struct ast_list_t
 // handled separately
 static void doc_list_free(ast_list_t* list)
 {
-  assert(list != NULL);
+  pony_assert(list != NULL);
 
   ast_list_t* p = list->next;
 
@@ -76,8 +76,8 @@ static void doc_list_free(ast_list_t* list)
 static void doc_list_add(ast_list_t* list, ast_t* ast, const char* name,
   bool sort)
 {
-  assert(list != NULL);
-  assert(ast != NULL);
+  pony_assert(list != NULL);
+  pony_assert(ast != NULL);
 
   ast_list_t* n = POOL_ALLOC(ast_list_t);
   n->ast = ast;
@@ -90,7 +90,7 @@ static void doc_list_add(ast_list_t* list, ast_t* ast, const char* name,
 
   for(ast_list_t* p = prev->next; p != NULL; prev = p, p = p->next)
   {
-    assert(p->name != NULL);
+    pony_assert(p->name != NULL);
 
     if (sort && strcmp(p->name, name) > 0)
     {
@@ -115,11 +115,11 @@ static void doc_list_add(ast_list_t* list, ast_t* ast, const char* name,
 static void doc_list_add_named(ast_list_t* list, ast_t* ast, size_t id_index,
   bool allow_public, bool allow_private)
 {
-  assert(list != NULL);
-  assert(ast != NULL);
+  pony_assert(list != NULL);
+  pony_assert(ast != NULL);
 
   const char* name = ast_name(ast_childidx(ast, id_index));
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   if(is_name_internal_test(name))  // Ignore internally generated names
     return;
@@ -148,12 +148,12 @@ static void doc_list_add_named(ast_list_t* list, ast_t* ast, size_t id_index,
 static char* doc_cat(const char* a, const char* b, const char* c,
   const char* d, const char* e, size_t* out_buf_size)
 {
-  assert(a != NULL);
-  assert(b != NULL);
-  assert(c != NULL);
-  assert(d != NULL);
-  assert(e != NULL);
-  assert(out_buf_size != NULL);
+  pony_assert(a != NULL);
+  pony_assert(b != NULL);
+  pony_assert(c != NULL);
+  pony_assert(d != NULL);
+  pony_assert(e != NULL);
+  pony_assert(out_buf_size != NULL);
 
   size_t a_len = strlen(a);
   size_t b_len = strlen(b);
@@ -173,7 +173,7 @@ static char* doc_cat(const char* a, const char* b, const char* c,
 
   *(p++) = '\0';
 
-  assert(p == (buffer + buf_len));
+  pony_assert(p == (buffer + buf_len));
   *out_buf_size = buf_len;
   return buffer;
 }
@@ -195,11 +195,11 @@ static char* doc_cat(const char* a, const char* b, const char* c,
 // terminator.
 static char* write_tqfn(ast_t* type, const char* type_name, size_t* out_size)
 {
-  assert(type != NULL);
-  assert(out_size != NULL);
+  pony_assert(type != NULL);
+  pony_assert(out_size != NULL);
 
   ast_t* package = ast_nearest(type, TK_PACKAGE);
-  assert(package != NULL);
+  pony_assert(package != NULL);
 
   // We need the qualified package name and the type name
   const char* pkg_qual_name = package_qualified_name(package);
@@ -207,8 +207,8 @@ static char* write_tqfn(ast_t* type, const char* type_name, size_t* out_size)
   if(type_name == NULL)
     type_name = ast_name(ast_child(type));
 
-  assert(pkg_qual_name != NULL);
-  assert(type_name != NULL);
+  pony_assert(pkg_qual_name != NULL);
+  pony_assert(type_name != NULL);
 
   char* buffer = doc_cat(pkg_qual_name, "-", type_name, "", "", out_size);
 
@@ -235,9 +235,9 @@ static char* write_tqfn(ast_t* type, const char* type_name, size_t* out_size)
 static FILE* doc_open_file(docgen_t* docgen, bool in_sub_dir,
   const char* filename, const char* extn)
 {
-  assert(docgen != NULL);
-  assert(filename != NULL);
-  assert(extn != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(filename != NULL);
+  pony_assert(extn != NULL);
 
   // Build the type file name in a buffer.
   // Full file name is:
@@ -293,9 +293,9 @@ static const char* doc_get_cap(ast_t* cap)
 // Write the given type to the current type file
 static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(type != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(type != NULL);
 
   switch(ast_id(type))
   {
@@ -309,7 +309,7 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
       {
         // Find type we reference so we can link to it
         ast_t* target = (ast_t*)ast_data(type);
-        assert(target != NULL);
+        pony_assert(target != NULL);
 
         size_t link_len;
         char* tqfn = write_tqfn(target, NULL, &link_len);
@@ -386,7 +386,7 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
   }
 }
 
@@ -396,12 +396,12 @@ static void doc_type(docgen_t* docgen, ast_t* type, bool generate_links)
 static void doc_type_list(docgen_t* docgen, ast_t* list, const char* preamble,
   const char* separator, const char* postamble, bool generate_links, bool line_breaks)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(list != NULL);
-  assert(preamble != NULL);
-  assert(separator != NULL);
-  assert(postamble != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(list != NULL);
+  pony_assert(preamble != NULL);
+  pony_assert(separator != NULL);
+  pony_assert(postamble != NULL);
 
   if(ast_id(list) == TK_NONE)
     return;
@@ -431,8 +431,8 @@ static void doc_type_list(docgen_t* docgen, ast_t* list, const char* preamble,
 
 static bool is_for_testing(const char* name, ast_t* list)
 {
-  assert(name != NULL);
-  assert(list != NULL);
+  pony_assert(name != NULL);
+  pony_assert(list != NULL);
 
   if (strncmp(name, "_Test", 5) == 0) return true;
 
@@ -465,10 +465,10 @@ static bool is_for_testing(const char* name, ast_t* list)
 // If the field list is empty nothing is written.
 static void doc_fields(docgen_t* docgen, ast_list_t* fields, const char* title)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(fields != NULL);
-  assert(title != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(fields != NULL);
+  pony_assert(title != NULL);
 
   if(fields->next == NULL)  // No fields
     return;
@@ -478,11 +478,11 @@ static void doc_fields(docgen_t* docgen, ast_list_t* fields, const char* title)
   for(ast_list_t* p = fields->next; p != NULL; p = p->next)
   {
     ast_t* field = p->ast;
-    assert(field != NULL);
+    pony_assert(field != NULL);
 
     AST_GET_CHILDREN(field, id, type, init);
     const char* name = ast_name(id);
-    assert(name != NULL);
+    pony_assert(name != NULL);
 
     // Don't want ast_get_print() as that will give us flet or fvar
     const char* ftype = NULL;
@@ -492,7 +492,7 @@ static void doc_fields(docgen_t* docgen, ast_list_t* fields, const char* title)
       case TK_FVAR: ftype = "var"; break;
       case TK_FLET: ftype = "let"; break;
       case TK_EMBED: ftype = "embed"; break;
-      default: assert(0);
+      default: pony_assert(0);
     }
 
     fprintf(docgen->type_file, "* %s %s: ", ftype, name);
@@ -507,14 +507,14 @@ static void doc_fields(docgen_t* docgen, ast_list_t* fields, const char* title)
 static void doc_type_params(docgen_t* docgen, ast_t* t_params,
   bool generate_links)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(t_params != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(t_params != NULL);
 
   if(ast_id(t_params) == TK_NONE)
     return;
 
-  assert(ast_id(t_params) == TK_TYPEPARAMS);
+  pony_assert(ast_id(t_params) == TK_TYPEPARAMS);
 
   if(generate_links)
     fprintf(docgen->type_file, "\\[");
@@ -529,7 +529,7 @@ static void doc_type_params(docgen_t* docgen, ast_t* t_params,
 
     AST_GET_CHILDREN(t_param, id, constraint, default_type);
     const char* name = ast_name(id);
-    assert(name != NULL);
+    pony_assert(name != NULL);
 
     if(ast_id(default_type) != TK_NONE)
       fprintf(docgen->type_file, "optional ");
@@ -552,9 +552,9 @@ static void doc_type_params(docgen_t* docgen, ast_t* t_params,
 // surrounding (). If the given list is empty () is still written.
 static void code_block_doc_params(docgen_t* docgen, ast_t* params)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(params != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(params != NULL);
 
   fprintf(docgen->type_file, "(");
   ast_t* first = ast_child(params);
@@ -568,7 +568,7 @@ static void code_block_doc_params(docgen_t* docgen, ast_t* params)
 
     AST_GET_CHILDREN(param, id, type, def_val);
     const char* name = ast_name(id);
-    assert(name != NULL);
+    pony_assert(name != NULL);
 
     fprintf(docgen->type_file, "  %s: ", name);
     doc_type(docgen, type, false);
@@ -594,9 +594,9 @@ static void code_block_doc_params(docgen_t* docgen, ast_t* params)
 
 static void list_doc_params(docgen_t* docgen, ast_t* params)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(params != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(params != NULL);
 
   ast_t* first = ast_child(params);
 
@@ -609,7 +609,7 @@ static void list_doc_params(docgen_t* docgen, ast_t* params)
 
     AST_GET_CHILDREN(param, id, type, def_val);
     const char* name = ast_name(id);
-    assert(name != NULL);
+    pony_assert(name != NULL);
 
     fprintf(docgen->type_file, "  %s: ", name);
     doc_type(docgen, type, true);
@@ -638,14 +638,14 @@ static void list_doc_params(docgen_t* docgen, ast_t* params)
 // Write a description of the given method to the current type file
 static void doc_method(docgen_t* docgen, ast_t* method)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(method != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(method != NULL);
 
   AST_GET_CHILDREN(method, cap, id, t_params, params, ret, error, body, doc);
 
   const char* name = ast_name(id);
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   // Method
   fprintf(docgen->type_file, "### %s", name);
@@ -710,10 +710,10 @@ static void doc_method(docgen_t* docgen, ast_t* method)
 static void doc_methods(docgen_t* docgen, ast_list_t* methods,
   const char* variety)
 {
-  assert(docgen != NULL);
-  assert(docgen->type_file != NULL);
-  assert(methods != NULL);
-  assert(variety != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->type_file != NULL);
+  pony_assert(methods != NULL);
+  pony_assert(variety != NULL);
 
   if(methods->next == NULL)
     return;
@@ -728,14 +728,14 @@ static void doc_methods(docgen_t* docgen, ast_list_t* methods,
 // Write a description of the given entity to its own type file.
 static void doc_entity(docgen_t* docgen, ast_t* ast)
 {
-  assert(docgen != NULL);
-  assert(docgen->index_file != NULL);
-  assert(docgen->package_file != NULL);
-  assert(docgen->test_types != NULL);
-  assert(docgen->public_types != NULL);
-  assert(docgen->private_types != NULL);
-  assert(docgen->type_file == NULL);
-  assert(ast != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->index_file != NULL);
+  pony_assert(docgen->package_file != NULL);
+  pony_assert(docgen->test_types != NULL);
+  pony_assert(docgen->public_types != NULL);
+  pony_assert(docgen->private_types != NULL);
+  pony_assert(docgen->type_file == NULL);
+  pony_assert(ast != NULL);
 
   // First open a file
   size_t tqfn_len;
@@ -750,7 +750,7 @@ static void doc_entity(docgen_t* docgen, ast_t* ast)
   AST_GET_CHILDREN(ast, id, tparams, cap, provides, members, c_api, doc);
 
   const char* name = ast_name(id);
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   fprintf(docgen->index_file, "  - %s %s: \"%s.md\"\n",
     ast_get_print(ast), name, tqfn);
@@ -826,7 +826,7 @@ static void doc_entity(docgen_t* docgen, ast_t* ast)
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
         break;
     }
   }
@@ -856,16 +856,16 @@ static void doc_package_home(docgen_t* docgen,
   ast_t* package,
   ast_t* doc_string)
 {
-  assert(docgen != NULL);
-  assert(docgen->index_file != NULL);
-  assert(docgen->home_file != NULL);
-  assert(docgen->package_file == NULL);
-  assert(docgen->test_types == NULL);
-  assert(docgen->public_types == NULL);
-  assert(docgen->private_types == NULL);
-  assert(docgen->type_file == NULL);
-  assert(package != NULL);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(docgen != NULL);
+  pony_assert(docgen->index_file != NULL);
+  pony_assert(docgen->home_file != NULL);
+  pony_assert(docgen->package_file == NULL);
+  pony_assert(docgen->test_types == NULL);
+  pony_assert(docgen->public_types == NULL);
+  pony_assert(docgen->private_types == NULL);
+  pony_assert(docgen->type_file == NULL);
+  pony_assert(package != NULL);
+  pony_assert(ast_id(package) == TK_PACKAGE);
 
   // First open a file
   size_t tqfn_len;
@@ -890,7 +890,7 @@ static void doc_package_home(docgen_t* docgen,
   // Now we can write the actual documentation for the package
   if(doc_string != NULL)
   {
-    assert(ast_id(doc_string) == TK_STRING);
+    pony_assert(ast_id(doc_string) == TK_STRING);
     fprintf(docgen->type_file, "%s", ast_name(doc_string));
   }
   else
@@ -913,12 +913,12 @@ static void doc_package_home(docgen_t* docgen,
 // Document the given package
 static void doc_package(docgen_t* docgen, ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_PACKAGE);
-  assert(docgen->package_file == NULL);
-  assert(docgen->test_types == NULL);
-  assert(docgen->public_types == NULL);
-  assert(docgen->private_types == NULL);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_PACKAGE);
+  pony_assert(docgen->package_file == NULL);
+  pony_assert(docgen->test_types == NULL);
+  pony_assert(docgen->public_types == NULL);
+  pony_assert(docgen->private_types == NULL);
 
   ast_list_t types = { NULL, NULL, NULL };
   ast_t* package_doc = NULL;
@@ -929,18 +929,18 @@ static void doc_package(docgen_t* docgen, ast_t* ast)
     if(ast_id(m) == TK_STRING)
     {
       // Package docstring
-      assert(package_doc == NULL);
+      pony_assert(package_doc == NULL);
       package_doc = m;
     }
     else
     {
-      assert(ast_id(m) == TK_MODULE);
+      pony_assert(ast_id(m) == TK_MODULE);
 
       for(ast_t* t = ast_child(m); t != NULL; t = ast_sibling(t))
       {
         if(ast_id(t) != TK_USE)
         {
-          assert(ast_id(t) == TK_TYPE || ast_id(t) == TK_INTERFACE ||
+          pony_assert(ast_id(t) == TK_TYPE || ast_id(t) == TK_INTERFACE ||
             ast_id(t) == TK_TRAIT || ast_id(t) == TK_PRIMITIVE ||
             ast_id(t) == TK_STRUCT || ast_id(t) == TK_CLASS ||
             ast_id(t) == TK_ACTOR);
@@ -990,19 +990,19 @@ static void doc_package(docgen_t* docgen, ast_t* ast)
 // Document the packages in the given program
 static void doc_packages(docgen_t* docgen, ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_PROGRAM);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_PROGRAM);
 
   // The Main package appears first, other packages in alphabetical order
   ast_t* package_1 = ast_child(ast);
-  assert(package_1 != NULL);
+  pony_assert(package_1 != NULL);
 
   ast_list_t packages = { NULL, NULL, NULL };
 
   // Sort packages
   for(ast_t* p = ast_sibling(package_1); p != NULL; p = ast_sibling(p))
   {
-    assert(ast_id(p) == TK_PACKAGE);
+    pony_assert(ast_id(p) == TK_PACKAGE);
 
     const char* name = package_qualified_name(p);
     doc_list_add(&packages, p, name, true);
@@ -1023,7 +1023,7 @@ static void doc_packages(docgen_t* docgen, ast_t* ast)
 // Delete all the files in the specified directory
 static void doc_rm_star(const char* path)
 {
-  assert(path != NULL);
+  pony_assert(path != NULL);
 
   PONY_ERRNO err;
   PONY_DIR* dir = pony_opendir(path, &err);
@@ -1070,9 +1070,9 @@ static void doc_rm_star(const char* path)
  */
 static void doc_setup_dirs(docgen_t* docgen, ast_t* program, pass_opt_t* opt)
 {
-  assert(docgen != NULL);
-  assert(program != NULL);
-  assert(opt != NULL);
+  pony_assert(docgen != NULL);
+  pony_assert(program != NULL);
+  pony_assert(opt != NULL);
 
   // First build our directory strings
   const char* output = opt->output;
@@ -1099,7 +1099,7 @@ static void doc_setup_dirs(docgen_t* docgen, ast_t* program, pass_opt_t* opt)
 
 void generate_docs(ast_t* program, pass_opt_t* options)
 {
-  assert(program != NULL);
+  pony_assert(program != NULL);
 
   if(ast_id(program) != TK_PROGRAM)
     return;

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -9,7 +9,7 @@
 #include "../expr/array.h"
 #include "../expr/ffi.h"
 #include "../expr/lambda.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool is_numeric_primitive(const char* name)
 {
@@ -81,7 +81,7 @@ bool is_result_needed(ast_t* ast)
     {
       // Only if it is a numeric primitive constructor.
       ast_t* type = ast_childidx(parent, 4);
-      assert(ast_id(type) == TK_NOMINAL);
+      pony_assert(ast_id(type) == TK_NOMINAL);
       const char* pkg_name = ast_name(ast_child(type));
       const char* type_name = ast_name(ast_childidx(type, 1));
       if(pkg_name == stringtab("$0")) // Builtin package.
@@ -321,7 +321,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
 
   if(!r)
   {
-    assert(errors_get_count(options->check.errors) > 0);
+    pony_assert(errors_get_count(options->check.errors) > 0);
     return AST_ERROR;
   }
 

--- a/src/libponyc/pass/finalisers.c
+++ b/src/libponyc/pass/finalisers.c
@@ -2,9 +2,9 @@
 #include "../type/lookup.h"
 #include "../type/subtype.h"
 #include "../type/reify.h"
+#include "ponyassert.h"
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 
 enum
 {
@@ -118,11 +118,11 @@ static int check_call_send(ast_t* ast, bool in_final)
     return FINAL_CAN_SEND;
 
   ast_t* def = receiver_def(type);
-  assert(def != NULL);
+  pony_assert(def != NULL);
 
   const char* method_name = ast_name(method);
   ast_t* fun = ast_get(def, method_name, NULL);
-  assert(fun != NULL);
+  pony_assert(fun != NULL);
 
   AST_GET_CHILDREN(fun, cap, id, typeparams, params, result, can_error, body);
   int r = check_body_send(body, false);

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -5,7 +5,7 @@
 #include "../type/compattype.h"
 #include "../type/subtype.h"
 #include "../type/typeparam.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static ast_result_t flatten_union(pass_opt_t* opt, ast_t** astp)
 {
@@ -167,10 +167,10 @@ static ast_result_t flatten_async(pass_opt_t* opt, ast_t* ast)
 static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
   ast_t* error_at, ast_t* list_parent, ast_t** list_end)
 {
-  assert(error_at != NULL);
-  assert(provides_type != NULL);
-  assert(list_parent != NULL);
-  assert(list_end != NULL);
+  pony_assert(error_at != NULL);
+  pony_assert(provides_type != NULL);
+  pony_assert(list_parent != NULL);
+  pony_assert(list_end != NULL);
 
   switch(ast_id(provides_type))
   {
@@ -189,7 +189,7 @@ static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
     {
       // Check type is a trait or interface
       ast_t* def = (ast_t*)ast_data(provides_type);
-      assert(def != NULL);
+      pony_assert(def != NULL);
 
       if(ast_id(def) != TK_TRAIT && ast_id(def) != TK_INTERFACE)
       {
@@ -220,7 +220,7 @@ static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
 static ast_result_t flatten_provides_list(pass_opt_t* opt, ast_t* provider,
   int index)
 {
-  assert(provider != NULL);
+  pony_assert(provider != NULL);
 
   ast_t* provides = ast_childidx(provider, index);
 

--- a/src/libponyc/pass/import.c
+++ b/src/libponyc/pass/import.c
@@ -2,13 +2,13 @@
 #include "../ast/ast.h"
 #include "../ast/symtab.h"
 #include "../ast/id.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <string.h>
 
 
 static bool import_use(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* import = (ast_t*)ast_data(ast);
 
@@ -16,17 +16,17 @@ static bool import_use(pass_opt_t* opt, ast_t* ast)
     return true;
 
   ast_t* module = ast_parent(ast);
-  assert(ast_id(module) == TK_MODULE);
+  pony_assert(ast_id(module) == TK_MODULE);
   symtab_t* mod_symtab = ast_get_symtab(module);
 
   ast_t* package = ast_parent(module);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   symtab_t* pkg_symtab = ast_get_symtab(package);
 
   ast_t* uri_child = ast_childidx(ast, 1);
-  assert(uri_child != NULL);
+  pony_assert(uri_child != NULL);
   const char* uri = ast_name(uri_child);
-  assert(uri != NULL);
+  pony_assert(uri != NULL);
 
   bool is_builtin = (strcmp(uri, "builtin") == 0);
   bool ok = true;
@@ -34,7 +34,7 @@ static bool import_use(pass_opt_t* opt, ast_t* ast)
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
   symtab_t* src_symtab = ast_get_symtab(import);
-  assert(src_symtab != NULL);
+  pony_assert(src_symtab != NULL);
 
   while((sym = symtab_next(src_symtab, &i)) != NULL)
   {

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -4,7 +4,7 @@
 #include "../type/reify.h"
 #include "../type/viewpoint.h"
 #include "../pkg/package.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool names_applycap(pass_opt_t* opt, ast_t* ast, ast_t* cap,
   ast_t* ephemeral)
@@ -63,7 +63,7 @@ static bool names_applycap(pass_opt_t* opt, ast_t* ast, ast_t* cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -91,7 +91,7 @@ static bool names_resolvealias(pass_opt_t* opt, ast_t* def, ast_t** type)
       return false;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -169,7 +169,7 @@ static bool names_typeparam(pass_opt_t* opt, ast_t** astp, ast_t* def)
 {
   ast_t* ast = *astp;
   AST_GET_CHILDREN(ast, package, id, typeargs, cap, ephemeral);
-  assert(ast_id(package) == TK_NONE);
+  pony_assert(ast_id(package) == TK_NONE);
 
   if(ast_id(typeargs) != TK_NONE)
   {
@@ -240,7 +240,7 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
 
 static ast_t* get_package_scope(pass_opt_t* opt, ast_t* scope, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_NOMINAL);
+  pony_assert(ast_id(ast) == TK_NOMINAL);
   ast_t* package_id = ast_child(ast);
 
   // Find our actual package.

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -14,10 +14,10 @@
 #include "docgen.h"
 #include "../codegen/codegen.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 
 #include <string.h>
 #include <stdbool.h>
-#include <assert.h>
 
 
 bool limit_passes(pass_opt_t* opt, const char* pass)
@@ -132,9 +132,9 @@ void pass_opt_done(pass_opt_t* options)
 static bool check_limit(ast_t** astp, pass_opt_t* options, pass_id pass,
   pass_id last_pass)
 {
-  assert(astp != NULL);
-  assert(*astp != NULL);
-  assert(options != NULL);
+  pony_assert(astp != NULL);
+  pony_assert(*astp != NULL);
+  pony_assert(options != NULL);
 
   if(last_pass < pass || options->limit < pass)
     return false;
@@ -152,7 +152,7 @@ static bool check_limit(ast_t** astp, pass_opt_t* options, pass_id pass,
 static bool visit_pass(ast_t** astp, pass_opt_t* options, pass_id last_pass,
   bool* out_r, pass_id pass, ast_visit_t pre_fn, ast_visit_t post_fn)
 {
-  assert(out_r != NULL);
+  pony_assert(out_r != NULL);
 
   if(!check_limit(astp, options, pass, last_pass))
   {
@@ -195,7 +195,7 @@ bool module_passes(ast_t* package, pass_opt_t* options, source_t* source)
 // Peform the AST passes on the given AST up to the specified last pass
 static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   bool r;
 
   if(!visit_pass(astp, options, last, &r, PASS_SUGAR, pass_sugar, NULL))
@@ -254,7 +254,7 @@ bool ast_passes_type(ast_t** astp, pass_opt_t* options)
 {
   ast_t* ast = *astp;
 
-  assert(ast_id(ast) == TK_ACTOR || ast_id(ast) == TK_CLASS ||
+  pony_assert(ast_id(ast) == TK_ACTOR || ast_id(ast) == TK_CLASS ||
     ast_id(ast) == TK_STRUCT || ast_id(ast) == TK_PRIMITIVE ||
     ast_id(ast) == TK_TRAIT || ast_id(ast) == TK_INTERFACE);
 
@@ -294,7 +294,7 @@ bool generate_passes(ast_t* program, pass_opt_t* options)
 
 static void record_ast_pass(ast_t* ast, pass_id pass)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(pass == PASS_ALL)
     return;
@@ -307,8 +307,8 @@ static void record_ast_pass(ast_t* ast, pass_id pass)
 ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
   pass_opt_t* options, pass_id pass)
 {
-  assert(ast != NULL);
-  assert(*ast != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(*ast != NULL);
 
   pass_id ast_pass = (pass_id)ast_checkflag(*ast, AST_FLAG_PASS_MASK);
 
@@ -358,7 +358,7 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
 
         case AST_IGNORE:
           // Can never happen
-          assert(0);
+          pony_assert(0);
           break;
 
         case AST_ERROR:
@@ -406,8 +406,8 @@ ast_result_t ast_visit_scope(ast_t** ast, ast_visit_t pre, ast_visit_t post,
   typecheck_t* t = &options->check;
   ast_t* module = ast_nearest(*ast, TK_MODULE);
   ast_t* package = ast_parent(module);
-  assert(module != NULL);
-  assert(package != NULL);
+  pony_assert(module != NULL);
+  pony_assert(package != NULL);
 
   frame_push(t, NULL);
   frame_push(t, package);

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -7,8 +7,8 @@
 #include "../ast/stringtab.h"
 #include "../ast/astbuild.h"
 #include "../ast/id.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 /**
  * Insert a name->AST mapping into the specified scope.
@@ -16,7 +16,7 @@
 static bool set_scope(pass_opt_t* opt, typecheck_t* t, ast_t* scope,
   ast_t* name, ast_t* value)
 {
-  assert(ast_id(name) == TK_ID);
+  pony_assert(ast_id(name) == TK_ID);
   const char* s = ast_name(name);
 
   if(is_name_dontcare(s))
@@ -61,7 +61,7 @@ static bool set_scope(pass_opt_t* opt, typecheck_t* t, ast_t* scope,
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -84,8 +84,8 @@ static bool set_scope(pass_opt_t* opt, typecheck_t* t, ast_t* scope,
 bool use_package(ast_t* ast, const char* path, ast_t* name,
   pass_opt_t* options)
 {
-  assert(ast != NULL);
-  assert(path != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(path != NULL);
 
   ast_t* package = package_load(ast, path, options);
 
@@ -106,7 +106,7 @@ bool use_package(ast_t* ast, const char* path, ast_t* name,
 
 static void set_fields_undefined(ast_t* ast)
 {
-  assert(ast_id(ast) == TK_NEW);
+  pony_assert(ast_id(ast) == TK_NEW);
 
   ast_t* members = ast_parent(ast);
   ast_t* member = ast_child(members);
@@ -175,7 +175,7 @@ static ast_result_t scope_entity(pass_opt_t* opt, typecheck_t* t, ast_t* ast)
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
         return AST_FATAL;
     }
 

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -12,14 +12,14 @@
 #include "../ast/stringtab.h"
 #include "../ast/token.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 
 static ast_t* make_create(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // Default constructors on classes can be iso, on actors they must be tag
   token_id cap = TK_NONE;
@@ -85,7 +85,7 @@ bool has_member(ast_t* members, const char* name)
 
 static void add_default_constructor(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_t* members = ast_childidx(ast, 4);
 
   // If we have no constructors and no "create" member, add a "create"
@@ -117,7 +117,7 @@ static ast_result_t sugar_module(pass_opt_t* opt, ast_t* ast)
   ast_t* docstring = ast_child(ast);
 
   ast_t* package = ast_parent(ast);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(ast_id(package) == TK_PACKAGE);
 
   if(strcmp(package_name(package), "$0") != 0)
   {
@@ -213,7 +213,7 @@ static ast_result_t sugar_entity(pass_opt_t* opt, ast_t* ast, bool add_create,
           AST_GET_CHILDREN(member, n_cap, n_id, n_typeparam, n_params,
             n_result, n_partial, n_body);
 
-          assert(ast_id(n_body) == TK_SEQ);
+          pony_assert(ast_id(n_body) == TK_SEQ);
 
           ast_t* init = ast_child(init_seq);
 
@@ -259,7 +259,7 @@ static ast_result_t sugar_typeparam(ast_t* ast)
 
 static void sugar_docstring(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, cap, id, type_params, params, return_type,
     error, body, docstring);
@@ -285,7 +285,7 @@ static void sugar_docstring(ast_t* ast)
 // something nasty let in by the case method value parsing.
 static ast_result_t check_params(pass_opt_t* opt, ast_t* params)
 {
-  assert(params != NULL);
+  pony_assert(params != NULL);
   ast_result_t result = AST_OK;
 
   // Check each parameter.
@@ -320,7 +320,7 @@ static ast_result_t check_params(pass_opt_t* opt, ast_t* params)
 // Check for leftover stuff from case methods.
 static ast_result_t check_method(pass_opt_t* opt, ast_t* method)
 {
-  assert(method != NULL);
+  pony_assert(method != NULL);
 
   ast_result_t result = AST_OK;
   ast_t* params = ast_childidx(method, 3);
@@ -328,7 +328,7 @@ static ast_result_t check_method(pass_opt_t* opt, ast_t* method)
 
   // Also check the guard expression doesn't exist.
   ast_t* guard = ast_childidx(method, 8);
-  assert(guard != NULL);
+  pony_assert(guard != NULL);
 
   if(ast_id(guard) != TK_NONE)
   {
@@ -390,7 +390,7 @@ static ast_result_t sugar_be(pass_opt_t* opt, ast_t* ast)
 
 void fun_defaults(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body,
     docstring);
 
@@ -449,7 +449,7 @@ static ast_result_t sugar_return(pass_opt_t* opt, ast_t* ast)
 
   if((ast_id(ast) == TK_RETURN) && (ast_id(opt->check.frame->method) == TK_NEW))
   {
-    assert(ast_id(return_value) == TK_NONE);
+    pony_assert(ast_id(return_value) == TK_NONE);
     ast_setid(return_value, TK_THIS);
   } else {
     expand_none(return_value, false);
@@ -528,14 +528,14 @@ static ast_result_t sugar_for(pass_opt_t* opt, ast_t** astp)
 
 static void build_with_dispose(ast_t* dispose_clause, ast_t* idseq)
 {
-  assert(dispose_clause != NULL);
-  assert(idseq != NULL);
+  pony_assert(dispose_clause != NULL);
+  pony_assert(idseq != NULL);
 
   if(ast_id(idseq) == TK_LET)
   {
     // Just a single variable
     ast_t* id = ast_child(idseq);
-    assert(id != NULL);
+    pony_assert(id != NULL);
 
     // Don't call dispose() on don't cares
     if(is_name_dontcare(ast_name(id)))
@@ -551,7 +551,7 @@ static void build_with_dispose(ast_t* dispose_clause, ast_t* idseq)
   }
 
   // We have a list of variables
-  assert(ast_id(idseq) == TK_TUPLE);
+  pony_assert(ast_id(idseq) == TK_TUPLE);
 
   for(ast_t* p = ast_child(idseq); p != NULL; p = ast_sibling(p))
     build_with_dispose(dispose_clause, p);
@@ -590,7 +590,7 @@ static ast_result_t sugar_with(pass_opt_t* opt, ast_t** astp)
   // Add the "with" variables from each with element
   for(ast_t* p = ast_child(withexpr); p != NULL; p = ast_sibling(p))
   {
-    assert(ast_id(p) == TK_SEQ);
+    pony_assert(ast_id(p) == TK_SEQ);
     AST_GET_CHILDREN(p, idseq, init);
     const char* init_name = package_hygienic_id(&opt->check);
 
@@ -702,8 +702,8 @@ static ast_result_t sugar_case(pass_opt_t* opt, ast_t* ast)
   while(ast_id(next_body) == TK_NONE)
   {
     next = ast_sibling(next);
-    assert(next != NULL);
-    assert(ast_id(next) == TK_CASE);
+    pony_assert(next != NULL);
+    pony_assert(ast_id(next) == TK_CASE);
     next_body = ast_childidx(next, 2);
   }
 
@@ -715,7 +715,7 @@ static ast_result_t sugar_case(pass_opt_t* opt, ast_t* ast)
 static ast_result_t sugar_update(ast_t** astp)
 {
   ast_t* ast = *astp;
-  assert(ast_id(ast) == TK_ASSIGN);
+  pony_assert(ast_id(ast) == TK_ASSIGN);
 
   AST_GET_CHILDREN(ast, value, call);
 
@@ -942,7 +942,7 @@ static ast_result_t sugar_object(pass_opt_t* opt, ast_t** astp)
 static void add_as_type(pass_opt_t* opt, ast_t* type, ast_t* pattern,
   ast_t* body)
 {
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   switch(ast_id(type))
   {
@@ -1025,7 +1025,7 @@ static ast_result_t sugar_as(pass_opt_t* opt, ast_t** astp)
   }
 
   // Don't need top sequence in pattern
-  assert(ast_id(ast_child(pattern_root)) == TK_SEQ);
+  pony_assert(ast_id(ast_child(pattern_root)) == TK_SEQ);
   ast_t* pattern = ast_pop(ast_child(pattern_root));
   ast_free(pattern_root);
 
@@ -1123,8 +1123,8 @@ static ast_result_t sugar_ffi(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t sugar_ifdef(pass_opt_t* opt, ast_t* ast)
 {
-  assert(opt != NULL);
-  assert(ast != NULL);
+  pony_assert(opt != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, cond, then_block, else_block, else_cond);
 
@@ -1134,7 +1134,7 @@ static ast_result_t sugar_ifdef(pass_opt_t* opt, ast_t* ast)
   if(parent_ifdef_cond != NULL)
   {
     // We have a parent ifdef, combine its condition with ours.
-    assert(ast_id(ast_parent(parent_ifdef_cond)) == TK_IFDEF);
+    pony_assert(ast_id(ast_parent(parent_ifdef_cond)) == TK_IFDEF);
 
     REPLACE(&else_cond,
       NODE(TK_AND,
@@ -1172,7 +1172,7 @@ static ast_result_t sugar_ifdef(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t sugar_use(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // Normalise condition so and, or and not nodes aren't sugared to function
   // calls.
@@ -1191,10 +1191,10 @@ static ast_result_t sugar_use(pass_opt_t* opt, ast_t* ast)
 static ast_result_t sugar_semi(pass_opt_t* options, ast_t** astp)
 {
   ast_t* ast = *astp;
-  assert(ast_id(ast) == TK_SEMI);
+  pony_assert(ast_id(ast) == TK_SEMI);
 
   // Semis are pointless, discard them
-  assert(ast_child(ast) == NULL);
+  pony_assert(ast_child(ast) == NULL);
   *astp = ast_sibling(ast);
   ast_remove(ast);
 
@@ -1206,9 +1206,9 @@ static ast_result_t sugar_semi(pass_opt_t* options, ast_t** astp)
 
 static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_EXTRACT_CHILDREN(ast, apply_cap, apply_name, apply_t_params, params,
     ret_type, error, interface_cap, ephemeral);
@@ -1321,7 +1321,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
 
 ast_t* expand_location(ast_t* location)
 {
-  assert(location != NULL);
+  pony_assert(location != NULL);
 
   const char* file_name = ast_source(location)->file;
 
@@ -1378,9 +1378,9 @@ ast_t* expand_location(ast_t* location)
 
 static ast_result_t sugar_location(pass_opt_t* opt, ast_t** astp)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(ast_id(ast_parent(ast)) == TK_PARAM)
     // Location is a default argument, do not expand yet.
@@ -1400,7 +1400,7 @@ static ast_result_t sugar_location(pass_opt_t* opt, ast_t** astp)
 ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
 {
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   switch(ast_id(ast))
   {

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -7,7 +7,7 @@
 #include "../pkg/platformfuns.h"
 #include "../type/assemble.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <string.h>
 #include <ctype.h>
 
@@ -145,8 +145,8 @@ static bool is_expr_infix(token_id id)
 static bool check_provides_type(pass_opt_t* opt, ast_t* type,
   const char* description)
 {
-  assert(type != NULL);
-  assert(description != NULL);
+  pony_assert(type != NULL);
+  pony_assert(description != NULL);
 
   switch(ast_id(type))
   {
@@ -194,13 +194,13 @@ static bool check_provides_type(pass_opt_t* opt, ast_t* type,
 static bool check_permission(pass_opt_t* opt, const permission_def_t* def,
   int element, ast_t* actual, const char* context, ast_t* report_at)
 {
-  assert(def != NULL);
-  assert(actual != NULL);
-  assert(context != NULL);
+  pony_assert(def != NULL);
+  pony_assert(actual != NULL);
+  pony_assert(context != NULL);
 
   char permission = def->permissions[element];
 
-  assert(permission == 'Y' || permission == 'N' || permission == 'X');
+  pony_assert(permission == 'Y' || permission == 'N' || permission == 'X');
 
   if(permission == 'N' && ast_id(actual) != TK_NONE)
   {
@@ -223,8 +223,8 @@ static bool check_permission(pass_opt_t* opt, const permission_def_t* def,
 // Check whether the given method has any illegal parts
 static bool check_method(pass_opt_t* opt, ast_t* ast, int method_def_index)
 {
-  assert(ast != NULL);
-  assert(method_def_index >= 0 && method_def_index < DEF_METHOD_COUNT);
+  pony_assert(ast != NULL);
+  pony_assert(method_def_index >= 0 && method_def_index < DEF_METHOD_COUNT);
   bool r = true;
 
   const permission_def_t* def = &_method_def[method_def_index];
@@ -271,8 +271,8 @@ static bool check_method(pass_opt_t* opt, ast_t* ast, int method_def_index)
 // Check whether the given entity members are legal in their entity
 static bool check_members(pass_opt_t* opt, ast_t* members, int entity_def_index)
 {
-  assert(members != NULL);
-  assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
+  pony_assert(members != NULL);
+  pony_assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
   bool r = true;
 
   const permission_def_t* def = &_entity_def[entity_def_index];
@@ -328,7 +328,7 @@ static bool check_members(pass_opt_t* opt, ast_t* members, int entity_def_index)
 
       default:
         ast_print(members);
-        assert(0);
+        pony_assert(0);
         return false;
     }
 
@@ -343,8 +343,8 @@ static bool check_members(pass_opt_t* opt, ast_t* members, int entity_def_index)
 static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
   int entity_def_index)
 {
-  assert(ast != NULL);
-  assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
+  pony_assert(ast != NULL);
+  pony_assert(entity_def_index >= 0 && entity_def_index < DEF_ENTITY_COUNT);
   ast_result_t r = AST_OK;
 
   const permission_def_t* def = &_entity_def[entity_def_index];
@@ -405,9 +405,9 @@ static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
 
 static ast_result_t syntax_thistype(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_t* parent = ast_parent(ast);
-  assert(parent != NULL);
+  pony_assert(parent != NULL);
   ast_result_t r = AST_OK;
 
   if(ast_id(parent) != TK_ARROW)
@@ -444,7 +444,7 @@ static ast_result_t syntax_thistype(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
 
   switch(ast_id(right))
@@ -473,7 +473,7 @@ static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_nominal(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, package, name, typeargs, cap, eph);
 
   if(!is_name_dontcare(ast_name(name)))
@@ -515,12 +515,12 @@ static ast_result_t syntax_nominal(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_match(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // The last case must have a body
   ast_t* cases = ast_childidx(ast, 1);
-  assert(cases != NULL);
-  assert(ast_id(cases) == TK_CASES);
+  pony_assert(cases != NULL);
+  pony_assert(ast_id(cases) == TK_CASES);
 
   ast_t* case_ast = ast_child(cases);
 
@@ -546,7 +546,7 @@ static ast_result_t syntax_match(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_ffi(pass_opt_t* opt, ast_t* ast,
   bool return_optional)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, id, typeargs, args, named_args);
   ast_result_t r = AST_OK;
 
@@ -565,7 +565,7 @@ static ast_result_t syntax_ffi(pass_opt_t* opt, ast_t* ast,
     if(ast_id(p) == TK_PARAM)
     {
       ast_t* def_val = ast_childidx(p, 2);
-      assert(def_val != NULL);
+      pony_assert(def_val != NULL);
 
       if(ast_id(def_val) != TK_NONE)
       {
@@ -588,11 +588,11 @@ static ast_result_t syntax_ffi(pass_opt_t* opt, ast_t* ast,
 
 static ast_result_t syntax_ellipsis(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   ast_result_t r = AST_OK;
 
   ast_t* fn = ast_parent(ast_parent(ast));
-  assert(fn != NULL);
+  pony_assert(fn != NULL);
 
   if(ast_id(fn) != TK_FFIDECL)
   {
@@ -613,17 +613,17 @@ static ast_result_t syntax_ellipsis(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_infix_expr(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
 
   token_id op = ast_id(ast);
 
-  assert(left != NULL);
+  pony_assert(left != NULL);
   token_id left_op = ast_id(left);
   bool left_clash = (left_op != op) && is_expr_infix(left_op) &&
     !ast_checkflag(left, AST_FLAG_IN_PARENS);
 
-  assert(right != NULL);
+  pony_assert(right != NULL);
   token_id right_op = ast_id(right);
   bool right_clash = (right_op != op) && is_expr_infix(right_op) &&
     !ast_checkflag(right, AST_FLAG_IN_PARENS);
@@ -661,10 +661,10 @@ static ast_result_t syntax_consume(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_return(pass_opt_t* opt, ast_t* ast,
   size_t max_value_count)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* value_seq = ast_child(ast);
-  assert(ast_id(value_seq) == TK_SEQ || ast_id(value_seq) == TK_NONE);
+  pony_assert(ast_id(value_seq) == TK_SEQ || ast_id(value_seq) == TK_NONE);
   size_t value_count = ast_childcount(value_seq);
 
   if(value_count > max_value_count)
@@ -720,8 +720,8 @@ static ast_result_t syntax_return(pass_opt_t* opt, ast_t* ast,
 
 static ast_result_t syntax_semi(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_parent(ast) != NULL);
-  assert(ast_id(ast_parent(ast)) == TK_SEQ);
+  pony_assert(ast_parent(ast) != NULL);
+  pony_assert(ast_id(ast_parent(ast)) == TK_SEQ);
 
   if(ast_checkflag(ast, AST_FLAG_BAD_SEMI))
   {
@@ -779,8 +779,8 @@ static const char* _illegal_flags[] =
 // such as "ifdef condition" or "use guard".
 static bool syntax_ifdef_cond(pass_opt_t* opt, ast_t* ast, const char* context)
 {
-  assert(ast != NULL);
-  assert(context != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(context != NULL);
 
   switch(ast_id(ast))
   {
@@ -866,7 +866,7 @@ static bool syntax_ifdef_cond(pass_opt_t* opt, ast_t* ast, const char* context)
 
 static ast_result_t syntax_ifdef(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(!syntax_ifdef_cond(opt, ast_child(ast), "ifdef condition"))
     return AST_ERROR;
@@ -877,7 +877,7 @@ static ast_result_t syntax_ifdef(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_use(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, id, url, guard);
 
   if(ast_id(id) != TK_NONE && !check_id_package(opt, id))
@@ -908,7 +908,7 @@ static ast_result_t syntax_lambda_capture(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_compile_intrinsic(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* parent = ast_parent(ast);
-  assert(ast_id(parent) == TK_SEQ);
+  pony_assert(ast_id(parent) == TK_SEQ);
 
   ast_t* method = ast_parent(parent);
 
@@ -949,7 +949,7 @@ static ast_result_t syntax_compile_intrinsic(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_compile_error(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* parent = ast_parent(ast);
-  assert(ast_id(parent) == TK_SEQ);
+  pony_assert(ast_id(parent) == TK_SEQ);
 
   if(ast_id(ast_parent(parent)) != TK_IFDEF)
   {
@@ -985,7 +985,7 @@ static ast_result_t syntax_compile_error(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_LAMBDA);
+  pony_assert(ast_id(ast) == TK_LAMBDA);
   AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
     ret_type, raises, body, reference_cap);
   switch(ast_id(ret_type))
@@ -1031,7 +1031,7 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_object(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_OBJECT);
+  pony_assert(ast_id(ast) == TK_OBJECT);
   AST_GET_CHILDREN(ast, cap, provides, members);
 
   // Check for illegal members - even though object literals can be non-actors,
@@ -1045,7 +1045,7 @@ static ast_result_t syntax_object(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_fun(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_FUN);
+  pony_assert(ast_id(ast) == TK_FUN);
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, type, can_error, body);
   switch(ast_id(type))
   {
@@ -1116,9 +1116,9 @@ static ast_result_t syntax_cap_set(pass_opt_t* opt, ast_t* ast)
 
 ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   token_id id = ast_id(ast);
   ast_result_t r = AST_OK;

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -8,7 +8,7 @@
 #include "../type/subtype.h"
 #include "../type/reify.h"
 #include "../../libponyrt/mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 /** The following defines how we determine the signature and body to use for
@@ -66,7 +66,7 @@ static bool trait_entity(ast_t* entity, pass_opt_t* options);
 // Report whether the given node is a method.
 static bool is_method(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   token_id variety = ast_id(ast);
   return (variety == TK_BE) || (variety == TK_FUN) || (variety == TK_NEW);
@@ -76,7 +76,7 @@ static bool is_method(ast_t* ast)
 // Attach a new method_t structure to the given method.
 static method_t* attach_method_t(ast_t* method)
 {
-  assert(method != NULL);
+  pony_assert(method != NULL);
 
   method_t* p = POOL_ALLOC(method_t);
   p->body_donor = NULL;
@@ -92,10 +92,10 @@ static method_t* attach_method_t(ast_t* method)
 // Setup a method_t structure for each method in the given type.
 static void setup_local_methods(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   ast_t* members = ast_childidx(ast, 4);
-  assert(members != NULL);
+  pony_assert(members != NULL);
 
   for(ast_t* p = ast_child(members); p != NULL; p = ast_sibling(p))
   {
@@ -114,17 +114,17 @@ static void setup_local_methods(ast_t* ast)
 // Tidy up the method_t structures in the given entity.
 static void tidy_up(ast_t* entity)
 {
-  assert(entity != NULL);
+  pony_assert(entity != NULL);
 
   ast_t* members = ast_childidx(entity, 4);
-  assert(members != NULL);
+  pony_assert(members != NULL);
 
   for(ast_t* p = ast_child(members); p != NULL; p = ast_sibling(p))
   {
     if(is_method(p))
     {
       method_t* info = (method_t*)ast_data(p);
-      assert(info != NULL);
+      pony_assert(info != NULL);
       ast_t* body_donor = info->body_donor;
       POOL_FREE(method_t, info);
 
@@ -238,13 +238,13 @@ static bool compare_signatures(ast_t* sig_a, ast_t* sig_b)
 static ast_t* reify_provides_type(ast_t* method, ast_t* trait_ref,
   pass_opt_t* opt)
 {
-  assert(method != NULL);
-  assert(trait_ref != NULL);
+  pony_assert(method != NULL);
+  pony_assert(trait_ref != NULL);
 
   // Apply the type args (if any) from the trait reference to the type
   // parameters from the trait definition.
   ast_t* trait_def = (ast_t*)ast_data(trait_ref);
-  assert(trait_def != NULL);
+  pony_assert(trait_def != NULL);
   ast_t* type_args = ast_childidx(trait_ref, 2);
   ast_t* type_params = ast_childidx(trait_def, 1);
 
@@ -268,8 +268,8 @@ static ast_t* reify_provides_type(ast_t* method, ast_t* trait_ref,
 // Return the method with the specified name or NULL if not found.
 static ast_t* find_method(ast_t* entity, const char* name)
 {
-  assert(entity != NULL);
-  assert(name != NULL);
+  pony_assert(entity != NULL);
+  pony_assert(name != NULL);
 
   ast_t* method = ast_get(entity, name, NULL);
 
@@ -294,10 +294,10 @@ static ast_t* find_method(ast_t* entity, const char* name)
 static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
   const char* adjective, pass_opt_t* opt)
 {
-  assert(entity != NULL);
-  assert(trait_ref != NULL);
-  assert(basis_method != NULL);
-  assert(adjective != NULL);
+  pony_assert(entity != NULL);
+  pony_assert(trait_ref != NULL);
+  pony_assert(basis_method != NULL);
+  pony_assert(adjective != NULL);
 
   const char* name = ast_name(ast_childidx(basis_method, 1));
 
@@ -334,7 +334,7 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
     // Should already have checked for methods.
     token_id variety = ast_id(existing);
     (void)variety;
-    assert((variety == TK_FVAR) || (variety == TK_FLET) || (variety == TK_EMBED));
+    pony_assert((variety == TK_FVAR) || (variety == TK_FLET) || (variety == TK_EMBED));
 
     ast_error(opt->check.errors, trait_ref,
       "%s method '%s' clashes with field", adjective, name);
@@ -365,7 +365,7 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
         break;
 
       default:
-        assert(0);
+        pony_assert(0);
         break;
     }
 
@@ -417,7 +417,7 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
     case TK_PARAM:
     case TK_TYPEPARAM:
     {
-      assert(ast_child(ast) != NULL);
+      pony_assert(ast_child(ast) != NULL);
       ast_set(ast, ast_name(ast_child(ast)), ast, SYM_DEFINED, true);
       break;
     }
@@ -441,7 +441,7 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
 
     case TK_TYPEPARAMREF:
     {
-      assert(ast_child(ast) != NULL);
+      pony_assert(ast_child(ast) != NULL);
       ast_t* def = ast_get(ast, ast_name(ast_child(ast)), NULL);
       ast_setdata(ast, def);
       break;
@@ -464,9 +464,9 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
 static bool add_method_from_trait(ast_t* entity, ast_t* method,
   ast_t* trait_ref, pass_opt_t* opt)
 {
-  assert(entity != NULL);
-  assert(method != NULL);
-  assert(trait_ref != NULL);
+  pony_assert(entity != NULL);
+  pony_assert(method != NULL);
+  pony_assert(trait_ref != NULL);
 
   AST_GET_CHILDREN(method, cap, id, t_params, params, result, error,
     method_body);
@@ -490,7 +490,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
 
   // A method with this name already exists.
   method_t* info = (method_t*)ast_data(existing_method);
-  assert(info != NULL);
+  pony_assert(info != NULL);
 
   // Method has already caused an error, do nothing.
   if(info->failed)
@@ -502,7 +502,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
   // Existing method is also provided, signatures must match exactly.
   if(!compare_signatures(existing_method, method))
   {
-    assert(info->trait_ref != NULL);
+    pony_assert(info->trait_ref != NULL);
 
     ast_error(opt->check.errors, trait_ref,
       "clashing definitions for method '%s' provided, local disambiguation "
@@ -547,7 +547,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
     return true;
 
   // Trait provides default body. Use it and patch up symbol tables.
-  assert(ast_id(existing_body) == TK_NONE);
+  pony_assert(ast_id(existing_body) == TK_NONE);
   ast_replace(&existing_body, method_body);
   ast_visit(&method_body, rescope, NULL, opt, PASS_ALL);
 
@@ -561,7 +561,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
 // provides list.
 static bool provided_methods(ast_t* entity, pass_opt_t* opt)
 {
-  assert(entity != NULL);
+  pony_assert(entity != NULL);
 
   ast_t* provides = ast_childidx(entity, 3);
   bool r = true;
@@ -571,7 +571,7 @@ static bool provided_methods(ast_t* entity, pass_opt_t* opt)
     trait_ref = ast_sibling(trait_ref))
   {
     ast_t* trait = (ast_t*)ast_data(trait_ref);
-    assert(trait != NULL);
+    pony_assert(trait != NULL);
 
     if(!trait_entity(trait, opt))
       return false;
@@ -582,7 +582,7 @@ static bool provided_methods(ast_t* entity, pass_opt_t* opt)
     for(ast_t* method = ast_child(members); method != NULL;
       method = ast_sibling(method))
     {
-      assert(is_method(method));
+      pony_assert(is_method(method));
 
       ast_t* reified = reify_provides_type(method, trait_ref, opt);
 
@@ -608,7 +608,7 @@ static bool provided_methods(ast_t* entity, pass_opt_t* opt)
 // Check that the given entity, if concrete, has bodies for all methods.
 static bool check_concrete_bodies(ast_t* entity, pass_opt_t* opt)
 {
-  assert(entity != NULL);
+  pony_assert(entity != NULL);
 
   token_id variety = ast_id(entity);
   if((variety != TK_PRIMITIVE) && (variety != TK_STRUCT) &&
@@ -617,14 +617,14 @@ static bool check_concrete_bodies(ast_t* entity, pass_opt_t* opt)
 
   bool r = true;
   ast_t* members = ast_childidx(entity, 4);
-  assert(members != NULL);
+  pony_assert(members != NULL);
 
   for(ast_t* p = ast_child(members); p != NULL; p = ast_sibling(p))
   {
     if(is_method(p))
     {
       method_t* info = (method_t*)ast_data(p);
-      assert(info != NULL);
+      pony_assert(info != NULL);
 
       if(!info->failed)
       {
@@ -640,7 +640,7 @@ static bool check_concrete_bodies(ast_t* entity, pass_opt_t* opt)
         else if(info->body_donor == NULL)
         {
           // Concrete types must have method bodies.
-          assert(info->trait_ref != NULL);
+          pony_assert(info->trait_ref != NULL);
           ast_error(opt->check.errors, info->trait_ref,
             "no body found for method '%s'", name);
           r = false;
@@ -656,7 +656,7 @@ static bool check_concrete_bodies(ast_t* entity, pass_opt_t* opt)
 // Add provided methods to the given entity.
 static bool trait_entity(ast_t* entity, pass_opt_t* opt)
 {
-  assert(entity != NULL);
+  pony_assert(entity != NULL);
 
   int state = ast_checkflag(entity,
     AST_FLAG_RECURSE_1 | AST_FLAG_DONE_1 | AST_FLAG_ERROR_1);
@@ -682,7 +682,7 @@ static bool trait_entity(ast_t* entity, pass_opt_t* opt)
       return false;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -703,7 +703,7 @@ static bool trait_entity(ast_t* entity, pass_opt_t* opt)
 // Check that embed fields are not recursive.
 static bool embed_fields(ast_t* entity, pass_opt_t* opt)
 {
-  assert(entity != NULL);
+  pony_assert(entity != NULL);
 
   int state = ast_checkflag(entity,
     AST_FLAG_RECURSE_2 | AST_FLAG_DONE_2 | AST_FLAG_ERROR_2);
@@ -729,7 +729,7 @@ static bool embed_fields(ast_t* entity, pass_opt_t* opt)
       return false;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -742,7 +742,7 @@ static bool embed_fields(ast_t* entity, pass_opt_t* opt)
     {
       AST_GET_CHILDREN(member, f_id, f_type);
       ast_t* def = (ast_t*)ast_data(f_type);
-      assert(def != NULL);
+      pony_assert(def != NULL);
 
       if(!embed_fields(def, opt))
         return false;
@@ -763,12 +763,12 @@ static bool embed_fields(ast_t* entity, pass_opt_t* opt)
 // after the name pass (to get temporal capabilities).
 static void local_types(ast_t* ast)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // Setup type or mark as inferred now to allow calling create on a
   // non-inferred local to initialise itself
   AST_GET_CHILDREN(ast, id, type);
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   if(ast_id(type) == TK_NONE)
   {
@@ -786,7 +786,7 @@ static void local_types(ast_t* ast)
 // Add eq() and ne() functions to the given entity.
 static bool add_comparable(ast_t* ast, pass_opt_t* options)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   AST_GET_CHILDREN(ast, id, typeparams, defcap, traits, members);
   ast_t* typeargs = ast_from(typeparams, TK_NONE);

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -2,7 +2,7 @@
 #include "../verify/call.h"
 #include "../verify/control.h"
 #include "../verify/fun.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
 {
@@ -56,7 +56,7 @@ ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
 
   if(!r)
   {
-    assert(errors_get_count(options->check.errors) > 0);
+    pony_assert(errors_get_count(options->check.errors) > 0);
     return AST_ERROR;
   }
 

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -3,8 +3,8 @@
 #include "../ast/stringtab.h"
 #include "../../libponyrt/ds/hash.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 #include <stdio.h>
 
 
@@ -71,21 +71,21 @@ typedef struct flag_t
 // Functions required for our hash table type.
 static size_t flag_hash(flag_t* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
   return ponyint_hash_ptr(flag->name);
 }
 
 static bool flag_cmp(flag_t* a, flag_t* b)
 {
-  assert(a != NULL);
-  assert(b != NULL);
+  pony_assert(a != NULL);
+  pony_assert(b != NULL);
 
   return a->name == b->name;
 }
 
 static flag_t* flag_dup(flag_t* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
 
   flag_t* f = POOL_ALLOC(flag_t);
   memcpy(f, flag, sizeof(flag_t));
@@ -94,7 +94,7 @@ static flag_t* flag_dup(flag_t* flag)
 
 static void flag_free(flag_t* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
   POOL_FREE(flag_t, flag);
 }
 
@@ -122,7 +122,7 @@ struct buildflagset_t
 buildflagset_t* buildflagset_create()
 {
   buildflagset_t* p = POOL_ALLOC(buildflagset_t);
-  assert(p != NULL);
+  pony_assert(p != NULL);
 
   p->have_os_flags = false;
   p->have_arch_flags = false;
@@ -156,7 +156,7 @@ void buildflagset_free(buildflagset_t* set)
 // Returns: index of flag into _os_flags array, or <0 if not an OS flag.
 static ssize_t os_index(const char* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
 
   stringtab_mutexgroups();
 
@@ -173,7 +173,7 @@ static ssize_t os_index(const char* flag)
 // Returns: index of flag into _arch_flags array, or <0 if not an arch flag.
 static ssize_t arch_index(const char* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
 
   stringtab_mutexgroups();
 
@@ -190,7 +190,7 @@ static ssize_t arch_index(const char* flag)
 // Returns: index of flag into _size_flags array, or <0 if not a size flag.
 static ssize_t size_index(const char* flag)
 {
-  assert(flag != NULL);
+  pony_assert(flag != NULL);
 
   stringtab_mutexgroups();
 
@@ -205,10 +205,10 @@ static ssize_t size_index(const char* flag)
 
 void buildflagset_add(buildflagset_t* set, const char* flag)
 {
-  assert(set != NULL);
-  assert(flag != NULL);
-  assert(set->flags != NULL);
-  assert(!set->started_enum);
+  pony_assert(set != NULL);
+  pony_assert(flag != NULL);
+  pony_assert(set->flags != NULL);
+  pony_assert(!set->started_enum);
 
   // First check for mutually exclusive groups.
   if(os_index(flag) >= 0)
@@ -249,8 +249,8 @@ void buildflagset_add(buildflagset_t* set, const char* flag)
 
 double buildflagset_configcount(buildflagset_t* set)
 {
-  assert(set != NULL);
-  assert(set->flags != NULL);
+  pony_assert(set != NULL);
+  pony_assert(set->flags != NULL);
 
   double r = 1.0;
 
@@ -294,8 +294,8 @@ double buildflagset_configcount(buildflagset_t* set)
 
 void buildflagset_startenum(buildflagset_t* set)
 {
-  assert(set != NULL);
-  assert(set->flags != NULL);
+  pony_assert(set != NULL);
+  pony_assert(set->flags != NULL);
 
   set->started_enum = true;
   set->first_config_ready = true;
@@ -315,9 +315,9 @@ void buildflagset_startenum(buildflagset_t* set)
 
 bool buildflagset_next(buildflagset_t* set)
 {
-  assert(set != NULL);
-  assert(set->flags != NULL);
-  assert(set->started_enum);
+  pony_assert(set != NULL);
+  pony_assert(set->flags != NULL);
+  pony_assert(set->started_enum);
 
   if(set->first_config_ready)
   {
@@ -383,10 +383,10 @@ bool buildflagset_next(buildflagset_t* set)
 
 bool buildflagset_get(buildflagset_t* set, const char* flag)
 {
-  assert(set != NULL);
-  assert(flag != NULL);
-  assert(set->flags != NULL);
-  assert(set->started_enum);
+  pony_assert(set != NULL);
+  pony_assert(flag != NULL);
+  pony_assert(set->flags != NULL);
+  pony_assert(set->started_enum);
 
   // First check mutually exclusive groups.
   ssize_t index = os_index(flag);
@@ -410,7 +410,7 @@ bool buildflagset_get(buildflagset_t* set, const char* flag)
   flag_t* f2 = flagtab_get(set->flags, &f1, &h_index);
 
   // Flag MUST have been added previously.
-  assert(f2 != NULL);
+  pony_assert(f2 != NULL);
 
   return f2->value;
 }
@@ -421,9 +421,9 @@ bool buildflagset_get(buildflagset_t* set, const char* flag)
 // Advance the location pointer whether the text is written or not.
 static void print_str(const char* s, buildflagset_t* set, char** pointer)
 {
-  assert(s != NULL);
-  assert(set != NULL);
-  assert(pointer != NULL);
+  pony_assert(s != NULL);
+  pony_assert(set != NULL);
+  pony_assert(pointer != NULL);
 
   size_t len = strlen(s);
 
@@ -443,8 +443,8 @@ static void print_str(const char* s, buildflagset_t* set, char** pointer)
 static void print_flag(const char* flag, bool sense, buildflagset_t* set,
   char** pointer)
 {
-  assert(flag != NULL);
-  assert(set != NULL);
+  pony_assert(flag != NULL);
+  pony_assert(set != NULL);
 
   if(*pointer != set->text_buffer)
     print_str(" ", set, pointer);
@@ -458,8 +458,8 @@ static void print_flag(const char* flag, bool sense, buildflagset_t* set,
 
 const char* buildflagset_print(buildflagset_t* set)
 {
-  assert(set != NULL);
-  assert(set->flags != NULL);
+  pony_assert(set != NULL);
+  pony_assert(set->flags != NULL);
 
   char* p = set->text_buffer;
 
@@ -499,7 +499,7 @@ const char* buildflagset_print(buildflagset_t* set)
   }
 
   // Add terminator.
-  assert(set->text_buffer != NULL);
+  pony_assert(set->text_buffer != NULL);
   set->text_buffer[size_needed - 1] = '\0';
   return set->text_buffer;
 }
@@ -509,7 +509,7 @@ static flagtab_t* _user_flags = NULL;
 
 bool define_build_flag(const char* name)
 {
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   if(_user_flags == NULL)
   {
@@ -535,7 +535,7 @@ bool define_build_flag(const char* name)
 
 bool is_build_flag_defined(const char* name)
 {
-  assert(name != NULL);
+  pony_assert(name != NULL);
 
   if(_user_flags == NULL)
     // Table is not initialised, so no flags are defined.

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -6,18 +6,18 @@
 #include "../ast/symtab.h"
 #include "platformfuns.h"
 #include "../pass/pass.h"
+#include "ponyassert.h"
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 
 
 // Normalise the given ifdef condition.
 static void cond_normalise(ast_t** astp)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
 
   ast_t* ast = *astp;
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   switch(ast_id(ast))
   {
@@ -82,9 +82,9 @@ static void cond_normalise(ast_t** astp)
     case TK_SEQ:
     {
       // Remove the sequence node.
-      assert(ast_childcount(ast) == 1);
+      pony_assert(ast_childcount(ast) == 1);
       ast_t* child = ast_pop(ast);
-      assert(child != NULL);
+      pony_assert(child != NULL);
 
       cond_normalise(&child);
       ast_replace(astp, child);
@@ -100,7 +100,7 @@ static void cond_normalise(ast_t** astp)
 
     default:
       ast_fprint(stderr, ast);
-      assert(0);
+      pony_assert(0);
       break;
   }
 }
@@ -111,7 +111,7 @@ static void cond_normalise(ast_t** astp)
 static bool cond_eval(ast_t* ast, buildflagset_t* config, bool release,
   pass_opt_t* opt)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   switch(ast_id(ast))
   {
@@ -157,7 +157,7 @@ static bool cond_eval(ast_t* ast, buildflagset_t* config, bool release,
 
     default:
       ast_fprint(stderr, ast);
-      assert(0);
+      pony_assert(0);
       return false;
   }
 }
@@ -166,8 +166,8 @@ static bool cond_eval(ast_t* ast, buildflagset_t* config, bool release,
 // Find the build config flags used in the given ifdef condition.
 static void find_flags_in_cond(ast_t* ast, buildflagset_t* config)
 {
-  assert(ast != NULL);
-  assert(config != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(config != NULL);
 
   switch(ast_id(ast))
   {
@@ -197,7 +197,7 @@ static void find_flags_in_cond(ast_t* ast, buildflagset_t* config)
 
     default:
       ast_fprint(stderr, ast);
-      assert(0);
+      pony_assert(0);
       break;
   }
 }
@@ -208,9 +208,9 @@ static void find_flags_in_cond(ast_t* ast, buildflagset_t* config)
 static bool find_decl_flags(ast_t* package, const char* ffi_name,
   buildflagset_t* config)
 {
-  assert(package != NULL);
-  assert(ffi_name != NULL);
-  assert(config != NULL);
+  pony_assert(package != NULL);
+  pony_assert(ffi_name != NULL);
+  pony_assert(config != NULL);
 
   bool had_decl = false;
 
@@ -259,11 +259,11 @@ static bool find_decl_for_config(ast_t* call, ast_t* package,
   const char* ffi_name, buildflagset_t* config, ffi_decl_t* decl_info,
   pass_opt_t* opt)
 {
-  assert(call != NULL);
-  assert(package != NULL);
-  assert(ffi_name != NULL);
-  assert(config != NULL);
-  assert(decl_info != NULL);
+  pony_assert(call != NULL);
+  pony_assert(package != NULL);
+  pony_assert(ffi_name != NULL);
+  pony_assert(config != NULL);
+  pony_assert(decl_info != NULL);
 
   bool had_valid_decl = false;
 
@@ -331,8 +331,8 @@ static bool find_decl_for_config(ast_t* call, ast_t* package,
 // lot.
 static void check_config_count(buildflagset_t* config, ast_t* location)
 {
-  assert(config != NULL);
-  assert(location != NULL);
+  pony_assert(config != NULL);
+  pony_assert(location != NULL);
 
   double config_count = buildflagset_configcount(config);
 
@@ -359,9 +359,9 @@ static void check_config_count(buildflagset_t* config, ast_t* location)
 static bool find_ffi_decl(ast_t* ast, ast_t* package, ast_t* ifdef_cond,
   ast_t** out_decl, pass_opt_t* opt)
 {
-  assert(ast != NULL);
-  assert(package != NULL);
-  assert(out_decl != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(package != NULL);
+  pony_assert(out_decl != NULL);
 
   const char* ffi_name = ast_name(ast_child(ast));
   buildflagset_t* config = buildflagset_create();
@@ -395,12 +395,12 @@ static bool find_ffi_decl(ast_t* ast, ast_t* package, ast_t* ifdef_cond,
         return false;
       }
 
-      assert(decl_info.decl != NULL);
+      pony_assert(decl_info.decl != NULL);
     }
   }
 
   buildflagset_free(config);
-  assert(decl_info.decl != NULL);
+  pony_assert(decl_info.decl != NULL);
   *out_decl = decl_info.decl;
   return true;
 }
@@ -408,8 +408,8 @@ static bool find_ffi_decl(ast_t* ast, ast_t* package, ast_t* ifdef_cond,
 
 bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* opt)
 {
-  assert(astp != NULL);
-  assert(*astp != NULL);
+  pony_assert(astp != NULL);
+  pony_assert(*astp != NULL);
 
   if(ast_id(*astp) == TK_NONE)  // No condition to normalise.
     return true;
@@ -436,7 +436,7 @@ bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* opt)
 
 bool ifdef_cond_eval(ast_t* ast, pass_opt_t* opt)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   if(ast_id(ast) == TK_NONE)  // No condition to evaluate
     return true;
@@ -448,9 +448,9 @@ bool ifdef_cond_eval(ast_t* ast, pass_opt_t* opt)
 bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl,
   pass_opt_t* opt)
 {
-  assert(t != NULL);
-  assert(ast != NULL);
-  assert(out_decl != NULL);
+  pony_assert(t != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(out_decl != NULL);
 
   const char* ffi_name = ast_name(ast_child(ast));
 
@@ -458,7 +458,7 @@ bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl,
   // just search up through scopes as normal since FFI declarations in outer
   // scopes may not be valid within our ifdef.
   ast_t* ifdef = t->frame->ifdef_clause;
-  assert(ifdef != NULL);
+  pony_assert(ifdef != NULL);
 
   symtab_t* symtab = ast_get_symtab(ifdef);
   sym_status_t status;
@@ -471,7 +471,7 @@ bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl,
   if(status == SYM_NONE)
   {
     // We've not looked that up yet.
-    assert(decl == NULL);
+    pony_assert(decl == NULL);
     if(!find_ffi_decl(ast, t->frame->package, t->frame->ifdef_cond, &decl, opt))
     {
       // That went wrong. Record that so we don't try again.

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -8,6 +8,7 @@
 #include "../ast/token.h"
 #include "../expr/literal.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -15,7 +16,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
-#include <assert.h>
 
 #if defined(PLATFORM_IS_LINUX)
 #include <unistd.h>
@@ -98,9 +98,9 @@ static magic_package_t* find_magic_package(const char* path)
 static bool parse_source_file(ast_t* package, const char* file_path,
   pass_opt_t* opt)
 {
-  assert(package != NULL);
-  assert(file_path != NULL);
-  assert(opt != NULL);
+  pony_assert(package != NULL);
+  pony_assert(file_path != NULL);
+  pony_assert(opt != NULL);
 
   if(opt->print_filenames)
     printf("Opening %s\n", file_path);
@@ -126,14 +126,14 @@ static bool parse_source_file(ast_t* package, const char* file_path,
 static bool parse_source_code(ast_t* package, const char* src,
   pass_opt_t* opt)
 {
-  assert(src != NULL);
-  assert(opt != NULL);
+  pony_assert(src != NULL);
+  pony_assert(opt != NULL);
 
   if(opt->print_filenames)
     printf("Opening magic source\n");
 
   source_t* source = source_open_string(src);
-  assert(source != NULL);
+  pony_assert(source != NULL);
 
   return module_passes(package, opt, source);
 }
@@ -245,11 +245,11 @@ static const char* try_path(const char* base, const char* path)
 
 static bool is_root(const char* path)
 {
-  assert(path != NULL);
+  pony_assert(path != NULL);
 
 #if defined(PLATFORM_IS_WINDOWS)
-  assert(path[0] != '\0');
-  assert(path[1] == ':');
+  pony_assert(path[0] != '\0');
+  pony_assert(path[1] == ':');
 
   if((path[2] == '\0'))
     return true;
@@ -842,7 +842,7 @@ ast_t* program_load(const char* path, pass_opt_t* opt)
 
 ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt)
 {
-  assert(from != NULL);
+  pony_assert(from != NULL);
 
   magic_package_t* magic = find_magic_package(path);
   const char* full_path = path;
@@ -955,8 +955,8 @@ ast_t* package_id(ast_t* ast)
 
 const char* package_path(ast_t* package)
 {
-  assert(package != NULL);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(package != NULL);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   package_t* pkg = (package_t*)ast_data(package);
 
   return pkg->path;
@@ -965,8 +965,8 @@ const char* package_path(ast_t* package)
 
 const char* package_qualified_name(ast_t* package)
 {
-  assert(package != NULL);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(package != NULL);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   package_t* pkg = (package_t*)ast_data(package);
 
   return pkg->qualified_name;
@@ -975,10 +975,10 @@ const char* package_qualified_name(ast_t* package)
 
 const char* package_filename(ast_t* package)
 {
-  assert(package != NULL);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(package != NULL);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   package_t* pkg = (package_t*)ast_data(package);
-  assert(pkg != NULL);
+  pony_assert(pkg != NULL);
 
   return pkg->filename;
 }
@@ -986,10 +986,10 @@ const char* package_filename(ast_t* package)
 
 const char* package_symbol(ast_t* package)
 {
-  assert(package != NULL);
-  assert(ast_id(package) == TK_PACKAGE);
+  pony_assert(package != NULL);
+  pony_assert(ast_id(package) == TK_PACKAGE);
   package_t* pkg = (package_t*)ast_data(package);
-  assert(pkg != NULL);
+  pony_assert(pkg != NULL);
 
   return pkg->symbol;
 }
@@ -997,7 +997,7 @@ const char* package_symbol(ast_t* package)
 
 const char* package_hygienic_id(typecheck_t* t)
 {
-  assert(t->frame->package != NULL);
+  pony_assert(t->frame->package != NULL);
   package_t* pkg = (package_t*)ast_data(t->frame->package);
   size_t id = pkg->next_hygienic_id++;
 
@@ -1007,7 +1007,7 @@ const char* package_hygienic_id(typecheck_t* t)
 
 bool package_allow_ffi(typecheck_t* t)
 {
-  assert(t->frame->package != NULL);
+  pony_assert(t->frame->package != NULL);
   package_t* pkg = (package_t*)ast_data(t->frame->package);
   return pkg->allow_ffi;
 }

--- a/src/libponyc/pkg/platformfuns.c
+++ b/src/libponyc/pkg/platformfuns.c
@@ -1,15 +1,15 @@
 #include "platformfuns.h"
 #include "../codegen/genopt.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <string.h>
 
 
 // Report whether the named platform attribute is true
 bool os_is_target(const char* attribute, bool release, bool* out_is_target, pass_opt_t* options)
 {
-  assert(attribute != NULL);
-  assert(out_is_target != NULL);
-  assert(options != NULL);
+  pony_assert(attribute != NULL);
+  pony_assert(out_is_target != NULL);
+  pony_assert(options != NULL);
 
   if(!strcmp(attribute, OS_FREEBSD_NAME))
   {

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -2,8 +2,8 @@
 #include "package.h"
 #include "../ast/stringtab.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 
 // Per program state.
@@ -21,8 +21,8 @@ typedef struct program_t
 // Append the given text to the program's lib args, handling reallocs.
 static void append_to_args(program_t* program, const char* text)
 {
-  assert(program != NULL);
-  assert(text != NULL);
+  pony_assert(program != NULL);
+  pony_assert(text != NULL);
 
   size_t text_len = strlen(text);
   size_t new_len = program->lib_args_size + text_len + 1; // +1 for terminator
@@ -32,7 +32,7 @@ static void append_to_args(program_t* program, const char* text)
     size_t new_alloc = 2 * new_len; // 2* so there's spare space for next arg
     program->lib_args = (char*)realloc(program->lib_args, new_alloc);
     program->lib_args_alloced = new_alloc;
-    assert(new_len <= program->lib_args_alloced);
+    pony_assert(new_len <= program->lib_args_alloced);
   }
 
   strcat(program->lib_args, text);
@@ -55,7 +55,7 @@ program_t* program_create()
 
 void program_free(program_t* program)
 {
-  assert(program != NULL);
+  pony_assert(program != NULL);
 
   strlist_free(program->libpaths);
   strlist_free(program->libs);
@@ -66,11 +66,11 @@ void program_free(program_t* program)
 
 uint32_t program_assign_pkg_id(ast_t* ast)
 {
-  assert(ast != NULL);
-  assert(ast_id(ast) == TK_PROGRAM);
+  pony_assert(ast != NULL);
+  pony_assert(ast_id(ast) == TK_PROGRAM);
 
   program_t* data = (program_t*)ast_data(ast);
-  assert(data != NULL);
+  pony_assert(data != NULL);
 
   return data->next_package_id++;
 }
@@ -84,7 +84,7 @@ uint32_t program_assign_pkg_id(ast_t* ast)
 static const char* quoted_locator(pass_opt_t* opt, ast_t* use,
   const char* locator)
 {
-  assert(locator != NULL);
+  pony_assert(locator != NULL);
 
   if(strpbrk(locator, INVALID_LOCATOR_CHARS) != NULL)
   {
@@ -117,7 +117,7 @@ bool use_library(ast_t* use, const char* locator, ast_t* name,
 
   ast_t* p = ast_nearest(use, TK_PROGRAM);
   program_t* prog = (program_t*)ast_data(p);
-  assert(prog->lib_args == NULL); // Not yet built args
+  pony_assert(prog->lib_args == NULL); // Not yet built args
 
   if(strlist_find(prog->libs, libname) != NULL) // Ignore duplicate
     return true;
@@ -140,7 +140,7 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 
   ast_t* p = ast_nearest(use, TK_PROGRAM);
   program_t* prog = (program_t*)ast_data(p);
-  assert(prog->lib_args == NULL); // Not yet built args
+  pony_assert(prog->lib_args == NULL); // Not yet built args
 
   if(strlist_find(prog->libpaths, libpath) != NULL) // Ignore duplicate
     return true;
@@ -155,16 +155,16 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
   const char* global_preamble, const char* global_postamble,
   const char* lib_premable, const char* lib_postamble)
 {
-  assert(program != NULL);
-  assert(ast_id(program) == TK_PROGRAM);
-  assert(global_preamble != NULL);
-  assert(global_postamble != NULL);
-  assert(lib_premable != NULL);
-  assert(lib_postamble != NULL);
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+  pony_assert(global_preamble != NULL);
+  pony_assert(global_postamble != NULL);
+  pony_assert(lib_premable != NULL);
+  pony_assert(lib_postamble != NULL);
 
   program_t* data = (program_t*)ast_data(program);
-  assert(data != NULL);
-  assert(data->lib_args == NULL); // Not yet built args
+  pony_assert(data != NULL);
+  pony_assert(data->lib_args == NULL); // Not yet built args
 
   // Start with an arbitrary amount of space
   data->lib_args_alloced = 256;
@@ -233,12 +233,12 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
 
 const char* program_lib_args(ast_t* program)
 {
-  assert(program != NULL);
-  assert(ast_id(program) == TK_PROGRAM);
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
 
   program_t* data = (program_t*)ast_data(program);
-  assert(data != NULL);
-  assert(data->lib_args != NULL); // Args have been built
+  pony_assert(data != NULL);
+  pony_assert(data->lib_args != NULL); // Args have been built
 
   return data->lib_args;
 }

--- a/src/libponyc/pkg/use.c
+++ b/src/libponyc/pkg/use.c
@@ -6,8 +6,8 @@
 #include "../pass/pass.h"
 #include "../pass/scope.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 
 /** Use commands are of the form:
@@ -57,9 +57,9 @@ void use_test_handler(use_handler_t handler, bool allow_alias,
 // Find the index of the handler for the given URI
 static int find_handler(pass_opt_t* opt, ast_t* uri, const char** out_locator)
 {
-  assert(uri != NULL);
-  assert(out_locator != NULL);
-  assert(ast_id(uri) == TK_STRING);
+  pony_assert(uri != NULL);
+  pony_assert(out_locator != NULL);
+  pony_assert(ast_id(uri) == TK_STRING);
 
   const char* text = ast_name(uri);
   const char* colon = strchr(text, ':');
@@ -109,9 +109,9 @@ static int find_handler(pass_opt_t* opt, ast_t* uri, const char** out_locator)
 static bool uri_command(pass_opt_t* opt, ast_t* ast, ast_t* uri, ast_t* alias,
   ast_t* guard)
 {
-  assert(uri != NULL);
-  assert(alias != NULL);
-  assert(guard != NULL);
+  pony_assert(uri != NULL);
+  pony_assert(alias != NULL);
+  pony_assert(guard != NULL);
 
   const char* locator;
   int index = find_handler(opt, uri, &locator);
@@ -136,7 +136,7 @@ static bool uri_command(pass_opt_t* opt, ast_t* ast, ast_t* uri, ast_t* alias,
   if(ifdef_cond_normalise(&guard, opt) && !ifdef_cond_eval(guard, opt))
     return true;
 
-  assert(handlers[index].handler != NULL);
+  pony_assert(handlers[index].handler != NULL);
   return handlers[index].handler(ast, locator, alias, opt);
 }
 
@@ -144,7 +144,7 @@ static bool uri_command(pass_opt_t* opt, ast_t* ast, ast_t* uri, ast_t* alias,
 // Handle an ffi command
 static bool ffi_command(pass_opt_t* opt, ast_t* alias)
 {
-  assert(alias != NULL);
+  pony_assert(alias != NULL);
 
   if(ast_id(alias) != TK_NONE)
   {
@@ -158,12 +158,12 @@ static bool ffi_command(pass_opt_t* opt, ast_t* alias)
 
 ast_result_t use_command(ast_t* ast, pass_opt_t* options)
 {
-  assert(ast != NULL);
-  assert(options != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(options != NULL);
 
   AST_GET_CHILDREN(ast, alias, spec, guard);
-  assert(spec != NULL);
-  assert(guard != NULL);
+  pony_assert(spec != NULL);
+  pony_assert(guard != NULL);
 
   switch(ast_id(spec))
   {
@@ -180,7 +180,7 @@ ast_result_t use_command(ast_t* ast, pass_opt_t* options)
     break;
 
   default:
-    assert(0);
+    pony_assert(0);
     return AST_ERROR;
   }
 

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -172,8 +172,8 @@ static bool find_kernel32(vcvars_t* vcvars, errors_t* errors)
 
   vcvars->ucrt[0] = '\0';
   strcpy(vcvars->default_libs,
-    "kernel32.lib msvcrt.lib Ws2_32.lib advapi32.lib "
-    "vcruntime.lib legacy_stdio_definitions.lib");
+    "kernel32.lib msvcrt.lib Ws2_32.lib advapi32.lib vcruntime.lib "
+    "legacy_stdio_definitions.lib dbghelp.lib");
 
   strcpy(vcvars->kernel32, sdk.path);
   strcat(vcvars->kernel32, "Lib\\");

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -1,8 +1,8 @@
 #include "paint.h"
 #include "../../libponyrt/ds/hash.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 #include <stdio.h>
 
 /** We use a greedy algorithm that gives a reasonable trade-off between
@@ -127,7 +127,7 @@ typedef struct painter_t
 // Print out a type map, for debugging only
 static void print_typemap(size_t size, uint64_t* map)
 {
-  assert(map != NULL);
+  pony_assert(map != NULL);
 
   for(size_t i = 0; i < size; i++)
   {
@@ -144,7 +144,7 @@ static void print_typemap(size_t size, uint64_t* map)
 // This is not static so compiler doesn't complain about it not being used
 void painter_print(painter_t* painter)
 {
-  assert(painter != NULL);
+  pony_assert(painter != NULL);
 
   printf("Painter typemaps are " __zu " bits\n",
     painter->typemap_size * sizeof(uint64_t) * 8);
@@ -181,8 +181,8 @@ void painter_print(painter_t* painter)
 // Add a method name record
 static name_record_t* add_name(painter_t* painter, const char* name)
 {
-  assert(painter != NULL);
-  assert(name != NULL);
+  pony_assert(painter != NULL);
+  pony_assert(name != NULL);
 
   size_t map_byte_count = painter->typemap_size * sizeof(uint64_t);
 
@@ -201,7 +201,7 @@ static name_record_t* add_name(painter_t* painter, const char* name)
 // Add a colour record
 static colour_record_t* add_colour(painter_t* painter)
 {
-  assert(painter != NULL);
+  pony_assert(painter != NULL);
 
   size_t map_byte_count = painter->typemap_size * sizeof(uint64_t);
 
@@ -232,8 +232,8 @@ static name_record_t* find_name(painter_t* painter, const char* name)
 // are distinct, ie there is no overlap in their bitmaps.
 static bool is_name_compatible(colour_record_t* colour, name_record_t* name)
 {
-  assert(colour != NULL);
-  assert(name != NULL);
+  pony_assert(colour != NULL);
+  pony_assert(name != NULL);
 
   // Check for type bitmap intersection
   for(size_t i = 0; i < name->typemap_size; i++)
@@ -250,8 +250,8 @@ static bool is_name_compatible(colour_record_t* colour, name_record_t* name)
 // Assign the given name to the given colour
 static void assign_name_to_colour(colour_record_t* colour, name_record_t* name)
 {
-  assert(colour != NULL);
-  assert(name != NULL);
+  pony_assert(colour != NULL);
+  pony_assert(name != NULL);
 
   // Union the type bitmaps
   for(size_t i = 0; i < name->typemap_size; i++)
@@ -264,8 +264,8 @@ static void assign_name_to_colour(colour_record_t* colour, name_record_t* name)
 // Step 1
 static void find_names_types_use(painter_t* painter, reach_types_t* types)
 {
-  assert(painter != NULL);
-  assert(types != NULL);
+  pony_assert(painter != NULL);
+  pony_assert(types != NULL);
 
   size_t i = HASHMAP_BEGIN;
   size_t typemap_index = 0;
@@ -274,7 +274,7 @@ static void find_names_types_use(painter_t* painter, reach_types_t* types)
 
   while((t = reach_types_next(types, &i)) != NULL)
   {
-    assert(typemap_index < painter->typemap_size);
+    pony_assert(typemap_index < painter->typemap_size);
     size_t j = HASHMAP_BEGIN;
     reach_method_name_t* n;
 
@@ -343,8 +343,8 @@ static void assign_colours_to_names(painter_t* painter)
 // Step 5
 static void distribute_info(painter_t* painter, reach_types_t* types)
 {
-  assert(painter != NULL);
-  assert(types != NULL);
+  pony_assert(painter != NULL);
+  pony_assert(types != NULL);
 
   size_t i = HASHMAP_BEGIN;
   reach_type_t* t;
@@ -370,7 +370,7 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
         // Store colour assigned to name in reachable types set
         const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
-        assert(name_rec != NULL);
+        pony_assert(name_rec != NULL);
 
         uint32_t colour = name_rec->colour;
         m->vtable_index = colour;
@@ -389,7 +389,7 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
 // Free everything we've allocated
 static void painter_tidy(painter_t* painter)
 {
-  assert(painter != NULL);
+  pony_assert(painter != NULL);
 
   size_t map_byte_count = painter->typemap_size * sizeof(uint64_t);
 
@@ -409,7 +409,7 @@ static void painter_tidy(painter_t* painter)
 
 void paint(reach_types_t* types)
 {
-  assert(types != NULL);
+  pony_assert(types != NULL);
 
   size_t type_count = reach_types_size(types);
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -7,9 +7,9 @@
 #include "../type/reify.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 DEFINE_STACK(reach_method_stack, reach_method_stack_t,
   reach_method_t);
@@ -298,7 +298,7 @@ static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
 }
 
 static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
@@ -498,7 +498,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
       {
         ast_t* r_member = lookup(NULL, NULL, t->ast,
           ast_name(ast_child(member)));
-        assert(r_member != NULL);
+        pony_assert(r_member != NULL);
 
         AST_GET_CHILDREN(r_member, name, type, init);
 
@@ -750,7 +750,7 @@ static reach_type_t* add_type(reach_t* r, ast_t* type, pass_opt_t* opt)
       return add_nominal(r, type, opt);
 
     default:
-      assert(0);
+      pony_assert(0);
   }
 
   return NULL;
@@ -930,7 +930,7 @@ static void reachable_expr(reach_t* r, ast_t* ast, pass_opt_t* opt)
     case TK_IF:
     {
       AST_GET_CHILDREN(ast, cond, then_clause, else_clause);
-      assert(ast_id(cond) == TK_SEQ);
+      pony_assert(ast_id(cond) == TK_SEQ);
       cond = ast_child(cond);
 
       ast_t* type = ast_type(ast);
@@ -991,7 +991,7 @@ static void reachable_method(reach_t* r, ast_t* type, const char* name,
     {
       // If the method is a finaliser, don't mark the ref and val versions as
       // reachable.
-      assert(n->cap == TK_BOX);
+      pony_assert(n->cap == TK_BOX);
       return;
     }
 

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -4,7 +4,7 @@
 #include "cap.h"
 #include "../ast/token.h"
 #include "../ast/astbuild.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static ast_t* alias_single(ast_t* type)
 {
@@ -45,7 +45,7 @@ static ast_t* alias_single(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -106,7 +106,7 @@ static ast_t* recover_single(ast_t* type, token_id rcap)
           break;
 
         default:
-          assert(0);
+          pony_assert(0);
           return NULL;
       }
       break;
@@ -125,7 +125,7 @@ static ast_t* recover_single(ast_t* type, token_id rcap)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -226,7 +226,7 @@ ast_t* alias(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -288,7 +288,7 @@ ast_t* consume_type(ast_t* type, token_id cap)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -302,7 +302,7 @@ static ast_t* recover_complex(ast_t* type, token_id cap)
       break;
 
     default:
-      assert(false);
+      pony_assert(false);
       break;
   }
 
@@ -376,7 +376,7 @@ ast_t* recover_type(ast_t* type, token_id cap)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -422,7 +422,7 @@ ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call)
         case TK_CAP_ANY:
           // If the receiver is #any, the call is on a tag method and we can
           // chain as #any.
-          assert(fun_cap == TK_TAG);
+          pony_assert(fun_cap == TK_TAG);
           return ast_dup(type);
 
         default: {}
@@ -430,13 +430,13 @@ ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call)
 
       if(ast_id(eph) == TK_NONE)
       {
-        assert(recovered_call || (fun_cap == TK_TAG));
+        pony_assert(recovered_call || (fun_cap == TK_TAG));
         // If the receiver isn't ephemeral, we recovered the call and the type
         // stays the same.
         return ast_dup(type);
       }
 
-      assert(ast_id(eph) == TK_EPHEMERAL);
+      pony_assert(ast_id(eph) == TK_EPHEMERAL);
 
       // If the call was auto-recovered, no alias can exist outside of the
       // object's isolation boundary.
@@ -474,7 +474,7 @@ ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call)
           break;
 
         default:
-          assert(false);
+          pony_assert(false);
           return NULL;
       }
 
@@ -502,7 +502,7 @@ ast_t* chain_type(ast_t* type, token_id fun_cap, bool recovered_call)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -560,7 +560,7 @@ bool sendable(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -618,6 +618,6 @@ bool immutable_or_opaque(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }

--- a/src/libponyc/type/assemble.c
+++ b/src/libponyc/type/assemble.c
@@ -7,7 +7,7 @@
 #include "../pass/names.h"
 #include "../pass/flatten.h"
 #include "../pass/expr.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static void append_one_to_union(pass_opt_t* opt, ast_t* ast, ast_t* append)
 {
@@ -199,7 +199,7 @@ ast_t* type_sugar(ast_t* from, const char* package, const char* name)
 ast_t* control_type_add_branch(pass_opt_t* opt, ast_t* control_type,
   ast_t* branch)
 {
-  assert(branch != NULL);
+  pony_assert(branch != NULL);
 
   ast_t* branch_type = ast_type(branch);
 
@@ -220,7 +220,7 @@ ast_t* control_type_add_branch(pass_opt_t* opt, ast_t* control_type,
       ast_settype(control_type, old_control);
     }
 
-    assert(ast_id(control_type) == TK_LITERAL);
+    pony_assert(ast_id(control_type) == TK_LITERAL);
 
     // Add a literal branch reference to the new branch
     ast_t* member = ast_from(branch, TK_LITERALBRANCH);
@@ -440,6 +440,6 @@ ast_t* set_cap_and_ephemeral(ast_t* type, token_id cap, token_id ephemeral)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -1,7 +1,7 @@
 #include "cap.h"
 #include "../ast/token.h"
 #include "viewpoint.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 // The resulting eph will always be TK_EPHEMERAL or TK_NONE.
 static void cap_aliasing(token_id* cap, token_id* eph)
@@ -632,7 +632,7 @@ ast_t* cap_fetch(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -701,7 +701,7 @@ token_id cap_dispatch(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return TK_NONE;
 }
 
@@ -847,7 +847,7 @@ bool cap_view_upper(token_id left_cap, token_id left_eph,
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -1018,7 +1018,7 @@ bool cap_view_lower(token_id left_cap, token_id left_eph,
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 

--- a/src/libponyc/type/compattype.c
+++ b/src/libponyc/type/compattype.c
@@ -1,7 +1,7 @@
 #include "compattype.h"
 #include "cap.h"
 #include "viewpoint.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool is_nominal_compat_nominal(ast_t* a, ast_t* b)
 {
@@ -200,7 +200,7 @@ static bool is_tuple_compat_x(ast_t* a, ast_t* b)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -229,7 +229,7 @@ static bool is_nominal_compat_x(ast_t* a, ast_t* b)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -258,7 +258,7 @@ static bool is_typeparam_compat_x(ast_t* a, ast_t* b)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -287,7 +287,7 @@ static bool is_arrow_compat_x(ast_t* a, ast_t* b)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -316,6 +316,6 @@ bool is_compat_type(ast_t* a, ast_t* b)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -9,8 +9,8 @@
 #include "../pass/pass.h"
 #include "../pass/expr.h"
 #include "../expr/literal.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static ast_t* lookup_base(pass_opt_t* opt, ast_t* from, ast_t* orig,
   ast_t* type, const char* name, bool errors);
@@ -18,7 +18,7 @@ static ast_t* lookup_base(pass_opt_t* opt, ast_t* from, ast_t* orig,
 static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
   ast_t* type, const char* name, bool errors)
 {
-  assert(ast_id(type) == TK_NOMINAL);
+  pony_assert(ast_id(type) == TK_NOMINAL);
   typecheck_t* t = &opt->check;
 
   ast_t* def = (ast_t*)ast_data(type);
@@ -135,7 +135,7 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
       }
 
       default:
-        assert(0);
+        pony_assert(0);
         return NULL;
     }
 
@@ -375,7 +375,7 @@ static ast_t* lookup_base(pass_opt_t* opt, ast_t* from, ast_t* orig,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -4,7 +4,7 @@
 #include "subtype.h"
 #include "typeparam.h"
 #include "viewpoint.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
   pass_opt_t* opt);
@@ -203,7 +203,7 @@ static matchtype_t is_x_match_tuple(ast_t* operand, ast_t* pattern,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return MATCHTYPE_DENY;
 }
 
@@ -313,7 +313,7 @@ static matchtype_t is_nominal_match_trait(ast_t* operand, ast_t* pattern,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return MATCHTYPE_DENY;
 }
 
@@ -339,7 +339,7 @@ static matchtype_t is_nominal_match_nominal(ast_t* operand, ast_t* pattern,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return MATCHTYPE_DENY;
 }
 
@@ -400,7 +400,7 @@ static matchtype_t is_x_match_nominal(ast_t* operand, ast_t* pattern,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return MATCHTYPE_DENY;
 }
 
@@ -467,7 +467,7 @@ static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return MATCHTYPE_DENY;
 }
 

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -4,18 +4,18 @@
 #include "assemble.h"
 #include "alias.h"
 #include "../ast/token.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static void reify_typeparamref(ast_t** astp, ast_t* typeparam, ast_t* typearg)
 {
   ast_t* ast = *astp;
-  assert(ast_id(ast) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(ast) == TK_TYPEPARAMREF);
 
   ast_t* ref_def = (ast_t*)ast_data(ast);
   ast_t* param_def = (ast_t*)ast_data(typeparam);
 
-  assert(ref_def != NULL);
-  assert(param_def != NULL);
+  pony_assert(ref_def != NULL);
+  pony_assert(param_def != NULL);
 
   if(ref_def != param_def)
     return;
@@ -35,7 +35,7 @@ static void reify_typeparamref(ast_t** astp, ast_t* typeparam, ast_t* typearg)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
   }
 
   ast_replace(astp, typearg);
@@ -44,7 +44,7 @@ static void reify_typeparamref(ast_t** astp, ast_t* typeparam, ast_t* typearg)
 static void reify_arrow(ast_t** astp)
 {
   ast_t* ast = *astp;
-  assert(ast_id(ast) == TK_ARROW);
+  pony_assert(ast_id(ast) == TK_ARROW);
   AST_GET_CHILDREN(ast, left, right);
 
   ast_t* r_left = left;
@@ -94,11 +94,11 @@ static void reify_one(ast_t** astp, ast_t* typeparam, ast_t* typearg)
 bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   pass_opt_t* opt)
 {
-  assert(
+  pony_assert(
     (ast_id(typeparams) == TK_TYPEPARAMS) ||
     (ast_id(typeparams) == TK_NONE)
     );
-  assert(
+  pony_assert(
     (ast_id(typeargs) == TK_TYPEARGS) ||
     (ast_id(typeargs) == TK_NONE)
     );
@@ -153,11 +153,11 @@ ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt,
   bool duplicate)
 {
   (void)opt;
-  assert(
+  pony_assert(
     (ast_id(typeparams) == TK_TYPEPARAMS) ||
     (ast_id(typeparams) == TK_NONE)
     );
-  assert(
+  pony_assert(
     (ast_id(typeargs) == TK_TYPEARGS) ||
     (ast_id(typeargs) == TK_NONE)
     );
@@ -179,8 +179,8 @@ ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt,
     typearg = ast_sibling(typearg);
   }
 
-  assert(typeparam == NULL);
-  assert(typearg == NULL);
+  pony_assert(typeparam == NULL);
+  pony_assert(typearg == NULL);
   return r_ast;
 }
 
@@ -196,7 +196,7 @@ ast_t* reify_method_def(ast_t* ast, ast_t* typeparams, ast_t* typeargs,
       break;
 
     default:
-      assert(false);
+      pony_assert(false);
   }
 
   // Remove the body AST to avoid duplicating it.
@@ -304,7 +304,7 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
     typearg = ast_sibling(typearg);
   }
 
-  assert(typeparam == NULL);
-  assert(typearg == NULL);
+  pony_assert(typeparam == NULL);
+  pony_assert(typearg == NULL);
   return true;
 }

--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -1,7 +1,7 @@
 #include "safeto.h"
 #include "cap.h"
 #include "viewpoint.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static bool safe_field_write(token_id cap, ast_t* type)
 {
@@ -48,7 +48,7 @@ static bool safe_field_write(token_id cap, ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -91,7 +91,7 @@ bool safe_to_write(ast_t* ast, ast_t* type)
     case TK_TUPLE:
     {
       // At this point, we know these will be the same length.
-      assert(ast_id(type) == TK_TUPLETYPE);
+      pony_assert(ast_id(type) == TK_TUPLETYPE);
       ast_t* child = ast_child(ast);
       ast_t* type_child = ast_child(type);
 
@@ -104,7 +104,7 @@ bool safe_to_write(ast_t* ast, ast_t* type)
         type_child = ast_sibling(type_child);
       }
 
-      assert(type_child == NULL);
+      pony_assert(type_child == NULL);
       return true;
     }
 
@@ -119,7 +119,7 @@ bool safe_to_write(ast_t* ast, ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -186,6 +186,6 @@ bool safe_to_autorecover(ast_t* receiver_type, ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }

--- a/src/libponyc/type/sanitise.c
+++ b/src/libponyc/type/sanitise.c
@@ -1,19 +1,19 @@
 #include "sanitise.h"
 #include "../ast/astbuild.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 // Collect the given type parameter
 static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args)
 {
-  assert(orig_param != NULL);
+  pony_assert(orig_param != NULL);
 
   // Get original type parameter info
   AST_GET_CHILDREN(orig_param, id, constraint, deflt);
   const char* name = ast_name(id);
 
   constraint = sanitise_type(constraint);
-  assert(constraint != NULL);
+  pony_assert(constraint != NULL);
 
   // New type parameter has the same constraint as the old one (sanitised)
   if(params != NULL)
@@ -47,7 +47,7 @@ static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args)
 
 void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // Create params and args as TK_NONE, we'll change them if we find any type
   // params
@@ -103,10 +103,10 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
 // Sanitise the given type (sub)AST, which has already been copied
 static void sanitise(ast_t** astp)
 {
-  assert(astp != NULL);
+  pony_assert(astp != NULL);
 
   ast_t* type = *astp;
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   ast_clearflag(*astp, AST_FLAG_PASS_MASK);
 
@@ -114,10 +114,10 @@ static void sanitise(ast_t** astp)
   {
     // We have a type param reference, convert to a nominal
     ast_t* def = (ast_t*)ast_data(type);
-    assert(def != NULL);
+    pony_assert(def != NULL);
 
     const char* name = ast_name(ast_child(def));
-    assert(name != NULL);
+    pony_assert(name != NULL);
 
     REPLACE(astp,
       NODE(TK_NOMINAL,
@@ -138,7 +138,7 @@ static void sanitise(ast_t** astp)
 
 ast_t* sanitise_type(ast_t* type)
 {
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   ast_t* new_type = ast_dup(type);
   sanitise(&new_type);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -8,8 +8,8 @@
 #include "viewpoint.h"
 #include "../ast/astbuild.h"
 #include "../expr/literal.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 
 typedef enum
@@ -173,15 +173,15 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
     }
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
 static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
   pass_opt_t* opt)
 {
-  assert(ast_id(a) == TK_NOMINAL);
-  assert(ast_id(b) == TK_NOMINAL);
+  pony_assert(ast_id(a) == TK_NOMINAL);
+  pony_assert(ast_id(b) == TK_NOMINAL);
 
   // Check typeargs are the same.
   ast_t* a_arg = ast_child(ast_childidx(a, 2));
@@ -375,7 +375,7 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -387,7 +387,7 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -724,7 +724,7 @@ static bool is_tuple_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -809,12 +809,12 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
     // Reify the method on the subtype.
     ast_t* r_sub_member = reify_method_def(sub_member, sub_typeparams,
       sub_typeargs, opt);
-    assert(r_sub_member != NULL);
+    pony_assert(r_sub_member != NULL);
 
     // Reify the method on the supertype.
     ast_t* r_super_member = reify_method_def(super_member, super_typeparams,
       super_typeargs, opt);
-    assert(r_super_member != NULL);
+    pony_assert(r_super_member != NULL);
 
     // Check the reified methods.
     bool ok = is_fun_sub_fun(r_sub_member, r_super_member, errorf, opt);
@@ -885,7 +885,7 @@ static bool nominal_provides_trait(ast_t* type, ast_t* trait,
   {
     // Reify the child with our typeargs.
     ast_t* r_child = reify(child, typeparams, typeargs, opt, true);
-    assert(r_child != NULL);
+    pony_assert(r_child != NULL);
 
     // Use the cap and ephemerality of the trait.
     ast_t* rr_child = set_cap_and_ephemeral(r_child, tcap, teph);
@@ -1006,7 +1006,7 @@ static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1033,7 +1033,7 @@ static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1171,7 +1171,7 @@ static bool is_nominal_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1285,7 +1285,7 @@ static bool is_typeparam_base_sub_x(ast_t* sub, ast_t* super,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1511,15 +1511,15 @@ static bool is_arrow_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
 bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
   errorframe_t* errorf, pass_opt_t* opt)
 {
-  assert(sub != NULL);
-  assert(super != NULL);
+  pony_assert(sub != NULL);
+  pony_assert(super != NULL);
 
   if(ast_id(super) == TK_DONTCARETYPE)
     return true;
@@ -1552,7 +1552,7 @@ bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1582,7 +1582,7 @@ bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt)
 bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,
   pass_opt_t* opt)
 {
-  assert(ast_id(type) == TK_NOMINAL);
+  pony_assert(ast_id(type) == TK_NOMINAL);
   return is_nominal_sub_structural(type, provides, errorf, opt);
 }
 
@@ -1733,7 +1733,7 @@ bool is_constructable(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1793,7 +1793,7 @@ bool is_concrete(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1853,7 +1853,7 @@ bool is_known(ast_t* type)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -1912,7 +1912,7 @@ bool is_entity(ast_t* type, token_id entity)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -2,7 +2,7 @@
 #include "cap.h"
 #include "subtype.h"
 #include "../ast/token.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static token_id cap_union_constraint(token_id a, token_id b)
 {
@@ -333,7 +333,7 @@ static token_id cap_from_constraint(ast_t* type)
   }
 
   // Tuples and arrows can't be used as constraints.
-  assert(0);
+  pony_assert(0);
   return TK_NONE;
 }
 
@@ -433,7 +433,7 @@ static bool apply_cap_to_single(ast_t* type, token_id tcap, token_id teph)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return false;
   }
 
@@ -469,7 +469,7 @@ static bool apply_cap(ast_t* type, token_id tcap, token_id teph)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return false;
 }
 
@@ -497,7 +497,7 @@ static ast_t* constraint_cap(ast_t* typeparamref)
 
 ast_t* typeparam_constraint(ast_t* typeparamref)
 {
-  assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   ast_t* def = (ast_t*)ast_data(typeparamref);
   ast_t* constraint = ast_childidx(def, 1);
   astlist_t* def_list = astlist_push(NULL, def);
@@ -522,13 +522,13 @@ ast_t* typeparam_constraint(ast_t* typeparamref)
 
 ast_t* typeparam_upper(ast_t* typeparamref)
 {
-  assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   return constraint_cap(typeparamref);
 }
 
 ast_t* typeparam_lower(ast_t* typeparamref)
 {
-  assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   ast_t* constraint = typeparam_constraint(typeparamref);
 
   // A constraint must be a final type (primitive, struct, class, actor) in
@@ -541,7 +541,7 @@ ast_t* typeparam_lower(ast_t* typeparamref)
 
 void typeparam_set_cap(ast_t* typeparamref)
 {
-  assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   AST_GET_CHILDREN(typeparamref, id, cap, eph);
   ast_t* constraint = typeparam_constraint(typeparamref);
   token_id tcap = cap_from_constraint(constraint);

--- a/src/libponyc/type/viewpoint.c
+++ b/src/libponyc/type/viewpoint.c
@@ -3,7 +3,7 @@
 #include "assemble.h"
 #include "cap.h"
 #include "../ast/astbuild.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 enum
 {
@@ -66,7 +66,7 @@ ast_t* viewpoint_type(ast_t* l_type, ast_t* r_type)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -120,7 +120,7 @@ ast_t* viewpoint_type(ast_t* l_type, ast_t* r_type)
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -151,7 +151,7 @@ ast_t* viewpoint_upper(ast_t* type)
   // upper(s p'->T k p) = isect[k' in s](T (k'->k) eph(s, p', p))
   // eph(s, p', p) = { unalias(p) if p' = ^, forall k in s . k in {iso, trn}
   //                 { p          otherwise
-  assert(ast_id(type) == TK_ARROW);
+  pony_assert(ast_id(type) == TK_ARROW);
   AST_GET_CHILDREN(type, left, right);
   ast_t* r_right = right;
 
@@ -170,7 +170,7 @@ ast_t* viewpoint_upper(ast_t* type)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -204,7 +204,7 @@ ast_t* viewpoint_upper(ast_t* type)
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -233,7 +233,7 @@ ast_t* viewpoint_lower(ast_t* type)
   // upper(s p'->T k p) = union[k' in s](T (k'->k) eph(s, p', p))
   // eph(s, p', p) = { unalias(p) if p' = ^, exists k in s . k in {iso, trn}
   //                 { p          otherwise
-  assert(ast_id(type) == TK_ARROW);
+  pony_assert(ast_id(type) == TK_ARROW);
   AST_GET_CHILDREN(type, left, right);
   ast_t* r_right = right;
 
@@ -252,7 +252,7 @@ ast_t* viewpoint_lower(ast_t* type)
       break;
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -286,7 +286,7 @@ ast_t* viewpoint_lower(ast_t* type)
     }
 
     default:
-      assert(0);
+      pony_assert(0);
       return NULL;
   }
 
@@ -366,7 +366,7 @@ static void replace_type(ast_t** astp, ast_t* target, ast_t* with)
       }
 
       default:
-        assert(0);
+        pony_assert(0);
     }
   } else if(ast_id(ast) == TK_ARROW) {
     // Recalculate all arrow types.
@@ -381,7 +381,7 @@ ast_t* viewpoint_replace(ast_t* ast, ast_t* target, ast_t* with)
   // Target is thistype or a typeparamref. With is a type (when replacing
   // `this` in a reified method signature) or a single capability (when
   // typechecking arrow types).
-  assert(
+  pony_assert(
     (ast_id(target) == TK_THISTYPE) ||
     (ast_id(target) == TK_TYPEPARAMREF));
 
@@ -408,7 +408,7 @@ static void replace_typeparam(ast_t* tuple, ast_t* type, ast_t* typeparamref,
 
 ast_t* viewpoint_reifytypeparam(ast_t* type, ast_t* typeparamref)
 {
-  assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   AST_GET_CHILDREN(typeparamref, id, cap, eph);
 
   switch(ast_id(cap))
@@ -472,7 +472,7 @@ ast_t* viewpoint_reifytypeparam(ast_t* type, ast_t* typeparamref)
     default: {}
   }
 
-  assert(0);
+  pony_assert(0);
   return NULL;
 }
 
@@ -497,8 +497,8 @@ ast_t* viewpoint_reifythis(ast_t* type)
 
 bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b)
 {
-  assert(ast_id(a) == TK_ARROW);
-  assert(ast_id(b) == TK_ARROW);
+  pony_assert(ast_id(a) == TK_ARROW);
+  pony_assert(ast_id(b) == TK_ARROW);
 
   // Find the first left side that needs reification.
   ast_t* test = a;

--- a/src/libponyc/verify/call.c
+++ b/src/libponyc/verify/call.c
@@ -1,12 +1,12 @@
 #include "call.h"
 #include "../pkg/package.h"
 #include "../type/lookup.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+  pony_assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
     (ast_id(ast) == TK_NEWREF));
   AST_GET_CHILDREN(ast, receiver, method);
 
@@ -18,7 +18,7 @@ static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
   // Look up the original method definition for this method call.
   ast_t* method_def = lookup(opt, receiver, ast_type(receiver),
     ast_name(method));
-  assert(ast_id(method_def) == TK_FUN || ast_id(method_def) == TK_BE ||
+  pony_assert(ast_id(method_def) == TK_FUN || ast_id(method_def) == TK_BE ||
     ast_id(method_def) == TK_NEW);
 
   token_id can_error = ast_id(ast_childidx(method_def, 5));
@@ -32,7 +32,7 @@ static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
 
 static bool check_partial_ffi_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_FFICALL);
+  pony_assert(ast_id(ast) == TK_FFICALL);
   AST_GET_CHILDREN(ast, call_name, call_ret_typeargs, args, named_args,
     call_error);
 
@@ -43,7 +43,7 @@ static bool check_partial_ffi_call(pass_opt_t* opt, ast_t* ast)
     if(ast_id(call_error) == TK_QUESTION)
       ast_seterror(ast);
   } else {
-    assert(ast_id(decl) == TK_FFIDECL);
+    pony_assert(ast_id(decl) == TK_FFIDECL);
     AST_GET_CHILDREN(decl, decl_name, decl_ret_typeargs, params, named_params,
       decl_error);
 
@@ -66,7 +66,7 @@ static bool check_partial_ffi_call(pass_opt_t* opt, ast_t* ast)
 
 bool verify_function_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+  pony_assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
     (ast_id(ast) == TK_NEWREF));
 
   ast_inheritflags(ast);
@@ -81,7 +81,7 @@ bool verify_function_call(pass_opt_t* opt, ast_t* ast)
 bool verify_behaviour_call(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
-  assert((ast_id(ast) == TK_BEREF) || (ast_id(ast) == TK_BECHAIN) ||
+  pony_assert((ast_id(ast) == TK_BEREF) || (ast_id(ast) == TK_BECHAIN) ||
     (ast_id(ast) == TK_NEWBEREF));
 
   ast_inheritflags(ast);
@@ -92,7 +92,7 @@ bool verify_behaviour_call(pass_opt_t* opt, ast_t* ast)
 
 bool verify_ffi_call(pass_opt_t* opt, ast_t* ast)
 {
-  assert(ast_id(ast) == TK_FFICALL);
+  pony_assert(ast_id(ast) == TK_FFICALL);
 
   if(!package_allow_ffi(&opt->check))
   {

--- a/src/libponyc/verify/control.c
+++ b/src/libponyc/verify/control.c
@@ -1,10 +1,10 @@
 #include "control.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 
 bool verify_try(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_TRY) || (ast_id(ast) == TK_TRY_NO_CHECK));
+  pony_assert((ast_id(ast) == TK_TRY) || (ast_id(ast) == TK_TRY_NO_CHECK));
   AST_GET_CHILDREN(ast, body, else_clause, then_clause);
 
   // It has to be possible for the left side to result in an error.

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -1,7 +1,7 @@
 #include "fun.h"
 #include "../type/subtype.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 
 static bool verify_main_create(pass_opt_t* opt, ast_t* ast)
@@ -216,7 +216,7 @@ static bool show_partiality(pass_opt_t* opt, ast_t* ast)
 
 bool verify_fun(pass_opt_t* opt, ast_t* ast)
 {
-  assert((ast_id(ast) == TK_BE) || (ast_id(ast) == TK_FUN) ||
+  pony_assert((ast_id(ast) == TK_BE) || (ast_id(ast) == TK_FUN) ||
     (ast_id(ast) == TK_NEW));
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, type, can_error, body);
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -6,9 +6,9 @@
 #include "../mem/pool.h"
 #include "../gc/cycle.h"
 #include "../gc/trace.h"
+#include "ponyassert.h"
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 #include <dtrace.h>
 
 #ifdef USE_VALGRIND
@@ -173,7 +173,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
 
   // We didn't hit our app message batch limit. We now believe our queue to be
   // empty, but we may have received further messages.
-  assert(app < batch);
+  pony_assert(app < batch);
   try_gc(ctx, actor);
 
   if(has_flag(actor, FLAG_UNSCHEDULED))
@@ -204,7 +204,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
 
 void ponyint_actor_destroy(pony_actor_t* actor)
 {
-  assert(has_flag(actor, FLAG_PENDINGDESTROY));
+  pony_assert(has_flag(actor, FLAG_PENDINGDESTROY));
 
   // Make sure the actor being destroyed has finished marking its queue
   // as empty. Otherwise, it may spuriously see that tail and head are not
@@ -284,7 +284,7 @@ void ponyint_actor_setnoblock(bool state)
 
 PONY_API pony_actor_t* pony_create(pony_ctx_t* ctx, pony_type_t* type)
 {
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   DTRACE1(ACTOR_ALLOC, (uintptr_t)ctx->scheduler);
 
@@ -448,6 +448,6 @@ PONY_API void pony_become(pony_ctx_t* ctx, pony_actor_t* actor)
 
 PONY_API void pony_poll(pony_ctx_t* ctx)
 {
-  assert(ctx->current != NULL);
+  pony_assert(ctx->current != NULL);
   ponyint_actor_run(ctx, ctx->current, 1);
 }

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -2,8 +2,8 @@
 
 #include "messageq.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #ifdef USE_VALGRIND
 #include <valgrind/helgrind.h>
@@ -45,7 +45,7 @@ void ponyint_messageq_init(messageq_t* q)
 void ponyint_messageq_destroy(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
-  assert((((uintptr_t)atomic_load_explicit(&q->head, memory_order_acquire) &
+  pony_assert((((uintptr_t)atomic_load_explicit(&q->head, memory_order_acquire) &
     ~(uintptr_t)1)) == (uintptr_t)tail);
 #ifdef USE_VALGRIND
 #  ifdef NDEBUG

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -2,8 +2,8 @@
 #include "asio.h"
 #include "../actor/actor.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 PONY_API asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
   uint32_t flags, uint64_t nsec, bool noisy)
@@ -43,7 +43,7 @@ PONY_API void pony_asio_event_destroy(asio_event_t* ev)
 {
   if((ev == NULL) || (ev->magic != ev) || (ev->flags != ASIO_DISPOSABLE))
   {
-    assert(0);
+    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -4,13 +4,13 @@
 
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <sys/event.h>
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <signal.h>
-#include <assert.h>
 
 struct asio_backend_t
 {
@@ -196,7 +196,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    assert(0);
+    pony_assert(0);
     return;
   }
 
@@ -253,7 +253,7 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    assert(0);
+    pony_assert(0);
     return;
   }
 
@@ -286,7 +286,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    assert(0);
+    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/ds/hash.c
+++ b/src/libponyrt/ds/hash.c
@@ -1,7 +1,7 @@
 #include "hash.h"
+#include "ponyassert.h"
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 // Minimum HASHMAP size allowed
 #define MIN_HASHMAP_SIZE 8
@@ -97,7 +97,7 @@ static void resize(hashmap_t* map, cmp_fn cmp, alloc_fn alloc,
       (s * sizeof(hashmap_entry_t)), old_item_bitmap);
   }
 
-  assert(map->count == c);
+  pony_assert(map->count == c);
 }
 
 static size_t optimize_item(hashmap_t* map, alloc_fn alloc,
@@ -222,11 +222,11 @@ static void shift_put(hashmap_t* map, void* entry, size_t hash, cmp_fn cmp,
   size_t probe_length = pl;
   size_t oi_probe_length = oi_pl;
 
-  assert(probe_length > oi_probe_length ||
+  pony_assert(probe_length > oi_probe_length ||
     (probe_length == oi_probe_length && probe_length == 0));
 
   while(true) {
-    assert(pos < map->size);
+    pony_assert(pos < map->size);
 
     // need to swap elements
     if(elem == NULL && map->buckets[pos].ptr != NULL)
@@ -307,7 +307,7 @@ void ponyint_hashmap_putindex(hashmap_t* map, void* entry, size_t hash,
   if(map->size == 0)
     ponyint_hashmap_init(map, 4, alloc);
 
-  assert(pos < map->size);
+  pony_assert(pos < map->size);
 
   // if bucket is empty
   if(map->buckets[pos].ptr == NULL)
@@ -350,7 +350,7 @@ void ponyint_hashmap_putindex(hashmap_t* map, void* entry, size_t hash,
 
 static void shift_delete(hashmap_t* map, size_t index)
 {
-  assert(index < map->size);
+  pony_assert(index < map->size);
   size_t pos = index;
   size_t mask = map->size - 1;
   size_t next_pos = (pos + 1) & mask;
@@ -445,7 +445,7 @@ void* ponyint_hashmap_next(size_t* i, size_t count, bitmap_t* item_bitmap,
       index += (ffs_offset - 1);
 
       // no need to check if valid element because item bitmap keeps track of it
-      assert(buckets[index].ptr != NULL);
+      pony_assert(buckets[index].ptr != NULL);
       *i = index;
       return buckets[index].ptr;
     }

--- a/src/libponyrt/ds/list.c
+++ b/src/libponyrt/ds/list.c
@@ -1,7 +1,7 @@
 #include "list.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <stdlib.h>
-#include <assert.h>
 
 typedef struct list_t
 {

--- a/src/libponyrt/ds/stack.c
+++ b/src/libponyrt/ds/stack.c
@@ -1,6 +1,6 @@
 #include "stack.h"
 #include "../mem/pool.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static Stack* stack_new(Stack* prev, void* data)
 {
@@ -14,8 +14,8 @@ static Stack* stack_new(Stack* prev, void* data)
 
 Stack* ponyint_stack_pop(Stack* stack, void** data)
 {
-  assert(stack != NULL);
-  assert(data != NULL);
+  pony_assert(stack != NULL);
+  pony_assert(data != NULL);
 
   stack->index--;
   *data = stack->data[stack->index];

--- a/src/libponyrt/gc/actormap.c
+++ b/src/libponyrt/gc/actormap.c
@@ -5,8 +5,8 @@
 #include "../ds/hash.h"
 #include "../ds/fun.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 static size_t actorref_hash(actorref_t* aref)
 {

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -5,10 +5,10 @@
 #include "../ds/stack.h"
 #include "../ds/hash.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include <assert.h>
 
 typedef struct init_msg_t
 {
@@ -268,7 +268,7 @@ static bool mark_grey(detector_t* d, view_t* view, size_t rc)
   if(view->color == COLOR_GREY)
     return false;
 
-  assert(view->color == COLOR_BLACK);
+  pony_assert(view->color == COLOR_BLACK);
   view->color = COLOR_GREY;
   return true;
 }
@@ -298,7 +298,7 @@ static bool mark_black(view_t* view, size_t rc, int* count)
 {
   if(!view->blocked || (view->actor == NULL))
   {
-    assert(view->color == COLOR_BLACK);
+    pony_assert(view->color == COLOR_BLACK);
     return false;
   }
 
@@ -345,7 +345,7 @@ static bool mark_white(view_t* view, int* count)
   if(view->color != COLOR_GREY)
     return false;
 
-  assert(view->blocked);
+  pony_assert(view->blocked);
 
   if(view->rc > 0)
   {
@@ -354,7 +354,7 @@ static bool mark_white(view_t* view, int* count)
     return false;
   }
 
-  assert(view->perceived == NULL);
+  pony_assert(view->perceived == NULL);
 
   view->color = COLOR_WHITE;
   *count = *count + 1;
@@ -390,8 +390,8 @@ static bool collect_view(perceived_t* per, view_t* view, size_t rc, int* count)
 {
   if(view->color == COLOR_WHITE)
   {
-    assert(view->deferred == false);
-    assert(view->perceived == NULL);
+    pony_assert(view->deferred == false);
+    pony_assert(view->perceived == NULL);
 
     view->perceived = per;
     ponyint_viewmap_put(&per->map, view);
@@ -445,11 +445,11 @@ static void send_conf(pony_ctx_t* ctx, detector_t* d, perceived_t* per)
 
 static bool detect(pony_ctx_t* ctx, detector_t* d, view_t* view)
 {
-  assert(view->perceived == NULL);
+  pony_assert(view->perceived == NULL);
 
   scan_grey(d, view, 0);
   int count = scan_white(view);
-  assert(count >= 0);
+  pony_assert(count >= 0);
 
   if(count == 0)
     return false;
@@ -466,8 +466,8 @@ static bool detect(pony_ctx_t* ctx, detector_t* d, view_t* view)
   int count2 = collect_white(per, view, 0);
 
   (void)count2;
-  assert(count2 == count);
-  assert(ponyint_viewmap_size(&per->map) == (size_t)count);
+  pony_assert(count2 == count);
+  pony_assert(ponyint_viewmap_size(&per->map) == (size_t)count);
 
   send_conf(ctx, d, per);
   return true;
@@ -488,7 +488,7 @@ static void deferred(pony_ctx_t* ctx, detector_t* d)
 
   while((view = ponyint_viewmap_next(&d->deferred, &i)) != NULL)
   {
-    assert(view->deferred == true);
+    pony_assert(view->deferred == true);
     ponyint_viewmap_removeindex(&d->deferred, i);
 
     // always scan again from same index because robin hood hashmap
@@ -543,7 +543,7 @@ static void collect(pony_ctx_t* ctx, detector_t* d, perceived_t* per)
   // mark actors in the cycle as pending destruction
   while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
   {
-    assert(view->perceived == per);
+    pony_assert(view->perceived == per);
 
     // remove from the deferred set
     if(view->deferred)
@@ -631,7 +631,7 @@ static void unblock(detector_t* d, pony_actor_t* actor)
 
   // we must be in the views, because we must have blocked in order to unblock
   view_t* view = ponyint_viewmap_get(&d->views, &key, &index);
-  assert(view != NULL);
+  pony_assert(view != NULL);
 
   // record that we're unblocked
   view->blocked = false;
@@ -775,7 +775,7 @@ static void check_view(detector_t* d, view_t* view)
 
   scan_grey(d, view, 0);
   int count = scan_white(view);
-  assert(count >= 0);
+  pony_assert(count >= 0);
 
   printf("%p: %s\n", view->actor, count > 0 ? "COLLECTABLE" : "uncollectable");
 }
@@ -880,8 +880,8 @@ void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t min_deferred,
 
 void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
 {
-  assert(ctx->current == actor);
-  assert(&actor->gc == gc);
+  pony_assert(ctx->current == actor);
+  pony_assert(&actor->gc == gc);
 
   block_msg_t* m = (block_msg_t*)pony_alloc_msg(
     POOL_INDEX(sizeof(block_msg_t)), ACTORMSG_BLOCK);
@@ -889,7 +889,7 @@ void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
   m->actor = actor;
   m->rc = ponyint_gc_rc(gc);
   m->delta = ponyint_gc_delta(gc);
-  assert(gc->delta == NULL);
+  pony_assert(gc->delta == NULL);
 
   pony_sendv(ctx, cycle_detector, &m->msg);
 }

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -2,8 +2,8 @@
 #include "../actor/actor.h"
 #include "../sched/scheduler.h"
 #include "../mem/pagemap.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #define GC_ACTOR_HEAP_EQUIV 1024
 #define GC_IMMUT_HEAP_EQUIV 1024
@@ -51,7 +51,7 @@ static void recv_local_actor(gc_t* gc)
   if(gc->rc_mark != gc->mark)
   {
     gc->rc_mark = gc->mark;
-    assert(gc->rc > 0);
+    pony_assert(gc->rc > 0);
     gc->rc--;
   }
 }
@@ -63,7 +63,7 @@ static void acquire_local_actor(gc_t* gc)
 
 static void release_local_actor(gc_t* gc)
 {
-  assert(gc->rc > 0);
+  pony_assert(gc->rc > 0);
   gc->rc--;
 }
 
@@ -157,7 +157,7 @@ static void recv_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   size_t index = HASHMAP_UNKNOWN;
   gc_t* gc = ponyint_actor_gc(ctx->current);
   object_t* obj = ponyint_objectmap_getobject(&gc->local, p, &index);
-  assert(obj != NULL);
+  pony_assert(obj != NULL);
 
   if(obj->mark == gc->mark)
     return;
@@ -225,7 +225,7 @@ static void release_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   size_t index = HASHMAP_UNKNOWN;
   gc_t* gc = ponyint_actor_gc(ctx->current);
   object_t* obj = ponyint_objectmap_getobject(&gc->local, p, &index);
-  assert(obj != NULL);
+  pony_assert(obj != NULL);
 
   if(obj->mark == gc->mark)
     return;
@@ -652,7 +652,7 @@ bool ponyint_gc_acquire(gc_t* gc, actorref_t* aref)
 bool ponyint_gc_release(gc_t* gc, actorref_t* aref)
 {
   size_t rc = aref->rc;
-  assert(gc->rc >= rc);
+  pony_assert(gc->rc >= rc);
   gc->rc -= rc;
 
   objectmap_t* map = &aref->map;
@@ -665,7 +665,7 @@ bool ponyint_gc_release(gc_t* gc, actorref_t* aref)
     void* p = obj->address;
     object_t* obj_local = ponyint_objectmap_getobject(&gc->local, p, &index);
 
-    assert(obj_local->rc >= obj->rc);
+    pony_assert(obj_local->rc >= obj->rc);
     obj_local->rc -= obj->rc;
   }
 
@@ -696,7 +696,7 @@ void ponyint_gc_sendacquire(pony_ctx_t* ctx)
     pony_sendp(ctx, aref->actor, ACTORMSG_ACQUIRE, aref);
   }
 
-  assert(ponyint_actormap_size(&ctx->acquire) == 0);
+  pony_assert(ponyint_actormap_size(&ctx->acquire) == 0);
 }
 
 void ponyint_gc_sendrelease(pony_ctx_t* ctx, gc_t* gc)
@@ -715,7 +715,7 @@ void ponyint_gc_sendrelease_manual(pony_ctx_t* ctx)
     pony_sendp(ctx, aref->actor, ACTORMSG_RELEASE, aref);
   }
 
-  assert(ponyint_actormap_size(&ctx->acquire) == 0);
+  pony_assert(ponyint_actormap_size(&ctx->acquire) == 0);
 }
 
 void ponyint_gc_register_final(pony_ctx_t* ctx, void* p, pony_final_fn final)

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -4,7 +4,7 @@
 #include "../ds/fun.h"
 #include "../mem/pool.h"
 #include "../mem/pagemap.h"
-#include <assert.h>
+#include "ponyassert.h"
 
 static size_t object_hash(object_t* obj)
 {

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -5,8 +5,8 @@
 #include "serialise.h"
 #include "../sched/scheduler.h"
 #include "../lang/lang.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #if defined(PLATFORM_IS_POSIX_BASED)
 #include <dlfcn.h>
@@ -194,7 +194,7 @@ PONY_API size_t pony_serialise_offset(pony_ctx_t* ctx, void* p)
 PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, void* out)
 {
   // This can raise an error.
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_serialise_object;
   ctx->trace_actor = ponyint_serialise_actor;
   ctx->serialise_size = 0;

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -3,12 +3,12 @@
 #include "../sched/scheduler.h"
 #include "../sched/cpu.h"
 #include "../actor/actor.h"
-#include <assert.h>
+#include "ponyassert.h"
 #include <dtrace.h>
 
 PONY_API void pony_gc_send(pony_ctx_t* ctx)
 {
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_sendobject;
   ctx->trace_actor = ponyint_gc_sendactor;
 
@@ -17,7 +17,7 @@ PONY_API void pony_gc_send(pony_ctx_t* ctx)
 
 PONY_API void pony_gc_recv(pony_ctx_t* ctx)
 {
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_recvobject;
   ctx->trace_actor = ponyint_gc_recvactor;
 
@@ -26,21 +26,21 @@ PONY_API void pony_gc_recv(pony_ctx_t* ctx)
 
 void ponyint_gc_mark(pony_ctx_t* ctx)
 {
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_markobject;
   ctx->trace_actor = ponyint_gc_markactor;
 }
 
 PONY_API void pony_gc_acquire(pony_ctx_t* ctx)
 {
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_acquireobject;
   ctx->trace_actor = ponyint_gc_acquireactor;
 }
 
 PONY_API void pony_gc_release(pony_ctx_t* ctx)
 {
-  assert(ctx->stack == NULL);
+  pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_releaseobject;
   ctx->trace_actor = ponyint_gc_releaseactor;
 }

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -3,9 +3,9 @@
 #ifdef PLATFORM_IS_POSIX_BASED
 
 #include "lsda.h"
+#include "ponyassert.h"
 #include <unwind.h>
 #include <stdlib.h>
-#include <assert.h>
 
 PONY_EXTERN_C_BEGIN
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -6,9 +6,9 @@
 #include "lang.h"
 #include "../asio/asio.h"
 #include "../asio/event.h"
+#include "ponyassert.h"
 #include <stdbool.h>
 #include <string.h>
-#include <assert.h>
 
 #ifdef PLATFORM_IS_WINDOWS
 // Disable warnings about deprecated non-unicode WSA functions.
@@ -428,7 +428,7 @@ static int socket_from_addrinfo(struct addrinfo* p, bool reuse)
 #elif defined(PLATFORM_IS_WINDOWS)
   UINT_PTR skt = WSASocket(p->ai_family, p->ai_socktype, p->ai_protocol, NULL,
     0, WSA_FLAG_OVERLAPPED);
-  assert((skt == INVALID_SOCKET) || ((skt >> 31) == 0));
+  pony_assert((skt == INVALID_SOCKET) || ((skt >> 31) == 0));
   int fd = (int)skt;
 #else
   int fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -1,8 +1,8 @@
 #include "heap.h"
 #include "pagemap.h"
 #include "../ds/fun.h"
+#include "ponyassert.h"
 #include <string.h>
-#include <assert.h>
 
 #include <platform.h>
 #include <dtrace.h>

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -4,12 +4,12 @@
 #include "alloc.h"
 #include "../ds/fun.h"
 #include "../sched/cpu.h"
+#include "ponyassert.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include <platform.h>
 #include <pony/detail/atomics.h>
@@ -269,7 +269,7 @@ static void track_alloc(void* p, size_t size)
 static void track_free(void* p, size_t size)
 {
   track_init();
-  assert(!track.internal);
+  pony_assert(!track.internal);
 
   track.internal = true;
 
@@ -284,7 +284,7 @@ static void track_free(void* p, size_t size)
 static void track_push(pool_item_t* p, size_t length, size_t size)
 {
   track_init();
-  assert(!track.internal);
+  pony_assert(!track.internal);
 
   track.internal = true;
   uint64_t tsc = ponyint_cpu_tick();
@@ -309,7 +309,7 @@ static void track_push(pool_item_t* p, size_t length, size_t size)
 static void track_pull(pool_item_t* p, size_t length, size_t size)
 {
   track_init();
-  assert(!track.internal);
+  pony_assert(!track.internal);
 
   track.internal = true;
   uint64_t tsc = ponyint_cpu_tick();
@@ -466,7 +466,7 @@ static void pool_push(pool_local_t* thread, pool_global_t* global)
   thread->pool = NULL;
   thread->length = 0;
 
-  assert(p->length == global->count);
+  pony_assert(p->length == global->count);
   TRACK_PUSH((pool_item_t*)p, p->length, global->size);
 
   size_t my_ticket = atomic_fetch_add_explicit(&global->ticket, 1,
@@ -533,7 +533,7 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
 
   pool_item_t* p = (pool_item_t*)top;
 
-  assert(top->length == global->count);
+  pony_assert(top->length == global->count);
   TRACK_PULL(p, top->length, global->size);
 
   thread->pool = p->next;
@@ -616,7 +616,7 @@ void ponyint_pool_free(size_t index, void* p)
 #endif
 
   TRACK_FREE(p, POOL_MIN << index);
-  assert(index < POOL_COUNT);
+  pony_assert(index < POOL_COUNT);
 
   pool_local_t* thread = &pool_local[index];
   pool_global_t* global = &pool_global[index];

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -1,0 +1,142 @@
+#define PONY_WANT_ATOMIC_DEFS
+
+#include "ponyassert.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef PLATFORM_IS_POSIX_BASED
+#  include <execinfo.h>
+#  include <unistd.h>
+#else
+#  include <Windows.h>
+#  include <DbgHelp.h>
+#endif
+
+#include <pony/detail/atomics.h>
+
+static atomic_flag assert_guard = ATOMIC_FLAG_INIT;
+
+#ifdef PLATFORM_IS_POSIX_BASED
+
+void ponyint_assert_fail(const char* expr, const char* file, size_t line,
+  const char* func)
+{
+  while(atomic_flag_test_and_set_explicit(&assert_guard, memory_order_acq_rel))
+  {
+    // If the guard is already set, an assertion fired in another thread. The
+    // things here aren't thread safe, so we just start an infinite loop.
+    struct timespec ts = {1, 0};
+    nanosleep(&ts, NULL);
+  }
+
+  fprintf(stderr, "%s:" __zu ": %s: Assertion `%s` failed.\n\n", file, line,
+    func, expr);
+
+  void* addrs[256];
+  int depth = backtrace(addrs, 256);
+  char** strings = backtrace_symbols(addrs, depth);
+
+  fputs("Backtrace:\n", stderr);
+
+  for(int i = 0; i < depth; i++)
+    printf("  %s\n", strings[i]);
+
+  free(strings);
+
+  if(strcmp(PONY_BUILD_CONFIG, "release") == 0)
+  {
+    fputs("This is an optimised version of ponyc: the backtrace may be "
+      "imprecise or incorrect.\nUse a debug version to get more meaningful "
+      "information.\n", stderr);
+  }
+
+  fflush(stderr);
+  abort();
+}
+
+#elif defined(PLATFORM_IS_WINDOWS)
+
+void ponyint_assert_fail(const char* expr, const char* file, size_t line,
+  const char* func)
+{
+  while(atomic_flag_test_and_set_explicit(&assert_guard, memory_order_acq_rel))
+  {
+    // If the guard is already set, an assertion fired in another thread. The
+    // things here aren't thread safe, so we just start an infinite loop.
+    Sleep(1);
+  }
+
+  fprintf(stderr, "%s:" __zu ": %s: Assertion `%s` failed.\n\n", file, line,
+    func, expr);
+
+  HANDLE process = GetCurrentProcess();
+  HANDLE thread = GetCurrentThread();
+
+  CONTEXT context;
+  memset(&context, 0, sizeof(context));
+  context.ContextFlags = CONTEXT_ALL;
+  RtlCaptureContext(&context);
+  SymInitialize(process, NULL, true);
+
+  STACKFRAME64 frame;
+  memset(&frame, 0, sizeof(frame));
+  frame.AddrPC.Mode = AddrModeFlat;
+  frame.AddrStack.Mode = AddrModeFlat;
+  frame.AddrFrame.Mode = AddrModeFlat;
+
+#  ifdef _M_IX86
+  frame.AddrPC.Offset = context.Eip;
+  frame.AddrStack.Offset = context.Esp;
+  frame.AddrFrame.Offset = context.Ebp;
+  DWORD machine = IMAGE_FILE_MACHINE_I386;
+#  elif defined(_M_X64)
+  frame.AddrPC.Offset = context.Rip;
+  frame.AddrStack.Offset = context.Rsp;
+  frame.AddrFrame.Offset = context.Rbp;
+  DWORD machine = IMAGE_FILE_MACHINE_AMD64;
+#  endif
+
+  fputs("Backtrace:\n", stderr);
+
+  while(true)
+  {
+    SetLastError(0);
+    if(!StackWalk64(machine, process, thread, &frame, &context, 0,
+      SymFunctionTableAccess64, SymGetModuleBase64, 0))
+      break;
+
+    DWORD64 addr = frame.AddrFrame.Offset;
+    if(addr == 0)
+      break;
+
+    union
+    {
+      SYMBOL_INFO sym;
+      BYTE buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME];
+    } sym_buf;
+    PSYMBOL_INFO symbol = &sym_buf.sym;
+    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    symbol->MaxNameLen = MAX_SYM_NAME;
+
+    if(SymFromAddr(process, frame.AddrPC.Offset, NULL, symbol))
+    {
+      fprintf(stderr, "  (%s) [%p]\n", symbol->Name,
+        (void*)frame.AddrPC.Offset);
+    } else {
+      fprintf(stderr, "  () [%p]\n", (void*)frame.AddrPC.Offset);
+    }
+  }
+
+  if(strcmp(PONY_BUILD_CONFIG, "release") == 0)
+  {
+    fputs("This is an optimised version of ponyc: the backtrace may be "
+      "imprecise or incorrect.\nUse a debug version to get more meaningful "
+      "information.\n", stderr);
+  }
+
+  SymCleanup(process);
+  fflush(stderr);
+  abort();
+}
+
+#endif

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -7,10 +7,10 @@
 #include "../gc/cycle.h"
 #include "../asio/asio.h"
 #include "../mem/pool.h"
+#include "ponyassert.h"
 #include <dtrace.h>
 #include <string.h>
 #include <stdio.h>
-#include <assert.h>
 
 #define SCHED_BATCH 100
 
@@ -277,7 +277,7 @@ static void run(scheduler_t* sched)
       if(actor == NULL)
       {
         // Termination.
-        assert(pop(sched) == NULL);
+        pony_assert(pop(sched) == NULL);
         return;
       }
       DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)actor);

--- a/test/libponyc/lexint.cc
+++ b/test/libponyc/lexint.cc
@@ -5,6 +5,7 @@
 #include <ast/lexint.h>
 
 #include "util.h"
+#include "ponyassert.h"
 
 
 class LexIntTest : public testing::Test
@@ -13,7 +14,7 @@ class LexIntTest : public testing::Test
 
 static lexint_t* lexint(lexint_t* i, uint64_t high, uint64_t low)
 {
-  assert(i != NULL);
+  pony_assert(i != NULL);
   i->low = low;
   i->high = high;
   return i;

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -3,6 +3,7 @@
 #include <type/matchtype.h>
 #include <ast/astbuild.h>
 #include "util.h"
+#include "ponyassert.h"
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
 
@@ -343,8 +344,8 @@ TEST_F(MatchTypeTest, Tuples)
   // t1t2 instead.
   ast_t* t1t2 = type_of("t1t2");
   AST_GET_CHILDREN(t1t2, elem1, elem2);
-  assert(ast_id(elem1) == TK_NOMINAL);
-  assert(ast_id(elem2) == TK_NOMINAL);
+  pony_assert(ast_id(elem1) == TK_NOMINAL);
+  pony_assert(ast_id(elem2) == TK_NOMINAL);
 
   REPLACE(&elem2, NODE(TK_DONTCARETYPE));
 

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -6,6 +6,7 @@
 #include <../libponyrt/mem/pool.h>
 
 #include "util.h"
+#include "ponyassert.h"
 
 class PaintTest: public testing::Test
 {
@@ -91,7 +92,7 @@ protected:
       m2.name = n->name;
       reach_method_t* method = reach_methods_get(&n->r_methods, &m2, &index);
 
-      assert(method != NULL);
+      pony_assert(method != NULL);
 
       if(method->vtable_index > max_colour)
         max_colour = method->vtable_index;

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -10,11 +10,11 @@
 #include <codegen/genjit.h>
 #include <../libponyrt/pony.h>
 #include <../libponyrt/mem/pool.h>
+#include <ponyassert.h>
 
 #include "util.h"
 #include <string.h>
 #include <string>
-#include <assert.h>
 
 using std::string;
 
@@ -108,8 +108,8 @@ static const char* _builtin =
 // Check whether the 2 given ASTs are identical
 static bool compare_asts(ast_t* expected, ast_t* actual, errors_t *errors)
 {
-  assert(expected != NULL);
-  assert(actual != NULL);
+  pony_assert(expected != NULL);
+  pony_assert(actual != NULL);
 
   token_id expected_id = ast_id(expected);
   token_id actual_id = ast_id(actual);
@@ -349,26 +349,26 @@ void PassTest::test_equiv(const char* actual_src, const char* actual_pass,
 
 ast_t* PassTest::type_of(const char* name)
 {
-  assert(name != NULL);
-  assert(program != NULL);
+  pony_assert(name != NULL);
+  pony_assert(program != NULL);
   return type_of_within(program, name);
 }
 
 
 ast_t* PassTest::numeric_literal(uint64_t num)
 {
-  assert(program != NULL);
+  pony_assert(program != NULL);
   return numeric_literal_within(program, num);
 }
 
 
 ast_t* PassTest::lookup_in(ast_t* ast, const char* name)
 {
-  assert(ast != NULL);
-  assert(name != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(name != NULL);
 
   symtab_t* symtab = ast_get_symtab(ast);
-  assert(symtab != NULL);
+  pony_assert(symtab != NULL);
 
   return symtab_find(symtab, stringtab(name), NULL);
 }
@@ -376,18 +376,18 @@ ast_t* PassTest::lookup_in(ast_t* ast, const char* name)
 
 ast_t* PassTest::lookup_type(const char* name)
 {
-  assert(package != NULL);
+  pony_assert(package != NULL);
   return lookup_in(package, name);
 }
 
 
 ast_t* PassTest::lookup_member(const char* type_name, const char* member_name)
 {
-  assert(type_name != NULL);
-  assert(member_name != NULL);
+  pony_assert(type_name != NULL);
+  pony_assert(member_name != NULL);
 
   ast_t* type = lookup_type(type_name);
-  assert(type != NULL);
+  pony_assert(type != NULL);
 
   return lookup_in(type, member_name);
 }
@@ -395,7 +395,7 @@ ast_t* PassTest::lookup_member(const char* type_name, const char* member_name)
 
 bool PassTest::run_program(int* exit_code)
 {
-  assert(compile != NULL);
+  pony_assert(compile != NULL);
 
   pony_exitcode(0);
   jit_symbol_t symbols[] = {{"__DescTable", &__DescTable},
@@ -497,8 +497,8 @@ void PassTest::build_package(const char* pass, const char* src,
 
 ast_t* PassTest::type_of_within(ast_t* ast, const char* name)
 {
-  assert(ast != NULL);
-  assert(name != NULL);
+  pony_assert(ast != NULL);
+  pony_assert(name != NULL);
 
   // Is this node the definition we're looking for?
   switch(ast_id(ast))
@@ -536,7 +536,7 @@ ast_t* PassTest::type_of_within(ast_t* ast, const char* name)
 
 ast_t* PassTest::numeric_literal_within(ast_t* ast, uint64_t num)
 {
-  assert(ast != NULL);
+  pony_assert(ast != NULL);
 
   // Is this node the definition we're looking for?
   if (ast_id(ast) == TK_INT && lexint_cmp64(ast_int(ast), num) == 0)

--- a/wscript
+++ b/wscript
@@ -74,7 +74,8 @@ def configure(ctx):
         ctx.env.PONYC_EXTRA_LIBS = [
             'kernel32', 'user32', 'gdi32', 'winspool', 'comdlg32',
             'advapi32', 'shell32', 'ole32', 'oleaut32', 'uuid',
-            'odbc32', 'odbccp32', 'vcruntime', 'ucrt', 'Ws2_32'
+            'odbc32', 'odbccp32', 'vcruntime', 'ucrt', 'Ws2_32',
+            'dbghelp'
         ]
 
         ctx.env.MSVC_VERSIONS = ['msvc ' + MSVC_VERSION + '.0']
@@ -240,7 +241,8 @@ def build(ctx):
         features = 'c cxx cxxstlib seq',
         target   = 'libponyrt',
         source   = ctx.path.ant_glob('src/libponyrt/**/*.c'),
-        includes = [ 'src/common', 'src/libponyrt' ] + sslIncludes
+        includes = [ 'src/common', 'src/libponyrt' ] + sslIncludes,
+        defines  = [ 'PONY_NO_ASSERT' ]
     )
 
     # ponyc


### PR DESCRIPTION
This change will allow getting more complete reports from assertion failures. This will smooth the the bug report process, as users won't have to get a backtrace from a debugger. As part of this change, assertions are now enabled in release builds of the compiler, as discussed in #1553. They still are disabled in release builds of the runtime.

In the future, this system could be extended with even more precise information like line numbers. Parsing the debug information of the executables and libraries will be required for this.

Closes #1553.

PS: The tests should all fail, I've added an always firing assertion to check if the backtrace report works correctly on all systems.