### PR TITLE
Cleanup and fixes for Windows sockets

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,9 +98,10 @@ task:
 
   name: "PR: x86-64-unknown-freebsd-13.0"
 
+  os_configuration_script:
+    - sysctl net.inet.tcp.keepinit=1000
+
   install_script:
-    - sysctl net.inet.tcp.keepinit
-    - sysctl net.inet.tcp.keepinit=3000
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - echo "IGNORE_OSVERSION = yes" >> /usr/local/etc/pkg.conf
     - pkg update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,6 +99,8 @@ task:
   name: "PR: x86-64-unknown-freebsd-13.0"
 
   install_script:
+    - sysctl net.inet.tcp.keepinit
+    - sysctl net.inet.tcp.keepinit=3000
     - echo "FETCH_RETRY = 6" >> /usr/local/etc/pkg.conf
     - echo "IGNORE_OSVERSION = yes" >> /usr/local/etc/pkg.conf
     - pkg update

--- a/.release-notes/3816.md
+++ b/.release-notes/3816.md
@@ -1,4 +1,11 @@
-## Address Windows socket errors
+## Fixed Windows TCP faulty connection error
 
 Fixed a bug where a `TCPConnection` could connect to a socket that wasn't listening.
-Fixed a bug where socket events were sometimes never unsubscribed to.
+
+## Fixed zombie Windows TCP connection error
+
+Fixed a bug where socket events were sometimes never unsubscribed to which would lead to "zombie" connections that were open but couldn't receive data.
+
+## Fixed "oversleeping" on Windows
+
+Previously, we were calling `Sleep` rather than `SleepEx` when putting scheduler threads to sleep. This could have caused Windows IO events to be missed.

--- a/.release-notes/3816.md
+++ b/.release-notes/3816.md
@@ -1,3 +1,4 @@
-## Cleanup and fixes for sockets on Windows
+## Address Windows socket errors
 
-Fixed a few infelicities in the Windows socket code, in particular that clients connecting to an invalid port would think they were successfully connected.
+Fixed a bug where a `TCPConnection` could connect to a socket that wasn't listening.
+Fixed a bug where socket events were sometimes never unsubscribed to.

--- a/.release-notes/3816.md
+++ b/.release-notes/3816.md
@@ -1,0 +1,3 @@
+## Cleanup and fixes for sockets on Windows
+
+Fixed a few infelicities in the Windows socket code, in particular that clients connecting to an invalid port would think they were successfully connected.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -704,7 +704,7 @@ class _TestTCPConnectionFailed is UnitTest
         end,
         host,
         port)
-      h.long_test(20_000_000_000)
+      h.long_test(140_000_000_000)
       h.dispose_when_done(connection)
     else
       h.fail("error creating TCPConnection")
@@ -793,7 +793,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
       )
 
       h.dispose_when_done(listener)
-      h.long_test(20_000_000_000)
+      h.long_test(140_000_000_000)
     else
       h.fail("error creating listener")
       h.complete(false)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -689,6 +689,9 @@ class _TestTCPConnectionFailed is UnitTest
         object iso is TCPConnectionNotify
           let _h: TestHelper = h
 
+          fun ref connecting(conn: TCPConnection ref, count: U32) =>
+            h.log("connecting...")
+
           fun ref connected(conn: TCPConnection ref) =>
             _h.fail("fail: connected to a non-existent host and port")
             _h.complete(false)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -745,7 +745,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
   fun exclusion_group(): String => "network"
 
   fun ref apply(h: TestHelper) =>
-    h.expect_action("server listening on 127.0.0.1")
+    h.expect_action("server listening")
     h.expect_action("client connection failed")
 
     try
@@ -760,7 +760,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
             try
               (host, port) = listener.local_address().name()?
               _h.log("server listening on " + host + ":" + port)
-              _h.complete_action("listening on " + host)
+              _h.complete_action("server listening")
             else
               _h.fail("server unable to get local address")
               _h.complete(false)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -680,7 +680,7 @@ class _TestTCPConnectionFailed is UnitTest
   fun ref apply(h: TestHelper) =>
     h.expect_action("connection failed")
 
-    let host = "127.0.0.1"
+    let host = "localhost"
     let port = "7669"
 
     try

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -785,7 +785,8 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
               fun ref connect_failed(conn: TCPConnection ref) => None
               fun ref closed(conn: TCPConnection ref) => None
             end
-        end
+        end,
+        "127.0.0.1"
       )
 
       h.dispose_when_done(listener)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -690,7 +690,7 @@ class _TestTCPConnectionFailed is UnitTest
           let _h: TestHelper = h
 
           fun ref connected(conn: TCPConnection ref) =>
-            _h.complete_action("connection failed", false)
+            _h.fail_action("connection failed")
 
           fun ref connect_failed(conn: TCPConnection ref) =>
             _h.complete_action("connection failed")
