### PR TITLE
Make actor flag accesses atomic

### DIFF
--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -26,7 +26,7 @@ typedef struct pony_actor_t
   pony_type_t* type;
   messageq_t q;
   pony_msg_t* continuation;
-  uint8_t flags;
+  PONY_ATOMIC(uint8_t) flags;
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes


### PR DESCRIPTION
The flags can be accessed concurrently so they have to be atomic. Specifically, a given actor can change any of its GC-related flags while any other actor is sending it a message and reading its UNSCHEDULED flag.

Since there are no actual race conditions on flag accesses, all operations on flags are done with a relaxed memory ordering and no atomic RMW operations are introduced. For these reasons, there is no performance penalty on both x86 and ARM.