### PR TITLE
Cleanup TCPConnection GC-safety mechanism for writev buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Do not permit leading zeros in JSON numbers ([PR #3167](https://github.com/ponylang/ponyc/pull/3167))
 - Make reading via TCPConnection re-entrant safe ([PR #3175](https://github.com/ponylang/ponyc/pull/3175))
+- Cleanup TCPConnection GC-safety mechanism for writev buffers ([#3177](https://github.com/ponylang/ponyc/pull/3177))
 
 ### Added
 
@@ -17,6 +18,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Do not permit leading zeros in JSON numbers ([PR #3167](https://github.com/ponylang/ponyc/pull/3167))
 - Make TCPConnection yield on writes to not hog cpu ([PR #3176](https://github.com/ponylang/ponyc/pull/3176))
+- Add `pointer.offset` to get arbitrary pointer tags via offset ([#3177](https://github.com/ponylang/ponyc/pull/3177))
 
 ## [0.28.1] - 2019-06-01
 

--- a/packages/builtin/pointer.pony
+++ b/packages/builtin/pointer.pony
@@ -52,6 +52,12 @@ struct Pointer[A]
     """
     compile_intrinsic
 
+  fun tag offset(n: USize): Pointer[A] tag =>
+    """
+    Return a tag pointer to the n-th element.
+    """
+     _unsafe()._offset(n)
+
   fun tag _element_size(): USize =>
     """
     Return the size of a single element in an array of type A.


### PR DESCRIPTION
Prior to this commit, the TCPConnection `pending_writev` buffer had to
have a secondary buffer called `_pending` to ensure that the data
wouldn't get GC'd too early by the runtime.

This commit removes that hack and replaces it with a slightly different
hack based on the strategy used in `File` in PR #2775. The hacky part
is that now we have two buffers for `writev` data. One for windows
(`_pending_windows`) and one for non-windows (`_pending_posix`) to
account for the difference in order of the struct between windows
and posix. This, however, seems less bad than the previous hack of
having the secondary buffer to ensure GC safety.

resolves #2782
resolves #2779