### PR TITLE
Optimise type IDs assignment

### DIFF
--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -466,6 +466,9 @@ void gendesc_table(compile_t* c)
 
   while((t = reach_types_next(&c->reach->types, &i)) != NULL)
   {
+    if(t->is_trait || (t->underlying == TK_STRUCT))
+      continue;
+
     LLVMValueRef desc;
 
     if(t->desc != NULL)

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -443,6 +443,10 @@ LLVMValueRef gen_numeric_size_table(compile_t* c)
   {
     t = reach_types_next(&c->reach->types, &i);
     pony_assert(t != NULL);
+
+    if(t->is_trait || (t->underlying == TK_STRUCT))
+      continue;
+
     uint32_t type_id = t->type_id;
     if((type_id % 4) == 0)
     {

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -98,6 +98,7 @@ struct reach_type_t
   size_t abi_size;
   uint32_t vtable_size;
   bool can_be_boxed;
+  bool is_trait;
 
   LLVMTypeRef structure;
   LLVMTypeRef structure_ptr;
@@ -131,6 +132,7 @@ typedef struct
   uint32_t numeric_type_count;
   uint32_t tuple_type_count;
   uint32_t total_type_count;
+  uint32_t trait_type_count;
 } reach_t;
 
 /// Allocate a new set of reachable types.


### PR DESCRIPTION
- Don't assign type IDs to structs
- Use a distinct numbering for traits and concrete types

The main goal of this change is to reduce the size of the type descriptor table used for serialisation: type IDs for serialisable types are less sparse, which results in less "holes" in the table.