### PR TITLE
Fix FilePath.walk performance issues (issue #2158).

### DIFF
--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -118,14 +118,16 @@ class val FilePath
     expanded by removing them from the `dir_entries` list.
     """
     try
-      var entries: Array[String] ref = Directory(this)?.entries()?
-      handler(this, entries)
-      for e in entries.values() do
-        let p = this.join(e)?
-        if not follow_links and FileInfo(p)?.symlink then
-          continue
+      with dir = Directory(this)? do
+        var entries: Array[String] ref = dir.entries()?
+        handler(this, entries)
+        for e in entries.values() do
+          let p = this.join(e)?
+          let info = FileInfo(p)?
+          if info.directory and (follow_links or not info.symlink) then
+            p.walk(handler, follow_links)
+          end
         end
-        p.walk(handler, follow_links)
       end
     else
       return


### PR DESCRIPTION
Hi, this PR fixes 2 issues mentioned in #2158:
- directory is disposed in the end of the loop, otherwise it can result in too many open files error.
- files are omitted from recursive descend, so `Directory(this)?` should work without throwing so many errors.