### PR TITLE
Non-x86_64 CI via cross compiling and qemu

### DIFF
--- a/.ci-dockerfiles/cross-llvm-3.9.1-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-aarch64/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-3.9.1
+
+ARG CROSS_TRIPLE=aarch64-unknown-linux-gnu
+ARG CROSS_CC=aarch64-linux-gnu-gcc
+ARG CROSS_CXX=aarch64-linux-gnu-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=64
+ARG CROSS_LINKER=aarch64-linux-gnu-gcc
+ARG CROSS_TUNE=cortex-a53
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/aarch64-linux-gnu/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz -C /usr/local --strip 1 \
+ && aarch64-linux-gnu-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static -O /usr/bin/qemu-aarch64-static \
+ && chmod +x /usr/bin/qemu-aarch64-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-3.9.1-aarch64/README.md
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-aarch64/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-3.9.1-aarch64 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-391-aarch64 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-3.9.1-aarch64 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-391-aarch64-debug
+circleci build --job cross-llvm-391-aarch64-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-3.9.1-aarch64
+```

--- a/.ci-dockerfiles/cross-llvm-3.9.1-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-arm/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-3.9.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabi
+ARG CROSS_CC=arm-linux-gnueabi-gcc
+ARG CROSS_CXX=arm-linux-gnueabi-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabi-gcc
+ARG CROSS_TUNE=cortex-a9
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabi/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabi-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-3.9.1-arm/README.md
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-arm/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-3.9.1-arm .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-391-arm --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-3.9.1-arm bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-391-arm-debug
+circleci build --job cross-llvm-391-arm-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-3.9.1-arm
+```

--- a/.ci-dockerfiles/cross-llvm-3.9.1-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-armhf/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-3.9.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabihf
+ARG CROSS_CC=arm-linux-gnueabihf-gcc
+ARG CROSS_CXX=arm-linux-gnueabihf-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabihf-gcc
+ARG CROSS_TUNE=cortex-a7
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabihf/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabihf-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-3.9.1-armhf/README.md
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-armhf/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-3.9.1-armhf .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-391-armhf --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-3.9.1-armhf bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-391-armhf-debug
+circleci build --job cross-llvm-391-armhf-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-3.9.1-armhf
+```

--- a/.ci-dockerfiles/cross-llvm-3.9.1-i686/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-i686/Dockerfile
@@ -1,0 +1,50 @@
+FROM ponylang/ponyc-ci:llvm-3.9.1
+
+ARG CROSS_TRIPLE=i686-unknown-linux-gnu
+ARG CROSS_CC=gcc-6
+ARG CROSS_CXX=g++-6
+ARG CROSS_CFLAGS=-m32
+ARG CROSS_CXXFLAGS=-m32
+ARG CROSS_LDFLAGS=-m32
+ARG CROSS_BITS=32
+ARG CROSS_LINKER='gcc-6 -m32'
+ARG CROSS_TUNE=generic
+
+USER root
+
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y \
+  libc6:i386 \
+  libc6-dev:i386 \
+  linux-libc-dev:i386 \
+  zlib1g:i386 \
+  zlib1g-dev:i386 \
+  g++-6 \
+  g++-6-multilib \
+  gcc-6-multilib \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5* \
+# cleanup
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-3.9.1-i686/README.md
+++ b/.ci-dockerfiles/cross-llvm-3.9.1-i686/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-3.9.1-i686 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-391-i686 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-3.9.1-i686 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-391-i686-debug
+circleci build --job cross-llvm-391-i686-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-3.9.1-i686
+```

--- a/.ci-dockerfiles/cross-llvm-4.0.1-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-aarch64/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-4.0.1
+
+ARG CROSS_TRIPLE=aarch64-unknown-linux-gnu
+ARG CROSS_CC=aarch64-linux-gnu-gcc
+ARG CROSS_CXX=aarch64-linux-gnu-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=64
+ARG CROSS_LINKER=aarch64-linux-gnu-gcc
+ARG CROSS_TUNE=cortex-a53
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/aarch64-linux-gnu/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz -C /usr/local --strip 1 \
+ && aarch64-linux-gnu-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static -O /usr/bin/qemu-aarch64-static \
+ && chmod +x /usr/bin/qemu-aarch64-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-4.0.1-aarch64/README.md
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-aarch64/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-4.0.1-aarch64 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-401-aarch64 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-4.0.1-aarch64 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-401-aarch64-debug
+circleci build --job cross-llvm-401-aarch64-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-4.0.1-aarch64
+```

--- a/.ci-dockerfiles/cross-llvm-4.0.1-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-arm/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-4.0.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabi
+ARG CROSS_CC=arm-linux-gnueabi-gcc
+ARG CROSS_CXX=arm-linux-gnueabi-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabi-gcc
+ARG CROSS_TUNE=cortex-a9
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabi/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabi-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-4.0.1-arm/README.md
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-arm/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-4.0.1-arm .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-401-arm --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-4.0.1-arm bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-401-arm-debug
+circleci build --job cross-llvm-401-arm-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-4.0.1-arm
+```

--- a/.ci-dockerfiles/cross-llvm-4.0.1-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-armhf/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-4.0.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabihf
+ARG CROSS_CC=arm-linux-gnueabihf-gcc
+ARG CROSS_CXX=arm-linux-gnueabihf-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabihf-gcc
+ARG CROSS_TUNE=cortex-a7
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabihf/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabihf-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-4.0.1-armhf/README.md
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-armhf/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-4.0.1-armhf .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-401-armhf --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-4.0.1-armhf bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-401-armhf-debug
+circleci build --job cross-llvm-401-armhf-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-4.0.1-armhf
+```

--- a/.ci-dockerfiles/cross-llvm-4.0.1-i686/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-i686/Dockerfile
@@ -1,0 +1,50 @@
+FROM ponylang/ponyc-ci:llvm-4.0.1
+
+ARG CROSS_TRIPLE=i686-unknown-linux-gnu
+ARG CROSS_CC=gcc-6
+ARG CROSS_CXX=g++-6
+ARG CROSS_CFLAGS=-m32
+ARG CROSS_CXXFLAGS=-m32
+ARG CROSS_LDFLAGS=-m32
+ARG CROSS_BITS=32
+ARG CROSS_LINKER='gcc-6 -m32'
+ARG CROSS_TUNE=generic
+
+USER root
+
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y \
+  libc6:i386 \
+  libc6-dev:i386 \
+  linux-libc-dev:i386 \
+  zlib1g:i386 \
+  zlib1g-dev:i386 \
+  g++-6 \
+  g++-6-multilib \
+  gcc-6-multilib \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5* \
+# cleanup
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-4.0.1-i686/README.md
+++ b/.ci-dockerfiles/cross-llvm-4.0.1-i686/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-4.0.1-i686 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-401-i686 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-4.0.1-i686 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-401-i686-debug
+circleci build --job cross-llvm-401-i686-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-4.0.1-i686
+```

