### PR TITLE
Initial CLI package implementation w/ tests and updated examples

### DIFF
--- a/examples/commandline/main.pony
+++ b/examples/commandline/main.pony
@@ -27,7 +27,7 @@ actor Main
     let cs = CommandSpec.parent("chat", "A sample chat program", [
       OptionSpec.bool("admin", "Chat as admin" where default' = false)
       OptionSpec.string("name", "Your name" where short' = 'n')
-      OptionSpec.f64("volume", "Chat volume" where short' = 'v')
+      OptionSpec.i64("volume", "Chat volume" where short' = 'v')
     ], [
       CommandSpec.leaf("say", "Say something", Array[OptionSpec](), [
         ArgSpec.string("words", "The words to say")

--- a/examples/commandline/main.pony
+++ b/examples/commandline/main.pony
@@ -1,0 +1,48 @@
+use "cli"
+
+actor Main
+  new create(env: Env) =>
+    try
+      let cs = cli_spec()
+      let cmd = match CommandParser(cs).parse(env.args)
+        | let c: Command => c
+        | let ch: CommandHelp =>
+            ch.print_help(OutWriter(env.out))
+            return
+        | let se: SyntaxError =>
+            env.out.print(se.string())
+            return
+        else
+          error  // can't happen
+        end
+
+        // cmd is a valid Command, now use it.
+
+    end
+
+  fun tag cli_spec(): CommandSpec box ? =>
+    """
+    Builds and returns the spec for a sample chat client's CLI.
+    """
+    let cs = CommandSpec.parent("chat", "A sample chat program", [
+      OptionSpec.bool("admin", "Chat as admin" where default' = false)
+      OptionSpec.string("name", "Your name" where short' = 'n')
+      OptionSpec.f64("volume", "Chat volume" where short' = 'v')
+    ], [
+      CommandSpec.leaf("say", "Say something", Array[OptionSpec](), [
+        ArgSpec.string("words", "The words to say")
+      ])
+      CommandSpec.leaf("emote", "Send an emotion", [
+        OptionSpec.f64("speed", "Emote play speed" where default' = F64(1.0))
+      ], [
+        ArgSpec.string("emotion", "Emote to send")
+      ])
+      CommandSpec.parent("config", "Configuration commands", Array[OptionSpec](), [
+        CommandSpec.leaf("server", "Server configuration", Array[OptionSpec](), [
+          ArgSpec.string("address", "Address of the server")
+        ])
+      ])
+    ])
+    cs.add_help()
+    cs
+

--- a/examples/commandline/main.pony
+++ b/examples/commandline/main.pony
@@ -3,17 +3,17 @@ use "cli"
 actor Main
   new create(env: Env) =>
     try
-      let cs = cli_spec()
-      let cmd = match CommandParser(cs).parse(env.args)
+      let cmd =
+        match CommandParser(cli_spec()).parse(env.args, env.vars())
         | let c: Command => c
         | let ch: CommandHelp =>
             ch.print_help(OutWriter(env.out))
+            env.exitcode(0)
             return
         | let se: SyntaxError =>
             env.out.print(se.string())
+            env.exitcode(1)
             return
-        else
-          error  // can't happen
         end
 
         // cmd is a valid Command, now use it.
@@ -45,4 +45,3 @@ actor Main
     ])
     cs.add_help()
     cs
-

--- a/examples/commandline/main.pony
+++ b/examples/commandline/main.pony
@@ -7,7 +7,7 @@ actor Main
         match CommandParser(cli_spec()).parse(env.args, env.vars())
         | let c: Command => c
         | let ch: CommandHelp =>
-            ch.print_help(OutWriter(env.out))
+            ch.print_help(env.out)
             env.exitcode(0)
             return
         | let se: SyntaxError =>

--- a/examples/gups_basic/main.pony
+++ b/examples/gups_basic/main.pony
@@ -21,13 +21,13 @@ class val Config
       match CommandParser(cs).parse(env.args, env.vars())
       | let c: Command => c
       | let ch: CommandHelp =>
-          ch.print_help(OutWriter(env.out))
-          env.exitcode(0)
-          error
+        ch.print_help(env.out)
+        env.exitcode(0)
+        error
       | let se: SyntaxError =>
-          env.out.print(se.string())
-          env.exitcode(1)
-          error
+        env.out.print(se.string())
+        env.exitcode(1)
+        error
       end
     logtable = cmd.option("table").i64().usize()
     iterate = cmd.option("iterate").i64().usize()

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -20,13 +20,13 @@ class val Config
       match CommandParser(cs).parse(env.args, env.vars())
       | let c: Command => c
       | let ch: CommandHelp =>
-          ch.print_help(OutWriter(env.out))
-          env.exitcode(0)
-          error
+        ch.print_help(env.out)
+        env.exitcode(0)
+        error
       | let se: SyntaxError =>
-          env.out.print(se.string())
-          env.exitcode(1)
-          error
+        env.out.print(se.string())
+        env.exitcode(1)
+        error
       end
     logtable = cmd.option("table").i64().usize()
     iterate = cmd.option("iterate").i64().usize()

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -1,88 +1,81 @@
-use "options"
-use "time"
+use "cli"
 use "collections"
+use "time"
 
-class Config
-  var logtable: USize = 20
-  var iterate: USize = 10000
-  var logchunk: USize = 10
-  var logactors: USize = 2
+class val Config
+  let logtable: USize
+  let iterate: USize
+  let logchunk: USize
+  let logactors: USize
 
-  fun ref apply(env: Env): Bool =>
-    var options = Options(env.args)
-
-    options
-      .add("table", "t", I64Argument)
-      .add("iterate", "i", I64Argument)
-      .add("chunk", "c", I64Argument)
-      .add("actors", "a", I64Argument)
-
-    for option in options do
-      match option
-      | ("table", let arg: I64) => logtable = arg.usize()
-      | ("iterate", let arg: I64) => iterate = arg.usize()
-      | ("chunk", let arg: I64) => logchunk = arg.usize()
-      | ("actors", let arg: I64) => logactors = arg.usize()
-      | let err: ParseError =>
-        err.report(env.out)
-        env.out.print(
-          """
-          gups_opt [OPTIONS]
-            --table     N   log2 of the total table size. Defaults to 20.
-            --iterate   N   number of iterations. Defaults to 10000.
-            --chunk     N   log2 of the chunk size. Defaults to 10.
-            --actors    N   log2 of the actor count. Defaults to 2.
-          """
-          )
-        return false
+  new val create(env: Env) ? =>
+    let cs = CommandSpec.parent("gups_opt", "", [
+      OptionSpec.i64("table", "Log2 of the total table size."
+        where default' = 20)
+      OptionSpec.i64("iterate", "Number of iterations." where default' = 10000)
+      OptionSpec.i64("chunk", "Log2 of the chunk size." where default' = 10)
+      OptionSpec.i64("actors", "Log2 of the actor count." where default' = 2)
+    ]).>add_help()
+    let cmd =
+      match CommandParser(cs).parse(env.args, env.vars())
+      | let c: Command => c
+      | let ch: CommandHelp =>
+          ch.print_help(OutWriter(env.out))
+          env.exitcode(0)
+          error
+      | let se: SyntaxError =>
+          env.out.print(se.string())
+          env.exitcode(1)
+          error
       end
-    end
+    logtable = cmd.option("table").i64().usize()
+    iterate = cmd.option("iterate").i64().usize()
+    logchunk = cmd.option("chunk").i64().usize()
+    logactors = cmd.option("actors").i64().usize()
 
     env.out.print(
       "logtable: " + logtable.string() +
       "\niterate: " + iterate.string() +
       "\nlogchunk: " + logchunk.string() +
-      "\nlogactors: " + logactors.string()
-      )
-    true
+      "\nlogactors: " + logactors.string())
 
 actor Main
   let _env: Env
-  let _config: Config = Config
-
   var _updates: USize = 0
   var _confirm: USize = 0
-  let _start: U64
+  var _start: U64 = 0
   var _actors: Array[Updater] val
 
   new create(env: Env) =>
     _env = env
 
-    if _config(env) then
-      let actor_count = 1 << _config.logactors
-      let loglocal = _config.logtable - _config.logactors
-      let chunk_size = 1 << _config.logchunk
-      let chunk_iterate = chunk_size * _config.iterate
-
-      _updates = chunk_iterate * actor_count
-      _confirm = actor_count
-
-      var updaters = recover Array[Updater](actor_count) end
-
-      for i in Range(0, actor_count) do
-        updaters.push(Updater(this, actor_count, i, loglocal, chunk_size,
-          chunk_iterate * i))
-      end
-
-      _actors = consume updaters
-      _start = Time.nanos()
-
-      for a in _actors.values() do
-        a.start(_actors, _config.iterate)
-      end
+    let c = try
+      Config(env)
     else
-      _start = 0
       _actors = recover Array[Updater] end
+      return
+    end
+
+    let actor_count = 1 << c.logactors
+    let loglocal = c.logtable - c.logactors
+    let chunk_size = 1 << c.logchunk
+    let chunk_iterate = chunk_size * c.iterate
+
+    _updates = chunk_iterate * actor_count
+    _confirm = actor_count
+
+    var updaters = recover Array[Updater](actor_count) end
+
+    for i in Range(0, actor_count) do
+      updaters.push(Updater(this, actor_count, i, loglocal, chunk_size,
+        chunk_iterate * i))
+    end
+
+    _actors = consume updaters
+    _start = Time.nanos()
+
+    for a in _actors.values() do
+      a.start(_actors, c.iterate)
     end
 
   be done() =>

--- a/examples/httpget/httpget.pony
+++ b/examples/httpget/httpget.pony
@@ -27,13 +27,13 @@ class val Config
       match CommandParser(cs).parse(env.args, env.vars())
       | let c: Command => c
       | let ch: CommandHelp =>
-          ch.print_help(OutWriter(env.out))
-          env.exitcode(0)
-          error
+        ch.print_help(env.out)
+        env.exitcode(0)
+        error
       | let se: SyntaxError =>
-          env.out.print(se.string())
-          env.exitcode(1)
-          error
+        env.out.print(se.string())
+        env.exitcode(1)
+        error
       end
     user = cmd.option("user").string()
     pass = cmd.option("pass").string()

--- a/examples/main.pony
+++ b/examples/main.pony
@@ -13,6 +13,7 @@ use "ponytest"
 // Commented packages are broken at the moment. We have to fix them and
 // then keep the tests green.
 use ex_circle = "circle"
+use ex_commandline = "commandline"
 use ex_counter = "counter"
 use ex_echo = "echo"
 // use ex_ffi_struct = "ffi-struct"

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -100,13 +100,13 @@ class val Config
       match CommandParser(cs).parse(env.args, env.vars())
       | let c: Command => c
       | let ch: CommandHelp =>
-          ch.print_help(OutWriter(env.out))
-          env.exitcode(0)
-          error
+        ch.print_help(env.out)
+        env.exitcode(0)
+        error
       | let se: SyntaxError =>
-          env.out.print(se.string())
-          env.exitcode(1)
-          error
+        env.out.print(se.string())
+        env.exitcode(1)
+        error
       end
     iterations = cmd.option("iterations").i64().usize()
     limit = cmd.option("limit").f64().f32()

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -1,6 +1,6 @@
-use "files"
-use "options"
+use "cli"
 use "collections"
+use "files"
 
 actor Worker
   new mandelbrot(main: Main, x: USize, y: USize, width: USize,
@@ -65,28 +65,92 @@ actor Worker
       main.draw(x * (width >> 3), consume view)
     end
 
+class val Config
+  let iterations: USize
+  let limit: F32
+  let chunks: USize
+  let width: USize
+  let outpath: (FilePath | None)
+
+  new val create(env: Env) ? =>
+    let cs = CommandSpec.parent("gups_opt",
+      """
+      The binary output can be converted to a PNG with the following command
+      (ImageMagick Tools required):
+
+        convert <output> PNG:<output>.png""",
+      [
+      OptionSpec.i64("iterations",
+        "Maximum amount of iterations to be done for each pixel."
+        where short' = 'i', default' = 50)
+      OptionSpec.f64("limit",
+        "Square of the limit that pixels need to exceed in order to escape from the Mandelbrot set."
+        where short' = 'l', default' = 4.0)
+      OptionSpec.i64("chunks",
+        "Maximum line count of chunks the image should be divided into for divide & conquer processing."
+        where short' = 'c', default' = 16)
+      OptionSpec.i64("width",
+        "Lateral length of the resulting mandelbrot image."
+        where short' = 'w', default' = 16000)
+      OptionSpec.string("output",
+        "File to write the output to."
+        where short' = 'o', default' = "")
+    ]).>add_help()
+    let cmd =
+      match CommandParser(cs).parse(env.args, env.vars())
+      | let c: Command => c
+      | let ch: CommandHelp =>
+          ch.print_help(OutWriter(env.out))
+          env.exitcode(0)
+          error
+      | let se: SyntaxError =>
+          env.out.print(se.string())
+          env.exitcode(1)
+          error
+      end
+    iterations = cmd.option("iterations").i64().usize()
+    limit = cmd.option("limit").f64().f32()
+    chunks = cmd.option("chunks").i64().usize()
+    width = cmd.option("width").i64().usize()
+    outpath =
+      try
+        FilePath(env.root as AmbientAuth, cmd.option("output").string())
+      else
+        None
+      end
+
+  new val none() =>
+    iterations = 0
+    limit = 0
+    chunks = 0
+    width = 0
+    outpath = None
+
 actor Main
-  var iterations: USize = 50
-  var limit: F32 = 4.0
-  var chunks: USize = 16
-  var width: USize = 16000
+  let c: Config
+  var outfile: (File | None) = None
   var actors: USize = 0
   var header: USize = 0
   var real: Array[F32] val = recover Array[F32] end
   var imaginary: Array[F32] val = recover Array[F32] end
-  var outfile: (File | None) = None
 
   new create(env: Env) =>
     try
-      arguments(env)
+      c = Config(env)
+      outfile =
+        match c.outpath
+        | let fp: FilePath => File(fp)
+        else
+          None
+        end
 
-      let length = width
-      let recip_width = 2.0 / width.f32()
+      let length = c.width
+      let recip_width = 2.0 / c.width.f32()
 
       var r = recover Array[F32](length) end
       var i = recover Array[F32](length) end
 
-      for j in Range(0, width) do
+      for j in Range(0, c.width) do
         r.push((recip_width * j.f32()) - 1.5)
         i.push((recip_width * j.f32()) - 1.0)
       end
@@ -97,6 +161,7 @@ actor Main
       spawn_actors()
       create_outfile()
     end
+    c = Config.none()
 
   be draw(offset: USize, pixels: Array[U8] val) =>
     match outfile
@@ -111,79 +176,24 @@ actor Main
   fun ref create_outfile() =>
     match outfile
     | let f: File =>
-      f.print("P4\n " + width.string() + " " + width.string() + "\n")
+      f.print("P4\n " + c.width.string() + " " + c.width.string() + "\n")
       header = f.size()
-      f.set_length((width * (width >> 3)) + header)
+      f.set_length((c.width * (c.width >> 3)) + header)
     end
 
   fun ref spawn_actors() =>
-    actors = ((width + (chunks - 1)) / chunks)
-
-    var rest = width % chunks
-
-    if rest == 0 then rest = chunks end
+    actors = ((c.width + (c.chunks - 1)) / c.chunks)
+    var rest = c.width % c.chunks
+    if rest == 0 then rest = c.chunks end
 
     var x: USize = 0
     var y: USize = 0
 
     for i in Range(0, actors - 1) do
-      x = i * chunks
-      y = x + chunks
-      Worker.mandelbrot(this, x, y, width, iterations, limit, real, imaginary)
+      x = i * c.chunks
+      y = x + c.chunks
+      Worker.mandelbrot(this, x, y, c.width, c.iterations, c.limit, real, imaginary)
     end
 
-    Worker.mandelbrot(this, y, y + rest, width, iterations, limit, real,
+    Worker.mandelbrot(this, y, y + rest, c.width, c.iterations, c.limit, real,
       imaginary)
-
-  fun ref arguments(env: Env) ? =>
-    let options = Options(env.args)
-
-    options
-      .add("iterations", "i", I64Argument)
-      .add("limit", "l", F64Argument)
-      .add("chunks", "c", I64Argument)
-      .add("width", "w", I64Argument)
-      .add("output", "o", StringArgument)
-
-    for option in options do
-      match option
-      | ("iterations", let arg: I64) => iterations = arg.usize()
-      | ("limit", let arg: F64) => limit = arg.f32()
-      | ("chunks", let arg: I64) => chunks = arg.usize()
-      | ("width", let arg: I64) => width = arg.usize()
-      | ("output", let arg: String) =>
-        outfile = try File(FilePath(env.root as AmbientAuth, arg)) end
-      | let err: ParseError => err.report(env.out) ; usage(env) ; error
-      end
-    end
-
-  fun tag usage(env: Env) =>
-    env.out.print(
-      """
-      mandelbrot [OPTIONS]
-
-      The binary output can be converted to a BMP with the following command
-      (ImageMagick Tools required):
-
-        convert <output> JPEG:<output>.jpg
-
-      Available options:
-
-      --iterations, -i  Maximum amount of iterations to be done for each pixel.
-                        Defaults to 50.
-
-      --limit, -l       Square of the limit that pixels need to exceed in order
-                        to escape from the Mandelbrot set.
-                        Defaults to 4.0.
-
-      --chunks, -c      Maximum line count of chunks the image should be
-                        divided into for divide & conquer processing.
-                        Defaults to 16.
-
-      --width, -w       Lateral length of the resulting mandelbrot image.
-                        Defaults to 16000.
-
-      --output, -o      File to write the output to.
-
-      """
-      )

--- a/examples/printargs/printargs.pony
+++ b/examples/printargs/printargs.pony
@@ -1,4 +1,4 @@
-use "options"
+use "cli"
 
 actor Main
   new create(env: Env) =>

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -212,16 +212,16 @@ actor Main
 
     let cmd =
       match CommandParser(cs).parse(_env.args, _env.vars())
-        | let c: Command => c
-        | let ch: CommandHelp =>
-            ch.print_help(OutWriter(_env.out))
-            _env.exitcode(0)
-            return
-        | let se: SyntaxError =>
-            _env.out.print(se.string())
-            _env.exitcode(1)
-            return
-        end
+      | let c: Command => c
+      | let ch: CommandHelp =>
+        ch.print_help(_env.out)
+        _env.exitcode(0)
+        return
+      | let se: SyntaxError =>
+        _env.out.print(se.string())
+        _env.exitcode(1)
+        return
+      end
 
     var punk: Bool = cmd.option("punk").bool()
     var perf: U64 = cmd.option("bench").i64().u64()

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -1,47 +1,44 @@
 """
+An actor behaviour is intended for short lived finite interactions executed
+asynchronously. Sometimes it is useful to be able to naturally code behaviours
+of short lived finite signals punctuating over a longer lived (but finite)
+behaviour. In actor implementations that do not feature causal messaging this is
+fairly natural and idiomatic. But in pony, without yield, this is impossible.
 
-An actor behaviour is intended for short lived finite interactions
-executed asynchronously. Sometimes it is useful to be able to naturally
-code behaviours of short lived finite signals punctuating over a
-longer lived ( but finite ) behaviour. In actor implementations that
-do not feature causal messaging this is fairly natural and idiomatic.
-But in pony, without yield, this is impossible.
+The causal messaging guarantee, and asynchronous execution means that the
+messages enqueued in the actor's mailbox will never be scheduled for execution
+if the receiving behaviour is infinite, which it can be in the worst case (bad
+code).
 
-The causal messaging guarantee, and asynchronous execution means that
-the messages enqueued in the actor's mailbox will never be scheduled
-for execution if the receiving behaviour is infinite, which it can be
-in the worst case ( bad code ).
-
-By rediculo ad absurdum the simplest manifestation of this problem is
-a signaling behaviour, say a 'kill' message, that sets a flag to conditionally
+By rediculo ad absurdum the simplest manifestation of this problem is a
+signaling behaviour, say a 'kill' message, that sets a flag to conditionally
 stop accepting messages. The runtime will only detect an actor as GCable if it
-reaches quiescence *and* there are no pending messages waiting to be enqueued
-to the actor in its mailbox. But, our 'kill' message can never proceed
-from the mailbox as the currently active behaviour ( infinite ) never completes.
+reaches quiescence *and* there are no pending messages waiting to be enqueued to
+the actor in its mailbox. But, our 'kill' message can never proceed from the
+mailbox as the currently active behaviour (infinite) never completes.
 
 We call this the lonely pony problem. And, it can be solved in 0 lines of pony.
 
-Yield in pony is a simple clever trick. By transforming loops in long
-running behaviours to lazy tail-recursive behaviour calls composed,
-we can yield conditionally whilst preserving causal messaging guarantees,
-and enforcing at-most-once delivery semantics.
+Yield in pony is a simple clever trick. By transforming loops in long running
+behaviours to lazy tail-recursive behaviour calls composed, we can yield
+conditionally whilst preserving causal messaging guarantees, and enforcing at-
+most-once delivery semantics.
 
 The benefits of causal messaging, garbage collectible actors, and safe mutable
 actors far outweigh the small price manifested by the lonely pony problem. The
 solution, that uncovered the consume apply idiom and its application to enable
-interruptible behaviours that are easy to use are far more valuable at the cost to
-the actor implementor of only a few extra lines of code per behaviour to enable
-interruptible semantics with strong causal guarantees.
+interruptible behaviours that are easy to use are far more valuable at the cost
+to the actor implementor of only a few extra lines of code per behaviour to
+enable interruptible semantics with strong causal guarantees.
 
 In a nutshell, by avoiding for and while loops, and writing behaviours tail
-recursively, the ability to compose long-lived with short-lived behaviours
-is a builtin feature of pony.
-
+recursively, the ability to compose long-lived with short-lived behaviours is a
+builtin feature of pony.
 """
 
+use "cli"
 use "collections"
 use "debug"
-use "options"
 use "time"
 
 class StopWatch
@@ -82,7 +79,7 @@ actor LonelyPony
 
   be forever() =>
     """
-    The trivial case of a badly written behaviour that eats a scheduler ( forever )
+    The trivial case of a badly written behaviour that eats a scheduler (forever)
     """
     while _alive do
       if _debug then
@@ -188,73 +185,66 @@ actor Main
   new create(env: Env) =>
     _env = env
 
-    var punk: Bool = false
-    var lonely: Bool = false
-    var perf: U64 = 0
-    var debug: Bool = false
-    var err: Bool = false
+    let cs = try
+        CommandSpec.parent("yield",
+        """
+        Demonstrate use of the yield behaviour when writing tail recursive
+        behaviours in pony.
 
-    let options = Options(env.args) +
-      ("punk", "p", None) +
-      ("lonely", "l", None) +
-      ("bench", "b", I64Argument) +
-      ("debug", "d", None)
-      ("help", "h", None)
-
-    for opt in options do
-      match opt
-      | ("punk", None) => punk = true
-      | ("lonely", None) => lonely = true
-      | ("bench", let arg: I64) => perf = arg.u64()
-      | ("debug", None) => debug = true
-      else
-        err = true
-      end
+        By Default, the actor will run quiet and interruptibly.""",
+        [
+        OptionSpec.bool("punk",
+          "Run a punctuated stream demonstration."
+          where short' = 'p', default' = false)
+        OptionSpec.i64("bench",
+          "Run an instrumented behaviour to guesstimate overhead of non/interruptive."
+          where short' = 'b', default' = 0)
+        OptionSpec.bool("lonely",
+          "Run a non-interruptible behaviour with logic that runs forever."
+          where short' = 'l', default' = false)
+        OptionSpec.bool("debug", "Run in debug mode with verbose output."
+          where short' = 'd', default' = false)
+      ]).>add_help()
+    else
+      _env.exitcode(-1)  // some kind of coding error
+      return
     end
 
-    match err
+    let cmd =
+      match CommandParser(cs).parse(_env.args, _env.vars())
+        | let c: Command => c
+        | let ch: CommandHelp =>
+            ch.print_help(OutWriter(_env.out))
+            _env.exitcode(0)
+            return
+        | let se: SyntaxError =>
+            _env.out.print(se.string())
+            _env.exitcode(1)
+            return
+        end
+
+    var punk: Bool = cmd.option("punk").bool()
+    var perf: U64 = cmd.option("bench").i64().u64()
+    var lonely: Bool = cmd.option("lonely").bool()
+    var debug: Bool = cmd.option("lonely").bool()
+
+    match punk
     | true =>
-      usage()
-      return
+      PunkDemo(env)
+        .>loop()
+        .>inc().>inc().>inc()
+        .>dec().>dec().>dec()
+        .>inc().>dec()
+        .>kill()
     else
-      match punk
+      match perf > 0
       | true =>
-        PunkDemo(env)
-          .>loop()
-          .>inc().>inc().>inc()
-          .>dec().>dec().>dec()
-          .>inc().>dec()
-          .>kill()
+        InterruptiblePony(env,debug,perf).perf()
+        LonelyPony(env,debug,perf).perf()
       else
-        match perf > 0
-        | true =>
-          InterruptiblePony(env,debug,perf).perf()
-          LonelyPony(env,debug,perf).perf()
-        else
-          match lonely
-          | false => InterruptiblePony(env,debug).>forever().>kill()
-          | true => LonelyPony(env,debug).>forever().>kill()
-          end
+        match lonely
+        | false => InterruptiblePony(env,debug).>forever().>kill()
+        | true => LonelyPony(env,debug).>forever().>kill()
         end
       end
     end
-
-  fun usage() =>
-    _env.out.print(
-    """
-      yield ( --punk | --lonely | --bench NUM ) [ OPTIONS ]
-        --punk, -p      Run a punctuated stream demonstration
-        --lonely, -l    Run a non-interruptible behaviour with logic that runs forever
-        --bench, -b NUM Run an instrumented behaviour to guesstimate overhead of non/interruptive
-
-      OPTIONS
-        --debug, -d     Run in debug mode with verbose output
-        --help, -h      This help
-
-      DESCRIPTION
-
-      Demonstrate use of the yield behaviour when writing tail recursive
-      behaviours in pony.
-
-      By Default, the actor will run quiet and interruptibly.
-    """)

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -30,7 +30,7 @@ class iso _TestMinimal is UnitTest
         OptionSpec.bool("aflag", "")
     ])
 
-    h.assert_eq[String]("minimal", cs.name)
+    h.assert_eq[String]("minimal", cs.name())
 
     let args: Array[String] = ["ignored"; "--aflag=true"]
     let cmdErr = CommandParser(cs).parse(args)
@@ -38,7 +38,7 @@ class iso _TestMinimal is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("aflag").value as Bool)
+    h.assert_eq[Bool](true, cmd.option("aflag").bool())
 
 class iso _TestBadName is UnitTest
   fun name(): String => "ponycli/badname"
@@ -65,7 +65,7 @@ class iso _TestHyphenArg is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[String]("-", cmd.args("name").value as String)
+    h.assert_eq[String]("-", cmd.arg("name").string())
 
 class iso _TestBools is UnitTest
   fun name(): String => "ponycli/bools"
@@ -80,10 +80,10 @@ class iso _TestBools is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("aaa").value as Bool)
-    h.assert_eq[Bool](true, cmd.options("bbb").value as Bool)
-    h.assert_eq[Bool](true, cmd.options("ccc").value as Bool)
-    h.assert_eq[Bool](false, cmd.options("ddd").value as Bool)
+    h.assert_eq[Bool](true, cmd.option("aaa").bool())
+    h.assert_eq[Bool](true, cmd.option("bbb").bool())
+    h.assert_eq[Bool](true, cmd.option("ccc").bool())
+    h.assert_eq[Bool](false, cmd.option("ddd").bool())
 
 class iso _TestDefaults is UnitTest
   fun name(): String => "ponycli/defaults"
@@ -98,10 +98,10 @@ class iso _TestDefaults is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolo").value as Bool)
-    h.assert_eq[String]("astring", cmd.options("stringo").value as String)
-    h.assert_eq[I64](42, cmd.options("into").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolo").bool())
+    h.assert_eq[String]("astring", cmd.option("stringo").string())
+    h.assert_eq[I64](42, cmd.option("into").i64())
+    h.assert_eq[F64](42.0, cmd.option("floato").f64())
 
 class iso _TestShortsAdj is UnitTest
   fun name(): String => "ponycli/shorts_adjacent"
@@ -116,10 +116,10 @@ class iso _TestShortsAdj is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
-    h.assert_eq[String]("--", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolr").bool())
+    h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestShortsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"
@@ -134,10 +134,10 @@ class iso _TestShortsEq is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
-    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolr").bool())
+    h.assert_eq[String]("astring", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestShortsNext is UnitTest
   fun name(): String => "ponycli/shorts_next"
@@ -154,10 +154,10 @@ class iso _TestShortsNext is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
-    h.assert_eq[String]("--", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolr").bool())
+    h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestLongsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"
@@ -175,10 +175,10 @@ class iso _TestLongsEq is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
-    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolr").bool())
+    h.assert_eq[String]("astring", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestLongsNext is UnitTest
   fun name(): String => "ponycli/longs_next"
@@ -196,9 +196,9 @@ class iso _TestLongsNext is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[String]("--", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestEnvs is UnitTest
   fun name(): String => "ponycli/envs"
@@ -221,10 +221,10 @@ class iso _TestEnvs is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
-    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
-    h.assert_eq[I64](42, cmd.options("intr").value as I64)
-    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+    h.assert_eq[Bool](true, cmd.option("boolr").bool())
+    h.assert_eq[String]("astring", cmd.option("stringr").string())
+    h.assert_eq[I64](42, cmd.option("intr").i64())
+    h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
 class iso _TestOptionStop is UnitTest
   fun name(): String => "ponycli/option_stop"
@@ -243,8 +243,8 @@ class iso _TestOptionStop is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[String]("-f=1.0", cmd.args("words").value as String)
-    h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
+    h.assert_eq[String]("-f=1.0", cmd.arg("words").string())
+    h.assert_eq[F64](42.0, cmd.option("floato").f64())
 
 class iso _TestDuplicate is UnitTest
   fun name(): String => "ponycli/duplicate"
@@ -263,7 +263,7 @@ class iso _TestDuplicate is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[String]("newstring", cmd.options("stringr").value as String)
+    h.assert_eq[String]("newstring", cmd.option("stringr").string())
 
 class iso _TestChatMin is UnitTest
   fun name(): String => "ponycli/chat_min"
@@ -277,7 +277,7 @@ class iso _TestChatMin is UnitTest
     h.log("Parsed: " + cmdErr.string())
 
     let cmd = match cmdErr | let c: Command => c else error end
-    h.assert_eq[String]("chat", cs.name)
+    h.assert_eq[String]("chat", cs.name())
 
 class iso _TestChatAll is UnitTest
   fun name(): String => "ponycli/chat_all"
@@ -295,23 +295,23 @@ class iso _TestChatAll is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
 
-    h.assert_eq[String]("say", cmd.spec.name)
+    h.assert_eq[String]("say", cmd.spec().name())
 
-    let f1 = cmd.options("admin")
-    h.assert_eq[String]("admin", f1.spec.name)
-    h.assert_eq[Bool](true, f1.value as Bool)
+    let f1 = cmd.option("admin")
+    h.assert_eq[String]("admin", f1.spec().name())
+    h.assert_eq[Bool](true, f1.bool())
 
-    let f2 = cmd.options("name")
-    h.assert_eq[String]("name", f2.spec.name)
-    h.assert_eq[String]("carl", f2.value as String)
+    let f2 = cmd.option("name")
+    h.assert_eq[String]("name", f2.spec().name())
+    h.assert_eq[String]("carl", f2.string())
 
-    let f3 = cmd.options("volume")
-    h.assert_eq[String]("volume", f3.spec.name)
-    h.assert_eq[F64](80.0, f3.value as F64)
+    let f3 = cmd.option("volume")
+    h.assert_eq[String]("volume", f3.spec().name())
+    h.assert_eq[F64](80.0, f3.f64())
 
-    let a1 = cmd.args("words")
-    h.assert_eq[String]("words", a1.spec.name)
-    h.assert_eq[String]("hello", a1.value as String)
+    let a1 = cmd.arg("words")
+    h.assert_eq[String]("words", a1.spec().name())
+    h.assert_eq[String]("hello", a1.string())
 
 class iso _TestHelp is UnitTest
   fun name(): String => "ponycli/help"
@@ -352,7 +352,7 @@ primitive _Fixtures
       OptionSpec.i64("into" where short' = 'i', default' = I64(42))
       OptionSpec.f64("floatr" where short' = 'F')
       OptionSpec.f64("floato" where short' = 'f', default' = F64(42.0))
-    ],[
+    ], [
       ArgSpec.string("words" where default' = "hello")
     ])
 
@@ -364,13 +364,13 @@ primitive _Fixtures
       OptionSpec.bool("admin", "Chat as admin" where default' = false)
       OptionSpec.string("name", "Your name" where short' = 'n')
       OptionSpec.f64("volume", "Chat volume" where short' = 'v')
-    ],[
+    ], [
       CommandSpec.leaf("say", "Say something", Array[OptionSpec](), [
         ArgSpec.string("words", "The words to say")
       ])
       CommandSpec.leaf("emote", "Send an emotion", [
         OptionSpec.f64("speed", "Emote play speed" where default' = F64(1.0))
-      ],[
+      ], [
         ArgSpec.string("emotion", "Emote to send")
       ])
       CommandSpec.parent("config", "Configuration commands", Array[OptionSpec](), [

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -1,0 +1,399 @@
+use "ponytest"
+
+actor Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestMinimal)
+    test(_TestBadName)
+    test(_TestHyphenArg)
+    test(_TestBools)
+    test(_TestDefaults)
+    test(_TestShortsAdj)
+    test(_TestShortsEq)
+    test(_TestShortsNext)
+    test(_TestLongsEq)
+    test(_TestLongsNext)
+    test(_TestEnvs)
+    test(_TestOptionStop)
+    test(_TestDuplicate)
+    test(_TestChatMin)
+    test(_TestChatAll)
+    test(_TestHelp)
+
+
+class iso _TestMinimal is UnitTest
+  fun name(): String => "ponycli/minimal"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = CommandSpec.leaf("minimal", "", [
+        OptionSpec.bool("aflag", "")
+    ])
+
+    h.assert_eq[String]("minimal", cs.name)
+
+    let args: Array[String] = ["ignored"; "--aflag=true"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("aflag").value as Bool)
+
+
+class iso _TestBadName is UnitTest
+  fun name(): String => "ponycli/badname"
+
+  fun apply(h: TestHelper) ? =>
+    try
+        let cs = CommandSpec.leaf("min imal", "")
+    else
+        return // error was expected
+    end
+    error  // lack of error is bad
+
+
+class iso _TestHyphenArg is UnitTest
+  fun name(): String => "ponycli/hyphen"
+
+  // Rule 1
+  fun apply(h: TestHelper) ? =>
+    let cs = CommandSpec.leaf("minimal" where args' = [
+        ArgSpec.string("name", "")
+    ])
+    let args: Array[String] = ["ignored"; "-"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[String]("-", cmd.args("name").value as String)
+
+
+class iso _TestBools is UnitTest
+  fun name(): String => "ponycli/bools"
+
+  // Rules 2, 3, 5, 7 w/ Bools
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.bools_cli_spec()
+
+    let args: Array[String] = ["ignored"; "-ab"; "-c=true"; "-d=false"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("aaa").value as Bool)
+    h.assert_eq[Bool](true, cmd.options("bbb").value as Bool)
+    h.assert_eq[Bool](true, cmd.options("ccc").value as Bool)
+    h.assert_eq[Bool](false, cmd.options("ddd").value as Bool)
+
+
+class iso _TestDefaults is UnitTest
+  fun name(): String => "ponycli/defaults"
+
+  // Rules 2, 3, 5, 6
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = ["ignored"; "-B"; "-S--"; "-I42"; "-F42.0"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolo").value as Bool)
+    h.assert_eq[String]("astring", cmd.options("stringo").value as String)
+    h.assert_eq[I64](42, cmd.options("into").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
+
+
+class iso _TestShortsAdj is UnitTest
+  fun name(): String => "ponycli/shorts_adjacent"
+
+  // Rules 2, 3, 5, 6, 8
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = ["ignored"; "-BS--"; "-I42"; "-F42.0"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
+    h.assert_eq[String]("--", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestShortsEq is UnitTest
+  fun name(): String => "ponycli/shorts_eq"
+
+  // Rules 2, 3, 5, 7
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = ["ignored"; "-BS=astring"; "-I=42"; "-F=42.0"]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
+    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestShortsNext is UnitTest
+  fun name(): String => "ponycli/shorts_next"
+
+  // Rules 2, 3, 5, 8
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+        "ignored"; "-BS"; "--"; "-I"; "42"; "-F"; "42.0"
+    ]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
+    h.assert_eq[String]("--", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestLongsEq is UnitTest
+  fun name(): String => "ponycli/shorts_eq"
+
+  // Rules 4, 5, 7
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+        "ignored"
+        "--boolr=true"; "--stringr=astring"; "--intr=42"; "--floatr=42.0"
+    ]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
+    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestLongsNext is UnitTest
+  fun name(): String => "ponycli/longs_next"
+
+  // Rules 4, 5, 8
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+        "ignored"
+        "--boolr"; "--stringr"; "--"; "--intr"; "42"; "--floatr"; "42.0"
+    ]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[String]("--", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestEnvs is UnitTest
+  fun name(): String => "ponycli/envs"
+
+  // Rules
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+      "ignored"
+    ]
+    let envs: Array[String] = [
+      "SHORTS_BOOLR=true"
+      "SHORTS_STRINGR=astring"
+      "SHORTS_INTR=42"
+      "SHORTS_FLOATR=42.0"
+    ]
+    let cmdErr = CommandParser(cs).parse(args, envs)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[Bool](true, cmd.options("boolr").value as Bool)
+    h.assert_eq[String]("astring", cmd.options("stringr").value as String)
+    h.assert_eq[I64](42, cmd.options("intr").value as I64)
+    h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
+
+
+class iso _TestOptionStop is UnitTest
+  fun name(): String => "ponycli/option_stop"
+
+  // Rules 2, 3, 5, 7, 9
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+      "ignored"
+      "-BS=astring"; "-I=42"; "-F=42.0"
+      "--"; "-f=1.0"
+    ]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[String]("-f=1.0", cmd.args("words").value as String)
+    h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
+
+
+class iso _TestDuplicate is UnitTest
+  fun name(): String => "ponycli/duplicate"
+
+  // Rules 4, 5, 7, 10
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()
+
+    let args: Array[String] = [
+        "ignored"
+        "--boolr=true"; "--stringr=astring"; "--intr=42"; "--floatr=42.0"
+        "--stringr=newstring"
+    ]
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[String]("newstring", cmd.options("stringr").value as String)
+
+
+class iso _TestChatMin is UnitTest
+  fun name(): String => "ponycli/chat_min"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.chat_cli_spec()
+
+    let args: Array[String] = ["ignored"; "--name=me"; "--volume=42"]
+
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+    h.assert_eq[String]("chat", cs.name)
+
+
+class iso _TestChatAll is UnitTest
+  fun name(): String => "ponycli/chat_all"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.chat_cli_spec()
+
+    let args: Array[String] = [
+        "ignored"
+        "--admin"; "--name=carl"; "say"; "-v80"; "hello"
+    ]
+
+    let cmdErr = CommandParser(cs).parse(args)
+    h.log("Parsed: " + cmdErr.string())
+
+    let cmd = match cmdErr | let c: Command => c else error end
+
+    h.assert_eq[String]("say", cmd.spec.name)
+
+    let f1 = cmd.options("admin")
+    h.assert_eq[String]("admin", f1.spec.name)
+    h.assert_eq[Bool](true, f1.value as Bool)
+
+    let f2 = cmd.options("name")
+    h.assert_eq[String]("name", f2.spec.name)
+    h.assert_eq[String]("carl", f2.value as String)
+
+    let f3 = cmd.options("volume")
+    h.assert_eq[String]("volume", f3.spec.name)
+    h.assert_eq[F64](80.0, f3.value as F64)
+
+    let a1 = cmd.args("words")
+    h.assert_eq[String]("words", a1.spec.name)
+    h.assert_eq[String]("hello", a1.value as String)
+
+
+class iso _TestHelp is UnitTest
+  fun name(): String => "ponycli/help"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.chat_cli_spec()
+
+    let chErr = Help.for_command(cs, ["config"; "server"])
+    let ch = match chErr | let c: CommandHelp => c else error end
+
+    let help = ch.help_string()
+    h.log(help)
+    h.assert_true(help.contains("Address of the server"))
+
+
+primitive _Fixtures
+
+  fun bools_cli_spec(): CommandSpec box ? =>
+    """
+    Builds and returns the spec for a CLI with four bool options.
+    """
+    CommandSpec.leaf("bools", "A sample CLI with four bool options", [
+      OptionSpec.bool("aaa" where short' = 'a')
+      OptionSpec.bool("bbb" where short' = 'b')
+      OptionSpec.bool("ccc" where short' = 'c')
+      OptionSpec.bool("ddd" where short' = 'd')
+    ])
+
+  fun simple_cli_spec(): CommandSpec box ? =>
+    """
+    Builds and returns the spec for a CLI with short options of each type.
+    """
+    CommandSpec.leaf("shorts",
+        "A sample program with various short options, optional and required", [
+      OptionSpec.bool("boolr" where short' = 'B')
+      OptionSpec.bool("boolo" where short' = 'b', default' = true)
+      OptionSpec.string("stringr" where short' = 'S')
+      OptionSpec.string("stringo" where short' = 's', default' = "astring")
+      OptionSpec.i64("intr" where short' = 'I')
+      OptionSpec.i64("into" where short' = 'i', default' = I64(42))
+      OptionSpec.f64("floatr" where short' = 'F')
+      OptionSpec.f64("floato" where short' = 'f', default' = F64(42.0))
+    ],[
+      ArgSpec.string("words" where default' = "hello")
+    ])
+
+  fun chat_cli_spec(): CommandSpec box ? =>
+    """
+    Builds and returns the spec for a sample chat client's CLI.
+    """
+    CommandSpec.parent("chat", "A sample chat program", [
+      OptionSpec.bool("admin", "Chat as admin" where default' = false)
+      OptionSpec.string("name", "Your name" where short' = 'n')
+      OptionSpec.f64("volume", "Chat volume" where short' = 'v')
+    ],[
+      CommandSpec.leaf("say", "Say something", Array[OptionSpec](), [
+        ArgSpec.string("words", "The words to say")
+      ])
+      CommandSpec.leaf("emote", "Send an emotion", [
+        OptionSpec.f64("speed", "Emote play speed" where default' = F64(1.0))
+      ],[
+        ArgSpec.string("emotion", "Emote to send")
+      ])
+      CommandSpec.parent("config", "Configuration commands", Array[OptionSpec](), [
+        CommandSpec.leaf("server", "Server configuration", Array[OptionSpec](), [
+          ArgSpec.string("address", "Address of the server")
+        ])
+      ])
+    ])

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -22,7 +22,6 @@ actor Main is TestList
     test(_TestChatAll)
     test(_TestHelp)
 
-
 class iso _TestMinimal is UnitTest
   fun name(): String => "ponycli/minimal"
 
@@ -41,7 +40,6 @@ class iso _TestMinimal is UnitTest
 
     h.assert_eq[Bool](true, cmd.options("aflag").value as Bool)
 
-
 class iso _TestBadName is UnitTest
   fun name(): String => "ponycli/badname"
 
@@ -52,7 +50,6 @@ class iso _TestBadName is UnitTest
         return // error was expected
     end
     error  // lack of error is bad
-
 
 class iso _TestHyphenArg is UnitTest
   fun name(): String => "ponycli/hyphen"
@@ -69,7 +66,6 @@ class iso _TestHyphenArg is UnitTest
     let cmd = match cmdErr | let c: Command => c else error end
 
     h.assert_eq[String]("-", cmd.args("name").value as String)
-
 
 class iso _TestBools is UnitTest
   fun name(): String => "ponycli/bools"
@@ -89,7 +85,6 @@ class iso _TestBools is UnitTest
     h.assert_eq[Bool](true, cmd.options("ccc").value as Bool)
     h.assert_eq[Bool](false, cmd.options("ddd").value as Bool)
 
-
 class iso _TestDefaults is UnitTest
   fun name(): String => "ponycli/defaults"
 
@@ -107,7 +102,6 @@ class iso _TestDefaults is UnitTest
     h.assert_eq[String]("astring", cmd.options("stringo").value as String)
     h.assert_eq[I64](42, cmd.options("into").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
-
 
 class iso _TestShortsAdj is UnitTest
   fun name(): String => "ponycli/shorts_adjacent"
@@ -127,7 +121,6 @@ class iso _TestShortsAdj is UnitTest
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
 
-
 class iso _TestShortsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"
 
@@ -145,7 +138,6 @@ class iso _TestShortsEq is UnitTest
     h.assert_eq[String]("astring", cmd.options("stringr").value as String)
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
-
 
 class iso _TestShortsNext is UnitTest
   fun name(): String => "ponycli/shorts_next"
@@ -166,7 +158,6 @@ class iso _TestShortsNext is UnitTest
     h.assert_eq[String]("--", cmd.options("stringr").value as String)
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
-
 
 class iso _TestLongsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"
@@ -189,7 +180,6 @@ class iso _TestLongsEq is UnitTest
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
 
-
 class iso _TestLongsNext is UnitTest
   fun name(): String => "ponycli/longs_next"
 
@@ -209,7 +199,6 @@ class iso _TestLongsNext is UnitTest
     h.assert_eq[String]("--", cmd.options("stringr").value as String)
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
-
 
 class iso _TestEnvs is UnitTest
   fun name(): String => "ponycli/envs"
@@ -237,7 +226,6 @@ class iso _TestEnvs is UnitTest
     h.assert_eq[I64](42, cmd.options("intr").value as I64)
     h.assert_eq[F64](42.0, cmd.options("floatr").value as F64)
 
-
 class iso _TestOptionStop is UnitTest
   fun name(): String => "ponycli/option_stop"
 
@@ -258,7 +246,6 @@ class iso _TestOptionStop is UnitTest
     h.assert_eq[String]("-f=1.0", cmd.args("words").value as String)
     h.assert_eq[F64](42.0, cmd.options("floato").value as F64)
 
-
 class iso _TestDuplicate is UnitTest
   fun name(): String => "ponycli/duplicate"
 
@@ -278,7 +265,6 @@ class iso _TestDuplicate is UnitTest
 
     h.assert_eq[String]("newstring", cmd.options("stringr").value as String)
 
-
 class iso _TestChatMin is UnitTest
   fun name(): String => "ponycli/chat_min"
 
@@ -292,7 +278,6 @@ class iso _TestChatMin is UnitTest
 
     let cmd = match cmdErr | let c: Command => c else error end
     h.assert_eq[String]("chat", cs.name)
-
 
 class iso _TestChatAll is UnitTest
   fun name(): String => "ponycli/chat_all"
@@ -328,7 +313,6 @@ class iso _TestChatAll is UnitTest
     h.assert_eq[String]("words", a1.spec.name)
     h.assert_eq[String]("hello", a1.value as String)
 
-
 class iso _TestHelp is UnitTest
   fun name(): String => "ponycli/help"
 
@@ -342,9 +326,7 @@ class iso _TestHelp is UnitTest
     h.log(help)
     h.assert_true(help.contains("Address of the server"))
 
-
 primitive _Fixtures
-
   fun bools_cli_spec(): CommandSpec box ? =>
     """
     Builds and returns the spec for a CLI with four bool options.

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -1,0 +1,74 @@
+use col = "collections"
+
+class box Command
+  """
+  Command contains all of the information describing a command with its spec
+  and effective options and arguments, ready to use.
+  """
+  let spec: CommandSpec box
+  let options: col.Map[String, Option]
+  let args: col.Map[String, Arg]
+
+  new create(spec': CommandSpec box, options': col.Map[String, Option],
+      args': col.Map[String, Arg])
+    =>
+      spec = spec'
+      options = options'
+      args = args'
+
+  fun string(): String =>
+    let s: String iso = spec.name.clone()
+    for o in options.values() do
+      s.append(" ")
+      s.append(o.string())
+    end
+    for a in args.values() do
+      s.append(" ")
+      s.append(a.string())
+    end
+    s
+
+
+class val Option
+  """
+  Option contains a spec and an effective value for a given option.
+  """
+  let spec: OptionSpec
+  let value: Value
+
+  new val create(spec': OptionSpec, value': Value) =>
+    spec = spec'
+    value = value'
+
+  fun string(): String =>
+    spec.deb_string() + "=" + value.string()
+
+
+class val Arg
+  """
+  Arg contains a spec and an effective value for a given arg.
+  """
+  let spec: ArgSpec
+  let value: Value
+
+  new val create(spec': ArgSpec, value': Value) =>
+    spec = spec'
+    value = value'
+
+  fun string(): String =>
+    "(" + spec.deb_string() + "=)" + value.string()
+
+
+class val SyntaxError
+  """
+  SyntaxError summarizes a syntax error in a given parsed command line.
+  """
+  let token: String
+  let msg: String
+
+  new val create(token': String, msg': String) =>
+    token = token'
+    msg = msg'
+
+  fun string(): String =>
+    "Error: " + msg + " at: '" + token + "'"

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -5,93 +5,106 @@ class box Command
   Command contains all of the information describing a command with its spec
   and effective options and arguments, ready to use.
   """
-  let spec: CommandSpec box
-  let options: Map[String, Option]
-  let args: Map[String, Arg]
+  let _spec: CommandSpec box
+  let _options: Map[String, Option] box
+  let _args: Map[String, Arg] box
 
   new create(
     spec': CommandSpec box,
-    options': Map[String, Option],
-    args': Map[String, Arg])
+    options': Map[String, Option] box,
+    args': Map[String, Arg] box)
   =>
-    spec = spec'
-    options = options'
-    args = args'
+    _spec = spec'
+    _options = options'
+    _args = args'
 
   fun string(): String =>
-    let s: String iso = spec.name.clone()
-    for o in options.values() do
+    let s: String iso = _spec.name().clone()
+    for o in _options.values() do
       s.append(" ")
       s.append(o.deb_string())
     end
-    for a in args.values() do
+    for a in _args.values() do
       s.append(" ")
       s.append(a.deb_string())
     end
     s
 
+  fun box spec() : CommandSpec box => _spec
+
+  fun box option(name: String): Option =>
+    try _options(name) else Option(OptionSpec.bool(name), false) end
+
+  fun box arg(name: String): Arg =>
+    try _args(name) else Arg(ArgSpec.bool(name), false) end
+
 class val Option
   """
   Option contains a spec and an effective value for a given option.
   """
-  let spec: OptionSpec
-  let value: Value
+  let _spec: OptionSpec
+  let _value: Value
 
   new val create(spec': OptionSpec, value': Value) =>
-    spec = spec'
-    value = value'
+    _spec = spec'
+    _value = value'
+
+  fun spec() : OptionSpec => _spec
 
   fun bool(): Bool =>
-    try return value as Bool else false end
+    try _value as Bool else false end
 
   fun string(): String =>
-    try return value as String else "" end
+    try _value as String else "" end
 
   fun i64(): I64 =>
-    try return value as I64 else I64(0) end
+    try _value as I64 else I64(0) end
 
   fun f64(): F64 =>
-    try return value as F64 else F64(0) end
+    try _value as F64 else F64(0) end
 
   fun deb_string(): String =>
-    spec.deb_string() + "=" + value.string()
+    _spec.deb_string() + "=" + _value.string()
 
 class val Arg
   """
   Arg contains a spec and an effective value for a given arg.
   """
-  let spec: ArgSpec
-  let value: Value
+  let _spec: ArgSpec
+  let _value: Value
 
   new val create(spec': ArgSpec, value': Value) =>
-    spec = spec'
-    value = value'
+    _spec = spec'
+    _value = value'
+
+  fun spec(): ArgSpec => _spec
 
   fun bool(): Bool =>
-    try return value as Bool else false end
+    try _value as Bool else false end
 
   fun string(): String =>
-    try return value as String else "" end
+    try _value as String else "" end
 
   fun i64(): I64 =>
-    try return value as I64 else I64(0) end
+    try _value as I64 else I64(0) end
 
   fun f64(): F64 =>
-    try return value as F64 else F64(0) end
+    try _value as F64 else F64(0) end
 
   fun deb_string(): String =>
-    "(" + spec.deb_string() + "=)" + value.string()
+    "(" + _spec.deb_string() + "=)" + _value.string()
 
 class val SyntaxError
   """
   SyntaxError summarizes a syntax error in a given parsed command line.
   """
-  let token: String
-  let msg: String
+  let _token: String
+  let _msg: String
 
   new val create(token': String, msg': String) =>
-    token = token'
-    msg = msg'
+    _token = token'
+    _msg = msg'
 
-  fun string(): String =>
-    "Error: " + msg + " at: '" + token + "'"
+  fun token(): String => _token
+
+  fun string(): String => "Error: " + _msg + " at: '" + _token + "'"

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -22,11 +22,11 @@ class box Command
     let s: String iso = spec.name.clone()
     for o in options.values() do
       s.append(" ")
-      s.append(o.string())
+      s.append(o.deb_string())
     end
     for a in args.values() do
       s.append(" ")
-      s.append(a.string())
+      s.append(a.deb_string())
     end
     s
 
@@ -41,7 +41,19 @@ class val Option
     spec = spec'
     value = value'
 
+  fun bool(): Bool =>
+    try return value as Bool else false end
+
   fun string(): String =>
+    try return value as String else "" end
+
+  fun i64(): I64 =>
+    try return value as I64 else I64(0) end
+
+  fun f64(): F64 =>
+    try return value as F64 else F64(0) end
+
+  fun deb_string(): String =>
     spec.deb_string() + "=" + value.string()
 
 class val Arg
@@ -55,7 +67,19 @@ class val Arg
     spec = spec'
     value = value'
 
+  fun bool(): Bool =>
+    try return value as Bool else false end
+
   fun string(): String =>
+    try return value as String else "" end
+
+  fun i64(): I64 =>
+    try return value as I64 else I64(0) end
+
+  fun f64(): F64 =>
+    try return value as F64 else F64(0) end
+
+  fun deb_string(): String =>
     "(" + spec.deb_string() + "=)" + value.string()
 
 class val SyntaxError

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -1,4 +1,4 @@
-use col = "collections"
+use "collections"
 
 class box Command
   """
@@ -6,13 +6,13 @@ class box Command
   and effective options and arguments, ready to use.
   """
   let spec: CommandSpec box
-  let options: col.Map[String, Option]
-  let args: col.Map[String, Arg]
+  let options: Map[String, Option]
+  let args: Map[String, Arg]
 
   new create(
     spec': CommandSpec box,
-    options': col.Map[String, Option],
-    args': col.Map[String, Arg])
+    options': Map[String, Option],
+    args': Map[String, Arg])
   =>
     spec = spec'
     options = options'

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -43,9 +43,9 @@ class val Option
   Option contains a spec and an effective value for a given option.
   """
   let _spec: OptionSpec
-  let _value: Value
+  let _value: _Value
 
-  new val create(spec': OptionSpec, value': Value) =>
+  new val create(spec': OptionSpec, value': _Value) =>
     _spec = spec'
     _value = value'
 
@@ -71,9 +71,9 @@ class val Arg
   Arg contains a spec and an effective value for a given arg.
   """
   let _spec: ArgSpec
-  let _value: Value
+  let _value: _Value
 
-  new val create(spec': ArgSpec, value': Value) =>
+  new val create(spec': ArgSpec, value': _Value) =>
     _spec = spec'
     _value = value'
 

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -9,12 +9,14 @@ class box Command
   let options: col.Map[String, Option]
   let args: col.Map[String, Arg]
 
-  new create(spec': CommandSpec box, options': col.Map[String, Option],
-      args': col.Map[String, Arg])
-    =>
-      spec = spec'
-      options = options'
-      args = args'
+  new create(
+    spec': CommandSpec box,
+    options': col.Map[String, Option],
+    args': col.Map[String, Arg])
+  =>
+    spec = spec'
+    options = options'
+    args = args'
 
   fun string(): String =>
     let s: String iso = spec.name.clone()
@@ -27,7 +29,6 @@ class box Command
       s.append(a.string())
     end
     s
-
 
 class val Option
   """
@@ -43,7 +44,6 @@ class val Option
   fun string(): String =>
     spec.deb_string() + "=" + value.string()
 
-
 class val Arg
   """
   Arg contains a spec and an effective value for a given arg.
@@ -57,7 +57,6 @@ class val Arg
 
   fun string(): String =>
     "(" + spec.deb_string() + "=)" + value.string()
-
 
 class val SyntaxError
   """

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -21,9 +21,6 @@ primitive Help
           | let ccs: CommandSpec box =>
             let cch = CommandHelp._create(ch, ccs)
             return _parse(ccs, cch, argv.slice(1))
-          else
-            // TODO https://github.com/ponylang/ponyc/issues/1898
-            return SyntaxError("issue", "1898")
           end
         end
         return SyntaxError(cname, "unknown command")

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -1,9 +1,7 @@
 use "buffered"
 
 primitive Help
-
-  fun general(cs: CommandSpec box): CommandHelp
-  =>
+  fun general(cs: CommandSpec box): CommandHelp =>
     CommandHelp._create(None, cs)
 
   fun for_command(cs: CommandSpec box, argv: Array[String] box)

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -16,8 +16,8 @@ primitive Help
     if argv.size() > 0 then
       try
         let cname = argv(0)
-        if cs.commands.contains(cname) then
-          match cs.commands(cname)
+        if cs.commands().contains(cname) then
+          match cs.commands()(cname)
           | let ccs: CommandSpec box =>
             let cch = CommandHelp._create(ch, ccs)
             return _parse(ccs, cch, argv.slice(1))
@@ -35,32 +35,32 @@ class box CommandHelp
   identified to get help on. Use `Help.general()` or `Help.for_command()` to
   create a CommandHelp instance.
   """
-  let parent: (CommandHelp box | None)
-  let spec: CommandSpec box
+  let _parent: (CommandHelp box | None)
+  let _spec: CommandSpec box
 
   new _create(parent': (CommandHelp box | None), spec': CommandSpec box) =>
-    parent = parent'
-    spec = spec'
+    _parent = parent'
+    _spec = spec'
 
-  fun fullname(): String =>
-    match parent
-    | let p: CommandHelp => p.fullname() + " " + spec.name
+  fun box fullname(): String =>
+    match _parent
+    | let p: CommandHelp => p.fullname() + " " + _spec.name()
     else
-      spec.name
+     _spec.name()
     end
 
-  fun string(): String => fullname()
+  fun box string(): String => fullname()
 
-  fun help_string(): String =>
+  fun box help_string(): String =>
     let w: StringWriter ref = StringWriter
     print_help(w)
     w.string()
 
-  fun print_help(w: Writer) =>
+  fun box print_help(w: Writer) =>
     print_usage(w)
-    if spec.descr.size() > 0 then
+    if _spec.descr().size() > 0 then
       w.write("\n")
-      w.write(spec.descr + "\n")
+      w.write(_spec.descr() + "\n")
     end
 
     let options = all_options()
@@ -68,26 +68,26 @@ class box CommandHelp
       w.write("\nOptions:\n")
       print_options(w, options)
     end
-    if spec.commands.size() > 0 then
+    if _spec.commands().size() > 0 then
       w.write("\nCommands:\n")
       print_commands(w)
     end
-    let args = spec.args
+    let args = _spec.args()
     if args.size() > 0 then
       w.write("\nArgs:\n")
       print_args(w, args)
     end
 
-  fun print_usage(w: Writer) =>
+  fun box print_usage(w: Writer) =>
     w.write("usage: " + fullname())
     if any_options() then
       w.write(" [<options>]")
     end
-    if spec.commands.size() > 0 then
+    if _spec.commands().size() > 0 then
       w.write(" <command>")
     end
-    if spec.args.size() > 0 then
-      for a in spec.args.values() do
+    if _spec.args().size() > 0 then
+      for a in _spec.args().values() do
         w.write(" " + a.help_string())
       end
     else
@@ -95,56 +95,56 @@ class box CommandHelp
     end
     w.write("\n")
 
-  fun print_options(w: Writer, options: Array[OptionSpec box] box) =>
+  fun box print_options(w: Writer, options: Array[OptionSpec box] box) =>
     let cols = Array[(String,String)]()
     for o in options.values() do
-      cols.push(("  " + o.help_string(), o.descr))
+      cols.push(("  " + o.help_string(), o.descr()))
     end
     _Columns.print(w, cols)
 
-  fun print_commands(w: Writer) =>
+  fun box print_commands(w: Writer) =>
     let cols = Array[(String,String)]()
-    _list_commands(spec, cols, 1)
+    _list_commands(_spec, cols, 1)
     _Columns.print(w, cols)
 
-  fun _list_commands(
+  fun box _list_commands(
     cs: CommandSpec box,
     cols: Array[(String,String)],
     level: USize)
   =>
-    for c in cs.commands.values() do
-      cols.push((_Columns.indent(level*2) + c.help_string(), c.descr))
+    for c in cs.commands().values() do
+      cols.push((_Columns.indent(level*2) + c.help_string(), c.descr()))
       _list_commands(c, cols, level + 1)
     end
 
-  fun print_args(w: Writer, args: Array[ArgSpec] box) =>
+  fun box print_args(w: Writer, args: Array[ArgSpec] box) =>
     let cols = Array[(String,String)]()
     for a in args.values() do
-      cols.push(("  " + a.help_string(), a.descr))
+      cols.push(("  " + a.help_string(), a.descr()))
     end
     _Columns.print(w, cols)
 
-  fun any_options(): Bool =>
-    if spec.options.size() > 0 then
+  fun box any_options(): Bool =>
+    if _spec.options().size() > 0 then
       true
     else
-      match parent
+      match _parent
       | let p: CommandHelp => p.any_options()
       else
         false
       end
     end
 
-  fun all_options(): Array[OptionSpec box] =>
+  fun box all_options(): Array[OptionSpec box] =>
     let options = Array[OptionSpec box]()
     _all_options(options)
     options
 
-  fun _all_options(options: Array[OptionSpec box]) =>
-    match parent
+  fun box _all_options(options: Array[OptionSpec box]) =>
+    match _parent
     | let p: CommandHelp => p._all_options(options)
     end
-    for o in spec.options.values() do
+    for o in _spec.options().values() do
       options.push(o)
     end
 

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -58,13 +58,14 @@ class box CommandHelp
 
   fun print_help(w: Writer) =>
     print_usage(w)
-    w.write("\n")
-    w.write(spec.descr + "\n")
-    w.write("\n")
+    if spec.descr.size() > 0 then
+      w.write("\n")
+      w.write(spec.descr + "\n")
+    end
 
     let options = all_options()
     if options.size() > 0 then
-      w.write("Options:\n")
+      w.write("\nOptions:\n")
       print_options(w, options)
     end
     if spec.commands.size() > 0 then

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -1,0 +1,196 @@
+
+primitive Help
+
+  fun general(cs: CommandSpec box): CommandHelp
+  =>
+    CommandHelp._create(None, cs)
+
+  fun for_command(cs: CommandSpec box, argv: Array[String] box):
+    (CommandHelp | SyntaxError)
+  =>
+    let ch = CommandHelp._create(None, cs)
+    _parse(cs, ch, argv)
+
+  fun _parse(cs: CommandSpec box, ch: CommandHelp, argv: Array[String] box):
+    (CommandHelp | SyntaxError)
+  =>
+    if argv.size() > 0 then
+      try
+        let cname = argv(0)
+        if cs.commands.contains(cname) then
+          try
+            match cs.commands(cname)
+            | let ccs: CommandSpec box =>
+              let cch = CommandHelp._create(ch, ccs)
+              return _parse(ccs, cch, argv.slice(1))
+            end
+          end
+        end
+        return SyntaxError(cname, "unknown command")
+      end
+    end
+    ch
+
+class box CommandHelp
+  """
+  CommandHelp encapsulates the information needed to generate a user help
+  message for a given CommandSpec, optionally with a specific command
+  identified to get help on. Use `Help.general()` or `Help.for_command()` to
+  create a CommandHelp instance.
+  """
+  let parent: (CommandHelp box | None)
+  let spec: CommandSpec box
+
+  new _create(parent': (CommandHelp box | None), spec': CommandSpec box) =>
+    parent = parent'
+    spec = spec'
+
+  fun fullname(): String =>
+    match parent
+    | let p: CommandHelp => p.fullname() + " " + spec.name
+    else
+      spec.name
+    end
+
+  fun string(): String => fullname()
+
+  fun help_string(): String =>
+    let w: StringWriter ref = StringWriter
+    print_help(w)
+    w.string()
+
+  fun print_help(w: Writer) =>
+    print_usage(w)
+    w.write("\n")
+    w.write(spec.descr + "\n")
+    w.write("\n")
+
+    let options = all_options()
+    if options.size() > 0 then
+      w.write("Options:\n")
+      print_options(w, options)
+    end
+    if spec.commands.size() > 0 then
+      w.write("\nCommands:\n")
+      print_commands(w)
+    end
+    let args = spec.args
+    if args.size() > 0 then
+      w.write("\nArgs:\n")
+      print_args(w, args)
+    end
+
+  fun print_usage(w: Writer) =>
+    w.write("usage: " + fullname())
+    if any_options() then
+      w.write(" [<options>]")
+    end
+    if spec.commands.size() > 0 then
+      w.write(" <command>")
+    end
+    if spec.args.size() > 0 then
+      for a in spec.args.values() do
+        w.write(" " + a.help_string())
+      end
+    else
+      w.write(" [<args> ...]")
+    end
+    w.write("\n")
+
+  fun print_options(w: Writer, options: Array[OptionSpec box] box) =>
+    let cols = Array[(String,String)]()
+    for o in options.values() do
+      cols.push(("  " + o.help_string(), o.descr))
+    end
+    Columns.print(w, cols)
+
+  fun print_commands(w: Writer) =>
+    let cols = Array[(String,String)]()
+    _list_commands(spec, cols, 1)
+    Columns.print(w, cols)
+
+  fun _list_commands(cs: CommandSpec box, cols: Array[(String,String)], level: USize) =>
+    for c in cs.commands.values() do
+      cols.push((Columns.indent(level*2) + c.help_string(), c.descr))
+      _list_commands(c, cols, level + 1)
+    end
+
+  fun print_args(w: Writer, args: Array[ArgSpec] box) =>
+    let cols = Array[(String,String)]()
+    for a in args.values() do
+      cols.push(("  " + a.help_string(), a.descr))
+    end
+    Columns.print(w, cols)
+
+  fun any_options(): Bool =>
+    if spec.options.size() > 0 then
+      true
+    else
+      match parent
+      | let p: CommandHelp => p.any_options()
+      else
+        false
+      end
+    end
+
+  fun all_options(): Array[OptionSpec box] =>
+    let options = Array[OptionSpec box]()
+    _all_options(options)
+    options
+
+  fun _all_options(options: Array[OptionSpec box]) =>
+    match parent
+    | let p: CommandHelp => p._all_options(options)
+    end
+    for o in spec.options.values() do
+      options.push(o)
+    end
+
+"""
+This interface and two classes allow the help output to go to a general Writer
+that can be implemented for string creation or to an OutStream. Or other
+targets. This could be polished up and moved into a more central package.
+"""
+interface Writer
+  fun ref write(data: ByteSeq)
+
+class StringWriter
+  let _s: String ref = String
+
+  fun ref write(data: ByteSeq) =>
+    _s.append(data)
+
+  fun string(): String iso^ =>
+    _s.clone()
+
+class OutWriter
+  let _os: OutStream tag
+
+  new create(os: OutStream tag) =>
+    _os = os
+
+  fun ref write(data: ByteSeq) =>
+    _os.write(data)
+
+
+primitive Columns
+  fun indent(n: USize): String =>
+    let spaces = "                                "
+    spaces.substring(0, n.isize())
+
+  fun print(w: Writer, cols: Array[(String,String)]) =>
+    var widest: USize = 0
+    for c in cols.values() do
+      (let c1, _) = c
+      let c1s = c1.size()
+      if c1s > widest then
+        widest = c1s
+      end
+    end
+    for c in cols.values() do
+      (let c1, let c2) = c
+      w.write(indent(1))
+      w.write(c1)
+      w.write(indent((widest - c1.size()) + 2))
+      w.write(c2 + "\n")
+    end

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -1,3 +1,4 @@
+use "buffered"
 
 primitive Help
 
@@ -46,41 +47,48 @@ class box CommandHelp
     match _parent
     | let p: CommandHelp => p.fullname() + " " + _spec.name()
     else
-     _spec.name()
+      _spec.name()
     end
 
   fun box string(): String => fullname()
 
   fun box help_string(): String =>
-    let w: StringWriter ref = StringWriter
-    print_help(w)
-    w.string()
+    let w: Writer = Writer
+    _write_help(w)
+    let str = recover trn String(w.size()) end
+    for bytes in w.done().values() do str.append(bytes) end
+    consume str
 
-  fun box print_help(w: Writer) =>
-    print_usage(w)
+  fun box print_help(os: OutStream) =>
+    let w: Writer = Writer
+    _write_help(w)
+    os.writev(w.done())
+
+  fun box _write_help(w: Writer) =>
+    _write_usage(w)
     if _spec.descr().size() > 0 then
       w.write("\n")
       w.write(_spec.descr() + "\n")
     end
 
-    let options = all_options()
+    let options = _all_options()
     if options.size() > 0 then
       w.write("\nOptions:\n")
-      print_options(w, options)
+      _write_options(w, options)
     end
     if _spec.commands().size() > 0 then
       w.write("\nCommands:\n")
-      print_commands(w)
+      _write_commands(w)
     end
     let args = _spec.args()
     if args.size() > 0 then
       w.write("\nArgs:\n")
-      print_args(w, args)
+      _write_args(w, args)
     end
 
-  fun box print_usage(w: Writer) =>
+  fun box _write_usage(w: Writer) =>
     w.write("usage: " + fullname())
-    if any_options() then
+    if _any_options() then
       w.write(" [<options>]")
     end
     if _spec.commands().size() > 0 then
@@ -95,104 +103,80 @@ class box CommandHelp
     end
     w.write("\n")
 
-  fun box print_options(w: Writer, options: Array[OptionSpec box] box) =>
-    let cols = Array[(String,String)]()
+  fun box _write_options(w: Writer, options: Array[OptionSpec box] box) =>
+    let cols = Array[(USize,String,String)]()
     for o in options.values() do
-      cols.push(("  " + o.help_string(), o.descr()))
+      cols.push((2, o.help_string(), o.descr()))
     end
-    _Columns.print(w, cols)
+    _Columns.write(w, cols)
 
-  fun box print_commands(w: Writer) =>
-    let cols = Array[(String,String)]()
+  fun box _write_commands(w: Writer) =>
+    let cols = Array[(USize,String,String)]()
     _list_commands(_spec, cols, 1)
-    _Columns.print(w, cols)
+    _Columns.write(w, cols)
 
   fun box _list_commands(
     cs: CommandSpec box,
-    cols: Array[(String,String)],
+    cols: Array[(USize,String,String)],
     level: USize)
   =>
     for c in cs.commands().values() do
-      cols.push((_Columns.indent(level*2) + c.help_string(), c.descr()))
+      cols.push((level*2, c.help_string(), c.descr()))
       _list_commands(c, cols, level + 1)
     end
 
-  fun box print_args(w: Writer, args: Array[ArgSpec] box) =>
-    let cols = Array[(String,String)]()
+  fun box _write_args(w: Writer, args: Array[ArgSpec] box) =>
+    let cols = Array[(USize,String,String)]()
     for a in args.values() do
-      cols.push(("  " + a.help_string(), a.descr()))
+      cols.push((2, a.help_string(), a.descr()))
     end
-    _Columns.print(w, cols)
+    _Columns.write(w, cols)
 
-  fun box any_options(): Bool =>
+  fun box _any_options(): Bool =>
     if _spec.options().size() > 0 then
       true
     else
       match _parent
-      | let p: CommandHelp => p.any_options()
+      | let p: CommandHelp => p._any_options()
       else
         false
       end
     end
 
-  fun box all_options(): Array[OptionSpec box] =>
+  fun box _all_options(): Array[OptionSpec box] =>
     let options = Array[OptionSpec box]()
-    _all_options(options)
+    _all_options_fill(options)
     options
 
-  fun box _all_options(options: Array[OptionSpec box]) =>
+  fun box _all_options_fill(options: Array[OptionSpec box]) =>
     match _parent
-    | let p: CommandHelp => p._all_options(options)
+    | let p: CommandHelp => p._all_options_fill(options)
     end
     for o in _spec.options().values() do
       options.push(o)
     end
 
-interface Writer
-  """
-  This interface and two classes allow the help output to go to a general
-  Writer that can be implemented for string creation or to an OutStream. Or
-  other targets. This could be polished up and moved into a more central
-  package.
-  """
-  fun ref write(data: ByteSeq)
-
-class StringWriter
-  let _s: String ref = String
-
-  fun ref write(data: ByteSeq) =>
-    _s.append(data)
-
-  fun string(): String iso^ =>
-    _s.clone()
-
-class OutWriter
-  let _os: OutStream tag
-
-  new create(os: OutStream tag) =>
-    _os = os
-
-  fun ref write(data: ByteSeq) =>
-    _os.write(data)
-
 primitive _Columns
-  fun indent(n: USize): String =>
-    let spaces = "                                "
-    spaces.substring(0, n.isize())
+  fun indent(w: Writer, n: USize) =>
+    var i = n
+    while i > 0 do
+      w.write(" ")
+      i = i - 1
+    end
 
-  fun print(w: Writer, cols: Array[(String,String)]) =>
+  fun write(w: Writer, cols: Array[(USize,String,String)]) =>
     var widest: USize = 0
     for c in cols.values() do
-      (let c1, _) = c
-      let c1s = c1.size()
+      (let c0, let c1, _) = c
+      let c1s = c0 + c1.size()
       if c1s > widest then
         widest = c1s
       end
     end
     for c in cols.values() do
-      (let c1, let c2) = c
-      w.write(indent(1))
+      (let c0, let c1, let c2) = c
+      indent(w, 1 + c0)
       w.write(c1)
-      w.write(indent((widest - c1.size()) + 2))
+      indent(w, (widest - c1.size()) + 2)
       w.write(c2 + "\n")
     end

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -102,8 +102,6 @@ class CommandParser
             | let cs: CommandSpec box =>
               return CommandParser._sub(cs, this).
                 _parse_command(tokens, options, args, envsmap, opt_stop)
-            else
-              None // TODO https://github.com/ponylang/ponyc/issues/1898
             end
           end
         else
@@ -157,8 +155,6 @@ class CommandParser
         match arg
         | "" => return Help.general(_root_spec())
         | let c: String => return Help.for_command(_root_spec(), [c])
-        else
-          None // TODO https://github.com/ponylang/ponyc/issues/1898
         end
       end
       return Help.general(_root_spec())

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -1,0 +1,340 @@
+use col = "collections"
+
+class CommandParser
+  let _spec: CommandSpec box
+  let _parent: (CommandParser box | None)
+
+  new box create(spec': CommandSpec box) =>
+    _spec = spec'
+    _parent = None
+
+  new box _sub(spec': CommandSpec box, parent': CommandParser box) =>
+    _spec = spec'
+    _parent = parent'
+
+  fun box parse(
+    argv: Array[String] box,
+    envs: (Array[String] box | None) = None)
+  : (Command | CommandHelp | SyntaxError)
+  =>
+    """
+    Parses all of the command line tokens and env vars and returns a Command,
+    or the first SyntaxError.
+    """
+    let tokens = argv.clone()
+    try tokens.shift() end  // argv[0] is the program name, so skip it
+    let options: col.Map[String,Option] ref = options.create()
+    let args: col.Map[String,Arg] ref = args.create()
+    _parse_command(tokens, options, args, env_map(envs), false)
+
+  fun box _root_spec(): CommandSpec box =>
+    match _parent
+    | let p: CommandParser box => p._root_spec()
+    else
+      _spec
+    end
+
+  fun env_map(envs: (Array[String] box | None)): col.Map[String, String] val =>
+    """
+    Turns env array into a k,v map, filtering for only vars that begin with the
+    command name uppercased, and then stripping that off. So:
+      <COMMAND>_<KEY>=<VALUE>
+    becomes:
+      {key, VALUE}
+    """
+    let envsmap = recover col.Map[String, String]() end
+    let prefix = _spec.name.upper() + "_"
+    let prelen = prefix.size().isize()
+    match envs
+      | let envsarr: Array[String] box =>
+        for e in envsarr.values() do
+          let eqpos = try e.find("=") else 0 end // should find 1 =
+          let ek: String val = e.substring(0, eqpos)
+          let ev: String val = e.substring(eqpos+1)
+          if ek.at(prefix, 0) then
+            envsmap.update(ek.substring(prelen).lower(), ev)
+          end
+        end
+    end
+    consume envsmap
+
+  fun box _parse_command(
+    tokens: Array[String] ref,
+    options: col.Map[String,Option] ref,
+    args: col.Map[String,Arg] ref,
+    envsmap: col.Map[String, String] box,
+    ostop: Bool): (Command | CommandHelp | SyntaxError)
+  =>
+    """
+    Parses all of the command line tokens and env vars into the given options
+    and args maps. Returns the first SyntaxError, or the Command when OK.
+    """
+    var opt_stop = ostop
+    var arg_pos: USize = 0
+
+    while tokens.size() > 0 do
+      let token = try tokens.shift() else "" end
+      if token == "--" then
+        opt_stop = true
+
+      elseif not opt_stop and (token.compare_sub("--", 2, 0) == Equal) then
+        match _parse_long_option(token.substring(2), tokens)
+        | let f: Option => options.update(f.spec.name, f)
+        | let se: SyntaxError => return se
+        end
+
+      elseif not opt_stop and
+        ((token.compare_sub("-", 1, 0) == Equal) and (token.size() > 1)) then
+        match _parse_short_options(token.substring(1), tokens)
+        | let fs: Array[Option] =>
+          for f in fs.values() do options.update(f.spec.name, f) end
+        | let se: SyntaxError =>
+          return se
+        end
+
+      else // no dashes, must be a command or an arg
+        if _spec.commands.contains(token) then
+          try
+            match _spec.commands(token)
+            | let cs: CommandSpec box =>
+              return CommandParser._sub(cs, this).
+                _parse_command(tokens, options, args, envsmap, opt_stop)
+            end
+          end
+        else
+          match _parse_arg(token, arg_pos)
+          | let a: Arg => args.update(a.spec.name, a); arg_pos = arg_pos + 1
+          | let se: SyntaxError => return se
+          end
+        end
+      end
+    end
+
+    // Fill in option values from env or from coded defaults.
+    for fs in _spec.options.values() do
+      if not options.contains(fs.name) then
+        // Lookup and use env vars before code defaults
+        if envsmap.contains(fs.name) then
+          let vs = try envsmap(fs.name) else "" end // else? we know it's in there
+          let v: Value = match ValueParser.parse(fs.typ, vs)
+            | let v: Value => v
+            | let e: SyntaxError => return e
+            else
+              false // Pony should know e,v above covers all match types
+            end
+          options.update(fs.name, Option(fs, v))
+        else
+          if not fs.required then
+            options.update(fs.name, Option(fs, fs.default))
+          end
+        end
+      end
+    end
+
+    // If it's a help option, return a general or specific CommandHelp.
+    if options.contains(_help_name()) then
+      if _spec is _root_spec() then
+        return Help.general(_root_spec())
+      else
+        return Help.for_command(_root_spec(), [_spec.name])
+      end
+    end
+
+    // If it's a help command, return a general or specific CommandHelp.
+    if _spec.name == _help_name() then
+      try
+        let arg = args("command").value as String
+        match arg
+          | "" => return Help.general(_root_spec())
+          | let c: String => return Help.for_command(_root_spec(), [c])
+        end
+      end
+      return Help.general(_root_spec())
+    end
+
+    // Check for missing options and error if any exist.
+    for os in _spec.options.values() do
+      if not options.contains(os.name) then
+        if os.required then
+          return SyntaxError(os.name, "missing value for required option")
+        end
+      end
+    end
+
+    // Check for missing args and error if found.
+    while arg_pos < _spec.args.size() do
+      try
+        let ars = _spec.args(arg_pos)
+        if ars.required then
+          return SyntaxError(ars.name, "missing value for required argument")
+        end
+        args.update(ars.name, Arg(ars, ars.default))
+      end
+      arg_pos = arg_pos + 1
+    end
+
+    // A successfully parsed and populated leaf Command
+    Command(_spec, options, args)
+
+  fun box _parse_long_option(
+    token: String,
+    args: Array[String] ref): (Option | SyntaxError)
+  =>
+    """
+    --opt=foo => --opt has argument foo
+    --opt foo => --opt has argument foo, iff arg is required
+    """
+    let parts = token.split("=")
+    let name = try parts(0) else "???" end
+    let targ = try parts(1) else None end
+    match _option_with_name(name)
+    | let fs: OptionSpec => OptionParser.parse(fs, targ, args)
+    | None => SyntaxError(name, "unknown long option")
+    else
+      // TODO: Ponyc should know we've covered all match cases above
+      SyntaxError(name, "Pony shouldn't allow this")
+    end
+
+  fun box _parse_short_options(
+    token: String,
+    args: Array[String] ref): (Array[Option] | SyntaxError)
+  =>
+    """
+    if 'O' requires an argument
+      -OFoo  => -O has argument Foo
+      -O=Foo => -O has argument Foo
+      -O Foo => -O has argument Foo
+    else
+      -O=Foo => -O has argument foo
+    -abc => options a, b, c.
+    -abcFoo => options a, b, c. c has argument Foo iff its arg is required.
+    -abc=Foo => options a, b, c. c has argument Foo.
+    -abc Foo => options a, b, c. c has argument Foo iff its arg is required.
+    """
+    let parts = token.split("=")
+    let shorts = (try parts(0) else "" end).clone()
+    var targ = try parts(1) else None end
+
+    let options: Array[Option] ref = options.create()
+    while shorts.size() > 0 do
+      let c = try shorts.shift() else 0 end  // Should never error since checked
+      match _option_with_short(c)
+      | let fs: OptionSpec =>
+        if fs._requires_arg() and (shorts.size() > 0) then
+          // opt needs an arg, so consume the remainder of the shorts for targ
+          if targ is None then
+            targ = shorts.clone()
+            shorts.truncate(0)
+          else
+            return SyntaxError(short_string(c), "ambiguous args for short option")
+          end
+        end
+        let arg = if shorts.size() == 0 then targ else None end
+        match OptionParser.parse(fs, arg, args)
+        | let f: Option => options.push(f)
+        | let se: SyntaxError => return se
+        end
+      | None => SyntaxError(short_string(c), "unknown short option")
+      else
+        // TODO: Ponyc should know we've covered all match cases above
+        return SyntaxError(token, "Pony shouldn't allow this")
+      end
+    end
+    options
+
+  fun box _parse_arg(token: String, arg_pos: USize): (Arg | SyntaxError) =>
+    try
+      let arg_spec = _spec.args(arg_pos)
+      ArgParser.parse(arg_spec, token)
+    else
+      return SyntaxError(token, "too many positional arguments")
+    end
+
+  fun box _option_with_name(name: String): (OptionSpec | None) =>
+    try
+      return _spec.options(name)
+    end
+    match _parent
+    | let p: CommandParser box => p._option_with_name(name)
+    else
+      None
+    end
+
+  fun box _option_with_short(short: U8): (OptionSpec | None) =>
+    for f in _spec.options.values() do
+      if f._has_short(short) then
+        return f
+      end
+    end
+    match _parent
+    | let p: CommandParser box => p._option_with_short(short)
+    else
+      None
+    end
+
+  fun short_string(c: U8): String =>
+    recover String.from_utf32(c.u32()) end
+
+  fun box _help_name(): String =>
+    _root_spec().help_name
+
+
+primitive OptionParser
+  fun parse(
+    spec: OptionSpec,
+    targ: (String|None),
+    args: Array[String] ref): (Option | SyntaxError)
+  =>
+    // Grab the token-arg if provided, else consume an arg if one is required.
+    let arg = match targ
+      | (let fn: None) if spec._requires_arg() =>
+        try args.shift() else None end
+      else
+        targ
+      end
+    // Now convert the arg to Type, detecting missing or mis-typed args
+    match arg
+    | let a: String =>
+      match ValueParser.parse(spec.typ, a)
+      | let v: Value => Option(spec, v)
+      | let se: SyntaxError => se
+      else
+          // TODO: Ponyc should know we've covered all match cases above
+          SyntaxError(a, "Pony shouldn't allow this")
+      end
+    else
+      if not spec._requires_arg() then
+        Option(spec, spec._default_arg())
+      else
+        SyntaxError(spec.name, "missing arg for option")
+      end
+    end
+
+
+primitive ArgParser
+  fun parse(spec: ArgSpec, arg: String): (Arg | SyntaxError) =>
+    match ValueParser.parse(spec.typ, arg)
+    | let v: Value => Arg(spec, v)
+    | let se: SyntaxError => se
+    else
+        // TODO: Ponyc should know we've covered all match cases above
+        SyntaxError(arg, "Pony shouldn't allow this")
+    end
+
+
+primitive ValueParser
+  fun box parse(typ: ValueType, arg: String): (Value | SyntaxError) =>
+    try
+      match typ
+      | let b: BoolType => arg.bool()
+      | let s: StringType => arg
+      | let f: F64Type => arg.f64()
+      | let i: I64Type => arg.i64()
+      else
+        // TODO: Ponyc should know we've covered all match cases above
+        SyntaxError(arg,
+          "Pony shouldn't allow this: unknown value type " + typ.string())
+      end
+    else
+      SyntaxError(arg, "unable to convert '" + arg + "' to " + typ.string())
+    end

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -115,6 +115,27 @@ class CommandParser
       end
     end
 
+    // If it's a help option, return a general or specific CommandHelp.
+    if options.contains(_help_name()) then
+      return
+        if _spec is _root_spec() then
+          Help.general(_root_spec())
+        else
+          Help.for_command(_root_spec(), [_spec.name])
+        end
+    end
+
+    // If it's a help command, return a general or specific CommandHelp.
+    if _spec.name == _help_name() then
+      try
+        match args("command").value
+        | "" => return Help.general(_root_spec())
+        | let c: String => return Help.for_command(_root_spec(), [c])
+        end
+      end
+      return Help.general(_root_spec())
+    end
+
     // Fill in option values from env or from coded defaults.
     for os in _spec.options.values() do
       if not options.contains(os.name) then
@@ -138,27 +159,6 @@ class CommandParser
           end
         end
       end
-    end
-
-    // If it's a help option, return a general or specific CommandHelp.
-    if options.contains(_help_name()) then
-      return
-        if _spec is _root_spec() then
-          Help.general(_root_spec())
-        else
-          Help.for_command(_root_spec(), [_spec.name])
-        end
-    end
-
-    // If it's a help command, return a general or specific CommandHelp.
-    if _spec.name == _help_name() then
-      try
-        match args("command").value
-        | "" => return Help.general(_root_spec())
-        | let c: String => return Help.for_command(_root_spec(), [c])
-        end
-      end
-      return Help.general(_root_spec())
     end
 
     // Check for missing options and error if any exist.

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -127,15 +127,15 @@ class CommandParser
             else  // TODO(cq) why is else needed? we just checked
               ""
             end
-          let v: Value =
-            match _ValueParser.parse(os.typ(), vs)
-            | let v: Value => v
+          let v: _Value =
+            match _ValueParser.parse(os._typ_p(), vs)
+            | let v: _Value => v
             | let se: SyntaxError => return se
             end
           options.update(os.name(), Option(os, v))
         else
           if not os.required() then
-            options.update(os.name(), Option(os, os.default()))
+            options.update(os.name(), Option(os, os._default_p()))
           end
         end
       end
@@ -157,7 +157,7 @@ class CommandParser
         if ars.required() then
           return SyntaxError(ars.name(), "missing value for required argument")
         end
-        args.update(ars.name(), Arg(ars, ars.default()))
+        args.update(ars.name(), Arg(ars, ars._default_p()))
       end
       arg_pos = arg_pos + 1
     end
@@ -251,9 +251,9 @@ class CommandParser
     end
 
   fun box _option_with_short(short: U8): (OptionSpec | None) =>
-    for f in _spec.options().values() do
-      if f._has_short(short) then
-        return f
+    for o in _spec.options().values() do
+      if o._has_short(short) then
+        return o
       end
     end
     match _parent
@@ -285,8 +285,8 @@ primitive _OptionParser
     // Now convert the arg to Type, detecting missing or mis-typed args
     match arg
     | let a: String =>
-      match _ValueParser.parse(spec.typ(), a)
-      | let v: Value => Option(spec, v)
+      match _ValueParser.parse(spec._typ_p(), a)
+      | let v: _Value => Option(spec, v)
       | let se: SyntaxError => se
       end
     else
@@ -299,19 +299,19 @@ primitive _OptionParser
 
 primitive _ArgParser
   fun parse(spec: ArgSpec, arg: String): (Arg | SyntaxError) =>
-    match _ValueParser.parse(spec.typ(), arg)
-    | let v: Value => Arg(spec, v)
+    match _ValueParser.parse(spec._typ_p(), arg)
+    | let v: _Value => Arg(spec, v)
     | let se: SyntaxError => se
     end
 
 primitive _ValueParser
-  fun box parse(typ: ValueType, arg: String): (Value | SyntaxError) =>
+  fun box parse(typ: _ValueType, arg: String): (_Value | SyntaxError) =>
     try
       match typ
-      | let b: BoolType => arg.bool()
-      | let s: StringType => arg
-      | let f: F64Type => arg.f64()
-      | let i: I64Type => arg.i64()
+      | let b: _BoolType => arg.bool()
+      | let s: _StringType => arg
+      | let f: _F64Type => arg.f64()
+      | let i: _I64Type => arg.i64()
       end
     else
       SyntaxError(arg, "unable to convert '" + arg + "' to " + typ.string())

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -87,7 +87,8 @@ class CommandParser
           end
         else
           match _parse_arg(token, arg_pos)
-          | let a: Arg => args.update(a.spec().name(), a); arg_pos = arg_pos + 1
+          | let a: Arg => args.update(a.spec().name(), a)
+            arg_pos = arg_pos + 1
           | let se: SyntaxError => return se
           end
         end

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -1,0 +1,278 @@
+"""
+This package implements command line parsing with the notion of commands that
+are specified as a hierarchy.
+See RFC-xxx for more details.
+
+The general EBNF of the command line looks like:
+  command_line ::= root_command (option | command)* (option | arg)*
+  command ::= alphanum_word
+  alphanum_word ::= alphachar(alphachar | numchar | '_' | '-')*
+  option ::= longoption | shortoptionset
+  longoption ::= '--'alphanum_word['='arg | ' 'arg]
+  shortoptionset := '-'alphachar[alphachar]...['='arg | ' 'arg]
+  arg := boolarg | intarg | floatarg | stringarg
+  boolarg := 'true' | 'false'
+  intarg> := ['-'] numchar...
+  floatarg ::= ['-'] numchar... ['.' numchar...]
+  stringarg ::= anychar
+
+Some Examples:
+  usage: chat [<options>] <command> [<options>] [<args> ...]
+"""
+use col = "collections"
+
+class CommandSpec
+  """
+  CommandSpec describes the specification of a parent or leaf command. Each
+  command has the following attributes:
+
+  - a name: a simple string token that identifies the command.
+  - a description: used in the syntax message.
+  - a map of options: the valid options for this command.
+  - an optional help option+command name for help parsing
+  - one of:
+     - a Map of child commands.
+     - an Array of arguments.
+  """
+  let name: String
+  let descr: String
+  let options: col.Map[String, OptionSpec] = options.create()
+  var help_name: String = "xxx" // TODO: make this nice.
+
+  // A parent commands can have sub-commands; leaf commands can have args.
+  let commands: col.Map[String, CommandSpec box] = commands.create()
+  let args: Array[ArgSpec] = args.create()
+
+  new parent(name': String, descr': String = "",
+    options': Array[OptionSpec] box = Array[OptionSpec](),
+    commands': Array[CommandSpec] box = Array[CommandSpec]()) ?
+  =>
+    """
+    Create a command spec that can accept options and child commands, but not
+    arguments.
+    """
+    name = _assertName(name')
+    descr = descr'
+    for o in options'.values() do
+      options.update(o.name, o)
+    end
+    for c in commands'.values() do
+      commands.update(c.name, c)
+    end
+
+  new leaf(name': String, descr': String = "",
+    options': Array[OptionSpec] box = Array[OptionSpec](),
+    args': Array[ArgSpec] box = Array[ArgSpec]()) ?
+  =>
+    """
+    Create a command spec that can accept options and arguments, but not child
+    commands.
+    """
+    name = _assertName(name')
+    descr = descr'
+    for f in options'.values() do
+      options.update(f.name, f)
+    end
+    for a in args'.values() do
+      args.push(a)
+    end
+
+    fun tag _assertName(nm: String): String ? =>
+      for b in nm.values() do
+        if (b != '-') and (b != '_') and
+          not ((b >= '0') and (b <= '9')) and
+          not ((b >= 'A') and (b <= 'Z')) and
+          not ((b >= 'a') and (b <= 'z')) then
+          error
+        end
+      end
+      nm
+
+  fun ref add_command(cmd: CommandSpec) ? =>
+    """
+    Add an additional child command to this parent command.
+    """
+    if args.size() > 0 then error end
+    commands.update(cmd.name, cmd)
+
+  fun ref add_help(hname: String = "help") ? =>
+    """
+    Add a standard help option and command to this root command.
+    """
+    if args.size() > 0 then error end
+    help_name = hname
+    let help_cmd = CommandSpec.leaf(help_name, "", Array[OptionSpec](), [
+      ArgSpec.string("command" where default'="")
+    ])
+    commands.update(help_cmd.name, help_cmd)
+    let help_option = OptionSpec.bool(help_name, "", 'h')
+    options.update(help_option.name, help_option)
+
+  fun help_string(): String =>
+    let s = name.clone()
+    s.append(" ")
+    for a in args.values() do
+      s.append(a.help_string())
+    end
+    s
+
+
+class val OptionSpec
+  """
+  OptionSpec describes the specification of an option. Options have a name,
+  descr(iption), a short-name, a typ(e), and a default value when they are not
+  required. Options can be placed anywhere before or after commands, and can be
+  thought of like named arguments.
+  """
+  let name: String
+  let descr: String
+  let short: (U8 | None)
+  let typ: ValueType
+  let default: Value
+  let required: Bool
+
+  fun tag _init(typ': ValueType, default': (Value | None)) :
+    (ValueType, Value, Bool) ?
+  =>
+    match default'
+      | None =>
+        (typ', false, true)
+    else
+      (typ', default' as Value, false)
+    end
+
+  new val bool(name': String, descr': String = "",
+    short': (U8 | None) = None, default': (Bool | None) = None) ?
+  =>
+    name = name'
+    descr = descr'
+    short = short'
+    (typ, default, required) = _init(BoolType, default')
+
+  new val string(name': String, descr': String = "",
+    short': (U8 | None) = None, default': (String | None) = None) ?
+  =>
+    name = name'
+    descr = descr'
+    short = short'
+    (typ, default, required) = _init(StringType, default')
+
+  new val i64(name': String, descr': String = "",
+    short': (U8 | None) = None, default': (I64 | None) = None) ?
+  =>
+    name = name'
+    descr = descr'
+    short = short'
+    (typ, default, required) = _init(I64Type, default')
+
+  new val f64(name': String, descr': String = "",
+    short': (U8 | None) = None, default': (F64 | None) = None) ?
+  =>
+    name = name'
+    descr = descr'
+    short = short'
+    (typ, default, required) = _init(F64Type, default')
+
+  // Other than bools, all options require args.
+  fun _requires_arg(): Bool =>
+    match typ |(let b: BoolType) => false else true end
+    // TODO: why can't Pony match on just type? |BoolType=>...
+
+  // Used for bool options to get the true arg when option is present w/o arg
+  fun _default_arg(): Value =>
+    match typ |(let b: BoolType) => true else false end
+
+  fun _has_short(sh: U8): Bool =>
+    match short
+    | let ss: U8 => sh == ss
+    else
+      false
+    end
+
+  fun deb_string(): String =>
+    "--" + name + "[" + typ.string() + "]" +
+      if not required then "(=" + default.string() + ")" else "" end
+
+  fun help_string(): String =>
+    let s = match short
+      | let ss: U8 => "-" + String.from_utf32(ss.u32()) + ", "
+      else
+        "    "
+      end
+    let l = "--" + name
+    s + l
+
+
+class val ArgSpec
+  """
+  ArgSpec describes the specification of a positional argument. Args always
+  come after a leaf command, and are assigned in their positional order.
+  """
+  let name: String
+  let descr: String
+  let typ: ValueType
+  let default: Value
+  let required: Bool
+
+  fun tag _init(typ': ValueType, default': (Value | None))
+  :
+    (ValueType, Value, Bool) ?
+  =>
+    match default'
+      | None =>
+        (typ', false, true)
+    else
+      (typ', default' as Value, false)
+    end
+
+  new val bool(name': String, descr': String="", default': (Bool|None)=None) ?
+  =>
+    name = name'
+    descr = descr'
+    (typ, default, required) = _init(BoolType, default')
+
+  new val string(name': String, descr': String="", default': (String|None)=None) ?
+  =>
+    name = name'
+    descr = descr'
+    (typ, default, required) = _init(StringType, default')
+
+  new val i64(name': String, descr': String="", default': (I64|None)=None) ?
+  =>
+    name = name'
+    descr = descr'
+    (typ, default, required) = _init(I64Type, default')
+
+  new val f64(name': String, descr': String="", default': (F64|None)=None) ?
+  =>
+    name = name'
+    descr = descr'
+    (typ, default, required) = _init(F64Type, default')
+
+  fun deb_string(): String =>
+    name + "[" + typ.string() + "]" +
+      if not required then "(=" + default.string() + ")" else "" end
+
+  fun help_string(): String =>
+    "<" + name + ">"
+
+
+type Value is (Bool | String | I64 | F64)
+
+primitive BoolType
+  fun string(): String => "Bool"
+
+primitive StringType
+  fun string(): String => "String"
+
+primitive I64Type
+  fun string(): String => "I64"
+
+primitive F64Type
+  fun string(): String => "F64"
+
+type ValueType is
+  ( BoolType
+  | StringType
+  | I64Type
+  | F64Type)

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -145,19 +145,19 @@ class val OptionSpec
   let _name: String
   let _descr: String
   let _short: (U8 | None)
-  let _typ: ValueType
-  let _default: Value
+  let _typ: _ValueType
+  let _default: _Value
   let _required: Bool
 
-  fun tag _init(typ': ValueType, default': (Value | None))
-    : (ValueType, Value, Bool)
+  fun tag _init(typ': _ValueType, default': (_Value | None))
+    : (_ValueType, _Value, Bool)
   =>
     match default'
     | None => (typ', false, true)
-    | let d: Value => (typ', d, false)
+    | let d: _Value => (typ', d, false)
     else
       // Ponyc limitation: else can't happen, but segfaults without it
-      (BoolType, false, false)
+      (_BoolType, false, false)
     end
 
   new val bool(
@@ -169,7 +169,7 @@ class val OptionSpec
     _name = name'
     _descr = descr'
     _short = short'
-    (_typ, _default, _required) = _init(BoolType, default')
+    (_typ, _default, _required) = _init(_BoolType, default')
 
   new val string(
     name': String,
@@ -180,7 +180,7 @@ class val OptionSpec
     _name = name'
     _descr = descr'
     _short = short'
-    (_typ, _default, _required) = _init(StringType, default')
+    (_typ, _default, _required) = _init(_StringType, default')
 
   new val i64(name': String,
     descr': String = "",
@@ -190,7 +190,7 @@ class val OptionSpec
     _name = name'
     _descr = descr'
     _short = short'
-    (_typ, _default, _required) = _init(I64Type, default')
+    (_typ, _default, _required) = _init(_I64Type, default')
 
   new val f64(name': String,
     descr': String = "",
@@ -200,30 +200,30 @@ class val OptionSpec
     _name = name'
     _descr = descr'
     _short = short'
-    (_typ, _default, _required) = _init(F64Type, default')
+    (_typ, _default, _required) = _init(_F64Type, default')
 
   fun name(): String => _name
 
   fun descr(): String => _descr
 
-  fun typ(): ValueType => _typ
+  fun _typ_p(): _ValueType => _typ
 
-  fun default(): Value => _default
+  fun _default_p(): _Value => _default
 
   fun required(): Bool => _required
 
   // Other than bools, all options require args.
   fun _requires_arg(): Bool =>
     match _typ
-    | let _: BoolType => false
+    | let _: _BoolType => false
     else
       true
     end
 
   // Used for bool options to get the true arg when option is present w/o arg
-  fun _default_arg(): Value =>
+  fun _default_arg(): _Value =>
     match _typ
-    | let _: BoolType => true
+    | let _: _BoolType => true
     else
       false
     end
@@ -259,19 +259,19 @@ class val ArgSpec
   """
   let _name: String
   let _descr: String
-  let _typ: ValueType
-  let _default: Value
+  let _typ: _ValueType
+  let _default: _Value
   let _required: Bool
 
-  fun tag _init(typ': ValueType, default': (Value | None))
-    : (ValueType, Value, Bool)
+  fun tag _init(typ': _ValueType, default': (_Value | None))
+    : (_ValueType, _Value, Bool)
   =>
     match default'
     | None => (typ', false, true)
-    | let d: Value => (typ', d, false)
+    | let d: _Value => (typ', d, false)
     else
       // Ponyc limitation: else can't happen, but segfaults without it
-      (BoolType, false, false)
+      (_BoolType, false, false)
     end
 
   new val bool(
@@ -281,7 +281,7 @@ class val ArgSpec
   =>
     _name = name'
     _descr = descr'
-    (_typ, _default, _required) = _init(BoolType, default')
+    (_typ, _default, _required) = _init(_BoolType, default')
 
   new val string(
     name': String,
@@ -290,7 +290,7 @@ class val ArgSpec
   =>
     _name = name'
     _descr = descr'
-    (_typ, _default, _required) = _init(StringType, default')
+    (_typ, _default, _required) = _init(_StringType, default')
 
   new val i64(name': String,
     descr': String = "",
@@ -298,7 +298,7 @@ class val ArgSpec
   =>
     _name = name'
     _descr = descr'
-    (_typ, _default, _required) = _init(I64Type, default')
+    (_typ, _default, _required) = _init(_I64Type, default')
 
   new val f64(name': String,
     descr': String = "",
@@ -306,15 +306,15 @@ class val ArgSpec
   =>
     _name = name'
     _descr = descr'
-    (_typ, _default, _required) = _init(F64Type, default')
+    (_typ, _default, _required) = _init(_F64Type, default')
 
   fun name(): String => _name
 
   fun descr(): String => _descr
 
-  fun typ(): ValueType => _typ
+  fun _typ_p(): _ValueType => _typ
 
-  fun default(): Value => _default
+  fun _default_p(): _Value => _default
 
   fun required(): Bool => _required
 
@@ -325,22 +325,22 @@ class val ArgSpec
     _name + "[" + _typ.string() + "]" +
       if not _required then "(=" + _default.string() + ")" else "" end
 
-type Value is (Bool | String | I64 | F64)
+type _Value is (Bool | String | I64 | F64)
 
-primitive BoolType
+primitive _BoolType
   fun string(): String => "Bool"
 
-primitive StringType
+primitive _StringType
   fun string(): String => "String"
 
-primitive I64Type
+primitive _I64Type
   fun string(): String => "I64"
 
-primitive F64Type
+primitive _F64Type
   fun string(): String => "F64"
 
-type ValueType is
-  ( BoolType
-  | StringType
-  | I64Type
-  | F64Type )
+type _ValueType is
+  ( _BoolType
+  | _StringType
+  | _I64Type
+  | _F64Type )

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -34,14 +34,14 @@ class CommandSpec
      - a Map of child commands.
      - an Array of arguments.
   """
-  let name: String
-  let descr: String
-  let options: Map[String, OptionSpec] = options.create()
-  var help_name: String = ""
+  let _name: String
+  let _descr: String
+  let _options: Map[String, OptionSpec] = _options.create()
+  var _help_name: String = ""
 
   // A parent commands can have sub-commands; leaf commands can have args.
-  let commands: Map[String, CommandSpec box] = commands.create()
-  let args: Array[ArgSpec] = args.create()
+  let _commands: Map[String, CommandSpec box] = _commands.create()
+  let _args: Array[ArgSpec] = _args.create()
 
   new parent(
     name': String,
@@ -53,13 +53,13 @@ class CommandSpec
     Create a command spec that can accept options and child commands, but not
     arguments.
     """
-    name = _assertName(name')
-    descr = descr'
+    _name = _assertName(name')
+    _descr = descr'
     for o in options'.values() do
-      options.update(o.name, o)
+      _options.update(o.name(), o)
     end
     for c in commands'.values() do
-      commands.update(c.name, c)
+      _commands.update(c.name(), c)
     end
 
   new leaf(
@@ -72,13 +72,13 @@ class CommandSpec
     Create a command spec that can accept options and arguments, but not child
     commands.
     """
-    name = _assertName(name')
-    descr = descr'
-    for f in options'.values() do
-      options.update(f.name, f)
+    _name = _assertName(name')
+    _descr = descr'
+    for o in options'.values() do
+      _options.update(o.name(), o)
     end
     for a in args'.values() do
-      args.push(a)
+      _args.push(a)
     end
 
   fun tag _assertName(nm: String): String ? =>
@@ -92,103 +92,129 @@ class CommandSpec
     end
     nm
 
-  fun ref add_command(cmd: CommandSpec) ? =>
+  fun ref add_command(cmd: CommandSpec box) ? =>
     """
     Add an additional child command to this parent command.
     """
-    if args.size() > 0 then error end
-    commands.update(cmd.name, cmd)
+    if _args.size() > 0 then error end
+    _commands.update(cmd.name(), cmd)
 
   fun ref add_help(hname: String = "help") ? =>
     """
-    Add a standard help option and command to this root command.
+    Add a standard help option and, optionally, command to a root command.
     """
-    if args.size() > 0 then error end
-    help_name = hname
-    let help_cmd = CommandSpec.leaf(help_name, "", Array[OptionSpec](), [
-      ArgSpec.string("command" where default' = "")
-    ])
-    commands.update(help_cmd.name, help_cmd)
-    let help_option = OptionSpec.bool(help_name, "", 'h', false)
-    options.update(help_option.name, help_option)
+    _help_name = hname
+    let help_option = OptionSpec.bool(_help_name, "", 'h', false)
+    _options.update(_help_name, help_option)
+    if _args.size() == 0 then
+      let help_cmd = CommandSpec.leaf(_help_name, "", Array[OptionSpec](), [
+        ArgSpec.string("command" where default' = "")
+      ])
+      _commands.update(_help_name, help_cmd)
+    end
 
-  fun help_string(): String =>
-    let s = name.clone()
+  fun box name(): String => _name
+
+  fun box descr(): String => _descr
+
+  fun box options(): Map[String, OptionSpec] box => _options
+
+  fun box commands(): Map[String, CommandSpec box] box => _commands
+
+  fun box args(): Array[ArgSpec] box => _args
+
+  fun box help_name(): String => _help_name
+
+  fun box help_string(): String =>
+    let s = _name.clone()
     s.append(" ")
-    for a in args.values() do
+    for a in _args.values() do
       s.append(a.help_string())
     end
     s
 
 class val OptionSpec
   """
-  OptionSpec describes the specification of an option. Options have a name,
+  OptionSpec describes the specification of a named Option. They have a name,
   descr(iption), a short-name, a typ(e), and a default value when they are not
-  required. Options can be placed anywhere before or after commands, and can be
-  thought of as named (vs positional) arguments.
+  required.
+
+  Options can be placed anywhere before or after commands, and can be thought of
+  as named arguments.
   """
-  let name: String
-  let descr: String
-  let short: (U8 | None)
-  let typ: ValueType
-  let default: Value
-  let required: Bool
+  let _name: String
+  let _descr: String
+  let _short: (U8 | None)
+  let _typ: ValueType
+  let _default: Value
+  let _required: Bool
 
   fun tag _init(typ': ValueType, default': (Value | None))
-    : (ValueType, Value, Bool) ?
+    : (ValueType, Value, Bool)
   =>
     match default'
-    | None =>
-      (typ', false, true)
+    | None => (typ', false, true)
+    | let d: Value => (typ', d, false)
     else
-      (typ', default' as Value, false)
+      // Ponyc limitation: else can't happen, but segfaults without it
+      (BoolType, false, false)
     end
 
   new val bool(
     name': String,
     descr': String = "",
     short': (U8 | None) = None,
-    default': (Bool | None) = None) ?
+    default': (Bool | None) = None)
   =>
-    name = name'
-    descr = descr'
-    short = short'
-    (typ, default, required) = _init(BoolType, default')
+    _name = name'
+    _descr = descr'
+    _short = short'
+    (_typ, _default, _required) = _init(BoolType, default')
 
   new val string(
     name': String,
     descr': String = "",
     short': (U8 | None) = None,
-    default': (String | None) = None) ?
+    default': (String | None) = None)
   =>
-    name = name'
-    descr = descr'
-    short = short'
-    (typ, default, required) = _init(StringType, default')
+    _name = name'
+    _descr = descr'
+    _short = short'
+    (_typ, _default, _required) = _init(StringType, default')
 
   new val i64(name': String,
     descr': String = "",
     short': (U8 | None) = None,
-    default': (I64 | None) = None) ?
+    default': (I64 | None) = None)
   =>
-    name = name'
-    descr = descr'
-    short = short'
-    (typ, default, required) = _init(I64Type, default')
+    _name = name'
+    _descr = descr'
+    _short = short'
+    (_typ, _default, _required) = _init(I64Type, default')
 
   new val f64(name': String,
     descr': String = "",
     short': (U8 | None) = None,
-    default': (F64 | None) = None) ?
+    default': (F64 | None) = None)
   =>
-    name = name'
-    descr = descr'
-    short = short'
-    (typ, default, required) = _init(F64Type, default')
+    _name = name'
+    _descr = descr'
+    _short = short'
+    (_typ, _default, _required) = _init(F64Type, default')
+
+  fun name(): String => _name
+
+  fun descr(): String => _descr
+
+  fun typ(): ValueType => _typ
+
+  fun default(): Value => _default
+
+  fun required(): Bool => _required
 
   // Other than bools, all options require args.
   fun _requires_arg(): Bool =>
-    match typ
+    match _typ
     | let _: BoolType => false
     else
       true
@@ -196,95 +222,108 @@ class val OptionSpec
 
   // Used for bool options to get the true arg when option is present w/o arg
   fun _default_arg(): Value =>
-    match typ
+    match _typ
     | let _: BoolType => true
     else
       false
     end
 
   fun _has_short(sh: U8): Bool =>
-    match short
+    match _short
     | let ss: U8 => sh == ss
     else
       false
     end
 
-  fun deb_string(): String =>
-    "--" + name + "[" + typ.string() + "]" +
-      if not required then "(=" + default.string() + ")" else "" end
-
   fun help_string(): String =>
     let s =
-      match short
+      match _short
       | let ss: U8 => "-" + String.from_utf32(ss.u32()) + ", "
       else
         "    "
       end
-    s + "--" + name
+    s + "--" + _name +
+      if not _required then "=" + _default.string() else "" end
+
+  fun deb_string(): String =>
+    "--" + _name + "[" + _typ.string() + "]" +
+      if not _required then "(=" + _default.string() + ")" else "" end
 
 class val ArgSpec
   """
-  ArgSpec describes the specification of a positional argument. Args always
-  come after a leaf command, and are assigned in their positional order.
+  ArgSpec describes the specification of a positional Arg(ument). They have a
+  name, descr(iption), a typ(e), and a default value when they are not required.
+
+  Args always come after a leaf command, and are assigned in their positional
+  order.
   """
-  let name: String
-  let descr: String
-  let typ: ValueType
-  let default: Value
-  let required: Bool
+  let _name: String
+  let _descr: String
+  let _typ: ValueType
+  let _default: Value
+  let _required: Bool
 
   fun tag _init(typ': ValueType, default': (Value | None))
-    : (ValueType, Value, Bool) ?
+    : (ValueType, Value, Bool)
   =>
     match default'
-    | None =>
-      (typ', false, true)
+    | None => (typ', false, true)
+    | let d: Value => (typ', d, false)
     else
-      (typ', default' as Value, false)
+      // Ponyc limitation: else can't happen, but segfaults without it
+      (BoolType, false, false)
     end
 
   new val bool(
     name': String,
     descr': String = "",
-    default': (Bool|None) = None) ?
+    default': (Bool | None) = None)
   =>
-    name = name'
-    descr = descr'
-    (typ, default, required) = _init(BoolType, default')
+    _name = name'
+    _descr = descr'
+    (_typ, _default, _required) = _init(BoolType, default')
 
   new val string(
     name': String,
     descr': String = "",
-    default': (String|None) = None) ?
+    default': (String | None) = None)
   =>
-    name = name'
-    descr = descr'
-    (typ, default, required) = _init(StringType, default')
+    _name = name'
+    _descr = descr'
+    (_typ, _default, _required) = _init(StringType, default')
 
-  new val i64(
-    name': String,
+  new val i64(name': String,
     descr': String = "",
-    default': (I64|None) = None) ?
+    default': (I64 | None) = None)
   =>
-    name = name'
-    descr = descr'
-    (typ, default, required) = _init(I64Type, default')
+    _name = name'
+    _descr = descr'
+    (_typ, _default, _required) = _init(I64Type, default')
 
-  new val f64(
-    name': String,
+  new val f64(name': String,
     descr': String = "",
-    default': (F64|None) = None) ?
+    default': (F64 | None) = None)
   =>
-    name = name'
-    descr = descr'
-    (typ, default, required) = _init(F64Type, default')
+    _name = name'
+    _descr = descr'
+    (_typ, _default, _required) = _init(F64Type, default')
 
-  fun deb_string(): String =>
-    name + "[" + typ.string() + "]" +
-      if not required then "(=" + default.string() + ")" else "" end
+  fun name(): String => _name
+
+  fun descr(): String => _descr
+
+  fun typ(): ValueType => _typ
+
+  fun default(): Value => _default
+
+  fun required(): Bool => _required
 
   fun help_string(): String =>
-    "<" + name + ">"
+    "<" + _name + ">"
+
+  fun deb_string(): String =>
+    _name + "[" + _typ.string() + "]" +
+      if not _required then "(=" + _default.string() + ")" else "" end
 
 type Value is (Bool | String | I64 | F64)
 

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -125,7 +125,7 @@ class val OptionSpec
   OptionSpec describes the specification of an option. Options have a name,
   descr(iption), a short-name, a typ(e), and a default value when they are not
   required. Options can be placed anywhere before or after commands, and can be
-  thought of like named arguments.
+  thought of as named (vs positional) arguments.
   """
   let name: String
   let descr: String

--- a/packages/cli/env_vars.pony
+++ b/packages/cli/env_vars.pony
@@ -1,0 +1,38 @@
+use "collections"
+
+primitive EnvVars
+  fun apply(
+    envs: (Array[String] box | None),
+    prefix: String = "",
+    squash: Bool = false):
+    Map[String, String] val
+  =>
+    """
+    Turns an array of strings that look like environment variables, ie.
+    key=value, into a map from string to string. Can optionally filter for
+    keys matching a 'prefix', and will squash resulting keys to lowercase
+    iff 'squash' is true.
+
+    So:
+      <PREFIX><KEY>=<VALUE>
+    becomes:
+      {KEY, VALUE} or {key, VALUE}
+    """
+    let envsmap = recover Map[String, String]() end
+    match envs
+    | let envsarr: Array[String] box =>
+      let prelen = prefix.size().isize()
+      for e in envsarr.values() do
+        let eqpos = try e.find("=") else ISize.max_value() end
+        let ek: String val = e.substring(0, eqpos)
+        let ev: String val = e.substring(eqpos + 1)
+        if (prelen == 0) or ek.at(prefix, 0) then
+          if squash then
+            envsmap.update(ek.substring(prelen).lower(), ev)
+          else
+            envsmap.update(ek.substring(prelen), ev)
+          end
+        end
+      end
+    end
+    envsmap


### PR DESCRIPTION
Implementation of https://github.com/ponylang/rfcs/blob/master/text/0038-cli-format.md.
All rules and syntaxes are supported, and a help command and option are supported.

One small example is included, but the tests are pretty thorough as far as specs and command line combinations go.

I still need to deprecate the options package (I'm not sure how to do that). And update existing examples and the tutorial.

As a follow up, I also want to add support for list types, (lists of String, etc.), and a 'no' prefix to negate bool options.

I'm open to suggestions, especially regarding Pony usage, and how the value types are handled.