### PR TITLE
Add sending a repository_dispatch event when a release is done

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -213,3 +213,20 @@ jobs:
           repository: ${{ matrix.repo }}
           event-type: ponyc-musl-nightly-released
           client-payload: '{}'
+
+  send-musl-release-event:
+    needs: [build-release-musl-docker-image]
+
+    name: Send release event
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['ponylang/shared-docker']
+    steps:
+      - name: Send
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: ponyc-musl-released
+          client-payload: '{}'


### PR DESCRIPTION
Sends a repository_dispatch event of type `ponyc-musl-release` when
all Linux musl release artifacts have been built. Event is only sent
to repositories that have been "registered to receive" by adding to
the repo matrix in the "send-release-event" job.

Sending a repository_dispatch event allows other ponylang repos to
kick off workflows in response to some part of a release being done.