### PR TITLE
Add whitespace between multiple args on cli help output

### DIFF
--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -26,6 +26,7 @@ actor Main is TestList
     test(_TestChat)
     test(_TestMustBeLeaf)
     test(_TestHelp)
+    test(_TestHelpMultipleArgs)
 
 class iso _TestMinimal is UnitTest
   fun name(): String => "ponycli/minimal"
@@ -512,6 +513,17 @@ class iso _TestHelp is UnitTest
     let help = ch.help_string()
     h.log(help)
     h.assert_true(help.contains("Address of the server"))
+
+class iso _TestHelpMultipleArgs is UnitTest
+  fun name(): String => "ponycli/help-multiple-args"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.simple_cli_spec()?
+
+    let help = cs.help_string()
+    h.log(help)
+    h.assert_true(
+      help.contains("simple <words> <argz>"))
 
 primitive _Fixtures
   fun bools_cli_spec(): CommandSpec box ? =>

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -149,8 +149,10 @@ class CommandSpec
     """
     let s = _name.clone()
     s.append(" ")
-    for a in _args.values() do
+    let args_iter = _args.values()
+    for a in args_iter do
       s.append(a.help_string())
+      if args_iter.has_next() then s.append(" ") end
     end
     s
 


### PR DESCRIPTION
before:

```
usage: stable [<options>] <command> [<args> ...]

...

Commands:
   ...         
   add <type><source>    Adds a new dependency to the local `bundle.json`.
   ...
```

after:

```
usage: stable [<options>] <command> [<args> ...]

...

Commands:
   ...         
   add <type> <source>    Adds a new dependency to the local `bundle.json`.
   ...
```