### PR TITLE
Add serialisation of compiler objects

### DIFF
--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -205,6 +205,8 @@ void ast_extract_children(ast_t* parent, size_t child_count,
       children); \
   }
 
+pony_type_t* ast_pony_type();
+
 typedef struct unattached_asts_t
 {
   ast_t** storage;

--- a/src/libponyc/ast/source.h
+++ b/src/libponyc/ast/source.h
@@ -6,6 +6,8 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef const struct _pony_type_t pony_type_t;
+
 typedef struct source_t
 {
   const char* file;  // NULL => from string, not file
@@ -31,6 +33,8 @@ source_t* source_open_string(const char* source_code);
  * May be called on sources that failed to open.
  */
 void source_close(source_t* source);
+
+pony_type_t* source_pony_type();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -1,5 +1,6 @@
 #include "stringtab.h"
 #include "../../libponyrt/ds/hash.h"
+#include "../../libponyrt/gc/serialise.h"
 #include "../../libponyrt/mem/pool.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -115,4 +116,126 @@ void stringtab_done()
 {
   strtable_destroy(&table);
   memset(&table, 0, sizeof(strtable_t));
+}
+
+static void string_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset, int mutability)
+{
+  (void)ctx;
+  (void)mutability;
+
+  const char* string = (const char*)object;
+
+  memcpy((void*)((uintptr_t)buf + offset), object, strlen(string) + 1);
+}
+
+static __pony_thread_local struct _pony_type_t string_pony =
+{
+  0,
+  0,
+  0,
+  0,
+  NULL,
+  NULL,
+  NULL,
+  string_serialise,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL
+};
+
+void string_trace(pony_ctx_t* ctx, const char* string)
+{
+  string_trace_len(ctx, string, strlen(string));
+}
+
+void string_trace_len(pony_ctx_t* ctx, const char* string, size_t len)
+{
+  string_pony.size = (uint32_t)(len + 1);
+  pony_traceknown(ctx, (char*)string, &string_pony, PONY_TRACE_OPAQUE);
+}
+
+static void* string_deserialise(void* buf, size_t remaining_size)
+{
+  size_t len = 1;
+
+  do
+  {
+    if(len >= remaining_size)
+      return NULL;
+  } while(((char*)buf)[len++] != '\0');
+
+  return (void*)stringtab_len((const char*)buf, len - 1);
+}
+
+const char* string_deserialise_offset(pony_ctx_t* ctx, uintptr_t offset)
+{
+  return (const char*)pony_deserialise_raw(ctx, offset, string_deserialise);
+}
+
+static void strlist_serialise_trace(pony_ctx_t* ctx, void* object)
+{
+  strlist_t* list = (strlist_t*)object;
+
+  if(list->contents.data != NULL)
+    string_trace(ctx, (const char*)list->contents.data);
+
+  if(list->contents.next != NULL)
+    pony_traceknown(ctx, list->contents.next, strlist_pony_type(),
+      PONY_TRACE_MUTABLE);
+}
+
+static void strlist_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset, int mutability)
+{
+  (void)mutability;
+
+  strlist_t* list = (strlist_t*)object;
+  strlist_t* dst = (strlist_t*)((uintptr_t)buf + offset);
+
+  dst->contents.data = (void*)pony_serialise_offset(ctx, list->contents.data);
+  dst->contents.next = (list_t*)pony_serialise_offset(ctx, list->contents.next);
+
+}
+
+static void strlist_deserialise(pony_ctx_t* ctx, void* object)
+{
+  strlist_t* list = (strlist_t*)object;
+
+  list->contents.data = (void*)string_deserialise_offset(ctx,
+    (uintptr_t)list->contents.data);
+  list->contents.next = (list_t*)pony_deserialise_offset(ctx,
+    strlist_pony_type(), (uintptr_t)list->contents.next);
+}
+
+static pony_type_t strlist_pony =
+{
+  0,
+  sizeof(strlist_t),
+  0,
+  0,
+  NULL,
+  NULL,
+  strlist_serialise_trace,
+  strlist_serialise,
+  strlist_deserialise,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL
+};
+
+pony_type_t* strlist_pony_type()
+{
+  return &strlist_pony;
 }

--- a/src/libponyc/ast/stringtab.h
+++ b/src/libponyc/ast/stringtab.h
@@ -8,6 +8,8 @@ PONY_EXTERN_C_BEGIN
 
 DECLARE_LIST(strlist, strlist_t, const char);
 
+typedef struct pony_ctx_t pony_ctx_t;
+
 void stringtab_init();
 const char* stringtab(const char* string);
 const char* stringtab_len(const char* string, size_t len);
@@ -18,6 +20,13 @@ const char* stringtab_len(const char* string, size_t len);
 const char* stringtab_consume(const char* string, size_t buf_size);
 
 void stringtab_done();
+
+void string_trace(pony_ctx_t* ctx, const char* string);
+void string_trace_len(pony_ctx_t* ctx, const char* string, size_t len);
+
+const char* string_deserialise_offset(pony_ctx_t* ctx, uintptr_t offset);
+
+pony_type_t* strlist_pony_type();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -2,6 +2,7 @@
 #include "stringtab.h"
 #include "ast.h"
 #include "id.h"
