### PR TITLE
Change benchmarks to limit use of `PauseTiming`/`ResumeTiming`

### DIFF
--- a/benchmark/libponyc/common/common.cc
+++ b/benchmark/libponyc/common/common.cc
@@ -1,0 +1,37 @@
+#include <benchmark/benchmark.h>
+
+static void $$$$$$_PauseResumeOverheadOnce(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadOnce);
+
+static void $$$$$$_PauseResumeOverheadTwice(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadTwice);
+
+static void $$$$$$_PauseResumeOverheadThrice(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadThrice);

--- a/benchmark/libponyrt/common/common.cc
+++ b/benchmark/libponyrt/common/common.cc
@@ -1,0 +1,37 @@
+#include <benchmark/benchmark.h>
+
+static void $$$$$$_PauseResumeOverheadOnce(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadOnce);
+
+static void $$$$$$_PauseResumeOverheadTwice(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadTwice);
+
+static void $$$$$$_PauseResumeOverheadThrice(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+    st.PauseTiming();
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK($$$$$$_PauseResumeOverheadThrice);

--- a/benchmark/libponyrt/mem/heap.cc
+++ b/benchmark/libponyrt/mem/heap.cc
@@ -28,21 +28,17 @@ void HeapBench::TearDown(const ::benchmark::State& st)
   }
 }
 
-BENCHMARK_DEFINE_F(HeapBench, HeapAlloc)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(HeapBench, HeapAlloc$)(benchmark::State& st) {
   pony_actor_t* actor = (pony_actor_t*)0xDBEEFDEADBEEF;
 
   while (st.KeepRunning()) {
-    st.PauseTiming();
     if(st.range(0) > HEAP_MAX)
     {
-      st.ResumeTiming();
       ponyint_heap_alloc_large(actor, &_heap, st.range(0));
-      st.PauseTiming();
     } else {
-      st.ResumeTiming();
       ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(st.range(0)));
-      st.PauseTiming();
     }
+    st.PauseTiming();
     ponyint_heap_destroy(&_heap);
     ponyint_heap_init(&_heap);
     st.ResumeTiming();
@@ -50,24 +46,86 @@ BENCHMARK_DEFINE_F(HeapBench, HeapAlloc)(benchmark::State& st) {
   st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(HeapBench, HeapAlloc)->RangeMultiplier(2)->Ranges({{32, 1024<<10}});
+BENCHMARK_REGISTER_F(HeapBench, HeapAlloc$)->RangeMultiplier(2)->Ranges({{32, 1024<<10}});
 
-BENCHMARK_DEFINE_F(HeapBench, HeapDestroy)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(HeapBench, HeapAlloc$_)(benchmark::State& st) {
   pony_actor_t* actor = (pony_actor_t*)0xDBEEFDEADBEEF;
 
   while (st.KeepRunning()) {
+    if(st.range(0) > HEAP_MAX)
+    {
+      for(int i = 0; i < st.range(1); i++)
+        ponyint_heap_alloc_large(actor, &_heap, st.range(0));
+    } else {
+      for(int i = 0; i < st.range(1); i++)
+        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(st.range(0)));
+    }
     st.PauseTiming();
+    ponyint_heap_destroy(&_heap);
+    ponyint_heap_init(&_heap);
+    st.ResumeTiming();
+  }
+  st.SetItemsProcessed(st.iterations()*st.range(1));
+}
+
+BENCHMARK_REGISTER_F(HeapBench, HeapAlloc$_)->RangeMultiplier(2)->Ranges({{32, 1024<<10}, {1<<10, 1<<10}});
+
+BENCHMARK_DEFINE_F(HeapBench, HeapDestroy$)(benchmark::State& st) {
+  pony_actor_t* actor = (pony_actor_t*)0xDBEEFDEADBEEF;
+
+  ponyint_heap_destroy(&_heap);
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    ponyint_heap_init(&_heap);
     if(st.range(0) > HEAP_MAX)
       ponyint_heap_alloc_large(actor, &_heap, st.range(0));
     else
       ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(st.range(0)));
     st.ResumeTiming();
     ponyint_heap_destroy(&_heap);
-    st.PauseTiming();
-    ponyint_heap_init(&_heap);
-    st.ResumeTiming();
   }
   st.SetItemsProcessed(st.iterations());
+  ponyint_heap_init(&_heap);
 }
 
-BENCHMARK_REGISTER_F(HeapBench, HeapDestroy)->RangeMultiplier(2)->Ranges({{32, 1024<<10}});
+BENCHMARK_REGISTER_F(HeapBench, HeapDestroy$)->RangeMultiplier(2)->Ranges({{32, 1024<<10}});
+
+BENCHMARK_DEFINE_F(HeapBench, HeapDestroyMultiple$)(benchmark::State& st) {
+  pony_actor_t* actor = (pony_actor_t*)0xDBEEFDEADBEEF;
+
+  ponyint_heap_destroy(&_heap);
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    ponyint_heap_init(&_heap);
+    if(st.range(0) > HEAP_MAX)
+      for(int i = 0; i < st.range(1); i++)
+        ponyint_heap_alloc_large(actor, &_heap, st.range(0));
+    else
+      for(int i = 0; i < st.range(1); i++)
+        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(st.range(0)));
+    st.ResumeTiming();
+    ponyint_heap_destroy(&_heap);
+  }
+  st.SetItemsProcessed(st.iterations());
+  ponyint_heap_init(&_heap);
+}
+
+BENCHMARK_REGISTER_F(HeapBench, HeapDestroyMultiple$)->RangeMultiplier(2)->Ranges({{32, 1024<<10}, {1<<10, 1<<10}});
+
+BENCHMARK_DEFINE_F(HeapBench, HeapInitAllocDestroy)(benchmark::State& st) {
+  pony_actor_t* actor = (pony_actor_t*)0xDBEEFDEADBEEF;
+
+  ponyint_heap_destroy(&_heap);
+  while (st.KeepRunning()) {
+    ponyint_heap_init(&_heap);
+    if(st.range(0) > HEAP_MAX)
+      ponyint_heap_alloc_large(actor, &_heap, st.range(0));
+    else
+      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(st.range(0)));
+    ponyint_heap_destroy(&_heap);
+  }
+  st.SetItemsProcessed(st.iterations());
+  ponyint_heap_init(&_heap);
+}
+
+BENCHMARK_REGISTER_F(HeapBench, HeapInitAllocDestroy)->RangeMultiplier(2)->Ranges({{32, 1024<<10}});

--- a/benchmark/libponyrt/mem/pool.cc
+++ b/benchmark/libponyrt/mem/pool.cc
@@ -2,7 +2,14 @@
 #include <platform.h>
 #include <mem/pool.h>
 
