### PR TITLE
Minor muting/overload related cleanups and bug fixes

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -15,6 +15,9 @@
 #include <valgrind/helgrind.h>
 #endif
 
+// default actor batch size
+#define PONY_ACTOR_DEFAULT_BATCH 100
+
 // Ignore padding at the end of the type.
 pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
    sizeof(pony_actor_pad_t), "Wrong actor pad size!");
@@ -230,10 +233,55 @@ static void try_gc(pony_ctx_t* ctx, pony_actor_t* actor)
   DTRACE1(GC_END, (uintptr_t)ctx->scheduler);
 }
 
-bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
+// return true if mute occurs
+static bool maybe_mute(pony_actor_t* actor)
+{
+  // if we become muted as a result of handling a message, bail out now.
+  // we aren't set to "muted" at this point. setting to muted during a
+  // a behavior can lead to race conditions that might result in a
+  // deadlock.
+  // Given that actor's are not run when they are muted, then when we
+  // started out batch, actor->muted would have been 0. If any of our
+  // message sends would result in the actor being muted, that value will
+  // have changed to greater than 0.
+  //
+  // We will then set the actor to "muted". Once set, any actor sending
+  // a message to it will be also be muted unless said sender is marked
+  // as overloaded.
+  //
+  // The key points here is that:
+  //   1. We can't set the actor to "muted" until after its finished running
+  //   a behavior.
+  //   2. We should bail out from running the actor and return false so that
+  //   it won't be rescheduled.
+  if(atomic_load_explicit(&actor->muted, memory_order_relaxed) > 0)
+  {
+    ponyint_mute_actor(actor);
+    return true;
+  }
+
+  return false;
+}
+
+static bool batch_limit_reached(pony_actor_t* actor, bool polling)
+{
+  if(!has_flag(actor, FLAG_OVERLOADED) && !polling)
+  {
+    // If we hit our batch size, consider this actor to be overloaded
+    // only if we're not polling from C code.
+    // Overloaded actors are allowed to send to other overloaded actors
+    // and to muted actors without being muted themselves.
+    ponyint_actor_setoverloaded(actor);
+  }
+
+  return !has_flag(actor, FLAG_UNSCHEDULED);
+}
+
+bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
   pony_assert(!ponyint_is_muted(actor));
   ctx->current = actor;
+  size_t batch = PONY_ACTOR_DEFAULT_BATCH;
 
   pony_msg_t* msg;
   size_t app = 0;
@@ -253,8 +301,14 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
       app++;
       try_gc(ctx, actor);
 
-      if(app == batch)
-        return !has_flag(actor, FLAG_UNSCHEDULED);
+      // maybe mute actor
+      if(maybe_mute(actor))
+        return false;
+
+      // if we've reached our batch limit
+      // or if we're polling where we want to stop after one app message
+      if(app == batch || polling)
+        return batch_limit_reached(actor, polling);
     }
   }
 #endif
@@ -274,42 +328,14 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch)
       app++;
       try_gc(ctx, actor);
 
-      // if we become muted as a result of handling a message, bail out now.
-      // we aren't set to "muted" at this point. setting to muted during a
-      // a behavior can lead to race conditions that might result in a
-      // deadlock.
-      // Given that actor's are not run when they are muted, then when we
-      // started out batch, actor->muted would have been 0. If any of our
-      // message sends would result in the actor being muted, that value will
-      // have changed to greater than 0.
-      //
-      // We will then set the actor to "muted". Once set, any actor sending
-      // a message to it will be also be muted unless said sender is marked
-      // as overloaded.
-      //
-      // The key points here is that:
-      //   1. We can't set the actor to "muted" until after its finished running
-      //   a behavior.
-      //   2. We should bail out from running the actor and return false so that
-      //   it won't be rescheduled.
-      if(atomic_load_explicit(&actor->muted, memory_order_relaxed) > 0)
-      {
-        ponyint_mute_actor(actor);
+      // maybe mute actor; returns true if mute occurs
+      if(maybe_mute(actor))
         return false;
-      }
 
-      if(app == batch)
-      {
-        if(!has_flag(actor, FLAG_OVERLOADED))
-        {
-          // If we hit our batch size, consider this actor to be overloaded.
-          // Overloaded actors are allowed to send to other overloaded actors
-          // and to muted actors without being muted themselves.
-          ponyint_actor_setoverloaded(actor);
-        }
-
-        return !has_flag(actor, FLAG_UNSCHEDULED);
-      }
+      // if we've reached our batch limit
+      // or if we're polling where we want to stop after one app message
+      if(app == batch || polling)
+        return batch_limit_reached(actor, polling);
     }
 
     // Stop handling a batch if we reach the head we found when we were
