### PR TITLE
Fail pony_start if ASIO backend wasn't successfully initialized

### DIFF
--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -46,6 +46,10 @@ void ponyint_asio_init(uint32_t cpu)
 
 bool ponyint_asio_start()
 {
+  // if the backend wasn't successfully initialized
+  if(running_base.backend == NULL)
+    return false;
+
   if(!ponyint_thread_create(&running_base.tid, ponyint_asio_backend_dispatch,
     asio_cpu, running_base.backend))
     return false;


### PR DESCRIPTION
Prior to this commit, the ASIO backend could fail initialization
but the runtime would continue to start up anyway resulting in
segfaults or assertion failures.

This commit changes things so that if the backend initialization
fails, the runtime exits immediately with an error.

This commit also fixes the asio restart logic from PR #2373 to
properly re-initialize the backend first.