### PR TITLE
Trigger GC after a set number of messages

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -331,10 +331,6 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
         set_internal_flag(actor, FLAG_BLOCKED_SENT);
         pony_assert(ctx->current == actor);
         ponyint_cycle_block(actor, &actor->gc);
-
-        // trigger a GC if we're blocked and have done work since the last GC
-        if(actor->msgs_since_gc > 0)
-          pony_triggergc(ctx);
       }
 
       return false;

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -414,8 +414,9 @@ static void try_gc(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   // only run GC is the heap has grow sufficiently
   // or if the actor has processed a sufficient number of application messages
+  //    and the actor heap is > 0
   if(!ponyint_heap_startgc(&actor->heap)
-    && (actor->msgs_since_gc < ACTOR_MSGS_TIL_GC))
+    && ((actor->msgs_since_gc < ACTOR_MSGS_TIL_GC) || (actor->heap.used == 0)))
     return;
 
   DTRACE1(GC_START, (uintptr_t)ctx->scheduler);

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -38,6 +38,7 @@ typedef struct pony_actor_t
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes
   size_t muted; // 4/8 bytes
+  uint32_t msgs_since_gc; // 4 bytes
   // internal flags are only ever accessed from a single scheduler thread
   uint8_t internal_flags; // 4/8 bytes (after alignment)
   gc_t gc; // 48/88 bytes

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -40,7 +40,7 @@ typedef struct pony_actor_t
   size_t muted; // 4/8 bytes
   uint32_t msgs_since_gc; // 4 bytes
   // internal flags are only ever accessed from a single scheduler thread
-  uint8_t internal_flags; // 4/8 bytes (after alignment)
+  uint8_t internal_flags; // 4 bytes (after alignment)
   gc_t gc; // 48/88 bytes
 } pony_actor_t;
 
@@ -49,7 +49,8 @@ typedef struct pony_actor_t
  * 56 bytes: initial header, not including the type descriptor
  * 52/104 bytes: heap
  * 4/8 bytes: muted counter
- * 4/8 bytes: internal flags (after alignment)
+ * 4 bytes: msgs_since_gc counter
+ * 4 bytes: internal flags (after alignment)
  * 48/88 bytes: gc
  * 24/56 bytes: padding to 64 bytes, ignored
  */


### PR DESCRIPTION
This PR includes two changes related to when actor GC gets triggered:

```
Trigger GC for actors after they process a number of app msgs

Prior to this commit, GC would only be triggered if an actor's heap
grew to reach the next heap size cutoff for GC. This would
potentially result in some actors not getting GC'd (and so holding
on to memory for longer than necessary) because they happen to not
allocate large amounts of memory even when processing lots of
application messages and take a very long time to reach the next
heap size for GC to occur.

This commit adds an alternate way that GC for an actor can be
triggered in order to force actors that don't allocate large
amounts of memory to GC and free up memory more frequently. This
is done by keeping track of the number of application messages
processed since the last GC and forcing a GC if the number of
messages handled passes a threshold (10x actor batch size).
```

~and~

~Trigger GC for actors when they tell the cycle detector they're blocked~

~Prior to this commit, if an actor blocked, it did not run GC to free
any memory it no longer needed. This would result in blocked actors
holding on to (potentially lots of) memory unnecessarily.~

~This commit causes GC to be triggered when the cycle detector asks
an actor if it is blocked and the actor responds telling the cycle
detector that it is blocked. This should result in memory being
held by blocked actors to be freed more quickly even if the cycle
detector doesn't end up detecting a cycle and reaping the actors.~ (broken out into https://github.com/ponylang/ponyc/pull/3278)