### PR TITLE
Use test-and-test-and-set for scheduler scaling logic

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -157,7 +157,8 @@ static void wake_suspended_threads(int32_t current_scheduler_id)
 #else
     // get the bool that controls modifying the active scheduler count variable
     // if using signals
-    if(!atomic_exchange_explicit(&scheduler_count_changing, true,
+    if(!atomic_load_explicit(&scheduler_count_changing, memory_order_relaxed)
+      && !atomic_exchange_explicit(&scheduler_count_changing, true,
       memory_order_acquire))
 #endif
     {
@@ -535,7 +536,8 @@ static pony_actor_t* suspend_scheduler(scheduler_t* sched,
   {
     // get the bool that controls modifying the active scheduler
     // count variable if using signals
-    if(!atomic_exchange_explicit(&scheduler_count_changing, true,
+    if(!atomic_load_explicit(&scheduler_count_changing, memory_order_relaxed)
+      && !atomic_exchange_explicit(&scheduler_count_changing, true,
       memory_order_acquire))
     {
 #endif
@@ -599,8 +601,9 @@ static pony_actor_t* perhaps_suspend_scheduler(
 #else
     // try and get the bool that controls modifying the active scheduler count
     // variable if using signals
-    && !atomic_exchange_explicit(&scheduler_count_changing, true,
-      memory_order_acquire)
+    && (!atomic_load_explicit(&scheduler_count_changing, memory_order_relaxed)
+      && !atomic_exchange_explicit(&scheduler_count_changing, true,
+      memory_order_acquire))
 #endif
     )
   {
@@ -1214,8 +1217,9 @@ void ponyint_sched_maybe_wakeup(int32_t current_scheduler_id)
 #else
     // try and get the bool that controls modifying the active scheduler count
     // variable if using signals
-    !atomic_exchange_explicit(&scheduler_count_changing, true,
-    memory_order_acquire)
+    (!atomic_load_explicit(&scheduler_count_changing, memory_order_relaxed)
+      && !atomic_exchange_explicit(&scheduler_count_changing, true,
+      memory_order_acquire))
 #endif
     )
   {


### PR DESCRIPTION
This commit switches from test-and-set to test-and-test-and-set
approach for the scheduler_count_changing atomic bool when
relying on signals for dynamic scheduler scaling because
test-and-test-and-set reduces cache line invalidations and scales
better. See the following link for more details:

https://geidav.wordpress.com/2016/03/23/test-and-set-spinlocks/