### PR TITLE
Remove the allocation parameterisation of runtime hashmaps

### DIFF
--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -40,8 +40,7 @@ static void stringtab_free(stringtab_entry_t* a)
 
 DECLARE_HASHMAP(strtable, strtable_t, stringtab_entry_t);
 DEFINE_HASHMAP(strtable, strtable_t, stringtab_entry_t, stringtab_hash,
-  stringtab_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
-  stringtab_free);
+  stringtab_cmp, stringtab_free);
 
 static strtable_t table;
 

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -33,7 +33,7 @@ static void sym_free(symbol_t* sym)
 }
 
 DEFINE_HASHMAP_SERIALISE(symtab, symtab_t, symbol_t, sym_hash, sym_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, sym_free, symbol_pony_type());
+  sym_free, symbol_pony_type());
 
 static const char* name_without_case(const char* name)
 {

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -44,8 +44,7 @@ static void compile_local_free(compile_local_t* p)
 }
 
 DEFINE_HASHMAP(compile_locals, compile_locals_t, compile_local_t,
-  compile_local_hash, compile_local_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, compile_local_free);
+  compile_local_hash, compile_local_cmp, compile_local_free);
 
 static void fatal_error(const char* reason)
 {

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -37,8 +37,7 @@ static void genned_string_free(genned_string_t* s)
 }
 
 DEFINE_HASHMAP(genned_strings, genned_strings_t, genned_string_t,
-  genned_string_hash, genned_string_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, genned_string_free);
+  genned_string_hash, genned_string_cmp, genned_string_free);
 
 LLVMValueRef gen_this(compile_t* c, ast_t* ast)
 {

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -34,8 +34,7 @@ static bool tbaa_metadata_cmp(tbaa_metadata_t* a, tbaa_metadata_t* b)
 }
 
 DEFINE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t,
-  tbaa_metadata_hash, tbaa_metadata_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, NULL);
+  tbaa_metadata_hash, tbaa_metadata_cmp, NULL);
 
 tbaa_metadatas_t* tbaa_metadatas_new()
 {

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -99,8 +99,7 @@ static void flag_free(flag_t* flag)
 }
 
 DECLARE_HASHMAP(flagtab, flagtab_t, flag_t);
-DEFINE_HASHMAP(flagtab, flagtab_t, flag_t, flag_hash, flag_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, flag_free);
+DEFINE_HASHMAP(flagtab, flagtab_t, flag_t, flag_hash, flag_cmp, flag_free);
 
 
 struct buildflagset_t

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -102,8 +102,7 @@ static void name_record_free(name_record_t* p)
 
 DECLARE_HASHMAP(name_records, name_records_t, name_record_t);
 DEFINE_HASHMAP(name_records, name_records_t, name_record_t, name_record_hash,
-  name_record_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
-  name_record_free);
+  name_record_cmp, name_record_free);
 
 
 typedef struct colour_record_t

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -40,8 +40,7 @@ static bool reach_method_cmp(reach_method_t* a, reach_method_t* b)
 }
 
 DEFINE_HASHMAP_SERIALISE(reach_methods, reach_methods_t, reach_method_t,
-  reach_method_hash, reach_method_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, NULL, reach_method_pony_type());
+  reach_method_hash, reach_method_cmp, NULL, reach_method_pony_type());
 
 static size_t reach_mangled_hash(reach_method_t* m)
 {
@@ -74,8 +73,8 @@ static void reach_mangled_free(reach_method_t* m)
 }
 
 DEFINE_HASHMAP_SERIALISE(reach_mangled, reach_mangled_t, reach_method_t,
-  reach_mangled_hash, reach_mangled_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, reach_mangled_free, reach_method_pony_type());
+  reach_mangled_hash, reach_mangled_cmp, reach_mangled_free,
+  reach_method_pony_type());
 
 static size_t reach_method_name_hash(reach_method_name_t* n)
 {
@@ -96,8 +95,7 @@ static void reach_method_name_free(reach_method_name_t* n)
 }
 
 DEFINE_HASHMAP_SERIALISE(reach_method_names, reach_method_names_t,
-  reach_method_name_t, reach_method_name_hash,
-  reach_method_name_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
+  reach_method_name_t, reach_method_name_hash, reach_method_name_cmp,
   reach_method_name_free, reach_method_name_pony_type());
 
 static size_t reach_type_hash(reach_type_t* t)
