### PR TITLE
Potentially save on space for an actor in the future

### DIFF
--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -36,9 +36,9 @@ typedef struct pony_actor_t
 #ifdef USE_ACTOR_CONTINUATIONS
   pony_msg_t* continuation;
 #endif
+  PONY_ATOMIC(size_t) muted;
   PONY_ATOMIC(uint8_t) flags;
   PONY_ATOMIC(uint8_t) is_muted;
-  PONY_ATOMIC(size_t) muted;
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes


### PR DESCRIPTION
While doing a separate review together, Sylvan noticed that while not
currently wasteful, that the layout of pony_actor_t could end up in
resulting in excess alignment packing in the future.