### PR TITLE
Fix building with GCC 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Building ponyc with GCC 8+ ([PR #3345](https://github.com/ponylang/ponyc/pull/3345))
 
 ### Added
 

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -151,7 +151,7 @@ static const char* generate_multi_dot_name(ast_t* ast, ast_t** def_found) {
   size_t offset = 0;
   const char* name = ast_name(temp_ast);
   size_t slen = strlen(name);
-  strncpy(buf + offset, name, slen);
+  memcpy(buf + offset, name, slen);
   offset += slen;
   temp_ast = ast_parent(temp_ast);
 
@@ -162,7 +162,7 @@ static const char* generate_multi_dot_name(ast_t* ast, ast_t** def_found) {
     temp_ast = ast_sibling(temp_ast);
     name = ast_name(temp_ast);
     slen = strlen(name);
-    strncpy(buf + offset, name, slen);
+    memcpy(buf + offset, name, slen);
     offset += slen;
     temp_ast = ast_parent(temp_ast);
   }
@@ -347,7 +347,7 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
     // Try with a leading underscore
     char* buf = (char*)ponyint_pool_alloc_size(name_len + 2);
     buf[0] = '_';
-    strncpy(buf + 1, name, name_len + 1);
+    memcpy(buf + 1, name, name_len + 1);
     const char* try_name = stringtab_consume(buf, name_len + 2);
 
     if(ast_get(ast, try_name, NULL) != NULL)

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -193,7 +193,7 @@ static const char* get_multi_ref_name(ast_t* ast)
   size_t offset = 0;
   const char* name = ast_name(temp_ast);
   size_t slen = strlen(name);
-  strncpy(buf + offset, name, slen);
+  memcpy(buf + offset, name, slen);
   offset += slen;
   temp_ast = ast_parent(temp_ast);
 
@@ -204,7 +204,7 @@ static const char* get_multi_ref_name(ast_t* ast)
     temp_ast = ast_sibling(temp_ast);
     name = ast_name(temp_ast);
     slen = strlen(name);
-    strncpy(buf + offset, name, slen);
+    memcpy(buf + offset, name, slen);
     offset += slen;
     temp_ast = ast_parent(temp_ast);
   }

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -820,7 +820,7 @@ bool handle_path_list(const char* paths, path_fn f, pass_opt_t* opt)
     } else {
       char path[FILENAME_MAX];
 
-      strncpy(path, paths, len);
+      memcpy(path, paths, len);
       path[len] = '\0';
       ok = f(path, opt) && ok;
     }


### PR DESCRIPTION
Starting with GCC 8, they added a new warning `stringops-truncation`. It
is well intentioned but, seems prone to a lot of false positives.

It found several false positives in the Pony codebase and because we treat
all warnings as errors, you can't build ponyc with GCC 8+.

This commit switches from using strncpy to memcpy. They are in the end, the
same operation except a difference in return type. However, with the new
gcc option, memcpy will not complain about not copying the null terminator.

Fixes #3313