### PR TITLE
Improve pattern matching error reporting

### DIFF
--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -151,6 +151,7 @@ void ast_printverbose(ast_t* ast);
 void ast_fprint(FILE* fp, ast_t* ast, size_t width);
 void ast_fprintverbose(FILE* fp, ast_t* ast);
 const char* ast_print_type(ast_t* type);
+const char* ast_print_type_no_cap(ast_t* type);
 
 void ast_error(errors_t* errors, ast_t* ast, const char* fmt, ...)
   __attribute__((format(printf, 3, 4)));

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -848,7 +848,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
     ast_t* pattern_type = deferred_reify(reify, ast_type(the_case), c->opt);
     bool ok = true;
 
-    matchtype_t match = is_matchtype(match_type, pattern_type, c->opt);
+    matchtype_t match = is_matchtype(match_type, pattern_type, NULL, c->opt);
 
     ast_free_unattached(pattern_type);
 

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -547,7 +547,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
   // val and tag in that order.
   if(orig_cap == TK_ISO)
   {
-    if(is_matchtype(orig, type, opt) == MATCHTYPE_ACCEPT)
+    if(is_matchtype(orig, type, NULL, opt) == MATCHTYPE_ACCEPT)
     {
       return PONY_TRACE_MUTABLE;
     } else {
@@ -557,7 +557,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
 
   if(ast_id(cap) == TK_VAL)
   {
-    if(is_matchtype(orig, type, opt) == MATCHTYPE_ACCEPT)
+    if(is_matchtype(orig, type, NULL, opt) == MATCHTYPE_ACCEPT)
     {
       ast_setid(cap, orig_cap);
       return PONY_TRACE_IMMUTABLE;
@@ -569,7 +569,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
   pony_assert(ast_id(cap) == TK_TAG);
 
   int ret = -1;
-  if(is_matchtype(orig, type, opt) == MATCHTYPE_ACCEPT)
+  if(is_matchtype(orig, type, NULL, opt) == MATCHTYPE_ACCEPT)
     ret = PONY_TRACE_OPAQUE;
 
   ast_setid(cap, orig_cap);

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -7,10 +7,10 @@
 #include "ponyassert.h"
 
 static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt);
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt);
 
 static matchtype_t is_union_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   matchtype_t ok = MATCHTYPE_REJECT;
 
@@ -18,7 +18,7 @@ static matchtype_t is_union_match_x(ast_t* operand, ast_t* pattern,
     child != NULL;
     child = ast_sibling(child))
   {
-    switch(is_x_match_x(child, pattern, opt))
+    switch(is_x_match_x(child, pattern, NULL, false, opt))
     {
       case MATCHTYPE_ACCEPT:
         // If any type in the operand union accepts a match, then the entire
@@ -32,7 +32,34 @@ static matchtype_t is_union_match_x(ast_t* operand, ast_t* pattern,
       case MATCHTYPE_DENY:
         // If any type in the operand union denies a match, then the entire
         // operand union is denied a match.
-        return MATCHTYPE_DENY;
+        ok = MATCHTYPE_DENY;
+        break;
+    }
+
+    if(ok == MATCHTYPE_DENY)
+      break;
+  }
+
+  if((ok != MATCHTYPE_ACCEPT) && (errorf != NULL))
+  {
+    if(ok == MATCHTYPE_DENY)
+      report_reject = false;
+
+    for(ast_t* child = ast_child(operand);
+      child != NULL;
+      child = ast_sibling(child))
+    {
+      is_x_match_x(child, pattern, errorf, report_reject, opt);
+    }
+
+    if(ok == MATCHTYPE_DENY)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities",
+        ast_print_type(operand), ast_print_type(pattern));
+    } else if(report_reject) {
+      ast_error_frame(errorf, pattern, "no element of %s can match %s",
+        ast_print_type(operand), ast_print_type(pattern));
     }
   }
 
@@ -40,7 +67,7 @@ static matchtype_t is_union_match_x(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_isect_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   matchtype_t ok = MATCHTYPE_ACCEPT;
 
@@ -48,7 +75,7 @@ static matchtype_t is_isect_match_x(ast_t* operand, ast_t* pattern,
     child != NULL;
     child = ast_sibling(child))
   {
-    switch(is_x_match_x(child, pattern, opt))
+    switch(is_x_match_x(child, pattern, NULL, false, opt))
     {
       case MATCHTYPE_ACCEPT:
         break;
@@ -62,7 +89,34 @@ static matchtype_t is_isect_match_x(ast_t* operand, ast_t* pattern,
       case MATCHTYPE_DENY:
         // If any type in the operand isect denies a match, then the entire
         // operand isect is denied a match.
-        return MATCHTYPE_DENY;
+        ok = MATCHTYPE_DENY;
+        break;
+    }
+
+    if(ok == MATCHTYPE_DENY)
+      break;
+  }
+
+  if((ok != MATCHTYPE_ACCEPT) && (errorf != NULL))
+  {
+    if(ok == MATCHTYPE_DENY)
+      report_reject = false;
+
+    for(ast_t* child = ast_child(operand);
+      child != NULL;
+      child = ast_sibling(child))
+    {
+      is_x_match_x(child, pattern, errorf, report_reject, opt);
+    }
+
+    if(ok == MATCHTYPE_DENY)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities",
+        ast_print_type(operand), ast_print_type(pattern));
+    } else if(report_reject) {
+      ast_error_frame(errorf, pattern, "not every element of %s can match %s",
+        ast_print_type(operand), ast_print_type(pattern));
     }
   }
 
@@ -70,7 +124,7 @@ static matchtype_t is_isect_match_x(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_x_match_union(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   matchtype_t ok = MATCHTYPE_REJECT;
 
@@ -78,7 +132,7 @@ static matchtype_t is_x_match_union(ast_t* operand, ast_t* pattern,
     child != NULL;
     child = ast_sibling(child))
   {
-    switch(is_x_match_x(operand, child, opt))
+    switch(is_x_match_x(operand, child, NULL, false, opt))
     {
       case MATCHTYPE_ACCEPT:
         // If any type in the pattern union accepts a match, the entire pattern
@@ -92,7 +146,34 @@ static matchtype_t is_x_match_union(ast_t* operand, ast_t* pattern,
       case MATCHTYPE_DENY:
         // If any type in the pattern union denies a match, the entire pattern
         // union denies a match.
-        return MATCHTYPE_DENY;
+        ok = MATCHTYPE_DENY;
+        break;
+    }
+
+    if(ok == MATCHTYPE_DENY)
+      break;
+  }
+
+  if((ok != MATCHTYPE_ACCEPT) && (errorf != NULL))
+  {
+    if(ok == MATCHTYPE_DENY)
+      report_reject = false;
+
+    for(ast_t* child = ast_child(pattern);
+      child != NULL;
+      child = ast_sibling(child))
+    {
+      is_x_match_x(operand, child, errorf, report_reject, opt);
+    }
+
+    if(ok == MATCHTYPE_DENY)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities",
+        ast_print_type(operand), ast_print_type(pattern));
+    } else if(report_reject) {
+      ast_error_frame(errorf, pattern, "%s cannot match any element of %s",
+        ast_print_type(operand), ast_print_type(pattern));
     }
   }
 
@@ -100,7 +181,7 @@ static matchtype_t is_x_match_union(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_x_match_isect(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   matchtype_t ok = MATCHTYPE_ACCEPT;
 
@@ -108,7 +189,7 @@ static matchtype_t is_x_match_isect(ast_t* operand, ast_t* pattern,
     child != NULL;
     child = ast_sibling(child))
   {
-    switch(is_x_match_x(operand, child, opt))
+    switch(is_x_match_x(operand, child, NULL, false, opt))
     {
       case MATCHTYPE_ACCEPT:
         break;
@@ -122,7 +203,34 @@ static matchtype_t is_x_match_isect(ast_t* operand, ast_t* pattern,
       case MATCHTYPE_DENY:
         // If any type in the pattern isect denies a match, the entire pattern
         // isect denies a match.
-        return MATCHTYPE_DENY;
+        ok = MATCHTYPE_DENY;
+        break;
+    }
+
+    if(ok == MATCHTYPE_DENY)
+      break;
+  }
+
+  if((ok != MATCHTYPE_ACCEPT) && (errorf != NULL))
+  {
+    if(ok == MATCHTYPE_DENY)
+      report_reject = false;
+
+    for(ast_t* child = ast_child(pattern);
+      child != NULL;
+      child = ast_sibling(child))
+    {
+      is_x_match_x(operand, child, errorf, report_reject, opt);
+    }
+
+    if(ok == MATCHTYPE_DENY)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities",
+        ast_print_type(operand), ast_print_type(pattern));
+    } else if(report_reject) {
+      ast_error_frame(errorf, pattern, "%s cannot match every element of %s",
+        ast_print_type(operand), ast_print_type(pattern));
     }
   }
 
@@ -130,11 +238,20 @@ static matchtype_t is_x_match_isect(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_tuple_match_tuple(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   // Must be a pairwise match.
   if(ast_childcount(operand) != ast_childcount(pattern))
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: they have a different number of elements",
+        ast_print_type(operand), ast_print_type(pattern));
+    }
+
     return MATCHTYPE_REJECT;
+  }
 
   ast_t* operand_child = ast_child(operand);
   ast_t* pattern_child = ast_child(pattern);
@@ -142,7 +259,7 @@ static matchtype_t is_tuple_match_tuple(ast_t* operand, ast_t* pattern,
 
   while(operand_child != NULL)
   {
-    switch(is_x_match_x(operand_child, pattern_child, opt))
+    switch(is_x_match_x(operand_child, pattern_child, NULL, false, opt))
     {
       case MATCHTYPE_ACCEPT:
         break;
@@ -152,31 +269,84 @@ static matchtype_t is_tuple_match_tuple(ast_t* operand, ast_t* pattern,
         break;
 
       case MATCHTYPE_DENY:
-        return MATCHTYPE_DENY;
+        ok = MATCHTYPE_DENY;
+        break;
     }
+
+    if(ok == MATCHTYPE_DENY)
+      break;
 
     operand_child = ast_sibling(operand_child);
     pattern_child = ast_sibling(pattern_child);
+  }
+
+  if((ok != MATCHTYPE_ACCEPT) && (errorf != NULL))
+  {
+    if(ok == MATCHTYPE_DENY)
+      report_reject = false;
+
+    operand_child = ast_child(operand);
+    pattern_child = ast_child(pattern);
+
+    while(operand_child != NULL)
+    {
+      is_x_match_x(operand_child, pattern_child, errorf, report_reject, opt);
+
+      operand_child = ast_sibling(operand_child);
+      pattern_child = ast_sibling(pattern_child);
+    }
+
+    if(ok == MATCHTYPE_DENY)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities",
+        ast_print_type(operand), ast_print_type(pattern));
+    } else if(report_reject) {
+      ast_error_frame(errorf, pattern, "%s cannot pairwise match %s",
+        ast_print_type(operand), ast_print_type(pattern));
+    }
   }
 
   return ok;
 }
 
 static matchtype_t is_nominal_match_tuple(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   if(!is_top_type(operand, true))
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_t* operand_def = (ast_t*)ast_data(operand);
+
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: the pattern type is a tuple",
+        ast_print_type(operand), ast_print_type(pattern));
+      ast_error_frame(errorf, operand_def, "this might be possible if the "
+        "match type were an empty interface, such as the Any type");
+    }
+
     return MATCHTYPE_REJECT;
