### PR TITLE
Switch to using ponylang-main version of ssh-action

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run remote command
-        uses: appleboy/ssh-action@ffff33f8fe0318345a4f00f0e847325954b2a3ed
+        uses: ponylang-main/ssh-action@ffff33f8fe0318345a4f00f0e847325954b2a3ed
         with:
           host: ${{ secrets.PLAYGROUND_HOST }}
           username: ${{ secrets.PLAYGROUND_ADMIN_USER }}


### PR DESCRIPTION
We don't want the github action disappearing out from under us,
so we forked it into ponylang-main where we can use it from.