### PR TITLE
Clean up child process exits on Windows

### DIFF
--- a/.release-notes/3187.md
+++ b/.release-notes/3187.md
@@ -1,0 +1,3 @@
+## Clean up child process exits on Windows
+
+Fixed the `ProcessMonitor` class sometimes waiting on an invalid process handle on Windows.

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -25,6 +25,7 @@ actor Main is TestList
     test(_TestBadExec)
     test(_TestLongRunningChild)
     test(_TestKillLongRunningChild)
+    test(_TestWaitingOnClosedProcessTwice)
 
 class _PathResolver
   let _path: Array[FilePath] val
@@ -677,6 +678,93 @@ class iso _TestKillLongRunningChild is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
+class iso _TestWaitingOnClosedProcessTwice is UnitTest
+  fun name(): String => "process/wait-on-closed-process-twice"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper)? =>
+    let auth = h.env.root as AmbientAuth
+    try
+      let path_resolver = _PathResolver(h.env.vars, auth)
+      let path = FilePath(auth, _SleepCommand.path(path_resolver)?)?
+      h.log(path.path)
+      let args = _SleepCommand.args(where seconds = 2)
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      // we want to make sure that ProcessMonitor is not checking the exit
+      // status of a process after it has already exited
+      // since it calls dispose() on its notifier after it has checked the
+      // exit status, we test whether or not we get more than 1 dispose()
+
+      // we start a process that should take less than 3 seconds
+      // after 3 seconds we send 2 dispose() messages to it
+      // when we are notified of the first dispose() message, we check the exit
+      // status to make sure we've exited successfully, then we start a second
+      // timer that will check if we were notified of the 2nd dispose()
+      // we shouldn't have been
+
+      let timers = Timers
+
+      let pn = object iso is ProcessNotify
+        var n: USize = 0
+        fun ref dispose(pm: ProcessMonitor ref, status: ProcessExitStatus) =>
+          n = n + 1
+          h.log("dispose() called " + n.string() + " time")
+          match status
+          | Signaled(Sig.term()) =>
+            h.log("child signaled")
+            ifdef windows then
+              h.fail("child signaled")
+              h.complete(false)
+              return
+            end
+          | Exited(0) =>
+            h.log("child exited")
+            ifdef posix then
+              h.fail("child exited")
+              h.complete(false)
+              return
+            end
+          else
+            h.fail("child did not exit")
+            h.complete(false)
+            return
+          end
+
+          if n == 1 then
+            let timer2 = Timer(
+              object iso is TimerNotify
+                fun ref apply(timer: Timer, count: U64): Bool =>
+                  h.log("timer2 called; n == " + n.string())
+                  if n == 1 then
+                    h.complete(true)
+                  else
+                    h.fail("notifier received dispose() more than once")
+                    h.complete(false)
+                  end
+                  true
+              end,
+              500_000_000, 0
+            )
+            timers(consume timer2)
+          end
+      end
+      let pm = ProcessMonitor(auth, auth, consume pn, path, args, vars)
+
+      let timer1 = Timer(
+        object iso is TimerNotify
+          fun ref apply(timer: Timer, count: U64): Bool =>
+            h.log("timer1 calling pm.dispose() twice")
+            pm.dispose()
+            pm.dispose()
+            true
+        end,
+        3_000_000_000, 0)
+      timers(consume timer1)
+
+      h.long_test(5_000_000_000)
+    else
+      h.fail("process monitor threw an error")
+    end
 
 class _ProcessClient is ProcessNotify
   """

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -710,20 +710,8 @@ class iso _TestWaitingOnClosedProcessTwice is UnitTest
           n = n + 1
           h.log("dispose() called " + n.string() + " time")
           match status
-          | Signaled(Sig.term()) =>
-            h.log("child signaled")
-            ifdef windows then
-              h.fail("child signaled")
-              h.complete(false)
-              return
-            end
           | Exited(0) =>
             h.log("child exited")
-            ifdef posix then
-              h.fail("child exited")
-              h.complete(false)
-              return
-            end
           else
             h.fail("child did not exit")
             h.complete(false)

--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -128,7 +128,8 @@ PONY_API int32_t ponyint_win_process_wait(size_t hProcess, int32_t* exit_code_pt
     int32_t retval = 0;
 
     // just poll
-    switch (WaitForSingleObject((HANDLE)hProcess, 0))
+    DWORD result = WaitForSingleObject((HANDLE)hProcess, 0);
+    switch (result)
     {
         case WAIT_OBJECT_0: // process exited
             if (GetExitCodeProcess((HANDLE)hProcess, (DWORD*)exit_code_ptr) == 0)
@@ -143,6 +144,8 @@ PONY_API int32_t ponyint_win_process_wait(size_t hProcess, int32_t* exit_code_pt
         case WAIT_FAILED:
             retval = GetLastError();
             if (retval == 0) retval = -1;
+            break;
+        default:
             break;
     }
 


### PR DESCRIPTION
In Windows we are closing the process handle when the process successfully exits. However, the wait timer in `ProcessMonitor` repeatedly calls wait on the child, even after it's exited.

This change makes `ProcessMonitor` and `_ProcessWindows` cache final values for the process exit status, so repeated calls to wait on the child will not be referencing an invalid handle.

This also fixes a combinatorial explosion of timers in `ProcessMonitor._wait_for_child()`.