### PR TITLE
Fix broken release process

### DIFF
--- a/.github/workflows/handle-external-events.yml
+++ b/.github/workflows/handle-external-events.yml
@@ -191,10 +191,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Trigger
-        uses: ponylang/release-bot-action@0.3.1
+        uses: ponylang/release-bot-action@0.3.2
         with:
           step: trigger-release-announcement
           git_user_name: "Ponylang Main Bot"
           git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ github.event.client_payload.data.version }}


### PR DESCRIPTION
The release process for ponyc was broken. Prior to this commit,
the final step of the release process, announcing the release, was never
triggered.

This happened because the trigger-release-announcement step of the process
didn't work correctly. The previous versions of release-bot-action would
only work if trigger-release-announcement was started by a tag being pushed.

For all other ponylang repos, this was the case. ponylang/ponyc is different.
With ponyc, assets are built on CirrusCI rather than GitHub. This means that
we can't include the triggering of the announcement in release.yml (which is
started by a tag being pushed). Instead trigger-release-announcement is
triggered from handle-external-event.yml.

handle-external-event.yml is started when HTTP POST calls are made from
Cloudsmith to GitHub to inform us that a new asset has been uploaded. The
github.ref at the time that is done is refs/heads/master. The problem is
that trigger-release-announcement was expecting something like refs/tags/1.0.0.
The end result? We couldn't find the version to correctly construct the
announce-VERSION tag that we push to kick off the final step of the release process.

release-bot-action 0.3.2 allows for a new environment variable VERSION that can
be used to provide the version directly rather than parsing it out of github.ref.

This commit updates to release-bot-action 0.3.2 and sets VERSION to the value of
the ponyc asset that was uploaded to Cloudsmith. The version is available to us
in the JSON for the event we receive from Cloudsmith.