### PR TITLE
Fix compiler assertion failure at code generation

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -675,14 +675,14 @@ static bool genfun_forward(compile_t* c, reach_type_t* t,
     LLVMValueRef value = LLVMGetParam(c_m->func, i);
     args[i] = gen_assign_cast(c,
       ((compile_type_t*)m2->params[i - 1].type->c_type)->use_type, value,
-      m->params[i - 1].type->ast);
+      m->params[i - 1].type->ast_cap);
   }
 
   codegen_debugloc(c, m2->r_fun);
   LLVMValueRef ret = codegen_call(c, c_m2->func, args, count, m->cap != TK_AT);
   codegen_debugloc(c, NULL);
   ret = gen_assign_cast(c, ((compile_type_t*)m->result->c_type)->use_type, ret,
-    m2->result->ast);
+    m2->result->ast_cap);
   LLVMBuildRet(c->builder, ret);
   codegen_finishfun(c);
   return true;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -818,3 +818,23 @@ TEST_F(BadPonyTest, DontCareUnusedBranchValue)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(BadPonyTest, ForwardTuple)
+{
+  // From issue #2097
+  const char* src =
+    "class val X\n"
+
+    "trait T\n"
+    "  fun f(): Any val\n"
+
+    "class C is T\n"
+    "  fun f(): (X, USize) => (X, 0)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let t: T = C\n"
+    "    t.f()";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
This change fixes an assertion failure that occurred when generating forwarding functions boxing non-ref tuples. The tuple AST without reference capabilities was being used, which could be a non-reachable type, resulting in an assertion failure in `gen_box`.

Closes #2097.