### PR TITLE
Fix bad package names in generated documentation

### DIFF
--- a/.release-notes/3700.md
+++ b/.release-notes/3700.md
@@ -1,0 +1,3 @@
+## Fix bad package names in generated documentation
+
+Previously when you used ponyc's documentation generation functions on a code base that used relative imports like `use "../foo"`, the package name in the generated documentation would be incorrect.


### PR DESCRIPTION
Fixes incorrect qualified path name building for relative package imports,
Instead of doing the relative path in relation to the package we were in,
it did it based on the base of the program.

So for example instead of getting

"semver/version"
or an equiv
"semver/test/version/../../version"

You'd end up with

"semver/../../version"