### PR TITLE
Fix invalid IR generation in the MergeTrace pass

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -933,7 +933,8 @@ public:
           while(iter != first.done)
           {
             auto& inst = *(iter++);
-            inst.moveBefore(&(*next.trace));
+            if(inst.getOpcode() == Instruction::Call)
+              inst.moveBefore(&(*next.trace));
           }
 
           iter++;
@@ -947,7 +948,8 @@ public:
           while(iter != first_send_post)
           {
             auto& inst = *(iter++);
-            inst.moveBefore(&(*next_done_post));
+            if(inst.getOpcode() == Instruction::Call)
+              inst.moveBefore(&(*next_done_post));
           }
 
           next.trace = first.trace;

--- a/test/libponyc/codegen_optimisation.cc
+++ b/test/libponyc/codegen_optimisation.cc
@@ -39,3 +39,23 @@ TEST_F(CodegenOptimisationTest, MergeTraceMessageReordering)
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 1);
 }
+
+TEST_F(CodegenOptimisationTest, MergeTraceCrossMessaging)
+{
+  // Test that we don't produce invalid LLVM IR that would cause a crash.
+  const char* src =
+    "actor A\n"
+    "  be m(a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    test(A, A)\n"
+
+    "  be test(a1: A, a2: A) =>\n"
+    "    a1.m(a2)\n"
+    "    a2.m(a1)";
+
+  opt.release = true;
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
This change fixes an edge case in MergeTrace that occurred on "cross-messaging", for example:

```pony
x.m(y)
y.m(x)
```

In those cases, IR instructions were reordered such that some instructions were defined after they were being used, resulting in invalid IR.

No changelog entry since the optimisation pass is unreleased.