### PR TITLE
Fix incorrect disposable/destroyed epoll resubscribe handling

### DIFF
--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -274,10 +274,13 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
       if(flags != 0)
       {
-        if(ev->auto_resub && !(flags & ASIO_WRITE))
-          pony_asio_event_resubscribe_write(ev);
-        if(ev->auto_resub && !(flags & ASIO_READ))
-          pony_asio_event_resubscribe_read(ev);
+        if (!(flags & ASIO_DESTROYED) || !(flags & ASIO_DISPOSABLE))
+        {
+          if(ev->auto_resub && !(flags & ASIO_WRITE))
+            pony_asio_event_resubscribe_write(ev);
+          if(ev->auto_resub && !(flags & ASIO_READ))
+            pony_asio_event_resubscribe_read(ev);
+        }
         pony_asio_event_send(ev, flags, count);
       }
     }


### PR DESCRIPTION
Neither ASIO_DISPOSABLE or ASIO_DESTROYED events should cause a
read/write resubscription. However, we were allowing this.

Fixes #2684