### PR TITLE
Combine release and debug OSX builds into one travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,17 +178,6 @@ matrix:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.7.1"
         - LLVM_CONFIG="llvm-config-3.7"
-        - config=debug
-        - CC1=clang-3.7
-        - CXX1=clang++-3.7
-
-    - os: osx
-      env:
-        - FAVORITE_CONFIG=no
-        - LLVM_VERSION="3.7.1"
-        - LLVM_CONFIG="llvm-config-3.7"
-        - config=release
-        - lto=no
         - CC1=clang-3.7
         - CXX1=clang++-3.7
 
@@ -197,36 +186,14 @@ matrix:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.8.1"
         - LLVM_CONFIG="llvm-config-3.8"
-        - config=debug
         - CC1=clang-3.8
         - CXX1=clang++-3.8
 
     - os: osx
       env:
         - FAVORITE_CONFIG=no
-        - LLVM_VERSION="3.8.1"
-        - LLVM_CONFIG="llvm-config-3.8"
-        - config=release
-        - lto=no
-        - CC1=clang-3.8
-        - CXX1=clang++-3.8
-        
-    - os: osx
-      env:
-        - FAVORITE_CONFIG=no
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
-        - config=debug
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
-
-    - os: osx
-      env:
-        - FAVORITE_CONFIG=no
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - config=release
-        - lto=no
         - CC1=clang-3.9
         - CXX1=clang++-3.9
 
@@ -235,17 +202,6 @@ matrix:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="4.0.1"
         - LLVM_CONFIG="llvm-config-4.0"
-        - config=debug
-        - CC1=clang-4.0
-        - CXX1=clang++-4.0
-
-    - os: osx
-      env:
-        - FAVORITE_CONFIG=no
-        - LLVM_VERSION="4.0.1"
-        - LLVM_CONFIG="llvm-config-4.0"
-        - config=release
-        - lto=no
         - CC1=clang-4.0
         - CXX1=clang++-4.0
 
@@ -254,17 +210,6 @@ matrix:
         - FAVORITE_CONFIG=no
         - LLVM_VERSION="5.0.0"
         - LLVM_CONFIG="llvm-config-5.0"
-        - config=debug
-        - CC1=clang-5.0
-        - CXX1=clang++-5.0
-
-    - os: osx
-      env:
-        - FAVORITE_CONFIG=no
-        - LLVM_VERSION="5.0.0"
-        - LLVM_CONFIG="llvm-config-5.0"
-        - config=release
-        - lto=no
         - CC1=clang-5.0
         - CXX1=clang++-5.0
 

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -92,25 +92,50 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
   ;;
 
   "osx:llvm-config-3.7")
+    echo "Running config=debug build..."
+    export config=debug
+    ponyc-test
+    echo "Running config=release build..."
+    export config=release
     ponyc-test
   ;;
 
   "osx:llvm-config-3.8")
+    echo "Running config=debug build..."
+    export config=debug
+    ponyc-test
+    echo "Running config=release build..."
+    export config=release
     ponyc-test
   ;;
 
   "osx:llvm-config-3.9")
     export PATH=llvmsym/:$PATH
+    echo "Running config=debug build..."
+    export config=debug
+    ponyc-test
+    echo "Running config=release build..."
+    export config=release
     ponyc-test
   ;;
 
   "osx:llvm-config-4.0")
     export PATH=llvmsym/:$PATH
+    echo "Running config=debug build..."
+    export config=debug
+    ponyc-test
+    echo "Running config=release build..."
+    export config=release
     ponyc-test
   ;;
 
   "osx:llvm-config-5.0")
     export PATH=llvmsym/:$PATH
+    echo "Running config=debug build..."
+    export config=debug
+    ponyc-test
+    echo "Running config=release build..."
+    export config=release
     ponyc-test
   ;;
 


### PR DESCRIPTION
Prior to this commit, OSX builds for travis would run two separate
jobs for `config=debug` and `config=release` for each LLVM version
supported.

This commit combines the two `config=debug` and `config=release`
builds for each LLVM version supported into a single job. This is
mainly because recently Travis has been overloaded on the OSX
side of things and jobs end up waiting for a long time to start.
This change halves the number of jobs that need to run with no loss
of coverage. This is only possible as long as both builds combined
finish in under travis' job timeout of 50 minutes.