### PR TITLE
Inherit AST flags by default.

### DIFF
--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -206,35 +206,9 @@ ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
     case TK_TRY:
     case TK_TRY_NO_CHECK: r = verify_try(options, ast); break;
     case TK_DONTCAREREF:  r = verify_dontcareref(options, ast); break;
-    case TK_LETREF:
-    case TK_VARREF:
-    case TK_FLETREF:
-    case TK_FVARREF:
-    case TK_EMBEDREF:
-    case TK_TUPLEELEMREF:
-    case TK_CALL:
-    case TK_QUALIFY:
-    case TK_TUPLE:
-    case TK_MATCH:
-    case TK_CASES:
-    case TK_CASE:
-    case TK_IS:
-    case TK_ISNT:
-    case TK_SEQ:
-    case TK_BREAK:
-    case TK_RETURN:
-    case TK_IF:
-    case TK_IFDEF:
-    case TK_WHILE:
-    case TK_REPEAT:
-    case TK_RECOVER:
-    case TK_POSITIONALARGS:
-    case TK_NAMEDARGS:
-    case TK_NAMEDARG:
-    case TK_UPDATEARG:    ast_inheritflags(ast); break;
     case TK_ERROR:        ast_seterror(ast); break;
 
-    default: {}
+    default:              ast_inheritflags(ast); break;
   }
 
   if(!r)

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -447,6 +447,22 @@ TEST_F(VerifyTest, InterfaceNonPartialFunctionError)
     "function body can raise an error");
 }
 
+TEST_F(VerifyTest, IfTypeError)
+{
+  const char* src =
+    "primitive A\n"
+    "primitive B\n"
+
+    "primitive Foo\n"
+    "  fun apply[X: (A|B)]() =>\n"
+    "    iftype X <: A then\n"
+    "      error\n"
+    "    end\n";
+
+  TEST_ERRORS_1(src, "function signature is not marked as partial but the "
+    "function body can raise an error");
+}
+
 TEST_F(VerifyTest, FFICallPartial)
 {
   const char* src =


### PR DESCRIPTION
TK_IFTYPE handling was not added to the verify pass, which leads to
errors in iftype blocks to not be propagated.

This commit makes inheriting of flags the default, so it is not forgotten
when adding more features.

Fixes #1954