### PR TITLE
Fix codegen failure on field access

### DIFF
--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1302,6 +1302,9 @@ static void reachable_expr(reach_t* r, ast_t* ast, pass_opt_t* opt)
 
     case TK_LET:
     case TK_VAR:
+    case TK_FLETREF:
+    case TK_FVARREF:
+    case TK_EMBEDREF:
     case TK_TUPLE:
     {
       ast_t* type = ast_type(ast);

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -299,6 +299,23 @@ TEST_F(CodegenTest, UnionOfTuplesToTuple)
 }
 
 
+TEST_F(CodegenTest, ViewpointAdaptedFieldReach)
+{
+  // From issue #2238
+  const char* src =
+    "class A\n"
+    "class B\n"
+    "  var f: (A | None) = None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let l = B\n"
+    "    l.f = A";
+
+  TEST_COMPILE(src);
+}
+
+
 TEST_F(CodegenTest, CustomSerialization)
 {
   const char* src =


### PR DESCRIPTION
This fixes a bug occurring when accessing a field with a viewpoint-adapted type that wasn't being reached.

Closes #2238.