### PR TITLE
RFC 56: Make buffered.reader.line return String iso^

### DIFF
--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -169,7 +169,7 @@ class Reader
     u8()?
     b
 
-  fun ref line(): String ? =>
+  fun ref line(): String iso^ ? =>
     """
     Return a \n or \r\n terminated line as a string. The newline is not
     included in the returned string, but it is removed from the network buffer.
@@ -202,7 +202,7 @@ class Reader
     out.truncate(len -
       if (len >= 2) and (out.at_offset(-2)? == '\r') then 2 else 1 end)
 
-    out
+    consume out
 
   fun ref u8(): U8 ? =>
     """

--- a/packages/net/http/_http_parser.pony
+++ b/packages/net/http/_http_parser.pony
@@ -214,7 +214,7 @@ class _HTTPParser
         else
           // A non-empty line *must* be a header. Error if not.
           try
-            _process_header(line)?
+            _process_header(consume line)?
           else
             _state = _ExpectError
             break

--- a/packages/net/http/_test.pony
+++ b/packages/net/http/_test.pony
@@ -521,10 +521,11 @@ primitive _FixedResponseHTTPServerNotify
               reader.append(consume data)
               while true do
                 var blank = false
-                try 
+                try
                   let l = reader.line()?
-                  h.log("received line: " + l)
-                  if l.size() == 0 then
+                  let l_size = l.size()
+                  h.log("received line: " + consume l)
+                  if l_size == 0 then
                     // Write the response.
                     nr = nr + 1
                     for r in response.values() do

--- a/packages/term/readline.pony
+++ b/packages/term/readline.pony
@@ -384,7 +384,7 @@ class Readline is ANSINotify
     try
       with file = File.open(_path as FilePath) do
         for line in file.lines() do
-          _add_history(line)
+          _add_history(consume line)
         end
       end
     end


### PR DESCRIPTION
This implements [RFC 56](https://github.com/ponylang/rfcs/blob/master/text/0056-buffered-reader-line-iso.md) and fixes #2755 

This is a breaking change for code bases that do not use explicit types when assigning the returned `String iso^` to a variable:

```pony
let line = reader.line()?
```

These code bases need to either add an explicit type to their variable (`let line: String val = reader.line()?`) or need to `consume` the line upon aliasing or giving away to another function/behaviour.