### PR TITLE
Add a nightly stress test CI job

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -627,3 +627,90 @@ task:
     - ps: .\make.ps1 -Command package -Config Release -Prefix "build\install\release" -Version (Get-Content .\VERSION)
   upload_script:
     - ps: $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/releases build\ponyc-x86-64-pc-windows-msvc.zip
+
+# Nightly stress tests using message-ubench
+task:
+  only_if: $CIRRUS_CRON == "stress"
+
+  matrix:
+  - name: "Stress Test: x86-64-unknown-linux-ubuntu20.04 [release]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+    environment:
+      CACHE_BUSTER: 20210224
+      TRIPLE_VENDOR: unknown
+      TRIPLE_OS: linux-ubuntu20.04
+      TARGET: test-stress-release
+  - name: "Stress Test: x86-64-unknown-linux-ubuntu20.04 [debug]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+    environment:
+      CACHE_BUSTER: 20210224
+      TRIPLE_VENDOR: unknown
+      TRIPLE_OS: linux-ubuntu20.04
+      TARGET: test-stress-debug
+  - name: "Stress Test: x86-64-unknown-linux-musl [release]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+    environment:
+      CACHE_BUSTER: 20210224
+      TRIPLE_VENDOR: unknown
+      TRIPLE_OS: linux-musl
+      TARGET: test-stress-release
+  - name: "Stress Test: x86-64-unknown-linux-musl [debug]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+    environment:
+      CACHE_BUSTER: 20210224
+      TRIPLE_VENDOR: unknown
+      TRIPLE_OS: linux-musl
+      TARGET: test-stress-debug
+
+  container:
+    cpu: 8
+    memory: 24
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script:
+      - echo "`md5sum lib/CMakeLists.txt` ${TRIPLE_VENDOR}-${TRIPLE_OS} ${CACHE_BUSTER} stress"
+    populate_script: make libs build_flags=-j8
+  upload_caches:
+    - libs
+
+  configure_script:
+    - make configure config=debug
+  build_script:
+    - make build config=debug
+  stress_test_script:
+    - make ${TARGET} config=debug
+
+task:
+  only_if: $CIRRUS_CRON == "stress"
+
+  arm_container:
+    image: ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder:20211003
+    cpu: 8
+    memory: 24
+
+  matrix:
+    - name: "Stress Test: arm64-unknown-linux-gnu-builder [release]"
+      environment:
+        TARGET: test-stress-release
+    - name: "Stress Test: arm64-unknown-linux-gnu-builder [debug]"
+      environment:
+        TARGET: test-stress-debug
+
+  libs_cache:
+    folder: build/libs
+    fingerprint_script: echo "`md5sum lib/CMakeLists.txt` aarch64-linux-gnu 20211003 stress"
+    populate_script: make libs build_flags=-j8
+  upload_caches:
+    - libs
+
+  configure_script:
+    - make configure config=debug
+  build_script:
+    - make build config=debug
+  stress_test_script:
+    - make ${TARGET} config=debug

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ ifdef use
 endif
 
 .DEFAULT_GOAL := build
-.PHONY: all libs cleanlibs configure cross-configure build test test-ci test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-validate-grammar clean
+.PHONY: all libs cleanlibs configure cross-configure build test test-ci test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'
@@ -204,6 +204,12 @@ test-examples: all
 
 test-validate-grammar: all
 	$(SILENT)cd '$(outDir)' && ./ponyc --antlr >> pony.g.new && diff ../../pony.g pony.g.new
+
+test-stress-release: all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../examples/message-ubench && echo Built `pwd`/ubench && $(cross_runner) ./ubench --pingers 320 --initial-pings 5 --report-count 1 --report-interval 18000 --ponynoblock --ponynoscale
+
+test-stress-debug: all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../examples/message-ubench && echo Built `pwd`/ubench && $(cross_runner) ./ubench --pingers 320 --initial-pings 5 --report-count 1 --report-interval 18000 --ponynoblock --ponynoscale
 
 clean:
 	$(SILENT)([ -d '$(buildDir)' ] && cd '$(buildDir)' && cmake --build '$(buildDir)' --config $(config) --target clean) || true


### PR DESCRIPTION
Runs message-ubench on 3 platforms making sure we don't get any
crashes. This can help verify that we don't have bugs that
have snuck past the shorter PR tests.

We run both release and debug versions of ubench to check for any
issues with either optimization level.

A debug version of the ponyc runtime is used so that we will trigger
any asserts if they are violated.

Currently the stress test is set to run for 30 minutes for each version.