### PR TITLE
Always unsubscribe process_monitor fds before closing them (#2529)

### DIFF
--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -537,7 +537,15 @@ actor ProcessMonitor
 
   fun ref _close_fd(fd: U32) =>
     """
-    Close a file descriptor.
+    Close a file descriptor.  This function also handles unsubscribing
+    the asio event (if the file descriptor has one), the file
+    descriptor should always be closed _after_ unsubscribing the
+    event, otherwise there is the possibility of reusing the file
+    descriptor in another thread and then unsubscribing the reused
+    file descriptor here!  Unsubscribing and closing the file
+    descriptor should be treated as one operation, and as this
+    function is called from many places in this module put the
+    unsubscribing logic here too.
     """
     match fd
     | _stdin_write =>

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -539,6 +539,20 @@ actor ProcessMonitor
     """
     Close a file descriptor.
     """
+    match fd
+    | _stdin_write =>
+      if _stdin_event isnt AsioEvent.none() then
+        @pony_asio_event_unsubscribe(_stdin_event)
+      end
+    | _stdout_read =>
+      if _stdout_event isnt AsioEvent.none() then
+        @pony_asio_event_unsubscribe(_stdout_event)
+      end
+    | _stderr_read =>
+      if _stderr_event isnt AsioEvent.none() then
+        @pony_asio_event_unsubscribe(_stderr_event)
+      end
+    end
     @close[I32](fd)
     match fd
     | _stdin_read => _stdin_read = -1
@@ -551,7 +565,7 @@ actor ProcessMonitor
 
   fun ref _close() =>
     """
-    Close all pipes, unsubscribe events and wait for the child process to exit.
+    Close all pipes wait for the child process to exit.
     """
     ifdef posix then
       if not _closed then
@@ -565,15 +579,6 @@ actor ProcessMonitor
         _stdin_writeable = false
         _stdout_readable = false
         _stderr_readable = false
-        if _stdin_event isnt AsioEvent.none() then
-          @pony_asio_event_unsubscribe(_stdin_event)
-        end
-        if _stdout_event isnt AsioEvent.none() then
-          @pony_asio_event_unsubscribe(_stdout_event)
-        end
-        if _stderr_event isnt AsioEvent.none() then
-          @pony_asio_event_unsubscribe(_stderr_event)
-        end
         if _child_pid > 0 then
           // This is the parent, so capture the exit status of the child
           var wstatus: I32 = 0


### PR DESCRIPTION
This is a 99% fix for #2529; instead of the test program in the issue failing almost immediately with 10 subprocesses, it fails after somewhere in the region of 3k to 50k iterations, depending on whether ponyc is a debug build, has extra debugging printfs inserted, etc. When some extra code is inserted into the epoll asio backend to check the return value of epoll_ctl(..., EPOLL_CTL_DEL,...), call is always failing as the fd is already closed. I don't quite understand why the test program eventually hangs; it almost seems like some events are not being posted to the receiving actor. This needs further testing, so please leave #2529 open.