### PR TITLE
Call finalisers for embedded fields when parent type has no finalizer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,8 @@ endif
 # target specific build options
 libponyrt.buildoptions = -DPONY_NO_ASSERT
 
+libponyrt.tests.linkoptions += -rdynamic
+
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -294,7 +294,7 @@ static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
 }
 
 static void call_embed_finalisers(compile_t* c, reach_type_t* t,
-  LLVMValueRef obj)
+  ast_t* method_body, LLVMValueRef obj)
 {
   uint32_t base = 0;
   if(t->underlying != TK_STRUCT)
@@ -314,7 +314,9 @@ static void call_embed_finalisers(compile_t* c, reach_type_t* t,
       continue;
 
     LLVMValueRef field_ref = LLVMBuildStructGEP(c->builder, obj, base + i, "");
+    codegen_debugloc(c, method_body);
     LLVMBuildCall(c->builder, final_fn, &field_ref, 1, "");
+    codegen_debugloc(c, NULL);
   }
 }
 
@@ -329,7 +331,7 @@ static bool genfun_fun(compile_t* c, reach_type_t* t, reach_method_t* m)
   name_params(c, t, m, params, m->func);
 
   if(m->func == t->final_fn)
-    call_embed_finalisers(c, t, gen_this(c, NULL));
+    call_embed_finalisers(c, t, body, gen_this(c, NULL));
 
   LLVMValueRef value = gen_expr(c, body);
 

--- a/test/libponyc/codegen_final.cc
+++ b/test/libponyc/codegen_final.cc
@@ -1,0 +1,106 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+#define TEST_COMPILE(src) DO(test_compile(src, "ir"))
+
+
+class CodegenFinalTest : public PassTest
+{};
+
+
+TEST_F(CodegenFinalTest, PrimitiveInit)
+{
+  const char* src =
+    "primitive PrimitiveInit\n"
+    "  fun _init() =>\n"
+    "    @pony_exitcode[None](I32(1))\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(CodegenFinalTest, PrimitiveFinal)
+{
+  const char* src =
+    "primitive PrimitiveFinal\n"
+    "  fun _final() =>\n"
+    "    @pony_exitcode[None](I32(1))\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(CodegenFinalTest, ClassFinal)
+{
+  const char* src =
+    "class ClassFinal\n"
+    "  fun _final() =>\n"
+    "    @pony_exitcode[None](I32(1))\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    ClassFinal";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(CodegenFinalTest, EmbedFinal)
+{
+  const char* src =
+    "class EmbedFinal\n"
+    "  fun _final() =>\n"
+    "    @pony_exitcode[None](I32(1))\n"
+
+    "actor Main\n"
+    "  embed c: EmbedFinal = EmbedFinal\n"
+
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(CodegenFinalTest, ActorFinal)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None\n"
+
+    "  fun _final() =>\n"
+    "    @pony_exitcode[None](I32(1))";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}


### PR DESCRIPTION
This fixes a case overlooked in 087ebc7. In that commit, the finaliser of an embedded field was only called if the parent object (or actor) had an explicit finaliser. This change adds implicit finalisers to objects that must finalise an embedded field, including recursively.

PS: If this gets merged before the pending release this shouldn't get a changelog entry since it is covered by the one from #1586.