### PR TITLE
Remove unneeded curl installation during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,6 @@ jobs:
     docker:
       - image: ponylang/changelog-tool:release
     steps:
-      - run: apt-get update
-      - run: apt-get install -y curl
       - checkout
       - run: changelog-tool verify CHANGELOG.md
       - zulip/status:


### PR DESCRIPTION
curl is now provided in the changelog-tool:release image.

Closes #3253