### PR TITLE
Fix `make test-examples` errors if missing example apps were included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -898,6 +898,7 @@ test: all
 	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
 	@./stdlib --sequential
 	@rm stdlib
+	@make test-examples
 
 test-examples: all
 	@PONYPATH=. $(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,19 @@
+
+## Reminder: when adding/removing/renaming new examples
+
+The `main.pony` source takes advantage of Pony's `use` statement
+to compile all example source code in this directory into a single
+executable.  The final app doesn't do much, but it does force the
+compiler to check all example apps for syntax errors, data type
+errors, reference capability errors, and all other compiler errors
+that should not exist in this collection of Pony code.
+
+Therefore, to avoid `make test-examples` or `test-ci` errors, please do
+the following whenever a new example app is added (or an example
+app is removed or renamed), please:
+
+
+1. Update the `main.pony` source to add/remove/change the name of the app.
+2. Run the `make test-examples` command to verify that all example
+   apps can be compiled cleanly.
+

--- a/examples/main.pony
+++ b/examples/main.pony
@@ -12,10 +12,17 @@ use "ponytest"
 
 // Commented packages are broken at the moment. We have to fix them and
 // then keep the tests green.
+
+// The FFI examples below are commented out beccause they may
+// not link correctly due to one or more missing libraries that
+// our naive Makefile does not know about.
+
 use ex_circle = "circle"
 use ex_commandline = "commandline"
 use ex_counter = "counter"
+// No compilable Pony code inside: use ex_dtrace = "dtrace"
 use ex_echo = "echo"
+// use ex_ffi_callbacks = "ffi-callbacks"
 // use ex_ffi_struct = "ffi-struct"
 use ex_files = "files"
 use ex_gups_basic = "gups_basic"
@@ -31,12 +38,14 @@ use ex_message_ubench = "message-ubench"
 use ex_mixed = "mixed"
 use ex_n_body = "n-body"
 use ex_net = "net"
+use ex_overload = "overload"
 use ex_printargs = "printargs"
 use ex_producer_consumer = "producer-consumer"
 use ex_readline = "readline"
 use ex_ring = "ring"
 use ex_spreader = "spreader"
 use ex_timers = "timers"
+use ex_under_pressure = "under_pressure"
 use ex_yield = "yield"
 
 

--- a/examples/overload/main.pony
+++ b/examples/overload/main.pony
@@ -15,10 +15,10 @@ use "time"
 
 actor Receiver
   var _msgs: U64 = 0
-  let _out: StdStream
+  let _out: OutStream
   var _last: U64 = Time.nanos()
 
-  new create(out: StdStream) =>
+  new create(out: OutStream) =>
     _out = out
     _out.print("Single receiver started.")
 
@@ -52,7 +52,7 @@ actor Main
   be loop() => None
     loop()
 
-  fun ref start_messaging(out: StdStream) =>
+  fun ref start_messaging(out: OutStream) =>
     let r = Receiver(out)
     out.print("Starting " + _size.string() + " senders.")
     for i in Range[U32](0, _size) do

--- a/examples/under_pressure/main.pony
+++ b/examples/under_pressure/main.pony
@@ -62,9 +62,9 @@ use "time"
 
 class SlowDown is TCPConnectionNotify
   let _auth: BackpressureAuth
-  let _out: StdStream
+  let _out: OutStream
 
-  new iso create(auth: BackpressureAuth, out: StdStream) =>
+  new iso create(auth: BackpressureAuth, out: OutStream) =>
     _auth = auth
     _out = out
 


### PR DESCRIPTION
The `examples/main.pony` source, which is used for the
`make test-examples` test, didn't include the relatively
new `examples/under_pressure` and `examples/overload` apps.

This PR fixes:

1. The omission of `under_pressure` and `overload` from the
   `make test-examples` check.  (Plus a few comments in `examples/main.c`.)

2. Add `examples/README.md` in hopes that documentation can help
   avoid repeating the omission problem.

3. Add `make test-examples` to the list of stuff done by the
   `make test-ci` target.

4. Fix the compilation errors in `under_pressure` and `overload`.