### PR TITLE
Make digestof and hash() return USize instead of U64 and add hash64()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Support OpenSSL 1.1.0 ([PR #2415](https://github.com/ponylang/ponyc/pull/2415))
 - Add U64 type to `cli` package. ([PR #2488](https://github.com/ponylang/ponyc/pull/2488))
 - Allow customisation of `Env.input` and `Env.exitcode` in artificial environments
+- `hash64()` function and related helper types in `collections` for 64-bit hashes ([PR #2615](https://github.com/ponylang/ponyc/pull/2615))
 
 ### Changed
 
@@ -53,6 +54,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix and re-enable dynamic scheduler scaling ([PR #2483](https://github.com/ponylang/ponyc/pull/2483))
 - Expose OutStream rather than StdStream in Env ([PR #2463](https://github.com/ponylang/ponyc/pull/2463))
 - Rename StdinNotify to InputNotify
+- `digestof` and `hash()` now return USize instead of U64 ([PR #2615](https://github.com/ponylang/ponyc/pull/2615))
 
 ## [0.21.3] - 2018-01-14
 

--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -169,7 +169,8 @@ primitive F32 is FloatingPoint[F32]
 
   fun copysign(sign: F32): F32 => @"llvm.copysign.f32"[F32](this, sign)
 
-  fun hash(): U64 => bits().hash()
+  fun hash(): USize => bits().hash()
+  fun hash64(): U64 => bits().hash64()
 
   fun i128(): I128 => f64().i128()
   fun u128(): U128 => f64().u128()
@@ -359,7 +360,8 @@ primitive F64 is FloatingPoint[F64]
 
   fun copysign(sign: F64): F64 => @"llvm.copysign.f64"[F64](this, sign)
 
-  fun hash(): U64 => bits().hash()
+  fun hash(): USize => bits().hash()
+  fun hash64(): U64 => bits().hash64()
 
   fun i128(): I128 =>
     if this > I128.max_value().f64() then

--- a/packages/builtin/pointer.pony
+++ b/packages/builtin/pointer.pony
@@ -109,8 +109,14 @@ struct Pointer[A]
   fun tag ge(that: Pointer[A] tag): Bool => not lt(that)
   fun tag gt(that: Pointer[A] tag): Bool => not le(that)
 
-  fun tag hash(): U64 =>
+  fun tag hash(): USize =>
     """
     Returns a hash of the address.
     """
     usize().hash()
+
+  fun tag hash64(): U64 =>
+    """
+    Returns a 64-bit hash of the address.
+    """
+    usize().hash64()

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -156,8 +156,25 @@ trait val Real[A: Real[A] val] is
   fun min(y: A): A
   fun max(y: A): A
 
-  fun hash(): U64 =>
+  fun hash(): USize =>
+    var x = usize()
+
+    ifdef ilp32 then
+      x = (not x) + (x << 15)
+      x = x xor (x >> 12)
+      x = x + (x << 2)
+      x = x xor (x >> 4)
+      x = (x + (x << 3)) + (x << 11)
+      x = x xor (x >> 16)
+
+      x
+    else
+      hash64().usize()
+    end
+
+  fun hash64(): U64 =>
     var x = u64()
+
     x = (not x) + (x << 21)
     x = x xor (x >> 24)
     x = (x + (x << 3)) + (x << 8)
@@ -165,6 +182,7 @@ trait val Real[A: Real[A] val] is
     x = (x + (x << 2)) + (x << 4)
     x = x xor (x >> 28)
     x = x + (x << 31)
+
     x
 
   fun _value(): A => compile_intrinsic

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -152,6 +152,7 @@ primitive I64 is _SignedInteger[I64, U64]
 
   fun min(y: I64): I64 => if this < y then this else y end
   fun max(y: I64): I64 => if this > y then this else y end
+  fun hash(): USize => u64().hash()
 
   fun addc(y: I64): (I64, Bool) =>
     @"llvm.sadd.with.overflow.i64"[(I64, Bool)](this, y)
@@ -227,6 +228,7 @@ primitive ILong is _SignedInteger[ILong, ULong]
   fun bitwidth(): ULong => ifdef ilp32 or llp64 then 32 else 64 end
   fun min(y: ILong): ILong => if this < y then this else y end
   fun max(y: ILong): ILong => if this > y then this else y end
+  fun hash(): USize => ulong().hash()
 
   fun addc(y: ILong): (ILong, Bool) =>
     ifdef ilp32 or llp64 then
@@ -366,7 +368,8 @@ primitive I128 is _SignedInteger[I128, U128]
   fun bitwidth(): U128 => 128
   fun min(y: I128): I128 => if this < y then this else y end
   fun max(y: I128): I128 => if this > y then this else y end
-  fun hash(): U64 => ((this.u128() >> 64).u64() xor this.u64()).hash()
+  fun hash(): USize => u128().hash()
+  fun hash64(): U64 => u128().hash64()
 
   fun string(): String iso^ =>
     _ToString._u128(abs().u128(), this < 0)

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -1480,8 +1480,11 @@ actor Main
       F64(0)
     end
 
-  fun hash(): U64 =>
-    @ponyint_hash_block[U64](_ptr, _size)
+  fun hash(): USize =>
+    @ponyint_hash_block[USize](_ptr, _size)
+
+  fun hash64(): U64 =>
+    @ponyint_hash_block64[U64](_ptr, _size)
 
   fun string(): String iso^ =>
     clone()

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -165,6 +165,13 @@ primitive U64 is _UnsignedInteger[U64]
   fun min(y: U64): U64 => if this < y then this else y end
   fun max(y: U64): U64 => if this > y then this else y end
 
+  fun hash(): USize =>
+    ifdef ilp32 then
+      ((this >> 32).u32() xor this.u32()).hash()
+    else
+      usize().hash()
+    end
+
   fun addc(y: U64): (U64, Bool) =>
     @"llvm.uadd.with.overflow.i64"[(U64, Bool)](this, y)
 
@@ -246,6 +253,13 @@ primitive ULong is _UnsignedInteger[ULong]
   fun bitwidth(): ULong => ifdef ilp32 or llp64 then 32 else 64 end
   fun min(y: ULong): ULong => if this < y then this else y end
   fun max(y: ULong): ULong => if this > y then this else y end
+
+  fun hash(): USize =>
+    ifdef ilp32 or llp64 then
+      u32().hash()
+    else
+      u64().hash()
+    end
 
   fun addc(y: ULong): (ULong, Bool) =>
     ifdef ilp32 or llp64 then
@@ -396,7 +410,19 @@ primitive U128 is _UnsignedInteger[U128]
   fun bitwidth(): U128 => 128
   fun min(y: U128): U128 => if this < y then this else y end
   fun max(y: U128): U128 => if this > y then this else y end
-  fun hash(): U64 => ((this >> 64).u64() xor this.u64()).hash()
+
+  fun hash(): USize =>
+    ifdef ilp32 then
+      ((this >> 96).u32() xor
+      (this >> 64).u32() xor
+      (this >> 32).u32() xor
+      this.u32()).hash()
+    else
+      ((this >> 64).u64() xor this.u64()).hash()
+    end
+
+  fun hash64(): U64 =>
+    ((this >> 64).u64() xor this.u64()).hash64()
 
   fun string(): String iso^ =>
     _ToString._u128(this, false)

--- a/packages/net/http/_host_service.pony
+++ b/packages/net/http/_host_service.pony
@@ -10,7 +10,7 @@ class val _HostService is (Hashable & Equatable[_HostService])
     host = host'
     service = service'
 
-  fun hash(): U64 =>
+  fun hash(): USize =>
     scheme.hash() xor host.hash() xor service.hash()
 
   fun eq(that: _HostService box): Bool =>

--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -24,7 +24,7 @@ typedef struct stringtab_entry_t
 
 static size_t stringtab_hash(stringtab_entry_t* a)
 {
-  return (size_t)ponyint_hash_block(a->str, a->len);
+  return ponyint_hash_block(a->str, a->len);
 }
 
 static bool stringtab_cmp(stringtab_entry_t* a, stringtab_entry_t* b)

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -704,8 +704,8 @@ bool expr_digestof(pass_opt_t* opt, ast_t* ast)
       return false;
   }
 
-  // Set the type to U64.
-  ast_t* type = type_builtin(opt, expr, "U64");
+  // Set the type to USize.
+  ast_t* type = type_builtin(opt, expr, "USize");
   ast_settype(ast, type);
   return true;
 }

--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -11,68 +11,69 @@ static const unsigned char the_key[16] = {
 
 #ifdef PLATFORM_IS_ILP32
 
-#define ROTL(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
+#define ROTL32(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
 
-#define SIPROUND \
-    do { \
-        v0 += v1; v1=ROTL(v1,5); v1 ^= v0; v0 = ROTL(v0,16); \
-        v2 += v3; v3=ROTL(v3,8); v3 ^= v2; \
-	v0 += v3; v3=ROTL(v3,7); v3 ^= v0; \
-        v2 += v1; v1=ROTL(v1,13); v1 ^= v2; v2 = ROTL(v2,16); \
-    } while (0)
-
-
-static uint32_t halfsiphash24(const unsigned char* key, const char *in, size_t len)
-  {
-    uint32_t k0 = *(uint32_t*)(key);
-    uint32_t k1 = *(uint32_t*)(key + 4);
-    uint32_t b = (uint32_t)len << 24;
-
-    uint32_t v0 = k0 ^ 0x736f6d65;
-    uint32_t v1 = k1 ^ 0x646f7261;
-    uint32_t v2 = k0 ^ 0x6c796765;
-    uint32_t v3 = k1 ^ 0x74656462;
-
-    const char* end = (in + len) - (len % 4);
-
-    for (; in != end; in += 4)
-    {
-      uint32_t m = *(uint32_t*)in;
-      v3 ^= m;
-      SIPROUND;
-      SIPROUND;
-      v0 ^= m;
-    }
-
-    switch (len & 3)
-    {
-      case 3: b |= ((uint32_t)in[2]) << 16; // fallthrough
-      case 2: b |= ((uint32_t)in[1]) << 8;  // fallthrough
-      case 1: b |= ((uint32_t)in[0]);
-    }
-
-    v3 ^= b;
-    SIPROUND;
-    SIPROUND;
-    v0 ^= b;
-    v2 ^= 0xff;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-    SIPROUND;
-
-    return v0 ^ v1 ^ v2 ^ v3;
-}
-#else
-
-#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
-
-#define SIPROUND \
+#define SIPROUND32 \
   do { \
-    v0 += v1; v1=ROTL(v1,13); v1 ^= v0; v0=ROTL(v0,32); \
-    v2 += v3; v3=ROTL(v3,16); v3 ^= v2; \
-    v0 += v3; v3=ROTL(v3,21); v3 ^= v0; \
-    v2 += v1; v1=ROTL(v1,17); v1 ^= v2; v2=ROTL(v2,32); \
+    v0 += v1; v1=ROTL32(v1,5); v1 ^= v0; v0 = ROTL32(v0,16); \
+    v2 += v3; v3=ROTL32(v3,8); v3 ^= v2; \
+    v0 += v3; v3=ROTL32(v3,7); v3 ^= v0; \
+    v2 += v1; v1=ROTL32(v1,13); v1 ^= v2; v2 = ROTL32(v2,16); \
+  } while (0)
+
+
+static uint32_t halfsiphash24(const unsigned char* key, const char* in,
+  size_t len)
+{
+  uint32_t k0 = *(uint32_t*)(key);
+  uint32_t k1 = *(uint32_t*)(key + 4);
+  uint32_t b = (uint32_t)len << 24;
+
+  uint32_t v0 = k0 ^ 0x736f6d65;
+  uint32_t v1 = k1 ^ 0x646f7261;
+  uint32_t v2 = k0 ^ 0x6c796765;
+  uint32_t v3 = k1 ^ 0x74656462;
+
+  const char* end = (in + len) - (len % 4);
+
+  for (; in != end; in += 4)
+  {
+    uint32_t m = *(uint32_t*)in;
+    v3 ^= m;
+    SIPROUND32;
+    SIPROUND32;
+    v0 ^= m;
+  }
+
+  switch (len & 3)
+  {
+    case 3: b |= ((uint32_t)in[2]) << 16; // fallthrough
+    case 2: b |= ((uint32_t)in[1]) << 8;  // fallthrough
+    case 1: b |= ((uint32_t)in[0]);
+  }
+
+  v3 ^= b;
+  SIPROUND32;
+  SIPROUND32;
+  v0 ^= b;
+  v2 ^= 0xff;
+  SIPROUND32;
+  SIPROUND32;
+  SIPROUND32;
+  SIPROUND32;
+
+  return v0 ^ v1 ^ v2 ^ v3;
+}
+#endif
+
+#define ROTL64(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define SIPROUND64 \
+  do { \
+    v0 += v1; v1=ROTL64(v1,13); v1 ^= v0; v0=ROTL64(v0,32); \
+    v2 += v3; v3=ROTL64(v3,16); v3 ^= v2; \
+    v0 += v3; v3=ROTL64(v3,21); v3 ^= v0; \
+    v2 += v1; v1=ROTL64(v1,17); v1 ^= v2; v2=ROTL64(v2,32); \
   } while(0)
 
 
@@ -93,8 +94,8 @@ static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
   {
     uint64_t m = *(uint64_t*)in;
     v3 ^= m;
-    SIPROUND;
-    SIPROUND;
+    SIPROUND64;
+    SIPROUND64;
     v0 ^= m;
   }
 
@@ -110,28 +111,31 @@ static uint64_t siphash24(const unsigned char* key, const char* in, size_t len)
   }
 
   v3 ^= b;
-  SIPROUND;
-  SIPROUND;
+  SIPROUND64;
+  SIPROUND64;
   v0 ^= b;
   v2 ^= 0xff;
-  SIPROUND;
-  SIPROUND;
-  SIPROUND;
-  SIPROUND;
+  SIPROUND64;
+  SIPROUND64;
+  SIPROUND64;
+  SIPROUND64;
 
   return v0 ^ v1 ^ v2 ^ v3;
 }
-#endif
 
 PONY_API size_t ponyint_hash_block(const void* p, size_t len)
 {
 #ifdef PLATFORM_IS_ILP32
-  return halfsiphash24(the_key, (const char*) p, len);
+  return halfsiphash24(the_key, (const char*)p, len);
 #else
-  return siphash24(the_key, (const char*) p, len);
+  return siphash24(the_key, (const char*)p, len);
 #endif
 }
 
+PONY_API uint64_t ponyint_hash_block64(const void* p, size_t len)
+{
+  return siphash24(the_key, (const char*)p, len);
+}
 
 size_t ponyint_hash_str(const char* str)
 {

--- a/src/libponyrt/ds/fun.h
+++ b/src/libponyrt/ds/fun.h
@@ -23,6 +23,8 @@ typedef void (*free_size_fn)(size_t size, void* data);
 
 PONY_API size_t ponyint_hash_block(const void* p, size_t len);
 
+PONY_API uint64_t ponyint_hash_block64(const void* p, size_t len);
+
 size_t ponyint_hash_str(const char* str);
 
 size_t ponyint_hash_ptr(const void* p);

--- a/test/libponyc/codegen_identity.cc
+++ b/test/libponyc/codegen_identity.cc
@@ -247,7 +247,7 @@ TEST_F(CodegenIdentityTest, DigestofObject)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    let dg = digestof env\n"
-    "    if dg == @ptr_to_int[USize](env).u64() then\n"
+    "    if dg == @ptr_to_int[USize](env) then\n"
     "      @pony_exitcode[None](I32(1))\n"
     "    end";
 

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -66,6 +66,7 @@ static const char* const _builtin =
   "primitive USize is Real[USize]"
   "  new create(a: USize = 0) => a\n"
   "  fun u64(): U64 => compile_intrinsic\n"
+  "  fun op_xor(a: USize): USize => this xor a\n"
   "primitive ISize is Real[ISize]"
   "  new create(a: ISize = 0) => a\n"
   "  fun neg(): ISize => -this\n"


### PR DESCRIPTION
Having hash values being 64-bit wide on both 32 and 64-bit platforms was a bit odd. With USize, that width will match the machine word width on every platform.