### PR TITLE
Scope "handle external events" to cloudsmith events only

### DIFF
--- a/.github/workflows/handle-cloudsmith-events.yml
+++ b/.github/workflows/handle-cloudsmith-events.yml
@@ -1,10 +1,12 @@
-name: Handle external events
+name: Handle cloudsmith events
 
-on: repository_dispatch
+on:
+  repository_dispatch:
+    types: [cloudsmith-event]
 
 jobs:
-  log-external-event:
-    name: Log all incoming events
+  log-cloudsmith-event:
+    name: Log all incoming cloudsmith events
     runs-on: ubuntu-latest
     steps:
       - name: Log event


### PR DESCRIPTION
The handle external events workflow was overly broad. It was only
used for cloudsmith related events. Mixing in other events into
the same workflow would be problematic.

This PR scopes the workflow correctly which will allow the use
of respository_dispatch with other workflows in the future.