### PR TITLE
Fix: Compiler crash when using `as` on numeric literal

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -539,8 +539,15 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
   pony_assert(ast_id(ast) == TK_AS);
   AST_GET_CHILDREN(ast, expr, type);
 
-  if(is_typecheck_error(ast_type(expr)))
+  ast_t* expr_type = ast_type(expr);
+  if(is_typecheck_error(expr_type))
     return false;
+
+  if(ast_id(expr_type) == TK_LITERAL || ast_id(expr_type) == TK_OPERATORLITERAL)
+  {
+    ast_error(opt->check.errors, expr, "Cannot cast uninferred literal");
+    return false;
+  }
 
   ast_t* pattern_root = ast_from(type, TK_LEX_ERROR);
   ast_t* body_root = ast_from(type, TK_LEX_ERROR);

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -3,7 +3,6 @@
 #include "../ast/parser.h"
 #include "../ast/stringtab.h"
 #include "../ast/token.h"
-#include "../expr/literal.h"
 #include "../pkg/package.h"
 #include "../pkg/platformfuns.h"
 #include "../type/assemble.h"

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -3,6 +3,7 @@
 #include "../ast/parser.h"
 #include "../ast/stringtab.h"
 #include "../ast/token.h"
+#include "../expr/literal.h"
 #include "../pkg/package.h"
 #include "../pkg/platformfuns.h"
 #include "../type/assemble.h"
@@ -1259,6 +1260,29 @@ static ast_result_t syntax_annotation(pass_opt_t* opt, ast_t* ast)
 }
 
 
+static ast_result_t syntax_as(pass_opt_t* opt, ast_t* ast)
+{
+  pony_assert(ast_id(ast) == TK_AS);
+  AST_GET_CHILDREN(ast, expr);
+
+  switch (ast_id(expr))
+  {
+    case TK_INT:
+    case TK_FLOAT:
+      ast_error(opt->check.errors, expr,
+        "Cannot cast uninferred numeric literal");
+      ast_error_continue(opt->check.errors, expr,
+        "To give a numeric literal a specific type, "
+        "use constructor of primitive");
+      return AST_ERROR;
+
+    default: break;
+  }
+
+  return AST_OK;
+}
+
+
 ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
 {
   pony_assert(astp != NULL);
@@ -1341,6 +1365,8 @@ ast_result_t pass_syntax(ast_t** astp, pass_opt_t* options)
         "Compile time expressions not yet supported");
       r = AST_ERROR;
       break;
+
+    case TK_AS:         r = syntax_as(options, ast); break;
 
     default: break;
   }

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1273,7 +1273,7 @@ static ast_result_t syntax_as(pass_opt_t* opt, ast_t* ast)
         "Cannot cast uninferred numeric literal");
       ast_error_continue(opt->check.errors, expr,
         "To give a numeric literal a specific type, "
-        "use constructor of primitive");
+        "use the constructor of that numeric type");
       return AST_ERROR;
 
     default: break;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -703,3 +703,17 @@ TEST_F(BadPonyTest, AsFromUninferredReference)
     "argument not a subtype of parameter",
     "cannot infer type of b");
 }
+
+TEST_F(BadPonyTest, AsUninferredNumericLiteral)
+{
+  // From issue #2037
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    0 as I64\n"
+    "    0.0 as F64";
+
+  TEST_ERRORS_2(src,
+    "Cannot cast uninferred numeric literal",
+    "Cannot cast uninferred numeric literal");
+}

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -761,3 +761,14 @@ TEST_F(BadPonyTest, AsUninferredNumericLiteral)
     "Cannot cast uninferred numeric literal",
     "Cannot cast uninferred numeric literal");
 }
+
+TEST_F(BadPonyTest, AsNestedUninferredNumericLiteral)
+{
+  // From issue #2037
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    (0, 1) as (I64, I64)";
+
+  TEST_ERRORS_1(src, "Cannot cast uninferred literal");
+}


### PR DESCRIPTION
Fix #2037, adding a check for `as` on numeric literals to syntax pass.
Also, it shows following message as "info"

    To give a numeric literal a specific type, use constructor of primitive

If wording is strange, please let me know.