### PR TITLE
Revert "Implement RFC0067"

### DIFF
--- a/packages/logger/_test.pony
+++ b/packages/logger/_test.pony
@@ -91,7 +91,7 @@ class _TestObjectLogging is _LoggerTest[U64]
     logger'(Error) and logger'.log(U64(42))
 
 primitive _TestFormatter is LogFormatter
-  fun apply(lvl: LogLevel, msg: String, loc: SourceLoc): String =>
+  fun apply(msg: String, loc: SourceLoc): String =>
     msg + "\n"
 
 actor _TestStream is OutStream

--- a/packages/logger/logger.pony
+++ b/packages/logger/logger.pony
@@ -78,7 +78,6 @@ override the standard formatting, you can create an object that implements:
 ```pony
 interface val LogFormatter
   fun apply(
-    level: LogLevel,
     msg: String,
     file_name: String,
     file_linenum: String,
@@ -98,19 +97,15 @@ type LogLevel is
 
 primitive Fine
   fun apply(): U32 => 0
-  fun string(): String iso^ => recover "FINE".clone() end
 
 primitive Info
   fun apply(): U32 => 1
-  fun string(): String iso^ => recover "INFO".clone() end
 
 primitive Warn
   fun apply(): U32 => 2
-  fun string(): String iso^ => recover "WARN".clone() end
 
 primitive Error
   fun apply(): U32 => 3
-  fun string(): String iso^ => recover "ERRR".clone() end
 
 class val Logger[A]
   let _level: LogLevel
@@ -133,7 +128,7 @@ class val Logger[A]
     level() >= _level()
 
   fun log(value: A, loc: SourceLoc = __loc): Bool =>
-    _out.print(_formatter(_level, _f(consume value), loc))
+    _out.print(_formatter(_f(consume value), loc))
     true
 
 primitive StringLogger
@@ -154,10 +149,10 @@ interface val LogFormatter
 
   See `DefaultLogFormatter` for an example of how to implement a LogFormatter.
   """
-  fun apply(lvl: LogLevel, msg: String, loc: SourceLoc): String
+  fun apply(msg: String, loc: SourceLoc): String
 
 primitive DefaultLogFormatter is LogFormatter
-  fun apply(lvl: LogLevel, msg: String, loc: SourceLoc): String =>
+  fun apply(msg: String, loc: SourceLoc): String =>
     let file_name: String = loc.file()
     let file_linenum: String  = loc.line().string()
     let file_linepos: String  = loc.pos().string()


### PR DESCRIPTION
This reverts commit 4d4cb9223bf7a790e9eb64e45661b3e6119f2322.

The original intent behind RFC0067 was to make it easy to add a prefix with the
log level for any given log message. However, there is a logic bug in the
implementation; the log level prefix added to messages in LogFormatter would
always be the log level specified in Logger.create(), not the log level desired
at specific call sites. This would lead to misleading log messages where the log
level prefix doesn't match the severity of the log message, such as "FINE:
Critical error. Shutting down".

It would be better if these changes were reverted so a more thought-out solution
could be implemented in the future.