### PR TITLE
Fix compiler crash when a field is used in a default argument.

### DIFF
--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -624,17 +624,17 @@ bool expr_digestof(pass_opt_t* opt, ast_t* ast)
 
 bool expr_this(pass_opt_t* opt, ast_t* ast)
 {
-  if(ast_id(ast_child(opt->check.frame->method)) == TK_AT)
-  {
-    ast_error(opt->check.errors, ast,
-      "can't reference 'this' in a bare method");
-    return false;
-  }
-
   if(opt->check.frame->def_arg != NULL)
   {
     ast_error(opt->check.errors, ast,
       "can't reference 'this' in a default argument");
+    return false;
+  }
+
+  if(ast_id(ast_child(opt->check.frame->method)) == TK_AT)
+  {
+    ast_error(opt->check.errors, ast,
+      "can't reference 'this' in a bare method");
     return false;
   }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -585,3 +585,17 @@ TEST_F(BadPonyTest, TypeArgErrorInsideReturn)
 
   TEST_ERRORS_1(src, "not enough type arguments");
 }
+
+TEST_F(BadPonyTest, FieldReferenceInDefaultArgument)
+{
+  const char* src =
+    "actor Main\n"
+    "  let _env: Env\n"
+    "  new create(env: Env) =>\n"
+    "    _env = env\n"
+    "    foo()\n"
+    "  fun foo(env: Env = _env) =>\n"
+    "    None";
+
+  TEST_ERRORS_1(src, "can't reference 'this' in a default argument");
+}


### PR DESCRIPTION
This PR fixes a compiler crash when a field is used in a default argument.

This was broken as a side effect the placement of a check
introduced in #1858, and was fixed by just changing the order
of the checks so that we don't expect to be in a method body frame
if we are in a default argument frame.