### PR TITLE
Stop supporting Ubuntu Trusty

### DIFF
--- a/.bintray_deb.bash
+++ b/.bintray_deb.bash
@@ -2,7 +2,7 @@
 
 REPO_TYPE=debian
 PACKAGE_VERSION=$1  # e.g., 0.24.0
-DISTRO=$2 # e.g., trusty
+DISTRO=$2 # e.g., bionic
 
 if [[ "$PACKAGE_VERSION" == "" ]]; then
   echo "Error! PACKAGE_VERSION (argument 1) required!"

--- a/.ci-dockerfiles/deb-builder/Dockerfile
+++ b/.ci-dockerfiles/deb-builder/Dockerfile
@@ -1,8 +1,8 @@
 ARG FROM_DISTRO=ubuntu
-ARG FROM_VERSION=trusty
+ARG FROM_VERSION=xenial
 FROM ${FROM_DISTRO}:${FROM_VERSION}
 
-ARG FROM_VERSION=trusty
+ARG FROM_VERSION=xenial
 
 RUN apt-get update \
  && apt-get install -y \

--- a/.ci-dockerfiles/deb-builder/README.md
+++ b/.ci-dockerfiles/deb-builder/README.md
@@ -1,11 +1,6 @@
 # Build image for different distros
 
 ```bash
-# Ubuntu Trusty
-docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=trusty -t ponylang/ponyc-ci:trusty-deb-builder .
-```
-
-```bash
 # Ubuntu Xenial
 docker build --build-arg FROM_DISTRO=ubuntu --build-arg FROM_VERSION=xenial -t ponylang/ponyc-ci:xenial-deb-builder .
 ```

--- a/.packaging/deb/rules
+++ b/.packaging/deb/rules
@@ -19,14 +19,10 @@ DEB_DISTRIBUTION = $(call dpkg_late_eval,DEB_DISTRIBUTION,dpkg-parsechangelog -S
 MAKE_OPTIONS := prefix=/usr
 
 ifeq ($(DEB_HOST_ARCH),amd64)
-ifeq ($(DEB_DISTRIBUTION),trusty)
-	MAKE_OPTIONS += arch=x86-64 tune=generic
-else
 ifeq ($(DEB_DISTRIBUTION),jessie)
 	MAKE_OPTIONS += arch=x86-64 tune=generic use="llvm_link_static"
 else
 	MAKE_OPTIONS += arch=x86-64 tune=intel
-endif
 endif
 endif
 
@@ -38,9 +34,9 @@ ifeq ($(DEB_HOST_ARCH),armhf)
 	MAKE_OPTIONS += arch=armv7 tune=arm7
 endif
 
-# jessie, trusty, xenial and artful are on openssl 1.0
+# jessie, xenial and artful are on openssl 1.0
 # artful and newer require PIC
-ifeq (,$(filter $(DEB_DISTRIBUTION),jessie trusty xenial artful))
+ifeq (,$(filter $(DEB_DISTRIBUTION),jessie xenial artful))
 	MAKE_OPTIONS += default_ssl='openssl_1.1.0' default_pic=true
 else
 ifeq ($(DEB_DISTRIBUTION),artful)
@@ -65,7 +61,7 @@ override_dh_auto_test:
 	$(MAKE) test-ci $(MAKE_OPTIONS)
 
 # if newer debian/ubuntu disable unform compression in deb for bintray
-ifeq (,$(filter $(DEB_DISTRIBUTION),jessie stretch trusty xenial artful))
+ifeq (,$(filter $(DEB_DISTRIBUTION),jessie stretch xenial artful))
 override_dh_builddeb:
 	dh_builddeb -- --no-uniform-compression
 endif

--- a/.travis_commands.bash
+++ b/.travis_commands.bash
@@ -145,7 +145,6 @@ ponyc-build-debs-ubuntu(){
   build_deb xenial
   build_deb artful
   build_deb bionic
-  build_deb trusty
 
   ls -la
   set +x

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ By default, the Pony DEB package is compiled without support for AVX CPU instruc
 
 ### Linux Mint
 
-All steps to install Pony in Linux Mint are the same from Ubuntu, but you must use the Ubuntu package base (`trusty`, `xenial`, `bionic`) instead of the Linux Mint release.
+All steps to install Pony in Linux Mint are the same from Ubuntu, but you must use the Ubuntu package base (`xenial`, `bionic`) instead of the Linux Mint release.
 
 Install pre-requisites and add the correct `apt` repository:
 
@@ -445,59 +445,6 @@ To build ponyc, compile and run helloworld:
 ```bash
 cd ~/ponyc/
 make default_pic=true
-./build/release/ponyc examples/helloworld
-./helloworld
-```
-
-### Ubuntu Trusty
-
-Add the LLVM apt repo to /etc/apt/sources.list. Open `/etc/apt/sources.list` and add the following lines to the end of the file:
-
-```
-deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
-deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
-```
-
-Add the LLVM repo as a trusted source:
-
-```bash
-cd /tmp
-wget -O llvm-snapshot.gpg.key http://apt.llvm.org/llvm-snapshot.gpg.key
-sudo apt-key add llvm-snapshot.gpg.key
-```
-
-Install dependencies:
-
-```bash
-sudo apt-get update
-sudo apt-get install -y build-essential git zlib1g-dev libncurses5-dev \
-  libssl-dev llvm-3.9
-```
-
-Install libprce2:
-
-```bash
-cd /tmp
-wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
-tar xjvf pcre2-10.21.tar.bz2
-cd pcre2-10.21
-./configure --prefix=/usr
-make
-sudo make install
-```
-
-Clone the ponyc repo:
-
-```bash
-cd ~/
-git clone https://github.com/ponylang/ponyc.git
-```
-
-Build ponyc, compile and run helloworld:
-
-```bash
-cd ~/ponyc/
-make
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```


### PR DESCRIPTION
It's end of life is in April. We don't have any releases before then,
time to say goodbye to our trusty old Trusty.

Closes #3060