### PR TITLE
Remove redundant error message for unhandled partial calls that are actually in a try block.

### DIFF
--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -332,6 +332,13 @@ static bool show_partiality(pass_opt_t* opt, ast_t* ast)
   ast_t* child = ast_child(ast);
   bool found = false;
 
+  if((ast_id(ast) == TK_TRY) || (ast_id(ast) == TK_TRY_NO_CHECK))
+  {
+      pony_assert(child != NULL);
+      // Skip error in body.
+      child = ast_sibling(child);
+  }
+
   while(child != NULL)
   {
     if(ast_canerror(child))

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -359,6 +359,56 @@ void PassTest::test_expected_errors(const char* src, const char* pass,
 }
 
 
+void PassTest::test_expected_error_frames(const char* src, const char* pass,
+  const char** errors, const char*** frames)
+{
+  PassTest::test_expected_errors(src, pass, errors);
+
+  size_t expected_count = 0;
+  while(frames[expected_count] != NULL)
+  {
+    expected_count++;
+  }
+
+  ASSERT_EQ(expected_count, errors_get_count(opt.check.errors));
+
+  size_t frame = 0;
+  errormsg_t* e = errors_get_first(opt.check.errors);
+  while(e != NULL) {
+    const char** expected_errors = frames[frame];
+
+    {
+      size_t expected_count = 0;
+      while(expected_errors[expected_count] != NULL)
+      {
+        expected_count++;
+      }
+
+      size_t error_count = 0;
+      errormsg_t* ef = e->frame;
+      while(ef != NULL)
+      {
+        error_count++;
+        ef = ef->frame;
+      }
+
+      ASSERT_EQ(expected_count, error_count);
+    }
+
+    for(errormsg_t* ef = e->frame; ef != NULL; ef = ef->frame)
+    {
+      const char* expected_error = *expected_errors;
+      EXPECT_FALSE(strstr(ef->msg, expected_error) == NULL)
+        << "Actual error: " << ef->msg;
+      expected_errors++;
+    }
+
+    e = e->next;
+    frame++;
+  }
+}
+
+
 void PassTest::test_equiv(const char* actual_src, const char* actual_pass,
   const char* expect_src, const char* expect_pass)
 {

--- a/test/libponyc/util.h
+++ b/test/libponyc/util.h
@@ -82,6 +82,12 @@ protected:
   void test_expected_errors(const char* src, const char* pass,
     const char** errors);
 
+  // Performs the same check as test_expected_errors, and alse checks all
+  // errors within each error frame, given as a NULL-terminated array of
+  // NULL-terminated arrays of additional error messages.
+  void test_expected_error_frames(const char* src, const char* pass,
+    const char** errors, const char*** frames);
+
   // Check that the 2 given sources compile to give the same AST for the first
   // package
   void test_equiv(const char* actual_src, const char* actual_pass,

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -665,3 +665,20 @@ TEST_F(VerifyTest, LambdaTypeGenericAliased)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(VerifyTest, PartialFunCallInTryBlock)
+{
+  // From issue #2146
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try partial()? else partial()? end\n"
+    "fun partial() ? => error";
+
+  {
+      const char* errs[] = {"an actor constructor must handle any potential error", NULL};
+      const char* frame1[] = {"an error can be raised here", NULL};
+      const char** frames[] = {frame1, NULL};
+      DO(test_expected_error_frames(src, "verify", errs, frames));
+  }
+}


### PR DESCRIPTION
Fix for #2146. Created a testing procedure for inspecting all error messages in a reported error.