### PR TITLE
Fix broken ponytest "only" filter

### DIFF
--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -394,8 +394,8 @@ actor PonyTest
         _exclude = arg.substring(10)
       elseif arg.compare_sub("--label=", 8) is Equal then
         _label = arg.substring(8)
-      elseif arg.compare_sub("--only=", 9) is Equal then
-        _only = arg.substring(8)
+      elseif arg.compare_sub("--only=", 7) is Equal then
+        _only = arg.substring(7)
       else
         _env.out.print("Unrecognised argument \"" + arg + "\"")
         _env.out.print("")


### PR DESCRIPTION
Wasn't recognized because string size was wrong.

Manually tested from what I am sure is the correct directory this time. I have no idea what I did to mess this up so it didnt work when testing the first time but I thought I did.