### PR TITLE
Runtime scheduler configuration of quiescence cycle timeout count.

### DIFF
--- a/packages/builtin/env.pony
+++ b/packages/builtin/env.pony
@@ -63,11 +63,20 @@ class val Env
       end
     end
 
-  fun tag exitcode(code: I32) =>
+  fun tag exitcode(code: I32, quiescence_cycles: U64 = 0) =>
     """
     Sets the application exit code. If this is called more than once, the last
     value set will be the exit code. The exit code defaults to 0.
+
+    The quiescence_cycles is a performance optimisation to reduce overhead during
+    message handling. But, higher values will result in a longer wait time to detecting
+    that the application has terminated. As such, it defaults to 0, since setting then
+    the exit code is generally an indication that the application should terminate soon.
+    (A value of 10E9 would equate to approximatly 5 seconds on 2017 hardware).
     """
+    // tell the scheduler to use the update cycle count when checking for completion
+    @pony_scheduler_set_quiescence[None](quiescence_cycles)
+    // set the exit code for the process
     @pony_exitcode[None](code)
 
   fun tag _count_strings(data: Pointer[Pointer[U8]] val): USize =>

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -445,6 +445,7 @@ actor PonyTest
 
     if fail_count == 0 then
       // Success, nothing failed.
+      _env.exitcode(0)
       return
     end
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -57,6 +57,8 @@ struct scheduler_t
   uint32_t ack_count;
   mutemap_t mute_mapping;
 
+  uint64_t quiescence_cycles;
+
   // These are accessed by other scheduler threads. The mpmcq_t is aligned.
   mpmcq_t q;
   messageq_t mq;
@@ -86,6 +88,8 @@ void ponyint_sched_noisy_asio();
 /** Mark asio as not being noisy
  */
 void ponyint_sched_unnoisy_asio();
+
+PONY_API void pony_scheduler_set_quiescence(uint64_t cycles);
 
 PONY_EXTERN_C_END
 

--- a/test/libponyrt/sched/scheduler.cc
+++ b/test/libponyrt/sched/scheduler.cc
@@ -1,0 +1,26 @@
+#include <platform.h>
+
+#include <sched/scheduler.h>
+
+#include <gtest/gtest.h>
+
+TEST(Scheduler, MpmcqAlignment)
+{
+  // An mpmcq_t is embedded in the scheduler_t structure.
+  // For the performance and scheduling code we need to ensure that this is 64-bit aligned.
+#ifndef PLATFORM_IS_VISUAL_STUDIO // TODO(sgebbie) Hmmm, I need to work out the correct syntax for 'alignof' under Visual Studio
+  ASSERT_EQ(64, alignof(scheduler_t::q));
+  scheduler_t sched;
+  ASSERT_EQ(64, alignof(sched.q));
+#endif
+}
+
+TEST(Scheduler, QuiescenceSize)
+{
+  // The scheduler parameter controling the quiescence cycle timeout is communicated via
+  // pony_msgi_t and therefore we must make sure that the integer storage is sufficiently large.
+  // If this test fails on any platform then we will need to create a new, more suitable, pony_msgx_t
+  ASSERT_EQ(sizeof(uint64_t), sizeof(scheduler_t::quiescence_cycles));
+  ASSERT_EQ(sizeof(intptr_t), sizeof(pony_msgi_t::i));
+  ASSERT_TRUE(sizeof(scheduler_t::quiescence_cycles) <= sizeof(pony_msgi_t::i));
+}


### PR DESCRIPTION
# Notes

I have tested this in terms of the expected behaviour. However, I would need some guidance regarding verifying that there is no unexpected impact to performance due to changes to the code on the critical path.

Finally, my choice for tying this to `Env.exitcode(...)` was driven by my view of the principle of least surprise, because many programs will then unwittingly experience the same behaviour they did before if they explicitly set the exit code. However, this needs to be debated, as it may be more appropriate to decouple this from `Env.exitcode(...)`.

# Commit Message

PR #2355 included a change that improved runtime performance at
the cost of significantly delaying program termination.

This commit makes it possible to have the best of both worlds. At start
up time the quiescence cycle timeout count will default to 10E9 (around 5
seconds on 2017 hardware). And, therefore, programs can still benefit
from this enhancement.

However, this exposes the means to then update the cycle timeout value
to a lower value (defaulting to 0). That way, programs can still control
their termination time.

The implementation ties the quiescence timeout configuration to setting
of an exit code. This is based on the idea that setting an exit code is
a strong signal that the program is intending to exit soon.

Finally, care is taken to propagate the timeout value to the scheduler
thread via the scheduler messaging mechanism rather than using
something like an atomic variable. This ensures that on the critical
path that the performance is not negatively impacted by cache
invalidation. Rather, the scheduler_t hold the value locally the
scheduler's thread.