### PR TITLE
set workdir in Dockerfile

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -13,4 +13,6 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly
 
+WORKDIR /src/main
+
 CMD ponyc

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -14,4 +14,6 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly
 
+WORKDIR /src/main
+
 CMD ponyc

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -13,4 +13,6 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
  && ponyup update corral release \
  && ponyup update changelog-tool release
 
+WORKDIR /src/main
+
 CMD ponyc

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -14,4 +14,6 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
  && ponyup update corral release \
  && ponyup update changelog-tool release
 
+WORKDIR /src/main
+
 CMD ponyc


### PR DESCRIPTION
This should resolve https://github.com/ponylang/ponyc/issues/3411.

I was not sure if the proper fix is to update the readme to use a different docker command, or to update the Dockerfiles to use `/src/main` as workdir.

This PR sets the workdir for the Dockerfile to `/src/main`
