### PR TITLE
Fix building libs with Visual Studio 16.7

### DIFF
--- a/.release-notes/3635.md
+++ b/.release-notes/3635.md
@@ -1,0 +1,3 @@
+# Fix building libs with Visual Studio 16.7
+
+Visual Studio 16.7 introduced a change in C++20 compatibility that breaks building LLVM on Windows (#3634). We've added a patch for LLVM that fixes the issue.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,6 +31,7 @@ install(TARGETS blake2
 find_package(Git)
 
 set(LLVM_DESIRED_HASH "c1a0a213378a458fbea1a5c77b315c7dce08fd05")
+set(PATCHES_DESIRED_HASH "9063f83d727bf042a1232420e168c1ea192bf6a2960d35e57123245b630eb923")
 
 if(GIT_FOUND)
     if(EXISTS "${PROJECT_SOURCE_DIR}/../.git")
@@ -62,13 +63,24 @@ if(GIT_FOUND)
     # Apply patches
     message("Applying patches...")
     file(GLOB PONY_LLVM_PATCHES "${PROJECT_SOURCE_DIR}/llvm/patches/*.diff")
+
+    # check to see if the patch hashes match
+    set(PATCHES_ACTUAL_HASH "")
+    foreach (PATCH ${PONY_LLVM_PATCHES})
+        file(SHA256 ${PATCH} patch_file_hash)
+        string(CONCAT PATCHES_ACTUAL_HASH patch_file_hash)
+    endforeach()
+    string(SHA256 PATCHES_ACTUAL_HASH ${PATCHES_ACTUAL_HASH})
+    if(NOT PATCHES_ACTUAL_HASH EQUAL "${PATCHES_DESIRED_HASH}")
+        message(FATAL_ERROR "Patch hash actual ${PATCHES_ACTUAL_HASH} does not match desired ${PATCHES_DESIRED_HASH}")
+    endif()
+
     foreach (PATCH ${PONY_LLVM_PATCHES})
         message("  Checking ${PATCH}")
         execute_process(COMMAND ${GIT_EXECUTABLE} apply --check -p 1 --ignore-whitespace --whitespace=nowarn ${PATCH}
                         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/llvm/src"
                         ERROR_VARIABLE _err_out
                         RESULT_VARIABLE git_apply_check_result)
-        #message("git_apply_check_result ${git_apply_check_result}")
         if(git_apply_check_result EQUAL "0")
             message("    Applying ${PATCH}")
             execute_process(COMMAND ${GIT_EXECUTABLE} apply -p 1 --ignore-whitespace --whitespace=nowarn ${PATCH}

--- a/lib/llvm/patches/2020-09-01-is-trivially-copyable.diff
+++ b/lib/llvm/patches/2020-09-01-is-trivially-copyable.diff
@@ -1,0 +1,14 @@
+diff --git a/llvm/include/llvm/Config/config.h.cmake b/llvm/include/llvm/Config/config.h.cmake
+index 1a38bc15ab9..9a3417f1c8c 100644
+--- a/llvm/include/llvm/Config/config.h.cmake
++++ b/llvm/include/llvm/Config/config.h.cmake
+@@ -333,7 +333,9 @@
+ #cmakedefine RETSIGTYPE ${RETSIGTYPE}
+ 
+ /* Define if std::is_trivially_copyable is supported */
++#if !defined(_MSC_VER) || _MSC_VER < 1927
+ #cmakedefine HAVE_STD_IS_TRIVIALLY_COPYABLE ${HAVE_STD_IS_TRIVIALLY_COPYABLE}
++#endif
+ 
+ /* Define to a function implementing stricmp */
+ #cmakedefine stricmp ${stricmp}


### PR DESCRIPTION
Visual Studio 16.7 introduced a change in C++20 compatibility that breaks building LLVM on Windows (#3634).  This change adds a patch for LLVM that fixes the issue.  Fixes #3634.

The change also introduces a check in CMake of the hashes of the patch files. Since the build caches in CI depend on the contents of `libs/CMakeLists.txt`, and that file contains the desired hash, changing the patches (and thus the desired hash) will force a rebuild of the libs build caches (in the same way as changing the Git checkout for LLVM will force a rebuild).