### PR TITLE
Mark generated constants as unnamed_addr when appropriate

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -986,6 +986,8 @@ bool codegen(ast_t* program, pass_opt_t* opt)
   compile_t c;
   memset(&c, 0, sizeof(compile_t));
 
+  genned_strings_init(&c.strings, 64);
+
   if(!init_module(&c, program, opt))
     return false;
 
@@ -1006,6 +1008,8 @@ bool codegen(ast_t* program, pass_opt_t* opt)
 bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt)
 {
   memset(c, 0, sizeof(compile_t));
+
+  genned_strings_init(&c->strings, 64);
 
   if(!init_module(c, program, opt))
     return false;
@@ -1057,6 +1061,7 @@ void codegen_cleanup(compile_t* c)
   LLVMContextDispose(c->context);
   LLVMDisposeTargetMachine(c->machine);
   tbaa_metadatas_free(c->tbaa_mds);
+  genned_strings_destroy(&c->strings);
   reach_free(c->reach);
 }
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -61,6 +61,9 @@ LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module);
 
 #define GEN_NOTNEEDED (LLVMConstInt(c->ibool, 0, false))
 
+typedef struct genned_string_t genned_string_t;
+DECLARE_HASHMAP(genned_strings, genned_strings_t, genned_string_t);
+
 typedef struct compile_local_t compile_local_t;
 DECLARE_HASHMAP(compile_locals, compile_locals_t, compile_local_t);
 
@@ -90,6 +93,7 @@ typedef struct compile_t
   pass_opt_t* opt;
   reach_t* reach;
   tbaa_metadatas_t* tbaa_mds;
+  genned_strings_t strings;
   const char* filename;
 
   const char* str_builtin;

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -283,6 +283,7 @@ static LLVMValueRef make_field_list(compile_t* c, reach_type_t* t)
   LLVMSetGlobalConstant(global, true);
   LLVMSetLinkage(global, LLVMPrivateLinkage);
   LLVMSetInitializer(global, field_array);
+  LLVMSetUnnamedAddr(global, true);
 
   ponyint_pool_free_size(buf_size, list);
   return global;


### PR DESCRIPTION
`unnamed_addr` means that identical constants can be merged. This change reduces the size of optimised binaries by avoiding duplicated constants. Constants with meaningful addresses (e.g. type descriptors) still aren't marked as `unnamed_addr`.

As a side-effect of this change, different instances of the same string literal now have the same identity. `gen_string` now caches generated strings in order to have a consistent behaviour on string literal
identity between debug and release builds, since `unnamed_addr` constants aren't merged in non-optimised builds.