### PR TITLE
Give more user control on language features initialisation in pony_start

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -583,10 +583,10 @@ static void init_runtime(compile_t* c)
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,
     inacc_or_arg_mem_attr);
 
-  // i1 pony_start(i1, i1, i32*)
+  // i1 pony_start(i1, i32*, i8*)
   params[0] = c->i1;
-  params[1] = c->i1;
-  params[2] = LLVMPointerType(c->i32, 0);
+  params[1] = LLVMPointerType(c->i32, 0);
+  params[2] = LLVMPointerType(c->i8, 0);
   type = LLVMFunctionType(c->i1, params, 3, false);
   value = LLVMAddFunction(c->module, "pony_start", type);
 

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -446,15 +446,7 @@ void gendesc_init(compile_t* c, reach_type_t* t)
 
 void gendesc_table(compile_t* c)
 {
-  uint32_t object_id_max = (c->reach->object_type_count * 2) + 1;
-  uint32_t numeric_id_max = c->reach->numeric_type_count * 4;
-  uint32_t tuple_id_max = (c->reach->tuple_type_count * 4) + 2;
-
-  uint32_t len = object_id_max;
-  if(len < numeric_id_max)
-    len = numeric_id_max;
-  if(len < tuple_id_max)
-    len = tuple_id_max;
+  uint32_t len = reach_max_type_id(c->reach);
 
   size_t size = len * sizeof(LLVMValueRef);
   LLVMValueRef* args = (LLVMValueRef*)ponyint_pool_alloc_size(size);
@@ -483,24 +475,12 @@ void gendesc_table(compile_t* c)
   }
 
   LLVMTypeRef type = LLVMArrayType(c->descriptor_ptr, len);
-  LLVMValueRef table = LLVMAddGlobal(c->module, type, "__PonyDescTable");
+  LLVMValueRef table = LLVMAddGlobal(c->module, type, "__DescTable");
   LLVMValueRef value = LLVMConstArray(c->descriptor_ptr, args, len);
   LLVMSetInitializer(table, value);
   LLVMSetGlobalConstant(table, true);
   LLVMSetLinkage(table, LLVMPrivateLinkage);
   c->desc_table = table;
-
-  type = LLVMPointerType(type, 0);
-  LLVMValueRef table_ptr = LLVMAddGlobal(c->module, type, "__PonyDescTablePtr");
-  LLVMSetInitializer(table_ptr, table);
-  LLVMSetGlobalConstant(table_ptr, true);
-  LLVMSetDLLStorageClass(table_ptr, LLVMDLLExportStorageClass);
-
-  LLVMValueRef table_size = LLVMAddGlobal(c->module, c->intptr,
-    "__PonyDescTableSize");
-  LLVMSetInitializer(table_size, LLVMConstInt(c->intptr, len, false));
-  LLVMSetGlobalConstant(table_size, true);
-  LLVMSetDLLStorageClass(table_size, LLVMDLLExportStorageClass);
 
   ponyint_pool_free_size(size, args);
 }

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1709,6 +1709,23 @@ uint32_t reach_vtable_index(reach_type_t* t, const char* name)
   return m->vtable_index;
 }
 
+uint32_t reach_max_type_id(reach_t* r)
+{
+  uint32_t object_id_max = (r->object_type_count * 2) + 1;
+  uint32_t numeric_id_max = r->numeric_type_count * 4;
+  uint32_t tuple_id_max = (r->tuple_type_count * 4) + 2;
+
+  uint32_t len = object_id_max;
+
+  if(len < numeric_id_max)
+    len = numeric_id_max;
+
+  if(len < tuple_id_max)
+    len = tuple_id_max;
+
+  return len;
+}
+
 void reach_dump(reach_t* r)
 {
   printf("REACH\n");

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -157,6 +157,8 @@ reach_method_name_t* reach_method_name(reach_type_t* t,
 
 uint32_t reach_vtable_index(reach_type_t* t, const char* name);
 
+uint32_t reach_max_type_id(reach_t* r);
+
 void reach_dump(reach_t* r);
 
 pony_type_t* reach_method_pony_type();

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -81,25 +81,10 @@ static void custom_deserialise(pony_ctx_t* ctx)
   }
 }
 
