### PR TITLE
Clean up llvm-config options

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -226,9 +226,7 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-  ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-  else ifneq (,$(shell which llvm-config-7.0 2> /dev/null))
+  ifneq (,$(shell which llvm-config-7.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-7.0
   else ifneq (,$(shell which llvm-config70 2> /dev/null))
     LLVM_CONFIG = llvm-config70
@@ -238,18 +236,12 @@ ifndef LLVM_CONFIG
     LLVM_CONFIG = llvm-config-6.0
   else ifneq (,$(shell which llvm-config-mp-6.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-mp-6.0
-  else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-5.0
-  else ifneq (,$(shell which /usr/local/opt/llvm/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /usr/local/opt/llvm/bin/llvm-config
-  else ifneq (,$(shell which llvm-config 2> /dev/null))
-    LLVM_CONFIG = llvm-config
   else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
     LLVM_CONFIG = llvm-config-5.0
-  else ifneq (,$(shell which /opt/llvm-5.0.1/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-5.0.1/bin/llvm-config
-  else ifneq (,$(shell which /opt/llvm-5.0.0/bin/llvm-config 2> /dev/null))
-    LLVM_CONFIG = /opt/llvm-5.0.0/bin/llvm-config
+  else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
+    LLVM_CONFIG = llvm-config-mp-5.0
+  else ifneq (,$(shell which llvm-config 2> /dev/null))
+    LLVM_CONFIG = llvm-config
   else
     $(error No LLVM installation found!)
   endif


### PR DESCRIPTION
Does a few small things:

1- orders our search in terms of preference where we prefer newer LLVMs
to
older ones. Generic llvm-config is considered the least desirable.

2- only search in the users PATH. don't go poking into "magic"
directories
where some tool might have installed a version looking for llvm-config.
If we do that, then it makes it impossible for a user with more than 1
LLVM installation to pick the version to use based solely on their PATH.