### PR TITLE
Add Pointer._convert and remove Pointer._consume_from

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -184,12 +184,12 @@ class Array[A] is Seq[A]
       if _size.next_pow2() != _alloc.next_pow2() then
         _alloc = _size.next_pow2()
         let old_ptr = _ptr = Pointer[A]._alloc(_alloc)
-        _ptr._consume_from(consume old_ptr, _size)
+        old_ptr._copy_to(_ptr._convert[A!](), _size)
       end
     elseif _size < _alloc then
       _alloc = _size
       let old_ptr = _ptr = Pointer[A]._alloc(_alloc)
-      _ptr._consume_from(consume old_ptr, _size)
+      old_ptr._copy_to(_ptr._convert[A!](), _size)
     end
 
   fun ref undefined[B: (A & Real[B] val & Number) = A](len: USize) =>

--- a/packages/builtin/pointer.pony
+++ b/packages/builtin/pointer.pony
@@ -28,6 +28,12 @@ struct Pointer[A]
     """
     compile_intrinsic
 
+  fun _convert[B](): this->Pointer[B] =>
+    """
+    Convert from Pointer[A] to Pointer[B].
+    """
+    compile_intrinsic
+
   fun _apply(i: USize): this->A =>
     """
     Retrieve index i.
@@ -71,12 +77,6 @@ struct Pointer[A]
   fun _copy_to(that: Pointer[this->A!], n: USize): this->Pointer[A] =>
     """
     Copy n elements from this to that.
-    """
-    compile_intrinsic
-
-  fun ref _consume_from(that: Pointer[A]^, n: USize): Pointer[A]^ =>
-    """
-    Copy n elements from that to this.
     """
     compile_intrinsic
 

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -302,13 +302,13 @@ actor Main
       if (_size + 1).next_pow2() != _alloc.next_pow2() then
         _alloc = (_size + 1).next_pow2()
         let old_ptr = _ptr = Pointer[U8]._alloc(_alloc)
-        _ptr._consume_from(consume old_ptr, _size)
+        old_ptr._copy_to(_ptr, _size)
         _set(_size, 0)
       end
     elseif (_size + 1) < _alloc then
       _alloc = (_size + 1)
       let old_ptr = _ptr = Pointer[U8]._alloc(_alloc)
-      _ptr._consume_from(consume old_ptr, _size)
+      old_ptr._copy_to(_ptr, _size)
       _set(_size, 0)
     end
 


### PR DESCRIPTION
`_consume_from` was implemented as a workaround for `Array.compact`, which needed to copy elements from a pointer to another without aliasing, and thus couldn't use `Pointer._copy_to`. The API of
`_consume_from` didn't reflect the function name, as the receiver wasn't necessarily consumed. Even though the function could only be used from the builtin package, the discrepancy was somewhat confusing and could have lead to subtle bugs within builtin.

The new `_convert` function does a raw (potentially unsafe) cast between pointer types and is used in `Array.compact` to construct an aliased pointer type. This is still an unsafe hack around the type system's safety, but it is now a clear and straightforward hack, similar to `Pointer._unsafe`.

No changelog entry since this is a change to a private API.