### PR TITLE
Update musl-based Docker images to alpine 3.13

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 RUN apk update \
   && apk upgrade \

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 

--- a/.release-notes/alpine-update.md
+++ b/.release-notes/alpine-update.md
@@ -1,0 +1,3 @@
+## Update base version for alpine Docker images
+
+We've upgraded from 3.12 to 3.13 for the base image for the `ponylang/ponyc:alpine` and `ponylang/ponyc:release-alpine` images.


### PR DESCRIPTION
Not going to 3.14.1 as it requires Docker 20.10.x version or it won't work and I'm not sure that everywhere we need to be supports it.