### PR TITLE
Remove references to groups.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Some things to note that aren't immediately obvious to folks just starting out:
 2. Any changes you make on your branch that you used for the PR will automatically appear in the PR so if you have more than 1 PR, be sure to always create different branches for them.
 3. Weird things happen with commit history if you don't create your PR branches off of master so always make sure you have the master branch checked out before creating a branch for a PR
 
-If you feel overwhelmed at any point, don't worry, it can be a lot to learn when you get started. Feel free to reach out via [Zulip](https://ponylang.zulipchat.com) or the [pony developer mailing list](https://pony.groups.io/g/dev) for assistance.
+If you feel overwhelmed at any point, don't worry, it can be a lot to learn when you get started. Feel free to reach out via [Zulip](https://ponylang.zulipchat.com).
 
 You can get help using GitHub via [the official documentation](https://help.github.com/). Some highlights include:
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ We have a couple resources designed to help you learn, we suggest starting with 
 * [Standard library docs](http://stdlib.ponylang.io/).
 * [Build Problems, see FAQ Compiling](https://www.ponylang.io/faq/#compiling).
 
-If you are looking for an answer "right now", we suggest you give our Zulip community a try. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or Zulip isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
-
-* [Mailing list](mailto:pony+user@groups.io).
-* [Zulip](https://ponylang.zulipchat.com)
+If you are looking for an answer "right now", we suggest you give our [Zulip](https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help) community a try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
 Think you've found a bug? Check your understanding first by writing the mailing list. Once you know it's a bug, open an issue.
 * [Open an issue](https://github.com/ponylang/ponyc/issues)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -9,7 +9,7 @@ In order to do a release, you absolutely must have:
 * Commit access to the `ponyc` repo
 * The latest release of the [changelog tool](https://github.com/ponylang/changelog-tool/releases) installed
 * Access to the ponylang twitter account
-* Accounts on reddit/hacker news/lobste.rs/ponylang irc for posting release notes
+* Accounts on reddit/hacker news/lobste.rs for posting release notes
 * An account on the [Pony Zulip](https://ponylang.zulipchat.com)
 
 While not strictly required, your life will be made much easier if you:
@@ -190,12 +190,6 @@ Once all the release steps have been confirmed as successful, merge the PR you c
 ### Inform the Pony Zulip
 
 Once Travis, Appveyor and Homebrew are all finished, drop a note in the [#announce stream](https://ponylang.zulipchat.com/#narrow/stream/189932-announce) with a topic like "0.3.1 has been released" of the Pony Zulip letting everyone know that the release is out and include a link the release blog post.
-
-If this is an "emergency release" that is designed to get a high priority bug fix out, be sure to note that everyone is advised to update ASAP. If the high priority bug only affects certain platforms, adjust the "update ASAP" note accordingly.
-
-### Inform pony-user
-
-Once Travis, Appveyor and Homebrew are all finished, send an email to the [pony user](https://pony.groups.io/g/user) mailing list letting everyone know that the release is out and include a link the release blog post. ([example](https://pony.groups.io/g/user/topic/pony_0_22_2_has_been_released/20332095))
 
 If this is an "emergency release" that is designed to get a high priority bug fix out, be sure to note that everyone is advised to update ASAP. If the high priority bug only affects certain platforms, adjust the "update ASAP" note accordingly.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,14 +4,11 @@ Looking for help with Pony? Awesome. We are here to help. Before you open an iss
 
 ## Should I open an issue?
 
-We ask you to refrain from opening GitHub issues for non-actionable items. We use GitHub issues to track bugs and other problems that can be resolved. If you are not sure how to code a particular problem, how to decipher an error message, wondering about a benchmark, or anything of that sort, please use the [mailing list][mailing list] or [Zulip][zulip].
+We ask you to refrain from opening GitHub issues for non-actionable items. We use GitHub issues to track bugs and other problems that can be resolved. If you are not sure how to code a particular problem, how to decipher an error message, wondering about a benchmark, or anything of that sort, please use reach out via [our Zulip community][zulip].
 
 ## How to get help
 
-You have a couple of different options on how you can get help from the Pony community. If you are looking for an answer "right now," we suggest you give our Zulip community a try. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or Zulip isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
-
-* [Mailing list][mailing list].
-* [Zulip][zulip].
+If you are looking for an answer "right now," we suggest you give our [Zulip community][zulip-beginner-help] a try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
 Many folks encounter the same issues or have the same questions, be sure to give the [frequently asked questions][FAQ] section of this website a read.
 
@@ -21,8 +18,8 @@ Think you've found a bug? It's entirely possible. Pony is a relatively young lan
 
 The Pony community while small is helpful and inviting. We think you'll find interacting with us to be an enjoyable experience. You can get a lot more community-related resources in the [community section][website community section] of this site. 
 
-[mailing list]: https://pony.groups.io/g/user
 [FAQ]: https://www.ponylang.io/faq/
 [zulip]: https://ponylang.zulipchat.com
+[zulip-beginner-help]: https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help
 [issues]: https://github.com/ponylang/ponyc/issues
 [website community section]: https://www.ponylang.io/community/


### PR DESCRIPTION
We are going to be deprecating the mailing lists there soon as they get
very little usage.

[skip ci]