### PR TITLE
Fix erratic cycle detector triggering on some Arm systems

### DIFF
--- a/.release-notes/3854.md
+++ b/.release-notes/3854.md
@@ -1,0 +1,7 @@
+## Fix erratic cycle detector triggering on some Arm systems
+
+Triggering of cycle detector runs was based on an assumption that our "tick" time source would monotonically increase. That is, that the values seen by getting a tick would always increase in value.
+
+This assumption is true as long as we have a hardware source of ticks to use. However, on some Arm systems, the hardware cycle counter isn't available to user code. On these these, we fall back to use `clock_gettime` as a source of ticks. When `clock_gettime` is the source of ticks, the ticks are no longer monotonically increasing.
+
+Usage of the cycle detector with the non-monotonically increasing tick sources would cause the cycle detector run very infrequently and somewhat erratically. This was most likely to be seen on hardware like the Raspberry Pi.

--- a/src/libponyrt/sched/cpu.h
+++ b/src/libponyrt/sched/cpu.h
@@ -23,6 +23,9 @@ void ponyint_cpu_relax();
 
 uint64_t ponyint_cpu_tick();
 
+uint64_t ponyint_cpu_tick_diff(uint64_t supposedly_earlier,
+  uint64_t supposedly_later);
+
 PONY_EXTERN_C_END
 
 #endif


### PR DESCRIPTION
This commit reworks tick usage to be safe with tick values that wrap around.

Most of our tick value sources will provide a monotonically increasing
value. However, our fallbacks, currently used on non Apple Arm CPUs
do not maintain the invariants.

They are implemented using clock_gettime and as such, wrap around fairly
regularly. They shouldn't wrap around quick enough that they are likely
to go around more than once.

This PR adds a "difference" function that will get the amount of ticks
between compared ticks. Within the runtime ticks are used to set
an amount of time to pause when there's no work to do and are used to
determine when to run the cycle detector.

Prior to this patch, on some Arm hardware, the cycle detector would end up running
very infrequently.