### PR TITLE
Contribution and doc build guidelines

### DIFF
--- a/packages/stdlib/index.md
+++ b/packages/stdlib/index.md
@@ -1,0 +1,18 @@
+# Standard Library
+
+Contains all packages available within the standard library.
+
+## Contributions
+
+If you wish to contribute to improving this documentation, please open pull requests on the [ponyc](https://github.com/ponylang/ponyc) repository after reading through our [contributing](https://github.com/ponylang/ponyc/blob/main/CONTRIBUTING.md) guidelines.
+
+### Building Documentation Locally
+
+Pony has a documentation generator which builds into mkdocs format; we then use `mkdocs` to build and deploy the documentation. In brief, these are the steps to build a local instance of the `stdlib` documentation.
+
+```console
+ponyc packages/stdlib --docs-public --pass expr
+sed -i 's/site_name:\ stdlib/site_name:\ Pony Standard Library/' stdlib-docs/mkdocs.yml
+sed -i -e '1 e cat packages/stdlib/index.md' stdlib-docs/docs/index.md
+cd stdlib-docs; mkdocs serve; cd ../
+```


### PR DESCRIPTION
Will close #1829 when merged.

Had to use a bit of `sed` to insert a "fake" index page in the correct place.

Improvements as I see them prior to merging:

+ Process currently does not match the existing docs building process from [CI](https://github.com/ponylang/ponyc/blob/main/.ci-scripts/build-and-push-stdlib-documentation.bash) -- this process of adding content will need to change the CI process as well (once the process is agreed upon)
+ Using `sed` to insert at the top of the file is dropping the final blank line from the incoming `index.md` -- we need this blank line to be copied or a new blank be added otherwise "Packages" will be put in the final paragraph on the MkDocs `index.md`
+ Actual content being inserted is meek right now -- improvements are in the future, my initial work here was to "get it working" rather than focus too much on "is it perfect"