### PR TITLE
add use=coverage option to Make to obtain coverage information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,3 +102,39 @@ For code formatting guidelines please see [The Style Guide](https://github.com/p
 Standard Library File Naming
 ----------------
 For standard library file naming guidelines see [The Style Guide](https://github.com/ponylang/ponyc/blob/master/STYLE_GUIDE.md#naming).
+
+Source Code Coverage of Ponyc
+----------------
+
+To get C code coverage information for test runs or for calling ponyc, call `make` with `use=coverage config=debug`. This works both for *clang* and *gcc*. Make sure to configure `CC` and `CXX` environment variables both to either `gcc` and `g++` or `clang` and `clang++`.
+
+### Using gcc and lcov
+
+* Compile ponyc with `use=coverage config=debug` and environment variables `CC=gcc CXX=g++`
+* Run ponyc or the test suite from `build/debug-coverage`
+* generate the html coverage report:
+
+  ```
+  # generate coverage report
+  lcov --directory .build/debug-coverage/obj –zerocounters
+  lcov --directory .build/debug-coverage/obj --capture --output-file ponyc.info
+  genhtml -o build/debug-coverage/coverage ponyc.info
+  ```
+* open the html report at `build/debug-coverage/coverage/index.html`
+
+### Using clang and llvm-cov
+
+* Compile ponyc with `use=coverage config=debug` and environment variables `CC=clang CXX=clang++`
+* Run ponyc or the test suite from `build/debug-coverage` with environment variable: `LLVM_PROFILE_FILE="build/debug-coverage/coverage.profraw"`
+* generate coverage data:
+
+  ```
+  llvm-profdata merge -sparse -output=build/debug-coverage/coverage.profdata build/debug-coverage/coverage.profraw
+  ```
+
+* show coverage data (only for `lexer.c` in this case):
+
+  ```
+  llvm-cov show ./build/debug-coverage/libponyc.tests -instr-profile=./build/debug-coverage/coverage.profdata src/libponyc/ast/lexer.c 
+  ```
+

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,25 @@ ifdef use
     PONY_BUILD_DIR := $(PONY_BUILD_DIR)-valgrind
   endif
 
+  ifneq (,$(filter $(use), coverage))
+    ifneq (,$(shell $(CC) -v 2>&1 | grep clang))
+      # clang
+      COVERAGE_FLAGS = -O0 -fprofile-instr-generate -fcoverage-mapping
+      LINKER_FLAGS += -fprofile-instr-generate -fcoverage-mapping
+    else
+      ifneq (,$(shell $(CC) -v 2>&1 | grep "gcc version"))
+        # gcc
+        COVERAGE_FLAGS = -O0 -fprofile-arcs -ftest-coverage
+        LINKER_FLAGS += -fprofile-arcs
+      else
+        $(error coverage not supported for this compiler/platform)
+      endif
+      ALL_CFLAGS += $(COVERAGE_FLAGS)
+      ALL_CXXFLAGS += $(COVERAGE_FLAGS)
+    endif
+    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-coverage
+  endif
+
   ifneq (,$(filter $(use), pooltrack))
     ALL_CFLAGS += -DUSE_POOLTRACK
     PONY_BUILD_DIR := $(PONY_BUILD_DIR)-pooltrack
@@ -907,6 +926,7 @@ help:
 	@echo '   pooltrack'
 	@echo '   dtrace'
 	@echo '   actor_continuations'
+	@echo '   coverage'
 	@echo
 	@echo 'TARGETS:'
 	@echo '  libponyc               Pony compiler library'


### PR DESCRIPTION
from runs of ponyc or the test commands

both for gcc (using gcov and lcov) and for clang (using llvm-cov).

# gcc and gcov and lcov 

```bash
# compile ponyc
CC=gcc CXX="g++" make config=debug use=coverage

# run some test or ponyc
./build/debug-coverage/libponyc.tests --gtest_filter='LexerTest.*'

# generate coverage report
lcov --directory .build/debug-coverage/obj –zerocounters
lcov --directory .build/debug-coverage/obj --capture --output-file ponyc.info
genhtml -o build/debug-coverage/coverage ponyc.info

# open build/debug-coverage/coverage/index.html
```

# clang and llvm-cov

```bash
# compile ponyc for coverage
CC=clang CXX="clang++" VERBOSE=true make clean all config=debug use=coverage

# run the program for which you want to obtain coverage information
LLVM_PROFILE_FILE="build/debug-coverage/coverage.profraw" ./build/debug-coverage/libponyc.tests --gtest_filter='LexerTest.*'

# generate coverage data
llvm-profdata merge -sparse -output=build/debug-coverage/coverage.profdata build/debug-coverage/coverage.profraw

# show coverage data (only for lexer.c in this case)
llvm-cov show ./build/debug-coverage/libponyc.tests -instr-profile=./build/debug-coverage/coverage.profdata src/libponyc/ast/lexer.c 
```