### PR TITLE
Revert to LLVM 3.9.1 as the default for Windows builds.

### DIFF
--- a/wscript
+++ b/wscript
@@ -49,9 +49,9 @@ MSVC_VERSIONS = [ '15.9', '15.8', '15.7', '15.6', '15.4', '15.0', '14.0' ]
 
 # keep these in sync with the list in .appveyor.yml
 LLVM_VERSIONS = [
-    '7.0.1',
     '3.9.1',
-    '6.0.1'
+    '6.0.1',
+    '7.0.1'
 ]
 
 LIBRESSL_VERSION = "2.9.0"


### PR DESCRIPTION
Like a moron I had made the Windows build system only run debug-mode `stdlib` tests, which masked the fact that there is some kind of memory corruption going on for both 6.0.1 and 7.0.1 builds in release mode.

3.9.1 will need to be the default until that can be figured out.