### PR TITLE
Make LLVM 7.0.1 the default for Windows builds and releases.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,9 @@ branches:
 
 environment:
   matrix:
-  - llvm: 3.9.1
-  - llvm: 6.0.1
   - llvm: 7.0.1
+  - llvm: 6.0.1
+  - llvm: 3.9.1
 
 configuration:
   - release

--- a/wscript
+++ b/wscript
@@ -49,9 +49,9 @@ MSVC_VERSIONS = [ '15.9', '15.8', '15.7', '15.6', '15.4', '15.0', '14.0' ]
 
 # keep these in sync with the list in .appveyor.yml
 LLVM_VERSIONS = [
-    '3.9.1',
+    '7.0.1',
     '6.0.1',
-    '7.0.1'
+    '3.9.1'
 ]
 
 LIBRESSL_VERSION = "2.9.0"


### PR DESCRIPTION
This should be merged after #3030