### PR TITLE
Allow use of OpenSSL 1.1.1 when building Pony

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,8 +113,8 @@ jobs:
         user: pony
     steps:
       - checkout
-      - run: make all default_ssl=openssl_1.1.0 default_pic=true -j3
-      - run: make test-ci default_ssl=openssl_1.1.0 default_pic=true
+      - run: make all default_ssl=openssl_1.1.x default_pic=true -j3
+      - run: make test-ci default_ssl=openssl_1.1.x default_pic=true
 
   alpine-llvm-5-debug:
     docker:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,8 @@ task:
     - pkg install -y gmake pcre2 libunwind llvm70 git
 
   test_script:
-    - LLVM_CONFIG=llvm-config70 gmake all config=release -j3 default_ssl=openssl_1.1.0
-    - LLVM_CONFIG=llvm-config70 gmake test-ci config=release default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake all config=release -j3 default_ssl=openssl_1.1.x
+    - LLVM_CONFIG=llvm-config70 gmake test-ci config=release default_ssl=openssl_1.1.x
 
 task:
   freebsd_instance:
@@ -26,8 +26,8 @@ task:
     - pkg install -y gmake pcre2 libunwind llvm70 git
 
   test_script:
-    - LLVM_CONFIG=llvm-config70 gmake all config=debug -j3 default_ssl=openssl_1.1.0
-    - LLVM_CONFIG=llvm-config70 gmake test-ci config=debug default_ssl=openssl_1.1.0
+    - LLVM_CONFIG=llvm-config70 gmake all config=debug -j3 default_ssl=openssl_1.1.x
+    - LLVM_CONFIG=llvm-config70 gmake test-ci config=debug default_ssl=openssl_1.1.x
 
 task:
   osx_instance:

--- a/.packaging/deb/rules
+++ b/.packaging/deb/rules
@@ -35,7 +35,7 @@ ifeq ($(DEB_HOST_ARCH),armhf)
 endif
 
 ifeq (,$(filter $(DEB_DISTRIBUTION),xenial))
-	MAKE_OPTIONS += default_ssl='openssl_1.1.0' default_pic=true
+	MAKE_OPTIONS += default_ssl='openssl_1.1.x' default_pic=true
 endif
 
 

--- a/.packaging/rpm/ponyc.spec
+++ b/.packaging/rpm/ponyc.spec
@@ -10,9 +10,9 @@
 %global extra_build_args use="llvm_link_static" LLVM_CONFIG=/usr/lib64/llvm3.9/bin/llvm-config
 %else
 %if %{?_vendor} == suse
-%global extra_build_args default_ssl='openssl_1.1.0'
+%global extra_build_args default_ssl='openssl_1.1.x'
 %else
-%global extra_build_args default_ssl='openssl_1.1.0' LLVM_CONFIG=/usr/lib64/llvm3.9/bin/llvm-config
+%global extra_build_args default_ssl='openssl_1.1.x' LLVM_CONFIG=/usr/lib64/llvm3.9/bin/llvm-config
 %endif
 %endif
 

--- a/Makefile-lib-llvm
+++ b/Makefile-lib-llvm
@@ -53,7 +53,7 @@ rebuild-test: clean
 #
 # For example:
 #  $ time CC=clang CXX=clang++ make -j10 -f Makefile-lib-llvm \
-#  verbose=1 config=debug default_pic=true default_ssl=openssl_1.1.0 llvm_target=llvm-current rebuild-some-tests \
+#  verbose=1 config=debug default_pic=true default_ssl=openssl_1.1.x llvm_target=llvm-current rebuild-some-tests \
 #  gtest_filter=--gtest_filter=CodegenOptimisationTest.MergeSendMessageReordering 2>&1 | tee clang-rebuild-some-tests.txt
 .PHONY: rebuild-some-tests
 rebuild-some-tests: clean
@@ -100,7 +100,7 @@ help:
 	@echo '  default_ssl=Name     Make Name the default ssl version'
 	@echo '                       where Name is one of:'
 	@echo '                         openssl_0.9.0'
-	@echo '                         openssl_1.1.0'
+	@echo '                         openssl_1.1.x'
 	@echo '  llvm_target=Target   Make llvm where Target is one of:'
 	@echo '                         all (default if not specified)'
 	@echo '                         rebuild'

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -383,19 +383,20 @@ ifeq ($(runtime-bitcode),yes)
 endif
 
 # Set default ssl version
+valid_ssl_versions=openssl_0.9.0 openssl_1.1.0 openssl_1.1.1 openssl_1.1.x
 ifdef default_ssl
