### PR TITLE
Reify unconstrained type parameters in iftype conditions correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Disable mcx16 on aarch64 ([PR #1856](https://github.com/ponylang/ponyc/pull/1856))
 - Fix assert failure on explicit reference to `this` in constructor. (issue #1865) ([PR #1867](https://github.com/ponylang/ponyc/pull/1867))
+- Compiler crash when using unconstrained type parameters in an `iftype` condition (issue #1689)
 
 
 ### Added

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -24,7 +24,8 @@ static void reify_typeparamref(pass_opt_t* opt, ast_t** astp, ast_t* typeparam, 
   {
     if(ast_name(ref_name) == ast_name(param_name))
     {
-      if(!is_subtype(ref_constraint, param_constraint, NULL, opt))
+      if((ast_id(param_constraint) != TK_TYPEPARAMREF) &&
+        !is_subtype(ref_constraint, param_constraint, NULL, opt))
         return;
     } else {
       return;

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -229,3 +229,22 @@ TEST_F(IftypeTest, Codegen_False)
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 1);
 }
+
+
+TEST_F(IftypeTest, UnconstrainedTypeparam)
+{
+  const char* src =
+    "class C\n"
+    "  fun tag c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A](x: A) =>\n"
+    "    iftype A <: C then\n"
+    "      x.c()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Closes #1869.

The changelog entry is included in the PR since the commit message/PR title would be too technical for a changelog entry.