### PR TITLE
Fix: compiler crash when using the `as` operator with an uninferrable reference.

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -539,6 +539,9 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
   pony_assert(ast_id(ast) == TK_AS);
   AST_GET_CHILDREN(ast, expr, type);
 
+  if(is_typecheck_error(ast_type(expr)))
+    return false;
+
   ast_t* pattern_root = ast_from(type, TK_LEX_ERROR);
   ast_t* body_root = ast_from(type, TK_LEX_ERROR);
   if(!add_as_type(opt, ast, expr, type, pattern_root, body_root))

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -686,3 +686,20 @@ TEST_F(BadPonyTest, CodegenMangledFunptr)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(BadPonyTest, AsFromUninferredReference)
+{
+  // From issue #2035
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let b = apply(true)\n"
+    "    b as Bool\n"
+
+    "  fun ref apply(s: String): (Bool | None) =>\n"
+    "    true";
+
+  TEST_ERRORS_2(src,
+    "argument not a subtype of parameter",
+    "cannot infer type of b");
+}


### PR DESCRIPTION
Resolves #2035.