@@ -728,7 +728,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
             listener.close()
 
           fun ref not_listening(listener: TCPListener ref) =>
-            _h.complete_action("server listening", false)
+            _h.fail_action("server listening")
 
           fun ref closed(listener: TCPListener ref) =>
             _TCPConnectionToClosedServerFailedConnector.connect(_h, host, port)
@@ -763,7 +763,7 @@ actor _TCPConnectionToClosedServerFailedConnector
           let _h: TestHelper = h
 
           fun ref connected(conn: TCPConnection ref) =>
-            _h.complete_action("client connection failed", false)
+            _h.fail_action("client connection failed")
 
           fun ref connect_failed(conn: TCPConnection ref) =>
             _h.complete_action("client connection failed")

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -680,7 +680,7 @@ class _TestTCPConnectionFailed is UnitTest
   fun ref apply(h: TestHelper) =>
     h.expect_action("connection failed")
 
-    let host = "localhost"
+    let host = "127.0.0.1"
     let port = "7669"
 
     try
@@ -700,11 +700,10 @@ class _TestTCPConnectionFailed is UnitTest
           fun ref connect_failed(conn: TCPConnection ref) =>
             _h.complete_action("connection failed")
             conn.close()
-            _h.complete(true)
         end,
         host,
         port)
-      h.long_test(140_000_000_000)
+      h.long_test(2_000_000_000)
       h.dispose_when_done(connection)
     else
       h.fail("error creating TCPConnection")
@@ -727,7 +726,6 @@ actor _Connector
           fun ref connect_failed(conn: TCPConnection ref) =>
             _h.complete_action("client connection failed")
             conn.close()
-            _h.complete(true)
 
           fun ref closed(conn: TCPConnection ref) =>
             _h.log("client closed")
@@ -793,7 +791,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
       )
 
       h.dispose_when_done(listener)
-      h.long_test(140_000_000_000)
+      h.long_test(2_000_000_000)
     else
       h.fail("error creating listener")
       h.complete(false)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -681,7 +681,7 @@ class _TestTCPConnectionFailed is UnitTest
     h.expect_action("connection failed")
 
     let host = "127.0.0.1"
