### PR TITLE
Build with a newer GCC on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,78 +16,78 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=debug
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=debug
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-6
       env:
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=release
-        - CC1=gcc-5
-        - CXX1=g++-5
+        - CC1=gcc-6
+        - CXX1=g++-6
     - os: osx
       env:
         - LLVM_VERSION="3.7.1"


### PR DESCRIPTION
We noticed an error in builds like [this one](https://travis-ci.org/ponylang/ponyc/builds/212313591):
```
gcc -MMD -MP -march=x86-64 -mtune=intel -Werror -Wconversion -Wno-sign-conversion -Wextra -Wall -mcx16 -O3 -DNDEBUG -std=gnu11 -fexceptions -DPONY_VERSION=\"0.11.3-853c3e7\" -DLLVM_VERSION=\"3.9.1\" -DPONY_COMPILER=\"gcc\" -DPONY_ARCH=\"x86-64\" -DBUILD_COMPILER=\""gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4"\" -DPONY_BUILD_CONFIG=\"release\" -D_FILE_OFFSET_BITS=64  -DPONY_NO_ASSERT -c -o build/release/obj/libponyrt/platform/threads.o src/libponyrt/platform/threads.c  -I src/common/ -I src/libponyrt/
src/libponyrt/platform/threads.c:1:0: error: bad value (intel) for -mtune= switch
 #ifdef __linux__
 ^
make: *** [build/release/obj/libponyrt/platform/threads.o] Error 1
```

And @sylvanc suggested upgrading to GCC 6.