### PR TITLE
Fix compilation problem with GCC 7.2.1

### DIFF
--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -263,7 +263,7 @@ LLVMMetadataRef LLVMDIBuilderCreateArrayType(LLVMDIBuilderRef d,
 {
   DIBuilder* pd = unwrap(d);
 
-  return wrap(pd->createArrayType(size_bits, align_bits,
+  return wrap(pd->createArrayType(size_bits, static_cast<uint32_t>(align_bits),
     unwrap<DIType>(elem_type), DINodeArray(unwrap<MDTuple>(subscripts))));
 }
 


### PR DESCRIPTION
Compilation failed with GCC 7.2.1 due to size conversion warning. Cast to match LLVM code:

http://llvm.org/doxygen/classllvm_1_1DIBuilder.html#a3e8ce86870f37aaf9f3df4320122e843