-#define LARGE_ALLOC 1 << 21
+#define LARGE_ALLOC ponyint_pool_adjust_size(POOL_MAX + 1)
+
+/// When we mmap, pull at least this many bytes.
+#ifdef PLATFORM_IS_ILP32
+#define POOL_MMAP (16 * 1024 * 1024) // 16 MB
+#else
+#define POOL_MMAP (128 * 1024 * 1024) // 128 MB
+#endif
 
 typedef char block_t[32];
 
@@ -32,7 +39,7 @@ BENCHMARK_DEFINE_F(PoolBench, pool_index)(benchmark::State& st) {
 
 BENCHMARK_REGISTER_F(PoolBench, pool_index)->RangeMultiplier(3)->Ranges({{1, 1024<<10}});
 
-BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC$)(benchmark::State& st) {
   while (st.KeepRunning()) {
     void* p = POOL_ALLOC(block_t);
     st.PauseTiming();
@@ -42,27 +49,25 @@ BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC)(benchmark::State& st) {
   st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC);
+BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC$);
 
-BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_multiple)(benchmark::State& st) {
-  void* p[100];
+BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_multiple$_)(benchmark::State& st) {
+  int num_allocs = st.range(0);
+  void* p[num_allocs];
   while (st.KeepRunning()) {
-    st.PauseTiming();
-    for(int i = 0; i < 100; i++)
-    {
-      st.ResumeTiming();
+    for(int i = 0; i < num_allocs; i++)
       p[i] = POOL_ALLOC(block_t);
-      st.PauseTiming();
-    }
-    for(int i = 99; i >= 0; i--)
+    st.PauseTiming();
+    for(int i = num_allocs - 1; i >= 0; i--)
       POOL_FREE(block_t, p[i]);
+    st.ResumeTiming();
   }
-  st.SetItemsProcessed(st.iterations()*100);
+  st.SetItemsProcessed(st.iterations()*num_allocs);
 }
 
-BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC_multiple);
+BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC_multiple$_)->Arg(1<<10);
 
-BENCHMARK_DEFINE_F(PoolBench, POOL_FREE)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(PoolBench, POOL_FREE$)(benchmark::State& st) {
   while (st.KeepRunning()) {
     st.PauseTiming();
     void* p = POOL_ALLOC(block_t);
@@ -72,28 +77,49 @@ BENCHMARK_DEFINE_F(PoolBench, POOL_FREE)(benchmark::State& st) {
   st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(PoolBench, POOL_FREE);
+BENCHMARK_REGISTER_F(PoolBench, POOL_FREE$);
 
-BENCHMARK_DEFINE_F(PoolBench, POOL_FREE_multiple)(benchmark::State& st) {
-  void* p[100];
+BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_FREE)(benchmark::State& st) {
+  while (st.KeepRunning()) {
+    void* p = POOL_ALLOC(block_t);
+    POOL_FREE(block_t, p);
+  }
+  st.SetItemsProcessed(st.iterations());
+}
+
+BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC_FREE);
+
+BENCHMARK_DEFINE_F(PoolBench, POOL_FREE_multiple$_)(benchmark::State& st) {
+  int num_allocs = st.range(0);
+  void* p[num_allocs];
   while (st.KeepRunning()) {
     st.PauseTiming();
-    for(int i = 0; i < 100; i++)
+    for(int i = 0; i < num_allocs; i++)
       p[i] = POOL_ALLOC(block_t);
-    for(int i = 99; i >= 0; i--)
-    {
-      st.ResumeTiming();
+    st.ResumeTiming();
+    for(int i = num_allocs - 1; i >= 0; i--)
       POOL_FREE(block_t, p[i]);
-      st.PauseTiming();
-    }
-    st.ResumeTiming();
   }
-  st.SetItemsProcessed(st.iterations()*100);
+  st.SetItemsProcessed(st.iterations()*num_allocs);
 }
 
-BENCHMARK_REGISTER_F(PoolBench, POOL_FREE_multiple);
+BENCHMARK_REGISTER_F(PoolBench, POOL_FREE_multiple$_)->Arg(1<<10);
 
-BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_FREE_multiple)(benchmark::State& st) {
+  int num_allocs = st.range(0);
+  void* p[num_allocs];
+  while (st.KeepRunning()) {
+    for(int i = 0; i < num_allocs; i++)
+      p[i] = POOL_ALLOC(block_t);
+    for(int i = num_allocs - 1; i >= 0; i--)
+      POOL_FREE(block_t, p[i]);
+  }
+  st.SetItemsProcessed(st.iterations()*num_allocs);
+}
+
+BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC_FREE_multiple)->Arg(1<<10);
+
+BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size$)(benchmark::State& st) {
   while (st.KeepRunning()) {
     void* p = ponyint_pool_alloc_size(LARGE_ALLOC);
     st.PauseTiming();
@@ -103,27 +129,25 @@ BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size)(benchmark::State& st) {
   st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(PoolBench, pool_alloc_size);
+BENCHMARK_REGISTER_F(PoolBench, pool_alloc_size$);
 
-BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size_multiple)(benchmark::State& st) {
-  void* p[100];
+BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size_multiple$_)(benchmark::State& st) {
+  size_t num_allocs = st.range(0);
+  void* p[num_allocs];
   while (st.KeepRunning()) {
-    st.PauseTiming();
-    for(int i = 0; i < 100; i++)
-    {
-      st.ResumeTiming();
+    for(size_t i = 0; i < num_allocs; i++)
       p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);
-      st.PauseTiming();
-    }
-    for(int i = 99; i >= 0; i--)
-      ponyint_pool_free_size(LARGE_ALLOC, p[i]);
+    st.PauseTiming();
+    for(size_t i = num_allocs; i > 0; i--)
+      ponyint_pool_free_size(LARGE_ALLOC, p[i-1]);
+    st.ResumeTiming();
   }
-  st.SetItemsProcessed(st.iterations()*100);
+  st.SetItemsProcessed(st.iterations()*num_allocs);
 }
 
-BENCHMARK_REGISTER_F(PoolBench, pool_alloc_size_multiple);
+BENCHMARK_REGISTER_F(PoolBench, pool_alloc_size_multiple$_)->Arg((int)(POOL_MMAP/LARGE_ALLOC));
 
