### PR TITLE
Fix "not match" and "not if" causing a syntax error

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -429,9 +429,9 @@ end
 
   // Not OK
   output
-  .> append(file_name)
-  .> append(":")
-  .> append(msg)
+    .>append(file_name)
+    .>append(":")
+    .>append(msg)
   ```
 
 - Function arguments mostly follow the same rules as arguments in method declarations. However, all arguments may be placed on the following line with an additional level of indentation if all arguments would fit on that line. Otherwise, arguments must be placed on individual lines. These rules also apply to FFI calls. A `where` keyword and the following arguments may all exist on their own line.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -429,9 +429,9 @@ end
 
   // Not OK
   output
-    .>append(file_name)
-    .>append(":")
-    .>append(msg)
+  .> append(file_name)
+  .> append(":")
+  .> append(msg)
   ```
 
 - Function arguments mostly follow the same rules as arguments in method declarations. However, all arguments may be placed on the following line with an additional level of indentation if all arguments would fit on that line. Otherwise, arguments must be placed on individual lines. These rules also apply to FFI calls. A `where` keyword and the following arguments may all exist on their own line.

--- a/pony.g
+++ b/pony.g
@@ -128,7 +128,7 @@ withelem
   ;
 
 caseexpr
-  : '|' ('\\' ID (',' ID)* '\\')? pattern? ('if' rawseq)? ('=>' rawseq)?
+  : '|' ('\\' ID (',' ID)* '\\')? casepattern? ('if' rawseq)? ('=>' rawseq)?
   ;
 
 elseiftype
@@ -162,6 +162,11 @@ nextpattern
   | nextparampattern
   ;
 
+casepattern
+  : ('var' | 'let' | 'embed') ID (':' type)?
+  | caseparampattern
+  ;
+
 pattern
   : ('var' | 'let' | 'embed') ID (':' type)?
   | parampattern
@@ -170,6 +175,11 @@ pattern
 nextparampattern
   : ('not' | 'addressof' | MINUS_NEW | MINUS_TILDE_NEW | 'digestof') parampattern
   | nextpostfix
+  ;
+
+caseparampattern
+  : ('not' | 'addressof' | '-' | '-~' | MINUS_NEW | MINUS_TILDE_NEW | 'digestof') caseparampattern
+  | casepostfix
   ;
 
 parampattern
@@ -181,8 +191,12 @@ nextpostfix
   : nextatom antlr_2*
   ;
 
+casepostfix
+  : caseatom antlr_3*
+  ;
+
 postfix
-  : atom antlr_3*
+  : atom antlr_4*
   ;
 
 call
@@ -212,6 +226,24 @@ nextatom
   | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) lambdaparams? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
