### PR TITLE
Add Makefile-ponyc to the Appveyor ignore list

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,7 @@ skip_commits:
     - '**/Dockerfile'
     - LICENSE
     - Makefile
+    - Makefile-ponyc
     - release.bash
     - '**/*.md'
     - '**/*.txt'


### PR DESCRIPTION
Changes to that Makefile have no impact on the Windows build and
shouldn't trigger a build.

[skip  ci]