### PR TITLE
Replace memory-leak-inciting `Writer.reserve` with more intuitive `Writer.reserve_current` method.

### DIFF
--- a/packages/buffered/writer.pony
+++ b/packages/buffered/writer.pony
@@ -67,11 +67,11 @@ class Writer
     """
     _chunks.reserve(size')
 
-  fun ref reserve(size': USize) =>
+  fun ref reserve_current(size': USize) =>
     """
-    Reserve space for size additional bytes.
+    Reserve space for size bytes in `_current`.
     """
-    _current.undefined(_current.size() + size')
+    _check(size')
 
   fun size(): USize =>
     _size


### PR DESCRIPTION
Prior to this commit, multiple calls to `Writer.reserve` would
allocate more and more memory in `_current` even if a sufficient
amount of unused memory was already available and allocated in
`_current`.

This commit changes the logic in `reserve` to call `_check` as
that has similar logic to confirm/reserve memory required but
without the memory leak.

----------------

For context:

We had a piece of code with a memory leak related to `Writer.reserve` calls. Removing the calls removed the leak. We were calling `Writer.reserve` right after `create` and `Writer.done` and then filling the `Writer` using `Writer.write` in between. This resulted in a memory leak because `Writer.write` doesn't use `_current` and `Writer.done` doesn't change/reallocate `_current` if there was no data written to it. As a result, over time, multiple `Writer.reserve`/`Writer.write`/`Writer.done` cycles resulted in the memory leak because `Writer.reserve` would continually add more memory to `_current` even though it already had enough unused space already allocated. This PR corrects the memory leak.

----------------

Note: I wasn't able to think of a good test to add to `_test.pony` to prevent a regression because `_current` is hidden behind the `Writer` interface and there is no way to inspect it directly. I'd appreciate any ideas regarding adding a test to prevent a regression.