### PR TITLE
Add before/after iteration hooks to ponybench

### DIFF
--- a/packages/buffered/benchmarks/main.pony
+++ b/packages/buffered/benchmarks/main.pony
@@ -8,11 +8,8 @@ actor Main is BenchmarkList
 
   fun tag benchmarks(bench: PonyBench) =>
     bench(_ReaderU8)
-    bench(_ReaderU8Samples)
     bench(_ReaderU16LE)
-    bench(_ReaderU16LESamples)
     bench(_ReaderU16LESplit)
-    bench(_ReaderU16LESplitSamples)
     bench(_ReaderU16BE)
     bench(_ReaderU16BESplit)
     bench(_ReaderU32LE)
@@ -55,28 +52,6 @@ class iso _ReaderU8 is MicroBenchmark
     DoNotOptimise[U8](_d.u8()?)
     DoNotOptimise.observe()
 
-class iso _ReaderU8Samples is MicroBenchmark
-  // Benchmark reading U8
-  let _d: Reader = _d.create()
-  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
-
-  fun name(): String =>
-    "_ReaderU8Samples"
-
-  fun config(): BenchConfig =>
-    // run for 1_000_000 samples of 1 iteration each
-    BenchConfig(1_000_000, 1)
-
-  fun ref before() =>
-    if _d.size() < 2 then
-      _d.clear()
-      _d.append(_b)
-    end
-
-  fun ref apply()? =>
-    DoNotOptimise[U8](_d.u8()?)
-    DoNotOptimise.observe()
-
 class iso _ReaderU16LE is MicroBenchmark
   // Benchmark reading Little Endian U16
   let _d: Reader = _d.create()
@@ -86,28 +61,6 @@ class iso _ReaderU16LE is MicroBenchmark
     "_ReaderU16LE"
 
   fun ref before_iteration() =>
-    if _d.size() < 2 then
-      _d.clear()
-      _d.append(_b)
-    end
-
-  fun ref apply()? =>
-    DoNotOptimise[U16](_d.u16_le()?)
-    DoNotOptimise.observe()
-
-class iso _ReaderU16LESamples is MicroBenchmark
-  // Benchmark reading Little Endian U16
-  let _d: Reader = _d.create()
-  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
-
-  fun name(): String =>
-    "_ReaderU16LESamples"
-
-  fun config(): BenchConfig =>
-    // run for 1_000_000 samples of 1 iteration each
-    BenchConfig(1_000_000, 1)
-
-  fun ref before() =>
     if _d.size() < 2 then
       _d.clear()
       _d.append(_b)
@@ -131,35 +84,6 @@ class iso _ReaderU16LESplit is MicroBenchmark
     "_ReaderU16LESplit"
 
   fun ref before_iteration() =>
-    while _d.size() < 2 do
-      _d.clear()
-      for a in _a.values() do
-        _d.append(a)
-      end
-    end
-
-  fun ref apply()? =>
-    DoNotOptimise[U16](_d.u16_le()?)
-    DoNotOptimise.observe()
-
-class iso _ReaderU16LESplitSamples is MicroBenchmark
-  // Benchmark reading split Little Endian U16
-  let _d: Reader = _d.create()
-  let _a: Array[Array[U8] val] = _a.create()
-
-  new iso create() =>
-    while _a.size() < 2 do
-      _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-  fun name(): String =>
-    "_ReaderU16LESplitSamples"
-
-  fun config(): BenchConfig =>
-    // run for 1_000_000 samples of 1 iteration each
-    BenchConfig(1_000_000, 1)
-
-  fun ref before() =>
     while _d.size() < 2 do
       _d.clear()
       for a in _a.values() do

--- a/packages/buffered/benchmarks/main.pony
+++ b/packages/buffered/benchmarks/main.pony
@@ -8,8 +8,11 @@ actor Main is BenchmarkList
 
   fun tag benchmarks(bench: PonyBench) =>
     bench(_ReaderU8)
+    bench(_ReaderU8Samples)
     bench(_ReaderU16LE)
+    bench(_ReaderU16LESamples)
     bench(_ReaderU16LESplit)
+    bench(_ReaderU16LESplitSamples)
     bench(_ReaderU16BE)
     bench(_ReaderU16BESplit)
     bench(_ReaderU32LE)
