### PR TITLE
Fix cli usage in examples

### DIFF
--- a/examples/gups_basic/main.pony
+++ b/examples/gups_basic/main.pony
@@ -10,7 +10,7 @@ class val Config
   let updater_count: USize
 
   new val create(env: Env) ? =>
-    let cs = CommandSpec.parent("gups_basic", "", [
+    let cs = CommandSpec.leaf("gups_basic", "", [
       OptionSpec.i64("table", "Log2 of the total table size." where default' = 20)
       OptionSpec.i64("iterate", "Number of iterations." where default' = 10000)
       OptionSpec.i64("chunk", "Chunk size." where default' = 1024)

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -9,7 +9,7 @@ class val Config
   let logactors: USize
 
   new val create(env: Env) ? =>
-    let cs = CommandSpec.parent("gups_opt", "", [
+    let cs = CommandSpec.leaf("gups_opt", "", [
       OptionSpec.i64("table", "Log2 of the total table size."
         where default' = 20)
       OptionSpec.i64("iterate", "Number of iterations." where default' = 10000)

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -73,7 +73,7 @@ class val Config
   let outpath: (FilePath | None)
 
   new val create(env: Env) ? =>
-    let cs = CommandSpec.parent("gups_opt",
+    let cs = CommandSpec.leaf("gups_opt",
       """
       The binary output can be converted to a PNG with the following command
       (ImageMagick Tools required):

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -186,7 +186,7 @@ actor Main
     _env = env
 
     let cs = try
-        CommandSpec.parent("yield",
+        CommandSpec.leaf("yield",
         """
         Demonstrate use of the yield behaviour when writing tail recursive
         behaviours in pony.


### PR DESCRIPTION
Although the commands specified in the examples don't have subcommands they used CommandSpec.parent,
which is meant for commands having at least 1 subcommand. Using CommandSpec.leaf fixes this issue,
as leaf is meant for single commands without subcommands. A parent CommandSpec adds a help subcommand
when calling add_help() on it and this rendered the commands unusable as a subcommand was expected.

Fixes #2314 