### PR TITLE
Split reach types into generic and LLVM-specific ones

### DIFF
--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -1,5 +1,6 @@
 #include "genbox.h"
 #include "gencall.h"
+#include "genfun.h"
 #include "genname.h"
 #include "gentype.h"
 #include "ponyassert.h"
@@ -13,8 +14,9 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
 
   reach_type_t* t = reach_type(c->reach, type);
   pony_assert(t != NULL);
+  compile_type_t* c_t = (compile_type_t*)t->c_type;
 
-  if(l_type != t->primitive)
+  if(l_type != c_t->primitive)
     return NULL;
 
   // Allocate the object.
@@ -41,13 +43,14 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
 
   reach_type_t* t = reach_type(c->reach, type);
   pony_assert(t != NULL);
+  compile_type_t* c_t = (compile_type_t*)t->c_type;
 
-  if(t->primitive == NULL)
+  if(c_t->primitive == NULL)
     return object;
 
   // Extract the primitive type from element 1 and return it.
   LLVMValueRef this_ptr = LLVMBuildBitCast(c->builder, object,
-    t->structure_ptr, "");
+    c_t->structure_ptr, "");
   LLVMValueRef value_ptr = LLVMBuildStructGEP(c->builder, this_ptr, 1, "");
 
   LLVMValueRef value = LLVMBuildLoad(c->builder, value_ptr, "");

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -1,6 +1,7 @@
 #include "gencontrol.h"
-#include "genexpr.h"
 #include "gencall.h"
+#include "genexpr.h"
+#include "genfun.h"
 #include "genname.h"
 #include "../pass/expr.h"
 #include "../type/subtype.h"
@@ -39,10 +40,10 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   ast_t* right_type = ast_type(right);
 
   // We will have no type if both branches have return statements.
-  reach_type_t* phi_type = NULL;
+  compile_type_t* phi_type = NULL;
 
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
-    phi_type = reach_type(c->reach, type);
+    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
 
   LLVMValueRef c_value = gen_expr(c, cond);
 
@@ -174,10 +175,10 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reach_type_t* phi_type = NULL;
+  compile_type_t* phi_type = NULL;
 
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
-    phi_type = reach_type(c->reach, type);
+    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
 
   LLVMBasicBlockRef init_block = codegen_block(c, "while_init");
   LLVMBasicBlockRef body_block = codegen_block(c, "while_body");
@@ -298,10 +299,10 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reach_type_t* phi_type = NULL;
+  compile_type_t* phi_type = NULL;
 
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
-    phi_type = reach_type(c->reach, type);
+    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
 
   LLVMBasicBlockRef body_block = codegen_block(c, "repeat_body");
   LLVMBasicBlockRef cond_block = codegen_block(c, "repeat_cond");
@@ -513,11 +514,11 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   ast_t* body_type = ast_type(body);
   ast_t* else_type = ast_type(else_clause);
 
-  reach_type_t* phi_type = NULL;
+  compile_type_t* phi_type = NULL;
 
   // We will have no type if both branches have return statements.
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
-    phi_type = reach_type(c->reach, type);
+    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
 
   LLVMBasicBlockRef block = LLVMGetInsertBlock(c->builder);
   LLVMBasicBlockRef else_block = codegen_block(c, "try_else");

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -1,10 +1,10 @@
 #include "genexe.h"
-#include "genopt.h"
-#include "genobj.h"
 #include "gencall.h"
+#include "genfun.h"
 #include "genname.h"
-#include "genprim.h"
+#include "genobj.h"
 #include "genopt.h"
+#include "genprim.h"
 #include "../reach/paint.h"
 #include "../pkg/package.h"
 #include "../pkg/program.h"
