### PR TITLE
Fix build for Clang 3.5

### DIFF
--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -28,9 +28,6 @@ using std::atomic_compare_exchange_strong_explicit;
 using std::atomic_fetch_add_explicit;
 using std::atomic_fetch_sub_explicit;
 using std::atomic_thread_fence;
-using std::atomic_flag_test_and_set_explicit;
-
-using std::atomic_flag;
 #  endif
 #elif defined(__GNUC__) && !defined(__clang__)
 #  include <features.h>
@@ -49,8 +46,6 @@ using std::atomic_flag;
 #  elif __GNUC_PREREQ(4, 7)
 // Valid on x86 and ARM given our uses of atomics.
 #    define PONY_ATOMIC(T) T
-#    define atomic_flag bool
-#    define ATOMIC_FLAG_INIT false
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use GCC >= 4.7"
@@ -64,8 +59,6 @@ using std::atomic_flag;
 #  elif __clang_major__ >= 3 && __clang_minor__ >= 3
 // Valid on x86 and ARM given our uses of atomics.
 #    define PONY_ATOMIC(T) T
-#    define atomic_flag bool
-#    define ATOMIC_FLAG_INIT false
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use Clang >= 3.3"
@@ -211,9 +204,6 @@ namespace ponyint_atomics
 
 #    define atomic_thread_fence(MO) \
       __atomic_thread_fence(MO)
-
-#    define atomic_flag_test_and_set_explicit(PTR, MO) \
-      __atomic_test_and_set(PTR, MO)
 
 #    undef PONY_ATOMIC_BUILTINS
 #  endif

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -14,14 +14,14 @@
 
 #include <pony/detail/atomics.h>
 
-static atomic_flag assert_guard = ATOMIC_FLAG_INIT;
+static PONY_ATOMIC(bool) assert_guard = false;
 
 #ifdef PLATFORM_IS_POSIX_BASED
 
 void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   const char* func)
 {
-  while(atomic_flag_test_and_set_explicit(&assert_guard, memory_order_acq_rel))
+  while(atomic_exchange_explicit(&assert_guard, true, memory_order_acq_rel))
   {
     // If the guard is already set, an assertion fired in another thread. The
     // things here aren't thread safe, so we just start an infinite loop.
@@ -59,7 +59,7 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
 void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   const char* func)
 {
-  while(atomic_flag_test_and_set_explicit(&assert_guard, memory_order_acq_rel))
+  while(atomic_exchange_explicit(&assert_guard, true, memory_order_acq_rel))
   {
     // If the guard is already set, an assertion fired in another thread. The
     // things here aren't thread safe, so we just start an infinite loop.


### PR DESCRIPTION
Clang 3.5 has support of atomics for C++ but not for C. When compiling a C++ file, the atomic_flag preprocessor define in the Pony source files was conflicting with std::atomic_flag from the C++ standard library.

@jemc Can you try and see if it fixes the build for you?