### PR TITLE
Experimental support for LLVM 4.0.1 (#1592) and 5.0.0.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,11 @@ branches:
 
 environment:
   matrix:
-  - llvm: 3.9.1
-  - llvm: 3.8.1
   - llvm: 3.7.1
+  - llvm: 3.8.1
+  - llvm: 3.9.1
+  - llvm: 4.0.1
+  - llvm: 5.0.0
 
 configuration:
   - release

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,66 @@ matrix:
         - ICC1=gcc-6
         - ICXX1=g++-6
 
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.1"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=debug
+        - CC1=gcc-6
+        - CXX1=g++-6
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.1"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=release
+        - CC1=gcc-6
+        - CXX1=g++-6
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="5.0.0"
+        - LLVM_CONFIG="llvm-config-5.0"
+        - config=debug
+        - CC1=gcc-6
+        - CXX1=g++-6
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="5.0.0"
+        - LLVM_CONFIG="llvm-config-5.0"
+        - config=release
+        - CC1=gcc-6
+        - CXX1=g++-6
+
     - os: osx
       env:
         - FAVORITE_CONFIG=no
@@ -150,7 +210,7 @@ matrix:
         - lto=no
         - CC1=clang-3.8
         - CXX1=clang++-3.8
-
+        
     - os: osx
       env:
         - FAVORITE_CONFIG=no
@@ -169,6 +229,44 @@ matrix:
         - lto=no
         - CC1=clang-3.9
         - CXX1=clang++-3.9
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.1"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=debug
+        - CC1=clang-4.0
+        - CXX1=clang++-4.0
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="4.0.1"
+        - LLVM_CONFIG="llvm-config-4.0"
+        - config=release
+        - lto=no
+        - CC1=clang-4.0
+        - CXX1=clang++-4.0
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="5.0.0"
+        - LLVM_CONFIG="llvm-config-5.0"
+        - config=debug
+        - CC1=clang-5.0
+        - CXX1=clang++-5.0
+
+    - os: osx
+      env:
+        - FAVORITE_CONFIG=no
+        - LLVM_VERSION="5.0.0"
+        - LLVM_CONFIG="llvm-config-5.0"
+        - config=release
+        - lto=no
+        - CC1=clang-5.0
+        - CXX1=clang++-5.0
 
 rvm:
   - 2.2.3

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -56,6 +56,16 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     set_linux_compiler
   ;;
 
+  "linux:llvm-config-4.0")
+    download_llvm
+    download_pcre
+  ;;
+
+  "linux:llvm-config-5.0")
+    download_llvm
+    download_pcre
+  ;;
+
   "osx:llvm-config-3.7")
     brew update
     brew install pcre2
@@ -71,7 +81,7 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
     brew install llvm38
   ;;
-
+  
   "osx:llvm-config-3.9")
     brew update
     brew install shellcheck
@@ -88,6 +98,42 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
     # do this elsewhere:
     #export PATH=llvmsym/:$PATH
