### PR TITLE
Add llvm_config_{begin|end}.h

### DIFF
--- a/src/common/llvm_config_begin.h
+++ b/src/common/llvm_config_begin.h
@@ -1,0 +1,26 @@
+/**
+ * Include this before including any llvm headers
+ * And then include llvm_config_end.h after those
+ * headers.
+ */
+
+#ifndef LLVM_CONFIG_BEGIN_H
+#define LLVM_CONFIG_BEGIN_H
+
+#ifdef _MSC_VER
+#  pragma warning(push)
+
+//because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
+#  pragma warning(disable:4244)
+#  pragma warning(disable:4800)
+#  pragma warning(disable:4267)
+#  pragma warning(disable:4624)
+#  pragma warning(disable:4141)
+#  pragma warning(disable:4291)
+#  pragma warning(disable:4146)
+
+// LLVM claims DEBUG as a macro name. Conflicts with MSVC headers.
+#  pragma warning(disable:4005)
+#endif
+
+#endif

--- a/src/common/llvm_config_end.h
+++ b/src/common/llvm_config_end.h
@@ -1,0 +1,11 @@
+/**
+ * Used to undo any changes llvm_config_begin.h has done
+ */
+#ifndef LLVM_CONFIG_END_H
+#define LLVM_CONFIG_END_H
+
+#ifdef _MSC_VER
+#  pragma warning(pop)
+#endif
+
+#endif

--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -1,21 +1,14 @@
 #include "codegen.h"
 #include "gendebug.h"
 
-#ifdef _MSC_VER
-#  pragma warning(push)
-//because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4800)
-#  pragma warning(disable:4267)
-#  pragma warning(disable:4624)
-#  pragma warning(disable:4141)
-#  pragma warning(disable:4146)
-#endif
+#include "llvm_config_begin.h"
 
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/Path.h>
+
+#include "llvm_config_end.h"
 
 #define DW_TAG_auto_variable 0x100
 #define DW_TAG_arg_variable 0x101

--- a/src/libponyc/codegen/genjit.cc
+++ b/src/libponyc/codegen/genjit.cc
@@ -2,17 +2,7 @@
 #include "genexe.h"
 #include "genopt.h"
 
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4800)
-#  pragma warning(disable:4267)
-#  pragma warning(disable:4624)
-#  pragma warning(disable:4141)
-#  pragma warning(disable:4291)
-#  pragma warning(disable:4146)
-#  pragma warning(disable:4005)
-#endif
+#include "llvm_config_begin.h"
 
 #include <llvm/IR/Mangler.h>
 #include <llvm/IR/Module.h>
@@ -26,9 +16,7 @@
 #endif
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
+#include "llvm_config_end.h"
 
 namespace orc = llvm::orc;
 

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1,18 +1,7 @@
-#ifdef _MSC_VER
-#  pragma warning(push)
-// because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4800)
-#  pragma warning(disable:4267)
-#  pragma warning(disable:4624)
-#  pragma warning(disable:4141)
-#  pragma warning(disable:4146)
-// LLVM claims DEBUG as a macro name. Conflicts with MSVC headers.
-#  pragma warning(disable:4005)
-#endif
-
 #include "genopt.h"
 #include <string.h>
+
+#include "llvm_config_begin.h"
 
 #include <llvm/IR/Module.h>
 #include <llvm/IR/CallSite.h>
@@ -39,9 +28,7 @@
 #include "../../libponyrt/mem/heap.h"
 #include "ponyassert.h"
 
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
+#include "llvm_config_end.h"
 
 using namespace llvm;
 using namespace llvm::legacy;

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -1,14 +1,4 @@
-#ifdef _MSC_VER
-#  pragma warning(push)
-//because LLVM IR Builder code is broken: e.g. Instructions.h:521-527
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4800)
-#  pragma warning(disable:4267)
-#  pragma warning(disable:4624)
-#  pragma warning(disable:4141)
-#  pragma warning(disable:4291)
-#  pragma warning(disable:4146)
-#endif
+#include "llvm_config_begin.h"
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Function.h>
@@ -21,9 +11,7 @@
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/Target/TargetOptions.h>
 
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
+#include "llvm_config_end.h"
 
 #include <stdio.h>
 #include "codegen.h"

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -6,24 +6,12 @@
 
 #include "util.h"
 
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4800)
-#  pragma warning(disable:4267)
-#  pragma warning(disable:4624)
-#  pragma warning(disable:4141)
-#  pragma warning(disable:4146)
-#  pragma warning(disable:4005)
-#endif
+#include "llvm_config_begin.h"
 
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
 
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
-
+#include "llvm_config_end.h"
 
 #define TEST_COMPILE(src) DO(test_compile(src, "ir"))
 


### PR DESCRIPTION
Consolidate the special handling of including llvm headers into
llvm_config_begin.h and llvm_config.end.

Fix issue #2802