--- a/.ci-dockerfiles/cross-llvm-5.0.1-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-aarch64/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-5.0.1
+
+ARG CROSS_TRIPLE=aarch64-unknown-linux-gnu
+ARG CROSS_CC=aarch64-linux-gnu-gcc
+ARG CROSS_CXX=aarch64-linux-gnu-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=64
+ARG CROSS_LINKER=aarch64-linux-gnu-gcc
+ARG CROSS_TUNE=cortex-a53
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/aarch64-linux-gnu/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz -C /usr/local --strip 1 \
+ && aarch64-linux-gnu-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static -O /usr/bin/qemu-aarch64-static \
+ && chmod +x /usr/bin/qemu-aarch64-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-5.0.1-aarch64/README.md
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-aarch64/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-5.0.1-aarch64 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-501-aarch64 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-5.0.1-aarch64 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-501-aarch64-debug
+circleci build --job cross-llvm-501-aarch64-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-5.0.1-aarch64
+```

--- a/.ci-dockerfiles/cross-llvm-5.0.1-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-arm/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-5.0.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabi
+ARG CROSS_CC=arm-linux-gnueabi-gcc
+ARG CROSS_CXX=arm-linux-gnueabi-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabi-gcc
+ARG CROSS_TUNE=cortex-a9
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabi/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabi-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-5.0.1-arm/README.md
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-arm/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-5.0.1-arm .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-501-arm --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-5.0.1-arm bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-501-arm-debug
+circleci build --job cross-llvm-501-arm-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-5.0.1-arm
+```

--- a/.ci-dockerfiles/cross-llvm-5.0.1-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-armhf/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-5.0.1
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabihf
+ARG CROSS_CC=arm-linux-gnueabihf-gcc
+ARG CROSS_CXX=arm-linux-gnueabihf-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabihf-gcc
+ARG CROSS_TUNE=cortex-a7
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabihf/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabihf-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-5.0.1-armhf/README.md
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-armhf/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-5.0.1-armhf .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-501-armhf --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-5.0.1-armhf bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-501-armhf-debug
+circleci build --job cross-llvm-501-armhf-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-5.0.1-armhf
+```

--- a/.ci-dockerfiles/cross-llvm-5.0.1-i686/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-i686/Dockerfile
@@ -1,0 +1,50 @@
+FROM ponylang/ponyc-ci:llvm-5.0.1
+
+ARG CROSS_TRIPLE=i686-unknown-linux-gnu
+ARG CROSS_CC=gcc-6
+ARG CROSS_CXX=g++-6
+ARG CROSS_CFLAGS=-m32
+ARG CROSS_CXXFLAGS=-m32
+ARG CROSS_LDFLAGS=-m32
+ARG CROSS_BITS=32
+ARG CROSS_LINKER='gcc-6 -m32'
+ARG CROSS_TUNE=generic
+
+USER root
+
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y \
+  libc6:i386 \
+  libc6-dev:i386 \
+  linux-libc-dev:i386 \
+  zlib1g:i386 \
+  zlib1g-dev:i386 \
+  g++-6 \
+  g++-6-multilib \
+  gcc-6-multilib \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5* \
+# cleanup
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-5.0.1-i686/README.md
+++ b/.ci-dockerfiles/cross-llvm-5.0.1-i686/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-5.0.1-i686 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-501-i686 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-5.0.1-i686 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-501-i686-debug
+circleci build --job cross-llvm-501-i686-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-5.0.1-i686
+```

--- a/.ci-dockerfiles/cross-llvm-6.0.0-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-aarch64/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-6.0.0
+
+ARG CROSS_TRIPLE=aarch64-unknown-linux-gnu
+ARG CROSS_CC=aarch64-linux-gnu-gcc
+ARG CROSS_CXX=aarch64-linux-gnu-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=64
+ARG CROSS_LINKER=aarch64-linux-gnu-gcc
+ARG CROSS_TUNE=cortex-a53
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/aarch64-linux-gnu/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz -C /usr/local --strip 1 \
+ && aarch64-linux-gnu-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static -O /usr/bin/qemu-aarch64-static \
+ && chmod +x /usr/bin/qemu-aarch64-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-6.0.0-aarch64/README.md
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-aarch64/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-6.0.0-aarch64 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-600-aarch64 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-6.0.0-aarch64 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-600-aarch64-debug
+circleci build --job cross-llvm-600-aarch64-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-6.0.0-aarch64
+```

--- a/.ci-dockerfiles/cross-llvm-6.0.0-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-arm/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-6.0.0
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabi
+ARG CROSS_CC=arm-linux-gnueabi-gcc
+ARG CROSS_CXX=arm-linux-gnueabi-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabi-gcc
+ARG CROSS_TUNE=cortex-a9
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabi/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabi-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-6.0.0-arm/README.md
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-arm/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-6.0.0-arm .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-600-arm --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-6.0.0-arm bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-600-arm-debug
+circleci build --job cross-llvm-600-arm-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-6.0.0-arm
+```

--- a/.ci-dockerfiles/cross-llvm-6.0.0-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-armhf/Dockerfile
@@ -1,0 +1,44 @@
+FROM ponylang/ponyc-ci:llvm-6.0.0
+
+ARG CROSS_TRIPLE=arm-unknown-linux-gnueabihf
+ARG CROSS_CC=arm-linux-gnueabihf-gcc
+ARG CROSS_CXX=arm-linux-gnueabihf-g++
+ARG CROSS_CFLAGS=
+ARG CROSS_CXXFLAGS=
+ARG CROSS_LDFLAGS=
+ARG CROSS_BITS=32
+ARG CROSS_LINKER=arm-linux-gnueabihf-gcc
+ARG CROSS_TUNE=cortex-a7
+
+ARG QEMU_VERSION=2.12.0
+ARG COMPILER_RELEASE=2018.05
+
+USER root
+
+RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPILER_RELEASE}/arm-linux-gnueabihf/gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz" \
+ && tar xJvf gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz -C /usr/local --strip 1 \
+ && arm-linux-gnueabihf-gcc --version \
+ && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz \
+ && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
+ && chmod +x /usr/bin/qemu-arm-static \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-6.0.0-armhf/README.md
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-armhf/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-6.0.0-armhf .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-600-armhf --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-6.0.0-armhf bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-600-armhf-debug
+circleci build --job cross-llvm-600-armhf-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-6.0.0-armhf
+```

--- a/.ci-dockerfiles/cross-llvm-6.0.0-i686/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-i686/Dockerfile
@@ -1,0 +1,50 @@
+FROM ponylang/ponyc-ci:llvm-6.0.0
+
+ARG CROSS_TRIPLE=i686-unknown-linux-gnu
+ARG CROSS_CC=gcc-6
+ARG CROSS_CXX=g++-6
+ARG CROSS_CFLAGS=-m32
+ARG CROSS_CXXFLAGS=-m32
+ARG CROSS_LDFLAGS=-m32
+ARG CROSS_BITS=32
+ARG CROSS_LINKER='gcc-6 -m32'
+ARG CROSS_TUNE=generic
+
+USER root
+
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y \
+  libc6:i386 \
+  libc6-dev:i386 \
+  linux-libc-dev:i386 \
+  zlib1g:i386 \
+  zlib1g-dev:i386 \
+  g++-6 \
+  g++-6-multilib \
+  gcc-6-multilib \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr/cross --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# install libressl
+ && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
+ && tar -xzvf libressl-2.4.5.tar.gz \
+ && cd libressl-2.4.5 \
+ && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
+ && make \
+ && make install \
+ && cd .. \
+ && rm -rf libressl-2.4.5* \
+# cleanup
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-6.0.0-i686/README.md
+++ b/.ci-dockerfiles/cross-llvm-6.0.0-i686/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:cross-llvm-6.0.0-i686 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-cross-llvm-600-i686 --user pony --rm -i -t ponylang/ponyc-ci:cross-llvm-6.0.0-i686 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job cross-llvm-600-i686-debug
+circleci build --job cross-llvm-600-i686-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:cross-llvm-6.0.0-i686
+```

