### PR TITLE
Make the File.open constructor use read-only mode (Issue #2567)

### DIFF
--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -151,9 +151,9 @@ class File
       _errno = FileError
     else
       _fd = ifdef windows then
-        @_open[I32](path.path.cstring(), @ponyint_o_rdwr())
+        @_open[I32](path.path.cstring(), @ponyint_o_rdonly())
       else
-        @open[I32](path.path.cstring(), @ponyint_o_rdwr())
+        @open[I32](path.path.cstring(), @ponyint_o_rdonly())
       end
 
       if _fd == -1 then


### PR DESCRIPTION
Use @ponyint_o_rdonly rather than _rdwr in the calls to @open and
@_open.