### PR TITLE
Expose OutStream rather than StdStream in Env

### DIFF
--- a/examples/producer-consumer/buffer.pony
+++ b/examples/producer-consumer/buffer.pony
@@ -4,9 +4,9 @@ actor Buffer
   var _future_products: USize = 0
   var _producers_waiting: Array[Producer] = Array[Producer]
   var _consumers_waiting: Array[Consumer] = Array[Consumer]
-  let _out: StdStream
+  let _out: OutStream
 
-  new create(capacity': USize, out: StdStream) =>
+  new create(capacity': USize, out: OutStream) =>
     capacity = capacity'
     _products = Array[Product](capacity)
     _out = out

--- a/examples/producer-consumer/consumer.pony
+++ b/examples/producer-consumer/consumer.pony
@@ -3,9 +3,9 @@ use "collections"
 actor Consumer
   var _quantity_to_consume: U32
   let _buffer: Buffer
-  let _out: StdStream
+  let _out: OutStream
 
-  new create(quantity_to_consume: U32, buffer: Buffer, out: StdStream) =>
+  new create(quantity_to_consume: U32, buffer: Buffer, out: OutStream) =>
     _quantity_to_consume = quantity_to_consume
     _buffer = buffer
     _out = out

--- a/examples/producer-consumer/producer.pony
+++ b/examples/producer-consumer/producer.pony
@@ -4,9 +4,9 @@ actor Producer
   var _quantity_to_produce: U32
   let _buffer: Buffer
   var _num: U32 = 0
-  let _out: StdStream
+  let _out: OutStream
 
-  new create(quantity_to_produce: U32, buffer: Buffer, out: StdStream) =>
+  new create(quantity_to_produce: U32, buffer: Buffer, out: OutStream) =>
     _quantity_to_produce = quantity_to_produce
     _buffer = buffer
     _out = out

--- a/packages/builtin/env.pony
+++ b/packages/builtin/env.pony
@@ -5,8 +5,8 @@ class val Env
   """
   let root: (AmbientAuth | None)
   let input: Stdin
-  let out: StdStream
-  let err: StdStream
+  let out: OutStream
+  let err: OutStream
   let args: Array[String] val
   let _envp: Pointer[Pointer[U8]] val
   let _vars: (Array[String] val | None)
@@ -33,8 +33,8 @@ class val Env
 
   new create(
     root': (AmbientAuth | None),
-    input': Stdin, out': StdStream,
-    err': StdStream, args': Array[String] val,
+    input': Stdin, out': OutStream,
+    err': OutStream, args': Array[String] val,
     vars': (Array[String] val | None))
   =>
     """


### PR DESCRIPTION
By making Env expose and rely on the OutStream interface it becomes
possible to create mock environments for testing. For example one can
implement an OutStreamStringAccumulator that accumulates output to a
String that can then be checked in a unit test.

Currently the 'create()' method is provided in order to build an
'artificial' environment. This simply extends this ability to support
providing alternative 'out' and 'err' stream implementations.