### PR TITLE
Change default_openssl to default_ssl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - image: ponylang/ponyc-ci:openssl-1.1.0
     steps:
       - checkout
-      - run: make default_openssl=openssl_1.1.0 test-ci
+      - run: make default_ssl=openssl_1.1.0 test-ci
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -292,20 +292,20 @@ ifeq ($(runtime-bitcode),yes)
   endif
 endif
 
-# Set default openssl version
-ifdef default_openssl
-  ifeq ("openssl_0.9.0","$(default_openssl)")
-    default_openssl_valid:=ok
+# Set default ssl version
+ifdef default_ssl
+  ifeq ("openssl_0.9.0","$(default_ssl)")
+    default_ssl_valid:=ok
   endif
-  ifeq ("openssl_1.1.0","$(default_openssl)")
-    default_openssl_valid:=ok
+  ifeq ("openssl_1.1.0","$(default_ssl)")
+    default_ssl_valid:=ok
   endif
-  ifeq (ok,$(default_openssl_valid))
-    $(warning default_openssl is $(default_openssl))
+  ifeq (ok,$(default_ssl_valid))
+    $(warning default_ssl is $(default_ssl))
   else
-    $(error default_openssl=$(default_openssl) is invalid, expecting one of openssl_0.9.0 or openssl_1.1.0)
+    $(error default_ssl=$(default_ssl) is invalid, expecting one of openssl_0.9.0 or openssl_1.1.0)
   endif
-  BUILD_FLAGS += -DPONY_DEFAULT_OPENSSL=\"$(default_openssl)\"
+  BUILD_FLAGS += -DPONY_DEFAULT_SSL=\"$(default_ssl)\"
 endif
 
 makefile_abs_path := $(realpath $(lastword $(MAKEFILE_LIST)))
@@ -1019,7 +1019,7 @@ help:
 	@echo
 	@echo 'Compile time default options:'
 	@echo '  default_pic=true     Make --pic the default'
-	@echo '  default_openssl=Name Make Name the default openssl version'
+	@echo '  default_ssl=Name     Make Name the default ssl version'
 	@echo '                       where Name is one of:'
 	@echo '                         openssl_0.9.0'
 	@echo '                         openssl_1.1.0'

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ To build ponyc and compile and helloworld:
 
 ```bash
 cd ~/ponyc/
-make default_pic=true default_openssl='openssl_1.1.0'
+make default_pic=true default_ssl='openssl_1.1.0'
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -18,9 +18,9 @@
 
 #define MAYBE_UNUSED(x) (void)x
 
-#if !defined(PONY_DEFAULT_OPENSSL)
+#if !defined(PONY_DEFAULT_SSL)
 // This default value is defined in packages/crypto and packages/net/ssl
-#define PONY_DEFAULT_OPENSSL "openssl_0.9.0"
+#define PONY_DEFAULT_SSL "openssl_0.9.0"
 #endif
 
 enum
@@ -158,7 +158,7 @@ static void usage(void)
     "    =name          Default is the host architecture.\n"
     "  --linker         Set the linker command to use.\n"
     "    =name          Default is the compiler used to compile ponyc.\n"
-    "  --define, -D     Define which openssl version to use default is " PONY_DEFAULT_OPENSSL "\n"
+    "  --define, -D     Define which openssl version to use default is " PONY_DEFAULT_SSL "\n"
     "    =openssl_1.1.0\n"
     "    =openssl_0.9.0\n"
     ,
@@ -275,7 +275,7 @@ static ponyc_opt_process_t special_opt_processing(pass_opt_t *opt)
   define_build_flag("scheduler_scaling_pthreads");
 #endif
 
-  define_build_flag(PONY_DEFAULT_OPENSSL);
+  define_build_flag(PONY_DEFAULT_SSL);
 
   return CONTINUE;
 }
@@ -300,8 +300,8 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
     {
       case OPT_VERSION:
         printf("%s\n", PONY_VERSION_STR);
-        printf("Defaults: pic=%s openssl=%s\n", opt->pic ? "true" : "false",
-            PONY_DEFAULT_OPENSSL);
+        printf("Defaults: pic=%s ssl=%s\n", opt->pic ? "true" : "false",
+            PONY_DEFAULT_SSL);
         return EXIT_0;
 
       case OPT_HELP:


### PR DESCRIPTION
Changing default_openssl to default_ssl is slightly less verbose and
in the future will allow the possibility of different libraries to be
specified, such as libressl.

Also, change PONY_DEFAULT_OPENSSL to PONY_DEFAULT_SSL.