### PR TITLE
Fix partial FFI declarations ignoring partial annotation

### DIFF
--- a/.release-notes/3713.md
+++ b/.release-notes/3713.md
@@ -1,0 +1,3 @@
+## Fix FFI declarations ignoring partial annotation
+
+Previously, the compiler would ignore any `?` annotations on FFI declarations, which could result in the generated code lacking any guards for errors, causing the final program to abort at runtime. This change fixes the problem by ensuring that the compiler checks if FFI declarations specify a partial annotation.

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -1174,7 +1174,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
     if(decl != NULL)
     {
       // Define using the declared types.
-      AST_GET_CHILDREN(decl, decl_id, decl_ret, decl_params, decl_err);
+      AST_GET_CHILDREN(decl, decl_id, decl_ret, decl_params, decl_named_params, decl_err);
       err = (ast_id(decl_err) == TK_QUESTION);
       func = declare_ffi(c, f_name, t, decl_params, false);
     } else if(!strncmp(f_name, "llvm.", 5) || !strncmp(f_name, "internal.", 9)) {


### PR DESCRIPTION
Previously, the compiler would ignore any `?` annotations on FFI
declarations, which could result in the generated code lacking any
guards for errors, causing the final program to abort at runtime.

h/t to @jemc for noticing what needed to be fixed.