### PR TITLE
Fix compiler assert on arrow to typeparam in constraint.

### DIFF
--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -137,29 +137,9 @@ static ast_result_t flatten_async(pass_opt_t* opt, ast_t* ast)
   return flatten_sendable_params(opt, params);
 }
 
-static ast_result_t flatten_tupletype(pass_opt_t* opt, ast_t* ast)
-{
-  if(opt->check.frame->constraint != NULL)
-  {
-    ast_error(opt->check.errors, ast,
-      "tuple types can't be used as constraints");
-    return AST_ERROR;
-  }
-
-  return AST_OK;
-}
-
 static ast_result_t flatten_arrow(pass_opt_t* opt, ast_t** astp)
 {
   AST_GET_CHILDREN(*astp, left, right);
-
-  if((opt->check.frame->constraint != NULL) &&
-    (opt->check.frame->method == NULL))
-  {
-    ast_error(opt->check.errors, *astp,
-      "arrow types can't be used as type constraints");
-    return AST_ERROR;
-  }
 
   switch(ast_id(left))
   {
@@ -291,9 +271,6 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
 
     case TK_BE:
       return flatten_async(options, ast);
-
-    case TK_TUPLETYPE:
-      return flatten_tupletype(options, ast);
 
     case TK_ARROW:
       return flatten_arrow(options, astp);

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -442,10 +442,18 @@ static ast_result_t syntax_thistype(pass_opt_t* opt, ast_t* ast)
 }
 
 
-static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
+static ast_result_t syntax_arrow(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
+
+  if((opt->check.frame->constraint != NULL) &&
+    (opt->check.frame->method == NULL))
+  {
+    ast_error(opt->check.errors, ast,
+      "arrow types can't be used as type constraints");
+    return AST_ERROR;
+  }
 
   switch(ast_id(right))
   {
@@ -465,6 +473,19 @@ static ast_result_t syntax_arrowtype(pass_opt_t* opt, ast_t* ast)
       return AST_ERROR;
 
     default: {}
+  }
+
+  return AST_OK;
+}
+
+
+static ast_result_t syntax_tupletype(pass_opt_t* opt, ast_t* ast)
+{
+  if(opt->check.frame->constraint != NULL)
+  {
+    ast_error(opt->check.errors, ast,
+      "tuple types can't be used as type constraints");
+    return AST_ERROR;
   }
 
   return AST_OK;
@@ -1134,7 +1155,8 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_TRAIT:      r = syntax_entity(options, ast, DEF_TRAIT); break;
     case TK_INTERFACE:  r = syntax_entity(options, ast, DEF_INTERFACE); break;
     case TK_THISTYPE:   r = syntax_thistype(options, ast); break;
-    case TK_ARROW:      r = syntax_arrowtype(options, ast); break;
+    case TK_ARROW:      r = syntax_arrow(options, ast); break;
+    case TK_TUPLETYPE:  r = syntax_tupletype(options, ast); break;
     case TK_NOMINAL:    r = syntax_nominal(options, ast); break;
     case TK_MATCH:      r = syntax_match(options, ast); break;
     case TK_FFIDECL:    r = syntax_ffi(options, ast, false); break;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -401,3 +401,15 @@ TEST_F(BadPonyTest, TypeParamArrowClass)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(BadPonyTest, ArrowTypeParamInConstraint)
+{
+  // From issue #1694
+  const char* src =
+    "trait T1[A: B->A, B]\n"
+    "trait T2[A: box->B, B]";
+
+  TEST_ERRORS_2(src,
+    "arrow types can't be used as type constraints",
+    "arrow types can't be used as type constraints");
+}


### PR DESCRIPTION
Fixes by moving "in constraint" checks for arrow and tupletype
from the flatten pass to the syntax pass, so that they are guaranteed
to happen before we try to set the cap on the typeparamref.

It's also more appropriate to run them there since they are syntax-level
checks that require no knowledge of name resolution, or anything else
beyond simple syntax frame lookups.

Resolves #1694.