### PR TITLE
Add ability to default enable PIC when compiling ponyc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,6 +444,12 @@ ifeq ($(OSTYPE), linux)
   libponyrt-pic.buildoptions += -fpic
 endif
 
+# default enable PIC compiling if requested
+ifdef default_pic
+  libponyrt.buildoptions += -fpic
+  BUILD_FLAGS += -DPONY_DEFAULT_PIC=true
+endif
+
 # target specific disabling of build options
 libgtest.disable = -Wconversion -Wno-sign-conversion -Wextra
 libgbenchmark.disable = -Wconversion -Wno-sign-conversion -Wextra

--- a/README.md
+++ b/README.md
@@ -246,10 +246,12 @@ If you get errors like
  'Array_String_val_Trace' which may overflow at runtime; recompile with -fPIC
 ```
 
-try running `ponyc` with the `--pic` flag.
+You need to rebuild `ponyc` with `default_pic=true`
 
 ```bash
-$ ./build/release/ponyc --pic examples/helloworld
+$ make clean
+$ make default_pic=true
+$ ./build/release/ponyc examples/helloworld
 ```
 
 ### Debian Jessie
@@ -343,16 +345,9 @@ To build ponyc, compile and run helloworld:
 
 ```bash
 $ cd ~/ponyc/
-$ make
-$ ./build/release/ponyc --pic examples/helloworld
+$ make default_pic=true
+$ ./build/release/ponyc examples/helloworld
 $ ./helloworld
-```
-
-NOTE: You need to pass `--pic` to `ponyc` or you will get errors like the following during linking:
-
-```bash
-/usr/bin/ld.gold: error: ./fb.o: requires dynamic R_X86_64_32 reloc against
- 'Array_String_val_Trace' which may overflow at runtime; recompile with -fPIC
 ```
 
 ### Other Linux distributions

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -31,6 +31,7 @@ enum
   OPT_LIBRARY,
   OPT_RUNTIMEBC,
   OPT_PIC,
+  OPT_NOPIC,
   OPT_DOCS,
 
   OPT_SAFE,
@@ -70,6 +71,7 @@ static opt_arg_t args[] =
   {"library", 'l', OPT_ARG_NONE, OPT_LIBRARY},
   {"runtimebc", '\0', OPT_ARG_NONE, OPT_RUNTIMEBC},
   {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
+  {"nopic", '\0', OPT_ARG_NONE, OPT_NOPIC},
   {"docs", 'g', OPT_ARG_NONE, OPT_DOCS},
 
   {"safe", '\0', OPT_ARG_OPTIONAL, OPT_SAFE},
@@ -119,6 +121,7 @@ static void usage()
     "  --library, -l   Generate a C-API compatible static library.\n"
     "  --runtimebc     Compile with the LLVM bitcode file for the runtime.\n"
     "  --pic           Compile using position independent code.\n"
+    "  --nopic         Don't compile using position independent code.\n"
     "  --docs, -g      Generate code documentation.\n"
     ,
     "Rarely needed options:\n"
@@ -272,6 +275,10 @@ int main(int argc, char* argv[])
   bool print_usage = false;
   int id;
 
+#if defined(PONY_DEFAULT_PIC)
+  opt.pic = true;
+#endif
+
   while((id = ponyint_opt_next(&s)) != -1)
   {
     switch(id)
@@ -292,6 +299,7 @@ int main(int argc, char* argv[])
       case OPT_LIBRARY: opt.library = true; break;
       case OPT_RUNTIMEBC: opt.runtimebc = true; break;
       case OPT_PIC: opt.pic = true; break;
+      case OPT_NOPIC: opt.pic = false; break;
       case OPT_DOCS: opt.docs = true; break;
 
       case OPT_SAFE:


### PR DESCRIPTION
This commit allows folks compiling from source (for packaging or
for their own use) to easily specify that `ponyc` should always
compile programs using Position Independent Code (PIC). The main
driving force behind this is a smoother user experience for folks
on distributions where PIC is enabled by default so they don't
have to always remember to pass `--pic` to `ponyc` when compiling
programs. Alpine Edge is one such example. With this change,
packaging for Alpine Edge is as simple as `make force_pic=true`
and then users of `ponyc` on Alpine Edge don't need to be aware
of PIC being enabled by default at all and don't have to remember
to pass `--pic` to every invocation of `ponyc`.

NOTE: This does not change the default behavior of `ponyc` when
not compiling with `force_pic=true` and it is mainly a convenience
meant to be used only when the person compiling knows that the
toolset being used (gcc on a distro with PIC enabled by default)
will cause issues otherwise.

-----------

@ponylang/core This is related to #1811 and #1484 where alternate solutions have been discussed. Hopefully this is an acceptable compromise until the longer term solutions previously discussed can be implemented.