### PR TITLE
More efficient object finalising implementation

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -428,11 +428,10 @@ static void init_runtime(compile_t* c)
   LLVMSetDereferenceableOrNull(value, 0, HEAP_MIN);
 #endif
 
-  // i8* pony_alloc_final(i8*, intptr, c->final_fn)
+  // i8* pony_alloc_final(i8*, intptr)
   params[0] = c->void_ptr;
   params[1] = c->intptr;
-  params[2] = c->final_fn;
-  type = LLVMFunctionType(c->void_ptr, params, 3, false);
+  type = LLVMFunctionType(c->void_ptr, params, 2, false);
   value = LLVMAddFunction(c->module, "pony_alloc_final", type);
 #if PONY_LLVM >= 309
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
@@ -449,6 +448,50 @@ static void init_runtime(compile_t* c)
 #  endif
   LLVMSetReturnNoAlias(value);
   LLVMSetDereferenceableOrNull(value, 0, HEAP_MIN);
+#endif
+
+  // i8* pony_alloc_small_final(i8*, i32)
+  params[0] = c->void_ptr;
+  params[1] = c->i32;
+  type = LLVMFunctionType(c->void_ptr, params, 2, false);
+  value = LLVMAddFunction(c->module, "pony_alloc_small_final", type);
+#if PONY_LLVM >= 309
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,
+    inacc_or_arg_mem_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, noalias_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex,
+    deref_alloc_small_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, align_heap_attr);
+#else
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+#  if PONY_LLVM >= 308
+  LLVMSetInaccessibleMemOrArgMemOnly(value);
+#  endif
+  LLVMSetReturnNoAlias(value);
+  LLVMSetDereferenceable(value, 0, HEAP_MIN);
+#endif
+
+  // i8* pony_alloc_large_final(i8*, intptr)
+  params[0] = c->void_ptr;
+  params[1] = c->intptr;
+  type = LLVMFunctionType(c->void_ptr, params, 2, false);
+  value = LLVMAddFunction(c->module, "pony_alloc_large_final", type);
+#if PONY_LLVM >= 309
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,
+    inacc_or_arg_mem_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, noalias_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex,
+    deref_alloc_large_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, align_heap_attr);
+#else
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+#  if PONY_LLVM >= 308
+  LLVMSetInaccessibleMemOrArgMemOnly(value);
+#  endif
+  LLVMSetReturnNoAlias(value);
+  LLVMSetDereferenceable(value, 0, HEAP_MAX << 1);
 #endif
 
   // $message* pony_alloc_msg(i32, i32)

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -1142,21 +1142,20 @@ LLVMValueRef gencall_allocstruct(compile_t* c, reach_type_t* t)
   if(size == 0)
     size = 1;
 
-  if(t->final_fn == NULL)
+  if(size <= HEAP_MAX)
   {
-    if(size <= HEAP_MAX)
-    {
-      uint32_t index = ponyint_heap_index(size);
-      args[1] = LLVMConstInt(c->i32, index, false);
+    uint32_t index = ponyint_heap_index(size);
+    args[1] = LLVMConstInt(c->i32, index, false);
+    if(t->final_fn == NULL)
       result = gencall_runtime(c, "pony_alloc_small", args, 2, "");
-    } else {
-      args[1] = LLVMConstInt(c->intptr, size, false);
-      result = gencall_runtime(c, "pony_alloc_large", args, 2, "");
-    }
+    else
+      result = gencall_runtime(c, "pony_alloc_small_final", args, 2, "");
   } else {
     args[1] = LLVMConstInt(c->intptr, size, false);
-    args[2] = LLVMConstBitCast(t->final_fn, c->final_fn);
-    result = gencall_runtime(c, "pony_alloc_final", args, 3, "");
+    if(t->final_fn == NULL)
+      result = gencall_runtime(c, "pony_alloc_large", args, 2, "");
+    else
+      result = gencall_runtime(c, "pony_alloc_large_final", args, 2, "");
   }
 
   result = LLVMBuildBitCast(c->builder, result, t->structure_ptr, "");

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -18,7 +18,6 @@ typedef struct gc_t
   uint32_t mark;
   uint32_t rc_mark;
   size_t rc;
-  size_t finalisers;
   objectmap_t local;
   actormap_t foreign;
   deltamap_t* delta;
@@ -74,10 +73,6 @@ bool ponyint_gc_release(gc_t* gc, actorref_t* aref);
 size_t ponyint_gc_rc(gc_t* gc);
 
 deltamap_t* ponyint_gc_delta(gc_t* gc);
-
-void ponyint_gc_register_final(pony_ctx_t* ctx, void* p, pony_final_fn final);
-
-void ponyint_gc_final(pony_ctx_t* ctx, gc_t* gc);
 
 void ponyint_gc_done(gc_t* gc);
 

--- a/src/libponyrt/gc/objectmap.h
+++ b/src/libponyrt/gc/objectmap.h
@@ -9,7 +9,6 @@ PONY_EXTERN_C_BEGIN
 typedef struct object_t
 {
   void* address;
-  pony_final_fn final;
   size_t rc;
   uint32_t mark;
   bool immutable;
@@ -22,12 +21,7 @@ object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address, size_t* i
 object_t* ponyint_objectmap_getorput(objectmap_t* map, void* address,
   uint32_t mark);
 
-object_t* ponyint_objectmap_register_final(objectmap_t* map, void* address,
-  pony_final_fn final, uint32_t mark);
-
-void ponyint_objectmap_final(objectmap_t* map);
-
-size_t ponyint_objectmap_sweep(objectmap_t* map);
+void ponyint_objectmap_sweep(objectmap_t* map);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -37,6 +37,8 @@ void ponyint_heap_init(heap_t* heap);
 
 void ponyint_heap_destroy(heap_t* heap);
 
+void ponyint_heap_final(heap_t* heap);
+
 __pony_spec_malloc__(
   void* ponyint_heap_alloc(pony_actor_t* actor, heap_t* heap, size_t size)
   );
@@ -52,6 +54,20 @@ void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size)
 
 void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
   size_t size);
