### PR TITLE
Fix unhandled null pointer returning from os_addrinfo_intern

### DIFF
--- a/.release-notes/3687.md
+++ b/.release-notes/3687.md
@@ -1,0 +1,3 @@
+## Fix unhandled null pointer that can lead to a segfault
+
+Previously, the `os_socket_listen` and `os_socket_connect` internal functions would assume that calls to `os_addrinfo_intern` would never fail. The `os_addrinfo_intern` function returns a null pointer on failure, which could result in the callers attempting to free an invalid pointer, and causing a segfault. This change adds error handling on the socket functions, which fixes the problem.

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -562,6 +562,10 @@ static bool os_connect(pony_actor_t* owner, int fd, struct addrinfo *p,
   {
     struct addrinfo* result = os_addrinfo_intern(p->ai_family, 0, 0, from,
       NULL, false);
+
+    if(result == NULL)
+      return false;
+
     struct addrinfo* lp = result;
     bool bound = false;
 
@@ -634,6 +638,9 @@ static asio_event_t* os_socket_listen(pony_actor_t* owner, const char* host,
   struct addrinfo* result = os_addrinfo_intern(family, socktype, proto, host,
     service, true);
 
+  if(result == NULL)
+    return NULL;
+
   struct addrinfo* p = result;
 
   while(p != NULL)
@@ -666,6 +673,9 @@ static int os_socket_connect(pony_actor_t* owner, const char* host,
 
   struct addrinfo* result = os_addrinfo_intern(family, socktype, proto, host,
     service, false);
+
+  if(result == NULL)
+    return 0;
 
   struct addrinfo* p = result;
   int count = 0;


### PR DESCRIPTION
`os_socket_listen`, `os_socket_connect` and `os_connect` incorrectly
assumed that the return value from `os_addrinfo_intern` would never be
NULL, and therefore would call freeadrinfo with a null pointer, causing
a segmentation fault.

This should fix #3685.