### PR TITLE
[BREAKING] Make Env.root not-optional.

### DIFF
--- a/examples/echo/echo.pony
+++ b/examples/echo/echo.pony
@@ -2,11 +2,7 @@ use "net"
 
 actor Main
   new create(env: Env) =>
-    try
-      TCPListener(env.root as AmbientAuth, Listener(env.out))
-    else
-      env.out.print("unable to use the network")
-    end
+    TCPListener(env.root, Listener(env.out))
 
 class Listener is TCPListenNotify
   let _out: OutStream

--- a/examples/files/files.pony
+++ b/examples/files/files.pony
@@ -6,7 +6,7 @@ actor Main
 
     try
       with file = OpenFile(
-        FilePath(env.root as AmbientAuth, env.args(1)?, caps)?) as File
+        FilePath(env.root, env.args(1)?, caps)?) as File
       do
         env.out.print(file.path.path)
         for line in file.lines() do

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -114,7 +114,7 @@ class val Config
     width = cmd.option("width").i64().usize()
     outpath =
       try
-        FilePath(env.root as AmbientAuth, cmd.option("output").string())?
+        FilePath(env.root, cmd.option("output").string())?
       else
         None
       end

--- a/examples/net/listener.pony
+++ b/examples/net/listener.pony
@@ -45,16 +45,11 @@ class Listener is TCPListenNotify
     _count = _count + 1
     _env.out.print("spawn " + _count.string())
 
-    try
-      let env = _env
+    let env = _env
 
-      _env.out.print("Client starting")
-      TCPConnection(
-        _env.root as AmbientAuth,
-        ClientSide(env),
-        _host,
-        _service)
-    else
-      _env.out.print("couldn't create client side")
-      listen.close()
-    end
+    _env.out.print("Client starting")
+    TCPConnection(
+      _env.root,
+      ClientSide(env),
+      _host,
+      _service)

--- a/examples/net/net.pony
+++ b/examples/net/net.pony
@@ -8,10 +8,6 @@ actor Main
       1
     end
 
-    try
-      let auth = env.root as AmbientAuth
-      TCPListener(auth, recover Listener(env, limit) end)
-      UDPSocket(auth, recover Pong(env) end)
-    else
-      env.out.print("unable to use the network")
-    end
+    let auth = env.root
+    TCPListener(auth, recover Listener(env, limit) end)
+    UDPSocket(auth, recover Pong(env) end)

--- a/examples/net/pong.pony
+++ b/examples/net/pong.pony
@@ -13,7 +13,7 @@ class Pong is UDPNotify
       _env.out.print("Pong: listening on " + host + ":" + service)
 
       let env = _env
-      let auth = env.root as AmbientAuth
+      let auth = env.root
 
       if ip.ip4() then
         UDPSocket.ip4(auth, recover Ping(env, ip) end)

--- a/examples/under_pressure/main.pony
+++ b/examples/under_pressure/main.pony
@@ -117,12 +117,10 @@ class Send is TimerNotify
 
 actor Main
   new create(env: Env) =>
-    try
-      let auth = env.root as AmbientAuth
-      let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
-        "", "7669")
+    let auth = env.root
+    let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
+      "", "7669")
 
-      let timers = Timers
-      let t = Timer(Send(socket), 0, 5_000_000)
-      timers(consume t)
-    end
+    let timers = Timers
+    let t = Timer(Send(socket), 0, 5_000_000)
+    timers(consume t)

--- a/packages/backpressure/backpressure.pony
+++ b/packages/backpressure/backpressure.pony
@@ -69,11 +69,9 @@ class SlowDown is TCPConnectionNotify
 
 actor Main
   new create(env: Env) =>
