### PR TITLE
Refactor assignment code generation to avoid closed-world assumptions

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -259,8 +259,9 @@ static void init_runtime(compile_t* c)
   // field descriptor
   // Also needed to build a descriptor structure.
   params[0] = c->i32;
-  params[1] = c->descriptor_ptr;
-  c->field_descriptor = LLVMStructTypeInContext(c->context, params, 2, false);
+  params[1] = c->i32;
+  params[2] = c->descriptor_ptr;
+  c->field_descriptor = LLVMStructTypeInContext(c->context, params, 3, false);
 
   // descriptor, filled in
   gendesc_basetype(c, c->descriptor_type);

--- a/src/libponyc/codegen/genbox.h
+++ b/src/libponyc/codegen/genbox.h
@@ -13,6 +13,12 @@ PONY_EXTERN_C_BEGIN
 LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value);
 
 /**
+ * Create a box from a pointer to a value whose type is only known at runtime.
+ */
+LLVMValueRef gen_box_ptr(compile_t* c, LLVMValueRef ptr, LLVMValueRef size,
+  LLVMValueRef desc);
+
+/**
  * If the value is a pointer, unbox it as the specified type. Otherwise return
  * the value.
  */

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -18,6 +18,8 @@ LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object);
 
 LLVMValueRef gendesc_typeid(compile_t* c, LLVMValueRef desc);
 
+LLVMValueRef gendesc_size(compile_t* c, LLVMValueRef desc);
+
 LLVMValueRef gendesc_instance(compile_t* c, LLVMValueRef desc);
 
 LLVMValueRef gendesc_trace(compile_t* c, LLVMValueRef desc);
@@ -38,6 +40,8 @@ LLVMValueRef gendesc_fieldptr(compile_t* c, LLVMValueRef ptr,
 
 LLVMValueRef gendesc_fieldload(compile_t* c, LLVMValueRef ptr,
   LLVMValueRef field_info);
+
+LLVMValueRef gendesc_fieldsize(compile_t* c, LLVMValueRef field_info);
 
 LLVMValueRef gendesc_fielddesc(compile_t* c, LLVMValueRef field_info);
 

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -7,6 +7,7 @@
 #include "genmatch.h"
 #include "genname.h"
 #include "genoperator.h"
+#include "genopt.h"
 #include "genreference.h"
 #include "../type/subtype.h"
 #include "../../libponyrt/mem/pool.h"
@@ -254,50 +255,184 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
   return result;
 }
 
-static LLVMValueRef assign_union_to_tuple(compile_t* c, LLVMTypeRef l_type,
-  LLVMValueRef r_value, ast_t* type)
+static LLVMValueRef assign_ptr_to_tuple(compile_t* c, LLVMTypeRef l_type,
+  LLVMValueRef r_value, LLVMValueRef r_desc);
+
+static LLVMValueRef assign_ptr_to_tuple_element_object(compile_t* c,
+  LLVMTypeRef l_field_type, LLVMValueRef r_field)
 {
-  reach_type_t* t = reach_type(c->reach, type);
-  pony_assert(t != NULL);
-  pony_assert(t->underlying == TK_UNIONTYPE);
-
-  LLVMValueRef r_desc = gendesc_fetch(c, r_value);
-  LLVMValueRef r_typeid = gendesc_typeid(c, r_desc);
-
-  LLVMBasicBlockRef unreachable_block = codegen_block(c, "unreachable");
-  LLVMBasicBlockRef post_block = codegen_block(c, "assign_union_tuple_post");
-  LLVMValueRef type_switch = LLVMBuildSwitch(c->builder, r_typeid,
-    unreachable_block, 0);
-
-  LLVMPositionBuilderAtEnd(c->builder, post_block);
-  LLVMValueRef phi = LLVMBuildPhi(c->builder, l_type, "");
-
-  reach_type_t* sub;
-  size_t i = HASHMAP_BEGIN;
-
-  while((sub = reach_type_cache_next(&t->subtypes, &i)) != NULL)
+  switch(LLVMGetTypeKind(l_field_type))
   {
-    pony_assert(sub->underlying == TK_TUPLETYPE);
+    case LLVMIntegerTypeKind:
+    case LLVMHalfTypeKind:
+    case LLVMFloatTypeKind:
+    case LLVMDoubleTypeKind:
+    {
+      LLVMValueRef offset = LLVMConstInt(c->i32,
+        target_is_ilp32(c->opt->triple) ? 4 : 8, false);
+      r_field = LLVMBuildBitCast(c->builder, r_field, c->void_ptr, "");
+      r_field = LLVMBuildInBoundsGEP(c->builder, r_field, &offset, 1, "");
+      r_field = LLVMBuildBitCast(c->builder, r_field,
+        LLVMPointerType(l_field_type, 0), "");
+      return LLVMBuildLoad(c->builder, r_field, "");
+    }
 
-    LLVMBasicBlockRef sub_block = codegen_block(c, "assign_union_tuple_sub");
-    LLVMAddCase(type_switch, LLVMConstInt(c->i32, sub->type_id, false),
-      sub_block);
-    LLVMPositionBuilderAtEnd(c->builder, sub_block);
+    case LLVMStructTypeKind:
+    {
+      return assign_ptr_to_tuple(c, l_field_type, r_field, NULL);
+    }
 
-    LLVMValueRef r_unbox = gen_unbox(c, sub->ast_cap, r_value);
-    r_unbox = assign_to_tuple(c, l_type, r_unbox, sub->ast_cap);
-    LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
-    LLVMAddIncoming(phi, &r_unbox, &this_block, 1);
-    LLVMBuildBr(c->builder, post_block);
+    case LLVMPointerTypeKind:
+    {
+      return LLVMBuildBitCast(c->builder, r_field, l_field_type, "");
+    }
+
+    default: {}
   }
 
-  LLVMMoveBasicBlockAfter(unreachable_block, LLVMGetInsertBlock(c->builder));
-  LLVMPositionBuilderAtEnd(c->builder, unreachable_block);
-  LLVMBuildUnreachable(c->builder);
+  pony_assert(0);
+  return NULL;
+}
 
