### PR TITLE
Fix undersized string buffer for library link command in Windows.

### DIFF
--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -148,7 +148,7 @@ static bool link_lib(compile_t* c, const char* file_o)
     return false;
   }
 
-  size_t len = 128 + strlen(file_lib) + strlen(file_o);
+  size_t len = strlen(vcvars.ar) + strlen(file_lib) + strlen(file_o) + 64;
   char* cmd = (char*)ponyint_pool_alloc_size(len);
 
   snprintf(cmd, len, "cmd /C \"\"%s\" /NOLOGO /OUT:%s %s\"", vcvars.ar,


### PR DESCRIPTION
The compiler was not allocating a big enough buffer for the linker command line on Windows.  This change makes it allocate more than enough space.

Fixes #2222.