### PR TITLE
Update Google benchmark dependency

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT DEFINED PONYC_LIBS_BUILD_TYPE)
     set(PONYC_LIBS_BUILD_TYPE Release)
 endif()
 
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.4.tar.gz)
+set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz)
 endif()


### PR DESCRIPTION
1.5.4 is unable to build with clang 13. Upgrading to 1.5.6 should
address that issue.

We still can't update FreeBSD as 1.5.3 continues to be the last
version that builds on it.