### PR TITLE
Fix for bug #2620

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -948,16 +948,15 @@ actor TCPConnection
   fun ref _apply_backpressure() =>
     if not _throttled then
       _throttled = true
-      ifdef not windows then
-        _writeable = false
-
-        // this is safe because asio thread isn't currently subscribed
-        // for a write event so will not be writing to the readable flag
-        @pony_asio_event_set_writeable(_event, false)
-        @pony_asio_event_resubscribe_write(_event)
-      end
-
       _notify.throttled(this)
+    end
+    ifdef not windows then
+      _writeable = false
+
+      // this is safe because asio thread isn't currently subscribed
+      // for a write event so will not be writing to the readable flag
+      @pony_asio_event_set_writeable(_event, false)
+      @pony_asio_event_resubscribe_write(_event)
     end
 
   fun ref _release_backpressure() =>


### PR DESCRIPTION
This is a small simplification of the bug fix proposed in the description of bug #2620.

Variations of this bugfix, tested in the Wallaroo source, work well to prevent #2620's busy-looping problem.  It's not easy to create a deterministic test case for this, but if reviewers insist, I can try to be creative.

Fixes #2620 
