### PR TITLE
Fix redundant move in return statement error

### DIFF
--- a/src/libponyc/codegen/genjit.cc
+++ b/src/libponyc/codegen/genjit.cc
@@ -43,7 +43,7 @@ public:
         if (symbol) return symbol;
 
         auto err = symbol.takeError();
-        if (err) return std::move(err);
+        if (err) return err;
 
         auto symaddr = RTDyldMemoryManager::getSymbolAddressInProcess(name);
         if (symaddr)


### PR DESCRIPTION
Before fix:

 $ make -j12 LLVM_CFG=llvm-default.cfg default_pic=true -f Makefile-lib-llvm
 make[1]: Entering directory '/home/wink/prgs/ponylang/ponyc/lib/llvm'
 make[1]: Leaving directory '/home/wink/prgs/ponylang/ponyc/lib/llvm'
 make[1]: Entering directory '/home/wink/prgs/ponylang/ponyc'
 Building into build/release
 genjit.cc
 src/libponyc/codegen/genjit.cc: In lambda function:
 src/libponyc/codegen/genjit.cc:46:34: error: redundant move in return statement [-Werror=redundant-move]
    46 |         if (err) return std::move(err);
       |                         ~~~~~~~~~^~~~~
 src/libponyc/codegen/genjit.cc:46:34: note: remove ‘std::move’ call
 cc1plus: all warnings being treated as errors
 make[1]: *** [Makefile-ponyc:925: build/release/obj-native/libponyc/codegen/genjit.o] Error 1
 make[1]: Leaving directory '/home/wink/prgs/ponylang/ponyc'
 make: *** [Makefile-lib-llvm:33: libponyc] Error 2


After fix all is well:

 $ make -j12 LLVM_CFG=llvm-default.cfg default_pic=true -f Makefile-lib-llvm
 make[1]: Entering directory '/home/wink/prgs/ponylang/ponyc/lib/llvm'
 make[1]: Leaving directory '/home/wink/prgs/ponylang/ponyc/lib/llvm'
 make[1]: Entering directory '/home/wink/prgs/ponylang/ponyc'
 Building into build/release
 genjit.cc
 Linking libponyc
 Linking ponyc
 Linking libponyc.tests
 Linking libponyc.benchmarks
 make[1]: Leaving directory '/home/wink/prgs/ponylang/ponyc'
 wink@wink-desktop: \~/prgs/ponylang/ponyc (fix-genjig-redundant-move-error)
 $ ./build/release/ponyc examples/helloworld/
 Building builtin -> /home/wink/prgs/ponylang/ponyc/packages/builtin
 Building examples/helloworld/ -> /home/wink/prgs/ponylang/ponyc/examples/helloworld
 Generating
  Reachability
  Selector painting
  Data prototypes
  Data types
  Function prototypes
  Functions
  Descriptors
 Optimising
 Writing ./helloworld.o
 Linking ./helloworld
 wink@wink-desktop:~/prgs/ponylang/ponyc (fix-genjig-redundant-move-error)
 $ ./helloworld
 Hello, world.