### PR TITLE
Initial version of AppImage packaging for ponyc

### DIFF
--- a/.bintray.bash
+++ b/.bintray.bash
@@ -38,6 +38,13 @@ case "$REPO_TYPE" in
       ],
     \"publish\": true"
     ;;
+  "appimage")
+    FILES="\"files\":
+      [
+        {\"includePattern\": \"/home/travis/build/ponylang/ponyc/(.*.AppImage)\", \"uploadPattern\": \"\$1\"}
+      ],
+    \"publish\": true"
+    ;;
 esac
 
 JSON="{

--- a/.travis.yml
+++ b/.travis.yml
@@ -450,6 +450,16 @@ deploy:
 
   - provider: bintray
     user: pony-buildbot-2
+    file: /home/travis/build/ponylang/ponyc/bintray_appimage.json
+    skip_cleanup: true
+    on:
+      branch: release
+      condition: "$RELEASE_CONFIG == yes && -z $RELEASE_DEBS"
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
     file: /home/travis/build/ponylang/ponyc/bintray_debian_trusty.json
     skip_cleanup: true
     on:

--- a/.travis_commands.bash
+++ b/.travis_commands.bash
@@ -9,13 +9,61 @@ osx-ponyc-test(){
   make CC="$CC1" CXX="$CXX1" test-ci
 }
 
+build_appimage(){
+  package_version=$1
+
+  mkdir ponyc.AppDir
+
+  cat > ./ponyc.desktop <<\EOF
+[Desktop Entry]
+Name=Pony Compiler
+Icon=ponyc
+Type=Application
+NoDisplay=true
+Exec=ponyc
+Terminal=true
+Categories=Development;
+EOF
+
+  curl https://www.ponylang.org/images/logo.png -o ponyc.png
+
+  curl https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o linuxdeploy-x86_64.AppImage -J -L
+  chmod +x linuxdeploy-x86_64.AppImage
+
+  # remove any existing build artifacts
+  sudo rm -rf build
+
+  # can't run appimages in docker; need to extract and then run
+  ./linuxdeploy-x86_64.AppImage --appimage-extract
+
+  # need to run in CentOS 7 docker image
+  sudo docker run -v "$(pwd):/home/pony" --rm ponylang/ponyc-ci:centos7-llvm-3.9.1 sh -c "make arch=x86-64 tune=generic default_pic=true use=llvm_link_static DESTDIR=ponyc.AppDir ponydir=/usr prefix= test-ci"
+  sudo docker run -v "$(pwd):/home/pony" --rm ponylang/ponyc-ci:centos7-llvm-3.9.1 sh -c "make arch=x86-64 tune=generic default_pic=true use=llvm_link_static DESTDIR=ponyc.AppDir ponydir=/usr prefix= install"
+
+  # build stdlib to ensure libraries like openssl and pcre2 get packaged in the appimage
+  sudo docker run -v "$(pwd):/home/pony" --rm ponylang/ponyc-ci:centos7-llvm-3.9.1 sh -c "./build/release/ponyc packages/stdlib"
+  cp stdlib ponyc.AppDir/usr/bin
+
+  sudo docker run -v "$(pwd):/home/pony" --rm ponylang/ponyc-ci:centos7-llvm-3.9.1 sh -c "ARCH=x86_64 ./squashfs-root/AppRun --appdir ponyc.AppDir --desktop-file=ponyc.desktop --icon-file=ponyc.png --app-name=ponyc"
+
+  # delete stdlib to not include it in appimage
+  rm ponyc.AppDir/usr/bin/stdlib
+
+  # build appimage
+  sudo docker run -v "$(pwd):/home/pony" --rm ponylang/ponyc-ci:centos7-llvm-3.9.1 sh -c "ARCH=x86_64 ./squashfs-root/AppRun --appdir ponyc.AppDir --desktop-file=ponyc.desktop --icon-file=ponyc.png --app-name=ponyc --output appimage"
+
+  mv Pony_Compiler-x86_64.AppImage "Pony_Compiler-${package_version}-x86_64.AppImage"
+
+  bash .bintray.bash appimage "${package_version}" ponyc
+}
+
 build_deb(){
   deb_distro=$1
 
   # untar source code
   tar -xzf "ponyc_${package_version}.orig.tar.gz"
 
-  pushd "ponyc-${package_version}"
+  pushd ponyc-*
 
   cp -r .packaging/deb debian
   cp LICENSE debian/copyright
@@ -39,7 +87,7 @@ build_deb(){
   mv "ponyc_${package_version}_amd64.deb" "ponyc_${package_version}_${deb_distro}_amd64.deb"
 
   # clean up old build directory to ensure things are all clean
-  sudo rm -rf "ponyc-${package_version}"
+  sudo rm -rf ponyc-*
 }
 
 ponyc-build-debs-ubuntu(){
@@ -53,6 +101,12 @@ ponyc-build-debs-ubuntu(){
 
   echo "Building off ponyc debs for bintray..."
   wget "https://github.com/ponylang/ponyc/archive/${package_version}.tar.gz" -O "ponyc_${package_version}.orig.tar.gz"
+
+  if [ "${package_version}" == "master" ]
+  then
+    mv "ponyc_${package_version}.orig.tar.gz" "ponyc_$(cat VERSION).orig.tar.gz"
+    package_version=$(cat VERSION)
+  fi
 
   build_deb xenial
   build_deb artful
@@ -74,6 +128,12 @@ ponyc-build-debs-debian(){
 
   echo "Building off ponyc debs for bintray..."
   wget "https://github.com/ponylang/ponyc/archive/${package_version}.tar.gz" -O "ponyc_${package_version}.orig.tar.gz"
+
+  if [ "${package_version}" == "master" ]
+  then
+    mv "ponyc_${package_version}.orig.tar.gz" "ponyc_$(cat VERSION).orig.tar.gz"
+    package_version=$(cat VERSION)
+  fi
 
   build_deb buster
   build_deb stretch

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -17,6 +17,13 @@ case "${TRAVIS_OS_NAME}" in
       exit
     fi
 
+    # when building appimage package for a nightly cron job to make sure packaging isn't broken
+    if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "cron" && "$RELEASE_DEBS" == "" ]]
+    then
+      build_appimage "$(cat VERSION)"
+      exit
+    fi
+
     # when building debian packages for a release
     if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" && "$RELEASE_DEBS" != "" ]]
     then
@@ -52,6 +59,7 @@ case "${TRAVIS_OS_NAME}" in
       ponyc-kickoff-copr-ppa
       ponyc-build-packages
       ponyc-build-docs
+      build_appimage "$(cat VERSION)"
     fi
   ;;
 


### PR DESCRIPTION
NOTE: The bintray upload will fail until a generic repo with the name `ponyc-appimage` is created in the pony-language bintray account.

----------------------------------

See https://appimage.org/ for more info about the AppImage format.

The AppImage packages are built in a CentOS 7 docker image and
should theoretically be compatible with all glibc based x86_64
distros with the same or a newer glibc version.

This commit also fixes an issue with the nighly build of debian
packages.