### PR TITLE
Bare methods and bare lambdas (RFC 34)

### DIFF
--- a/examples/ffi-callbacks/callbacks.c
+++ b/examples/ffi-callbacks/callbacks.c
@@ -1,0 +1,6 @@
+typedef void(*CB)(void*, int);
+
+void do_callback(CB callback, void* env)
+{
+  callback(env, 10);
+}

--- a/examples/ffi-callbacks/callbacks.pony
+++ b/examples/ffi-callbacks/callbacks.pony
@@ -1,0 +1,42 @@
+"""
+Example of the syntax used to pass Pony functions as callbacks to C functions.
+First, build the C file as a library, then build the Pony program.
+"""
+
+use "path:./"
+use "lib:ffi-callbacks"
+
+use @do_callback[None](fptr: CB, env: Env)
+
+// This is a bare lambda type, used to interface with C function pointer types.
+// The equivalent C type for this lambda type is `void(*)(Env*, int)` (bare
+// lambdas returning `None` are used for C functions returning `void`).
+type CB is @{(Env, I32)}
+
+// Bare lambda types can be used as field types to represent structures
+// containing function pointers.
+struct ContainsFunctionPointer
+  var ptr: CB = @{(env: Env, i: I32) => None}
+
+primitive Callback
+  // This is a bare function, i.e. a function with no receiver. Bare functions
+  // can be used as callbacks. Bare functions can be part of any type.
+  fun @callback(env: Env, i: I32) =>
+    env.out.print(i.string()) // Prints 10
+
+actor Main
+  new create(env: Env) =>
+    // Use `addressof` to get a function pointer to pass to C.
+    @do_callback(addressof Callback.callback, env)
+
+    // This is a bare lambda.
+    let callback = @{(env: Env, i: I32) =>
+      env.out.print(i.string()) // Prints 10
+    }
+    // The underlying value of a bare lambda is equivalent to a function pointer,
+    // which means that it can directly be passed as a callback.
+    @do_callback(callback, env)
+
+    let cfp = ContainsFunctionPointer
+    // The partial application of a bare method yields a bare lambda.
+    cfp.ptr = Callback~callback()

--- a/pony.g
+++ b/pony.g
@@ -34,7 +34,7 @@ field
   ;
 
 method
-  : ('fun' | 'be' | 'new') ('\\' ID (',' ID)* '\\')? cap? ID typeparams? ('(' | LPAREN_NEW) params? ')' (':' type)? '?'? STRING? ('if' rawseq)? ('=>' rawseq)?
+  : ('fun' | 'be' | 'new') ('\\' ID (',' ID)* '\\')? (cap | '@')? ID typeparams? ('(' | LPAREN_NEW) params? ')' (':' type)? '?'? STRING? ('if' rawseq)? ('=>' rawseq)?
   ;
 
 annotatedrawseq
@@ -202,6 +202,7 @@ nextatom
   | 'object' ('\\' ID (',' ID)* '\\')? cap? ('is' type)? members 'end'
   | '{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | 'lambda' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;
@@ -215,6 +216,7 @@ atom
   | 'object' ('\\' ID (',' ID)* '\\')? cap? ('is' type)? members 'end'
   | '{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | 'lambda' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
+  | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
   ;
@@ -253,6 +255,11 @@ atomtype
   | ('(' | LPAREN_NEW) infixtype tupletype? ')'
   | nominal
   | lambdatype
+  | barelambdatype
+  ;
+
+barelambdatype
+  : '@{' cap? ID? typeparams? ('(' | LPAREN_NEW) (type (',' type)*)? ')' (':' type)? '?'? '}' (cap | gencap)? ('^' | '!')?
   ;
 
 lambdatype

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -40,7 +40,7 @@
  * no annotation, the type will be stored in the annotation_type field.
  *
  * These situations can be distinguished because an annotation must always be a
- * TK_BACKSLASH, and the type may never be a TK_BACKSLASH.
+ * TK_ANNOTATION, and the type may never be a TK_ANNOTATION.
  *
  * It is STRONGLY recommended to only access them through provided functions:
  *   ast_type()
@@ -55,7 +55,7 @@ enum
   AST_ORPHAN = 0x10,
   AST_INHERIT_FLAGS = (AST_FLAG_CAN_ERROR | AST_FLAG_CAN_SEND |
     AST_FLAG_MIGHT_SEND | AST_FLAG_RECURSE_1 | AST_FLAG_RECURSE_2),
-  AST_ALL_FLAGS = 0x1FFFFF
+  AST_ALL_FLAGS = 0x3FFFFF
 };
 
 
@@ -653,13 +653,13 @@ ast_t* ast_type(ast_t* ast)
   pony_assert(ast != NULL);
 
   // An annotation may never have a type.
-  if(ast_id(ast) == TK_BACKSLASH)
+  if(ast_id(ast) == TK_ANNOTATION)
     return NULL;
 
   // If the annotation_type is an annotation, the type node (if any) is in the
   // annotation_type field of the annotation node.
   ast_t* type = ast->annotation_type;
-  if((type != NULL) && (ast_id(type) == TK_BACKSLASH))
+  if((type != NULL) && (ast_id(type) == TK_ANNOTATION))
     type = type->annotation_type;
 
   return type;
@@ -670,12 +670,12 @@ static void settype(ast_t* ast, ast_t* type, bool allow_free)
   pony_assert(ast != NULL);
 
   // An annotation may never have a type.
-  if(ast_id(ast) == TK_BACKSLASH)
+  if(ast_id(ast) == TK_ANNOTATION)
     pony_assert(type == NULL);
 
-  // A type can never be a TK_BACKSLASH (the annotation token).
+  // A type can never be a TK_ANNOTATION.
   if(type != NULL)
-    pony_assert(ast_id(type) != TK_BACKSLASH);
+    pony_assert(ast_id(type) != TK_ANNOTATION);
 
   ast_t* prev_type = ast_type(ast);
   if(prev_type == type)
@@ -690,7 +690,7 @@ static void settype(ast_t* ast, ast_t* type, bool allow_free)
   }
 
   if((ast->annotation_type != NULL) &&
-    (ast_id(ast->annotation_type) == TK_BACKSLASH))
+    (ast_id(ast->annotation_type) == TK_ANNOTATION))
     ast->annotation_type->annotation_type = type;
   else
     ast->annotation_type = type;
@@ -709,12 +709,12 @@ ast_t* ast_annotation(ast_t* ast)
   pony_assert(ast != NULL);
 
   // An annotation may never be annotated.
-  if(ast_id(ast) == TK_BACKSLASH)
+  if(ast_id(ast) == TK_ANNOTATION)
     return NULL;
 
   // If annotation_type is an annotation, we return it.
   ast_t* annotation = ast->annotation_type;
-  if((annotation != NULL) && (ast_id(annotation) == TK_BACKSLASH))
+  if((annotation != NULL) && (ast_id(annotation) == TK_ANNOTATION))
     return annotation;
 
   return NULL;
@@ -725,12 +725,12 @@ void setannotation(ast_t* ast, ast_t* annotation, bool allow_free)
   pony_assert(ast != NULL);
 
   // An annotation may never be annotated.
-  if(ast_id(ast) == TK_BACKSLASH)
+  if(ast_id(ast) == TK_ANNOTATION)
     pony_assert(annotation == NULL);
 
-  // An annotation must always be a TK_BACKSLASH (or NULL).
+  // An annotation must always be a TK_ANNOTATION (or NULL).
   if(annotation != NULL)
-    pony_assert(ast_id(annotation) == TK_BACKSLASH);
+    pony_assert(ast_id(annotation) == TK_ANNOTATION);
 
   ast_t* prev_annotation = ast_annotation(ast);
   if(prev_annotation == annotation)
@@ -781,7 +781,7 @@ bool ast_has_annotation(ast_t* ast, const char* name)
 
   ast_t* annotation = ast_annotation(ast);
 
