### PR TITLE
Correctly allocate memory for linker arguments

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -277,11 +277,11 @@ static bool link_exe(compile_t* c, ast_t* program,
   const char* lib_args = program_lib_args(program);
 
   size_t arch_len = arch - c->opt->triple;
-  size_t ld_len = 128 + arch_len + strlen(file_exe) + strlen(file_o) +
-    strlen(lib_args);
+  const char* linker = c->opt->linker != NULL ? c->opt->linker : "ld";
+  size_t ld_len = 128 + arch_len + strlen(linker) + strlen(file_exe) +
+    strlen(file_o) + strlen(lib_args);
+
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
-  const char* linker = c->opt->linker != NULL ? c->opt->linker
-                                              : "ld";
 
   snprintf(ld_cmd, ld_len,
     "%s -execute -no_pie -arch %.*s "


### PR DESCRIPTION
This was original brought up by @saolsen in PR #2694. This is a cleaned
up version of that PR based on feedback from @jemc.