+
+__pony_spec_malloc__(
+  void* ponyint_heap_alloc_final(pony_actor_t* actor, heap_t* heap, size_t size)
+  );
+
+__pony_spec_malloc__(
+void* ponyint_heap_alloc_small_final(pony_actor_t* actor, heap_t* heap,
+  uint32_t sizeclass)
+  );
+
+__pony_spec_malloc__(
+void* ponyint_heap_alloc_large_final(pony_actor_t* actor, heap_t* heap,
+  size_t size)
+  );
 
 /**
  * Adds to the used memory figure kept by the heap. This allows objects

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -209,8 +209,14 @@ PONY_API ATTRIBUTE_MALLOC void* pony_realloc(pony_ctx_t* ctx, void* p, size_t si
  * Attach a finaliser that will be run on memory when it is collected. Such
  * memory cannot be safely realloc'd.
  */
-PONY_API ATTRIBUTE_MALLOC void* pony_alloc_final(pony_ctx_t* ctx, size_t size,
-  pony_final_fn final);
+PONY_API ATTRIBUTE_MALLOC void* pony_alloc_final(pony_ctx_t* ctx, size_t size);
+
+/// Allocate using a HEAP_INDEX instead of a size in bytes.
+PONY_API ATTRIBUTE_MALLOC void* pony_alloc_small_final(pony_ctx_t* ctx,
+  uint32_t sizeclass);
+
+/// Allocate when we know it's larger than HEAP_MAX.
+PONY_API ATTRIBUTE_MALLOC void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size);
 
 /// Trigger GC next time the current actor is scheduled
 PONY_API void pony_triggergc(pony_actor_t* actor);

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -28,7 +28,6 @@ typedef struct pony_ctx_t
   trace_actor_fn trace_actor;
   gcstack_t* stack;
   actormap_t acquire;
-  bool finalising;
 
   void* serialise_buffer;
   size_t serialise_size;


### PR DESCRIPTION
This PR includes 2 changes

* Ponybench arguments + finaliser benchmarks
  This commit enhances `ponybench` to use `options` to take
optional command line arguments to change `autobench_time`
and `autobench_max_ops` dynamically at runtime.
  This commit also adds benchmarks for objects with and without
finalisers to `minimal-cates/finalisers`.

* More efficient object finalising implementation
  Thanks to @sylvanc  and @aturley for their ideas.
  * The old finaliser implementation used the object hashmap to keep
  track of finalisers that needed to be run. This was not ideal
  because while the hashmap provides constant time operations,
  the constant time was still much larger than the time for a normal
  no finaliser allocation. Additionally, keeping track of finalisers
  in the object hashmap meant that every object with a finaliser
  would be added to the object hashmap even if it was only transient
  and never sent to another actor. This, once again, was different
  from normal allocations where the objects wouldn't be added to
  the hashmap until they were sent to another actor. The benchmark
  using ponybench showed that objects with finalisers were about
  1 order of magnitude slower than objects without finalisers due
  to the overhead of using the object hashmap for tracking them.
  * The new finaliser implementation keeps the finaliser information
  in the chunk where the memory was allocated from. This is exactly
  the same as how non-finaliser allocations are tracked except for
  the additional work to keep track of the finaliser. The resulting
  benefit is that objects with finalisers will only get added to the
  object hashmap under the same circumstances as objects without
  finalisers. This gives us an increase in performance by 1 order of
  magnitude so that now objects with finalisers have the same allocation
  performance as objects without finalisers.
  * Keep a finaliser bitmap in chunk_t instead of an array of finaliser
  pointers. Run the finaliser from the pony_type_t->final_fn instead
  of storing/using the function passed in to pony_alloc_final.
  * Add pony_alloc_small_final and pony_alloc_large_final functions
  to avoid having to go through a branch and another function call
  to allocate memory with a finaliser.
  * Update compiler to call the appropriate one of pony_alloc_small_final
  or pony_alloc_large_final instead of pony_alloc_final.

  Future work:

  * It should be possible to remove pony_alloc_*_final finctions altogether and
  update pony_alloc, pony_alloc_small, pony_alloc_large to take
  a boolean as to whether a finaliser exists for the type or not.
  This would also require changes to the compiler to generate the
  appropriate boolean true/false for when a finaliser exists or not.

----------

Benchmarks before:
```
vagrant@buffy-leader-1:~/hp2$ ./finalisers --autobench_time 100_000_000
primitive init
nofinal	  20000000	        11 ns/op
final	   2000000	       125 ns/op
actor final
embed final
class final
primitive final
```

Benchmarks after:
```
vagrant@buffy-leader-1:~/hp2$ sudo chrt -f 80 ./finalisers --autobench_time 100_000_000
primitive init
nofinal	  10000000	        12 ns/op
final	  10000000	        13 ns/op
actor final
embed final
class final
primitive final
```

---------------

Please let me know if there are any questions or concerns or if any of the changes need to go through an RFC.

Also, as always, feedback/suggestions for improvements welcome.