### PR TITLE
fix changelog message for docgen PR 2112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
-- docgen: ingore test types and only document public types by default ([PR #2112](https://github.com/ponylang/ponyc/pull/2112))
+- docgen: ignore test types and add cli flag to only document public types ([PR #2112](https://github.com/ponylang/ponyc/pull/2112))
 
 
 ## [0.16.1] - 2017-07-30


### PR DESCRIPTION
I am sorry, but my commit message/PR title does not reflect what this PR contained.
This was due to changes that were introduced due to helpful remarks from @SeanTAllen in the process.

i hope this does not break the changelog tool that automatically generates those messages.