### PR TITLE
Stop trying to be clever when finding user's LLVM installation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,8 +8,8 @@ task:
     - pkg install -y gmake pcre2 libunwind llvm70 git
 
   test_script:
-    - gmake all config=release -j3 default_ssl=openssl_1.1.0
-    - gmake test-ci config=release default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake all config=release -j3 default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake test-ci config=release default_ssl=openssl_1.1.0
 
 task:
   freebsd_instance:
@@ -24,5 +24,5 @@ task:
     - pkg install -y gmake pcre2 libunwind llvm70 git
 
   test_script:
-    - gmake all config=debug -j3 default_ssl=openssl_1.1.0
-    - gmake test-ci config=debug default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake all config=debug -j3 default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake test-ci config=debug default_ssl=openssl_1.1.0

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -226,27 +226,15 @@ ifeq ($(OSTYPE),osx)
 endif
 
 ifndef LLVM_CONFIG
-  ifneq (,$(shell which llvm-config-7.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-7.0
-  else ifneq (,$(shell which llvm-config70 2> /dev/null))
-    LLVM_CONFIG = llvm-config70
-  else ifneq (,$(shell which llvm-config-mp-7.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-7.0
-  else ifneq (,$(shell which llvm-config-6.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-6.0
-  else ifneq (,$(shell which llvm-config-mp-6.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-6.0
-  else ifneq (,$(shell which llvm-config-5.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-5.0
-  else ifneq (,$(shell which llvm-config-mp-5.0 2> /dev/null))
-    LLVM_CONFIG = llvm-config-mp-5.0
-  else ifneq (,$(shell which llvm-config 2> /dev/null))
+  ifneq (,$(shell which llvm-config 2> /dev/null))
     LLVM_CONFIG = llvm-config
   else
-    $(error No LLVM installation found!)
+    $(error No LLVM installation found! Set LLVM_CONFIG environment variable \
+      to the `llvm-config` binary for your installation)
   endif
 else ifeq (,$(shell which $(LLVM_CONFIG) 2> /dev/null))
-  $(error No LLVM installation found!)
+  $(error No LLVM installation found! Set LLVM_CONFIG environment variable \
+    to the `llvm-config` binary for your installation)
 endif
 
 LLVM_BINDIR := $(shell $(LLVM_CONFIG) --bindir 2> /dev/null)


### PR DESCRIPTION
Clever is bad. Eventually it bites you in the ass. Ask The Narrator, he
knows.

Prior to this commit, we were trying to be clever and helpful and would
bend over backwards to try and find the user's LLVM installation
whereever their package manager of choice might put it. This was, in the
end, a losing battle. We were constantly adding more and more
variations.

To make it worse, we tried to have a hierarchy where we would look for
LLVM 7 first then 6 etc. We did this by looking something like:

llvm-config-7
llvm-config-6

The problem with this approach was that some installations, wouldn't use
the `-7` notation. For example, if you download a release directly from
releases.llvm.org, then your llvm-config will simply be `llvm-config`.

I discovered this when, after installing LLVM 7 from releases.llvm.org,
I continued to have LLVM 6 used because the search loooked something
like:

llvm-config-7
llvm-config-6
... more stuff ...
llvm-config

In the end, that's all just too much clever.

With this change, we'll use the first `llvm-config` we find in your path
IF you haven't set the LLVM_CONFIG environment variable which should be
considered the preferred way to select an LLVM when building ponyc.

Closes #3072