### PR TITLE
Add divc method to integer types

### DIFF
--- a/packages/builtin/_partial_arithmetic.pony
+++ b/packages/builtin/_partial_arithmetic.pony
@@ -15,7 +15,7 @@ trait _PartialArithmetic
 primitive _UnsignedPartialArithmetic is _PartialArithmetic
 
   fun div_checked[T: _UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
-    (x /~ y, (y == T.from[U8](0)))
+    (x / y, (y == T.from[U8](0)))
 
   fun div_partial[T: _UnsignedInteger[T] val](x: T, y: T): T? =>
     if (y == T.from[U8](0)) then
@@ -41,7 +41,7 @@ primitive _UnsignedPartialArithmetic is _PartialArithmetic
 primitive _SignedPartialArithmetic is _PartialArithmetic
 
   fun div_checked[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
-    (x /~ y, (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())))
+    (x / y, (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())))
 
   fun div_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): T? =>
     if (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())) then

--- a/packages/builtin/_partial_arithmetic.pony
+++ b/packages/builtin/_partial_arithmetic.pony
@@ -13,6 +13,10 @@ trait _PartialArithmetic
     if overflow then error else r end
 
 primitive _UnsignedPartialArithmetic is _PartialArithmetic
+
+  fun div_checked[T: _UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
+    (x /~ y, (y == T.from[U8](0)))
+
   fun div_partial[T: _UnsignedInteger[T] val](x: T, y: T): T? =>
     if (y == T.from[U8](0)) then
       error
@@ -35,6 +39,9 @@ primitive _UnsignedPartialArithmetic is _PartialArithmetic
     end
 
 primitive _SignedPartialArithmetic is _PartialArithmetic
+
+  fun div_checked[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
+    (x /~ y, (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())))
 
   fun div_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): T? =>
     if (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())) then

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -294,6 +294,11 @@ trait val Integer[A: Integer[A] val] is Real[A]
     """
     Multiply `y` with this integer and return the result and a flag indicating overflow.
     """
+  fun divc(y: A): (A, Bool)
+    """
+    Divide this integer by `y` and return the result and a flag indicating overflow or division by zero.
+    """
+
   fun op_and(y: A): A => this and y
   fun op_or(y: A): A => this or y
   fun op_xor(y: A): A => this xor y

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -40,6 +40,9 @@ primitive I8 is _SignedInteger[I8, U8]
   fun mulc(y: I8): (I8, Bool) =>
     @"llvm.smul.with.overflow.i8"[(I8, Bool)](this, y)
 
+  fun divc(y: I8): (I8, Bool) =>
+    _SignedPartialArithmetic.div_checked[I8, U8](this, y)
+
   fun add_partial(y: I8): I8 ? =>
     _SignedPartialArithmetic.add_partial[I8](this, y)?
 
@@ -99,6 +102,9 @@ primitive I16 is _SignedInteger[I16, U16]
 
   fun mulc(y: I16): (I16, Bool) =>
     @"llvm.smul.with.overflow.i16"[(I16, Bool)](this, y)
+
+  fun divc(y: I16): (I16, Bool) =>
+    _SignedPartialArithmetic.div_checked[I16, U16](this, y)
 
   fun add_partial(y: I16): I16 ? =>
     _SignedPartialArithmetic.add_partial[I16](this, y)?
@@ -161,6 +167,9 @@ primitive I32 is _SignedInteger[I32, U32]
   fun mulc(y: I32): (I32, Bool) =>
     @"llvm.smul.with.overflow.i32"[(I32, Bool)](this, y)
 
+  fun divc(y: I32): (I32, Bool) =>
+    _SignedPartialArithmetic.div_checked[I32, U32](this, y)
+
   fun add_partial(y: I32): I32 ? =>
     _SignedPartialArithmetic.add_partial[I32](this, y)?
 
@@ -221,6 +230,9 @@ primitive I64 is _SignedInteger[I64, U64]
 
   fun mulc(y: I64): (I64, Bool) =>
     _SignedCheckedArithmetic._mulc[U64, I64](this, y)
+
+  fun divc(y: I64): (I64, Bool) =>
+    _SignedPartialArithmetic.div_checked[I64, U64](this, y)
 
   fun add_partial(y: I64): I64 ? =>
     _SignedPartialArithmetic.add_partial[I64](this, y)?
@@ -335,6 +347,9 @@ primitive ILong is _SignedInteger[ILong, ULong]
       _SignedCheckedArithmetic._mulc[ULong, ILong](this, y)
     end
 
