### PR TITLE
Document Array.contains's default predicate

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -510,6 +510,9 @@ class Array[A] is Seq[A]
   =>
     """
     Returns true if the array contains `value`, false otherwise.
+
+    The default predicate checks for matches by identity. To search for matches
+    by structural equality, pass an object literal such as `{(l, r) => l == r}`.
     """
     var i = USize(0)
 


### PR DESCRIPTION
Fix #2759 

I added a few lines to the docstring for `Array.contains`, and provided an alternative predicate function object for matching by structural identity.