### PR TITLE
Fix missing Makefile lines to re-enable multiple `use=` options

### DIFF
--- a/.release-notes/3637.md
+++ b/.release-notes/3637.md
@@ -1,0 +1,3 @@
+# Fix missing Makefile lines to re-enable multiple `use=` options
+
+When implementing the CMake build system, I missed copying a couple of lines from the old Makefile that meant that you could only specify one use= option when doing make configure on Posix. This change restores those lines, so you can specify multiple options for use, e.g. make configure use=memtrack_messages,address_sanitizer.

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,10 @@ endif
 
 PONY_USES =
 
+comma:= ,
+empty:=
+space:= $(empty) $(empty)
+
 define USE_CHECK
   $$(info Enabling use option: $1)
   ifeq ($1,valgrind)


### PR DESCRIPTION
When implementing the CMake build system, I missed copying a couple of lines from the old Makefile that meant that you could only specify one `use=` option when doing `make configure` on Posix.  This change restores those lines, so you can specify multiple options for `use`, e.g. `make configure use=memtrack_messages,address_sanitizer`.