### PR TITLE
Lower requested RAM for Linux nightly and release builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -310,7 +310,7 @@ task:
 
   container:
     cpu: 8
-    memory: 24
+    memory: 4
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
@@ -478,7 +478,7 @@ task:
 
   container:
     cpu: 8
-    memory: 24
+    memory: 4
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]


### PR DESCRIPTION
Checking the history of our usage, we never use more than a little
over 3 gigs of memory. By setting our requested amount at 4, we
might be able to get additional concurrent VMs and complete the
release processes quicker.