### PR TITLE
Change default to disable pinning of scheduler threads to CPU cores

### DIFF
--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -213,10 +213,11 @@ static void usage(void)
     "                   point value. Defaults to 2.0.\n"
     "  --ponynoyield    Do not yield the CPU when no work is available.\n"
     "  --ponynoblock    Do not send block messages to the cycle detector.\n"
-    "  --ponynopin      Do not pin scheduler threads or the ASIO thread, even\n"
-    "                   if --ponypinasio is set.\n"
+    "  --ponypin        Pin scheduler threads to CPU cores. The ASIO thread\n"
+    "                   can also be pinned if `--ponypinasio` is set.\n"
     "  --ponypinasio    Pin the ASIO thread to a CPU the way scheduler\n"
-    "                   threads are pinned to CPUs.\n"
+    "                   threads are pinned to CPUs. Requires `--ponypin` to\n"
+    "                   be set to have any effect.\n"
     "  --ponyversion    Print the version of the compiler and exit.\n"
     );
 }

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -58,7 +58,7 @@ enum
   OPT_GCFACTOR,
   OPT_NOYIELD,
   OPT_NOBLOCK,
-  OPT_NOPIN,
+  OPT_PIN,
   OPT_PINASIO,
   OPT_VERSION
 };
@@ -73,7 +73,7 @@ static opt_arg_t args[] =
   {"ponygcfactor", 0, OPT_ARG_REQUIRED, OPT_GCFACTOR},
   {"ponynoyield", 0, OPT_ARG_NONE, OPT_NOYIELD},
   {"ponynoblock", 0, OPT_ARG_NONE, OPT_NOBLOCK},
-  {"ponynopin", 0, OPT_ARG_NONE, OPT_NOPIN},
+  {"ponypin", 0, OPT_ARG_NONE, OPT_PIN},
   {"ponypinasio", 0, OPT_ARG_NONE, OPT_PINASIO},
   {"ponyversion", 0, OPT_ARG_NONE, OPT_VERSION},
 
@@ -98,7 +98,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_GCFACTOR: opt->gc_factor = atof(s.arg_val); break;
       case OPT_NOYIELD: opt->noyield = true; break;
       case OPT_NOBLOCK: opt->noblock = true; break;
-      case OPT_NOPIN: opt->nopin = true; break;
+      case OPT_PIN: opt->nopin = false; break;
       case OPT_PINASIO: opt->pinasio = true; break;
       case OPT_VERSION: opt->version = true; break;
 
@@ -134,6 +134,7 @@ PONY_API int pony_init(int argc, char** argv)
   opt.cd_detect_interval = 100;
   opt.gc_initial = 14;
   opt.gc_factor = 2.0f;
+  opt.nopin = true;
 
   argc = parse_opts(argc, argv, &opt);
 


### PR DESCRIPTION
Prior to this commit, if a random user happened to be running
multiple pony applications that are CPU intensive, they would run
into unnecessary CPU contention due to CPU pinning (at least on
Linux) due to the first few cores being the ones used by all the
applications even if the system may have more cores available. This
was particularly troublesome because users may not even be aware
that the application they're running is a pony application.

This commit changes the default to not pin scheduler threads to CPU
cores. It also removes the `--ponynopin` CLI argument and replaces
it with the `--ponypin` CLI argument to leave the control for
pinning as an option for advanced users without requiring all users
of pony applications to understand pinning and how to disable it.

Resolves #3023