### PR TITLE
Implement RFC 47 (Serialise signature)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,13 +349,16 @@ libgtest.files := $(libgtest.dir)/gtest-all.cc
 libgbenchmark := $(lib)
 libgbenchmark.dir := lib/gbenchmark
 libgbenchmark.files := $(libgbenchmark.dir)/gbenchmark_main.cc $(libgbenchmark.dir)/gbenchmark-all.cc
+libblake2 := $(lib)
+libblake2.dir := lib/blake2
+libblake2.files := $(libblake2.dir)/blake2b-ref.c
 
 # We don't add libponyrt here. It's a special case because it can be compiled
 # to LLVM bitcode.
 ifeq ($(OSTYPE), linux)
-  libraries := libponyc libponyrt-pic libgtest libgbenchmark
+  libraries := libponyc libponyrt-pic libgtest libgbenchmark libblake2
 else
-  libraries := libponyc libgtest libgbenchmark
+  libraries := libponyc libgtest libgbenchmark libblake2
 endif
 
 # Third party, but prebuilt. Prebuilt libraries are defined as
@@ -403,7 +406,8 @@ benchmarks := libponyc.benchmarks libponyrt.benchmarks
 
 # Define include paths for targets if necessary. Note that these include paths
 # will automatically apply to the test suite of a target as well.
-libponyc.include := -I src/common/ -I src/libponyrt/ $(llvm.include)
+libponyc.include := -I src/common/ -I src/libponyrt/ $(llvm.include) \
+  -isystem lib/blake2
 libponycc.include := -I src/common/ $(llvm.include)
 libponyrt.include := -I src/common/ -I src/libponyrt/
 libponyrt-pic.include := $(libponyrt.include)
@@ -420,6 +424,7 @@ libponyrt.benchmarks.include := -I src/common/ -I src/libponyrt/ -isystem \
 ponyc.include := -I src/common/ -I src/libponyrt/ $(llvm.include)
 libgtest.include := -isystem lib/gtest/
 libgbenchmark.include := -isystem lib/gbenchmark/include/
+libblake2.include := -isystem lib/blake2/
 
 ifneq (,$(filter $(OSTYPE), osx bsd))
   libponyrt.include += -I /usr/local/include
@@ -482,13 +487,14 @@ endif
 # target specific disabling of build options
 libgtest.disable = -Wconversion -Wno-sign-conversion -Wextra
 libgbenchmark.disable = -Wconversion -Wno-sign-conversion -Wextra
+libblake2.disable = -Wconversion -Wno-sign-conversion -Wextra
 
 # Link relationships.
-ponyc.links = libponyc libponyrt llvm
-libponyc.tests.links = libgtest libponyc llvm
+ponyc.links = libponyc libponyrt llvm libblake2
+libponyc.tests.links = libgtest libponyc llvm libblake2
 libponyc.tests.links.whole = libponyrt
 libponyrt.tests.links = libgtest libponyrt
-libponyc.benchmarks.links = libgbenchmark libponyc libponyrt llvm
+libponyc.benchmarks.links = libblake2 libgbenchmark libponyc libponyrt llvm
 libponyrt.benchmarks.links = libgbenchmark libponyrt
 
 ifeq ($(OSTYPE),linux)
@@ -523,7 +529,7 @@ all: $(targets)
 	@:
 
 # Dependencies
-libponyc.depends := libponyrt
+libponyc.depends := libponyrt libblake2
 libponyc.tests.depends := libponyc libgtest
 libponyrt.tests.depends := libponyrt libgtest
 libponyc.benchmarks.depends := libponyc libgbenchmark

