### PR TITLE
Minor updates to persistent map

### DIFF
--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -152,13 +152,13 @@ class val _MapNode[K: (mut.Hashable val & Equatable[K]), V: Any #share]
       end
     end
 
-  fun _set_bit(bm: U32, i: U32): U32 => bm or (1 << i)
+  fun _set_bit(bm: U32, i: U32): U32 => bm or (U32(1) <<~ i)
 
-  fun _clear_bit(bm: U32, i: U32): U32 => bm and (not (1 << i))
+  fun _clear_bit(bm: U32, i: U32): U32 => bm and (not (U32(1) <<~ i))
 
-  fun _has_bit(bm: U32, i: U32): Bool => (bm and (1 << i)) != 0
+  fun _has_bit(bm: U32, i: U32): Bool => (bm and (U32(1) <<~ i)) != 0
 
-  fun _mask(hash: U32, l: U8): U32 => (hash >> (5 * l.u32())) and 0x01f
+  fun _mask(hash: U32, l: U8): U32 => (hash >> (U32(5) *~ l.u32())) and 0x01f
 
   fun _array_index(nm: U32, dm: U32, idx: U32): U32 =>
     let msk = not(0xffff_ffff << idx)

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -6,14 +6,14 @@ primitive Maps
     """
     Return an empty map.
     """
-    Map[K, V]._empty()
+    Map[K, V]
 
   fun val from[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   (pairs: Array[(K, val->V)]): Map[K, V] ? =>
     """
     Return a map containing the provided key-value pairs.
     """
-    var m = Map[K, V]._empty()
+    var m = Map[K, V]
     for pair in pairs.values() do
       m = m(pair._1) = pair._2
     end
@@ -40,7 +40,7 @@ class val Map[K: (mut.Hashable val & Equatable[K]), V: Any #share]
   let _root: _MapNode[K, V]
   let _size: USize
 
-  new val _empty() =>
+  new val create() =>
     _root = _MapNode[K, V].empty(0)
     _size = 0
 


### PR DESCRIPTION
This PR makes two minor changes to the persistent Map:
1. `_MapNode` methods `_set_bit`, `_clear_bit`, `_has_bit`, and `_mask` use unsafe operators since the variable `i` is never greater than 31 and the variable `l` is never greater than 6.
2. The constructor for an empty Map is made available to the user. Previously, the functionality of a basic create method was only available through a separate primitive method.