### PR TITLE
Fix __digestof phi expression returns the wrong type (#2683)

### DIFF
--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -374,7 +374,7 @@ static LLVMValueRef gen_digestof_box(compile_t* c, reach_type_t* type,
     LLVMBuildBr(c->builder, post_block);
 
     LLVMPositionBuilderAtEnd(c->builder, post_block);
-    LLVMValueRef phi = LLVMBuildPhi(c->builder, c->i64, "");
+    LLVMValueRef phi = LLVMBuildPhi(c->builder, c->intptr, "");
     LLVMAddIncoming(phi, &box_digest, &box_block, 1);
     LLVMAddIncoming(phi, &nonbox_digest, &nonbox_block, 1);
     return phi;


### PR DESCRIPTION
I encountered this while porting pony to illumos.  On LLVM 3.9.1 when building the compiler/libs/etc as 32-bit, running the libponyrt tests would trip an LLVM assert (as described in the bug), and several other tests would segfault.  After applying this fix, the LLVM assert was not triggered and the segfaulting tests now completed successfully.  In addition another user has stated that applying the fix to 32-bit ARM also fixes problems encountered there. 