### PR TITLE
Turn off LTO by default on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,6 @@ else
   endif
 endif
 
-ifndef lto
-  ifeq ($(UNAME_S),Darwin)
-  	# turn lto on for OSX if user hasn't specified a value
-   	lto := yes
-   endif
-endif
-
 ifdef LTO_PLUGIN
   lto := yes
 endif

--- a/README.md
+++ b/README.md
@@ -630,6 +630,12 @@ Other commands include `clean`, which will clean a specified configuration; and 
 
 ## Building with link-time optimisation (LTO)
 
+Link-time optimizations provide a performance improvement. You should strongly consider turning on LTO if you build ponyc from source. It's off by default as it comes with some caveats:
+
+- If you aren't using clang as your linker, we've seen LTO generate incorrect binaries. It's rare but it can happen. Before turning on LTO you need to be aware that it's possible. 
+
+- If you are on MacOS, turning on LTO means that if you upgrade your version of XCode, you will have to rebuild your Pony compiler. You won't be able to link Pony programs if there is a mismatch between the version of XCode used to build the Pony runtime and the version of XCode you currently have installed.
+
 You can enable LTO when building the compiler in release mode. There are slight differences between platforms so you'll need to do a manual setup. LTO is enabled by setting `lto` to `yes` in the build command line:
 
 ```bash


### PR DESCRIPTION
This turns off LTO by default on MacOS. This will have performance
implications for default installs, however, turning on LTO by default
can lead users to have broken installs via "spookey action at a
distance".

Here's the scenario. For LTO to work, you need to be using the same
bitcode for the linker in both the Pony runtime and the currently
installed linker. Ways that having LTO can lead to a broken install:

1) install Pony
2) upgrade XCode such that the linker bitcode version changes

In that scenario, you no longer can compile programs.

Another scenerio (which can happen via homebrew).

1) build pony and its runtime on a machine that has XCode version X
2) install onto a machine that has an older version of XCode

The pony will fail to build programs and fail with a fairly inscrutable
error.

At one point in the past LTO off was and I advocated for turning it on
for MacOS where we felt it was safe to do. "Safe" meant, "won't bork
your programs". The issue we were looking at is, LTO is still
experimental in GCC but not clang. So, OSX where we use clang's linker,
we felt good about making the change.

What we didn't think about at the time was that this can lead to broken
installs for unknowing users. With this commit, we are turning off LTO
by default. Additionally...

This commit adds more details about turning on LTO to the README and
gives specific information about how it can break MacOS installs if you
change your XCode version. This should have it safe for more experienced
"build from source" MacOS users to turn on LTO and understand the
consequences. No more "spooky breakage at a distance" problem. Further,
when reviewing the "performance cheatsheet" on the Pony website, I
realized LTO wasn't mentioned. I'll be adding information about building
with LTO to the performance cheatsheet with the appropriate caveats.