### PR TITLE
Use human-friendly package version numbers in AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -76,7 +76,7 @@ deploy:
     subject: pony-language
     repo: ponyc-win
     package: ponyc
-    version: $(appveyor_build_version)
+    version: ponyc-$(package_version)
     on:
         branch: release
         llvm: 3.9.1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,7 +49,7 @@ build_script:
   - python -x waf configure
   - python -x waf build --config %configuration% --llvm %llvm%
   - ps: |
-      $ponydir = "${env:appveyor_build_version}-win64"
+      $ponydir = "ponyc-${package_version}-win64"
       cd C:\projects\ponyc
       md "$ponydir"
       md "${ponydir}\ponyc"

--- a/make.bat
+++ b/make.bat
@@ -95,4 +95,6 @@ goto running
 
 rem @echo Using %PYTHON%
 
-"%PYTHON%" -x "%~dp0waf" %*  & Endlocal & exit /b %ERRORLEVEL%
+"%PYTHON%" -x "%~dp0waf" %*
+Endlocal
+%COMSPEC% /c exit /b %ERRORLEVEL%


### PR DESCRIPTION
Also fixes errorlevel returns in the `make.bat` build script.