### PR TITLE
Rename the bintray descriptor script, ShellCheck it, and note it makes JSON not YAML [skip ci]

### DIFF
--- a/.bintray.bash
+++ b/.bintray.bash
@@ -1,12 +1,14 @@
+#! /bin/bash
+
 REPO_TYPE=$1        # e.g., rpm | debian | source
 PACKAGE_VERSION=$2  # e.g., 0.2.1-234.master.abcdefa
 PACKAGE_NAME=$3     # e.g., ponyc
 
 # TODO: cut "ponyc" out of the repo names
 BINTRAY_REPO_NAME="ponyc-$REPO_TYPE"
-OUTPUT_TARGET="bintray_${REPO_TYPE}.yml"
+OUTPUT_TARGET="bintray_${REPO_TYPE}.json"
 
-DATE=`date +%Y-%m-%d`
+DATE="$(date +%Y-%m-%d)"
 
 case "$REPO_TYPE" in
   "debian")
@@ -38,7 +40,7 @@ case "$REPO_TYPE" in
     ;;
 esac
 
-YAML="{
+JSON="{
   \"package\": {
     \"repo\": \"$BINTRAY_REPO_NAME\",
     \"name\": \"$PACKAGE_NAME\",
@@ -52,10 +54,10 @@ YAML="{
     \"gpgSign\": false
   },"
 
-YAML="$YAML$FILES}"
+JSON="$JSON$FILES}"
 
-echo "Writing YAML to file: $OUTPUT_TARGET, from within `pwd` ..."
-echo "$YAML" >> "$OUTPUT_TARGET"
+echo "Writing JSON to file: $OUTPUT_TARGET, from within $(pwd) ..."
+echo "$JSON" >> "$OUTPUT_TARGET"
 
 echo "=== WRITTEN FILE =========================="
 cat -v "$OUTPUT_TARGET"

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,7 @@ notifications:
 deploy:
   - provider: bintray
     user: pony-buildbot-2
-    file: /home/travis/build/ponylang/ponyc/bintray_debian.yml
+    file: /home/travis/build/ponylang/ponyc/bintray_debian.json
     on:
       branch: release
       condition: "$FAVORITE_CONFIG == yes"
@@ -176,7 +176,7 @@ deploy:
 
   - provider: bintray
     user: pony-buildbot-2
-    file: /home/travis/build/ponylang/ponyc/bintray_rpm.yml
+    file: /home/travis/build/ponylang/ponyc/bintray_rpm.json
     on:
       branch: release
       condition: "$FAVORITE_CONFIG == yes"
@@ -185,7 +185,7 @@ deploy:
 
   - provider: bintray
     user: pony-buildbot-2
-    file: /home/travis/build/ponylang/ponyc/bintray_source.yml
+    file: /home/travis/build/ponylang/ponyc/bintray_source.json
     on:
       branch: release
       condition: "$FAVORITE_CONFIG == yes"

--- a/Makefile
+++ b/Makefile
@@ -764,9 +764,9 @@ test-ci: all
 # FIXME: why is $(branch) empty?
 define EXPAND_DEPLOY
 deploy: test
-	$(SILENT)sh .bintray.sh debian "$(package_version)" "$(package_name)"
-	$(SILENT)sh .bintray.sh rpm    "$(package_version)" "$(package_name)"
-	$(SILENT)sh .bintray.sh source "$(package_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash debian "$(package_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash rpm    "$(package_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash source "$(package_version)" "$(package_name)"
 	@mkdir build/bin
 	@mkdir -p $(package)/usr/bin
 	@mkdir -p $(package)/usr/include/pony/detail


### PR DESCRIPTION
Note that this won't run on a master build, just release.

Conveniently: #1738 is coming...

@SeanTAllen Have I fat-fingered anything here?