### PR TITLE
Add a compile-time check for the actor pad size

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -7,6 +7,7 @@
 #include "../gc/cycle.h"
 #include "../gc/trace.h"
 #include "ponyassert.h"
+#include <assert.h>
 #include <string.h>
 #include <stdio.h>
 #include <dtrace.h>
@@ -14,6 +15,10 @@
 #ifdef USE_VALGRIND
 #include <valgrind/helgrind.h>
 #endif
+
+// Ignore padding at the end of the type.
+static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
+  sizeof(pony_actor_pad_t), "Wrong actor pad size!");
 
 enum
 {

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -30,7 +30,7 @@ typedef struct pony_actor_t
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes
-  gc_t gc; // 44/80 bytes
+  gc_t gc; // 48/88 bytes
 } pony_actor_t;
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -137,12 +137,13 @@ typedef const struct _pony_type_t
  *
  * 56 bytes: initial header, not including the type descriptor
  * 52/104 bytes: heap
- * 44/80 bytes: gc
+ * 48/88 bytes: gc
+ * 28/0 bytes: padding to 64 bytes, ignored
  */
 #if INTPTR_MAX == INT64_MAX
-#  define PONY_ACTOR_PAD_SIZE 256
+#  define PONY_ACTOR_PAD_SIZE 248
 #elif INTPTR_MAX == INT32_MAX
-#  define PONY_ACTOR_PAD_SIZE 164
+#  define PONY_ACTOR_PAD_SIZE 160
 #endif
 
 typedef struct pony_actor_pad_t


### PR DESCRIPTION
The goal of this check is to avoid uncatched bugs in case the runtime layout of actors ever changes.

The size of the actor pad was reduced to an optimal size. This doesn't fix any correctness issue.