### PR TITLE
Include optimisation bug example.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,7 +883,7 @@ test: all
 	@rm stdlib
 
 test-examples: all
-	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify examples
+	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -s --checktree --verify examples
 	@./examples1
 	@rm examples1
 

--- a/examples/literal-optimisation/literal-optimisation.pony
+++ b/examples/literal-optimisation/literal-optimisation.pony
@@ -1,0 +1,40 @@
+"""
+This code triggered a ponyc segmentation fault when using LLVM versions
+prior to 5.0.1. The crash only took place when building optimised binaries.
+i.e. ponyc -d did not tigger the crash.
+
+It is included here in order to protect againt regressions.
+
+See: https://github.com/ponylang/ponyc/issues/2280
+"""
+
+primitive GT
+	fun arb(): Bool => true
+primitive LT
+	fun arb(): Bool => true
+
+type Comp is (LT | GT)
+
+type Tuple is (I32, I32)
+
+actor LiteralOptimisation
+
+	new create() =>
+		let b: Tuple = if select((5,0),(2,0)) is LT then
+			(0,0)
+		else
+			(0,1)
+		end
+		let c: Comp = select((5,0), b)
+		c.arb()
+
+	fun select(lhs: Tuple, rhs: Tuple): Comp =>
+		if lhs._1 < rhs._1 then
+			LT
+		else
+			GT
+		end
+
+actor Main
+	new create(env: Env) =>
+		let worker: LiteralOptimisation = LiteralOptimisation

--- a/examples/main.pony
+++ b/examples/main.pony
@@ -38,8 +38,12 @@ use ex_ring = "ring"
 use ex_spreader = "spreader"
 use ex_timers = "timers"
 use ex_yield = "yield"
+use ex_literalopt = "literal-optimisation"
 
 
 actor Main
   new create(env: Env) =>
     env.out.write("All examples compile!\n")
+
+    // instantiate items to ensure they are pushed through all compilaton phases
+    let literopt: ex_literalopt.LiteralOptimisation = ex_literalopt.LiteralOptimisation


### PR DESCRIPTION
My feeling is the the following pull request is not exactly the right way to introduce a regression test for this case.

Is there a better way to introduce a test for this problem?

Additionally, is there a way to have the test only run for LLVM 5.0.1 and above, since it has now been shown that the issue is resolved with these versions of LLVM?

Thanks,
Stewart.

---

This includes the code snippet from: https://github.com/ponylang/ponyc/issues/2280

However, since this bug is only triggered during the optimisation
phase, the Makefile has been updated accordingly to remove '-d'.

Additionally, because the optimisation phase will "optimise away" the
bug, the example Main actor has been updated to explicitly instantiate
the affected code.