### PR TITLE
Refactor identity code generation to avoid closed-world assumptions

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -896,7 +896,6 @@ bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt,
 
     reach(c->reach, main_ast, c->str_create, NULL, opt);
     reach(c->reach, env_ast, c->str__create, NULL, opt);
-    reach_done(c->reach, c->opt);
 
     ast_free(main_ast);
     ast_free(env_ast);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -493,7 +493,6 @@ bool genexe(compile_t* c, ast_t* program)
     fprintf(stderr, " Reachability\n");
   reach(c->reach, main_ast, c->str_create, NULL, c->opt);
   reach(c->reach, env_ast, c->str__create, NULL, c->opt);
-  reach_done(c->reach, c->opt);
 
   if(c->opt->limit == PASS_REACH)
   {

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -11,6 +11,10 @@
 #include "ponyassert.h"
 #include <string.h>
 
+static LLVMValueRef tuple_is_box(compile_t* c, ast_t* left_type,
+  reach_type_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value,
+  LLVMValueRef r_desc, bool rhs_boxed, bool check_cardinality);
+
 static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
   ast_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value);
 
@@ -108,47 +112,293 @@ static LLVMValueRef raw_is_box(compile_t* c, ast_t* left_type,
   return phi;
 }
 
-static LLVMValueRef tuple_is_box(compile_t* c, ast_t* left_type,
-  reach_type_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value)
+static LLVMValueRef tuple_element_is_box_unboxed_element(compile_t* c,
+  ast_t* l_field_type, LLVMValueRef l_field, LLVMValueRef r_field,
+  LLVMValueRef r_field_desc, int field_kind)
 {
-  pony_assert(LLVMGetTypeKind(LLVMTypeOf(r_value)) == LLVMPointerTypeKind);
+  LLVMValueRef zero = LLVMConstInt(c->i1, 0, false);
 
-  LLVMValueRef r_desc = gendesc_fetch(c, r_value);
-  LLVMValueRef r_typeid = gendesc_typeid(c, r_desc);
+  LLVMBasicBlockRef num_block = codegen_block(c, "is_tuple_num");
+  LLVMBasicBlockRef bothnum_block = NULL;
 
-  LLVMBasicBlockRef entry_block = LLVMGetInsertBlock(c->builder);
+  if(field_kind == SUBTYPE_KIND_NUMERIC)
+    bothnum_block = codegen_block(c, "is_tuple_bothnum");
+
+  LLVMBasicBlockRef tuple_block = codegen_block(c, "is_tuple_tuple");
+  LLVMBasicBlockRef nonbox_block = codegen_block(c, "is_tuple_nonbox");
   LLVMBasicBlockRef post_block = codegen_block(c, "is_tuple_post");
-  LLVMValueRef type_switch = LLVMBuildSwitch(c->builder, r_typeid,
-    post_block, 0);
+  LLVMValueRef boxed_mask = LLVMConstInt(c->i32, 3, false);
+
+  LLVMValueRef r_field_typeid = gendesc_typeid(c, r_field_desc);
+  LLVMValueRef boxed = LLVMBuildAnd(c->builder, r_field_typeid, boxed_mask,
+    "");
+  LLVMValueRef box_switch = LLVMBuildSwitch(c->builder, boxed, nonbox_block, 0);
+  LLVMAddCase(box_switch, LLVMConstInt(c->i32, 0, false), num_block);
+  LLVMAddCase(box_switch, LLVMConstInt(c->i32, 2, false), tuple_block);
+
   LLVMPositionBuilderAtEnd(c->builder, post_block);
   LLVMValueRef phi = LLVMBuildPhi(c->builder, c->i1, "");
 
-  size_t cardinality = ast_childcount(left_type);
-  reach_type_t* right;
-  size_t i = HASHMAP_BEGIN;
+  LLVMPositionBuilderAtEnd(c->builder, num_block);
 
-  while((right = reach_type_cache_next(&right_type->subtypes, &i)) != NULL)
+  switch(field_kind)
   {
-    if((ast_id(right->ast_cap) != TK_TUPLETYPE) ||
-      (ast_childcount(right->ast_cap) != cardinality))
-      continue;
+    case SUBTYPE_KIND_NUMERIC:
+    {
+      compile_type_t* c_t_left =
+        (compile_type_t*)reach_type(c->reach, l_field_type)->c_type;
+      LLVMValueRef l_desc = LLVMBuildBitCast(c->builder, c_t_left->desc,
+        c->descriptor_ptr, "");
+      LLVMValueRef same_type = LLVMBuildICmp(c->builder, LLVMIntEQ, l_desc,
+        r_field_desc, "");
+      LLVMBuildCondBr(c->builder, same_type, bothnum_block, post_block);
+      LLVMAddIncoming(phi, &zero, &num_block, 1);
 
-    LLVMBasicBlockRef reltype_block = codegen_block(c, "is_reltype");
-    LLVMAddCase(type_switch, LLVMConstInt(c->i32, right->type_id, false),
-      reltype_block);
-    LLVMPositionBuilderAtEnd(c->builder, reltype_block);
+      LLVMPositionBuilderAtEnd(c->builder, bothnum_block);
+      LLVMValueRef r_ptr = LLVMBuildBitCast(c->builder, r_field,
+        LLVMPointerType(c_t_left->mem_type, 0), "");
+      LLVMValueRef r_value = LLVMBuildLoad(c->builder, r_ptr, "");
+      r_value = gen_assign_cast(c, c_t_left->use_type, r_value, l_field_type);
+      LLVMValueRef same_identity = gen_is_value(c, l_field_type, l_field_type,
+        l_field, r_value);
+      LLVMBuildBr(c->builder, post_block);
+      pony_assert(LLVMGetInsertBlock(c->builder) == bothnum_block);
+      LLVMAddIncoming(phi, &same_identity, &bothnum_block, 1);
+      break;
+    }
 
-    LLVMValueRef r_unbox = gen_unbox(c, right->ast_cap, r_value);
-    LLVMValueRef is = tuple_is(c, left_type, right->ast_cap, l_value, r_unbox);
-    LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
-    LLVMAddIncoming(phi, &is, &this_block, 1);
-    LLVMBuildBr(c->builder, post_block);
+    default:
+    {
+      LLVMBuildBr(c->builder, post_block);
+      LLVMAddIncoming(phi, &zero, &num_block, 1);
+      break;
+    }
+  }
+
+  LLVMPositionBuilderAtEnd(c->builder, tuple_block);
+
+  switch(field_kind)
+  {
+    case SUBTYPE_KIND_TUPLE:
+    {
+      LLVMValueRef same_identity = tuple_is_box(c, l_field_type, NULL, l_field,
+        r_field, r_field_desc, false, true);
+      LLVMBuildBr(c->builder, post_block);
+      LLVMBasicBlockRef cur_block = LLVMGetInsertBlock(c->builder);
+      LLVMAddIncoming(phi, &same_identity, &cur_block, 1);
+      break;
+    }
+
+    default:
+    {
+      LLVMBuildBr(c->builder, post_block);
+      LLVMAddIncoming(phi, &zero, &tuple_block, 1);
+      break;
+    }
+  }
+
+  LLVMMoveBasicBlockAfter(nonbox_block, LLVMGetInsertBlock(c->builder));
+  LLVMPositionBuilderAtEnd(c->builder, nonbox_block);
+
+  switch(field_kind)
+  {
+    case SUBTYPE_KIND_UNBOXED:
+    {
+      LLVMValueRef l_object = LLVMBuildBitCast(c->builder, l_field,
+        c->object_ptr, "");
+      LLVMValueRef r_object = LLVMBuildLoad(c->builder, r_field, "");
+      LLVMValueRef same_identity = LLVMBuildICmp(c->builder, LLVMIntEQ,
+        l_object, r_object, "");
+      LLVMBuildBr(c->builder, post_block);
+      LLVMAddIncoming(phi, &same_identity, &nonbox_block, 1);
+      break;
+    }
+
+    default:
+    {
+      LLVMBuildBr(c->builder, post_block);
+      LLVMAddIncoming(phi, &zero, &nonbox_block, 1);
+      break;
+    }
   }
 
   LLVMMoveBasicBlockAfter(post_block, LLVMGetInsertBlock(c->builder));
   LLVMPositionBuilderAtEnd(c->builder, post_block);
+  return phi;
+}
+
+static LLVMValueRef tuple_is_box_element(compile_t* c, ast_t* l_field_type,
+  LLVMValueRef l_field, LLVMValueRef r_fields, LLVMValueRef r_desc,
+  unsigned int field_index)
+{
+  int field_kind = SUBTYPE_KIND_UNBOXED;
+
+  if((ast_id(l_field_type) == TK_TUPLETYPE))
+    field_kind = SUBTYPE_KIND_TUPLE;
+  else if(is_machine_word(l_field_type))
+    field_kind = SUBTYPE_KIND_NUMERIC;
+
+  LLVMValueRef r_field_info = gendesc_fieldinfo(c, r_desc, field_index);
+  LLVMValueRef r_field_ptr = gendesc_fieldptr(c, r_fields, r_field_info);
+  LLVMValueRef r_field_desc = gendesc_fielddesc(c, r_field_info);
+
+  LLVMTypeRef obj_ptr_ptr = LLVMPointerType(c->object_ptr, 0);
+  r_field_ptr = LLVMBuildBitCast(c->builder, r_field_ptr,
+    obj_ptr_ptr, "");
+
+  LLVMBasicBlockRef null_block = codegen_block(c, "is_tuple_null_desc");
+  LLVMBasicBlockRef nonnull_block = codegen_block(c, "is_tuple_nonnull_desc");
+  LLVMBasicBlockRef continue_block = codegen_block(c, "is_tuple_merge_desc");
+  LLVMValueRef test = LLVMBuildIsNull(c->builder, r_field_desc, "");
+  LLVMBuildCondBr(c->builder, test, null_block, nonnull_block);
+
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
+  LLVMValueRef phi = LLVMBuildPhi(c->builder, c->i1, "");
+
+  LLVMPositionBuilderAtEnd(c->builder, null_block);
+  LLVMValueRef r_field = LLVMBuildLoad(c->builder, r_field_ptr, "");
+  LLVMValueRef field_test;
+
+  switch(field_kind)
+  {
+    case SUBTYPE_KIND_NUMERIC:
+      field_test = raw_is_box(c, l_field_type, l_field, r_field);
+      break;
+
+    case SUBTYPE_KIND_TUPLE:
+      field_test = tuple_is_box(c, l_field_type, NULL, l_field, r_field, NULL,
+        true, true);
+      break;
+
+    case SUBTYPE_KIND_UNBOXED:
+      field_test = gen_is_value(c, l_field_type, NULL, l_field, r_field);
+      break;
+
+    default: {}
+  }
+
+  LLVMBuildBr(c->builder, continue_block);
+  LLVMBasicBlockRef cur_block = LLVMGetInsertBlock(c->builder);
+  LLVMAddIncoming(phi, &field_test, &cur_block, 1);
+
+  LLVMMoveBasicBlockAfter(nonnull_block, LLVMGetInsertBlock(c->builder));
+  LLVMPositionBuilderAtEnd(c->builder, nonnull_block);
+
+  field_test = tuple_element_is_box_unboxed_element(c, l_field_type, l_field,
+    r_field_ptr, r_field_desc, field_kind);
+  LLVMBuildBr(c->builder, continue_block);
+  cur_block = LLVMGetInsertBlock(c->builder);
+  LLVMAddIncoming(phi, &field_test, &cur_block, 1);
+
+  LLVMMoveBasicBlockAfter(continue_block, LLVMGetInsertBlock(c->builder));
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
+  return phi;
+}
+
+static LLVMValueRef tuple_is_box(compile_t* c, ast_t* left_type,
+  reach_type_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value,
+  LLVMValueRef r_desc, bool rhs_boxed, bool check_cardinality)
+{
+  pony_assert(LLVMGetTypeKind(LLVMTypeOf(l_value)) == LLVMStructTypeKind);
+  pony_assert(LLVMGetTypeKind(LLVMTypeOf(r_value)) == LLVMPointerTypeKind);
+
+  size_t cardinality = ast_childcount(left_type);
+
+  // If check_cardinality is false, trust the caller and don't do the check.
+  // If check_cardinality is true, we can avoid the check if every possible
+  // subtype is a tuple and has the correct cardinality.
+  if(check_cardinality && (right_type != NULL))
+  {
+    check_cardinality = false;
+
+    reach_type_t* r_sub;
+    size_t i = HASHMAP_BEGIN;
+
+    while((r_sub = reach_type_cache_next(&right_type->subtypes, &i)) != NULL)
+    {
+      if((ast_id(r_sub->ast) != TK_TUPLETYPE) ||
+        (ast_childcount(r_sub->ast) != cardinality))
+      {
+        check_cardinality = true;
+        break;
+      }
+    }
+  }
+
   LLVMValueRef zero = LLVMConstInt(c->i1, 0, false);
-  LLVMAddIncoming(phi, &zero, &entry_block, 1);
+  LLVMValueRef one = LLVMConstInt(c->i1, 1, false);
+
+  LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
+  LLVMBasicBlockRef card_block = NULL;
+
+  if(check_cardinality)
+    card_block = codegen_block(c, "is_tuple_card");
+
+  LLVMBasicBlockRef post_block = codegen_block(c, "is_tuple_post");
+
+  LLVMPositionBuilderAtEnd(c->builder, post_block);
+  LLVMValueRef phi = LLVMBuildPhi(c->builder, c->i1, "");
+
+  LLVMPositionBuilderAtEnd(c->builder, this_block);
+
+  // If rhs_boxed is false, we're handling an unboxed tuple nested as a field
+  // in a boxed tuple.
+
+  if(r_desc == NULL)
+  {
+    pony_assert(rhs_boxed);
+    r_desc = gendesc_fetch(c, r_value);
+  }
+
+  if(card_block != NULL)
+  {
+    LLVMValueRef l_card = LLVMConstInt(c->i32, cardinality, false);
+    LLVMValueRef r_card = gendesc_fieldcount(c, r_desc);
+    LLVMValueRef card_test = LLVMBuildICmp(c->builder, LLVMIntEQ, l_card,
+      r_card, "");
+    LLVMBuildCondBr(c->builder, card_test, card_block, post_block);
+    LLVMAddIncoming(phi, &zero, &this_block, 1);
+
+    LLVMPositionBuilderAtEnd(c->builder, card_block);
+  }
+
+  LLVMValueRef r_fields;
+
+  if(rhs_boxed)
+    r_fields = gendesc_ptr_to_fields(c, r_value, r_desc);
+  else
+    r_fields = LLVMBuildBitCast(c->builder, r_value, c->void_ptr, "");
+
+  ast_t* l_child = ast_child(left_type);
+  unsigned int i = 0;
+
+  LLVMBasicBlockRef next_block = NULL;
+
+  while(l_child != NULL)
+  {
+    reach_type_t* t = reach_type(c->reach, l_child);
+    compile_type_t* c_t = (compile_type_t*)t->c_type;
+
+    LLVMValueRef l_elem = LLVMBuildExtractValue(c->builder, l_value, i, "");
+    l_elem = gen_assign_cast(c, c_t->use_type, l_elem, l_child);
+    LLVMValueRef elem_test = tuple_is_box_element(c, l_child, l_elem, r_fields,
+      r_desc, i);
+    next_block = codegen_block(c, "is_tuple_next");
+    LLVMBuildCondBr(c->builder, elem_test, next_block, post_block);
+    LLVMBasicBlockRef cur_block = LLVMGetInsertBlock(c->builder);
+    LLVMAddIncoming(phi, &zero, &cur_block, 1);
+
+    LLVMPositionBuilderAtEnd(c->builder, next_block);
+
+    l_child = ast_sibling(l_child);
+    i++;
+  }
+
+  LLVMBuildBr(c->builder, post_block);
+  LLVMAddIncoming(phi, &one, &next_block, 1);
+
+  LLVMMoveBasicBlockAfter(post_block, next_block);
+  LLVMPositionBuilderAtEnd(c->builder, post_block);
   return phi;
 }
 
