### PR TITLE
Update build for OpenBSD 6.5

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -35,6 +35,8 @@ else
   ifeq ($(UNAME_S),OpenBSD)
     OSTYPE = bsd
     CXX = c++
+    LLVM_CONFIG = /usr/local/bin/llvm-config
+    default_pic = true
   endif
 endif
 

--- a/README.md
+++ b/README.md
@@ -708,7 +708,7 @@ gmake
 
 ## Building on OpenBSD
 
-OpenBSD has been tested on OpenBSD 6.4.
+OpenBSD has been tested on OpenBSD 6.5.
 
 First, install the required dependencies:
 
@@ -719,7 +719,7 @@ doas pkg_add gmake libexecinfo llvm pcre2
 This will build ponyc and compile helloworld:
 
 ```bash
-gmake verbose=true default_pic=true bits=64
+gmake verbose=true bits=64
 ./build/release/ponyc examples/helloworld
 ```
 


### PR DESCRIPTION
OpenBSD 6.5 has /usr/bin/llvm-config as part of the base install, but
base doesn't include /usr/bin/llc, so the llvm port is still required.
The port installs /usr/local/bin/llvm-config, so the Makefile can end
up using the wrong llvm-config which means it can't find llc.

Pointing LLVM_CONFIG at the port's path fixed the build for me.  I
think this gives the right behavior for anyone on OpenBSD.