### PR TITLE
Fix byte chunks being sent separately over SSL with writev()

### DIFF
--- a/packages/net/ssl/ssl_connection.pony
+++ b/packages/net/ssl/ssl_connection.pony
@@ -63,11 +63,17 @@ class SSLConnection is TCPConnectionNotify
     ""
 
   fun ref sentv(conn: TCPConnection ref, data: ByteSeqIter): ByteSeqIter =>
+    let data_array = recover Array[U8] end
     for bytes in data.values() do
-      sent(conn, bytes)
+      match bytes
+      | let b: String =>
+        data_array.append(b.array())
+      | let b: Array[U8] val =>
+        data_array.append(b)
+      end
     end
-
-  recover val Array[ByteSeq] end
+    sent(conn, consume data_array)
+    recover val Array[ByteSeq] end
 
   fun ref received(
     conn: TCPConnection ref,


### PR DESCRIPTION
Currently, writing ByteSeqIter data to an SSLConnection with
`writev()` will break each chunk of ByteSeq and send them separately
on the SSL layer. This means that each individual sequence of bytes
is sent over separate packets, which happens frequently when using
buffers to format data.

This change joins all values in ByteSeqIter into a single ByteSeq,
so that they are sent in a single packet.
  