+#include "../../libponyrt/gc/serialise.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
 #include <stdlib.h>
@@ -31,6 +32,9 @@ static void sym_free(symbol_t* sym)
   POOL_FREE(symbol_t, sym);
 }
 
+DEFINE_HASHMAP_SERIALISE(symtab, symtab_t, symbol_t, sym_hash, sym_cmp,
+  ponyint_pool_alloc_size, ponyint_pool_free_size, sym_free, symbol_pony_type());
+
 static const char* name_without_case(const char* name)
 {
   size_t len = strlen(name) + 1;
@@ -47,9 +51,6 @@ static const char* name_without_case(const char* name)
 
   return stringtab_consume(buf, len);
 }
-
-DEFINE_HASHMAP(symtab, symtab_t, symbol_t, sym_hash, sym_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, sym_free);
 
 symtab_t* symtab_new()
 {
@@ -338,4 +339,64 @@ void symtab_print(symtab_t* symtab)
         break;
     }
   }
+}
+
+static void symbol_serialise_trace(pony_ctx_t* ctx, void* object)
+{
+  symbol_t* sym = (symbol_t*)object;
+
+  string_trace(ctx, (char*)sym->name);
+
+  if(sym->def != NULL)
+    pony_traceknown(ctx, sym->def, ast_pony_type(), PONY_TRACE_MUTABLE);
+}
+
+static void symbol_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset, int mutability)
+{
+  (void)mutability;
+
+  symbol_t* sym = (symbol_t*)object;
+  symbol_t* dst = (symbol_t*)((uintptr_t)buf + offset);
+
+  dst->name = (const char*)pony_serialise_offset(ctx, (char*)sym->name);
+  dst->def = (ast_t*)pony_serialise_offset(ctx, sym->def);
+  dst->status = sym->status;
+  dst->branch_count = sym->branch_count;
+}
+
+static void symbol_deserialise(pony_ctx_t* ctx, void* object)
+{
+  (void)ctx;
+  symbol_t* sym = (symbol_t*)object;
+
+  sym->name = string_deserialise_offset(ctx, (uintptr_t)sym->name);
+  sym->def = (ast_t*)pony_deserialise_offset(ctx, ast_pony_type(),
+    (uintptr_t)sym->def);
+}
+
+static pony_type_t symbol_pony =
+{
+  0,
+  sizeof(symbol_t),
+  0,
+  0,
+  NULL,
+  NULL,
+  symbol_serialise_trace,
+  symbol_serialise,
+  symbol_deserialise,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL
+};
+
+pony_type_t* symbol_pony_type()
+{
+  return &symbol_pony;
 }

--- a/src/libponyc/ast/symtab.h
+++ b/src/libponyc/ast/symtab.h
@@ -28,7 +28,7 @@ typedef struct symbol_t
   size_t branch_count;
 } symbol_t;
 
-DECLARE_HASHMAP(symtab, symtab_t, symbol_t);
+DECLARE_HASHMAP_SERIALISE(symtab, symtab_t, symbol_t);
 
 bool is_type_name(const char* name);
 
@@ -60,6 +60,8 @@ bool symtab_can_merge_public(symtab_t* dst, symtab_t* src);
 bool symtab_merge_public(symtab_t* dst, symtab_t* src);
 
 bool symtab_check_all_defined(symtab_t* symtab, errors_t* errors);
+
+pony_type_t* symbol_pony_type();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -5,6 +5,7 @@
 
 #include "lexint.h"
 #include "source.h"
+#include "../libponyrt/pony.h"
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -288,6 +289,9 @@ token_t* token_dup_new_id(token_t* token, token_id id);
   * The token argument may be NULL.
   */
 void token_free(token_t* token);
+
+/// Get a pony_type_t for token_t. Should only be used for serialisation.
+pony_type_t* token_pony_type();
 
 
 // Read accessors

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -235,7 +235,8 @@ void codegen_pass_cleanup(pass_opt_t* opt);
 
 bool codegen(ast_t* program, pass_opt_t* opt);
 
-bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt);
+bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt,
+  pass_id last_pass);
 
 void codegen_cleanup(compile_t* c);
 

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -87,6 +87,30 @@ static lit_op_info_t* lookup_literal_op(const char* name)
 }
 
 
