### PR TITLE
Fix inability to fully build pony on Raspberry PI 4's with 64-bit Raspbian

### DIFF
--- a/.release-notes/3949.md
+++ b/.release-notes/3949.md
@@ -1,0 +1,5 @@
+## Fix inability to fully build pony on Raspberry PI 4's with 64-bit Raspbian
+
+Building on 64-bit Raspbian needs the flag `-fPIC` instead of `-fpic` which is used by default on Unix builds.
+
+We've added a Makefile flag `pic_flag` that you can set to either `-fpic` or `-fPIC` for both libs and configure steps, e.g. `make libs pic_flag=-fPIC` and `make configure pic_flag=-fPIC`. It will default to `-fpic` if not specified.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,16 @@ endif()
 # LLVM component setup
 message("Compiler architecture is ${_compiler_arch}")
 
+if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
+    if(_compiler_arch STREQUAL "aarch64")
+        set(PONY_PIC_FLAG "-fPIC")
+    else()
+        set(PONY_PIC_FLAG "-fpic")
+    endif()
+else()
+    set(PONY_PIC_FLAG "-fpic")
+endif()
+
 if(NOT PONY_CROSS_LIBPONYRT)
     set(LLVM_COMPONENTS
         core
@@ -190,8 +200,8 @@ if(MSVC)
         $<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>
     )
 else()
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wextra -Wall -Wno-unknown-warning-option -fpic -fexceptions")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fno-rtti -fpic -fexceptions")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wextra -Wall -Wno-unknown-warning-option ${PONY_PIC_FLAG} -fexceptions")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11 -fno-rtti ${PONY_PIC_FLAG} -fexceptions")
     add_link_options(-rdynamic)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,17 @@ if(NOT DEFINED PONY_ARCH)
     set(PONY_ARCH "native")
 endif()
 
