### PR TITLE
Allow CirrusCI to run for PRs from forked repos

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,11 +10,11 @@ task:
     if [ -n "$CIRRUS_TAG" ]
     then
       echo "cloning for tag $CIRRUS_TAG"
-      git clone --depth 1 --branch "$CIRRUS_TAG" --recurse-submodules https://github.com/ponylang/ponyc.git
+      git clone --depth 1 --branch "$CIRRUS_TAG" --recurse-submodules "$CIRRUS_REPO_CLONE_URL"
     elif [ -n "$CIRRUS_BRANCH" ]
     then
       echo "cloning for branch $CIRRUS_BRANCH"
-      git clone --depth 1 --branch "$CIRRUS_BRANCH" --recurse-submodules https://github.com/ponylang/ponyc.git
+      git clone --depth 1 --branch "$CIRRUS_BRANCH" --recurse-submodules "$CIRRUS_REPO_CLONE_URL"
     fi
 
   test_script:
@@ -36,11 +36,11 @@ task:
     if [ -n "$CIRRUS_TAG" ]
     then
       echo "cloning for tag $CIRRUS_TAG"
-      git clone --depth 1 --branch "$CIRRUS_TAG" --recurse-submodules https://github.com/ponylang/ponyc.git
+      git clone --depth 1 --branch "$CIRRUS_TAG" --recurse-submodules "$CIRRUS_REPO_CLONE_URL"
     elif [ -n "$CIRRUS_BRANCH" ]
     then
       echo "cloning for branch $CIRRUS_BRANCH"
-      git clone --depth 1 --branch "$CIRRUS_BRANCH" --recurse-submodules https://github.com/ponylang/ponyc.git
+      git clone --depth 1 --branch "$CIRRUS_BRANCH" --recurse-submodules "$CIRRUS_REPO_CLONE_URL"
     fi
 
   test_script:


### PR DESCRIPTION
The custom clone script for building with Vendored LLVM was hard
coded to using the ponylang/ponyc repo. That fails when the PR
is coming from a fork.