### PR TITLE
Only build LLVM 7.0.1 for Windows CI.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,6 @@ branches:
 environment:
   matrix:
   - llvm: 7.0.1
-  - llvm: 6.0.1
-  - llvm: 3.9.1
 
 configuration:
   - release


### PR DESCRIPTION
In order to simplify our CI, we will only build with LLVM 7.0.1 for Windows.