### PR TITLE
Fix extracting docstring from constructors

### DIFF
--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -151,6 +151,30 @@ static ast_result_t sugar_module(pass_opt_t* opt, ast_t* ast)
 }
 
 
+static void sugar_docstring(ast_t* ast)
+{
+  pony_assert(ast != NULL);
+
+  AST_GET_CHILDREN(ast, cap, id, type_params, params, return_type,
+    error, body, docstring);
+
+  if(ast_id(docstring) == TK_NONE)
+  {
+    ast_t* first = ast_child(body);
+
+    // First expression in body is a docstring if it is a string literal and
+    // there are any other expressions in the body sequence
+    if((first != NULL) &&
+      (ast_id(first) == TK_STRING) &&
+      (ast_sibling(first) != NULL))
+    {
+      ast_pop(body);
+      ast_replace(&docstring, first);
+    }
+  }
+}
+
+
 static ast_result_t sugar_entity(pass_opt_t* opt, ast_t* ast, bool add_create,
   token_id def_def_cap)
 {
@@ -216,6 +240,8 @@ static ast_result_t sugar_entity(pass_opt_t* opt, ast_t* ast, bool add_create,
 
           pony_assert(ast_id(n_body) == TK_SEQ);
 
+          sugar_docstring(member);
+
           ast_t* init = ast_child(init_seq);
 
           while(init != NULL)
@@ -256,29 +282,6 @@ static ast_result_t sugar_typeparam(ast_t* ast)
   return AST_OK;
 }
 
-
-static void sugar_docstring(ast_t* ast)
-{
-  pony_assert(ast != NULL);
-
-  AST_GET_CHILDREN(ast, cap, id, type_params, params, return_type,
-    error, body, docstring);
-
-  if(ast_id(docstring) == TK_NONE)
-  {
-    ast_t* first = ast_child(body);
-
-    // First expression in body is a docstring if it is a string literal and
-    // there are any other expressions in the body sequence
-    if((first != NULL) &&
-      (ast_id(first) == TK_STRING) &&
-      (ast_sibling(first) != NULL))
-    {
-      ast_pop(body);
-      ast_replace(&docstring, first);
-    }
-  }
-}
 
 
 static ast_result_t sugar_new(pass_opt_t* opt, ast_t* ast)


### PR DESCRIPTION
from classes or actors with initialized fields

by executing `sugar_docstring` on the constructors before adding the initializers. This will actually execute `sugar_docstring` twice on such constructors, but as it is idempotent, there is no danger here.

The docstrings have been inlined into the constructor body before.

Now they will show up correctly in the generated docs.

Fixes #2582 