### PR TITLE
Allow Flags instances to be created with a set bit encoding

### DIFF
--- a/.release-notes/3778.md
+++ b/.release-notes/3778.md
@@ -1,0 +1,6 @@
+## Allow Flags instances to be created with a set bit encoding
+
+Extending Flags.create to (optionally) allow initialization of a Flags
+object with the numeric representation populated. This value defaults
+to 0 (no flags set).
+

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -903,6 +903,20 @@ class iso _TestFlags is UnitTest
     h.assert_false(t(_TestFlagC))
     h.assert_false(t(_TestFlagD))
 
+    // Check instance creation default
+    t = _TestFlagsFlags
+    h.assert_false(t(_TestFlagA))
+    h.assert_false(t(_TestFlagB))
+    h.assert_false(t(_TestFlagC))
+    h.assert_false(t(_TestFlagD))
+
+    // Check instance creation with specified value
+    t = _TestFlagsFlags(0b1001)
+    h.assert_true(t(_TestFlagA))
+    h.assert_false(t(_TestFlagB))
+    h.assert_false(t(_TestFlagC))
+    h.assert_true(t(_TestFlagD))
+
 type _TestFlagsFlags is Flags[(_TestFlagA|_TestFlagB|_TestFlagC|_TestFlagD), U8]
 primitive _TestFlagA fun value(): U8 => 1
 primitive _TestFlagB fun value(): U8 => 2

--- a/packages/collections/flag.pony
+++ b/packages/collections/flag.pony
@@ -27,6 +27,13 @@ class Flags[A: Flag[B] val, B: (Unsigned & Integer[B] val) = U64] is
   """
   var _value: B = 0
 
+  new iso create(value': B = 0) =>
+    """
+    Create a Flags instance with an optional initial value.
+    Default is 0 (no flags set).
+    """
+    _value = value'
+
   fun value(): B =>
     """
     Returns the bit encoding of the set flags.


### PR DESCRIPTION
Extending Flags.create to (optionally) allow initialization of a
Flags object with the numeric representation populated. This value
defaults to 0 (no flags set).