### PR TITLE
Fix illegal instruction errors on older cpus when using packaged Pony

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -214,7 +214,7 @@ after_success:
           PACKAGE_CONFLICTS="ponyc-release";
       fi;
       PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
-      make verbose=1 arch= config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
+      make verbose=1 arch=x86-64 config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
     fi;
 
   # For a release release build with the latest stable LLVM, upload docs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY lib      /src/ponyc/lib
 COPY test     /src/ponyc/test
 COPY packages /src/ponyc/packages
 
-RUN make arch= \
+RUN make arch=x86-64 \
  && make install \
  && rm -rf /src/ponyc/build
 


### PR DESCRIPTION
This should be followed by modifying the makefile to allow
setting -mtune to intel.

This should however fix issue #1682.