### PR TITLE
Fix compilation warning on windows.

### DIFF
--- a/src/libponyc/codegen/gendebug.cc
+++ b/src/libponyc/codegen/gendebug.cc
@@ -81,7 +81,7 @@ LLVMMetadataRef LLVMDIBuilderCreateCompileUnit(LLVMDIBuilderRef d,
   return wrap(pd->createCompileUnit(lang, difile, producer,
     optimized ? true : false, flags, runtimever));
 #else
-  return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized,
+  return wrap(pd->createCompileUnit(lang, file, dir, producer, optimized ? true : false,
     flags, runtimever, StringRef())); // use the defaults
 #endif
 }


### PR DESCRIPTION
Existing code results in a warning, and since warnings are treated as errors, the compilation fails.