### PR TITLE
Always allow field access for objects defined inside a recover block

### DIFF
--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -197,6 +197,7 @@ bool expr_contained_in(ast_t* ast, ast_t* expected_recover)
 {
   token_id id = ast_id(ast);
   ast_t* def;
+  ast_t* def_recover = NULL;
   while(true)
   {
     switch (id)
@@ -214,7 +215,7 @@ bool expr_contained_in(ast_t* ast, ast_t* expected_recover)
       case TK_PARAMREF:
         def = (ast_t*)ast_data(ast);
         pony_assert( def != NULL );
-        ast_t* def_recover = ast_nearest(def, TK_RECOVER);
+        def_recover = ast_nearest(def, TK_RECOVER);
         return def_recover == expected_recover;
 
       case TK_REFERENCE:

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -260,7 +260,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
   }
 
   // In a recover expression, we can access obj.field if field is sendable
-  // and not being assigned to, even if obj isn't sendable.
+  // even if obj isn't sendable.
 
   ast_t* nearest_recover = opt->check.frame->recover;
   if(nearest_recover != NULL)
@@ -269,23 +269,13 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
     {
       if(!sendable(l_type))
       {
-        ast_t* parent = ast_parent(ast);
-        ast_t* current = ast;
-        while(ast_id(parent) != TK_RECOVER && ast_id(parent) != TK_ASSIGN)
-        {
-          current = parent;
-          parent = ast_parent(parent);
-        }
-        if(ast_id(parent) == TK_ASSIGN && ast_childidx(parent, 1) != current)
-        {
-          errorframe_t frame = NULL;
-          ast_error_frame(&frame, ast, "can't access field of non-sendable "
-              "object inside of a recover expression");
-          ast_error_frame(&frame, parent, "this would be possible if the field "
-              "wasn't assigned to");
-          errorframe_report(&frame, opt->check.errors);
-          return false;
-        }
+        errorframe_t frame = NULL;
+        ast_error_frame(&frame, ast, "can't access field of non-sendable "
+            "object inside of a recover expression");
+        ast_error_frame(&frame, find, "this would be possible if the field was "
+            "sendable");
+        errorframe_report(&frame, opt->check.errors);
+        return false;
       }
     }
   }

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -264,7 +264,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
   // and not being assigned to, even if obj isn't sendable.
 
   ast_t* nearest_recover = opt->check.frame->recover;
