### PR TITLE
Add note for setting CC and CXX for prebuilt pony installs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,8 @@
 
 Prebuilt Pony binaries are available on a number of platforms. They are built using a very generic CPU instruction set and as such, will not provide maximum performance. If you need to get the best performance possible from your Pony program, we strongly recommend [building from source](BUILD.md).
 
+Prebuilt Pony installations will use clang as the default C compiler and clang++ as the default C++ compiler. If you prefer to use different compilers, such as gcc and g++, these defaults can be overridden by setting the `$CC` and `$CXX` environment variables to your compiler of choice.
+
 ## FreeBSD 12.1
 
 Prebuilt FreeBSD 12.1 nightly packages are available for download from our [Cloudsmith repository](https://cloudsmith.io/~ponylang/repos/nightlies/packages/?q=name%3A%27%5Eponyc-x86-64-unknown-freebsd-12.1.tar.gz%24%27).


### PR DESCRIPTION
This adds a note to the ponyc install documentation
to inform users that clang will be used as default
compiler, and gives them instructions on how to
override with their compiler of choice.

Fixes #3520 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>