### PR TITLE
Revert gbenchmark DragonFly BSD 4.8 Support in gbenchmark

### DIFF
--- a/lib/gbenchmark/src/internal_macros.h
+++ b/lib/gbenchmark/src/internal_macros.h
@@ -47,7 +47,7 @@
     #endif
   #endif
 #elif defined(__FreeBSD__)
-  #define BENCHMARK_OS_BSD 1
+  #define BENCHMARK_OS_FREEBSD 1
 #elif defined(__NetBSD__)
   #define BENCHMARK_OS_NETBSD 1
 #elif defined(__linux__)

--- a/lib/gbenchmark/src/sysinfo.cc
+++ b/lib/gbenchmark/src/sysinfo.cc
@@ -26,7 +26,7 @@
 #include <sys/time.h>
 #include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
 #include <unistd.h>
-#if defined BENCHMARK_OS_BSD || defined BENCHMARK_OS_MACOSX || \
+#if defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX || \
     defined BENCHMARK_OS_NETBSD
 #define BENCHMARK_HAS_SYSCTL
 #include <sys/sysctl.h>

--- a/lib/gbenchmark/src/timers.cc
+++ b/lib/gbenchmark/src/timers.cc
@@ -27,7 +27,7 @@
 #include <sys/time.h>
 #include <sys/types.h>  // this header must be included before 'sys/sysctl.h' to avoid compilation error on FreeBSD
 #include <unistd.h>
-#if defined BENCHMARK_OS_BSD || defined BENCHMARK_OS_MACOSX
+#if defined BENCHMARK_OS_FREEBSD || defined BENCHMARK_OS_MACOSX
 #include <sys/sysctl.h>
 #endif
 #if defined(BENCHMARK_OS_MACOSX)


### PR DESCRIPTION
These changes serve no real purpose in gbenchmark where there are no
differences between FREE BSD and DragonFly BSD.

I didn't realize that when I created PR #2573 "Update gbenchmark" and
merged in the gbenchmark changes from PR #2183. This reverts back to
just using BENCHMARK_OS_FREEBSD in lib/gbenchmark and thus a few less
differences between lib/gbenchmark and google/benchmark.