### PR TITLE
Add support for custom serialisation (RFC 21)

### DIFF
--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -189,9 +189,6 @@ class iso _TestArrays is UnitTest
 
 actor _EmptyActor
 
-class _HasPointer
-  var x: Pointer[U8] = Pointer[U8]
-
 class _HasActor
   var x: _EmptyActor = _EmptyActor
 
@@ -204,10 +201,6 @@ class iso _TestFailures is UnitTest
   fun apply(h: TestHelper) ? =>
     let ambient = h.env.root as AmbientAuth
     let serialise = SerialiseAuth(ambient)
-
-    h.assert_error({()(serialise)? =>
-      Serialised(serialise, _HasPointer)
-    })
 
     h.assert_error({()(serialise)? =>
       Serialised(serialise, _HasActor)

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -172,6 +172,9 @@ static void init_runtime(compile_t* c)
   c->str__init = stringtab("_init");
   c->str__final = stringtab("_final");
   c->str__event_notify = stringtab("_event_notify");
+  c->str__serialise_space = stringtab("_serialise_space");
+  c->str__serialise = stringtab("_serialise");
+  c->str__deserialise = stringtab("_deserialise");
 
   LLVMTypeRef type;
   LLVMTypeRef params[5];
@@ -222,6 +225,19 @@ static void init_runtime(compile_t* c)
   params[4] = c->i32;
   c->serialise_type = LLVMFunctionType(c->void_type, params, 5, false);
   c->serialise_fn = LLVMPointerType(c->serialise_type, 0);
+
+  // serialise_space
+  // i64 (__object*)
+  params[0] = c->object_ptr;
+  c->custom_serialise_space_fn = LLVMPointerType(
+    LLVMFunctionType(c->i64, params, 1, false), 0);
+
+  // custom_deserialise
+  // void (*)(__object*, void*)
+  params[0] = c->object_ptr;
+  params[1] = c->void_ptr;
+  c->custom_deserialise_fn = LLVMPointerType(
+  LLVMFunctionType(c->void_type, params, 2, false), 0);
 
   // dispatch
   // void (*)(i8*, __object*, $message*)

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -163,6 +163,9 @@ typedef struct compile_t
   const char* str__init;
   const char* str__final;
   const char* str__event_notify;
+  const char* str__serialise_space;
+  const char* str__serialise;
+  const char* str__deserialise;
 
   LLVMCallConv callconv;
   LLVMLinkage linkage;
@@ -210,6 +213,8 @@ typedef struct compile_t
   LLVMTypeRef dispatch_type;
   LLVMTypeRef dispatch_fn;
   LLVMTypeRef final_fn;
+  LLVMTypeRef custom_serialise_space_fn;
+  LLVMTypeRef custom_deserialise_fn;
 
   LLVMValueRef personality;
 

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -17,14 +17,16 @@
 #define DESC_SERIALISE_TRACE 7
 #define DESC_SERIALISE 8
 #define DESC_DESERIALISE 9
-#define DESC_DISPATCH 10
-#define DESC_FINALISE 11
-#define DESC_EVENT_NOTIFY 12
-#define DESC_TRAITS 13
-#define DESC_FIELDS 14
-#define DESC_VTABLE 15
+#define DESC_CUSTOM_SERIALISE_SPACE 10
+#define DESC_CUSTOM_DESERIALISE 11
+#define DESC_DISPATCH 12
+#define DESC_FINALISE 13
+#define DESC_EVENT_NOTIFY 14
+#define DESC_TRAITS 15
+#define DESC_FIELDS 16
+#define DESC_VTABLE 17
 
-#define DESC_LENGTH 16
+#define DESC_LENGTH 18
 
 static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
   reach_method_t* m)
@@ -344,6 +346,8 @@ void gendesc_basetype(compile_t* c, LLVMTypeRef desc_type)
   params[DESC_SERIALISE_TRACE] = c->trace_fn;
   params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
+  params[DESC_CUSTOM_SERIALISE_SPACE] = c->custom_serialise_space_fn;
+  params[DESC_CUSTOM_DESERIALISE] = c->custom_deserialise_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
   params[DESC_FINALISE] = c->final_fn;
   params[DESC_EVENT_NOTIFY] = c->i32;
@@ -393,6 +397,8 @@ void gendesc_type(compile_t* c, reach_type_t* t)
   params[DESC_SERIALISE_TRACE] = c->trace_fn;
   params[DESC_SERIALISE] = c->serialise_fn;
   params[DESC_DESERIALISE] = c->trace_fn;
+  params[DESC_CUSTOM_SERIALISE_SPACE] = c->custom_serialise_space_fn;
+  params[DESC_CUSTOM_DESERIALISE] = c->custom_deserialise_fn;
   params[DESC_DISPATCH] = c->dispatch_fn;
   params[DESC_FINALISE] = c->final_fn;
   params[DESC_EVENT_NOTIFY] = c->i32;
@@ -431,6 +437,10 @@ void gendesc_init(compile_t* c, reach_type_t* t)
     c->trace_fn);
   args[DESC_SERIALISE] = make_desc_ptr(t->serialise_fn, c->serialise_fn);
   args[DESC_DESERIALISE] = make_desc_ptr(t->deserialise_fn, c->trace_fn);