@@ -24,7 +24,8 @@ static LLVMValueRef create_main(compile_t* c, reach_type_t* t,
   // Create the main actor and become it.
   LLVMValueRef args[2];
   args[0] = ctx;
-  args[1] = LLVMConstBitCast(t->desc, c->descriptor_ptr);
+  args[1] = LLVMConstBitCast(((compile_type_t*)t->c_type)->desc,
+    c->descriptor_ptr);
   LLVMValueRef actor = gencall_runtime(c, "pony_create", args, 2, "");
 
   args[0] = ctx;
@@ -72,7 +73,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   env_args[1] = args[0];
   env_args[2] = LLVMBuildBitCast(c->builder, args[1], c->void_ptr, "");
   env_args[3] = LLVMBuildBitCast(c->builder, args[2], c->void_ptr, "");
-  codegen_call(c, m->func, env_args, 4, true);
+  codegen_call(c, ((compile_method_t*)m->c_method)->func, env_args, 4, true);
   LLVMValueRef env = env_args[0];
 
   // Run primitive initialisers using the main actor's heap.
@@ -107,7 +108,8 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
 
   args[0] = ctx;
   args[1] = LLVMBuildBitCast(c->builder, env, c->object_ptr, "");
-  args[2] = LLVMBuildBitCast(c->builder, t_env->desc, c->descriptor_ptr, "");
+  args[2] = LLVMBuildBitCast(c->builder, ((compile_type_t*)t_env->c_type)->desc,
+    c->descriptor_ptr, "");
   args[3] = LLVMConstInt(c->i32, PONY_TRACE_IMMUTABLE, false);
   gencall_runtime(c, "pony_traceknown", args, 4, "");
 

--- a/src/libponyc/codegen/genfun.h
+++ b/src/libponyc/codegen/genfun.h
@@ -7,8 +7,22 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct compile_method_t
+{
+  compile_opaque_free_fn free_fn;
+
+  LLVMTypeRef func_type;
+  LLVMTypeRef msg_type;
+  LLVMValueRef func;
+  LLVMValueRef func_handler;
+  LLVMMetadataRef di_method;
+  LLVMMetadataRef di_file;
+} compile_method_t;
+
 void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   LLVMValueRef fun);
+
+void genfun_allocate_compile_methods(compile_t* c, reach_type_t* t);
 
 bool genfun_method_sigs(compile_t* c, reach_type_t* t);
 

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -3,6 +3,7 @@
 #include "gencall.h"
 #include "gendesc.h"
 #include "genexpr.h"
+#include "genfun.h"
 #include "genopt.h"
 #include "../reach/subtype.h"
 #include "../type/subtype.h"
@@ -481,14 +482,16 @@ void gen_is_tuple_fun(compile_t* c, reach_type_t* t)
   if(m == NULL)
     return;
 
+  compile_method_t* c_m = (compile_method_t*)m->c_method;
+
   LLVMTypeRef params[3];
   params[0] = c->object_ptr;
   params[1] = c->object_ptr;
   params[2] = c->i32;
-  m->func_type = LLVMFunctionType(c->i1, params, 3, false);
-  m->func = codegen_addfun(c, m->full_name, m->func_type);
+  c_m->func_type = LLVMFunctionType(c->i1, params, 3, false);
+  c_m->func = codegen_addfun(c, m->full_name, c_m->func_type);
 
-  codegen_startfun(c, m->func, NULL, NULL, false);
+  codegen_startfun(c, c_m->func, NULL, NULL, false);
   LLVMValueRef l_value = LLVMGetParam(codegen_fun(c), 0);
   LLVMValueRef r_value = LLVMGetParam(codegen_fun(c), 1);
   LLVMValueRef r_id = LLVMGetParam(codegen_fun(c), 2);
@@ -545,7 +548,8 @@ LLVMValueRef gen_numeric_size_table(compile_t* c)
     uint32_t type_id = t->type_id;
     if((type_id % 4) == 0)
     {
-      size_t type_size = (size_t)LLVMABISizeOfType(c->target_data, t->use_type);
+      size_t type_size = (size_t)LLVMABISizeOfType(c->target_data,
+        ((compile_type_t*)t->c_type)->use_type);
       args[type_id >> 2] = LLVMConstInt(c->i32, type_size, false);
       count++;
     }

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -6,12 +6,14 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct compile_type_t compile_type_t;
+
 void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
   LLVMValueRef ctx, LLVMValueRef ptr, LLVMValueRef offset);
 
 void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
 
