### PR TITLE
Add DTrace/SystemTap probes for muted & unmuted events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Allow use of OpenSSL 1.1.1 when building Pony ([PR #3156](https://github.com/ponylang/ponyc/pull/3156))
 - Add `pointer.offset` to get arbitrary pointer tags via offset ([#3177](https://github.com/ponylang/ponyc/pull/3177))
+- Add DTrace/SystemTap probes for muted & unmuted events ([#3196](https://github.com/ponylang/ponyc/pull/3196))
 
 ### Changed
 

--- a/src/common/dtrace_probes.d
+++ b/src/common/dtrace_probes.d
@@ -93,6 +93,18 @@ provider pony {
   probe actor__pressure__released(uintptr_t actor);
 
   /**
+   * Fired when actor is muted
+   * @param actor is the muted actor
+   */
+  probe actor__muted(uintptr_t actor);
+
+  /**
+   * Fired when actor is no longer muted
+   * @param actor is the no longer muted actor
+   */
+  probe actor__unmuted(uintptr_t actor);
+
+  /**
    * Fired when cpu goes into nanosleep
    * @param ns is nano seconds spent in sleep
    */

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -875,6 +875,7 @@ void ponyint_mute_actor(pony_actor_t* actor)
 {
    uint8_t is_muted = atomic_load_explicit(&actor->is_muted, memory_order_relaxed);
    pony_assert(is_muted == 0);
+   DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
    is_muted++;
    atomic_store_explicit(&actor->is_muted, is_muted, memory_order_relaxed);
 
@@ -884,5 +885,6 @@ void ponyint_unmute_actor(pony_actor_t* actor)
 {
   uint8_t is_muted = atomic_fetch_sub_explicit(&actor->is_muted, 1, memory_order_relaxed);
   pony_assert(is_muted == 1);
+  DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
   (void)is_muted;
 }


### PR DESCRIPTION
@SeanTAllen reminded me that I was going to add these probes in a separate PR soon after the original DTrace probes were added.  I'd forgotten until now, silly me.