### PR TITLE
Build Debian release packages using LLVM 3.9.1

### DIFF
--- a/.ci-dockerfiles/llvm-3.9.1/Dockerfile
+++ b/.ci-dockerfiles/llvm-3.9.1/Dockerfile
@@ -1,0 +1,12 @@
+FROM ponylang/ponyc-ci:ubuntu-16.04-base
+
+ENV LLVM_VERSION 3.9.1
+
+USER root
+
+RUN wget -O - http://llvm.org/releases/${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04.tar.xz \
+ | tar xJf - --strip-components 1 -C /usr/local/ clang+llvm-${LLVM_VERSION}-x86_64-linux-gnu-ubuntu-16.04 \
+   && chown -R root:root /usr/local
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/llvm-3.9.1/README.md
+++ b/.ci-dockerfiles/llvm-3.9.1/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:llvm-3.9.1 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-llvm-391 --user pony --rm -i -t ponylang/ponyc-ci:llvm-3.9.1 bash
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI job using this image
+from the ponyc project root:
+
+```bash
+circleci build --job llvm-391-debug
+circleci build --job llvm-391-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:llvm-3.9.1
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,24 @@ jobs:
       - run: make all config=release default_pic=true -j3
       - run: make test-ci config=release default_pic=true
 
+  llvm-391-debug:
+    docker:
+      - image: ponylang/ponyc-ci:llvm-3.9.1
+        user: pony
+    steps:
+      - checkout
+      - run: make all config=debug default_pic=true -j3
+      - run: make test-ci config=debug default_pic=true
+
+  llvm-391-release:
+    docker:
+      - image: ponylang/ponyc-ci:llvm-3.9.1
+        user: pony
+    steps:
+      - checkout
+      - run: make all config=release default_pic=true -j3
+      - run: make test-ci config=release default_pic=true
+
   openssl-110:
     docker:
       - image: ponylang/ponyc-ci:openssl-1.1.0
@@ -268,6 +286,9 @@ workflows:
       - llvm-502-release:
           requires:
             - llvm-701-release
+      - llvm-391-release:
+          requires:
+            - llvm-701-release
 
       ### p2 tests
       - llvm-701-debug:
@@ -279,6 +300,9 @@ workflows:
       - llvm-502-debug:
           requires:
             - llvm-502-release
+      - llvm-391-debug:
+          requires:
+            - llvm-391-release
 
       # alpine
       - alpine-llvm-5-release:

--- a/.packaging/deb/control
+++ b/.packaging/deb/control
@@ -1,6 +1,6 @@
 Source: ponyc
 Maintainer: Pony Core Team <buildbot@pony.groups.io>
-Build-Depends: debhelper (>= 9.0.0), git, zlib1g-dev, libncurses5-dev, libssl-dev, libpcre2-dev, llvm, llvm-dev
+Build-Depends: debhelper (>= 9.0.0), git, zlib1g-dev, libncurses5-dev, libssl-dev, libpcre2-dev, llvm-3.9, llvm-3.9-dev
 Priority: optional
 Standards-Version: 3.9.7
 Section: devel


### PR DESCRIPTION
This reverse previous deprecation of 3.9.1. We are going to keep 3.9.1
for as long as it is the default system LLVM for distro versions we
support. This may change if we determine that shipping packages using a
vendored LLVM works.