-  if((annotation != NULL) && (ast_id(annotation) == TK_BACKSLASH))
+  if((annotation != NULL) && (ast_id(annotation) == TK_ANNOTATION))
   {
     const char* strtab_name = stringtab(name);
     ast_t* elem = ast_child(annotation);

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -45,6 +45,7 @@ enum
   AST_FLAG_ERROR_2      = 0x40000,
   AST_FLAG_JUMPS_AWAY   = 0x80000, // Jumps away (control flow) without a value.
   AST_FLAG_INCOMPLETE   = 0x100000, // Not all fields of `this` are defined yet.
+  AST_FLAG_IMPORT       = 0x200000, // Import the referenced package.
 };
 
 DECLARE_LIST(astlist, astlist_t, ast_t);

--- a/src/libponyc/ast/astbuild.h
+++ b/src/libponyc/ast/astbuild.h
@@ -29,6 +29,10 @@
  */
 #define BUILD(var, existing, ...) \
   ast_t* var; \
+  BUILD_NO_DECL(var, existing, __VA_ARGS__)
+
+/// Builds an AST but without declaring a new variable.
+#define BUILD_NO_DECL(var, existing, ...) \
   { \
     ast_t* basis_ast = existing; \
     ast_t* parent = NULL; \

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -84,6 +84,8 @@ static const lextoken_t symbols[] =
 
   { "\\", TK_BACKSLASH },
 
+  { "@{", TK_AT_LBRACE },
+
   { "{", TK_LBRACE },
   { "}", TK_RBRACE },
   { "(", TK_LPAREN },
@@ -243,6 +245,7 @@ static const lextoken_t abstract[] =
   { "thistype", TK_THISTYPE },
   { "funtype", TK_FUNTYPE },
   { "lambdatype", TK_LAMBDATYPE },
+  { "barelambdatype", TK_BARELAMBDATYPE },
   { "dontcaretype", TK_DONTCARETYPE },
   { "infer", TK_INFERTYPE },
   { "errortype", TK_ERRORTYPE },
@@ -264,6 +267,8 @@ static const lextoken_t abstract[] =
   { "updatearg", TK_UPDATEARG },
   { "lambdacaptures", TK_LAMBDACAPTURES },
   { "lambdacapture", TK_LAMBDACAPTURE },
+
+  { "barelambda", TK_BARELAMBDA },
 
   { "seq", TK_SEQ },
   { "qualify", TK_QUALIFY },
@@ -295,6 +300,8 @@ static const lextoken_t abstract[] =
   { "funapp", TK_FUNAPP },
   { "bechain", TK_BECHAIN },
   { "funchain", TK_FUNCHAIN },
+
+  { "annotation", TK_ANNOTATION },
 
   { "\\n", TK_NEWLINE },
   {NULL, (token_id)0}

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -58,6 +58,7 @@ typedef enum token_id
   TK_MOD,
   TK_MOD_TILDE,
   TK_AT,
+  TK_AT_LBRACE,
 
   TK_LSHIFT,
   TK_LSHIFT_TILDE,
@@ -109,6 +110,7 @@ typedef enum token_id
   TK_ACTOR,
   TK_OBJECT,
   TK_LAMBDA,
+  TK_BARELAMBDA,
 
   TK_AS,
   TK_IS,
@@ -195,6 +197,7 @@ typedef enum token_id
   TK_THISTYPE,
   TK_FUNTYPE,
   TK_LAMBDATYPE,
+  TK_BARELAMBDATYPE,
   TK_DONTCARETYPE,
   TK_INFERTYPE,
   TK_ERRORTYPE,
@@ -248,6 +251,8 @@ typedef enum token_id
   TK_FUNAPP,
   TK_BECHAIN,
   TK_FUNCHAIN,
+
+  TK_ANNOTATION,
 
   // Pseudo tokens that never actually exist
   TK_NEWLINE,  // Used by parser macros

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -84,6 +84,7 @@ typedef struct compile_frame_t
   LLVMMetadataRef di_scope;
   bool is_function;
   bool early_termination;
+  bool bare_function;
 
   struct compile_frame_t* prev;
 } compile_frame_t;
@@ -178,6 +179,7 @@ typedef struct compile_t
   LLVMValueRef none_instance;
   LLVMValueRef primitives_init;
   LLVMValueRef primitives_final;
+  LLVMValueRef desc_table;
   LLVMValueRef numeric_sizes;
 
   LLVMTypeRef void_type;
@@ -233,7 +235,7 @@ void codegen_cleanup(compile_t* c);
 LLVMValueRef codegen_addfun(compile_t* c, const char* name, LLVMTypeRef type);
 
 void codegen_startfun(compile_t* c, LLVMValueRef fun, LLVMMetadataRef file,
-  LLVMMetadataRef scope);
+  LLVMMetadataRef scope, bool bare);
 
 void codegen_finishfun(compile_t* c);
 
