### PR TITLE
Remove references to the #ponylang IRC channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Some things to note that aren't immediately obvious to folks just starting out:
 2. Any changes you make on your branch that you used for the PR will automatically appear in the PR so if you have more than 1 PR, be sure to always create different branches for them.
 3. Weird things happen with commit history if you don't create your PR branches off of master so always make sure you have the master branch checked out before creating a branch for a PR
 
-If you feel overwhelmed at any point, don't worry, it can be a lot to learn when you get started. Feel free to reach out via [IRC](https://webchat.freenode.net/?channels=%23ponylang), [Slack](https://www.ponylang.io/get-slack-invite) or the [pony developer mailing list](https://pony.groups.io/g/dev) for assistance.
+If you feel overwhelmed at any point, don't worry, it can be a lot to learn when you get started. Feel free to reach out via [Slack](https://www.ponylang.io/get-slack-invite) or the [pony developer mailing list](https://pony.groups.io/g/dev) for assistance.
 
 You can get help using GitHub via [the official documentation](https://help.github.com/). Some highlights include:
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ We have a couple resources designed to help you learn, we suggest starting with 
 * [Standard library docs](http://stdlib.ponylang.io/).
 * [Build Problems, see FAQ Compiling](https://www.ponylang.io/faq/#compiling).
 
-If you are looking for an answer "right now", we suggest you give our IRC channel a try. It's #ponylang on Freenode. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or IRC isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
+If you are looking for an answer "right now", we suggest you give our Slack community a try. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or Slack isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
 * [Mailing list](mailto:pony+user@groups.io).
-* [IRC](https://webchat.freenode.net/?channels=%23ponylang).
 * [Slack](https://www.ponylang.io/get-slack-invite)
 
 Think you've found a bug? Check your understanding first by writing the mailing list. Once you know it's a bug, open an issue.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -165,7 +165,7 @@ curl -sL https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula
 
 If the formulae has been successfully updated, you'll see the new download url in the output of the command. If it hasn't, you'll see the old url.
 
-Note that its often quite quick to get everything through Homebrew's CI and merge process, however its often quite slow as well. We've seen their Jenkins CI often fail with errors that are unrelated to PR in question. Don't wait too long on Homebrew. If it hasn't passed CI and been merged within a couple hours move ahead without it having passed. If Homebrew is being slow about merging, when you inform IRC, Slack, and pony-user of the release, note that the Homebrew version isn't available yet and include a link to the Homebrew PR and the ponyc Github release issue so that people can follow along. When the Homebrew PR is eventually merged, update pony-user, Slack, and IRC.
+Note that its often quite quick to get everything through Homebrew's CI and merge process, however its often quite slow as well. We've seen their Jenkins CI often fail with errors that are unrelated to PR in question. Don't wait too long on Homebrew. If it hasn't passed CI and been merged within a couple hours move ahead without it having passed. If Homebrew is being slow about merging, when you inform Slack, and pony-user of the release, note that the Homebrew version isn't available yet and include a link to the Homebrew PR and the ponyc Github release issue so that people can follow along. When the Homebrew PR is eventually merged, update pony-user and Slack.
 
 ### Wait on Docker images to be built
 
@@ -184,12 +184,6 @@ Once the dockerhub images have been updated, visit the [Pony Playground](https:/
 ### Merge the release blog post PR for the ponylang website
 
 Once all the release steps have been confirmed as successful, merge the PR you created earlier for ponylang.github.io for the blog post announcing the release. Confirm it is successfully published to the [blog](https://www.ponylang.io/blog/).
-
-### Inform #ponylang
-
-Once Travis, Appveyor and Homebrew are all finished, drop a note in the #ponylang IRC channel (on freenode) letting everyone know that the release is out and include a link the release blog post. ([example](https://irclog.whitequark.org/ponylang/2018-05-26#22183154;))
-
-If this is an "emergency release" that is designed to get a high priority bug fix out, be sure to note that everyone is advised to update ASAP. If the high priority bug only affects certain platforms, adjust the "update ASAP" note accordingly.
 
 ### Inform the Pony Slack
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,14 +4,13 @@ Looking for help with Pony? Awesome. We are here to help. Before you open an iss
 
 ## Should I open an issue?
 
-We ask you to refrain from opening GitHub issues for non-actionable items. We use GitHub issues to track bugs and other problems that can be resolved. If you are not sure how to code a particular problem, how to decipher an error message, wondering about a benchmark, or anything of that sort, please use the [mailing list][mailing list], [slack][slack] or [IRC][IRC].
+We ask you to refrain from opening GitHub issues for non-actionable items. We use GitHub issues to track bugs and other problems that can be resolved. If you are not sure how to code a particular problem, how to decipher an error message, wondering about a benchmark, or anything of that sort, please use the [mailing list][mailing list] or [slack][slack].
 
 ## How to get help
 
-You have a couple of different options on how you can get help from the Pony community. If you are looking for an answer "right now," we suggest you give our IRC channel a try. It's `#ponylang` on Freenode. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or IRC isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
+You have a couple of different options on how you can get help from the Pony community. If you are looking for an answer "right now," we suggest you give our Slack community a try. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or Slack isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
 * [Mailing list][mailing list].
-* [IRC][IRC].
 * [Slack][slack].
 
 Many folks encounter the same issues or have the same questions, be sure to give the [frequently asked questions][FAQ] section of this website a read.
@@ -23,7 +22,6 @@ Think you've found a bug? It's entirely possible. Pony is a relatively young lan
 The Pony community while small is helpful and inviting. We think you'll find interacting with us to be an enjoyable experience. You can get a lot more community-related resources in the [community section][website community section] of this site. 
 
 [mailing list]: https://pony.groups.io/g/user
-[IRC]: https://webchat.freenode.net/?channels=%23ponylang
 [FAQ]: https://www.ponylang.io/faq/
 [slack]: https://www.ponylang.io/get-slack-invite
 [issues]: https://github.com/ponylang/ponyc/issues


### PR DESCRIPTION
We've decided to deprecate it. Everyone seems to want a Slack channel
rather than IRC so we are shutting down the IRC channel.

[skip ci]