### PR TITLE
Move release image building to being trigger based

### DIFF
--- a/.ci-scripts/build-alpine-docker-images-on-release.bash
+++ b/.ci-scripts/build-alpine-docker-images-on-release.bash
@@ -1,30 +1,50 @@
 #!/bin/bash
 
-#
 # *** You should already be logged in to DockerHub when you run this ***
 #
+# Builds docker release images with two tags:
+#
+# - release-alpine
+# - X.Y.Z-alpine for example 0.32.1-alpine
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - docker
 
 set -o errexit
-set -o nounset
 
-# Gather expected arguments.
-if [ $# -lt 1 ]
-then
-  echo "Tag is required"
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the GitHub actions environment should
+# provide all of these if properly configured
+if [[ -z "${VERSION}" ]]; then
+  echo -e "\e[31mThe version number needs to be set in VERSION."
+  echo -e "\e[31mThe tag should be in the following form:"
+  echo -e "\e[31m    X.Y.Z"
+  echo -e "\e[31mExiting.\e[0m"
   exit 1
 fi
 
-# We aren't validating TAG is in our x.y.z format but we could.
-# For now, TAG validating is left up to the configuration in
-# .circleci/config.yml.
-TAG=$1
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
+  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
+  echo -e "\e[31m     ponylang/ponyup"
+  echo -e "\e[31mThis will be used as the docker image name."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
 
-# Build and push :TAG tag e.g. ponyc:0.32.1-alpine.
-DOCKER_TAG=ponylang/ponyc:"${TAG}"-alpine
-docker build --pull --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+# Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1-alpine
+DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}-alpine"
+docker build --pull --file .dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
-# Build and push "release" tag e.g. ponyc:release-alpine
-DOCKER_TAG=ponylang/ponyc:release-alpine
-docker build --pull --file=.dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
+# Build and push "release" tag e.g. ponylang/ponyup:release-alpine
+DOCKER_TAG=${GITHUB_REPOSITORY}:release-alpine
+docker build --pull --file .dockerhub/alpine/Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.ci-scripts/build-docker-images-on-release.bash
+++ b/.ci-scripts/build-docker-images-on-release.bash
@@ -1,30 +1,50 @@
 #!/bin/bash
 
-#
 # *** You should already be logged in to DockerHub when you run this ***
 #
+# Builds docker release images with two tags:
+#
+# - release
+# - X.Y.Z for example 0.32.1
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - docker
 
 set -o errexit
-set -o nounset
 
-# Gather expected arguments.
-if [ $# -lt 1 ]
-then
-  echo "Tag is required"
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the GitHub actions environment should
+# provide all of these if properly configured
+if [[ -z "${VERSION}" ]]; then
+  echo -e "\e[31mThe version number needs to be set in VERSION."
+  echo -e "\e[31mThe tag should be in the following form:"
+  echo -e "\e[31m    X.Y.Z"
+  echo -e "\e[31mExiting.\e[0m"
   exit 1
 fi
 
-# We aren't validating TAG is in our x.y.z format but we could.
-# For now, TAG validating is left up to the configuration in
-# .circleci/config.yml.
-TAG=$1
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
+  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
+  echo -e "\e[31m     ponylang/ponyup"
+  echo -e "\e[31mThis will be used as the docker image name."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
 
-# Build and push :TAG tag e.g. ponyc:0.32.1.
-DOCKER_TAG=ponylang/ponyc:"${TAG}"
-docker build --pull --file=Dockerfile -t "${DOCKER_TAG}" .
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+# Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
+DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}"
+docker build --pull --file Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
-# Build and push "release" tag e.g. ponyc:release
-DOCKER_TAG=ponylang/ponyc:release
-docker build --pull --file=Dockerfile -t "${DOCKER_TAG}" .
+# Build and push "release" tag e.g. ponylang/ponyup:release
+DOCKER_TAG=${GITHUB_REPOSITORY}:release
+docker build --pull --file Dockerfile -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,29 +22,6 @@ jobs:
       - zulip/status:
           fail_only: true
 
-  # Docker image building
-  build-release-alpine-docker-image:
-      docker:
-        - image: ponylang/shared-docker-ci-docker-builder:20190808
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run: docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-        - run: bash .ci-scripts/build-alpine-docker-images-on-release.bash "$CIRCLE_TAG"
-        - zulip/status:
-            fail_only: true
-
-  build-release-docker-image:
-      docker:
-        - image: ponylang/shared-docker-ci-docker-builder:20190808
-      steps:
-        - checkout
-        - setup_remote_docker
-        - run: docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-        - run: bash .ci-scripts/build-docker-images-on-release.bash "$CIRCLE_TAG"
-        - zulip/status:
-            fail_only: true
-
   # Jobs for building and testing with ponyc system installed cross-llvm
   cross-llvm-701-arm:
     docker:
@@ -102,28 +79,6 @@ jobs:
 
 workflows:
   version: 2.1
-
-  # Build docker images on release
-  # We don't need to build `latest` here as there's another commit
-  # to master immediately after release gets kicked off that will pick
-  # up all the meaningful changes. Only the TAG will be missing.
-  build-release-docker-images:
-    jobs:
-      - build-release-alpine-docker-image:
-          context: org-global
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
-
-      - build-release-docker-image:
-          context: org-global
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
 
   # Build release packages to upload to Cloudsmith
   build-cloudsmith-release-packages:

--- a/.github/workflows/handle-external-events.yml
+++ b/.github/workflows/handle-external-events.yml
@@ -47,3 +47,43 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Build and push
         run: bash .dockerfiles/x86-64-unknown-linux-musl/build-and-push.bash
+
+  build-release-docker-image:
+    if: |
+      github.event.action == 'cloudsmith-package-synchronised' &&
+      github.event.client_payload.data.repository == 'releases' &&
+      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-gnu.tar.gz'
+
+    name: Build latest Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash .ci-scripts/build-docker-images-on-release.bash
+        env:
+          VERSION: ${{ github.event.client_payload.data.version }}
+
+  build-release-alpine-docker-image:
+    if: |
+      github.event.action == 'cloudsmith-package-synchronised' &&
+      github.event.client_payload.data.repository == 'releases' &&
+      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-musl.tar.gz'
+
+    name: Build latest Alpine based Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash .ci-scripts/build-alpine-docker-images-on-release.bash
+        env:
+          VERSION: ${{ github.event.client_payload.data.version }}


### PR DESCRIPTION
We don't need it to be trigger based as we aren't building via Ponyup
yet, but we plan to be before the next release. If we aren't using
Ponyup to populate the images before the next release, this is still
fine and doesn't do any harm.