### PR TITLE
Fix race condition in cycle detector block sent handling

### DIFF
--- a/.release-notes/cd-double-free.md
+++ b/.release-notes/cd-double-free.md
@@ -1,0 +1,3 @@
+## Fix race condition that can result in a segfault
+
+We recently introduced some improvements to the handling of garbage collection for short-lived actors when the cycle detector is running. In the process, we introduced a race condition in the runtime that could result in an actor being garbage collected twice which if it were to occur, would result in a crashing program.


### PR DESCRIPTION
This fixes a bug introduced with the recent short-lived actor garbage
collection improvements.

Here's the race:

- Cycle detector is on
- Cycle detector is aware of an actor

1. Actor finishes a scheduler run
2. Actor marks queue as empty
3. Actor has rc of 0 so it sends a BLOCK message to the cycle detector

Between 2 and 3, the cycle detector sends an IS_BLOCKED message to
the actor. The actor is rescheduled on the same scheduler thread as the
cycle detector.

Because in 3, we sent a BLOCK message and the rc is 0 (and can't change),
the cycle detector is going to delete the actor when it processes the
BLOCK message.

However, the actor exists on another schedulers queue. Either of the following
could happen:

- Actor runs again before deletion, sends another BLOCK message to the cycle
  detector.
- Actor is deleted by the cycle detector before the other scheduler runs it

Either way, hilarity in the form of segfaults or other race condition oddities
will occur.

As the comment in actor.c says:

If we mark the queue as empty, then it is no longer safe to do any
operations on this actor that aren't concurrency safe unless, the actor
has an rc of 0 and the cycle detector isn't aware of the actor's
existence.

Prior to this commit, sending a block message to the cd after marking the
queue as empty was not concurrency safe due to the aforementioned race
condition.