### PR TITLE
Handle command line option errors more gracefully

### DIFF
--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -382,6 +382,10 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
         }
         break;
 
+      case -2:
+        // ponyint_opt_next already took care of printing the error message
+        return EXIT_255;
+
       default:
         printf("BUG: unprocessed option id %d\n", id);
         return EXIT_255;

--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -247,5 +247,5 @@ int ponyint_opt_next(opt_state_t* s)
 
   strip_accepted_opts(s);
 
-  return m->id;
+  return (int)m->id;
 }

--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -1,5 +1,6 @@
 #include "options.h"
 
+#include "ponyassert.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
@@ -103,8 +104,9 @@ static void strip_accepted_opts(opt_state_t* s)
   {
     *s->argc -= s->remove;
 
+    pony_assert(*s->argc >= s->idx);
     memmove(&s->argv[s->idx], &s->argv[s->idx + s->remove],
-      (*s->argc - s->idx) * sizeof(char*));
+      (unsigned int)(*s->argc - s->idx) * sizeof(char*));
 
     s->idx--;
 

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -76,6 +76,13 @@ typedef struct opt_state_t
 void ponyint_opt_init(const opt_arg_t* args, opt_state_t* s, int* argc,
   char** argv);
 
+/** Find the unsigned identifier of the next option.
+ *
+ * Special return values:
+ *
+ * -1 when there are no more options to process.
+ * -2 when an error is detected and an error message is printed.
+ */
 int ponyint_opt_next(opt_state_t* s);
 
 #endif

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -156,7 +156,14 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_VERSION: opt->version = true; break;
       case OPT_PONYHELP: opt->ponyhelp = true; break;
 
-      default: exit(-1);
+      case -2:
+        // an error message has been printed by ponyint_opt_next
+        exit(-1);
+        break;
+
+      default:
+        exit(-1);
+        break;
     }
   }
 


### PR DESCRIPTION
Stop printing the "BUG: unprocessed option id -2" message when user
passes wrong arguments.

Before this change:

    $ ./build/release/ponyc -V
    ./build/release/ponyc: '-V' option requires an argument!
    BUG: unprocessed option id -2
    $ echo $?
    255

After this change:

    $ ./build/release/ponyc -V
    ./build/release/ponyc: '-V' option requires an argument!
    $ echo $?
    255