+void operatorliteral_serialise_data(ast_t* ast, ast_t* dst)
+{
+  lit_op_info_t* data = (lit_op_info_t*)ast_data(ast);
+  if(data != NULL)
+  {
+    size_t index = (size_t)(data - _operator_fns);
+    ast_setdata(dst, (void*)index);
+  } else {
+    ast_setdata(dst, (void*)((size_t)(~0)));
+  }
+}
+
+
+void operatorliteral_deserialise_data(ast_t* ast)
+{
+  size_t index = (size_t)ast_data(ast);
+
+  if(index > 17)
+    ast_setdata(ast, (void*)NULL);
+  else
+    ast_setdata(ast, &_operator_fns[index]);
+}
+
+
 bool expr_literal(pass_opt_t* opt, ast_t* ast, const char* name)
 {
   ast_t* type = type_builtin(opt, ast, name);

--- a/src/libponyc/expr/literal.h
+++ b/src/libponyc/expr/literal.h
@@ -7,6 +7,9 @@
 
 PONY_EXTERN_C_BEGIN
 
+void operatorliteral_serialise_data(ast_t* ast, ast_t* dst);
+
+void operatorliteral_deserialise_data(ast_t* ast);
 
 bool expr_literal(pass_opt_t* opt, ast_t* ast, const char* name);
 

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -7,6 +7,7 @@
 #include "../ast/ast.h"
 #include "../ast/token.h"
 #include "../expr/literal.h"
+#include "../../libponyrt/gc/serialise.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
 #include <stdlib.h>
@@ -1054,6 +1055,83 @@ void package_done()
   safe = NULL;
 
   package_clear_magic();
+}
+
+
+static void package_serialise_trace(pony_ctx_t* ctx, void* object)
+{
+  package_t* package = (package_t*)object;
+
+  string_trace(ctx, package->path);
+  string_trace(ctx, package->qualified_name);
+  string_trace(ctx, package->id);
+  string_trace(ctx, package->filename);
+
+  if(package->symbol != NULL)
+    string_trace(ctx, package->symbol);
+}
+
+
+static void package_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset, int mutability)
+{
+  (void)mutability;
+
+  package_t* package = (package_t*)object;
+  package_t* dst = (package_t*)((uintptr_t)buf + offset);
+
+  dst->path = (const char*)pony_serialise_offset(ctx, (char*)package->path);
+  dst->qualified_name = (const char*)pony_serialise_offset(ctx,
+    (char*)package->qualified_name);
+  dst->id = (const char*)pony_serialise_offset(ctx, (char*)package->id);
+  dst->filename = (const char*)pony_serialise_offset(ctx,
+    (char*)package->filename);
+  dst->symbol = (const char*)pony_serialise_offset(ctx, (char*)package->symbol);
+
+  dst->next_hygienic_id = package->next_hygienic_id;
+  dst->allow_ffi = package->allow_ffi;
+}
+
+
+static void package_deserialise(pony_ctx_t* ctx, void* object)
+{
+  package_t* package = (package_t*)object;
+
+  package->path = string_deserialise_offset(ctx, (uintptr_t)package->path);
+  package->qualified_name = string_deserialise_offset(ctx,
+    (uintptr_t)package->qualified_name);
+  package->id = string_deserialise_offset(ctx, (uintptr_t)package->id);
+  package->filename = string_deserialise_offset(ctx,
+    (uintptr_t)package->filename);
+  package->symbol = string_deserialise_offset(ctx, (uintptr_t)package->symbol);
+}
+
+
+static pony_type_t package_pony =
+{
+  0,
+  sizeof(package_t),
+  0,
+  0,
+  NULL,
+  NULL,
+  package_serialise_trace,
+  package_serialise,
+  package_deserialise,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL
+};
+
+
+pony_type_t* package_pony_type()
+{
+  return &package_pony;
 }
 
 

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -144,6 +144,8 @@ const char* package_alias_from_id(ast_t* module, const char* id);
  */
 void package_done();
 
+pony_type_t* package_pony_type();
+
 bool is_path_absolute(const char* path);
 
 bool is_path_relative(const char* path);

--- a/src/libponyc/pkg/program.h
+++ b/src/libponyc/pkg/program.h
@@ -42,6 +42,8 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
  */
 const char* program_lib_args(ast_t* program);
 
+pony_type_t* program_pony_type();
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -19,11 +19,12 @@ typedef struct reach_type_t reach_type_t;
 
 DECLARE_STACK(reachable_expr_stack, reachable_expr_stack_t, ast_t);
 DECLARE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
