### PR TITLE
Fix compilation error with 'use=dtrace' for FreeBSD 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -696,9 +696,15 @@ $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
 	@echo 'Linking libponyrt'
     ifneq (,$(DTRACE))
     ifeq ($(OSTYPE), linux)
-	@echo 'Generating dtrace object file'
+	@echo 'Generating dtrace object file (linux)'
 	$(SILENT)$(DTRACE) -G -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_BUILD_DIR)/dtrace_probes.o
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles) $(PONY_BUILD_DIR)/dtrace_probes.o
+    else ifeq ($(OSTYPE), bsd)
+	@echo 'Generating dtrace object file (bsd)'
+	$(SILENT)rm -f $(PONY_BUILD_DIR)/dtrace_probes.o
+	$(SILENT)$(DTRACE) -G -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_BUILD_DIR)/dtrace_probes.o $(ofiles)
+	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles) $(PONY_BUILD_DIR)/dtrace_probes.o
+	$(SILENT)$(AR) $(AR_FLAGS) $(PONY_BUILD_DIR)/libdtrace_probes.a $(PONY_BUILD_DIR)/dtrace_probes.o
     else
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
     endif
@@ -752,6 +758,9 @@ endif
 ifneq ($(wildcard $(PONY_BUILD_DIR)/libponyrt.bc),)
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.bc $(destdir)/lib
 endif
+ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
+	$(SILENT)cp $(PONY_BUILD_DIR)/libdtrace_probes.a $(destdir)/lib
+endif
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyc.a $(destdir)/lib
 	$(SILENT)cp $(PONY_BUILD_DIR)/ponyc $(destdir)/bin
 	$(SILENT)cp src/libponyrt/pony.h $(destdir)/include
@@ -768,6 +777,11 @@ ifeq ($(OSTYPE),linux)
 endif
 ifneq ($(wildcard $(destdir)/lib/libponyrt.bc),)
 	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libponyrt.bc $(prefix)/lib/libponyrt.bc
+endif
+ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
+	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a
+else
+	damnit
 endif
 	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
 	$(SILENT)ln $(symlink.flags) $(destdir)/include/pony.h $(prefix)/include/pony.h
@@ -787,6 +801,9 @@ ifeq ($(OSTYPE),linux)
 endif
 ifneq ($(wildcard $(prefix)/lib/libponyrt.bc),)
 	-$(SILENT)rm $(prefix)/lib/libponyrt.bc 2>/dev/null ||:
+endif
+ifneq ($(wildcard $(prefix)/lib/libdtrace_probes.a),)
+	-$(SILENT)rm $(prefix)/lib/libdtrace_probes.a 2>/dev/null ||:
 endif
 	-$(SILENT)rm $(prefix)/lib/libponyc.a 2>/dev/null ||:
 	-$(SILENT)rm $(prefix)/include/pony.h 2>/dev/null ||:
@@ -865,6 +882,9 @@ endif
 ifneq ($(wildcard $(PONY_BUILD_DIR)/libponyrt.bc),)
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.bc $(package)/usr/lib/pony/$(package_version)/lib
 endif
+ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
+	$(SILENT)cp $(PONY_BUILD_DIR)/libdtrace_probes.a $(package)/usr/lib/pony/$(package_version)/lib
+endif
 	$(SILENT)cp $(PONY_BUILD_DIR)/ponyc $(package)/usr/lib/pony/$(package_version)/bin
 	$(SILENT)cp src/libponyrt/pony.h $(package)/usr/lib/pony/$(package_version)/include
 	$(SILENT)cp src/common/pony/detail/atomics.h $(package)/usr/lib/pony/$(package_version)/include/pony/detail
@@ -874,6 +894,9 @@ ifeq ($(OSTYPE),linux)
 endif
 ifneq ($(wildcard /usr/lib/pony/$(package_version)/lib/libponyrt.bc),)
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/lib/libponyrt.bc $(package)/usr/lib/libponyrt.bc
+endif
+ifneq ($(wildcard /usr/lib/pony/$(package_version)/lib/libdtrace_probes.a),)
+	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/lib/libdtrace_probes.a $(package)/usr/lib/libdtrace_probes.a
 endif
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/lib/libponyc.a $(package)/usr/lib/libponyc.a
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/bin/ponyc $(package)/usr/bin/ponyc

