### PR TITLE
Add basic compiler plugins

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -319,6 +319,7 @@ inline uint64_t __pony_clzl(uint64_t x)
 #    error "Clang doesn't support `static_assert` or `_Static_assert`."
 #  endif
 #else
+#  include <assert.h>
 #  define pony_static_assert(c, m) static_assert(c, m)
 #endif
 

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -55,11 +55,15 @@
 // The private bits of the flags values
 enum
 {
-  AST_ORPHAN = 0x10,
+  AST_ORPHAN = 0x20,
   AST_INHERIT_FLAGS = (AST_FLAG_CAN_ERROR | AST_FLAG_CAN_SEND |
     AST_FLAG_MIGHT_SEND | AST_FLAG_RECURSE_1 | AST_FLAG_RECURSE_2),
-  AST_ALL_FLAGS = 0x3FFFFF
+  AST_ALL_FLAGS = 0x7FFFFF
 };
+
+
+pony_static_assert((int)PASS_ALL <= (int)AST_FLAG_PASS_MASK, "Wrong pass mask");
+pony_static_assert(AST_ORPHAN == (AST_FLAG_PASS_MASK + 1), "Wrong AST_ORPHAN");
 
 
 struct ast_t

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -28,24 +28,24 @@ typedef enum
 
 enum
 {
-  AST_FLAG_PASS_MASK    = 0x0F,
-  AST_FLAG_CAN_ERROR    = 0x20,
-  AST_FLAG_CAN_SEND     = 0x40,
-  AST_FLAG_MIGHT_SEND   = 0x80,
-  AST_FLAG_IN_PARENS    = 0x100,
-  AST_FLAG_AMBIGUOUS    = 0x200,
-  AST_FLAG_BAD_SEMI     = 0x400,
-  AST_FLAG_MISSING_SEMI = 0x800,
-  AST_FLAG_PRESERVE     = 0x1000, // Do not process
-  AST_FLAG_RECURSE_1    = 0x2000,
-  AST_FLAG_DONE_1       = 0x4000,
-  AST_FLAG_ERROR_1      = 0x8000,
-  AST_FLAG_RECURSE_2    = 0x10000,
-  AST_FLAG_DONE_2       = 0x20000,
-  AST_FLAG_ERROR_2      = 0x40000,
-  AST_FLAG_JUMPS_AWAY   = 0x80000, // Jumps away (control flow) without a value.
-  AST_FLAG_INCOMPLETE   = 0x100000, // Not all fields are defined.
-  AST_FLAG_IMPORT       = 0x200000, // Import the referenced package.
+  AST_FLAG_PASS_MASK    = 0x1F,
+  AST_FLAG_CAN_ERROR    = 0x40,
+  AST_FLAG_CAN_SEND     = 0x80,
+  AST_FLAG_MIGHT_SEND   = 0x100,
+  AST_FLAG_IN_PARENS    = 0x200,
+  AST_FLAG_AMBIGUOUS    = 0x400,
+  AST_FLAG_BAD_SEMI     = 0x800,
+  AST_FLAG_MISSING_SEMI = 0x1000,
+  AST_FLAG_PRESERVE     = 0x2000, // Do not process
+  AST_FLAG_RECURSE_1    = 0x4000,
+  AST_FLAG_DONE_1       = 0x8000,
+  AST_FLAG_ERROR_1      = 0x10000,
+  AST_FLAG_RECURSE_2    = 0x20000,
+  AST_FLAG_DONE_2       = 0x40000,
+  AST_FLAG_ERROR_2      = 0x80000,
+  AST_FLAG_JUMPS_AWAY   = 0x100000, // Jumps away (control flow) without a value.
+  AST_FLAG_INCOMPLETE   = 0x200000, // Not all fields are defined.
+  AST_FLAG_IMPORT       = 0x400000, // Import the referenced package.
 };
 
 DECLARE_LIST(astlist, astlist_t, ast_t);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -8,6 +8,7 @@
 #include "../reach/paint.h"
 #include "../pkg/package.h"
 #include "../pkg/program.h"
+#include "../plugin/plugin.h"
 #include "../type/assemble.h"
 #include "../type/lookup.h"
 #include "../../libponyrt/mem/pool.h"
