### PR TITLE
Fix memory corruption with Array.chop and String.chop

### DIFF
--- a/.release-notes/realloc-fix.md
+++ b/.release-notes/realloc-fix.md
@@ -1,0 +1,15 @@
+## Fix memory corruption of chopped Arrays and Strings
+
+With the introduction of `chop` on `Array` and `String` a few years ago, a constraint for the memory allocator was violated. This resulted in an optimization in the realloc code of the allocator no longer being safe.
+
+Prior to this fix, the following code would print `cats` and `sog`. After the fix, it doesn't corrupt memory and correctly prints `cats` and `dog`.
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let catdog = "catdog".clone().iso_array()
+    (let cat, let dog) = (consume catdog).chop(3)
+    cat.push('s')
+    env.out.print(consume cat)
+    env.out.print(consume dog)
+```

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -51,6 +51,7 @@ actor Main is TestList
     test(_TestStringRecalc)
     test(_TestStringTruncate)
     test(_TestStringChop)
+    test(_TestStringChopWithPush)
     test(_TestStringUnchop)
     test(_TestStringRepeatStr)
     test(_TestStringConcatOffsetLen)
@@ -68,6 +69,7 @@ actor Main is TestList
     test(_TestArrayFind)
     test(_TestArraySwapElements)
     test(_TestArrayChop)
+    test(_TestArrayChopWithPush)
     test(_TestArrayUnchop)
     test(_TestArrayFromCPointer)
     test(_TestMath128)
@@ -1189,6 +1191,19 @@ class iso _TestStringChop is UnitTest
     h.assert_eq[String box](expected_left, consume left)
     h.assert_eq[String box](expected_right, consume right)
 
+class iso _TestStringChopWithPush is UnitTest
+  """
+  Test chopping a string then pushing to the left side
+  """
+  fun name(): String => "builtin/String.chop_with_push"
+
+  fun apply(h: TestHelper) =>
+    let catdog = "catdog".clone()
+    (let cat, let dog) = (consume catdog).chop(3)
+    cat.push('s')
+    h.assert_eq[String box]("cats", consume cat)
+    h.assert_eq[String box]("dog", consume dog)
+
 class iso _TestStringUnchop is UnitTest
   """
   Test unchopping a string
@@ -1622,6 +1637,19 @@ class iso _TestArrayChop is UnitTest
     (let left: Array[U8] iso, let right: Array[U8] iso) = (consume orig).chop(split_point)
     h.assert_array_eq[U8](expected_left, consume left)
     h.assert_array_eq[U8](expected_right, consume right)
+
+class iso _TestArrayChopWithPush is UnitTest
+  """
+  Test chopping an array with a subsequent push to the left side
+  """
+  fun name(): String => "builtin/Array.chop_with_push"
+
+  fun apply(h: TestHelper) =>
+    let catdog: Array[U8] iso = recover iso ['c'; 'a'; 't'; 'd'; 'o'; 'g'] end
+    (let cat, let dog) = (consume catdog).chop(3)
+    cat.push('s')
+    h.assert_array_eq[U8](['c'; 'a'; 't'; 's'], consume cat)
+    h.assert_array_eq[U8](['d'; 'o'; 'g'], consume dog)
 
 class iso _TestArrayUnchop is UnitTest
   """

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -557,30 +557,9 @@ void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
     // Previous allocation was a ponyint_heap_alloc_small.
     void* ext = EXTERNAL_PTR(p, chunk->size);
 
-    // If the new allocation is a ponyint_heap_alloc_small and the pointer is
-    // not an internal pointer, we may be able to reuse this memory. If it is
-    // an internal pointer, we know where the old allocation begins but not
-    // where it ends, so we cannot reuse this memory.
-    if((size <= HEAP_MAX) && (p == ext))
-    {
-      uint32_t sizeclass = ponyint_heap_index(size);
-
-      // If the new allocation is the same size or smaller, return the old
-      // one.
-      if(sizeclass <= chunk->size)
-        return p;
-    }
-
     oldsize = SIZECLASS_SIZE(chunk->size) - ((uintptr_t)p - (uintptr_t)ext);
   } else {
     // Previous allocation was a ponyint_heap_alloc_large.
-    if((size <= chunk->size) && (p == chunk->m))
-    {
-      // If the new allocation is the same size or smaller, and this is not an
-      // internal pointer, return the old one. We can't reuse internal
-      // pointers in large allocs for the same reason as small ones.
-      return p;
-    }
 
     oldsize = chunk->size - ((uintptr_t)p - (uintptr_t)chunk->m);
   }


### PR DESCRIPTION
Both Array.chop and String.chop violate an expectation that the memory
allocator had.

The memory allocator was written before the standard library and assumed
it would be responsible for doing "smart things" with realloc. That is,
when you ask for a realloc, perhaps you don't really need it. Perhaps
you already have enough.

This worked without issue in the standard library until `chop` came along.
Chop turns a single previous object allocation into 2 and that confused
the memory allocator and could lead to it not reallocating (malloc and copy)
when safety required it. Instead it would return the same pointer it was given.

Based on how the Pony standard library ended up, with String and Array understanding
how much they allocated, we do not need that realloc behavior.

This commit removes the behavior from realloc and leaves it so that it will allows
do a malloc and copy which is what the standard library code expects it to do.