### PR TITLE
Update build time googletest dependency to 1.11.0

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,8 +19,13 @@ ExternalProject_Add(gbenchmark
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
 )
 
+set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.11.0.tar.gz)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+    set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz)
+endif()
+
 ExternalProject_Add(googletest
-    URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz
+    URL ${PONYC_GOOGLETEST_URL}
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=-fpic -Dgtest_force_shared_crt=ON --no-warn-unused-cli
 )
 


### PR DESCRIPTION
This commit leaves FreeBSD at 1.10.00 because 1.11.0 isn't working
on FreeBSD.