### PR TITLE
Deb packaging for bintray to allow for old version installation

### DIFF
--- a/.bintray_deb.bash
+++ b/.bintray_deb.bash
@@ -1,0 +1,68 @@
+#! /bin/bash
+
+REPO_TYPE=debian
+PACKAGE_VERSION=$1  # e.g., 0.24.0
+DISTRO=$2 # e.g., trusty
+
+if [[ "$PACKAGE_VERSION" == "" ]]; then
+  echo "Error! PACKAGE_VERSION (argument 1) required!"
+  exit 1
+fi
+
+if [[ "$DISTRO" == "" ]]; then
+  echo "Error! DISTRO (argument 2) required!"
+  exit 1
+fi
+
+BINTRAY_REPO_NAME="ponylang-debian"
+OUTPUT_TARGET="bintray_${REPO_TYPE}_${DISTRO}.json"
+
+DATE="$(date +%Y-%m-%d)"
+
+case "$REPO_TYPE" in
+  "debian")
+    FILES="\"files\":
+        [
+          {
+            \"includePattern\": \"/home/travis/build/ponylang/ponyc/(ponyc_.*${DISTRO}.*.deb)\", \"uploadPattern\": \"pool/main/p/ponyc/\$1\",
+            \"matrixParams\": {
+            \"deb_distribution\": \"${DISTRO}\",
+            \"deb_component\": \"main\",
+            \"deb_architecture\": \"amd64\"}
+         }
+       ],
+       \"publish\": true"
+    ;;
+esac
+
+JSON="{
+  \"package\": {
+    \"repo\": \"$BINTRAY_REPO_NAME\",
+    \"name\": \"ponyc\",
+    \"subject\": \"pony-language\",
+    \"website_url\": \"https://www.ponylang.org/\",
+    \"issue_tracker_url\": \"https://github.com/ponylang/ponyc/issues\",
+    \"vcs_url\": \"https://github.com/ponylang/ponyc.git\",
+    \"licenses\": [\"BSD 2-Clause\"],
+    \"github_repo\": \"ponylang/ponyc\",
+    \"github_release_notes_file\": \"CHANGELOG.md\"
+    \"public_download_numbers\": true
+  },
+  \"version\": {
+    \"name\": \"$PACKAGE_VERSION\",
+    \"desc\": \"ponyc release $PACKAGE_VERSION\",
+    \"released\": \"$DATE\",
+    \"vcs_tag\": \"$PACKAGE_VERSION\",
+    \"github_use_tag_release_notes\": true,
+    \"github_release_notes_file\": \"CHANGELOG.md\"
+  },"
+
+JSON="$JSON$FILES}"
+
+echo "Writing JSON to file: $OUTPUT_TARGET, from within $(pwd) ..."
+echo "$JSON" > "$OUTPUT_TARGET"
+
+echo "=== WRITTEN FILE =========================="
+cat -v "$OUTPUT_TARGET"
+echo "==========================================="
+

--- a/.ci-dockerfiles/deb-builder/Dockerfile
+++ b/.ci-dockerfiles/deb-builder/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_DISTRO=ubuntu
+ARG FROM_VERSION=trusty
+FROM ${FROM_DISTRO}:${FROM_VERSION}
+
+ARG FROM_VERSION=trusty
+
+RUN apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  dirmngr \
+  gnupg \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "47E4F8DEE04F0923" \
+ && echo deb https://dl.bintray.com/pony-language/ponylang-debian ${FROM_VERSION} main | tee -a /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get install -y \
+  devscripts \
+  build-essential \
+  lintian \
+  debhelper \
+  equivs
+
+WORKDIR /home/pony
+

--- a/.ci-dockerfiles/deb-builder/Dockerfile.jessie
+++ b/.ci-dockerfiles/deb-builder/Dockerfile.jessie
@@ -1,0 +1,28 @@
+ARG FROM_DISTRO=debian
+ARG FROM_VERSION=jessie
+FROM ${FROM_DISTRO}:${FROM_VERSION}
+
+ARG FROM_VERSION=jessie
+
+RUN apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  ca-certificates \
+  dirmngr \
+  gnupg \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "47E4F8DEE04F0923" \
+ && echo deb https://dl.bintray.com/pony-language/ponylang-debian ${FROM_VERSION} main | tee -a /etc/apt/sources.list \
+ && apt-get install -y wget \
+ && echo "deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main" >> /etc/apt/sources.list \
+ && echo "deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.9 main" >> /etc/apt/sources.list \
+ && wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - \
+ && apt-get update \
+ && apt-get install -y \
+  devscripts \
+  build-essential \
+  lintian \
+  debhelper \
+  equivs
+
+WORKDIR /home/pony
+

