### PR TITLE
Partially mitigate LLVM's infinite loops bug

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -85,16 +85,7 @@ static LLVMTargetMachineRef make_machine(pass_opt_t* opt, bool jit)
     return NULL;
   }
 
-  LLVMCodeGenOptLevel opt_level =
-    opt->release ? LLVMCodeGenLevelAggressive : LLVMCodeGenLevelNone;
-
-  LLVMRelocMode reloc =
-    (opt->pic || opt->library) ? LLVMRelocPIC : LLVMRelocDefault;
-
-  LLVMCodeModel model = jit ? LLVMCodeModelJITDefault : LLVMCodeModelDefault;
-
-  LLVMTargetMachineRef machine = LLVMCreateTargetMachine(target, opt->triple,
-    opt->cpu, opt->features, opt_level, reloc, model);
+  LLVMTargetMachineRef machine = codegen_machine(target, opt, jit);
 
   if(machine == NULL)
   {

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -230,6 +230,9 @@ bool codegen_pass_init(pass_opt_t* opt);
 
 void codegen_pass_cleanup(pass_opt_t* opt);
 
+LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt,
+  bool jit);
+
 bool codegen(ast_t* program, pass_opt_t* opt);
 
 bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt,


### PR DESCRIPTION
The LLVM optimiser in its current state treats infinite loops as provoking undefined behaviour, which can lead to very undesirable effects in Pony programs (for example, an incorrect behaviour being called on a message receive.)

This change should completely fix the example described above, and fix some other less catastrophic manifestations of this bug.

There are ongoing efforts to fix these bugs on LLVM's side. Once they are completely fixed, this workaround can be removed.