### PR TITLE
Add building a musl libc version of Pony nightly

### DIFF
--- a/.ci-scripts/x86-64-unknown-nightly-musl-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-nightly-musl-nightly.bash
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+API_KEY=$1
+if [[ ${API_KEY} == "" ]]
+then
+  echo "API_KEY needs to be supplied as first script argument."
+  exit 1
+fi
+
+TODAY=$(date +%Y%m%d)
+
+# Compiler target parameters
+ARCH=x86-64
+PIC=true
+
+# Triple construction
+VENDOR=unknown
+OS=linux-musl
+TRIPLE=${ARCH}-${VENDOR}-${OS}
+
+# Build parameters
+MAKE_PARALLELISM=4
+BUILD_PREFIX=$(mktemp -d)
+DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION="nightly-${TODAY}"
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=ponyc-${TRIPLE}
+
+# Cloudsmith configuration
+CLOUDSMITH_VERSION=${TODAY}
+ASSET_OWNER=ponylang
+ASSET_REPO=nightlies
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="Pony compiler"
+ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
+
+# Build pony installation
+echo "Building ponyc installation..."
+make install prefix=${BUILD_PREFIX} default_pic=${PIC} arch=${ARCH} \
+  -j${MAKE_PARALLELISM} -f Makefile-lib-llvm symlink=no use=llvm_link_static \
+  version="${PONY_VERSION}"
+
+# Package it all up
+echo "Creating .tar.gz of ponyc installation..."
+pushd ${DESTINATION} || exit 1
+tar -cvzf ${ASSET_FILE} *
+popd || exit 1
+
+# Ship it off to cloudsmith
+echo "Uploading package to cloudsmith..."
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
+  ${ASSET_PATH} ${ASSET_FILE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,15 @@ jobs:
       - zulip/status:
           fail_only: true
 
+  x86-64-unknown-linux-musl-nightly:
+    docker:
+      - image: ponylang/ponyc-ci:x86-64-unknown-linux-musl-nightly
+    steps:
+      - checkout
+      - run: bash .ci-scripts/x86-64-unknown-linux-musl-nightly.bash ${CLOUDSMITH_API_KEY}
+      - zulip/status:
+          fail_only: true
+
   verify-changelog:
     docker:
       - image: ponylang/changelog-tool:release
@@ -308,6 +317,8 @@ workflows:
               only: master
     jobs:
       - x86-64-unknown-linux-gnu-nightly:
+          context: org-global
+      - x86-64-unknown-linux-musl-nightly:
           context: org-global
 
   # Docker `latest` image building


### PR DESCRIPTION
At this moment, the script to run the build and upload is an almost
complete copy of the GNU version. I'm leaving the duplication for now
as we are going to have additional variations coming soon and I don't
want to "DRY" up the scripts too soon.