### PR TITLE
Correctly use pony_assert in the runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,9 +441,6 @@ ifneq (,$(filter $(OSTYPE), osx bsd))
 endif
 
 # target specific build options
-libponyrt.buildoptions = -DPONY_NO_ASSERT
-libponyrt-pic.buildoptions = -DPONY_NO_ASSERT
-
 libponyrt.tests.linkoptions += -rdynamic
 
 ifneq ($(ALPINE),)
@@ -453,10 +450,12 @@ endif
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS
+libponyc.buildoptions += -DPONY_ALWAYS_ASSERT
 
 libponyc.tests.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.tests.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.tests.buildoptions += -D__STDC_LIMIT_MACROS
+libponyc.tests.buildoptions += -DPONY_ALWAYS_ASSERT
 libponyc.tests.buildoptions += -DPONY_PACKAGES_DIR=\"$(packages_abs_src)\"
 
 libponyc.tests.linkoptions += -rdynamic

--- a/src/common/ponyassert.h
+++ b/src/common/ponyassert.h
@@ -2,12 +2,15 @@
 #define PLATFORM_PONYASSERT_H
 
 #include "platform.h"
-#include <assert.h>
 
 PONY_EXTERN_C_BEGIN
 
-#if defined(PONY_NO_ASSERT)
-#  define pony_assert(expr) assert(expr)
+#if !defined(PONY_NDEBUG) && !defined(PONY_ALWAYS_ASSERT) && defined(NDEBUG)
+#  define PONY_NDEBUG
+#endif
+
+#if defined(PONY_NDEBUG)
+#  define pony_assert(expr) ((void)0)
 #else
 #  define pony_assert(expr) \
     ((expr) ? (void)0 : \

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -72,7 +72,7 @@ struct ast_t
   ast_t* sibling;
   ast_t* annotation_type;
   uint32_t flags;
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+#ifndef PONY_NDEBUG
   bool frozen;
 #endif
 };
@@ -1591,7 +1591,7 @@ bool ast_is_frozen(ast_t* ast)
 {
   pony_assert(ast != NULL);
 
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+#ifndef PONY_NDEBUG
   return ast->frozen;
 #else
   return false;
@@ -1600,7 +1600,8 @@ bool ast_is_frozen(ast_t* ast)
 
 void ast_freeze(ast_t* ast)
 {
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  (void)ast;
+#ifndef PONY_NDEBUG
   if((ast == NULL) || ast->frozen)
     return;
 
@@ -2260,7 +2261,7 @@ static void ast_serialise(pony_ctx_t* ctx, void* object, void* buf,
   dst->sibling = (ast_t*)pony_serialise_offset(ctx, ast->sibling);
   dst->annotation_type = (ast_t*)pony_serialise_offset(ctx, ast->annotation_type);
   dst->flags = ast->flags;
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+#ifndef PONY_NDEBUG
   dst->frozen = ast->frozen;
 #endif
 }

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -28,7 +28,7 @@ struct token_t
     lexint_t integer;
   };
 
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+#ifndef PONY_NDEBUG
   bool frozen;
 #endif
 };
