### PR TITLE
Fix bug in Valtrace builtin test

### DIFF
--- a/packages/builtin_test/_test_valtrace.pony
+++ b/packages/builtin_test/_test_valtrace.pony
@@ -48,7 +48,7 @@ actor _Valtrace
     @pony_triggergc[None](@pony_ctx[Pointer[None]]())
     a1.gc(a1, h, s)
     a2.gc(a1, h, s)
-    a2.gc(a1, h, s)
+    a3.gc(a1, h, s)
     gc(a1, h, s)
 
   be gc(a: _Valtrace, h: TestHelper, s: String) =>


### PR DESCRIPTION
Comment says "test all 4 actors". It is testing 3 because it is
testing the same one twice and skipping one.