### PR TITLE
Make reading via TCPConnection re-entrant safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Do not permit leading zeros in JSON numbers ([PR #3167](https://github.com/ponylang/ponyc/pull/3167))
+- Make reading via TCPConnection re-entrant safe ([PR #3175](https://github.com/ponylang/ponyc/pull/3175))
 
 ### Added
 

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -198,6 +198,7 @@ actor TCPConnection
   var _event: AsioEventID = AsioEvent.none()
   var _connected: Bool = false
   var _readable: Bool = false
+  var _reading: Bool = false
   var _writeable: Bool = false
   var _throttled: Bool = false
   var _closed: Bool = false
@@ -414,7 +415,9 @@ actor TCPConnection
     Start reading off this TCPConnection again after having been muted.
     """
     _muted = false
-    _pending_reads()
+    if not _reading then
+      _pending_reads()
+    end
 
   be set_notify(notify: TCPConnectionNotify iso) =>
     """
@@ -811,9 +814,11 @@ actor TCPConnection
       try
         var sum: USize = 0
         var received_called: USize = 0
+        _reading = true
 
         while _readable and not _shutdown_peer do
           if _muted then
+            _reading = false
             return
           end
 
@@ -830,6 +835,7 @@ actor TCPConnection
             // for a read event so will not be writing to the readable flag
             @pony_asio_event_set_readable(_event, false)
             _readable = false
+            _reading = false
             @pony_asio_event_resubscribe_read(_event)
             return
           | _next_size =>
@@ -848,6 +854,7 @@ actor TCPConnection
             if not _notify.received(this, consume data, received_called) then
               _read_buf_size()
               _read_again()
+              _reading = false
               return
             else
               _read_buf_size()
@@ -859,6 +866,7 @@ actor TCPConnection
           if sum >= _max_size then
             // If we've read _max_size, yield and read again later.
             _read_again()
+            _reading = false
             return
           end
         end
@@ -868,6 +876,8 @@ actor TCPConnection
         close()
       end
     end
+
+    _reading = false
 
   fun ref _notify_connecting() =>
     """


### PR DESCRIPTION
Port over bc6f78bcaad55156393753c540befe9f581065bc from wallaroo.

There's a nasty possible bug in TCPConnection before
applying this change.

Because `_mute` and `_unmute` are synchronous methods on
TCPConnection and because they can be called inside
`_pending_reads` via code executing in `notify.received`, its
possible to mute and unmute a source while executing
`_pending_reads`.

Prior to this change, if you were to unmute from inside a pending
reads via the above scenario, `_unmute` would synchronously call
`_pending_reads` to re-enter that function and start processing
data out of order. Further, we could end up in an infinite loop
so long as enough data existed.