### PR TITLE
Validate shellscripts in their own CircleCI job

### DIFF
--- a/.ci-dockerfiles/shellcheck/Dockerfile
+++ b/.ci-dockerfiles/shellcheck/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:17.10
+
+RUN apt-get update \
+  && apt-get install -y \
+    git \
+    shellcheck

--- a/.ci-dockerfiles/shellcheck/README.md
+++ b/.ci-dockerfiles/shellcheck/README.md
@@ -1,0 +1,21 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:shellcheck .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing
+
+```bash
+docker run --name ponyc-ci-shellcheck --rm -i -t ponylang/ponyc-ci:shellcheck bash
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:shellcheck
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ jobs:
     steps:
       - checkout
       - run: changelog-tool verify CHANGELOG.md
+  validate-shell-scripts:
+    docker:
+      - image: ponylang/ponyc-ci:shellcheck
+    steps:
+      - checkout
+      - run: find . -name '*.bash' -exec shellcheck {} \;
   llvm-501-debug:
     docker:
       - image: ponylang/ponyc-ci:llvm-5.0.1
@@ -48,6 +54,7 @@ workflows:
   llvms:
     jobs:
       - verify-changelog
+      - validate-shell-scripts
       - llvm-501-debug
       - llvm-501-release
       - llvm-401-debug

--- a/.travis_install.bash
+++ b/.travis_install.bash
@@ -48,8 +48,6 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
   "osx:llvm-config-3.9")
     brew update
-    brew install shellcheck
-    shellcheck ./.*.bash ./*.bash
 
     brew install pcre2
     brew install libressl
@@ -66,8 +64,6 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
   "osx:llvm-config-4.0")
     brew update
-    brew install shellcheck
-    shellcheck ./.*.bash ./*.bash
 
     brew install pcre2
     brew install libressl
@@ -84,8 +80,6 @@ case "${TRAVIS_OS_NAME}:${LLVM_CONFIG}" in
 
   "osx:llvm-config-5.0")
     brew update
-    brew install shellcheck
-    shellcheck ./.*.bash ./*.bash
 
     brew install pcre2
     brew install libressl


### PR DESCRIPTION
CircleCI jobs are quite quick to fire up. TravisCI jobs on the other
hand are not; particularly MacOS jobs.

This commit moves our shellscript validate from running as part of MacOS
CI jobs to it's own CircleCI job.

This means:

If shellcheck reports and error. Other CI tasks will still run.

Additionally, I updated the logic that runs shellcheck to validate all
'*.bash' files rather than the more limited directory based set of our
previous logic.

No longer will we wait a long time to get MacOS resources on CircleCI
and have it fail because a new addition to a shellscript doesn't pass
shellcheck. In the future, the quick to fire up CircleCI task will fail
and standard MacOS CI tasks can run to completion.