### PR TITLE
Fix pthread condition variable usage for dynamic scheduler scaling

### DIFF
--- a/src/common/threads.h
+++ b/src/common/threads.h
@@ -59,6 +59,6 @@ pony_thread_id_t ponyint_thread_self();
 
 void ponyint_thread_suspend(pony_signal_event_t signal);
 
-void ponyint_thread_wake(pony_thread_id_t thread, pony_signal_event_t signal);
+int ponyint_thread_wake(pony_thread_id_t thread, pony_signal_event_t signal);
 
 #endif

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -199,7 +199,7 @@ static void usage(void)
     "  --ponythreads    Use N scheduler threads. Defaults to the number of\n"
     "                   cores (not hyperthreads) available.\n"
     "  --ponyminthreads Minimum number of active scheduler threads allowed.\n"
-    "                   Defaults to 1.\n"
+    "                   Defaults to the number of '--ponythreads'.\n"
     "  --ponycdmin      Defer cycle detection until 2^N actors have blocked.\n"
     "                   Defaults to 2^4.\n"
     "  --ponycdmax      Always cycle detect when 2^N actors have blocked.\n"

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -276,19 +276,18 @@ void ponyint_thread_suspend(pony_signal_event_t signal)
 #endif
 }
 
-void ponyint_thread_wake(pony_thread_id_t thread, pony_signal_event_t signal)
+int ponyint_thread_wake(pony_thread_id_t thread, pony_signal_event_t signal)
 {
+  int ret;
 #if defined(PLATFORM_IS_WINDOWS)
   (void) thread;
-  SetEvent(signal);
+  ret = !SetEvent(signal);
 #elif defined(USE_SCHEDULER_SCALING_PTHREADS)
   (void) thread;
-  int ret;
   // signal condition variable
   ret = pthread_cond_signal(signal);
-  // TODO: What to do if `ret` is an unrecoverable error?
-  (void) ret;
 #else
-  pthread_kill(thread, signal);
+  ret = pthread_kill(thread, signal);
 #endif
+  return ret;
 }

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -673,9 +673,9 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
   if(threads == 0)
     threads = ponyint_cpu_count();
 
-  // If no minimum thread count is specified, use 1
+  // If no minimum thread count is specified, use # of threads
   if(min_threads == 0)
-    min_threads = 1;
+    min_threads = threads;
 
   // If minimum thread count is > thread count, cap it at thread count
   if(min_threads > threads)

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -161,6 +161,11 @@ static bool read_msg(scheduler_t* sched)
         if(atomic_load_explicit(&detect_quiescence, memory_order_relaxed) &&
           (sched->block_count == get_active_scheduler_count()))
         {
+          // reset ack token count to 0 because dynamic scheduler scaling means
+          // that a new thread can suspend changing active_scheduler_count and
+          // we can think we've received enough acks when we really haven't
+          sched->ack_count = 0;
+
           // If we think all threads are blocked, send CNF(token) to everyone.
           send_msg_all_active(sched->index, SCHED_CNF, sched->ack_token);
         }
@@ -174,6 +179,13 @@ static bool read_msg(scheduler_t* sched)
         if(atomic_load_explicit(&detect_quiescence, memory_order_relaxed) &&
           (sched->block_count == get_active_scheduler_count()))
         {
+          // reset ack token count to 0 because dynamic scheduler scaling means
+          // that a new thread can wake up changing active_scheduler_count and
+          // then block causing block_count == active_scheduler_count for a
+          // second time and if we don't reset, we can think we've received
+          // enough acks when we really haven't
+          sched->ack_count = 0;
+
           // If we think all threads are blocked, send CNF(token) to everyone.
           send_msg_all_active(sched->index, SCHED_CNF, sched->ack_token);
         }
@@ -431,12 +443,6 @@ static pony_actor_t* steal(scheduler_t* sched)
           && !atomic_exchange_explicit(&scheduler_count_changing, true,
             memory_order_acquire))
         {
-          // let sched 0 know we're suspending
-          send_msg(sched->index, 0, SCHED_SUSPEND, 0);
-
-          // dtrace suspend notification
-          DTRACE1(THREAD_SUSPEND, (uintptr_t)sched);
-
           // decrement active_scheduler_count so other schedulers know we're
           // sleeping
           uint32_t sched_count = atomic_load_explicit(&active_scheduler_count,
@@ -452,6 +458,20 @@ static pony_actor_t* steal(scheduler_t* sched)
           // variable
           atomic_store_explicit(&scheduler_count_changing, false,
             memory_order_release);
+
+          // let sched 0 know we're suspending only after decrementing
+          // active_scheduler_count to avoid a race condition between
+          // when we update active_scheduler_count and scheduler 0 processes
+          // the SCHED_SUSPEND message we send it. If we don't do this,
+          // and scheduler 0 processes the SCHED_SUSPEND message before we
+          // decrement active_scheduler_count, it could think that
+          // active_scheduler_count > block_count and not start the CNF/ACK
+          // process for termination and potentiall hang the runtime instead
+          // of allowing it to reach quiescence.
+          send_msg(sched->index, 0, SCHED_SUSPEND, 0);
+
+          // dtrace suspend notification
+          DTRACE1(THREAD_SUSPEND, (uintptr_t)sched);
 
           // sleep waiting for signal to wake up again
           ponyint_thread_suspend(sched->sleep_object);


### PR DESCRIPTION
Prior to this commit, the pthreads variant of the dynamic scheduler
scaling functionality didn't use pthread condition variables
correctly for the logic required. It relied on a single pthread
condition variable for all threads to sleep against. Unfortunately,
there's no way to wake up a specific thread when relying on pthread
condition variables and the operating system is free to wake up any
thread that is sleeping against a pthread condition variable. This
resulted in out of order waking of sleeping threads which broke one
of the invariants for how dynamic scheduler scaling is supposed to
work.

This commit fixes the code to create a separate pthread condition
variable for each scheduler thread ensure that we can wake up a
specific single thread at a time correctly.

This commit also adds some error handling and asssertions to help
catch any other logic error that might exist.

Thanks to @winksaville for all his help in testing and debugging
this. It likely wouldn't have been found/fixed so soon if it
weren't for him.

NOTE: While this fixes at least one of the causes of #2451, I don't
believe it resolves the entire issue. Hopefully @winksaville is
able to test and confirm if the issue still exists or not.