### PR TITLE
Bring treecheckdef up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -809,12 +809,12 @@ benchmark: all
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
-	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib
+	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
 	@./stdlib --sequential
 	@rm stdlib
 
 test-examples: all
-	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
+	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify examples
 	@./examples1
 	@rm examples1
 
@@ -822,13 +822,13 @@ test-ci: all
 	@$(PONY_BUILD_DIR)/ponyc --version
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests
-	@$(PONY_BUILD_DIR)/ponyc -d -s --verify packages/stdlib
+	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
 	@./stdlib --sequential
 	@rm stdlib
-	@$(PONY_BUILD_DIR)/ponyc --verify packages/stdlib
+	@$(PONY_BUILD_DIR)/ponyc --checktree --verify packages/stdlib
 	@./stdlib --sequential
 	@rm stdlib
-	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s examples
+	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify examples
 	@./examples1
 	@rm examples1
 	@$(PONY_BUILD_DIR)/ponyc --antlr > pony.g.new

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -217,6 +217,8 @@ static const lextoken_t keywords[] =
   { "$ifdefnot", TK_IFDEFNOT },
   { "$flag", TK_IFDEFFLAG },
   { "$let", TK_MATCH_CAPTURE },
+  { "$dontcare", TK_MATCH_DONTCARE },
+  { "$iftype", TK_IFTYPE },
 
   { NULL, (token_id)0 }
 };

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -20,6 +20,7 @@ DECL(annotatedrawseq);
 DECL(annotatedseq);
 DECL(exprseq);
 DECL(nextexprseq);
+DECL(jump);
 DECL(assignment);
 DECL(term);
 DECL(infix);
@@ -68,6 +69,7 @@ DEF(provides);
 DEF(defaultarg);
   PRINT_INLINE();
   SCOPE();
+  AST_NODE(TK_SEQ);
   RULE("default value", infix);
   DONE();
 
@@ -723,6 +725,7 @@ DEF(iftype);
   RULE("type", type);
   SKIP(NULL, TK_THEN);
   RULE("then value", seq);
+  AST_NODE(TK_NONE);
   DONE();
 
 // ELSEIF [annotations] iftype [elseiftype | (ELSE seq)]
@@ -883,7 +886,7 @@ DEF(test_try_block);
   TERMINATE("try expression", TK_END);
   DONE();
 
-// RECOVER [annotations] [CAP] rawseq END
+// RECOVER [annotations] [CAP] seq END
 DEF(recover);
   PRINT_INLINE();
   TOKEN(NULL, TK_RECOVER);
@@ -1007,7 +1010,6 @@ DEF(test_binop);
   INFIX_BUILD();
   TOKEN("binary operator", TK_IFDEFAND, TK_IFDEFOR);
   RULE("value", term);
-  OPT TOKEN(NULL, TK_NONE);
   DONE();
 
 // term {binop | isop | asop}

