### PR TITLE
Codegen: Use distinct memory representation types

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -180,7 +180,6 @@ static void init_runtime(compile_t* c)
   LLVMValueRef value;
 
   c->void_type = LLVMVoidTypeInContext(c->context);
-  c->ibool = LLVMInt8TypeInContext(c->context);
   c->i1 = LLVMInt1TypeInContext(c->context);
   c->i8 = LLVMInt8TypeInContext(c->context);
   c->i16 = LLVMInt16TypeInContext(c->context);

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -188,7 +188,6 @@ typedef struct compile_t
   LLVMValueRef numeric_sizes;
 
   LLVMTypeRef void_type;
-  LLVMTypeRef ibool;
   LLVMTypeRef i1;
   LLVMTypeRef i8;
   LLVMTypeRef i16;

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -1,5 +1,6 @@
 #include "genbox.h"
 #include "gencall.h"
+#include "genexpr.h"
 #include "genfun.h"
 #include "genname.h"
 #include "gentype.h"
@@ -18,6 +19,8 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
 
   if(l_type != c_t->primitive)
     return NULL;
+
+  value = gen_assign_cast(c, c_t->mem_type, value, t->ast_cap);
 
   // Allocate the object.
   LLVMValueRef this_ptr = gencall_allocstruct(c, t);
@@ -60,5 +63,5 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
   const char id[] = "tbaa";
   LLVMSetMetadata(value, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
 
-  return value;
+  return gen_assign_cast(c, c_t->use_type, value, t->ast_cap);
 }

--- a/src/libponyc/codegen/gencall.h
+++ b/src/libponyc/codegen/gencall.h
@@ -6,8 +6,8 @@
 
 PONY_EXTERN_C_BEGIN
 
-void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef orig_args[],
-  LLVMValueRef cast_args[], ast_t* args_ast);
+void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
+  ast_t* args_ast);
 
 LLVMValueRef gen_funptr(compile_t* c, ast_t* ast);
 

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -72,8 +72,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   if(!ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
     post_block = codegen_block(c, "if_post");
 
-  LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
-  LLVMValueRef br = LLVMBuildCondBr(c->builder, test, then_block, else_block);
+  LLVMValueRef br = LLVMBuildCondBr(c->builder, c_value, then_block, else_block);
 
   handle_branch_prediction_default(c->context, br, ast);
 
@@ -211,8 +210,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   if(i_value == NULL)
     return NULL;
 
-  LLVMValueRef test = LLVMBuildTrunc(c->builder, i_value, c->i1, "");
-  LLVMValueRef br = LLVMBuildCondBr(c->builder, test, body_block, else_block);
+  LLVMValueRef br = LLVMBuildCondBr(c->builder, i_value, body_block, else_block);
 
   handle_branch_prediction_default(c->context, br, ast);
 
@@ -240,8 +238,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
       return NULL;
 
     body_from = LLVMGetInsertBlock(c->builder);
-    LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
-    br = LLVMBuildCondBr(c->builder, test, body_block, post_block);
+    br = LLVMBuildCondBr(c->builder, c_value, body_block, post_block);
 
     handle_branch_prediction_default(c->context, br, ast);
   }
@@ -350,8 +347,8 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
       return NULL;
 
     body_from = LLVMGetInsertBlock(c->builder);
-    LLVMValueRef test = LLVMBuildTrunc(c->builder, c_value, c->i1, "");
-    LLVMValueRef br = LLVMBuildCondBr(c->builder, test, post_block, body_block);
+    LLVMValueRef br = LLVMBuildCondBr(c->builder, c_value, post_block,
+      body_block);
 
     handle_branch_prediction_default(c->context, br, cond);
   }
@@ -363,8 +360,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   LLVMPositionBuilderAtEnd(c->builder, cond_block);
   LLVMValueRef i_value = gen_expr(c, cond);
 
-  LLVMValueRef test = LLVMBuildTrunc(c->builder, i_value, c->i1, "");
-  LLVMValueRef br = LLVMBuildCondBr(c->builder, test, else_block, body_block);
+  LLVMValueRef br = LLVMBuildCondBr(c->builder, i_value, else_block, body_block);
 
   handle_branch_prediction_default(c->context, br, cond);
 

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -1,4 +1,5 @@
 #include "gendesc.h"
+#include "genexpr.h"
 #include "genfun.h"
 #include "genname.h"
 #include "genopt.h"
