### PR TITLE
Forbid AST modifications during code generation

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -72,6 +72,9 @@ struct ast_t
   ast_t* sibling;
   ast_t* annotation_type;
   uint32_t flags;
+#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  bool frozen;
+#endif
 };
 
 // Minimal AST structure for signature computation.
@@ -322,6 +325,7 @@ static bool hasparent(ast_t* ast)
 static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   ast->parent = parent;
   ast_clearflag(ast, AST_ORPHAN);
@@ -331,6 +335,7 @@ static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 static void set_scope_no_parent(ast_t* ast, ast_t* scope)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   ast->parent = scope;
   ast_setflag(ast, AST_ORPHAN);
@@ -339,6 +344,9 @@ static void set_scope_no_parent(ast_t* ast, ast_t* scope)
 // Remove the given node's parent without changing its scope (if any)
 static void make_orphan_leave_scope(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
+
   ast_setflag(ast, AST_ORPHAN);
 }
 
@@ -457,9 +465,68 @@ ast_t* ast_dup(ast_t* ast)
   return duplicate(NULL, ast);
 }
 
+ast_t* ast_dup_partial(ast_t* ast, bool* dup_child, bool dup_type,
+  bool dup_annotation, bool dup_symtab)
+{
+  if(ast == NULL)
+    return NULL;
+
+  pony_assert(ast_id(ast) != TK_PROGRAM && ast_id(ast) != TK_PACKAGE &&
+    ast_id(ast) != TK_MODULE);
+
+  ast_t* n = ast_token(token_dup(ast->t));
+  n->data = ast->data;
+  n->flags = ast->flags & AST_ALL_FLAGS;
+  set_scope_no_parent(n, ast->parent);
+
+  if(dup_annotation)
+    ast_setannotation(n, duplicate(NULL, ast_annotation(ast)));
+
+  if(dup_type)
+    ast_settype(n, duplicate(NULL, ast_type(ast)));
+
+  if(dup_symtab && (ast->symtab != NULL))
+    n->symtab = symtab_dup(ast->symtab);
+
+  ast_t* src_child = ast->child;
+
+  if(src_child != NULL)
+  {
+    ast_t* dst_child;
+
+    if(dup_child[0])
+      dst_child = duplicate(NULL, src_child);
+    else
+      dst_child = ast_blank(TK_NONE);
+
+    n->child = dst_child;
+    set_scope_and_parent(dst_child, n);
+
+    src_child = ast_sibling(src_child);
+    size_t idx = 1;
+
+    for(; src_child != NULL; (src_child = ast_sibling(src_child)), idx++)
+    {
+      ast_t* dst_sibling;
+
+      if(dup_child[idx])
+        dst_sibling = duplicate(NULL, src_child);
+      else
+        dst_sibling = ast_blank(TK_NONE);
+
+      dst_child->sibling = dst_sibling;
+      dst_child = dst_sibling;
+      set_scope_and_parent(dst_sibling, n);
+    }
+  }
+
+  return n;
+}
+
 void ast_scope(ast_t* ast)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast->symtab = symtab_new();
 }
 
@@ -472,6 +539,7 @@ bool ast_has_scope(ast_t* ast)
 void ast_set_scope(ast_t* ast, ast_t* scope)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   pony_assert(!hasparent(ast));
   set_scope_no_parent(ast, scope);
 }
@@ -479,12 +547,16 @@ void ast_set_scope(ast_t* ast, ast_t* scope)
 symtab_t* ast_get_symtab(ast_t* ast)
 {
   pony_assert(ast != NULL);
+  // Allowing direct access to the symtab includes write access, so we forbid
+  // any direct access if the AST is immutable.
+  pony_assert(!ast->frozen);
   return ast->symtab;
 }
 
 ast_t* ast_setid(ast_t* ast, token_id id)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   token_set_id(ast->t, id);
   return ast;
 }
@@ -492,6 +564,7 @@ ast_t* ast_setid(ast_t* ast, token_id id)
 void ast_setpos(ast_t* ast, source_t* source, size_t line, size_t pos)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   token_set_pos(ast->t, source, line, pos);
 }
 
