### PR TITLE
Update Debian packages to use "available system LLVM"

### DIFF
--- a/.packaging/deb/control
+++ b/.packaging/deb/control
@@ -1,6 +1,6 @@
 Source: ponyc
 Maintainer: Pony Core Team <buildbot@pony.groups.io>
-Build-Depends: debhelper (>= 9.0.0), git, zlib1g-dev, libncurses5-dev, libssl-dev, libpcre2-dev, llvm-3.9, llvm-3.9-dev
+Build-Depends: debhelper (>= 9.0.0), git, zlib1g-dev, libncurses5-dev, libssl-dev, libpcre2-dev, llvm, llvm-dev
 Priority: optional
 Standards-Version: 3.9.7
 Section: devel


### PR DESCRIPTION
Previously it was hardcoded to LLVM-3.9.1. Note this impacts Ubuntu as
well here because "Debian" here refers to the packaging format shared by
Ubuntu.