### PR TITLE
Hide C header implementation details related to actor pad size.

### DIFF
--- a/.release-notes/hide_actor_pad_size.md
+++ b/.release-notes/hide_actor_pad_size.md
@@ -1,0 +1,8 @@
+## Hide C header implementation details related to actor pad size.
+
+Previously, in the `pony.h` header that exposes the "public API" of the Pony runtime, information about the size of an actor struct was published as public information.
+
+This change removes that from the public header into a private header, to hide
+implementation details that may be subject to change in future versions of the Pony runtime.
+
+This change does not impact Pony programs - only C programs using the `pony.h` header to use the Pony runtime in some other way than inside of a Pony program, or to create custom actors written in C.

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -11,6 +11,7 @@
 #include "../reach/paint.h"
 #include "../type/assemble.h"
 #include "../type/lookup.h"
+#include "../../libponyrt/actor/actor.h"
 #include "../../libponyrt/mem/heap.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -41,6 +41,33 @@ typedef struct pony_actor_t
   gc_t gc; // 48/88 bytes
 } pony_actor_t;
 
+/** Padding for actor types.
+ *
+ * 56 bytes: initial header, not including the type descriptor
+ * 52/104 bytes: heap
+ * 48/88 bytes: gc
+ * 28/0 bytes: padding to 64 bytes, ignored
+ */
+#if INTPTR_MAX == INT64_MAX
+#ifdef USE_MEMTRACK
+#  define PONY_ACTOR_PAD_SIZE 280
+#else
+#  define PONY_ACTOR_PAD_SIZE 248
+#endif
+#elif INTPTR_MAX == INT32_MAX
+#ifdef USE_MEMTRACK
+#  define PONY_ACTOR_PAD_SIZE 176
+#else
+#  define PONY_ACTOR_PAD_SIZE 160
+#endif
+#endif
+
+typedef struct pony_actor_pad_t
+{
+  pony_type_t* type;
+  char pad[PONY_ACTOR_PAD_SIZE];
+} pony_actor_pad_t;
+
 enum
 {
   FLAG_BLOCKED = 1 << 0,

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -179,33 +179,6 @@ typedef struct pony_language_features_init_t
   size_t descriptor_table_size;
 } pony_language_features_init_t;
 
-/** Padding for actor types.
- *
- * 56 bytes: initial header, not including the type descriptor
- * 52/104 bytes: heap
- * 48/88 bytes: gc
- * 28/0 bytes: padding to 64 bytes, ignored
- */
-#if INTPTR_MAX == INT64_MAX
-#ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 280
-#else
-#  define PONY_ACTOR_PAD_SIZE 248
-#endif
-#elif INTPTR_MAX == INT32_MAX
-#ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 176
-#else
-#  define PONY_ACTOR_PAD_SIZE 160
-#endif
-#endif
-
-typedef struct pony_actor_pad_t
-{
-  pony_type_t* type;
-  char pad[PONY_ACTOR_PAD_SIZE];
-} pony_actor_pad_t;
-
 /// The currently executing context.
 PONY_API pony_ctx_t* pony_ctx();
 


### PR DESCRIPTION
Previously, in the `pony.h` header that exposes the "public API" of the Pony runtime, information about the size of an actor struct was published as public information.

This change removes that from the public header into a private header, to hide
implementation details that may be subject to change in future versions of the Pony runtime.

This change does not impact Pony programs - only C programs using the `pony.h` header to use the Pony runtime in some other way than inside of a Pony program, or to create custom actors written in C.

---

This commit moves the `PONY_ACTOR_PAD_SIZE` preprocessor value and `pony_actor_pad_t` struct into `actor.h`.
