### PR TITLE
Improve performance of muting/unmuting logic

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -868,17 +868,15 @@ bool ponyint_triggers_muting(pony_actor_t* actor)
 
 bool ponyint_is_muted(pony_actor_t* actor)
 {
-  return (atomic_fetch_add_explicit(&actor->is_muted, 0, memory_order_relaxed) > 0);
+  return (atomic_load_explicit(&actor->is_muted, memory_order_relaxed) > 0);
 }
 
 void ponyint_mute_actor(pony_actor_t* actor)
 {
-   uint8_t is_muted = atomic_load_explicit(&actor->is_muted, memory_order_relaxed);
+   uint8_t is_muted = atomic_fetch_add_explicit(&actor->is_muted, 1, memory_order_relaxed);
    pony_assert(is_muted == 0);
    DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
-   is_muted++;
-   atomic_store_explicit(&actor->is_muted, is_muted, memory_order_relaxed);
-
+   (void)is_muted;
 }
 
 void ponyint_unmute_actor(pony_actor_t* actor)

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1301,6 +1301,9 @@ void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor)
   send_msg_all_active(from, SCHED_UNMUTE_ACTOR, (intptr_t)actor);
 }
 
+DECLARE_STACK(ponyint_actorstack, actorstack_t, pony_actor_t);
+DEFINE_STACK(ponyint_actorstack, actorstack_t, pony_actor_t);
+
 bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   size_t actors_rescheduled = 0;
@@ -1315,6 +1318,7 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
   {
     size_t i = HASHMAP_UNKNOWN;
     pony_actor_t* muted = NULL;
+    actorstack_t* needs_unmuting = NULL;
 
     // Find and collect any actors that need to be unmuted
     while((muted = ponyint_muteset_next(&mref->value, &i)) != NULL)
@@ -1328,22 +1332,32 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
       // is longer muted
       if(muted_count == 1)
       {
-        if(!has_flag(muted, FLAG_UNSCHEDULED))
-        {
-          ponyint_unmute_actor(muted);
-          // TODO: we don't want to reschedule if our queue is empty.
-          // That's wasteful.
-          ponyint_sched_add(ctx, muted);
-          DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)muted);
-          actors_rescheduled++;
-        }
-
-        ponyint_sched_start_global_unmute(ctx->scheduler->index, muted);
+        needs_unmuting = ponyint_actorstack_push(needs_unmuting, muted);
       }
     }
 
     ponyint_mutemap_removeindex(&sched->mute_mapping, index);
     ponyint_muteref_free(mref);
+
+    // Unmute any actors that need to be unmuted
+    pony_actor_t* to_unmute;
+
+    while(needs_unmuting != NULL)
+    {
+      needs_unmuting = ponyint_actorstack_pop(needs_unmuting, &to_unmute);
+
+      if(!has_flag(to_unmute, FLAG_UNSCHEDULED))
+      {
+        ponyint_unmute_actor(to_unmute);
+        // TODO: we don't want to reschedule if our queue is empty.
+        // That's wasteful.
+        ponyint_sched_add(ctx, to_unmute);
+        DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);
+        actors_rescheduled++;
+      }
+
+      ponyint_sched_start_global_unmute(ctx->scheduler->index, to_unmute);
+    }
   }
 
   return actors_rescheduled > 0;


### PR DESCRIPTION
This commit changes some of the muting/unmuting logic to improve
performance. It combines some atomic load/store pairs with single
add/sub atomic operations. It also removes an unecessary stack when
unmuting actors that may have been muted due to sending messages
to an overload or muted actor.

-------------------------------------------------------------------------

The following are some microbenchmarks to measure impact of this change. Please keep in mind that they were run on a linux virtualbox vm on windows 10 system without cpu isolation and thermal cpu scaling/throttling was enabled.

Output of running master for `message-ubench`:
```
./message-ubench.master --report-count 25
```

```
# pingers 8, report-interval 10, report-count 25, initial-pings 5
time,run-ns,rate
1566723387.255238972,999563862,14461124
1566723388.255102083,999067631,16710694
1566723389.254093746,998343965,15634037
1566723390.253951069,999087766,16886193
1566723391.252900933,998155042,16542884
1566723392.251347437,997521984,16391086
1566723393.250994912,998984701,16610290
1566723394.251271166,998883410,16090986
1566723395.250243623,998451010,15765251
1566723396.249057532,998145997,15654424
1566723397.248955181,998800270,16193356
1566723398.248113605,997828300,15646769
1566723399.247059103,998585826,13434367
1566723400.246015471,998835544,14445065
1566723401.246560227,999631967,14883959
1566723402.244838641,997656561,15055603
1566723403.244674611,998952071,15467312
1566723404.242842546,997408854,16069395
1566723405.243019588,999794245,15243844
1566723406.242800709,999410888,14936100
1566723407.241937544,998127917,13334696
1566723408.240326693,997593758,15052876
1566723409.240343167,999261564,15107548
1566723410.238885887,998174139,15041296
1566723411.238757629,999004097,15496370
```


Output of running this PR for `message-ubench`:
```
./message-ubench.muteperf --report-count 25
```

```
# pingers 8, report-interval 10, report-count 25, initial-pings 5
time,run-ns,rate
1566723412.247474527,1000216964,14999568
1566723413.246220400,998607115,17405733
1566723414.246007220,999654955,17618117
1566723415.244748877,998622698,17669181
1566723416.244255875,999410857,18476473
1566723417.243595121,998562456,16810306
1566723418.242524395,998205127,18228413
1566723419.242940268,1000282514,16980115
1566723420.241979416,998918591,16987442
1566723421.240797511,998705049,17546099
1566723422.240716097,998692474,18092376
1566723423.239171402,997594264,18738215
1566723424.239579625,1000070331,17620886
1566723425.238015729,998266851,17859697
1566723426.237655279,996601443,19341474
1566723427.236911836,998189224,19531057
1566723428.235509460,997813161,17786343
1566723429.235831128,1000237946,18076933
1566723430.234721364,998655503,17347175
1566723431.233271283,998435503,18643981
1566723432.233824335,999695410,18420653
1566723433.232523593,997883831,18904400
1566723434.231941203,999028375,18173765
1566723435.231456776,999135939,18497714
1566723436.230534868,996913704,18757261
```
