### PR TITLE
Temporarily turn off LLVM 3.9.1 builds on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,39 +10,39 @@ sudo: required
 
 matrix:
   include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - FAVORITE_CONFIG=no
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - config=debug
-        - CC1=gcc
-        - CXX1=g++
-        - ICC1=gcc-6
-        - ICXX1=g++-6
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-6
+    #   env:
+    #     - FAVORITE_CONFIG=no
+    #     - LLVM_VERSION="3.9.1"
+    #     - LLVM_CONFIG="llvm-config-3.9"
+    #     - config=debug
+    #     - CC1=gcc
+    #     - CXX1=g++
+    #     - ICC1=gcc-6
+    #     - ICXX1=g++-6
 
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - FAVORITE_CONFIG=yes
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - config=release
-        - CC1=gcc
-        - CXX1=g++
-        - ICC1=gcc-6
-        - ICXX1=g++-6
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-6
+    #   env:
+    #     - FAVORITE_CONFIG=yes
+    #     - LLVM_VERSION="3.9.1"
+    #     - LLVM_CONFIG="llvm-config-3.9"
+    #     - config=release
+    #     - CC1=gcc
+    #     - CXX1=g++
+    #     - ICC1=gcc-6
+    #     - ICXX1=g++-6
 
     - os: osx
       env:


### PR DESCRIPTION
packages are unavailable for download.

For normal CI, when I can, I'll move to a docker image running on
CircleCI. Need to come up with a more reliable location to get 3.9.1
package from for release builds. I'm trying to grab a couple copies from
them asap so we can figure that out.