### PR TITLE
Fix symbol table patching for overriding default methods

### DIFF
--- a/.release-notes/3719.md
+++ b/.release-notes/3719.md
@@ -1,0 +1,21 @@
+## Fix symbol table patching for default implementations that replaces another method
+
+This release fixes a compiler crash that could happen when a default
+implementation replaced another method with the same signature. An example of
+this is when intersecting two interfaces that both have a method with the same
+signature and the second interface provides a default implementation:
+
+```pony
+interface A
+  fun f(): U32
+
+interface B
+  fun f(): U32 =>
+    let x: U32 = 42
+    x
+
+interface C is (A & B)
+```
+
+In this case, the default implementation was copied to `C`, but without its
+symbol table, subsequently resulting in a compiler crash.

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -542,7 +542,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
   // Trait provides default body. Use it and patch up symbol tables.
   pony_assert(ast_id(existing_body) == TK_NONE);
   ast_replace(&existing_body, method_body);
-  ast_visit(&method_body, rescope, NULL, opt, PASS_ALL);
+  ast_visit(&existing_body, rescope, NULL, opt, PASS_ALL);
 
   info->body_donor = (ast_t*)ast_data(method);
   info->trait_ref = trait_ref;

--- a/test/libponyc/traits.cc
+++ b/test/libponyc/traits.cc
@@ -579,6 +579,22 @@ TEST_F(TraitsTest, DiamondInheritance)
   TEST_EQUIV(src, expect);
 }
 
+TEST_F(TraitsTest, DefaultUsedInIntersection)
+{
+  const char* src =
+    "trait T1\n"
+    "  fun f(): U32\n"
+
+    "trait T2\n"
+    "  fun f(): U32 =>\n"
+    "    let x: U32 = 1\n"
+    "    x\n"
+
+    "class C is (T1 & T2)\n";
+
+  TEST_COMPILE(src);
+}
+
 
 // Method variety
 


### PR DESCRIPTION
`ast_replace` (potentially) copies the input AST, hence it's important
to do the symbol table patching on the output AST. Otherwise the
patching will happen on the wrong nodes, which leads to methods with
a wrong symbol table.

Fixes #3305