### PR TITLE
Add Apple Silicon as a supported platform

### DIFF
--- a/.release-notes/m1.md
+++ b/.release-notes/m1.md
@@ -1,0 +1,3 @@
+## Add Apple Silicon as a supported platform
+
+Pony is now supported on Apple Silicon (M1 processors). Our support is "best effort" for now, since we currently lack continuous integration for Apple Silicon. Users on this platform will need to install Pony from source for the time being.

--- a/BUILD.md
+++ b/BUILD.md
@@ -71,10 +71,21 @@ Note that you only need to run `make libs` once the first time you build (or if 
 
 ## macOS
 
+For Intel-based macOS:
+
 ```bash
 make libs
 make configure
 make build
+sudo make install
+```
+
+For Apple Silicon macOS (M1 processors):
+
+```bash
+make libs
+make configure arch=armv8
+make build arch=armv8
 sudo make install
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ To install the most recent ponyc on macOS for Intel:
 ponyup update ponyc release
 ```
 
-At this time, Pony is unsupported on M1 Apple Silicon. We are interested in getting Pony working on Apple Silicon but need assistance. If you have access to M1 Apple Silicon and would like to get Pony working, please contact us on the [ponylang Zulip](https://ponylang.zulipchat.com/#narrow/stream/192795-contribute-to.20Pony/topic/m1.20help).
+At this time, we don't offer prebuilt Pony binaries for M1 Apple Silicon. You will need to build Pony [from source](BUILD.md).
 
 ## Windows
 

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -466,14 +466,14 @@ TEST_F(CodegenTest, DoNotOptimiseApplyPrimitive)
 }
 
 
-// Doesn't work on windows. The C++ code doesn't catch C++ exceptions if they've
-// traversed a Pony frame. This is suspected to be related to how SEH and LLVM
-// exception code generation interact.
+// Doesn't work on windows or on Apple Silicon. The C++ code doesn't catch C++
+// exceptions if they've traversed a Pony frame. This is suspected to be related
+// to how SEH and LLVM exception code generation interact.
 // See https://github.com/ponylang/ponyc/issues/2455 for more details.
 //
 // This test is disabled on LLVM 3.9 and 4.0 because exceptions crossing JIT
 // boundaries are broken with the ORC JIT on these versions.
-#if !defined(PLATFORM_IS_WINDOWS)
+#if !(defined(PLATFORM_IS_WINDOWS) || (defined(PLATFORM_IS_MACOSX) && defined(PLATFORM_IS_ARM)))
 TEST_F(CodegenTest, TryBlockCantCatchCppExcept)
 {
   const char* src =


### PR DESCRIPTION
Pony is now supported on Apple Silicon (M1 processors). Our support is "best effort" for now, since we currently lack continuous integration for Apple Silicon. Users on this platform will need to install Pony from source for the time being.