### PR TITLE
Fixed Makefile for FreeBSD

### DIFF
--- a/.release-notes/3808.md
+++ b/.release-notes/3808.md
@@ -1,0 +1,4 @@
+## Fixed compiler build issues on FreeBSD host
+
+Added relevant include and lib search paths under `/usr/local` 
+prefix on FreeBSD, to satisfy build dependencies for Pony compiler.

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,16 @@ else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
   endif
 endif
 
+# Make sure the compiler gets all relevant search paths on FreeBSD
+ifeq ($(shell uname -o),FreeBSD)
+  ifeq (,$(findstring /usr/local/include,$(shell echo $CPATH)))
+    export CPATH = /usr/local/include:$CPATH
+  endif
+  ifeq (,$(findstring /usr/local/lib,$(shell echo $LIBRARY_PATH)))
+    export LIBRARY_PATH = /usr/local/lib:$LIBRARY_PATH
+  endif
+endif
+
 srcDir := $(shell dirname '$(subst /Volumes/Macintosh HD/,/,$(realpath $(lastword $(MAKEFILE_LIST))))')
 buildDir := $(srcDir)/build/build_$(config)
 outDir := $(srcDir)/build/$(config)


### PR DESCRIPTION
FreeBSD puts all non-base system files under /usr/local prefix, which results in `<unwind.h>` not being found (with **libunwind** being actually installed) when compiling with `runtime-bitcode=yes` option, unless proper `CPATH` and `LIBRARY_PATH` environment variables are defined. This PR addresses the issue, by providing relevant checks and adjustments in the Makefile.