### PR TITLE
Exhaustive match (RFC 40)

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -1044,6 +1044,9 @@ void ast_inheritstatus(ast_t* dst, ast_t* src)
 
 void ast_inheritbranch(ast_t* dst, ast_t* src)
 {
+  pony_assert(dst->symtab != NULL);
+  pony_assert(src->symtab != NULL);
+
   symtab_inherit_branch(dst->symtab, src->symtab);
 }
 

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -5,11 +5,125 @@
 #include "../type/matchtype.h"
 #include "../type/alias.h"
 #include "../type/lookup.h"
+#include "../ast/astbuild.h"
 #include "../ast/stringtab.h"
 #include "../ast/id.h"
+#include "../expr/control.h"
+#include "../expr/reference.h"
 #include "../pass/expr.h"
 #include "../pass/pass.h"
 #include "ponyassert.h"
+
+
+static bool case_expr_matches_type_alone(pass_opt_t* opt, ast_t* case_expr)
+{
+  switch(ast_id(case_expr))
+  {
+    // These pattern forms match on type alone.
+    case TK_MATCH_CAPTURE:
+    case TK_MATCH_DONTCARE:
+      return true;
+
+    // This pattern form matches any type (ignoring the value entirely).
+    case TK_DONTCAREREF:
+      return true;
+
+    // Tuple patterns may contain a mixture of matching on types and values,
+    // so we only return true if *all* elements return true.
+    case TK_TUPLE:
+      for(ast_t* e = ast_child(case_expr); e != NULL; e = ast_sibling(e))
+        if(!case_expr_matches_type_alone(opt, ast_childlast(e)))
+          return false;
+      return true;
+
+    default: {}
+  }
+
+  // For all other case expression forms, we're matching on structural equality,
+  // which can only be supported for primitives that use the default eq method,
+  // and are not "special" builtin primitives that can have more than one
+  // distinct value (machine words).
+  // A value expression pattern that meets these conditions may be treated as
+  // matching on type alone, because the value is a singleton for that type
+  // and the result of the eq method will always be true if the type matches.
+
+  ast_t* type = ast_type(case_expr);
+
+  if(is_typecheck_error(type))
+    return false;
+
+  ast_t* def = (ast_t*)ast_data(type);
+  pony_assert(def != NULL);
+
+  if((ast_id(def) != TK_PRIMITIVE) || is_machine_word(type))
+    return false;
+
+  ast_t* eq_def = ast_get(def, stringtab("eq"), NULL);
+  pony_assert(ast_id(eq_def) == TK_FUN);
+
+  ast_t* eq_params = ast_childidx(eq_def, 3);
+  pony_assert(ast_id(eq_params) == TK_PARAMS);
+  pony_assert(ast_childcount(eq_params) == 1);
+
+  ast_t* eq_body = ast_childidx(eq_def, 6);
+  pony_assert(ast_id(eq_body) == TK_SEQ);
+
+  // Expect to see a body containing the following AST:
+  //   (is (this) (paramref (id that)))
+  // where `that` is the name of the first parameter.
+  if((ast_childcount(eq_body) != 1) ||
+    (ast_id(ast_child(eq_body)) != TK_IS) ||
+    (ast_id(ast_child(ast_child(eq_body))) != TK_THIS) ||
+    (ast_id(ast_childidx(ast_child(eq_body), 1)) != TK_PARAMREF))
+    return false;
+
+  const char* that_param_name =
+    ast_name(ast_child(ast_childidx(ast_child(eq_body), 1)));
+
+  if(ast_name(ast_child(ast_child(eq_params))) != that_param_name)
+    return false;
+
+  return true;
+}
+
+static bool is_match_exhaustive(pass_opt_t* opt, ast_t* expr_type, ast_t* cases)
+{
+  pony_assert(expr_type != NULL);
+  pony_assert(ast_id(cases) == TK_CASES);
+
+  // Construct a union of all pattern types that count toward exhaustive match.
+  ast_t* cases_union_type = ast_from(cases, TK_UNIONTYPE);
+
+  for(ast_t* c = ast_child(cases); c != NULL; c = ast_sibling(c))
+  {
+    AST_GET_CHILDREN(c, case_expr, guard, case_body);
+    ast_t* pattern_type = ast_type(c);
+
+    // Only cases with no guard clause can count toward exhaustive match,
+    // because the truth of a guard clause can't be statically evaluated.
+    // So, for the purposes of exhaustive match, we ignore those cases.
+    if(ast_id(guard) != TK_NONE)
+      continue;
+
+    // Only cases that match on type alone can count toward exhaustive match,
+    // because matches on structural equality can't be statically evaluated.
+    // So, for the purposes of exhaustive match, we ignore those cases.
+    if(!case_expr_matches_type_alone(opt, case_expr))
+      continue;
+
+    // It counts, so add this pattern type to our running union type.
+    ast_add(cases_union_type, pattern_type);
+  }
+
+  // If our cases types union is a supertype of the match expression type,
+  // then the match must be exhaustive, because all types are covered by cases.
+  bool ret = (ast_childcount(cases_union_type) > 0) &&
+    is_subtype(expr_type, cases_union_type, NULL, opt);
+
+  ast_free_unattached(cases_union_type);
+
+  return ret;
+}
 
 bool expr_match(pass_opt_t* opt, ast_t* ast)
 {
@@ -40,7 +154,27 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
     type = control_type_add_branch(opt, type, cases);
   }
 
