### PR TITLE
Change to Steed's model of subtyping

### DIFF
--- a/.release-notes/3643.md
+++ b/.release-notes/3643.md
@@ -1,0 +1,24 @@
+## Fix unsound checks for return subtyping
+
+Changed the subtyping model used in the compiler,
+fixing some unsound cases that were allowed for function returns.
+This also will result in changed error messages, with more
+instances of unaliasing instead of aliasing. The tutorial has
+been updated with these changes.
+
+This is a breaking change, as some code which used to be accepted
+by the typechecker is now rejected. This could include sound code
+which was not technically type-safe, as well as unsound code.
+
+This code used to be erroneously allowed and is now rejected
+(it would allow a val and an iso to alias):
+```
+class Foo
+  let x: Bar iso = Bar
+  fun get_bad(): Bar val =>
+    x
+```
+
+In addition, the standard library Map class now has a weaker
+type signature as it could not implement its current type signature.
+The `upsert` and `insert_if_absent` methods now return T! instead of T

--- a/packages/collections/map.pony
+++ b/packages/collections/map.pony
@@ -75,7 +75,7 @@ class HashMap[K, V, H: HashFunction[K] val]
       end
     end
 
-  fun ref upsert(key: K, value: V, f: {(V, V): V^} box): V =>
+  fun ref upsert(key: K, value: V, f: {(V, V): V^} box): V! =>
     """
     Combines a provided value with the current value for the provided key
     using the provided function. If the provided key has not been added to
@@ -153,7 +153,7 @@ class HashMap[K, V, H: HashFunction[K] val]
       value'
     end
 
-  fun ref insert_if_absent(key: K, value: V): V =>
+  fun ref insert_if_absent(key: K, value: V): V! =>
     """
     Set a value in the map if the key doesn't already exist in the Map.
     Saves an extra lookup when doing a pattern like:

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -609,7 +609,7 @@ static bool static_value(compile_t* c, LLVMValueRef value, ast_t* type,
   // Get the type of the right-hand side of the pattern's eq() function.
   ast_t* param_type = eq_param_type(c, pattern);
 
-  if(!is_subtype(type, param_type, NULL, c->opt))
+  if(!is_subtype_ignore_cap(type, param_type, NULL, c->opt))
   {
     // Switch to dynamic value checking.
     pony_assert(LLVMTypeOf(value) == c->object_ptr);
@@ -635,7 +635,7 @@ static bool static_capture(compile_t* c, LLVMValueRef value, ast_t* type,
   ast_t* pattern_type = deferred_reify(c->frame->reify, ast_type(pattern),
     c->opt);
 
-  bool is_sub = is_subtype(type, pattern_type, NULL, c->opt);
+  bool is_sub = is_subtype_ignore_cap(type, pattern_type, NULL, c->opt);
 
   ast_free_unattached(pattern_type);
 

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -99,7 +99,8 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
     // discarded.
     if(is_dontcare)
     {
-      ast_t* v_type = alias(ast_type(value));
+      ast_t* p_type = consume_type(type, TK_NONE);
+      ast_t* v_type = ast_type(value);
       errorframe_t info = NULL;
 
       if(!is_subtype(v_type, type, &info, opt))
@@ -109,14 +110,14 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
         ast_error_frame(&frame, value, "argument type is %s",
                         ast_print_type(v_type));
         ast_error_frame(&frame, id_node, "parameter type is %s",
-                        ast_print_type(type));
+                        ast_print_type(p_type));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
-        ast_free_unattached(v_type);
+        ast_free_unattached(p_type);
         return false;
       }
 
-      ast_free_unattached(v_type);
+      ast_free_unattached(p_type);
     }
   }
 

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -411,11 +411,10 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
     ok = false;
   }
 
-  ast_t* r_type = set_cap_and_ephemeral(pattern_type, ast_id(cap), TK_NONE);
-  ast_t* a_type = alias(pattern_type);
+  ast_t* r_type = set_cap_and_ephemeral(pattern_type, ast_id(cap), TK_EPHEMERAL);
   errorframe_t info = NULL;
 
