### PR TITLE
Add dispose method to HTTPSession actors

### DIFF
--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -109,6 +109,7 @@ actor _GetWork
 
         // Submit the request
         let sentreq = client(consume req, dumpMaker)
+
         // Could send body data via `sentreq`, if it was a POST
       else
         try env.out.print("Malformed URL: " + env.args(1)) end
@@ -206,9 +207,11 @@ class HttpNotify is HTTPHandler
 
   fun ref finished() =>
     """
-    This marks the end of the received body data.
+    This marks the end of the received body data.  We are done with the
+    session.
     """
     _main.finished()
+    _session.dispose()
     
   fun ref cancelled() =>
     _main.cancelled()

--- a/packages/net/http/_client_connection.pony
+++ b/packages/net/http/_client_connection.pony
@@ -186,7 +186,7 @@ actor _ClientConnection is HTTPSession
     Close the connection from the client end.
     """
     match _conn
-      | let c: TCPConnection => c.dispose()
+    | let c: TCPConnection => c.dispose()
     end
 
   be throttled() =>

--- a/packages/net/http/_client_connection.pony
+++ b/packages/net/http/_client_connection.pony
@@ -181,6 +181,14 @@ actor _ClientConnection is HTTPSession
     """
     None
 
+  be dispose() =>
+    """
+    Close the connection from the client end.
+    """
+    match _conn
+      | let c: TCPConnection => c.dispose()
+    end
+
   be throttled() =>
     """
     The connection to the server can not accept data for a while.

--- a/packages/net/http/_server_connection.pony
+++ b/packages/net/http/_server_connection.pony
@@ -77,6 +77,12 @@ actor _ServerConnection is HTTPSession
     """
     _backend.finished()
 
+  be dispose() =>
+    """
+    Close the connection from the server end.
+    """
+    _conn.dispose()
+
   be cancel(msg: Payload val) =>
     """
     Cancel the current response.  The connection has closed.

--- a/packages/net/http/http_notify.pony
+++ b/packages/net/http/http_notify.pony
@@ -45,6 +45,11 @@ interface tag HTTPSession
     submission of the HTTP message is complete.
     """
 
+  be dispose()
+    """
+    Close the connection from this end.
+    """
+
   be write(data: ByteSeq val)
     """
     Write raw byte stream to the outbound TCP connection.


### PR DESCRIPTION
This fixes a problem reported on the user mailing list, wherein the examples/htttpget program hangs at the end rather than exiting.