### PR TITLE
Annotate variadic FFI functions

### DIFF
--- a/examples/fan-in/main.pony
+++ b/examples/fan-in/main.pony
@@ -32,6 +32,7 @@ use "cli"
 use "collections"
 use "random"
 use "time"
+use @printf[I32](fmt: Pointer[U8] tag, ...)
 
 actor Main
   new create(env: Env) =>
@@ -242,7 +243,7 @@ actor Sender
     try
       _analyzers(_rand.int_unbiased[USize](_analyzers.size()))?.msg_from_sender()
     else
-      @printf[I32]("BBBBAAADDDD\n".cstring())
+      @printf("BBBBAAADDDD\n".cstring())
     end
 
     if not _done then

--- a/examples/message-ubench/main.pony
+++ b/examples/message-ubench/main.pony
@@ -30,6 +30,7 @@ use "cli"
 use "collections"
 use "random"
 use "time"
+use @printf[I32](fmt: Pointer[U8] tag, ...)
 
 actor Main
   new create(env: Env) =>
@@ -150,7 +151,7 @@ actor SyncLeader
     _done = done
 
     (let t_s: I64, let t_ns: I64) = Time.now()
-    @printf[I32]("%ld.%09ld".cstring(), t_s, t_ns)
+    @printf("%ld.%09ld".cstring(), t_s, t_ns)
     _current_t = to_ns(t_s, t_ns)
 
     for p in _ps.values() do
@@ -167,7 +168,7 @@ actor SyncLeader
     """
     _waiting_for = _waiting_for - 1
     if (_waiting_for is 0) then
-      @printf[I32](",".cstring())
+      @printf(",".cstring())
       for p in _ps.values() do
         p.report()
       end
@@ -191,7 +192,7 @@ actor SyncLeader
     if (_waiting_for is 0) then
       let run_ns: I64 = _current_t - _last_t
       let rate: I64 = (_partial_count.i64() * 1_000_000_000) / run_ns
-      @printf[I32]("%lld,%lld\n".cstring(), run_ns, rate)
+      @printf("%lld,%lld\n".cstring(), run_ns, rate)
 
       if not _done then
         (let t_s: I64, let t_ns: I64) = Time.now()

--- a/examples/under_pressure/main.pony
+++ b/examples/under_pressure/main.pony
@@ -59,6 +59,7 @@ use "backpressure"
 use "collections"
 use "net"
 use "time"
+use @printf[I32](fmt: Pointer[U8] tag, ...)
 
 class SlowDown is TCPConnectionNotify
   let _auth: BackpressureAuth
@@ -71,20 +72,20 @@ class SlowDown is TCPConnectionNotify
   fun ref connected(conn: TCPConnection ref) =>
     let bufsiz: U32 = 5000
 
-    @printf[I32]("Querying and setting socket options:\n".cstring())
-    @printf[I32]("\tgetsockopt so_error = %d\n".cstring(),
+    @printf("Querying and setting socket options:\n".cstring())
+    @printf("\tgetsockopt so_error = %d\n".cstring(),
       conn.get_so_error()._2)
-    @printf[I32]("\tgetsockopt get_tcp_nodelay = %d\n".cstring(),
+    @printf("\tgetsockopt get_tcp_nodelay = %d\n".cstring(),
       conn.get_tcp_nodelay()._2)
-    @printf[I32]("\tgetsockopt set_tcp_nodelay(true) return value = %d\n".cstring(),
+    @printf("\tgetsockopt set_tcp_nodelay(true) return value = %d\n".cstring(),
       conn.set_tcp_nodelay(true))
-    @printf[I32]("\tgetsockopt get_tcp_nodelay = %d\n".cstring(), conn.get_tcp_nodelay()._2)
+    @printf("\tgetsockopt get_tcp_nodelay = %d\n".cstring(), conn.get_tcp_nodelay()._2)
 
-    @printf[I32]("\tgetsockopt rcvbuf = %d\n".cstring(), conn.get_so_rcvbuf()._2)
-    @printf[I32]("\tgetsockopt sndbuf = %d\n".cstring(), conn.get_so_sndbuf()._2)
-    @printf[I32]("\tsetsockopt rcvbuf %d return was %d\n".cstring(), bufsiz,
+    @printf("\tgetsockopt rcvbuf = %d\n".cstring(), conn.get_so_rcvbuf()._2)
+    @printf("\tgetsockopt sndbuf = %d\n".cstring(), conn.get_so_sndbuf()._2)
+    @printf("\tsetsockopt rcvbuf %d return was %d\n".cstring(), bufsiz,
       conn.set_so_rcvbuf(bufsiz))
-    @printf[I32]("\tsetsockopt sndbuf %d return was %d\n".cstring(), bufsiz,
+    @printf("\tsetsockopt sndbuf %d return was %d\n".cstring(), bufsiz,
       conn.set_so_rcvbuf(bufsiz))
 
   fun ref throttled(connection: TCPConnection ref) =>
@@ -100,7 +101,7 @@ class SlowDown is TCPConnectionNotify
     Backpressure.release(_auth)
 
   fun ref connect_failed(conn: TCPConnection ref) =>
-    @printf[I32]("connect_failed\n".cstring())
+    @printf("connect_failed\n".cstring())
     None
 
 class Send is TimerNotify

--- a/packages/assert/assert.pony
+++ b/packages/assert/assert.pony
@@ -6,6 +6,8 @@ when your code was compiled with the `debug` flag, check out `Assert`. For
 assertions that are always enabled, check out `Fact`.
 """
 
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+
 primitive Assert
   """
   This is a debug only assertion. If the test is false, it will print any
@@ -24,7 +26,7 @@ primitive Fact
   fun apply(test: Bool, msg: String = "") ? =>
     if not test then
       if msg.size() > 0 then
-        @fprintf[I32](@pony_os_stderr[Pointer[U8]](), "%s\n".cstring(),
+        @fprintf(@pony_os_stderr[Pointer[U8]](), "%s\n".cstring(),
           msg.cstring())
       end
       error

--- a/packages/builtin/_to_string.pony
+++ b/packages/builtin/_to_string.pony
@@ -1,3 +1,8 @@
+use @snprintf[I32](str: Pointer[U8] tag, size: USize, fmt: Pointer[U8] tag, ...)
+  if not windows
+use @_snprintf[I32](str: Pointer[U8] tag, count: USize, fmt: Pointer[U8] tag, ...)
+  if windows
+
 primitive _ToString
   """
   Worker type providing simple to string conversions for numbers.
