### PR TITLE
Add SourceLoc.type_name method, showing the name of the containing type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- `SourceLoc.type_name` method ([PR #2643](https://github.com/ponylang/ponyc/pull/2643))
 - Update with experimental support for LLVM 6.0.0 ([PR #2595](https://github.com/ponylang/ponyc/pull/2595))
 - Improve pattern matching error reporting ([PR #2628](https://github.com/ponylang/ponyc/pull/2628))
 - Allow recovering at most one element of a tuple to mutable capability. ([PR #2585](https://github.com/ponylang/ponyc/pull/2585))
@@ -48,6 +49,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- `SourceLoc.method` renamed as `SourceLoc.method_name` method ([PR #2643](https://github.com/ponylang/ponyc/pull/2643))
 - New Ponybench API (RFC 52) ([PR #2578](https://github.com/ponylang/ponyc/pull/2578))
 - Forbid impossible pattern matching on generic capabilities ([PR #2499](https://github.com/ponylang/ponyc/pull/2499))
 - Remove case functions ([PR #2542](https://github.com/ponylang/ponyc/pull/2542))

--- a/packages/builtin/source_loc.pony
+++ b/packages/builtin/source_loc.pony
@@ -7,12 +7,12 @@ interface val SourceLoc
     Name and path of source file.
     """
 
-  fun typ(): String
+  fun type_name(): String
     """
     Name of nearest class, actor, primitive, struct, interface, or trait.
     """
 
-  fun method(): String
+  fun method_name(): String
     """
     Name of containing method.
     """

--- a/packages/builtin/source_loc.pony
+++ b/packages/builtin/source_loc.pony
@@ -7,6 +7,11 @@ interface val SourceLoc
     Name and path of source file.
     """
 
+  fun typ(): String
+    """
+    Name of nearest class, actor, primitive, struct, interface, or trait.
+    """
+
   fun method(): String
     """
     Name of containing method.
@@ -23,4 +28,3 @@ interface val SourceLoc
     Character position on line.
     Character positions start at 1.
     """
-    

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1065,6 +1065,21 @@ ast_t* expand_location(ast_t* location)
     }
   }
 
+  // Find name of containing type.
+  const char* type_name = "";
+  for(ast_t* typ = location; typ != NULL; typ = ast_parent(typ))
+  {
+    token_id variety = ast_id(typ);
+
+    if(variety == TK_INTERFACE || variety == TK_TRAIT ||
+      variety == TK_PRIMITIVE || variety == TK_STRUCT ||
+      variety == TK_CLASS || variety == TK_ACTOR)
+    {
+      type_name = ast_name(ast_child(typ));
+      break;
+    }
+  }
+
   // Create an object literal.
   BUILD(ast, location,
     NODE(TK_OBJECT, DATA("__loc")
@@ -1076,6 +1091,12 @@ ast_t* expand_location(ast_t* location)
           NODE(TK_NOMINAL, NONE ID("String") NONE NONE NONE)
           NONE
           NODE(TK_SEQ, STRING(file_name))
+          NONE)
+        NODE(TK_FUN, AST_SCOPE
+          NODE(TK_TAG) ID("typ") NONE NONE
+          NODE(TK_NOMINAL, NONE ID("String") NONE NONE NONE)
+          NONE
+          NODE(TK_SEQ, STRING(type_name))
           NONE)
         NODE(TK_FUN, AST_SCOPE
           NODE(TK_TAG) ID("method") NONE NONE

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1093,13 +1093,13 @@ ast_t* expand_location(ast_t* location)
           NODE(TK_SEQ, STRING(file_name))
           NONE)
         NODE(TK_FUN, AST_SCOPE
-          NODE(TK_TAG) ID("typ") NONE NONE
+          NODE(TK_TAG) ID("type_name") NONE NONE
           NODE(TK_NOMINAL, NONE ID("String") NONE NONE NONE)
           NONE
           NODE(TK_SEQ, STRING(type_name))
           NONE)
         NODE(TK_FUN, AST_SCOPE
-          NODE(TK_TAG) ID("method") NONE NONE
+          NODE(TK_TAG) ID("method_name") NONE NONE
           NODE(TK_NOMINAL, NONE ID("String") NONE NONE NONE)
           NONE
           NODE(TK_SEQ, STRING(method_name))

--- a/test/libponyc/sugar_expr.cc
+++ b/test/libponyc/sugar_expr.cc
@@ -564,6 +564,7 @@ TEST_F(SugarExprTest, Location)
     "  fun box bar(): None =>\n"
     "    object\n"
     "      fun tag file(): String => \"\"\n"
+    "      fun tag typ(): String => \"Foo\"\n"
     "      fun tag method(): String => \"bar\"\n"
     "      fun tag line(): USize => 4\n"
     "      fun tag pos(): USize => 5\n"
@@ -578,6 +579,7 @@ TEST_F(SugarExprTest, LocationDefaultArg)
   const char* short_form =
     "interface val SourceLoc\n"
     "  fun file(): String\n"
+    "  fun typ(): String\n"
     "  fun method(): String\n"
     "  fun line(): USize\n"
     "  fun pos(): USize\n"
@@ -585,13 +587,15 @@ TEST_F(SugarExprTest, LocationDefaultArg)
     "class Foo\n"
     "  var create: U32\n"
     "  fun bar() =>\n"
-    "    wombat()\n"
-    "  fun wombat(x: SourceLoc = __loc) =>\n"
-    "    None";
+    "    Log.apply()"
+
+    "primitive Log\n"
+    "  fun apply(x: SourceLoc = __loc) => None\n";
 
   const char* full_form =
     "interface val SourceLoc\n"
     "  fun file(): String\n"
+    "  fun typ(): String\n"
     "  fun method(): String\n"
     "  fun line(): USize\n"
     "  fun pos(): USize\n"
@@ -599,14 +603,16 @@ TEST_F(SugarExprTest, LocationDefaultArg)
     "class Foo\n"
     "  var create: U32\n"
     "  fun bar() =>\n"
-    "    wombat(object\n"
+    "    Log.apply(object\n"
     "      fun tag file(): String => \"\"\n"
+    "      fun tag typ(): String => \"Foo\"\n"
     "      fun tag method(): String => \"bar\"\n"
-    "      fun tag line(): USize => 9\n"
-    "      fun tag pos(): USize => 11\n"
-    "    end)\n"
-    "  fun wombat(x: SourceLoc = __loc) =>\n"
-    "    None";
+    "      fun tag line(): USize => 10\n"
+    "      fun tag pos(): USize => 14\n"
+    "    end)"
+
+    "primitive Log\n"
+    "  fun apply(x: SourceLoc = __loc) => None\n";
 
   TEST_EQUIV(short_form, full_form);
 }

--- a/test/libponyc/sugar_expr.cc
+++ b/test/libponyc/sugar_expr.cc
@@ -564,8 +564,8 @@ TEST_F(SugarExprTest, Location)
     "  fun box bar(): None =>\n"
     "    object\n"
     "      fun tag file(): String => \"\"\n"
-    "      fun tag typ(): String => \"Foo\"\n"
-    "      fun tag method(): String => \"bar\"\n"
+    "      fun tag type_name(): String => \"Foo\"\n"
+    "      fun tag method_name(): String => \"bar\"\n"
     "      fun tag line(): USize => 4\n"
     "      fun tag pos(): USize => 5\n"
     "    end";
@@ -579,8 +579,8 @@ TEST_F(SugarExprTest, LocationDefaultArg)
   const char* short_form =
     "interface val SourceLoc\n"
     "  fun file(): String\n"
-    "  fun typ(): String\n"
-    "  fun method(): String\n"
+    "  fun type_name(): String\n"
+    "  fun method_name(): String\n"
     "  fun line(): USize\n"
     "  fun pos(): USize\n"
 
@@ -595,8 +595,8 @@ TEST_F(SugarExprTest, LocationDefaultArg)
   const char* full_form =
     "interface val SourceLoc\n"
     "  fun file(): String\n"
-    "  fun typ(): String\n"
-    "  fun method(): String\n"
+    "  fun type_name(): String\n"
+    "  fun method_name(): String\n"
     "  fun line(): USize\n"
     "  fun pos(): USize\n"
 
@@ -605,8 +605,8 @@ TEST_F(SugarExprTest, LocationDefaultArg)
     "  fun bar() =>\n"
     "    Log.apply(object\n"
     "      fun tag file(): String => \"\"\n"
-    "      fun tag typ(): String => \"Foo\"\n"
-    "      fun tag method(): String => \"bar\"\n"
+    "      fun tag type_name(): String => \"Foo\"\n"
+    "      fun tag method_name(): String => \"bar\"\n"
     "      fun tag line(): USize => 10\n"
     "      fun tag pos(): USize => 14\n"
     "    end)"


### PR DESCRIPTION
SourceLoc already shows the method name of the __loc object,
but not the type name. Adding the type name is a logical next step,
since it is available.

EDIT:
Also renames `method` as `method_name`.