### PR TITLE
Create a standalone libponyc on Linux

### DIFF
--- a/.release-notes/3716.md
+++ b/.release-notes/3716.md
@@ -1,0 +1,16 @@
+## Create a standalone libponyc on Linux
+
+It's possible to use libponyc from projects other than ponyc. Using the
+library gives you access to all the various compiler functionality. However,
+it is hard to use the library because, you need to link in the correct libstdc++,
+libblake, and LLVM. Figuring out what is the correct version of each is very
+difficult.
+
+With this change, a new library `libponyc-standalone.a` will be created as
+part of the build process.
+
+Applications like the "in pony documentation generator" that we are working on will
+be able to link to libponyc-standalone and pick up all it's required dependencies.
+
+Windows, BSD, and macOS libraries are not created at this time but can be added
+as needed in the future.

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ install: build
 	@mkdir -p $(ponydir)/include/pony/detail
 	$(SILENT)cp $(buildDir)/src/libponyrt/libponyrt.a $(ponydir)/lib/$(arch)
 	$(SILENT)if [ -f $(outDir)/libponyc.a ]; then cp $(outDir)/libponyc.a $(ponydir)/lib/$(arch); fi
+	$(SILENT)if [ -f $(outDir)/libponyc-standalone.a ]; then cp $(outDir)/libponyc-standalone.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyrt-pic.a ]; then cp $(outDir)/libponyrt-pic.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)cp $(outDir)/ponyc $(ponydir)/bin
 	$(SILENT)cp src/libponyrt/pony.h $(ponydir)/include
@@ -221,6 +222,7 @@ ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/include/pony/detail
 	$(SILENT)ln -s -f $(ponydir)/bin/ponyc $(prefix)/bin/ponyc
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc.a $(prefix)/lib/libponyc.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt.a $(prefix)/lib/libponyrt.a; fi
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
@@ -230,7 +232,7 @@ endif
 uninstall:
 	-$(SILENT)rm -rf $(ponydir) ||:
 	-$(SILENT)rm -f $(prefix)/bin/ponyc ||:
-	-$(SILENT)rm -f $(prefix)/lib/libponyc.a ||:
+	-$(SILENT)rm -f $(prefix)/lib/libponyc*.a ||:
 	-$(SILENT)rm -f $(prefix)/lib/libponyrt*.a ||:
 	-$(SILENT)rm -rf $(prefix)/lib/pony ||:
 	-$(SILENT)rm -f $(prefix)/include/pony.h ||:

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -121,3 +121,41 @@ if (NOT MSVC)
         COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_BINARY_DIR}/libponyc.a ${CMAKE_BINARY_DIR}/../minsizerel/
     )
 endif (NOT MSVC)
+
+# build a standalone version of libponyc.a with all needed dependencies linked statically
+if (MSVC)
+    # TODO
+    #file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/build_libs/llvm/src/llvm/Release/lib/*.lib")
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
+    # TODO
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "BSD")
+    # TODO
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
+    # TODO
+else()
+    # add a rule to generate the standalone library if needed
+    add_custom_command(OUTPUT libponyc-standalone.a
+        COMMAND cp `find /usr/lib/ -name 'libstdc++.a' -print -quit` libstdcpp.a
+        COMMAND echo "create libponyc-standalone.a" > standalone.mri
+        COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
+        COMMAND echo "addlib libstdcpp.a" >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "libLLVM*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
+        COMMAND echo "save" >> standalone.mri
+        COMMAND echo "end" >> standalone.mri
+        COMMAND ar -M < standalone.mri
+        DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
+    )
+    # add a separate target that depends on the standalone library file
+    add_custom_target(libponyc-standalone ALL
+        DEPENDS libponyc
+        SOURCES libponyc-standalone.a
+    )
+    # copy the generated file after it is built
+    add_custom_command(TARGET libponyc-standalone POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug/
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release/
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo/
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel/
+    )
+endif (MSVC)


### PR DESCRIPTION
It's possible to use libponyc from projects other than ponyc. Using the
library gives you access to all the various compiler functionality. However,
it is hard to use the library because, you need to link in the correct libstdc++,
libblake, and LLVM. Figuring out what is the correct version of each is very
difficult.

With this change, a new library `libponyc-standalone.a` will be created as
part of the build process.

Applications like the "in pony documentation generator" that I am on will
be able to link to libponyc-standalone and pick up all it's required dependencies.

Windows, BSD, and macOS libraries are not created at this time but can be added
as needed in the future.