### PR TITLE
Add README for each examples/ entry

### DIFF
--- a/examples/circle/README.md
+++ b/examples/circle/README.md
@@ -1,0 +1,42 @@
+# circle
+
+Define, instantiate, and summarize a set of circles. Our `Circle` class only requires defining the radius of the circle and from that radius we are able to calculate the area and circumference of the corresponding circle.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./circle.o
+Linking ./circle
+```
+
+## How to Run
+
+Once `circle` has been compiled, in the same directory as this README file run `./circle`. You should see a series of circle definitions printed, which ends with:
+
+```console
+$ ./circle
+...
+Radius: 98
+Circumference: 615.752
+Area: 30171.9
+
+Radius: 99
+Circumference: 622.035
+Area: 30790.8
+
+Radius: 100
+Circumference: 628.319
+Area: 31415.9
+```

--- a/examples/circle/README.md
+++ b/examples/circle/README.md
@@ -40,3 +40,28 @@ Radius: 100
 Circumference: 628.319
 Area: 31415.9
 ```
+
+## Program Modifications
+
+Modify the program to add a `get_diameter()` method and print the diameter alongside the other measures -- diameter is two times the radius.
+
+```console
+$ ./circle
+...
+Radius: 98
+Diameter: 196
+Circumference: 615.752
+Area: 30171.9
+
+Radius: 99
+Diameter: 198
+Circumference: 622.035
+Area: 30790.8
+
+Radius: 100
+Diameter: 200
+Circumference: 628.319
+Area: 31415.9
+```
+
+For further modification, modify the program so that `get_circumference()` is calculated using your `get_diameter()` method.

--- a/examples/commandline/README.md
+++ b/examples/commandline/README.md
@@ -1,0 +1,54 @@
+# commandline
+
+A naive `echo` program which repeats its arguments, optionally uppercase words.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./commandline.o
+Linking ./commandline
+```
+
+## How to Run
+
+Once `commandline` has been compiled, in the same directory as this README file run `./commandline Example words to echo`. You should see your same message repeated back to you:
+
+```console
+$ ./commandline Example words to echo
+Example words to echo
+```
+
+We can access a help message by using `--help`.
+
+```console
+$ ./commandline --help
+usage: echo [<options>] <words>
+
+A sample echo program
+
+Options:
+   -h, --help=false     
+   -U, --upper=false    Uppercase words
+
+Args:
+   <words>    The words to echo
+```
+
+From here we can see that there is an option to uppercase words (`-U`).
+
+```console
+$ ./commandline -U Example words to echo
+EXAMPLE WORDS TO ECHO 
+```

--- a/examples/commandline/README.md
+++ b/examples/commandline/README.md
@@ -52,3 +52,14 @@ From here we can see that there is an option to uppercase words (`-U`).
 $ ./commandline -U Example words to echo
 EXAMPLE WORDS TO ECHO 
 ```
+
+## Program Modifications
+
+Modify the program to have a new option called "lower" which works similar to "upper" except that it uses `String.lower()` rather than `String.upper()`.
+
+```console
+$ ./commandline --lower EXAMPLE WORDS TO ECHO
+example words to echo
+```
+
+For further modification, modify the program so that using both options `./commandline --upper --lower ...` prints an error then the help message.

--- a/examples/commandline/README.md
+++ b/examples/commandline/README.md
@@ -39,7 +39,7 @@ usage: echo [<options>] <words>
 A sample echo program
 
 Options:
-   -h, --help=false     
+   -h, --help=false
    -U, --upper=false    Uppercase words
 
 Args:
@@ -50,7 +50,7 @@ From here we can see that there is an option to uppercase words (`-U`).
 
 ```console
 $ ./commandline -U Example words to echo
-EXAMPLE WORDS TO ECHO 
+EXAMPLE WORDS TO ECHO
 ```
 
 ## Program Modifications

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,55 @@
+# counter
+
+An asynchronous, shared counter. This example shows something subtle: a way to safely "share mutable data" by dedicating a data owner, then communicating with that owner.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./counter.o
+Linking ./counter
+```
+
+## How to Run
+
+Once `counter` has been compiled, in the same directory as this README file run `./counter`. You should see your count:
+
+```console
+$ ./counter 100
+100
+```
+
+If you want to prove to yourself that the counter is running in realtime, you can add the following behaviors to see more output.
+
+```pony
+actor Counter
+...
+  be is_running(main: Main) =>
+    main.still_running()
+...
+
+actor Main
+...
+    for i in Range[U32](0, count) do
+      counter.increment()
+      counter.is_running(this)
+    end
+...
+  be still_running() =>
+    _env.out.print("Your message here")
+```
+
+Doing this will print "Your message here" after each `increment()`.
+
+As an exercise, modify the program to have `Main` `display(...)` the current count after each `counter.increment()` -- hint: you need to add a parameter to the `increment()` behavior.

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -30,7 +30,9 @@ $ ./counter 100
 100
 ```
 
-If you want to prove to yourself that the counter is running in realtime, you can add the following behaviors to see more output.
+## Program Modifications
+
+If you want to prove to yourself that the counter is running in realtime (rather than pre-computing the result), you can add the following behaviors to see more output.
 
 ```pony
 actor Counter
@@ -52,4 +54,4 @@ actor Main
 
 Doing this will print "Your message here" after each `increment()`.
 
-As an exercise, modify the program to have `Main` `display(...)` the current count after each `counter.increment()` -- hint: you need to add a parameter to the `increment()` behavior.
+As an exercise, modify the program so you `display(...)` the current count after each `counter.increment()` -- hint: you need to add a parameter to the `increment()` behavior.

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -1,0 +1,45 @@
+# echo
+
+A simple server which echos back the data that it is sent.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./echo.o
+Linking ./echo
+```
+
+## How to Run
+
+Once `echo` has been compiled, in the same directory as this README file run `./echo`. You should see a message containing your local address and a randomly selected port number:
+
+```console
+$ ./echo
+listening on 127.0.0.1:40503
+```
+
+If you visit this address using a web browser, you will see further output:
+
+```console
+$ ./echo
+listening on 127.0.0.1:40503
+connection accepted
+data received, looping it back
+...
+```
+
+## Program Modifications
+
+TODO: Add content here

--- a/examples/echo/README.md
+++ b/examples/echo/README.md
@@ -28,18 +28,39 @@ Once `echo` has been compiled, in the same directory as this README file run `./
 ```console
 $ ./echo
 listening on 127.0.0.1:40503
