### PR TITLE
RFC #48 Change String.join to take Iterable

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -1144,14 +1144,14 @@ actor Main
     let s = recover String(len) end
     (consume s)._append(this)._append(that)
 
-  fun join(data: ReadSeq[Stringable]): String iso^ =>
+  fun join(data: Iterator[Stringable]): String iso^ =>
     """
     Return a string that is a concatenation of the strings in data, using this
     as a separator.
     """
     var buf = recover String end
     var first = true
-    for v in data.values() do
+    for v in data do
       if first then
         first = false
       else

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -704,11 +704,11 @@ class iso _TestStringJoin is UnitTest
   fun name(): String => "builtin/String.join"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("_".join(["zomg"]), "zomg")
-    h.assert_eq[String]("_".join(["hi"; "there"]), "hi_there")
-    h.assert_eq[String](" ".join(["1"; ""; "2"; ""]), "1  2 ")
-    h.assert_eq[String](" ".join([as Stringable: U32(1); U32(4)]), "1 4")
-    h.assert_eq[String](" ".join(Array[String]), "")
+    h.assert_eq[String]("_".join(["zomg"].values()), "zomg")
+    h.assert_eq[String]("_".join(["hi"; "there"].values()), "hi_there")
+    h.assert_eq[String](" ".join(["1"; ""; "2"; ""].values()), "1  2 ")
+    h.assert_eq[String](" ".join([as Stringable: U32(1); U32(4)].values()), "1 4")
+    h.assert_eq[String](" ".join(Array[String].values()), "")
 
 class iso _TestStringCount is UnitTest
   """

--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -44,7 +44,7 @@ primitive Debug
     default separator is ", ", and the default output stream is stdout.
     """
     ifdef debug then
-      _print(sep.join(msg), stream)
+      _print(sep.join(msg.values()), stream)
     end
 
   fun out(msg: Stringable = "") =>

--- a/packages/ponybench/pony_bench.pony
+++ b/packages/ponybench/pony_bench.pony
@@ -118,7 +118,7 @@ actor PonyBench
         Format.int[U64](nspo where width = 10)
         " ns/op"
       ]
-    _env.out.print(String.join(sl))
+    _env.out.print(String.join(sl.values()))
     _next()
 
   be _failure(name: String, timeout: Bool) =>
@@ -128,7 +128,7 @@ actor PonyBench
       sl.push(" (timeout)")
     end
     sl.push(ANSI.reset())
-    _env.out.print(String.join(sl))
+    _env.out.print(String.join(sl.values()))
     _next()
 
   fun ref _add(name: String, b: _Benchmark) =>

--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -338,7 +338,7 @@ class val TestHelper
     Generate a printable string of the contents of the given readseq to use in
     error messages.
     """
-    "[len=" + array.size().string() + ": " + ", ".join(array) + "]"
+    "[len=" + array.size().string() + ": " + ", ".join(array.values()) + "]"
 
   fun long_test(timeout: U64) =>
     """

--- a/packages/promises/_test.pony
+++ b/packages/promises/_test.pony
@@ -120,7 +120,7 @@ class iso _TestPromisesJoin is UnitTest
     h.expect_action("abc")
     (let a, let b, let c) = (Promise[String], Promise[String], Promise[String])
     let abc = Promises[String].join([a; b; c].values())
-      .next[String]({(l: Array[String] val): String => String.join(l) } iso)
+      .next[String]({(l: Array[String] val): String => String.join(l.values()) } iso)
       .next[None]({(s: String) =>
         if
           (s.contains("a") and s.contains("b")) and


### PR DESCRIPTION
Implements RFC #48. For full details see
https://github.com/ponylang/rfcs/blob/master/text/0048-change-String-join-to-take-iterable.md.

The Iterator interface places fewer requirements on the implementation
when compared to ReadSeq. The ReadSeq requires that your implementation
have random access (apply(USize): T), have a known size (size(): USize)
and support sequential (ordered) access by returning an Iterator from
the values() function. Where as the Iterator only requires that the
implementation have sequential access, so is a subset of the
functionality if ReadSeq. There are a number of cases where supporting
an Iterator interface rather than ReadSeq would be desirable. Supporting
a database cursor or a stream from a network service are two that come
immediately to mind.

The other case that crops up is compatibility with other parts of the
pony stdlib. The itertools package which provides a number of useful
functions over unbounded streams of data, similar java streams library.
The specific case I was looking at taking a stream of data, mapping a
transformation over it, then joining the result. Itertools was the only
part of the library that supported that sort of functionality, but
didn't provide a join or reduce function. I found the join function on
String, which required that the call supply a ReadSeq, but internally
only ever needs in Iterator. It seems a simple and obvious change to
make the join function take an Iterator making it a more useful
function. It is trivial to convert from a ReadSeq to an Iterator,
however it is more difficult and has a higher cost to convert in the
other direction.