### PR TITLE
Forbid single '_' in case expr and case methods

### DIFF
--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -107,6 +107,11 @@ static bool is_match_exhaustive(pass_opt_t* opt, ast_t* expr_type, ast_t* cases)
     AST_GET_CHILDREN(c, case_expr, guard, case_body);
     ast_t* pattern_type = ast_type(c);
 
+    // if any case is a `_` we have an exhaustive match
+    // and we can shortcut here
+    if(ast_id(case_expr) == TK_DONTCAREREF)
+      return true;
+
     // Only cases with no guard clause can count toward exhaustive match,
     // because the truth of a guard clause can't be statically evaluated.
     // So, for the purposes of exhaustive match, we ignore those cases.
@@ -429,6 +434,13 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
   {
     ast_error(opt->check.errors, ast,
       "can't have a case with no conditions, use an else clause");
+    return false;
+  }
+
+  if((ast_id(pattern) == TK_DONTCAREREF))
+  {
+    ast_error(opt->check.errors, pattern,
+      "can't have a case with `_` only, use an else clause");
     return false;
   }
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -52,7 +52,7 @@ static bool check_provides(pass_opt_t* opt, ast_t* type, ast_t* provides,
 
 static bool is_legal_dontcare_read(ast_t* ast)
 {
-  // We either are the LHS of an assignment or a tuple element. That tuple must
+  // We either are the LHS of an assignment, a case expr or a tuple element. That tuple must
   // either be a pattern or the LHS of an assignment. It can be embedded in
   // other tuples, which may appear in sequences.
 
@@ -70,7 +70,16 @@ static bool is_legal_dontcare_read(ast_t* ast)
         return true;
       return false;
     }
-
+    case TK_CASE:
+    {
+      // we have a single `_` as case pattern
+      // which is actually forbidden in favor for the else clause
+      // but it is referentially legal
+      AST_GET_CHILDREN(parent, case_pattern);
+      if(case_pattern == ast)
+        return true;
+      return false;
+    }
     case TK_TUPLE:
     {
       ast_t* grandparent = ast_parent(parent);

--- a/src/libponyc/pass/casemethod.c
+++ b/src/libponyc/pass/casemethod.c
@@ -265,7 +265,15 @@ static ast_t* process_params(ast_t* match_params, ast_t* case_params,
   {
     AST_GET_CHILDREN(case_param, id, type, def_arg);
 
-    if(ast_id(type) != TK_NONE)
+    if ((ast_childcount(case_params) == 1)
+        && (ast_id(id) == TK_REFERENCE)
+        && (is_name_dontcare(ast_name(ast_child(id)))))
+    {
+      ast_error(opt->check.errors, case_param,
+        "can't have '_' as single parameter in a case method");
+      ok = false;
+    }
+    else if(ast_id(type) != TK_NONE)
     {
       // We have a parameter.
       if(!param_with_type(case_param, match_param, pattern, opt))
@@ -763,6 +771,8 @@ static bool sugar_case_method(ast_t* first_case_method, ast_t* members,
       // This method is in the case set.
       ast_t* case_ast = add_case_method(wrapper, p, opt);
 
+      ast_setid(p, TK_NONE);  // Mark for removal, even in case of errors.
+
       if(case_ast == NULL)
       {
         ast_free(wrapper);
@@ -771,7 +781,6 @@ static bool sugar_case_method(ast_t* first_case_method, ast_t* members,
       }
 
       ast_append(match_cases, case_ast);
-      ast_setid(p, TK_NONE);  // Mark for removal.
     }
   }
 

--- a/test/libponyc/dontcare.cc
+++ b/test/libponyc/dontcare.cc
@@ -176,3 +176,25 @@ TEST_F(DontcareTest, CannotUseDontcareAsFunctionArgument)
 
   TEST_ERRORS_1(src, "can't read from '_'");
 }
+
+TEST_F(DontcareTest, CannotUseDontcareInCaseExpression)
+{
+  const char* src =
+    "class C\n"
+    "  fun c_ase(x: I32): I32 =>\n"
+    "    match x\n"
+    "      | let x1: I32 => -1\n"
+    "      | _ => 42\n"
+    "    end";
+  TEST_ERRORS_1(src, "can't have a case with `_` only, use an else clause");
+}
+
+TEST_F(DontcareTest, CannotUseDontcareInCaseMethod)
+{
+    const char* src =
+      "class C\n"
+      "  fun case_function(x: I32): I32 => -1\n"
+      "  fun case_function(_): I32 => 42\n";
+    TEST_ERRORS_1(src, "can't have '_' as single parameter in a case method");
+}
+

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -2395,12 +2395,12 @@ TEST_F(SugarTest, CaseFunctionDocStringMerge)
         "    exit case\n"
         "    \"\"\"\n"
         "    0\n"
-        "  fun with_docstring(a : U64): U64 if a > 1 =>\n"
+        "  fun with_docstring(a : U64): U64 if a > 4 =>\n"
         "    \"\"\"\n"
-        "    bigger than one\n"
+        "    bigger than four\n"
         "    \"\"\"\n"
         "    a-1\n"
-        "  fun with_docstring(_): U64 =>\n"
+        "  fun with_docstring(2): U64 =>\n"
         "    \"\"\"\n"
         "    dont care\n"
         "    \"\"\"\n"
@@ -2437,10 +2437,10 @@ TEST_F(SugarTest, CaseFunctionDocStringMerge)
       "`with_docstring(0): U64`: exit case\n"
       "\n"
       "\n"
-      "`with_docstring(a: U64): U64`: bigger than one\n"
+      "`with_docstring(a: U64): U64`: bigger than four\n"
       "\n"
       "\n"
-      "`with_docstring(_): U64`: dont care\n");
+      "`with_docstring(2): U64`: dont care\n");
 }
 
 


### PR DESCRIPTION
as the else clause is equivalent. Error messages for case expr tell users to use an else clause.
For case methods there is no equivalent, but this has not been workin before anyways.

This fixes a part of #2253 