### PR TITLE
Add ability to static build ponyc

### DIFF
--- a/.ci-dockerfiles/alpine-llvm-7/Dockerfile
+++ b/.ci-dockerfiles/alpine-llvm-7/Dockerfile
@@ -1,14 +1,18 @@
 FROM alpine
 
+ENV LLVM_VERSION 7
+
 RUN apk add --update \
   alpine-sdk \
   binutils-gold \
+  llvm${LLVM_VERSION} \
+  llvm${LLVM_VERSION}-dev \
+  llvm${LLVM_VERSION}-static \
   libexecinfo-dev \
   libexecinfo-static \
   coreutils \
   linux-headers \
   cmake \
-  python \
   git \
   zlib-dev \
   bash \

--- a/.ci-dockerfiles/alpine-llvm-7/README.md
+++ b/.ci-dockerfiles/alpine-llvm-7/README.md
@@ -1,0 +1,31 @@
+# Build image
+
+```bash
+docker build -t ponylang/ponyc-ci:alpine-llvm-7 .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyc-ci-alpine-llvm-7 --user pony --rm -i -t ponylang/ponyc-ci:alpine-llvm-7 /bin/sh
+```
+
+# Run CircleCI jobs locally
+
+Use the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/) to run the CI jobs using this image
+from the ponyc project root:
+
+```bash
+circleci build --job alpine-llvm-7-debug
+circleci build --job alpine-llvm-7-release
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyc-ci:alpine-llvm-7
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,18 @@ jobs:
           fail_only: true
 
   # temporary hack.. fixme
+  alpine-lib-llvm-debug-static:
+    docker:
+      - image: alpine:3.10.1
+    steps:
+      - checkout
+      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
+      - run: make -f Makefile-lib-llvm all config=debug default_pic=true staticbuild=true -j3
+      - run: make -f Makefile-lib-llvm test-ci config=debug default_pic=true staticbuild=true
+      - zulip/status:
+          fail_only: true
+
+  # temporary hack.. fixme
   alpine-llvm-7-debug-static:
     docker:
       - image: alpine:3.10.1
@@ -268,6 +280,11 @@ workflows:
           context: org-global
 
       - alpine-llvm-7-debug-static:
+          requires:
+            - lib-llvm-ubuntu-debug
+          context: org-global
+
+      - alpine-lib-llvm-debug-static:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       - image: alpine:3.10.1
     steps:
       - checkout
-      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
+      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static python coreutils linux-headers cmake git zlib-dev curl bash
       - run: make -f Makefile-lib-llvm all config=debug default_pic=true staticbuild=true -j3
       - run: make -f Makefile-lib-llvm test-ci config=debug default_pic=true staticbuild=true
       - zulip/status:
@@ -280,13 +280,13 @@ workflows:
           context: org-global
 
       - alpine-llvm-7-debug-static:
-          requires:
-            - lib-llvm-ubuntu-debug
+#          requires:
+#            - lib-llvm-ubuntu-debug
           context: org-global
 
       - alpine-lib-llvm-debug-static:
-          requires:
-            - lib-llvm-ubuntu-debug
+#          requires:
+#            - lib-llvm-ubuntu-debug
           context: org-global
 
       # p2 cross compilation tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,18 @@ jobs:
       - zulip/status:
           fail_only: true
 
+  # temporary hack.. fixme
+  alpine-llvm-7-debug-static:
+    docker:
+      - image: alpine:3.10.1
+    steps:
+      - checkout
+      - run: apk add --update alpine-sdk binutils-gold llvm7 llvm7-dev llvm7-static libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
+      - run: make LLVM_CONFIG=llvm7-config all config=debug default_pic=true staticbuild=true -j3
+      - run: make LLVM_CONFIG=llvm7-config test-ci config=debug default_pic=true staticbuild=true
+      - zulip/status:
+          fail_only: true
+
   alpine-llvm-5-debug:
     docker:
       - image: ponylang/ponyc-ci:alpine-llvm-5
@@ -251,6 +263,11 @@ workflows:
           context: org-global
 
       - alpine-llvm-5-debug:
+          requires:
+            - lib-llvm-ubuntu-debug
+          context: org-global
+
+      - alpine-llvm-7-debug-static:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,49 +51,45 @@ jobs:
       - zulip/status:
           fail_only: true
 
-  # temporary hack.. fixme
   alpine-lib-llvm-debug-static:
     docker:
-      - image: alpine:3.10.1
+      - image: ponylang/ponyc-ci:alpine
+        user: pony
     steps:
       - checkout
-      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static python coreutils linux-headers cmake git zlib-dev curl bash
       - run: make -f Makefile-lib-llvm all config=debug default_pic=true staticbuild=true -j3
       - run: make -f Makefile-lib-llvm test-ci config=debug default_pic=true staticbuild=true
       - zulip/status:
           fail_only: true
 
-  # temporary hack.. fixme
   alpine-lib-llvm-release-static:
     docker:
-      - image: alpine:3.10.1
+      - image: ponylang/ponyc-ci:alpine
+        user: pony
     steps:
       - checkout
-      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static python coreutils linux-headers cmake git zlib-dev curl bash
       - run: make -f Makefile-lib-llvm all config=release default_pic=true staticbuild=true -j3
       - run: make -f Makefile-lib-llvm test-ci config=release default_pic=true staticbuild=true
       - zulip/status:
           fail_only: true
 
-  # temporary hack.. fixme
   alpine-llvm-7-debug-static:
     docker:
-      - image: alpine:3.10.1
+      - image: ponylang/ponyc-ci:alpine-llvm-7
+        user: pony
     steps:
       - checkout
-      - run: apk add --update alpine-sdk binutils-gold llvm7 llvm7-dev llvm7-static libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
       - run: make LLVM_CONFIG=llvm7-config all config=debug default_pic=true staticbuild=true -j3
       - run: make LLVM_CONFIG=llvm7-config test-ci config=debug default_pic=true staticbuild=true
       - zulip/status:
           fail_only: true
 
-  # temporary hack.. fixme
   alpine-llvm-7-release-static:
     docker:
-      - image: alpine:3.10.1
+      - image: ponylang/ponyc-ci:alpine-llvm-7
+        user: pony
     steps:
       - checkout
-      - run: apk add --update alpine-sdk binutils-gold llvm7 llvm7-dev llvm7-static libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
       - run: make LLVM_CONFIG=llvm7-config all config=release default_pic=true staticbuild=true -j3
       - run: make LLVM_CONFIG=llvm7-config test-ci config=release default_pic=true staticbuild=true
       - zulip/status:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,18 @@ jobs:
           fail_only: true
 
   # temporary hack.. fixme
+  alpine-lib-llvm-release-static:
+    docker:
+      - image: alpine:3.10.1
+    steps:
+      - checkout
+      - run: apk add --update alpine-sdk binutils-gold libexecinfo-dev libexecinfo-static python coreutils linux-headers cmake git zlib-dev curl bash
+      - run: make -f Makefile-lib-llvm all config=release default_pic=true staticbuild=true -j3
+      - run: make -f Makefile-lib-llvm test-ci config=release default_pic=true staticbuild=true
+      - zulip/status:
+          fail_only: true
+
+  # temporary hack.. fixme
   alpine-llvm-7-debug-static:
     docker:
       - image: alpine:3.10.1
@@ -72,6 +84,18 @@ jobs:
       - run: apk add --update alpine-sdk binutils-gold llvm7 llvm7-dev llvm7-static libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
       - run: make LLVM_CONFIG=llvm7-config all config=debug default_pic=true staticbuild=true -j3
       - run: make LLVM_CONFIG=llvm7-config test-ci config=debug default_pic=true staticbuild=true
+      - zulip/status:
+          fail_only: true
+
+  # temporary hack.. fixme
+  alpine-llvm-7-release-static:
+    docker:
+      - image: alpine:3.10.1
+    steps:
+      - checkout
+      - run: apk add --update alpine-sdk binutils-gold llvm7 llvm7-dev llvm7-static libexecinfo-dev libexecinfo-static coreutils linux-headers cmake git zlib-dev curl bash
+      - run: make LLVM_CONFIG=llvm7-config all config=release default_pic=true staticbuild=true -j3
+      - run: make LLVM_CONFIG=llvm7-config test-ci config=release default_pic=true staticbuild=true
       - zulip/status:
           fail_only: true
 
@@ -280,13 +304,23 @@ workflows:
           context: org-global
 
       - alpine-llvm-7-debug-static:
-#          requires:
-#            - lib-llvm-ubuntu-debug
+          requires:
+            - lib-llvm-ubuntu-debug
+          context: org-global
+
+      - alpine-llvm-7-release-static:
+          requires:
+            - lib-llvm-ubuntu-release
           context: org-global
 
       - alpine-lib-llvm-debug-static:
-#          requires:
-#            - lib-llvm-ubuntu-debug
+          requires:
+            - lib-llvm-ubuntu-debug
+          context: org-global
+
+      - alpine-lib-llvm-release-static:
+          requires:
+            - lib-llvm-ubuntu-release
           context: org-global
 
       # p2 cross compilation tests

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -51,15 +51,17 @@ tune ?= generic
 cpu ?= $(arch)
 fpu ?=
 bits ?= $(shell getconf LONG_BIT)
-staticbuild ?= false
+static ?= false
 
 # Set static building if requested
-ifeq (true,$(staticbuild))
-  use += llvm_link_static
-else
-  ifneq (false,$(staticbuild))
-    $(error staticbuild must be true or false)
+ifdef static
+  ifeq (,$(filter $(static), true false))
+    $(error static must be true or false)
   endif
+endif
+
+ifeq ($(static),true)
+  use += llvm_link_static
 endif
 
 ifndef verbose
@@ -236,7 +238,7 @@ define USE_CHECK
 endef
 
 ifdef use
-  $(foreach useitem,$(subst $(comma),$(space),$(use)),$(eval $(call USE_CHECK,$(useitem))))
+  $(foreach useitem,$(sort $(subst $(comma),$(space),$(use))),$(eval $(call USE_CHECK,$(useitem))))
 endif
 
 ifdef config
@@ -549,7 +551,7 @@ ifneq ($(ALPINE),)
 endif
 
 # link statically
-ifeq (true,$(staticbuild))
+ifeq (true,$(static))
   libponyrt.tests.linkoptions += -static
 endif
 
@@ -573,7 +575,8 @@ ifneq ($(ALPINE),)
 endif
 
 # link statically
-#ifeq (true,$(staticbuild))
+# TODO: uncomment when this is fixed
+#ifeq (true,$(static))
 #  libponyc.tests.linkoptions += -static
 #endif
 
@@ -593,7 +596,7 @@ ifneq ($(ALPINE),)
 endif
 
 # link statically
-ifeq (true,$(staticbuild))
+ifeq (true,$(static))
   libponyc.benchmarks.linkoptions += -static
   libponyrt.benchmarks.linkoptions += -static
 endif
@@ -608,7 +611,7 @@ ifneq ($(ALPINE),)
 endif
 
 # link statically
-ifeq (true,$(staticbuild))
+ifeq (true,$(static))
   ponyc.linkoptions += -static
 endif
 
@@ -1135,7 +1138,7 @@ help:
 	@echo 'options:'
 	@echo '  arch=Name            Architecture if Name not specified then host name'
 	@echo '  default_pic=true     Make --pic the default'
-	@echo '  staticbuild=true     Link ponyc statically'
+	@echo '  static=true          Link ponyc statically'
 	@echo
 	@echo 'USE OPTIONS:'
 	@echo '   valgrind'

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -382,7 +382,7 @@ ifneq ($(MAKECMDGOALS),clean)
   llvm.include = $(shell $(loopit))
   #$(info llvm.include="$(llvm.include)")
 
-  llvm.libs    := $(shell $(LLVM_CONFIG) --libs $(LLVM_LINK_STATIC)) -lz -lncurses
+  llvm.libs    := $(shell $(LLVM_CONFIG) --libs $(LLVM_LINK_STATIC)) $(shell $(LLVM_CONFIG) --system-libs $(LLVM_LINK_STATIC))
 endif
 
 compiler_version := "$(shell $(CC) --version | sed -n 1p)"

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -573,9 +573,9 @@ ifneq ($(ALPINE),)
 endif
 
 # link statically
-ifeq (true,$(staticbuild))
-  libponyc.tests.linkoptions += -static
-endif
+#ifeq (true,$(staticbuild))
+#  libponyc.tests.linkoptions += -static
+#endif
 
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_FORMAT_MACROS

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -51,6 +51,16 @@ tune ?= generic
 cpu ?= $(arch)
 fpu ?=
 bits ?= $(shell getconf LONG_BIT)
+staticbuild ?= false
+
+# Set static building if requested
+ifeq (true,$(staticbuild))
+  use += llvm_link_static
+else
+  ifneq (false,$(staticbuild))
+    $(error staticbuild must be true or false)
+  endif
+endif
 
 ifndef verbose
   SILENT = @
@@ -538,6 +548,11 @@ ifneq ($(ALPINE),)
   libponyrt.tests.linkoptions += -lexecinfo
 endif
 
+# link statically
+ifeq (true,$(staticbuild))
+  libponyrt.tests.linkoptions += -static
+endif
+
 libponyc.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.buildoptions += -D__STDC_LIMIT_MACROS
@@ -557,6 +572,11 @@ ifneq ($(ALPINE),)
   libponyc.tests.linkoptions += -lexecinfo
 endif
 
+# link statically
+ifeq (true,$(staticbuild))
+  libponyc.tests.linkoptions += -static
+endif
+
 libponyc.benchmarks.buildoptions = -D__STDC_CONSTANT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_FORMAT_MACROS
 libponyc.benchmarks.buildoptions += -D__STDC_LIMIT_MACROS
@@ -572,6 +592,12 @@ ifneq ($(ALPINE),)
   libponyrt.benchmarks.linkoptions += -lexecinfo
 endif
 
+# link statically
+ifeq (true,$(staticbuild))
+  libponyc.benchmarks.linkoptions += -static
+  libponyrt.benchmarks.linkoptions += -static
+endif
+
 ponyc.buildoptions = $(libponyc.buildoptions)
 
 ponyc.linkoptions += -rdynamic
@@ -579,6 +605,11 @@ ponyc.linkoptions += -rdynamic
 ifneq ($(ALPINE),)
   ponyc.linkoptions += -lexecinfo
   BUILD_FLAGS += -DALPINE_LINUX
+endif
+
+# link statically
+ifeq (true,$(staticbuild))
+  ponyc.linkoptions += -static
 endif
 
 ifeq ($(OSTYPE), linux)
@@ -1104,6 +1135,7 @@ help:
 	@echo 'options:'
 	@echo '  arch=Name            Architecture if Name not specified then host name'
 	@echo '  default_pic=true     Make --pic the default'
+	@echo '  staticbuild=true     Link ponyc statically'
 	@echo
 	@echo 'USE OPTIONS:'
 	@echo '   valgrind'


### PR DESCRIPTION
* Use `llvm-config`'s `--system-libs` option
* Add option to statically link ponyc
* Add an alpine static link build

Note: This supersedes https://github.com/ponylang/ponyc/pull/3260 as it changes the hardcoded system libs for llvm to be dynamic based on whatever `llvm-config` outputs. This effectively removes the `ncurses` dependency on linux while leaving it for mac. I haven't updated the docs/dockerfiles in this PR though.

Note the second: the alpine static build for circleci is a temporary hack that needs to be fixed.