### PR TITLE
Reimplement files.FileLines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix validation of provides lists of object literals. ([PR #2860](https://github.com/ponylang/ponyc/pull/2860))
 - Fix `files/Path.clean()` not correctly handling multiple `..` ([PR #2862](https://github.com/ponylang/ponyc/pull/2862))
 - Fix skipped try-then clauses on return, break and continue statements ([PR #2853](https://github.com/ponylang/ponyc/pull/2853))
+- Fix performance and memory consumption issues with `files.FileLines` ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 
 ### Added
 
 - Added OpenBSD support. ([PR #2823](https://github.com/ponylang/ponyc/pull/2823))
+- Add SSL APLN support ([PR #2816](https://github.com/ponylang/ponyc/pull/2816))
+- Make dynamic scheduler scaling more robust and configurable ([PR #2801](https://github.com/ponylang/ponyc/pull/2801))
+- Added `set_up` method to `ponytest.UnitTest` as equivalent to existing `tear_down` method ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 
 ### Changed
 
 -  Use RLIMIT_STACK's current limit for Pthreads stack size if it is sane ([PR #2852](https://github.com/ponylang/ponyc/pull/2852))
+- Remove `File.line` method in favor of using `FileLines` ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 
 ## [0.24.4] - 2018-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Added OpenBSD support. ([PR #2823](https://github.com/ponylang/ponyc/pull/2823))
-- Add SSL APLN support ([PR #2816](https://github.com/ponylang/ponyc/pull/2816))
-- Make dynamic scheduler scaling more robust and configurable ([PR #2801](https://github.com/ponylang/ponyc/pull/2801))
 - Added `set_up` method to `ponytest.UnitTest` as equivalent to existing `tear_down` method ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 - Added `keep_line_breaks` argument to function `buffered.Reader.line` ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Add SSL APLN support ([PR #2816](https://github.com/ponylang/ponyc/pull/2816))
 - Make dynamic scheduler scaling more robust and configurable ([PR #2801](https://github.com/ponylang/ponyc/pull/2801))
 - Added `set_up` method to `ponytest.UnitTest` as equivalent to existing `tear_down` method ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
+- Added `keep_line_breaks` argument to function `buffered.Reader.line` ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 
 ### Changed
 

--- a/examples/files/files.pony
+++ b/examples/files/files.pony
@@ -10,7 +10,7 @@ actor Main
       do
         env.out.print(file.path.path)
         for line in file.lines() do
-          env.out.print(line)
+          env.out.print(consume line)
         end
       end
     else

--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -169,10 +169,11 @@ class Reader
     u8()?
     b
 
-  fun ref line(): String iso^ ? =>
+  fun ref line(keep_line_breaks: Bool = false): String iso^ ? =>
     """
-    Return a \n or \r\n terminated line as a string. The newline is not
-    included in the returned string, but it is removed from the network buffer.
+    Return a \n or \r\n terminated line as a string. By default the newline is not
+    included in the returned string, but it is removed from the buffer.
+    Set `keep_line_breaks` to `true` to keep the line breaks in the returned line.
     """
     let len = _search_length()?
 
@@ -199,8 +200,15 @@ class Reader
       _chunks.shift()?
     end
 
-    out.truncate(len -
-      if (len >= 2) and (out.at_offset(-2)? == '\r') then 2 else 1 end)
+    let trunc_len: USize =
+      if keep_line_breaks then
+        0
+      elseif (len >= 2) and (out.at_offset(-2)? == '\r') then
+        2
+      else
+        1
+      end
+    out.truncate(len - trunc_len)
 
     consume out
 

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -817,7 +817,7 @@ class iso _TestFileFlush is UnitTest
 
         // Now expect to be able to see the data.
         with read_file = CreateFile(path) as File do
-          h.assert_eq[String]("foobar\n", read_file.read_string(7))
+          h.assert_eq[String]("foobar", "".join(read_file.lines()))
         end
       end
       path.remove()

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -2,9 +2,12 @@ use "ponytest"
 use "collections"
 use "buffered"
 use "term"
+use "random"
+use "time"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
+
   new make() => None
 
   fun tag tests(test: PonyTest) =>
@@ -41,6 +44,9 @@ actor Main is TestList
     test(_TestFileWritevLarge)
     test(_TestFileFlush)
     test(_TestFileReadMore)
+    test(_TestFileLinesEmptyFile)
+    test(_TestFileLinesSingleLine)
+    test(_TestFileLinesMultiLine)
 
 primitive _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath ? =>
@@ -344,17 +350,15 @@ class iso _TestFileEOF is UnitTest
       let path = "tmp.eof"
       let filepath = FilePath(h.env.root as AmbientAuth, path)?
       with file = File(filepath) do
-        file.print("foobar")
+        file.write("foobar")
         file.sync()
         file.seek_start(0)
-        let line1 = file.line()?
+        let line1 = file.read_string(6)
         h.assert_eq[String]("foobar", consume line1)
-        try
-          let line2 = file.line()?
-          h.fail("Read beyond EOF without error!")
-        else
-          h.assert_true(file.errno() is FileEOF)
-        end
+
+        let line2 = file.read_string(1)
+        h.assert_eq[USize](line2.size(), 0, "Read beyond EOF without error!")
+        h.assert_true(file.errno() is FileEOF)
       end
       filepath.remove()
     else
@@ -372,8 +376,7 @@ class iso _TestFileCreate is UnitTest
         file.print("foobar")
       end
       with file2 = CreateFile(filepath) as File do
-        let line1 = file2.line()?
-        h.assert_eq[String]("foobar", consume line1)
+        h.assert_eq[String]("foobar", "".join(file2.lines()))
       end
       filepath.remove()
     else
@@ -394,7 +397,7 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
 
       // preparing the non-writable, but readable file
       with file = CreateFile(filepath) as File do
-        file.print(content)
+        file.write(content)
       end
 
       h.assert_true(filepath.chmod(mode))
@@ -403,8 +406,8 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
         h.assert_false(file2.valid())
         h.assert_is[FileErrNo](file2.errno(), FilePermissionDenied)
 
-        let line = file2.line()?
-        h.fail("read on invalid file succeeded")
+        let line = file2.read(6)
+        h.assert_eq[USize](0, line.size(), "read on invalid file succeeded")
       end
       mode.owner_read = true
       mode.owner_write = true // required on Windows to delete the file
@@ -526,11 +529,12 @@ class iso _TestFileOpen is UnitTest
       with file = CreateFile(filepath) as File do
         file.print("foobar")
       end
-      with file2 = OpenFile(filepath) as File do
-        let line1 = file2.line()?
-        h.assert_eq[String]("foobar", consume line1)
+      try
+        let file2 = OpenFile(filepath) as File
+        h.assert_eq[String]("foobar", "".join(file2.lines()))
         h.assert_true(file2.valid())
         h.assert_false(file2.writeable)
+        file2.dispose()
       else
         h.fail("Failed read on opened file!")
       end
@@ -621,7 +625,7 @@ class iso _TestFileLongLine is UnitTest
         file.print(longline)
         file.sync()
         file.seek_start(0)
-        let line1 = file.line()?
+        let line1 = file.read_string(longline.size())
         h.assert_eq[String](longline, consume line1)
       end
       filepath.remove()
@@ -639,8 +643,8 @@ class iso _TestFileWrite is UnitTest
         file.write("foobar\n")
       end
       with file2 = CreateFile(filepath) as File do
-        let line1 = file2.line()?
-        h.assert_eq[String]("foobar", consume line1)
+        let line1 = file2.read_string(8)
+        h.assert_eq[String]("foobar\n", consume line1)
       end
       filepath.remove()
     else
@@ -662,10 +666,10 @@ class iso _TestFileWritev is UnitTest
         h.assert_true(file.writev(wb.done()))
       end
       with file2 = CreateFile(filepath) as File do
-        let fileline1 = file2.line()?
-        let fileline2 = file2.line()?
-        h.assert_eq[String](line1.split("\n")(0)?, consume fileline1)
-        h.assert_eq[String](line2.split("\n")(0)?, consume fileline2)
+        h.assert_eq[String](
+          "foobar barfoo",
+          " ".join(file2.lines())
+        )
       end
       filepath.remove()
     else
@@ -682,8 +686,7 @@ class iso _TestFileQueue is UnitTest
         file.queue("foobar\n")
       end
       with file2 = CreateFile(filepath) as File do
-        let line1 = file2.line()?
-        h.assert_eq[String]("foobar", consume line1)
+        h.assert_eq[String]("foobar", "".join(file2.lines()))
       end
       filepath.remove()
     else
@@ -705,10 +708,7 @@ class iso _TestFileQueuev is UnitTest
         file.queuev(wb.done())
       end
       with file2 = CreateFile(filepath) as File do
-        let fileline1 = file2.line()?
-        let fileline2 = file2.line()?
-        h.assert_eq[String](line1.split("\n")(0)?, consume fileline1)
-        h.assert_eq[String](line2.split("\n")(0)?, consume fileline2)
+        h.assert_eq[String]("foobar barfoo", " ".join(file2.lines()))
       end
       filepath.remove()
     else
@@ -746,15 +746,19 @@ class iso _TestFileMixedWriteQueue is UnitTest
         file.writev(consume writev_data)
       end
       with file2 = CreateFile(filepath) as File do
-        h.assert_eq[String](line3, file2.line()?)
-        h.assert_eq[String](line5.split("\n")(0)?, file2.line()?)
-        h.assert_eq[String](line1.split("\n")(0)?, file2.line()?)
-        h.assert_eq[String](line3, file2.line()?)
-        h.assert_eq[String](line4, file2.line()?)
-        h.assert_eq[String](line5.split("\n")(0)?, file2.line()?)
-        h.assert_eq[String](line6.split("\n")(0)?, file2.line()?)
-        h.assert_eq[String](line1.split("\n")(0)?, file2.line()?)
-        h.assert_eq[String](line2.split("\n")(0)?, file2.line()?)
+        h.assert_eq[String](
+          "".join([
+            line3 + "\n"
+            line5
+            line1
+            line3 + "\n"
+            line4 + "\n"
+            line5
+            line6
+            line1
+            line2
+          ].values()),
+          file2.read_string(256))
       end
       filepath.remove()
     else
@@ -779,9 +783,8 @@ class iso _TestFileWritevLarge is UnitTest
       end
       with file2 = CreateFile(filepath) as File do
         count = 0
-        while count < writev_batch_size do
-          let fileline1 = file2.line()?
-          h.assert_eq[String](count.string(), consume fileline1)
+        for line in file2.lines() do
+          h.assert_eq[String](count.string(), consume line)
           count = count + 1
           h.log(count.string())
         end
@@ -814,7 +817,7 @@ class iso _TestFileFlush is UnitTest
 
         // Now expect to be able to see the data.
         with read_file = CreateFile(path) as File do
-          h.assert_eq[String]("foobar", read_file.line()?)
+          h.assert_eq[String]("foobar\n", read_file.read_string(7))
         end
       end
       path.remove()
@@ -844,3 +847,159 @@ class iso _TestFileReadMore is UnitTest
         "File errno is not EOF after reading past the last byte")
     end
     path.remove()
+
+class iso _TestFileLinesEmptyFile is UnitTest
+  var tmp_dir: (FilePath | None) = None
+
+  fun ref set_up(h: TestHelper) ? =>
+    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "empty")?
+
+  fun ref tear_down(h: TestHelper) =>
+    try (tmp_dir as FilePath).remove() end
+
+  fun name(): String => "files/FileLines.empty"
+
+  fun ref apply(h: TestHelper) ? =>
+    let tmp_file = (tmp_dir as FilePath).join("empty")?
+    with file = CreateFile(tmp_file) as File do
+      file.write(Array[U8])
+    end
+
+    with f = OpenFile(tmp_file) as File do
+      let fl = FileLines(f)
+      var lines_returned: USize = 0
+      for _ in fl do
+        lines_returned = lines_returned + 1
+      end
+      h.assert_eq[USize](lines_returned, 0, "FileLines returned a line for an empty file")
+    end
+
+class iso _TestFileLinesSingleLine is UnitTest
+
+  let lines: Array[String] = [ as String:
+    "a"
+    "a\n"
+    "a\r\n"
+    "abcd"
+    "ABCD\n"
+    "ABCD\r\n"
+    String.from_array(recover val Array[U8].init('a', 255) end)
+    String.from_array(recover val Array[U8].init('a', 255) end) + "\n"
+    String.from_array(recover val Array[U8].init('a', 255) end) + "\r\n"
+    String.from_array(recover val Array[U8].init('b', 256) end)
+    String.from_array(recover val Array[U8].init('b', 256) end) + "\n"
+    String.from_array(recover val Array[U8].init('b', 256) end) + "\r\n"
+    String.from_array(recover val Array[U8].init('c', 257) end)
+    String.from_array(recover val Array[U8].init('c', 257) end) + "\n"
+    String.from_array(recover val Array[U8].init('c', 257) end) + "\r\n"
+    String.from_array(recover val Array[U8].init('d', 100_000) end)
+  ]
+
+  var tmp_dir: (FilePath | None) = None
+
+  fun ref set_up(h: TestHelper) ? =>
+    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "single-line")?
+
+  fun ref tear_down(h: TestHelper) =>
+    try
+      (tmp_dir as FilePath).remove()
+    end
+
+  fun name(): String => "files/FileLines.single_line"
+
+  fun ref apply(h: TestHelper)? =>
+    var i: USize = 0
+    for line in lines.values() do
+      let tmp_file = (tmp_dir as FilePath).join("single-line-" + i.string())?
+      with file = CreateFile(tmp_file) as File do
+        h.assert_true(
+          file.write(line),
+          "could not write to file: " + tmp_file.path)
+      end
+
+      with file = OpenFile(tmp_file) as File do
+        let fl = FileLines(file)
+        var lines_returned: USize = 0
+        for read_line in fl do
+          let compare_line =
+            if line.contains("\r\n") then
+              line.substring(0, line.size().isize() - 2)
+            elseif line.contains("\n") then
+              line.substring(0, line.size().isize() -1)
+            else
+              line
+            end
+          h.assert_eq[String](consume read_line, compare_line)
+          lines_returned = lines_returned + 1
+        end
+        h.assert_eq[USize](lines_returned, 1,
+          "FileLines returned " + lines_returned.string() +
+          " for single line: '" + line + "'")
+      end
+      i = i + 1
+    end
+
+class _TestFileLinesMultiLine is UnitTest
+  var tmp_dir: (FilePath | None) = None
+
+  let line_endings: Array[String] val = [ "\n"; "\r\n" ]
+  let file_contents: Array[(Array[String] val, USize)] val = [
+    (["a"; "b"], 2)
+    (["a"; ""; "b"], 3)
+    (["a"; "b"; ""], 2)
+    ([""; "b"; "c"], 3)
+    ([""; ""], 1)
+    ([""; " "], 2)
+    ([""; ""; ""], 2)
+    ([
+      String.from_array(recover val Array[U8].init('a', 254) end)
+      String.from_array(recover val Array[U8].init('a', 257) end)], 2)
+    ([
+      String.from_array(recover val Array[U8].init('b', 256) end)
+      ""
+      String.from_array(recover val Array[U8].init('c', 256) end)
+      ], 3)
+  ]
+
+  fun ref set_up(h: TestHelper) ? =>
+    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "multi-line")?
+
+  fun ref tear_down(h: TestHelper) =>
+    try
+      (tmp_dir as FilePath).remove()
+    end
+
+  fun name(): String => "files/FileLines.multi_line"
+
+  fun ref apply(h: TestHelper)? =>
+    var i: USize = 0
+    for lines_and_count in file_contents.values() do
+      let lines = lines_and_count._1
+      for line_ending in line_endings.values() do
+        let tmp_file = (tmp_dir as FilePath).join("multi-line-" + i.string())?
+        let content = recover val line_ending.join(lines.values()) end
+
+        with file = CreateFile(tmp_file) as File do
+          h.assert_true(
+            file.write(content),
+            "could not write to file: " + tmp_file.path)
+        end
+
+        with file = OpenFile(tmp_file) as File do
+          let fl = FileLines(file)
+          var lines_returned: USize = 0
+          for read_line in fl do
+            lines_returned = lines_returned + 1
+          end
+          let expected_line_count = lines_and_count._2
+          h.assert_eq[USize](
+            lines_returned,
+            expected_line_count,
+            "FileLines returned " + lines_returned.string() + " (expected " +
+            expected_line_count.string() + ") lines for file
+            content:\n----\n" + content + "\n----\n")
+        end
+        i = i + 1
+      end
+    end
+

--- a/packages/files/file_lines.pony
+++ b/packages/files/file_lines.pony
@@ -1,0 +1,86 @@
+use "buffered"
+
+class FileLines is Iterator[String iso^]
+  """
+  Iterate over the lines in a file.
+  """
+  let _reader: Reader = Reader
+  let _file: File
+  let _min_read_size: USize
+  var _last_line_length: USize = 256
+  var _cursor: USize
+  var _has_next: Bool
+
+  new create(
+    file: File,
+    start_position: (USize | None) = None,
+    min_read_size: USize = 256) =>
+    _file = file
+    _cursor =
+      match start_position
+      | let pos: USize => pos
+      | None => _file.position()
+      end
+    _min_read_size = min_read_size
+    _has_next = _file.valid()
+
+  fun ref has_next(): Bool =>
+    _has_next
+
+  fun ref next(): String iso^ ? =>
+    // get back to position of last line
+    let current_pos = _file.position()
+    _file.seek_start(_cursor)
+
+    try
+      while _file.errno() isnt FileEOF do
+        try
+          return _read_line()?
+        else
+          if _file.valid() then
+            // get new line from file
+            let read_bytes = _last_line_length.max(_min_read_size)
+            let read_buf = _file.read(read_bytes)
+            _cursor = _file.position()
+
+            let errno = _file.errno()
+            if (read_buf.size() == 0) and (errno isnt FileOK) and (errno isnt FileEOF) then
+              _has_next = false
+              error
+            end
+
+            // TODO: Limit size of read buffer
+            _reader.append(consume read_buf)
+          else
+            _has_next = false
+            error
+          end
+
+        end
+      end
+      // don't forget the last line
+      _has_next = false
+      if _reader.size() > 0 then
+        return _read_last_line()?
+      else
+        error
+      end
+    else
+      // propagating error
+      error
+    then
+      // reset position to not disturb other operations on the file
+      _file.seek_start(current_pos)
+    end
+
+  fun ref _read_line(): String iso^ ? =>
+    let line = _reader.line()?
+    _last_line_length = line.size()
+    consume line
+
+  fun ref _read_last_line(): String iso^ ? =>
+    let block = _reader.block(_reader.size())?
+    String.from_iso_array(consume block)
+
+
+

--- a/packages/ponytest/_test_runner.pony
+++ b/packages/ponytest/_test_runner.pony
@@ -58,9 +58,15 @@ actor _TestRunner
     _ponytest._test_started(_id)
 
     try
-      _test(_helper)?
+      _test.set_up(_helper)?
+      try
+        _test(_helper)?
+      else
+        log("Test threw an error", false)
+        _pass = false
+      end
     else
-      log("Test threw an error", false)
+      log("Test threw an error during set_up", false)
       _pass = false
     end
 

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -181,22 +181,62 @@ class iso _I8AddTest is UnitTest
 
 ```
 
-## Tear down
+## Setting up and tearing down a test environment
 
-Each unit test object may define a tear_down() function. This is called after
+### Set Up
+
+Any kind of fixture or environment necessary for executing a [UnitTest](ponytest-UnitTest)
+can be set up either in the tests constructor or in a function called [set_up()](ponytest-UnitTest#set_up).
+
+[set_up()](ponytest-UnitTest#set_up) is called before the test is executed. It is partial,
+if it errors, the test is not executed but reported as failing during set up.
+The test's [TestHelper](ponytest-TestHelper) is handed to [set_up()](ponytest-UnitTest#set_up)
+in order to log messages or access the tests [Env](builtin-Env) via [TestHelper.env](ponytest-TestHelper#let-env-env-val).
+
+### Tear Down
+
+Each unit test object may define a [tear_down()](ponytest-UnitTest#tear_down) function. This is called after
 the test has finished to allow tearing down of any complex environment that had
 to be set up for the test.
 
-The tear_down() function is called for each test regardless of whether it
-passed or failed. If a test times out tear_down() will be called after
+The [tear_down()](ponytest-UnitTest#tear_down) function is called for each test regardless of whether it
+passed or failed. If a test times out [tear_down()](ponytest-UnitTest#tear_down) will be called after
 timed_out() returns.
 
-When a test is in an exclusion group, the tear_down() call is considered part
+When a test is in an exclusion group, the [tear_down()](ponytest-UnitTest#tear_down) call is considered part
 of the tests run. The next test in the exclusion group will not start until
-after tear_down() returns on the current test.
+after [tear_down()](ponytest-UnitTest#tear_down) returns on the current test.
 
-The test's TestHelper is handed to tear_down() and it is permitted to log
+The test's [TestHelper](ponytest-TestHelper) is handed to [tear_down()](ponytest-UnitTest#tear_down) and it is permitted to log
 messages and call assert functions during tear down.
+
+### Example
+
+The following example creates a temporary directory in the [set_up()](ponytest-UnitTest#set_up) function
+and removes it in the [tear_down()](ponytest-UnitTest#tear_down) function, thus
+simplifying the test function itself:
+
+```pony
+use "ponytest"
+use "files"
+
+class iso TempDirTest
+  var tmp_dir: (FilePath | None) = None
+
+  fun name(): String => "temp-dir"
+
+  fun ref set_up(h: TestHelper)? =>
+    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "temp-dir")?
+
+  fun ref tear_down(h: TestHelper) =>
+    try
+      (tmp_dir as FilePath).remove()
+    end
+
+  fun apply(h: TestHelper)? =>
+    let dir = tmp_dir as FilePath
+    // do something inside the temporary directory
+```
 
 """
 

--- a/packages/ponytest/unit_test.pony
+++ b/packages/ponytest/unit_test.pony
@@ -34,6 +34,13 @@ trait UnitTest
     """
     None
 
+  fun ref set_up(h: TestHelper) ? =>
+    """
+    Set up the testing environment before a test method is called.
+    Default is to do nothing.
+    """
+    None
+
   fun ref tear_down(h: TestHelper) =>
     """
     Tidy up after the test has completed.


### PR DESCRIPTION
* remove `File.line`
* add `ponytest.UnitTest.set_up` method for initializing test state that needs a `TestHelper` (i.e. for getting an `Env`)

Fixes #2185
