### PR TITLE
Rename FreeBSD artifacts

### DIFF
--- a/.ci-scripts/x86-64-unknown-freebsd-12.1-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-12.1-nightly.bash
@@ -12,28 +12,31 @@ if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   exit 1
 fi
 
+TODAY=$(date +%Y%m%d)
+
 # Compiler target parameters
 ARCH=x86-64
 PIC=true
 
 # Triple construction
 VENDOR=unknown
-OS=freebsd12.1
+OS=freebsd-12.1
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION="nightly-${TODAY}"
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
 PACKAGE=ponyc-${TRIPLE}
 
 # Cloudsmith configuration
-CLOUDSMITH_VERSION=$(cat VERSION)
+CLOUDSMITH_VERSION=${TODAY}
 ASSET_OWNER=ponylang
-ASSET_REPO=releases
+ASSET_REPO=nightlies
 ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
 ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
 ASSET_SUMMARY="Pony compiler"
@@ -41,10 +44,12 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-gmake configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
-gmake build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
+gmake configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+  version="${PONY_VERSION}"
+gmake build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+  version="${PONY_VERSION}"
 gmake install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM}
+  build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."

--- a/.ci-scripts/x86-64-unknown-freebsd-12.1-release.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-12.1-release.bash
@@ -12,31 +12,28 @@ if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   exit 1
 fi
 
-TODAY=$(date +%Y%m%d)
-
 # Compiler target parameters
 ARCH=x86-64
 PIC=true
 
 # Triple construction
 VENDOR=unknown
-OS=freebsd12.1
+OS=freebsd-12.1
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters
 MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
-PONY_VERSION="nightly-${TODAY}"
 
 # Asset information
 PACKAGE_DIR=$(mktemp -d)
 PACKAGE=ponyc-${TRIPLE}
 
 # Cloudsmith configuration
-CLOUDSMITH_VERSION=${TODAY}
+CLOUDSMITH_VERSION=$(cat VERSION)
 ASSET_OWNER=ponylang
-ASSET_REPO=nightlies
+ASSET_REPO=releases
 ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
 ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
 ASSET_SUMMARY="Pony compiler"
@@ -44,12 +41,10 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-gmake configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
-gmake build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
-  version="${PONY_VERSION}"
+gmake configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
+gmake build arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
 gmake install prefix=${BUILD_PREFIX} symlink=no arch=${ARCH} \
-  build_flags=-j${MAKE_PARALLELISM} version="${PONY_VERSION}"
+  build_flags=-j${MAKE_PARALLELISM}
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ task:
     cpu: 8
     memory: 24
 
-  name: "PR: x86-64-unknown-freebsd12.1"
+  name: "PR: x86-64-unknown-freebsd-12.1"
 
   install_script:
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
@@ -86,7 +86,7 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd12.1"
+    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd-12.1"
     populate_script: gmake libs arch=x86-64 build_flags=-j8
 
   configure_script:
@@ -305,7 +305,7 @@ task:
     cpu: 8
     memory: 24
 
-  name: "nightly: x86-64-unknown-freebsd12.1"
+  name: "nightly: x86-64-unknown-freebsd-12.1"
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
@@ -319,11 +319,11 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd12.1"
+    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd-12.1"
     populate_script: gmake libs arch=x86-64 build_flags=-j8
 
   nightly_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd12.1-nightly.bash
+    - bash .ci-scripts/x86-64-unknown-freebsd-12.1-nightly.bash
 
 task:
   only_if: $CIRRUS_CRON == "master-midnight"
@@ -464,7 +464,7 @@ task:
     cpu: 8
     memory: 24
 
-  name: "release: x86-64-unknown-freebsd12.1"
+  name: "release: x86-64-unknown-freebsd-12.1"
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
@@ -478,11 +478,11 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd12.1"
+    fingerprint_script: echo "`md5 lib/CMakeLists.txt` freebsd-12.1"
     populate_script: gmake libs arch=x86-64 build_flags=-j8
 
   release_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd12.1-release.bash
+    - bash .ci-scripts/x86-64-unknown-freebsd-12.1-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Prebuilt Pony binaries are available on a number of platforms. They are built us
 
 ## FreeBSD 12.1
 
-Prebuilt FreeBSD 12.1 nightly packages are available for download from our [Cloudsmith repository](https://cloudsmith.io/~ponylang/repos/nightlies/packages/?q=name%3A%27%5Eponyc-x86-64-unknown-freebsd12.1.tar.gz%24%27).
+Prebuilt FreeBSD 12.1 nightly packages are available for download from our [Cloudsmith repository](https://cloudsmith.io/~ponylang/repos/nightlies/packages/?q=name%3A%27%5Eponyc-x86-64-unknown-freebsd-12.1.tar.gz%24%27).
 
 Starting with the next ponyc release, you'll also be able to download prebuilt ponyc releases from Cloudsmith. We'll update this page with the link once they become available.
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -72,7 +72,7 @@ You can verify that the release artifacts were successfully built and uploaded b
 Package names will be:
 
 - ponyc-x86-64-apple-darwin.tar.gz
-- ponyc-x86-64-unknown-freebsd12.1.tar.gz
+- ponyc-x86-64-unknown-freebsd-12.1.tar.gz
 - ponyc-x86-64-pc-windows-msvc.zip
 - ponyc-x86-64-unknown-linux-gnu.tar.gz
 - ponyc-x86-64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
It's highly problematic for ponyup to name artifacts with freebsd12.1 rather
than freebsd-12.1 as it goes against the expected naming scheme for ponyup
managed resources.