### PR TITLE
Delay union folding until the expr pass

### DIFF
--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -8,27 +8,9 @@
 #include "../type/viewpoint.h"
 #include "ponyassert.h"
 
-static ast_result_t flatten_union(pass_opt_t* opt, ast_t** astp)
+static void flatten_typeexpr_element(ast_t* type, ast_t* elem, token_id id)
 {
-  ast_t* ast = *astp;
-
-  // If there are more than 2 children, this has already been flattened.
-  if(ast_childcount(ast) > 2)
-    return AST_OK;
-
-  AST_EXTRACT_CHILDREN(ast, left, right);
-
-  ast_t* r_ast = type_union(opt, left, right);
-  ast_replace(astp, r_ast);
-  ast_free_unattached(left);
-  ast_free_unattached(right);
-
-  return AST_OK;
-}
-
-static void flatten_isect_element(ast_t* type, ast_t* elem)
-{
-  if(ast_id(elem) != TK_ISECTTYPE)
+  if(ast_id(elem) != id)
   {
     ast_append(type, elem);
     return;
@@ -43,6 +25,23 @@ static void flatten_isect_element(ast_t* type, ast_t* elem)
   }
 
   ast_free_unattached(elem);
+}
+
+static ast_result_t flatten_union(pass_opt_t* opt, ast_t* ast)
+{
+  (void)opt;
+  // Flatten unions without testing subtyping. This will be tested after the
+  // traits pass, when we have full subtyping information.
+  // If there are more than 2 children, this has already been flattened.
+  if(ast_childcount(ast) > 2)
+    return AST_OK;
+
+  AST_EXTRACT_CHILDREN(ast, left, right);
+
+  flatten_typeexpr_element(ast, left, TK_UNIONTYPE);
+  flatten_typeexpr_element(ast, right, TK_UNIONTYPE);
+
+  return AST_OK;
 }
 
 static ast_result_t flatten_isect(pass_opt_t* opt, ast_t* ast)
@@ -69,8 +68,8 @@ static ast_result_t flatten_isect(pass_opt_t* opt, ast_t* ast)
     return AST_ERROR;
   }
 
-  flatten_isect_element(ast, left);
-  flatten_isect_element(ast, right);
+  flatten_typeexpr_element(ast, left, TK_ISECTTYPE);
+  flatten_typeexpr_element(ast, right, TK_ISECTTYPE);
 
   return AST_OK;
 }
@@ -255,7 +254,7 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
   switch(ast_id(ast))
   {
     case TK_UNIONTYPE:
-      return flatten_union(options, astp);
+      return flatten_union(options, ast);
 
     case TK_ISECTTYPE:
       return flatten_isect(options, ast);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -830,6 +830,13 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
   ast_t* sub_def = (ast_t*)ast_data(sub);
   ast_t* super_def = (ast_t*)ast_data(super);
 
+  // We could be reporting false negatives if the traits pass hasn't processed
+  // our defs yet.
+  pass_id sub_pass = (pass_id)ast_checkflag(sub_def, AST_FLAG_PASS_MASK);
+  pass_id super_pass = (pass_id)ast_checkflag(super_def, AST_FLAG_PASS_MASK);
+  pony_assert((sub_pass >= PASS_TRAITS) && (super_pass >= PASS_TRAITS));
+  (void)sub_pass; (void)super_pass;
+
   if(is_bare(sub) != is_bare(super))
   {
     if(errorf != NULL)


### PR DESCRIPTION
Previously, union folding (the process of removing members from the union if they have a redundant subtyping relationship) was done during the flatten pass. This was problematic, as the `is_subtype` function needed for folding can return false negatives for structural subtyping if the AST processing hasn't reached the traits pass.

Union folding now happens during the expr pass, which runs after the traits pass. The flatten pass now only flattens union members in a single AST node. This doesn't fix any type checking issue as getting a false negative in that situation only meant that a redundant union member would be present. However, it does allow us to prevent other potential bugs since we can now add an assertion checking the pass status in the structural subtyping code.