### PR TITLE
Remove global state or make it mostly thread safe

### DIFF
--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -141,12 +141,11 @@ void ast_reorder_children(ast_t* ast, const size_t* new_order,
 void ast_free(ast_t* ast);
 void ast_free_unattached(ast_t* ast);
 
-void ast_print(ast_t* ast);
+void ast_print(ast_t* ast, size_t width);
 void ast_printverbose(ast_t* ast);
-void ast_fprint(FILE* fp, ast_t* ast);
+void ast_fprint(FILE* fp, ast_t* ast, size_t width);
 void ast_fprintverbose(FILE* fp, ast_t* ast);
 const char* ast_print_type(ast_t* type);
-void ast_setwidth(size_t w);
 
 void ast_error(errors_t* errors, ast_t* ast, const char* fmt, ...)
   __attribute__((format(printf, 3, 4)));

--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -32,7 +32,7 @@
 
 
 // Fixed text to add to printed BNF to make complete antlr file
-static const char* antlr_pre =
+static const char* const antlr_pre =
   "// ANTLR v3 grammar\n"
   "grammar pony;\n\n"
   "options\n"
@@ -42,7 +42,7 @@ static const char* antlr_pre =
   "}\n\n"
   "// Parser\n";
 
-static const char* antlr_post =
+static const char* const antlr_post =
   "// Rules of the form antlr_* are only present to avoid a bug in the\n"
   "// interpreter\n\n"
   "/* Precedence\n\n"

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -15,6 +15,7 @@ struct lexer_t
 {
   source_t* source;
   errors_t* errors;
+  bool allow_test_symbols;
 
   // Information about next unused character in file
   size_t ptr;
@@ -308,15 +309,6 @@ static const lextoken_t abstract[] =
   { "\\n", TK_NEWLINE },
   {NULL, (token_id)0}
 };
-
-
-static bool allow_test_symbols = false;
-
-
-void lexer_allow_test_symbols()
-{
-  allow_test_symbols = true;
-}
 
 
 // Report an error at the specified location
@@ -1197,7 +1189,7 @@ static token_t* dollar(lexer_t* lexer)
   append_to_token(lexer, look(lexer));  // $
   consume_chars(lexer, 1);
 
-  if(allow_test_symbols)
+  if(lexer->allow_test_symbols)
   {
     // Test mode, allow test keywords and identifiers.
     // Note that a lone '$' is always an error to allow tests to force a lexer
@@ -1261,7 +1253,8 @@ static token_t* symbol(lexer_t* lexer)
 }
 
 
-lexer_t* lexer_open(source_t* source, errors_t* errors)
+lexer_t* lexer_open(source_t* source, errors_t* errors,
+  bool allow_test_symbols)
 {
   pony_assert(source != NULL);
 
@@ -1270,6 +1263,7 @@ lexer_t* lexer_open(source_t* source, errors_t* errors)
 
   lexer->source = source;
   lexer->errors = errors;
+  lexer->allow_test_symbols = allow_test_symbols;
   lexer->len = source->len;
   lexer->line = 1;
   lexer->pos = 1;

--- a/src/libponyc/ast/lexer.h
+++ b/src/libponyc/ast/lexer.h
@@ -11,16 +11,12 @@ PONY_EXTERN_C_BEGIN
 typedef struct lexer_t lexer_t;
 typedef struct errors_t errors_t;
 
-/** Allow test symbols to be generated in all lexers.
- * Should only be used for unit tests.
- */
-void lexer_allow_test_symbols();
-
 /** Create a new lexer to handle the given source.
  * The created lexer must be freed later with lexer_close().
  * Never returns NULL.
  */
-lexer_t* lexer_open(source_t* source, errors_t* errors);
+lexer_t* lexer_open(source_t* source, errors_t* errors,
+  bool allow_test_symbols);
 
 /** Free a previously opened lexer.
  * The lexer argument may be NULL.

--- a/src/libponyc/ast/lexint.c
+++ b/src/libponyc/ast/lexint.c
@@ -17,7 +17,7 @@ void lexint_zero(lexint_t* i)
   i->high = 0;
 }
 
-int lexint_cmp(lexint_t* a, lexint_t* b)
+int lexint_cmp(lexint_t const* a, lexint_t const* b)
 {
   if(a->high > b->high)
     return 1;

--- a/src/libponyc/ast/lexint.h
+++ b/src/libponyc/ast/lexint.h
@@ -14,7 +14,7 @@ typedef struct lexint_t
 
 void lexint_zero(lexint_t* i);
 
-int lexint_cmp(lexint_t* a, lexint_t* b);
+int lexint_cmp(lexint_t const* a, lexint_t const* b);
 
 int lexint_cmp64(lexint_t* a, uint64_t b);
 

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -1226,10 +1226,11 @@ DEF(module);
 #ifdef PARSER
 
 // external API
-bool pass_parse(ast_t* package, source_t* source, errors_t* errors)
+bool pass_parse(ast_t* package, source_t* source, errors_t* errors,
+  bool allow_test_symbols, bool trace)
 {
   return parse(package, source, module, "class, actor, primitive or trait",
-    errors);
+    errors, allow_test_symbols, trace);
 }
 
 #endif

--- a/src/libponyc/ast/parser.h
+++ b/src/libponyc/ast/parser.h
@@ -4,6 +4,7 @@
 #include "ast.h"
 #include "source.h"
 
-bool pass_parse(ast_t* package, source_t* source, errors_t* errors);
+bool pass_parse(ast_t* package, source_t* source, errors_t* errors,
+  bool allow_test_symbols, bool trace);
 
 #endif

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -129,9 +129,6 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state);
 
 // External API
 
-/// Enable or disable parsing trace output
-void parse_trace(bool enable);
-
 /** Generates a module AST and attaches it to the given package AST.
  * The expected argument is used in the generated error message if nothing is
  * found. It is not stored.
@@ -139,7 +136,7 @@ void parse_trace(bool enable);
  * failure.
  */
 bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
-  errors_t* errors);
+  errors_t* errors, bool allow_test_symbols, bool trace);
 
 
 /* The API for parser rules starts here */
