### PR TITLE
Compiler error instead of crash for too few args to constructor in case pattern.

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -156,6 +156,10 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 
   // Structural equality, pattern.eq(match).
   ast_t* pattern_type = ast_type(pattern);
+
+  if(is_typecheck_error(pattern_type))
+    return NULL;
+
   ast_t* fun = lookup(opt, pattern, pattern_type, stringtab("eq"));
 
   if(fun == NULL)

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -499,3 +499,18 @@ TEST_F(BadPonyTest, CapSetInConstraintTypeParam)
   TEST_ERRORS_1(src,
     "a capability set can only appear in a type constraint");
 }
+
+TEST_F(BadPonyTest, MatchCasePatternConstructorTooFewArguments)
+{
+  const char* src =
+    "class C\n"
+    "  new create(key: String) => None\n"
+
+    "primitive Foo\n"
+    "  fun apply(c: (C | None)) =>\n"
+    "    match c\n"
+    "    | C => None\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "not enough arguments");
+}


### PR DESCRIPTION
This compiler crash occurs when the user accidentally used the non-`let` format of a case pattern, where the case is trying to instantiate the type and match with `eq` instead of matching on type,, *and* there was an earlier error when type-checking the case pattern expression (for example, too few arguments, as we have here..

```pony
class C
  new create(key: String) => None

actor Main
  new create(env: Env) =>
    let c: (C | None) = None
    match c
    | C => None
    end
```

This crash was originally encountered by @funkybob in #1878, but it was found to be a completely different bug.
