### PR TITLE
Update persistent map benchmarks

### DIFF
--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -40,8 +40,7 @@ class val _MapNode[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     match _entries(i.usize_unsafe())
     | (_, let v: V) => v
     | let sn: _MapNode[K, V, H] => sn(hash, key)
-    else
-      let cn = _entries(i.usize_unsafe()) as _MapCollisions[K, V, H]
+    | let cn: _MapCollisions[K, V, H] =>
       for l in cn.values() do
         if H.eq(l._1, key) then return l._2 end
       end

--- a/packages/collections/persistent/benchmarks/main.pony
+++ b/packages/collections/persistent/benchmarks/main.pony
@@ -5,12 +5,12 @@ actor Main
   new create(env: Env) =>
     let bench = PonyBench(env)
 
-    var map = Maps.empty[U64, U64]()
-    try map = map.update(0, 0) end
+    var map = Map[U64, U64]
+    map = map.update(0, 0)
 
     bench[Map[U64, U64]](
       "insert level 0",
-      {(): Map[U64, U64] ? => map.update(1, 1)} val)
+      {(): Map[U64, U64] => map.update(1, 1)} val)
 
     bench[U64](
       "get level 0",
@@ -18,7 +18,7 @@ actor Main
 
     bench[Map[U64, U64]](
       "update level 0",
-      {(): Map[U64, U64] ? => map.update(0, 1)} val)
+      {(): Map[U64, U64] => map.update(0, 1)} val)
 
     bench[Map[U64, U64]](
       "delete level 0",
@@ -26,10 +26,10 @@ actor Main
 
     bench[Map[U64, U64]](
       "create sub-node",
-      {(): Map[U64, U64] ? => map.update(32, 32)} val)
+      {(): Map[U64, U64] => map.update(32, 32)} val)
 
     // expand index 0 into 2 sub-nodes
-    try map = map.update(32, 32) end
+    map = map.update(32, 32)
 
     bench[Map[U64, U64]](
       "remove sub-node",
@@ -37,7 +37,7 @@ actor Main
 
     bench[Map[U64, U64]](
       "insert level 1",
-      {(): Map[U64, U64] ? => map.update(1, 1)} val)
+      {(): Map[U64, U64] => map.update(1, 1)} val)
 
     bench[U64](
       "get level 1",
@@ -45,9 +45,9 @@ actor Main
 
     bench[Map[U64, U64]](
       "update level 1",
-      {(): Map[U64, U64] ? => map.update(0, 1)} val)
+      {(): Map[U64, U64] => map.update(0, 1)} val)
 
-    try map = map.update(1, 1) end
+    map = map.update(1, 1)
 
     bench[Map[U64, U64]](
       "delete level 1",

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -170,7 +170,6 @@ class MapPairs[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
         _inc_i()
         next()
       end
-    else error
     end
 
   fun ref _push(n: _MapNode[K, V, H]) =>


### PR DESCRIPTION
This PR simplifies some of the _MapNode code with the recent addition of exhaustive match expressions. The benchmarks for persistent map is also updated so that it compiles.