### PR TITLE
Allow gnu latest images to be used with the Pony playground

### DIFF
--- a/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile
@@ -4,7 +4,8 @@ ENV PATH "/root/.pony/ponyup/bin:$PATH"
 
 RUN apt-get update \
  && apt-get install -y \
-    curl
+    curl \
+    g++
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc nightly --libc=gnu \


### PR DESCRIPTION
Was missing dependencies needed to build and link programs in the image.

Closes #3388