@@ -757,8 +783,10 @@ PONY_API void pony_become(pony_ctx_t* ctx, pony_actor_t* actor)
 
 PONY_API void pony_poll(pony_ctx_t* ctx)
 {
+  // TODO: this seems like it could allow muted actors to get `ponyint_actor_run`
+  // which shouldn't be allowed. Fixing might require API changes.
   pony_assert(ctx->current != NULL);
-  ponyint_actor_run(ctx, ctx->current, 1);
+  ponyint_actor_run(ctx, ctx->current, true);
 }
 
 void ponyint_actor_setoverloaded(pony_actor_t* actor)

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -16,7 +16,7 @@
 #endif
 
 // default actor batch size
-#define PONY_ACTOR_DEFAULT_BATCH 100
+#define PONY_SCHED_BATCH 100
 
 // Ignore padding at the end of the type.
 pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
@@ -281,7 +281,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
   pony_assert(!ponyint_is_muted(actor));
   ctx->current = actor;
-  size_t batch = PONY_ACTOR_DEFAULT_BATCH;
+  size_t batch = PONY_SCHED_BATCH;
 
   pony_msg_t* msg;
   size_t app = 0;

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -37,8 +37,8 @@ typedef struct pony_actor_t
   pony_msg_t* continuation;
 #endif
   PONY_ATOMIC(uint8_t) flags;
-  PONY_ATOMIC(uint64_t) muted;
   PONY_ATOMIC(uint8_t) is_muted;
+  PONY_ATOMIC(size_t) muted;
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes
@@ -59,7 +59,7 @@ enum
 
 bool has_flag(pony_actor_t* actor, uint8_t flag);
 
-bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, size_t batch);
+bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
 
 void ponyint_actor_destroy(pony_actor_t* actor);
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include "mutemap.h"
 
-#define PONY_SCHED_BATCH 100
 #define PONY_SCHED_BLOCK_THRESHOLD 1000000
 
 static DECLARE_THREAD_FN(run_thread);
@@ -897,7 +896,7 @@ static void run(scheduler_t* sched)
       ponyint_sched_maybe_wakeup(sched->index);
 
     // Run the current actor and get the next actor.
-    bool reschedule = ponyint_actor_run(&sched->ctx, actor, PONY_SCHED_BATCH);
+    bool reschedule = ponyint_actor_run(&sched->ctx, actor, false);
     pony_actor_t* next = pop_global(sched);
 
     if(reschedule)
@@ -1293,7 +1292,7 @@ void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* rec
     // This is safe because an actor can only ever be in a single scheduler's
     // mutemap
     ponyint_muteset_putindex(&mref->value, sender, index2);
-    uint64_t muted = atomic_load_explicit(&sender->muted, memory_order_relaxed);
+    size_t muted = atomic_load_explicit(&sender->muted, memory_order_relaxed);
     muted++;
     atomic_store_explicit(&sender->muted, muted, memory_order_relaxed);
   }
@@ -1328,7 +1327,7 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
     {
       // This is safe because an actor can only ever be in a single scheduler's
       // mutemap
-      uint64_t muted_count = atomic_load_explicit(&muted->muted, memory_order_relaxed);
+      size_t muted_count = atomic_load_explicit(&muted->muted, memory_order_relaxed);
       pony_assert(muted_count > 0);
       muted_count--;
       atomic_store_explicit(&muted->muted, muted_count, memory_order_relaxed);


### PR DESCRIPTION
* Change actor->muted to be size_t
* Reorganize some muting/overload related checks/actions into
  functions (`maybe_mute` and `batch_limit_reached`)
* Use the new functions for both normal message processing
  and continuations (these checks were missing prior to this commit)
* Change `ponyint_actor_run` signature to have a boolean if it is
  being run in polling mode or not and remove batch size. Batch size
  is now set from a constant at the top of the function.
* Change logic related to how overload is set to ensure it is not
  set when polling to avoid overload/mute getting set unnecessarily
  due to polling using `batch size == 1` (previously; now, batch
  size is always the default).

TODO/OPEN ITEM: `pony_poll` can currently result in a muted actor
getting run via `ponyint_actor_run` when it shouldn't be.