### PR TITLE
Make Range.next() partial

### DIFF
--- a/.release-notes/3639.md
+++ b/.release-notes/3639.md
@@ -1,0 +1,21 @@
+## Make Range.next partial
+
+Range.next used to return the final index over and over when you reached the end. It was decided that this was a confusing and error prone API.
+
+Range.next is now partial and will return error when you try to iterate past the end of the range.
+
+Where you previously had code like:
+
+```pony
+let r = Range(0,5)
+let a = r.next()
+```
+
+you now need (or similar based on your usage of Range.next
+
+```pony
+try
+  let r = Range(0,5)
+  let a = r.next()?
+end
+```

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -11,7 +11,9 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
   // iterating over Range of U8 with while-loop
   let range = Range[U8](5, 100, 5)
   while range.has_next() do
-    handle_u8(range.next())
+    try
+      handle_u8(range.next()?)
+    end
   end
   ```
 
@@ -97,11 +99,11 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
       _idx > _max
     end
 
-  fun ref next(): A =>
+  fun ref next(): A ? =>
     if has_next() then
       _idx = _idx + _inc
     else
-      _idx
+      error
     end
 
   fun ref rewind() =>


### PR DESCRIPTION
It was agreed when discussing #2969 that Range.next should be partial
and return an error when you reach the end rather than returning the
end index over and over again.

This is a breaking change.

Closes #2969