### PR TITLE
Add ld.gold to linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ $ brew update
 $ brew install ponyc
 ```
 
+## "cannot find 'ld'" error
+
+If you get an error when trying to use `ponyc` to compile pony source
+that looks like this:
+
+```bash
+collect2: fatal error: cannot find 'ld'
+```
+
+you might have to install the `ld-gold` linker. It can typically be
+found by searching your distro's package repository for `binutils-gold`
+or just `ld-gold`.
+
+
 ## Mac OS X using [Homebrew](http://brew.sh)
 
 ```bash


### PR DESCRIPTION
If a user's machine does not have `ld.gold`, then compilation with
`ponyc` can fail. This adds a section to the linux installation
instructions explaining what the error means and how to fix it.

I spoke with Sean about this in [#1812](https://github.com/ponylang/ponyc/issues/1812), but I wasn't sure whether to put this in the "Building on Linux" section or "Installing on Linux" section, because `ponyc` will actually build fine if `ld.gold` is not present, it only occurs when trying to use `ponyc` to build pony programs.