### PR TITLE
Enable shuffling of tests that use the gtest framework

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -975,8 +975,8 @@ test-stdlib: stdlib
 	$(SILENT)rm stdlib
 
 test-core: all
-	$(SILENT)$(PONY_BUILD_DIR)/libponyc.tests
-	$(SILENT)$(PONY_BUILD_DIR)/libponyrt.tests
+	$(SILENT)$(PONY_BUILD_DIR)/libponyc.tests --gtest_shuffle
+	$(SILENT)$(PONY_BUILD_DIR)/libponyrt.tests --gtest_shuffle
 
 test: test-core test-stdlib test-examples
 

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -643,3 +643,13 @@ bool is_build_flag_defined(const char* name)
 
   return f2 != NULL;
 }
+
+void clear_build_flags()
+{
+  if(_user_flags != NULL)
+  {
+    flagtab_destroy(_user_flags);
+    POOL_FREE(flagtab_t, _user_flags);
+    _user_flags = NULL;
+  }
+}

--- a/src/libponyc/pkg/buildflagset.h
+++ b/src/libponyc/pkg/buildflagset.h
@@ -90,6 +90,9 @@ bool is_build_flag_defined(const char* name);
 // Returns: true if one or more of the flags were removed
 bool remove_build_flags(const char* flags[]);
 
+// Remove all flags.
+void clear_build_flags();
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -219,6 +219,7 @@ PONY_API void pony_serialise(pony_ctx_t* ctx, void* p, pony_type_t* t,
   out->size = ctx->serialise_size;
   out->alloc = out->size;
   out->ptr = (char*)alloc_fn(ctx, out->size);
+  memset(out->ptr, 0, out->size);
 
   size_t i = HASHMAP_BEGIN;
   serialise_t* s;

--- a/test/libponyc/buildflagset.cc
+++ b/test/libponyc/buildflagset.cc
@@ -158,12 +158,14 @@ TEST(BuildFlagSetTest, MultipleFlags)
 
 TEST(BuildFlagSetTest, UserFlagNoneDefined)
 {
+  clear_build_flags();
   ASSERT_FALSE(is_build_flag_defined("foo"));
 }
 
 
 TEST(BuildFlagSetTest, UserFlagDefined)
 {
+  clear_build_flags();
   define_build_flag("foo");
 
   ASSERT_TRUE(is_build_flag_defined("foo"));
@@ -172,6 +174,7 @@ TEST(BuildFlagSetTest, UserFlagDefined)
 
 TEST(BuildFlagSetTest, UserFlagNotDefined)
 {
+  clear_build_flags();
   define_build_flag("foo");
 
   ASSERT_TRUE(is_build_flag_defined("foo"));
@@ -181,6 +184,7 @@ TEST(BuildFlagSetTest, UserFlagNotDefined)
 
 TEST(BuildFlagSetTest, UserFlagCaseSensitive)
 {
+  clear_build_flags();
   define_build_flag("foo");
 
   ASSERT_TRUE(is_build_flag_defined("foo"));
@@ -190,6 +194,7 @@ TEST(BuildFlagSetTest, UserFlagCaseSensitive)
 
 TEST(BuildFlagSetTest, UserFlagMultiple)
 {
+  clear_build_flags();
   define_build_flag("foo");
   define_build_flag("BAR");
   define_build_flag("Wombat");

--- a/wscript
+++ b/wscript
@@ -436,14 +436,14 @@ def test(ctx):
 
         total = total + 1
         testc = os.path.join(buildDir, 'libponyc.tests')
-        returncode = subprocess.call([ testc ])
+        returncode = subprocess.call([ testc, '--gtest_shuffle' ])
         if returncode == 0:
             passed = passed + 1
 
         total = total + 1
         testrt = os.path.join(buildDir, 'libponyrt.tests')
         print(testrt)
-        returncode = subprocess.call([ testrt ])
+        returncode = subprocess.call([ testrt, '--gtest_shuffle' ])
         if returncode == 0:
             passed = passed + 1
 


### PR DESCRIPTION
As indicated in the google test advanced documentation
(https://github.com/google/googletest/blob/master/googletest/docs/advanced.md#shuffling-the-tests),
shuffling tests can help identify bad dependencies between tests.