### PR TITLE
Build documentation on release

### DIFF
--- a/.ci-dockerfiles/stdlib-builder/Dockerfile
+++ b/.ci-dockerfiles/stdlib-builder/Dockerfile
@@ -1,0 +1,9 @@
+FROM ponylang/ponyc:latest
+
+RUN apt-get update \
+ && apt-get install -y \
+  python3 \
+  python3-pip \
+ && pip3 install mkdocs
+
+RUN pip3 install --user mkdocs-ponylang

--- a/.ci-dockerfiles/stdlib-builder/build-and-push.bash
+++ b/.ci-dockerfiles/stdlib-builder/build-and-push.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build -t "ponylang/ponyc-ci-stdlib-builder:latest" "${DOCKERFILE_DIR}"
+docker push "ponylang/ponyc-ci-stdlib-builder:latest"

--- a/.ci-scripts/build-and-push-stdlib-documentation.bash
+++ b/.ci-scripts/build-and-push-stdlib-documentation.bash
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+
+STDLIB_TOKEN=$1
+if [[ ${STDLIB_TOKEN} == "" ]]
+then
+  echo "STDLIB_TOKEN needs to be supplied as first script argument."
+  exit 1
+fi
+
+ponyc packages/stdlib --docs-public --pass expr
+sed -i 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
+
+echo "Uploading docs using mkdocs..."
+git remote add gh-token "https://${STDLIB_TOKEN}@github.com/ponylang/stdlib.ponylang.io"
+git fetch gh-token
+git reset gh-token/master
+pushd stdlib-docs
+mkdocs gh-deploy -v --clean --remote-name gh-token --remote-branch master
+popd

--- a/.github/workflows/publish-stdlib-documentation.yml
+++ b/.github/workflows/publish-stdlib-documentation.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    tags:
+      - \d+.\d+.\d+
+
+jobs:
+  build-and-push-stdlib-documentation:
+    name: Build and Push standard library documentation
+    runs-on: ubuntu-latest
+    container:
+      image: ponylang/ponyc-ci-stdlib-builder:latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build and push
+        run: "bash .ci-scripts/build-and-push-stdlib-documentation $STDLIB_TOKEN"
+        env:
+          STDLIB_TOKEN: ${{ secrets.STDLIB_TOKEN }}
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  build-stdlib-builder-image:
+    name: Build stdlib-builder Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash

--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -1052,9 +1052,6 @@ test-cross-ci: test-ci
 docs: all
 	$(SILENT)$(PONY_BUILD_DIR)/ponyc packages/stdlib --docs-public --pass expr
 
-docs-online: docs
-	$(SILENT)$(SED_INPLACE) 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
-
 # Note: linux only
 define EXPAND_DEPLOY
 deploy: test docs


### PR DESCRIPTION
Previously, we built the standard library documentation on release
as part of our TravisCI setup. We've since deprecated TravisCI usage.

This commit adds

- building documentation via GitHub Action on each release
- Dockerfile for image that is used for doing the building
- GitHub Action to update the stdlib-builder image daily

This commit remove

- `online-docs` Makefile rule

Although this is set to run on each release, it could be run locally
if we needed to update the documentation. I ran used the image and
script that does the building to update our documentation after the
0.33.0 release failed to build documentation due to an error on the
TravisCI side.

Closes #3362