### PR TITLE
Do not permit leading zeros in JSON numbers

### DIFF
--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -80,6 +80,9 @@ class iso _TestParseNumber is UnitTest
     doc.parse("0")?
     h.assert_eq[I64](0, doc.data as I64)
 
+    doc.parse("-0")?
+    h.assert_eq[I64](0, doc.data as I64)
+
     doc.parse("13")?
     h.assert_eq[I64](13, doc.data as I64)
 
@@ -109,6 +112,11 @@ class iso _TestParseNumber is UnitTest
     h.assert_error({() ? => JsonDoc.parse("1.")? })
     h.assert_error({() ? => JsonDoc.parse("1.-3")? })
     h.assert_error({() ? => JsonDoc.parse("1e")? })
+
+    // RFC 8259 does not permit leading zeros
+    h.assert_error({() ? => JsonDoc.parse("01")? })
+    h.assert_error({() ? => JsonDoc.parse("-01")? })
+    h.assert_error({() ? => JsonDoc.parse("-012")? })
 
 class iso _TestParseString is UnitTest
   """

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -116,13 +116,20 @@ class JsonDoc
       _get_char()? // Consume -
     end
 
+    let leading_zero = _peek_char()? == '0'
+
     var frac: I64 = 0
     var frac_digits: U8 = 0
     var exp: I64 = 0
     var exp_digits: U8 = 0
 
     // Start with integer part
-    (let int, _) = _parse_decimal()?
+    (let int, let int_digits) = _parse_decimal()?
+
+    if (int_digits > 1) and (leading_zero == true) then
+      _error("Leading 0 not permitted")
+      error
+    end
 
     if _peek_char()? == '.' then
       // We have a . so expect a fractional part


### PR DESCRIPTION
Fixes #3097

I am very new to pony, so entirely possible I've done something obviously wrong here, or mucked up some style stuff.

Played around with a couple different implementations, including passing a flag to `_parse_decimal` to indicate whether it should check for leading zeros (*not* in the case of exp/frac), but this approach seemed clearer.