### PR TITLE
Make tuples be subtypes of empty interfaces (like Any).

### DIFF
--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -713,25 +713,19 @@ static bool is_tuple_sub_nominal(ast_t* sub, ast_t* super,
     if(ast_childcount(super_members) == 0)
     {
       // This is an empty interface, so we let the tuple be a subtype if the
-      // caps of the elements of the tuple are subcaps of the supertype cap.
+      // caps of the elements of the tuple are subcaps of the interface cap.
       for(ast_t* child = ast_child(sub);
         child != NULL;
         child = ast_sibling(child))
       {
-        if(!is_sub_cap_and_eph(child, super, check_cap, errorf, opt))
+        if(!is_x_sub_x(child, super, check_cap, errorf, opt))
         {
           if(errorf != NULL)
           {
-            ast_t* child_cap = cap_fetch(child);
-            ast_t* child_eph = ast_sibling(child_cap);
-            ast_t* super_cap = cap_fetch(super);
-            ast_t* super_eph = ast_sibling(super_cap);
-
             ast_error_frame(errorf, child,
-              "%s is not a subtype of %s: %s%s is not a subcap of %s%s",
+              "%s is not a subtype of %s: %s is not a subtype of %s",
               ast_print_type(sub), ast_print_type(super),
-              ast_print_type(child_cap), ast_print_type(child_eph),
-              ast_print_type(super_cap), ast_print_type(super_eph));
+              ast_print_type(child), ast_print_type(super));
           }
           return false;
         }

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1097,6 +1097,20 @@ TEST_F(SubTypeTest, TupleTagTagNotSubAnyVal)
 }
 
 
+TEST_F(SubTypeTest, TupleRefValOrValSubAnyBox)
+{
+  const char* src =
+    "class C\n"
+    "class D\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C ref, (C val | D val))) =>\n"
+    "    let x': Any box = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
 TEST_F(SubTypeTest, TupleValTagSubAnyShare)
 {
   const char* src =

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -5,6 +5,10 @@
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
 
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
 class SubTypeTest: public PassTest
 {};
 
@@ -1051,4 +1055,67 @@ TEST_F(SubTypeTest, IsTypeparamSubIntersect)
   ASSERT_TRUE(is_subtype(type_of("b"), type_of("a"), NULL, &opt));
 
   pass_opt_init(&opt);
+}
+
+
+TEST_F(SubTypeTest, TupleValRefSubAnyBox)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C val, C ref)) =>\n"
+    "    let x': Any box = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTagTagSubAnyTag)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C tag, C tag)) =>\n"
+    "    let x': Any tag = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTagTagNotSubAnyVal)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C tag, C tag)) =>\n"
+    "    let x': Any val = consume x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleValTagSubAnyShare)
+{
+  const char* src =
+    "class C[A: Any #share]\n"
+    "primitive P\n"
+    "  fun apply() =>\n"
+    "    C[(String val, String tag)]";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleValRefNotSubAnyShare)
+{
+  const char* src =
+    "class C[A: Any #share]\n"
+    "primitive P\n"
+    "  fun apply() =>\n"
+    "    C[(String val, String ref)]";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
 }


### PR DESCRIPTION
After this commit, a tuple is considered a subtype of `Any ${cap}`
if all of the elements of the tuple are subcaps of the cap.

This is a principle of least surprise issue, as it is surprising
that a type param constraint of `Any #any` does not behave the same
as an unconstrained type param, with the latter accepting tuple
type args, and the latter not doing so.

Previously, there was no way to allow tuples of any cardinality
as a type argument, while restricting what caps were allowed to
be in those tuples (such as for the concerns of aliasing or
sendability). For example, `class List[A]` in the `collections`
package allowed tuples as type args, but `class List[A: Any #share]`
in the `collections/persistent` package did not. Now they both
allow tuple type args, and the `Any #share` constrains the type arg
so that all tuple elements must be shareable (`val` or `tag`).

Resolves #1767.