### PR TITLE
Add Ubuntu Artful section to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,28 @@ make
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```
+### Ubuntu Artful
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential git zlib1g-dev libncurses5-dev libssl-dev libpcre2-dev llvm-3.9
+```
+
+Clone the ponyc repo:
+
+```bash
+cd ~/
+git clone https://github.com/ponylang/ponyc.git
+```
+
+Build ponyc, compile and run helloworld:
+
+```bash
+cd ~/ponyc/
+make default_pic=true
+./build/release/ponyc examples/helloworld
+./helloworld
+```
 
 ### Fedora (25)
 


### PR DESCRIPTION
Build instructions for Ubuntu Xenial didn't work for me and needed an extra parameter. Added a section to the README.