### PR TITLE
Prevent html escaping in documentation

### DIFF
--- a/packages/cli/env_vars.pony
+++ b/packages/cli/env_vars.pony
@@ -14,9 +14,9 @@ primitive EnvVars
     iff 'squash' is true.
 
     So:
-      <PREFIX><KEY>=<VALUE>
+      `<PREFIX><KEY>=<VALUE>`
     becomes:
-      {KEY, VALUE} or {key, VALUE}
+      `{KEY, VALUE}` or `{key, VALUE}`
     """
     let envsmap = recover Map[String, String]() end
     match envs


### PR DESCRIPTION
Currently the doc generator doesn't escape html-like tags, and merely inserts them as-is in the final document. This should be fixed, but for now we can avoid that by enclosing tag-like in code/pre tags ourselves.