### PR TITLE
Add libexecinfo to debug builds for BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,8 @@ endif
 llvm.libs    := $(shell $(LLVM_CONFIG) --libs $(LLVM_LINK_STATIC)) -lz -lncurses
 
 ifeq ($(OSTYPE), bsd)
-  llvm.libs += -lpthread -lexecinfo
+  extra.bsd.libs = -lpthread -lexecinfo
+  llvm.libs += $(extra.bsd.libs)
 endif
 
 prebuilt := llvm
@@ -582,9 +583,9 @@ endif
 
 ifeq ($(OSTYPE),bsd)
   libponyc.tests.links += libpthread
-  libponyrt.tests.links += libpthread
+  libponyrt.tests.links += $(extra.bsd.libs)
   libponyc.benchmarks.links += libpthread
-  libponyrt.benchmarks.links += libpthread
+  libponyrt.benchmarks.links += $(extra.bsd.libs)
 endif
 
 ifneq (, $(DTRACE))

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -347,7 +347,8 @@ static bool link_exe(compile_t* c, ast_t* program,
     "";
 #endif
   const char* lexecinfo =
-#if (defined(PLATFORM_IS_LINUX) && !defined(__GLIBC__))
+#if (defined(PLATFORM_IS_LINUX) && !defined(__GLIBC__)) || \
+    (defined(PLATFORM_IS_BSD) && defined(DEBUG))
    "-lexecinfo";
 #else
     "";


### PR DESCRIPTION
While investigating #2823 for OpenBSD support and also #2825, I also tried twiddling a bit with FreeBSD and discovered that it isn't possible to compile with `config=debug` successfully.  Running `gmake config=debug test verbose=true` on ponyc's tag `0.24.0` on both FreeBSD 11 + LLVM 3.9.1 and DragonflyBSD 4.8.1 + LLVM 3.9.1:

```
[...]
c++ -MMD -MP -march=native -mtune=generic -Werror -Wconversion -Wno-sign-conversion -Wextra -Wall -g -DDEBUG -std=gnu++11 -fno-rtti   -c -o build/debug/obj/tests/libponyrt/util.o test/libponyrt/util.cc  -I src/common/ -I src/libponyrt/ -isystem lib/gtest/
Linking libponyrt.tests
c++ -o build/debug/libponyrt.tests build/debug/obj/tests/libponyrt/ds/fun.o build/debug/obj/tests/libponyrt/ds/hash.o build/debug/obj/tests/libponyrt/ds/list.o build/debug/obj/tests/libponyrt/lang/error.o build/debug/obj/tests/libponyrt/mem/heap.o build/debug/obj/tests/libponyrt/mem/pagemap.o build/debug/obj/tests/libponyrt/mem/pool.o build/debug/obj/tests/libponyrt/util.o -march=native -mtune=generic -L build/debug -lgtest -lponyrt -lpthread -L /usr/local/lib -rdynamic
build/debug/libponyrt.a(ponyassert.o): In function `ponyint_assert_fail':
/usr/home/vagrant/ponyc/src/libponyrt/platform/ponyassert.c:42: undefined reference to `backtrace'
/usr/home/vagrant/ponyc/src/libponyrt/platform/ponyassert.c:43: undefined reference to `backtrace_symbols'
c++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake: *** [Makefile:821: build/debug/libponyrt.tests] Error 1
```
