### PR TITLE
docgen: ingore test types and only document public types by default

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -122,6 +122,10 @@ static bool is_for_testing(const char* name, ast_t* list)
 
   for(ast_t* p = ast_child(list); p != NULL; p = ast_sibling(p))
   {
+    if (ast_id(p) == TK_PROVIDES) {
+        // descent 1 level down to TK_NOMINAL
+        p = ast_child(p);
+    }
     if(ast_id(p) == TK_NOMINAL)
     {
       ast_t* id = ast_childidx(p, 1);

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -142,6 +142,14 @@ static bool is_for_testing(const char* name, ast_t* list)
   return false;
 }
 
+// detect if a whole package is for testing purposes
+// statically checks if package name is "test" or "builtin_test"
+static bool is_package_for_testing(const char* name)
+{
+    pony_assert(name != NULL);
+    return (strcmp(name, "test") == 0 || strcmp(name, "builtin_test") == 0);
+}
+
 
 // Add the given AST to the given list, using the name from the specified
 // child.
@@ -1033,8 +1041,12 @@ static void doc_packages(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
   docgen->private_types = NULL;
   doc_package(docgen, docgen_opt, package_1);
 
-  for(ast_list_t* p = packages.next; p != NULL; p = p->next)
-    doc_package(docgen, docgen_opt, p->ast);
+  for(ast_list_t* p = packages.next; p != NULL; p = p->next) {
+    const char* p_name = package_qualified_name(p->ast);
+    if (!is_package_for_testing(p_name)) {
+        doc_package(docgen, docgen_opt, p->ast);
+    }
+  }
 }
 
 

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -172,16 +172,16 @@ static void doc_list_add_named(ast_list_t* list, ast_t* ast, size_t id_index,
   if(is_for_testing(name, ast)) // Ignore test types
     return;
 
-  bool private = is_name_private(name);
+  bool has_private_name = is_name_private(name);
 
-  if(private && !allow_private)  // Ignore private
+  if(has_private_name && !allow_private)  // Ignore private
     return;
 
 
-  if(!private && !allow_public)  // Ignore public
+  if(!has_private_name && !allow_public)  // Ignore public
     return;
 
-  if(private)  // Ignore leading underscore for ordering
+  if(has_private_name)  // Ignore leading underscore for ordering
     name++;
 
   doc_list_add(list, ast, name, false);
@@ -360,7 +360,7 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
       // indicated by a name created by package_hygienic_id)
       // and if the type not private if we exclude private types.
       const char* type_id_name = ast_name(id);
-      if(generate_links && *type_id_name != '$' 
+      if(generate_links && *type_id_name != '$'
               && (docgen_opt->include_private || !is_name_private(type_id_name)))
       {
         // Find type we reference so we can link to it

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -43,7 +43,7 @@ typedef struct docgen_t
 // Define options for doc generation
 typedef struct docgen_opt_t
 {
-    bool include_private;
+  bool include_private;
 } docgen_opt_t;
 
 
@@ -312,8 +312,8 @@ static FILE* doc_open_file(docgen_t* docgen, bool in_sub_dir,
 // Functions to handle types
 
 static void doc_type_list(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* list,
-        const char* preamble, const char* separator, const char* postamble,
-        bool generate_links, bool line_breaks);
+  const char* preamble, const char* separator, const char* postamble,
+  bool generate_links, bool line_breaks);
 
 // Report the human readable description for the given capability node.
 // The returned string is valid forever and should not be freed.
@@ -344,7 +344,7 @@ static const char* doc_get_cap(ast_t* cap)
 
 // Write the given type to the current type file
 static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
-                     ast_t* type, bool generate_links)
+  ast_t* type, bool generate_links)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -361,7 +361,7 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
       // and if the type not private if we exclude private types.
       const char* type_id_name = ast_name(id);
       if(generate_links && *type_id_name != '$'
-              && (docgen_opt->include_private || !is_name_private(type_id_name)))
+        && (docgen_opt->include_private || !is_name_private(type_id_name)))
       {
         // Find type we reference so we can link to it
         ast_t* target = (ast_t*)ast_data(type);
@@ -450,8 +450,8 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
 // preamble, separator and postamble text. If the list is empty nothing is
 // written.
 static void doc_type_list(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* list,
-        const char* preamble, const char* separator, const char* postamble,
-        bool generate_links, bool line_breaks)
+  const char* preamble, const char* separator, const char* postamble,
+  bool generate_links, bool line_breaks)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -493,7 +493,8 @@ static void doc_type_list(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* lis
 // Write the given list of fields to the current type file.
 // The given title text is used as a section header.
 // If the field list is empty nothing is written.
-static void doc_fields(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_list_t* fields, const char* title)
+static void doc_fields(docgen_t* docgen, docgen_opt_t* docgen_opt,
+  ast_list_t* fields, const char* title)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -534,8 +535,8 @@ static void doc_fields(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_list_t* f
 
 // Write the given list of type parameters to the current type file, with
 // surrounding []. If the given list is empty nothing is written.
-static void doc_type_params(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* t_params,
-  bool generate_links)
+static void doc_type_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
+  ast_t* t_params, bool generate_links)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -581,7 +582,7 @@ static void doc_type_params(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* t
 // Write the given list of parameters to the current type file, with
 // surrounding (). If the given list is empty () is still written.
 static void code_block_doc_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
-        ast_t* params)
+  ast_t* params)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -624,7 +625,7 @@ static void code_block_doc_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
 }
 
 static void list_doc_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
