### PR TITLE
Prevent non-opaque structs from being used as behaviour parameters

### DIFF
--- a/.release-notes/3765.md
+++ b/.release-notes/3765.md
@@ -1,0 +1,34 @@
+## Prevent non-opaque structs from being used as behaviour parameters
+
+When a non-opaque object is sent across actors, its type descriptor is used by the garbage collector in order to trace it. Since structs lack a type descriptor, using a `val` or `iso` struct as a parameter behaviour could lead to a runtime segfault. This also applies to tuple parameters where at least one element is a non-opaque struct.
+
+This is a breaking change. Existing code will need to wrap struct parameters in classes or structs, or use structs with a `tag` capability. Where you previously had code like:
+
+```pony
+struct Foo
+
+actor Main
+  new create(env: Env) =>
+    inspect(recover Foo end)
+
+  be inspect(f: Foo iso) =>
+    // Do something with f
+```
+
+you will now need
+
+```pony
+struct Foo
+
+class Bar
+  let f: Foo = Foo
+
+actor Main
+  new create(env: Env) =>
+    inspect(recover Bar end)
+
+  be inspect(wrap: Bar iso) =>
+    // Do something with wrap.f
+```
+
+When using tuples with struct elements, you don't need to wrap the entire tuple. It is enough to wrap the struct elements.

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -487,6 +487,95 @@ static bool show_partiality(pass_opt_t* opt, ast_t* ast)
   return false;
 }
 
+// From https://github.com/ponylang/ponyc/issues/3765:
+//
+// When an immutable object is sent across actors, the garbage collector traces
+// its associated object graph, using the associated type descriptor.
+// Structs don't have a type descriptor, so the GC can't trace them.
+//
+// An option is to track additional information for objects without type
+// descriptors, but this incurs in severe overhead for the normal case.
+//
+// Another option is to disallow non-opaque objects without type descriptors to
+// be the root of an object graph. Essentially, this means that one has to wrap
+// non-tag structs (and tuple containing non-tag structs, since the GC will try
+// to trace each element) inside another object with a type descriptor.
+bool verify_behaviour_root_struct_param(pass_opt_t* opt, ast_t* type, bool is_in_tuple)
+{
+  // For correct error location, keep track of the original AST node,
+  // even if we have to use the node's data as type node.
+  ast_t* type_node = type;
+  ast_t* cap = NULL;
+  if (ast_id(type) == TK_NOMINAL)
+  {
+    // We're still interested in the capability of the type as it was used,
+    // so save that information.
+    cap = ast_childidx(type, 3);
+    type = (ast_t*)ast_data(type);
+  }
+
+  switch(ast_id(type))
+  {
+    case TK_STRUCT:
+    {
+      if(cap == NULL)
+        cap = ast_childidx(type, 2);
+
+      if(ast_id(cap) == TK_TAG)
+        return true;
+
+      if(is_in_tuple)
+      {
+        ast_error(opt->check.errors, type_node,
+          "cannot use a tuple with a struct type member as parameter to a behaviour; "
+          "you will need to wrap the struct in a class or actor, "
+          "or change its capability to \"tag\"");
+      } else {
+        ast_error(opt->check.errors, type_node,
+          "only \"tag\" structs can be used as parameters to a behaviour; "
+          "you will need to wrap the struct in a class or actor, "
+          "or change its capability to \"tag\"");
+      }
+      ast_error_continue(opt->check.errors, type, "definition is here");
+      return false;
+    }
+
+    case TK_TUPLETYPE:
+    {
+      ast_t* member = ast_child(type);
+      while(member != NULL)
+      {
+        if(!verify_behaviour_root_struct_param(opt, member, true))
+          return false;
+        member = ast_sibling(member);
+      }
+    }
+
+    default: {}
+  }
+
+  return true;
+}
+
+bool verify_behaviour_parameters(pass_opt_t* opt, ast_t* ast)
+{
+  if(ast_id(ast) != TK_BE)
+    return true;
+
+  AST_GET_CHILDREN(ast, cap, id, typeparams, params, type, can_error, body);
+  ast_t* param = ast_child(params);
+  while(param != NULL)
+  {
+    ast_t* type = ast_type(param);
+    if(!verify_behaviour_root_struct_param(opt, type, false))
+      return false;
+
+    param = ast_sibling(param);
+  }
+
+  return true;
+}
+
 bool verify_fun(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert((ast_id(ast) == TK_BE) || (ast_id(ast) == TK_FUN) ||
@@ -498,7 +587,8 @@ bool verify_fun(pass_opt_t* opt, ast_t* ast)
     !verify_main_runtime_override_defaults(opt, ast) ||
     !verify_primitive_init(opt, ast) ||
     !verify_any_final(opt, ast) ||
-    !verify_any_serialise(opt, ast))
+    !verify_any_serialise(opt, ast) ||
+    !verify_behaviour_parameters(opt, ast))
     return false;
 
   // Check partial functions.

