### PR TITLE
Fix silent crash with incorrect time formats in Windows

### DIFF
--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -275,6 +275,7 @@ actor PonyTest
     _env = env
     _process_opts()
     _groups.push(("", _SimultaneousGroup))
+    @ponyint_assert_disable_popups[None]()
     list.tests(this)
     _all_tests_applied()
 

--- a/packages/time/_test.pony
+++ b/packages/time/_test.pony
@@ -37,3 +37,12 @@ class iso _TestPosixDate is UnitTest
     h.assert_eq[I64](1, PosixDate(-1, 1_000_000_000).time())
     // negative nanoseconds cannot not affect time
     h.assert_eq[I64](1, PosixDate(1, -1_000_000_000).time())
+
+    // Windows should throw error when %L is in format string
+    ifdef windows then
+      h.assert_error({() ? =>
+        (let seconds, let nanos) = Time.now()
+        let d = PosixDate(seconds, nanos)
+        d.format("%Y-%m-%d %H:%M:%S.%L")?
+      })
+    end

--- a/packages/time/posix_date.pony
+++ b/packages/time/posix_date.pony
@@ -37,13 +37,13 @@ class PosixDate
     """
     @ponyint_gmtime[None](this, time(), nsec)
 
-  fun format(fmt: String): String =>
+  fun format(fmt: String): String ? =>
     """
     Format the time as for strftime.
     """
     recover
       String.from_cstring(@ponyint_formattime[Pointer[U8]](this,
-        fmt.cstring()))
+        fmt.cstring())?)
     end
 
   fun _negative_to_zero(value: I64): I64 =>

--- a/src/common/ponyassert.h
+++ b/src/common/ponyassert.h
@@ -20,6 +20,8 @@ PONY_EXTERN_C_BEGIN
 void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   const char* func);
 
+void ponyint_assert_disable_popups();
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyrt/lang/time.c
+++ b/src/libponyrt/lang/time.c
@@ -83,12 +83,19 @@ PONY_API void ponyint_gmtime(date_t* date, int64_t sec, int64_t nsec)
   tm_to_date(&tm, (int)nsec, date);
 }
 
-void format_invalid_parameter_handler(const wchar_t* /*expression*/,
-  const wchar_t* /*function*/,
-  const wchar_t* /*file*/,
-  unsigned int /*line*/,
-  uintptr_t /*p_reserved*/)
+void format_invalid_parameter_handler(const wchar_t* expression,
+  const wchar_t* function,
+  const wchar_t* file,
+  unsigned int line,
+  uintptr_t p_reserved)
 {
+  // Cast all parameters to void to silence unused parameter warning
+  (void) expression;
+  (void) function;
+  (void) file;
+  (void) line;
+  (void) p_reserved;
+
   // Throw a pony error
   pony_error();
 }

--- a/src/libponyrt/lang/time.c
+++ b/src/libponyrt/lang/time.c
@@ -127,14 +127,14 @@ PONY_API char* ponyint_formattime(date_t* date, const char* fmt)
     #ifdef PLATFORM_IS_WINDOWS
       _invalid_parameter_handler old_handler, new_handler;
       new_handler = format_invalid_parameter_handler;
-      old_handler = _set_invalid_parameter_handler(new_handler);
+      old_handler = _set_thread_local_invalid_parameter_handler(new_handler);
     #endif
 
     r = strftime(buffer, len, fmt, &tm);
 
     // Reset the invalid parameter handler
     #ifdef PLATFORM_IS_WINDOWS
-      _set_invalid_parameter_handler(old_handler);
+      _set_thread_local_invalid_parameter_handler(old_handler);
     #endif
 
     len <<= 1;

--- a/src/libponyrt/lang/time.c
+++ b/src/libponyrt/lang/time.c
@@ -83,6 +83,16 @@ PONY_API void ponyint_gmtime(date_t* date, int64_t sec, int64_t nsec)
   tm_to_date(&tm, (int)nsec, date);
 }
 
+void format_invalid_parameter_handler(const wchar_t* /*expression*/,
+  const wchar_t* /*function*/,
+  const wchar_t* /*file*/,
+  unsigned int /*line*/,
+  uintptr_t /*p_reserved*/)
+{
+  // Throw a pony error
+  pony_error();
+}
+
 PONY_API char* ponyint_formattime(date_t* date, const char* fmt)
 {
   pony_ctx_t* ctx = pony_ctx();
@@ -105,7 +115,21 @@ PONY_API char* ponyint_formattime(date_t* date, const char* fmt)
   while(r == 0)
   {
     buffer = (char*)pony_alloc(ctx, len);
+
+    // Set up an invalid parameter handler on Windows to throw a Pony error
+    #ifdef PLATFORM_IS_WINDOWS
+      _invalid_parameter_handler old_handler, new_handler;
+      new_handler = format_invalid_parameter_handler;
+      old_handler = _set_invalid_parameter_handler(new_handler);
+    #endif
+
     r = strftime(buffer, len, fmt, &tm);
+
+    // Reset the invalid parameter handler
+    #ifdef PLATFORM_IS_WINDOWS
+      _set_invalid_parameter_handler(old_handler);
+    #endif
+
     len <<= 1;
   }
 

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -146,3 +146,22 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
 }
 
 #endif
+
+void ponyint_assert_disable_popups()
+{
+  // from LLVM utils/unittest/UnitTestMain/TestMain.cpp
+# if defined(_WIN32)
+  // Disable all of the possible ways Windows conspires to make automated
+  // testing impossible.
+  ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#   if defined(_MSC_VER)
+    ::_set_error_mode(_OUT_TO_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#   endif
+# endif
+}


### PR DESCRIPTION
This is a pull request to address issue #2729 . It sets the `PosixDate.format()` function as a partial function, and catches the structured exception thrown by Windows, throwing a Pony error instead.