### PR TITLE
Fix CommandParser incorrectly handling multiple end-of-option delimiters

### DIFF
--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -64,7 +64,7 @@ class CommandParser
 
     while tokens.size() > 0 do
       let token = try tokens.shift()? else "" end
-      if token == "--" then
+      if (token == "--") and (opt_stop == false) then
         opt_stop = true
 
       elseif not opt_stop and (token.compare_sub("--", 2, 0) == Equal) then


### PR DESCRIPTION
Previously, the command parser would swallow all "--" after the first
one. For me, this manifested itself in not allowing corral to be used
with lldb "corral exec -- lldb ponyc -- $(ponyc) -V=0 -o ./build/
./utility" since the second "--" is required to be passed to lldb.

This change is dependency for a PR being submitted to corral to allow
use of corral with lldb (for debugging ponyc itself).