### PR TITLE
Fix FFI definitions for vararg capsicum functions

### DIFF
--- a/packages/capsicum/cap_rights.pony
+++ b/packages/capsicum/cap_rights.pony
@@ -1,9 +1,9 @@
 use "files"
-use @__cap_rights_init[Pointer[U64]](version: I32, rights: Pointer[U64], ...)
+use @__cap_rights_init[Pointer[U64]](version: I32, ...)
   if freebsd or "capsicum"
-use @__cap_rights_clear[Pointer[U64]](rights: Pointer[U64], ...)
+use @__cap_rights_clear[Pointer[U64]](...)
   if freebsd or "capsicum"
-use @__cap_rights_set[Pointer[U64]](rights: Pointer[U64], ...)
+use @__cap_rights_set[Pointer[U64]](...)
   if freebsd or "capsicum"
 use @__cap_rights_get[I32](version: I32, fd: I32, rights: Pointer[U64])
   if freebsd or "capsicum"


### PR DESCRIPTION
The definitions of these functions appear to have a mixture of fixed and
optional parameters, but looking at [upstream definitions](https://github.com/freebsd/freebsd-src/blob/de1aa3dab23c06fec962a14da3e7b4755c5880cf/sys/sys/capsicum.h#L326-L340)
suggests that some of these functions should have different function
signatures.

For example, while the function __cap_rights_set is defined as taking a
fixed argument, the cap_rights_set calls it with __VA_ARGS__, which
means that all arguments are optional. In case of doubt, we should go
with what the macros do, to avoid any future failures during the verify
step of LLVM. In any case, upstream should probably fix these definitions.

---

This was causing a CI error for #3768, but it should probably go into its own PR for better visibility, so it should be merged before that one.
