### PR TITLE
Consistent handling of  function calls in consume expressions

### DIFF
--- a/.release-notes/3467.md
+++ b/.release-notes/3467.md
@@ -1,0 +1,20 @@
+## Fix function calls in consume expressions
+
+Function calls are not allowed in `consume` expressions. However, if the expression being `consume`d is a field access expression, whose LHS happens to be a function call,
+the compiler fails after hitting an assertion.
+
+For instance the following results in a compilation failure
+
+```pony
+    let a = "I am a string"
+    let x:C iso! = consume a.chop(1)
+```
+
+but the following results in a compiler crash with an assertion failure
+
+```pony
+    let a = "I am a string"
+    let x:C iso! = consume a.chop(1)._1
+```
+
+The fix ensures that both the scenarios are handled gracefully.

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1166,11 +1166,10 @@ static bool refer_consume(pass_opt_t* opt, ast_t* ast)
             "can't consume a let or embed field");
           return false;
         }
-      }
-      else if (ast_id(left) == TK_CALL) {
-          ast_error(opt->check.errors, ast,
-              "Consume expressions must specify a single identifier");
-          return false;
+      } else if (ast_id(left) == TK_CALL) {
+        ast_error(opt->check.errors, ast,
+          "consume expressions must specify a single identifier");
+        return false;
       }
       else
       {

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1167,6 +1167,11 @@ static bool refer_consume(pass_opt_t* opt, ast_t* ast)
           return false;
         }
       }
+      else if (ast_id(left) == TK_CALL) {
+          ast_error(opt->check.errors, ast,
+              "Consume expressions must specify a single identifier");
+          return false;
+      }
       else
       {
         // get fully qualified string identifier without `this`

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -838,3 +838,14 @@ TEST_F(ReferTest, ConsumeParamVarSubfieldReassignSameExpressionReuse)
   TEST_ERRORS_1(src,
     "can't use a consumed local or field in an expression");
 }
+
+TEST_F(ReferTest, ConsumeTupleAccessorOfFunctionValResult)
+{
+    const char* src = "actor Main\n"
+                      "    new create(env: Env) =>\n"
+                      "       let a = \"I am a string\"\n"
+                      "       consume a.chop(1)._1\n";
+
+    TEST_ERRORS_1(src,
+        "Consume expressions must specify a single identifier");
+}

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -841,10 +841,11 @@ TEST_F(ReferTest, ConsumeParamVarSubfieldReassignSameExpressionReuse)
 
 TEST_F(ReferTest, ConsumeTupleAccessorOfFunctionValResult)
 {
-    const char* src = "actor Main\n"
-                      "    new create(env: Env) =>\n"
-                      "       let a = \"I am a string\"\n"
-                      "       consume a.chop(1)._1\n";
+    const char* src =
+      "actor Main\n"
+        "new create(env: Env) =>\n"
+          "let a = \"I am a string\"\n"
+          "consume a.chop(1)._1";
 
     TEST_ERRORS_1(src,
         "Consume expressions must specify a single identifier");

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -848,5 +848,5 @@ TEST_F(ReferTest, ConsumeTupleAccessorOfFunctionValResult)
           "consume a.chop(1)._1";
 
     TEST_ERRORS_1(src,
-        "Consume expressions must specify a single identifier");
+      "consume expressions must specify a single identifier");
 }


### PR DESCRIPTION
Function calls in `consume` are deemed invalid by the syntax checker.
However, they seep in via field accessors on the function call
expressions. This change fixes #3453.