### PR TITLE
Remove the old lambda syntax from the compiler

### DIFF
--- a/pony.g
+++ b/pony.g
@@ -201,7 +201,6 @@ nextatom
   | LSQUARE_NEW ('as' type ':')? rawseq ']'
   | 'object' ('\\' ID (',' ID)* '\\')? cap? ('is' type)? members 'end'
   | '{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
-  | 'lambda' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
@@ -215,7 +214,6 @@ atom
   | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq ']'
   | 'object' ('\\' ID (',' ID)* '\\')? cap? ('is' type)? members 'end'
   | '{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
-  | 'lambda' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq 'end'
   | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) params? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -140,7 +140,6 @@ static const lextoken_t keywords[] =
   { "class", TK_CLASS },
   { "actor", TK_ACTOR },
   { "object", TK_OBJECT },
-  { "lambda", TK_LAMBDA },
 
   { "as", TK_AS },
   { "is", TK_IS },
@@ -268,6 +267,7 @@ static const lextoken_t abstract[] =
   { "lambdacaptures", TK_LAMBDACAPTURES },
   { "lambdacapture", TK_LAMBDACAPTURE },
 
+  { "lambda", TK_LAMBDA },
   { "barelambda", TK_BARELAMBDA },
 
   { "seq", TK_SEQ },

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -360,31 +360,6 @@ DEF(lambdacaptures);
   SKIP(NULL, TK_RPAREN);
   DONE();
 
-// LAMBDA [annotations] [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params]
-// RPAREN [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq END
-DEF(oldlambda);
-  PRINT_INLINE();
-  TOKEN(NULL, TK_LAMBDA);
-  ANNOTATE(annotations);
-  OPT RULE("receiver capability", cap);
-  OPT TOKEN("function name", TK_ID);
-  OPT RULE("type parameters", typeparams);
-  SKIP(NULL, TK_LPAREN, TK_LPAREN_NEW);
-  OPT RULE("parameters", params);
-  SKIP(NULL, TK_RPAREN);
-  OPT RULE("captures", lambdacaptures);
-  IF(TK_COLON, RULE("return type", type));
-  OPT TOKEN(NULL, TK_QUESTION);
-  SKIP(NULL, TK_DBLARROW);
-  RULE("lambda body", rawseq);
-  TERMINATE("lambda expression", TK_END);
-  AST_NODE(TK_QUESTION); // Reference capability - question indicates old syntax
-  SET_CHILD_FLAG(2, AST_FLAG_PRESERVE); // Type parameters
-  SET_CHILD_FLAG(3, AST_FLAG_PRESERVE); // Parameters
-  SET_CHILD_FLAG(5, AST_FLAG_PRESERVE); // Return type
-  SET_CHILD_FLAG(7, AST_FLAG_PRESERVE); // Body
-  DONE();
-
 // LBRACE [annotations] [CAP] [ID] [typeparams] (LPAREN | LPAREN_NEW) [params]
 // RPAREN [lambdacaptures] [COLON type] [QUESTION] ARROW rawseq RBRACE [CAP]
 DEF(lambda);
@@ -532,14 +507,14 @@ DEF(ffi);
 // location
 DEF(atom);
   RULE("value", ref, thisliteral, literal, groupedexpr, array, object, lambda,
-    oldlambda, barelambda, ffi, location);
+    barelambda, ffi, location);
   DONE();
 
 // ref | this | literal | tuple | array | object | lambda | barelambda| ffi |
 // location
 DEF(nextatom);
   RULE("value", ref, thisliteral, literal, nextgroupedexpr, nextarray, object,
-    lambda, oldlambda, barelambda, ffi, location);
+    lambda, barelambda, ffi, location);
   DONE();
 
 // DOT ID

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1065,13 +1065,6 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
     ret_type, raises, body, reference_cap);
   bool r = true;
 
-  if(ast_id(reference_cap) == TK_QUESTION)
-  {
-    ast_error(opt->check.errors, ast,
-      "lambda ... end is no longer supported syntax; use {...} for lambdas");
-    r = false;
-  }
-
   switch(ast_id(ret_type))
   {
     case TK_ISO:

--- a/test/libponyc/lambda.cc
+++ b/test/libponyc/lambda.cc
@@ -88,18 +88,6 @@ TEST_F(LambdaTest, LambdaCaptureTypeWithoutExpressionFail)
 }
 
 
-TEST_F(LambdaTest, LambdaOldSyntax)
-{
-  const char* src =
-    "actor Main\n"
-    "  new create(env: Env) =>\n"
-    "    lambda() => None end";
-
-  TEST_ERRORS_1(src,
-    "lambda ... end is no longer supported syntax; use {...} for lambdas");
-}
-
-
 TEST_F(LambdaTest, LambdaCaptureFree)
 {
   const char* src =


### PR DESCRIPTION
In version 0.9, the concise lambda syntax from RFC 24 was implemented, removing the `lambda ... end` syntax from the language. This syntax was kept in the compiler to help report a helpful compiler error to aid users in the transition.

Version 0.9 happened a while ago and users had time to adapt. Removing the syntax altogether (treating old lambdas as plain parsing errors) cleans up the compiler and doesn't have ill effects at that point.