### PR TITLE
Clarify wording for some subtyping errors

### DIFF
--- a/.release-notes/3933.md
+++ b/.release-notes/3933.md
@@ -1,0 +1,6 @@
+## Clarify wording for some subtyping errors
+
+The wording of a small number of errors relating
+to the subtyping of capabilities were improved.
+These were previously technically incorrect,
+or otherwise unnecessarily obtuse.

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -241,7 +241,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     if(!is_subtype(arg_type, wp_type, &info, opt))
     {
       errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument cannot be assigned to parameter");
+      ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(arg_type));
       ast_error_frame(&frame, param, "parameter requires %s",

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -241,10 +241,10 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     if(!is_subtype(arg_type, wp_type, &info, opt))
     {
       errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument not a subtype of parameter");
+      ast_error_frame(&frame, arg, "argument cannot be assigned to parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(arg_type));
-      ast_error_frame(&frame, param, "parameter type is %s",
+      ast_error_frame(&frame, param, "parameter requires %s",
                       ast_print_type(wp_type));
       errorframe_append(&frame, &info);
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -244,7 +244,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(arg_type));
-      ast_error_frame(&frame, param, "parameter requires %s",
+      ast_error_frame(&frame, param, "parameter type requires %s",
                       ast_print_type(wp_type));
       errorframe_append(&frame, &info);
 

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -241,7 +241,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
     if(!is_subtype(arg_type, wp_type, &info, opt))
     {
       errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument not a subtype of parameter");
+      ast_error_frame(&frame, arg, "argument not assignable to parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(arg_type));
       ast_error_frame(&frame, param, "parameter type requires %s",

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -72,7 +72,7 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
       !is_subtype(a_type, p_type, &info, opt))
     {
       errorframe_t frame = NULL;
-      ast_error_frame(&frame, arg, "argument not a subtype of parameter");
+      ast_error_frame(&frame, arg, "argument not a assignable to parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(a_type));
       ast_error_frame(&frame, param, "parameter type requires %s",

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -75,7 +75,7 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
       ast_error_frame(&frame, arg, "argument not a subtype of parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
                       ast_print_type(a_type));
-      ast_error_frame(&frame, param, "parameter type is %s",
+      ast_error_frame(&frame, param, "parameter type requires %s",
                       ast_print_type(p_type));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -106,7 +106,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
       if(!is_subtype(v_type, type, &info, opt))
       {
         errorframe_t frame = NULL;
-        ast_error_frame(&frame, value, "argument not a subtype of parameter");
+        ast_error_frame(&frame, value, "argument not assignable to parameter");
         ast_error_frame(&frame, value, "argument type is %s",
                         ast_print_type(v_type));
         ast_error_frame(&frame, id_node, "parameter type requires %s",

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -109,7 +109,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
         ast_error_frame(&frame, value, "argument not a subtype of parameter");
         ast_error_frame(&frame, value, "argument type is %s",
                         ast_print_type(v_type));
-        ast_error_frame(&frame, id_node, "parameter type is %s",
+        ast_error_frame(&frame, id_node, "parameter type requires %s",
                         ast_print_type(p_type));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -140,7 +140,6 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
           ast_id(super_eph)))
           ast_error_frame(errorf, sub_cap,
             "this would be possible if the subcap were more ephemeral, such as by using `consume`");
-        }
       }
 
       return false;

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -140,7 +140,7 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
           ast_id(super_eph)))
           ast_error_frame(errorf, sub_cap,
             "this would be possible if the subcap were more ephemeral."
-            "Perhaps you meant to consume a variable here.");
+            "Perhaps you meant to consume a variable here");
       }
 
       return false;

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -139,7 +139,8 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
         if(is_cap_sub_cap(ast_id(sub_cap), TK_EPHEMERAL, ast_id(super_cap),
           ast_id(super_eph)))
           ast_error_frame(errorf, sub_cap,
-            "this would be possible if the subcap were more ephemeral, such as by using `consume`");
+            "this would be possible if the subcap were more ephemeral."
+            "Perhaps you meant to consume a variable here.");
       }
 
       return false;

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -139,7 +139,8 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
         if(is_cap_sub_cap(ast_id(sub_cap), TK_EPHEMERAL, ast_id(super_cap),
           ast_id(super_eph)))
           ast_error_frame(errorf, sub_cap,
-            "this would be possible if the subcap were more ephemeral");
+            "this would be possible if the subcap were more ephemeral, such as by using `consume`");
+        }
       }
 
       return false;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -753,7 +753,7 @@ TEST_F(BadPonyTest, AsFromUninferredReference)
     "    true";
 
   TEST_ERRORS_2(src,
-    "argument not a subtype of parameter",
+    "argument not assignable to parameter",
     "cannot infer type of b");
 }
 
@@ -1047,7 +1047,7 @@ TEST_F(BadPonyTest, ThisViewpointWithIsoReceiver)
     "  let opaque : A tag = A.create()\n"
     "  let not_opaque : A box = (consume revealer).reveal(opaque)\n";
 
-  TEST_ERRORS_1(src, "argument not a subtype of parameter");
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
 
 TEST_F(BadPonyTest, DisallowPointerAndMaybePointerInEmbeddedType)

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -83,7 +83,7 @@ TEST_F(RecoverTest, CanSee_LetLocalRefAsTag)
     "    let inner: Inner ref = Inner\n"
     "    recover Wrap(inner) end";
 
-  TEST_ERRORS_1(src, "argument not a subtype of parameter");
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
 
 TEST_F(RecoverTest, CanAccess_LetLocalVal)
@@ -128,7 +128,7 @@ TEST_F(RecoverTest, CanSee_VarLocalRefAsTag)
     "    var inner: Inner ref = Inner\n"
     "    recover Wrap(inner) end";
 
-  TEST_ERRORS_1(src, "argument not a subtype of parameter");
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
 
 TEST_F(RecoverTest, CanAccess_VarLocalVal)
@@ -172,7 +172,7 @@ TEST_F(RecoverTest, CanSee_ParamRefAsTag)
     "  fun apply(inner: Inner ref): Wrap iso =>\n"
     "    recover Wrap(inner) end";
 
-  TEST_ERRORS_1(src, "argument not a subtype of parameter");
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
 
 TEST_F(RecoverTest, CanAccess_ParamVal)


### PR DESCRIPTION
A few subtyping errors were technically incorrect, or unnecessarily obtuse. This improves the wording to better clarify the meaning of these.

Fixes #3929 and #3928