### PR TITLE
Pick up changes to the exit code from primitive finalisers

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -697,6 +697,17 @@ static void init_runtime(compile_t* c)
 #  endif
 #endif
 
+  // i32 pony_get_exitcode()
+  type = LLVMFunctionType(c->i32, NULL, 0, false);
+  value = LLVMAddFunction(c->module, "pony_get_exitcode", type);
+#if PONY_LLVM >= 309
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, readonly_attr);
+#else
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+  LLVMAddFunctionAttr(value, LLVMReadOnlyAttribute);
+#endif
+
   // void pony_throw()
   type = LLVMFunctionType(c->void_type, NULL, 0, false);
   value = LLVMAddFunction(c->module, "pony_throw", type);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -133,6 +133,9 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
     LLVMBuildCall(c->builder, c->primitives_final, NULL, 0, "");
     args[0] = final_actor;
     gencall_runtime(c, "ponyint_destroy", args, 1, "");
+    // The exit code may have been set by one of the primitive finalisers.
+    // Reload it.
+    rc = gencall_runtime(c, "pony_get_exitcode", NULL, 0, "");
   }
 
   // Return the runtime exit code.

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -377,10 +377,15 @@ PONY_API int pony_stop();
 /** Set the exit code.
  *
  * The value returned by pony_start() will be 0 unless set to something else
- * with this call. If called more than once, the value from the last call is
- * returned.
+ * with this call.
  */
 PONY_API void pony_exitcode(int code);
+
+/** Get the exit code.
+ *
+ * Get the value of the last pony_exitcode() call.
+ */
+PONY_API int pony_get_exitcode();
 
 /**
  * If an actor is currently unscheduled, this will reschedule it. This is not

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -141,7 +141,13 @@ PONY_API int pony_start(bool library, bool language_features)
   if(library)
     return 0;
 
-  return atomic_load_explicit(&exit_code, memory_order_relaxed);
+  if(language_init)
+  {
+    ponyint_os_sockets_final();
+    language_init = false;
+  }
+
+  return pony_get_exitcode();
 }
 
 PONY_API int pony_stop()
@@ -153,10 +159,15 @@ PONY_API int pony_stop()
     language_init = false;
   }
 
-  return atomic_load_explicit(&exit_code, memory_order_relaxed);
+  return pony_get_exitcode();
 }
 
 PONY_API void pony_exitcode(int code)
 {
   atomic_store_explicit(&exit_code, code, memory_order_relaxed);
+}
+
+PONY_API int pony_get_exitcode()
+{
+  return atomic_load_explicit(&exit_code, memory_order_relaxed);
 }


### PR DESCRIPTION
Previously, a primitive finaliser calling `pony_exitcode` wouldn't affect the actual exit code of the program. This occurred because the value used was the value returned from `pony_start`, and finalisers were ran after returning from `pony_start`.

This change adds the `pony_get_exitcode` function, which returns the current value of the exit code as set by `pony_exitcode`.