### PR TITLE
Compiler error instead of crash for invalid this-dot reference in a trait.

### DIFF
--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -441,6 +441,20 @@ static bool refer_this_dot(pass_opt_t* opt, ast_t* ast)
   ast_t* def = ast_get(ast, name, &status);
   ast_setdata(ast, (void*)def);
 
+  // If nothing was found, we fail, but also try to suggest an alternate name.
+  if(def == NULL)
+  {
+    const char* alt_name = suggest_alt_name(ast, name);
+
+    if(alt_name == NULL)
+      ast_error(opt->check.errors, ast, "can't find declaration of '%s'", name);
+    else
+      ast_error(opt->check.errors, ast,
+        "can't find declaration of '%s', did you mean '%s'?", name, alt_name);
+
+    return false;
+  }
+
   switch(ast_id(def))
   {
     case TK_FVAR:

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -514,3 +514,17 @@ TEST_F(BadPonyTest, MatchCasePatternConstructorTooFewArguments)
 
   TEST_ERRORS_1(src, "not enough arguments");
 }
+
+TEST_F(BadPonyTest, ThisDotWhereDefIsntInTheTrait)
+{
+  // From issue #1878
+  const char* src =
+    "trait T\n"
+    "  fun foo(): USize => this.u\n"
+
+    "class C is T\n"
+    "  var u: USize = 0\n";
+
+  TEST_ERRORS_1(src,
+    "can't find declaration of 'u'");
+}


### PR DESCRIPTION
Resolves #1878.