### PR TITLE
Add info message for TK_SEQ (arguments must be separated by a comma)

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -242,6 +242,10 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       errorframe_append(&frame, &info);
 
+      if (ast_childcount(arg) > 1)
+        ast_error_frame(&frame, arg,
+          "note that arguments must be separated by a comma");
+
       if(ast_checkflag(ast_type(arg), AST_FLAG_INCOMPLETE))
         ast_error_frame(&frame, arg,
           "this might be possible if all fields were already defined");


### PR DESCRIPTION
 This PR adds info message on the argument subtyping as described by @Praetonus on #2211.

Obs.: I tried to add tests for this PR on test file `badpony.cc`, but I could not find any way of testing "Info". For the code below:

 ```C
TEST_F(BadPonyTest, SequencesSeparatedByComma)
{
  // From issue #2211
  const char* src =
    "actor Main\n"
    "  new create(env: Env) =>\n"
    "    let t: U64 = 0\n"
    "    foo(\n"
    "      \"foo\"\n"
    "      t)\n"

    "  fun foo(str: String, t: U64) =>\n"
    "    None";

  TEST_ERRORS_3(src,
    "argument not a subtype of parameter",
    "U64 val is not a subtype of String val",
    "note that arguments must be separated by a comma");
}
```

The test fails with the message:
![separatedbycomma](https://user-images.githubusercontent.com/6173065/31881895-e2b07c92-b799-11e7-8ed1-fe97238aa79f.png)

I know that it makes sense, as it is __indeed__ `1 error message` with `2 info messages`.
I am sorry if here is the wrong place to ask, but as this is my first PR, is there any way that I can test info messages?

Thanks! Oh, and please let me know what I can do to improve this PR!