--- a/Makefile
+++ b/Makefile
@@ -780,8 +780,6 @@ ifneq ($(wildcard $(destdir)/lib/libponyrt.bc),)
 endif
 ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
 	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a
-else
-	damnit
 endif
 	$(SILENT)ln $(symlink.flags) $(destdir)/lib/libponyc.a $(prefix)/lib/libponyc.a
 	$(SILENT)ln $(symlink.flags) $(destdir)/include/pony.h $(prefix)/include/pony.h


### PR DESCRIPTION
The current build procedure for 'make use=dtrace' is working
correctly for OS X and Linux+SystemTap because both are hybrids
compared to the original Solaris implementation.  FreeBSD's
implementation is very close to Solaris's.

The original implemntation requires a two-stage process for compiling
the USDT probe specification file, e.g., `src/common/dtrace_probes.d`).
The first stage, `dtrace -h`, creates the C header file prerequisite
for compilation.  The second stage, `dtrace -G`, analyzes the object
files for DTrace probe data and creates a new object file that must
also be linked into the executable.

The `Makefile` procedure for the second stage for Linux is apparently
sufficient for Linux+SystemTap but isn't sufficient for FreeBSD.
The FreeBSD linker does not automatically add the `dtrace_probes.o`
object file to its workflow.  (Presumably Linux's linker does.)  The
result are these errors at linking time, using the command
`gmake use=dtrace verbose=true`:

    Linking ponyc
    c++  -o build/release-dtrace/ponyc build/release-dtrace/obj/ponyc/main.o -march=native -mtune=generic -mcx16 -L build/release-dtrace -L /usr/local/lib  -L/usr/local/llvm39/lib  -lponyc -lponyrt -lLLVMLTO -lLLVMObjCARCOpts -lLLVMSymbolize -lLLVMDebugInfoPDB -lLLVMDebugInfoDWARF -lLLVMMIRParser -lLLVMCoverage -lLLVMTableGen -lLLVMOrcJIT -lLLVMXCoreDisassembler -lLLVMXCoreCodeGen -lLLVMXCoreDesc -lLLVMXCoreInfo -lLLVMXCoreAsmPrinter -lLLVMSystemZDisassembler -lLLVMSystemZCodeGen -lLLVMSystemZAsmParser -lLLVMSystemZDesc -lLLVMSystemZInfo -lLLVMSystemZAsmPrinter -lLLVMSparcDisassembler -lLLVMSparcCodeGen -lLLVMSparcAsmParser -lLLVMSparcDesc -lLLVMSparcInfo -lLLVMSparcAsmPrinter -lLLVMPowerPCDisassembler -lLLVMPowerPCCodeGen -lLLVMPowerPCAsmParser -lLLVMPowerPCDesc -lLLVMPowerPCInfo -lLLVMPowerPCAsmPrinter -lLLVMNVPTXCodeGen -lLLVMNVPTXDesc -lLLVMNVPTXInfo -lLLVMNVPTXAsmPrinter -lLLVMMSP430CodeGen -lLLVMMSP430Desc -lLLVMMSP430Info -lLLVMMSP430AsmPrinter -lLLVMMipsDisassembler -lLLVMMipsCodeGen -lLLVMMipsAsmParser -lLLVMMipsDesc -lLLVMMipsInfo -lLLVMMipsAsmPrinter -lLLVMHexagonDisassembler -lLLVMHexagonCodeGen -lLLVMHexagonAsmParser -lLLVMHexagonDesc -lLLVMHexagonInfo -lLLVMBPFCodeGen -lLLVMBPFDesc -lLLVMBPFInfo -lLLVMBPFAsmPrinter -lLLVMARMDisassembler -lLLVMARMCodeGen -lLLVMARMAsmParser -lLLVMARMDesc -lLLVMARMInfo -lLLVMARMAsmPrinter -lLLVMAMDGPUDisassembler -lLLVMAMDGPUCodeGen -lLLVMAMDGPUAsmParser -lLLVMAMDGPUDesc -lLLVMAMDGPUInfo -lLLVMAMDGPUAsmPrinter -lLLVMAMDGPUUtils -lLLVMAArch64Disassembler -lLLVMAArch64CodeGen -lLLVMGlobalISel -lLLVMAArch64AsmParser -lLLVMAArch64Desc -lLLVMAArch64Info -lLLVMAArch64AsmPrinter -lLLVMAArch64Utils -lLLVMObjectYAML -lLLVMLibDriver -lLLVMOption -lLLVMX86Disassembler -lLLVMX86AsmParser -lLLVMX86CodeGen -lLLVMSelectionDAG -lLLVMAsmPrinter -lLLVMDebugInfoCodeView -lLLVMX86Desc -lLLVMMCDisassembler -lLLVMX86Info -lLLVMX86AsmPrinter -lLLVMX86Utils -lLLVMMCJIT -lLLVMLineEditor -lLLVMPasses -lLLVMipo -lLLVMVectorize -lLLVMLinker -lLLVMIRReader -lLLVMAsmParser -lLLVMInterpreter -lLLVMExecutionEngine -lLLVMRuntimeDyld -lLLVMObject -lLLVMMCParser -lLLVMCodeGen -lLLVMTarget -lLLVMScalarOpts -lLLVMInstCombine -lLLVMInstrumentation -lLLVMTransformUtils -lLLVMMC -lLLVMBitWriter -lLLVMBitReader -lLLVMAnalysis -lLLVMProfileData -lLLVMCore -lLLVMSupport -lz -lncurses -lpthread -lexecinfo -lblake2 -rdynamic
    build/release-dtrace/libponyrt.a(trace.o): In function `pony_gc_send':
    src/libponyrt/gc/trace.c:(.text+0x19): undefined reference to `__dtrace_pony___gc__send__start'
    build/release-dtrace/libponyrt.a(trace.o): In function `pony_gc_recv':
    src/libponyrt/gc/trace.c:(.text+0x39): undefined reference to `__dtrace_pony___gc__recv__start'
    build/release-dtrace/libponyrt.a(trace.o): In function `pony_send_done':
    src/libponyrt/gc/trace.c:(.text+0xd1): undefined reference to `__dtrace_pony___gc__send__end'
    build/release-dtrace/libponyrt.a(trace.o): In function `pony_recv_done':
    src/libponyrt/gc/trace.c:(.text+0x109): undefined reference to `__dtrace_pony___gc__recv__end'
    build/release-dtrace/libponyrt.a(heap.o): In function `ponyint_heap_setnextgcfactor':
    src/libponyrt/mem/heap.c:(.text+0x5a): undefined reference to `__dtrace_pony___gc__threshold'
    [... 54 additional lines of output omitted ...]

AFAICT, the Pony compiler gives the linker several `-L` flags in to
specify where `libponyrt.a` and perhaps other library files may
be stored: in the `ponyc` repo, or in the `make install` destination
directory.  If we tell the linker to link `dtrace_probes.o`
directly, then we need to give a correct, full path to it.
However, if we put `dtrace_probes.o` into a library, then we can
let the linker search its list of directories (one of them will be
good).

To force the linker to read & use the data in the new shared
library, `libdtrace_probes.a`, I've also added the flag
`-Wl,--whole-archive` to the linker's command line.  (NOTE: using
the `--whole-archive` trick on the entire `libponyrt.a` library
had some side effects that IMHO makes it worthwhile to put the
DTrace stuff into a new library file.  If PR review really does
not like the new library file, please say so.)

Tested on FreeBSD 11.1-RELEASE, Ubuntu 16.04, and OS X Sierra, all 64 bit, all with & without `use=dtrace` argument to `make`.