+  args[DESC_CUSTOM_SERIALISE_SPACE] =
+    make_desc_ptr(t->custom_serialise_space_fn, c->custom_serialise_space_fn);
+  args[DESC_CUSTOM_DESERIALISE] =
+    make_desc_ptr(t->custom_deserialise_fn, c->custom_deserialise_fn);
   args[DESC_DISPATCH] = make_desc_ptr(t->dispatch_fn, c->dispatch_fn);
   args[DESC_FINALISE] = make_desc_ptr(t->final_fn, c->final_fn);
   args[DESC_EVENT_NOTIFY] = LLVMConstInt(c->i32, event_notify_index, false);

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -254,6 +254,19 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     t->final_fn = m->func;
     LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
     LLVMSetLinkage(m->func, LLVMExternalLinkage);
+  } else if(n->name == c->str__serialise_space)
+  {
+    t->custom_serialise_space_fn = m->func;
+    LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
+    LLVMSetLinkage(m->func, LLVMExternalLinkage);
+  } else if(n->name == c->str__serialise)
+  {
+    t->custom_serialise_fn = m->func;
+  } else if(n->name == c->str__deserialise)
+  {
+    t->custom_deserialise_fn = m->func;
+    LLVMSetFunctionCallConv(m->func, LLVMCCallConv);
+    LLVMSetLinkage(m->func, LLVMExternalLinkage);
   }
 
   if((n->cap == TK_AT) && (m->func != NULL))

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -12,6 +12,7 @@
 #include "expr.h"
 #include "verify.h"
 #include "finalisers.h"
+#include "serialisers.h"
 #include "docgen.h"
 #include "../codegen/codegen.h"
 #include "../../libponyrt/mem/pool.h"
@@ -242,6 +243,9 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
     return true;
 
   if(!pass_finalisers(*astp, options))
+    return false;
+
+  if (!pass_serialisers(*astp, options))
     return false;
 
   if(options->check_tree)