-bool ponyint_serialise_setup()
+bool ponyint_serialise_setup(pony_type_t** table, size_t table_size)
 {
-#if defined(PLATFORM_IS_POSIX_BASED)
-  void* tbl_size_sym = dlsym(RTLD_DEFAULT, "__PonyDescTableSize");
-  void* tbl_ptr_sym = dlsym(RTLD_DEFAULT, "__PonyDescTablePtr");
-#else
-  HMODULE program = GetModuleHandle(NULL);
-
-  if(program == NULL)
-    return false;
-
-  void* tbl_size_sym = (void*)GetProcAddress(program, "__PonyDescTableSize");
-  void* tbl_ptr_sym = (void*)GetProcAddress(program, "__PonyDescTablePtr");
-#endif
-  if((tbl_size_sym == NULL) || (tbl_ptr_sym == NULL))
-    return false;
-
-  desc_table_size = *(size_t*)tbl_size_sym;
-  desc_table = *(pony_type_t***)tbl_ptr_sym;
+  desc_table = table;
+  desc_table_size = table_size;
 
   return true;
 }

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -23,7 +23,7 @@ typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
 
-bool ponyint_serialise_setup();
+bool ponyint_serialise_setup(pony_type_t** table, size_t table_size);
 
 void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -151,6 +151,34 @@ typedef const struct _pony_type_t
   void* vtable;
 } pony_type_t;
 
+/** Language feature initialiser.
+ *
+ * Contains initialisers for the various language features initialised by
+ * the pony_start() function.
+ */
+typedef struct pony_language_features_init_t
+{
+  /// Network-related initialisers.
+
+  bool init_network;
+
+
+  /// Serialisation-related initialisers.
+
+  bool init_serialisation;
+
+  /** Type descriptor table pointer.
+   *
+   * Should point to an array of type descriptors. For each element in the
+   * array, the id field should correspond to the array index. The array can
+   * contain NULL elements.
+   */
+  pony_type_t** descriptor_table;
+
+  /// The total size of the descriptor_table array.
+  size_t descriptor_table_size;
+} pony_language_features_init_t;
+
 /** Padding for actor types.
  *
  * 56 bytes: initial header, not including the type descriptor
@@ -430,12 +458,14 @@ PONY_API int pony_init(int argc, char** argv);
  * The value pointed by exit_code will not be modified if library is true. Use
  * the return value of pony_stop() in that case.
  *
- * If language_features is false, the features of the runtime specific to the
- * Pony language, such as network or serialisation, won't be initialised.
+ * language_features specifies which features of the runtime specific to the
+ * Pony language, such as network or serialisation, should be initialised.
+ * If language_features is NULL, no feature will be initialised.
  *
  * It is not safe to call this again before the runtime has terminated.
  */
