### PR TITLE
Only run superlinter on changed files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lint codebase
-        uses: docker://github/super-linter:v3
+        uses: docker://github/super-linter:v3.8.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           VALIDATE_BASH: true
           VALIDATE_DOCKERFILE: true
           VALIDATE_MD: true


### PR DESCRIPTION
Supposedly this works if you switch to a newer version.