### PR TITLE
Add git to Dockerfiles

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 RUN apt-get update \
  && apt-get install -y \
     curl \
-    g++
+    g++ \
+    git
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc nightly --libc=gnu \

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --update \
     build-base \
     binutils-gold \
     libexecinfo-dev \
-    libexecinfo-static
+    libexecinfo-static \
+    git
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc nightly --libc=musl \

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -5,7 +5,8 @@ ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 RUN apt-get update \
  && apt-get install -y \
     curl \
-    g++
+    g++ \
+    git
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc release --libc=gnu \

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --update \
     build-base \
     binutils-gold \
     libexecinfo-dev \
-    libexecinfo-static
+    libexecinfo-static \
+    git
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc release --libc=musl \


### PR DESCRIPTION
`stable` and `corral` are effectively useless without git in the
environment. Seems like a reasonable edition.

Previously, our images included git. I removed when updated the
images because I thought "bah, we don't really need". I didn't
think through the "every image based off this will need to add
git if it wants to use stable" angle.