### PR TITLE
Do not mutate the AST when adding implicit finalisers

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -392,7 +392,7 @@ static void add_dispatch_case(compile_t* c, reach_type_t* t, ast_t* params,
 }
 
 static void call_embed_finalisers(compile_t* c, reach_type_t* t,
-  ast_t* method_body, LLVMValueRef obj)
+  ast_t* call_location, LLVMValueRef obj)
 {
   uint32_t base = 0;
   if(t->underlying != TK_STRUCT)
@@ -412,7 +412,7 @@ static void call_embed_finalisers(compile_t* c, reach_type_t* t,
       continue;
 
     LLVMValueRef field_ref = LLVMBuildStructGEP(c->builder, obj, base + i, "");
-    codegen_debugloc(c, method_body);
+    codegen_debugloc(c, call_location);
     LLVMBuildCall(c->builder, final_fn, &field_ref, 1, "");
     codegen_debugloc(c, NULL);
   }
@@ -611,6 +611,27 @@ static void copy_subordinate(reach_method_t* m)
     c_m2->func = c_m->func;
     m2 = m2->subordinate;
   }
+}
+
+static bool genfun_implicit_final(compile_t* c, reach_type_t* t,
+  reach_method_t* m)
+{
+  compile_type_t* c_t = (compile_type_t*)t->c_type;
+  compile_method_t* c_m = (compile_method_t*)m->c_method;
+
+  c_m->func_type = LLVMFunctionType(c->void_type, &c_t->use_type, 1, false);
+  c_m->func = codegen_addfun(c, m->full_name, c_m->func_type, true);
+
+  codegen_startfun(c, c_m->func, NULL, NULL, false);
+  call_embed_finalisers(c, t, NULL, gen_this(c, NULL));
+  LLVMBuildRetVoid(c->builder);
+  codegen_finishfun(c);
+
+  c_t->final_fn = c_m->func;
+  LLVMSetFunctionCallConv(c_m->func, LLVMCCallConv);
+  LLVMSetLinkage(c_m->func, LLVMExternalLinkage);
+
+  return true;
 }
 
 static bool genfun_allocator(compile_t* c, reach_type_t* t)
@@ -867,10 +888,13 @@ bool genfun_method_bodies(compile_t* c, reach_type_t* t)
     while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
     {
       if(m->intrinsic)
-        continue;
-
-      if(m->forwarding)
       {
+        if(m->internal && (n->name == c->str__final))
+        {
+          if(!genfun_implicit_final(c, t, m))
+            return false;
+        }
+      } else if(m->forwarding) {
         if(!genfun_forward(c, t, n, m))
           return false;
       } else {

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -45,8 +45,7 @@ struct reach_method_t
   bool intrinsic;
 
   // Mark as true if the compiler supplies an implementation and the function
-  // isn't exposed to the user at all. The method will also be automatically
-  // added to supertypes.
+  // isn't exposed to the user at all.
   bool internal;
 
   // Mark as true if the method is a forwarding method.


### PR DESCRIPTION
Implicit finalisers are added to types without an explicit finaliser but with embedded fields with a finaliser (either implicit or explicit).

Previously, ASTs for these finalisers were sugared during reachability analysis, which wasn't very clean since the main program AST isn't supposed to be mutated during code generation.

Now implicit finalisers are directly added as internal methods without mutating the AST.