### PR TITLE
Allow use of runtime TCP connect without ASIO one shot

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -239,9 +239,15 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
+    let asio_flags =
+      ifdef not windows then
+        AsioEvent.read_write_oneshot()
+      else
+        AsioEvent.read_write()
+      end
     _connect_count =
       @pony_os_connect_tcp[U32](this, host.cstring(), service.cstring(),
-        from.cstring())
+        from.cstring(), asio_flags)
     _notify_connecting()
 
   new ip4(
@@ -260,9 +266,15 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
+    let asio_flags =
+      ifdef not windows then
+        AsioEvent.read_write_oneshot()
+      else
+        AsioEvent.read_write()
+      end
     _connect_count =
       @pony_os_connect_tcp4[U32](this, host.cstring(), service.cstring(),
-        from.cstring())
+        from.cstring(), asio_flags)
     _notify_connecting()
 
   new ip6(
@@ -281,9 +293,15 @@ actor TCPConnection
     _next_size = init_size
     _max_size = max_size
     _notify = consume notify
+    let asio_flags =
+      ifdef not windows then
+        AsioEvent.read_write_oneshot()
+      else
+        AsioEvent.read_write()
+      end
     _connect_count =
       @pony_os_connect_tcp6[U32](this, host.cstring(), service.cstring(),
-        from.cstring())
+        from.cstring(), asio_flags)
     _notify_connecting()
 
   new _accept(

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -552,7 +552,7 @@ static asio_event_t* os_listen(pony_actor_t* owner, int fd,
 }
 
 static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
-  const char* from)
+  const char* from, uint32_t asio_flags)
 {
   map_any_to_loopback(p->ai_addr);
 
@@ -600,8 +600,7 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
   }
 
   // Create an event and subscribe it.
-  asio_event_t* ev = pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE,
-    0, true);
+  asio_event_t* ev = pony_asio_event_create(owner, fd, asio_flags, 0, true);
 
   if(!iocp_connect(ev, p))
   {
@@ -619,8 +618,7 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
   }
 
   // Create an event and subscribe it.
-  pony_asio_event_create(owner, fd, ASIO_READ | ASIO_WRITE | ASIO_ONESHOT, 0,
-    true);
+  pony_asio_event_create(owner, fd, asio_flags, 0, true);
 #endif
 
   return true;
@@ -661,7 +659,8 @@ static asio_event_t* os_socket_listen(pony_actor_t* owner, const char* host,
  * in-flight, which may be 0.
  */
 static int os_socket_connect(pony_actor_t* owner, const char* host,
-  const char* service, const char* from, int family, int socktype, int proto)
+  const char* service, const char* from, int family, int socktype, int proto,
+  uint32_t asio_flags)
 {
   bool reuse = (from == NULL) || (from[0] != '\0');
 
@@ -677,7 +676,7 @@ static int os_socket_connect(pony_actor_t* owner, const char* host,
 
     if(fd != -1)
     {
-      if(os_connect(owner, fd, p, from))
+      if(os_connect(owner, fd, p, from, asio_flags))
         count++;
     }
 
@@ -731,24 +730,24 @@ PONY_API asio_event_t* pony_os_listen_udp6(pony_actor_t* owner,
 }
 
 PONY_API int pony_os_connect_tcp(pony_actor_t* owner, const char* host,
-  const char* service, const char* from)
+  const char* service, const char* from, uint32_t asio_flags)
 {
   return os_socket_connect(owner, host, service, from, AF_UNSPEC, SOCK_STREAM,
-    IPPROTO_TCP);
+    IPPROTO_TCP, asio_flags);
 }
 
 PONY_API int pony_os_connect_tcp4(pony_actor_t* owner, const char* host,
-  const char* service, const char* from)
+  const char* service, const char* from, uint32_t asio_flags)
 {
   return os_socket_connect(owner, host, service, from, AF_INET, SOCK_STREAM,
-    IPPROTO_TCP);
+    IPPROTO_TCP, asio_flags);
 }
 
 PONY_API int pony_os_connect_tcp6(pony_actor_t* owner, const char* host,
-  const char* service, const char* from)
+  const char* service, const char* from, uint32_t asio_flags)
 {
   return os_socket_connect(owner, host, service, from, AF_INET6, SOCK_STREAM,
-    IPPROTO_TCP);
+    IPPROTO_TCP, asio_flags);
 }
 
 PONY_API int pony_os_accept(asio_event_t* ev)


### PR DESCRIPTION
Prior to this commit, the usage of ASIO_ONESHOT was coded into every
outgoing connection created by the runtime. This is a little odd when we
consider that incoming connection can pick their asio flags to use in
_accept.

With the change, selecting asio flags for read/write/one shot is mostly
in the control of the Pony level tcp library. Listeners still start as
non-one shot and read only. It would be reasonable to allow listeners to
select one shot or not, however, at this time, there isn't a need.

Whereas, there is a need for allowing this change. Currently, my Lori
library doesn't work because it doesn't yet support one shot. It worked
with many Pony versions until we fixed a bug where one shot was being
turned off in the runtime after the first event.

Exposing this bug in Lori lead me to check out how we are handling Asio
setup in the runtime. Based on that, the Lori work, and my slow movement
towards allowing TCP and Asio runtimes other than the ones built into
our runtime, I believe this is an important change and a step towards
being about to use non-kernel defined TCP networking with Pony.