### PR TITLE
Fix losing data when reading from STDIN.

### DIFF
--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -157,7 +157,7 @@ actor Stdin
         var again: Bool = false
 
         let len =
-          @pony_os_stdin_read[USize](data.cpointer(), data.space(),
+          @pony_os_stdin_read[USize](data.cpointer(), data.size(),
             addressof again)
 
         match len


### PR DESCRIPTION
The current implementation fills the full underlying array based on the
"space" available.

However, the space may be larger than the chunk size since space is
allocated in powers of two. However, when the data buffer is passed back
via the InputNotify handle it is first appropriately truncated to the
actual `len` read by @pony_os_stdin_read. But, the implementation of
truncate sets the size to max(len, size) and does not take into account
the underlying allocated space.

The net result is that reading of stdin looses data unless the chunk
size provided is actually a power of two — in which case
`_size == _alloc`.

This change simply limits the read to `data.size()` rather than
`data.space()`.

Please see: https://github.com/ponylang/ponyc/issues/2871.