### PR TITLE
[RFC 60] Add binary heaps

### DIFF
--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -1,4 +1,6 @@
 use "ponytest"
+use "random"
+use "time"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -27,6 +29,7 @@ actor Main is TestList
     test(_TestHashSetIntersect)
     test(_TestSort)
     test(_TestRange)
+    test(_TestHeap)
 
 class iso _TestList is UnitTest
   fun name(): String => "collections/List"
@@ -641,3 +644,71 @@ class iso _TestRange is UnitTest
       count = count + 1
     end
     count
+
+class iso _TestHeap is UnitTest
+  fun name(): String => "collections/BinaryHeap"
+
+  fun apply(t: TestHelper) ? =>
+    _gen_test(t, Time.millis())?
+
+  fun _gen_test(t: TestHelper, seed: U64) ? =>
+    let rand = Rand(seed)
+    let len = rand.int[USize](100)
+
+    let ns = Array[USize](len)
+    for _ in Range(0, len) do
+      ns.push(rand.int[USize](100))
+    end
+
+    _test_push[MinHeapPriority[USize]](t, ns)?
+    _test_push[MaxHeapPriority[USize]](t, ns)?
+    _test_append[MinHeapPriority[USize]](t, ns)?
+    _test_append[MaxHeapPriority[USize]](t, ns)?
+    _test_pop[MinHeapPriority[USize]](t, ns)?
+    _test_pop[MaxHeapPriority[USize]](t, ns)?
+
+  fun _test_push[P: BinaryHeapPriority[USize]](t: TestHelper, ns: Array[USize]) ? =>
+    let h = BinaryHeap[USize, P](ns.size())
+    for n in ns.values() do
+      h.push(n)
+      _verify[P](t, h)?
+    end
+    t.assert_eq[USize](h.size(), ns.size())
+
+  fun _test_append[P: BinaryHeapPriority[USize]](t: TestHelper, ns: Array[USize]) ? =>
+    let h = BinaryHeap[USize, P](ns.size())
+    h.append(ns)
+    t.assert_eq[USize](h.size(), ns.size())
+    _verify[P](t, h)?
+
+  fun _test_pop[P: BinaryHeapPriority[USize]](t: TestHelper, ns: Array[USize]) ? =>
+    let h = BinaryHeap[USize, P](ns.size())
+    h.append(ns)
+
+    if ns.size() == 0 then return end
+
+    var prev = h.pop()?
+    _verify[P](t, h)?
+
+    for _ in Range(1, ns.size()) do
+      let n = h.pop()?
+      t.assert_true((prev == n) or P(prev, n))
+      prev = n
+      _verify[P](t, h)?
+    end
+    t.assert_eq[USize](h.size(), 0)
+
+  fun _verify[P: BinaryHeapPriority[USize]]
+    (t: TestHelper, h: BinaryHeap[USize, P], i: USize = 0) ?
+  =>
+    let a = (2 * i) + 1
+    let b = a + 1
+
+    if a < h.size() then
+      t.assert_false(P(h._apply(a)?, h._apply(i)?))
+      _verify[P](t, h, a)?
+    end
+    if b < h.size() then
+      t.assert_false(P(h._apply(b)?, h._apply(i)?))
+      _verify[P](t, h, b)?
+    end

