### PR TITLE
Change lib/llvm default target to be tag llvmorg-7.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ test-ci-lib-llvm: &test-ci-lib-llvm
   command: |
     # When testing override CPUs in command line, such as:
     #   $ circleci build -e CPUs=11 --job ubuntu-debug
-    echo 'if [ "$CPUs" == "" ]; then cnt=$(nproc); if (( $cnt >= 4 )); then (( cnt=$cnt / 4 )); else cnt=1; fi; export CPUs=$cnt; fi;' >> $BASH_ENV
+    echo 'if [ "$CPUs" == "" ]; then cnt=$(nproc); if (( $cnt >= 4 )); then (( cnt=$cnt / 4 )); else cnt=1; fi; if (( $cnt > 4 )); then cnt=4; fi; export CPUs=$cnt; fi;' >> $BASH_ENV
     source $BASH_ENV
     echo "make-llvm: CPUs=$CPUs test_ci_params='$test_ci_params'"
     make -f Makefile-lib-llvm test-ci -j$CPUs $test_ci_params

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "lib/llvm/src"]
 	path = lib/llvm/src
 	url = https://github.com/llvm/llvm-project
-	branch = release/3.9.x

--- a/README.md
+++ b/README.md
@@ -340,6 +340,31 @@ Typically you only need to build the LLVM sources once, as the `make clean` targ
 
 NOTE: If LLVM version < 5.0.0 is used, cpu feature `avx512f` is disabled automagically to avoid [LLVM bug 30542](https://bugs.llvm.org/show_bug.cgi?id=30542) otherwise the compiler crashes during the optimization phase.
 
+### Changing the commit associated with llvm_target=llvm-default
+
+When llvm_target is not specified or it is llvm-default the commit associated with the lib/llvm/src submodule is checked out as the llvm source to be built. To change to a different commit, for instance a tag `llvmorg-8.0.0`, simply clone ponyc and have the lib/llvm/src submodule up to date and initialized. The simplest way to do that is clone ponyc with --recursive-submodule. Then checkout the desired commit the lib/llvm/src directory and push it to the repo, for example:
+```
+git clone --recurse-submodules  https://github.com/you/ponyc ponyc
+cd ponyc
+git checkout -b update-lib-llvm-src-to-llvmorg-8.0.0 master
+cd lib/llvm/src
+git checkout llvmorg-8.0.0:
+cd ../../../
+```
+Now build and test using `llvm_target=llvm-current` and any other appropriate parameters:
+```
+make -j12 llvm_target=llvm-current default_pic=true default_ssl=openssl_1.1.0 -f Makefile-lib-llvm
+# Debug/test ....
+```
+When satisfied create a commit pushing to your repo:
+```
+git add lib/llvm/src
+git commit -m "Update submodule lib/llvm/src to llvmorg-8.0.0"
+git push origin update-lib-llvm-src-to-llvmorg-8.0.0
+```
+And finally create a pull request and work hard getting CI to pass, :)
+See the [Submodule section of the git-scm book](https://git-scm.com/book/en/v2/Git-Tools-Submodules) for more information.
+
 ## Building on Linux
 
 Get the pony source from GitHub (For information on setting up Git, see https://help.github.com/articles/set-up-git/):

--- a/lib/llvm/Makefile
+++ b/lib/llvm/Makefile
@@ -43,17 +43,17 @@ ifeq ($(MAKECMDGOALS),rebuild)
 else ifeq ($(MAKECMDGOALS),llvm-7.x)
   LLVM_TARGET := llvm-7.x
   GET_LLVM_SRC_TARGET := get-llvm-src-$(LLVM_TARGET)
-  LLVM_SRC_DEPTH := --depth=1
+  LLVM_SRC_DEPTH :=
   LLVM_BRANCH := -b release/7.x
 else ifeq ($(MAKECMDGOALS),llvm-6.x)
   LLVM_TARGET := llvm-6.x
   GET_LLVM_SRC_TARGET := get-llvm-src-$(LLVM_TARGET)
-  LLVM_SRC_DEPTH := --depth=1
+  LLVM_SRC_DEPTH :=
   LLVM_BRANCH := -b release/6.x
 else ifeq ($(MAKECMDGOALS),llvm-3.9.1)
   LLVM_TARGET := llvm-3.9.1
   GET_LLVM_SRC_TARGET := get-llvm-src-$(LLVM_TARGET)
-  LLVM_SRC_DEPTH := --depth=1
+  LLVM_SRC_DEPTH :=
   LLVM_BRANCH := -b release/3.9.x
 else ifeq ($(MAKECMDGOALS),llvm-current)
   LLVM_TARGET := llvm-current
@@ -64,7 +64,7 @@ else ifeq ($(MAKECMDGOALS),llvm-default)
   $(warning llvm-default.....)
   LLVM_TARGET := llvm-default
   GET_LLVM_SRC_TARGET := get-default-llvm-src
-  LLVM_SRC_DEPTH := --depth=1
+  LLVM_SRC_DEPTH :=
   LLVM_URL :=
   LLVM_BRANCH :=
 else ifeq ($(MAKECMDGOALS),buildit)
@@ -122,36 +122,43 @@ else
   LLVM_ENABLE_PROJECTS :=
 endif
 
-ifeq ($(LLVM_BUILD_ENGINE),Ninja)
-MAKE := ninja
-MAKEFILE := build.ninja
-else
-MAKE := make
-MAKEFILE := Makefile
-endif
-
 ifneq (,$(verbose))
   VERBOSE_CMAKE := -DCMAKE_VERBOSE_MAKEFILE=true
 endif
 
 $(LLVM_TARGET): installed-llvm-$(LLVM_TARGET)
-	@echo "hi installed $(LLVM_TARGET)"
 
 .PHONY: rebuild
 rebuild: clean-built-installed
-	make installed-llvm-$(LLVM_TARGET) LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
+	$(MAKE) installed-llvm-$(LLVM_TARGET) LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
 
+ifeq ($(LLVM_BUILD_ENGINE),Ninja)
+.PHONY: buildit
+buildit:
+	@echo building $(LLVM_TARGET) `git -C src log -1 --pretty="format:hash=%h ref=%d subject='%s'"`
+	ninja -C $(LLVM_BUILD_DIR)
+	touch built-llvm-$(LLVM_TARGET)
+else
 .PHONY: buildit
 buildit:
 	@echo building $(LLVM_TARGET) `git -C src log -1 --pretty="format:hash=%h ref=%d subject='%s'"`
 	$(MAKE) -C $(LLVM_BUILD_DIR)
 	touch built-llvm-$(LLVM_TARGET)
+endif
 
+ifeq ($(LLVM_BUILD_ENGINE),Ninja)
+.PHONY: installit
+installit:
+	@echo installing $(LLVM_TARGET)
+	ninja -C $(LLVM_BUILD_DIR) install
+	touch installed-llvm-$(LLVM_TARGET)
+else
 .PHONY: installit
 installit:
 	@echo installing $(LLVM_TARGET)
 	$(MAKE) -C $(LLVM_BUILD_DIR) install
 	touch installed-llvm-$(LLVM_TARGET)
+endif
 
 .PHONY: generateit
 generateit:
@@ -161,26 +168,22 @@ generateit:
 	touch $(LLVM_BUILD_DIR)/generated-llvm-makefile-$(LLVM_TARGET)
 
 $(LLVM_BUILD_DIR)/generated-llvm-makefile-$(LLVM_TARGET): $(GET_LLVM_SRC_TARGET)
-	make generateit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
+	$(MAKE) generateit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
 
-ifeq ($(MAKE),ninja)
-built-llvm-$(LLVM_TARGET): $(LLVM_BUILD_DIR)/generated-llvm-makefile-$(LLVM_TARGET)
-	make buildit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
-else
 built-llvm-$(LLVM_TARGET): $(LLVM_BUILD_DIR)/generated-llvm-makefile-$(LLVM_TARGET)
 	$(MAKE) buildit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
-endif
 
 installed-llvm-$(LLVM_TARGET): built-llvm-$(LLVM_TARGET)
-	make installit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
+	$(MAKE) installit LLVM_TARGET=$(LLVM_TARGET) LLVM_SRC_DIR=$(LLVM_SRC_DIR) LLVM_BUILD_DIR=$(LLVM_BUILD_DIR)
 
-.PHONY: get-nothing
-get-nothing: clean
+get-nothing:
+	touch get-nothing
 
 get-default-llvm-src:
 	@echo get-default-llvm-src
 	rm -rf $(LLVM_SRC_DIR)
 	mkdir $(LLVM_SRC_DIR)
+	git submodule sync
 	git submodule update --init $(LLVM_SRC_DEPTH)
 	touch get-default-llvm-src
 


### PR DESCRIPTION
.circle/config.yml:
    Cap CPUs to a maximum of 4 if using $(nproc) in .circle/config.yml

.gitmodule and lib/llvm/src:
    Remove branch and and Changed lib/llvm/src tag llvmorg-7.0.1

README.md:
    updated with instructions for changing default target

lib/llvm/Makefile:
- Don't use --depth=1 as I found it was more trouble then it's worth.
  It makes switching to other commits difficult and looks like it takes
  longer to transfer with circle CI.
- Change get-nothing target to not be a .PHONY target as prior to this target:
   `$(LLVM_BUILD_DIR)/generated-llvm-makefile-$(LLVM_TARGET): $(GET_LLVM_SRC_TARGET)`
    would always need updating.
- Use $(MAKE) instead of make directly except in buildit and installit
  where its conditional as we need to use ninja or $(MAKE) as
  appropriate.