### PR TITLE
Make actor continuations a build time option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ ifdef use
     ALL_CFLAGS += -DUSE_DYNAMIC_TRACE
     PONY_BUILD_DIR := $(PONY_BUILD_DIR)-dtrace
   endif
+
+  ifneq (,$(filter $(use), actor_continuations))
+    ALL_CFLAGS += -DUSE_ACTOR_CONTINUATIONS
+    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-actor_continuations
+  endif
 endif
 
 ifdef config
@@ -896,6 +901,7 @@ help:
 	@echo '   valgrind'
 	@echo '   pooltrack'
 	@echo '   dtrace'
+	@echo '   actor_continuations'
 	@echo
 	@echo 'TARGETS:'
 	@echo '  libponyc               Pony compiler library'

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -143,6 +143,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   pony_msg_t* msg;
   size_t app = 0;
 
+#ifdef USE_ACTOR_CONTINUATIONS
   while(actor->continuation != NULL)
   {
     msg = actor->continuation;
@@ -161,6 +162,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
         return !has_flag(actor, FLAG_UNSCHEDULED);
     }
   }
+#endif
 
   // If we have been scheduled, the head will not be marked as empty.
   pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
@@ -402,6 +404,7 @@ PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
   pony_sendv(ctx, to, &m->msg);
 }
 
+#ifdef USE_ACTOR_CONTINUATIONS
 PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m)
 {
   pony_assert(ctx->current != NULL);
@@ -409,6 +412,7 @@ PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m)
   atomic_store_explicit(&m->next, self->continuation, memory_order_relaxed);
   self->continuation = m;
 }
+#endif
 
 PONY_API void* pony_alloc(pony_ctx_t* ctx, size_t size)
 {

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -25,7 +25,9 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
+#ifdef USE_ACTOR_CONTINUATIONS
   pony_msg_t* continuation;
+#endif
   PONY_ATOMIC(uint8_t) flags;
 
   // keep things accessed by other actors on a separate cache line

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -211,7 +211,9 @@ PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
  *
  * Not used in Pony.
  */
+#ifdef USE_ACTOR_CONTINUATIONS
 PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m);
+#endif
 
 /** Allocate memory on the current actor's heap.
  *


### PR DESCRIPTION
The Encore project uses the Pony runtime and has implemented
continuations for actors. There's a small amount of code in the Pony
runtime to support these continuations. It's a fairly unobtrusive bit of
code except for one small point. There's a check for continuation in a
hot path when actors are handling messages. This commit makes actor
continuation support a compile time option.

To get previous actor continuation support, USE_ACTOR_CONTINUATIONS
should be defined. Support for this exists in the Makefile as a "use"
directive.