### PR TITLE
Make clang our default compiler on Linux, macOS, and FreeBSD

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,7 +24,7 @@ The build system is divided into several stages:
 - `make clean` will clean your ponyc build, but not the libraries.
 - `make distclean` will delete the entire `build` directory, including the libraries.
 
-The build system defaults to using Clang on Unix.  In order to use GCC, you must explicitly set it in the `configure` step: `make configure CC=gcc`.
+The build system defaults to using Clang on Unix.  In order to use GCC, you must explicitly set it in the `configure` step: `make configure CC=gcc CXX=g++`.
 
 ## FreeBSD
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,11 +1,11 @@
 # Building ponyc from source
 
-First of all, you need a compiler with decent C11 support. The following compilers are supported, though we recommend to use the most recent versions.
+First of all, you need a compiler with decent C11 support. We officially support Clang on Unix and MSVC on Windows; the following are known to work:
 
-- GCC >= 4.7
 - Clang >= 3.4
-- MSVC >= 2017
 - XCode Clang >= 6.0
+- MSVC >= 2017
+- GCC >= 4.7
 
 You also need [CMake](https://cmake.org/download/) version 3.15 or higher.
 
@@ -17,11 +17,14 @@ The build system is divided into several stages:
 
 - Build the vendored LLVM libraries that are included in the `lib/llvm/src` Git submodule by running `make libs` (`.\make.ps1 libs` on Windows).  This stage only needs to be run once the first time you build (or if the vendored LLVM submodule changes, or if you run `make distclean`).
 
-- `make build` will build ponyc and put it in `build/release`.  Use `make build config=debug` (`.\make.ps1 build -Config Debug` on Windows) for a debug build.
+- `make configure` to configure the CMake build directory.  Use `make configure config=debug` (`.\make.ps1 configure -Config Debug`) for a debug build.
+- `make build` will build ponyc and put it in `build/release`.  Use `make build config=debug` (`.\make.ps1 build -Config Debug` on Windows) for a debug build that goes in `build/debug`.
 - `make test` will run the test suite.
 - `make install` will install ponyc to `/usr/local` by default (`make install prefix=/foo` to install elsewhere; `make install -Prefix foo` on Windows).
 - `make clean` will clean your ponyc build, but not the libraries.
-- `make distclean` will delete the `build` directory, including the libraries.
+- `make distclean` will delete the entire `build` directory, including the libraries.
+
+The build system defaults to using Clang on Unix.  In order to use GCC, you must explicitly set it in the `configure` step: `make configure CC=gcc`.
 
 ## FreeBSD
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,7 +14,7 @@ ponyup update ponyc release
 
 Additional requirements:
 
-All ponyc Linux installations need a C compiler such as gcc or clang installed. The following distributions have additional requirements:
+All ponyc Linux installations need to have a C compiler such as clang installed. Compilers other than clang might work, but clang is the officially supported C compiler. The following distributions have additional requirements:
 
 Distribution | Requires
 --- | ---

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,19 @@ else
   ponydir ?= $(prefix)/lib/pony/$(tag)
 endif
 
+# Use clang by default
+ifndef CC
+  ifneq (,$(shell clang --version 2>&1 | grep 'clang version'))
+    CC = clang
+    CXX = clang++
+  endif
+else ifeq ($(CC), cc)
+  ifneq (,$(shell clang --version 2>&1 | grep 'clang version'))
+    CC = clang
+    CXX = clang++
+  endif
+endif
+
 # By default, CC is cc and CXX is g++
 # So if you use standard alternatives on many Linuxes
 # You can get clang and g++ and then bad things will happen

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ else
   ponydir ?= $(prefix)/lib/pony/$(tag)
 endif
 
-# Use clang by default
+# Use clang by default; because CC defaults to 'cc'
+# you must explicitly set CC=gcc to use gcc
 ifndef CC
   ifneq (,$(shell clang --version 2>&1 | grep 'clang version'))
     CC = clang

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 # By default, CC is cc and CXX is g++
 # So if you use standard alternatives on many Linuxes
 # You can get clang and g++ and then bad things will happen
-ifneq (,$(shell $(CC) --version 2>&1 | grep clang))
+ifneq (,$(shell $(CC) --version 2>&1 | grep 'clang version'))
   ifneq (,$(shell $(CXX) --version 2>&1 | grep "Free Software Foundation"))
     CXX = c++
   endif
@@ -53,11 +53,11 @@ ifneq (,$(shell $(CC) --version 2>&1 | grep clang))
     $(error CC is clang but CXX is g++. They must be from matching compilers.)
   endif
 else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
-  ifneq (,$(shell $(CXX) --version 2>&1 | grep clang))
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep 'clang version'))
     CXX = c++
   endif
 
-  ifneq (,$(shell $(CXX) --version 2>&1 | grep clang))
+  ifneq (,$(shell $(CXX) --version 2>&1 | grep 'clang version'))
     $(error CC is gcc but CXX is clang++. They must be from matching compilers.)
   endif
 endif


### PR DESCRIPTION
If `CC` is not defined when running make, or is equal to `cc`, and `clang` is in the PATH, this sets `CC=clang` and `CXX=clang++`.