### PR TITLE
add notes about net.NetAddress representing sockaddr_in4/6

### DIFF
--- a/packages/net/net_address.pony
+++ b/packages/net/net_address.pony
@@ -4,6 +4,13 @@ class val NetAddress is Equatable[NetAddress]
   type. The addr field is either the IPv4 address or the IPv6 flow info. The
   addr1-4 fields are the IPv6 address, or invalid for an IPv4 address. The
   scope field is the IPv6 scope, or invalid for an IPv4 address.
+
+  This class is modelled after the C data structure for holding socket
+  addresses for both IPv4 and IPv6 `sockaddr_storage`.
+
+  The public fields of this class model exactly the fields of `sockaddr_in`
+  and are in network byte order. Use the `name` method
+  to obtain address/hostname and port/service as Strings.
   """
   let length: U8 = 0
   let family: U8 = 0
@@ -33,7 +40,21 @@ class val NetAddress is Equatable[NetAddress]
     : (String, String) ?
   =>
     """
-    Return the host and service name.
+    Returns the host and service name.
+
+    If `reversedns` is an instance of `DNSLookupAuth`
+    a DNS lookup will be executed and the hostname
+    for this address is returned as first element of the result tuple.
+    If no hostname could be found, an error is raised.
+    If `reversedns` is `None` the plain IP address is given
+    and no DNS lookup is executed.
+
+    If `servicename` is `false` the numeric port is returned
+    as second element of the result tuple.
+    If it is `true` the port is translated into its
+    corresponding servicename (e.g. port 80 is returned as `"http"`).
+
+    Internally this method uses the POSIX C function `getnameinfo`.
     """
     var host: Pointer[U8] iso = recover Pointer[U8] end
     var serv: Pointer[U8] iso = recover Pointer[U8] end


### PR DESCRIPTION
and about the name method possibly doing a DNS lookup.

This is not obvious but is a big point of confusion, especially when trying to retrieve the numeric port, which is in network byte-order. 

[skip ci]