-        ast_t* params)
+  ast_t* params)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -669,7 +670,7 @@ static void list_doc_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
 
 // Write a description of the given method to the current type file
 static void doc_method(docgen_t* docgen, docgen_opt_t* docgen_opt, 
-        ast_t* method)
+  ast_t* method)
 {
   pony_assert(docgen != NULL);
   pony_assert(docgen->type_file != NULL);
@@ -814,7 +815,8 @@ static void doc_entity(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
   fprintf(docgen->type_file, "%s", name);
 
   doc_type_params(docgen, docgen_opt, tparams, false);
-  doc_type_list(docgen, docgen_opt, provides, " is\n  ", ",\n  ", "", false, false);
+  doc_type_list(docgen, docgen_opt, provides, " is\n  ", ",\n  ", "",
+    false, false);
   fprintf(docgen->type_file, "\n```\n\n");
 
   if (ast_id(ast) !=  TK_TYPE)
@@ -848,12 +850,14 @@ static void doc_entity(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
 
       case TK_BE:
         doc_list_add_named(&pub_bes, p, 1, true, false);
-        doc_list_add_named(&priv_bes, p, 1, false, docgen_opt->include_private);
+        doc_list_add_named(&priv_bes, p, 1, 
+          false, docgen_opt->include_private);
         break;
 
       case TK_FUN:
         doc_list_add_named(&pub_funs, p, 1, true, false);
-        doc_list_add_named(&priv_funs, p, 1, false, docgen_opt->include_private);
+        doc_list_add_named(&priv_funs, p, 1,
+          false, docgen_opt->include_private);
         break;
 
       default:
@@ -974,13 +978,7 @@ static void doc_package(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
             ast_id(t) == TK_STRUCT || ast_id(t) == TK_CLASS ||
             ast_id(t) == TK_ACTOR);
           // We have a type
-          doc_list_add_named(
-                  &types,
-                  t,
-                  0,
-                  true,
-                  docgen_opt->include_private
-          );
+          doc_list_add_named(&types, t, 0, true, docgen_opt->include_private);
         }
       }
     }
