### PR TITLE
Various simplifications to the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ script:
       echo "Building packages to deploy...";
       make clean config=release;
       make verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
-      echo "If \$UPLOAD is yes (UPLOAD: $UPLOAD), packages will be deployed below.";
+      echo "If UPLOAD is yes, packages will be deployed below.";
 
       echo "Building and uploading docs...";
       git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -219,7 +219,7 @@ script:
     else
       if [[ "$TRAVIS_BRANCH" == "release" ]];
       then
-        echo "Finished already.  This matrix element is unneded in a release build.";
+        echo "Finished already.  This matrix element is unneeded in a release build.";
       else
         echo "Building and testing ponyc...";
         make CC=$CC1 CXX=$CXX1 test-ci;

--- a/.travis.yml
+++ b/.travis.yml
@@ -217,8 +217,13 @@ script:
       sed -i '' 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' mkdocs.yml;
       mkdocs gh-deploy -v --clean --remote-name gh-token;
     else
-      echo "Building and testing ponyc...";
-      make CC=$CC1 CXX=$CXX1 test-ci;
+      if [[ "$TRAVIS_BRANCH" == "release" ]];
+      then
+        echo "Finished already.  This matrix element is unneded in a release build.";
+      else
+        echo "Building and testing ponyc...";
+        make CC=$CC1 CXX=$CXX1 test-ci;
+      fi;
     fi;
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,6 @@ rvm:
   - 2.2.3
 
 install:
-  # For a master or release release build with the latest stable LLVM,
-  # prepare to deploy artifacts.
   - if [[
       "$LLVM_VERSION" == "3.9.1" &&
       "$config" == "release" &&
@@ -148,6 +146,7 @@ install:
       "$TRAVIS_BRANCH" == "release"
     ]];
     then
+      echo "This build will create packages and docs."
       export CREATE_PACKAGES=yes;
 
       sudo apt-get install -y rpm;

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ matrix:
           packages:
             - g++-6
       env:
+        - FAVORITE_CONFIG=yes
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=release
@@ -149,12 +150,7 @@ rvm:
   - 2.2.3
 
 install:
-  - if [[
-      "$LLVM_VERSION" == "3.9.1" &&
-      "$config" == "release" &&
-      "$TRAVIS_OS_NAME" == "linux" &&
-      "$TRAVIS_BRANCH" == "release"
-    ]];
+  - if [[ "$FAVORITE_CONFIG" == "yes" && "$TRAVIS_BRANCH" == "release" ]];
     then
       echo "This build will create packages and docs."
       export CREATE_PACKAGES=yes;

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,6 @@ install:
       "$LLVM_VERSION" == "3.9.1" &&
       "$config" == "release" &&
       "$TRAVIS_OS_NAME" == "linux" &&
-      "$TRAVIS_PULL_REQUEST" == "false" &&
       "$TRAVIS_BRANCH" == "release"
     ]];
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
         - config=debug
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: linux
       addons:
         apt:
@@ -36,6 +37,7 @@ matrix:
         - config=release
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: linux
       addons:
         apt:
@@ -49,6 +51,7 @@ matrix:
         - config=debug
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: linux
       addons:
         apt:
@@ -62,6 +65,7 @@ matrix:
         - config=release
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: linux
       addons:
         apt:
@@ -75,6 +79,7 @@ matrix:
         - config=debug
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: linux
       addons:
         apt:
@@ -88,6 +93,7 @@ matrix:
         - config=release
         - CC1=gcc-6
         - CXX1=g++-6
+
     - os: osx
       env:
         - LLVM_VERSION="3.7.1"
@@ -95,6 +101,7 @@ matrix:
         - config=debug
         - CC1=clang-3.7
         - CXX1=clang++-3.7
+
     - os: osx
       env:
         - LLVM_VERSION="3.7.1"
@@ -103,6 +110,7 @@ matrix:
         - lto=no
         - CC1=clang-3.7
         - CXX1=clang++-3.7
+
     - os: osx
       env:
         - LLVM_VERSION="3.8.1"
@@ -110,6 +118,7 @@ matrix:
         - config=debug
         - CC1=clang-3.8
         - CXX1=clang++-3.8
+
     - os: osx
       env:
         - LLVM_VERSION="3.8.1"
@@ -118,6 +127,7 @@ matrix:
         - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
+
     - os: osx
       env:
         - LLVM_VERSION="3.9.1"
@@ -125,6 +135,7 @@ matrix:
         - config=debug
         - CC1=clang-3.9
         - CXX1=clang++-3.9
