### PR TITLE
Fix memory safety problem with Array.from_cpointer

### DIFF
--- a/.release-notes/3675.md
+++ b/.release-notes/3675.md
@@ -1,0 +1,7 @@
+## Fix memory safety problem with Array.from_cpointer
+
+Previously, the `from_cpointer` method in arrays would trust the user to pass a
+valid pointer. This created an issue where the user could pass a null pointer using
+`Pointer.create`, leading to a situation where memory safety could be violated
+by trying to access an element of the array. This change makes it safe to pass a
+null pointer to `from_cpointer`, which will create a zero-length array.

--- a/.release-notes/3675.md
+++ b/.release-notes/3675.md
@@ -1,7 +1,3 @@
 ## Fix memory safety problem with Array.from_cpointer
 
-Previously, the `from_cpointer` method in arrays would trust the user to pass a
-valid pointer. This created an issue where the user could pass a null pointer using
-`Pointer.create`, leading to a situation where memory safety could be violated
-by trying to access an element of the array. This change makes it safe to pass a
-null pointer to `from_cpointer`, which will create a zero-length array.
+Previously, the `from_cpointer` method in arrays would trust the user to pass a valid pointer. This created an issue where the user could pass a null pointer using `Pointer.create`, leading to a situation where memory safety could be violated by trying to access an element of the array. This change makes it safe to pass a null pointer to `from_cpointer`, which will create a zero-length array.

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -129,7 +129,6 @@ class Array[A] is Seq[A]
     if ptr.is_null() then
       _size = 0
       _alloc = 0
-      _ptr = ptr
     else
       _size = len
       if alloc > len then
@@ -137,8 +136,9 @@ class Array[A] is Seq[A]
       else
         _alloc = len
       end
-      _ptr = ptr
     end
+
+    _ptr = ptr
 
   fun _copy_to(
     ptr: Pointer[this->A!],

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -126,19 +126,17 @@ class Array[A] is Seq[A]
     Create an array from a C-style pointer and length. The contents are not
     copied.
     """
-    _size = len
-
     if ptr.is_null() then
       _size = 0
-      _alloc = 1
-      _ptr = Pointer[A]._alloc(_alloc)
+      _alloc = 0
+      _ptr = ptr
     else
+      _size = len
       if alloc > len then
         _alloc = alloc
       else
         _alloc = len
       end
-
       _ptr = ptr
     end
 

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -128,13 +128,19 @@ class Array[A] is Seq[A]
     """
     _size = len
 
-    if alloc > len then
-      _alloc = alloc
+    if ptr.is_null() then
+      _size = 0
+      _alloc = 1
+      _ptr = Pointer[A]._alloc(_alloc)
     else
-      _alloc = len
-    end
+      if alloc > len then
+        _alloc = alloc
+      else
+        _alloc = len
+      end
 
-    _ptr = ptr
+      _ptr = ptr
+    end
 
   fun _copy_to(
     ptr: Pointer[this->A!],

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -54,6 +54,7 @@ actor Main is TestList
     test(_TestStringUnchop)
     test(_TestStringRepeatStr)
     test(_TestStringConcatOffsetLen)
+    test(_TestStringFromCPointer)
     test(_TestSpecialValuesF32)
     test(_TestSpecialValuesF64)
     test(_TestArrayAppend)
@@ -68,6 +69,7 @@ actor Main is TestList
     test(_TestArraySwapElements)
     test(_TestArrayChop)
     test(_TestArrayUnchop)
+    test(_TestArrayFromCPointer)
     test(_TestMath128)
     test(_TestRem)
     test(_TestMod)
@@ -1275,6 +1277,16 @@ class iso _TestStringConcatOffsetLen is UnitTest
   fun apply(h: TestHelper) =>
     h.assert_eq[String](recover String.>concat("ABCD".values(), 1, 2) end, "BC")
 
+class iso _TestStringFromCPointer is UnitTest
+  """
+  Test creating a string from a pointer
+  """
+  fun name(): String => "builtin/String.from_cpointer"
+
+  fun apply(h: TestHelper) =>
+    let str = String.from_cpointer(Pointer[U8], 1, 1)
+    h.assert_eq[USize](0, str.size())
+
 class iso _TestArrayAppend is UnitTest
   fun name(): String => "builtin/Array.append"
 
@@ -1680,6 +1692,16 @@ class iso _TestArrayUnchop is UnitTest
     else
       error
     end
+
+class iso _TestArrayFromCPointer is UnitTest
+  """
+  Test creating an array from a pointer
+  """
+  fun name(): String => "builtin/Array.from_cpointer"
+
+  fun apply(h: TestHelper) =>
+    let arr = Array[U8].from_cpointer(Pointer[U8], 1, 1)
+    h.assert_eq[USize](0, arr.size())
 
 class iso _TestMath128 is UnitTest
   """


### PR DESCRIPTION
Fixes #3668. String already checked for a potential null pointer before constructing, so it was safe. Also added a test case to check this.