### PR TITLE
Add ability to specify maximum memory a pony program is allowed to use

### DIFF
--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -79,6 +79,7 @@ static const uint8_t sizeclass_table[HEAP_MAX / HEAP_MIN] =
 
 static size_t heap_initialgc = 1 << 14;
 static double heap_nextgc_factor = 2.0;
+static double heap_nextgc_factor_aggressive = 1.5;
 
 #ifdef USE_RUNTIMESTATS
 /** Get the total number of allocations on the heap.
@@ -391,13 +392,18 @@ void ponyint_heap_setinitialgc(size_t size)
   heap_initialgc = (size_t)1 << size;
 }
 
-void ponyint_heap_setnextgcfactor(double factor)
+void ponyint_heap_setnextgcfactor(double factor, double aggressive_factor)
 {
   if(factor < 1.0)
     factor = 1.0;
 
   DTRACE1(GC_THRESHOLD, factor);
   heap_nextgc_factor = factor;
+
+  if(aggressive_factor < 1.0)
+    aggressive_factor = 1.0;
+
+  heap_nextgc_factor_aggressive = aggressive_factor;
 }
 
 void ponyint_heap_init(heap_t* heap)
@@ -791,7 +797,11 @@ void ponyint_heap_endgc(heap_t* heap
   actor->actorstats.heap_num_allocated = num_allocated;
   actor->actorstats.heap_gc_counter++;
 #endif
-  heap->next_gc = (size_t)((double)heap->used * heap_nextgc_factor);
+
+  if(ponyint_pool_mem_pressure())
+    heap->next_gc = (size_t)((double)heap->used * heap_nextgc_factor_aggressive);
+  else
+    heap->next_gc = (size_t)((double)heap->used * heap_nextgc_factor);
 
   if(heap->next_gc < heap_initialgc)
     heap->next_gc = heap_initialgc;

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -37,7 +37,7 @@ uint32_t ponyint_heap_index(size_t size);
 
 void ponyint_heap_setinitialgc(size_t size);
 
-void ponyint_heap_setnextgcfactor(double factor);
+void ponyint_heap_setnextgcfactor(double factor, double aggr_factor);
 
 void ponyint_heap_init(heap_t* heap);
 

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -391,8 +391,7 @@ static void track_mem_allocated(size_t size)
 #define MAX_MAX_MEM_MB_ALLOWED 8589934592
 #endif
 
-#define MAX_MAX_MEM_ALLOWED (MAX_MAX_MEM_MB_ALLOWED * 1024 * 1024)
-
+#define MAX_MAX_MEM_ALLOWED ((size_t)MAX_MAX_MEM_MB_ALLOWED * (size_t)1024 * (size_t)1024)
 
 void ponyint_pool_init(size_t max_mem_mb, size_t aggr_gc_threshold_mb)
 {

--- a/src/libponyrt/mem/pool.h
+++ b/src/libponyrt/mem/pool.h
@@ -31,6 +31,8 @@ void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p);
 
 void ponyint_pool_thread_cleanup();
 
+void ponyint_pool_init(size_t max_mem);
+
 size_t ponyint_pool_index(size_t size);
 
 size_t ponyint_pool_used_size(size_t index);

--- a/src/libponyrt/mem/pool.h
+++ b/src/libponyrt/mem/pool.h
@@ -31,7 +31,9 @@ void* ponyint_pool_realloc_size(size_t old_size, size_t new_size, void* p);
 
 void ponyint_pool_thread_cleanup();
 
-void ponyint_pool_init(size_t max_mem);
+void ponyint_pool_init(size_t max_mem, size_t aggr_gc_threshold);
+
+bool ponyint_pool_mem_pressure();
 
 size_t ponyint_pool_index(size_t size);
 

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -24,6 +24,8 @@
   "  --ponynoscale    Don't scale down the scheduler threads.\n" \
   "                   See --ponymaxthreads on how to specify the number of threads\n" \
   "                   explicitly. Can't be used with --ponyminthreads.\n" \
+  "  --ponymaxmem     Maximum amount of dynamic memory allowed to be used\n" \
+  "                   (in MB).\n" \
   "  --ponysuspendthreshold\n" \
   "                   Amount of idle time before a scheduler thread suspends\n" \
   "                   itself to minimize resource consumption (max 1000 ms,\n" \

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -38,6 +38,15 @@
   "  --ponygcfactor   After GC, an actor will next be GC'd at a heap memory\n" \
   "                   usage N times its current value. This is a floating\n" \
   "                   point value. Defaults to 2.0.\n" \
+  "  --ponyaggressivegcthreshold\n" \
+  "                   Maximum amount of dynamic memory allowed to be used\n" \
+  "                   before aggressive GC factor is used (in MB). Disabled\n" \
+  "                   unless specified.\n" \
+  "  --ponyaggressivegcfactor\n" \
+  "                   After GC, an actor will next be GC'd at a heap memory\n" \
+  "                   usage N times its current value if we've hit the memory\n" \
+  "                   threshold for aggressive GC. This is a floating\n" \
+  "                   point value. Defaults to 1.5.\n" \
   "  --ponynoyield    Do not yield the CPU when no work is available.\n" \
   "  --ponynoblock    Do not send block messages to the cycle detector.\n" \
   "  --ponypin        Pin scheduler threads to CPU cores. The ASIO thread\n" \


### PR DESCRIPTION
Prior to this commit, a pony program would keep growing in terms of
memory use until the OS would be unable to allocate more virtual
memory.

This commit adds a new `--ponymaxmem` command line argument to limit
the maximum amount of dynamically allocated memory a pony program is
allowed to use before the runtime refuses to allocate any more. The
limit enforced is in MB and does not exactly match the RSS of a
process in linux due to memory allocated by the process outside of
the pony pool allocator. Additionally, GC is now triggered for actors
if the application is close to having allocated all of the memory it
is allowed and it doesn't have much free in the pool allocator itself.


--------------------------------------------------------------

The following program:

```pony
actor Main
  new create(env: Env) =>
    do_stuff()

  fun do_stuff() =>
    var i: USize = 200
    while(i > 0) do
      let z = Array[U8].init(1, 1024*1024)
      i = i - 1
    end
```

Uses about 210 MB when run:

```
vagrant@ubuntu-bionic:~/dhp2$ /usr/bin/time ./maxmemtest
0.05user 0.17system 0:00.19elapsed 111%CPU (0avgtext+0avgdata 209136maxresident)k
0inputs+0outputs (0major+51810minor)pagefaults 0swaps
```

Results in an error when limited to 100 MB with the new `--ponymaxmem` option once it tries to allocated more than it is allowed:

```
vagrant@ubuntu-bionic:~/dhp2$ /usr/bin/time ./maxmemtest --ponymaxmem 100
ERROR: Memory limit reached! Allocating 32768 would use more than 104857600 allowed!
Command terminated by signal 6
0.05user 0.08system 0:00.46elapsed 30%CPU (0avgtext+0avgdata 103672maxresident)k
0inputs+0outputs (0major+25472minor)pagefaults 0swaps
```