@@ -37,38 +40,82 @@ actor Main is BenchmarkList
 class iso _ReaderU8 is MicroBenchmark
   // Benchmark reading U8
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU8"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U8](_d.u8()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
+
+class iso _ReaderU8Samples is MicroBenchmark
+  // Benchmark reading U8
+  let _d: Reader = _d.create()
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
+
+  fun name(): String =>
+    "_ReaderU8Samples"
+
+  fun config(): BenchConfig =>
+    // run for 1_000_000 samples of 1 iteration each
+    BenchConfig(1_000_000, 1)
+
+  fun ref before() =>
+    if _d.size() < 2 then
       _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
+      _d.append(_b)
     end
+
+  fun ref apply()? =>
+    DoNotOptimise[U8](_d.u8()?)
+    DoNotOptimise.observe()
 
 class iso _ReaderU16LE is MicroBenchmark
   // Benchmark reading Little Endian U16
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU16LE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U16](_d.u16_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
+
+class iso _ReaderU16LESamples is MicroBenchmark
+  // Benchmark reading Little Endian U16
+  let _d: Reader = _d.create()
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
+
+  fun name(): String =>
+    "_ReaderU16LESamples"
+
+  fun config(): BenchConfig =>
+    // run for 1_000_000 samples of 1 iteration each
+    BenchConfig(1_000_000, 1)
+
+  fun ref before() =>
+    if _d.size() < 2 then
       _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
+      _d.append(_b)
     end
+
+  fun ref apply()? =>
+    DoNotOptimise[U16](_d.u16_le()?)
+    DoNotOptimise.observe()
 
 class iso _ReaderU16LESplit is MicroBenchmark
   // Benchmark reading split Little Endian U16
@@ -76,44 +123,71 @@ class iso _ReaderU16LESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 2 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU16LESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 2 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U16](_d.u16_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
+
+class iso _ReaderU16LESplitSamples is MicroBenchmark
+  // Benchmark reading split Little Endian U16
+  let _d: Reader = _d.create()
+  let _a: Array[Array[U8] val] = _a.create()
+
+  new iso create() =>
+    while _a.size() < 2 do
+      _a.push(recover Array[U8].>undefined(1) end)
+    end
+
+  fun name(): String =>
+    "_ReaderU16LESplitSamples"
+
+  fun config(): BenchConfig =>
+    // run for 1_000_000 samples of 1 iteration each
+    BenchConfig(1_000_000, 1)
+
+  fun ref before() =>
+    while _d.size() < 2 do
       _d.clear()
-      for b in _a.values() do
-        _d.append(b)
+      for a in _a.values() do
+        _d.append(a)
       end
     end
+
+  fun ref apply()? =>
+    DoNotOptimise[U16](_d.u16_le()?)
+    DoNotOptimise.observe()
 
 class iso _ReaderU16BE is MicroBenchmark
   // Benchmark reading Big Endian U16
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU16BE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U16](_d.u16_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU16BESplit is MicroBenchmark
   // Benchmark reading split Big Endian U16
@@ -121,44 +195,42 @@ class iso _ReaderU16BESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 2 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU16BESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 2 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U16](_d.u16_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU32LE is MicroBenchmark
   // Benchmark reading Little Endian U32
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU32LE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U32](_d.u32_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU32LESplit is MicroBenchmark
   // Benchmark reading split Little Endian U32
@@ -166,44 +238,42 @@ class iso _ReaderU32LESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 4 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU32LESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 4 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U32](_d.u32_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU32BE is MicroBenchmark
   // Benchmark reading Big Endian U32
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU32BE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U32](_d.u32_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU32BESplit is MicroBenchmark
   // Benchmark reading split Big Endian U32
@@ -211,44 +281,42 @@ class iso _ReaderU32BESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 4 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU32BESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 4 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U32](_d.u32_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU64LE is MicroBenchmark
   // Benchmark reading Little Endian U64
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU64LE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U64](_d.u64_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU64LESplit is MicroBenchmark
   // Benchmark reading split Little Endian U64
@@ -256,44 +324,42 @@ class iso _ReaderU64LESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 8 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU64LESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 8 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U64](_d.u64_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU64BE is MicroBenchmark
   // Benchmark reading Big Endian U64
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU64BE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U64](_d.u64_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU64BESplit is MicroBenchmark
   // Benchmark reading split Big Endian U64
@@ -301,44 +367,42 @@ class iso _ReaderU64BESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 8 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU64BESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 8 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U64](_d.u64_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU128LE is MicroBenchmark
   // Benchmark reading Little Endian U128
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU128LE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U128](_d.u128_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU128LESplit is MicroBenchmark
   // Benchmark reading split Little Endian U128
@@ -346,44 +410,42 @@ class iso _ReaderU128LESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 16 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU128LESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 16 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U128](_d.u128_le()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _ReaderU128BE is MicroBenchmark
   // Benchmark reading Big Endian U128
   let _d: Reader = _d.create()
-
-  new iso create() =>
-    _d.append(recover Array[U8].>undefined(10485760) end)
+  let _b: Array[U8] val = recover Array[U8].>undefined(10485760) end
 
   fun name(): String =>
     "_ReaderU128BE"
 
+  fun ref before_iteration() =>
+    if _d.size() < 2 then
+      _d.clear()
+      _d.append(_b)
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U128](_d.u128_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      _d.append(recover Array[U8].>undefined(10485760) end)
-    end
 
 class iso _ReaderU128BESplit is MicroBenchmark
   // Benchmark reading split Big Endian U128
@@ -391,26 +453,24 @@ class iso _ReaderU128BESplit is MicroBenchmark
   let _a: Array[Array[U8] val] = _a.create()
 
   new iso create() =>
-    while _a.size() < 65536 do
+    while _a.size() < 16 do
       _a.push(recover Array[U8].>undefined(1) end)
-    end
-
-    for b in _a.values() do
-      _d.append(b)
     end
 
   fun name(): String =>
     "_ReaderU128BESplit"
 
+  fun ref before_iteration() =>
+    while _d.size() < 16 do
+      _d.clear()
+      for a in _a.values() do
+        _d.append(a)
+      end
+    end
+
   fun ref apply()? =>
     DoNotOptimise[U128](_d.u128_be()?)
     DoNotOptimise.observe()
-    if _d.size() < 128 then
-      _d.clear()
-      for b in _a.values() do
-        _d.append(b)
-      end
-    end
 
 class iso _WriterU8 is MicroBenchmark
   // Benchmark writing U8
@@ -420,14 +480,16 @@ class iso _WriterU8 is MicroBenchmark
   fun name(): String =>
     "_WriterU8"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u8(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u8(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU16LE is MicroBenchmark
   // Benchmark writing Little Endian U16
@@ -437,14 +499,16 @@ class iso _WriterU16LE is MicroBenchmark
   fun name(): String =>
     "_WriterU16LE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u16_le(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u16_le(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU16BE is MicroBenchmark
   // Benchmark writing Big Endian U16
@@ -454,14 +518,16 @@ class iso _WriterU16BE is MicroBenchmark
   fun name(): String =>
     "_WriterU16BE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u16_be(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u16_be(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU32LE is MicroBenchmark
   // Benchmark writing Little Endian U32
@@ -471,14 +537,16 @@ class iso _WriterU32LE is MicroBenchmark
   fun name(): String =>
     "_WriterU32LE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u32_le(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u32_le(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU32BE is MicroBenchmark
   // Benchmark writing Big Endian U32
@@ -488,14 +556,16 @@ class iso _WriterU32BE is MicroBenchmark
   fun name(): String =>
     "_WriterU32BE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u32_be(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u32_be(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU64LE is MicroBenchmark
   // Benchmark writing Little Endian U64
@@ -505,14 +575,16 @@ class iso _WriterU64LE is MicroBenchmark
   fun name(): String =>
     "_WriterU64LE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u64_le(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u64_le(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU64BE is MicroBenchmark
   // Benchmark writing Big Endian U64
@@ -522,14 +594,16 @@ class iso _WriterU64BE is MicroBenchmark
   fun name(): String =>
     "_WriterU64BE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u64_be(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u64_be(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU128LE is MicroBenchmark
   // Benchmark writing Little Endian U128
@@ -539,14 +613,16 @@ class iso _WriterU128LE is MicroBenchmark
   fun name(): String =>
     "_WriterU128LE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u128_le(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u128_le(_i))
+    DoNotOptimise.observe()
 
 class iso _WriterU128BE is MicroBenchmark
   // Benchmark writing Big Endian U128
@@ -556,11 +632,13 @@ class iso _WriterU128BE is MicroBenchmark
   fun name(): String =>
     "_WriterU128BE"
 
-  fun ref apply() =>
-    DoNotOptimise[None](_d.u128_be(_i))
-    DoNotOptimise.observe()
+  fun ref before_iteration() =>
     _i = _i + 1
     if _d.size() > 10485760 then
       _d.done()
       _d.reserve_current(10485760)
     end
+
+  fun ref apply() =>
+    DoNotOptimise[None](_d.u128_be(_i))
+    DoNotOptimise.observe()

--- a/packages/ponybench/_runner.pony
+++ b/packages/ponybench/_runner.pony
@@ -134,7 +134,6 @@ actor _RunAsync is _Runner
     end
 
   be _after_done_cont(e: U64) =>
-    @printf[I32](("Done iterations: " + _n.string() + ", total time: " + _a.string() + "\n").cstring())
     _aggregator.complete(_name, _a)
 
   be _fail() =>

--- a/packages/ponybench/_runner.pony
+++ b/packages/ponybench/_runner.pony
@@ -21,15 +21,20 @@ actor _RunSync is _Runner
     apply()
 
   be apply() =>
-    _bench.before()
-    _gc_next_behavior()
-    _run_iteration()
+    try
+      _bench.before()?
+      _gc_next_behavior()
+      _run_iteration()
+    else
+      _fail()
+    end
 
   be _run_iteration(n: U64 = 0, a: U64 = 0) =>
     if n == _aggregator.iterations then
       _complete(a)
     else
       try
+        _bench.before_iteration()?
         let s =
           ifdef x86 then
             Time.perf_begin()
@@ -43,6 +48,7 @@ actor _RunSync is _Runner
           else
             Time.nanos()
           end
+         _bench.after_iteration()?
         _run_iteration(n + 1, a + (e - s))
       else
         _fail()
@@ -50,8 +56,12 @@ actor _RunSync is _Runner
     end
 
   be _complete(t: U64) =>
-    _bench.after()
-    _aggregator.complete(_name, t)
+    try
+      _bench.after()?
+      _aggregator.complete(_name, t)
+    else
+      _fail()
+    end
 
   be _fail() =>
     _ponybench._fail(_name)
@@ -69,11 +79,15 @@ actor _RunAsync is _Runner
   var _a: U64 = 0
 
   embed _before_cont: AsyncBenchContinue =
-    AsyncBenchContinue._create(this, recover this~_apply_cont() end)
-  embed _bench_cont: AsyncBenchContinue =
-    AsyncBenchContinue._create(this, recover this~_run_iteration() end)
+    AsyncBenchContinue._create(this, recover this~_before_done_cont() end)
+  embed _before_iteration_cont: AsyncBenchContinue =
+    AsyncBenchContinue._create(this, recover this~_before_iteration_done_cont() end)
+  embed _iteration_cont: AsyncBenchContinue =
+    AsyncBenchContinue._create(this, recover this~_iteration_done_cont() end)
+  embed _after_iteration_cont: AsyncBenchContinue =
+    AsyncBenchContinue._create(this, recover this~_after_iteration_done_cont() end)
   embed _after_cont: AsyncBenchContinue =
-    AsyncBenchContinue._create(this, recover this~_complete_cont() end)
+    AsyncBenchContinue._create(this, recover this~_after_done_cont() end)
 
   new create(
     ponybench: PonyBench,
@@ -89,33 +103,38 @@ actor _RunAsync is _Runner
   be apply() =>
     _bench.before(_before_cont)
 
-  be _apply_cont(e: U64) =>
+  be _before_done_cont(e: U64) =>
     _n = 0
     _a = 0
     _start_time = 0
-    _gc_next_behavior()
-    _run_iteration(0)
+    _bench.before_iteration(_before_iteration_cont)
 
-  be _run_iteration(e: U64) =>
-    if _start_time > 0 then
-      _a = _a + (e - _start_time)
-    end
-    if _n == _aggregator.iterations then
-      _complete()
+  be _before_iteration_done_cont(e: U64) =>
+    _run_iteration()
+
+  be _run_iteration() =>
+    try
+      _n = _n + 1
+      _gc_next_behavior()
+      _start_time = Time.nanos()
+      _bench(_iteration_cont)?
     else
-      try
-        _n = _n + 1
-        _start_time = Time.nanos()
-        _bench(_bench_cont)?
-      else
-        _fail()
-      end
+      _fail()
     end
 
-  be _complete() =>
-    _bench.after(_after_cont)
+  be _iteration_done_cont(e: U64) =>
+    _a = _a + (e - _start_time)
+    _bench.after_iteration(_after_iteration_cont)
 
-  be _complete_cont(e: U64) =>
+  be _after_iteration_done_cont(e: U64) =>
+    if _n == _aggregator.iterations then
+      _bench.after(_after_cont)
+    else
+      _bench.before_iteration(_before_iteration_cont)
+    end
+
+  be _after_done_cont(e: U64) =>
+    @printf[I32](("Done iterations: " + _n.string() + ", total time: " + _a.string() + "\n").cstring())
     _aggregator.complete(_name, _a)
 
   be _fail() =>

--- a/packages/ponybench/benchmark.pony
+++ b/packages/ponybench/benchmark.pony
@@ -13,17 +13,17 @@ trait iso MicroBenchmark
   and `after` methods respectively. The `before` method runs before a sample
   of benchmarks and `after` runs after the all iterations in the sample have
   completed. If your benchmark requires setup and/or teardown to occur beween
-  each iteration of the benchmark, then you must set the configuration of the
-  benchmark to have `max_iterations = 1`. It should be noted that a larger
-  `sample_size` may be necessary in this scenario for statistically
-  significant results.
+  each iteration of the benchmark, then you can use `before_iteration` and
+  `after_iteration` methods respectively that run before/after each iteration.
   """
   fun box name(): String
   fun box config(): BenchConfig => BenchConfig
   fun box overhead(): MicroBenchmark^ => OverheadBenchmark
-  fun ref before() => None
+  fun ref before() ? => None
+  fun ref before_iteration() ? => None
   fun ref apply() ?
-  fun ref after() => None
+  fun ref after() ? => None
+  fun ref after_iteration() ? => None
 
 trait iso AsyncMicroBenchmark
   """
@@ -34,16 +34,17 @@ trait iso AsyncMicroBenchmark
   `before` method runs before a sample of benchmarks and `after` runs after
   the all iterations in the sample have completed. If your benchmark requires
   setup and/or teardown to occur beween each iteration of the benchmark, then
-  you must set the configuration of the benchmark to have `max_iterations = 1`.
-  It should be noted that a larger `sample_size` may be necessary in this
-  scenario for statistically significant results.
+  you can use `before_iteration` and `after_iteration` methods respectively
+  that run before/after each iteration.
   """
   fun box name(): String
   fun box config(): BenchConfig => BenchConfig
   fun box overhead(): AsyncMicroBenchmark^ => AsyncOverheadBenchmark
   fun ref before(c: AsyncBenchContinue) => c.complete()
+  fun ref before_iteration(c: AsyncBenchContinue) => c.complete()
   fun ref apply(c: AsyncBenchContinue) ?
   fun ref after(c: AsyncBenchContinue) => c.complete()
+  fun ref after_iteration(c: AsyncBenchContinue) => c.complete()
 
 interface tag BenchmarkList
   fun tag benchmarks(bench: PonyBench)


### PR DESCRIPTION
This commit adds `before_iteration` and `after_iteration` to ponybench
benchmarks. It also changes the syncbenchmark `before` and `after`
to allow them to throw errors.

This commit also updates the `buffered` package benchmarks to use the
new `before_iteration` and `after_iteration` hooks.

----------------------------------

NOTE: These changes might need to go through the RFC process. They seem like "principle of least surprise" to me but others may not agree.

----------------------------------------

old benchmark results:

```
vagrant@ubuntu-xenial:~/dhp/packages/buffered/benchmarks$ ./benchmarks.after --ponythreads=1 --ponyminthreads=1
Benchmark results will have their mean and median adjusted for overhead.
You may disable this with --noadjust.

Benchmark                                   mean            median   deviation  iterations
_ReaderU8                                  34 ns             34 ns      ±2.76%     2000000
_ReaderU16LE                               33 ns             34 ns      ±1.62%     2000000
_ReaderU16LESplit                         459 ns            493 ns     ±14.70%     1000000
_ReaderU16BE                               43 ns             43 ns      ±4.41%     2000000
_ReaderU16BESplit                         502 ns            513 ns      ±8.88%     1000000
_ReaderU32LE                               45 ns             45 ns      ±1.58%     2000000
_ReaderU32LESplit                         925 ns            944 ns      ±6.64%      300000
_ReaderU32BE                               45 ns             45 ns      ±2.91%     2000000
_ReaderU32BESplit                        1022 ns           1040 ns      ±7.33%      500000
_ReaderU64LE                               49 ns             49 ns      ±2.69%     2000000
_ReaderU64LESplit                        1841 ns           1878 ns      ±8.32%      100000
_ReaderU64BE                               49 ns             49 ns      ±2.64%     2000000
_ReaderU64BESplit                        1934 ns           1919 ns      ±5.91%      100000
_ReaderU128LE                              51 ns             50 ns      ±2.20%     2000000
_ReaderU128LESplit                       3812 ns           3839 ns      ±7.86%       50000
_ReaderU128BE                              40 ns             40 ns      ±1.05%     2000000
_ReaderU128BESplit                       3055 ns           3252 ns     ±17.97%       50000
_WriterU8                                   8 ns              8 ns      ±1.28%     3000000
_WriterU16LE                                5 ns              5 ns      ±1.14%     5000000
_WriterU16BE                                7 ns              7 ns      ±1.47%     5000000
_WriterU32LE                                6 ns              6 ns      ±1.70%     3000000
_WriterU32BE                                7 ns              6 ns      ±1.61%     3000000
_WriterU64LE                                8 ns              8 ns      ±1.55%     3000000
_WriterU64BE                                7 ns              7 ns      ±1.73%     3000000
_WriterU128LE                               7 ns              7 ns      ±0.65%     3000000
_WriterU128BE                              10 ns             10 ns      ±0.98%     2000000
```

new benchmark results:

The `*Samples` line items show how it looks using the current method to accomplish the same thing of doing before/after iteration setup/teardown via using `1` iteration and `1000000` samples. The equivalent new way of doing before/after iteration setup/teardown is the line immediately preceding the `*Samples` line item. NOTE: the `*Samples` benchmarks have been removed in the second commit of this PR and will not actually there after the PR is merged. They are here to show them as a contrast with the new approach.

```
vagrant@ubuntu-xenial:~/dhp$ ./benchmarks --ponythreads=1 --ponyminthreads=1
Benchmark results will have their mean and median adjusted for overhead.
You may disable this with --noadjust.

Benchmark                                   mean            median   deviation  iterations
_ReaderU8                                  43 ns             42 ns      ±2.04%     2000000
_ReaderU8Samples                           47 ns             42 ns    ±438.12%           1
_ReaderU16LE                               47 ns             45 ns      ±9.94%     2000000
_ReaderU16LESamples                        44 ns             44 ns    ±345.14%           1
_ReaderU16LESplit                          76 ns             76 ns      ±1.20%     1000000
_ReaderU16LESplitSamples                   91 ns             78 ns    ±492.33%           1
_ReaderU16BE                               45 ns             44 ns      ±2.45%     2000000
_ReaderU16BESplit                          75 ns             75 ns      ±2.49%     1000000
_ReaderU32LE                               41 ns             41 ns      ±1.27%     2000000
_ReaderU32LESplit                         131 ns            130 ns      ±1.97%     1000000
_ReaderU32BE                               43 ns             43 ns      ±0.93%     2000000
_ReaderU32BESplit                         120 ns            120 ns      ±1.20%     1000000
_ReaderU64LE                               39 ns             39 ns      ±1.13%     2000000
_ReaderU64LESplit                         221 ns            220 ns      ±1.19%      500000
_ReaderU64BE                               35 ns             35 ns      ±1.07%     2000000
_ReaderU64BESplit                         222 ns            221 ns      ±1.42%      500000
_ReaderU128LE                              33 ns             33 ns      ±1.42%     2000000
_ReaderU128LESplit                        398 ns            397 ns      ±1.67%      300000
_ReaderU128BE                              42 ns             40 ns      ±8.17%     2000000
_ReaderU128BESplit                        424 ns            423 ns      ±1.60%      300000
_WriterU8                                   3 ns              3 ns      ±1.21%     5000000
_WriterU16LE                                2 ns              2 ns      ±1.52%     5000000
_WriterU16BE                                3 ns              3 ns      ±1.73%     5000000
_WriterU32LE                                2 ns              2 ns      ±2.14%     5000000
_WriterU32BE                                3 ns              3 ns      ±1.00%     5000000
_WriterU64LE                                3 ns              3 ns      ±1.59%     5000000
_WriterU64BE                                3 ns              3 ns      ±0.82%     5000000
_WriterU128LE                               6 ns              6 ns      ±0.80%     3000000
_WriterU128BE                               5 ns              5 ns      ±4.55%     3000000
```