### PR TITLE
Speed up cycle detector reaping some actors

### DIFF
--- a/.release-notes/dipin-cd-patch.md
+++ b/.release-notes/dipin-cd-patch.md
@@ -1,0 +1,47 @@
+## Speed up cycle detector reaping some actors
+
+When an actor is done running, we now do a check similar to the check we do for when --ponynoblock is on:
+
+- Check to see if the actor's message queue is empty
+- Check to see if it has a reference count of 0
+
+If both are true, then the actor can be deleted. When --ponynoblock is used, this is done immediately. It can't be done immediately when the cycle detector is in use because, it might have references to the actor in question.
+
+In order to safely cleanup and reap actors, the cycle detector must be the one to do the reaping. This would eventually be done without this change. However, it is possible to write programs where the speed at which the cycle detectors protocol will operate is unable to keep up with the speed at which new "one shot" actors are created.
+
+Here's an example of such a program:
+
+```pony
+actor Main
+  new create(e: Env) =>
+    Spawner.run()
+
+actor Spawner
+  var _living_children: U64 = 0
+
+  new create() =>
+    None
+
+  be run() =>
+    _living_children = _living_children + 1
+    Spawnee(this).run()
+
+  be collect() =>
+    _living_children = _living_children - 1
+    run()
+
+actor Spawnee
+  let _parent: Spawner
+
+  new create(parent: Spawner) =>
+    _parent = parent
+
+  be run() =>
+    _parent.collect()
+```
+
+Without this patch, that program will have large amount of memory growth and eventually, run out of memory. With the patch, Spawnee actors will be reaped much more quickly and stable memory growth can be achieved.
+
+This is not a complete solution to the problem as issue #1007 is still a problem due to reasons I outlined at https://github.com/ponylang/ponyc/issues/1007#issuecomment-689826407.
+
+It should also be noted that in the process of developing this patch, we discovered a use after free race condition in the runtime mpmcq implementation. That race condition can and will result in segfaults when running the above example program. There's no issue opened yet for that problem, but one will be coming.

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -710,9 +710,55 @@ static void actor_destroyed(detector_t* d, pony_actor_t* actor)
   }
 }
 
-static void block(detector_t* d, pony_actor_t* actor,
+static void block(detector_t* d, pony_ctx_t* ctx, pony_actor_t* actor,
   size_t rc, deltamap_t* map)
 {
+  if (rc == 0)
+  {
+    // if rc == 0 then this is a zombie actor with no references left to it
+    // - the actor blocked because it has no messages in its queue
+    // - there's no references to this actor because rc == 0
+    // therefore the actor is a zombie and can be reaped.
+
+    view_t* view = get_view(d, actor, false);
+
+    if (view != NULL)
+    {
+      // remove from the deferred set
+      if(view->deferred)
+        ponyint_viewmap_remove(&d->deferred, view);
+
+      // if we're in a perceived cycle, that cycle is invalid
+      expire(d, view);
+
+      // free the view on the actor
+      ponyint_viewmap_remove(&d->views, view);
+      view_free(view);
+    }
+
+    if (map != NULL)
+    {
+      // free deltamap
+      #ifdef USE_MEMTRACK
+        d->mem_used -= ponyint_deltamap_total_mem_size(map);
+        d->mem_allocated -= ponyint_deltamap_total_alloc_size(map);
+      #endif
+
+      ponyint_deltamap_free(map);
+    }
+
+    // invoke the actor's finalizer and destroy it
+    ponyint_actor_setpendingdestroy(actor);
+    ponyint_actor_final(ctx, actor);
+    ponyint_actor_sendrelease(ctx, actor);
+    ponyint_actor_destroy(actor);
+
+    d->destroyed++;
+
+    return;
+  }
+
+
   view_t* view = get_view(d, actor, true);
 
   // update reference count
@@ -989,7 +1035,7 @@ static void cycle_dispatch(pony_ctx_t* ctx, pony_actor_t* self,
 #endif
 
       block_msg_t* m = (block_msg_t*)msg;
-      block(d, m->actor, m->rc, m->delta);
+      block(d, ctx, m->actor, m->rc, m->delta);
       break;
     }
 


### PR DESCRIPTION
This commit speeds up reaping of some actors by the cycle-detector.
When an actor is done running, we do a check similar to the check
we do for when --ponynoblock is on:

- Check to see if the actor's message queue is empty
- Check to see if it has a reference count of 0

If both are true, then the actor can be deleted. When --ponynoblock
is used, this is done immediately. It can't be done immediately when
the cycle detector is in use because, it might have references to
the actor in question.

In order to safely cleanup and reap actors, the cycle detector must
be the one to do the reaping. This would eventually be done without
this change. However, it is possible to write programs where the
speed at which the cycle detectors protocol will operate is unable
to keep up with the speed at which new "one shot" actors are created.

Here's an example of such a program:

```pony
actor Main
  new create(e: Env) =>
    Spawner.run()

actor Spawner
  var _living_children: U64 = 0

  new create() =>
    None

  be run() =>
    _living_children = _living_children + 1
    Spawnee(this).run()

  be collect() =>
    _living_children = _living_children - 1
    run()

actor Spawnee
  let _parent: Spawner

  new create(parent: Spawner) =>
    _parent = parent

  be run() =>
    _parent.collect()
```

Without this patch, that program will have large amount of memory growth
and eventually, run out of memory. With the patch, Spawnee actors will be
reaped much more quickly and stable memory growth can be achieved.

This is not a complete solution to the problem as issue #1007 is still a
problem due to reasons I outlined at
https://github.com/ponylang/ponyc/issues/1007#issuecomment-689826407.

It should also be noted that in the process of developing this patch,
Dipin Hora and I discovered a use after free race condition in the
runtime mpmcq implementation. That race condition can and will result
in segfaults when running the above example program. There's no issue
opened yet for that problem, but one will be coming.

While my name is on the commit, credit should be divided up between myself
and Dipin. I came up with the basic idea of how to reap some "one shot"
actors earlier and Dipin reimplemented by my idea to work much better with
the existing cycle-detector than my approach which was overly complicated and
had a number of areas that were likely sources of subtle bugs.