### PR TITLE
Add changelog tool to release process and CI

### DIFF
--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -22,7 +22,7 @@ download_llvm(){
 download_pcre(){
   echo "Downloading and building PCRE2..."
 
-  wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
+  wget "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2"
   tar -xjvf pcre2-10.21.tar.bz2
   pushd pcre2-10.21 && ./configure --prefix=/usr && make && sudo make install
   popd

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -14,6 +14,23 @@ ponyc-test(){
   make CC="$CC1" CXX="$CXX1" test-ci
 }
 
+verify-changelog(){
+  echo "Building changelog tool..."
+  make CC="$CC1" CXX="$CXX1" && sudo make install
+
+  pushd /tmp
+
+  git clone "https://github.com/jemc/pony-stable"
+  cd pony-stable && make && sudo make install && cd -
+
+  git clone "https://github.com/ponylang/changelog-tool"
+  cd changelog-tool && git checkout tags/0.1.2 && make && sudo make install && cd -
+
+  popd
+
+  changelog-tool verify CHANGELOG.md
+}
+
 ponyc-build-packages(){
   echo "Installing ruby, rpm, and fpm..."
   rvm use 2.2.3 --default
@@ -63,6 +80,7 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
       ponyc-build-docs
     else
       ponyc-test
+      verify-changelog
     fi
   ;;
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,6 +7,7 @@ This document is aimed at members of the Pony team who might be cutting a releas
 In order to do a release, you absolutely must have:
 
 * Commit access to the `ponyc` repo
+* The latest release of the [changelog tool](https://github.com/ponylang/changelog-tool/releases) installed
 
 While not strictly required, you life will be made much easier if you:
 

--- a/release.bash
+++ b/release.bash
@@ -3,13 +3,6 @@
 set -o errexit
 set -o nounset
 
-case $OSTYPE in
-darwin*) SED=gsed;;
-*) SED=sed;;
-esac
-
-release_date="$(date +%Y-%m-%d)"
-
 verify_args() {
   echo "Cutting a release for version $version with commit $commit"
   while true; do
@@ -25,40 +18,6 @@ verify_args() {
 update_version() {
   echo "$version" > VERSION
   echo "VERSION set to $version"
-}
-
-update_changelog() {
-  # cut out empty "Fixed", "Added", or "Changed" sections
-  remove_empty_sections
-
-  local match="## \[unreleased\] \- unreleased"
-  local heading="## [$version] - $release_date"
-  $SED -i "/$match/c $heading" CHANGELOG.md
-}
-
-remove_empty_sections() {
-  local unreleased_section
-  unreleased_section="$($SED -n "/## \[unreleased\] - unreleased/,/## \[/p" < CHANGELOG.md)"
-  if [[ "$unreleased_section" != "" ]]; then
-    for section in "Fixed" "Added" "Changed"; do
-      local section_text
-      local first
-      section_text="$(echo "$unreleased_section" | $SED -n "/### $section/{:a;n;/##/b;p;ba}")"
-      first="$(echo "$section_text" | $SED "/^\s*$/d" | cut -c 1)"
-      if [[ "$first" == "" ]]; then
-        echo "Removing empty CHANGELOG section: $section"
-        local line_num
-        line_num="$(grep -n -m1 "$section" CHANGELOG.md | cut -d : -f 1)"
-        $SED -i "$line_num{N;N;d}" CHANGELOG.md
-      fi
-    done
-  fi
-}
-
-add_changelog_unreleased_section() {
-  echo "Adding unreleased section to CHANGELOG"
-  local replace='## [unreleased] - unreleased\n\n### Fixed\n\n\n### Added\n\n\n### Changed\n\n\n'
-  $SED -i "/## \[$version\] \- $release_date/i $replace" CHANGELOG.md
 }
 
 check_for_commit_and_push() {
@@ -95,7 +54,7 @@ git checkout -b "release-$version" "$commit"
 
 # update VERSION and CHANGELOG
 update_version
-update_changelog
+changelog-tool release CHANGELOG.md "$version" -e
 
 # commit VERSION and CHANGELOG updates
 git add CHANGELOG.md VERSION
@@ -122,7 +81,6 @@ git push origin "$version"
 # update CHANGELOG for new entries
 git checkout master
 git merge "release-$version"
-add_changelog_unreleased_section
 
 # check if user wants to continue
 check_for_commit_and_push


### PR DESCRIPTION
This PR uses the new changelog tool to modify the changelog and check that it is valid every time CI is run on travis.