--- a/lib/blake2/blake2-impl.h
+++ b/lib/blake2/blake2-impl.h
@@ -1,0 +1,160 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+#ifndef BLAKE2_IMPL_H
+#define BLAKE2_IMPL_H
+
+#include <stdint.h>
+#include <string.h>
+
+#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
+  #if   defined(_MSC_VER)
+    #define BLAKE2_INLINE __inline
+  #elif defined(__GNUC__)
+    #define BLAKE2_INLINE __inline__
+  #else
+    #define BLAKE2_INLINE
+  #endif
+#else
+  #define BLAKE2_INLINE inline
+#endif
+
+static BLAKE2_INLINE uint32_t load32( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint32_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint32_t )( p[0] ) <<  0) |
+         (( uint32_t )( p[1] ) <<  8) |
+         (( uint32_t )( p[2] ) << 16) |
+         (( uint32_t )( p[3] ) << 24) ;
+#endif
+}
+
+static BLAKE2_INLINE uint64_t load64( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint64_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint64_t )( p[0] ) <<  0) |
+         (( uint64_t )( p[1] ) <<  8) |
+         (( uint64_t )( p[2] ) << 16) |
+         (( uint64_t )( p[3] ) << 24) |
+         (( uint64_t )( p[4] ) << 32) |
+         (( uint64_t )( p[5] ) << 40) |
+         (( uint64_t )( p[6] ) << 48) |
+         (( uint64_t )( p[7] ) << 56) ;
+#endif
+}
+
+static BLAKE2_INLINE uint16_t load16( const void *src )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  uint16_t w;
+  memcpy(&w, src, sizeof w);
+  return w;
+#else
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint16_t )( p[0] ) <<  0) |
+         (( uint16_t )( p[1] ) <<  8) ;
+#endif
+}
+
+static BLAKE2_INLINE void store16( void *dst, uint16_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  *p++ = ( uint8_t )w; w >>= 8;
+  *p++ = ( uint8_t )w;
+#endif
+}
+
+static BLAKE2_INLINE void store32( void *dst, uint32_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+#endif
+}
+
+static BLAKE2_INLINE void store64( void *dst, uint64_t w )
+{
+#if defined(NATIVE_LITTLE_ENDIAN)
+  memcpy(dst, &w, sizeof w);
+#else
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+  p[4] = (uint8_t)(w >> 32);
+  p[5] = (uint8_t)(w >> 40);
+  p[6] = (uint8_t)(w >> 48);
+  p[7] = (uint8_t)(w >> 56);
+#endif
+}
+
+static BLAKE2_INLINE uint64_t load48( const void *src )
+{
+  const uint8_t *p = ( const uint8_t * )src;
+  return (( uint64_t )( p[0] ) <<  0) |
+         (( uint64_t )( p[1] ) <<  8) |
+         (( uint64_t )( p[2] ) << 16) |
+         (( uint64_t )( p[3] ) << 24) |
+         (( uint64_t )( p[4] ) << 32) |
+         (( uint64_t )( p[5] ) << 40) ;
+}
+
+static BLAKE2_INLINE void store48( void *dst, uint64_t w )
+{
+  uint8_t *p = ( uint8_t * )dst;
+  p[0] = (uint8_t)(w >>  0);
+  p[1] = (uint8_t)(w >>  8);
+  p[2] = (uint8_t)(w >> 16);
+  p[3] = (uint8_t)(w >> 24);
+  p[4] = (uint8_t)(w >> 32);
+  p[5] = (uint8_t)(w >> 40);
+}
+
+static BLAKE2_INLINE uint32_t rotr32( const uint32_t w, const unsigned c )
+{
+  return ( w >> c ) | ( w << ( 32 - c ) );
+}
+
+static BLAKE2_INLINE uint64_t rotr64( const uint64_t w, const unsigned c )
+{
+  return ( w >> c ) | ( w << ( 64 - c ) );
+}
+
+/* prevents compiler optimizing out memset() */
+static BLAKE2_INLINE void secure_zero_memory(void *v, size_t n)
+{
+  static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
+  memset_v(v, 0, n);
+}
+
+#endif

