### PR TITLE
Add Windows PATH instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -76,6 +76,8 @@ Note that you need to provide these options each time you run make.bat; the syst
 
 Other commands include `clean`, which will clean a specified configuration; and `distclean`, which will wipe out the entire build directory.  You will need to run `make configure` after a distclean.
 
+Following building, to make `ponyc.exe` globally available, add it to your `PATH` either by using Advanced System Settings->Environment Variables to extend `PATH` or by using the `setx` command, e.g. `setx PATH "%PATH%;<ponyc repo>\build\release-llvm-7.0.1"`
+
 ----
 
 # Additional Build options

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,3 +41,5 @@ Windows users will need to install:
   - If using Visual Studio 2017 or 2019, or Visual C++ Build Tools 2017 or 2019, make sure the latest `Windows 10 SDK (10.x.x.x) for Desktop` will be installed.
 
 Once you have installed the prerequisites, you can download the latest ponyc release from [bintray](https://dl.bintray.com/pony-language/ponyc-win/).
+
+Unzip the release file in a convenient location, and you will find `ponyc.exe` in the `ponyc\bin` directory. Following extraction, to make `ponyc.exe` globally available, add it to your `PATH` either by using Advanced System Settings->Environment Variables to extend `PATH` or by using the `setx` command, e.g. `setx PATH "%PATH%;<directory you unzipped to>\ponyc\bin"`


### PR DESCRIPTION
Closes #3414 by adding Windows PATH instructions to both prebuilt binary download (INSTALL.md) and building from source (BUILD.md) installation. 