### PR TITLE
Add the contents of `.docs` to a `docs-support` directory in Windows packages.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,6 +60,7 @@ build_script:
       copy $builddir\ponyrt.* "${ponydir}\ponyc\bin"
       copy $builddir\*.lib "${ponydir}\ponyc\bin"
       copy -recurse packages "${ponydir}\packages"
+      copy -recurse ".docs" "${ponydir}\docs-support"
       7z a -tzip "C:\projects\ponyc\${ponydir}.zip" "${ponydir}"
 
 artifacts:


### PR DESCRIPTION
This is the AppVeyor part of #2291.