### PR TITLE
Ensure methods reached through a union are detected as reachable.

### DIFF
--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -543,6 +543,7 @@ static void add_traits_to_type(reach_t* r, reach_type_t* t,
           {
             reach_type_cache_put(&t->subtypes, t2);
             reach_type_cache_put(&t2->subtypes, t);
+            add_methods_to_type(r, t2, t, opt);
 
             if(t->underlying == TK_TUPLETYPE)
               add_internal(r, t2, "__is", opt);


### PR DESCRIPTION
Prior to this PR, the fact of whether methods of a union member were marked
as reachable when called via a union (or intersection) reference was
accidentally depending on the order in which things were marked
reachable in the compiler execution. When a type was marked
as a subtype of the union before the method call was reached,
everything was okay, but when that order was reversed
(possible through indirection of a trait), things were not okay -
the methods seen as reachable through the union weren't copied
into being reachable on the subtype of the union as they were
supposed to.

The result was the possibility of runtime segfaults when the
expected vtable entries were not present, as observed in #3096.

This PR fixes that by ensuring this copy happens. Prior to this PR,
the copy was only happening for traits and interface subtypes,
but now it happens for union and intersection subtypes too.

Resolves #3096.