### PR TITLE
Change the signature of runtime functions to take a pony_ctx_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - RFC #48 Change String.join to take Iterable ([PR #2159](https://github.com/ponylang/ponyc/pull/2159))
 - Change fallback linker to "gcc" from "gcc-6" on Linux. ([PR #2166](https://github.com/ponylang/ponyc/pull/2166))
+- Change the signature of `pony_continuation` and `pony_triggergc` to take a `pony_ctx_t*` instead of a `pony_actor_t*`.
 
 
 ## [0.17.0] - 2017-08-05

--- a/packages/builtin_test/_test_valtrace.pony
+++ b/packages/builtin_test/_test_valtrace.pony
@@ -17,7 +17,7 @@ actor _Valtrace
     """
     Create a String iso, send it to a new actor.
     """
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     let s = recover String .> append("test") end
     _Valtrace.two(this, h, consume s)
 
@@ -27,7 +27,7 @@ actor _Valtrace
     Append to it.
     Send it as a val to a third actor.
     """
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     s.append("ing")
     _Valtrace.three(a1, this, h, consume s)
 
@@ -35,7 +35,7 @@ actor _Valtrace
     """
     Receive a String that was an iso that passed through another actor.
     """
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     h.assert_eq[String]("testing", s)
     _Valtrace.four(a1, a2, this, h, s)
 
@@ -45,14 +45,14 @@ actor _Valtrace
     """
     Ask all actors to test the string.
     """
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     a1.gc(a1, h, s)
     a2.gc(a1, h, s)
     a2.gc(a1, h, s)
     gc(a1, h, s)
 
   be gc(a: _Valtrace, h: TestHelper, s: String) =>
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     h.assert_eq[String]("testing", s)
     a.done(h)
 

--- a/packages/ponybench/_bench.pony
+++ b/packages/ponybench/_bench.pony
@@ -12,7 +12,7 @@ actor _Bench[A: Any #share] is _Benchmark
 
   be run() =>
     try
-      @pony_triggergc[None](this)
+      @pony_triggergc[None](@pony_ctx[Pointer[None]]())
       let start = Time.nanos()
       for i in Range[U64](0, _ops) do
         DoNotOptimise[A](_f()?)

--- a/packages/ponybench/_bench_async.pony
+++ b/packages/ponybench/_bench_async.pony
@@ -20,7 +20,7 @@ actor _BenchAsync[A: Any #share] is _Benchmark
     (_name, _notify, _f, _ops, _timeout) = (name, notify, f, ops, timeout)
 
   be run() =>
-    @pony_triggergc[None](this)
+    @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     if _timeout > 0 then
       Timers.apply(Timer(
         object iso is TimerNotify

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -390,14 +390,17 @@ PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
   pony_sendv(ctx, to, &m->msg);
 }
 
-PONY_API void pony_continuation(pony_actor_t* self, pony_msg_t* m)
+PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m)
 {
+  pony_assert(ctx->current != NULL);
+  pony_actor_t* self = ctx->current;
   atomic_store_explicit(&m->next, self->continuation, memory_order_relaxed);
   self->continuation = m;
 }
 
 PONY_API void* pony_alloc(pony_ctx_t* ctx, size_t size)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
   return ponyint_heap_alloc(ctx->current, &ctx->current->heap, size);
@@ -405,6 +408,7 @@ PONY_API void* pony_alloc(pony_ctx_t* ctx, size_t size)
 
 PONY_API void* pony_alloc_small(pony_ctx_t* ctx, uint32_t sizeclass)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, HEAP_MIN << sizeclass);
 
   return ponyint_heap_alloc_small(ctx->current, &ctx->current->heap, sizeclass);
@@ -412,6 +416,7 @@ PONY_API void* pony_alloc_small(pony_ctx_t* ctx, uint32_t sizeclass)
 
 PONY_API void* pony_alloc_large(pony_ctx_t* ctx, size_t size)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
   return ponyint_heap_alloc_large(ctx->current, &ctx->current->heap, size);
@@ -419,6 +424,7 @@ PONY_API void* pony_alloc_large(pony_ctx_t* ctx, size_t size)
 
 PONY_API void* pony_realloc(pony_ctx_t* ctx, void* p, size_t size)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
   return ponyint_heap_realloc(ctx->current, &ctx->current->heap, p, size);
@@ -426,6 +432,7 @@ PONY_API void* pony_realloc(pony_ctx_t* ctx, void* p, size_t size)
 
 PONY_API void* pony_alloc_final(pony_ctx_t* ctx, size_t size)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
   return ponyint_heap_alloc_final(ctx->current, &ctx->current->heap, size);
@@ -433,6 +440,7 @@ PONY_API void* pony_alloc_final(pony_ctx_t* ctx, size_t size)
 
 void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, HEAP_MIN << sizeclass);
 
   return ponyint_heap_alloc_small_final(ctx->current, &ctx->current->heap,
@@ -441,15 +449,17 @@ void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
 
 void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
 {
+  pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
   return ponyint_heap_alloc_large_final(ctx->current, &ctx->current->heap,
     size);
 }
 
-PONY_API void pony_triggergc(pony_actor_t* actor)
+PONY_API void pony_triggergc(pony_ctx_t* ctx)
 {
-  actor->heap.next_gc = 0;
+  pony_assert(ctx->current != NULL);
+  ctx->current->heap.next_gc = 0;
 }
 
 PONY_API void pony_schedule(pony_ctx_t* ctx, pony_actor_t* actor)

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -8,6 +8,7 @@
 
 PONY_API void pony_gc_send(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_sendobject;
   ctx->trace_actor = ponyint_gc_sendactor;
@@ -17,6 +18,7 @@ PONY_API void pony_gc_send(pony_ctx_t* ctx)
 
 PONY_API void pony_gc_recv(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_recvobject;
   ctx->trace_actor = ponyint_gc_recvactor;
@@ -33,6 +35,7 @@ void ponyint_gc_mark(pony_ctx_t* ctx)
 
 PONY_API void pony_gc_acquire(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_acquireobject;
   ctx->trace_actor = ponyint_gc_acquireactor;
@@ -40,6 +43,7 @@ PONY_API void pony_gc_acquire(pony_ctx_t* ctx)
 
 PONY_API void pony_gc_release(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   pony_assert(ctx->stack == NULL);
   ctx->trace_object = ponyint_gc_releaseobject;
   ctx->trace_actor = ponyint_gc_releaseactor;
@@ -47,6 +51,7 @@ PONY_API void pony_gc_release(pony_ctx_t* ctx)
 
 PONY_API void pony_send_done(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   ponyint_gc_handlestack(ctx);
   ponyint_gc_sendacquire(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
@@ -56,6 +61,7 @@ PONY_API void pony_send_done(pony_ctx_t* ctx)
 
 PONY_API void pony_recv_done(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   ponyint_gc_handlestack(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 
@@ -73,6 +79,7 @@ void ponyint_mark_done(pony_ctx_t* ctx)
 
 PONY_API void pony_acquire_done(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   ponyint_gc_handlestack(ctx);
   ponyint_gc_sendacquire(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
@@ -80,6 +87,7 @@ PONY_API void pony_acquire_done(pony_ctx_t* ctx)
 
 PONY_API void pony_release_done(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   ponyint_gc_handlestack(ctx);
   ponyint_gc_sendrelease_manual(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
@@ -87,6 +95,7 @@ PONY_API void pony_release_done(pony_ctx_t* ctx)
 
 PONY_API void pony_send_next(pony_ctx_t* ctx)
 {
+  pony_assert(ctx->current != NULL);
   ponyint_gc_handlestack(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -196,13 +196,12 @@ PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
 
 /** Store a continuation.
  *
- * This puts a message at the front of the actor's queue, instead of at the
- * back. This is not concurrency safe: an actor should only push a continuation
- * to itself.
+ * This puts a message at the front of the current actor's queue, instead of at
+ * the back.
  *
  * Not used in Pony.
  */
-PONY_API void pony_continuation(pony_actor_t* self, pony_msg_t* m);
+PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m);
 
 /** Allocate memory on the current actor's heap.
  *
@@ -239,7 +238,7 @@ PONY_API ATTRIBUTE_MALLOC void* pony_alloc_small_final(pony_ctx_t* ctx,
 PONY_API ATTRIBUTE_MALLOC void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size);
 
 /// Trigger GC next time the current actor is scheduled
-PONY_API void pony_triggergc(pony_actor_t* actor);
+PONY_API void pony_triggergc(pony_ctx_t* ctx);
 
 /** Start gc tracing for sending.
  *

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -474,5 +474,6 @@ PONY_API void pony_unregister_thread()
 
 PONY_API pony_ctx_t* pony_ctx()
 {
+  pony_assert(this_scheduler != NULL);
   return &this_scheduler->ctx;
 }

--- a/test/libponyc/codegen_trace.cc
+++ b/test/libponyc/codegen_trace.cc
@@ -97,7 +97,7 @@ TEST_F(CodegenTraceTest, NoTrace)
 
     "  new create(env: Env) =>\n"
          // Trigger GC to remove env from the object map.
-    "    @pony_triggergc[None](this)\n"
+    "    @pony_triggergc[None](@pony_ctx[Pointer[None]]())\n"
     "    test()\n"
 
     "  be test() =>\n"


### PR DESCRIPTION
This changes the signature of the public runtime functions `pony_continuation` and `pony_triggergc` to take the execution context instead of an actor as a parameter. Since these functions are only safe to use on the current actor, this signature change better conveys the function contract and can avoid misuse.

This also adds assertion checks on public runtime functions expecting a current actor.

Manual changelog entry for a complete explanation of the change.