--- a/src/libponyc/ast/treecheckdef.h
+++ b/src/libponyc/ast/treecheckdef.h
@@ -45,7 +45,6 @@ RULE(ffidecl,
 
 RULE(class_def,
   IS_SCOPE  // name -> TYPEPARAM | FVAR | FVAL | EMBED | method
-  //HAS_DATA  // Type checking state
   CHILD(id)
   CHILD(type_params, none)
   CHILD(cap, none)
@@ -73,7 +72,7 @@ RULE(field,
 RULE(method,
   IS_SCOPE  // name -> TYPEPARAM | PARAM
   HAS_DATA  // Body donor type
-  CHILD(cap, none)
+  CHILD(cap, at, none)
   CHILD(id)
   CHILD(type_params, none)
   CHILD(params, none)
@@ -87,6 +86,7 @@ RULE(method,
 RULE(type_params, ONE_OR_MORE(type_param), TK_TYPEPARAMS);
 
 RULE(type_param,
+  HAS_DATA // Original typeparam definition
   CHILD(id)
   CHILD(type, none)   // Constraint
   CHILD(type, none),  // Default
@@ -95,7 +95,7 @@ RULE(type_param,
 RULE(type_args, ONE_OR_MORE(type), TK_TYPEARGS);
 
 RULE(params,
-  ONE_OR_MORE(param)
+  ZERO_OR_MORE(param)
   OPTIONAL(ellipsis),
   TK_PARAMS);
 
@@ -103,7 +103,7 @@ RULE(param,
   HAS_TYPE(type)
   CHILD(id, expr)
   CHILD(type, none)
-  CHILD(expr, none),
+  CHILD(seq, none),
   TK_PARAM);
 
 RULE(seq,
@@ -117,9 +117,15 @@ RULE(rawseq,
   ONE_OR_MORE(jump, intrinsic, compile_error, expr, semi),
   TK_SEQ);
 
+RULE(seq_or_rawseq,
+  MAYBE_SCOPE
+  HAS_TYPE(type)
+  ONE_OR_MORE(jump, intrinsic, compile_error, expr, semi),
+  TK_SEQ);
+
 RULE(jump,
   HAS_TYPE(type)
-  CHILD(rawseq, none),
+  CHILD(rawseq, this_ref, none),
   TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR);
 
 RULE(intrinsic,
@@ -133,26 +139,27 @@ RULE(compile_error,
   TK_COMPILE_ERROR);
 
 GROUP(expr,
-  local, infix, isop, assignop, asop, tuple, consume, recover, prefix, dot,
-  tilde, qualify, call, ffi_call, match_capture,
-  if_expr, ifdef, whileloop, repeat, for_loop, with, match, try_expr, lambda,
-  array_literal, object_literal, int_literal, float_literal, string,
-  bool_literal, id, rawseq, package_ref, location,
-  this_ref, ref, fun_ref, type_ref, field_ref, tuple_elem_ref, local_ref);
+  local, binop, isop, assignop, asop, tuple, consume, recover, prefix, dot,
+  tilde, chain, qualify, call, ffi_call, match_capture,
+  if_expr, ifdef, iftypeset, whileloop, repeat, for_loop, with, match, try_expr,
+  lambda, barelambda, array_literal, object_literal, int_literal, float_literal,
+  string, bool_literal, id, rawseq, package_ref, location,
+  this_ref, ref, fun_ref, type_ref, field_ref, tuple_elem_ref, local_ref,
+  param_ref);
 
 RULE(local,
   HAS_TYPE(type)
   CHILD(id)
   CHILD(type, none),
-  TK_LET, TK_VAR);
+  TK_LET, TK_VAR, TK_DONTCARE);
 
 RULE(match_capture,
   HAS_TYPE(type)
   CHILD(id)
   CHILD(type),
-  TK_MATCH_CAPTURE);
+  TK_MATCH_CAPTURE, TK_MATCH_DONTCARE);
 
-RULE(infix,
+RULE(binop,
   HAS_TYPE(type)
   CHILD(expr)
   CHILD(expr)
@@ -160,7 +167,7 @@ RULE(infix,
   TK_PLUS, TK_MINUS, TK_MULTIPLY, TK_DIVIDE, TK_MOD, TK_LSHIFT, TK_RSHIFT,
   TK_PLUS_TILDE, TK_MINUS_TILDE, TK_MULTIPLY_TILDE, TK_DIVIDE_TILDE,
   TK_MOD_TILDE, TK_LSHIFT_TILDE, TK_RSHIFT_TILDE,
-  TK_EQ, TK_NE, TK_LT, TK_LE, TK_GT, TK_GE, TK_IS, TK_ISNT,
+  TK_EQ, TK_NE, TK_LT, TK_LE, TK_GT, TK_GE,
   TK_EQ_TILDE, TK_NE_TILDE, TK_LT_TILDE, TK_LE_TILDE, TK_GT_TILDE, TK_GE_TILDE,
   TK_AND, TK_OR, TK_XOR);
 
@@ -207,7 +214,8 @@ RULE(prefix,
 RULE(dot,
   HAS_TYPE(type)
   CHILD(expr)
-  CHILD(id, int_literal, type_args),
+  CHILD(id, int_literal, type_args)
+  IF((CHILD_ID(0) == TK_THIS), HAS_DATA),
   TK_DOT);
 
 RULE(tilde,
@@ -215,6 +223,12 @@ RULE(tilde,
   CHILD(expr)
   CHILD(id),
   TK_TILDE);
+
+RULE(chain,
+  HAS_TYPE(type)
+  CHILD(expr)
+  CHILD(id),
+  TK_CHAIN);
 
 RULE(qualify,
   CHILD(expr)
@@ -239,7 +253,7 @@ RULE(ffi_call,
   CHILD(question, none),
   TK_FFICALL);
 
-RULE(positional_args, ONE_OR_MORE(rawseq), TK_POSITIONALARGS);
+RULE(positional_args, ZERO_OR_MORE(seq_or_rawseq), TK_POSITIONALARGS);
 
 RULE(named_args, ONE_OR_MORE(named_arg), TK_NAMEDARGS);
 
@@ -272,6 +286,22 @@ RULE(ifdef_not,
 RULE(ifdef_flag,
   CHILD(id),
   TK_IFDEFFLAG);
+
+RULE(iftypeset,
+  IS_SCOPE
+  HAS_TYPE(type)
+  CHILD(iftype) // Condition/then body
+  CHILD(seq, iftypeset, none), // Else body
+  TK_IFTYPE_SET);
+
+RULE(iftype,
+  IS_SCOPE
+  HAS_TYPE(type)
+  CHILD(type) // Subtype
+  CHILD(type) // Supertype
+  CHILD(seq) // Then body
+  CHILD(type_params, none),
+  TK_IFTYPE);
 
 RULE(if_expr,
   IS_SCOPE
@@ -328,6 +358,7 @@ RULE(cases,
 
 RULE(match_case,
   IS_SCOPE
+  HAS_TYPE(type)
   CHILD(expr, no_case_expr)
   CHILD(rawseq, none)   // Guard
   CHILD(rawseq, none),  // Body
@@ -352,7 +383,7 @@ RULE(lambda,
   CHILD(type, none) // Return
   CHILD(question, none)
   CHILD(rawseq)
-  CHILD(cap, none, question), // Type reference cap (? indicates old syntax)
+  CHILD(cap, none), // Type reference cap
   TK_LAMBDA);
 
 RULE(lambda_captures, ONE_OR_MORE(lambda_capture), TK_LAMBDACAPTURES);
@@ -362,6 +393,19 @@ RULE(lambda_capture,
   CHILD(type, none)
   CHILD(expr, none),
   TK_LAMBDACAPTURE);
+
+RULE(barelambda,
+  HAS_TYPE(type)
+  CHILD(at, none) // Receiver cap
+  CHILD(id, none)
+  CHILD(none) // Typeparams
+  CHILD(params, none)
+  CHILD(none) // Captures
+  CHILD(type, none) // Return
+  CHILD(question, none)
+  CHILD(rawseq)
+  CHILD(cap_val, none), // Type reference cap
+  TK_BARELAMBDA);
 
 RULE(array_literal,
   CHILD(type, none)
@@ -378,20 +422,23 @@ RULE(object_literal,
 RULE(ref,
   HAS_TYPE(type)
   CHILD(id),
-  TK_REFERENCE, TK_PARAMREF);
+  TK_REFERENCE);
 
 RULE(package_ref,
+  HAS_DATA // Package import
   CHILD(id),
   TK_PACKAGEREF);
 
 RULE(fun_ref,
   HAS_TYPE(type)
+  HAS_DATA // Method definition
   CHILD(expr)
   CHILD(id, type_args),
-  TK_FUNREF, TK_BEREF, TK_NEWREF, TK_NEWBEREF);
+  TK_FUNREF, TK_BEREF, TK_NEWREF, TK_NEWBEREF, TK_FUNCHAIN, TK_BECHAIN);
 
 RULE(type_ref,
   HAS_TYPE(type)
+  HAS_DATA // Type definition
   CHILD(package_ref, none)
   CHILD(id, none)
   CHILD(type_args, none),
@@ -399,6 +446,7 @@ RULE(type_ref,
 
 RULE(field_ref,
   HAS_TYPE(type)
+  HAS_DATA // Field definition
   CHILD(expr)
   CHILD(id),
   TK_FVARREF, TK_FLETREF, TK_EMBEDREF);
@@ -411,15 +459,22 @@ RULE(tuple_elem_ref,
 
 RULE(local_ref,
   HAS_TYPE(type)
+  HAS_DATA // Local definition
   CHILD(expr)
   OPTIONAL(id),
-  TK_VARREF, TK_LETREF);
+  TK_VARREF, TK_LETREF, TK_DONTCAREREF);
+
+RULE(param_ref,
+  HAS_TYPE(type)
+  HAS_DATA // Parameter definition
+  CHILD(id),
+  TK_PARAMREF);
 
 
 GROUP(type,
   type_infix, type_tuple, type_arrow, type_this, cap, nominal,
-  type_param_ref, dontcare_type, fun_type, error_type, lambda_type,
-  literal_type, opliteral_type, control_type);
+  type_param_ref, dontcare_type, fun_type, error_type, infer_type, lambda_type,
+  barelambda_type, literal_type, opliteral_type, control_type);
 
 RULE(type_infix, ONE_OR_MORE(type), TK_UNIONTYPE, TK_ISECTTYPE);
 
@@ -431,7 +486,7 @@ RULE(type_arrow,
   TK_ARROW);
 
 RULE(fun_type,
-  CHILD(cap)
+  CHILD(cap, at)
   CHILD(type_params, none)
   CHILD(params, none)
   CHILD(type, none), // Return type
@@ -447,6 +502,17 @@ RULE(lambda_type,
   CHILD(cap, gencap, none)  // Type reference cap
   CHILD(aliased, ephemeral, none),
   TK_LAMBDATYPE);
+
+RULE(barelambda_type,
+  CHILD(none) // Apply function cap
+  CHILD(id, none)
+  CHILD(none) // Typeparams
+  CHILD(type_list, none) // Params
+  CHILD(type, none) // Return type
+  CHILD(question, none)
+  CHILD(cap_val, none) // Type reference cap
+  CHILD(aliased, ephemeral, none),
+  TK_BARELAMBDATYPE);
 
 RULE(type_list, ONE_OR_MORE(type), TK_PARAMS);
 
@@ -471,12 +537,14 @@ RULE(at, LEAF, TK_AT);
 RULE(bool_literal, HAS_TYPE(type), TK_TRUE, TK_FALSE);
 RULE(aliased, LEAF, TK_ALIASED);
 RULE(cap, LEAF, TK_ISO, TK_TRN, TK_REF, TK_VAL, TK_BOX, TK_TAG);
+RULE(cap_val, LEAF, TK_VAL);
 RULE(control_type, LEAF, TK_IF, TK_CASES, TK_COMPILE_INTRINSIC,
   TK_COMPILE_ERROR, TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR);
 RULE(dontcare_type, LEAF, TK_DONTCARETYPE);
 RULE(ellipsis, LEAF, TK_ELLIPSIS);
 RULE(ephemeral, LEAF, TK_EPHEMERAL);
 RULE(error_type, LEAF, TK_ERRORTYPE);
+RULE(infer_type, LEAF, TK_INFERTYPE);
 RULE(float_literal, HAS_TYPE(type), TK_FLOAT);
 RULE(gencap, LEAF, TK_CAP_READ, TK_CAP_SEND, TK_CAP_SHARE, TK_CAP_ALIAS,
   TK_CAP_ANY);

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -245,7 +245,7 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
   if(!pass_finalisers(*astp, options))
     return false;
 
-  if (!pass_serialisers(*astp, options))
+  if(!pass_serialisers(*astp, options))
     return false;
 
   if(options->check_tree)

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -203,7 +203,7 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_IFTYPE);
 
-  AST_GET_CHILDREN(ast, subtype, supertype);
+  AST_GET_CHILDREN(ast, subtype, supertype, body, typeparam_store);
 
   ast_t* typeparams = ast_from(ast, TK_TYPEPARAMS);
 
@@ -284,7 +284,8 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
   // We don't want the scope pass to run on typeparams. The compiler would think
   // that type parameters are declared twice.
   ast_pass_record(typeparams, PASS_SCOPE);
-  ast_append(ast, typeparams);
+  pony_assert(ast_id(typeparam_store) == TK_NONE);
+  ast_replace(&typeparam_store, typeparams);
   return AST_OK;
 }
 

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1165,7 +1165,7 @@ static ast_result_t sugar_location(pass_opt_t* opt, ast_t** astp)
   ast_t* ast = *astp;
   pony_assert(ast != NULL);
 
-  if(ast_id(ast_parent(ast)) == TK_PARAM)
+  if(ast_id(ast_parent(ast_parent(ast))) == TK_PARAM)
     // Location is a default argument, do not expand yet.
     return AST_OK;
 

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -385,6 +385,7 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
   {
     ast_set_name(doc, "");
     ast_setid(doc, TK_NONE);
+    ast_settype(doc, NULL);
   }
 
   ast_t* local = ast_append(ast_childidx(entity, 4), basis_method);

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -25,7 +25,9 @@ static void cond_normalise(ast_t** astp)
     {
       ast_setid(ast, TK_IFDEFAND);
 
-      AST_GET_CHILDREN(ast, left, right);
+      AST_GET_CHILDREN(ast, left, right, question);
+      pony_assert(ast_id(question) == TK_NONE);
+      ast_remove(question);
       cond_normalise(&left);
       cond_normalise(&right);
       break;
@@ -35,7 +37,9 @@ static void cond_normalise(ast_t** astp)
     {
       ast_setid(ast, TK_IFDEFOR);
 
-      AST_GET_CHILDREN(ast, left, right);
+      AST_GET_CHILDREN(ast, left, right, question);
+      pony_assert(ast_id(question) == TK_NONE);
+      ast_remove(question);
       cond_normalise(&left);
       cond_normalise(&right);
       break;
@@ -70,10 +74,8 @@ static void cond_normalise(ast_t** astp)
           NODE(TK_IFDEFOR,
             NODE(TK_IFDEFOR,
               NODE(TK_IFDEFFLAG, ID(OS_LINUX_NAME))
-              NODE(TK_IFDEFFLAG, ID(OS_MACOSX_NAME))
-              NODE(TK_NONE))
-            NODE(TK_IFDEFFLAG, ID(OS_BSD_NAME))
-            NODE(TK_NONE)));
+              NODE(TK_IFDEFFLAG, ID(OS_MACOSX_NAME)))
+            NODE(TK_IFDEFFLAG, ID(OS_BSD_NAME))));
         break;
       }
 

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -66,16 +66,19 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
 
             if((ast_id(def_arg) != TK_NONE) && (ast_type(def_arg) == NULL))
             {
-              ast_settype(def_arg, ast_from(def_arg, TK_INFERTYPE));
+              ast_t* child = ast_child(def_arg);
+
+              if(ast_id(child) == TK_CALL)
+                ast_settype(child, ast_from(child, TK_INFERTYPE));
 
               if(ast_visit_scope(&param, pass_pre_expr, pass_expr, opt,
                 PASS_EXPR) != AST_OK)
-                return false;
+                return NULL;
 
               def_arg = ast_childidx(param, 2);
 
               if(!coerce_literals(&def_arg, type, opt))
-                return false;
+                return NULL;
             }
 
             param = ast_sibling(param);

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -179,6 +179,7 @@ static void usage()
     "  --width, -w     Width to target when printing the AST.\n"
     "    =columns      Defaults to the terminal width.\n"
     "  --immerr        Report errors immediately rather than deferring.\n"
+    "  --checktree     Verify AST well-formedness.\n"
     "  --verify        Verify LLVM IR.\n"
     "  --extfun        Set function default linkage to external.\n"
     "  --simplebuiltin Use a minimal builtin package.\n"

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -241,6 +241,7 @@ void PassTest::SetUp()
   package_clear_magic();
   package_suppress_build_message();
   opt.verbosity = VERBOSITY_QUIET;
+  opt.check_tree = true;
   last_pass = PASS_PARSE;
 }
 

--- a/wscript
+++ b/wscript
@@ -349,7 +349,7 @@ def test(ctx):
 
     ctx(
         features = 'seq',
-        rule     = os.path.join(ctx.bldnode.abspath(), 'ponyc') + ' -d -s ../../packages/stdlib',
+        rule     = os.path.join(ctx.bldnode.abspath(), 'ponyc') + ' -d -s --checktree --verify ../../packages/stdlib',
         target   = stdlibTarget,
         source   = ctx.bldnode.ant_glob('ponyc*') + ctx.path.ant_glob('packages/**/*.pony'),
     )


### PR DESCRIPTION
This change updates the AST checking pass in `treecheckdef.h` with the newer language constructs and fixes some discrepancies with existing constructs.

The AST checking pass is now enabled in the compiler and standard library tests.

Closes #2240.