-  if(!is_subtype(a_type, r_type, &info, opt))
+  if(!is_subtype(pattern_type, r_type, &info, opt))
   {
     errorframe_t frame = NULL;
     ast_error_frame(&frame, pattern, "eq cannot be called on this pattern");
@@ -443,7 +442,6 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
   }
 
   ast_free_unattached(r_type);
-  ast_free_unattached(a_type);
   ast_free_unattached(r_fun);
   deferred_reify_free(fun);
 
@@ -506,11 +504,10 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
 
   ast_settype(ast, pattern_type);
 
-  ast_t* operand_type = alias(match_type);
   bool ok = true;
   errorframe_t info = NULL;
 
-  switch(is_matchtype(operand_type, pattern_type, &info, opt))
+  switch(is_matchtype(match_type, pattern_type, &info, opt))
   {
     case MATCHTYPE_ACCEPT:
       break;
@@ -520,7 +517,7 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
       errorframe_t frame = NULL;
       ast_error_frame(&frame, pattern, "this pattern can never match");
       ast_error_frame(&frame, match_type, "match type: %s",
-        ast_print_type(operand_type));
+        ast_print_type(match_type));
       // TODO report unaliased type when body is consume !
       ast_error_frame(&frame, pattern, "pattern type: %s",
         ast_print_type(pattern_type));
@@ -541,7 +538,7 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
       ast_error_frame(&frame, match_type, "the match type allows for more than "
         "one possibility with the same type as pattern type, but different "
         "capabilities. match type: %s",
-        ast_print_type(operand_type));
+        ast_print_type(match_type));
       ast_error_frame(&frame, pattern, "pattern type: %s",
         ast_print_type(pattern_type));
       errorframe_append(&frame, &info);
@@ -564,8 +561,6 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
         "guard must be a boolean expression");
     }
   }
-
-  ast_free_unattached(operand_type);
   return ok;
 }
 

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -139,13 +139,20 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
     case TK_IF:
     case TK_WHILE:
     case TK_MATCH:
+    case TK_IFDEF:
       // The condition is not the result.
+    case TK_WITH:
+      // The with variable is not the result
       if(ast_child(parent) == ast)
         return false;
       break;
 
     case TK_IFTYPE:
       // The subtype and the supertype are not the result.
+    case TK_FOR:
+      // The index variable and collection are not the result.
+    case TK_CASE:
+      // The pattern and the guard are not the result.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
       break;
@@ -156,11 +163,6 @@ bool is_method_result(typecheck_t* t, ast_t* ast)
         return false;
       break;
 
-    case TK_CASE:
-      // The pattern and the guard are not the result.
-      if(ast_childidx(parent, 2) != ast)
-        return false;
-      break;
 
     case TK_CASES:
     case TK_IFTYPE_SET:

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -212,7 +212,7 @@ static ast_t* consume_single(ast_t* type, token_id ccap)
   }
 
   // We're only modifying the cap, not the type, so the bounds are the same.
