### PR TITLE
Change to dynamic memory allocation/commit on windows

### DIFF
--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -18,7 +18,7 @@ void* ponyint_virt_alloc(size_t bytes)
   void* p;
 
 #if defined(PLATFORM_IS_WINDOWS)
-  p = VirtualAlloc(NULL, bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  p = VirtualAlloc(NULL, bytes, MEM_RESERVE, PAGE_READWRITE);
 #elif defined(PLATFORM_IS_POSIX_BASED)
 #if defined(PLATFORM_IS_LINUX)
   p = mmap(0, bytes, PROT_READ | PROT_WRITE,

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -677,6 +677,14 @@ static void* pool_alloc_pages(size_t size)
   pool_block_t* block = (pool_block_t*)ponyint_virt_alloc(POOL_MMAP);
   size_t rem = POOL_MMAP - size;
 
+#if defined(PLATFORM_IS_WINDOWS)
+  // Commit pages that have only been reserved so far
+  // so block information can be written.
+  // This is safe even if the same pages have already
+  // been commited previously.
+  VirtualAlloc(block, 1024, MEM_COMMIT, PAGE_READWRITE);
+#endif
+
   block->size = rem;
   block->next = NULL;
   block->prev = NULL;
@@ -853,6 +861,13 @@ void* ponyint_pool_alloc(size_t index)
   pool_local_t* pool = pool_local;
   void* p = pool_get(pool, index);
 
+#if defined(PLATFORM_IS_WINDOWS)
+  // Commit pages that have only been reserved so far.
+  // This is safe even if the same pages have already
+  // been commited previously.
+  VirtualAlloc(p, ponyint_pool_size(index), MEM_COMMIT, PAGE_READWRITE);
+#endif
+
   TRACK_ALLOC(p, POOL_MIN << index);
 
 #ifdef USE_VALGRIND
@@ -904,6 +919,13 @@ void* ponyint_pool_alloc_size(size_t size)
 
   size = ponyint_pool_adjust_size(size);
   void* p = pool_alloc_pages(size);
+
+#if defined(PLATFORM_IS_WINDOWS)
+  // Commit pages that have only been reserved so far.
+  // This is safe even if the same pages have already
+  // been commited previously.
+  VirtualAlloc(p, size, MEM_COMMIT, PAGE_READWRITE);
+#endif
 
   TRACK_ALLOC(p, size);
 


### PR DESCRIPTION
/cc @Praetonus

This PR implements suggestion 2 from https://github.com/ponylang/ponyc/pull/1614#issuecomment-284553911 to switch to using dynamic memory allocation/commitment for Windows.

-------------

This commit changes how the Windows memory allocation/commitment
is done by switching from committing all memory immediately
to only committing memory dynamically as it gets allocated.

This resolves the Windows errors that PR #1614 and PR #1629 have
been encountering related to `ponyint_virt_alloc` and `The paging
file is too small for this operation to complete.`