-    let port = "12345"
+    let port = "7669"
 
     try
       let connection = TCPConnection(
@@ -715,19 +715,19 @@ actor _Connector
       let connection = TCPConnection(
         h.env.root as AmbientAuth,
         object iso is TCPConnectionNotify
-          let _hh: TestHelper = h
+          let _h: TestHelper = h
 
           fun ref connected(conn: TCPConnection ref) =>
-            _hh.fail("client connected to a closed listener")
-            _hh.complete(false)
+            _h.fail("client connected to a closed listener")
+            _h.complete(false)
             conn.close()
 
           fun ref connect_failed(conn: TCPConnection ref) =>
-            _hh.complete_action("client connection failed")
-            _hh.complete(true)
+            _h.complete_action("client connection failed")
+            _h.complete(true)
 
           fun ref closed(conn: TCPConnection ref) =>
-            _hh.log("client closed")
+            _h.log("client closed")
         end,
         host,
         port)

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -690,14 +690,13 @@ class _TestTCPConnectionFailed is UnitTest
           let _h: TestHelper = h
 
           fun ref connected(conn: TCPConnection ref) =>
-            _h.log("log: connected to a non-existent host and port")
             _h.fail("fail: connected to a non-existent host and port")
             _h.complete(false)
             conn.close()
 
           fun ref connect_failed(conn: TCPConnection ref) =>
-            _h.log("log: connection failed")
             _h.complete_action("connection failed")
+            conn.close()
             _h.complete(true)
         end,
         host,
@@ -724,6 +723,7 @@ actor _Connector
 
           fun ref connect_failed(conn: TCPConnection ref) =>
             _h.complete_action("client connection failed")
+            conn.close()
             _h.complete(true)
 
           fun ref closed(conn: TCPConnection ref) =>
@@ -749,7 +749,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
     h.expect_action("client connection failed")
 
     try
-      let listener = TCPListener.ip4(
+      let listener = TCPListener(
         h.env.root as AmbientAuth,
         object iso is TCPListenNotify
           let _h: TestHelper = h

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -18,6 +18,10 @@ actor Main is TestList
       test(_TestTCPThrottle)
     end
     test(_TestTCPProxy)
+    test(_TestTCPConnectionFailed)
+    ifdef not windows then
+      test(_TestTCPConnectionToClosedServerFailed)
+    end
 
 class _TestPing is UDPNotify
   let _h: TestHelper
@@ -649,8 +653,8 @@ class _TestTCPProxy is UnitTest
   fun exclusion_group(): String => "network"
 
   fun ref apply(h: TestHelper) =>
-    h.expect_action("sender connected") 
-    h.expect_action("sender proxy request") 
+    h.expect_action("sender connected")
+    h.expect_action("sender proxy request")
 
     _TestTCP(h)(_TestTCPProxyNotify(h),
       _TestTCPProxyNotify(h))
@@ -669,3 +673,124 @@ class _TestTCPProxyNotify is TCPConnectionNotify
 
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("sender connect failed")
+
+class _TestTCPConnectionFailed is UnitTest
+  fun name(): String => "net/TCPConnectionFailed"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("connection failed")
+
+    let host = "127.0.0.1"
+    let port = "12345"
+
+    try
+      let connection = TCPConnection(
+        h.env.root as AmbientAuth,
+        object iso is TCPConnectionNotify
+          let _h: TestHelper = h
+
+          fun ref connected(conn: TCPConnection ref) =>
+            _h.log("log: connected to a non-existent host and port")
+            _h.fail("fail: connected to a non-existent host and port")
+            _h.complete(false)
+            conn.close()
+
+          fun ref connect_failed(conn: TCPConnection ref) =>
+            _h.log("log: connection failed")
+            _h.complete_action("connection failed")
+            _h.complete(true)
+        end,
+        host,
+        port)
+      h.long_test(20_000_000_000)
+      h.dispose_when_done(connection)
+    else
+      h.fail("error creating TCPConnection")
+      h.complete(false)
+    end
+
+actor _Connector
+  be connect(h: TestHelper, host: String, port: String) =>
+    try
+      let connection = TCPConnection(
+        h.env.root as AmbientAuth,
+        object iso is TCPConnectionNotify
+          let _hh: TestHelper = h
+
+          fun ref connected(conn: TCPConnection ref) =>
+            _hh.fail("client connected to a closed listener")
+            _hh.complete(false)
+            conn.close()
+
+          fun ref connect_failed(conn: TCPConnection ref) =>
+            _hh.complete_action("client connection failed")
+            _hh.complete(true)
+
+          fun ref closed(conn: TCPConnection ref) =>
+            _hh.log("client closed")
+        end,
+        host,
+        port)
+      h.dispose_when_done(connection)
+    else
+      h.fail("unable to create connection")
+      h.complete(false)
+    end
+
+class _TestTCPConnectionToClosedServerFailed is UnitTest
+  """
+  Check that you can't connect to a closed listener.
+  """
+  fun name(): String => "net/TCPConnectionToClosedServerFailed"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("server listening on 127.0.0.1")
+    h.expect_action("client connection failed")
+
+    try
+      let listener = TCPListener.ip4(
+        h.env.root as AmbientAuth,
+        object iso is TCPListenNotify
+          let _h: TestHelper = h
+          var host: String = "?"
+          var port: String = "?"
+
+          fun ref listening(listener: TCPListener ref) =>
+            try
+              (host, port) = listener.local_address().name()?
+              _h.log("server listening on " + host + ":" + port)
+              _h.complete_action("listening on " + host)
+            else
+              _h.fail("server unable to get local address")
+              _h.complete(false)
+            end
+            listener.close()
+
+          fun ref not_listening(listener: TCPListener ref) =>
+            _h.fail("server not listening")
+            _h.complete(false)
+
+          fun ref closed(listener: TCPListener ref) =>
+            _h.log("server closed")
+            _Connector.connect(_h, host, port)
+
+          fun ref connected(listener: TCPListener ref)
+            : TCPConnectionNotify iso^
+          =>
+            object iso is TCPConnectionNotify
+              fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
+                times: USize): Bool => true
+              fun ref accepted(conn: TCPConnection ref) => None
+              fun ref connect_failed(conn: TCPConnection ref) => None
+              fun ref closed(conn: TCPConnection ref) => None
+            end
+        end
+      )
+
+      h.dispose_when_done(listener)
+      h.long_test(20_000_000_000)
+    else
+      h.fail("error creating listener")
+      h.complete(false)
+    end

--- a/packages/net/ossocket.pony
+++ b/packages/net/ossocket.pony
@@ -28,6 +28,12 @@ primitive _OSSocket
     """
     getsockopt_u32(fd, OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
 
+  fun get_so_connect_time(fd: U32): (U32, U32) =>
+    """
+    Wrapper for the FFI call `getsockopt(fd, SOL_SOCKET, SO_CONNECT_TIME, ...)`
+    """
+    getsockopt_u32(fd, OSSockOpt.sol_socket(), OSSockOpt.so_connect_time())
+
   fun set_so_rcvbuf(fd: U32, bufsize: U32): U32 =>
     """
     Wrapper for the FFI call `setsockopt(fd, SOL_SOCKET, SO_RCVBUF, ...)`
@@ -39,7 +45,6 @@ primitive _OSSocket
     Wrapper for the FFI call `setsockopt(fd, SOL_SOCKET, SO_SNDBUF, ...)`
     """
     setsockopt_u32(fd, OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf(), bufsize)
-
 
   fun getsockopt(fd: U32, level: I32, option_name: I32, option_max_size: USize = 4): (U32, Array[U8] iso^) =>
     """

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -1086,8 +1086,6 @@ actor TCPConnection
 
     if _connected and _shutdown and _shutdown_peer then
       hard_close()
-    else
-      @pony_asio_event_unsubscribe(_event)
     end
 
   fun ref hard_close() =>

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -258,10 +258,7 @@ actor TCPListener
     _closed = true
 
     if not _event.is_null() then
-      // When not on windows, the unsubscribe is done immediately.
-      ifdef not windows then
-        @pony_asio_event_unsubscribe(_event)
-      end
+      @pony_asio_event_unsubscribe(_event)
 
       @pony_os_socket_close(_fd)
       _fd = -1

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -612,7 +612,7 @@ class iso _TestLongRunningChild is UnitTest
       let pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       pm.done_writing()
       h.dispose_when_done(pm)
-      h.long_test(5_000_000_000)
+      h.long_test(10_000_000_000)
     else
       h.fail("failed to set up calling sleep/timeout.")
     end
@@ -670,7 +670,7 @@ class iso _TestKillLongRunningChild is UnitTest
       let pm = ProcessMonitor(auth, auth, consume notifier, path, args, vars)
       pm.dispose()
       pm.done_writing()
-      h.long_test(3_000_000_000)
+      h.long_test(10_000_000_000)
     else
       h.fail("failed to set up calling sleep/timeout.")
     end
@@ -749,7 +749,7 @@ class iso _TestWaitingOnClosedProcessTwice is UnitTest
         3_000_000_000, 0)
       timers(consume timer1)
 
-      h.long_test(5_000_000_000)
+      h.long_test(10_000_000_000)
     else
       h.fail("process monitor threw an error")
     end

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -271,14 +271,15 @@ static void CALLBACK iocp_callback(DWORD err, DWORD bytes, OVERLAPPED* ov)
 
         setsockopt(acc->ns, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
           (char*)&s, sizeof(SOCKET));
+
+        // Dispatch a read event with the new socket as the argument.
+        pony_asio_event_send(iocp->ev, ASIO_READ, (int)acc->ns);
       } else {
         // Close the new socket.
-        closesocket(acc->ns);
+        pony_os_socket_close((int)acc->ns);
         acc->ns = INVALID_SOCKET;
       }
 
