### PR TITLE
Fix cloudsmith package directory structure

### DIFF
--- a/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
@@ -3,8 +3,7 @@
 set -e
 
 API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
+if [[ ${API_KEY} == "" ]]; then
   echo "API_KEY needs to be supplied as first script argument."
   exit 1
 fi
@@ -13,7 +12,6 @@ TODAY=$(date +%Y%m%d)
 
 # Compiler target parameters
 ARCH=x86-64
-PIC=true
 
 # Triple construction
 VENDOR=unknown
@@ -23,8 +21,8 @@ TRIPLE=${ARCH}-${VENDOR}-${OS}
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
-DESTINATION=${BUILD_PREFIX}/lib/pony
 PONY_VERSION="nightly-${TODAY}"
+DESTINATION=${BUILD_PREFIX}/${PONY_VERSION}
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
@@ -41,21 +39,20 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
-make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
+MAKE_FLAGS="arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+version=${PONY_VERSION}"
+make configure "${MAKE_FLAGS}"
+make build "${MAKE_FLAGS}"
+make install "DESTDIR=${DESTINATION}" "${MAKE_FLAGS}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
-pushd ${DESTINATION} || exit 1
-tar -cvzf ${ASSET_FILE} *
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" "${PONY_VERSION}"
 popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key "${API_KEY}" \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+  "${ASSET_PATH}" "${ASSET_FILE}"

--- a/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
@@ -3,15 +3,13 @@
 set -e
 
 API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
+if [[ ${API_KEY} == "" ]]; then
   echo "API_KEY needs to be supplied as first script argument."
   exit 1
 fi
 
 # Compiler target parameters
 ARCH=x86-64
-PIC=true
 
 # Triple construction
 VENDOR=unknown
@@ -21,14 +19,15 @@ TRIPLE=${ARCH}-${VENDOR}-${OS}
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
-DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION=$(cat VERSION)
+DESTINATION=${BUILD_PREFIX}/${PONY_VERSION}
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
 PACKAGE=ponyc-${TRIPLE}
 
 # Cloudsmith configuration
-CLOUDSMITH_VERSION=$(cat VERSION)
+CLOUDSMITH_VERSION=${PONY_VERSION}
 ASSET_OWNER=ponylang
 ASSET_REPO=releases
 ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
@@ -38,19 +37,19 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM}
+MAKE_FLAGS="arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}"
+make configure "${MAKE_FLAGS}"
+make build "${MAKE_FLAGS}"
+make install "DESTDIR=${DESTINATION}" "${MAKE_FLAGS}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
-pushd ${DESTINATION} || exit 1
-tar -cvzf ${ASSET_FILE} *
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" "${PONY_VERSION}"
 popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key "${API_KEY}" \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+  "${ASSET_PATH}" "${ASSET_FILE}"

--- a/.ci-scripts/x86-64-unknown-linux-musl-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-musl-nightly.bash
@@ -3,8 +3,7 @@
 set -e
 
 API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
+if [[ ${API_KEY} == "" ]]; then
   echo "API_KEY needs to be supplied as first script argument."
   exit 1
 fi
@@ -13,7 +12,6 @@ TODAY=$(date +%Y%m%d)
 
 # Compiler target parameters
 ARCH=x86-64
-PIC=true
 
 # Triple construction
 VENDOR=unknown
@@ -23,8 +21,8 @@ TRIPLE=${ARCH}-${VENDOR}-${OS}
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
-DESTINATION=${BUILD_PREFIX}/lib/pony
 PONY_VERSION="nightly-${TODAY}"
+DESTINATION=${BUILD_PREFIX}/${PONY_VERSION}
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
@@ -41,21 +39,20 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
-make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
+MAKE_FLAGS="arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+version=${PONY_VERSION}"
+make configure "${MAKE_FLAGS}"
+make build "${MAKE_FLAGS}"
+make install "DESTDIR=${DESTINATION}" "${MAKE_FLAGS}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
-pushd ${DESTINATION} || exit 1
-tar -cvzf ${ASSET_FILE} *
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" "${PONY_VERSION}"
 popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key "${API_KEY}" \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+  "${ASSET_PATH}" "${ASSET_FILE}"

--- a/.ci-scripts/x86-64-unknown-linux-musl-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-musl-release.bash
@@ -3,15 +3,13 @@
 set -e
 
 API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
+if [[ ${API_KEY} == "" ]]; then
   echo "API_KEY needs to be supplied as first script argument."
   exit 1
 fi
 
 # Compiler target parameters
 ARCH=x86-64
-PIC=true
 
 # Triple construction
 VENDOR=unknown
@@ -21,14 +19,15 @@ TRIPLE=${ARCH}-${VENDOR}-${OS}
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
-DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION=$(cat VERSION)
+DESTINATION=${BUILD_PREFIX}/${PONY_VERSION}
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
 PACKAGE=ponyc-${TRIPLE}
 
 # Cloudsmith configuration
-CLOUDSMITH_VERSION=$(cat VERSION)
+CLOUDSMITH_VERSION=${PONY_VERSION}
 ASSET_OWNER=ponylang
 ASSET_REPO=releases
 ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
@@ -38,19 +37,19 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM}
+MAKE_FLAGS="arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}"
+make configure "${MAKE_FLAGS}"
+make build "${MAKE_FLAGS}"
+make install "DESTDIR=${DESTINATION}" "${MAKE_FLAGS}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
-pushd ${DESTINATION} || exit 1
-tar -cvzf ${ASSET_FILE} *
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" "${PONY_VERSION}"
 popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key "${API_KEY}" \
   --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+  "${ASSET_PATH}" "${ASSET_FILE}"


### PR DESCRIPTION
clousmith packages became malformed with the switch to CMake because the `DESTDIR` provided to the Makefile did not include the version tag directory.