### PR TITLE
Fix memory overflow when allocating CPUs when numa is enabled

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -97,7 +97,7 @@ void ponyint_cpu_init()
   CPU_ZERO(&hw_cpus);
   CPU_ZERO(&ht_cpus);
 
-  avail_cpu_count = CPU_COUNT(&all_cpus);
+  avail_cpu_size = avail_cpu_count = CPU_COUNT(&all_cpus);
   uint32_t index = 0;
   uint32_t found = 0;
 
@@ -130,7 +130,6 @@ void ponyint_cpu_init()
     avail_cpu_count =
       ponyint_numa_core_list(&hw_cpus, &ht_cpus, avail_cpu_list);
   } else {
-    avail_cpu_size = avail_cpu_count;
     avail_cpu_list =
       (uint32_t*)ponyint_pool_alloc_size(avail_cpu_size * sizeof(uint32_t));
 


### PR DESCRIPTION
Specifically when numa is enabled and the count of available cpus isn't
greater than the number of numa cores.

Previously, when

```
    if(avail_cpu_count > numa_count)
          avail_cpu_size = numa_count;
```

was executed, then at that point avail_cpu_size was 0. this means if
`avail_cpu_count` is not greater than `numa_count` then `avail_cpu_size`
will remain 0 and:

```
ponyint_pool_alloc_size(avail_cpu_size * sizeof(uint32_t));
```

will allocate no memory and bad segfaulting things will happen.

This commit patches the bug to set `avail_cpu_size` to the CPU_COUNT
when we enter `ponyint_cpu_init`.

`  avail_cpu_size = avail_cpu_count = CPU_COUNT(&all_cpus);`

Fixes #2559
Fixes #2689