+  }
 
   ast_t* child = ast_child(pattern);
 
   while(child != NULL)
   {
-    matchtype_t r = is_x_match_x(operand, child, opt);
+    matchtype_t r = is_x_match_x(operand, child, errorf, false, opt);
     pony_assert(r != MATCHTYPE_REJECT);
 
     if(r == MATCHTYPE_DENY)
+    {
+      if(errorf != NULL)
+      {
+        ast_error_frame(errorf, pattern,
+          "matching %s with %s could violate capabilities",
+          ast_print_type(operand), ast_print_type(pattern));
+      }
+
       return r;
+    }
 
     child = ast_sibling(child);
   }
@@ -185,7 +355,7 @@ static matchtype_t is_nominal_match_tuple(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_typeparam_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   ast_t* operand_upper = typeparam_upper(operand);
 
@@ -194,13 +364,14 @@ static matchtype_t is_typeparam_match_x(ast_t* operand, ast_t* pattern,
     return MATCHTYPE_ACCEPT;
 
   // Check if the constraint can match the pattern.
-  matchtype_t ok = is_x_match_x(operand_upper, pattern, opt);
+  matchtype_t ok = is_x_match_x(operand_upper, pattern, errorf, report_reject,
+    opt);
   ast_free_unattached(operand_upper);
   return ok;
 }
 
 static matchtype_t is_arrow_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   // upperbound(this->T1) match T2
   // ---
@@ -220,35 +391,50 @@ static matchtype_t is_arrow_match_x(ast_t* operand, ast_t* pattern,
     operand_view = viewpoint_lower(operand);
 
   if(operand_view == NULL)
-    return MATCHTYPE_DENY;
+  {
+    if(errorf != NULL)
+    {
+      // this->X always has an upper bound.
+      pony_assert(ast_id(left) != TK_THISTYPE);
 
-  matchtype_t ok = is_x_match_x(operand_view, pattern, opt);
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities: "
+        "the match type has no lower bounds",
+        ast_print_type(operand), ast_print_type(pattern));
+    }
+
+    return MATCHTYPE_DENY;
+  }
+
+  matchtype_t ok = is_x_match_x(operand_view, pattern, errorf, report_reject,
+    opt);
   ast_free_unattached(operand_view);
   return ok;
 }
 
 static matchtype_t is_x_match_tuple(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   switch(ast_id(operand))
   {
     case TK_UNIONTYPE:
-      return is_union_match_x(operand, pattern, opt);
+      return is_union_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_ISECTTYPE:
-      return is_isect_match_x(operand, pattern, opt);
+      return is_isect_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_TUPLETYPE:
-      return is_tuple_match_tuple(operand, pattern, opt);
+      return is_tuple_match_tuple(operand, pattern, errorf, report_reject, opt);
 
     case TK_NOMINAL:
-      return is_nominal_match_tuple(operand, pattern, opt);
+      return is_nominal_match_tuple(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_TYPEPARAMREF:
-      return is_typeparam_match_x(operand, pattern, opt);
+      return is_typeparam_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_ARROW:
-      return is_arrow_match_x(operand, pattern, opt);
+      return is_arrow_match_x(operand, pattern, errorf, report_reject, opt);
 
     default: {}
   }
@@ -258,34 +444,53 @@ static matchtype_t is_x_match_tuple(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_nominal_match_entity(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(operand, o_pkg, o_id, o_typeargs, o_cap, o_eph);
   AST_GET_CHILDREN(pattern, p_pkg, p_id, p_typeargs, p_cap, p_eph);
 
-  // We say the pattern provides the operand if it is a subtype after changing
-  // it to have the same refcap as the operand.
-  token_id tcap = ast_id(p_cap);
-  token_id teph = ast_id(p_eph);
-  ast_t* r_operand = set_cap_and_ephemeral(operand, tcap, teph);
-  bool provides = is_subtype(pattern, r_operand, NULL, opt);
-  ast_free_unattached(r_operand);
+  // We say the pattern provides the operand if it is a subtype without taking
+  // capabilities into account.
+  bool provides = is_subtype_ignore_cap(pattern, operand, NULL, opt);
 
   // If the pattern doesn't provide the operand, reject the match.
   if(!provides)
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: %s isn't a subtype of %s",
+        ast_print_type(operand), ast_print_type(pattern),
+        ast_print_type_no_cap(pattern), ast_print_type_no_cap(operand));
+    }
+
     return MATCHTYPE_REJECT;
+  }
 
   // If the operand does provide the pattern, but the operand refcap can't
   // match the pattern refcap, deny the match.
-  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph), tcap, teph))
+  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
+    ast_id(p_cap), ast_id(p_eph)))
+  {
+    if(errorf != NULL)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities: "
+        "%s%s isn't a subcap of %s%s",
+        ast_print_type(operand), ast_print_type(pattern),
+        ast_print_type(o_cap), ast_print_type(o_eph),
+        ast_print_type(p_cap), ast_print_type(p_eph));
+    }
+
     return MATCHTYPE_DENY;
