### PR TITLE
Add missing space in expected error message.

### DIFF
--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -54,7 +54,7 @@ TEST_F(VerifyTest, MainActorNewCreateTwoParams)
     "    None";
 
   TEST_ERRORS_1(src,
-    "the create constructor of the Main actor must take only a single Env"
+    "the create constructor of the Main actor must take only a single Env "
     "parameter");
 }
 


### PR DESCRIPTION
The space was added in the compiler in #2077, but the corresponding test
was not updated.