### PR TITLE
Fix literal inference through partial function

### DIFF
--- a/.release-notes/3729.md
+++ b/.release-notes/3729.md
@@ -1,0 +1,3 @@
+## Fix literal inference with partial functions
+
+Before this change, code such as `1~add(2)` would hit an assertion error when the compiler tried to infer the type of the literal `2`. The compiler tries to find the type of the receiver of the function (in this case `1`), but before it lacked the ability to do so when using partial functions. In those cases, the compiler would try to look at the type of the `~` token, which is not a valid value literal, and as such it would fail.

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -789,8 +789,10 @@ static bool coerce_literal_to_type(ast_t** astp, ast_t* target_type,
       return true;
     }
 
+    case TK_TILDE:
     case TK_DOT:
     {
+      // Get real receiver
       ast_t* receiver = ast_child(literal_expr);
       if(!coerce_literal_to_type(&receiver, target_type, chain, opt,
         report_errors))

--- a/test/libponyc/literal_inference.cc
+++ b/test/libponyc/literal_inference.cc
@@ -364,6 +364,16 @@ TEST_F(LiteralTest, CantInfer_While_InvalidElseValue )
   TEST_ERROR(src);
 }
 
+// See #3531, inference wasn't being done across partial functions
+TEST_F(LiteralTest, CantApply_Partial_Function)
+{
+  const char* src =
+    "class Foo15c\n"
+    "  fun test() => \n"
+    "    1~add(1)\n";
+
+    TEST_ERROR(src);
+}
 
 
 


### PR DESCRIPTION
Before this change, code such as `1~add(2)` would hit an assertion error
when the compiler tried to infer the type of the literal 2. The compiler
tries to find the type of the receiver of the function, in this case
`1`, but it lacked the ability to do so when using partial functions. In
those cases, the compiler would try to look at the type of the `~`
token, which is not a valid value literal, and as such it would fail.

Fixes #3531