### PR TITLE
Prevent compiler crashes on certain `consume` expressions

### DIFF
--- a/.release-notes/3650.md
+++ b/.release-notes/3650.md
@@ -1,17 +1,5 @@
-## Graceful error handling on `consume` expressions
+## Handling compiler crashes in some `consume` expressions
 
-The fix ensures 
-* `consume (consume variable).field` results in a graceful compilation error
-* `consume f().field` results in similar compilation error as `consume f()`
-* Allow `(consume obj).field` expressions
-  The following snippet 
-  
-  ```pony
-	 (consume f).b =  recover Bar end
-  ```
-  must be equivalent to
-  
-  ```pony
-     let x = consume f
-	 x.b = recover Bar end
- ```
+Previously  an expression of the form `consume (consume variable).field` resulted in the compiler crashing down with an assertion failure. With this fix, we get a friendly error message pointing to the erroneous line.
+
+Likewise, a valid assignment of the form `(consume f).b =  recover Bar end` resulted in a compiler crash. With the fix, the compiler successfuly type checks the assignment and ensures that `f` is _consumed_.

--- a/.release-notes/3650.md
+++ b/.release-notes/3650.md
@@ -5,6 +5,7 @@ The fix ensures
 * `consume f().field` results in similar compilation error as `consume f()`
 * Allow `(consume obj).field` expressions
   The following snippet 
+  
   ```pony
 	 (consume f).b =  recover Bar end
   ```
@@ -14,4 +15,3 @@ The fix ensures
      let x = consume f
 	 x.b = recover Bar end
  ```
-

--- a/.release-notes/3650.md
+++ b/.release-notes/3650.md
@@ -1,0 +1,17 @@
+## Graceful error handling on `consume` expressions
+
+The fix ensures 
+* `consume (consume variable).field` results in a graceful compilation error
+* `consume f().field` results in similar compilation error as `consume f()`
+* Allow `(consume obj).field` expressions
+  The following snippet 
+  ```pony
+	 (consume f).b =  recover Bar end
+  ```
+  must be equivalent to
+  
+  ```pony
+     let x = consume f
+	 x.b = recover Bar end
+ ```
+

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -139,6 +139,8 @@ static const char* generate_multi_dot_name(ast_t* ast, ast_t** def_found) {
 
     default:
     {
+      if (def == NULL)
+        return stringtab("");
       pony_assert(0);
     }
   }
@@ -146,7 +148,7 @@ static const char* generate_multi_dot_name(ast_t* ast, ast_t** def_found) {
   if(def_found != NULL)
   {
     *def_found = def;
-
+  
     if(def == NULL)
       return stringtab("");
   }
@@ -1166,10 +1168,6 @@ static bool refer_consume(pass_opt_t* opt, ast_t* ast)
             "can't consume a let or embed field");
           return false;
         }
-      } else if (ast_id(left) == TK_CALL) {
-        ast_error(opt->check.errors, ast,
-          "consume expressions must specify a single identifier");
-        return false;
       }
       else
       {

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -148,7 +148,6 @@ static const char* generate_multi_dot_name(ast_t* ast, ast_t** def_found) {
   if(def_found != NULL)
   {
     *def_found = def;
-  
     if(def == NULL)
       return stringtab("");
   }

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -698,11 +698,11 @@ static ast_result_t syntax_consume(pass_opt_t* opt, ast_t* ast)
     case TK_REFERENCE:
       return AST_OK;
     case TK_DOT: {
-        AST_GET_CHILDREN(term, left, right);
-        if (ast_id(left) != TK_CALL && ast_id(left) != TK_SEQ) 
-        {
-          return AST_OK;
-        }
+      AST_GET_CHILDREN(term, left, right);
+      if (ast_id(left) != TK_CALL && ast_id(left) != TK_SEQ)
+      {
+        return AST_OK;
+      }
     }
     default: {}
   }

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -696,14 +696,19 @@ static ast_result_t syntax_consume(pass_opt_t* opt, ast_t* ast)
   {
     case TK_THIS:
     case TK_REFERENCE:
-    case TK_DOT:
       return AST_OK;
-
+    case TK_DOT: {
+        AST_GET_CHILDREN(term, left, right);
+        if (ast_id(left) != TK_CALL && ast_id(left) != TK_SEQ) 
+        {
+          return AST_OK;
+        }
+    }
     default: {}
   }
 
   ast_error(opt->check.errors, term,
-    "Consume expressions must specify a single identifier");
+    "Consume expressions must specify an identifier or field");
   return AST_ERROR;
 }
 


### PR DESCRIPTION
* `consume (consume variable).field` must result in similar compilation error as  `consume (consume variable)`.
* `consume f().field` must result in similar compilation error as `consume f()`
* `(consume c).field` must not result in a crash.

 Fixes #3463, #3567 (and #3453)