### PR TITLE
Fix linking with '--as-needed' (sensitive to linking order)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,8 +560,8 @@ define CONFIGURE_LINKER
     linker := $(CXX)
   endif
 
-  $(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
   $(eval $(call CONFIGURE_LINKER_WHOLE,$(1)))
+  $(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
   linkcmd += $(libs) $($(1).linkoptions)
 endef
 


### PR DESCRIPTION
While working on a Gentoo ebuild, where I make sure that the environment CFLAGS and LDFLAGS are used - as is policy - I encountered a linking failure when having "--as-needed" in LDFLAGS. Turns out it was due to the linking order ("-ldl" appearing before "-lponyrt").

This patch changes the order of the "whole archive" and the regular libraries, thus fixing the problem.