### PR TITLE
Cleanup Unixen TCPConnection read buffer resizing

### DIFF
--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -471,7 +471,6 @@ actor TCPConnection
     """
     if not _in_sent then
       _expect = _notify.expect(this, qty)
-      _read_buf_size()
     end
 
   fun ref set_nodelay(state: Bool) =>
@@ -875,7 +874,6 @@ actor TCPConnection
               received_called))
               or (received_called >= _max_received_called)
             then
-              _read_buf_size()
               _read_again()
               _reading = false
               return
@@ -885,16 +883,12 @@ actor TCPConnection
           if sum >= _yield_after_reading then
             // If we've read _yield_after_reading bytes
             // yield and read again later.
-            _read_buf_size()
             _read_again()
             _reading = false
             return
           end
 
-          // make sure we have enough space to read enough data for _expect
-          if _read_buf.size() <= _expect then
-            _read_buf_size()
-          end
+          _read_buf_size()
 
           // Read as much data as possible.
           let len = @pony_os_recv[USize](


### PR DESCRIPTION
We were calling it in a number of places that don't matter. Ends up
being extra function calls that serve no purpose. Also, removes a
duplicate guard around doing a resize. In that one case, we'd check the
resize condition twice in a row.