### PR TITLE
Resolved compiler segfault on optimization pass (issue #1225)

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -449,8 +449,10 @@ static RegisterPass<HeapToStack>
 static void addHeapToStackPass(const PassManagerBuilder& pmb,
   PassManagerBase& pm)
 {
-  if(pmb.OptLevel >= 2)
+  if(pmb.OptLevel >= 2) {
+    pm.add(new DominatorTreeWrapperPass());
     pm.add(new HeapToStack());
+  }
 }
 
 class DispatchPonyCtx : public FunctionPass


### PR DESCRIPTION
"Move hep allocations to the stack" optimization pass depends on `DominatorTreeWrapperPass`, which wasn't initialized.