### PR TITLE
Fix #2596,Failing compilation when embedded structs are of type Pointers/MaybePointers

### DIFF
--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -24,7 +24,7 @@ typedef struct stringtab_entry_t
 
 static size_t stringtab_hash(stringtab_entry_t* a)
 {
-  return (size_t)ponyint_hash_block(a->str, a->len);
+  return ponyint_hash_block(a->str, a->len);
 }
 
 static bool stringtab_cmp(stringtab_entry_t* a, stringtab_entry_t* b)

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -290,7 +290,7 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
       AST_GET_CHILDREN(ast, id, type, init);
       bool ok = true;
 
-      if(ast_id(type) != TK_NOMINAL)
+      if(ast_id(type) != TK_NOMINAL || is_pointer(type) || is_maybe(type))
         ok = false;
 
       ast_t* def = (ast_t*)ast_data(type);

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -116,7 +116,7 @@ static size_t package_hash(package_t* pkg)
   // Hash the full string instead of the stringtab pointer. We want a
   // deterministic hash in order to enable deterministic hashmap iteration,
   // which in turn enables deterministic package signatures.
-  return (size_t)ponyint_hash_str(pkg->qualified_name);
+  return ponyint_hash_str(pkg->qualified_name);
 }
 
 

--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -19,7 +19,7 @@ static const unsigned char the_key[16] = {
   } while(0)
 
 
-static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
+static size_t siphash24(const unsigned char* key, const char* in, size_t len)
 {
   uint64_t k0 = *(uint64_t*)(key);
   uint64_t k1 = *(uint64_t*)(key + 8);
@@ -65,12 +65,12 @@ static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
   return v0 ^ v1 ^ v2 ^ v3;
 }
 
-PONY_API uint64_t ponyint_hash_block(const void* p, size_t len)
+PONY_API size_t ponyint_hash_block(const void* p, size_t len)
 {
   return siphash24(the_key, (const char*)p, len);
 }
 
-uint64_t ponyint_hash_str(const char* str)
+size_t ponyint_hash_str(const char* str)
 {
   return siphash24(the_key, str, strlen(str));
 }

--- a/src/libponyrt/ds/fun.h
+++ b/src/libponyrt/ds/fun.h
@@ -20,9 +20,9 @@ typedef void (*free_fn)(void* data);
 
 typedef void (*free_size_fn)(size_t size, void* data);
 
-PONY_API uint64_t ponyint_hash_block(const void* p, size_t len);
+PONY_API size_t ponyint_hash_block(const void* p, size_t len);
 
-uint64_t ponyint_hash_str(const char* str);
+size_t ponyint_hash_str(const char* str);
 
 size_t ponyint_hash_ptr(const void* p);
 


### PR DESCRIPTION
Failing compilation when embedded structs are of type Pointers/MaybePointers

Before Fix:
Embedded structs of type Pointers/MaybePointers resulted in assert failures

After Fix:
Embedded structs of type Pointers/MaybePointers results in compilation failures
 
Tests and Build Passed Successfully.

[Ticket: #2596 ]