### PR TITLE
Add DTrace probes for all message push and pop operations

### DIFF
--- a/examples/dtrace/mbox-size-all-actor-messages.d
+++ b/examples/dtrace/mbox-size-all-actor-messages.d
@@ -1,0 +1,66 @@
+#!/usr/bin/env dtrace -x aggsortkey -x aggsortkeypos=0 -q -s
+
+/*
+ * Messages such as ACTORMSG_ACK and ACTORMSG_CONF (see telemetry.d)
+ * aren't caused directly by Pony code that is visible to the
+ * programmer.
+ *
+ * This script will treat system message IDs as twos-complement and
+ * convert them to negative numbers.  See the comments on the right
+ * margin to find their negative integer representation.
+ */
+
+inline unsigned int UINT32_MAX = 4294967295;
+inline unsigned int ACTORMSG_APPLICATION_START = (UINT32_MAX - 7);  /* -8 */
+inline unsigned int ACTORMSG_BLOCK = (UINT32_MAX - 6);              /* -7 */
+inline unsigned int ACTORMSG_UNBLOCK = (UINT32_MAX - 5);            /* -6 */
+inline unsigned int ACTORMSG_ACQUIRE = (UINT32_MAX - 4);            /* -5 */
+inline unsigned int ACTORMSG_RELEASE = (UINT32_MAX - 3);            /* -4 */
+inline unsigned int ACTORMSG_CONF = (UINT32_MAX - 2);               /* -3 */
+inline unsigned int ACTORMSG_ACK = (UINT32_MAX - 1);                /* -2 */
+
+inline unsigned int SMALLEST_ACTORMSG = ACTORMSG_APPLICATION_START;
+
+BEGIN
+{
+  printf("Column headings:    actor id, msg id (sys msg < zero), msg-in|msg-out, =, count\n");
+  printf("System message ids: ACK = -2, CONF = -3, RELEASE = -4,\n");
+  printf("                    ACQUIRE = -5, UNBLOCK = -6,\n");
+  printf("                    BLOCK = -7, APPLICATION_START = -8\n");
+  printf("\n");
+}
+
+pony$target:::actor-msg-push
+{
+  this->scheduler = arg0;
+  this->msg_id = arg1;
+  this->actor_from = arg2;
+  this->actor_to = arg3;
+  this->msg_id = (this->msg_id < SMALLEST_ACTORMSG) ? \
+      this->msg_id : (-1 * (this->msg_id ^ 0xffffffff)) - 1;
+  @all[this->actor_to, this->msg_id, "msg-in"] = count();
+}
+
+pony$target:::actor-msg-pop
+{
+  this->scheduler = arg0;
+  this->msg_id = arg1;
+  this->actor = arg2;
+  this->msg_id = (this->msg_id < SMALLEST_ACTORMSG) ? \
+      this->msg_id : (-1 * (this->msg_id ^ 0xffffffff)) - 1;
+  @all[this->actor, this->msg_id, "msg-out"] = count();
+}
+
+tick-1sec
+{
+  printa("%12d %5d %-7s = %@12d\n", @all);
+  printf("\n");
+  clear(@all);
+}
+
+END
+{
+  printf("Final:\n");
+  printa("%12d %5d %-7s = %@12d\n", @all);
+  printf("\n");
+}

--- a/examples/dtrace/mbox-size-all-thread-messages.d
+++ b/examples/dtrace/mbox-size-all-thread-messages.d
@@ -1,0 +1,42 @@
+#!/usr/bin/env dtrace -x aggsortkey -x aggsortkeypos=0 -q -s
+
+BEGIN
+{
+  printf("Column headings:      scheduler #, msg type, msg-in|msg-out, =, count\n");
+  printf("Special scheduler #s: KQUEUE = -10, IOCP = -11, EPOLL =- 12\n");
+  printf("Message types:        SCHED_BLOCK = 20, SCHED_UNBLOCK = 21,\n");
+  printf("Message types:        SCHED_CNF = 30, SCHED_ACK = 31,\n");
+  printf("Message types:        SCHED_TERMINATE = 40, SCHED_UNMUTE_ACTOR = 50\n");
+  printf("Message types:        SCHED_NOISY_ASIO = 51, SCHED_UNNOISY_ASIO = 52\n");
+  printf("Message types:        OTHER = 0\n");
+  printf("\n");
+}
+
+pony$target:::thread-msg-push
+{
+  this->msg_id = arg0;
+  this->thread_from = arg1;
+  this->thread_to = arg2;
+  @all[this->thread_to, this->msg_id, "msg-in"] = count();
+}
+
+pony$target:::thread-msg-pop
+{
+  this->msg_id = arg0;
+  this->thread = arg1;
+  @all[this->thread, this->msg_id, "msg-out"] = count();
+}
+
+tick-1sec
+{
+  printa("%3d %3d %-7s = %@12d\n", @all);
+  printf("\n");
+  clear(@all);
+}
+
+END
+{
+  printf("Final:\n");
+  printa("%3d %3d %-7s = %@12d\n", @all);
+  printf("\n");
+}

