### PR TITLE
Don't run PR acceptance tests on master or release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,25 +288,64 @@ workflows:
       - x86-64-unknown-linux-gnu-nightly:
           context: org-global
 
-  tests:
+  # Docker `latest` image building
+  build-latest-docker-images:
+    jobs:
+      - build-latest-alpine-docker-image:
+          context: org-global
+          filters:
+            branches:
+              only:
+                - master
+
+      - build-latest-docker-image:
+          context: org-global
+          filters:
+            branches:
+              only:
+                - master
+
+  # PR acceptance tests, shouldn't run on `master` or `release` branches
+  pr-acceptance-tests:
     jobs:
       # sanity tests
       - verify-changelog:
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+
       - validate-shell-scripts:
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - lib-llvm-ubuntu-release:
           requires:
             - verify-changelog
             - validate-shell-scripts
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - lib-llvm-ubuntu-debug:
           requires:
             - verify-changelog
             - validate-shell-scripts
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - validate-docker-image-builds:
           requires:
@@ -324,80 +363,130 @@ workflows:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - alpine-llvm-5-debug:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - alpine-llvm-7-debug-static:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - alpine-llvm-7-release-static:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - alpine-lib-llvm-debug-static:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - alpine-lib-llvm-release-static:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
-
-      # Docker `latest` image building
-      - build-latest-alpine-docker-image:
-          requires:
-            - alpine-llvm-5-release
-          context: org-global
           filters:
             branches:
-              only:
+              ignore:
                 - master
+                - release
 
-      - build-latest-docker-image:
+      - alpine-lib-llvm-release-static:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
           filters:
             branches:
-              only:
+              ignore:
                 - master
+                - release
 
       # p2 cross compilation tests
       - cross-llvm-701-release-arm:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - cross-llvm-701-debug-arm:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - cross-llvm-701-release-armhf:
           requires:
             - lib-llvm-ubuntu-release
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
       - cross-llvm-701-debug-armhf:
           requires:
             - lib-llvm-ubuntu-debug
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
 #     Currently don't pass
 #      - cross-llvm-701-release-aarch64:
 #           requires:
 #             - lib-llvm-ubuntu-release
 #           context: org-global
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#                - release
 #
 #      - cross-llvm-701-debug-aarch64:
 #           requires:
 #             - lib-llvm-ubuntu-debugS
 #           context: org-global
-
+#          filters:
+#            branches:
+#              ignore:
+#                - master
+#                - release


### PR DESCRIPTION
Almost all our CircleCI jobs are PR acceptance tests that don't need
to be run when we merge to master. It should have already been handled
when we tested the PR.