### PR TITLE
Rollback the addition of 'tune=intel' to ponyc release builds

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -27,7 +27,7 @@ ponyc-build-packages(){
   PACKAGE_ITERATION="${TRAVIS_BUILD_NUMBER}.$(git rev-parse --short --verify 'HEAD^{commit}')"
 
   echo "Building ponyc packages for deployment..."
-  make verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
+  make verbose=1 arch=x86-64 config=release package_name="ponyc" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
 }
 
 ponyc-build-docs(){

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - Call finalisers for embedded fields when parent type has no finalizer. (PR #1629)
 - Fix compiling errors for 32-bit (PR #1709)
 - Improved persistent map api (RFC 36) (PR #1705)
-- Improve packaged Linux binary performance (PR #1706)
 - Fix compiler assert on arrow to typeparam in constraint. (PR #1701)
 - Segmentation fault on runtime termination.
 


### PR DESCRIPTION
The Dockerfile still specifies this, but we're seeing Travis builds fail
on this setting (see #1738) and will revisit this soon.

@SeanTAllen I'm going to merge this, then merge it over to 'release' and shift the tag manually, to avoid cutting 0.11.5, if I can.
