### PR TITLE
Fix assertion failure on nested tuple identity

### DIFF
--- a/test/libponyc/codegen_identity.cc
+++ b/test/libponyc/codegen_identity.cc
@@ -203,6 +203,25 @@ TEST_F(CodegenIdentityTest, AbstractTypeNoSubtyping)
 }
 
 
+TEST_F(CodegenIdentityTest, NestedTuple)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: (((U8, U16) | None, U8) | None) = None\n"
+    "    let b: (((U8, U16) | None, U8) | None) = None\n"
+    "    if a is b then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
 TEST_F(CodegenIdentityTest, DigestofObject)
 {
   const char* src =


### PR DESCRIPTION
This fixes a bug introduced in 9b9c084 caused by the `__is` method of a tuple nested in another tuple not being reached.

This should only get a changelog entry if we do a new release before merging this, since the bug exists only in the unreleased version.