+...
 ```
 
-If you visit this address using a web browser, you will see further output:
+Your program is now listening for any message sent to your local address on the selected port number. To check the program is working as intended, you should open a second terminal window and run the following `netcat` command matching the local address and port from the `echo` program:
 
 ```console
-$ ./echo
-listening on 127.0.0.1:40503
-connection accepted
-data received, looping it back
+$ nc 127.0.0.1 40503
+...
+```
+
+This gives us a client which we can use to send `echo` a message. try typing any message and the `echo` program will echo it back to you.
+
+```console
+$ nc 127.0.0.1 40503
+Hello world!
+server says: Hello world!
 ...
 ```
 
 ## Program Modifications
 
-TODO: Add content here
+Modify your program to send a welcome message to a user which provides instructions on interacting with the server.
+
+```console
+$ ./echo
+listening on 127.0.0.1:40503
+...
+```
+
+```console
+$ nc 127.0.0.1 40503
+Welcome! Write your message below then hit the Enter key.
+Hello world!
+server says: Hello world!
+...
+```

--- a/examples/fan-in/README.md
+++ b/examples/fan-in/README.md
@@ -1,0 +1,52 @@
+# fan-in
+
+A program simulating thundering herd/fan-in type workloads and how the Pony runtime backpressure impacts such workloads.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./fan-in.o
+Linking ./fan-in
+```
+
+## How to Run
+
+Once `fan-in` has been compiled, in the same directory as this README file run `./fan-in`. You should see a message containing the number of senders, analyzers, analyzer-interval, analyzer-report-count, and receiver-workload -- all configurable by CLI arguments (see `./fan-in --help` for details) -- followed by the timestamp, the run time in nanoseconds, and the rate of work. Let the program run to the end of message sending.
+
+```console
+$ ./fan-in
+# senders 100, analyzers 1000, analyzer-interval 100, analyzer-report-count 10, receiver-workload 10000
+time,run-ns,rate
+...
+Done with message sending... Waiting for Receiver to work through its backlog...
+```
+
+The rate of work should drop occasionally -- this is the backpressure system catching up with work from the thundering herd/fan-in. If the rate does not drop, try changing the CLI arguments to increase the workload.
+
+## Program Modifications
+
+Modify the program to print a message when backpressure is being experienced.
+
+```console
+$ ./fan-in
+# senders 100, analyzers 1000, analyzer-interval 100, analyzer-report-count 10, receiver-workload 10000
+time,run-ns,rate
+...
+1627792832506124895,9999369982,24400146
+1627792842505604411,9999479516,122  # Backpressure experienced
+1627792852503830247,9998225836,23161873
+...
+Done with message sending... Waiting for Receiver to work through its backlog...
+```

--- a/examples/ffi-callbacks/README.md
+++ b/examples/ffi-callbacks/README.md
@@ -46,7 +46,6 @@ Whenever we interface with C code, we need to tell the Pony compiler how to find
 
 There are two ways of doing this. One is by adding a `use path:XXX` statement to our Pony code, like in our example:
 
-
 ```pony
 use "path:./"
 use "lib:ffi-callbacks"

--- a/examples/ffi-callbacks/README.md
+++ b/examples/ffi-callbacks/README.md
@@ -1,0 +1,59 @@
+# ffi-callbacks
+
+This program shows how to pass Pony functions as callbacks to C functions. In this example, the `Main` actor uses two ways to do so: either via bare functions, or using bare lambdas. The C code then calls this callback with some hard-coded arguments. For more information on bare functions and bare lambdas, check the [Callbacks](https://tutorial.ponylang.io/c-ffi/callbacks.html) section of the C-FFI tutorial.
+
+## How to Compile
+
+The first step is to compile our C code to a shared library. For this example, we're using `clang` on macOS. The exact details may vary when using other compilers and platforms, so be sure to check the appropriate documentation. Run the following commands in the same directory as this README:
+
+```console
+clang -fPIC -Wall -Wextra -g -MM callbacks.c > callbacks.d
+clang -fPIC -Wall -Wextra -g -c -o callbacks.o callbacks.c
+clang -shared -o libffi-callbacks.dylib callbacks.o
+```
+
+Now we should be ready to compile our Pony code. With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ffi-callbacks.o
+Linking ./ffi-callbacks
+```
+
+## How to Run
+
+Once `ffi-callbacks` has been compiler, in the same directory as this README file run `./ffi-callbacks`. You should see the number `10` printed three times:
+
+```console
+$ ./ffi-callbacks
+10
+10
+10
+```
+
+## Program Modifications
+
+Whenever we interface with C code, we need to tell the Pony compiler how to find and link the C libraries we're using. By default, the Pony compiler will look for libraries in standard places. In our case, since we're compiling a C library in another directory, we will need to be explicit.
+
+There are two ways of doing this. One is by adding a `use path:XXX` statement to our Pony code, like in our example:
+
+
+```pony
+use "path:./"
+use "lib:ffi-callbacks"
+```
+
+This tells the compiler to include the current path when linking our code. Another option is to use the `--path <path>` option in the Pony compiler. Try deleting the `use "path:./"` line from the Pony code, and running `ponyc` again. The compiler should show an error about being "unable to link" our callback library.
+
+Now try passing the `--path .` option to `ponyc` when building the code. Everything should be fine again, and by running the resulting program, you should be able to see the same output as before.
+
+For further modification, modify the Pony and C code so that you can change which number is passed to the Pony callback. You can do this by adding a new parameter to the `do_callback` function and to the `CB` type. Remember to update the FFI signature of `do_callback`!

--- a/examples/ffi-callbacks/README.md
+++ b/examples/ffi-callbacks/README.md
@@ -7,7 +7,6 @@ This program shows how to pass Pony functions as callbacks to C functions. In th
 The first step is to compile our C code to a shared library. For this example, we're using `clang` on macOS. The exact details may vary when using other compilers and platforms, so be sure to check the appropriate documentation. Run the following commands in the same directory as this README:
 
 ```console
-clang -fPIC -Wall -Wextra -g -MM callbacks.c > callbacks.d
 clang -fPIC -Wall -Wextra -g -c -o callbacks.o callbacks.c
 clang -shared -o libffi-callbacks.dylib callbacks.o
 ```

--- a/examples/ffi-callbacks/README.md
+++ b/examples/ffi-callbacks/README.md
@@ -31,7 +31,7 @@ Linking ./ffi-callbacks
 
 ## How to Run
 
