### PR TITLE
Fix validation of provides lists of object literals.

### DIFF
--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -639,9 +639,8 @@ static bool catch_up_provides(pass_opt_t* opt, ast_t* provides)
       return false;
 
     ast_t* def = (ast_t*)ast_data(child);
-    pony_assert(def != NULL);
 
-    if(!ast_passes_type(&def, opt, PASS_EXPR))
+    if(def != NULL && !ast_passes_type(&def, opt, PASS_EXPR))
       return false;
 
     child = ast_sibling(child);

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -220,7 +220,7 @@ static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
       if(ast_id(def) != TK_TRAIT && ast_id(def) != TK_INTERFACE)
       {
         ast_error(opt->check.errors, error_at,
-          "can only provide traits and interfaces");
+          "invalid provides type. Can only be interfaces, traits and intersects of those.");
         ast_error_continue(opt->check.errors, provides_type,
           "invalid type here");
         return false;
@@ -235,7 +235,7 @@ static bool flatten_provided_type(pass_opt_t* opt, ast_t* provides_type,
 
     default:
       ast_error(opt->check.errors, error_at,
-        "provides type may only be an intersect of traits and interfaces");
+        "invalid provides type. Can only be interfaces, traits and intersects of those.");
       ast_error_continue(opt->check.errors, provides_type, "invalid type here");
       return false;
   }

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1158,7 +1158,6 @@ static ast_result_t syntax_object(pass_opt_t* opt, ast_t* ast)
     return AST_ERROR;
 
   if(ast_id(provides) != TK_NONE && !check_provides_type(opt, provides, "provides"))
-
     return AST_ERROR;
 
   return AST_OK;

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1157,6 +1157,10 @@ static ast_result_t syntax_object(pass_opt_t* opt, ast_t* ast)
   if(!check_members(opt, members, DEF_ACTOR))
     return AST_ERROR;
 
+  if(ast_id(provides) != TK_NONE && !check_provides_type(opt, provides, "provides"))
+
+    return AST_ERROR;
+
   return AST_OK;
 }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -47,7 +47,7 @@ TEST_F(BadPonyTest, ClassInOtherClassProvidesList)
     "  new create(env: Env) =>\n"
     "    None";
 
-  TEST_ERRORS_1(src, "can only provide traits and interfaces");
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
 }
 
 TEST_F(BadPonyTest, TypeParamMissingForTypeInProvidesList)

--- a/test/libponyc/object.cc
+++ b/test/libponyc/object.cc
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "verify"))
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "verify", errs)); }
+
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "verify", errs)); }
+
+#define TEST_ERRORS_3(src, err1, err2, err3) \
+  { const char* errs[] = {err1, err2, err3, NULL}; \
+    DO(test_expected_errors(src, "verify", errs)); }
+
+class ObjectTest : public PassTest
+{};
+
+TEST_F(ObjectTest, ObjectProvidesClass)
+{
+   const char* src =
+    "class X1\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    let obj = object is X1 end\n";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+TEST_F(ObjectTest, ClassProvidesUnionOfInterfaces)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun i1()\n"
+    "interface I2\n"
+    "  fun i2()\n"
+    "\n"
+    "class X1 is (I1 | I2)\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    None\n";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+TEST_F(ObjectTest, ObjectProvidesUnionInterfaces)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun i1()\n"
+    "interface I2\n"
+    "  fun i2()\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    let obj = object is (I1 | I2) end";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+TEST_F(ObjectTest, ClassProvidesTypeAliasUnionInterfaces)
+{
+  const char* src =
+    "interface I1\n"
+    "interface I2\n"
+    "type T1000 is (I1 | I2)\n"
+    "\n"
+    "class X1 is T1000\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    None";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+TEST_F(ObjectTest, ObjectProvidesTypeAliasUnionInterfaces)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun i1()\n"
+    "interface I2\n"
+    "  fun i2()\n"
+    "type T1000 is (I1 | I2)\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    object is T1000 end";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+TEST_F(ObjectTest, ObjectProvidesTypeAliasUnionTraits)
+{
+  const char* src =
+    "trait T1\n"
+    "trait T2\n"
+    "type T3 is (T1 | T2)\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    object is T3 end";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+
+
+TEST_F(ObjectTest, ObjectProvidesNestedUnionTypeAliasProvides)
+{
+  const char* src =
+    "interface I1\n"
+    "  fun i1()\n"
+    "interface I2\n"
+    "  fun i2()\n"
+    "trait TR1\n"
+    "type T1 is (I1 | I2)\n"
+    "\n"
+    "actor Main\n"
+    "  new create(e: Env) =>\n"
+    "    let obj = object is (TR1 & T1)end";
+  TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
+}
+


### PR DESCRIPTION
Previously using a type alias pointing to a UNION type in the provides list of an object literal made the compiler assert.

fixes #2829 

There is still a missing case where one would in general expect a compiler error, but nothing is thrown: Having a union of subtypes behind a type-alias:

```pony
interface I1
interface I2

type T1 is (I1 | I2)

actor Main
  new env(e: Env) =>
    object is T1 end
```

By the time the object AST is resolved the union folding already kicked in, so `T1` only resolves to `I1`, not a union anymore. I am unsure what to do about this. Is this really a case that we should care about?