### PR TITLE
Fix major source of runtime instability on non-x86 based platforms

### DIFF
--- a/.release-notes/3871.md
+++ b/.release-notes/3871.md
@@ -1,0 +1,3 @@
+## Fix major source of runtime instability on non-x86 based platforms
+
+We've replaced our existing code for handling [the ABA problem](https://en.wikipedia.org/wiki/ABA_problem) when running on Arm CPUs. The implementation we replaced was buggy and resulted in runtime instability including crashes and memory corruption.

--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -17,13 +17,7 @@ PONY_ABA_PROTECTED_PTR_DECLARE(mpmcq_node_t)
 typedef struct mpmcq_t
 {
   alignas(64) PONY_ATOMIC(mpmcq_node_t*) head;
-#ifdef PLATFORM_IS_X86
   PONY_ATOMIC_ABA_PROTECTED_PTR(mpmcq_node_t) tail;
-#else
-  // On ARM, the ABA problem is dealt with by the hardware with
-  // LoadLinked/StoreConditional instructions.
-  PONY_ATOMIC(mpmcq_node_t*) tail;
-#endif
 } mpmcq_t;
 
 void ponyint_mpmcq_init(mpmcq_t* q);


### PR DESCRIPTION
Within our pool and mpmcq implementations, we have code for handling
the ABA problem. The code is split into an X86 version and a "not X86"
version which at this time means "Arm".

The X86 version is heavily tested and works quite well. It has a theoretical
problem that needs to be addressed by deeper changes, but overall, it
is very solid.

The Arm code, on the other hand, isn't working properly. What exactly is wrong
isn't something that I've determined. What I can say is that when in use,
I am seeing issues with asserts being triggered related to scheduler muting
and memory pool usage. These asserts should only trigger if something is
very wrong.

The assert related problems felt like "an atomics issue" and really, like
a problem around the ABA code. I tested the changes in this PR on both 32-bit
and 64-bit ARM and all the problems disappeared. In particular, the test
was to run the message ubench stress test for approximately 18 hours. With
these changes, it ran fine. Without, I would see weird failure and what
looked like memory corruption anywhere from immediately to within 30 minutes.

Longer term, we need to replace the ABA related code in the Pony runtime with
a port of the queue and ABA code from Verona including its epoch implementation.
That change is a lot deeper and more complicated. In the meantime, the changes
in this PR will bring us very close to Pony being usable on Arm machines.

See https://en.wikipedia.org/wiki/ABA_problem if you aren't familiar
with the ABA problem and would like more background.