### PR TITLE
Avoid flattening arrow to type param, fixing typechecking when reified with another type param.

### DIFF
--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -612,6 +612,17 @@ static void typeparam_current_inner(ast_t* type, ast_t* scope)
       break;
     }
 
+    // These can appear on the left side of a TK_ARROW,
+    // but we have no need to do anything with them here.
+    case TK_ISO:
+    case TK_TRN:
+    case TK_REF:
+    case TK_VAL:
+    case TK_BOX:
+    case TK_TAG:
+    case TK_THISTYPE:
+      break;
+
     default:
       pony_assert(0);
   }

--- a/src/libponyc/type/viewpoint.c
+++ b/src/libponyc/type/viewpoint.c
@@ -35,8 +35,11 @@ ast_t* viewpoint_type(ast_t* l_type, ast_t* r_type)
       return type;
     }
 
-    case TK_NOMINAL:
     case TK_TYPEPARAMREF:
+      upper = VIEW_UPPER_NO;
+      break;
+
+    case TK_NOMINAL:
     {
       ast_t* cap = cap_fetch(r_type);
 

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1133,3 +1133,29 @@ TEST_F(SubTypeTest, TupleValRefNotSubAnyShare)
 
   TEST_ERRORS_1(src, "type argument is outside its constraint");
 }
+
+
+TEST_F(SubTypeTest, BoxArrowTypeParamReifiedWithTypeParam)
+{
+  const char* src =
+    "interface _V[A: _V[A] ref]\n"
+    "  fun ref reset(delta: A): A\n"
+    "  fun ref converge(other: box->A)\n"
+
+    "class ref Container[V: _V[V] ref] is _V[Container[V]]\n"
+    "  let _value: V\n"
+    "  new ref create(value': V) => _value = value'\n"
+
+    "  fun ref reset(delta: Container[V]): Container[V] =>\n"
+    "    _value.reset(delta._value)\n"
+    "    delta\n"
+
+    "  fun ref converge(other: Container[V] box) =>\n"
+    "    _value.converge(other._value)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
This PR fixes a case I ran into where typechecking was broken for `box->A`, when `A` was a type parameter that gets reified with a different type parameter at the outer level.

The case is demonstrated in the example from the new new unit test.