### PR TITLE
Fix temporary file from test not getting deleted on Windows

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -395,6 +395,9 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
         let line = file2.line()?
         h.fail("read on invalid file succeeded")
       end
+      mode.owner_read = true
+      mode.owner_write = true // required on Windows to delete the file
+      filepath.chmod(mode)
       filepath.remove()
     else
       h.fail("Unhandled error!")


### PR DESCRIPTION
The test `files/File.create-exists-not-writeable` creates a temporary file which is then supposed to be deleted.  This PR successfully deletes the file on Windows.