### PR TITLE
Better error message for check_receiver_cap

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -403,8 +403,18 @@ static bool check_receiver_cap(pass_opt_t* opt, ast_t* ast, bool* recovered)
 
     ast_error_frame(&frame, ast,
       "receiver type is not a subtype of target type");
-    ast_error_frame(&frame, ast_child(lhs),
-      "receiver type: %s", ast_print_type(a_type));
+
+    switch (ast_id(a_type)) { // provide better information if the refcap is `this->*`
+      case TK_ARROW:
+        ast_error_frame(&frame, ast_child(lhs),
+          "receiver type: %s (which becomes '%s' in this context)", ast_print_type(a_type), ast_print_type(viewpoint_upper(a_type)));
+        break;
+
+      default:
+        ast_error_frame(&frame, ast_child(lhs),
+          "receiver type: %s", ast_print_type(a_type));
+    }
+
     ast_error_frame(&frame, cap,
       "target type: %s", ast_print_type(t_type));
     errorframe_append(&frame, &info);


### PR DESCRIPTION
This addresses issue #2986 by:

- giving a local equivalent to the `this->x` viewpoint adaptation (which is what is printed on the last line of the "Infos" section)
- giving a hint when the `this->x` viewpoint adaptation turns into a `box/val/iso` in the current context while also trying to access a `ref` method

As an example, this is what the error from the code included in the original issue looks like on 0.33.1:

```
Error:
/_/main.pony:19:8: receiver type is not a subtype of target type
    fox()
       ^
    Info:
    /_/main.pony:19:5: receiver type: this->Fox ref
        fox()
        ^
    /_/main.pony:28:3: target type: Fox ref
      fun ref apply() =>
      ^
    /_/main.pony:10:12: Fox box is not a subtype of Fox ref: box is not a subcap of ref
      let fox: Fox ref
```

And this is what the error looks like with this patch:

```
Error:
/_/main.pony:19:8: receiver type is not a subtype of target type
    fox()
       ^
    Info:
    /_/main.pony:19:5: receiver type: this->Fox ref (which becomes 'Fox box' in this context)
        fox()
        ^
    /_/main.pony:28:3: target type: Fox ref
      fun ref apply() =>
      ^
    /_/main.pony:10:12: Fox box is not a subtype of Fox ref: box is not a subcap of ref
      let fox: Fox ref
               ^
    /_/main.pony:17:3: you are trying to change state in a box function; this would be possible in a ref function
      fun apply() =>
      ^
```