### PR TITLE
Disable -avx512f on LLVM < 5.0.0 to avoid LLVM bug 30542

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ There is experimental support for building with LLVM 4.0.1 or 5.0.0,
 but this may result in decreased performance or crashes in generated
 applications.
 
+NOTE: If LLVM version < 5.0.0 is used, cpu feature `avx512f` is diabled automagically to avoid [LLVM bug 30542](https://bugs.llvm.org/show_bug.cgi?id=30542) otherwise the compiler crashes during the optimization phase.
+
 Compiling Pony is only possible on x86 and ARM (either 32 or 64 bits).
 
 ## Building on Linux

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -46,6 +46,11 @@ char* LLVMGetHostCPUFeatures()
   for(auto it = features.begin(); it != features.end(); it++)
     buf_size += (*it).getKey().str().length() + 2; // plus +/- char and ,/null
 
+#if PONY_LLVM < 500
+  // Add extra buffer space for llvm bug workaround
+  buf_size += 9;
+#endif
+
   char* buf = (char*)malloc(buf_size);
   pony_assert(buf != NULL);
   buf[0] = 0;
@@ -63,6 +68,11 @@ char* LLVMGetHostCPUFeatures()
     if(it != features.end())
       strcat(buf, ",");
   }
+
+#if PONY_LLVM < 500
+  // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
+  strcat(buf, ",-avx512f");
+#endif
 
   return buf;
 }


### PR DESCRIPTION
Prior to this commit, we could accidentally trigger llvm bug 30542
(https://bugs.llvm.org/show_bug.cgi?id=30542) on a cpu with the
`avx512f` feature. See https://github.com/WallarooLabs/wallaroo/issues/1925
for one particular example of this occurring.

This commit automagically disables `avx512f` if the LLVM in use is
below version 5.0.0 to work around the issue.