@@ -275,7 +277,7 @@ LLVMValueRef codegen_fun(compile_t* c);
 LLVMBasicBlockRef codegen_block(compile_t* c, const char* name);
 
 LLVMValueRef codegen_call(compile_t* c, LLVMValueRef fun, LLVMValueRef* args,
-  size_t count);
+  size_t count, bool setcc);
 
 const char* suffix_filename(compile_t* c, const char* dir, const char* prefix,
   const char* file, const char* extension);

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -201,6 +201,10 @@ static bool special_case_call(compile_t* c, ast_t* ast, LLVMValueRef* value)
 static LLVMValueRef dispatch_function(compile_t* c, reach_type_t* t,
   reach_method_t* m, LLVMValueRef l_value)
 {
+  if(t->bare_method == m)
+    return LLVMBuildBitCast(c->builder, l_value,
+      LLVMPointerType(m->func_type, 0), "");
+
   switch(t->underlying)
   {
     case TK_UNIONTYPE:
@@ -208,8 +212,11 @@ static LLVMValueRef dispatch_function(compile_t* c, reach_type_t* t,
     case TK_INTERFACE:
     case TK_TRAIT:
     {
+      pony_assert(t->bare_method == NULL);
+
       // Get the function from the vtable.
-      LLVMValueRef func = gendesc_vtable(c, l_value, m->vtable_index);
+      LLVMValueRef func = gendesc_vtable(c, gendesc_fetch(c, l_value),
+        m->vtable_index);
 
       return LLVMBuildBitCast(c->builder, func,
         LLVMPointerType(m->func_type, 0), "");
@@ -237,21 +244,21 @@ static bool call_needs_receiver(ast_t* postfix, reach_type_t* t)
   {
     case TK_NEWREF:
     case TK_NEWBEREF:
-      break;
+      // No receiver if a new primitive.
+      if(t->primitive != NULL)
+        return false;
 
+      // No receiver if a new Pointer or Maybe.
+      if(is_pointer(t->ast) || is_maybe(t->ast))
+        return false;
+
+      return true;
+
+    // Always generate the receiver, even for bare function calls. This ensures
+    // that side-effects always happen.
     default:
       return true;
   }
-
-  // No receiver if a new primitive.
-  if(t->primitive != NULL)
-    return false;
-
-  // No receiver if a new Pointer or Maybe.
-  if(is_pointer(t->ast) || is_maybe(t->ast))
-    return false;
-
-  return true;
 }
 
 static void set_descriptor(compile_t* c, reach_type_t* t, LLVMValueRef value)
@@ -332,10 +339,12 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
   reach_method_t* m = reach_method(t, cap, name, typeargs);
   LLVMValueRef funptr = dispatch_function(c, t, m, value);
 
-  if(c->linkage != LLVMExternalLinkage)
+  if((m->cap != TK_AT) && (c->linkage != LLVMExternalLinkage))
   {
     // We must reset the function linkage and calling convention since we're
-    // passing a function pointer to a FFI call.
+    // passing a function pointer to a FFI call. Bare methods always use the
+    // external linkage and the C calling convention so we don't need to process
+    // them.
     switch(t->underlying)
     {
       case TK_PRIMITIVE:
@@ -726,10 +735,12 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     }
   }
 
+  bool bare = m->cap == TK_AT;
+
   // Cast the arguments to the parameter types.
   LLVMTypeRef f_type = LLVMGetElementType(LLVMTypeOf(func));
   LLVMTypeRef* params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
-  LLVMGetParamTypes(f_type, params);
+  LLVMGetParamTypes(f_type, params + (bare ? 1 : 0));
 
   arg = ast_child(positional);
   i = 1;
@@ -775,6 +786,13 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       i++;
     }
 
+    intptr_t arg_offset = 0;
+    if(bare)
+    {
+      arg_offset = 1;
+      i--;
+    }
+
     if(func != NULL)
     {
       // If we can error out and we have an invoke target, generate an invoke
@@ -782,9 +800,9 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       codegen_debugloc(c, ast);
 
       if(ast_canerror(ast) && (c->frame->invoke_target != NULL))
-        r = invoke_fun(c, func, args, i, "", true);
+        r = invoke_fun(c, func, args + arg_offset, i, "", !bare);
       else
-        r = codegen_call(c, func, args, i);
+        r = codegen_call(c, func, args + arg_offset, i, !bare);
 
       if(is_new_call)
       {
@@ -795,6 +813,11 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       codegen_debugloc(c, NULL);
     }
   }
+
+  // Bare methods with None return type return void, special case a None return
+  // value.
+  if(bare && is_none(m->result->ast))
+    r = c->none_instance;
 
   // Class constructors return void, expression result is the receiver.
   if(((ast_id(postfix) == TK_NEWREF) || (ast_id(postfix) == TK_NEWBEREF)) &&
@@ -867,7 +890,7 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
   args[1] = r_value;
 
   codegen_debugloc(c, pattern);
-  LLVMValueRef result = codegen_call(c, func, args, 2);
+  LLVMValueRef result = codegen_call(c, func, args, 2, true);
   codegen_debugloc(c, NULL);
 
   return result;

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -16,13 +16,15 @@ void gendesc_table(compile_t* c);
 
 LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object);
 
-LLVMValueRef gendesc_typeid(compile_t* c, LLVMValueRef object);
+LLVMValueRef gendesc_typeid(compile_t* c, LLVMValueRef desc);
 
-LLVMValueRef gendesc_trace(compile_t* c, LLVMValueRef object);
+LLVMValueRef gendesc_instance(compile_t* c, LLVMValueRef desc);
 
-LLVMValueRef gendesc_dispatch(compile_t* c, LLVMValueRef object);
+LLVMValueRef gendesc_trace(compile_t* c, LLVMValueRef desc);
 
-LLVMValueRef gendesc_vtable(compile_t* c, LLVMValueRef object, size_t colour);
+LLVMValueRef gendesc_dispatch(compile_t* c, LLVMValueRef desc);
+
+LLVMValueRef gendesc_vtable(compile_t* c, LLVMValueRef desc, size_t colour);
 
 LLVMValueRef gendesc_ptr_to_fields(compile_t* c, LLVMValueRef object,
   LLVMValueRef desc);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -44,7 +44,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   LLVMTypeRef ftype = LLVMFunctionType(c->i32, params, 3, false);
   LLVMValueRef func = LLVMAddFunction(c->module, "main", ftype);
 
-  codegen_startfun(c, func, NULL, NULL);
+  codegen_startfun(c, func, NULL, NULL, false);
 
   LLVMValueRef args[4];
   args[0] = LLVMGetParam(func, 0);
@@ -72,7 +72,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   env_args[1] = args[0];
   env_args[2] = LLVMBuildBitCast(c->builder, args[1], c->void_ptr, "");
   env_args[3] = LLVMBuildBitCast(c->builder, args[2], c->void_ptr, "");
-  codegen_call(c, m->func, env_args, 4);
+  codegen_call(c, m->func, env_args, 4, true);
   LLVMValueRef env = env_args[0];
 
   // Run primitive initialisers using the main actor's heap.

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -53,6 +53,7 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       ret = gen_localload(c, ast);
       break;
 
+    case TK_TYPEREF:
     case TK_DONTCARE:
     case TK_DONTCAREREF:
     case TK_MATCH_DONTCARE:

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -90,7 +90,8 @@ static void print_type_name(compile_t* c, printbuf_t* buf, ast_t* type)
   }
 }
 
