### PR TITLE
Add prebuilt ponyc binaries for CentOS 8

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-centos8-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-centos8-builder/Dockerfile
@@ -1,0 +1,26 @@
+FROM centos:centos8
+
+RUN yum install -y \
+    dnf-plugins-core \
+    epel-release \
+  && yum config-manager --set-enabled PowerTools
+
+RUN yum install -y \
+    clang \
+    diffutils \
+    git \
+    libatomic \
+    libstdc++-static \
+    make \
+    python3-pip \
+    zlib-devel \
+  && pip3 install cloudsmith-cli
+
+# install a newer cmake
+RUN curl --output cmake-3.15.3-Linux-x86_64.sh https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh \
+ && sh cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+
+# add user pony in order to not run tests as root
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x86-64-unknown-linux-centos8-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-centos8-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+NAME="ponylang/ponyc-ci-x86-64-unknown-linux-centos8-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -232,6 +232,13 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   matrix:
+    - name: "nightly: x86-64-unknown-linux-centos8"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-centos8:20200828
+      environment:
+        CACHE_BUSTER: 20200828
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: centos8
     - name: "nightly: x86-64-unknown-linux-gnu"
       container:
         image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
@@ -366,6 +373,13 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   matrix:
+    - name: "release: x86-64-unknown-linux-centos8"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-centos8-builder:20200828
+      environment:
+        CACHE_BUSTER: 20200828
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-centos8
     - name: "release: x86-64-unknown-linux-gnu"
       container:
         image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423

--- a/.release-notes/3629.md
+++ b/.release-notes/3629.md
@@ -1,0 +1,5 @@
+## Add prebuilt ponyc binaries for CentOS 8
+
+Prebuilt nightly versions of ponyc are now available from our [Cloudsmith nightlies repo](https://cloudsmith.io/~ponylang/repos/nightlies/packages/). Release versions will be available in the [release repo](https://cloudsmith.io/~ponylang/repos/releases/packages/) starting with this release.
+
+CentOS 8 releases were added at the request of Damon Kwok. If you are a Pony user and are looking for prebuilt releases for your distribution, open an issue and let us know. We'll do our best to add support for any Linux distribution version that is still supported by their creators.

--- a/BUILD.md
+++ b/BUILD.md
@@ -51,9 +51,10 @@ Additional Requirements:
 
 Distribution | Requires
 --- | ---
-alpine | cmake, g++, make, libexecinfo
-ubuntu | cmake, g++, make
-fedora | cmake, gcc-c++, make, libatomic, libstdc++-static
+Alpine | cmake, g++, libexecinfo, make
+CentOS 8 | clang, cmake, diffutils, libatomic, libstdc++-static, make, zlib-devel
+Fedora | cmake, gcc-c++, libatomic, libstdc++-static, make
+Ubuntu | cmake, g++, make
 
 Note that you only need to run `make libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 


### PR DESCRIPTION
At the request of Damon Kwok, we are adding prebuilt CentOS 8 versions
of ponyc. Both nightly and release builds.