### PR TITLE
Fix compiler assert in names pass on TypeParam->Class.

### DIFF
--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -2,7 +2,6 @@
 #include "../ast/astbuild.h"
 #include "../ast/id.h"
 #include "../type/reify.h"
-#include "../type/viewpoint.h"
 #include "../pkg/package.h"
 #include "ponyassert.h"
 
@@ -361,34 +360,6 @@ bool names_nominal(pass_opt_t* opt, ast_t* scope, ast_t** astp, bool expr)
   return r;
 }
 
-static bool names_arrow(pass_opt_t* opt, ast_t** astp)
-{
-  AST_GET_CHILDREN(*astp, left, right);
-
-  switch(ast_id(left))
-  {
-    case TK_ISO:
-    case TK_TRN:
-    case TK_REF:
-    case TK_VAL:
-    case TK_BOX:
-    case TK_TAG:
-    case TK_THISTYPE:
-    case TK_TYPEPARAMREF:
-    {
-      ast_t* r_ast = viewpoint_type(left, right);
-      ast_replace(astp, r_ast);
-      return true;
-    }
-
-    default: {}
-  }
-
-  ast_error(opt->check.errors, left,
-    "only 'this', refcaps, and type parameters can be viewpoints");
-  return false;
-}
-
 ast_result_t pass_names(ast_t** astp, pass_opt_t* options)
 {
   (void)options;
@@ -397,11 +368,6 @@ ast_result_t pass_names(ast_t** astp, pass_opt_t* options)
   {
     case TK_NOMINAL:
       if(!names_nominal(options, *astp, astp, false))
-        return AST_FATAL;
-      break;
-
-    case TK_ARROW:
-      if(!names_arrow(options, astp))
         return AST_FATAL;
       break;
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -389,3 +389,15 @@ TEST_F(BadPonyTest, RefCapViolationViaCapAnyTypeParameter)
 
   TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
 }
+
+TEST_F(BadPonyTest, TypeParamArrowClass)
+{
+  // From issue #1687
+  const char* src =
+    "class C1\n"
+
+    "trait Test[A]\n"
+      "fun foo(a: A): A->C1";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Moves arrow viewpoint processing from names pass to flatten pass,
so that typeparam_set_cap will have already been run.

Resolves #1687.