@@ -464,7 +461,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
  * be freed within the provided code.
  *
  * Example:
- *    REWRITE(ast_print(ast));
+ *    REWRITE(ast_print(ast, 80));
  */
 #define REWRITE(body) \
   { \

--- a/src/libponyc/ast/treecheck.h
+++ b/src/libponyc/ast/treecheck.h
@@ -2,13 +2,15 @@
 #define TREE_CHECK_H
 
 #include <platform.h>
-#include "ast.h"
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct ast_t ast_t;
+typedef struct pass_opt_t pass_opt_t;
+
 // Check that the given AST is well formed.
 // Does nothing in release builds of the compiler.
-void check_tree(ast_t* tree, errors_t* errors);
+void check_tree(ast_t* tree, pass_opt_t* opt);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -890,11 +890,11 @@ static bool init_module(compile_t* c, ast_t* program, pass_opt_t* opt)
 
 bool codegen_merge_runtime_bitcode(compile_t* c)
 {
-  strlist_t* search = package_paths();
   char path[FILENAME_MAX];
   LLVMModuleRef runtime = NULL;
 
-  for(strlist_t* p = search; p != NULL && runtime == NULL; p = strlist_next(p))
+  for(strlist_t* p = c->opt->package_search_paths;
+    (p != NULL) && (runtime == NULL); p = strlist_next(p))
   {
     path_cat(strlist_data(p), "libponyrt.bc", path);
     runtime = LLVMParseIRFileInContext(c->context, path);

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -24,7 +24,7 @@ static struct
   const char* name;
   lexint_t limit;
   bool neg_plus_one;    // Is a negated value allowed to be 1 bigger
-} _str_uif_types[UIF_COUNT] =
+} const _str_uif_types[UIF_COUNT] =
 {
   { "U8", {0x100, 0}, false },
   { "U16", {0x10000, 0}, false },
@@ -53,7 +53,7 @@ typedef struct lit_op_info_t
   bool neg_plus_one;
 } lit_op_info_t;
 
-static lit_op_info_t _operator_fns[] =
+static const lit_op_info_t _operator_fns[] =
 {
   { "add", 1, true, false },
   { "sub", 1, true, false },
@@ -77,7 +77,7 @@ static lit_op_info_t _operator_fns[] =
 };
 
 
-static lit_op_info_t* lookup_literal_op(const char* name)
+static lit_op_info_t const* lookup_literal_op(const char* name)
 {
   for(int i = 0; _operator_fns[i].name != NULL; i++)
     if(strcmp(name, _operator_fns[i].name) == 0)
@@ -89,7 +89,7 @@ static lit_op_info_t* lookup_literal_op(const char* name)
 
 void operatorliteral_serialise_data(ast_t* ast, ast_t* dst)
 {
-  lit_op_info_t* data = (lit_op_info_t*)ast_data(ast);
+  lit_op_info_t const* data = (lit_op_info_t*)ast_data(ast);
   if(data != NULL)
   {
     size_t index = (size_t)(data - _operator_fns);
@@ -107,7 +107,7 @@ void operatorliteral_deserialise_data(ast_t* ast)
   if(index > 17)
     ast_setdata(ast, (void*)NULL);
   else
-    ast_setdata(ast, &_operator_fns[index]);
+    ast_setdata(ast, (void*)&_operator_fns[index]);
 }
 
 
@@ -588,7 +588,7 @@ static bool uif_type_from_chain(pass_opt_t* opt, ast_t* literal,
 
         if(parent_type != NULL && ast_id(parent_type) == TK_OPERATORLITERAL &&
           ast_child(parent) == literal &&
-          ((lit_op_info_t*)ast_data(parent_type))->neg_plus_one)
+          ((lit_op_info_t const*)ast_data(parent_type))->neg_plus_one)
           neg_plus_one = true;
       }
 
@@ -900,7 +900,7 @@ bool literal_member_access(ast_t* ast, pass_opt_t* opt)
   // Look up member name
   pony_assert(ast_id(name_node) == TK_ID);
   const char* name = ast_name(name_node);
-  lit_op_info_t* op = lookup_literal_op(name);
+  lit_op_info_t const* op = lookup_literal_op(name);
 
   if(op == NULL || ast_id(ast_parent(ast)) != TK_CALL)
   {
@@ -937,7 +937,7 @@ bool literal_call(ast_t* ast, pass_opt_t* opt)
   if(ast_id(recv_type) != TK_OPERATORLITERAL) // Nothing to do
     return true;
 
-  lit_op_info_t* op = (lit_op_info_t*)ast_data(recv_type);
+  lit_op_info_t const* op = (lit_op_info_t const*)ast_data(recv_type);
   pony_assert(op != NULL);
 
   if(ast_childcount(named_args) != 0)

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -97,6 +97,7 @@ void pass_opt_init(pass_opt_t* options)
   options->limit = PASS_ALL;
   options->verbosity = VERBOSITY_INFO;
   options->check.errors = errors_alloc();
+  options->ast_print_width = 80;
   frame_push(&options->check, NULL);
 }
 
@@ -179,7 +180,8 @@ static bool visit_pass(ast_t** astp, pass_opt_t* options, pass_id last_pass,
 
 bool module_passes(ast_t* package, pass_opt_t* options, source_t* source)
 {
-  if(!pass_parse(package, source, options->check.errors))
+  if(!pass_parse(package, source, options->check.errors,
+    options->allow_test_symbols, options->parse_trace))
     return false;
 
   if(options->limit < PASS_SYNTAX)
@@ -191,7 +193,7 @@ bool module_passes(ast_t* package, pass_opt_t* options, source_t* source)
     return false;
 
   if(options->check_tree)
-    check_tree(module, options->check.errors);
+    check_tree(module, options);
   return true;
 }
 
@@ -206,7 +208,7 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
     return r;
 
   if(options->check_tree)
-    check_tree(*astp, options->check.errors);
+    check_tree(*astp, options);
 
   if(!visit_pass(astp, options, last, &r, PASS_SCOPE, pass_scope, NULL))
     return r;
@@ -250,7 +252,7 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
     return false;
 
   if(options->check_tree)
-    check_tree(*astp, options->check.errors);
+    check_tree(*astp, options);
 
   if(ast_id(*astp) == TK_PROGRAM)
   {

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -204,6 +204,8 @@ typedef enum pass_id
   PASS_ALL
 } pass_id;
 
+typedef struct magic_package_t magic_package_t;
+
 /** Pass options.
  */
 typedef struct pass_opt_t
@@ -225,6 +227,15 @@ typedef struct pass_opt_t
   bool docs_private;
 
   verbosity_level verbosity;
+
+  size_t ast_print_width;
+  bool allow_test_symbols;
+  bool parse_trace;
+
+  strlist_t* package_search_paths;
+  strlist_t* safe_packages;
+  magic_package_t* magic_packages;
+
   const char* output;
   char* link_arch;
   char* linker;
@@ -234,6 +245,8 @@ typedef struct pass_opt_t
   char* features;
 
   typecheck_t check;
+
+  void* data; // User-defined data for unit test callbacks.
 } pass_opt_t;
 
 /** Limit processing to the specified pass. All passes up to and including the

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -336,7 +336,6 @@ static bool check_members(pass_opt_t* opt, ast_t* members, int entity_def_index)
       }
 
       default:
-        ast_print(members);
         pony_assert(0);
         return false;
     }
@@ -805,7 +804,7 @@ static ast_result_t syntax_type_param(pass_opt_t* opt, ast_t* ast)
 }
 
 
-static const char* _illegal_flags[] =
+static const char* const _illegal_flags[] =
 {
   "ndebug",
   "unknown_os",

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -43,7 +43,7 @@ static bool _stringtabed = false;
 
 // Replace all the strings in the _os_flags, _arch_flags and _size_flags
 // arrays with stringtab'ed versions the first time this is called.
-// This method of initialisatino is obviously not at all concurrency safe, but
+// This method of initialisation is obviously not at all concurrency safe, but
 // it works with unit tests trivially.
 static void stringtab_mutexgroups()
 {

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -103,7 +103,6 @@ static void cond_normalise(ast_t** astp)
       break;
 
     default:
-      ast_fprint(stderr, ast);
       pony_assert(0);
       break;
   }
@@ -160,7 +159,6 @@ static bool cond_eval(ast_t* ast, buildflagset_t* config, bool release,
     }
 
     default:
-      ast_fprint(stderr, ast);
       pony_assert(0);
       return false;
   }
@@ -200,7 +198,6 @@ static void find_flags_in_cond(ast_t* ast, buildflagset_t* config)
     }
 
     default:
-      ast_fprint(stderr, ast);
       pony_assert(0);
       break;
   }

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -12,6 +12,7 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct package_t package_t;
 typedef struct package_group_t package_group_t;
+typedef struct magic_package_t magic_package_t;
 
 DECLARE_LIST_SERIALISE(package_group_list, package_group_list_t,
   package_group_t)
@@ -28,11 +29,6 @@ void path_cat(const char* part1, const char* part2, char result[FILENAME_MAX]);
  * specified in the PONYPATH environment variable.
  */
 bool package_init(pass_opt_t* opt);
-
-/**
- * Gets the list of search paths.
- */
-strlist_t* package_paths();
 
 /**
  * Appends a list of paths to the list of paths that will be searched for
@@ -57,23 +53,19 @@ bool package_add_safe(const char* paths, pass_opt_t* opt);
  * The specified path is not expanded or normalised and must exactly match that
  * requested.
  */
-void package_add_magic_src(const char* path, const char* src);
+void package_add_magic_src(const char* path, const char* src, pass_opt_t* opt);
 
 /**
  * Add a magic package. Same as package_add_magic_src but uses an alternative
  * path instead.
  */
-void package_add_magic_path(const char* path, const char* mapped_path);
+void package_add_magic_path(const char* path, const char* mapped_path,
+  pass_opt_t* opt);
 
 /**
  * Clear any magic packages that have been added.
  */
-void package_clear_magic();
-
-/**
- * Suppress printing "building" message for each package.
- */
-void package_suppress_build_message();
+void package_clear_magic(pass_opt_t* opt);
 
 /**
  * Load a program. The path specifies the package that represents the program.
@@ -171,7 +163,7 @@ void package_group_dump(package_group_t* group);
 /**
  * Cleans up the list of search directories.
  */
-void package_done();
+void package_done(pass_opt_t* opt);
 
 pony_type_t* package_dep_signature_pony_type();
 

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -205,7 +205,7 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
   }
 
   // Library paths from the command line and environment variable.
-  for(strlist_t* p = package_paths(); p != NULL; p = strlist_next(p))
+  for(strlist_t* p = opt->package_search_paths; p != NULL; p = strlist_next(p))
   {
     const char* libpath = quoted_locator(opt, NULL, strlist_data(p));
 

--- a/src/libponyc/pkg/use.c
+++ b/src/libponyc/pkg/use.c
@@ -20,14 +20,16 @@
  */
 
 
-struct
+typedef struct use_scheme_t
 {
   const char* scheme; // Interned textual identifier including :
   size_t scheme_len;  // Number of characters in scheme, including :
   bool allow_name;    // Is the name clause allowed
   bool allow_guard;   // Is the guard expression allowed
   use_handler_t handler;
-} handlers[] =
+} use_scheme_t;
+
+static __pony_thread_local use_scheme_t handlers[] =
 {
   {"package:", 8, true, false, use_package},
   {"lib:", 4, false, true, use_library},

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -20,7 +20,7 @@ typedef struct vsinfo_t
   char* lib_path;    // lib subdir; must NOT have trailing '\\'
 } vsinfo_t;
 
-static vsinfo_t vs_infos[] =
+static const vsinfo_t vs_infos[] =
 {
   { // VS2017 full install & Visual C++ Build Tools 2017
     "15.0", "SOFTWARE\\WOW6432Node\\Microsoft\\VisualStudio\\SxS\\VS7", 
@@ -326,7 +326,7 @@ static bool find_msvcrt_and_linker(compile_t *c, vcvars_t* vcvars, errors_t* err
   TCHAR link_path[MAX_PATH + 1];
   TCHAR lib_path[MAX_PATH + 1];
 
-  vsinfo_t* info;
+  const vsinfo_t* info;
   for (info = vs_infos; info->version != NULL; info++)
   {
     if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)

--- a/src/libponyc/ponyc.c
+++ b/src/libponyc/ponyc.c
@@ -20,7 +20,7 @@ bool ponyc_init(pass_opt_t* options)
 void ponyc_shutdown(pass_opt_t* options)
 {
   errors_print(options->check.errors);
-  package_done();
+  package_done(options);
   codegen_pass_cleanup(options);
   codegen_llvm_shutdown();
   stringtab_done();

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -14,8 +14,8 @@ PONY_EXTERN_C_BEGIN
 #include <stdio.h>
 #endif
 
-static __thread struct _Unwind_Exception exception;
-static __thread uintptr_t landing_pad;
+static __pony_thread_local struct _Unwind_Exception exception;
+static __pony_thread_local uintptr_t landing_pad;
 
 static void exception_cleanup(_Unwind_Reason_Code reason,
   struct _Unwind_Exception* exception)

--- a/src/libponyrt/lang/win_except.c
+++ b/src/libponyrt/lang/win_except.c
@@ -7,7 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-static __declspec(thread) uintptr_t landing_pad;
+static __pony_thread_local uintptr_t landing_pad;
 
 PONY_API void pony_throw()
 {

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -8,6 +8,7 @@
 #include "../gc/serialise.h"
 #include "../lang/socket.h"
 #include "../options/options.h"
+#include "ponyassert.h"
 #include <dtrace.h>
 #include <string.h>
 #include <stdlib.h>
@@ -28,6 +29,7 @@ typedef struct options_t
 } options_t;
 
 // global data
+static PONY_ATOMIC(bool) initialised;
 static PONY_ATOMIC(int) exit_code;
 static bool language_init;
 
@@ -92,6 +94,14 @@ static int parse_opts(int argc, char** argv, options_t* opt)
 
 PONY_API int pony_init(int argc, char** argv)
 {
+  bool prev_init = atomic_exchange_explicit(&initialised, true,
+    memory_order_acquire);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&initialised);
+#endif
+  (void)prev_init;
+  pony_assert(!prev_init);
+
   DTRACE0(RT_INIT);
   options_t opt;
   memset(&opt, 0, sizeof(options_t));
@@ -124,6 +134,8 @@ PONY_API int pony_init(int argc, char** argv)
 
 PONY_API int pony_start(bool library, bool language_features)
 {
+  pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
+
   if(language_features)
   {
     if(!ponyint_os_sockets_init())
@@ -147,11 +159,19 @@ PONY_API int pony_start(bool library, bool language_features)
     language_init = false;
   }
 
-  return pony_get_exitcode();
+  int ec = pony_get_exitcode();
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&initialised);
+#endif
+  atomic_thread_fence(memory_order_acq_rel);
+  atomic_store_explicit(&initialised, false, memory_order_relaxed);
+  return ec;
 }
 
 PONY_API int pony_stop()
 {
+  pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
+
   ponyint_sched_stop();
   if(language_init)
   {
@@ -159,7 +179,13 @@ PONY_API int pony_stop()
     language_init = false;
   }
 
-  return pony_get_exitcode();
+  int ec = pony_get_exitcode();
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&initialised);
+#endif
+  atomic_thread_fence(memory_order_acq_rel);
+  atomic_store_explicit(&initialised, false, memory_order_relaxed);
+  return ec;
 }
 
 PONY_API void pony_exitcode(int code)

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -251,10 +251,10 @@ static bool compile_package(const char* path, pass_opt_t* opt,
     return false;
 
   if(print_program_ast)
-    ast_fprint(stderr, program);
+    ast_fprint(stderr, program, opt->ast_print_width);
 
   if(print_package_ast)
-    ast_fprint(stderr, ast_child(program));
+    ast_fprint(stderr, ast_child(program), opt->ast_print_width);
 
   bool ok = generate_passes(program, opt);
   ast_free(program);
@@ -270,8 +270,8 @@ int main(int argc, char* argv[])
 
   opt.release = true;
   opt.output = ".";
+  opt.ast_print_width = get_width();
 
-  ast_setwidth(get_width());
   bool print_program_ast = false;
   bool print_package_ast = false;
 
@@ -333,8 +333,8 @@ int main(int argc, char* argv[])
 
       case OPT_AST: print_program_ast = true; break;
       case OPT_ASTPACKAGE: print_package_ast = true; break;
-      case OPT_TRACE: parse_trace(true); break;
-      case OPT_WIDTH: ast_setwidth(atoi(s.arg_val)); break;
+      case OPT_TRACE: opt.parse_trace = true; break;
+      case OPT_WIDTH: opt.ast_print_width = atoi(s.arg_val); break;
       case OPT_IMMERR: errors_set_immediate(opt.check.errors, true); break;
       case OPT_VERIFY: opt.verify = true; break;
       case OPT_EXTFUN: opt.extfun = true; break;

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -145,7 +145,7 @@ TEST_F(CodegenTest, BoxBoolAsUnionIntoTuple)
 extern "C"
 {
 
-uint32_t num_objects = 0;
+static uint32_t num_objects = 0;
 
 EXPORT_SYMBOL void codegentest_small_finalisers_increment_num_objects() {
   num_objects++;

--- a/test/libponyc/compiler_serialisation.cc
+++ b/test/libponyc/compiler_serialisation.cc
@@ -20,7 +20,7 @@ public:
   void test_pass_reach(const char* pass);
 };
 
-static const char* src =
+static const char* const src =
   "actor Main\n"
   "  new create(env: Env) =>\n"
   "    let x = recover Array[U8] end\n"

--- a/test/libponyc/lexer.cc
+++ b/test/libponyc/lexer.cc
@@ -36,7 +36,7 @@ protected:
   {
     errors_t* errors = errors_alloc();
     source_t* source = source_open_string(src);
-    lexer_t* lexer = lexer_open(source, errors);
+    lexer_t* lexer = lexer_open(source, errors, false);
     token_id id = TK_LEX_ERROR;
     string actual;
 


### PR DESCRIPTION
This change removes global state from the compiler and runtime, or makes it thread safe when removal would be impractical.

The stringtab in the compiler still uses thread unsafe global state as it affects many parts of the compiler and would deserve a separate refactoring.