### PR TITLE
Add Ubuntu18.04 builds

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+ && apt-get install -y \
+  apt-transport-https \
+  build-essential \
+  clang \
+  curl \
+  git \
+  make \
+  python-pip \
+  xz-utils \
+  zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && pip install cloudsmith-cli
+
+# install a newer cmake
+RUN curl --output cmake-3.15.3-Linux-x86_64.sh https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh \
+ && sh cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+
+# add user pony in order to not run tests as root
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+NAME="ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,6 +27,27 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   container:
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
+    cpu: 8
+    memory: 24
+
+  name: "nightly: x86-64-unknown-linux-ubuntu18.04"
+
+  environment:
+    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` ubuntu18.04 20200507"
+    populate_script: make libs build_flags=-j8
+
+  nightly_script:
+    - bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash ${CLOUDSMITH_API_KEY}
+
+task:
+  only_if: $CIRRUS_CRON == "master-midnight"
+
+  container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200421
     cpu: 8
     memory: 24
@@ -148,6 +169,27 @@ task:
   libs_cache:
     folder: build/libs
     fingerprint_script: echo "`md5sum lib/CMakeLists.txt` glibc 20200423"
+    populate_script: make libs build_flags=-j8
+
+  release_script:
+    - bash .ci-scripts/x86-64-unknown-linux-gnu-release.bash ${CLOUDSMITH_API_KEY}
+
+task:
+  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+
+  container:
+    image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
+    cpu: 8
+    memory: 24
+
+  name: "release: x86-64-unknown-linux-ubuntu18.04"
+
+  environment:
+    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` ubuntu18.04 20200507"
     populate_script: make libs build_flags=-j8
 
   release_script:


### PR DESCRIPTION
We switched our generic glibc builds to Ubuntu 20.04 and now the nightly
and release builds do not work on Ubuntu 18.04. This adds support for those
builds so that users still on Ubuntu 18.04 (like me!) can use ponyup to
install a working ponyc.