### PR TITLE
Don't ignore buffer length when printing

### DIFF
--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -512,7 +512,7 @@ PONY_API void pony_os_std_print(FILE* fp, char* buffer, size_t len)
   if(len == 0)
     return;
 
-  fprintf(fp, "%s\n", buffer);
+  fprintf(fp, "%*.*s\n", (int)len, (int)len, buffer);
 }
 
 PONY_API void pony_os_std_write(FILE* fp, char* buffer, size_t len)


### PR DESCRIPTION
As a left-over from when Pony strings where null terminated,
pony_os_std_print wasn't checking the length of the passed in
buffer and would print the entire buffer and beyond until it
hit a null terminator.

This PR fixes that issue so that we will now correctly only
print `len` elements from the buffer.