### PR TITLE
Run the syntax pass on lambdas and object literals

### DIFF
--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -339,7 +339,8 @@ ast_result_t ast_visit(ast_t** ast, ast_visit_t pre, ast_visit_t post,
   if(ast_pass >= pass)  // This pass already done for this AST node
     return AST_OK;
 
-  if(ast_checkflag(*ast, AST_FLAG_PRESERVE))  // Do not process this subtree
+  // Do not process this subtree
+  if((pass > PASS_SYNTAX) && ast_checkflag(*ast, AST_FLAG_PRESERVE))
     return AST_OK;
 
   typecheck_t* t = &options->check;

--- a/test/libponyc/lambda.cc
+++ b/test/libponyc/lambda.cc
@@ -194,6 +194,19 @@ TEST_F(LambdaTest, ObjectCaptureRefInActor)
   TEST_ERRORS_1(src, "this parameter must be sendable");
 }
 
+TEST_F(LambdaTest, ObjectSyntaxErrorInMethod)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun f() =>\n"
+    "    object\n"
+    "      fun wrong_syntax() =>\n"
+    "        1 + 2 * 4\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "Operator precedence is not supported. Parentheses required.");
+}
+
 
 TEST_F(LambdaTest, InferFromArgType)
 {


### PR DESCRIPTION
Lambdas and Object Literals have been marked with `AST_FLAG_PRESERVE` in order to delay their evaluation until the type of the lambda or object literal is available in the `expr` pass.

The generated type AST was never run through the syntax pass.
It seems safe to run the syntax pass on those flagged AST nodes but no other passes, as the syntax pass is not mutating the AST and only checking for syntax errors.

This fixes #2413 