### PR TITLE
Fix undefined behavior for bit shifts in heap logic

### DIFF
--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -91,7 +91,7 @@ static void final_small(chunk_t* chunk, uint32_t mark)
     (*(pony_type_t**)p)->final(p);
 
     // clear finaliser in chunk
-    chunk->finalisers &= ~(1 << bit);
+    chunk->finalisers &= ~((uint32_t)1 << bit);
 
     // clear bit just found in our local finaliser map
     finalisers &= (finalisers - 1);
@@ -373,13 +373,13 @@ void* ponyint_heap_alloc_small_final(pony_actor_t* actor, heap_t* heap,
     // Clear and use the first available slot.
     uint32_t slots = chunk->slots;
     uint32_t bit = __pony_ctz(slots);
-    slots &= ~(1 << bit);
+    slots &= ~((uint32_t)1 << bit);
 
     m = chunk->m + (bit << HEAP_MINBITS);
     chunk->slots = slots;
 
     // note that a finaliser needs to run
-    chunk->finalisers |= (1 << bit);
+    chunk->finalisers |= ((uint32_t)1 << bit);
 
     if(slots == 0)
     {


### PR DESCRIPTION
The undefined behavior sanitizer identified the left shifting of
the constant 1 by 31 to be undefined behavior due to the type
being `int` by default. This commit avoids the undefined behavior
by explicitly casting the constant 1 to uint32_t.