### PR TITLE
Fix soundness problem with Array.chop

### DIFF
--- a/.release-notes/3657.md
+++ b/.release-notes/3657.md
@@ -1,4 +1,4 @@
-## Restrict Array.chop to be used with sendable element types
+## Fix soundness problem with Array.chop
 
 Previously, the `chop` method on arrays could be used for any element type,
 and return two isolated halves. While this is fine for sendable data,

--- a/.release-notes/3657.md
+++ b/.release-notes/3657.md
@@ -1,0 +1,14 @@
+## Restrict Array.chop to be used with sendable element types
+
+Previously, the `chop` method on arrays could be used for any element type,
+and return two isolated halves. While this is fine for sendable data,
+`ref` elements could have shared references between elements which could
+violate this isolation and make the method unsound. This change now
+requires that the argument is sendable to call the method.
+
+This is a breaking change. Because the array itself is isolated,
+a usage that is genuinely sound can likely be fixed by ensuring
+that the element type is `iso` instead of `ref` or `trn`, or `val`
+instead of `box`, and recovering when elements are constructed.
+
+

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -433,7 +433,7 @@ class Array[A] is Seq[A]
       end
     end
 
-  fun iso chop(split_point: USize): (Array[A] iso^, Array[A] iso^) =>
+  fun iso chop[B: (A & Any #send) = A](split_point: USize): (Array[A] iso^, Array[A] iso^) =>
     """
     Chops the array in half at the split point requested and returns both
     the left and right portions. The original array is trimmed in place and

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -440,8 +440,10 @@ class Array[A] is Seq[A]
     returned as the left portion. If the split point is larger than the
     array, the left portion is the original array and the right portion
     is a new empty array.
-    Both arrays are isolated and mutable, as they do not share memory.
     The operation does not allocate a new array pointer nor copy elements.
+
+    The entry type must be sendable so that the two array pieces can
+    be deeply isolated from each other.
     """
     let start_ptr = cpointer(split_point)
     let size' = _size - _size.min(split_point)

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -444,7 +444,20 @@ class Array[A] is Seq[A]
 
     The entry type must be sendable so that the two halves can be isolated.
     Otherwise, two entries may have shared references to mutable data,
-    or even to each other.
+    or even to each other, such as in the code below:
+
+    ```pony
+      class Example
+         var other: (Example | None) = None
+
+      let arr: Array[Example] iso = recover
+         let obj1 = Example
+         let obj2 = Example
+         obj1.other = obj2
+         obj2.other = obj1
+         [obj1; obj2]
+      end
+    ```
     """
     let start_ptr = cpointer(split_point)
     let size' = _size - _size.min(split_point)

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -442,8 +442,9 @@ class Array[A] is Seq[A]
     is a new empty array.
     The operation does not allocate a new array pointer nor copy elements.
 
-    The entry type must be sendable so that the two array pieces can
-    be deeply isolated from each other.
+    The entry type must be sendable so that the two halves can be isolated.
+    Otherwise, two entries may have shared references to mutable data,
+    or even to each other.
     """
     let start_ptr = cpointer(split_point)
     let size' = _size - _size.min(split_point)


### PR DESCRIPTION
While the memory of the two array pieces was disjoint, a non-sendable element type could allow aliases between the two array portions that would violate isolation.

Fixes https://github.com/ponylang/ponyc/issues/3652