### PR TITLE
Refactor gen_tuple

### DIFF
--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -210,15 +210,10 @@ LLVMValueRef gen_tuple(compile_t* c, ast_t* ast)
     // We'll have an undefined element if one of our source elements is a
     // variable declaration. This is ok, since the tuple value will never be
     // used.
-    if(value == GEN_NOVALUE)
+    if(value == GEN_NOVALUE || value == GEN_NOTNEEDED)
     {
       ponyint_pool_free_size(buf_size, elements);
-      return GEN_NOVALUE;
-    }
-    else if(value == GEN_NOTNEEDED)
-    {
-      ponyint_pool_free_size(buf_size, elements);
-      return GEN_NOTNEEDED;
+      return value;
     }
 
     ast_t* child_type = deferred_reify(reify, ast_type(child), c->opt);


### PR DESCRIPTION
I recently added code to gen_tuple to fix a bug. That fix while
technically correct, added a bit of code duplication. I don't mind code
duplication, but unneeded duplication around freeing resources does tend
to bother me. It's usually an easy way to eventually end up not freeing
something.

This commit changes the code I added to gen_tuple to remove the
duplication.