### PR TITLE
Don't error out when building vendored LLVM when PATH is "odd"

### DIFF
--- a/Makefile-lib-llvm
+++ b/Makefile-lib-llvm
@@ -30,7 +30,7 @@ pony_targets += stdlib test-stdlib stdlib-debug test-stdlib-debug test-examples 
 
 .PHONY: $(pony_targets)
 $(pony_targets): $(llvm_config)
-	@PATH=$(new_path) $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config) LLVM_CONFIG=$(llvm_config) $(MAKECMDGOALS)
+	@PATH="$(new_path)" $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config) LLVM_CONFIG=$(llvm_config) $(MAKECMDGOALS)
 
 .PHONY: $(llvm_config)
 $(llvm_config):
@@ -40,13 +40,13 @@ $(llvm_config):
 .PHONY: rebuild
 rebuild: clean
 	@$(MAKE) -C $(pony_lib_llvm_dir) rebuild
-	@PATH=$(new_path) $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
+	@PATH="$(new_path)" $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
 
 # Clean is needed otherwise the rebuild of llvm won't be linked
 .PHONY: rebuild-test
 rebuild-test: clean
 	@$(MAKE) -C $(pony_lib_llvm_dir) rebuild
-	@PATH=$(new_path) $(MAKE)  test -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
+	@PATH="$(new_path)" $(MAKE)  test -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
 
 # Rebuild and then run some tests as passed in the command line parameter gtest_filter.
 # Note, the clean is needed otherwise the rebuild of llvm won't be linked.
@@ -58,19 +58,19 @@ rebuild-test: clean
 .PHONY: rebuild-some-tests
 rebuild-some-tests: clean
 	@$(MAKE) -C $(pony_lib_llvm_dir) rebuild
-	@PATH=$(new_path) $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
+	@PATH="$(new_path)" $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config)
 	@$(MAKE) -f Makefile-lib-llvm some-tests
 
 # Run the some passing gtest_filter on command line, for example:
 #  make -f Makefile-lib-llvm some-tests gtest_filter=--gtest_filter=CodegenOptimisationTest.MergeSendMessageReordering
 .PHONY: some-tests
 some-tests:
-	@PATH=$(new_path) ./build/debug/libponyc.tests $(gtest_filter)
+	@PATH="$(new_path)" ./build/debug/libponyc.tests $(gtest_filter)
 
 # Clean just ponyc
 .PHONY: clean
 clean:
-	@PATH=$(new_path) $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config) clean
+	@PATH="$(new_path)" $(MAKE) -f Makefile-ponyc LLVM_VENDOR=true config=$(config) clean
 
 # Clean ponyc and lib/llvm
 .PHONY: clean-all


### PR DESCRIPTION
I was building ponyc with a vendored LLVM in a WSL2 environment and
had it fail because `sh` couldn't make heads or tails of some of the
characters in my PATH entry. In particular, because of spaces in
some of the path names.