### PR TITLE
Fix type parameters not being visible to a lambda type in a type alias

### DIFF
--- a/src/libponyc/type/sanitise.c
+++ b/src/libponyc/type/sanitise.c
@@ -60,7 +60,7 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
   while(entity != NULL && ast_id(entity) != TK_INTERFACE &&
     ast_id(entity) != TK_TRAIT && ast_id(entity) != TK_PRIMITIVE &&
     ast_id(entity) != TK_STRUCT && ast_id(entity) != TK_CLASS &&
-    ast_id(entity) != TK_ACTOR)
+    ast_id(entity) != TK_ACTOR && ast_id(entity) != TK_TYPE)
   {
     entity = ast_parent(entity);
   }

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -492,3 +492,11 @@ TEST_F(VerifyTest, FFICallPartialWithNonPartialDeclaration)
 
   TEST_ERRORS_1(src, "call is partial but the declaration is not");
 }
+
+TEST_F(VerifyTest, LambdaTypeGenericAliased)
+{
+  const char* src =
+    "type Foo[T] is {(T): T}";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Currently the following code does not compile:

    type Foo[T] is { (T): T }

The compiler gives the error:

    lambdaalias.pony:1:19: can't find definition of 'T'
    type Foo[T] is { (T): T }

This PR allows the lambda type to find type parameters from an enclosing type alias, as well as class, actor, etc.

I don't think this should affect anything else, since the only other use of the `collect_type_params()` function is for sugaring object literals, which aren't allowed in a type alias.  Please let me know if this change will have wider implications.