### PR TITLE
Add test-stdlib and test-stdlib-debug targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,12 +871,17 @@ stdlib-debug: all
 stdlib: all
 	$(PONY_BUILD_DIR)/ponyc --checktree --verify packages/stdlib
 
-stdlib-loop:
-	while true; do echo "Date: `date +%y%m%d-%H%M%S.%N`"; ./stdlib --sequential; echo "stdlib done"; done 2>&1 | tee stdlib-`date +%y%m%d-%H%M%S.%N`.txt
+test-stdlib-debug: stdlib-debug
+	./stdlib --sequential
 
-test-stdlib-debug: stdlib-debug stdlib-loop
+test-stdlib: stdlib
+	./stdlib --sequential
 
-test-stdlib: stdlib stdlib-loop
+# For a long term test build stdlib-debug or stdlib
+# and uncomment test-long-term. This will will run
+# stdlib forever pushing the output to stdlib-xxxx.txt
+#test-long-term:
+#	while true; do echo "Date: `date +%y%m%d-%H%M%S.%N`"; ./stdlib --sequential; echo "stdlib done"; done 2>&1 | tee stdlib-`date +%y%m%d-%H%M%S.%N`.txt
 
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests

--- a/Makefile
+++ b/Makefile
@@ -877,12 +877,6 @@ test-stdlib-debug: stdlib-debug
 test-stdlib: stdlib
 	./stdlib --sequential
 
-# For a long term test build stdlib-debug or stdlib
-# and uncomment test-long-term. This will will run
-# stdlib forever pushing the output to stdlib-xxxx.txt
-#test-long-term:
-#	while true; do echo "Date: `date +%y%m%d-%H%M%S.%N`"; ./stdlib --sequential; echo "stdlib done"; done 2>&1 | tee stdlib-`date +%y%m%d-%H%M%S.%N`.txt
-
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests

--- a/Makefile
+++ b/Makefile
@@ -865,6 +865,19 @@ benchmark: all
 	@echo "Running libponyrt benchmarks..."
 	@$(PONY_BUILD_DIR)/libponyrt.benchmarks
 
+stdlib-debug: all
+	$(PONY_BUILD_DIR)/ponyc -d --checktree --verify packages/stdlib
+
+stdlib: all
+	$(PONY_BUILD_DIR)/ponyc --checktree --verify packages/stdlib
+
+stdlib-loop:
+	while true; do echo "Date: `date +%y%m%d-%H%M%S.%N`"; ./stdlib --sequential; echo "stdlib done"; done 2>&1 | tee stdlib-`date +%y%m%d-%H%M%S.%N`.txt
+
+test-stdlib-debug: stdlib-debug stdlib-loop
+
+test-stdlib: stdlib stdlib-loop
+
 test: all
 	@$(PONY_BUILD_DIR)/libponyc.tests
 	@$(PONY_BUILD_DIR)/libponyrt.tests


### PR DESCRIPTION
The targets can be used to test issue #2451

These use the sub-targets stdlib-debug, stdlib to compile stdlib either
in debug or not. And stdlib-loop will execute stdlib in a forever while
loop capturing the output to stdlib-xxxx.txt where xxx is the current
date and time.