### PR TITLE
Don't allow interfaces to have private methods

### DIFF
--- a/.release-notes/3973.md
+++ b/.release-notes/3973.md
@@ -1,0 +1,76 @@
+## Don't allow interfaces to have private methods
+
+When Pony allowed interfaces to have private methods, it was possible to use an interface to break encapsulation for objects and access private methods from outside their enclosing package.
+
+The following code used to be legal Pony code but will now fail with a compiler error:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let x: String ref = "sailor".string()
+    let y: Foo = x
+    y._set(0, 'f')
+    env.out.print("Hello, " + x)
+
+interface Foo
+  fun ref _set(i: USize, value: U8): U8
+```
+
+If you were previously using interfaces with private methods in your code, you'll need to switch them to being traits and then use nominal typing on all the implementers.
+
+For example:
+
+```pony
+interface Foo
+  fun ref _bar()
+```
+
+would become:
+
+```pony
+trait Foo
+  fun ref _bar()
+```
+
+And any objects that need to provide `Foo` would be changed from:
+
+```pony
+class ProvidesFoo
+```
+
+to
+
+```pony
+class ProvidesFoo is Foo
+```
+
+We believe that the only impact of this change will primarily be a single interface in the standard library `AsioEventNotify` and updates that need to be done to deal with it changing from an interface to a trait.
+
+If you are unable to make the changes above, it means that you were taking the encapsulation violation bug we've fixed and will need to rethink your design. If you need assistance with such a redesign, please stop by the [Pony Zulip](https://ponylang.zulipchat.com/) and we'll do what we can to help.
+
+## Change `builtin/AsioEventNotify` from an interface to a trait
+
+The "Don't allow interfaces to have private methods" change that is part of this release required that we change the `AsioEventNotify` interface to a trait.
+If you are one of the few users outside of the standard library to be using the ASIO subsystem directly in your Pony code, you'll need to make an update to
+conform to this change.
+
+Where previously you had something like:
+
+```pony
+class AsioEventReceivingClass
+  be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
+    ...
+```
+
+You'll need to switch to using nominal typing rather than structural:
+
+```pony
+class AsioEventReceivingClass is AsioEventNotify
+  be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
+    ...
+```
+
+As far as we know, there are two codebases that will be impacted by this change:
+
+- [Lori](https://github.com/seantallen-org/lori)
+- [Wallaroo](https://github.com/wallaroolabs/wally)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Fix return checking in behaviours and constructors ([PR #3971](https://github.com/ponylang/ponyc/pull/3971))
 - Fix issue that could lead to a muted actor being run ([PR #3974](https://github.com/ponylang/ponyc/pull/3974))
+- Fix loophole that allowed interfaces to be used to violate encapsulation ([PR #3973](https://github.com/ponylang/ponyc/pull/3973))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Remove simplebuiltin compiler option ([PR #3965](https://github.com/ponylang/ponyc/pull/3965))
 - Remove library mode option from ponyc ([PR #3975](https://github.com/ponylang/ponyc/pull/3975))
+- Change `builtin/AsioEventNotify` from an interface to a trait ([PR #3973](https://github.com/ponylang/ponyc/pull/3973))
 
 ## [0.46.0] - 2022-01-16
 

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -1,6 +1,6 @@
 type AsioEventID is Pointer[AsioEvent] tag
 
-interface tag AsioEventNotify
+trait tag AsioEventNotify
   be _event_notify(event: AsioEventID, flags: U32, arg: U32)
 
 primitive AsioEvent

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -39,7 +39,7 @@ interface tag InputStream
     """
     None
 
-actor Stdin
+actor Stdin is AsioEventNotify
   """
   Asynchronous access to stdin. The constructor is private to ensure that
   access is provided only via an environment.

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -30,7 +30,7 @@ use @pony_os_peername[Bool](fd: U32, ip: NetAddress tag)
 
 type TCPConnectionAuth is (AmbientAuth | NetAuth | TCPAuth | TCPConnectAuth)
 
-actor TCPConnection
+actor TCPConnection is AsioEventNotify
   """
   A TCP connection. When connecting, the Happy Eyeballs algorithm is used.
 

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -8,7 +8,7 @@ use @pony_os_listen_tcp6[AsioEventID](owner: AsioEventNotify, host: Pointer[U8] 
 
 type TCPListenerAuth is (AmbientAuth | NetAuth | TCPAuth | TCPListenAuth)
 
-actor TCPListener
+actor TCPListener is AsioEventNotify
   """
   Listens for new network connections.
 

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -18,7 +18,7 @@ use @pony_os_multicast_interface[None](fd: U32, from: Pointer[U8] tag)
 
 type UDPSocketAuth is (AmbientAuth | NetAuth | UDPAuth)
 
-actor UDPSocket
+actor UDPSocket is AsioEventNotify
   """
   Creates a UDP socket that can be used for sending and receiving UDP messages.
 

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -6,7 +6,7 @@ use "time"
 
 type ProcessMonitorAuth is (AmbientAuth | StartProcessAuth)
 
-actor ProcessMonitor
+actor ProcessMonitor is AsioEventNotify
   """
   Fork+execs / creates a child process and monitors it. Notifies a client about
   STDOUT / STDERR events.

--- a/packages/signals/signal_handler.pony
+++ b/packages/signals/signal_handler.pony
@@ -7,7 +7,7 @@ use @pony_asio_event_create[AsioEventID](
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
-actor SignalHandler
+actor SignalHandler is AsioEventNotify
   """
   Listen for a specific signal.
   If the wait parameter is true, the program will not terminate until the SignalHandler's dispose method is called, or if the SignalNotify returns false, after handling the signal as this also disposes the SignalHandler and unsubscribes it.

--- a/packages/time/timers.pony
+++ b/packages/time/timers.pony
@@ -10,7 +10,7 @@ use @pony_asio_event_setnsec[U32](event: AsioEventID, nsec: U64)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
-actor Timers
+actor Timers is AsioEventNotify
   """
   A hierarchical set of timing wheels.
   """

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -528,6 +528,7 @@ ast_result_t pass_verify(ast_t** astp, pass_opt_t* options)
   {
     case TK_STRUCT:       r = verify_struct(options, ast); break;
     case TK_ASSIGN:       r = verify_assign(options, ast); break;
+    case TK_INTERFACE:    r = verify_interface(options, ast); break;
     case TK_FUN:
     case TK_NEW:
     case TK_BE:           r = verify_fun(options, ast); break;

--- a/src/libponyc/verify/type.c
+++ b/src/libponyc/verify/type.c
@@ -66,3 +66,38 @@ bool verify_struct(pass_opt_t* opt, ast_t* ast)
 
   return ok;
 }
+
+bool verify_interface(pass_opt_t* opt, ast_t* ast)
+{
+  pony_assert(ast_id(ast) == TK_INTERFACE);
+
+  AST_GET_CHILDREN(ast, id, typeparams, defcap, provides, members, c_api);
+
+  ast_t* member = ast_child(members);
+  while(member != NULL)
+  {
+    switch(ast_id(member))
+    {
+      case TK_FUN:
+      case TK_BE:
+      {
+        AST_GET_CHILDREN(member, cap, id, type_params, params, return_type,
+          error, body, docstring);
+
+        const char* type_id_name = ast_name(id);
+
+        if(is_name_private(type_id_name))
+        {
+          ast_error(opt->check.errors, member,
+          "interfaces can't have private methods, only traits can.");
+        }
+      }
+      default: {}
+    }
+
+    member = ast_sibling(member);
+  }
+
+  return true;
+}
+

--- a/src/libponyc/verify/type.c
+++ b/src/libponyc/verify/type.c
@@ -71,9 +71,11 @@ bool verify_interface(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_INTERFACE);
 
-  AST_GET_CHILDREN(ast, id, typeparams, defcap, provides, members, c_api);
+  bool ok = true;
 
+  AST_GET_CHILDREN(ast, id, typeparams, defcap, provides, members, c_api);
   ast_t* member = ast_child(members);
+
   while(member != NULL)
   {
     switch(ast_id(member))
@@ -88,8 +90,9 @@ bool verify_interface(pass_opt_t* opt, ast_t* ast)
 
         if(is_name_private(type_id_name))
         {
-          ast_error(opt->check.errors, member,
-          "interfaces can't have private methods, only traits can.");
+          ast_error(opt->check.errors, id,
+            "interfaces can't have private methods, only traits can.");
+          ok = false;
         }
       }
       default: {}
@@ -98,6 +101,6 @@ bool verify_interface(pass_opt_t* opt, ast_t* ast)
     member = ast_sibling(member);
   }
 
-  return true;
+  return ok;
 }
 

--- a/src/libponyc/verify/type.c
+++ b/src/libponyc/verify/type.c
@@ -91,7 +91,7 @@ bool verify_interface(pass_opt_t* opt, ast_t* ast)
         if(is_name_private(type_id_name))
         {
           ast_error(opt->check.errors, id,
-            "interfaces can't have private methods, only traits can.");
+            "interfaces can't have private methods, only traits can");
           ok = false;
         }
       }

--- a/src/libponyc/verify/type.h
+++ b/src/libponyc/verify/type.h
@@ -3,11 +3,13 @@
 
 #include <platform.h>
 #include "../ast/ast.h"
+#include "../ast/id.h"
 #include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
 bool verify_struct(pass_opt_t* opt, ast_t* ast);
+bool verify_interface(pass_opt_t* opt, ast_t* ast);
 
 PONY_EXTERN_C_END
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1060,11 +1060,11 @@ TEST_F(BadPonyTest, DisallowPointerAndMaybePointerInEmbeddedType)
     "  embed ok: Ok = Ok\n"
     "  embed not_ok: Pointer[None] = Pointer[None]\n"
     "  embed also_not_ok: NullablePointer[Ok] = NullablePointer[Ok](Ok)\n"
-    
+
     "actor Main\n"
     "new create(env: Env) =>\n"
     "  Whoops";
-    
+
   TEST_ERRORS_2(src,
     "embedded fields must be classes or structs",
     "embedded fields must be classes or structs")
@@ -1101,4 +1101,15 @@ TEST_F(BadPonyTest, AllowNestedTupleAccess)
 
   TEST_ERRORS_1(src,
     "Cannot look up member _2 on a literal")
+}
+
+TEST_F(BadPonyTest, InterfacesCantHavePrivateMethods)
+{
+  // From issue #2287
+  const char* src =
+    "interface Foo\n"
+    "  fun ref _set(i: USize, value: U8): U8";
+
+  TEST_ERRORS_1(src,
+    "interfaces can't have private methods, only traits can.")
 }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1111,5 +1111,5 @@ TEST_F(BadPonyTest, InterfacesCantHavePrivateMethods)
     "  fun ref _set(i: USize, value: U8): U8";
 
   TEST_ERRORS_1(src,
-    "interfaces can't have private methods, only traits can.")
+    "interfaces can't have private methods, only traits can")
 }


### PR DESCRIPTION
When Pony allowed interfaces to have private methods, it was possible to use an interface to break encapsulation for objects and access private methods from outside their enclosing package.

The following code used to be legal Pony code but will now fail with a compiler error:

```pony
actor Main
  new create(env: Env) =>
    let x: String ref = "sailor".string()
    let y: Foo = x
    y._set(0, 'f')
    env.out.print("Hello, " + x)

interface Foo
  fun ref _set(i: USize, value: U8): U8
```

`AsioEventNotify` in the standard library had to be changed from an interface with a single private method to a trait in order to conform with this change.

Fixes #2772