### PR TITLE
Only run CirrusCI against branches other than master and release

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,8 @@ task:
     - LLVM_CONFIG=llvm-config70 gmake all config=release -j3
     - LLVM_CONFIG=llvm-config70 gmake test-ci config=release
 
+  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_BRANCH != 'release'
+
 task:
   freebsd_instance:
     image: freebsd-12-0-release-amd64
@@ -28,6 +30,8 @@ task:
   test_script:
     - LLVM_CONFIG=llvm-config70 gmake all config=debug -j3
     - LLVM_CONFIG=llvm-config70 gmake test-ci config=debug
+
+  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_BRANCH != 'release'
 
 task:
   osx_instance:
@@ -49,6 +53,8 @@ task:
     - export LLVM_CONFIG=/opt/local/bin/llvm-config-mp-7.0
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" -j$(sysctl -n hw.ncpu) config=release all
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" config=release test-ci
+
+  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_BRANCH != 'release'
 
 task:
   osx_instance:
@@ -72,3 +78,5 @@ task:
     - export LLVM_CONFIG=/opt/local/bin/llvm-config-mp-7.0
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" -j$(sysctl -n hw.ncpu) config=debug all
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" config=debug test-ci
+
+  only_if: $CIRRUS_BRANCH != 'master' || $CIRRUS_BRANCH != 'release'


### PR DESCRIPTION
Those are special branches that we consider "not PR related" and
all the current CirrusCI tasks are for PRs only.