### PR TITLE
Use heap-to-stack workaround for Windows

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -306,7 +306,7 @@ public:
           // hoisting loads (see #2303, #2061, #1592).
           // TODO: figure out the real reason LLVM 4 and 5 produce bad code
           // when hoisting stack allocated loads.
-#if PONY_LLVM >= 400 && !defined(_MSC_VER)
+#if PONY_LLVM >= 400
           // fall through
 #else
           break;

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -319,7 +319,11 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
     switch(id)
     {
       case OPT_VERSION:
+#ifdef _MSC_VER
+        printf("%s %d\n", PONY_VERSION_STR, _MSC_VER);
+#else
         printf("%s\n", PONY_VERSION_STR);
+#endif
         printf("Defaults: pic=%s ssl=%s\n", opt->pic ? "true" : "false",
             PONY_DEFAULT_SSL);
         return EXIT_0;

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -138,7 +138,11 @@ PONY_API int pony_init(int argc, char** argv)
   argc = parse_opts(argc, argv, &opt);
 
   if (opt.version) {
-    printf("%s\n", PONY_VERSION_STR);
+#ifdef _MSC_VER
+        printf("%s %d\n", PONY_VERSION_STR, _MSC_VER);
+#else
+        printf("%s\n", PONY_VERSION_STR);
+#endif
     exit(0);
   }
 

--- a/wscript
+++ b/wscript
@@ -399,22 +399,23 @@ def test(ctx):
 
     ctx(
         features = 'seq',
-        rule     = '"' + os.path.join(ctx.bldnode.abspath(), 'ponyc') + '" -d -s --checktree --verify -b ' + stdlibDebugBinary + ' ../../packages/stdlib',
+        rule     = '"' + os.path.join(ctx.bldnode.abspath(), 'ponyc') + '" -d --checktree --verify -b ' + stdlibDebugBinary + ' ../../packages/stdlib',
         target   = stdlibDebugTarget,
         source   = ctx.bldnode.ant_glob('ponyc*') + ctx.path.ant_glob('packages/**/*.pony'),
     )
 
-    stdlibReleaseBinary = 'stdlib-release'
-    stdlibReleaseTarget = stdlibReleaseBinary
-    if os_is('win32'):
-        stdlibReleaseTarget = 'stdlib-release.exe'
+    if not ctx.variant.startswith('debug'):
+        stdlibReleaseBinary = 'stdlib-release'
+        stdlibReleaseTarget = stdlibReleaseBinary
+        if os_is('win32'):
+            stdlibReleaseTarget = 'stdlib-release.exe'
 
-    ctx(
-        features = 'seq',
-        rule     = '"' + os.path.join(ctx.bldnode.abspath(), 'ponyc') + '" -s --checktree --verify -b ' + stdlibReleaseBinary + ' ../../packages/stdlib',
-        target   = stdlibReleaseTarget,
-        source   = ctx.bldnode.ant_glob('ponyc*') + ctx.path.ant_glob('packages/**/*.pony'),
-    )
+        ctx(
+            features = 'seq',
+            rule     = '"' + os.path.join(ctx.bldnode.abspath(), 'ponyc') + '" -s --checktree --verify -b ' + stdlibReleaseBinary + ' ../../packages/stdlib',
+            target   = stdlibReleaseTarget,
+            source   = ctx.bldnode.ant_glob('ponyc*') + ctx.path.ant_glob('packages/**/*.pony'),
+        )
 
     # grammar file
     ctx(
@@ -453,12 +454,13 @@ def test(ctx):
         if returncode == 0:
             passed = passed + 1
 
-        total = total + 1
-        stdlib = os.path.join(buildDir, 'stdlib-release')
-        print(stdlib)
-        returncode = subprocess.call([ stdlib, '--sequential' ])
-        if returncode == 0:
-            passed = passed + 1
+        if not ctx.variant.startswith('debug'):
+            total = total + 1
+            stdlib = os.path.join(buildDir, 'stdlib-release')
+            print(stdlib)
+            returncode = subprocess.call([ stdlib, '--sequential' ])
+            if returncode == 0:
+                passed = passed + 1
 
         total = total + 1
         ponyg = os.path.join(sourceDir, 'pony.g')


### PR DESCRIPTION
Until LLVM 7 the heap-to-stack workaround was not necessary on Windows.  However, it seems we need it for LLVM 7.

This change also correctly runs the stdlib tests in release mode for Windows CI.

Fixes #3011 