### PR TITLE
Switch macOS PRs to run against Monterey

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,7 +126,7 @@ task:
   timeout_in: 120m
 
   osx_instance:
-    image: big-sur-xcode-12.5
+    image: monterey-xcode-13.1
 
   name: "x86-64 Apple Darwin"
 
@@ -135,7 +135,7 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 lib/CMakeLists.txt` macos big-sur-xcode-12.5 20210710"
+    fingerprint_script: echo "`md5 lib/CMakeLists.txt` macos monterey-xcode-13.1 20210710"
     populate_script: make libs build_flags=-j12
   upload_caches:
     - libs


### PR DESCRIPTION
Until this is proven working, the nightlies and releases will stay
on Big Sur. Given there is a ponyc release coming very soon, I
want to delay the nightlies and releases updates until after that release
is done.