### PR TITLE
Update the macOS image on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ task:
 
 task:
   osx_instance:
-    image: mojave-xcode-11.1
+    image: mojave-xcode-11.2.1
 
   name: "macOS"
 


### PR DESCRIPTION
We were being auto-upgraded. This commit makes the change known
and explicit.