### PR TITLE
Fix distclean error

### DIFF
--- a/lib/llvm/Makefile
+++ b/lib/llvm/Makefile
@@ -196,7 +196,8 @@ clean: clean-except-get
 
 .PHONY: distclean
 distclean: clean-except-get
-	rm -rf $(LLVM_SRC_DIR)/* $(LLVM_SRC_DIR)/.*
+	rm -rf $(LLVM_SRC_DIR)
+	mkdir $(LLVM_SRC_DIR)
 	rm -f get-*
 
 .PHONY: clean-except-get


### PR DESCRIPTION
In lib/llvm/Makefile a distclean causes an error:

  wink@wink-desktop:~/prgs/ponylang/ponyc-wink0/lib/llvm (fix-distclean)
  $ make distclean
  Makefile:36: "lib/llvm/Makefile MAKECMDGOALS=distclean"
  Makefile:109: "lib/llvm/Makefile: LLVM_PROJECT_LIST="
  Makefile:117: "lib/llvm/Makefile: PROJECT_LIST="
  rm -f built-* installed-*
  rm -rf /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/build /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/dist
  rm -rf /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src/* /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src/.*
  rm: refusing to remove '.' or '..' directory: skipping '/home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src/.'
  rm: refusing to remove '.' or '..' directory: skipping '/home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src/..'
  make: *** [Makefile:199: distclean] Error 1


After this change there is no error:

  wink@wink-desktop:~/prgs/ponylang/ponyc-wink0/lib/llvm (fix-distclean)
  $ make distclean
  Makefile:36: "lib/llvm/Makefile MAKECMDGOALS=distclean"
  Makefile:109: "lib/llvm/Makefile: LLVM_PROJECT_LIST="
  Makefile:117: "lib/llvm/Makefile: PROJECT_LIST="
  rm -f built-* installed-*
  rm -rf /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/build /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/dist
  rm -rf /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src
  mkdir /home/wink/prgs/ponylang/ponyc-wink0/lib/llvm/src
  rm -f get-*