### PR TITLE
Don't print capabilities for type params when generating docs

### DIFF
--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -383,6 +383,7 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
       }
 
       const char* cap_text = doc_get_cap(cap);
+
       if(cap_text != NULL)
         fprintf(docgen->type_file, " %s", cap_text);
 
@@ -408,10 +409,6 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
     {
       AST_GET_CHILDREN(type, id, cap, ephemeral);
       fprintf(docgen->type_file, "%s", ast_nice_name(id));
-
-      const char* cap_text = doc_get_cap(cap);
-      if(cap_text != NULL)
-        fprintf(docgen->type_file, " %s", cap_text);
 
       if(ast_id(ephemeral) != TK_NONE)
         fprintf(docgen->type_file, "%s", ast_get_print(ephemeral));
@@ -669,7 +666,7 @@ static void list_doc_params(docgen_t* docgen, docgen_opt_t* docgen_opt,
 }
 
 // Write a description of the given method to the current type file
-static void doc_method(docgen_t* docgen, docgen_opt_t* docgen_opt, 
+static void doc_method(docgen_t* docgen, docgen_opt_t* docgen_opt,
   ast_t* method)
 {
   pony_assert(docgen != NULL);
@@ -850,7 +847,7 @@ static void doc_entity(docgen_t* docgen, docgen_opt_t* docgen_opt, ast_t* ast)
 
       case TK_BE:
         doc_list_add_named(&pub_bes, p, 1, true, false);
-        doc_list_add_named(&priv_bes, p, 1, 
+        doc_list_add_named(&priv_bes, p, 1,
           false, docgen_opt->include_private);
         break;
 
@@ -935,7 +932,7 @@ static void doc_package_home(docgen_t* docgen,
 
 
   ponyint_pool_free_size(tqfn_len, tqfn);
-  
+
   docgen->public_types = printbuf_new();
   docgen->private_types = printbuf_new();
 


### PR DESCRIPTION
Per https://github.com/ponylang/ponyc/issues/2145#issuecomment-321131037,
this shouldn't be allowed as its not legal Pony. As #2145 generally
comments on we only want legal code output in the documentation.

This addresses the specific issue in #2145, however, there are other
instances we might want to expand this to. I decided to limit to this
specifically as I think any change we make in other sections of docgen
would require a thorough auditing of output documentation to make sure
there weren't any unintended consquences.

Prior to this change, generated documentation for:

```pony
type Set[A: (Hashable #read & Equatable[A] #read)] is HashSet[A,
HashEq[A]]
```

would be

```pony
type Set[A: (Hashable #read & Equatable[A #read] #read)] is
  HashSet[A #read, HashEq[A #read] val] ref
```

now it is

```
type Set[A: (Hashable #read & Equatable[A] #read)] is
  HashSet[A, HashEq[A] val] ref
```