### PR TITLE
Add CircleCI job for testing Pony with OpenSSL 1.1.0

### DIFF
--- a/.ci-dockerfiles/openssl-1.1.0/Dockerfile
+++ b/.ci-dockerfiles/openssl-1.1.0/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+ENV LLVM_VERSION 5.0.1
+
+RUN apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  g++ \
+  git \
+  libncurses5-dev \
+  libpcre2-dev \
+  make \
+  wget \
+  xz-utils \
+  zlib1g-dev \
+ && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
+ | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04
+
+ RUN wget https://www.openssl.org/source/openssl-1.1.0.tar.gz \
+   && tar xf openssl-1.1.0.tar.gz \
+   && cd openssl-1.1.0 \
+   && ./config \
+   && make \
+   && make install \
+   && cd .. \
+   && rm -rf openssl-1.1.0*

--- a/.ci-dockerfiles/openssl-1.1.0/README.md
+++ b/.ci-dockerfiles/openssl-1.1.0/README.md
@@ -1,0 +1,21 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:openssl-1.1.0 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing
+
+```bash
+docker run --name ponyc-ci-openssl-110 --rm -i -t ponylang/ponyc-ci:openssl-1.1.0 bash
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:openssl-1.1.0
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,16 @@ jobs:
     steps:
       - checkout
       - run: make test-ci config=release
+  openssl-110:
+    docker:
+      - image: ponylang/ponyc-ci:openssl-1.1.0
+    steps:
+      - checkout
+      - run: make default_openssl=openssl_1.1.0 test-ci
 
 workflows:
   version: 2
-  llvms:
+  tests:
     jobs:
       - verify-changelog
       - validate-shell-scripts
@@ -61,3 +67,4 @@ workflows:
       - llvm-401-release
       - llvm-391-debug
       - llvm-391-release
+      - openssl-110


### PR DESCRIPTION
Our standard tests all use OpenSSL 0.9. We don't use the full matrix as
we decided that LLVM version shoudn't matter for what these tests might
catch as failures.

Closes #2501