### PR TITLE
Turn off Debug builds for Windows on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,6 @@ environment:
 
 configuration:
   - release
-  - debug
 
 clone_depth: 100
 skip_tags: true


### PR DESCRIPTION
As Windows stdlib tests are currently failing when built in Debug mode (#3094), we are disabling these for now. Closes #3237