### PR TITLE
Remove the check for union types on match error

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -333,25 +333,12 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
 
     case MATCHTYPE_DENY:
     {
-      if(ast_id(match_type) == TK_UNIONTYPE) {
-        token_id cap = ast_id(ast_childidx(ast_child(match_type), 3));
-        for(size_t i=1; i<ast_childcount(match_type); i++) {
-          if(ast_id(ast_childidx(ast_childidx(match_type, i), 3)) != cap) {
-            ast_error(opt->check.errors, match_expr, 
-              "match type may not be a union of types with different "
-              "capabilities");
-            ast_error_continue(opt->check.errors, match_type, "match type: %s",
-              ast_print_type(operand_type));
-          }
-        }
-      } else {
-        ast_error(opt->check.errors, pattern,
-          "this capture violates capabilities");
-        ast_error_continue(opt->check.errors, match_type, "match type: %s",
-          ast_print_type(operand_type));
-        ast_error_continue(opt->check.errors, pattern, "pattern type: %s",
-          ast_print_type(pattern_type));
-      }
+      ast_error(opt->check.errors, pattern,
+        "this capture violates capabilities");
+      ast_error_continue(opt->check.errors, match_type, "match type: %s",
+        ast_print_type(operand_type));
+      ast_error_continue(opt->check.errors, pattern, "pattern type: %s",
+        ast_print_type(pattern_type));
 
       ok = false;
       break;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -316,29 +316,6 @@ TEST_F(BadPonyTest, IndexArrayWithBrackets)
   TEST_ERRORS_1(src, "Value formal parameters not yet supported");
 }
 
-TEST_F(BadPonyTest, MatchUnionOfDifferentCaps)
-{
-  // From issue #1506
-  const char* src =
-    "interface box Foo\n"
-      "fun foo(): None\n"
-
-    "interface ref Bar\n"
-      "fun ref bar(): None\n"
-
-    "actor Main\n"
-      "new create(env: Env) => None\n"
-
-      "fun apply(x: (Foo | Bar)) =>\n"
-        "match x\n"
-        "| let f: Foo => f.foo()\n"
-        "| let b: Bar => b.bar()\n"
-        "end";
-
-  TEST_ERRORS_1(src,
-    "match type may not be a union of types with different capabilities");
-}
-
 TEST_F(BadPonyTest, ShadowingBuiltinTypeParameter)
 {
   const char* src =


### PR DESCRIPTION
A nice attempt to produce a much friendlier error message when a union
type pattern is involved and a match expression doesn't type check is
sadly removed in this commit.

Unfortunately, it assumed union types would be composed of nominal types
(not true), and that the problem with the match was a union type with
varying capabilities (this is actually allowed).

A nicer error message would indeed be useful here. The right approach
would be to emit errors in `matchtype.c` when they are needed, i.e. on
DENY.