### PR TITLE
Install doc creation support files on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -776,6 +776,7 @@ else
 install: libponyc libponyrt ponyc
 endif
 	@mkdir -p $(destdir)/bin
+	@mkdir -p $(destdir)/docs-support
 	@mkdir -p $(destdir)/lib
 	@mkdir -p $(destdir)/include/pony/detail
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.a $(destdir)/lib
@@ -793,6 +794,7 @@ endif
 	$(SILENT)cp src/libponyrt/pony.h $(destdir)/include
 	$(SILENT)cp src/common/pony/detail/atomics.h $(destdir)/include/pony/detail
 	$(SILENT)cp -r packages $(destdir)/
+	$(SILENT)cp -r .docs/* $(destdir)/docs-support/
 ifeq ($$(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib


### PR DESCRIPTION
As part of issue #2291, we've decided to create a `docs-support`
directory as part of the standard install that can be used to include
additional javascript, css, and other content used when building package
documentation.

This PR fulfills that when building from source on MacOS and Linux.
Additionally, it should install when using homebrew. RPM and Debian
packages will require another PR.