### PR TITLE
Fix extreme CPU use in scheduler on Windows

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -305,7 +305,7 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
   DTRACE1(CPU_NANOSLEEP, ts.tv_nsec);
   nanosleep(&ts, NULL);
 #else
-  Sleep(0);
+  Sleep(yield ? 1 : 0);
 #endif
 }
 


### PR DESCRIPTION
This PR fixes #1625 (50% CPU usage for a simple timer demo) for Windows.

Inspired by the [ancient wisdom of Joe Duffy](http://joeduffyblog.com/2006/08/22/priorityinduced-starvation-why-sleep1-is-better-than-sleep0-and-the-windows-balance-set-manager/), we now yield a Pony scheduler thread by calling `Sleep(1)` instead of `Sleep(0)`.  This results in a sleep of anywhere from 1 to 16 milliseconds, depending on the global value of the system timer.

The example in #1625 now runs with minimal CPU usage on my system.  Comparing `libponyrt.benchmarks` before and after the change doesn't seem to show a significant difference.