### PR TITLE
schedule the cycle detector with higher priority using the inject queue

### DIFF
--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -1064,7 +1064,7 @@ void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t detect_interval)
   d->last_checked = HASHMAP_BEGIN;
 }
 
-bool ponyint_cycle_check_blocked(pony_ctx_t* ctx, uint64_t tsc, uint64_t tsc2)
+bool ponyint_cycle_check_blocked(uint64_t tsc, uint64_t tsc2)
 {
   // if tsc > tsc2 then don't trigger cycle detector
   // this is used to ensure scheduler queue is empty during
@@ -1077,6 +1077,7 @@ bool ponyint_cycle_check_blocked(pony_ctx_t* ctx, uint64_t tsc, uint64_t tsc2)
   // if enough time has passed, trigger cycle detector
   if((tsc2 - tsc) > d->detect_interval)
   {
+    pony_ctx_t* ctx = ponyint_sched_get_inject_context();
     pony_send(ctx, cycle_detector, ACTORMSG_CHECKBLOCKED);
     return true;
   }
@@ -1084,27 +1085,31 @@ bool ponyint_cycle_check_blocked(pony_ctx_t* ctx, uint64_t tsc, uint64_t tsc2)
   return false;
 }
 
-void ponyint_cycle_actor_created(pony_ctx_t* ctx, pony_actor_t* actor)
+void ponyint_cycle_actor_created(pony_actor_t* actor)
 {
   // this will only be false during the creation of the cycle detector
   // and after the runtime has been shut down
-  if(cycle_detector)
+  if(cycle_detector) {
+    pony_ctx_t* ctx = ponyint_sched_get_inject_context();
     pony_sendp(ctx, cycle_detector, ACTORMSG_CREATED, actor);
+  }
 }
 
-void ponyint_cycle_actor_destroyed(pony_ctx_t* ctx, pony_actor_t* actor)
+void ponyint_cycle_actor_destroyed(pony_actor_t* actor)
 {
   // this will only be false during the creation of the cycle detector
   // and after the runtime has been shut down or if the cycle detector
   // is being destroyed
-  if(cycle_detector && !ponyint_is_cycle(actor))
+  if(cycle_detector && !ponyint_is_cycle(actor)) {
+    pony_ctx_t* ctx = ponyint_sched_get_inject_context();
     pony_sendp(ctx, cycle_detector, ACTORMSG_DESTROYED, actor);
+  }
 }
 
-void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
+void ponyint_cycle_block(pony_actor_t* actor, gc_t* gc)
 {
-  pony_assert(ctx->current == actor);
   pony_assert(&actor->gc == gc);
+  pony_ctx_t* ctx = ponyint_sched_get_inject_context();
 
   block_msg_t* m = (block_msg_t*)pony_alloc_msg(
     POOL_INDEX(sizeof(block_msg_t)), ACTORMSG_BLOCK);
@@ -1122,18 +1127,22 @@ void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc)
   pony_sendv(ctx, cycle_detector, &m->msg, &m->msg, false);
 }
 
-void ponyint_cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor)
+void ponyint_cycle_unblock(pony_actor_t* actor)
 {
+  pony_ctx_t* ctx = ponyint_sched_get_inject_context();
   pony_sendp(ctx, cycle_detector, ACTORMSG_UNBLOCK, actor);
 }
 
-void ponyint_cycle_ack(pony_ctx_t* ctx, size_t token)
+void ponyint_cycle_ack(size_t token)
 {
+  pony_ctx_t* ctx = ponyint_sched_get_inject_context();
   pony_sendi(ctx, cycle_detector, ACTORMSG_ACK, token);
 }
 
-void ponyint_cycle_terminate(pony_ctx_t* ctx)
+void ponyint_cycle_terminate()
 {
+  pony_ctx_t* ctx = ponyint_sched_get_inject_context();
+
   pony_become(ctx, cycle_detector);
   final(ctx, cycle_detector);
   ponyint_destroy(ctx, cycle_detector);
@@ -1144,7 +1153,6 @@ bool ponyint_is_cycle(pony_actor_t* actor)
 {
   return actor == cycle_detector;
 }
-
 
 #ifdef USE_MEMTRACK
 size_t ponyint_cycle_mem_size()

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -11,19 +11,19 @@ PONY_EXTERN_C_BEGIN
 
 void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t detect_interval);
 
-bool ponyint_cycle_check_blocked(pony_ctx_t* ctx, uint64_t tsc, uint64_t tsc2);
+bool ponyint_cycle_check_blocked(uint64_t tsc, uint64_t tsc2);
 
-void ponyint_cycle_actor_created(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_cycle_actor_created(pony_actor_t* actor);
 
-void ponyint_cycle_actor_destroyed(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_cycle_actor_destroyed(pony_actor_t* actor);
 
-void ponyint_cycle_block(pony_ctx_t* ctx, pony_actor_t* actor, gc_t* gc);
+void ponyint_cycle_block(pony_actor_t* actor, gc_t* gc);
 
-void ponyint_cycle_unblock(pony_ctx_t* ctx, pony_actor_t* actor);
+void ponyint_cycle_unblock(pony_actor_t* actor);
 
-void ponyint_cycle_ack(pony_ctx_t* ctx, size_t token);
+void ponyint_cycle_ack(size_t token);
 
-void ponyint_cycle_terminate(pony_ctx_t* ctx);
+void ponyint_cycle_terminate();
 
 bool ponyint_is_cycle(pony_actor_t* actor);
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -125,6 +125,10 @@ void ponyint_sched_maybe_wakeup(int32_t current_scheduler_id);
 // threads are asleep
 void ponyint_sched_maybe_wakeup_if_all_asleep(int32_t current_scheduler_id);
 
+// Retrieves the global main thread context for scheduling
+// special actors on the inject queue.
+pony_ctx_t* ponyint_sched_get_inject_context();
+
 #ifdef USE_MEMTRACK
 /** Get the static memory used by the scheduler subsystem.
  */


### PR DESCRIPTION
This addresses #3501.

PR #2709 introduced the cycle detector being lazily scheduled once a certain amount of cpu ticks (`--ponycdinterval`) has passed. Scheduler thread 0 would then 'wake up' the the cycle detector by sending it a `CHECK_BLOCKED` message. The cycle detector would then be appended to back of scheduler-0's queue. The cycle detector would then only be scheduled if either

1. Scheduler 0 is available (i.e. its queue was empty in the previous loop iteration)
2. Another scheduler thread is available and steals the cycle detector from scheduler 0's queue. However, this would only happen when the cycle detector has 'travelled' to the head of said queue.

This could create pathological behavior where cycle detection is actually deferred to a point in time where the program would be almost quiescent, especially for programs that create lots of actors right at program start, such that the distance for the cycle detector to reach the head of the scheduling queue might be relatively long.

This change treats the cycle detector as a special system actor that is maintained on the schedulers global inject queue. That is, it is always scheduled using its original start up main context (which is not related to any runtime thread), making sure that a `CHECK_BLOCK` message (and any other message it would receive after being blocked) will cause it to be pushed to the global inject queue. Every scheduler thread become available would first try to consume an item from this queue before attempting to get an actors from its local queue.

This should have the following effect on runtime system behavior:

1. Get the cycle detector to be scheduled closer to --ponycdinterval, making this a theoretical upper bound setting
2. Have the cycle detector to be scheduled with higher priority as it can be 'pop_global'd' by any scheduler thread from the inject queue.
3. Not defer garbage collection of large actor graphs for long running programs right to the end (or close to) a quiescent system.