--- a/lib/blake2/blake2.h
+++ b/lib/blake2/blake2.h
@@ -1,0 +1,91 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+#ifndef BLAKE2_H
+#define BLAKE2_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_MSC_VER)
+#define BLAKE2_PACKED(x) __pragma(pack(push, 1)) x __pragma(pack(pop))
+#else
+#define BLAKE2_PACKED(x) x __attribute__((packed))
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+  enum blake2b_constant
+  {
+    BLAKE2B_BLOCKBYTES = 128,
+    BLAKE2B_OUTBYTES   = 64,
+    BLAKE2B_KEYBYTES   = 64,
+    BLAKE2B_SALTBYTES  = 16,
+    BLAKE2B_PERSONALBYTES = 16
+  };
+
+  typedef struct blake2b_state__
+  {
+    uint64_t h[8];
+    uint64_t t[2];
+    uint64_t f[2];
+    uint8_t  buf[BLAKE2B_BLOCKBYTES];
+    size_t   buflen;
+    size_t   outlen;
+    uint8_t  last_node;
+  } blake2b_state;
+
+  BLAKE2_PACKED(struct blake2b_param__
+  {
+    uint8_t  digest_length; /* 1 */
+    uint8_t  key_length;    /* 2 */
+    uint8_t  fanout;        /* 3 */
+    uint8_t  depth;         /* 4 */
+    uint32_t leaf_length;   /* 8 */
+    uint32_t node_offset;   /* 12 */
+    uint32_t xof_length;    /* 16 */
+    uint8_t  node_depth;    /* 17 */
+    uint8_t  inner_length;  /* 18 */
+    uint8_t  reserved[14];  /* 32 */
+    uint8_t  salt[BLAKE2B_SALTBYTES]; /* 48 */
+    uint8_t  personal[BLAKE2B_PERSONALBYTES];  /* 64 */
+  });
+
+  typedef struct blake2b_param__ blake2b_param;
+
+  /* Padded structs result in a compile-time error */
+  enum {
+    BLAKE2_DUMMY_2 = 1/(int)(sizeof(blake2b_param) == BLAKE2B_OUTBYTES)
+  };
+
+  /* Streaming API */
+  int blake2b_init( blake2b_state *S, size_t outlen );
+  int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen );
+  int blake2b_init_param( blake2b_state *S, const blake2b_param *P );
+  int blake2b_update( blake2b_state *S, const void *in, size_t inlen );
+  int blake2b_final( blake2b_state *S, void *out, size_t outlen );
+
+  /* Simple API */
+  int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+  /* This is simply an alias for blake2b */
+  int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen );
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/lib/blake2/blake2b-ref.c
+++ b/lib/blake2/blake2b-ref.c
@@ -1,0 +1,379 @@
+/*
+   BLAKE2 reference source code package - reference C implementations
+
+   Copyright 2012, Samuel Neves <sneves@dei.uc.pt>.  You may use this under the
+   terms of the CC0, the OpenSSL Licence, or the Apache Public License 2.0, at
+   your option.  The terms of these licenses can be found at:
+
+   - CC0 1.0 Universal : http://creativecommons.org/publicdomain/zero/1.0
+   - OpenSSL license   : https://www.openssl.org/source/license.html
+   - Apache 2.0        : http://www.apache.org/licenses/LICENSE-2.0
+
+   More information about the BLAKE2 hash function can be found at
+   https://blake2.net.
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "blake2.h"
+#include "blake2-impl.h"
+
+static const uint64_t blake2b_IV[8] =
+{
+  0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL,
+  0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+  0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+  0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+};
+
+static const uint8_t blake2b_sigma[12][16] =
+{
+  {  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15 } ,
+  { 14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3 } ,
+  { 11,  8, 12,  0,  5,  2, 15, 13, 10, 14,  3,  6,  7,  1,  9,  4 } ,
+  {  7,  9,  3,  1, 13, 12, 11, 14,  2,  6,  5, 10,  4,  0, 15,  8 } ,
+  {  9,  0,  5,  7,  2,  4, 10, 15, 14,  1, 11, 12,  6,  8,  3, 13 } ,
+  {  2, 12,  6, 10,  0, 11,  8,  3,  4, 13,  7,  5, 15, 14,  1,  9 } ,
+  { 12,  5,  1, 15, 14, 13,  4, 10,  0,  7,  6,  3,  9,  2,  8, 11 } ,
+  { 13, 11,  7, 14, 12,  1,  3,  9,  5,  0, 15,  4,  8,  6,  2, 10 } ,
+  {  6, 15, 14,  9, 11,  3,  0,  8, 12,  2, 13,  7,  1,  4, 10,  5 } ,
+  { 10,  2,  8,  4,  7,  6,  1,  5, 15, 11,  9, 14,  3, 12, 13 , 0 } ,
+  {  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15 } ,
+  { 14, 10,  4,  8,  9, 15, 13,  6,  1, 12,  0,  2, 11,  7,  5,  3 }
+};
+
+
+static void blake2b_set_lastnode( blake2b_state *S )
+{
+  S->f[1] = (uint64_t)-1;
+}
+
+/* Some helper functions, not necessarily useful */
+static int blake2b_is_lastblock( const blake2b_state *S )
+{
+  return S->f[0] != 0;
+}
+
+static void blake2b_set_lastblock( blake2b_state *S )
+{
+  if( S->last_node ) blake2b_set_lastnode( S );
+
+  S->f[0] = (uint64_t)-1;
+}
+
+static void blake2b_increment_counter( blake2b_state *S, const uint64_t inc )
+{
+  S->t[0] += inc;
+  S->t[1] += ( S->t[0] < inc );
+}
+
+static void blake2b_init0( blake2b_state *S )
+{
+  size_t i;
+  memset( S, 0, sizeof( blake2b_state ) );
+
+  for( i = 0; i < 8; ++i ) S->h[i] = blake2b_IV[i];
+}
+
+/* init xors IV with input parameter block */
+int blake2b_init_param( blake2b_state *S, const blake2b_param *P )
+{
+  const uint8_t *p = ( const uint8_t * )( P );
+  size_t i;
+
+  blake2b_init0( S );
+
+  /* IV XOR ParamBlock */
+  for( i = 0; i < 8; ++i )
+    S->h[i] ^= load64( p + sizeof( S->h[i] ) * i );
+
+  S->outlen = P->digest_length;
+  return 0;
+}
+
+
+
+int blake2b_init( blake2b_state *S, size_t outlen )
+{
+  blake2b_param P[1];
+
+  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
+
+  P->digest_length = (uint8_t)outlen;
+  P->key_length    = 0;
+  P->fanout        = 1;
+  P->depth         = 1;
+  store32( &P->leaf_length, 0 );
+  store32( &P->node_offset, 0 );
+  store32( &P->xof_length, 0 );
+  P->node_depth    = 0;
+  P->inner_length  = 0;
+  memset( P->reserved, 0, sizeof( P->reserved ) );
+  memset( P->salt,     0, sizeof( P->salt ) );
+  memset( P->personal, 0, sizeof( P->personal ) );
+  return blake2b_init_param( S, P );
+}
+
+
+int blake2b_init_key( blake2b_state *S, size_t outlen, const void *key, size_t keylen )
+{
+  blake2b_param P[1];
+
+  if ( ( !outlen ) || ( outlen > BLAKE2B_OUTBYTES ) ) return -1;
+
+  if ( !key || !keylen || keylen > BLAKE2B_KEYBYTES ) return -1;
+
+  P->digest_length = (uint8_t)outlen;
+  P->key_length    = (uint8_t)keylen;
+  P->fanout        = 1;
+  P->depth         = 1;
+  store32( &P->leaf_length, 0 );
+  store32( &P->node_offset, 0 );
+  store32( &P->xof_length, 0 );
+  P->node_depth    = 0;
+  P->inner_length  = 0;
+  memset( P->reserved, 0, sizeof( P->reserved ) );
+  memset( P->salt,     0, sizeof( P->salt ) );
+  memset( P->personal, 0, sizeof( P->personal ) );
+
+  if( blake2b_init_param( S, P ) < 0 ) return -1;
+
+  {
+    uint8_t block[BLAKE2B_BLOCKBYTES];
+    memset( block, 0, BLAKE2B_BLOCKBYTES );
+    memcpy( block, key, keylen );
+    blake2b_update( S, block, BLAKE2B_BLOCKBYTES );
+    secure_zero_memory( block, BLAKE2B_BLOCKBYTES ); /* Burn the key from stack */
+  }
+  return 0;
+}
+
+#define G(r,i,a,b,c,d)                      \
+  do {                                      \
+    a = a + b + m[blake2b_sigma[r][2*i+0]]; \
+    d = rotr64(d ^ a, 32);                  \
+    c = c + d;                              \
+    b = rotr64(b ^ c, 24);                  \
+    a = a + b + m[blake2b_sigma[r][2*i+1]]; \
+    d = rotr64(d ^ a, 16);                  \
+    c = c + d;                              \
+    b = rotr64(b ^ c, 63);                  \
+  } while(0)
+
+#define ROUND(r)                    \
+  do {                              \
+    G(r,0,v[ 0],v[ 4],v[ 8],v[12]); \
+    G(r,1,v[ 1],v[ 5],v[ 9],v[13]); \
+    G(r,2,v[ 2],v[ 6],v[10],v[14]); \
+    G(r,3,v[ 3],v[ 7],v[11],v[15]); \
+    G(r,4,v[ 0],v[ 5],v[10],v[15]); \
+    G(r,5,v[ 1],v[ 6],v[11],v[12]); \
+    G(r,6,v[ 2],v[ 7],v[ 8],v[13]); \
+    G(r,7,v[ 3],v[ 4],v[ 9],v[14]); \
+  } while(0)
+
+static void blake2b_compress( blake2b_state *S, const uint8_t block[BLAKE2B_BLOCKBYTES] )
+{
+  uint64_t m[16];
+  uint64_t v[16];
+  size_t i;
+
+  for( i = 0; i < 16; ++i ) {
+    m[i] = load64( block + i * sizeof( m[i] ) );
+  }
+
+  for( i = 0; i < 8; ++i ) {
+    v[i] = S->h[i];
+  }
+
+  v[ 8] = blake2b_IV[0];
+  v[ 9] = blake2b_IV[1];
+  v[10] = blake2b_IV[2];
+  v[11] = blake2b_IV[3];
+  v[12] = blake2b_IV[4] ^ S->t[0];
+  v[13] = blake2b_IV[5] ^ S->t[1];
+  v[14] = blake2b_IV[6] ^ S->f[0];
+  v[15] = blake2b_IV[7] ^ S->f[1];
+
+  ROUND( 0 );
+  ROUND( 1 );
+  ROUND( 2 );
+  ROUND( 3 );
+  ROUND( 4 );
+  ROUND( 5 );
+  ROUND( 6 );
+  ROUND( 7 );
+  ROUND( 8 );
+  ROUND( 9 );
+  ROUND( 10 );
+  ROUND( 11 );
+
+  for( i = 0; i < 8; ++i ) {
+    S->h[i] = S->h[i] ^ v[i] ^ v[i + 8];
+  }
+}
+
+#undef G
+#undef ROUND
+
+int blake2b_update( blake2b_state *S, const void *pin, size_t inlen )
+{
+  const unsigned char * in = (const unsigned char *)pin;
+  if( inlen > 0 )
+  {
+    size_t left = S->buflen;
+    size_t fill = BLAKE2B_BLOCKBYTES - left;
+    if( inlen > fill )
+    {
+      S->buflen = 0;
+      memcpy( S->buf + left, in, fill ); /* Fill buffer */
+      blake2b_increment_counter( S, BLAKE2B_BLOCKBYTES );
+      blake2b_compress( S, S->buf ); /* Compress */
+      in += fill; inlen -= fill;
+      while(inlen > BLAKE2B_BLOCKBYTES) {
+        blake2b_increment_counter(S, BLAKE2B_BLOCKBYTES);
+        blake2b_compress( S, in );
+        in += BLAKE2B_BLOCKBYTES;
+        inlen -= BLAKE2B_BLOCKBYTES;
+      }
+    }
+    memcpy( S->buf + S->buflen, in, inlen );
+    S->buflen += inlen;
+  }
+  return 0;
+}
+
+int blake2b_final( blake2b_state *S, void *out, size_t outlen )
+{
+  uint8_t buffer[BLAKE2B_OUTBYTES] = {0};
+  size_t i;
+
+  if( out == NULL || outlen < S->outlen )
+    return -1;
+
+  if( blake2b_is_lastblock( S ) )
+    return -1;
+
+  blake2b_increment_counter( S, S->buflen );
+  blake2b_set_lastblock( S );
+  memset( S->buf + S->buflen, 0, BLAKE2B_BLOCKBYTES - S->buflen ); /* Padding */
+  blake2b_compress( S, S->buf );
+
+  for( i = 0; i < 8; ++i ) /* Output full hash to temp buffer */
+    store64( buffer + sizeof( S->h[i] ) * i, S->h[i] );
+
+  memcpy( out, buffer, S->outlen );
+  secure_zero_memory(buffer, sizeof(buffer));
+  return 0;
+}
+
+/* inlen, at least, should be uint64_t. Others can be size_t. */
+int blake2b( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen )
+{
+  blake2b_state S[1];
+
+  /* Verify parameters */
+  if ( NULL == in && inlen > 0 ) return -1;
+
+  if ( NULL == out ) return -1;
+
+  if( NULL == key && keylen > 0 ) return -1;
+
+  if( !outlen || outlen > BLAKE2B_OUTBYTES ) return -1;
+
+  if( keylen > BLAKE2B_KEYBYTES ) return -1;
+
+  if( keylen > 0 )
+  {
+    if( blake2b_init_key( S, outlen, key, keylen ) < 0 ) return -1;
+  }
+  else
+  {
+    if( blake2b_init( S, outlen ) < 0 ) return -1;
+  }
+
+  blake2b_update( S, ( const uint8_t * )in, inlen );
+  blake2b_final( S, out, outlen );
+  return 0;
+}
+
+int blake2( void *out, size_t outlen, const void *in, size_t inlen, const void *key, size_t keylen ) {
+  return blake2b(out, outlen, in, inlen, key, keylen);
+}
+
+#if defined(SUPERCOP)
+int crypto_hash( unsigned char *out, unsigned char *in, unsigned long long inlen )
+{
+  return blake2b( out, BLAKE2B_OUTBYTES, in, inlen, NULL, 0 );
+}
+#endif
+
+#if defined(BLAKE2B_SELFTEST)
+#include <string.h>
+#include "blake2-kat.h"
+int main( void )
+{
+  uint8_t key[BLAKE2B_KEYBYTES];
+  uint8_t buf[BLAKE2_KAT_LENGTH];
+  size_t i, step;
+
+  for( i = 0; i < BLAKE2B_KEYBYTES; ++i )
+    key[i] = ( uint8_t )i;
+
+  for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
+    buf[i] = ( uint8_t )i;
+
+  /* Test simple API */
+  for( i = 0; i < BLAKE2_KAT_LENGTH; ++i )
+  {
+    uint8_t hash[BLAKE2B_OUTBYTES];
+    blake2b( hash, BLAKE2B_OUTBYTES, buf, i, key, BLAKE2B_KEYBYTES );
+
+    if( 0 != memcmp( hash, blake2b_keyed_kat[i], BLAKE2B_OUTBYTES ) )
+    {
+      goto fail;
+    }
+  }
+
+  /* Test streaming API */
+  for(step = 1; step < BLAKE2B_BLOCKBYTES; ++step) {
+    for (i = 0; i < BLAKE2_KAT_LENGTH; ++i) {
+      uint8_t hash[BLAKE2B_OUTBYTES];
+      blake2b_state S;
+      uint8_t * p = buf;
+      size_t mlen = i;
+      int err = 0;
+
+      if( (err = blake2b_init_key(&S, BLAKE2B_OUTBYTES, key, BLAKE2B_KEYBYTES)) < 0 ) {
+        goto fail;
+      }
+
+      while (mlen >= step) {
+        if ( (err = blake2b_update(&S, p, step)) < 0 ) {
+          goto fail;
+        }
+        mlen -= step;
+        p += step;
+      }
+      if ( (err = blake2b_update(&S, p, mlen)) < 0) {
+        goto fail;
+      }
+      if ( (err = blake2b_final(&S, hash, BLAKE2B_OUTBYTES)) < 0) {
+        goto fail;
+      }
+
+      if (0 != memcmp(hash, blake2b_keyed_kat[i], BLAKE2B_OUTBYTES)) {
+        goto fail;
+      }
+    }
+  }
+
+  puts( "ok" );
+  return 0;
+fail:
+  puts("error");
+  return -1;
+}
+#endif

