### PR TITLE
Fix link errors on macOS Big Sur

### DIFF
--- a/.release-notes/3686.md
+++ b/.release-notes/3686.md
@@ -1,0 +1,3 @@
+## Fix link errors on macOS Big Sur
+
+With the change from Catalina to Big Sur, Apple moved the location of the System library, which broke the linking phase of the compiler. This change fixes the problem by specifying the absolute path of the System library.

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -287,14 +287,15 @@ static bool link_exe(compile_t* c, ast_t* program,
     "";
 #endif
 
-  size_t ld_len = 128 + arch_len + strlen(linker) + strlen(file_exe) +
+  size_t ld_len = 256 + arch_len + strlen(linker) + strlen(file_exe) +
     strlen(file_o) + strlen(lib_args) + strlen(sanitizer_arg);
 
   char* ld_cmd = (char*)ponyint_pool_alloc_size(ld_len);
 
   snprintf(ld_cmd, ld_len,
     "%s -execute -no_pie -arch %.*s "
-    "-macosx_version_min 10.12 -o %s %s %s %s -lSystem %s",
+    "-macosx_version_min 10.12 -o %s %s %s %s "
+    "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg
     );


### PR DESCRIPTION
With the change from Catalina to Big Sur, Apple moved the location of
libraries. On Big Sur, it is required to pass the location of the System
library. The `-lSystem` option is still required for macOS 10.15.7 and
lower.

We don't currently distinguish between different macOS versions, so we
should keep both options. As long as the absolute path of the System
library is present, the `-lSystem` option won't pose any problems on Big
Sur.

This should fix #3684. 