@@ -530,48 +603,61 @@ void* ast_data(ast_t* ast)
 ast_t* ast_setdata(ast_t* ast, void* data)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast->data = data;
   return ast;
 }
 
 bool ast_canerror(ast_t* ast)
 {
+  pony_assert(ast != NULL);
   return ast_checkflag(ast, AST_FLAG_CAN_ERROR) != 0;
 }
 
 void ast_seterror(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast_setflag(ast, AST_FLAG_CAN_ERROR);
 }
 
 bool ast_cansend(ast_t* ast)
 {
+  pony_assert(ast != NULL);
   return ast_checkflag(ast, AST_FLAG_CAN_SEND) != 0;
 }
 
 void ast_setsend(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast_setflag(ast, AST_FLAG_CAN_SEND);
 }
 
 bool ast_mightsend(ast_t* ast)
 {
+  pony_assert(ast != NULL);
   return ast_checkflag(ast, AST_FLAG_MIGHT_SEND) != 0;
 }
 
 void ast_setmightsend(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast_setflag(ast, AST_FLAG_MIGHT_SEND);
 }
 
 void ast_clearmightsend(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   ast_clearflag(ast, AST_FLAG_MIGHT_SEND);
 }
 
 void ast_inheritflags(ast_t* ast)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   for(ast_t* child = ast->child; child != NULL; child = ast_sibling(child))
     ast_setflag(ast, child->flags & AST_INHERIT_FLAGS);
@@ -589,6 +675,7 @@ void ast_setflag(ast_t* ast, uint32_t flag)
 {
   pony_assert(ast != NULL);
   pony_assert((flag & AST_ALL_FLAGS) == flag);
+  pony_assert(!ast->frozen);
 
   ast->flags |= flag;
 }
@@ -597,6 +684,7 @@ void ast_clearflag(ast_t* ast, uint32_t flag)
 {
   pony_assert(ast != NULL);
   pony_assert((flag & AST_ALL_FLAGS) == flag);
+  pony_assert(!ast->frozen);
 
   ast->flags &= ~flag;
 }
@@ -607,6 +695,8 @@ void ast_resetpass(ast_t* ast, uint32_t flag)
 
   if(ast == NULL)
     return;
+
+  pony_assert(!ast->frozen);
 
   if(ast_checkflag(ast, AST_FLAG_PRESERVE))
     return;
@@ -653,6 +743,7 @@ size_t ast_name_len(ast_t* ast)
 void ast_set_name(ast_t* ast, const char* name)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
   token_set_string(ast->t, name, 0);
 }
 
@@ -688,6 +779,7 @@ ast_t* ast_type(ast_t* ast)
 static void settype(ast_t* ast, ast_t* type, bool allow_free)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   // An annotation may never have a type.
   if(ast_id(ast) == TK_ANNOTATION)
@@ -743,6 +835,7 @@ ast_t* ast_annotation(ast_t* ast)
 void setannotation(ast_t* ast, ast_t* annotation, bool allow_free)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   // An annotation may never be annotated.
   if(ast_id(ast) == TK_ANNOTATION)