--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -20,7 +20,23 @@ possibly including recompilation of the same code. This is due to the use of
 type identifiers rather than a heavy-weight self-describing serialisation
 schema. This also means it isn't safe to deserialise something serialised by
 the same program compiled for a different platform.
+
+The Serialise.signature method is provided for the purposes of comparing
+communicating Pony binaries to determine if they are the same. Confirming this
+before deserialising data can help mitigate the risk of accidental serialisation
+across different Pony binaries, but does not on its own address the security
+issues of accepting data from untrusted sources.
 """
+
+primitive Serialise
+  fun signature(): Array[U8] val =>
+    """
+    Returns a byte array that is unique to this compiled Pony binary, for the
+    purposes of comparing before deserialising any data from that source.
+    It is statistically impossible for two serialisation-incompatible Pony
+    binaries to have the same serialise signature.
+    """
+    @"internal.signature"[Array[U8] val]()
 
 primitive SerialiseAuth
   """

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -205,6 +205,10 @@ void ast_extract_children(ast_t* parent, size_t child_count,
       children); \
   }
 
+pony_type_t* ast_signature_pony_type();
+
+pony_type_t* ast_nominal_pkg_id_signature_pony_type();
+
 pony_type_t* ast_pony_type();
 
 #if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -15,6 +15,8 @@ extern "C" {
 
 typedef struct token_t token_t;
 
