### PR TITLE
Remove exception parameterisation from serialisation

### DIFF
--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -92,9 +92,8 @@ class val Serialised
       @{(ctx: Pointer[None], size: USize): Pointer[None] =>
         @pony_alloc[Pointer[None]](ctx, size)
       }
-    let throw_fn = @{() ? => error }
     @pony_serialise[None](@pony_ctx[Pointer[None]](), data, Pointer[None], r,
-      alloc_fn, throw_fn) ?
+      alloc_fn) ?
     _data = consume r
 
   new input(auth: InputSerialisedAuth, data: Array[U8] val) =>
@@ -120,9 +119,8 @@ class val Serialised
       @{(ctx: Pointer[None], size: USize): Pointer[None] =>
         @pony_alloc_final[Pointer[None]](ctx, size)
       }
-    let throw_fn = @{() ? => error }
     @pony_deserialise[Any iso^](@pony_ctx[Pointer[None]](), Pointer[None], _data,
-      alloc_fn, alloc_final_fn, throw_fn) ?
+      alloc_fn, alloc_final_fn) ?
 
   fun output(auth: OutputSerialisedAuth): Array[U8] val =>
     """

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -1558,12 +1558,6 @@ static void* s_alloc_fn(pony_ctx_t* ctx, size_t size)
 }
 
 
-static void s_throw_fn()
-{
-  pony_assert(false);
-}
-
-
 // TODO: Make group signature indiependent of package load order.
 const char* package_group_signature(package_group_t* group)
 {
@@ -1576,7 +1570,7 @@ const char* package_group_signature(package_group_t* group)
     char* buf = (char*)ponyint_pool_alloc_size(SIGNATURE_LENGTH);
 
     pony_serialise(&ctx, group, package_group_signature_pony_type(), &array,
-      s_alloc_fn, s_throw_fn);
+      s_alloc_fn);
     int status = blake2b(buf, SIGNATURE_LENGTH, array.ptr, array.size, NULL, 0);
     (void)status;
     pony_assert(status == 0);

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -15,8 +15,6 @@ typedef struct
 
 typedef void* (*serialise_alloc_fn)(pony_ctx_t* ctx, size_t size);
 
-typedef void (*serialise_throw_fn)();
-
 typedef void* (*deserialise_raw_fn)(void* buf, size_t remaining_size);
 
 typedef struct serialise_t serialise_t;
@@ -31,14 +29,13 @@ void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_serialise_actor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  ponyint_array_t* out, serialise_alloc_fn alloc_fn,
-  serialise_throw_fn throw_fn);
+  ponyint_array_t* out, serialise_alloc_fn alloc_fn);
 PONY_API size_t pony_serialise_offset(pony_ctx_t* ctx, void* p);
 PONY_API void pony_serialise_reserve(pony_ctx_t* ctx, void* p, size_t size);
 
 PONY_API void* pony_deserialise(pony_ctx_t* ctx, pony_type_t* t,
   ponyint_array_t* in, serialise_alloc_fn alloc_fn,
-  serialise_alloc_fn alloc_final_fn, serialise_throw_fn throw_fn);
+  serialise_alloc_fn alloc_final_fn);
 PONY_API void* pony_deserialise_block(pony_ctx_t* ctx, uintptr_t offset,
   size_t size);
 PONY_API void* pony_deserialise_offset(pony_ctx_t* ctx, pony_type_t* t,

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -46,7 +46,6 @@ typedef struct pony_ctx_t
   ponyint_serialise_t serialise;
   serialise_alloc_fn serialise_alloc;
   serialise_alloc_fn serialise_alloc_final;
-  serialise_throw_fn serialise_throw;
 } pony_ctx_t;
 
 struct scheduler_t

--- a/test/libponyc/compiler_serialisation.cc
+++ b/test/libponyc/compiler_serialisation.cc
@@ -40,11 +40,6 @@ static void* s_alloc_fn(pony_ctx_t* ctx, size_t size)
   return ponyint_pool_alloc_size(size);
 }
 
-static void s_throw_fn()
-{
-  throw std::exception{};
-}
-
 struct pool_size_deleter
 {
   size_t size;
@@ -99,11 +94,11 @@ void CompilerSerialisationTest::test_pass_ast(const char* pass)
   ponyint_array_t array;
   memset(&array, 0, sizeof(ponyint_array_t));
 
-  pony_serialise(&ctx, program, ast_pony_type(), &array, s_alloc_fn, s_throw_fn);
+  pony_serialise(&ctx, program, ast_pony_type(), &array, s_alloc_fn);
   auto array_guard = manage_array(array);
   std::unique_ptr<ast_t, ast_deleter> new_guard{
     (ast_t*)pony_deserialise(&ctx, ast_pony_type(), &array, s_alloc_fn,
-      s_alloc_fn, s_throw_fn)};
+      s_alloc_fn)};
 
   ast_t* new_program = new_guard.get();
 
@@ -139,12 +134,12 @@ void CompilerSerialisationTest::test_pass_reach(const char* pass)
   ponyint_array_t array;
   memset(&array, 0, sizeof(ponyint_array_t));
 
-  pony_serialise(&ctx, r, reach_pony_type(), &array, s_alloc_fn, s_throw_fn);
+  pony_serialise(&ctx, r, reach_pony_type(), &array, s_alloc_fn);
   auto array_guard = manage_array(array);
   array_guard.get_deleter().size = array.size;
   std::unique_ptr<reach_t, reach_deleter> new_guard{
     (reach_t*)pony_deserialise(&ctx, reach_pony_type(), &array, s_alloc_fn,
-      s_alloc_fn, s_throw_fn)};
+      s_alloc_fn)};
 
   reach_t* new_r = new_guard.get();
 

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -429,18 +429,17 @@ TEST_F(HashMapTest, Serialisation)
       (void)ctx;
       return ponyint_pool_alloc_size(size);
     };
-  auto throw_fn = [](){throw std::exception{}; };
 
   pony_ctx_t ctx;
   memset(&ctx, 0, sizeof(pony_ctx_t));
   ponyint_array_t array;
   memset(&array, 0, sizeof(ponyint_array_t));
 
-  pony_serialise(&ctx, &_map, testmap_pony_type(), &array, alloc_fn, throw_fn);
+  pony_serialise(&ctx, &_map, testmap_pony_type(), &array, alloc_fn);
   auto array_guard = manage_array(array);
   std::unique_ptr<testmap_t, testmap_deleter> out_guard{
     (testmap_t*)pony_deserialise(&ctx, testmap_pony_type(), &array, alloc_fn,
-      alloc_fn, throw_fn)};
+      alloc_fn)};
 
   testmap_t* out = out_guard.get();
 


### PR DESCRIPTION
This change removes the possibility to define custom exception functions when serialising object graphs. The previous behaviour, which is to always raise Pony errors, has been re-implemented.

Now that we have the `pony_try` function and that we know that a C++ catch-all clause can catch Pony errors, we don't need exception parameterisation.