### PR TITLE
Add pony stable to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV LLVM_VERSION 3.9.1
 
 RUN apt-get update \
  && apt-get install -y \
+  apt-transport-https \
   g++ \
   git \
   libncurses5-dev \
@@ -13,6 +14,11 @@ RUN apt-get update \
   wget \
   xz-utils \
   zlib1g-dev \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2" \
+ && echo "deb https://dl.bintray.com/pony-language/pony-stable-debian /" | tee -a /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get install -y \
+  pony-stable \
  && rm -rf /var/lib/apt/lists/* \
  && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04


### PR DESCRIPTION
This allows users of the docker image to do the following:

* `docker run -it ponylang/ponyc stable fetch` to fetch dependencies
* `docker run -it ponylang/ponyc stable env ponyc` to build with
  dependencies