### PR TITLE
DTrace actor additions

### DIFF
--- a/examples/dtrace/gc.d
+++ b/examples/dtrace/gc.d
@@ -1,6 +1,7 @@
 #!/usr/bin/env dtrace -s
 
 #pragma D option quiet
+#pragma D option dynvarsize=64m
 
 pony$target:::gc-start
 {
@@ -9,9 +10,11 @@ pony$target:::gc-start
 }
 
 pony$target:::gc-end
+/self->start_gc != 0/
 {
   @quant["Time in GC (ns)"] = quantize(timestamp - self->start_gc);
   @times["Total time"] = sum(timestamp - self->start_gc);
+  self->start_gc = 0;
 }
 
 END

--- a/examples/dtrace/mbox-size.d
+++ b/examples/dtrace/mbox-size.d
@@ -1,0 +1,33 @@
+#!/usr/bin/env dtrace -s
+
+#pragma D option quiet
+
+/*
+ * This script only tracks user actor -> user actor messages.
+ * Messages such as ACTORMSG_ACK and ACTORMSG_CONF (see telemetry.d)
+ * aren't caused directly by Pony code that is visible to the
+ * programmer.  Invisible system messages are detected with the
+ * 0xffffff00 mask.
+ */
+
+pony$target:::actor-msg-send
+/(arg1 & 0xffffff00)!= 0xffffff00/
+{
+  @in[arg3] = count();
+}
+
+pony$target:::actor-msg-run
+{
+  @out[arg1] = count();
+}
+
+tick-1sec
+{
+  printf("Into mbox (actor-msg-send):\n");
+  printa(@in);
+  clear(@in);
+  printf("Out of mbox (actor-msg-run):\n");
+  printa(@out);
+  clear(@out);
+  printf("\n");
+}

--- a/examples/dtrace/message-types.d
+++ b/examples/dtrace/message-types.d
@@ -1,0 +1,15 @@
+#!/usr/bin/env dtrace -s
+
+#pragma D option quiet
+
+pony$target:::actor-msg-send
+{
+  @type[arg1] = count();
+}
+
+tick-1sec
+{
+  printa(@type);
+  clear(@type);
+  printf("\n");
+}

--- a/examples/dtrace/nanosleep.d
+++ b/examples/dtrace/nanosleep.d
@@ -1,0 +1,15 @@
+#!/usr/bin/env dtrace -s
+
+#pragma D option quiet
+
+pony$target:::cpu-nanosleep
+{
+  @sleep[cpu] = quantize(arg0 / 1000);
+}
+
+tick-1sec
+{
+  printf("nanosleep call times, in microseconds, per CPU\n");
+  printa(@sleep);
+  clear(@sleep);
+}

--- a/src/common/dtrace_probes.d
+++ b/src/common/dtrace_probes.d
@@ -1,14 +1,19 @@
 provider pony {
   /**
    * Fired when a actor is being created
+   * @param scheduler is the scheduler that created the actor
+   * @actor is the actor that was created
    */
-  probe actor__alloc(uintptr_t scheduler);
+  probe actor__alloc(uintptr_t scheduler, uintptr_t actor);
 
   /**
    * Fired when a message is being send
+   * @param scheduler is the active scheduler
    * @param id the message id
+   * @param actor_from is the sending actor
+   * @param actor_to is the receiving actor
    */
-  probe actor__msg__send(uintptr_t scheduler, uint32_t id);
+  probe actor__msg__send(uintptr_t scheduler, uint32_t id, uintptr_t actor_from, uintptr_t actor_to);
 
   /**
    * Fired when a message is being run by an actor


### PR DESCRIPTION
Hi, everyone.  I'm a Pony newbie.  I tried using Pony's DTrace probes for understanding a behavior problem inside of Wallaroo and found that a couple of probe descriptions had omitted some useful information.  This PR contains changes to a couple of existing DTrace probe definitions, a change to the `gc.d` script, and add several new scripts.

### Changes to existing DTrace probe definitions

The `actor-alloc` and `actor-msg-send` probes were missing information about the actor(s) involved with the probe.  I added actor information to the end of their respective argument lists.

### Enhance the gc.d script

The `gc.d` script was leaking memory by not clearing the `self->start_gc` variable.  I also added a pragma to reduce the number of error messages that I saw, casued by the small default dynamic variable buffer size.

### Add new scripts

Driven equally by sheer curiosity and by a real investigation need, I've created a few new scripts.

* `mbox-size.d` Show the number of messages sent to an actor and consumed by an actor.  Reports are printed in one second time intervals. This has been useful for testing theories of about how a slow actor's mailbox size might grow over time.

* `message-types.d` Enumerate the runtime's unique types of messages (usually called `msg->id` in the Pony runtime code) and how messages of each type was sent.  Reports are printed in one second time intervals.

* `nanosleep.d` Print a histogram of the length of time (in microseconds) for calls to `nanosleep()` or equivalent.  Reports are printed in one second time intervals, with separate reports for each CPU.