### PR TITLE
fix promise tests

### DIFF
--- a/packages/promises/promise.pony
+++ b/packages/promises/promise.pony
@@ -186,11 +186,15 @@ actor Promise[A: Any #share]
           end
       end
 
-    next[None]({(a: A) => c.fulfill_a(a) } iso)
+    next[None](
+      {(a: A) => c.fulfill_a(a) } iso,
+      {() => p'.reject() } iso)
+
     p.next[None](
       object iso is Fulfill[B, None]
         fun ref apply(b: B) => c.fulfill_b(b)
-      end)
+      end,
+      {() => p'.reject() } iso)
 
     p'
 


### PR DESCRIPTION
Previously, the unit test for `Promise.add` wasn't testing the correct method. This change resolves that problem and modifies `add` rejection so that it behaves as described in the documentation.