### PR TITLE
Install libdtrace_probes.a into the right directory on FreeBSD

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -806,7 +806,7 @@ $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
 	$(SILENT)rm -f $(PONY_BUILD_DIR)/dtrace_probes.o
 	$(SILENT)$(DTRACE) -G -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_BUILD_DIR)/dtrace_probes.o $(ofiles)
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles) $(PONY_BUILD_DIR)/dtrace_probes.o
-	$(SILENT)$(AR) $(AR_FLAGS) $(PONY_BUILD_DIR)/libdtrace_probes.a $(PONY_BUILD_DIR)/dtrace_probes.o
+	$(SILENT)$(AR) $(AR_FLAGS) $(lib)/libdtrace_probes.a $(PONY_BUILD_DIR)/dtrace_probes.o
     else
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
     endif


### PR DESCRIPTION
Later in the makefile, it's looking at `$(wildcard $(lib)/libdtrace_probes.a)` to copy it.