### PR TITLE
Add example code for the format package

### DIFF
--- a/packages/format/format.pony
+++ b/packages/format/format.pony
@@ -1,3 +1,37 @@
+"""
+# Format package
+
+The Format package provides support for formatting strings. It can be
+used to set things like width, padding and alignment, as well as
+controlling the way numbers are displayed (decimal, octal,
+hexadecimal).
+
+# Example program
+
+```pony
+use "format"
+
+actor Main
+  fun disp(desc: String, v: I32, fmt: FormatInt = FormatDefault): String =>
+    Format(desc where width = 10)
+      + ":"
+      + Format.int[I32](v where width = 10, align = AlignRight, fmt = fmt)
+
+  new create(env: Env) =>
+    try
+      (let x, let y) = (env.args(1).i32(), env.args(2).i32())
+      env.out.print(disp("x", x))
+      env.out.print(disp("y", y))
+      env.out.print(disp("hex(x)", x, FormatHex))
+      env.out.print(disp("hex(y)", y, FormatHex))
+      env.out.print(disp("x * y", x * y))
+    else
+      let exe = try env.args(0) else "fmt_example" end
+      env.err.print("Usage: " + exe + " NUMBER1 NUMBER2")
+    end
+```
+"""
+
 use "collections"
 
 primitive Format
@@ -16,7 +50,7 @@ primitive Format
   *align. Specify whether fill characters should be added at the beginning or
   end of the generated string, or both.
   *fill: The character to pad a string with if is is shorter than width.
-  """
+z  """
   fun apply(str: String, fmt: FormatDefault = FormatDefault,
     prefix: PrefixDefault = PrefixDefault, prec: USize = -1, width: USize = 0,
     align: Align = AlignLeft, fill: U32 = ' '

--- a/packages/format/format.pony
+++ b/packages/format/format.pony
@@ -50,7 +50,7 @@ primitive Format
   *align. Specify whether fill characters should be added at the beginning or
   end of the generated string, or both.
   *fill: The character to pad a string with if is is shorter than width.
-z  """
+  """
   fun apply(str: String, fmt: FormatDefault = FormatDefault,
     prefix: PrefixDefault = PrefixDefault, prec: USize = -1, width: USize = 0,
     align: Align = AlignLeft, fill: U32 = ' '


### PR DESCRIPTION
This commit adds a short example to the format package that
demonstrates how the package can be used to format strings. The
example is not meant to be comprehensive, only to demonstrate usage in
order ot make it easier to start using the package.