### PR TITLE
Fix broken standard library documentation builder

### DIFF
--- a/.ci-dockerfiles/stdlib-builder/Dockerfile
+++ b/.ci-dockerfiles/stdlib-builder/Dockerfile
@@ -1,9 +1,19 @@
-FROM ponylang/ponyc:release
+ARG FROM_TAG=release-alpine
+FROM ponylang/ponyc:${FROM_TAG}
 
-RUN apt-get update \
- && apt-get install -y \
+RUN apk update \
+  && apk upgrade \
+  && apk add --update \
+  bash \
+  git-fast-import \
+  libffi \
+  libffi-dev \
+  libressl \
+  libressl-dev \
   python3 \
-  python3-pip \
- && pip3 install mkdocs
-
-RUN pip3 install --user mkdocs-ponylang
+  python3-dev \
+  py3-pip \
+  && pip3 install --upgrade pip \
+  && pip3 install wheel \
+  && pip3 install mkdocs \
+  && pip3 install mkdocs-ponylang

--- a/.ci-dockerfiles/stdlib-builder/build-and-push.bash
+++ b/.ci-dockerfiles/stdlib-builder/build-and-push.bash
@@ -9,5 +9,16 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
-docker build --pull -t "ponylang/ponyc-ci-stdlib-builder:latest" "${DOCKERFILE_DIR}"
-docker push "ponylang/ponyc-ci-stdlib-builder:latest"
+# built from ponyc release tag
+FROM_TAG=release-alpine
+TAG_AS=release
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
+
+# built from ponyc latest tag
+FROM_TAG=alpine
+TAG_AS=latest
+docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
+  -t ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"

--- a/.github/workflows/handle-external-events.yml
+++ b/.github/workflows/handle-external-events.yml
@@ -126,8 +126,8 @@ jobs:
         env:
           VERSION: ${{ github.event.client_payload.data.version }}
 
-  update-stdlib-builder-image:
-    needs: build-release-gnu-docker-image
+  update-stdlib-builder-image-on-release:
+    needs: build-release-musl-docker-image
 
     name: Updates stdlib-builder Docker image with newly released ponyc version
     runs-on: ubuntu-latest
@@ -141,13 +141,28 @@ jobs:
       - name: Build and push
         run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
 
+  update-stdlib-builder-image-on-nightly:
+    needs: build-latest-musl-docker-image
+
+    name: Updates stdlib-builder Docker image with nightly ponyc version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker login
+        run: "docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
+
   build-and-push-stdlib-documentation:
-    needs: update-stdlib-builder-image
+    needs: update-stdlib-builder-image-on-release
 
     name: Build and Push standard library documentation
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc-ci-stdlib-builder:latest
+      image: ponylang/ponyc-ci-stdlib-builder:release
     steps:
       - uses: actions/checkout@v1
       - name: Build and push


### PR DESCRIPTION
The image that was based on Ubuntu wasn't correctly installing
the ponylang theme and then doc building would fail.

This PR

- Switches to alpine for the base of the doc building image because it works
- Adds building the doc builder image both after a release and after each nightly
- Switches to having 2 tags for the image
  - release
  - latest

By building a latest on each nightly, we can catch any errors building the image
before we get to a release (hopefully).