### PR TITLE
Update ProcessMonitor errors to contain error messages

### DIFF
--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -222,17 +222,18 @@ class _ProcessWindows is _Process
       processError =
         if hProcess == 0 then
           match error_code
-          | _ERRORBADEXEFORMAT() => ExecveError("Invalid executable.")
+          | _ERRORBADEXEFORMAT() => ProcessError(ExecveError)
           | _ERRORDIRECTORY() =>
             let wdirpath =
               match wdir
               | let wdir_fp: FilePath => wdir_fp.path
               | None => "?"
               end
-            ChdirError("Failed to change directory to " + wdirpath)
+            ProcessError(ChdirError, "Failed to change directory to "
+              + wdirpath)
           else
             let message = String.from_cstring(error_message)
-            ForkError(recover message.clone() end)
+            ProcessError(ForkError, recover message.clone() end)
           end
         end
     else

--- a/packages/process/process_error.pony
+++ b/packages/process/process_error.pony
@@ -1,0 +1,78 @@
+type ProcessError is
+  ( ExecveError
+  | PipeError
+  | ForkError
+  | WaitpidError
+  | WriteError
+  | KillError
+  | CapError
+  | ChdirError
+  | UnknownError
+  )
+
+class val ExecveError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val PipeError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val ForkError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val WaitpidError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val WriteError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val KillError   // Not thrown at this time
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val CapError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val ChdirError
+  let _message: String
+
+  new val create(message: String) =>
+    _message = message
+
+  fun string(): String => _message
+
+class val UnknownError
+  fun string(): String => "Unknown error."

--- a/packages/process/process_error.pony
+++ b/packages/process/process_error.pony
@@ -8,10 +8,19 @@ class val ProcessError
     error_type = error_type'
     message = message'
 
-  fun string(): String =>
+  fun string(): String iso^ =>
     match message
-    | let m: String => error_type.string() + ": " + m
-    else error_type.string()
+    | let m: String =>
+      recover
+        let etc = error_type.string()
+        let err = String(etc.size() + 2 + m.size())
+        err.append(consume etc)
+        err.append(": ")
+        err.append(m)
+        err
+      end
+    else
+      error_type.string()
     end
 
 type ProcessErrorType is
@@ -27,28 +36,28 @@ type ProcessErrorType is
   )
 
 primitive ExecveError
-  fun string(): String => "ExecveError"
+  fun string(): String iso^ => "ExecveError".clone()
 
 primitive PipeError
-  fun string(): String => "PipeError"
+  fun string(): String iso^ => "PipeError".clone()
 
 primitive ForkError
-  fun string(): String => "ForkError"
+  fun string(): String iso^ => "ForkError".clone()
 
 primitive WaitpidError
-  fun string(): String => "WaitpidError"
+  fun string(): String iso^ => "WaitpidError".clone()
 
 primitive WriteError
-  fun string(): String => "WriteError"
+  fun string(): String iso^ => "WriteError".clone()
 
 primitive KillError   // Not thrown at this time
-  fun string(): String => "KillError"
+  fun string(): String iso^ => "KillError".clone()
 
 primitive CapError
-  fun string(): String => "CapError"
+  fun string(): String iso^ => "CapError".clone()
 
 primitive ChdirError
-  fun string(): String => "ChdirError"
+  fun string(): String iso^ => "ChdirError".clone()
 
 primitive UnknownError
-  fun string(): String => "UnknownError"
+  fun string(): String iso^ => "UnknownError".clone()

