### PR TITLE
Trigger GC for actors when they tell the cycle detector they're blocked

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -1165,10 +1165,7 @@ void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
 PONY_API void pony_triggergc(pony_ctx_t* ctx)
 {
   pony_assert(ctx->current != NULL);
-
-  // only trigger gc if actor allocated something on the heap
-  if(ctx->current->heap.used > 0)
-    ctx->current->heap.next_gc = 0;
+  ctx->current->heap.next_gc = 0;
 }
 
 void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor)

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -308,6 +308,7 @@ static void send_block(pony_ctx_t* ctx, pony_actor_t* actor)
   pony_triggergc(ctx);
   try_gc(ctx, actor);
 
+
   // We're blocked, send block message.
   set_internal_flag(actor, FLAG_BLOCKED_SENT);
   set_internal_flag(actor, FLAG_CD_CONTACTED);

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -251,9 +251,9 @@ static void send_unblock(pony_actor_t* actor)
 static void send_block(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   // We're blocked, send block message.
+  pony_assert(ctx->current == actor);
   set_internal_flag(actor, FLAG_BLOCKED_SENT);
   set_internal_flag(actor, FLAG_CD_CONTACTED);
-  pony_assert(ctx->current == actor);
   ponyint_cycle_block(actor, &actor->gc);
 
   // Trigger garbage collection. GC will get run next time `try_gc` is called 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -652,7 +652,11 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 
       // Try and run GC because we're blocked and sending a block message
       // to the CD and we're past the normal point at which `try_gc` is
-      // called as part of this function
+      // called as part of this function. This will try and free any
+      // memory the actor has in its heap that wouldn't get freed otherwise
+      // until the actor is destroyed or happens to receive more work via
+      // application messages that eventually trigger a GC which may not
+      // happen for a long time (or ever).
       try_gc(ctx, actor);
     }
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -256,9 +256,8 @@ static void send_block(pony_ctx_t* ctx, pony_actor_t* actor)
   pony_assert(ctx->current == actor);
   ponyint_cycle_block(actor, &actor->gc);
 
-  // trigger a GC if we're sending a block message to the CD
-  // GC will get run next time `try_gc` is called which should
-  // happen once all messages get processed in the messageq
+  // Trigger garbage collection. GC will get run next time `try_gc` is called 
+  // which should happen once all messages get processed in the messageq
   // at the time `pony_actor_run` was called if not earlier
   // when an app message is processed
   pony_triggergc(ctx);


### PR DESCRIPTION
Prior to this commit, if an actor blocked, it did not run GC to free
any memory it no longer needed. This would result in blocked actors
holding on to (potentially lots of) memory unnecessarily.

This commit causes GC to be triggered when the cycle detector asks
an actor if it is blocked and the actor responds telling the cycle
detector that it is blocked. This should result in memory being
held by blocked actors to be freed more quickly even if the cycle
detector doesn't end up detecting a cycle and reaping the actors.

This will force a GC for an actor based on the following three things:

* The actor processed at least one message since it's last GC (i.e. it did some work [GC acquire/release message or app message)
* The actor's heap is greater than 0 (i.e. it has memory that could potentially be freed)
* The actor is blocked and is about to tell the cycle detector that it is blocked (i.e. it thinks it has no more work to do at the moment)

The sequence of events for GC'ing when sending a block message to the CD is:

1. actor gets a message from another actor
1. gets rescheduled because it processed an application message
1. next run has an empty queue (and the actor gets marked internally as blocked but doesn't send a block message to the CD)
1. some time passes and the CD eventually asks the actor if it is blocked
1. the actor garbage collects because of this change before sending the block message to the CD (to prevent race conditions)
1. the actor responds to the CD by sending a block message

This shouldn't be a performance hit because step 4 is based on how often the CD runs (not very often) along with the fact that the CD doesn't ask all actors it knows about if they're blocked on every run, it asks them in batches instead and so step 4 will not occur very frequently for any actor even if steps 1 - 3 happen regularly.