### PR TITLE
Alpine Linux compatibility for pony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ else
         AR = gcc-ar
       endif
     endif
+
+    ALPINE=$(wildcard /etc/alpine-release)
   endif
 
   ifeq ($(UNAME_S),Darwin)
@@ -396,8 +398,13 @@ endif
 
 # target specific build options
 libponyrt.buildoptions = -DPONY_NO_ASSERT
+libponyrt-pic.buildoptions = -DPONY_NO_ASSERT
 
 libponyrt.tests.linkoptions += -rdynamic
+
+ifneq ($(ALPINE),)
+  libponyrt.tests.linkoptions += -lexecinfo
+endif
 
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
@@ -410,15 +417,28 @@ libponyc.tests.buildoptions += -DPONY_PACKAGES_DIR=\"$(packages_abs_src)\"
 
 libponyc.tests.linkoptions += -rdynamic
 
+ifneq ($(ALPINE),)
+  libponyc.tests.linkoptions += -lexecinfo
+endif
+
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
 
 libgbenchmark.buildoptions := -DHAVE_POSIX_REGEX
 
+ifneq ($(ALPINE),)
+  libponyc.benchmarks.linkoptions += -lexecinfo
+  libponyrt.benchmarks.linkoptions += -lexecinfo
+endif
+
 ponyc.buildoptions = $(libponyc.buildoptions)
 
 ponyc.linkoptions += -rdynamic
+
+ifneq ($(ALPINE),)
+  ponyc.linkoptions += -lexecinfo
+endif
 
 ifeq ($(OSTYPE), linux)
   libponyrt-pic.buildoptions += -fpic

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -1,6 +1,12 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -36,7 +36,7 @@ using std::atomic_thread_fence;
 #  endif
 #elif defined(__GNUC__) && !defined(__clang__)
 #  include <features.h>
-#  if __GNUC_PREREQ(4, 9)
+#  if ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((4) << 16) + (9))
 #    ifdef __cplusplus
 //     g++ doesn't like C11 atomics. We never need atomic ops in C++ files so
 //     we only define the atomic types.
@@ -50,7 +50,7 @@ using std::atomic_thread_fence;
 #      define PONY_ATOMIC(T) T _Atomic
 #      define PONY_ATOMIC_RVALUE(T) T _Atomic
 #    endif
-#  elif __GNUC_PREREQ(4, 7)
+#  elif ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((4) << 16) + (7))
 #    define PONY_ATOMIC(T) alignas(sizeof(T)) T
 #    define PONY_ATOMIC_RVALUE(T) T
 #    define PONY_ATOMIC_BUILTINS

--- a/src/common/ponyassert.h
+++ b/src/common/ponyassert.h
@@ -2,11 +2,12 @@
 #define PLATFORM_PONYASSERT_H
 
 #include "platform.h"
+#include <assert.h>
 
 PONY_EXTERN_C_BEGIN
 
-#if defined(NDEBUG) && defined(PONY_NO_ASSERT)
-#  define pony_assert(expr) ((void)0)
+#if defined(PONY_NO_ASSERT)
+#  define pony_assert(expr) assert(expr)
 #else
 #  define pony_assert(expr) \
     ((expr) ? (void)0 : \

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -261,6 +261,7 @@ static bool link_exe(compile_t* c, ast_t* program,
       "Warning: environment variable $CC undefined, using %s as the linker\n",
       PONY_COMPILER);
   }
+
   const char* mcx16_arg = target_is_ilp32(c->opt->triple) ? "" : "-mcx16";
   const char* fuseld = target_is_linux(c->opt->triple) ? "-fuse-ld=gold" : "";
   const char* ldl = target_is_linux(c->opt->triple) ? "-ldl" : "";

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -33,6 +33,11 @@ asio_backend_t* ponyint_asio_get_backend()
   return running_base.backend;
 }
 