--- a/.ci-dockerfiles/deb-builder/README.md
+++ b/.ci-dockerfiles/deb-builder/README.md
@@ -1,0 +1,44 @@
+# Build image for different distros
+
+```bash
+# Ubuntu Trusty
+docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=trusty -t ponylang/ponyc-ci:trusty-deb-builder .
+```
+
+```bash
+# Ubuntu Xenial
+docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=xenial -t ponylang/ponyc-ci:xenial-deb-builder .
+```
+
+```bash
+# Ubuntu Artful
+docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=artful -t ponylang/ponyc-ci:artful-deb-builder .
+```
+
+```bash
+# Ubuntu Bionic
+docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=bionic -t ponylang/ponyc-ci:bionic-deb-builder .
+```
+
+```bash
+# Debian Stretch
+docker build --build-arg FROM_DISTRO=debian --build-arg FROM_VERSION=stretch -t ponylang/ponyc-ci:stretch-deb-builder .
+```
+
+```bash
+# Debian Buster
+docker build --build-arg FROM_DISTRO=debian --build-arg FROM_VERSION=buster -t ponylang/ponyc-ci:buster-deb-builder .
+```
+
+```bash
+# Debian Jessie
+docker build --build-arg FROM_DISTRO=debian --build-arg FROM_VERSION=jessie -t ponylang/ponyc-ci:jessie-deb-builder --file Dockerfile.jessie .
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:${DIST}-deb-builder
+```

--- a/.packaging/deb/rules
+++ b/.packaging/deb/rules
@@ -22,7 +22,11 @@ ifeq ($(DEB_HOST_ARCH),amd64)
 ifeq ($(DEB_DISTRIBUTION),trusty)
 	MAKE_OPTIONS += arch=x86-64 tune=generic
 else
+ifeq ($(DEB_DISTRIBUTION),jessie)
+	MAKE_OPTIONS += arch=x86-64 tune=generic use="llvm_link_static"
+else
 	MAKE_OPTIONS += arch=x86-64 tune=intel
+endif
 endif
 endif
 
@@ -34,9 +38,9 @@ ifeq ($(DEB_HOST_ARCH),armhf)
 	MAKE_OPTIONS += arch=armv7 tune=arm7
 endif
 
-# trusty, xenial and artful are on openssl 1.0
+# jessie, trusty, xenial and artful are on openssl 1.0
 # artful and newer require PIC
-ifeq (,$(filter $(DEB_DISTRIBUTION),trusty xenial artful))
+ifeq (,$(filter $(DEB_DISTRIBUTION),jessie trusty xenial artful))
 	MAKE_OPTIONS += default_ssl='openssl_1.1.0' default_pic=true
 else
 ifeq ($(DEB_DISTRIBUTION),artful)
@@ -51,6 +55,7 @@ endif
 override_dh_auto_build:
 	env
 	uname -m
+	echo $(DEB_DISTRIBUTION)
 	dh_auto_build -- $(MAKE_OPTIONS)
 
 override_dh_auto_install:
@@ -58,6 +63,12 @@ override_dh_auto_install:
 
 override_dh_auto_test:
 	$(MAKE) test-ci $(MAKE_OPTIONS)
+
+# if newer debian/ubuntu disable unform compression in deb for bintray
+ifeq (,$(filter $(DEB_DISTRIBUTION),jessie stretch trusty xenial artful))
+override_dh_builddeb:
+	dh_builddeb -- --no-uniform-compression
+endif
 
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
             - g++-6
       env:
         - RELEASE_CONFIG=yes
+        - RELEASE_DEBS=
         - LLVM_VERSION="3.9.1"
         - LLVM_CONFIG="llvm-config-3.9"
         - config=release
@@ -34,6 +35,16 @@ matrix:
         - CXX1=g++
         - ICC1=gcc-6
         - ICXX1=g++-6
+
+    - os: linux
+      env:
+        - RELEASE_CONFIG=yes
+        - RELEASE_DEBS=ubuntu
+
+    - os: linux
+      env:
+        - RELEASE_CONFIG=yes
+        - RELEASE_DEBS=debian
 
     - os: osx
 
@@ -79,6 +90,90 @@ deploy:
     on:
       branch: release
       condition: "$RELEASE_CONFIG == yes"
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_trusty.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == ubuntu"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_xenial.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == ubuntu"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_artful.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == ubuntu"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_bionic.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == ubuntu"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_jessie.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == debian"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_stretch.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == debian"
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_debian_buster.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes"
+      condition: "$RELEASE_DEBS == debian"
+
     key:
       secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
 

