### PR TITLE
Remove extra commit in release script

### DIFF
--- a/release.bash
+++ b/release.bash
@@ -85,9 +85,4 @@ git merge "release-$version"
 # check if user wants to continue
 check_for_commit_and_push
 
-# commit changelog and push to master
-git add CHANGELOG.md
-git commit -m "Add unreleased section to CHANGELOG post $version release prep
-
-[skip ci]"
 git push origin master


### PR DESCRIPTION
The changelog is now modified once rather than twice. This caused
the script to exit by failing to commit changes that didn't happen.

closes #1860
[skip ci]