### PR TITLE
Fix underlying time source for Time.nanos() on macOS

### DIFF
--- a/.release-notes/clock_uptime_raw.md
+++ b/.release-notes/clock_uptime_raw.md
@@ -1,0 +1,6 @@
+## Fix underlying time source for Time.nanos() on macOS
+
+Previously, we were using `mach_absolute_time` on macOS to get the number of ticks since boot, with the assumption that ticks increment at nanosecond intervals. However, as noted by [Apple](https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code#Apply-Timebase-Information-to-Mach-Absolute-Time-Values), this assumption is flawed on Apple Silicon, and will also affect any binaries that were built on Intel, as the Rosetta 2 translator will not apply any time conversion.
+
+The recommended replacement to `mach_absolute_time` is to use `clock_gettime_nsec_np` with a clock of type `CLOCK_UPTIME_RAW`.
+


### PR DESCRIPTION
Previously, we were using `mach_absolute_time` on macOS to get the number of ticks since boot, with the assumption that ticks increment at nanosecond intervals. However, as noted by [Apple](https://developer.apple.com/documentation/apple-silicon/addressing-architectural-differences-in-your-macos-code#Apply-Timebase-Information-to-Mach-Absolute-Time-Values), this assumption is flawed on Apple Silicon, and will also affect any binaries that were built on Intel, as the Rosetta 2 translator will not apply any time conversion.

The recommended replacement to `mach_absolute_time` is to use `clock_gettime_nsec_np` with a clock of type `CLOCK_UPTIME_RAW`.

Joe already applied this fix to `cpu.c` on 197b952d3d753a15a088d9a1bb9043295d588280, but we missed the call to `mach_absolute_time` on `time.pony`