### PR TITLE
Build latest docker images once a day

### DIFF
--- a/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+
+ENV PATH "/root/.pony/ponyup/bin:$PATH"
+
+RUN apt-get update \
+ && apt-get install -y \
+    curl
+
+RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
+ && ponyup update nightly --libc=gnu
+
+CMD ponyc

--- a/.dockerfiles/x86-64-unknown-linux-gnu/build-and-push.bash
+++ b/.dockerfiles/x86-64-unknown-linux-gnu/build-and-push.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build -t "ponylang/ponyc:latest" "${DOCKERFILE_DIR}"
+docker push "ponylang/ponyc:latest"

--- a/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.10
+
+ENV PATH "/root/.pony/ponyup/bin:$PATH"
+
+RUN apk add --update \
+    curl
+
+RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
+ && ponyup update nightly --libc=musl
+
+CMD ponyc

--- a/.dockerfiles/x86-64-unknown-linux-musl/build-and-push.bash
+++ b/.dockerfiles/x86-64-unknown-linux-musl/build-and-push.bash
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build -t "ponylang/ponyc:alpine" "${DOCKERFILE_DIR}"
+docker push "ponylang/ponyc:alpine"

--- a/.github/workflows/latest-docker-images.yml
+++ b/.github/workflows/latest-docker-images.yml
@@ -1,9 +1,8 @@
 name: Build latest Docker images
 
 on:
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: '0 5 * * *'
 
 jobs:
   build-latest-docker-image:
@@ -16,10 +15,8 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Docker build
-        run: "docker build --file=Dockerfile -t ponylang/ponyc:latest ."
-      - name: Push image to Docker Hub
-        run: "docker push ponylang/ponyc:latest"
+      - name: Build and push
+        run: bash .dockerfiles/x86-84-unknown-linux-gnu/build-and-push.bash
 
   build-latest-alpine-docker-image:
     name: Build latest Alpine based Docker image
@@ -31,7 +28,5 @@ jobs:
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      - name: Docker build
-        run: "docker build --file=.dockerhub/alpine/Dockerfile -t ponylang/ponyc:alpine ."
-      - name: Push image to Docker Hub
-        run: "docker push ponylang/ponyc:alpine"
+      - name: Build and push
+        run: bash .dockerfiles/x86-84-unknown-linux-musl/build-and-push.bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,22 @@ jobs:
       - name: Docker build
         run: "docker build --file=Dockerfile ."
 
+  validate-musl-docker-image-builds:
+    name: Validate musl Docker image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker build
+        run: "docker build --file=.dockerfiles/x86-64-unknown-linux-musl/Dockerfile ."
+
+  validate-gnu-docker-image-builds:
+    name: Validate GNU Docker image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker build
+        run: "docker build --file=.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile ."
+
   verify-changelog:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest


### PR DESCRIPTION
As part of our move to using a vendored LLVM that we build for our
ponyc releases, we decided that our Docker images should also use
the vendored LLVM.

However, building the vendored LLVM requires a lot of resources to do
in a timely fashion. None of the available Docker builder environments
are particularly effective at building.

We came together and decided that really, once a day was enough to
update the "latest" images and that using ponyup to install the most
recently nightly builds of ponyc, stable, et al seemed like a very good
approach.

This commit adds a new directory for storing our Dockerfiles that are
used for building these end user prebuilt ponyc images. I am leaving
the old files in place as they are used by both the release and latest
builds and this commit only updates the latest images to use ponyup.

A future commit will add vendored LLVM usage for building release images
and will also remove the then unused Dockerfiles.

This commit partially addresses #3142.