### PR TITLE
Upgrade Docker image to use LLVM 7.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ENV LLVM_VERSION 3.9.1
+ENV LLVM_VERSION 7.0.1
 
 RUN apt-get update \
  && apt-get install -y \


### PR DESCRIPTION
Part of our general move off of LLVM 3.9.1.