### PR TITLE
Ifdef out ANSITerm signal handler for SIGWINCH

### DIFF
--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -66,7 +66,9 @@ actor ANSITerm
     _notify = consume notify
     _source = source
 
-    SignalHandler(recover _TermResizeNotify(this) end, Sig.winch())
+    ifdef not windows then
+      SignalHandler(recover _TermResizeNotify(this) end, Sig.winch())
+    end
 
     _size()
 


### PR DESCRIPTION
Bugfix: SIGWINCH does not exist on Windows, so the ANSITerm library
failed to compile.  

Addresses #1764 