@@ -72,6 +73,8 @@ static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
   LLVMValueRef metadata = tbaa_metadata_for_box_type(c, box_name);
   const char id[] = "tbaa";
   LLVMSetMetadata(primitive, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+
+  primitive = gen_assign_cast(c, c_t->use_type, primitive, t->ast_cap);
 
   LLVMValueRef* args = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
 

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -268,8 +268,7 @@ static bool check_value(compile_t* c, ast_t* pattern, ast_t* param_type,
   if(next_block == NULL)
     next_block = continue_block;
 
-  LLVMValueRef test = LLVMBuildTrunc(c->builder, result, c->i1, "");
-  LLVMValueRef br = LLVMBuildCondBr(c->builder, test, continue_block,
+  LLVMValueRef br = LLVMBuildCondBr(c->builder, result, continue_block,
     next_block);
 
   handle_branch_prediction_default(c->context, br, ast_parent(pattern));
@@ -716,8 +715,7 @@ static bool guard_match(compile_t* c, ast_t* guard,
   if(next_block == NULL)
     next_block = continue_block;
 
-  LLVMValueRef test = LLVMBuildTrunc(c->builder, value, c->i1, "");
-  LLVMBuildCondBr(c->builder, test, continue_block, next_block);
+  LLVMBuildCondBr(c->builder, value, continue_block, next_block);
   LLVMPositionBuilderAtEnd(c->builder, continue_block);
   return true;
 }

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1240,6 +1240,23 @@ bool target_is_arm(char* t)
   return !strcmp("arm", arch);
 }
 
+// This function is used to safeguard against potential oversights on the size
+// of Bool on any future port to PPC32.
+// We do not currently support compilation to PPC. It could work, but no
+// guarantees.
+bool target_is_ppc(char* t)
+{
+  Triple triple = Triple(t);
+
+#if PONY_LLVM >= 400
+  const char* arch = Triple::getArchTypePrefix(triple.getArch()).data();
+#else
+  const char* arch = Triple::getArchTypePrefix(triple.getArch());
+#endif
+
+  return !strcmp("ppc", arch);
+}
+
 bool target_is_lp64(char* t)
 {
   Triple triple = Triple(t);

--- a/src/libponyc/codegen/genopt.h
+++ b/src/libponyc/codegen/genopt.h
@@ -14,6 +14,7 @@ bool target_is_windows(char* triple);
 bool target_is_posix(char* triple);
 bool target_is_x86(char* triple);
 bool target_is_arm(char* triple);
+bool target_is_ppc(char* triple);
 bool target_is_lp64(char* triple);
 bool target_is_llp64(char* triple);
 bool target_is_ilp32(char* triple);

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -170,7 +170,7 @@ void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
     // Machine word, write the bits to the buffer.
     LLVMValueRef value = LLVMBuildLoad(c->builder, ptr, "");
     LLVMValueRef loc = LLVMBuildBitCast(c->builder, offset,
-      LLVMPointerType(c_t->primitive, 0), "");
+      LLVMPointerType(c_t->mem_type, 0), "");
     LLVMBuildStore(c->builder, value, loc);
   } else if(t->bare_method != NULL) {
     // Bare object, either write the type id directly if it is a concrete object
@@ -349,7 +349,7 @@ void gendeserialise_element(compile_t* c, reach_type_t* t, bool embed,
     LLVMValueRef object = gencall_runtime(c, "pony_deserialise_offset",
       args, 3, "");
 
-    object = LLVMBuildBitCast(c->builder, object, c_t->use_type, "");
+    object = LLVMBuildBitCast(c->builder, object, c_t->mem_type, "");
     LLVMBuildStore(c->builder, object, ptr);
   }
 }

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -16,6 +16,7 @@ typedef struct compile_type_t
   LLVMTypeRef structure_ptr;
   LLVMTypeRef primitive;
   LLVMTypeRef use_type;
+  LLVMTypeRef mem_type;
 
   LLVMTypeRef desc_type;
   LLVMValueRef desc;


### PR DESCRIPTION
This change adds a new distinction in object types in the code generator between a type's memory representation type and value type. For example, Bool previously used LLVM's `i8` and now uses LLVM's `i1` as its value type and either `i8` or `i32` as its memory representation type depending on the platform. This currently is the only type whose value and memory types differ.

The motivation for this change is to improve Pony's compatiblity with the C ABI, which has the same kind of distinctions (for example, Clang uses the same LLVM types as above to express C's boolean type).