-  ifeq ("openssl_0.9.0","$(default_ssl)")
-    default_ssl_valid:=ok
-  endif
-  ifeq ("openssl_1.1.0","$(default_ssl)")
-    default_ssl_valid:=ok
-  endif
-  ifeq (ok,$(default_ssl_valid))
-    $(warning default_ssl is $(default_ssl))
+  ifeq ($(filter-out $(valid_ssl_versions),$(default_ssl)),)
+    # both openssl_1.1.0 and openssl_1.1.1 are translated to openssl_1.1.x
+    ifneq (,$(findstring openssl_1.1.,$(default_ssl)))
+      pony_default_ssl:=openssl_1.1.x
+    else
+      pony_default_ssl:=$(default_ssl)
+    endif
+    $(info pony_default_ssl is $(pony_default_ssl))
   else
-    $(error default_ssl=$(default_ssl) is invalid, expecting one of openssl_0.9.0 or openssl_1.1.0)
+    $(error default_ssl=$(default_ssl) is invalid (valid values: $(valid_ssl_versions)))
   endif
-  BUILD_FLAGS += -DPONY_DEFAULT_SSL=\"$(default_ssl)\"
+  BUILD_FLAGS += -DPONY_DEFAULT_SSL=\"$(pony_default_ssl)\"
 endif
 
 makefile_abs_path := $(realpath $(lastword $(MAKEFILE_LIST)))
@@ -1112,7 +1113,7 @@ help:
 	@echo '  default_ssl=Name     Make Name the default ssl version'
 	@echo '                       where Name is one of:'
 	@echo '                         openssl_0.9.0'
-	@echo '                         openssl_1.1.0'
+	@echo '                         openssl_1.1.x'
 	@echo
 	@echo 'USE OPTIONS:'
 	@echo '   valgrind'

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ cd ../../../
 #### Debug/test ....
 Now build and test using `LLVM_CFG=llvm-default.cfg` and any other appropriate parameters:
 ```
-make -j12 LLVM_CFG=llvm-default.cfg default_pic=true default_ssl=openssl_1.1.0 -f Makefile-lib-llvm
+make -j12 LLVM_CFG=llvm-default.cfg default_pic=true default_ssl=openssl_1.1.x -f Makefile-lib-llvm
 ```
 When satisfied create a commit pushing to your repo:
 ```
@@ -390,7 +390,7 @@ To build ponyc and compile and run helloworld:
 
 ```bash
 cd ~/ponyc/
-make default_pic=true default_ssl=openssl_1.1.0
+make default_pic=true default_ssl=openssl_1.1.x
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```
@@ -469,7 +469,7 @@ Build ponyc, compile and run helloworld:
 
 ```bash
 cd ~/ponyc/
-make default_pic=true default_ssl=openssl_1.1.0
+make default_pic=true default_ssl=openssl_1.1.x
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```
@@ -513,7 +513,7 @@ To build ponyc, compile and run helloworld:
 
 ```bash
 cd ~/ponyc/
