### PR TITLE
Increase number of times we try fetching from FreeBSD repos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@ task:
 
   name: "freebsd-12-release"
   install_script:
+    - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - pkg update
     - pkg install -y gmake pcre2 libunwind llvm70 git
 
@@ -20,6 +21,7 @@ task:
     - freebsd-12-release
 
   install_script:
+    - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - pkg update
     - pkg install -y gmake pcre2 libunwind llvm70 git
 


### PR DESCRIPTION
Some of our CI jobs for FreeBSD are timing out trying to install
packages using pkg.

There are two values we can change to control this:

FETCH_TIMEOUT and FETCH_RETRY. They default to 30 (for seconds) and 3
(for times). Each is set in /usr/local/etc/pkg.conf.

This commit doubles the number of retries from the default of 3 and
should hopefully cut down on our failures encountered while trying to
install dependencies.