+  }
 
   // Otherwise, accept the match.
   return MATCHTYPE_ACCEPT;
 }
 
 static matchtype_t is_nominal_match_struct(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   // A struct pattern can only be used if the operand is the same struct.
   // Otherwise, since there is no type descriptor, there is no way to
@@ -296,40 +501,72 @@ static matchtype_t is_nominal_match_struct(ast_t* operand, ast_t* pattern,
   // This must be a deny to prevent a union or intersection type that includes
   // the same struct as the pattern from matching.
   if(operand_def != pattern_def)
-    return MATCHTYPE_DENY;
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: the pattern type is a struct",
+        ast_print_type(operand), ast_print_type(pattern));
+      ast_error_frame(errorf, pattern,
+        "since a struct has no type descriptor, pattern matching at runtime "
+        "would be impossible");
+    }
 
-  return is_nominal_match_entity(operand, pattern, opt);
+    return MATCHTYPE_DENY;
+  }
+
+  return is_nominal_match_entity(operand, pattern, errorf, report_reject, opt);
 }
 
 static matchtype_t is_entity_match_trait(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(operand, o_pkg, o_id, o_typeargs, o_cap, o_eph);
   AST_GET_CHILDREN(pattern, p_pkg, p_id, p_typeargs, p_cap, p_eph);
 
-  token_id tcap = ast_id(p_cap);
-  token_id teph = ast_id(p_eph);
-  ast_t* r_operand = set_cap_and_ephemeral(operand, tcap, teph);
-  bool provides = is_subtype(r_operand, pattern, NULL, opt);
-  ast_free_unattached(r_operand);
+  bool provides = is_subtype_ignore_cap(operand, pattern, NULL, opt);
 
   // If the operand doesn't provide the pattern (trait or interface), reject
   // the match.
   if(!provides)
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: %s isn't a subtype of %s",
+        ast_print_type(operand), ast_print_type(pattern),
+        ast_print_type_no_cap(operand), ast_print_type_no_cap(pattern));
+    }
+
     return MATCHTYPE_REJECT;
