### PR TITLE
Remove unused actor continutations code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,6 @@ if(PONY_USE_DTRACE)
     add_compile_options(-DUSE_DYNAMIC_TRACE)
 endif()
 
-if(PONY_USE_ACTOR_CONTINUATIONS)
-    set(PONY_OUTPUT_SUFFIX "-actor_continuations")
-    add_compile_options(-DUSE_ACTOR_CONTINUATIONS)
-endif()
-
 if(PONY_USE_MEMTRACK)
     set(PONY_OUTPUT_SUFFIX "-memtrack")
     add_compile_options(-DUSE_MEMTRACK)

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,6 @@ define USE_CHECK
       $$(error No dtrace compatible user application static probe generation tool found)
     endif
     PONY_USES += -DPONY_USE_DTRACE=true
-  else ifeq ($1,actor_continuations)
-    PONY_USES += -DPONY_USE_ACTOR_CONTINUATIONS=true
   else ifeq ($1,scheduler_scaling_pthreads)
     PONY_USES += -DPONY_USE_SCHEDULER_SCALING_PTHREADS=true
   else ifeq ($1,memtrack)

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -33,9 +33,6 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
-#ifdef USE_ACTOR_CONTINUATIONS
-  pony_msg_t* continuation;
-#endif
   PONY_ATOMIC(size_t) muted;
   PONY_ATOMIC(uint8_t) flags;
   PONY_ATOMIC(uint8_t) is_muted;

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -281,17 +281,6 @@ PONY_API void pony_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
 PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
   intptr_t i);
 
-/** Store a continuation.
- *
- * This puts a message at the front of the current actor's queue, instead of at
- * the back.
- *
- * Not used in Pony.
- */
-#ifdef USE_ACTOR_CONTINUATIONS
-PONY_API void pony_continuation(pony_ctx_t* ctx, pony_msg_t* m);
-#endif
-
 /** Allocate memory on the current actor's heap.
  *
  * This is garbage collected memory. This can only be done while an actor is


### PR DESCRIPTION
Pony doesn't use continutations and never has. The code
was added when the runtime was shared with other projects.