### PR TITLE
Run windows standard library tests sequentially

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -254,7 +254,7 @@ switch ($Command.ToLower())
         if ($LastExitCode -eq 0)
         {
             Write-Output "$outDir\stdlib-debug.exe"
-            & $outDir\stdlib-debug.exe --exclude="net/Broadcast"
+            & $outDir\stdlib-debug.exe --sequential --exclude="net/Broadcast"
             $err = $LastExitCode
             if ($err -ne 0) { $failedTestSuites += 'stdlib-debug' }
         }
@@ -270,7 +270,7 @@ switch ($Command.ToLower())
         if ($LastExitCode -eq 0)
         {
             Write-Output "$outDir\stdlib-release.exe"
-            & $outDir\stdlib-release.exe --exclude="net/Broadcast"
+            & $outDir\stdlib-release.exe --sequential --exclude="net/Broadcast"
             $err = $LastExitCode
             if ($err -ne 0) { $failedTestSuites += 'stdlib-release' }
         }


### PR DESCRIPTION
This matches what we do with Linux and makes sure that tests that
have competing needs for resources can't accidentally clash.