-      // Dispatch a read event with the new socket as the argument.
-      pony_asio_event_send(iocp->ev, ASIO_READ, (int)acc->ns);
       iocp_accept_destroy(acc);
       break;
     }

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -74,7 +74,7 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   {
     // If the guard is already set, an assertion fired in another thread. The
     // things here aren't thread safe, so we just start an infinite loop.
-    Sleep(1);
+    SleepEx(1, true);
   }
 
   fprintf(stderr, "%s:" __zu ": %s: Assertion `%s` failed.\n\n", file, line,

--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -368,7 +368,7 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
   }
 
 #ifdef PLATFORM_IS_WINDOWS
-  Sleep(ts);
+  SleepEx(ts, true);
 #else
   DTRACE1(CPU_NANOSLEEP, ts.tv_nsec);
   nanosleep(&ts, NULL);


### PR DESCRIPTION
On Windows the `TCPConnection` code was not immediately unsubscribing to ASIO events when trying to shut down a connection. It was also not ever checking to see if all the relevant IOCP operations were complete, so in certain cases it would wait forever on the ASIO event and hang the program.  This change makes `TCPConnection` immediately unsubscribe. There may be some pending IOCP events left over but since we're shutting down we don't care about them reaching client code.

On Windows the recommended way to check the status of a connection is to use `SO_CONNECT_TIME` rather than `SO_ERROR`. Certain failing IOCP operations will not set `SO_ERROR`, so this changes `TCPClient._is_sock_connected()` to use `SO_CONNECT_TIME` on Windows.

Fixes a case in `TCPConnection._event_notify` where clients might receive spurious `connecting` calls when a connection in a different network family failed.

Changes the use of `Sleep()` on Windows to `SleepEX()`, which will wake up for IO operations.

Adds a new test `net/TCPConnectionFailed` that tests if a connection to a bogus port will fail immediately. This was broken on Windows.

Adds a new test for Unix only `new/TCPConnectionToClosedServerFailed` that tests if a connection to a recently-closed server will fail immediately. This test is disabled on Windows because it seems that per investigation of #3656 listening sockets that have an `AcceptEx` in process stick around in the `CLOSE_WAIT` state and will allow connections even if the accepting and listening sockets have been closed.