### PR TITLE
Add support for prebuilt Rocky Linux versions

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/Dockerfile
@@ -1,0 +1,30 @@
+FROM rockylinux/rockylinux:8
+
+RUN yum install -y \
+    dnf-plugins-core \
+    epel-release \
+  && yum config-manager --set-enabled powertools
+
+RUN yum install -y \
+    clang \
+    diffutils \
+    git \
+    libatomic \
+    libstdc++-static \
+    make \
+    python3-pip \
+    zlib-devel \
+  && pip3 install cloudsmith-cli
+
+# install a newer cmake
+RUN curl --output cmake-3.15.3-Linux-x86_64.sh https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh \
+ && sh cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+
+# this broken, incorrect libstdc++.a breaks building libponc-standalone.a
+# so, let's delete it!
+RUN rm /usr/lib/gcc/x86_64-redhat-linux/8/32/libstdc++.a
+
+# add user pony in order to not run tests as root
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+NAME="ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,6 +6,13 @@ task:
   only_if: $CIRRUS_PR != ''
 
   matrix:
+  - name: "PR: x86-64-unknown-linux-rocky8"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+    environment:
+      CACHE_BUSTER: 20210707
+      TRIPLE_VENDOR: unknown
+      TRIPLE_OS: linuxrocky8
   - name: "PR: x86-64-unknown-linux-centos8"
     container:
       image: ponylang/ponyc-ci-x86-64-unknown-linux-centos8-builder:20210225
@@ -245,6 +252,13 @@ task:
   only_if: $CIRRUS_CRON == "nightly"
 
   matrix:
+    - name: "nightly: x86-64-unknown-linux-rocky8"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+      environment:
+        CACHE_BUSTER: 20210707
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-rocky8
     - name: "nightly: x86-64-unknown-linux-centos8"
       container:
         image: ponylang/ponyc-ci-x86-64-unknown-linux-centos8-builder:20210225
@@ -391,6 +405,13 @@ task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
 
   matrix:
+    - name: "release: x86-64-unknown-linux-rocky8"
+      container:
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+      environment:
+        CACHE_BUSTER: 20210707
+        TRIPLE_VENDOR: unknown
+        TRIPLE_OS: linux-rocky8
     - name: "release: x86-64-unknown-linux-centos8"
       container:
         image: ponylang/ponyc-ci-x86-64-unknown-linux-centos8-builder:20210225

--- a/.release-notes/rocky.md
+++ b/.release-notes/rocky.md
@@ -1,0 +1,7 @@
+## Add prebuilt ponyc binaries for Rocky Linux 8
+
+Prebuilt nightly versions of ponyc are now available from our [Cloudsmith nightlies repo](https://cloudsmith.io/~ponylang/repos/nightlies/packages/). Release versions will be available in the [release repo](https://cloudsmith.io/~ponylang/repos/releases/packages/) starting with this release.
+
+CentOS 8 releases were added as we currently support CentOS 8, but it will be discontinued in a few months and Rocky Linux provides a seamless transition path.
+
+If you are a Pony user and are looking for prebuilt releases for your distribution, open an issue and let us know. We'll do our best to add support for any Linux distribution version that is still supported by their creators.

--- a/BUILD.md
+++ b/BUILD.md
@@ -63,6 +63,7 @@ Distribution | Requires
 Alpine | cmake, g++, libexecinfo, make
 CentOS 8 | clang, cmake, diffutils, libatomic, libstdc++-static, make, zlib-devel
 Fedora | cmake, gcc-c++, libatomic, libstdc++-static, make
+Rocky | clang, cmake, diffutils, libatomic, libstdc++-static, make, zlib-devel
 Ubuntu | cmake, g++, make
 
 Note that you only need to run `make libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).


### PR DESCRIPTION
With CentOS 8 no longer being supported as of the end of 2021, many of
the former CentOS users are migrating to Rocky Linux which offers the
same model that CentOS previously offered.

By adding nightly and release version now, we'll be ready when CentOS 8
is discontinued to provide a path for any CentOS pony users.

Another PR will come once we have a release version of pony out and we
have added support in ponyup to add installation instructions for Rocky
Linux.