### PR TITLE
Issue a compiler error on a known annotation in an invalid location

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -855,8 +855,10 @@ void setannotation(ast_t* ast, ast_t* annotation, bool allow_free)
 
   if(annotation != NULL)
   {
-    pony_assert(!hasparent(annotation) &&
-      (annotation->annotation_type == NULL));
+    pony_assert(annotation->annotation_type == NULL);
+
+    if(hasparent(annotation))
+      annotation = duplicate(ast, annotation);
 
     if(prev_annotation != NULL)
     {
@@ -867,6 +869,8 @@ void setannotation(ast_t* ast, ast_t* annotation, bool allow_free)
     }
 
     ast->annotation_type = annotation;
+
+    set_scope_and_parent(annotation, ast);
   } else {
     pony_assert(prev_annotation != NULL);
 

--- a/test/libponyc/annotations.cc
+++ b/test/libponyc/annotations.cc
@@ -187,3 +187,36 @@ TEST_F(AnnotationsTest, InternalAnnotation)
 
   TEST_ERROR(src);
 }
+
+TEST_F(AnnotationsTest, StandardAnnotationLocationGood)
+{
+  const char* src =
+    "struct \\packed\\ Foo\n"
+    "  fun foo() =>\n"
+    "    if \\likely\\ bar then None end\n"
+    "    while \\unlikely\\ bar do None end\n"
+    "    repeat None until \\likely\\ bar end\n"
+    "    match bar | \\unlikely\\ bar => None end";
+
+  TEST_COMPILE(src, "syntax");
+}
+
+TEST_F(AnnotationsTest, StandardAnnotationLocationBad)
+{
+  const char* src =
+    "class \\packed\\ Foo\n"
+    "  fun foo() =>\n"
+    "    try \\likely\\ bar else None end\n"
+    "    repeat \\unlikely\\ None until bar end";
+
+  const char* errs[] = {
+    "a 'packed' annotation can only appear on a struct declaration",
+    "a 'likely' annotation can only appear on the condition of an if, while, "
+      "or until, or on the case of a match",
+    "a 'unlikely' annotation can only appear on the condition of an if, while, "
+      "or until, or on the case of a match",
+    NULL
+  };
+
+  DO(test_expected_errors(src, "syntax", errs));
+}

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -77,50 +77,6 @@ TEST_F(CodegenTest, NonPackedStructIsntPacked)
 }
 
 
-TEST_F(CodegenTest, ClassCannotBePacked)
-{
-  const char* src =
-    "class \\packed\\ Foo\n"
-    "  var a: U8 = 0\n"
-    "  var b: U32 = 0\n"
-
-    "actor Main\n"
-    "  new create(env: Env) =>\n"
-    "    Foo";
-
-  TEST_COMPILE(src);
-
-  reach_t* reach = compile->reach;
-  reach_type_t* foo = reach_type_name(reach, "Foo");
-  ASSERT_TRUE(foo != NULL);
-
-  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
-  ASSERT_TRUE(!LLVMIsPackedStruct(type));
-}
-
-
-TEST_F(CodegenTest, ActorCannotBePacked)
-{
-  const char* src =
-    "actor \\packed\\ Foo\n"
-    "  var a: U8 = 0\n"
-    "  var b: U32 = 0\n"
-
-    "actor Main\n"
-    "  new create(env: Env) =>\n"
-    "    Foo";
-
-  TEST_COMPILE(src);
-
-  reach_t* reach = compile->reach;
-  reach_type_t* foo = reach_type_name(reach, "Foo");
-  ASSERT_TRUE(foo != NULL);
-
-  LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
-  ASSERT_TRUE(!LLVMIsPackedStruct(type));
-}
-
-
 TEST_F(CodegenTest, JitRun)
 {
   const char* src =


### PR DESCRIPTION
The compiler now checks for known annotation locations, and errors when that location is incorrect, for example a `packed` annotation on something else than a struct definition. This doesn't affect annotations that aren't recognised by the compiler.