### PR TITLE
Make windows zip file name `x86-64` instead of `x86_64`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,7 +98,7 @@ task:
   package_script:
     - ps: .\make.ps1 -Command package -Config Release -Prefix "build\install\release" -Version nightly
   upload_script:
-    - ps: $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/nightlies build\ponyc-x86_64-pc-windows-msvc.zip
+    - ps: $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/nightlies build\ponyc-x86-64-pc-windows-msvc.zip
 
 #
 # Release build tasks
@@ -199,7 +199,7 @@ task:
   package_script:
     - ps: .\make.ps1 -Command package -Config Release -Prefix "build\install\release" -Version (Get-Content .\VERSION)
   upload_script:
-    - ps: $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/releases build\ponyc-x86_64-pc-windows-msvc.zip
+    - ps: $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/releases build\ponyc-x86-64-pc-windows-msvc.zip
 
 #
 # Pull Request Tasks

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,6 @@ Windows users will need to install:
   - If using Visual C++ Build Tools, install the `Visual C++ build tools` workload, and the `C++ core features` individual component.
   - Install the latest `Windows 10 SDK (10.x.x.x) for Desktop` component.
 
-Once you have installed the prerequisites, you can download the latest ponyc release from [Cloudsmith](https://cloudsmith.io/~ponylang/repos/releases/packages/detail/raw/ponyc-x86_64-pc-windows-msvc.zip).
+Once you have installed the prerequisites, you can download the latest ponyc release from [Cloudsmith](https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip).
 
-Unzip the release file in a convenient location, and you will find `ponyc.exe` in the `ponyc\bin` directory. Following extraction, to make `ponyc.exe` globally available, add it to your `PATH` either by using Advanced System Settings->Environment Variables to extend `PATH` or by using the `setx` command, e.g. `setx PATH "%PATH%;<directory you unzipped to>\ponyc\bin"`
+Unzip the release file in a convenient location, and you will find `ponyc.exe` in the `bin` directory. Following extraction, to make `ponyc.exe` globally available, add it to your `PATH` either by using Advanced System Settings->Environment Variables to extend `PATH` or by using the `setx` command, e.g. `setx PATH "%PATH%;<directory you unzipped to>\bin"`

--- a/make.ps1
+++ b/make.ps1
@@ -322,7 +322,7 @@ switch ($Command.ToLower())
     }
     "package"
     {
-        $package = "ponyc-x86_64-pc-windows-msvc.zip"
+        $package = "ponyc-x86-64-pc-windows-msvc.zip"
         Write-Output "Creating $buildDir\..\$package"
 
         Compress-Archive -Path "$Prefix\bin", "$Prefix\lib", "$Prefix\packages", "$Prefix\examples" -DestinationPath "$buildDir\..\$package" -Force


### PR DESCRIPTION
This conforms to the other OS package names.