### PR TITLE
Sleep for 1ns to avoid busy waiting on OSX

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -299,6 +299,10 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
     } else if((tsc2 - tsc) > 1000000000) {
       // If it has been 1 billion cycles, pause 1 ms.
       ts.tv_nsec = 1000000;
+    } else {
+      // Sleeping for 0 ns is a no-op on certain platforms.
+      // Sleep for at least 1 ns to avoid this.
+      ts.tv_nsec = 1;
     }
   }
 


### PR DESCRIPTION
On macOS Sierra nanosleep(0) is now a no-op, which can cause extreme
busy waiting and high CPU usage.

Fixes #1787

-------
I can't find any resources online about this change in behaviour for nanosleep, and I don't have any pre-Sierra machine to compare. On my Sierra machine nanosleep(0) takes about 1300 cycles whereas it takes 175000 on linux.