### PR TITLE
Fix return type checking to allow aliasing for non-ephemeral return types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Add SSL tests and fix some SSL related bugs ([PR #3174](https://github.com/ponylang/ponyc/pull/3174))
 - Fix lib/llvm to support MacOS ([PR #3181](https://github.com/ponylang/ponyc/pull/3181))
 - Close Denial of Service issue with TCPConnection.expect ([PR #3197](https://github.com/ponylang/ponyc/pull/3197))
+- Fix return type checking to allow aliasing for non-ephemeral return types. ([PR #3201](https://github.com/ponylang/ponyc/pull/3201))
 
 ### Added
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -981,7 +981,7 @@ static bool check_return_type(pass_opt_t* opt, ast_t* ast)
   bool ok = true;
 
   errorframe_t info = NULL;
-  if(!is_subtype(body_type, type, &info, opt) ||
+  if(!is_subtype(body_type, type, &info, opt) &&
     !is_subtype(a_body_type, a_type, &info, opt))
   {
     errorframe_t frame = NULL;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1051,3 +1051,24 @@ TEST_F(BadPonyTest, DisallowPointerAndMaybePointerInEmbeededType)
     "embedded fields must be classes or structs",
     "embedded fields must be classes or structs")
 }
+
+TEST_F(BadPonyTest, AllowAliasForNonEphemeralReturn)
+{
+  const char* src =
+    "class iso Inner\n"
+    "  new iso create() => None\n"
+
+    "class Container[A: Inner #any]\n"
+    "  var inner: A\n"
+    "  new create(inner': A) => inner = consume inner'\n"
+    "  fun get_1(): this->A => inner                        // works\n"
+    "  fun get_2(): this->A => let tmp = inner; consume tmp // also works\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let o = Container[Inner iso](Inner)\n"
+    "    let i_1 : Inner tag = o.get_1()\n"
+    "    let i_2 : Inner tag = o.get_2()";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
This PR fixes return type checking to allow aliasing for non-ephemeral return types.

I discovered this type system issue after a discussion with @rkallos in which we discussed how to fix `Map.insert` (and others) to not have an unreachable error case.

Looking into it further, I discovered that the type system had a simple bug that wasn't obvious due to the inconsistency in how Pony handles return type checking (the fact that using the ephemeral modifier is required to describe a unique return type, whereas on all other type specifications, the ephemeral modifier is useless).

This PR doesn't address that inconsistency, because it would be a major breaking change for the language, but this does fix the small bug that went unnoticed because of it.

The bug can be reproduced with the following code, in which `get_1` and `get_2` are valid and functionally identical, but the latter fails to compile:

```pony
class iso Inner
  new iso create() => None

class Container[A: Inner #any]
  var inner: A
  new create(inner': A) => inner = consume inner'
  fun get_1(): this->A => inner                        // works
  fun get_2(): this->A => let tmp = inner; consume tmp // fails

actor Main
  new create(env: Env) =>
    let o = Container[Inner iso](Inner)
    let i_1 : Inner tag = o.get_1()
    let i_2 : Inner tag = o.get_2()
```

Upon investigation, it turned out to be a simple boolean logic bug, in which `not (A or B)` was expressed as `!a || !b` instead of the correct `!a && !b`. The code comment  several lines above the change expresses the intended meaning, so I know that this fixed logic reflects the code author's original intent.