### PR TITLE
Change Python version in FreeBSD CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -314,7 +314,7 @@ task:
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - echo "IGNORE_OSVERSION = yes" >> /usr/local/etc/pkg.conf
     - pkg update
-    - pkg install -y bash cmake gmake libunwind git py37-pip
+    - pkg install -y bash cmake gmake libunwind git py38-pip
     - pip install --upgrade cloudsmith-cli
 
   libs_cache:
@@ -460,7 +460,7 @@ task:
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - echo "IGNORE_OSVERSION = yes" >> /usr/local/etc/pkg.conf
     - pkg update
-    - pkg install -y bash cmake gmake libunwind git py37-pip
+    - pkg install -y bash cmake gmake libunwind git py38-pip
     - pip install --upgrade cloudsmith-cli
 
   libs_cache:


### PR DESCRIPTION
py37-pip package is coming back as no longer available. Let's move
up to the next version.