### PR TITLE
Improved CHAMP map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Fix hash collision handling in persistent map ([PR #2894](https://github.com/ponylang/ponyc/pull/2894))
 - Correctly handle modifier keys for TTY stdin on Windows ([PR #2892](https://github.com/ponylang/ponyc/pull/2892))
 - Fix installation of libponyrt.bc on Linux ([PR #2893](https://github.com/ponylang/ponyc/pull/2893))
-- Fix hash collision handling in persistent map ([PR #2894](https://github.com/ponylang/ponyc/pull/2894))
 - Fix compilation warning on windows. ([PR #2877](https://github.com/ponylang/ponyc/pull/2877))
 - Fix building on Windows in a directory with spaces in its name ([PR #2879](https://github.com/ponylang/ponyc/pull/2879))
 - Fix losing data when reading from STDIN. ([PR #2872](https://github.com/ponylang/ponyc/pull/2872))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Correctly handle modifier keys for TTY stdin on Windows ([PR #2892](https://github.com/ponylang/ponyc/pull/2892))
 - Fix installation of libponyrt.bc on Linux ([PR #2893](https://github.com/ponylang/ponyc/pull/2893))
+- Fix hash collision handling in persistent map ([PR #2894](https://github.com/ponylang/ponyc/pull/2894))
 - Fix compilation warning on windows. ([PR #2877](https://github.com/ponylang/ponyc/pull/2877))
 - Fix building on Windows in a directory with spaces in its name ([PR #2879](https://github.com/ponylang/ponyc/pull/2879))
 - Fix losing data when reading from STDIN. ([PR #2872](https://github.com/ponylang/ponyc/pull/2872))
@@ -28,7 +29,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
--  Use RLIMIT_STACK's current limit for Pthreads stack size if it is sane ([PR #2852](https://github.com/ponylang/ponyc/pull/2852))
+- Improved CHAMP map ([PR #2894](https://github.com/ponylang/ponyc/pull/2894))
+- Use RLIMIT_STACK's current limit for Pthreads stack size if it is sane ([PR #2852](https://github.com/ponylang/ponyc/pull/2852))
 - Remove `File.line` method in favor of using `FileLines` ([PR #2707](https://github.com/ponylang/ponyc/pull/2707))
 
 ## [0.24.4] - 2018-07-29
@@ -427,7 +429,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Alpine Linux compatibility for pony ([PR #1844](https://github.com/ponylang/ponyc/pull/1844))
-- Add cli package implementing the CLI syntax ([RFC #38](https://github.com/ponylang/rfcs/blob/master/text/0038-cli-format.md)) 
+- Add cli package implementing the CLI syntax ([RFC #38](https://github.com/ponylang/rfcs/blob/master/text/0038-cli-format.md))
    - Initial ([PR #1897](https://github.com/ponylang/ponyc/pull/1897)) implemented the full RFC and contained:
       - Enhanced Posix / GNU program argument syntax.
       - Commands and sub-commands.

--- a/packages/collections/persistent/_bits.pony
+++ b/packages/collections/persistent/_bits.pony
@@ -1,15 +1,20 @@
 primitive _Bits
+  fun collision_depth(): U32 => 6
+
   fun set_bit(bm: U32, i: U32): U32 =>
     bm or (U32(1) <<~ i)
 
   fun clear_bit(bm: U32, i: U32): U32 =>
     bm and (not (U32(1) <<~ i))
 
-  fun has_bit(bm: U32, i: U32): Bool =>
+  fun check_bit(bm: U32, i: U32): Bool =>
     (bm and (U32(1) <<~ i)) != 0
 
+  fun mask32(n: U32, d: U32): U32 =>
+    (n >> (d *~ 5)) and 0b11111
+
   fun mask(n: USize, d: USize): USize =>
-    (n >> (d *~ 5)) and 0x01f
+    (n >> (d *~ 5)) and 0b11111
 
   fun next_pow32(n: USize): USize =>
     USize(32) << (n *~ 5)

--- a/packages/collections/persistent/_map_node.pony
+++ b/packages/collections/persistent/_map_node.pony
@@ -11,16 +11,6 @@ class val _MapEntry[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
   fun apply(k: K): (V | None) =>
     if H.eq(k, key) then value end
 
-  // fun _debug(): String iso^ =>
-  //   recover
-  //     String
-  //       .> append("(")
-  //       .> append(iftype K <: Stringable val then key.string() else "?" end)
-  //       .> append(", ")
-  //       .> append(iftype V <: Stringable val then value.string() else "?" end)
-  //       .> append(")")
-  //   end
-
 class val _MapCollisions[
   K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
 
@@ -99,11 +89,6 @@ class val _MapCollisions[
         e
     end
 
-  // fun _debug(): String iso^ =>
-  //   let strs = [as Stringable: "<"]
-  //   for bin in bins.values() do strs.push("[" + bin.size().string() + "]") end
-  //   " ".join(strs .> push(">") .values())
-
 type _MapNode[K: Any #share, V: Any #share, H: mut.HashFunction[K] val] is
   ( _MapEntry[K, V, H]
   | _MapCollisions[K, V, H]
@@ -143,7 +128,6 @@ class val _MapSubNodes[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     | let cs: _MapCollisions[K, V, H] box => cs(hash, k)?
     end
 
-  // TODO: compact on remove
   fun val remove(depth: U32, hash: U32, k: K): _MapSubNodes[K, V, H] ? =>
     let idx = _Bits.mask32(hash, depth)
     let c_idx = compressed_idx(idx)
@@ -270,24 +254,3 @@ class val _MapSubNodes[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
         | let cs: _MapCollisions[K, V, H] => cs.iter()
         end
     end
-
-  // fun val _debug_path(depth: U32, hash: U32) =>
-  //   let idx = _Bits.mask32(hash, depth)
-  //   let c_idx = compressed_idx(idx).usize()
-  //   let strs = [as Stringable: "{"]
-  //   for (i, node) in nodes.pairs() do
-  //     strs.push(
-  //       match node
-  //       | let e: _MapEntry[K, V, H] => e._debug()
-  //       | let ns: _MapSubNodes[K, V, H] =>
-  //         if i == c_idx then "**" else "{}" end
-  //       | let cs: _MapCollisions[K, V, H] =>
-  //         if i == c_idx then cs._debug() else "<>" end
-  //       end)
-  //   end
-  //   Debug(strs .> push("}"), " ")
-  //   try
-  //     match nodes(c_idx)?
-  //     | let ns: _MapSubNodes[K, V, H] => ns._debug_path(depth+1, hash)
-  //     end
-  //   end

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -272,7 +272,20 @@ class iso _TestMap is UnitTest
 
     let seed = Time.millis()
     h.log("seed: " + seed.string())
-    gen_test(h, Rand(seed))?
+    let rand = Rand(seed)
+
+    var map = Map[USize, None]
+    for n in mut.Range(0, 100) do
+      try
+        map(USize.max_value())?
+      else
+        h.fail()
+        return
+      end
+      map = map.update(rand.int[USize](USize.max_value() - 1), None)
+    end
+
+    gen_test(h, rand)?
 
   fun gen_test(h: TestHelper, rand: Rand) ? =>
     var a = _Map

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -275,7 +275,7 @@ class iso _TestMap is UnitTest
     gen_test(h, Rand(seed))?
 
   fun gen_test(h: TestHelper, rand: Rand) ? =>
-    var a = TestMap
+    var a = _Map
     let b = mut.Map[U64, U64]
 
     let ops = gen_ops(1000, rand)?
@@ -292,8 +292,8 @@ class iso _TestMap is UnitTest
       h.assert_eq[USize](n, a.size())
     end
 
-  fun gen_ops(n: USize, rand: Rand): Array[Op] ? =>
-    let ops = Array[Op](n)
+  fun gen_ops(n: USize, rand: Rand): Array[_TestOp] ? =>
+    let ops = Array[_TestOp](n)
     let keys = Array[U64](n)
     for v in mut.Range[U64](0, n.u64()) do
       let op_n = if keys.size() == 0 then 0 else rand.int[U64](4) end
@@ -303,31 +303,31 @@ class iso _TestMap is UnitTest
           // insert
           let k = rand.u64()
           keys.push(k)
-          MapUpdate(k, v)
+          _OpMapUpdate(k, v)
         | 2 =>
           // update
           let k = keys(rand.int[USize](keys.size()))?
-          MapUpdate(k, v)
+          _OpMapUpdate(k, v)
         | 3 =>
           // remove
           let k = keys.delete(rand.int[USize](keys.size()))?
-          MapRemove(k)
+          _OpMapRemove(k)
         else error
         end)
     end
     ops
 
-type TestMap is HashMap[U64, U64, CollisionHash]
+type _Map is HashMap[U64, U64, CollisionHash]
 
 primitive CollisionHash is mut.HashFunction[U64]
   fun hash(x: U64): USize => x.usize() % 100
   fun eq(x: U64, y: U64): Bool => x == y
 
-interface val Op
-  fun apply(a: TestMap, b: mut.Map[U64, U64]): TestMap ?
+interface val _TestOp
+  fun apply(a: _Map, b: mut.Map[U64, U64]): _Map ?
   fun str(): String
 
-class val MapUpdate
+class val _OpMapUpdate
   let k: U64
   let v: U64
 
@@ -335,20 +335,20 @@ class val MapUpdate
     k = k'
     v = v'
 
-  fun apply(a: TestMap, b: mut.Map[U64, U64]): TestMap =>
+  fun apply(a: _Map, b: mut.Map[U64, U64]): _Map =>
     b.update(k, v)
     a(k) = v
 
   fun str(): String =>
     "".join(["Update("; k; "_"; CollisionHash.hash(k); ", "; v; ")"].values())
 
-class val MapRemove
+class val _OpMapRemove
   let k: U64
 
   new val create(k': U64) =>
     k = k'
 
-  fun apply(a: TestMap, b: mut.Map[U64, U64]): TestMap ? =>
+  fun apply(a: _Map, b: mut.Map[U64, U64]): _Map ? =>
     b.remove(k)?
     a.remove(k)?
 

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -278,7 +278,7 @@ class iso _TestMap is UnitTest
     var a = _Map
     let b = mut.Map[U64, U64]
 
-    let ops = gen_ops(1000, rand)?
+    let ops = gen_ops(300, rand)?
     for op in ops.values() do
       h.log(op.str())
       let prev = a

--- a/packages/collections/persistent/benchmarks/main.pony
+++ b/packages/collections/persistent/benchmarks/main.pony
@@ -10,13 +10,15 @@ actor Main is BenchmarkList
     PonyBench(env, this)
 
   fun tag benchmarks(bench: PonyBench) =>
-    for n in mut.Range(0, 14, 2) do
+    let max_shift: USize = 8
+
+    for n in mut.Range(0, max_shift + 1, 2) do
       bench(MapApply(32 << n))
     end
-    for n in mut.Range(0, 14, 2) do
+    for n in mut.Range(0, max_shift + 1, 2) do
       bench(MapUpdate(32 << n))
     end
-    for n in mut.Range(0, 14, 2) do
+    for n in mut.Range(0, max_shift + 1, 2) do
       bench(MapIter(32 << n))
     end
 

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -35,14 +35,14 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
       end
   ```
   """
-  let _root: _MapNode[K, V, H]
+  let _root: _MapSubNodes[K, V, H]
   let _size: USize
 
   new val create() =>
-    _root = _MapNode[K, V, H].empty(0)
+    _root = _MapSubNodes[K, V, H]
     _size = 0
 
-  new val _create(r: _MapNode[K, V, H], s: USize) =>
+  new val _create(r: _MapSubNodes[K, V, H], s: USize) =>
     _root = r
     _size = s
 
@@ -50,7 +50,7 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     """
     Attempt to get the value corresponding to k.
     """
-    _root(H.hash(k), k)?
+    _root(0, H.hash(k).u32(), k)? as V
 
   fun val size(): USize =>
     """
@@ -64,7 +64,7 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     """
     (let r, let insertion) =
       try
-        _root.update(H.hash(key), (key, value))?
+        _root.put(0, H.hash(key).u32(), key, value)?
       else
         (_root, false) // should not occur
       end
@@ -75,7 +75,7 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     """
     Try to remove the provided key from the Map.
     """
-    _create(_root.remove(H.hash(k), k)?, _size - 1)
+    _create(_root.remove(0, H.hash(k).u32(), k)?, _size - 1)
 
   fun val get_or_else(k: K, alt: val->V): val->V =>
     """
@@ -83,20 +83,20 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     return the provided alternate value.
     """
     try
-      apply(k)?
+      match _root(0, H.hash(k).u32(), k)?
+      | let v: V => v
+      else alt
+      end
     else
-      alt
+      alt // should not occur
     end
 
   fun val contains(k: K): Bool =>
     """
     Check whether the node contains the provided key.
     """
-    try
-      apply(k)?
-      true
-    else
-      false
+    try _root(0, H.hash(k).u32(), k)? isnt None
+    else false // should not occur
     end
 
   fun val concat(iter: Iterator[(val->K, val->V)]): HashMap[K, V, H] =>
@@ -115,7 +115,7 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
 
   fun val pairs(): MapPairs[K, V, H] => MapPairs[K, V, H](this)
 
-  fun _root_node(): _MapNode[K, V, H] => _root
+  fun _root_node(): _MapSubNodes[K, V, H] => _root
 
 class MapKeys[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
   embed _pairs: MapPairs[K, V, H]
@@ -135,62 +135,25 @@ class MapValues[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
 
   fun ref next(): val->V ? => _pairs.next()?._2
 
+interface _MapIter[K: Any #share, V: Any #share, H: mut.HashFunction[K] val] is
+  Iterator[(_MapEntry[K, V, H] | _MapIter[K, V, H])]
+
 class MapPairs[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
-  embed _path: Array[_MapNode[K, V, H]]
-  embed _idxs: Array[USize]
-  var _i: USize = 0
-  let _size: USize
-  var _ci: USize = 0
+  embed _stack: Array[_MapIter[K, V, H]] = []
 
   new create(m: HashMap[K, V, H]) =>
-    _size = m.size()
-    _path = Array[_MapNode[K, V, H]]
-    _path.push(m._root_node())
-    _idxs = Array[USize]
-    _idxs.push(0)
+    _stack.push(m._root_node().iter())
 
-  fun has_next(): Bool => _i < _size
+  fun has_next(): Bool =>
+    _stack.size() > 0
 
-  fun ref next(): (K, val->V) ? =>
-    (let n, let i) = _cur()?
-    if i >= n.entries().size() then
-      _backup()?
-      return next()?
-    end
-    match n.entries()(i)?
-    | let l: _MapLeaf[K, V, H] =>
-      _inc_i()?
-      _i = _i + 1
-      l
-    | let sn: _MapNode[K, V, H] =>
-      _push(sn)
+  fun ref next(): (K, V) ? =>
+    let iter = _stack(_stack.size() - 1)?
+    let x = iter.next()?
+    if not iter.has_next() then _stack.pop()? end
+    match x
+    | let e: _MapEntry[K, V, H] => (e.key, e.value)
+    | let i: _MapIter[K, V, H] =>
+      _stack.push(i)
       next()?
-    | let cs: _MapCollisions[K, V, H] =>
-      if _ci < cs.size() then
-        let l = cs(_ci)?
-        _ci = _ci + 1
-        _i = _i + 1
-        l
-      else
-        _ci = 0
-        _inc_i()?
-        next()?
-      end
     end
-
-  fun ref _push(n: _MapNode[K, V, H]) =>
-    _path.push(n)
-    _idxs.push(0)
-
-  fun ref _backup() ? =>
-    _path.pop()?
-    _idxs.pop()?
-    _inc_i()?
-
-  fun ref _inc_i() ? =>
-    let i = _idxs.size() - 1
-    _idxs(i)? = _idxs(i)? + 1
-
-  fun _cur(): (_MapNode[K, V, H], USize) ? =>
-    let i = _idxs.size() - 1
-    (_path(i)?, _idxs(i)?)

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -64,7 +64,7 @@ class val HashMap[K: Any #share, V: Any #share, H: mut.HashFunction[K] val]
     """
     (let r, let insertion) =
       try
-        _root.put(0, H.hash(key).u32(), key, value)?
+        _root.update(0, H.hash(key).u32(), key, value)?
       else
         (_root, false) // should not occur
       end


### PR DESCRIPTION
This PR includes modifications to the persistent hash map which have also resulted in a fix for #2866. The improvements include removing the `U8` level field from all nodes and applying full CHAMP compression to the entries at each node.