### PR TITLE
Refactor pagemap

### DIFF
--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -420,7 +420,7 @@ static void acq_or_rel_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
 void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -441,7 +441,7 @@ void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -462,7 +462,7 @@ void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -483,7 +483,7 @@ void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -504,7 +504,7 @@ void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -600,7 +600,7 @@ void ponyint_gc_markimmutable(pony_ctx_t* ctx, gc_t* gc)
     {
       // Mark in our heap and recurse if it wasn't already marked.
       void* p = obj->address;
-      chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+      chunk_t* chunk = ponyint_pagemap_get(p);
       pony_type_t* type = *(pony_type_t**)p;
       mark_local_object(ctx, chunk, p, type, PONY_TRACE_IMMUTABLE);
     }

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -70,7 +70,7 @@ void ponyint_objectmap_sweep(objectmap_t* map)
 
     if(obj->rc > 0)
     {
-      chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+      chunk_t* chunk = ponyint_pagemap_get(p);
       ponyint_heap_mark_shallow(chunk, p);
     } else {
       ponyint_objectmap_clearindex(map, i);

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -459,7 +459,7 @@ void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
   if(p == NULL)
     return ponyint_heap_alloc(actor, heap, size);
 
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get(p);
 
   if(chunk == NULL)
   {

--- a/src/libponyrt/mem/pagemap.c
+++ b/src/libponyrt/mem/pagemap.c
@@ -39,8 +39,9 @@ typedef struct pagemap_level_t
   size_t size_index;
 } pagemap_level_t;
 
-/* Constructed for a 48 bit address space where we are interested in memory
- * with POOL_ALIGN_BITS granularity.
+/* The pagemap is a prefix tree that maps heap memory to its corresponding
+ * bookkeeping data structure. It is constructed for a 48 bit address space
+ * where we are interested in memory with POOL_ALIGN_BITS granularity.
  *
  * At the first level, we shift 35 and mask on the low 13 bits, giving us bits
  * 35-47. At the second level, we shift 23 and mask on the low 12 bits, giving
@@ -63,110 +64,113 @@ static const pagemap_level_t level[PAGEMAP_LEVELS] =
     POOL_INDEX((1 << L1_MASK) * sizeof(void*)) }
 };
 
-static PONY_ATOMIC(void**) root;
+static PONY_ATOMIC(void*) root;
 
-void* ponyint_pagemap_get(const void* m)
+chunk_t* ponyint_pagemap_get(const void* addr)
 {
-  void** v = atomic_load_explicit(&root, memory_order_relaxed);
+  PONY_ATOMIC(void*)* next_node = &root;
+  void* node = atomic_load_explicit(next_node, memory_order_relaxed);
 
-  for(int i = 0; i < PAGEMAP_LEVELS; i++)
+  for(size_t i = 0; i < PAGEMAP_LEVELS; i++)
   {
-    if(v == NULL)
+    if(node == NULL)
       return NULL;
 
-    uintptr_t ix = ((uintptr_t)m >> level[i].shift) & level[i].mask;
-    PONY_ATOMIC(void**)* av = (PONY_ATOMIC_RVALUE(void**)*)&(v[ix]);
-    v = atomic_load_explicit(av, memory_order_relaxed);
+    uintptr_t ix = ((uintptr_t)addr >> level[i].shift) & level[i].mask;
+    next_node = &(((PONY_ATOMIC_RVALUE(void*)*)node)[ix]);
+    node = atomic_load_explicit(next_node, memory_order_relaxed);
   }
 
-  return v;
+  return (chunk_t*)node;
 }
 
-void ponyint_pagemap_set(const void* m, void* v)
+void ponyint_pagemap_set(const void* addr, chunk_t* chunk)
 {
-  PONY_ATOMIC(void**)* pv = &root;
-  void* p;
+  PONY_ATOMIC(void*)* next_node = &root;
 
-  for(int i = 0; i < PAGEMAP_LEVELS; i++)
+  for(size_t i = 0; i < PAGEMAP_LEVELS; i++)
   {
-    void** pv_ld = atomic_load_explicit(pv, memory_order_acquire);
-    if(pv_ld == NULL)
+    void* node = atomic_load_explicit(next_node, memory_order_acquire);
+    if(node == NULL)
     {
-      p = ponyint_pool_alloc(level[i].size_index);
-      memset(p, 0, level[i].size);
-      void** prev = NULL;
+      void* new_node = ponyint_pool_alloc(level[i].size_index);
+      memset(new_node, 0, level[i].size);
+      void* prev = NULL;
 
 #ifdef USE_VALGRIND
-        ANNOTATE_HAPPENS_BEFORE(pv);
+      ANNOTATE_HAPPENS_BEFORE(next_node);
 #endif
-      if(!atomic_compare_exchange_strong_explicit(pv, &prev, (void**)p,
+      if(!atomic_compare_exchange_strong_explicit(next_node, &prev, new_node,
         memory_order_release, memory_order_acquire))
       {
 #ifdef USE_VALGRIND
-        ANNOTATE_HAPPENS_AFTER(pv);
+        ANNOTATE_HAPPENS_AFTER(next_node);
 #endif
-        ponyint_pool_free(level[i].size_index, p);
-        pv_ld = prev;
+        ponyint_pool_free(level[i].size_index, new_node);
+        node = prev;
       } else {
-        pv_ld = (void**)p;
+        node = new_node;
       }
     }
 
-    uintptr_t ix = ((uintptr_t)m >> level[i].shift) & level[i].mask;
-    pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
+    uintptr_t ix = ((uintptr_t)addr >> level[i].shift) & level[i].mask;
+    next_node = &(((PONY_ATOMIC_RVALUE(void*)*)node)[ix]);
   }
 
-  atomic_store_explicit(pv, (void**)v, memory_order_relaxed);
+  atomic_store_explicit(next_node, chunk, memory_order_relaxed);
 }
 
-void ponyint_pagemap_set_bulk(const void* m, void* v, size_t size)
+void ponyint_pagemap_set_bulk(const void* addr, chunk_t* chunk, size_t size)
 {
-  PONY_ATOMIC(void**)* pv = NULL;
-  void* p;
-  void** pv_ld = NULL;
+  PONY_ATOMIC(void*)* next_node = NULL;
+  void* node = NULL;
   uintptr_t ix = 0;
-  uintptr_t m_ptr = (uintptr_t)m;
-  uintptr_t m_end = (uintptr_t)m + size;
+  uintptr_t addr_ptr = (uintptr_t)addr;
+  uintptr_t addr_end = (uintptr_t)addr + size;
 
-  while(m_ptr < m_end)
+  while(addr_ptr < addr_end)
   {
-    pv = &root;
-    for(int i = 0; i < PAGEMAP_LEVELS; i++)
+    next_node = &root;
+    for(size_t i = 0; i < PAGEMAP_LEVELS; i++)
     {
-      pv_ld = atomic_load_explicit(pv, memory_order_acquire);
-      if(pv_ld == NULL)
+      node = atomic_load_explicit(next_node, memory_order_acquire);
+      if(node == NULL)
       {
-        p = ponyint_pool_alloc(level[i].size_index);
-        memset(p, 0, level[i].size);
-        void** prev = NULL;
+        void* new_node = ponyint_pool_alloc(level[i].size_index);
+        memset(new_node, 0, level[i].size);
+        void* prev = NULL;
 
 #ifdef USE_VALGRIND
         ANNOTATE_HAPPENS_BEFORE(pv);
 #endif
-        if(!atomic_compare_exchange_strong_explicit(pv, &prev, (void**)p,
+        if(!atomic_compare_exchange_strong_explicit(next_node, &prev, new_node,
           memory_order_release, memory_order_acquire))
         {
 #ifdef USE_VALGRIND
           ANNOTATE_HAPPENS_AFTER(pv);
 #endif
-          ponyint_pool_free(level[i].size_index, p);
-          pv_ld = prev;
+          ponyint_pool_free(level[i].size_index, new_node);
+          node = prev;
         } else {
-          pv_ld = (void**)p;
+          node = new_node;
         }
       }
 
-      ix = (m_ptr >> level[i].shift) & level[i].mask;
-      pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
+      ix = (addr_ptr >> level[i].shift) & level[i].mask;
+      next_node = &(((PONY_ATOMIC_RVALUE(void*)*)node)[ix]);
     }
 
-    // store as many pagemap entries as would fit into this pagemap level segment
-    do {
-      atomic_store_explicit(pv, (void**)v, memory_order_relaxed);
-      m_ptr += POOL_ALIGN;
+    // Store as many pagemap entries as would fit into this pagemap level
+    // segment.
+    do
+    {
+      atomic_store_explicit(next_node, chunk, memory_order_relaxed);
+      addr_ptr += POOL_ALIGN;
       ix++;
-      pv = (PONY_ATOMIC_RVALUE(void**)*)&(pv_ld[ix]);
-      // if ix is greater than mask we need to move to the next pagement level segment
-    } while((m_ptr < m_end) && (ix <= (uintptr_t)level[PAGEMAP_LEVELS-1].mask));
+      next_node = &(((PONY_ATOMIC_RVALUE(void*)*)node)[ix]);
+      // If ix is greater than mask we need to move to the next pagemap level
+      // segment.
+    } while((addr_ptr < addr_end) &&
+        (ix <= (uintptr_t)level[PAGEMAP_LEVELS-1].mask));
   }
 }

--- a/src/libponyrt/mem/pagemap.h
+++ b/src/libponyrt/mem/pagemap.h
@@ -5,11 +5,13 @@
 
 PONY_EXTERN_C_BEGIN
 
-void* ponyint_pagemap_get(const void* m);
+typedef struct chunk_t chunk_t;
 
-void ponyint_pagemap_set(const void* m, void* v);
+chunk_t* ponyint_pagemap_get(const void* addr);
 
-void ponyint_pagemap_set_bulk(const void* m, void* v, size_t size);
+void ponyint_pagemap_set(const void* addr, chunk_t* chunk);
+
+void ponyint_pagemap_set_bulk(const void* addr, chunk_t* chunk, size_t size);
 
 PONY_EXTERN_C_END
 

--- a/test/libponyrt/mem/pagemap.cc
+++ b/test/libponyrt/mem/pagemap.cc
@@ -13,10 +13,10 @@ TEST(Pagemap, UnmappedIsNull)
 
 TEST(Pagemap, SetAndUnset)
 {
-  void* m = (void*)(44 << 12);
+  char* m = (char*)(44 << 12);
 
-  ponyint_pagemap_set(m, m);
-  ASSERT_EQ(m, ponyint_pagemap_get(m));
+  ponyint_pagemap_set(m, (chunk_t*)m);
+  ASSERT_EQ(m, (char*)ponyint_pagemap_get(m));
 
   ponyint_pagemap_set(m, NULL);
   ASSERT_EQ(NULL, ponyint_pagemap_get(m));
@@ -25,16 +25,45 @@ TEST(Pagemap, SetAndUnset)
 TEST(Pagemap, SubAddressing)
 {
   char* m = (char*)(99 << 12);
-  ponyint_pagemap_set(m, m);
+  ponyint_pagemap_set(m, (chunk_t*)m);
 
   char* p = m;
   char* end = p + 1024;
 
   while(p < end)
   {
-    ASSERT_EQ(m, ponyint_pagemap_get(p));
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p));
     p += 64;
   }
 
-  ASSERT_EQ(NULL, ponyint_pagemap_get(end));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end));
+}
+
+TEST(Pagemap, SetAndUnsetBulk)
+{
+  char* m = (char*)(155 << 12);
+  size_t size = 65536;
+
+  ponyint_pagemap_set_bulk(m, (chunk_t*)m, size);
+
+  char* p = m;
+  char* end = p + size;
+
+  while(p < end)
+  {
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p));
+    p += 1024;
+  }
+
+  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end));
+
+  ponyint_pagemap_set_bulk(m, NULL, size);
+
+  p = m;
+
+  while(p < end)
+  {
+    ASSERT_EQ(NULL, (char*)ponyint_pagemap_get((chunk_t*)p));
+    p += 1024;
+  }
 }


### PR DESCRIPTION
This change renames many elements in pagemap.c to use more explicit names. In addition, the description of the pagemap has been extended to better explain how the data structure works.

This change also adds a test for `ponyint_pagemap_set_bulk`, as this function wasn't covered yet.