### PR TITLE
Fix small chunk finaliser bug

### DIFF
--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -81,8 +81,9 @@ static void final_small(chunk_t* chunk, uint32_t mark)
   uint64_t bit = 0;
 
   // if there's a finaliser to run for a used slot
-  while((finalisers != 0) && (0 != (bit = __pony_ctzl(finalisers))))
+  while(finalisers != 0)
   {
+    bit = __pony_ctzl(finalisers);
     p = chunk->m + (bit << HEAP_MINBITS);
 
     // run finaliser
@@ -108,8 +109,9 @@ static void final_small_freed(chunk_t* chunk)
   uint64_t bit = 0;
 
   // if there's a finaliser to run for a used slot
-  while((finalisers != 0) && (0 != (bit = __pony_ctzl(finalisers))))
+  while(finalisers != 0)
   {
+    bit = __pony_ctzl(finalisers);
     p = chunk->m + (bit << HEAP_MINBITS);
 
     // run finaliser
@@ -126,6 +128,7 @@ static void final_large(chunk_t* chunk, uint32_t mark)
   if(chunk->finalisers == 1)
   {
     // run finaliser
+    pony_assert((*(pony_type_t**)chunk->m)->final != NULL);
     (*(pony_type_t**)chunk->m)->final(chunk->m);
     chunk->finalisers = 0;
   }

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -145,6 +145,44 @@ TEST_F(CodegenTest, BoxBoolAsUnionIntoTuple)
 extern "C"
 {
 
+uint32_t num_objects = 0;
+
+EXPORT_SYMBOL void codegentest_small_finalisers_increment_num_objects() {
+  num_objects++;
+  pony_exitcode(num_objects);
+}
+
+}
+
+
+TEST_F(CodegenTest, SmallFinalisers)
+{
+  const char* src =
+    "use \"collections\"\n"
+
+    "class _Final\n"
+    "  fun _final() =>\n"
+    "    @codegentest_small_finalisers_increment_num_objects[None]()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    for i in Range[I32](0, 42) do\n"
+    "      _Final\n"
+    "    end\n";
+
+  set_builtin(NULL);
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 42);
+}
+
+
+extern "C"
+{
+
 typedef int (*codegentest_ccallback_fn)(void* self, int value);
 
 EXPORT_SYMBOL int codegentest_ccallback(void* self, codegentest_ccallback_fn cb,


### PR DESCRIPTION
Prior to this commit there was a bug which prevented the finaliser
from running for the first slot of a small `chunk` in an actors
`heap`. This would result in incorrect behavior but only on a subset
of all objects created depending on which slot in a small chunk the
object happened to occupy.

This commit fixes this issue and also adds a test to catch the
issue to prevent regression.

---------

This bugfix is the last remaining hurdle preventing completion of WallarooLabs/wallaroo/issues/1605