-BENCHMARK_DEFINE_F(PoolBench, pool_free_size)(benchmark::State& st) {
+BENCHMARK_DEFINE_F(PoolBench, pool_free_size$)(benchmark::State& st) {
   while (st.KeepRunning()) {
     st.PauseTiming();
     void* p = ponyint_pool_alloc_size(LARGE_ALLOC);
@@ -133,23 +157,44 @@ BENCHMARK_DEFINE_F(PoolBench, pool_free_size)(benchmark::State& st) {
   st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(PoolBench, pool_free_size);
+BENCHMARK_REGISTER_F(PoolBench, pool_free_size$);
 
-BENCHMARK_DEFINE_F(PoolBench, pool_free_size_multiple)(benchmark::State& st) {
-  void* p[100];
+BENCHMARK_DEFINE_F(PoolBench, pool_alloc_free_size)(benchmark::State& st) {
   while (st.KeepRunning()) {
-    st.PauseTiming();
-    for(int i = 0; i < 100; i++)
-      p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);
-    for(int i = 99; i >= 0; i--)
-    {
-      st.ResumeTiming();
-      ponyint_pool_free_size(LARGE_ALLOC, p[i]);
-      st.PauseTiming();
-    }
-    st.ResumeTiming();
+    void* p = ponyint_pool_alloc_size(LARGE_ALLOC);
+    ponyint_pool_free_size(LARGE_ALLOC, p);
   }
-  st.SetItemsProcessed(st.iterations()*100);
+  st.SetItemsProcessed(st.iterations());
 }
 
-BENCHMARK_REGISTER_F(PoolBench, pool_free_size_multiple);
+BENCHMARK_REGISTER_F(PoolBench, pool_alloc_free_size);
+
+BENCHMARK_DEFINE_F(PoolBench, pool_free_size_multiple$_)(benchmark::State& st) {
+  int num_allocs = st.range(0);
+  void* p[num_allocs];
+  while (st.KeepRunning()) {
+    st.PauseTiming();
+    for(int i = 0; i < num_allocs; i++)
+      p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);
+    st.ResumeTiming();
+    for(int i = num_allocs - 1; i >= 0; i--)
+      ponyint_pool_free_size(LARGE_ALLOC, p[i]);
+  }
+  st.SetItemsProcessed(st.iterations()*num_allocs);
+}
+
+BENCHMARK_REGISTER_F(PoolBench, pool_free_size_multiple$_)->Arg((int)(POOL_MMAP/LARGE_ALLOC));
+
+BENCHMARK_DEFINE_F(PoolBench, pool_alloc_free_size_multiple)(benchmark::State& st) {
+  int num_allocs = st.range(0);
+  void* p[num_allocs];
+  while (st.KeepRunning()) {
+    for(int i = 0; i < num_allocs; i++)
+      p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);
+    for(int i = num_allocs - 1; i >= 0; i--)
+      ponyint_pool_free_size(LARGE_ALLOC, p[i]);
+  }
+  st.SetItemsProcessed(st.iterations()*num_allocs);
+}
+
+BENCHMARK_REGISTER_F(PoolBench, pool_alloc_free_size_multiple)->Arg((int)(POOL_MMAP/LARGE_ALLOC));

--- a/lib/gbenchmark/gbenchmark_main.cc
+++ b/lib/gbenchmark/gbenchmark_main.cc
@@ -2,4 +2,25 @@
 
 #include "benchmark/benchmark.h"
 
-BENCHMARK_MAIN()
+int main(int argc, char** argv) {
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+
+  printf("\n");
+
+  printf("*********\n");
+  printf(">> NOTE: Benchmarks ending in `$` use PauseTiming/ResumeTiming.\n");
+  printf(">> NOTE: Using PauseTiming/ResumeTiming adds time/overhead to benchmarks.\n");
+  printf(">> NOTE: Overhead seems to be about 200ns on a modern intel processor.\n");
+  printf(">> NOTE: See output of `$$$$$$_PauseResumeOverhead*` benchmarks for approximate\n");
+  printf(">> NOTE: overhead on the benchmark machine.\n");
+  printf(">> NOTE: See: https://github.com/google/benchmark/issues/179.\n");
+  printf("*********\n");
+  printf(">> NOTE: Benchmarks ending in `$_` use PauseTiming/ResumeTiming and\n");
+  printf(">> NOTE: run the function multiple times and need to be divided by\n");
+  printf(">> NOTE: the count (last argument) to get a value for a single call.\n");
+  printf("*********\n");
+
+}
+


### PR DESCRIPTION
This change was precipitated by @SeanTAllen pointing me to: https://probablydance.com/2017/02/26/i-wrote-the-fastest-hashtable/ where the numbers for different hashmap implementations were significantly different from the previous benchmark numbers we had.

--------------

I'm not exactly happy with everything and would appreciate any feedback/suggestions for improvements if anyone has any ideas.

--------------

According to the Google Benchmark library issue:

google/benchmark#179

The `PauseTiming`/`ResumeTiming` functions introduce a large
amount of overhead and are not recommended to be used for
microbenchmarks without understanding the overheads involved.

This commit is an attempt to minimise use of these functions along
with adding a disclaimer for when these functions are used and
a link to the issue so everyone can understand the implications.

It also changes names of some benchmarks in order to make it easy
to visually identify benchmarks that use these functions.

------------

The disclaimer is:

```
*********
>> NOTE: Benchmarks ending in `$` use PauseTiming/ResumeTiming.
>> NOTE: Using PauseTiming/ResumeTiming adds time/overhead to benchmarks.
>> NOTE: Overhead seems to be about 200ns on a modern intel processor.
>> NOTE: See output of `$$$$$$_PauseResumeOverhead*` benchmarks for approximate
>> NOTE: overhead on the benchmark machine.
>> NOTE: See: https://github.com/google/benchmark/issues/179.
*********
>> NOTE: Benchmarks ending in `$_` use PauseTiming/ResumeTiming and
>> NOTE: run the function multiple times and need to be divided by
>> NOTE: the count (last argument) to get a value for a single call.
*********
```

-------------

The benchmarks are now (note: these were run in vagrant/virtualbox and not in a controlled cpu isolated environment):

```
vagrant@buffy-leader-1:~/hp$ ./build/release/libponyrt.benchmarks --benchmark_min_time=0.01
Run on (2 X 2194.92 MHz CPU s)
2017-03-03 15:55:59
Benchmark                                            Time           CPU Iterations
----------------------------------------------------------------------------------
HashMapBench/HashDestroy$/1/0                      349 ns        326 ns      44379   2.92439M items/s
HashMapBench/HashDestroy$/2/0                      342 ns        321 ns      43569   2.96972M items/s
HashMapBench/HashDestroy$/4/0                      359 ns        335 ns      45077   2.84987M items/s
HashMapBench/HashDestroy$/8/0                      476 ns        450 ns      31771   2.11762M items/s
HashMapBench/HashDestroy$/16/0                     514 ns        490 ns      25596    1.9469M items/s
HashMapBench/HashDestroy$/32/0                     761 ns        736 ns      18754   1.29535M items/s
HashMapBench/HashDestroy$/64/0                    1149 ns       1129 ns      12784   865.187k items/s
HashMapBench/HashDestroy$/128/0                   2054 ns       2034 ns       6080    480.05k items/s
HashMapBench/HashDestroy$/256/0                   3784 ns       3769 ns       3828    259.13k items/s
HashMapBench/HashDestroy$/512/0                   7454 ns       7398 ns       1993   132.011k items/s
HashMapBench/HashDestroy$/1024/0                 16208 ns      16114 ns        965   60.6044k items/s
HashMapBench/HashDestroy$/2k/0                   46529 ns      46314 ns        316   21.0858k items/s
HashMapBench/HashDestroy$/4k/0                  111642 ns     111485 ns         92   8.75959k items/s
HashMapBench/HashDestroy$/8k/0                  255403 ns     251397 ns         59   3.88454k items/s
HashMapBench/HashDestroy$/16k/0                 591626 ns     591546 ns         24   1.65087k items/s
HashMapBench/HashDestroy$/32k/0                1483267 ns    1474911 ns         11    678.007 items/s
HashMapBench/HashResize$/1/0                       497 ns        499 ns      27228   1.91233M items/s
HashMapBench/HashResize$/2/0                       514 ns        528 ns      26451   1.80505M items/s
HashMapBench/HashResize$/4/0                       512 ns        513 ns      27718   1.85887M items/s
HashMapBench/HashResize$/8/0                       571 ns        572 ns      26408   1.66766M items/s
HashMapBench/HashResize$/16/0                      647 ns        646 ns      19930   1.47701M items/s
HashMapBench/HashResize$/32/0                     1067 ns       1062 ns      10000   919.712k items/s
HashMapBench/HashResize$/64/0                     1368 ns       1364 ns      10570   716.017k items/s
HashMapBench/HashResize$/128/0                    2324 ns       2229 ns       6525   438.052k items/s
HashMapBench/HashResize$/256/0                    4046 ns       4025 ns       3614   242.637k items/s
HashMapBench/HashResize$/512/0                    7944 ns       7897 ns       1873   123.657k items/s
HashMapBench/HashResize$/1024/0                  16563 ns      16504 ns        912   59.1705k items/s
HashMapBench/HashResize$/2k/0                    40821 ns      40611 ns        405   24.0468k items/s
HashMapBench/HashResize$/4k/0                    90932 ns      89380 ns        190   10.9259k items/s
HashMapBench/HashResize$/8k/0                   147849 ns     147778 ns         82   6.60829k items/s
HashMapBench/HashResize$/16k/0                  354268 ns     354341 ns         44     2.756k items/s
HashMapBench/HashResize$/32k/0                  697837 ns     698092 ns         17    1.3989k items/s
HashMapBench/HashNext/1/1                            9 ns          9 ns    1551772   209.151M items/s
HashMapBench/HashNext/2/1                           11 ns         11 ns    1393977   173.676M items/s
HashMapBench/HashNext/4/1                           11 ns         11 ns     978775   177.024M items/s
HashMapBench/HashNext/8/1                           10 ns         10 ns    1188370   197.035M items/s
HashMapBench/HashNext/16/1                           9 ns          9 ns    1313379   206.996M items/s
HashMapBench/HashNext/32/1                           9 ns          9 ns    1347442    205.73M items/s
HashMapBench/HashNext/64/1                          12 ns         12 ns    1147201   164.919M items/s
HashMapBench/HashNext/128/1                         13 ns         13 ns    1055684   145.953M items/s
HashMapBench/HashNext/256/1                         19 ns         19 ns     536130   99.4762M items/s
HashMapBench/HashNext/512/1                         30 ns         30 ns     508413   64.4953M items/s
HashMapBench/HashNext/1024/1                        47 ns         47 ns     271725   40.5342M items/s
HashMapBench/HashNext/2k/1                         103 ns        103 ns     106434   18.5845M items/s
HashMapBench/HashNext/4k/1                         188 ns        188 ns      81391   10.1587M items/s
HashMapBench/HashNext/8k/1                         348 ns        348 ns      32514    5.4761M items/s
HashMapBench/HashNext/16k/1                        594 ns        594 ns      21506   3.21164M items/s
HashMapBench/HashNext/32k/1                       1193 ns       1194 ns      11513   1.59805M items/s
HashMapBench/HashNext/1/2                           16 ns         16 ns     802063   174.778M items/s
HashMapBench/HashNext/2/2                           16 ns         16 ns     852780   178.567M items/s
HashMapBench/HashNext/4/2                           19 ns         19 ns     576110   151.422M items/s
HashMapBench/HashNext/8/2                           16 ns         16 ns     964630   180.069M items/s
HashMapBench/HashNext/16/2                          15 ns         15 ns     853173   185.759M items/s
HashMapBench/HashNext/32/2                          15 ns         15 ns     955423   188.659M items/s
HashMapBench/HashNext/64/2                          16 ns         16 ns     820300   174.412M items/s
HashMapBench/HashNext/128/2                         20 ns         20 ns     667987   140.874M items/s
HashMapBench/HashNext/256/2                         28 ns         28 ns     491158   102.827M items/s
HashMapBench/HashNext/512/2                         33 ns         33 ns     414842   87.3468M items/s
HashMapBench/HashNext/1024/2                        56 ns         56 ns     255710   51.1074M items/s
HashMapBench/HashNext/2k/2                          98 ns         98 ns     130786    29.162M items/s
HashMapBench/HashNext/4k/2                         179 ns        179 ns      76525   15.9737M items/s
HashMapBench/HashNext/8k/2                         354 ns        348 ns      44872   8.21441M items/s
HashMapBench/HashNext/16k/2                        629 ns        629 ns      21417   4.54842M items/s
HashMapBench/HashNext/32k/2                       1428 ns       1429 ns       7513   2.00278M items/s
HashMapBench/HashNext/1/4                           31 ns         31 ns     503007    153.88M items/s
HashMapBench/HashNext/2/4                           29 ns         29 ns     454819   161.768M items/s
HashMapBench/HashNext/4/4                           29 ns         29 ns     471008     164.8M items/s
HashMapBench/HashNext/8/4                           29 ns         29 ns     511117   166.702M items/s
HashMapBench/HashNext/16/4                          30 ns         30 ns     458244   158.023M items/s
HashMapBench/HashNext/32/4                          30 ns         30 ns     431164    158.08M items/s
HashMapBench/HashNext/64/4                          29 ns         29 ns     482929   164.935M items/s
HashMapBench/HashNext/128/4                         35 ns         35 ns     408814   136.299M items/s
HashMapBench/HashNext/256/4                         47 ns         46 ns     357099   103.921M items/s
HashMapBench/HashNext/512/4                         45 ns         45 ns     309103   106.667M items/s
HashMapBench/HashNext/1024/4                        70 ns         70 ns     205006   68.0279M items/s
HashMapBench/HashNext/2k/4                         115 ns        114 ns     136980   41.6578M items/s
HashMapBench/HashNext/4k/4                         191 ns        188 ns      71914   25.3626M items/s
HashMapBench/HashNext/8k/4                         350 ns        350 ns      39885   13.6252M items/s
HashMapBench/HashNext/16k/4                        680 ns        676 ns      16282   7.05628M items/s
HashMapBench/HashNext/32k/4                       1235 ns       1233 ns      11537   3.86861M items/s
HashMapBench/HashNext/1/8                           60 ns         60 ns     223733   143.003M items/s
HashMapBench/HashNext/2/8                           70 ns         70 ns     247656   123.333M items/s
HashMapBench/HashNext/4/8                           62 ns         62 ns     245000    138.44M items/s
HashMapBench/HashNext/8/8                           68 ns         68 ns     228480   126.833M items/s
HashMapBench/HashNext/16/8                          57 ns         57 ns     249153   151.274M items/s
HashMapBench/HashNext/32/8                          62 ns         62 ns     222908   137.875M items/s
HashMapBench/HashNext/64/8                          57 ns         57 ns     213839   150.071M items/s
HashMapBench/HashNext/128/8                         64 ns         64 ns     233132   134.946M items/s
HashMapBench/HashNext/256/8                         69 ns         69 ns     188289   125.229M items/s
HashMapBench/HashNext/512/8                         76 ns         76 ns     163445   113.041M items/s
HashMapBench/HashNext/1024/8                        99 ns         99 ns     136949   86.7813M items/s
HashMapBench/HashNext/2k/8                         134 ns        134 ns      95370   64.1119M items/s
HashMapBench/HashNext/4k/8                         222 ns        222 ns      62971   38.6387M items/s
HashMapBench/HashNext/8k/8                         383 ns        382 ns      38466   22.4608M items/s
HashMapBench/HashNext/16k/8                        710 ns        710 ns      18350   12.0907M items/s
HashMapBench/HashNext/32k/8                       1330 ns       1330 ns      11158   6.45126M items/s
HashMapBench/HashNext/1/16                         117 ns        117 ns     112884   138.235M items/s
HashMapBench/HashNext/2/16                         126 ns        126 ns     104965   128.441M items/s
HashMapBench/HashNext/4/16                         121 ns        121 ns     108477   134.489M items/s
HashMapBench/HashNext/8/16                         129 ns        129 ns      94896    125.96M items/s
HashMapBench/HashNext/16/16                        121 ns        121 ns     104670   134.514M items/s
HashMapBench/HashNext/32/16                        125 ns        125 ns     112181    129.45M items/s
HashMapBench/HashNext/64/16                        123 ns        123 ns     106601   132.317M items/s
HashMapBench/HashNext/128/16                       131 ns        131 ns     117570   123.471M items/s
HashMapBench/HashNext/256/16                       127 ns        127 ns     109793   127.194M items/s
HashMapBench/HashNext/512/16                       150 ns        149 ns      92825    108.74M items/s
HashMapBench/HashNext/1024/16                      184 ns        184 ns      79250   88.0174M items/s
HashMapBench/HashNext/2k/16                        185 ns        185 ns      75899   87.6453M items/s
HashMapBench/HashNext/4k/16                        270 ns        270 ns      56515   60.1091M items/s
HashMapBench/HashNext/8k/16                        431 ns        431 ns      31545   37.5866M items/s
HashMapBench/HashNext/16k/16                       827 ns        827 ns      14245   19.6074M items/s
HashMapBench/HashNext/32k/16                      1503 ns       1503 ns       9063   10.7838M items/s
HashMapBench/HashNext/1/32                         246 ns        245 ns      54006     128.5M items/s
HashMapBench/HashNext/2/32                         274 ns        274 ns      57951    114.92M items/s
HashMapBench/HashNext/4/32                         252 ns        252 ns      60710   125.078M items/s
HashMapBench/HashNext/8/32                         301 ns        301 ns      54029    104.45M items/s
HashMapBench/HashNext/16/32                        241 ns        241 ns      50610   130.727M items/s
HashMapBench/HashNext/32/32                        256 ns        255 ns      58120   123.613M items/s
HashMapBench/HashNext/64/32                        255 ns        254 ns      53548   123.901M items/s
HashMapBench/HashNext/128/32                       244 ns        244 ns      59381   129.236M items/s
HashMapBench/HashNext/256/32                       271 ns        271 ns      55381   115.928M items/s
HashMapBench/HashNext/512/32                       274 ns        274 ns      51095   115.025M items/s
HashMapBench/HashNext/1024/32                      287 ns        287 ns      52244   109.785M items/s
HashMapBench/HashNext/2k/32                        301 ns        301 ns      48086   104.644M items/s
HashMapBench/HashNext/4k/32                        390 ns        390 ns      35751   80.6288M items/s
HashMapBench/HashNext/8k/32                        635 ns        635 ns      26778   49.5591M items/s
HashMapBench/HashNext/16k/32                       912 ns        912 ns      16354   34.5002M items/s
HashMapBench/HashNext/32k/32                      1629 ns       1616 ns       8089   19.4771M items/s
HashMapBench/HashNext/1/1                           10 ns         10 ns    1487862   197.139M items/s
HashMapBench/HashNext/1/2                           16 ns         16 ns     912862   177.725M items/s
HashMapBench/HashNext/1/4                           31 ns         31 ns     455504   151.612M items/s
HashMapBench/HashNext/1/8                           59 ns         58 ns     206691   147.619M items/s
HashMapBench/HashNext/1/16                         133 ns        132 ns      94746   122.365M items/s
HashMapBench/HashNext/1/32                         249 ns        249 ns      54213   126.196M items/s
HashMapBench/HashNext/1/64                         479 ns        478 ns      25522   129.728M items/s
HashMapBench/HashNext/1/128                        991 ns        990 ns      13751   124.312M items/s
HashMapBench/HashNext/1/256                       2081 ns       2081 ns       6622   117.752M items/s
HashMapBench/HashNext/1/512                       4657 ns       4658 ns       3317   105.039M items/s
HashMapBench/HashNext/1/1024                     10747 ns      10708 ns       1739   91.2908M items/s
HashMapBench/HashNext/1/2k                       16929 ns      16900 ns        836   115.626M items/s
HashMapBench/HashNext/1/4k                       35624 ns      35521 ns        353   109.996M items/s
HashMapBench/HashNext/1/8k                       70151 ns      70027 ns        223   111.578M items/s
HashMapBench/HashNext/1/16k                     143347 ns     143358 ns        104       109M items/s
HashMapBench/HashNext/1/32k                     309944 ns     309651 ns         37   100.923M items/s
HashMapBench/HashPut/32k/0                          16 ns         16 ns     824224   60.3742M items/s
HashMapBench/HashPutResize/1/0                      45 ns         45 ns     392127   21.1487M items/s
HashMapBench/HashPutNew/32k/0                       16 ns         16 ns     862416   59.4884M items/s
HashMapBench/HashPutNewResize/1/0                   68 ns         68 ns     238822   14.0152M items/s
HashMapBench/HashRemove$_/32k/0/1024             13297 ns      13306 ns        959   73.3913M items/s
HashMapBench/HashRemove$_/32k/0/2k               31147 ns      31157 ns        467   62.6865M items/s
HashMapBench/HashRemove$_/32k/0/4k               64911 ns      64803 ns        208   60.2788M items/s
HashMapBench/HashRemove$_/32k/0/8k              140623 ns     140658 ns         93   55.5426M items/s
HashMapBench/HashRemove$_/32k/0/16k             348700 ns     348729 ns         45   44.8056M items/s
HashMapBench/HashRemove$_/32k/0/32k             798786 ns     798746 ns         17   39.1238M items/s
HashMapBench/HashRemove$_/32k/0/64k            2374172 ns    2373897 ns          6    26.328M items/s
HashMapBench/HashSearch/1/1024/0                    13 ns         13 ns    1013114    71.844M items/s
HashMapBench/HashSearch/1/2k/0                      17 ns         17 ns     775978   56.0397M items/s
HashMapBench/HashSearch/1/4k/0                      17 ns         17 ns     899925   55.6557M items/s
HashMapBench/HashSearch/1/8k/0                      21 ns         21 ns     719319   44.6307M items/s
HashMapBench/HashSearch/1/16k/0                     26 ns         26 ns     631476    37.046M items/s
HashMapBench/HashSearch/1/32k/0                     32 ns         32 ns     391304   29.7363M items/s
HashMapBench/HashSearch/1/1024/1                    11 ns         11 ns    1295718   88.5369M items/s
HashMapBench/HashSearch/1/2k/1                      18 ns         18 ns     790958   51.7699M items/s
HashMapBench/HashSearch/1/4k/1                      10 ns         10 ns    1534005   98.0885M items/s
HashMapBench/HashSearch/1/8k/1                      14 ns         14 ns    1029520   69.7202M items/s
HashMapBench/HashSearch/1/16k/1                     21 ns         21 ns     681580    45.156M items/s
HashMapBench/HashSearch/1/32k/1                     11 ns         11 ns    1000000   90.0437M items/s
HashMapBench/HashSearchDeletes/1/1024/64/0          11 ns         11 ns    1351469   88.2252M items/s
HashMapBench/HashSearchDeletes/1/2k/64/0            13 ns         13 ns    1064932   71.7653M items/s
HashMapBench/HashSearchDeletes/1/4k/64/0            14 ns         14 ns    1190008   68.8073M items/s
HashMapBench/HashSearchDeletes/1/8k/64/0            16 ns         16 ns     968869   59.2635M items/s
HashMapBench/HashSearchDeletes/1/16k/64/0           19 ns         19 ns     586129   49.7416M items/s
HashMapBench/HashSearchDeletes/1/32k/64/0           26 ns         26 ns     609098   36.0845M items/s
HashMapBench/HashSearchDeletes/1/1024/90/0          11 ns         11 ns    1406923   90.7117M items/s
HashMapBench/HashSearchDeletes/1/2k/90/0            11 ns         11 ns    1374340   84.3497M items/s
HashMapBench/HashSearchDeletes/1/4k/90/0            11 ns         11 ns    1154404   83.3402M items/s
HashMapBench/HashSearchDeletes/1/8k/90/0            11 ns         11 ns    1183438   83.5173M items/s
HashMapBench/HashSearchDeletes/1/16k/90/0           16 ns         16 ns     981396   59.8771M items/s
HashMapBench/HashSearchDeletes/1/32k/90/0           21 ns         20 ns     665497   47.2493M items/s
HashMapBench/HashSearchDeletes/1/1024/99/0          10 ns         10 ns    1385672   98.2062M items/s
HashMapBench/HashSearchDeletes/1/2k/99/0            10 ns         10 ns    1439047   91.5226M items/s
HashMapBench/HashSearchDeletes/1/4k/99/0            11 ns         11 ns    1274639   89.4293M items/s
HashMapBench/HashSearchDeletes/1/8k/99/0            11 ns         11 ns    1443779   86.8919M items/s
HashMapBench/HashSearchDeletes/1/16k/99/0           11 ns         11 ns    1145846   90.6283M items/s
HashMapBench/HashSearchDeletes/1/32k/99/0           11 ns         11 ns    1271141   86.9244M items/s
HashMapBench/HashSearchDeletes/1/1024/101/0         10 ns         10 ns    1435314   98.2346M items/s
HashMapBench/HashSearchDeletes/1/2k/101/0           10 ns         10 ns    1000000   91.8688M items/s
HashMapBench/HashSearchDeletes/1/4k/101/0           10 ns         10 ns    1303293   98.0834M items/s
HashMapBench/HashSearchDeletes/1/8k/101/0           11 ns         11 ns    1264098   89.6479M items/s
HashMapBench/HashSearchDeletes/1/16k/101/0          11 ns         11 ns    1000000   90.5659M items/s
HashMapBench/HashSearchDeletes/1/32k/101/0          10 ns         10 ns    1433890   98.9809M items/s
HashMapBench/HashSearchDeletes/1/1024/64/1           8 ns          8 ns    1645215   112.559M items/s
HashMapBench/HashSearchDeletes/1/2k/64/1            10 ns         10 ns    1383503   94.6806M items/s
HashMapBench/HashSearchDeletes/1/4k/64/1             8 ns          8 ns    1658260   117.414M items/s
HashMapBench/HashSearchDeletes/1/8k/64/1             9 ns          9 ns    1693163   108.538M items/s
HashMapBench/HashSearchDeletes/1/16k/64/1           10 ns         10 ns    1200962   91.9215M items/s
HashMapBench/HashSearchDeletes/1/32k/64/1            8 ns          8 ns    1791728   115.256M items/s
HashMapBench/HashSearchDeletes/1/1024/90/1           7 ns          7 ns    1772516   128.713M items/s
HashMapBench/HashSearchDeletes/1/2k/90/1             8 ns          8 ns    1369618   117.741M items/s
HashMapBench/HashSearchDeletes/1/4k/90/1             7 ns          7 ns    1741431   128.581M items/s
HashMapBench/HashSearchDeletes/1/8k/90/1             8 ns          8 ns    1890336   119.697M items/s
HashMapBench/HashSearchDeletes/1/16k/90/1            8 ns          8 ns    1350145   119.761M items/s
HashMapBench/HashSearchDeletes/1/32k/90/1            8 ns          8 ns    1743925   114.883M items/s
HashMapBench/HashSearchDeletes/1/1024/99/1           7 ns          7 ns    2018372   137.598M items/s
HashMapBench/HashSearchDeletes/1/2k/99/1             8 ns          8 ns    2023992   123.677M items/s
HashMapBench/HashSearchDeletes/1/4k/99/1             8 ns          8 ns    2021373   117.173M items/s
HashMapBench/HashSearchDeletes/1/8k/99/1             8 ns          8 ns    1798974   124.372M items/s
HashMapBench/HashSearchDeletes/1/16k/99/1            8 ns          8 ns    1977480   120.423M items/s
HashMapBench/HashSearchDeletes/1/32k/99/1            7 ns          7 ns    1864576    135.23M items/s
HashMapBench/HashSearchDeletes/1/1024/101/1          7 ns          7 ns    2014456   137.372M items/s
HashMapBench/HashSearchDeletes/1/2k/101/1            8 ns          8 ns    1996170   123.369M items/s
HashMapBench/HashSearchDeletes/1/4k/101/1            7 ns          7 ns    1788655   136.936M items/s
HashMapBench/HashSearchDeletes/1/8k/101/1            7 ns          7 ns    1839328   134.417M items/s
HashMapBench/HashSearchDeletes/1/16k/101/1           7 ns          7 ns    1801706   132.806M items/s
HashMapBench/HashSearchDeletes/1/32k/101/1           7 ns          7 ns    1995901   137.556M items/s
$$$$$$_PauseResumeOverheadOnce                     210 ns        212 ns      63826   4.48841M items/s
$$$$$$_PauseResumeOverheadTwice                    445 ns        450 ns      30839   2.12112M items/s
$$$$$$_PauseResumeOverheadThrice                   642 ns        644 ns      19901   1.47972M items/s
PoolBench/pool_index/1                               2 ns          2 ns    6772312   474.295M items/s
PoolBench/pool_index/3                               2 ns          2 ns    7471317   499.324M items/s
PoolBench/pool_index/9                               2 ns          2 ns    7386779   527.086M items/s
PoolBench/pool_index/27                              2 ns          2 ns    7094750   479.652M items/s
PoolBench/pool_index/81                              3 ns          3 ns    5195788   339.665M items/s
PoolBench/pool_index/243                             2 ns          2 ns    5603685   387.895M items/s
PoolBench/pool_index/729                             3 ns          3 ns    5780020   370.072M items/s
PoolBench/pool_index/2.13574k                        3 ns          3 ns    5052100   362.014M items/s
PoolBench/pool_index/6.40723k                        3 ns          3 ns    5705327   360.004M items/s
PoolBench/pool_index/19.2217k                        3 ns          3 ns    5563165   376.461M items/s
PoolBench/pool_index/57.665k                         3 ns          3 ns    5236916    353.81M items/s
PoolBench/pool_index/172.995k                        3 ns          3 ns    5707667     365.9M items/s
PoolBench/pool_index/518.985k                        2 ns          2 ns    5752603   394.797M items/s
PoolBench/pool_index/1024k                           3 ns          3 ns    5291731   355.921M items/s
PoolBench/POOL_ALLOC$                              231 ns        232 ns      58146   4.10811M items/s
PoolBench/POOL_ALLOC_multiple$_/1024              4343 ns       4329 ns       3357   225.599M items/s
PoolBench/POOL_FREE$                               218 ns        219 ns      53795   4.35367M items/s
PoolBench/POOL_ALLOC_FREE                            7 ns          7 ns    2021541   128.227M items/s
PoolBench/POOL_FREE_multiple$_/1024               4567 ns       4537 ns       3086   215.239M items/s
PoolBench/POOL_ALLOC_FREE_multiple/1024           8331 ns       8331 ns       1678   117.218M items/s
PoolBench/pool_alloc_size$                         226 ns        228 ns      57814   4.19151M items/s
PoolBench/pool_alloc_size_multiple$_/127          1633 ns       1635 ns       8218   74.0842M items/s
PoolBench/pool_free_size$                          235 ns        236 ns      63438   4.03647M items/s
PoolBench/pool_alloc_free_size                      11 ns         11 ns    1385025   86.3045M items/s
PoolBench/pool_free_size_multiple$_/127           1439 ns       1443 ns      10309   83.9591M items/s
PoolBench/pool_alloc_free_size_multiple/127       2841 ns       2841 ns       5288   42.6322M items/s
HeapBench/HeapAlloc$/32                            246 ns        248 ns      56407   3.84389M items/s
HeapBench/HeapAlloc$/64                            247 ns        250 ns      52045   3.80752M items/s
HeapBench/HeapAlloc$/128                           291 ns        289 ns      58233   3.29626M items/s
HeapBench/HeapAlloc$/256                           269 ns        270 ns      53409   3.52592M items/s
HeapBench/HeapAlloc$/512                           259 ns        261 ns      52491   3.65834M items/s
HeapBench/HeapAlloc$/1024                          249 ns        251 ns      54900   3.80452M items/s
HeapBench/HeapAlloc$/2k                            249 ns        250 ns      52717   3.80876M items/s
HeapBench/HeapAlloc$/4k                            262 ns        264 ns      53897   3.61909M items/s
HeapBench/HeapAlloc$/8k                            249 ns        251 ns      57867   3.80222M items/s
HeapBench/HeapAlloc$/16k                           273 ns        276 ns      50298   3.45106M items/s
HeapBench/HeapAlloc$/32k                           274 ns        276 ns      53697   3.46138M items/s
HeapBench/HeapAlloc$/64k                           302 ns        304 ns      43687   3.13724M items/s
HeapBench/HeapAlloc$/128k                          359 ns        360 ns      42087   2.64585M items/s
HeapBench/HeapAlloc$/256k                          388 ns        389 ns      33691   2.45225M items/s
HeapBench/HeapAlloc$/512k                          568 ns        578 ns      23958   1.65112M items/s
HeapBench/HeapAlloc$/1024k                         847 ns        846 ns      17368   1.12743M items/s
HeapBench/HeapAlloc$_/32/1024                     7125 ns       7111 ns       1839   137.338M items/s
HeapBench/HeapAlloc$_/64/1024                     7592 ns       7601 ns       2046    128.47M items/s
HeapBench/HeapAlloc$_/128/1024                    8348 ns       8351 ns       1754   116.936M items/s
HeapBench/HeapAlloc$_/256/1024                   10047 ns      10022 ns       1442    97.437M items/s
HeapBench/HeapAlloc$_/512/1024                   13946 ns      13936 ns       1018   70.0771M items/s
HeapBench/HeapAlloc$_/1024/1024                  21737 ns      21735 ns        649   44.9298M items/s
HeapBench/HeapAlloc$_/2k/1024                    24211 ns      24175 ns        536    40.395M items/s
HeapBench/HeapAlloc$_/4k/1024                    28308 ns      28284 ns        523   34.5275M items/s
HeapBench/HeapAlloc$_/8k/1024                    28329 ns      28340 ns        455   34.4591M items/s
HeapBench/HeapAlloc$_/16k/1024                   43301 ns      43176 ns        378   22.6179M items/s
HeapBench/HeapAlloc$_/32k/1024                   46516 ns      46500 ns        299   21.0015M items/s
HeapBench/HeapAlloc$_/64k/1024                   81350 ns      81286 ns        166   12.0139M items/s
HeapBench/HeapAlloc$_/128k/1024                 146400 ns     144536 ns        106   6.75652M items/s
HeapBench/HeapAlloc$_/256k/1024                 224129 ns     224156 ns         61   4.35663M items/s
HeapBench/HeapAlloc$_/512k/1024                 443374 ns     443283 ns         31   2.20302M items/s
HeapBench/HeapAlloc$_/1024k/1024                672208 ns     670572 ns         18   1.45631M items/s
HeapBench/HeapDestroy$/32                          238 ns        240 ns      58808   3.97904M items/s
HeapBench/HeapDestroy$/64                          255 ns        257 ns      47458   3.70973M items/s
HeapBench/HeapDestroy$/128                         250 ns        255 ns      55376   3.74565M items/s
HeapBench/HeapDestroy$/256                         284 ns        284 ns      52801   3.36326M items/s
HeapBench/HeapDestroy$/512                         274 ns        279 ns      58438   3.41964M items/s
HeapBench/HeapDestroy$/1024                        237 ns        239 ns      54895   3.98701M items/s
HeapBench/HeapDestroy$/2k                          269 ns        269 ns      50408   3.54107M items/s
HeapBench/HeapDestroy$/4k                          241 ns        244 ns      55877   3.91448M items/s
HeapBench/HeapDestroy$/8k                          272 ns        272 ns      51623   3.50312M items/s
HeapBench/HeapDestroy$/16k                         265 ns        266 ns      55267   3.58133M items/s
HeapBench/HeapDestroy$/32k                         271 ns        273 ns      45730   3.48727M items/s
HeapBench/HeapDestroy$/64k                         321 ns        323 ns      47136   2.95238M items/s
HeapBench/HeapDestroy$/128k                        331 ns        333 ns      31241   2.86295M items/s
HeapBench/HeapDestroy$/256k                        464 ns        457 ns      33085    2.0865M items/s
HeapBench/HeapDestroy$/512k                        549 ns        544 ns      24934   1.75462M items/s
HeapBench/HeapDestroy$/1024k                       830 ns        831 ns      16134    1.1476M items/s
HeapBench/HeapDestroyMultiple$/32/1024             653 ns        655 ns      20467    1.4566M items/s
HeapBench/HeapDestroyMultiple$/64/1024            1132 ns       1131 ns      12110   863.274k items/s
HeapBench/HeapDestroyMultiple$/128/1024           2051 ns       2055 ns       7330   475.185k items/s
HeapBench/HeapDestroyMultiple$/256/1024           4502 ns       4496 ns       2629   217.211k items/s
HeapBench/HeapDestroyMultiple$/512/1024          10963 ns      10953 ns       1000   89.1594k items/s
HeapBench/HeapDestroyMultiple$/1024/1024         21886 ns      21891 ns        601   44.6104k items/s
HeapBench/HeapDestroyMultiple$/2k/1024           24547 ns      24623 ns        604    39.661k items/s
HeapBench/HeapDestroyMultiple$/4k/1024           26377 ns      26415 ns        605   36.9704k items/s
HeapBench/HeapDestroyMultiple$/8k/1024           28481 ns      28465 ns        473   34.3069k items/s
HeapBench/HeapDestroyMultiple$/16k/1024          34111 ns      34090 ns        410   28.6464k items/s
HeapBench/HeapDestroyMultiple$/32k/1024          51591 ns      51589 ns        264   18.9297k items/s
HeapBench/HeapDestroyMultiple$/64k/1024          71641 ns      71603 ns        192   13.6387k items/s
HeapBench/HeapDestroyMultiple$/128k/1024        120850 ns     120872 ns        111   8.07932k items/s
HeapBench/HeapDestroyMultiple$/256k/1024        208820 ns     207988 ns         68   4.69529k items/s
HeapBench/HeapDestroyMultiple$/512k/1024        394192 ns     394192 ns         36   2.47737k items/s
HeapBench/HeapDestroyMultiple$/1024k/1024       697658 ns     697733 ns         21   1.39962k items/s
HeapBench/HeapInitAllocDestroy/32                   57 ns         57 ns     271596   16.8784M items/s
HeapBench/HeapInitAllocDestroy/64                   48 ns         48 ns     281770   20.0505M items/s
HeapBench/HeapInitAllocDestroy/128                  50 ns         50 ns     276855   19.2149M items/s
HeapBench/HeapInitAllocDestroy/256                  44 ns         44 ns     305202   21.5205M items/s
HeapBench/HeapInitAllocDestroy/512                  49 ns         49 ns     311546   19.4547M items/s
HeapBench/HeapInitAllocDestroy/1024                 55 ns         55 ns     252677   17.4257M items/s
HeapBench/HeapInitAllocDestroy/2k                   50 ns         50 ns     281858   18.9631M items/s
HeapBench/HeapInitAllocDestroy/4k                   53 ns         53 ns     261950   17.9965M items/s
HeapBench/HeapInitAllocDestroy/8k                   56 ns         56 ns     240964   16.9082M items/s
HeapBench/HeapInitAllocDestroy/16k                  69 ns         69 ns     210709   13.7808M items/s
HeapBench/HeapInitAllocDestroy/32k                  83 ns         83 ns     124479   11.5364M items/s
HeapBench/HeapInitAllocDestroy/64k                 136 ns        136 ns      98362   6.99308M items/s
HeapBench/HeapInitAllocDestroy/128k                204 ns        204 ns      66984   4.67424M items/s
HeapBench/HeapInitAllocDestroy/256k                360 ns        360 ns      41480     2.649M items/s
HeapBench/HeapInitAllocDestroy/512k                636 ns        636 ns      22405   1.50027M items/s
HeapBench/HeapInitAllocDestroy/1024k              1388 ns       1388 ns       9669   703.497k items/s

*********
>> NOTE: Benchmarks ending in `$` use PauseTiming/ResumeTiming.
>> NOTE: Using PauseTiming/ResumeTiming adds time/overhead to benchmarks.
>> NOTE: Overhead seems to be about 200ns on a modern intel processor.
>> NOTE: See output of `$$$$$$_PauseResumeOverhead*` benchmarks for approximate
>> NOTE: overhead on the benchmark machine.
>> NOTE: See: https://github.com/google/benchmark/issues/179.
*********
>> NOTE: Benchmarks ending in `$_` use PauseTiming/ResumeTiming and
>> NOTE: run the function multiple times and need to be divided by
>> NOTE: the count (last argument) to get a value for a single call.
*********
```