### PR TITLE
Initial version of nightly packaging builds

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -10,6 +10,14 @@ set -o nounset
 
 case "${TRAVIS_OS_NAME}" in
   "linux")
+    # when building debian packages for a nightly cron job to make sure packaging isn't broken
+    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "cron" && "$RELEASE_DEBS" != "" ]]
+    then
+      "ponyc-build-debs-$RELEASE_DEBS" master
+      exit
+    fi
+
+    # when building debian packages for a release
     if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$RELEASE_DEBS" != "" ]]
     then
       "ponyc-build-debs-$RELEASE_DEBS" "$(cat VERSION)"
@@ -48,6 +56,14 @@ case "${TRAVIS_OS_NAME}" in
   ;;
 
   "osx")
+    # when running for a nightly cron job to make sure packaging isn't broken
+    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "cron" ]]
+    then
+      brew install ponyc --HEAD
+      brew uninstall ponyc
+      exit
+    fi
+
     if [[ "$TRAVIS_BRANCH" != "release" ]]
     then
       brew update


### PR DESCRIPTION
NOTE: This will require the cron job functionality to be enabled through the Travis UI (https://docs.travis-ci.com/user/cron-jobs/).

-------------------------------

Currently only for Travis and only builds debian packages and
installs ponyc HEAD using brew.

Currenly doesn't save any packages built but will be useful to catch
any packaging related issues.