### PR TITLE
Rework ASIO pony API

### DIFF
--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -1,3 +1,12 @@
+use @pony_asio_event_alloc[AsioEventID](
+  owner: AsioEventNotify,
+  flags: U32,
+  noisy: Bool)
+use @pony_asio_event_set_nsec[None](event: AsioEventID, nsec: U64)
+use @pony_asio_event_set_fd[None](event: AsioEventID, fd: U32)
+use @pony_asio_event_set_signal[None](event: AsioEventID, sig: U32)
+use @pony_asio_event_subscribe[None](event: AsioEventID)
+
 type AsioEventID is Pointer[AsioEvent] tag
 
 interface tag AsioEventNotify
@@ -12,6 +21,24 @@ primitive AsioEvent
     An empty event.
     """
     AsioEventID
+
+  fun make(owner: AsioEventNotify, flags: U32, fd: U32 = 0,
+    nsec: U64 = 0, noisy: Bool = true, sig: U32 = 0): AsioEventID =>
+    """
+      Creates an ASIO event based on the provided parameters
+    """
+    let event = @pony_asio_event_alloc(owner, flags, noisy)
+    if (nsec != 0) then
+      @pony_asio_event_set_nsec(event, nsec)
+    end
+    if (fd != 0) then
+      @pony_asio_event_set_fd(event, fd)
+    end
+    if (sig != 0) then
+      @pony_asio_event_set_signal(event, sig)
+    end
+    @pony_asio_event_subscribe(event)
+    event
 
   fun readable(flags: U32): Bool =>
     """

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -22,20 +22,20 @@ primitive AsioEvent
     """
     AsioEventID
 
-  fun make(owner: AsioEventNotify, flags: U32, fd: U32 = 0,
-    nsec: U64 = 0, noisy: Bool = true, sig: U32 = 0): AsioEventID =>
+  fun make(owner: AsioEventNotify, flags: U32, fd: (None | U32) = None,
+    nsec: (None | U64) = None, noisy: Bool = true, sig: (None | U32) = None): AsioEventID =>
     """
       Creates an ASIO event based on the provided parameters
     """
     let event = @pony_asio_event_alloc(owner, flags, noisy)
-    if (nsec != 0) then
-      @pony_asio_event_set_nsec(event, nsec)
+    match nsec
+    | let nsec2: U64 => @pony_asio_event_set_nsec(event, nsec2)
     end
-    if (fd != 0) then
-      @pony_asio_event_set_fd(event, fd)
+    match fd
+    | let fd2: U32 => @pony_asio_event_set_fd(event, fd2)
     end
-    if (sig != 0) then
-      @pony_asio_event_set_signal(event, sig)
+    match sig
+    | let sig2: U32 => @pony_asio_event_set_signal(event, sig2)
     end
     @pony_asio_event_subscribe(event)
     event

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -1,10 +1,3 @@
-use @pony_asio_event_create[AsioEventID](
-  owner: AsioEventNotify,
-  fd: U32,
-  flags: U32,
-  nsec: U64,
-  noisy: Bool)
-
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
@@ -108,7 +101,7 @@ actor Stdin
     elseif _notify is None then
       if _use_event then
         // Create a new event.
-        _event = @pony_asio_event_create(this, 0, AsioEvent.read(), 0, true)
+        _event = AsioEvent.make(this, AsioEvent.read())
       else
         // Start the read loop.
         _loop_read()

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -1,7 +1,5 @@
 use "collections"
 
-use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
-  flags: U32, nsec: U64, noisy: Bool)
 use @pony_asio_event_fd[U32](event: AsioEventID)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_resubscribe_read[None](event: AsioEventID)
@@ -294,11 +292,9 @@ actor TCPConnection
     _connect_count = 0
     _fd = fd
     ifdef not windows then
-      _event = @pony_asio_event_create(this, fd,
-        AsioEvent.read_write_oneshot(), 0, true)
+      _event = AsioEvent.make(this, AsioEvent.read_write_oneshot() where fd = fd)
     else
-      _event = @pony_asio_event_create(this, fd,
-        AsioEvent.read_write(), 0, true)
+      _event = AsioEvent.make(this, AsioEvent.read_write() where fd = fd)
     end
     _connected = true
     ifdef not windows then

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -92,8 +92,6 @@ use "collections"
 use "files"
 
 use @pony_os_errno[I32]()
-use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
-      flags: U32, nsec: U64, noisy: Bool)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
@@ -322,11 +320,11 @@ actor ProcessMonitor
     """
     ifdef posix then
       _stdin_event  =
-        @pony_asio_event_create(this, _stdin_write, AsioEvent.write(), 0, true)
+        AsioEvent.make(this, AsioEvent.write() where fd =_stdin_write)
       _stdout_event =
-        @pony_asio_event_create(this, _stdout_read, AsioEvent.read(), 0, true)
+        AsioEvent.make(this, AsioEvent.read() where fd = _stdout_read)
       _stderr_event =
-        @pony_asio_event_create(this, _stderr_read, AsioEvent.read(), 0, true)
+        AsioEvent.make(this, AsioEvent.read() where fd = _stderr_read)
       _close_fd(_stdin_read)
       _close_fd(_stdout_write)
       _close_fd(_stderr_write)

