### PR TITLE
Fix segfault in String.trim_in_place

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -342,7 +342,7 @@ actor Main
 
     _size = last - offset
     _alloc = _alloc - offset
-    _ptr = if _size > 0 then _ptr._offset(offset) else _ptr.create() end
+    _ptr = _ptr._offset(offset)
 
   fun val trim(from: USize = 0, to: USize = -1): String val =>
     """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -31,6 +31,7 @@ actor Main is TestList
     test(_TestStringCut)
     test(_TestStringTrim)
     test(_TestStringTrimInPlace)
+    test(_TestStringTrimInPlaceWithAppend)
     test(_TestStringIsNullTerminated)
     test(_TestStringReplace)
     test(_TestStringSplit)
@@ -476,6 +477,26 @@ class iso _TestStringTrimInPlace is UnitTest
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
     h.assert_eq[String box](expected, copy.clone()) // safe to clone
+
+class iso _TestStringTrimInPlaceWithAppend is UnitTest
+  """
+  Test trimming part of a string in place then append and trim again
+
+  Verifies we don't get a regression for:
+  https://github.com/ponylang/ponyc/issues/1996
+  """
+  fun name(): String => "builtin/String.trim_in_place_with_append"
+
+  fun apply(h: TestHelper) =>
+    let a: String ref = "Hello".clone()
+    let big: Array[U8] val = recover val Array[U8].init(U8(1), 12_000) end
+    a.trim_in_place(a.size())
+    h.assert_eq[String box]("", a)
+    a.append(big)
+    a.trim_in_place(a.size())
+    h.assert_eq[String box]("", a)
+    a.append("Hello")
+    h.assert_eq[String box]("Hello", a)
 
 class iso _TestStringIsNullTerminated is UnitTest
   """


### PR DESCRIPTION
String.trim_in_place wasn't written to work correctly if you were
to trim the string down to nothing and then append a size less than the
"alloc" value that is left. This combination could result in incorrect
handling for strings that end up with a size of 0.

This is because, a new pointer was created, but we retained incorrect
alloc info. This wouldn't cause an error so long as when you used the
string for something like an append, reserve allocated new memory.
However, if the appended value was less than the perceived alloc size,
no additional memory would be added and kaboom.

Closes #1996