### PR TITLE
Improved error for undefined but used left side of declarations

### DIFF
--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -723,6 +723,7 @@ bool refer_qualify(pass_opt_t* opt, ast_t* ast)
 
 static void error_check_used_decl(errorframe_t* frame, ast_t* ast)
 {
+  // Prints an info about why the lvalue is needed
   ast_t* parent = ast_parent(ast);
   pony_assert(parent != NULL);
   token_id parent_id = ast_id(parent);
@@ -734,6 +735,7 @@ static void error_check_used_decl(errorframe_t* frame, ast_t* ast)
 
 static void error_consumed_but_used(pass_opt_t* opt, ast_t* ast)
 {
+  // Prints an error about an lvalue's old value being needed, but consumed (it is unknown wether or not this code can be reached in any pratical case)
   errorframe_t frame = NULL;
   ast_error_frame(&frame, ast,
     "the left side is consumed but its value is used");
@@ -745,6 +747,7 @@ static void error_consumed_but_used(pass_opt_t* opt, ast_t* ast)
 
 static void error_undefined_but_used(pass_opt_t* opt, ast_t* ast)
 {
+  // Prints an error about an lvalue's old value being needed, but undefined
   errorframe_t frame = NULL;
   ast_error_frame(&frame, ast,
     "the left side is undefined but its value is used");

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -729,7 +729,7 @@ static void error_check_used_decl(errorframe_t* frame, ast_t* ast)
   token_id parent_id = ast_id(parent);
 
   if (parent_id == TK_VAR || parent_id == TK_LET) {
-    ast_error_frame(frame, parent, "the previous value of '%s' is used because you are trying to use the return value of this %s declaration", ast_print_type(ast), ast_print_type(parent));
+    ast_error_frame(frame, parent, "the previous value of '%s' is used because you are trying to use the resulting value of this %s declaration", ast_print_type(ast), ast_print_type(parent));
   }
 }
 

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -405,6 +405,20 @@ TEST_F(ReferTest, RepeatLoopDeclareLetAndUseOutside)
     "can't find declaration of 'c3'");
 }
 
+TEST_F(ReferTest, UndefinedVarValueNeeded)
+{
+  const char* src =
+    "class iso C\n"
+
+    "actor Main\n"
+      "new create(env: Env) => None\n"
+      "fun apply(): C =>\n"
+        "var c = C";
+
+  TEST_ERRORS_1(src,
+    "the left side is undefined but its value is used");
+}
+
 TEST_F(ReferTest, RepeatLoopDefineVarAndUseOutside)
 {
   const char* src =


### PR DESCRIPTION
This addresses #2828

Declaring a variable at the end of a function which expects a return value or having generally a variable declaration where the compiler expects to use the return value caused in most cases an error stating that the variable is undefined but its value is used:

```
actor Main
  new create(env:Env) =>
    confusing_error_msg()
    
  fun confusing_error_msg(): String =>
    var s = "A string."
```

This bit of code triggers the following error on 0.33.1:

```
Error:
main.pony:26:9: the left side is undefined but its value is used
    var s = "A string."
        ^
Error:
main.pony:26:11: left side must be something that can be assigned to
    var s = "A string."
          ^
```

The presence of the second error was also considered to be erroneous.

This patch discriminates in the `is_lvalue` function from `pass/refer.c` cases where the left-hand side of the assignment is not an `lvalue` and cases where it triggers an error. This way, the compiler can tell between the left side not being something that can be assigned to or it having triggered an error.

Additionally, an *Info* message is triggered when the left side's old value is needed in a declaration.

This is what the error message now looks like:

```
Error:
main.pony:6:9: the left side is undefined but its value is used
    var s = "A string."
        ^
    Info:
    main.pony:6:5: the previous value of 's' is used because you are trying to use the return value of this var declaration
        var s = "A string."
        ^
```