### PR TITLE
Fix compiler crash on "_" as argument in a case expression.

### DIFF
--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1588,7 +1588,7 @@ static bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
   pony_assert(sub != NULL);
   pony_assert(super != NULL);
 
-  if(ast_id(super) == TK_DONTCARETYPE)
+  if((ast_id(super) == TK_DONTCARETYPE) || (ast_id(sub) == TK_DONTCARETYPE))
     return true;
 
   switch(ast_id(sub))

--- a/test/libponyc/dontcare.cc
+++ b/test/libponyc/dontcare.cc
@@ -147,3 +147,21 @@ TEST_F(DontcareTest, CannotUseDontcareInTupleRHS)
 
   TEST_ERRORS_1(src, "can't read from '_'");
 }
+
+
+TEST_F(DontcareTest, CannotUseDontcareAsArgumentInCaseExpression)
+{
+  // From issue #1922
+  const char* src =
+    "class C\n"
+    "  new create(i: U32) => None\n"
+    "  fun eq(that: C): Bool => false\n"
+
+    "primitive Foo\n"
+    "  fun apply(c: (C | None)) =>\n"
+    "    match c\n"
+    "    | C(_) => None\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "can't read from '_'");
+}


### PR DESCRIPTION
Resolves #1922.