### PR TITLE
xoroshiro128+ implementation

### DIFF
--- a/packages/random/mt.pony
+++ b/packages/random/mt.pony
@@ -1,11 +1,13 @@
 class MT is Random
   """
-  A Mersenne Twister. This is a non-cryptographic random number generator.
+  A Mersenne Twister. This is a non-cryptographic random number generator. This
+  should only be used for legacy applications that require a Mersenne Twister,
+  otherwise use Rand.
   """
   embed _state: Array[U64]
   var _index: USize
 
-  new create(seed: U64 = 5489) =>
+  new create(x: U64 = 5489, y: U64 = 0) =>
     """
     Create with the specified seed. Returned values are deterministic for a
     given seed.
@@ -13,14 +15,14 @@ class MT is Random
     _state = Array[U64](_n())
     _index = _n()
 
-    var x = seed
+    var seed = x xor y
 
-    _state.push(x)
+    _state.push(seed)
     var i: USize = 1
 
     while i < _n() do
-      x = ((x xor (x >> 62)) * 6364136223846793005) + i.u64()
-      _state.push(x)
+      seed = ((seed xor (seed >> 62)) * 6364136223846793005) + i.u64()
+      _state.push(seed)
       i = i + 1
     end
 

--- a/packages/random/random.pony
+++ b/packages/random/random.pony
@@ -4,7 +4,20 @@
 The Random package provides support generating random numbers. The package
 provides random number generators you can use in your code, a dice roller and
 a trait for implementing your own random number generator.
+
+If your application does not require a specific generator, use Rand.
+
+Seed values can contain up to 128 bits of randomness in the form of two U64s.
+A common non-cryptographically secure way to seed a generator is with
+`Time.now`.
+
+```
+let rand = Rand
+let n = rand.next()
+```
 """
+type Rand is XorOshiro128Plus
+
 trait Random
   """
   The `Random` trait should be implemented by all random number generators. The
@@ -12,6 +25,12 @@ trait Random
   has been implemented, the `Random` trait provides default implementations of
   conversions to other number types.
   """
+  new create(x: U64 = 5489, y: U64 = 0)
+    """
+    Create with the specified seed. Returned values are deterministic for a
+    given seed.
+    """
+
   fun tag has_next(): Bool =>
     """
     If used as an iterator, this always has another value.

--- a/packages/random/xoroshiro.pony
+++ b/packages/random/xoroshiro.pony
@@ -1,0 +1,31 @@
+class XorOshiro128Plus is Random
+  """
+  This is an implementation of xoroshiro128+, as detailed at:
+
+  http://xoroshiro.di.unimi.it
+
+  This is currently the default Rand implementation.
+  """
+  var _x: U64
+  var _y: U64
+
+  new create(x: U64 = 5489, y: U64 = 0) =>
+    """
+    Create with the specified seed. Returned values are deterministic for a
+    given seed.
+    """
+    _x = x
+    _y = y
+
+  fun ref next(): U64 =>
+    """
+    A random integer in [0, 2^64 - 1]
+    """
+    let x = _x
+    var y = _y
+    let r = x + y
+
+    y = x xor y
+    _x = x.rotl(55) xor y xor (y << 14)
+    _y = y.rotl(36)
+    r

--- a/packages/random/xorshift.pony
+++ b/packages/random/xorshift.pony
@@ -1,0 +1,31 @@
+class XorShift128Plus is Random
+  """
+  This is an implementation of xorshift+, as detailed at:
+
+  http://xoroshiro.di.unimi.it
+
+  This should only be used for legacy applications that specifically require
+  XorShift128Plus, otherwise use Rand.
+  """
+  var _x: U64
+  var _y: U64
+
+  new create(x: U64 = 5489, y: U64 = 0) =>
+    """
+    Create with the specified seed. Returned values are deterministic for a
+    given seed.
+    """
+    _x = x
+    _y = y
+
+  fun ref next(): U64 =>
+    """
+    A random integer in [0, 2^64 - 1]
+    """
+    var y = _x
+    let x = _y
+    let r = x + y
+    _x = x
+    y = y xor (y << 23)
+    _y = y xor x xor (y >> 18) xor (x >> 5)
+    r


### PR DESCRIPTION
This adds both xoroshiro128+ and xorshift128+ implementations.
The XorOshiro128Plus type should be used as the default
non-cryptographic PRNG. To make this simpler, a new Rand type
that aliases the preferred PRNG has been added, so that if a
new PRNG becomes preferred, the type alias can be changed.