### PR TITLE
Fixed issue with ponyc not being able to find Visual Studio Build Tools in non-standard locations.

### DIFF
--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -353,7 +353,7 @@ static bool find_executables(compile_t *c, const vsinfo_t *info, vcvars_t *vcvar
 }
 
 static const TCHAR* VSWHERE_PATH =
-  "\"\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest\"";
+  "\"\"%ProgramFiles(x86)%\\Microsoft Visual Studio\\Installer\\vswhere.exe\" -latest -products *\"";
 
 static bool find_msvcrt_and_linker(compile_t *c, vcvars_t* vcvars,
   errors_t *errors)


### PR DESCRIPTION
Fixed issue with ponyc not being able to find Visual Studio Build Tools in non-standard locations, as per https://github.com/ponylang/ponyc/issues/3067