### PR TITLE
Make building with MacPorts LLVM easy

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -232,8 +232,14 @@ ifndef LLVM_CONFIG
     LLVM_CONFIG = llvm-config-7.0
   else ifneq (,$(shell which llvm-config70 2> /dev/null))
     LLVM_CONFIG = llvm-config70
+  else ifneq (,$(shell which llvm-config-mp-7.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-mp-7.0
   else ifneq (,$(shell which llvm-config-6.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-6.0
+  else ifneq (,$(shell which llvm-config-mp-6.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-mp-6.0
+  else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-mp-5.0
   else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
     LLVM_CONFIG = llvm-config-3.9
   else ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))


### PR DESCRIPTION
MacPorts installed LLVM works fine with building ponyc. However, the
makefile currently only looks for llvm-config versions using the
Homebrew naming scheme.

This commit adds support for finding llvm-config with its standard
MacPorts naming scheme:

llvm-config-mp-VERSION

[skip ci]