### PR TITLE
Fix empty string serialisation

### DIFF
--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -1044,15 +1044,6 @@ void genprim_string_serialise_trace(compile_t* c, reach_type_t* t)
 
   LLVMValueRef size = field_value(c, object, 1);
 
-  LLVMBasicBlockRef trace_block = codegen_block(c, "trace");
-  LLVMBasicBlockRef post_block = codegen_block(c, "post");
-
-  LLVMValueRef cond = LLVMBuildICmp(c->builder, LLVMIntNE, size,
-    LLVMConstInt(c->intptr, 0, false), "");
-  LLVMBuildCondBr(c->builder, cond, trace_block, post_block);
-
-  LLVMPositionBuilderAtEnd(c->builder, trace_block);
-
   LLVMValueRef alloc = LLVMBuildAdd(c->builder, size,
     LLVMConstInt(c->intptr, 1, false), "");
 
@@ -1064,10 +1055,6 @@ void genprim_string_serialise_trace(compile_t* c, reach_type_t* t)
   args[1] = ptr;
   args[2] = alloc;
   gencall_runtime(c, "pony_serialise_reserve", args, 3, "");
-
-  LLVMBuildBr(c->builder, post_block);
-
-  LLVMPositionBuilderAtEnd(c->builder, post_block);
 
   LLVMBuildRetVoid(c->builder);
   codegen_finishfun(c);

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -316,6 +316,34 @@ TEST_F(CodegenTest, ViewpointAdaptedFieldReach)
 }
 
 
+TEST_F(CodegenTest, StringSerialization)
+{
+  // From issue 2245
+  const char* src =
+    "use \"serialise\"\n"
+
+    "class V\n"
+    "  let _v: String = \"\"\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      let auth = env.root as AmbientAuth\n"
+    "      let v: V = V\n"
+    "      Serialised(SerialiseAuth(auth), v)?\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  set_builtin(NULL);
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}
+
+
 TEST_F(CodegenTest, CustomSerialization)
 {
   const char* src =


### PR DESCRIPTION
This commit fixes a bug in how empty strings are serialised.

Resolves #2245.

----------

This PR is based on @Praetonus's PR #2246 and includes the codegen test he added. It is an implementation of the diff I suggested in my comment on that PR.