### PR TITLE
Only update online API docs when releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -233,14 +233,14 @@ after_success:
       make verbose=1 config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
     fi;
 
-  # For a master release build with the latest stable LLVM, upload docs.
+  # For a release release build with the latest stable LLVM, upload docs.
   - if [[
         "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
         "$LLVM_VERSION" == "3.9.1" &&
         "$config" == "release" &&
         "$TRAVIS_OS_NAME" == "linux" &&
         "$TRAVIS_PULL_REQUEST" == "false" &&
-        "$TRAVIS_BRANCH" == "master"
+        "$TRAVIS_BRANCH" == "release"
     ]];
     then
       git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}";


### PR DESCRIPTION
This will keep the online API docs in sync with the last release.
This feels like a less surprising thing to happen then to
have the docs change with each commit to master.

We could invest more time in the future to keep multiple versions
of the docs online + latest build docs but that is more than I
have time for at the moment.

If someone wanted to take that on, I'd be happy to guide them.