### PR TITLE
Fix NullablePointer type constraint check being omitted in FFI declarations

### DIFF
--- a/.release-notes/3758.md
+++ b/.release-notes/3758.md
@@ -1,0 +1,3 @@
+## Fix type constraint check against NullablePointer being omitted in FFI declarations
+
+This release fixes an issue where the compiler would not perform some type checks against FFI declarations. Specifically, the compiler would fail to validate that the type parameter to the `NullablePointer` type had to be a struct type. This check is important since a program that used a non-struct type in a `NullablePointer` could theoretically segfault at runtime.

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -524,10 +524,14 @@ ast_result_t pass_pre_expr(ast_t** astp, pass_opt_t* options)
   switch(ast_id(ast))
   {
     case TK_ARRAY: return expr_pre_array(options, astp);
-    case TK_USE:
-      // Don't look in use commands to avoid false type errors from the guard
-      return AST_IGNORE;
-
+    case TK_IFDEFNOT:
+    case TK_IFDEFAND:
+    case TK_IFDEFOR:
+    case TK_IFDEFFLAG:
+      // Don't look in guards for use commands to avoid false type errors
+      if((ast_parent(ast) != NULL) && (ast_id(ast_parent(ast)) == TK_USE))
+        return AST_IGNORE;
+      break;
     default: {}
   }
 

--- a/test/libponyc/ffi.cc
+++ b/test/libponyc/ffi.cc
@@ -5,6 +5,11 @@
 // FFI type checking tests
 
 #define TEST_ERROR(src) DO(test_error(src, "expr"))
+
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
 
 
@@ -200,4 +205,25 @@ TEST_F(FFITest, DeclarationAlias)
     "    @foo(x)";
 
   TEST_ERROR(src);
+}
+
+TEST_F(FFITest, DeclarationWithNullablePointer)
+{
+  // From issue #3757
+  const char* src =
+    "use @foo[NullablePointer[(U64, U64)]]()\n"
+    "use @bar[NullablePointer[P1]]()\n"
+    "primitive P1\n"
+
+    "actor Main\n"
+    " new create(env: Env) =>\n"
+    "   None";
+
+    TEST_ERRORS_2(src,
+      "NullablePointer[(U64 val, U64 val)] ref is not allowed: "
+        "the type argument to NullablePointer must be a struct",
+
+      "NullablePointer[P1 val] ref is not allowed: "
+        "the type argument to NullablePointer must be a struct");
+
 }


### PR DESCRIPTION
We're only interested in ignoring the "guard" part of a use command, but
we still want to go through the arguments to check for any possible
errors during the expr pass. In particular, we're interested in the
NullablePointer constraint check.

----

043dbb1ede410ab6432ef6d16edc73c7cebcaf82 added the original code that ignored `use` statements during the `expr` pass.

I don't know the specific rationale, but it seems we can do this check in a more fine-grained manner so that the rest of a `use` statement goes through the expr pass.

Fixes #3757 

Edit: I made this a draft PR since I'm sure there could be a better way of doing this if I understood the reason for ignoring `use` statements.