-  if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
+  // If we have no else clause, and the match is not found to be exhaustive,
+  // we must generate an implicit else clause that returns None as the value.
+  if((ast_id(else_clause) == TK_NONE) &&
+    !is_match_exhaustive(opt, expr_type, cases))
+  {
+    ast_scope(else_clause);
+    ast_setid(else_clause, TK_SEQ);
+
+    BUILD(ref, else_clause,
+      NODE(TK_TYPEREF,
+        NONE
+        ID("None")
+        NONE));
+    ast_add(else_clause, ref);
+
+    if(!expr_typeref(opt, &ref) || !expr_seq(opt, else_clause))
+      return false;
+  }
+
+  if((ast_id(else_clause) != TK_NONE) &&
+    !ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(else_clause)))
       return false;

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1059,7 +1059,8 @@ static bool refer_match(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     branch_count++;
-    ast_inheritbranch(ast, else_clause);
+    if(ast_id(else_clause) != TK_NONE)
+      ast_inheritbranch(ast, else_clause);
   }
 
   // If all branches jump away with no value, then we do too.

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1227,7 +1227,6 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_FUN:              return sugar_fun(options, ast);
     case TK_RETURN:           return sugar_return(options, ast);
     case TK_IF:
-    case TK_MATCH:
     case TK_WHILE:
     case TK_REPEAT:           return sugar_else(ast, 2);
     case TK_IFTYPE:           return sugar_else(ast, 3);

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -946,8 +946,6 @@ TEST_F(SugarTest, MatchWithNoElse)
     "  fun box f(): U32 val =>\n"
     "    match(x)\n"
     "    |1 => 2\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -1881,8 +1879,6 @@ TEST_F(SugarTest, CaseFunction)
     "    | 0 => 0\n"
     "    | 1 => 1\n"
     "    | $let y: U64 => fib(y.sub(2)).add(fib(y.sub(1)))\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -1912,8 +1908,6 @@ TEST_F(SugarTest, CaseFunctionPlusOtherFun)
     "    | 0 => 0\n"
     "    | 1 => 1\n"
     "    | $let y: U64 => fib(y.sub(2)).add(fib(y.sub(1)))\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -1942,8 +1936,6 @@ TEST_F(SugarTest, CaseFunction2InOneClassPlusOtherFun)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let x: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end\n"
     "  fun box bar(y: U32): (None | U32 | U32) =>\n"
     "    $3(consume y)\n"
@@ -1951,8 +1943,6 @@ TEST_F(SugarTest, CaseFunction2InOneClassPlusOtherFun)
     "    match consume $4\n"
     "    | 0 => 0\n"
     "    | $let y: U32 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -1979,8 +1969,6 @@ TEST_F(SugarTest, CaseFunctionParamNamedTwice)
     "    | 0 => 0\n"
     "    | $let y: U64 => 1\n"
     "    | $let y: U64 => 2\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2005,8 +1993,6 @@ TEST_F(SugarTest, CaseFunction2Params)
     "    match (consume $2, consume $3)\n"
     "    | (0, 0) => 0\n"
     "    | ($let a: U64, $let b: U32) => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2031,8 +2017,6 @@ TEST_F(SugarTest, CaseFunctionParamTypeUnion)
     "    match consume $2\n"
     "    | $let a: U32 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2057,8 +2041,6 @@ TEST_F(SugarTest, CaseFunctionReturnUnion)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2083,8 +2065,6 @@ TEST_F(SugarTest, CaseFunctionCap)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2121,8 +2101,6 @@ TEST_F(SugarTest, CaseFunctionOneErrors)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2147,8 +2125,6 @@ TEST_F(SugarTest, CaseFunctionAllError)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2247,8 +2223,6 @@ TEST_F(SugarTest, CaseFunctionDontCare)
     "    | (0, _) => 0\n"
     "    | ($let a: U64, $let b: U32) => 1\n"
     "    | (_, _) => 2\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2273,8 +2247,6 @@ TEST_F(SugarTest, CaseFunctionGuard)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 if a.gt(3) => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2299,8 +2271,6 @@ TEST_F(SugarTest, CaseFunctionDefaultValue)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2337,8 +2307,6 @@ TEST_F(SugarTest, CaseBehaviour)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end\n"
     "    None";
 
@@ -2388,8 +2356,6 @@ TEST_F(SugarTest, CaseFunctionTypeParam)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2414,8 +2380,6 @@ TEST_F(SugarTest, CaseFunction2TypeParams)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2440,8 +2404,6 @@ TEST_F(SugarTest, CaseFunctionTypeParamConstraint)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2466,8 +2428,6 @@ TEST_F(SugarTest, CaseFunctionTypeParamConstraintIntersect)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);
@@ -2517,8 +2477,6 @@ TEST_F(SugarTest, CaseFunctionDefaultTypeParam)
     "    match consume $2\n"
     "    | 0 => 0\n"
     "    | $let a: U64 => 1\n"
-    "    else\n"
-    "      None\n"
     "    end";
 
   TEST_EQUIV(short_form, full_form);


### PR DESCRIPTION
This PR implements [RFC 40](https://github.com/ponylang/rfcs/blob/master/text/0040-exhaustive-match.md).

Construct a union type of all cases in the match that match on type alone,
and if this union is a supertype of the match expression type,
then the match is exhaustive so we don't need to sugar the `else None`.

As a result, users won't have to deal with the type system possibility of a `None`
result for match blocks which can easily be shown to never reach the `else` case.

Closes #1772.