### PR TITLE
Allow overriding of ponyc version

### DIFF
--- a/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
@@ -7,6 +7,8 @@ then
   exit 1
 fi
 
+TODAY=$(date +%Y%m%d)
+
 # Compiler target parameters
 ARCH=x86-64
 PIC=true
@@ -20,13 +22,14 @@ TRIPLE=${ARCH}-${VENDOR}-${OS}
 MAKE_PARALLELISM=4
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION="nightly-${TODAY}"
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
 PACKAGE=ponyc-${TRIPLE}
 
 # Cloudsmith configuration
-VERSION=$(date +%Y%m%d)
+CLOUDSMITH_VERSION=${TODAY}
 ASSET_OWNER=main-pony
 ASSET_REPO=pony-nightlies
 ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
@@ -37,7 +40,8 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 # Build pony installation
 echo "Building ponyc installation..."
 make install prefix=${BUILD_PREFIX} default_pic=${PIC} arch=${ARCH} \
-  -j${MAKE_PARALLELISM} -f Makefile-lib-llvm symlink=no use=llvm_link_static
+  -j${MAKE_PARALLELISM} -f Makefile-lib-llvm symlink=no use=llvm_link_static \
+  version="${PONY_VERSION}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
@@ -47,6 +51,6 @@ popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${VERSION}" --api-key ${API_KEY} \
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
   ${ASSET_PATH} ${ASSET_FILE}

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -58,10 +58,21 @@ else
   SILENT =
 endif
 
-ifneq ($(wildcard .git),)
-  tag := $(shell cat VERSION)-$(shell git rev-parse --short HEAD)
+# Default to version from `VERSION` file but allowing overridding on the
+# make command line like:
+# make version="nightly-19710702"
+# overridden version *should not* contain spaces or characters that aren't
+# legal in filesystem path names
+ifndef version
+  version := $(shell cat VERSION)
+  ifneq ($(wildcard .git),)
+    sha := $(shell git rev-parse --short HEAD)
+    tag := $(version)-$(sha)
+  else
+    tag := $(version)
+  endif
 else
-  tag := $(shell cat VERSION)
+  tag := $(version)
 endif
 
 version_str = "$(tag) [$(config)]\ncompiled with: llvm $(llvm_version) \


### PR DESCRIPTION
Nightly builds aren't particularly meaningful with a version like
0.29.0-a334234vv. The version we are telling people is in the form,
nightly-YYYYMMDD. This commit changes our setup to allow the overriding
of the version/tag that is used to identify this build and package
version. It also updates the nightly builds to take advantage of that.

We should as part of the new release process we are moving towards,
revisit the naming we use for all package builds as well as the
displayed version information. This is, however, an excellent start and
should allow us to fairly easily identify nightly releases if folks
report errors and then go get that particular version for testing.

I'm open to the idea that the displayed version should include a SHA like:

nightly-YYYYMMDD-SHA