### PR TITLE
Remove unsupported LLVM versions from detection

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -240,32 +240,16 @@ ifndef LLVM_CONFIG
     LLVM_CONFIG = llvm-config-mp-6.0
   else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-mp-5.0
-  else ifneq (,$(shell which llvm-config-3.9 2> /dev/null))
-    LLVM_CONFIG = llvm-config-3.9
-  else ifneq (,$(shell which /usr/local/opt/llvm@3.9/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm@3.9/bin/llvm-config
-  else ifneq (,$(shell which llvm-config39 2> /dev/null))
-    LLVM_CONFIG = llvm-config39
   else ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
     LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-  else ifneq (,$(shell which /usr/lib64/llvm3.9/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/lib64/llvm3.9/bin/llvm-config
   else ifneq (,$(shell which llvm-config 2> /dev/null))
     LLVM_CONFIG = llvm-config
   else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-5.0
-  else ifneq (,$(shell which llvm-config-4.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-4.0
-  else ifneq (,$(shell which /usr/local/opt/llvm@4.0/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm@4.0/bin/llvm-config
-  else ifneq (,$(shell which /opt/llvm-3.9.1/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-3.9.1/bin/llvm-config
   else ifneq (,$(shell which /opt/llvm-5.0.1/bin/llvm-config 2> /dev/null))
     LLVM_CONFIG = /opt/llvm-5.0.1/bin/llvm-config
   else ifneq (,$(shell which /opt/llvm-5.0.0/bin/llvm-config 2> /dev/null))
     LLVM_CONFIG = /opt/llvm-5.0.0/bin/llvm-config
-  else ifneq (,$(shell which /opt/llvm-4.0.0/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-4.0.0/bin/llvm-config
   else
     $(error No LLVM installation found!)
   endif


### PR DESCRIPTION
We don't support 3 or 4 anymore so, there's no point detecting them to
tell people that we don't support them anymore. I'm running this through
CI to verify that none of our jobs rely on these.