### PR TITLE
Switch Linux nightly and release config to matrix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -231,67 +231,42 @@ task:
 task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
+  matrix:
+    - name: "nightly: x86-64-unknown-linux-gnu"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
+      environment:
+        CACHE_BUSTER: 20200423
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-gnu
+    - name: "nightly: x86-64-unknown-linux-ubuntu18.04"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
+      environment:
+        CACHE_BUSTER: 20200507
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-ubuntu18.04
+    - name: "nightly: x86-64-unknown-linux-musl"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200421
+      environment:
+        CACHE_BUSTER: 20200421
+        TRIPLE_VENDOR: unknown
+        TRIPLE_VENDOR: linux-musl
+
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
     cpu: 8
     memory: 24
 
-  name: "nightly: x86-64-unknown-linux-gnu"
-
   environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-gnu
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` glibc 20200423"
-    populate_script: make libs build_flags=-j8
-
-  nightly_script:
-    - bash .ci-scripts/x86-64-nightly.bash
-
-task:
-  only_if: $CIRRUS_CRON == "master-midnight"
-
-  container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
-    cpu: 8
-    memory: 24
-
-  name: "nightly: x86-64-unknown-linux-ubuntu18.04"
-
-  environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-ubuntu18.04
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` ubuntu18.04 20200507"
-    populate_script: make libs build_flags=-j8
-
-  nightly_script:
-    - bash .ci-scripts/x86-64-nightly.bash
-
-task:
-  only_if: $CIRRUS_CRON == "master-midnight"
-
-  container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200421
-    cpu: 8
-    memory: 24
-
-  name: "nightly: x86-64-unknown-linux-musl"
-
-  environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-musl
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` musl"
+    fingerprint_script:
+      - echo "`md5sum lib/CMakeLists.txt`"
+      - echo "${TRIPLE_VENDOR}-${TRIPLE_OS}"
+      - echo "cache buster ${CACHE_BUSTER}"
     populate_script: make libs build_flags=-j8
 
   nightly_script:
@@ -390,67 +365,42 @@ task:
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
+  matrix:
+    - name: "release: x86-64-unknown-linux-gnu"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
+      environment:
+        CACHE_BUSTER: 20200423
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-gnu
+    - name: "release: x86-64-unknown-linux-ubuntu18.04"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
+      environment:
+        CACHE_BUSTER: 20200507
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-ubuntu18.04
+    - name: "release: x86-64-unknown-linux-musl"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200421
+      environment:
+        CACHE_BUSTER: 20200421
+        TRIPLE_VENDOR: unknown
+        TRIPLE_VENDOR: linux-musl
+
   container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
     cpu: 8
     memory: 24
 
-  name: "release: x86-64-unknown-linux-gnu"
-
   environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-gnu
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` glibc 20200423"
-    populate_script: make libs build_flags=-j8
-
-  release_script:
-    - bash .ci-scripts/x86-64-release.bash
-
-task:
-  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
-
-  container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20200507
-    cpu: 8
-    memory: 24
-
-  name: "release: x86-64-unknown-linux-ubuntu18.04"
-
-  environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-ubuntu18.04
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` ubuntu18.04 20200507"
-    populate_script: make libs build_flags=-j8
-
-  release_script:
-    - bash .ci-scripts/x86-64-release.bash
-
-task:
-  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
-
-  container:
-    image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20200421
-    cpu: 8
-    memory: 24
-
-  name: "release: x86-64-unknown-linux-musl"
-
-  environment:
-    TRIPLE_VENDOR: unknown
-    TRIPLE_OS: linux-musl
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` musl"
+    fingerprint_script:
+      - echo "`md5sum lib/CMakeLists.txt`"
+      - echo "${TRIPLE_VENDOR}-${TRIPLE_OS}"
+      - echo "cache buster ${CACHE_BUSTER}"
     populate_script: make libs build_flags=-j8
 
   release_script:


### PR DESCRIPTION
As we are going to be adding more Linux distros that we support based
on community request, using a matrix of the few differences between
each should make it easier for us to support adding new ones.

We could eventually incorporate the macOS and FreeBSD builds as well,
but this seems like a good first step.