### PR TITLE
Add deferred reification

### DIFF
--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -36,12 +36,13 @@ static bool static_match(compile_t* c, LLVMValueRef value, ast_t* type,
 static ast_t* eq_param_type(compile_t* c, ast_t* pattern)
 {
   ast_t* pattern_type = ast_type(pattern);
-  ast_t* fun = lookup(NULL, pattern, pattern_type, c->str_eq);
+  deferred_reification_t* fun = lookup(NULL, pattern, pattern_type, c->str_eq);
 
-  AST_GET_CHILDREN(fun, cap, id, typeparams, params, result, partial);
+  AST_GET_CHILDREN(fun->ast, cap, id, typeparams, params, result, partial);
   ast_t* param = ast_child(params);
+  ast_t* type = ast_childidx(param, 1);
 
-  return ast_childidx(param, 1);
+  return deferred_reify(fun, type, c->opt);
 }
 
 static bool check_nominal(compile_t* c, LLVMValueRef desc, ast_t* pattern_type,

--- a/src/libponyc/type/lookup.h
+++ b/src/libponyc/type/lookup.h
@@ -2,14 +2,17 @@
 #define TYPE_LOOKUP_H
 
 #include <platform.h>
+#include "reify.h"
 #include "../ast/ast.h"
 #include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
-ast_t* lookup(pass_opt_t* opt, ast_t* from, ast_t* type, const char* name);
+deferred_reification_t* lookup(pass_opt_t* opt, ast_t* from, ast_t* type,
+  const char* name);
 
-ast_t* lookup_try(pass_opt_t* opt, ast_t* from, ast_t* type, const char* name);
+deferred_reification_t* lookup_try(pass_opt_t* opt, ast_t* from, ast_t* type,
+  const char* name);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -7,6 +7,16 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct deferred_reification_t
+{
+  ast_t* ast;
+  ast_t* type_typeparams;
+  ast_t* type_typeargs;
+  ast_t* method_typeparams;
+  ast_t* method_typeargs;
+  ast_t* thistype;
+} deferred_reification_t;
+
 bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   pass_opt_t* opt);
 
@@ -15,6 +25,20 @@ ast_t* reify(ast_t* ast, ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt,
 
 ast_t* reify_method_def(ast_t* ast, ast_t* typeparams, ast_t* typeargs,
   pass_opt_t* opt);
+
+deferred_reification_t* deferred_reify_new(ast_t* ast, ast_t* typeparams,
+  ast_t* typeargs, ast_t* thistype);
+
+void deferred_reify_add_method_params(deferred_reification_t* deferred,
+  ast_t* typeparams, ast_t* typeargs);
+
+ast_t* deferred_reify(deferred_reification_t* deferred, ast_t* ast,
+  pass_opt_t* opt);
+
+ast_t* deferred_reify_method_def(deferred_reification_t* deferred, ast_t* ast,
+  pass_opt_t* opt);
+
+void deferred_reify_free(deferred_reification_t* deferred);
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
   bool report_errors, pass_opt_t* opt);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -484,7 +484,7 @@ static bool is_fun_sub_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
       super_typeparam = ast_sibling(super_typeparam);
     }
 
-    r_sub = reify(sub, sub_typeparams, typeargs, opt, true);
+    r_sub = reify_method_def(sub, sub_typeparams, typeargs, opt);
     ast_free_unattached(typeargs);
   }
 

--- a/src/libponyc/type/viewpoint.h
+++ b/src/libponyc/type/viewpoint.h
@@ -25,12 +25,13 @@ ast_t* viewpoint_lower(ast_t* type);
  * Replace all instances of target with some type. The target must either be
  * `this` or a typeparamref.
  */
-ast_t* viewpoint_replace(ast_t* ast, ast_t* target, ast_t* with);
+ast_t* viewpoint_replace(ast_t* ast, ast_t* target, ast_t* with,
+  bool duplicate);
 
 /**
  * Replace all instances of `this` with some type.
  */
-ast_t* viewpoint_replacethis(ast_t* ast, ast_t* with);
+ast_t* viewpoint_replacethis(ast_t* ast, ast_t* with, bool duplicate);
 
 /**
  * Returns a tuple of type reified with every possible instantiation of


### PR DESCRIPTION
This change adds support for deferred reification to the compiler. This allows AST reifications to be delayed until the reified version is actually needed.

For now this is only used for the `lookup` function. In the future, this will be used during code generation in order to avoid unnecessary AST copying and to reduce the amount of simultaneous copies, as these are the main culprits of the high memory usage of the compiler.