### PR TITLE
Add "getting started with GitHub" info to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ There are a number of ways to contribute to Pony. As this document is a little l
 
 * [Feature request](#feature-request)
 * [Bug report](#bug-report)
+* [How to contribute](#how-to-contribute)
 * [Pull request](#pull-request)
 
 Additional notes regarding formatting:
@@ -34,6 +35,34 @@ Provide the following details:
   - environment details: at least operating system and compiler version (`ponyc -v`).
 
 If possible, try to isolate the problem and provide just enough code to demonstrate it. Add any related information which might help to fix the issue.
+
+How to contribute
+-----------------
+
+We use a fairly standard GitHub pull request workflow. If you have already contributed to a project via GitHub pull request, you can skip this section and proceed to the [specific details of what we ask for in a pull request](#pull-request). If this is your first time contributing to a project via GitHub, read on.
+
+Here is the basic GitHub workflow:
+
+1. Fork the ponyc repo. you can do this via the GitHub website. This will result in you having your own copy of the ponyc repo under your GitHub account. 
+2. Clone your ponyc repo to your local machine
+3. Make a branch for your change
+4. Make your change on that branch
+5. Push your change to your repo 
+6. Use the github ui to open a PR
+
+Some things to note that aren't immediately obvious to folks just starting out:
+
+1. Your fork doesn't automatically stay up to date with change in the main repo.
+2. Any changes you make on your branch that you used for the PR will automatically appear in the PR so if you have more than 1 PR, be sure to always create different braches for them.
+3. Weird things happen with commit history if you dont create your PR branches off of master so always make sure you have the master branch checked out before creating a branch for a PR
+
+If you feel overwhelmed at any point, don't worry, it can be a lot to learn when you get started. Feel free to reach out via [IRC](https://webchat.freenode.net/?channels=%23ponylang) or the [pony developer mailing list](https://pony.groups.io/g/dev) for assistance.
+
+You can get help using GitHub via [the official documentation](https://help.github.com/). Some hightlights include:
+
+- [Fork A Repo](https://help.github.com/articles/fork-a-repo/)
+- [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/)
+- [Syncing a fork](https://help.github.com/articles/syncing-a-fork/)
 
 Pull request
 ------------


### PR DESCRIPTION
From time-to-time we have folks wanting to contribute who have never
contributed via GitHub before. The process can be very daunting. This
commit adds a basic overview of the process to our CONTRIBUTING doc.
Additionally, it links to more detailed instructions on GitHub's site as
well as giving information on how the potential contributor can reach
out to the Pony community for help contributing.

[skip ci]