### PR TITLE
WIP Introduce apply() getters for JSON data.

### DIFF
--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -652,30 +652,38 @@ class iso _TestApplyGetter is UnitTest
   fun name(): String => "JSON/apply.getter"
 
   fun apply(h: TestHelper) ? =>
-		// create an iso JSON document with a map
-		let doc_iso: JsonDoc iso = recover iso
-			JsonDoc.>parse("""{ "stuff" : 123, "inner" : [ 1,2,3 ] }""")?
-		end
+    // create an iso JSON document with a map
+    let doc_iso: JsonDoc iso = recover iso
+      JsonDoc.>parse("""{ "stuff" : 123, "inner" : [ 1,2,3 ] }""")?
+    end
 
-		// sanity check to confirm that the "canary" values do not exist
-		let jtxt: String val = doc_iso.string()
-		h.assert_false(jtxt.contains("more_stuff"))
-		h.assert_false(jtxt.contains("789"))
+    // sanity check to confirm that the "canary" values do not exist
+    let jtxt: String val = doc_iso.string()
+    h.assert_false(jtxt.contains("more_stuff"))
+    h.assert_false(jtxt.contains("789"))
 
-		// now perform an update to the map and recover the iso
-		let doc_iso' = recover iso
-			let jdoc_ref = consume ref doc_iso
-			// below is an example of JsonDoc.apply() as well as JsonObject.apply()
-			let map_ref: Map[String, JsonType] ref = (jdoc_ref() as JsonObject)()
-			map_ref("more_stuff") = I64(456)
-			let json_array: JsonArray ref = (map_ref("inner")? as JsonArray)
-			// below is an example of JsonArray.apply()
-			let array_ref: Array[JsonType] ref = json_array()
-			array_ref.push(I64(789))
-			jdoc_ref
-		end
+    // now perform an update to the map and recover the iso
+    let doc_iso' = recover iso
+      let jdoc_ref = consume ref doc_iso
+      // below is an example of JsonDoc.apply() as well as JsonObject.apply()
+      let map_ref: Map[String, JsonType] ref = (jdoc_ref() as JsonObject)()
+      map_ref("more_stuff") = I64(456)
 
-		// now check for the newly added "canary" values
-		let jtxt': String val = doc_iso'.string()
-		h.assert_true(jtxt'.contains("more_stuff"))
-		h.assert_true(jtxt'.contains("789"))
+      // examples of sugar access
+      (jdoc_ref() as JsonObject)()("exclusive_sugar") = true
+      (jdoc_ref() as JsonObject).apply()("mixed_sugar") = true
+      (jdoc_ref.apply() as JsonObject)
+        .apply().update("no_sugar" where value = true)
+
+      // below is an example of JsonArray.apply()
+      let json_array: JsonArray ref = (map_ref("inner")? as JsonArray)
+      let array_ref: Array[JsonType] ref = json_array()
+      array_ref.push(I64(789))
+
+      jdoc_ref
+    end
+
+    // now check for the newly added "canary" values
+    let jtxt': String val = doc_iso'.string()
+    h.assert_true(jtxt'.contains("more_stuff"))
+    h.assert_true(jtxt'.contains("789"))

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -27,6 +27,12 @@ class JsonDoc
     """
     data = None
 
+  fun apply(): this->JsonType! =>
+	"""
+	A getter to access the document data relative to the receiver's reference capability.
+	"""
+    data
+
   fun string(indent: String = "", pretty_print: Bool = false): String =>
     """
     Generate string representation of this document.

--- a/packages/json/json_doc.pony
+++ b/packages/json/json_doc.pony
@@ -27,7 +27,7 @@ class JsonDoc
     """
     data = None
 
-  fun apply(): this->JsonType! =>
+  fun apply(): this->JsonType =>
 	"""
 	A getter to access the document data relative to the receiver's reference capability.
 	"""

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -23,6 +23,13 @@ class JsonArray
     """
     data = data'
 
+  fun apply(): this->Array[JsonType]! =>
+	"""
+	A getter to access the array data relative to the receiver's reference
+	capability.
+	"""
+    data
+
   fun string(indent: String = "", pretty_print: Bool = false): String =>
     """
     Generate string representation of this array.
@@ -93,6 +100,13 @@ class JsonObject
     Create a Json object from a map.
     """
     data = data'
+
+  fun apply(): this->Map[String, JsonType]! =>
+	"""
+	A getter to access the map data relative to the receiver's reference
+	capability.
+	"""
+    data
 
   fun string(indent: String = "", pretty_print: Bool = false): String =>
     """

--- a/packages/json/json_type.pony
+++ b/packages/json/json_type.pony
@@ -23,7 +23,7 @@ class JsonArray
     """
     data = data'
 
-  fun apply(): this->Array[JsonType]! =>
+  fun apply(): this->Array[JsonType] =>
 	"""
 	A getter to access the array data relative to the receiver's reference
 	capability.
@@ -101,7 +101,7 @@ class JsonObject
     """
     data = data'
 
-  fun apply(): this->Map[String, JsonType]! =>
+  fun apply(): this->Map[String, JsonType] =>
 	"""
 	A getter to access the map data relative to the receiver's reference
 	capability.


### PR DESCRIPTION
This introduces a viewpoint for accessing the internal data for a JSON
element: document, object, array.

This simplifies the process for modifying `iso` instances of `JsonDoc`
after prior creation.

ponylang/ponyc#3922