### PR TITLE
Build: use AR if already defined and avoid the direct use of cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ else
   ifeq ($(UNAME_S),Linux)
     OSTYPE = linux
 
-    ifneq (,$(shell which gcc-ar 2> /dev/null))
-      AR = gcc-ar
+    ifndef AR
+      ifneq (,$(shell which gcc-ar 2> /dev/null))
+        AR = gcc-ar
+      endif
     endif
   endif
 
@@ -329,7 +331,7 @@ endif
 # (4) a list of the libraries to link against
 llvm.ldflags := $(shell $(LLVM_CONFIG) --ldflags)
 llvm.include.dir := $(shell $(LLVM_CONFIG) --includedir)
-include.paths := $(shell echo | cc -v -E - 2>&1)
+include.paths := $(shell echo | $(CC) -v -E - 2>&1)
 ifeq (,$(findstring $(llvm.include.dir),$(include.paths)))
 # LLVM include directory is not in the existing paths;
 # put it at the top of the system list


### PR DESCRIPTION
Hi !

I was packaging ponyc for the distribution I use (Exherbo, a source based distribution) when I ran into some troubles. We don't authorize our build system to use un-prefixed build tools (like `cc` or `gcc-ar`). Instead, we use a prefixed tool which makes cross-compilation easier (like `x86_64-pc-linux-gnu-cc`).

For `cc`, you already use `$(CC)` everywhere else so I guessed it was OK to use it here too.

For `AR`, our build tool also defines `AR` environment variable with the prefixed tool as its value (which is `x86_64-pc-linux-gnu-ar` for us). I'm really not sure about that fix, my logic was "don't override the AR environment variable if already defined".

Tell me if there is something wrong in there, in the meantime, I'll continue to explore pony :-)