### PR TITLE
Remove unnecessary allocation of full nodes in persistent collections

### DIFF
--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -20,7 +20,7 @@ class val _MapNode[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
       match l
       | 6 => Array[_MapEntry[K, V, H]](4)
       else
-        Array[_MapEntry[K, V, H]](32)
+        Array[_MapEntry[K, V, H]]
       end
     end
     _nodemap = 0

--- a/packages/collections/persistent/_vec_node.pony
+++ b/packages/collections/persistent/_vec_node.pony
@@ -9,8 +9,8 @@ class val _VecNode[A: Any #share]
 
   new val empty(level: U8) =>
     _entries =
-      if level == 1 then recover Array[Array[A] val](32) end
-      else recover Array[_VecNode[A]](32) end
+      if level == 1 then recover Array[Array[A] val] end
+      else recover Array[_VecNode[A]] end
       end
     _level = level
 
@@ -18,7 +18,7 @@ class val _VecNode[A: Any #share]
     (_entries, _level) = (consume entries, level)
 
   fun val new_root(): _VecNode[A] =>
-    let entries = recover val Array[_VecNode[A]](32) .> push(this) end
+    let entries = recover val Array[_VecNode[A]](1) .> push(this) end
     create(entries, _level + 1)
 
   fun apply(i: USize): A ? =>

--- a/packages/collections/persistent/vec.pony
+++ b/packages/collections/persistent/vec.pony
@@ -14,7 +14,7 @@ class val Vec[A: Any #share]
 
   new val create() =>
     _root = None
-    _tail = recover Array[A](32) end
+    _tail = recover Array[A] end
     _size = 0
     _depth = 1
     _tail_offset = 0
@@ -117,7 +117,7 @@ class val Vec[A: Any #share]
         try (_root as _VecNode[A]).new_root().push(_tail_offset, _tail)
         else _root
         end
-      let tail = recover val Array[A](32) .> push(value) end
+      let tail = recover val Array[A](1) .> push(value) end
       _create(root, tail, _size + 1, _depth + 1, _tail_offset + 32)
     else
       // push tail into root
@@ -129,7 +129,7 @@ class val Vec[A: Any #share]
           let r = _VecNode[A].empty(1)
           try r.push(0, _tail) else r end
         end
-      let tail = recover val Array[A](32) .> push(value) end
+      let tail = recover val Array[A](1) .> push(value) end
       _create(root, tail, _size + 1, _depth, _tail_offset + 32)
     end
 


### PR DESCRIPTION
This PR removes unnecessary allocation of full nodes (size 32). These allocations have no benefit since the nodes are copied when modified.