### PR TITLE
fix changelog typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix type parameters not being visible to a lambda type in a type alias (PR #1633)
 - Remove the check for union types on match error (PR #1630)
 - TCPListener: unsubscribe asio before socket close (PR #1626)
-- Fix buffer overlow in case method docstring (PR #1615)
+- Fix buffer overflow in case method docstring (PR #1615)
 - Fix capability checking for gencap-constrained type parameters. (PR #1593)
 - Fix error in ANTLR grammar regarding duplicate '-~'. (#1602) (PR #1604)
 - Escape special characters in ANLTR strings. (#1600) (PR #1601)


### PR DESCRIPTION
`buffer overlow` -> `buffer overflow`