+# System information
+message("-- CMAKE_SYSTEM_INFO_FILE: ${CMAKE_SYSTEM_INFO_FILE}")
+message("-- CMAKE_SYSTEM_NAME:      ${CMAKE_SYSTEM_NAME}")
+message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+message("-- CMAKE_SYSTEM:           ${CMAKE_SYSTEM}")
+
 set(_compiler_arch ${CMAKE_C_COMPILER_ARCHITECTURE_ID})
 if("${_compiler_arch}" STREQUAL "")
     set(_compiler_arch ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
-# LLVM component setup
 message("Compiler architecture is ${_compiler_arch}")
 
 if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
@@ -120,6 +125,7 @@ else()
     set(PONY_PIC_FLAG "-fpic")
 endif()
 
+# LLVM component setup
 if(NOT PONY_CROSS_LIBPONYRT)
     set(LLVM_COMPONENTS
         core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,14 +115,10 @@ endif()
 
 message("Compiler architecture is ${_compiler_arch}")
 
-if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
-    if(_compiler_arch STREQUAL "aarch64")
-        set(PONY_PIC_FLAG "-fPIC")
-    else()
+if(NOT MSVC)
+    if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
         set(PONY_PIC_FLAG "-fpic")
     endif()
-else()
-    set(PONY_PIC_FLAG "-fpic")
 endif()
 
 # LLVM component setup

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ build_flags ?= -j2
 llvm_archs ?= X86;ARM;AArch64
 llvm_config ?= Release
 llc_arch ?= x86-64
+pic_flag ?=
 
 ifndef version
   version := $(shell cat VERSION)
@@ -156,7 +157,7 @@ endif
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'
-	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(libsBuildDir)' -S '$(libsSrcDir)' -DCMAKE_INSTALL_PREFIX="$(libsOutDir)" -DCMAKE_BUILD_TYPE="$(llvm_config)" -DLLVM_TARGETS_TO_BUILD="$(llvm_archs)" $(CMAKE_FLAGS)
+	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(libsBuildDir)' -S '$(libsSrcDir)' -DPONY_PIC_FLAG=$(pic_flag) -DCMAKE_INSTALL_PREFIX="$(libsOutDir)" -DCMAKE_BUILD_TYPE="$(llvm_config)" -DLLVM_TARGETS_TO_BUILD="$(llvm_archs)" $(CMAKE_FLAGS)
 	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --build '$(libsBuildDir)' --target install --config $(llvm_config) -- $(build_flags)
 
 cleanlibs:
@@ -165,7 +166,7 @@ cleanlibs:
 
 configure:
 	$(SILENT)mkdir -p '$(buildDir)'
-	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(buildDir)' -S '$(srcDir)' -DCMAKE_BUILD_TYPE=$(config) -DPONY_ARCH=$(arch) -DPONYC_VERSION=$(tag) -DCMAKE_C_FLAGS="-march=$(arch) -mtune=$(tune)" -DCMAKE_CXX_FLAGS="-march=$(arch) -mtune=$(tune)" $(BITCODE_FLAGS) $(LTO_CONFIG_FLAGS) $(CMAKE_FLAGS) $(PONY_USES)
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(buildDir)' -S '$(srcDir)' -DCMAKE_BUILD_TYPE=$(config) -DPONY_ARCH=$(arch) -DPONY_PIC_FLAG=$(pic_flag) -DPONYC_VERSION=$(tag) -DCMAKE_C_FLAGS="-march=$(arch) -mtune=$(tune)" -DCMAKE_CXX_FLAGS="-march=$(arch) -mtune=$(tune)" $(BITCODE_FLAGS) $(LTO_CONFIG_FLAGS) $(CMAKE_FLAGS) $(PONY_USES)
 
 all: build
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,12 +9,17 @@ if(NOT DEFINED PONYC_LIBS_BUILD_TYPE)
     set(PONYC_LIBS_BUILD_TYPE Release)
 endif()
 
+# System information
+message("-- CMAKE_SYSTEM_INFO_FILE: ${CMAKE_SYSTEM_INFO_FILE}")
+message("-- CMAKE_SYSTEM_NAME:      ${CMAKE_SYSTEM_NAME}")
+message("-- CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+message("-- CMAKE_SYSTEM:           ${CMAKE_SYSTEM}")
+
 set(_compiler_arch ${CMAKE_C_COMPILER_ARCHITECTURE_ID})
 if("${_compiler_arch}" STREQUAL "")
     set(_compiler_arch ${CMAKE_SYSTEM_PROCESSOR})
 endif()
 
-# LLVM component setup
 message("Compiler architecture is ${_compiler_arch}")
 
 if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
@@ -26,6 +31,8 @@ if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
 else()
     set(PONY_PIC_FLAG "-fpic")
 endif()
+
+# Libraries
 
 set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,24 @@ if(NOT DEFINED PONYC_LIBS_BUILD_TYPE)
     set(PONYC_LIBS_BUILD_TYPE Release)
 endif()
 
+set(_compiler_arch ${CMAKE_C_COMPILER_ARCHITECTURE_ID})
+if("${_compiler_arch}" STREQUAL "")
+    set(_compiler_arch ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
+# LLVM component setup
+message("Compiler architecture is ${_compiler_arch}")
+
+if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
+    if(_compiler_arch STREQUAL "aarch64")
+        set(PONY_PIC_FLAG "-fPIC")
+    else()
+        set(PONY_PIC_FLAG "-fpic")
+    endif()
+else()
+    set(PONY_PIC_FLAG "-fpic")
+endif()
+
 set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz)
@@ -16,7 +34,7 @@ endif()
 
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=-fpic --no-warn-unused-cli
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
 )
 
 set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.11.0.tar.gz)
@@ -26,7 +44,7 @@ endif()
 
 ExternalProject_Add(googletest
     URL ${PONYC_GOOGLETEST_URL}
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=-fpic -Dgtest_force_shared_crt=ON --no-warn-unused-cli
+    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} -Dgtest_force_shared_crt=ON --no-warn-unused-cli
 )
 
 add_library(blake2 STATIC blake2/blake2b-ref.c)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -22,14 +22,10 @@ endif()
 
 message("Compiler architecture is ${_compiler_arch}")
 
-if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
-    if(_compiler_arch STREQUAL "aarch64")
-        set(PONY_PIC_FLAG "-fPIC")
-    else()
+if(NOT MSVC)
+    if((NOT DEFINED PONY_PIC_FLAG) OR (PONY_PIC_FLAG STREQUAL ""))
         set(PONY_PIC_FLAG "-fpic")
     endif()
-else()
-    set(PONY_PIC_FLAG "-fpic")
 endif()
 
 # Libraries


### PR DESCRIPTION
- Adds a Makefile variable `pic_flag` that you can set to either `-fpic` or `-fPIC` for both `make libs` and `make configure`
- ~~On `aarch64`, the variable will default to `-fPIC` for `make libs` and `make configure` (see #3870); on other Unix architectures it will be set to `-fpic`~~.
- Fixes #3870