--- a/packages/collections/heap.pony
+++ b/packages/collections/heap.pony
@@ -1,0 +1,145 @@
+
+type MinHeap[A: Comparable[A] #read] is BinaryHeap[A, MinHeapPriority[A]]
+type MaxHeap[A: Comparable[A] #read] is BinaryHeap[A, MaxHeapPriority[A]]
+
+class BinaryHeap[A: Comparable[A] #read, P: BinaryHeapPriority[A]]
+  """
+  A priority queue implemented as a binary heap. The `BinaryHeapPriority` type
+  parameter determines whether this is max-heap or a min-heap.
+  """
+  embed _data: Array[A]
+
+  new create(len: USize) =>
+    """
+    Create an empty heap with space for `len` elements.
+    """
+    _data = Array[A](len)
+
+  fun ref clear() =>
+    """
+    Remove all elements from the heap.
+    """
+    _data.clear()
+
+  fun size(): USize =>
+    """
+    Return the number of elements in the heap.
+    """
+    _data.size()
+
+  fun peek(): this->A ? =>
+    """
+    Return the highest priority item in the heap. For max-heaps, the greatest
+    item will be returned. For min-heaps, the smallest item will be returned.
+    """
+    _data(0)?
+
+  fun ref push(value: A) =>
+    """
+    Push an item into the heap.
+
+    The time complexity of this operation is O(log(n)) with respect to the size
+    of the heap.
+    """
+    _data.push(value)
+    _sift_up(size() - 1)
+
+  fun ref pop(): A^ ? =>
+    """
+    Remove the highest priority value from the heap and return it. For
+    max-heaps, the greatest item will be returned. For min-heaps, the smallest
+    item will be returned.
+
+    The time complexity of this operation is O(log(n)) with respect to the size
+    of the heap.
+    """
+    let n = size() - 1
+    _data.swap_elements(0, n)?
+    _sift_down(0, n)
+    _data.pop()?
+
+  fun ref append(
+    seq: (ReadSeq[A] & ReadElement[A^]),
+    offset: USize = 0,
+    len: USize = -1)
+  =>
+    """
+    Append len elements from a sequence, starting from the given offset.
+    """
+    _data.append(seq, offset, len)
+    _make_heap()
+
+  fun ref concat(iter: Iterator[A^], offset: USize = 0, len: USize = -1) =>
+    """
+    Add len iterated elements, starting from the given offset.
+    """
+    _data.concat(iter, offset, len)
+    _make_heap()
+
+  fun values(): ArrayValues[A, this->Array[A]]^ =>
+    """
+    Return an iterator for the elements in the heap. The order of elements is
+    arbitrary.
+    """
+    _data.values()
+
+  fun ref _make_heap() =>
+    let n = size()
+    if n < 2 then return end
+    var i = (n / 2)
+    while (i = i - 1) > 0 do
+      _sift_down(i, n)
+    end
+
+  fun ref _sift_up(n: USize) =>
+    var idx = n
+    try
+      while true do
+        let parent_idx = (idx - 1) / 2
+        if (parent_idx == idx) or not P(_data(idx)?, _data(parent_idx)?) then
+          break
+        end
+        _data.swap_elements(parent_idx, idx)?
+        idx = parent_idx
+      end
+    end
+
+  fun ref _sift_down(start: USize, n: USize): Bool =>
+    var idx = start
+    try
+      while true do
+        var left = (2 * idx) + 1
+        if (left >= n) or (left < 0) then
+          break
+        end
+        let right = left + 1
+        if (right < n) and P(_data(right)?, _data(left)?) then
+          left = right
+        end
+        if not P(_data(left)?, _data(idx)?) then
+          break
+        end
+        _data.swap_elements(idx, left)?
+        idx = left
+      end
+    end
+    idx > start
+
+  fun _apply(i: USize): this->A ? =>
+    _data(i)?
+
+type BinaryHeapPriority[A: Comparable[A] #read] is
+  ( _BinaryHeapPriority[A]
+  & (MinHeapPriority[A] | MaxHeapPriority[A]))
+
+interface val _BinaryHeapPriority[A: Comparable[A] #read]
+  new val create()
+  fun apply(x: A, y: A): Bool
+
+primitive MinHeapPriority[A: Comparable[A] #read] is _BinaryHeapPriority[A]
+  fun apply(x: A, y: A): Bool =>
+    x < y
+
+primitive MaxHeapPriority [A: Comparable[A] #read] is _BinaryHeapPriority[A]
+  fun apply(x: A, y: A): Bool =>
+    x > y


### PR DESCRIPTION
This PR adds binary heaps to the standard collections package. This includes both minimum and maximum priority heaps through the `MinHeap` and `MaxHeap` classes.

closes #2948 