### PR TITLE
Disallow exhaustive match when all cases jump away.

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -91,6 +91,11 @@ static bool is_match_exhaustive(pass_opt_t* opt, ast_t* expr_type, ast_t* cases)
   pony_assert(expr_type != NULL);
   pony_assert(ast_id(cases) == TK_CASES);
 
+  // Exhaustive match not yet supported for matches where all cases "jump away".
+  // The return/error/break/continue should be moved to outside the match.
+  if(ast_checkflag(cases, AST_FLAG_JUMPS_AWAY))
+    return false;
+
   // Construct a union of all pattern types that count toward exhaustive match.
   ast_t* cases_union_type = ast_from(cases, TK_UNIONTYPE);
 

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1056,11 +1056,14 @@ static bool refer_match(pass_opt_t* opt, ast_t* ast)
     ast_inheritbranch(ast, cases);
   }
 
-  if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
+  if(ast_id(else_clause) == TK_NONE)
   {
     branch_count++;
-    if(ast_id(else_clause) != TK_NONE)
-      ast_inheritbranch(ast, else_clause);
+  }
+  else if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
+  {
+    branch_count++;
+    ast_inheritbranch(ast, else_clause);
   }
 
   // If all branches jump away with no value, then we do too.

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -528,3 +528,18 @@ TEST_F(BadPonyTest, ThisDotWhereDefIsntInTheTrait)
   TEST_ERRORS_1(src,
     "can't find declaration of 'u'");
 }
+
+TEST_F(BadPonyTest, ExhaustiveMatchCasesJumpAway)
+{
+  // From issue #1898
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(b: Bool) =>\n"
+    "    if true then\n"
+    "      match b\n"
+    "      | let b': Bool => return\n"
+    "      end\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/sugar_expr.cc
+++ b/test/libponyc/sugar_expr.cc
@@ -865,3 +865,41 @@ TEST_F(SugarExprTest, MatchExhaustiveTupleIncludesDontCareType)
 
   TEST_COMPILE(src);
 }
+
+
+TEST_F(SugarExprTest, MatchNonExhaustiveAllCasesJumpAway)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "trait T3\n"
+
+    "primitive Foo\n"
+    "  fun apply(t': (T1 | T2 | T3)): Bool =>\n"
+    "    match t'\n"
+    "    | let t: T1 => return true\n"
+    "    | let t: T2 => return false\n"
+    "    | let t: T3 => return true\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+
+
+TEST_F(SugarExprTest, MatchExhaustiveSomeCasesJumpAway)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "trait T3\n"
+
+    "primitive Foo\n"
+    "  fun apply(t': (T1 | T2 | T3)): Bool =>\n"
+    "    match t'\n"
+    "    | let t: T1 => true\n"
+    "    | let t: T2 => return false\n"
+    "    | let t: T3 => return true\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Theoretically, it would be possible to detect and take advantage of
exhaustive match when all exhaustive cases jump away, and treat the
entire match block as jumping away. Unfortunately there is a circular
dependency between the code that determines which expressions jump away
and the code that detects an exhaustive match.

For now, we simply disable exhaustive match detection in such cases.

In practice, you should still be able to do what you're trying to do -
if you move the "jump away" code to outside the match block, then
exhaustive match can be detected on the match block.

Resolves #1898.

No changelog entry needed, since this fixes a bug in code that hasn't been in a release yet. 