### PR TITLE
Properly report default argument inference errors

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -186,7 +186,7 @@ static bool apply_default_arg(pass_opt_t* opt, ast_t* param, ast_t** argp)
     ast_replace(argp, def_arg);
   }
 
-  if(!expr_seq(opt, *argp))
+  if(!ast_passes_subtree(argp, opt, PASS_EXPR))
     return false;
 
   return true;

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -500,10 +500,7 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_FVAR:
     case TK_FLET:
     case TK_EMBED:      r = expr_field(options, ast); break;
-    case TK_PARAM:
-      if(!expr_param(options, ast))
-        return AST_FATAL; // avoid duplicating error messages for default arg errors
-      break;
+    case TK_PARAM:      r = expr_param(options, ast); break;
     case TK_NEW:
     case TK_BE:
     case TK_FUN:        r = expr_fun(options, ast); break;

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -500,7 +500,10 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
     case TK_FVAR:
     case TK_FLET:
     case TK_EMBED:      r = expr_field(options, ast); break;
-    case TK_PARAM:      r = expr_param(options, ast); break;
+    case TK_PARAM:
+      if(!expr_param(options, ast))
+        return AST_FATAL; // avoid duplicating error messages for default arg errors
+      break;
     case TK_NEW:
     case TK_BE:
     case TK_FUN:        r = expr_fun(options, ast); break;

--- a/test/libponyc/literal_inference.cc
+++ b/test/libponyc/literal_inference.cc
@@ -6,6 +6,9 @@
 #define TEST_ERROR(src) DO(test_error(src, "expr"))
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
 
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
 
 class LiteralTest : public PassTest
 {
@@ -243,7 +246,21 @@ TEST_F(LiteralTest, CantInfer_Let_InsufficientlySpecifiedGeneric)
     "  new create() =>\n"
     "    let x: A = 17";
 
-  TEST_ERROR(src);
+  TEST_ERRORS_1(src, "could not infer literal type, no valid types found");
+}
+
+TEST_F(LiteralTest, CantInfer_DefaultArg_InsufficientlySpecifiedGeneric)
+{
+  const char* src =
+    "class Foo[A]\n"
+    "  new create(field: A = 0) =>\n"
+    "    None\n"
+    "\n"
+    "class Bar\n"
+    "  new create() =>\n"
+    "    let foo = Foo[U16]()";
+
+  TEST_ERRORS_1(src, "could not infer literal type, no valid types found");
 }
 
 


### PR DESCRIPTION
Errors for default arguments could leave the AST in an illegal state,
which was causing assertions when evaluating default args during TK_CALL evaluation in the expr pass.

This PR makes those errors stop compilation immediately, so they are properly reported.

This fixes #2496 

I did not handle `TK_LITERAL` in `uifset` as it seemed to be more of an unwanted state of the AST in general, if such an AST node reaches this function and thus tried to avoid getting into this branch in the first place.