### PR TITLE
Fix building ponyc with clang on Ubuntu

### DIFF
--- a/Makefile-ponyc
+++ b/Makefile-ponyc
@@ -40,6 +40,28 @@ else
   endif
 endif
 
+# By default, CC is cc and CXX is g++
+# So if you use standard alternatives on many Linuxes
+# You can get clang and g++ and then bad things will happen
+ifneq (,$(shell $(CC) --version 2>&1 | grep clang))
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep "Free Software Foundation"))
+    CXX = c++
+  endif
+
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep "Free Software Foundation"))
+    $(error CC is clang but CXX is g++. They must be from matching compilers.)
+  endif
+else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep clang))
+    CXX = c++
+  endif
+
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep clang))
+    $(error CC is gcc but CXX is clang++. They must be from matching compilers.)
+  endif
+endif
+
+
 ifdef LTO_PLUGIN
   lto := yes
 endif


### PR DESCRIPTION
So Ubuntu and some other Linux distros use the "alternatives" system
to switch common system tools like cc and c++. When a distro uses this
approach, then cc and c++ are symlinks to a program that returns a
value for what compilers to actually use.

So if I want to use clang and clang++ then I can use alternatives to set
cc and c++ accordingly.

Unfortunately, GNU make sets default values for the CC and CXX macros that
do not play well with the alternatives approach.  It sets CC to cc which
plays well with alternatives, but CXX is set to g++ which doesn't.

So on ubuntu, you will get a compilation error if you use alternatives
and try to build ponyc with clang as it will end up using clang and g++.

This commit addresses the situation by checking to see if CC and CXX are
returning conflicting compilers and attempts to address.