### PR TITLE
Rename packages from "ponyc-release" to "ponyc"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ install:
       $package_commit = git rev-parse --short --verify "HEAD^{commit}"
       $package_version = (Get-Content "VERSION")
       $package_iteration = "$package_iteration${env:appveyor_build_number}.$package_commit"
-      Update-AppveyorBuild -Version "ponyc-${env:appveyor_repo_branch}-$package_version-$package_iteration"
+      Update-AppveyorBuild -Version "ponyc-$package_version-$package_iteration"
   - cd C:\projects\ponyc
   - python -x waf configure
   - python -x waf build --config %configuration% --llvm %llvm%
@@ -60,7 +60,7 @@ deploy:
         secure: 4KgdDQLp2kX816XH27d5xdJBPlKGhYXN6ttdHTSt5qe1MVIF+/VResUstg0zuJ6m
     subject: pony-language
     repo: ponyc-win
-    package: ponyc-release
+    package: ponyc
     version: $(appveyor_build_version)
     on:
         branch: release

--- a/.bintray.sh
+++ b/.bintray.sh
@@ -1,6 +1,6 @@
 REPO_TYPE=$1        # e.g., rpm | debian | source
 PACKAGE_VERSION=$2  # e.g., 0.2.1-234.master.abcdefa
-PACKAGE_NAME=$3     # e.g., ponyc-master | ponyc-release
+PACKAGE_NAME=$3     # e.g., ponyc
 
 # TODO: cut "ponyc" out of the repo names
 BINTRAY_REPO_NAME="ponyc-$REPO_TYPE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -215,22 +215,11 @@ after_success:
   # The PACKAGE_ITERATION will be fed to the DEB and RPM systems by FPM
   # as a suffix to the base version (DEB:debian_revision or RPM:release,
   # used to disambiguate packages with the same version).
-  #
-  # PACKAGE_NAME and PACKAGE_CONFLICTS are used (by FPM) to create mutually exclusive packages
-  # like "ponyc-master" and "ponyc-release".
   - if [[ "$CREATE_PACKAGES" == "yes" ]];
     then
-      if [[ "$TRAVIS_BRANCH" == "release" ]];
-      then
-          PACKAGE_NAME="ponyc-release";
-          PACKAGE_CONFLICTS="ponyc-master";
-      else
-          PACKAGE_NAME="ponyc-$TRAVIS_BRANCH";
-          PACKAGE_CONFLICTS="ponyc-release";
-      fi;
       make clean config=release;
       PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
-      make verbose=1 arch=x86-64 tune=intel config=release package_name="$PACKAGE_NAME" package_conflicts="$PACKAGE_CONFLICTS" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
+      make verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
     fi;
 
   # For a release release build with the latest stable LLVM, upload docs.
@@ -254,32 +243,7 @@ after_success:
     fi;
 
 deploy:
-  # - provider: bintray
-  #   user: pony-buildbot-2
-  #   file: /home/travis/build/ponylang/ponyc/bintray_debian.yml
-  #   on:
-  #     branch: master
-  #     condition: "$UPLOAD = yes"
-  #   key:
-  #     secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
-
-  # - provider: bintray
-  #   user: pony-buildbot-2
-  #   file: /home/travis/build/ponylang/ponyc/bintray_rpm.yml
-  #   on:
-  #     branch: master
-  #     condition: "$UPLOAD = yes"
-  #   key:
-  #     secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
-
-  # - provider: bintray
-  #   user: pony-buildbot-2
-  #   file: /home/travis/build/ponylang/ponyc/bintray_source.yml
-  #   on:
-  #     branch: master
-  #     condition: "$UPLOAD = yes"
-  #   key:
-  #     secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+  # Although we build artifacts for master, only deploy them for release.
 
   - provider: bintray
     user: pony-buildbot-2

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ endif
 # package_name, _version, and _iteration can be overridden by Travis or AppVeyor
 package_base_version ?= $(tag)
 package_iteration ?= "1"
-package_name ?= "ponyc-unknown"
-package_conflicts ?= "ponyc-release"
+package_name ?= "ponyc"
 package_version = $(package_base_version)-$(package_iteration)
 archive = $(package_name)-$(package_version).tar
 package = build/$(package_name)-$(package_version)
@@ -799,8 +798,8 @@ endif
 	$(SILENT)ln -s /usr/lib/pony/$(package_version)/include/pony/detail/atomics.h $(package)/usr/include/pony/detail/atomics.h
 	$(SILENT)cp -r packages $(package)/usr/lib/pony/$(package_version)/
 	$(SILENT)build/release/ponyc packages/stdlib -rexpr -g -o $(package)/usr/lib/pony/$(package_version)
-	$(SILENT)fpm -s dir -t deb -C $(package) -p build/bin --name $(package_name) --conflicts $(package_conflicts) --version $(package_base_version) --iteration "$(package_iteration)" --description "The Pony Compiler"
-	$(SILENT)fpm -s dir -t rpm -C $(package) -p build/bin --name $(package_name) --conflicts $(package_conflicts) --version $(package_base_version) --iteration "$(package_iteration)" --description "The Pony Compiler" --provides ponyc --depends ponydep-ncurses
+	$(SILENT)fpm -s dir -t deb -C $(package) -p build/bin --name $(package_name) --conflicts "ponyc-master" --conflicts "ponyc-release" --version $(package_base_version) --iteration "$(package_iteration)" --description "The Pony Compiler" --provides "ponyc" --provides "ponyc-release"
+	$(SILENT)fpm -s dir -t rpm -C $(package) -p build/bin --name $(package_name) --conflicts "ponyc-master" --conflicts "ponyc-release" --version $(package_base_version) --iteration "$(package_iteration)" --description "The Pony Compiler" --provides "ponyc" --provides "ponyc-release" --depends "ponydep-ncurses"
 	$(SILENT)git archive HEAD > build/bin/$(archive)
 	$(SILENT)cp -r $(package)/usr/lib/pony/$(package_version)/stdlib-docs stdlib-docs
 	$(SILENT)tar rvf build/bin/$(archive) stdlib-docs

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To install release builds via DNF:
 wget https://bintray.com/pony-language/ponyc-rpm/rpm -O bintray-pony-language-ponyc-rpm.repo
 sudo mv bintray-pony-language-ponyc-rpm.repo /etc/yum.repos.d/
 
-sudo dnf --refresh install ponyc-release
+sudo dnf --refresh install ponyc
 ```
 
 Or via Yum:
@@ -82,7 +82,7 @@ Or via Yum:
 wget https://bintray.com/pony-language/ponyc-rpm/rpm -O bintray-pony-language-ponyc-rpm.repo
 sudo mv bintray-pony-language-ponyc-rpm.repo /etc/yum.repos.d/
 
-sudo yum install ponyc-release
+sudo yum install ponyc
 ```
 
 ### RPM and AVX2 Support
@@ -98,7 +98,7 @@ To install release builds via Apt:
 ```bash
 echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
-sudo apt-get install ponyc-release
+sudo apt-get install ponyc
 ```
 
 


### PR DESCRIPTION
Simplifies a bunch of finicky little things.

Note, this would also require renaming (if possible) or creating new packages on Bintray with the name "ponyc" instead of "ponyc-release".  😅 

As noted on #1713.