### PR TITLE
Increase timeout for stress test runs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -594,6 +594,8 @@ task:
 task:
   only_if: $CIRRUS_CRON == "stress"
 
+  timeout_in: 120m
+
   matrix:
   - name: "Stress Test: x86-64-unknown-linux-ubuntu20.04 [release]"
     container:
@@ -653,6 +655,8 @@ task:
 
 task:
   only_if: $CIRRUS_CRON == "stress"
+
+  timeout_in: 120m
 
   arm_container:
     image: ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder:20211003


### PR DESCRIPTION
Tonight we had a musl based job take 39 minutes to build LLVM which
ended up with us timing out just before the 20 minute stress test
finished.

With this commit, we get an extra 20 minutes which should be enough.