### PR TITLE
Fix failing aarch64 (ARM64) build (issue #1719)

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -170,6 +170,11 @@
  */
 #if defined(ARMV2) || defined(__arm__) || defined(__aarch64__)
 # define PLATFORM_IS_ARM
+# if defined(__aarch64__)
+#  define PLATFORM_IS_ARM64
+# else
+#  define PLATFORM_IS_ARM32
+# endif
 #elif defined(__i386__) || defined(_M_IX86) || defined(_X86_) || \
  defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || \
  defined(_M_AMD64)

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -48,6 +48,8 @@ static void set_registers(struct _Unwind_Exception* exception,
   _Unwind_SetIP(context, landing_pad);
 }
 
+// Switch to ARM EHABI for ARM32 devices.
+// Note that this does not apply to ARM64 devices which use DWARF Exception Handling.
 #ifdef PLATFORM_IS_ARM32
 
 _Unwind_Reason_Code __gnu_unwind_frame(_Unwind_Exception*, _Unwind_Context*);

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -7,7 +7,7 @@
 #include <unwind.h>
 #include <stdlib.h>
 
-#ifdef PLATFORM_IS_ARM
+#ifdef PLATFORM_IS_ARM32
 #include <string.h>
 #define PONY_EXCEPTION_CLASS "Pony\0\0\0\0"
 #else
@@ -28,7 +28,7 @@ static void exception_cleanup(_Unwind_Reason_Code reason,
 
 PONY_API void pony_error()
 {
-#ifdef PLATFORM_IS_ARM
+#ifdef PLATFORM_IS_ARM32
   memcpy(exception.exception_class, PONY_EXCEPTION_CLASS, 8);
 #else
   exception.exception_class = PONY_EXCEPTION_CLASS;
@@ -48,7 +48,7 @@ static void set_registers(struct _Unwind_Exception* exception,
   _Unwind_SetIP(context, landing_pad);
 }
 
-#ifdef PLATFORM_IS_ARM
+#ifdef PLATFORM_IS_ARM32
 
 _Unwind_Reason_Code __gnu_unwind_frame(_Unwind_Exception*, _Unwind_Context*);
 


### PR DESCRIPTION
Fix of issue #1719.

ARM64 systems do not use ARM Exception Handling ABI (EHABI), but rather the DWARF exception handling standard.

The fix turns off special ARM handling of exceptions when the target platform is ARM64.
This enables builds of the codebase on ARM64 systems with standard implementation of libunwind as shipped with gcc 5+.

* Tested on [ODROID-C2](http://www.hardkernel.com/main/products/prdt_info.php?g_code=G145457216438)
* Built arm64v8 Docker image with ponyc binary and passing tests: [vassilvk/arm64v8-ponyc](https://hub.docker.com/r/vassilvk/arm64v8-ponyc/)
* [Dockerfile](https://gist.github.com/vassilvk/7a0c119049723b3c2ea76758984bcf4c) for above image