--- a/test/libponyc/codegen_trace.cc
+++ b/test/libponyc/codegen_trace.cc
@@ -522,14 +522,18 @@ TEST_F(CodegenTraceTest, TraceStructField)
     "struct Bar\n"
     "  let f: Foo = Foo\n"
 
+    "class WrapBar\n"
+    "  let s: Bar = Bar\n"
+
     "actor Main\n"
     "  new create(env: Env) =>\n"
-    "    trace(recover Bar end)\n"
+    "    trace(recover WrapBar end)\n"
 
-    "  be trace(x: Bar iso) =>\n"
+    "  be trace(w: WrapBar iso) =>\n"
+    "    let x = consume ref w\n"
     "    let map = @gc_local(this)\n"
-    "    let ok = @objectmap_has_object(map, x) and\n"
-    "      @objectmap_has_object_rc(map, x.f, USize(0))\n"
+    "    let ok = @objectmap_has_object(map, x.s) and\n"
+    "      @objectmap_has_object_rc(map, x.s.f, 0)\n"
     "    @pony_exitcode(I32(if ok then 1 else 0 end))";
 
   TEST_COMPILE(src);

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -5869,3 +5869,41 @@ TEST_F(VerifyTest,
 
   TEST_COMPILE(src);
 }
+
+// From issue #3765
+TEST_F(VerifyTest, NonRootStructBehaviourParam)
+{
+  const char* src =
+    "struct iso AA\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "inspect(AA)\n"
+
+      "be inspect(a: AA val) => None";
+
+  TEST_ERRORS_1(src,
+    "only \"tag\" structs can be used as parameters to a behaviour; "
+    "you will need to wrap the struct in a class or actor, "
+    "or change its capability to \"tag\""
+  )
+}
+
+// From issue #3765
+TEST_F(VerifyTest, NonRootStructTupleBehaviourParam)
+{
+  const char* src =
+    "struct iso AA\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "inspect((AA, 0))\n"
+
+      "be inspect(a: (AA val, U8)) => None";
+
+  TEST_ERRORS_1(src,
+    "cannot use a tuple with a struct type member as parameter to a behaviour; "
+    "you will need to wrap the struct in a class or actor, "
+    "or change its capability to \"tag\""
+  )
+}


### PR DESCRIPTION
When an immutable object is sent across actors, the garbage collector
traces its associated object graph, using the type descriptor of the
root object. Structs don't have a type descriptor, so the GC can't trace
them.

An option is to track additional information for objects without type
descriptors, but this incurs in severe overhead for the normal case.

Another option, what this commit does, is to disallow non-opaque objects
without type descriptors to be the root of an object graph when used as
parameters to behaviours. Essentially, this means that one has to wrap
non-tag structs inside another object with a type descriptor. This also
applies to structs inside tuples, since the GC will try to trace each
element in the tuple.

---

Fixes #3765