### PR TITLE
Clean up llvm-config options

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -2,44 +2,44 @@
 OSTYPE ?=
 
 ifeq ($(OS),Windows_NT)
-  OSTYPE = windows
+	OSTYPE = windows
 else
-  UNAME_S := $(shell uname -s)
+	UNAME_S := $(shell uname -s)
 
-  ifeq ($(UNAME_S),Linux)
-    OSTYPE = linux
+	ifeq ($(UNAME_S),Linux)
+		OSTYPE = linux
 
-    ifndef AR
-      ifneq (,$(shell which gcc-ar 2> /dev/null))
-        AR = gcc-ar
-      endif
-    endif
+		ifndef AR
+			ifneq (,$(shell which gcc-ar 2> /dev/null))
+				AR = gcc-ar
+			endif
+		endif
 
-    ALPINE=$(wildcard /etc/alpine-release)
-  endif
+		ALPINE=$(wildcard /etc/alpine-release)
+	endif
 
-  ifeq ($(UNAME_S),Darwin)
-    OSTYPE = osx
-  endif
+	ifeq ($(UNAME_S),Darwin)
+		OSTYPE = osx
+	endif
 
-  ifeq ($(UNAME_S),FreeBSD)
-    OSTYPE = bsd
-    CXX = c++
-  endif
+	ifeq ($(UNAME_S),FreeBSD)
+		OSTYPE = bsd
+		CXX = c++
+	endif
 
-  ifeq ($(UNAME_S),DragonFly)
-    OSTYPE = bsd
-    CXX = c++
-  endif
+	ifeq ($(UNAME_S),DragonFly)
+		OSTYPE = bsd
+		CXX = c++
+	endif
 
-  ifeq ($(UNAME_S),OpenBSD)
-    OSTYPE = bsd
-    CXX = c++
-  endif
+	ifeq ($(UNAME_S),OpenBSD)
+		OSTYPE = bsd
+		CXX = c++
+	endif
 endif
 
 ifdef LTO_PLUGIN
-  lto := yes
+	lto := yes
 endif
 
 # Default settings (silent release build).
@@ -51,19 +51,19 @@ fpu ?=
 bits ?= $(shell getconf LONG_BIT)
 
 ifndef verbose
-  SILENT = @
+	SILENT = @
 else
-  SILENT =
+	SILENT =
 endif
 
 ifneq ($(wildcard .git),)
-  tag := $(shell cat VERSION)-$(shell git rev-parse --short HEAD)
+	tag := $(shell cat VERSION)-$(shell git rev-parse --short HEAD)
 else
-  tag := $(shell cat VERSION)
+	tag := $(shell cat VERSION)
 endif
 
 version_str = "$(tag) [$(config)]\ncompiled with: llvm $(llvm_version) \
-  -- "$(compiler_version)
+	-- "$(compiler_version)
 
 # package_name, _version, and _iteration can be overridden by Travis or AppVeyor
 package_base_version ?= $(tag)
@@ -80,43 +80,43 @@ libdir ?= $(prefix)/lib
 
 # destdir is for backward compatibility only, use ponydir instead.
 ifdef destdir
-  $(warning Please use ponydir instead of destdir.)
-  ponydir ?= $(destdir)
+	$(warning Please use ponydir instead of destdir.)
+	ponydir ?= $(destdir)
 endif
 ponydir ?= $(libdir)/pony/$(tag)
 
 symlink := yes
 
 ifdef ponydir
-  ifndef prefix
-    symlink := no
-  endif
+	ifndef prefix
+		symlink := no
+	endif
 endif
 
 ifneq (,$(filter $(OSTYPE), osx bsd))
-  symlink.flags = -sf
+	symlink.flags = -sf
 else
-  symlink.flags = -srf
+	symlink.flags = -srf
 endif
 
 ifneq (,$(filter $(OSTYPE), osx bsd))
-  SED_INPLACE = sed -i -e
+	SED_INPLACE = sed -i -e
 else
-  SED_INPLACE = sed -i
+	SED_INPLACE = sed -i
 endif
 
 LIB_EXT ?= a
 BUILD_FLAGS = -march=$(arch) -mtune=$(tune) -Werror -Wconversion \
-  -Wno-sign-conversion -Wextra -Wall
+	-Wno-sign-conversion -Wextra -Wall
 LINKER_FLAGS = -march=$(arch) -mtune=$(tune) $(LDFLAGS)
 AR_FLAGS ?= rcs
 ALL_CFLAGS = -std=gnu11 -fexceptions \
-  -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
-  -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
-  -DBUILD_COMPILER=\"$(compiler_version)\" \
-  -DPONY_BUILD_CONFIG=\"$(config)\" \
-  -DPONY_VERSION_STR=\"$(version_str)\" \
-  -D_FILE_OFFSET_BITS=64
+	-DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
+	-DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
+	-DBUILD_COMPILER=\"$(compiler_version)\" \
+	-DPONY_BUILD_CONFIG=\"$(config)\" \
+	-DPONY_VERSION_STR=\"$(version_str)\" \
+	-D_FILE_OFFSET_BITS=64
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 LL_FLAGS = -mcpu=$(cpu)
 
@@ -125,17 +125,17 @@ BITS := $(bits)
 UNAME_M := $(shell uname -m)
 
 ifeq ($(BITS),64)
-  ifeq ($(UNAME_M),x86_64)
-    ifeq (,$(filter $(arch), armv8-a))
-      BUILD_FLAGS += -mcx16
-      LINKER_FLAGS += -mcx16
-    endif
-  endif
+	ifeq ($(UNAME_M),x86_64)
+		ifeq (,$(filter $(arch), armv8-a))
+			BUILD_FLAGS += -mcx16
+			LINKER_FLAGS += -mcx16
+		endif
+	endif
 endif
 
 ifneq ($(fpu),)
