### PR TITLE
cleanup build files after doc generation merge

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,7 +60,6 @@ build_script:
       copy $builddir\ponyrt.* "${ponydir}\ponyc\bin"
       copy $builddir\*.lib "${ponydir}\ponyc\bin"
       copy -recurse packages "${ponydir}\packages"
-      copy -recurse ".docs" "${ponydir}\docs-support"
       7z a -tzip "C:\projects\ponyc\${ponydir}.zip" "${ponydir}"
 
 artifacts:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ COPY src      /src/ponyc/src
 COPY lib      /src/ponyc/lib
 COPY test     /src/ponyc/test
 COPY packages /src/ponyc/packages
-COPY .docs    /src/ponyc/.docs
 
 RUN make arch=x86-64 tune=intel \
  && make install \

--- a/Makefile
+++ b/Makefile
@@ -784,7 +784,6 @@ else
 install: libponyc libponyrt ponyc
 endif
 	@mkdir -p $(destdir)/bin
-	@mkdir -p $(destdir)/docs-support
 	@mkdir -p $(destdir)/lib
 	@mkdir -p $(destdir)/include/pony/detail
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.a $(destdir)/lib
@@ -802,7 +801,6 @@ endif
 	$(SILENT)cp src/libponyrt/pony.h $(destdir)/include
 	$(SILENT)cp src/common/pony/detail/atomics.h $(destdir)/include/pony/detail
 	$(SILENT)cp -r packages $(destdir)/
-	$(SILENT)cp -r .docs/* $(destdir)/docs-support/
 ifeq ($$(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -905,7 +903,6 @@ test-ci: all
 
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs --pass expr
-	$(SILENT)cp .docs/extra.js stdlib-docs/docs/
 
 docs-online: docs
 	$(SILENT)$(SED_INPLACE) 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
@@ -922,7 +919,6 @@ deploy: test docs
 	@mkdir -p $(package)/usr/include/pony/detail
 	@mkdir -p $(package)/usr/lib
 	@mkdir -p $(package)/usr/lib/pony/$(package_version)/bin
-	@mkdir -p $(package)/usr/lib/pony/$(package_version)/docs-support
 	@mkdir -p $(package)/usr/lib/pony/$(package_version)/include/pony/detail
 	@mkdir -p $(package)/usr/lib/pony/$(package_version)/lib
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyc.a $(package)/usr/lib/pony/$(package_version)/lib
@@ -953,7 +949,6 @@ endif
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/bin/ponyc $(package)/usr/bin/ponyc
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/include/pony.h $(package)/usr/include/pony.h
 	$(SILENT)ln -f -s /usr/lib/pony/$(package_version)/include/pony/detail/atomics.h $(package)/usr/include/pony/detail/atomics.h
-	$(SILENT)cp -r .docs/* $(package)/usr/lib/pony/$(package_version)/docs-support/
 	$(SILENT)cp -r packages $(package)/usr/lib/pony/$(package_version)/
 	$(SILENT)fpm -s dir -t deb -C $(package) -p build/bin --name $(package_name) --conflicts "ponyc-master" --conflicts "ponyc-release" --version $(package_base_version) --description "The Pony Compiler" --provides "ponyc" --provides "ponyc-release"
 	$(SILENT)fpm -s dir -t rpm -C $(package) -p build/bin --name $(package_name) --conflicts "ponyc-master" --conflicts "ponyc-release" --version $(package_base_version) --description "The Pony Compiler" --provides "ponyc" --provides "ponyc-release" --depends "ponydep-ncurses"


### PR DESCRIPTION
We forgot to remove some lines dealing with extra files that have been required in order to build the docs.
They got deleted but not all build files have been updated.

This is hereby done.

fixes #2537 