### PR TITLE
Build ponyc for Linux with the upstream LLVM 3.9[.1] APT distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,10 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.9
           packages:
             - g++-6
+            - llvm-3.9-dev
       env:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.9.1"
@@ -91,8 +93,10 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.9
           packages:
             - g++-6
+            - llvm-3.9-dev
       env:
         - FAVORITE_CONFIG=yes
         - LLVM_VERSION="3.9.1"

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -9,7 +9,7 @@ then
   exit 0
 fi
 
-download-llvm(){
+download_llvm(){
   echo "Downloading and installing the LLVM specified by envvars..."
 
   wget "http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz"
@@ -19,7 +19,7 @@ download-llvm(){
   popd
 }
 
-download-pcre(){
+download_pcre(){
   echo "Downloading and building PCRE2..."
 
   wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
@@ -33,18 +33,30 @@ echo "Installing ponyc build dependencies..."
 case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
   "linux:llvm-config-3.7")
-    download-llvm
-    download-pcre
+    download_llvm
+    download_pcre
   ;;
 
   "linux:llvm-config-3.8")
-    download-llvm
-    download-pcre
+    download_llvm
+    download_pcre
   ;;
 
   "linux:llvm-config-3.9")
-    download-llvm
-    download-pcre
+    download_pcre
+
+    echo "Logging LLVM binary locations (installed via APT)..."
+    echo "llvm-config-3.9: $(which llvm-config-3.9)"
+    echo "clang++-3.9: $(which clang++-3.9)"
+    echo "clang-3.9: $(which clang-3.9)"
+
+    found_version="$(llvm-config-3.9 --version)"
+    echo "LLVM version: $found_version"
+
+    if [[ "$found_version" != "$LLVM_VERSION" ]]
+    then
+      echo "WARNING: the LLVM version expected ($LLVM_VERSION) does not match that installed ($found_version)!"
+    fi
   ;;
 
   "osx:llvm-config-3.7")


### PR DESCRIPTION
LLVM's Debian/Ubuntu packaging hosted on http://apt.llvm.org is
available through Travis' APT whitelist!