### PR TITLE
Switch to libunwind for backtrace printing on *nix systems

### DIFF
--- a/.ci-dockerfiles/llvm-3.9.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-3.9.1/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
   build-essential \
   g++-6 \
   git \
+  libunwind8-dev \
   libncurses5-dev \
   libssl-dev \
   make \
@@ -19,6 +20,9 @@ RUN apt-get update \
   zlib1g-dev \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
+
+# delete the libunwind files shipped with LLVM, they conflict with the system libunwind files
+RUN rm /usr/local/lib/libunwind*
 
 # install pcre2
 RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \

--- a/.ci-dockerfiles/llvm-4.0.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-4.0.1/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
   build-essential \
   g++-6 \
   git \
+  libunwind8-dev \
   libncurses5-dev \
   libssl-dev \
   make \
@@ -19,6 +20,9 @@ RUN apt-get update \
   zlib1g-dev \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
+
+# delete the libunwind files shipped with LLVM, they conflict with the system libunwind files
+RUN rm /usr/local/lib/libunwind*
 
 # install pcre2
 RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \

--- a/.ci-dockerfiles/llvm-5.0.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-5.0.1/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
   apt-transport-https \
   g++ \
   git \
+  libunwind-dev \
   libncurses5-dev \
   libpcre2-dev \
   libssl-dev \
@@ -16,3 +17,6 @@ RUN apt-get update \
   zlib1g-dev \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04
+
+# delete the libunwind files shipped with LLVM, they conflict with the system libunwind files
+RUN rm /usr/local/lib/libunwind*

--- a/.ci-dockerfiles/openssl-1.1.0/Dockerfile
+++ b/.ci-dockerfiles/openssl-1.1.0/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
   apt-transport-https \
   g++ \
   git \
+  libunwind-dev \
   libncurses5-dev \
   libpcre2-dev \
   make \
@@ -15,6 +16,9 @@ RUN apt-get update \
   zlib1g-dev \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04
+
+# delete the libunwind files shipped with LLVM, they conflict with the system libunwind files
+RUN rm /usr/local/lib/libunwind*
 
  RUN wget https://www.openssl.org/source/openssl-1.1.0.tar.gz \
    && tar xf openssl-1.1.0.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
   apt-transport-https \
   g++ \
   git \
+  libunwind-dev \
   libncurses5-dev \
   libpcre2-dev \
   libssl-dev \
@@ -22,6 +23,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04
+
+# delete the libunwind files shipped with LLVM, they conflict with the system libunwind files
+RUN rm /usr/local/lib/libunwind*
 
 WORKDIR /src/ponyc
 COPY Makefile LICENSE VERSION /src/ponyc/

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ endif
 llvm.libs    := $(shell $(LLVM_CONFIG) --libs $(LLVM_LINK_STATIC)) -lz -lncurses
 
 ifeq ($(OSTYPE), bsd)
-  llvm.libs += -lpthread -lexecinfo
+  llvm.libs += -lpthread
 endif
 
 prebuilt := llvm
@@ -443,10 +443,6 @@ endif
 # target specific build options
 libponyrt.tests.linkoptions += -rdynamic
 
-ifneq ($(ALPINE),)
-  libponyrt.tests.linkoptions += -lexecinfo
-endif
-
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS
@@ -460,28 +456,15 @@ libponyc.tests.buildoptions += -DPONY_PACKAGES_DIR=\"$(packages_abs_src)\"
 
 libponyc.tests.linkoptions += -rdynamic
 
-ifneq ($(ALPINE),)
-  libponyc.tests.linkoptions += -lexecinfo
-endif
-
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
 
 libgbenchmark.buildoptions := -DHAVE_POSIX_REGEX
 
-ifneq ($(ALPINE),)
-  libponyc.benchmarks.linkoptions += -lexecinfo
-  libponyrt.benchmarks.linkoptions += -lexecinfo
-endif
-
 ponyc.buildoptions = $(libponyc.buildoptions)
 
 ponyc.linkoptions += -rdynamic
-
-ifneq ($(ALPINE),)
-  ponyc.linkoptions += -lexecinfo
-endif
 
 ifeq ($(OSTYPE), linux)
   libponyrt-pic.buildoptions += -fpic
@@ -515,18 +498,19 @@ libponyc.benchmarks.links = libblake2 libgbenchmark libponyc libponyrt llvm
 libponyrt.benchmarks.links = libgbenchmark libponyrt
 
 ifeq ($(OSTYPE),linux)
-  ponyc.links += libpthread libdl libatomic
-  libponyc.tests.links += libpthread libdl libatomic
-  libponyrt.tests.links += libpthread libdl libatomic
-  libponyc.benchmarks.links += libpthread libdl libatomic
-  libponyrt.benchmarks.links += libpthread libdl libatomic
+  ponyc.links += libpthread libdl libatomic libunwind
+  libponyc.tests.links += libpthread libdl libatomic libunwind
+  libponyrt.tests.links += libpthread libdl libatomic libunwind
+  libponyc.benchmarks.links += libpthread libdl libatomic libunwind
+  libponyrt.benchmarks.links += libpthread libdl libatomic libunwind
 endif
 
 ifeq ($(OSTYPE),bsd)
-  libponyc.tests.links += libpthread
-  libponyrt.tests.links += libpthread
-  libponyc.benchmarks.links += libpthread
-  libponyrt.benchmarks.links += libpthread
+  ponyc.links += libpthread libunwind
+  libponyc.tests.links += libpthread libunwind
+  libponyrt.tests.links += libpthread libunwind
+  libponyc.benchmarks.links += libpthread libunwind
+  libponyrt.benchmarks.links += libpthread libunwind
 endif
 
 ifneq (, $(DTRACE))


### PR DESCRIPTION
This removes the dependency on libexecinfo.

cc @dipinhora to make sure this doesn't break compatiblity with Alpine.