### PR TITLE
Only enable mcx16 for gcc for x86_64 targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ BITS := $(bits)
 UNAME_M := $(shell uname -m)
 
 ifeq ($(BITS),64)
-  ifneq ($(UNAME_M),aarch64)
+  ifeq ($(UNAME_M),x86_64)
     BUILD_FLAGS += -mcx16
     LINKER_FLAGS += -mcx16
   endif

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -333,7 +333,8 @@ static bool link_exe(compile_t* c, ast_t* program,
   bool fallback_linker = false;
   const char* linker = c->opt->linker != NULL ? c->opt->linker :
     env_cc_or_pony_compiler(&fallback_linker);
-  const char* mcx16_arg = target_is_ilp32(c->opt->triple) ? "" : "-mcx16";
+  const char* mcx16_arg = (target_is_lp64(c->opt->triple)
+    && target_is_x86(c->opt->triple)) ? "-mcx16" : "";
   const char* fuseld = target_is_linux(c->opt->triple) ? "-fuse-ld=gold" : "";
   const char* ldl = target_is_linux(c->opt->triple) ? "-ldl" : "";
   const char* atomic = target_is_linux(c->opt->triple) ? "-latomic" : "";


### PR DESCRIPTION
The -mcx16 option for GCC is only valid on the x86 compiler and
it only applies to 64 bit code. See the following url for x86
options for GCC:
https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html

This commit changes it to only be enabled for x86_64 targets.