### PR TITLE
Move release building from CircleCI to CirrusCI

### DIFF
--- a/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
@@ -19,7 +19,7 @@ OS=linux-gnu
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters
-MAKE_PARALLELISM=4
+MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 

--- a/.ci-scripts/x86-64-unknown-linux-musl-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-musl-release.bash
@@ -19,7 +19,7 @@ OS=linux-musl
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters
-MAKE_PARALLELISM=4
+MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,24 +4,6 @@ orbs:
   zulip: ponylang/zulip@1
 
 jobs:
-  x86-64-unknown-linux-gnu-release:
-    docker:
-      - image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191105
-    steps:
-      - checkout
-      - run: bash .ci-scripts/x86-64-unknown-linux-gnu-release.bash ${CLOUDSMITH_API_KEY}
-      - zulip/status:
-          fail_only: true
-
-  x86-64-unknown-linux-musl-release:
-    docker:
-      - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191105
-    steps:
-      - checkout
-      - run: bash .ci-scripts/x86-64-unknown-linux-musl-release.bash ${CLOUDSMITH_API_KEY}
-      - zulip/status:
-          fail_only: true
-
   # Jobs for building and testing with ponyc system installed cross-llvm
   cross-llvm-701-arm:
     docker:
@@ -79,25 +61,6 @@ jobs:
 
 workflows:
   version: 2.1
-
-  # Build release packages to upload to Cloudsmith
-  build-cloudsmith-release-packages:
-    jobs:
-      - x86-64-unknown-linux-gnu-release:
-          context: org-global
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
-
-      - x86-64-unknown-linux-musl-release:
-          context: org-global
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
-              ignore: /.*/
 
   # PR acceptance tests, shouldn't run on `master` or `release` branches
   pr-acceptance-tests:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,8 @@
 #
 
 task:
+  only_if: $CIRRUS_API_CREATED == "true"
+
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191105
     cpu: 8
@@ -14,11 +16,12 @@ task:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
 
   nightly_script:
-    -  bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash ${CLOUDSMITH_API_KEY}
 
-  only_if: $CIRRUS_API_CREATED == "true"
 
 task:
+  only_if: $CIRRUS_API_CREATED == "true"
+
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191105
     cpu: 8
@@ -30,15 +33,51 @@ task:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
 
   nightly_script:
-    -  bash .ci-scripts/x86-64-unknown-linux-musl-nightly.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-linux-musl-nightly.bash ${CLOUDSMITH_API_KEY}
 
-  only_if: $CIRRUS_API_CREATED == "true"
+#
+# Release build tasks
+#
+
+task:
+  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+
+  container:
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191105
+    cpu: 8
+    memory: 24
+
+  name: "release: x86-64-unknown-linux-gnu"
+
+  environment:
+    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
+
+  release_script:
+    - bash .ci-scripts/x86-64-unknown-linux-gnu-release.bash ${CLOUDSMITH_API_KEY}
+
+task:
+  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+
+  container:
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191105
+    cpu: 8
+    memory: 24
+
+  name: "release: x86-64-unknown-linux-musl"
+
+  environment:
+    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
+
+  release_script:
+    - bash .ci-scripts/x86-64-unknown-linux-musl-release.bash ${CLOUDSMITH_API_KEY}
 
 #
 # Pull Request Tasks
 #
 
 task:
+  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
+
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191105
     cpu: 8
@@ -50,9 +89,9 @@ task:
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release -j8
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
 
+task:
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
 
-task:
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191105
     cpu: 8
@@ -64,9 +103,9 @@ task:
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release link=static -j8
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release link=static test-ci
 
+task:
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
 
-task:
   freebsd_instance:
     image: freebsd-12-0-release-amd64
     cpu: 8
@@ -83,9 +122,9 @@ task:
     - gmake -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release -j8
     - gmake -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
 
+task:
   only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
 
-task:
   osx_instance:
     image: mojave-xcode-11.2.1
 
@@ -99,5 +138,3 @@ task:
     - export CXX1=clang++
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release -j8
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
-
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"


### PR DESCRIPTION
This is almost the last job to move off of CircleCI for ponyc.
We still have library jobs, but as part of the consolidation
of new release and testing process, we are working our way down
to only using CirrusCI for the heavy lifting jobs and GitHub actions
for everything else.

This is another step in that direction.