### PR TITLE
Adapt to new mkdocs version in pony theme

### DIFF
--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -68,7 +68,7 @@ actor Stdin
         512)
   ```
 
-  **Note:** For reading user input from a terminal, use the [term](term--index) package.
+  **Note:** For reading user input from a terminal, use the [term](term--index.md) package.
   """
   var _notify: (InputNotify | None) = None
   var _chunk_size: USize = 32

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -1,35 +1,35 @@
 """
 # JSON Package
 
-The `json` package provides the [JsonDoc](json-JsonDoc) class both as a container for a JSON
-document and as means of parsing from and writing to [String](builtin-String).
+The `json` package provides the [JsonDoc](json-JsonDoc.md) class both as a container for a JSON
+document and as means of parsing from and writing to [String](builtin-String.md).
 
 ## JSON Representation
 
 JSON is represented in Pony as the following types:
 
-* object - [JsonObject](json-JsonObject)
-* array  - [JsonArray](json-JsonArray)
-* string - [String](builtin-String)
-* integer - [I64](builtin-I64)
-* float   - [F64](builtin-F64)
-* boolean - [Bool](builtin-Bool)
-* null    - [None](builtin-None)
+* object - [JsonObject](json-JsonObject.md)
+* array  - [JsonArray](json-JsonArray.md)
+* string - [String](builtin-String.md)
+* integer - [I64](builtin-I64.md)
+* float   - [F64](builtin-F64.md)
+* boolean - [Bool](builtin-Bool.md)
+* null    - [None](builtin-None.md)
 
 The collection types JsonObject and JsonArray can contain any other JSON
 structures arbitrarily nested.
 
-[JsonType](json-JsonType) is used to subsume all possible JSON types. It can
+[JsonType](json-JsonType.md) is used to subsume all possible JSON types. It can
 also be used to describe everything that can be serialized using this package.
 
 ## Parsing JSON
 
 For getting JSON from a String into proper Pony data structures,
-[JsonDoc.parse](json-JsonDoc#parse) needs to be used. This will populate the
-public field `JsonDoc.data`, which is [None](builtin-None), if [parse](json-JsonDoc#parse) has
+[JsonDoc.parse](json-JsonDoc.md#parse) needs to be used. This will populate the
+public field `JsonDoc.data`, which is [None](builtin-None.md), if [parse](json-JsonDoc.md#parse) has
 not been called yet.
 
-Every call to [parse](json-JsonDoc#parse) overwrites the `data` field, so one
+Every call to [parse](json-JsonDoc.md#parse) overwrites the `data` field, so one
 JsonDoc instance can be used to parse multiple JSON Strings one by one.
 
 ```pony
@@ -49,7 +49,7 @@ let last: Bool        = array.data(2)? as Bool
 
 ### Sending JSON
 
-[JsonDoc](json-JsonDoc) has the `ref` reference capability, which means it is
+[JsonDoc](json-JsonDoc.md) has the `ref` reference capability, which means it is
 not sendable by default. If you need to send it to another actor you need to
 recover it to a sendable reference capability (either `val` or `iso`). For the
 sake of simplicity it is recommended to do the parsing already in the recover
@@ -72,8 +72,8 @@ receiving side in order to be able to properly access the json structures in
 
 ## Writing JSON
 