+uint32_t ponyint_asio_get_cpu()
+{
+  return asio_cpu;
+}
+
 void ponyint_asio_init(uint32_t cpu)
 {
   asio_cpu = cpu;

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -68,6 +68,11 @@ bool ponyint_asio_start();
  */
 asio_backend_t* ponyint_asio_get_backend();
 
+/** Returns the cpu assigned for the ASIO thread.
+ *
+ */
+uint32_t ponyint_asio_get_cpu();
+
 /** Attempts to stop an asynchronous event mechanism.
  *
  * Stopping an event mechanism is only possible if there are no pending "noisy"

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -6,6 +6,7 @@
 
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
+#include "../sched/cpu.h"
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/timerfd.h>
@@ -163,6 +164,7 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
 
 DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 {
+  ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = arg;
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -7,6 +7,7 @@
 
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
+#include "../sched/cpu.h"
 #include <string.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -101,6 +102,7 @@ void ponyint_asio_backend_final(asio_backend_t* b)
 
 DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 {
+  ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = (asio_backend_t*)arg;
   asio_event_t* stdin_event = NULL;

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -4,6 +4,7 @@
 
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
+#include "../sched/cpu.h"
 #include "ponyassert.h"
 #include <sys/event.h>
 #include <string.h>
@@ -120,6 +121,7 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
 
 DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 {
+  ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = arg;
   struct kevent fired[MAX_EVENTS];

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -176,8 +176,6 @@ bool ponyint_thread_create(pony_thread_id_t* thread, thread_fn start,
     CPU_ZERO(&set);
     CPU_SET(cpu, &set);
 
-    pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &set);
-
     if(use_numa)
     {
       struct rlimit limit;

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -256,7 +256,11 @@ void ponyint_cpu_affinity(uint32_t cpu)
     return;
 
 #if defined(PLATFORM_IS_LINUX)
-  // Affinity is handled when spawning the thread.
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+
+    sched_setaffinity(0, sizeof(cpu_set_t), &set);
 #elif defined(PLATFORM_IS_FREEBSD)
   // No pinning, since we cannot yet determine hyperthreads vs physical cores.
 #elif defined(PLATFORM_IS_MACOSX)

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#define SCHED_BATCH 100
+#define PONY_SCHED_BATCH 100
 
 static DECLARE_THREAD_FN(run_thread);
 
@@ -284,7 +284,7 @@ static void run(scheduler_t* sched)
     }
 
     // Run the current actor and get the next actor.
-    bool reschedule = ponyint_actor_run(&sched->ctx, actor, SCHED_BATCH);
+    bool reschedule = ponyint_actor_run(&sched->ctx, actor, PONY_SCHED_BATCH);
     pony_actor_t* next = pop_global(sched);
 
     if(reschedule)
@@ -370,6 +370,7 @@ static void ponyint_sched_shutdown()
 pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
   bool pinasio)
 {
+  this_scheduler = NULL;
   pony_register_thread();
   this_scheduler->ctx.current = NULL;
 


### PR DESCRIPTION
Changes related to getting pony compiling and running on Alpine
Linux Edge.

* Define `_GNU_SOURCE` so musl glibc compatibility is enabled.
* Makefile changes to detect Alpine Linux and link in `libexecinfo`
* Changes to stop using glibc specific `__GNUC_PREREQ` macro
* Changes to genexe linking to link in `libexecinfo` if on Alpine
  or FreeBSD (this is likely also needed but untested)
* Changes to move Linux cpu affinity setting outside of thread
  creation function and into same set affinity function as for
  other platforms. This also includes enabling asio thread affinity
  setting for non-linux platforms.
* Rename `SCHED_BATCH` to `PONY_SCHED_BATCH` to avoid conflict with
  musl.
* Set `this_scheduler` thread-local variable to `NULL` on
  `ponyint_sched_init` to avoid segfault in running codegen test
  suite.

Resolves #1729

NOTE: This is unlikely to make pony compatible with all musl based distributions/compiling attempts because pony still relies on `execinfo.h` and `musl` doesn't provide that. Some distributions include `libexecinfo` (as Alpine did) but others (`ubuntu` for example) may not. According this post (http://www.openwall.com/lists/musl/2015/04/10/2) in the `musl` mailing list, the appropriate longer term solution might be to use `libunwind`.

/cc @sylvanc (for a review of the affinity changes in particular and everything in general)
/cc @Praetonus (for a review of the `this_scheduler` and `execinfo` stuff in particular and everything in general)

--------------------

Tested using the following in `docker run --privileged -it  --rm alpine:edge sh` on an `Ubuntu 16.04 VM`:

* Install build tools/dependencies:
  `apk add --update alpine-sdk libressl-dev cmake binutils-gold llvm llvm-dev pcre2-dev less libexecinfo-dev`
* Add: `#undef open64`
  to: `/usr/include/llvm/Analysis/TargetLibraryInfo.h` (around line 28)
  This is only needed until the changes in https://github.com/alpinelinux/aports/pull/1273
 are merged.
* Install `coreutils` for process monitor tests to pass or else they have an issue with `/bin/cat` being a link:
  `apk add --update coreutils`
* `git clone https://github.com/ponylang/ponyc`
* `make test` (this will fail due to the unresolved PIC/PIE issues; see #1811 and #1484)
* `./build/release/ponyc -d --pic packages/stdlib`
* `./stdlib`
