### PR TITLE
Fix Linux release scripts

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -25,11 +25,18 @@ ponyc-build-packages(){
   # used to disambiguate packages with the same version).
   PACKAGE_ITERATION="${TRAVIS_BUILD_NUMBER}.$(git rev-parse --short --verify 'HEAD^{commit}')"
 
+  echo "Removing any existing ponyc installs before creating for deployment..."
+  make CC="$CC1" CXX="$CXX1" clean
   echo "Building ponyc packages for deployment..."
   make CC="$CC1" CXX="$CXX1" verbose=1 arch=x86-64 tune=intel config=release package_name="ponyc" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
 }
 
 ponyc-build-docs(){
+  echo "Removing any existing ponyc installs before creating for doc generation..."
+  make clean
+  echo "Building ponyc for doc generation..."
+  make CC="$CC1" CXX="$CXX1"
+
   echo "Checking out the gh-pages branch..."
   git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}"
   git fetch gh-token && git fetch gh-token gh-pages:gh-pages
@@ -41,7 +48,7 @@ ponyc-build-docs(){
   cd stdlib-docs
   sudo -H pip install mkdocs
   cp ../.docs/extra.js docs/
-  sed -i '' 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' mkdocs.yml
+  sed -i 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' mkdocs.yml
   mkdocs gh-deploy -v --clean --remote-name gh-token
 }
 
@@ -59,8 +66,8 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     # when FAVORITE_CONFIG stops matching part of this case, move this logic
     if [[ "$TRAVIS_BRANCH" == "release" && "$FAVORITE_CONFIG" == "yes" ]]
     then
-      ponyc-build-docs
       ponyc-build-packages
+      ponyc-build-docs
     else
       ponyc-test
     fi


### PR DESCRIPTION
the make deploy step ends up removing all created ponyc binaries,
this means if make docs comes after that, it will fail.

this commit makes each of the steps explicitly handle dependencies.

in the case of "deploy" this means running `make clean` first to
verify a clean working environment before building for deploy.

in the case of "make docs" this means building a ponyc installation
to use for creating docs from.