### PR TITLE
Use NOMINMAX to get gbenchmark to compile on windows

### DIFF
--- a/lib/gbenchmark/src/commandlineflags.cc
+++ b/lib/gbenchmark/src/commandlineflags.cc
@@ -20,14 +20,6 @@
 #include <iostream>
 #include <limits>
 
-#ifdef max
-#undef max
-#endif
-
-#ifdef min
-#undef min
-#endif
-
 namespace benchmark {
 // Parses 'str' for a 32-bit signed integer.  If successful, writes
 // the result to *value and returns true; otherwise leaves *value

--- a/wscript
+++ b/wscript
@@ -276,7 +276,7 @@ def build(ctx):
         target   = 'gbenchmark',
         source   = ctx.path.ant_glob('lib/gbenchmark/*.cc'),
         includes = [ 'lib/gbenchmark/include' ],
-        defines  = [ 'HAVE_STD_REGEX' ]
+        defines  = [ 'HAVE_STD_REGEX', 'NOMINMAX' ]
     )
 
     # blake2


### PR DESCRIPTION
This seems cleaner than using #undef's that where used when change
9c0053990ba7d4748274f9c7ddce85756488eb0a added them to commandlineflags.cc.

@kulibali, could you review this please.