### PR TITLE
Add OSSockOpt constants added by Linux 5.1 kernel

### DIFF
--- a/packages/net/ossockopt.pony
+++ b/packages/net/ossockopt.pony
@@ -1320,3 +1320,7 @@ primitive OSSockOpt
   fun udp_no_check6_rx():I32 => @pony_os_sockopt_option(I32(1095))
   fun udp_no_check6_tx():I32 => @pony_os_sockopt_option(I32(1096))
   fun udp_vendor():I32 => @pony_os_sockopt_option(I32(1097))
+  fun so_rcvtimeo_old():I32 => @pony_os_sockopt_option(I32(1098))
+  fun so_rcvtimeo_new():I32 => @pony_os_sockopt_option(I32(1099))
+  fun so_sndtimeo_old():I32 => @pony_os_sockopt_option(I32(1100))
+  fun so_sndtimeo_new():I32 => @pony_os_sockopt_option(I32(1101))

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -5103,6 +5103,18 @@ PONY_API int pony_os_sockopt_option(int option)
 #ifdef UDP_VENDOR
     case 1097: return UDP_VENDOR;
 #endif
+#ifdef SO_RCVTIMEO_OLD
+    case 1098: return SO_RCVTIMEO_OLD;
+#endif
+#ifdef SO_RCVTIMEO_NEW
+    case 1099: return SO_RCVTIMEO_NEW;
+#endif
+#ifdef SO_SNDTIMEO_OLD
+    case 1100: return SO_SNDTIMEO_OLD;
+#endif
+#ifdef SO_SNDTIMEO_NEW
+    case 1101: return SO_SNDTIMEO_NEW;
+#endif
     default: return -1;
   }
 }


### PR DESCRIPTION
Add SO_RCVTIMEO_OLD, SO_RCVTIMEO_NEW, SO_SNDTIMEO_OLD, & SO_SNDTIMEO_NEW, which were added to the Linux kernel 5.1, see #3498.

Fixes #3498 

Using this test program:

```Pony
use "net"

actor Main
  new create(env: Env) =>
    @printf[I32]("so_rcvtimeo = %d\n".cstring(), OSSockOpt.so_rcvtimeo())
    @printf[I32]("so_rcvtimeo_old = %d\n".cstring(), OSSockOpt.so_rcvtimeo_old())
    @printf[I32]("so_rcvtimeo_new = %d\n".cstring(), OSSockOpt.so_rcvtimeo_new())
    @printf[I32]("so_sndtimeo = %d\n".cstring(), OSSockOpt.so_sndtimeo())
    @printf[I32]("so_sndtimeo_old = %d\n".cstring(), OSSockOpt.so_sndtimeo_old())
    @printf[I32]("so_sndtimeo_new = %d\n".cstring(), OSSockOpt.so_sndtimeo_new())
```

... I get the following output on an Ubuntu 19.10 x86-64 VM with a Linux 5.3.0-46-generic kernel.

```
so_rcvtimeo = 20
so_rcvtimeo_old = 20
so_rcvtimeo_new = 66
so_sndtimeo = 21
so_sndtimeo_old = 21
so_sndtimeo_new = 67
```
