### PR TITLE
Fix release build stripping for non-MSVC compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,11 @@ if(MSVC)
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wextra -Wall -fpic -fexceptions")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fno-rtti -fpic -fexceptions")
-    add_link_options(-rdynamic)
+    add_link_options(
+        -rdynamic
+        $<$<CONFIG:Release>:-s>
+        $<$<CONFIG:MinSizeRel>:-s>
+    )
 endif()
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
It is tentatively assumed, that Release (aka Production) build targets should be stripped of debug info, to make them smaller. At this time, this is not the case for Pony compiler builds with the "release" config.

This change does exactly that - makes sure to strip all debug info from result build artifacts during link time, for "release" and "minsizerel" targets on supported GCC & Clang/LLVM platforms.

Tested on FreeBSD-14 (CURRENT), amd64.