--- a/.ci-dockerfiles/llvm-3.9.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-3.9.1/Dockerfile
@@ -1,35 +1,11 @@
-FROM ubuntu:14.04
+FROM ponylang/ponyc-ci:ubuntu-14.04-base
 
 ENV LLVM_VERSION 3.9.1
 
-RUN apt-get update \
- && apt-get install -y software-properties-common \
- && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
- && apt-get update \
- && apt-get install -y \
-  apt-transport-https \
-  build-essential \
-  g++-6 \
-  git \
-  libncurses5-dev \
-  libssl-dev \
-  make \
-  wget \
-  xz-utils \
-  zlib1g-dev \
- && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
+USER root
+
+RUN wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
 
-# install pcre2
-RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
- && tar xvf pcre2-10.21.tar.bz2 \
- && cd pcre2-10.21 \
- && ./configure --prefix=/usr \
- && make install \
- && cd .. \
- && rm -rf pcre2-10.21*
-
-# add user pony in order to not run tests as root
-RUN useradd -ms /bin/bash -d /home/pony -g root pony
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/llvm-4.0.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-4.0.1/Dockerfile
@@ -1,35 +1,11 @@
-FROM ubuntu:14.04
+FROM ponylang/ponyc-ci:ubuntu-14.04-base
 
 ENV LLVM_VERSION 4.0.1
 
-RUN apt-get update \
- && apt-get install -y software-properties-common \
- && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
- && apt-get update \
- && apt-get install -y \
-  apt-transport-https \
-  build-essential \
-  g++-6 \
-  git \
-  libncurses5-dev \
-  libssl-dev \
-  make \
-  wget \
-  xz-utils \
-  zlib1g-dev \
- && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
+USER root
+
+RUN wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
  | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
 
-# install pcre2
-RUN wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
- && tar xvf pcre2-10.21.tar.bz2 \
- && cd pcre2-10.21 \
- && ./configure --prefix=/usr \
- && make install \
- && cd .. \
- && rm -rf pcre2-10.21*
-
-# add user pony in order to not run tests as root
-RUN useradd -ms /bin/bash -d /home/pony -g root pony
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/llvm-5.0.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-5.0.1/Dockerfile
@@ -1,23 +1,11 @@
-FROM ubuntu:16.04
+FROM ponylang/ponyc-ci:ubuntu-14.04-base
 
 ENV LLVM_VERSION 5.0.1
 
-RUN apt-get update \
- && apt-get install -y \
-  apt-transport-https \
-  g++ \
-  git \
-  libncurses5-dev \
-  libpcre2-dev \
-  libssl-dev \
-  make \
-  wget \
-  xz-utils \
-  zlib1g-dev \
- && wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
- | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04
+USER root
 
-# add user pony in order to not run tests as root
-RUN useradd -ms /bin/bash -d /home/pony -g root pony
+RUN wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
+ | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
+
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/llvm-6.0.0/Dockerfile
+++ b/.ci-dockerfiles/llvm-6.0.0/Dockerfile
@@ -1,32 +1,11 @@
-FROM ubuntu:14.04
+FROM ponylang/ponyc-ci:ubuntu-14.04-base
 
 ENV LLVM_VERSION 6.0.0
 
-RUN apt-get update \
- && apt-get install -y \
-  apt-transport-https \
-  build-essential \
-  g++ \
-  git \
-  libncurses5-dev \
-  libssl-dev \
-  make \
-  wget \
-  xz-utils \
-  zlib1g-dev \
- && cd /tmp \
- && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
- && tar xjvf pcre2-10.21.tar.bz2 \
- && cd pcre2-10.21 \
- && ./configure --prefix=/usr \
- && make \
- && sudo make install \
- && cd / \
- && rm -rf /tmp/pcre* \
- && wget -O - http://releases.llvm.org/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04.tar.xz \
- | tar xJf - --no-same-owner --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-14.04
+USER root
 
-# add user pony in order to not run tests as root
-RUN useradd -ms /bin/bash -d /home/pony -g root pony
+RUN wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8.tar.xz \
+ | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-debian8
+
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu-14.04-base/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-14.04-base/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:14.04
+
+RUN apt-get update \
+ && apt-get install -y software-properties-common \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  build-essential \
+  g++-6 \
+  git \
+  libncurses5-dev \
+  libssl-dev \
+  make \
+  wget \
+  xz-utils \
+  zlib1g-dev \
+# install pcre2
+ && wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2 \
+ && tar xvf pcre2-10.21.tar.bz2 \
+ && cd pcre2-10.21 \
+ && ./configure --prefix=/usr \
+ && make install \
+ && cd .. \
+ && rm -rf pcre2-10.21* \
+# cleanup
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean
+
+# add user pony in order to not run tests as root
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu-14.04-base/README.md
+++ b/.ci-dockerfiles/ubuntu-14.04-base/README.md
@@ -1,0 +1,17 @@
+# Overview
+
+This docker image is used as a base for most of the other images for testing different llvm versions in CI.
+
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:ubuntu-14.04-base .
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:ubuntu-14.04-base
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,21 @@ jobs:
     steps:
       - checkout
       - run: changelog-tool verify CHANGELOG.md
+
   validate-docker-image-builds:
       docker:
         - image: docker:17.05.0-ce-git
       steps:
         - checkout
         - setup_remote_docker
+
         - run: docker build --cache-from=app -t app .
   validate-shell-scripts:
     docker:
       - image: ponylang/ponyc-ci:shellcheck
     steps:
       - checkout
+
       - run: find . -name '*.bash' -exec shellcheck {} \;
   llvm-600-debug:
     docker:
@@ -25,91 +28,500 @@ jobs:
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true -j3
       - run: make test-ci config=debug default_pic=true
+
   llvm-600-release:
     docker:
       - image: ponylang/ponyc-ci:llvm-6.0.0
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
+
   llvm-501-debug:
     docker:
       - image: ponylang/ponyc-ci:llvm-5.0.1
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true -j3
       - run: make test-ci config=debug default_pic=true
+
   llvm-501-release:
     docker:
       - image: ponylang/ponyc-ci:llvm-5.0.1
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
+
   llvm-401-debug:
     docker:
       - image: ponylang/ponyc-ci:llvm-4.0.1
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true -j3
       - run: make test-ci config=debug default_pic=true
+
   llvm-401-release:
     docker:
       - image: ponylang/ponyc-ci:llvm-4.0.1
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
+
   llvm-391-debug:
     docker:
       - image: ponylang/ponyc-ci:llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true -j3
       - run: make test-ci config=debug default_pic=true
