### PR TITLE
Ensure non-blocking process wait and correctly report process exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Fixed
 
 - Fix CommandParser incorrectly handling multiple end-of-option delimiters ([PR #3541](https://github.com/ponylang/ponyc/pull/3541))
+- Correctly report process termination status in ProcessNotify.dispose() ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
 
 ### Added
 
 
 ### Changed
 
+- Ensure that waiting on a child process when using ProcessMonitor is non-blocking ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
 
 ## [0.34.1] - 2020-05-07
 
@@ -41,8 +43,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - Let processmonitor chdir before exec ([PR #3530](https://github.com/ponylang/ponyc/pull/3530))
 - Removed unused Unsupported error from ProcessMonitor([PR #3530](https://github.com/ponylang/ponyc/pull/3530))
 - Update ProcessMonitor errors to contain error messages ([PR #3532](https://github.com/ponylang/ponyc/pull/3532))
-- Correctly report process termination status in ProcessNotify.dispose() ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
-- Ensure that waiting on a child process when using ProcessMonitor is non-blocking ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
 
 ## [0.33.2] - 2020-02-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Let processmonitor chdir before exec ([PR #3530](https://github.com/ponylang/ponyc/pull/3530))
 - Removed unused Unsupported error from ProcessMonitor([PR #3530](https://github.com/ponylang/ponyc/pull/3530))
 - Update ProcessMonitor errors to contain error messages ([PR #3532](https://github.com/ponylang/ponyc/pull/3532))
+- Correctly report process termination status in ProcessNotify.dispose() ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
+- Ensure that waiting on a child process when using ProcessMonitor is non-blocking ([PR #3419](https://github.com/ponylang/ponyc/pull/3419))
 
 ## [0.33.2] - 2020-02-03
 

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -79,6 +79,9 @@ class val Exited is (Stringable & Equatable[ProcessExitStatus])
     _exit_code = code
 
   fun exit_code(): I32 =>
+    """
+    Retrieve the exit code of the exited process.
+    """
     _exit_code
 
   fun string(): String iso^ =>
@@ -107,6 +110,9 @@ class val Signaled is (Stringable & Equatable[ProcessExitStatus])
     _signal = sig
 
   fun signal(): U32 =>
+    """
+    Retrieve the signal number that exited the process.
+    """
     _signal
 
   fun string(): String iso^ =>
@@ -292,6 +298,10 @@ class _ProcessPosix is _Process
     end
 
 primitive _WaitPidStatus
+  """
+  Pure Pony implementaton of C macros for investigating
+  the status returned by `waitpid()`.
+  """
 
   fun exited(wstatus: I32): Bool =>
     termsig(wstatus) == 0

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -61,7 +61,7 @@ primitive _StepChdir
 primitive _StepExecve
   fun apply(): U8 => 2
 
-primitive WNOHANG
+primitive _WNOHANG
   fun apply(): I32 =>
     ifdef posix then
       @ponyint_wnohang[I32]()
@@ -263,7 +263,7 @@ class _ProcessPosix is _Process
     """Only polls, does not block."""
     if pid > 0 then
       var wstatus: I32 = 0
-      let options: I32 = 0 or WNOHANG()
+      let options: I32 = 0 or _WNOHANG()
       // poll, do not block
       match @waitpid[I32](pid, addressof wstatus, options)
       | let err: I32 if err < 0 =>

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -5,6 +5,7 @@ use "collections"
 use "files"
 use "itertools"
 use "time"
+use "signals"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -619,7 +620,7 @@ class iso _TestKillLongRunningChild is UnitTest
 
         fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
           match child_exit_status
-          | Signaled(15) => h.complete(true)
+          | Signaled(Sig.term()) => h.complete(true)
           else
             h.fail("process exited with " + child_exit_status.string())
             h.complete(false)

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -67,14 +67,14 @@ class _PathResolver
 primitive _SleepCommand
   fun path(path_resolver: _PathResolver): String ? =>
     ifdef windows then
-      "C:\\Windows\\System32\\timeout.exe"
+      "C:\\Windows\\System32\\ping.exe"
     else
       path_resolver.resolve("sleep")?.path
     end
 
   fun args(seconds: USize): Array[String] val =>
     ifdef windows then
-      ["timeout"; "/t"; seconds.string(); "/nobreak"]
+      ["ping"; "127.0.0.1"; "-n"; seconds.string()]
     else
       ["sleep"; seconds.string()]
     end

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -22,17 +22,71 @@ actor Main is TestList
     test(_TestChdir)
     test(_TestBadChdir)
     test(_TestBadExec)
+    test(_TestLongRunningChild)
+    test(_TestKillLongRunningChild)
 
-primitive _CatPath
-  fun apply(): String =>
+class _PathResolver
+  let _path: Array[FilePath] val
+
+  new create(env_vars: Array[String] val, auth: AmbientAuth) =>
+    let path =
+      for env_var in env_vars.values() do
+        try
+          if env_var.find("PATH=")? == 0 then
+            let paths = Path.split_list(env_var.trim(5))
+            let size = paths.size()
+
+            break
+              recover val
+                Iter[String]((consume paths).values())
+                  .map[FilePath]({(str_path)? => FilePath(auth, str_path)? })
+                  .collect[Array[FilePath] ref](Array[FilePath](size))
+              end
+          end
+        end
+      end
+    match path
+    | let paths: Array[FilePath] val => _path = paths
+    else
+      _path = []
+    end
+
+  fun resolve(name: String): FilePath ? =>
+    for path_candidate in _path.values() do
+      try
+        let candidate = path_candidate.join(name)?
+        if candidate.exists() then
+          // TODO: check if executable for current user
+          return candidate
+        end
+      end
+    end
+    error
+
+primitive _SleepCommand
+  fun path(path_resolver: _PathResolver): String ? =>
+    ifdef windows then
+      "C:\\Windows\\System32\\timeout.exe"
+    else
+      path_resolver.resolve("sleep")?.path
+    end
+
+  fun args(seconds: USize): Array[String] val =>
+    ifdef windows then
+      ["timeout"; "/t"; seconds.string(); "/nobreak"]
+    else
+      ["sleep"; seconds.string()]
+    end
+
+primitive _CatCommand
+  fun path(path_resolver: _PathResolver): String ? =>
     ifdef windows then
       "C:\\Windows\\System32\\find.exe"
     else
-      "/bin/cat"
+      path_resolver.resolve("cat")?.path
     end
 
-primitive _CatArgs
-  fun apply(): Array[String] val =>
+  fun args(): Array[String] val =>
     ifdef windows then
       ["find"; "/v"; "\"\""]
     else
@@ -40,11 +94,11 @@ primitive _CatArgs
     end
 
 primitive _EchoPath
-  fun apply(): String =>
+  fun apply(path_resolver: _PathResolver): String ? =>
     ifdef windows then
       "C:\\Windows\\System32\\cmd.exe" // Have to use "cmd /c echo ..."
     else
-      "/bin/echo"
+      path_resolver.resolve("echo")?.path
     end
 
 primitive _BadExecPath
@@ -82,8 +136,11 @@ class iso _TestFileExecCapabilityIsRequired is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient(0, "", 1, h,
       ProcessError(CapError))
     try
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
       let path =
-        FilePath(h.env.root as AmbientAuth, _CatPath(),
+        FilePath(
+          h.env.root as AmbientAuth,
+          _CatCommand.path(path_resolver)?,
           recover val FileCaps .> all() .> unset(FileExec) end)?
       let args: Array[String] val = ["dontcare"]
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
@@ -140,7 +197,7 @@ class iso _TestNonExecutablePathResultsInExecveError is UnitTest
         end
         _cleanup()
 
-      fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
+      fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
         _h.fail("Dispose shouldn't have been called.")
         _h.complete(false)
         _cleanup()
@@ -161,8 +218,9 @@ class iso _TestStdinStdout is UnitTest
     let size: USize = input.size() + ifdef windows then 2 else 0 end
     let notifier: ProcessNotify iso = _ProcessClient(size, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, _CatPath())?
-      let args: Array[String] val = _CatArgs()
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
+      let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
@@ -198,12 +256,8 @@ class iso _TestStderr is UnitTest
     let exit_code: I32 = ifdef windows then 0 else 1 end
     let notifier: ProcessNotify iso = _ProcessClient(0, errmsg, exit_code, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth,
-        ifdef windows then
-          "C:\\Windows\\System32\\cmd.exe"
-        else
-          _CatPath()
-        end)?
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
       let args: Array[String] val = ifdef windows then
         ["cmd"; "/c"; "\"(echo message-to-stderr)1>&2\""]
       else
@@ -252,20 +306,26 @@ class iso _TestExpect is UnitTest
           process.expect(if _expect == 2 then 4 else 2 end)
           _out.push(String.from_array(consume data))
 
-        fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
-          _h.assert_eq[I32](child_exit_code, 0)
-          let expected: Array[String] val = ifdef windows then
-            ["he"; "llo "; "ca"; "rl \r"]
+        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
+          match child_exit_status
+          | Exited(0) =>
+            let expected: Array[String] val = ifdef windows then
+              ["he"; "llo "; "ca"; "rl \r"]
+            else
+              ["he"; "llo "; "th"; "ere!"]
+            end
+            _h.assert_array_eq[String](_out, expected)
+            _h.complete(true)
           else
-            ["he"; "llo "; "th"; "ere!"]
+            _h.fail("child exited with: " + child_exit_status.string())
+            _h.complete(false)
           end
-          _h.assert_array_eq[String](_out, expected)
-          _h.complete(true)
       end
     end
 
     try
-      let path = FilePath(h.env.root as AmbientAuth, _EchoPath())?
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _EchoPath(path_resolver)?)?
       let args: Array[String] val = ifdef windows then
         ["cmd"; "/c"; "echo"; "hello carl"]
       else
@@ -297,8 +357,9 @@ class iso _TestWritevOrdering is UnitTest
     let expected: USize = ifdef windows then 13 else 11 end
     let notifier: ProcessNotify iso = _ProcessClient(expected, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, _CatPath())?
-      let args: Array[String] val = _CatArgs()
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
+      let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
@@ -328,8 +389,9 @@ class iso _TestPrintvOrdering is UnitTest
     let expected: USize = ifdef windows then 17 else 14 end
     let notifier: ProcessNotify iso = _ProcessClient(expected, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, _CatPath())?
-      let args: Array[String] val = _CatArgs()
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
+      let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       let auth = h.env.root as AmbientAuth
@@ -369,8 +431,9 @@ class iso _TestStdinWriteBuf is UnitTest
 
     let notifier: ProcessNotify iso = _ProcessClient(out_size, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, _CatPath())?
-      let args: Array[String] val = _CatArgs()
+      let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
+      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
+      let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       // fork the child process and attach a ProcessMonitor
@@ -487,6 +550,101 @@ class _TestBadExec is UnitTest
       h.fail("Could not create FilePath!")
     end
 
+class iso _TestLongRunningChild is UnitTest
+  fun name(): String => "process/long-running-child"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper)? =>
+    let auth = h.env.root as AmbientAuth
+    let notifier =
+      object iso is ProcessNotify
+        fun ref created(process: ProcessMonitor ref) =>
+          h.log("created")
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          match err
+          | ExecveError => h.log("execve-error")
+          | ForkError => h.log("fork-error")
+          | PipeError => h.log("pipe-error")
+          | WaitpidError => h.log("waitpid-error")
+          | WriteError => h.log("write-error")
+          | CapError => h.log("cap-error")
+          end
+          h.fail("process failed.")
+
+        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
+          match child_exit_status
+          | Exited(0) => h.complete(true)
+          else
+            h.fail("process exited with " + child_exit_status.string())
+          end
+      end
+
+    try
+      let path_resolver = _PathResolver(h.env.vars, auth)
+      let path = FilePath(auth, _SleepCommand.path(path_resolver)?)?
+      h.log(path.path)
+      let args = _SleepCommand.args(where seconds = 2)
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      let pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
+      pm.done_writing()
+      h.dispose_when_done(pm)
+      h.long_test(5_000_000_000)
+    else
+      h.fail("failed to set up calling sleep/timeout.")
+    end
+
+
+  fun timed_out(h: TestHelper) =>
+    h.complete(false)
+
+class iso _TestKillLongRunningChild is UnitTest
+  fun name(): String => "process/kill-long-running-child"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper)? =>
+    let auth = h.env.root as AmbientAuth
+    let notifier =
+      object iso is ProcessNotify
+        fun ref created(process: ProcessMonitor ref) =>
+          h.log("created")
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          match err
+          | ExecveError => h.log("execve-error")
+          | ForkError => h.log("fork-error")
+          | PipeError => h.log("pipe-error")
+          | WaitpidError => h.log("waitpid-error")
+          | WriteError => h.log("write-error")
+          | CapError => h.log("cap-error")
+          end
+          h.fail("process failed.")
+
+        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
+          match child_exit_status
+          | Signaled(15) => h.complete(true)
+          else
+            h.fail("process exited with " + child_exit_status.string())
+            h.complete(false)
+          end
+      end
+
+    try
+      let path_resolver = _PathResolver(h.env.vars, auth)
+      let path = FilePath(auth, _SleepCommand.path(path_resolver)?)?
+      h.log(path.path)
+      let args = _SleepCommand.args(where seconds = 2)
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      let pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
+      pm.dispose()
+      pm.done_writing()
+      h.long_test(3_000_000_000)
+    else
+      h.fail("failed to set up calling sleep/timeout.")
+    end
+
+  fun timed_out(h: TestHelper) =>
+    h.complete(false)
+
+
 class _ProcessClient is ProcessNotify
   """
   Notifications for Process connections.
@@ -555,13 +713,20 @@ class _ProcessClient is ProcessNotify
       _h.fail(actual.string())
     end
 
-  fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
+  fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
     """
     Called when ProcessMonitor terminates to cleanup ProcessNotify
     We receive the exit code of the child process from ProcessMonitor.
     """
     let last_data: U64 = Time.nanos()
-    _h.log("dispose: child exit code: " + child_exit_code.string())
+    match child_exit_status
+    | let e: Exited =>
+      _h.log("dispose: child exit code: " + e.exit_code().string())
+      _h.assert_eq[I32](_exit_code, e.exit_code())
+    | let s: Signaled =>
+      _h.log("dispose: child terminated by signal: " + s.signal().string())
+      _h.fail("didn't expect that.")
+    end
     _h.log("dispose: stdout: " + _d_stdout_chars.string() + " bytes")
     _h.log("dispose: stderr: '" + _d_stderr + "'")
     if (_first_data > 0) then
@@ -576,5 +741,4 @@ class _ProcessClient is ProcessNotify
     _h.assert_eq[USize](_out, _d_stdout_chars)
     _h.assert_eq[USize](_err.size(), _d_stderr.size())
     _h.assert_eq[String box](_err, _d_stderr)
-    _h.assert_eq[I32](_exit_code, child_exit_code)
     _h.complete(true)

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -258,7 +258,13 @@ class iso _TestStderr is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient(0, errmsg, exit_code, h)
     try
       let path_resolver = _PathResolver(h.env.vars, h.env.root as AmbientAuth)
-      let path = FilePath(h.env.root as AmbientAuth, _CatCommand.path(path_resolver)?)?
+      let path = FilePath(
+        h.env.root as AmbientAuth, 
+        ifdef windows then
+          "C:\\Windows\\System32\\cmd.exe"
+        else
+          _CatCommand.path(path_resolver)?
+        end)?
       let args: Array[String] val = ifdef windows then
         ["cmd"; "/c"; "\"(echo message-to-stderr)1>&2\""]
       else

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -567,14 +567,7 @@ class iso _TestLongRunningChild is UnitTest
           h.log("[STDERR] " + recover val String.from_iso_array(consume data) end)
 
         fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-          match err
-          | ExecveError => h.log("execve-error")
-          | ForkError => h.log("fork-error")
-          | PipeError => h.log("pipe-error")
-          | WaitpidError => h.log("waitpid-error")
-          | WriteError => h.log("write-error")
-          | CapError => h.log("cap-error")
-          end
+          h.log(err.string())
           h.fail("process failed.")
 
         fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
@@ -620,14 +613,7 @@ class iso _TestKillLongRunningChild is UnitTest
           h.log("[STDERR] " + recover val String.from_iso_array(consume data) end)
 
         fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-          match err
-          | ExecveError => h.log("execve-error")
-          | ForkError => h.log("fork-error")
-          | PipeError => h.log("pipe-error")
-          | WaitpidError => h.log("waitpid-error")
-          | WriteError => h.log("write-error")
-          | CapError => h.log("cap-error")
-          end
+          h.log(err.string())
           h.fail("process failed.")
 
         fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>

--- a/packages/process/_test.sh
+++ b/packages/process/_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/please-dont-exist
+
+true

--- a/packages/process/_test.sh
+++ b/packages/process/_test.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/please-dont-exist
-
-true

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -58,26 +58,44 @@ class ProcessClient is ProcessNotify
   fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
     _env.out.print(err.string())
 
-  fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
+  fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
     let code: I32 = consume child_exit_code
-    _env.out.print("Child exit code: " + code.string())
+    match child_exit_status
+    | let exited: Exited =>
+      _env.out.print("Child exit code: " + exited.exit_code().string())
+    | let signaled: Signaled =>
+      _env.out.print("Child terminated by signal: " + signaled.signal().string())
+    end
 ```
 
 ## Process portability
 
-The ProcessMonitor supports spawning processes on Linux, FreeBSD and OSX.
-Processes are not supported on Windows and attempting to use them will cause
-a runtime error.
+The ProcessMonitor supports spawning processes on Linux, FreeBSD, OSX and Windows.
 
 ## Shutting down ProcessMonitor and external process
 
-Document waitpid behaviour (stops world)
+When a process is spawned using ProcessMonitor, and it is not necessart to communicating with it any further
+using `stdin` and `stdout` or `stderr`, calling [done_writing()](process-ProcessMonitor.md#done_writing)
+will close stdin to the child process. Processes expecting input will be notified of an `EOF` on their `stdin`
+and will terminate.
+
+If a running program needs to be canceled and the [ProcessMonitor](process-ProcessMonitor.md) should be shut down,
+calling [dispose](process-ProcessMonitor.md#dispose) will terminate the child
+process and clean up all resources.
+
+Once the child process is detected to be closed, the process exit status is retrieved and
+[ProcessNotify.dispose](process-ProcessNotify.md#dispose) is called.
+
+This can be either an instance of [Exited](process-Exited.md) containing
+the process exit code in case the program exited on its own,
+or (only on posix systems like linux, osx or bsd) an instance of [Signaled](process-Signaled.md) containing the signal number that terminated the process.
 
 """
 use "backpressure"
 use "collections"
 use "files"
 use "time"
+
 
 type ProcessMonitorAuth is (AmbientAuth | StartProcessAuth)
 
@@ -347,12 +365,11 @@ actor ProcessMonitor
       // TODO: make polling interval configurable
       let timer = Timer(consume tn, 100_000_000, 100_000_000)
       timers(consume timer)
-    | let ec: _ExitCode =>
-      // process child exit code
-      _notifier.dispose(this, ec.code)
+    | let exit_status: ProcessExitStatus =>
+      // process child exit code or termination signal
+      _notifier.dispose(this, exit_status)
       _dispose_timers()
     | let wpe: _WaitPidError =>
-      @printf[None]("wait errored with code: ".cstring(), wpe.error_code.string().cstring())
       _notifier.failed(this, ProcessError(WaitpidError))
       _dispose_timers()
     end

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -132,7 +132,7 @@ actor ProcessMonitor
     filepath: FilePath,
     args: Array[String] val,
     vars: Array[String] val,
-    wdir: (FilePath | None) = None),
+    wdir: (FilePath | None) = None,
     process_poll_interval: U64 = Nanos.from_millis(100))
   =>
     """

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -74,10 +74,10 @@ The ProcessMonitor supports spawning processes on Linux, FreeBSD, OSX and Window
 
 ## Shutting down ProcessMonitor and external process
 
-When a process is spawned using ProcessMonitor, and it is not necessart to communicating with it any further
+When a process is spawned using ProcessMonitor, and it is not necessary to communicate to it any further
 using `stdin` and `stdout` or `stderr`, calling [done_writing()](process-ProcessMonitor.md#done_writing)
 will close stdin to the child process. Processes expecting input will be notified of an `EOF` on their `stdin`
-and will terminate.
+and can terminate.
 
 If a running program needs to be canceled and the [ProcessMonitor](process-ProcessMonitor.md) should be shut down,
 calling [dispose](process-ProcessMonitor.md#dispose) will terminate the child
@@ -86,7 +86,7 @@ process and clean up all resources.
 Once the child process is detected to be closed, the process exit status is retrieved and
 [ProcessNotify.dispose](process-ProcessNotify.md#dispose) is called.
 
-This can be either an instance of [Exited](process-Exited.md) containing
+The process exit status can be either an instance of [Exited](process-Exited.md) containing
 the process exit code in case the program exited on its own,
 or (only on posix systems like linux, osx or bsd) an instance of [Signaled](process-Signaled.md) containing the signal number that terminated the process.
 
@@ -365,7 +365,6 @@ actor ProcessMonitor
             pm._wait_for_child()
             true
         end
-      // TODO: make polling interval configurable
       let timer = Timer(consume tn, _process_poll_interval, _process_poll_interval)
       timers(consume timer)
     | let exit_status: ProcessExitStatus =>

--- a/packages/process/process_notify.pony
+++ b/packages/process/process_notify.pony
@@ -34,8 +34,14 @@ interface ProcessNotify
     """
     qty
 
-  fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
+  fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
     """
     Call when ProcessMonitor terminates to cleanup ProcessNotify.
-    We return the exit code of the child process.
+    We return the exit status of the child process, it can be either an instance of
+    [Exited](process-Exited.md) if the process finished. The childs exit code can be retrieved
+    using [Exited.exit_code()](process-Exited.md#exit_code).
+
+    On Posix systems, if the process has been killed by a signal (e.g. through the `kill` command),
+    `child_exit_status` will be an instance of [Signaled](process-Signaled.md) with the signal number
+    that terminated the process available via [Signaled.signal()](process-Signaled.md#signal).
     """

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -22,6 +22,7 @@ set(_c_src
     gc/serialise.c
     gc/trace.c
     lang/directory.c
+    lang/errno.c
     lang/io.c
     lang/lsda.c
     lang/paths.c

--- a/src/libponyrt/lang/directory.c
+++ b/src/libponyrt/lang/directory.c
@@ -28,16 +28,6 @@ PONY_API int pony_os_eexist()
   return EEXIST;
 }
 
-PONY_API void pony_os_clear_errno()
-{
-  errno = 0;
-}
-
-PONY_API int pony_os_errno()
-{
-  return errno;
-}
-
 static bool skip_entry(const char* entry, size_t len)
 {
   if((len == 1) && (entry[0] == '.'))

--- a/src/libponyrt/lang/errno.c
+++ b/src/libponyrt/lang/errno.c
@@ -1,0 +1,16 @@
+#include <platform.h>
+#include "errno.h"
+
+PONY_EXTERN_C_BEGIN
+
+PONY_API void pony_os_clear_errno()
+{
+  errno = 0;
+}
+
+PONY_API int pony_os_errno()
+{
+  return errno;
+}
+
+PONY_EXTERN_C_END

--- a/src/libponyrt/lang/errno.h
+++ b/src/libponyrt/lang/errno.h
@@ -1,0 +1,14 @@
+#ifndef lang_errno_h
+#define lang_errno_h
+
+#include <platform.h>
+#include <pony.h>
+
+PONY_EXTERN_C_BEGIN
+
+PONY_API void pony_os_clear_errno();
+PONY_API int pony_os_errno();
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -3,6 +3,15 @@
 
 PONY_EXTERN_C_BEGIN
 
+#ifdef PLATFORM_IS_POSIX_BASED
+
+#include <sys/wait.h>
+
+PONY_API int32_t ponyint_wnohang() {
+  return WNOHANG;
+}
+#endif
+
 #ifdef PLATFORM_IS_WINDOWS
 
 
@@ -149,12 +158,6 @@ PONY_API int32_t ponyint_win_process_kill(size_t hProcess)
     } else {
         return GetLastError();
     }
-}
-
-#elif defined(PLATFORM_IS_POSIX_BASED)
-
-PONY_API int32_t ponyint_wnohang() {
-  return WNOHANG;
 }
 #endif // PLATFORM_IS_WINDOWS
 

--- a/src/libponyrt/lang/process.h
+++ b/src/libponyrt/lang/process.h
@@ -14,7 +14,7 @@ PONY_API size_t ponyint_win_process_create(char* appname, char* cmdline,
     char* environ, char* wdir, uint32_t stdin_fd, uint32_t stdout_fd,
     uint32_t stderr_fd, uint32_t* error_code, char** error_msg);
 
-PONY_API int32_t ponyint_win_process_wait(size_t hProcess);
+PONY_API int32_t ponyint_win_process_wait(size_t hProcess, int32_t* exit_code_ptr);
 
 PONY_API int32_t ponyint_win_process_kill(size_t hProcess);
 

--- a/src/libponyrt/lang/process.h
+++ b/src/libponyrt/lang/process.h
@@ -1,6 +1,8 @@
 #ifndef lang_process_h
 #define lang_process_h
 
+#include <platform.h>
+
 PONY_EXTERN_C_BEGIN
 
 #ifdef PLATFORM_IS_WINDOWS
@@ -15,6 +17,10 @@ PONY_API size_t ponyint_win_process_create(char* appname, char* cmdline,
 PONY_API int32_t ponyint_win_process_wait(size_t hProcess);
 
 PONY_API int32_t ponyint_win_process_kill(size_t hProcess);
+
+#elif defined(PLATFORM_IS_POSIX_BASED)
+
+PONY_API int32_t ponyint_wnohang();
 
 #endif
 


### PR DESCRIPTION
Waiting or a process to finish was potentially blocking both on windows and posix systems. It was only ever called when the child process was killed beforehand or has closed both stdout and stderr, so the actual risk to block was low, but still. Now it calls `waitpid` (and the windows equivalent) with `WNOHANG` (on windows with timeout of 0) to ensure it does not block. If the process is still running at that point, a timer is scheduled to poll the process using the non-blocking `waitpid`.

During testing I discovered that processes terminated by signals were usually reported as exited with exit-code 0, which is wrong. I changed the `ProcessNotify.dispose` signature to receive a `Signaled` or `Exited` class containing signal number or exit code. 

This works pretty well, the only case this does not catch is, when a process exits and sets an exit-code in a signal handler. `ProcessNotify.dispose` will be called with `Signaled`, not with `Exited` and the exit code is basically lost. But I still prefer this.

As this is a breaking change, I thought to keep it as draft at first, in order to discuss it.
I would consider the non-blocking waitpid call as internal and the improved exit status reporting as actually fixing a bug, that is why I didn't create an RFC for this.