@@ -1015,7 +1013,8 @@ static void doc_package(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
 
 
 // Document the packages in the given program
-static void doc_packages(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
+static void doc_packages(docgen_t* docgen, docgen_opt_t* docgen_opt,
+  ast_t* ast)
 {
   pony_assert(ast != NULL);
   pony_assert(ast_id(ast) == TK_PROGRAM);
@@ -1041,10 +1040,12 @@ static void doc_packages(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
   docgen->private_types = NULL;
   doc_package(docgen, docgen_opt, package_1);
 
-  for(ast_list_t* p = packages.next; p != NULL; p = p->next) {
+  for(ast_list_t* p = packages.next; p != NULL; p = p->next)
+  {
     const char* p_name = package_qualified_name(p->ast);
-    if (!is_package_for_testing(p_name)) {
-        doc_package(docgen, docgen_opt, p->ast);
+    if(!is_package_for_testing(p_name))
+    {
+      doc_package(docgen, docgen_opt, p->ast);
     }
   }
 }

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -221,6 +221,8 @@ typedef struct pass_opt_t
   bool print_filenames;
   bool check_tree;
   bool docs;
+  bool docs_private;
+
   verbosity_level verbosity;
   const char* output;
   char* link_arch;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -33,7 +33,7 @@ enum
   OPT_PIC,
   OPT_NOPIC,
   OPT_DOCS,
-  OPT_DOCS_PRIVATE,
+  OPT_DOCS_PUBLIC,
 
   OPT_SAFE,
   OPT_CPU,
@@ -74,7 +74,7 @@ static opt_arg_t args[] =
   {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   {"nopic", '\0', OPT_ARG_NONE, OPT_NOPIC},
   {"docs", 'g', OPT_ARG_NONE, OPT_DOCS},
-  {"docs-private", '\0', OPT_ARG_NONE, OPT_DOCS_PRIVATE},
+  {"docs-public", '\0', OPT_ARG_NONE, OPT_DOCS_PUBLIC},
 
   {"safe", '\0', OPT_ARG_OPTIONAL, OPT_SAFE},
   {"cpu", '\0', OPT_ARG_REQUIRED, OPT_CPU},
@@ -125,8 +125,7 @@ static void usage()
     "  --pic           Compile using position independent code.\n"
     "  --nopic         Don't compile using position independent code.\n"
     "  --docs, -g      Generate code documentation.\n"
-    "  --docs-private  Generate code documentation for private types\n"
-    "                  as well as for public types.\n"
+    "  --docs-public   Generate code documentation for public types only.\n"
     ,
     "Rarely needed options:\n"
     "  --safe          Allow only the listed packages to use C FFI.\n"
@@ -304,9 +303,18 @@ int main(int argc, char* argv[])
       case OPT_RUNTIMEBC: opt.runtimebc = true; break;
       case OPT_PIC: opt.pic = true; break;
       case OPT_NOPIC: opt.pic = false; break;
-      case OPT_DOCS: opt.docs = true; break;
-      case OPT_DOCS_PRIVATE: opt.docs_private = true; break;
-
+      case OPT_DOCS:
+        {
+          opt.docs = true;
+          opt.docs_private = true;
+        }
+        break;
+      case OPT_DOCS_PUBLIC:
+        {
+          opt.docs = true;
+          opt.docs_private = false;
+        }
+        break;
       case OPT_SAFE:
         if(!package_add_safe(s.arg_val, &opt))
           ok = false;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -33,6 +33,7 @@ enum
   OPT_PIC,
   OPT_NOPIC,
   OPT_DOCS,
+  OPT_DOCS_PRIVATE,
 
   OPT_SAFE,
   OPT_CPU,
@@ -73,6 +74,7 @@ static opt_arg_t args[] =
   {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   {"nopic", '\0', OPT_ARG_NONE, OPT_NOPIC},
   {"docs", 'g', OPT_ARG_NONE, OPT_DOCS},
+  {"docs-private", '\0', OPT_ARG_NONE, OPT_DOCS_PRIVATE},
 
   {"safe", '\0', OPT_ARG_OPTIONAL, OPT_SAFE},
   {"cpu", '\0', OPT_ARG_REQUIRED, OPT_CPU},
@@ -123,6 +125,8 @@ static void usage()
     "  --pic           Compile using position independent code.\n"
     "  --nopic         Don't compile using position independent code.\n"
     "  --docs, -g      Generate code documentation.\n"
+    "  --docs-private  Generate code documentation for private types\n"
+    "                  as well as for public types.\n"
     ,
     "Rarely needed options:\n"
     "  --safe          Allow only the listed packages to use C FFI.\n"
@@ -301,6 +305,7 @@ int main(int argc, char* argv[])
       case OPT_PIC: opt.pic = true; break;
       case OPT_NOPIC: opt.pic = false; break;
       case OPT_DOCS: opt.docs = true; break;
+      case OPT_DOCS_PRIVATE: opt.docs_private = true; break;
 
       case OPT_SAFE:
         if(!package_add_safe(s.arg_val, &opt))


### PR DESCRIPTION
This PR changes the docgen pass (invoked by calling ``ponyc --docs``) to ignore all types that are considered to be test related. That is:

* private types with names starting with ``_Test``
* ``TestList`` and ``UnitTest`` implementations
* whole packages called ``builtin_test`` (static check to filter out stdlib package) or ``test``

A new command-line flag "--docs-public" is introduced to only generate documentation for public types, behaviors, constructors and methods.

This fixes #2092 and #2089  