### PR TITLE
Prepare Docker images for sending CircleCI notifications to Zulip

### DIFF
--- a/.ci-dockerfiles/alpine-llvm-5/Dockerfile
+++ b/.ci-dockerfiles/alpine-llvm-5/Dockerfile
@@ -11,7 +11,9 @@ RUN apk add --update \
   coreutils \
   linux-headers \
   zlib-dev \
-  ncurses-dev
+  ncurses-dev \
+  bash \
+  curl
 
 # add user pony in order to not run tests as root
 RUN adduser -D -s /bin/sh -h /home/pony -g root pony

--- a/.ci-dockerfiles/alpine/Dockerfile
+++ b/.ci-dockerfiles/alpine/Dockerfile
@@ -9,7 +9,9 @@ RUN apk add --update \
   cmake \
   python \
   zlib-dev \
-  ncurses-dev
+  ncurses-dev \
+  bash \
+  curl
 
 # add user pony in order to not run tests as root
 RUN adduser -D -s /bin/sh -h /home/pony -g root pony

--- a/.ci-dockerfiles/centos7-llvm-3.9.1/Dockerfile
+++ b/.ci-dockerfiles/centos7-llvm-3.9.1/Dockerfile
@@ -12,6 +12,7 @@ RUN yum install -y \
     zlib-devel \
     ncurses-devel \
     libatomic \
+    curl \
  && yum copr enable -y alonid/llvm-${LLVM_VERSION} \
  && yum install -y \
     llvm-${LLVM_VERSION} \

--- a/.ci-dockerfiles/ubuntu-16.04-base/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-16.04-base/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
   wget \
   xz-utils \
   zlib1g-dev \
+  curl \
  && apt-get remove -y llvm-6.0 \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \

--- a/.ci-dockerfiles/ubuntu-18.04-base/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-18.04-base/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
   wget \
   xz-utils \
   zlib1g-dev \
+  curl \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \
  && apt-get -y clean

--- a/.ci-dockerfiles/ubuntu/Dockerfile
+++ b/.ci-dockerfiles/ubuntu/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update \
   wget \
   xz-utils \
   zlib1g-dev \
-  python
+  python \
+  curl
 
 # install a newer cmake
 RUN wget https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.sh \

--- a/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-gnu-nightly/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
   xz-utils \
   zlib1g-dev \
   python-pip \
+  curl \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \
  && apt-get -y clean \

--- a/.dockerhub/alpine/Dockerfile
+++ b/.dockerhub/alpine/Dockerfile
@@ -13,7 +13,9 @@ RUN apk add --update --no-cache \
   cmake \
   git \
   zlib-dev \
-  ncurses-dev
+  ncurses-dev \
+  curl \
+  bash
 
 WORKDIR /src/ponyc
 COPY Makefile LICENSE VERSION /src/ponyc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
   wget \
   xz-utils \
   zlib1g-dev \
+  curl \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 DBE1D0A2" \
  && echo "deb https://dl.bintray.com/pony-language/pony-stable-debian /" | tee -a /etc/apt/sources.list \
  && apt-get update \


### PR DESCRIPTION
I'm working on adding support for sending notifications from CircleCI
to the Pony Zulip. bash and curl are required for it work.

This commit updates our Dockerfiles to assure that bash and curl are
installed.