### PR TITLE
Avoid busy loop when waiting for input on stdin.

### DIFF
--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -438,15 +438,20 @@ PONY_API bool pony_os_stdin_setup()
   // Always use events
   return true;
 #else
-  if(fd_type(STDIN_FILENO) == FD_TYPE_TTY)
+  switch(fd_type(STDIN_FILENO))
   {
-    if(is_stdout_tty)
-      stdin_tty();
-
-    return true;
+    case FD_TYPE_TTY:
+    {
+      if(is_stdout_tty)
+        stdin_tty();
+      return true;
+      break;
+    }
+    case FD_TYPE_FILE:
+      return false;
+    default:
+      return true;
   }
-
-  return false;
 #endif
 }
 


### PR DESCRIPTION
This affected a program of mine which implemented a server waiting for input on stdin. The actor `Stdin` was spawned with `_use_events=false` and thus using a busy loop to read from stdin. 

The current logic is only to use events for `Stdin` if stdin is connected to a tty. When the pony server is forked and stdin is connected to the parent process it is currently doing a busy loop.

This busy loop, constantly polling for data to read, is suitable when stdin is a redirected file like in './pony_program < inputfile.txt', but does not make sense when listening for spare input. 1 CPU was at 100% all the time while the program did nothing and received nothing.

The proposed solution is to only **not** use asio events to wait for data to be available when stdin can be detected to be a file. This has been successfully tested for regressions (e.g. hangs) on linux with:

```pony
actor Main
  """
  Simple Echo program
  """
  new create(env: Env) =>
    env.input.apply(
      object iso is InputNotify
        fun ref apply(data: Array[U8] iso) =>
          env.out.write(consume data)
        fun ref dispose() => None
      end)
```
in the following scenarios:
```
$ cat file.txt | ./pony_echo > file.txt.clone // md5sums of input and output file are equal
$ echo "ABC | ./pony_echo
$ ./pony_echo < file.txt > file.txt.clone  // md5sums of input and output file are equal
```

I am marking this as "needs discussion during sync" in case someone has an idea if and why this might be the wrong thing.