### PR TITLE
Update Backpressure.apply/release examples

### DIFF
--- a/examples/under_pressure/main.pony
+++ b/examples/under_pressure/main.pony
@@ -95,6 +95,10 @@ class SlowDown is TCPConnectionNotify
     _out.print("Releasing backpressure!")
     Backpressure.release(_auth)
 
+  fun ref closed(connection: TCPConnection ref) =>
+    _out.print("Releasing backpressure if applied!")
+    Backpressure.release(_auth)
+
   fun ref connect_failed(conn: TCPConnection ref) =>
     @printf[I32]("connect_failed\n".cstring())
     None

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -107,6 +107,12 @@ actor TCPConnection
       _out.print("Releasing backpressure!")
       Backpressure.release(_auth)
 
+    fun ref closed(connection: TCPConnection ref) =>
+      // if backpressure has been applied, make sure we release
+      // when shutting down
+      _out.print("Releasing backpressure if applied!")
+      Backpressure.release(_auth)
+
     fun ref connect_failed(conn: TCPConnection ref) =>
       None
 


### PR DESCRIPTION
The examples given for how to use manually applied backpressure could lead
to deadlocking as it would be possible to dispose of the TCPConnection
or close it while backpressure had been applied and then not release it.

[skip ci]