### PR TITLE
Fix Python error in Windows when "make clean" is run

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,6 +47,7 @@ build_script:
       Update-AppveyorBuild -Version "ponyc-$package_version-$package_iteration"
   - cd C:\projects\ponyc
   - python -x waf configure
+  - python -x waf clean --config %configuration% --llvm %llvm%
   - python -x waf build --config %configuration% --llvm %llvm%
   - ps: |
       $ponydir = "ponyc-${package_version}-win64"

--- a/wscript
+++ b/wscript
@@ -188,6 +188,7 @@ def build(ctx):
 
     llvmIncludes = []
     llvmLibs = []
+    llvmBuildMode = ''
     sslIncludes = []
 
     # download windows libraries needed for building


### PR DESCRIPTION
`llvmBuildMode` needs to be defined even for `make clean`.