### PR TITLE
Fix File.flush return value for case of zero bytes to flush.

### DIFF
--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -461,19 +461,22 @@ class File
     """
     Write pending data.
     Returns false if the file wasn't opened with write permission.
-    Returns raises error if not all the bytes were written.
+    Raises an error if not all the bytes were written.
     Returns true if it sent all pending data.
     Returns num_processed and new pending_total also.
     """
-    // TODO: Make writev_batch_size user configurable
-    let writev_batch_size = @pony_os_writev_max()
     var num_to_send: I32 = 0
     var num_sent: USize = 0
     var bytes_to_send: USize = 0
     var pending_total = _pending_writev_total
-    while
-      writeable and (pending_total > 0) and (_fd != -1)
-    do
+
+    if (not writeable) or (_fd == -1) then
+      return (false, num_sent, pending_total)
+    end
+
+    // TODO: Make writev_batch_size user configurable
+    let writev_batch_size = @pony_os_writev_max()
+    while pending_total > 0 do
       //determine number of bytes and buffers to send
       if (_pending_writev.size().i32()/2) < writev_batch_size then
         num_to_send = _pending_writev.size().i32()/2
@@ -500,20 +503,14 @@ class File
           num_to_send).isize()
       end
 
-      if len < bytes_to_send.isize() then
-        error
-      else
-        // sent all data we requested in this batch
-        pending_total = pending_total - bytes_to_send
-        num_sent = num_sent + num_to_send.usize()
+      if len < bytes_to_send.isize() then error end
 
-        if pending_total == 0 then
-          return (true, num_sent, pending_total)
-        end
-      end
+      // sent all data we requested in this batch
+      pending_total = pending_total - bytes_to_send
+      num_sent = num_sent + num_to_send.usize()
     end
 
-    (false, num_sent, pending_total)
+    (true, num_sent, pending_total)
 
   fun ref position(): USize =>
     """


### PR DESCRIPTION
Currently, `File.flush` returns `false` when the number of bytes pending to write is zero, even though the docstring says that:

```
    Returns false if the file wasn't opened with write permission.
    Raises an error if not all the bytes were written.
    Returns true if it sent all pending data.
```

This situation should fall under the `true` condition - all pending data was successfully written - it's just that the number of bytes was zero. It definitely doesn't fall under the `false` condition because it has nothing to do with write permissions.

This PR fixes that bug and adds a test.