### PR TITLE
Fix cursor location for displaying compiler errors and info.

### DIFF
--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -211,21 +211,25 @@ static void add_ast(parser_t* parser, rule_state_t* state, ast_t* new_ast,
 
 
 // Add an AST node for the specified token, which may be deferred
-void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id)
+void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id,
+  token_t* token_for_pos)
 {
-  pony_assert(parser->last_token != NULL);
+  if(token_for_pos == NULL)
+    token_for_pos = parser->token;
+
+  pony_assert(token_for_pos != NULL);
 
   if(!state->matched && state->ast == NULL && !state->deferred)
   {
     // This is the first AST node, defer creation
     state->deferred = true;
     state->deferred_id = id;
-    state->line = token_line_number(parser->last_token);
-    state->pos = token_line_position(parser->last_token);
+    state->line = token_line_number(token_for_pos);
+    state->pos = token_line_position(token_for_pos);
     return;
   }
 
-  add_ast(parser, state, ast_new(parser->last_token, id), default_builder);
+  add_ast(parser, state, ast_new(token_for_pos, id), default_builder);
 }
 
 
@@ -348,7 +352,7 @@ static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
   {
     // Optional token / sub rule not found
     if(state->deflt_id != TK_EOF) // Default node is specified
-      add_deferrable_ast(parser, state, state->deflt_id);
+      add_deferrable_ast(parser, state, state->deflt_id, parser->last_token);
 
     state->deflt_id = TK_LEX_ERROR;
     return PARSE_OK;

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -112,7 +112,8 @@ void infix_builder(rule_state_t* state, ast_t* new_ast);
 
 void infix_reverse_builder(rule_state_t* state, ast_t* new_ast);
 
-void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id);
+void add_deferrable_ast(parser_t* parser, rule_state_t* state, token_id id,
+  token_t* token_for_pos);
 
 ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
   const char* terminating, const token_id* id_set, bool make_ast,
@@ -198,7 +199,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
  * Example:
  *    AST_NODE(TK_CASE);
  */
-#define AST_NODE(ID)  add_deferrable_ast(parser, &state, ID)
+#define AST_NODE(ID)  add_deferrable_ast(parser, &state, ID, NULL)
 
 
 /** Map our AST node ID.


### PR DESCRIPTION
In PR #2039 (explicit partial calls), one of the changes I made was
to make it so that the cursor, when reporting on an error for a token
that was missing (like the missing '?' for an explicit partial call,
would be placed under the token to the left of where the missing
token should be, instead of under the token to the right (which
was often on the next line).

However, in doing this, I accidentally made it so that many other
(non-missing) tokens were also being reported one token to the left
instead of under the actual token itself. For example:

    main.pony:5:5: can't find declaration of 'present'
        until present end
        ^

Which should be displayed as:

    main.pony:5:5: can't find declaration of 'present'
        until present end
              ^

This PR fixes the accidental breakage, while retaining the desired
behaviour introduced in PR #2039, so that the "explicit partial calls"
migration script will still work correctly. Now all tokens should be
reported in the correct position when displaying errors.