### PR TITLE
Add sending events when nightly releases are finished

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -195,3 +195,18 @@ jobs:
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           VERSION: ${{ github.event.client_payload.data.version }}
+
+  send-nightly-release-event:
+    name: Send nightly release event
+    runs-on: ubuntu-latest
+    needs: [build-latest-gnu-docker-image, build-latest-musl-docker-image, build-latest-windows-docker-image]
+    strategy:
+      matrix:
+        repo: ['ponylang/shared-docker']
+    steps:
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
+        repository: ${{ matrix.repo }}
+        event-type: ponyc-nightly-released
+        client-payload: '{}'


### PR DESCRIPTION
Adds sending a GitHub repository dispatch event to ponylang/shared-docker
when all 3 nightly docker images are done building.

This will allow us to trigger nightly shared-docker image rebuilds when
the new images are available rather than hoping that the times line up.

Additional triggered jobs will be added once I know this is working.
For example, triggering testing against the latest ponyc master images
in our various repos.

Additional repos to send to can be added to the `repos` section of the
job's matrix.

At this time, we don't send any payload data with the event as I'm not
aware of what we might need to include.