### PR TITLE
Add information what to install from Visual C++ Build Tools 2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,9 @@ Windows users will need to install:
 
 - Visual Studio 2017 or 2015 (available [here](https://www.visualstudio.com/vs/community/)) or the Visual C++ Build Tools 2017 or 2015 (available [here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)), and
   - If using Visual Studio 2015, install the Windows 10 SDK (available [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
-  - If using Visual Studio 2017 or the Visual C++ Build Tools 2017, install the "Desktop Development for C++" workload, and the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio installer.
+  - If using Visual Studio 2017, install the "Desktop Development with C++" workload.
+  - If using Visual C++ Build Tools 2017, install the "Visual C++ build tools" workload, and the "Visual Studio C++ core features" individual component.
+  - In any case install the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio 2017 or Visual C++ Build Tools 2017 installer.
 
 Once you have installed the prerequisites, you can download the latest ponyc release from [bintray](https://dl.bintray.com/pony-language/ponyc-win/).
 
@@ -832,7 +834,9 @@ Building on Windows requires the following:
 
 - Visual Studio 2017 or 2015 (available [here](https://www.visualstudio.com/vs/community/)) or the Visual C++ Build Tools 2017 or 2015 (available [here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)), and
   - If using Visual Studio 2015, install the Windows 10 SDK (available [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
-  - If using Visual Studio 2017 or the Visual C++ Build Tools 2017, install the "Desktop Development for C++" workload and the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio installer.
+  - If using Visual Studio 2017, install the "Desktop Development with C++" workload.
+  - If using Visual C++ Build Tools 2017, install the "Visual C++ build tools" workload, and the "Visual Studio C++ core features" individual component.
+  - In any case install the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio 2017 or Visual C++ Build Tools 2017 installer.
 - [Python](https://www.python.org/downloads) (3.6 or 2.7) needs to be in your PATH.
 
 In a command prompt in the `ponyc` source directory, run the following:

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Windows users will need to install:
   - If using Visual Studio 2015, install the Windows 10 SDK (available [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
   - If using Visual Studio 2017, install the "Desktop Development with C++" workload.
   - If using Visual C++ Build Tools 2017, install the "Visual C++ build tools" workload, and the "Visual Studio C++ core features" individual component.
-  - In any case install the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio 2017 or Visual C++ Build Tools 2017 installer.
+  - If using Visual Studio 2017 or Visual C++ Build Tools 2017, make sure the latest `Windows 10 SDK (10.x.x.x) for Desktop` will be installed.
 
 Once you have installed the prerequisites, you can download the latest ponyc release from [bintray](https://dl.bintray.com/pony-language/ponyc-win/).
 
@@ -836,7 +836,7 @@ Building on Windows requires the following:
   - If using Visual Studio 2015, install the Windows 10 SDK (available [here](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk)).
   - If using Visual Studio 2017, install the "Desktop Development with C++" workload.
   - If using Visual C++ Build Tools 2017, install the "Visual C++ build tools" workload, and the "Visual Studio C++ core features" individual component.
-  - In any case install the latest `Windows 10 SDK (10.x.x.x) for Desktop` from the Visual Studio 2017 or Visual C++ Build Tools 2017 installer.
+  - If using Visual Studio 2017 or Visual C++ Build Tools 2017, make sure the latest `Windows 10 SDK (10.x.x.x) for Desktop` will be installed.
 - [Python](https://www.python.org/downloads) (3.6 or 2.7) needs to be in your PATH.
 
 In a command prompt in the `ponyc` source directory, run the following:


### PR DESCRIPTION
There is not enough information on this in the readme. It's necessary to select the "Visual Studio C++ core features" individual component in the Visual C++ Build Tools 2017 installer to get an installation that works for pony.

As fair as I can tell it adds the "SxS" key in the "VisualStudio" key in the registry. Without this ponyc will complain that "Microsoft link.exe" cannot be located.