+  }
 
   // If the operand does provide the pattern, but the operand refcap can't
   // match the pattern refcap, deny the match.
-  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph), tcap, teph))
+  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
+    ast_id(p_cap), ast_id(p_eph)))
+  {
+    if(errorf != NULL)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities: "
+        "%s%s isn't a subcap of %s%s",
+        ast_print_type(operand), ast_print_type(pattern),
+        ast_print_type(o_cap), ast_print_type(o_eph),
+        ast_print_type(p_cap), ast_print_type(p_eph));
+    }
+
     return MATCHTYPE_DENY;
+  }
 
   // Otherwise, accept the match.
   return MATCHTYPE_ACCEPT;
 }
 
 static matchtype_t is_trait_match_trait(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
+  (void)report_reject;
   (void)opt;
   AST_GET_CHILDREN(operand, o_pkg, o_id, o_typeargs, o_cap, o_eph);
   AST_GET_CHILDREN(pattern, p_pkg, p_id, p_typeargs, p_cap, p_eph);
@@ -337,14 +574,26 @@ static matchtype_t is_trait_match_trait(ast_t* operand, ast_t* pattern,
   // If the operand refcap can't match the pattern refcap, deny the match.
   if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
     ast_id(p_cap), ast_id(p_eph)))
+  {
+    if(errorf != NULL)
+    {
+      ast_error_frame(errorf, pattern,
+        "matching %s with %s could violate capabilities: "
+        "%s%s isn't a subcap of %s%s",
+        ast_print_type(operand), ast_print_type(pattern),
+        ast_print_type(o_cap), ast_print_type(o_eph),
+        ast_print_type(p_cap), ast_print_type(p_eph));
+    }
+
     return MATCHTYPE_DENY;
+  }
 
   // Otherwise, accept the match.
   return MATCHTYPE_ACCEPT;
 }
 
 static matchtype_t is_nominal_match_trait(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   ast_t* operand_def = (ast_t*)ast_data(operand);
 
@@ -354,11 +603,13 @@ static matchtype_t is_nominal_match_trait(ast_t* operand, ast_t* pattern,
     case TK_STRUCT:
     case TK_CLASS:
     case TK_ACTOR:
-      return is_entity_match_trait(operand, pattern, opt);
+      return is_entity_match_trait(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_TRAIT:
     case TK_INTERFACE:
-      return is_trait_match_trait(operand, pattern, opt);
+      return is_trait_match_trait(operand, pattern, errorf, report_reject,
+        opt);
 
     default: {}
   }
@@ -368,7 +619,7 @@ static matchtype_t is_nominal_match_trait(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_nominal_match_nominal(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   ast_t* pattern_def = (ast_t*)ast_data(pattern);
 
@@ -377,14 +628,17 @@ static matchtype_t is_nominal_match_nominal(ast_t* operand, ast_t* pattern,
     case TK_PRIMITIVE:
     case TK_CLASS:
     case TK_ACTOR:
-      return is_nominal_match_entity(operand, pattern, opt);
+      return is_nominal_match_entity(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_STRUCT:
-      return is_nominal_match_struct(operand, pattern, opt);
+      return is_nominal_match_struct(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_TRAIT:
     case TK_INTERFACE:
-      return is_nominal_match_trait(operand, pattern, opt);
+      return is_nominal_match_trait(operand, pattern, errorf, report_reject,
+        opt);
 
     default: {}
   }
@@ -393,28 +647,45 @@ static matchtype_t is_nominal_match_nominal(ast_t* operand, ast_t* pattern,
   return MATCHTYPE_DENY;
 }
 
+static matchtype_t is_tuple_match_nominal(ast_t* operand, ast_t* pattern,
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
+{
+  (void)opt;
+
+  if((errorf != NULL) && report_reject)
+  {
+    ast_error_frame(errorf, pattern,
+      "%s cannot match %s: the match type is a tuple",
+      ast_print_type(operand), ast_print_type(pattern));
+  }
+
+  return MATCHTYPE_REJECT;
+}
+
 static matchtype_t is_x_match_nominal(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   switch(ast_id(operand))
   {
     case TK_UNIONTYPE:
-      return is_union_match_x(operand, pattern, opt);
+      return is_union_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_ISECTTYPE:
-      return is_isect_match_x(operand, pattern, opt);
+      return is_isect_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_TUPLETYPE:
-      return MATCHTYPE_REJECT;
+      return is_tuple_match_nominal(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_NOMINAL:
-      return is_nominal_match_nominal(operand, pattern, opt);
+      return is_nominal_match_nominal(operand, pattern, errorf, report_reject,
+        opt);
 
     case TK_TYPEPARAMREF:
-      return is_typeparam_match_x(operand, pattern, opt);
+      return is_typeparam_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_ARROW:
-      return is_arrow_match_x(operand, pattern, opt);
+      return is_arrow_match_x(operand, pattern, errorf, report_reject, opt);
 
     case TK_FUNTYPE:
       return MATCHTYPE_REJECT;
@@ -427,7 +698,7 @@ static matchtype_t is_x_match_nominal(ast_t* operand, ast_t* pattern,
 }
 
 static matchtype_t is_x_match_typeparam(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   ast_t* pattern_upper = typeparam_upper(pattern);
 
@@ -436,13 +707,14 @@ static matchtype_t is_x_match_typeparam(ast_t* operand, ast_t* pattern,
     return MATCHTYPE_ACCEPT;
 
   // Otherwise, match the constraint.
-  matchtype_t ok = is_x_match_x(operand, pattern_upper, opt);
+  matchtype_t ok = is_x_match_x(operand, pattern_upper, errorf, report_reject,
+    opt);
   ast_free_unattached(pattern_upper);
   return ok;
 }
 
 static matchtype_t is_x_match_arrow(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   // T1 match upperbound(T2->T3)
   // ---
@@ -450,15 +722,25 @@ static matchtype_t is_x_match_arrow(ast_t* operand, ast_t* pattern,
   ast_t* pattern_upper = viewpoint_upper(pattern);
 
   if(pattern_upper == NULL)
-    return MATCHTYPE_REJECT;
+  {
+    if((errorf != NULL) && report_reject)
+    {
+      ast_error_frame(errorf, pattern,
+        "%s cannot match %s: the pattern type has no upper bounds",
+        ast_print_type(operand), ast_print_type(pattern));
+    }
 
-  matchtype_t ok = is_x_match_x(operand, pattern_upper, opt);
+    return MATCHTYPE_REJECT;
+  }
+
+  matchtype_t ok = is_x_match_x(operand, pattern_upper, errorf, report_reject,
+    opt);
   ast_free_unattached(pattern_upper);
   return ok;
 }
 
 static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
-  pass_opt_t* opt)
+  errorframe_t* errorf, bool report_reject, pass_opt_t* opt)
 {
   if(ast_id(pattern) == TK_DONTCARETYPE)
     return MATCHTYPE_ACCEPT;
@@ -466,22 +748,22 @@ static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
   switch(ast_id(pattern))
   {
     case TK_UNIONTYPE:
-      return is_x_match_union(operand, pattern, opt);
+      return is_x_match_union(operand, pattern, errorf, report_reject, opt);
 
     case TK_ISECTTYPE:
-      return is_x_match_isect(operand, pattern, opt);
+      return is_x_match_isect(operand, pattern, errorf, report_reject, opt);
 
     case TK_TUPLETYPE:
-      return is_x_match_tuple(operand, pattern, opt);
+      return is_x_match_tuple(operand, pattern, errorf, report_reject, opt);
 
     case TK_NOMINAL:
-      return is_x_match_nominal(operand, pattern, opt);
+      return is_x_match_nominal(operand, pattern, errorf, report_reject, opt);
 
     case TK_TYPEPARAMREF:
-      return is_x_match_typeparam(operand, pattern, opt);
+      return is_x_match_typeparam(operand, pattern, errorf, report_reject, opt);
 
     case TK_ARROW:
-      return is_x_match_arrow(operand, pattern, opt);
+      return is_x_match_arrow(operand, pattern, errorf, report_reject, opt);
 
     case TK_FUNTYPE:
       return MATCHTYPE_DENY;
@@ -493,7 +775,8 @@ static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
   return MATCHTYPE_DENY;
 }
 
-matchtype_t is_matchtype(ast_t* operand, ast_t* pattern, pass_opt_t* opt)
+matchtype_t is_matchtype(ast_t* operand, ast_t* pattern, errorframe_t* errorf,
+  pass_opt_t* opt)
 {
-  return is_x_match_x(operand, pattern, opt);
+  return is_x_match_x(operand, pattern, errorf, true, opt);
 }

--- a/src/libponyc/type/matchtype.h
+++ b/src/libponyc/type/matchtype.h
@@ -37,7 +37,8 @@ typedef enum
  *
  * Return REJECT if no such type can exist.
  */
-matchtype_t is_matchtype(ast_t* operand, ast_t* pattern, pass_opt_t* opt);
+matchtype_t is_matchtype(ast_t* operand, ast_t* pattern, errorframe_t* errorf,
+  pass_opt_t* opt);
 
 PONY_EXTERN_C_END
 

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -37,24 +37,24 @@ TEST_F(MatchTypeTest, SimpleTypes)
 
   TEST_COMPILE(src);
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1"), &opt));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c2"), &opt));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c2"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1"), NULL, &opt));
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("t1"), &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("t1"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1"), NULL, &opt));
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t2"), &opt));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t2"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1"), NULL, &opt));
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("i1"), &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("i1"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1"), NULL, &opt));
 
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("i2"), &opt));
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1"), &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("i2"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1"), NULL, &opt));
 
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t2"), &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1"), &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t2"), NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1"), NULL, &opt));
 }
 
 
