### PR TITLE
Fix reference-after-free in reachability map

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -32,6 +32,7 @@
  *   set_scope_no_parent()
  *   make_orphan_leave_scope()
  *   ast_parent()
+ *   ast_set_scope()
  */
 
 /* Every AST node has an annotation_type field, which points to the annotation
@@ -454,6 +455,13 @@ bool ast_has_scope(ast_t* ast)
 {
   pony_assert(ast != NULL);
   return ast->symtab != NULL;
+}
+
+void ast_set_scope(ast_t* ast, ast_t* scope)
+{
+  pony_assert(ast != NULL);
+  pony_assert(!hasparent(ast));
+  set_scope_no_parent(ast, scope);
 }
 
 symtab_t* ast_get_symtab(ast_t* ast)

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -60,6 +60,7 @@ ast_t* ast_from_float(ast_t* ast, double value);
 ast_t* ast_dup(ast_t* ast);
 void ast_scope(ast_t* ast);
 bool ast_has_scope(ast_t* ast);
+void ast_set_scope(ast_t* ast, ast_t* scope);
 symtab_t* ast_get_symtab(ast_t* ast);
 ast_t* ast_setid(ast_t* ast, token_id id);
 void ast_setpos(ast_t* ast, source_t* source, size_t line, size_t pos);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -639,7 +639,10 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
           ast_name(ast_child(member)));
         pony_assert(r_member != NULL);
 
-        AST_GET_CHILDREN(r_member, name, type, init);
+        ast_t* name = ast_pop(r_member);
+        ast_t* type = ast_pop(r_member);
+        ast_add(r_member, name);
+        ast_set_scope(type, member);
 
         bool embed = t->fields[index].embed = ast_id(member) == TK_EMBED;
         t->fields[index].ast = reify(ast_type(member), typeparams, typeargs,
@@ -650,8 +653,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
         if(embed && !has_finaliser && !needs_finaliser)
           needs_finaliser = embed_has_finaliser(type, str_final);
 
-        if(r_member != member)
-          ast_free_unattached(r_member);
+        ast_free_unattached(r_member);
 
         index++;
         break;


### PR DESCRIPTION
This change fixes an issue in the reachability map where a previously freed AST was still being referenced by other ASTs.

This wasn't causing any problem in the current version of the compiler, but resulted in an use-after-free bug in the upcoming AST serialisation work.