### PR TITLE
Let processmonitor chdir before exec

### DIFF
--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -234,7 +234,16 @@ class _ProcessWindows is _Process
   fun tag _make_cmdline(args: Array[String] val): String =>
     var cmdline: String = ""
     for arg in args.values() do
-      cmdline = cmdline + arg + " "
+      // quote args with spaces on Windows
+      var next = arg
+      ifdef windows then
+        try
+          if arg.contains(" ") and (not arg(0)? == '"') then
+            next = "\"" + arg + "\""
+          end
+        end
+      end
+      cmdline = cmdline + next + " "
     end
     cmdline
 

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -8,7 +8,7 @@ primitive _ERRORBADEXEFORMAT
     """
     ERROR_BAD_EXE_FORMAT
     %1 is not a valid Win32 application.
-    """ 
+    """
     193 // 0xC1
 
 primitive _ERRORDIRECTORY
@@ -125,15 +125,12 @@ class _ProcessPosix is _Process
     _dup2(stderr.far_fd, _STDERRFILENO()) // redirect stderr
 
     var step: U8 = _StepChdir()
-    var errno: I32 = 0
 
     match wdir
     | let d: FilePath =>
       let dir: Pointer[U8] tag = d.path.cstring()
       if 0 > @chdir[I32](dir) then
-        errno = @pony_os_errno()
-        @write[ISize](err.far_fd, addressof errno, USize(4))
-        @write[ISize](err.far_fd, addressof step, USize(1))        
+        @write[ISize](err.far_fd, addressof step, USize(1))
         @_exit[None](_EXOSERR())
       end
     | None => None
@@ -143,8 +140,6 @@ class _ProcessPosix is _Process
     if 0 > @execve[I32](path.cstring(), argp.cpointer(),
       envp.cpointer())
     then
-      errno = @pony_os_errno()
-      @write[ISize](err.far_fd, addressof errno, USize(4))
       @write[ISize](err.far_fd, addressof step, USize(1))
       @_exit[None](_EXOSERR())
     end
@@ -229,7 +224,7 @@ class _ProcessWindows is _Process
           | _ERRORBADEXEFORMAT() => ExecveError
           | _ERRORDIRECTORY() => ChdirError
           else
-            UnknownError // TODO: what other errors can we distinguish here? 
+            UnknownError // TODO: what other errors can we distinguish here?
           end
         end
     else

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -430,7 +430,6 @@ class _TestBadChdir is UnitTest
 
   fun ref apply(h: TestHelper) =>
     let badpath = Path.abs(Path.random(10))
-    h.env.out.print(badpath)
     let notifier: ProcessNotify iso =
       _ProcessClient(0, "", _EXOSERR(), h, ChdirError)
     try
@@ -458,7 +457,6 @@ class _TestBadExec is UnitTest
     "process-monitor"
 
   fun ref apply(h: TestHelper) =>
-    //let expected_error = ifdef windows 
     let notifier: ProcessNotify iso =
       _ProcessClient(0, "", _EXOSERR(), h, ExecveError)
     try

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -366,11 +366,10 @@ class iso _TestStdinWriteBuf is UnitTest
       _pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
 
       // create a message larger than pipe_cap bytes
-      let message: Array[U8] val = recover Array[U8].>undefined(pipe_cap + 1) end
+      let message: Array[U8] val = recover Array[U8].init('\n', pipe_cap + 1) end
 
       if _pm isnt None then // write to STDIN of the child process
         let pm = _pm as ProcessMonitor
-        pm.write(message)
         pm.write(message)
         pm.done_writing() // closing stdin allows "cat" to terminate
         h.dispose_when_done(pm)

--- a/packages/process/_test.sh
+++ b/packages/process/_test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/please-dont-exist
+
+true

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -197,7 +197,7 @@ actor ProcessMonitor
         _child = windows_child
         // notify about errors
         match windows_child.processError
-        | let pe: ProcessError => 
+        | let pe: ProcessError =>
           _notifier.failed(this, pe)
           return
         end
@@ -404,8 +404,7 @@ actor ProcessMonitor
       | _stderr.near_fd =>
         _notifier.stderr(this, consume data)
       | _err.near_fd =>
-        let child_errno: I32 = try data.read_u32(0)?.i32() else -1 end
-        let step: U8 = try data.read_u8(4)? else -1 end
+        let step: U8 = try data.read_u8(0)? else -1 end
         match step
         | _StepChdir() =>
           _notifier.failed(this, ChdirError)

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -65,10 +65,7 @@ actor Main is TestList
     logger.Main.make().tests(test)
     net.Main.make().tests(test)
     options.Main.make().tests(test)
-
     process.Main.make().tests(test)
-    
-
     promises.Main.make().tests(test)
     random.Main.make().tests(test)
     serialise.Main.make().tests(test)

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -66,10 +66,8 @@ actor Main is TestList
     net.Main.make().tests(test)
     options.Main.make().tests(test)
 
-    ifdef posix then
-      // The process package currently only supports posix
-      process.Main.make().tests(test)
-    end
+    process.Main.make().tests(test)
+    
 
     promises.Main.make().tests(test)
     random.Main.make().tests(test)

--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -57,7 +57,11 @@ PONY_API size_t ponyint_win_process_create(
     char* appname,
     char* cmdline,
     char* environ,
-    uint32_t stdin_fd, uint32_t stdout_fd, uint32_t stderr_fd)
+    char* wdir,
+    uint32_t stdin_fd, 
+    uint32_t stdout_fd, 
+    uint32_t stderr_fd,
+    uint32_t* error_code)
 {
     STARTUPINFO si;
     ZeroMemory(&si, sizeof(si));
@@ -78,15 +82,17 @@ PONY_API size_t ponyint_win_process_create(
         TRUE,        // handles are inherited
         0,           // creation flags
         environ,     // environment to use
-        NULL,        // use parent's current directory
+        wdir,        // current directory of the process
         &si,         // STARTUPINFO pointer
         &pi);        // receives PROCESS_INFORMATION
 
     if (success) {
         // Close the thread handle now as we don't need access to it
         CloseHandle(pi.hThread);
+        *error_code = 0;
         return (size_t) pi.hProcess;
     } else {
+        *error_code = GetLastError();
         return 0;  // Null handle return on non-success.
     }
 }

--- a/src/libponyrt/lang/process.h
+++ b/src/libponyrt/lang/process.h
@@ -8,7 +8,7 @@ PONY_EXTERN_C_BEGIN
 PONY_API uint32_t ponyint_win_pipe_create(uint32_t* near_fd, uint32_t* far_fd, bool outgoing);
 
 PONY_API size_t ponyint_win_process_create(char* appname, char* cmdline,
-    char* environ, uint32_t stdin_fd, uint32_t stdout_fd, uint32_t stderr_fd);
+    char* environ, char* wdir, uint32_t stdin_fd, uint32_t stdout_fd, uint32_t stderr_fd, uint32_t* error_code);
 
 PONY_API int32_t ponyint_win_process_wait(size_t hProcess);
 


### PR DESCRIPTION
I have taken the liberty of rebasing #2981 (and fixing a couple of Windows issues) because I am too impatient to wait for @mfelsche to have time to look at it.

Quoth @rkallos:

Fixes #2821.

This PR adds a pipe for errors that take place after fork() and exec(), which might also solve #2719. Data sent across this pipe winds up calling ProcessNotify.stderr. This is disingenuous, since the data was actually sent along a separate pipe. However, it seems intuitive enough, as I imagine that is where error dispatch and handling would take place. I also did not want to inflict a large change on ProcessNotify without the blessing of the Pony core team. All in all, this seemed like the path of least resistance for fixing the issue. I would be happy to change the behavior to something else.