### PR TITLE
Fix invalid allocation bug in runtime that allows for segfaults

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -1052,5 +1052,9 @@ size_t ponyint_pool_adjust_size(size_t size)
   if((size & POOL_ALIGN_MASK) != 0)
     size = (size & ~POOL_ALIGN_MASK) + POOL_ALIGN;
 
+  // we've overflowed the `size_t` datatype
+  if(size == 0)
+    size = size - 1;
+
   return size;
 }


### PR DESCRIPTION
Thanks to @malte for identifying the root cause of #2013.

This PR fixes things so that if there's a request for a `size_t`
sized allocation, it actually tries to allocate it instead of
pretending that it allocated it while not actually allocating
anything which results in memory clobbering and segfaults.

resolves #2013