### PR TITLE
Ensure type and method IDs determinism between recompilations

### DIFF
--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -15,11 +15,10 @@ invariants. However, if only "trusted" data (i.e. data produced by Pony
 serialisation from the same binary) is deserialised, it will always maintain a
 well-formed heap and all object invariants.
 
-Note that serialised data is not usable between different Pony binaries,
-possibly including recompilation of the same code. This is due to the use of
-type identifiers rather than a heavy-weight self-describing serialisation
-schema. This also means it isn't safe to deserialise something serialised by
-the same program compiled for a different platform.
+Note that serialised data is not usable between different Pony binaries. This is
+due to the use of type identifiers rather than a heavy-weight self-describing
+serialisation schema. This also means it isn't safe to deserialise something
+serialised by the same program compiled for a different platform.
 
 The Serialise.signature method is provided for the purposes of comparing
 communicating Pony binaries to determine if they are the same. Confirming this

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -86,7 +86,7 @@ typedef struct name_record_t
 // We keep our name records in a hash map
 static size_t name_record_hash(name_record_t* p)
 {
-  return ponyint_hash_ptr(p->name);
+  return ponyint_hash_str(p->name);
 }
 
 static bool name_record_cmp(name_record_t* a, name_record_t* b)

--- a/test/libponyc/reach.cc
+++ b/test/libponyc/reach.cc
@@ -6,8 +6,10 @@
 
 #include "util.h"
 
+#include <memory>
 
-#define TEST_COMPILE(src) DO(test_compile(src, "reach"))
+
+#define TEST_COMPILE(src, pass) DO(test_compile(src, pass))
 
 
 class ReachTest : public PassTest
@@ -32,7 +34,7 @@ TEST_F(ReachTest, IsectHasSubtypes)
     "  fun a() => None\n"
     "  fun b() => None";
 
-  TEST_COMPILE(src);
+  TEST_COMPILE(src, "reach");
 
   ast_t* ab_ast = type_of("ab");
   ASSERT_NE(ab_ast, (void*)NULL);
@@ -55,4 +57,112 @@ TEST_F(ReachTest, IsectHasSubtypes)
   }
 
   ASSERT_TRUE(found);
+}
+
+struct reach_deleter
+{
+  void operator()(reach_t* r)
+  {
+    reach_free(r);
+  }
+};
+
+TEST_F(ReachTest, Determinism)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun f1()\n"
+    "interface I2\n"
+    "  fun f2()\n"
+    "interface I3\n"
+    "  fun f3()\n"
+    "interface I4\n"
+    "  fun f4()\n"
+
+    "class C1 is (I1 & I2)\n"
+    "  fun f1() => None\n"
+    "  fun f2() => None\n"
+    "class C2 is (I2 & I3)\n"
+    "  fun f2() => None\n"
+    "  fun f3() => None\n"
+    "class C3 is (I3 & I4)\n"
+    "  fun f3() => None\n"
+    "  fun f4() => None\n"
+    "class C4 is (I4 & I1)\n"
+    "  fun f4() => None\n"
+    "  fun f1() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    env.out.print(\"\")\n"
+
+    "    U8(0) ; I8(0) ; U16(0) ; I16(0) ; U32(0) ; I32(0)\n"
+
+    "    (C1, C2)\n"
+    "    (C2, C3)\n"
+    "    (C3, C4)\n"
+    "    (C4, C1)\n"
+
+    "    let i1: I1 = C1\n"
+    "    let i2: I2 = C2\n"
+    "    let i3: I3 = C3\n"
+    "    let i4: I4 = C4\n"
+
+    "    i1.f1()\n"
+    "    i2.f2()\n"
+    "    i3.f3()\n"
+    "    i4.f4()";
+
+  set_builtin(nullptr);
+
+  TEST_COMPILE(src, "paint");
+
+  std::unique_ptr<reach_t, reach_deleter> reach_guard{compile->reach};
+  compile->reach = nullptr;
+
+  TEST_COMPILE(src, "paint");
+
+  reach_t* r1 = reach_guard.get();
+  reach_t* r2 = compile->reach;
+
+  ASSERT_EQ(r1->object_type_count, r2->object_type_count);
+  ASSERT_EQ(r1->numeric_type_count, r2->numeric_type_count);
+  ASSERT_EQ(r1->tuple_type_count, r2->tuple_type_count);
+  ASSERT_EQ(r1->total_type_count, r2->total_type_count);
+  ASSERT_EQ(r1->trait_type_count, r2->trait_type_count);
+
+  reach_type_t* t1;
+  size_t i = HASHMAP_BEGIN;
+
+  while((t1 = reach_types_next(&r1->types, &i)) != nullptr)
+  {
+    size_t j = HASHMAP_UNKNOWN;
+    reach_type_t* t2 = reach_types_get(&r2->types, t1, &j);
+
+    ASSERT_NE(t2, nullptr);
+    ASSERT_EQ(t1->type_id, t2->type_id);
+
+    reach_method_name_t* n1;
+    j = HASHMAP_BEGIN;
+
+    while((n1 = reach_method_names_next(&t1->methods, &j)) != nullptr)
+    {
+      size_t k = HASHMAP_UNKNOWN;
+      reach_method_name_t* n2 = reach_method_names_get(&t2->methods, n1, &j);
+
+      ASSERT_NE(n2, nullptr);
+
+      reach_method_t* m1;
+      k = HASHMAP_BEGIN;
+
+      while((m1 = reach_mangled_next(&n1->r_mangled, &k)) != nullptr)
+      {
+        size_t l = HASHMAP_UNKNOWN;
+        reach_method_t* m2 = reach_mangled_get(&n2->r_mangled, m1, &l);
+
+        ASSERT_NE(m2, nullptr);
+        ASSERT_EQ(m1->vtable_index, m2->vtable_index);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This change ensures that for every compilation of the same code with the same compiler version, type and method IDs will not change. This is done by ensuring a deterministic iteration order of the reachability map (which is done by hashing object contents rather than object addresses.)