### PR TITLE
Replace static_assert with _Static_assert in actor.c

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -306,6 +306,22 @@ inline uint64_t __pony_clzl(uint64_t x)
 
 #endif
 
+/** Static assert
+ *
+ */
+
+#if defined(__clang__)
+#  if __has_feature(cxx_static_assert)
+#    define pony_static_assert(c, m) static_assert(c, m)
+#  elif __has_feature(c_static_assert)
+#    define pony_static_assert(c, m) _Static_assert(c, m)
+#  else
+#    error "Clang doesn't support `static_assert` or `_Static_assert`."
+#  endif
+#else
+#  define pony_static_assert(c, m) static_assert(c, m)
+#endif
+
 /** Storage class modifiers.
  *
  */

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -17,8 +17,8 @@
 #endif
 
 // Ignore padding at the end of the type.
-static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
-  sizeof(pony_actor_pad_t), "Wrong actor pad size!");
+pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
+   sizeof(pony_actor_pad_t), "Wrong actor pad size!");
 
 enum
 {


### PR DESCRIPTION
The macro static_assert fails to compile as detailed in issue #2271

Since static_assert expands to _Static_assert, this should be a suitable replacement
to circumvent the failure while compiling.

**Update:** Due to the failure on Windows, added a definition to `platform.h` for `pony_static_assert` which uses `static_assert` or `_Static_assert` dependent on what's defined for `clang`. Defaults to `static_assert` for all others. Thanks to @dipinhora for the help on that.