### PR TITLE
Statically link libgcc and libstdc++ when we can

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -228,6 +228,10 @@ define USE_CHECK
   else ifeq ($1,llvm_link_static)
     ifeq (,$(LLVM_LINK_STATIC))
       LLVM_LINK_STATIC=--link-static
+      LINKER_FLAGS += -static-libstdc++
+      ifneq (,$(shell $(CC) -v 2>&1 | grep gcc))
+        LINKER_FLAGS += -static-libgcc
+      endif
       $$(info "linking llvm statically")
     else
       $$(warning LLVM_LINK_STATIC already set to '$(LLVM_LINK_STATIC)'; using pre-existing value)


### PR DESCRIPTION
It makes for a more portable Linux binary. This is safe to do if
we statically link LLVM, otherwise, it is very bad.