@@ -93,45 +93,45 @@ TEST_F(MatchTypeTest, CompoundOperand)
 
   // (C1 | C2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("c2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("t1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("t1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("t2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("t2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("i1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1or2"), type_of("i1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("i2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1or2"), type_of("i2"), NULL, &opt));
 
   // (C1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("c1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1ort2"), type_of("c2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1ort2"), type_of("c2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1ort2"), type_of("t2"), NULL, &opt));
 
   // (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1and2"), type_of("c2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("c3"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("c3"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t3"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("t3"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1and2"), type_of("i2"), NULL, &opt));
 }
 
 
@@ -170,45 +170,45 @@ TEST_F(MatchTypeTest, CompoundPattern)
 
   // (C1 | C2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1or2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1or2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c2"), type_of("c1or2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c2"), type_of("c1or2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1or2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1or2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1or2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("t2"), type_of("c1or2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1or2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1or2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1or2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1or2"), NULL, &opt));
 
   // (C1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1ort2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1"), type_of("c1ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1ort2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("c1ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1ort2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("c1ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("c1ort2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("c1ort2"), NULL, &opt));
 
   // (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t1and2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("t1and2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c2"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c3"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c3"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t2"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t3"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t3"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("t1and2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("i2"), type_of("t1and2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i2"), type_of("t1and2"), NULL, &opt));
 }
 
 
