### PR TITLE
Add clang to CI builder images

### DIFF
--- a/.ci-dockerfiles/cross-aarch64/Dockerfile
+++ b/.ci-dockerfiles/cross-aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
 
 ARG CROSS_TRIPLE=aarch64-unknown-linux-gnu
 ARG CROSS_CC=aarch64-linux-gnu-gcc

--- a/.ci-dockerfiles/cross-arm/Dockerfile
+++ b/.ci-dockerfiles/cross-arm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
 
 ARG CROSS_TRIPLE=arm-unknown-linux-gnueabi
 ARG CROSS_CC=arm-linux-gnueabi-gcc

--- a/.ci-dockerfiles/cross-armhf/Dockerfile
+++ b/.ci-dockerfiles/cross-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+FROM ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
 
 ARG CROSS_TRIPLE=arm-unknown-linux-gnueabihf
 ARG CROSS_CC=arm-linux-gnueabihf-gcc

--- a/.ci-dockerfiles/x86-64-unknown-linux-gnu-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-gnu-builder/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update \
  && apt-get install -y \
   apt-transport-https \
   build-essential \
+  clang \
   g++-6 \
   git \
   make \

--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update \
   && apk add --update \
   alpine-sdk \
   binutils-gold \
+  clang \
   libexecinfo-dev \
   libexecinfo-static \
   coreutils \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
     cpu: 8
     memory: 24
 
@@ -27,7 +27,7 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200419
     cpu: 8
     memory: 24
 
@@ -136,7 +136,7 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
     cpu: 8
     memory: 24
 
@@ -157,7 +157,7 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200419
     cpu: 8
     memory: 24
 
@@ -237,7 +237,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
     cpu: 8
     memory: 24
 
@@ -259,7 +259,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200419
     cpu: 8
     memory: 24
 
@@ -281,7 +281,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20191106
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200419
     cpu: 8
     memory: 24
 
@@ -407,7 +407,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-cross-arm:20200127
+    image: ponylang/ponyc-ci-cross-arm:20200419
     cpu: 8
     memory: 24
 
@@ -433,7 +433,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   container:
-    image: ponylang/ponyc-ci-cross-armhf:20200212
+    image: ponylang/ponyc-ci-cross-armhf:20200419
     cpu: 8
     memory: 24
 


### PR DESCRIPTION
In prep to switching to using clang as our supported compiler. Currently,
we have no specific compiler we are defaulting to. It's been decided that
we will settle on clang not gcc.