--- a/.travis_commands.bash
+++ b/.travis_commands.bash
@@ -8,6 +8,91 @@ ponyc-test(){
   make CC="$CC1" CXX="$CXX1" test-ci
 }
 
+build_deb(){
+  deb_distro=$1
+
+  # untar source code
+  tar -xzf "ponyc_${package_version}.orig.tar.gz"
+
+  pushd "ponyc-${package_version}"
+
+  cp -r .packaging/deb debian
+  cp LICENSE debian/copyright
+
+  # create changelog
+  rm -f debian/changelog
+  dch --package ponyc -v "${package_version}" -D "${deb_distro}" --force-distribution --controlmaint --create "Release ${package_version}"
+
+  # remove pcre2 dependency from package and tests for trusty and jessie
+  if [[ ("$deb_distro" == "trusty") || ("$deb_distro" == "jessie") ]]
+  then
+    sed -i 's/, libpcre2-dev//g' debian/control
+    sed -i 's#use glob#//use glob#g' packages/stdlib/_test.pony
+    sed -i 's#glob.Main.make#None//glob.Main.make#g' packages/stdlib/_test.pony
+    sed -i 's#use regex#//use regex#g' packages/stdlib/_test.pony
+    sed -i 's#regex.Main.make#//regex.Main.make#g' packages/stdlib/_test.pony
+    EDITOR=/bin/true dpkg-source --commit . removepcredep
+  fi
+
+  # create package for distro using docker to run debuild
+  sudo docker run -v "$(pwd)/..:/home/pony" --rm --user root "ponylang/ponyc-ci:${deb_distro}-deb-builder" sh -c 'cd ponyc* && mk-build-deps -t "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y" -i -r && debuild -b -us -uc'
+
+  ls -l ..
+
+  # restore original working directory
+  popd
+
+  # create bintray upload json file
+  bash .bintray_deb.bash "$package_version" "$deb_distro"
+
+  # rename package to avoid clashing across different distros packages
+  mv "ponyc_${package_version}_amd64.deb" "ponyc_${package_version}_${deb_distro}_amd64.deb"
+
+  # clean up old build directory to ensure things are all clean
+  sudo rm -rf "ponyc-${package_version}"
+}
+
+ponyc-build-debs-ubuntu(){
+  package_version=$1
+
+  set -x
+
+  echo "Install devscripts..."
+  sudo apt-get update
+  sudo apt-get install -y devscripts
+
+  echo "Building off ponyc debs for bintray..."
+  wget "https://github.com/ponylang/ponyc/archive/${package_version}.tar.gz" -O "ponyc_${package_version}.orig.tar.gz"
+
+  build_deb xenial
+  build_deb artful
+  build_deb bionic
+  build_deb trusty
+
+  ls -la
+  set +x
+}
+
+ponyc-build-debs-debian(){
+  package_version=$1
+
+  set -x
+
+  echo "Install devscripts..."
+  sudo apt-get update
+  sudo apt-get install -y devscripts
+
+  echo "Building off ponyc debs for bintray..."
+  wget "https://github.com/ponylang/ponyc/archive/${package_version}.tar.gz" -O "ponyc_${package_version}.orig.tar.gz"
+
+  build_deb buster
+  build_deb stretch
+  build_deb jessie
+
+  ls -la
+  set +x
+}
+
 build_and_submit_deb_src(){
   deb_distro=$1
   rm -f debian/changelog

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -10,6 +10,11 @@ set -o nounset
 
 case "${TRAVIS_OS_NAME}" in
   "linux")
+    if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$RELEASE_DEBS" != "" ]]
+    then
+      "ponyc-build-debs-$RELEASE_DEBS" "$(cat VERSION)"
+    fi
+
     # when RELEASE_CONFIG stops matching part of this case, move this logic
     if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" ]]
     then


### PR DESCRIPTION
With the introduction of deb packaging/distribution via Ubuntu
Launchpad PPA, we lost the ability for folks to be able to install
old versions of ponyc via their package manager. See:
https://github.com/ansible/ansible/issues/23143 for more info.
This commit switches back from Launchpad to Bintray for
hosting/distribution of deb packages. This necessitated that we
build the deb packages ourselves.

This PR includes changes to the travis ci config to now run two
additional jobs for every release build. One to build all the
debian version packages. The other to build all the ubuntu version
packages. The changes also include uploading the packages to a new
bintray debian repo.

Unfortunately, I ran into some issues with using `sbuild` on trusty
so I had to fall back to using docker containers for building the
packages for the different distros.