### PR TITLE
Use a constant-time algorithm for trait subtyping tests

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -167,6 +167,8 @@ typedef struct compile_t
   const char* str__serialise;
   const char* str__deserialise;
 
+  uint32_t trait_bitmap_size;
+
   LLVMCallConv callconv;
   LLVMLinkage linkage;
   LLVMContextRef context;

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -118,7 +118,7 @@ const char* genname_alloc(const char* type)
   return stringtab_two(type, "Alloc");
 }
 
-const char* genname_traitlist(const char* type)
+const char* genname_traitmap(const char* type)
 {
   return stringtab_two(type, "Traits");
 }

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -12,7 +12,7 @@ const char* genname_type_and_cap(ast_t* ast);
 
 const char* genname_alloc(const char* type);
 
-const char* genname_traitlist(const char* type);
+const char* genname_traitmap(const char* type);
 
 const char* genname_fieldlist(const char* type);
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -737,6 +737,11 @@ bool gentypes(compile_t* c)
   reach_type_t* t;
   size_t i;
 
+  if(target_is_ilp32(c->opt->triple))
+    c->trait_bitmap_size = ((c->reach->trait_type_count + 31) & ~31) >> 5;
+  else
+    c->trait_bitmap_size = ((c->reach->trait_type_count + 63) & ~63) >> 6;
+
   c->tbaa_root = make_tbaa_root(c->context);
   c->tbaa_descriptor = make_tbaa_descriptor(c->context, c->tbaa_root);
   c->tbaa_descptr = make_tbaa_descptr(c->context, c->tbaa_root);

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -274,6 +274,9 @@ static void find_names_types_use(painter_t* painter, reach_types_t* types)
 
   while((t = reach_types_next(types, &i)) != NULL)
   {
+    if(t->bare_method != NULL)
+      continue;
+
     pony_assert(typemap_index < painter->typemap_size);
     size_t j = HASHMAP_BEGIN;
     reach_method_name_t* n;
@@ -352,7 +355,7 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
   // Iterate over all types
   while((t = reach_types_next(types, &i)) != NULL)
   {
-    if(reach_method_names_size(&t->methods) == 0)
+    if((reach_method_names_size(&t->methods) == 0) || (t->bare_method != NULL))
       continue;
 
     size_t j = HASHMAP_BEGIN;

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -850,7 +850,6 @@ static pony_type_t cycle_type =
   sizeof(detector_t),
   0,
   0,
-  0,
   NULL,
   NULL,
   NULL,

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -114,7 +114,6 @@ typedef const struct _pony_type_t
 {
   uint32_t id;
   uint32_t size;
-  uint32_t trait_count;
   uint32_t field_count;
   uint32_t field_offset;
   void* instance;
@@ -127,7 +126,7 @@ typedef const struct _pony_type_t
   pony_dispatch_fn dispatch;
   pony_final_fn final;
   uint32_t event_notify;
-  uint32_t** traits;
+  uintptr_t** traits;
   void* fields;
   void* vtable;
 } pony_type_t;


### PR DESCRIPTION
The previous algorithm for subtyping tests (used e.g. in pattern matching) used an array of provided types in each type descriptor. The array was iterated looking for the tested type, resulting in O(n) complexity.

The algorithm implemented in this commit uses a bitmap of provided types. A type provides a trait if the bit for that trait (determined using the trait ID) is set. This results in O(1) complexity, with no branching and a shorter code sequence.

The space complexity is now O(n) on the total number of traits instead of the number of provided traits.