### PR TITLE
Fix GC tracing of struct fields

### DIFF
--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -920,6 +920,7 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
   switch(t->underlying)
   {
     case TK_CLASS:
+    case TK_STRUCT:
     case TK_ACTOR:
       break;
 

--- a/test/libponyc/codegen_trace.cc
+++ b/test/libponyc/codegen_trace.cc
@@ -434,3 +434,28 @@ TEST_F(CodegenTraceTest, TraceTupleWithNumberBoxedSentThroughInterface)
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 1);
 }
+
+TEST_F(CodegenTraceTest, TraceStructField)
+{
+  const char* src =
+    "class Foo\n"
+
+    "struct Bar\n"
+    "  let f: Foo = Foo\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    trace(recover Bar end)\n"
+
+    "  be trace(x: Bar iso) =>\n"
+    "    let map = @gc_local[Pointer[None]](this)\n"
+    "    let ok = @objectmap_has_object[Bool](map, x) and\n"
+    "      @objectmap_has_object[Bool](map, x.f)\n"
+    "    @pony_exitcode[None](I32(if ok then 1 else 0 end))";
+
+  TEST_COMPILE(src);
+
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+  ASSERT_EQ(exit_code, 1);
+}


### PR DESCRIPTION
Previously, tracing functions weren't being generated for structs, which caused their fields to never be traced, resulting in various bugs including premature GC collection.

Closes #2308.