### PR TITLE
TCPListener: unsubscribe asio before socket close

### DIFF
--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -216,13 +216,13 @@ actor TCPListener
     _closed = true
 
     if not _event.is_null() then
-      @pony_os_socket_close[None](_fd)
-      _fd = -1
-
       // When not on windows, the unsubscribe is done immediately.
       ifdef not windows then
         @pony_asio_event_unsubscribe(_event)
       end
+
+      @pony_os_socket_close[None](_fd)
+      _fd = -1
 
       _notify.closed(this)
     end


### PR DESCRIPTION
This commit changes TCPListener to unsubscribe asio events
prior to closing the socket and file descriptor.

This prevents events from being reported for closed sockets
due to any race conditions related to socket close and
epoll receiving an event between the socket close request
and the actual close occurring.

See: http://stackoverflow.com/questions/8707601/is-it-necessary-to-deregister-a-socket-from-epoll-before-closing-it

---------------

In my limited testing, this change results in less failures in the TCP tests with the following output where the server never accepts a connection:

```
**** FAILED: net/TCPMute
Test timed out without completing
Action never completed: receiver accepted
Action never completed: receiver muted
Action never completed: receiver asks for data
Action never completed: sender sent data
Action never completed: server accept
```

This failure seems to mostly be due to a combination of `fd reuse` combined with the lack of unsubscribe before the close which this PR resolves.