### PR TITLE
Fix setsockopt example in OSSockOpt docs

### DIFF
--- a/packages/net/ossockopt.pony
+++ b/packages/net/ossockopt.pony
@@ -51,7 +51,7 @@ primitive OSSockOpt
 
   /* In Pony */
   var option: I32 = 4455;
-  @pony_os_setsockopt[I32](fd, OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(),
+  @setsockopt[I32](fd, OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(),
     addressof option, I32(4))
   ```
   """


### PR DESCRIPTION
The example mentions the `@pony_os_setsockopt` function, which was
originally added in PR #2513, but eventually removed before the PR got
merged.