-PONY_API bool pony_start(bool library, bool language_features, int* exit_code);
+PONY_API bool pony_start(bool library, int* exit_code,
+  const pony_language_features_init_t* language_features);
 
 /**
  * Call this to create a pony_ctx_t for a non-scheduler thread. This has to be

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -35,10 +35,19 @@ typedef struct options_t
   bool version;
 } options_t;
 
+typedef enum running_kind_t
+{
+  NOT_RUNNING,
+  RUNNING_DEFAULT,
+  RUNNING_LIBRARY
+} running_kind_t;
+
 // global data
 static PONY_ATOMIC(bool) initialised;
+static PONY_ATOMIC(running_kind_t) running;
 static PONY_ATOMIC(int) rt_exit_code;
-static bool language_init;
+
+static pony_language_features_init_t language_init;
 
 enum
 {
@@ -108,12 +117,17 @@ static int parse_opts(int argc, char** argv, options_t* opt)
 PONY_API int pony_init(int argc, char** argv)
 {
   bool prev_init = atomic_exchange_explicit(&initialised, true,
-    memory_order_acquire);
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_AFTER(&initialised);
-#endif
+    memory_order_relaxed);
   (void)prev_init;
   pony_assert(!prev_init);
+  pony_assert(
+    atomic_load_explicit(&running, memory_order_relaxed) == NOT_RUNNING);
+
+  atomic_thread_fence(memory_order_acquire);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&initialised);
+  ANNOTATE_HAPPENS_AFTER(&running);
+#endif
 
   DTRACE0(RT_INIT);
   options_t opt;
@@ -150,39 +164,66 @@ PONY_API int pony_init(int argc, char** argv)
   return argc;
 }
 
-PONY_API bool pony_start(bool library, bool language_features, int* exit_code)
+PONY_API bool pony_start(bool library, int* exit_code,
+  const pony_language_features_init_t* language_features)
 {
   pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
 
-  if(language_features)
+  // Set to RUNNING_DEFAULT even if library is true so that pony_stop() isn't
+  // callable until the runtime has actually started.
+  running_kind_t prev_running = atomic_exchange_explicit(&running,
+    RUNNING_DEFAULT, memory_order_relaxed);
+  (void)prev_running;
+  pony_assert(prev_running == NOT_RUNNING);
+
+  if(language_features != NULL)
   {
-    if(!ponyint_os_sockets_init())
-      return false;
+    memcpy(&language_init, language_features,
+      sizeof(pony_language_features_init_t));
 
-    if(!ponyint_serialise_setup())
+    if(language_init.init_network && !ponyint_os_sockets_init())
+    {
+      atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
       return false;
+    }
 
-    language_init = true;
+    if(language_init.init_serialisation &&
+      !ponyint_serialise_setup(language_init.descriptor_table,
+        language_init.descriptor_table_size))
+    {
+      atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
+      return false;
+    }
+  } else {
+    memset(&language_init, 0, sizeof(pony_language_features_init_t));
   }
 
   if(!ponyint_sched_start(library))
+  {
+    atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
     return false;
+  }
 
   if(library)
-    return true;
-
-  if(language_init)
   {
-    ponyint_os_sockets_final();
-    language_init = false;
+#ifdef USE_VALGRIND
+    ANNOTATE_HAPPENS_BEFORE(&running);
+#endif
+    atomic_store_explicit(&running, RUNNING_LIBRARY, memory_order_release);
+    return true;
   }
+
+  if(language_init.init_network)
+    ponyint_os_sockets_final();
 
   int ec = pony_get_exitcode();
 #ifdef USE_VALGRIND
   ANNOTATE_HAPPENS_BEFORE(&initialised);
+  ANNOTATE_HAPPENS_BEFORE(&running);
 #endif
   atomic_thread_fence(memory_order_acq_rel);
   atomic_store_explicit(&initialised, false, memory_order_relaxed);
+  atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
 
   if(exit_code != NULL)
     *exit_code = ec;
@@ -194,19 +235,27 @@ PONY_API int pony_stop()
 {
   pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
 
+  running_kind_t loc_running = atomic_load_explicit(&running,
+    memory_order_acquire);
+#ifdef USE_VALGRIND
+  ANNOTATE_HAPPENS_AFTER(&running);
+#endif
+  (void)loc_running;
+  pony_assert(loc_running == RUNNING_LIBRARY);
+
   ponyint_sched_stop();
-  if(language_init)
-  {
+
+  if(language_init.init_network)
     ponyint_os_sockets_final();
-    language_init = false;
-  }
 
   int ec = pony_get_exitcode();
 #ifdef USE_VALGRIND
   ANNOTATE_HAPPENS_BEFORE(&initialised);
+  ANNOTATE_HAPPENS_BEFORE(&running);
 #endif
   atomic_thread_fence(memory_order_acq_rel);
   atomic_store_explicit(&initialised, false, memory_order_relaxed);
+  atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
   return ec;
 }
 

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -20,14 +20,6 @@
 using std::string;
 
 
-// These will be set when running a JIT'ed program.
-extern "C"
-{
-  EXPORT_SYMBOL pony_type_t** __PonyDescTablePtr;
-  EXPORT_SYMBOL size_t __PonyDescTableSize;
-}
-
-
 static const char* const _builtin =
   "primitive U8 is Real[U8]\n"
   "  new create(a: U8 = 0) => a\n"
@@ -478,10 +470,7 @@ bool PassTest::run_program(int* exit_code)
   pony_assert(compile != NULL);
 
   pony_exitcode(0);
-  jit_symbol_t symbols[] = {
-    {"__PonyDescTablePtr", &__PonyDescTablePtr, sizeof(pony_type_t**)},
-    {"__PonyDescTableSize", &__PonyDescTableSize, sizeof(size_t)}};
-  return gen_jit_and_run(compile, exit_code, symbols, 2);
+  return gen_jit_and_run(compile, exit_code, NULL, 0);
 }
 
 


### PR DESCRIPTION
Individual features can now be initialised separately and the user can specify a type descriptor array to be used for serialisation. The latter change allows us to remove the usage of `dlsym` to find the type descriptor array.