### PR TITLE
Fix array literals (according to STYLE_GUIDE.md)

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -955,7 +955,7 @@ class iso _TestFileLinesSingleLine is UnitTest
 class _TestFileLinesMultiLine is UnitTest
   var tmp_dir: (FilePath | None) = None
 
-  let line_endings: Array[String] val = [ "\n"; "\r\n" ]
+  let line_endings: Array[String] val = ["\n"; "\r\n"]
   let file_contents: Array[(Array[String] val, USize)] val = [
     (["a"; "b"], 2)
     (["a"; ""; "b"], 3)

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -31,8 +31,8 @@ class iso _TestStdinStdout is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient(size, "", 0, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/cat")?
-      let args: Array[String] val = [ "cat" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["cat"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       let pm: ProcessMonitor =
@@ -62,8 +62,8 @@ class iso _TestStderr is UnitTest
       "cat: file_does_not_exist: No such file or directory\n", 1, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/cat")?
-      let args: Array[String] val = [ "cat"; "file_does_not_exist" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["cat"; "file_does_not_exist"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       _pm  = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
@@ -100,8 +100,8 @@ class iso _TestFileExecCapabilityIsRequired is UnitTest
       let path =
         FilePath(h.env.root as AmbientAuth, "/bin/date",
           recover val FileCaps .> all() .> unset(FileExec) end)?
-      let args: Array[String] val = [ "date" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["date"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       let pm: ProcessMonitor =
@@ -199,8 +199,8 @@ class iso _TestExpect is UnitTest
 
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/echo")?
-      let args: Array[String] val = [ "echo"; "hello there!" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["echo"; "hello there!"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
@@ -227,13 +227,13 @@ class iso _TestWritevOrdering is UnitTest
       _ProcessClient(11, "", 0, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/cat")?
-      let args: Array[String] val = [ "cat" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["cat"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
-      let params: Array[String] val = [ "one"; "two"; "three" ]
+      let params: Array[String] val = ["one"; "two"; "three"]
 
       pm.writev(params)
       pm.done_writing()  // closing stdin allows "cat" to terminate
@@ -258,13 +258,13 @@ class iso _TestPrintvOrdering is UnitTest
       _ProcessClient(14, "", 0, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/cat")?
-      let args: Array[String] val = [ "cat" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["cat"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
-      let params: Array[String] val = [ "one"; "two"; "three" ]
+      let params: Array[String] val = ["one"; "two"; "three"]
 
       pm.printv(params)
       pm.done_writing()  // closing stdin allows "cat" to terminate
@@ -293,8 +293,8 @@ class iso _TestStdinWriteBuf is UnitTest
       "", 0, h)
     try
       let path = FilePath(h.env.root as AmbientAuth, "/bin/cat")?
-      let args: Array[String] val = [ "cat" ]
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let args: Array[String] val = ["cat"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       // fork the child process and attach a ProcessMonitor
       let auth = h.env.root as AmbientAuth

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -26,9 +26,9 @@ actor Main
     try
       let path = FilePath(env.root as AmbientAuth, "/bin/cat")?
       // define the arguments; first arg is always the binary name
-      let args: Array[String] val = [ "cat" ]
+      let args: Array[String] val = ["cat"]
       // define the environment variable for the execution
-      let vars: Array[String] val = [ "HOME=/"; "PATH=/bin" ]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
       // create a ProcessMonitor and spawn the child process
       let auth = env.root as AmbientAuth
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,


### PR DESCRIPTION
Most of these, I've recently introduced in #2953.

Fix provided by

    rg -g '*.pony' -l '\[ .* \]' | xargs gsed -i 's/\[ \(.*\) \]/[\1]/g'