### PR TITLE
Rename FileMode.os to FileMode.u32

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,11 +1,8 @@
 ## Fixed compiler build issues on FreeBSD host
 
-Added relevant include and lib search paths under `/usr/local` 
+Added relevant include and lib search paths under `/usr/local`
 prefix on FreeBSD, to satisfy build dependencies for Pony compiler.
 
-## Make FileMode._os public
+## Add FileMode.u32
 
-FileMode has always had a private method for getting an integer representation of the file mode. However, it was private and only available for use within the `files` package.
-
-It is now public as `FileMode.os`.
-
+Adds a public method on FileMode to get an OS-specific representation of the FileMode as a u32.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- Add FileMode.u32 ([PR #3809](https://github.com/ponylang/ponyc/pull/3809))
+- Add FileMode.u32 ([PR #3810](https://github.com/ponylang/ponyc/pull/3810))
 
 ### Changed
 
-- Make FileMode._os public ([PR #3809](https://github.com/ponylang/ponyc/pull/3809))
 
 ## [0.43.0] - 2021-07-14
 

--- a/packages/files/_file_des.pony
+++ b/packages/files/_file_des.pony
@@ -21,7 +21,7 @@ primitive _FileDes
     ifdef windows then
       path.chmod(mode)
     else
-      @fchmod(fd, mode.os()) == 0
+      @fchmod(fd, mode.u32()) == 0
     end
 
   fun chown(fd: I32, path: FilePath, uid: U32, gid: U32): Bool =>

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -352,7 +352,7 @@ class Directory
       let path' = FilePath(path, target, path.caps)?
 
       ifdef linux or bsd then
-        0 == @fchmodat(_fd, target.cstring(), mode.os(), I32(0))
+        0 == @fchmodat(_fd, target.cstring(), mode.u32(), I32(0))
       else
         path'.chmod(mode)
       end

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -114,7 +114,7 @@ class File
       _errno = FileError
     else
       var flags: I32 = @ponyint_o_rdwr()
-      let mode = FileMode.os() // default file permissions
+      let mode = FileMode.u32() // default file permissions
       if not path.exists() then
         if not path.caps(FileCreate) then
           _errno = FileError

--- a/packages/files/file_mode.pony
+++ b/packages/files/file_mode.pony
@@ -77,7 +77,7 @@ class FileMode
     any_write = false
     any_exec = false
 
-  fun os(): U32 =>
+  fun u32(): U32 =>
     """
     Get the OS specific integer for a file mode. On Windows, if any read flag
     is set, the path is made readable, and if any write flag is set, the path

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -355,7 +355,7 @@ class val FilePath
       return false
     end
 
-    let m = mode.os()
+    let m = mode.u32()
 
     ifdef windows then
       0 == @_chmod(path.cstring(), m)


### PR DESCRIPTION
Joe pointed out that the previous (not yet released change) that made
FileMode._os could be better. u32 is a more clear name. _os didn't
really matter as a name as it was private. With the functionality
becoming public we need the best name possible. u32() makes perfect
sense as the name as it is the filemode in a U32 representation.