### PR TITLE
Order basic blocks in LLVM IR in a logical way

### DIFF
--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -103,6 +103,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   }
 
   // Right branch.
+  LLVMMoveBasicBlockAfter(else_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, else_block);
   LLVMValueRef r_value;
 
@@ -134,6 +135,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
     return GEN_NOVALUE;
 
   // Continue in the post block.
+  LLVMMoveBasicBlockAfter(post_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, post_block);
 
   if(needed)
@@ -248,6 +250,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   // else
   // If the loop doesn't generate a value (doesn't execute, or continues on the
   // last iteration), the else clause generates the value.
+  LLVMMoveBasicBlockAfter(else_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, else_block);
   LLVMValueRef r_value = gen_expr(c, else_clause);
   LLVMBasicBlockRef else_from = NULL;
@@ -268,6 +271,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
     return GEN_NOVALUE;
 
   // post
+  LLVMMoveBasicBlockAfter(post_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, post_block);
 
   if(needed)
@@ -353,6 +357,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   // cond block
   // This is only evaluated from a continue, jumping either back to the body
   // or to the else block.
+  LLVMMoveBasicBlockAfter(cond_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, cond_block);
   LLVMValueRef i_value = gen_expr(c, cond);
 
@@ -366,6 +371,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
 
   // else
   // Only happens for a continue in the last iteration.
+  LLVMMoveBasicBlockAfter(else_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, else_block);
   LLVMValueRef else_value = gen_expr(c, else_clause);
   LLVMBasicBlockRef else_from = NULL;
@@ -386,6 +392,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
     return GEN_NOVALUE;
 
   // post
+  LLVMMoveBasicBlockAfter(post_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, post_block);
 
   if(needed)
@@ -545,6 +552,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   codegen_poptry(c);
 
   // Else block.
+  LLVMMoveBasicBlockAfter(else_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, else_block);
 
   // The landing pad is marked as a cleanup, since exceptions are typeless and
@@ -593,6 +601,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
     return GEN_NOVALUE;
 
   // Continue in the post block.
+  LLVMMoveBasicBlockAfter(post_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, post_block);
 
   if(needed)

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -115,6 +115,7 @@ static LLVMValueRef tuple_is(compile_t* c, ast_t* left_type, ast_t* right_type,
   LLVMPositionBuilderAtEnd(c->builder, this_block);
   LLVMBuildBr(c->builder, post_block);
 
+  LLVMMoveBasicBlockAfter(post_block, this_block);
   LLVMPositionBuilderAtEnd(c->builder, post_block);
   LLVMValueRef one = LLVMConstInt(c->i1, 1, false);
   LLVMAddIncoming(phi, &one, &this_block, 1);
@@ -143,6 +144,7 @@ static LLVMValueRef raw_is_box(compile_t* c, ast_t* left_type,
   LLVMBuildBr(c->builder, post_block);
   value_block = LLVMGetInsertBlock(c->builder);
 
+  LLVMMoveBasicBlockAfter(post_block, value_block);
   LLVMPositionBuilderAtEnd(c->builder, post_block);
   LLVMValueRef phi = LLVMBuildPhi(c->builder, c->i1, "");
   LLVMValueRef zero = LLVMConstInt(c->i1, 0, false);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -478,6 +478,7 @@ static void trace_maybe(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   gentrace(c, ctx, object, object, elem, elem);
   LLVMBuildBr(c->builder, is_true);
 
+  LLVMMoveBasicBlockAfter(is_true, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, is_true);
 }
 
@@ -758,6 +759,7 @@ static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
 
   // Continue with other possible tracings.
   LLVMBuildBr(c->builder, is_false);
+  LLVMMoveBasicBlockAfter(is_false, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, is_false);
 }
 
@@ -822,6 +824,7 @@ static void trace_dynamic_nominal(compile_t* c, LLVMValueRef ctx,
     LLVMBuildBr(c->builder, is_false);
 
   // Carry on, whether we have traced or not.
+  LLVMMoveBasicBlockAfter(is_false, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, is_false);
 }
 
@@ -1008,6 +1011,7 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,
       LLVMBasicBlockRef next_block = codegen_block(c, "");
       trace_dynamic(c, ctx, dst_value, src_type, dst_type, NULL, next_block);
       LLVMBuildBr(c->builder, next_block);
+      LLVMMoveBasicBlockAfter(next_block, LLVMGetInsertBlock(c->builder));
       LLVMPositionBuilderAtEnd(c->builder, next_block);
       return;
     }


### PR DESCRIPTION
This commit changes the ordering of basic blocks in generated LLVM IR to better reflect the high level control structures of Pony. This makes the resulting IR much more easier to understand.

This commit doesn't contain any functional changes.