### PR TITLE
Fix read past the end of a buffer in `pool.c`.

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -971,7 +971,7 @@ void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p)
     new_p = pool_alloc_size(new_adj_size);
   }
 
-  memcpy(new_p, p, old_size);
+  memcpy(new_p, p, old_size < new_size ? old_size : new_size);
 
   if(old_index < POOL_COUNT)
     ponyint_pool_free(old_index, p);

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -971,7 +971,7 @@ void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p)
     new_p = pool_alloc_size(new_adj_size);
   }
 
-  memcpy(new_p, p, new_size);
+  memcpy(new_p, p, old_size);
 
   if(old_index < POOL_COUNT)
     ponyint_pool_free(old_index, p);


### PR DESCRIPTION
This change fixes `ponyint_pool_realloc_size`, which was reading past the end of the old buffer, which in some circumstances triggered a page fault.