### PR TITLE
Always use most up to date base image

### DIFF
--- a/.ci-dockerfiles/cross-llvm-7.0.1-aarch64/README.md
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-aarch64/README.md
@@ -1,7 +1,7 @@
 # Build image
 
 ```bash
-docker build -t ponylang/ponyc-ci:cross-llvm-7.0.1-aarch64 .
+docker build --pull -t ponylang/ponyc-ci:cross-llvm-7.0.1-aarch64 .
 ```
 
 # Run image to test

--- a/.ci-dockerfiles/cross-llvm-7.0.1-arm/README.md
+++ b/.ci-dockerfiles/cross-llvm-7.0.1-arm/README.md
@@ -1,7 +1,7 @@
 # Build image
 
 ```bash
-docker build -t ponylang/ponyc-ci:cross-llvm-7.0.1-arm .
+docker build --pull -t ponylang/ponyc-ci:cross-llvm-7.0.1-arm .
 ```
 
 # Run image to test

--- a/.ci-dockerfiles/llvm-7.0.1/README.md
+++ b/.ci-dockerfiles/llvm-7.0.1/README.md
@@ -1,7 +1,7 @@
 # Build image
 
 ```bash
-docker build -t ponylang/ponyc-ci:llvm-7.0.1 .
+docker build --pull -t ponylang/ponyc-ci:llvm-7.0.1 .
 ```
 
 # Run image to test

--- a/.ci-dockerfiles/stdlib-builder/build-and-push.bash
+++ b/.ci-dockerfiles/stdlib-builder/build-and-push.bash
@@ -9,5 +9,5 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/ponyc-ci-stdlib-builder:latest" "${DOCKERFILE_DIR}"
+docker build --pull -t "ponylang/ponyc-ci-stdlib-builder:latest" "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc-ci-stdlib-builder:latest"

--- a/.ci-dockerfiles/ubuntu-16.04-base/README.md
+++ b/.ci-dockerfiles/ubuntu-16.04-base/README.md
@@ -5,7 +5,7 @@ This docker image is used as a base for most of the other images for testing dif
 # Build image
 
 ```bash
-docker build -t ponylang/ponyc-ci:ubuntu-16.04-base .
+docker build --pull -t ponylang/ponyc-ci:ubuntu-16.04-base .
 ```
 
 # Run image to test

--- a/.ci-dockerfiles/x86-64-unknown-linux-gnu-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-gnu-builder/build-and-push.bash
@@ -10,6 +10,6 @@ set -o nounset
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:${TODAY}" \
+docker build --pull -t "ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:${TODAY}" \
   "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:${TODAY}"

--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/build-and-push.bash
@@ -10,6 +10,6 @@ set -o nounset
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:${TODAY}" \
+docker build --pull -t "ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:${TODAY}" \
   "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:${TODAY}"

--- a/.ci-scripts/build-alpine-docker-images-on-release.bash
+++ b/.ci-scripts/build-alpine-docker-images-on-release.bash
@@ -21,10 +21,10 @@ TAG=$1
 
 # Build and push :TAG tag e.g. ponyc:0.32.1-alpine.
 DOCKER_TAG=ponylang/ponyc:"${TAG}"-alpine
-docker build --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+docker build --pull --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponyc:release-alpine
 DOCKER_TAG=ponylang/ponyc:release-alpine
-docker build --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+docker build --pull --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.ci-scripts/build-docker-images-on-release.bash
+++ b/.ci-scripts/build-docker-images-on-release.bash
@@ -21,10 +21,10 @@ TAG=$1
 
 # Build and push :TAG tag e.g. ponyc:0.32.1.
 DOCKER_TAG=ponylang/ponyc:"${TAG}"
-docker build --file=Dockerfile -t "${DOCKER_TAG}" .
+docker build --pull --file=Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponyc:release
 DOCKER_TAG=ponylang/ponyc:release
-docker build --file=Dockerfile -t "${DOCKER_TAG}" .
+docker build --pull --file=Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.dockerfiles/x86-64-unknown-linux-gnu/build-and-push.bash
+++ b/.dockerfiles/x86-64-unknown-linux-gnu/build-and-push.bash
@@ -9,5 +9,5 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/ponyc:latest" "${DOCKERFILE_DIR}"
+docker build --pull -t "ponylang/ponyc:latest" "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc:latest"

--- a/.dockerfiles/x86-64-unknown-linux-musl/build-and-push.bash
+++ b/.dockerfiles/x86-64-unknown-linux-musl/build-and-push.bash
@@ -9,5 +9,5 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build -t "ponylang/ponyc:alpine" "${DOCKERFILE_DIR}"
+docker build --pull -t "ponylang/ponyc:alpine" "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc:alpine"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --file=.dockerhub/alpine/Dockerfile ."
+        run: "docker build --pull --file=.dockerhub/alpine/Dockerfile ."
 
   validate-docker-image-builds:
     name: Validate Docker image builds
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --file=Dockerfile ."
+        run: "docker build --pull --file=Dockerfile ."
 
   validate-musl-docker-image-builds:
     name: Validate musl Docker image builds
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --file=.dockerfiles/x86-64-unknown-linux-musl/Dockerfile ."
+        run: "docker build --pull --file=.dockerfiles/x86-64-unknown-linux-musl/Dockerfile ."
 
   validate-gnu-docker-image-builds:
     name: Validate GNU Docker image builds
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --file=.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile ."
+        run: "docker build --pull --file=.dockerfiles/x86-64-unknown-linux-gnu/Dockerfile ."
 
   verify-changelog:
     name: Verify CHANGELOG is valid


### PR DESCRIPTION
Add `--pull` to all our `docker build` commands to make sure that
we aren't using a cached local version of base images if a more
recent version is available.