### PR TITLE
Add 64-bit Arm (Graviton) as a supported platform

### DIFF
--- a/.ci-dockerfiles/aarch64-unknown-linux-ubuntu20.04-builder/Dockerfile
+++ b/.ci-dockerfiles/aarch64-unknown-linux-ubuntu20.04-builder/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+
+# Keep annoying tzdata prompt from coming up
+# Thanks cmake!
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
+RUN apt-get -o Acquire::Max-FutureTime=86400 update \
+ && apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  build-essential \
+  clang \
+  cmake \
+  git \
+  make \
+  xz-utils \
+  zlib1g-dev \
+  curl \
+  python3-pip \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && pip3 install cloudsmith-cli
+
+# add user pony in order to not run tests as root
+RUN useradd -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/aarch64-unknown-linux-ubuntu20.04-builder/build-and-push.bash
+++ b/.ci-dockerfiles/aarch64-unknown-linux-ubuntu20.04-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+NAME="ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker buildx  build --platform linux/arm64 --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,6 +78,30 @@ task:
 task:
   only_if: $CIRRUS_PR != ''
 
+  arm_container:
+    image: ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder:20211003
+    cpu: 8
+    memory: 24
+
+  name: "PR: aarch64-unknown-linux-ubuntu20.04-builder"
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` aarch64-linux-gnu 20211003"
+    populate_script: make libs arch=armv8-a build_flags=-j8
+  upload_caches:
+    - libs
+
+  configure_script:
+    - make configure arch=armv8-a
+  build_script:
+    - make build arch=armv8-a
+  test_script:
+    - make test-ci arch=armv8-a
+
+task:
+  only_if: $CIRRUS_PR != ''
+
   container:
     image: ponylang/ponyc-ci-x86-64-unknown-linux-gnu-builder:20200423
     cpu: 8

--- a/.release-notes/3876.md
+++ b/.release-notes/3876.md
@@ -1,0 +1,5 @@
+## Add Graviton 64-bit Arm CPUs as a supported architecture
+
+We've add continuous integration testing on AWS Graviton instances via CirrusCI. All code changes going forward will be tested on Graviton.
+
+This provides us some fairly good coverage for "64-bit Arm" support in general although various other platforms like the Raspberry Pi 4B and Apple M1 chips are still "best effort" as we don't have any CI for them and we've found them to be somewhat different than Graviton.


### PR DESCRIPTION
We have CI for 64-bit Arm via Graviton. We know that at least
on the 64-bit Raspberry Pi that there are still issues.