--- a/src/common/dtrace_probes.d
+++ b/src/common/dtrace_probes.d
@@ -23,6 +23,38 @@ provider pony {
   probe actor__msg__run(uintptr_t scheduler, uintptr_t actor, uint32_t id);
 
   /**
+   * Fired when a message is being sent to an actor
+   * @param scheduler is the active scheduler's index
+   * @param id the message id
+   * @param actor_from is the sending actor
+   * @param actor_to is the receiving actor
+   */
+  probe actor__msg__push(int32_t scheduler_index, uint32_t id, uintptr_t actor_from, uintptr_t actor_to);
+
+  /**
+   * Fired when a message is being run by an actor
+   * @param scheduler is the active scheduler's index
+   * @param id the message id
+   * @param actor_to is the receiving actor
+   */
+  probe actor__msg__pop(int32_t scheduler_index, uint32_t id, uintptr_t actor);
+
+  /**
+   * Fired when a message is being sent to an thread
+   * @param id the message id
+   * @param thread_from is the sending thread index
+   * @param thread_to is the receiving thread index
+   */
+  probe thread__msg__push(uint32_t id, uintptr_t thread_from, uintptr_t thread_to);
+
+  /**
+   * Fired when a message is being run by an thread
+   * @param id the message id
+   * @param thread_to is the receiving thread index
+   */
+  probe thread__msg__pop(uint32_t id, uintptr_t thread);
+
+  /**
    * Fired when actor is scheduled
    * @param scheduler is the scheduler that scheduled the actor
    * @param actor is the scheduled actor

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -217,7 +217,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   // If we have been scheduled, the head will not be marked as empty.
   pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
 
-  while((msg = ponyint_actor_messageq_pop(ctx->scheduler, ctx->current, &actor->q)) != NULL)
+  while((msg = ponyint_actor_messageq_pop(&actor->q, ctx->scheduler, ctx->current)) != NULL)
   {
     if(handle_message(ctx, actor, msg))
     {
@@ -492,8 +492,8 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_actor_messageq_push(ctx->scheduler, ctx->current, to,
-       &to->q, first, last))
+  if(ponyint_actor_messageq_push(&to->q, first, last,
+    ctx->scheduler, ctx->current, to))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {
@@ -528,8 +528,8 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_actor_messageq_push_single(ctx->scheduler, ctx->current, to,
-       &to->q, first, last))
+  if(ponyint_actor_messageq_push_single(&to->q, first, last,
+    ctx->scheduler, ctx->current, to))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -217,7 +217,11 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   // If we have been scheduled, the head will not be marked as empty.
   pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
 
-  while((msg = ponyint_actor_messageq_pop(&actor->q, ctx->scheduler, ctx->current)) != NULL)
+  while((msg = ponyint_actor_messageq_pop(&actor->q
+#ifdef USE_DYNAMIC_TRACE    
+    , ctx->scheduler, ctx->current
+#endif
+    )) != NULL)
   {
     if(handle_message(ctx, actor, msg))
     {
@@ -492,8 +496,11 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_actor_messageq_push(&to->q, first, last,
-    ctx->scheduler, ctx->current, to))
+  if(ponyint_actor_messageq_push(&to->q, first, last
+#ifdef USE_DYNAMIC_TRACE 
+    , ctx->scheduler, ctx->current, to
+#endif
+    ))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {
@@ -528,8 +535,11 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_actor_messageq_push_single(&to->q, first, last,
-    ctx->scheduler, ctx->current, to))
+  if(ponyint_actor_messageq_push_single(&to->q, first, last
+#ifdef USE_DYNAMIC_TRACE
+    , ctx->scheduler, ctx->current, to
+#endif
+    ))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -217,7 +217,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   // If we have been scheduled, the head will not be marked as empty.
   pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
 
-  while((msg = ponyint_messageq_pop(&actor->q)) != NULL)
+  while((msg = ponyint_actor_messageq_pop(ctx->scheduler, ctx->current, &actor->q)) != NULL)
   {
     if(handle_message(ctx, actor, msg))
     {
@@ -492,7 +492,8 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_messageq_push(&to->q, first, last))
+  if(ponyint_actor_messageq_push(ctx->scheduler, ctx->current, to,
+       &to->q, first, last))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {
@@ -527,7 +528,8 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   if(has_app_msg)
     ponyint_maybe_mute(ctx, to);
 
-  if(ponyint_messageq_push_single(&to->q, first, last))
+  if(ponyint_actor_messageq_push_single(ctx->scheduler, ctx->current, to,
+       &to->q, first, last))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED) && !ponyint_is_muted(to))
     {
@@ -708,11 +710,12 @@ bool ponyint_actor_overloaded(pony_actor_t* actor)
 
 void ponyint_actor_unsetoverloaded(pony_actor_t* actor)
 {
+  pony_ctx_t* ctx = pony_ctx();
   unset_flag(actor, FLAG_OVERLOADED);
   DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
   if (!has_flag(actor, FLAG_UNDER_PRESSURE))
   {
-    ponyint_sched_start_global_unmute(actor);
+    ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
   }
 }
 
@@ -729,7 +732,7 @@ PONY_API void pony_release_backpressure()
   unset_flag(ctx->current, FLAG_UNDER_PRESSURE);
   DTRACE1(ACTOR_PRESSURE_RELEASED, (uintptr_t)ctx->current);
   if (!has_flag(ctx->current, FLAG_OVERLOADED))
-      ponyint_sched_start_global_unmute(ctx->current);
+    ponyint_sched_start_global_unmute(ctx->scheduler->index, ctx->current);
 }
 
 bool ponyint_triggers_muting(pony_actor_t* actor)

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -107,9 +107,9 @@ void ponyint_messageq_destroy(messageq_t* q)
   q->tail = NULL;
 }
 
-bool ponyint_actor_messageq_push(scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor,
-  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+bool ponyint_actor_messageq_push(messageq_t* q, pony_msg_t* first,
+  pony_msg_t* last, scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor)
 {
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
@@ -134,8 +134,8 @@ bool ponyint_actor_messageq_push(scheduler_t* sched,
   return messageq_push(q, first, last);
 }
 
-bool ponyint_thread_messageq_push(uintptr_t from_thr, uintptr_t to_thr,
-  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+bool ponyint_thread_messageq_push(messageq_t* q, pony_msg_t* first,
+  pony_msg_t* last, uintptr_t from_thr, uintptr_t to_thr)
 {
   if(DTRACE_ENABLED(THREAD_MSG_PUSH))
   {
@@ -156,9 +156,9 @@ bool ponyint_thread_messageq_push(uintptr_t from_thr, uintptr_t to_thr,
   return messageq_push(q, first, last);
 }
 
-bool ponyint_actor_messageq_push_single(scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor,
-  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+bool ponyint_actor_messageq_push_single(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor)
 {
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
@@ -183,9 +183,9 @@ bool ponyint_actor_messageq_push_single(scheduler_t* sched,
   return messageq_push_single(q, first, last);
 }
 
-bool ponyint_thread_messageq_push_single(
-  uintptr_t from_thr, uintptr_t to_thr,
-  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+bool ponyint_thread_messageq_push_single(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last,
+  uintptr_t from_thr, uintptr_t to_thr)
 {
   if(DTRACE_ENABLED(THREAD_MSG_PUSH))
   {
@@ -206,8 +206,8 @@ bool ponyint_thread_messageq_push_single(
   return messageq_push_single(q, first, last);
 }
 
-pony_msg_t* ponyint_actor_messageq_pop(scheduler_t* sched,
-  pony_actor_t* actor, messageq_t* q)
+pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q,
+  scheduler_t* sched, pony_actor_t* actor)
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
@@ -230,7 +230,7 @@ pony_msg_t* ponyint_actor_messageq_pop(scheduler_t* sched,
   return next;
 }
 
-pony_msg_t* ponyint_thread_messageq_pop(uintptr_t thr, messageq_t* q)
+pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q, uintptr_t thr)
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -4,6 +4,7 @@
 #include "../mem/pool.h"
 #include "ponyassert.h"
 #include <string.h>
+#include <dtrace.h>
 
 #ifdef USE_VALGRIND
 #include <valgrind/helgrind.h>
@@ -26,6 +27,56 @@ static size_t messageq_size_debug(messageq_t* q)
 }
 
 #endif
+
+static bool messageq_push(messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+{
+  atomic_store_explicit(&last->next, NULL, memory_order_relaxed);
+
+  // Without that fence, the store to last->next above could be reordered after
+  // the exchange on the head and after the store to prev->next done by the
+  // next push, which would result in the pop incorrectly seeing the queue as
+  // empty.
+  // Also synchronise with the pop on prev->next.
+  atomic_thread_fence(memory_order_release);
+
+  pony_msg_t* prev = atomic_exchange_explicit(&q->head, last,
+    memory_order_relaxed);
+
+  bool was_empty = ((uintptr_t)prev & 1) != 0;
+  prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
+
+#ifdef USE_VALGRIND
+  // Double fence with Valgrind since we need to have prev in scope for the
+  // synchronisation annotation.
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+  atomic_thread_fence(memory_order_release);
+#endif
+  atomic_store_explicit(&prev->next, first, memory_order_relaxed);
+
+  return was_empty;
+}
+
+static bool messageq_push_single(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last)
+{
+  atomic_store_explicit(&last->next, NULL, memory_order_relaxed);
+
+  // If we have a single producer, the swap of the head need not be atomic RMW.
+  pony_msg_t* prev = atomic_load_explicit(&q->head, memory_order_relaxed);
+  atomic_store_explicit(&q->head, last, memory_order_relaxed);
+
+  bool was_empty = ((uintptr_t)prev & 1) != 0;
+  prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
+
+  // If we have a single producer, the fence can be replaced with a store
+  // release on prev->next.
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_BEFORE(&prev->next);
+#endif
+  atomic_store_explicit(&prev->next, first, memory_order_release);
+
+  return was_empty;
+}
 
 void ponyint_messageq_init(messageq_t* q)
 {
@@ -56,63 +107,114 @@ void ponyint_messageq_destroy(messageq_t* q)
   q->tail = NULL;
 }
 
-bool ponyint_messageq_push(messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+bool ponyint_actor_messageq_push(scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor,
+  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
 {
-  atomic_store_explicit(&last->next, NULL, memory_order_relaxed);
+  if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
+  {
+    pony_msg_t* m = first;
+    int32_t index = (sched == NULL) ? UNKNOWN_SCHEDULER : sched->index;
 
-  // Without that fence, the store to last->next above could be reordered after
-  // the exchange on the head and after the store to prev->next done by the
-  // next push, which would result in the pop incorrectly seeing the queue as
-  // empty.
-  // Also synchronise with the pop on prev->next.
-  atomic_thread_fence(memory_order_release);
+    while(m != last)
+    {
+      DTRACE4(ACTOR_MSG_PUSH, index, m->id,
+        (uintptr_t)from_actor, (uintptr_t)to_actor);
+      m = atomic_load_explicit(&m->next, memory_order_relaxed);
+    }
 
-  pony_msg_t* prev = atomic_exchange_explicit(&q->head, last,
-    memory_order_relaxed);
+    DTRACE4(ACTOR_MSG_PUSH, index, last->id,
+      (uintptr_t)from_actor, (uintptr_t)to_actor);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)index;
+    (void)from_actor;
+    (void)to_actor;
+  }
 
-  bool was_empty = ((uintptr_t)prev & 1) != 0;
-  prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
-
-#ifdef USE_VALGRIND
-  // Double fence with Valgrind since we need to have prev in scope for the
-  // synchronisation annotation.
-  ANNOTATE_HAPPENS_BEFORE(&prev->next);
-  atomic_thread_fence(memory_order_release);
-#endif
-  atomic_store_explicit(&prev->next, first, memory_order_relaxed);
-
-  return was_empty;
+  return messageq_push(q, first, last);
 }
 
-bool ponyint_messageq_push_single(messageq_t* q, pony_msg_t* first,
-  pony_msg_t* last)
+bool ponyint_thread_messageq_push(uintptr_t from_thr, uintptr_t to_thr,
+  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
 {
-  atomic_store_explicit(&last->next, NULL, memory_order_relaxed);
+  if(DTRACE_ENABLED(THREAD_MSG_PUSH))
+  {
+    pony_msg_t* m = first;
 
-  // If we have a single producer, the swap of the head need not be atomic RMW.
-  pony_msg_t* prev = atomic_load_explicit(&q->head, memory_order_relaxed);
-  atomic_store_explicit(&q->head, last, memory_order_relaxed);
+    while(m != last)
+    {
+      DTRACE3(THREAD_MSG_PUSH, m->id, from_thr, to_thr);
+      m = atomic_load_explicit(&m->next, memory_order_relaxed);
+    }
 
-  bool was_empty = ((uintptr_t)prev & 1) != 0;
-  prev = (pony_msg_t*)((uintptr_t)prev & ~(uintptr_t)1);
+    DTRACE3(THREAD_MSG_PUSH, last->id, from_thr, to_thr);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)from_thr;
+    (void)to_thr;
+  }
 
-  // If we have a single producer, the fence can be replaced with a store
-  // release on prev->next.
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_BEFORE(&prev->next);
-#endif
-  atomic_store_explicit(&prev->next, first, memory_order_release);
-
-  return was_empty;
+  return messageq_push(q, first, last);
 }
 
-pony_msg_t* ponyint_messageq_pop(messageq_t* q)
+bool ponyint_actor_messageq_push_single(scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor,
+  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+{
+  if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
+  {
+    pony_msg_t* m = first;
+    int32_t index = (sched == NULL) ? UNKNOWN_SCHEDULER : sched->index;
+
+    while(m != last)
+    {
+      DTRACE4(ACTOR_MSG_PUSH, index, m->id,
+        (uintptr_t)from_actor, (uintptr_t)to_actor);
+      m = atomic_load_explicit(&m->next, memory_order_relaxed);
+    }
+
+    DTRACE4(ACTOR_MSG_PUSH, index, m->id,
+      (uintptr_t)from_actor, (uintptr_t)to_actor);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)index;
+    (void)from_actor;
+    (void)to_actor;
+  }
+
+  return messageq_push_single(q, first, last);
+}
+
+bool ponyint_thread_messageq_push_single(
+  uintptr_t from_thr, uintptr_t to_thr,
+  messageq_t* q, pony_msg_t* first, pony_msg_t* last)
+{
+  if(DTRACE_ENABLED(THREAD_MSG_PUSH))
+  {
+    pony_msg_t* m = first;
+
+    while(m != last)
+    {
+      DTRACE3(THREAD_MSG_PUSH, m->id, from_thr, to_thr);
+      m = atomic_load_explicit(&m->next, memory_order_relaxed);
+    }
+
+    DTRACE3(THREAD_MSG_PUSH, m->id, from_thr, to_thr);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)from_thr;
+    (void)to_thr;
+  }
+
+  return messageq_push_single(q, first, last);
+}
+
+pony_msg_t* ponyint_actor_messageq_pop(scheduler_t* sched,
+  pony_actor_t* actor, messageq_t* q)
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
 
   if(next != NULL)
   {
+    DTRACE3(ACTOR_MSG_POP, sched->index, (uint32_t) next->id, (uintptr_t) actor);
     q->tail = next;
     atomic_thread_fence(memory_order_acquire);
 #ifdef USE_VALGRIND
@@ -120,6 +222,31 @@ pony_msg_t* ponyint_messageq_pop(messageq_t* q)
     ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
 #endif
     ponyint_pool_free(tail->index, tail);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)sched;
+    (void)actor;
+  }
+
+  return next;
+}
+
+pony_msg_t* ponyint_thread_messageq_pop(uintptr_t thr, messageq_t* q)
+{
+  pony_msg_t* tail = q->tail;
+  pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
+
+  if(next != NULL)
+  {
+    DTRACE2(THREAD_MSG_POP, (uint32_t) next->id, (uintptr_t) thr);
+    q->tail = next;
+    atomic_thread_fence(memory_order_acquire);
+#ifdef USE_VALGRIND
+    ANNOTATE_HAPPENS_AFTER(&tail->next);
+    ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
+#endif
+    ponyint_pool_free(tail->index, tail);
+    /* Hush compiler warnings when DTrace isn't available */
+    (void)thr;
   }
 
   return next;

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -108,9 +108,14 @@ void ponyint_messageq_destroy(messageq_t* q)
 }
 
 bool ponyint_actor_messageq_push(messageq_t* q, pony_msg_t* first,
-  pony_msg_t* last, scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor)
+  pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor
+#endif
+  )
 {
+#ifdef USE_DYNAMIC_TRACE
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
     pony_msg_t* m = first;
@@ -130,13 +135,18 @@ bool ponyint_actor_messageq_push(messageq_t* q, pony_msg_t* first,
     (void)from_actor;
     (void)to_actor;
   }
-
+#endif
   return messageq_push(q, first, last);
 }
 
 bool ponyint_thread_messageq_push(messageq_t* q, pony_msg_t* first,
-  pony_msg_t* last, uintptr_t from_thr, uintptr_t to_thr)
+  pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , uintptr_t from_thr, uintptr_t to_thr
+#endif
+  )
 {
+#ifdef USE_DYNAMIC_TRACE
   if(DTRACE_ENABLED(THREAD_MSG_PUSH))
   {
     pony_msg_t* m = first;
@@ -152,14 +162,18 @@ bool ponyint_thread_messageq_push(messageq_t* q, pony_msg_t* first,
     (void)from_thr;
     (void)to_thr;
   }
-
+#endif
   return messageq_push(q, first, last);
 }
 
 bool ponyint_actor_messageq_push_single(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor)
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched, pony_actor_t* from_actor, pony_actor_t* to_actor
+#endif
+  )
 {
+#ifdef USE_DYNAMIC_TRACE
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
     pony_msg_t* m = first;
@@ -179,14 +193,18 @@ bool ponyint_actor_messageq_push_single(messageq_t* q,
     (void)from_actor;
     (void)to_actor;
   }
-
+#endif
   return messageq_push_single(q, first, last);
 }
 
 bool ponyint_thread_messageq_push_single(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last,
-  uintptr_t from_thr, uintptr_t to_thr)
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , uintptr_t from_thr, uintptr_t to_thr
+#endif
+  )
 {
+#ifdef USE_DYNAMIC_TRACE
   if(DTRACE_ENABLED(THREAD_MSG_PUSH))
   {
     pony_msg_t* m = first;
@@ -202,12 +220,15 @@ bool ponyint_thread_messageq_push_single(messageq_t* q,
     (void)from_thr;
     (void)to_thr;
   }
-
+#endif
   return messageq_push_single(q, first, last);
 }
 
-pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q,
-  scheduler_t* sched, pony_actor_t* actor)
+pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched, pony_actor_t* actor
+#endif
+  )
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
@@ -222,15 +243,16 @@ pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q,
     ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
 #endif
     ponyint_pool_free(tail->index, tail);
