### PR TITLE
Fix `collections/persistent/Lists.from()` to return elements in the correct order

### DIFF
--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -60,7 +60,7 @@ class iso _TestListFrom is UnitTest
   fun name(): String => "collections/persistent/Lists (from)"
 
   fun apply(h: TestHelper) ? =>
-    let l1 = Lists[U32]([1; 2; 3])
+    let l1 = Lists[U32].from([1; 2; 3].values())
     h.assert_eq[USize](l1.size(), 3)
     h.assert_eq[U32](l1.head()?, 1)
 

--- a/packages/collections/persistent/list.pony
+++ b/packages/collections/persistent/list.pony
@@ -55,11 +55,7 @@ primitive Lists[A]
     """
     Builds a new list from an Array
     """
-    var lst = this.empty()
-    for v in arr.values() do
-      lst = lst.prepend(v)
-    end
-    lst.reverse()
+    this.from(arr.values())
 
   fun from(iter: Iterator[val->A]): List[A] =>
     """
@@ -70,7 +66,7 @@ primitive Lists[A]
     for i in iter do
       l = Cons[A](i, l)
     end
-    l
+    l.reverse()
 
   fun eq[T: Equatable[T] val = A](l1: List[T], l2: List[T]): Bool ? =>
     """


### PR DESCRIPTION
This change fixes `Lists.from()`, which returned a reversed list, and the associated test, which didn't actually call it.

The change also changes `apply()` to use `from()` so as to have a single implementation of making a list from a sequence.