### PR TITLE
Ignore parser errors when other errors have already been noticed.

### DIFF
--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -625,6 +625,8 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
   parser->errors = errors;
   parser->trace_enable = trace;
 
+  const size_t error_count = errors_get_count(errors);
+
   // Parse given start rule
   builder_fn_t build_fn;
   ast_t* ast = start(parser, &build_fn, expected);
@@ -644,7 +646,7 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     ast = NULL;
   }
 
-  if(errors_get_count(errors) > 0)
+  if(errors_get_count(errors) > error_count)
   {
     ast_free(ast);
     ast = NULL;

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -555,11 +555,17 @@ TEST_F(SugarTest, FunctionNoReturnBody)
 
 TEST_F(SugarTest, FunctionParamMustBeId)
 {
-  const char* good =
+  const char* good1 =
     "trait Foo\n"
     "  fun foo(x: U64) => 3";
 
-  TEST_COMPILE(good);
+  TEST_COMPILE(good1);
+
+  const char* good2 =
+    "trait Foo\n"
+    "  fun foo(_: U64) => 3";
+
+  TEST_COMPILE(good2);
 
   const char* bad1 =
     "trait Foo\n"
@@ -569,15 +575,9 @@ TEST_F(SugarTest, FunctionParamMustBeId)
 
   const char* bad2 =
     "trait Foo\n"
-    "  fun foo(_: U64) => 3";
-
-  TEST_ERROR(bad2);
-
-  const char* bad3 =
-    "trait Foo\n"
     "  fun foo($: U64) => 3";
 
-  TEST_ERROR(bad3);
+  TEST_ERROR(bad2);
 }
 
 


### PR DESCRIPTION
In case we already have an error state, only count errors arising from
this parser pass.