### PR TITLE
Change how globbing is done in release scripts

### DIFF
--- a/.ci-scripts/x86-64-nightly.bash
+++ b/.ci-scripts/x86-64-nightly.bash
@@ -63,7 +63,7 @@ make install prefix="${BUILD_PREFIX}" symlink=no arch=${ARCH} \
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
 pushd "${DESTINATION}" || exit 1
-tar -cvzf "${ASSET_FILE}" ./*
+tar -cvzf "${ASSET_FILE}" -- *
 popd || exit 1
 
 # Ship it off to cloudsmith

--- a/.ci-scripts/x86-64-release.bash
+++ b/.ci-scripts/x86-64-release.bash
@@ -58,7 +58,7 @@ make install prefix="${BUILD_PREFIX}" symlink=no arch=${ARCH} \
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
 pushd "${DESTINATION}" || exit 1
-tar -cvzf "${ASSET_FILE}" ./*
+tar -cvzf "${ASSET_FILE}" -- *
 popd || exit 1
 
 # Ship it off to cloudsmith

--- a/.ci-scripts/x86-64-unknown-freebsd-12.1-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-12.1-nightly.bash
@@ -53,7 +53,7 @@ gmake install prefix="${BUILD_PREFIX}" symlink=no arch=${ARCH} \
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
 pushd "${DESTINATION}" || exit 1
-tar -cvzf "${ASSET_FILE}" ./*
+tar -cvzf "${ASSET_FILE}" -- *
 popd || exit 1
 
 # Ship it off to cloudsmith

--- a/.ci-scripts/x86-64-unknown-freebsd-12.1-release.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-12.1-release.bash
@@ -48,7 +48,7 @@ gmake install prefix="${BUILD_PREFIX}" symlink=no arch=${ARCH} \
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."
 pushd "${DESTINATION}" || exit 1
-tar -cvzf "${ASSET_FILE}" ./*
+tar -cvzf "${ASSET_FILE}" -- *
 popd || exit 1
 
 # Ship it off to cloudsmith

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
         uses: docker://github/super-linter:v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           VALIDATE_BASH: true
           VALIDATE_DOCKERFILE: true
           VALIDATE_MD: true


### PR DESCRIPTION
The previous change from * to ./* which made shellcheck happy broke
the release process slightly because it changed the directory names
in the created tar file.

This new change has the same shellcheck is happy impact but doesn't
change the paths in the tar file.