--- a/packages/signals/signal_handler.pony
+++ b/packages/signals/signal_handler.pony
@@ -1,9 +1,3 @@
-use @pony_asio_event_create[AsioEventID](
-  owner: AsioEventNotify,
-  fd: U32,
-  flags: U32,
-  nsec: U64,
-  noisy: Bool)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
@@ -15,14 +9,14 @@ actor SignalHandler
   let _sig: U32
   var _event: AsioEventID
 
-  new create(notify: SignalNotify iso, sig: U32) =>
+  new create(notify: SignalNotify iso, sig: U32, wait: Bool = false) =>
     """
     Create a signal handler.
     """
     _notify = consume notify
     _sig = sig
     _event =
-      @pony_asio_event_create(this, 0, AsioEvent.signal(), sig.u64(), false)
+      AsioEvent.make(this, AsioEvent.signal() where noisy = wait, sig = sig)
 
   be raise() =>
     """

--- a/packages/time/timers.pony
+++ b/packages/time/timers.pony
@@ -1,12 +1,6 @@
 use "collections"
 
-use @pony_asio_event_create[AsioEventID](
-  owner: AsioEventNotify,
-  fd: U32,
-  flags: U32,
-  nsec: U64,
-  noisy: Bool)
-use @pony_asio_event_setnsec[U32](event: AsioEventID, nsec: U64)
+use @pony_asio_event_update_nsec[None](event: AsioEventID, nsec: U64)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
@@ -112,12 +106,12 @@ actor Timers
       if nsec != -1 then
         // Create a new event.
         _event =
-          @pony_asio_event_create(this, 0, AsioEvent.timer(), nsec, true)
+          AsioEvent.make(this, AsioEvent.timer() where nsec = nsec)
       end
     else
       if nsec != -1 then
         // Update an existing event.
-        @pony_asio_event_setnsec(_event, nsec)
+        @pony_asio_event_update_nsec(_event, nsec)
       else
         // Unsubscribe an existing event.
         @pony_asio_event_unsubscribe(_event)

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -12,15 +12,40 @@ PONY_EXTERN_C_BEGIN
  *
  *  Used to carry user defined data for event notifications.
  */
+
 typedef struct asio_event_t
 {
   struct asio_event_t* magic;
   pony_actor_t* owner;  /* owning actor */
   uint32_t msg_id;      /* I/O handler (actor message) */
-  int fd;               /* file descriptor */
   uint32_t flags;       /* event filter flags */
+  union
+  {
+    /*
+     * This exists as a shared component, amongst all objects which have an FD as the first member.
+     * Rather than places where that FD is shared between multiple components (eventfd, timer fd, etc..),
+     * and all of those components have some common registration being broken out, they can use this
+     * one directly.
+     */
+    struct {
+        int shared_fd;
+    };
+    struct
+    {
+      int       timer_fd; /* This is used on Linux for timerfd, and not exposed to Pony */
+      uint64_t  nsec; /* nanoseconds for timers */
+    } timer_data;
+    struct
+    {
+      int event_fd;
+      int signal; /* signal to subscribe / unsubscribe on */
+    } signal_data;
+    struct
+    {
+      int fd; /* file descriptor */
+    } io_data;
+  };
   bool noisy;           /* prevents termination? */
-  uint64_t nsec;        /* nanoseconds for timers */
 
 #ifdef PLATFORM_IS_LINUX
   // automagically resubscribe to an event on an FD when another event is
@@ -51,9 +76,18 @@ typedef struct asio_msg_t
  *
  *  An event is noisy, if it should prevent the runtime system from terminating
  *  based on quiescence.
+ *
+ *  Event allocation and subscription occur in two different steps. Event
+ *  allocation requires a call to allocate memory for the event. There
+ *  are setters to populate the event prior to "creating" the event.
  */
-PONY_API asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
-  uint32_t flags, uint64_t nsec, bool noisy);
+PONY_API asio_event_t* pony_asio_event_alloc(pony_actor_t* owner,
+  uint32_t flags, bool noisy);
+PONY_API void pony_asio_event_subscribe(asio_event_t* ev);
+
+PONY_API void pony_asio_event_set_nsec(asio_event_t* ev, uint64_t nsec);
+PONY_API void pony_asio_event_set_fd(asio_event_t* ev, int fd);
+PONY_API void pony_asio_event_set_signal(asio_event_t* ev, int signal);
 
 /** Deallocates an ASIO event.
  */
@@ -75,14 +109,16 @@ PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
  *
  *  Subscriptions are not incremental. Registering an event multiple times will
  *  overwrite the previous event filter mask.
+ *
+ *  This is the per-ASIO provider implementation of pony_asio_event_subscribe.
  */
-PONY_API void pony_asio_event_subscribe(asio_event_t* ev);
+void ponyint_pony_asio_event_subscribe(asio_event_t* ev);
 
 /** Update an event.
  *
  * Used for timers.
  */
-PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec);
+PONY_API void pony_asio_event_update_nsec(asio_event_t* ev, uint64_t nsec);
 
 /** Unsubscribe an event.
  *


### PR DESCRIPTION
This changes the C ASIO API to separate event allocation, and event
subscription.

Also, rather than accepting all of the arguments at creation time,
and reloading certain asio event fields, like "nsec" for signals,
event creation now only initializes fields which are required,
via setter APIs that are exposed from C.

This came out of adding a waitpid approach to the ASIO API, and rather than adding yet another field beyond nsec, signal, and FD, it seemed better to try to collapse them down to a union, so we could collapse them down to a single set of items, and stop doing nasty tricks like casting nsec (int64) to signal (int)