### PR TITLE
Add the ponyint_messageq_push_single runtime function

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -336,12 +336,29 @@ static void init_runtime(compile_t* c)
 #  endif
 #endif
 
-  // void pony_sendv(i8*, __object*, $message*);
+  // void pony_sendv(i8*, __object*, $message*)
   params[0] = c->void_ptr;
   params[1] = c->object_ptr;
   params[2] = c->msg_ptr;
   type = LLVMFunctionType(c->void_type, params, 3, false);
   value = LLVMAddFunction(c->module, "pony_sendv", type);
+#if PONY_LLVM >= 309
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
+  LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,
+    inacc_or_arg_mem_attr);
+#else
+  LLVMAddFunctionAttr(value, LLVMNoUnwindAttribute);
+#  if PONY_LLVM >= 308
+  LLVMSetInaccessibleMemOrArgMemOnly(value);
+#  endif
+#endif
+
+  // void pony_sendv_single(i8*, __object*, $message*)
+  params[0] = c->void_ptr;
+  params[1] = c->object_ptr;
+  params[2] = c->msg_ptr;
+  type = LLVMFunctionType(c->void_type, params, 3, false);
+  value = LLVMAddFunction(c->module, "pony_sendv_single", type);
 #if PONY_LLVM >= 309
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -575,7 +575,13 @@ void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
   msg_args[0] = ctx;
   msg_args[1] = LLVMBuildBitCast(c->builder, args[0], c->object_ptr, "");
   msg_args[2] = msg;
-  LLVMValueRef send = gencall_runtime(c, "pony_sendv", msg_args, 3, "");
+  LLVMValueRef send;
+
+  if(ast_id(m->r_fun) == TK_NEW)
+    send = gencall_runtime(c, "pony_sendv_single", msg_args, 3, "");
+  else
+    send = gencall_runtime(c, "pony_sendv", msg_args, 3, "");
+
   LLVMSetMetadataStr(send, "pony.msgsend", md);
 
   ponyint_pool_free_size(params_buf_size, param_types);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -120,7 +120,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   args[0] = ctx;
   args[1] = main_actor;
   args[2] = msg;
-  gencall_runtime(c, "pony_sendv", args, 3, "");
+  gencall_runtime(c, "pony_sendv_single", args, 3, "");
 
   // Start the runtime.
   args[0] = LLVMConstInt(c->i32, 0, false);

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -978,8 +978,8 @@ public:
     size_t fn_index;
 
     std::tie(trace, fn_index) =
-      findCallTo(std::vector<StringRef>{"pony_gc_send", "pony_sendv"},
-      std::next(alloc), end, true);
+      findCallTo(std::vector<StringRef>{"pony_gc_send", "pony_sendv",
+        "pony_sendv_single"}, std::next(alloc), end, true);
 
     if(fn_index != 0)
       return false;
@@ -989,7 +989,8 @@ public:
     if(done == end)
       return false;
 
-    auto send = findCallTo("pony_sendv", std::next(done), end, true);
+    auto send = findCallTo(std::vector<StringRef>{"pony_sendv",
+      "pony_sendv_single"}, std::next(done), end, true).first;
 
     if(send == end)
       return false;

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -364,6 +364,18 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* m)
   }
 }
 
+PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
+  pony_msg_t* m)
+{
+  DTRACE2(ACTOR_MSG_SEND, (uintptr_t)ctx->scheduler, m->id);
+
+  if(ponyint_messageq_push_single(&to->q, m))
+  {
+    if(!has_flag(to, FLAG_UNSCHEDULED))
+      ponyint_sched_add(ctx, to);
+  }
+}
+
 PONY_API void pony_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id)
 {
   pony_msg_t* m = pony_alloc_msg(POOL_INDEX(sizeof(pony_msg_t)), id);

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -18,6 +18,8 @@ void ponyint_messageq_destroy(messageq_t* q);
 
 bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m);
 
+bool ponyint_messageq_push_single(messageq_t* q, pony_msg_t* m);
+
 pony_msg_t* ponyint_messageq_pop(messageq_t* q);
 
 bool ponyint_messageq_markempty(messageq_t* q);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -174,6 +174,16 @@ PONY_API pony_msg_t* pony_alloc_msg_size(size_t size, uint32_t id);
 /// Sends a message to an actor.
 PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* m);
 
+/** Single producer version of pony_sendv.
+ *
+ * This is a more efficient version of pony_sendv in the single producer case.
+ * This is unsafe to use with multiple producers, only use this function when
+ * you know nobody else will try to send a message to the actor at the same
+ * time.
+ */
+PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
+  pony_msg_t* m);
+
 /** Convenience function to send a message with no arguments.
  *
  * The dispatch function receives a pony_msg_t.


### PR DESCRIPTION
This function is a more efficient push operation in the single producer case, but is unsafe to use in the multiple producers case. The goal of this function is to enable more efficiency with message queues when
pushes are known to be single producers.

In the public interface of the runtime, a `pony_sendv_single` function has been added, which behaves in the same way `pony_sendv` does but calls `ponyint_messageq_push_single` (and is therefore unsafe to use with
multiple producers).

The compiler now generates `pony_sendv_single` calls when sending actor constructor messages, since these messages are always in the single producer case.