### PR TITLE
Fix type system logic for detecting if a type param can match itself.

### DIFF
--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -64,7 +64,7 @@ class HashMap[K, V, H: HashFunction[K] val]
       (let i, let found) = _search(key)
 
       let k = if found then
-        _array(i)? as (K^, _)
+        (_array(i)? = _MapDeleted) as (K^, _)
       else
         consume key
       end

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -109,48 +109,9 @@ class Iter[A] is Iterator[A]
     `filter`.
     """
     Iter[A](
-      object
-        var _next: (A! | _None) = _None
-
-        fun ref _find_next() =>
-          try
-            match _next
-            | _None =>
-              if _iter.has_next() then
-                let a = _iter.next()?
-                if try f(a)? else false end then
-                  _next = a
-                else
-                  _find_next()
-                end
-              end
-            end
-          end
-
-        fun ref has_next(): Bool =>
-          match _next
-          | _None =>
-            if _iter.has_next() then
-              _find_next()
-              has_next()
-            else
-              false
-            end
-          else
-            true
-          end
-
-        fun ref next(): A ? =>
-          match _next = _None
-          | let a: A => consume a
-          else
-            if _iter.has_next() then
-              _find_next()
-              next()?
-            else
-              error
-            end
-          end
+      object ref is Iterator[A]
+        fun ref has_next(): Bool => false
+        fun ref next(): A ? => error
       end)
 
   fun ref filter_map_stateful[B](f: {ref(A!): (B | None) ?}): Iter[B]^ =>
@@ -159,48 +120,9 @@ class Iter[A] is Iterator[A]
     similar to `filter_map`.
     """
     Iter[B](
-      object is Iterator[B]
-        var _next: (B | _None) = _None
-
-        fun ref _find_next() =>
-          try
-            match _next
-            | _None =>
-              if _iter.has_next() then
-                match f(_iter.next()?)?
-                | let b: B => _next = consume b
-                | None => _find_next()
-                end
-              end
-            end
-          end
-
-        fun ref has_next(): Bool =>
-          match _next
-          | _None =>
-            if _iter.has_next() then
-              _find_next()
-              has_next()
-            else
-              false
-            end
-          else
-            true
-          end
-
-        fun ref next(): B ? =>
-          match _next
-          | let b: B =>
-            _next = _None
-            consume b
-          else
-            if _iter.has_next() then
-              _find_next()
-              next()?
-            else
-              error
-            end
-          end
+      object ref is Iterator[B]
+        fun ref has_next(): Bool => false
+        fun ref next(): B ? => error
       end)
 
   fun ref all(f: {(A!): Bool ?} box): Bool =>
@@ -724,36 +646,9 @@ class Iter[A] is Iterator[A]
     `1 2 3`
     """
     Iter[A](
-      object
-        var _done: Bool = false
-        var _next: (A! | None) = None
-
-        fun ref has_next(): Bool =>
-          if _next isnt None then true
-          else _try_next()
-          end
-
-        fun ref next(): A ? =>
-          if (_next isnt None) or _try_next() then
-            (_next = None) as A
-          else error
-          end
-
-        fun ref _try_next(): Bool =>
-          if _done then false
-          elseif not _iter.has_next() then
-            _done = true
-            false
-          else
-            _next =
-              try _iter.next()?
-              else
-                _done = true
-                return false
-              end
-            _done = try not f(_next as A)? else true end
-            not _done
-          end
+      object ref is Iterator[A]
+        fun ref has_next(): Bool => false
+        fun ref next(): A ? => error
       end)
 
   /*

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -526,6 +526,7 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
         ast_print_type(pattern_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
+      is_matchtype(operand_type, pattern_type, &info, opt);
 
       ok = false;
       break;

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -456,6 +456,9 @@ TEST_F(MatchTypeTest, TypeParams)
     "trait T2\n"
     "  fun g()\n"
 
+    "trait T3[A: T3[A]]\n"
+    "  fun h()\n"
+
     "class C1 is T1\n"
     "  fun f() => None\n"
 
@@ -463,9 +466,9 @@ TEST_F(MatchTypeTest, TypeParams)
 
     "interface Test\n"
     "  fun z[A1: C2 ref, A2: T1 ref, A3: T2 ref, A4: T2 box,\n"
-    "    A5: (T1 ref | T2 ref)]\n"
+    "    A5: (T1 ref | T2 ref), A6: (T3[A6] ref & (C1 ref | C2 ref))]\n"
     "    (c1: C1, c2: C2, t1: T1, t2: T2,\n"
-    "    ac2: A1, at1: A2, at2: A3, at2box: A4, aunion: A5)";
+    "    ac2: A1, at1: A2, at2: A3, at2box: A4, aunion: A5, aisect: A6)";
 
   TEST_COMPILE(src);
 
@@ -485,7 +488,12 @@ TEST_F(MatchTypeTest, TypeParams)
 
   // Union constraint
   ASSERT_EQ(
-    MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1"), NULL, &opt));
+    MATCHTYPE_ACCEPT, is_matchtype(type_of("aunion"), type_of("c1"), NULL, &opt));;
+
+  // Intersection of generic trait and union constraint
+  ASSERT_EQ(
+    MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("aisect"), type_of("aisect"), NULL, &opt));
 }
 
 


### PR DESCRIPTION
This PR fixes type system logic for detecting if a type param can match itself.

For example, this snippet doesn't compile with current ponyc master, but should:
```pony
trait val T[A: T[A]]

class val C1 is T[C1]
class val C2 is T[C2]

primitive Foo[A: (T[A] val & (C1 | C2)) = U64]
  fun apply(a: (A | None)): Bool =>
    match a
    | let _: A => true
    else false
    end

actor Main
  new create(env: Env) =>
    env.out.print(Foo[C1](C1).string())
    env.out.print(Foo[C1](None).string())
```

Note that this breaks a few methods in `Iter` that are actually capability-unsafe, so we have to figure out what to do about that. I'm marking as "DO NOT MERGE" and "needs discussion during sync" so we can discuss this aspect.

This may be related to #2584, but I don't think it has the same problem as @Praetonus' solution in #2597. Note that my code example above doesn't have the issue of `None` being a possible subtype of `A`. As such, I don't think we have to wait for @Praetonus' RFC to merge this. Still, I'll ask @Praetonus to comment here if he can.

This may also be related to #2646, which had a runtime segfault in `Iter.filter_stateful`, one of the methods found to be unsafe by this type system fix.