### PR TITLE
Document type parameters of TestHelper ReadSeq methods

### DIFF
--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -250,6 +250,9 @@ class val TestHelper
   =>
     """
     Assert that the contents of the 2 given ReadSeqs are equal.
+
+    The type parameter of this function is the type parameter of the
+    elements in both ReadSeqs.
     """
     var ok = true
 
@@ -292,6 +295,9 @@ class val TestHelper
   =>
     """
     Assert that the contents of the 2 given ReadSeqs are equal ignoring order.
+
+    The type parameter of this function is the type parameter of the
+    elements in both ReadSeqs.
     """
     try
       let missing = Array[box->A]
@@ -344,6 +350,9 @@ class val TestHelper
     """
     Generate a printable string of the contents of the given readseq to use in
     error messages.
+
+    The type parameter of this function is the type parameter of the
+    elements in the ReadSeq.
     """
     "[len=" + array.size().string() + ": " + ", ".join(array.values()) + "]"
 

--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -252,7 +252,15 @@ class val TestHelper
     Assert that the contents of the 2 given ReadSeqs are equal.
 
     The type parameter of this function is the type parameter of the
-    elements in both ReadSeqs.
+    elements in both ReadSeqs. For instance, when comparing two `Array[U8]`,
+    you should call this method as follows:
+    
+    ```pony
+    fun apply(h: TestHelper) =>
+      let a: Array[U8] = [1; 2; 3]
+      let b: Array[U8] = [1; 2; 3]
+      h.assert_array_eq[U8](a, b)
+    ```
     """
     var ok = true
 
@@ -297,7 +305,15 @@ class val TestHelper
     Assert that the contents of the 2 given ReadSeqs are equal ignoring order.
 
     The type parameter of this function is the type parameter of the
-    elements in both ReadSeqs.
+    elements in both ReadSeqs. For instance, when comparing two `Array[U8]`,
+    you should call this method as follows:
+    
+    ```pony
+    fun apply(h: TestHelper) =>
+      let a: Array[U8] = [1; 2; 3]
+      let b: Array[U8] = [1; 3; 2]
+      h.assert_array_eq_unordered[U8](a, b)
+    ```
     """
     try
       let missing = Array[box->A]


### PR DESCRIPTION
Following discussion from [this Slack thread](https://ponylang.slack.com/archives/CFFPDRCDT/p1549153332153100).

[ci skip]