### PR TITLE
Trigger latest docker image builds via Cloudsmith upload

### DIFF
--- a/.github/workflows/handle-external-events.yml
+++ b/.github/workflows/handle-external-events.yml
@@ -1,11 +1,11 @@
-name: Build latest Docker images
+name: Handle external events
 
-on:
-  schedule:
-    - cron: '30 1 * * *'
+on: repository_dispatch
 
 jobs:
   build-latest-docker-image:
+    if: github.event.action == 'cloudsmith-package-synchnronised' && github.event.client_payload.data.filename == 'ponyc-x86-64-unknown-linux-gnu.tar.gz'
+
     name: Build latest Docker image
     runs-on: ubuntu-latest
     steps:
@@ -19,6 +19,8 @@ jobs:
         run: bash .dockerfiles/x86-64-unknown-linux-gnu/build-and-push.bash
 
   build-latest-alpine-docker-image:
+    if: github.event.action == 'cloudsmith-package-synchnronised' && github.event.client_payload.data.filename == 'ponyc-x86-64-unknown-linux-musl.tar.gz'
+
     name: Build latest Alpine based Docker image
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Prior to this commit, we were building our daily "latest" Docker images
at a fixed time of day. This should usually be fine as that days nightly
build should be done and uploaded by then.

However, there is no guarantee that this will be the case. It's possible
the daily build could fail or it could be delayed.

This commit changes how latest docker image builds are triggered. Instead
of daily at the same time, we trigger in response to a webhook from the
Cloudsmith "nightlies" repo on package synchronisation.