### PR TITLE
Fix over allocation in buffered Writer

### DIFF
--- a/packages/buffered/writer.pony
+++ b/packages/buffered/writer.pony
@@ -297,13 +297,15 @@ class Writer
     end
 
   fun ref _check(size': USize) =>
-    if (_current.size() - _offset) < size' then
-      _current.undefined(_offset + size')
+    let available = _current.space() - _offset
+    if (available < size') then
+      let need = size' - available
+      _current.undefined(_current.space() + need)
     end
 
   fun ref _byte(data: U8) =>
     try
-      _current(_offset)? = data
+      _current.insert(_offset, data)?
       _offset = _offset + 1
       _size = _size + 1
     end


### PR DESCRIPTION
Prior to this fix, when allocating memory on demand in Writer, it didn't
check how much memory had already been allocated. It instead checked how
much memory was used. This would mean, that if you reserved 8 bytes of
data, it would then allocate a new 8 bytes of data.