### PR TITLE
Fix code generation failure with tuples in recover blocks

### DIFF
--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -459,6 +459,27 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   return GEN_NOTNEEDED;
 }
 
+LLVMValueRef gen_recover(compile_t* c, ast_t* ast)
+{
+  ast_t* body = ast_childidx(ast, 1);
+  LLVMValueRef ret = gen_expr(c, body);
+
+  if(is_result_needed(ast))
+  {
+    deferred_reification_t* reify = c->frame->reify;
+
+    ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
+    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    ast_free_unattached(type);
+
+    type = deferred_reify(reify, ast_type(body), c->opt);
+    ret = gen_assign_cast(c, c_t->use_type, ret, type);
+    ast_free_unattached(type);
+  }
+
+  return ret;
+}
+
 LLVMValueRef gen_break(compile_t* c, ast_t* ast)
 {
   ast_t* body = ast_child(ast);

--- a/src/libponyc/codegen/gencontrol.h
+++ b/src/libponyc/codegen/gencontrol.h
@@ -16,6 +16,8 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_repeat(compile_t* c, ast_t* ast);
 
+LLVMValueRef gen_recover(compile_t* c, ast_t* ast);
+
 LLVMValueRef gen_break(compile_t* c, ast_t* ast);
 
 LLVMValueRef gen_continue(compile_t* c, ast_t* ast);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -116,7 +116,7 @@ LLVMValueRef gen_expr(compile_t* c, ast_t* ast)
     }
 
     case TK_RECOVER:
-      ret = gen_expr(c, ast_childidx(ast, 1));
+      ret = gen_recover(c, ast);
       break;
 
     case TK_BREAK:

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1433,6 +1433,7 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
     case TK_WHILE:
     case TK_REPEAT:
     case TK_TRY:
+    case TK_RECOVER:
     {
       if(is_result_needed(ast) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
       {

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -368,7 +368,7 @@ TEST_F(CodegenTest, ViewpointAdaptedFieldReach)
 
 TEST_F(CodegenTest, StringSerialization)
 {
-  // From issue 2245
+  // From issue #2245
   const char* src =
     "use \"serialise\"\n"
 
@@ -622,4 +622,24 @@ TEST_F(CodegenTest, DescTable)
     ASSERT_EQ(type_id->getBitWidth(), 32);
     ASSERT_EQ(type_id->getZExtValue(), i);
   }
+}
+
+
+TEST_F(CodegenTest, RecoverCast)
+{
+  // From issue #2639
+  const char* src =
+    "class A\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: ((None, None) | (A iso, None)) =\n"
+    "      if false then\n"
+    "        (None, None)\n"
+    "      else\n"
+    "        recover (A, None) end\n"
+    "      end";
+
+  TEST_COMPILE(src);
 }


### PR DESCRIPTION
This fixes a bug where code generation would fail when trying to convert a tuple from a recover block to an abstract type. This was occurring because the `gen_assign_cast` function was expecting the tuple to have the LLVM type corresponding to the Pony type outside of the recover block, but it was encountering the type from inside of the recover block. This was failing because we use different LLVM types for tuples with differing capabilities.

Objects from recover blocks are now casted to the correct expected type before being handled to their user.

Closes #2639.