+
     - os: osx
       env:
         - LLVM_VERSION="3.9.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,6 @@ install:
   # For a master or release release build with the latest stable LLVM,
   # prepare to deploy artifacts.
   - if [[
-      "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
       "$LLVM_VERSION" == "3.9.1" &&
       "$config" == "release" &&
       "$TRAVIS_OS_NAME" == "linux" &&
@@ -222,7 +221,6 @@ after_success:
 
   # For a release release build with the latest stable LLVM, upload docs.
   - if [[
-        "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
         "$LLVM_VERSION" == "3.9.1" &&
         "$config" == "release" &&
         "$TRAVIS_OS_NAME" == "linux" &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,27 +197,15 @@ install:
     fi;
 
 script:
-  - make CC=$CC1 CXX=$CXX1 test-ci
-
-notifications:
-  email:
-    on_success: always
-    on_failure: always
-    recipients:
-    - buildbot@lists.ponylang.org
-
-after_success:
-  # If successful, set $UPLOAD to "yes".
-  #
-  # The PACKAGE_ITERATION will be fed to the DEB and RPM systems by FPM
-  # as a suffix to the base version (DEB:debian_revision or RPM:release,
-  # used to disambiguate packages with the same version).
   - if [[ "$CREATE_PACKAGES" == "yes" ]];
     then
+      echo "Deriving the iteration number, needed for builds of the same version..."
+      PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
+
       echo "Building packages to deploy...";
       make clean config=release;
-      PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
       make verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
+      echo "If \$UPLOAD is yes (UPLOAD: $UPLOAD), packages will be deployed below.";
 
       echo "Building and uploading docs...";
       git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}";
@@ -228,11 +216,19 @@ after_success:
       cp ../.docs/extra.js docs/;
       sed -i '' 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' mkdocs.yml;
       mkdocs gh-deploy -v --clean --remote-name gh-token;
+    else
+      echo "Building and testing ponyc...";
+      make CC=$CC1 CXX=$CXX1 test-ci;
     fi;
 
-deploy:
-  # Although we build artifacts for master, only deploy them for release.
+notifications:
+  email:
+    on_success: always
+    on_failure: always
+    recipients:
+    - buildbot@lists.ponylang.org
 
+deploy:
   - provider: bintray
     user: pony-buildbot-2
     file: /home/travis/build/ponylang/ponyc/bintray_debian.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -214,20 +214,12 @@ after_success:
   # used to disambiguate packages with the same version).
   - if [[ "$CREATE_PACKAGES" == "yes" ]];
     then
+      echo "Building packages to deploy...";
       make clean config=release;
       PACKAGE_ITERATION="${PACKAGE_ITERATION}${TRAVIS_BUILD_NUMBER}.`git rev-parse --short --verify HEAD^{commit}`";
       make verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="`cat VERSION`" package_iteration="$PACKAGE_ITERATION" deploy && export UPLOAD=yes;
-    fi;
 
-  # For a release release build with the latest stable LLVM, upload docs.
-  - if [[
-        "$LLVM_VERSION" == "3.9.1" &&
-        "$config" == "release" &&
-        "$TRAVIS_OS_NAME" == "linux" &&
-        "$TRAVIS_PULL_REQUEST" == "false" &&
-        "$TRAVIS_BRANCH" == "release"
-    ]];
-    then
+      echo "Building and uploading docs...";
       git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}";
       git fetch gh-token && git fetch gh-token gh-pages:gh-pages;
       build/release/ponyc packages/stdlib --docs;

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,12 +157,7 @@ install:
 
   - if [ "${TRAVIS_OS_NAME}" = "linux" ];
     then
-      if [ "${LLVM_VERSION}" = "3.6.2" ];
-      then
-        wget "http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz";
-      else
-        wget "http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz";
-      fi;
+      wget "http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz";
       tar -xvf clang+llvm*;
       cd clang+llvm* && sudo mkdir /tmp/llvm && sudo cp -r * /tmp/llvm/;
       sudo ln -s /tmp/llvm/bin/llvm-config /usr/local/bin/${LLVM_CONFIG};
@@ -172,10 +167,10 @@ install:
       cd pcre2-10.21 && ./configure --prefix=/usr && make && sudo make install;
       cd -;
     fi;
+
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];
     then
       brew update;
-      brew install gmp; brew link --overwrite gmp;
       if [ "${LLVM_VERSION}" = "3.7.1" ];
       then
         brew install llvm37;

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,21 +141,19 @@ install:
   # For a master or release release build with the latest stable LLVM,
   # prepare to deploy artifacts.
   - if [[
-        "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
-        "$LLVM_VERSION" == "3.9.1" &&
-        "$config" == "release" &&
-        "$TRAVIS_OS_NAME" == "linux" &&
-        "$TRAVIS_PULL_REQUEST" == "false"
+      "$TRAVIS_REPO_SLUG" == "ponylang/ponyc" &&
+      "$LLVM_VERSION" == "3.9.1" &&
+      "$config" == "release" &&
+      "$TRAVIS_OS_NAME" == "linux" &&
+      "$TRAVIS_PULL_REQUEST" == "false" &&
+      "$TRAVIS_BRANCH" == "release"
     ]];
     then
-        if [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "release" ]];
-        then
-            export CREATE_PACKAGES=yes;
+      export CREATE_PACKAGES=yes;
 
-            sudo apt-get install -y rpm;
-            rvm use 2.2.3 --default;
-            gem install fpm;
-        fi;
+      sudo apt-get install -y rpm;
+      rvm use 2.2.3 --default;
+      gem install fpm;
     fi;
 
   - if [ "${TRAVIS_OS_NAME}" = "linux" ];


### PR DESCRIPTION
Amongst other things, this:
* moves the package builds (RPM, DEB, etc.) and docs into the `script` section (out of `after_success`, and
* quiets unnecessary matrix elements during a release build.

@SeanTAllen This might cause less angst.