### PR TITLE
Fix `cli` package from mangling option arguments with equal signs

### DIFF
--- a/.release-notes/fix_cli.md
+++ b/.release-notes/fix_cli.md
@@ -1,0 +1,24 @@
+## Fix `cli` package from mangling option arguments with equal signs
+
+The current command parser in the `cli` package cuts option arguments of `String` type at the first equal sign. This release fixes the problem for long options (`--option=foo=bar`) and for short options such as `-O=foo=bar`. Short options such as `-Ofoo=bar` will continue to raise an "ambiguous args" error.
+
+The code below shows the bug, with the option argument being cut short at the first equal sign. The code below prints "foo" instead of the complete value, "foo=bar". The same is true when uses the short version of the option, like `-t=foo=bar`.
+
+```pony
+use "cli"
+
+actor Main
+  new create(env: Env) =>
+    try
+      let cs =
+        CommandSpec.leaf("simple", "", [
+          OptionSpec.string("test" where short' = 't')
+        ])?
+      
+      let args: Array[String] = [
+        "ignored"; "--test=foo=bar"
+      ]
+      let cmdErr = CommandParser(cs).parse(args) as Command
+      env.out.print(cmdErr.option("test").string())
+    end
+```

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -249,8 +249,7 @@ class iso _TestShortsAdj is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "-BS--"; "-swords=with=signs"
-      "-I42"; "-U47"; "-F42.0"; "-zaaa"; "-zbbb"
+      "-BS--"; "-I42"; "-U47"; "-F42.0"; "-zaaa"; "-zbbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
@@ -259,7 +258,6 @@ class iso _TestShortsAdj is UnitTest
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("--", cmd.option("stringr").string())
-    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
@@ -267,6 +265,18 @@ class iso _TestShortsAdj is UnitTest
     h.assert_eq[USize](2, stringso.string_seq().size())
     h.assert_eq[String]("aaa", stringso.string_seq()(0)?)
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
+
+    let ambiguous_args: Array[String] = [
+      "ignored"; "-swords=with=signs"
+    ]
+    let cmdSyntax = CommandParser(cs).parse(ambiguous_args)
+    match cmdSyntax
+    | let se: SyntaxError =>
+      h.assert_eq[String](
+        "Error: ambiguous args for short option at: 's'", se.string())
+    else
+      h.fail("expected syntax error for ambiguous args: " + cmdSyntax.string())
+    end
 
 class iso _TestShortsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -249,7 +249,8 @@ class iso _TestShortsAdj is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "-BS--"; "-I42"; "-U47"; "-F42.0"; "-zaaa"; "-zbbb"
+      "-BS--"; "-swords=with=signs"
+      "-I42"; "-U47"; "-F42.0"; "-zaaa"; "-zbbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
@@ -258,6 +259,7 @@ class iso _TestShortsAdj is UnitTest
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
@@ -275,7 +277,8 @@ class iso _TestShortsEq is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "-BS=astring"; "-I=42"; "-U=47"; "-F=42.0"; "-z=aaa"; "-z=bbb"
+      "-BS=astring"; "-s=words=with=signs"
+      "-I=42"; "-U=47"; "-F=42.0"; "-z=aaa"; "-z=bbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
@@ -284,6 +287,7 @@ class iso _TestShortsEq is UnitTest
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("astring", cmd.option("stringr").string())
+    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
@@ -301,7 +305,8 @@ class iso _TestShortsNext is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "-BS"; "--"; "-I"; "42"; "-U"; "47"
+      "-BS"; "--"; "-s"; "words=with=signs"
+      "-I"; "42"; "-U"; "47"
       "-F"; "42.0"; "-z"; "aaa"; "-z"; "bbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
@@ -311,6 +316,7 @@ class iso _TestShortsNext is UnitTest
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
@@ -320,7 +326,7 @@ class iso _TestShortsNext is UnitTest
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
 
 class iso _TestLongsEq is UnitTest
-  fun name(): String => "ponycli/shorts_eq"
+  fun name(): String => "ponycli/longs_eq"
 
   // Rules 4, 5, 7
   fun apply(h: TestHelper) ? =>
@@ -328,8 +334,9 @@ class iso _TestLongsEq is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "--boolr=true"; "--stringr=astring"; "--intr=42"; "--uintr=47"
-      "--floatr=42.0"; "--stringso=aaa"; "--stringso=bbb"
+      "--boolr=true"; "--stringr=astring"; "--stringo=words=with=signs"
+      "--intr=42"; "--uintr=47"; "--floatr=42.0"
+      "--stringso=aaa"; "--stringso=bbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
@@ -338,6 +345,7 @@ class iso _TestLongsEq is UnitTest
 
     h.assert_eq[Bool](true, cmd.option("boolr").bool())
     h.assert_eq[String]("astring", cmd.option("stringr").string())
+    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
@@ -355,8 +363,9 @@ class iso _TestLongsNext is UnitTest
 
     let args: Array[String] = [
       "ignored"
-      "--boolr"; "--stringr"; "--"; "--intr"; "42"; "--uintr"; "47"
-      "--floatr"; "42.0"; "--stringso"; "aaa"; "--stringso"; "bbb"
+      "--boolr"; "--stringr"; "--"; "--stringo"; "words=with=signs"
+      "--intr"; "42"; "--uintr"; "47"; "--floatr"; "42.0"
+      "--stringso"; "aaa"; "--stringso"; "bbb"
     ]
     let cmdErr = CommandParser(cs).parse(args)
     h.log("Parsed: " + cmdErr.string())
@@ -364,6 +373,7 @@ class iso _TestLongsNext is UnitTest
     let cmd = cmdErr as Command
 
     h.assert_eq[String]("--", cmd.option("stringr").string())
+    h.assert_eq[String]("words=with=signs", cmd.option("stringo").string())
     h.assert_eq[I64](42, cmd.option("intr").i64())
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -208,7 +208,9 @@ class CommandParser
     --opt=foo => --opt has argument foo
     --opt foo => --opt has argument foo, iff arg is required
     """
-    let parts = token.split("=")
+    // Only split the token in two parts. If argument contains '=',
+    // and the token is of the form --opt=foo=bar, then targ will contain foo=bar
+    let parts = token.split("=", 2)
     let name = try parts(0)? else "???" end
     let targ = try parts(1)? else None end
     match _option_with_name(name)

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -235,7 +235,7 @@ class CommandParser
     -abc=Foo => options a, b, c. c has argument Foo.
     -abc Foo => options a, b, c. c has argument Foo iff its arg is required.
     """
-    let parts = token.split("=")
+    let parts = token.split("=", 2)
     let shorts = (try parts(0)? else "" end).clone()
     var targ = try parts(1)? else None end
 


### PR DESCRIPTION
The current command parser in the `cli` package cuts option arguments of `String` type at the first equal sign. This release fixes the problem for long options (`--option=foo=bar`) and for short options such as `-O=foo=bar`. Short options such as `-Ofoo=bar` will continue to raise an "ambiguous args" error.

The code below shows the bug, with the option argument being cut short at the first equal sign. The code below prints "foo" instead of the complete value, "foo=bar". The same is true when uses the short version of the option, like `-t=foo=bar`.

```pony
use "cli"

actor Main
  new create(env: Env) =>
    try
      let cs =
        CommandSpec.leaf("simple", "", [
          OptionSpec.string("test" where short' = 't')
        ])?
      
      let args: Array[String] = [
        "ignored"; "--test=foo=bar"
      ]
      let cmdErr = CommandParser(cs).parse(args) as Command
      env.out.print(cmdErr.option("test").string())
    end
```