-    try
-      let auth = env.root as AmbientAuth
-      let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
-        "", "7669")
-    end
+    let auth = env.root
+    let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
+      "", "7669")
 ```
 
 ## Caveat

--- a/packages/builtin/env.pony
+++ b/packages/builtin/env.pony
@@ -3,7 +3,7 @@ class val Env
   An environment holds the command line and other values injected into the
   program by default by the runtime.
   """
-  let root: (AmbientAuth | None)
+  let root: AmbientAuth
     """
     The root capability.
 
@@ -55,14 +55,14 @@ class val Env
     exitcode = {(code: I32) => @pony_exitcode[None](code) }
 
   new val create(
-    root': (AmbientAuth | None),
+    root': AmbientAuth,
     input': InputStream, out': OutStream,
     err': OutStream, args': Array[String] val,
     vars': Array[String] val,
     exitcode': {(I32)} val)
   =>
     """
-    Build an artificial environment. A root capability may be supplied.
+    Build an artificial environment. A root capability must be supplied.
     """
     root = root'
     input = input'

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -54,7 +54,7 @@ actor Main is TestList
 
 primitive _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath ? =>
-    let top = Directory(FilePath.mkdtemp(h.env.root as AmbientAuth,
+    let top = Directory(FilePath.mkdtemp(h.env.root,
       "tmp._FileHelper.")?)?
     for f in files.values() do
       try
@@ -103,7 +103,7 @@ trait iso _NonRootTest is UnitTest
 class iso _TestMkdtemp is UnitTest
   fun name(): String => "files/FilePath.mkdtemp"
   fun apply(h: TestHelper) ? =>
-    let tmp = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp.TestMkdtemp.")?
+    let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestMkdtemp.")?
     try
       h.assert_true(FileInfo(tmp)?.directory)
     then
@@ -140,7 +140,7 @@ class iso _TestWalk is UnitTest
 class iso _TestDirectoryOpen is UnitTest
   fun name(): String => "files/File.open.directory"
   fun apply(h: TestHelper) ? =>
-    let tmp = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp.TestDiropen.")?
+    let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestDiropen.")?
 
     try
       h.assert_true(FileInfo(tmp)?.directory)
@@ -158,7 +158,7 @@ class iso _TestDirectoryFileOpen is UnitTest
   try
     // make a temporary directory
     let dir_path = FilePath.mkdtemp(
-      h.env.root as AmbientAuth,
+      h.env.root,
       "tmp.directory.open-file")?
     try
       let dir = Directory(dir_path)?
@@ -361,7 +361,7 @@ class iso _TestFileEOF is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.eof"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = File(filepath) do
         file.write("foobar")
         file.sync()
@@ -384,7 +384,7 @@ class iso _TestFileCreate is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.create"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.print("foobar")
       end
@@ -403,7 +403,7 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
     try
       let content = "unwriteable"
       let path = "tmp.create-not-writeable"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       let mode: FileMode ref = FileMode.>private()
       mode.owner_read = true
       mode.owner_write = false
@@ -438,7 +438,7 @@ class iso _TestFileCreateDirNotWriteable is _NonRootTest
       try
         let dir_path =
           FilePath.mkdtemp(
-            h.env.root as AmbientAuth,
+            h.env.root,
             "tmp.create-dir-not-writeable")?
         let mode: FileMode ref = FileMode.>private()
         mode.owner_read = true
@@ -471,7 +471,7 @@ class iso _TestFileOpenInDirNotWriteable is UnitTest
       try
         // make a temporary directory
         let dir_path = FilePath.mkdtemp(
-          h.env.root as AmbientAuth,
+          h.env.root,
           "tmp.open-dir-not-writeable")?
         try
           let dir = Directory(dir_path)?
@@ -506,7 +506,7 @@ class iso _TestFileCreateMissingCaps is UnitTest
       let no_write_caps = FileCaps.>all().>unset(FileRead)
 
       let file_path1 = FilePath(
-        h.env.root as AmbientAuth,
+        h.env.root,
         "tmp.create-missing-caps1",
         consume no_create_caps)?
       let file1 = File(file_path1)
@@ -514,7 +514,7 @@ class iso _TestFileCreateMissingCaps is UnitTest
       h.assert_is[FileErrNo](file1.errno(), FileError)
 
       let file_path2 = FilePath(
-        h.env.root as AmbientAuth,
+        h.env.root,
         "tmp.create-missing-caps2",
         consume no_read_caps)?
       let file2 = File(file_path2)
@@ -522,7 +522,7 @@ class iso _TestFileCreateMissingCaps is UnitTest
       h.assert_is[FileErrNo](file2.errno(), FileError)
 
       let file_path3 = FilePath(
-        h.env.root as AmbientAuth,
+        h.env.root,
         "tmp.create-missing-caps3",
         consume no_write_caps)?
       let file3 = File(file_path3)
@@ -538,7 +538,7 @@ class iso _TestFileOpen is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.open"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.print("foobar")
       end
@@ -562,7 +562,7 @@ class iso _TestFileOpenError is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.openerror"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       h.assert_false(filepath.exists())
       let file = OpenFile(filepath)
       h.assert_true(file is FileError)
@@ -576,7 +576,7 @@ class _TestFileOpenWrite is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.open-write"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.print("write on file opened read-only")
       end
@@ -600,7 +600,7 @@ class iso _TestFileOpenPermissionDenied is _NonRootTest
         // on windows all files are always writeable
         // with chmod there is no way to make a file not readable
       try
-        let filepath = FilePath(h.env.root as AmbientAuth, "tmp.open-not-readable")?
+        let filepath = FilePath(h.env.root, "tmp.open-not-readable")?
         with file = CreateFile(filepath) as File do
           file.print("unreadable")
         end
@@ -629,7 +629,7 @@ class iso _TestFileLongLine is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.longline"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = File(filepath) do
         var longline = "foobar"
         for d in Range(0, 10) do
@@ -651,7 +651,7 @@ class iso _TestFileWrite is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.write"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.write("foobar\n")
       end
@@ -674,7 +674,7 @@ class iso _TestFileWritev is UnitTest
       wb.write(line1)
       wb.write(line2)
       let path = "tmp.writev"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         h.assert_true(file.writev(wb.done()))
       end
@@ -694,7 +694,7 @@ class iso _TestFileQueue is UnitTest
   fun apply(h: TestHelper) =>
     try
       let path = "tmp.queue"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.queue("foobar\n")
       end
@@ -716,7 +716,7 @@ class iso _TestFileQueuev is UnitTest
       wb.write(line1)
       wb.write(line2)
       let path = "tmp.queuev"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.queuev(wb.done())
       end
@@ -749,7 +749,7 @@ class iso _TestFileMixedWriteQueue is UnitTest
       wb.write(line6)
       let queuev_data = wb.done()
       let path = "tmp.mixedwrite"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         file.print(line3)
         file.queue(line5)
@@ -790,7 +790,7 @@ class iso _TestFileWritevLarge is UnitTest
         count = count + 1
       end
       let path = "tmp.writevlarge"
-      let filepath = FilePath(h.env.root as AmbientAuth, path)?
+      let filepath = FilePath(h.env.root, path)?
       with file = CreateFile(filepath) as File do
         h.assert_true(file.writev(wb.done()))
       end
@@ -811,7 +811,7 @@ class iso _TestFileFlush is UnitTest
   fun name(): String => "files/File.flush"
   fun apply(h: TestHelper) =>
     try
-      let path = FilePath(h.env.root as AmbientAuth, "tmp.flush")?
+      let path = FilePath(h.env.root, "tmp.flush")?
       with file = CreateFile(path) as File do
         // Flush with no writes succeeds trivially, but does nothing.
         h.assert_true(file.flush())
@@ -838,7 +838,7 @@ class iso _TestFileFlush is UnitTest
 class iso _TestFileReadMore is UnitTest
   fun name(): String => "files/File.read-more"
   fun apply(h: TestHelper)? =>
-    let path = FilePath(h.env.root as AmbientAuth, "tmp-read-more")?
+    let path = FilePath(h.env.root, "tmp-read-more")?
     with file = CreateFile(path) as File do
       h.assert_true(file.write("foobar"))
     end
@@ -862,7 +862,7 @@ class iso _TestFileLinesEmptyFile is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>
-    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "empty")?
+    tmp_dir = FilePath.mkdtemp(h.env.root, "empty")?
 
   fun ref tear_down(h: TestHelper) =>
     try (tmp_dir as FilePath).remove() end
@@ -908,7 +908,7 @@ class iso _TestFileLinesSingleLine is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>
-    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "single-line")?
+    tmp_dir = FilePath.mkdtemp(h.env.root, "single-line")?
 
   fun ref tear_down(h: TestHelper) =>
     try
@@ -975,7 +975,7 @@ class _TestFileLinesMultiLine is UnitTest
   ]
 
   fun ref set_up(h: TestHelper) ? =>
-    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "multi-line")?
+    tmp_dir = FilePath.mkdtemp(h.env.root, "multi-line")?
 
   fun ref tear_down(h: TestHelper) =>
     try
@@ -1020,7 +1020,7 @@ class _TestFileLinesMovingCursor is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>
-    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "moving-cursor")?
+    tmp_dir = FilePath.mkdtemp(h.env.root, "moving-cursor")?
 
   fun ref tear_down(h: TestHelper) =>
     try

--- a/packages/files/files.pony
+++ b/packages/files/files.pony
@@ -32,7 +32,7 @@ actor Main
   new create(env: Env) =>
     try
       for file_name in env.args.slice(1).values() do
-        let path = FilePath(env.root as AmbientAuth, file_name)?
+        let path = FilePath(env.root, file_name)?
         match OpenFile(path)
         | let file: File =>
           while file.errno() is FileOK do

--- a/packages/ini/ini.pony
+++ b/packages/ini/ini.pony
@@ -17,7 +17,7 @@ use "files"
 actor Main
   new create(env:Env) =>
     try
-      let ini_file = File(FilePath(env.root as AmbientAuth, "example.ini")?)
+      let ini_file = File(FilePath(env.root, "example.ini")?)
       let sections = IniParse(ini_file.lines())?
       for section in sections.keys() do
         env.out.print("Section name is: " + section)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -27,7 +27,7 @@ class _TestPing is UDPNotify
     _h = h
 
     _ip = try
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       (_, let service) = ip.name()?
 
       let list = if ip.ip4() then
@@ -85,18 +85,14 @@ class _TestPong is UDPNotify
     sock.set_broadcast(true)
     let ip = sock.local_address()
 
-    try
-      let auth = _h.env.root as AmbientAuth
-      let h = _h
-      if ip.ip4() then
-        _h.dispose_when_done(
-          UDPSocket.ip4(auth, recover _TestPing(h, ip) end))
-      else
-        _h.dispose_when_done(
-          UDPSocket.ip6(auth, recover _TestPing(h, ip) end))
-      end
+    let auth = _h.env.root
+    let h = _h
+    if ip.ip4() then
+      _h.dispose_when_done(
+        UDPSocket.ip4(auth, recover _TestPing(h, ip) end))
     else
-      _h.fail_action("ping create")
+      _h.dispose_when_done(
+        UDPSocket.ip6(auth, recover _TestPing(h, ip) end))
     end
 
   fun ref received(
@@ -128,12 +124,8 @@ class iso _TestBroadcast is UnitTest
     h.expect_action("pong receive")
     h.expect_action("ping receive")
 
-    try
-      let auth = h.env.root as AmbientAuth
-      h.dispose_when_done(UDPSocket(auth, recover _TestPong(h) end))
-    else
-      h.fail_action("pong create")
-    end
+    let auth = h.env.root
+    h.dispose_when_done(UDPSocket(auth, recover _TestPong(h) end))
 
     h.long_test(2_000_000_000) // 2 second timeout
 
@@ -166,13 +158,9 @@ class _TestTCP is TCPListenNotify
     h.expect_action("client create")
     h.expect_action("server accept")
 
-    try
-      let auth = h.env.root as AmbientAuth
-      h.dispose_when_done(TCPListener(auth, consume this))
-      h.complete_action("server create")
-    else
-      h.fail_action("server create")
-    end
+    let auth = h.env.root
+    h.dispose_when_done(TCPListener(auth, consume this))
+    h.complete_action("server create")
 
     h.long_test(2_000_000_000)
 
@@ -183,7 +171,7 @@ class _TestTCP is TCPListenNotify
     _h.complete_action("server listen")
 
     try
-      let auth = _h.env.root as AmbientAuth
+      let auth = _h.env.root
       let notify = (_client_conn_notify = None) as TCPConnectionNotify iso^
       (let host, let port) = listen.local_address().name()?
       _h.dispose_when_done(TCPConnection(auth, consume notify, host, port))
@@ -649,8 +637,8 @@ class _TestTCPProxy is UnitTest
   fun exclusion_group(): String => "network"
 
   fun ref apply(h: TestHelper) =>
-    h.expect_action("sender connected") 
-    h.expect_action("sender proxy request") 
+    h.expect_action("sender connected")
+    h.expect_action("sender proxy request")
 
     _TestTCP(h)(_TestTCPProxyNotify(h),
       _TestTCPProxyNotify(h))
@@ -663,7 +651,7 @@ class _TestTCPProxyNotify is TCPConnectionNotify
   fun ref proxy_via(host: String, service: String): (String, String) =>
     _h.complete_action("sender proxy request")
     (host, service)
-    
+
   fun ref connected(conn: TCPConnection ref) =>
     _h.complete_action("sender connected")
 

--- a/packages/net/proxy.pony
+++ b/packages/net/proxy.pony
@@ -10,7 +10,7 @@ class val NoProxy is Proxy
   actor MyClient
     new create(host: String, service: String, proxy: Proxy = NoProxy) =>
       let conn: TCPConnection = TCPConnection.create(
-        env.root as AmbientAuth,
+        env.root,
         proxy.apply(MyConnectionNotify.create()),
         "localhost",
         "80")

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -48,10 +48,8 @@ actor TCPConnection
 
   actor Main
     new create(env: Env) =>
-      try
-        TCPConnection(env.root as AmbientAuth,
+        TCPConnection(env.root,
           recover MyTCPConnectionNotify(env.out) end, "", "8989")
-      end
   ```
 
   Note: when writing to the connection data will be silently discarded if the