@@ -173,9 +423,7 @@ static LLVMValueRef box_is_box(compile_t* c, reach_type_t* left_type,
 
   if((sub_kind & SUBTYPE_KIND_TUPLE) != 0)
   {
-    if(sub_kind != SUBTYPE_KIND_TUPLE)
-      tuple_block = codegen_block(c, "is_tuple");
-
+    tuple_block = codegen_block(c, "is_tuple");
     bothtuple_block = codegen_block(c, "is_bothtuple");
   }
 
@@ -197,7 +445,7 @@ static LLVMValueRef box_is_box(compile_t* c, reach_type_t* left_type,
   {
     LLVMBuildBr(c->builder, num_block);
   } else if(sub_kind == SUBTYPE_KIND_TUPLE) {
-    LLVMBuildBr(c->builder, bothtuple_block);
+    LLVMBuildBr(c->builder, tuple_block);
   } else {
     l_desc = gendesc_fetch(c, l_value);
     l_typeid = gendesc_typeid(c, l_desc);
@@ -253,48 +501,38 @@ static LLVMValueRef box_is_box(compile_t* c, reach_type_t* left_type,
     LLVMBuildBr(c->builder, post_block);
   }
 
-  LLVMValueRef r_typeid = NULL;
+  LLVMValueRef is_tuple = NULL;
   if(tuple_block != NULL)
   {
     LLVMPositionBuilderAtEnd(c->builder, tuple_block);
-    LLVMValueRef r_desc = gendesc_fetch(c, r_value);
-    r_typeid = gendesc_typeid(c, r_desc);
-    LLVMValueRef right_tuple = LLVMBuildAnd(c->builder, r_typeid, boxed_mask,
-      "");
-    right_tuple = LLVMBuildICmp(c->builder, LLVMIntEQ, right_tuple,
-      LLVMConstInt(c->i32, 2, false), "");
-    LLVMBuildCondBr(c->builder, right_tuple, bothtuple_block, post_block);
-  }
 
-  LLVMValueRef is_tuple = NULL;
-  if(bothtuple_block != NULL)
-  {
-    // Call the type-specific __is function, which will unbox the tuples.
+    if(l_desc == NULL)
+      l_desc = gendesc_fetch(c, l_value);
+
+    LLVMValueRef l_card = gendesc_fieldcount(c, l_desc);
+    LLVMValueRef r_desc = gendesc_fetch(c, r_value);
+    LLVMValueRef r_card = gendesc_fieldcount(c, r_desc);
+    LLVMValueRef card_test = LLVMBuildICmp(c->builder, LLVMIntEQ, l_card,
+      r_card, "");
+    LLVMBuildCondBr(c->builder, card_test, bothtuple_block, post_block);
+
+    // Call the type-specific __is function, which will unbox the LHS.
     LLVMPositionBuilderAtEnd(c->builder, bothtuple_block);
     reach_method_t* is_fn = reach_method(left_type, TK_BOX, stringtab("__is"),
       NULL);
     pony_assert(is_fn != NULL);
 
-    if(l_desc == NULL)
-      l_desc = gendesc_fetch(c, l_value);
-
     LLVMValueRef func = gendesc_vtable(c, l_desc, is_fn->vtable_index);
-
-    if(r_typeid == NULL)
-    {
-      LLVMValueRef r_desc = gendesc_fetch(c, r_value);
-      r_typeid = gendesc_typeid(c, r_desc);
-    }
 
     LLVMTypeRef params[3];
     params[0] = c->object_ptr;
     params[1] = c->object_ptr;
-    params[2] = c->i32;
+    params[2] = c->descriptor_ptr;
     LLVMTypeRef type = LLVMFunctionType(c->i1, params, 3, false);
     func = LLVMBuildBitCast(c->builder, func, LLVMPointerType(type, 0), "");
     args[0] = l_value;
     args[1] = r_value;
-    args[2] = r_typeid;
+    args[2] = r_desc;
     is_tuple = codegen_call(c, func, args, 3, true);
     LLVMBuildBr(c->builder, post_block);
   }
@@ -329,8 +567,12 @@ static LLVMValueRef box_is_box(compile_t* c, reach_type_t* left_type,
 static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
   ast_t* right_type, LLVMValueRef l_value, LLVMValueRef r_value)
 {
+  pony_assert(left_type != NULL);
+
   LLVMTypeRef l_type = LLVMTypeOf(l_value);
   LLVMTypeRef r_type = LLVMTypeOf(r_value);
+
+  bool right_null = right_type == NULL;
 
   switch(LLVMGetTypeKind(l_type))
   {
@@ -342,7 +584,7 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
 
       // If left_type is a subtype of right_type, check if r_value is a boxed
       // numeric primitive.
-      if(is_subtype(left_type, right_type, NULL, c->opt))
+      if(right_null || is_subtype(left_type, right_type, NULL, c->opt))
         return raw_is_box(c, left_type, l_value, r_value);
 
       // It can't have the same identity.
@@ -358,7 +600,7 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
 
       // If left_type is a subtype of right_type, check if r_value is a boxed
       // numeric primitive.
-      if(is_subtype(left_type, right_type, NULL, c->opt))
+      if(right_null || is_subtype(left_type, right_type, NULL, c->opt))
         return raw_is_box(c, left_type, l_value, r_value);
 
       // It can't have the same identity.
@@ -372,10 +614,11 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
         // Pairwise comparison.
         if(ast_childcount(left_type) == ast_childcount(right_type))
           return tuple_is(c, left_type, right_type, l_value, r_value);
-      } else if(!is_known(right_type)) {
+      } else if(right_null || !is_known(right_type)) {
         // If right_type is an abstract type, check if r_value is a boxed tuple.
         reach_type_t* r_right = reach_type(c->reach, right_type);
-        return tuple_is_box(c, left_type, r_right, l_value, r_value);
+        return tuple_is_box(c, left_type, r_right, l_value, r_value, NULL,
+          true, true);
       }
 
       // It can't have the same identity.
@@ -391,9 +634,10 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
       r_value = LLVMBuildBitCast(c->builder, r_value, c->object_ptr, "");
 
       bool left_known = is_known(left_type);
-      bool right_known = is_known(right_type);
+      bool right_known = !right_null && is_known(right_type);
       reach_type_t* r_left = reach_type(c->reach, left_type);
-      reach_type_t* r_right = reach_type(c->reach, right_type);
+      reach_type_t* r_right = !right_null ?
+        reach_type(c->reach, right_type) : NULL;
 
       if(!left_known && !right_known)
       {
@@ -423,7 +667,7 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
         }
 
         // If the types can be the same, check the address.
-        if(is_subtype(known, unknown, NULL, c->opt))
+        if(right_null || is_subtype(known, unknown, NULL, c->opt))
           return LLVMBuildICmp(c->builder, LLVMIntEQ, l_value, r_value, "");
       }
 
@@ -491,39 +735,22 @@ void gen_is_tuple_fun(compile_t* c, reach_type_t* t)
   LLVMTypeRef params[3];
   params[0] = c->object_ptr;
   params[1] = c->object_ptr;
-  params[2] = c->i32;
+  params[2] = c->descriptor_ptr;
   c_m->func_type = LLVMFunctionType(c->i1, params, 3, false);
   c_m->func = codegen_addfun(c, m->full_name, c_m->func_type, true);
 
   codegen_startfun(c, c_m->func, NULL, NULL, false);
   LLVMValueRef l_value = LLVMGetParam(codegen_fun(c), 0);
   LLVMValueRef r_value = LLVMGetParam(codegen_fun(c), 1);
-  LLVMValueRef r_id = LLVMGetParam(codegen_fun(c), 2);
+  LLVMValueRef r_desc = LLVMGetParam(codegen_fun(c), 2);
 
   l_value = gen_unbox(c, t->ast_cap, l_value);
-  LLVMBasicBlockRef notreltype_block = codegen_block(c, "not_reltype");
-  LLVMValueRef type_switch = LLVMBuildSwitch(c->builder, r_id, notreltype_block,
-    0);
 
-  pony_assert(m->tuple_is_types != NULL);
-  reach_type_t* right;
-  size_t i = HASHMAP_BEGIN;
-
-  while((right = reach_type_cache_next(m->tuple_is_types, &i)) != NULL)
-  {
-    LLVMBasicBlockRef reltype_block = codegen_block(c, "reltype");
-    LLVMAddCase(type_switch, LLVMConstInt(c->i32, right->type_id, false),
-      reltype_block);
-    LLVMPositionBuilderAtEnd(c->builder, reltype_block);
-
-    LLVMValueRef r_unbox = gen_unbox(c, right->ast_cap, r_value);
-    LLVMBuildRet(c->builder, tuple_is(c, t->ast_cap, right->ast_cap, l_value,
-      r_unbox));
-  }
-
-  LLVMMoveBasicBlockAfter(notreltype_block, LLVMGetInsertBlock(c->builder));
-  LLVMPositionBuilderAtEnd(c->builder, notreltype_block);
-  LLVMBuildRet(c->builder, LLVMConstInt(c->i1, 0, false));
+  // We've already checked the cardinality in the checks generated by
+  // box_is_box(). Don't recheck it in tuple_is_box().
+  LLVMValueRef same_identity = tuple_is_box(c, t->ast_cap, NULL, l_value,
+    r_value, r_desc, true, false);
+  LLVMBuildRet(c->builder, same_identity);
 
   codegen_finishfun(c);
 }

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -91,8 +91,6 @@ static bool reachable_actors(compile_t* c, ast_t* program)
     package = ast_sibling(package);
   }
 
-  reach_done(c->reach, c->opt);
-
   if(!found)
   {
     errorf(errors, NULL, "no C-API actors found in package '%s'", c->filename);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -13,8 +13,6 @@
 #include <stdio.h>
 #include <string.h>
 
-DEFINE_STACK(reachable_expr_stack, reachable_expr_stack_t, void);
-
 DEFINE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
 
 static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
@@ -56,12 +54,6 @@ static void reach_mangled_free(reach_method_t* m)
 {
   if(m->param_count > 0)
     ponyint_pool_free_size(m->param_count * sizeof(reach_param_t), m->params);
-
-  if(m->tuple_is_types != NULL)
-  {
-    reach_type_cache_destroy(m->tuple_is_types);
-    POOL_FREE(reach_type_cache_t, m->tuple_is_types);
-  }
 
   if(m->c_method != NULL)
     m->c_method->free_fn(m->c_method);
@@ -247,24 +239,12 @@ static const char* make_full_name(reach_type_t* t, reach_method_t* m)
   return name;
 }
 
-bool valid_internal_method_for_type(reach_type_t* type, const char* method_name)
-{
-  if(method_name == stringtab("__is"))
-    return type->underlying == TK_TUPLETYPE;
-
-  if(method_name == stringtab("__digestof"))
-    return type->can_be_boxed;
-
-  pony_assert(0);
-  return false;
-}
-
 static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
-  reach_method_name_t* n, reach_method_t* m, pass_opt_t* opt, bool internal)
+  reach_method_name_t* n, reach_method_t* m, pass_opt_t* opt)
 {
   // Add the method to the type if it isn't already there.
-  reach_method_name_t* n2 = add_method_name(t, n->name, internal);
-  add_rmethod(r, t, n2, m->cap, m->typeargs, opt, internal);
+  reach_method_name_t* n2 = add_method_name(t, n->name, false);
+  add_rmethod(r, t, n2, m->cap, m->typeargs, opt, false);
 
   // Add this mangling to the type if it isn't already there.
   size_t index = HASHMAP_UNKNOWN;
@@ -303,8 +283,10 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
 }
 
 static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
