### PR TITLE
Make buffered.Reader.append accept any ByteSeq.

### DIFF
--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -79,12 +79,20 @@ class Reader
     _chunks.clear()
     _available = 0
 
-  fun ref append(data: Array[U8] val) =>
+  fun ref append(data: ByteSeq) =>
     """
     Add a chunk of data.
     """
-    _available = _available + data.size()
-    _chunks.push((data, 0))
+    let data_array: Array[U8] val =
+      match data
+      | let data': Array[U8] val => data'
+      | let data': String        => data'.array()
+      else // unreachable
+        recover val Array[U8] end
+      end
+
+    _available = _available + data_array.size()
+    _chunks.push((data_array, 0))
 
   fun ref skip(n: USize) ? =>
     """


### PR DESCRIPTION
This is an issue of principle-of-least-surprise, since `buffered.Writer`
emits `ByteSeq`s in its output, so having `buffered.Reader` accept `ByteSeq`s
at its input makes it symmetrical and least surprising.

This doesn't break any user code, since it only makes an argument type
more general, and does not make any return types more general.

This came up in a discussion in #1639.