### PR TITLE
Enable CodeView debug information with MSVC on Windows

### DIFF
--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -1,12 +1,6 @@
 #ifndef CODEGEN_H
 #define CODEGEN_H
 
-#include "gendebug.h"
-#include "../reach/reach.h"
-#include "../pass/pass.h"
-#include "../ast/ast.h"
-#include "../ast/printbuf.h"
-
 #include <platform.h>
 #include <llvm-c/Core.h>
 #include <llvm-c/Target.h>
@@ -15,9 +9,15 @@
 #include <llvm-c/Analysis.h>
 #include <stdio.h>
 
-PONY_EXTERN_C_BEGIN
-
 #define PONY_LLVM ((LLVM_VERSION_MAJOR * 100) + LLVM_VERSION_MINOR)
+
+#include "gendebug.h"
+#include "../reach/reach.h"
+#include "../pass/pass.h"
+#include "../ast/ast.h"
+#include "../ast/printbuf.h"
+
+PONY_EXTERN_C_BEGIN
 
 // Missing from C API.
 char* LLVMGetHostCPUName();

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -1,5 +1,5 @@
-#include "gendebug.h"
 #include "codegen.h"
+#include "gendebug.h"
 
 #ifdef _MSC_VER
 #  pragma warning(push)
@@ -96,6 +96,18 @@ LLVMMetadataRef LLVMDIBuilderCreateFile(LLVMDIBuilderRef d, const char* file)
 
   return wrap(pd->createFile(filename, dir));
 }
+
+#if PONY_LLVM >= 309
+
+LLVMMetadataRef LLVMDIBuilderCreateNamespace(LLVMDIBuilderRef d, 
+  LLVMMetadataRef scope, const char* name, LLVMMetadataRef file, unsigned line)
+{
+  DIBuilder* pd = unwrap(d);
+  return wrap(pd->createNameSpace(unwrap<DIScope>(scope), name, 
+    unwrap<DIFile>(file), line));
+}
+
+#endif
 
 LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(LLVMDIBuilderRef d,
   LLVMMetadataRef scope, LLVMMetadataRef file, unsigned line, unsigned col)

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -45,11 +45,16 @@ void LLVMMetadataReplaceAllUsesWith(LLVMMetadataRef md_old,
 LLVMDIBuilderRef LLVMNewDIBuilder(LLVMModuleRef m)
 {
   Module* pm = unwrap(m);
+
+#if defined(_MSC_VER) && PONY_LLVM >= 309
+  pm->addModuleFlag(Module::Warning, "CodeView", 1);
+#else
   unsigned dwarf = dwarf::DWARF_VERSION;
   unsigned debug_info = DEBUG_METADATA_VERSION;
-
+  
   pm->addModuleFlag(Module::Warning, "Dwarf Version", dwarf);
   pm->addModuleFlag(Module::Warning, "Debug Info Version", debug_info);
+#endif
 
   return wrap(new DIBuilder(*pm));
 }

--- a/src/libponyc/codegen/gendebug.h
+++ b/src/libponyc/codegen/gendebug.h
@@ -54,6 +54,12 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef d,
 
 LLVMMetadataRef LLVMDIBuilderCreateFile(LLVMDIBuilderRef d, const char* file);
 
+#if PONY_LLVM >= 309
+LLVMMetadataRef LLVMDIBuilderCreateNamespace(LLVMDIBuilderRef d, 
+  LLVMMetadataRef scope, const char* name, LLVMMetadataRef file, 
+  unsigned line);
+#endif
+
 LLVMMetadataRef LLVMDIBuilderCreateLexicalBlock(LLVMDIBuilderRef d,
   LLVMMetadataRef scope, LLVMMetadataRef file, unsigned line, unsigned col);
 

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -189,6 +189,15 @@ static void make_function_debug(compile_t* c, reach_type_t* t,
   else
     scope = c_t->di_type;
 
+#if PONY_LLVM >= 309 && defined(_MSC_VER)
+  // CodeView on Windows doesn't like "non-class" methods
+  if (c_t->primitive != NULL)
+  {
+    scope = LLVMDIBuilderCreateNamespace(c->di, c->di_unit, t->name, 
+      c_t->di_file, (unsigned)ast_line(t->ast));
+  }
+#endif
+
   c_m->di_method = LLVMDIBuilderCreateMethod(c->di, scope, ast_name(id),
     m->full_name, c_m->di_file, (unsigned)ast_line(m->r_fun), subroutine, func,
     c->opt->release);

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -379,10 +379,6 @@ int main(int argc, char* argv[])
     }
   }
 
-#if defined(PLATFORM_IS_WINDOWS)
-  opt.strip_debug = true;
-#endif
-
   if(!ok)
   {
     errors_print(opt.check.errors);


### PR DESCRIPTION
@oraoto mentioned in #2331 that debug information is not output for Pony programs on Windows.
This PR implements CodeView debug information so that you can see functions and variables when debugging in Windows.