### PR TITLE
Use deferred reification during reachability analysis

### DIFF
--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -536,7 +536,7 @@ void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
   for(size_t i = 0; i < m->param_count; i++)
   {
     cast_args[i+1] = gen_assign_cast(c, param_types[i+3], args[i+1],
-     ast_type(arg_ast));
+      ast_type(arg_ast));
     arg_ast = ast_sibling(arg_ast);
   }
 
@@ -556,20 +556,17 @@ void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
   }
 
   // Trace while populating the message contents.
-  ast_t* params = ast_childidx(m->r_fun, 3);
-  ast_t* param = ast_child(params);
   arg_ast = ast_child(args_ast);
   bool need_trace = false;
 
-  while(param != NULL)
+  for(size_t i = 0; i < m->param_count; i++)
   {
-    if(gentrace_needed(c, ast_type(arg_ast), ast_type(param)))
+    if(gentrace_needed(c, ast_type(arg_ast), m->params[i].ast))
     {
       need_trace = true;
       break;
     }
 
-    param = ast_sibling(param);
     arg_ast = ast_sibling(arg_ast);
   }
 
@@ -579,14 +576,12 @@ void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
   {
     LLVMValueRef gc = gencall_runtime(c, "pony_gc_send", &ctx, 1, "");
     LLVMSetMetadataStr(gc, "pony.msgsend", md);
-    param = ast_child(params);
     arg_ast = ast_child(args_ast);
 
     for(size_t i = 0; i < m->param_count; i++)
     {
       gentrace(c, ctx, args[i+1], cast_args[i+1], ast_type(arg_ast),
-        ast_type(param));
-      param = ast_sibling(param);
+        m->params[i].ast);
       arg_ast = ast_sibling(arg_ast);
     }
 
@@ -602,7 +597,7 @@ void gen_send_message(compile_t* c, reach_method_t* m, LLVMValueRef args[],
   msg_args[4] = LLVMConstInt(c->i1, 1, false);
   LLVMValueRef send;
 
-  if(ast_id(m->r_fun) == TK_NEW)
+  if(ast_id(m->fun->ast) == TK_NEW)
     send = gencall_runtime(c, "pony_sendv_single", msg_args, 5, "");
   else
     send = gencall_runtime(c, "pony_sendv", msg_args, 5, "");
@@ -676,7 +671,7 @@ static bool can_inline_message_send(reach_type_t* t, reach_method_t* m,
         return false;
 
       case TK_ACTOR:
-        if(ast_id(m_sub->r_fun) == TK_FUN)
+        if(ast_id(m_sub->fun->ast) == TK_FUN)
           return false;
         break;
 

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -47,7 +47,7 @@ static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
   const char* unbox_name = genname_unbox(m->full_name);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
-  if(ast_id(m->r_fun) != TK_NEW)
+  if(ast_id(m->fun->ast) != TK_NEW)
   {
     // It's the same type, but it takes the boxed type instead of the primitive
     // type as the receiver.
@@ -82,7 +82,7 @@ static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
 
   LLVMValueRef* args = (LLVMValueRef*)ponyint_pool_alloc_size(buf_size);
 
-  if(ast_id(m->r_fun) != TK_NEW)
+  if(ast_id(m->fun->ast) != TK_NEW)
   {
     // If it's not a constructor, pass the extracted primitive as the receiver.
     args[0] = primitive;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -3,6 +3,7 @@
 
 #include "../ast/ast.h"
 #include "../pass/pass.h"
+#include "../type/reify.h"
 #include "../../libponyrt/ds/hash.h"
 #include "../../libponyrt/ds/stack.h"
 
@@ -14,7 +15,7 @@ typedef struct reach_field_t reach_field_t;
 typedef struct reach_param_t reach_param_t;
 typedef struct reach_type_t reach_type_t;
 
-DECLARE_STACK(reachable_expr_stack, reachable_expr_stack_t, ast_t);
+DECLARE_STACK(reachable_expr_stack, reachable_expr_stack_t, void);
 DECLARE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
 DECLARE_HASHMAP_SERIALISE(reach_methods, reach_methods_t, reach_method_t);
 DECLARE_HASHMAP_SERIALISE(reach_mangled, reach_mangled_t, reach_method_t);
@@ -37,8 +38,8 @@ struct reach_method_t
   const char* full_name;
 
   token_id cap;
+  deferred_reification_t* fun;
   ast_t* typeargs;
-  ast_t* r_fun;
   uint32_t vtable_index;
 
   // Mark as true if the compiler supplies an implementation.
@@ -83,6 +84,8 @@ struct reach_field_t
 
 struct reach_param_t
 {
+  const char* name;
+  ast_t* ast;
   reach_type_t* type;
   token_id cap;
 };

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -29,8 +29,8 @@ ast_t* reify_method_def(ast_t* ast, ast_t* typeparams, ast_t* typeargs,
 deferred_reification_t* deferred_reify_new(ast_t* ast, ast_t* typeparams,
   ast_t* typeargs, ast_t* thistype);
 
-void deferred_reify_add_method_params(deferred_reification_t* deferred,
-  ast_t* typeparams, ast_t* typeargs);
+void deferred_reify_add_method_typeparams(deferred_reification_t* deferred,
+  ast_t* typeparams, ast_t* typeargs, pass_opt_t* opt);
 
 ast_t* deferred_reify(deferred_reification_t* deferred, ast_t* ast,
   pass_opt_t* opt);
@@ -38,10 +38,14 @@ ast_t* deferred_reify(deferred_reification_t* deferred, ast_t* ast,
 ast_t* deferred_reify_method_def(deferred_reification_t* deferred, ast_t* ast,
   pass_opt_t* opt);
 
+deferred_reification_t* deferred_reify_dup(deferred_reification_t* deferred);
+
 void deferred_reify_free(deferred_reification_t* deferred);
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
   bool report_errors, pass_opt_t* opt);
+
+pony_type_t* deferred_reification_pony_type();
 
 PONY_EXTERN_C_END
 

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -52,8 +52,8 @@ protected:
     memset(method, 0, sizeof(reach_method_t));
     method->name = stringtab(name);
     method->mangled_name = method->name;
+    method->fun = NULL;
     method->typeargs = NULL;
-    method->r_fun = NULL;
     method->vtable_index = (uint32_t)-1;
 
     reach_methods_put(&n->r_methods, method);


### PR DESCRIPTION
This change is a followup to abdcf2e. Instead of fully reifying functions during reachability analysis, the pass now uses deferred reification as needed.

Functions are now fully reified one at a time during code generation, instead of all at once during reachability analysis. In the future, code generation will use deferred reification as well.

This change results in a huge improvement in the memory usage of the compiler.