### PR TITLE
Allocate less memory from VirtualAlloc on Windows

### DIFF
--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -16,9 +16,12 @@
 void* ponyint_virt_alloc(size_t bytes)
 {
   void* p;
+  bool ok = true;
 
 #if defined(PLATFORM_IS_WINDOWS)
   p = VirtualAlloc(NULL, bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+  if(p == NULL)
+    ok = false;
 #elif defined(PLATFORM_IS_POSIX_BASED)
 #if defined(PLATFORM_IS_LINUX)
   p = mmap(0, bytes, PROT_READ | PROT_WRITE,
@@ -30,13 +33,15 @@ void* ponyint_virt_alloc(size_t bytes)
   p = mmap(0, bytes, PROT_READ | PROT_WRITE,
     MAP_PRIVATE | MAP_ANON | MAP_ALIGNED_SUPER, -1, 0);
 #endif
-
   if(p == MAP_FAILED)
+    ok = false;
+#endif
+
+  if(!ok)
   {
     perror("out of memory: ");
     abort();
   }
-#endif
 
   return p;
 }

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -26,9 +26,13 @@
 
 /// When we mmap, pull at least this many bytes.
 #ifdef PLATFORM_IS_ILP32
-#define POOL_MMAP (16 * 1024 * 1024) // 16 MB
+#  define POOL_MMAP (16 * 1024 * 1024) // 16 MB
 #else
-#define POOL_MMAP (128 * 1024 * 1024) // 128 MB
+#  ifdef PLATFORM_IS_WINDOWS
+#    define POOL_MMAP (16 * 1024 * 1024) // 16 MB
+#  else
+#    define POOL_MMAP (128 * 1024 * 1024) // 128 MB
+#  endif
 #endif
 
 /// An item on a per-size thread-local free list.


### PR DESCRIPTION
We currently commit all memory allocated from VirtualAlloc immediately. Allocating huge blocks at once can make memory exhaustion more probable.