### PR TITLE
Fix make error on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
 endif
 
 # Make sure the compiler gets all relevant search paths on FreeBSD
-ifeq ($(shell uname -o),FreeBSD)
+ifeq ($(shell uname -s),FreeBSD)
   ifeq (,$(findstring /usr/local/include,$(shell echo $CPATH)))
     export CPATH = /usr/local/include:$CPATH
   endif


### PR DESCRIPTION
uname -o isn't supported on MacOS, however, -s and works on all
platforms that we support via ponyup.

Closes #3832