### PR TITLE
 Fix incorrect disposable/destroyed epoll resubscribe handling

### DIFF
--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -274,7 +274,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
       if(flags != 0)
       {
-        if (!(flags & ASIO_DESTROYED) || !(flags & ASIO_DISPOSABLE))
+        if (!(flags & ASIO_DESTROYED) && !(flags & ASIO_DISPOSABLE))
         {
           if(ev->auto_resub && !(flags & ASIO_WRITE))
             pony_asio_event_resubscribe_write(ev);


### PR DESCRIPTION
 Correctly this time as I messed up the boolean logic in
 8b21f0a519fafdefef4ebdc7ed86cb629c572c2e.

 Closes #2684

 See for initial incorrect PR

 https://github.com/ponylang/ponyc/pull/2744