### PR TITLE
Change iftype to use elseif instead of elseiftype as next keyword.

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -128,7 +128,7 @@ caseexpr
   ;
 
 elseiftype
-  : 'elseiftype' ('\\' ID (',' ID)* '\\')? type '<:' type 'then' rawseq (elseiftype | ('else' annotatedrawseq))?
+  : 'elseif' ('\\' ID (',' ID)* '\\')? type '<:' type 'then' rawseq (elseiftype | ('else' annotatedrawseq))?
   ;
 
 elseifdef

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -171,7 +171,6 @@ static const lextoken_t keywords[] =
   { "then", TK_THEN },
   { "else", TK_ELSE },
   { "elseif", TK_ELSEIF },
-  { "elseiftype", TK_ELSEIFTYPE },
   { "end", TK_END },
   { "for", TK_FOR },
   { "in", TK_IN },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -678,11 +678,11 @@ DEF(ifdef);
   REORDER(0, 2, 3, 1);
   DONE();
 
-// ELSEIFTYPE [annotations] type <: type THEN seq [elseiftype | (ELSE seq)]
+// ELSEIF [annotations] type <: type THEN seq [elseiftype | (ELSE seq)]
 DEF(elseiftype);
   AST_NODE(TK_IFTYPE);
   SCOPE();
-  SKIP(NULL, TK_ELSEIFTYPE);
+  SKIP(NULL, TK_ELSEIF);
   ANNOTATE(annotations);
   RULE("type", type);
   SKIP(NULL, TK_SUBTYPE);

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -148,7 +148,6 @@ typedef enum token_id
   TK_THEN,
   TK_ELSE,
   TK_ELSEIF,
-  TK_ELSEIFTYPE,
   TK_END,
   TK_WHILE,
   TK_DO,

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -231,6 +231,33 @@ TEST_F(IftypeTest, Codegen_False)
 }
 
 
+
+TEST_F(IftypeTest, Codegen_ElseIfTrue)
+{
+  const char* src =
+    "trait T\n"
+    "class C1 is T\n"
+    "class C2 is T\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C2](C2)\n"
+
+    "  fun foo[A: T](x: A) =>\n"
+    "    iftype A <: C1 then\n"
+    "      None\n"
+    "    elseif A <: C2 then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
 TEST_F(IftypeTest, UnconstrainedTypeparam)
 {
   const char* src =


### PR DESCRIPTION
This PR changes one of the keywords used in the new `iftype` syntax introduced in #1855.

Specifically, it changes the use of `elseiftype` to `elseif`. This is more consistent with `ifdef`, which uses `elseif` and not `elseifdef`.

The detail of what keyword to use for this wasn't included in [the RFC](https://github.com/ponylang/rfcs/blob/master/text/0026-subtype-checking.md), and I doubt very many people are using this feature yet given that the plan was to not formally announce it until the rest of the RFC was complete, so it seems like fair game to change.

Also, there were no tests using `elseiftype`, so I added a test using `elseif`.