### PR TITLE
Add check to Path.clean() for root directory

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -23,6 +23,7 @@ actor Main is TestList
     test(_TestPathBase)
     test(_TestPathExt)
     test(_TestPathVolume)
+    test(_TestPathRoot)
     test(_TestFileEOF)
     test(_TestFileOpenError)
     test(_TestFileCreate)
@@ -342,6 +343,15 @@ class iso _TestPathVolume is UnitTest
       h.assert_eq[String](res1, "")
       h.assert_eq[String](res2, "")
     end
+
+
+class iso _TestPathRoot is UnitTest
+  fun name(): String => "files/Path.root"
+  fun apply(h: TestHelper) =>
+    let res1 = Path.abs("/")
+    let res2 = Path.abs("/foo/../")
+    h.assert_eq[String](res1, "/")
+    h.assert_eq[String](res2, "/")
 
 
 class iso _TestFileEOF is UnitTest

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -174,7 +174,7 @@ primitive Path
     end
 
     try
-      if is_sep(s(s.size()-1)?) then
+      if is_sep(s(s.size()-1)?) and (s.size() > 1) then
         s.delete(-1, sep().size())
       end
     end


### PR DESCRIPTION
Fix #2911

Consider https://playground.ponylang.io/?gist=632ab1520993f82692e5c552a90f4418

This commit adds a check to the cleaned path's size, and prevents deleting a
separator character if it is the only character in the path. This fixes the bug
where Path.clean("/") returns ".", and adds a unit test to ensure it stays
fixed.