### PR TITLE
Prevent duplicate Windows releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ configuration:
   - debug
 
 clone_depth: 100
+skip_tags: true
 
 clone_folder: C:\projects\ponyc
 


### PR DESCRIPTION
Appveyor differs from TravisCI in that Appveyor will
kick off a CI run for a push to GitHub that is only
tags, no new commits.

As detailed in issue #1655, this combined with the
two pushes to release we do in `release.sh` means that
we do two release to bintray for each Windows release.

Initially I was going to merge the two git pushes into
a single push to solve the problem. After some thought,
I decided that the best solution is to make TravisCI and
Appveyor behave the same. If they continue to behave
differently in this regard, we might encounter additional
odd errors in the future.

Closes #1655