+typedef struct token_signature_t token_signature_t;
+
 typedef enum token_id
 {
   TK_EOF,
@@ -290,6 +292,13 @@ token_t* token_dup_new_id(token_t* token, token_id id);
   * The token argument may be NULL.
   */
 void token_free(token_t* token);
+
+/// Get a pony_type_t for token_t. Should only be used for signature computation.
+pony_type_t* token_signature_pony_type();
+
+/// Get a pony_type_t for a docstring token_t. Should only be used for signature
+/// computation.
+pony_type_t* token_docstring_signature_pony_type();
 
 /// Get a pony_type_t for token_t. Should only be used for serialisation.
 pony_type_t* token_pony_type();

--- a/src/libponyc/codegen/genprim.h
+++ b/src/libponyc/codegen/genprim.h
@@ -29,6 +29,8 @@ void genprim_string_deserialise(compile_t* c, reach_type_t* t);
 
 void genprim_platform_methods(compile_t* c, reach_type_t* t);
 
+void genprim_signature(compile_t* c);
+
 void genprim_builtins(compile_t* c);
 
 void genprim_reachable_init(compile_t* c, ast_t* program);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -847,6 +847,8 @@ bool gentypes(compile_t* c)
     make_global_instance(c, t);
   }
 
+  genprim_signature(c);
+
   // Cache the instance of None, which is used as the return value for
   // behaviour calls.
   t = reach_type_name(c->reach, "None");

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -15,6 +15,7 @@
 #include "serialisers.h"
 #include "docgen.h"
 #include "../codegen/codegen.h"
