### PR TITLE
Stop using debug ponyc builds for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,18 +69,7 @@ jobs:
       - zulip/status:
           fail_only: true
 
-  alpine-lib-llvm-debug-static:
-    docker:
-      - image: ponylang/ponyc-ci:alpine
-        user: pony
-    steps:
-      - checkout
-      - run: make -f Makefile-lib-llvm all config=debug default_pic=true link=static -j3
-      - run: make -f Makefile-lib-llvm test-ci config=debug default_pic=true link=static
-      - zulip/status:
-          fail_only: true
-
-  alpine-lib-llvm-release-static:
+  alpine-lib-llvm:
     docker:
       - image: ponylang/ponyc-ci:alpine
         user: pony
@@ -115,25 +104,7 @@ jobs:
             fail_only: true
 
   # Jobs for building and testing with ponyc system installed cross-llvm
-  cross-llvm-701-debug-arm:
-    docker:
-      - image: ponylang/ponyc-ci:cross-llvm-7.0.1-arm
-        user: pony
-    steps:
-      - checkout
-      # build and test for x86_64 first
-      - run: make config=debug verbose=1 -j3 all
-      - run: make config=debug verbose=1 test-ci
-      # build libponyrt for target arch
-      - run: make config=debug verbose=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
-      # build ponyc for target cross compilation
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" -j3 all
-      # run tests for cross built stdlib using ponyc cross building support
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" test-cross-ci
-      - zulip/status:
-          fail_only: true
-
-  cross-llvm-701-release-arm:
+  cross-llvm-701-arm:
     docker:
       - image: ponylang/ponyc-ci:cross-llvm-7.0.1-arm
         user: pony
@@ -151,25 +122,7 @@ jobs:
       - zulip/status:
           fail_only: true
 
-  cross-llvm-701-debug-armhf:
-    docker:
-      - image: ponylang/ponyc-ci:cross-llvm-7.0.1-armhf
-        user: pony
-    steps:
-      - checkout
-      # build and test for x86_64 first
-      - run: make config=debug verbose=1 -j3 all
-      - run: make config=debug verbose=1 test-ci
-      # build libponyrt for target arch
-      - run: make config=debug verbose=1 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a tune=cortex-a9 bits=32 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
-      # build ponyc for target cross compilation
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" -j3 all
-      # run tests for cross built stdlib using ponyc cross building support
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc QEMU_RUNNER="qemu-arm-static --cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" test-cross-ci
-      - zulip/status:
-          fail_only: true
-
-  cross-llvm-701-release-armhf:
+  cross-llvm-701-armhf:
     docker:
       - image: ponylang/ponyc-ci:cross-llvm-7.0.1-armhf
         user: pony
@@ -187,25 +140,7 @@ jobs:
       - zulip/status:
           fail_only: true
 
-  cross-llvm-701-debug-aarch64:
-    docker:
-      - image: ponylang/ponyc-ci:cross-llvm-7.0.1-aarch64
-        user: pony
-    steps:
-      - checkout
-      # build and test for x86_64 first
-      - run: make config=debug verbose=1 -j3 all
-      - run: make config=debug verbose=1 test-ci
-      # build libponyrt for target arch
-      - run: make config=debug verbose=1 CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ arch=armv8-a tune=cortex-a53 bits=64 CFLAGS="-idirafter /usr/cross/include/" CXXFLAGS="-idirafter /usr/cross/include/" LDFLAGS="-idirafter /usr/cross/include/" PONYPATH=/usr/cross/lib -j3 libponyrt
-      # build ponyc for target cross compilation
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" -j3 all
-      # run tests for cross built stdlib using ponyc cross building support
-      - run: make config=debug verbose=1 PONYPATH=/usr/cross/lib cross_triple=aarch64-unknown-linux-gnu cross_arch=armv8-a cross_cpu=cortex-a53 cross_linker=aarch64-linux-gnu-gcc QEMU_RUNNER="qemu-aarch64-static --cpu cortex-a53 -L /usr/local/aarch64-linux-gnu/libc" test-cross-ci
-      - zulip/status:
-          fail_only: true
-
-  cross-llvm-701-release-aarch64:
+  cross-llvm-701-aarch64:
     docker:
       - image: ponylang/ponyc-ci:cross-llvm-7.0.1-aarch64
         user: pony
@@ -311,18 +246,7 @@ workflows:
                 - master
                 - release
 
