### PR TITLE
Fix tests being excluded or skipped unnecessarily.

### DIFF
--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -242,6 +242,7 @@ actor PonyTest
     """
     Run the given test, subject to our filters and options.
     """
+    
     if _do_nothing then
       return
     end
@@ -249,12 +250,12 @@ actor PonyTest
     var name = test.name()
 
     // Ignore any tests that satisfy our "exclude" filter
-    if name.at(_exclude, 0) then
+    if (_exclude != "") and name.at(_exclude, 0) then
       return
     end
 
     // Ignore any tests that don't satisfy our "only" filter
-    if not name.at(_only, 0) then
+    if (_only != "") and (not name.at(_only, 0)) then
       return
     end
 


### PR DESCRIPTION
A recent change to `pony_test` (51c11a3c80974847fa49931907ea76f5ef34419f) compares test names to an `_exclude` field using `name.at(_exclude, 0)`.  On Windows at least, `String.at("", 0)` always returns `true` (which is maybe a bug?), so all tests get excluded.

This PR only excludes tests if the `_exclude` field (and its related field `_only`) are non-empty.