@@ -119,11 +117,9 @@ actor TCPConnection
 
   actor Main
     new create(env: Env) =>
-      try
-        let auth = env.root as AmbientAuth
-        let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
-          "", "7669")
-      end
+      let auth = env.root
+      let socket = TCPConnection(auth, recover SlowDown(auth, env.out) end,
+        "", "7669")
 
   ```
 
@@ -162,10 +158,8 @@ actor TCPConnection
 
   actor Main
     new create(env: Env) =>
-      try
-        TCPConnection(env.root as AmbientAuth,
-          recover ThrowItAway end, "", "7669")
-      end
+      TCPConnection(env.root,
+        recover ThrowItAway end, "", "7669")
   ```
 
   In general, unless you have a very specific use case, we strongly advise that
@@ -214,7 +208,7 @@ actor TCPConnection
   actor MyClient
     new create(host: String, service: String, proxy: Proxy = NoProxy) =>
       let conn: TCPConnection = TCPConnection.create(
-        env.root as AmbientAuth,
+        env.root,
         proxy.apply(MyConnectionNotify.create()),
         host,
         service)
@@ -263,7 +257,7 @@ actor TCPConnection
     fun ref received(conn, data, times) => _wrapped.received(conn, data, times)
     fun ref connect_failed(conn: TCPConnection ref) => None
   ```
-  
+
   """
   var _listen: (TCPListener | None) = None
   var _notify: TCPConnectionNotify

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -32,10 +32,8 @@ actor TCPListener
 
   actor Main
     new create(env: Env) =>
-      try
-        TCPListener(env.root as AmbientAuth,
-          recover MyTCPListenNotify end, "", "8989")
-      end
+      TCPListener(env.root,
+        recover MyTCPListenNotify end, "", "8989")
   ```
   """
   var _notify: TCPListenNotify

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -30,10 +30,8 @@ actor UDPSocket
 
   actor Main
     new create(env: Env) =>
-      try
-        UDPSocket(env.root as AmbientAuth,
-          MyUDPNotify, "", "8989")
-      end
+      UDPSocket(env.root,
+        MyUDPNotify, "", "8989")
   ```
 
   The client is implemented like this:
@@ -70,8 +68,8 @@ actor UDPSocket
     new create(env: Env) =>
       try
         let destination =
-          DNS.ip4(env.root as AmbientAuth, "localhost", "8989")(0)?
-        UDPSocket(env.root as AmbientAuth,
+          DNS.ip4(env.root, "localhost", "8989")(0)?
+        UDPSocket(env.root,
           recover MyUDPNotify(env.out, consume destination) end)
       end
   ```

--- a/packages/ponytest/pony_test.pony
+++ b/packages/ponytest/pony_test.pony
@@ -226,7 +226,7 @@ class iso TempDirTest
   fun name(): String => "temp-dir"
 
   fun ref set_up(h: TestHelper)? =>
-    tmp_dir = FilePath.mkdtemp(h.env.root as AmbientAuth, "temp-dir")?
+    tmp_dir = FilePath.mkdtemp(h.env.root, "temp-dir")?
 
   fun ref tear_down(h: TestHelper) =>
     try

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -55,12 +55,12 @@ class iso _TestFileExecCapabilityIsRequired is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient(0, "", 1, h)
     try
       let path =
-        FilePath(h.env.root as AmbientAuth, CatPath(),
+        FilePath(h.env.root, CatPath(),
           recover val FileCaps .> all() .> unset(FileExec) end)?
       let args: Array[String] val = ["dontcare"]
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       h.dispose_when_done(pm)
@@ -81,7 +81,7 @@ class iso _TestNonExecutablePathResultsInExecveError is UnitTest
 
   fun apply(h: TestHelper) =>
     try
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let path = FilePath.mkdtemp(auth, "pony_execve_test")?
       let args: Array[String] val = []
       let vars: Array[String] val = []
@@ -133,11 +133,11 @@ class iso _TestStdinStdout is UnitTest
     let size: USize = input.size() + ifdef windows then 2 else 0 end
     let notifier: ProcessNotify iso = _ProcessClient(size, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, CatPath())?
+      let path = FilePath(h.env.root, CatPath())?
       let args: Array[String] val = CatArgs()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       pm.write(input)
@@ -170,7 +170,7 @@ class iso _TestStderr is UnitTest
     let exit_code: I32 = ifdef windows then 2 else 1 end
     let notifier: ProcessNotify iso = _ProcessClient(0, errmsg, exit_code, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, CatPath())?
+      let path = FilePath(h.env.root, CatPath())?
       let args: Array[String] val = ifdef windows then
         ["find"; "/q"]
       else
@@ -178,7 +178,7 @@ class iso _TestStderr is UnitTest
       end
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       _pm  = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       if _pm isnt None then // write to STDIN of the child process
         let pm = _pm as ProcessMonitor
@@ -232,7 +232,7 @@ class iso _TestExpect is UnitTest
     end
 
     try
-      let path = FilePath(h.env.root as AmbientAuth, EchoPath())?
+      let path = FilePath(h.env.root, EchoPath())?
       let args: Array[String] val = ifdef windows then
         ["cmd"; "/c"; "echo"; "hello carl"]
       else
@@ -240,7 +240,7 @@ class iso _TestExpect is UnitTest
       end
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
         path, args, vars)
       pm.done_writing()  // closing stdin allows "echo" to terminate
@@ -264,11 +264,11 @@ class iso _TestWritevOrdering is UnitTest
     let expected: USize = ifdef windows then 13 else 11 end
     let notifier: ProcessNotify iso = _ProcessClient(expected, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, CatPath())?
+      let path = FilePath(h.env.root, CatPath())?
       let args: Array[String] val = CatArgs()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       let params: Array[String] val = ["one"; "two"; "three"]
@@ -295,11 +295,11 @@ class iso _TestPrintvOrdering is UnitTest
     let expected: USize = ifdef windows then 17 else 14 end
     let notifier: ProcessNotify iso = _ProcessClient(expected, "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, CatPath())?
+      let path = FilePath(h.env.root, CatPath())?
       let args: Array[String] val = CatArgs()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       let pm: ProcessMonitor =
         ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       let params: Array[String] val = ["one"; "two"; "three"]
@@ -330,12 +330,12 @@ class iso _TestStdinWriteBuf is UnitTest
     let notifier: ProcessNotify iso = _ProcessClient((pipe_cap + 1) * 2,
       "", 0, h)
     try
-      let path = FilePath(h.env.root as AmbientAuth, CatPath())?
+      let path = FilePath(h.env.root, CatPath())?
       let args: Array[String] val = CatArgs()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
       // fork the child process and attach a ProcessMonitor
-      let auth = h.env.root as AmbientAuth
+      let auth = h.env.root
       _pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
 
       // create a message larger than pipe_cap bytes

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -24,13 +24,13 @@ actor Main
     let notifier: ProcessNotify iso = consume client
     // define the binary to run
     try
-      let path = FilePath(env.root as AmbientAuth, "/bin/cat")?
+      let path = FilePath(env.root, "/bin/cat")?
       // define the arguments; first arg is always the binary name
       let args: Array[String] val = ["cat"]
       // define the environment variable for the execution
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
       // create a ProcessMonitor and spawn the child process
-      let auth = env.root as AmbientAuth
+      let auth = env.root
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
       path, args, vars)
       // write to STDIN of the child process

--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -53,7 +53,7 @@ class _StructWords
   var usize: USize = 1 << (USize(0).bitwidth() - 1)
 
   fun eq(that: _StructWords box): Bool =>
-    (u8 == that.u8) 
+    (u8 == that.u8)
       and (u16 == that.u16)
       and (u32 == that.u32)
       and (u64 == that.u64)
@@ -113,7 +113,7 @@ class iso _TestSimple is UnitTest
   fun name(): String => "serialise/Simple"
 
   fun apply(h: TestHelper) ? =>
-    let ambient = h.env.root as AmbientAuth
+    let ambient = h.env.root
     let serialise = SerialiseAuth(ambient)
     let deserialise = DeserialiseAuth(ambient)
 
@@ -130,7 +130,7 @@ class iso _TestArrays is UnitTest
   fun name(): String => "serialise/Arrays"
 
   fun apply(h: TestHelper) ? =>
-    let ambient = h.env.root as AmbientAuth
+    let ambient = h.env.root
     let serialise = SerialiseAuth(ambient)
     let deserialise = DeserialiseAuth(ambient)
 
@@ -199,8 +199,8 @@ class iso _TestFailures is UnitTest
   """
   fun name(): String => "serialise/Failures"
 
