### PR TITLE
Add compile error for generic Main

### DIFF
--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -360,10 +360,20 @@ static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
   AST_GET_CHILDREN(ast, id, typeparams, defcap, provides, members, c_api);
 
   // Check if we're called Main
-  if(def->permissions[ENTITY_MAIN] == 'N' && ast_name(id) == stringtab("Main"))
+  if(ast_name(id) == stringtab("Main"))
   {
-    ast_error(opt->check.errors, ast, "Main must be an actor");
-    r = AST_ERROR;
+    if(ast_id(typeparams) != TK_NONE)
+    {
+      ast_error(opt->check.errors, typeparams,
+        "the Main actor cannot have type parameters");
+      r = AST_ERROR;
+    }
+
+    if(def->permissions[ENTITY_MAIN] == 'N')
+    {
+      ast_error(opt->check.errors, ast, "Main must be an actor");
+      r = AST_ERROR;
+    }
   }
 
   if(!check_id_type(opt, id, def->desc))

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -14,22 +14,13 @@ static bool verify_main_create(pass_opt_t* opt, ast_t* ast)
   if(strcmp(ast_name(type_id), "Main"))
     return true;
 
-  bool ok = true;
-
-  ast_t* type_params = ast_childidx(opt->check.frame->type, 1);
-
-  if (ast_id(type_params) == TK_TYPEPARAMS)
-  {
-    ast_error(opt->check.errors, type_params,
-      "the Main actor cannot have type parameters");
-    ok = false;
-  }
-
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error);
   ast_t* type = ast_parent(ast_parent(ast));
 
   if(strcmp(ast_name(id), "create"))
     return true;
+
+  bool ok = true;
 
   if(ast_id(ast) != TK_NEW)
   {

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -14,13 +14,22 @@ static bool verify_main_create(pass_opt_t* opt, ast_t* ast)
   if(strcmp(ast_name(type_id), "Main"))
     return true;
 
+  bool ok = true;
+
+  ast_t* type_params = ast_childidx(opt->check.frame->type, 1);
+
+  if (ast_id(type_params) == TK_TYPEPARAMS)
+  {
+    ast_error(opt->check.errors, type_params,
+      "the Main actor cannot have type parameters");
+    ok = false;
+  }
+
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error);
   ast_t* type = ast_parent(ast_parent(ast));
 
   if(strcmp(ast_name(id), "create"))
     return true;
-
-  bool ok = true;
 
   if(ast_id(ast) != TK_NEW)
   {

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -613,7 +613,6 @@ TEST_F(BadPonyTest, FieldReferenceInDefaultArgument)
   TEST_ERRORS_1(src, "can't reference 'this' in a default argument");
 }
 
-
 TEST_F(BadPonyTest, DefaultArgScope)
 {
   const char* src =
@@ -622,4 +621,13 @@ TEST_F(BadPonyTest, DefaultArgScope)
     "    y";
 
   TEST_ERRORS_1(src, "can't find declaration of 'y'");
+}
+
+TEST_F(BadPonyTest, GenericMain)
+{
+  const char* src =
+    "actor Main[X]"
+    "  new create(env: Env) => None";
+
+  TEST_ERRORS_1(src, "the Main actor cannot have type parameters");
 }


### PR DESCRIPTION
This PR adds a compile error for a Main actor with type parameters.

closes #1936 