### PR TITLE
Update changelog-tool usage to match version 0.3.0 changes

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -7,7 +7,7 @@ This document is aimed at members of the Pony team who might be cutting a releas
 In order to do a release, you absolutely must have:
 
 * Commit access to the `ponyc` repo
-* The latest release of the [changelog tool](https://github.com/ponylang/changelog-tool/releases) installed
+* Verison 0.3.x of the [changelog tool](https://github.com/ponylang/changelog-tool/releases) installed
 * Access to the ponylang twitter account
 * Accounts on reddit/hacker news/lobste.rs for posting release notes
 * An account on the [Pony Zulip](https://ponylang.zulipchat.com)

--- a/release.bash
+++ b/release.bash
@@ -54,7 +54,7 @@ git checkout -b "release-$version" "$commit"
 
 # update VERSION and CHANGELOG
 update_version
-changelog-tool release CHANGELOG.md "$version" -e
+changelog-tool release "$version" -e
 
 # commit VERSION and CHANGELOG updates
 git add CHANGELOG.md VERSION
@@ -81,7 +81,7 @@ git push origin "$version"
 # update CHANGELOG for new entries
 git checkout master
 git merge "release-$version"
-changelog-tool unreleased CHANGELOG.md -e
+changelog-tool unreleased -e
 
 # check if user wants to continue
 check_for_commit_and_push


### PR DESCRIPTION
This shouldn't be merged until @Theodus reviews to make sure I got the changes in flags for changelog-tool correct and until changelog-tool 0.3.0 is released. 