-  if(nearest_recover != NULL && !expr_contained_in(left, nearest_recover))
+  if(nearest_recover != NULL && !expr_contained_in_recover(left, nearest_recover))
   {
     if(!sendable(type))
     {

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -271,8 +271,8 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
       if(!sendable(l_type))
       {
         errorframe_t frame = NULL;
-        ast_error_frame(&frame, ast, "can't access field of non-sendable "
-            "object inside of a recover expression");
+        ast_error_frame(&frame, ast, "can't access non-sendable field of "
+            "non-sendable object inside of a recover expression");
         errorframe_report(&frame, opt->check.errors);
         return false;
       }
@@ -289,10 +289,8 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
       if(ast_id(parent) == TK_ASSIGN && ast_childidx(parent, 1) != current)
       {
         errorframe_t frame = NULL;
-        ast_error_frame(&frame, ast, "can't access field of non-sendable "
+        ast_error_frame(&frame, ast, "can't assign to field of non-sendable "
             "object inside of a recover expression");
-        ast_error_frame(&frame, parent, "this would be possible if the field "
-            "wasn't assigned to");
         errorframe_report(&frame, opt->check.errors);
         return false;
       }

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -193,7 +193,7 @@ bool expr_field(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-bool expr_contained_in(ast_t* ast, ast_t* expected_recover)
+static bool expr_contained_in_recover(ast_t* ast, ast_t* expected_recover)
 {
   token_id id = ast_id(ast);
   ast_t* def;

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -264,9 +264,9 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
   // and not being assigned to, even if obj isn't sendable.
 
   ast_t* nearest_recover = opt->check.frame->recover;
-  if(nearest_recover != NULL)
+  if(nearest_recover != NULL && !expr_contained_in(left, nearest_recover))
   {
-    if(!sendable(type) && !expr_contained_in(left, nearest_recover))
+    if(!sendable(type))
     {
       if(!sendable(l_type))
       {

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -261,7 +261,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
   }
 
   // In a recover expression, we can access obj.field if field is sendable
-  // even if obj isn't sendable.
+  // and not being assigned to, even if obj isn't sendable.
 
   ast_t* nearest_recover = opt->check.frame->recover;
   if(nearest_recover != NULL)
@@ -273,8 +273,26 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
         errorframe_t frame = NULL;
         ast_error_frame(&frame, ast, "can't access field of non-sendable "
             "object inside of a recover expression");
-        ast_error_frame(&frame, find, "this would be possible if the field was "
-            "sendable");
+        errorframe_report(&frame, opt->check.errors);
+        return false;
+      }
+    }
+    else
+    {
+      ast_t* parent = ast_parent(ast);
+      ast_t* current = ast;
+      while(ast_id(parent) != TK_RECOVER && ast_id(parent) != TK_ASSIGN)
+      {
+        current = parent;
+        parent = ast_parent(parent);
+      }
+      if(ast_id(parent) == TK_ASSIGN && ast_childidx(parent, 1) != current)
+      {
+        errorframe_t frame = NULL;
+        ast_error_frame(&frame, ast, "can't access field of non-sendable "
+            "object inside of a recover expression");
+        ast_error_frame(&frame, parent, "this would be possible if the field "
+            "wasn't assigned to");
         errorframe_report(&frame, opt->check.errors);
         return false;
       }

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -290,7 +290,7 @@ TEST_F(RecoverTest, CantAccess_NonSendableField)
     "  fun apply(): Wrap iso =>\n"
     "    recover Wrap(inner) end";
 
-  TEST_ERRORS_1(src, "can't access field of non-sendable object");
+  TEST_ERRORS_1(src, "can't access non-sendable field of non-sendable object");
 }
 
 TEST_F(RecoverTest, CantAccess_AssignedField)
@@ -305,7 +305,7 @@ TEST_F(RecoverTest, CantAccess_AssignedField)
     "  fun ref apply(): Wrap iso =>\n"
     "    recover Wrap(inner = recover Inner end) end";
 
-  TEST_ERRORS_2(src, "can't access field of non-sendable object",
+  TEST_ERRORS_2(src, "can't assign to field of non-sendable object",
     "left side must be something that can be assigned to");
 }
 
@@ -516,7 +516,7 @@ TEST_F(RecoverTest, CantWrite_This_NonSendable)
     "      this.str = str'\n"
     "    end";
 
-  TEST_ERRORS_2(src, "can't access field of non-sendable "
+  TEST_ERRORS_2(src, "can't access non-sendable field of non-sendable "
             "object inside of a recover expression",
     "left side must be something that can be assigned to");
 }

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -293,22 +293,6 @@ TEST_F(RecoverTest, CantAccess_NonSendableField)
   TEST_ERRORS_1(src, "can't access field of non-sendable object");
 }
 
-TEST_F(RecoverTest, CantAccess_AssignedField)
-{
-  const char* src =
-    "class Inner\n"
-    "class Wrap\n"
-    "  new create(s: Inner box) => None\n"
-
-    "class Class\n"
-    "  var inner: Inner iso = recover Inner end\n"
-    "  fun ref apply(): Wrap iso =>\n"
-    "    recover Wrap(inner = recover Inner end) end";
-
-  TEST_ERRORS_2(src, "can't access field of non-sendable object",
-    "left side must be something that can be assigned to");
-}
-
 TEST_F(RecoverTest, CantAccess_ThisOriginallyTagField)
 {
   const char* src =

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -443,7 +443,7 @@ TEST_F(RecoverTest, CanAccess_LocalAssigned)
   TEST_COMPILE(src);
 }
 
-TEST_F(RecoverTest, CantAccess_NonLocalField)
+TEST_F(RecoverTest, CantWrite_NonLocalField)
 {
   const char* src =
     "class StringRef\n"

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -616,6 +616,7 @@ TEST_F(RecoverTest, CanAccess_LocalField)
     "      var local: StringRef ref = StringRef\n"
     "      local.str = String\n"
     "    end";
+}
 
   TEST_COMPILE(src);
 }

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -623,7 +623,7 @@ TEST_F(RecoverTest, CanAccess_DeepLocalFields)
 {
   const char* src =
     "class StringRef\n"
-    "  var str: String = String\n"
+    "  var str: String ref = String\n"
     "class StringRefRef\n"
     "  var strref: StringRef = StringRef\n"
     "class Foo\n"
@@ -634,6 +634,21 @@ TEST_F(RecoverTest, CanAccess_DeepLocalFields)
     "    end";
 
   TEST_COMPILE(src);
+}
+TEST_F(RecoverTest, CantAccess_This_NonSendable)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String ref = String\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      let str': String ref = String\n"
+    "      this.str = str'\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access field of non-sendable "
+            "object inside of a recover expression",
+    "left side must be something that can be assigned to");
 }
 
   TEST_COMPILE(src);

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -616,6 +616,8 @@ TEST_F(RecoverTest, CanAccess_LocalField)
     "      var local: StringRef ref = StringRef\n"
     "      local.str = String\n"
     "    end";
+
+  TEST_COMPILE(src);
 }
 
   TEST_COMPILE(src);

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -293,6 +293,22 @@ TEST_F(RecoverTest, CantAccess_NonSendableField)
   TEST_ERRORS_1(src, "can't access field of non-sendable object");
 }
 
