### PR TITLE
Make _SignedInteger and _UnsignedInteger public

### DIFF
--- a/packages/builtin/_partial_arithmetic.pony
+++ b/packages/builtin/_partial_arithmetic.pony
@@ -14,27 +14,27 @@ trait _PartialArithmetic
 
 primitive _UnsignedPartialArithmetic is _PartialArithmetic
 
-  fun div_checked[T: _UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
+  fun div_checked[T: UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
     (x / y, (y == T.from[U8](0)))
 
-  fun rem_checked[T: _UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
+  fun rem_checked[T: UnsignedInteger[T] val](x: T, y: T): (T, Bool) =>
     (x % y, y == T.from[U8](0))
 
-  fun div_partial[T: _UnsignedInteger[T] val](x: T, y: T): T? =>
+  fun div_partial[T: UnsignedInteger[T] val](x: T, y: T): T? =>
     if (y == T.from[U8](0)) then
       error
     else
       x /~ y
     end
 
-  fun rem_partial[T: _UnsignedInteger[T] val](x: T, y: T): T? =>
+  fun rem_partial[T: UnsignedInteger[T] val](x: T, y: T): T? =>
     if (y == T.from[U8](0)) then
       error
     else
       x %~ y
     end
 
-  fun divrem_partial[T: _UnsignedInteger[T] val](x: T, y: T): (T, T)? =>
+  fun divrem_partial[T: UnsignedInteger[T] val](x: T, y: T): (T, T)? =>
     if (y == T.from[U8](0)) then
       error
     else
@@ -43,34 +43,34 @@ primitive _UnsignedPartialArithmetic is _PartialArithmetic
 
 primitive _SignedPartialArithmetic is _PartialArithmetic
 
-  fun div_checked[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
+  fun div_checked[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
     (x / y, (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())))
 
-  fun rem_checked[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
+  fun rem_checked[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T, y: T): (T, Bool) =>
     (x % y, (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())))
 
-  fun div_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): T? =>
+  fun div_partial[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T, y: T): T? =>
     if (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())) then
       error
     else
       x /~ y
     end
 
-  fun rem_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): T? =>
+  fun rem_partial[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T, y: T): T? =>
     if (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())) then
       error
     else
       x %~ y
     end
 
-  fun divrem_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T, y: T): (T, T)? =>
+  fun divrem_partial[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T, y: T): (T, T)? =>
     if (y == T.from[I8](0)) or ((y == T.from[I8](I8(-1))) and (x == T.min_value())) then
       error
     else
       (x/~y, x %~ y)
     end
 
-  fun neg_partial[T: (_SignedInteger[T, U] val & Signed), U: _UnsignedInteger[U] val](x: T): T? =>
+  fun neg_partial[T: (SignedInteger[T, U] val & Signed), U: UnsignedInteger[U] val](x: T): T? =>
     if x == T.min_value() then
       error
     else

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -320,8 +320,8 @@ trait val Integer[A: Integer[A] val] is Real[A]
 
   fun bswap(): A
 
-trait val _SignedInteger[A: _SignedInteger[A, B] val,
-    B: _UnsignedInteger[B] val] is Integer[A]
+trait val SignedInteger[A: SignedInteger[A, B] val,
+    B: UnsignedInteger[B] val] is Integer[A]
   fun abs(): B
 
   fun shl(y: B): A => this << y
