### PR TITLE
Build libponyc and libponyrt benchmarks on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ tags
 .*.swp
 .*.swo
 *.dSYM/
+*.psess
+*.vspx
 waf-*
 waf3-*
 .lock-waf*

--- a/benchmark/libponyrt/mem/pool.cc
+++ b/benchmark/libponyrt/mem/pool.cc
@@ -53,7 +53,7 @@ BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC$);
 
 BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_multiple$_)(benchmark::State& st) {
   int num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     for(int i = 0; i < num_allocs; i++)
       p[i] = POOL_ALLOC(block_t);
@@ -91,7 +91,7 @@ BENCHMARK_REGISTER_F(PoolBench, POOL_ALLOC_FREE);
 
 BENCHMARK_DEFINE_F(PoolBench, POOL_FREE_multiple$_)(benchmark::State& st) {
   int num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     st.PauseTiming();
     for(int i = 0; i < num_allocs; i++)
@@ -107,7 +107,7 @@ BENCHMARK_REGISTER_F(PoolBench, POOL_FREE_multiple$_)->Arg(1<<10);
 
 BENCHMARK_DEFINE_F(PoolBench, POOL_ALLOC_FREE_multiple)(benchmark::State& st) {
   int num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     for(int i = 0; i < num_allocs; i++)
       p[i] = POOL_ALLOC(block_t);
@@ -133,7 +133,7 @@ BENCHMARK_REGISTER_F(PoolBench, pool_alloc_size$);
 
 BENCHMARK_DEFINE_F(PoolBench, pool_alloc_size_multiple$_)(benchmark::State& st) {
   size_t num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     for(size_t i = 0; i < num_allocs; i++)
       p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);
@@ -171,7 +171,7 @@ BENCHMARK_REGISTER_F(PoolBench, pool_alloc_free_size);
 
 BENCHMARK_DEFINE_F(PoolBench, pool_free_size_multiple$_)(benchmark::State& st) {
   int num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     st.PauseTiming();
     for(int i = 0; i < num_allocs; i++)
@@ -187,7 +187,7 @@ BENCHMARK_REGISTER_F(PoolBench, pool_free_size_multiple$_)->Arg((int)(POOL_MMAP/
 
 BENCHMARK_DEFINE_F(PoolBench, pool_alloc_free_size_multiple)(benchmark::State& st) {
   int num_allocs = st.range(0);
-  void* p[num_allocs];
+  void** p = (void**)alloca(sizeof(void *) * num_allocs);
   while (st.KeepRunning()) {
     for(int i = 0; i < num_allocs; i++)
       p[i] = ponyint_pool_alloc_size(LARGE_ALLOC);

--- a/lib/gbenchmark/src/commandlineflags.cc
+++ b/lib/gbenchmark/src/commandlineflags.cc
@@ -20,6 +20,14 @@
 #include <iostream>
 #include <limits>
 
+#ifdef max
+#undef max
+#endif
+
+#ifdef min
+#undef min
+#endif
+
 namespace benchmark {
 // Parses 'str' for a 32-bit signed integer.  If successful, writes
 // the result to *value and returns true; otherwise leaves *value

--- a/wscript
+++ b/wscript
@@ -75,7 +75,7 @@ def configure(ctx):
             'kernel32', 'user32', 'gdi32', 'winspool', 'comdlg32',
             'advapi32', 'shell32', 'ole32', 'oleaut32', 'uuid',
             'odbc32', 'odbccp32', 'vcruntime', 'ucrt', 'Ws2_32',
-            'dbghelp'
+            'dbghelp', 'Shlwapi'
         ]
 
         base_env = ctx.env
@@ -227,6 +227,15 @@ def build(ctx):
         source   = ctx.path.ant_glob('lib/gtest/*.cc'),
     )
 
+    # gbenchmark
+    ctx(
+        features = 'cxx cxxstlib seq',
+        target   = 'gbenchmark',
+        source   = ctx.path.ant_glob('lib/gbenchmark/*.cc'),
+        includes = [ 'lib/gbenchmark/include' ],
+        defines  = [ 'HAVE_STD_REGEX' ]
+    )
+
     # libponyc
     ctx(
         features  = 'c cxx cxxstlib seq',
@@ -236,6 +245,16 @@ def build(ctx):
         includes  = [ 'src/common' ] + llvmIncludes + sslIncludes
     )
 
+    # libponyc.benchmarks
+    ctx(
+        features = 'cxx cxxprogram seq',
+        target   = 'libponyc.benchmarks',
+        source   = ctx.path.ant_glob('benchmark/libponyc/**/*.cc'),
+        includes = [ 'lib/gbenchmark/include' ],
+        use      = [ 'libponyc', 'gbenchmark' ],
+        lib      = ctx.env.PONYC_EXTRA_LIBS
+    )
+
     # libponyrt
     ctx(
         features = 'c cxx cxxstlib seq',
@@ -243,6 +262,16 @@ def build(ctx):
         source   = ctx.path.ant_glob('src/libponyrt/**/*.c'),
         includes = [ 'src/common', 'src/libponyrt' ] + sslIncludes,
         defines  = [ 'PONY_NO_ASSERT' ]
+    )
+
+    # libponyrt.benchmarks
+    ctx(
+        features = 'cxx cxxprogram seq',
+        target   = 'libponyrt.benchmarks',
+        source   = ctx.path.ant_glob('benchmark/libponyrt/**/*.cc'),
+        includes = [ 'lib/gbenchmark/include', 'src/common', 'src/libponyrt' ],
+        use      = [ 'libponyrt', 'gbenchmark' ],
+        lib      = ctx.env.PONYC_EXTRA_LIBS
     )
 
     # ponyc


### PR DESCRIPTION
This PR makes the Windows build system build the `libponyc.benchmarks` and `libponyrt.benchmarks` executables.

The ignored files are Visual Studio profiler outputs.

Microsoft C++ doesn't have variable-length arrays, so I replaced a few instances of these with calls to `alloca()`.