### PR TITLE
Clean up Linux ponyup installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@ Prebuilt Pony binaries are available on a number of platforms. They are built us
 
 Prebuilt Linux packages are available via [ponyup](https://github.com/ponylang/ponyup) for Glibc and musl libc based Linux distribution. You can install nightly builds as well as official releases using ponyup.
 
-To install the most recent ponyc on a Glibc distribution (for example, Debian, Ubuntu, and most distros):
+To install the most recent ponyc:
 
 ```bash
 ponyup update ponyc release


### PR DESCRIPTION
There's a single command for glibc and musl distros. The language
in the install still referenced glibc spefically. That's left over
from when it had glibc and musl specific instructions.