@@ -245,41 +245,41 @@ TEST_F(MatchTypeTest, BothCompound)
 
   // (C1 | C2) vs (T1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc2"), type_of("t1ort2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc2"), type_of("t1ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("c1orc2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("c1orc2"), NULL, &opt));
 
   // (C1 | C2) vs (C3 | T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("c3ort2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("c3ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c3ort2"), type_of("c1orc2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c3ort2"), type_of("c1orc2"), NULL, &opt));
 
   // (C1 | C2) vs (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("t1andt2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1orc2"), type_of("t1andt2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("t1andt2"), type_of("c1orc2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("t1andt2"), type_of("c1orc2"), NULL, &opt));
 
   // (C1 | C3) vs (T1 & T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc3"), type_of("t1andt2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1orc3"), type_of("t1andt2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("c1orc3"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("c1orc3"), NULL, &opt));
 
   // (T1 & T2) vs (T1 | T2)
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("t1ort2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1andt2"), type_of("t1ort2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("t1andt2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("t1ort2"), type_of("t1andt2"), NULL, &opt));
 
   // (T1 & T2) vs (I1 & I2)
   ASSERT_EQ(
     MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1andt2"), type_of("i1andi2"), &opt));
+    is_matchtype(type_of("t1andt2"), type_of("i1andi2"), NULL, &opt));
   ASSERT_EQ(
     MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("i1andi2"), type_of("t1andt2"), &opt));
