### PR TITLE
Fix annotation-related compiler assertion failure (issue #1751)

### DIFF
--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -413,3 +413,16 @@ TEST_F(BadPonyTest, ArrowTypeParamInConstraint)
     "arrow types can't be used as type constraints",
     "arrow types can't be used as type constraints");
 }
+
+TEST_F(BadPonyTest, AnnotatedIfClause)
+{
+  // From issue #1751
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    if \\likely\\ U32(1) == 1 then\n"
+    "      None\n"
+    "    end\n";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
This PR fixes #1751, a compiler assertion error related to the efficient storage system for AST annotations and types, introduced in #1649.

This PR also changes the system somewhat, to rely on the token type that annotations use (`TK_BACKSLASH`), instead of using the `AST_ANNOTATED` flag.