### PR TITLE
Ensure bintray deb travis jobs don't try and run PPA/COPR/etc

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -36,7 +36,7 @@ case "${TRAVIS_OS_NAME}" in
     fi
 
     # when RELEASE_CONFIG stops matching part of this case, move this logic
-    if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" ]]
+    if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$RELEASE_DEBS" == "" ]]
     then
       download_llvm
       download_pcre

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+ - Nothing - this was purely to fix a problem in the previously release
 
 ### Changed
 


### PR DESCRIPTION
I missed one minor detail in the bintray deb packaging PR as I was
cleaning things up for the PR and that caused the bintray debs
travis jobs to fail when they tried to install LLVM as part of the
normal release steps.

This commit fixes that to ensure the normal release steps don't
run during the bintray deb building jobs.