--- a/packages/process/process_error.pony
+++ b/packages/process/process_error.pony
@@ -1,4 +1,20 @@
-type ProcessError is
+class val ProcessError
+  let error_type: ProcessErrorType
+  let message: (String | None)
+
+  new val create(error_type': ProcessErrorType,
+    message': (String | None) = None)
+  =>
+    error_type = error_type'
+    message = message'
+
+  fun string(): String =>
+    match message
+    | let m: String => error_type.string() + ": " + m
+    else error_type.string()
+    end
+
+type ProcessErrorType is
   ( ExecveError
   | PipeError
   | ForkError
@@ -10,69 +26,29 @@ type ProcessError is
   | UnknownError
   )
 
-class val ExecveError
-  let _message: String
+primitive ExecveError
+  fun string(): String => "ExecveError"
 
-  new val create(message: String) =>
-    _message = message
+primitive PipeError
+  fun string(): String => "PipeError"
 
-  fun string(): String => _message
+primitive ForkError
+  fun string(): String => "ForkError"
 
-class val PipeError
-  let _message: String
+primitive WaitpidError
+  fun string(): String => "WaitpidError"
 
-  new val create(message: String) =>
-    _message = message
+primitive WriteError
+  fun string(): String => "WriteError"
 
-  fun string(): String => _message
+primitive KillError   // Not thrown at this time
+  fun string(): String => "KillError"
 
-class val ForkError
-  let _message: String
+primitive CapError
+  fun string(): String => "CapError"
 
-  new val create(message: String) =>
-    _message = message
+primitive ChdirError
+  fun string(): String => "ChdirError"
 
-  fun string(): String => _message
-
-class val WaitpidError
-  let _message: String
-
-  new val create(message: String) =>
-    _message = message
-
-  fun string(): String => _message
-
-class val WriteError
-  let _message: String
-
-  new val create(message: String) =>
-    _message = message
-
-  fun string(): String => _message
-
-class val KillError   // Not thrown at this time
-  let _message: String
-
-  new val create(message: String) =>
-    _message = message
-
-  fun string(): String => _message
-
-class val CapError
-  let _message: String
-
-  new val create(message: String) =>
-    _message = message
-
-  fun string(): String => _message
-
-class val ChdirError
-  let _message: String
-
-  new val create(message: String) =>
-    _message = message
-
-  fun string(): String => _message
-
-class val UnknownError
-  fun string(): String => "Unknown error."
+primitive UnknownError
+  fun string(): String => "UnknownError"

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -56,16 +56,7 @@ class ProcessClient is ProcessNotify
     _env.out.print("STDERR: " + err)
 
   fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-    match err
-    | ExecveError => _env.out.print("ProcessError: ExecveError")
-    | PipeError => _env.out.print("ProcessError: PipeError")
-    | ForkError => _env.out.print("ProcessError: ForkError")
-    | WaitpidError => _env.out.print("ProcessError: WaitpidError")
-    | WriteError => _env.out.print("ProcessError: WriteError")
-    | KillError => _env.out.print("ProcessError: KillError")
-    | CapError => _env.out.print("ProcessError: CapError")
-    else _env.out.print("Unknown ProcessError!")
-    end
+    _env.out.print(err.string())
 
   fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>
     let code: I32 = consume child_exit_code
@@ -135,7 +126,7 @@ actor ProcessMonitor
     // We need permission to execute and the
     // file itself needs to be an executable
     if not filepath.caps(FileExec) then
-      _notifier.failed(this, CapError(filepath.path
+      _notifier.failed(this, ProcessError(CapError, filepath.path
         + " is not an executable or we do not have execute capability."))
       return
     end
@@ -148,7 +139,7 @@ actor ProcessMonitor
     if not ok then
       // unable to stat the file path given so it may not exist
       // or may be a directory.
-      _notifier.failed(this, ExecveError(filepath.path
+      _notifier.failed(this, ProcessError(ExecveError, filepath.path
         + " does not exist or is a directory."))
       return
     end
@@ -157,7 +148,8 @@ actor ProcessMonitor
       _stdin = _Pipe.outgoing()?
     else
       _stdin.close()
-      _notifier.failed(this, PipeError("Failed to open pipe for stdin."))
+      _notifier.failed(this, ProcessError(PipeError,
+        "Failed to open pipe for stdin."))
       return
     end
 
@@ -166,7 +158,8 @@ actor ProcessMonitor
     else
       _stdin.close()
       _stdout.close()
-      _notifier.failed(this, PipeError("Failed to open pipe for stdout."))
+      _notifier.failed(this, ProcessError(PipeError,
+        "Failed to open pipe for stdout."))
       return
     end
 
@@ -176,7 +169,8 @@ actor ProcessMonitor
       _stdin.close()
       _stdout.close()
       _stderr.close()
-      _notifier.failed(this, PipeError("Failed to open pipe for stderr."))
+      _notifier.failed(this, ProcessError(PipeError,
+        "Failed to open pipe for stderr."))
       return
     end
 
@@ -187,7 +181,8 @@ actor ProcessMonitor
       _stdout.close()
       _stderr.close()
       _err.close()
-      _notifier.failed(this, PipeError("Failed to open auxiliary error pipe."))
+      _notifier.failed(this, ProcessError(PipeError,
+        "Failed to open auxiliary error pipe."))
       return
     end
 
@@ -228,7 +223,7 @@ actor ProcessMonitor
         _timers = timers
       end
     else
-      _notifier.failed(this, ForkError("Failed to create child process."))
+      _notifier.failed(this, ProcessError(ForkError))
       return
     end
     _notifier.created(this)
@@ -347,7 +342,7 @@ actor ProcessMonitor
       let exit_code = _child.wait()
       if exit_code < 0 then
         // An error waiting for pid
-        _notifier.failed(this, WaitpidError("Failed to wait for process exit."))
+        _notifier.failed(this, ProcessError(WaitpidError))
       else
         // process child exit code
         _notifier.dispose(this, exit_code)
@@ -411,11 +406,11 @@ actor ProcessMonitor
         let step: U8 = try data.read_u8(0)? else -1 end
         match step
         | _StepChdir() =>
-          _notifier.failed(this, ChdirError("Failed to change directory."))
+          _notifier.failed(this, ProcessError(ChdirError))
         | _StepExecve() =>
-          _notifier.failed(this, ExecveError("Invalid executable."))
+          _notifier.failed(this, ProcessError(ExecveError))
         else
-          _notifier.failed(this, UnknownError)
+          _notifier.failed(this, ProcessError(UnknownError))
         end
       end
 
@@ -463,7 +458,7 @@ actor ProcessMonitor
           Backpressure.apply(_backpressure_auth)
         else
           // Notify caller of error, close fd and done.
-          _notifier.failed(this, WriteError("Failed to write to pipe."))
+          _notifier.failed(this, ProcessError(WriteError))
           _stdin.close_near()
         end
       elseif len.usize() < data.size() then
@@ -498,7 +493,7 @@ actor ProcessMonitor
             return
           else
             // Close pipe and bail out.
-            _notifier.failed(this, WriteError("Failed to write to pipe."))
+            _notifier.failed(this, ProcessError(WriteError))
             _stdin.close_near()
             return
           end
@@ -519,7 +514,7 @@ actor ProcessMonitor
         end
       else
         // handle error
-        _notifier.failed(this, WriteError("Failed to write to pipe."))
+        _notifier.failed(this, ProcessError(WriteError))
         return
       end
     end

--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -58,10 +58,11 @@ PONY_API size_t ponyint_win_process_create(
     char* cmdline,
     char* environ,
     char* wdir,
-    uint32_t stdin_fd, 
-    uint32_t stdout_fd, 
+    uint32_t stdin_fd,
+    uint32_t stdout_fd,
     uint32_t stderr_fd,
-    uint32_t* error_code)
+    uint32_t* error_code,
+    char** error_message)
 {
     STARTUPINFO si;
     ZeroMemory(&si, sizeof(si));
@@ -93,6 +94,10 @@ PONY_API size_t ponyint_win_process_create(
         return (size_t) pi.hProcess;
     } else {
         *error_code = GetLastError();
+        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER
+            | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            NULL, *error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            (LPSTR)error_message, 0, NULL);
         return 0;  // Null handle return on non-success.
     }
 }

--- a/src/libponyrt/lang/process.h
+++ b/src/libponyrt/lang/process.h
@@ -5,10 +5,12 @@ PONY_EXTERN_C_BEGIN
 
 #ifdef PLATFORM_IS_WINDOWS
 
-PONY_API uint32_t ponyint_win_pipe_create(uint32_t* near_fd, uint32_t* far_fd, bool outgoing);
+PONY_API uint32_t ponyint_win_pipe_create(uint32_t* near_fd, uint32_t* far_fd,
+    bool outgoing);
 
 PONY_API size_t ponyint_win_process_create(char* appname, char* cmdline,
-    char* environ, char* wdir, uint32_t stdin_fd, uint32_t stdout_fd, uint32_t stderr_fd, uint32_t* error_code);
+    char* environ, char* wdir, uint32_t stdin_fd, uint32_t stdout_fd,
+    uint32_t stderr_fd, uint32_t* error_code, char** error_msg);
 
 PONY_API int32_t ponyint_win_process_wait(size_t hProcess);
 


### PR DESCRIPTION
This is a breaking change, as the `ProcessError` types are now classes, not primitives, and have a `.string()` method to return their error messages.

In addition, there is no more `Unsupported` error type.