### PR TITLE
Update sample code in ProcessMonitor documentation

### DIFF
--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -34,8 +34,8 @@ actor Main
       vars.push("PATH=/bin")
       // create a ProcessMonitor and spawn the child process
       let auth = env.root as AmbientAuth
-      let pm: ProcessMonitor = ProcessMonitor(auth, consume notifier, path,
-      consume args, consume vars)
+      let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
+      path, consume args, consume vars)
       // write to STDIN of the child process
       pm.write("one, two, three")
       pm.done_writing() // closing stdin allows cat to terminate


### PR DESCRIPTION
In 1104a6ccc182d94e3ec25afa4a2d028d6c642cc4 an extra BackpressureAuth
parameter was added to ProcessMonitor::create(), but the sample code
was not updated.

[skip ci]