### PR TITLE
Abort releasing if there are local-only changes to master or release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -78,6 +78,11 @@ verify_args
 # create version release branch
 git checkout master
 git pull
+if ! git diff --exit-code master origin/master
+then
+  echo "ERROR! There are local-only changes on branch 'master'!"
+  exit 1
+fi
 git checkout -b release-$version $commit
 
 # update VERSION and CHANGELOG
@@ -92,6 +97,11 @@ git commit -m "Prep for $version release
 
 # merge into release
 git checkout release
+if ! git diff --exit-code release origin/release
+then
+  echo "ERROR! There are local-only changes on branch 'release'!"
+  exit 1
+fi
 git merge release-$version -m "Release $version"
 
 # tag release


### PR DESCRIPTION
Before this change, it was possible that if you had local changes on `master` ahead of `origin/master`, those changes would be released.  For example:
```
kevin-ponyc $ git fetch origin
kevin-ponyc $ git ll --oneline -2 master
* 685d1a97 (HEAD -> master) WHOOOEEEE
* e7e5ca7d (origin/master, origin/HEAD) Add unreleased section to CHANGELOG post 0.12.4 release prep
kevin-ponyc $   
kevin-ponyc $ bash release.bash 0.12.5 685d1a97
...
kevin-ponyc $ git ll --oneline -3 master
* 2daf67fa (HEAD -> master, origin/master, origin/HEAD) Add unreleased section to CHANGELOG post 0.12.5 release prep
* b689a862 (release-0.12.5) Prep for 0.12.5 release
* 685d1a97 WHOOOEEEE
```

Now the release script should fail with an error describing the problem.