### PR TITLE
Build Docker release images on CircleCI

### DIFF
--- a/.ci-scripts/build-alpine-docker-images-on-release.bash
+++ b/.ci-scripts/build-alpine-docker-images-on-release.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+set -o errexit
+set -o nounset
+
+# Gather expected arguments.
+if [ $# -lt 1 ]
+then
+  echo "Tag is required"
+  exit 1
+fi
+
+# We aren't validating TAG is in our x.y.z format but we could.
+# For now, TAG validating is left up to the configuration in
+# .circleci/config.yml.
+TAG=$1
+
+# Build and push :TAG tag e.g. ponyc:0.32.1-alpine.
+DOCKER_TAG=ponylang/ponyc:"${TAG}"-alpine
+docker build --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"
+
+# Build and push "release" tag e.g. ponyc:release-alpine
+DOCKER_TAG=ponylang/ponyc:release-alpine
+docker build --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"

--- a/.ci-scripts/build-docker-images-on-release.bash
+++ b/.ci-scripts/build-docker-images-on-release.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+set -o errexit
+set -o nounset
+
+# Gather expected arguments.
+if [ $# -lt 1 ]
+then
+  echo "Tag is required"
+  exit 1
+fi
+
+# We aren't validating TAG is in our x.y.z format but we could.
+# For now, TAG validating is left up to the configuration in
+# .circleci/config.yml.
+TAG=$1
+
+# Build and push :TAG tag e.g. ponyc:0.32.1.
+DOCKER_TAG=ponylang/ponyc:"${TAG}"
+docker build --file=Dockerfile -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"
+
+# Build and push "release" tag e.g. ponyc:release
+DOCKER_TAG=ponylang/ponyc:release
+docker build --file=Dockerfile -t "${DOCKER_TAG}" .
+docker push "${DOCKER_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,28 @@ jobs:
         - zulip/status:
             fail_only: true
 
+  build-release-alpine-docker-image:
+      docker:
+        - image: ponylang/shared-docker-ci-docker-builder:20190808
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run: docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+        - run: bash build-alpine-docker-images-on-release.bash "$CIRCLE_TAG"
+        - zulip/status:
+            fail_only: true
+
+  build-release-docker-image:
+      docker:
+        - image: ponylang/shared-docker-ci-docker-builder:20190808
+      steps:
+        - checkout
+        - setup_remote_docker
+        - run: docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+        - run: bash build-docker-images-on-release.bash "$CIRCLE_TAG"
+        - zulip/status:
+            fail_only: true
+
   # Jobs for building and testing with ponyc system installed cross-llvm
   cross-llvm-701-debug-arm:
     docker:
@@ -277,7 +299,7 @@ jobs:
 
 workflows:
   version: 2.1
-  nightly:
+  build-nightlies:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -304,6 +326,28 @@ workflows:
             branches:
               only:
                 - master
+
+  # Build docker images on release
+  # We don't need to build `latest` here as there's another commit
+  # to master immediately after release gets kicked off that will pick
+  # up all the meaningful changes. Only the TAG will be missing.
+  build-release-docker-images:
+    jobs:
+      - build-latest-alpine-docker-image:
+          context: org-global
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+
+      - build-latest-docker-image:
+          context: org-global
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
 
   # PR acceptance tests, shouldn't run on `master` or `release` branches
   pr-acceptance-tests:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -12,12 +12,12 @@ In order to do a release, you absolutely must have:
 * Accounts on reddit/hacker news/lobste.rs for posting release notes
 * An account on the [Pony Zulip](https://ponylang.zulipchat.com)
 
-While not strictly required, your life will be made much easier if you:
+While not strictly required, you probably be unable to deal with any errors that arise without:
 
-* Have a [bintray account](https://bintray.com/) and have been granted access `pony-language` organization by a "release admin".
-* Have read and write access to the ponylang [travis-ci](https://travis-ci.org) account
-* Have read and write access to the ponylang [appveyor](https://www.appveyor.com) account
-* Have read and write access to the ponylang [dockerhub organization](https://hub.docker.com/u/ponylang/dashboard/)
+* A [bintray account](https://bintray.com/) and have been granted access `pony-language` organization by a "release admin".
+* Read and write access to the ponylang [travis-ci](https://travis-ci.org) account
+* Read and write access to the ponylang [circleci](https://circleci.com) account
+* Read and write access to the ponylang [appveyor](https://www.appveyor.com) account
 
 ## Prerequisites for specific releases
 
@@ -173,11 +173,11 @@ As part of every release, 6 Docker images are built:
   - release-alpine
   - 0.3.1-alpine
 
-Visit the ponylang dockerhub organization [build page](https://hub.docker.com/r/ponylang/ponyc/builds/) and verify that all 6 images were successfully built. From the time the release starts, it can take several hours for all images to be built. You can track the progress of builds on [build activity page](https://cloud.docker.com/u/ponylang/repository/docker/ponylang/ponyc/builds); scroll down to the bottom of the page to see completed, in-progress, and pending jobs.
+The images are built on [CircleCI](https://circleci.com/gh/ponylang/ponyc). You can track the progress of the builds (including failures) there. You can validate that all the images have been pushed by checking the [tag page](https://hub.docker.com/r/ponylang/ponyc/tags) of the [ponyc DockerHub repository](https://hub.docker.com/r/ponylang/ponyc/).
 
 ### Verify that the Pony Playground updated to the new version
 
-Once the dockerhub images have been updated, visit the [Pony Playground](https://playground.ponylang.io/) and verify that it has been updated to the correct version by compiling some code and checking the compiler version number in the output.
+Once the DockerHub images have been updated, visit the [Pony Playground](https://playground.ponylang.io/) and verify that it has been updated to the correct version by compiling some code and checking the compiler version number in the output.
 
 If it doesn't update automatically, it will need to be done manually. Ping @jemc, @seantallen, or @plietar.
 


### PR DESCRIPTION
Prior to this commit, we built our Docker images for each release
using DockerHub's infrastructure. This was slow and would take many
ours because:

- Builds would run sequentially
- The build server is slow and underpowered

With this commit, we will now be building on CircleCI. This allows us
a quicker process to get images built. It will also allow us to
switch to using vendored LLVM in for our Docker images.

Using vendored LLVM wasn't possible when images were built on DockerHub's
infrastructure as the build times would have been excessive (and might
have ended up timing out).