### PR TITLE
Make String.join take a Iterator instead of a ReadSeq

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -1131,14 +1131,14 @@ actor Main
     let s = recover String(len) end
     (consume s)._append(this)._append(that)
 
-  fun join(data: ReadSeq[Stringable]): String iso^ =>
+  fun join(data: Iterator[Stringable]): String iso^ =>
     """
     Return a string that is a concatenation of the strings in data, using this
     as a separator.
     """
     var buf = recover String end
     var first = true
-    for v in data.values() do
+    for v in data do
       if first then
         first = false
       else

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -704,11 +704,11 @@ class iso _TestStringJoin is UnitTest
   fun name(): String => "builtin/String.join"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("_".join(["zomg"]), "zomg")
-    h.assert_eq[String]("_".join(["hi"; "there"]), "hi_there")
-    h.assert_eq[String](" ".join(["1"; ""; "2"; ""]), "1  2 ")
-    h.assert_eq[String](" ".join([as Stringable: U32(1); U32(4)]), "1 4")
-    h.assert_eq[String](" ".join(Array[String]), "")
+    h.assert_eq[String]("_".join(["zomg"].values()), "zomg")
+    h.assert_eq[String]("_".join(["hi"; "there"].values()), "hi_there")
+    h.assert_eq[String](" ".join(["1"; ""; "2"; ""].values()), "1  2 ")
+    h.assert_eq[String](" ".join([as Stringable: U32(1); U32(4)].values()), "1 4")
+    h.assert_eq[String](" ".join(Array[String].values()), "")
 
 class iso _TestStringCount is UnitTest
   """

--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -44,7 +44,7 @@ primitive Debug
     default separator is ", ", and the default output stream is stdout.
     """
     ifdef debug then
-      _print(sep.join(msg), stream)
+      _print(sep.join(msg.values()), stream)
     end
 
   fun out(msg: Stringable = "") =>

--- a/packages/ponybench/pony_bench.pony
+++ b/packages/ponybench/pony_bench.pony
@@ -118,7 +118,7 @@ actor PonyBench
         Format.int[U64](nspo where width = 10)
         " ns/op"
       ]
-    _env.out.print(String.join(sl))
+    _env.out.print(String.join(sl.values()))
     _next()
 
   be _failure(name: String, timeout: Bool) =>
@@ -128,7 +128,7 @@ actor PonyBench
       sl.push(" (timeout)")
     end
     sl.push(ANSI.reset())
-    _env.out.print(String.join(sl))
+    _env.out.print(String.join(sl.values()))
     _next()
 
   fun ref _add(name: String, b: _Benchmark) =>

--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -338,7 +338,7 @@ class val TestHelper
     Generate a printable string of the contents of the given readseq to use in
     error messages.
     """
-    "[len=" + array.size().string() + ": " + ", ".join(array) + "]"
+    "[len=" + array.size().string() + ": " + ", ".join(array.values()) + "]"
 
   fun long_test(timeout: U64) =>
     """


### PR DESCRIPTION
This changes String.join to take an iterator instead of a ReadSeq, which I think it makes it more useful (less restrictive type).  This does however break existing code.  I'm not sure what the policy on breaking changes in the pony stdlib is, but I thought I'd submit for feedback anyway.