-  fun apply(h: TestHelper) ? =>
-    let ambient = h.env.root as AmbientAuth
+  fun apply(h: TestHelper) =>
+    let ambient = h.env.root
     let serialise = SerialiseAuth(ambient)
 
     h.assert_error({() ? => Serialised(serialise, _HasActor)? })
@@ -215,7 +215,7 @@ class iso _TestBoxedMachineWord is UnitTest
   fun name(): String => "serialise/BoxedMachineWord"
 
   fun apply(h: TestHelper) ? =>
-    let ambient = h.env.root as AmbientAuth
+    let ambient = h.env.root
     let serialise = SerialiseAuth(ambient)
     let deserialise = DeserialiseAuth(ambient)
 

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -322,7 +322,7 @@ TEST_F(CodegenTest, StringSerialization)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    try\n"
-    "      let auth = env.root as AmbientAuth\n"
+    "      let auth = env.root\n"
     "      let v: V = V\n"
     "      Serialised(SerialiseAuth(auth), v)?\n"
     "      @pony_exitcode[None](I32(1))\n"
@@ -371,7 +371,7 @@ TEST_F(CodegenTest, CustomSerialization)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    try\n"
-    "      let ambient = env.root as AmbientAuth\n"
+    "      let ambient = env.root\n"
     "      let serialise = SerialiseAuth(ambient)\n"
     "      let deserialise = DeserialiseAuth(ambient)\n"
 


### PR DESCRIPTION
In order to gain usability improvements in the normal case.

The type of `Env.root` changes from `(AmbientAuth | None)` to just `AmbientAuth`.
Constructing an artifical `Env` now requires to provide an `AmbientAuth`.

This is taking the discussion started on zulip: https://ponylang.zulipchat.com/#narrow/stream/189985-beginner-help/topic/Main.20boilerplate and moves it here, narrowing it down to the change presented here.

Its purpose is to make it easier to access the `AmbientAuth` from env, as the case for which `Env.root` has been made optional, are not actual used.