### PR TITLE
Fix GC-safety issue with writev pointers in File.

### DIFF
--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -96,7 +96,7 @@ class File
   var _fd: I32
   var _last_line_length: USize = 256
   var _errno: FileErrNo = FileOK
-  embed _pending_writev: Array[USize] = _pending_writev.create()
+  embed _pending_writev: Array[(Pointer[U8] tag, USize)] = _pending_writev.create()
   var _pending_writev_total: USize = 0
 
   new create(from: FilePath) =>
@@ -401,7 +401,7 @@ class File
     NOTE: Queue'd data will always be written before normal print/write
     requested data
     """
-    _pending_writev .> push(data.cpointer().usize()) .> push(data.size())
+    _pending_writev .> push((data.cpointer(), data.size()))
     _pending_writev_total = _pending_writev_total + data.size()
 
   fun ref queuev(data: ByteSeqIter box) =>
@@ -443,7 +443,6 @@ class File
         end
         for d in Range[USize](0, num_written, 1) do
           _pending_writev.shift()?
-          _pending_writev.shift()?
         end
       end
       return result
@@ -478,7 +477,7 @@ class File
     let writev_batch_size = @pony_os_writev_max()
     while pending_total > 0 do
       // Determine the number of bytes and buffers to send.
-      num_to_send = (_pending_writev.size().i32() / 2) - num_sent.i32()
+      num_to_send = _pending_writev.size().i32() - num_sent.i32()
       if num_to_send <= writev_batch_size then
         bytes_to_send = pending_total
       else
@@ -486,20 +485,20 @@ class File
         // We must iterate over the buffers being sent to add up to the total.
         num_to_send = writev_batch_size
         bytes_to_send = 0
-        var counter: I32 = (num_sent.i32() * 2) + 1
+        var counter: I32 = num_sent.i32()
         repeat
-          bytes_to_send = bytes_to_send + _pending_writev(counter.usize())?
-          counter = counter + 2
-        until counter >= (num_to_send * 2) end
+          bytes_to_send = bytes_to_send + _pending_writev(counter.usize())?._2
+          counter = counter + 1
+        until counter >= num_to_send end
       end
 
       // Write as much data as possible (vectored i/o).
       // On Windows only write 1 buffer at a time.
       var len = ifdef windows then
-        @_write(_fd, _pending_writev(num_sent * 2)?,
+        @_write(_fd, _pending_writev(num_sent)?._1,
           bytes_to_send.i32()).isize()
       else
-        @writev(_fd, _pending_writev.cpointer(num_sent * 2),
+        @writev(_fd, _pending_writev.cpointer(num_sent),
           num_to_send).isize()
       end
 


### PR DESCRIPTION
Prior to this commit, there was a garbage-collection safety issue
with the way that the `_pending_writev` array worked in the `File`
class. The pending writev data was being stored in a flat array
with element type of `USize`, with the byte pointers being converted
to type `USize` in order to be stored alongside the buffer length
numbers in the same array.

Storing these pointers as numbers meant that they are no longer
traced by the garbage as being pointers, meaning that the garbage
collector would try to free the underlying memory due to no longer
being pointed to by any valid pointer.

This PR fixes the issue by using an `Array[(Pointer[U8], USize)]`
instead of an `Array[USize]`. This also eliminates some complexity
in the code that was related to accessing the array data in blocks
of 2 elements per logical element.

This resolves part of https://github.com/ponylang/ponyc/issues/2526.
We could resolve the issue entirely by doing the same fix for
TCPConnection, though that may have some addiitonal complexity from
needing to be compatible with IOCP on windows.