-    /* Hush compiler warnings when DTrace isn't available */
-    (void)sched;
-    (void)actor;
   }
 
   return next;
 }
 
-pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q, uintptr_t thr)
+pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q
+#ifdef USE_DYNAMIC_TRACE
+  , uintptr_t thr
+#endif
+  )
 {
   pony_msg_t* tail = q->tail;
   pony_msg_t* next = atomic_load_explicit(&tail->next, memory_order_relaxed);
@@ -245,8 +267,6 @@ pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q, uintptr_t thr)
     ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(tail);
 #endif
     ponyint_pool_free(tail->index, tail);
-    /* Hush compiler warnings when DTrace isn't available */
-    (void)thr;
   }
 
   return next;

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -2,9 +2,6 @@
 #define messageq_h
 
 #include "../pony.h"
-#include <platform.h>
-
-PONY_EXTERN_C_BEGIN
 
 typedef struct messageq_t
 {
@@ -12,16 +9,38 @@ typedef struct messageq_t
   pony_msg_t* tail;
 } messageq_t;
 
+#include "../sched/scheduler.h"
+#include <platform.h>
+
+#define UNKNOWN_SCHEDULER -1
+
+PONY_EXTERN_C_BEGIN
+
 void ponyint_messageq_init(messageq_t* q);
 
 void ponyint_messageq_destroy(messageq_t* q);
 
