### PR TITLE
More platform agnostic `make docs`

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -51,7 +51,7 @@ ponyc-build-docs(){
   sudo -H pip install mkdocs
 
   echo "Building ponyc docs..."
-  make CC="$CC1" CXX="$CXX1" docs
+  make CC="$CC1" CXX="$CXX1" docs-online
 
   echo "Uploading docs using mkdocs..."
   git remote add gh-token "https://${STDLIB_TOKEN}@github.com/ponylang/stdlib.ponylang.org"

--- a/Makefile
+++ b/Makefile
@@ -883,6 +883,8 @@ test-ci: all
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs --pass expr
 	$(SILENT)cp .docs/extra.js stdlib-docs/docs/
+
+docs-online: docs
 	$(SILENT)$(SED_INPLACE) 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
 
 # Note: linux only

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,12 @@ else
   symlink.flags = -srf
 endif
 
+ifneq (,$(filter $(OSTYPE), osx bsd))
+  SED_INPLACE = sed -i -e
+else
+  SED_INPLACE = sed -i
+endif
+
 prefix ?= /usr/local
 destdir ?= $(prefix)/lib/pony/$(tag)
 
@@ -877,7 +883,7 @@ test-ci: all
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs --pass expr
 	$(SILENT)cp .docs/extra.js stdlib-docs/docs/
-	$(SILENT)sed -i 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
+	$(SILENT)$(SED_INPLACE) 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
 
 # Note: linux only
 define EXPAND_DEPLOY


### PR DESCRIPTION
This fixes #2316 

This pull request is broken into two commits. One makes possible to run the current `make docs` on BSD and OSX as well as Linux. The second one breaks them up as suggested in the issue.