### PR TITLE
Remove whitespace-only lines from stdlib

### DIFF
--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -561,7 +561,7 @@ class iso _TestMultipleEndOfOptions is UnitTest
 
     let cmd = cmdErr as Command
     h.assert_eq[String]("corral/exec", cmd.fullname())
-    
+
     let argss = cmd.arg("args").string_seq()
     h.assert_eq[String]("lldb", argss(0)?)
     h.assert_eq[String]("ponyc", argss(1)?)
@@ -626,8 +626,8 @@ primitive _Fixtures
         ])?
       ])?
     ])?
-    
-  
+
+
   fun corral_spec(): CommandSpec box ? =>
     """
     A snippet from Corral's command spec to demonstrate multiple end of option arguments

--- a/packages/collections/list.pony
+++ b/packages/collections/list.pony
@@ -13,7 +13,7 @@ class List[A] is Seq[A]
 
   As you would expect. functions are provided to perform all the common list operations such as
   creation, traversal, node addition and removal, iteration, mapping, filtering, etc.
-  
+
   ## Example program
   There are a _lot_ of functions in List. The following code picks out a few common examples.
 
@@ -43,30 +43,30 @@ class List[A] is Seq[A]
       The size of our second partitioned list (doesn't match predicate): 1
       Our matching partition elements are:
         Second BOOM!
-  
+
   ```pony
     use "collections"
 
     actor Main
       new create(env:Env) =>
-        
+
         // Create a new empty List of type String
         let my_list = List[String]()
-        
+
         env.out.print("A new empty list has " + my_list.size().string() + " nodes.") // 0
-        
+
         // Push a String literal onto our empty List
         my_list.push("A single String")
         env.out.print("Adding one node to our empty list means it now has a size of "
                       + my_list.size().string() + ".") // 1
-        
+
         // Get the first element of our List
         try env.out.print("The first (index 0) node has the value: "
                           + my_list.index(0)?()?.string()) end // A single String
-        
+
         // Create a second List from a single String literal
         let my_second_list = List[String].unit("Another String")
-        
+
         // Append the second List to the first
         my_list.append_list(my_second_list)
         env.out.print("A list created by appending our second single-node list onto our first has size: "
@@ -78,7 +78,7 @@ class List[A] is Seq[A]
         // NOTE: this _moves_ the elements so second_list consequently ends up empty
         env.out.print("Append *moves* the nodes from the second list so that now has "
                       + my_second_list.size().string() + " nodes.") // 0
-        
+
         // Create a third List from a Seq(ence)
         // (In this case a literal array of Strings)
         let my_third_list = List[String].from(["First"; "Second"; "Third"])
@@ -87,7 +87,7 @@ class List[A] is Seq[A]
         for n in my_third_list.values() do
           env.out.print("\t" + n.string())
         end
-        
+
         // Map over the third List, concatenating some "BOOM!'s" into a new List
         let new_list = my_third_list.map[String]({ (n) => n + " BOOM!" })
         env.out.print("Mapping over our three-node list produces a new list of size: "
@@ -104,7 +104,7 @@ class List[A] is Seq[A]
         for n in filtered_list.values() do
           env.out.print("\t" + n.string()) // Second BOOM!\nThird BOOM!
         end
-        
+
         // Partition the filtered list
         let partitioned_lists = filtered_list.partition({ (n) => n.string().contains("Second") })
         env.out.print("The size of our first partitioned list (matches predicate): " + partitioned_lists._1.size().string())        // 1
@@ -114,7 +114,7 @@ class List[A] is Seq[A]
           env.out.print("\t" + n.string()) // Second BOOM!
         end
   ```
-  
+
   """
   var _head: (ListNode[A] | None) = None
   var _tail: (ListNode[A] | None) = None

--- a/packages/collections/list_node.pony
+++ b/packages/collections/list_node.pony
@@ -1,10 +1,10 @@
 class ListNode[A]
   """
   A node in a doubly linked list.
-  
+
   (See Ponylang [collections.List](https://stdlib.ponylang.io/collections-List/)
   class for usage examples.)
-  
+
   Each node contains four fields: two link fields (references to the previous and
   to the next node in the sequence of nodes), one data field, and the reference to
   the in which it resides.
@@ -18,7 +18,7 @@ class ListNode[A]
   [collections.List](https://stdlib.ponylang.io/collections-List/) class is the
   correct way to create these. _Do not attempt to create a Linked List using only
   ListNodes._
-  
+
   ## Example program
   The functions which are illustrated below are only those which operate on an
   individual ListNode.
@@ -34,14 +34,14 @@ class ListNode[A]
     use "collections"
     actor Main
       new create(env:Env) =>
-        
+
         // Create a new ListNode of type String
         let my_list_node = ListNode[String]("My Node item")
         try 
           env.out.print("My node has the item value: "
                         + my_list_node.apply()?) // My Node item
         end
-        
+
         // Update the item contained in the ListNode
         try
           my_list_node.update("My updated Node item")?
@@ -126,7 +126,7 @@ class ListNode[A]
     Append a node to this one. If `that` is already in a list, it is removed
     before it is appended. Returns true if `that` was removed from another
     list.
-    
+
     If the ListNode is not contained within a List the append will fail.
     """
     if (_next is that) or (this is that) then
