### PR TITLE
Fix array and string trim_in_place allocation bounds check

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -271,7 +271,17 @@ class Array[A] is Seq[A]
     _alloc = if last == _size then _alloc - offset else size' end
 
     _size = size'
-    _ptr = _ptr._offset(offset)
+
+    // if _alloc == 0 then we've trimmed all the memory originally allocated.
+    // if we do _ptr._offset, we will spill into memory not allocated/owned
+    // by this array and could potentially cause a segfault if we cross
+    // a pagemap boundary into a pagemap address that hasn't been allocated
+    // yet when `reserve` is called next.
+    if _alloc == 0 then
+      _ptr = Pointer[A]
+    else
+      _ptr = _ptr._offset(offset)
+    end
 
   fun val trim(from: USize = 0, to: USize = -1): Array[A] val =>
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -360,7 +360,17 @@ actor Main
     _alloc = if last == _size then _alloc - offset else size' end
 
     _size = size'
-    _ptr = _ptr._offset(offset)
+
+    // if _alloc == 0 then we've trimmed all the memory originally allocated.
+    // if we do _ptr._offset, we will spill into memory not allocated/owned
+    // by this string and could potentially cause a segfault if we cross
+    // a pagemap boundary into a pagemap address that hasn't been allocated
+    // yet when `reserve` is called next.
+    if _alloc == 0 then
+      _ptr = Pointer[U8]
+    else
+      _ptr = _ptr._offset(offset)
+    end
 
   fun val trim(from: USize = 0, to: USize = -1): String val =>
     """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -502,6 +502,7 @@ class iso _TestStringTrimInPlace is UnitTest
     case(h, "", "0123456", 4, 1, 0)
     case(h, "456", "0123456789".clone().>trim_in_place(1, 8), 3, 6, 3)
     case(h, "456", "0123456789".trim(1, 8), 3, 6, 3)
+    case(h, "", "0123456789".clone().>trim_in_place(1, 8), 3, 3, 0)
 
   fun case(
     h: TestHelper,
@@ -512,10 +513,17 @@ class iso _TestStringTrimInPlace is UnitTest
     space: USize = 0)
   =>
     let copy: String ref = orig.clone()
+    let pre_trim_pagemap = @ponyint_pagemap_get[Pointer[None]](copy.cpointer())
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
     h.assert_eq[USize](space, copy.space())
     h.assert_eq[String box](expected, copy.clone()) // safe to clone
+    let post_trim_pagemap = @ponyint_pagemap_get[Pointer[None]](copy.cpointer())
+    if copy.space() == 0 then
+      h.assert_eq[USize](0, post_trim_pagemap.usize())
+    else
+      h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())
+    end
 
 class iso _TestStringTrimInPlaceWithAppend is UnitTest
   """
@@ -1236,6 +1244,7 @@ class iso _TestArrayTrimInPlace is UnitTest
     case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4 where space = 4)
     case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 4, 0)
     case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 1, 0)
+    case(h, Array[U8], Array[U8].init(8, 1024), 1024)
 
   fun case(
     h: TestHelper,
@@ -1246,9 +1255,16 @@ class iso _TestArrayTrimInPlace is UnitTest
     space: USize = 0)
   =>
     let copy: Array[U8] ref = orig.clone()
+    let pre_trim_pagemap = @ponyint_pagemap_get[Pointer[None]](copy.cpointer())
     copy.trim_in_place(from, to)
     h.assert_eq[USize](space, copy.space())
     h.assert_array_eq[U8](expected, copy)
+    let post_trim_pagemap = @ponyint_pagemap_get[Pointer[None]](copy.cpointer())
+    if copy.space() == 0 then
+      h.assert_eq[USize](0, post_trim_pagemap.usize())
+    else
+      h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())
+    end
 
 class iso _TestArrayTrimInPlaceWithAppend is UnitTest
   """


### PR DESCRIPTION
Prior to this commit, if `Array.trim_in_place` and `String.trim_in place`
trimmed all of the memory allocated for the array or string (i.e.
`trim_point == space()`) then trim_in_place would still use _ptr._offset
to set the pointer to be the byte after the last byte allocated by the
array or string. This was bad for many reasons but sometimes especially
bad if that next byte happened to be in a different pagemap that had not
yet been allocated. This would result in a segfault the next time `reserve`
was called because the runtime would think this pointer was not allocated
by pony and complain that it cannot realloc memory not allocated by pony.

This commit fixes the logic in trim_in_place to allocate a new Pointer
if _alloc == 0 (i.e. all of the memory allocated for the array or string
has been trimmed away). This ensures that the `_ptr` will never point to
memory not owned/allocated by the array also guaranteeing no segfaults
will occur due to unallocated pagemap references.

This commit also modifies the `Array.trim_in_place` and
`String.trim_in_place` tests to prevent a regression.