### PR TITLE
Make asserts consistent across asio implementations

### DIFF
--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -149,7 +149,10 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);
@@ -174,7 +177,10 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);
@@ -304,7 +310,10 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);
@@ -376,7 +385,10 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   if(ev->flags & ASIO_TIMER)
   {
@@ -390,7 +402,10 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -263,7 +263,10 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);
@@ -300,7 +303,10 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   if((ev->flags & ASIO_TIMER) != 0)
   {

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -104,7 +104,10 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);
@@ -132,7 +135,10 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
   if((ev == NULL) ||
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
+  {
+    pony_assert(0);
     return;
+  }
 
   asio_backend_t* b = ponyint_asio_get_backend();
   pony_assert(b != NULL);


### PR DESCRIPTION
Also added asserts to pony_asio_event_resubscribe_(read|write); only for epoll & kqueue because iocp doesn’t have those two functions.

This is based on a request @mfelsche made in #2580.

While I have your attention, I'll just note that pony_event_resubscribe_(read|write) are not declared in event.h, despite being marked with `PONY_API`. However, as they are not defined at all for Windows it's not clear if they are actually part of the api, or just some internals that can be used in pony code, so the only place they are used in ponyc is in tcp_connection.c.