### PR TITLE
removed backslashes from parsing examples

### DIFF
--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -35,7 +35,7 @@ JsonDoc instance can be used to parse multiple JSON Strings one by one.
 ```pony
 let doc = JsonDoc
 // parsing
-doc.parse("""{"key":"value", "property: true, "array":[1, 2.5, false]}""")?
+doc.parse("{\"key\":\"value\", \"property\": true, \"array\":[1, 2.5, false]}")?
 
 // extracting values from a JSON structure
 let json: JsonObject  = doc.data as JsonObject
@@ -57,7 +57,7 @@ block:
 
 ```pony
 // sending an iso doc
-let json_string = """{"array":[1, true, null]}"""
+let json_string = "{\"array\":[1, true, null]}"
 let sendable_doc: JsonDoc iso = recover iso JsonDoc.>parse(json_string)? end
 some_actor.send(consume sendable_doc)
 

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -35,7 +35,7 @@ JsonDoc instance can be used to parse multiple JSON Strings one by one.
 ```pony
 let doc = JsonDoc
 // parsing
-doc.parse(\"\"\"{"key":"value", "property: true, "array":[1, 2.5, false]}\"\"\")?
+doc.parse("""{"key":"value", "property: true, "array":[1, 2.5, false]}""")?
 
 // extracting values from a JSON structure
 let json: JsonObject  = doc.data as JsonObject
@@ -57,7 +57,7 @@ block:
 
 ```pony
 // sending an iso doc
-let json_string = \"\"\"{"array":[1, true, null]}\"\"\"
+let json_string = """{"array":[1, true, null]}"""
 let sendable_doc: JsonDoc iso = recover iso JsonDoc.>parse(json_string)? end
 some_actor.send(consume sendable_doc)
 


### PR DESCRIPTION
Hi,

The parsing examples in Pony docs contain redundant backslashes which provoke compilation errors. 

One example, taken from [here](https://stdlib.ponylang.io/json--index/#parsing-json): 

```pony
doc.parse(\"\"\"{"key":"value", "property: true, "array":[1, 2.5, false]}\"\"\")?
```
The idea for the commit is from @srenatus who helped me find the error in the first place. 
All potential errors in this commit are mine. 

Cheers,