### PR TITLE
Update for recent ponyup breaking changes

### DIFF
--- a/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
     curl
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
- && ponyup update nightly --libc=gnu
+ && ponyup update ponyc nightly --libc=gnu \
+ && ponyup update stable nightly --libc=gnu \
+ && ponyup update corral nightly --libc=gnu
 
 CMD ponyc

--- a/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --update \
     curl
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
- && ponyup update nightly --libc=musl
+ && ponyup update ponyc nightly --libc=musl \
+ && ponyup update stable nightly --libc=musl \
+ && ponyup update corral nightly --libc=musl
 
 CMD ponyc


### PR DESCRIPTION
As part of adding the ability to install release channel applications
using ponyup, the cli changed.

This commit updates for those changes.

See https://github.com/ponylang/ponyup/pull/22 for more information.

[skip ci]