### PR TITLE
Turn off CI for LLVM 3.9 on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,22 +118,6 @@ matrix:
         - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
-    - os: osx
-      env:
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - config=debug
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
-    - os: osx
-      env:
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - config=release
-        - lto=no
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
-
 
 rvm:
   - 2.2.3


### PR DESCRIPTION
Homebrew switched the version of llvm installed by

`brew install llvm`

from 3.9 to 4.0

CI falls as our Makefile only works with 3.7 to 3.9. However,
even without that Makefile issue, ponyc won't compile with 4.0.

Sadly, at the moment, there is no way to install llvm 3.9 via
homebrew. There is no @version available for 3.9 like there is
with llvm@3.7 and llvm@3.8