### PR TITLE
Release builders: normalize cloudsmith api key usage

### DIFF
--- a/.ci-scripts/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/x86-64-apple-darwin-nightly.bash
@@ -2,10 +2,13 @@
 
 set -e
 
-API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
-  echo "API_KEY needs to be supplied as first script argument."
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the CI environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
   exit 1
 fi
 
@@ -56,6 +59,6 @@ popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
-  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key ${CLOUDSMITH_API_KEY} --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} ${ASSET_FILE}

--- a/.ci-scripts/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/x86-64-apple-darwin-release.bash
@@ -2,13 +2,15 @@
 
 set -e
 
-API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
-  echo "API_KEY needs to be supplied as first script argument."
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the CI environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
   exit 1
 fi
-
 
 # Compiler target parameters
 ARCH=x86-64
@@ -52,6 +54,6 @@ popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
-  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key ${CLOUDSMITH_API_KEY} --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} ${ASSET_FILE}

--- a/.ci-scripts/x86-64-unknown-freebsd12.1-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd12.1-nightly.bash
@@ -2,10 +2,13 @@
 
 set -e
 
-API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
-  echo "API_KEY needs to be supplied as first script argument."
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the CI environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
   exit 1
 fi
 
@@ -56,6 +59,6 @@ popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
-  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key ${CLOUDSMITH_API_KEY} --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} ${ASSET_FILE}

--- a/.ci-scripts/x86-64-unknown-freebsd12.1-release.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd12.1-release.bash
@@ -2,13 +2,15 @@
 
 set -e
 
-API_KEY=$1
-if [[ ${API_KEY} == "" ]]
-then
-  echo "API_KEY needs to be supplied as first script argument."
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the CI environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
   exit 1
 fi
-
 
 # Compiler target parameters
 ARCH=x86-64
@@ -52,6 +54,6 @@ popd || exit 1
 
 # Ship it off to cloudsmith
 echo "Uploading package to cloudsmith..."
-cloudsmith push raw --version "${CLOUDSMITH_VERSION}" --api-key ${API_KEY} \
-  --summary "${ASSET_SUMMARY}" --description "${ASSET_DESCRIPTION}" \
-  ${ASSET_PATH} ${ASSET_FILE}
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key ${CLOUDSMITH_API_KEY} --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} ${ASSET_FILE}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -320,7 +320,7 @@ task:
     populate_script: gmake libs arch=x86-64 build_flags=-j8
 
   nightly_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd12.1-nightly.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-freebsd12.1-nightly.bash
 
 task:
   only_if: $CIRRUS_CRON == "master-midnight"
@@ -344,7 +344,7 @@ task:
 
   nightly_script:
     - export TZ=utc
-    - bash .ci-scripts/x86-64-apple-darwin-nightly.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-apple-darwin-nightly.bash
 
 task:
   only_if: $CIRRUS_CRON == "master-midnight"
@@ -474,7 +474,7 @@ task:
     populate_script: gmake libs arch=x86-64 build_flags=-j8
 
   release_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd12.1-release.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-unknown-freebsd12.1-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
@@ -497,7 +497,7 @@ task:
     - pip3 install --upgrade cloudsmith-cli
 
   release_script:
-    - bash .ci-scripts/x86-64-apple-darwin-release.bash ${CLOUDSMITH_API_KEY}
+    - bash .ci-scripts/x86-64-apple-darwin-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'


### PR DESCRIPTION
This PR brings ponyc in line without scripts we have for building
to take the cloudsmith api key from the environment rather than via
the command line