-void gendeserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
+void gendeserialise_typeid(compile_t* c, compile_type_t* t, LLVMValueRef offset);
 
 void gendeserialise_element(compile_t* c, reach_type_t* t, bool embed,
   LLVMValueRef ctx, LLVMValueRef ptr);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -1,6 +1,7 @@
 #include "gentrace.h"
 #include "gencall.h"
 #include "gendesc.h"
+#include "genfun.h"
 #include "genname.h"
 #include "genprim.h"
 #include "../type/cap.h"
@@ -494,7 +495,8 @@ static void trace_known(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   LLVMValueRef args[4];
   args[0] = ctx;
   args[1] = LLVMBuildBitCast(c->builder, object, c->object_ptr, "");
-  args[2] = LLVMBuildBitCast(c->builder, t->desc, c->descriptor_ptr, "");
+  args[2] = LLVMBuildBitCast(c->builder, ((compile_type_t*)t->c_type)->desc,
+    c->descriptor_ptr, "");
   args[3] = LLVMConstInt(c->i32, mutability, false);
 
   gencall_runtime(c, "pony_traceknown", args, 4, "");
@@ -940,7 +942,8 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
   if(!need_trace)
     return;
 
-  t->trace_fn = codegen_addfun(c, genname_trace(t->name), c->trace_type);
+  ((compile_type_t*)t->c_type)->trace_fn = codegen_addfun(c,
+    genname_trace(t->name), c->trace_type);
 }
 
 void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -6,6 +6,36 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct compile_type_t
