### PR TITLE
Escape quotes " in JSON package documentation.

### DIFF
--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -57,7 +57,7 @@ block:
 
 ```pony
 // sending an iso doc
-let json_string = """{"array":[1, true, null]}"""
+let json_string = \"\"\"{"array":[1, true, null]}\"\"\"
 let sendable_doc: JsonDoc iso = recover iso JsonDoc.>parse(json_string)? end
 some_actor.send(consume sendable_doc)
 


### PR DESCRIPTION
The """ ... """ cases the following error:

> Error:
> /home/stewart/opt/pony/bleed/packages/json/json.pony:60:22: syntax
> error: expected type, interface, trait, primitive, class, actor, member
> or method after # JSON Package