### PR TITLE
Move editor support from README.md to EDITORS.md

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -1,0 +1,21 @@
+# Editor support
+
+* Sublime Text: [Pony Language](https://packagecontrol.io/packages/Pony%20Language)
+* Atom: [language-pony](https://atom.io/packages/language-pony)
+* Visual Studio: [VS-pony](https://github.com/ponylang/VS-pony)
+* Visual Studio Code: [vscode-pony](https://marketplace.visualstudio.com/items?itemName=npruehs.pony)
+* Vim:
+  * [vim-pony](https://github.com/jakwings/vim-pony)
+  * [pony.vim](https://github.com/dleonard0/pony-vim-syntax)
+  * [currycomb: Syntastic support](https://github.com/killerswan/pony-currycomb.vim)
+  * [SpaceVim](http://spacevim.org), available as layer for Vim and [Neovim](https://neovim.io). Just follow [installation instructions](https://github.com/SpaceVim/SpaceVim) then load `lang#pony` layer inside configuration file (*$HOME/.SpaceVim.d/init.toml*)
+* Emacs:
+  * [ponylang-mode](https://github.com/ponylang/ponylang-mode)
+  * [flycheck-pony](https://github.com/ponylang/flycheck-pony)
+  * [pony-snippets](https://github.com/ponylang/pony-snippets)
+* BBEdit: [bbedit-pony](https://github.com/TheMue/bbedit-pony)
+* Micro: [micro-pony-plugin](https://github.com/Theodus/micro-pony-plugin)
+* Nano: [pony.nanorc file](https://github.com/serialhex/nano-highlight/blob/master/pony.nanorc)
+* Kate: update syntax definition file: Settings -> Configure Kate -> Open/Save -> Modes & Filetypes -> Download Highlighting Files
+* CudaText: lexer in Addon Manager
+* Vis: has a [lexer](https://github.com/martanne/vis/blob/master/lua/lexers/pony.lua) for Pony

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [BUILD.md](BUILD.md).
 
 ## Docker images
 
-See [INSTALL_DOCKER.md](INSTALL_DOCKER.md)
+See [INSTALL_DOCKER.md](INSTALL_DOCKER.md).
 
 ## Resources
 
@@ -46,25 +46,7 @@ See [INSTALL_DOCKER.md](INSTALL_DOCKER.md)
 
 ## Editor support
 
-* Sublime Text: [Pony Language](https://packagecontrol.io/packages/Pony%20Language)
-* Atom: [language-pony](https://atom.io/packages/language-pony)
-* Visual Studio: [VS-pony](https://github.com/ponylang/VS-pony)
-* Visual Studio Code: [vscode-pony](https://marketplace.visualstudio.com/items?itemName=npruehs.pony)
-* Vim:
-  * [vim-pony](https://github.com/jakwings/vim-pony)
-  * [pony.vim](https://github.com/dleonard0/pony-vim-syntax)
-  * [currycomb: Syntastic support](https://github.com/killerswan/pony-currycomb.vim)
-  * [SpaceVim](http://spacevim.org), available as layer for Vim and [Neovim](https://neovim.io). Just follow [installation instructions](https://github.com/SpaceVim/SpaceVim) then load `lang#pony` layer inside configuration file (*$HOME/.SpaceVim.d/init.toml*)
-* Emacs:
-  * [ponylang-mode](https://github.com/ponylang/ponylang-mode)
-  * [flycheck-pony](https://github.com/ponylang/flycheck-pony)
-  * [pony-snippets](https://github.com/ponylang/pony-snippets)
-* BBEdit: [bbedit-pony](https://github.com/TheMue/bbedit-pony)
-* Micro: [micro-pony-plugin](https://github.com/Theodus/micro-pony-plugin)
-* Nano: [pony.nanorc file](https://github.com/serialhex/nano-highlight/blob/master/pony.nanorc)
-* Kate: update syntax definition file: Settings -> Configure Kate -> Open/Save -> Modes & Filetypes -> Download Highlighting Files
-* CudaText: lexer in Addon Manager
-* Vis: has a [lexer](https://github.com/martanne/vis/blob/master/lua/lexers/pony.lua) for Pony
+See [EDITORS.md](EDITORS.md).
 
 ## Contributing
 


### PR DESCRIPTION
Not sure you want this, but i thought i clean up the README.md somewhat, by moving the editor support list to a separate file and link to it from README.md.