### PR TITLE
Restart ASIO if needed while runtime is attempting to terminate.

### DIFF
--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -7,6 +7,7 @@
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
+#include "ponyassert.h"
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
 #include <sys/timerfd.h>
@@ -34,6 +35,7 @@ struct asio_backend_t
 static void send_request(asio_event_t* ev, int req)
 {
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   asio_msg_t* msg = (asio_msg_t*)pony_alloc_msg(
     POOL_INDEX(sizeof(asio_msg_t)), 0);
@@ -52,6 +54,7 @@ static void signal_handler(int sig)
   // Reset the signal handler.
   signal(sig, signal_handler);
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
   asio_event_t* ev = atomic_load_explicit(&b->sighandlers[sig],
     memory_order_acquire);
 
@@ -122,6 +125,7 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   struct epoll_event ep;
   ep.data.ptr = ev;
@@ -146,6 +150,7 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   struct epoll_event ep;
   ep.data.ptr = ev;
@@ -167,6 +172,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = arg;
+  pony_assert(b != NULL);
 
   while(!atomic_load_explicit(&b->terminate, memory_order_relaxed))
   {
@@ -265,6 +271,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
     ponyint_asio_noisy_add();
@@ -336,6 +343,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
   {

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -8,6 +8,7 @@
 #include "../actor/messageq.h"
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
+#include "ponyassert.h"
 #include <string.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -43,6 +44,7 @@ enum // Event requests
 static void send_request(asio_event_t* ev, int req)
 {
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   asio_msg_t* msg = (asio_msg_t*)pony_alloc_msg(
     POOL_INDEX(sizeof(asio_msg_t)), 0);
@@ -62,6 +64,7 @@ static void signal_handler(int sig)
   // Reset the signal handler.
   signal(sig, signal_handler);
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
   asio_event_t* ev = b->sighandlers[sig];
   pony_asio_event_send(ev, ASIO_SIGNAL, 1);
 }
@@ -105,6 +108,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = (asio_backend_t*)arg;
+  pony_assert(b != NULL);
   asio_event_t* stdin_event = NULL;
   HANDLE handles[2];
   handles[0] = b->wakeup;
@@ -251,6 +255,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
     ponyint_asio_noisy_add();
@@ -299,6 +304,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
   {

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -79,6 +79,7 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   struct kevent event[1];
   int i = 0;
@@ -106,6 +107,7 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
     return;
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   struct kevent event[2];
   int i = 0;
@@ -130,6 +132,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   ponyint_cpu_affinity(ponyint_asio_get_cpu());
   pony_register_thread();
   asio_backend_t* b = arg;
+  pony_assert(b != NULL);
   struct kevent fired[MAX_EVENTS];
 
   while(b->kq != -1)
@@ -225,6 +228,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
   }
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
     ponyint_asio_noisy_add();
@@ -282,6 +286,7 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
   }
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   struct kevent event[1];
   int i = 0;
@@ -315,6 +320,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
   }
 
   asio_backend_t* b = ponyint_asio_get_backend();
+  pony_assert(b != NULL);
 
   if(ev->noisy)
   {

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -107,6 +107,20 @@ static bool read_msg(scheduler_t* sched)
 
       case SCHED_UNBLOCK:
       {
+        // if the ASIO thread has already been stopped
+        if (sched->asio_stopped)
+        {
+          // restart the ASIO thread
+          bool asio_started = ponyint_asio_start();
+          pony_assert(asio_started);
+          (void) asio_started;
+          sched->asio_stopped = false;
+        }
+
+        // make sure asio hasn't already been stopped or else runtime is in
+        // an invalid state without the ASIO thread running
+        pony_assert(!sched->asio_stopped);
+
         // Cancel all acks and increment the ack token, so that any pending
         // acks in the queue will be dropped when they are received.
         sched->block_count--;


### PR DESCRIPTION
Prior to this commit, the shutdown process could potentially cause
the runtime to end up in an invalid state where the ASIO backend
had been stopped but the shutdown of the runtime was aborted. If
this occurred and any actor subsequently tried to subscribe to
an ASIO event, it would cause a segfault because the ASIO backend
would be `NULL` instead of an actual `asio_backend_t*`.

This commit changes things so that if the shutdown is aborted due
to the receipt of a new `UNBLOCK` message and the ASIO backend
has already been stopped, we try and restart the ASIO backend.

This commit also adds some extra assertions around the use of the
ASIO backend to ensure it is not `NULL` when it shouldn't be.

This should resolve WallarooLabs/wallaroo#1608.