### PR TITLE
Garbage collect actors when --ponynoblock is in use

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -249,8 +249,22 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
     ponyint_cycle_block(ctx, actor, &actor->gc);
   }
 
+  bool empty = ponyint_messageq_markempty(&actor->q);
+  if (empty && actor_noblock && (actor->gc.rc == 0))
+  {
+    // when 'actor_noblock` is true, the cycle detector isn't running.
+    // this means actors won't be garbage collected unless we take special
+    // action. Here, we know that:
+    // - the actor has no messages in its queue
+    // - there's no references to this actor
+    // therefore if `noblock` is on, we should garbage collect the actor.
+    ponyint_actor_setpendingdestroy(actor);
+    ponyint_actor_final(ctx, actor);
+    ponyint_actor_destroy(actor);
+  }
+
   // Return true (i.e. reschedule immediately) if our queue isn't empty.
-  return !ponyint_messageq_markempty(&actor->q);
+  return !empty;
 }
 
 void ponyint_actor_destroy(pony_actor_t* actor)


### PR DESCRIPTION
Prior to this commit, actors wouldn't be garbage collected when using
--ponynoblock. With this change, any actors that aren't part of a cycle
will be garbage collected if they can no longer do work.

Before this change, using `--ponynoblock` with an application that
created transient actors would result in never ending memory growth as
the actors would never be gc'd. You can see an example of this by taking
a Pony program that listens for TCP connections and do a repeating cycle
of open/close. None of the created `TCPConnection` actors would be
garbage collected.

Closes #2306