+
   llvm-391-release:
     docker:
       - image: ponylang/ponyc-ci:llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
+
   openssl-110:
     docker:
       - image: ponylang/ponyc-ci:openssl-1.1.0
         user: pony
     steps:
       - checkout
+      - run: make all default_ssl=openssl_1.1.0 default_pic=true -j3
       - run: make test-ci default_ssl=openssl_1.1.0 default_pic=true
+
   alpine-llvm-391-debug:
     docker:
       - image: ponylang/ponyc-ci:alpine-llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true -j3
       - run: make test-ci config=debug default_pic=true
+
   alpine-llvm-391-release:
     docker:
       - image: ponylang/ponyc-ci:alpine-llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
+
   centos7-llvm-391-debug:
     docker:
       - image: ponylang/ponyc-ci:centos7-llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=debug default_pic=true use="llvm_link_static" -j3
       - run: make test-ci config=debug default_pic=true use="llvm_link_static"
+
   centos7-llvm-391-release:
     docker:
       - image: ponylang/ponyc-ci:centos7-llvm-3.9.1
         user: pony
     steps:
       - checkout
+      - run: make all config=release default_pic=true use="llvm_link_static" -j3
       - run: make test-ci config=release default_pic=true use="llvm_link_static"
+
+  cross-llvm-600-debug-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-600-release-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-501-debug-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-501-release-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-401-debug-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-401-release-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-391-debug-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-391-release-arm:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-arm
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
+
+  cross-llvm-600-debug-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-600-release-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-501-debug-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-501-release-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-401-debug-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-401-release-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-391-debug-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-391-release-armhf:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-armhf
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
+
+  cross-llvm-600-debug-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-600-release-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-6.0.0-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-501-debug-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-501-release-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-5.0.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-401-debug-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-401-release-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-4.0.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-391-debug-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=debug verbose=1 -j3 all
+      - run: make config=debug verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=debug verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
+
+  cross-llvm-391-release-aarch64:
+    docker:
+      - image: ponylang/ponyc-ci:cross-llvm-3.9.1-aarch64
+        user: pony
+    steps:
+      - checkout
+      # build and test for x86_64 first
+      - run: make config=release verbose=1 -j3 all
+      - run: make config=release verbose=1 test-ci
+      # build libponyrt for target arch
+      - run: make config=release verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
+      # build ponyc for target cross compilation
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
+      # run tests for cross built stdlib using ponyc cross building support
+      - run: make config=release verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
 
 workflows:
   version: 2
@@ -131,3 +543,27 @@ workflows:
       - alpine-llvm-391-release
       - centos7-llvm-391-debug
       - centos7-llvm-391-release
+      - cross-llvm-600-debug-arm
+      - cross-llvm-600-release-arm
+      - cross-llvm-501-debug-arm
+      - cross-llvm-501-release-arm
+      - cross-llvm-401-debug-arm
+      - cross-llvm-401-release-arm
+      - cross-llvm-391-debug-arm
+      - cross-llvm-391-release-arm
+      - cross-llvm-600-debug-armhf
+      - cross-llvm-600-release-armhf
+      - cross-llvm-501-debug-armhf
+      - cross-llvm-501-release-armhf
+      - cross-llvm-401-debug-armhf
+      - cross-llvm-401-release-armhf
+      - cross-llvm-391-debug-armhf
+      - cross-llvm-391-release-armhf
+#      - cross-llvm-600-debug-aarch64
+#      - cross-llvm-600-release-aarch64
+      - cross-llvm-501-debug-aarch64
+      - cross-llvm-501-release-aarch64
+      - cross-llvm-401-debug-aarch64
+      - cross-llvm-401-release-aarch64
+      - cross-llvm-391-debug-aarch64
+      - cross-llvm-391-release-aarch64

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
 dist: trusty
 sudo: required
 
+services:
+  - docker
+
 # NOTE: This holds fedora COPR API related variables. Unfortunately, the values expire every 180 days.
 # As a result, we have to remember to visit https://copr.fedorainfracloud.org/api/ and generate a new token
 # and then run the following to update variables and replace the "secure" value.
@@ -16,8 +19,21 @@ env:
   global:
     secure: "YoSty8dHJOOj52w7Y1ycbO95GCNIGxAr0ZujtiINreMp4u6zAGkehYAy4rnPtDzbhwEf3SoQLegnG+yxg5TOaNejUJw85ZD1FgzAHOTbxHJAzLMnj544TuXt37Pd34m/P1FgG9OuGdMJQMaTBVCaOEeZ7y54fXcXpTQFH6gnDCRqRA0UQRZNR4Y6AtkDt5rfiwbQG3KJhb7oSydF7MgDOK9D+D5M40L4ANjAp1e8Imu4YMXZUUhZs2Vy49LQWOWD2Kuv0MOZt9W4ISrPaSR7lDMvtaWsScU+asrji/Jnc68SBmjCcU4sMxY0WeBF3fzu5h7VP7Yovkxju4e0UQG0PI/EEYukgw5b6k9za6flTczqs+pLIVhPwBWIE943nhqrLE9/l00vEpVBBj4X1iofrT9r4TSmaMzewZQx3cX4IOmwSuHA14NPUapXgwrP97ANtk+mkYg4HJ9W1e5/nD7juGBondfDTp/cW1z+1PUN4PQZrJJ9UFbryX51/2YB/8K5mdU970qcdsrljcB9WSxTUCogo+s6bc/hFUmH6BRmN10x10wrGbO62J/v0PpxKtymwSqAwvkr2cDejrCfm3bS/6Uoqo7gC6smTOlKSH8rEdLty1lA584/rXL0VvfjtUrn94g5BCkV1jRlufT33hv3nQjpkpCRokt0phKUQLxjv8c="
 
+env:
+  global:
+    - CROSS_ARCH=
+    - RELEASE_CONFIG=no
+    - RELEASE_DEBS=
+    - CC1=gcc
+    - CXX1=g++
+    - ICC1=gcc-6
+    - ICXX1=g++-6
+
 matrix:
-   include:
+  include:
+
+    - os: osx
+
     - os: linux
       addons:
         apt:
@@ -27,14 +43,9 @@ matrix:
             - g++-6
       env:
         - RELEASE_CONFIG=yes
-        - RELEASE_DEBS=
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=release
-        - CC1=gcc
-        - CXX1=g++
-        - ICC1=gcc-6
-        - ICXX1=g++-6
 
     - os: linux
       env:
@@ -46,7 +57,355 @@ matrix:
         - RELEASE_CONFIG=yes
         - RELEASE_DEBS=debian
 