-DECLARE_HASHMAP(reach_methods, reach_methods_t, reach_method_t);
-DECLARE_HASHMAP(reach_mangled, reach_mangled_t, reach_method_t);
-DECLARE_HASHMAP(reach_method_names, reach_method_names_t, reach_method_name_t);
-DECLARE_HASHMAP(reach_types, reach_types_t, reach_type_t);
-DECLARE_HASHMAP(reach_type_cache, reach_type_cache_t, reach_type_t);
+DECLARE_HASHMAP_SERIALISE(reach_methods, reach_methods_t, reach_method_t);
+DECLARE_HASHMAP_SERIALISE(reach_mangled, reach_mangled_t, reach_method_t);
+DECLARE_HASHMAP_SERIALISE(reach_method_names, reach_method_names_t,
+  reach_method_name_t);
+DECLARE_HASHMAP_SERIALISE(reach_types, reach_types_t, reach_type_t);
+DECLARE_HASHMAP_SERIALISE(reach_type_cache, reach_type_cache_t, reach_type_t);
 
 struct reach_method_t
 {
@@ -175,6 +176,18 @@ reach_method_name_t* reach_method_name(reach_type_t* t,
 uint32_t reach_vtable_index(reach_type_t* t, const char* name);
 
 void reach_dump(reach_t* r);
+
+pony_type_t* reach_method_pony_type();
+
+pony_type_t* reach_method_name_pony_type();
+
+pony_type_t* reach_field_pony_type();
+
+pony_type_t* reach_param_pony_type();
+
+pony_type_t* reach_type_pony_type();
+
+pony_type_t* reach_pony_type();
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -1,10 +1,10 @@
 #ifndef actor_h
 #define actor_h
 
+#include "messageq.h"
 #include "../gc/gc.h"
 #include "../mem/heap.h"
-#include "messageq.h"
-#include <pony.h>
+#include "../pony.h"
 #include <stdint.h>
 #include <stdbool.h>
 #ifndef __cplusplus

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -1,7 +1,7 @@
 #ifndef messageq_h
 #define messageq_h
 
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 
 PONY_EXTERN_C_BEGIN

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -1,7 +1,7 @@
 #ifndef asio_asio_h
 #define asio_asio_h
 
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 #include <stdbool.h>
 

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -1,7 +1,7 @@
 #ifndef asio_event_h
 #define asio_event_h
 
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/libponyrt/ds/list.c
+++ b/src/libponyrt/ds/list.c
@@ -1,13 +1,8 @@
 #include "list.h"
+#include "../gc/serialise.h"
 #include "../mem/pool.h"
 #include "ponyassert.h"
 #include <stdlib.h>
-
-typedef struct list_t
-{
-  void* data;
-  struct list_t* next;
-} list_t;
 
 list_t* ponyint_list_pop(list_t* list, void** data)
 {

--- a/src/libponyrt/ds/list.h
+++ b/src/libponyrt/ds/list.h
@@ -2,13 +2,18 @@
 #define ds_list_h
 
 #include "fun.h"
+#include "../pony.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <platform.h>
 
 PONY_EXTERN_C_BEGIN
 
-typedef struct list_t list_t;
+typedef struct list_t
+{
+  void* data;
+  struct list_t* next;
+} list_t;
 
 list_t* ponyint_list_pop(list_t* list, void** data);
 
@@ -59,7 +64,7 @@ void ponyint_list_free(list_t* list, free_fn f);
   void name##_free(name_t* list); \
 
 #define DEFINE_LIST(name, name_t, elem, cmpf, freef) \
-  struct name_t {}; \
+  struct name_t {list_t contents;}; \
   \
   name_t* name##_pop(name_t* list, elem** data) \
   { \

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -2,7 +2,7 @@
 #define cycle_h
 
 #include "gc.h"
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/src/libponyrt/gc/delta.h
+++ b/src/libponyrt/gc/delta.h
@@ -2,7 +2,7 @@
 #define gc_delta_h
 
 #include "../ds/hash.h"
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 
 PONY_EXTERN_C_BEGIN

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -6,7 +6,7 @@
 #include "delta.h"
 #include "../mem/heap.h"
 #include "../ds/stack.h"
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 
 #define GC_INC_MORE 256

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -9,6 +9,8 @@ typedef void* (*serialise_alloc_fn)(pony_ctx_t* ctx, size_t size);
 
 typedef void (*serialise_throw_fn)();
 
+typedef void* (*deserialise_raw_fn)(void* buf, size_t remaining_size);
+
 typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
@@ -32,6 +34,8 @@ PONY_API void* pony_deserialise_block(pony_ctx_t* ctx, uintptr_t offset,
   size_t size);
 PONY_API void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,
   uintptr_t offset);
+PONY_API void* pony_deserialise_raw(pony_ctx_t* ctx, uintptr_t offset,
+  deserialise_raw_fn ds_fn);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/gc/trace.h
+++ b/src/libponyrt/gc/trace.h
@@ -1,7 +1,7 @@
 #ifndef gc_trace_h
 #define gc_trace_h
 
-#include <pony.h>
+#include "../pony.h"
 #include <platform.h>
 
 PONY_EXTERN_C_BEGIN

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -4,12 +4,12 @@
 #ifndef __cplusplus
 #  include <stdalign.h>
 #endif
-#include <pony.h>
-#include <platform.h>
-#include "actor/messageq.h"
-#include "gc/gc.h"
-#include "gc/serialise.h"
 #include "mpmcq.h"
+#include "../actor/messageq.h"
+#include "../gc/gc.h"
+#include "../gc/serialise.h"
+#include "../pony.h"
+#include <platform.h>
 
 PONY_EXTERN_C_BEGIN
 

--- a/test/libponyc/compiler_serialisation.cc
+++ b/test/libponyc/compiler_serialisation.cc
@@ -1,0 +1,214 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <../libponyrt/mem/pool.h>
+#include <../libponyrt/sched/scheduler.h>
+
+#include "util.h"
+
+#include <memory>
+
+#define TEST_COMPILE(src, pass) DO(test_compile(src, pass))
+
+#define TEST_COMPILE_RESUME(pass) DO(test_compile_resume(pass))
+
+class CompilerSerialisationTest : public PassTest
+{
+public:
+  void test_pass_ast(const char* pass);
+
+  void test_pass_reach(const char* pass);
+};
+
+static const char* src =
+  "actor Main\n"
+  "  new create(env: Env) =>\n"
+  "    let x = recover Array[U8] end\n"
+  "    x.push(42)\n"
+  "    foo(consume x)\n"
+
+  "  be foo(x: Array[U8] val) =>\n"
+  "    try\n"
+  "      if x(0) == 42 then\n"
+  "        @pony_exitcode[None](U32(1))\n"
+  "      end\n"
+  "    end";
+
+static void* s_alloc_fn(pony_ctx_t* ctx, size_t size)
+{
+  (void)ctx;
+  return ponyint_pool_alloc_size(size);
+}
+
+static void s_throw_fn()
+{
+  throw std::exception{};
+}
+
+typedef struct ponyint_array_t
+{
+  void* desc;
+  size_t size;
+  size_t alloc;
+  char* ptr;
+} ponyint_array_t;
+
+struct pool_deleter
+{
+  size_t size;
+
+  void operator()(void* ptr)
+  {
+    ponyint_pool_free_size(size, ptr);
+  }
+};
+
+struct ast_deleter
+{
+  void operator()(ast_t* ptr)
+  {
+    ast_free(ptr);
+  }
+};
+
+struct reach_deleter
+{
+  void operator()(reach_t* ptr)
+  {
+    reach_free(ptr);
+  }
+};
+
+void CompilerSerialisationTest::test_pass_ast(const char* pass)
+{
+  set_builtin(NULL);
+
+  TEST_COMPILE(src, pass);
+
+  pony_ctx_t ctx;
+  memset(&ctx, 0, sizeof(pony_ctx_t));
+  ponyint_array_t array;
+  memset(&array, 0, sizeof(ponyint_array_t));
+
+  pony_serialise(&ctx, program, ast_pony_type(), &array, s_alloc_fn, s_throw_fn);
+  std::unique_ptr<char, pool_deleter> array_guard{array.ptr};
+  array_guard.get_deleter().size = array.size;
+  std::unique_ptr<ast_t, ast_deleter> new_guard{
+    (ast_t*)pony_deserialise(&ctx, ast_pony_type(), &array, s_alloc_fn,
+      s_alloc_fn, s_throw_fn)};
+
+  ast_t* new_program = new_guard.get();
+
+  ASSERT_NE(new_program, (void*)NULL);
+
+  DO(check_ast_same(program, new_program));
+
+  new_guard.release();
+  new_guard.reset(program);
+  program = new_program;
+  package = ast_child(program);
+  module = ast_child(package);
+
+  TEST_COMPILE_RESUME("ir");
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+void CompilerSerialisationTest::test_pass_reach(const char* pass)
+{
+  set_builtin(NULL);
+
+  TEST_COMPILE(src, pass);
+
+  ASSERT_NE(compile, (void*)NULL);
+
+  reach_t* r = compile->reach;
+
+  pony_ctx_t ctx;
+  memset(&ctx, 0, sizeof(pony_ctx_t));
+  ponyint_array_t array;
+  memset(&array, 0, sizeof(ponyint_array_t));
+
+  pony_serialise(&ctx, r, reach_pony_type(), &array, s_alloc_fn, s_throw_fn);
+  std::unique_ptr<char, pool_deleter> array_guard{array.ptr};
+  array_guard.get_deleter().size = array.size;
+  std::unique_ptr<reach_t, reach_deleter> new_guard{
+    (reach_t*)pony_deserialise(&ctx, reach_pony_type(), &array, s_alloc_fn,
+      s_alloc_fn, s_throw_fn)};
+
+  reach_t* new_r = new_guard.get();
+
+  ASSERT_NE(new_r, (void*)NULL);
+  
+  new_guard.release();
+  new_guard.reset(r);
+  compile->reach = new_r;
+
+  TEST_COMPILE_RESUME("ir");
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterSugar)
+{
+  test_pass_ast("sugar");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterScope)
+{
+  test_pass_ast("scope");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterImport)
+{
+  test_pass_ast("import");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterName)
+{
+  test_pass_ast("name");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterFlatten)
+{
+  test_pass_ast("flatten");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterTraits)
+{
+  test_pass_ast("traits");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterRefer)
+{
+  test_pass_ast("refer");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterExpr)
+{
+  test_pass_ast("expr");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterVerify)
+{
+  test_pass_ast("verify");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterFinal)
+{
+  test_pass_ast("final");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterReach)
+{
+  test_pass_reach("reach");
+}
+
+TEST_F(CompilerSerialisationTest, SerialiseAfterPaint)
+{
+  test_pass_reach("paint");
+}

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -6,6 +6,7 @@
 #include <ast/lexer.h>
 #include <ast/source.h>
 #include <ast/stringtab.h>
+#include <pass/pass.h>
 #include <pkg/package.h>
 #include <codegen/genjit.h>
 #include <../libponyrt/pony.h>
@@ -232,6 +233,7 @@ void PassTest::SetUp()
   package_clear_magic();
   package_suppress_build_message();
   opt.verbosity = VERBOSITY_QUIET;
+  last_pass = PASS_PARSE;
 }
 
 
@@ -247,6 +249,7 @@ void PassTest::TearDown()
   program = NULL;
   package = NULL;
   module = NULL;
+  last_pass = PASS_PARSE;
   package_done();
   codegen_pass_cleanup(&opt);
   pass_opt_done(&opt);
@@ -312,16 +315,22 @@ void PassTest::check_ast_same(ast_t* expect, ast_t* actual)
 
 void PassTest::test_compile(const char* src, const char* pass)
 {
-  DO(build_package(pass, src, _first_pkg_path, true, NULL));
+  DO(build_package(pass, src, _first_pkg_path, true, NULL, false));
 
   package = ast_child(program);
   module = ast_child(package);
 }
 
 
+void PassTest::test_compile_resume(const char* pass)
+{
+  DO(build_package(pass, NULL, NULL, true, NULL, true));
+}
+
+
 void PassTest::test_error(const char* src, const char* pass)
 {
-  DO(build_package(pass, src, _first_pkg_path, false, NULL));
+  DO(build_package(pass, src, _first_pkg_path, false, NULL, false));
 
   package = NULL;
   module = NULL;
@@ -332,7 +341,7 @@ void PassTest::test_error(const char* src, const char* pass)
 void PassTest::test_expected_errors(const char* src, const char* pass,
   const char** errors)
 {
-  DO(build_package(pass, src, _first_pkg_path, false, errors));
+  DO(build_package(pass, src, _first_pkg_path, false, errors, false));
 
   package = NULL;
   module = NULL;
@@ -343,7 +352,7 @@ void PassTest::test_expected_errors(const char* src, const char* pass,
 void PassTest::test_equiv(const char* actual_src, const char* actual_pass,
   const char* expect_src, const char* expect_pass)
 {
-  DO(build_package(expect_pass, expect_src, "expect", true, NULL));
+  DO(build_package(expect_pass, expect_src, "expect", true, NULL, false));
   ast_t* expect_ast = program;
   ast_t* expect_package = ast_child(expect_ast);
   program = NULL;
@@ -416,58 +425,89 @@ bool PassTest::run_program(int* exit_code)
 // Private methods
 
 void PassTest::build_package(const char* pass, const char* src,
-  const char* package_name, bool check_good, const char** expected_errors)
+  const char* package_name, bool check_good, const char** expected_errors,
+  bool resume)
 {
   ASSERT_NE((void*)NULL, pass);
-  ASSERT_NE((void*)NULL, src);
-  ASSERT_NE((void*)NULL, package_name);
 
-  if(compile != NULL)
+  if(!resume)
   {
-    codegen_cleanup(compile);
-    POOL_FREE(compile_t, compile);
-    compile = NULL;
-  }
-  ast_free(program);
-  program = NULL;
-  package = NULL;
-  module = NULL;
+    ASSERT_NE((void*)NULL, src);
+    ASSERT_NE((void*)NULL, package_name);
 
-  lexer_allow_test_symbols();
-
-  package_clear_magic();
-
-#ifndef PONY_PACKAGES_DIR
-#  error Packages directory undefined
-#else
-  if(_builtin_src != NULL)
-  {
-    package_add_magic_src("builtin", _builtin_src);
-  } else {
-    char path[FILENAME_MAX];
-    path_cat(PONY_PACKAGES_DIR, "builtin", path);
-    package_add_magic_path("builtin", path);
-  }
-#endif
-
-  package_add_magic_src(package_name, src);
-
-  package_suppress_build_message();
-
-  limit_passes(&opt, pass);
-  program = program_load(stringtab(package_name), &opt);
-
-  if((program != NULL) && (opt.limit >= PASS_REACH))
-  {
-    compile = POOL_ALLOC(compile_t);
-
-    if(!codegen_gen_test(compile, program, &opt))
+    if(compile != NULL)
     {
       codegen_cleanup(compile);
       POOL_FREE(compile_t, compile);
       compile = NULL;
     }
+    ast_free(program);
+    program = NULL;
+    package = NULL;
+    module = NULL;
+    last_pass = PASS_PARSE;
+
+    lexer_allow_test_symbols();
+
+    package_clear_magic();
+
+#ifndef PONY_PACKAGES_DIR
+#  error Packages directory undefined
+#else
+    if(_builtin_src != NULL)
+    {
+      package_add_magic_src("builtin", _builtin_src);
+    } else {
+      char path[FILENAME_MAX];
+      path_cat(PONY_PACKAGES_DIR, "builtin", path);
+      package_add_magic_path("builtin", path);
+    }
+#endif
+
+    package_add_magic_src(package_name, src);
+
+    package_suppress_build_message();
+
+    limit_passes(&opt, pass);
+    program = program_load(stringtab(package_name), &opt);
+
+    if((program != NULL) && (opt.limit >= PASS_REACH))
+    {
+      compile = POOL_ALLOC(compile_t);
+
+      if(!codegen_gen_test(compile, program, &opt, PASS_PARSE))
+      {
+        codegen_cleanup(compile);
+        POOL_FREE(compile_t, compile);
+        compile = NULL;
+      }
+    }
+  } else {
+    ASSERT_NE((void*)NULL, program);
+
+    limit_passes(&opt, pass);
+
+    if(ast_passes_program(program, &opt))
+    {
+      if(opt.limit >= PASS_REACH)
+      {
+        if(compile == NULL)
+          compile = POOL_ALLOC(compile_t);
+
+        if(!codegen_gen_test(compile, program, &opt, last_pass))
+        {
+          codegen_cleanup(compile);
+          POOL_FREE(compile_t, compile);
+          compile = NULL;
+        }
+      }
+    } else {
+      ast_free(program);
+      program = NULL;
+    }
   }
+
+  last_pass = opt.limit;
 
   if(expected_errors != NULL)
   {

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -34,6 +34,7 @@ protected:
   ast_t* package; // AST of first package, cache of ast_child(program)
   ast_t* module;  // AST of first module in first package
   compile_t* compile;
+  pass_id last_pass;
 
   virtual void SetUp();
   virtual void TearDown();
@@ -67,6 +68,10 @@ protected:
 
   // Check that the given source compiles to the specified pass without error
   void test_compile(const char* src, const char* pass);
+
+  // Check that the given source compiles to the specified pass without error.
+  // Starts from an AST built in a previous call to test_compile
+  void test_compile_resume(const char* src);
 
   // Check that the given source fails when compiled to the specified pass
   void test_error(const char* src, const char* pass);
@@ -118,7 +123,8 @@ private:
   // Attempt to compile the package with the specified name into a program.
   // Errors are checked with ASSERTs, call in ASSERT_NO_FATAL_FAILURE.
   void build_package(const char* pass, const char* src,
-    const char* package_name, bool check_good, const char** expected_errors);
+    const char* package_name, bool check_good, const char** expected_errors,
+    bool resume);
 
   // Find the type of the parameter, field or local variable with the specified
   // name in the given AST.

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -6,13 +6,16 @@
 
 #include <ds/fun.h>
 #include <ds/hash.h>
+#include <sched/scheduler.h>
+
+#include <memory>
 
 #define INITIAL_SIZE 8
 #define BELOW_HALF (INITIAL_SIZE + (2 - 1)) / 2
 
 typedef struct hash_elem_t hash_elem_t;
 
-DECLARE_HASHMAP(testmap, testmap_t, hash_elem_t);
+DECLARE_HASHMAP_SERIALISE(testmap, testmap_t, hash_elem_t);
 
 class HashMapTest: public testing::Test
 {
@@ -32,15 +35,61 @@ class HashMapTest: public testing::Test
     static void free_buckets(size_t size, void* p);
 };
 
-DEFINE_HASHMAP(testmap, testmap_t, hash_elem_t, HashMapTest::hash_tst,
-  HashMapTest::cmp_tst, malloc, HashMapTest::free_buckets,
-  HashMapTest::free_elem);
-
 struct hash_elem_t
 {
   size_t key;
   size_t val;
 };
+
+static void hash_elem_serialise_trace(pony_ctx_t* ctx, void* object)
+{
+  (void)ctx;
+  (void)object;
+}
+
+static void hash_elem_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset, int mutability)
+{
+  (void)ctx;
+  (void)mutability;
+
+  hash_elem_t* elem = (hash_elem_t*)object;
+  hash_elem_t* dst = (hash_elem_t*)((uintptr_t)buf + offset);
+
+  dst->key = elem->key;
+  dst->val = elem->val;
+}
+
+static void hash_elem_deserialise(pony_ctx_t* ctx, void* object)
+{
+  (void)ctx;
+  (void)object;
+}
+
+static pony_type_t hash_elem_pony =
+{
+  0,
+  sizeof(hash_elem_t),
+  0,
+  0,
+  NULL,
+  NULL,
+  hash_elem_serialise_trace,
+  hash_elem_serialise,
+  hash_elem_deserialise,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  NULL
+};
+
+DEFINE_HASHMAP_SERIALISE(testmap, testmap_t, hash_elem_t, HashMapTest::hash_tst,
+  HashMapTest::cmp_tst, malloc, HashMapTest::free_buckets,
+  HashMapTest::free_elem, &hash_elem_pony);
 
 void HashMapTest::SetUp()
 {
@@ -67,7 +116,7 @@ void HashMapTest::put_elements(size_t count)
 
 hash_elem_t* HashMapTest::get_element()
 {
-  return (hash_elem_t*) malloc(sizeof(hash_elem_t));
+  return (hash_elem_t*)malloc(sizeof(hash_elem_t));
 }
 
 size_t HashMapTest::hash_tst(hash_elem_t* p)
@@ -90,6 +139,14 @@ void HashMapTest::free_buckets(size_t len, void* p)
   (void)len;
   free(p);
 }
+
+struct free_deleter
+{
+  void operator()(void* ptr)
+  {
+    free(ptr);
+  }
+};
 
 /** The default size of a map is 0 or at least 8,
  *  i.e. a full cache line of void* on 64-bit systems.
@@ -154,6 +211,7 @@ TEST_F(HashMapTest, TryGetNonExistent)
 {
   hash_elem_t* e1 = get_element();
   hash_elem_t* e2 = get_element();
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{e2};
   size_t index = HASHMAP_UNKNOWN;
 
   e1->key = 1;
@@ -181,6 +239,7 @@ TEST_F(HashMapTest, ReplacingElementReturnsReplaced)
   testmap_put(&_map, e1);
 
   hash_elem_t* n = testmap_put(&_map, e2);
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{n};
   ASSERT_EQ(n, e1);
 
   hash_elem_t* m = testmap_get(&_map, e2, &index);
@@ -209,6 +268,7 @@ TEST_F(HashMapTest, DeleteElement)
   ASSERT_EQ(l, (size_t)2);
 
   hash_elem_t* n1 = testmap_remove(&_map, e1);
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{n1};
 
   l = testmap_size(&_map);
 
@@ -278,6 +338,7 @@ TEST_F(HashMapTest, RemoveByIndex)
   }
 
   testmap_removeindex(&_map, i);
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{p};
 
   ASSERT_EQ(NULL, testmap_get(&_map, p, &index));
 }
@@ -290,6 +351,7 @@ TEST_F(HashMapTest, EmptyPutByIndex)
   hash_elem_t* e = get_element();
   e->key = 1000;
   e->val = 42;
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{e};
   size_t index = HASHMAP_UNKNOWN;
 
   hash_elem_t* n = testmap_get(&_map, e, &index);
@@ -297,6 +359,7 @@ TEST_F(HashMapTest, EmptyPutByIndex)
   ASSERT_EQ(NULL, n);
   ASSERT_EQ(HASHMAP_UNKNOWN, index);
 
+  elem_guard.release();
   testmap_putindex(&_map, e, index);
 
   hash_elem_t* m = testmap_get(&_map, e, &index);
@@ -314,12 +377,14 @@ TEST_F(HashMapTest, NotEmptyPutByIndex)
   hash_elem_t* e = get_element();
   e->key = 1000;
   e->val = 42;
+  std::unique_ptr<hash_elem_t, free_deleter> elem_guard{e};
   size_t index = HASHMAP_UNKNOWN;
 
   hash_elem_t* n = testmap_get(&_map, e, &index);
 
   ASSERT_EQ(NULL, n);
 
+  elem_guard.release();
   testmap_putindex(&_map, e, index);
 
   hash_elem_t* m = testmap_get(&_map, e, &index);
@@ -327,3 +392,78 @@ TEST_F(HashMapTest, NotEmptyPutByIndex)
   ASSERT_EQ(e->val, m->val);
 }
 
+typedef struct ponyint_array_t
+{
+  void* desc;
+  size_t size;
+  size_t alloc;
+  char* ptr;
+} ponyint_array_t;
+
+struct testmap_deleter
+{
+  void operator()(testmap_t* ptr)
+  {
+    testmap_destroy(ptr);
+    free(ptr);
+  }
+};
+
+TEST_F(HashMapTest, Serialisation)
+{
+  for(uint32_t i = 0; i < 100; i++)
+  {
+    hash_elem_t* curr = get_element();
+
+    curr->key = i;
+    curr->val = i;
+
+    testmap_put(&_map, curr);
+  }
+
+  auto alloc_fn = [](pony_ctx_t* ctx, size_t size)
+    {
+      (void)ctx;
+      return malloc(size);
+    };
+  auto throw_fn = [](){throw std::exception{}; };
+
+  pony_ctx_t ctx;
+  memset(&ctx, 0, sizeof(pony_ctx_t));
+  ponyint_array_t array;
+  memset(&array, 0, sizeof(ponyint_array_t));
+
+  pony_serialise(&ctx, &_map, testmap_pony_type(), &array, alloc_fn, throw_fn);
+  std::unique_ptr<char, free_deleter> array_guard{array.ptr};
+  std::unique_ptr<testmap_t, testmap_deleter> out_guard{
+    (testmap_t*)pony_deserialise(&ctx, testmap_pony_type(), &array, alloc_fn,
+      alloc_fn, throw_fn)};
+
+  testmap_t* out = out_guard.get();
+
+  ASSERT_NE(out, (void*)NULL);
+
+  size_t i = HASHMAP_BEGIN;
+  size_t j = i;
+
+  hash_elem_t* orig_elem;
+  hash_elem_t* out_elem;
+
+  while((orig_elem = testmap_next(&_map, &i)) != NULL)
+  {
+    out_elem = testmap_get(out, orig_elem, &j);
+    ASSERT_NE(out_elem, (void*)NULL);
+    ASSERT_EQ(i, j);
+    ASSERT_EQ(orig_elem->val, out_elem->val);
+  }
+
+  i = j = HASHMAP_BEGIN;
+
+  while((out_elem = testmap_next(out, &j)) != NULL)
+  {
+    orig_elem = testmap_get(&_map, out_elem, &i);
+    ASSERT_NE(orig_elem, (void*)NULL);
+    ASSERT_EQ(j, i);
+    ASSERT_EQ(out_elem->val, orig_elem->val);
+  }
+}


### PR DESCRIPTION
This is preliminary work for incremental and separate compilation. The AST and reachability map (and all associated data structures) can now be serialised.