+    is_matchtype(type_of("i1andi2"), type_of("t1andt2"), NULL, &opt));
 }
 
 
@@ -314,19 +314,19 @@ TEST_F(MatchTypeTest, Tuples)
   TEST_COMPILE(src);
 
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c1c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1"), type_of("c1c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1c1"), type_of("c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1c1"), type_of("c1"), NULL, &opt));
 
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("c1c2"), type_of("t1t2"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("c1c2"), type_of("t1t2"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c3"), type_of("t1t2"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c3"), type_of("t1t2"), NULL, &opt));
 
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1c1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("i1"), type_of("c1c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("i2"), type_of("c1c1"), NULL, &opt));
 
   // We can't make types with don't cares in as the type of a parameter. Modify
   // t1t2 instead.
@@ -338,14 +338,14 @@ TEST_F(MatchTypeTest, Tuples)
   REPLACE(&elem2, NODE(TK_DONTCARETYPE));
 
   // (T1, _)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, NULL, &opt));
 
   REPLACE(&elem1, NODE(TK_DONTCARETYPE));
 
   // (_, _)
-  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, &opt));
+  ASSERT_EQ(MATCHTYPE_REJECT, is_matchtype(type_of("c1"), t1t2, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(type_of("c1c2"), t1t2, NULL, &opt));
 }
 
 
