### PR TITLE
Fix ponyint_cpu_tick for Apple ARM.

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -383,7 +383,7 @@ uint64_t ponyint_cpu_tick()
 {
 #if defined PLATFORM_IS_ARM
 # if defined(__APPLE__)
-  return mach_absolute_time();
+  return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 # else
 #   if defined ARMV6
   // V6 is the earliest arch that has a standard cyclecount


### PR DESCRIPTION
While looking at M1 stuff, I noticed that this function was using the wrong
implementation for modern Apple ARM - the tick unit for `mach_absolute_time`
is no longer expected to always be nanoseconds, and `clock_gettime_nsec_np`
with a clock type of `CLOCK_UPTIME_RAW` is the recommended replacement.

See:
- https://eclecticlight.co/2020/09/08/changing-the-clock-in-apple-silicon-macs/
- https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time

I don't think a release note is needed, because as far as I know,
this ifdef section for Apple ARM only applies to M1 and iOS/WatchOS/AppleTVOS,
none of which are currently officially supported by Pony.

But M1 hopefully will be soon.