### PR TITLE
Fix symbol clash that arises from LLVM debug/release mismatch #2776

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,18 @@ LLVM_LINK := $(LLVM_BINDIR)/llvm-link
 LLVM_OPT := $(LLVM_BINDIR)/opt
 LLVM_LLC := $(LLVM_BINDIR)/llc
 LLVM_AS := $(LLVM_BINDIR)/llvm-as
+llvm_build_mode := $(shell $(LLVM_CONFIG) --build-mode)
+ifeq (Release,$(llvm_build_mode))
+  LLVM_BUILD_MODE=LLVM_BUILD_MODE_Release
+else ifeq (RelWithDebInfo,$(llvm_build_mode))
+  LLVM_BUILD_MODE=LLVM_BUILD_MODE_RelWithDebInfo
+else ifeq (Debug,$(llvm_build_mode))
+  LLVM_BUILD_MODE=LLVM_BUILD_MODE_Debug
+else
+  $(error "Uknown llvm build-mode of $(llvm_build_mode)", aborting)
+endif
+
+
 
 llvm_version := $(shell $(LLVM_CONFIG) --version)
 
@@ -488,12 +500,14 @@ libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS
 libponyc.buildoptions += -DPONY_ALWAYS_ASSERT
+libponyc.buildoptions += -DLLVM_BUILD_MODE=$(LLVM_BUILD_MODE)
 
 libponyc.tests.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.tests.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.tests.buildoptions += -D__STDC_LIMIT_MACROS
 libponyc.tests.buildoptions += -DPONY_ALWAYS_ASSERT
 libponyc.tests.buildoptions += -DPONY_PACKAGES_DIR=\"$(packages_abs_src)\"
+libponyc.tests.buildoptions += -DLLVM_BUILD_MODE=$(LLVM_BUILD_MODE)
 
 libponyc.tests.linkoptions += -rdynamic
 
@@ -504,6 +518,7 @@ endif
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
+libponyc.benchmarks.buildoptions += -DLLVM_BUILD_MODE=$(LLVM_BUILD_MODE)
 
 libgbenchmark.buildoptions := \
   -Wshadow -pedantic -pedantic-errors \

--- a/src/common/llvm_config_begin.h
+++ b/src/common/llvm_config_begin.h
@@ -7,6 +7,11 @@
 #ifndef LLVM_CONFIG_BEGIN_H
 #define LLVM_CONFIG_BEGIN_H
 
+// Valid LLVM_BULD_MODE's must match corresponding names in Makefile-ponyc
+#define LLVM_BUILD_MODE_Release 1
+#define LLVM_BUILD_MODE_RelWithDebInfo 2
+#define LLVM_BUILD_MODE_Debug 3
+
 #ifdef _MSC_VER
 #  pragma warning(push)
 
@@ -21,6 +26,31 @@
 
 // LLVM claims DEBUG as a macro name. Conflicts with MSVC headers.
 #  pragma warning(disable:4005)
+#endif
+
+#if PONY_LLVM < 400
+/**
+ * This is needed because llvm 3.9.1 uses NDEBUG to
+ * control code generation of templates and these
+ * versions must be consistent with between the library
+ * and users of the library. See issue #2776 in
+ * ponylang/ponyc.
+ */
+
+// Save current value for NDEBUG
+#  pragma push_macro("NDEBUG")
+
+// Undefine NDEBUG so we can define for release modes
+#  undef NDEBUG
+
+#if ((LLVM_BUILD_MODE == LLVM_BUILD_MODE_Release) || (LLVM_BUILD_MODE == LLVM_BUILD_MODE_RelWithDebInfo))
+   // Define NDEBUG for release builds
+#  define NDEBUG
+#elif LLVM_BUILD_MODE == LLVM_BUILD_MODE_Debug
+   // Leave NDEBUG undefined
+#else
+#  error "Unknown LLVM_BUILD_MODE was expecting Release, RelWithDebInfo or Debug"
+#endif
 #endif
 
 #endif

--- a/src/common/llvm_config_end.h
+++ b/src/common/llvm_config_end.h
@@ -4,6 +4,10 @@
 #ifndef LLVM_CONFIG_END_H
 #define LLVM_CONFIG_END_H
 
+#if PONY_LLVM < 400
+#  pragma pop_macro("NDEBUG")
+#endif
+
 #ifdef _MSC_VER
 #  pragma warning(pop)
 #endif

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -25,10 +25,10 @@
 #include <llvm-c/DebugInfo.h>
 #endif
 
+#include "llvm_config_end.h"
+
 #include "../../libponyrt/mem/heap.h"
 #include "ponyassert.h"
-
-#include "llvm_config_end.h"
 
 using namespace llvm;
 using namespace llvm::legacy;


### PR DESCRIPTION
This change uses llvm-config to get the build-mode for llvm. This is then
used to set NDEBUG appropriately so the llvm headers included in
llvm_config_begin.h have NDEBUG defined if the build was Release or
RelWithDebInof and undefined if Debug.

See ponylang issue #2776 for more details.