### PR TITLE
Fix two dynamic scaling race conditions

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -87,7 +87,10 @@ static pony_actor_t* pop_global(scheduler_t* sched)
   if(actor != NULL)
     return actor;
 
-  return pop(sched);
+  if (sched == NULL)
+    return NULL;
+  else
+    return pop(sched);
 }
 
 /**
@@ -403,11 +406,7 @@ static pony_actor_t* steal(scheduler_t* sched)
   {
     scheduler_t* victim = choose_victim(sched);
 
-    if(victim == NULL)
-      actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
-    else
-      actor = pop_global(victim);
-
+    actor = pop_global(victim);
     if(actor != NULL)
     {
       DTRACE3(WORK_STEAL_SUCCESSFUL, (uintptr_t)sched, (uintptr_t)victim, (uintptr_t)actor);
@@ -545,7 +544,7 @@ static pony_actor_t* steal(scheduler_t* sched)
               // new event
               if(sched->index == 0)
               {
-                actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
+                actor = pop_global(NULL);
                 if(actor != NULL)
                   break;
               }
@@ -747,7 +746,7 @@ static pony_actor_t* steal(scheduler_t* sched)
             // new event
             if(sched->index == 0)
             {
-              actor = (pony_actor_t*)ponyint_mpmcq_pop(&inject);
+              actor = pop_global(NULL);
               if(actor != NULL)
                 break;
             }

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -390,6 +390,130 @@ static scheduler_t* choose_victim(scheduler_t* sched)
   return NULL;
 }
 
+/**
+ * Suspend this thread for some time, including no sleep at all if
+ * pop_global() can give us an actor immediately.
+ *
+ * WARNING: steal_suspend_thread must be called in critical section
+ *          protected by sched_mut/scheduler_count_changing,
+ *          and we return with that mechanism locked.
+ */
+static pony_actor_t* steal_suspend_thread(scheduler_t* sched)
+{
+  pony_actor_t* actor = NULL;
+  uint32_t current_active_scheduler_count = get_active_scheduler_count();
+
+  // decrement active_scheduler_count so other schedulers know we're
+  // sleeping
+  uint32_t sched_count = atomic_load_explicit(&active_scheduler_count,
+    memory_order_relaxed);
+
+  // make sure the scheduler count didn't change
+  pony_assert(sched_count == current_active_scheduler_count);
+  (void)current_active_scheduler_count;
+
+  atomic_store_explicit(&active_scheduler_count, sched_count - 1,
+    memory_order_relaxed);
+
+#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
+  // unlock the bool that controls modifying the active scheduler count
+  // variable if using signals
+  atomic_store_explicit(&scheduler_count_changing, false,
+    memory_order_release);
+#endif
+
+  // let sched 0 know we're suspending only after decrementing
+  // active_scheduler_count to avoid a race condition between
+  // when we update active_scheduler_count and scheduler 0 processes
+  // the SCHED_SUSPEND message we send it. If we don't do this,
+  // and scheduler 0 processes the SCHED_SUSPEND message before we
+  // decrement active_scheduler_count, it could think that
+  // active_scheduler_count > block_count and not start the CNF/ACK
+  // process for termination and potentiall hang the runtime instead
+  // of allowing it to reach quiescence.
+  if(sched->index != 0)
+    send_msg(sched->index, 0, SCHED_SUSPEND, 0);
+
+  // dtrace suspend notification
+  DTRACE1(THREAD_SUSPEND, (uintptr_t)sched);
+
+  while(get_active_scheduler_count() <= (uint32_t)sched->index)
+  {
+    // if we're scheduler 0 with noisy actors check to make
+    // sure inject queue is empty to avoid race condition
+    // between thread 0 sleeping and the ASIO thread getting a
+    // new event
+    if(sched->index == 0)
+    {
+      actor = pop_global(NULL);
+      if(actor != NULL)
+        break;
+    }
+
+    // sleep waiting for signal to wake up again
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+    ponyint_thread_suspend(sched->sleep_object, &sched_mut);
+#else
+    ponyint_thread_suspend(sched->sleep_object);
+#endif
+  }
+
+  // dtrace resume notification
+  DTRACE1(THREAD_RESUME, (uintptr_t)sched);
+
+
+  // if we're scheduler 0 with noisy actors
+  // and we just pulled an actor off the  inject queue
+  // break to return the actor
+  if((sched->index == 0) && (actor != NULL))
+  {
+#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
+    // make sure active_scheduler_count == 1
+    while (
+      (current_active_scheduler_count = get_active_scheduler_count())
+        == 0)
+    {
+      // get the bool that controls modifying the active scheduler
+      // count variable if using signals
+      if(!atomic_exchange_explicit(&scheduler_count_changing, true,
+        memory_order_acquire))
+      {
+        // in case the count changed between the while check and now
+        current_active_scheduler_count = get_active_scheduler_count();
+
+        // check active scheduler count is valid
+        pony_assert(current_active_scheduler_count <= 1);
+
+        if(current_active_scheduler_count == 0)
+        {
+          // set active_scheduler_count to 1
+          current_active_scheduler_count = 1;
+          atomic_store_explicit(&active_scheduler_count,
+            current_active_scheduler_count, memory_order_relaxed);
+        }
+      }
+    }
+#else
+    // When using pthreads, no need to acquire mutex because we
+    // already acquired it earlier
+
+    // get active_scheduler_count
+    sched_count = atomic_load_explicit(&active_scheduler_count,
+      memory_order_relaxed);
+
+    // check active scheduler count is valid
+    pony_assert(sched_count <= 1);
+
+    // make sure active_scheduler_count == 1
+    if(sched_count == 0)
+    {
+      atomic_store_explicit(&active_scheduler_count, 1,
+        memory_order_relaxed);
+    }
+#endif
+  }
+  return actor;
+}
 
 /**
  * Use mpmcqs to allow stealing directly from a victim, without waiting for a
@@ -503,152 +627,37 @@ static pony_actor_t* steal(scheduler_t* sched)
           // there is at least one noisy actor registered
           if((sched->index > 0) || ((sched->index == 0) && sched->asio_noisy))
           {
-            // decrement active_scheduler_count so other schedulers know we're
-            // sleeping
-            uint32_t sched_count = atomic_load_explicit(&active_scheduler_count,
-              memory_order_relaxed);
-
-            // make sure the scheduler count didn't change
-            pony_assert(sched_count == current_active_scheduler_count);
-
-            atomic_store_explicit(&active_scheduler_count, sched_count - 1,
-              memory_order_relaxed);
-
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-            // unlock the bool that controls modifying the active scheduler count
-            // variable if using signals
-            atomic_store_explicit(&scheduler_count_changing, false,
-              memory_order_release);
-#endif
-
-            // let sched 0 know we're suspending only after decrementing
-            // active_scheduler_count to avoid a race condition between
-            // when we update active_scheduler_count and scheduler 0 processes
-            // the SCHED_SUSPEND message we send it. If we don't do this,
-            // and scheduler 0 processes the SCHED_SUSPEND message before we
-            // decrement active_scheduler_count, it could think that
-            // active_scheduler_count > block_count and not start the CNF/ACK
-            // process for termination and potentiall hang the runtime instead
-            // of allowing it to reach quiescence.
-            if(sched->index != 0)
-              send_msg(sched->index, 0, SCHED_SUSPEND, 0);
-
-            // dtrace suspend notification
-            DTRACE1(THREAD_SUSPEND, (uintptr_t)sched);
-
-            while(get_active_scheduler_count() <= (uint32_t)sched->index)
-            {
-              // if we're scheduler 0 with noisy actors check to make
-              // sure inject queue is empty to avoid race condition
-              // between thread 0 sleeping and the ASIO thread getting a
-              // new event
-              if(sched->index == 0)
-              {
-                actor = pop_global(NULL);
-                if(actor != NULL)
-                  break;
-              }
-
-              // sleep waiting for signal to wake up again
-#if defined(USE_SCHEDULER_SCALING_PTHREADS)
-              ponyint_thread_suspend(sched->sleep_object, &sched_mut);
-#else
-              ponyint_thread_suspend(sched->sleep_object);
-#endif
-            }
-
-            // dtrace resume notification
-            DTRACE1(THREAD_RESUME, (uintptr_t)sched);
-
+            actor = steal_suspend_thread(sched);
             // reset steal_attempts so we try to steal from all other schedulers
             // prior to suspending again
             steal_attempts = 0;
-
-            // if we're scheduler 0 with noisy actors
-            // and we just pulled an actor off the  inject queue
-            // break to return the actor
-            if((sched->index == 0) && (actor != NULL))
-            {
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-              // make sure active_scheduler_count == 1
-              while (
-                (current_active_scheduler_count = get_active_scheduler_count())
-                  == 0)
-              {
-                // get the bool that controls modifying the active scheduler
-                // count variable if using signals
-                if(!atomic_exchange_explicit(&scheduler_count_changing, true,
-                  memory_order_acquire))
-                {
-                  // in case the count changed between the while check and now
-                  current_active_scheduler_count = get_active_scheduler_count();
-
-                  // check active scheduler count is valid
-                  pony_assert(current_active_scheduler_count <= 1);
-
-                  if(current_active_scheduler_count == 0)
-                  {
-                    // set active_scheduler_count to 1
-                    current_active_scheduler_count = 1;
-                    atomic_store_explicit(&active_scheduler_count,
-                      current_active_scheduler_count, memory_order_relaxed);
-                  }
-
-                  // unlock the bool that controls modifying the active
-                  // scheduler count variable if using signals.
-                  atomic_store_explicit(&scheduler_count_changing, false,
-                    memory_order_release);
-                }
-              }
-#else
-              // When using pthreads, no need to acquire mutex because we
-              // already acquired it earlier
-
-              // get active_scheduler_count
-              sched_count = atomic_load_explicit(&active_scheduler_count,
-                memory_order_relaxed);
-
-              // check active scheduler count is valid
-              pony_assert(sched_count <= 1);
-
-              // make sure active_scheduler_count == 1
-              if(sched_count == 0)
-              {
-                atomic_store_explicit(&active_scheduler_count, 1,
-                  memory_order_relaxed);
-              }
-
-              // unlock mutex if using pthreads
-              pthread_mutex_unlock(&sched_mut);
-#endif
-
-              DTRACE3(WORK_STEAL_SUCCESSFUL, (uintptr_t)sched,
-                (uintptr_t)victim, (uintptr_t)actor);
-              break;
-            }
           }
           else
           {
             pony_assert(sched->index == 0);
             pony_assert(!sched->asio_noisy);
 
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-            // unlock the bool that controls modifying the active scheduler count
-            // variable if using signals
-            atomic_store_explicit(&scheduler_count_changing, false,
-              memory_order_release);
-#endif
-
             // send block message if there are no noisy actors registered
             // with the ASIO thread and this is scheduler 0
             handle_sched_block(sched);
             block_sent = true;
           }
-
+#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
+          // unlock the bool that controls modifying the active scheduler count
+          // variable if using signals
+          atomic_store_explicit(&scheduler_count_changing, false,
+            memory_order_release);
+#endif
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
           // unlock mutex if using pthreads
           pthread_mutex_unlock(&sched_mut);
 #endif
+          if(actor != NULL)
+          {
+            DTRACE3(WORK_STEAL_SUCCESSFUL, (uintptr_t)sched,
+              (uintptr_t)victim, (uintptr_t)actor);
+            break;
+          }
         }
         else if(!sched->asio_noisy)
         {
@@ -705,147 +714,32 @@ static pony_actor_t* steal(scheduler_t* sched)
 
           block_sent = false;
 
-          // decrement active_scheduler_count so other schedulers know we're
-          // sleeping
-          uint32_t sched_count = atomic_load_explicit(&active_scheduler_count,
-            memory_order_relaxed);
-
-          // make sure the scheduler count didn't change
-          pony_assert(sched_count == current_active_scheduler_count);
-
-          atomic_store_explicit(&active_scheduler_count, sched_count - 1,
-            memory_order_relaxed);
-
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-          // unlock the bool that controls modifying the active scheduler count
-          // variable if using signals
-          atomic_store_explicit(&scheduler_count_changing, false,
-            memory_order_release);
-#endif
-
-          // let sched 0 know we're suspending only after decrementing
-          // active_scheduler_count to avoid a race condition between
-          // when we update active_scheduler_count and scheduler 0 processes
-          // the SCHED_SUSPEND message we send it. If we don't do this,
-          // and scheduler 0 processes the SCHED_SUSPEND message before we
-          // decrement active_scheduler_count, it could think that
-          // active_scheduler_count > block_count and not start the CNF/ACK
-          // process for termination and potentiall hang the runtime instead
-          // of allowing it to reach quiescence.
-          if(sched->index != 0)
-            send_msg(sched->index, 0, SCHED_SUSPEND, 0);
-
-          // dtrace suspend notification
-          DTRACE1(THREAD_SUSPEND, (uintptr_t)sched);
-
-          while(get_active_scheduler_count() <= (uint32_t)sched->index)
-          {
-            // if we're scheduler 0 with noisy actors check to make
-            // sure inject queue is empty to avoid race condition
-            // between thread 0 sleeping and the ASIO thread getting a
-            // new event
-            if(sched->index == 0)
-            {
-              actor = pop_global(NULL);
-              if(actor != NULL)
-                break;
-            }
-
-            // sleep waiting for signal to wake up again
-#if defined(USE_SCHEDULER_SCALING_PTHREADS)
-            ponyint_thread_suspend(sched->sleep_object, &sched_mut);
-#else
-            ponyint_thread_suspend(sched->sleep_object);
-#endif
-          }
-
-          // dtrace resume notification
-          DTRACE1(THREAD_RESUME, (uintptr_t)sched);
-
+          actor = steal_suspend_thread(sched);
           // reset steal_attempts so we try to steal from all other schedulers
           // prior to suspending again
           steal_attempts = 0;
-
-          // if we're scheduler 0 with noisy actors
-          // and we just pulled an actor off the  inject queue
-          // break to return the actor
-          if((sched->index == 0) && (actor != NULL))
-          {
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-              // make sure active_scheduler_count == 1
-              while (
-                (current_active_scheduler_count = get_active_scheduler_count())
-                  == 0)
-              {
-                // get the bool that controls modifying the active scheduler
-                // count variable if using signals
-                if(!atomic_exchange_explicit(&scheduler_count_changing, true,
-                  memory_order_acquire))
-                {
-                  // in case the count changed between the while check and now
-                  current_active_scheduler_count = get_active_scheduler_count();
-
-                  // check active scheduler count is valid
-                  pony_assert(current_active_scheduler_count <= 1);
-
-                  if(current_active_scheduler_count == 0)
-                  {
-                    // set active_scheduler_count to 1
-                    current_active_scheduler_count = 1;
-                    atomic_store_explicit(&active_scheduler_count,
-                      current_active_scheduler_count, memory_order_relaxed);
-                  }
-
-                  // unlock the bool that controls modifying the active
-                  // scheduler count variable if using signals.
-                  atomic_store_explicit(&scheduler_count_changing, false,
-                    memory_order_release);
-                }
-              }
-#else
-              // When using pthreads, no need to acquire mutex because we
-              // already acquired it earlier
-
-              // get active_scheduler_count
-              sched_count = atomic_load_explicit(&active_scheduler_count,
-                memory_order_relaxed);
-
-              // check active scheduler count is valid
-              pony_assert(sched_count <= 1);
-
-              // make sure active_scheduler_count == 1
-              if(sched_count == 0)
-              {
-                atomic_store_explicit(&active_scheduler_count, 1,
-                  memory_order_relaxed);
-              }
-
-              // unlock mutex if using pthreads
-              pthread_mutex_unlock(&sched_mut);
-#endif
-
-            DTRACE3(WORK_STEAL_SUCCESSFUL, (uintptr_t)sched,
-              (uintptr_t)victim, (uintptr_t)actor);
-            break;
-          }
         }
         else
         {
           pony_assert(sched->index == 0);
           pony_assert(!sched->asio_noisy);
-
-#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
-          // unlock the bool that controls modifying the active scheduler count
-          // variable if using signals
-          atomic_store_explicit(&scheduler_count_changing, false,
-            memory_order_release);
-#endif
         }
-
+#if !defined(USE_SCHEDULER_SCALING_PTHREADS)
+        // unlock the bool that controls modifying the active scheduler count
+        // variable if using signals
+        atomic_store_explicit(&scheduler_count_changing, false,
+          memory_order_release);
+#endif
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
         // unlock mutex if using pthreads
         pthread_mutex_unlock(&sched_mut);
 #endif
+        if(actor != NULL)
+        {
+          DTRACE3(WORK_STEAL_SUCCESSFUL, (uintptr_t)sched,
+            (uintptr_t)victim, (uintptr_t)actor);
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
@dipinhora's commit (described immediately below) is the minimum required to fix the two race conditions that I'd found in the Pony 0.21.3 runtime that would cause occasional failures of the Wallaroo integration test suite.

    Prior to this commit, there were two race conditions where an ASIO
    event could be received and not result in a wake up notification
    to scheduler 0. One was because scheduler 0 had not actually
    suspended yet so the ASIO thread didn't send a notification at all.
    The other was because scheduler thread 0 had not released the mutex
    so the ASIO thread wasn't able to send a notification because it
    wasn't able to acquire the mutex and didn't retry. Both would result
    in hangs due to the lost wake ups.
    
    This commit fixes things by ensuring that even after scheduler 0
    decides to suspend, it does one final check of the inject queue
    to see if any new work has been queued by the ASIO thread. If yes,
    it doesn't suspend to prevent lost wake ups and the associated
    hangs. It also changes the logic so that the ASIO thread will retry
    waking up scheduler thread 0 if it is unable to acquire the mutex
    until it is successful.

After Dipin's work above, I had suggested and implemented three changes:

* make pop_global() more flexible to adapt to 3 callers in `steal()`
* refactor two nearly identical pieces of `steal()` into a new function `suspend_scheduler()`
* refactor two other nearly identical pieces of `steal()` into a new function `maybe_suspend_scheduler()`

Dipin gave an informal "there might be a performance regression" to my 3 review suggestions, which are also included in this branch, informal approval to number 2, and hasn't yet looked at number 3.  Reviewers are welcome to critique any/all of them.  Taken all together, they make `steal()` much easier to read, IMHO.

Regarding performance regression, I've seen on:

* OS X: no significant degradation in `examples/message-ubench` with 14 different combinations of pinger actors, messages sent, and Pony runtime threads used.  OR ELSE this branch is about 5% faster, which is both nice and also not well understood.
* Linux: I'm currently running more tests with `examples/message-ubench` on a 36 core AWS c4.8xlarge instance now.
