### PR TITLE
Run docker image validation earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,12 @@ workflows:
           requires:
             - llvm-701-debug
 
+      # p3 did we break docker image building?
+      - validate-docker-image-builds:
+          requires:
+            - lib-llvm-ubuntu-release
+            - lib-llvm-ubuntu-debug
+
       # p3 validate centos7
       - lib-llvm-centos7-release:
           requires:
@@ -369,8 +375,4 @@ workflows:
           requires:
             - lib-llvm-ubuntu-debug
 
-      # p4 did we break docker image building?
-      - validate-docker-image-builds:
-          requires:
-            - lib-llvm-centos7-release
-            - lib-llvm-centos7-debug
+


### PR DESCRIPTION
It was possible for it not to get run if arm builds failed
and people might merge something broken given that arm
builds fail sometimes.

A more general clean up of circleci ordering is needed but this
is good for now. That more general clean up will be coming
when the release process is changed.