+#include "../pkg/program.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
 
@@ -250,6 +251,15 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
 
   if(options->check_tree)
     check_tree(*astp, options->check.errors);
+
+  if(ast_id(*astp) == TK_PROGRAM)
+  {
+    program_signature(*astp);
+
+    if(options->verbosity >= VERBOSITY_TOOL_INFO)
+      program_dump(*astp);
+  }
+
   return true;
 }
 

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -92,6 +92,10 @@ bool use_package(ast_t* ast, const char* path, ast_t* name,
   // again
   ast_setdata(ast, (void*)package);
 
+  ast_t* curr_package = ast_nearest(ast, TK_PACKAGE);
+  pony_assert(curr_package != NULL);
+  package_add_dependency(curr_package, package);
+
   if(name != NULL && ast_id(name) == TK_ID) // We have an alias
     return set_scope(options, ast, name, package, false);
 

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -6,9 +6,15 @@
 #include "../ast/stringtab.h"
 #include "../pass/pass.h"
 
+#define SIGNATURE_LENGTH 64
+
 PONY_EXTERN_C_BEGIN
 
 typedef struct package_t package_t;
+typedef struct package_group_t package_group_t;
+
+DECLARE_LIST_SERIALISE(package_group_list, package_group_list_t,
+  package_group_t)
 
 /**
  * Cat together the 2 given path fragments into the given buffer.
@@ -140,11 +146,44 @@ bool package_allow_ffi(typecheck_t* t);
 const char* package_alias_from_id(ast_t* module, const char* id);
 
 /**
+ * Adds a package to the dependency list of another package.
+ */
+void package_add_dependency(ast_t* package, ast_t* dep);
+
+const char* package_signature(ast_t* package);
+
+size_t package_group_index(ast_t* package);
+
+package_group_t* package_group_new();
+
+void package_group_free(package_group_t* group);
+
+/**
+ * Build a list of the dependency groups (the strongly connected components) in
+ * the package dependency graph. The list is topologically sorted.
+ */
+package_group_list_t* package_dependency_groups(ast_t* first_package);
+
+const char* package_group_signature(package_group_t* group);
+
+void package_group_dump(package_group_t* group);
+
+/**
  * Cleans up the list of search directories.
  */
 void package_done();
 
+pony_type_t* package_dep_signature_pony_type();
+
+pony_type_t* package_signature_pony_type();
+
+pony_type_t* package_group_dep_signature_pony_type();
+
+pony_type_t* package_group_signature_pony_type();
+
 pony_type_t* package_pony_type();
+
+pony_type_t* package_group_pony_type();
 
 bool is_path_absolute(const char* path);
 

--- a/src/libponyc/pkg/program.h
+++ b/src/libponyc/pkg/program.h
@@ -42,6 +42,10 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
  */
 const char* program_lib_args(ast_t* program);
 
+const char* program_signature(ast_t* program);
+
+void program_dump(ast_t* program);
+
 pony_type_t* program_pony_type();
 
 PONY_EXTERN_C_END

--- a/src/libponyrt/ds/list.c
+++ b/src/libponyrt/ds/list.c
@@ -178,3 +178,35 @@ void ponyint_list_free(list_t* list, free_fn f)
     list = next;
   }
 }
