### PR TITLE
Make Map insertion functions total

### DIFF
--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -71,9 +71,7 @@ class CommandParser
         match _parse_long_option(token.substring(2), tokens)
         | let o: Option =>
           if o.spec()._typ_p().is_seq() then
-            try
-              options.upsert(o.spec().name(), o, {(x, n) => x._append(n) })?
-            end
+            options.upsert(o.spec().name(), o, {(x, n) => x._append(n) })
           else
             options.update(o.spec().name(), o)
           end
@@ -86,9 +84,7 @@ class CommandParser
         | let os: Array[Option] =>
           for o in os.values() do
             if o.spec()._typ_p().is_seq() then
-              try
-                options.upsert(o.spec().name(), o, {(x, n) => x._append(n) })?
-              end
+              options.upsert(o.spec().name(), o, {(x, n) => x._append(n) })
             else
               options.update(o.spec().name(), o)
             end
@@ -112,9 +108,7 @@ class CommandParser
           match _parse_arg(token, arg_pos)
           | let a: Arg =>
             if a.spec()._typ_p().is_seq() then
-              try
-                args.upsert(a.spec().name(), a, {(x, n) => x._append(n) })?
-              end
+              args.upsert(a.spec().name(), a, {(x, n) => x._append(n) })
             else
               args.update(a.spec().name(), a)
               arg_pos = arg_pos + 1

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -98,13 +98,13 @@ class iso _TestMap is UnitTest
     h.assert_eq[U32](11, (a("1") = 1) as U32)
 
     let b = Map[String, U32]
-    h.assert_eq[U32](0, b.insert("0", 0)?)
-    h.assert_eq[U32](1, b.insert("1", 1)?)
-    h.assert_eq[U32](2, b.insert("2", 2)?)
-    h.assert_eq[U32](3, b.insert("3", 3)?)
-    h.assert_eq[U32](4, b.insert("4", 4)?)
-    h.assert_eq[U32](5, b.insert("5", 5)?)
-    h.assert_eq[U32](6, b.insert("6", 6)?)
+    h.assert_eq[U32](0, b.insert("0", 0))
+    h.assert_eq[U32](1, b.insert("1", 1))
+    h.assert_eq[U32](2, b.insert("2", 2))
+    h.assert_eq[U32](3, b.insert("3", 3))
+    h.assert_eq[U32](4, b.insert("4", 4))
+    h.assert_eq[U32](5, b.insert("5", 5))
+    h.assert_eq[U32](6, b.insert("6", 6))
 
     h.assert_eq[USize](7, a.size())
     h.assert_eq[USize](16, a.space())

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -164,28 +164,28 @@ class iso _TestMapUpsert is UnitTest
   fun apply(h: TestHelper) ? =>
     let x: Map[U32, U64] = Map[U32,U64]
     let f = {(x: U64, y: U64): U64 => x + y }
-    x.upsert(1, 5, f)?
+    x.upsert(1, 5, f)
     h.assert_eq[U64](5, x(1)?)
-    x.upsert(1, 3, f)?
+    x.upsert(1, 3, f)
     h.assert_eq[U64](8, x(1)?)
-    x.upsert(1, 4, f)?
+    x.upsert(1, 4, f)
     h.assert_eq[U64](12, x(1)?)
-    x.upsert(1, 2, f)?
+    x.upsert(1, 2, f)
     h.assert_eq[U64](14, x(1)?)
-    x.upsert(1, 1, f)?
+    x.upsert(1, 1, f)
     h.assert_eq[U64](15, x(1)?)
 
     let x2: Map[U32, String] = Map[U32,String]
     let g = {(x: String, y: String): String => x + ", " + y }
-    x2.upsert(1, "1", g)?
+    x2.upsert(1, "1", g)
     h.assert_eq[String]("1", x2(1)?)
-    x2.upsert(1, "2", g)?
+    x2.upsert(1, "2", g)
     h.assert_eq[String]("1, 2", x2(1)?)
-    x2.upsert(1, "3", g)?
+    x2.upsert(1, "3", g)
     h.assert_eq[String]("1, 2, 3", x2(1)?)
-    x2.upsert(1, "abc", g)?
+    x2.upsert(1, "abc", g)
     h.assert_eq[String]("1, 2, 3, abc", x2(1)?)
-    x2.upsert(1, "def", g)?
+    x2.upsert(1, "def", g)
     h.assert_eq[String]("1, 2, 3, abc, def", x2(1)?)
 
     // verify correct results when we trigger a resize
@@ -194,23 +194,23 @@ class iso _TestMapUpsert is UnitTest
     let x3: Map[U32, U64] = Map[U32,U64](prealloc)
     let f' = {(x: U64, y: U64): U64 => x + y }
     h.assert_eq[USize](expected_initial_size, x3.space())