-bool ponyint_messageq_push(messageq_t* q, pony_msg_t* first, pony_msg_t* last);
+bool ponyint_actor_messageq_push(scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor, messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last);
 
-bool ponyint_messageq_push_single(messageq_t* q, pony_msg_t* first,
-  pony_msg_t* last);
+bool ponyint_actor_messageq_push_single(scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor, messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last);
 
-pony_msg_t* ponyint_messageq_pop(messageq_t* q);
+pony_msg_t* ponyint_actor_messageq_pop(scheduler_t* sched,
+  pony_actor_t* actor, messageq_t* q);
+
+bool ponyint_thread_messageq_push(
+  uintptr_t from_thread, uintptr_t to_thread, messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last);
+
+bool ponyint_thread_messageq_push_single(
+  uintptr_t from_thread, uintptr_t to_thread, messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last);
+
+pony_msg_t* ponyint_thread_messageq_pop(
+  uintptr_t thr, messageq_t* q);
 
 bool ponyint_messageq_markempty(messageq_t* q);
 

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -20,27 +20,27 @@ void ponyint_messageq_init(messageq_t* q);
 
 void ponyint_messageq_destroy(messageq_t* q);
 
-bool ponyint_actor_messageq_push(scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor, messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last);
+bool ponyint_actor_messageq_push(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor);
 
