### PR TITLE
Fix compiler segfault caused by dead code removal of tupled variables

### DIFF
--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -215,6 +215,11 @@ LLVMValueRef gen_tuple(compile_t* c, ast_t* ast)
       ponyint_pool_free_size(buf_size, elements);
       return GEN_NOVALUE;
     }
+    else if(value == GEN_NOTNEEDED)
+    {
+      ponyint_pool_free_size(buf_size, elements);
+      return GEN_NOTNEEDED;
+    }
 
     ast_t* child_type = deferred_reify(reify, ast_type(child), c->opt);
     value = gen_assign_cast(c, elements[i], value, child_type);

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -614,6 +614,19 @@ TEST_F(CodegenTest, VariableDeclNestedTuple)
   TEST_COMPILE(src);
 }
 
+TEST_F(CodegenTest, TupleRemoveUnreachableBlock)
+{
+  // From issue #2735
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    if true then\n"
+    "      (let f, let g) = (U8(2), U8(3))\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(CodegenTest, RedundantUnionInForLoopIteratorValueType)
 {
   // From issue #2736


### PR DESCRIPTION
Insight for fix came from Sylvan.

Closes #2735