### PR TITLE
Update pony_os_keepalive for OSX

### DIFF
--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -1066,17 +1066,19 @@ PONY_API void pony_os_keepalive(int fd, int secs)
   if(on == 0)
     return;
 
-#if defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_BSD)
+#if defined(PLATFORM_IS_LINUX) || defined(PLATFORM_IS_BSD) || defined(PLATFORM_IS_MACOSX)
   int probes = secs / 2;
   setsockopt(s, IPPROTO_TCP, TCP_KEEPCNT, &probes, sizeof(int));
 
   int idle = secs / 2;
+#if defined(PLATFORM_IS_MACOSX)
+  setsockopt(s, IPPROTO_TCP, TCP_KEEPALIVE, &idle, sizeof(int));
+#else
   setsockopt(s, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(int));
+#endif
 
   int intvl = 1;
   setsockopt(s, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(int));
-#elif defined(PLATFORM_IS_MACOSX)
-  setsockopt(s, IPPROTO_TCP, TCP_KEEPALIVE, &secs, sizeof(int));
 #elif defined(PLATFORM_IS_WINDOWS)
   DWORD ret = 0;
 


### PR DESCRIPTION
As of OSX Mountain Lion, there are new options for keepalive
socket options that allow the same amount of control as on
Linux and BSD. See the following two links reference the
new options and their behavior:

https://lists.apple.com/archives/macnetworkprog/2012/Jul/msg00005.html
https://github.com/dotnet/corefx/issues/14237#issue-193825607

This commit updates the pony_os_keepalive function to take
advantage of this functionality.