@@ -158,7 +158,7 @@ class ListNode[A]
   fun ref remove() =>
     """
     Remove a node from a list.
-    
+
     The ListNode must be contained within a List for this to succeed.
     """
     match _list

--- a/packages/collections/sort.pony
+++ b/packages/collections/sort.pony
@@ -3,26 +3,26 @@ primitive Sort[A: Seq[B] ref, B: Comparable[B] #read]
   Implementation of dual-pivot quicksort.  It operates in-place on the provided Seq, using 
   a small amount of additional memory. The nature of the element-realation is expressed via 
   the supplied comparator.
-  
+
   (The following is paraphrased from [Wikipedia](https://en.wikipedia.org/wiki/Quicksort).)
-  
+
   Quicksort is a common implementation of a sort algorithm which can sort items of any type 
   for which a "less-than" relation (formally, a total order) is defined. 
-  
+
   On average, the algorithm takes O(n log n) comparisons to sort n items. In the worst case, 
   it makes O(n2) comparisons, though this behavior is rare.  Multi-pivot implementations 
   (of which dual-pivot is one) make efficient use of modern processor caches.
-  
+
   ## Example program
   The following takes an reverse-alphabetical array of Strings ("third", "second", "first"), 
   and sorts it in place alphabetically using the default String Comparator.
-  
+
   It outputs:
-    
+
   > first
   > second
   > third
-  
+
   ```pony
   use "collections"
 

--- a/packages/math/_test.pony
+++ b/packages/math/_test.pony
@@ -21,7 +21,7 @@ primitive _IsPrimeTestBuilder[A: (UnsignedInteger[A] val & Unsigned)]
   Since 2 divides (6k + 0), (6k + 2), 
   and (6k + 4), while 3 divides (6k + 3) that leaves only (6k - 1) and (6k + 1) 
   for expressing primes.
-  
+
   Given the above, (6k + 0), (6k + 2), 6k + 4), (6k + 3) should always express composites.
   """
   fun apply(s: String): UnitTest iso^ =>
@@ -43,7 +43,7 @@ primitive _IsPrimeTestBuilder[A: (UnsignedInteger[A] val & Unsigned)]
           let plusTwo: A = plusNone + 2
           let plusThree: A = plusNone + 3
           let plusFour: A = plusNone + 4
-          
+
           h.assert_false(IsPrime[A](plusNone))
           h.assert_false(IsPrime[A](plusTwo))
           h.assert_false(IsPrime[A](plusThree))

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -663,7 +663,7 @@ class _TestTCPProxyNotify is TCPConnectionNotify
   fun ref proxy_via(host: String, service: String): (String, String) =>
     _h.complete_action("sender proxy request")
     (host, service)
-    
+
   fun ref connected(conn: TCPConnection ref) =>
     _h.complete_action("sender connected")
 

--- a/packages/net/net_address.pony
+++ b/packages/net/net_address.pony
@@ -25,7 +25,7 @@ class val NetAddress is Equatable[NetAddress]
     """
     Port number in network byte order.
     """
-    
+
   let _addr: U32 = 0
     """
     IPv4 address in network byte order.

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -280,7 +280,7 @@ actor TCPConnection
     fun ref received(conn, data, times) => _wrapped.received(conn, data, times)
     fun ref connect_failed(conn: TCPConnection ref) => None
   ```
-  
+
   """
   var _listen: (TCPListener | None) = None
   var _notify: TCPConnectionNotify

--- a/packages/ponytest/test_helper.pony
+++ b/packages/ponytest/test_helper.pony
@@ -254,7 +254,7 @@ class val TestHelper
     The type parameter of this function is the type parameter of the
     elements in both ReadSeqs. For instance, when comparing two `Array[U8]`,
     you should call this method as follows:
-    
+
     ```pony
     fun apply(h: TestHelper) =>
       let a: Array[U8] = [1; 2; 3]
@@ -307,7 +307,7 @@ class val TestHelper
     The type parameter of this function is the type parameter of the
     elements in both ReadSeqs. For instance, when comparing two `Array[U8]`,
     you should call this method as follows:
-    
+
     ```pony
     fun apply(h: TestHelper) =>
       let a: Array[U8] = [1; 2; 3]


### PR DESCRIPTION
This small change removes whitespace-only lines from files in the standard library. All I did was run this with GNU Sed:

```sh
sed -i -sE 's|^\s+$||' packages/**/*.pony
```

You might want to [review this with whitespace changes disabled](https://github.com/ponylang/ponyc/pull/3761/files?w=1).

I don't think this merits a changelog update.

There may be some long-term improvements to make here, like an update to the style guide or adding some sort of autoformatter, but this is my first contribution!