### PR TITLE
ponytest/test_helper: fix link, line width

### DIFF
--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -23,9 +23,9 @@ class val TestHelper
     """
     The process environment.
 
-    This is useful for getting the [root authority](builtin-AmbienAuth) in order to access
-    the filesystem (See [files](files--index)) or the network (See [net](net--index))
-    in your tests.
+    This is useful for getting the [root authority](builtin-AmbientAuth) in
+    order to access the filesystem (See [files](files--index)) or the network
+    (See [net](net--index)) in your tests.
     """
 
   new val _create(runner: _TestRunner, env': Env) =>


### PR DESCRIPTION
ℹ️ This was missing a `t` in `AmbienAuth`.