### PR TITLE
Fix linker error when creating symlinks on Windows

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -12,6 +12,7 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestMkdtemp)
+    test(_TestSymlink)
     test(_TestWalk)
     test(_TestDirectoryOpen)
     test(_TestDirectoryFileOpen)
@@ -136,6 +137,17 @@ class iso _TestWalk is UnitTest
       h.assert_true(top.remove())
     end
 
+class iso _TestSymlink is UnitTest
+  fun name(): String => "files/FilePath.symlink"
+  fun apply(h: TestHelper) ? =>
+    let link_to = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp.symlink.")?
+    let link = FilePath(h.env.root as AmbientAuth, "link_to_it")?
+    try
+      h.assert_true(link_to.symlink(link))
+    then
+      link.remove()
+      link_to.remove()
+    end
 
 class iso _TestDirectoryOpen is UnitTest
   fun name(): String => "files/File.open.directory"

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -246,7 +246,7 @@ class val FilePath
 
     0 == @rename[I32](path.cstring(), new_path.path.cstring())
 
-  fun symlink(link_name: FilePath): Bool =>
+  fun val symlink(link_name: FilePath): Bool =>
     """
     Create a symlink to a file or directory.
     """
@@ -255,7 +255,16 @@ class val FilePath
     end
 
     ifdef windows then
-      0 != @CreateSymbolicLink[U8](link_name.path.cstring(), path.cstring())
+      try
+        let dword: U32 = if FileInfo(this)?.directory then
+          1
+        else
+          0
+        end
+        0 != @CreateSymbolicLinkA[U8](link_name.path.cstring(), path.cstring(), dword)
+      else
+        false
+      end
     else
       0 == @symlink[I32](path.cstring(), link_name.path.cstring())
     end

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -249,6 +249,9 @@ class val FilePath
   fun val symlink(link_name: FilePath): Bool =>
     """
     Create a symlink to a file or directory.
+
+    Note that on Windows a program must be running with elevated priviledges to
+    be able to create symlinks.
     """
     if not caps(FileLink) or not link_name.caps(FileCreate) then
       return false
@@ -256,12 +259,59 @@ class val FilePath
 
     ifdef windows then
       try
-        let dword: U32 = if FileInfo(this)?.directory then
-          1
-        else
-          0
+        var err: U32 = 0
+
+        // look up the ID of the SE_CREATE_SYMBOLIC_LINK privilege
+        let priv_name = "SeCreateSymbolicLinkPrivilege"
+        var luid: U64 = 0
+        var ret = @LookupPrivilegeValueA[U8](
+          USize(0),
+          priv_name.cstring(),
+          addressof luid)
+        if ret == 0 then
+          return false
         end
-        0 != @CreateSymbolicLinkA[U8](link_name.path.cstring(), path.cstring(), dword)
+
+        // get current process pseudo-handle
+        let handle = @GetCurrentProcess[USize]()
+        if handle == 0 then
+          return false
+        end
+
+        // get security token
+        var token: USize = 0
+        let rights: U32 = 0x0020 // TOKEN_ADJUST_PRIVILEGES
+        ret = @OpenProcessToken[U8](handle, rights, addressof token)
+        if ret == 0 then
+          return false
+        end
+
+        // try to turn on SE_CREATE_SYMBOLIC_LINK privilege
+        // this won't work unless we are administrator or have Developer Mode on
+        // https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+        var privileges: _TokenPrivileges ref = _TokenPrivileges
+        privileges.privilege_count = 1
+        privileges.privileges_0.luid = luid
+        privileges.privileges_0.attributes = 0x00000002 // SE_PRIVILEGE_ENABLED
+        ret = @AdjustTokenPrivileges[U8](
+          token,
+          U8(0),
+          privileges,
+          U32(0),
+          USize(0),
+          USize(0))
+        @CloseHandle[U8](token)
+        if ret == 0 then
+          return false
+        end
+
+        // now actually try to create the link
+        let flags: U32 = if FileInfo(this)?.directory then 3 else 0 end
+        ret = @CreateSymbolicLinkA[U8](
+          link_name.path.cstring(),
+          path.cstring(),
+          flags)
+        ret != 0
       else
         false
       end
@@ -323,3 +373,11 @@ class val FilePath
 
       0 == @utimes[I32](path.cstring(), addressof tv)
     end
+
+struct ref _TokenPrivileges
+  var privilege_count: U32 = 1
+  embed privileges_0: _LuidAndAttributes = _LuidAndAttributes
+
+struct ref _LuidAndAttributes
+  var luid: U64 = 0
+  var attributes: U32 = 0


### PR DESCRIPTION
When working on Windows builds for ponyup, I found that it wouldn't
link due to an error with the FFI call in `symlink`. This commit
adds a test to verify that `symlink` works.

This PR contains a test that I verified fails on Windows and then adds a change to FilePath.symlink that then allows the failing test to pass.