@@ -54,9 +59,9 @@ primitive _ToString
       var f = String(31) .> append("%g")
 
       ifdef windows then
-        @_snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
+        @_snprintf(s.cstring(), s.space(), f.cstring(), x)
       else
-        @snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
+        @snprintf(s.cstring(), s.space(), f.cstring(), x)
       end
 
       s .> recalc()

--- a/packages/capsicum/cap_rights.pony
+++ b/packages/capsicum/cap_rights.pony
@@ -1,4 +1,10 @@
 use "files"
+use @__cap_rights_init[Pointer[U64]](version: I32, rights: Pointer[U64], ...)
+  if freebsd or "capsicum"
+use @__cap_rights_clear[Pointer[U64]](rights: Pointer[U64], ...)
+  if freebsd or "capsicum"
+use @__cap_rights_set[Pointer[U64]](rights: Pointer[U64], ...)
+  if freebsd or "capsicum"
 
 type CapRights is CapRights0
 
@@ -59,12 +65,12 @@ class CapRights0
 
   fun ref set(cap: U64) =>
     ifdef freebsd or "capsicum" then
-      @__cap_rights_set[None](addressof _r0, cap, U64(0))
+      @__cap_rights_set(addressof _r0, cap, U64(0))
     end
 
   fun ref unset(cap: U64) =>
     ifdef freebsd or "capsicum" then
-      @__cap_rights_clear[None](addressof _r0, cap, U64(0))
+      @__cap_rights_clear(addressof _r0, cap, U64(0))
     end
 
   fun limit(fd: I32): Bool =>
