### PR TITLE
Fix OOM on MacOS when using xcode 12.5

### DIFF
--- a/.release-notes/fix-3789.md
+++ b/.release-notes/fix-3789.md
@@ -1,0 +1,5 @@
+## Fix OOM error when running ponyc built with xcode 12.5
+
+Changes in Big Sur and xcode as of 12.5 have lead to an out of memory error with ponyc. If pony's allocator is built with usage of VM_FLAGS_SUPERPAGE_SIZE_ANY on, it will run out of memory if xcode 12.5 was used to build.
+
+VM_FLAGS_SUPERPAGE_SIZE_ANY isn't required on earlier versions. It does however, improve performance when allocating. Usage of VM_FLAGS_SUPERPAGE_SIZE_ANY has been removed as it also doesn't work on newer M1 based machines and thus, is on its way out in general.

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -28,7 +28,7 @@ void* ponyint_virt_alloc(size_t bytes)
     MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
 #elif defined(PLATFORM_IS_MACOSX)
   p = mmap(0, bytes, PROT_READ | PROT_WRITE,
-    MAP_PRIVATE | MAP_ANON | VM_FLAGS_SUPERPAGE_SIZE_ANY, -1, 0);
+    MAP_PRIVATE | MAP_ANON, -1, 0);
 #elif defined(PLATFORM_IS_DRAGONFLY)
   p = mmap(0, bytes, PROT_READ | PROT_WRITE,
     MAP_PRIVATE | MAP_ANON, -1, 0);


### PR DESCRIPTION
Usage of VM_FLAGS_SUPERPAGE_SIZE_ANY when doing allocations causes
ponyc to OOM if it is built with xcode 12.5.

Fixes #3789