### PR TITLE
Correctly pass `arch=` when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY lib      /src/ponyc/lib
 COPY test     /src/ponyc/test
 COPY packages /src/ponyc/packages
 
-RUN make -arch= \
+RUN make arch= \
  && make install \
  && rm -rf /src/ponyc/build
 


### PR DESCRIPTION
In previous commit, it was being passed with `-arch=`
rather than the correct `arch=`