### PR TITLE
Fix cycle detector memory issue with actor block/unblock messages

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -270,7 +270,17 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
     // Stop handling a batch if we reach the head we found when we were
     // scheduled.
     if(msg == head)
+    {
+      // if cycle detector, have it do actual block checking now that it has
+      // processed all block/unblock messages and accumulated all work in
+      // its deferred hashmap
+      if(ponyint_is_cycle(actor))
+      {
+        ponyint_cycle_check_blocked(ctx);
+      }
+
       break;
+    }
   }
 
   // We didn't hit our app message batch limit. We now believe our queue to be

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -18,6 +18,8 @@ void ponyint_cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_cycle_ack(pony_ctx_t* ctx, size_t token);
 
+void ponyint_cycle_check_blocked(pony_ctx_t* ctx);
+
 void ponyint_cycle_terminate(pony_ctx_t* ctx);
 
 bool ponyint_is_cycle(pony_actor_t* actor);


### PR DESCRIPTION
Prior to this commit, the cycle detector would try and check for
cycles while processing actor `block` messages. This resulted in
a memory backup because the cycle detector was not able to keep
up with the incoming block/unblock messages.

This commit changes how the cycle detector works so that it no
longer tries to check for cycles while processing `block` messages.
Now, it queues all actors that need checking for cycles in its
deferred hashmap and then processes them once after it has gone
through all block/unblock messages that were waiting in its queue
when it started.

------------------------

NOTE: I don't believe this does anything to fundamentally change the behavior of cycle detector (i.e. I don't think I broke it), but it would be great if @sylvanc (or someone else knowledgeable) could do a quick review to confirm.

------------------------

Memory usage for (a slightly modified version of) the `message-ubench` example before this change:

```
Dipins-MBP:dhp dipinhora$ /usr/bin/time -l ./message-ubench --ponyminthreads 9999 --pingers 1000
# pingers 1000, report-interval 10, initial-pings 5, total-iterations 10
time,run-ns,rate
1515556584.698211000,999696000,17431986
1515556585.697852000,998639000,17948154
1515556586.697245000,998521000,17600761
1515556587.695662000,997629000,17583785
1515556588.695618000,999066000,16636094
1515556589.694019000,997344000,17146566
1515556590.693403000,998397000,18059305
1515556591.694389000,999939000,17323791
1515556592.692174000,996908000,15490498
1515556593.692337000,998997000,18015068
       15.06 real        43.75 user         0.66 sys
 729784320  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
    178081  page reclaims
        65  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
     83167  involuntary context switches
```

Memory usage for (a slightly modified version of) the `message-ubench` example after this change:

```
Dipins-MBP:dhp dipinhora$ /usr/bin/time -l ./message-ubench --ponyminthreads 9999 --pingers 1000
# pingers 1000, report-interval 10, initial-pings 5, total-iterations 10
time,run-ns,rate
1515556534.548423000,998948000,17711049
1515556535.547454000,998019000,18018261
1515556536.546946000,998548000,18283155
1515556537.545198000,997162000,18121703
1515556538.545210000,999162000,18393570
1515556539.544460000,998375000,18092003
1515556540.543887000,998380000,18451412
1515556541.542271000,997508000,18128957
1515556542.541669000,998412000,17811436
1515556543.541329000,998818000,18064227
       10.00 real        39.42 user         0.22 sys
  10510336  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
      2494  page reclaims
        67  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         0  signals received
         0  voluntary context switches
     66621  involuntary context switches
```

Fun fact: If you run `message-ubench` with and without `--ponynoblock` you can compare the performance overhead of the cycle detector vs no cycle detector (on my mac it's about a 5M rate difference).