### PR TITLE
Build Docker images for windows builds

### DIFF
--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
@@ -1,6 +1,6 @@
 #escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1909
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -8,7 +8,7 @@ ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a
 ADD https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
 
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc; `
-    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `    
+    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `
     setx /M PATH $($env:PATH + ';C:\ponyc\bin')
 
 CMD C:\ponyc\bin\ponyc.exe

--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
@@ -1,0 +1,14 @@
+#escape=`
+
+FROM mcr.microsoft.com/windows/servercore:1909
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+ADD https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
+
+RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc; `
+    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `    
+    setx /M PATH $($env:PATH + ';C:\ponyc\bin')
+
+CMD C:\ponyc\bin\ponyc.exe

--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
@@ -1,0 +1,7 @@
+# You should already be logged in to DockerHub when you run this.
+$ErrorActionPreference = 'Stop'
+
+$dockerfileDir = Split-Path $script:MyInvocation.MyCommand.Path
+
+docker build --pull -t "ponylang/ponyc:windows" $dockerfileDir
+docker push "ponylang/ponyc:windows"

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
@@ -1,6 +1,6 @@
 #escape=`
 
-FROM mcr.microsoft.com/windows/servercore:1909
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -8,7 +8,7 @@ ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a
 ADD https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
 
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc; `
-    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `    
+    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `
     setx /M PATH $($env:PATH + ';C:\ponyc\bin')
 
 CMD C:\ponyc\bin\ponyc.exe

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
@@ -1,0 +1,14 @@
+#escape=`
+
+FROM mcr.microsoft.com/windows/servercore:1909
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+ADD https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
+
+RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc; `
+    & C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `    
+    setx /M PATH $($env:PATH + ';C:\ponyc\bin')
+
+CMD C:\ponyc\bin\ponyc.exe

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
@@ -1,0 +1,22 @@
+# You should already be logged in to DockerHub when you run this.
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhitespace($env:VERSION))
+{
+    throw "The version number needs to be set in the VERSION environment variable (e.g. X.Y.Z)."
+}
+
+if ([string]::IsNullOrWhitespace($env:GITHUB_REPOSITORY))
+{
+    throw "The name of this repository needs to be set in the GITHUB_REPOSITORY environment variable (e.g. ponylang/ponyup)."
+}
+
+$dockerfileDir = Split-Path $script:MyInvocation.MyCommand.Path
+
+$dockerTag = $env:GITHUB_REPOSITORY + ':' + $env:VERSION + '-windows'
+docker build --pull -t "$dockerTag" "$dockerfileDir"
+docker push "$dockerTag"
+
+$dockerTag = $env:GITHUB_REPOSITORY + ':release-windows'
+docker build --pull -t "$dockerTag" "$dockerfileDir"
+docker push "$dockerTag"

--- a/.github/workflows/handle-external-events.yml
+++ b/.github/workflows/handle-external-events.yml
@@ -48,6 +48,24 @@ jobs:
       - name: Build and push
         run: bash .dockerfiles/latest/x86-64-unknown-linux-musl/build-and-push.bash
 
+  build-latest-windows-docker-image:
+    if: |
+      github.event.action == 'cloudsmith-package-synchronised' &&
+      github.event.client_payload.data.repository == 'nightlies' &&
+      github.event.client_payload.data.name == 'ponyc-x86-64-pc-windows-msvc.zip'
+
+    name: Build latest Windows Docker image
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: .dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
+
   build-release-gnu-docker-image:
     if: |
       github.event.action == 'cloudsmith-package-synchronised' &&
@@ -85,6 +103,26 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Build and push
         run: bash .dockerfiles/release/x86-64-unknown-linux-musl/build-and-push.bash
+        env:
+          VERSION: ${{ github.event.client_payload.data.version }}
+
+  build-release-windows-docker-image:
+    if: |
+      github.event.action == 'cloudsmith-package-synchronised' &&
+      github.event.client_payload.data.repository == 'releases' &&
+      github.event.client_payload.data.name == 'ponyc-x86-64-pc-windows-msvc.zip'
+
+    name: Build release Windows Docker image
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: .dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
         env:
           VERSION: ${{ github.event.client_payload.data.version }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Docker build
         run: "docker build --pull --file=.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile ."
 
+  validate-windows-docker-latest-image-builds:
+    name: Validate Windows Docker image builds
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker build
+        run: "docker build --pull --file=.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile ."
+
   validate-musl-docker-release-image-builds:
     name: Validate musl Docker release image builds
     runs-on: ubuntu-latest
@@ -44,6 +52,14 @@ jobs:
       - uses: actions/checkout@v1
       - name: Docker build
         run: "docker build --pull --file=.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile ."
+
+  validate-windows-docker-release-image-builds:
+    name: Validate Windows Docker release image builds
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker build
+        run: "docker build --pull --file=.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile ."
 
   verify-changelog:
     name: Verify CHANGELOG is valid


### PR DESCRIPTION
This change adds Dockerfiles and associated GitHub actions to build Windows Docker images for nightlies and releases.