### PR TITLE
Run standard library tests without the cycle detector

### DIFF
--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -89,6 +89,9 @@ actor Main is TestList
     test(_TestLambdaCapture)
     test(_TestValtrace)
 
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+     rto.ponynoblock = true
+
 class iso _TestAbs is UnitTest
   """
   Test abs function

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -78,3 +78,6 @@ actor Main is TestList
 
     strings.Main.make().tests(test)
     time.Main.make().tests(test)
+
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+     rto.ponynoblock = true


### PR DESCRIPTION
At the moment, there's a race condition that can cause a segfault when
garbage collecting an actor if the cycle detector is on. I haven't had
the solid block of time to fix the problem.

In the meantime, there have been distracting CI failures.

This commit turns off the cycle detector for standard library tests. This
will give us more confidence in those tests. If there is a segfault, we
know it isn't from the known issue.

The changes in this commit will be removed along with the fix for the
race condition.