### PR TITLE
Correctly fix build on old compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Changed
 
 - Forbid returning and passing tuples to FFI functions ([PR #2012](https://github.com/ponylang/ponyc/pull/2012))
+- Deprecate support of Clang 3.3
 
 
 ## [0.15.0] - 2017-07-08

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Once you have installed the prerequisites, you can download the latest ponyc rel
 First of all, you need a compiler with decent C11 support. The following compilers are supported, though we recommend to use the most recent versions.
 
 - GCC >= 4.7
-- Clang >= 3.3
+- Clang >= 3.4
 - MSVC >= 2013
 - XCode Clang >= 6.0
 

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -16,6 +16,7 @@
 // MSVC has no support of C11 atomics.
 #  include <atomic>
 #  define PONY_ATOMIC(T) std::atomic<T>
+#  define PONY_ATOMIC_RVALUE(T) std::atomic<T>
 #  ifdef PONY_WANT_ATOMIC_DEFS
 using std::memory_order_relaxed;
 using std::memory_order_consume;
@@ -41,14 +42,17 @@ using std::atomic_thread_fence;
 //     we only define the atomic types.
 #      include <atomic>
 #      define PONY_ATOMIC(T) std::atomic<T>
+#      define PONY_ATOMIC_RVALUE(T) std::atomic<T>
 #    else
 #      ifdef PONY_WANT_ATOMIC_DEFS
 #        include <stdatomic.h>
 #      endif
 #      define PONY_ATOMIC(T) T _Atomic
+#      define PONY_ATOMIC_RVALUE(T) T _Atomic
 #    endif
 #  elif __GNUC_PREREQ(4, 7)
 #    define PONY_ATOMIC(T) alignas(sizeof(T)) T
+#    define PONY_ATOMIC_RVALUE(T) T
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use GCC >= 4.7"
@@ -59,11 +63,13 @@ using std::atomic_thread_fence;
 #      include <stdatomic.h>
 #    endif
 #    define PONY_ATOMIC(T) T _Atomic
-#  elif __clang_major__ >= 3 && __clang_minor__ >= 3
+#    define PONY_ATOMIC_RVALUE(T) T _Atomic
+#  elif __clang_major__ >= 3 && __clang_minor__ >= 4
 #    define PONY_ATOMIC(T) alignas(sizeof(T)) T
+#    define PONY_ATOMIC_RVALUE(T) T
 #    define PONY_ATOMIC_BUILTINS
 #  else
-#    error "Please use Clang >= 3.3"
+#    error "Please use Clang >= 3.4"
 #  endif
 #else
 #  error "Unsupported compiler"

--- a/src/libponyrt/mem/pagemap.c
+++ b/src/libponyrt/mem/pagemap.c
@@ -75,7 +75,7 @@ void* ponyint_pagemap_get(const void* m)
       return NULL;
 
     uintptr_t ix = ((uintptr_t)m >> level[i].shift) & level[i].mask;
-    PONY_ATOMIC(void**)* av = (PONY_ATOMIC(void**)*)&(v[ix]);
+    PONY_ATOMIC(void**)* av = (PONY_ATOMIC_RVALUE(void**)*)&(v[ix]);
     v = atomic_load_explicit(av, memory_order_relaxed);
   }
 
@@ -113,7 +113,7 @@ void ponyint_pagemap_set(const void* m, void* v)
     }
 
     uintptr_t ix = ((uintptr_t)m >> level[i].shift) & level[i].mask;
-    pv = (PONY_ATOMIC(void**)*)&(pv_ld[ix]);
+    pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
   }
 
   atomic_store_explicit(pv, (void**)v, memory_order_relaxed);
@@ -157,7 +157,7 @@ void ponyint_pagemap_set_bulk(const void* m, void* v, size_t size)
       }
 
       ix = (m_ptr >> level[i].shift) & level[i].mask;
-      pv = (PONY_ATOMIC(void**)*)&(pv_ld[ix]);
+      pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
     }
 
     // store as many pagemap entries as would fit into this pagemap level segment
@@ -165,7 +165,7 @@ void ponyint_pagemap_set_bulk(const void* m, void* v, size_t size)
       atomic_store_explicit(pv, (void**)v, memory_order_relaxed);
       m_ptr += POOL_ALIGN;
       ix++;
-      pv = (PONY_ATOMIC(void**)*)&(pv_ld[ix]);
+      pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
       // if ix is greater than mask we need to move to the next pagement level segment
     } while((m_ptr < m_end) && (ix <= (uintptr_t)level[PAGEMAP_LEVELS-1].mask));
   }


### PR DESCRIPTION
Also deprecate support of Clang 3.3 since it doesn't support the `-mcx16` flag.

Manual changelog entry for Clang 3.3. No changelog entry for the build fix since the breakage is unreleased.