### PR TITLE
Use partial arithmetic in read_int instead of custom overflow check

### DIFF
--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -1422,18 +1422,12 @@ actor Main
         break
       end
 
-      let new_value: A = if minus then
-        (value * base') - digit
+      value = if minus then
+        (value *? base') -? digit
       else
-        (value * base') + digit
+        (value *? base') +? digit
       end
 
-      if (new_value / base') != value then
-        // Overflow
-        error
-      end
-
-      value = new_value
       had_digit = true
       index = index + 1
     end


### PR DESCRIPTION
Hopefully partial arithmetic will be able to make use of carry/overflow registers to make this faster than the custom overflow check that was used previously.