### PR TITLE
Iftype conditions (RFC 26)

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -90,6 +90,7 @@ binop
 nextterm
   : 'if' ('\\' ID (',' ID)* '\\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
   | 'ifdef' ('\\' ID (',' ID)* '\\')? infix 'then' rawseq (elseifdef | ('else' annotatedrawseq))? 'end'
+  | 'iftype' ('\\' ID (',' ID)* '\\')? type '<:' type 'then' rawseq (elseiftype | ('else' annotatedrawseq))? 'end'
   | 'match' ('\\' ID (',' ID)* '\\')? rawseq caseexpr* ('else' annotatedrawseq)? 'end'
   | 'while' ('\\' ID (',' ID)* '\\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
   | 'repeat' ('\\' ID (',' ID)* '\\')? rawseq 'until' annotatedrawseq ('else' annotatedrawseq)? 'end'
@@ -105,6 +106,7 @@ nextterm
 term
   : 'if' ('\\' ID (',' ID)* '\\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
   | 'ifdef' ('\\' ID (',' ID)* '\\')? infix 'then' rawseq (elseifdef | ('else' annotatedrawseq))? 'end'
+  | 'iftype' ('\\' ID (',' ID)* '\\')? type '<:' type 'then' rawseq (elseiftype | ('else' annotatedrawseq))? 'end'
   | 'match' ('\\' ID (',' ID)* '\\')? rawseq caseexpr* ('else' annotatedrawseq)? 'end'
   | 'while' ('\\' ID (',' ID)* '\\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
   | 'repeat' ('\\' ID (',' ID)* '\\')? rawseq 'until' annotatedrawseq ('else' annotatedrawseq)? 'end'
@@ -123,6 +125,10 @@ withelem
 
 caseexpr
   : '|' ('\\' ID (',' ID)* '\\')? pattern? ('if' rawseq)? ('=>' rawseq)?
+  ;
+
+elseiftype
+  : 'elseiftype' ('\\' ID (',' ID)* '\\')? type '<:' type 'then' rawseq (elseiftype | ('else' annotatedrawseq))?
   ;
 
 elseifdef

--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -112,6 +112,9 @@ bool frame_push(typecheck_t* t, ast_t* ast)
     {
       ast_t* parent = ast_parent(ast);
 
+      if(parent == NULL)
+        return pop;
+
       switch(ast_id(parent))
       {
         case TK_TYPEPARAM:
@@ -255,6 +258,20 @@ bool frame_push(typecheck_t* t, ast_t* ast)
             pop = push_frame(t);
             t->frame->ifdef_cond = else_cond;
             t->frame->ifdef_clause = else_clause;
+          }
+          break;
+        }
+
+        case TK_IFTYPE:
+        {
+          AST_GET_CHILDREN(parent, l_type, r_type, body);
+
+          pop = push_frame(t);
+          if(r_type == ast)
+          {
+            t->frame->iftype_constraint = ast;
+          } else if(body == ast) {
+            t->frame->iftype_body = ast;
           }
           break;
         }

--- a/src/libponyc/ast/frame.h
+++ b/src/libponyc/ast/frame.h
@@ -32,6 +32,8 @@ typedef struct typecheck_frame_t
   ast_t* recover;
   ast_t* ifdef_cond;
   ast_t* ifdef_clause;
+  ast_t* iftype_constraint;
+  ast_t* iftype_body;
 
   struct typecheck_frame_t* prev;
 } typecheck_frame_t;

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -80,6 +80,8 @@ static const lextoken_t symbols[] =
 
   { ".>", TK_CHAIN },
 
+  { "<:", TK_SUBTYPE },
+
   { "\\", TK_BACKSLASH },
 
   { "{", TK_LBRACE },
@@ -165,9 +167,11 @@ static const lextoken_t keywords[] =
 
   { "if", TK_IF },
   { "ifdef", TK_IFDEF },
+  { "iftype", TK_IFTYPE },
   { "then", TK_THEN },
   { "else", TK_ELSE },
   { "elseif", TK_ELSEIF },
+  { "elseiftype", TK_ELSEIFTYPE },
   { "end", TK_END },
   { "for", TK_FOR },
   { "in", TK_IN },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -678,6 +678,35 @@ DEF(ifdef);
   REORDER(0, 2, 3, 1);
   DONE();
 
+// ELSEIFTYPE [annotations] type <: type THEN seq [elseiftype | (ELSE seq)]
+DEF(elseiftype);
+  AST_NODE(TK_IFTYPE);
+  SCOPE();
+  SKIP(NULL, TK_ELSEIFTYPE);
+  ANNOTATE(annotations);
+  RULE("type", type);
+  SKIP(NULL, TK_SUBTYPE);
+  RULE("type", type);
+  SKIP(NULL, TK_THEN);
+  RULE("then value", seq);
+  OPT RULE("else clause", elseiftype, elseclause);
+  DONE();
+
+// IFTYPE [annotations] type <: type THEN seq [elseiftype | (ELSE seq)] END
+DEF(iftype);
+  PRINT_INLINE();
+  TOKEN(NULL, TK_IFTYPE);
+  ANNOTATE(annotations);
+  SCOPE();
+  RULE("type", type);
+  SKIP(NULL, TK_SUBTYPE);
+  RULE("type", type);
+  SKIP(NULL, TK_THEN);
+  RULE("then value", seq);
+  OPT RULE("else clause", elseiftype, elseclause);
+  TERMINATE("iftype expression", TK_END);
+  DONE();
+
 // PIPE [annotations] [infix] [WHERE rawseq] [ARROW rawseq]
 DEF(caseexpr);
   AST_NODE(TK_CASE);
@@ -876,18 +905,18 @@ DEF(test_ifdef_flag);
   TOKEN(NULL, TK_ID);
   DONE();
 
-// cond | ifdef | match | whileloop | repeat | forloop | with | try |
+// cond | ifdef | iftype | match | whileloop | repeat | forloop | with | try |
 // recover | consume | pattern | const_expr | test_<various>
 DEF(term);
-  RULE("value", cond, ifdef, match, whileloop, repeat, forloop, with,
+  RULE("value", cond, ifdef, iftype, match, whileloop, repeat, forloop, with,
     try_block, recover, consume, pattern, const_expr, test_noseq,
     test_seq_scope, test_try_block, test_ifdef_flag, test_prefix);
   DONE();
 
-// cond | ifdef | match | whileloop | repeat | forloop | with | try |
+// cond | ifdef | iftype | match | whileloop | repeat | forloop | with | try |
 // recover | consume | pattern | const_expr | test_<various>
 DEF(nextterm);
-  RULE("value", cond, ifdef, match, whileloop, repeat, forloop, with,
+  RULE("value", cond, ifdef, iftype, match, whileloop, repeat, forloop, with,
     try_block, recover, consume, nextpattern, const_expr, test_noseq,
     test_seq_scope, test_try_block, test_ifdef_flag, test_prefix);
   DONE();

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -82,6 +82,7 @@ typedef enum token_id
   TK_ISECTTYPE,
   TK_EPHEMERAL,
   TK_ALIASED,
+  TK_SUBTYPE,
 
   TK_QUESTION,
   TK_UNARY_MINUS,
@@ -143,9 +144,11 @@ typedef enum token_id
 
   TK_IF,
   TK_IFDEF,
+  TK_IFTYPE,
   TK_THEN,
   TK_ELSE,
   TK_ELSEIF,
+  TK_ELSEIFTYPE,
   TK_END,
   TK_WHILE,
   TK_DO,

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -152,6 +152,16 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   return GEN_NOTNEEDED;
 }
 
+LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
+{
+  AST_GET_CHILDREN(ast, subtype, supertype, left, right);
+
+  if(is_subtype_constraint(subtype, supertype, NULL, c->opt))
+    return gen_expr(c, left);
+
+  return gen_expr(c, right);
+}
+
 LLVMValueRef gen_while(compile_t* c, ast_t* ast)
 {
   bool needed = is_result_needed(ast);

--- a/src/libponyc/codegen/gencontrol.h
+++ b/src/libponyc/codegen/gencontrol.h
@@ -10,6 +10,8 @@ LLVMValueRef gen_seq(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_if(compile_t* c, ast_t* ast);
 
+LLVMValueRef gen_iftype(compile_t* c, ast_t* ast);
+
 LLVMValueRef gen_while(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_repeat(compile_t* c, ast_t* ast);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -63,6 +63,10 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       ret = gen_if(c, ast);
       break;
 
+    case TK_IFTYPE:
+      ret = gen_iftype(c, ast);
+      break;
+
     case TK_WHILE:
       ret = gen_while(c, ast);
       break;

--- a/src/libponyc/expr/control.h
+++ b/src/libponyc/expr/control.h
@@ -9,6 +9,7 @@ PONY_EXTERN_C_BEGIN
 
 bool expr_seq(pass_opt_t* opt, ast_t* ast);
 bool expr_if(pass_opt_t* opt, ast_t* ast);
+bool expr_iftype(pass_opt_t* opt, ast_t* ast);
 bool expr_while(pass_opt_t* opt, ast_t* ast);
 bool expr_repeat(pass_opt_t* opt, ast_t* ast);
 bool expr_try(pass_opt_t* opt, ast_t* ast);

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -13,6 +13,7 @@
 #include "../type/cap.h"
 #include "../type/reify.h"
 #include "../type/lookup.h"
+#include "../type/typeparam.h"
 #include "../ast/astbuild.h"
 #include "ponyassert.h"
 
@@ -126,6 +127,8 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
     return false;
 
   AST_GET_CHILDREN(find, id, f_type, init);
+
+  f_type = typeparam_current(opt, f_type, ast);
 
   // Viewpoint adapted type of the field.
   ast_t* type = viewpoint_type(l_type, f_type);
@@ -368,6 +371,8 @@ bool expr_localref(pass_opt_t* opt, ast_t* ast)
   if(is_typecheck_error(type))
     return false;
 
+  type = typeparam_current(opt, type, ast);
+
   if(!sendable(type))
   {
     if(opt->check.frame->recover != NULL)
@@ -424,6 +429,8 @@ bool expr_paramref(pass_opt_t* opt, ast_t* ast)
 
   if(is_typecheck_error(type))
     return false;
+
+  type = typeparam_current(opt, type, ast);
 
   if(!sendable(type) && (opt->check.frame->recover != NULL))
   {

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -56,6 +56,13 @@ bool is_result_needed(ast_t* ast)
 
       return is_result_needed(parent);
 
+    case TK_IFTYPE:
+      // Sub/supertype not needed, body/else needed only if parent needed.
+      if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
+        return false;
+
+      return is_result_needed(parent);
+
     case TK_REPEAT:
       // Cond needed, body/else needed only if parent needed.
       if(ast_childidx(parent, 1) == ast)
@@ -125,6 +132,12 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
     case TK_MATCH:
       // The condition is not the result.
       if(ast_child(parent) == ast)
+        return false;
+      break;
+
+    case TK_IFTYPE:
+      // The subtype and the supertype are not the result.
+      if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
       break;
 
@@ -241,6 +254,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_CALL:       r = expr_call(options, astp); break;
     case TK_IFDEF:
     case TK_IF:         r = expr_if(options, ast); break;
+    case TK_IFTYPE:     r = expr_iftype(options, ast); break;
     case TK_WHILE:      r = expr_while(options, ast); break;
     case TK_REPEAT:     r = expr_repeat(options, ast); break;
     case TK_TRY_NO_CHECK:

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -56,6 +56,7 @@ static ast_result_t flatten_isect(pass_opt_t* opt, ast_t* ast)
   AST_EXTRACT_CHILDREN(ast, left, right);
 
   if((opt->check.frame->constraint == NULL) &&
+    (opt->check.frame->iftype_constraint == NULL) &&
     (opt->check.frame->provides == NULL) &&
     !is_compat_type(left, right))
   {

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -190,12 +190,17 @@ static bool names_typeparam(pass_opt_t* opt, ast_t** astp, ast_t* def)
     }
   }
 
+  const char* name = ast_name(id);
+
   // Change to a typeparamref.
   REPLACE(astp,
     NODE(TK_TYPEPARAMREF,
       TREE(id)
       TREE(cap)
       TREE(ephemeral)));
+
+  if(opt->check.frame->iftype_body != NULL)
+    def = ast_get(ast, name, NULL);
 
   ast_setdata(*astp, def);
   return true;
@@ -210,7 +215,8 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
 
   if(tcap == TK_NONE)
   {
-    if(opt->check.frame->constraint != NULL)
+    if((opt->check.frame->constraint != NULL) ||
+      (opt->check.frame->iftype_constraint != NULL))
     {
       // A primitive constraint is a val, otherwise #any.
       if(ast_id(def) == TK_PRIMITIVE)

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -298,7 +298,7 @@ bool generate_passes(ast_t* program, pass_opt_t* options)
 }
 
 
-static void record_ast_pass(ast_t* ast, pass_id pass)
+void ast_pass_record(ast_t* ast, pass_id pass)
 {
   pony_assert(ast != NULL);
 
@@ -346,7 +346,7 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
         break;
 
       case AST_FATAL:
-        record_ast_pass(*ast, pass);
+        ast_pass_record(*ast, pass);
 
         if(pop)
           frame_pop(t);
@@ -376,7 +376,7 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
           break;
 
         case AST_FATAL:
-          record_ast_pass(*ast, pass);
+          ast_pass_record(*ast, pass);
 
           if(pop)
             frame_pop(t);
@@ -401,7 +401,7 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
         break;
 
       case AST_FATAL:
-        record_ast_pass(*ast, pass);
+        ast_pass_record(*ast, pass);
 
         if(pop)
           frame_pop(t);
@@ -413,7 +413,7 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
   if(pop)
     frame_pop(t);
 
-  record_ast_pass(*ast, pass);
+  ast_pass_record(*ast, pass);
   return ret;
 }
 

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -304,6 +304,10 @@ bool ast_passes_subtree(ast_t** astp, pass_opt_t* options, pass_id last_pass);
  */
 bool generate_passes(ast_t* program, pass_opt_t* options);
 
+/** Record the specified pass as done for the given AST.
+ */
+void ast_pass_record(ast_t* ast, pass_id pass);
+
 
 typedef ast_result_t(*ast_visit_t)(ast_t** astp, pass_opt_t* options);
 

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -916,6 +916,38 @@ static bool refer_if(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
+static bool refer_iftype(pass_opt_t* opt, ast_t* ast)
+{
+  (void)opt;
+  pony_assert(ast_id(ast) == TK_IFTYPE);
+  AST_GET_CHILDREN(ast, sub, super, left, right);
+
+  size_t branch_count = 0;
+
+  if(!ast_checkflag(left, AST_FLAG_JUMPS_AWAY))
+  {
+    branch_count++;
+    ast_inheritbranch(ast, left);
+  }
+
+  if(!ast_checkflag(right, AST_FLAG_JUMPS_AWAY))
+  {
+    branch_count++;
+    ast_inheritbranch(ast, right);
+  }
+
+  ast_consolidate_branches(ast, branch_count);
+
+  // If all branches jump away with no value, then we do too.
+  if(branch_count == 0)
+    ast_setflag(ast, AST_FLAG_JUMPS_AWAY);
+
+  // Push our symbol status to our parent scope.
+  ast_inheritstatus(ast_parent(ast), ast);
+
+  return true;
+}
+
 static bool refer_while(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_WHILE);
@@ -1237,6 +1269,7 @@ ast_result_t pass_refer(ast_t** astp, pass_opt_t* options)
     case TK_SEQ:       r = refer_seq(options, ast); break;
     case TK_IFDEF:
     case TK_IF:        r = refer_if(options, ast); break;
+    case TK_IFTYPE:    r = refer_iftype(options, ast); break;
     case TK_WHILE:     r = refer_while(options, ast); break;
     case TK_REPEAT:    r = refer_repeat(options, ast); break;
     case TK_MATCH:     r = refer_match(options, ast); break;

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -459,9 +459,9 @@ static ast_result_t sugar_return(pass_opt_t* opt, ast_t* ast)
 }
 
 
-static ast_result_t sugar_else(ast_t* ast)
+static ast_result_t sugar_else(ast_t* ast, size_t index)
 {
-  ast_t* else_clause = ast_childidx(ast, 2);
+  ast_t* else_clause = ast_childidx(ast, index);
   expand_none(else_clause, true);
   return AST_OK;
 }
@@ -976,7 +976,7 @@ static ast_result_t sugar_ifdef(pass_opt_t* opt, ast_t* ast)
     return AST_ERROR;
   }
 
-  return sugar_else(ast);
+  return sugar_else(ast, 2);
 }
 
 
@@ -1229,7 +1229,8 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_IF:
     case TK_MATCH:
     case TK_WHILE:
-    case TK_REPEAT:           return sugar_else(ast);
+    case TK_REPEAT:           return sugar_else(ast, 2);
+    case TK_IFTYPE:           return sugar_else(ast, 3);
     case TK_TRY:              return sugar_try(ast);
     case TK_FOR:              return sugar_for(options, astp);
     case TK_WITH:             return sugar_with(options, astp);

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -447,7 +447,8 @@ static ast_result_t syntax_arrow(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
 
-  if((opt->check.frame->constraint != NULL) &&
+  if(((opt->check.frame->constraint != NULL) ||
+    (opt->check.frame->iftype_constraint != NULL)) &&
     (opt->check.frame->method == NULL))
   {
     ast_error(opt->check.errors, ast,
@@ -1124,7 +1125,8 @@ static ast_result_t syntax_cap(pass_opt_t* opt, ast_t* ast)
 static ast_result_t syntax_cap_set(pass_opt_t* opt, ast_t* ast)
 {
   // Cap sets can only appear in type parameter constraints.
-  if(opt->check.frame->constraint == NULL)
+  if((opt->check.frame->constraint == NULL) &&
+    (opt->check.frame->iftype_constraint == NULL))
   {
     ast_error(opt->check.errors, ast,
       "a capability set can only appear in a type constraint");

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1102,6 +1102,23 @@ static void reachable_expr(reach_t* r, ast_t* ast, pass_opt_t* opt)
       break;
     }
 
+    case TK_IFTYPE:
+    {
+      AST_GET_CHILDREN(ast, sub, super, left, right);
+
+      ast_t* type = ast_type(ast);
+
+      if(is_result_needed(ast) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+        add_type(r, type, opt);
+
+      if(is_subtype_constraint(sub, super, NULL, opt))
+        reachable_expr(r, left, opt);
+      else
+        reachable_expr(r, right, opt);
+
+      return;
+    }
+
     case TK_MATCH:
     case TK_WHILE:
     case TK_REPEAT:

--- a/src/libponyc/type/typeparam.h
+++ b/src/libponyc/type/typeparam.h
@@ -4,6 +4,7 @@
 #include <platform.h>
 #include "../ast/ast.h"
 #include "../ast/frame.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -28,6 +29,11 @@ ast_t* typeparam_lower(ast_t* typeparamref);
  * be bound.
  */
 void typeparam_set_cap(ast_t* typeparamref);
+
+/**
+ * The constraint of the typeparam in the current scope.
+ */
+ast_t* typeparam_current(pass_opt_t* opt, ast_t* typeparamref, ast_t* scope);
 
 PONY_EXTERN_C_END
 

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -1,0 +1,231 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <reach/reach.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "ir"))
+
+#define TEST_ERROR(src, err) \
+  { const char* errs[] = {err, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
+
+class IftypeTest : public PassTest
+{};
+
+
+TEST_F(IftypeTest, ThenClause_TypeConstraint)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+    "  fun tag c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: T](x: A) =>\n"
+    "    iftype A <: C then\n"
+    "      x.c()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, ElseClause_NoTypeConstraint)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+    "  fun tag c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: T](x: A) =>\n"
+    "    iftype A <: C then\n"
+    "      None\n"
+    "    else\n"
+    "      x.c()\n"
+    "    end";
+
+  TEST_ERROR(src, "couldn't find 'c' in 'T'");
+}
+
+
+TEST_F(IftypeTest, ThenClause_CapConstraint)
+{
+  const char* src =
+    "class C\n"
+    "  fun c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: C](x: A) =>\n"
+    "    iftype A <: C box then\n"
+    "      x.c()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, ElseClause_NoCapConstraint)
+{
+  const char* src =
+    "class C\n"
+    "  fun c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: C](x: A) =>\n"
+    "    iftype A <: C box then\n"
+    "      None\n"
+    "    else\n"
+    "      x.c()\n"
+    "    end";
+
+  TEST_ERROR(src, "receiver type is not a subtype of target type");
+}
+
+
+TEST_F(IftypeTest, Cond_InvalidType)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C]()\n"
+
+    "  fun foo[A: T]() =>\n"
+    "    iftype C <: A then\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERROR(src, "the subtype in an iftype condition must be a type parameter "
+    "or a tuple of type parameters");
+}
+
+
+TEST_F(IftypeTest, TupleCond_Valid)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "class C1 is T1\n"
+    "class C2 is T2\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C1, C2]()\n"
+
+    "  fun foo[A: T1, B: T2]() =>\n"
+    "    iftype (A, B) <: (C1, C2) then\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, TupleCond_InvalidType)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "class C1 is T1\n"
+    "class C2 is T2\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C1, C2]()\n"
+
+    "  fun foo[A: T1, B: T2]() =>\n"
+    "    iftype (A, B) <: C1 then\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERROR(src, "iftype subtype is a tuple but supertype isn't");
+}
+
+
+TEST_F(IftypeTest, TupleCond_InvalidCardinality)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "class C1 is T1\n"
+    "class C2 is T2\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C1, C2]()\n"
+
+    "  fun foo[A: T1, B: T2]() =>\n"
+    "    iftype (A, B) <: (C1, C2, C1) then\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERROR(src, "the subtype and the supertype in an iftype condition must "
+    "have the same cardinality");
+}
+
+
+TEST_F(IftypeTest, Codegen_True)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: T](x: A) =>\n"
+    "    iftype A <: C then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(IftypeTest, Codegen_False)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[T](C)\n"
+
+    "  fun foo[A: T](x: A) =>\n"
+    "    iftype A <: C then\n"
+    "      None\n"
+    "    else\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}


### PR DESCRIPTION
These new conditions allow programmers to get information on subtyping relationships of type parameters at compile time to conditionally compile code.

Most of the work is done during the scope pass, where the definition assigned to a type parameter reference differs based on whether the reference occurs in the then clause of an iftype condition.

This change implements only a part of RFC 26. Method specialisation is still to be implemented.