### PR TITLE
Fix segfault due to Cycle Detector viewref inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Fix `which dtrace` path check ([PR #3229](https://github.com/ponylang/ponyc/pull/3229))
+- Fix segfault due to Cycle Detector viewref inconsistency ([PR #3254](https://github.com/ponylang/ponyc/pull/3254))
 
 ### Added
 

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -611,11 +611,11 @@ static void block(detector_t* d, pony_actor_t* actor,
   // update reference count
   view->rc = rc;
 
-  // apply any previous delta and store the new delta
+  // apply delta immediately
   if(map != NULL)
   {
-    apply_delta(d, view);
     view->delta = map;
+    apply_delta(d, view);
   }
 
   // record that we're blocked


### PR DESCRIPTION
Prior to this fix, the Cycle Detector could end up in a situation
where it would have an inconsistent viewref which would result
in a segfault with the cycle detector trying to send a message
to an actor that was already destroyed.

This commit fixes the bug by making the cycle detector apply
deltamap updates from actor block messages immediately.

resolves #2977