### PR TITLE
Fix outdated methods in persistent.Map docstring.

### DIFF
--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -19,14 +19,14 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
 
   ## Usage
   ```
-  let empty: Map[String,U32] = Maps.empty[String,U32]() // {}
+  let empty = Map[String,U32] // {}
   // Update returns a new map with the provided key set
   // to the provided value. The old map is unchanged.
   let m2 = m1("a") = 5 // {a: 5}
   let m3 = m2("b") = 10 // {a: 5, b: 10}
   let m4 = m3.remove("a") // {b: 10}
   // You can create a new map from key value pairs.
-  let map = Maps.from[String,U32]([("a", 2), ("b", 3)]) // {a: 2, b: 3}
+  let m5 = Map[String,U32].concat([("a", 2), ("b", 3)].values()) // {a: 2, b: 3}
   ```
   """
   let _root: _MapNode[K, V, H]


### PR DESCRIPTION
This PR removes some references to outdated methods in the docstring for `persistent.Map`.