### PR TITLE
Add support for getting the index of a scheduler

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -218,7 +218,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
   pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
 
   while((msg = ponyint_actor_messageq_pop(&actor->q
-#ifdef USE_DYNAMIC_TRACE    
+#ifdef USE_DYNAMIC_TRACE
     , ctx->scheduler, ctx->current
 #endif
     )) != NULL)
@@ -507,7 +507,7 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
     ponyint_maybe_mute(ctx, to);
 
   if(ponyint_actor_messageq_push(&to->q, first, last
-#ifdef USE_DYNAMIC_TRACE 
+#ifdef USE_DYNAMIC_TRACE
     , ctx->scheduler, ctx->current, to
 #endif
     ))

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -485,6 +485,8 @@ PONY_API void pony_register_thread();
  */
 PONY_API void pony_unregister_thread();
 
+PONY_API int32_t pony_scheduler_index(pony_ctx_t* ctx);
+
 /** Signals that the pony runtime may terminate.
  *
  * This only needs to be called if pony_start() was called with library set to

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -983,6 +983,7 @@ PONY_API void pony_register_thread()
   this_scheduler = POOL_ALLOC(scheduler_t);
   memset(this_scheduler, 0, sizeof(scheduler_t));
   this_scheduler->tid = ponyint_thread_self();
+  this_scheduler->index = -1;
 }
 
 PONY_API void pony_unregister_thread()
@@ -1193,3 +1194,8 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
   return actors_rescheduled > 0;
 }
 
+// Return the scheduler's index
+PONY_API int32_t pony_sched_index(pony_ctx_t* ctx)
+{
+  return ctx->scheduler->index;
+}


### PR DESCRIPTION
This commit adds a C function that, given a scheduler context, returns
the index of the scheduler. This can be useful in applications that
interact with C libraries and need to do things on a per-thread basis.