### PR TITLE
Fully close unspecified family TCP connections on Windows.

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -497,6 +497,7 @@ actor TCPConnection
           // We're already connected, unsubscribe the event and close.
           @pony_asio_event_unsubscribe(event)
           @pony_os_socket_close[None](fd)
+          _try_shutdown()
         end
       else
         // It's not our event.


### PR DESCRIPTION
On Windows, the TCPConnection actor waits for leftover IOCP messages (e.g. from a second happy eyeballs connection when IPv4 or IPv6 is unspecified) before closing, but does not check if it should shut down after such messages are received.  This change makes it check again.

This fixes #2322.