### PR TITLE
Add experimental flag to compile a static binary.

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -337,6 +337,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* fuseld = target_is_linux(c->opt->triple) ? "-fuse-ld=gold" : "";
   const char* ldl = target_is_linux(c->opt->triple) ? "-ldl" : "";
   const char* atomic = target_is_linux(c->opt->triple) ? "-latomic" : "";
+  const char* staticbin = c->opt->staticbin ? "-static" : "";
   const char* dtrace_args =
 #if defined(PLATFORM_IS_BSD) && defined(USE_DYNAMIC_TRACE)
    "-Wl,--whole-archive -ldtrace_probes -Wl,--no-whole-archive -lelf";
@@ -352,7 +353,8 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   size_t ld_len = 512 + strlen(file_exe) + strlen(file_o) + strlen(lib_args)
                   + strlen(arch) + strlen(mcx16_arg) + strlen(fuseld)
-                  + strlen(ldl) + strlen(dtrace_args) + strlen(lexecinfo);
+                  + strlen(ldl) + strlen(atomic) + strlen(staticbin)
+                  + strlen(dtrace_args) + strlen(lexecinfo);
 
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
@@ -367,9 +369,9 @@ static bool link_exe(compile_t* c, ast_t* program,
     // for backtrace reporting.
     "-rdynamic "
 #endif
-    "%s %s %s %s -lpthread %s %s %s -lm %s",
-    linker, file_exe, arch, mcx16_arg, atomic, fuseld, file_o, lib_args,
-    dtrace_args, ponyrt, ldl, lexecinfo
+    "%s %s %s %s %s -lpthread %s %s %s -lm %s",
+    linker, file_exe, arch, mcx16_arg, atomic, staticbin, fuseld, file_o,
+    lib_args, dtrace_args, ponyrt, ldl, lexecinfo
     );
 
   if(c->opt->verbosity >= VERBOSITY_TOOL_INFO)

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -36,6 +36,7 @@ enum
   OPT_BIN_NAME,
   OPT_LIBRARY,
   OPT_RUNTIMEBC,
+  OPT_STATIC,
   OPT_PIC,
   OPT_NOPIC,
   OPT_DOCS,
@@ -81,6 +82,7 @@ static opt_arg_t std_args[] =
   {"bin-name", 'b', OPT_ARG_REQUIRED, OPT_BIN_NAME},
   {"library", 'l', OPT_ARG_NONE, OPT_LIBRARY},
   {"runtimebc", '\0', OPT_ARG_NONE, OPT_RUNTIMEBC},
+  {"static", '\0', OPT_ARG_NONE, OPT_STATIC},
   {"pic", '\0', OPT_ARG_NONE, OPT_PIC},
   {"nopic", '\0', OPT_ARG_NONE, OPT_NOPIC},
   {"docs", 'g', OPT_ARG_NONE, OPT_DOCS},
@@ -141,6 +143,7 @@ static void usage(void)
     "    =name          Defaults to name of the directory.\n"
     "  --library, -l    Generate a C-API compatible static library.\n"
     "  --runtimebc      Compile with the LLVM bitcode file for the runtime.\n"
+    "  --static         Compile a static binary (experimental).\n"
     "  --pic            Compile using position independent code.\n"
     "  --nopic          Don't compile using position independent code.\n"
     "  --docs, -g       Generate code documentation.\n"
@@ -346,6 +349,7 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
       case OPT_BIN_NAME: opt->bin_name = s->arg_val; break;
       case OPT_LIBRARY: opt->library = true; break;
       case OPT_RUNTIMEBC: opt->runtimebc = true; break;
+      case OPT_STATIC: opt->staticbin = true; break;
       case OPT_PIC: opt->pic = true; break;
       case OPT_NOPIC: opt->pic = false; break;
       case OPT_DOCS:

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -143,7 +143,7 @@ static void usage(void)
     "    =name          Defaults to name of the directory.\n"
     "  --library, -l    Generate a C-API compatible static library.\n"
     "  --runtimebc      Compile with the LLVM bitcode file for the runtime.\n"
-    "  --static         Compile a static binary (experimental).\n"
+    "  --static         Compile a static binary (experimental, Linux-only).\n"
     "  --pic            Compile using position independent code.\n"
     "  --nopic          Don't compile using position independent code.\n"
     "  --docs, -g       Generate code documentation.\n"

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -268,6 +268,7 @@ typedef struct pass_opt_t
   bool release;
   bool library;
   bool runtimebc;
+  bool staticbin;
   bool pic;
   bool print_stats;
   bool verify;


### PR DESCRIPTION
I'm experimenting with compiling static binaries for easier distribution of compiled Pony programs.

I'm not sure yet everything that will be required, but this PR is a first step. Using this flag, I was able to compile a static binary within an alpine docker container, and run it on my host.

At some point after merging this, I want to formalize this process and write up some instructions for it. Then we can remove the "experimental" warning from this flag.