@@ -98,7 +104,7 @@ class CapRights0
     Clear all rights.
     """
     ifdef freebsd or "capsicum" then
-      @__cap_rights_init[Pointer[U64]](I32(0), addressof _r0, U64(0))
+      @__cap_rights_init(_version(), addressof _r0, U64(0))
     end
 
   fun contains(that: CapRights0): Bool =>

--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -16,6 +16,8 @@ actor Main
     env.out.print("This will always be seen")
 ```
 """
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+
 primitive DebugOut
 primitive DebugErr
 
@@ -58,7 +60,7 @@ primitive Debug
 
   fun _print(msg: String, stream: DebugStream) =>
     ifdef debug then
-      @fprintf[I32](_stream(stream), "%s\n".cstring(), msg.cstring())
+      @fprintf(_stream(stream), "%s\n".cstring(), msg.cstring())
     end
 
   fun _stream(stream: DebugStream): Pointer[U8] =>

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -7,6 +7,8 @@ use @ponyint_o_trunc[I32]()
 use @ponyint_o_directory[I32]()
 use @ponyint_o_cloexec[I32]()
 use @ponyint_at_removedir[I32]()
+use @openat[I32](fd: I32, path: Pointer[U8] tag, flags: I32, ...)
+  if linux or bsd
 use @unlinkat[I32](fd: I32, target: Pointer[U8] tag, flags: I32)
 
 primitive _DirectoryHandle
@@ -51,7 +53,7 @@ class Directory
 
     ifdef posix then
       _fd =
