### PR TITLE
Only run PR tasks on PR

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ task:
 #
 
 task:
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
+  only_if: $CIRRUS_PR != ''
 
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191105
@@ -90,7 +90,7 @@ task:
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
 
 task:
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
+  only_if: $CIRRUS_PR != ''
 
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191105
@@ -104,7 +104,7 @@ task:
     - make -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release link=static test-ci
 
 task:
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
+  only_if: $CIRRUS_PR != ''
 
   freebsd_instance:
     image: freebsd-12-0-release-amd64
@@ -123,7 +123,7 @@ task:
     - gmake -f Makefile-lib-llvm default_pic=true arch=x86-64 config=release test-ci
 
 task:
-  only_if: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH != 'release' && $CIRRUS_API_CREATED != "true"
+  only_if: $CIRRUS_PR != ''
 
   osx_instance:
     image: mojave-xcode-11.2.1


### PR DESCRIPTION
The previous command would run for tagged commits as the tag rather
than branch name would end up in the CIRRUS_BRANCH environment variable.

Fedor from Cirrus pointed me to this change as the correct solution.