### PR TITLE
Add the --simplebuiltin compiler option

### DIFF
--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -217,6 +217,7 @@ typedef struct pass_opt_t
   bool print_stats;
   bool verify;
   bool extfun;
+  bool simple_builtin;
   bool strip_debug;
   bool print_filenames;
   bool check_tree;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -50,6 +50,24 @@
 #  pragma warning(disable:4996)
 #endif
 
+
+static const char* simple_builtin =
+  "primitive Bool\n"
+  "  new create(a: Bool) => a\n"
+  "primitive U8 is Real[U8]\n"
+  "  new create(a: U8) => a\n"
+  "primitive U32 is Real[U32]\n"
+  "  new create(a: U32) => a\n"
+  "trait val Real[A: Real[A] val]\n"
+  "type Number is (U8 | U32)\n"
+  "primitive None\n"
+  "struct Pointer[A]\n"
+  "class val Env\n"
+  "  new _create(argc: U32, argv: Pointer[Pointer[U8]] val,\n"
+  "    envp: Pointer[Pointer[U8]] val)\n"
+  "  => None";
+
+
 // Per package state
 typedef struct package_t
 {
@@ -704,6 +722,10 @@ bool package_init(pass_opt_t* opt)
   }
 
   safe = full_safe;
+
+  if(opt->simple_builtin)
+    package_add_magic_src("builtin", simple_builtin);
+
   return true;
 }
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -53,11 +53,12 @@ enum
   OPT_VERIFY,
   OPT_FILENAMES,
   OPT_CHECKTREE,
+  OPT_EXTFUN,
+  OPT_SIMPLEBUILTIN,
 
   OPT_BNF,
   OPT_ANTLR,
-  OPT_ANTLRRAW,
-  OPT_EXTFUN
+  OPT_ANTLRRAW
 };
 
 static opt_arg_t args[] =
@@ -94,11 +95,12 @@ static opt_arg_t args[] =
   {"verify", '\0', OPT_ARG_NONE, OPT_VERIFY},
   {"files", '\0', OPT_ARG_NONE, OPT_FILENAMES},
   {"checktree", '\0', OPT_ARG_NONE, OPT_CHECKTREE},
+  {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
+  {"simplebuiltin", '\0', OPT_ARG_NONE, OPT_SIMPLEBUILTIN},
 
   {"bnf", '\0', OPT_ARG_NONE, OPT_BNF},
   {"antlr", '\0', OPT_ARG_NONE, OPT_ANTLR},
   {"antlrraw", '\0', OPT_ARG_NONE, OPT_ANTLRRAW},
-  {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
   OPT_ARGS_FINISH
 };
 
@@ -179,6 +181,7 @@ static void usage()
     "  --immerr        Report errors immediately rather than deferring.\n"
     "  --verify        Verify LLVM IR.\n"
     "  --extfun        Set function default linkage to external.\n"
+    "  --simplebuiltin Use a minimal builtin package.\n"
     "  --files         Print source file names as each is processed.\n"
     "  --bnf           Print out the Pony grammar as human readable BNF.\n"
     "  --antlr         Print out the Pony grammar as an ANTLR file.\n"
@@ -334,6 +337,7 @@ int main(int argc, char* argv[])
       case OPT_IMMERR: errors_set_immediate(opt.check.errors, true); break;
       case OPT_VERIFY: opt.verify = true; break;
       case OPT_EXTFUN: opt.extfun = true; break;
+      case OPT_SIMPLEBUILTIN: opt.simple_builtin = true; break;
       case OPT_FILENAMES: opt.print_filenames = true; break;
       case OPT_CHECKTREE: opt.check_tree = true; break;
 


### PR DESCRIPTION
This option forces the compiler to use a minimal builtin package instead of the real package. This is intended for debugging purposes only.