### PR TITLE
Change minimum supported MacOS API version to 10.14

### DIFF
--- a/.release-notes/fix-3792.md
+++ b/.release-notes/fix-3792.md
@@ -1,0 +1,3 @@
+## Change minimum supported MacOS API version to 10.14
+
+Our policy is to support the last 3 MacOS API versions with ponyc. We are now only supporting MacOS API versions 10.14 and up. Attempting to use ponyc on an earlier version of MacOS is not guaranteed to work and is no longer supported.

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -294,7 +294,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   snprintf(ld_cmd, ld_len,
     "%s -execute -no_pie -arch %.*s "
-    "-macosx_version_min 10.12 -o %s %s %s %s "
+    "-macosx_version_min 10.14 -o %s %s %s %s "
     "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg


### PR DESCRIPTION
We only support the last 3 versions.

Closes #3792