-  BUILD_FLAGS += -mfpu=$(fpu)
-  LINKER_FLAGS += -mfpu=$(fpu)
+	BUILD_FLAGS += -mfpu=$(fpu)
+	LINKER_FLAGS += -mfpu=$(fpu)
 endif
 
 PONY_BUILD_DIR   ?= build/$(config)
@@ -144,117 +144,109 @@ PONY_TEST_DIR ?= test
 PONY_BENCHMARK_DIR ?= benchmark
 
 ifdef use
-  ifneq (,$(filter $(use), valgrind))
-    ALL_CFLAGS += -DUSE_VALGRIND
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-valgrind
-  endif
+	ifneq (,$(filter $(use), valgrind))
+		ALL_CFLAGS += -DUSE_VALGRIND
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-valgrind
+	endif
 
-  ifneq (,$(filter $(use), coverage))
-    ifneq (,$(shell $(CC) -v 2>&1 | grep clang))
-      # clang
-      COVERAGE_FLAGS = -O0 -fprofile-instr-generate -fcoverage-mapping
-      LINKER_FLAGS += -fprofile-instr-generate -fcoverage-mapping
-    else
-      ifneq (,$(shell $(CC) -v 2>&1 | grep "gcc version"))
-        # gcc
-        COVERAGE_FLAGS = -O0 -fprofile-arcs -ftest-coverage
-        LINKER_FLAGS += -fprofile-arcs
-      else
-        $(error coverage not supported for this compiler/platform)
-      endif
-      ALL_CFLAGS += $(COVERAGE_FLAGS)
-      ALL_CXXFLAGS += $(COVERAGE_FLAGS)
-    endif
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-coverage
-  endif
+	ifneq (,$(filter $(use), coverage))
+		ifneq (,$(shell $(CC) -v 2>&1 | grep clang))
+			# clang
+			COVERAGE_FLAGS = -O0 -fprofile-instr-generate -fcoverage-mapping
+			LINKER_FLAGS += -fprofile-instr-generate -fcoverage-mapping
+		else
+			ifneq (,$(shell $(CC) -v 2>&1 | grep "gcc version"))
+				# gcc
+				COVERAGE_FLAGS = -O0 -fprofile-arcs -ftest-coverage
+				LINKER_FLAGS += -fprofile-arcs
+			else
+				$(error coverage not supported for this compiler/platform)
+			endif
+			ALL_CFLAGS += $(COVERAGE_FLAGS)
+			ALL_CXXFLAGS += $(COVERAGE_FLAGS)
+		endif
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-coverage
+	endif
 
-  ifneq (,$(filter $(use), pooltrack))
-    ALL_CFLAGS += -DUSE_POOLTRACK
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-pooltrack
-  endif
+	ifneq (,$(filter $(use), pooltrack))
+		ALL_CFLAGS += -DUSE_POOLTRACK
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-pooltrack
+	endif
 
-  ifneq (,$(filter $(use), dtrace))
-    DTRACE ?= $(shell which dtrace)
-    ifeq (, $(DTRACE))
-      $(error No dtrace compatible user application static probe generation tool found)
-    endif
+	ifneq (,$(filter $(use), dtrace))
+		DTRACE ?= $(shell which dtrace)
+		ifeq (, $(DTRACE))
+			$(error No dtrace compatible user application static probe generation tool found)
+		endif
 
-    ALL_CFLAGS += -DUSE_DYNAMIC_TRACE
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-dtrace
-  endif
+		ALL_CFLAGS += -DUSE_DYNAMIC_TRACE
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-dtrace
+	endif
 
-  ifneq (,$(filter $(use), actor_continuations))
-    ALL_CFLAGS += -DUSE_ACTOR_CONTINUATIONS
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-actor_continuations
-  endif
+	ifneq (,$(filter $(use), actor_continuations))
+		ALL_CFLAGS += -DUSE_ACTOR_CONTINUATIONS
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-actor_continuations
+	endif
 
-  ifneq (,$(filter $(use), scheduler_scaling_pthreads))
-    ALL_CFLAGS += -DUSE_SCHEDULER_SCALING_PTHREADS
-    PONY_BUILD_DIR := $(PONY_BUILD_DIR)-scheduler_scaling_pthreads
-  endif
+	ifneq (,$(filter $(use), scheduler_scaling_pthreads))
+		ALL_CFLAGS += -DUSE_SCHEDULER_SCALING_PTHREADS
+		PONY_BUILD_DIR := $(PONY_BUILD_DIR)-scheduler_scaling_pthreads
+	endif
 endif
 
 ifdef config
-  ifeq (,$(filter $(config),debug release))
-    $(error Unknown configuration "$(config)")
-  endif
+	ifeq (,$(filter $(config),debug release))
+		$(error Unknown configuration "$(config)")
+	endif
 endif
 
 ifeq ($(config),release)
-  BUILD_FLAGS += -O3 -DNDEBUG
-  LL_FLAGS += -O3
+	BUILD_FLAGS += -O3 -DNDEBUG
+	LL_FLAGS += -O3
 
-  ifeq ($(lto),yes)
-    BUILD_FLAGS += -flto -DPONY_USE_LTO
-    LINKER_FLAGS += -flto
+	ifeq ($(lto),yes)
+		BUILD_FLAGS += -flto -DPONY_USE_LTO
+		LINKER_FLAGS += -flto
 
