### PR TITLE
Don't emit internal methods to library headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Compiler error instead of crash for invalid this-dot reference in a trait. ([PR #1879](https://github.com/ponylang/ponyc/pull/1879))
 - Compiler error instead of crash for too few args to constructor in case pattern. ([PR #1880](https://github.com/ponylang/ponyc/pull/1880))
 - Pony runtime hashmap bug that resulted in issues [#1483](https://github.com/ponylang/ponyc/issues/1483), [#1781](https://github.com/ponylang/ponyc/issues/1781), and [#1872](https://github.com/ponylang/ponyc/issues/1872). ([PR #1886](https://github.com/ponylang/ponyc/pull/1886)) 
+- Compiler crash when compiling to a library (issue #1881)
+
 
 ### Added
 

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -123,8 +123,12 @@ static void print_params(compile_t* c, printbuf_t* buf, ast_t* params)
 
 static bool emit_fun(ast_t* fun)
 {
-  // No signature for any function with a tuple argument or return value, or
-  // any function that might raise an error.
+  // No signature for any internal function (i.e. functions without an AST), or
+  // any function with a tuple argument or return value, or any function that
+  // might raise an error.
+  if(fun == NULL)
+    return false;
+
   AST_GET_CHILDREN(fun, cap, id, typeparams, params, result, can_error);
 
   if(ast_id(can_error) == TK_QUESTION)


### PR DESCRIPTION
Closes #1881.

I've made a manual changelog entry to better reflect the problem fixed on the user's side.