### PR TITLE
Avoid allocating multiple vtable indices to subordinate methods

### DIFF
--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -302,6 +302,9 @@ static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
 
     while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
     {
+      if(m->is_subordinate)
+        continue;
+
       uint32_t index = m->vtable_index;
       pony_assert(index != (uint32_t)-1);
       pony_assert(vtable[index] == NULL);

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -287,6 +287,9 @@ static void find_names_types_use(painter_t* painter, reach_types_t* types)
 
       while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
+        if(m->is_subordinate)
+          continue;
+
         const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
 
@@ -369,6 +372,9 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
 
       while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
+        if(m->is_subordinate)
+          continue;
+
         // Store colour assigned to name in reachable types set
         const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
@@ -376,6 +382,14 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
 
         uint32_t colour = name_rec->colour;
         m->vtable_index = colour;
+
+        reach_method_t* s = m->subordinate;
+
+        while(s != NULL)
+        {
+          s->vtable_index = colour;
+          s = s->subordinate;
+        }
 
         if(colour > max_colour)
           max_colour = colour;

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -1348,6 +1348,7 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
       if(subordinate)
       {
         m2->intrinsic = true;
+        m2->is_subordinate = true;
         m->subordinate = m2;
         m = m2;
       }
@@ -1358,6 +1359,7 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
     if(subordinate)
     {
       m2->intrinsic = true;
+      m2->is_subordinate = true;
       m->subordinate = m2;
       m = m2;
     }
@@ -1366,6 +1368,7 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
     {
       m2 = add_rmethod(r, t, n, TK_BOX, typeargs, opt, false);
       m2->intrinsic = true;
+      m2->is_subordinate = true;
       m->subordinate = m2;
       m = m2;
     }
@@ -1647,6 +1650,7 @@ static void reach_method_serialise(pony_ctx_t* ctx, void* object, void* buf,
 
   dst->subordinate = (reach_method_t*)pony_serialise_offset(ctx,
     m->subordinate);
+  dst->is_subordinate = m->is_subordinate;
 
   dst->param_count = m->param_count;
   dst->params = (reach_param_t*)pony_serialise_offset(ctx, m->params);

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -53,6 +53,7 @@ struct reach_method_t
 
   // Linked list of instantiations that use the same func.
   reach_method_t* subordinate;
+  bool is_subordinate;
 
   size_t param_count;
   reach_param_t* params;


### PR DESCRIPTION
This reduces vtable sizes.