+  fun divc(y: ILong): (ILong, Bool) =>
+    _SignedPartialArithmetic.div_checked[ILong, ULong](this, y)
+
   fun add_partial(y: ILong): ILong ? =>
     _SignedPartialArithmetic.add_partial[ILong](this, y)?
 
@@ -446,6 +461,9 @@ primitive ISize is _SignedInteger[ISize, USize]
     else
       _SignedCheckedArithmetic._mulc[USize, ISize](this, y)
     end
+
+  fun divc(y: ISize): (ISize, Bool) =>
+    _SignedPartialArithmetic.div_checked[ISize, USize](this, y)
 
   fun add_partial(y: ISize): ISize ? =>
     _SignedPartialArithmetic.add_partial[ISize](this, y)?
@@ -654,6 +672,9 @@ primitive I128 is _SignedInteger[I128, U128]
     // the following implementation is more or less exactly was __muloti4 is
     // doing
     _SignedCheckedArithmetic._mulc[U128, I128](this, y)
+
+  fun divc(y: I128): (I128, Bool) =>
+    _SignedPartialArithmetic.div_checked[I128, U128](this, y)
 
   fun add_partial(y: I128): I128 ? =>
     _SignedPartialArithmetic.add_partial[I128](this, y)?

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -43,6 +43,9 @@ primitive U8 is _UnsignedInteger[U8]
   fun mulc(y: U8): (U8, Bool) =>
     @"llvm.umul.with.overflow.i8"[(U8, Bool)](this, y)
 
