### PR TITLE
Add --ponyversion option to compiled binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ else
   tag := $(shell cat VERSION)
 endif
 
+version_str = "$(tag) [$(config)]\ncompiled with: llvm $(llvm_version) \
+  -- "$(compiler_version)
+
 # package_name, _version, and _iteration can be overridden by Travis or AppVeyor
 package_base_version ?= $(tag)
 package_iteration ?= "1"
@@ -90,6 +93,7 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
   -DBUILD_COMPILER=\"$(compiler_version)\" \
   -DPONY_BUILD_CONFIG=\"$(config)\" \
+  -DPONY_VERSION_STR=\"$(version_str)\" \
   -D_FILE_OFFSET_BITS=64
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -12,6 +12,7 @@
 #include <dtrace.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 typedef struct options_t
 {
@@ -26,6 +27,7 @@ typedef struct options_t
   bool noblock;
   bool nopin;
   bool pinasio;
+  bool version;
 } options_t;
 
 // global data
@@ -44,7 +46,8 @@ enum
   OPT_NOYIELD,
   OPT_NOBLOCK,
   OPT_NOPIN,
-  OPT_PINASIO
+  OPT_PINASIO,
+  OPT_VERSION
 };
 
 static opt_arg_t args[] =
@@ -59,6 +62,7 @@ static opt_arg_t args[] =
   {"ponynoblock", 0, OPT_ARG_NONE, OPT_NOBLOCK},
   {"ponynopin", 0, OPT_ARG_NONE, OPT_NOPIN},
   {"ponypinasio", 0, OPT_ARG_NONE, OPT_PINASIO},
+  {"ponyversion", 0, OPT_ARG_NONE, OPT_VERSION},
 
   OPT_ARGS_FINISH
 };
@@ -83,6 +87,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_NOBLOCK: opt->noblock = true; break;
       case OPT_NOPIN: opt->nopin = true; break;
       case OPT_PINASIO: opt->pinasio = true; break;
+      case OPT_VERSION: opt->version = true; break;
 
       default: exit(-1);
     }
@@ -114,6 +119,11 @@ PONY_API int pony_init(int argc, char** argv)
   opt.gc_factor = 2.0f;
 
   argc = parse_opts(argc, argv, &opt);
+
+  if (opt.version) {
+    printf("%s\n", PONY_VERSION_STR);
+    exit(0);
+  }
 
   ponyint_cpu_init();
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -208,6 +208,7 @@ static void usage()
     "                  threads are pinned to CPUs.\n"
     "  --ponypinasio   Pin the ASIO thread to a CPU the way scheduler\n"
     "                  threads are pinned to CPUs.\n"
+    "  --ponyversion   Print the version of the compiler and exit.\n"
     );
 }
 
@@ -291,8 +292,7 @@ int main(int argc, char* argv[])
     switch(id)
     {
       case OPT_VERSION:
-        printf("%s [%s]\ncompiled with: llvm %s -- %s\n", PONY_VERSION, PONY_BUILD_CONFIG,
-          LLVM_VERSION, BUILD_COMPILER);
+        printf("%s\n", PONY_VERSION_STR);
         return 0;
 
       case OPT_HELP:

--- a/wscript
+++ b/wscript
@@ -98,7 +98,11 @@ def configure(ctx):
             bld_env.PCRE2_DIR = os.path.join(bld_env.PONYLIBS_DIR, \
                 'lib', 'pcre2-' + PCRE2_VERSION)
             bld_env.append_value('DEFINES', [
-                'LLVM_VERSION="' + llvm_version + '"'
+                'LLVM_VERSION="' + llvm_version + '"',
+                'PONY_VERSION_STR="' + \
+                    '%s [%s]\\ncompiled with: llvm %s -- msvc-%d-x64"' % \
+                    (VERSION, ctx.options.config, \
+                        llvm_version, base_env.MSVC_VERSION)
             ])
 
             libs_name = 'PonyWinLibs' + \


### PR DESCRIPTION
Allow pony applications to print the version of ponyc that compiled it
and exit with the `--ponyversion` option.

resolves #2285