### PR TITLE
Make TCPConnection yield on writes to not hog cpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Changed
 
 - Do not permit leading zeros in JSON numbers ([PR #3167](https://github.com/ponylang/ponyc/pull/3167))
+- Make TCPConnection yield on writes to not hog cpu ([PR #3176](https://github.com/ponylang/ponyc/pull/3176))
 
 ## [0.28.1] - 2019-06-01
 

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -628,6 +628,12 @@ actor TCPConnection
       end
     end
 
+  be _write_again() =>
+    """
+    Resume writing.
+    """
+    _pending_writes()
+
   fun ref _pending_writes(): Bool =>
     """
     Send pending data. If any data can't be sent, keep it and mark as not
@@ -639,7 +645,12 @@ actor TCPConnection
       let writev_batch_size: USize = @pony_os_writev_max[I32]().usize()
       var num_to_send: USize = 0
       var bytes_to_send: USize = 0
+      var bytes_sent: USize = 0
       while _writeable and (_pending_writev_total > 0) do
+        if bytes_sent >= _max_size then
+          _write_again()
+          return false
+        end
         try
           // Determine number of bytes and buffers to send.
           if (_pending_writev.size() / 2) < writev_batch_size then
@@ -662,6 +673,8 @@ actor TCPConnection
           if _manage_pending_buffer(len, bytes_to_send, num_to_send)? then
             return true
           end
+
+          bytes_sent = bytes_sent + len
         else
           // Non-graceful shutdown on error.
           hard_close()


### PR DESCRIPTION
Port over of the following PR from wallaroo:

https://github.com/WallarooLabs/wallaroo/pull/2565

This commit adds a `_write_again` to the `TCPConnection` actor
and modifies the `_pending_writes` function to yield by calling
`_write_again` after having sent at least `_max_size` bytes.
This will allow other actors and GC to run when a large amount
of data has been queued up to be sent.