+TEST_F(RecoverTest, CantAccess_AssignedField)
+{
+  const char* src =
+    "class Inner\n"
+    "class Wrap\n"
+    "  new create(s: Inner box) => None\n"
+
+    "class Class\n"
+    "  var inner: Inner iso = recover Inner end\n"
+    "  fun ref apply(): Wrap iso =>\n"
+    "    recover Wrap(inner = recover Inner end) end";
+
+  TEST_ERRORS_2(src, "can't access field of non-sendable object",
+    "left side must be something that can be assigned to");
+}
+
 TEST_F(RecoverTest, CantAccess_ThisOriginallyTagField)
 {
   const char* src =

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -416,6 +416,96 @@ TEST_F(RecoverTest, CantAccess_MethodReturnNonSendable)
   TEST_ERRORS_1(src, "can't call method on non-sendable object");
 }
 
+TEST_F(RecoverTest, CantAccess_NonSendableLocalAssigned)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    var nonlocal: String ref = String\n"
+    "    recover\n"
+    "      nonlocal = String\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
+    "left side must be something that can be assigned to");
+}
+
+TEST_F(RecoverTest, CanAccess_LocalAssigned)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: String ref = String\n"
+    "      local = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantAccess_NonLocalField)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String = String\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    var nonlocal: StringRef ref = StringRef\n"
+    "    recover\n"
+    "      nonlocal.str = String\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
+    "left side must be something that can be assigned to");
+}
+
+TEST_F(RecoverTest, CanAccess_LocalField)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String = String\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: StringRef ref = StringRef\n"
+    "      local.str = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+TEST_F(RecoverTest, CanAccess_DeepLocalFields)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String ref = String\n"
+    "class StringRefRef\n"
+    "  var strref: StringRef = StringRef\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: StringRefRef ref = StringRefRef\n"
+    "      local.strref.str = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+TEST_F(RecoverTest, CantWrite_This_NonSendable)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String ref = String\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      let str': String ref = String\n"
+    "      this.str = str'\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access field of non-sendable "
+            "object inside of a recover expression",
+    "left side must be something that can be assigned to");
+}
+
+
 TEST_F(RecoverTest, CanDoPartialApplication_TagWithLowerToTag)
 {
   const char* src =
@@ -546,97 +636,6 @@ TEST_F(RecoverTest, CantRecover_TupleInUnionMultipleLifts)
   TEST_ERRORS_1(src, "can't recover to this capability");
 }
 