-  if(!is_cap_sub_cap_bound(tcap, TK_NONE, ccap, TK_NONE))
+  if(!is_cap_sub_cap_bound(tcap, TK_EPHEMERAL, ccap, TK_NONE))
   {
     ast_free_unattached(type);
     return NULL;

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -377,7 +377,7 @@ static matchtype_t is_typeparam_match_typeparam(ast_t* operand, ast_t* pattern,
 
   if(operand_def == pattern_def)
   {
-    r = is_cap_sub_cap_bound(ast_id(o_cap), ast_id(o_eph),
+    r = is_cap_sub_cap_bound(ast_id(o_cap), TK_EPHEMERAL,
       ast_id(p_cap), ast_id(p_eph)) ? MATCHTYPE_ACCEPT : MATCHTYPE_DENY;
   }
 
@@ -525,7 +525,7 @@ static matchtype_t is_nominal_match_entity(ast_t* operand, ast_t* pattern,
 
   // If the operand does provide the pattern, but the operand refcap can't
   // match the pattern refcap, deny the match.
-  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
+  if(!is_cap_sub_cap(ast_id(o_cap), TK_EPHEMERAL,
     ast_id(p_cap), ast_id(p_eph)))
   {
     if(errorf != NULL)
@@ -599,7 +599,7 @@ static matchtype_t is_entity_match_trait(ast_t* operand, ast_t* pattern,
 
   // If the operand does provide the pattern, but the operand refcap can't
   // match the pattern refcap, deny the match.
-  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
+  if(!is_cap_sub_cap(ast_id(o_cap), TK_EPHEMERAL,
     ast_id(p_cap), ast_id(p_eph)))
   {
     if(errorf != NULL)
@@ -628,7 +628,7 @@ static matchtype_t is_trait_match_trait(ast_t* operand, ast_t* pattern,
   AST_GET_CHILDREN(pattern, p_pkg, p_id, p_typeargs, p_cap, p_eph);
 
   // If the operand refcap can't match the pattern refcap, deny the match.
-  if(!is_cap_sub_cap(ast_id(o_cap), ast_id(o_eph),
+  if(!is_cap_sub_cap(ast_id(o_cap), TK_EPHEMERAL,
     ast_id(p_cap), ast_id(p_eph)))
   {
     if(errorf != NULL)

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -136,7 +136,7 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
           ast_print_type(sub_cap), ast_print_type(sub_eph),
           ast_print_type(super_cap), ast_print_type(super_eph));
 
-        if(is_cap_sub_cap(ast_id(sub_cap), ast_id(super_eph), ast_id(super_cap),
+        if(is_cap_sub_cap(ast_id(sub_cap), TK_EPHEMERAL, ast_id(super_cap),
           ast_id(super_eph)))
           ast_error_frame(errorf, sub_cap,
             "this would be possible if the subcap were more ephemeral");
@@ -339,8 +339,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
 
   while((sub_param != NULL) && (super_param != NULL))
   {
-    ast_t* sub_type = ast_childidx(sub_param, 1);
-    ast_t* super_type = ast_childidx(super_param, 1);
+    // observational: must pass K^ to argument of type K
+    ast_t* sub_type = consume_type(ast_childidx(sub_param, 1), TK_NONE);
+    ast_t* super_type = consume_type(ast_childidx(super_param, 1), TK_NONE);
 
     // Contravariant: the super type must be a subtype of the sub type.
     if(!is_x_sub_x(super_type, sub_type, CHECK_CAP_SUB, errorf, opt))
@@ -351,8 +352,12 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
           ast_print_type(sub_type), ast_print_type(super_type));
       }
 
+      ast_free_unattached(sub_type);
+      ast_free_unattached(super_type);
       return false;
     }
+    ast_free_unattached(sub_type);
+    ast_free_unattached(super_type);
 
     sub_param = ast_sibling(sub_param);
     super_param = ast_sibling(super_param);

--- a/test/libponyc/array.cc
+++ b/test/libponyc/array.cc
@@ -319,7 +319,7 @@ TEST_F(ArrayTest, InferFromValuesOfArrayInterface)
     "class iso C3 is T\n"
 
     "interface ArrayishOfArrayOfT\n"
-    "  fun values(): Iterator[Array[T]]^\n"
+    "  fun values(): Iterator[this->Array[T]]^\n"
 
     "primitive Foo\n"
     "  fun apply(): ArrayishOfArrayOfT =>\n"

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -401,6 +401,40 @@ TEST_F(BadPonyTest, RefCapViolationViaCapAnyTypeParameter)
   TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
 }
 
+TEST_F(BadPonyTest, AliasAny)
+{
+  // Safeguard ensuring #alias <= #any not allowed by
+  // is_cap_sub_cap_bound, related to PR #3643
+  const char* src =
+    "class Foo\n"
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let a: Foo val = Foo\n"
+        "alias_bound[Foo val](a)\n"
+
+      "fun alias_bound[A](x: A) =>\n"
+        "let x': A = x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+TEST_F(BadPonyTest, ReturnUnmovedIso)
+{
+  // Issue #1964
+  const char* src =
+    "class Bar\n"
+    "class Foo\n"
+      "let x: Bar iso = Bar\n"
+      "fun get_bad(): Bar val =>\n"
+        "x\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "None\n";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+
 TEST_F(BadPonyTest, TypeParamArrowClass)
 {
   // From issue #1687

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <platform.h>
 #include <type/subtype.h>
+#include <type/alias.h>
 #include "util.h"
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
@@ -344,6 +345,8 @@ TEST_F(SubTypeTest, IsSubTypeIntersect)
   pass_opt_t opt;
   pass_opt_init(&opt);
 
+
+  // intersections of caps
   ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1and2"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1"), type_of("t1and2"), NULL, &opt));
   ASSERT_TRUE(is_subtype(type_of("t3"), type_of("t1and2"), NULL, &opt));
@@ -353,21 +356,34 @@ TEST_F(SubTypeTest, IsSubTypeIntersect)
   ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1val"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("t1"), type_of("t1refand2box"), NULL, &opt));
-  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1refand2box"), NULL, &opt));
-  ASSERT_TRUE(is_subtype(type_of("t3iso"), type_of("t1valand2box"), NULL, &opt));
-  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1refand2box"), NULL, &opt));
-  ASSERT_TRUE(is_subtype(type_of("t3trn"), type_of("t1valand2box"), NULL, &opt));
+
+  ASSERT_FALSE(is_subtype(type_of("t3iso"), type_of("t1refand2box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t3iso"), type_of("t1valand2box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t3trn"), type_of("t1refand2box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("t3trn"), type_of("t1valand2box"), NULL, &opt));
+
   ASSERT_FALSE(is_subtype(type_of("t1val"), type_of("t1valand2box"), NULL, &opt));
   ASSERT_TRUE(is_subtype(type_of("t1refand2box"), type_of("t1"), NULL, &opt));
   ASSERT_TRUE(is_subtype(type_of("t1valand2box"), type_of("t1val"), NULL, &opt));
-  ASSERT_TRUE(
-    is_subtype(type_of("t1isoand2iso"), type_of("t1refand2box"), NULL, &opt));
-  ASSERT_TRUE(
-    is_subtype(type_of("t1trnand2trn"), type_of("t1refand2box"), NULL, &opt));
-  ASSERT_TRUE(
-    is_subtype(type_of("t1isoand2iso"), type_of("t1valand2box"), NULL, &opt));
-  ASSERT_TRUE(
-    is_subtype(type_of("t1trnand2trn"), type_of("t1valand2box"), NULL, &opt));
+
+  // ephemerals
+  ast_t* t3isohat = consume_type(type_of("t3iso"), TK_NONE);
+  ast_t* t3trnhat = consume_type(type_of("t3trn"), TK_NONE);
+  ASSERT_TRUE(is_subtype(t3isohat, type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t3isohat, type_of("t1valand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t3trnhat, type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t3trnhat, type_of("t1valand2box"), NULL, &opt));
+  ast_free_unattached(t3isohat);
+  ast_free_unattached(t3trnhat);
+
+  ast_t* t1t2iso = consume_type(type_of("t1isoand2iso"), TK_NONE);
+  ast_t* t1t2trn = consume_type(type_of("t1trnand2trn"), TK_NONE);
+  ASSERT_TRUE(is_subtype(t1t2iso, type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t1t2trn, type_of("t1refand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t1t2iso, type_of("t1valand2box"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(t1t2trn, type_of("t1valand2box"), NULL, &opt));
+  ast_free_unattached(t1t2iso);
+  ast_free_unattached(t1t2trn);
 
   pass_opt_init(&opt);
 }
@@ -530,19 +546,19 @@ TEST_F(SubTypeTest, IsSubTypeCap)
   ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1iso"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1iso"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1ref"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1iso"), type_of("t1ref"), NULL, &opt));
   ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1ref"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1val"), type_of("t1ref"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1ref"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1ref"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1val"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1iso"), type_of("t1val"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1ref"), type_of("t1val"), NULL, &opt));
   ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1val"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1box"), type_of("t1val"), NULL, &opt));
   ASSERT_FALSE(is_subtype(type_of("c1tag"), type_of("t1val"), NULL, &opt));
 
-  ASSERT_TRUE (is_subtype(type_of("c1iso"), type_of("t1box"), NULL, &opt));
+  ASSERT_FALSE(is_subtype(type_of("c1iso"), type_of("t1box"), NULL, &opt));
   ASSERT_TRUE (is_subtype(type_of("c1ref"), type_of("t1box"), NULL, &opt));
   ASSERT_TRUE (is_subtype(type_of("c1val"), type_of("t1box"), NULL, &opt));
   ASSERT_TRUE (is_subtype(type_of("c1box"), type_of("t1box"), NULL, &opt));
@@ -1177,4 +1193,48 @@ TEST_F(SubTypeTest, BoxArrowTypeParamReifiedWithTypeParam)
     "    None";
 
   TEST_COMPILE(src);
+}
+TEST_F(SubTypeTest, ConsumeIsoSubRef)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: C iso) =>\n"
+    "    let x': C ref = consume x";
+
+  TEST_COMPILE(src);
+}
+TEST_F(SubTypeTest, IsoNotSubRef)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: C iso) =>\n"
+    "    let x': C ref = x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+TEST_F(SubTypeTest, CantConsumeRefToIso)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: C ref) =>\n"
+    "    let x': C ref = consume iso x";
+
+  TEST_ERRORS_1(src, "can't consume to this capability");
+}
+TEST_F(SubTypeTest, ConsumeRefNotIso)
+{
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: C ref) =>\n"
+    "    let x': C iso = consume x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
 }

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -100,6 +100,9 @@ static const char* const _builtin =
   // - call .values() iterator in a for loop
   // - be a subtype of Seq
   // - call genprim_array_serialise_trace (which expects the three fields)
+  "class ArrayValues[A]\n"
+  "  fun ref has_next(): Bool => false\n"
+  "  fun ref next(): A ? => error\n"
   "class Array[A] is Seq[A]\n"
   "  var _size: USize = 0\n"
   "  var _alloc: USize = 0\n"
@@ -107,10 +110,8 @@ static const char* const _builtin =
   "  new create(len: USize = 0) => true\n"
   "  fun ref push(value: A) => true\n"
   "  fun apply(index: USize): this->A ? => error\n"
-  "  fun values(): Iterator[A] => object ref\n"
-  "    fun ref has_next(): Bool => false\n"
-  "    fun ref next(): A ? => error\n"
-  "  end\n"
+  "  fun values(): Iterator[this->A]^ =>\n"
+  "    ArrayValues[this->A]\n"
   "interface Iterator[A]\n"
   "  fun ref has_next(): Bool\n"
   "  fun ref next(): A ?\n"


### PR DESCRIPTION
Most individual commits have a long comment describing what they do.
Notably, had to weaken the type of two map methods as they were incorrect for the implementation that they had (and it should be reasonably obvious I hope).

We will also need to ensure that documentation correctly disambiguates between `iso` and `iso^` when talking about subtyping, as otherwise the error messages may be quite confusing (`iso` is not a subcap of `ref`). This is painfully unintuitive  with current docs/cap-naming, but that unintuitiveness was exactly what got us into this unsound subtyping mess.

Fixes #1964 

Updated subtyping table:
![image](https://user-images.githubusercontent.com/6874204/92316239-12f6df80-efa6-11ea-8d46-729904830779.png)