### PR TITLE
Reduce the escaping in Bintray descriptor files

### DIFF
--- a/.bintray.bash
+++ b/.bintray.bash
@@ -15,7 +15,7 @@ case "$REPO_TYPE" in
     FILES="\"files\":
         [
           {
-            \"includePattern\": \"\\\\/home\\\\/travis\\\\/build\\\\/ponylang\\\\/ponyc\\\\/build\\\\/bin\\\\/(.*\\\\.deb)\", \"uploadPattern\": \"\$1\",
+            \"includePattern\": \"/home/travis/build/ponylang/ponyc/build/bin/(.*.deb)\", \"uploadPattern\": \"\$1\",
             \"matrixParams\": {
             \"deb_distribution\": \"pony-language\",
             \"deb_component\": \"main\",
@@ -27,14 +27,14 @@ case "$REPO_TYPE" in
   "rpm")
     FILES="\"files\":
       [
-        {\"includePattern\": \"\\\\/home\\\\/travis\\\\/build\\\\/ponylang\\\\/ponyc\\\\/build\\\\/bin\\\\/(.*\\\\.rpm)\", \"uploadPattern\": \"\$1\"}
+        {\"includePattern\": \"/home/travis/build/ponylang/ponyc/build/bin/(.*.rpm)\", \"uploadPattern\": \"\$1\"}
       ],
     \"publish\": true" 
     ;;
   "source")
     FILES="\"files\":
       [
-        {\"includePattern\": \"\\\\/home\\\\/travis\\\\/build\\\\/ponylang\\\\/ponyc\\\\/build\\\\/bin\\\\/(.*\\\\.tar.bz2)\", \"uploadPattern\": \"\$1\"}
+        {\"includePattern\": \"/home/travis/build/ponylang/ponyc/build/bin/(.*.tar.bz2)\", \"uploadPattern\": \"\$1\"}
       ],
     \"publish\": true"
     ;;


### PR DESCRIPTION
In the 0.11.4 release effort I've noticed that:
> Travis build has a Travis->Bintray deployment regex problem resulting in a message: `[Bintray Upload] Warning: Path: \/home\/travis\/build\/ponylang\/ponyc\/build\/bin\/ does not exist.` which causes nothing to be deployed (just like I've fixed [elsewhere](https://github.com/ponylang/ponyc/issues/1732#issuecomment-288615392), but which I don't understand how it could be introduced when the pattern in bintray.[ba]sh [hasn't changed](https://github.com/ponylang/ponyc/compare/917610c48c82e5138153bba30c470def5a550601...eaf9a8676f7f584ec5823ff3b512cc9d7fd87695#diff-8611111525017e2f47651e71edc92e9a)),

The biggest change related to this is not the .YML to .JSON rename, but converting the script from .SH to .BASH: https://github.com/ponylang/ponyc/compare/917610c48c82e5138153bba30c470def5a550601...eaf9a8676f7f584ec5823ff3b512cc9d7fd87695#diff-8611111525017e2f47651e71edc92e9a

I'd not expect this, but what you can see in comparing the logs from 0.11.3 to 0.11.4(b), however, is that this includePattern "regex" (note: not necessarily a regex), has changed as written to file.

See the 0.11.3 release [here](https://s3.amazonaws.com/archive.travis-ci.org/jobs/211856226/log.txt):
```
Writing YAML to file: bintray_rpm.yml, from within /home/travis/build/ponylang/ponyc ...
=== WRITTEN FILE ==========================
{
  "package": {
    "repo": "ponyc-rpm",
    "name": "ponyc-release",
    "subject": "pony-language"
  },
  "version": {
    "name": "0.11.3-2912.917610c",
    "desc": "ponyc release 0.11.3-2912.917610c",
    "released": "2017-03-16",
    "vcs_tag": "0.11.3-2912.917610c",
    "gpgSign": false
  },"files":
      [
        {"includePattern": "\/home\/travis\/build\/ponylang\/ponyc\/build\/bin\/(.*\.rpm)", "uploadPattern": "$1"}
      ],
    "publish": true}
===========================================
```
and the 0.11.4(b) build [here](https://s3.amazonaws.com/archive.travis-ci.org/jobs/214479063/log.txt):
```
Writing JSON to file: bintray_rpm.json, from within /home/travis/build/ponylang/ponyc ...
=== WRITTEN FILE ==========================
{
  "package": {
    "repo": "ponyc-rpm",
    "name": "ponyc",
    "subject": "pony-language"
  },
  "version": {
    "name": "0.11.4-3029.5618e86",
    "desc": "ponyc release 0.11.4-3029.5618e86",
    "released": "2017-03-24",
    "vcs_tag": "0.11.4-3029.5618e86",
    "gpgSign": false
  },"files":
      [
        {"includePattern": "\\/home\\/travis\\/build\\/ponylang\\/ponyc\\/build\\/bin\\/(.*\\.rpm)", "uploadPattern": "$1"}
      ],
    "publish": true}
===========================================
```

The fix I found on another project of mine is to just stop escaping those slashes!

I'm testing this commit using another branch ([here](https://github.com/ponylang/ponyc/compare/master...killerswan:escaping)) on my own Travis ([here](https://travis-ci.org/killerswan/ponyc/builds/214493649)) and Bintray (RPM [here](https://bintray.com/killerswan/ponyc-rpm/ponyc)).  Don't merge unless that succeeds and is deploying the RPM.