### PR TITLE
Add explicit OS version + amd64/64-bit prerequisites to FreeBSD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,13 @@ gmake
 
 First, install the required dependencies:
 
+* FreeBSD 11 for amd64 (64-bit).  It is extremely difficult to
+coordinate the LLVM version, operating system support for atomics, and
+Pony to work in harmony on FreeBSD 10 or earlier.  (See additional
+info below that mentions problems with 32-bit executable support.)
+
+* The following packages, with their installation commands:
+
 ```bash
 sudo pkg install gmake
 sudo pkg install llvm38


### PR DESCRIPTION
Since there are problems with compiling `ponyc` on FreeBSD 10, and since those problems disappear when using FreeBSD 11, I've created a patch to the top README file to strongly suggest using FreeBSD 11.  Then perhaps a handful of people may avoid the rabbit hole I just fell into.  `^_^`  This is a suggestion: reviewers are welcome to bend this in another direction if they wish.

This is a workaround for #2339, not a fix ... unless someone decides to abandon hope on FreeBSD 10 support.
