### PR TITLE
Update parser comment to read recursive descent

### DIFF
--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -13,7 +13,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-/** We use a simple recursive decent parser. Each grammar rule is specified
+/** We use a simple recursive descent parser. Each grammar rule is specified
  * using the macros defined below. Whilst it is perfectly possible to mix
  * normal C code in with the macros it should not be necessary. The underlying
  * functions that the macros use should not be called outside of the macros.


### PR DESCRIPTION
Fixes minor typo in parser description to read recursive descent instead
of recursive decent. I do in fact believe the parser is also pretty
decent.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>