### PR TITLE
Fix CommandSpec without args and help

### DIFF
--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -6,6 +6,7 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestMinimal)
+    test(_TestMinimalWithHelp)
     test(_TestBadName)
     test(_TestUnknownCommand)
     test(_TestUnexpectedArg)
@@ -35,15 +36,30 @@ class iso _TestMinimal is UnitTest
     ])?
 
     h.assert_eq[String]("minimal", cs.name())
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = ["ignored"; "--aflag=true"]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("minimal", cmd.fullname())
     h.assert_eq[Bool](true, cmd.option("aflag").bool())
+
+class iso _TestMinimalWithHelp is UnitTest
+  fun name(): String => "ponycli/minimal_help"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = CommandSpec.leaf("minimal_help", "",[])? .> add_help()?
+    h.assert_eq[String]("minimal_help", cs.name())
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
+
+    let args: Array[String] = ["--help"]
+    // test for successful parsing
+    let cmdErr = CommandParser(cs).parse(args) as Command
 
 class iso _TestBadName is UnitTest
   fun name(): String => "ponycli/badname"
@@ -61,6 +77,8 @@ class iso _TestUnknownCommand is UnitTest
   // Negative test: unknown command should report
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.chat_cli_spec()?
+    h.assert_false(cs.is_leaf())
+    h.assert_true(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -83,6 +101,8 @@ class iso _TestUnexpectedArg is UnitTest
   // Negative test: unexpected arg/command token should report
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.bools_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -106,6 +126,8 @@ class iso _TestUnknownShort is UnitTest
   // Negative test: unknown short option should report
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.bools_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -129,6 +151,8 @@ class iso _TestUnknownLong is UnitTest
   // Negative test: unknown long option should report
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.bools_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -155,11 +179,13 @@ class iso _TestHyphenArg is UnitTest
     let cs = CommandSpec.leaf("minimal" where args' = [
       ArgSpec.string("name", "")
     ])?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
     let args: Array[String] = ["ignored"; "-"]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("minimal", cmd.fullname())
     h.assert_eq[String]("-", cmd.arg("name").string())
@@ -170,12 +196,14 @@ class iso _TestBools is UnitTest
   // Rules 2, 3, 5, 7 w/ Bools
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.bools_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = ["ignored"; "-ab"; "-c=true"; "-d=false"]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("bools", cmd.fullname())
     h.assert_eq[Bool](true, cmd.option("aaa").bool())
@@ -189,13 +217,15 @@ class iso _TestDefaults is UnitTest
   // Rules 2, 3, 5, 6
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.simple_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] =
       ["ignored"; "-B"; "-S--"; "-I42"; "-U47"; "-F42.0"]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolo").bool())
     h.assert_eq[String]("astring", cmd.option("stringo").string())
@@ -210,6 +240,8 @@ class iso _TestShortsAdj is UnitTest
   // Rules 2, 3, 5, 6, 8
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.simple_cli_spec()?
+    h.assert_true(cs.is_leaf())
+    h.assert_false(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -218,7 +250,7 @@ class iso _TestShortsAdj is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("--", cmd.option("stringr").string())
@@ -244,7 +276,7 @@ class iso _TestShortsEq is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("astring", cmd.option("stringr").string())
@@ -271,7 +303,7 @@ class iso _TestShortsNext is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("--", cmd.option("stringr").string())
@@ -298,7 +330,7 @@ class iso _TestLongsEq is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("astring", cmd.option("stringr").string())
@@ -325,7 +357,7 @@ class iso _TestLongsNext is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("--", cmd.option("stringr").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
@@ -356,7 +388,7 @@ class iso _TestEnvs is UnitTest
     let cmdErr = CommandParser(cs).parse(args, envs)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("astring", cmd.option("stringr").string())
@@ -379,7 +411,7 @@ class iso _TestOptionStop is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("-f=1.0", cmd.arg("words").string())
     h.assert_eq[F64](42.0, cmd.option("floato").f64())
@@ -399,7 +431,7 @@ class iso _TestDuplicate is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("newstring", cmd.option("stringr").string())
 
@@ -408,6 +440,8 @@ class iso _TestChat is UnitTest
 
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.chat_cli_spec()?
+    h.assert_false(cs.is_leaf())
+    h.assert_true(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -417,7 +451,7 @@ class iso _TestChat is UnitTest
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
 
-    let cmd = match cmdErr | let c: Command => c else error end
+    let cmd = cmdErr as Command
 
     h.assert_eq[String]("chat/say", cmd.fullname())
 
@@ -449,6 +483,8 @@ class iso _TestMustBeLeaf is UnitTest
   // Negative test: can't just supply parent command
   fun apply(h: TestHelper) ? =>
     let cs = _Fixtures.chat_cli_spec()?
+    h.assert_false(cs.is_leaf())
+    h.assert_true(cs.is_parent())
 
     let args: Array[String] = [
       "ignored"
@@ -471,7 +507,7 @@ class iso _TestHelp is UnitTest
     let cs = _Fixtures.chat_cli_spec()?
 
     let chErr = Help.for_command(cs, ["config"; "server"])
-    let ch = match chErr | let c: CommandHelp => c else error end
+    let ch = chErr as CommandHelp
 
     let help = ch.help_string()
     h.log(help)

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -373,7 +373,7 @@ class iso _TestOptionStop is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "-BS=astring"; "-I=42"; "-F=42.0"
+      "-BS=astring"; "-I=42"; "-F=42.0"; "-U=23"
       "--"; "-f=1.0"
     ]
     let cmdErr = CommandParser(cs).parse(args)

--- a/packages/cli/cli.pony
+++ b/packages/cli/cli.pony
@@ -100,7 +100,7 @@ actor Main
       end
 
     let cmd =
-      match CommandParser(cs).parse(env.args, env.vars())
+      match CommandParser(cs).parse(env.args, env.vars)
       | let c: Command => c
       | let ch: CommandHelp =>
           ch.print_help(env.out)

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -195,7 +195,7 @@ class CommandParser
     end
 
     // Specifying only the parent and not a leaf command is an error.
-    if _spec.commands().size() > 0 then
+    if _spec.is_parent() then
       return SyntaxError(_spec.name(), "missing subcommand")
     end
 

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -58,6 +58,7 @@ actor Main is TestList
     builtin_test.Main.make().tests(test)
     buffered.Main.make().tests(test)
     bureaucracy.Main.make().tests(test)
+    cli.Main.make().tests(test)
     collections.Main.make().tests(test)
     collections_persistent.Main.make().tests(test)
     crypto.Main.make().tests(test)


### PR DESCRIPTION
And Actually run the cli tests (that weren't passing).

To fix the case of a `CommandSpec.leaf` without args and with help i added a `_type` fields and getters for properly determining if a `CommandSpec` is a parent or a leaf. I would be more comfortable with having two different classes here that share a common trait, but i tried going that route and it entails some breaking API changes that need to go through the RFC process. I decided to ease the pain for now with this fix, but will most likely do a separate RFC soon.