### PR TITLE
Fix stack-use-after-scope in compiler test

### DIFF
--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -864,7 +864,7 @@ void package_add_magic_path(const char* path, const char* mapped_path,
   magic_package_t* n = POOL_ALLOC(magic_package_t);
   n->path = stringtab(path);
   n->src = NULL;
-  n->mapped_path = mapped_path;
+  n->mapped_path = stringtab(mapped_path);
   n->next = opt->magic_packages;
   opt->magic_packages = n;
 }


### PR DESCRIPTION
The address sanitizer identified a stack-use-after-scope error in
a function used for tests. This commit fixes this error by ensuring
the path passed to the package_add_magic_path function is properly
copied.