### PR TITLE
pony_become() the null actor on program termination

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -140,6 +140,10 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
     rc = gencall_runtime(c, "pony_get_exitcode", NULL, 0, "");
   }
 
+  args[0] = ctx;
+  args[1] = LLVMConstNull(c->object_ptr);
+  gencall_runtime(c, "pony_become", args, 2, "");
+
   // Return the runtime exit code.
   LLVMBuildRet(c->builder, rc);
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -370,9 +370,7 @@ static void ponyint_sched_shutdown()
 pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
   bool pinasio)
 {
-  this_scheduler = NULL;
   pony_register_thread();
-  this_scheduler->ctx.current = NULL;
 
   use_yield = !noyield;
 


### PR DESCRIPTION
This change stops an instance of a Pony program from retaining a reference to one of the actors it created. This prevents compiler JIT tests from having a dangling reference to an actor from the previous JIT test.

This also reverts 6f0c33a and a part of 1e1c484 since these changes fixed symptoms of the problem and not the problem itself.