### PR TITLE
Make builds with `musl` on `glibc` systems possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Add `--link-ldcmd` command line argument for overriding the `ld` command used for linking ([PR #3259](https://github.com/ponylang/ponyc/pull/3259))
+- Make builds with `musl` on `glibc` systems possible ([PR #3263](https://github.com/ponylang/ponyc/pull/3263))
 
 ### Changed
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -50,7 +50,7 @@ typedef int SOCKET;
 #include <linux/atm.h>
 #include <linux/dn.h>
 #include <linux/rds.h>
-#ifndef ALPINE_LINUX
+#if defined(__GLIBC__)
 #include <netatalk/at.h>
 #include <netax25/ax25.h>
 #include <netax25/ax25.h>

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -5,7 +5,9 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef PLATFORM_IS_POSIX_BASED
+#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX)
 #  include <execinfo.h>
+#endif
 #  include <unistd.h>
 #else
 #  include <Windows.h>
@@ -38,6 +40,7 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   fprintf(stderr, "%s:" __zu ": %s: Assertion `%s` failed.\n\n", file, line,
     func, expr);
 
+#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX)
   void* addrs[256];
   stack_depth_t depth = backtrace(addrs, 256);
   char** strings = backtrace_symbols(addrs, depth);
@@ -55,7 +58,9 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
       "imprecise or incorrect.\nUse a debug version to get more meaningful "
       "information.\n", stderr);
   }
-
+#else
+  fputs("Backtrace functionality not available.\n", stderr);
+#endif
   fflush(stderr);
   abort();
 }


### PR DESCRIPTION
Prior to this commit building with a toolchain based on `musl`
in a `glibc` distribution (like ubuntu) would result in an error.
For these environments `execinfo.h` is not available because
`musl` doesn't include it and these distributions don't package
`libexecinfo` resulting in an error.

This commit changes things to allow the builds to succeed by
ensuring that the `socket.c` includes are only used if the
`__GLIBC__` macro is defined. It also updates `ponyassert.c` to
work around the lack of `execinfo.h` by `ifdef`'ing out the
call to `backtrace` resulting in a binary that compiles but is
not able to print a stacktrace on an assertion.