### PR TITLE
Force removing read-only files on Windows with `FilePath.remove()`

### DIFF
--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -929,6 +929,7 @@ class iso _TestFileRemoveReadOnly is UnitTest
 
 class iso _TestDirectoryRemoveReadOnly is UnitTest
   fun name(): String => "files/File.remove-readonly-directory"
+
   fun apply(h: TestHelper) ? =>
     let path = FilePath.mkdtemp(h.env.root as AmbientAuth, "tmp-read-only-dir")?
     let dir = Directory(path)?
@@ -936,10 +937,13 @@ class iso _TestDirectoryRemoveReadOnly is UnitTest
       let mode: FileMode ref = FileMode
       mode.owner_read = true
       mode.owner_write = false
+      mode.owner_exec = true
       mode.group_read = true
       mode.group_write = false
+      mode.group_exec = true
       mode.any_read = true
       mode.any_write = false
+      mode.any_exec = true
       h.assert_true(path.chmod(mode))
     then
       h.assert_true(path.remove())

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -50,6 +50,7 @@ actor Main is TestList
     test(_TestFileWritevLarge)
     test(_TestFileFlush)
     test(_TestFileReadMore)
+    test(_TestFileRemoveReadOnly)
     test(_TestFileLinesEmptyFile)
     test(_TestFileLinesSingleLine)
     test(_TestFileLinesMultiLine)
@@ -473,7 +474,7 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
       mode.owner_read = true
       mode.owner_write = true // required on Windows to delete the file
       filepath.chmod(mode)
-      filepath.remove()
+      h.assert_true(filepath.remove())
     else
       h.fail("Unhandled error!")
     end
@@ -905,6 +906,27 @@ class iso _TestFileReadMore is UnitTest
         "File errno is not EOF after reading past the last byte")
     end
     path.remove()
+
+class iso _TestFileRemoveReadOnly is UnitTest
+  fun name(): String => "files/File.remove-readonly"
+  fun apply(h: TestHelper) ? =>
+    let path = FilePath(h.env.root as AmbientAuth, "tmp-read-only")?
+    try
+      with file = CreateFile(path) as File do
+        None
+      end
+
+      let mode: FileMode ref = FileMode
+      mode.owner_read = true
+      mode.owner_write = false
+      mode.group_read = true
+      mode.group_write = false
+      mode.any_read = true
+      mode.any_write = false
+      h.assert_true(path.chmod(mode))
+    then
+      h.assert_true(path.remove())
+    end
 
 class iso _TestFileLinesEmptyFile is UnitTest
   var tmp_dir: (FilePath | None) = None

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -220,12 +220,12 @@ class val FilePath
       end
 
       ifdef windows then
+        // _unlink() on Windows can't remove readonly files
+        // so we change mode to _S_IWRITE just in case
+        @_chmod[I32](path.cstring(), I32(0x0080))
         if info.directory and not info.symlink then
           0 == @_rmdir[I32](path.cstring())
         else
-          // _unlink() on Windows can't remove readonly files
-          // so we change mode to _S_IWRITE just in case
-          @_chmod[I32](path.cstring(), I32(0x0080))
           0 == @_unlink[I32](path.cstring())
         end
       else

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -223,6 +223,9 @@ class val FilePath
         if info.directory and not info.symlink then
           0 == @_rmdir[I32](path.cstring())
         else
+          // _unlink() on Windows can't remove readonly files
+          // so we change mode to _S_IWRITE just in case
+          @_chmod[I32](path.cstring(), I32(0x0080))
           0 == @_unlink[I32](path.cstring())
         end
       else


### PR DESCRIPTION
On Windows, `_unlink()` cannot remove a file if it is read-only. This change calls `_chmod(..., _S_IWrite)` on files that are about to be removed so as to make sure they are removable.

This fixes an issue with temp directories being left around from tests in Corral, as Git often makes some of its files read-only.