+  | 'if' ('\\' ID (',' ID)* '\\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
+  | 'while' ('\\' ID (',' ID)* '\\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'for' ('\\' ID (',' ID)* '\\')? idseq 'in' rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  ;
+
+caseatom
+  : ID
+  | 'this'
+  | literal
+  | ('(' | LPAREN_NEW) rawseq tuple? ')'
+  | ('[' | LSQUARE_NEW) ('as' type ':')? rawseq? ']'
+  | 'object' ('\\' ID (',' ID)* '\\')? cap? ('is' type)? members 'end'
+  | '{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) lambdaparams? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) lambdaparams? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
+  | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
+  | '__loc'
+  | 'while' ('\\' ID (',' ID)* '\\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'for' ('\\' ID (',' ID)* '\\')? idseq 'in' rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
   ;
 
 atom
@@ -225,6 +257,9 @@ atom
   | '@{' ('\\' ID (',' ID)* '\\')? cap? ID? typeparams? ('(' | LPAREN_NEW) lambdaparams? ')' lambdacaptures? (':' type)? '?'? '=>' rawseq '}' cap?
   | '@' (ID | STRING) typeargs? ('(' | LPAREN_NEW) positional? named? ')' '?'?
   | '__loc'
+  | 'if' ('\\' ID (',' ID)* '\\')? rawseq 'then' rawseq (elseif | ('else' annotatedrawseq))? 'end'
+  | 'while' ('\\' ID (',' ID)* '\\')? rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
+  | 'for' ('\\' ID (',' ID)* '\\')? idseq 'in' rawseq 'do' rawseq ('else' annotatedrawseq)? 'end'
   ;
 
 tuple
@@ -285,7 +320,7 @@ tupletype
   ;
 
 infixtype
-  : type antlr_4*
+  : type antlr_5*
   ;
 
 isecttype
@@ -380,6 +415,14 @@ antlr_3
   ;
 
 antlr_4
+  : dot
+  | tilde
+  | chain
+  | typeargs
+  | call
+  ;
+
+antlr_5
   : uniontype
   | isecttype
   ;

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -30,7 +30,8 @@ DECL(pattern);
 DECL(idseq_in_seq);
 DECL(members);
 DECL(thisliteral);
-
+DECL(cond);
+DECL(whileloop);
 
 /* Precedence
  *
@@ -519,18 +520,19 @@ DEF(ffi);
   OPT TOKEN(NULL, TK_QUESTION);
   DONE();
 
+// atom
 // ref | this | literal | tuple | array | object | lambda | barelambda | ffi |
 // location
 DEF(atom);
   RULE("value", ref, thisliteral, literal, groupedexpr, array, object, lambda,
-    barelambda, ffi, location);
+    barelambda, ffi, location, cond, whileloop);
   DONE();
 
 // ref | this | literal | tuple | array | object | lambda | barelambda| ffi |
 // location
 DEF(nextatom);
   RULE("value", ref, thisliteral, literal, nextgroupedexpr, nextarray, object,
-    lambda, barelambda, ffi, location);
+    lambda, barelambda, ffi, location, cond, whileloop);
   DONE();
 
 // DOT ID

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -32,6 +32,7 @@ DECL(members);
 DECL(thisliteral);
 DECL(cond);
 DECL(whileloop);
+DECL(forloop);
 
 /* Precedence
  *
@@ -521,18 +522,18 @@ DEF(ffi);
   DONE();
 
 // atom
-// ref | this | literal | tuple | array | object | lambda | barelambda | ffi |
+// ref | this | literal | tuple | array | object | lambda | barelambda | ffi | cond | whileloop | forloop
 // location
 DEF(atom);
   RULE("value", ref, thisliteral, literal, groupedexpr, array, object, lambda,
-    barelambda, ffi, location, cond, whileloop);
+    barelambda, ffi, location, cond, whileloop, forloop);
   DONE();
 
-// ref | this | literal | tuple | array | object | lambda | barelambda| ffi |
+// ref | this | literal | tuple | array | object | lambda | barelambda| ffi | cond | whileloop | forloop
 // location
 DEF(nextatom);
   RULE("value", ref, thisliteral, literal, nextgroupedexpr, nextarray, object,
-    lambda, barelambda, ffi, location, cond, whileloop);
+    lambda, barelambda, ffi, location, cond, whileloop, forloop);
   DONE();
 
 // DOT ID

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -644,6 +644,18 @@ TEST_F(SugarTest, IfWithElse)
 }
 
 
+TEST_F(SugarTest, NotIf)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  fun f() =>\n"
+    "    let a = true\n"
+    "    if not if a then not a else a end then a end";
+
+  TEST_COMPILE(short_form);
+}
+
+
 TEST_F(SugarTest, WhileWithoutElse)
 {
   const char* short_form =
@@ -670,6 +682,18 @@ TEST_F(SugarTest, WhileWithElse)
     "  var create: U32\n"
     "  fun f(): U32 val =>\n"
     "    while 1 do 2 else 3 end";
+
+  TEST_COMPILE(short_form);
+}
+
+
+TEST_F(SugarTest, NotWhileWithElse)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  fun f(): U32 val =>\n"
+    "    let a = true\n"
+    "    not while a do true else false end";
 
   TEST_COMPILE(short_form);
 }
@@ -803,6 +827,17 @@ TEST_F(SugarTest, ForWithElse)
     "  )";
 
   TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, NotForWithElse)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  fun f()=>\n"
+    "    not for i in 1 do true else false end";
+
+  TEST_COMPILE(short_form);
 }
 
 


### PR DESCRIPTION
This pull request fixes issue #2988, where `not if`, `not for` and `not while` resulted in a parse error, even though these should technically be valid.

Tests have been included to prevent this issue from happening again in the future.