### PR TITLE
Forbid returning and passing tuples to FFI functions

### DIFF
--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -703,3 +703,47 @@ TEST_F(BadPonyTest, AsFromUninferredReference)
     "argument not a subtype of parameter",
     "cannot infer type of b");
 }
+
+TEST_F(BadPonyTest, FFIDeclaredTupleArgument)
+{
+  const char* src =
+    "use @foo[None](x: (U8, U8))\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @foo((0, 0))";
+
+  TEST_ERRORS_1(src, "cannot pass tuples as FFI arguments");
+}
+
+TEST_F(BadPonyTest, FFIUndeclaredTupleArgument)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @foo[None]((U8(0), U8(0)))";
+
+  TEST_ERRORS_1(src, "cannot pass tuples as FFI arguments");
+}
+
+TEST_F(BadPonyTest, FFIDeclaredTupleReturn)
+{
+  const char* src =
+    "use @foo[(U8, U8)]()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @foo()";
+
+  TEST_ERRORS_1(src, "an FFI function cannot return a tuple");
+}
+
+TEST_F(BadPonyTest, FFIUndeclaredTupleReturn)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    @foo[(U8, U8)]()";
+
+  TEST_ERRORS_1(src, "an FFI function cannot return a tuple");
+}


### PR DESCRIPTION
Passing complex objects by value in C is hard: there are many different calling conventions depending on the platform. For example, a C compiler is allowed to split the members of an object into different parameters, or to change the return value into an out parameter.

The Pony compiler currently uses a naive implementation to pass objects to FFI functions and isn't able to use the correct calling convention for every call. Ideally, we'd want to rely on a C compiler API (like LibClang) to generate the correct signatures and calls.

This change is a temporary measure to avoid spurious FFI bugs until we have the interoperability detailed above. LLVM intrinsics are still allowed to return and be passed tuples since their signatures are defined by LLVM.