### PR TITLE
Forbid lookup on primitive _init functions

### DIFF
--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -142,7 +142,7 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
         return NULL;
     }
 
-    if(!strcmp(name, "_final"))
+    if(name == stringtab("_final"))
     {
       switch(ast_id(find))
       {
@@ -157,6 +157,23 @@ static ast_t* lookup_nominal(pass_opt_t* opt, ast_t* from, ast_t* orig,
 
         default: {}
       }
+    } else if((name == stringtab("_init")) && (ast_id(def) == TK_PRIMITIVE)) {
+      switch(ast_id(find))
+      {
+        case TK_NEW:
+        case TK_BE:
+        case TK_FUN:
+          break;
+
+        default:
+          pony_assert(0);
+      }
+
+      if(errors)
+        ast_error(opt->check.errors, from,
+          "can't lookup an _init function on a primitive");
+
+      return NULL;
     }
   }
 

--- a/test/libponyc/finalisers.cc
+++ b/test/libponyc/finalisers.cc
@@ -110,3 +110,27 @@ TEST_F(FinalisersTest, FinalCannotCallChainedBehaviour)
 
   TEST_ERRORS_1(src, "_final cannot create actors or send messages");
 }
+
+TEST_F(FinalisersTest, CannotLookupFinal)
+{
+  const char* src =
+    "class Actor\n"
+    "  fun apply() =>\n"
+    "    _final()\n"
+    "  fun _final() =>\n"
+    "    None";
+
+  TEST_ERRORS_1(src, "can't lookup a _final function");
+}
+
+TEST_F(FinalisersTest, CannotLookupPrimitiveInit)
+{
+  const char* src =
+    "primitive Prim\n"
+    "  fun apply() =>\n"
+    "    _init()\n"
+    "  fun _init() =>\n"
+    "    None";
+
+  TEST_ERRORS_1(src, "can't lookup an _init function on a primitive");
+}


### PR DESCRIPTION
These functions are meant for automatic FFI-related initialisation and forbidding access to them can avoid mistakes from the programmer.