### PR TITLE
Error on unreachable cases in match expressions and illegal as expressions.

### DIFF
--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -81,7 +81,7 @@ class val _MapNode[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
         // update sub-node
         let sn = _entries(i.usize_unsafe())? as _MapNode[K, V, H]
         let es = recover _entries.clone() end
-        (let sn', let u) = sn.update(hash, leaf)? as (_MapNode[K, V, H], Bool)
+        (let sn', let u) = sn.update(hash, leaf)?
         es(i.usize_unsafe())? = sn'
         (create(consume es, _nodemap, _datamap, _level), u)
       end
@@ -107,9 +107,8 @@ class val _MapNode[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
       else
         // create new sub-node
         var sn = empty(_level + 1)
-        (sn, _) =
-          sn.update(H.hash(old._1).u32(), old)? as (_MapNode[K, V, H], Bool)
-        (sn, _) = sn.update(hash, leaf)? as (_MapNode[K, V, H], Bool)
+        (sn, _) = sn.update(H.hash(old._1).u32(), old)?
+        (sn, _) = sn.update(hash, leaf)?
         let es = recover _entries.clone() end
         let nm = _Bits.set_bit(_nodemap, idx)
         let dm = _Bits.clear_bit(_datamap, idx)

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -34,23 +34,22 @@ class val FilePath
     """
     caps.union(caps')
 
-    match base
-    | let b: FilePath =>
-      if not b.caps(FileLookup) then
-        error
-      end
+    path = match base
+      | let b: FilePath =>
+        if not b.caps(FileLookup) then
+          error
+        end
 
-      path = Path.join(b.path, path')
-      caps.intersect(b.caps)
+        let tmp_path = Path.join(b.path, path')
+        caps.intersect(b.caps)
 
-      if not path.at(b.path, 0) then
-        error
+        if not tmp_path.at(b.path, 0) then
+          error
+        end
+        tmp_path
+      | let b: AmbientAuth =>
+        Path.abs(path')
       end
-    | let b: AmbientAuth =>
-      path = Path.abs(path')
-    else
-      error
-    end
 
   new val mkdtemp(
     base: (FilePath | AmbientAuth),

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -386,7 +386,7 @@ class Iter[A] is Iterator[A]
     """
     filter_stateful({(a: A!): Bool ? => f(a)? })
 
-  fun ref find(f: {(A!): Bool ?} box, n: USize = 1): A ? =>
+  fun ref find(f: {(A!): Bool ?} box, n: USize = 1): A! ? =>
     """
     Return the nth value in the iterator that satisfies the predicate `f`.
 
@@ -408,7 +408,7 @@ class Iter[A] is Iterator[A]
     for x in _iter do
       if try f(x)? else false end then
         if c == 1 then
-          return consume x as A
+          return x
         else
           c = c - 1
         end

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -434,7 +434,6 @@ class _ProcessClient is ProcessNotify
     | KillError => _h.fail("ProcessError: KillError")
     | Unsupported => _h.fail("ProcessError: Unsupported")
     | CapError => _h.complete(true) // used in _TestFileExec
-    else _h.fail("Unknown ProcessError!")
     end
 
   fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -549,6 +549,23 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
     return false;
   }
 
+  if(is_eqtype(expr_type, type, NULL, opt))
+  {
+    ast_error(opt->check.errors, ast, "Cannot cast to same type");
+    ast_error_continue(opt->check.errors, expr,
+      "Expression is already of type %s", ast_print_type(type));
+
+    return false;
+  }
+
+  if(is_subtype(expr_type, type, NULL, opt))
+  {
+    ast_error(opt->check.errors, ast, "Cannot cast to subtype");
+    ast_error_continue(opt->check.errors, expr,
+      "%s is a subtype of this Expression. 'as' is not needed here.", ast_print_type(type));
+    return false;
+  }
+
   ast_t* pattern_root = ast_from(type, TK_LEX_ERROR);
   ast_t* body_root = ast_from(type, TK_LEX_ERROR);
   if(!add_as_type(opt, ast, expr, type, pattern_root, body_root))

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -549,20 +549,20 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
     return false;
   }
 
-  if(is_eqtype(expr_type, type, NULL, opt))
-  {
-    ast_error(opt->check.errors, ast, "Cannot cast to same type");
-    ast_error_continue(opt->check.errors, expr,
-      "Expression is already of type %s", ast_print_type(type));
-
-    return false;
-  }
-
   if(is_subtype(expr_type, type, NULL, opt))
   {
-    ast_error(opt->check.errors, ast, "Cannot cast to subtype");
-    ast_error_continue(opt->check.errors, expr,
-      "%s is a subtype of this Expression. 'as' is not needed here.", ast_print_type(type));
+    if(is_subtype(type, expr_type, NULL, opt))
+    {
+      ast_error(opt->check.errors, ast, "Cannot cast to same type");
+      ast_error_continue(opt->check.errors, expr,
+        "Expression is already of type %s", ast_print_type(type));
+    }
+    else
+    {
+      ast_error(opt->check.errors, ast, "Cannot cast to subtype");
+      ast_error_continue(opt->check.errors, expr,
+        "%s is a subtype of this Expression. 'as' is not needed here.", ast_print_type(type));
+    }
     return false;
   }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -675,7 +675,7 @@ TEST_F(BadPonyTest, AsUnaliased)
     "class trn Foo\n"
 
     "actor Main\n"
-    "  let foo: Foo = Foo\n"
+    "  let foo: (Foo|None) = Foo\n"
 
     "  new create(env: Env) => None\n"
 

--- a/test/libponyc/dontcare.cc
+++ b/test/libponyc/dontcare.cc
@@ -181,9 +181,9 @@ TEST_F(DontcareTest, CannotUseDontcareInCaseExpression)
 {
   const char* src =
     "class C\n"
-    "  fun c_ase(x: I32): I32 =>\n"
+    "  fun c_ase(x: (I32 | None)): I32 =>\n"
     "    match x\n"
-    "      | let x1: I32 => -1\n"
+    "      | let x1: I32 => x1\n"
     "      | _ => 42\n"
     "    end";
   TEST_ERRORS_1(src, "can't have a case with `_` only, use an else clause");

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -936,7 +936,7 @@ TEST_F(SugarTest, MatchWithNoElse)
     "  var create: U32\n"
     "  fun f(): U32 val =>\n"
     "    match(x)\n"
-    "    |1=> 2\n"
+    "    |1 => 2\n"
     "    end";
 
   const char* full_form =


### PR DESCRIPTION
this checks for exhaustive matches that have an else clause, which is unreachable,
this also checks for cases that are unreachable because previous cases are already exhaustive,

this also affects the 'as' clause as it is rewritten to a match internally:

this checks for 'as' clauses that try to cast to the same type or a subtype
which would result in an exhaustive match internally and can be considered illegal use of 'as'.

This is a breaking change, ***but for good***. If it affects any pony codebase, then it had a possible source of bugs.

The following examples will be invalid with this PR:

```pony
class Foo
  fun ex_match(a: (String| Bool)): String => 
    match a
    | let a: Stringable => a.string()
    | let b: Bool => if b then "true" else "false" end // unreachable already
    else
      "unreachable"
    end
```

```pony
class Foo
   fun subtype_cast(a: String): Stringable ? =>
     a as Stringable // useless as, is actually not partial

   fun eq_cast(a: Array[String]) =>
     let tmp = a as Array[String] // no as needed
    ...
```

```pony
class Foo[A]
  fun alias_cast(a: A!): A ? =>
    a as A
```