### PR TITLE
Fix poor randomness properties of first call to `Rand.next()`.

### DIFF
--- a/packages/random/mt.pony
+++ b/packages/random/mt.pony
@@ -28,7 +28,7 @@ class MT is Random
 
   fun ref next(): U64 =>
     """
-    A random integer in [0, 2^64 - 1]
+    A random integer in [0, 2^64)
     """
     if _index >= _n() then
       _populate()

--- a/packages/random/xoroshiro.pony
+++ b/packages/random/xoroshiro.pony
@@ -16,10 +16,11 @@ class XorOshiro128Plus is Random
     """
     _x = x
     _y = y
+    next()
 
   fun ref next(): U64 =>
     """
-    A random integer in [0, 2^64 - 1]
+    A random integer in [0, 2^64)
     """
     let x = _x
     var y = _y

--- a/packages/random/xorshift.pony
+++ b/packages/random/xorshift.pony
@@ -17,10 +17,11 @@ class XorShift128Plus is Random
     """
     _x = x
     _y = y
+    next()
 
   fun ref next(): U64 =>
     """
-    A random integer in [0, 2^64 - 1]
+    A random integer in [0, 2^64)
     """
     var y = _x
     let x = _y


### PR DESCRIPTION
The current implementations of XorOshiro128Plus and XorShift128Plus return the sum of input seed values for the first value, which is unsafe. Rather than telling people to discard the first value, skip past it in the actual implementation.

This commit also fixes the documentation of current implementations for consistency with the Random trait.

Resolves #2320