### PR TITLE
Have stdlib documentation building fail build if it fails

### DIFF
--- a/.ci-scripts/build-and-push-stdlib-documentation.bash
+++ b/.ci-scripts/build-and-push-stdlib-documentation.bash
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+
 export LC_ALL=C.UTF-8
 export LANG=C.UTF-8
 


### PR DESCRIPTION
Prior to this change, we haven't built the standard lib docs due to
an error since February yet, the build has been green. This
should fix that issue. I hope.