-    - os: osx
+    # i686
+    - os: linux
+      env:
+        - DOCKER_ARCH=i686
+        - CROSS_ARCH=i686
+        - LLVM_VERSION="3.9.1"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=debug
+        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_BITS=32
+        - CROSS_TRIPLE=i686-unknown-linux-gnu
+        - CROSS_LINKER='gcc-6 -m32'
+        - CROSS_CC=gcc-6
+        - CROSS_CXX=g++-6
+        - CROSS_TUNE=generic
+
+    - os: linux
+      env:
+        - DOCKER_ARCH=i686
+        - CROSS_ARCH=i686
+        - LLVM_VERSION="3.9.1"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=release
+        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_BITS=32
+        - CROSS_TRIPLE=i686-unknown-linux-gnu
+        - CROSS_LINKER='gcc-6 -m32'
+        - CROSS_CC=gcc-6
+        - CROSS_CXX=g++-6
+        - CROSS_TUNE=generic
+
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="4.0.1"
+#        - LLVM_CONFIG="llvm-config-4.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="4.0.1"
+#        - LLVM_CONFIG="llvm-config-4.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="5.0.1"
+#        - LLVM_CONFIG="llvm-config-5.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="5.0.1"
+#        - LLVM_CONFIG="llvm-config-5.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="6.0.0"
+#        - LLVM_CONFIG="llvm-config-6.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="6.0.0"
+#        - LLVM_CONFIG="llvm-config-6.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+
+     # aarch64
+    - os: linux
+      env:
+        - DOCKER_ARCH=aarch64
+        - CROSS_ARCH=armv8-a
+        - LLVM_VERSION="6.0.0"
+        - LLVM_CONFIG="llvm-config-6.0"
+        - config=debug
+        - CROSS_CFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_BITS=64
+        - CROSS_TRIPLE=aarch64-unknown-linux-gnu
+        - CROSS_LINKER=aarch64-linux-gnu-gcc
+        - CROSS_CC=aarch64-linux-gnu-gcc
+        - CROSS_CXX=aarch64-linux-gnu-g++
+        - QEMU_RUNNER='qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc'
+        - CROSS_TUNE=cortex-a53
+
+    - os: linux
+      env:
+        - DOCKER_ARCH=aarch64
+        - CROSS_ARCH=armv8-a
+        - LLVM_VERSION="6.0.0"
+        - LLVM_CONFIG="llvm-config-6.0"
+        - config=release
+        - CROSS_CFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_BITS=64
+        - CROSS_TRIPLE=aarch64-unknown-linux-gnu
+        - CROSS_LINKER=aarch64-linux-gnu-gcc
+        - CROSS_CC=aarch64-linux-gnu-gcc
+        - CROSS_CXX=aarch64-linux-gnu-g++
+        - QEMU_RUNNER='qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc'
+        - CROSS_TUNE=cortex-a53
+
+  allow_failures:
+
+    # i686
+    - os: linux
+      env:
+        - DOCKER_ARCH=i686
+        - CROSS_ARCH=i686
+        - LLVM_VERSION="3.9.1"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=debug
+        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_BITS=32
+        - CROSS_TRIPLE=i686-unknown-linux-gnu
+        - CROSS_LINKER='gcc-6 -m32'
+        - CROSS_CC=gcc-6
+        - CROSS_CXX=g++-6
+        - CROSS_TUNE=generic
+
+    - os: linux
+      env:
+        - DOCKER_ARCH=i686
+        - CROSS_ARCH=i686
+        - LLVM_VERSION="3.9.1"
+        - LLVM_CONFIG="llvm-config-3.9"
+        - config=release
+        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+        - CROSS_BITS=32
+        - CROSS_TRIPLE=i686-unknown-linux-gnu
+        - CROSS_LINKER='gcc-6 -m32'
+        - CROSS_CC=gcc-6
+        - CROSS_CXX=g++-6
+        - CROSS_TUNE=generic
+
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="4.0.1"
+#        - LLVM_CONFIG="llvm-config-4.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="4.0.1"
+#        - LLVM_CONFIG="llvm-config-4.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="5.0.1"
+#        - LLVM_CONFIG="llvm-config-5.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="5.0.1"
+#        - LLVM_CONFIG="llvm-config-5.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="6.0.0"
+#        - LLVM_CONFIG="llvm-config-6.0"
+#        - config=debug
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+#
+#    - os: linux
+#      env:
+#        - DOCKER_ARCH=i686
+#        - CROSS_ARCH=i686
+#        - LLVM_VERSION="6.0.0"
+#        - LLVM_CONFIG="llvm-config-6.0"
+#        - config=release
+#        - CROSS_CFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_CXXFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_LDFLAGS='-m32 -idirafter /usr/cross/include/'
+#        - CROSS_BITS=32
+#        - CROSS_TRIPLE=i686-unknown-linux-gnu
+#        - CROSS_LINKER='gcc-6 -m32'
+#        - CROSS_CC=gcc-6
+#        - CROSS_CXX=g++-6
+#        - CROSS_TUNE=generic
+
+     # aarch64
+    - os: linux
+      env:
+        - DOCKER_ARCH=aarch64
+        - CROSS_ARCH=armv8-a
+        - LLVM_VERSION="6.0.0"
+        - LLVM_CONFIG="llvm-config-6.0"
+        - config=debug
+        - CROSS_CFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_BITS=64
+        - CROSS_TRIPLE=aarch64-unknown-linux-gnu
+        - CROSS_LINKER=aarch64-linux-gnu-gcc
+        - CROSS_CC=aarch64-linux-gnu-gcc
+        - CROSS_CXX=aarch64-linux-gnu-g++
+        - QEMU_RUNNER='qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc'
+        - CROSS_TUNE=cortex-a53
+
+    - os: linux
+      env:
+        - DOCKER_ARCH=aarch64
+        - CROSS_ARCH=armv8-a
+        - LLVM_VERSION="6.0.0"
+        - LLVM_CONFIG="llvm-config-6.0"
+        - config=release
+        - CROSS_CFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_CXXFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_LDFLAGS='-idirafter /usr/cross/include/'
+        - CROSS_BITS=64
+        - CROSS_TRIPLE=aarch64-unknown-linux-gnu
+        - CROSS_LINKER=aarch64-linux-gnu-gcc
+        - CROSS_CC=aarch64-linux-gnu-gcc
+        - CROSS_CXX=aarch64-linux-gnu-g++
+        - QEMU_RUNNER='qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc'
+        - CROSS_TUNE=cortex-a53
 
 rvm:
   - 2.2.3

--- a/.travis_commands.bash
+++ b/.travis_commands.bash
@@ -3,8 +3,9 @@
 set -o errexit
 set -o nounset
 
