### PR TITLE
Don't verify partial calls for method bodies inherited from a trait.

### DIFF
--- a/src/libponyc/verify/call.c
+++ b/src/libponyc/verify/call.c
@@ -41,7 +41,7 @@ static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
     )
     skip_partial_check = true;
 
-  // If the method definition containinf the call site had its body inherited
+  // If the method definition containing the call site had its body inherited
   // from a trait, we don't want to check partiality of the call site here -
   // it should only be checked in the context of the original trait.
   ast_t* body_donor = (ast_t*)ast_data(opt->check.frame->method);

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -639,6 +639,25 @@ TEST_F(VerifyTest, PartialSugaredBinaryOperatorCall)
   TEST_COMPILE(src);
 }
 
+TEST_F(VerifyTest, PartialTraitCall)
+{
+  // From issue #2228
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let b = B\n"
+
+    "trait A\n"
+    "  fun a1() ?\n"
+    "  fun a2() ? => a1()?\n"
+
+    "class B is A\n"
+    "  fun a1() =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(VerifyTest, LambdaTypeGenericAliased)
 {
   const char* src =


### PR DESCRIPTION
Resolves #2228.