### PR TITLE
Add behaviour OutStream.flush for explicitly flushing streams. 

### DIFF
--- a/packages/builtin/std_stream.pony
+++ b/packages/builtin/std_stream.pony
@@ -30,6 +30,11 @@ interface tag OutStream
     Write an iterable collection of ByteSeqs.
     """
 
+  be flush()
+    """
+    Flush the stream.
+    """
+
 actor StdStream
   """
   Asynchronous access to stdout and stderr. The constructors are private to
@@ -76,6 +81,12 @@ actor StdStream
     for bytes in data.values() do
       _write(bytes)
     end
+
+  be flush() =>
+    """
+    Flush any data out to the os (ignoring failures).
+    """
+    @pony_os_std_flush[None](_stream)
 
   fun ref _write(data: ByteSeq) =>
     """

--- a/packages/files/file_stream.pony
+++ b/packages/files/file_stream.pony
@@ -31,3 +31,9 @@ actor FileStream is OutStream
     Write an iterable collection of ByteSeqs.
     """
     _file.writev(data)
+
+  be flush() =>
+    """
+    Flush pending data to write.
+    """
+    _file.flush()

--- a/packages/logger/_test.pony
+++ b/packages/logger/_test.pony
@@ -119,6 +119,8 @@ actor _TestStream is OutStream
       _collect(bytes)
     end
 
+  be flush() => None
+
   fun ref _collect(data: ByteSeq) =>
     _output.append(data)
 

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -755,6 +755,21 @@ PONY_API void pony_os_std_write(FILE* fp, char* buffer, size_t len)
 #endif
 }
 
+PONY_API void pony_os_std_flush(FILE* fp)
+{
+  // avoid flushing all streams
+  if(fp == NULL)
+    return;
+
+#ifdef PLATFORM_IS_WINDOWS
+  _fflush_nolock(fp);
+#elif defined PLATFORM_IS_LINUX
+  fflush_unlocked(fp);
+#else
+  fflush(fp);
+#endif
+}
+
 #ifdef PLATFORM_IS_WINDOWS
 // Unsurprisingly Windows uses a different order for colors. Map them here.
 // We use the bright versions here, hence the additional 8 on each value.

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -546,7 +546,7 @@ PONY_API void pony_os_std_write(FILE* fp, char* buffer, size_t len)
       if(pos > last)
       {
         // Write any pending data.
-        fwrite(&buffer[last], pos - last, 1, fp);
+        _fwrite_nolock(&buffer[last], pos - last, 1, fp);
         last = pos;
       }
 


### PR DESCRIPTION
This was missing for stdout and stderr and was mostly causing issues on windows.

Fixes #3095