### PR TITLE
Fix compiler crash on non-existent field reference in constructor.

### DIFF
--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -633,7 +633,9 @@ static bool is_lvalue(pass_opt_t* opt, ast_t* ast, bool need_value)
       if(ast_id(left) == TK_THIS)
       {
         ast_t* def = (ast_t*)ast_data(ast);
-        pony_assert(def != NULL);
+
+        if(def == NULL)
+          return false;
 
         switch(ast_id(def))
         {

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -571,6 +571,19 @@ TEST_F(BadPonyTest, CallArgTypeErrorInsideTuple)
   TEST_ERRORS_1(src, "argument not a subtype of parameter");
 }
 
+TEST_F(BadPonyTest, NonExistFieldReferenceInConstructor)
+{
+  // From issue #1932
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    this.x = None";
+
+  TEST_ERRORS_2(src,
+    "can't find declaration of 'x'",
+    "left side must be something that can be assigned to");
+}
+
 TEST_F(BadPonyTest, TypeArgErrorInsideReturn)
 {
   const char* src =


### PR DESCRIPTION
This PR fixes a compiler crash on non-existent field reference in constructor.

Resolves #1932.