-make default_ssl='openssl_1.1.0'
+make default_ssl='openssl_1.1.x'
 ./build/release/ponyc examples/helloworld
 ./helloworld
 ```

--- a/packages/crypto/digest.pony
+++ b/packages/crypto/digest.pony
@@ -18,7 +18,7 @@ class Digest
     Use the MD5 algorithm to calculate the hash.
     """
     _digest_size = 16
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -30,7 +30,7 @@ class Digest
     Use the RIPEMD160 algorithm to calculate the hash.
     """
     _digest_size = 20
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -42,7 +42,7 @@ class Digest
     Use the SHA1 algorithm to calculate the hash.
     """
     _digest_size = 20
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -54,7 +54,7 @@ class Digest
     Use the SHA256 algorithm to calculate the hash.
     """
     _digest_size = 28
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -66,7 +66,7 @@ class Digest
     Use the SHA256 algorithm to calculate the hash.
     """
     _digest_size = 32
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -78,7 +78,7 @@ class Digest
     Use the SHA384 algorithm to calculate the hash.
     """
     _digest_size = 48
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -90,7 +90,7 @@ class Digest
     Use the SHA512 algorithm to calculate the hash.
     """
     _digest_size = 64
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @EVP_MD_CTX_new[Pointer[_EVPCTX]]()
     else
       _ctx = @EVP_MD_CTX_create[Pointer[_EVPCTX]]()
@@ -118,7 +118,7 @@ class Digest
           @pony_alloc[Pointer[U8]](@pony_ctx[Pointer[None] iso](), size), size)
         end
       @EVP_DigestFinal_ex[None](_ctx, digest.cpointer(), Pointer[USize])
-      ifdef "openssl_1.1.0" then
+      ifdef "openssl_1.1.x" then
         @EVP_MD_CTX_free[None](_ctx)
       else
         @EVP_MD_CTX_cleanup[None](_ctx)

--- a/packages/net/ssl/_ssl_init.pony
+++ b/packages/net/ssl/_ssl_init.pony
@@ -19,7 +19,7 @@ primitive _SSLInit
   This initialises SSL when the program begins.
   """
   fun _init() =>
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       let settings = @OPENSSL_INIT_new()
       @OPENSSL_init_ssl(_OpenSslInitLoadSslStrings.apply()
           + _OpenSslInitLoadCryptoStrings.apply(), settings)

--- a/packages/net/ssl/ssl.pony
+++ b/packages/net/ssl/ssl.pony
@@ -77,7 +77,7 @@ class SSL
     """
     var ptr: Pointer[U8] iso = recover Pointer[U8] end
     var len = U32(0)
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       @SSL_get0_alpn_selected[None](_ssl, addressof ptr, addressof len)
     end
 

--- a/packages/net/ssl/ssl_context.pony
+++ b/packages/net/ssl/ssl_context.pony
@@ -55,7 +55,7 @@ class val SSLContext
     """
     Create an SSL context.
     """
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       _ctx = @SSL_CTX_new(@TLS_method())
 
       // Allow only newer ciphers.
@@ -74,14 +74,14 @@ class val SSLContext
     end
 
   fun _set_options(opts: ULong) =>
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       @SSL_CTX_set_options(_ctx, opts)
     else
       @SSL_CTX_ctrl(_ctx, _SslCtrlSetOptions.apply(), opts, Pointer[None])
     end
 
   fun _clear_options(opts: ULong) =>
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       @SSL_CTX_clear_options(_ctx, opts)
     else
       @SSL_CTX_ctrl(_ctx, _SslCtrlClearOptions.apply(), opts, Pointer[None])
@@ -238,7 +238,7 @@ class val SSLContext
     Returns true on success
     Requires OpenSSL >= 1.0.2
     """
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       @SSL_CTX_set_alpn_select_cb[None](_ctx, addressof SSLContext._alpn_select_cb, resolver)
       return true
     end
@@ -253,7 +253,7 @@ class val SSLContext
     Returns true on success
     Requires OpenSSL >= 1.0.2
     """
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       try
         let proto_list = _ALPNProtocolList.from_array(protocols)?
         let result = @SSL_CTX_set_alpn_protos[I32](_ctx, proto_list.cpointer(), proto_list.size())

--- a/packages/net/ssl/x509.pony
+++ b/packages/net/ssl/x509.pony
@@ -70,7 +70,7 @@ primitive X509
     end
 
     var name =
-      ifdef "openssl_1.1.0" then
+      ifdef "openssl_1.1.x" then
         @OPENSSL_sk_pop[Pointer[_GeneralName]](stack)
       else
         @sk_pop[Pointer[_GeneralName]](stack)
@@ -114,14 +114,14 @@ primitive X509
       end
 
       @GENERAL_NAME_free[None](name)
-      ifdef "openssl_1.1.0" then
+      ifdef "openssl_1.1.x" then
         name = @OPENSSL_sk_pop[Pointer[_GeneralName]](stack)
       else
         name = @sk_pop[Pointer[_GeneralName]](stack)
       end
     end
 
-    ifdef "openssl_1.1.0" then
+    ifdef "openssl_1.1.x" then
       @OPENSSL_sk_free[None](stack)
     else
       @sk_free[None](stack)

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -167,7 +167,7 @@ static void usage(void)
     "  --plugin         Use the specified plugin(s).\n"
     "    =name\n"
     "  --define, -D     Define which openssl version to use.\n"
-    "    =openssl_1.1.0 Default is " PONY_DEFAULT_SSL ".\n"
+    "    =openssl_1.1.x Default is " PONY_DEFAULT_SSL ".\n"
     "    =openssl_0.9.0\n"
     ,
     "Debugging options:\n"


### PR DESCRIPTION
This introduces an array of valid versions, and only errors out if the
passed default_ssl version is not among them.

Unfortunately, the list of valid default_ssl version in the help output
does not use that variable.

Also switches the default_ssl debug output to "info" (was "error").

Fixes #3150, I hope.