### PR TITLE
Avoid building packages and docs on pull requests to 'release'

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -73,7 +73,7 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
   "linux:llvm-config-3.9")
     # when FAVORITE_CONFIG stops matching part of this case, move this logic
-    if [[ "$TRAVIS_BRANCH" == "release" && "$FAVORITE_CONFIG" == "yes" ]]
+    if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$FAVORITE_CONFIG" == "yes" ]]
     then
       ponyc-build-packages
       ponyc-build-docs


### PR DESCRIPTION
[skip ci] because this needs testing on:
* a release branch build, and
* a pull request to the release branch.

According to [Travis docs](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables):
> * `TRAVIS_BRANCH`:
>   * for push builds, or builds not triggered by a pull request, this is the name of the branch.
>   * for builds triggered by a pull request this is the name of the branch targeted by the pull request.
> ...
> * `TRAVIS_PULL_REQUEST`: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

@SeanTAllen this is what I mentioned yesterday! 😅 