### PR TITLE
Fix broken "make" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ destdir ?= $(prefix)/lib/pony/$(tag)
 LIB_EXT ?= a
 BUILD_FLAGS = -march=$(arch) -mtune=$(tune) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
-LINKER_FLAGS = -march=$(arch) -mtune=$(tune) -L /usr/local/lib
+LINKER_FLAGS = -march=$(arch) -mtune=$(tune)
 AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
@@ -610,7 +610,7 @@ define CONFIGURE_LINKER_WHOLE
 endef
 
 define CONFIGURE_LINKER
-  $(eval linkcmd := $(LINKER_FLAGS) -L $(lib))
+  $(eval linkcmd := $(LINKER_FLAGS) -L $(lib) -L /usr/local/lib )
   $(eval linker := $(CC))
   $(eval libs :=)
 


### PR DESCRIPTION
My PR to introduce support for DragonFlyBSD added /usr/local/lib to the
linker search path. We assumed this would be harmless, however it was
not. Because /usr/local/lib was added to the path in a fashion where it
would appear before the local "build" directory then the following would
happen:

- Run `make`
- Get a linker failure if you'd previously installed ponyc

Whereas

- Run `make` install
- No linker error

The problem occured because the pony libraries in /usr/local/lib were
being used instead of those in build.

This PR moves the addition of /usr/local/lib to being AFTER build path.

Closes #2219