### PR TITLE
Fix usage string not complying with -Woverlength-strings.

### DIFF
--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -100,11 +100,11 @@ static opt_arg_t args[] =
 
 static void usage()
 {
-  printf(
+  printf("%s\n%s\n%s\n%s\n%s\n%s", // for complying with -Woverlength-strings
     "ponyc [OPTIONS] <package directory>\n"
-    "\n"
+    ,
     "The package directory defaults to the current directory.\n"
-    "\n"
+    ,
     "Options:\n"
     "  --version, -v   Print the version of the compiler and exit.\n"
     "  --help, -h      Print this help text and exit.\n"
@@ -120,7 +120,7 @@ static void usage()
     "  --runtimebc     Compile with the LLVM bitcode file for the runtime.\n"
     "  --pic           Compile using position independent code.\n"
     "  --docs, -g      Generate code documentation.\n"
-    "\n"
+    ,
     "Rarely needed options:\n"
     "  --safe          Allow only the listed packages to use C FFI.\n"
     "    =package      With no packages listed, only builtin is allowed.\n"
@@ -136,7 +136,7 @@ static void usage()
     "    =name         Default is the host architecture.\n"
     "  --linker        Set the linker command to use.\n"
     "    =name         Default is the compiler used to compile ponyc.\n"
-    "\n"
+    ,
     "Debugging options:\n"
     "  --verbose, -V   Verbosity level.\n"
     "    =0            Only print errors.\n"
@@ -176,7 +176,7 @@ static void usage()
     "  --files         Print source file names as each is processed.\n"
     "  --bnf           Print out the Pony grammar as human readable BNF.\n"
     "  --antlr         Print out the Pony grammar as an ANTLR file.\n"
-    "\n"
+    ,
     "Runtime options for Pony programs (not for use with ponyc):\n"
     "  --ponythreads   Use N scheduler threads. Defaults to the number of\n"
     "                  cores (not hyperthreads) available.\n"


### PR DESCRIPTION
A side effect of #1899 was that the usage string literal became too long for ISO C99. See https://github.com/ponylang/ponyc/pull/1899#issuecomment-300801255

This PR fixes that issue by breaking up the string into multiple string literals, joined by `printf`.

No changelog entry is necesary since this fixes a build issue on master, which has not been released yet. 