### PR TITLE
Fix libponyrt CMakeLists.txt for standalone build.

### DIFF
--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -48,7 +48,7 @@ set(_c_src
     sched/start.c
 )
 
-set(_ll_except_src "${CMAKE_SOURCE_DIR}/src/libponyrt/lang/except_try_catch.ll")
+set(_ll_except_src "${CMAKE_CURRENT_SOURCE_DIR}/lang/except_try_catch.ll")
 set(_ll_except_obj "${CMAKE_BINARY_DIR}/except_try_catch.o")
 
 find_file(_llc_command


### PR DESCRIPTION
This commit changes `src/libponyrt/CMakeLists.txt`
to prefer `${CMAKE_CURRENT_SOURCE_DIR}` (which refers to `src/libponyrt`)
over `${CMAKE_SOURCE_DIR}/src/libponyrt` (which is a more roundabout way
of referring to the same directory, but breaks if you try to use `src/libponyrt`
as the root source directory for CMake).

This change makes it possible to build `libponyrt.bc` by itself,
without building anything else in the repo, with a sequence of commands like this:

```
mkdir src/libponyrt/build
env CC=clang CXX=clang++ cmake -S src/libponyrt -B src/libponyrt/build -DPONY_RUNTIME_BITCODE=true
env cmake --build src/libponyrt/build --target libponyrt_bc
```

This doesn't require building LLVM (i.e. `make libs`) or anything else in the repo,
so the whole build process completes within a few seconds.