### PR TITLE
Add Test Reporting to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -222,7 +222,7 @@ before_install:
   - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
       curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-darwin.tgz | tar -zxvf- -C $HOME/bin;
     else
-      curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux-dev.tgz | tar -zxvf- -C $HOME/bin;
+      curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin;
     fi
   - testspace config url $TS_ORG.testspace.com
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - master
     - release
+    - add-test-reporting
 
 dist: trusty
 sudo: required
@@ -216,11 +217,28 @@ matrix:
 rvm:
   - 2.2.3
 
+before_install:
+  - mkdir -p $HOME/bin
+  - if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
+      curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-darwin.tgz | tar -zxvf- -C $HOME/bin;
+    else
+      curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux-dev.tgz | tar -zxvf- -C $HOME/bin;
+    fi
+  - testspace config url $TS_ORG.testspace.com
+
 install:
   - bash .travis_install.bash
 
 script:
   - bash .travis_script.bash
+
+after_script:
+ -  if [[ "${TRAVIS_OS_NAME}" = "osx" ]]; then
+      testspace [${TRAVIS_OS_NAME}/LLVM_${LLVM_VERSION}/debug]build/debug/libpony*.xml{test};
+      testspace [${TRAVIS_OS_NAME}/LLVM_${LLVM_VERSION}/release]build/release/libpony*.xml{test};
+    else
+      testspace [${TRAVIS_OS_NAME}/LLVM_${LLVM_VERSION}/${config}]build/${config}/libpony*.xml{test};
+    fi
 
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -865,8 +865,8 @@ test-examples: all
 
 test-ci: all
 	@$(PONY_BUILD_DIR)/ponyc --version
-	@$(PONY_BUILD_DIR)/libponyc.tests
-	@$(PONY_BUILD_DIR)/libponyrt.tests
+	@$(PONY_BUILD_DIR)/libponyc.tests --gtest_output=xml:$(PONY_BUILD_DIR)/libponyc.xml
+	@$(PONY_BUILD_DIR)/libponyrt.tests --gtest_output=xml:$(PONY_BUILD_DIR)/libponyrt.xml
 	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
 	@./stdlib --sequential
 	@rm stdlib


### PR DESCRIPTION
**Test Reporting for Travis using [Testspace.com](https://testspace.com)**

Hi `ponyc` team. We added test reporting to your repo. We have a blog article on [why we are staging repos](https://blog.testspace.com/testspace-and-open-source).

Note that there a lots of different ways to organize your test results. We choose creating folders based on the os type: `linux` and `osx`.  Note, if interested we could purse bringing in `Windows` running on AppVeyor.  Thus, would have all of your testing consolidated. 

Few of the benefits using Testspace: 
- view all your test results from a single dashboard
- triage and manage your test failures faster
- add more metrics
- leverage built-in analytics 
- get a [test badge](https://help.testspace.com/how-to:get-badge) 
[![Space Health](https://open.testspace.com/spaces/74863/badge?token=f6c8e31828d842c8bed53507f3299d973496bb95)](https://open.testspace.com/spaces/74863?utm_campaign=badge&utm_medium=referral&utm_source=test "Test Cases")

Checkout **your** test results: https://open.testspace.com/projects/TryTestspace:ponyc from our fork.

----

**Give Testspace a try?**

1. Create **Open** (free) account: https://testspace.com/pricing
2. Add a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on subdomain selected in step 1
4. Invite others: https://help.testspace.com/how-to:invite-other-users
