### PR TITLE
Fix segfaults with debug mode code on 64-bit Arm

### DIFF
--- a/.release-notes/3875.md
+++ b/.release-notes/3875.md
@@ -1,0 +1,5 @@
+## Fix segfaults with debug builds on 64-bit Arm
+
+Debug builds on 64-bit Arm platforms were segfaulting. The code generated when doing `ponyc --debug` wouldn't work and would eventually crash. We believe the source to be an LLVM bug but, aren't certain.
+
+We've introduced a work around that fixes the segfault problem, but does some optimization of debug builds for 64-bit Arm platforms. Additional investigation is underway. You can track progress by [following issue #3874](https://github.com/ponylang/ponyc/issues/3874).

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include "codegen.h"
+#include "genopt.h"
 #include "ponyassert.h"
 
 using namespace llvm;
@@ -27,8 +28,12 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt,
   if(opt->pic || opt->library)
     reloc = Reloc::PIC_;
 
+  // The Arm debug fix is a "temporary" fix for issue #3874
+  // https://github.com/ponylang/ponyc/issues/3874
+  // Hopefully we get #3874 figured out in a reasonable amount of time.
   CodeGenOpt::Level opt_level =
-    opt->release ? CodeGenOpt::Aggressive : CodeGenOpt::None;
+    opt->release ? CodeGenOpt::Aggressive :
+      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::None;
 
   TargetOptions options;
   options.TrapUnreachable = true;


### PR DESCRIPTION
While getting pony working on 64-bit Arm, we found a bug where the
`test-stdlib-debug` tests would segfault. Everything worked fine with `release`
builds, but `debug` builds would crash.

After investigation, we've found that in `codegen_machine` in `host.cc` if the
`opt_level` is get to either `CodeGenOpt::Default` or `CodeGenOpt::Aggressive`
 instead of `CodeGenOpt::None` the problem goes away.

It seems likely that this is an LLVM bug, but that hasn't been established.
We've committed a fix in `host.cc` that when the target is `arm` (which is
64-bit arm) that we use `CodeGenOpt::Default`. This is far from ideal, but gets
us working compilations until we can investigate further.

The end result of this should either be a patch that we upstream to LLVM or
possibly, the discovery that we are doing something wrong with our Arm code
generation that optimization manages to fix.