### PR TITLE
Fix race condition for last_cd_tsc initialization

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -821,7 +821,9 @@ static pony_actor_t* steal(scheduler_t* sched)
  */
 static void run(scheduler_t* sched)
 {
-  last_cd_tsc = 0;
+  if(sched->index == 0)
+    last_cd_tsc = 0;
+
   pony_actor_t* actor = pop_global(sched);
   if (DTRACE_ENABLED(ACTOR_SCHEDULED) && actor != NULL) {
     DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)actor);


### PR DESCRIPTION
The thread sanitizer identified the initialization of last_cd_tsc
to 0 as a race condition because every thread would set the value
to 0 on start. This commit changes things so the initialization is
done once as variable declaration time to avoid this race.