### PR TITLE
Disable neon for armhf if not supported by C/C++ compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ config ?= release
 arch ?= native
 tune ?= generic
 cpu ?= $(arch)
+fpu ?= 
 bits ?= $(shell getconf LONG_BIT)
 
 ifndef verbose
@@ -114,6 +115,11 @@ ifeq ($(BITS),64)
     BUILD_FLAGS += -mcx16
     LINKER_FLAGS += -mcx16
   endif
+endif
+
+ifneq ($(fpu),)
+  BUILD_FLAGS += -mfpu=$(fpu)
+  LINKER_FLAGS += -mfpu=$(fpu)
 endif
 
 PONY_BUILD_DIR   ?= build/$(config)

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -369,4 +369,8 @@ inline uint64_t __pony_clzl(uint64_t x)
 #  include "vcvars.h"
 #endif
 
+#if defined(ARMV7) && !defined(__ARM_NEON) && !defined(__ARM_NEON__)
+#  define PLATFORM_IS_ARMHF_WITHOUT_NEON 1
+#endif
+
 #endif

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -109,6 +109,7 @@ char* LLVMGetHostCPUFeatures()
 #endif
 
 #ifdef PLATFORM_IS_ARMHF_WITHOUT_NEON
+  // Workaround for https://bugs.llvm.org/show_bug.cgi?id=30842
   strcat(buf, ",-neon");
 #endif
 

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -81,6 +81,10 @@ char* LLVMGetHostCPUFeatures()
   buf_size += 9;
 #endif
 
+#ifdef PLATFORM_IS_ARMHF_WITHOUT_NEON
+  buf_size += 6;
+#endif
+
   char* buf = (char*)malloc(buf_size);
   pony_assert(buf != NULL);
   buf[0] = 0;
@@ -102,6 +106,10 @@ char* LLVMGetHostCPUFeatures()
 #if PONY_LLVM < 500 and defined(PLATFORM_IS_X86)
   // Disable -avx512f on LLVM < 5.0.0 to avoid bug https://bugs.llvm.org/show_bug.cgi?id=30542
   strcat(buf, ",-avx512f");
+#endif
+
+#ifdef PLATFORM_IS_ARMHF_WITHOUT_NEON
+  strcat(buf, ",-neon");
 #endif
 
   return buf;


### PR DESCRIPTION
Hi, this minor PR is a workaround for [llvm's bug 30842](https://bugs.llvm.org/show_bug.cgi?id=30842). The issue is that `neon` instructions are enabled by default for armhf even if target CPU doesn't support them. As a result llvm backend may generate code that has unsupported instructions and program can crash with SIGILL.

It's not a big issue for ponyc as neon can be disabled with `ponyc --features=-neon`, but it's problematic for `libponyc` unit tests as compilation target is configured automatically and neon can't be disabled easily for such cases. As a result unit tests are failing on tests like `BoxedTupleIsBoxedTuple` where vectorisation is used which isn't great.

My current solution is to disable neon by default (setting `--features=` for ponyc explicitly will revert the behavior) if neon instruction set was disabled for C/C++ compiler. I created a new var in Makefile `fpu` that corresponds to `-mfpu` flag and can be redefined for arm targets, otherwise it doesn't have any effect. 

I hope it makes sense. 