### PR TITLE
Fix overly restrictive field reference rule in recover expressions.

### DIFF
--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -147,10 +147,10 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
     ast_free_unattached(upper);
   }
 
-  // In a recover expression, we can access obj.field if field is sendable
-  // and not being assigned to, even if obj isn't sendable.
+  // In a recover expression, we can access `this.field` if field is sendable
+  // and not being assigned to, even if the `this` object isn't sendable.
 
-  if(opt->check.frame->recover != NULL)
+  if((opt->check.frame->recover != NULL) && (ast_id(left) == TK_THIS))
   {
     if(!sendable(type))
     {
@@ -158,9 +158,9 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
       {
         errorframe_t frame = NULL;
         ast_error_frame(&frame, ast, "can't access field of non-sendable "
-          "object inside of a recover expression");
-        ast_error_frame(&frame, find, "this would be possible if the field was "
-          "sendable");
+          "`this` object inside of a recover expression");
+        ast_error_frame(&frame, find, "this would be possible if the field "
+          "was sendable");
         errorframe_report(&frame, opt->check.errors);
         return false;
       }
@@ -178,7 +178,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
       {
         errorframe_t frame = NULL;
         ast_error_frame(&frame, ast, "can't access field of non-sendable "
-          "object inside of a recover expression");
+          "`this` object inside of a recover expression");
         ast_error_frame(&frame, parent, "this would be possible if the field "
           "wasn't assigned to");
         errorframe_report(&frame, opt->check.errors);
@@ -399,7 +399,7 @@ bool expr_localref(pass_opt_t* opt, ast_t* ast)
           {
             ast_error(opt->check.errors, ast, "can't access a non-sendable "
               "local defined outside of a recover expression from within "
-              "that recover epression");
+              "that recover expression");
             ast_error_continue(opt->check.errors, parent, "this would be "
               "possible if the local wasn't assigned to");
             return false;

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -290,7 +290,25 @@ TEST_F(RecoverTest, CantAccess_NonSendableField)
     "  fun apply(): Wrap iso =>\n"
     "    recover Wrap(inner) end";
 
-  TEST_ERRORS_1(src, "can't access field of non-sendable object");
+  TEST_ERRORS_1(src, "can't access field of non-sendable `this` object");
+}
+
+TEST_F(RecoverTest, CanAccess_NonSendableFieldOfLocalRef)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  let inner: Inner = Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover\n"
+    "      let c: Class = Class\n"
+    "      Wrap(c.inner)\n"
+    "    end";
+
+  TEST_COMPILE(src);
 }
 
 TEST_F(RecoverTest, CantAccess_AssignedField)
@@ -305,8 +323,26 @@ TEST_F(RecoverTest, CantAccess_AssignedField)
     "  fun apply(): Wrap iso =>\n"
     "    recover Wrap(inner = recover Inner end) end";
 
-  TEST_ERRORS_2(src, "can't access field of non-sendable object",
+  TEST_ERRORS_2(src, "can't access field of non-sendable `this` object",
     "left side must be something that can be assigned to");
+}
+
+TEST_F(RecoverTest, CanAccess_AssignedFieldOfLocalRef)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  var inner: Inner = Inner\n"
+    "  fun apply(): Wrap iso =>\n"
+    "    recover\n"
+    "      let c: Class = Class\n"
+    "      Wrap(c.inner = recover Inner end)\n"
+    "    end";
+
+  TEST_COMPILE(src);
 }
 
 TEST_F(RecoverTest, CantAccess_ThisOriginallyTagField)


### PR DESCRIPTION
This PR fixes an overly restrictive field reference rule in recover expressions.

Specifically, a rule meant to prevent non-sendable or assigned-to field references of the current `this` object was being applied to *all* field references, including references to fields of objects created inside the recover expression, where they are supposed to be considered already safe. Note that we don't have to apply this case to references to local variables from outside the recover scope, since any non-sendable references to those will already be disallowed.

