### PR TITLE
Reify type refs in inherited method bodies

### DIFF
--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -61,6 +61,29 @@ static void reify_arrow(ast_t** astp)
   ast_replace(astp, r_type);
 }
 
+static void reify_reference(ast_t** astp, ast_t* typeparam, ast_t* typearg)
+{
+  ast_t* ast = *astp;
+  pony_assert(ast_id(ast) == TK_REFERENCE);
+
+  const char* name = ast_name(ast_child(ast));
+
+  sym_status_t status;
+  ast_t* ref_def = ast_get(ast, name, &status);
+
+  if(ref_def == NULL)
+    return;
+
+  ast_t* param_def = (ast_t*)ast_data(typeparam);
+  pony_assert(param_def != NULL);
+
+  if(ref_def != param_def)
+    return;
+
+  ast_setid(ast, TK_TYPEREF);
+  ast_settype(ast, typearg);
+}
+
 static void reify_one(ast_t** astp, ast_t* typeparam, ast_t* typearg)
 {
   ast_t* ast = *astp;
@@ -85,6 +108,10 @@ static void reify_one(ast_t** astp, ast_t* typeparam, ast_t* typearg)
 
     case TK_ARROW:
       reify_arrow(astp);
+      break;
+
+    case TK_REFERENCE:
+      reify_reference(astp, typeparam, typearg);
       break;
 
     default: {}

--- a/test/libponyc/traits.cc
+++ b/test/libponyc/traits.cc
@@ -668,3 +668,40 @@ TEST_F(TraitsTest, LetInFunction)
   // to belong here as fix is in traits.c.
   DO(test_compile(src, "expr"));
 }
+
+
+TEST_F(TraitsTest, TypeargInFunction)
+{
+  const char* src =
+    "trait T[A]\n"
+    " fun foo(x: A): A =>\n"
+    "   consume x\n"
+
+    "class Baz is T[U32]\n"
+    " fun bar(): U32 => foo(U32(0))\n";
+
+  // Tests typearg reification in methods inherited from parameterised traits.
+  DO(test_compile(src, "expr"));
+}
+
+
+TEST_F(TraitsTest, TypeargInFunction2)
+{
+  const char* src =
+    "trait T1\n"
+    " new val create()\n"
+
+    "trait T2\n"
+
+    "primitive P is (T1 & T2)\n"
+
+    "trait T3[A: T1 val]\n"
+    " fun foo(): A =>\n"
+    "   A\n"
+
+    "class Baz is T3[(T2 & P)]\n"
+    " fun bar(): P => foo()\n";
+
+  // Tests typearg reification in methods inherited from parameterised traits.
+  DO(test_compile(src, "expr"));
+}


### PR DESCRIPTION
Previously, a trait that had a method body that used a typearg as
a class to call a constructor on would fail when the method body
was inherited, as the TK_REFERENCE wasn't reified. Now the
TK_REFERENCE is reified as a TK_TYPEREF.