### PR TITLE
Don't add unnecessary methods to virtual tables

### DIFF
--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -293,6 +293,9 @@ static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
 
     while((m = reach_mangled_next(&n->r_mangled, &j)) != NULL)
     {
+      if(!m->needs_vtable_index)
+        continue;
+
       uint32_t index = m->vtable_index;
       pony_assert(index != (uint32_t)-1);
       pony_assert(vtable[index] == NULL);
@@ -512,6 +515,8 @@ LLVMValueRef gendesc_dispatch(compile_t* c, LLVMValueRef desc)
 
 LLVMValueRef gendesc_vtable(compile_t* c, LLVMValueRef desc, size_t colour)
 {
+  pony_assert(colour != (size_t)-1);
+
   LLVMValueRef vtable = LLVMBuildStructGEP(c->builder, desc, DESC_VTABLE, "");
 
   LLVMValueRef gep[2];

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -289,6 +289,13 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     // If the method is a forwarding mangling, we don't need the handler.
     if(!m->forwarding)
     {
+      // Assign a message ID if there isn't already one.
+      if(!m->needs_vtable_index)
+      {
+        pony_assert(m->vtable_index == (uint32_t)-1);
+        m->vtable_index = t->behaviour_index++;
+      }
+
       // Change the return type to void for the handler.
       LLVMTypeRef handler_type = LLVMFunctionType(c->void_type, tparams,
         (int)count, false);
@@ -342,6 +349,8 @@ static void add_dispatch_case(compile_t* c, reach_type_t* t,
   reach_param_t* params, uint32_t index, LLVMValueRef handler,
   LLVMTypeRef fun_type, LLVMTypeRef msg_type)
 {
+  pony_assert(index != (uint32_t)-1);
+
   // Add a case to the dispatch function to handle this message.
   compile_type_t* c_t = (compile_type_t*)t->c_type;
   codegen_startfun(c, c_t->dispatch_fn, NULL, NULL, NULL, false);

--- a/src/libponyc/reach/paint.c
+++ b/src/libponyc/reach/paint.c
@@ -287,6 +287,9 @@ static void find_names_types_use(painter_t* painter, reach_types_t* types)
 
       while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
+        if(!m->needs_vtable_index)
+          continue;
+
         const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
 
@@ -369,6 +372,9 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
 
       while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
       {
+        if(!m->needs_vtable_index)
+          continue;
+
         // Store colour assigned to name in reachable types set
         const char* name = m->mangled_name;
         name_record_t* name_rec = find_name(painter, name);
@@ -383,7 +389,7 @@ static void distribute_info(painter_t* painter, reach_types_t* types)
     }
 
     // Store vtable size for type
-    t->vtable_size = max_colour + 1;
+    t->vtable_size = t->behaviour_index = max_colour + 1;
   }
 }
 

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -40,6 +40,7 @@ struct reach_method_t
   deferred_reification_t* fun;
   ast_t* typeargs;
   uint32_t vtable_index;
+  bool needs_vtable_index;
 
   // Mark as true if the compiler supplies an implementation.
   bool intrinsic;
@@ -101,6 +102,7 @@ struct reach_type_t
   uint32_t vtable_size;
   bool can_be_boxed;
   bool is_trait;
+  uint32_t behaviour_index;
 
   uint32_t field_count;
   reach_field_t* fields;

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -55,6 +55,7 @@ protected:
     method->fun = NULL;
     method->typeargs = NULL;
     method->vtable_index = (uint32_t)-1;
+    method->needs_vtable_index = true;
 
     reach_methods_put(&n->r_methods, method);
     reach_mangled_put(&n->r_mangled, method);


### PR DESCRIPTION
Methods are now only added to virtual tables when they can actually
be called through a trait. This allows the compiler to generate
smaller and more compact virtual tables.

This work was originally done by Benoit in PR #1917