### PR TITLE
Remove unnecessary argument to Map.sub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- Remove unnecessary argument to `Map.sub` ([PR #3275](https://github.com/ponylang/ponyc/pull/3275))
 
 ## [0.30.0] - 2019-07-27
 
@@ -1391,4 +1392,3 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - When using a package without a package identifier (eg. `use "foo"` as opposed to `use f = "foo"`), a `Main` type in the package will not be imported. This allows all packages to include unit tests that are run from their included `Main` actor without causing name conflicts.
 - The `for` sugar now wraps the `next()` call in a try expression that does a `continue` if an error is raised.
-

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -140,6 +140,12 @@ class iso _TestMap is UnitTest
     h.assert_eq[U32](0, c.insert_if_absent("0", 0))
     h.assert_eq[U32](0, c.insert_if_absent("0", 1))
 
+    let d = c - "a"
+    h.assert_error({() ? => d("a")? })
+
+    let e = d + ("a", 1)
+    h.assert_eq[U32](1, e("a")?)
+
 class iso _TestMapRemove is UnitTest
   fun name(): String => "collections/Map.remove"
 

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -254,9 +254,7 @@ class HashMap[K, V, H: HashFunction[K] val]
     r(key) = value
     r
 
-  fun sub[H2: HashFunction[this->K!] val = H](
-    key: this->K!,
-    value: this->V!)
+  fun sub[H2: HashFunction[this->K!] val = H](key: this->K!)
     : HashMap[this->K!, this->V!, H2]^
   =>
     """


### PR DESCRIPTION
`Map.sub` accepts a `value` argument that it never uses.