### PR TITLE
fix Range with negative or 0 step and allow backward Ranges (having `min > max`)

### DIFF
--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -25,6 +25,7 @@ actor Main is TestList
     test(_TestListsReverse)
     test(_TestHashSetContains)
     test(_TestSort)
+    test(_TestRange)
 
 class iso _TestList is UnitTest
   fun name(): String => "collections/List"
@@ -534,3 +535,67 @@ class iso _TestSort is UnitTest
     unsorted: Array[A])
   =>
     h.assert_array_eq[A](sorted, Sort[Array[A], A](unsorted))
+
+class iso _TestRange is UnitTest
+  fun name(): String => "collections/Range"
+
+  fun apply(h: TestHelper) =>
+    _assert_range[USize](h, 0, 0, 1, [])
+    _assert_range[USize](h, 0, 0, 0, [])
+    _assert_range[USize](h, 0, 0, -1, [])
+    _assert_range[USize](h, 0, 0, 2, [])
+
+    _assert_range[USize](h, 0, 1, 1, [0])
+    _assert_infinite[I8](h, 0, 1, -1)
+    _assert_infinite[I8](h, 0, 1, 0)
+    _assert_infinite[I8](h, 1, 0, 0)
+    _assert_infinite[I8](h, 1, 0, 1)
+    _assert_range[I8](h, -1, 1, 1, [-1; 0])
+
+    _assert_range[USize](h, 0, 1, 2, [0])
+    _assert_range[USize](h, 0, 10, 1, [0; 1; 2; 3; 4; 5; 6; 7; 8; 9])
+    _assert_range[USize](h, 0, 10, 2, [0; 2; 4; 6; 8])
+    _assert_range[I8](h, 2, -2, -1, [2; 1; 0; -1])
+    _assert_range[I8](h, -10, -7, 1, [-10; -9; -8])
+
+    _assert_range[F32](h, 0.0, 0.0, 1.0, [])
+    _assert_range[F32](h, 0.0, 0.0, F32.epsilon(), [])
+    _assert_range[F32](h, 0.0, F32.epsilon(), F32.epsilon(), [0.0])
+    _assert_range[F64](h, -0.1, 0.2, 0.1, [-0.1; 0.0; 0.1])
+    _assert_infinite[F64](h, -0.1, 0.2, -0.1)
+    _assert_range[F64](h, 0.1, -0.2, -0.1, [0.1; 0.0; -0.1])
+    _assert_infinite[F64](h, 0.2, -0.1, 0.1)
+    _assert_infinite[F64](h, 0.2, -0.1, 0.0)
+
+  fun _assert_infinite[N: (Real[N] val & Number)](
+    h: TestHelper,
+    min: N,
+    max: N,
+    step: N = 1
+  ) =>
+    let range: Range[N] = Range[N](min, max, step)
+    let range_str = "Range(" + min.string() + ", " + max.string() + ", " + step.string() + ")"
+
+    h.assert_true(range.is_infinite(), range_str + " should be infinite")
+
+  fun _assert_range[N: (Real[N] val & Number)](
+    h: TestHelper,
+    min: N,
+    max: N,
+    step: N = 1,
+    expected: Array[N] val
+  ) =>
+    let range: Range[N] = Range[N](min, max, step)
+    let range_str = "Range(" + min.string() + ", " + max.string() + ", " + step.string() + ")"
+
+    h.assert_false(range.is_infinite(), range_str + " is infinite")
+    let collector = Array[N].create(0) .> concat(range)
+    h.assert_array_eq[N](expected, collector, range_str + " should produce expected elements")
+
+
+  fun _count_range[N: (Real[N] val & Number)](range: Range[N]): USize =>
+    var count: USize = 0
+    for _ in range do
+      count = count + 1
+    end
+    count

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -561,11 +561,29 @@ class iso _TestRange is UnitTest
     _assert_range[F32](h, 0.0, 0.0, 1.0, [])
     _assert_range[F32](h, 0.0, 0.0, F32.epsilon(), [])
     _assert_range[F32](h, 0.0, F32.epsilon(), F32.epsilon(), [0.0])
+
     _assert_range[F64](h, -0.1, 0.2, 0.1, [-0.1; 0.0; 0.1])
     _assert_infinite[F64](h, -0.1, 0.2, -0.1)
+
     _assert_range[F64](h, 0.1, -0.2, -0.1, [0.1; 0.0; -0.1])
     _assert_infinite[F64](h, 0.2, -0.1, 0.1)
     _assert_infinite[F64](h, 0.2, -0.1, 0.0)
