### PR TITLE
Turn off Windows debug builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,6 @@ environment:
 
 configuration:
   - release
-  - debug
 
 clone_depth: 100
 skip_tags: true


### PR DESCRIPTION
Temporary til we figure out why they are failing constantly.

Closes #3237