### PR TITLE
Make cycle detector block checking incremental

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -744,7 +744,7 @@ static pony_actor_t* steal(scheduler_t* sched)
     }
 
     // if we're scheduler 0 and cycle detection is enabled
-    if((sched->index == 0) && !ponyint_actor_getnoblock())
+    if(!ponyint_actor_getnoblock() && (sched->index == 0))
     {
       // trigger cycle detector by sending it a message if it is time
       uint64_t current_tsc = ponyint_cpu_tick();
@@ -786,7 +786,7 @@ static void run(scheduler_t* sched)
   while(true)
   {
     // if we're scheduler 0 and cycle detection is enabled
-    if((sched->index == 0) && !ponyint_actor_getnoblock())
+    if(!ponyint_actor_getnoblock() && (sched->index == 0))
     {
       // trigger cycle detector by sending it a message if it is time
       uint64_t current_tsc = ponyint_cpu_tick();


### PR DESCRIPTION
In PR #2709, @sylvanc pointed out a concern regarding the cycle
detector creating a message storm due to how it would ask all
actors whether they are blocked or not on every interval.

This commit changes the logic so that the cycle detector only
asks set number of actors whether they are blocked or not. If
it is not able to ask all actors, it will resume iterating actors
on the next iteration.

This commit also addresses @SeanTAllen's concern regarding the
conditional check order using `ponyint_actor_getnoblock`.