### PR TITLE
Add additional files to Appveyor skip list

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,13 +22,18 @@ skip_tags: true
 skip_commits:
   files:
     - .bintray.sh
+    - .gitattributes
     - .gitignore
+    - .gitmodules
     - .travis.yml
     - .travis_install.bash
     - .travis_script.bash
-
-    # top-level markdown files
-    - '*.md'
+    - Dockerfile
+    - LICENSE
+    - Makefile
+    - release.sh
+    - '**/*.md'
+    - '**/*.txt'
 
 clone_folder: C:\projects\ponyc
 


### PR DESCRIPTION
There's no reason to run an Appveyor CI run for any of
these files changing.

Note according to Appveyor folks

`**/*.md` should match ANY .md files. We should verify that
turns out to be true. I'll keep an eye out for that. Same for
`**/*.txt`

Resolves #1707