### PR TITLE
Search for /usr/local/lib last

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,7 +704,7 @@ define CONFIGURE_LINKER
 
   $(eval $(call CONFIGURE_LINKER_WHOLE,$(1)))
   $(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
-  linkcmd += $(libs) -L $(libdir) $($(1).linkoptions)
+  linkcmd += $(libs) -L /usr/local/lib $($(1).linkoptions)
 endef
 
 define PREPARE

--- a/Makefile
+++ b/Makefile
@@ -692,7 +692,7 @@ define CONFIGURE_LINKER_WHOLE
 endef
 
 define CONFIGURE_LINKER
-  $(eval linkcmd := $(LINKER_FLAGS) -L $(lib) -L /usr/local/lib )
+  $(eval linkcmd := $(LINKER_FLAGS) -L $(lib))
   $(eval linker := $(CC))
   $(eval libs :=)
 
@@ -704,7 +704,7 @@ define CONFIGURE_LINKER
 
   $(eval $(call CONFIGURE_LINKER_WHOLE,$(1)))
   $(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
-  linkcmd += $(libs) $($(1).linkoptions)
+  linkcmd += $(libs) -L $(libdir) $($(1).linkoptions)
 endef
 
 define PREPARE


### PR DESCRIPTION
I ran into a problem linking lib/llvm failed because the system installed
llvm was installed in /usr/local/lib. When I tried to link the version
in <ponyc>lib/llvm it failed because the llvm in /usr/local/lib was linked
instead.