-static void print_params(compile_t* c, printbuf_t* buf, ast_t* params)
+static void print_params(compile_t* c, printbuf_t* buf, ast_t* params,
+  bool initial_comma)
 {
   ast_t* param = ast_child(params);
 
@@ -99,7 +100,11 @@ static void print_params(compile_t* c, printbuf_t* buf, ast_t* params)
     AST_GET_CHILDREN(param, id, ptype);
 
     // Print the parameter.
-    printbuf(buf, ", ");
+    if(initial_comma)
+      printbuf(buf, ", ");
+    else
+      initial_comma = true;
+
     print_type_name(c, buf, ptype);
 
     // Smash trailing primes to underscores.
@@ -173,7 +178,11 @@ static void print_method(compile_t* c, printbuf_t* buf, reach_type_t* t,
   }
 
   // Print the function signature.
-  print_type_name(c, buf, rtype);
+  if((ast_id(cap) != TK_AT) || !is_none(rtype))
+    print_type_name(c, buf, rtype);
+  else
+    printbuf(buf, "void");
+
   printbuf(buf, " %s", m->full_name);
 
   switch(ast_id(m->r_fun))
@@ -193,9 +202,15 @@ static void print_method(compile_t* c, printbuf_t* buf, reach_type_t* t,
   }
 
   printbuf(buf, "(");
-  print_type_name(c, buf, t->ast);
-  printbuf(buf, " self");
-  print_params(c, buf, params);
+  if(ast_id(cap) != TK_AT)
+  {
+    print_type_name(c, buf, t->ast);
+    printbuf(buf, " self");
+    print_params(c, buf, params, true);
+  } else {
+    print_params(c, buf, params, false);
+  }
+
   printbuf(buf, ");\n\n");
 }
 

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -183,7 +183,7 @@ static LLVMValueRef box_is_box(compile_t* c, ast_t* left_type,
   LLVMValueRef l_typeid = NULL;
   if((possible_boxes & BOXED_SUBTYPES_UNBOXED) != 0)
   {
-    l_typeid = gendesc_typeid(c, l_value);
+    l_typeid = gendesc_typeid(c, l_desc);
     LLVMValueRef boxed_mask = LLVMConstInt(c->i32, 1, false);
     LLVMValueRef left_boxed = LLVMBuildAnd(c->builder, l_typeid, boxed_mask,
       "");
@@ -201,7 +201,7 @@ static LLVMValueRef box_is_box(compile_t* c, ast_t* left_type,
   if((possible_boxes & BOXED_SUBTYPES_BOXED) == BOXED_SUBTYPES_BOXED)
   {
     if(l_typeid == NULL)
-      l_typeid = gendesc_typeid(c, l_value);
+      l_typeid = gendesc_typeid(c, l_desc);
     LLVMValueRef num_mask = LLVMConstInt(c->i32, 2, false);
     LLVMValueRef boxed_num = LLVMBuildAnd(c->builder, l_typeid, num_mask, "");
     LLVMValueRef zero = LLVMConstInt(c->i32, 0, false);
@@ -221,7 +221,7 @@ static LLVMValueRef box_is_box(compile_t* c, ast_t* left_type,
     // Get the machine word size and memcmp without unboxing.
     LLVMPositionBuilderAtEnd(c->builder, num_block);
     if(l_typeid == NULL)
-      l_typeid = gendesc_typeid(c, l_value);
+      l_typeid = gendesc_typeid(c, l_desc);
     LLVMValueRef num_sizes = LLVMBuildBitCast(c->builder, c->numeric_sizes,
       c->void_ptr, "");
     args[0] = LLVMBuildZExt(c->builder, l_typeid, c->intptr, "");
@@ -251,7 +251,7 @@ static LLVMValueRef box_is_box(compile_t* c, ast_t* left_type,
     reach_method_t* is_fn = reach_method(r_left, TK_BOX, stringtab("__is"),
       NULL);
     pony_assert(is_fn != NULL);
-    LLVMValueRef func = gendesc_vtable(c, l_value, is_fn->vtable_index);
+    LLVMValueRef func = gendesc_vtable(c, l_desc, is_fn->vtable_index);
     LLVMTypeRef params[2];
     params[0] = c->object_ptr;
     params[1] = c->object_ptr;
@@ -259,7 +259,7 @@ static LLVMValueRef box_is_box(compile_t* c, ast_t* left_type,
     func = LLVMBuildBitCast(c->builder, func, LLVMPointerType(type, 0), "");
     args[0] = l_value;
     args[1] = r_value;
-    is_tuple = codegen_call(c, func, args, 2);
+    is_tuple = codegen_call(c, func, args, 2, true);
     LLVMBuildBr(c->builder, post_block);
   }
 
@@ -416,7 +416,7 @@ void gen_is_tuple_fun(compile_t* c, reach_type_t* t)
   m->func_type = LLVMFunctionType(c->i1, params, 2, false);
   m->func = codegen_addfun(c, m->full_name, m->func_type);
 
-  codegen_startfun(c, m->func, NULL, NULL);
+  codegen_startfun(c, m->func, NULL, NULL, false);
   LLVMValueRef l_value = LLVMGetParam(codegen_fun(c), 0);
   LLVMValueRef r_value = LLVMGetParam(codegen_fun(c), 1);
 

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -167,7 +167,10 @@ const char* genname_fun(token_id cap, const char* name, ast_t* typeargs)
 {
   // cap_name[_Arg1_Arg2]
   printbuf_t* buf = printbuf_new();
-  printbuf(buf, "%s_%s", lexer_print(cap), name);
+  if(cap == TK_AT)
+    printbuf(buf, "%s", name);
+  else
+    printbuf(buf, "%s_%s", lexer_print(cap), name);
   types_append(buf, typeargs);
   return stringtab_buf(buf);
 }

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -35,7 +35,7 @@ static void start_function(compile_t* c, reach_type_t* t, reach_method_t* m,
   m->func_type = LLVMFunctionType(result, params, count, false);
   m->func = codegen_addfun(c, m->full_name, m->func_type);
   genfun_param_attrs(c, t, m, m->func);
-  codegen_startfun(c, m->func, NULL, NULL);
+  codegen_startfun(c, m->func, NULL, NULL, false);
 }
 
 static void box_function(compile_t* c, generate_box_fn gen, void* gen_data)
@@ -710,7 +710,7 @@ static void trace_array_elements(compile_t* c, reach_type_t* t,
 
 void genprim_array_trace(compile_t* c, reach_type_t* t)
 {
-  codegen_startfun(c, t->trace_fn, NULL, NULL);
+  codegen_startfun(c, t->trace_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->trace_fn, LLVMCCallConv);
   LLVMSetLinkage(t->trace_fn, LLVMExternalLinkage);
   LLVMValueRef ctx = LLVMGetParam(t->trace_fn, 0);
@@ -737,7 +737,7 @@ void genprim_array_serialise_trace(compile_t* c, reach_type_t* t)
   t->serialise_trace_fn = codegen_addfun(c, genname_serialise_trace(t->name),
     c->trace_type);
 
-  codegen_startfun(c, t->serialise_trace_fn, NULL, NULL);
+  codegen_startfun(c, t->serialise_trace_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->serialise_trace_fn, LLVMCCallConv);
   LLVMSetLinkage(t->serialise_trace_fn, LLVMExternalLinkage);
 
@@ -778,7 +778,7 @@ void genprim_array_serialise(compile_t* c, reach_type_t* t)
   t->serialise_fn = codegen_addfun(c, genname_serialise(t->name),
     c->serialise_type);
 
-  codegen_startfun(c, t->serialise_fn, NULL, NULL);
+  codegen_startfun(c, t->serialise_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
   LLVMSetLinkage(t->serialise_fn, LLVMExternalLinkage);
 
@@ -903,7 +903,7 @@ void genprim_array_deserialise(compile_t* c, reach_type_t* t)
   t->deserialise_fn = codegen_addfun(c, genname_deserialise(t->name),
     c->trace_type);
 
-  codegen_startfun(c, t->deserialise_fn, NULL, NULL);
+  codegen_startfun(c, t->deserialise_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->deserialise_fn, LLVMCCallConv);
   LLVMSetLinkage(t->deserialise_fn, LLVMExternalLinkage);
 
@@ -985,7 +985,7 @@ void genprim_string_serialise_trace(compile_t* c, reach_type_t* t)
   t->serialise_trace_fn = codegen_addfun(c, genname_serialise_trace(t->name),
     c->serialise_type);
 
-  codegen_startfun(c, t->serialise_trace_fn, NULL, NULL);
+  codegen_startfun(c, t->serialise_trace_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->serialise_trace_fn, LLVMCCallConv);
   LLVMSetLinkage(t->serialise_trace_fn, LLVMExternalLinkage);
 
@@ -1017,7 +1017,7 @@ void genprim_string_serialise(compile_t* c, reach_type_t* t)
   t->serialise_fn = codegen_addfun(c, genname_serialise(t->name),
     c->serialise_type);
 
-  codegen_startfun(c, t->serialise_fn, NULL, NULL);
+  codegen_startfun(c, t->serialise_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->serialise_fn, LLVMCCallConv);
   LLVMSetLinkage(t->serialise_fn, LLVMExternalLinkage);
 
@@ -1086,7 +1086,7 @@ void genprim_string_deserialise(compile_t* c, reach_type_t* t)
   t->deserialise_fn = codegen_addfun(c, genname_deserialise(t->name),
     c->trace_type);
 
-  codegen_startfun(c, t->deserialise_fn, NULL, NULL);
+  codegen_startfun(c, t->deserialise_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->deserialise_fn, LLVMCCallConv);
   LLVMSetLinkage(t->deserialise_fn, LLVMExternalLinkage);
 
@@ -1863,7 +1863,7 @@ static void make_cpuid(compile_t* c)
     LLVMTypeRef f_type = LLVMFunctionType(r_type, &c->i32, 1, false);
     LLVMValueRef fun = codegen_addfun(c, "internal.x86.cpuid", f_type);
     LLVMSetFunctionCallConv(fun, LLVMCCallConv);
-    codegen_startfun(c, fun, NULL, NULL);
+    codegen_startfun(c, fun, NULL, NULL, false);
 
     LLVMValueRef cpuid = LLVMConstInlineAsm(f_type,
       "cpuid", "={ax},={bx},={cx},={dx},{ax}", false, false);
@@ -1892,7 +1892,7 @@ static void make_rdtscp(compile_t* c)
     f_type = LLVMFunctionType(c->i64, &i32_ptr, 1, false);
     LLVMValueRef fun = codegen_addfun(c, "internal.x86.rdtscp", f_type);
     LLVMSetFunctionCallConv(fun, LLVMCCallConv);
-    codegen_startfun(c, fun, NULL, NULL);
+    codegen_startfun(c, fun, NULL, NULL, false);
 
     // Cast i32* to i8* and call the intrinsic.
     LLVMValueRef arg = LLVMGetParam(fun, 0);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -290,7 +290,11 @@ static trace_t trace_type_isect(ast_t* type)
 
 static trace_t trace_type_nominal(ast_t* type)
 {
-  switch(ast_id((ast_t*)ast_data(type)))
+  if(is_bare(type))
+    return TRACE_PRIMITIVE;
+
+  ast_t* def = (ast_t*)ast_data(type);
+  switch(ast_id(def))
   {
     case TK_INTERFACE:
     case TK_TRAIT:

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -226,13 +226,20 @@ static bool make_opaque_struct(compile_t* c, reach_type_t* t)
         }
       }
 
-      t->structure = LLVMStructCreateNamed(c->context, t->name);
-      t->structure_ptr = LLVMPointerType(t->structure, 0);
+      if(t->bare_method == NULL)
+      {
+        t->structure = LLVMStructCreateNamed(c->context, t->name);
+        t->structure_ptr = LLVMPointerType(t->structure, 0);
 
-      if(t->primitive != NULL)
-        t->use_type = t->primitive;
-      else
-        t->use_type = t->structure_ptr;
+        if(t->primitive != NULL)
+          t->use_type = t->primitive;
+        else
+          t->use_type = t->structure_ptr;
+      } else {
+        t->structure = c->void_ptr;
+        t->structure_ptr = c->void_ptr;
+        t->use_type = c->void_ptr;
+      }
 
       return true;
     }
@@ -362,13 +369,12 @@ static void make_global_instance(compile_t* c, reach_type_t* t)
   if(t->primitive != NULL)
     return;
 
+  if(t->bare_method != NULL)
+    return;
+
   // Create a unique global instance.
   const char* inst_name = genname_instance(t->name);
-
-  LLVMValueRef args[1];
-  args[0] = t->desc;
-  LLVMValueRef value = LLVMConstNamedStruct(t->structure, args, 1);
-
+  LLVMValueRef value = LLVMConstNamedStruct(t->structure, &t->desc, 1);
   t->instance = LLVMAddGlobal(c->module, t->structure, inst_name);
   LLVMSetInitializer(t->instance, value);
   LLVMSetGlobalConstant(t->instance, true);
@@ -386,7 +392,7 @@ static void make_dispatch(compile_t* c, reach_type_t* t)
   t->dispatch_fn = codegen_addfun(c, dispatch_name, c->dispatch_type);
   LLVMSetFunctionCallConv(t->dispatch_fn, LLVMCCallConv);
   LLVMSetLinkage(t->dispatch_fn, LLVMExternalLinkage);
-  codegen_startfun(c, t->dispatch_fn, NULL, NULL);
+  codegen_startfun(c, t->dispatch_fn, NULL, NULL, false);
 
   LLVMBasicBlockRef unreachable = codegen_block(c, "unreachable");
 
@@ -410,6 +416,9 @@ static bool make_struct(compile_t* c, reach_type_t* t)
   LLVMTypeRef type;
   int extra = 0;
   bool packed = false;
+
+  if(t->bare_method != NULL)
+    return true;
 
   switch(t->underlying)
   {
@@ -674,7 +683,7 @@ static bool make_trace(compile_t* c, reach_type_t* t)
   }
 
   // Generate the trace function.
-  codegen_startfun(c, t->trace_fn, NULL, NULL);
+  codegen_startfun(c, t->trace_fn, NULL, NULL, false);
   LLVMSetFunctionCallConv(t->trace_fn, LLVMCCallConv);
   LLVMSetLinkage(t->trace_fn, LLVMExternalLinkage);
 

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -197,15 +197,20 @@ static bool type_access(pass_opt_t* opt, ast_t** astp)
       ret = method_access(opt, ast, find);
       break;
 
+    case TK_FUN:
+      if(ast_id(ast_child(find)) == TK_AT)
+      {
+        ret = method_access(opt, ast, find);
+        break;
+      }
+      //fallthrough
+
     case TK_FVAR:
     case TK_FLET:
     case TK_EMBED:
     case TK_BE:
-    case TK_FUN:
     {
       // Make this a lookup on a default constructed object.
-      ast_free_unattached(find);
-
       if(!strcmp(ast_name(right), "create"))
       {
         ast_error(opt->check.errors, right,
@@ -230,7 +235,8 @@ static bool type_access(pass_opt_t* opt, ast_t** astp)
       if(!expr_call(opt, &call))
         return false;
 
-      return expr_dot(opt, astp);
+      ret = expr_dot(opt, astp);
+      break;
     }
 
     default:

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -229,6 +229,8 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
   {
     case TK_QUALIFY:
     case TK_DOT:
+    case TK_TILDE:
+    case TK_CHAIN:
       break;
 
     case TK_CALL:
@@ -517,27 +519,77 @@ bool expr_addressof(pass_opt_t* opt, ast_t* ast)
       return false;
   }
 
-  // Set the type to Pointer[ast_type(expr)]. Set to Pointer[None] for function
-  // pointers.
   ast_t* expr_type = ast_type(expr);
 
   if(is_typecheck_error(expr_type))
     return false;
 
+  ast_t* type = NULL;
+
   switch(ast_id(expr))
   {
     case TK_FUNREF:
     case TK_BEREF:
+    {
       if(!method_check_type_params(opt, &expr))
         return false;
 
-      expr_type = type_builtin(opt, ast, "None");
-      break;
+      AST_GET_CHILDREN(expr, receiver, method);
+      if(ast_id(receiver) == ast_id(expr))
+        AST_GET_CHILDREN_NO_DECL(receiver, receiver, method);
 
-    default: {}
+      ast_t* def = lookup(opt, expr, ast_type(receiver), ast_name(method));
+      pony_assert((ast_id(def) == TK_FUN) || (ast_id(def) == TK_BE));
+
+      // Set the type to a bare lambda type equivalent to the function type.
+      bool bare = ast_id(ast_child(def)) == TK_AT;
+      ast_t* params = ast_childidx(def, 3);
+      ast_t* result = ast_sibling(params);
+      ast_t* partial = ast_sibling(result);
+
+      ast_t* lambdatype_params = ast_from(params, TK_NONE);
+      if(ast_id(params) != TK_NONE)
+      {
+        ast_setid(lambdatype_params, TK_PARAMS);
+        ast_t* param = ast_child(params);
+        while(param != NULL)
+        {
+          ast_t* param_type = ast_childidx(param, 1);
+          ast_append(lambdatype_params, param_type);
+          param = ast_sibling(param);
+        }
+      }
+
+      if(!bare)
+      {
+        ast_setid(lambdatype_params, TK_PARAMS);
+        ast_t* receiver_type = ast_type(receiver);
+        ast_add(lambdatype_params, receiver_type);
+      }
+
+      BUILD_NO_DECL(type, expr_type,
+        NODE(TK_BARELAMBDATYPE,
+          NONE // receiver cap
+          NONE // id
+          NONE // type parameters
+          TREE(lambdatype_params)
+          TREE(result)
+          TREE(partial)
+          NODE(TK_VAL) // object cap
+          NONE)); // object cap mod
+
+      if(!ast_passes_subtree(&type, opt, PASS_EXPR))
+        return false;
+
+      break;
+    }
+
+    default:
+      // Set the type to Pointer[ast_type(expr)].
+      type = type_pointer_to(opt, expr_type);
+      break;
   }
 
-  ast_t* type = type_pointer_to(opt, expr_type);
   ast_settype(ast, type);
   return true;
 }
@@ -572,6 +624,13 @@ bool expr_digestof(pass_opt_t* opt, ast_t* ast)
 
 bool expr_this(pass_opt_t* opt, ast_t* ast)
 {
+  if(ast_id(ast_child(opt->check.frame->method)) == TK_AT)
+  {
+    ast_error(opt->check.errors, ast,
+      "can't reference 'this' in a bare method");
+    return false;
+  }
+
   if(opt->check.frame->def_arg != NULL)
   {
     ast_error(opt->check.errors, ast,

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -289,6 +289,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
       break;
 
     case TK_LAMBDA:
+    case TK_BARELAMBDA:
       if(!expr_lambda(options, astp))
         return AST_FATAL;
       break;

--- a/src/libponyc/pass/import.c
+++ b/src/libponyc/pass/import.c
@@ -10,10 +10,11 @@ static bool import_use(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast != NULL);
 
-  ast_t* import = (ast_t*)ast_data(ast);
-
-  if(import == NULL) // Nothing to import.
+  if(!ast_checkflag(ast, AST_FLAG_IMPORT))
     return true;
+
+  ast_t* import = (ast_t*)ast_data(ast);
+  pony_assert(import != NULL);
 
   ast_t* module = ast_parent(ast);
   pony_assert(ast_id(module) == TK_MODULE);

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -88,12 +88,15 @@ bool use_package(ast_t* ast, const char* path, ast_t* name,
     return false;
   }
 
-  if(name != NULL && ast_id(name) == TK_ID) // We have an alias
-    return set_scope(options, ast, name, package, false);
-
   // Store the package so we can import it later without having to look it up
   // again
   ast_setdata(ast, (void*)package);
+
+  if(name != NULL && ast_id(name) == TK_ID) // We have an alias
+    return set_scope(options, ast, name, package, false);
+
+  ast_setflag(ast, AST_FLAG_IMPORT);
+
   return true;
 }
 

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -62,36 +62,38 @@ static const permission_def_t _entity_def[DEF_ENTITY_COUNT] =
 };
 
 #define METHOD_CAP 0
-#define METHOD_RETURN 2
-#define METHOD_ERROR 4
-#define METHOD_BODY 6
+#define METHOD_BARE 2
+#define METHOD_RETURN 4
+#define METHOD_ERROR 6
+#define METHOD_BODY 8
 
 // Index by DEF_<ENTITY> + DEF_<METHOD>
 static const permission_def_t _method_def[DEF_METHOD_COUNT] =
 { //                           cap
-  //                           | return
-  //                           | | error
-  //                           | | | body
-  { "actor function",         "X X X Y" },
-  { "class function",         "X X X Y" },
-  { "struct function",        "X X X Y" },
-  { "primitive function",     "X X X Y" },
-  { "trait function",         "X X X X" },
-  { "interface function",     "X X X X" },
+  //                           | bare
+  //                           | | return
+  //                           | | | error
+  //                           | | | | body
+  { "actor function",         "X X X X Y" },
+  { "class function",         "X X X X Y" },
+  { "struct function",        "X X X X Y" },
+  { "primitive function",     "X X X X Y" },
+  { "trait function",         "X X X X X" },
+  { "interface function",     "X X X X X" },
   { "type alias function",    NULL },
-  { "actor behaviour",        "N N N Y" },
+  { "actor behaviour",        "N N N N Y" },
   { "class behaviour",        NULL },
   { "struct behaviour",       NULL },
   { "primitive behaviour",    NULL },
-  { "trait behaviour",        "N N N X" },
-  { "interface behaviour",    "N N N X" },
+  { "trait behaviour",        "N N N N X" },
+  { "interface behaviour",    "N N N N X" },
   { "type alias behaviour",   NULL },
-  { "actor constructor",      "N N N Y" },
-  { "class constructor",      "X N X Y" },
-  { "struct constructor",     "X N X Y" },
-  { "primitive constructor",  "N N X Y" },
-  { "trait constructor",      "X N X N" },
-  { "interface constructor",  "X N X N" },
+  { "actor constructor",      "N N N N Y" },
+  { "class constructor",      "X N N X Y" },
+  { "struct constructor",     "X N N X Y" },
+  { "primitive constructor",  "N N N X Y" },
+  { "trait constructor",      "X N N X N" },
+  { "interface constructor",  "X N N X N" },
   { "type alias constructor", NULL }
 };
 
@@ -238,8 +240,15 @@ static bool check_method(pass_opt_t* opt, ast_t* ast, int method_def_index)
   AST_GET_CHILDREN(ast, cap, id, type_params, params, return_type,
     error, body, docstring);
 
-  if(!check_permission(opt, def, METHOD_CAP, cap, "receiver capability", cap))
+  if(ast_id(cap) == TK_AT)
+  {
+    if(!check_permission(opt, def, METHOD_BARE, cap, "bareness", cap))
+      r = false;
+  } else if(!check_permission(opt, def, METHOD_CAP, cap, "receiver capability",
+    cap))
+  {
     r = false;
+  }
 
   if(!check_id_method(opt, id))
     r = false;
@@ -926,6 +935,41 @@ static ast_result_t syntax_lambda_capture(pass_opt_t* opt, ast_t* ast)
 }
 
 
+static ast_result_t syntax_barelambdatype(pass_opt_t* opt, ast_t* ast)
+{
+  AST_GET_CHILDREN(ast, fun_cap, id, typeparams, params, return_type, partial,
+    obj_cap, obj_mod);
+
+  if(ast_id(fun_cap) != TK_NONE)
+  {
+    ast_error(opt->check.errors, fun_cap, "a bare lambda cannot specify a "
+      "receiver capability");
+    return AST_ERROR;
+  }
+
+  if(ast_id(typeparams) != TK_NONE)
+  {
+    ast_error(opt->check.errors, typeparams, "a bare lambda cannot specify "
+      "type parameters");
+    return AST_ERROR;
+  }
+
+  switch(ast_id(obj_cap))
+  {
+    case TK_VAL:
+    case TK_NONE:
+      break;
+
+    default:
+      ast_error(opt->check.errors, obj_cap, "a bare lambda can only have a "
+        "'val' capability");
+      return AST_ERROR;
+  }
+
+  return AST_OK;
+}
+
+
 static ast_result_t syntax_compile_intrinsic(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* parent = ast_parent(ast);
@@ -1006,9 +1050,17 @@ static ast_result_t syntax_compile_error(pass_opt_t* opt, ast_t* ast)
 
 static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
 {
-  pony_assert(ast_id(ast) == TK_LAMBDA);
+  pony_assert((ast_id(ast) == TK_LAMBDA) || (ast_id(ast) == TK_BARELAMBDA));
   AST_GET_CHILDREN(ast, receiver_cap, name, t_params, params, captures,
     ret_type, raises, body, reference_cap);
+
+  if(ast_id(reference_cap) == TK_QUESTION)
+  {
+    ast_error(opt->check.errors, ast,
+      "lambda ... end is no longer supported syntax; use {...} for lambdas");
+    return AST_ERROR;
+  }
+
   switch(ast_id(ret_type))
   {
     case TK_ISO:
@@ -1027,6 +1079,42 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
     default: {}
   }
 
+  if(ast_id(ast) == TK_BARELAMBDA)
+  {
+    if(ast_id(receiver_cap) != TK_NONE)
+    {
+      ast_error(opt->check.errors, receiver_cap, "a bare lambda cannot specify "
+        "a receiver capability");
+      return AST_ERROR;
+    }
+
+    if(ast_id(t_params) != TK_NONE)
+    {
+      ast_error(opt->check.errors, t_params, "a bare lambda cannot specify "
+        "type parameters");
+      return AST_ERROR;
+    }
+
+    if(ast_id(captures) != TK_NONE)
+    {
+      ast_error(opt->check.errors, captures, "a bare lambda cannot specify "
+        "captures");
+      return AST_ERROR;
+    }
+
+    switch(ast_id(reference_cap))
+    {
+      case TK_VAL:
+      case TK_NONE:
+        break;
+
+      default:
+        ast_error(opt->check.errors, reference_cap, "a bare lambda can only "
+          "have a 'val' capability");
+        return AST_ERROR;
+    }
+  }
+
   ast_t* capture = ast_child(captures);
   while(capture != NULL)
   {
@@ -1037,13 +1125,6 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
       return AST_ERROR;
     }
     capture = ast_sibling(capture);
-  }
-
-  if(ast_id(reference_cap) == TK_QUESTION)
-  {
-    ast_error(opt->check.errors, ast,
-      "lambda ... end is no longer supported syntax; use {...} for lambdas");
-    return AST_ERROR;
   }
 
   return AST_OK;
@@ -1098,6 +1179,7 @@ static ast_result_t syntax_cap(pass_opt_t* opt, ast_t* ast)
     case TK_ARROW:
     case TK_OBJECT:
     case TK_LAMBDA:
+    case TK_BARELAMBDA:
     case TK_RECOVER:
     case TK_CONSUME:
     case TK_FUN:
@@ -1111,6 +1193,7 @@ static ast_result_t syntax_cap(pass_opt_t* opt, ast_t* ast)
     case TK_CLASS:
     case TK_ACTOR:
     case TK_LAMBDATYPE:
+    case TK_BARELAMBDATYPE:
       return AST_OK;
 
     default: {}
@@ -1130,6 +1213,30 @@ static ast_result_t syntax_cap_set(pass_opt_t* opt, ast_t* ast)
     ast_error(opt->check.errors, ast,
       "a capability set can only appear in a type constraint");
     return AST_ERROR;
+  }
+
+  return AST_OK;
+}
+
+
+static ast_result_t syntax_annotation(pass_opt_t* opt, ast_t* ast)
+{
+  pony_assert(ast_id(ast) == TK_ANNOTATION);
+
+  const char ponyint[] = "ponyint";
+
+  for(ast_t* child = ast_child(ast); child != NULL; child = ast_sibling(child))
+  {
+    const char* str = ast_name(child);
+    if(strlen(str) < (sizeof ponyint - 1))
+      continue;
+
+    if(strncmp(str, ponyint, sizeof ponyint - 1) == 0)
+    {
+      ast_error(opt->check.errors, child,
+        "annotations starting with 'ponyint' are reserved for internal use");
+      return AST_ERROR;
+    }
   }
 
   return AST_OK;
@@ -1176,6 +1283,8 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_USE:        r = syntax_use(options, ast); break;
     case TK_LAMBDACAPTURE:
                         r = syntax_lambda_capture(options, ast); break;
+    case TK_BARELAMBDATYPE:
+                        r = syntax_barelambdatype(options, ast); break;
     case TK_COMPILE_INTRINSIC:
                         r = syntax_compile_intrinsic(options, ast); break;
     case TK_COMPILE_ERROR:
@@ -1188,7 +1297,8 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_BOX:
     case TK_TAG:        r = syntax_cap(options, ast); break;
 
-    case TK_LAMBDA:     r = syntax_lambda(options, ast); break;
+    case TK_LAMBDA:
+    case TK_BARELAMBDA: r = syntax_lambda(options, ast); break;
     case TK_OBJECT:     r = syntax_object(options, ast); break;
     case TK_FUN:        r = syntax_fun(options, ast); break;
 
@@ -1198,11 +1308,13 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
     case TK_CAP_ALIAS:
     case TK_CAP_ANY:    r = syntax_cap_set(options, ast); break;
 
+    case TK_ANNOTATION: r = syntax_annotation(options, ast); break;
+
     case TK_VALUEFORMALARG:
     case TK_VALUEFORMALPARAM:
       ast_error(options->check.errors, ast,
         "Value formal parameters not yet supported");
-      ast_error_continue(options->check.errors, ast_parent(ast), 
+      ast_error_continue(options->check.errors, ast_parent(ast),
         "Note that many functions including array indexing use the apply "
         "method rather than square brackets");
       r = AST_ERROR;
@@ -1226,6 +1338,10 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
       "Use a semi colon to separate expressions on the same line");
     r = AST_ERROR;
   }
+
+  ast_t* annotation = ast_annotation(ast);
+  if(annotation != NULL)
+    r = ast_visit(&annotation, pass_syntax, NULL, options, PASS_SYNTAX);
 
   return r;
 }

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -1013,6 +1013,38 @@ bool package_allow_ffi(typecheck_t* t)
 }
 
 
+const char* package_alias_from_id(ast_t* module, const char* id)
+{
+  pony_assert(ast_id(module) == TK_MODULE);
+
+  const char* strtab_id = stringtab(id);
+
+  ast_t* use = ast_child(module);
+  while(ast_id(use) == TK_USE)
+  {
+    ast_t* imported = (ast_t*)ast_data(use);
+    pony_assert((imported != NULL) && (ast_id(imported) == TK_PACKAGE));
+
+    package_t* pkg = (package_t*)ast_data(imported);
+    pony_assert(pkg != NULL);
+
+    if(pkg->id == strtab_id)
+    {
+      ast_t* alias = ast_child(use);
+      if(ast_id(alias) == TK_NONE)
+        return NULL;
+
+      return ast_name(alias);
+    }
+
+    use = ast_sibling(use);
+  }
+
+  pony_assert(false);
+  return NULL;
+}
+
+
 void package_done()
 {
   strlist_free(search);

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -128,6 +128,18 @@ const char* package_hygienic_id(typecheck_t* t);
 bool package_allow_ffi(typecheck_t* t);
 
 /**
+ * Gets the alias of a package in the current module from the hygienic ID
+ * of that package. Returns NULL if there is no alias. The package must have
+ * been imported in the current module.
+ *
+ * For example, if the package `foo` was imported in the current module with
+ * `use foo = "foo"` and the global ID of the package "foo" is `$2`, the call
+ * `package_alias_from_id(current_module_ast, "$2")` will return the string
+ * "foo".
+ */
+const char* package_alias_from_id(ast_t* module, const char* id);
+
+/**
  * Cleans up the list of search directories.
  */
 void package_done();

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -93,6 +93,7 @@ struct reach_type_t
   token_id underlying;
 
   reach_method_names_t methods;
+  reach_method_t* bare_method;
   reach_type_cache_t subtypes;
   uint32_t type_id;
   size_t abi_size;

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -218,6 +218,7 @@ ast_t* alias(ast_t* type)
     }
 
     case TK_LAMBDATYPE:
+    case TK_BARELAMBDATYPE:
     case TK_FUNTYPE:
     case TK_INFERTYPE:
     case TK_ERRORTYPE:

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -261,6 +261,17 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
 
   while(typeparam != NULL)
   {
+    if(is_bare(typearg))
+    {
+      if(report_errors)
+      {
+        ast_error(opt->check.errors, typearg,
+          "a bare type cannot be used as a type argument");
+      }
+
+      return false;
+    }
+
     switch(ast_id(typearg))
     {
       case TK_NOMINAL:

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -50,6 +50,8 @@ bool is_concrete(ast_t* type);
 
 bool is_known(ast_t* type);
 
+bool is_bare(ast_t* type);
+
 bool is_entity(ast_t* type, token_id entity);
 
 bool contains_dontcare(ast_t* ast);

--- a/test/libponyc/annotations.cc
+++ b/test/libponyc/annotations.cc
@@ -112,7 +112,7 @@ TEST_F(AnnotationsTest, AnnotationsArePresent)
 
   ast = ast_annotation(ast);
 
-  ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_BACKSLASH));
+  ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ANNOTATION));
   ast = ast_child(ast);
 
   ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ID) &&
@@ -178,4 +178,12 @@ TEST_F(AnnotationsTest, AnnotateLambda)
   ast = lookup_in(ast, "apply");
 
   ASSERT_TRUE(ast_has_annotation(ast, "a"));
+}
+
+TEST_F(AnnotationsTest, InternalAnnotation)
+{
+  const char* src =
+    "actor \\ponyint\\ A\n";
+
+  TEST_ERROR(src);
 }

--- a/test/libponyc/bare.cc
+++ b/test/libponyc/bare.cc
@@ -1,0 +1,478 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <type/subtype.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "ir"))
+
+#define TEST_ERROR(src, err) \
+  { const char* errs[] = {err, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
+
+class BareTest : public PassTest
+{};
+
+
+TEST_F(BareTest, BareMethod_Simple)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo()\n"
+
+    "  fun @foo() =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(BareTest, BareMethod_ConstructorCantBeBare)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo()\n"
+
+    "  new @foo() =>\n"
+    "    None";
+
+  TEST_ERROR(src, "actor constructor cannot specify bareness");
+}
+
+
+TEST_F(BareTest, BareMethod_BehaviourCantBeBare)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo()\n"
+
+    "  be @foo() =>\n"
+    "    None";
+
+  TEST_ERROR(src, "actor behaviour cannot specify bareness");
+}
+
+
+TEST_F(BareTest, BareMethod_ThisReference)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo()\n"
+
+    "  fun @foo() =>\n"
+    "    this";
+
+  TEST_ERROR(src, "can't reference 'this' in a bare method");
+}
+
+
+TEST_F(BareTest, BareMethod_Subtyping)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun @foo()\n"
+
+    "interface I2\n"
+    "  fun bar()\n"
+
+    "interface I3\n"
+    "  fun foo()\n"
+
+    "interface I4\n"
+    "  fun @bar()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let t = this\n"
+    "    let o = object ref\n"
+    "      fun foo() => None\n"
+    "      fun @bar() => None\n"
+    "    end\n"
+
+    "    let i1: I1 = t\n"
+    "    let i2: I2 = t\n"
+    "    let i3: I3 = o\n"
+    "    let i4: I4 = o\n"
+
+    "  fun @foo() =>\n"
+    "    None\n"
+
+    "  fun bar() =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+
+  ASSERT_FALSE(is_subtype(type_of("t"), type_of("i3"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t"), type_of("i4"), NULL, &opt));
+}
+
+
+TEST_F(BareTest, BareMethod_AbstractCall)
+{
+  const char* src =
+    "interface I\n"
+    "  fun @foo()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    I.foo()";
+
+  TEST_ERROR(src, "a bare method cannot be called on an abstract type "
+    "reference");
+}
+
+
+TEST_F(BareTest, BareMethod_PartialApplicationYieldsBareLambda)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = this~foo()\n"
+
+    "  fun @foo() => None";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(BareTest, BareMethod_PartialApplicationArguments)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = this~foo(42)\n"
+
+    "  fun @foo(x: U8) => None";
+
+  TEST_ERROR(src, "the partial application of a bare method cannot take "
+    "arguments");
+}
+
+
+TEST_F(BareTest, BareMethod_PartialApplicationTypeArguments)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = this~foo()\n"
+
+    "  fun @foo[A](x: U8) => None";
+
+  TEST_ERROR(src, "not enough type arguments");
+}
+
+
+TEST_F(BareTest, BareLambda_Simple)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = @{() => None}";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(BareTest, BareLambda_IsVal)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} val = @{() => None}";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(BareTest, BareLambda_CantChangeCap)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = @{() => None} ref";
+
+  TEST_ERROR(src, "a bare lambda can only have a 'val' capability");
+}
+
+
+TEST_F(BareTest, BareLambda_TypeCantChangeCap)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} ref = @{() => None}";
+
+  TEST_ERROR(src, "a bare lambda can only have a 'val' capability");
+}
+
+
+TEST_F(BareTest, BareLambda_Captures)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = @{()(env) => None}";
+
+  TEST_ERROR(src, "a bare lambda cannot specify captures");
+}
+
+
+TEST_F(BareTest, BareLambda_ThisReference)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = @{() => this}";
+
+  TEST_ERROR(src, "can't reference 'this' in a bare method");
+}
+
+
+TEST_F(BareTest, BareLambda_ReceiverCap)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: @{()} = @{ref() => None}";
+
+  TEST_ERROR(src, "a bare lambda cannot specify a receiver capability");
+}
+
+
+TEST_F(BareTest, BareLambda_TypeParameters)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x = @{[A]() => None}";
+
+  TEST_ERROR(src, "a bare lambda cannot specify type parameters");
+}
+
+
+TEST_F(BareTest, BareLambda_TypeTypeParameters)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    var x: @{[A]()}";
+
+  TEST_ERROR(src, "a bare lambda cannot specify type parameters");
+}
+
+
+TEST_F(BareTest, BareLambda_Subtyping)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let concrete_bare = @{() => None}\n"
+    "    let concrete_nonbare = {() => None}\n"
+    "    let interface_bare: @{()} = concrete_bare\n"
+    "    let interface_nonbare: {()} val = concrete_nonbare";
+
+  TEST_COMPILE(src);
+
+  ASSERT_FALSE(is_subtype(type_of("concrete_bare"),
+    type_of("interface_nonbare"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("concrete_nonbare"),
+    type_of("interface_bare"), NULL, &opt));
+}
+
+
+TEST_F(BareTest, BareType_Union)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: (U8 | @{()}) = @{() => None}";
+
+  TEST_ERROR(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(BareTest, BareType_Match)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: (U8 | @{()}) = 42\n"
+    "    match a\n"
+    "    | let _: U8 => None\n"
+    "    end";
+
+  TEST_ERROR(src, "a match operand cannot have a bare type");
+}
+
+
+TEST_F(BareTest, BareType_TypeArgument)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[@{()}]()\n"
+
+    "  fun foo[A]() => None";
+
+  TEST_ERROR(src, "a bare type cannot be used as a type argument");
+}
+
+
+TEST_F(BareTest, Codegen_BareFunctionCall)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo(42)\n"
+
+    "  fun @foo(x: USize) =>\n"
+    "    if x == 42 then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(BareTest, Codegen_BareLambdaCall)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let lbd = @{(x: USize) =>\n"
+    "      if x == 42 then\n"
+    "        @pony_exitcode[None](I32(1))\n"
+    "      end\n"
+    "    }\n"
+    "    lbd(42)";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+extern "C"
+{
+
+typedef void (*baretest_callback_fn)(size_t value);
+
+EXPORT_SYMBOL void baretest_callback(baretest_callback_fn cb, size_t value)
+{
+  cb(value);
+}
+
+}
+
+
+TEST_F(BareTest, Codegen_BareFunctionCallbackAddressof)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @baretest_callback[None](addressof foo, USize(42))\n"
+
+    "  fun @foo(x: USize) =>\n"
+    "    if x == 42 then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(BareTest, Codegen_BareFunctionCallbackPartialApplication)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @baretest_callback[None](this~foo(), USize(42))\n"
+
+    "  fun @foo(x: USize) =>\n"
+    "    if x == 42 then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(BareTest, Codegen_BareLambdaCallback)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let lbd = @{(x: USize) =>\n"
+    "      if x == 42 then\n"
+    "        @pony_exitcode[None](I32(1))\n"
+    "      end\n"
+    "    }\n"
+    "    @baretest_callback[None](lbd, USize(42))";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
+TEST_F(BareTest, BareFunction_TyperefCallNoConstructorCall)
+{
+  const char* src =
+    "class C\n"
+    "  new create() => @pony_exitcode[None](I32(1))\n"
+    "  fun @foo() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    C.foo()";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 0);
+}
+
+
+TEST_F(BareTest, BareFunction_ReceiverSideEffect)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo().bar()\n"
+
+    "  fun foo(): Main => \n"
+    "    @pony_exitcode[None](I32(1))\n"
+    "    this\n"
+
+    "  fun @bar() => None";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 #include <platform.h>
 
-#include <reach/reach.h>
-
 #include "util.h"
 
 


### PR DESCRIPTION
These new language constructs can be used in FFI interoperation with C libraries that use function pointers as callbacks.

Closes #1690.