### PR TITLE
Build Linux release binaries correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -213,6 +213,7 @@ after_success:
           PACKAGE_NAME="ponyc-$TRAVIS_BRANCH";
           PACKAGE_CONFLICTS="ponyc-release";
       fi;
+      make clean config=release;
       PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
       make verbose=1 arch=x86-64 config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
     fi;


### PR DESCRIPTION
Before this change, when releasing to bintray, we would run

`make deploy arch=x86-64 ... deploy`

with the intent of building a pony compiler and runtime that targets
the x68-64 instruction set. Unfortunately that isn't what would happen.
Because we had previously run

`make test-ci`

Which doesnt specify an architecture and therefore uses features
available on the build machine, we were in fact uploading an arch
specific build- the one created by `make test-ci`.

With this change, we will remove all `make test-ci` related items and
then rebuild for release with the correct make settings.

Fixes #1696