+  ;;
+
+  "osx:llvm-config-4.0")
+    brew update
+    brew install shellcheck
+    shellcheck ./.*.bash ./*.bash
+
+    brew install pcre2
+    brew install libressl
+
+    brew install llvm@4
+    brew link --overwrite --force llvm@4
+    mkdir llvmsym
+    ln -s "$(which llvm-config)" llvmsym/llvm-config-4.0
+    ln -s "$(which clang++)" llvmsym/clang++-4.0
+
+    # do this elsewhere:
+    export PATH=llvmsym/:$PATH
+  ;;
+
+  "osx:llvm-config-5.0")
+    brew update
+    brew install shellcheck
+    shellcheck ./.*.bash ./*.bash
+
+    brew install pcre2
+    brew install libressl
+
+    brew install llvm@5
+    brew link --overwrite --force llvm@5
+    mkdir llvmsym
+    ln -s "$(which llvm-config)" llvmsym/llvm-config-5.0
+    ln -s "$(which clang++)" llvmsym/clang++-5.0
+
+    # do this elsewhere:
+    export PATH=llvmsym/:$PATH
   ;;
 
   *)

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -70,7 +70,7 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   "linux:llvm-config-3.8")
     ponyc-test
   ;;
-
+  
   "linux:llvm-config-3.9")
     # when FAVORITE_CONFIG stops matching part of this case, move this logic
     if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$FAVORITE_CONFIG" == "yes" ]]
@@ -83,6 +83,14 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
     fi
   ;;
 
+  "linux:llvm-config-4.0")
+    ponyc-test
+  ;;
+
+  "linux:llvm-config-5.0")
+    ponyc-test
+  ;;
+
   "osx:llvm-config-3.7")
     ponyc-test
   ;;
@@ -92,6 +100,16 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   ;;
 
   "osx:llvm-config-3.9")
+    export PATH=llvmsym/:$PATH
+    ponyc-test
+  ;;
+
+  "osx:llvm-config-4.0")
+    export PATH=llvmsym/:$PATH
+    ponyc-test
+  ;;
+
+  "osx:llvm-config-5.0")
     export PATH=llvmsym/:$PATH
     ponyc-test
   ;;

--- a/Makefile
+++ b/Makefile
@@ -190,14 +190,18 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-	ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm@3.9/bin/llvm-config
-    LLVM_LINK = /usr/local/opt/llvm@3.9/bin/llvm-link
-    LLVM_OPT = /usr/local/opt/llvm@3.9/bin/opt
+	ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm/bin/opt
   else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.9
     LLVM_LINK = llvm-link-3.9
-    LLVM_OPT = opt-3.9
+		LLVM_OPT = opt-3.9
+  else ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm@3.9/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm@3.9/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm@3.9/bin/opt
   else ifneq (,$(shell which llvm-config-3.8 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.8
     LLVM_LINK = llvm-link-3.8
@@ -234,6 +238,18 @@ ifndef LLVM_CONFIG
     LLVM_CONFIG = llvm-config
     LLVM_LINK = llvm-link
     LLVM_OPT = opt
+  else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-5.0
+    LLVM_LINK = llvm-link-5.0
+    LLVM_OPT = opt-5.0
+  else ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-4.0
+    LLVM_LINK = llvm-link-4.0
+    LLVM_OPT = opt-4.0
+	else ifneq (,$(shell which /usr/local/opt/llvm@4.0/bin/llvm-config 2> /dev/null))
+    LLVM_CONFIG = /usr/local/opt/llvm@4.0/bin/llvm-config
+    LLVM_LINK = /usr/local/opt/llvm@4.0/bin/llvm-link
+    LLVM_OPT = /usr/local/opt/llvm@4.0/bin/opt
   endif
 endif
 
@@ -245,7 +261,6 @@ llvm_version := $(shell $(LLVM_CONFIG) --version)
 
 ifeq ($(OSTYPE),osx)
 	llvm_bindir := $(shell $(LLVM_CONFIG) --bindir)
-
   ifneq (,$(shell which $(llvm_bindir)/llvm-ar 2> /dev/null))
     AR = $(llvm_bindir)/llvm-ar
     AR_FLAGS := rcs
@@ -264,6 +279,12 @@ endif
 ifeq ($(llvm_version),3.7.1)
 else ifeq ($(llvm_version),3.8.1)
 else ifeq ($(llvm_version),3.9.1)
+else ifeq ($(llvm_version),4.0.1)
+  $(warning WARNING: LLVM 4 support is experimental and may result in decreased performance or crashes)
+else ifeq ($(llvm_version),5.0.0)
+  $(warning WARNING: LLVM 5 support is experimental and may result in decreased performance or crashes)
+else ifeq ($(llvm_version),5.0.1)
+  $(warning WARNING: LLVM 5 support is experimental and may result in decreased performance or crashes)
 else
   $(warning WARNING: Unsupported LLVM version: $(llvm_version))
   $(warning Please use LLVM 3.7.1, 3.8.1, or 3.9.1)

--- a/README.md
+++ b/README.md
@@ -180,8 +180,11 @@ sudo apt-get -V install ponyc
 ## Arch Linux
 
 Currently the ponyc package in Arch does not work because
-Arch is using LLVM 5 and ponyc requires LLVM 3.7 to 3.9. Also,
-building from source does not work for the same reason.
+Arch is using LLVM 5 and ponyc requires LLVM 3.7 to 3.9.
+
+There is experimental support for building from source with LLVM 5.0.0,
+but this may cause decreased performance or crashes in generated
+applications.
 
 Using [Docker](#using-docker) is one choice, another is to
 use [ponyc-rpm](https://aur.archlinux.org/packages/ponyc-rpm/)
@@ -265,7 +268,7 @@ First of all, you need a compiler with decent C11 support. The following compile
 
 - GCC >= 4.7
 - Clang >= 3.4
-- MSVC >= 2013
+- MSVC >= 2015
 - XCode Clang >= 6.0
 
 Pony requires one of the following versions of LLVM:
@@ -273,6 +276,10 @@ Pony requires one of the following versions of LLVM:
 - 3.7.1
 - 3.8.1
 - 3.9.1
+
+There is experimental support for building with LLVM 4.0.1 or 5.0.0,
+but this may result in decreased performance or crashes in generated
+applications.
 
 Compiling Pony is only possible on x86 and ARM (either 32 or 64 bits).
 
@@ -319,8 +326,8 @@ make default_pic=true
 Add the following to `/etc/apt/sources`:
 
 ```
-deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
-deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
+deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main
+deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main
 ```
 
 Install the LLVM toolchain public GPG key, update `apt` and install packages:
@@ -329,7 +336,7 @@ Install the LLVM toolchain public GPG key, update `apt` and install packages:
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-get update
 sudo apt-get install make gcc g++ git zlib1g-dev libncurses5-dev \
-                       libssl-dev llvm-3.8-dev
+                       libssl-dev llvm-3.9-dev
 ```
 
 Debian Jessie and some other Linux distributions don't include pcre2 in their package manager. pcre2 is used by the Pony regex package. To download and build pcre2 from source:
@@ -419,7 +426,7 @@ Build ponyc, compile and run helloworld:
 
 ```bash
 cd ~/ponyc/
-make 
+make
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```
@@ -520,11 +527,14 @@ make default_pic=true
 
 You need to have the development versions of the following installed:
 
-* LLVM 3.7.1, 3.8.1, or 3.9.1
+* 3.7.1, 3.8.1, or 3.9.1
 * zlib
 * ncurses
 * pcre2
 * libssl
+
+There is experimental support for LLVM 4.0.1 and 5.0.0, but this may
+result in decreased performance or crashes in generated applications.
 
 If your distribution doesn't have a package for prce2, you will need to download and build it from source:
 
@@ -590,12 +600,13 @@ gmake
 ./build/release/ponyc examples/helloworld
 ```
 
-Please note that on 32-bit X86, using LLVM 3.7.1 or 3.8.1 on FreeBSD currently produces executables that don't run. Please use LLVM 3.9.1. 64-bit X86 does not have this problem, and works fine with LLVM 3.7.1 and 3.8.1.
-
 ## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-You'll need llvm 3.7.1, 3.8.1 or 3.9.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install your dependencies. Please note that llvm 3.9.1 is not available via homebrew. As such, the instructions below install 3.8.1
+You'll need llvm 3.7.1, 3.8.1, or 3.9.1 and the pcre2 library to build Pony. You can use either homebrew or MacPorts to install your dependencies.
+
+There is experimental support for LLVM 4.0.1 or 5.0.0, but this may result in
+decreased performance or crashes in generated applications.
 
 Installation via [homebrew](http://brew.sh):
 ```
@@ -651,8 +662,8 @@ This will automatically perform the following steps:
 
 You can provide the following options to `make.bat` when running the `build` or `test` commands:
 
-- `--config debug|release`: whether or not to build a debug or release build (debug is the default).
-- `--llvm <version>`: the LLVM version to build against (3.9.1 is the default).
+- `--config debug|release`: whether or not to build a debug or release build (`release` is the default).
+- `--llvm <version>`: the LLVM version to build against (`3.9.1` is the default).
 
 Note that you need to provide these options each time you run make.bat; the system will not remember your last choice.
 
@@ -662,7 +673,7 @@ Other commands include `clean`, which will clean a specified configuration; and 
 
 Link-time optimizations provide a performance improvement. You should strongly consider turning on LTO if you build ponyc from source. It's off by default as it comes with some caveats:
 
-- If you aren't using clang as your linker, we've seen LTO generate incorrect binaries. It's rare but it can happen. Before turning on LTO you need to be aware that it's possible. 
+- If you aren't using clang as your linker, we've seen LTO generate incorrect binaries. It's rare but it can happen. Before turning on LTO you need to be aware that it's possible.
 
 - If you are on MacOS, turning on LTO means that if you upgrade your version of XCode, you will have to rebuild your Pony compiler. You won't be able to link Pony programs if there is a mismatch between the version of XCode used to build the Pony runtime and the version of XCode you currently have installed.
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -41,12 +41,14 @@ LLVMValueRef LLVMConstInf(LLVMTypeRef type, bool negative);
 LLVMModuleRef LLVMParseIRFileInContext(LLVMContextRef ctx, const char* file);
 bool LLVMHasMetadataStr(LLVMValueRef val, const char* str);
 void LLVMSetMetadataStr(LLVMValueRef val, const char* str, LLVMValueRef node);
+void LLVMMDNodeReplaceOperand(LLVMValueRef parent, unsigned i,
+  LLVMValueRef node);
 
 // Intrinsics.
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32);
 LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32);
-LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module);
-LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module);
+LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module, LLVMTypeRef type);
+LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module, LLVMTypeRef type);
 
 #if PONY_LLVM >= 309
 #define LLVM_DECLARE_ATTRIBUTEREF(decl, name, val) \
@@ -184,8 +186,10 @@ typedef struct compile_t
   LLVMDIBuilderRef di;
   LLVMMetadataRef di_unit;
   LLVMValueRef tbaa_root;
+#if LLVM_PONY < 400
   LLVMValueRef tbaa_descriptor;
   LLVMValueRef tbaa_descptr;
+#endif
   LLVMValueRef none_instance;
   LLVMValueRef primitives_init;
   LLVMValueRef primitives_final;

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -31,8 +31,12 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
 
   const char* box_name = genname_box(t->name);
   LLVMValueRef metadata = tbaa_metadata_for_box_type(c, box_name);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, store);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return this_ptr;
 }
@@ -60,8 +64,12 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
 
   const char* box_name = genname_box(t->name);
   LLVMValueRef metadata = tbaa_metadata_for_box_type(c, box_name);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, value);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(value, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return gen_assign_cast(c, c_t->use_type, value, t->ast_cap);
 }

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -32,8 +32,10 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
       break;
 
     case TK_TUPLEELEMREF:
+    {
       ret = gen_tupleelemptr(c, ast);
       break;
+    }
 
     case TK_EMBEDREF:
       ret = gen_fieldembed(c, ast);

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -359,11 +359,17 @@ static LLVMValueRef assign_field(compile_t* c, LLVMValueRef l_value,
 
   // Store to the field.
   LLVMValueRef store = LLVMBuildStore(c->builder, r_value, l_value);
-
   LLVMValueRef metadata = tbaa_metadata_for_type(c, p_type);
+
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+  tbaa_tag(c, metadata, store);
+#else
   const char id[] = "tbaa";
-  LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
-  LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+  unsigned md_kind = LLVMGetMDKindID(id, sizeof(id) - 1);
+  LLVMSetMetadata(result, md_kind, metadata);
+  LLVMSetMetadata(store, md_kind, metadata);
+#endif
 
   return gen_assign_cast(c, c_t->use_type, result, l_type);
 }

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -21,6 +21,8 @@
 #include <llvm/IR/DebugInfo.h>
 
 #include <llvm/IR/LegacyPassManager.h>
+#include <llvm/Analysis/CallGraph.h>
+#include <llvm/Analysis/Lint.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 
@@ -110,7 +112,7 @@ public:
       {
         Instruction* inst = &(*(iter++));
 
-        if(runOnInstruction(builder, inst, dt))
+        if(runOnInstruction(builder, inst, dt, f))
           changed = true;
       }
     }
@@ -119,7 +121,7 @@ public:
   }
 
   bool runOnInstruction(IRBuilder<>& builder, Instruction* inst,
-    DominatorTree& dt)
+    DominatorTree& dt, Function& f)
   {
     CallSite call(inst);
 
@@ -179,11 +181,35 @@ public:
     // TODO: for variable size alloca, don't insert at the beginning.
     Instruction* begin = &(*call.getCaller()->getEntryBlock().begin());
 
+#if PONY_LLVM < 500
     AllocaInst* replace = new AllocaInst(builder.getInt8Ty(), int_size, "",
       begin);
+#else
+    AllocaInst* replace = new AllocaInst(builder.getInt8Ty(),
+      0, int_size, "", begin);
+#endif
 
     replace->setDebugLoc(call->getDebugLoc());
     inst->replaceAllUsesWith(replace);
+
+#if PONY_LLVM < 400
+    (void)f;
+#else
+    if (call.isInvoke())
+    {
+      InvokeInst *invoke = cast<InvokeInst>(call.getInstruction());
+      BranchInst::Create(invoke->getNormalDest(), invoke);
+      invoke->getUnwindDest()->removePredecessor(call->getParent());
+    }
+    CallGraphWrapperPass *cg_pass =
+      getAnalysisIfAvailable<CallGraphWrapperPass>();
+    CallGraph *cg = cg_pass ? &cg_pass->getCallGraph() : nullptr;
+    CallGraphNode *cg_node = cg ? (*cg)[&f] : nullptr;
+    if (cg_node)
+    {
+      cg_node->removeCallEdgeFor(call);
+    }
+#endif
     inst->eraseFromParent();
 
     for(auto new_call: new_calls)
@@ -274,7 +300,15 @@ public:
         }
 
         case Instruction::Load:
+          // This is a workaround for a problem with LLVM 4 & 5 on *nix when 
+          // hoisting loads (see #2303, #2061, #1592).
+          // TODO: figure out the real reason LLVM 4 and 5 produce bad code 
+          // when hoisting stack allocated loads.
+#if PONY_LLVM >= 400 && !defined(_MSC_VER)
+          // fall through
+#else
           break;
+#endif
 
         case Instruction::Store:
         {
@@ -511,7 +545,7 @@ public:
   }
 };
 
-char DispatchPonyCtx::ID = 0;
+char DispatchPonyCtx::ID = 1;
 
 static RegisterPass<DispatchPonyCtx>
   DPC("dispatchponyctx", "Replace pony_ctx calls in a dispatch function by the\
@@ -826,23 +860,38 @@ public:
       ArrayRef<Type*>(params, 2), false);
     Function* fn = Function::Create(fn_type, Function::ExternalLinkage, name,
       &m);
-    fn->addAttribute(AttributeSet::FunctionIndex, Attribute::NoUnwind);
+
+#if PONY_LLVM < 500
+    unsigned functionIndex = AttributeSet::FunctionIndex;
+    unsigned returnIndex = AttributeSet::ReturnIndex;
+#else
+    unsigned functionIndex = AttributeList::FunctionIndex;
+    unsigned returnIndex = AttributeList::ReturnIndex;
+#endif
+
+    fn->addAttribute(functionIndex, Attribute::NoUnwind);
 #if PONY_LLVM >= 308
-    fn->addAttribute(AttributeSet::FunctionIndex,
+    fn->addAttribute(functionIndex,
       Attribute::InaccessibleMemOrArgMemOnly);
 #endif
+
+#if PONY_LLVM < 500
     fn->setDoesNotAlias(0);
+#endif
 
     if(can_be_null)
-      fn->addDereferenceableOrNullAttr(AttributeSet::ReturnIndex, min_size);
+      fn->addDereferenceableOrNullAttr(returnIndex, min_size);
     else
-      fn->addDereferenceableAttr(AttributeSet::ReturnIndex, min_size);
+      fn->addDereferenceableAttr(returnIndex, min_size);
 
     AttrBuilder attr;
     attr.addAlignmentAttr(32);
-    unsigned index = AttributeSet::ReturnIndex;
-    fn->addAttributes(index, AttributeSet::get(m.getContext(), index, attr));
-
+#if PONY_LLVM < 500
+    fn->addAttributes(returnIndex, AttributeSet::get(m.getContext(),
+      returnIndex, attr));
+#else
+    fn->addAttributes(returnIndex, AttributeSet::get(m.getContext(), attr));
+#endif
     return fn;
   }
 
@@ -860,7 +909,7 @@ public:
   }
 };
 
-char MergeRealloc::ID = 0;
+char MergeRealloc::ID = 2;
 
 static RegisterPass<MergeRealloc>
   MR("mergerealloc", "Merge successive reallocations of the same variable");
@@ -1226,7 +1275,14 @@ public:
       {unwrap(c->void_ptr)}, false);
     Function* fn = Function::Create(fn_type, Function::ExternalLinkage,
       "pony_send_next", &m);
-    fn->addAttribute(AttributeSet::FunctionIndex, Attribute::NoUnwind);
+
+#if PONY_LLVM < 500
+    unsigned functionIndex = AttributeSet::FunctionIndex;
+#else
+    unsigned functionIndex = AttributeList::FunctionIndex;
+#endif
+
+    fn->addAttribute(functionIndex, Attribute::NoUnwind);
     return fn;
   }
 
@@ -1236,15 +1292,22 @@ public:
       {unwrap(c->msg_ptr), unwrap(c->msg_ptr)}, false);
     Function* fn = Function::Create(fn_type, Function::ExternalLinkage,
       "pony_chain", &m);
-    fn->addAttribute(AttributeSet::FunctionIndex, Attribute::NoUnwind);
-    fn->addAttribute(AttributeSet::FunctionIndex, Attribute::ArgMemOnly);
+
+#if PONY_LLVM < 500
+    unsigned functionIndex = AttributeSet::FunctionIndex;
+#else
+    unsigned functionIndex = AttributeList::FunctionIndex;
+#endif
+
+    fn->addAttribute(functionIndex, Attribute::NoUnwind);
+    fn->addAttribute(functionIndex, Attribute::ArgMemOnly);
     fn->addAttribute(1, Attribute::NoCapture);
     fn->addAttribute(2, Attribute::ReadNone);
     return fn;
   }
 };
 
-char MergeMessageSend::ID = 0;
+char MergeMessageSend::ID = 3;
 
 static RegisterPass<MergeMessageSend>
   MMS("mergemessagesend", "Group message sends in the same BasicBlock");
@@ -1297,7 +1360,9 @@ static void optimise(compile_t* c, bool pony_specific)
   pmb.LoopVectorize = true;
   pmb.SLPVectorize = true;
   pmb.RerollLoops = true;
+#if PONY_LLVM < 500
   pmb.LoadCombine = true;
+#endif
 
   if(pony_specific)
   {
@@ -1345,6 +1410,9 @@ static void optimise(compile_t* c, bool pony_specific)
 
   if(c->opt->strip_debug)
     lpm.add(createStripSymbolsPass());
+
+  if(c->opt->lint_llvm)
+    fpm.add(createLintPass());
 
   fpm.doInitialization();
 
@@ -1441,7 +1509,11 @@ bool target_is_x86(char* t)
 {
   Triple triple = Triple(t);
 
+#if PONY_LLVM >= 400
+  const char* arch = Triple::getArchTypePrefix(triple.getArch()).data();
+#else
   const char* arch = Triple::getArchTypePrefix(triple.getArch());
+#endif
 
   return !strcmp("x86", arch);
 }
@@ -1450,7 +1522,11 @@ bool target_is_arm(char* t)
 {
   Triple triple = Triple(t);
 
+#if PONY_LLVM >= 400
+  const char* arch = Triple::getArchTypePrefix(triple.getArch()).data();
+#else
   const char* arch = Triple::getArchTypePrefix(triple.getArch());
+#endif
 
   return !strcmp("arm", arch);
 }

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -218,8 +218,12 @@ static void pointer_apply(compile_t* c, void* data, token_id cap)
   ast_setid(tcap, cap);
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   ast_setid(tcap, tmp_cap);
 
@@ -254,9 +258,14 @@ static void pointer_update(compile_t* c, reach_type_t* t,
   LLVMValueRef store = LLVMBuildStore(c->builder, value, loc);
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+  tbaa_tag(c, metadata, store);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
   LLVMSetMetadata(store, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   result = gen_assign_cast(c, c_t_elem->use_type, result, t_elem->ast_cap);
   LLVMBuildRet(c->builder, result);
@@ -360,8 +369,12 @@ static void pointer_delete(compile_t* c, reach_type_t* t,
   LLVMValueRef result = LLVMBuildLoad(c->builder, elem_ptr, "");
 
   LLVMValueRef metadata = tbaa_metadata_for_type(c, t->ast);
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, result);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(result, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   LLVMValueRef src = LLVMBuildInBoundsGEP(c->builder, elem_ptr, &n, 1, "");
   src = LLVMBuildBitCast(c->builder, src, c_t->use_type, "");

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -63,9 +63,10 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
   pony_assert(ast_id(l_type) == TK_NOMINAL);
   pony_assert(ast_id(right) == TK_ID);
 
-  ast_t* def = (ast_t*)ast_data(l_type);
-  ast_t* field = ast_get(def, ast_name(right), NULL);
-  int index = (int)ast_index(field);
+  ast_t* def;
+  ast_t* field;
+  uint32_t index;
+  get_fieldinfo(l_type, right, &def, &field, &index);
 
   if(ast_id(def) != TK_STRUCT)
     index++;
@@ -104,9 +105,14 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   field = LLVMBuildLoad(c->builder, field, "");
+
   LLVMValueRef metadata = tbaa_metadata_for_type(c, ast_type(left));
+#if PONY_LLVM >= 400
+  tbaa_tag(c, metadata, field);
+#else
   const char id[] = "tbaa";
   LLVMSetMetadata(field, LLVMGetMDKindID(id, sizeof(id) - 1), metadata);
+#endif
 
   return gen_assign_cast(c, c_t->use_type, field, type);
 }

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -19,11 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void compile_type_free(void* p)
-{
-  POOL_FREE(compile_type_t, p);
-}
-
 static size_t tbaa_metadata_hash(tbaa_metadata_t* a)
 {
   return ponyint_hash_ptr(a->name);
@@ -116,6 +111,32 @@ LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name)
   return md->metadata;
 }
 
+void tbaa_tag(compile_t* c, LLVMValueRef metadata, LLVMValueRef instr)
+{
+  const char id[] = "tbaa";
+  unsigned md_kind = LLVMGetMDKindID(id, sizeof(id) - 1);
+
+  LLVMValueRef params[3];
+  params[0] = metadata;
+  params[1] = metadata;
+  params[2] = LLVMConstInt(c->i32, 0, false);
+
+  LLVMValueRef tag = LLVMMDNodeInContext(c->context, params, 3);
+  LLVMSetMetadata(instr, md_kind, tag);
+}
+
+void get_fieldinfo(ast_t* l_type, ast_t* right, ast_t** l_def,
+  ast_t** field, uint32_t* index)
+{
+  ast_t* d = (ast_t*)ast_data(l_type);
+  ast_t* f = ast_get(d, ast_name(right), NULL);
+  uint32_t i = (uint32_t)ast_index(f);
+
+  *l_def = d;
+  *field = f;
+  *index = i;
+}
+
 static LLVMValueRef make_tbaa_root(LLVMContextRef ctx)
 {
   const char str[] = "Pony TBAA";
@@ -129,8 +150,10 @@ static LLVMValueRef make_tbaa_descriptor(LLVMContextRef ctx, LLVMValueRef root)
   LLVMValueRef params[3];
   params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
   params[1] = root;
+#if PONY_LLVM < 400
   params[2] = LLVMConstInt(LLVMInt64TypeInContext(ctx), 1, false);
-  return LLVMMDNodeInContext(ctx, params, 3);
+#endif
+  return LLVMMDNodeInContext(ctx, params, PONY_LLVM < 400 ? 3 : 2);
 }
 
 static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
@@ -140,6 +163,11 @@ static LLVMValueRef make_tbaa_descptr(LLVMContextRef ctx, LLVMValueRef root)
   params[0] = LLVMMDStringInContext(ctx, str, sizeof(str) - 1);
   params[1] = root;
   return LLVMMDNodeInContext(ctx, params, 2);
+}
+
+static void compile_type_free(void* p)
+{
+  POOL_FREE(compile_type_t, p);
 }
 
 static void allocate_compile_types(compile_t* c)
@@ -807,6 +835,7 @@ bool gentypes(compile_t* c)
     c->trait_bitmap_size = ((c->reach->trait_type_count + 63) & ~63) >> 6;
 
   c->tbaa_root = make_tbaa_root(c->context);
+
   c->tbaa_descriptor = make_tbaa_descriptor(c->context, c->tbaa_root);
   c->tbaa_descptr = make_tbaa_descptr(c->context, c->tbaa_root);
 

--- a/src/libponyc/codegen/gentype.h
+++ b/src/libponyc/codegen/gentype.h
@@ -6,6 +6,27 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct tbaa_metadata_t
+{
+  const char* name;
+  LLVMValueRef metadata;
+} tbaa_metadata_t;
+
+DECLARE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t);
+
+tbaa_metadatas_t* tbaa_metadatas_new();
+
+void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
+
+LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
+
+LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name);
+
+void tbaa_tag(compile_t* c, LLVMValueRef metadata, LLVMValueRef instr);
+
+void get_fieldinfo(ast_t* l_type, ast_t* right, ast_t** l_def,
+  ast_t** field, uint32_t* index);
+
 typedef struct compile_type_t
 {
   compile_opaque_free_fn free_fn;
@@ -36,22 +57,6 @@ typedef struct compile_type_t
   LLVMMetadataRef di_type;
   LLVMMetadataRef di_type_embed;
 } compile_type_t;
-
-typedef struct tbaa_metadata_t
-{
-  const char* name;
-  LLVMValueRef metadata;
-} tbaa_metadata_t;
-
-DECLARE_HASHMAP(tbaa_metadatas, tbaa_metadatas_t, tbaa_metadata_t);
-
-tbaa_metadatas_t* tbaa_metadatas_new();
-
-void tbaa_metadatas_free(tbaa_metadatas_t* tbaa_metadatas);
-
-LLVMValueRef tbaa_metadata_for_type(compile_t* c, ast_t* type);
-
-LLVMValueRef tbaa_metadata_for_box_type(compile_t* c, const char* box_name);
 
 bool gentypes(compile_t* c);
 

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -222,6 +222,17 @@ void LLVMSetMetadataStr(LLVMValueRef val, const char* str, LLVMValueRef node)
     cast<Function>(v)->setMetadata(str, n);
 }
 
+void LLVMMDNodeReplaceOperand(LLVMValueRef parent, unsigned i,
+  LLVMValueRef node)
+{
+  pony_assert(parent != NULL);
+  pony_assert(node != NULL);
+
+  MDNode *pn = extractMDNode(unwrap<MetadataAsValue>(parent));
+  MDNode *cn = extractMDNode(unwrap<MetadataAsValue>(node));
+  pn->replaceOperandWith(i, cn);
+}
+
 LLVMValueRef LLVMMemcpy(LLVMModuleRef module, bool ilp32)
 {
   Module* m = unwrap(module);
@@ -246,16 +257,28 @@ LLVMValueRef LLVMMemmove(LLVMModuleRef module, bool ilp32)
   return wrap(Intrinsic::getDeclaration(m, Intrinsic::memmove, {params, 3}));
 }
 
-LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module)
+LLVMValueRef LLVMLifetimeStart(LLVMModuleRef module, LLVMTypeRef type)
 {
   Module* m = unwrap(module);
 
+#if PONY_LLVM < 500
+  (void)type;
   return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_start, {}));
+#else
+  Type* t[1] = { unwrap(type) };
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_start, t));
+#endif
 }
 
-LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module)
+LLVMValueRef LLVMLifetimeEnd(LLVMModuleRef module, LLVMTypeRef type)
 {
   Module* m = unwrap(module);
 
+#if PONY_LLVM < 500
+  (void)type;
   return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_end, {}));
+#else
+  Type* t[1] = { unwrap(type) };
+  return wrap(Intrinsic::getDeclaration(m, Intrinsic::lifetime_end, t));
+#endif
 }

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -223,6 +223,7 @@ typedef struct pass_opt_t
   bool strip_debug;
   bool print_filenames;
   bool check_tree;
+  bool lint_llvm;
   bool docs;
   bool docs_private;
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -55,6 +55,7 @@ enum
   OPT_CHECKTREE,
   OPT_EXTFUN,
   OPT_SIMPLEBUILTIN,
+  OPT_LINT_LLVM,
 
   OPT_BNF,
   OPT_ANTLR,
@@ -97,6 +98,7 @@ static opt_arg_t args[] =
   {"checktree", '\0', OPT_ARG_NONE, OPT_CHECKTREE},
   {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
   {"simplebuiltin", '\0', OPT_ARG_NONE, OPT_SIMPLEBUILTIN},
+  {"lint-llvm", '\0', OPT_ARG_NONE, OPT_LINT_LLVM},
 
   {"bnf", '\0', OPT_ARG_NONE, OPT_BNF},
   {"antlr", '\0', OPT_ARG_NONE, OPT_ANTLR},
@@ -186,6 +188,7 @@ static void usage()
     "  --files         Print source file names as each is processed.\n"
     "  --bnf           Print out the Pony grammar as human readable BNF.\n"
     "  --antlr         Print out the Pony grammar as an ANTLR file.\n"
+    "  --lint-llvm     Run the LLVM linting pass on generated IR.\n"
     ,
     "Runtime options for Pony programs (not for use with ponyc):\n"
     "  --ponythreads   Use N scheduler threads. Defaults to the number of\n"
@@ -341,6 +344,7 @@ int main(int argc, char* argv[])
       case OPT_SIMPLEBUILTIN: opt.simple_builtin = true; break;
       case OPT_FILENAMES: opt.print_filenames = true; break;
       case OPT_CHECKTREE: opt.check_tree = true; break;
+      case OPT_LINT_LLVM: opt.lint_llvm = true; break;
 
       case OPT_BNF: print_grammar(false, true); return 0;
       case OPT_ANTLR: print_grammar(true, true); return 0;

--- a/wscript
+++ b/wscript
@@ -44,7 +44,9 @@ MSVC_VERSIONS = [ '15.4', '15.0', '14.0' ]
 LLVM_VERSIONS = [
     '3.9.1',
     '3.8.1',
-    '3.7.1'
+    '3.7.1',
+    '5.0.0',
+    '4.0.1'
 ]
 
 WINDOWS_LIBS_TAG = "v1.5.0"
@@ -247,6 +249,9 @@ def build(ctx):
                 llvmLibs = [re.sub(r'.*[\\\/]([^\\\/)]+)\.lib', r'\1', x) for x in llvmLibFiles.split(' ')]
 
     # build targets:
+
+    if ctx.options.llvm.startswith('4') or ctx.options.llvm.startswith('5'):
+        print('WARNING: LLVM 4 and 5 support is experimental and may result in decreased performance or crashes')
 
     # gtest
     ctx(


### PR DESCRIPTION
This change includes the following:

- Compiler code updates for changes to the LLVM 4.0.0 and 5.0.0 API.
- Updates to Type-Based Alias Analysis metadata format for LLVM 4.0.0 and up.