### PR TITLE
Don't allow PONYPATH to override standard library

### DIFF
--- a/.release-notes/3779-fix.md
+++ b/.release-notes/3779-fix.md
@@ -1,0 +1,5 @@
+## Don't allow PONYPATH to override standard library
+
+Prior to this change, a library could contain a package called `builtin` that would override to standard library version. This could be an attack vector. You can still override the standard library location by using the ponyc `--paths` option.
+
+Any code which relied on the PONYPATH items being before the standard library in the package search path will need to switch to using `--paths` on the ponyc command line.

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -756,15 +756,18 @@ static bool add_exec_dir(pass_opt_t* opt)
 
 bool package_init(pass_opt_t* opt)
 {
-  // package_add_paths for command line paths has already been done. Here, we
-  // append the paths from an optional environment variable, and then the paths
-  // that are relative to the compiler location on disk.
-  package_add_paths(getenv("PONYPATH"), opt);
+  // package_add_paths for command line paths has already been done.
+  // Here, we add the package paths that are relative to the compiler location
+  // on disk. Then we append the paths from an optional environment variable
+  // PONYPATH. Previously we did PONYPATH before the compiler relative location,
+  // however, that allows packages to silently override the builtin module.
+  // See https://github.com/ponylang/ponyc/issues/3779
   if(!add_exec_dir(opt))
   {
     errorf(opt->check.errors, NULL, "Error adding package paths relative to ponyc binary location");
     return false;
   }
+  package_add_paths(getenv("PONYPATH"), opt);
 
   // Finally we add OS specific paths.
 #ifdef PLATFORM_IS_POSIX_BASED


### PR DESCRIPTION
Prior to this change, a library could contain a package called `builtin`
that would override to standard library version. This could be an attack
vector. You can still override the standard library location by using the
ponyc `--paths` option.

Any code which relied on the PONYPATH items being before the standard
library in the package search path will need to switch to using `--paths`
on the ponyc command line.

Closes #3779