-TEST_F(RecoverTest, CantAccess_NonSendableLocalAssigned)
-{
-  const char* src =
-    "class Foo\n"
-    "  fun apply() =>\n"
-    "    var nonlocal: String ref = String\n"
-    "    recover\n"
-    "      nonlocal = String\n"
-    "    end";
-
-  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
-    "left side must be something that can be assigned to");
-}
-
-TEST_F(RecoverTest, CanAccess_LocalAssigned)
-{
-  const char* src =
-    "class Foo\n"
-    "  fun apply() =>\n"
-    "    recover\n"
-    "      var local: String ref = String\n"
-    "      local = String\n"
-    "    end";
-
-  TEST_COMPILE(src);
-}
-
-TEST_F(RecoverTest, CantAccess_NonLocalField)
-{
-  const char* src =
-    "class StringRef\n"
-    "  var str: String = String\n"
-    "class Foo\n"
-    "  fun apply() =>\n"
-    "    var nonlocal: StringRef ref = StringRef\n"
-    "    recover\n"
-    "      nonlocal.str = String\n"
-    "    end";
-
-  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
-    "left side must be something that can be assigned to");
-}
-
-TEST_F(RecoverTest, CanAccess_LocalField)
-{
-  const char* src =
-    "class StringRef\n"
-    "  var str: String = String\n"
-    "class Foo\n"
-    "  fun apply() =>\n"
-    "    recover\n"
-    "      var local: StringRef ref = StringRef\n"
-    "      local.str = String\n"
-    "    end";
-
-  TEST_COMPILE(src);
-}
-TEST_F(RecoverTest, CanAccess_DeepLocalFields)
-{
-  const char* src =
-    "class StringRef\n"
-    "  var str: String ref = String\n"
-    "class StringRefRef\n"
-    "  var strref: StringRef = StringRef\n"
-    "class Foo\n"
-    "  fun apply() =>\n"
-    "    recover\n"
-    "      var local: StringRefRef ref = StringRefRef\n"
-    "      local.strref.str = String\n"
-    "    end";
-
-  TEST_COMPILE(src);
-}
-TEST_F(RecoverTest, CantAccess_This_NonSendable)
-{
-  const char* src =
-    "class StringRef\n"
-    "  var str: String ref = String\n"
-    "  fun apply() =>\n"
-    "    recover\n"
-    "      let str': String ref = String\n"
-    "      this.str = str'\n"
-    "    end";
-
-  TEST_ERRORS_2(src, "can't access field of non-sendable "
-            "object inside of a recover expression",
-    "left side must be something that can be assigned to");
-}
-
-  TEST_COMPILE(src);
-}
 TEST_F(RecoverTest, CantReturnTrn_TrnAutoRecovery)
 {
   const char* src =

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -619,6 +619,22 @@ TEST_F(RecoverTest, CanAccess_LocalField)
 
   TEST_COMPILE(src);
 }
+TEST_F(RecoverTest, CanAccess_DeepLocalFields)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String = String\n"
+    "class StringRefRef\n"
+    "  var strref: StringRef = StringRef\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: StringRefRef ref = StringRefRef\n"
+    "      local.strref.str = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
 
   TEST_COMPILE(src);
 }

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -567,16 +567,58 @@ TEST_F(RecoverTest, CantAccess_NonSendableLocalAssigned)
   const char* src =
     "class Foo\n"
     "  fun apply() =>\n"
-    "    var a: String ref = String\n"
+    "    var nonlocal: String ref = String\n"
     "    recover\n"
-    "      let b: String ref = String\n"
-    "      a = b\n"
+    "      nonlocal = String\n"
     "    end";
 
   TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
     "left side must be something that can be assigned to");
 }
 
+TEST_F(RecoverTest, CanAccess_LocalAssigned)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: String ref = String\n"
+    "      local = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(RecoverTest, CantAccess_NonLocalField)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String = String\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    var nonlocal: StringRef ref = StringRef\n"
+    "    recover\n"
+    "      nonlocal.str = String\n"
+    "    end";
+
+  TEST_ERRORS_2(src, "can't access a non-sendable local defined outside",
+    "left side must be something that can be assigned to");
+}
+
+TEST_F(RecoverTest, CanAccess_LocalField)
+{
+  const char* src =
+    "class StringRef\n"
+    "  var str: String = String\n"
+    "class Foo\n"
+    "  fun apply() =>\n"
+    "    recover\n"
+    "      var local: StringRef ref = StringRef\n"
+    "      local.str = String\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
 TEST_F(RecoverTest, CantReturnTrn_TrnAutoRecovery)
 {
   const char* src =


### PR DESCRIPTION
I should have opened this ages ago, but this change always allows simple assignments with variables defined locally:
`x.y = e`, `x.y.z.q = e`
Soundness can be seen because this functionality is possible today using methods, it is just very cumbersome.

This also includes a change to enable field-writes to non-local variables when the destination is sendable (this is slightly less than the most general: which would include writing a sendable expression to any field; but that requires adding more check logic). The current checks had very strange logic, and don't seem to be necessary: We only need to maintain isolation of the recover region, so it's perfectly fine to move sendable items in or out without restriction, since they cannot violate the guarantees. See https://github.com/ponylang/ponyc/pull/1057 for context of those original changes.

Fixes https://github.com/ponylang/ponyc/issues/3069

