### PR TITLE
Fix alloc bug in String/Array trimming functions

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -183,9 +183,14 @@ class Array[A] is Seq[A]
     """
     let last = _size.min(to)
     let offset = last.min(from)
+    let size' = last - offset
 
-    _size = last - offset
-    _alloc = _alloc - offset
+    // use the new size' for alloc if we're not including the last used byte
+    // from the original data and only include the extra allocated bytes if
+    // we're including the last byte.
+    _alloc = if last == _size then _alloc - offset else size' end
+
+    _size = size'
     _ptr = _ptr._offset(offset)
 
   fun val trim(from: USize = 0, to: USize = -1): Array[A] val =>
@@ -199,7 +204,11 @@ class Array[A] is Seq[A]
 
     recover
       let size' = last - offset
-      let alloc = _alloc - offset
+
+      // use the new size' for alloc if we're not including the last used byte
+      // from the original data and only include the extra allocated bytes if
+      // we're including the last byte.
+      let alloc = if last == _size then _alloc - offset else size' end
 
       if size' > 0 then
         from_cpointer(_ptr._offset(offset)._unsafe(), size', alloc)

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -444,10 +444,15 @@ class iso _TestStringTrim is UnitTest
 
   fun apply(h: TestHelper) =>
     h.assert_eq[String]("45", "0123456".trim(4, 6))
+    h.assert_eq[USize](2, "0123456".trim(4, 6).space())
     h.assert_eq[String]("456", "0123456".trim(4, 7))
+    h.assert_eq[USize](3, "0123456".trim(4, 7).space())
     h.assert_eq[String]("456", "0123456".trim(4))
+    h.assert_eq[USize](3, "0123456".trim(4).space())
     h.assert_eq[String]("", "0123456".trim(4, 4))
+    h.assert_eq[USize](0, "0123456".trim(4, 4).space())
     h.assert_eq[String]("", "0123456".trim(4, 1))
+    h.assert_eq[USize](0, "0123456".trim(4, 1).space())
 
 class iso _TestStringTrimInPlace is UnitTest
   """
@@ -456,22 +461,24 @@ class iso _TestStringTrimInPlace is UnitTest
   fun name(): String => "builtin/String.trim_in_place"
 
   fun apply(h: TestHelper) =>
-    case(h, "45", "0123456", 4, 6)
-    case(h, "456", "0123456", 4, 7)
-    case(h, "456", "0123456", 4)
-    case(h, "", "0123456", 4, 4)
-    case(h, "", "0123456", 4, 1)
+    case(h, "45", "0123456", 4, 6, 2)
+    case(h, "456", "0123456", 4, 7, 3)
+    case(h, "456", "0123456", 4 where space = 3)
+    case(h, "", "0123456", 4, 4, 0)
+    case(h, "", "0123456", 4, 1, 0)
 
   fun case(
     h: TestHelper,
     expected: String,
     orig: String,
     from: USize,
-    to: USize = -1)
+    to: USize = -1,
+    space: USize = 0)
   =>
     let copy: String ref = orig.clone()
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
+    h.assert_eq[USize](space, copy.space())
     h.assert_eq[String box](expected, copy.clone()) // safe to clone
 
 class iso _TestStringTrimInPlaceWithAppend is UnitTest
@@ -1136,10 +1143,15 @@ class iso _TestArrayTrim is UnitTest
   fun apply(h: TestHelper) =>
     let orig: Array[U8] val = [0; 1; 2; 3; 4; 5; 6]
     h.assert_array_eq[U8]([4; 5], orig.trim(4, 6))
+    h.assert_eq[USize](2, orig.trim(4, 6).space())
     h.assert_array_eq[U8]([4; 5; 6], orig.trim(4, 7))
+    h.assert_eq[USize](4, orig.trim(4, 7).space())
     h.assert_array_eq[U8]([4; 5; 6], orig.trim(4))
+    h.assert_eq[USize](4, orig.trim(4).space())
     h.assert_array_eq[U8](Array[U8], orig.trim(4, 4))
+    h.assert_eq[USize](0, orig.trim(4, 4).space())
     h.assert_array_eq[U8](Array[U8], orig.trim(4, 1))
+    h.assert_eq[USize](0, orig.trim(4, 1).space())
 
 class iso _TestArrayTrimInPlace is UnitTest
   """
@@ -1148,21 +1160,23 @@ class iso _TestArrayTrimInPlace is UnitTest
   fun name(): String => "builtin/Array.trim_in_place"
 
   fun apply(h: TestHelper) =>
-    case(h, [4; 5], [0; 1; 2; 3; 4; 5; 6], 4, 6)
-    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4, 7)
-    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4)
-    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 4)
-    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 1)
+    case(h, [4; 5], [0; 1; 2; 3; 4; 5; 6], 4, 6, 2)
+    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4, 7, 4)
+    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4 where space = 4)
+    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 4, 0)
+    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 1, 0)
 
   fun case(
     h: TestHelper,
     expected: Array[U8],
     orig: Array[U8],
     from: USize,
-    to: USize = -1)
+    to: USize = -1,
+    space: USize = 0)
   =>
     let copy: Array[U8] ref = orig.clone()
     copy.trim_in_place(from, to)
+    h.assert_eq[USize](space, copy.space())
     h.assert_array_eq[U8](expected, copy)
 
 class iso _TestArrayTrimInPlaceWithAppend is UnitTest


### PR DESCRIPTION
Prior to this commit, the trim/trim_in_place functions of Array
and String incorrectly calculated the new `_alloc` value.

This commit changes the logic to set `_alloc` to be the same
as the new `_size` if the last byte is not included and to
only included extra allocated bytes if we're including the
last byte.

This commit also changes how `String.from_cpointer` calculates
the `_alloc` value as it was incorrectly adding a byte when it
shouldn't have been (this was likely due to an assumption of a
null terminator being present that doesn't hold any longer).

Tests have also been enhanced to prevent regressions.