### PR TITLE
Fix GPG key for bintray in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ export CC=`which gcc`
 Install ponyc via bintray:
 
 ```bash
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2"
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "379CE192D401AB61"
 echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get -V install ponyc


### PR DESCRIPTION
When trying to install via DEB package on bintray, according to the README instructions, I hit issues with this command:

```
sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2"
```
```
gpg: "D401AB61 DBE1D0A2" not a key ID: skipping
```

After reading [this ticket](https://github.com/ponylang/ponyc/issues/1825) and seeing a different key there, I changed it to the following, and everything worked:

```
apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "379CE192D401AB61"
```

Did the old command ever work?
Am I missing something?