### PR TITLE
Fix race conditions that can lead to a segfault

### DIFF
--- a/.release-notes/3667.md
+++ b/.release-notes/3667.md
@@ -1,0 +1,3 @@
+## Fix race conditions that can lead to a segfault
+
+The [0.38.0](https://github.com/ponylang/ponyc/releases/tag/0.38.0) release introduced improvement to handling of short-lived actors. However, in the process it also introduced some race condition situations that could lead to segfaults. [0.38.1](https://github.com/ponylang/ponyc/releases/tag/0.38.1) introduced a fix that we hoped would address the problems, however, after that release we realized that it didn't fully address the situation. With this change, we've reworked the implementation of the short-lived actor improvements to avoid the trigger for the known race conditions entirely.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -484,6 +484,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 
         // "Locally delete" the actor.
         ponyint_actor_setpendingdestroy(actor);
+        ponyint_actor_sendrelease(ctx, actor);
         ponyint_actor_final(ctx, actor);
         ponyint_actor_destroy(actor);
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -519,8 +519,14 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
         // will not send it any more messages because it is set as pending
         // destroy.
 
-        // the invariant that should hold true at this point is that we have
-        // not sent the cycle detector a `block` message already
+        // Based on how the cycle detector protocol works, FLAG_BLOCKED_SENT
+        // shouldn't be set at this time. We have previously contact the
+        // cycle detector and sent a blocked message then we should have
+        // unblocked before having gotten here.
+        // Dipin is 99% sure this invariant applies. Sean is less certain.
+        // It's possible this might be a source of bug. If it is, then the
+        // solution is probably to make this an if that encloses the remaining
+        // logic in this block.
         pony_assert(!has_flag(actor, FLAG_BLOCKED_SENT));
 
         // Tell cycle detector that this actor is a zombie and will not get

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -442,7 +442,8 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   {
     // Here, we is what we know to be true:
     //
-    // - the actor is blocked and likely has no meesages in its queue
+    // - the actor is blocked
+    // - the actor likely has no messages in its queue
     // - there's no references to this actor
     //
 
@@ -739,8 +740,8 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
 
   pony_assert(well_formed_msg_chain(first, last));
 
-  // make sure we're not trying to send a message to an actor
-  // that is about to be destroyed
+  // Make sure we're not trying to send a message to an actor that is about
+  // to be destroyed.
   pony_assert(!ponyint_actor_pendingdestroy(to));
 
   if(DTRACE_ENABLED(ACTOR_MSG_SEND))

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -484,8 +484,8 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 
         // "Locally delete" the actor.
         ponyint_actor_setpendingdestroy(actor);
-        //ponyint_actor_sendrelease(ctx, actor);
         ponyint_actor_final(ctx, actor);
+        ponyint_actor_sendrelease(ctx, actor);
         ponyint_actor_destroy(actor);
 
         // make sure the scheduler will not reschedule this actor

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -484,7 +484,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 
         // "Locally delete" the actor.
         ponyint_actor_setpendingdestroy(actor);
-        ponyint_actor_sendrelease(ctx, actor);
+        //ponyint_actor_sendrelease(ctx, actor);
         ponyint_actor_final(ctx, actor);
         ponyint_actor_destroy(actor);
 

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -291,3 +291,14 @@ bool ponyint_messageq_markempty(messageq_t* q)
   return atomic_compare_exchange_strong_explicit(&q->head, &tail, head,
     memory_order_release, memory_order_relaxed);
 }
+
+bool ponyint_messageq_isempty(messageq_t* q)
+{
+  pony_msg_t* tail = q->tail;
+  pony_msg_t* head = atomic_load_explicit(&q->head, memory_order_relaxed);
+
+  if(((uintptr_t)head & 1) != 0)
+    return true;
+
+  return head == tail;
+}

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -64,6 +64,8 @@ pony_msg_t* ponyint_thread_messageq_pop(messageq_t* q
 
 bool ponyint_messageq_markempty(messageq_t* q);
 
+bool ponyint_messageq_isempty(messageq_t* q);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1481,7 +1481,7 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
 
         // Only reschedule if the queue isn't empty. The queue hasn't been
         // marked as empty when the actor was muted.
-        if(!ponyint_messageq_isempty(&to_unmute->q))
+        //if(!ponyint_messageq_isempty(&to_unmute->q))
         {
           ponyint_sched_add(ctx, to_unmute);
           DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1481,7 +1481,7 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
 
         // Only reschedule if the queue isn't empty. The queue hasn't been
         // marked as empty when the actor was muted.
-        //if(!ponyint_messageq_markempty(&to_unmute->q))
+        if(!ponyint_messageq_isempty(&to_unmute->q))
         {
           ponyint_sched_add(ctx, to_unmute);
           DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1481,7 +1481,7 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
 
         // Only reschedule if the queue isn't empty. The queue hasn't been
         // marked as empty when the actor was muted.
-        if(!ponyint_messageq_markempty(&to_unmute->q))
+        //if(!ponyint_messageq_markempty(&to_unmute->q))
         {
           ponyint_sched_add(ctx, to_unmute);
           DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1479,14 +1479,9 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
       {
         ponyint_unmute_actor(to_unmute);
 
-        // Only reschedule if the queue isn't empty. The queue hasn't been
-        // marked as empty when the actor was muted.
-        //if(!ponyint_messageq_isempty(&to_unmute->q))
-        {
-          ponyint_sched_add(ctx, to_unmute);
-          DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);
-          actors_rescheduled++;
-        }
+        ponyint_sched_add(ctx, to_unmute);
+        DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);
+        actors_rescheduled++;
       }
 
       ponyint_sched_start_global_unmute(ctx->scheduler->index, to_unmute);


### PR DESCRIPTION
Prior to this commit, there could be race conditions with a actor
running concurrently on two different threads due to work being
done after an actors queue was marked empty.

This commit reworks the logic to ensure that the actors queue being
marked empty is the last thing that occurs in `ponyint_actor_run`
to prevent these race conditions.

This commit also adds logic in the cycle detector to not send any
messages to actors that are marked as pending destroy to ensure
that the cycle detector cannot create a race condition by sending
messages to a zombie actor (with `rc == 0`) that is about to be
reaped in the near future.