### PR TITLE
 Fixed state handling of HTTP client connections

### DIFF
--- a/packages/net/http/_client_connection.pony
+++ b/packages/net/http/_client_connection.pony
@@ -87,7 +87,7 @@ actor _ClientConnection is HTTPSession
     try
       for node in _unsent.nodes() do
         if node()? is request then
-          node.>remove().pop()?
+          node .> remove().pop()?
           return
         end
       end
@@ -99,7 +99,7 @@ actor _ClientConnection is HTTPSession
         if node()? is request then
           try (_conn as TCPConnection).dispose() end
           _conn = None
-          node.>remove().pop()?
+          node .> remove().pop()?
           break
         end
       end

--- a/packages/net/http/_client_connection.pony
+++ b/packages/net/http/_client_connection.pony
@@ -176,8 +176,11 @@ actor _ClientConnection is HTTPSession
 
   be _finish() =>
     """
-    Inidcates that the last *inbound* body chunk has been sent to
+    Indicates that the last *inbound* body chunk has been sent to
     `_chunk`. This is passed on to the front end.
+
+    _send_pending is called to detect that _unsent and _sent are emptye
+    and that _conn can be disposed. 
     """
     _app_handler.finished()
     _send_pending()
@@ -190,7 +193,7 @@ actor _ClientConnection is HTTPSession
 
   be dispose() =>
     """
-    Close the connection from the client end.
+    Cancels all requests and disposes the tcp connection.
     """
     _cancel_all()
     match _conn

--- a/packages/net/http/_client_connection.pony
+++ b/packages/net/http/_client_connection.pony
@@ -192,9 +192,11 @@ actor _ClientConnection is HTTPSession
     """
     Close the connection from the client end.
     """
+    _cancel_all()
     match _conn
     | let c: TCPConnection => c.dispose()
     end
+    _conn = None
 
   be throttled() =>
     """

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -480,6 +480,11 @@ class iso _HTTPConnTest is UnitTest
     h.long_test(5_000_000_000)
 
 primitive _FixedResponseHTTPServerNotify
+  """
+  Test http server spitting out fixed responses.
+  apply returns a TCPListenNotify object.
+  """
+
   fun apply(
     h': TestHelper, 
     f: {(String val)} iso, 

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -29,7 +29,6 @@ actor Main is TestList
     test(_Valid)
     test(_ToStringFun)
 
-    // Disabled to check if this causes the appveyor block.
     test(_HTTPConnTest)
 
 class iso _Encode is UnitTest
@@ -418,7 +417,7 @@ class iso _HTTPConnTest is UnitTest
 
       be listening(service: String) =>
         try
-          // Need two or more request to check if the fix worked.
+          // Need two or more request to check if the fix works.
           let loops: USize = 2
           // let service: String val = "12345"
           h.log("received service: [" + service + "]")
@@ -440,16 +439,7 @@ class iso _HTTPConnTest is UnitTest
           h.log("Error in worker.listening")
           h.complete(false)
         end // try
-
-      be dispose() =>
-        // try
-        //   (client as HTTPClient iso).dispose()
-        // end
-        None
-
     end // object
-
-   // h.dispose_when_done(worker)
 
     // Start the fake server.
     h.dispose_when_done(
@@ -481,7 +471,7 @@ class iso _HTTPConnTest is UnitTest
 
 primitive _FixedResponseHTTPServerNotify
   """
