### PR TITLE
Don't run appveyor CI for TravisCI only change

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,9 @@ configuration:
 
 clone_depth: 100
 skip_tags: true
+skip_commits:
+  files:
+    - .travis.yml
 
 clone_folder: C:\projects\ponyc
 


### PR DESCRIPTION
If the only file changed is `.travis.yml`, there's no point in
doing an Appveyor run.

See:

https://www.appveyor.com/docs/how-to/filtering-commits/#commit-files-github-and-bitbucket-only

for more information