### PR TITLE
Readd printing of defaults with `--version`

### DIFF
--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -296,6 +296,8 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
 #else
         printf("%s\n", PONY_VERSION_STR);
 #endif
+
+        printf("Defaults: pic=%s\n", opt->pic ? "true" : "false");
         return EXIT_0;
 
       case OPT_HELP:


### PR DESCRIPTION
As part of f26953fd8b09194a34fec859be093f72471d4003, I removed all
of the defaults rather than only the printing of the removed openssl
version.

This commit readds it.