### PR TITLE
Fix cycle detector issue with checking for blocked actors

### DIFF
--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -559,7 +559,9 @@ static void check_blocked(pony_ctx_t* ctx, detector_t* d)
       pony_send(ctx, view->actor, ACTORMSG_ISBLOCKED);
     }
 
-    // if we've hit the max limit for # of actors to check
+    // Stop if we've hit the max limit for # of actors to check
+    // (either the CD_MAX_CHECK_BLOCKED constant, or 10% of the total number
+    // of actors, whichever limit is larger)
     n++;
     if(n > (total/10 > CD_MAX_CHECK_BLOCKED ? total/10 : CD_MAX_CHECK_BLOCKED))
       break;

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -546,6 +546,8 @@ static void collect(pony_ctx_t* ctx, detector_t* d, perceived_t* per)
 static void check_blocked(pony_ctx_t* ctx, detector_t* d)
 {
   size_t i = d->last_checked;
+  size_t total = ponyint_viewmap_size(&d->views);
+  size_t n = 0;
   view_t* view;
 
   while((view = ponyint_viewmap_next(&d->views, &i)) != NULL)
@@ -558,7 +560,8 @@ static void check_blocked(pony_ctx_t* ctx, detector_t* d)
     }
 
     // if we've hit the max limit for # of actors to check
-    if(i > CD_MAX_CHECK_BLOCKED)
+    n++;
+    if(n > (total/10 > CD_MAX_CHECK_BLOCKED ? total/10 : CD_MAX_CHECK_BLOCKED))
       break;
   }
 

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -765,8 +765,8 @@ TEST_F(CodegenTest, CycleDetector)
 
 
     "actor Main\n"
-    "  var _ring_size: U32 = 5\n"
-    "  var _ring_count: U32 = 2\n"
+    "  var _ring_size: U32 = 100\n"
+    "  var _ring_count: U32 = 100\n"
     "  var _pass: USize = 10\n"
 
     "  new create(env: Env) =>\n"


### PR DESCRIPTION
As part of PR #2800, I broke the cycle detector due to incorrect
incremental logic for querying actors for if they're blocked. I
relied on the hashmap internal array/bucket index value instead
of keeping tracking of # of actors queried for if they're blocked
during the current function call.

This commit resolves the logic issue described above by keeping
a running count of actors queried during the current function
call.

This commit also implements @plprofetes suggestion to make the
threshold for # of actors to query for if they're blocked into
a dynamic value. Specifically, the threshold is now the larger
of the `CD_MAX_CHECK_BLOCKED` constant (which is 1000) or 10%
of the total number of actors currently known to exist by the
cycle detector.

Resolves #2975.