-  Test http server spitting out fixed responses.
+  Test http server that spits out fixed responses.
   apply returns a TCPListenNotify object.
   """
 

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -28,7 +28,8 @@ actor Main is TestList
     test(_Valid)
     test(_ToStringFun)
 
-    test(_HTTPConnTest)
+    // Disabled to check if this causes the appveyor block.
+    // test(_HTTPConnTest)
 
 class iso _Encode is UnitTest
   fun name(): String => "net/http/URLEncode.encode"
@@ -485,7 +486,6 @@ primitive _FixedResponseHTTPServerNotify
           try
             // Get the service as numeric.
             let name = listen.local_address().name()?
-            h.env.out.print("Listening on service:" + name._2)
             listen_cb(name._2)
           end
 

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -417,6 +417,7 @@ class iso _HTTPConnTest is UnitTest
   fun label(): String => "conn-fix"
 
   fun ref apply(h: TestHelper) ? =>
+    // Need two or more request to check if the fix worked.
     let urls: Array[URL] = 
       [ 
         URL.build(
@@ -425,29 +426,11 @@ class iso _HTTPConnTest is UnitTest
           "http://localhost:50000")?
         URL.build(
           "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
-        URL.build(
-          "http://localhost:50000")?
       ]
-
+    // Start the fake server.
     server = TCPListener(
       h.env.root as AmbientAuth,
-      MyTCPListenNotify, 
+      _MyTCPListenNotify, 
       "", 
       "50000")
 
@@ -461,14 +444,14 @@ class iso _HTTPConnTest is UnitTest
       client(consume payload, hf)?
     end
 
-    // Start a long test. Will work for really slow lines. Ahem.
-    h.long_test(10_000_000_000)
+    // Start a long test for 2 seconds.
+    h.long_test(2_000_000_000)
 
   fun ref tear_down(h: TestHelper) =>
     try (server as TCPListener).dispose() end
 
 ////////////////////////
-primitive ResponseWriter
+primitive _ResponseWriter
   fun val ok(): Array[String val] val^ =>
     [ as String val: 
       "HTTP/1.1 200 OK"
@@ -497,7 +480,7 @@ primitive ResponseWriter
     end
 
 
-class iso MyTCPConnectionNotify is TCPConnectionNotify
+class iso _MyTCPConnectionNotify is TCPConnectionNotify
   let reader: Reader
 
   new iso create() =>
@@ -522,7 +505,7 @@ class iso MyTCPConnectionNotify is TCPConnectionNotify
 
       // Write the response.
       if start then
-        ResponseWriter.write(conn, ResponseWriter.ok())
+        _ResponseWriter.write(conn, _ResponseWriter.ok())
       end
     end // while
     true
@@ -539,7 +522,7 @@ class iso MyTCPConnectionNotify is TCPConnectionNotify
   fun ref closed(conn: TCPConnection ref) =>
     None
 
-class MyTCPListenNotify is TCPListenNotify
+class _MyTCPListenNotify is TCPListenNotify
   new iso create() =>
     None
 
@@ -553,5 +536,5 @@ class MyTCPListenNotify is TCPListenNotify
     None
 
   fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
-    MyTCPConnectionNotify
+    _MyTCPConnectionNotify
 

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -1,6 +1,7 @@
 use "ponytest"
 use "net"
 use "collections"
+use "buffered"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -366,20 +367,18 @@ primitive _Test
     h.assert_eq[String](query, url.query)
     h.assert_eq[String](fragment, url.fragment)
 
-
-
 // Actor and classes to test the HTTPClient and modified _HTTPConnection.
 actor _HTTPHandlerActor
   let h: TestHelper
   var tries: USize
-
+  
   new create(h': TestHelper, tries': USize) =>
     h = h'
     tries = tries'
     h.log("_HTTPHandlerActor create called")
 
   be apply(p: Payload val) =>
-    h.log("_HTTPHandlerActor apply called: " + tries.string())
+    h.log("_HTTPHandlerActor apply called. Tries to go: " + tries.string())
     if (tries = tries - 1) == 1 then 
       h.complete(true)
     end
@@ -413,22 +412,45 @@ class val _TestHandlerFactory is HandlerFactory
     _TestHTTPHandler(ha, h)
 
 class iso _HTTPConnTest is UnitTest
+  var server: (TCPListener | None) = None
   fun name(): String => "net/http/_HTTPConnection._new_conn"
+  fun label(): String => "conn-fix"
 
-  fun apply(h: TestHelper) ? =>
+  fun ref apply(h: TestHelper) ? =>
     let urls: Array[URL] = 
       [ 
         URL.build(
-          "https://raw.githubusercontent.com/ponylang/ponyc/master/README.md")?
+          "http://localhost:50000")?
         URL.build(
-          "https://raw.githubusercontent.com/ponylang/ponyc/master/README.md")?
+          "http://localhost:50000")?
         URL.build(
-          "https://github.com/ponylang/ponyc/blob/master/CODE_OF_CONDUCT.md")?
+          "http://localhost:50000")?
         URL.build(
-          "https://github.com/ponylang/ponyc/blob/master/CODE_OF_CONDUCT.md")?
+          "http://localhost:50000")?
         URL.build(
-          "http://www.nu.nl")?
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
+        URL.build(
+          "http://localhost:50000")?
       ]
+
+    server = TCPListener(
+      h.env.root as AmbientAuth,
+      MyTCPListenNotify, 
+      "", 
+      "50000")
+
 
     let ha = _HTTPHandlerActor(h, urls.size())
     let hf = _TestHandlerFactory(ha, h)
@@ -441,4 +463,95 @@ class iso _HTTPConnTest is UnitTest
 
     // Start a long test. Will work for really slow lines. Ahem.
     h.long_test(10_000_000_000)
+
+  fun ref tear_down(h: TestHelper) =>
+    try (server as TCPListener).dispose() end
+
+////////////////////////
+primitive ResponseWriter
+  fun val ok(): Array[String val] val^ =>
+    [ as String val: 
+      "HTTP/1.1 200 OK"
+      "Server: pony_fake_server"
+      // "Date: Wed, 11 Oct 2017 15:16:32 GMT"
+      // "Content-Type: text/html; charset=utf-8"
+      "Content-Length: 0"
+      "Status: 200 OK"
+      ""
+    ]
+
+  fun val error_503(): Array[String val] val^ =>
+    [ as String val: 
+      "HTTP/1.1 520 Unknown Error"
+      "Server: pony_fake_server"
+      // "Date: Wed, 11 Oct 2017 15:16:32 GMT"
+      // "Content-Type: text/html; charset=utf-8"
+      "Content-Length: 0"
+      "Status: 520 Unknown Error"
+      ""
+    ]
+
+  fun write(conn: TCPConnection, resp: Array[String val] val) =>
+    for r in resp.values() do
+      conn.write(r + "\n")
+    end
+
+
+class iso MyTCPConnectionNotify is TCPConnectionNotify
+  let reader: Reader
+
+  new iso create() =>
+    reader = Reader
+
+  fun ref received(
+    conn: TCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    // Test if the request was issued completely.
+    reader.append(consume data)
+    while true do
+      let start = 
+        try 
+          let l = reader.line()?
+          l.contains("HTTP/1.1")
+        else
+          break
+        end
+
+      // Write the response.
+      if start then
+        ResponseWriter.write(conn, ResponseWriter.ok())
+      end
+    end // while
+    true
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    None
+
+  fun ref connecting(conn: TCPConnection ref, count: U32) =>
+    None
+  
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    None
+  
+  fun ref closed(conn: TCPConnection ref) =>
+    None
+
+class MyTCPListenNotify is TCPListenNotify
+  new iso create() =>
+    None
+
+  fun ref listening(listen: TCPListener ref) =>
+    None
+
+  fun ref not_listening(listen: TCPListener ref) =>
+    None
+
+  fun ref closed(listen: TCPListener ref) =>
+    None
+
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
+    MyTCPConnectionNotify
 

--- a/packages/net/http/client.pony
+++ b/packages/net/http/client.pony
@@ -53,6 +53,11 @@ class HTTPClient
     let valrequest: Payload val = consume request
     session(valrequest)
     valrequest
+
+  fun dispose() =>
+    for s in _sessions.values() do
+      s.dispose()
+    end
     
 /*
   fun ref cancel(request: Payload val) =>

--- a/packages/net/http/client.pony
+++ b/packages/net/http/client.pony
@@ -54,10 +54,14 @@ class HTTPClient
     session(valrequest)
     valrequest
 
-  fun dispose() =>
+  fun ref dispose() =>
+    """
+    Disposes the sessions and cancels all pending requests.
+    """
     for s in _sessions.values() do
       s.dispose()
     end
+    _sessions.clear()
     
 /*
   fun ref cancel(request: Payload val) =>


### PR DESCRIPTION
The _conn: TCPConnection was used before it was opened.
Added an extra state _ConnConnecting for proper handling.

Also fixed _ClientConnection not closing the connection
when not work needed to be done by calling _send_pending
after having received the body part of the HTTP response.

Added one trick pony http server for testing
