### PR TITLE
Register the thread calling pony_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ## [unreleased] - unreleased
 
-{{hook}}- Fix compiler assert on arrow to typeparam in constraint. (PR #1701)
+### Fixed
+
+- Fix compiler assert on arrow to typeparam in constraint. (PR #1701)
+- Segmentation fault on runtime termination.
 
 ### Added
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -367,8 +367,8 @@ PONY_API int pony_start(bool library, bool language_features);
  * done before calling pony_ctx(), and before calling any Pony code from the
  * thread.
  *
- * The thread that calls pony_start() is automatically registered. It's safe,
- * but not necessary, to call this more than once.
+ * Threads that call pony_init() or pony_start() are automatically registered.
+ * It's safe, but not necessary, to call this more than once.
  */
 PONY_API void pony_register_thread();
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -370,6 +370,8 @@ static void ponyint_sched_shutdown()
 pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
   bool pinasio)
 {
+  pony_register_thread();
+
   use_yield = !noyield;
 
   // If no thread count is specified, use the available physical core count.
@@ -392,16 +394,15 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
     ponyint_mpmcq_init(&scheduler[i].q);
   }
 
-  this_scheduler = &scheduler[0];
   ponyint_mpmcq_init(&inject);
   ponyint_asio_init(asio_cpu);
 
-  return &scheduler[0].ctx;
+  return pony_ctx();
 }
 
 bool ponyint_sched_start(bool library)
 {
-  this_scheduler = NULL;
+  pony_register_thread();
 
   if(!ponyint_asio_start())
     return false;
@@ -410,11 +411,6 @@ bool ponyint_sched_start(bool library)
 
   DTRACE0(RT_START);
   uint32_t start = 0;
-
-  if(library)
-  {
-    pony_register_thread();
-  }
 
   for(uint32_t i = start; i < scheduler_count; i++)
   {


### PR DESCRIPTION
Previously, the thread initialising the runtime would use the runtime context of one of the scheduler threads. Now that the pony_unregister_thread function exists and is freeing the runtime context of the schedulers when the runtime exits, the initialising thread must have its own context.

This should fix the segfault encountered by #1629.