### PR TITLE
Fix "iftype" expressions not being usable in lambdas or object literals

### DIFF
--- a/.release-notes/3763.md
+++ b/.release-notes/3763.md
@@ -1,0 +1,3 @@
+## Fix "iftype" expressions not being usable in lambdas or object literals
+
+This release fixes an issue where the compiler would hit an assertion error when compiling programs that placed `iftype` expressions inside lambdas or object literals.

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -208,6 +208,12 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast_id(ast) == TK_IFTYPE);
 
   AST_GET_CHILDREN(ast, subtype, supertype, body, typeparam_store);
+  // Prevent this from running again, if, for example, the iftype
+  // occurs inside an object literal (or lambda). In those cases,
+  // a "catch up" will take place and the compiler will try to run
+  // this pass again.
+  if(ast_id(typeparam_store) != TK_NONE)
+    return AST_IGNORE;
 
   ast_t* typeparams = ast_from(ast, TK_TYPEPARAMS);
 

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -368,3 +368,24 @@ TEST_F(IftypeTest, ReplaceTypeargs)
     "  new create(env: Env) => None";
   TEST_COMPILE(src);
 }
+
+TEST_F(IftypeTest, InsideLambda)
+{
+  // From #3762
+  const char* src =
+    "primitive DoIt[T: (U8 | I8)]\n"
+    "  fun apply(arg: T): T =>\n"
+    "    let do_it = {(v: T): T =>\n"
+    "      iftype T <: U8 then\n"
+    "        v\n"
+    "      else\n"
+    "        v\n"
+    "      end\n"
+    "    }\n"
+    "    do_it(arg)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+    TEST_COMPILE(src);
+}


### PR DESCRIPTION
Fixes #3762, but paging @jemc just in case he thinks if this should be fixed somewhere else in the compiler