### PR TITLE
Fix linker library version error on MacOS when installed via Homebrew

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -221,8 +221,8 @@ else
 endif
 
 ifeq ($(OSTYPE),osx)
-  ALL_CFLAGS += -mmacosx-version-min=10.8 -DUSE_SCHEDULER_SCALING_PTHREADS
-  ALL_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=10.8
+  ALL_CFLAGS += -mmacosx-version-min=10.12 -DUSE_SCHEDULER_SCALING_PTHREADS
+  ALL_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=10.12
 endif
 
 ifndef LLVM_CONFIG

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -286,7 +286,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   snprintf(ld_cmd, ld_len,
     "%s -execute -no_pie -arch %.*s "
-    "-macosx_version_min 10.8 -o %s %s %s %s -lSystem",
+    "-macosx_version_min 10.12 -o %s %s %s %s -lSystem",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt
     );


### PR DESCRIPTION
Updating minimum OSX version from 10.8 to the current minimum version of 10.12 supported by Apple.  The minimum supported OSX version is not officially advertised but can be worked out by looking at the Apple updates web page here https://support.apple.com/en-us/HT201222.  See also the discussion on this issue https://github.com/ponylang/ponyc/issues/2920.