### PR TITLE
Fix calculation of # CPU cores (FreeBSD/DragonFly)

### DIFF
--- a/.release-notes/3707.md
+++ b/.release-notes/3707.md
@@ -1,0 +1,20 @@
+## Fix calculating the number of CPU cores on FreeBSD/DragonFly
+
+The number of CPU cores is used by Pony to limit the number of scheduler
+threads (`--ponymaxthreads`) and also used as the default number of scheduler
+threads.
+
+Previously, `sysctl hw.ncpu` was incorrectly used to determine the number of
+CPU cores on FreeBSD and DragonFly. On both systems `sysctl hw.ncpu` reports
+the number of logical CPUs (hyperthreads) and NOT the number of physical CPU
+cores.
+
+This has been fixed to use `kern.smp.cores` on FreeBSD and
+`hw.cpu_topology_core_ids` * `hw.cpu_topology_phys_ids` on DragonFly to
+correctly determine the number of physical CPU cores.
+
+This change only affects FreeBSD and DragonFly systems with hardware that
+support hyperthreading. For instance, on a 4-core system with 2-way HT,
+previously 8 scheduler threads would be used by default. After this change, the
+number of scheduler threads on the same system is limited to 4 (one per CPU
+core).


### PR DESCRIPTION
* On both FreeBSD and DragonFly, `sysctl hw.ncpu` returns the number of
  logical CPUs, NOT the number of physical CPU cores.

* FreeBSD has sysctl `kern.smp.cores`.

* DragonFly has sysctl's `hw.cpu_topology_core_ids` and
  `hw.cpu_topology_phys_ids`. Both multiplied together results in the
  number of cores.

* If `kern.smp.cores` (FreeBSD) or `hw.cpu_topology_*` (DragonFly) is
  not available, use `hw.ncpu` instead.

* For example on FreeBSD 12.2p3 running a i7-8565U:

  sysctl hw.ncpu # => 8
  sysctl kern.smp.cores # => 4

* For example on DragonFly 5.9-DEVELOPMENT with Xeon E5-1620:

  sysctl hw.ncpu # => 8
  sysctl hw.cpu_topology_phys_ids # => 1
  sysctl hw.cpu_topology_core_ids # => 4
  sysctl hw.cpu_topology_ht_ids   # => 2

* I found this by running a HTTP benchmark on a FreeBSD system
  (i7-8565U, 4 cores / 8 logical CPUs), where setting --ponymaxthreads=4
  improved latency significantly over the default value "8" (hw.ncpu).
  And I was wondering why I could set --ponymaxthreads to 8, even so the
  documentation explicitly states that it cannot be set to anything
  above the number of CPU cores.