### PR TITLE
Fix wrong runtime error message on exit code assignment

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -759,10 +759,11 @@ static void init_runtime(compile_t* c)
 #  endif
 #endif
 
-  // i32 pony_start(i32, i32)
-  params[0] = c->i32;
-  params[1] = c->i32;
-  type = LLVMFunctionType(c->i32, params, 2, false);
+  // i1 pony_start(i1, i1, i32*)
+  params[0] = c->i1;
+  params[1] = c->i1;
+  params[2] = LLVMPointerType(c->i32, 0);
+  type = LLVMFunctionType(c->i1, params, 3, false);
   value = LLVMAddFunction(c->module, "pony_start", type);
 #if PONY_LLVM >= 309
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -401,20 +401,23 @@ PONY_API int pony_init(int argc, char** argv);
 
 /** Starts the pony runtime.
  *
- * Returns -1 if the scheduler couldn't start, otherwise returns the exit code
- * set with pony_exitcode(), defaulting to 0.
+ * Returns false if the runtime couldn't start, otherwise returns true with
+ * the value pointed by exit_code set with pony_exitcode(), defaulting to 0.
+ * exit_code can be NULL if you don't care about the exit code.
  *
  * If library is false, this call will return when the pony program has
  * terminated. If library is true, this call will return immediately, with an
  * exit code of 0, and the runtime won't terminate until pony_stop() is
  * called. This allows further processing to be done on the current thread.
+ * The value pointed by exit_code will not be modified if library is true. Use
+ * the return value of pony_stop() in that case.
  *
  * If language_features is false, the features of the runtime specific to the
  * Pony language, such as network or serialisation, won't be initialised.
  *
  * It is not safe to call this again before the runtime has terminated.
  */
-PONY_API int pony_start(bool library, bool language_features);
+PONY_API bool pony_start(bool library, bool language_features, int* exit_code);
 
 /**
  * Call this to create a pony_ctx_t for a non-scheduler thread. This has to be

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -33,7 +33,7 @@ typedef struct options_t
 
 // global data
 static PONY_ATOMIC(bool) initialised;
-static PONY_ATOMIC(int) exit_code;
+static PONY_ATOMIC(int) rt_exit_code;
 static bool language_init;
 
 enum
@@ -146,26 +146,26 @@ PONY_API int pony_init(int argc, char** argv)
   return argc;
 }
 
-PONY_API int pony_start(bool library, bool language_features)
+PONY_API bool pony_start(bool library, bool language_features, int* exit_code)
 {
   pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
 
   if(language_features)
   {
     if(!ponyint_os_sockets_init())
-      return -1;
+      return false;
 
     if(!ponyint_serialise_setup())
-      return -1;
+      return false;
 
     language_init = true;
   }
 
   if(!ponyint_sched_start(library))
-    return -1;
+    return false;
 
   if(library)
-    return 0;
+    return true;
 
   if(language_init)
   {
@@ -179,7 +179,11 @@ PONY_API int pony_start(bool library, bool language_features)
 #endif
   atomic_thread_fence(memory_order_acq_rel);
   atomic_store_explicit(&initialised, false, memory_order_relaxed);
-  return ec;
+
+  if(exit_code != NULL)
+    *exit_code = ec;
+
+  return true;
 }
 
 PONY_API int pony_stop()
@@ -204,10 +208,10 @@ PONY_API int pony_stop()
 
 PONY_API void pony_exitcode(int code)
 {
-  atomic_store_explicit(&exit_code, code, memory_order_relaxed);
+  atomic_store_explicit(&rt_exit_code, code, memory_order_relaxed);
 }
 
 PONY_API int pony_get_exitcode()
 {
-  return atomic_load_explicit(&exit_code, memory_order_relaxed);
+  return atomic_load_explicit(&rt_exit_code, memory_order_relaxed);
 }


### PR DESCRIPTION
This change fixes an oversight from c2557a9. If the runtime had successfully been started but exited with an exit code of -1, the error message saying that the runtime couldn't be started would be printed. This was caused by the way `pony_start` propagates errors, with a startup failure and an exit code of -1 both resulting in `pony_start` returning -1.

`pony_start` now returns a boolean indicating whether the runtime was successfully started and returns the exit code in an output parameter.