### PR TITLE
Fix race condition in runtime atomic queues

### DIFF
--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -45,12 +45,9 @@ void ponyint_messageq_init(messageq_t* q)
 void ponyint_messageq_destroy(messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
-  pony_assert((((uintptr_t)atomic_load_explicit(&q->head, memory_order_acquire) &
+  pony_assert((((uintptr_t)atomic_load_explicit(&q->head, memory_order_relaxed) &
     ~(uintptr_t)1)) == (uintptr_t)tail);
 #ifdef USE_VALGRIND
-#  ifdef NDEBUG
-  ANNOTATE_HAPPENS_AFTER(&q->head);
-#  endif
   ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
 #endif
 
@@ -63,6 +60,13 @@ bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m)
 {
   atomic_store_explicit(&m->next, NULL, memory_order_relaxed);
 
+  // Without that fence, the store to m->next above could be reordered after
+  // the exchange on the head and after the store to prev->next done by the
+  // next push, which would result in the pop incorrectly seeing the queue as
+  // empty.
+  // Also synchronise with the pop on prev->next.
+  atomic_thread_fence(memory_order_release);
+
   pony_msg_t* prev = atomic_exchange_explicit(&q->head, m,
     memory_order_relaxed);
 
@@ -70,9 +74,12 @@ bool ponyint_messageq_push(messageq_t* q, pony_msg_t* m)
   prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
 
 #ifdef USE_VALGRIND
+  // Double fence with Valgrind since we need to have prev in scope for the
+  // synchronisation annotation.
   ANNOTATE_HAPPENS_BEFORE(&prev->next);
+  atomic_thread_fence(memory_order_release);
 #endif
-  atomic_store_explicit(&prev->next, m, memory_order_release);
+  atomic_store_explicit(&prev->next, m, memory_order_relaxed);
 
   return was_empty;
 }
@@ -88,6 +95,8 @@ bool ponyint_messageq_push_single(messageq_t* q, pony_msg_t* m)
   bool was_empty = ((uintptr_t)prev & 1) != 0;
   prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
 
+  // If we have a single producer, the fence can be replaced with a store
+  // release on prev->next.
 #ifdef USE_VALGRIND
   ANNOTATE_HAPPENS_BEFORE(&prev->next);
 #endif


### PR DESCRIPTION
This change fixes a race condition in the runtime atomic MPSC and MPMC queues where the initialisation of a node in a push operation could conflict with the modification of that node in the next push operation,
resulting in pop operations incorrectly seeing the queue as empty.

This problem couldn't occur on x86 because of platform-specific memory ordering constraints. It could theoretically occur on ARM but no actual case has been reported.

This change doesn't incur any performance impact on x86. It could incur a small performance penalty on ARM but no benchmarking has been done.