### PR TITLE
Make FileMode._os public

### DIFF
--- a/.release-notes/mode-os.md
+++ b/.release-notes/mode-os.md
@@ -1,0 +1,5 @@
+## Make FileMode._os public
+
+FileMode has always had a private method for getting an integer representation of the file mode. However, it was private and only available for use within the `files` package.
+
+It is now public as `FileMode.os`.

--- a/packages/files/_file_des.pony
+++ b/packages/files/_file_des.pony
@@ -21,7 +21,7 @@ primitive _FileDes
     ifdef windows then
       path.chmod(mode)
     else
-      @fchmod(fd, mode._os()) == 0
+      @fchmod(fd, mode.os()) == 0
     end
 
   fun chown(fd: I32, path: FilePath, uid: U32, gid: U32): Bool =>

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -352,7 +352,7 @@ class Directory
       let path' = FilePath(path, target, path.caps)?
 
       ifdef linux or bsd then
-        0 == @fchmodat(_fd, target.cstring(), mode._os(), I32(0))
+        0 == @fchmodat(_fd, target.cstring(), mode.os(), I32(0))
       else
         path'.chmod(mode)
       end

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -114,7 +114,7 @@ class File
       _errno = FileError
     else
       var flags: I32 = @ponyint_o_rdwr()
-      let mode = FileMode._os() // default file permissions
+      let mode = FileMode.os() // default file permissions
       if not path.exists() then
         if not path.caps(FileCreate) then
           _errno = FileError

--- a/packages/files/file_mode.pony
+++ b/packages/files/file_mode.pony
@@ -77,7 +77,7 @@ class FileMode
     any_write = false
     any_exec = false
 
-  fun _os(): U32 =>
+  fun os(): U32 =>
     """
     Get the OS specific integer for a file mode. On Windows, if any read flag
     is set, the path is made readable, and if any write flag is set, the path

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -355,7 +355,7 @@ class val FilePath
       return false
     end
 
-    let m = mode._os()
+    let m = mode.os()
 
     ifdef windows then
       0 == @_chmod(path.cstring(), m)


### PR DESCRIPTION
FileMode has always had a private method for getting an integer
representation of the file mode. However, it was private and only
available for use within the `files` package.

I discovered this when writing a pure pony tar library and needed
exactly the functionality of _os.

This commit changes `_os` from private to public as `os` and updates
its callers.