### PR TITLE
Actually pass arg to internal.x86.cpuid

### DIFF
--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -1914,12 +1914,10 @@ static void make_cpuid(compile_t* c)
     LLVMValueRef fun = codegen_addfun(c, "internal.x86.cpuid", f_type, false);
     LLVMSetFunctionCallConv(fun, LLVMCCallConv);
     codegen_startfun(c, fun, NULL, NULL, NULL, false);
+    LLVMValueRef cpuid = LLVMGetInlineAsm(f_type, "cpuid", 5, "={ax},={bx},={cx},={dx},{ax}", 28, false, false, LLVMInlineAsmDialectATT, false);
+    LLVMValueRef arg = LLVMGetParam(fun, 0);
 
-    LLVMValueRef cpuid = LLVMConstInlineAsm(f_type,
-      "cpuid", "={ax},={bx},={cx},={dx},{ax}", false, false);
-    LLVMValueRef zero = LLVMConstInt(c->i32, 0, false);
-
-    LLVMValueRef result = LLVMBuildCall(c->builder, cpuid, &zero, 1, "");
+    LLVMValueRef result = LLVMBuildCall(c->builder, cpuid, &arg, 1, "");
     LLVMBuildRet(c->builder, result);
 
     codegen_finishfun(c);


### PR DESCRIPTION
in order to get all the possible information out of the cpuid instructions.
Previously it has only been used in time.pony for performance measurements to
avoid reordering of instructions together with RDTSCP. Now it can be used to detect CPU features.

Example of the current behaviour prior to this PR:

```pony
use @"internal.x86.cpuid"[(I32, I32, I32, I32)](eax: I32)

actor Main
  new create(env: Env) =>
    (let a1, let b1, let c1, let d1) = @"internal.x86.cpuid"(I32(0))
    (let a2, let b2, let c2, let d2) = @"internal.x86.cpuid"(I32(1))
    env.out.print("a1 == a2 -> " + (a1 == a2).string())
    env.out.print("b1 == b2 -> " + (b1 == b2).string())
    env.out.print("c1 == c2 -> " + (c1 == c2).string())
    env.out.print("d1 == d2 -> " + (d1 == d2).string())
```

According to https://en.wikipedia.org/wiki/CPUID those calls should have completely different outputs.

I don't know if this needs a Changelog entry, but I am happy to provide one.