-JSON is written using the [JsonDoc.string](json-JsonDoc#string) method. This
-will serialize the contents of the `data` field to [String](builtin-String).
+JSON is written using the [JsonDoc.string](json-JsonDoc.md#string) method. This
+will serialize the contents of the `data` field to [String](builtin-String.md).
 
 ```pony
 // building up the JSON data structure

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -185,35 +185,35 @@ class iso _I8AddTest is UnitTest
 
 ### Set Up
 
-Any kind of fixture or environment necessary for executing a [UnitTest](ponytest-UnitTest)
-can be set up either in the tests constructor or in a function called [set_up()](ponytest-UnitTest#set_up).
+Any kind of fixture or environment necessary for executing a [UnitTest](ponytest-UnitTest.md)
+can be set up either in the tests constructor or in a function called [set_up()](ponytest-UnitTest.md#set_up).
 
-[set_up()](ponytest-UnitTest#set_up) is called before the test is executed. It is partial,
+[set_up()](ponytest-UnitTest.md#set_up) is called before the test is executed. It is partial,
 if it errors, the test is not executed but reported as failing during set up.
-The test's [TestHelper](ponytest-TestHelper) is handed to [set_up()](ponytest-UnitTest#set_up)
-in order to log messages or access the tests [Env](builtin-Env) via [TestHelper.env](ponytest-TestHelper#let-env-env-val).
+The test's [TestHelper](ponytest-TestHelper.md) is handed to [set_up()](ponytest-UnitTest.md#set_up)
+in order to log messages or access the tests [Env](builtin-Env.md) via [TestHelper.env](ponytest-TestHelper.md#let-env-env-val).
 
 ### Tear Down
 
-Each unit test object may define a [tear_down()](ponytest-UnitTest#tear_down) function. This is called after
+Each unit test object may define a [tear_down()](ponytest-UnitTest.md#tear_down) function. This is called after
 the test has finished to allow tearing down of any complex environment that had
 to be set up for the test.
 
-The [tear_down()](ponytest-UnitTest#tear_down) function is called for each test regardless of whether it
-passed or failed. If a test times out [tear_down()](ponytest-UnitTest#tear_down) will be called after
+The [tear_down()](ponytest-UnitTest.md#tear_down) function is called for each test regardless of whether it
+passed or failed. If a test times out [tear_down()](ponytest-UnitTest.md#tear_down) will be called after
 timed_out() returns.
 
-When a test is in an exclusion group, the [tear_down()](ponytest-UnitTest#tear_down) call is considered part
+When a test is in an exclusion group, the [tear_down()](ponytest-UnitTest.md#tear_down) call is considered part
 of the tests run. The next test in the exclusion group will not start until
-after [tear_down()](ponytest-UnitTest#tear_down) returns on the current test.
+after [tear_down()](ponytest-UnitTest.md#tear_down) returns on the current test.
 
-The test's [TestHelper](ponytest-TestHelper) is handed to [tear_down()](ponytest-UnitTest#tear_down) and it is permitted to log
+The test's [TestHelper](ponytest-TestHelper.md) is handed to [tear_down()](ponytest-UnitTest.md#tear_down) and it is permitted to log
 messages and call assert functions during tear down.
 
 ### Example
 
-The following example creates a temporary directory in the [set_up()](ponytest-UnitTest#set_up) function
-and removes it in the [tear_down()](ponytest-UnitTest#tear_down) function, thus
+The following example creates a temporary directory in the [set_up()](ponytest-UnitTest.md#set_up) function
+and removes it in the [tear_down()](ponytest-UnitTest.md#tear_down) function, thus
 simplifying the test function itself:
 
 ```pony

--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -23,9 +23,9 @@ class val TestHelper
     """
     The process environment.
 
-    This is useful for getting the [root authority](builtin-AmbientAuth) in
-    order to access the filesystem (See [files](files--index)) or the network
-    (See [net](net--index)) in your tests.
+    This is useful for getting the [root authority](builtin-AmbientAuth.md) in
+    order to access the filesystem (See [files](files--index.md)) or the network
+    (See [net](net--index.md)) in your tests.
     """
 
   new val _create(runner: _TestRunner, env': Env) =>

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1377,7 +1377,7 @@ void generate_docs(ast_t* program, pass_opt_t* options)
     fprintf(docgen.index_file, "markdown_extensions:\n");
     fprintf(docgen.index_file, "- markdown.extensions.toc:\n");
     fprintf(docgen.index_file, "    permalink: true\n");
-    fprintf(docgen.index_file, "pages:\n");
+    fprintf(docgen.index_file, "nav:\n");
     fprintf(docgen.index_file, "- %s: index.md\n", name);
 
     doc_packages(&docgen, &docgen_opt, program);

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -391,7 +391,8 @@ static void doc_type(docgen_t* docgen, docgen_opt_t* docgen_opt,
         char* tqfn = write_tqfn(target, NULL, &link_len);
 
         // Links are of the form: [text](target)
-        fprintf(docgen->type_file, "[%s](%s)", ast_nice_name(id), tqfn);
+        // mkdocs requires the full filename for creating proper links
+        fprintf(docgen->type_file, "[%s](%s.md)", ast_nice_name(id), tqfn);
         ponyint_pool_free_size(link_len, tqfn);
 
         doc_type_list(docgen, docgen_opt, tparams, "\\[", ", ", "\\]", true, false);
@@ -1133,7 +1134,7 @@ static void doc_package_home(docgen_t* docgen,
   fprintf(docgen->index_file, "  - Package: \"%s.md\"\n", tqfn);
 
   // Add reference to package to home file
-  fprintf(docgen->home_file, "* [%s](%s)\n", package_qualified_name(package),
+  fprintf(docgen->home_file, "* [%s](%s.md)\n", package_qualified_name(package),
     tqfn);
 
   // Now we can write the actual documentation for the package


### PR DESCRIPTION
as this is required for new mkdocs 1.0.4 the ponylang theme is now based on ( the pages section is now deprecated).

[skip ci]