### PR TITLE
Update TCPConnection docs around local and remote addresses

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -412,7 +412,8 @@ actor TCPConnection
 
   fun local_address(): NetAddress =>
     """
-    Return the local IP address.
+    Return the local IP address. If this TCPConnection is closed then the
+    address returned is invalid.
     """
     let ip = recover NetAddress end
     @pony_os_sockname[Bool](_fd, ip)
@@ -420,7 +421,8 @@ actor TCPConnection
 
   fun remote_address(): NetAddress =>
     """
-    Return the remote IP address.
+    Return the remote IP address. If this TCPConnection is closed then the
+    address returned is invalid.
     """
     let ip = recover NetAddress end
     @pony_os_peername[Bool](_fd, ip)
@@ -1127,4 +1129,3 @@ actor TCPConnection
     var word: Array[U8] ref =
       _OSSocket.u32_to_bytes4(if state then 1 else 0 end)
     _OSSocket.setsockopt(_fd, OSSockOpt.sol_socket(), OSSockOpt.tcp_nodelay(), word)
-


### PR DESCRIPTION
When `TCPConnection` is closed the remote and local addresses are _empty_ - they are no longer valid as the addresses have been reset/lost.  This PR documents this case in the associated doc strings.