-ponyc-test(){
+osx-ponyc-test(){
   echo "Building and testing ponyc..."
+  make CC="$CC1" CXX="$CXX1" -j$(sysctl -n hw.ncpu) all
   make CC="$CC1" CXX="$CXX1" test-ci
 }
 

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/bin/bash
 
 set -o errexit
 set -o nounset
@@ -13,6 +13,26 @@ case "${TRAVIS_OS_NAME}" in
     if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$RELEASE_DEBS" != "" ]]
     then
       "ponyc-build-debs-$RELEASE_DEBS" "$(cat VERSION)"
+    fi
+
+    # when running a cross build of ponyc
+    if [[ "${CROSS_ARCH}" != "" ]]
+    then
+      set -x
+      # build and test for x86_64 first
+      echo "Building and testing ponyc..."
+      docker run --rm -u pony:2000 -v $(pwd):/home/pony "ponylang/ponyc-ci:cross-llvm-${LLVM_VERSION}-${DOCKER_ARCH}" make config=${config} CC="$CC1" CXX="$CXX1" verbose=1 -j$(nproc) all
+      docker run --rm -u pony:2000 -v $(pwd):/home/pony "ponylang/ponyc-ci:cross-llvm-${LLVM_VERSION}-${DOCKER_ARCH}" make config=${config} CC="$CC1" CXX="$CXX1" verbose=1 test-ci
+
+      echo "Building and testing cross ponyc..."
+      # build libponyrt for target arch
+      docker run --rm -u pony:2000 -v $(pwd):/home/pony "ponylang/ponyc-ci:cross-llvm-${LLVM_VERSION}-${DOCKER_ARCH}" make config=${config} verbose=1 CC="${CROSS_CC}" CXX="${CROSS_CXX}" arch="${CROSS_ARCH}" tune="${CROSS_TUNE}" bits="${CROSS_BITS}" CFLAGS="${CROSS_CFLAGS}" CXXFLAGS="${CROSS_CXXFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" -j$(nproc) libponyrt
+      # build ponyc for target cross compilation
+      docker run --rm -u pony:2000 -v $(pwd):/home/pony "ponylang/ponyc-ci:cross-llvm-${LLVM_VERSION}-${DOCKER_ARCH}" make config=${config} verbose=1 -j$(nproc) all PONYPATH=/usr/cross/lib cross_triple="${CROSS_TRIPLE}" cross_cpu="${CROSS_TUNE}" cross_arch="${CROSS_ARCH}" cross_linker="${CROSS_LINKER}"
+      # run tests for cross built stdlib using ponyc cross building support
+      docker run --rm -u pony:2000 -v $(pwd):/home/pony "ponylang/ponyc-ci:cross-llvm-${LLVM_VERSION}-${DOCKER_ARCH}" make config=${config} verbose=1 test-cross-ci PONYPATH=/usr/cross/lib cross_triple="${CROSS_TRIPLE}" cross_cpu="${CROSS_TUNE}" cross_arch="${CROSS_ARCH}" cross_linker="${CROSS_LINKER}" QEMU_RUNNER="${QEMU_RUNNER:-}"
+
+      set +x
     fi
 
     # when RELEASE_CONFIG stops matching part of this case, move this logic
@@ -47,10 +67,10 @@ case "${TRAVIS_OS_NAME}" in
       export CXX1=clang++-3.9
       echo "Running LLVM 3.9 config=debug build..."
       export config=debug
-      ponyc-test
+      osx-ponyc-test
       echo "Running LLVM 3.9 config=release build..."
       export config=release
-      ponyc-test
+      osx-ponyc-test
 
       make clean
       brew uninstall llvm@3.9
@@ -65,7 +85,7 @@ case "${TRAVIS_OS_NAME}" in
       export CXX1=clang++-5.0
       echo "Running LLVM 5.0 config=release build..."
       export config=release
-      ponyc-test
+      osx-ponyc-test
 
       make clean
       brew uninstall llvm@5
@@ -84,7 +104,7 @@ case "${TRAVIS_OS_NAME}" in
       export CXX1=clang++-6.0
       echo "Running LLVM 6.0 config=release build..."
       export config=release
-      ponyc-test
+      osx-ponyc-test
 
       make clean
       brew uninstall llvm

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ endif
 LIB_EXT ?= a
 BUILD_FLAGS = -march=$(arch) -mtune=$(tune) -Werror -Wconversion \
   -Wno-sign-conversion -Wextra -Wall
-LINKER_FLAGS = -march=$(arch) -mtune=$(tune)
+LINKER_FLAGS = -march=$(arch) -mtune=$(tune) $(LDFLAGS)
 AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
@@ -121,8 +121,10 @@ UNAME_M := $(shell uname -m)
 
 ifeq ($(BITS),64)
   ifeq ($(UNAME_M),x86_64)
-    BUILD_FLAGS += -mcx16
-    LINKER_FLAGS += -mcx16
+    ifeq (,$(filter $(arch), armv8-a))
+      BUILD_FLAGS += -mcx16
+      LINKER_FLAGS += -mcx16
+    endif
   endif
 endif
 
@@ -327,11 +329,11 @@ packages_abs_src := $(shell dirname $(makefile_abs_path))/packages
 
 $(shell mkdir -p $(PONY_BUILD_DIR))
 
-lib   := $(PONY_BUILD_DIR)
+lib   := $(PONY_BUILD_DIR)/lib/$(arch)
 bin   := $(PONY_BUILD_DIR)
 tests := $(PONY_BUILD_DIR)
 benchmarks := $(PONY_BUILD_DIR)
-obj   := $(PONY_BUILD_DIR)/obj
+obj   := $(PONY_BUILD_DIR)/obj-$(arch)
 
 # Libraries. Defined as
 # (1) a name and output directory
@@ -582,7 +584,7 @@ libponyrt.benchmarks.linker = $(CXX)
 # make targets
 targets := $(libraries) libponyrt $(binaries) $(tests) $(benchmarks)
 
-.PHONY: all $(targets) install uninstall clean stats deploy prerelease
+.PHONY: all $(targets) install uninstall clean stats deploy prerelease check-version test-core test-stdlib-debug test-stdlib test-examples validate-grammar test-ci test-cross-ci benchmark stdlib stdlib-debug
 all: $(targets)
 	@:
 
@@ -680,7 +682,7 @@ endef
 
 define CONFIGURE_LIBS_WHOLE
   ifeq ($(OSTYPE),osx)
-    wholelibs += -Wl,-force_load,$(PONY_BUILD_DIR)/$(1).a
+    wholelibs += -Wl,-force_load,$(lib)/$(1).a
   else
     wholelibs += $(subst lib,-l,$(1))
   endif
@@ -771,6 +773,7 @@ $(foreach d,$($(1).depends),$(eval depends += $($(d))/$(d).$(LIB_EXT)))
 
 ifeq ($(1),libponyrt)
 $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
+	@mkdir -p $$(dir $$@)
 	@echo 'Linking libponyrt'
     ifneq (,$(DTRACE))
     ifeq ($(OSTYPE), linux)
@@ -791,6 +794,7 @@ $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
     endif
   ifeq ($(runtime-bitcode),yes)
 $($(1))/libponyrt.bc: $(depends) $(bcfiles)
+	@mkdir -p $$(dir $$@)
 	@echo 'Generating bitcode for libponyrt'
 	$(SILENT)$(LLVM_LINK) -o $$@ $(bcfiles)
     ifeq ($(config),release)
@@ -802,11 +806,13 @@ libponyrt: $($(1))/libponyrt.$(LIB_EXT)
   endif
 else ifneq ($(filter $(1),$(libraries)),)
 $($(1))/$(1).$(LIB_EXT): $(depends) $(ofiles)
+	@mkdir -p $$(dir $$@)
 	@echo 'Linking $(1)'
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
 $(1): $($(1))/$(1).$(LIB_EXT)
 else
 $($(1))/$(1): $(depends) $(ofiles)
+	@mkdir -p $$(dir $$@)
 	@echo 'Linking $(1)'
 	$(SILENT)$(linker) -o $$@ $(ofiles) $(linkcmd)
 $(1): $($(1))/$(1)
@@ -822,25 +828,33 @@ $(foreach target,$(targets),$(eval $(call EXPAND_COMMAND,$(target))))
 
 define EXPAND_INSTALL
 ifeq ($(OSTYPE),linux)
+install-libponyrt-pic: libponyrt-pic
+	@mkdir -p $(destdir)/lib/$(arch)
+	$(SILENT)cp $(lib)/libponyrt-pic.a $(DESTDIR)$(ponydir)/lib/$(arch)
+endif
+install-libponyrt: libponyrt
+	@mkdir -p $(destdir)/lib/$(arch)
+	$(SILENT)cp $(lib)/libponyrt.a $(DESTDIR)$(ponydir)/lib/$(arch)
+ifeq ($(OSTYPE),linux)
 install: libponyc libponyrt libponyrt-pic ponyc
 else
 install: libponyc libponyrt ponyc
 endif
 	@mkdir -p $(DESTDIR)$(ponydir)/bin
-	@mkdir -p $(DESTDIR)$(ponydir)/lib
+	@mkdir -p $(DESTDIR)$(ponydir)/lib/$(arch)
 	@mkdir -p $(DESTDIR)$(ponydir)/include/pony/detail
-	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.a $(DESTDIR)$(ponydir)/lib
+	$(SILENT)cp $(lib)/libponyrt.a $(DESTDIR)$(ponydir)/lib/$(arch)
 ifeq ($(OSTYPE),linux)
-	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt-pic.a $(DESTDIR)$(ponydir)/lib
+	$(SILENT)cp $(lib)/libponyrt-pic.a $(DESTDIR)$(ponydir)/lib/$(arch)
 endif
 ifneq ($(wildcard $(PONY_BUILD_DIR)/libponyrt.bc),)
 	$(SILENT)cp $(PONY_BUILD_DIR)/libponyrt.bc $(DESTDIR)$(ponydir)/lib
 endif
-ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
-	$(SILENT)cp $(PONY_BUILD_DIR)/libdtrace_probes.a $(DESTDIR)$(ponydir)/lib
+ifneq ($(wildcard $(lib)/libdtrace_probes.a),)
+	$(SILENT)cp $(lib)/libdtrace_probes.a $(DESTDIR)$(ponydir)/lib/$(arch)
 endif
-	$(SILENT)cp $(PONY_BUILD_DIR)/libponyc.a $(DESTDIR)$(ponydir)/lib
-	$(SILENT)cp $(PONY_BUILD_DIR)/ponyc $(DESTDIR)$(ponydir)/bin
+	$(SILENT)cp $(lib)/libponyc.a $(DESTDIR)$(ponydir)/lib/$(arch)
+	$(SILENT)cp $(bin)/ponyc $(DESTDIR)$(ponydir)/bin
 	$(SILENT)cp src/libponyrt/pony.h $(DESTDIR)$(ponydir)/include
 	$(SILENT)cp src/common/pony/detail/atomics.h $(DESTDIR)$(ponydir)/include/pony/detail
 	$(SILENT)cp -r packages $(DESTDIR)$(ponydir)/
@@ -849,17 +863,17 @@ ifeq ($$(symlink),yes)
 	@mkdir -p $(DESTDIR)$(libdir)
 	@mkdir -p $(DESTDIR)$(includedir)/pony/detail
 	$(SILENT)ln $(symlink.flags) $(ponydir)/bin/ponyc $(DESTDIR)$(bindir)/ponyc
-	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/libponyrt.a $(DESTDIR)$(libdir)/libponyrt.a
+	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/$(arch)/libponyrt.a $(DESTDIR)$(libdir)/libponyrt.a
 ifeq ($(OSTYPE),linux)
-	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/libponyrt-pic.a $(DESTDIR)$(libdir)/libponyrt-pic.a
+	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/$(arch)/libponyrt-pic.a $(DESTDIR)$(libdir)/libponyrt-pic.a
 endif
 ifneq ($(wildcard $(DESTDIR)$(ponydir)/lib/libponyrt.bc),)
 	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/libponyrt.bc $(DESTDIR)$(libdir)/libponyrt.bc
 endif
 ifneq ($(wildcard $(PONY_BUILD_DIR)/libdtrace_probes.a),)
-	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/libdtrace_probes.a $(DESTDIR)$(libdir)/libdtrace_probes.a
+	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/$(arch)/libdtrace_probes.a $(DESTDIR)$(libdir)/libdtrace_probes.a
 endif
-	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/libponyc.a $(DESTDIR)$(libdir)/libponyc.a
+	$(SILENT)ln $(symlink.flags) $(ponydir)/lib/$(arch)/libponyc.a $(DESTDIR)$(libdir)/libponyc.a
 	$(SILENT)ln $(symlink.flags) $(ponydir)/include/pony.h $(DESTDIR)$(includedir)/pony.h
 	$(SILENT)ln $(symlink.flags) $(ponydir)/include/pony/detail/atomics.h $(DESTDIR)$(includedir)/pony/detail/atomics.h
 endif
@@ -897,48 +911,47 @@ ifeq ($(lto),yes)
 endif
 
 benchmark: all
-	@echo "Running libponyc benchmarks..."
-	@$(PONY_BUILD_DIR)/libponyc.benchmarks
-	@echo "Running libponyrt benchmarks..."
-	@$(PONY_BUILD_DIR)/libponyrt.benchmarks
+	$(SILENT)echo "Running libponyc benchmarks..."
+	$(SILENT)$(PONY_BUILD_DIR)/libponyc.benchmarks
+	$(SILENT)echo "Running libponyrt benchmarks..."
+	$(SILENT)(PONY_BUILD_DIR)/libponyrt.benchmarks
 
 stdlib-debug: all
-	$(PONY_BUILD_DIR)/ponyc -d --checktree --verify packages/stdlib
+	$(SILENT)PONYPATH=.:$(PONYPATH) $(PONY_BUILD_DIR)/ponyc $(cross_args) -d -s --checktree --verify packages/stdlib
 
 stdlib: all
-	$(PONY_BUILD_DIR)/ponyc --checktree --verify packages/stdlib
+	$(SILENT)PONYPATH=.:$(PONYPATH) $(PONY_BUILD_DIR)/ponyc $(cross_args) --checktree --verify packages/stdlib
 
 test-stdlib-debug: stdlib-debug
-	./stdlib --sequential
+	$(SILENT)$(cross_runner) ./stdlib --sequential
+	$(SILENT)rm stdlib
 
 test-stdlib: stdlib
-	./stdlib --sequential
+	$(SILENT)$(cross_runner) ./stdlib --sequential
+	$(SILENT)rm stdlib
 
-test: all
-	@$(PONY_BUILD_DIR)/libponyc.tests
-	@$(PONY_BUILD_DIR)/libponyrt.tests
-	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
-	@./stdlib --sequential
-	@rm stdlib
-	@make test-examples
+test-core: all
+	$(SILENT)$(PONY_BUILD_DIR)/libponyc.tests
+	$(SILENT)$(PONY_BUILD_DIR)/libponyrt.tests
+
+test: test-core test-stdlib test-examples
 
 test-examples: all
-	@PONYPATH=. find examples/*/* -name '*.pony' -print | xargs -n 1 dirname  | sort -u | grep -v ffi- | xargs -n 1 -I {} $(PONY_BUILD_DIR)/ponyc -d -s --checktree -o {} {}
+	$(SILENT)PONYPATH=.:$(PONYPATH) find examples/*/* -name '*.pony' -print | xargs -n 1 dirname  | sort -u | grep -v ffi- | xargs -n 1 -I {} $(PONY_BUILD_DIR)/ponyc $(cross_args) -d -s --checktree -o {} {}
 
-test-ci: all
-	@$(PONY_BUILD_DIR)/ponyc --version
-	@$(PONY_BUILD_DIR)/libponyc.tests
-	@$(PONY_BUILD_DIR)/libponyrt.tests
-	@$(PONY_BUILD_DIR)/ponyc -d -s --checktree --verify packages/stdlib
-	@./stdlib --sequential
-	@rm stdlib
-	@$(PONY_BUILD_DIR)/ponyc --checktree --verify packages/stdlib
-	@./stdlib --sequential
-	@rm stdlib
-	@PONYPATH=. find examples/*/* -name '*.pony' -print | xargs -n 1 dirname  | sort -u | grep -v ffi- | xargs -n 1 -I {} $(PONY_BUILD_DIR)/ponyc -d -s --checktree -o {} {}
-	@$(PONY_BUILD_DIR)/ponyc --antlr > pony.g.new
-	@diff pony.g pony.g.new
-	@rm pony.g.new
+check-version: all
+	$(SILENT)$(PONY_BUILD_DIR)/ponyc --version
+
+validate-grammar: all
+	$(SILENT)$(PONY_BUILD_DIR)/ponyc --antlr > pony.g.new
+	$(SILENT)diff pony.g pony.g.new
+	$(SILENT)rm pony.g.new
+
+test-ci: all check-version test-core test-stdlib-debug test-stdlib test-examples validate-grammar
+
+test-cross-ci: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) --linker='$(cross_linker)'
+test-cross-ci: cross_runner=$(QEMU_RUNNER)
+test-cross-ci: test-ci
 
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs --pass expr
@@ -1063,6 +1076,10 @@ help:
 	@echo '  test                   Run test suite'
 	@echo '  benchmark              Build and run benchmark suite'
 	@echo '  install                Install ponyc'
+	@echo '  install-libponyrt      Install libponyrt only (for cross'
+	@echo '                         linking)'
+	@echo '  install-libponyrt-pic  Install libponyrt-pic only (for cross'
+	@echo '                         linking)'
 	@echo '  uninstall              Remove all versions of ponyc'
 	@echo '  stats                  Print Pony cloc statistics'
 	@echo '  clean                  Delete all build files'

--- a/packages/ponybench/_runner.pony
+++ b/packages/ponybench/_runner.pony
@@ -30,11 +30,19 @@ actor _RunSync is _Runner
       _complete(a)
     else
       try
-        Time.perf_begin()
-        let s = Time.nanos()
+        let s =
+          ifdef x86 then
+            Time.perf_begin()
+          else
+            Time.nanos()
+          end
         _bench()?
-        let e = Time.nanos()
-        Time.perf_end()
+        let e =
+          ifdef x86 then
+            Time.perf_end()
+          else
+            Time.nanos()
+          end
         _run_iteration(n + 1, a + (e - s))
       else
         _fail()
@@ -97,7 +105,6 @@ actor _RunAsync is _Runner
     else
       try
         _n = _n + 1
-        Time.perf_begin()
         _start_time = Time.nanos()
         _bench(_bench_cont)?
       else
@@ -127,7 +134,6 @@ class val AsyncBenchContinue
 
   fun complete() =>
     let e = Time.nanos()
-    Time.perf_end()
     _f(e)
 
   fun fail() =>

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1528,7 +1528,7 @@ bool target_is_arm(char* t)
   const char* arch = Triple::getArchTypePrefix(triple.getArch());
 #endif
 
-  return !strcmp("arm", arch);
+  return (!strcmp("arm", arch) || !strcmp("aarch64", arch));
 }
 
 // This function is used to safeguard against potential oversights on the size

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -691,7 +691,27 @@ static bool add_exec_dir(pass_opt_t* opt)
 #ifdef PLATFORM_IS_WINDOWS
   success = add_relative_path(path, "..\\lib", opt);
 #else
-  success = add_relative_path(path, "../lib", opt);
+  const char* link_arch = opt->link_arch != NULL ? opt->link_arch
+                                              : "native";
+  size_t lib_len = 8 + strlen(link_arch);
+  char* lib_path = (char*)ponyint_pool_alloc_size(lib_len);
+  snprintf(lib_path, lib_len, "../lib/%s", link_arch);
+
+  success = add_relative_path(path, lib_path, opt);
+
+  ponyint_pool_free_size(lib_len, lib_path);
+
+  if(!success)
+    return false;
+
+  // for when run from build directory
+  lib_len = 5 + strlen(link_arch);
+  lib_path = (char*)ponyint_pool_alloc_size(lib_len);
+  snprintf(lib_path, lib_len, "lib/%s", link_arch);
+
+  success = add_relative_path(path, lib_path, opt);
+
+  ponyint_pool_free_size(lib_len, lib_path);
 #endif
 
   if(!success)


### PR DESCRIPTION
NOTE: The Docker images used in this PR as it currently exists are from my repo (dipinhora/ponyc-ci) instead of the ponylang one (ponylang/ponyc-ci). This was to ensure that my experimentation did not inadvertently impact normal pony CI processes. Assuming folks review the changes and are okay with things, we can update the ponylang docker images and I can update the PR to point to them.

The i686 CI builds for llvm > 3.9.1 are commented out/disabled in .travis.yml because they have the same issue as the builds for llvm 3.9.1 and I figured we might as well try and save a tiny bit of build time. I can re-enable them if that is desired.

Also, while I have the arm/armhf/aarch64 tests running under Circle CI, it is easy to move them to run under Travis CI and marked as "Allowed Failures" if desired (see the failing aarch64 llvm 6.0.0 build as an example).

Additionally, I am about 50% to having a functional FreeBSD CI using vagrant/qemu. Not sure how well it'll turn out yet but it seems promising (except for the time limit issue on travis ci). That'll hopefully become another PR in the near future.

Lastly, this commit changes the directory layout used by `install` and some other part of the `Makefile` and so needs to be tested to ensure it doesn't break packaging for OSX/various Linux distros (I don't believe it does but I haven't done a thorough test yet).

---------------------------------------

This commit adds CI builds for non-x86_64 targets using a combination
of cross compiling and qemu.

The architectures included are:

* arm
* armhf
* aarch64
* i686

This commit also includes some changes to ponyc and it's Makefile so
that cross compiling is a little easier to accomplish. Also included
are a couple of minor fixes related to getting CI to pass on arm
targets.

Lastly, this commit inlcudes changes to the CI dockerfiles to make
the different ubuntu based docker images more consistent by having
them all inherit from a single base.