### PR TITLE
Enhance brackets in CAS loops

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -733,11 +733,12 @@ static void pool_push(pool_local_t* thread, pool_global_t* global)
 #ifdef USE_VALGRIND
     ANNOTATE_HAPPENS_BEFORE(&global->central);
 #endif
+  }
 #ifdef PLATFORM_IS_X86
-  } while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
+  while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
     xchg, memory_order_release, memory_order_relaxed));
 #else
-  } while(!atomic_compare_exchange_weak_explicit(&global->central, &top, p,
+  while(!atomic_compare_exchange_weak_explicit(&global->central, &top, p,
     memory_order_release, memory_order_relaxed));
 #endif
 }
@@ -771,10 +772,13 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
 #ifdef PLATFORM_IS_X86
     xchg.object = next;
     xchg.counter = cmp.counter + 1;
-  } while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
+#endif
+  }
+#ifdef PLATFORM_IS_X86
+  while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
     xchg, memory_order_acquire, memory_order_relaxed));
 #else
-  } while(!atomic_compare_exchange_weak_explicit(&global->central, &top, next,
+  while(!atomic_compare_exchange_weak_explicit(&global->central, &top, next,
     memory_order_acquire, memory_order_relaxed));
 #endif
 

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -116,10 +116,13 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
 #ifdef PLATFORM_IS_X86
     xchg.object = next;
     xchg.counter = cmp.counter + 1;
-  } while(!bigatomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
+#endif
+  }
+#ifdef PLATFORM_IS_X86
+  while(!bigatomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
     memory_order_relaxed, memory_order_relaxed));
 #else
-  } while(!atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
+  while(!atomic_compare_exchange_weak_explicit(&q->tail, &tail, next,
     memory_order_relaxed, memory_order_relaxed));
 #endif
 


### PR DESCRIPTION
The duplicate brackets due to ifdefs were rendering badly in some text editors.