### PR TITLE
Fix value duplication bug in persistent Vec

### DIFF
--- a/packages/collections/persistent/_vec_node.pony
+++ b/packages/collections/persistent/_vec_node.pony
@@ -69,7 +69,10 @@ class val _VecNode[A: Any #share]
       (let sn', let tail) = sns(idx).pop(i)
       let entries = recover val sns.clone() .> update(idx, sn') end
       (create(entries, _level), tail)
-    | let lns: _VecLeafNodes[A] => (this, lns(idx))
+    | let lns: _VecLeafNodes[A] =>
+      let ln = recover val lns(idx).clone() .> pop() end
+      let lns' = recover val lns.clone() .> pop() end
+      (create(lns', _level), ln)
     end
 
   fun val leaf_nodes(lns: Array[Array[A] val]): Array[Array[A] val]^ =>

--- a/packages/collections/persistent/vec.pony
+++ b/packages/collections/persistent/vec.pony
@@ -137,7 +137,7 @@ class val Vec[A: Any #share]
     """
     Return a vector with the value at the end removed.
     """
-    if (_tail.size() > 1) or (_size == 1) then
+    if (_tail.size() > 0) or (_size == 1) then
       let tail = recover val _tail.clone() .> pop() end
       _create(_root, tail, _size - 1, _depth, _tail_offset)
     else


### PR DESCRIPTION
This PR fixes a bug in the persistent Vec where values are duplicated when `pop` is called and the tail is empty.