### PR TITLE
Support GCC7 on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,11 +463,11 @@ libponyc.benchmarks.links = libgbenchmark libponyc libponyrt llvm
 libponyrt.benchmarks.links = libgbenchmark libponyrt
 
 ifeq ($(OSTYPE),linux)
-  ponyc.links += libpthread libdl
-  libponyc.tests.links += libpthread libdl
-  libponyrt.tests.links += libpthread libdl
-  libponyc.benchmarks.links += libpthread libdl
-  libponyrt.benchmarks.links += libpthread libdl
+  ponyc.links += libpthread libdl libatomic
+  libponyc.tests.links += libpthread libdl libatomic
+  libponyrt.tests.links += libpthread libdl libatomic
+  libponyc.benchmarks.links += libpthread libdl libatomic
+  libponyrt.benchmarks.links += libpthread libdl libatomic
 endif
 
 ifeq ($(OSTYPE),freebsd)

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -272,6 +272,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* export = target_is_linux(c->opt->triple) ?
     "-Wl,--export-dynamic-symbol=__PonyDescTablePtr "
     "-Wl,--export-dynamic-symbol=__PonyDescTableSize" : "-rdynamic";
+  const char* atomic = target_is_linux(c->opt->triple) ? "-latomic" : "";
 
   size_t ld_len = 512 + strlen(file_exe) + strlen(file_o) + strlen(lib_args)
                   + strlen(arch) + strlen(mcx16_arg) + strlen(fuseld)
@@ -284,9 +285,9 @@ static bool link_exe(compile_t* c, ast_t* program,
 #ifdef PONY_USE_LTO
     "-flto -fuse-linker-plugin "
 #endif
-    "%s %s %s %s -lpthread %s -lm %s",
-    linker, file_exe, arch, mcx16_arg, fuseld, file_o, lib_args, ponyrt, ldl,
-    export
+    "%s %s %s %s -lpthread %s %s -lm %s",
+    linker, file_exe, arch, mcx16_arg, atomic, fuseld, file_o, lib_args,
+    ponyrt, ldl, export
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)


### PR DESCRIPTION
Our only GCC7 issue appears to that it needs to be linked against
libatomic explicitly. This commit links to libamotic explicitly on any
Linux platform regardless of compiler version.

Closes #1756