### PR TITLE
Codegen: Mark non-bare functions unnamed_addr

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -1117,6 +1117,7 @@ LLVMValueRef codegen_addfun(compile_t* c, const char* name, LLVMTypeRef type)
   LLVMValueRef fun = LLVMAddFunction(c->module, name, type);
   LLVMSetFunctionCallConv(fun, c->callconv);
   LLVMSetLinkage(fun, c->linkage);
+  LLVMSetUnnamedAddr(fun, true);
 
   LLVMValueRef arg = LLVMGetFirstParam(fun);
   uint32_t i = 1;

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -300,10 +300,11 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     LLVMSetLinkage(c_m->func, LLVMExternalLinkage);
   }
 
-  if((n->cap == TK_AT) && (c_m->func != NULL))
+  if(n->cap == TK_AT)
   {
     LLVMSetFunctionCallConv(c_m->func, LLVMCCallConv);
     LLVMSetLinkage(c_m->func, LLVMExternalLinkage);
+    LLVMSetUnnamedAddr(c_m->func, false);
 
     if(t->bare_method == m)
     {


### PR DESCRIPTION
This change allows better optimisations, particularly from the LLVM MergeFunctions pass. Bare functions aren't affected by this change since their addresses are significant for identification.