### PR TITLE
Fix memory freeing in ponyint_pool_realloc

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -1006,7 +1006,7 @@ void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p)
 
   memcpy(new_p, p, new_size);
 
-  if(old_index <= POOL_COUNT)
+  if(old_index < POOL_COUNT)
     ponyint_pool_free(old_index, p);
   else
     pool_free_size(old_adj_size, p);


### PR DESCRIPTION
Previously, the index-based pool free function was always called, which was wrong for oversized pool allocations.