### PR TITLE
Reify function references used as addressof operands correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Properly account for foreign objects in GC ([PR #1842](https://github.com/ponylang/ponyc/pull/1842))
+- Compiler crash when using the `addressof` operator on a function with an incorrect number of type arguments
 
 ### Added
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -34,7 +34,7 @@ static bool insert_apply(pass_opt_t* opt, ast_t** astp)
   return expr_call(opt, astp);
 }
 
-static bool check_type_params(pass_opt_t* opt, ast_t** astp)
+bool method_check_type_params(pass_opt_t* opt, ast_t** astp)
 {
   ast_t* lhs = *astp;
   ast_t* type = ast_type(lhs);
@@ -488,7 +488,7 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
 {
   AST_GET_CHILDREN(ast, positional, namedargs, lhs);
 
-  if(!check_type_params(opt, &lhs))
+  if(!method_check_type_params(opt, &lhs))
     return false;
 
   ast_t* type = ast_type(lhs);

--- a/src/libponyc/expr/call.h
+++ b/src/libponyc/expr/call.h
@@ -7,6 +7,8 @@
 
 PONY_EXTERN_C_BEGIN
 
+bool method_check_type_params(pass_opt_t* opt, ast_t** astp);
+
 bool expr_call(pass_opt_t* opt, ast_t** astp);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -528,6 +528,9 @@ bool expr_addressof(pass_opt_t* opt, ast_t* ast)
   {
     case TK_FUNREF:
     case TK_BEREF:
+      if(!method_check_type_params(opt, &expr))
+        return false;
+
       expr_type = type_builtin(opt, ast, "None");
       break;
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -454,3 +454,17 @@ TEST_F(BadPonyTest, ObjectInheritsLaterTraitMethodWithParameter)
 
   TEST_COMPILE(src);
 }
+
+
+TEST_F(BadPonyTest, AddressofMissingTypearg)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @foo[None](addressof fn)\n"
+
+    "  fun fn[A]() => None";
+
+  TEST_ERRORS_1(src,
+    "not enough type arguments");
+}


### PR DESCRIPTION
Previously, a function reference used as the operand of `addressof` was only reified in `expr_qualify`. Since this function is only called when there is at least one type argument, a function referenced with no type arguments wouldn't be checked. This change fixes the issue by reifying the function in `expr_addressof` if the function reference wasn't already reified.