### PR TITLE
Add arg and param type to "not a subtype" error (issue #2530)

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -242,7 +242,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(a_type));
-      ast_error_frame(&frame, arg, "parameter type is %s",
+      ast_error_frame(&frame, param, "parameter type is %s",
                       ast_print_type(p_type));
       errorframe_append(&frame, &info);
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -240,6 +240,10 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
+      ast_error_frame(&frame, arg, "argument type is %s",
+                      ast_print_type(a_type));
+      ast_error_frame(&frame, arg, "parameter type is %s",
+                      ast_print_type(p_type));
       errorframe_append(&frame, &info);
 
       if (ast_childcount(arg) > 1)

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -74,6 +74,10 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
     {
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
+      ast_error_frame(&frame, arg, "argument type is %s",
+                      ast_print_type(a_type));
+      ast_error_frame(&frame, arg, "parameter type is %s",
+                      ast_print_type(p_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
       ast_free_unattached(a_type);

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -76,7 +76,7 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(a_type));
-      ast_error_frame(&frame, arg, "parameter type is %s",
+      ast_error_frame(&frame, param, "parameter type is %s",
                       ast_print_type(p_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -108,7 +108,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
         ast_error_frame(&frame, value, "argument not a subtype of parameter");
         ast_error_frame(&frame, value, "argument type is %s",
                         ast_print_type(v_type));
-        ast_error_frame(&frame, value, "parameter type is %s",
+        ast_error_frame(&frame, id_node, "parameter type is %s",
                         ast_print_type(type));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -106,6 +106,10 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
       {
         errorframe_t frame = NULL;
         ast_error_frame(&frame, value, "argument not a subtype of parameter");
+        ast_error_frame(&frame, value, "argument type is %s",
+                        ast_print_type(v_type));
+        ast_error_frame(&frame, value, "parameter type is %s",
+                        ast_print_type(type));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ast_free_unattached(v_type);


### PR DESCRIPTION
Add type info for arguments and parameters in the "argument not a subtype of parameter" error.

Fix for issue #2530.