--- a/src/libponyc/pass/serialisers.c
+++ b/src/libponyc/pass/serialisers.c
@@ -1,0 +1,93 @@
+#include "serialisers.h"
+#include "../type/lookup.h"
+#include "../type/subtype.h"
+#include "../type/reify.h"
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+static bool entity_serialiser(pass_opt_t* opt, ast_t* entity,
+                              const char* serialise_space, const char* serialise, const char* deserialise)
+{
+  ast_t* ast_serialise_space = ast_get(entity, serialise_space, NULL);
+  ast_t* ast_serialise = ast_get(entity, serialise, NULL);
+  ast_t* ast_deserialise = ast_get(entity, deserialise, NULL);
+
+  if(ast_serialise_space == NULL && ast_serialise == NULL &&
+    ast_deserialise == NULL)
+    return true;
+
+  if(ast_serialise_space == NULL || ast_serialise == NULL ||
+    ast_deserialise == NULL)
+  {
+    ast_error(opt->check.errors, entity,
+      "If a custom serialisation strategy exists then _serialise_space, "
+      "_serialise and _deserialise must all be provided");
+    return false;
+  }
+
+  return true;
+}
+
+static bool module_serialisers(pass_opt_t* opt, ast_t* module,
+  const char* serialise_space, const char* serialise, const char* deserialise)
+{
+  ast_t* entity = ast_child(module);
+  bool ok = true;
+
+  while(entity != NULL)
+  {
+    switch(ast_id(entity))
+    {
+    case TK_CLASS:
+      if(!entity_serialiser(opt, entity, serialise_space, serialise,
+        deserialise))
+        ok = false;
+      break;
+
+    default: {}
+    }
+
+    entity = ast_sibling(entity);
+  }
+
+  return ok;
+}
+
+static bool package_serialisers(pass_opt_t* opt, ast_t* package,
+  const char* serialise_space, const char* serialise, const char* deserialise)
+{
+  ast_t* module = ast_child(package);
+  bool ok = true;
+
+  while(module != NULL)
+  {
+    if(!module_serialisers(opt, module, serialise_space, serialise,
+      deserialise))
+      ok = false;
+
+    module = ast_sibling(module);
+  }
+
+  return ok;
+}
+
+bool pass_serialisers(ast_t* program, pass_opt_t* options)
+{
+  ast_t* package = ast_child(program);
+  const char* serialise_space = stringtab("_serialise_space");
+  const char* serialise = stringtab("_serialise");
+  const char* deserialise = stringtab("_deserialise");
+  bool ok = true;
+
+  while(package != NULL)
+  {
+    if(!package_serialisers(options, package, serialise_space, serialise,
+      deserialise))
+      ok = false;
+
+    package = ast_sibling(package);
+  }
+
+  return ok;
+}

--- a/src/libponyc/pass/serialisers.h
+++ b/src/libponyc/pass/serialisers.h
@@ -1,0 +1,14 @@
+#ifndef PASS_SERIALISERS_H
+#define PASS_SERIALISERS_H
+
+#include <platform.h>
+#include "../ast/ast.h"
+#include "../pass/pass.h"
+
+PONY_EXTERN_C_BEGIN
+
+bool pass_serialisers(ast_t* program, pass_opt_t* options);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -795,6 +795,9 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
     case TK_CLASS:
       add_traits_to_type(r, t, opt);
       add_special(r, t, type, "_final", opt);
+      add_special(r, t, type, "_serialise_space", opt);
+      add_special(r, t, type, "_serialise", opt);
+      add_special(r, t, type, "_deserialise", opt);
       add_fields(r, t, opt);
       break;
 

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -114,6 +114,9 @@ struct reach_type_t
   LLVMValueRef serialise_trace_fn;
   LLVMValueRef serialise_fn;
   LLVMValueRef deserialise_fn;
+  LLVMValueRef custom_serialise_space_fn;
+  LLVMValueRef custom_serialise_fn;
+  LLVMValueRef custom_deserialise_fn;
   LLVMValueRef final_fn;
   LLVMValueRef dispatch_fn;
   LLVMValueRef dispatch_switch;

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -856,6 +856,8 @@ static pony_type_t cycle_type =
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
   cycle_dispatch,
   NULL,
   0,

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -78,6 +78,22 @@ typedef void (*pony_trace_fn)(pony_ctx_t* ctx, void* p);
 typedef void (*pony_serialise_fn)(pony_ctx_t* ctx, void* p, void* addr,
   size_t offset, int m);
 
