### PR TITLE
Relax ProcessMonitor checks for execute bits

### DIFF
--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -138,18 +138,18 @@ class iso _TestNonExecutablePathResultsInExecveError is UnitTest
 
   fun apply(h: TestHelper) =>
     try
-      let path = _setup_file(h)?
+      let auth = h.env.root as AmbientAuth
+      let path = FilePath.mkdtemp(auth, "pony_execve_test")?
       let args: Array[String] iso = recover Array[String](1) end
       let vars: Array[String] iso = recover Array[String](2) end
 
-      let auth = h.env.root as AmbientAuth
       let notifier = _setup_notifier(h, path)
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
         path, consume args, consume vars)
       h.dispose_when_done(pm)
       h.long_test(30_000_000_000)
     else
-      h.fail("Could not create FilePath!")
+      h.fail("Could not create temporary FilePath!")
     end
 
   fun timed_out(h: TestHelper) =>
@@ -177,16 +177,6 @@ class iso _TestNonExecutablePathResultsInExecveError is UnitTest
       fun _cleanup() =>
         _path.remove()
     end end
-
-  fun _setup_file(h: TestHelper): FilePath ? =>
-    let tmp_dir = FilePath(h.env.root as AmbientAuth, "/tmp/")?
-    let path =
-      FilePath(h.env.root as AmbientAuth, tmp_dir.path + "/" + Path.random(32))?
-    let tmp_file = CreateFile(path) as File
-    let mode = FileMode
-    mode.any_exec = false
-    tmp_file.path.chmod(consume mode)
-    path
 
 class iso _TestExpect is UnitTest
   fun name(): String =>

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -242,12 +242,13 @@ actor ProcessMonitor
     end
 
     let ok = try
-      FileInfo(filepath)?.mode.any_exec
+      FileInfo(filepath)?.file
     else
       false
     end
     if not ok then
-      // path is to a non-executable file or that file doesn't exist
+      // unable to stat the file path given so it may not exist
+      // or may be a directory.
       _notifier.failed(this, ExecveError)
       return
     end


### PR DESCRIPTION
This is part one of addressing issue #2714. We avoid breaking compatibility with the API in this change.

We should rely on the system to do these checks properly. Since we don't currently have a clean way to signal failure of execv, we'll assert that the path is a proper file first.
