### PR TITLE
Fix incorrect Windows process waiting

### DIFF
--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -137,9 +137,9 @@ PONY_API int32_t ponyint_win_process_wait(size_t hProcess, int32_t* exit_code_pt
                 if (retval == 0) retval = -1;
             }
             break;
-        case WAIT_ABANDONED: // shouldn't happen to a process
         case WAIT_TIMEOUT: // process is still going
             return 1; // don't close the handle
+        case WAIT_ABANDONED: // shouldn't happen to a process
         case WAIT_FAILED:
             retval = GetLastError();
             if (retval == 0) retval = -1;


### PR DESCRIPTION
I think there are a couple of problems with recent changes to `ponyint_win_process_wait`.  I should have caught them in review.

Changing the timeout value to 0 means that `WaitForSingleObject` won't block, so we can't close the handle in that case.  Also 0x80 is the return code `WAIT_ABANDONED` which doesn't apply to processes.  We should be checking for `WAIT_TIMEOUT` (0x102) which means the process hasn't exited yet.  Also we need to make sure that retval is not 0 or 1 in an error case where `GetLastError()` returns 0 for some reason.