-      # alpine
-      - alpine-lib-llvm-debug-static:
-          requires:
-            - validate-docker-image-builds
-          context: org-global
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-
-      - alpine-lib-llvm-release-static:
+      - alpine-lib-llvm:
           requires:
             - validate-docker-image-builds
           context: org-global
@@ -333,7 +257,7 @@ workflows:
                 - release
 
       # p2 cross compilation tests
-      - cross-llvm-701-release-arm:
+      - cross-llvm-701-arm:
           requires:
             - validate-docker-image-builds
           context: org-global
@@ -343,27 +267,7 @@ workflows:
                 - master
                 - release
 
-      - cross-llvm-701-debug-arm:
-          requires:
-            - validate-docker-image-builds
-          context: org-global
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-
-      - cross-llvm-701-release-armhf:
-          requires:
-            - validate-docker-image-builds
-          context: org-global
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-
-      - cross-llvm-701-debug-armhf:
+      - cross-llvm-701-armhf:
           requires:
             - validate-docker-image-builds
           context: org-global

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,12 +19,7 @@ task:
 
   test_script:
     - cd ponyc
-    - echo -e "\e[44m***** Building debug ponyc - includes building LLVM"
-    - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=debug -j8
-    - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=debug test-ci
-    - echo -e "\e[44m***** Cleaning ponyc build in prep for release build tests"
-    - make config=debug clean
-    - echo -e "\e[44m***** Building release ponyc"
+    - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release -j8
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
 
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release'
@@ -33,7 +28,8 @@ task:
   freebsd_instance:
     image: freebsd-12-0-release-amd64
 
-  name: "freebsd-12-release"
+  name: "FreeBSD 12"
+
   install_script:
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - pkg update
@@ -46,29 +42,10 @@ task:
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release'
 
 task:
-  freebsd_instance:
-    image: freebsd-12-0-release-amd64
-
-  name: "freebsd-12-debug"
-  depends_on:
-    - freebsd-12-release
-
-  install_script:
-    - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
-    - pkg update
-    - pkg install -y gmake libunwind llvm70 git
-
-  test_script:
-    - LLVM_CONFIG=llvm-config70 gmake all config=debug -j3
-    - LLVM_CONFIG=llvm-config70 gmake test-ci config=debug
-
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release'
-
-task:
   osx_instance:
     image: mojave-xcode-11.1
 
-  name: "macOS-release"
+  name: "macOS"
 
   install_script:
     - curl -o macports.pkg https://distfiles.macports.org/MacPorts/MacPorts-2.6.0-10.14-Mojave.pkg
@@ -84,30 +61,5 @@ task:
     - export LLVM_CONFIG=/opt/local/bin/llvm-config-mp-7.0
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" -j$(sysctl -n hw.ncpu) config=release all
     - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" config=release test-ci
-
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release'
-
-task:
-  osx_instance:
-    image: mojave-xcode-11.1
-
-  name: "macOS-debug"
-  depends_on:
-    - macOS-release
-
-  install_script:
-    - curl -o macports.pkg https://distfiles.macports.org/MacPorts/MacPorts-2.6.0-10.14-Mojave.pkg
-    - sudo installer -verbose -pkg macports.pkg -target /
-    - sudo /opt/local/bin/port selfupdate
-    - sudo /opt/local/bin/port install llvm-7.0
-
-  test_script:
-    - export LDFLAGS="-L/opt/local/lib"
-    - export PATH=/usr/local/opt/llvm/bin/:$PATH
-    - export CC1=clang
-    - export CXX1=clang++
-    - export LLVM_CONFIG=/opt/local/bin/llvm-config-mp-7.0
-    - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" -j$(sysctl -n hw.ncpu) config=debug all
-    - make LLVM_CONFIG="$LLVM_CONFIG" CC="$CC1" CXX="$CXX1" config=debug test-ci
 
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release'


### PR DESCRIPTION
Prior to this commit we were running the following for CI:

release build of pony that:

- built examples
- ran stdlib tests with -d
- ran stdlib tests
- ran the core tests
- validated the grammar

and for the same commit we were doing:

debug build of pony that:

- built examples
- ran stdlib tests with -d
- ran stdlib tests
- ran the core tests
- validated grammar

We decided we weren't getting much out of doing both release and debug build tests of ponyc.
This commit drops the debug ponyc builds. Note, we are still testing the standard library
with the pony specific `--debug` mode. It's only the runtime that we aren't doing debug for.