### PR TITLE
Fix broken cloudsmith packaging

### DIFF
--- a/.ci-scripts/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/x86-64-apple-darwin-nightly.bash
@@ -45,7 +45,7 @@ make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
 
 # Package it all up

--- a/.ci-scripts/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/x86-64-apple-darwin-release.bash
@@ -41,7 +41,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 echo "Building ponyc installation..."
 make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM}
 
 # Package it all up

--- a/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-nightly.bash
@@ -45,7 +45,7 @@ make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
 
 # Package it all up

--- a/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-gnu-release.bash
@@ -40,7 +40,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 echo "Building ponyc installation..."
 make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM}
 
 # Package it all up

--- a/.ci-scripts/x86-64-unknown-linux-musl-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-musl-nightly.bash
@@ -45,7 +45,7 @@ make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
   version="${PONY_VERSION}"
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
 
 # Package it all up

--- a/.ci-scripts/x86-64-unknown-linux-musl-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-musl-release.bash
@@ -40,7 +40,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 echo "Building ponyc installation..."
 make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
 make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-make install DESTDIR=${DESTINATION} arch=${ARCH} \
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
   build_flags=-j${MAKE_PARALLELISM}
 
 # Package it all up


### PR DESCRIPTION
Was changed during cmake switch over but DESTDIR change from using prefix
and symlink=no had additional unintended ramifications on the creation of
the `version` directory that was expected.

This commit reverts to the prior usage that was specifically crafted for
Cloudsmith packaging.