### PR TITLE
Remove and replace misleading Time.wall_to_nanos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,14 @@ All notable changes to the Pony compiler and standard library will be documented
 - xoroshiro128+ implementation ([PR #1909](https://github.com/ponylang/ponyc/pull/1909))
 - Exhaustive match ([RFC #40](https://github.com/ponylang/rfcs/blob/master/text/0040-exhaustive-match.md)) ([PR #1891](https://github.com/ponylang/ponyc/pull/1891))
 - Command line options for printing help ([PR #1899](https://github.com/ponylang/ponyc/pull/1899))
+- `Nanos.from_wall_clock` function to convert from a wall clock as obtained from `Time.now()` into number of nanoseconds since "the beginning of time". ([PR #1967](https://github.com/ponylang/ponyc/pull/1967))
 
 
 ### Changed
 
 - Change machine word constructors to have no default argument. ([PR #1938](https://github.com/ponylang/ponyc/pull/1938))
 - Change iftype to use elseif instead of elseiftype as next keyword. ([PR #1905](https://github.com/ponylang/ponyc/pull/1905))
-
+- Removed misleading `Time.wall_to_nanos`. ([PR #1967](https://github.com/ponylang/ponyc/pull/1967))
 
 ## [0.14.0] - 2017-05-06
 

--- a/packages/time/nanos.pony
+++ b/packages/time/nanos.pony
@@ -21,3 +21,6 @@ primitive Nanos
 
   fun from_micros_f(t: F64): U64 =>
     (t * 1_000).trunc().u64()
+
+  fun from_wall_clock(wall: (I64, I64)): U64 =>
+    ((wall._1 * 1000000000) + wall._2).u64()

--- a/packages/time/time.pony
+++ b/packages/time/time.pony
@@ -116,16 +116,6 @@ primitive Time
       compile_error "unsupported platform"
     end
 
-  fun wall_to_nanos(wall: (I64, I64)): U64 =>
-    """
-    Converts a wall-clock adjusted system time to monotonic unadjusted
-    nanoseconds.
-    """
-    let wall_now = now()
-    nanos()
-      + (((wall._1 * 1000000000) + wall._2)
-      - ((wall_now._1 * 1000000000) + wall_now._2)).u64()
-
   fun cycles(): U64 =>
     """
     Processor cycle count. Don't use this for performance timing, as it does

--- a/packages/time/timer.pony
+++ b/packages/time/timer.pony
@@ -56,7 +56,7 @@ class Timer
     Creates a new timer with an absolute expiration time rather than a relative
     time. The expiration time is wall-clock adjusted system time.
     """
-    _expiration = Time.wall_to_nanos(expiration)
+    _expiration = _abs_expiration_time(expiration)
     _interval = interval
     _notify = notify
     _node = ListNode[Timer]
@@ -113,3 +113,13 @@ class Timer
     Returns the next expiration time.
     """
     _expiration
+
+  fun tag _abs_expiration_time(wall: (I64, I64)): U64 =>
+    """
+    Converts a wall-clock adjusted system time to absolute expiration time
+    """
+    let wall_now = Time.now()
+    Time.nanos()
+      + (((wall._1 * 1000000000) + wall._2)
+      - ((wall_now._1 * 1000000000) + wall_now._2)).u64()
+


### PR DESCRIPTION
Based on its description and name, one would be reasonable in expecting
`Time.wall_to_nanos` to take a wall clock time and convert it the number
of nanoseconds since the "start of time". That isn't however what it
does. It was getting an absolute time to fire a timer setup in
Timer.abs.

This PR correct this problem by moving the functionality that previously
existed in `wall_to_nanos` into Timer as a private method and adds a
function to `Nanos` to convert from a wall clock time to nanoseconds.