-        @open[I32](from.path.cstring(),
+        @open(from.path.cstring(),
           @ponyint_o_rdonly()
             or @ponyint_o_directory()
             or @ponyint_o_cloexec())
@@ -99,7 +101,7 @@ class Directory
         let h =
           ifdef linux or bsd then
             let fd =
-              @openat[I32](fd', ".".cstring(),
+              @openat(fd', ".".cstring(),
                 @ponyint_o_rdonly()
                   or @ponyint_o_directory()
                   or @ponyint_o_cloexec())
@@ -159,7 +161,7 @@ class Directory
 
     ifdef linux or bsd then
       let fd' =
-        @openat[I32](_fd, target.cstring(),
+        @openat(_fd, target.cstring(),
           @ponyint_o_rdonly()
             or @ponyint_o_directory()
             or @ponyint_o_cloexec())
@@ -225,7 +227,7 @@ class Directory
 
     ifdef linux or bsd then
       let fd' =
-        @openat[I32](_fd, target.cstring(),
+        @openat(_fd, target.cstring(),
           @ponyint_o_rdwr()
             or @ponyint_o_creat()
             or @ponyint_o_cloexec(),
@@ -250,7 +252,7 @@ class Directory
 
     ifdef linux or bsd then
       let fd' =
-        @openat[I32](_fd, target.cstring(),
+        @openat(_fd, target.cstring(),
           @ponyint_o_rdonly() or @ponyint_o_cloexec(),
           I32(0x1B6))
       recover File._descriptor(fd', path')? end

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -1,3 +1,5 @@
+use @_open[I32](path: Pointer[U8] tag, flags: I32, ...) if windows
+use @open[I32](path: Pointer[U8] tag, flags: I32, ...) if not windows
 use @_read[I32](fd: I32, buffer: Pointer[None], bytes_to_read: I32) if windows
 use @read[ISize](fd: I32, buffer: Pointer[None], bytes_to_read: USize)
   if not windows
@@ -122,9 +124,9 @@ class File
       end
 
       _fd = ifdef windows then
-        @_open[I32](path.path.cstring(), flags, mode.i32())
+        @_open(path.path.cstring(), flags, mode.i32())
       else
-        @open[I32](path.path.cstring(), flags, mode)
+        @open(path.path.cstring(), flags, mode)
       end
 
       if _fd == -1 then
@@ -159,9 +161,9 @@ class File
       _errno = FileError
     else
       _fd = ifdef windows then
-        @_open[I32](path.path.cstring(), @ponyint_o_rdonly())
+        @_open(path.path.cstring(), @ponyint_o_rdonly())
       else
-        @open[I32](path.path.cstring(), @ponyint_o_rdonly())
+        @open(path.path.cstring(), @ponyint_o_rdonly())
       end
 
       if _fd == -1 then

--- a/packages/format/_format_float.pony
+++ b/packages/format/_format_float.pony
@@ -1,3 +1,8 @@
+use @snprintf[I32](str: Pointer[U8] tag, size: USize, fmt: Pointer[U8] tag, ...)
+  if not windows
+use @_snprintf[I32](str: Pointer[U8] tag, count: USize, fmt: Pointer[U8] tag, ...)
+  if windows
+
 primitive _FormatFloat
   """
   Worker type providing to string conversions for floats.
@@ -34,9 +39,9 @@ primitive _FormatFloat
       end
 
       ifdef windows then
-        @_snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
+        @_snprintf(s.cstring(), s.space(), f.cstring(), x)
       else
-        @snprintf[I32](s.cstring(), s.space(), f.cstring(), x)
+        @snprintf(s.cstring(), s.space(), f.cstring(), x)
       end
 
       s .> recalc()

--- a/packages/process/_pipe.pony
+++ b/packages/process/_pipe.pony
@@ -2,6 +2,7 @@ use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
       flags: U32, nsec: U64, noisy: Bool)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
+use @fcntl[I32](fd: U32, cmd: I32, ...)
 
 primitive _FSETFL
   fun apply(): I32 => 4
@@ -104,11 +105,11 @@ class _Pipe
     end
 
   fun _set_fd(fd: U32, flags: I32) ? =>
-    let result = @fcntl[I32](fd, _FSETFD(), flags)
+    let result = @fcntl(fd, _FSETFD(), flags)
     if result < 0 then error end
 
   fun _set_fl(fd: U32, flags: I32) ? =>
-    let result = @fcntl[I32](fd, _FSETFL(), flags)
+    let result = @fcntl(fd, _FSETFL(), flags)
     if result < 0 then error end
 
   fun ref begin(owner: AsioEventNotify) =>

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -199,7 +199,7 @@ actor ANSITerm
     """
     let ws: _TermSize = _TermSize
     ifdef posix then
-      @ioctl[I32](0, _TIOCGWINSZ(), ws) // do error handling
+      @ioctl(0, _TIOCGWINSZ(), ws) // do error handling
       _notify.size(ws.row, ws.col)
     end
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -117,10 +117,10 @@ TEST_F(BadPonyTest, TypeErrorInFFIArguments)
 {
   // From issue #2114
   const char *src =
-    "use @printf[None](argc: Pointer[U32])\n"
+    "use @foo[None](i: Pointer[U32])\n"
     "actor Main\n"
     "  fun create(env: Env) =>\n"
-    "    @printf(addressof U32(0))";
+    "    @foo(addressof U32(0))";
 
   TEST_ERRORS_1(src, "can only take the address of a local, field or method");
 }

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -717,6 +717,8 @@ TEST_F(CodegenTest, RepeatLoopBreakOnlyInBranches)
 TEST_F(CodegenTest, CycleDetector)
 {
   const char* src =
+    "use @printf[I32](fmt: Pointer[U8] tag, ...)\n"
+
     "actor Ring\n"
     "  let _id: U32\n"
     "  var _next: (Ring | None)\n"
@@ -754,7 +756,7 @@ TEST_F(CodegenTest, CycleDetector)
     "      end\n"
     "      _c = _c + 1\n"
     "      if _c > 50 then\n"
-    "        @printf[I32](\"Ran out of time... exit count is: %d instead of %d\n\".cstring(), @pony_get_exitcode[I32](), num)\n"
+    "        @printf(\"Ran out of time... exit count is: %d instead of %d\n\".cstring(), @pony_get_exitcode[I32](), num)\n"
     "        @pony_exitcode[None](I32(1))\n"
     "      else\n"
     "        check_done(num)\n"


### PR DESCRIPTION
In preparation of support of Apple silicon, add a declaration for all variadic FFI functions. This needs to be in place before the changes in #3731 can be applied.