@@ -384,60 +384,60 @@ TEST_F(MatchTypeTest, Capabilities)
 
   // Classes
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1ref"), type_of("c1ref"), &opt));
+    is_matchtype(type_of("c1ref"), type_of("c1ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1ref"), type_of("c1val"), &opt));
+    is_matchtype(type_of("c1ref"), type_of("c1val"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1ref"), type_of("c1box"), &opt));
+    is_matchtype(type_of("c1ref"), type_of("c1box"), NULL, &opt));
 
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1val"), type_of("c1ref"), &opt));
+    is_matchtype(type_of("c1val"), type_of("c1ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1val"), type_of("c1val"), &opt));
+    is_matchtype(type_of("c1val"), type_of("c1val"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1val"), type_of("c1box"), &opt));
+    is_matchtype(type_of("c1val"), type_of("c1box"), NULL, &opt));
 
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1box"), type_of("c1ref"), &opt));
+    is_matchtype(type_of("c1box"), type_of("c1ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1box"), type_of("c1val"), &opt));
+    is_matchtype(type_of("c1box"), type_of("c1val"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1box"), type_of("c1box"), &opt));
+    is_matchtype(type_of("c1box"), type_of("c1box"), NULL, &opt));
 
   ASSERT_EQ(MATCHTYPE_REJECT,
-    is_matchtype(type_of("c1box"), type_of("c2ref"), &opt));
+    is_matchtype(type_of("c1box"), type_of("c2ref"), NULL, &opt));
 
   // Tuples
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2ref"), &opt));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1valc2ref"), &opt));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1valc2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2val"), &opt));
+    is_matchtype(type_of("c1refc2ref"), type_of("c1refc2val"), NULL, &opt));
 
   // Unions
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2ref"), &opt));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1valorc2ref"), &opt));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1valorc2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2val"), &opt));
+    is_matchtype(type_of("c1reforc2ref"), type_of("c1reforc2val"), NULL, &opt));
 
   // Intersect vs union
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2ref"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1valort2ref"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1valort2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2val"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refort2val"), NULL, &opt));
 
   // Intersects
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2ref"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2ref"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_DENY,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2box"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1valandt2box"), NULL, &opt));
   ASSERT_EQ(MATCHTYPE_ACCEPT,
-    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2box"), &opt));
+    is_matchtype(type_of("t1refandt2ref"), type_of("t1refandt2box"), NULL, &opt));
 }
 
 
@@ -465,21 +465,21 @@ TEST_F(MatchTypeTest, TypeParams)
 
   // Ref constraints
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("ac2"), type_of("c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("ac2"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_REJECT, is_matchtype(type_of("at2"), type_of("c1"), &opt));
+    MATCHTYPE_REJECT, is_matchtype(type_of("at2"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("at1"), type_of("c1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("at1"), type_of("c1"), NULL, &opt));
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("at2"), type_of("t1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("at2"), type_of("t1"), NULL, &opt));
 
   // Box constraint
   ASSERT_EQ(
-    MATCHTYPE_DENY, is_matchtype(type_of("at2box"), type_of("t1"), &opt));
+    MATCHTYPE_DENY, is_matchtype(type_of("at2box"), type_of("t1"), NULL, &opt));
 
   // Union constraint
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1"), &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1"), NULL, &opt));
 }
 
 
@@ -516,44 +516,44 @@ TEST_F(MatchTypeTest, GenericCap)
   ast_t* tag = type_of("tag'");
 
   // #read {ref, val, box}
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, iso, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, trn, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, ref, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, val, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(read, box, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(read, tag, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, iso, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, trn, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, ref, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(read, val, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(read, box, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(read, tag, NULL, &opt));
 
   // #send {iso, val, tag}
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, iso, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, trn, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, ref, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, val, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, box, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(send, tag, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, iso, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, trn, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, ref, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, val, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(send, box, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(send, tag, NULL, &opt));
 
   // #share {val, tag}
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, iso, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, trn, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, ref, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, val, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, box, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(share, tag, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, iso, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, trn, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, ref, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, val, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(share, box, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(share, tag, NULL, &opt));
 
   // #alias {ref, val, box, tag}
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, iso, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, trn, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, ref, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, val, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, box, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(alias, tag, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, iso, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, trn, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, ref, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, val, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(alias, box, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(alias, tag, NULL, &opt));
 
   // #any {iso, trn, ref, val, box, tag}
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, iso, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, trn, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, ref, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, val, &opt));
-  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, box, &opt));
-  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(any, tag, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, iso, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, trn, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, ref, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, val, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_DENY, is_matchtype(any, box, NULL, &opt));
+  ASSERT_EQ(MATCHTYPE_ACCEPT, is_matchtype(any, tag, NULL, &opt));
 
   if(send != send_base)
     ast_free_unattached(send);


### PR DESCRIPTION
Detailed information is now reported by each `is_x_match_x` function, similar to how subtyping errors are reported.