### PR TITLE
Forbid structs with embed fields with finalisers

### DIFF
--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -2,6 +2,7 @@
 #include "../verify/call.h"
 #include "../verify/control.h"
 #include "../verify/fun.h"
+#include "../verify/type.h"
 #include "expr.h"
 #include "ponyassert.h"
 
@@ -111,6 +112,7 @@ ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
 
   switch(ast_id(ast))
   {
+    case TK_STRUCT:       r = verify_struct(options, ast); break;
     case TK_ASSIGN:       r = verify_assign(options, ast); break;
     case TK_FUN:
     case TK_NEW:

--- a/src/libponyc/verify/type.c
+++ b/src/libponyc/verify/type.c
@@ -1,0 +1,68 @@
+#include "type.h"
+#include "ponyassert.h"
+
+
+static bool embed_struct_field_has_finaliser(pass_opt_t* opt, ast_t* field,
+  ast_t* base)
+{
+  ast_t* type = ast_type(field);
+  pony_assert(ast_id(type) == TK_NOMINAL);
+
+  ast_t* def = (ast_t*)ast_data(type);
+
+  ast_t* final = ast_get(def, stringtab("_final"), NULL);
+
+  if(final != NULL)
+  {
+    ast_error(opt->check.errors, base,
+      "a struct cannot have a field with a _final method");
+
+    if(field != base)
+      ast_error_continue(opt->check.errors, field, "nested field is here");
+
+    ast_error_continue(opt->check.errors, final, "_final method is here");
+
+    return false;
+  }
+
+  ast_t* members = ast_childidx(def, 4);
+  ast_t* member = ast_child(members);
+
+  bool ok = true;
+
+  while(member != NULL)
+  {
+    if(ast_id(member) == TK_EMBED)
+    {
+      if(!embed_struct_field_has_finaliser(opt, member, base))
+        ok = false;
+    }
+
+    member = ast_sibling(member);
+  }
+
+  return ok;
+}
+
+bool verify_struct(pass_opt_t* opt, ast_t* ast)
+{
+  pony_assert(ast_id(ast) == TK_STRUCT);
+
+  ast_t* members = ast_childidx(ast, 4);
+  ast_t* member = ast_child(members);
+
+  bool ok = true;
+
+  while(member != NULL)
+  {
+    if(ast_id(member) == TK_EMBED)
+    {
+      if(!embed_struct_field_has_finaliser(opt, member, member))
+        ok = false;
+    }
+
+    member = ast_sibling(member);
+  }
+
+  return ok;
+}

--- a/src/libponyc/verify/type.h
+++ b/src/libponyc/verify/type.h
@@ -1,0 +1,14 @@
+#ifndef VERIFY_TYPE_H
+#define VERIFY_TYPE_H
+
+#include <platform.h>
+#include "../ast/ast.h"
+#include "../pass/pass.h"
+
+PONY_EXTERN_C_BEGIN
+
+bool verify_struct(pass_opt_t* opt, ast_t* ast);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -168,6 +168,19 @@ TEST_F(VerifyTest, StructFinal)
   TEST_ERRORS_1(src, "a struct cannot have a _final method");
 }
 
+TEST_F(VerifyTest, StructEmbedFieldFinal)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun _final() =>\n"
+    "    None\n"
+
+    "struct Bar\n"
+    "  embed f: Foo = Foo";
+
+  TEST_ERRORS_1(src, "a struct cannot have a field with a _final method");
+}
+
 TEST_F(VerifyTest, PrimitiveWithTypeParamsFinal)
 {
   const char* src =


### PR DESCRIPTION
This fixes an oversight from b16d61a. This forbids cases where an implicit finaliser would be added to a struct.