### PR TITLE
Have travis build Pony binaries using "gcc" as PONY_COMPILER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,10 @@ matrix:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=debug
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: linux
       addons:
@@ -38,8 +40,10 @@ matrix:
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
         - config=release
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: linux
       addons:
@@ -53,8 +57,10 @@ matrix:
         - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=debug
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: linux
       addons:
@@ -68,8 +74,10 @@ matrix:
         - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
         - config=release
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: linux
       addons:
@@ -83,8 +91,10 @@ matrix:
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=debug
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: linux
       addons:
@@ -98,8 +108,10 @@ matrix:
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=release
-        - CC1=gcc-6
-        - CXX1=g++-6
+        - CC1=gcc
+        - CXX1=g++
+        - ICC1=gcc-6
+        - ICXX1=g++-6
 
     - os: osx
       env:

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -28,6 +28,12 @@ download_pcre(){
   popd
 }
 
+set_linux_compiler(){
+  echo "Setting $ICC1 and $ICXX1 as default compiler"
+
+  sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/$ICC1" 60 --slave /usr/bin/g++ g++ "/usr/bin/$ICXX1"
+}
+
 echo "Installing ponyc build dependencies..."
 
 case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
@@ -35,16 +41,19 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   "linux:llvm-config-3.7")
     download_llvm
     download_pcre
+    set_linux_compiler
   ;;
 
   "linux:llvm-config-3.8")
     download_llvm
     download_pcre
+    set_linux_compiler
   ;;
 
   "linux:llvm-config-3.9")
     download_llvm
     download_pcre
+    set_linux_compiler
   ;;
 
   "osx:llvm-config-3.7")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Changed
 
 - RFC #48 Change String.join to take Iterable ([PR #2159](https://github.com/ponylang/ponyc/pull/2159))
+- Change fallback linker to "gcc" from "gcc-6" on Linux. ([PR #2166](https://github.com/ponylang/ponyc/pull/2166))
 
 
 ## [0.17.0] - 2017-08-05


### PR DESCRIPTION
This should default the pony compiler when installed from bintray to
looking for "gcc" rather than "gcc-6". That should be a much better user
experience.