### PR TITLE
Change machine word constructors to have no default argument.

### DIFF
--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -1,5 +1,5 @@
 primitive I8 is _SignedInteger[I8, U8]
-  new create(value: I8 = 0) => value
+  new create(value: I8) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i8()
 
   new min_value() => -0x80
@@ -38,7 +38,7 @@ primitive I8 is _SignedInteger[I8, U8]
     @"llvm.smul.with.overflow.i8"[(I8, Bool)](this, y)
 
 primitive I16 is _SignedInteger[I16, U16]
-  new create(value: I16 = 0) => value
+  new create(value: I16) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i16()
 
   new min_value() => -0x8000
@@ -77,7 +77,7 @@ primitive I16 is _SignedInteger[I16, U16]
     @"llvm.smul.with.overflow.i16"[(I16, Bool)](this, y)
 
 primitive I32 is _SignedInteger[I32, U32]
-  new create(value: I32 = 0) => value
+  new create(value: I32) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i32()
 
   new min_value() => -0x8000_0000
@@ -116,7 +116,7 @@ primitive I32 is _SignedInteger[I32, U32]
     @"llvm.smul.with.overflow.i32"[(I32, Bool)](this, y)
 
 primitive I64 is _SignedInteger[I64, U64]
-  new create(value: I64 = 0) => value
+  new create(value: I64) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i64()
 
   new min_value() => -0x8000_0000_0000_0000
@@ -155,7 +155,7 @@ primitive I64 is _SignedInteger[I64, U64]
     @"llvm.smul.with.overflow.i64"[(I64, Bool)](this, y)
 
 primitive ILong is _SignedInteger[ILong, ULong]
-  new create(value: ILong = 0) => value
+  new create(value: ILong) => value
   new from[A: (Number & Real[A] val)](a: A) => a.ilong()
 
   new min_value() =>
@@ -242,7 +242,7 @@ primitive ILong is _SignedInteger[ILong, ULong]
     end
 
 primitive ISize is _SignedInteger[ISize, USize]
-  new create(value: ISize = 0) => value
+  new create(value: ISize) => value
   new from[A: (Number & Real[A] val)](a: A) => a.isize()
 
   new min_value() =>
@@ -329,7 +329,7 @@ primitive ISize is _SignedInteger[ISize, USize]
     end
 
 primitive I128 is _SignedInteger[I128, U128]
-  new create(value: I128 = 0) => value
+  new create(value: I128) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i128()
 
   new min_value() => -0x8000_0000_0000_0000_0000_0000_0000_0000

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -1,5 +1,5 @@
 primitive U8 is _UnsignedInteger[U8]
-  new create(value: U8 = 0) => value
+  new create(value: U8) => value
   new from[B: (Number & Real[B] val)](a: B) => a.u8()
 
   new min_value() => 0
@@ -41,7 +41,7 @@ primitive U8 is _UnsignedInteger[U8]
     @"llvm.umul.with.overflow.i8"[(U8, Bool)](this, y)
 
 primitive U16 is _UnsignedInteger[U16]
-  new create(value: U16 = 0) => value
+  new create(value: U16) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u16()
 
   new min_value() => 0
@@ -83,7 +83,7 @@ primitive U16 is _UnsignedInteger[U16]
     @"llvm.umul.with.overflow.i16"[(U16, Bool)](this, y)
 
 primitive U32 is _UnsignedInteger[U32]
-  new create(value: U32 = 0) => value
+  new create(value: U32) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u32()
 
   new min_value() => 0
@@ -125,7 +125,7 @@ primitive U32 is _UnsignedInteger[U32]
     @"llvm.umul.with.overflow.i32"[(U32, Bool)](this, y)
 
 primitive U64 is _UnsignedInteger[U64]
-  new create(value: U64 = 0) => value
+  new create(value: U64) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u64()
 
   new min_value() => 0
@@ -167,7 +167,7 @@ primitive U64 is _UnsignedInteger[U64]
     @"llvm.umul.with.overflow.i64"[(U64, Bool)](this, y)
 
 primitive ULong is _UnsignedInteger[ULong]
-  new create(value: ULong = 0) => value
+  new create(value: ULong) => value
   new from[A: (Number & Real[A] val)](a: A) => a.ulong()
 
   new min_value() => 0
@@ -261,7 +261,7 @@ primitive ULong is _UnsignedInteger[ULong]
     end
 
 primitive USize is _UnsignedInteger[USize]
-  new create(value: USize = 0) => value
+  new create(value: USize) => value
   new from[A: (Number & Real[A] val)](a: A) => a.usize()
 
   new min_value() => 0
@@ -355,7 +355,7 @@ primitive USize is _UnsignedInteger[USize]
     end
 
 primitive U128 is _UnsignedInteger[U128]
-  new create(value: U128 = 0) => value
+  new create(value: U128) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u128()
 
   new min_value() => 0

--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -25,8 +25,8 @@ class _MachineWords
   var i32: I32 = 0x12345678
   var i64: I64 = 0x7EDCBA9876543210
   var i128: I128 = 0x7EDCBA9876543210123456789ABCDEFE
-  var ilong: ILong = ILong(1) << (ILong.bitwidth() - 1)
-  var isize: ISize = ISize(1) << (ISize.bitwidth() - 1)
+  var ilong: ILong = ILong(1) << (ILong(0).bitwidth() - 1)
+  var isize: ISize = ISize(1) << (ISize(0).bitwidth() - 1)
   var f32: F32 = 1.2345e-13
   var f64: F64 = 9.82643431e19
 
@@ -49,8 +49,8 @@ class _StructWords
   var u32: U32 = 0x12345678
   var u64: U64 = 0xFEDCBA9876543210
   var u128: U128 = 0xFEDCBA9876543210123456789ABCDEFE
-  var ulong: ULong = 1 << (ULong.bitwidth() - 1)
-  var usize: USize = 1 << (USize.bitwidth() - 1)
+  var ulong: ULong = 1 << (ULong(0).bitwidth() - 1)
+  var usize: USize = 1 << (USize(0).bitwidth() - 1)
 
   fun eq(that: _StructWords box): Bool =>
     (u8 == that.u8) and


### PR DESCRIPTION
This is meant to prevent confusion/surprise with respect to other primitives
whose value can be compared using `is ${PrimitiveName}`. Machine words
are special primitives that can have multiple values, and comparing
with `is ${MachineWord}` is currently equivalent to comparing to zero.

Incidentally, fixing this also alerts us to the bug in #1920.

We should hold off on merging this PR until after #1927 is merged.