### PR TITLE
Fix implicit fallthrough in array inference.

### DIFF
--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -150,6 +150,7 @@ static void find_possible_element_types(pass_opt_t* opt, ast_t* ast,
 
       // Note this as a possible element type and move on.
       *list = astlist_push(*list, elem_type);
+      return;
     }
 
     case TK_ARROW:
@@ -189,8 +190,8 @@ static void find_possible_iterator_element_types(pass_opt_t* opt, ast_t* ast,
       if(stringtab("Iterator") == ast_name(name))
       {
         *list = astlist_push(*list, ast_child(typeargs));
-        return;
       }
+      return;
     }
 
     case TK_ARROW:


### PR DESCRIPTION
Without these returns, these switches fail to compile on a Debian system with gcc 7.2.0 because of `-Werror=implicit-fallthrough`.  I didn't spend any time scrutinizing this part of the code to determine if the fallthroughs were intentional, and it's possible that there's something strange about my setup that causes this to be a problem, but I figured the best course of action was just to open a PR and see what happens.

I don't think it makes a difference, but the command I used to build was:
```
make config=release prefix=$HOME/lib/pony all install
```