### PR TITLE
Update the Pony compiler to be able to use LLVM 4.0.0 (#1592).

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ branches:
 
 environment:
   matrix:
+  - llvm: 4.0.0
   - llvm: 3.9.1
   - llvm: 3.8.1
   - llvm: 3.7.1
@@ -37,7 +38,7 @@ skip_commits:
 
 clone_folder: C:\projects\ponyc
 
-install:
+build_script:
   - ps: |
       $package_commit = git rev-parse --short --verify "HEAD^{commit}"
       $package_version = (Get-Content "VERSION")
@@ -79,9 +80,6 @@ deploy:
         llvm: 3.9.1
         configuration: release
     publish: true
-
-build:
-  none
 
 test_script:
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,4 +83,4 @@ deploy:
 
 test_script:
   - cd C:\projects\ponyc
-  - python -x waf test --config $env:configuration --llvm $env:llvm
+  - python -x waf test --config %configuration% --llvm %llvm%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,6 +82,5 @@ deploy:
     publish: true
 
 test_script:
-  - ps: |
-      cd C:\projects\ponyc
-      python -x waf test --config $env:configuration --llvm $env:llvm
+  - cd C:\projects\ponyc
+  - python -x waf test --config $env:configuration --llvm $env:llvm

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ branches:
 
 environment:
   matrix:
-  - llvm: 4.0.0
+  - llvm: 4.0.1
   - llvm: 3.9.1
   - llvm: 3.8.1
   - llvm: 3.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ matrix:
           packages:
             - g++-6
       env:
-        - FAVORITE_CONFIG=yes
+        - FAVORITE_CONFIG=no
         - LLVM_VERSION="4.0.0"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=release
@@ -212,12 +212,12 @@ matrix:
     - os: osx
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="3.9.1"
+        - LLVM_VERSION="4.0.0"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=release
         - lto=no
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
+        - CC1=clang-4.0
+        - CXX1=clang++-4.0
 
 rvm:
   - 2.2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,36 @@ matrix:
         - ICC1=gcc-6
         - ICXX1=g++-6
 
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.0"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=debug
+        - CC1=gcc-6
+        - CXX1=g++-6
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=yes
+        - LLVM_VERSION="4.0.0"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=release
+        - CC1=gcc-6
+        - CXX1=g++-6
+
     - os: osx
       env:
         - FAVORITE_CONFIG=no
@@ -165,6 +195,25 @@ matrix:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
+        - config=release
+        - lto=no
+        - CC1=clang-3.9
+        - CXX1=clang++-3.9
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.0"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=debug
+        - CC1=clang-3.9
+        - CXX1=clang++-3.9
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="3.9.1"
+        - LLVM_CONFIG="llvm-config-4.0"
         - config=release
         - lto=no
         - CC1=clang-3.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,8 +206,8 @@ matrix:
         - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=debug
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
+        - CC1=clang-4.0
+        - CXX1=clang++-4.0
 
     - os: osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ matrix:
             - g++-6
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="4.0.0"
+        - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=debug
         - CC1=gcc-6
@@ -137,7 +137,7 @@ matrix:
             - g++-6
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="4.0.0"
+        - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=release
         - CC1=gcc-6
@@ -203,7 +203,7 @@ matrix:
     - os: osx
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="4.0.0"
+        - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=debug
         - CC1=clang-3.9
@@ -212,7 +212,7 @@ matrix:
     - os: osx
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="4.0.0"
+        - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
         - config=release
         - lto=no

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -56,6 +56,11 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     set_linux_compiler
   ;;
 
+  "linux:llvm-config-4.0")
+    download_llvm
+    download_pcre
+  ;;
+
   "osx:llvm-config-3.7")
     brew update
     brew install pcre2
@@ -85,6 +90,24 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     mkdir llvmsym
     ln -s "$(which llvm-config)" llvmsym/llvm-config-3.9
     ln -s "$(which clang++)" llvmsym/clang++-3.9
