### PR TITLE
Fix compilation issue with clang 13 / gcc 11 on linux 5.15

### DIFF
--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -181,7 +181,7 @@ bool ponyint_thread_create(pony_thread_id_t* thread, thread_fn start,
   // Let's use RLIMIT_STACK's current limit if it is sane.
   if(getrlimit(RLIMIT_STACK, &limit) == 0 &&
     limit.rlim_cur != RLIM_INFINITY &&
-    limit.rlim_cur >= PTHREAD_STACK_MIN)
+    limit.rlim_cur >= (unsigned long)PTHREAD_STACK_MIN)
   {
 #if defined(PLATFORM_IS_LINUX)
     if(cpu != (uint32_t)-1 && use_numa)

--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -181,7 +181,7 @@ bool ponyint_thread_create(pony_thread_id_t* thread, thread_fn start,
   // Let's use RLIMIT_STACK's current limit if it is sane.
   if(getrlimit(RLIMIT_STACK, &limit) == 0 &&
     limit.rlim_cur != RLIM_INFINITY &&
-    limit.rlim_cur >= (unsigned long)PTHREAD_STACK_MIN)
+    limit.rlim_cur >= (rlim_t)PTHREAD_STACK_MIN)
   {
 #if defined(PLATFORM_IS_LINUX)
     if(cpu != (uint32_t)-1 && use_numa)


### PR DESCRIPTION
Tested in pop! OS 21.10 with kernel 5.15. The `rlim_t` type has been changed to `unsigned long int`, it seems.

Let's see if CI with an older kernel reports breakage.