### PR TITLE
Add clang to nightly and release Docker containers

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -4,6 +4,7 @@ ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
 RUN apt-get update \
  && apt-get install -y \
+    clang \
     curl \
     g++ \
     git \

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -3,12 +3,13 @@ FROM alpine:3.11
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
 RUN apk add --update \
-    curl \
-    build-base \
     binutils-gold \
+    build-base \
+    clang \
+    curl \
+    git \
     libexecinfo-dev \
-    libexecinfo-static \
-    git
+    libexecinfo-static
 
 RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
  && ponyup update ponyc nightly --platform=musl\

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -4,6 +4,7 @@ ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
 RUN apt-get update \
  && apt-get install -y \
+    clang \
     curl \
     g++ \
     git \

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.11
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
 RUN apk add --update \
+    clang \
     curl \
     build-base \
     binutils-gold \


### PR DESCRIPTION
We recently switched to using clang as our default compiler. This
means that if $CC isn't set when compiling a ponyc program it will
look for clang to do linking.

Currently, clang isn't installed in the docker containers nor is $CC
set.

This wasn't an issue previously because gcc was installed so $CC not
being set didn't cause problems.