-  reach_method_name_t* n, reach_method_t* m, pass_opt_t* opt, bool internal)
+  reach_method_name_t* n, reach_method_t* m, pass_opt_t* opt)
 {
+  pony_assert(!m->internal);
+
   switch(t->underlying)
   {
     case TK_UNIONTYPE:
@@ -315,10 +297,7 @@ static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
       reach_type_t* t2;
 
       while((t2 = reach_type_cache_next(&t->subtypes, &i)) != NULL)
-      {
-        if(!internal || valid_internal_method_for_type(t2, n->name))
-          add_rmethod_to_subtype(r, t2, n, m, opt, internal);
-      }
+        add_rmethod_to_subtype(r, t2, n, m, opt);
 
       break;
     }
@@ -330,20 +309,15 @@ static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
 
       for(; child != NULL; child = ast_sibling(child))
       {
-        if(!internal)
-        {
-          deferred_reification_t* find = lookup_try(NULL, NULL, child, n->name);
+        deferred_reification_t* find = lookup_try(NULL, NULL, child, n->name);
 
-          if(find == NULL)
-            continue;
+        if(find == NULL)
+          continue;
 
-          deferred_reify_free(find);
-        }
+        deferred_reify_free(find);
 
         t2 = add_type(r, child, opt);
-
-        if(!internal || valid_internal_method_for_type(t2, n->name))
-          add_rmethod_to_subtype(r, t2, n, m, opt, internal);
+        add_rmethod_to_subtype(r, t2, n, m, opt);
       }
 
       break;
@@ -408,10 +382,10 @@ static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
   {
     // Put on a stack of reachable methods to trace.
     r->method_stack = reach_method_stack_push(r->method_stack, m);
-  }
 
-  // Add the method to any subtypes.
-  add_rmethod_to_subtypes(r, t, n, m, opt, internal);
+    // Add the method to any subtypes.
+    add_rmethod_to_subtypes(r, t, n, m, opt);
+  }
 
   return m;
 }
