### PR TITLE
Fix memory leaks identified by address sanitizer

### DIFF
--- a/packages/net/ssl/_ssl_init.pony
+++ b/packages/net/ssl/_ssl_init.pony
@@ -4,6 +4,7 @@ use "lib:crypto"
 
 use @OPENSSL_init_ssl[I32](opts: U64, settings: Pointer[_OpenSslInitSettings])
 use @OPENSSL_INIT_new[Pointer[_OpenSslInitSettings]]()
+use @OPENSSL_INIT_free[None](settings: Pointer[_OpenSslInitSettings])
 
 primitive _OpenSslInitSettings
 
@@ -22,6 +23,7 @@ primitive _SSLInit
       let settings = @OPENSSL_INIT_new()
       @OPENSSL_init_ssl(_OpenSslInitLoadSslStrings.apply()
           + _OpenSslInitLoadCryptoStrings.apply(), settings)
+      @OPENSSL_INIT_free(settings)
     else
       @SSL_load_error_strings[None]()
       @SSL_library_init[I32]()

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1322,13 +1322,13 @@ static void optimise(compile_t* c, bool pony_specific)
   llvm::legacy::PassManager mpm;
   llvm::legacy::FunctionPassManager fpm(m);
 
-  TargetLibraryInfoImpl* tl = new TargetLibraryInfoImpl(
+  TargetLibraryInfoImpl tl = TargetLibraryInfoImpl(
     Triple(m->getTargetTriple()));
 
   lpm.add(createTargetTransformInfoWrapperPass(
     machine->getTargetIRAnalysis()));
 
-  mpm.add(new TargetLibraryInfoWrapperPass(*tl));
+  mpm.add(new TargetLibraryInfoWrapperPass(tl));
   mpm.add(createTargetTransformInfoWrapperPass(
     machine->getTargetIRAnalysis()));
 


### PR DESCRIPTION
The address sanitizer identified a couple of minor memory leaks,
one in the compiler optimise function in genopt and another in
the ssl initialization code in the stdlib. This commit resolves
both memory leaks.