### PR TITLE
Make "this capture violates capabilities" msg more beginner friendly

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -474,8 +474,12 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
     case MATCHTYPE_DENY:
     {
       ast_error(opt->check.errors, pattern,
-        "this capture violates capabilities");
-      ast_error_continue(opt->check.errors, match_type, "match type: %s",
+        "this capture violates capabilities, because the match would "
+        "need to differentiate by capability at runtime instead of matching "
+        "on type alone");
+      ast_error_continue(opt->check.errors, match_type, "the match type "
+        "allows for more than one possibility with the same type as "
+        "pattern type, but different capabilities. match type: %s",
         ast_print_type(operand_type));
       ast_error_continue(opt->check.errors, pattern, "pattern type: %s",
         ast_print_type(pattern_type));


### PR DESCRIPTION
The current "this caputre violates capabilities" message is not very
beginner friendly. It frequently trips up new Pony users. This commit
will change from the current message format:

```
Error:
main.pony:15:13: this capture violates capabilities
          | let ch: U8 =>
            ^
    Info:
    main.pony:13:21: match type: this->ReadSeq[T #read] box->T #read
            for item in _expected.values() do
                        ^
    main.pony:15:13: pattern type: U8 val
              | let ch: U8 =>
```

To the more verbose and hopefully more informative:

```
Error:
main.pony:15:13: this capture violates capabilities, because the match would need to differentiate by capability at runtime instead of matching on type alone
          | let ch: U8 =>
            ^
    Info:
    main.pony:13:21: the match type allows for more than one possibility with the same type as pattern type, but different capabilities. match type: this->ReadSeq[T #read] box->T #read
            for item in _expected.values() do
                        ^
    main.pony:15:13: pattern type: U8 val
              | let ch: U8 =>
```

Closes #2152