### PR TITLE
Fix serialisation of Array and String

### DIFF
--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -782,7 +782,7 @@ void genprim_array_serialise_trace(compile_t* c, reach_type_t* t)
   LLVMBasicBlockRef post_block = codegen_block(c, "post");
 
   LLVMValueRef cond = LLVMBuildICmp(c->builder, LLVMIntNE, size,
-    LLVMConstInt(c->intptr, 0, false), "");
+    LLVMConstInt(c->intptr, PONY_TRACE_OPAQUE, false), "");
   LLVMBuildCondBr(c->builder, cond, trace_block, post_block);
 
   LLVMPositionBuilderAtEnd(c->builder, trace_block);
@@ -1048,7 +1048,7 @@ void genprim_string_serialise_trace(compile_t* c, reach_type_t* t)
   LLVMBasicBlockRef post_block = codegen_block(c, "post");
 
   LLVMValueRef cond = LLVMBuildICmp(c->builder, LLVMIntNE, size,
-    LLVMConstInt(c->intptr, 0, false), "");
+    LLVMConstInt(c->intptr, PONY_TRACE_OPAQUE, false), "");
   LLVMBuildCondBr(c->builder, cond, trace_block, post_block);
 
   LLVMPositionBuilderAtEnd(c->builder, trace_block);

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -316,6 +316,34 @@ TEST_F(CodegenTest, ViewpointAdaptedFieldReach)
 }
 
 
+TEST_F(CodegenTest, StringSerialization)
+{
+  // From issue 2245
+  const char* src =
+    "use \"serialise\"\n"
+
+    "class V\n"
+    "  let _v: String = \"\"\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      let auth = env.root as AmbientAuth\n"
+    "      let v: V = V\n"
+    "      Serialised(SerialiseAuth(auth), v)?\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  set_builtin(NULL);
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
 TEST_F(CodegenTest, CustomSerialization)
 {
   const char* src =


### PR DESCRIPTION
This change fixes a bug in `Array/String_Serialise_Trace` where the data pointer would be traced for immutable and opaque objects, instead of mutable and immutable ones.

Closes #2245.