@@ -819,6 +912,7 @@ bool ast_has_annotation(ast_t* ast, const char* name)
 void ast_erase(ast_t* ast)
 {
   pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
 
   ast_t* child = ast->child;
 
@@ -1019,9 +1113,12 @@ ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status)
 bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
   bool allow_shadowing)
 {
+  pony_assert(ast != NULL);
+
   while(ast->symtab == NULL)
     ast = ast->parent;
 
+  pony_assert(!ast->frozen);
   ast_t* find;
 
   if(allow_shadowing)
@@ -1045,25 +1142,33 @@ bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
 
 void ast_setstatus(ast_t* ast, const char* name, sym_status_t status)
 {
+  pony_assert(ast != NULL);
+
   while(ast->symtab == NULL)
     ast = ast->parent;
 
+  pony_assert(!ast->frozen);
   symtab_set_status(ast->symtab, name, status);
 }
 
 void ast_inheritstatus(ast_t* dst, ast_t* src)
 {
+  pony_assert(src != NULL);
+
   if(dst == NULL)
     return;
 
   while(dst->symtab == NULL)
     dst = dst->parent;
 
+  pony_assert(!dst->frozen);
   symtab_inherit_status(dst->symtab, src->symtab);
 }
 
 void ast_inheritbranch(ast_t* dst, ast_t* src)
 {
+  pony_assert(dst != NULL);
+  pony_assert(src != NULL);
   pony_assert(dst->symtab != NULL);
   pony_assert(src->symtab != NULL);
 
@@ -1072,7 +1177,10 @@ void ast_inheritbranch(ast_t* dst, ast_t* src)
 
 void ast_consolidate_branches(ast_t* ast, size_t count)
 {
+  pony_assert(ast != NULL);
   pony_assert(hasparent(ast));
+  pony_assert(ast->symtab != NULL);
+  pony_assert(!ast->frozen);
 
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
@@ -1101,6 +1209,9 @@ void ast_consolidate_branches(ast_t* ast, size_t count)
 
 bool ast_canmerge(ast_t* dst, ast_t* src)
 {
+  pony_assert(dst != NULL);
+  pony_assert(src != NULL);
+
   while(dst->symtab == NULL)
     dst = dst->parent;
 
@@ -1109,14 +1220,21 @@ bool ast_canmerge(ast_t* dst, ast_t* src)
 
 bool ast_merge(ast_t* dst, ast_t* src)
 {
+  pony_assert(dst != NULL);
+  pony_assert(src != NULL);
+
   while(dst->symtab == NULL)
     dst = dst->parent;
 
+  pony_assert(!dst->frozen);
   return symtab_merge_public(dst->symtab, src->symtab);
 }
 
 bool ast_within_scope(ast_t* outer, ast_t* inner, const char* name)
 {
+  pony_assert(outer != NULL);
+  pony_assert(inner != NULL);
+
   do
   {
     if(inner->symtab != NULL)
@@ -1139,6 +1257,9 @@ bool ast_within_scope(ast_t* outer, ast_t* inner, const char* name)
 
 bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner, errorframe_t* errorf)
 {
+  pony_assert(outer != NULL);
+  pony_assert(inner != NULL);
+
   ast_t* from = inner;
   bool ok = true;
 
@@ -1182,6 +1303,9 @@ bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner, errorframe_t* errorf)
 
 void ast_clear(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
+
   if(ast->symtab != NULL)
   {
     symtab_free(ast->symtab);
@@ -1199,6 +1323,9 @@ void ast_clear(ast_t* ast)
 
 void ast_clear_local(ast_t* ast)
 {
+  pony_assert(ast != NULL);
+  pony_assert(!ast->frozen);
+
   if(ast->symtab != NULL)
   {
     symtab_free(ast->symtab);
@@ -1211,9 +1338,12 @@ ast_t* ast_add(ast_t* parent, ast_t* child)
   pony_assert(parent != NULL);
   pony_assert(parent != child);
   pony_assert(parent->child != child);
+  pony_assert(!parent->frozen);
 
   if(hasparent(child))
     child = ast_dup(child);
+  else
+    pony_assert(!child->frozen);
 
   set_scope_and_parent(child, parent);
   child->sibling = parent->child;
@@ -1227,9 +1357,12 @@ ast_t* ast_add_sibling(ast_t* older_sibling, ast_t* new_sibling)
   pony_assert(new_sibling != NULL);
   pony_assert(older_sibling != new_sibling);
   pony_assert(hasparent(older_sibling));
+  pony_assert(!older_sibling->parent->frozen);
 
   if(hasparent(new_sibling))
     new_sibling = ast_dup(new_sibling);
+  else
+    pony_assert(!new_sibling->frozen);
 
   pony_assert(new_sibling->sibling == NULL);
 
@@ -1241,6 +1374,9 @@ ast_t* ast_add_sibling(ast_t* older_sibling, ast_t* new_sibling)
 
 ast_t* ast_pop(ast_t* parent)
 {
+  pony_assert(parent != NULL);
+  pony_assert(!parent->frozen);
+
   ast_t* child = parent->child;
 
   if(child != NULL)
@@ -1258,9 +1394,12 @@ ast_t* ast_append(ast_t* parent, ast_t* child)
   pony_assert(parent != NULL);
   pony_assert(child != NULL);
   pony_assert(parent != child);
+  pony_assert(!parent->frozen);
 
   if(hasparent(child))
     child = ast_dup(child);
+  else
+  pony_assert(!child->frozen);
 
   set_scope_and_parent(child, parent);
 
@@ -1306,13 +1445,18 @@ void ast_remove(ast_t* ast)
 {
   pony_assert(ast != NULL);
   pony_assert(hasparent(ast));
+  pony_assert(!ast->frozen);
 
   ast_t* last = ast_previous(ast);
 
   if(last != NULL)
+  {
+    pony_assert(!last->frozen);
     last->sibling = ast->sibling;
-  else
+  } else {
+    pony_assert(!ast->parent->frozen);
     ast->parent->child = ast->sibling;
+  }
 
   ast->parent = NULL;
   ast->sibling = NULL;
@@ -1323,12 +1467,16 @@ void ast_swap(ast_t* prev, ast_t* next)
 {
   pony_assert(prev != NULL);
   pony_assert(prev != next);
+  pony_assert(!prev->frozen);
 
   ast_t* parent = ast_parent(prev);
   pony_assert(parent != NULL);
+  pony_assert(!parent->frozen);
 
   if(hasparent(next))
     next = ast_dup(next);
+  else
+    pony_assert(!next->frozen);
 
   if(ast_type(parent) == prev)
   {
@@ -1352,6 +1500,8 @@ void ast_swap(ast_t* prev, ast_t* next)
 
 void ast_replace(ast_t** prev, ast_t* next)
 {
+  pony_assert(!(*prev)->frozen);
+
   if(*prev == next)
     return;
 
@@ -1393,6 +1543,8 @@ void ast_free(ast_t* ast)
   if(ast == NULL)
     return;
 
+  ast->frozen = false;
+
   ast_t* child = ast->child;
   ast_t* next;
 
@@ -1433,6 +1585,33 @@ void ast_free_unattached(ast_t* ast)
 {
   if((ast != NULL) && !hasparent(ast))
     ast_free(ast);
+}
+
+bool ast_is_frozen(ast_t* ast)
+{
+  pony_assert(ast != NULL);
+
+#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  return ast->frozen;
+#else
+  return false;
+#endif
+}
+
+void ast_freeze(ast_t* ast)
+{
+#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  if((ast == NULL) || ast->frozen)
+    return;
+
+  ast->frozen = true;
+  token_freeze(ast->t);
+
+  for(ast_t* child = ast->child; child != NULL; child = ast_sibling(child))
+    ast_freeze(child);
+
+  ast_freeze(ast->annotation_type);
+#endif
 }
 
 void ast_print(ast_t* ast, size_t width)
@@ -2081,6 +2260,9 @@ static void ast_serialise(pony_ctx_t* ctx, void* object, void* buf,
   dst->sibling = (ast_t*)pony_serialise_offset(ctx, ast->sibling);
   dst->annotation_type = (ast_t*)pony_serialise_offset(ctx, ast->annotation_type);
   dst->flags = ast->flags;
+#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  dst->frozen = ast->frozen;
+#endif
 }
 
 static void ast_deserialise(pony_ctx_t* ctx, void* object)

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -58,6 +58,8 @@ ast_t* ast_from_string(ast_t* ast, const char* name);
 ast_t* ast_from_int(ast_t* ast, uint64_t value);
 ast_t* ast_from_float(ast_t* ast, double value);
 ast_t* ast_dup(ast_t* ast);
+ast_t* ast_dup_partial(ast_t* ast, bool* dup_child, bool dup_type,
+  bool dup_annotation, bool dup_symtab);
 void ast_scope(ast_t* ast);
 bool ast_has_scope(ast_t* ast);
 void ast_set_scope(ast_t* ast, ast_t* scope);
@@ -140,6 +142,9 @@ void ast_reorder_children(ast_t* ast, const size_t* new_order,
   ast_t** shuffle_space);
 void ast_free(ast_t* ast);
 void ast_free_unattached(ast_t* ast);
+
+bool ast_is_frozen(ast_t* ast);
+void ast_freeze(ast_t* ast);
 
 void ast_print(ast_t* ast, size_t width);
 void ast_printverbose(ast_t* ast);

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -293,6 +293,9 @@ token_t* token_dup_new_id(token_t* token, token_id id);
   */
 void token_free(token_t* token);
 
+/// Set the token as read-only.
+void token_freeze(token_t* token);
+
 /// Get a pony_type_t for token_t. Should only be used for signature computation.
 pony_type_t* token_signature_pony_type();
 

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -254,6 +254,8 @@ static bool ast_passes(ast_t** astp, pass_opt_t* options, pass_id last)
   if(options->check_tree)
     check_tree(*astp, options);
 
+  ast_freeze(*astp);
+
   if(ast_id(*astp) == TK_PROGRAM)
   {
     program_signature(*astp);

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -234,17 +234,10 @@ ast_t* reify_method_def(ast_t* ast, ast_t* typeparams, ast_t* typeargs,
       pony_assert(false);
   }
 
-  // Remove the body AST to avoid duplicating it.
-  ast_t* body = ast_childidx(ast, 6);
-  ast_t* temp_body = ast_blank(TK_NONE);
-  ast_swap(body, temp_body);
-
-  ast_t* r_ast = reify(ast, typeparams, typeargs, opt, true);
-
-  ast_swap(temp_body, body);
-  ast_free_unattached(temp_body);
-
-  return r_ast;
+  // Do not duplicate the body and docstring.
+  bool dup_child[9] = {true, true, true, true, true, true, false, false, true};
+  ast_t* r_ast = ast_dup_partial(ast, dup_child, true, true, true);
+  return reify(r_ast, typeparams, typeargs, opt, false);
 }
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,


### PR DESCRIPTION
This change adds an `ast_freeze` function that sets an AST as immutable. Mutable AST functions will then assert if called on a frozen AST.

The program AST is frozen after all AST passes are done, before reachability analysis and code generation.

The eventual goal of this change is to help with ensuring correctness when implementing ad-hoc AST reification in code generation to reduce memory usage.