### PR TITLE
Make work-stealing "scheduler is blocked" logic smarterer

### DIFF
--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -70,12 +70,12 @@ bool ponyint_asio_stop()
   return true;
 }
 
-void ponyint_asio_noisy_add()
+uint64_t ponyint_asio_noisy_add()
 {
-  atomic_fetch_add_explicit(&running_base.noisy_count, 1, memory_order_relaxed);
+  return atomic_fetch_add_explicit(&running_base.noisy_count, 1, memory_order_relaxed);
 }
 
-void ponyint_asio_noisy_remove()
+uint64_t ponyint_asio_noisy_remove()
 {
-  atomic_fetch_sub_explicit(&running_base.noisy_count, 1, memory_order_relaxed);
+  return atomic_fetch_sub_explicit(&running_base.noisy_count, 1, memory_order_relaxed);
 }

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -85,11 +85,11 @@ bool ponyint_asio_stop();
 
 /** Add a noisy event subscription.
  */
-void ponyint_asio_noisy_add();
+uint64_t ponyint_asio_noisy_add();
 
 /** Remove a noisy event subscription.
  */
-void ponyint_asio_noisy_remove();
+uint64_t ponyint_asio_noisy_remove();
 
 /** Destroys an ASIO backend.
  *

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -46,6 +46,7 @@ struct scheduler_t
   uint32_t node;
   bool terminate;
   bool asio_stopped;
+  bool asio_noisy;
 
   // These are changed primarily by the owning scheduler thread.
   alignas(64) struct scheduler_t* last_victim;
@@ -77,6 +78,14 @@ void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* rec
 void ponyint_sched_start_global_unmute(pony_actor_t* actor);
 
 bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor);
+
+/** Mark asio as being noisy
+ */
+void ponyint_sched_noisy_asio();
+
+/** Mark asio as not being noisy
+ */
+void ponyint_sched_unnoisy_asio();
 
 PONY_EXTERN_C_END
 


### PR DESCRIPTION
Prior to this commit, we sent scheduler block/unblock messages even
if there were noisy actors registered with the ASIO thread/subsystem
and there was no chance the program was ready to terminate (because
the program is not allowed to terminate as long as there are any
noisy actors registered with the ASIO thread/subsystem).

This commit changes the block/unblock sending logic to only send
these messages if there are no noisy actors registered with the
ASIO thread/subsystem (in addition to all the logic that already
existed prior to this commit).