-bool ponyint_actor_messageq_push_single(scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor, messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last);
+bool ponyint_actor_messageq_push_single(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor);
 
-pony_msg_t* ponyint_actor_messageq_pop(scheduler_t* sched,
-  pony_actor_t* actor, messageq_t* q);
+pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q,
+  scheduler_t* sched, pony_actor_t* actor);
 
-bool ponyint_thread_messageq_push(
-  uintptr_t from_thread, uintptr_t to_thread, messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last);
+bool ponyint_thread_messageq_push(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last,
+  uintptr_t from_thread, uintptr_t to_thread);
 
-bool ponyint_thread_messageq_push_single(
-  uintptr_t from_thread, uintptr_t to_thread, messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last);
+bool ponyint_thread_messageq_push_single(messageq_t* q,
+  pony_msg_t* first, pony_msg_t* last,
+  uintptr_t from_thread, uintptr_t to_thread);
 
-pony_msg_t* ponyint_thread_messageq_pop(
-  uintptr_t thr, messageq_t* q);
+pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q,
+  uintptr_t thr);
 
 bool ponyint_messageq_markempty(messageq_t* q);
 

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -21,26 +21,46 @@ void ponyint_messageq_init(messageq_t* q);
 void ponyint_messageq_destroy(messageq_t* q);
 
 bool ponyint_actor_messageq_push(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor);
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor
+#endif
+  );
 
 bool ponyint_actor_messageq_push_single(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last, scheduler_t* sched,
-  pony_actor_t* from_actor, pony_actor_t* to_actor);
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched,
+  pony_actor_t* from_actor, pony_actor_t* to_actor
+#endif
+  );
 
-pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q,
-  scheduler_t* sched, pony_actor_t* actor);
+pony_msg_t* ponyint_actor_messageq_pop(messageq_t* q
+#ifdef USE_DYNAMIC_TRACE
+  , scheduler_t* sched, pony_actor_t* actor
+#endif
+  );
 
 bool ponyint_thread_messageq_push(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last,
-  uintptr_t from_thread, uintptr_t to_thread);
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE 
+  , uintptr_t from_thread, uintptr_t to_thread
+#endif
+  );
 
 bool ponyint_thread_messageq_push_single(messageq_t* q,
-  pony_msg_t* first, pony_msg_t* last,
-  uintptr_t from_thread, uintptr_t to_thread);
+  pony_msg_t* first, pony_msg_t* last
+#ifdef USE_DYNAMIC_TRACE
+  , uintptr_t from_thread, uintptr_t to_thread
+#endif
+  );
 
-pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q,
-  uintptr_t thr);
+pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q
+#ifdef USE_DYNAMIC_TRACE
+  , uintptr_t thr
+#endif
+  );
 
 bool ponyint_messageq_markempty(messageq_t* q);
 

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -42,8 +42,11 @@ static void send_request(asio_event_t* ev, int req)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = req;
-  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
-    SPECIAL_THREADID_EPOLL, SPECIAL_THREADID_EPOLL);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg
+#ifdef USE_DYNAMIC_TRACE
+    , SPECIAL_THREADID_EPOLL, SPECIAL_THREADID_EPOLL
+#endif
+    );
 
   eventfd_write(b->wakeup, 1);
 }
@@ -74,7 +77,11 @@ static void handle_queue(asio_backend_t* b)
 {
   asio_msg_t* msg;
 
-  while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(&b->q, SPECIAL_THREADID_EPOLL)) != NULL)
+  while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(&b->q
+#ifdef USE_DYNAMIC_TRACE
+    , SPECIAL_THREADID_EPOLL
+#endif
+    )) != NULL)
   {
     asio_event_t* ev = msg->event;
 

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -42,8 +42,8 @@ static void send_request(asio_event_t* ev, int req)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = req;
-  ponyint_thread_messageq_push(SPECIAL_THREADID_EPOLL, SPECIAL_THREADID_EPOLL,
-    &b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
+    SPECIAL_THREADID_EPOLL, SPECIAL_THREADID_EPOLL);
 
   eventfd_write(b->wakeup, 1);
 }
@@ -74,7 +74,7 @@ static void handle_queue(asio_backend_t* b)
 {
   asio_msg_t* msg;
 
-  while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(SPECIAL_THREADID_EPOLL, &b->q)) != NULL)
+  while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(&b->q, SPECIAL_THREADID_EPOLL)) != NULL)
   {
     asio_event_t* ev = msg->event;
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -52,8 +52,11 @@ static void send_request(asio_event_t* ev, int req)
   msg->event = ev;
   msg->flags = req;
 
-  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
-    SPECIAL_THREADID_IOCP, SPECIAL_THREADID_IOCP);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg
+#ifdef USE_DYNAMIC_TRACE
+    , SPECIAL_THREADID_IOCP, SPECIAL_THREADID_IOCP
+#endif
+    );
 
   SetEvent(b->wakeup);
 }
@@ -134,7 +137,11 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
         asio_msg_t* msg;
 
         while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(
-          &b->q, SPECIAL_THREADID_IOCP)) != NULL)
+          &b->q
+#ifdef USE_DYNAMIC_TRACE
+          , SPECIAL_THREADID_IOCP
+#endif
+          )) != NULL)
         {
           asio_event_t* ev = msg->event;
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -51,7 +51,9 @@ static void send_request(asio_event_t* ev, int req)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = req;
-  ponyint_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
+
+  ponyint_thread_messageq_push(SPECIAL_THREADID_IOCP, SPECIAL_THREADID_IOCP,
+    &b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
 
   SetEvent(b->wakeup);
 }
@@ -131,7 +133,8 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
         // time we reach here.
         asio_msg_t* msg;
 
-        while((msg = (asio_msg_t*)ponyint_messageq_pop(&b->q)) != NULL)
+        while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(
+          &b->q, SPECIAL_THREADID_IOCP)) != NULL)
         {
           asio_event_t* ev = msg->event;
 
@@ -264,7 +267,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     // tell scheduler threads that asio has at least one noisy actor
     // if the old_count was 0
     if (old_count == 0)
-      ponyint_sched_noisy_asio();
+      ponyint_sched_noisy_asio(SPECIAL_THREADID_IOCP);
   }
 
   if((ev->flags & ASIO_TIMER) != 0)
