### PR TITLE
Fix signals on Sierra

### DIFF
--- a/packages/signals/signal_notify.pony
+++ b/packages/signals/signal_notify.pony
@@ -21,4 +21,11 @@ primitive SignalRaise
   Raise a signal.
   """
   fun apply(sig: U32) =>
-    @raise[I32](sig)
+    ifdef osx then
+      // On Darwin, @raise delivers the signal to the current thread, not the
+      // process, but kqueue EVFILT_SIGNAL will only see signals delivered to
+      // the process. @kill delivers the signal to a specific process.
+      @kill[I32](@getpid[I32](), sig)
+    else
+      @raise[I32](sig)
+    end


### PR DESCRIPTION
As of Sierra, `@raise` delivers signals to the current thread, not
the process. Use `@kill` on Darwin instead to deliver to the process,
as EVFILT_SIGNAL never sees signals delivered to specific threads.