### PR TITLE
Add unreleased section after release prep

### DIFF
--- a/release.bash
+++ b/release.bash
@@ -81,6 +81,7 @@ git push origin "$version"
 # update CHANGELOG for new entries
 git checkout master
 git merge "release-$version"
+changelog-tool unreleased CHANGELOG.md -e
 
 # check if user wants to continue
 check_for_commit_and_push


### PR DESCRIPTION
This will now work as intended with the most recent changes to the changelog tool.

closes #1860 
[skip-ci]