### PR TITLE
Add method to AsioEvent to see if an event is a oneshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Allow use of OpenSSL 1.1.1 when building Pony ([PR #3156](https://github.com/ponylang/ponyc/pull/3156))
-- Add `pointer.offset` to get arbitrary pointer tags via offset ([#3177](https://github.com/ponylang/ponyc/pull/3177))
+- Add `pointer.offset` to get arbitrary pointer tags via offset ([PR #3177](https://github.com/ponylang/ponyc/pull/3177))
 - Add DTrace/SystemTap probes for muted & unmuted events ([PR #3196](https://github.com/ponylang/ponyc/pull/3196))
 - Add method to AsioEvent to see if an event is a oneshot ([PR #3198](https://github.com/ponylang/ponyc/pull/3198))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Allow use of OpenSSL 1.1.1 when building Pony ([PR #3156](https://github.com/ponylang/ponyc/pull/3156))
 - Add `pointer.offset` to get arbitrary pointer tags via offset ([#3177](https://github.com/ponylang/ponyc/pull/3177))
+- Add method to AsioEvent to see if an event is a oneshot ([PR #3198](https://github.com/ponylang/ponyc/pull/3198))
 
 ### Changed
 

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -31,6 +31,12 @@ primitive AsioEvent
     """
     flags == 0
 
+  fun oneshotable(flags: U32): Bool =>
+    """
+    Returns true if the flags contain the oneshot flag.
+    """
+    (flags and (1 << 8)) != 0
+
   fun dispose(): U32 => 0
 
   fun read(): U32 => 1 << 0


### PR DESCRIPTION
I need this functionality in my Lori library to support both 1-shot and
edge triggered ASIO functionality in a single actor. I could put a
method to examine in my library but including for testing on AsioEvent
seems like the best course of action.