### PR TITLE
Change Array.clone to return iso^

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -420,14 +420,15 @@ class Array[A] is Seq[A]
 
     error
 
-  fun clone(): Array[this->A!]^ =>
+  fun clone(): Array[this->A!] iso^ =>
     """
     Clone the array.
     The new array contains references to the same elements that the old array
     contains, the elements themselves are not cloned.
     """
-    let out = Array[this->A!](_size)
-    _ptr._copy_to(out._ptr, _size)
+    let size' = _size
+    let out = recover Array[this->A!](size') end
+    _ptr._copy_to(out._ptr._unsafe(), size')
     out._size = _size
     out
 

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -58,6 +58,7 @@ actor Main is TestList
     test(_TestArrayInsert)
     test(_TestArrayValuesRewind)
     test(_TestArrayFind)
+    test(_TestArrayClone)
     test(_TestMath128)
     test(_TestDivMod)
     test(_TestAddc)
@@ -1261,6 +1262,39 @@ class iso _TestArrayFind is UnitTest
       predicate = {(l: _FindTestCls box, r: _FindTestCls box): Bool => l == r }
     ))
 
+class iso _TestArrayClone is UnitTest
+  """
+  Test iso cloning of arrays.
+  """
+  fun name(): String => "builtin/Array.clone"
+
+  fun apply(h: TestHelper) =>
+    // clone from ref
+    let refa: Array[String] ref = ["one"; "two"; "three"; "four"; "five"]
+    let refbval: Array[String] val = refa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], refbval)
+    let refbref: Array[String] ref = refa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], refbref)
+    let refbiso: Array[String] iso = refa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], consume refbiso)
+
+    // clone from iso
+    let isoa: Array[String] iso = recover iso ["one"; "two"; "three"; "four"; "five"] end
+    let isobval: Array[String] val = isoa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], isobval)
+    let isobref: Array[String] ref = isoa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], isobref)
+    let isobiso: Array[String] iso = isoa.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], consume isobiso)
+
+    // clone from val
+    let vala: Array[String] val = recover val ["one"; "two"; "three"; "four"; "five"] end
+    let valbval: Array[String] val = vala.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], valbval)
+    let valbref: Array[String] ref = vala.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], valbref)
+    let valbiso: Array[String] iso = vala.clone()
+    h.assert_array_eq[String](["one"; "two"; "three"; "four"; "five"], consume valbiso)
 
 class iso _TestMath128 is UnitTest
   """


### PR DESCRIPTION
The signature for Array.clone was:
```pony
fun clone(): Array[this->A!]^ =>
```
This commit changes it to:
```pony
fun clone(): Array[this->A!] iso^ =>
```

This brings Array.clone in line with the semantics of String.clone.

This is important to be able to easily make copies of local Arrays
that can be sent to other actors. That is, a given actor, Holder,
can now easily construct a copy of an Array to send:
```pony
actor Holder
  let _collected: Array[T val] iso
  ...
  be send() =>
    destination.process(_collected.clone())
```

Previously this might have been done in the following contrived way:
```pony
actor Holder
  let _collected: Array[T val] iso
  ...
  be send() =>
    destination.process(_cpy())

  fun ref _cpy(): Array[T val] val =>
    recover val
      let c: Array[T val] ref = Array[T val](0)
      let s = _collected.size()
      var i: USize = 0
      while i < s do
        try
          c.push(_collected(i))
        end
        i = i + 1
      end
      c
    end
```

This change also makes it possible to send copies when the local Array
is a ref field vs iso field.