### PR TITLE
Turn changelog-bot back on

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,0 +1,13 @@
+name: Changelog Bot
+
+on: push
+
+jobs:
+  changelog-bot:
+    runs-on: ubuntu-latest
+    name: Update CHANGELOG.md
+    steps:
+      - name: Update Changelog
+        uses: ponylang/changelog-bot-action@0.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Now version 0.0.2 instead of 0.0.1. Will now correctly work with
forked repositories.