### PR TITLE
Compile fix for the latest MSVC compiler (MSVC 19.26.28806.0, from Visual Studio 16.6.2)

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -83,6 +83,8 @@ typedef struct pool_block_t
   };
   size_t size;
   PONY_ATOMIC(bool) acquired;
+
+  pool_block_t() { }
 } pool_block_t;
 
 /// A thread local list of free blocks header.

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -84,7 +84,9 @@ typedef struct pool_block_t
   size_t size;
   PONY_ATOMIC(bool) acquired;
 
+#if defined(_MSC_VER)
   pool_block_t() { }
+#endif
 } pool_block_t;
 
 /// A thread local list of free blocks header.


### PR DESCRIPTION
Adds an explicit constructor to `pool_block_t` . Without the explicit constructor, the compiler says "attempting to reference a deleted function", referring to the auto-created constructor.