### PR TITLE
Allow reassignment of `consume`d variable in try (sometimes)

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -58,7 +58,7 @@ enum
   AST_ORPHAN = 0x20,
   AST_INHERIT_FLAGS = (AST_FLAG_CAN_ERROR | AST_FLAG_CAN_SEND |
     AST_FLAG_MIGHT_SEND | AST_FLAG_RECURSE_1 | AST_FLAG_RECURSE_2),
-  AST_ALL_FLAGS = 0xFFFFFF
+  AST_ALL_FLAGS = 0x1FFFFFF
 };
 
 
@@ -1288,7 +1288,8 @@ bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner, errorframe_t* errorf)
       {
         // If it's consumed, and has a null value, it's from outside of this
         // scope. We need to know if it's outside the loop scope.
-        if((sym->status == SYM_CONSUMED) && (sym->def == NULL))
+        if(((sym->status == SYM_CONSUMED) || (sym->status == SYM_CONSUMED_SAME_EXPR))
+          && (sym->def == NULL))
         {
           if(!ast_within_scope(outer, inner, sym->name))
           {

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -47,6 +47,7 @@ enum
   AST_FLAG_INCOMPLETE   = 0x200000, // Not all fields are defined.
   AST_FLAG_IMPORT       = 0x400000, // Import the referenced package.
   AST_FLAG_MAY_BREAK    = 0x800000, // This loop has seen a break statement in it.
+  AST_FLAG_CNSM_REASGN  = 0x1000000, // A variable is reassigned after a consume in the same expression
 };
 
 DECLARE_LIST(astlist, astlist_t, ast_t);

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -233,6 +233,10 @@ void symtab_inherit_branch(symtab_t* dst, symtab_t* src)
         // Consumed overrides everything.
         dsym->status = SYM_CONSUMED;
         dsym->branch_count = 0;
+      } else if(sym->status == SYM_CONSUMED_SAME_EXPR) {
+        // Consumed overrides everything.
+        dsym->status = SYM_CONSUMED_SAME_EXPR;
+        dsym->branch_count = 0;
       }
     } else {
       // Add this symbol to the destination.
@@ -332,6 +336,10 @@ void symtab_print(symtab_t* symtab)
 
       case SYM_CONSUMED:
         printf(": consumed\n");
+        break;
+
+      case SYM_CONSUMED_SAME_EXPR:
+        printf(": consumed same expression\n");
         break;
 
       default:

--- a/src/libponyc/ast/symtab.h
+++ b/src/libponyc/ast/symtab.h
@@ -16,6 +16,7 @@ typedef enum
   SYM_DEFINED,
   SYM_UNDEFINED,
   SYM_CONSUMED,
+  SYM_CONSUMED_SAME_EXPR,
   SYM_FFIDECL,
   SYM_ERROR
 } sym_status_t;

--- a/src/libponyc/verify/control.c
+++ b/src/libponyc/verify/control.c
@@ -1,7 +1,6 @@
 #include "control.h"
 #include "ponyassert.h"
 
-
 bool verify_try(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert((ast_id(ast) == TK_TRY) || (ast_id(ast) == TK_TRY_NO_CHECK));

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -221,11 +221,13 @@ TEST_F(ReferTest, ConsumeVarReassignTry)
       "new create(env: Env) =>\n"
         "var c = C\n"
         "try\n"
-        "  c = consume c\n"
+        "  let d = consume c\n"
+        "  c = consume d\n"
+        "  error\n"
         "end\n";
 
   TEST_ERRORS_2(src,
-    "can't reassign to a consumed identifier in a try expression",
+    "can't reassign to a consumed identifier in a try expression unless it is reassigned in the same expression",
     "left side must be something that can be assigned to");
 }
 

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -23,6 +23,212 @@ class ReferTest : public PassTest
 {};
 
 