+
+void ponyint_list_serialise_trace(pony_ctx_t* ctx, void* object,
+  pony_type_t* list_type, pony_type_t* elem_type)
+{
+  list_t* list = (list_t*)object;
+
+  if(list->data != NULL)
+    pony_traceknown(ctx, list->data, elem_type, PONY_TRACE_MUTABLE);
+
+  if(list->next != NULL)
+    pony_traceknown(ctx, list->next, list_type, PONY_TRACE_MUTABLE);
+}
+
+void ponyint_list_serialise(pony_ctx_t* ctx, void* object, void* buf,
+  size_t offset)
+{
+  list_t* list = (list_t*)object;
+  list_t* dst = (list_t*)((uintptr_t)buf + offset);
+
+  dst->data = (void*)pony_serialise_offset(ctx, list->data);
+  dst->next = (list_t*)pony_serialise_offset(ctx, list->next);
+}
+
+void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
+  pony_type_t* list_type, pony_type_t* elem_type)
+{
+  list_t* list = (list_t*)object;
+
+  list->data = pony_deserialise_offset(ctx, elem_type, (uintptr_t)list->data);
+  list->next = (list_t*)pony_deserialise_offset(ctx, list_type,
+    (uintptr_t)list->next);
+}

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -5,6 +5,14 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct
+{
+  pony_type_t* t;
+  size_t size;
+  size_t alloc;
+  char* ptr;
+} ponyint_array_t;
+
 typedef void* (*serialise_alloc_fn)(pony_ctx_t* ctx, size_t size);
 
 typedef void (*serialise_throw_fn)();
@@ -23,13 +31,14 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  void* out, serialise_alloc_fn alloc_fn, serialise_throw_fn throw_fn);
+  ponyint_array_t* out, serialise_alloc_fn alloc_fn,
+  serialise_throw_fn throw_fn);
 PONY_API size_t pony_serialise_offset(pony_ctx_t* ctx, void* p);
 PONY_API void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size);
 
-PONY_API void* pony_deserialise(pony_ctx_t* ctx, pony_type_t* t, void* in,
-  serialise_alloc_fn alloc_fn, serialise_alloc_fn alloc_final_fn,
-  serialise_throw_fn throw_fn);
+PONY_API void* pony_deserialise(pony_ctx_t* ctx, pony_type_t* t,
+  ponyint_array_t* in, serialise_alloc_fn alloc_fn,
+  serialise_alloc_fn alloc_final_fn, serialise_throw_fn throw_fn);
 PONY_API void* pony_deserialise_block(pony_ctx_t* ctx, uintptr_t offset,
   size_t size);
 PONY_API void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,

--- a/test/libponyc/compiler_serialisation.cc
+++ b/test/libponyc/compiler_serialisation.cc
@@ -45,14 +45,6 @@ static void s_throw_fn()
   throw std::exception{};
 }
 