@@ -428,8 +402,19 @@ static void add_methods_to_type(reach_t* r, reach_type_t* from,
     reach_method_t* m;
 
     while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
-      add_rmethod_to_subtype(r, to, n, m, opt, m->internal);
+    {
+      if(!m->internal)
+        add_rmethod_to_subtype(r, to, n, m, opt);
+    }
   }
+}
+
+static void add_internal(reach_t* r, reach_type_t* t, const char* name,
+  pass_opt_t* opt)
+{
+  name = stringtab(name);
+  reach_method_name_t* n = add_method_name(t, name, true);
+  add_rmethod(r, t, n, TK_BOX, NULL, opt, true);
 }
 
 static void add_types_to_trait(reach_t* r, reach_type_t* t,
@@ -479,8 +464,12 @@ static void add_types_to_trait(reach_t* r, reach_type_t* t,
             {
               reach_type_cache_put(&t->subtypes, t2);
               reach_type_cache_put(&t2->subtypes, t);
+
               if(ast_id(t->ast) == TK_NOMINAL)
                 add_methods_to_type(r, t, t2, opt);
+
+              if(t2->can_be_boxed)
+                add_internal(r, t, "__digestof", opt);
             }
             break;
 
@@ -502,6 +491,8 @@ static void add_types_to_trait(reach_t* r, reach_type_t* t,
         {
           reach_type_cache_put(&t->subtypes, t2);
           reach_type_cache_put(&t2->subtypes, t);
+          add_internal(r, t, "__is", opt);
+          add_internal(r, t, "__digestof", opt);
         }
 
         break;
@@ -532,6 +523,12 @@ static void add_traits_to_type(reach_t* r, reach_type_t* t,
             reach_type_cache_put(&t->subtypes, t2);
             reach_type_cache_put(&t2->subtypes, t);
             add_methods_to_type(r, t2, t, opt);
+
+            if(t->underlying == TK_TUPLETYPE)
+              add_internal(r, t2, "__is", opt);
+
+            if(t->can_be_boxed)
+              add_internal(r, t2, "__digestof", opt);
           }
           break;
 
@@ -546,6 +543,12 @@ static void add_traits_to_type(reach_t* r, reach_type_t* t,
           {
             reach_type_cache_put(&t->subtypes, t2);
             reach_type_cache_put(&t2->subtypes, t);
+
+            if(t->underlying == TK_TUPLETYPE)
+              add_internal(r, t2, "__is", opt);
+
+            if(t->can_be_boxed)
+              add_internal(r, t2, "__digestof", opt);
           }
           break;
 
@@ -695,6 +698,36 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
   }
 }
 
+// Type IDs are assigned as:
+// - Object type IDs:  1, 3, 5, 7, 9, ...
+// - Numeric type IDs: 0, 4, 8, 12, 16, ...
+// - Tuple type IDs:   2, 6, 10, 14, 18, ...
+// This allows to quickly check whether a type is unboxed or not.
+// Trait IDs use their own incremental numbering.
+
+static uint32_t get_new_trait_id(reach_t* r)
+{
+  return r->trait_type_count++;
+}
+
+static uint32_t get_new_object_id(reach_t* r)
+{
+  r->total_type_count++;
+  return (r->object_type_count++ * 2) + 1;
+}
+
+static uint32_t get_new_numeric_id(reach_t* r)
+{
+  r->total_type_count++;
+  return r->numeric_type_count++ * 4;
+}
+
+static uint32_t get_new_tuple_id(reach_t* r)
+{
+  r->total_type_count++;
+  return (r->tuple_type_count++ * 4) + 2;
+}
+
 static reach_type_t* add_reach_type(reach_t* r, ast_t* type)
 {
   reach_type_t* t = POOL_ALLOC(reach_type_t);
@@ -731,7 +764,7 @@ static reach_type_t* add_isect_or_union(reach_t* r, ast_t* type,
   add_types_to_trait(r, t, opt);
 
   if(t->type_id == (uint32_t)-1)
-    t->type_id = r->trait_type_count++;
+    t->type_id = get_new_trait_id(r);
 
   ast_t* child = ast_child(type);
 
@@ -756,7 +789,7 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
 
   t = add_reach_type(r, type);
   t->underlying = TK_TUPLETYPE;
-  t->type_id = (r->tuple_type_count++ * 4) + 2;
+  t->type_id = get_new_tuple_id(r);
   t->can_be_boxed = true;
 
   t->field_count = (uint32_t)ast_childcount(t->ast);
@@ -764,6 +797,8 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
       t->field_count * sizeof(reach_field_t));
 
   add_traits_to_type(r, t, opt);
+  add_internal(r, t, "__is", opt);
+  add_internal(r, t, "__digestof", opt);
 
   printbuf_t* mangle = printbuf_new();
   printbuf(mangle, "%d", t->field_count);
@@ -816,11 +851,15 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
       break;
 
     case TK_PRIMITIVE:
+      if(is_machine_word(type))
+      {
+        t->can_be_boxed = true;
+        add_internal(r, t, "__digestof", opt);
+      }
+
       add_traits_to_type(r, t, opt);
       add_special(r, t, type, "_init", opt);
       add_special(r, t, type, "_final", opt);
-      if(is_machine_word(type))
-        t->can_be_boxed = true;
       break;
 
     case TK_STRUCT:
@@ -878,11 +917,11 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
   if(t->type_id == (uint32_t)-1)
   {
     if(t->is_trait && !bare)
-      t->type_id = r->trait_type_count++;
+      t->type_id = get_new_trait_id(r);
     else if(t->can_be_boxed)
-      t->type_id = r->numeric_type_count++ * 4;
+      t->type_id = get_new_numeric_id(r);
     else if(t->underlying != TK_STRUCT)
-      t->type_id = (r->object_type_count++ * 2) + 1;
+      t->type_id = get_new_object_id(r);
   }
 
   if(ast_id(def) != TK_PRIMITIVE)
@@ -1106,220 +1145,6 @@ static void reachable_ffi(reach_t* r, deferred_reification_t* reify, ast_t* ast,
   }
 }
 
-typedef struct reach_identity_t
-{
-  reach_type_t* type;
-  reach_type_cache_t reached;
-} reach_identity_t;
-
-static size_t reach_identity_hash(reach_identity_t* id)
-{
-  return (size_t)id->type;
-}
-
-static bool reach_identity_cmp(reach_identity_t* a, reach_identity_t* b)
-{
-  return a->type == b->type;
-}
-
-static void reach_identity_free(reach_identity_t* id)
-{
-  reach_type_cache_destroy(&id->reached);
-  POOL_FREE(reach_identity_t, id);
-}
-
-DECLARE_HASHMAP(reach_identities, reach_identities_t, reach_identity_t);
-
-DEFINE_HASHMAP(reach_identities, reach_identities_t, reach_identity_t,
-  reach_identity_hash, reach_identity_cmp, reach_identity_free);
-
-static void reachable_identity_type(reach_t* r, ast_t* l_type, ast_t* r_type,
-  pass_opt_t* opt, reach_identities_t* reached_identities)
-{
-  if((ast_id(l_type) == TK_TUPLETYPE) && (ast_id(r_type) == TK_TUPLETYPE))
-  {
-    if(ast_childcount(l_type) != ast_childcount(r_type))
-      return;
-
-    ast_t* l_child = ast_child(l_type);
-    ast_t* r_child = ast_child(r_type);
-
-    while(l_child != NULL)
-    {
-      reachable_identity_type(r, l_child, r_child, opt, reached_identities);
-      l_child = ast_sibling(l_child);
-      r_child = ast_sibling(r_child);
-    }
-  } else if(!is_known(l_type) && !is_known(r_type)) {
-    reach_type_t* r_left = reach_type(r, l_type);
-    reach_type_t* r_right = reach_type(r, r_type);
-
-    int sub_kind = subtype_kind_overlap(r_left, r_right);
-
-    if((sub_kind & SUBTYPE_KIND_TUPLE) != 0)
-    {
-      const char* name = stringtab("__is");
-
-      reach_method_name_t* n = add_method_name(r_left, name, true);
-      reach_method_t* m = add_rmethod(r, r_left, n, TK_BOX, NULL, opt, true);
-
-      reach_type_t* l_sub;
-      size_t i = HASHMAP_BEGIN;
-
-      while((l_sub = reach_type_cache_next(&r_left->subtypes, &i)) != NULL)
-      {
-        if(l_sub->underlying != TK_TUPLETYPE)
-          continue;
-
-        m = reach_method(l_sub, TK_BOX, name, NULL);
-        pony_assert(m != NULL);
-
-        if(m->tuple_is_types == NULL)
-        {
-          m->tuple_is_types = POOL_ALLOC(reach_type_cache_t);
-          reach_type_cache_init(m->tuple_is_types, 1);
-        }
-
-        size_t cardinality = ast_childcount(l_sub->ast_cap);
-        reach_type_t* r_sub;
-        size_t j = HASHMAP_BEGIN;
-
-        while((r_sub = reach_type_cache_next(&r_right->subtypes, &j)) != NULL)
-        {
-          if((r_sub->underlying != TK_TUPLETYPE) ||
-            (ast_childcount(r_sub->ast_cap) != cardinality))
-            continue;
-
-          size_t k = HASHMAP_UNKNOWN;
-          reach_type_t* in_cache = reach_type_cache_get(m->tuple_is_types,
-            r_sub, &k);
-
-          if(in_cache == NULL)
-          {
-            reach_type_cache_putindex(m->tuple_is_types, r_sub, k);
-            reachable_identity_type(r, l_sub->ast_cap, r_sub->ast_cap, opt,
-              reached_identities);
-          }
-        }
-      }
-    }
-  } else {
-    ast_t* tuple;
-    ast_t* unknown;
-
-    if((ast_id(l_type) == TK_TUPLETYPE) && !is_known(r_type))
-    {
-      tuple = l_type;
-      unknown = r_type;
-    } else if((ast_id(r_type) == TK_TUPLETYPE) && !is_known(l_type)) {
-      tuple = r_type;
-      unknown = l_type;
-    } else {
-      return;
-    }
-
-    size_t cardinality = ast_childcount(tuple);
-    reach_type_t* r_tuple = reach_type(r, tuple);
-    reach_type_t* r_unknown = reach_type(r, unknown);
-    reach_identity_t k;
-    k.type = r_tuple;
-    size_t i = HASHMAP_UNKNOWN;
-    reach_identity_t* identity = reach_identities_get(reached_identities, &k,
-      &i);
-
-    if(identity == NULL)
-    {
-      identity = POOL_ALLOC(reach_identity_t);
-      identity->type = r_tuple;
-      reach_type_cache_init(&identity->reached, 0);
-      reach_identities_putindex(reached_identities, identity, i);
-    }
-
-    reach_type_t* u_sub;
-    i = HASHMAP_BEGIN;
-
-    while((u_sub = reach_type_cache_next(&r_unknown->subtypes, &i)) != NULL)
-    {
-      if((ast_id(u_sub->ast_cap) != TK_TUPLETYPE) ||
-        (ast_childcount(u_sub->ast_cap) == cardinality))
-        continue;
-
-      size_t j = HASHMAP_UNKNOWN;
-      reach_type_t* in_cache = reach_type_cache_get(&identity->reached,
-        u_sub, &j);
-
-      if(in_cache == NULL)
-      {
-        reach_type_cache_putindex(&identity->reached, u_sub, j);
-        reachable_identity_type(r, tuple, u_sub->ast_cap, opt,
-          reached_identities);
-      }
-    }
-  }
-}
-
-static void reachable_identity(reach_t* r, deferred_reification_t* reify,
-  ast_t* ast, pass_opt_t* opt, reach_identities_t* identities)
-{
-  AST_GET_CHILDREN(ast, left, right);
-
-  ast_t* l_type = deferred_reify(reify, ast_type(left), opt);
-  ast_t* r_type = deferred_reify(reify, ast_type(right), opt);
-
-  reachable_identity_type(r, l_type, r_type, opt, identities);
-
-  ast_free_unattached(l_type);
-  ast_free_unattached(r_type);
-}
-
-static void reachable_digestof_type(reach_t* r, ast_t* type, pass_opt_t* opt)
-{
-  if(ast_id(type) == TK_TUPLETYPE)
-  {
-    ast_t* child = ast_child(type);
-
-    while(child != NULL)
-    {
-      reachable_digestof_type(r, child, opt);
-      child = ast_sibling(child);
-    }
-  } else if(!is_known(type)) {
-    reach_type_t* t = reach_type(r, type);
-    int sub_kind = subtype_kind(t);
-
-    if((sub_kind & SUBTYPE_KIND_BOXED) != 0)
-    {
-      const char* name = stringtab("__digestof");
-
-      if(reach_method_name(t, name) != NULL)
-        return;
-
-      reach_method_name_t* n = add_method_name(t, name, true);
-      add_rmethod(r, t, n, TK_BOX, NULL, opt, true);
-
-      reach_type_t* sub;
-      size_t i = HASHMAP_BEGIN;
-
-      while((sub = reach_type_cache_next(&t->subtypes, &i)) != NULL)
-      {
-        if(sub->can_be_boxed)
-          reachable_digestof_type(r, sub->ast_cap, opt);
-      }
-    }
-  }
-}
-
-static void reachable_digestof(reach_t* r, deferred_reification_t* reify,
-  ast_t* ast, pass_opt_t* opt)
-{
-  ast_t* expr = ast_child(ast);
-  ast_t* type = deferred_reify(reify, ast_type(expr), opt);
-
-  reachable_digestof_type(r, type, opt);
-
-  ast_free_unattached(type);
-}
-
 static void reachable_expr(reach_t* r, deferred_reification_t* reify,
   ast_t* ast, pass_opt_t* opt)
 {
@@ -1457,11 +1282,6 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
       add_type(r, type, opt);
       ast_free_unattached(type);
 
-      // We might need to reach the `__is` method but we can't determine that
-      // yet since we don't know every reachable type.
-      // Put it on the expr stack in order to trace it later.
-      r->expr_stack = reachable_expr_stack_push(r->expr_stack, reify);
-      r->expr_stack = reachable_expr_stack_push(r->expr_stack, ast);
       break;
     }
 
@@ -1472,9 +1292,6 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
       add_type(r, type, opt);
       ast_free_unattached(type);
 
-      // Same as TK_IS but for `__digestof`
-      r->expr_stack = reachable_expr_stack_push(r->expr_stack, reify);
-      r->expr_stack = reachable_expr_stack_push(r->expr_stack, ast);
       break;
     }
 
@@ -1554,37 +1371,6 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
   }
 }
 
