### PR TITLE
Change refcap of JsonDoc to ref for better usability

### DIFF
--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -1,0 +1,70 @@
+"""
+# JSON Package
+
+The `json` package provides the [JsonDoc](json-JsonDoc) class both as a container for a JSON
+document and as means of parsing from and writing to [String](builtin-String).
+
+## JSON Representation
+
+JSON is represented in Pony as the following types:
+
+* object - [JsonObject](json-JsonObject)
+* array  - [JsonArray](json-JsonArray)
+* string - [String](builtin-String)
+* integer - [I64](builtin-I64)
+* float   - [F64](builtin-F64)
+* boolean - [Bool](builtin-Bool)
+* null    - [None](builtin-None)
+
+The collection types JsonObject and JsonArray can contain any other JSON
+structures arbitrarily nested.
+
+[JsonType](json-JsonType) is used to subsume all possible JSON types. It can
+also be used to describe everything that can be serialized using this package.
+
+## Parsing JSON
+
+For getting JSON from a String into proper Pony data structures,
+[JsonDoc.parse](json-JsonDoc#parse) needs to be used. This will populate the
+public field `JsonDoc.data`, which is [None](builtin-None), if [parse](json-JsonDoc#parse) has
+not been called yet.
+
+Every call to [parse](json-JsonDoc#parse) overwrites the `data` field, so one
+JsonDoc instance can be used to parse multiple JSON Strings one by one.
+
+```pony
+val doc = JsonDoc
+// parsing
+doc.parse(\"\"\"{"key":"value", "property: true, "array":[1, 2.5, false]}\"\"\")?
+
+// extracting values from a JSON structure
+val json: JsonObject  = doc.data as JsonObject
+val key: String       = json.data("key")? as String
+val property: Boolean = json.data("property")? as Bool
+val array: JsonArray  = json.data("array")?
+val first: I64        = array.data(0)? as I64
+val second: F64       = array.data(1)? as F64
+val last: Bool        = array.data(2)? as Bool
+```
+
+## Writing JSON
+
+JSON is written using the [JsonDoc.string](json-JsonDoc#string) method. This
+will serialize the contents of the `data` field to [String](builtin-String).
+
+```pony
+// building up the JSON data structure
+let doc = JsonDoc
+let obj = JsonObject
+obj.data("key") = "value"
+obj.data("property") = true
+obj.data("array") = JsonArray.from_array([ as JsonType: I64(1); F64(2.5); false])
+doc.data = obj
+
+// writing to String
+env.out.print(
+  doc.string(where indent="  ", pretty_print=true)
+)
+
+```
+"""

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -33,19 +33,42 @@ Every call to [parse](json-JsonDoc#parse) overwrites the `data` field, so one
 JsonDoc instance can be used to parse multiple JSON Strings one by one.
 
 ```pony
-val doc = JsonDoc
+let doc = JsonDoc
 // parsing
 doc.parse(\"\"\"{"key":"value", "property: true, "array":[1, 2.5, false]}\"\"\")?
 
 // extracting values from a JSON structure
-val json: JsonObject  = doc.data as JsonObject
-val key: String       = json.data("key")? as String
-val property: Boolean = json.data("property")? as Bool
-val array: JsonArray  = json.data("array")?
-val first: I64        = array.data(0)? as I64
-val second: F64       = array.data(1)? as F64
-val last: Bool        = array.data(2)? as Bool
+let json: JsonObject  = doc.data as JsonObject
+let key: String       = json.data("key")? as String
+let property: Boolean = json.data("property")? as Bool
+let array: JsonArray  = json.data("array")?
+let first: I64        = array.data(0)? as I64
+let second: F64       = array.data(1)? as F64
+let last: Bool        = array.data(2)? as Bool
 ```
+
+### Sending JSON
+
+[JsonDoc](json-JsonDoc) has the `ref` reference capability, which means it is
+not sendable by default. If you need to send it to another actor you need to
+recover it to a sendable reference capability (either `val` or `iso`). For the
+sake of simplicity it is recommended to do the parsing already in the recover
+block:
+
+```pony
+// sending an iso doc
+let json_string = """{"array":[1, true, null]}"""
+let sendable_doc: JsonDoc iso = recover iso JsonDoc.>parse(json_string)? end
+some_actor.send(consume sendable_doc)
+
+// sending a val doc
+let val_doc: JsonDoc val = recover val JsonDoc.>parse(json_string)? end
+some_actor.send_val(val_doc)
+```
+
+When sending an `iso` JsonDoc it is important to recover it to a `ref` on the
+receiving side in order to be able to properly access the json structures in
+`data`.
 
 ## Writing JSON
 

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -21,7 +21,7 @@ class JsonDoc
   var _err_msg: String = "" // ..
   var _last_index: USize = 0  // Last source index we peeked or got, for errors
 
-  new iso create() =>
+  new create() =>
     """
     Default constructor building a document containing a single null.
     """

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -11,7 +11,7 @@ class JsonArray
     The actual array containing JSON structures.
     """
 
-  new iso create(len: USize = 0) =>
+  new create(len: USize = 0) =>
     """
     Create an array with zero elements, but space for len elements.
     """
@@ -81,7 +81,7 @@ class JsonObject
     mapping `String` keys to other JSON structures.
     """
 
-  new iso create(prealloc: USize = 6) =>
+  new create(prealloc: USize = 6) =>
     """
     Create a map with space for prealloc elements without triggering a
     resize. Defaults to 6.


### PR DESCRIPTION
JsonType has not been sendable anyways as JsonObject and JsonArray have been of refcap ref in JsonType,
so this only changes JsonDoc to be non-sendable, which should only have very little effect.

My first iteration was to make JsonDoc, JsonObject and JsonArray iso but this turned out to be cumbersome to use (especially when traversing into nested structures).
The other possibility would be to make all elements of JsonType val but this also turns out to be a little limiting when constructing a JSON structure, so i went with
the least invasive way for now.

Also added some package docs.