### PR TITLE
Remove simplebuiltin compiler option

### DIFF
--- a/.release-notes/bye-simplebuiltin.md
+++ b/.release-notes/bye-simplebuiltin.md
@@ -1,0 +1,5 @@
+## Remove simplebuiltin compiler option
+
+The ponyc option `simplebuiltin` was never useful to users but had been exposed for testing purposes for Pony developers. We've removed the need for the "simplebuiltin" package for testing and have remove both it and the compiler option.
+
+Technically, this is a breaking change, but no end-users should be impacted.

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -58,7 +58,6 @@ enum
   OPT_FILENAMES,
   OPT_CHECKTREE,
   OPT_EXTFUN,
-  OPT_SIMPLEBUILTIN,
   OPT_LINT_LLVM,
   OPT_LLVM_ARGS,
 
@@ -106,7 +105,6 @@ static opt_arg_t std_args[] =
   {"files", '\0', OPT_ARG_NONE, OPT_FILENAMES},
   {"checktree", '\0', OPT_ARG_NONE, OPT_CHECKTREE},
   {"extfun", '\0', OPT_ARG_NONE, OPT_EXTFUN},
-  {"simplebuiltin", '\0', OPT_ARG_NONE, OPT_SIMPLEBUILTIN},
   {"lint-llvm", '\0', OPT_ARG_NONE, OPT_LINT_LLVM},
 #ifndef NDEBUG
   {"llvm-args", '\0', OPT_ARG_REQUIRED, OPT_LLVM_ARGS},
@@ -191,7 +189,6 @@ static void usage(void)
     "  --checktree      Verify AST well-formedness.\n"
     "  --verify         Verify LLVM IR.\n"
     "  --extfun         Set function default linkage to external.\n"
-    "  --simplebuiltin  Use a minimal builtin package.\n"
     "  --files          Print source file names as each is processed.\n"
     "  --bnf            Print out the Pony grammar as human readable BNF.\n"
     "  --antlr          Print out the Pony grammar as an ANTLR file.\n"
@@ -348,7 +345,6 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
       case OPT_IMMERR: errors_set_immediate(opt->check.errors, true); break;
       case OPT_VERIFY: opt->verify = true; break;
       case OPT_EXTFUN: opt->extfun = true; break;
-      case OPT_SIMPLEBUILTIN: opt->simple_builtin = true; break;
       case OPT_FILENAMES: opt->print_filenames = true; break;
       case OPT_CHECKTREE: opt->check_tree = true; break;
       case OPT_LINT_LLVM: opt->lint_llvm = true; break;

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -273,7 +273,6 @@ typedef struct pass_opt_t
   bool print_stats;
   bool verify;
   bool extfun;
-  bool simple_builtin;
   bool strip_debug;
   bool print_filenames;
   bool check_tree;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -42,24 +42,6 @@
 #  pragma warning(disable:4996)
 #endif
 
-
-static const char* const simple_builtin =
-  "primitive Bool\n"
-  "  new create(a: Bool) => a\n"
-  "primitive U8 is Real[U8]\n"
-  "  new create(a: U8) => a\n"
-  "primitive U32 is Real[U32]\n"
-  "  new create(a: U32) => a\n"
-  "trait val Real[A: Real[A] val]\n"
-  "type Number is (U8 | U32)\n"
-  "primitive None\n"
-  "struct Pointer[A]\n"
-  "class val Env\n"
-  "  new _create(argc: U32, argv: Pointer[Pointer[U8]] val,\n"
-  "    envp: Pointer[Pointer[U8]] val)\n"
-  "  => None";
-
-
 DECLARE_HASHMAP_SERIALISE(package_set, package_set_t, package_t)
 
 // Per package state
@@ -802,9 +784,6 @@ bool package_init(pass_opt_t* opt)
   }
 
   opt->safe_packages = full_safe;
-
-  if(opt->simple_builtin)
-    package_add_magic_src("builtin", simple_builtin, opt);
 
   return true;
 }


### PR DESCRIPTION
The ponyc option `simplebuiltin` was never useful to users but had been exposed
for testing purposes for Pony developers. We've removed the need for the
"simplebuiltin" package for testing and have remove both it and the compiler
option.

Technically, this is a breaking change, but no end-users should be impacted.