### PR TITLE
Remove extra crlf from ast_fprint

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -1631,7 +1631,6 @@ void ast_fprint(FILE* fp, ast_t* ast, size_t width)
     return;
 
   print(fp, ast, 0, NOT_SPECIAL, width);
-  fprintf(fp, "\n");
 }
 
 void ast_fprintverbose(FILE* fp, ast_t* ast)


### PR DESCRIPTION
the print routine in ast.c already prints a crlf so the one printed
in ast_fprint is unnecessary, this change removes the extra crlf.

To test I added some consecutive ast_print statements to
suggest_alt_name:
```
   if(case_ast != NULL)
   {
+    AST_GET_CHILDREN(case_ast, first, second);
+    printf("suggest_alt_name:    ast "); ast_print(ast, 200);
+    printf("suggest_alt_name:  first "); ast_print(first, 200);
+    printf("suggest_alt_name: second "); ast_print(second, 200);
+
+    return NULL;
+
```
Before this change the output would be:
```
$ ./build/debug/ponyc ../issue-2508/
Building builtin -> /home/wink/prgs/pony/ponyc/packages/builtin
Building ../issue-2508/ -> /home/wink/prgs/pony/issue-2508
suggest_alt_name:    ast (reference (id doit))

suggest_alt_name:  first box

suggest_alt_name: second (id doIt)

suggest_alt_name:    ast (reference (id astr))

suggest_alt_name:  first (id aStr)

suggest_alt_name: second (nominal (id $0) (id String) x val x x)

Error:
/home/wink/prgs/pony/issue-2508/main.pony:5:5: can't find declaration of 'doit'
    doit() // crash compiler
    ^
Error:
/home/wink/prgs/pony/issue-2508/main.pony:10:5: can't find declaration of 'astr'
    astr
    ^
```
After removing the extra crlf in this change the output is nicer:
```
$ ./build/debug/ponyc ../issue-2508/
Building builtin -> /home/wink/prgs/pony/ponyc/packages/builtin
Building ../issue-2508/ -> /home/wink/prgs/pony/issue-2508
suggest_alt_name:    ast (reference (id doit))
suggest_alt_name:  first box
suggest_alt_name: second (id doIt)
suggest_alt_name:    ast (reference (id astr))
suggest_alt_name:  first (id aStr)
suggest_alt_name: second (nominal (id $0) (id String) x val x x)
Error:
/home/wink/prgs/pony/issue-2508/main.pony:5:5: can't find declaration of 'doit'
    doit() // crash compiler
    ^
Error:
/home/wink/prgs/pony/issue-2508/main.pony:10:5: can't find declaration of 'astr'
    astr
    ^
```