### PR TITLE
Disable avx512f for x86 targets only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ endif
 config ?= release
 arch ?= native
 tune ?= generic
+cpu ?= $(arch)
 bits ?= $(shell getconf LONG_BIT)
 
 ifndef verbose
@@ -102,7 +103,7 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION_STR=\"$(version_str)\" \
   -D_FILE_OFFSET_BITS=64
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
-LL_FLAGS = -mcpu=$(arch)
+LL_FLAGS = -mcpu=$(cpu)
 
 # Determine pointer size in bits.
 BITS := $(bits)

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -797,39 +797,31 @@ bool codegen_pass_init(pass_opt_t* opt)
 #endif
   }
 
-#if PONY_LLVM < 500
-  bool target_x86 = strncmp(triple, "x86", 3) == 0;
-#endif
-
   if(opt->features != NULL)
   {
 #if PONY_LLVM < 500
-    size_t temp_len;
-    char* temp_str;
-
-    if(target_x86) {
+    if(target_is_x86(triple))
+    {
       // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
-      temp_len = strlen(opt->features) + 10;
-      temp_str = (char*)ponyint_pool_alloc_size(temp_len);
+      size_t temp_len = strlen(opt->features) + 10;
+      char* temp_str = (char*)ponyint_pool_alloc_size(temp_len);
       snprintf(temp_str, temp_len, "%s,-avx512f", opt->features);
 
-      opt->features = temp_str;
+      opt->features = LLVMCreateMessage(temp_str);
+
+      ponyint_pool_free_size(temp_len, temp_str);
+    } else {
+      opt->features = LLVMCreateMessage(opt->features);
     }
-#endif
-
+#else
     opt->features = LLVMCreateMessage(opt->features);
-
-
-#if PONY_LLVM < 500
-    if(target_x86)
-      ponyint_pool_free_size(temp_len, temp_str); // free memory for temp_str
 #endif
   } else {
     if((opt->cpu == NULL) && (opt->triple == NULL))
       opt->features = LLVMGetHostCPUFeatures();
     else
 #if PONY_LLVM < 500
-      opt->features = LLVMCreateMessage(target_x86 ? "-avx512f" : "");
+      opt->features = LLVMCreateMessage(target_is_x86(triple) ? "-avx512f" : "");
 #else
       opt->features = LLVMCreateMessage("");
 #endif

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -797,7 +797,9 @@ bool codegen_pass_init(pass_opt_t* opt)
 #endif
   }
 
+#if PONY_LLVM < 500
   bool target_x86 = strncmp(triple, "x86", 3) == 0;
+#endif
 
   if(opt->features != NULL)
   {

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -782,48 +782,59 @@ void codegen_llvm_shutdown()
 
 bool codegen_pass_init(pass_opt_t* opt)
 {
+  char *triple;
+
+  // Default triple, cpu and features.
+  if(opt->triple != NULL)
+  {
+    triple = LLVMCreateMessage(opt->triple);
+  } else {
+#ifdef PLATFORM_IS_MACOSX
+    // This is to prevent XCode 7+ from claiming OSX 14.5 is required.
+    triple = LLVMCreateMessage("x86_64-apple-macosx");
+#else
+    triple = LLVMGetDefaultTargetTriple();
+#endif
+  }
+
+  bool target_x86 = strncmp(triple, "x86", 3) == 0;
+
   if(opt->features != NULL)
   {
 #if PONY_LLVM < 500
-    // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
-    size_t temp_len = strlen(opt->features) + 9;
-    char* temp_str = (char*)ponyint_pool_alloc_size(temp_len);
-    snprintf(temp_str, temp_len, "%s,-avx512f", opt->features);
+    size_t temp_len;
+    char* temp_str;
 
-    opt->features = temp_str;
+    if(target_x86) {
+      // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
+      temp_len = strlen(opt->features) + 10;
+      temp_str = (char*)ponyint_pool_alloc_size(temp_len);
+      snprintf(temp_str, temp_len, "%s,-avx512f", opt->features);
+
+      opt->features = temp_str;
+    }
 #endif
 
     opt->features = LLVMCreateMessage(opt->features);
 
 
 #if PONY_LLVM < 500
-    // free memory for temp_str
-    ponyint_pool_free_size(temp_len, temp_str);
+    if(target_x86)
+      ponyint_pool_free_size(temp_len, temp_str); // free memory for temp_str
 #endif
   } else {
     if((opt->cpu == NULL) && (opt->triple == NULL))
       opt->features = LLVMGetHostCPUFeatures();
     else
 #if PONY_LLVM < 500
-      opt->features = LLVMCreateMessage("-avx512f");
+      opt->features = LLVMCreateMessage(target_x86 ? "-avx512f" : "");
 #else
       opt->features = LLVMCreateMessage("");
 #endif
   }
 
-  // Default triple, cpu and features.
-  if(opt->triple != NULL)
-  {
-    opt->triple = LLVMCreateMessage(opt->triple);
-  } else {
-#ifdef PLATFORM_IS_MACOSX
-    // This is to prevent XCode 7+ from claiming OSX 14.5 is required.
-    opt->triple = LLVMCreateMessage("x86_64-apple-macosx");
-#else
-    opt->triple = LLVMGetDefaultTargetTriple();
-#endif
-  }
-
+  opt->triple = triple;
+  
   if(opt->cpu != NULL)
     opt->cpu = LLVMCreateMessage(opt->cpu);
   else

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -76,7 +76,7 @@ char* LLVMGetHostCPUFeatures()
   for(auto it = features.begin(); it != features.end(); it++)
     buf_size += (*it).getKey().str().length() + 2; // plus +/- char and ,/null
 
-#if PONY_LLVM < 500
+#if PONY_LLVM < 500 and defined(PLATFORM_IS_X86)
   // Add extra buffer space for llvm bug workaround
   buf_size += 9;
 #endif
@@ -99,7 +99,7 @@ char* LLVMGetHostCPUFeatures()
       strcat(buf, ",");
   }
 
-#if PONY_LLVM < 500
+#if PONY_LLVM < 500 and defined(PLATFORM_IS_X86)
   // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
   strcat(buf, ",-avx512f");
 #endif


### PR DESCRIPTION
Hi, this PR is trying to fix minor compilation issues I've found building and using ponyc on arm (32bit only at the moment), I hope I haven't done anything completely wrong.

Currently `-avx512f` is added explicitly to the list of cpu features in `libponyc/codegen/host.cc` and `libponyc/codegen/codegen.c` for all platforms when llvm < 5.0.0, though it is only supported by `x86`. As a result ponyc is generating at least one warning `'-avx512f' is not a recognized feature for this target (ignoring feature)` at multiple stages. 

Plus there's a minor bug in line 789 of `src/libponyc/codegen/codegen.c` 
```
size_t temp_len = strlen(opt->features) + 9; // should be 10 instead
char* temp_str = (char*)ponyint_pool_alloc_size(temp_len);
snprintf(temp_str, temp_len, "%s,-avx512f", opt->features);
```

And running ponyc with a set of features (on all platforms) like `ponyc --features=+sse2` will give `'-avx512' is not a recognized feature for this target (ignoring feature)` as `f` in `-avx512f` was truncated.

Last issue is `-mcpu=$(arch)` won't work for arms most of the time if `arch` is redefined, e.g. for my armv7 target I need to set `march=armv7`, `mtune=cortex-a9` and `mcpu=cortex-a9`. Setting `cpu` to `armv7` (=arch) isn't correct and `llc` will log lots of warnings. I believe the simplest solution is to make `cpu` variable configurable.