### PR TITLE
Make musl latest images usable on Pony playground

### DIFF
--- a/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-musl/Dockerfile
@@ -3,7 +3,10 @@ FROM alpine:3.10
 ENV PATH "/root/.pony/ponyup/bin:$PATH"
 
 RUN apk add --update \
-    curl
+    curl \
+    build-base \
+    binutils-gold \
+    libexecinfo-dev
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc nightly --libc=musl \


### PR DESCRIPTION
You can't compile programs in the existing images due to missing
dependencies.

Closes #3389