@@ -506,6 +507,8 @@ bool genexe(compile_t* c, ast_t* program)
     fprintf(stderr, " Selector painting\n");
   paint(&c->reach->types);
 
+  plugin_visit_reach(c->reach, c->opt, true);
+
   if(c->opt->limit == PASS_PAINT)
   {
     ast_free(main_ast);
@@ -533,6 +536,8 @@ bool genexe(compile_t* c, ast_t* program)
     return false;
 
   gen_main(c, t_main, t_env);
+
+  plugin_visit_compile(c, c->opt);
 
   if(!genopt(c, true))
     return false;

--- a/src/libponyc/codegen/genlib.c
+++ b/src/libponyc/codegen/genlib.c
@@ -3,6 +3,7 @@
 #include "genobj.h"
 #include "genheader.h"
 #include "genprim.h"
+#include "../plugin/plugin.h"
 #include "../reach/paint.h"
 #include "../type/assemble.h"
 #include "../../libponyrt/mem/pool.h"
@@ -102,6 +103,9 @@ static bool reachable_actors(compile_t* c, ast_t* program)
   if(c->opt->verbosity >= VERBOSITY_INFO)
     fprintf(stderr, " Selector painting\n");
   paint(&c->reach->types);
+
+  plugin_visit_reach(c->reach, c->opt, true);
+
   return true;
 }
 
@@ -176,6 +180,8 @@ bool genlib(compile_t* c, ast_t* program)
     !genheader(c)
     )
     return false;
+
+  plugin_visit_compile(c, c->opt);
 
   if(!genopt(c, true))
     return false;

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -220,6 +220,7 @@ typedef enum pass_id
   PASS_EXPR,
   PASS_VERIFY,
   PASS_FINALISER,
+  PASS_SERIALISER,
   PASS_REACH,
   PASS_PAINT,
   PASS_LLVM_IR,
@@ -246,6 +247,7 @@ typedef enum pass_id
     "    =expr\n" \
     "    =verify\n" \
     "    =final\n" \
+    "    =serialise\n" \
     "    =reach\n" \
     "    =paint\n" \
     "    =ir            Output LLVM IR.\n" \
@@ -255,6 +257,7 @@ typedef enum pass_id
     "    =all           The default: generate an executable.\n"
 
 typedef struct magic_package_t magic_package_t;
+typedef struct plugins_t plugins_t;
 
 /** Pass options.
  */
@@ -297,6 +300,8 @@ typedef struct pass_opt_t
   char* features;
 
   typecheck_t check;
+
+  plugins_t* plugins;
 
   void* data; // User-defined data for unit test callbacks.
 } pass_opt_t;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -104,9 +104,6 @@ struct magic_package_t
   struct magic_package_t* next;
 };
 
-// Function that will handle a path in some way.
-typedef bool (*path_fn)(const char* path, pass_opt_t* opt);
-
 DECLARE_STACK(package_stack, package_stack_t, package_t)
 DEFINE_STACK(package_stack, package_stack_t, package_t)
 
@@ -762,7 +759,7 @@ bool package_init(pass_opt_t* opt)
 }
 
 
