### PR TITLE
Fix error reporting for non-sendable lambda captures.

### DIFF
--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -124,7 +124,7 @@ static ast_result_t flatten_sendable_params(pass_opt_t* opt, ast_t* params)
 
     if(!sendable(type))
     {
-      ast_error(opt->check.errors, type,
+      ast_error(opt->check.errors, param,
         "this parameter must be sendable (iso, val or tag)");
       r = AST_ERROR;
     }


### PR DESCRIPTION
Sendable lambdas/object literals can only capture sendable variables. They are converted into fields on the anonymous type
and constructor parameters. The error reporting was using the type of the parameter to determine the source location of the parameter, which for inferred types was referring to the location of the expr whose type was used when when inferring the type.

This change uses the actual parameter location for error reporting.

Fixes #3123 

The new output for the example in #3123 :

```
Error:
/home/mwahl/dev/pony/scratch/main.pony:9:36: this parameter must be sendable (iso, val or tag)
        p.next[None]({(x: None) => d.min})
                                   ^
```