-typedef struct ponyint_array_t
-{
-  void* desc;
-  size_t size;
-  size_t alloc;
-  char* ptr;
-} ponyint_array_t;
-
 struct pool_size_deleter
 {
   size_t size;

--- a/test/libponyc/signature.cc
+++ b/test/libponyc/signature.cc
@@ -1,0 +1,170 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <pkg/package.h>
+#include <pkg/program.h>
+
+#include "util.h"
+
+#define TEST_COMPILE(src) DO(test_compile(src, "ir"))
+
+class SignatureTest : public PassTest
+{};
+
+TEST_F(SignatureTest, RecompilationSameSignature)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  char first_signature[SIGNATURE_LENGTH];
+
+  TEST_COMPILE(src);
+
+  const char* signature = program_signature(program);
+  memcpy(first_signature, signature, SIGNATURE_LENGTH);
+
+  TEST_COMPILE(src);
+
+  signature = program_signature(program);
+
+  ASSERT_TRUE(memcmp(first_signature, signature, SIGNATURE_LENGTH) == 0);
+}
+
+TEST_F(SignatureTest, PackageReferences)
+{
+  const char* pkg =
+    "primitive Foo";
+
+  const char* src1 =
+    "use pkg1 = \"pkg1\"\n"
+    "use pkg2 = \"pkg2\"\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    pkg1.Foo";
+
+  const char* src2 =
+    "use pkg2 = \"pkg2\"\n"
+    "use pkg1 = \"pkg1\"\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    pkg2.Foo";
+
+  char main1_signature[SIGNATURE_LENGTH];
+  char pkg11_signature[SIGNATURE_LENGTH];
+  char pkg21_signature[SIGNATURE_LENGTH];
+
+  add_package("pkg1", pkg);
+  add_package("pkg2", pkg);
+
+  TEST_COMPILE(src1);
+
+  ast_t* main_ast = ast_child(program);
+  ast_t* pkg1_ast = ast_get(program, stringtab("pkg1"), nullptr);
+  ast_t* pkg2_ast = ast_get(program, stringtab("pkg2"), nullptr);
+
+  const char* signature = package_signature(main_ast);
+  memcpy(main1_signature, signature, SIGNATURE_LENGTH);
+  signature = package_signature(pkg1_ast);
+  memcpy(pkg11_signature, signature, SIGNATURE_LENGTH);
+  signature = package_signature(pkg2_ast);
+  memcpy(pkg21_signature, signature, SIGNATURE_LENGTH);
+
+  TEST_COMPILE(src2);
+
+  main_ast = ast_child(program);
+  pkg1_ast = ast_get(program, stringtab("pkg1"), nullptr);
+  pkg2_ast = ast_get(program, stringtab("pkg2"), nullptr);
+
+  signature = package_signature(main_ast);
+
+  ASSERT_FALSE(memcmp(main1_signature, signature, SIGNATURE_LENGTH) == 0);
+
+  signature = package_signature(pkg1_ast);
+
+  ASSERT_TRUE(memcmp(pkg11_signature, signature, SIGNATURE_LENGTH) == 0);
+
+  signature = package_signature(pkg2_ast);
+
+  ASSERT_TRUE(memcmp(pkg21_signature, signature, SIGNATURE_LENGTH) == 0);
+}
+
+TEST_F(SignatureTest, DocstringIgnored)
+{
+  const char* src1 =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  const char* src2 =
+    "actor Main\n"
+    "  \"\"\"Foo\"\"\"\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  const char* src3 =
+    "actor Main\n"
+    "  \"\"\"Bar\"\"\"\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  char first_signature[SIGNATURE_LENGTH];
+
+  TEST_COMPILE(src1);
+
+  const char* signature = program_signature(program);
+  memcpy(first_signature, signature, SIGNATURE_LENGTH);
+
+  TEST_COMPILE(src2);
+
+  signature = program_signature(program);
+
+  ASSERT_TRUE(memcmp(first_signature, signature, SIGNATURE_LENGTH) == 0);
+
+  TEST_COMPILE(src3);
+
+  signature = program_signature(program);
+
+  ASSERT_TRUE(memcmp(first_signature, signature, SIGNATURE_LENGTH) == 0);
+}
+
+extern "C"
+{
+
+static char sig_in[SIGNATURE_LENGTH];
+
+EXPORT_SYMBOL char* signature_get()
+{
+  return sig_in;
+}
+
+}
+
+TEST_F(SignatureTest, SerialiseSignature)
+{
+  const char* src =
+    "use \"serialise\"\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let sig_in = @signature_get[Pointer[U8]]()\n"
+    "    let sig = Serialise.signature()\n"
+    "    let ok = @memcmp[I32](sig_in, sig.cpointer(), sig.size())\n"
+    "    if ok == 0 then\n"
+    "      @pony_exitcode[None](I32(1))\n"
+    "    end";
+
+  set_builtin(nullptr);
+
+  TEST_COMPILE(src);
+
+  const char* signature = program_signature(program);
+  memcpy(sig_in, signature, SIGNATURE_LENGTH);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -386,14 +386,6 @@ TEST_F(HashMapTest, NotEmptyPutByIndex)
   ASSERT_EQ(e->val, m->val);
 }
 
-typedef struct ponyint_array_t
-{
-  void* desc;
-  size_t size;
-  size_t alloc;
-  char* ptr;
-} ponyint_array_t;
-
 struct testmap_deleter
 {
   void operator()(testmap_t* ptr)

--- a/wscript
+++ b/wscript
@@ -259,6 +259,13 @@ def build(ctx):
         includes = [ 'lib/gbenchmark/include' ],
         defines  = [ 'HAVE_STD_REGEX' ]
     )
+    
+    # blake2
+    ctx(
+        features = 'c seq',
+        target   = 'blake2',
+        source   = ctx.path.ant_glob('lib/blake2/*.c'),
+    )
 
     # libponyc
     ctx(
@@ -266,7 +273,8 @@ def build(ctx):
         target    = 'libponyc',
         source    = ctx.path.ant_glob('src/libponyc/**/*.c') + \
                     ctx.path.ant_glob('src/libponyc/**/*.cc'),
-        includes  = [ 'src/common' ] + llvmIncludes + sslIncludes
+        includes  = [ 'src/common', 'lib/blake2' ] + llvmIncludes + sslIncludes,
+        use       = [ 'blake2' ]
     )
 
     # libponyc.benchmarks


### PR DESCRIPTION
This change implements deterministic package and program signatures based on the contents and dependencies of the packages. Signatures are computed by hashing the serialised package ASTs with the BLAKE2 hash function. This hash function was chosen for its good speed and low collision rate.

The signature computation handles circular dependencies by computing signatures per package cycle instead of per package. Packages in the same group are discriminated by a group index.

In order to allow deterministic signatures, file parsing order is now always alphabetical inside of a package.

The compiler now outputs the package groups and dependencies when the `-V3` or `-V4` flags are enabled.

Signatures will be used for future work on separate package compilation in order to validate package identities.

Closes #2147.