### PR TITLE
Reverse the condition in ponyint_pool_index

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -1055,16 +1055,18 @@ void ponyint_pool_thread_cleanup()
 
 size_t ponyint_pool_index(size_t size)
 {
-  if(size <= POOL_MIN)
-    return 0;
-
 #ifdef PLATFORM_IS_ILP32
 #define BITS (32 - POOL_MIN_BITS)
 #else
 #define BITS (64 - POOL_MIN_BITS)
 #endif
 
-  return (size_t)BITS - __pony_clzl(size) - (!(size & (size - 1)));
+  // The condition is in that order for better branch prediction: non-zero pool
+  // indices are more likely than zero pool indices.
+  if(size > POOL_MIN)
+    return (size_t)BITS - __pony_clzl(size) - (!(size & (size - 1)));
+
+  return 0;
 }
 
 size_t ponyint_pool_size(size_t index)


### PR DESCRIPTION
Based on measurements on Pony programs, calculating a non-zero pool index is much more likely than calculating a  zero pool index. Since compilers will often treat the then part of a condition as more likely, reversing the condition in `ponyint_pool_index` can help with branch prediction when the branch isn't in the branch prediction cache.