### PR TITLE
Fix Iter.{skip,take,nth} to check '.has_next()' of their inner iterator

### DIFF
--- a/packages/itertools/_test.pony
+++ b/packages/itertools/_test.pony
@@ -357,6 +357,15 @@ class iso _TestIterNth is UnitTest
     h.assert_eq[USize](3,
       Iter[USize](input.values()).nth(3)?)
     h.assert_error({()? => Iter[USize](input.values()).nth(4)? })
+    h.assert_error({()? =>
+        Iter[U8](
+          object is Iterator[U8]
+            var c: U8 = 0
+            fun ref has_next(): Bool => c < 5
+            fun ref next(): U8 =>
+              c = c + 1
+          end).nth(6)?
+    })
 
 class iso _TestIterRun is UnitTest
   fun name(): String => "itertools/Iter.run"
@@ -399,6 +408,8 @@ class iso _TestIterSkip is UnitTest
     h.assert_eq[I64](3,
       Iter[I64](input.values()).skip(2).next()?)
 
+    h.assert_false(Iter[I64](input.values()).skip(4).has_next())
+
 class iso _TestIterSkipWhile is UnitTest
   fun name(): String => "itertools/Iter.skip_while"
 
@@ -433,6 +444,16 @@ class iso _TestIterTake is UnitTest
         end)
 
     h.assert_eq[USize](3, infinite.take(3).collect(Array[U64]).size())
+
+    let short = Iter[U64](
+      object is Iterator[U64]
+        var counter: U64 = 0
+        fun ref has_next(): Bool => false
+        fun ref next(): U64^ => counter = counter + 1
+      end
+    )
+    h.assert_eq[USize](0, short.take(10).collect(Array[U64]).size())
+
     h.complete(true)
 
 class iso _TestIterTakeWhile is UnitTest
@@ -455,7 +476,7 @@ class iso _TestIterTakeWhile is UnitTest
       Iter[I64](input.values())
         .take_while({(x) ? => error })
         .collect(Array[I64]))
-    
+
     let infinite =
       Iter[USize](Range(0, 3))
         .cycle()

--- a/packages/itertools/_test.pony
+++ b/packages/itertools/_test.pony
@@ -450,8 +450,7 @@ class iso _TestIterTake is UnitTest
         var counter: U64 = 0
         fun ref has_next(): Bool => false
         fun ref next(): U64^ => counter = counter + 1
-      end
-    )
+      end)
     h.assert_eq[USize](0, short.take(10).collect(Array[U64]).size())
 
     h.complete(true)

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -590,11 +590,15 @@ class Iter[A] is Iterator[A]
     `2`
     """
     var c = n
-    while c > 1 do
+    while _iter.has_next() and (c > 1) do
       _iter.next()?
       c = c - 1
     end
-    _iter.next()?
+    if not _iter.has_next() then
+      error
+    else
+      _iter.next()?
+    end
 
   fun ref run(on_error: {ref()} = {() => None } ref) =>
     """
@@ -634,10 +638,17 @@ class Iter[A] is Iterator[A]
       .skip(3)
     ```
     `4 5 6`
+
+    ```pony
+    Iter[I64]([1; 2; 3].values())
+      .skip(3)
+      .has_next()
+    ```
+    `false`
     """
     var c = n
     try
-      while c > 0 do
+      while _iter.has_next() and (c > 0) do
         _iter.next()?
         c = c - 1
       end
@@ -687,7 +698,7 @@ class Iter[A] is Iterator[A]
         var _countdown: USize = n
 
         fun ref has_next(): Bool =>
-          _countdown > 0
+          (_countdown > 0) and _iter.has_next()
 
         fun ref next(): A ? =>
           if _countdown > 0 then
@@ -739,7 +750,7 @@ class Iter[A] is Iterator[A]
               else
                 _done = true
                 return false
-              end 
+              end
             _done = try not f(_next as A)? else true end
             not _done
           end


### PR DESCRIPTION
Before this change `Iter.take` would continue iterating until `n` elements were taken or a call to `next()` of the inner iterator would error. `has_next()` has never been called.
The same is true for `Iter.nth` and `Iter.skip`. 

While this works e.g. on Iterators over `Array` (i.e. `ArrayValues`) it does not for Iterators that continue returning elements in `next()` although `has_next()` already returned `false` (e.g. `collections.Range`).