### PR TITLE
Replace calls to malloc by calls to the pool allocator

### DIFF
--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -133,7 +133,7 @@ class Directory
         until not @FindNextFileA[Bool](h, find) end
 
         @FindClose[Bool](h)
-        @free[None](find)
+        @ponyint_windows_find_data_free[None](find)
       else
         compile_error "unsupported platform"
       end

--- a/src/libponyc/ast/printbuf.c
+++ b/src/libponyc/ast/printbuf.c
@@ -7,7 +7,7 @@
 printbuf_t* printbuf_new()
 {
   printbuf_t* buf = POOL_ALLOC(printbuf_t);
-  buf->m = (char*)malloc(32);
+  buf->m = (char*)ponyint_pool_alloc_size(32);
   buf->m[0] = '\0';
   buf->size = 32;
   buf->offset = 0;
@@ -16,7 +16,7 @@ printbuf_t* printbuf_new()
 
 void printbuf_free(printbuf_t* buf)
 {
-  free(buf->m);
+  ponyint_pool_free_size(buf->size, buf->m);
   POOL_FREE(printbuf_t, buf);
 }
 
@@ -45,8 +45,9 @@ void printbuf(printbuf_t* buf, const char* fmt, ...)
 
   if((size_t)r >= avail)
   {
-    buf->size = buf->size + r + 1;
-    buf->m = (char*)realloc(buf->m, buf->size);
+    size_t new_size = buf->size + r + 1;
+    buf->m = (char*)ponyint_pool_realloc_size(buf->size, new_size, buf->m);
+    buf->size = new_size;
     avail = buf->size - buf->offset;
 
     va_start(ap, fmt);

--- a/src/libponyrt/lang/directory.c
+++ b/src/libponyrt/lang/directory.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #if defined(PLATFORM_IS_WINDOWS)
+#include "../mem/pool.h"
 #include <direct.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -62,7 +63,12 @@ PONY_API char* pony_os_cwd()
 
 PONY_API WIN32_FIND_DATA* ponyint_windows_find_data()
 {
-  return (WIN32_FIND_DATA*)malloc(sizeof(WIN32_FIND_DATA));
+  return POOL_ALLOC(WIN32_FIND_DATA);
+}
+
+PONY_API void ponyint_windows_find_data_free(WIN32_FIND_DATA* data)
+{
+  POOL_FREE(WIN32_FIND_DATA, data);
 }
 
 PONY_API const char* ponyint_windows_readdir(WIN32_FIND_DATA* find)

--- a/src/libponyrt/lang/ssl.c
+++ b/src/libponyrt/lang/ssl.c
@@ -1,4 +1,5 @@
 #include <platform.h>
+#include "../mem/pool.h"
 
 #if defined(PLATFORM_IS_WINDOWS)
 static HANDLE* locks;
@@ -39,12 +40,13 @@ static void locking_callback(int mode, int type, const char* file, int line)
 PONY_API void* ponyint_ssl_multithreading(uint32_t count)
 {
 #if defined(PLATFORM_IS_WINDOWS)
-  locks = (HANDLE*)malloc(count * sizeof(HANDLE*));
+  locks = (HANDLE*)ponyint_pool_alloc_size(count * sizeof(HANDLE*));
 
   for(uint32_t i = 0; i < count; i++)
     locks[i] = CreateMutex(NULL, FALSE, NULL);
 #else
-  locks = malloc(count * sizeof(pthread_mutex_t));
+  locks = (pthread_mutex_t*)
+    ponyint_pool_alloc_size(count * sizeof(pthread_mutex_t));
 
   for(uint32_t i = 0; i < count; i++)
     pthread_mutex_init(&locks[i], NULL);

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -23,6 +23,7 @@
 #if defined(PLATFORM_IS_LINUX)
 static uint32_t avail_cpu_count;
 static uint32_t* avail_cpu_list;
+static uint32_t avail_cpu_size;
 #endif
 
 #if defined(PLATFORM_IS_MACOSX) || defined(PLATFORM_IS_FREEBSD)
@@ -122,13 +123,16 @@ void ponyint_cpu_init()
     uint32_t numa_count = ponyint_numa_cores();
 
     if(avail_cpu_count > numa_count)
-      avail_cpu_count = numa_count;
+      avail_cpu_size = numa_count;
 
-    avail_cpu_list = (uint32_t*)malloc(avail_cpu_count * sizeof(uint32_t));
+    avail_cpu_list =
+      (uint32_t*)ponyint_pool_alloc_size(avail_cpu_size * sizeof(uint32_t));
     avail_cpu_count =
       ponyint_numa_core_list(&hw_cpus, &ht_cpus, avail_cpu_list);
   } else {
-    avail_cpu_list = (uint32_t*)malloc(avail_cpu_count * sizeof(uint32_t));
+    avail_cpu_size = avail_cpu_count;
+    avail_cpu_list =
+      (uint32_t*)ponyint_pool_alloc_size(avail_cpu_size * sizeof(uint32_t));
 
     uint32_t i = 0;
     i = cpu_add_mask_to_list(i, &hw_cpus);
@@ -146,16 +150,22 @@ void ponyint_cpu_init()
 
   while(true)
   {
-    DWORD rc = GetLogicalProcessorInformation(info, &len);
+    DWORD new_len = len;
+    DWORD rc = GetLogicalProcessorInformation(info, &new_len);
 
     if(rc != FALSE)
       break;
 
     if(GetLastError() == ERROR_INSUFFICIENT_BUFFER)
     {
-      ptr = info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)malloc(len);
+      ptr = info = (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION)
+        ponyint_pool_realloc_size(len, new_len, ptr);
+      len = new_len;
       continue;
     } else {
+      if(ptr != NULL)
+        ponyint_pool_free_size(len, ptr);
+
       return;
     }
   }
@@ -176,7 +186,7 @@ void ponyint_cpu_init()
   }
 
   if(ptr != NULL)
-    free(ptr);
+    ponyint_pool_free_size(len, ptr);
 #endif
 }
 
@@ -214,9 +224,9 @@ uint32_t ponyint_cpu_assign(uint32_t count, scheduler_t* scheduler,
   if(pinasio)
     asio_cpu = avail_cpu_list[count % avail_cpu_count];
 
-  avail_cpu_count = 0;
-  free(avail_cpu_list);
+  ponyint_pool_free_size(avail_cpu_size * sizeof(uint32_t), avail_cpu_list);
   avail_cpu_list = NULL;
+  avail_cpu_count = avail_cpu_size = 0;
 
   return asio_cpu;
 #elif defined(PLATFORM_IS_FREEBSD)

--- a/test/libponyrt/ds/fun.cc
+++ b/test/libponyrt/ds/fun.cc
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include <ds/fun.h>
+#include <mem/pool.h>
 
 /** Hashing the same integer returns the same key.
  *
@@ -34,14 +35,14 @@ TEST(DsFunTest, HashSameStringGivesSameKey)
  */
 TEST(DsFunTest, HashSamePointerGivesSameKey)
 {
-  void* p = malloc(sizeof(void*));
+  void* p = POOL_ALLOC(void*);
 
   uint64_t key2 = ponyint_hash_ptr(p);
   uint64_t key1 = ponyint_hash_ptr(p);
 
   ASSERT_EQ(key1, key2);
 
-  free(p);
+  POOL_FREE(void*, p);
 }
 
 /** Numbers are rounded to the next power of two.


### PR DESCRIPTION
This change replaces calls to the libc's `malloc` function by calls to allocation functions from the runtime pool allocator.

The remaining `malloc` calls weren't replaced because the allocated memory is used to interact with APIs that require the memory to be `malloc`ed.