### PR TITLE
Fix compiler crash when an if block ends with an assignment that has no result value.

### DIFF
--- a/.release-notes/issue-3669.md
+++ b/.release-notes/issue-3669.md
@@ -1,0 +1,3 @@
+## Fix compiler crash when an if block ends with an assignment that has no result value
+
+This release fixes a compiler crash that used to occur when certain kinds of assignment expressions that have no logical result value were used as the last expression in an `if` block, and possibly other control flow constructs as well. Now the compiler makes sure that the code generation for those cases always bears a value, even though the type system guarantees that the value will never be used in such a case. This prevents generating invalid LLVM IR blocks that have no proper terminator instruction.

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -480,7 +480,10 @@ static LLVMValueRef assign_rvalue(compile_t* c, ast_t* left, ast_t* r_type,
     case TK_EMBEDREF:
     {
       // Do nothing. The embed field was already passed as the receiver.
-      return GEN_NOVALUE;
+      // But we can't return GEN_NOVALUE - that's reserved only for branches
+      // that "jump away". So we just return the r_value we were given.
+      // The type system ensures that nobody will be able to use this value.
+      return r_value;
     }
 
     case TK_VARREF:
@@ -501,9 +504,11 @@ static LLVMValueRef assign_rvalue(compile_t* c, ast_t* left, ast_t* r_type,
     case TK_DONTCAREREF:
     case TK_MATCH_DONTCARE:
     {
-      // Do nothing. The type checker has already ensured that nobody will try
-      // to use the result of the assignment.
-      return GEN_NOVALUE;
+      // Do nothing.
+      // But we can't return GEN_NOVALUE - that's reserved only for branches
+      // that "jump away". So we just return the r_value we were given.
+      // The type system ensures that nobody will be able to use this value.
+      return r_value;
     }
 
     case TK_TUPLE:

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -946,3 +946,46 @@ TEST_F(CodegenTest, TryThenClauseContinueNested)
   ASSERT_TRUE(run_program(&exit_code));
   ASSERT_EQ(exit_code, 42);
 }
+
+TEST_F(CodegenTest, IfBlockEndingWithEmbedAssign)
+{
+  // From issue #3669
+  const char* src =
+    "class B\n"
+    "class A\n"
+    "  embed embedded: B\n"
+    "  new create() => \n"
+    "    if true\n"
+    "    then embedded = B\n"
+    "    else embedded = B\n"
+    "    end\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    A";
+
+  TEST_COMPILE(src);
+
+  // LLVM Module verification fails if bug is present:
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+}
+
+TEST_F(CodegenTest, IfBlockEndingWithDontCareAssign)
+{
+  // From issue #3669
+  const char* src =
+    "class B\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    if true\n"
+    "    then _ = B\n"
+    "    end";
+
+  TEST_COMPILE(src);
+
+  // LLVM Module verification fails if bug is present:
+  int exit_code = 0;
+  ASSERT_TRUE(run_program(&exit_code));
+}


### PR DESCRIPTION
This fixes a compiler crash that used to occur when certain kinds of assignment expressions that have no logical result value were used as the last expression in an `if` block, and possibly other control flow constructs as well. Now the compiler makes sure that the code generation for those cases always bears a value, even though the type system guarantees that the value will never be used in such a case. This prevents generating invalid LLVM IR blocks that have no proper terminator instruction.