+TEST_F(ReferTest, ConsumeThis)
+{
+  const char* src =
+    "class iso C\n"
+      "fun iso get(): C iso^ =>\n"
+        "consume this\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let c = C\n"
+        "(consume c).get()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ReferTest, ConsumeThisReuse)
+{
+  const char* src =
+    "class iso C\n"
+      "fun iso get(): C iso^ =>\n"
+        "consume this\n"
+        "consume this\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let c = C\n"
+        "(consume c).get()";
+
+  TEST_ERRORS_1(src,
+    "can't use a consumed 'this' in an expression");
+}
+
+TEST_F(ReferTest, ConsumeLet)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let c = C\n"
+        "P(consume c)";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ReferTest, ConsumeLetReassign)
+{
+  const char* src =
+    "class iso C\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let c = C\n"
+        "c = consume c";
+
+  TEST_ERRORS_2(src,
+    "can't reassign to a let local",
+    "left side must be something that can be assigned to");
+}
+
+TEST_F(ReferTest, ConsumeLetField)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "let c: C\n"
+      "new create(env: Env) =>\n"
+        "c = C\n"
+        "P(consume c)";
+
+  TEST_ERRORS_1(src,
+    "consume must take 'this', a local, or a parameter");
+}
+
+TEST_F(ReferTest, ConsumeVar)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "var c = C\n"
+        "P(consume c)";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ReferTest, ConsumeVarReuse)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "var c = C\n"
+        "consume c\n"
+        "P(consume c)";
+
+  TEST_ERRORS_2(src,
+    "can't use a consumed local in an expression",
+    "consume must take 'this', a local, or a parameter");
+}
+
+TEST_F(ReferTest, ConsumeVarReassign)
+{
+  const char* src =
+    "class iso C\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "var c = C\n"
+        "c = consume c";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ReferTest, ConsumeVarField)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "var c: C\n"
+      "new create(env: Env) =>\n"
+        "c = C\n"
+        "P(consume c)";
+
+  TEST_ERRORS_1(src,
+    "consume must take 'this', a local, or a parameter");
+}
+
+TEST_F(ReferTest, ConsumeEmbedField)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) => None\n"
+
+    "actor Main\n"
+      "embed c: C\n"
+      "new create(env: Env) =>\n"
+        "c = C\n"
+        "P(consume c)";
+
+  TEST_ERRORS_1(src,
+    "consume must take 'this', a local, or a parameter");
+}
+
+TEST_F(ReferTest, ConsumeVarTry)
+{
+  const char* src =
+    "class iso C\n"
+
+    "primitive P\n"
+      "fun apply(c: C) ? => error\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "var c = C\n"
+        "try\n"
+        "  P(consume c) ?"
+        "end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(ReferTest, ConsumeVarReassignTry)
+{
+  const char* src =
+    "class iso C\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "var c = C\n"
+        "try\n"
+        "  c = consume c\n"
+        "end\n";
+
+  TEST_ERRORS_2(src,
+    "can't reassign to a consumed identifier in a try expression",
+    "left side must be something that can be assigned to");
+}
+
 TEST_F(ReferTest, WhileLoopConsumeLet)
 {
   const char* src =

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -408,7 +408,8 @@ void PassTest::test_expected_error_frames(const char* src, const char* pass,
     {
       const char* expected_error = *expected_errors;
       EXPECT_FALSE(strstr(ef->msg, expected_error) == NULL)
-        << "Actual error: " << ef->msg;
+        << "Actual error: " << ef->msg
+        << "\nExpected error: " << expected_error;
       expected_errors++;
     }
 
@@ -594,7 +595,8 @@ void PassTest::build_package(const char* pass, const char* src,
         break;
 
       EXPECT_TRUE(strstr(e->msg, expected_error) != NULL)
-        << "Actual error: " << e->msg;
+        << "Actual error: " << e->msg
+        << "\nExpected error: " << expected_error;
       e = e->next;
     }
   }


### PR DESCRIPTION
Prior to this commit, a `consume`d variable could not be
reassigned in a `try` block. This commit changes things to allow
a `consume`d variable to be reassigned within a `try` block only
if it is reassigned in the same expression where it is consumed
(i.e. `z = do_stuff(consume z)`) and only if that expression does
not include any partial calls.

Also, add tests for various `consume` related scenarios.