+/** Serialise Space function.
+ *
+ * Each class may supply a group of custom serialisation function. This
+ * function returns the amount of extra space that the object needs for
+ * custom serialisation.
+ */
+typedef size_t (*pony_custom_serialise_space_fn)(void* p);
+
+/** Custom Deserialise function.
+ *
+ * Each class may supply a group of custom serialisation function. This
+ * function takes a pointer to a byte array and does whatever user-defined
+ * deserialization.
+ */
+typedef size_t (*pony_custom_deserialise_fn)(void* p, void *addr);
+
 /** Dispatch function.
  *
  * Each actor has a dispatch function that is invoked when the actor handles
@@ -106,6 +122,8 @@ typedef const struct _pony_type_t
   pony_trace_fn serialise_trace;
   pony_serialise_fn serialise;
   pony_trace_fn deserialise;
+  pony_custom_serialise_space_fn custom_serialise_space;
+  pony_custom_deserialise_fn custom_deserialise;
   pony_dispatch_fn dispatch;
   pony_final_fn final;
   uint32_t event_notify;

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -14,7 +14,8 @@
 
 
 class CodegenTest : public PassTest
-{};
+{
+};
 
 
 TEST_F(CodegenTest, PackedStructIsPacked)
@@ -154,7 +155,6 @@ TEST_F(CodegenTest, CCallback)
   ASSERT_EQ(exit_code, 6);
 }
 
-
 TEST_F(CodegenTest, MatchExhaustiveAllCasesOfUnion)
 {
   const char* src =
@@ -200,7 +200,6 @@ TEST_F(CodegenTest, MatchExhaustiveAllCasesIncludingDontCareAndTuple)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    @pony_exitcode[None](Foo((C3, true)))";
-
   TEST_COMPILE(src);
 
   int exit_code = 0;
@@ -233,4 +232,86 @@ TEST_F(CodegenTest, MatchExhaustiveAllCasesPrimitiveValues)
   int exit_code = 0;
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 3);
+}
+
+TEST_F(CodegenTest, CustomSerialization)
+{
+  const char* src =
+    "use \"serialise\"\n"
+
+    "class _Custom\n"
+    "  let s1: String = \"abc\"\n"
+    "  var p: Pointer[U8]\n"
+    "  let s2: String = \"efg\"\n"
+
+    "  new create() =>\n"
+    "    p = @test_custom_serialisation_get_object[Pointer[U8] ref]()\n"
+
+    "  fun _serialise_space(): USize =>\n"
+    "    8\n"
+
+    "  fun _serialise(bytes: Pointer[U8]) =>\n"
+    "    @test_custom_serialisation_serialise[None](p, bytes)\n"
+
+    "  fun ref _deserialise(bytes: Pointer[U8]) =>\n"
+    "    p = @test_custom_serialisation_deserialise[Pointer[U8] ref](bytes)\n"
+
+    "  fun eq(c: _Custom): Bool =>\n"
+    "    (@test_custom_serialisation_compare[U8](this.p, c.p) == 1) and\n"
+    "    (this.s1 == c.s1)\n"
+    "      and (this.s2 == c.s2)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      let ambient = env.root as AmbientAuth\n"
+    "      let serialise = SerialiseAuth(ambient)\n"
+    "      let deserialise = DeserialiseAuth(ambient)\n"
+
+    "      let x: _Custom = _Custom\n"
+    "      let sx = Serialised(serialise, x)\n"
+    "      let yd: Any ref = sx(deserialise)\n"
+    "      let y = yd as _Custom\n"
+    "      let r: I32 = if (x isnt y) and (x == y) then\n"
+    "        1\n"
+    "      else\n"
+    "        0\n"
+    "      end\n"
+    "      @pony_exitcode[None](r)\n"
+    "    end"
+    ;
+
+  set_builtin(NULL);
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+extern "C"
+{
+
+EXPORT_SYMBOL void *test_custom_serialisation_get_object() {
+  uint64_t *i = (uint64_t *) malloc(sizeof(uint64_t));
+  *i = 0xDEADBEEF10ADBEE5;
+  return i;
+}
+
+EXPORT_SYMBOL void test_custom_serialisation_serialise(uint64_t *p, unsigned char *bytes) {
+  *(uint64_t *)(bytes) = *p;
+}
+
+EXPORT_SYMBOL void *test_custom_serialisation_deserialise(unsigned char *bytes) {
+  uint64_t *p = (uint64_t *) malloc(sizeof(uint64_t));
+  *p = *(uint64_t *)(bytes);
+  return p;
+}
+
+EXPORT_SYMBOL char test_custom_serialisation_compare(uint64_t *p1, uint64_t *p2) {
+  return *p1 == *p2;
+}
+
 }


### PR DESCRIPTION
This commit adds support for custom serialisation. Custom
serialisation lets the user provide methods that are called by Pony's
serialisation and deserialisation system in order to add additional
information that otherwise would not be serialized. The primary goal
of this system is to provide a means of serialising data stored in
`Pointer` member variables.