### PR TITLE
Add mechanism to register (noisy) signal handler

### DIFF
--- a/packages/signals/signal_handler.pony
+++ b/packages/signals/signal_handler.pony
@@ -10,19 +10,21 @@ use @pony_asio_event_destroy[None](event: AsioEventID)
 actor SignalHandler
   """
   Listen for a specific signal.
+  If the wait parameter is true, the program will not terminate until the SignalHandler's dispose method is called, or if the SignalNotify returns false, after handling the signal as this also disposes the SignalHandler and unsubscribes it.
+
   """
   let _notify: SignalNotify
   let _sig: U32
   var _event: AsioEventID
 
-  new create(notify: SignalNotify iso, sig: U32) =>
+  new create(notify: SignalNotify iso, sig: U32, wait: Bool = false) =>
     """
     Create a signal handler.
     """
     _notify = consume notify
     _sig = sig
     _event =
-      @pony_asio_event_create(this, 0, AsioEvent.signal(), sig.u64(), false)
+      @pony_asio_event_create(this, 0, AsioEvent.signal(), sig.u64(), wait)
 
   be raise() =>
     """


### PR DESCRIPTION
This allows programs that are waiting on a signal to proceed to
work. Sometimes, there are programs that are waiting for an alarm,
or similar prior to performing I/O.

This was impossible, because signal handlers were never registered
as noisy actors in asio. This allows for an optional named parameter
to be passed with that context.

A simple example of a program that was not supposed to terminate until it received a signal:
```pony
use "signals"
use "bureaucracy"

actor Main
  new create(env: Env) =>
    // Create a TERM handler
    let custodian = Custodian
    let signal = SignalHandler(TermHandler(env, custodian), Sig.int())
    custodian(signal)

class TermHandler is SignalNotify
  let _env: Env
  let _custodian : Custodian

  new iso create(env: Env, custodian : Custodian) =>
    _env = env
    _custodian = custodian

  fun ref apply(count: U32): Bool =>
    _env.out.print("TERM signal received, shutting down")
    _custodian.dispose()
    true
```

In order to fix this behaviour under the PR, the signal handler can be created like so:
```pony
let signal = SignalHandler(TermHandler(env, custodian), Sig.int() where noisy = true)
```

