### PR TITLE
Add addc, subc and mulc functions to I128 and U128

### DIFF
--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -222,6 +222,18 @@ trait val Integer[A: Integer[A] val] is Real[A]
     """
     -~this
 
+  fun addc(y: A): (A, Bool)
+    """
+    Add `y` to this integer and return the result and a flag indicating overflow.
+    """
+  fun subc(y: A): (A, Bool)
+    """
+    Subtract `y` from this integer and return the result and a flag indicating overflow.
+    """
+  fun mulc(y: A): (A, Bool)
+    """
+    Multiply `y` with this integer and return the result and a flag indicating overflow.
+    """
   fun op_and(y: A): A => this and y
   fun op_or(y: A): A => this or y
   fun op_xor(y: A): A => this xor y

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -488,4 +488,41 @@ primitive I128 is _SignedInteger[I128, U128]
     """
     f64()
 
+  fun addc(y: I128): (I128, Bool) =>
+    ifdef native128 then
+      @"llvm.sadd.with.overflow.i128"[(I128, Bool)](this, y)
+    else
+      let overflow =
+        if y > 0 then
+          (this > (max_value() - y))
+        else
+          (this < (min_value() - y))
+        end
+
+      (this + y, overflow)
+    end
+
+  fun subc(y: I128): (I128, Bool) =>
+    ifdef native128 then
+      @"llvm.ssub.with.overflow.i128"[(I128, Bool)](this, y)
+    else
+      let overflow =
+        if y > 0 then
+          (this < (min_value() + y))
+        else
+          (this > (max_value() + y))
+        end
+
+      (this - y, overflow)
+    end
+
+  fun mulc(y: I128): (I128, Bool) =>
+    ifdef native128 then
+      @"llvm.smul.with.overflow.i128"[(I128, Bool)](this, y)
+    else
+      let result = this * y
+      let overflow = (this != 0) and ((result / this) != y)
+      (result, overflow)
+    end
+
 type Signed is (I8 | I16 | I32 | I64 | I128 | ILong | ISize)

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -517,12 +517,30 @@ primitive I128 is _SignedInteger[I128, U128]
     end
 
   fun mulc(y: I128): (I128, Bool) =>
-    ifdef native128 then
-      @"llvm.smul.with.overflow.i128"[(I128, Bool)](this, y)
+    // using llvm.smul.with.overflow.i128 would require to link
+    // llvm compiler-rt where the function implementing it lives: https://github.com/llvm-mirror/compiler-rt/blob/master/lib/builtins/muloti4.c
+    // See this bug for reference:
+    // the following implementation is more or less exactly was __muloti4 is
+    // doing
+    let result = this * y
+    if this == I128.min_value() then
+      return (result, (y != 0) and (y != 1))
+    end
+    if y == I128.min_value() then
+      return (result, (this != 0) and (this != 1))
+    end
+    let this_neg = this >> (this.bitwidth() - 1)
+    let this_abs = (this xor this_neg) - this_neg
+    let y_neg = y >> (this.bitwidth() - 1)
+    let y_abs = (y xor y_neg) - y_neg
+
+    if ((this_abs < 2) or (y_abs < 2)) then
+      return (result, false)
+    end
+    if (this_neg == y_neg) then
+      (result, (this_abs > (I128.max_value() / y_abs)))
     else
-      let result = this * y
-      let overflow = (this != 0) and ((result / this) != y)
-      (result, overflow)
+      (result, (this_abs > (I128.min_value() / -y_abs)))
     end
 
 type Signed is (I8 | I16 | I32 | I64 | I128 | ILong | ISize)

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -579,4 +579,29 @@ primitive U128 is _UnsignedInteger[U128]
     """
     f64()
 
+  fun addc(y: U128): (U128, Bool) =>
+    ifdef native128 then
+      @"llvm.uadd.with.overflow.i128"[(U128, Bool)](this, y)
+    else
+      let overflow = this > (max_value() - y)
+      (this + y, overflow)
+    end
+
+  fun subc(y: U128): (U128, Bool) =>
+    ifdef native128 then
+      @"llvm.usub.with.overflow.i128"[(U128, Bool)](this, y)
+    else
+      let overflow = this < y
+      (this - y, overflow)
+    end
+
+  fun mulc(y: U128): (U128, Bool) =>
+    ifdef native128 then
+      @"llvm.umul.with.overflow.i128"[(U128, Bool)](this, y)
+    else
+      let result = this * y
+      let overflow = (this != 0) and ((result / this) != y)
+      (result, overflow)
+    end
+
 type Unsigned is (U8 | U16 | U32 | U64 | U128 | ULong | USize)


### PR DESCRIPTION
These methods are pretty slow on non `native128` machines as we need to manually check for overflow.

fixes #2409