-static void handle_expr_stack(reach_t* r, pass_opt_t* opt)
-{
-  // New types must not be reached by this function. New methods are fine.
-  reach_identities_t identities;
-  reach_identities_init(&identities, 8);
-
-  while(r->expr_stack != NULL)
-  {
-    ast_t* ast;
-    deferred_reification_t* reify;
-    r->expr_stack = reachable_expr_stack_pop(r->expr_stack, (void**)&ast);
-    r->expr_stack = reachable_expr_stack_pop(r->expr_stack, (void**)&reify);
-
-    switch(ast_id(ast))
-    {
-      case TK_IS:
-      case TK_ISNT:
-        reachable_identity(r, reify, ast, opt, &identities);
-        break;
-
-      case TK_DIGESTOF:
-        reachable_digestof(r, reify, ast, opt);
-        break;
-
-      default: {}
-    }
-  }
-
-  reach_identities_destroy(&identities);
-}
-
 static void handle_method_stack(reach_t* r, pass_opt_t* opt)
 {
   while(r->method_stack != NULL)
@@ -1600,7 +1386,6 @@ static void handle_method_stack(reach_t* r, pass_opt_t* opt)
 reach_t* reach_new()
 {
   reach_t* r = POOL_ALLOC(reach_t);
-  r->expr_stack = NULL;
   r->method_stack = NULL;
   r->object_type_count = 0;
   r->numeric_type_count = 0;
@@ -1625,21 +1410,6 @@ void reach(reach_t* r, ast_t* type, const char* name, ast_t* typeargs,
 {
   reachable_method(r, NULL, type, name, typeargs, opt);
   handle_method_stack(r, opt);
-}
-
-void reach_done(reach_t* r, pass_opt_t* opt)
-{
-  // Type IDs are assigned as:
-  // - Object type IDs:  1, 3, 5, 7, 9, ...
-  // - Numeric type IDs: 0, 4, 8, 12, 16, ...
-  // - Tuple type IDs:   2, 6, 10, 14, 18, ...
-  // This allows to quickly check whether a type is unboxed or not.
-  // Trait IDs use their own incremental numbering.
-
-  r->total_type_count = r->object_type_count + r->numeric_type_count +
-    r->tuple_type_count;
-
-  handle_expr_stack(r, opt);
 }
 
 reach_type_t* reach_type(reach_t* r, ast_t* type)
@@ -1850,10 +1620,6 @@ static void reach_method_serialise_trace(pony_ctx_t* ctx, void* object)
 
   if(m->result != NULL)
     pony_traceknown(ctx, m->result, reach_type_pony_type(), PONY_TRACE_MUTABLE);
-
-  if(m->tuple_is_types != NULL)
-    pony_traceknown(ctx, m->tuple_is_types, reach_type_cache_pony_type(),
-      PONY_TRACE_MUTABLE);
 }
 
 static void reach_method_serialise(pony_ctx_t* ctx, void* object, void* buf,
@@ -1897,10 +1663,6 @@ static void reach_method_serialise(pony_ctx_t* ctx, void* object, void* buf,
   }
 
   dst->result = (reach_type_t*)pony_serialise_offset(ctx, m->result);
-
-  dst->tuple_is_types = (reach_type_cache_t*)pony_serialise_offset(ctx,
-    m->tuple_is_types);
-
   dst->c_method = NULL;
 }
 
@@ -1934,9 +1696,6 @@ static void reach_method_deserialise(pony_ctx_t* ctx, void* object)
 
   m->result = (reach_type_t*)pony_deserialise_offset(ctx, reach_type_pony_type(),
     (uintptr_t)m->result);
-
-  m->tuple_is_types = (reach_type_cache_t*)pony_deserialise_offset(ctx,
-    reach_type_cache_pony_type(), (uintptr_t)m->tuple_is_types);
 }
 
 static pony_type_t reach_method_pony =
@@ -2224,7 +1983,6 @@ static void reach_serialise(pony_ctx_t* ctx, void* object, void* buf,
 
   reach_types_serialise(ctx, &r->types, buf, offset + offsetof(reach_t, types),
     PONY_TRACE_MUTABLE);
-  dst->expr_stack = NULL;
   dst->method_stack = NULL;
   dst->object_type_count = r->object_type_count;
   dst->numeric_type_count = r->numeric_type_count;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -15,7 +15,6 @@ typedef struct reach_field_t reach_field_t;
 typedef struct reach_param_t reach_param_t;
 typedef struct reach_type_t reach_type_t;
 
-DECLARE_STACK(reachable_expr_stack, reachable_expr_stack_t, void);
 DECLARE_STACK(reach_method_stack, reach_method_stack_t, reach_method_t);
 DECLARE_HASHMAP_SERIALISE(reach_methods, reach_methods_t, reach_method_t);
 DECLARE_HASHMAP_SERIALISE(reach_mangled, reach_mangled_t, reach_method_t);
@@ -58,9 +57,6 @@ struct reach_method_t
   size_t param_count;
   reach_param_t* params;
   reach_type_t* result;
-
-  // Used when reaching and generating __is for tuples.
-  reach_type_cache_t* tuple_is_types;
 
   compile_opaque_t* c_method;
 };
@@ -115,7 +111,6 @@ struct reach_type_t
 typedef struct
 {
   reach_types_t types;
-  reachable_expr_stack_t* expr_stack;
   reach_method_stack_t* method_stack;
   uint32_t object_type_count;
   uint32_t numeric_type_count;
@@ -137,13 +132,6 @@ void reach_free(reach_t* r);
  */
 void reach(reach_t* r, ast_t* type, const char* name, ast_t* typeargs,
   pass_opt_t* opt);
-
-/** Finalise reached types before use.
- *
- * This must be called once all the necessary reachability analysis has been
- * done and before using the data.
- */
-void reach_done(reach_t* r, pass_opt_t* opt);
 
 reach_type_t* reach_type(reach_t* r, ast_t* type);
 

--- a/src/libponyc/reach/subtype.c
+++ b/src/libponyc/reach/subtype.c
@@ -3,6 +3,8 @@
 
 int subtype_kind(reach_type_t* type)
 {
+  pony_assert(type != NULL);
+
   int subtypes = SUBTYPE_KIND_NONE;
 
   size_t i = HASHMAP_BEGIN;
@@ -12,7 +14,7 @@ int subtype_kind(reach_type_t* type)
   {
     if(sub->can_be_boxed)
     {
-      if(type->underlying == TK_PRIMITIVE)
+      if(sub->underlying == TK_PRIMITIVE)
         subtypes |= SUBTYPE_KIND_NUMERIC;
       else
         subtypes |= SUBTYPE_KIND_TUPLE;
@@ -29,6 +31,11 @@ int subtype_kind(reach_type_t* type)
 
 int subtype_kind_overlap(reach_type_t* left, reach_type_t* right)
 {
+  pony_assert(left != NULL);
+
+  if(right == NULL)
+    return subtype_kind(left);
+
   int subtypes = SUBTYPE_KIND_NONE;
 
   size_t i = HASHMAP_BEGIN;

--- a/src/libponyc/reach/subtype.h
+++ b/src/libponyc/reach/subtype.h
@@ -16,8 +16,6 @@ enum subtype_kind_t
   SUBTYPE_KIND_ALL = SUBTYPE_KIND_BOXED | SUBTYPE_KIND_UNBOXED
 };
 
-// These functions shouldn't be called before `reach_done` has been called.
-
 int subtype_kind(reach_type_t* type);
 
 int subtype_kind_overlap(reach_type_t* left, reach_type_t* right);


### PR DESCRIPTION
The previous algorithm for identity of objects was based on closed-world assumptions. That is, code was generated based on the reachable types in the program and the resulting algorithm wasn't generic. The current code generation process used in the compiler being purely closed-world, that genericity wasn't needed and the algorithm worked fine.

With the upcoming work on separate compilation, there will be cases where the code generation process is open-world, i.e. where the compiler doesn't know every existing type in the program when generating code. In those cases, the previous algorithm won't be usable anymore.

In addition, the previous algorithm worked by enumerating every possible type and generating specific code for each one, which could result in a lot of code being generated. A generic algorithm can reduce the amount of code without losing too much efficiency compared to a specialised one since the amount of required steps in the algorithm is basically unchanged.

The new algorithm reuses the generic parts of the old algorithm and replaces the specific parts (mainly boxed tuple identity) with a process similar to the one used for pattern matching.