### PR TITLE
Reset the actor context on runtime initialisation

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -371,6 +371,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
   bool pinasio)
 {
   pony_register_thread();
+  this_scheduler->ctx.current = NULL;
 
   use_yield = !noyield;
 


### PR DESCRIPTION
Not reinitialising the context could result in the runtime referencing an invalid actor if the runtime was stopped and restarted.