+{
+  compile_opaque_free_fn free_fn;
+
+  size_t abi_size;
+
+  LLVMTypeRef structure;
+  LLVMTypeRef structure_ptr;
+  LLVMTypeRef primitive;
+  LLVMTypeRef use_type;
+
+  LLVMTypeRef desc_type;
+  LLVMValueRef desc;
+  LLVMValueRef instance;
+  LLVMValueRef trace_fn;
+  LLVMValueRef serialise_trace_fn;
+  LLVMValueRef serialise_fn;
+  LLVMValueRef deserialise_fn;
+  LLVMValueRef custom_serialise_space_fn;
+  LLVMValueRef custom_serialise_fn;
+  LLVMValueRef custom_deserialise_fn;
+  LLVMValueRef final_fn;
+  LLVMValueRef dispatch_fn;
+  LLVMValueRef dispatch_switch;
+
+  LLVMMetadataRef di_file;
+  LLVMMetadataRef di_type;
+  LLVMMetadataRef di_type_embed;
+} compile_type_t;
+
 typedef struct tbaa_metadata_t
 {
   const char* name;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -3,11 +3,8 @@
 
 #include "../ast/ast.h"
 #include "../pass/pass.h"
-#include "../codegen/gendebug.h"
 #include "../../libponyrt/ds/hash.h"
 #include "../../libponyrt/ds/stack.h"
-
-#include <llvm-c/Core.h>
 
 PONY_EXTERN_C_BEGIN
 
@@ -26,6 +23,13 @@ DECLARE_HASHMAP_SERIALISE(reach_method_names, reach_method_names_t,
 DECLARE_HASHMAP_SERIALISE(reach_types, reach_types_t, reach_type_t);
 DECLARE_HASHMAP_SERIALISE(reach_type_cache, reach_type_cache_t, reach_type_t);
 
+typedef void (*compile_opaque_free_fn)(void* p);
+
+typedef struct compile_opaque_t
+{
+  compile_opaque_free_fn free_fn;
+} compile_opaque_t;
+
 struct reach_method_t
 {
   const char* name;
@@ -36,13 +40,6 @@ struct reach_method_t
   ast_t* typeargs;
   ast_t* r_fun;
   uint32_t vtable_index;
-
-  LLVMTypeRef func_type;
-  LLVMTypeRef msg_type;
-  LLVMValueRef func;
-  LLVMValueRef func_handler;
-  LLVMMetadataRef di_method;
-  LLVMMetadataRef di_file;
 
   // Mark as true if the compiler supplies an implementation.
   bool intrinsic;
@@ -64,6 +61,8 @@ struct reach_method_t
 
   // Used when reaching and generating __is for tuples.
   reach_type_cache_t* tuple_is_types;
+
+  compile_opaque_t* c_method;
 };
 
 struct reach_method_name_t
@@ -101,36 +100,14 @@ struct reach_type_t
   reach_method_t* bare_method;
   reach_type_cache_t subtypes;
   uint32_t type_id;
-  size_t abi_size;
   uint32_t vtable_size;
   bool can_be_boxed;
   bool is_trait;
 
-  LLVMTypeRef structure;
-  LLVMTypeRef structure_ptr;
-  LLVMTypeRef primitive;
-  LLVMTypeRef use_type;
-
-  LLVMTypeRef desc_type;
-  LLVMValueRef desc;
-  LLVMValueRef instance;
-  LLVMValueRef trace_fn;
-  LLVMValueRef serialise_trace_fn;
-  LLVMValueRef serialise_fn;
-  LLVMValueRef deserialise_fn;
-  LLVMValueRef custom_serialise_space_fn;
-  LLVMValueRef custom_serialise_fn;
-  LLVMValueRef custom_deserialise_fn;
-  LLVMValueRef final_fn;
-  LLVMValueRef dispatch_fn;
-  LLVMValueRef dispatch_switch;
-
-  LLVMMetadataRef di_file;
-  LLVMMetadataRef di_type;
-  LLVMMetadataRef di_type_embed;
-
   uint32_t field_count;
   reach_field_t* fields;
+
+  compile_opaque_t* c_type;
 };
 
 typedef struct

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <platform.h>
 
-#include <reach/reach.h>
+#include <codegen/gentype.h>
 
 #include "util.h"
 
@@ -35,7 +35,7 @@ TEST_F(CodegenTest, PackedStructIsPacked)
   reach_type_t* foo = reach_type_name(reach, "Foo");
   ASSERT_TRUE(foo != NULL);
 
-  LLVMTypeRef type = foo->structure;
+  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
   ASSERT_TRUE(LLVMIsPackedStruct(type));
 }
 
@@ -57,7 +57,7 @@ TEST_F(CodegenTest, NonPackedStructIsntPacked)
   reach_type_t* foo = reach_type_name(reach, "Foo");
   ASSERT_TRUE(foo != NULL);
 
-  LLVMTypeRef type = foo->structure;
+  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
   ASSERT_TRUE(!LLVMIsPackedStruct(type));
 }
 
@@ -79,7 +79,7 @@ TEST_F(CodegenTest, ClassCannotBePacked)
   reach_type_t* foo = reach_type_name(reach, "Foo");
   ASSERT_TRUE(foo != NULL);
 
-  LLVMTypeRef type = foo->structure;
+  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
   ASSERT_TRUE(!LLVMIsPackedStruct(type));
 }
 
@@ -101,7 +101,7 @@ TEST_F(CodegenTest, ActorCannotBePacked)
   reach_type_t* foo = reach_type_name(reach, "Foo");
   ASSERT_TRUE(foo != NULL);
 
-  LLVMTypeRef type = foo->structure;
+  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
   ASSERT_TRUE(!LLVMIsPackedStruct(type));
 }
 


### PR DESCRIPTION
This change adds the `compile_type_t` and `compile_method_t`, which contains the LLVM-specific data for `reach_type_t` and `reach_method_t`, respectively. These new objects are accessed through opaque members on `reach_type_t` and `reach_method_t`.

There are two main goals for this change.

1. Do not depend on LLVM for anything other than codegen. This will make things easier if we ever need to add an alternative backend.
2. Avoid using up unnecessary space for unserialised LLVM data when serialising the reachability map.

I'm putting this up for initial review. It shouldn't be merged yet.