### PR TITLE
Fixed process/STDIN-WriteBuf on Windows.

### DIFF
--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -339,11 +339,10 @@ class iso _TestStdinWriteBuf is UnitTest
       _pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
 
       // create a message larger than pipe_cap bytes
-      let message: Array[U8] val = recover Array[U8].>undefined(pipe_cap + 1) end
+      let message: Array[U8] val = recover Array[U8].init('\n', pipe_cap + 1) end
 
       if _pm isnt None then // write to STDIN of the child process
         let pm = _pm as ProcessMonitor
-        pm.write(message)
         pm.write(message)
         pm.done_writing() // closing stdin allows "cat" to terminate
         h.dispose_when_done(pm)

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -344,6 +344,7 @@ class iso _TestStdinWriteBuf is UnitTest
       if _pm isnt None then // write to STDIN of the child process
         let pm = _pm as ProcessMonitor
         pm.write(message)
+        pm.write(message)
         pm.done_writing() // closing stdin allows "cat" to terminate
         h.dispose_when_done(pm)
       end

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -76,12 +76,7 @@ actor Main is TestList
     logger.Main.make().tests(test)
     net.Main.make().tests(test)
     options.Main.make().tests(test)
-
-    ifdef posix then
-      // The process package currently only supports posix
-      process.Main.make().tests(test)
-    end
-
+    process.Main.make().tests(test)
     promises.Main.make().tests(test)
     random.Main.make().tests(test)
     regex.Main.make().tests(test)


### PR DESCRIPTION
Tweaked process/STDIN-WriteBuf to use a buffer of newlines to avoid confusing Windows.
