### PR TITLE
Add _TestBroadcast.timed_out()

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -134,6 +134,13 @@ class iso _TestBroadcast is UnitTest
 
     h.long_test(2_000_000_000) // 2 second timeout
 
+  fun ref timed_out(h: TestHelper) =>
+    h.log("""
+      This test may fail if you have a firewall (such as firewalld) running.
+      If it does, try re-running the tests with the firewall de-activated, or
+      exclude this test by passing the --exclude="net/Broadcast" option.
+    """)
+
 class _TestTCP is TCPListenNotify
   """
   Run a typical TCP test consisting of a single TCPListener that accepts a


### PR DESCRIPTION
Fix  #1942.

This method will log a message explaining why the test might fail and give instructions on how to re-run the test suite with that test excluded.

I did my best to stick to the plan set out by @SeanTAllen [here](https://github.com/ponylang/ponyc/issues/1942#issuecomment-316504382), but I did not fulfill point 2, as the test already has a label. Instead, the log message explains how to use `--exclude` to run the rest of the test suite.