### PR TITLE
Enable virtual terminal color output on Windows.

### DIFF
--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -376,6 +376,12 @@ PONY_API void pony_os_stdout_setup()
   handle = GetStdHandle(STD_OUTPUT_HANDLE);
   type = GetFileType(handle);
 
+  DWORD mode;
+  if (GetConsoleMode(handle, &mode))
+  {
+    SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  }
+
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   GetConsoleScreenBufferInfo(handle, &csbi);
   stdout_reset = csbi.wAttributes;
@@ -383,6 +389,10 @@ PONY_API void pony_os_stdout_setup()
 
   handle = GetStdHandle(STD_ERROR_HANDLE);
   type = GetFileType(handle);
+  if (GetConsoleMode(handle, &mode))
+  {
+    SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+  }
 
   GetConsoleScreenBufferInfo(handle, &csbi);
   stderr_reset = csbi.wAttributes;


### PR DESCRIPTION
This enables support for ANSI escape sequences in Windows console output for `stdout` and `stderr` for all Pony programs.

Fixes #2700.

Note that this will only work on Windows 10 builds later than 10586.