### PR TITLE
Fix early pipe shutdown with Windows ProcessMonitor

### DIFF
--- a/.release-notes/3674.md
+++ b/.release-notes/3674.md
@@ -1,0 +1,4 @@
+## Fix early pipe shutdown with Windows' ProcessMonitor
+
+Due to incorrect handling of a Windows pipe return value, the ProcessMonitor would sometimes shut down its pipe connections to external processes before it should have.
+


### PR DESCRIPTION
This commit fixes a fun bug that results from multiple bits coming together.

First, the ProcessMonitor when running on Windows doesn't using ASIO. Instead
of having events pushed to it, we poll periodically to see if there's anything
to read or if we can write any pending writes.

Because of the polling, it is possible that we will attempt to read when there's
no data in the pipe. When using non-blocking IO with pipes, a read that would return
0 bytes returns an error and sets the error code to a no data error code.

We were interpreting the no data code as it should be when using blocking io. When
using non-blocking io, there error communicates "no data right now, try again later"
which wasn't what we were doing.

The same incorrect handling of the "no data" error code was present in the write code
path as well. That has also been fixed.

Fixes #3674