### PR TITLE
Parameterise allocations and exceptions in serialisation

### DIFF
--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -5,6 +5,10 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef void* (*serialise_alloc_fn)(pony_ctx_t* ctx, size_t size);
+
+typedef void (*serialise_throw_fn)();
+
 typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
@@ -16,11 +20,14 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
-PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, void* out);
+PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, pony_type_t* t,
+  void* out, serialise_alloc_fn alloc_fn, serialise_throw_fn throw_fn);
 PONY_API size_t pony_serialise_offset(pony_ctx_t* ctx, void* p);
 PONY_API void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size);
 
-PONY_API void* pony_deserialise(pony_ctx_t* ctx, void* in);
+PONY_API void* pony_deserialise(pony_ctx_t* ctx, pony_type_t* t, void* in,
+  serialise_alloc_fn alloc_fn, serialise_alloc_fn alloc_final_fn,
+  serialise_throw_fn throw_fn);
 PONY_API void* pony_deserialise_block(pony_ctx_t* ctx, uintptr_t offset,
   size_t size);
 PONY_API void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -32,6 +32,9 @@ typedef struct pony_ctx_t
   void* serialise_buffer;
   size_t serialise_size;
   ponyint_serialise_t serialise;
+  serialise_alloc_fn serialise_alloc;
+  serialise_alloc_fn serialise_alloc_final;
+  serialise_throw_fn serialise_throw;
 } pony_ctx_t;
 
 struct scheduler_t


### PR DESCRIPTION
This change allows custom allocation and exception raising strategies to be used in the serialisation API.

This is preliminary work for AST and reachability map serialisation (which is itself preliminary work for separate compilation). Serialising these data structures requires custom allocations (since compiler objects can't be allocated with `pony_alloc`) and custom exception raising (since C code can't catch Pony exceptions).