### PR TITLE
Add the ponyint_pool_realloc_size function

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -351,13 +351,8 @@ static void append_to_token(lexer_t* lexer, char c)
   if(lexer->buflen >= lexer->alloc)
   {
     size_t new_len = (lexer->alloc > 0) ? lexer->alloc << 1 : 64;
-    char* new_buf = (char*)ponyint_pool_alloc_size(new_len);
-    memcpy(new_buf, lexer->buffer, lexer->alloc);
-
-    if(lexer->alloc > 0)
-      ponyint_pool_free_size(lexer->alloc, lexer->buffer);
-
-    lexer->buffer = new_buf;
+    lexer->buffer =
+      (char*)ponyint_pool_realloc_size(lexer->alloc, new_len, lexer->buffer);
     lexer->alloc = new_len;
   }
 

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -443,12 +443,10 @@ static void tuple_indices_push(call_tuple_indices_t* ti, size_t idx)
 {
   if(ti->count == ti->alloc)
   {
-    size_t* tmp_data =
-      (size_t*)ponyint_pool_alloc_size(2 * ti->alloc * sizeof(size_t));
-    memcpy(tmp_data, ti->data, ti->count * sizeof(size_t));
-    ponyint_pool_free_size(ti->alloc * sizeof(size_t), ti->data);
+    size_t old_alloc = ti->alloc * sizeof(size_t);
+    ti->data =
+      (size_t*)ponyint_pool_realloc_size(old_alloc, old_alloc * 2, ti->data);
     ti->alloc *= 2;
-    ti->data = tmp_data;
   }
   ti->data[ti->count++] = idx;
 }

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -870,7 +870,6 @@ void* ponyint_pool_alloc(size_t index)
 
   pool_local_t* pool = pool_local;
   void* p = pool_get(pool, index);
-
   TRACK_ALLOC(p, POOL_MIN << index);
 
 #ifdef USE_VALGRIND
@@ -889,8 +888,8 @@ void ponyint_pool_free(size_t index, void* p)
   VALGRIND_DISABLE_ERROR_REPORTING;
 #endif
 
-  TRACK_FREE(p, POOL_MIN << index);
   pony_assert(index < POOL_COUNT);
+  TRACK_FREE(p, POOL_MIN << index);
 
   pool_local_t* thread = &pool_local[index];
   pool_global_t* global = &pool_global[index];
@@ -909,20 +908,13 @@ void ponyint_pool_free(size_t index, void* p)
 #endif
 }
 
-void* ponyint_pool_alloc_size(size_t size)
+static void* pool_alloc_size(size_t size)
 {
-  size_t index = ponyint_pool_index(size);
-
-  if(index < POOL_COUNT)
-    return ponyint_pool_alloc(index);
-
 #ifdef USE_VALGRIND
   VALGRIND_DISABLE_ERROR_REPORTING;
 #endif
 
-  size = ponyint_pool_adjust_size(size);
   void* p = pool_alloc_pages(size);
-
   TRACK_ALLOC(p, size);
 
 #ifdef USE_VALGRIND
@@ -934,6 +926,35 @@ void* ponyint_pool_alloc_size(size_t size)
   return p;
 }
 
+void* ponyint_pool_alloc_size(size_t size)
+{
+  size_t index = ponyint_pool_index(size);
+
+  if(index < POOL_COUNT)
+    return ponyint_pool_alloc(index);
+
+  size = ponyint_pool_adjust_size(size);
+  void* p = pool_alloc_size(size);
+
+  return p;
+}
+
+static void pool_free_size(size_t size, void* p)
+{
+#ifdef USE_VALGRIND
+  VALGRIND_HG_CLEAN_MEMORY(p, size);
+  VALGRIND_DISABLE_ERROR_REPORTING;
+#endif
+
+  TRACK_FREE(p, size);
+  pool_free_pages(p, size);
+
+#ifdef USE_VALGRIND
+  VALGRIND_ENABLE_ERROR_REPORTING;
+  VALGRIND_FREELIKE_BLOCK(p, 0);
+#endif
+}
+
 void ponyint_pool_free_size(size_t size, void* p)
 {
   size_t index = ponyint_pool_index(size);
@@ -941,20 +962,52 @@ void ponyint_pool_free_size(size_t size, void* p)
   if(index < POOL_COUNT)
     return ponyint_pool_free(index, p);
 
-#ifdef USE_VALGRIND
-  VALGRIND_HG_CLEAN_MEMORY(p, size);
-  VALGRIND_DISABLE_ERROR_REPORTING;
-#endif
-
   size = ponyint_pool_adjust_size(size);
-  pool_free_pages(p, size);
+  pool_free_size(size, p);
+}
 
-  TRACK_FREE(p, size);
+void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p)
+{
+  // Can only reuse the old pointer if the old index/adjusted size is equal to
+  // the new one, not greater.
 
-#ifdef USE_VALGRIND
-  VALGRIND_ENABLE_ERROR_REPORTING;
-  VALGRIND_FREELIKE_BLOCK(p, 0);
-#endif
+  if(p == NULL)
+    return ponyint_pool_alloc_size(new_size);
+
+  size_t old_index = ponyint_pool_index(old_size);
+  size_t new_index = ponyint_pool_index(new_size);
+  size_t old_adj_size = 0;
+
+  void* new_p;
+
+  if(new_index < POOL_COUNT)
+  {
+    if(old_index == new_index)
+      return p;
+
+    new_p = ponyint_pool_alloc(new_index);
+  } else {
+    size_t new_adj_size = ponyint_pool_adjust_size(new_size);
+
+    if(old_index == POOL_COUNT)
+    {
+      old_adj_size = ponyint_pool_adjust_size(old_size);
+
+      if(old_adj_size == new_adj_size)
+        return p;
+    }
+
+    new_p = pool_alloc_size(new_adj_size);
+  }
+
+  memcpy(new_p, p, new_size);
+
+  if(old_index <= POOL_COUNT)
+    ponyint_pool_free(old_index, p);
+  else
+    pool_free_size(old_adj_size, p);
+
+  return new_p;
 }
 
 void ponyint_pool_thread_cleanup()

--- a/src/libponyrt/mem/pool.h
+++ b/src/libponyrt/mem/pool.h
@@ -27,6 +27,8 @@ void ponyint_pool_free(size_t index, void* p);
 __pony_spec_malloc__(void* ponyint_pool_alloc_size(size_t size));
 void ponyint_pool_free_size(size_t size, void* p);
 
+void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p);
+
 void ponyint_pool_thread_cleanup();
 
 size_t ponyint_pool_index(size_t size);


### PR DESCRIPTION
This function has the same functionality as C's realloc but for the pool allocator.

Manual pool reallocation patterns in the compiler have been updated to use the new function.