@@ -319,7 +322,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     // tell scheduler threads that asio has no noisy actors
     // if the old_count was 1
     if (old_count == 1)
-      ponyint_sched_unnoisy_asio();
+      ponyint_sched_unnoisy_asio(SPECIAL_THREADID_IOCP);
     ev->noisy = false;
   }
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -52,8 +52,8 @@ static void send_request(asio_event_t* ev, int req)
   msg->event = ev;
   msg->flags = req;
 
-  ponyint_thread_messageq_push(SPECIAL_THREADID_IOCP, SPECIAL_THREADID_IOCP,
-    &b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
+    SPECIAL_THREADID_IOCP, SPECIAL_THREADID_IOCP);
 
   SetEvent(b->wakeup);
 }

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -63,7 +63,11 @@ static void handle_queue(asio_backend_t* b)
   asio_msg_t* msg;
 
   while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(
-    &b->q, SPECIAL_THREADID_KQUEUE)) != NULL)
+    &b->q
+#ifdef USE_DYNAMIC_TRACE
+    , SPECIAL_THREADID_KQUEUE
+#endif
+    )) != NULL)
   {
     pony_asio_event_send(msg->event, ASIO_DISPOSABLE, 0);
   }
@@ -378,8 +382,11 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = ASIO_DISPOSABLE;
-  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
-    SPECIAL_THREADID_KQUEUE, SPECIAL_THREADID_KQUEUE);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg
+#ifdef USE_DYNAMIC_TRACE
+    , SPECIAL_THREADID_KQUEUE, SPECIAL_THREADID_KQUEUE
+#endif
+    );
 
   retry_loop(b);
 }

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -63,7 +63,7 @@ static void handle_queue(asio_backend_t* b)
   asio_msg_t* msg;
 
   while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(
-    SPECIAL_THREADID_KQUEUE, &b->q)) != NULL)
+    &b->q, SPECIAL_THREADID_KQUEUE)) != NULL)
   {
     pony_asio_event_send(msg->event, ASIO_DISPOSABLE, 0);
   }
@@ -378,8 +378,8 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = ASIO_DISPOSABLE;
-  ponyint_thread_messageq_push(SPECIAL_THREADID_KQUEUE, SPECIAL_THREADID_KQUEUE,
-    &b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
+  ponyint_thread_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg,
+    SPECIAL_THREADID_KQUEUE, SPECIAL_THREADID_KQUEUE);
 
   retry_loop(b);
 }

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -5,6 +5,7 @@
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
+#include "../sched/scheduler.h"
 #include "ponyassert.h"
 #include <sys/event.h>
 #include <string.h>
@@ -61,8 +62,11 @@ static void handle_queue(asio_backend_t* b)
 {
   asio_msg_t* msg;
 
-  while((msg = (asio_msg_t*)ponyint_messageq_pop(&b->q)) != NULL)
+  while((msg = (asio_msg_t*)ponyint_thread_messageq_pop(
+    SPECIAL_THREADID_KQUEUE, &b->q)) != NULL)
+  {
     pony_asio_event_send(msg->event, ASIO_DISPOSABLE, 0);
+  }
 }
 
 static void retry_loop(asio_backend_t* b)
@@ -236,7 +240,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     // tell scheduler threads that asio has at least one noisy actor
     // if the old_count was 0
     if (old_count == 0)
-      ponyint_sched_noisy_asio();
+      ponyint_sched_noisy_asio(SPECIAL_THREADID_KQUEUE);
   }
 
   struct kevent event[4];
@@ -334,7 +338,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     // tell scheduler threads that asio has no noisy actors
     // if the old_count was 1
     if (old_count == 1)
-      ponyint_sched_unnoisy_asio();
+      ponyint_sched_unnoisy_asio(SPECIAL_THREADID_KQUEUE);
     ev->noisy = false;
   }
 
@@ -374,7 +378,8 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     POOL_INDEX(sizeof(asio_msg_t)), 0);
   msg->event = ev;
   msg->flags = ASIO_DISPOSABLE;
