### PR TITLE
Refactor to use new PassBuilder for LLVM > 4.

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -117,7 +117,7 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_BUILD_CONFIG=\"$(config)\" \
   -DPONY_VERSION_STR=\"$(version_str)\" \
   -D_FILE_OFFSET_BITS=64
-ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
+ALL_CXXFLAGS = -std=gnu++11 -fno-rtti -fabi-version=6
 LL_FLAGS = -mcpu=$(cpu)
 
 # Determine pointer size in bits.

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -117,8 +117,27 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_BUILD_CONFIG=\"$(config)\" \
   -DPONY_VERSION_STR=\"$(version_str)\" \
   -D_FILE_OFFSET_BITS=64
-ALL_CXXFLAGS = -std=gnu++11 -fno-rtti -fabi-version=6
+ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 LL_FLAGS = -mcpu=$(cpu)
+
+# If we're using gcc < 5.1, we have to use a workaround for a name mangling bug
+# with variadic templates that we use in our code that interfaces with LLVM.
+ifneq (,$(shell $(CC) -v 2>&1 | grep 'gcc version'))
+  # compiler is gcc
+  GCC_VERSION = $(shell $(CC) -v 2>&1 | grep -o 'gcc version [0-9].[0-9]' | cut -f3 -d' ')
+  ifeq ("1",$(shell expr `echo $(GCC_VERSION) | cut -f1 -d.` == 5))
+    # compiler is gcc 5.x
+    ifeq ("1",$(shell expr `echo $(GCC_VERSION) | cut -f2 -d.` \< 1))
+      # compiler is gcc < 5.1
+      ALL_CXXFLAGS += -fabi-version=6
+    endif
+  else
+    ifeq ("1",$(shell expr `echo $(GCC_VERSION) | cut -f1 -d.` \< 5))
+      # compiler is gcc < 5
+      ALL_CXXFLAGS += -fabi-version=6
+    endif
+  endif
+endif
 
 # Determine pointer size in bits.
 BITS := $(bits)

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1547,7 +1547,7 @@ static void optimise(compile_t* c, bool pony_specific)
   TargetMachine* machine = reinterpret_cast<TargetMachine*>(c->machine);
 
   auto opt_level = PassBuilder::OptimizationLevel::O3;
-  bool debug_log = true;
+  bool debug_log = false; // enable this for very verbose logging of LLVM passes
 
   // There is a problem with optimised debug info in certain cases. This is
   // due to unknown bugs in the way ponyc is generating debug info. When they


### PR DESCRIPTION
Using the new PassBuilder is impractical for LLVM 3.9
(so it remains for now behind a preprocessor ifdef),
but it will pave the way to fixing some other problems
with LLVM > 4, including #2371.