### PR TITLE
Dry run of running a small segment of "nightlies" on CircleCI

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  build-essential \
+  cmake \
+  g++-6 \
+  git \
+  libncurses5-dev \
+  make \
+  xz-utils \
+  zlib1g-dev \
+  python-pip \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && pip install cloudsmith-cli
+
+# add user pony in order to not run tests as root
+
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/README.md
+++ b/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/README.md
@@ -1,0 +1,21 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:x86-64-unknown-linux-gnu-nightly .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-x86-64-unknown-linux-gnu-nightly --user pony --rm -i -t ponylang/ponyc-ci:x86-64-unknown-linux-gnu-nightly bash
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:x86-64-unknown-linux-gnu-nightly
+```

--- a/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
@@ -35,15 +35,18 @@ ASSET_SUMMARY="Pony compiler"
 ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
+echo "Building ponyc installation..."
 make install prefix=${BUILD_PREFIX} default_pic=${PIC} arch=${ARCH} \
   -j${MAKE_PARALLELISM} -f Makefile-lib-llvm symlink=no use=llvm_link_static
 
 # Package it all up
+echo "Creating .tar.gz of ponyc installation..."
 pushd ${DESTINATION} || exit 1
 tar -cvzf ${ASSET_FILE} *
 popd || exit 1
 
 # Ship it off to cloudsmith
+echo "Uploading package to cloudsmith..."
 cloudsmith push raw --version "${VERSION}" --api-key ${API_KEY} \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
   ${ASSET_PATH} ${ASSET_FILE}

--- a/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+API_KEY=$1
+if [[ ${API_KEY} == "" ]]
+then
+  echo "API_KEY needs to be supplied as first script argument."
+  exit 1
+fi
+
+# Compiler target parameters
+ARCH=x86-64
+PIC=true
+
+# Triple construction
+VENDOR=unknown
+OS=linux-gnu
+TRIPLE=${ARCH}-${VENDOR}-${OS}
+
+# Build parameters
+MAKE_PARALLELISM=4
+BUILD_PREFIX=$(mktemp -d)
+DESTINATION=${BUILD_PREFIX}/lib/pony
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=ponyc-${TRIPLE}
+
+# Cloudsmith configuration
+VERSION=$(date +%Y%m%d)
+ASSET_OWNER=main-pony
+ASSET_REPO=pony-nightlies
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="Pony compiler"
+ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
+
+# Build pony installation
+make install prefix=${BUILD_PREFIX} default_pic=${PIC} arch=${ARCH} \
+  -j${MAKE_PARALLELISM} -f Makefile-lib-llvm symlink=no use=llvm_link_static
+
+# Package it all up
+pushd ${DESTINATION} || exit 1
+tar -cvzf ${ASSET_FILE} *
+popd || exit 1
+
+# Ship it off to cloudsmith
+cloudsmith push raw --version "${VERSION}" --api-key ${API_KEY} \
+  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
+  ${ASSET_PATH} ${ASSET_FILE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - image: ponylang/ponyc-ci:x86-64-unknown-linux-gnu-nightly
     steps:
       - checkout
-      - run: bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash 1cc732891a064c6542e3632a6ee281b69dbdce18
+      - run: bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash ${CLOUDSMITH_API_KEY}
 
   verify-changelog:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,13 @@ test-ci-lib-llvm: &test-ci-lib-llvm
 
 version: 2
 jobs:
+  x86-64-unknown-linux-gnu-nightly:
+    docker:
+      - image: ponylang/ponyc-ci:x86-64-unknown-linux-gnu-nightly
+    steps:
+      - checkout
+      - run: bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash 1cc732891a064c6542e3632a6ee281b69dbdce18
+
   verify-changelog:
     docker:
       - image: ponylang/changelog-tool:release
@@ -261,11 +268,23 @@ jobs:
 
 workflows:
   version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - x86-64-unknown-linux-gnu-nightly
+
   tests:
     jobs:
       # sanity tests
       - verify-changelog
       - validate-shell-scripts
+      # temp
+      - x86-64-unknown-linux-gnu-nightly
 
       # p1 tests
       - llvm-701-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,8 +283,6 @@ workflows:
       # sanity tests
       - verify-changelog
       - validate-shell-scripts
-      # temp
-      - x86-64-unknown-linux-gnu-nightly
 
       # p1 tests
       - llvm-701-release:


### PR DESCRIPTION
- This has the API Key hardcoded and public.
  It will be invalidated before this is merged and I will set up using
  an encrypted value.
- It's not putting nightlies into the "real" remote repository for them.
  Currently, its using `main-pony/ponyc-nightlies` which is a test area.
  This will also need to be updated once I know it's working.