### PR TITLE
Add Integer.bit_reverse, exposing the llvm.bitreverse intrinsic.

### DIFF
--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -257,6 +257,7 @@ trait val Integer[A: Integer[A] val] is Real[A]
   fun op_xor(y: A): A => this xor y
   fun op_not(): A => not this
 
+  fun bit_reverse(): A
   fun bswap(): A
 
 trait val _SignedInteger[A: _SignedInteger[A, B] val,

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -258,6 +258,11 @@ trait val Integer[A: Integer[A] val] is Real[A]
   fun op_not(): A => not this
 
   fun bit_reverse(): A
+    """
+    Reverse the order of the bits within the integer.
+    For example, 0b11101101 (237) would return 0b10110111 (183).
+    """
+
   fun bswap(): A
 
 trait val _SignedInteger[A: _SignedInteger[A, B] val,

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -6,6 +6,7 @@ primitive I8 is _SignedInteger[I8, U8]
   new max_value() => 0x7F
 
   fun abs(): U8 => if this < 0 then (-this).u8() else this.u8() end
+  fun bit_reverse(): I8 => @"llvm.bitreverse.i8"[I8](this)
   fun bswap(): I8 => this
   fun popcount(): U8 => @"llvm.ctpop.i8"[U8](this)
   fun clz(): U8 => @"llvm.ctlz.i8"[U8](this, false)
@@ -47,6 +48,7 @@ primitive I16 is _SignedInteger[I16, U16]
   new max_value() => 0x7FFF
 
   fun abs(): U16 => if this < 0 then (-this).u16() else this.u16() end
+  fun bit_reverse(): I16 => @"llvm.bitreverse.i16"[I16](this)
   fun bswap(): I16 => @"llvm.bswap.i16"[I16](this)
   fun popcount(): U16 => @"llvm.ctpop.i16"[U16](this)
   fun clz(): U16 => @"llvm.ctlz.i16"[U16](this, false)
@@ -88,6 +90,7 @@ primitive I32 is _SignedInteger[I32, U32]
   new max_value() => 0x7FFF_FFFF
 
   fun abs(): U32 => if this < 0 then (-this).u32() else this.u32() end
+  fun bit_reverse(): I32 => @"llvm.bitreverse.i32"[I32](this)
   fun bswap(): I32 => @"llvm.bswap.i32"[I32](this)
   fun popcount(): U32 => @"llvm.ctpop.i32"[U32](this)
   fun clz(): U32 => @"llvm.ctlz.i32"[U32](this, false)
@@ -129,6 +132,7 @@ primitive I64 is _SignedInteger[I64, U64]
   new max_value() => 0x7FFF_FFFF_FFFF_FFFF
 
   fun abs(): U64 => if this < 0 then (-this).u64() else this.u64() end
+  fun bit_reverse(): I64 => @"llvm.bitreverse.i64"[I64](this)
   fun bswap(): I64 => @"llvm.bswap.i64"[I64](this)
   fun popcount(): U64 => @"llvm.ctpop.i64"[U64](this)
   fun clz(): U64 => @"llvm.ctlz.i64"[U64](this, false)
@@ -183,6 +187,13 @@ primitive ILong is _SignedInteger[ILong, ULong]
     end
 
   fun abs(): ULong => if this < 0 then (-this).ulong() else this.ulong() end
+
+  fun bit_reverse(): ILong =>
+    ifdef ilp32 or llp64 then
+      @"llvm.bitreverse.i32"[ILong](this)
+    else
+      @"llvm.bitreverse.i64"[ILong](this)
+    end
 
   fun bswap(): ILong =>
     ifdef ilp32 or llp64 then
@@ -272,6 +283,13 @@ primitive ISize is _SignedInteger[ISize, USize]
 
   fun abs(): USize => if this < 0 then (-this).usize() else this.usize() end
 
+  fun bit_reverse(): ISize =>
+    ifdef ilp32 then
+      @"llvm.bitreverse.i32"[ISize](this)
+    else
+      @"llvm.bitreverse.i64"[ISize](this)
+    end
+
   fun bswap(): ISize =>
     ifdef ilp32 then
       @"llvm.bswap.i32"[ISize](this)
@@ -347,6 +365,7 @@ primitive I128 is _SignedInteger[I128, U128]
   new max_value() => 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
 
   fun abs(): U128 => if this < 0 then (-this).u128() else this.u128() end
+  fun bit_reverse(): I128 => @"llvm.bitreverse.i128"[I128](this)
   fun bswap(): I128 => @"llvm.bswap.i128"[I128](this)
   fun popcount(): U128 => @"llvm.ctpop.i128"[U128](this)
   fun clz(): U128 => @"llvm.ctlz.i128"[U128](this, false)

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -10,6 +10,7 @@ primitive U8 is _UnsignedInteger[U8]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U8 => this
+  fun bit_reverse(): U8 => @"llvm.bitreverse.i8"[U8](this)
   fun bswap(): U8 => this
   fun popcount(): U8 => @"llvm.ctpop.i8"[U8](this)
   fun clz(): U8 => @"llvm.ctlz.i8"[U8](this, false)
@@ -54,6 +55,7 @@ primitive U16 is _UnsignedInteger[U16]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U16 => this
+  fun bit_reverse(): U16 => @"llvm.bitreverse.i16"[U16](this)
   fun bswap(): U16 => @"llvm.bswap.i16"[U16](this)
   fun popcount(): U16 => @"llvm.ctpop.i16"[U16](this)
   fun clz(): U16 => @"llvm.ctlz.i16"[U16](this, false)
@@ -98,6 +100,7 @@ primitive U32 is _UnsignedInteger[U32]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U32 => this
+  fun bit_reverse(): U32 => @"llvm.bitreverse.i32"[U32](this)
   fun bswap(): U32 => @"llvm.bswap.i32"[U32](this)
   fun popcount(): U32 => @"llvm.ctpop.i32"[U32](this)
   fun clz(): U32 => @"llvm.ctlz.i32"[U32](this, false)
@@ -142,6 +145,7 @@ primitive U64 is _UnsignedInteger[U64]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U64 => this
+  fun bit_reverse(): U64 => @"llvm.bitreverse.i64"[U64](this)
   fun bswap(): U64 => @"llvm.bswap.i64"[U64](this)
   fun popcount(): U64 => @"llvm.ctpop.i64"[U64](this)
   fun clz(): U64 => @"llvm.ctlz.i64"[U64](this, false)
@@ -199,6 +203,13 @@ primitive ULong is _UnsignedInteger[ULong]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): ULong => this
+
+  fun bit_reverse(): ULong =>
+    ifdef ilp32 or llp64 then
+      @"llvm.bitreverse.i32"[ULong](this)
+    else
+      @"llvm.bitreverse.i64"[ULong](this)
+    end
 
   fun bswap(): ULong =>
     ifdef ilp32 or llp64 then
@@ -301,6 +312,13 @@ primitive USize is _UnsignedInteger[USize]
 
   fun abs(): USize => this
 
+  fun bit_reverse(): USize =>
+    ifdef ilp32 then
+      @"llvm.bitreverse.i32"[USize](this)
+    else
+      @"llvm.bitreverse.i64"[USize](this)
+    end
+
   fun bswap(): USize =>
     ifdef ilp32 then
       @"llvm.bswap.i32"[USize](this)
@@ -388,6 +406,7 @@ primitive U128 is _UnsignedInteger[U128]
     1 << (if x == 0 then 0 else bitwidth() - x end)
 
   fun abs(): U128 => this
+  fun bit_reverse(): U128 => @"llvm.bitreverse.i128"[U128](this)
   fun bswap(): U128 => @"llvm.bswap.i128"[U128](this)
   fun popcount(): U128 => @"llvm.ctpop.i128"[U128](this)
   fun clz(): U128 => @"llvm.ctlz.i128"[U128](this, false)


### PR DESCRIPTION
I had a need for bit reverse semantics, noticed that `Integer` has `bswap` which exposes the `llvm.bswap` intrinsic, but the `llvm.bitreverse` intrinsic was missing.

So this PR adds the exposure of that missing intrinsic.