### PR TITLE
Support for riscv

### DIFF
--- a/.ci-dockerfiles/cross-riscv64/Dockerfile
+++ b/.ci-dockerfiles/cross-riscv64/Dockerfile
@@ -1,0 +1,19 @@
+FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
+
+USER root
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+  gdb-multiarch \
+  qemu-user \
+  gcc-10-riscv64-linux-gnu \
+  g++-10-riscv64-linux-gnu \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && ln -s /usr/riscv64-linux-gnu/lib/* /lib
+
+RUN cmake --version
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/cross-riscv64/build-and-push.bash
+++ b/.ci-dockerfiles/cross-riscv64/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+NAME="ponylang/ponyc-ci-cross-riscv64"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -281,12 +281,12 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-cross-riscv64:20220715
+    image: ponylang/ponyc-ci-cross-riscv64:20220716
     cpu: 8
     memory: 6
 
   environment:
-    IMAGE: ponylang/ponyc-ci-cross-riscv64:20220715
+    IMAGE: ponylang/ponyc-ci-cross-riscv64:20220716
 
   name: "riscv64 Linux glibc"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -277,6 +277,37 @@ task:
   test_stdlib_cross_script:
     - make test-cross-ci PONYPATH=../armv7-a/release cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc"
 
+task:
+  only_if: $CIRRUS_PR != ''
+
+  container:
+    image: ponylang/ponyc-ci-cross-riscv64:20220715
+    cpu: 8
+    memory: 6
+
+  environment:
+    IMAGE: ponylang/ponyc-ci-cross-riscv64:20220715
+
+  name: "riscv64 Linux glibc"
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script: echo "`md5sum Makefile` `md5sum CMakeLists.txt` `md5sum lib/CMakeLists.txt` ${IMAGE}"
+    populate_script: make libs build_flags=-j8
+  upload_caches:
+    - libs
+
+  configure_script:
+    - make configure
+  build_script:
+    - make build
+  test_script:
+    - make test-ci
+  libponyrt_cross_script:
+    - make cross-libponyrt CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"
+  test_stdlib_cross_script:
+    - make test-cross-ci PONYPATH=../rv64gc/release cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_linker=riscv64-linux-gnu-gcc-10 cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c --link-ldcmd=bfd' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
+
 #
 # Nightly build tasks
 #

--- a/.release-notes/3435.md
+++ b/.release-notes/3435.md
@@ -1,0 +1,3 @@
+## Support for RISC-V
+
+Pony now supports compiling for RISC-V linux glibc systems. 64 bit `rv64gc`/`lp64d` is tested via CI. In theory 32 bit `rv32gc`/`ilp32d` might work but is untested currently.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,23 +133,62 @@ if(NOT PONY_CROSS_LIBPONYRT)
         demangle
         objcarcopts
         orcjit
-        x86asmparser
-        x86codegen
-        x86desc
-        x86info
-        aarch64asmparser
-        aarch64codegen
-        aarch64desc
-        aarch64info
-        armasmparser
-        armcodegen
-        armdesc
-        arminfo
-        webassemblyasmparser
-        webassemblycodegen
-        webassemblydesc
-        webassemblyinfo
     )
+
+    list (FIND LLVM_TARGETS_TO_BUILD "AArch64" _index)
+    if (${_index} GREATER -1)
+        list(APPEND
+            LLVM_COMPONENTS
+            aarch64asmparser
+            aarch64codegen
+            aarch64desc
+            aarch64info
+        )
+    endif()
+
+    list (FIND LLVM_TARGETS_TO_BUILD "ARM" _index)
+    if (${_index} GREATER -1)
+        list(APPEND
+            LLVM_COMPONENTS
+            armasmparser
+            armcodegen
+            armdesc
+            arminfo
+        )
+    endif()
+
+    list (FIND LLVM_TARGETS_TO_BUILD "WebAssembly" _index)
+    if (${_index} GREATER -1)
+        list(APPEND
+            LLVM_COMPONENTS
+            webassemblyasmparser
+            webassemblycodegen
+            webassemblydesc
+            webassemblyinfo
+        )
+    endif()
+
+    list (FIND LLVM_TARGETS_TO_BUILD "X86" _index)
+    if (${_index} GREATER -1)
+        list(APPEND
+            LLVM_COMPONENTS
+            x86asmparser
+            x86codegen
+            x86desc
+            x86info
+        )
+    endif()
+
+    list (FIND LLVM_TARGETS_TO_BUILD "RISCV" _index)
+    if (${_index} GREATER -1)
+        list(APPEND
+            LLVM_COMPONENTS
+            riscvasmparser
+            riscvcodegen
+            riscvdesc
+            riscvinfo
+        )
+    endif()
 
     llvm_map_components_to_libnames(PONYC_LLVM_LIBS ${LLVM_COMPONENTS})
     # message("PONYC_LLVM_LIBS: ${PONYC_LLVM_LIBS}")

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ config ?= release
 arch ?= native
 tune ?= generic
 build_flags ?= -j2
-llvm_archs ?= X86;ARM;AArch64;WebAssembly
+llvm_archs ?= X86;ARM;AArch64;WebAssembly;RISCV
 llvm_config ?= Release
 llc_arch ?= x86-64
 pic_flag ?=
@@ -186,7 +186,7 @@ test: all test-core test-stdlib-release test-examples
 
 test-ci: all test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-validate-grammar
 
-test-cross-ci: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) --linker='$(cross_linker)'
+test-cross-ci: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) --linker='$(cross_linker)' $(cross_ponyc_args)
 test-cross-ci: test-stdlib-debug test-stdlib-release
 
 test-check-version: all

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pony is still pre-1.0 and as such, semi-regularly introduces breaking changes. T
 ### CPUs
 
 * Full support for 64-bit platforms
-  * x86 and ARM CPUs only
+  * x86, ARM and RISC-V CPUs only
 * Partial support for 32-bit platforms
   * The `arm` and `armhf` architectures are tested via CI (Continuous
     Integration testing)

--- a/make.ps1
+++ b/make.ps1
@@ -144,12 +144,12 @@ switch ($Command.ToLower())
         Write-Output "Configuring libraries..."
         if ($Arch.Length -gt 0)
         {
-            & cmake.exe -B "$libsBuildDir" -S "$libsSrcDir" -G "$Generator" -A $Arch -Thost=x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;WebAssembly"
+            & cmake.exe -B "$libsBuildDir" -S "$libsSrcDir" -G "$Generator" -A $Arch -Thost=x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;WebAssembly;RISCV"
             $err = $LastExitCode
         }
         else
         {
-            & cmake.exe -B "$libsBuildDir" -S "$libsSrcDir" -G "$Generator" -Thost=x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;WebAssembly"
+            & cmake.exe -B "$libsBuildDir" -S "$libsSrcDir" -G "$Generator" -Thost=x64 -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_ENABLE_WARNINGS=OFF -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_OCAMLDOC=OFF -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;WebAssembly;RISCV"
             $err = $LastExitCode
         }
         if ($err -ne 0) { throw "Error: exit code $err" }

--- a/packages/builtin/platform.pony
+++ b/packages/builtin/platform.pony
@@ -10,6 +10,7 @@ primitive Platform
 
   fun x86(): Bool => compile_intrinsic
   fun arm(): Bool => compile_intrinsic
+  fun riscv(): Bool => compile_intrinsic
 
   fun lp64(): Bool => compile_intrinsic
   fun llp64(): Bool => compile_intrinsic

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -186,6 +186,8 @@
  defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || \
  defined(_M_AMD64)
 # define PLATFORM_IS_X86
+#elif defined(__riscv)
+# define PLATFORM_IS_RISCV
 #endif
 
 /** Data types.

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -4,7 +4,7 @@
 #if !defined(__ARM_ARCH_2__) && !defined(__arm__) && !defined(__aarch64__) && \
  !defined(__i386__) && !defined(_M_IX86) && !defined(_X86_) && \
  !defined(__amd64__) && !defined(__x86_64__) && !defined(_M_X64) && \
- !defined(_M_AMD64) && !defined(__EMSCRIPTEN__)
+ !defined(_M_AMD64) && !defined(__EMSCRIPTEN__) && !defined(__riscv)
 #  error "Unsupported platform"
 #endif
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -850,6 +850,9 @@ bool codegen_pass_init(pass_opt_t* opt)
 
   opt->triple = triple;
 
+  if(opt->abi != NULL)
+    opt->abi = LLVMCreateMessage(opt->abi);
+
   if(opt->cpu != NULL)
     opt->cpu = LLVMCreateMessage(opt->cpu);
   else
@@ -863,6 +866,11 @@ void codegen_pass_cleanup(pass_opt_t* opt)
   LLVMDisposeMessage(opt->triple);
   LLVMDisposeMessage(opt->cpu);
   LLVMDisposeMessage(opt->features);
+  if(opt->abi != NULL)
+  {
+    LLVMDisposeMessage(opt->abi);
+    opt->abi = NULL;
+  }
   opt->triple = NULL;
   opt->cpu = NULL;
   opt->features = NULL;

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1527,6 +1527,14 @@ bool target_is_arm32(char* t)
   return !strcmp("arm", arch) && target_is_ilp32(t);
 }
 
+bool target_is_riscv(char* t)
+{
+  Triple triple = Triple(t);
+  std::string s = Triple::getArchTypePrefix(triple.getArch()).str();
+  const char* arch = s.c_str();
+  return (!strcmp("riscv32", arch) || !strcmp("riscv64", arch));
+}
+
 // This function is used to safeguard against potential oversights on the size
 // of Bool on any future port to PPC32.
 // We do not currently support compilation to PPC. It could work, but no

--- a/src/libponyc/codegen/genopt.h
+++ b/src/libponyc/codegen/genopt.h
@@ -19,6 +19,7 @@ bool target_is_x86(char* triple);
 bool target_is_arm(char* triple);
 bool target_is_arm32(char* triple);
 bool target_is_ppc(char* triple);
+bool target_is_riscv(char* triple);
 bool target_is_lp64(char* triple);
 bool target_is_llp64(char* triple);
 bool target_is_ilp32(char* triple);

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -37,6 +37,9 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
 
   TargetOptions options;
 
+  if(opt->abi != NULL)
+    options.MCOptions.ABIName = opt->abi;
+
   Target* t = reinterpret_cast<Target*>(target);
 
   TargetMachine* m = t->createTargetMachine(opt->triple, opt->cpu,

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -37,6 +37,7 @@ enum
   OPT_DOCS_PUBLIC,
 
   OPT_SAFE,
+  OPT_ABI,
   OPT_CPU,
   OPT_FEATURES,
   OPT_TRIPLE,
@@ -83,6 +84,7 @@ static opt_arg_t std_args[] =
   {"docs-public", '\0', OPT_ARG_NONE, OPT_DOCS_PUBLIC},
 
   {"safe", '\0', OPT_ARG_OPTIONAL, OPT_SAFE},
+  {"abi", '\0', OPT_ARG_REQUIRED, OPT_ABI},
   {"cpu", '\0', OPT_ARG_REQUIRED, OPT_CPU},
   {"features", '\0', OPT_ARG_REQUIRED, OPT_FEATURES},
   {"triple", '\0', OPT_ARG_REQUIRED, OPT_TRIPLE},
@@ -148,6 +150,8 @@ static void usage(void)
     "Rarely needed options:\n"
     "  --safe           Allow only the listed packages to use C FFI.\n"
     "    =package       With no packages listed, only builtin is allowed.\n"
+    "  --abi            Set the target ABI.\n"
+    "    =name          Default is the host ABI.\n"
     "  --cpu            Set the target CPU.\n"
     "    =name          Default is the host CPU.\n"
     "  --features       CPU features to enable or disable.\n"
@@ -319,6 +323,7 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
         }
         break;
 
+      case OPT_ABI: opt->abi = s->arg_val; break;
       case OPT_CPU: opt->cpu = s->arg_val; break;
       case OPT_FEATURES: opt->features = s->arg_val; break;
       case OPT_TRIPLE: opt->triple = s->arg_val; break;

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -312,6 +312,7 @@ typedef struct pass_opt_t
 #endif
 
   char* triple;
+  char* abi;
   char* cpu;
   char* features;
 

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -441,6 +441,10 @@ uint64_t ponyint_cpu_tick()
 # endif
 #elif defined PLATFORM_IS_EMSCRIPTEN
   return (uint64_t)(emscripten_get_now() * 1e6);
+#elif defined PLATFORM_IS_RISCV
+  uint64_t cycles;
+  asm("rdcycle %0" : "=r"(cycles));
+  return cycles;
 #endif
 }
 


### PR DESCRIPTION
Support for riscv. All tests pass for the 64 bit target.

-------------------------------------------

Instructions for testing (validated on ubuntu 20.04):

```
# install cross compiling toolchain
sudo apt-get install -y gdb-multiarch qemu-user gcc-10-riscv64-linux-gnu g++-10-riscv64-linux-gnu

# soft link riscv libs to the right path for qemu based execution to work
ln -s /usr/riscv64-linux-gnu/lib/* /lib

# clean old build artifacts/state (including llvm)
make distclean

# compile libs/llvm with support for X86/RISCV
make libs llvm_archs='X86;RISCV' build_flags='-j8'

# configure for X86/RISCV ponyc
make config=debug configure llvm_archs='X86;RISCV' build_flags='-j8'

# build for X86/RISCV ponyc
make config=debug build llvm_archs='X86;RISCV' build_flags='-j8'

# run tests for normal X86 ponyc
make config=debug test llvm_archs='X86;RISCV' build_flags='-j8'

# cross compile libponyrt-pic for RISCV
make config=debug cross-libponyrt CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"

# cross compile stdlib and run it in qemu
make config=debug test-cross-ci PONYPATH=../rv64gc/debug cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_linker=riscv64-linux-gnu-gcc-10 cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c --link-ldcmd=bfd' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" verbose=1
```