### PR TITLE
Fix compiler crash on typecheck error in FFI call.

### DIFF
--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -2,6 +2,7 @@
 #include "literal.h"
 #include "../type/subtype.h"
 #include "../pkg/ifdef.h"
+#include "../pass/expr.h"
 #include "ponyassert.h"
 #include <string.h>
 
@@ -54,6 +55,9 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
       return false;
 
     ast_t* a_type = ast_type(arg);
+
+    if (is_typecheck_error(a_type))
+      return false;
 
     if(ast_id(a_type) == TK_TUPLETYPE)
     {

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -113,6 +113,18 @@ TEST_F(BadPonyTest, InvalidMethodReturnType)
   TEST_ERRORS_1(src, "function return type: iso");
 }
 
+TEST_F(BadPonyTest, TypeErrorInFFIArguments)
+{
+  // From issue #2114
+  const char *src =
+    "use @printf[None](argc: Pointer[U32])\n"
+    "actor Main\n"
+    "  fun create(env: Env) =>\n"
+    "    @printf(addressof U32(0))";
+
+  TEST_ERRORS_1(src, "can only take the address of a local, field or method");
+}
+
 TEST_F(BadPonyTest, ObjectLiteralUninitializedField)
 {
   // From issue #879


### PR DESCRIPTION
Running this build of ponyc on the code I posted in this issue https://github.com/ponylang/ponyc/issues/2114 results in a type error instead of a core dump.

```
Error:
/home/charles/code/stars/bindings.pony:13:21: can't take the address of a let local
    @glutInit[None](addressof argc, argv)
```

Is `return false` all that's needed?