### PR TITLE
Remove SSL from Docker images

### DIFF
--- a/.ci-dockerfiles/alpine-llvm-5/Dockerfile
+++ b/.ci-dockerfiles/alpine-llvm-5/Dockerfile
@@ -4,7 +4,6 @@ ENV LLVM_VERSION 5
 
 RUN apk add --update \
   alpine-sdk \
-  libressl-dev \
   binutils-gold \
   llvm${LLVM_VERSION} \
   llvm${LLVM_VERSION}-dev \

--- a/.ci-dockerfiles/alpine/Dockerfile
+++ b/.ci-dockerfiles/alpine/Dockerfile
@@ -2,7 +2,6 @@ FROM alpine
 
 RUN apk add --update \
   alpine-sdk \
-  libressl-dev \
   binutils-gold \
   libexecinfo-dev \
   coreutils \

--- a/.ci-dockerfiles/cross-llvm-7.0.1-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-aarch64/Dockerfile
@@ -20,16 +20,7 @@ RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPIL
  && aarch64-linux-gnu-gcc --version \
  && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_aarch64-linux-gnu.tar.xz \
  && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-aarch64-static -O /usr/bin/qemu-aarch64-static \
- && chmod +x /usr/bin/qemu-aarch64-static \
-# install libressl
- && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
- && tar -xzvf libressl-2.4.5.tar.gz \
- && cd libressl-2.4.5 \
- && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
- && make \
- && make install \
- && cd .. \
- && rm -rf libressl-2.4.5*
+ && chmod +x /usr/bin/qemu-aarch64-static
 
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-7.0.1-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-arm/Dockerfile
@@ -20,16 +20,7 @@ RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPIL
  && arm-linux-gnueabi-gcc --version \
  && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabi.tar.xz \
  && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
- && chmod +x /usr/bin/qemu-arm-static \
-# install libressl
- && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
- && tar -xzvf libressl-2.4.5.tar.gz \
- && cd libressl-2.4.5 \
- && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
- && make \
- && make install \
- && cd .. \
- && rm -rf libressl-2.4.5*
+ && chmod +x /usr/bin/qemu-arm-static
 
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-7.0.1-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-armhf/Dockerfile
@@ -20,16 +20,7 @@ RUN wget "https://releases.linaro.org/components/toolchain/binaries/6.4-${COMPIL
  && arm-linux-gnueabihf-gcc --version \
  && rm gcc-linaro-6.4.1-${COMPILER_RELEASE}-x86_64_arm-linux-gnueabihf.tar.xz \
  && wget https://github.com/multiarch/qemu-user-static/releases/download/v${QEMU_VERSION}/qemu-arm-static -O /usr/bin/qemu-arm-static \
- && chmod +x /usr/bin/qemu-arm-static \
-# install libressl
- && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
- && tar -xzvf libressl-2.4.5.tar.gz \
- && cd libressl-2.4.5 \
- && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
- && make \
- && make install \
- && cd .. \
- && rm -rf libressl-2.4.5*
+ && chmod +x /usr/bin/qemu-arm-static
 
 USER pony
 WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-llvm-7.0.1-i686/Dockerfile
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-i686/Dockerfile
@@ -26,15 +26,6 @@ RUN dpkg --add-architecture i386 \
   g++-6 \
   g++-6-multilib \
   gcc-6-multilib \
-# install libressl
- && wget "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-2.4.5.tar.gz" \
- && tar -xzvf libressl-2.4.5.tar.gz \
- && cd libressl-2.4.5 \
- && ./configure --prefix=/usr/cross --disable-asm --host="${CROSS_TRIPLE}" CC="${CROSS_CC}" CXX="${CROSS_CXX}" CFLAGS="${CROSS_CFLAGS}" LDFLAGS="${CROSS_LDFLAGS}" \
- && make \
- && make install \
- && cd .. \
- && rm -rf libressl-2.4.5* \
 # cleanup
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \

--- a/.ci-dockerfiles/ubuntu-16.04-base/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-16.04-base/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
   g++-6 \
   git \
   libncurses5-dev \
-  libssl-dev \
   make \
   wget \
   xz-utils \

--- a/.ci-dockerfiles/ubuntu-18.04-base/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-18.04-base/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
   g++-6 \
   git \
   libncurses5-dev \
-  libssl-dev \
   make \
   wget \
   xz-utils \

--- a/.ci-dockerfiles/ubuntu/Dockerfile
+++ b/.ci-dockerfiles/ubuntu/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
   g++-6 \
   git \
   libncurses5-dev \
-  libssl-dev \
   make \
   wget \
   xz-utils \

--- a/.dockerhub/alpine/Dockerfile
+++ b/.dockerhub/alpine/Dockerfile
@@ -4,7 +4,6 @@ ENV LLVM_VERSION 5
 
 RUN apk add --update --no-cache \
   alpine-sdk \
-  libressl-dev \
   binutils-gold \
   llvm${LLVM_VERSION} \
   llvm${LLVM_VERSION}-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get update \
   g++ \
   git \
   libncurses5-dev \
-  libssl-dev \
   make \
   wget \
   xz-utils \


### PR DESCRIPTION
We no longer have a dependency on SSL for building or testing Ponyc.

Closes #3240