### PR TITLE
Ensure ASIO thread cannot be stopped prematurely

### DIFF
--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -59,7 +59,7 @@ bool ponyint_asio_start()
 
 bool ponyint_asio_stop()
 {
-  if(atomic_load_explicit(&running_base.noisy_count, memory_order_relaxed) > 0)
+  if(!ponyint_asio_stoppable())
     return false;
 
   if(running_base.backend != NULL)
@@ -72,6 +72,12 @@ bool ponyint_asio_stop()
   }
 
   return true;
+}
+
+bool ponyint_asio_stoppable()
+{
+  // can only stop if we have no noisy actors
+  return atomic_load_explicit(&running_base.noisy_count, memory_order_relaxed) == 0;
 }
 
 uint64_t ponyint_asio_noisy_add()

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -83,6 +83,13 @@ uint32_t ponyint_asio_get_cpu();
  */
 bool ponyint_asio_stop();
 
+/** Checks if it is safe to stop the asynchronous event mechanism.
+ *
+ * Stopping an event mechanism is only possible if there are no pending "noisy"
+ * subscriptions.
+ */
+bool ponyint_asio_stoppable();
+
 /** Add a noisy event subscription.
  */
 uint64_t ponyint_asio_noisy_add();

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -56,7 +56,7 @@ struct scheduler_t
   uint32_t cpu;
   uint32_t node;
   bool terminate;
-  bool asio_stopped;
+  bool asio_stoppable;
   bool asio_noisy;
   pony_signal_event_t sleep_object;
 


### PR DESCRIPTION
Prior to this commit, it was possible for the ASIO thread to
be stopped in anticipation of runtime termination when runtime
termination didn't actually occur. This would leave the runtime
in an invalid state where a new ASIO thread would need to be
restarted.

This commit changes the behavior to ensure that the ASIO thread
is only stopped when the runtime is about to be terminated to
ensure the runtime cannot be in an invalid state where the ASIO
thread isn't running.