### PR TITLE
Turn back on checking release image as part of PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Docker build
         run: "docker build --pull --file=.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile ."
 
+  validate-gnu-docker-release-image-builds:
+    name: Validate GNU Docker release image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Docker build
+        run: "docker build --pull --file=.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile ."
+
   validate-windows-docker-release-image-builds:
     name: Validate Windows Docker release image builds
     runs-on: windows-latest


### PR DESCRIPTION
It was turned off because we merged a PR that broke it for
release images until such time as the next release was done.