### PR TITLE
Change directory.open_file() to use readonly open

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -11,6 +11,7 @@ actor Main is TestList
     test(_TestMkdtemp)
     test(_TestWalk)
     test(_TestDirectoryOpen)
+    test(_TestDirectoryFileOpen)
     test(_TestPathClean)
     test(_TestPathJoin)
     test(_TestPathRel)
@@ -138,6 +139,34 @@ class iso _TestDirectoryOpen is UnitTest
       h.assert_true(tmp.remove())
     end
 
+class iso _TestDirectoryFileOpen is UnitTest
+  fun name(): String => "files/Directory.open-file"
+  fun apply(h: TestHelper) =>
+  try
+    // make a temporary directory
+    let dir_path = FilePath.mkdtemp(
+      h.env.root as AmbientAuth,
+      "tmp.directory.open-file")?
+    try
+      let dir = Directory(dir_path)?
+
+      // create a file (rw)
+      let created:File = dir.create_file("created")?
+      h.assert_true(created.valid())
+      created.dispose()
+
+      // open a file (ro)
+      let readonly:File = dir.open_file("created")?
+      h.assert_true(readonly.valid())
+      readonly.dispose()
+    else
+      h.fail("Unhandled inner error!")
+    then
+      dir_path.remove()
+    end
+  else
+    h.fail("Unhandled error!")
+  end
 
 class iso _TestPathClean is UnitTest
   fun name(): String => "files/Path.clean"

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -151,12 +151,12 @@ class iso _TestDirectoryFileOpen is UnitTest
       let dir = Directory(dir_path)?
 
       // create a file (rw)
-      let created:File = dir.create_file("created")?
+      let created: File = dir.create_file("created")?
       h.assert_true(created.valid())
       created.dispose()
 
       // open a file (ro)
-      let readonly:File = dir.open_file("created")?
+      let readonly: File = dir.open_file("created")?
       h.assert_true(readonly.valid())
       readonly.dispose()
     else

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -255,7 +255,7 @@ class Directory
           I32(0x1B6))
       recover File._descriptor(fd', path')? end
     else
-      recover File(path') end
+      recover File.open(path') end
     end
 
   fun info(): FileInfo ? =>


### PR DESCRIPTION
On non-Linux and non-BSD platforms the direction.open_file() logic
defaults to a named path base open, rather than using `openat` calls.

However, this was using the `File.create(...)` call which opens files
for read/write, rather than just readonly. This in turn fails since
the `FileWrite` capability is explicitly dropped.

This commit simply switches to using `File.open(...)` which opens the
file in a readonly mode.

This fixes: https://github.com/ponylang/ponyc/issues/2695