### PR TITLE
Run FreeBSD CI jobs in sequence

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,14 +2,27 @@ task:
   freebsd_instance:
     image: freebsd-12-0-release-amd64
 
-  name: "freebsd-12"
+  name: "freebsd-12-release"
   install_script:
     - pkg update
     - pkg install -y gmake pcre2 libunwind llvm70 git
-  env:
-    matrix:
-      CONFIG: debug
-      CONFIG: release
+
   test_script:
-    - gmake all config=$CONFIG -j3 default_ssl=openssl_1.1.0
-    - gmake test-ci config=$CONFIG default_ssl=openssl_1.1.0
+    - gmake all config=release -j3 default_ssl=openssl_1.1.0
+    - gmake test-ci config=release default_ssl=openssl_1.1.0
+
+task:
+  freebsd_instance:
+    image: freebsd-12-0-release-amd64
+
+  name: "freebsd-12-debug"
+  depends_on:
+    - freebsd-12-release
+
+  install_script:
+    - pkg update
+    - pkg install -y gmake pcre2 libunwind llvm70 git
+
+  test_script:
+    - gmake all config=debug -j3 default_ssl=openssl_1.1.0
+    - gmake test-ci config=debug default_ssl=openssl_1.1.0


### PR DESCRIPTION
In all likelihood if one fails, both will fail. We have a maximum of 2 slots
for running FreeBSD jobs on Cirrus. With this change, they will be run in
sequence. First the release build tests, then the debug build tests.

This will allow for more than 1 PR to be doing FreeBSD tests at the same time.

Yes, it makes the total FreeBSD testing time longer for a given PR, however,
CircleCI and its many jobs that get run is the limiting factor for how long
it takes to fully test a PR, not Cirrus. In the end, the extra time of running
sequentially gets washed out for each individual PR.