-static bool handle_path_list(const char* paths, path_fn f, pass_opt_t* opt)
+bool handle_path_list(const char* paths, path_fn f, pass_opt_t* opt)
 {
   if(paths == NULL)
     return true;

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -2,9 +2,9 @@
 #define PACKAGE_H
 
 #include <platform.h>
-#include "../ast/ast.h"
-#include "../ast/stringtab.h"
-#include "../pass/pass.h"
+#include "../libponyrt/ds/list.h"
+
+#include <stdio.h>
 
 #define SIGNATURE_LENGTH 64
 
@@ -13,15 +13,23 @@ PONY_EXTERN_C_BEGIN
 typedef struct package_t package_t;
 typedef struct package_group_t package_group_t;
 typedef struct magic_package_t magic_package_t;
+typedef struct pass_opt_t pass_opt_t;
+typedef struct ast_t ast_t;
+typedef struct typecheck_t typecheck_t;
 
 DECLARE_LIST_SERIALISE(package_group_list, package_group_list_t,
   package_group_t)
+
+// Function that will handle a path in some way.
+typedef bool (*path_fn)(const char* path, pass_opt_t* opt);
 
 /**
  * Cat together the 2 given path fragments into the given buffer.
  * The first path fragment may be absolute, relative or NULL
  */
 void path_cat(const char* part1, const char* part2, char result[FILENAME_MAX]);
+
+bool handle_path_list(const char* paths, path_fn f, pass_opt_t* opt);
 
 /**
  * Initialises the search directories. This is composed of a "packages"

--- a/src/libponyc/plugin/plugin.c
+++ b/src/libponyc/plugin/plugin.c
@@ -1,0 +1,209 @@
+#include "plugin.h"
+#include "../ast/error.h"
+#include "../pass/pass.h"
+#include "../pkg/package.h"
+#include "../../libponyrt/ds/list.h"
+#include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
+
+#ifdef PLATFORM_IS_POSIX_BASED
+#  include <dlfcn.h>
+#  define PLUGIN_LOAD(path) dlopen(path, RTLD_LAZY)
+#  define PLUGIN_UNLOAD(handle) dlclose(handle)
+#  define PLUGIN_SYMBOL(handle, name) dlsym(handle, name)
+
+typedef void* plugin_handle_t;
+
+#elif defined(PLATFORM_IS_WINDOWS)
+#  include <Windows.h>
+#  define PLUGIN_LOAD(path) LoadLibrary(path)
+#  define PLUGIN_UNLOAD(handle) FreeLibrary(handle)
+#  define PLUGIN_SYMBOL(handle, name) GetProcAddress(handle, name)
+
+typedef HMODULE plugin_handle_t;
+
+#endif
+
+typedef bool(*plugin_init_fn)(pass_opt_t* opt, void** user_data);
+typedef void(*plugin_final_fn)(pass_opt_t* opt, void* user_data);
+typedef const char*(*plugin_help_fn)(void* user_data);
+typedef bool(*plugin_parse_options_fn)(pass_opt_t* opt, int* argc, char** argv,
+  void* user_data);
+typedef void(*plugin_visit_ast_fn)(const ast_t* ast, pass_opt_t* opt,
+  pass_id pass, void* user_data);
+typedef void(*plugin_visit_reach_fn)(const reach_t* r, pass_opt_t* opt,
+  bool built_vtables, void* user_data);
+typedef void(*plugin_visit_compile_fn)(const compile_t* c, pass_opt_t* opt,
+  void* user_data);
+
+typedef struct plugin_t
+{
+  plugin_handle_t handle;
+  const char* path;
+
+  plugin_init_fn init_fn;
+  plugin_final_fn final_fn;
+  plugin_help_fn help_fn;
+  plugin_parse_options_fn parse_options_fn;
+  plugin_visit_ast_fn visit_ast_fn;
+  plugin_visit_reach_fn visit_reach_fn;
+  plugin_visit_compile_fn visit_compile_fn;
+
+  void* user_data;
+} plugin_t;
+
+static __pony_thread_local pass_opt_t* opt_for_free = NULL;
+
+static void plugin_free(plugin_t* p)
+{
+  pony_assert(opt_for_free != NULL);
+
+  if(p->final_fn != NULL)
+    p->final_fn(opt_for_free, p->user_data);
+
+  PLUGIN_UNLOAD(p->handle);
+  POOL_FREE(plugin_t, p);
+}
+
+DECLARE_LIST(plugins, plugins_t, plugin_t);
+DEFINE_LIST(plugins, plugins_t, plugin_t, NULL, plugin_free);
+
+static bool load_plugin(const char* path, pass_opt_t* opt)
+{
+  plugin_handle_t handle = PLUGIN_LOAD(path);
+
+  if(handle == NULL)
+  {
+    errorf(opt->check.errors, NULL, "Couldn't find plugin %s", path);
+    return false;
+  }
+
+  plugin_t* p = POOL_ALLOC(plugin_t);
+  p->handle = handle;
+  p->path = stringtab(path);
+  p->user_data = NULL;
+
+  p->init_fn = (plugin_init_fn)PLUGIN_SYMBOL(handle, "pony_plugin_init");
+  p->final_fn = (plugin_final_fn)PLUGIN_SYMBOL(handle, "pony_plugin_final");
+  p->help_fn = (plugin_help_fn)PLUGIN_SYMBOL(handle, "pony_plugin_help");
+  p->parse_options_fn = (plugin_parse_options_fn)PLUGIN_SYMBOL(handle,
+    "pony_plugin_parse_options");
+  p->visit_ast_fn = (plugin_visit_ast_fn)PLUGIN_SYMBOL(handle,
+    "pony_plugin_visit_ast");
+  p->visit_reach_fn = (plugin_visit_reach_fn)PLUGIN_SYMBOL(handle,
+    "pony_plugin_visit_reach");
+  p->visit_compile_fn = (plugin_visit_compile_fn)PLUGIN_SYMBOL(handle,
+    "pony_plugin_visit_compile");
+
+  if((p->init_fn != NULL) && !p->init_fn(opt, &p->user_data))
+  {
+    PLUGIN_UNLOAD(p->handle);
+    POOL_FREE(plugin_t, p);
+    return false;
+  }
+
+  opt->plugins = plugins_append(opt->plugins, p);
+
+  return true;
+}
+
+bool plugin_load(pass_opt_t* opt, const char* paths)
+{
+  return handle_path_list(paths, load_plugin, opt);
+}
+
+void plugin_print_help(pass_opt_t* opt)
+{
+  plugins_t* plugins = opt->plugins;
+
+  while(plugins != NULL)
+  {
+    plugin_t* plugin = plugins_data(plugins);
+
+    if(plugin->help_fn != NULL)
+    {
+      const char* str = plugin->help_fn(plugin->user_data);
+      printf("\nHelp for plugin %s:\n%s\n", plugin->path, str);
+    } else {
+      printf("\nNo help for plugin %s\n", plugin->path);
+    }
+
+    plugins = plugins_next(plugins);
+  }
+}
+
+bool plugin_parse_options(pass_opt_t* opt, int* argc, char** argv)
+{
+  bool ok = true;
+  plugins_t* plugins = opt->plugins;
+
+  while(plugins != NULL)
+  {
+    plugin_t* plugin = plugins_data(plugins);
+
+    if(plugin->parse_options_fn != NULL)
+    {
+      if(!plugin->parse_options_fn(opt, argc, argv, plugin->user_data))
+        ok = false;
+    }
+
+    plugins = plugins_next(plugins);
+  }
+
+  return ok;
+}
+
+void plugin_visit_ast(const ast_t* ast, pass_opt_t* opt, pass_id pass)
+{
+  plugins_t* plugins = opt->plugins;
+
+  while(plugins != NULL)
+  {
+    plugin_t* plugin = plugins_data(plugins);
+
+    if(plugin->visit_ast_fn != NULL)
+      plugin->visit_ast_fn(ast, opt, pass, plugin->user_data);
+
+    plugins = plugins_next(plugins);
+  }
+}
+
+void plugin_visit_reach(const reach_t* r, pass_opt_t* opt, bool built_vtables)
+{
+  plugins_t* plugins = opt->plugins;
+
+  while(plugins != NULL)
+  {
+    plugin_t* plugin = plugins_data(plugins);
+
+    if(plugin->visit_reach_fn != NULL)
+      plugin->visit_reach_fn(r, opt, built_vtables, plugin->user_data);
+
+    plugins = plugins_next(plugins);
+  }
+}
+
+void plugin_visit_compile(const compile_t* c, pass_opt_t* opt)
+{
+  plugins_t* plugins = opt->plugins;
+
+  while(plugins != NULL)
+  {
+    plugin_t* plugin = plugins_data(plugins);
+
+    if(plugin->visit_compile_fn != NULL)
+      plugin->visit_compile_fn(c, opt, plugin->user_data);
+
+    plugins = plugins_next(plugins);
+  }
+}
+
+void plugin_unload(pass_opt_t* opt)
+{
+  opt_for_free = opt;
+
+  plugins_free(opt->plugins);
+  opt->plugins = NULL;
+
+  opt_for_free = NULL;
+}

--- a/src/libponyc/plugin/plugin.h
+++ b/src/libponyc/plugin/plugin.h
@@ -1,0 +1,86 @@
+#ifndef PLUGIN_PLUGIN_H
+#define PLUGIN_PLUGIN_H
+
+#include <platform.h>
+#include "../pass/pass.h"
+
+PONY_EXTERN_C_BEGIN
+
+// Plugins are shared objects/DLLs loaded through dlopen/LoadLibrary depending
+// on the platform. Plugins can supply the following functions. It isn't
+// mandatory to supply all of them.
+//
+// - bool pony_plugin_init(pass_opt_t* opt, void** user_data)
+//
+//    Called right after the plugin has been loaded. Should return true if
+//    initialisation was successful, false otherwise. Detailed initialisation
+//    errors can be reported through opt or outputted directly. Arbitrary data
+//    can be stored in user_data.
+//
+// - void pony_plugin_final(pass_opt_t* opt, void* user_data)
+//
+//    Called right before the plugin is unloaded. This shouldn't report errors.
+//
+// - const char* pony_plugin_help(void* user_data)
+//
+//    Should return a string to be displayed alongside the compiler help when
+//    invoking `ponyc --help`. If the string is dynamically allocated, the
+//    plugin has the responsibility to free it in pony_plugin_final.
+//
+// - bool pony_plugin_parse_options(pass_opt_t* opt, int* argc, char** argv,
+//     void* user_data)
+//
+//    Allows the plugin to parse command line options. argv contains all
+//    options that weren't recognised by the compiler or by previously loaded
+//    plugins. The function must remove the arguments that it recognised from
+//    argv and update argc accordingly. No other modification is allowed. It is
+//    recommended to use the options module in libponyrt (not libponyc), which
+//    meets the above requirement. Should return true if parsing was successful,
+//    false if it wasn't. Note that unrecognised options shouldn't count as
+//    unsucessful parsing. Examples of failures include bad formatting of
+//    recognised option arguments.
+//    Note that as stated above, plugins will consume command line options based
+//    on their loading order, which corresponds to their order of appearance in
+//    the --plugin command line option.
+//
+// - void pony_plugin_visit_ast(const ast_t* ast, pass_opt_t* opt, pass_id pass,
+//     void* user_data)
+//
+//    Called after each AST pass. The AST is the program AST. pass is the last
+//    pass the AST ran through. This shouldn't report errors.
+//
+// - void pony_plugin_visit_reach(const reach_t* r, pass_opt_t* opt,
+//     bool built_vtables, void* user_data)
+//
+//    Called after reachability analysis. built_vtables is true if vtable IDs
+//    have been assigned, false otherwise. This shouldn't report errors.
+//
+// - void pony_plugin_visit_compile(const compile_t* c, pass_opt_t* opt,
+//     void* user_data)
+//
+//    Called after LLVM code generation. This shouldn't report errors.
+//
+// Note that only read-only plugins are supported. A plugin **must not** modify
+// the compiler data structures passed to it unless stated otherwise.
+
+typedef struct ast_t ast_t;
+typedef struct reach_t reach_t;
+typedef struct compile_t compile_t;
+
+bool plugin_load(pass_opt_t* opt, const char* paths);
+
+void plugin_print_help(pass_opt_t* opt);
+
+bool plugin_parse_options(pass_opt_t* opt, int* argc, char** argv);
+
+void plugin_visit_ast(const ast_t* ast, pass_opt_t* opt, pass_id pass);
+
+void plugin_visit_reach(const reach_t* r, pass_opt_t* opt, bool built_vtables);
+
+void plugin_visit_compile(const compile_t* c, pass_opt_t* opt);
+
+void plugin_unload(pass_opt_t* opt);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -112,7 +112,7 @@ struct reach_type_t
   compile_opaque_t* c_type;
 };
 
-typedef struct
+typedef struct reach_t
 {
   reach_types_t types;
   reachable_expr_stack_t* expr_stack;

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -89,11 +89,14 @@ int main(int argc, char* argv[])
 
   exit_code = ponyc_opt_process(&s, &opt, &print_program_ast,
                   &print_package_ast);
+
   if(exit_code == EXIT_255)
   {
     errors_print(opt.check.errors);
+    pass_opt_done(&opt);
     return -1;
   } else if(exit_code == EXIT_0) {
+    pass_opt_done(&opt);
     return 0;
   }
 


### PR DESCRIPTION
This change adds a framework for compiler plugins. Plugins are specified through the new `--plugin` command line option and can observe the compiler data structures at various stages of the compilation process. Only read-only plugins are supported.

An example of this functionality is a plugin that reports detailed metrics about the compilation process.