### PR TITLE
Only generate internal methods when needed

### DIFF
--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -6,6 +6,7 @@
 #include "gencall.h"
 #include "gentype.h"
 #include "../expr/literal.h"
+#include "../reach/subtype.h"
 #include "../type/cap.h"
 #include "../type/subtype.h"
 #include "../type/viewpoint.h"
@@ -270,38 +271,7 @@ LLVMValueRef gen_addressof(compile_t* c, ast_t* ast)
   return NULL;
 }
 
-enum subtype_kind_t
-{
-  SUBTYPE_KIND_NONE,
-  SUBTYPE_KIND_BOXED = 1 << 0,
-  SUBTYPE_KIND_UNBOXED = 1 << 1,
-  SUBTYPE_KIND_BOTH = SUBTYPE_KIND_BOXED | SUBTYPE_KIND_UNBOXED
-};
-
-static int has_boxed_subtype(reach_t* reach, ast_t* type)
-{
-  reach_type_t* t = reach_type(reach, type);
-
-  int subtypes = SUBTYPE_KIND_NONE;
-
-  size_t i = HASHMAP_BEGIN;
-  reach_type_t* sub;
-
-  while((sub = reach_type_cache_next(&t->subtypes, &i)) != NULL)
-  {
-    if(sub->can_be_boxed)
-      subtypes |= SUBTYPE_KIND_BOXED;
-    else
-      subtypes |= SUBTYPE_KIND_UNBOXED;
-
-    if(subtypes == SUBTYPE_KIND_BOTH)
-      return subtypes;
-  }
-
-  return subtypes;
-}
-
-static LLVMValueRef gen_digestof_box(compile_t* c, ast_t* type,
+static LLVMValueRef gen_digestof_box(compile_t* c, reach_type_t* type,
   LLVMValueRef value, int boxed_subtype)
 {
   pony_assert(LLVMGetTypeKind(LLVMTypeOf(value)) == LLVMPointerTypeKind);
@@ -312,7 +282,7 @@ static LLVMValueRef gen_digestof_box(compile_t* c, ast_t* type,
 
   LLVMValueRef desc = gendesc_fetch(c, value);
 
-  if(boxed_subtype == SUBTYPE_KIND_BOTH)
+  if((boxed_subtype & SUBTYPE_KIND_UNBOXED) != 0)
   {
     box_block = codegen_block(c, "digestof_box");
     nonbox_block = codegen_block(c, "digestof_nonbox");
@@ -329,16 +299,15 @@ static LLVMValueRef gen_digestof_box(compile_t* c, ast_t* type,
   }
 
   // Call the type-specific __digestof function, which will unbox the value.
-  reach_type_t* t = reach_type(c->reach, type);
-  reach_method_t* digest_fn = reach_method(t, TK_BOX, stringtab("__digestof"),
-    NULL);
+  reach_method_t* digest_fn = reach_method(type, TK_BOX,
+    stringtab("__digestof"), NULL);
   pony_assert(digest_fn != NULL);
   LLVMValueRef func = gendesc_vtable(c, desc, digest_fn->vtable_index);
   LLVMTypeRef fn_type = LLVMFunctionType(c->i64, &c->object_ptr, 1, false);
   func = LLVMBuildBitCast(c->builder, func, LLVMPointerType(fn_type, 0), "");
   LLVMValueRef box_digest = codegen_call(c, func, &value, 1, true);
 
-  if(boxed_subtype == SUBTYPE_KIND_BOTH)
+  if((boxed_subtype & SUBTYPE_KIND_UNBOXED) != 0)
   {
     LLVMBuildBr(c->builder, post_block);
 
@@ -412,9 +381,11 @@ static LLVMValueRef gen_digestof_value(compile_t* c, ast_t* type,
     case LLVMPointerTypeKind:
       if(!is_known(type))
       {
-        int sub_kind = has_boxed_subtype(c->reach, type);
+        reach_type_t* t = reach_type(c->reach, type);
+        int sub_kind = subtype_kind(t);
+
         if((sub_kind & SUBTYPE_KIND_BOXED) != 0)
-          return gen_digestof_box(c, type, value, sub_kind);
+          return gen_digestof_box(c, t, value, sub_kind);
       }
 
       return LLVMBuildPtrToInt(c->builder, value, c->i64, "");
@@ -438,7 +409,9 @@ void gen_digestof_fun(compile_t* c, reach_type_t* t)
   pony_assert(t->can_be_boxed);
 
   reach_method_t* m = reach_method(t, TK_BOX, stringtab("__digestof"), NULL);
-  pony_assert(m != NULL);
+
+  if(m == NULL)
+    return;
 
   m->func_type = LLVMFunctionType(c->i64, &t->structure_ptr, 1, false);
   m->func = codegen_addfun(c, m->full_name, m->func_type);

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -17,6 +17,7 @@ typedef struct reach_field_t reach_field_t;
 typedef struct reach_param_t reach_param_t;
 typedef struct reach_type_t reach_type_t;
 
+DECLARE_STACK(reachable_expr_stack, reachable_expr_stack_t, ast_t);
 DECLARE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
 DECLARE_HASHMAP(reach_methods, reach_methods_t, reach_method_t);
 DECLARE_HASHMAP(reach_mangled, reach_mangled_t, reach_method_t);
@@ -128,7 +129,8 @@ struct reach_type_t
 typedef struct
 {
   reach_types_t types;
-  reach_method_stack_t* stack;
+  reachable_expr_stack_t* expr_stack;
+  reach_method_stack_t* method_stack;
   uint32_t object_type_count;
   uint32_t numeric_type_count;
   uint32_t tuple_type_count;

--- a/src/libponyc/reach/subtype.c
+++ b/src/libponyc/reach/subtype.c
@@ -1,0 +1,68 @@
+#include "subtype.h"
+#include <ponyassert.h>
+
+int subtype_kind(reach_type_t* type)
+{
+  int subtypes = SUBTYPE_KIND_NONE;
+
+  size_t i = HASHMAP_BEGIN;
+  reach_type_t* sub;
+
+  while((sub = reach_type_cache_next(&type->subtypes, &i)) != NULL)
+  {
+    if(sub->can_be_boxed)
+    {
+      if(type->underlying == TK_PRIMITIVE)
+        subtypes |= SUBTYPE_KIND_NUMERIC;
+      else
+        subtypes |= SUBTYPE_KIND_TUPLE;
+    } else {
+      subtypes |= SUBTYPE_KIND_UNBOXED;
+    }
+
+    if(subtypes == SUBTYPE_KIND_ALL)
+      return subtypes;
+  }
+
+  return subtypes;
+}
+
+int subtype_kind_overlap(reach_type_t* left, reach_type_t* right)
+{
+  int subtypes = SUBTYPE_KIND_NONE;
+
+  size_t i = HASHMAP_BEGIN;
+  reach_type_t* sub_left;
+
+  while((sub_left = reach_type_cache_next(&left->subtypes, &i)) != NULL)
+  {
+    if(!sub_left->can_be_boxed)
+    {
+      subtypes |= SUBTYPE_KIND_UNBOXED;
+      if(subtypes == SUBTYPE_KIND_ALL)
+        return subtypes;
+
+      continue;
+    }
+
+    reach_type_t k;
+    k.name = sub_left->name;
+    size_t j = HASHMAP_UNKNOWN;
+    reach_type_t* sub_right = reach_type_cache_get(&right->subtypes, &k, &j);
+
+    if(sub_right != NULL)
+    {
+      pony_assert(sub_left == sub_right);
+
+      if(sub_left->underlying == TK_PRIMITIVE)
+        subtypes |= SUBTYPE_KIND_NUMERIC;
+      else
+        subtypes |= SUBTYPE_KIND_TUPLE;
+
+      if(subtypes == SUBTYPE_KIND_ALL)
+        return subtypes;
+    }
+  }
+
+  return subtypes;
+}

--- a/src/libponyc/reach/subtype.h
+++ b/src/libponyc/reach/subtype.h
@@ -1,0 +1,27 @@
+#ifndef REACH_SUBTYPE_H
+#define REACH_SUBTYPE_H
+
+#include "reach.h"
+
+PONY_EXTERN_C_BEGIN
+
+enum subtype_kind_t
+{
+  SUBTYPE_KIND_NONE,
+  SUBTYPE_KIND_NUMERIC = 1 << 0,
+  SUBTYPE_KIND_TUPLE = 1 << 1,
+  SUBTYPE_KIND_UNBOXED = 1 << 2,
+
+  SUBTYPE_KIND_BOXED = SUBTYPE_KIND_NUMERIC | SUBTYPE_KIND_TUPLE,
+  SUBTYPE_KIND_ALL = SUBTYPE_KIND_BOXED | SUBTYPE_KIND_UNBOXED
+};
+
+// These functions shouldn't be called before `reach_done` has been called.
+
+int subtype_kind(reach_type_t* type);
+
+int subtype_kind_overlap(reach_type_t* left, reach_type_t* right);
+
+PONY_EXTERN_C_END
+
+#endif


### PR DESCRIPTION
This change is an optimisation allowing the compiler to generate the `__is` and `__digestof` methods for a type only when needed. This saves a vtable slot for each method which isn't generated.