### PR TITLE
Add null terminator for file source read

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -1264,7 +1264,7 @@ lexer_t* lexer_open(source_t* source, errors_t* errors,
   lexer->source = source;
   lexer->errors = errors;
   lexer->allow_test_symbols = allow_test_symbols;
-  lexer->len = source->len;
+  lexer->len = source->len - 1; // because we don't want the null terminator to be parsed.
   lexer->line = 1;
   lexer->pos = 1;
   lexer->newline = true;

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -55,7 +55,7 @@ source_t* source_open_string(const char* source_code)
 {
   source_t* source = POOL_ALLOC(source_t);
   source->file = NULL;
-  source->len = strlen(source_code);
+  source->len = strlen(source_code) + 1; // for null terminator
   source->m = (char*)ponyint_pool_alloc_size(source->len);
 
   memcpy(source->m, source_code, source->len);

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -44,7 +44,7 @@ source_t* source_open(const char* file, const char** error_msgp)
     fclose(fp);
     return NULL;
   }
-
+  source->m[size] = '\0';
   fclose(fp);
   return source;
 }

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -19,7 +19,6 @@ source_t* source_open(const char* file, const char** error_msgp)
 
   fseek(fp, 0, SEEK_END);
   ssize_t size = ftell(fp);
-  size = size + 1; // for null terminator
   
   if(size < 0)
   {
@@ -32,13 +31,13 @@ source_t* source_open(const char* file, const char** error_msgp)
 
   source_t* source = POOL_ALLOC(source_t);
   source->file = stringtab(file);
-  source->m = (char*)ponyint_pool_alloc_size(size);
-  source->len = size;
+  source->m = (char*)ponyint_pool_alloc_size(size + 1);
+  source->len = size + 1;
 
-  ssize_t read = fread(source->m, sizeof(char), size - 1, fp);
-  source->m[size - 1] = '\0';
+  ssize_t read = fread(source->m, sizeof(char), size, fp);
+  source->m[size] = '\0';
   
-  if(read < size - 1)
+  if(read < size)
   {
     *error_msgp = "failed to read entire file";
     ponyint_pool_free_size(source->len, source->m);

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -28,23 +28,25 @@ source_t* source_open(const char* file, const char** error_msgp)
   }
 
   fseek(fp, 0, SEEK_SET);
-
+  
+  ssize_t alloc_size = size + 1; // for null termintator
   source_t* source = POOL_ALLOC(source_t);
   source->file = stringtab(file);
-  source->m = (char*)ponyint_pool_alloc_size(size);
+  source->m = (char*)ponyint_pool_alloc_size(alloc_size);
   source->len = size;
 
   ssize_t read = fread(source->m, sizeof(char), size, fp);
-
+  source->m[size] = '\0';
+  
   if(read < size)
   {
     *error_msgp = "failed to read entire file";
-    ponyint_pool_free_size(source->len, source->m);
+    ponyint_pool_free_size(alloc_size, source->m);
     POOL_FREE(source_t, source);
     fclose(fp);
     return NULL;
   }
-  source->m[size] = '\0';
+
   fclose(fp);
   return source;
 }

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -20,6 +20,7 @@ source_t* source_open(const char* file, const char** error_msgp)
   fseek(fp, 0, SEEK_END);
   ssize_t size = ftell(fp);
   size = size + 1; // for null terminator
+  
   if(size < 0)
   {
     *error_msgp = "can't determine length of file";
@@ -28,7 +29,7 @@ source_t* source_open(const char* file, const char** error_msgp)
   }
 
   fseek(fp, 0, SEEK_SET);
-  
+
   source_t* source = POOL_ALLOC(source_t);
   source->file = stringtab(file);
   source->m = (char*)ponyint_pool_alloc_size(size);
@@ -40,7 +41,7 @@ source_t* source_open(const char* file, const char** error_msgp)
   if(read < size)
   {
     *error_msgp = "failed to read entire file";
-    ponyint_pool_free_size(size, source->m);
+    ponyint_pool_free_size(source->len, source->m);
     POOL_FREE(source_t, source);
     fclose(fp);
     return NULL;

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -35,10 +35,10 @@ source_t* source_open(const char* file, const char** error_msgp)
   source->m = (char*)ponyint_pool_alloc_size(size);
   source->len = size;
 
-  ssize_t read = fread(source->m, sizeof(char), size, fp);
+  ssize_t read = fread(source->m, sizeof(char), size - 1, fp);
   source->m[size - 1] = '\0';
   
-  if(read < size)
+  if(read < size - 1)
   {
     *error_msgp = "failed to read entire file";
     ponyint_pool_free_size(source->len, source->m);

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -19,7 +19,7 @@ source_t* source_open(const char* file, const char** error_msgp)
 
   fseek(fp, 0, SEEK_END);
   ssize_t size = ftell(fp);
-
+  size = size + 1; // for null terminator
   if(size < 0)
   {
     *error_msgp = "can't determine length of file";
@@ -29,19 +29,18 @@ source_t* source_open(const char* file, const char** error_msgp)
 
   fseek(fp, 0, SEEK_SET);
   
-  ssize_t alloc_size = size + 1; // for null termintator
   source_t* source = POOL_ALLOC(source_t);
   source->file = stringtab(file);
-  source->m = (char*)ponyint_pool_alloc_size(alloc_size);
+  source->m = (char*)ponyint_pool_alloc_size(size);
   source->len = size;
 
   ssize_t read = fread(source->m, sizeof(char), size, fp);
-  source->m[size] = '\0';
+  source->m[size - 1] = '\0';
   
   if(read < size)
   {
     *error_msgp = "failed to read entire file";
-    ponyint_pool_free_size(alloc_size, source->m);
+    ponyint_pool_free_size(size, source->m);
     POOL_FREE(source_t, source);
     fclose(fp);
     return NULL;


### PR DESCRIPTION
I ran into an issue where when writing back source to file where garbage appeared on some file. Looking at the code it seems there wasn't a null terminator put.