-  LLVMMoveBasicBlockAfter(post_block, unreachable_block);
-  LLVMPositionBuilderAtEnd(c->builder, post_block);
+static LLVMValueRef assign_ptr_to_tuple_element_box(compile_t* c,
+  LLVMValueRef r_field_ptr, LLVMValueRef r_field_size,
+  LLVMValueRef r_field_desc)
+{
+  LLVMBasicBlockRef box_block = codegen_block(c, "assign_ptr_tuple_box");
+  LLVMBasicBlockRef nonbox_block = codegen_block(c, "assign_ptr_tuple_nonbox");
+  LLVMBasicBlockRef continue_block = codegen_block(c,
+    "assign_ptr_tuple_merge_box");
+  LLVMValueRef boxed_mask = LLVMConstInt(c->i32, 1, false);
+
+  LLVMValueRef r_typeid = gendesc_typeid(c, r_field_desc);
+  LLVMValueRef boxed = LLVMBuildAnd(c->builder, r_typeid, boxed_mask, "");
+  boxed = LLVMBuildICmp(c->builder, LLVMIntEQ, boxed,
+    LLVMConstInt(c->i32, 0, false), "");
+  LLVMBuildCondBr(c->builder, boxed, box_block, nonbox_block);
+
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
+  LLVMValueRef phi = LLVMBuildPhi(c->builder, c->object_ptr, "");
+
+  LLVMPositionBuilderAtEnd(c->builder, box_block);
+  LLVMValueRef object = gen_box_ptr(c, r_field_ptr, r_field_size, r_field_desc);
+  LLVMBuildBr(c->builder, continue_block);
+  LLVMAddIncoming(phi, &object, &box_block, 1);
+
+  LLVMPositionBuilderAtEnd(c->builder, nonbox_block);
+  LLVMValueRef object_ptr = LLVMBuildBitCast(c->builder, r_field_ptr,
+    LLVMPointerType(c->object_ptr, 0), "");
+  object = LLVMBuildLoad(c->builder, object_ptr, "");
+  LLVMBuildBr(c->builder, continue_block);
+  LLVMAddIncoming(phi, &object, &nonbox_block, 1);
+
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
   return phi;
+}
+
+static LLVMValueRef assign_ptr_to_tuple_element_ptr(compile_t* c,
+  LLVMTypeRef l_field_type, LLVMValueRef r_field_ptr, LLVMValueRef r_field_size,
+  LLVMValueRef r_field_desc)
+{
+  switch(LLVMGetTypeKind(l_field_type))
+  {
+    case LLVMIntegerTypeKind:
+    case LLVMHalfTypeKind:
+    case LLVMFloatTypeKind:
+    case LLVMDoubleTypeKind:
+      r_field_ptr = LLVMBuildBitCast(c->builder, r_field_ptr,
+        LLVMPointerType(l_field_type, 0), "");
+      return LLVMBuildLoad(c->builder, r_field_ptr, "");
+
+    case LLVMStructTypeKind:
+      return assign_ptr_to_tuple(c, l_field_type, r_field_ptr, r_field_desc);
+
+    case LLVMPointerTypeKind:
+      return assign_ptr_to_tuple_element_box(c, r_field_ptr, r_field_size,
+        r_field_desc);
+
+    default: {}
+  }
+
+  pony_assert(0);
+  return NULL;
+}
+
+static LLVMValueRef assign_ptr_to_tuple_element(compile_t* c,
+  LLVMValueRef l_value, LLVMTypeRef l_field_type, LLVMValueRef r_fields,
+  LLVMValueRef r_desc, unsigned int field_index)
+{
+  LLVMValueRef r_field_info = gendesc_fieldinfo(c, r_desc, field_index);
+  LLVMValueRef r_field_ptr = gendesc_fieldptr(c, r_fields, r_field_info);
+  LLVMValueRef r_field_size = gendesc_fieldsize(c, r_field_info);
+  LLVMValueRef r_field_desc = gendesc_fielddesc(c, r_field_info);
+
+  LLVMTypeRef obj_ptr_ptr = LLVMPointerType(c->object_ptr, 0);
+  r_field_ptr = LLVMBuildBitCast(c->builder, r_field_ptr,
+    obj_ptr_ptr, "");
+
+  LLVMBasicBlockRef null_block = codegen_block(c,
+    "assign_ptr_tuple_null_desc");
+  LLVMBasicBlockRef nonnull_block = codegen_block(c,
+    "assign_ptr_tuple_nonnull_desc");
+  LLVMBasicBlockRef continue_block = codegen_block(c,
+    "assign_ptr_tuple_merge_desc");
+  LLVMValueRef test = LLVMBuildIsNull(c->builder, r_field_desc, "");
+  LLVMBuildCondBr(c->builder, test, null_block, nonnull_block);
+
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
+  LLVMValueRef phi = LLVMBuildPhi(c->builder, l_field_type, "");
+
+  LLVMPositionBuilderAtEnd(c->builder, null_block);
+  LLVMValueRef r_field = LLVMBuildLoad(c->builder, r_field_ptr, "");
+  LLVMValueRef l_field = assign_ptr_to_tuple_element_object(c, l_field_type,
+    r_field);
+  LLVMBuildBr(c->builder, continue_block);
+  LLVMBasicBlockRef cur_block = LLVMGetInsertBlock(c->builder);
+  LLVMAddIncoming(phi, &l_field, &cur_block, 1);
+
+  LLVMMoveBasicBlockAfter(nonnull_block, cur_block);
+  LLVMPositionBuilderAtEnd(c->builder, nonnull_block);
+  l_field = assign_ptr_to_tuple_element_ptr(c, l_field_type, r_field_ptr,
+    r_field_size, r_field_desc);
+  LLVMBuildBr(c->builder, continue_block);
+  cur_block = LLVMGetInsertBlock(c->builder);
+  LLVMAddIncoming(phi, &l_field, &cur_block, 1);
+
+  LLVMMoveBasicBlockAfter(continue_block, cur_block);
+  LLVMPositionBuilderAtEnd(c->builder, continue_block);
+  l_value = LLVMBuildInsertValue(c->builder, l_value, phi, field_index, "");
+
+  return l_value;
+}
+
+static LLVMValueRef assign_ptr_to_tuple(compile_t* c, LLVMTypeRef l_type,
+  LLVMValueRef r_value, LLVMValueRef r_desc)
+{
+  unsigned int count = LLVMCountStructElementTypes(l_type);
+  size_t buf_size = count * sizeof(LLVMTypeRef);
+  LLVMTypeRef* elements = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
+  LLVMGetStructElementTypes(l_type, elements);
+
+  LLVMValueRef result = LLVMGetUndef(l_type);
+  LLVMValueRef r_fields;
+
+  if(r_desc == NULL)
+  {
+    r_desc = gendesc_fetch(c, r_value);
+    r_fields = gendesc_ptr_to_fields(c, r_value, r_desc);
+  } else {
+    r_fields = LLVMBuildBitCast(c->builder, r_value, c->void_ptr, "");
+  }
+
+  for(unsigned int i = 0; i < count; i++)
+  {
+    result = assign_ptr_to_tuple_element(c, result, elements[i], r_fields,
+      r_desc, i);
+  }
+
+  ponyint_pool_free_size(buf_size, elements);
+
+  return result;
 }
 
 LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
@@ -354,7 +489,7 @@ LLVMValueRef gen_assign_cast(compile_t* c, LLVMTypeRef l_type,
         if(ast_id(type) == TK_TUPLETYPE)
           r_value = gen_unbox(c, type, r_value);
         else
-          return assign_union_to_tuple(c, l_type, r_value, type);
+          return assign_ptr_to_tuple(c, l_type, r_value, NULL);
 
         pony_assert(LLVMGetTypeKind(LLVMTypeOf(r_value)) == LLVMStructTypeKind);
       }


### PR DESCRIPTION
In the same vein as identity code generation (PR #2553), this change implements a new algorithm for tuple assignment code generation that doesn't need to know every type in the program (i.e. an open-world
algorithm).

Tuple assignment from an unknown type now uses a process similar to the one used for pattern matching.