### PR TITLE
Renamed --ponythreads to ponymaxthreads, fixes #3318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- `--ponythreads` has been renamed to `--ponymaxthreads` ([PR #3334](https://github.com/ponylang/ponyc/pull/3334))
 - All `--pony*` options that accept a value, will be checked for minimal values ([PR #3303](https://github.com/ponylang/ponyc/pull/3317))
 
 ## [0.32.0] - 2019-09-29

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -9,16 +9,16 @@
 #define OPT_ARGS_FINISH {NULL, 0, UINT32_MAX, UINT32_MAX}
 #define PONYRT_HELP \
   "Runtime options for Pony programs (not for use with ponyc):\n" \
-  "  --ponythreads    Use N scheduler threads. Defaults to the number of\n" \
+  "  --ponymaxthreads Use N scheduler threads. Defaults to the number of\n" \
   "                   cores (not hyperthreads) available.\n" \
   "                   This can't be larger than the number of cores available.\n" \
   "  --ponyminthreads Minimum number of active scheduler threads allowed.\n" \
   "                   Defaults to 0, meaning that all scheduler threads are\n" \
   "                   allowed to be suspended when no work is available.\n" \
-  "                   This can't be larger than --ponythreads if provided,\n" \
+  "                   This can't be larger than --ponymaxthreads if provided,\n" \
   "                   or the physical cores available\n" \
   "  --ponynoscale    Don't scale down the scheduler threads.\n" \
-  "                   See --ponythreads on how to specify the number of threads\n" \
+  "                   See --ponymaxthreads on how to specify the number of threads\n" \
   "                   explicitly. Can't be used with --ponyminthreads.\n" \
   "  --ponysuspendthreshold\n" \
   "                   Amount of idle time before a scheduler thread suspends\n" \

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -53,7 +53,7 @@ static pony_language_features_init_t language_init;
 
 enum
 {
-  OPT_THREADS,
+  OPT_MAXTHREADS,
   OPT_MINTHREADS,
   OPT_NOSCALE,
   OPT_SUSPENDTHRESHOLD,
@@ -70,7 +70,7 @@ enum
 
 static opt_arg_t args[] =
 {
-  {"ponythreads", 0, OPT_ARG_REQUIRED, OPT_THREADS},
+  {"ponymaxthreads", 0, OPT_ARG_REQUIRED, OPT_MAXTHREADS},
   {"ponyminthreads", 0, OPT_ARG_REQUIRED, OPT_MINTHREADS},
   {"ponynoscale", 0, OPT_ARG_NONE, OPT_NOSCALE},
   {"ponysuspendthreshold", 0, OPT_ARG_REQUIRED, OPT_SUSPENDTHRESHOLD},
@@ -125,7 +125,7 @@ static int parse_opts(int argc, char** argv, options_t* opt)
   {
     switch(id)
     {
-      case OPT_THREADS: if(parse_uint(&opt->threads, 1, s.arg_val)) err_out(id, "can't be less than 1"); break;
+      case OPT_MAXTHREADS: if(parse_uint(&opt->threads, 1, s.arg_val)) err_out(id, "can't be less than 1"); break;
       case OPT_MINTHREADS: if(parse_uint(&opt->min_threads, 0, s.arg_val)) err_out(id, "can't be less than 0"); minthreads_set = true; break;
       case OPT_NOSCALE: opt->noscale= true; break;
       case OPT_SUSPENDTHRESHOLD: if(parse_uint(&opt->thread_suspend_threshold, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
@@ -206,13 +206,13 @@ PONY_API int pony_init(int argc, char** argv)
   }
   else if (opt.threads > ponyint_cpu_count())
   {
-    printf("Can't have --%s > physical cores, the number of threads you'd be running with (%u > %u)\n", arg_name(OPT_THREADS), opt.threads, ponyint_cpu_count());
+    printf("Can't have --%s > physical cores, the number of threads you'd be running with (%u > %u)\n", arg_name(OPT_MAXTHREADS), opt.threads, ponyint_cpu_count());
     exit(-1);
   }
 
   if (opt.min_threads > opt.threads)
   {
-    printf("Can't have --%s > --%s (%u > %u)\n", arg_name(OPT_MINTHREADS), arg_name(OPT_THREADS), opt.min_threads, opt.threads);
+    printf("Can't have --%s > --%s (%u > %u)\n", arg_name(OPT_MINTHREADS), arg_name(OPT_MAXTHREADS), opt.min_threads, opt.threads);
     exit(-1);
   }
 


### PR DESCRIPTION
I think fixes #3318 

But this also means specifying `--ponythreads` would be silently ignored: 

```
./helloworld --ponythreads=1              
Hello, world.
$ ./helloworld --ponythreads=0   
Hello, world.
$ ./helloworld --ponymaxthreads=1
Hello, world.
$ ./helloworld --ponymaxthreads=0
--ponymaxthreads can't be less than 1
```

Should we alias the two? Forbid `--ponythreads` as an option? Maybe make sure the `--pony*` "namespace" only contains "known" options? … thinking out loud