### PR TITLE
Fix MacOS Sierra/High Sierra kernel panics

### DIFF
--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -569,8 +569,12 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
   }
 
   // Create an event and subscribe it.
+  #ifndef PLATFORM_IS_MACOSX
   pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0,
     true);
+  #else
+  pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE, 0, true);
+  #endif
 #endif
 
   return true;


### PR DESCRIPTION
The TCPConnection code currently uses kqueue one shot support on MacOS.
This works fine on MacOS versions prior to Sierra. It has come to out
attention that under load, one shot support causes kernel panics on
Sierra and High Sierra.

At this time, I don't have the time to investigate the cause further. In
the meeantime, given the serious nature of the problem, I'm turning off
one shot support on MacOS.

The kernel panic always displays:

Preemption level underflow, possible cause unlocking an unlocked mutex
or spinlock

As the error.