+
+    # do this elsewhere:
+    #export PATH=llvmsym/:$PATH
+  ;;
+
+  "osx:llvm-config-4.0")
+    brew update
+    brew install shellcheck
+    shellcheck ./.*.bash ./*.bash
+
+    brew install pcre2
+    brew install libressl
+
+    brew install llvm@4.0
+    brew link --overwrite --force llvm@4.0
+    mkdir llvmsym
+    ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
+    ln -s "$(which clang++)" llvmsym/clang++-4.0
 
     # do this elsewhere:
     #export PATH=llvmsym/:$PATH

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -104,13 +104,15 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     brew install libressl
 
     brew install llvm
-    # brew link --overwrite --force llvm@4.0
-    # mkdir llvmsym
-    # ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
-    # ln -s "$(which clang++)" llvmsym/clang++-4.0
+    brew link --overwrite --force llvm
+    mkdir llvmsym
+    ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
+    ln -s "$(which clang++)" llvmsym/clang++-4.0
+    #ln -s /usr/local/opt/llvm/bin/llvm-config llvmsym/llvm-config-4.0
+    #ln -s /usr/local/opt/llvm/bin/clang++ llvmsym/clang++-4.0
 
     # do this elsewhere:
-    #export PATH=llvmsym/:$PATH
+    export PATH=llvmsym/:$PATH
   ;;
 
   *)

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -103,11 +103,11 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     brew install pcre2
     brew install libressl
 
-    brew install llvm@4.0
-    brew link --overwrite --force llvm@4.0
-    mkdir llvmsym
-    ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
-    ln -s "$(which clang++)" llvmsym/clang++-4.0
+    brew install llvm
+    # brew link --overwrite --force llvm@4.0
+    # mkdir llvmsym
+    # ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
+    # ln -s "$(which clang++)" llvmsym/clang++-4.0
 
     # do this elsewhere:
     #export PATH=llvmsym/:$PATH

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -108,8 +108,6 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     mkdir llvmsym
     ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
     ln -s "$(which clang++)" llvmsym/clang++-4.0
-    #ln -s /usr/local/opt/llvm/bin/llvm-config llvmsym/llvm-config-4.0
-    #ln -s /usr/local/opt/llvm/bin/clang++ llvmsym/clang++-4.0
 
     # do this elsewhere:
     export PATH=llvmsym/:$PATH

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -83,6 +83,10 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     fi
   ;;
 
+  "linux:llvm-config-4.0")
+    ponyc-test
+  ;;  
+
   "osx:llvm-config-3.7")
     ponyc-test
   ;;
@@ -92,6 +96,11 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   ;;
 
   "osx:llvm-config-3.9")
+    export PATH=llvmsym/:$PATH
+    ponyc-test
+  ;;
+
+  "osx:llvm-config-4.0")
     export PATH=llvmsym/:$PATH
     ponyc-test
   ;;

--- a/Makefile
+++ b/Makefile
@@ -174,14 +174,18 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-	ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-    LLVM_LINK = /usr/local/opt/llvm/bin/llvm-link
-    LLVM_OPT = /usr/local/opt/llvm/bin/opt
-  else ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
+  ifneq ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-4.0
     LLVM_LINK = llvm-link-4.0
     LLVM_OPT = opt-4.0
+  else ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm@3.9/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm@3.9/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm@3.9/bin/opt
+  else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
+    LLVM_CONFIG = llvm-config-3.9
+    LLVM_LINK = llvm-link-3.9
+		LLVM_OPT = opt-3.9
   else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.9
     LLVM_LINK = llvm-link-3.9
@@ -233,7 +237,6 @@ llvm_version := $(shell $(LLVM_CONFIG) --version)
 
 ifeq ($(OSTYPE),osx)
 	llvm_bindir := $(shell $(LLVM_CONFIG) --bindir)
-
   ifneq (,$(shell which $(llvm_bindir)/llvm-ar 2> /dev/null))
     AR = $(llvm_bindir)/llvm-ar
     AR_FLAGS := rcs

--- a/Makefile
+++ b/Makefile
@@ -252,10 +252,10 @@ endif
 ifeq ($(llvm_version),3.7.1)
 else ifeq ($(llvm_version),3.8.1)
 else ifeq ($(llvm_version),3.9.1)
-else ifeq ($(llvm_version),4.0.0)
+else ifeq ($(llvm_version),4.0.1)
 else
   $(warning WARNING: Unsupported LLVM version: $(llvm_version))
-  $(warning Please use LLVM 3.7.1, 3.8.1, 3.9.1, or 4.0.0)
+  $(warning Please use LLVM 3.7.1, 3.8.1, 3.9.1, or 4.0.1)
 endif
 
 compiler_version := "$(shell $(CC) --version | sed -n 1p)"

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-  ifneq ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
+  ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-4.0
     LLVM_LINK = llvm-link-4.0
     LLVM_OPT = opt-4.0

--- a/Makefile
+++ b/Makefile
@@ -174,10 +174,10 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-	ifneq (,$(shell which /usr/local/opt/llvm@4.0/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm@4.0/bin/llvm-config
-    LLVM_LINK = /usr/local/opt/llvm@4.0/bin/llvm-link
-    LLVM_OPT = /usr/local/opt/llvm@4.0/bin/opt
+	ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm/bin/opt
   else ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-4.0
     LLVM_LINK = llvm-link-4.0

--- a/Makefile
+++ b/Makefile
@@ -174,10 +174,14 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-	ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm@3.9/bin/llvm-config
-    LLVM_LINK = /usr/local/opt/llvm@3.9/bin/llvm-link
-    LLVM_OPT = /usr/local/opt/llvm@3.9/bin/opt
+	ifneq (,$(shell which /usr/local/opt/llvm@4.0/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm@4.0/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm@4.0/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm@4.0/bin/opt
+  else ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-4.0
+    LLVM_LINK = llvm-link-4.0
+    LLVM_OPT = opt-4.0
   else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.9
     LLVM_LINK = llvm-link-3.9
@@ -248,9 +252,10 @@ endif
 ifeq ($(llvm_version),3.7.1)
 else ifeq ($(llvm_version),3.8.1)
 else ifeq ($(llvm_version),3.9.1)
+else ifeq ($(llvm_version),4.0.0)
 else
   $(warning WARNING: Unsupported LLVM version: $(llvm_version))
-  $(warning Please use LLVM 3.7.1, 3.8.1, or 3.9.1)
+  $(warning Please use LLVM 3.7.1, 3.8.1, 3.9.1, or 4.0.0)
 endif
 
 compiler_version := "$(shell $(CC) --version | sed -n 1p)"

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Pony requires one of the following versions of LLVM:
 - 3.7.1
 - 3.8.1
 - 3.9.1
+- 4.0.1
 
 Compiling Pony is only possible on x86 and ARM (either 32 or 64 bits).
 
@@ -392,7 +393,7 @@ Build ponyc, compile and run helloworld:
 
 ```bash
 cd ~/ponyc/
-make 
+make
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```
@@ -493,7 +494,7 @@ make default_pic=true
 
 You need to have the development versions of the following installed:
 
-* LLVM 3.7.1, 3.8.1, or 3.9.1
+* LLVM 3.7.1, 3.8.1, 3.9.1, 4.0.1
 * zlib
 * ncurses
 * pcre2
@@ -561,7 +562,7 @@ Please note that on 32-bit X86, using LLVM 3.7.1 or 3.8.1 on FreeBSD currently p
 ## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-You'll need llvm 3.7.1, 3.8.1 or 3.9.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install your dependencies. Please note that llvm 3.9.1 is not available via homebrew. As such, the instructions below install 3.8.1
+You'll need llvm 3.7.1, 3.8.1, 3.9.1, or 4.0.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install your dependencies. Please note that llvm 3.9.1 is not available via homebrew. As such, the instructions below install 3.8.1
 
 Installation via [homebrew](http://brew.sh):
 ```
@@ -617,8 +618,8 @@ This will automatically perform the following steps:
 
 You can provide the following options to `make.bat` when running the `build` or `test` commands:
 
-- `--config debug|release`: whether or not to build a debug or release build (debug is the default).
-- `--llvm <version>`: the LLVM version to build against (3.9.1 is the default).
+- `--config debug|release`: whether or not to build a debug or release build (`release` is the default).
+- `--llvm <version>`: the LLVM version to build against (`4.0.1` is the default).
 
 Note that you need to provide these options each time you run make.bat; the system will not remember your last choice.
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -181,10 +181,8 @@ typedef struct compile_t
   LLVMDIBuilderRef di;
   LLVMMetadataRef di_unit;
   LLVMValueRef tbaa_root;
-#if LLVM_PONY < 400
   LLVMValueRef tbaa_descriptor;
   LLVMValueRef tbaa_descptr;
-#endif  
   LLVMValueRef none_instance;
   LLVMValueRef primitives_init;
   LLVMValueRef primitives_final;

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -40,6 +40,8 @@ LLVMValueRef LLVMConstNaN(LLVMTypeRef type);
 LLVMValueRef LLVMConstInf(LLVMTypeRef type, bool negative);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
 void LLVMSetMetadataStr(LLVMValueRef val, const char* str, LLVMValueRef node);
+void LLVMMDNodeReplaceOperand(LLVMValueRef parent, unsigned i,
+  LLVMValueRef node);
 
 // Intrinsics.
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);
@@ -179,8 +181,10 @@ typedef struct compile_t
   LLVMDIBuilderRef di;
   LLVMMetadataRef di_unit;
   LLVMValueRef tbaa_root;
+#if LLVM_PONY < 400
   LLVMValueRef tbaa_descriptor;
   LLVMValueRef tbaa_descptr;
+#endif  
   LLVMValueRef none_instance;
   LLVMValueRef primitives_init;
   LLVMValueRef primitives_final;

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -31,8 +31,12 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
 
   const char* box_name = genname_box(t->name);
   LLVMValueRef metadata = tbaa_metadata_for_box_type(c, box_name);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, store);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return this_ptr;
 }
@@ -60,8 +64,12 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
 
   const char* box_name = genname_box(t->name);
   LLVMValueRef metadata = tbaa_metadata_for_box_type(c, box_name);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, value);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(value, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return gen_assign_cast(c, c_t->use_type, value, t->ast_cap);
 }

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -312,8 +312,12 @@ static void set_descriptor(compile_t* c, reach_type_t* t, LLVMValueRef value)
   LLVMValueRef desc_ptr = LLVMBuildStructGEP(c->builder, value, 0, "");
   LLVMValueRef store = LLVMBuildStore(c->builder,
     ((compile_type_t*)t->c_type)->desc, desc_ptr);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descptr, store);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), c->tbaa_descptr);
+#endif
 }
 
 // This function builds a stack of indices such that for an AST nested in an

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -69,16 +69,20 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef d,
   unsigned lang, const char* file, const char* dir, const char* producer,
   int optimized)
 {
-#if PONY_LLVM >= 309
   DIBuilder* pd = unwrap(d);
+  const StringRef flags = "";
+  const unsigned runtimever = 0;
 
+#if PONY_LLVM >= 400
+  DIFile* difile = pd->createFile(file, dir);
+  return wrap(pd->createCompileUnit(lang, difile, producer, 
+    optimized ? true : false, flags, runtimever));
+#elif PONY_LLVM >= 309
   return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized,
-    StringRef(), 0, StringRef())); // use the defaults
+    flags, runtimever, StringRef())); // use the defaults
 #else
-  DIBuilder* pd = unwrap(d);
-
   return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized,
-    StringRef(), 0, StringRef(), DIBuilder::FullDebug, 0, true));
+    flags, runtimever, StringRef(), DIBuilder::FullDebug, 0, true));
 #endif
 }
 
@@ -106,26 +110,31 @@ LLVMMetadataRef LLVMDIBuilderCreateMethod(LLVMDIBuilderRef d,
   LLVMMetadataRef file, unsigned line, LLVMMetadataRef type, LLVMValueRef func,
   int optimized)
 {
-#if PONY_LLVM >= 308
   DIBuilder* pd = unwrap(d);
   Function* f = unwrap<Function>(func);
 
+#if PONY_LLVM >= 400
   DISubprogram* di_method = pd->createMethod(unwrap<DIScope>(scope),
     name, linkage, unwrap<DIFile>(file), line, unwrap<DISubroutineType>(type),
-    false, true, 0, 0,
-#  if PONY_LLVM >= 309
-    0,
-#  else
-    nullptr,
-#  endif
-    0, optimized);
+    false, true, 0, 0, 0, nullptr, DINode::FlagZero, optimized ? true : false);
+
+  f->setSubprogram(di_method);
+  return wrap(di_method);
+#elif PONY_LLVM >= 309
+  DISubprogram* di_method = pd->createMethod(unwrap<DIScope>(scope),
+    name, linkage, unwrap<DIFile>(file), line, unwrap<DISubroutineType>(type),
+    false, true, 0, 0, 0, 0, optimized);
+
+  f->setSubprogram(di_method);
+  return wrap(di_method);
+#elif PONY_LLVM >= 308
+  DISubprogram* di_method = pd->createMethod(unwrap<DIScope>(scope),
+    name, linkage, unwrap<DIFile>(file), line, unwrap<DISubroutineType>(type),
+    false, true, 0, 0, nullptr, 0, optimized);
 
   f->setSubprogram(di_method);
   return wrap(di_method);
 #else
-  DIBuilder* pd = unwrap(d);
-  Function* f = unwrap<Function>(func);
-
   return wrap(pd->createMethod(unwrap<DIScope>(scope), name, linkage,
     unwrap<DIFile>(file), line, unwrap<DISubroutineType>(type),
     false, true, 0, 0, nullptr, 0, optimized, f));
@@ -136,14 +145,15 @@ LLVMMetadataRef LLVMDIBuilderCreateAutoVariable(LLVMDIBuilderRef d,
   LLVMMetadataRef scope, const char* name, LLVMMetadataRef file,
   unsigned line, LLVMMetadataRef type)
 {
-#if PONY_LLVM >= 308
   DIBuilder* pd = unwrap(d);
 
+#if PONY_LLVM >= 400
+  return wrap(pd->createAutoVariable(unwrap<DIScope>(scope), name,
+    unwrap<DIFile>(file), line, unwrap<DIType>(type), true, DINode::FlagZero));
+#elif PONY_LLVM >= 308
   return wrap(pd->createAutoVariable(unwrap<DIScope>(scope), name,
     unwrap<DIFile>(file), line, unwrap<DIType>(type), true, 0));
 #else
-  DIBuilder* pd = unwrap(d);
-
   return wrap(pd->createLocalVariable(DW_TAG_auto_variable,
     unwrap<DIScope>(scope), name, unwrap<DIFile>(file), line,
     unwrap<DIType>(type), true, 0));
@@ -154,15 +164,17 @@ LLVMMetadataRef LLVMDIBuilderCreateParameterVariable(LLVMDIBuilderRef d,
   LLVMMetadataRef scope, const char* name, unsigned arg,
   LLVMMetadataRef file, unsigned line, LLVMMetadataRef type)
 {
-#if PONY_LLVM >= 308
   DIBuilder* pd = unwrap(d);
 
+#if PONY_LLVM >= 400
+  return wrap(pd->createParameterVariable(
+    unwrap<DIScope>(scope), name, arg, unwrap<DIFile>(file), line,
+    unwrap<DIType>(type), true, DINode::FlagZero));
+#elif PONY_LLVM >= 308
   return wrap(pd->createParameterVariable(
     unwrap<DIScope>(scope), name, arg, unwrap<DIFile>(file), line,
     unwrap<DIType>(type), true, 0));
 #else
-  DIBuilder* pd = unwrap(d);
-
   return wrap(pd->createLocalVariable(DW_TAG_arg_variable,
     unwrap<DIScope>(scope), name, unwrap<DIFile>(file), line,
     unwrap<DIType>(type), true, 0, arg));
@@ -195,7 +207,13 @@ LLVMMetadataRef LLVMDIBuilderCreateBasicType(LLVMDIBuilderRef d,
   unsigned encoding)
 {
   DIBuilder* pd = unwrap(d);
+
+#if PONY_LLVM >= 400
+  (void)(align_bits);
+  return wrap(pd->createBasicType(name, size_bits, encoding));
+#else
   return wrap(pd->createBasicType(name, size_bits, align_bits, encoding));
+#endif
 }
 
 LLVMMetadataRef LLVMDIBuilderCreatePointerType(LLVMDIBuilderRef d,
@@ -204,7 +222,7 @@ LLVMMetadataRef LLVMDIBuilderCreatePointerType(LLVMDIBuilderRef d,
   DIBuilder* pd = unwrap(d);
 
   return wrap(pd->createPointerType(unwrap<DIType>(elem_type), size_bits,
-    align_bits));
+    static_cast<uint32_t>(align_bits)));
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateSubroutineType(LLVMDIBuilderRef d,
@@ -231,9 +249,16 @@ LLVMMetadataRef LLVMDIBuilderCreateStructType(LLVMDIBuilderRef d,
 {
   DIBuilder* pd = unwrap(d);
 
+#if PONY_LLVM >= 400
+  return wrap(pd->createStructType(unwrap<DIScope>(scope), name,
+    unwrap<DIFile>(file), line, size_bits, 
+    static_cast<uint32_t>(align_bits), DINode::FlagZero, nullptr,
+    elem_types ? DINodeArray(unwrap<MDTuple>(elem_types)) : nullptr));
+#else
   return wrap(pd->createStructType(unwrap<DIScope>(scope), name,
     unwrap<DIFile>(file), line, size_bits, align_bits, 0, nullptr,
     elem_types ? DINodeArray(unwrap<MDTuple>(elem_types)) : nullptr));
+#endif
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateReplaceableStruct(LLVMDIBuilderRef d,
@@ -252,9 +277,16 @@ LLVMMetadataRef LLVMDIBuilderCreateMemberType(LLVMDIBuilderRef d,
 {
   DIBuilder* pd = unwrap(d);
 
+#if PONY_LLVM >= 400
+  return wrap(pd->createMemberType(unwrap<DIScope>(scope), name,
+    unwrap<DIFile>(file), line, size_bits, static_cast<uint32_t>(align_bits),
+    offset_bits, flags ? DINode::FlagPrivate : DINode::FlagZero, 
+    unwrap<DIType>(type)));
+#else
   return wrap(pd->createMemberType(unwrap<DIScope>(scope), name,
     unwrap<DIFile>(file), line, size_bits, align_bits,
     offset_bits, flags, unwrap<DIType>(type)));
+#endif
 }
 
 LLVMMetadataRef LLVMDIBuilderCreateArrayType(LLVMDIBuilderRef d,
@@ -263,7 +295,7 @@ LLVMMetadataRef LLVMDIBuilderCreateArrayType(LLVMDIBuilderRef d,
 {
   DIBuilder* pd = unwrap(d);
 
-  return wrap(pd->createArrayType(size_bits, align_bits,
+  return wrap(pd->createArrayType(size_bits, static_cast<uint32_t>(align_bits),
     unwrap<DIType>(elem_type), DINodeArray(unwrap<MDTuple>(subscripts))));
 }
 

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -509,9 +509,13 @@ static LLVMValueRef desc_field(compile_t* c, LLVMValueRef desc, int index)
 {
   LLVMValueRef ptr = LLVMBuildStructGEP(c->builder, desc, index, "");
   LLVMValueRef field = LLVMBuildLoad(c->builder, ptr, "");
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descriptor, field);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1),
     c->tbaa_descriptor);
+#endif
   return field;
 }
 
@@ -519,8 +523,12 @@ LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object)
 {
   LLVMValueRef ptr = LLVMBuildStructGEP(c->builder, object, 0, "");
   LLVMValueRef desc = LLVMBuildLoad(c->builder, ptr, "");
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descptr, desc);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(desc, LLVMGetMDKindID(id, sizeof(id) - 1), c->tbaa_descptr);
+#endif
   return desc;
 }
 
@@ -554,8 +562,12 @@ LLVMValueRef gendesc_vtable(compile_t* c, LLVMValueRef desc, size_t colour)
 
   LLVMValueRef func_ptr = LLVMBuildInBoundsGEP(c->builder, vtable, gep, 2, "");
   LLVMValueRef fun = LLVMBuildLoad(c->builder, func_ptr, "");
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descriptor, fun);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(fun, LLVMGetMDKindID(id, sizeof(id) - 1), c->tbaa_descriptor);
+#endif
   return fun;
 }
 
@@ -586,9 +598,13 @@ LLVMValueRef gendesc_fieldinfo(compile_t* c, LLVMValueRef desc, size_t index)
   LLVMValueRef field_desc = LLVMBuildInBoundsGEP(c->builder, fields, gep, 2,
     "");
   LLVMValueRef field_info = LLVMBuildLoad(c->builder, field_desc, "");
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descriptor, field_info);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(field_info, LLVMGetMDKindID(id, sizeof(id) - 1),
     c->tbaa_descriptor);
+#endif
   return field_info;
 }
 
@@ -673,9 +689,13 @@ LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
   LLVMValueRef index = LLVMBuildInBoundsGEP(c->builder, bitmap, args, 2, "");
   index = LLVMBuildLoad(c->builder, index, "");
 
+#if PONY_LLVM >= 400
+  tbaa_tag(c, c->tbaa_descriptor, index);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(index, LLVMGetMDKindID(id, sizeof(id) - 1),
     c->tbaa_descriptor);
+#endif
 
   LLVMValueRef has_trait = LLVMBuildAnd(c->builder, index, mask, "");
   has_trait = LLVMBuildICmp(c->builder, LLVMIntNE, has_trait,

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -33,12 +33,10 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
 
     case TK_TUPLEELEMREF:
     {
-      ast_t* s_type;
-      uint32_t index;
-      ret = gen_tupleelemptr(c, ast, &s_type, &index);
+      ret = gen_tupleelemptr(c, ast);
       break;
     }
-    
+
     case TK_EMBEDREF:
       ret = gen_fieldembed(c, ast);
       break;

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -32,9 +32,13 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_TUPLEELEMREF:
-      ret = gen_tupleelemptr(c, ast);
+    {
+      ast_t* s_type;
+      uint32_t index;
+      ret = gen_tupleelemptr(c, ast, &s_type, &index);
       break;
-
+    }
+    
     case TK_EMBEDREF:
       ret = gen_fieldembed(c, ast);
       break;

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -345,9 +345,6 @@ static LLVMValueRef assign_local(compile_t* c, LLVMValueRef l_value,
 static LLVMValueRef assign_field(compile_t* c, LLVMValueRef l_value,
   LLVMValueRef r_value, ast_t* p_type, ast_t* l_type, ast_t* r_type)
 {
-  (void)(s_type); // these are for unfinished TBAA work
-  (void)(index);
-
   reach_type_t* t = reach_type(c->reach, l_type);
   pony_assert(t != NULL);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
@@ -471,9 +468,7 @@ static LLVMValueRef assign_rvalue(compile_t* c, ast_t* left, ast_t* r_type,
     case TK_TUPLEELEMREF:
     {
       // The result is the previous value of the tuple element.
-      ast_t* s_type;
-      uint32_t index;
-      LLVMValueRef l_value = gen_tupleelemptr(c, left, &s_type, &index);
+      LLVMValueRef l_value = gen_tupleelemptr(c, left);
       ast_t* p_type = ast_type(ast_child(left));
       ast_t* l_type = ast_type(left);
       return assign_field(c, l_value, r_value, p_type, l_type, r_type);

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1441,7 +1441,11 @@ bool target_is_x86(char* t)
 {
   Triple triple = Triple(t);
 
+#if PONY_LLVM >= 400
+  const char* arch = Triple::getArchTypePrefix(triple.getArch()).data();
+#else
   const char* arch = Triple::getArchTypePrefix(triple.getArch());
+#endif
 
   return !strcmp("x86", arch);
 }
@@ -1450,7 +1454,11 @@ bool target_is_arm(char* t)
 {
   Triple triple = Triple(t);
 
+#if PONY_LLVM >= 400
+  const char* arch = Triple::getArchTypePrefix(triple.getArch()).data();
+#else
   const char* arch = Triple::getArchTypePrefix(triple.getArch());
+#endif
 
   return !strcmp("arm", arch);
 }

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -216,8 +216,12 @@ static void pointer_apply(compile_t* c, void* data, token_id cap)
   ast_setid(tcap, cap);
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   ast_setid(tcap, tmp_cap);
 
@@ -252,9 +256,14 @@ static void pointer_update(compile_t* c, reach_type_t* t,
   LLVMValueRef store = LLVMBuildStore(c->builder, value, loc);
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+  tbaa_tag(c, metadata, store);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
   LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   result = gen_assign_cast(c, c_t_elem->use_type, result, t_elem->ast_cap);
   LLVMBuildRet(c->builder, result);
@@ -358,8 +367,12 @@ static void pointer_delete(compile_t* c, reach_type_t* t,
   LLVMValueRef result = LLVMBuildLoad(c->builder, elem_ptr, "");
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   LLVMValueRef src = LLVMBuildInBoundsGEP(c->builder, elem_ptr, &n, 1, "");
   src = LLVMBuildBitCast(c->builder, src, c_t->use_type, "");

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -129,16 +129,15 @@ LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast)
 }
 
 static LLVMValueRef make_tupleelemptr(compile_t* c, LLVMValueRef l_value,
-  ast_t* l_type, ast_t* right, uint32_t* index)
+  ast_t* l_type, ast_t* right)
 {
   pony_assert(ast_id(l_type) == TK_TUPLETYPE);
-  *index = (int)ast_int(right)->low;
+  int index = (int)ast_int(right)->low;
 
-  return LLVMBuildExtractValue(c->builder, l_value, *index, "");
+  return LLVMBuildExtractValue(c->builder, l_value, index, "");
 }
 
-LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast, ast_t** l_type,
-  uint32_t* index)
+LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast)
 {
   AST_GET_CHILDREN(ast, left, right);
 

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -63,9 +63,10 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
   pony_assert(ast_id(l_type) == TK_NOMINAL);
   pony_assert(ast_id(right) == TK_ID);
 
-  ast_t* def = (ast_t*)ast_data(l_type);
-  ast_t* field = ast_get(def, ast_name(right), NULL);
-  int index = (int)ast_index(field);
+  ast_t* def;
+  ast_t* field;
+  uint32_t index;
+  get_fieldinfo(l_type, right, &def, &field, &index);
 
   if(ast_id(def) != TK_STRUCT)
     index++;
@@ -104,9 +105,14 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   field = LLVMBuildLoad(c->builder, field, "");
+
   LLVMValueRef metadata = tbaa_metadata_for_type(c, ast_type(left));
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, field);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return gen_assign_cast(c, c_t->use_type, field, type);
 }
@@ -123,15 +129,16 @@ LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast)
 }
 
 static LLVMValueRef make_tupleelemptr(compile_t* c, LLVMValueRef l_value,
-  ast_t* l_type, ast_t* right)
+  ast_t* l_type, ast_t* right, uint32_t* index)
 {
   pony_assert(ast_id(l_type) == TK_TUPLETYPE);
-  int index = (int)ast_int(right)->low;
+  *index = (int)ast_int(right)->low;
 
-  return LLVMBuildExtractValue(c->builder, l_value, index, "");
+  return LLVMBuildExtractValue(c->builder, l_value, *index, "");
 }
 
-LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast)
+LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast, ast_t** l_type,
+  uint32_t* index)
 {
   AST_GET_CHILDREN(ast, left, right);
 

--- a/src/libponyc/codegen/genreference.h
+++ b/src/libponyc/codegen/genreference.h
@@ -16,7 +16,8 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast);
 
-LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast);
+LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast, ast_t** l_type, 
+  uint32_t* index);
 
 LLVMValueRef gen_tuple(compile_t* c, ast_t* ast);
 

--- a/src/libponyc/codegen/genreference.h
+++ b/src/libponyc/codegen/genreference.h
@@ -16,8 +16,7 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_fieldembed(compile_t* c, ast_t* ast);
 
-LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast, ast_t** l_type, 
-  uint32_t* index);
+LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_tuple(compile_t* c, ast_t* ast);
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -144,30 +144,6 @@ static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
   return LLVMMDNodeInContext(ctx, &mdstr, 1);
 }
 
-#if PONY_LLVM < 400
-
-static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, 
-  LLVMValueRef root)
-{
-  const char str[] = "Type descriptor";
-  LLVMValueRef params[3];
-  params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
-  params[1] = root;
-  params[2] = LLVMConstInt(LLVMInt64TypeInContext(ctx), 1, false);
-  return LLVMMDNodeInContext(ctx, params, 3);
-}
-
-static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
-{
-  const char str[] = "Descriptor pointer";
-  LLVMValueRef params[2];
-  params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
-  params[1] = root;
-  return LLVMMDNodeInContext(ctx, params, 2);
-}
-
-#endif
-
 static void compile_type_free(void* p)
 {
   POOL_FREE(compile_type_t, p);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -144,6 +144,25 @@ static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
   return LLVMMDNodeInContext(ctx, &mdstr, 1);
 }
 
+static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, LLVMValueRef root)
+{
+  const char str[] = "Type descriptor";
+  LLVMValueRef params[3];
+  params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
+  params[1] = root;
+  params[2] = LLVMConstInt(LLVMInt64TypeInContext(ctx), 1, false);
+  return LLVMMDNodeInContext(ctx, params, 3);
+}
+
+static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
+{
+  const char str[] = "Descriptor pointer";
+  LLVMValueRef params[2];
+  params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
+  params[1] = root;
+  return LLVMMDNodeInContext(ctx, params, 2);
+}
+
 static void compile_type_free(void* p)
 {
   POOL_FREE(compile_type_t, p);
@@ -814,7 +833,8 @@ bool gentypes(compile_t* c)
     c->trait_bitmap_size = ((c->reach->trait_type_count + 63) & ~63) >> 6;
 
   c->tbaa_root = make_tbaa_root(c->context);
-
+  c->tbaa_descriptor = make_tbaa_descriptor(c->context, c->tbaa_root);
+  c->tbaa_descptr = make_tbaa_descptr(c->context, c->tbaa_root);
 
   allocate_compile_types(c);
   genprim_builtins(c);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -19,11 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void compile_type_free(void* p)
-{
-  POOL_FREE(compile_type_t, p);
-}
-
 static size_t tbaa_metadata_hash(tbaa_metadata_t* a)
 {
   return ponyint_hash_ptr(a->name);
@@ -116,6 +111,32 @@ LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name)
   return md->metadata;
 }
 
+void tbaa_tag(compile_t* c, LLVMValueRef metadata, LLVMValueRef instr)
+{
+  const char id[] = "tbaa";
+  unsigned md_kind = LLVMGetMDKindID(id, sizeof(id) - 1);
+
+  LLVMValueRef params[3];
+  params[0] = metadata;
+  params[1] = metadata;
+  params[2] = LLVMConstInt(c->i32, 0, false);
+
+  LLVMValueRef tag = LLVMMDNodeInContext(c->context, params, 3);
+  LLVMSetMetadata(instr, md_kind, tag);
+}
+
+void get_fieldinfo(ast_t* l_type, ast_t* right, ast_t** l_def,
+  ast_t** field, uint32_t* index)
+{
+  ast_t* d = (ast_t*)ast_data(l_type);
+  ast_t* f = ast_get(d, ast_name(right), NULL);
+  uint32_t i = (uint32_t)ast_index(f);
+
+  *l_def = d;
+  *field = f;
+  *index = i;
+}
+
 static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
 {
   const char str[] = "Pony TBAA";
@@ -123,7 +144,10 @@ static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
   return LLVMMDNodeInContext(ctx, &mdstr, 1);
 }
 
-static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, LLVMValueRef root)
+#if PONY_LLVM < 400
+
+static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, 
+  LLVMValueRef root)
 {
   const char str[] = "Type descriptor";
   LLVMValueRef params[3];
@@ -140,6 +164,13 @@ static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
   params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
   params[1] = root;
   return LLVMMDNodeInContext(ctx, params, 2);
+}
+
+#endif
+
+static void compile_type_free(void* p)
+{
+  POOL_FREE(compile_type_t, p);
 }
 
 static void allocate_compile_types(compile_t* c)
@@ -807,8 +838,7 @@ bool gentypes(compile_t* c)
     c->trait_bitmap_size = ((c->reach->trait_type_count + 63) & ~63) >> 6;
 
   c->tbaa_root = make_tbaa_root(c->context);
-  c->tbaa_descriptor = make_tbaa_descriptor(c->context, c->tbaa_root);
-  c->tbaa_descptr = make_tbaa_descptr(c->context, c->tbaa_root);
+
 
   allocate_compile_types(c);
   genprim_builtins(c);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -144,6 +144,8 @@ static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
   return LLVMMDNodeInContext(ctx, &mdstr, 1);
 }
 
+#if PONY_LLVM < 400
+
 static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, LLVMValueRef root)
 {
   const char str[] = "Type descriptor";
@@ -162,6 +164,8 @@ static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
   params[1] = root;
   return LLVMMDNodeInContext(ctx, params, 2);
 }
+
+#endif
 
 static void compile_type_free(void* p)
 {
@@ -833,8 +837,14 @@ bool gentypes(compile_t* c)
     c->trait_bitmap_size = ((c->reach->trait_type_count + 63) & ~63) >> 6;
 
   c->tbaa_root = make_tbaa_root(c->context);
+
+#if PONY_LLVM >= 400
+  c->tbaa_descriptor = NULL;
+  c->tbaa_descptr = NULL;
+#else
   c->tbaa_descriptor = make_tbaa_descriptor(c->context, c->tbaa_root);
   c->tbaa_descptr = make_tbaa_descptr(c->context, c->tbaa_root);
+#endif
 
   allocate_compile_types(c);
   genprim_builtins(c);

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -6,6 +6,27 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct tbaa_metadata_t
+{
+  const char* name;
+  LLVMValueRef metadata;
+} tbaa_metadata_t;
+
+DECLARE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t);
+
+tbaa_metadatas_t* tbaa_metadatas_new();
+
+void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
+
+LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
+
+LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name);
+
+void tbaa_tag(compile_t* c, LLVMValueRef metadata, LLVMValueRef instr);
+
+void get_fieldinfo(ast_t* l_type, ast_t* right, ast_t** l_def,
+  ast_t** field, uint32_t* index);
+
 typedef struct compile_type_t
 {
   compile_opaque_free_fn free_fn;
@@ -36,22 +57,6 @@ typedef struct compile_type_t
   LLVMMetadataRef di_type;
   LLVMMetadataRef di_type_embed;
 } compile_type_t;
-
-typedef struct tbaa_metadata_t
-{
-  const char* name;
-  LLVMValueRef metadata;
-} tbaa_metadata_t;
-
-DECLARE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t);
-
-tbaa_metadatas_t* tbaa_metadatas_new();
-
-void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
-
-LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
-
-LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name);
 
 bool gentypes(compile_t* c);
 

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -206,6 +206,18 @@ void LLVMSetMetadataStr(LLVMValueRef inst, const char* str, LLVMValueRef node)
   unwrap<Instruction>(inst)->setMetadata(str, n);
 }
 
+void LLVMMDNodeReplaceOperand(LLVMValueRef parent, unsigned i, 
+  LLVMValueRef node)
+{
+  pony_assert(parent != NULL);
+  pony_assert(node != NULL);
+  pony_assert((int)i >= 0);
+
+  MDNode *pn = extractMDNode(unwrap<MetadataAsValue>(parent));
+  MDNode *cn = extractMDNode(unwrap<MetadataAsValue>(node));
+  pn->replaceOperandWith(i, cn);
+}
+
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32)
 {
   Module* m = unwrap(module);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -211,7 +211,6 @@ void LLVMMDNodeReplaceOperand(LLVMValueRef parent, unsigned i,
 {
   pony_assert(parent != NULL);
   pony_assert(node != NULL);
-  pony_assert((int)i >= 0);
 
   MDNode *pn = extractMDNode(unwrap<MetadataAsValue>(parent));
   MDNode *cn = extractMDNode(unwrap<MetadataAsValue>(node));

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -224,7 +224,11 @@ static bool find_kernel32(vcvars_t* vcvars, errors_t* errors)
 
   vcvars->ucrt[0] = '\0';
   strcpy(vcvars->default_libs,
-    "kernel32.lib msvcrt.lib Ws2_32.lib advapi32.lib vcruntime.lib "
+    "kernel32.lib "
+#if !defined(DEBUG)
+    "msvcrt.lib "
+#endif
+    "Ws2_32.lib advapi32.lib vcruntime.lib "
     "legacy_stdio_definitions.lib dbghelp.lib");
 
   strcpy(vcvars->kernel32, sdk.path);

--- a/wscript
+++ b/wscript
@@ -228,6 +228,7 @@ def build(ctx):
                 import shutil
                 if (ctx.options.config == 'debug'):
                     shutil.copy(os.path.join(pcre2Dir, 'pcre2-8d.lib'), buildDir)
+                    shutil.copy(os.path.join(pcre2Dir, 'pcre2-8d.lib'), os.path.join(buildDir, 'pcre2-8.lib'))
                 else:
                     shutil.copy(os.path.join(pcre2Dir, 'pcre2-8.lib'), buildDir)
                 shutil.copy(os.path.join(libresslDir, 'lib', 'crypto.lib'), buildDir)

--- a/wscript
+++ b/wscript
@@ -42,13 +42,13 @@ MSVC_VERSIONS = [ '15', '14' ]
 
 # keep these in sync with the list in .appveyor.yml
 LLVM_VERSIONS = [
-    '4.0.0',
+    '4.0.1',
     '3.9.1',
     '3.8.1',
     '3.7.1'
 ]
 
-WINDOWS_LIBS_TAG = "v1.4.0"
+WINDOWS_LIBS_TAG = "v1.4.1"
 LIBRESSL_VERSION = "2.5.0"
 PCRE2_VERSION = "10.21"
 


### PR DESCRIPTION
This change includes the following:

- Compiler code updates for changes to the LLVM 4.0.0 API.
- Updates to Type-Based Alias Analysis metadata format for LLVM 4.0.0.
- Builds in Release mode on Windows to conform to the Unix makefile.
- Some efficiency tweaks for the Windows build.