### PR TITLE
Fix MacOS version mismatch warnings when linking Pony programs

### DIFF
--- a/.release-notes/3789.md
+++ b/.release-notes/3789.md
@@ -1,0 +1,7 @@
+## Fix API mismatch errors when linking pony programs on MacOS
+
+We have been setting a minimal API version for ponyc that didn't match the LLVM value. This resulted in errors about how the link versions didn't match. The warnings caused no issues running programs, but did lead to confusion amongst new users. They were also annoying to look at all the time.
+
+We did some testing and determined that there's no need to set the value as we can build ponyc and other pony programs on Big Sur and still use on earlier versions of MacOS.
+
+There might be some issues that crop up in the future, but as far as we can tell, for normal ponyc MacOS usage, we dont need to set `macosx-version-min`.

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -12,7 +12,3 @@ Changes in Big Sur and xcode as of 12.5 have lead to an out of memory error with
 
 VM_FLAGS_SUPERPAGE_SIZE_ANY isn't required on earlier versions. It does however, improve performance when allocating. Usage of VM_FLAGS_SUPERPAGE_SIZE_ANY has been removed as it also doesn't work on newer M1 based machines and thus, is on its way out in general.
 
-## Change minimum supported MacOS API version to 10.14
-
-Our policy is to support the last 3 MacOS API versions with ponyc. We are now only supporting MacOS API versions 10.14 and up. Attempting to use ponyc on an earlier version of MacOS is not guaranteed to work and is no longer supported.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
-- Change minimum supported MacOS API version to 10.14 ([PR #3794](https://github.com/ponylang/ponyc/pull/3794))
 
 ## [0.42.0] - 2021-07-07
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,8 @@ else()
 endif()
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.14 -DUSE_SCHEDULER_SCALING_PTHREADS")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=10.14")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_SCHEDULER_SCALING_PTHREADS")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 endif()
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -294,7 +294,7 @@ static bool link_exe(compile_t* c, ast_t* program,
 
   snprintf(ld_cmd, ld_len,
     "%s -execute -no_pie -arch %.*s "
-    "-macosx_version_min 10.14 -o %s %s %s %s "
+    "-o %s %s %s %s "
     "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg


### PR DESCRIPTION
It turns out, from our testing, that `macosx-version-min` isn't needed.
We tested building ponyc and a pony program without macosx-version-min
on Catalina and were then able to use both without issue on an earlier
version of MacOS- Mojave.

After this is merged, we'll do additional testing with nightly versions
of ponyc and corral built on Big Sur by running them on earlier MacOS
releases.