### PR TITLE
tcp_connection.pony: fix _read_buf_size() realloc bug

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -809,7 +809,11 @@ actor TCPConnection
     Resize the read buffer.
     """
     if _expect != 0 then
-      _read_buf.undefined(_expect.next_pow2().max(_next_size))
+      // We know how much data to expect. If _read_buf is too small,
+      // then resize it.
+      if (_read_buf.size() - _read_buf_offset) <= _expect then
+        _read_buf.undefined(_expect.next_pow2().max(_next_size))
+      end
     else
       _read_buf.undefined(_next_size)
     end


### PR DESCRIPTION
Fixes #3182

When _expect != 0, then we know how many bytes to expect from
the socket, so only call _read_buf.undefined() when we know
that the buffer is too small to accomodate _expect bytes.