### PR TITLE
Fix skipped try-then clauses on return, break and continue statements

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -957,6 +957,12 @@ ast_t* ast_try_clause(ast_t* ast, size_t* clause)
         *clause = ast_index(last);
         return ast;
       }
+      case TK_NEW:
+      case TK_FUN:
+      case TK_BE:
+        // try clauses outside of the current constructor, function, behaviour
+        // are not considered
+        return NULL;
 
       default: {}
     }


### PR DESCRIPTION
`then` clauses could be skipped if the containing `try` expression was within a loop and the body or else clause contained a `continue` or `break` statements. Also if the `try` was somehow nested into another `try` and the body or else clause contained a `return` the `then` clause was skipped.

This has been solved by going up the AST and searching for all `then` clauses to generate.
 
fixes #2843