### PR TITLE
Refactor pony actor pad size as a function instead of preprocessor value.

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -193,7 +193,7 @@ static void init_runtime(compile_t* c)
   c->object_ptr = LLVMPointerType(c->object_type, 0);
 
   // padding required in an actor between the descriptor and fields
-  c->actor_pad = LLVMArrayType(c->i8, PONY_ACTOR_PAD_SIZE);
+  c->actor_pad = LLVMArrayType(c->i8, ponyint_actor_pad_size());
 
   // message
   params[0] = c->i32; // size
@@ -274,7 +274,7 @@ static void init_runtime(compile_t* c)
   LLVM_DECLARE_ATTRIBUTEREF(noalias_attr, noalias, 0);
   LLVM_DECLARE_ATTRIBUTEREF(noreturn_attr, noreturn, 0);
   LLVM_DECLARE_ATTRIBUTEREF(deref_actor_attr, dereferenceable,
-    PONY_ACTOR_PAD_SIZE + align_value);
+    ponyint_actor_pad_size() + align_value);
   LLVM_DECLARE_ATTRIBUTEREF(align_attr, align, align_value);
   LLVM_DECLARE_ATTRIBUTEREF(deref_or_null_alloc_attr, dereferenceable_or_null,
     HEAP_MIN);

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -41,33 +41,6 @@ typedef struct pony_actor_t
   gc_t gc; // 48/88 bytes
 } pony_actor_t;
 
-/** Padding for actor types.
- *
- * 56 bytes: initial header, not including the type descriptor
- * 52/104 bytes: heap
- * 48/88 bytes: gc
- * 28/0 bytes: padding to 64 bytes, ignored
- */
-#if INTPTR_MAX == INT64_MAX
-#ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 280
-#else
-#  define PONY_ACTOR_PAD_SIZE 248
-#endif
-#elif INTPTR_MAX == INT32_MAX
-#ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 176
-#else
-#  define PONY_ACTOR_PAD_SIZE 160
-#endif
-#endif
-
-typedef struct pony_actor_pad_t
-{
-  pony_type_t* type;
-  char pad[PONY_ACTOR_PAD_SIZE];
-} pony_actor_pad_t;
-
 enum
 {
   FLAG_BLOCKED = 1 << 0,
@@ -79,6 +52,17 @@ enum
   FLAG_UNDER_PRESSURE = 1 << 6,
   FLAG_CD_CONTACTED = 1 << 7,
 };
+
+#define PONYINT_RETURN_STATIC_ASSERT_ACTOR_PAD_SIZE(s) \
+  pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) == \
+    sizeof(pony_type_t*) + s, "Wrong actor pad size!"); \
+  return s;
+
+unsigned int ponyint_actor_pad_size();
+
+unsigned int ponyint_actor_base_size();
+
+void* ponyint_actor_fields(pony_actor_t* actor);
 
 bool has_flag(pony_actor_t* actor, uint8_t flag);
 


### PR DESCRIPTION
From the perspective of LLVM optimizations, this easily-inlined function
that returns a constant value should be the same a preprocessor value.

This change is desirable because if the actor pad comes from a function value,
and if the runtime is compiled as LLVM bitcode, it will be possible
for the Pony compiler to change the actor pad by modifying that
function's return value within the LLVM IR (decoded from the bitcode),
prior to linking LLVM optimizations and prior to linking with the user
program.

This means future work will be able to allow features like "memtrack"
(which need to change the size of the actor pad, among other things)
to be toggleable at Pony program compile time, provided that the
Pony user is using the `--runtimebc` feature.