### PR TITLE
Fix with expressions using tuple destructuring.

### DIFF
--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -542,7 +542,11 @@ static void build_with_dispose(ast_t* dispose_clause, ast_t* idseq)
   pony_assert(ast_id(idseq) == TK_TUPLE);
 
   for(ast_t* p = ast_child(idseq); p != NULL; p = ast_sibling(p))
-    build_with_dispose(dispose_clause, p);
+  {
+    pony_assert(ast_id(p) == TK_SEQ);
+    ast_t* let = ast_child(p);
+    build_with_dispose(dispose_clause, let);
+  }
 }
 
 

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -1933,3 +1933,141 @@ TEST_F(SugarTest, AsOperatorWithLambdaType)
 
   TEST_COMPILE(short_form);
 }
+
+TEST_F(SugarTest, WithExpr)
+{
+  const char* short_form =
+    "class Disposable\n"
+    "  var create: U32\n"
+    "  fun dispose(): None =>\n"
+    "    None"
+    "\n"
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun do_it() =>\n"
+    "    with a = Disposable, b = Disposable do\n"
+    "      error\n"
+    "    end\n";
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Disposable\n"
+    "  var create: U32\n"
+    "  \n"
+    "  fun box dispose(): None =>\n"
+    "    None\n"
+    "    None\n"
+    "\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box do_it(): None =>\n"
+    "    (\n"
+    "    let $1 = (Disposable)\n"
+    "    let $0 = (Disposable)\n"
+    "    $try_no_check\n"
+    "      let b = $1\n"
+    "      let a = $0\n"
+    "      (error)\n"
+    "    else\n"
+    "      let b = $1\n"
+    "      let a = $0\n"
+    "      (None)\n"
+    "    then\n"
+    "      let b = $1\n"
+    "      b.dispose()\n"
+    "      let a = $0\n"
+    "      a.dispose()\n"
+    "    end)\n"
+    "    None";
+  TEST_EQUIV(short_form, full_form);
+}
+
+TEST_F(SugarTest, WithExprWithTupleDestructuring)
+{
+  const char* short_form =
+    "class Disposable\n"
+    "  var create: U32\n"
+    "  fun dispose(): None =>\n"
+    "    None"
+    "\n"
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun do_it() =>\n"
+    "    with (a, b) = (Disposable, Disposable) do\n"
+    "      error\n"
+    "    end\n";
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Disposable\n"
+    "  var create: U32\n"
+    "  \n"
+    "  fun box dispose(): None =>\n"
+    "    None\n"
+    "    None\n"
+    "\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box do_it(): None =>\n"
+    "    (\n"
+    "    let $0 = (\n"
+    "      (Disposable, Disposable)\n"
+    "    )\n"
+    "    $try_no_check\n"
+    "      (let a, let b) = $0\n"
+    "      (error)\n"
+    "    else\n"
+    "      (let a, let b) = $0\n"
+    "      (None)\n"
+    "    then\n"
+    "      (let a, let b) = $0\n"
+    "      b.dispose()\n"
+    "      a.dispose()\n"
+    "    end)\n"
+    "    None";
+  TEST_EQUIV(short_form, full_form);
+}
+
+TEST_F(SugarTest, WithExprWithTupleDestructuringAndDontCare)
+{
+  const char* short_form =
+    "class Disposable\n"
+    "  var create: U32\n"
+    "  fun dispose(): None =>\n"
+    "    None"
+    "\n"
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun do_it() =>\n"
+    "    with (a, _, c) = (Disposable, Disposable, Disposable) do\n"
+    "      error\n"
+    "    end\n";
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Disposable\n"
+    "  var create: U32\n"
+    "  \n"
+    "  fun box dispose(): None =>\n"
+    "    None\n"
+    "    None\n"
+    "\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box do_it(): None =>\n"
+    "    (\n"
+    "    let $0 = (\n"
+    "      (Disposable, Disposable, Disposable)\n"
+    "    )\n"
+    "    $try_no_check\n"
+    "      (let a, let _, let c) = $0\n"
+    "      (error)\n"
+    "    else\n"
+    "      (let a, let _, let c) = $0\n"
+    "      (None)\n"
+    "    then\n"
+    "      (let a, let _, let c) = $0\n"
+    "      c.dispose()\n"
+    "      a.dispose()\n"
+    "    end)\n"
+    "    None";
+  TEST_EQUIV(short_form, full_form);
+}
+


### PR DESCRIPTION
A with expression like the following caused the compiler to abort:

```pony
with (a, b) = some_tuple do
   error
end
```

This PR fixes those cases and adds some test coverage for desugaring with expressions in general.

Fixes #3581