### PR TITLE
Fix non-release build crashes on Arm

### DIFF
--- a/.release-notes/3860.md
+++ b/.release-notes/3860.md
@@ -1,0 +1,5 @@
+## Fix non-release build crashes on Arm
+
+We've fixed a cause of "random" crashes that impacted at minimum, debug versions of Pony programs running on 32-bit Arm builds on the Raspberry Pi 4.
+
+It's likely that the crashes impacted debug versions of Pony programs running on all Arm systems, but we don't have enough testing infrastructure to know for sure.

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1401,27 +1401,7 @@ static void optimise(compile_t* c, bool pony_specific)
   }
 
   pmb.populateFunctionPassManager(fpm);
-
-  if(target_is_arm(c->opt->triple))
-  {
-    // On ARM, without this, trace functions are being loaded with a double
-    // indirection with a debug binary. An ldr r0, [LABEL] is done, loading
-    // the trace function address, but then ldr r2, [r0] is done to move the
-    // address into the 3rd arg to pony_traceobject. This double indirection
-    // gives a garbage trace function. In release mode, a different path is
-    // used and this error doesn't happen. Forcing an OptLevel of 1 for the MPM
-    // results in the alternate (working) asm being used for a debug build.
-    if(!c->opt->release)
-      pmb.OptLevel = 1;
-  }
-
   pmb.populateModulePassManager(mpm);
-
-  if(target_is_arm(c->opt->triple))
-  {
-    if(!c->opt->release)
-      pmb.OptLevel = 0;
-  }
 
   // LLVM 7 and up has a bug where running MergeFunctions more than once
   // causes an assert fail saying "Invalid RAUW on key of ValueMap". We can


### PR DESCRIPTION
The code removed in this commit dates to the very first Arm 32 support
that Sylvan added. It appears during the elapsed years, that the bug
that was being worked around was fixed. The workaround is now itself
a source of odd behavior and crashes for me as I try to get `main`
working on a Raspberry Pi 4 running a 32-bit version of Raspbian.

With the code as it stands before this patch is applied, I get
crashes when running the standard library tests in debug mode. I
can reliably reproduce using the `serialise` tests but it was
also happening "randomly" with other tests as well.

After removing Sylvan's workaround, I have seen a total lack of the
issue.

Closes #3851