@@ -134,12 +132,10 @@ static void reach_type_free(reach_type_t* t)
 }
 
 DEFINE_HASHMAP_SERIALISE(reach_types, reach_types_t, reach_type_t,
-  reach_type_hash, reach_type_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, reach_type_free, reach_type_pony_type());
+  reach_type_hash, reach_type_cmp, reach_type_free, reach_type_pony_type());
 
 DEFINE_HASHMAP_SERIALISE(reach_type_cache, reach_type_cache_t, reach_type_t,
-  reach_type_hash, reach_type_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, NULL, reach_type_pony_type());
+  reach_type_hash, reach_type_cmp, NULL, reach_type_pony_type());
 
 static reach_method_t* reach_rmethod(reach_method_name_t* n, const char* name)
 {
@@ -1103,8 +1099,7 @@ static void reach_identity_free(reach_identity_t* id)
 DECLARE_HASHMAP(reach_identities, reach_identities_t, reach_identity_t);
 
 DEFINE_HASHMAP(reach_identities, reach_identities_t, reach_identity_t,
-  reach_identity_hash, reach_identity_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, reach_identity_free);
+  reach_identity_hash, reach_identity_cmp, reach_identity_free);
 
 static void reachable_identity_type(reach_t* r, ast_t* l_type, ast_t* r_type,
   pass_opt_t* opt, reach_identities_t* reached_identities)

--- a/src/libponyrt/gc/actormap.c
+++ b/src/libponyrt/gc/actormap.c
@@ -48,8 +48,7 @@ void ponyint_actorref_free(actorref_t* aref)
 }
 
 DEFINE_HASHMAP(ponyint_actormap, actormap_t, actorref_t, actorref_hash,
-  actorref_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size,
-  ponyint_actorref_free);
+  actorref_cmp, ponyint_actorref_free);
 
 static actorref_t* move_unmarked_objects(actorref_t* from, uint32_t mark)
 {

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -55,7 +55,7 @@ DEFINE_STACK(ponyint_viewrefstack, viewrefstack_t, viewref_t);
 
 DECLARE_HASHMAP(ponyint_viewrefmap, viewrefmap_t, viewref_t);
 DEFINE_HASHMAP(ponyint_viewrefmap, viewrefmap_t, viewref_t, viewref_hash,
-  viewref_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size, viewref_free);
+  viewref_cmp, viewref_free);
 
 enum
 {
@@ -107,8 +107,7 @@ static void view_free(view_t* view)
 
 // no element free for a viewmap. views are kept in many maps.
 DECLARE_HASHMAP(ponyint_viewmap, viewmap_t, view_t);
-DEFINE_HASHMAP(ponyint_viewmap, viewmap_t, view_t, view_hash, view_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, NULL);
+DEFINE_HASHMAP(ponyint_viewmap, viewmap_t, view_t, view_hash, view_cmp, NULL);
 
 struct perceived_t
 {
@@ -136,8 +135,7 @@ static void perceived_free(perceived_t* per)
 
 DECLARE_HASHMAP(ponyint_perceivedmap, perceivedmap_t, perceived_t);
 DEFINE_HASHMAP(ponyint_perceivedmap, perceivedmap_t, perceived_t,
-  perceived_hash, perceived_cmp, ponyint_pool_alloc_size,
-  ponyint_pool_free_size, perceived_free);
+  perceived_hash, perceived_cmp, perceived_free);
 
 DECLARE_STACK(ponyint_pendingdestroystack, pendingdestroystack_t, pony_actor_t);
 DEFINE_STACK(ponyint_pendingdestroystack, pendingdestroystack_t, pony_actor_t);

--- a/src/libponyrt/gc/delta.c
+++ b/src/libponyrt/gc/delta.c
@@ -33,7 +33,7 @@ size_t ponyint_delta_rc(delta_t* delta)
 }
 
 DEFINE_HASHMAP(ponyint_deltamap, deltamap_t, delta_t, delta_hash, delta_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, delta_free);
+  delta_free);
 
 deltamap_t* ponyint_deltamap_update(deltamap_t* map, pony_actor_t* actor,
   size_t rc)

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -34,7 +34,7 @@ static void object_free(object_t* obj)
 }
 
 DEFINE_HASHMAP(ponyint_objectmap, objectmap_t, object_t, object_hash,
-  object_cmp, ponyint_pool_alloc_size, ponyint_pool_free_size, object_free);
+  object_cmp, object_free);
 
 object_t* ponyint_objectmap_getobject(objectmap_t* map, void* address, size_t* index)
 {

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -57,8 +57,7 @@ static void serialise_free(serialise_t* p)
 }
 
 DEFINE_HASHMAP(ponyint_serialise, ponyint_serialise_t,
-  serialise_t, serialise_hash, serialise_cmp,
-  ponyint_pool_alloc_size, ponyint_pool_free_size, serialise_free);
+  serialise_t, serialise_hash, serialise_cmp, serialise_free);
 
 static void recurse(pony_ctx_t* ctx, void* p, void* f)
 {


### PR DESCRIPTION
This change removes the ability to customise the allocation function used by different instances of runtime hashmaps. The pool allocator is now always used.

In an early version of libponyrt, hashmaps were being used with both `malloc` and the pool allocator. Now, every hashmap instance uses the pool allocator so the parameterisation isn't needed anymore.

Closes #2068.