### PR TITLE
Update root .gitignore to ignore Windows generated output files.  [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ tags
 *.bc
 *.a
 *.exe
+*.exp
+*.ilk
+*.lib
+*.pdb
 *.sublime*
 .*.swp
 .*.swo


### PR DESCRIPTION
To go along with the `.gitignore` files added for the examples, we now ignore intermediate files created during Windows compiles.