### PR TITLE
WIP - Treat cycle detector like normal actor

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -206,7 +206,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
 
   while((msg = ponyint_messageq_pop(&actor->q)) != NULL)
   {
-    if(handle_message(ctx, actor, msg))
+    if(handle_message(ctx, actor, msg) && !ponyint_is_cycle(actor))
     {
       // If we handle an application message, try to gc.
       app++;

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -311,26 +311,6 @@ static void run(scheduler_t* sched)
         DTRACE2(ACTOR_DESCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
         actor = next;
         DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
-      } else if(ponyint_is_cycle(actor)) {
-        // If all we have is the cycle detector, try to steal something else to
-        // run as well.
-        next = steal(sched, actor);
-
-        if(next == NULL)
-        {
-          // Termination.
-          DTRACE2(ACTOR_DESCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
-          return;
-        }
-
-        // Push the cycle detector and run the actor we stole.
-        if(actor != next)
-        {
-          push(sched, actor);
-          DTRACE2(ACTOR_DESCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
-          actor = next;
-          DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
-        }
       }
     } else {
       // We aren't rescheduling, so run the next actor. This may be NULL if our


### PR DESCRIPTION
see #2255.

@jonbrwn could you try running wallaroo pony marketspread against this branch **without** `--pony-no-block` and see how it performs compared to what we expect. I'm hoping this change will address the memory growth we see at high levels of load.