### PR TITLE
Improve packaged Linux binary performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -215,7 +215,7 @@ after_success:
       fi;
       make clean config=release;
       PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
-      make verbose=1 arch=x86-64 config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
+      make verbose=1 arch=x86-64 tune=intel config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
     fi;
 
   # For a release release build with the latest stable LLVM, upload docs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY lib      /src/ponyc/lib
 COPY test     /src/ponyc/test
 COPY packages /src/ponyc/packages
 
-RUN make arch=x86-64 \
+RUN make arch=x86-64 tune=intel \
  && make install \
  && rm -rf /src/ponyc/build
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ endif
 # Default settings (silent release build).
 config ?= release
 arch ?= native
+tune ?= generic
 bits ?= $(shell getconf LONG_BIT)
 
 ifndef verbose
@@ -91,9 +92,9 @@ prefix ?= /usr/local
 destdir ?= $(prefix)/lib/pony/$(tag)
 
 LIB_EXT ?= a
-BUILD_FLAGS = -march=$(arch) -Werror -Wconversion \
+BUILD_FLAGS = -march=$(arch) -mtune=$(tune) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
-LINKER_FLAGS = -march=$(arch)
+LINKER_FLAGS = -march=$(arch) -mtune=$(tune)
 AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \


### PR DESCRIPTION
This PR closes #1695 by adding Makefile support for `-mtune` and updates the .travis.yml and Dockerfile files to include `tune=intel`.