### PR TITLE
Add `Struct` package

### DIFF
--- a/packages/struct/_test.pony
+++ b/packages/struct/_test.pony
@@ -1,0 +1,267 @@
+use "ponytest"
+use "buffered"
+use "collections"
+
+actor Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestPackUnpack)
+    test(_TestParseFormat)
+
+class iso _TestPackUnpack is UnitTest
+  fun name(): String => "struct/pack_unpack"
+
+  fun apply(h: TestHelper) ? =>
+   // test a hand made string
+    let fmt1 = "<Iq10s5pfd"
+    let ar_u8_1: Array[U8] val = recover val [as U8: 9;9;9;9;9] end
+    let args1: Array[_Packable val] = recover
+                [ U32(10)
+                  I64(100)
+                  "abcdefghij"
+                  ar_u8_1
+                  F32(0.5)
+                  F64(0.25)] end
+    let o1 = Struct.pack(fmt1, args1)?
+    let r1 = Reader
+    for bs in o1.values() do
+      r1.append(consume bs)
+    end
+    let u1 = Struct.unpack(fmt1, consume r1)?
+    h.assert_eq[U32](args1(0)? as U32, u1(0)? as U32)
+    h.assert_eq[I64](args1(1)? as I64, u1(1)? as I64)
+    h.assert_eq[String](args1(2)? as String, u1(2)? as String)
+    let u1_u8: Array[U8] val = u1(3)? as Array[U8] val
+    for idx in u1_u8.keys() do
+      h.assert_eq[U8](ar_u8_1(idx)?, u1_u8(idx)?)
+    end
+    h.assert_eq[F32](args1(4)? as F32, u1(4)? as F32)
+    h.assert_eq[F64](args1(5)? as F64, u1(5)? as F64)
+
+    // test one sample for each type
+
+    // pad byte: x
+    var r = Reader
+    var packed = Struct.pack("xs", ["a"])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](2, r.size())
+    var unpacked = Struct.unpack(">xs", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[String]("a", unpacked(0)? as String)
+
+    // char (string of size 1): c
+    r = Reader
+    packed = Struct.pack("c", ["a"])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](1, r.size())
+    unpacked = Struct.unpack("c", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[String]("a", unpacked(0)? as String)
+
+    // I8: b
+    r = Reader
+    packed = Struct.pack("b", [I8(-1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](1, r.size())
+    unpacked = Struct.unpack("b", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[I8](-1, unpacked(0)? as I8)
+
+    // U8: B
+    r = Reader
+    packed = Struct.pack("B", [U8(1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](1, r.size())
+    unpacked = Struct.unpack("B", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[U8](1, unpacked(0)? as U8)
+
+    // Bool: ?
+    r = Reader
+    packed = Struct.pack("??", [true; false])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](2, r.size())
+    unpacked = Struct.unpack("??", consume r)?
+    h.assert_eq[USize](2, unpacked.size())
+    h.assert_eq[Bool](true, unpacked(0)? as Bool)
+    h.assert_eq[Bool](false, unpacked(1)? as Bool)
+
+    // I16: h
+    r = Reader
+    packed = Struct.pack("h", [I16(-1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](2, r.size())
+    unpacked = Struct.unpack("h", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[I16](-1, unpacked(0)? as I16)
+
+    // U16: H
+    r = Reader
+    packed = Struct.pack("H", [U16(1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](2, r.size())
+    unpacked = Struct.unpack("H", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[U16](1, unpacked(0)? as U16)
+
+    // I32: i, l
+    r = Reader
+    packed = Struct.pack("il", [I32(-1); I32(-2)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](8, r.size())
+    unpacked = Struct.unpack("il", consume r)?
+    h.assert_eq[USize](2, unpacked.size())
+    h.assert_eq[I32](-1, unpacked(0)? as I32)
+    h.assert_eq[I32](-2, unpacked(1)? as I32)
+
+    // U32: I, L
+    r = Reader
+    packed = Struct.pack("IL", [U32(1); U32(2)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](8, r.size())
+    unpacked = Struct.unpack("IL", consume r)?
+    h.assert_eq[USize](2, unpacked.size())
+    h.assert_eq[U32](1, unpacked(0)? as U32)
+    h.assert_eq[U32](2, unpacked(1)? as U32)
+
+
+    // I64: q
+    r = Reader
+    packed = Struct.pack("q", [I64(-1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](8, r.size())
+    unpacked = Struct.unpack("q", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[I64](-1, unpacked(0)? as I64)
+
+    // U64: Q
+    r = Reader
+    packed = Struct.pack("Q", [U64(1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](8, r.size())
+    unpacked = Struct.unpack("Q", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[U64](1, unpacked(0)? as U64)
+
+    // I128: u
+    r = Reader
+    packed = Struct.pack("u", [I128(-1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](16, r.size())
+    unpacked = Struct.unpack("u", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[I128](-1, unpacked(0)? as I128)
+
+    // U128: U
+    r = Reader
+    packed = Struct.pack("U", [U128(1)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](16, r.size())
+    unpacked = Struct.unpack("U", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[U128](1, unpacked(0)? as U128)
+
+    // F32: f
+    r = Reader
+    packed = Struct.pack("f", [F32(-0.5)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](4, r.size())
+    unpacked = Struct.unpack("f", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[F32](-0.5, unpacked(0)? as F32)
+
+    // F64: d
+    r = Reader
+    packed = Struct.pack("d", [F64(-0.5)])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](8, r.size())
+    unpacked = Struct.unpack("d", consume r)?
+    h.assert_eq[USize](1, unpacked.size())
+    h.assert_eq[F64](-0.5, unpacked(0)? as F64)
+
+    // String: [length]s  // if length left out, s is 1 char long
+    r = Reader
+    packed = Struct.pack("s4s", ["a"; "bcde"])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](5, r.size())
+    unpacked = Struct.unpack("s4s", consume r)?
+    h.assert_eq[USize](2, unpacked.size())
+    h.assert_eq[String]("a", unpacked(0)? as String)
+    h.assert_eq[String]("bcde", unpacked(1)? as String)
+
+    // Array[U8]: [length]p  // if length left out, p is 1 U8 long
+    r = Reader
+    packed = Struct.pack("p4p", [[as U8: 1]; [as U8: 2;3;4;5]])?
+    for bs in packed.values() do
+      r.append(consume bs)
+    end
+    h.assert_eq[USize](5, r.size())
+    unpacked = Struct.unpack("p4p", consume r)?
+    h.assert_eq[USize](2, unpacked.size())
+    h.assert_eq[U8](1, (unpacked(0)? as Array[U8] val)(0)?)
+    for (i, v) in (unpacked(1)? as Array[U8] val).pairs() do
+      h.assert_eq[U8](i.u8() + 2, v)
+    end
+
+class iso _TestParseFormat is UnitTest
+  fun name(): String => "struct/_parseformat"
+
+  fun apply(h: TestHelper) ? =>
+    // test handmade strings
+    let v = _ParseFormat(">Iq5s10s")?
+    let v' = _ParseFormat("<QcbB5s")?
+
+    // test a string of all types in both endiannesses
+    let b = _ParseFormat(">xcbB?hHiIlLqQuUfdsp10s10p")?
+    let l = _ParseFormat("<xcbB?hHiIlLqQuUfdsp10s10p")?
+    // Check the string and char[] types have appropriate lengths
+    h.assert_eq[USize](b._2(b._2.size()-1)?._2, 10)
+    h.assert_eq[USize](b._2(b._2.size()-2)?._2, 10)
+    h.assert_eq[USize](l._2(l._2.size()-1)?._2, 10)
+    h.assert_eq[USize](l._2(l._2.size()-2)?._2, 10)
+
+    // Test repetition and length specifiers
+    let a3 = _ParseFormat(">3x3c3b3B3?3h3H3i3I3l3L3q3Q3u3U3f3d3s3p")?
+    h.assert_eq[USize](3, a3._3)  // 3 padding bytes!
+    h.assert_eq[USize](51, a3._2.size())
+    for (c, s) in a3._2.values() do
+      if "xsp".contains(c) then
+        h.assert_eq[USize](3, s)
+      else
+        h.assert_eq[USize](1, s)
+      end
+    end

--- a/packages/struct/struct.pony
+++ b/packages/struct/struct.pony
@@ -1,0 +1,280 @@
+"""
+# Struct package
+
+This package performs conversions between Pony values and C structs represented
+as Pony ByteSeq objects. This can be used in handling binary data stored in
+files or from network connections, among other sources. It uses Format Strings
+as compact descriptions of the layout of the C structs and the intended
+conversion to/from Pony values.
+
+It is inspired by the Python Struct module:
+https://docs.python.org/3.7/library/struct.html
+
+## Usage
+
+### Struct.pack
+Pack an `Array[(Bool | Number | String | Array[U8] val)]` according to a format
+string:
+
+```pony
+let byte_seqs = Struct.pack(">Iqd5ss5p",
+  [ 1024
+    1544924117813084
+    3.141592653589793
+    "hello"
+    "!"
+    recover [as U8: 1;2;3;4;5] end
+    ] )?
+```
+
+### Struct.unpack
+Unpack a bytestream (a buffered Reader) into an
+`Array[(Bool | Number | String | Array[U8] val)]` according to a format string:
+
+```pony
+let unpacked = Struct.unpack(">Iq5s", consume reader)?
+let length: U32 = unpacked(0)?
+let nanosecond_offset = unpacked(1)? as I64
+let message: String = unpacked(2)?
+```
+
+## Byte Order
+Byte order can be optionally specified with the first character in the format
+string.
+
+| Byte order | character |
+|     -      |     -     |
+| Big Endian | >         |
+| Little Endian | <      |
+
+
+The format conversion specification is described in the table below.
+
+| Format | C Type             | Pony type | Standard size |
+|   -    |    -               |      -    |        -      |
+| x	     | pad byte           |	no value  | 1             |
+| c      | char               |	String    |	1	            |
+| b      | signed char        | I8        | 1             |
+| B	     | unsigned char      | U8        | 1             |
+| ?      | _Bool              | Bool      | 1             |
+| h      | short              | I16       | 2             |
+| H      | unsigned short     | U16       | 2             |
+| i      | int                | I32       | 4             |
+| I      | unsigned int       | U32       | 4	            |
+| l      | long               | I32       | 4             |
+| L      | unsigned long      | U32       | 4             |
+| q      | long long          | I64       | 8             |
+| Q      | unsigned long long | U64       | 8             |
+| u      | unsigned bigint    | U128      | 16            |
+| f      | float              | f32       | 4             |
+| d      | double             | f64       | 8             |
+| s      | char[]             | String    |               |
+| p      | char[]             | Array[U8] |               |
+
+
+Each type may be preceded with an integer representing its length (in the case
+of String and Array[U8]) or number repetitions (all other types).
+
+All types passed to `pack` must have a reference capability of val.
+"""
+
+use "buffered"
+use "collections"
+
+type _Packable is (Bool | Number | String | Array[U8] val)
+
+primitive _BigEndian
+  fun string(): String => "BigEndian"
+primitive _LittleEndian
+  fun string(): String => "LittlEndian"
+type Endian is (_BigEndian | _LittleEndian)
+
+primitive Struct
+  """
+  Convert between native Pony types and bytestreams.
+  """
+  fun pack(fmt: String, args: Array[_Packable val], wb: Writer = Writer):
+    Array[ByteSeq] ref^ ?
+  =>
+    """
+    Convert an `Array[(Bool | Number | String | Array[U8] val)]` to an
+    `Array[ByteSeq]` using a format specification string.
+    """
+    (let nd, let tspec, let pad_bytes) = _ParseFormat(fmt)?
+    let big: Bool =
+      match nd
+      | _BigEndian => true
+      else false
+      end
+
+    if (tspec.size() - pad_bytes) != args.size() then
+      error
+    end
+
+    // We need an offset count for padding bytes to use when accessing
+    // the args array with the tspec index
+    var offset: USize = 0
+    for idx in Range(0, tspec.size()) do
+      let ts = tspec(idx)?
+      let arg =
+        try
+          args(idx - offset)?
+        else
+          None
+        end
+
+      match (ts._1, arg)
+      | ("x", _) =>
+        wb.u8(0)
+        offset = offset + 1
+      | ("b", let a: I8) => wb.u8(a.u8())
+      | ("B", let a: U8) => wb.u8(a)
+      | ("?", let a: Bool) => if a then wb.u8(1) else wb.u8(0) end
+      | ("h", let a: I16) => if big then wb.i16_be(a) else wb.i16_le(a) end
+      | ("H", let a: U16) => if big then wb.u16_be(a) else wb.u16_le(a) end
+      | ("i", let a: I32) => if big then wb.i32_be(a) else wb.i32_le(a) end
+      | ("I", let a: U32) => if big then wb.u32_be(a) else wb.u32_le(a) end
+      | ("l", let a: I32) => if big then wb.i32_be(a) else wb.i32_le(a) end
+      | ("L", let a: U32) => if big then wb.u32_be(a) else wb.u32_le(a) end
+      | ("q", let a: I64) => if big then wb.i64_be(a) else wb.i64_le(a) end
+      | ("Q", let a: U64) => if big then wb.u64_be(a) else wb.u64_le(a) end
+      | ("u", let a: I128) => if big then wb.i128_be(a) else wb.i128_le(a) end
+      | ("U", let a: U128) => if big then wb.u128_be(a) else wb.u128_le(a) end
+      | ("f", let a: F32) => if big then wb.f32_be(a) else wb.f32_le(a) end
+      | ("d", let a: F64) => if big then wb.f64_be(a) else wb.f64_le(a) end
+      | ("c", let a: (String | U8)) =>
+        match a
+        | let a': String => wb.write(a')
+        | let a': U8 => wb.u8(a')
+        end
+      | ("s", let a: String) =>
+        if a.size() != ts._2 then
+          error
+        end
+        wb.write(a)
+      | ("p", let a: Array[U8] val) =>
+        if a.size() != ts._2 then
+          error
+        end
+        wb.write(a)
+      else
+          error
+      end
+    end
+    wb.done()
+
+  fun unpack(fmt: String, rb: Reader): Array[_Packable val] ref^ ? =>
+    """
+    Convert a buffered `Reader` to an
+    `Array[(Bool | Number | String | Array[U8] val)]` using a format
+    specification string.
+    """
+    (let nd, let tspec, _) = _ParseFormat(fmt)?
+    let big: Bool =
+      match nd
+      | _BigEndian => true
+      else false
+      end
+
+    let a: Array[_Packable] ref = recover Array[_Packable] end
+    for ts in tspec.values() do
+      match ts._1
+      | "x" => for i in Range(0, ts._2) do rb.skip(1)? end
+      | "b" => for i in Range(0, ts._2) do a.push(rb.i8()?) end
+      | "B" => for i in Range(0, ts._2) do a.push(rb.u8()?) end
+      | "?" => for i in Range(0, ts._2) do
+          a.push(if rb.u8()? == 1 then true else false end)
+        end
+      | "h" => for i in Range(0, ts._2) do
+          a.push(if big then rb.i16_be()? else rb.i16_le()? end)
+        end
+      | "H" => for i in Range(0, ts._2) do
+          a.push(if big then rb.u16_be()? else rb.u16_le()? end)
+        end
+      | "i" => for i in Range(0, ts._2) do
+          a.push(if big then rb.i32_be()? else rb.i32_le()? end)
+        end
+      | "I" => for i in Range(0, ts._2) do
+          a.push(if big then rb.u32_be()? else rb.u32_le()? end)
+        end
+      | "l" => for i in Range(0, ts._2) do
+          a.push(if big then rb.i32_be()? else rb.i32_le()? end)
+        end
+      | "L" => for i in Range(0, ts._2) do
+          a.push(if big then rb.u32_be()? else rb.u32_le()? end)
+        end
+      | "q" => for i in Range(0, ts._2) do
+          a.push(if big then rb.i64_be()? else rb.i64_le()? end)
+        end
+      | "Q" => for i in Range(0, ts._2) do
+          a.push(if big then rb.u64_be()? else rb.u64_le()? end)
+        end
+      | "u" => for i in Range(0, ts._2) do
+          a.push(if big then rb.i128_be()? else rb.i128_le()? end)
+        end
+      | "U" => for i in Range(0, ts._2) do
+          a.push(if big then rb.u128_be()? else rb.u128_le()? end)
+        end
+      | "f" => for i in Range(0, ts._2) do
+          a.push(if big then rb.f32_be()? else rb.f32_le()? end)
+        end
+      | "d" => for i in Range(0, ts._2) do
+          a.push(if big then rb.f64_be()? else rb.f64_le()? end)
+        end
+      | "c" => for i in Range(0, ts._2) do
+          a.push(String.from_array(rb.block(1)?))
+        end
+      | "s" => a.push(String.from_array(rb.block(ts._2)?))
+      | "p" => a.push(rb.block(ts._2)?)
+      else
+          error
+      end
+    end
+    consume a
+
+primitive _ParseFormat
+  fun apply(fmt: String): (Endian, Array[(String, USize)], USize) ? =>
+    var padding_bytes: USize = 0
+    var start_from: USize = 0
+    let nd: Endian =
+      if fmt.at("<", 0) then
+        start_from = 1
+        _LittleEndian
+      elseif fmt.at(">", 0) then
+        start_from = 1
+        _BigEndian
+      else
+        _BigEndian
+      end
+    let a: Array[(String, USize)] ref = recover Array[(String, USize)] end
+    var s: String = ""
+    for i in Range(start_from, fmt.size()) do
+      let c = String.from_array([fmt(i)?])
+      if "xcbB?hHiIlLqQuUfdsp".contains(c) then
+        if c == "x" then
+          if s == "" then
+            padding_bytes = padding_bytes + 1
+            a.push((c, 1))
+          else
+            padding_bytes = padding_bytes + s.usize()?
+            a.push((c, s.usize()?))
+            s = ""
+          end
+        else
+          if s == "" then
+            a.push((c, 1))
+          elseif "sp".contains(c) then
+            a.push((c, s.usize()?))
+            s = ""
+          else
+            for x in Range(0, s.usize()?) do
+              a.push((c, 1))
+            end
+            s = ""
+          end
+        end
+      else
+        s = s + c
+      end
+    end
+    (nd, consume a, padding_bytes)


### PR DESCRIPTION
Add a `struct` package for conversions from pony types to bytestreams and vice versa using a format string.
It is inspired by the [Python struct module](https://docs.python.org/3.7/library/struct.html)

Includes:
- Add struct package, using `Writer` and `Reader` to handle type
conversions from native pony types to a bystream and back.
- Documentation
- unit Tests


**Notes**:
- It's possible to do all of what this package does with the `Writer` and `Reader` in the `buffered` package. In fact, the `Struct` primitive uses the `Writer` and `Reader` classes to do the real conversions.
- However... When writing a network format spec between Python and Pony, I found myself wishing I could use the Python struct format to specify the actual bytestream formatting rules.
    - Even more appealing was the idea of using **the same** format string on both sides. But perhaps that's a bit too `Python<->Pony` specific to be generally applicable.
- Perhaps this could become part of `buffered` instead of being its own package.
- While this is really handy when converting from Pony to a bytestream, the other way around still feels a little clunky.
    Because the return type is  `Array[(Bool | Number | String | Array[U8] val)]`, when accessing the unpacked arguments, the user still has to explicitly cast to their target type.
    I'm not super happy about this part, but I don't have any good ideas on how to make this more user friendly. I'd be happy to incorporate any ideas or feedback you might have for this!
    e.g. (from one of the unit tests):
    ```pony
    let u1 = Struct.unpack(fmt1, consume r1)?
    h.assert_eq[U32](args1(0)? as U32, u1(0)? as U32)
    ```