### PR TITLE
Install all MacOS CI dependencies via MacPorts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,15 +36,13 @@ task:
   name: "macOS-release"
 
   install_script:
-    - brew update
-    - brew install pcre2
-    - brew install libressl
     - curl -o macports.pkg https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.13-HighSierra.pkg
     - sudo installer -verbose -pkg macports.pkg -target /
     - sudo /opt/local/bin/port selfupdate
-    - sudo /opt/local/bin/port install llvm-7.0
+    - sudo /opt/local/bin/port install llvm-7.0 pcre2
 
   test_script:
+    - export LDFLAGS="-L/opt/local/lib"
     - export PATH=/usr/local/opt/llvm/bin/:$PATH
     - export CC1=clang
     - export CXX1=clang++
@@ -61,15 +59,13 @@ task:
     - macOS-release
 
   install_script:
-    - brew update
-    - brew install pcre2
-    - brew install libressl
     - curl -o macports.pkg https://distfiles.macports.org/MacPorts/MacPorts-2.5.4-10.13-HighSierra.pkg
     - sudo installer -verbose -pkg macports.pkg -target /
     - sudo /opt/local/bin/port selfupdate
-    - sudo /opt/local/bin/port install llvm-7.0
+    - sudo /opt/local/bin/port install llvm-7.0 pcre2
 
   test_script:
+    - export LDFLAGS="-L/opt/local/lib"
     - export PATH=/usr/local/opt/llvm/bin/:$PATH
     - export CC1=clang
     - export CXX1=clang++


### PR DESCRIPTION
We were installing llvm 7 via MacPorts (not available via Homebrew) and
libressl and pcre2 via Homebrew. This switches us to a 100% MacPorts
installation.

Ideally, as our advised method of installation is via Homebrew (and most
people use Homebrew) we'd do everything via Homebrew. However, their
LLVM story is really poor (you can't easily select a version, sometimes,
a version isn't available at all - like LLVM 7 at this moment), so I
switched us to the far less problematic MacPorts.