### PR TITLE
Update Windows build docker image to use an image on DockerHub.

### DIFF
--- a/.ci-dockerfiles/windowsservercore/Dockerfile
+++ b/.ci-dockerfiles/windowsservercore/Dockerfile
@@ -1,6 +1,0 @@
-FROM cirrusci/windowsservercore:2019
-
-RUN choco install visualstudio2019buildtools -y --no-progress --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools;includeRecommended --locale en-US" \
-  && choco install python3 -y --no-progress \
-  && C:\Python37\python.exe -m pip install --upgrade cloudsmith-cli \
-  && choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'

--- a/.ci-dockerfiles/windowsservercore/README.md
+++ b/.ci-dockerfiles/windowsservercore/README.md
@@ -1,4 +1,0 @@
-# Overview
-
-This docker image is used to compile for Windows.
-Cirrus-CI will automatically (re)build it.

--- a/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
@@ -6,7 +6,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
 
-RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `
-  choco install python3 -y --no-progress; `
-  C:\Python38\python.exe -m pip install --upgrade cloudsmith-cli; `
-  choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'
+RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended
+RUN choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'
+RUN choco install python3 -y --no-progress; `
+  C:\Python38\python.exe -m pip install --upgrade cloudsmith-cli

--- a/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
@@ -1,0 +1,12 @@
+#escape=`
+
+FROM cirrusci/windowsservercore:2019
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+
+RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:\BuildTools; `
+  choco install python3 -y --no-progress; `
+  C:\Python38\python.exe -m pip install --upgrade cloudsmith-cli; `
+  choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'

--- a/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/README.md
+++ b/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+This docker image is used to compile PonyC for Windows.
+
+Run `.\build-and-push.ps1` to build and push an updated version.  You should already be logged in to DockerHub before you run it.

--- a/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/build-and-push.ps1
+++ b/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/build-and-push.ps1
@@ -1,0 +1,9 @@
+# You should already be logged in to DockerHub when you run this.
+$ErrorActionPreference = 'Stop'
+
+$today = (Get-Date -Format 'yyyyMMdd')
+$dockerfileDir = Split-Path $script:MyInvocation.MyCommand.Path
+
+$dockerTag = "ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:$today"
+docker build --pull -t "$dockerTag" "$dockerfileDir"
+docker push "$dockerTag"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -341,6 +341,7 @@ task:
       - ps: .\make.ps1 -Command libs -Generator "Visual Studio 16 2019"
 
   config_script:
+    - ps: cmake --help
     - ps: .\make.ps1 -Command configure -Config Release -Generator "Visual Studio 16 2019"
   build_script:
     - ps: .\make.ps1 -Command build -Config Release -Generator "Visual Studio 16 2019"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,7 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
     os_version: 2019
     cpu: 8
     memory: 24
@@ -173,7 +173,7 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
     os_version: 2019
     cpu: 8
     memory: 24
@@ -326,7 +326,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
     os_version: 2019
     cpu: 8
     memory: 24
@@ -341,7 +341,6 @@ task:
       - ps: .\make.ps1 -Command libs -Generator "Visual Studio 16 2019"
 
   config_script:
-    - ps: cmake --help
     - ps: .\make.ps1 -Command configure -Config Release -Generator "Visual Studio 16 2019"
   build_script:
     - ps: .\make.ps1 -Command build -Config Release -Generator "Visual Studio 16 2019"
@@ -352,7 +351,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
     os_version: 2019
     cpu: 8
     memory: 24

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,7 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   windows_container:
-    dockerfile: .ci-dockerfiles/windowsservercore/Dockerfile
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
     os_version: 2019
     cpu: 8
     memory: 24
@@ -173,7 +173,7 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   windows_container:
-    dockerfile: .ci-dockerfiles/windowsservercore/Dockerfile
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
     os_version: 2019
     cpu: 8
     memory: 24
@@ -326,7 +326,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    dockerfile: .ci-dockerfiles/windowsservercore/Dockerfile
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
     os_version: 2019
     cpu: 8
     memory: 24
@@ -351,7 +351,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    dockerfile: .ci-dockerfiles/windowsservercore/Dockerfile
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200406
     os_version: 2019
     cpu: 8
     memory: 24


### PR DESCRIPTION
This makes it work the same way as the Unix builds.