### PR TITLE
Fix incorrect tuple handling

### DIFF
--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -279,7 +279,7 @@ LLVMValueRef gen_localdecl(compile_t* c, ast_t* ast)
 
   // Put the builder back where it was.
   LLVMPositionBuilderAtEnd(c->builder, this_block);
-  return GEN_NOVALUE;
+  return GEN_NOTNEEDED;
 }
 
 LLVMValueRef gen_localptr(compile_t* c, ast_t* ast)

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -614,6 +614,20 @@ TEST_F(CodegenTest, VariableDeclNestedTuple)
   TEST_COMPILE(src);
 }
 
+TEST_F(CodegenTest, TupleRemoveUnreachableBlockInLoop)
+{
+  // From issue #2760
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    var token = U8(1)\n"
+    "    repeat\n"
+    "      (token, let source) = (U8(1), U8(2))\n"
+    "    until token == 2 end";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(CodegenTest, TupleRemoveUnreachableBlock)
 {
   // From issue #2735


### PR DESCRIPTION
I don't know the compiler well and I went off what I knew and believe I
found the root cause for our tuple bugs that started with 9222f08. Which
was in turn fixing https://github.com/ponylang/ponyc/issues/2735.

However, a number of bugs came from that fix because, it didn't fix the
root issue. Which was `gen_localdecl` returning GEN_NOVALUE where
GEN_NOTNEEDED was needed. This is why, prior to 9222f08, `gen_tuple` was
returning GEN_NOTNEEDED when the value it has was GEN_NOVALUE.

Fixes #2760