@@ -365,7 +365,7 @@ trait val _SignedInteger[A: _SignedInteger[A, B] val,
   fun string(): String iso^ =>
     _ToString._u64(abs().u64(), i64() < 0)
 
-trait val _UnsignedInteger[A: _UnsignedInteger[A] val] is Integer[A]
+trait val UnsignedInteger[A: UnsignedInteger[A] val] is Integer[A]
   fun abs(): A
 
   fun shl(y: A): A => this << y

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -1,4 +1,4 @@
-primitive I8 is _SignedInteger[I8, U8]
+primitive I8 is SignedInteger[I8, U8]
   new create(value: I8) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i8()
 
@@ -66,7 +66,7 @@ primitive I8 is _SignedInteger[I8, U8]
   fun divrem_partial(y: I8): (I8, I8) ? =>
     _SignedPartialArithmetic.divrem_partial[I8, U8](this, y)?
 
-primitive I16 is _SignedInteger[I16, U16]
+primitive I16 is SignedInteger[I16, U16]
   new create(value: I16) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i16()
 
@@ -135,7 +135,7 @@ primitive I16 is _SignedInteger[I16, U16]
     _SignedPartialArithmetic.divrem_partial[I16, U16](this, y)?
 
 
-primitive I32 is _SignedInteger[I32, U32]
+primitive I32 is SignedInteger[I32, U32]
   new create(value: I32) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i32()
 
@@ -203,7 +203,7 @@ primitive I32 is _SignedInteger[I32, U32]
   fun divrem_partial(y: I32): (I32, I32) ? =>
     _SignedPartialArithmetic.divrem_partial[I32, U32](this, y)?
 
-primitive I64 is _SignedInteger[I64, U64]
+primitive I64 is SignedInteger[I64, U64]
   new create(value: I64) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i64()
 
@@ -272,7 +272,7 @@ primitive I64 is _SignedInteger[I64, U64]
   fun divrem_partial(y: I64): (I64, I64) ? =>
     _SignedPartialArithmetic.divrem_partial[I64, U64](this, y)?
 
-primitive ILong is _SignedInteger[ILong, ULong]
+primitive ILong is SignedInteger[ILong, ULong]
   new create(value: ILong) => value
   new from[A: (Number & Real[A] val)](a: A) => a.ilong()
 
@@ -394,7 +394,7 @@ primitive ILong is _SignedInteger[ILong, ULong]
   fun divrem_partial(y: ILong): (ILong, ILong) ? =>
     _SignedPartialArithmetic.divrem_partial[ILong, ULong](this, y)?
 
-primitive ISize is _SignedInteger[ISize, USize]
+primitive ISize is SignedInteger[ISize, USize]
   new create(value: ISize) => value
   new from[A: (Number & Real[A] val)](a: A) => a.isize()
 
@@ -515,7 +515,7 @@ primitive ISize is _SignedInteger[ISize, USize]
   fun divrem_partial(y: ISize): (ISize, ISize) ? =>
     _SignedPartialArithmetic.divrem_partial[ISize, USize](this, y)?
 
-primitive I128 is _SignedInteger[I128, U128]
+primitive I128 is SignedInteger[I128, U128]
   new create(value: I128) => value
   new from[A: (Number & Real[A] val)](a: A) => a.i128()
 
@@ -736,7 +736,7 @@ type Signed is (I8 | I16 | I32 | I64 | I128 | ILong | ISize)
 
 
 primitive _SignedCheckedArithmetic
-  fun _mulc[U: _UnsignedInteger[U] val, T: (Signed & _SignedInteger[T, U] val)](x: T, y: T): (T, Bool) =>
+  fun _mulc[U: UnsignedInteger[U] val, T: (Signed & SignedInteger[T, U] val)](x: T, y: T): (T, Bool) =>
     """
     basically exactly what the runtime functions __muloti4, mulodi4 etc. are doing
     and roughly as fast as these.

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -1,4 +1,4 @@
-primitive U8 is _UnsignedInteger[U8]
+primitive U8 is UnsignedInteger[U8]
   new create(value: U8) => value
   new from[B: (Number & Real[B] val)](a: B) => a.u8()
 
@@ -70,7 +70,7 @@ primitive U8 is _UnsignedInteger[U8]
   fun divrem_partial(y: U8): (U8, U8) ? =>
     _UnsignedPartialArithmetic.divrem_partial[U8](this, y)?
 
-primitive U16 is _UnsignedInteger[U16]
+primitive U16 is UnsignedInteger[U16]
   new create(value: U16) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u16()
 
@@ -142,7 +142,7 @@ primitive U16 is _UnsignedInteger[U16]
   fun divrem_partial(y: U16): (U16, U16) ? =>
     _UnsignedPartialArithmetic.divrem_partial[U16](this, y)?
 
-primitive U32 is _UnsignedInteger[U32]
+primitive U32 is UnsignedInteger[U32]
   new create(value: U32) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u32()
 
@@ -214,7 +214,7 @@ primitive U32 is _UnsignedInteger[U32]
   fun divrem_partial(y: U32): (U32, U32) ? =>
     _UnsignedPartialArithmetic.divrem_partial[U32](this, y)?
 
-primitive U64 is _UnsignedInteger[U64]
+primitive U64 is UnsignedInteger[U64]
   new create(value: U64) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u64()
 
@@ -293,7 +293,7 @@ primitive U64 is _UnsignedInteger[U64]
   fun divrem_partial(y: U64): (U64, U64) ? =>
     _UnsignedPartialArithmetic.divrem_partial[U64](this, y)?
 
-primitive ULong is _UnsignedInteger[ULong]
+primitive ULong is UnsignedInteger[ULong]
   new create(value: ULong) => value
   new from[A: (Number & Real[A] val)](a: A) => a.ulong()
 
@@ -428,7 +428,7 @@ primitive ULong is _UnsignedInteger[ULong]
   fun divrem_partial(y: ULong): (ULong, ULong) ? =>
     _UnsignedPartialArithmetic.divrem_partial[ULong](this, y)?
 
-primitive USize is _UnsignedInteger[USize]
+primitive USize is UnsignedInteger[USize]
   new create(value: USize) => value
   new from[A: (Number & Real[A] val)](a: A) => a.usize()
 
@@ -556,7 +556,7 @@ primitive USize is _UnsignedInteger[USize]
   fun divrem_partial(y: USize): (USize, USize) ? =>
     _UnsignedPartialArithmetic.divrem_partial[USize](this, y)?
 
-primitive U128 is _UnsignedInteger[U128]
+primitive U128 is UnsignedInteger[U128]
   new create(value: U128) => value
   new from[A: (Number & Real[A] val)](a: A) => a.u128()
 


### PR DESCRIPTION
in order to enable use of shl/shr and other methods specialized for signed and unsigned integers in a generic context (e.g. for code handling all kinds of signed ints).

This fixes #2390 