### PR TITLE
Don't use llvm toolchain from apt.llvm.org for LLVM 3.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.9
           packages:
             - g++-6
-            - llvm-3.9-dev
       env:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.9.1"
@@ -93,10 +91,8 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.9
           packages:
             - g++-6
-            - llvm-3.9-dev
       env:
         - FAVORITE_CONFIG=yes
         - LLVM_VERSION="3.9.1"

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -43,20 +43,8 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   ;;
 
   "linux:llvm-config-3.9")
+    download_llvm
     download_pcre
-
-    echo "Logging LLVM binary locations (installed via APT)..."
-    echo "llvm-config-3.9: $(which llvm-config-3.9)"
-    echo "clang++-3.9: $(which clang++-3.9)"
-    echo "clang-3.9: $(which clang-3.9)"
-
-    found_version="$(llvm-config-3.9 --version)"
-    echo "LLVM version: $found_version"
-
-    if [[ "$found_version" != "$LLVM_VERSION" ]]
-    then
-      echo "WARNING: the LLVM version expected ($LLVM_VERSION) does not match that installed ($found_version)!"
-    fi
   ;;
 
   "osx:llvm-config-3.7")


### PR DESCRIPTION
as it will link ponyc against libllvm3.9 which is not available on most vanilla ubuntu distributions
and must be installed via http://apt.llvm.org/

Using the prebuilt binaries links llvm libs statically into the ponyc binary so we end up with a package
without (implicit) dependency on libllvm3.9

resolves #1833

---

i was not able to test the actual packaging process.