### PR TITLE
Move the CCallback test to the compiler tests

### DIFF
--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -65,7 +65,6 @@ actor Main is TestList
     test(_TestNumberConversionSaturation)
     test(_TestMaybePointer)
     test(_TestValtrace)
-    test(_TestCCallback)
 
 
 class iso _TestAbs is UnitTest
@@ -1545,19 +1544,3 @@ class iso _TestMaybePointer is UnitTest
 
     let from_b = b()
     h.assert_eq[U32](s.i, from_b.i)
-
-
-class Callback
-  fun apply(value: I32): I32 =>
-    value * 2
-
-class iso _TestCCallback is UnitTest
-  """
-  Test C callbacks.
-  """
-  fun name(): String => "builtin/CCallback"
-
-  fun apply(h: TestHelper) =>
-    let cb: Callback = Callback
-    let r = @pony_test_callback[I32](cb, addressof cb.apply, I32(3))
-    h.assert_eq[I32](6, r)

--- a/src/libponyrt/lang/paths.c
+++ b/src/libponyrt/lang/paths.c
@@ -32,11 +32,4 @@ PONY_API char* pony_os_realpath(const char* path)
   return cstring;
 }
 
-typedef int (*callback_fn)(void* self, int value);
-
-PONY_API int pony_test_callback(void* self, callback_fn cb, int value)
-{
-  return cb(self, value);
-}
-
 PONY_EXTERN_C_END

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -112,11 +112,44 @@ TEST_F(CodegenTest, JitRun)
     "  new create(env: Env) =>\n"
     "    @pony_exitcode[None](I32(1))";
 
-  set_builtin(NULL);
-
   TEST_COMPILE(src);
 
   int exit_code = 0;
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 1);
+}
+
+
+extern "C"
+{
+
+typedef int (*codegentest_ccallback_fn)(void* self, int value);
+
+EXPORT_SYMBOL int codegentest_ccallback(void* self, codegentest_ccallback_fn cb,
+  int value)
+{
+  return cb(self, value);
+}
+
+}
+
+
+TEST_F(CodegenTest, CCallback)
+{
+  const char* src =
+    "class Callback\n"
+    "  fun apply(value: I32): I32 =>\n"
+    "    value * 2\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let cb: Callback = Callback\n"
+    "    let r = @codegentest_ccallback[I32](cb, addressof cb.apply, I32(3))\n"
+    "    @pony_exitcode[None](r)";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 6);
 }

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -19,12 +19,6 @@
 using std::string;
 
 
