### PR TITLE
Upload Ubuntu 18.04 builds under the correct name

### DIFF
--- a/.ci-scripts/x86-64-unknown-linux-ubuntu18.04-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-ubuntu18.04-nightly.bash
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+API_KEY=$1
+if [[ ${API_KEY} == "" ]]
+then
+  echo "API_KEY needs to be supplied as first script argument."
+  exit 1
+fi
+
+TODAY=$(date +%Y%m%d)
+
+# Compiler target parameters
+ARCH=x86-64
+PIC=true
+
+# Triple construction
+VENDOR=unknown
+OS=linux-ubuntu18.04
+TRIPLE=${ARCH}-${VENDOR}-${OS}
+
+# Build parameters
+MAKE_PARALLELISM=8
+BUILD_PREFIX=$(mktemp -d)
+DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION="nightly-${TODAY}"
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=ponyc-${TRIPLE}
+
+# Cloudsmith configuration
+CLOUDSMITH_VERSION=${TODAY}
+ASSET_OWNER=ponylang
+ASSET_REPO=nightlies
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="Pony compiler"
+ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
+
+# Build pony installation
+echo "Building ponyc installation..."
+make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+  version="${PONY_VERSION}"
+make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+  version="${PONY_VERSION}"
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
+  build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
+
+# Package it all up
+echo "Creating .tar.gz of ponyc installation..."
+pushd ${DESTINATION} || exit 1
+tar -cvzf ${ASSET_FILE} *
+popd || exit 1
+
+# Ship it off to cloudsmith
+echo "Uploading package to cloudsmith..."
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
+  ${ASSET_PATH} ${ASSET_FILE}

--- a/.ci-scripts/x86-64-unknown-linux-ubuntu18.04-release.bash
+++ b/.ci-scripts/x86-64-unknown-linux-ubuntu18.04-release.bash
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -e
+
+API_KEY=$1
+if [[ ${API_KEY} == "" ]]
+then
+  echo "API_KEY needs to be supplied as first script argument."
+  exit 1
+fi
+
+# Compiler target parameters
+ARCH=x86-64
+PIC=true
+
+# Triple construction
+VENDOR=unknown
+OS=linux-ubuntu18.04
+TRIPLE=${ARCH}-${VENDOR}-${OS}
+
+# Build parameters
+MAKE_PARALLELISM=8
+BUILD_PREFIX=$(mktemp -d)
+DESTINATION=${BUILD_PREFIX}/lib/pony
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=ponyc-${TRIPLE}
+
+# Cloudsmith configuration
+CLOUDSMITH_VERSION=$(cat VERSION)
+ASSET_OWNER=ponylang
+ASSET_REPO=releases
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="Pony compiler"
+ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
+
+# Build pony installation
+echo "Building ponyc installation..."
+make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
+make build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
+make install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
+  build_flags=-j${MAKE_PARALLELISM}
+
+# Package it all up
+echo "Creating .tar.gz of ponyc installation..."
+pushd ${DESTINATION} || exit 1
+tar -cvzf ${ASSET_FILE} *
+popd || exit 1
+
+# Ship it off to cloudsmith
+echo "Uploading package to cloudsmith..."
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
+  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
+  ${ASSET_PATH} ${ASSET_FILE}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -268,7 +268,7 @@ task:
     populate_script: make libs build_flags=-j8
 
   nightly_script:
-    - bash .ci-scripts/x86-64-unknown-linux-gnu-nightly.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-linux-ubuntu18.04-nightly.bash ${CLOUDSMITH_API_KEY}
 
 task:
   only_if: $CIRRUS_CRON == "master-midnight"
@@ -419,7 +419,7 @@ task:
     populate_script: make libs build_flags=-j8
 
   release_script:
-    - bash .ci-scripts/x86-64-unknown-linux-gnu-release.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-linux-ubuntu18.04-release.bash ${CLOUDSMITH_API_KEY}
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'


### PR DESCRIPTION
Prior to this change, the Ubuntu 18.04 builds would use an incorrect
triple for building and uploading. They would end up overwriting (if they
came second), the normal gnu/glibc build.

While this change will fix the issue, it shows that it is time to start
making the scripts more compact and starting to DRY them up some. We've
previously discussed during sync calls switching from using bash to python
to make same-ness easier to do. I'm not sure we need to switch to python at
this point, however, it is time to remove some duplication. That will come
in another PR.