### PR TITLE
Link to libexecinfo on BSD always, not just in a debug compiler

### DIFF
--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -348,7 +348,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 #endif
   const char* lexecinfo =
 #if (defined(PLATFORM_IS_LINUX) && !defined(__GLIBC__)) || \
-    (defined(PLATFORM_IS_BSD) && defined(DEBUG))
+    defined(PLATFORM_IS_BSD)
    "-lexecinfo";
 #else
     "";


### PR DESCRIPTION
#2826 restricted -lexecinfo to debug compilers (not even to building something in debug mode).

This doesn't make much sense. I'm not sure why ordinary builds can succeed without -lexecinfo, but bitcode-runtime builds can't. Either way, if it's always included on non-glibc-Linux, it should always be included on BSD.