@@ -94,7 +94,8 @@ void token_free(token_t* token)
 
 void token_freeze(token_t* token)
 {
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+  (void)token;
+#ifndef PONY_NDEBUG
   pony_assert(token != NULL);
   token->frozen = true;
 #endif
@@ -498,7 +499,7 @@ static void token_serialise(pony_ctx_t* ctx, void* object, void* buf,
   dst->line = token->line;
   dst->pos = token->pos;
   dst->printed = NULL;
-#if !defined(NDEBUG) || !defined(PONY_NO_ASSERT)
+#ifndef PONY_NDEBUG
   dst->frozen = token->frozen;
 #endif
 

--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -326,7 +326,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
 
 void check_tree(ast_t* tree, pass_opt_t* opt)
 {
-#ifdef NDEBUG
+#ifdef PONY_NDEBUG
   // Keep compiler happy in release builds.
   (void)tree;
   (void)opt;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -1164,7 +1164,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
 
     size_t index = HASHMAP_UNKNOWN;
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
     ffi_decl_t k;
     k.func = func;
 

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -354,6 +354,12 @@ static bool link_exe(compile_t* c, ast_t* program,
 #ifdef PONY_USE_LTO
     "-flto -fuse-linker-plugin "
 #endif
+// The use of NDEBUG instead of PONY_NDEBUG here is intentional.
+#ifndef NDEBUG
+    // Allows the implementation of `pony_assert` to correctly get symbol names
+    // for backtrace reporting.
+    "-rdynamic "
+#endif
     "%s %s %s %s -lpthread %s %s %s -lm",
     linker, file_exe, arch, mcx16_arg, atomic, fuseld, file_o, lib_args,
     dtrace_args, ponyrt, ldl

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -859,7 +859,7 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
         // Only one bare method per bare type.
         pony_assert(bare_method == NULL);
         bare_method = member;
-#ifdef NDEBUG
+#ifdef PONY_NDEBUG
         break;
 #endif
       }

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -43,7 +43,7 @@ static void unset_flag(pony_actor_t* actor, uint8_t flag)
     memory_order_relaxed);
 }
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
 static bool well_formed_msg_chain(pony_msg_t* first, pony_msg_t* last)
 {
   // A message chain is well formed if last is reachable from first and is the
@@ -468,7 +468,7 @@ PONY_API pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id)
   pony_msg_t* msg = (pony_msg_t*)ponyint_pool_alloc(index);
   msg->index = index;
   msg->id = id;
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
   atomic_store_explicit(&msg->next, NULL, memory_order_relaxed);
 #endif
 

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -10,7 +10,7 @@
 #include <valgrind/helgrind.h>
 #endif
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
 
 static size_t messageq_size_debug(messageq_t* q)
 {
@@ -88,7 +88,7 @@ void ponyint_messageq_init(messageq_t* q)
     memory_order_relaxed);
   q->tail = stub;
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
   messageq_size_debug(q);
 #endif
 }

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -727,7 +727,7 @@ static void final(pony_ctx_t* ctx, pony_actor_t* self)
   ponyint_perceivedmap_destroy(&d->perceived);
 }
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
 
 static void dump_view(view_t* view)
 {
@@ -840,7 +840,7 @@ static void cycle_dispatch(pony_ctx_t* ctx, pony_actor_t* self,
       break;
     }
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
     default:
     {
       // Never happens, used to keep debug functions.

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -34,7 +34,7 @@ static void node_free(mpmcq_node_t* node)
   POOL_FREE(mpmcq_node_t, node);
 }
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
 
 static size_t mpmcq_size_debug(mpmcq_t* q)
 {
@@ -69,7 +69,7 @@ void ponyint_mpmcq_init(mpmcq_t* q)
   atomic_store_explicit(&q->tail, node, memory_order_relaxed);
 #endif
 
-#ifndef NDEBUG
+#ifndef PONY_NDEBUG
   mpmcq_size_debug(q);
 #endif
 }

--- a/wscript
+++ b/wscript
@@ -293,6 +293,7 @@ def build(ctx):
         source    = ctx.path.ant_glob('src/libponyc/**/*.c') + \
                     ctx.path.ant_glob('src/libponyc/**/*.cc'),
         includes  = [ 'src/common', 'lib/blake2' ] + llvmIncludes + sslIncludes,
+        defines   = [ 'PONY_ALWAYS_ASSERT' ],
         use       = [ 'blake2' ]
     )
 
@@ -312,8 +313,7 @@ def build(ctx):
         target   = 'libponyrt',
         source   = ctx.path.ant_glob('src/libponyrt/**/*.c') + \
                    ctx.path.ant_glob('src/libponyrt/**/*.ll'),
-        includes = [ 'src/common', 'src/libponyrt' ] + sslIncludes,
-        defines  = [ 'PONY_NO_ASSERT' ]
+        includes = [ 'src/common', 'src/libponyrt' ] + sslIncludes
     )
 
     # libponyrt.benchmarks
@@ -332,6 +332,7 @@ def build(ctx):
         target    = 'ponyc',
         source    = ctx.path.ant_glob('src/ponyc/**/*.c'),
         includes  = [ 'src/common' ],
+        defines   = [ 'PONY_ALWAYS_ASSERT' ],
         use       = [ 'libponyc', 'libponyrt' ],
         lib       = llvmLibs + ctx.env.PONYC_EXTRA_LIBS
     )
@@ -350,6 +351,7 @@ def build(ctx):
         includes  = [ 'src/common', 'src/libponyc', 'src/libponyrt',
                       'lib/gtest' ] + llvmIncludes,
         defines   = [
+            'PONY_ALWAYS_ASSERT',
             'PONY_PACKAGES_DIR="' + packagesDir.replace('\\', '\\\\') + '"',
             '_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING'
         ],


### PR DESCRIPTION
Previously, `pony_assert` was forwarding to `assert` when used in libponyrt due to the way the `PONY_NO_ASSERT` macro was being used.

This change removes the `PONY_NO_ASSERT` macro and adds two new macros: `PONY_ALWAYS_ASSERT` and `PONY_NDEBUG`.

- `PONY_ALWAYS_ASSERT` is the opposite of the `PONY_NO_ASSERT` macro. It is defined by the build system for libponyc.
- `PONY_NDEBUG` is defined when `NDEBUG` is defined and `PONY_ALWAYS_ASSERT` isn't defined. When `PONY_NDEBUG` is defined, `pony_assert` becomes a noop.

This change results in the following behaviour:

- In libponyrt debug, `pony_assert`s are checked.
- In libponyrt release, `pony_assert`s aren't checked.
- In libponyc, `pony_assert`s are always checked.