### PR TITLE
Allow llvm-6.0.1 in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,8 @@ else ifeq ($(llvm_version),5.0.1)
   $(warning WARNING: LLVM 5 support is experimental and may result in decreased performance or crashes)
 else ifeq ($(llvm_version),6.0.0)
   $(warning WARNING: LLVM 6 support is experimental and may result in decreased performance or crashes)
+else ifeq ($(llvm_version),6.0.1)
+  $(warning WARNING: LLVM 6 support is experimental and may result in decreased performance or crashes)
 else
   $(warning WARNING: Unsupported LLVM version: $(llvm_version))
   $(warning Please use LLVM 3.9.1)


### PR DESCRIPTION
It seems the apt.llvm.org packages already ship 6.0.1 although the official release is only scheduled for june, see http://lists.llvm.org/pipermail/llvm-dev/2018-March/121757.html. 

My `llvm-config-6.0 --version` installed from: `deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main` shows `6.0.1`.

So i adapted the Makefile to support it.

The stdlib tests and the examples compile and run just fine on my machine.
There are no ci tests using the apt.llvm.org packages. Should we add them?