-    ifdef LTO_PLUGIN
-      AR_FLAGS += --plugin $(LTO_PLUGIN)
-    endif
+		ifdef LTO_PLUGIN
+			AR_FLAGS += --plugin $(LTO_PLUGIN)
+		endif
 
-    ifneq (,$(filter $(OSTYPE),linux bsd))
-      LINKER_FLAGS += -fuse-linker-plugin -fuse-ld=gold
-    endif
-  endif
+		ifneq (,$(filter $(OSTYPE),linux bsd))
+			LINKER_FLAGS += -fuse-linker-plugin -fuse-ld=gold
+		endif
+	endif
 else
-  BUILD_FLAGS += -g -DDEBUG
+	BUILD_FLAGS += -g -DDEBUG
 endif
 
 ifeq ($(OSTYPE),osx)
-  ALL_CFLAGS += -mmacosx-version-min=10.12 -DUSE_SCHEDULER_SCALING_PTHREADS
-  ALL_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=10.12
+	ALL_CFLAGS += -mmacosx-version-min=10.12 -DUSE_SCHEDULER_SCALING_PTHREADS
+	ALL_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=10.12
 endif
 
 ifndef LLVM_CONFIG
-  ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-  else ifneq (,$(shell which llvm-config-7.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-7.0
-  else ifneq (,$(shell which llvm-config70 2> /dev/null))
-    LLVM_CONFIG = llvm-config70
-  else ifneq (,$(shell which llvm-config-mp-7.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-7.0
-  else ifneq (,$(shell which llvm-config-6.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-6.0
-  else ifneq (,$(shell which llvm-config-mp-6.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-6.0
-  else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-5.0
-  else ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-  else ifneq (,$(shell which llvm-config 2> /dev/null))
-    LLVM_CONFIG = llvm-config
-  else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-5.0
-  else ifneq (,$(shell which /opt/llvm-5.0.1/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-5.0.1/bin/llvm-config
-  else ifneq (,$(shell which /opt/llvm-5.0.0/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-5.0.0/bin/llvm-config
-  else
-    $(error No LLVM installation found!)
-  endif
+	ifneq (,$(shell which llvm-config-7.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-7.0
+	else ifneq (,$(shell which llvm-config70 2> /dev/null))
+		LLVM_CONFIG = llvm-config70
+	else ifneq (,$(shell which llvm-config-mp-7.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-mp-7.0
+	else ifneq (,$(shell which llvm-config-6.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-6.0
+	else ifneq (,$(shell which llvm-config-mp-6.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-mp-6.0
+	else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-5.0
+	else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
+		LLVM_CONFIG = llvm-config-mp-5.0
+	else ifneq (,$(shell which llvm-config 2> /dev/null))
+		LLVM_CONFIG = llvm-config
+	else
+		$(error No LLVM installation found!)
+	endif
 else ifeq (,$(shell which $(LLVM_CONFIG) 2> /dev/null))
-  $(error No LLVM installation found!)
+	$(error No LLVM installation found!)
 endif
 
 LLVM_BINDIR := $(shell $(LLVM_CONFIG) --bindir 2> /dev/null)
@@ -265,34 +257,34 @@ LLVM_LLC := $(LLVM_BINDIR)/llc
 LLVM_AS := $(LLVM_BINDIR)/llvm-as
 llvm_build_mode := $(shell $(LLVM_CONFIG) --build-mode)
 ifeq (Release,$(llvm_build_mode))
-  LLVM_BUILD_MODE=LLVM_BUILD_MODE_Release
+	LLVM_BUILD_MODE=LLVM_BUILD_MODE_Release
 else ifeq (RelWithDebInfo,$(llvm_build_mode))
-  LLVM_BUILD_MODE=LLVM_BUILD_MODE_RelWithDebInfo
+	LLVM_BUILD_MODE=LLVM_BUILD_MODE_RelWithDebInfo
 else ifeq (MinSizeRel,$(llvm_build_mode))
-  LLVM_BUILD_MODE=LLVM_BUILD_MODE_MinSizeRel
+	LLVM_BUILD_MODE=LLVM_BUILD_MODE_MinSizeRel
 else ifeq (Debug,$(llvm_build_mode))
-  LLVM_BUILD_MODE=LLVM_BUILD_MODE_Debug
+	LLVM_BUILD_MODE=LLVM_BUILD_MODE_Debug
 else
-  $(error "Unknown llvm build-mode of $(llvm_build_mode)", aborting)
+	$(error "Unknown llvm build-mode of $(llvm_build_mode)", aborting)
 endif
 
 llvm_version := $(shell $(LLVM_CONFIG) --version)
 
 ifeq (,$(LLVM_LINK_STATIC))
-  ifneq (,$(filter $(use), llvm_link_static))
-    LLVM_LINK_STATIC=--link-static
-    $(warning "linking llvm statically")
-  endif
+	ifneq (,$(filter $(use), llvm_link_static))
+		LLVM_LINK_STATIC=--link-static
+		$(warning "linking llvm statically")
+	endif
 endif
 
 ifeq ($(OSTYPE),osx)
-  ifneq (,$(shell which $(LLVM_BINDIR)/llvm-ar 2> /dev/null))
-    AR = $(LLVM_BINDIR)/llvm-ar
-    AR_FLAGS := rcs
-  else
-    AR = /usr/bin/ar
-    AR_FLAGS := -rcs
-  endif
+	ifneq (,$(shell which $(LLVM_BINDIR)/llvm-ar 2> /dev/null))
+		AR = $(LLVM_BINDIR)/llvm-ar
+		AR_FLAGS := rcs
+	else
+		AR = /usr/bin/ar
+		AR_FLAGS := -rcs
+	endif
 endif
 
 ifeq ($(llvm_version),3.9.1)
@@ -300,32 +292,32 @@ else ifeq ($(llvm_version),5.0.2)
 else ifeq ($(llvm_version),6.0.1)
 else ifeq ($(llvm_version),7.0.1)
 else
-  $(warning WARNING: Unsupported LLVM version: $(llvm_version))
-  $(warning Please use LLVM 3.9.1, 5.0.2, 6.0.1, 7.0.1)
+	$(warning WARNING: Unsupported LLVM version: $(llvm_version))
+	$(warning Please use LLVM 3.9.1, 5.0.2, 6.0.1, 7.0.1)
 endif
 
 compiler_version := "$(shell $(CC) --version | sed -n 1p)"
 
 ifeq ($(runtime-bitcode),yes)
-  ifeq (,$(shell $(CC) -v 2>&1 | grep clang))
-    $(error Compiling the runtime as a bitcode file requires clang)
-  endif
+	ifeq (,$(shell $(CC) -v 2>&1 | grep clang))
+		$(error Compiling the runtime as a bitcode file requires clang)
+	endif
 endif
 
 # Set default ssl version
 ifdef default_ssl
-  ifeq ("openssl_0.9.0","$(default_ssl)")
-    default_ssl_valid:=ok
-  endif
-  ifeq ("openssl_1.1.0","$(default_ssl)")
-    default_ssl_valid:=ok
-  endif
-  ifeq (ok,$(default_ssl_valid))
-    $(warning default_ssl is $(default_ssl))
-  else
-    $(error default_ssl=$(default_ssl) is invalid, expecting one of openssl_0.9.0 or openssl_1.1.0)
-  endif
-  BUILD_FLAGS += -DPONY_DEFAULT_SSL=\"$(default_ssl)\"
+	ifeq ("openssl_0.9.0","$(default_ssl)")
+		default_ssl_valid:=ok
+	endif
+	ifeq ("openssl_1.1.0","$(default_ssl)")
+		default_ssl_valid:=ok
+	endif
+	ifeq (ok,$(default_ssl_valid))
+		$(warning default_ssl is $(default_ssl))
+	else
+		$(error default_ssl=$(default_ssl) is invalid, expecting one of openssl_0.9.0 or openssl_1.1.0)
+	endif
+	BUILD_FLAGS += -DPONY_DEFAULT_SSL=\"$(default_ssl)\"
 endif
 
 makefile_abs_path := $(realpath $(lastword $(MAKEFILE_LIST)))
@@ -346,7 +338,7 @@ libponycc := $(lib)
 libponyrt := $(lib)
 
 ifeq ($(OSTYPE),linux)
-  libponyrt-pic := $(lib)
+	libponyrt-pic := $(lib)
 endif
 
 # Define special case rules for a targets source files. By default
@@ -356,27 +348,27 @@ endif
 # arbitrarily complex shell commands, as long as ':=' is used
 # for definition, instead of '='.
 ifneq ($(OSTYPE),windows)
-  libponyc.except += src/libponyc/platform/signed.cc
-  libponyc.except += src/libponyc/platform/unsigned.cc
-  libponyc.except += src/libponyc/platform/vcvars.c
+	libponyc.except += src/libponyc/platform/signed.cc
+	libponyc.except += src/libponyc/platform/unsigned.cc
+	libponyc.except += src/libponyc/platform/vcvars.c
 endif
 
 # Handle platform specific code to avoid "no symbols" warnings.
 libponyrt.except =
 
 ifneq ($(OSTYPE),windows)
-  libponyrt.except += src/libponyrt/asio/iocp.c
-  libponyrt.except += src/libponyrt/lang/win_except.c
+	libponyrt.except += src/libponyrt/asio/iocp.c
+	libponyrt.except += src/libponyrt/lang/win_except.c
 endif
 
 ifneq ($(OSTYPE),linux)
-  libponyrt.except += src/libponyrt/asio/epoll.c
+	libponyrt.except += src/libponyrt/asio/epoll.c
 endif
 
 ifneq ($(OSTYPE),osx)
-  ifneq ($(OSTYPE),bsd)
-    libponyrt.except += src/libponyrt/asio/kqueue.c
-  endif
+	ifneq ($(OSTYPE),bsd)
+		libponyrt.except += src/libponyrt/asio/kqueue.c
+	endif
 endif
 
 libponyrt.except += src/libponyrt/asio/sock.c
@@ -384,8 +376,8 @@ libponyrt.except += src/libponyrt/dist/dist.c
 libponyrt.except += src/libponyrt/dist/proto.c
 
 ifeq ($(OSTYPE),linux)
-  libponyrt-pic.dir := src/libponyrt
-  libponyrt-pic.except := $(libponyrt.except)
+	libponyrt-pic.dir := src/libponyrt
+	libponyrt-pic.except := $(libponyrt.except)
 endif
 
 # Third party, but requires compilation. Defined as
@@ -405,9 +397,9 @@ libblake2.files := $(libblake2.dir)/blake2b-ref.c
 # We don't add libponyrt here. It's a special case because it can be compiled
 # to LLVM bitcode.
 ifeq ($(OSTYPE), linux)
-  libraries := libponyc libponyrt-pic libgtest libgbenchmark libblake2
+	libraries := libponyc libponyrt-pic libgtest libgbenchmark libblake2
 else
-  libraries := libponyc libgtest libgbenchmark libblake2
+	libraries := libponyc libgtest libgbenchmark libblake2
 endif
 
 # Third party, but prebuilt. Prebuilt libraries are defined as
@@ -468,8 +460,8 @@ llvm.include = $(shell $(loopit))
 llvm.libs    := $(shell $(LLVM_CONFIG) --libs $(LLVM_LINK_STATIC)) -lz -lncurses
 
 ifeq ($(OSTYPE), bsd)
-  extra.bsd.libs = -lpthread -lexecinfo
-  llvm.libs += $(extra.bsd.libs)
+	extra.bsd.libs = -lpthread -lexecinfo
+	llvm.libs += $(extra.bsd.libs)
 endif
 
 prebuilt := llvm
@@ -499,19 +491,19 @@ benchmarks := libponyc.benchmarks libponyrt.benchmarks
 # Define include paths for targets if necessary. Note that these include paths
 # will automatically apply to the test suite of a target as well.
 libponyc.include := -I src/common/ -I src/libponyrt/ $(llvm.include) \
-  -isystem lib/blake2
+	-isystem lib/blake2
 libponycc.include := -I src/common/ $(llvm.include)
 libponyrt.include := -I src/common/ -I src/libponyrt/
 libponyrt-pic.include := $(libponyrt.include)
 
 libponyc.tests.include := -I src/common/ -I src/libponyc/ -I src/libponyrt \
-  $(llvm.include) -isystem lib/gtest/
+	$(llvm.include) -isystem lib/gtest/
 libponyrt.tests.include := -I src/common/ -I src/libponyrt/ -isystem lib/gtest/
 
 libponyc.benchmarks.include := -I src/common/ -I src/libponyc/ \
-  $(llvm.include) -isystem lib/gbenchmark/include/
+	$(llvm.include) -isystem lib/gbenchmark/include/
 libponyrt.benchmarks.include := -I src/common/ -I src/libponyrt/ -isystem \
-  lib/gbenchmark/include/
+	lib/gbenchmark/include/
 
 ponyc.include := -I src/common/ -I src/libponyrt/ $(llvm.include)
 libgtest.include := -isystem lib/gtest/
@@ -519,14 +511,14 @@ libgbenchmark.include := -isystem lib/gbenchmark/include/
 libblake2.include := -isystem lib/blake2/
 
 ifneq (,$(filter $(OSTYPE), osx bsd))
-  libponyrt.include += -I $(CROSS_SYSROOT)/usr/local/include
+	libponyrt.include += -I $(CROSS_SYSROOT)/usr/local/include
 endif
 
 # target specific build options
 libponyrt.tests.linkoptions += -rdynamic
 
 ifneq ($(ALPINE),)
-  libponyrt.tests.linkoptions += -lexecinfo
+	libponyrt.tests.linkoptions += -lexecinfo
 endif
 
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
@@ -545,7 +537,7 @@ libponyc.tests.buildoptions += -DLLVM_BUILD_MODE=$(LLVM_BUILD_MODE)
 libponyc.tests.linkoptions += -rdynamic
 
 ifneq ($(ALPINE),)
-  libponyc.tests.linkoptions += -lexecinfo
+	libponyc.tests.linkoptions += -lexecinfo
 endif
 
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
@@ -554,13 +546,13 @@ libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
 libponyc.benchmarks.buildoptions += -DLLVM_BUILD_MODE=$(LLVM_BUILD_MODE)
 
 libgbenchmark.buildoptions := \
-  -Wshadow -pedantic -pedantic-errors \
-  -Wfloat-equal -fstrict-aliasing -Wstrict-aliasing -Wno-invalid-offsetof \
-  -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK
+	-Wshadow -pedantic -pedantic-errors \
+	-Wfloat-equal -fstrict-aliasing -Wstrict-aliasing -Wno-invalid-offsetof \
+	-DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK
 
 ifneq ($(ALPINE),)
-  libponyc.benchmarks.linkoptions += -lexecinfo
-  libponyrt.benchmarks.linkoptions += -lexecinfo
+	libponyc.benchmarks.linkoptions += -lexecinfo
+	libponyrt.benchmarks.linkoptions += -lexecinfo
 endif
 
 ponyc.buildoptions = $(libponyc.buildoptions)
@@ -568,26 +560,26 @@ ponyc.buildoptions = $(libponyc.buildoptions)
 ponyc.linkoptions += -rdynamic
 
 ifneq ($(ALPINE),)
-  ponyc.linkoptions += -lexecinfo
-  BUILD_FLAGS += -DALPINE_LINUX
+	ponyc.linkoptions += -lexecinfo
+	BUILD_FLAGS += -DALPINE_LINUX
 endif
 
 ifeq ($(OSTYPE), linux)
-  libponyrt-pic.buildoptions += -fpic
-  libponyrt-pic.buildoptions-ll += -relocation-model=pic
+	libponyrt-pic.buildoptions += -fpic
+	libponyrt-pic.buildoptions-ll += -relocation-model=pic
 endif
 
 # Set default PIC for compiling if requested
 ifdef default_pic
-  ifeq (true,$(default_pic))
-    libponyrt.buildoptions += -fpic
-    libponyrt.buildoptions-ll += -relocation-model=pic
-    BUILD_FLAGS += -DPONY_DEFAULT_PIC=true
-  else
-    ifneq (false,$(default_pic))
-      $(error default_pic must be true or false)
-    endif
-  endif
+	ifeq (true,$(default_pic))
+		libponyrt.buildoptions += -fpic
+		libponyrt.buildoptions-ll += -relocation-model=pic
+		BUILD_FLAGS += -DPONY_DEFAULT_PIC=true
+	else
+		ifneq (false,$(default_pic))
+			$(error default_pic must be true or false)
+		endif
+	endif
 endif
 
 # target specific disabling of build options
@@ -604,22 +596,22 @@ libponyc.benchmarks.links = libblake2 libgbenchmark libponyc libponyrt llvm
 libponyrt.benchmarks.links = libgbenchmark libponyrt
 
 ifeq ($(OSTYPE),linux)
-  ponyc.links += libpthread libdl libatomic
-  libponyc.tests.links += libpthread libdl libatomic
-  libponyrt.tests.links += libpthread libdl libatomic
-  libponyc.benchmarks.links += libpthread libdl libatomic
-  libponyrt.benchmarks.links += libpthread libdl libatomic
+	ponyc.links += libpthread libdl libatomic
+	libponyc.tests.links += libpthread libdl libatomic
+	libponyrt.tests.links += libpthread libdl libatomic
+	libponyc.benchmarks.links += libpthread libdl libatomic
+	libponyrt.benchmarks.links += libpthread libdl libatomic
 endif
 
 ifeq ($(OSTYPE),bsd)
-  libponyc.tests.links += libpthread
-  libponyrt.tests.links += $(extra.bsd.libs)
-  libponyc.benchmarks.links += libpthread
-  libponyrt.benchmarks.links += $(extra.bsd.libs)
+	libponyc.tests.links += libpthread
+	libponyrt.tests.links += $(extra.bsd.libs)
+	libponyc.benchmarks.links += libpthread
+	libponyrt.benchmarks.links += $(extra.bsd.libs)
 endif
 
 ifneq (, $(DTRACE))
-  $(shell $(DTRACE) -h -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_SOURCE_DIR)/common/dtrace_probes.h)
+	$(shell $(DTRACE) -h -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_SOURCE_DIR)/common/dtrace_probes.h)
 endif
 
 # Overwrite the default linker for a target.
@@ -662,116 +654,116 @@ ponyc.depends := libponyc libponyrt
 #                                                                        #
 ##########################################################################
 define DIRECTORY
-  $(eval sourcedir := )
-  $(eval outdir := $(obj)/$(1))
+	$(eval sourcedir := )
+	$(eval outdir := $(obj)/$(1))
 
-  ifdef $(1).srcdir
-    sourcedir := $($(1).srcdir)
-  else ifdef $(1).dir
-    sourcedir := $($(1).dir)
-  else ifneq ($$(filter $(1),$(tests)),)
-    sourcedir := $(PONY_TEST_DIR)/$(subst .tests,,$(1))
-    outdir := $(obj)/tests/$(subst .tests,,$(1))
-  else ifneq ($$(filter $(1),$(benchmarks)),)
-    sourcedir := $(PONY_BENCHMARK_DIR)/$(subst .benchmarks,,$(1))
-    outdir := $(obj)/benchmarks/$(subst .benchmarks,,$(1))
-  else
-    sourcedir := $(PONY_SOURCE_DIR)/$(1)
-  endif
+	ifdef $(1).srcdir
+		sourcedir := $($(1).srcdir)
+	else ifdef $(1).dir
+		sourcedir := $($(1).dir)
+	else ifneq ($$(filter $(1),$(tests)),)
+		sourcedir := $(PONY_TEST_DIR)/$(subst .tests,,$(1))
+		outdir := $(obj)/tests/$(subst .tests,,$(1))
+	else ifneq ($$(filter $(1),$(benchmarks)),)
+		sourcedir := $(PONY_BENCHMARK_DIR)/$(subst .benchmarks,,$(1))
+		outdir := $(obj)/benchmarks/$(subst .benchmarks,,$(1))
+	else
+		sourcedir := $(PONY_SOURCE_DIR)/$(1)
+	endif
 endef
 
 define ENUMERATE
-  $(eval sourcefiles := )
+	$(eval sourcefiles := )
 
-  ifdef $(1).files
-    sourcefiles := $$($(1).files)
-  else
-    sourcefiles := $$(shell find $$(sourcedir) -type f -name "*.c" -or -name\
-      "*.cc" -or -name "*.ll" | grep -v '.*/\.')
-  endif
+	ifdef $(1).files
+		sourcefiles := $$($(1).files)
+	else
+		sourcefiles := $$(shell find $$(sourcedir) -type f -name "*.c" -or -name\
+			"*.cc" -or -name "*.ll" | grep -v '.*/\.')
+	endif
 
-  ifdef $(1).except
-    sourcefiles := $$(filter-out $($(1).except),$$(sourcefiles))
-  endif
+	ifdef $(1).except
+		sourcefiles := $$(filter-out $($(1).except),$$(sourcefiles))
+	endif
 endef
 
 define CONFIGURE_COMPILER
-  ifeq ($(suffix $(1)),.cc)
-    compiler := $(CXX)
-    flags := $(ALL_CXXFLAGS) $(CXXFLAGS)
-  endif
+	ifeq ($(suffix $(1)),.cc)
+		compiler := $(CXX)
+		flags := $(ALL_CXXFLAGS) $(CXXFLAGS)
+	endif
 
-  ifeq ($(suffix $(1)),.c)
-    compiler := $(CC)
-    flags := $(ALL_CFLAGS) $(CFLAGS)
-  endif
+	ifeq ($(suffix $(1)),.c)
+		compiler := $(CC)
+		flags := $(ALL_CFLAGS) $(CFLAGS)
+	endif
 
-  ifeq ($(suffix $(1)),.bc)
-    compiler := $(CC)
-    flags := $(ALL_CFLAGS) $(CFLAGS)
-  endif
+	ifeq ($(suffix $(1)),.bc)
+		compiler := $(CC)
+		flags := $(ALL_CFLAGS) $(CFLAGS)
+	endif
 
-  ifeq ($(suffix $(1)),.ll)
-    compiler := $(CC)
-    flags := $(ALL_CFLAGS) $(CFLAGS) -Wno-override-module
-  endif
+	ifeq ($(suffix $(1)),.ll)
+		compiler := $(CC)
+		flags := $(ALL_CFLAGS) $(CFLAGS) -Wno-override-module
+	endif
 endef
 
 define CONFIGURE_LIBS
-  ifneq (,$$(filter $(1),$(prebuilt)))
-    linkcmd += $($(1).ldflags)
-    libs += $($(1).libs)
-  else
-    libs += $(subst lib,-l,$(1))
-  endif
+	ifneq (,$$(filter $(1),$(prebuilt)))
+		linkcmd += $($(1).ldflags)
+		libs += $($(1).libs)
+	else
+		libs += $(subst lib,-l,$(1))
+	endif
 endef
 
 define CONFIGURE_LIBS_WHOLE
-  ifeq ($(OSTYPE),osx)
-    wholelibs += -Wl,-force_load,$(lib)/$(1).a
-  else
-    wholelibs += $(subst lib,-l,$(1))
-  endif
+	ifeq ($(OSTYPE),osx)
+		wholelibs += -Wl,-force_load,$(lib)/$(1).a
+	else
+		wholelibs += $(subst lib,-l,$(1))
+	endif
 endef
 
 define CONFIGURE_LINKER_WHOLE
-  $(eval wholelibs :=)
+	$(eval wholelibs :=)
 
-  ifneq ($($(1).links.whole),)
-    $(foreach lk,$($(1).links.whole),$(eval $(call CONFIGURE_LIBS_WHOLE,$(lk))))
-    ifeq ($(OSTYPE),osx)
-      libs += $(wholelibs)
-    else
-      libs += -Wl,--whole-archive $(wholelibs) -Wl,--no-whole-archive
-    endif
-  endif
+	ifneq ($($(1).links.whole),)
+		$(foreach lk,$($(1).links.whole),$(eval $(call CONFIGURE_LIBS_WHOLE,$(lk))))
+		ifeq ($(OSTYPE),osx)
+			libs += $(wholelibs)
+		else
+			libs += -Wl,--whole-archive $(wholelibs) -Wl,--no-whole-archive
+		endif
+	endif
 endef
 
 define CONFIGURE_LINKER
-  $(eval linkcmd := $(LINKER_FLAGS) -L $(lib))
-  $(eval linker := $(CC))
-  $(eval libs :=)
+	$(eval linkcmd := $(LINKER_FLAGS) -L $(lib))
+	$(eval linker := $(CC))
+	$(eval libs :=)
 
-  ifdef $(1).linker
-    linker := $($(1).linker)
-  else ifneq (,$$(filter .cc,$(suffix $(sourcefiles))))
-    linker := $(CXX)
-  endif
+	ifdef $(1).linker
+		linker := $($(1).linker)
+	else ifneq (,$$(filter .cc,$(suffix $(sourcefiles))))
+		linker := $(CXX)
+	endif
 
-  $(eval $(call CONFIGURE_LINKER_WHOLE,$(1)))
-  $(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
-  linkcmd += $(libs) -L $(CROSS_SYSROOT)/usr/local/lib $($(1).linkoptions)
+	$(eval $(call CONFIGURE_LINKER_WHOLE,$(1)))
+	$(foreach lk,$($(1).links),$(eval $(call CONFIGURE_LIBS,$(lk))))
+	linkcmd += $(libs) -L $(CROSS_SYSROOT)/usr/local/lib $($(1).linkoptions)
 endef
 
 define PREPARE
-  $(eval $(call DIRECTORY,$(1)))
-  $(eval $(call ENUMERATE,$(1)))
-  $(eval $(call CONFIGURE_LINKER,$(1)))
-  $(eval objectfiles  := $(subst $(sourcedir)/,$(outdir)/,$(addsuffix .o,\
-    $(sourcefiles))))
-  $(eval bitcodefiles := $(subst .o,.bc,$(objectfiles)))
-  $(eval dependencies := $(subst .c,,$(subst .cc,,$(subst .ll,,$(subst .o,.d,\
-    $(objectfiles))))))
+	$(eval $(call DIRECTORY,$(1)))
+	$(eval $(call ENUMERATE,$(1)))
+	$(eval $(call CONFIGURE_LINKER,$(1)))
+	$(eval objectfiles  := $(subst $(sourcedir)/,$(outdir)/,$(addsuffix .o,\
+		$(sourcefiles))))
+	$(eval bitcodefiles := $(subst .o,.bc,$(objectfiles)))
+	$(eval dependencies := $(subst .c,,$(subst .cc,,$(subst .ll,,$(subst .o,.d,\
+		$(objectfiles))))))
 endef
 
 define EXPAND_OBJCMD
@@ -779,23 +771,23 @@ $(eval file := $(subst .o,,$(1)))
 $(eval $(call CONFIGURE_COMPILER,$(file)))
 
 ifeq ($(3),libponyrtyes)
-  ifneq ($(suffix $(file)),.bc)
+	ifneq ($(suffix $(file)),.bc)
 $(subst .c,,$(subst .cc,,$(subst .ll,,$(1)))): $(subst .c,.bc,$(subst .cc,.bc,$(subst .ll,.bc,$(file))))
 	@echo '$$(notdir $$<)'
 	@mkdir -p $$(dir $$@)
 	$(SILENT)$(compiler) $(flags) -c -o $$@ $$<
-  else ifeq ($(suffix $(subst .bc,,$(file))),.ll)
+	else ifeq ($(suffix $(subst .bc,,$(file))),.ll)
 $(subst .ll,,$(1)): $(subst $(outdir)/,$(sourcedir)/,$(subst .bc,,$(file)))
 	@echo '$$(notdir $$<)'
 	@mkdir -p $$(dir $$@)
 	$(SILENT)$(LLVM_AS) -o $$@ $$<
-  else
+	else
 $(subst .c,,$(subst .cc,,$(1))): $(subst $(outdir)/,$(sourcedir)/,$(subst .bc,,$(file)))
 	@echo '$$(notdir $$<)'
 	@mkdir -p $$(dir $$@)
 	$(SILENT)$(compiler) -MMD -MP $(filter-out $($(2).disable),$(BUILD_FLAGS)) \
-    $(flags) $($(2).buildoptions) -emit-llvm -c -o $$@ $$<  $($(2).include)
-  endif
+		$(flags) $($(2).buildoptions) -emit-llvm -c -o $$@ $$<  $($(2).include)
+	endif
 else ifeq ($(suffix $(file)),.ll)
 $(subst .ll,,$(1)): $(subst $(outdir)/,$(sourcedir)/,$(file))
 	@echo '$$(notdir $$<)'
@@ -806,7 +798,7 @@ $(subst .c,,$(subst .cc,,$(1))): $(subst $(outdir)/,$(sourcedir)/,$(file))
 	@echo '$$(notdir $$<)'
 	@mkdir -p $$(dir $$@)
 	$(SILENT)$(compiler) -MMD -MP $(filter-out $($(2).disable),$(BUILD_FLAGS)) \
-    $(flags) $($(2).buildoptions) -c -o $$@ $$<  $($(2).include)
+		$(flags) $($(2).buildoptions) -c -o $$@ $$<  $($(2).include)
 endif
 endef
 
@@ -821,35 +813,35 @@ ifeq ($(1),libponyrt)
 $($(1))/libponyrt.$(LIB_EXT): $(depends) $(ofiles)
 	@mkdir -p $$(dir $$@)
 	@echo 'Linking libponyrt'
-    ifneq (,$(DTRACE))
-    ifeq ($(OSTYPE), linux)
+		ifneq (,$(DTRACE))
+		ifeq ($(OSTYPE), linux)
 	@echo 'Generating dtrace object file (linux)'
 	$(SILENT)$(DTRACE) -G -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_BUILD_DIR)/dtrace_probes.o
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles) $(PONY_BUILD_DIR)/dtrace_probes.o
-    else ifeq ($(OSTYPE), bsd)
+		else ifeq ($(OSTYPE), bsd)
 	@echo 'Generating dtrace object file (bsd)'
 	$(SILENT)rm -f $(PONY_BUILD_DIR)/dtrace_probes.o
 	$(SILENT)$(DTRACE) -G -s $(PONY_SOURCE_DIR)/common/dtrace_probes.d -o $(PONY_BUILD_DIR)/dtrace_probes.o $(ofiles)
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles) $(PONY_BUILD_DIR)/dtrace_probes.o
 	$(SILENT)$(AR) $(AR_FLAGS) $(lib)/libdtrace_probes.a $(PONY_BUILD_DIR)/dtrace_probes.o
-    else
+		else
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
-    endif
-    else
+		endif
+		else
 	$(SILENT)$(AR) $(AR_FLAGS) $$@ $(ofiles)
-    endif
-  ifeq ($(runtime-bitcode),yes)
+		endif
+	ifeq ($(runtime-bitcode),yes)
 $($(1))/libponyrt.bc: $(depends) $(bcfiles)
 	@mkdir -p $$(dir $$@)
 	@echo 'Generating bitcode for libponyrt'
 	$(SILENT)$(LLVM_LINK) -o $$@ $(bcfiles)
-    ifeq ($(config),release)
+		ifeq ($(config),release)
 	$(SILENT)$(LLVM_OPT) -O3 -o $$@ $$@
-    endif
+		endif
 libponyrt: $($(1))/libponyrt.bc $($(1))/libponyrt.$(LIB_EXT)
-  else
+	else
 libponyrt: $($(1))/libponyrt.$(LIB_EXT)
-  endif
+	endif
 else ifneq ($(filter $(1),$(libraries)),)
 $($(1))/$(1).$(LIB_EXT): $(depends) $(ofiles)
 	@mkdir -p $$(dir $$@)
@@ -949,11 +941,11 @@ endef
 $(eval $(call EXPAND_UNINSTALL))
 
 ifdef verbose
-  bench_verbose = -DCMAKE_VERBOSE_MAKEFILE=true
+	bench_verbose = -DCMAKE_VERBOSE_MAKEFILE=true
 endif
 
 ifeq ($(lto),yes)
-  bench_lto = -DBENCHMARK_ENABLE_LTO=true
+	bench_lto = -DBENCHMARK_ENABLE_LTO=true
 endif
 
 benchmark: all


### PR DESCRIPTION
Does a few small things:

1- orders our search in terms of preference where we prefer newer LLVMs to
   older ones. Generic `llvm-config` is considered the least desirable.
2- only search in the users PATH. don't go poking into "magic" directories
   where some tool might have installed a version looking for llvm-config.
   If we do that, then it makes it impossible for a user with more than 1
   LLVM installation to pick the version to use based solely on their PATH.