### PR TITLE
libponyc: resolve relative paths in use "path:..." statements

### DIFF
--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -560,7 +560,7 @@ static const char* create_package_symbol(ast_t* program, const char* filename)
 
 
 // Create a package AST, set up its state and add it to the given program
-static ast_t* create_package(ast_t* program, const char* name,
+ast_t* create_package(ast_t* program, const char* name,
   const char* qualified_name, pass_opt_t* opt)
 {
   ast_t* package = ast_blank(TK_PACKAGE);

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -86,6 +86,14 @@ ast_t* program_load(const char* path, pass_opt_t* opt);
 ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt);
 
 /**
+ * Create a package AST, set up its state and add it to the given program.
+ * used by package_load. Should not be used elsewhere but for setting up fake
+ * package for testing.
+ */
+ast_t* create_package(ast_t* program, const char* name,
+  const char* qualified_name, pass_opt_t* opt);
+
+/**
  * Free the package_t that is set as the ast_data of a package node.
  */
 void package_free(package_t* package);

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -149,23 +149,14 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
 {
   (void)name;
   char absolute[FILENAME_MAX];
+  const char* prefix = NULL;
 
-  ast_t* pkg_ast = ast_nearest(use, TK_PACKAGE);
-  const char* pkg_path = package_path(pkg_ast);
-
-  if(is_path_absolute(locator)) {
-    if(strlen(locator) > FILENAME_MAX)
-      return false;
-
-    strcpy(absolute, locator);
-  } else {
-    // resolve path relative to pkg path
-    if(strlen(pkg_path) + strlen(locator) >= FILENAME_MAX)
-      return false;
-
-    path_cat(pkg_path, locator, absolute);
+  if(!is_path_absolute(locator)) {
+    ast_t* pkg_ast = ast_nearest(use, TK_PACKAGE);
+    prefix = package_path(pkg_ast);
   }
 
+  path_cat(prefix, locator, absolute);
   const char* libpath = quoted_locator(options, use, absolute);
 
   if(libpath == NULL)

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -148,8 +148,7 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
   pass_opt_t* options)
 {
   (void)name;
-  char resolved[FILENAME_MAX];
-  char composite[FILENAME_MAX];
+  char absolute[FILENAME_MAX];
 
   ast_t* pkg_ast = ast_nearest(use, TK_PACKAGE);
   const char* pkg_path = package_path(pkg_ast);
@@ -158,22 +157,16 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
     if(strlen(locator) > FILENAME_MAX)
       return false;
 
-    strcpy(composite, locator);
+    strcpy(absolute, locator);
   } else {
     // resolve path relative to pkg path
     if(strlen(pkg_path) + strlen(locator) >= FILENAME_MAX)
       return false;
 
-    path_cat(pkg_path, locator, composite);
+    path_cat(pkg_path, locator, absolute);
   }
 
-  if(pony_realpath(composite, resolved) != resolved) {
-    errorf(options->check.errors, package_filename(pkg_ast),
-           "\"path:%s\": %s", locator, strerror(errno));
-    return false;
-  }
-
-  const char* libpath = quoted_locator(options, use, resolved);
+  const char* libpath = quoted_locator(options, use, absolute);
 
   if(libpath == NULL)
     return false;

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -151,26 +151,26 @@ bool use_path(ast_t* use, const char* locator, ast_t* name,
   char resolved[FILENAME_MAX];
   char composite[FILENAME_MAX];
 
+  ast_t* pkg_ast = ast_nearest(use, TK_PACKAGE);
+  const char* pkg_path = package_path(pkg_ast);
+
   if(is_path_absolute(locator)) {
     if(strlen(locator) > FILENAME_MAX)
       return false;
 
-    strcpy(resolved, locator);
+    strcpy(composite, locator);
   } else {
     // resolve path relative to pkg path
-    ast_t* pkg_ast = ast_nearest(use, TK_PACKAGE);
-    const char* pkg_path = package_path(pkg_ast);
-
     if(strlen(pkg_path) + strlen(locator) >= FILENAME_MAX)
       return false;
 
     path_cat(pkg_path, locator, composite);
+  }
 
-    if(pony_realpath(composite, resolved) != resolved) {
-      errorf(options->check.errors, package_filename(pkg_ast),
-             "resolve \"path:%s\": %s", locator, strerror(errno));
-      return false;
-    }
+  if(pony_realpath(composite, resolved) != resolved) {
+    errorf(options->check.errors, package_filename(pkg_ast),
+           "\"path:%s\": %s", locator, strerror(errno));
+    return false;
   }
 
   const char* libpath = quoted_locator(options, use, resolved);

--- a/test/libponyc/program.cc
+++ b/test/libponyc/program.cc
@@ -213,7 +213,11 @@ TEST(ProgramTest, LibPathsRelative)
   errors_print(opt.check.errors);
   pass_opt_done(&opt);
 
+#ifdef PLATFORM_IS_WINDOWS
+  const char* expect = "static\"/foo\\bar\" dynamic\"/foo\\bar\" ";
+#else
   const char* expect = "static\"/foo/bar\" dynamic\"/foo/bar\" ";
+#endif
   ASSERT_STREQ(expect, program_lib_args(prog));
 
   ast_free(prog);


### PR DESCRIPTION
This is for #2936.

The use of `pony_realpath` (which calls the POSIX `realpath` underneath)
is convenient, but brings a change in behaviour: before, we have passed
just about anything into `prog->libpaths`, regardless of the directory's
existence. With `realpath`, nonexistent directories will make the call
return an error.

To remediate the impact a bit, I've added an `errorf()` statement.

However, to make this round, I think we might have to either check for
existence in both cases~, or don't do that in either one.~

*Update*: I've rearrange stuff so that both absolute and relative paths are check (by being passed through `pony_realpath`. This is a potentially a backwards-incompatible change; I'd think it might be one we can accept, though? Let's discuss this 😃 