### PR TITLE
Do not realloc non-pony_alloc'ed memory in pony_realloc

### DIFF
--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -468,13 +468,9 @@ void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
 
   chunk_t* chunk = ponyint_pagemap_get(p);
 
-  if(chunk == NULL)
-  {
-    // Get new memory and copy from the old memory.
-    void* q = ponyint_heap_alloc(actor, heap, size);
-    memcpy(q, p, size);
-    return q;
-  }
+  // We can't realloc memory that wasn't pony_alloc'ed since we can't know how
+  // much to copy from the previous location.
+  pony_assert(chunk != NULL);
 
   size_t oldsize;
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -300,7 +300,8 @@ PONY_API ATTRIBUTE_MALLOC void* pony_alloc_large(pony_ctx_t* ctx, size_t size);
 /** Reallocate memory on the current actor's heap.
  *
  * Take heap memory and expand it. This is a no-op if there's already enough
- * space, otherwise it allocates and copies.
+ * space, otherwise it allocates and copies. The old memory must have been
+ * allocated via pony_alloc(), pony_alloc_small(), or pony_alloc_large().
  */
 PONY_API ATTRIBUTE_MALLOC void* pony_realloc(pony_ctx_t* ctx, void* p, size_t size);
 


### PR DESCRIPTION
This change forbids the reallocation of foreign memory in pony_realloc. This is because the function can only know the size of the old allocation (and thus the amount to copy) if the memory was pony_alloc'ed.