### PR TITLE
Make ContentsLogger implement the Logger interface

### DIFF
--- a/packages/net/http/common_log.pony
+++ b/packages/net/http/common_log.pony
@@ -9,8 +9,12 @@ class CommonLog is Logger
   new val create(out: OutStream) =>
     _out = out
 
-  fun val apply(ip: String, body_size: USize,
-    request: Payload val, response: Payload val) =>
+  fun val apply(
+    ip: String,
+    body_size: USize,
+    request: Payload val,
+    response: Payload val)
+  =>
 
     let list = recover Array[String](24) end
 

--- a/packages/net/http/contents_log.pony
+++ b/packages/net/http/contents_log.pony
@@ -1,4 +1,4 @@
-class ContentsLog
+class ContentsLog is Logger
   """
   Logs the contents of HTTP requests and responses.
   """
@@ -7,7 +7,12 @@ class ContentsLog
   new val create(out: OutStream) =>
     _out = out
 
-  fun val apply(ip: String, request: Payload val, response: Payload val) ? =>
+  fun val apply(
+    ip: String,
+    body_size: USize,
+    request: Payload val,
+    response: Payload val)
+  =>
     let list = recover Array[ByteSeq] end
 
     list.push("REQUEST\n")
@@ -36,9 +41,7 @@ class ContentsLog
       list.push("\n")
     end
 
-    for data in request.body()?.values() do
-      list.push(data)
-    end
+    try list.append(request.body()?) end
 
     list.push("\n")
 
@@ -57,9 +60,7 @@ class ContentsLog
       list.push("\n")
     end
 
-    for data in response.body()?.values() do
-      list.push(data)
-    end
+    try list.append(response.body()?) end
 
     list.push("\n\n")
     _out.writev(consume list)

--- a/packages/net/http/discard_log.pony
+++ b/packages/net/http/discard_log.pony
@@ -4,7 +4,7 @@ primitive DiscardLog
   """
   fun val apply(
     ip: String,
-    transferred: USize,
+    body_size: USize,
     request: Payload val,
     response: Payload val)
   =>

--- a/packages/net/http/server_notify.pony
+++ b/packages/net/http/server_notify.pony
@@ -4,7 +4,7 @@ interface val Logger
   """
   fun val apply(
     ip: String,
-    transfer: USize,
+    body_size: USize,
     request: Payload val,
     response: Payload val)
     : Any


### PR DESCRIPTION
Previously, `ContentsLogger` did not implement the `Logge`r interface. There
were also some inconsistencies between the parameter names in the `Logger`
apply method across its implementations.