### PR TITLE
Minor Docker linting fixes

### DIFF
--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
@@ -15,4 +15,4 @@ RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.Vi
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc
 RUN setx /M PATH $($env:PATH + ';C:\ponyc\bin')
 
-CMD C:\ponyc\bin\ponyc.exe
+CMD ["C:\ponyc\bin\ponyc.exe"]

--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -20,4 +20,4 @@ RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.
 
 WORKDIR /src/main
 
-CMD ponyc
+CMD ["ponyc"]

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --no-cache \
     libexecinfo-dev \
     libexecinfo-static
 
-RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
+RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc nightly --platform=musl\
  && ponyup update stable nightly \
  && ponyup update corral nightly \
@@ -19,4 +19,4 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
 
 WORKDIR /src/main
 
-CMD ponyc
+CMD ["ponyc"]

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
@@ -15,4 +15,4 @@ RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.Vi
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc
 RUN setx /M PATH $($env:PATH + ';C:\ponyc\bin')
 
-CMD C:\ponyc\bin\ponyc.exe
+CMD ["C:\ponyc\bin\ponyc.exe"]

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -20,4 +20,4 @@ RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.
 
 WORKDIR /src/main
 
-CMD ponyc
+CMD ["ponyc"]

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --no-cache \
     libexecinfo-static \
     git
 
-RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh \
+RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc release --platform=musl \
  && ponyup update stable release \
  && ponyup update corral release \
@@ -19,4 +19,4 @@ RUN curl -s --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/po
 
 WORKDIR /src/main
 
-CMD ponyc
+CMD ["ponyc"]


### PR DESCRIPTION
The following are fixes from the Hadolint docker linter. We
can't turn it on as part of the linting process as we can't turn
it off for our Windows Dockerfiles and it does not know how to
handle the Windows-ism in it.