-  ponyint_messageq_push(&b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
+  ponyint_thread_messageq_push(SPECIAL_THREADID_KQUEUE, SPECIAL_THREADID_KQUEUE,
+    &b->q, (pony_msg_t*)msg, (pony_msg_t*)msg);
 
   retry_loop(b);
 }

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -681,7 +681,8 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
 
   do
   {
-    while((msg = ponyint_messageq_pop(&self->q)) != NULL)
+    while((msg = ponyint_actor_messageq_pop(
+      ctx->scheduler, self, &self->q)) != NULL)
     {
       if(msg->id == ACTORMSG_BLOCK)
       {

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -681,8 +681,8 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
 
   do
   {
-    while((msg = ponyint_actor_messageq_pop(
-      ctx->scheduler, self, &self->q)) != NULL)
+    while((msg = ponyint_actor_messageq_pop(&self->q,
+      ctx->scheduler, self)) != NULL)
     {
       if(msg->id == ACTORMSG_BLOCK)
       {

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -681,8 +681,11 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
 
   do
   {
-    while((msg = ponyint_actor_messageq_pop(&self->q,
-      ctx->scheduler, self)) != NULL)
+    while((msg = ponyint_actor_messageq_pop(&self->q
+#ifdef USE_DYNAMIC_TRACE
+      , ctx->scheduler, self
+#endif
+      )) != NULL)
     {
       if(msg->id == ACTORMSG_BLOCK)
       {

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -76,7 +76,7 @@ static void send_msg(uint32_t from, uint32_t to, sched_msg_t msg, intptr_t arg)
     POOL_INDEX(sizeof(pony_msgi_t)), msg);
 
   m->i = arg;
-  ponyint_thread_messageq_push(from, to, &scheduler[to].mq, &m->msg, &m->msg);
+  ponyint_thread_messageq_push(&scheduler[to].mq, &m->msg, &m->msg, from, to);
 }
 
 static void send_msg_all(uint32_t from, sched_msg_t msg, intptr_t arg)
@@ -93,7 +93,7 @@ static bool read_msg(scheduler_t* sched)
 
   bool run_queue_changed = false;
 
-  while((m = (pony_msgi_t*)ponyint_thread_messageq_pop(sched->index, &sched->mq)) != NULL)
+  while((m = (pony_msgi_t*)ponyint_thread_messageq_pop(&sched->mq, sched->index)) != NULL)
   {
     switch(m->msg.id)
     {
@@ -442,7 +442,7 @@ static void ponyint_sched_shutdown()
 
   for(uint32_t i = 0; i < scheduler_count; i++)
   {
-    while(ponyint_thread_messageq_pop(i, &scheduler[i].mq) != NULL) { ; }
+    while(ponyint_thread_messageq_pop(&scheduler[i].mq, i) != NULL) { ; }
     ponyint_messageq_destroy(&scheduler[i].mq);
     ponyint_mpmcq_destroy(&scheduler[i].q);
   }

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -5,6 +5,9 @@
 #  include <stdalign.h>
 #endif
 #include "mpmcq.h"
+
+typedef struct scheduler_t scheduler_t;
+
 #include "../actor/messageq.h"
 #include "../gc/gc.h"
 #include "../gc/serialise.h"
@@ -12,14 +15,16 @@
 #include <platform.h>
 #include "mutemap.h"
 
+#define SPECIAL_THREADID_KQUEUE   -10
+#define SPECIAL_THREADID_IOCP     -11
+#define SPECIAL_THREADID_EPOLL    -12
+
 PONY_EXTERN_C_BEGIN
 
 typedef void (*trace_object_fn)(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);
 
 typedef void (*trace_actor_fn)(pony_ctx_t* ctx, pony_actor_t* actor);
-
-typedef struct scheduler_t scheduler_t;
 
 typedef struct pony_ctx_t
 {
@@ -42,6 +47,7 @@ struct scheduler_t
 {
   // These are rarely changed.
   pony_thread_id_t tid;
+  int32_t index;
   uint32_t cpu;
   uint32_t node;
   bool terminate;
@@ -75,17 +81,17 @@ uint32_t ponyint_sched_cores();
 
 void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* recv);
 
-void ponyint_sched_start_global_unmute(pony_actor_t* actor);
+void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor);
 
 bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor);
 
 /** Mark asio as being noisy
  */
-void ponyint_sched_noisy_asio();
+void ponyint_sched_noisy_asio(int32_t from);
 
 /** Mark asio as not being noisy
  */
-void ponyint_sched_unnoisy_asio();
+void ponyint_sched_unnoisy_asio(int32_t from);
 
 PONY_EXTERN_C_END
 


### PR DESCRIPTION
Existing DTrace probes for message sending & receiving / push&pop are
placed in an ad hoc fashion.  As a result, many actor messages are
not visible to DTrace.  This patch places new DTrace probes within the
lowest-level code for adding & removing messages from queues.

The same queue functions are used for communication between threads.
New probes are also added to observe inter-thread communication.

I've introduced C preprocessor macros to wrap the message push & pop
operations.  The purposes of the macros are:

* Encode the queue category into the function call: actor or thread.
* Avoid cluttering the runtime's code by hiding the casting of
  various args to uintptr_t.

Also added are two new scripts in the `examples/dtrace` directory:

* mbox-size-all-actor-messages.d: count probe firings for actor message
  pushes & pops.
* mbox-size-all-thread-messages.d: count probe firings for thread message
  pushes & pops.

Aside from adding new constants (usually via CPP macros), this patch
adds a field to `struct scheduler_t` to permit reporting of which
scheduler thread fires a DTrace probe.

Stuff I expect to get questions and/or AYFKM from reviewers `^_^` includes:

* Adding new probes vs. rearranging existing ones.  (I don't want to change the meaning of existing probes unless there's extremely wide consensus that it's a good idea.)
* (Ab)use of CPP macros, e.g., `ACTOR_MESSAGEQ_PUSH()` and `ACTOR_MESSAGEQ_POP()` to hide some argument casts & argument additions.  (Perhaps could use real functions and hope that inlining would do The Right Thing?)
* I haven't done any performance profiling or measurement yet.  Recommendations are welcome.
* I've chosen some arbitrary numeric constant values, e.g., `Q_TYPE_THREAD` and the `sched_msg_t` enum.
* Whitespace/indentation and other C style stuff.

I've been using [slow-actor.pony](https://gist.github.com/slfritchie/542f684da3477e576ab7bd9d2311e101) for testing on OS X Sierra/10.12.6.  Example output of the two new DTrace scripts can be found at https://gist.github.com/slfritchie/69ad5f5d00e5d02b05af9b3f117824fe and at https://gist.github.com/slfritchie/d4d30159864396d302f6f05d7fec0c89