+
+    let p_inf = F64.max_value() + F64.max_value()
+    let n_inf = -p_inf
+    let nan = F64(0) / F64(0)
+
+    _assert_infinite[F64](h, nan, 0, 1)
+    _assert_infinite[F64](h, 0, nan, 1)
+    _assert_infinite[F64](h, 0, 100, nan)
+
+    _assert_infinite[F64](h, p_inf, 10, -1)
+    _assert_infinite[F64](h, n_inf, p_inf, 1)
+    _assert_infinite[F64](h, 10, p_inf, 0)
+    _assert_infinite[F64](h, 0, 10, p_inf)
+    _assert_infinite[F64](h, 100, 10, n_inf)
+
+
 
   fun _assert_infinite[N: (Real[N] val & Number)](
     h: TestHelper,

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -1,10 +1,53 @@
 class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
   """
-  Produces [min, max).
+  Produces `[min, max)` with a step of `inc` for any `Number` type.
+
+  ```pony
+  // iterating with for-loop
+  for i in Range(0, 10) do
+    env.out.print(i.string())
+  end
+
+  // iterating over Range with while-loop
+  let range = Range(5, 100, 5)
+  while range.has_next() do
+    compute_something(range.next())
+  end
+  ```
+
+  Supports `min` being smaller than `max` with negative `inc`:
+
+  ```pony
+  var previous = 11
+  for left in Range[I64](10, -5, -1) do
+    if not (left < previous) then
+      error
+    end
+    previous = left
+  end
+  ```
+
+  If the `step` is not moving `min` towards `max` or if it is `0`,
+  the Range is considered infinite and iterating over it
+  will never terminate:
+
+  ```pony
+  let infinite_range1 = Range(0, 1, 0)
+  infinite_range1.is_infinite() == true
+
+  let infinite_range2 = Range[U8](0, 10, -1)
+  for _ in infinite_range2 do
+    env.out.print("will this ever end?")
+    env.err.print("no, never!")
+  end
+  ```
+
   """
   let _min: A
   let _max: A
   let _inc: A
+  let _forward: Bool
+  let _infinite: Bool
   var _idx: A
 
   new create(min: A, max: A, inc: A = 1) =>
@@ -12,9 +55,18 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
     _max = max
     _inc = inc
     _idx = min
+    _forward = (_min < _max) and (_inc > 0)
+    _infinite =
+      ((_inc == 0) and (min != max))    // no progress
+      or ((_min < _max) and (_inc < 0)) // progress into other directions
+      or ((_min > _max) and (_inc > 0))
 
   fun has_next(): Bool =>
-    _idx < _max
+    if _forward then
+      _idx < _max
+    else
+      _idx > _max
+    end
 
   fun ref next(): A =>
     if has_next() then
@@ -25,3 +77,6 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
 
   fun ref rewind() =>
     _idx = _min
+
+  fun is_infinite(): Bool =>
+    _infinite

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -15,7 +15,8 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
   end
   ```
 
-  Supports `min` being smaller than `max` with negative `inc`:
+  Supports `min` being smaller than `max` with negative `inc`
+  but only for signed integer types and floats:
 
   ```pony
   var previous = 11
@@ -35,7 +36,7 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
   let infinite_range1 = Range(0, 1, 0)
   infinite_range1.is_infinite() == true
 
-  let infinite_range2 = Range[U8](0, 10, -1)
+  let infinite_range2 = Range[I8](0, 10, -1)
   for _ in infinite_range2 do
     env.out.print("will this ever end?")
     env.err.print("no, never!")

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -44,10 +44,10 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
 
   When using `Range` with  floating point types (`F32` and `F64`)
   `inc` steps < 1.0 are possible. If any of the arguments contains
-  `NaN`, `+Inf` or `-Inf` the range is considered infinite operations on
-  any of them don't move `min` towards `max`.
-  The actual values produced by the range are determined by what IEEE 754
-  defines as the repeated result of `min` + `inc`:
+  `NaN`, `+Inf` or `-Inf` the range is considered infinite as operations on
+  any of them won't move `min` towards `max`.
+  The actual values produced by such a `Range` are determined by what IEEE 754
+  defines as the result of `min` + `inc`:
 
   ```pony
   for and_a_half in Range[F64](0.5, 100) do


### PR DESCRIPTION
Add is_infinite method to check whether a given Range would iterate infinitely (having an inc-step which does not move min towards max).

Previously Range would also not iterate over given intervals where min > max irrelevant of the sign of the inc-step.