-Once `ffi-callbacks` has been compiler, in the same directory as this README file run `./ffi-callbacks`. You should see the number `10` printed three times:
+Once `ffi-callbacks` has been compiled, in the same directory as this README file run `./ffi-callbacks`. You should see the number `10` printed three times:
 
 ```console
 $ ./ffi-callbacks

--- a/examples/ffi-callbacks/callbacks.pony
+++ b/examples/ffi-callbacks/callbacks.pony
@@ -40,3 +40,4 @@ actor Main
     let cfp = ContainsFunctionPointer
     // The partial application of a bare method yields a bare lambda.
     cfp.ptr = Callback~callback()
+    @do_callback(cfp.ptr, env)

--- a/examples/ffi-struct/README.md
+++ b/examples/ffi-struct/README.md
@@ -1,0 +1,59 @@
+# ffi-struct
+
+This program shows how to use the Pony `struct` type, as well as passing them to C functions. In this example, the `Main` actor passes both the `Outer` and `Inner` types as a struct pointer to C. The C code then modifies these structures. For more information on Pony structs, check the [Working with Structs](https://tutorial.ponylang.io/c-ffi/calling-c.html#working-with-structs-from-pony-to-c) section of the C-FFI tutorial.
+
+## How to Compile
+
+The first step is to compile our C code to a shared library. For this example, we're using `clang` on macOS. The exact details may vary when using other compilers and platforms, so be sure to check the appropriate documentation. Run the following commands in the same directory as this README:
+
+```console
+clang -fPIC -Wall -Wextra -g -c -o struct.o struct.c
+clang -shared -o libffi-struct.dylib struct.o
+```
+
+Now we should be ready to compile our Pony code. With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ffi-struct.o
+Linking ./ffi-struct
+```
+
+## How to Run
+
+Once `ffi-struct` has been compiled, in the same directory as this README file run `./ffi-struct`. You should see the following output:
+
+```console
+$ ./ffi-struct
+10
+15
+5
+5
+```
+
+## Program Modifications
+
+Whenever we interface with C code, we need to tell the Pony compiler how to find and link the C libraries we're using. By default, the Pony compiler will look for libraries in standard places. In our case, since we're compiling a C library in another directory, we will need to be explicit.
+
+There are two ways of doing this. One is by adding a `use path:XXX` statement to our Pony code, like in our example:
+
+
+```pony
+use "path:./"
+use "lib:ffi-struct"
+```
+
+This tells the compiler to include the current path when linking our code. Another option is to use the `--path <path>` option in the Pony compiler. Try deleting the `use "path:./"` line from the Pony code, and running `ponyc` again. The compiler should show an error about being "unable to link" our struct library.
+
+Now try passing the `--path .` option to `ponyc` when building the code. Everything should be fine again, and by running the resulting program, you should be able to see the same output as before.
+
+For further modification, add new C functions that take an integer and return an `Inner*` or `Outer*` struct, respectively. Then modify the Pony code so that it calls these functions and prints to screen their fields. Remember, you will need to allocate the structs in C! Hint: you can use the `NullablePointer` type to handle possible `null` pointers in Pony. You can read the [Working with Structs: from C to Pony](https://tutorial.ponylang.io/c-ffi/calling-c.html#working-with-structs-from-c-to-pony) section of the tutorial for more information.

--- a/examples/ffi-struct/README.md
+++ b/examples/ffi-struct/README.md
@@ -46,7 +46,6 @@ Whenever we interface with C code, we need to tell the Pony compiler how to find
 
 There are two ways of doing this. One is by adding a `use path:XXX` statement to our Pony code, like in our example:
 
-
 ```pony
 use "path:./"
 use "lib:ffi-struct"

--- a/examples/files/README.md
+++ b/examples/files/README.md
@@ -48,7 +48,7 @@ Modify the program to print the file contents with line numbers.
 $ ./files files.pony
 /home/ryan/dev/github.com/ponylang/ponyc/examples/files/files.pony
 1 use "files"
-2 
+2
 3 actor Main
 4   new create(env: Env) =>
 ...

--- a/examples/files/README.md
+++ b/examples/files/README.md
@@ -1,0 +1,60 @@
+# files
+
+A program which shows the basic usage of the "files" package by reading the path of the file and its contents.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./files.o
+Linking ./files
+```
+
+## How to Run
+
+Once `files` has been compiled, in the same directory as this README file run `./files files.pony`. You should see the absolute path of the `files.pony` source file, as well as its contents.
+
+```console
+$ ./files files.pony
+/home/ryan/dev/github.com/ponylang/ponyc/examples/files/files.pony
+use "files"
+
+actor Main
+  new create(env: Env) =>
+...
+    else
+      try
+        env.out.print("Couldn't open " + env.args(1)?)
+      end
+    end
+```
+
+## Program Modifications
+
+Modify the program to print the file contents with line numbers.
+
+```console
+$ ./files files.pony
+/home/ryan/dev/github.com/ponylang/ponyc/examples/files/files.pony
+1 use "files"
+2 
+3 actor Main
+4   new create(env: Env) =>
+...
+16    else
+17      try
+18        env.out.print("Couldn't open " + env.args(1)?)
+19      end
+20    end
+```

--- a/examples/gups_basic/README.md
+++ b/examples/gups_basic/README.md
@@ -1,6 +1,6 @@
 # gups_basic
 
-A program which...
+A program which runs a benchmark calculating GUPS (Giga updates per second) -- a random access metric.
 
 ## How to Compile
 
@@ -26,7 +26,7 @@ Linking ./gups_basic
 Once `gups_basic` has been compiled, in the same directory as this README file run `./gups_basic`. You should see a message containing the elapsed time and GUPS (Giga updates per second) for the run. The settings of a run are configurable by CLI arguments (see `./gups_basic --help` for details).
 
 ```console
-$ ./gups_basic 
+$ ./gups_basic
 Time: 0.594845 GUPS: 0.0688583
 ```
 

--- a/examples/gups_basic/README.md
+++ b/examples/gups_basic/README.md
@@ -1,0 +1,35 @@
+# gups_basic
+
+A program which...
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./gups_basic.o
+Linking ./gups_basic
+```
+
+## How to Run
+
+Once `gups_basic` has been compiled, in the same directory as this README file run `./gups_basic`. You should see a message containing the elapsed time and GUPS (Giga updates per second) for the run. The settings of a run are configurable by CLI arguments (see `./gups_basic --help` for details).
+
+```console
+$ ./gups_basic 
+Time: 0.594845 GUPS: 0.0688583
+```
+
+## Program Modifications
+
+This program is a benchmark and should be read rather than modified as a learning exercise.

--- a/examples/gups_opt/README.md
+++ b/examples/gups_opt/README.md
@@ -1,4 +1,4 @@
-# gups_opts
+# gups_opt
 
 A program which runs a benchmark calculating GUPS (Giga updates per second) -- a random access metric.
 

--- a/examples/gups_opt/README.md
+++ b/examples/gups_opt/README.md
@@ -26,7 +26,7 @@ Linking ./gups_opt
 Once `gups_opt` has been compiled, in the same directory as this README file run `./gups_opt`. You should see a message containing the settings, elapsed time, and GUPS (Giga updates per second) for the run. The settings of a run are configurable by CLI arguments (see `./gups_opt --help` for details).
 
 ```console
-$ ./gups_opt 
+$ ./gups_opt
 logtable: 20
 iterate: 10000
 logchunk: 10

--- a/examples/gups_opt/README.md
+++ b/examples/gups_opt/README.md
@@ -1,0 +1,40 @@
+# gups_opts
+
+A program which runs a benchmark calculating GUPS (Giga updates per second) -- a random access metric.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./gups_opt.o
+Linking ./gups_opt
+```
+
+## How to Run
+
+Once `gups_opt` has been compiled, in the same directory as this README file run `./gups_opt`. You should see a message containing the settings, elapsed time, and GUPS (Giga updates per second) for the run. The settings of a run are configurable by CLI arguments (see `./gups_opt --help` for details).
+
+```console
+$ ./gups_opt 
+logtable: 20
+iterate: 10000
+logchunk: 10
+logactors: 2
+Time: 0.114243
+GUPS: 0.358534
+```
+
+## Program Modifications
+
+This program is a benchmark and should be read rather than modified as a learning exercise.

--- a/examples/helloworld/README.md
+++ b/examples/helloworld/README.md
@@ -26,7 +26,7 @@ Linking ./helloworld
 Once `helloworld` has been compiled, in the same directory as this README file run `./helloworld`. You should see a brief hello.
 
 ```console
-$ ./helloworld 
+$ ./helloworld
 Hello, world.
 ```
 

--- a/examples/helloworld/README.md
+++ b/examples/helloworld/README.md
@@ -1,0 +1,45 @@
+# helloworld
+
+A program running the classic "Hello, world." learning example.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./helloworld.o
+Linking ./helloworld
+```
+
+## How to Run
+
+Once `helloworld` has been compiled, in the same directory as this README file run `./helloworld`. You should see a brief hello.
+
+```console
+$ ./helloworld 
+Hello, world.
+```
+
+## Program Modifications
+
+Modify the program to say hello to a specific name by first commandline argument -- when no argument is given, default to the world.
+
+```console
+$ ./helloworld Ryan
+Hello, Ryan.
+```
+
+```console
+$ ./helloworld
+Hello, world.
+```

--- a/examples/ifdef/README.md
+++ b/examples/ifdef/README.md
@@ -1,0 +1,80 @@
+# ifdef
+
+A program showing use of compile-time build flags.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ifdef.o
+Linking ./ifdef
+```
+
+## How to Run
+
+Once `ifdef` has been compiled, in the same directory as this README file run `./ifdef`. You should see three lines of output (yours may differ from below).
+
+```console
+$ ./ifdef 
+Hello Linux
+4
+Not failing
+```
+
+## Program Modifications
+
+As this program is showing compile-time build flags, you should leave the program as-is, but modify how you build the program.
+
+Try enabling the "foo" build flag to change the middle line of output.
+
+```console
+$ ponyc -D=foo
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ifdef.o
+Linking ./ifdef
+```
+
+```console
+$ ./ifdef 
+Hello Linux
+3
+Not failing
+```
+
+Try compiling with the "fail" build flag to see what a `compile_error` looks like.
+
+```console
+$ ponyc -D=fail
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+Error:
+/home/ryan/dev/github.com/ponylang/ponyc/examples/ifdef/ifdef.pony:39:7: compile error: We don't support failing
+      compile_error "We don't support failing"
+      ^
+```

--- a/examples/ifdef/README.md
+++ b/examples/ifdef/README.md
@@ -26,7 +26,7 @@ Linking ./ifdef
 Once `ifdef` has been compiled, in the same directory as this README file run `./ifdef`. You should see three lines of output (yours may differ from below).
 
 ```console
-$ ./ifdef 
+$ ./ifdef
 Hello Linux
 4
 Not failing
@@ -55,7 +55,7 @@ Linking ./ifdef
 ```
 
 ```console
-$ ./ifdef 
+$ ./ifdef
 Hello Linux
 3
 Not failing

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -1,0 +1,60 @@
+# lambda
+
+A program showing how to create and call lambda functions.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./lambda.o
+Linking ./lambda
+```
+
+## How to Run
+
+Once `lambda` has been compiled, in the same directory as this README file run `./lambda`. You should see a three line output showing the results of our lambdas.
+
+```console
+$ ./lambda
+Add: 9
+Mult: 18
+Error: 0
+```
+
+What is not immediately obvious while looking at our results or at the program itself is that Pony lambdas, just like all things in Pony, are objects. Lambdas are object literals with a single `apply` function defined the same as the lambda.
+
+```pony
+{(a: U32, b: U32): U32 => a + b }
+```
+
+is rewritten by the compiler to
+
+```pony
+object
+  fun apply(a: U32, b: U32): U32 => a + b
+end
+```
+
+The lambda syntax is often cleaner to read, while the object literal syntax is equivalent in functionality. Use whichever fits your needs!
+
+## Program Modifications
+
+Modify the program to replace each lambda with its object literal equivalent. The output should not change!
+
+```console
+$ ./lambda
+Add: 9
+Mult: 18
+Error: 0
+```

--- a/examples/mailbox/README.md
+++ b/examples/mailbox/README.md
@@ -1,0 +1,54 @@
+# mailbox
+
+A program which stress tests Pony's mailbox system.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./mailbox.o
+Linking ./mailbox
+```
+
+## How to Run
+
+Once `mailbox` has been compiled, in the same directory as this README file run `./mailbox`. You should the usage statement showing that the program requires positional arguments.
+
+```console
+$ ./mailbox
+mailbox OPTIONS
+  N   number of sending actors
+  M   number of messages to pass from each sender to the receiver
+```
+
+If we instead run this program with positional arguments we will see no output, but it will take time to run.
+
+```console
+$ ./mailbox 100 1000000
+
+```
+
+Try setting both positional arguments high enough that you have time to observe how memory usage changes while the program is running.
+
+## Program Modifications
+
+Modify the program to respond to every 1000 "pongs" by telling the user the current number of "pongs" processed.
+
+```console
+$ ./mailbox 100 1000000
+Processed 1000 pongs so far.
+Processed 2000 pongs so far.
+...
+Processed 100000000 pongs so far.
+```

--- a/examples/mailbox/README.md
+++ b/examples/mailbox/README.md
@@ -35,8 +35,7 @@ mailbox OPTIONS
 If we instead run this program with positional arguments we will see no output, but it will take time to run.
 
 ```console
-$ ./mailbox 100 1000000
-
+./mailbox 100 1000000
 ```
 
 Try setting both positional arguments high enough that you have time to observe how memory usage changes while the program is running.

--- a/examples/mandelbrot/README.md
+++ b/examples/mandelbrot/README.md
@@ -1,0 +1,62 @@
+# mandelbrot
+
+A program showing an example of how to implement a divide-and-conquer algorithm to plot a Mandelbrot set.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./mandelbrot.o
+Linking ./mandelbrot
+```
+
+## How to Run
+
+Once `mandelbrot` has been compiled, in the same directory as this README file run `./mandelbrot --output output.pbm`. After the program finishes executing, you should see that a file named `output.pbm` has been created in the same directory.
+
+If you have a suitable Netpbm viewer program, you can open this file directly. If you don't, you can use the `convert` tool (included in the ImageMagick Tools) to convert the output to a PNG image, using the following command:
+
+```console
+convert output.pbm PNG:output.png
+```
+
+You should now be able to open the PNG image, and see a depiction of a Mandelbrot set.
+
+## Program Modifications
+
+The program accepts different command-line arguments to modify the final image. You can run `./mandelbrot --help` to see them all:
+
+```console
+./mandelbrot --help
+
+usage: run [<options>] [<args> ...]
+
+Plot a Mandelbrot set using a divide-and-conquer algorithm.
+
+The output can be viewed directly with a suitable Netpbm viewer, or converted
+to a PNG with the following command
+(ImageMagick Tools required):
+
+  convert <output>.pbm PNG:<output>.png
+
+Options:
+   -i, --iterations=50    Maximum amount of iterations to be done for each pixel.
+   -w, --width=16000      Lateral length of the resulting mandelbrot image.
+   -c, --chunks=16        Maximum line count of chunks the image should be divided into for divide & conquer processing.
+   -h, --help=false       
+   -o, --output=          File to write the output to.
+   -l, --limit=4          Square of the limit that pixels need to exceed in order to escape from the Mandelbrot set.
+```
+
+You can tune the number of chunks (using the `--chunks` flag) that the image will be divided into, and see how it affects the time it takes for the program to finish.

--- a/examples/mandelbrot/README.md
+++ b/examples/mandelbrot/README.md
@@ -54,7 +54,7 @@ Options:
    -i, --iterations=50    Maximum amount of iterations to be done for each pixel.
    -w, --width=16000      Lateral length of the resulting mandelbrot image.
    -c, --chunks=16        Maximum line count of chunks the image should be divided into for divide & conquer processing.
-   -h, --help=false       
+   -h, --help=false
    -o, --output=          File to write the output to.
    -l, --limit=4          Square of the limit that pixels need to exceed in order to escape from the Mandelbrot set.
 ```

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -75,8 +75,10 @@ class val Config
   new val create(env: Env) ? =>
     let cs = CommandSpec.leaf("run",
       """
-      The binary output can be converted to a PNG with the following command
-      (ImageMagick Tools required):
+      Plot a Mandelbrot set using a divide-and-conquer algorithm.
+
+      The output can be viewed directly with a suitable Netpbm viewer, or converted
+      to a PNG with the following command (ImageMagick Tools required):
 
         convert <output> PNG:<output>.png""",
       [

--- a/examples/message-ubench/README.md
+++ b/examples/message-ubench/README.md
@@ -1,0 +1,63 @@
+# message-ubench
+
+A program simulating high message passing workloads and how the Pony runtime throughput responds to such workloads.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./message-ubench.o
+Linking ./message-ubench
+```
+
+## How to Run
+
+Once `message-ubench` has been compiled, in the same directory as this README file run `./message-ubench`. You should see a message containing the number of pingers, report interval, report count, and initial pings -- all configurable by CLI arguments (see `./message-ubench --help` for details) -- followed by the timestamp, the run time in nanoseconds, and the rate of work. By default this program run infinitely so you will need to kill/cancel the program at some point to proceed.
+
+```console
+$ ./message-ubench
+# pingers 8, report-interval 10, report-count 0, initial-pings 5
+time,run-ns,rate
+1629166694.245655917,999491638,18797083
+1629166695.244990149,999289492,21825087
+...
+```
+
+To create a run which does not run infinitely, you need to modify `--report-count` to define how many reports to generate before exiting.
+
+```console
+$ ./message-ubench --report-count 5
+# pingers 8, report-interval 10, report-count 0, initial-pings 5
+time,run-ns,rate
+1629167112.067643792,999387696,18909804
+1629167113.066978277,999285041,23451868
+1629167114.066308216,999281458,23511351
+1629167115.065636018,999293718,23549719
+1629167116.064974250,999304040,24435030
+```
+
+## Program Modifications
+
+Modify the program to change the number of messages "in flight" at any one time by causing Pingers to send two messages to their evenly indexed neighbors and no messages to their oddly indexed neighbors. Hint: modify `send_pings()` and use `(n % 2) == 0` to determine how many messages to send to neighbor `n`.
+
+```console
+$ ./message-ubench --report-count 5
+# pingers 8, report-interval 10, report-count 5, initial-pings 5
+time,run-ns,rate
+1629168710.593900613,999775030,412
+1629168711.593643741,999427681,2593
+1629168712.592208576,998285666,9065
+1629168713.591799316,999430123,2883
+1629168714.591319039,999361155,7306
+```

--- a/examples/mixed/README.md
+++ b/examples/mixed/README.md
@@ -1,0 +1,61 @@
+# mixed
+
+A program simulating rings of interconnected actors passing messages.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./mixed.o
+Linking ./mixed
+```
+
+## How to Run
+
+Once `mixed` has been compiled, in the same directory as this README file run `./mixed`. You should see a message showing the order of arguments -- number of rings, number of actors in each rin, number of messages to pass, and number of times to repeat.
+
+```console
+$ ./mixed
+mixed OPTIONS
+  N   number of rings
+  N   number of actors in each ring
+  N   number of messages to pass around each ring
+  N   number of times to repeat
+```
+
+To create a run which does work we must provide these arguments.
+
+```console
+./mixed 100 50 25 10
+```
+
+The above run has 100 rings with 50 actors in each passing 25 messages 10 times. You will notice there is no output to the console from this program.
+
+## Program Modifications
+
+Modify the program to use default values when no arguments are passed, but fail if non-numeric arguments are passed.
+
+```console
+./mixed
+```
+
+```console
+./mixed 100 50 25 nonsense
+Error: "nonsense" is not a valid arguement for number of times to repeat.
+mixed OPTIONS
+  N   number of rings
+  N   number of actors in each ring
+  N   number of messages to pass around each ring
+  N   number of times to repeat
+```

--- a/examples/mixed/main.pony
+++ b/examples/mixed/main.pony
@@ -122,9 +122,9 @@ actor Main
     _env.out.print(
       """
       mixed OPTIONS
-        N   number of actors in each ring"
-        N   number of rings"
-        N   number of messages to pass around each ring"
-        N   number of times to repeat"
+        N   number of rings
+        N   number of actors in each ring
+        N   number of messages to pass around each ring
+        N   number of times to repeat
       """
       )

--- a/examples/n-body/README.md
+++ b/examples/n-body/README.md
@@ -1,0 +1,46 @@
+# n-body
+
+A program representing an N-body simulation of five planetary bodies: Sun, Jupiter, Saturn, Uranus, and Neptune.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./n-body.o
+Linking ./n-body
+```
+
+## How to Run
+
+Once `n-body` has been compiled, in the same directory as this README file run `./n-body`. You should a measurement of the initial energy of the system. The program will continue running for a set number of cycles (by default, 50000000) then print the resulting energy of the system.
+
+```console
+$ ./n-body
+-0.169075
+-0.16906
+```
+
+To create a run which runs for a different number of cycles, provide a numeric argument.
+
+```console
+./n-body 100000000
+-0.169075
+-0.169035
+```
+
+The above run doubles the default number of cycles.
+
+## Program Modifications
+
+Modify the program to make `Body` a trait/interface and create classes for `Sun`, `Jupiter`, `Saturn`, `Uranus`, and `Neptune` which satisfy `Body`.

--- a/examples/net/README.md
+++ b/examples/net/README.md
@@ -1,0 +1,85 @@
+# net
+
+A program showing a Ping-Pong server.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./net.o
+Linking ./net
+```
+
+## How to Run
+
+Once `net` has been compiled, in the same directory as this README file run `./net`. You should see messages pertaining to clients being spawned, pings/pongs being sent, and the address/port each entity is listening on. Your output is not likely to match below, but you should see similar output.
+
+```console
+$ ./net
+listening on 127.0.0.1:40199
+spawn 1
+Client starting
+Pong: listening on 127.0.0.1:49486
+Ping: listening on 127.0.0.1:51350
+from 127.0.0.1:51350
+ping!
+Pong: closed
+from 127.0.0.1:49486
+pong!
+Ping: closed
+Server starting
+connecting: 1
+connected to 127.0.0.1:40199
+accepted from 127.0.0.1:53680
+client says hi
+server says hi
+client closed
+server closed
+```
+
+You can control the number of clients spawned by providing a numeric argument to `net` -- you will get a message for each spawn along with similar output as before.
+
+```console
+$ ./net 5
+listening on 127.0.0.1:41487
+spawn 1
+...
+spawn 2
+...
+spawn 3
+...
+spawn 4
+...
+spawn 5
+Client starting
+accepted from 127.0.0.1:50910
+client says hi
+client closed
+server says hi
+server closed
+Server starting
+connecting: 1
+client closed
+connected to 127.0.0.1:41487
+accepted from 127.0.0.1:50912
+server closed
+server says hi
+client says hi
+client closed
+server closed
+```
+
+## Program Modifications
+
+Modify the program to make use of `env.err.print` (as opposed to `env.out.print`) when things go wrong. Hint: look for uses of `try`-blocks to determine when things go wrong.

--- a/examples/overload/README.md
+++ b/examples/overload/README.md
@@ -1,0 +1,50 @@
+# overload
+
+A program simulating a single actor, `Receiver`, being overloaded with messages from `Sender`s. The Pony backpressure system prevents runaway memory growth by preventing `Sender`s from being scheduled until the `Receiver` is no longer overloaded.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./overload.o
+Linking ./overload
+```
+
+## How to Run
+
+Once `overload` has been compiled, in the same directory as this README file run `./overload`. You should a report of the number of senders, the single receiver starting, then messages about the number of messages received in a given timeframe. (This program will loop infinitely so you will need to force it to step.)
+
+```console
+$ ./overload
+Starting 10000 senders.
+Single receiver started.
+50000000 messages received in 10761731202 nanos.
+100000000 messages received in 12065642226 nanos.
+150000000 messages received in 13481541604 nanos.
+...
+```
+
+## Program Modifications
+
+Modify the program to allow providing the number of senders at the commandline interface.
+
+```console
+$ ./overload 2000000
+Starting 2000000 senders.
+Single receiver started.
+50000000 messages received in 9110934011 nanos.
+100000000 messages received in 9233131150 nanos.
+150000000 messages received in 9110256111 nanos.
+...
+```

--- a/examples/overload/README.md
+++ b/examples/overload/README.md
@@ -23,7 +23,7 @@ Linking ./overload
 
 ## How to Run
 
-Once `overload` has been compiled, in the same directory as this README file run `./overload`. You should a report of the number of senders, the single receiver starting, then messages about the number of messages received in a given timeframe. (This program will loop infinitely so you will need to force it to step.)
+Once `overload` has been compiled, in the same directory as this README file run `./overload`. You should see a report of the number of senders, the single receiver starting, then messages about the number of messages received in a given timeframe. (This program will loop infinitely so you will need to force it to step.)
 
 ```console
 $ ./overload

--- a/examples/ponybench/README.md
+++ b/examples/ponybench/README.md
@@ -23,7 +23,7 @@ Linking ./ponybench
 
 ## How to Run
 
-Once `ponybench` has been compiled, in the same directory as this README file run `./ponybench`. You should see a benchmark report including: benchmark name, mean, median, deviation, and interations.
+Once `ponybench` has been compiled, in the same directory as this README file run `./ponybench`. You should see a benchmark report including: benchmark name, mean, median, deviation, and iterations.
 
 ```console
 $ ./ponybench

--- a/examples/ponybench/README.md
+++ b/examples/ponybench/README.md
@@ -1,0 +1,59 @@
+# ponybench
+
+A program showing use of the `ponybench` package.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ponybench.o
+Linking ./ponybench
+```
+
+## How to Run
+
+Once `ponybench` has been compiled, in the same directory as this README file run `./ponybench`. You should see a benchmark report including: benchmark name, mean, median, deviation, and interations.
+
+```console
+$ ./ponybench
+Benchmark results will have their mean and median adjusted for overhead.
+You may disable this with --noadjust.
+
+Benchmark                                   mean            median   deviation  iterations
+Nothing                                     0 ns              0 ns      ±0.57%     5000000
+_Fib(5)                                    48 ns             48 ns      ±1.20%     2000000
+_Fib(10)                                  494 ns            495 ns      ±0.39%      300000
+_Fib(20)                                63498 ns          63550 ns      ±0.42%        2000
+_Timer (10000 ns)                        6025 ns           6060 ns      ±2.66%       20000
+```
+
+## Program Modifications
+
+Modify the program to add a benchmark using the math package's `Fibonacci` primitive.
+
+```console
+$ ./ponybench
+Benchmark results will have their mean and median adjusted for overhead.
+You may disable this with --noadjust.
+
+Benchmark                                   mean            median   deviation  iterations
+Nothing                                     0 ns              0 ns      ±0.76%     5000000
+_Fib(5)                                    39 ns             39 ns      ±0.87%     2000000
+_FibStd(5)                                 35 ns             35 ns      ±0.62%     2000000
+_Fib(10)                                  467 ns            468 ns      ±0.96%      300000
+_FibStd(10)                                63 ns             63 ns      ±0.83%     2000000
+_Fib(20)                                59269 ns          59379 ns      ±0.94%        3000
+_FibStd(20)                               131 ns            129 ns      ±7.57%     1000000
+_Timer(10000 ns)                         6101 ns           6078 ns      ±2.78%       20000
+```

--- a/examples/ponybench/main.pony
+++ b/examples/ponybench/main.pony
@@ -49,7 +49,7 @@ class iso _Timer is AsyncMicroBenchmark
     _ns = ns
 
   fun name(): String =>
-    "_Timer (" + _ns.string() + " ns)"
+    "_Timer(" + _ns.string() + " ns)"
 
   fun apply(c: AsyncBenchContinue) =>
     _ts(Timer(

--- a/examples/printargs/README.md
+++ b/examples/printargs/README.md
@@ -1,0 +1,56 @@
+# printargs
+
+A program showing use of the `cli` package to read/print commandline arguments and environment variables.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./printargs.o
+Linking ./printargs
+```
+
+## How to Run
+
+Once `printargs` has been compiled, in the same directory as this README file run `./printargs`. You should an echo of your command along with arguments followed by your environment variables. (You will likely have far more environment variables than what is shown below.)
+
+```console
+$ ./printargs
+./printargs This is a test
+...
+SHELL = /bin/bash
+USER = ryan
+HOME = /home/ryan
+LANGUAGE = en_US
+...
+```
+
+## Program Modifications
+
+Modify the program to take commands which print only arguments or environment variables.
+
+```console
+$ ./printargs args This is a test
+./printargs args This is a test
+```
+
+```console
+$ ./printargs env
+...
+SHELL = /bin/bash
+USER = ryan
+HOME = /home/ryan
+LANGUAGE = en_US
+...
+```

--- a/examples/producer-consumer/README.md
+++ b/examples/producer-consumer/README.md
@@ -1,0 +1,41 @@
+# producer-consumer
+
+A program showing the producer–consumer problem (also called the bounded-buffer problem) solved with actors.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./producer-consumer.o
+Linking ./producer-consumer
+```
+
+## How to Run
+
+Once `producer-consumer` has been compiled, in the same directory as this README file run `./producer-consumer`. You should a set of messages from: Main, Buffer, Producer, and Consumer actors.
+
+```console
+$ ./producer-consumer
+**Main** Finished.
+**Buffer** Permission_to_produce
+**Buffer** Permission_to_produce: Calling producer to produce
+...
+**Buffer** Store_product
+**Buffer** Store_product: Calling consumer to consume
+**Consumer** Consuming product 2
+```
+
+## Program Modifications
+
+Rather than modifying this program, pay attention to how the use of behaviors means this program is non-blocking and does not use locks/semaphores.

--- a/examples/readline/README.md
+++ b/examples/readline/README.md
@@ -49,7 +49,7 @@ Use 'quit' to exit.
 4 > count
 Current count is: 4
 5 > history
-Commands: 
+Commands:
   This
   is
   a

--- a/examples/readline/README.md
+++ b/examples/readline/README.md
@@ -1,0 +1,67 @@
+# readline
+
+A program showing usage of `Readline` from the `term` package.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./readline.o
+Linking ./readline
+```
+
+## How to Run
+
+Once `readline` has been compiled, in the same directory as this README file run `./readline`. You should see an brief message about how to exit followed by an interactive prompt. Use "quit" to exit.
+
+```console
+$ ./readline
+Use 'quit' to exit.
+0 > This
+1 > is
+2 > a
+3 > test
+4 > quit
+```
+
+## Program Modifications
+
+In addition to the "quit" command, add commands such as "count" which prints the current count number and "history" which prints the history of commands entered.
+
+```console
+$ ./readline
+Use 'quit' to exit.
+0 > This
+1 > is
+2 > a
+3 > test
+4 > count
+Current count is: 4
+5 > history
+Commands: 
+  This
+  is
+  a
+  test
+  count
+6 > history
+Commands:
+  This
+  is
+  a
+  test
+  count
+  history
+7 > quit
+```

--- a/examples/ring/README.md
+++ b/examples/ring/README.md
@@ -1,0 +1,49 @@
+# ring
+
+A program showing rings of actors passing messages.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./ring.o
+Linking ./ring
+```
+
+## How to Run
+
+Once `ring` has been compiled, in the same directory as this README file run `./ring`. You should see a single number printed.
+
+```console
+$ ./ring
+2
+```
+
+What this program is doing is setting up a ring of actors (each with an ID starting at 1), passing a set of messages, and the final actor to receive the message prints its ID.
+
+This program has arguments which can be seen using `--help`.
+
+```console
+$ ./ring --help
+rings OPTIONS
+  --size N number of actors in each ring
+  --count N number of rings
+  --pass N number of messages to pass around each ring
+```
+
+As stated above, `--size` changes the number of actors in a ring, `--count` changes the number of rings, and `--pass` changes the number of messages to pass. By default `--size` is 3, `--count` is 1, and `--pass` is 10.
+
+## Program Modifications
+
+Notice something about this program: any random argument will display the "help message" such as `./ring --this-is-not-an-argument`. Modify the program to use the `cli` package so that it has a defined `--help` command and rejects such random arguments.

--- a/examples/spreader/README.md
+++ b/examples/spreader/README.md
@@ -1,0 +1,54 @@
+# spreader
+
+A program producing a binary tree of actors at a given depth, which then counts/reports the number of actors in the tree.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./spreader.o
+Linking ./spreader
+```
+
+## How to Run
+
+Once `spreader` has been compiled, in the same directory as this README file run `./spreader`. You should see a message reporting the number of actors in the tree.
+
+```console
+$ ./spreader
+1023 actors
+```
+
+This program can take a numeric arguments stating the depth of the tree to build (the default is 10).
+
+```console
+$ ./spreader 5
+31 actors
+```
+
+## Program Modifications
+
+Modify this program to print its total depth.
+
+```console
+$ ./spreader 5
+31 actors at depth 5
+```
+
+Additionally, add a second argument for the branching factor.
+
+```console
+$ ./spreader 5 3
+242 actors at depth 5 with branch factor of 3
+```

--- a/examples/timers/README.md
+++ b/examples/timers/README.md
@@ -1,0 +1,42 @@
+# timers
+
+A program showing use of `Timer` to track time via behaviors.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./timers.o
+Linking ./timers
+```
+
+## How to Run
+
+Once `timers` has been compiled, in the same directory as this README file run `./timers`. You should see a message about one timer being canceled early, the other will continue running.
+
+```console
+$ ./timers
+timer cancelled
+timer: 1
+timer: 2
+...
+timer: 8
+timer: 9
+timer: 10
+timer cancelled
+```
+
+## Program Modifications
+
+Modify this program to make the count correspond to seconds passed. Hint: count corresponds to the number of times a given `Timer` has been called.

--- a/examples/under_pressure/README.md
+++ b/examples/under_pressure/README.md
@@ -1,0 +1,59 @@
+# under_pressure
+
+A program showing how to utilize the Pony backpressure system.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./under_pressure.o
+Linking ./under_pressure
+```
+
+## How to Run
+
+Once `under_pressure` has been compiled, in the same directory as this README file run `./under_pressure`. You should see a message reporting a connection failure.
+
+```console
+$ ./under_pressure
+connect_failed
+```
+
+This failure is because there is no receiver for the data `under_pressue` is receiving. You can start one with `netcat`.
+
+```console
+# Data receiver
+nc -l 127.0.0.1 7669 >> /dev/null
+```
+
+Now run `under_pressure` (your output w)
+
+```console
+$ ./under_pressure
+Querying and setting socket options:
+        getsockopt so_error = 0
+        getsockopt get_tcp_nodelay = 0
+        getsockopt set_tcp_nodelay(true) return value = 13
+        getsockopt get_tcp_nodelay = 0
+        getsockopt rcvbuf = 131072
+        getsockopt sndbuf = 2626560
+        setsockopt rcvbuf 5000 return was 0
+        setsockopt sndbuf 5000 return was 0
+```
+
+If you then stop the `netcat` process you will see `under_pressure` respond that is it experiencing backpressure. Restart `netcat` and `under_pressure` will release backpressure. If you look at a system monitor while under backpressure you will notice `under_pressure` has very low usage -- no actors are running!
+
+## Program Modifications
+
+Modify the program to use more than one `TCPConnection` -- all actors will respond to backpressure on its own.

--- a/examples/yield/README.md
+++ b/examples/yield/README.md
@@ -1,0 +1,77 @@
+# yield
+
+A program showing a pattern in Pony to transform for/while loops (which could run infinitely) into tail-recursive behavior calls -- the advantage of this beyond avoiding a non-yielding actor is that garbage collection occurs between behaviors.
+
+## How to Compile
+
+With a minimal Pony installation, in the same directory as this README file run `ponyc`. You should see content building the necessary packages, which ends with:
+
+```console
+...
+Generating
+ Reachability
+ Selector painting
+ Data prototypes
+ Data types
+ Function prototypes
+ Functions
+ Descriptors
+Optimising
+Writing ./yield.o
+Linking ./yield
+```
+
+## How to Run
+
+Once `yield` has been compiled, in the same directory as this README file run `./yield`. You should see a message showing the "infinite" actor has started, followed by the result of the kill command.
+
+```console
+$ ./yield
+Beep boop!
+Ugah!
+```
+
+This program has multiple "sub-programs" in it which you can see with `--help`.
+
+```console
+$ ./yield --help
+usage: yield [<options>] [<args> ...]
+
+Demonstrate use of the yield behaviour when writing tail recursive
+behaviours in pony.
+
+By Default, the actor will run quiet and interruptibly.
+
+Options:
+   -b, --bench=0         Run an instrumented behaviour to guesstimate overhead of non/interruptive.
+   -d, --debug=false     Run in debug mode with verbose output.
+   -h, --help=false      
+   -l, --lonely=false    Run a non-interruptible behaviour with logic that runs forever.
+   -p, --punk=false      Run a punctuated stream demonstration.
+```
+
+Try running each of these program, but beware `--lonely` will run forever so you will need to externally kill it.
+
+## Program Modifications
+
+Modify the program to make each of the above options into (leaf) subcommands by making the existing "yield" a parent command. `debug` should be the only subcommand which takes an argument.
+
+```console
+$ ./yield bench --perf=10
+...
+```
+
+```console
+$ ./yield debug
+...
+```
+
+```console
+$ ./yield lonely
+...
+```
+
+```console
+$ ./yield punk
+...
+```

--- a/examples/yield/README.md
+++ b/examples/yield/README.md
@@ -45,7 +45,7 @@ By Default, the actor will run quiet and interruptibly.
 Options:
    -b, --bench=0         Run an instrumented behaviour to guesstimate overhead of non/interruptive.
    -d, --debug=false     Run in debug mode with verbose output.
-   -h, --help=false      
+   -h, --help=false
    -l, --lonely=false    Run a non-interruptible behaviour with logic that runs forever.
    -p, --punk=false      Run a punctuated stream demonstration.
 ```


### PR DESCRIPTION
As suggested in #2394, it would be useful to have a README for each example which explains how to compile it, run it, and understand what it is doing from a high-level so a beginner can understand if the program is running properly or experiencing some incorrect behavior.

- [x] circle
- [x] commandline
- [x] counter
- [x] dtrace
- [x] echo
- [x] fan-in
- [x] ffi-callbacks
- [x] ffi-struct
- [x] files
- [x] gups_basic
- [x] gups_opt
- [x] helloworld
- [x] ifdef
- [x] lambda
- [x] mailbox
- [x] mandelbrot
- [x] message-ubench
- [x] mixed
- [x] n-body
- [x] net
- [x] overload
- [x] ponybench
- [x] printargs
- [x] producer-consumer
- [x] readline
- [x] ring
- [x] spreader
- [x] systemtap
- [x] timers
- [x] under_pressure
- [x] yield