### PR TITLE
Test for grammar changes in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ Once those conditions are met, the PR can be merged, and an automated system wil
 
 Please note, if your changes are purely to things like README, CHANGELOG etc, you can add [skip ci] as the last line of your commit message and your PR won't be run through our continuous integration systems. We ask that you use [skip ci] where appropriate as it helps to get changes through CI faster and doesn't waste resources that Appveyor and TravisCI are kindly donating to the Open Source community.
 
+Grammar Changes
+---------------
+If your contribution contains changes to the grammar of the language, you should update the `pony.g` file at the root of the repository with `ponyc --antlr > pony.g`.
+
 Documentation Formatting
 ---------------
 When contributing to documentation, try to keep the following style guidelines in mind:

--- a/Makefile
+++ b/Makefile
@@ -774,6 +774,9 @@ test-ci: all
 	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
 	@./examples1
 	@rm examples1
+	@$(PONY_BUILD_DIR)/ponyc --antlr > pony.g.new
+	@diff pony.g pony.g.new
+	@rm pony.g.new
 
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs --pass expr

--- a/wscript
+++ b/wscript
@@ -324,12 +324,21 @@ def build(ctx):
         target   = stdlibTarget,
         source   = ctx.bldnode.ant_glob('ponyc*') + ctx.path.ant_glob('packages/**/*.pony'),
     )
+    
+    # grammar file
+    ctx(
+        features = 'seq',
+        rule     = os.path.join(ctx.bldnode.abspath(), 'ponyc') + ' --antlr > pony.g.new',
+        target   = 'pony.g.new',
+    )
 
 
 # this command runs the test suites
 def test(ctx):
     import os
+
     buildDir = ctx.bldnode.abspath()
+    sourceDir = ctx.srcnode.abspath()
 
     total = 0
     passed = 0
@@ -358,6 +367,14 @@ def test(ctx):
     print('{0} test suites; {1} passed; {2} failed'.format(total, passed, total - passed))
     if passed < total:
         sys.exit(1)
+    
+    ponyg = os.path.join(sourceDir, 'pony.g')
+    ponygNew = os.path.join(buildDir, 'pony.g.new')
+    with open(ponyg, 'r') as pg:
+        with open(ponygNew, 'r') as pgn:
+            if pg.read() != pgn.read():
+                print('Grammar files differ')
+                sys.exit(1)
 
 
 # subclass the build context for the test command,


### PR DESCRIPTION
cc @ponylang/committer When merging a pull request that contain changes to the grammar (i.e. a change to the grammar rules in `parser.c` or to token symbols in `lexer.c`), we should ensure that it also contains an update of the pony.g file.