### PR TITLE
Fix missing break in refer_seq

### DIFF
--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -935,6 +935,7 @@ static bool refer_seq(pass_opt_t* opt, ast_t* ast)
           ast_consolidate_branches(then_clause, 2);
         }
       }
+      break;
 
       case TK_REPEAT:
       {
@@ -951,6 +952,7 @@ static bool refer_seq(pass_opt_t* opt, ast_t* ast)
           ast_consolidate_branches(else_clause, 2);
         }
       }
+      break;
 
       default: {}
     }


### PR DESCRIPTION
Commit 9eb1687e introduced a bug in the symbol status forward
propagation where breaks are missing between the different
switch cases, causing the TRY case to fall through into the
REPEAT case.