### PR TITLE
Use fake stdlib packages in the SmallFinaliser test

### DIFF
--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -158,19 +158,17 @@ EXPORT_SYMBOL void codegentest_small_finalisers_increment_num_objects() {
 TEST_F(CodegenTest, SmallFinalisers)
 {
   const char* src =
-    "use \"collections\"\n"
-
     "class _Final\n"
     "  fun _final() =>\n"
     "    @codegentest_small_finalisers_increment_num_objects[None]()\n"
 
     "actor Main\n"
     "  new create(env: Env) =>\n"
-    "    for i in Range[I32](0, 42) do\n"
+    "    var i: U64 = 0\n"
+    "    while i < 42 do\n"
     "      _Final\n"
-    "    end\n";
-
-  set_builtin(NULL);
+    "      i = i + 1\n"
+    "    end";
 
   TEST_COMPILE(src);
 

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -51,6 +51,7 @@ static const char* _builtin =
   "  new create(a: U64 = 0) => a\n"
   "  fun op_xor(a: U64): U64 => this xor a\n"
   "  fun add(a: U64): U64 => this + a\n"
+  "  fun lt(a: U64): Bool => this < a\n"
   "primitive I64 is Real[I64]"
   "  new create(a: I64 = 0) => a\n"
   "  fun neg():I64 => -this\n"


### PR DESCRIPTION
This makes the test run a lot faster as there is much less code to compile.