-    h.assert_eq[U64](1, x3.upsert(1, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(2, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(3, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(4, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(5, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(6, 1, f')?)
-    h.assert_eq[U64](1, x3.upsert(7, 1, f')?)
-    h.assert_eq[U64](2, x3.upsert(5, 1, f')?)
+    h.assert_eq[U64](1, x3.upsert(1, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(2, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(3, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(4, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(5, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(6, 1, f'))
+    h.assert_eq[U64](1, x3.upsert(7, 1, f'))
+    h.assert_eq[U64](2, x3.upsert(5, 1, f'))
     h.assert_ne[USize](expected_initial_size, x3.space())
 
     let x4: Map[I32, I64] = Map[I32,I64]
     let i = {(x: I64, y: I64): I64 => x - y }
-    x4.upsert(2, 4, i)?
+    x4.upsert(2, 4, i)
     h.assert_eq[I64](4, x4(2)?)
-    x4.upsert(2, 4, i)?
+    x4.upsert(2, 4, i)
     h.assert_eq[I64](0, x4(2)?)
-    x4.upsert(2, 4, i)?
+    x4.upsert(2, 4, i)
     h.assert_eq[I64](-4, x4(2)?)
 
 class iso _TestMapHashFunc is UnitTest

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -133,12 +133,12 @@ class iso _TestMap is UnitTest
     h.assert_eq[USize](8, b.space())
 
     let c = Map[String, U32]
-    c.insert_if_absent("a", 1)?
+    c.insert_if_absent("a", 1)
     h.assert_eq[U32](1, c("a")?)
-    c.insert_if_absent("a", 2)?
+    c.insert_if_absent("a", 2)
     h.assert_eq[U32](1, c("a")?)
-    h.assert_eq[U32](0, c.insert_if_absent("0", 0)?)
-    h.assert_eq[U32](0, c.insert_if_absent("0", 1)?)
+    h.assert_eq[U32](0, c.insert_if_absent("0", 0))
+    h.assert_eq[U32](0, c.insert_if_absent("0", 1))
 
 class iso _TestMapRemove is UnitTest
   fun name(): String => "collections/Map.remove"

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -121,10 +121,11 @@ class HashMap[K, V, H: HashFunction[K] val]
       error
     end
 
-  fun ref insert(key: K, value: V): V ? =>
+  fun ref insert(key: K, value: V): V =>
     """
     Set a value in the map. Returns the new value, allowing reuse.
     """
+    let value' = value
     try
       (let i, let found) = _search(key)
       let key' = key
@@ -135,14 +136,13 @@ class HashMap[K, V, H: HashFunction[K] val]
 
         if (_size * 4) > (_array.size() * 3) then
           _resize(_array.size() * 2)
-          return this(key')?
         end
       end
 
-      _array(i)? as (_, V)
+      value'
     else
       // This is unreachable, since index will never be out-of-bounds.
-      error
+      value'
     end
 
   fun ref insert_if_absent(key: K, value: V): V ? =>

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -153,7 +153,7 @@ class HashMap[K, V, H: HashFunction[K] val]
       value'
     end
 
-  fun ref insert_if_absent(key: K, value: V): V ? =>
+  fun ref insert_if_absent(key: K, value: V): V =>
     """
     Set a value in the map if the key doesn't already exist in the Map.
     Saves an extra lookup when doing a pattern like:
@@ -167,6 +167,8 @@ class HashMap[K, V, H: HashFunction[K] val]
     Returns the value, the same as `insert`, allowing 'insert_if_absent'
     to be used as a drop-in replacement for `insert`.
     """
+    let value' = value
+
     try
       (let i, let found) = _search(key)
       let key' = key
@@ -178,14 +180,13 @@ class HashMap[K, V, H: HashFunction[K] val]
 
         if (_size * 4) > (_array.size() * 3) then
           _resize(_array.size() * 2)
-          return this(key')?
         end
       end
 
       _array(i)? as (_, V)
     else
       // This is unreachable, since index will never be out-of-bounds.
-      error
+      value'
     end
 
   fun ref remove(key: box->K!): (K^, V^) ? =>

--- a/packages/ini/ini_map.pony
+++ b/packages/ini/ini_map.pony
@@ -19,17 +19,15 @@ primitive IniParse
       fun ref apply(section: String, key: String, value: String): Bool =>
         try
           if not map.contains(section) then
-            map.insert(section, Map[String, String])?
+            map.insert(section, Map[String, String])
           end
           map(section)?(key) = value
         end
         true
 
       fun ref add_section(section: String): Bool =>
-        try
-          if not map.contains(section) then
-            map.insert(section, Map[String, String])?
-          end
+        if not map.contains(section) then
+          map.insert(section, Map[String, String])
         end
         true
 


### PR DESCRIPTION
Thanks to https://github.com/ponylang/ponyc/pull/3201, it's now possible to make Map.insert & friends total functions. Not only that, but Map.insert should be slightly faster in the case where the insertion causes the underlying array to grow, as it is no longer necessary to do the lookup for the final value.

I suspect this would constitute a pretty large breaking change, as I'm sure code like `try map.insert(k, v)? end` is pretty common, and after this change it would be a compile-time error.

This PR is incomplete. There are some more partial-not-partial functions that can be fixed, like Map.insert_if_absent.