### PR TITLE
Report errors if nightly build doesn't trigger

### DIFF
--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Start a release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-start-an-application-release:20191106
+      image: ponylang/shared-docker-ci-release:20191107
     steps:
       - uses: actions/checkout@v1
       - name: Start release process

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,6 +8,8 @@ jobs:
   trigger-nightly-builds-on-cirrusci:
     name: Trigger nightly builds on CirrusCI
     runs-on: ubuntu-latest
+    container:
+      image: ponylang/shared-docker-ci-release:20191107
     steps:
       - uses: actions/checkout@v1
       - name: Send curl request


### PR DESCRIPTION
Prior to this commit, if the curl request was sent to CirrusCI but
it didn't succeed, the build would show as green.

As of this commit, we capture the output from CirrusCI and verify
that it contains a build id. If it doesn't, we failed. On failure:

- print error
- print captured curl output
- fail the build