+  fun divc(y: U8): (U8, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[U8](this, y)
+
   fun add_partial(y: U8): U8 ? =>
     _UnsignedPartialArithmetic.add_partial[U8](this, y)?
 
@@ -106,6 +109,9 @@ primitive U16 is _UnsignedInteger[U16]
   fun mulc(y: U16): (U16, Bool) =>
     @"llvm.umul.with.overflow.i16"[(U16, Bool)](this, y)
 
+  fun divc(y: U16): (U16, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[U16](this, y)
+
   fun add_partial(y: U16): U16 ? =>
     _UnsignedPartialArithmetic.add_partial[U16](this, y)?
 
@@ -168,6 +174,9 @@ primitive U32 is _UnsignedInteger[U32]
 
   fun mulc(y: U32): (U32, Bool) =>
     @"llvm.umul.with.overflow.i32"[(U32, Bool)](this, y)
+
+  fun divc(y: U32): (U32, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[U32](this, y)
 
   fun add_partial(y: U32): U32 ? =>
     _UnsignedPartialArithmetic.add_partial[U32](this, y)?
@@ -238,6 +247,9 @@ primitive U64 is _UnsignedInteger[U64]
 
   fun mulc(y: U64): (U64, Bool) =>
     @"llvm.umul.with.overflow.i64"[(U64, Bool)](this, y)
+
+  fun divc(y: U64): (U64, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[U64](this, y)
 
   fun add_partial(y: U64): U64 ? =>
     _UnsignedPartialArithmetic.add_partial[U64](this, y)?
@@ -365,6 +377,9 @@ primitive ULong is _UnsignedInteger[ULong]
       @"llvm.umul.with.overflow.i64"[(ULong, Bool)](this, y)
     end
 
+  fun divc(y: ULong): (ULong, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[ULong](this, y)
+
   fun add_partial(y: ULong): ULong ? =>
     _UnsignedPartialArithmetic.add_partial[ULong](this, y)?
 
@@ -483,6 +498,9 @@ primitive USize is _UnsignedInteger[USize]
     else
       @"llvm.umul.with.overflow.i64"[(USize, Bool)](this, y)
     end
+
+  fun divc(y: USize): (USize, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[USize](this, y)
 
   fun add_partial(y: USize): USize ? =>
     _UnsignedPartialArithmetic.add_partial[USize](this, y)?
@@ -756,6 +774,9 @@ primitive U128 is _UnsignedInteger[U128]
       let overflow = (this != 0) and ((result / this) != y)
       (result, overflow)
     end
+
+  fun divc(y: U128): (U128, Bool) =>
+    _UnsignedPartialArithmetic.div_checked[U128](this, y)
 
   fun add_partial(y: U128): U128 ? =>
     _UnsignedPartialArithmetic.add_partial[U128](this, y)?

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -70,6 +70,7 @@ actor Main is TestList
     test(_TestAddc)
     test(_TestSubc)
     test(_TestMulc)
+    test(_TestDivc)
     test(_TestSignedPartialArithmetic)
     test(_TestUnsignedPartialArithmetic)
     test(_TestNextPow2)
@@ -1565,6 +1566,13 @@ trait iso SafeArithmeticTest is UnitTest
     h.assert_eq[A](expected._1, actual._1 where loc=loc)
     h.assert_eq[Bool](expected._2, actual._2 where loc=loc)
 
+  fun test_overflow[A: (Equatable[A] #read & Stringable #read)](
+    h: TestHelper,
+    actual: (A, Bool),
+    loc: SourceLoc = __loc)
+  =>
+    h.assert_eq[Bool](true, actual._2)
+
 class iso _TestAddc is SafeArithmeticTest
   """
   Test addc on various bit widths.
@@ -1775,6 +1783,63 @@ class iso _TestMulc is SafeArithmeticTest
       I128(0x4000_0000_0000_0000_0000_0000_0000_0000).mulc(-2))
     test[I128](h, (0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe,  true),
       I128(0x4000_0000_0000_0000_0000_0000_0000_0001).mulc(-2))
+
+class iso _TestDivc is SafeArithmeticTest
+  fun name(): String => "builtin/Divc"
+
+  fun apply(h: TestHelper) =>
+    test[U8](h, (0x20, false), U8(0x40).divc(2))
+    test_overflow[U8](h, U8(0x40).divc(0))
+
+    test[U16](h, (0x20, false), U16(0x40).divc(2))
+    test_overflow[U16](h, U16(0x40).divc(0))
+
+    test[U32](h, (0x20, false), U32(0x40).divc(2))
+    test_overflow[U32](h, U32(0x40).divc(0))
+
+    test[U64](h, (0x20, false), U64(0x40).divc(2))
+    test_overflow[U64](h, U64(0x40).divc(0))
+
+    test[ULong](h, (0x20, false), ULong(0x40).divc(2))
+    test_overflow[ULong](h, ULong(0x40).divc(0))
+
+    test[USize](h, (0x20, false), USize(0x40).divc(2))
+    test_overflow[USize](h, USize(0x40).divc(0))
+
+    test[U128](h, (0x20, false), U128(0x40).divc(2))
+    test_overflow[U128](h, U128(0x40).divc(0))
+
+    test[I8](h, (0x20, false), I8(0x40).divc(2))
+    test_overflow[I8](h, I8(0x40).divc(0))
+    test_overflow[I8](h, I8.min_value().divc(I8(-1)))
+
+    test[I16](h, (0x20, false), I16(0x40).divc(2))
+    test_overflow[I16](h, I16(0x40).divc(0))
+    test_overflow[I16](h, I16.min_value().divc(I16(-1)))
+
+    test[I32](h, (0x20, false), I32(0x40).divc(2))
+    test_overflow[I32](h, I32(0x40).divc(0))
+    test_overflow[I32](h, I32.min_value().divc(I32(-1)))
+
+    test[I32](h, (0x20, false), I32(0x40).divc(2))
+    test_overflow[I32](h, I32(0x40).divc(0))
+    test_overflow[I32](h, I32.min_value().divc(I32(-1)))
+
+    test[I64](h, (0x20, false), I64(0x40).divc(2))
+    test_overflow[I64](h, I64(0x40).divc(0))
+    test_overflow[I64](h, I64.min_value().divc(I64(-1)))
+
+    test[ILong](h, (0x20, false), ILong(0x40).divc(2))
+    test_overflow[ILong](h, ILong(0x40).divc(0))
+    test_overflow[ILong](h, ILong.min_value().divc(ILong(-1)))
+
+    test[ISize](h, (0x20, false), ISize(0x40).divc(2))
+    test_overflow[ISize](h, ISize(0x40).divc(0))
+    test_overflow[ISize](h, ISize.min_value().divc(ISize(-1)))
+
+    test[I128](h, (0x20, false), I128(0x40).divc(2))
+    test_overflow[I128](h, I128(0x40).divc(0))
+    test_overflow[I128](h, I128.min_value().divc(I128(-1)))
 
 primitive _CommonPartialArithmeticTests[T: (Integer[T] val & Int)]
   fun apply(h: TestHelper)? =>


### PR DESCRIPTION
This is added in order to provide all basic operators as unsafe, normal, partial and checked version.

`modc` is following.