### PR TITLE
Fix `which dtrace` path check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Fix `which dtrace` path check ([PR #3229](https://github.com/ponylang/ponyc/pull/3229))
 
 ### Added
 

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -191,7 +191,7 @@ define USE_CHECK
     PONY_BUILD_DIR := $(PONY_BUILD_DIR)-pooltrack
   else ifeq ($1,dtrace)
     DTRACE ?= $(shell which dtrace)
-    ifeq (, $(DTRACE))
+    ifeq (, $$(DTRACE))
       $$(error No dtrace compatible user application static probe generation tool found)
     endif
     ALL_CFLAGS += -DUSE_DYNAMIC_TRACE


### PR DESCRIPTION
Fix a GNU Make macro bug that prevents `make use=dtrace` to work
correctly on FreeBSD and Linux+SystemTap platforms.  I don't
understand exactly why, but using `$(shell which dtrace 2> /dev/null)`
inside of the `USE_CHECK` macro definition always results in the
empty string.

When moved outside of the macro definition, plus using `+=` to
update the value of `$(DTRACE)`, works correctly on both
FreeBSD's GNU Make 4.2.1 and Ubuntu Xenial/16.04's GNU Make 4.1.