### PR TITLE
Improve Visual Studio and Microsoft C++ Build Tools detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ $ brew install ponyc
 
 Windows users will need to install:
 
-- Visual Studio 2015 (available [here](https://www.visualstudio.com/vs/community/)) or the Visual C++ Build Tools 2015 (available [here](http://landinghub.visualstudio.com/visual-cpp-build-tools)), and
+- Visual Studio 2017 or 2015 (available [here](https://www.visualstudio.com/vs/community/)) or the Visual C++ Build Tools 2017 or 2015 (available [here](http://landinghub.visualstudio.com/visual-cpp-build-tools)), and
 - Windows 10 SDK (available [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
 
 Once you have installed the prerequisites, you can download the latest ponyc release from [bintray](https://dl.bintray.com/pony-language/ponyc-win/).
@@ -339,8 +339,8 @@ _Note: it may also be possible (as tested on build 14372.0 of Windows 10) to bui
 
 Building on Windows requires the following:
 
-- [Visual Studio 2015](https://www.visualstudio.com/downloads/) at least Update 2; make sure that a Windows 10 SDK is installed; otherwise install it from [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).
-- [Python](https://www.python.org/downloads) (3.5 or 2.7) needs to be in your PATH.
+- [Visual Studio 2017 or 2015](https://www.visualstudio.com/downloads/) (for 2015, at least Update 2); make sure that a Windows 10 SDK is installed; otherwise install it from [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).
+- [Python](https://www.python.org/downloads) (3.6 or 2.7) needs to be in your PATH.
 
 In a command prompt in the `ponyc` source directory, run the following:
 

--- a/src/common/vcvars.h
+++ b/src/common/vcvars.h
@@ -1,6 +1,7 @@
 #ifndef PLATFORM_VCVARS_H
 #define PLATFORM_VCVARS_H
 
+typedef struct compile_t compile_t;
 typedef struct errors_t errors_t;
 
 typedef struct vcvars_t
@@ -13,6 +14,6 @@ typedef struct vcvars_t
   char default_libs[MAX_PATH];
 } vcvars_t;
 
-bool vcvars_get(vcvars_t* vcvars, errors_t* errors);
+bool vcvars_get(compile_t *c, vcvars_t* vcvars, errors_t* errors);
 
 #endif

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -296,7 +296,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 #elif defined(PLATFORM_IS_WINDOWS)
   vcvars_t vcvars;
 
-  if(!vcvars_get(&vcvars, errors))
+  if(!vcvars_get(c, &vcvars, errors))
   {
     errorf(errors, NULL, "unable to link: no vcvars");
     return false;

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -142,7 +142,7 @@ static bool link_lib(compile_t* c, const char* file_o)
 
   vcvars_t vcvars;
 
-  if(!vcvars_get(&vcvars, errors))
+  if(!vcvars_get(c, &vcvars, errors))
   {
     errorf(errors, NULL, "unable to link: no vcvars");
     return false;


### PR DESCRIPTION
Previously `ponyc` would only look for a linker from the version of Visual Studio with which it was compiled, and only looked at one registry key for install information.  A recent change (44b2d56c5618142fe0fd628eeadbd5975157d62f) broke support for Visual Build Tools C++ 2015.

This change provides registry key and path configuration information for several configurations, regardless of how `ponyc` was compiled for Windows:

- Visual Studio 2017 full install
- Visual C++ Build Tools 2017
- Visual Studio 2015 full install
- Visual C++ Build Tools 2015

The change also removes support for Windows SDKs prior to version 10, as `README.md` now specifies version 10.