### PR TITLE
Don’t consider type arguments inside a constraint as constraints.

### DIFF
--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -84,6 +84,8 @@ bool frame_push(typecheck_t* t, ast_t* ast)
       t->frame->method_type = NULL;
       t->frame->ffi_type = NULL;
       t->frame->local_type = NULL;
+      t->frame->constraint = NULL;
+      t->frame->iftype_constraint = NULL;
       break;
 
     case TK_CASE:

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -447,9 +447,8 @@ static ast_result_t syntax_arrow(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, left, right);
 
-  if(((opt->check.frame->constraint != NULL) ||
-    (opt->check.frame->iftype_constraint != NULL)) &&
-    (opt->check.frame->method == NULL))
+  if((opt->check.frame->constraint != NULL) ||
+    (opt->check.frame->iftype_constraint != NULL))
   {
     ast_error(opt->check.errors, ast,
       "arrow types can't be used as type constraints");

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -401,7 +401,7 @@ TEST_F(BadPonyTest, TypeParamArrowClass)
   TEST_COMPILE(src);
 }
 
-TEST_F(BadPonyTest, ArrowTypeParamInConstraint)
+TEST_F(BadPonyTest, ArrowTypeParamInTypeConstraint)
 {
   // From issue #1694
   const char* src =
@@ -410,6 +410,17 @@ TEST_F(BadPonyTest, ArrowTypeParamInConstraint)
 
   TEST_ERRORS_2(src,
     "arrow types can't be used as type constraints",
+    "arrow types can't be used as type constraints");
+}
+
+TEST_F(BadPonyTest, ArrowTypeParamInMethodConstraint)
+{
+  // From issue #1809
+  const char* src =
+    "class Foo\n"
+    "  fun foo[X: box->Y, Y](x: X) => None";
+
+  TEST_ERRORS_1(src,
     "arrow types can't be used as type constraints");
 }
 
@@ -477,4 +488,14 @@ TEST_F(BadPonyTest, ThisDotFieldRef)
     "    this.f = 1\n";
 
   TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, CapSetInConstraintTypeParam)
+{
+  const char* src =
+    "class A[X]\n"
+    "class B[X: A[Any #read]]\n";
+
+  TEST_ERRORS_1(src,
+    "a capability set can only appear in a type constraint");
 }


### PR DESCRIPTION
This better reflects their use. It allows arrow types and tuples to
appear in these positions. It also denies capability sets from appearing
in these positions. These have an extremely limited use, and are unlikely
to be used by anyone.

As a side effect, the default capability in these positions now
corresponds to the type default, rather than #any.

Also properly deny arrow types from appearing in constraints,
fixing #1809.

-----

I'd like to add some positive tests for arrows and tuples in these positions,
but I'm not sure where they fit.