### PR TITLE
Simplify buffering in TCPConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Make TCPConnection yield on writes to not hog cpu ([PR #3176](https://github.com/ponylang/ponyc/pull/3176))
 - Change how TCP connection reads data to improve performance ([PR #3178](https://github.com/ponylang/ponyc/pull/3178))
 - Allow use of runtime TCP connect without ASIO one shot ([PR #3171](https://github.com/ponylang/ponyc/pull/3171))
+- Simplify buffering in TCPConnection ([PR #3185](https://github.com/ponylang/ponyc/pull/3185))
 
 ## [0.28.1] - 2019-06-01
 

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -45,8 +45,7 @@ actor TCPListener
   let _limit: USize
   var _count: USize = 0
   var _paused: Bool = false
-  var _init_size: USize
-  var _max_size: USize
+  var _read_buffer_size: USize
 
   new create(
     auth: TCPListenerAuth,
@@ -54,8 +53,7 @@ actor TCPListener
     host: String = "",
     service: String = "0",
     limit: USize = 0,
-    init_size: USize = 64,
-    max_size: USize = 16384)
+    read_buffer_size: USize = 16384)
   =>
     """
     Listens for both IPv4 and IPv6 connections.
@@ -65,8 +63,7 @@ actor TCPListener
     _event =
       @pony_os_listen_tcp[AsioEventID](this,
         host.cstring(), service.cstring())
-    _init_size = init_size
-    _max_size = max_size
+    _read_buffer_size = read_buffer_size
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
@@ -76,8 +73,7 @@ actor TCPListener
     host: String = "",
     service: String = "0",
     limit: USize = 0,
-    init_size: USize = 64,
-    max_size: USize = 16384)
+    read_buffer_size: USize = 16384)
   =>
     """
     Listens for IPv4 connections.
@@ -87,8 +83,7 @@ actor TCPListener
     _event =
       @pony_os_listen_tcp4[AsioEventID](this, host.cstring(),
         service.cstring())
-    _init_size = init_size
-    _max_size = max_size
+    _read_buffer_size = read_buffer_size
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
@@ -98,8 +93,7 @@ actor TCPListener
     host: String = "",
     service: String = "0",
     limit: USize = 0,
-    init_size: USize = 64,
-    max_size: USize = 16384)
+    read_buffer_size: USize = 16384)
   =>
     """
     Listens for IPv6 connections.
@@ -109,8 +103,7 @@ actor TCPListener
     _event =
       @pony_os_listen_tcp6[AsioEventID](this, host.cstring(),
         service.cstring())
-    _init_size = init_size
-    _max_size = max_size
+    _read_buffer_size = read_buffer_size
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
 
@@ -217,8 +210,8 @@ actor TCPListener
     Spawn a new connection.
     """
     try
-      TCPConnection._accept(this, _notify.connected(this)?, ns, _init_size,
-        _max_size)
+      TCPConnection._accept(this, _notify.connected(this)?, ns,
+        _read_buffer_size)
       _count = _count + 1
     else
       @pony_os_socket_close[None](ns)


### PR DESCRIPTION
Prior to this commit, the buffering in TCPConnection was overly
complicated. This was a carry over from the old style of buffer
handling. However, after Dipin Hora's commits to bring over the "faster
tcp" changes from Wallaroo, the buffer handling no longer makes sense.

Prior to this commit, a TCPConnection would be provided two variables to
control read buffering: init_size, max_size. The read buffer would start
at init_size and would grow to max_size.

Before "faster tcp", the buffer would only grow in size if we read the
entire buffer's worth of data in one recv call. After the data was read,
the buffer would be truncated and then handed off to the
TCPConnectionNotify. This was very wasteful. If you had a buffer of 128
allocated bytes and only read 4, then the 124 allocated bytes would be
truncated away and the buffer would be reallocated.

With "faster tcp", we allocate a large buffer and when reading data, we
chop it off the buffer as needed. This means, that "grow the buffer"
doesn't make much sense anymore. The buffer will continually shrink in
size as we slowly chop more and more off. This meant that with the code
as it is prior to change, we would always grow to max buffer size.

If we are always going to grow to max buffer size, it makes sense to
simplify the code and our interfaces and only allow for setting the
buffer size. This commit makes that simplication. Now we will:

- allocate a buffer of size `read_buffer_size`
- reallocate when the buffer is empty
- reallocate if the caller is using `expect` and the buffer is too small
to hold the expected payload

This is a breaking change for TPCConnection and TCPListener as it
changes the constructor interfaces.