### PR TITLE
Correctly handle modifier keys for TTY stdin on Windows

### DIFF
--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -212,6 +212,10 @@ static bool add_input_record(char* buffer, size_t space, size_t *len,
           &rec->Event.KeyEvent.uChar.UnicodeChar, 1, out, 4,
           NULL, NULL);
       }
+      else
+      {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
Standard input on Windows was hanging when a modifier key (CTRL, ALT or SHIFT) was pressed.  This change correctly handles the console keydown event where there is no actual character value.

Fixes #2891