### PR TITLE
Update windows build dockerfile

### DIFF
--- a/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-pc-windows-msvc-builder/Dockerfile
@@ -4,9 +4,9 @@ FROM cirrusci/windowsservercore:2019
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+ADD https://download.visualstudio.microsoft.com/download/pr/9b3476ff-6d0a-4ff8-956d-270147f21cd4/ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0/vs_BuildTools.exe C:\vs_BuildTools.exe
 
 RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended
 RUN choco install cmake -y --no-progress --installargs 'ADD_CMAKE_TO_PATH=System'
 RUN choco install python3 -y --no-progress
-RUN C:\Python38\python.exe -m pip install --upgrade cloudsmith-cli
+RUN C:\Python39\python.exe -m pip install --upgrade cloudsmith-cli

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -123,7 +123,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20201208
     os_version: 2019
     cpu: 8
     memory: 24
@@ -148,7 +148,7 @@ task:
   only_if: $CIRRUS_PR != ''
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20201208
     os_version: 2019
     cpu: 8
     memory: 24
@@ -344,7 +344,7 @@ task:
   only_if: $CIRRUS_CRON == "master-midnight"
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20201208
     os_version: 2019
     cpu: 8
     memory: 24
@@ -491,7 +491,7 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   windows_container:
-    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20200407
+    image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20201208
     os_version: 2019
     cpu: 8
     memory: 24

--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
@@ -6,11 +6,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 COPY .\git.ini C:\
 
-ADD https://github.com/git-for-windows/git/releases/download/v2.26.0.windows.1/Git-2.26.0-64-bit.exe C:\Git-2.26.0-64-bit.exe
-ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+ADD https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/Git-2.29.2.3-64-bit.exe C:\Git-2.29.2.3-64-bit.exe
+ADD https://download.visualstudio.microsoft.com/download/pr/9b3476ff-6d0a-4ff8-956d-270147f21cd4/ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0/vs_BuildTools.exe C:\vs_BuildTools.exe
 ADD https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
 
-RUN C:\Git-2.26.0-64-bit.exe /VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF="C:\git.ini"
+RUN C:\Git-2.29.2.3-64-bit.exe /VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF="C:\git.ini"
 RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc
 RUN setx /M PATH $($env:PATH + ';C:\ponyc\bin')

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
@@ -6,11 +6,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 COPY .\git.ini C:\
 
-ADD https://github.com/git-for-windows/git/releases/download/v2.26.0.windows.1/Git-2.26.0-64-bit.exe C:\Git-2.26.0-64-bit.exe
-ADD https://download.visualstudio.microsoft.com/download/pr/220fe621-dd35-4fc0-a32e-10ff6f4551cd/4383a2e9eac72248bd56a25aed63051efb37393a7af3db4726868699c7cd99e4/vs_BuildTools.exe C:\vs_BuildTools.exe
+ADD https://github.com/git-for-windows/git/releases/download/v2.29.2.windows.3/Git-2.29.2.3-64-bit.exe Git-2.29.2.3-64-bit.exe
+ADD https://download.visualstudio.microsoft.com/download/pr/9b3476ff-6d0a-4ff8-956d-270147f21cd4/ccfb9355f4f753315455542f966025f96de734292d3908c8c3717e9685b709f0/vs_BuildTools.exe C:\vs_BuildTools.exe
 ADD https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip C:\ponyc.zip
 
-RUN C:\Git-2.26.0-64-bit.exe /VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF="C:\git.ini"
+RUN C:\Git-2.29.2.3-64-bit.exe /VERYSILENT /NORESTART /NOCANCEL /SP- /CLOSEAPPLICATIONS /RESTARTAPPLICATIONS /LOADINF="C:\git.ini"
 RUN C:\vs_BuildTools.exe --quiet --wait --norestart --nocache --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended
 RUN Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc
 RUN setx /M PATH $($env:PATH + ';C:\ponyc\bin')


### PR DESCRIPTION
The error in the recent Windows CI builds seems to indicate a problem with the Windows system in the container that Cirrus is using. This PR updates the dockerfile and Cirrus config to use an updated image.