### PR TITLE
Fix LLVM IR verification with DoNotOptimise

### DIFF
--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -473,3 +473,14 @@ EXPORT_SYMBOL char test_custom_serialisation_compare(uint64_t* p1, uint64_t* p2)
 }
 
 }
+
+
+TEST_F(CodegenTest, DoNotOptimiseApplyPrimitive)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    DoNotOptimise[I64](0)";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -120,7 +120,9 @@ static const char* const _builtin =
   "  end\n"
   "interface Iterator[A]\n"
   "  fun ref has_next(): Bool\n"
-  "  fun ref next(): A ?\n";
+  "  fun ref next(): A ?\n"
+  "primitive DoNotOptimise\n"
+  "  fun apply[A](obj: A) => compile_intrinsic";
 
 
 // Check whether the 2 given ASTs are identical
@@ -242,6 +244,7 @@ void PassTest::SetUp()
   package_clear_magic(&opt);
   opt.verbosity = VERBOSITY_QUIET;
   opt.check_tree = true;
+  opt.verify = true;
   opt.allow_test_symbols = true;
   last_pass = PASS_PARSE;
 }


### PR DESCRIPTION
This change fixes a bug where an incorrect attribute was being generated on primitive types used with `DoNotOptimise`.

Closes #2493.