### PR TITLE
Fix support for recursive constraints in iftype conditions.

### DIFF
--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -264,7 +264,7 @@ bool frame_push(typecheck_t* t, ast_t* ast)
           break;
         }
 
-        case TK_IFTYPE:
+        case TK_IFTYPE_CLAUSE:
         {
           AST_GET_CHILDREN(parent, l_type, r_type, body);
 

--- a/src/libponyc/ast/frame.c
+++ b/src/libponyc/ast/frame.c
@@ -264,7 +264,7 @@ bool frame_push(typecheck_t* t, ast_t* ast)
           break;
         }
 
-        case TK_IFTYPE_CLAUSE:
+        case TK_IFTYPE:
         {
           AST_GET_CHILDREN(parent, l_type, r_type, body);
 

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -169,7 +169,7 @@ static const lextoken_t keywords[] =
 
   { "if", TK_IF },
   { "ifdef", TK_IFDEF },
-  { "iftype", TK_IFTYPE },
+  { "iftype", TK_IFTYPE_SET },
   { "then", TK_THEN },
   { "else", TK_ELSE },
   { "elseif", TK_ELSEIF },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -739,8 +739,8 @@ DEF(ifdef);
   DONE();
 
 // type <: type THEN seq
-DEF(iftypeclause);
-  AST_NODE(TK_IFTYPE_CLAUSE);
+DEF(iftype);
+  AST_NODE(TK_IFTYPE);
   SCOPE();
   RULE("type", type);
   SKIP(NULL, TK_SUBTYPE);
@@ -749,23 +749,23 @@ DEF(iftypeclause);
   RULE("then value", seq);
   DONE();
 
-// ELSEIF [annotations] iftypeclause [elseiftype | (ELSE seq)]
+// ELSEIF [annotations] iftype [elseiftype | (ELSE seq)]
 DEF(elseiftype);
-  AST_NODE(TK_IFTYPE);
+  AST_NODE(TK_IFTYPE_SET);
   SKIP(NULL, TK_ELSEIF);
   ANNOTATE(annotations);
   SCOPE();
-  RULE("iftype clause", iftypeclause);
+  RULE("iftype clause", iftype);
   OPT RULE("else clause", elseiftype, elseclause);
   DONE();
 
-// IFTYPE [annotations] iftypeclause [elseiftype | (ELSE seq)] END
-DEF(iftype);
+// IFTYPE_SET [annotations] iftype [elseiftype | (ELSE seq)] END
+DEF(iftypeset);
   PRINT_INLINE();
-  TOKEN(NULL, TK_IFTYPE);
+  TOKEN(NULL, TK_IFTYPE_SET);
   SCOPE();
   ANNOTATE(annotations);
-  RULE("iftype clause", iftypeclause);
+  RULE("iftype clause", iftype);
   OPT RULE("else clause", elseiftype, elseclause);
   TERMINATE("iftype expression", TK_END);
   DONE();
@@ -968,18 +968,18 @@ DEF(test_ifdef_flag);
   TOKEN(NULL, TK_ID);
   DONE();
 
-// cond | ifdef | iftype | match | whileloop | repeat | forloop | with | try |
+// cond | ifdef | iftypeset | match | whileloop | repeat | forloop | with | try |
 // recover | consume | pattern | const_expr | test_<various>
 DEF(term);
-  RULE("value", cond, ifdef, iftype, match, whileloop, repeat, forloop, with,
+  RULE("value", cond, ifdef, iftypeset, match, whileloop, repeat, forloop, with,
     try_block, recover, consume, pattern, const_expr, test_noseq,
     test_seq_scope, test_try_block, test_ifdef_flag, test_prefix);
   DONE();
 
-// cond | ifdef | iftype | match | whileloop | repeat | forloop | with | try |
+// cond | ifdef | iftypeset | match | whileloop | repeat | forloop | with | try |
 // recover | consume | pattern | const_expr | test_<various>
 DEF(nextterm);
-  RULE("value", cond, ifdef, iftype, match, whileloop, repeat, forloop, with,
+  RULE("value", cond, ifdef, iftypeset, match, whileloop, repeat, forloop, with,
     try_block, recover, consume, nextpattern, const_expr, test_noseq,
     test_seq_scope, test_try_block, test_ifdef_flag, test_prefix);
   DONE();

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -738,31 +738,34 @@ DEF(ifdef);
   REORDER(0, 2, 3, 1);
   DONE();
 
-// ELSEIF [annotations] type <: type THEN seq [elseiftype | (ELSE seq)]
-DEF(elseiftype);
-  AST_NODE(TK_IFTYPE);
+// type <: type THEN seq
+DEF(iftypeclause);
+  AST_NODE(TK_IFTYPE_CLAUSE);
   SCOPE();
-  SKIP(NULL, TK_ELSEIF);
-  ANNOTATE(annotations);
   RULE("type", type);
   SKIP(NULL, TK_SUBTYPE);
   RULE("type", type);
   SKIP(NULL, TK_THEN);
   RULE("then value", seq);
+  DONE();
+
+// ELSEIF [annotations] iftypeclause [elseiftype | (ELSE seq)]
+DEF(elseiftype);
+  AST_NODE(TK_IFTYPE);
+  SKIP(NULL, TK_ELSEIF);
+  ANNOTATE(annotations);
+  SCOPE();
+  RULE("iftype clause", iftypeclause);
   OPT RULE("else clause", elseiftype, elseclause);
   DONE();
 
-// IFTYPE [annotations] type <: type THEN seq [elseiftype | (ELSE seq)] END
+// IFTYPE [annotations] iftypeclause [elseiftype | (ELSE seq)] END
 DEF(iftype);
   PRINT_INLINE();
   TOKEN(NULL, TK_IFTYPE);
-  ANNOTATE(annotations);
   SCOPE();
-  RULE("type", type);
-  SKIP(NULL, TK_SUBTYPE);
-  RULE("type", type);
-  SKIP(NULL, TK_THEN);
-  RULE("then value", seq);
+  ANNOTATE(annotations);
+  RULE("iftype clause", iftypeclause);
   OPT RULE("else clause", elseiftype, elseclause);
   TERMINATE("iftype expression", TK_END);
   DONE();

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -148,7 +148,7 @@ typedef enum token_id
   TK_IF,
   TK_IFDEF,
   TK_IFTYPE,
-  TK_IFTYPE_CLAUSE,
+  TK_IFTYPE_SET,
   TK_THEN,
   TK_ELSE,
   TK_ELSEIF,

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -148,6 +148,7 @@ typedef enum token_id
   TK_IF,
   TK_IFDEF,
   TK_IFTYPE,
+  TK_IFTYPE_CLAUSE,
   TK_THEN,
   TK_ELSE,
   TK_ELSEIF,

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -156,7 +156,8 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
 {
-  AST_GET_CHILDREN(ast, subtype, supertype, left, right);
+  AST_GET_CHILDREN(ast, left_clause, right);
+  AST_GET_CHILDREN(left_clause, subtype, supertype, left);
 
   if(is_subtype_constraint(subtype, supertype, NULL, c->opt))
     return gen_expr(c, left);

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -156,11 +156,11 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
 {
-  AST_GET_CHILDREN(ast, left_clause, right);
-  AST_GET_CHILDREN(left_clause, subtype, supertype, left);
+  AST_GET_CHILDREN(ast, left, right);
+  AST_GET_CHILDREN(left, subtype, supertype, body);
 
   if(is_subtype_constraint(subtype, supertype, NULL, c->opt))
-    return gen_expr(c, left);
+    return gen_expr(c, body);
 
   return gen_expr(c, right);
 }

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -64,7 +64,7 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       ret = gen_if(c, ast);
       break;
 
-    case TK_IFTYPE:
+    case TK_IFTYPE_SET:
       ret = gen_iftype(c, ast);
       break;
 

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -137,7 +137,8 @@ bool expr_if(pass_opt_t* opt, ast_t* ast)
 bool expr_iftype(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_IFTYPE);
-  AST_GET_CHILDREN(ast, sub, super, left, right);
+  AST_GET_CHILDREN(ast, left_control, right);
+  AST_GET_CHILDREN(left_control, sub, super, left);
 
   ast_t* type = NULL;
 

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -136,7 +136,7 @@ bool expr_if(pass_opt_t* opt, ast_t* ast)
 
 bool expr_iftype(pass_opt_t* opt, ast_t* ast)
 {
-  pony_assert(ast_id(ast) == TK_IFTYPE);
+  pony_assert(ast_id(ast) == TK_IFTYPE_SET);
   AST_GET_CHILDREN(ast, left_control, right);
   AST_GET_CHILDREN(left_control, sub, super, left);
 

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -56,7 +56,7 @@ bool is_result_needed(ast_t* ast)
 
       return is_result_needed(parent);
 
-    case TK_IFTYPE_CLAUSE:
+    case TK_IFTYPE:
       // Sub/supertype not needed, body needed only if parent needed.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
@@ -78,7 +78,7 @@ bool is_result_needed(ast_t* ast)
       return is_result_needed(parent);
 
     case TK_CASES:
-    case TK_IFTYPE:
+    case TK_IFTYPE_SET:
     case TK_TRY:
     case TK_TRY_NO_CHECK:
     case TK_RECOVER:
@@ -136,7 +136,7 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
         return false;
       break;
 
-    case TK_IFTYPE_CLAUSE:
+    case TK_IFTYPE:
       // The subtype and the supertype are not the result.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
@@ -155,7 +155,7 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
       break;
 
     case TK_CASES:
-    case TK_IFTYPE:
+    case TK_IFTYPE_SET:
     case TK_RECOVER:
       // These can be results.
       break;
@@ -256,7 +256,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_CALL:       r = expr_call(options, astp); break;
     case TK_IFDEF:
     case TK_IF:         r = expr_if(options, ast); break;
-    case TK_IFTYPE:     r = expr_iftype(options, ast); break;
+    case TK_IFTYPE_SET: r = expr_iftype(options, ast); break;
     case TK_WHILE:      r = expr_while(options, ast); break;
     case TK_REPEAT:     r = expr_repeat(options, ast); break;
     case TK_TRY_NO_CHECK:

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -56,8 +56,8 @@ bool is_result_needed(ast_t* ast)
 
       return is_result_needed(parent);
 
-    case TK_IFTYPE:
-      // Sub/supertype not needed, body/else needed only if parent needed.
+    case TK_IFTYPE_CLAUSE:
+      // Sub/supertype not needed, body needed only if parent needed.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
 
@@ -78,6 +78,7 @@ bool is_result_needed(ast_t* ast)
       return is_result_needed(parent);
 
     case TK_CASES:
+    case TK_IFTYPE:
     case TK_TRY:
     case TK_TRY_NO_CHECK:
     case TK_RECOVER:
@@ -135,7 +136,7 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
         return false;
       break;
 
-    case TK_IFTYPE:
+    case TK_IFTYPE_CLAUSE:
       // The subtype and the supertype are not the result.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
@@ -154,6 +155,7 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
       break;
 
     case TK_CASES:
+    case TK_IFTYPE:
     case TK_RECOVER:
       // These can be results.
       break;

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -935,7 +935,7 @@ static bool refer_if(pass_opt_t* opt, ast_t* ast)
 static bool refer_iftype(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
-  pony_assert(ast_id(ast) == TK_IFTYPE);
+  pony_assert(ast_id(ast) == TK_IFTYPE_SET);
 
   AST_GET_CHILDREN(ast, left_clause, right);
   AST_GET_CHILDREN(left_clause, sub, super, left);
@@ -1291,7 +1291,8 @@ ast_result_t pass_refer(ast_t** astp, pass_opt_t* options)
     case TK_SEQ:       r = refer_seq(options, ast); break;
     case TK_IFDEF:
     case TK_IF:        r = refer_if(options, ast); break;
-    case TK_IFTYPE:    r = refer_iftype(options, ast); break;
+    case TK_IFTYPE_SET:
+                       r = refer_iftype(options, ast); break;
     case TK_WHILE:     r = refer_while(options, ast); break;
     case TK_REPEAT:    r = refer_repeat(options, ast); break;
     case TK_MATCH:     r = refer_match(options, ast); break;

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -936,7 +936,9 @@ static bool refer_iftype(pass_opt_t* opt, ast_t* ast)
 {
   (void)opt;
   pony_assert(ast_id(ast) == TK_IFTYPE);
-  AST_GET_CHILDREN(ast, sub, super, left, right);
+
+  AST_GET_CHILDREN(ast, left_clause, right);
+  AST_GET_CHILDREN(left_clause, sub, super, left);
 
   size_t branch_count = 0;
 

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -203,7 +203,7 @@ static ast_result_t scope_iftype_clause(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_IFTYPE_CLAUSE);
 
-  AST_GET_CHILDREN(ast, subtype, supertype, body);
+  AST_GET_CHILDREN(ast, subtype, supertype);
 
   ast_t* typeparams = ast_from(ast, TK_TYPEPARAMS);
 
@@ -211,14 +211,14 @@ static ast_result_t scope_iftype_clause(pass_opt_t* opt, ast_t* ast)
   {
     case TK_NOMINAL:
     {
-      ast_t* typeparam = make_iftype_typeparam(opt, subtype, supertype, body);
+      ast_t* typeparam = make_iftype_typeparam(opt, subtype, supertype, ast);
       if(typeparam == NULL)
       {
         ast_free_unattached(typeparams);
         return AST_ERROR;
       }
 
-      if(!set_scope(opt, body, ast_child(typeparam), typeparam, true))
+      if(!set_scope(opt, ast, ast_child(typeparam), typeparam, true))
       {
         ast_free_unattached(typeparams);
         return AST_ERROR;
@@ -253,14 +253,14 @@ static ast_result_t scope_iftype_clause(pass_opt_t* opt, ast_t* ast)
       while(sub_child != NULL)
       {
         ast_t* typeparam = make_iftype_typeparam(opt, sub_child, super_child,
-          body);
+          ast);
         if(typeparam == NULL)
         {
           ast_free_unattached(typeparams);
           return AST_ERROR;
         }
 
-        if(!set_scope(opt, body, ast_child(typeparam), typeparam, true))
+        if(!set_scope(opt, ast, ast_child(typeparam), typeparam, true))
         {
           ast_free_unattached(typeparams);
           return AST_ERROR;

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -199,9 +199,11 @@ static ast_t* make_iftype_typeparam(pass_opt_t* opt, ast_t* subtype,
   return typeparam;
 }
 
-static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
+static ast_result_t scope_iftype_clause(pass_opt_t* opt, ast_t* ast)
 {
-  AST_GET_CHILDREN(ast, subtype, supertype, then_clause);
+  pony_assert(ast_id(ast) == TK_IFTYPE_CLAUSE);
+
+  AST_GET_CHILDREN(ast, subtype, supertype, body);
 
   ast_t* typeparams = ast_from(ast, TK_TYPEPARAMS);
 
@@ -209,15 +211,14 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
   {
     case TK_NOMINAL:
     {
-      ast_t* typeparam = make_iftype_typeparam(opt, subtype, supertype,
-        then_clause);
+      ast_t* typeparam = make_iftype_typeparam(opt, subtype, supertype, body);
       if(typeparam == NULL)
       {
         ast_free_unattached(typeparams);
         return AST_ERROR;
       }
 
-      if(!set_scope(opt, then_clause, ast_child(typeparam), typeparam, true))
+      if(!set_scope(opt, body, ast_child(typeparam), typeparam, true))
       {
         ast_free_unattached(typeparams);
         return AST_ERROR;
@@ -252,14 +253,14 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
       while(sub_child != NULL)
       {
         ast_t* typeparam = make_iftype_typeparam(opt, sub_child, super_child,
-          then_clause);
+          body);
         if(typeparam == NULL)
         {
           ast_free_unattached(typeparams);
           return AST_ERROR;
         }
 
-        if(!set_scope(opt, then_clause, ast_child(typeparam), typeparam, true))
+        if(!set_scope(opt, body, ast_child(typeparam), typeparam, true))
         {
           ast_free_unattached(typeparams);
           return AST_ERROR;
@@ -322,8 +323,8 @@ ast_result_t pass_scope(ast_t** astp, pass_opt_t* options)
       ast_setdata(ast, ast);
       break;
 
-    case TK_IFTYPE:
-      return scope_iftype(options, ast);
+    case TK_IFTYPE_CLAUSE:
+      return scope_iftype_clause(options, ast);
 
     default: {}
   }

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -199,9 +199,9 @@ static ast_t* make_iftype_typeparam(pass_opt_t* opt, ast_t* subtype,
   return typeparam;
 }
 
-static ast_result_t scope_iftype_clause(pass_opt_t* opt, ast_t* ast)
+static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
 {
-  pony_assert(ast_id(ast) == TK_IFTYPE_CLAUSE);
+  pony_assert(ast_id(ast) == TK_IFTYPE);
 
   AST_GET_CHILDREN(ast, subtype, supertype);
 
@@ -323,8 +323,8 @@ ast_result_t pass_scope(ast_t** astp, pass_opt_t* options)
       ast_setdata(ast, ast);
       break;
 
-    case TK_IFTYPE_CLAUSE:
-      return scope_iftype_clause(options, ast);
+    case TK_IFTYPE:
+      return scope_iftype(options, ast);
 
     default: {}
   }

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -193,7 +193,8 @@ static ast_t* make_iftype_typeparam(pass_opt_t* opt, ast_t* subtype,
       TREE(new_constraint)
       NONE));
 
-  ast_setdata(typeparam, typeparam);
+  // keep data pointing to the original def
+  ast_setdata(typeparam, ast_data(def));
 
   return typeparam;
 }

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1267,7 +1267,7 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_IF:
     case TK_WHILE:
     case TK_REPEAT:           return sugar_else(ast, 2);
-    case TK_IFTYPE:           return sugar_else(ast, 3);
+    case TK_IFTYPE:           return sugar_else(ast, 1);
     case TK_TRY:              return sugar_try(ast);
     case TK_FOR:              return sugar_for(options, astp);
     case TK_WITH:             return sugar_with(options, astp);

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1267,7 +1267,7 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_IF:
     case TK_WHILE:
     case TK_REPEAT:           return sugar_else(ast, 2);
-    case TK_IFTYPE:           return sugar_else(ast, 1);
+    case TK_IFTYPE_SET:       return sugar_else(ast, 1);
     case TK_TRY:              return sugar_try(ast);
     case TK_FOR:              return sugar_for(options, astp);
     case TK_WITH:             return sugar_with(options, astp);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1240,7 +1240,7 @@ static void reachable_expr(reach_t* r, ast_t* ast, pass_opt_t* opt)
       break;
     }
 
-    case TK_IFTYPE:
+    case TK_IFTYPE_SET:
     {
       AST_GET_CHILDREN(ast, left_clause, right);
       AST_GET_CHILDREN(left_clause, sub, super, left);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1242,7 +1242,8 @@ static void reachable_expr(reach_t* r, ast_t* ast, pass_opt_t* opt)
 
     case TK_IFTYPE:
     {
-      AST_GET_CHILDREN(ast, sub, super, left, right);
+      AST_GET_CHILDREN(ast, left_clause, right);
+      AST_GET_CHILDREN(left_clause, sub, super, left);
 
       ast_t* type = ast_type(ast);
 

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -273,3 +273,24 @@ TEST_F(IftypeTest, UnconstrainedTypeparam)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(IftypeTest, NestedCond)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+    "  fun tag c() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A](x: A) =>\n"
+    "    iftype A <: T then\n"
+    "      iftype A <: C then\n"
+    "        x.c()\n"
+    "      end\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -274,6 +274,57 @@ TEST_F(IftypeTest, UnconstrainedTypeparam)
   TEST_COMPILE(src);
 }
 
+TEST_F(IftypeTest, RecursiveConstraint)
+{
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A](x': A) =>\n"
+    "    var x = x'\n"
+    "    iftype A <: T[A] then\n"
+    "      x = x.m()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, Tuple_MutuallyRecursiveConstraint)
+{
+  const char* src =
+    "trait T[X]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[D]\n"
+    "  fun tag m(): D => D.create()\n"
+
+    "class val D is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C,D](C, D)\n"
+
+    "  fun foo[A, B](x': A, y': B) =>\n"
+    "    var x = x'\n"
+    "    var y = y'\n"
+    "    iftype (A, B) <: (T[B], T[A]) then\n"
+    "      x = y.m()\n"
+    "      y = x.m()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+
 TEST_F(IftypeTest, NestedCond)
 {
   const char* src =


### PR DESCRIPTION
By defining the shadowing TK_TYPEPARAM on the entire iftype clause, which
contains both the constraint and the body, the appropriate definition
of the type variable is used when it appears in the constraint.

Fixes #1960

---

Iftype is implemented by creating a new definition of the typeparameter with a constraint which combines both the original constraint and the RHS of the iftype. This TK_TYPEPARAM shadows the original definition inside the iftype body.

The third commit moves the shadowing constraint from the body to the entire iftype, so it gets picked up by the constraint as well. This allows recursive constraints such as the examples in #1960.

However we don't want it to get used by the else clause of the iftype. The second commit creates a new AST node, TK_IFTYPE_CLAUSE, containing the constraint and the body. This isolates the various branches of the iftypes in individual scopes.

Finally the reification used subtyping of constraints to compare if a typeparam was shadowing the other one. I ran into issues with this since the two constraints are defined in separate scopes now.

Instead, the first commit changes it to have the ast_data always point to the original typeparam.
This way, even if a typeparam is an iftype shadowing of another, their data pointers will be equal.
I believe this matches @sylvanc's original intention in cb5c611bcce7533c5862efcfefb04030c55596a2.

cc @jemc for #1960. This should allow my examples with recursive constraints in that issue
cc @Praetonus who implemented iftypes