### PR TITLE
Don't do line-length yaml linting

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -2,6 +2,4 @@ rules:
   key-duplicates:
     ignore: |
       .cirrus.yml
-  line-length:
-    ignore: |
-      .cirrus.yml
+  line-length: disable


### PR DESCRIPTION
A large number of our yml files for CI jobs won't pass with it on and we don't want to mess around with them to get them to pass.