### PR TITLE
add message error warning about rhs (fixes #3823)

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -333,7 +333,11 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   ast_t* r_type = ast_type(right);
 
   if(is_typecheck_error(r_type))
+  {
+    ast_error(opt->check.errors, ast,
+      "right side must be something that can be assigned");
     return false;
+  }
 
   if(ast_checkflag(right, AST_FLAG_JUMPS_AWAY))
   {
@@ -343,7 +347,13 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   }
 
   if(!infer_locals(opt, left, r_type))
+  {
+    /*
+    TODO: maybe add an ast_error here too, but I don't
+    know what error would happen here ~ mateus-md
+    */
     return false;
+  }
 
   // Inferring locals may have changed the left type.
   l_type = ast_type(left);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -334,8 +334,10 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
   if(is_typecheck_error(r_type))
   {
-    ast_error(opt->check.errors, ast,
-      "right side must be something that can be assigned");
+    if(errors_get_count(opt->check.errors) == 0){
+      ast_error(opt->check.errors, ast,
+        "right side must be something that can be assigned");
+    }
     return false;
   }
 
@@ -347,13 +349,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   }
 
   if(!infer_locals(opt, left, r_type))
-  {
-    /*
-    TODO: maybe add an ast_error here too, but I don't
-    know what error would happen here ~ mateus-md
-    */
     return false;
-  }
 
   // Inferring locals may have changed the left type.
   l_type = ast_type(left);


### PR DESCRIPTION
As suggested by @jemc in the issue #3823, I added an `ast_error` before returning false to the switch statement (see the issue for more details).
I saw more cases like this but I was not sure what error report, so I left a TODO instead.