-#ifdef PLATFORM_IS_VISUAL_STUDIO
-#  define EXPORT_SYMBOL __declspec(dllexport)
-#else
-#  define EXPORT_SYMBOL
-#endif
-
 // These will be set when running a JIT'ed program.
 extern "C"
 {
@@ -35,63 +29,66 @@ extern "C"
 
 static const char* _builtin =
   "primitive U8 is Real[U8]\n"
-  "  new create() => 0\n"
-  "  fun mul(a: U8): U8 => 0\n"
+  "  new create(a: U8 = 0) => a\n"
+  "  fun mul(a: U8): U8 => this * a\n"
   "primitive I8 is Real[I8]"
-  "  new create() => 0\n"
+  "  new create(a: I8 = 0) => a\n"
   "  fun neg():I8 => -this\n"
   "primitive U16 is Real[U16]"
-  "  new create() => 0\n"
+  "  new create(a: U16 = 0) => a\n"
   "primitive I16 is Real[I16]"
-  "  new create() => 0\n"
+  "  new create(a: I16 = 0) => a\n"
   "  fun neg():I16 => -this\n"
-  "  fun mul(a: I16): I16 => 0\n"
+  "  fun mul(a: I16): I16 => this * a\n"
   "primitive U32 is Real[U32]"
-  "  new create() => 0\n"
+  "  new create(a: U32 = 0) => a\n"
   "primitive I32 is Real[I32]"
-  "  new create() => 0\n"
+  "  new create(a: I32 = 0) => a\n"
   "  fun neg():I32 => -this\n"
+  "  fun mul(a: I32): I32 => this * a\n"
   "primitive U64 is Real[U64]"
-  "  new create() => 0\n"
+  "  new create(a: U64 = 0) => a\n"
   "primitive I64 is Real[I64]"
-  "  new create() => 0\n"
+  "  new create(a: I64 = 0) => a\n"
   "  fun neg():I64 => -this\n"
-  "  fun mul(a: I64): I64 => 0\n"
-  "  fun op_or(a: I64): I64 => 0\n"
-  "  fun op_and(a: I64): I64 => 0\n"
-  "  fun op_xor(a: I64): I64 => 0\n"
+  "  fun mul(a: I64): I64 => this * a\n"
+  "  fun op_or(a: I64): I64 => this or a\n"
+  "  fun op_and(a: I64): I64 => this and a\n"
+  "  fun op_xor(a: I64): I64 => this xor a\n"
   "primitive U128 is Real[U128]"
-  "  new create() => 0\n"
-  "  fun mul(a: U128): U128 => 0\n"
-  "  fun div(a: U128): U128 => 0\n"
+  "  new create(a: U128 = 0) => a\n"
+  "  fun mul(a: U128): U128 => this * a\n"
+  "  fun div(a: U128): U128 => this / a\n"
   "primitive I128 is Real[I128]"
-  "  new create() => 0\n"
+  "  new create(a: I128 = 0) => a\n"
   "  fun neg():I128 => -this\n"
   "primitive ULong is Real[ULong]"
-  "  new create() => 0\n"
+  "  new create(a: ULong = 0) => a\n"
   "primitive ILong is Real[ILong]"
-  "  new create() => 0\n"
+  "  new create(a: ILong = 0) => a\n"
   "  fun neg():ILong => -this\n"
   "primitive USize is Real[USize]"
-  "  new create() => 0\n"
+  "  new create(a: USize = 0) => a\n"
   "primitive ISize is Real[ISize]"
-  "  new create() => 0\n"
+  "  new create(a: ISize = 0) => a\n"
   "  fun neg():ISize => -this\n"
   "primitive F32 is Real[F32]"
-  "  new create() => 0\n"
+  "  new create(a: F32 = 0) => a\n"
   "primitive F64 is Real[F64]"
-  "  new create() => 0\n"
+  "  new create(a: F64 = 0) => a\n"
   "type Number is (Signed | Unsigned | Float)\n"
   "type Signed is (I8 | I16 | I32 | I64 | I128 | ILong | ISize)\n"
   "type Unsigned is (U8 | U16 | U32 | U64 | U128 | ULong | USize)\n"
   "type Float is (F32 | F64)\n"
   "trait val Real[A: Real[A] val]\n"
   "class val Env\n"
-  "  new _create() => None\n"
+  "  new _create(argc: U32, argv: Pointer[Pointer[U8]] val,\n"
+  "    envp: Pointer[Pointer[U8]] val)\n"
+  "  => None\n"
   "primitive None\n"
   "primitive Bool\n"
   "class val String\n"
-  "class Pointer[A]\n"
+  "struct Pointer[A]\n"
   "interface Seq[A]\n"
   // Fake up arrays and iterators enough to allow tests to
   // - create array literals
@@ -491,8 +488,7 @@ void PassTest::build_package(const char* pass, const char* src,
 
   if(check_good)
   {
-    if(program != NULL)
-      errors_print(opt.check.errors);
+    errors_print(opt.check.errors);
 
     ASSERT_NE((void*)NULL, program);
   }

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -19,6 +19,12 @@
     ASSERT_EQ(expected, ast_id(t)); \
   }
 
+#ifdef PLATFORM_IS_VISUAL_STUDIO
+#  define EXPORT_SYMBOL __declspec(dllexport)
+#else
+#  define EXPORT_SYMBOL
+#endif
+
 
 class PassTest : public testing::Test
 {


### PR DESCRIPTION
Now that we have JIT tests, this is the most logical place for this test and moving it allows removing the pony_test_callback from libponyrt.