### PR TITLE
Fix String.concat ignoring the len parameter

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -880,7 +880,7 @@ actor Main
 
       n = 0
 
-      while (n < len) or (len == USize(-1)) do
+      while n < len do
         if iter.has_next() then
           push(iter.next()?)
         else

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -880,12 +880,14 @@ actor Main
 
       n = 0
 
-      while n < len do
+      while (n < len) or (len == USize(-1)) do
         if iter.has_next() then
           push(iter.next()?)
         else
           return
         end
+
+        n = n + 1
       end
     end
 

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -1100,7 +1100,7 @@ class iso _TestStringConcatOffsetLen is UnitTest
   fun name(): String => "builtin/String.concat"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String](recover String .> concat("ABCD".values(), 1, 2) end, "BC")
+    h.assert_eq[String](recover String.>concat("ABCD".values(), 1, 2) end, "BC")
 
 class iso _TestArrayAppend is UnitTest
   fun name(): String => "builtin/Array.append"

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -51,6 +51,7 @@ actor Main is TestList
     test(_TestStringRecalc)
     test(_TestStringTruncate)
     test(_TestStringChop)
+    test(_TestStringConcatOffsetLen)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -1091,6 +1092,15 @@ class iso _TestStringChop is UnitTest
     (let left: String iso, let right: String iso) = (consume orig).chop(split_point)
     h.assert_eq[String box](expected_left, consume left)
     h.assert_eq[String box](expected_right, consume right)
+
+class iso _TestStringConcatOffsetLen is UnitTest
+  """
+  Test String.concat working correctly for non-default offset and len arguments
+  """
+  fun name(): String => "builtin/String.concat"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](recover String .> concat("ABCD".values(), 1, 2) end, "BC")
 
 class iso _TestArrayAppend is UnitTest
   fun name(): String => "builtin/Array.append"


### PR DESCRIPTION
The loop pushing values from iter didn't increment n, resulting in finite iterators getting concated completely.

Also infinite iterators such as `Iter.repeat_value` would result in the function never returning and eating up memory.

This behavior contradicts the docstring.