### PR TITLE
Fixed compiler segfault on empty triple quote comment.

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -524,8 +524,21 @@ static void normalise_string(lexer_t* lexer)
   if(memchr(lexer->buffer, '\n', lexer->buflen) == NULL)
     return;
 
-  // Calculate leading whitespace.
+  // Trim a leading newline if there is one.
   char* buf = lexer->buffer;
+
+  if((buf[0] == '\r') && (buf[1] == '\n'))
+  {
+    lexer->buflen -= 2;
+    memmove(&buf[0], &buf[2], lexer->buflen);
+  }
+  else if(buf[0] == '\n')
+  {
+    lexer->buflen--;
+    memmove(&buf[0], &buf[1], lexer->buflen);
+  }
+
+  // Calculate leading whitespace.
   size_t ws = lexer->buflen;
   size_t ws_this_line = 0;
   bool in_leading_ws = true;
@@ -540,7 +553,7 @@ static void normalise_string(lexer_t* lexer)
       {
         ws_this_line++;
       }
-      else if((c != '\r') && (c != '\n'))
+      else
       {
         if(ws_this_line < ws)
           ws = ws_this_line;
@@ -586,20 +599,6 @@ static void normalise_string(lexer_t* lexer)
     }
 
     lexer->buflen = compacted - lexer->buffer;
-  }
-
-  // Trim a leading newline if there is one.
-  buf = lexer->buffer;
-
-  if((buf[0] == '\r') && (buf[1] == '\n'))
-  {
-    lexer->buflen -= 2;
-    memmove(&buf[0], &buf[2], lexer->buflen);
-  }
-  else if(buf[0] == '\n')
-  {
-    lexer->buflen--;
-    memmove(&buf[0], &buf[1], lexer->buflen);
   }
 }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -766,3 +766,15 @@ TEST_F(BadPonyTest, MatchExhaustiveLastCaseUnionSubset)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(BadPonyTest, QuoteCommentsEmptyLine)
+{
+  // From issue #2027
+  const char* src =
+    "\"\"\"\n"
+    "\"\"\"\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Trim the leading NL first to simplify subsequent leading whitespace measurement.

Fixes: https://github.com/ponylang/ponyc/issues/2027

From "Low Hanging Fruit"
