### PR TITLE
Remove Launchpad PPA in favor of new Bintray DEB packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -420,26 +420,6 @@ notifications:
 deploy:
   - provider: bintray
     user: pony-buildbot-2
-    file: /home/travis/build/ponylang/ponyc/bintray_debian.json
-    skip_cleanup: true
-    on:
-      branch: release
-      condition: "$RELEASE_CONFIG == yes && -z $RELEASE_DEBS"
-    key:
-      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
-
-  - provider: bintray
-    user: pony-buildbot-2
-    file: /home/travis/build/ponylang/ponyc/bintray_rpm.json
-    skip_cleanup: true
-    on:
-      branch: release
-      condition: "$RELEASE_CONFIG == yes && -z $RELEASE_DEBS"
-    key:
-      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
-
-  - provider: bintray
-    user: pony-buildbot-2
     file: /home/travis/build/ponylang/ponyc/bintray_source.json
     skip_cleanup: true
     on:

--- a/.travis_commands.bash
+++ b/.travis_commands.bash
@@ -113,6 +113,15 @@ ponyc-build-debs-ubuntu(){
     package_version=$(cat VERSION)
   fi
 
+  # To add a new ubuntu version
+  # * Create and upload the appropriate docker image using .ci-dockerfiles/deb-builder templated Docker file
+  # * Add a new entry to the following list calling `build_deb` for the new distribution
+  #
+  # To remove a existing ubuntu version
+  # * Remove the exiting entry from the following list calling `build_deb` for the retired distribution
+  #
+  # To update the builder image for an existing ubuntu version
+  # * Create and upload a new version of the appropriate docker image using .ci-dockerfiles/deb-builder
   build_deb xenial
   build_deb artful
   build_deb bionic
@@ -140,6 +149,15 @@ ponyc-build-debs-debian(){
     package_version=$(cat VERSION)
   fi
 
+  # To add a new debian version
+  # * Create and upload the appropriate docker image using .ci-dockerfiles/deb-builder templated Docker file
+  # * Add a new entry to the following list calling `build_deb` for the new distribution
+  #
+  # To remove a existing debian version
+  # * Remove the exiting entry from the following list calling `build_deb` for the retired distribution
+  #
+  # To update the builder image for an existing debian version
+  # * Create and upload a new version of the appropriate docker image using .ci-dockerfiles/deb-builder
   build_deb buster
   build_deb stretch
   build_deb jessie
@@ -148,68 +166,12 @@ ponyc-build-debs-debian(){
   set +x
 }
 
-build_and_submit_deb_src(){
-  deb_distro=$1
-  rm -f debian/changelog
-  dch --package ponyc -v "${package_version}-0ppa1~${deb_distro}" -D "${deb_distro}" --controlmaint --create "Release ${package_version}"
-  debuild -S
-  dput custom-ppa "../ponyc_${package_version}-0ppa1~${deb_distro}_source.changes"
-}
-
-ponyc-kickoff-copr-ppa(){
+ponyc-kickoff-copr(){
   package_version=$(cat VERSION)
-
-  echo "Install debuild, dch, dput..."
-  sudo apt-get install -y devscripts build-essential lintian debhelper python-paramiko
-
-  echo "Decrypting and Importing gpg keys..."
-  # Disable shellcheck error SC2154 for uninitialized variables as these get set by travis-ci for us.
-  # See the following for error details: https://github.com/koalaman/shellcheck/wiki/SC2154
-  # shellcheck disable=SC2154
-  openssl aes-256-cbc -K "$encrypted_9035f6d310e4_key" -iv "$encrypted_9035f6d310e4_iv" -in .securefiles.tar.enc -out .securefiles.tar -d
-  tar -xvf .securefiles.tar
-  gpg --import ponylang-secret-gpg.key
-  gpg --import-ownertrust ponylang-ownertrust-gpg.txt
-  mv sshkey ~/sshkey
-  sudo chmod 600 ~/sshkey
-
-  echo "Kicking off ponyc packaging for PPA..."
-  wget "https://github.com/ponylang/ponyc/archive/${package_version}.tar.gz" -O "ponyc_${package_version}.orig.tar.gz"
-  tar -xvzf "ponyc_${package_version}.orig.tar.gz"
-  pushd "ponyc-${package_version}"
-  cp -r .packaging/deb debian
-  cp LICENSE debian/copyright
-
-  # ssh stuff for launchpad as a workaround for https://github.com/travis-ci/travis-ci/issues/9391
-  {
-    echo "[custom-ppa]"
-    echo "fqdn = ppa.launchpad.net"
-    echo "method = sftp"
-    echo "incoming = ~ponylang/ubuntu/ponylang/"
-    echo "login = ponylang"
-    echo "allow_unsigned_uploads = 0"
-  } >> ~/.dput.cf
-
-  mkdir -p ~/.ssh
-  {
-    echo "Host ppa.launchpad.net"
-    echo "    StrictHostKeyChecking no"
-    echo "    IdentityFile ~/sshkey"
-  } >> ~/.ssh/config
-  sudo chmod 400 ~/.ssh/config
-
-  build_and_submit_deb_src xenial
-  build_and_submit_deb_src artful
-  build_and_submit_deb_src bionic
-  build_and_submit_deb_src cosmic
-  build_and_submit_deb_src trusty
 
   # COPR for fedora/centos/suse
   echo "Kicking off ponyc packaging for COPR..."
   docker run -it --rm -e COPR_LOGIN="${COPR_LOGIN}" -e COPR_USERNAME=ponylang -e COPR_TOKEN="${COPR_TOKEN}" -e COPR_COPR_URL=https://copr.fedorainfracloud.org mgruener/copr-cli buildscm --clone-url https://github.com/ponylang/ponyc --commit "${package_version}" --subdir /.packaging/rpm/ --spec ponyc.spec --type git --nowait ponylang
-
-  # restore original working directory
-  popd
 }
 
 ponyc-build-packages(){

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -57,7 +57,7 @@ case "${TRAVIS_OS_NAME}" in
       download_pcre
       set_linux_compiler
       build_appimage "$(cat VERSION)"
-      ponyc-kickoff-copr-ppa
+      ponyc-kickoff-copr
       ponyc-build-packages
       ponyc-build-docs
     fi

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ docker run -v c:/path/to/my-code:/src/main ponylang/ponyc sh -c "ponyc && ./main
 
 By default, the Pony Docker image is compiled without support for AVX CPU instructions. For optimal performance, you should build your Pony installation from source.
 
+## Linux using an AppImage package (via Bintray)
+
+For most Linux distributions released after RHEL 7, the `release` builds are packaged and available on Bintray ([pony-language/ponylang-appimage](https://bintray.com/pony-language/ponylang-appimage)) as an AppImage.
+
+The AppImage (www.appimage.org) format allow for an easy ability to use applications with minimal clutter added to your system. The applications are available in a single file and can be run after they're made executable. Additionally, AppImages allow for multiple versions of Pony to be used side by with with no conflicts.
+
+To install builds via AppImage, you need to go to Bintray and download the appropriate file for the version you want. After the file is downloaded, you need to make it executable using `chmod`.
+
+### DEB and AVX2 Support
+
+By default, the Pony AppImage package is compiled without support for AVX CPU instructions. For optimal performance, you should build your Pony installation from source.
+
 ## Linux using an RPM package (via COPR)
 
 For Red Hat, CentOS, Oracle Linux, Fedora Linux, or OpenSuSE, the `release` builds are packaged and available on COPR ([ponylang/ponylang](https://copr.fedorainfracloud.org/coprs/ponylang/ponylang/)).
@@ -147,38 +159,29 @@ zypper install ponyc
 
 By default, the Pony RPM package is compiled without support for AVX CPU instructions. For optimal performance, you should build your Pony installation from source.
 
-## Ubuntu Linux using a DEB package (via Launchpad PPA)
+## Ubuntu and Debian Linux using a DEB package (via Bintray)
 
-For Ubuntu Linux (Trusty, Xenial, Artful, Bionic, Cosmic), the `release` builds are packaged and available on Launchpad PPA ([ponylang/ponylang](https://launchpad.net/~ponylang/+archive/ubuntu/ponylang)).
+For Ubuntu and Debian Linux, the `release` builds are packaged and available on Bintray ([pony-language/ponylang-debian](https://bintray.com/pony-language/ponylang-debian)).
 
-To install builds via Apt:
+Install packages to allow `apt` to use a repository over HTTPS:
 
 ```bash
-add-apt-repository ppa:ponylang/ponylang
-apt-get update
-apt-get install ponyc
+sudo apt-get install \
+     apt-transport-https \
+     ca-certificates \
+     curl \
+     gnupg2 \
+     software-properties-common
 ```
 
-NOTE: For Trusty, you will need to manually compile/install `libpcre2` to use `regex` related functionality.
-
-### DEB and AVX2 Support
-
-By default, the Pony DEB package is compiled without support for AVX CPU instructions. For optimal performance, you should build your Pony installation from source.
-
-## Debian Linux using a DEB package (via Bintray)
-
-For Debian Linux, the `release` builds are packaged and available on Bintray ([pony-language/ponyc-debian](https://bintray.com/pony-language/ponyc-debian)).
-
-To install builds via Apt (and install Bintray's public key):
+Install builds via Apt (and install Ponylang's public key):
 
 ```bash
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2"
-echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "E04F0923 B3B48BDA"
+sudo add-apt-repository "deb https://dl.bintray.com/pony-language/ponylang-debian  $(lsb_release -cs) main"
 sudo apt-get update
 sudo apt-get -V install ponyc
 ```
-
-You may need to install `ponyc` (current) instead of `ponyc-release` (deprecated).  And if you have issues with package authentication you may need to comment out the `deb` line in `/etc/apt/sources.list`, do an update, and uncomment it again.  Feel free to ask for help if you have any problems!
 
 ### DEB and AVX2 Support
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -24,6 +24,15 @@ Before getting started, you will need a number for the version that you will be 
 
 * It passed all CI checks
 
+While not strictly necessary, it is recommended to ensure one of the following to confirm that packaging isn't broken:
+
+* Confirm that the last Travis CI daily cron triggered jobs ran successfully (https://travis-ci.org/ponylang/ponyc/builds)
+* Manually kick off a run via an "API request" using the "Trigger Build" functionality in the Travis Web UI and wait to confirm all the jobs run successfully (https://travis-ci.org/ponylang/ponyc/builds)
+
+Both of these go through the motions to build all the packages we normally create to confirm there aren't any issues. While this will not guarantee no errors in other parts of the "release" CI run, it does confirm that there will not be any packaging related errors.
+
+If these jobs are not passing, you should get the issues resolved prior to releasing as both DEB and RPM packaging work off of the tag in GitHub and any changes or fixes made after tagging will not be included and will require a new release to be tagged.
+
 ### Validate external services are functional
 
 We rely on both Travis CI and Appveyor as part of our release process. Both need to be up and functional in order to do a release. Check the status of each before starting a release. If either is reporting issues, push the release back a day or until whenever they both are reporting no problems.
@@ -31,8 +40,7 @@ We rely on both Travis CI and Appveyor as part of our release process. Both need
 * [Travis CI Status](https://www.traviscistatus.com)
 * [Appveyor Status](https://appveyor.statuspage.io)
 * [COPR Build System](https://status.fedoraproject.org/)
-* [Launchpad Buildfarm](https://twitter.com/launchpadstatus)
-
+* [Bintray Status](http://status.bintray.com)
 
 ### A GitHub issue exists for the release
 
@@ -107,12 +115,22 @@ Additionally, any breaking changes that require end users to change their code s
 
 During the time since you push to the release branch, Travis CI and Appveyor have been busy building release artifacts. This can take up to a couple hours depending on how busy they are. Periodically check bintray to see if the releases are there yet.
 
-* [Debian](https://bintray.com/pony-language/ponyc-debian/ponyc)
-* [Windows](https://bintray.com/pony-language/ponyc-win/ponyc)
+* [Travis CI](https://travis-ci.org/ponylang/ponyc/builds) (confirm that the Travis jobs for the `release` branch ran successfully)
+* [AppImage](https://bintray.com/pony-language/ponylang-appimage/ponyc)
+* [Debian](https://bintray.com/pony-language/ponylang-debian/ponyc)
 
 The pattern for releases is similar as what we previously saw. In the case of Deb, the version looks something like:
 
 `0.3.1`
+
+It is recommended to check the files for the Deb version to ensure that every distribution we support has a file successfully uploaded.
+
+For AppImage, the versions look something like:
+
+`0.3.1`
+
+* [Appveyor](https://ci.appveyor.com/project/ponylang/ponyc/history) (confirm that Appveyor jobs ran successfully for at least the LLVM 3.9.1/Release job)
+* [Windows](https://bintray.com/pony-language/ponyc-win/ponyc)
 
 For windows, the versions look something like:
 
@@ -120,20 +138,15 @@ For windows, the versions look something like:
 
 where the `1526` is the AppVeyor build number and the `8a8ee28` is the abbreviated SHA for the commit we built from.
 
-### Wait on COPR/PPA
+### Wait on COPR
 
-The Travis CI build for the release branch kicks off packaging builds on Fedora COPR and Ubuntu Launchpad PPA. These packaging builds can take some time but are usually quick. Periodically check to see if the releases are finished and published on these site:
+The Travis CI build for the release branch kicks off packaging builds on Fedora COPR. These packaging builds can take some time but are usually quick. Periodically check to see if the releases are finished and published on this site:
 
 * [Fedora COPR](https://copr.fedorainfracloud.org/coprs/ponylang/ponylang/builds/)
-* [Ubuntu Launchpad PPA](https://launchpad.net/~ponylang/+archive/ubuntu/ponylang/+packages)
 
-The pattern for packaging release builds is similar as what we previously saw. In the case of Fedora COPR, the version looks something like:
+The pattern for packaging release builds is similar as what we previously saw. The version looks something like:
 
 `0.3.1-1.fc27` (confirm `status` is `succeeded`)
-
-The pattern for packaging release builds is similar as what we previously saw. In the case of Ubuntu Launchpad PPA, the versions looks something like:
-
-`ponyc - 0.3.1-0ppa1~<UBUNTU DISTRIBUTION NAME>` (confirm `build status` is a green checkmark)
 
 ### Wait on Homebrew
 


### PR DESCRIPTION
This commit removes the recently added Launchpad PPA generation now
that the new Bintray DEB packages are successfully building during
releases. The README is updated to direct users to use the new
Bintray DEB packages instead of the Launchpad PPA packages. This
was done mainly because Launchpad PPA does not allow installing of
older versions once a new version is released.

This commit also includes the details regarding how to use the
AppImage package that is now cre0ated and uploaded to Bintray.