### PR TITLE
Change directory.open_file() to use readonly open

### DIFF
--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -255,7 +255,7 @@ class Directory
           I32(0x1B6))
       recover File._descriptor(fd', path')? end
     else
-      recover File(path') end
+      recover File.open(path') end
     end
 
   fun info(): FileInfo ? =>


### PR DESCRIPTION
On non-Linux and non-BSD platforms the direction.open_file() logic
defaults to a named path base open, rather than using `openat` calls.

However, this was using the `File.create(...)` call which opens files
for read/write, rather than just readonly. This in turn fails since
the `FileWrite` capability is explicitly dropped.

This commit simply switches to using `File.open(...)` which opens the
file in a readonly mode.

This fixes: https://github.com/ponylang/ponyc/issues/2695