### PR TITLE
Fix compile error with GCC 8.3

### DIFF
--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -942,6 +942,7 @@ bool cap_safetomove(token_id into, token_id cap, direction direction)
 
         case TK_TRN:
           return direction == WRITE;
+          
         case TK_BOX:
           return direction == EXTRACT;
           


### PR DESCRIPTION
See:
```sh
[damon@localhost ponyc-git]$ make build
gmake[1]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[2]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 21%] Built target libponyrt
Scanning dependencies of target libponyc
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 26%] Built target libponyrt.tests
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 29%] Built target libponyrt.benchmarks
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 30%] Building C object src/libponyc/CMakeFiles/libponyc.dir/type/cap.c.o
/home/damon/.ome_local/repo/ponyc-git/src/libponyc/type/cap.c: In function ‘cap_safetomove’:
/home/damon/.ome_local/repo/ponyc-git/src/libponyc/type/cap.c:944:11: error: this statement may fall through [-Werror=implicit-fallthrough=]
           switch (direction) {
           ^~~~~~
/home/damon/.ome_local/repo/ponyc-git/src/libponyc/type/cap.c:948:9: note: here
         case TK_BOX:
         ^~~~
cc1: all warnings being treated as errors
gmake[3]: *** [src/libponyc/CMakeFiles/libponyc.dir/build.make:1109: src/libponyc/CMakeFiles/libponyc.dir/type/cap.c.o] Error 1
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[2]: *** [CMakeFiles/Makefile2:267: src/libponyc/CMakeFiles/libponyc.dir/all] Error 2
gmake[2]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[1]: *** [Makefile:149: all] Error 2
gmake[1]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
make: *** [Makefile:159: build] Error 2

```
This PR Fixed it.
```sh
[damon@localhost ponyc-git]$ make build
gmake[1]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[2]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 21%] Built target libponyrt
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 26%] Built target libponyrt.tests
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 70%] Built target libponyc
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 73%] Built target libponyrt.benchmarks
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 74%] Built target ponyc
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Entering directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[3]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
[ 76%] Built target libponyc.benchmarks
[100%] Built target libponyc.tests
gmake[2]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
gmake[1]: Leaving directory '/home/damon/.ome_local/repo/ponyc-git/build/build_release'
```