### PR TITLE
Allow getHostCPUFeatures to fail on ARM platforms

### DIFF
--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -56,7 +56,14 @@ char* LLVMGetHostCPUFeatures()
 {
   StringMap<bool> features;
   bool got_features = sys::getHostCPUFeatures(features);
+#ifdef PLATFORM_IS_ARM
+  // LLVM might not have CPU features support on e.g. FreeBSD/aarch64
+  if (!got_features) {
+    features["neon"] = true;
+  }
+#else
   pony_assert(got_features);
+#endif
   (void)got_features;
 
   // Calculate the size of buffer that will be needed to return all features.


### PR DESCRIPTION
LLVM does not yet support getting CPU features on FreeBSD/aarch64 (or armv6/7), the situation is probably similar on other non-Linux OSes.
In the case it fails, let's just assume NEON (it's mandatory on aarch64 and very likely present on armv7).