### PR TITLE
Use correct parameter order in Itertools Iter.Fold example

### DIFF
--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -284,7 +284,7 @@ class Iter[A] is Iterator[A]
 
     ```pony
     Iter[I64]([as I64: 1, 2, 3].values())
-      .fold[I64]({(x: I64, sum: I64): I64 => sum + x }, 0)
+      .fold[I64]({(sum: I64, x: I64): I64 => sum + x }, 0)
     ```
     `6`
     """


### PR DESCRIPTION
The original example is misleading in that it may lead one to assume the correct order for the lambda is `(iter_val, acc)` while the code uses `(acc, iter_val)`.

Changing the order in the code may break backwards compatibility for anyone already using this, so I think just fixing the example to use the correct order is a good option in this case.