### PR TITLE
Fix boxed tuple identity when type identifiers differ

### DIFF
--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -61,6 +61,9 @@ struct reach_method_t
   size_t param_count;
   reach_param_t* params;
   reach_type_t* result;
+
+  // Used when reaching and generating __is for tuples.
+  reach_type_cache_t* tuple_is_types;
 };
 
 struct reach_method_name_t

--- a/test/libponyc/codegen_identity.cc
+++ b/test/libponyc/codegen_identity.cc
@@ -222,6 +222,25 @@ TEST_F(CodegenIdentityTest, NestedTuple)
 }
 
 
+TEST_F(CodegenIdentityTest, TupleDifferentTypes)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: ((Any, U8) | None) = (U8(0), 0)\n"
+    "    let b: ((U8, U8) | None) = (0, 0)\n"
+    "    if a is b then \n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
 TEST_F(CodegenIdentityTest, DigestofObject)
 {
   const char* src =


### PR DESCRIPTION
Previously, boxed tuples with different type identifiers wouldn't be considered as having the same identity even when containing the same objects, for example when comparing `(U32(0), U32(0))` through `(U32, U32)` and `(Any, Any)` tuples.

The new identity algorithm for boxed values follows. "unchanged" means that this step of the algorithm didn't need any changes.

- Check if the addresses are the same (unchanged)
  - If they are, the identities are the same (unchanged)
  - Otherwise, check the kind of the LHS object
    - If it's an unboxed type, the identities are different (unchanged)
    - If it's a boxed number, check the type of the RHS object
      - If the types are the same, check the values via `memcmp` (unchanged)
      - Otherwise, the identities are different
    - If it's a boxed tuple, check the kind of the RHS object
      - If it's a boxed tuple of any type, check the values via the LHS's `__is` function
      - Otherwise, the identities are different

The algorithm of the `__is` function was also changed. Since it now needs to compare against any possible type, multiple cases are generated in the function, which each case unboxing to a particular type and doing the comparison. The case to execute is chosen based on the type ID of the RHS object.

Fixes #1950.