### PR TITLE
Fix freebsd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,6 +465,8 @@ ifeq ($(OSTYPE),linux)
 endif
 
 ifeq ($(OSTYPE),freebsd)
+  libponyc.tests.links += libpthread
+  libponyrt.tests.links += libpthread
   libponyc.benchmarks.links += libpthread
   libponyrt.benchmarks.links += libpthread
 endif


### PR DESCRIPTION
Prior to this commit freebsd builds weren't properly linking
`libponyrt.tests` due to not being able to find `pthread` related
symbols.

Resolves #2105 (it would be ideal to wait until after @tschuxxi is able to confirm this works for him before merging).