### PR TITLE
Add "nodoc" annotation

### DIFF
--- a/.release-notes/nodoc.md
+++ b/.release-notes/nodoc.md
@@ -1,0 +1,7 @@
+##  Add "nodoc" annotation
+
+The can be used to control the pony compilers documentation generation, any structure that can have a docstring (except packages) can be annotated with \nodoc\ to prevent documentation from being generated.
+
+This replaces a hack that has existed in the documentation generation system for several years to filter out items that were "for testing" by looking for Test and _Test at the beginning of the name as well as providing UnitTest or TestList.
+
+Note that the "should we include this package" hack to filter oupackages called "test" and "builtin_test" still exists for the timbeing until we have further discussion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Remove library mode option from ponyc ([PR #3975](https://github.com/ponylang/ponyc/pull/3975))
 - Change `builtin/AsioEventNotify` from an interface to a trait ([PR #3973](https://github.com/ponylang/ponyc/pull/3973))
 - Don't allow interfaces to have private methods ([PR #3973](https://github.com/ponylang/ponyc/pull/3973))
+- Remove hack that prevented documentation generation for "test classes" ([PR #3978](https://github.com/ponylang/ponyc/pull/3978))
 
 ## [0.46.0] - 2022-01-16
 

--- a/packages/buffered/_test.pony
+++ b/packages/buffered/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -9,7 +9,7 @@ actor Main is TestList
     test(_TestReader)
     test(_TestWriter)
 
-class iso _TestReader is UnitTest
+class \nodoc\ iso _TestReader is UnitTest
   """
   Test adding to and reading from a Reader.
   """
@@ -198,7 +198,7 @@ class iso _TestReader is UnitTest
     // the last byte is consumed by the reader
     h.assert_eq[USize](b.size(), 0)
 
-class iso _TestWriter is UnitTest
+class \nodoc\ iso _TestWriter is UnitTest
   """
   Test writing to and reading from a Writer.
   """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -16,7 +16,7 @@ use @ponyint_pagemap_get[Pointer[None]](p: Pointer[None] tag)
 use "ponytest"
 use "collections"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -103,7 +103,7 @@ actor Main is TestList
   fun @runtime_override_defaults(rto: RuntimeOptions) =>
      rto.ponynoblock = true
 
-class iso _TestAbs is UnitTest
+class \nodoc\ iso _TestAbs is UnitTest
   """
   Test abs function
   """
@@ -144,7 +144,7 @@ class iso _TestAbs is UnitTest
     h.assert_eq[U128](124, I128(-124).abs())
     h.assert_eq[U128](0, I128(0).abs())
 
-class iso _TestRotate is UnitTest
+class \nodoc\ iso _TestRotate is UnitTest
   """
   Test rotl and rotr function
   """
@@ -201,7 +201,7 @@ class iso _TestRotate is UnitTest
     h.assert_eq[U128](0x0F00, U128(0x0F00).rotr(128))
     h.assert_eq[U128](0x00F0, U128(0x0F00).rotr(132))
 
-class iso _TestStringRunes is UnitTest
+class \nodoc\ iso _TestStringRunes is UnitTest
   """
   Test iterating over the unicode codepoints in a string.
   """
@@ -216,7 +216,7 @@ class iso _TestStringRunes is UnitTest
 
     h.assert_array_eq[U32]([0x16dd; 'x'; 0xfb04], result)
 
-class iso _TestIntToString is UnitTest
+class \nodoc\ iso _TestIntToString is UnitTest
   """
   Test converting integers to strings.
   """
@@ -227,7 +227,7 @@ class iso _TestIntToString is UnitTest
     h.assert_eq[String]("3", U32(3).string())
     h.assert_eq[String]("1234", U32(1234).string())
 
-class iso _TestFloatToString is UnitTest
+class \nodoc\ iso _TestFloatToString is UnitTest
   """
   Test converting floats to strings.
   """
@@ -241,7 +241,7 @@ class iso _TestFloatToString is UnitTest
     h.assert_eq[String]("-0.35", F64(-3.5e-1).string())
     h.assert_eq[String]("123.125", F64(123.125).string())
 
-class iso _TestStringToBool is UnitTest
+class \nodoc\ iso _TestStringToBool is UnitTest
   """
   Test converting strings to Bools.
   """
@@ -255,7 +255,7 @@ class iso _TestStringToBool is UnitTest
 
     h.assert_error({() ? => "bogus".bool()? })
 
-class iso _TestStringToFloat is UnitTest
+class \nodoc\ iso _TestStringToFloat is UnitTest
   """
   Test converting strings to floats.
   """
@@ -324,7 +324,7 @@ class iso _TestStringToFloat is UnitTest
       h.assert_error({() ? => invalid_float.f64()? }, invalid_float + " did not fail for .f64()")
     end
 
-class iso _TestStringToU8 is UnitTest
+class \nodoc\ iso _TestStringToU8 is UnitTest
   """
   Test converting strings to U8s.
   """
@@ -353,7 +353,7 @@ class iso _TestStringToU8 is UnitTest
     h.assert_error({() ? => "0b3".u8()? }, "U8 0b3")
     h.assert_error({() ? => "0d4".u8()? }, "U8 0d4")
 
-class iso _TestStringToI8 is UnitTest
+class \nodoc\ iso _TestStringToI8 is UnitTest
   """
   Test converting strings to I8s.
   """
@@ -383,7 +383,7 @@ class iso _TestStringToI8 is UnitTest
     h.assert_error({() ? => "0b3".i8()? }, "U8 0b3")
     h.assert_error({() ? => "0d4".i8()? }, "U8 0d4")
 
-class iso _TestStringToIntLarge is UnitTest
+class \nodoc\ iso _TestStringToIntLarge is UnitTest
   """
   Test converting strings to I* and U* types bigger than 8 bit.
   """
@@ -432,7 +432,7 @@ class iso _TestStringToIntLarge is UnitTest
     h.assert_eq[I128](-10, "-10".i128()?)
     h.assert_error({() ? => "30L".i128()? }, "I128 30L")
 
-class iso _TestStringLstrip is UnitTest
+class \nodoc\ iso _TestStringLstrip is UnitTest
   """
   Test stripping leading characters from a string.
   """
@@ -446,7 +446,7 @@ class iso _TestStringLstrip is UnitTest
     h.assert_eq[String](recover "  foobar  ".clone() .> lstrip() end,
       "foobar  ")
 
-class iso _TestStringRstrip is UnitTest
+class \nodoc\ iso _TestStringRstrip is UnitTest
   """
   Test stripping trailing characters from a string.
   """
@@ -460,7 +460,7 @@ class iso _TestStringRstrip is UnitTest
     h.assert_eq[String](recover "  foobar  ".clone() .> rstrip() end,
       "  foobar")
 
-class iso _TestStringStrip is UnitTest
+class \nodoc\ iso _TestStringStrip is UnitTest
   """
   Test stripping leading and trailing characters from a string.
   """
@@ -473,7 +473,7 @@ class iso _TestStringStrip is UnitTest
     h.assert_eq[String](recover "foobarfoo".clone() .> strip("bar") end,
       "foobarfoo")
 
-class iso _TestStringStripNonAscii is UnitTest
+class \nodoc\ iso _TestStringStripNonAscii is UnitTest
   """
   Test stripping leading and trailing characters from a string that
   contains non-ascii text data.
@@ -495,7 +495,7 @@ class iso _TestStringStripNonAscii is UnitTest
     h.assert_eq[String](recover "\nპონი\n".clone() .> strip("\n") end, "პონი")
 
 
-class iso _TestStringRemove is UnitTest
+class \nodoc\ iso _TestStringRemove is UnitTest
   """
   Test removing characters from a string (independent of leading or trailing).
   """
@@ -522,7 +522,7 @@ class iso _TestStringRemove is UnitTest
     h.assert_eq[String](consume s3, "foobar!")
     h.assert_eq[String](consume s4, "f-o-o-b-a-r!")
 
-class iso _TestStringSubstring is UnitTest
+class \nodoc\ iso _TestStringSubstring is UnitTest
   """
   Test copying range of characters.
   """
@@ -536,7 +536,7 @@ class iso _TestStringSubstring is UnitTest
     h.assert_eq[String]("3456", "0123456".substring(3))
     h.assert_eq[String]("345", "0123456".substring(3, -1))
 
-class iso _TestStringCut is UnitTest
+class \nodoc\ iso _TestStringCut is UnitTest
   """
   Test cutting part of a string
   """
@@ -547,7 +547,7 @@ class iso _TestStringCut is UnitTest
     h.assert_eq[String]("0123", "0123456".cut(4, 7))
     h.assert_eq[String]("0123", "0123456".cut(4))
 
-class iso _TestStringTrim is UnitTest
+class \nodoc\ iso _TestStringTrim is UnitTest
   """
   Test trimming part of a string.
   """
@@ -571,7 +571,7 @@ class iso _TestStringTrim is UnitTest
     h.assert_eq[USize](3,
       "0123456789".clone().>trim_in_place(1, 8).trim(3, 6).space())
 
-class iso _TestStringTrimInPlace is UnitTest
+class \nodoc\ iso _TestStringTrimInPlace is UnitTest
   """
   Test trimming part of a string in place.
   """
@@ -608,7 +608,7 @@ class iso _TestStringTrimInPlace is UnitTest
       h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())
     end
 
-class iso _TestStringTrimInPlaceWithAppend is UnitTest
+class \nodoc\ iso _TestStringTrimInPlaceWithAppend is UnitTest
   """
   Test trimming part of a string in place then append and trim again
 
@@ -628,7 +628,7 @@ class iso _TestStringTrimInPlaceWithAppend is UnitTest
     a.append("Hello")
     h.assert_eq[String box]("Hello", a)
 
-class iso _TestStringIsNullTerminated is UnitTest
+class \nodoc\ iso _TestStringIsNullTerminated is UnitTest
   """
   Test checking if a string is null terminated.
   """
@@ -651,7 +651,7 @@ class iso _TestStringIsNullTerminated is UnitTest
         ['a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'] // power of two sized array
       end).is_null_terminated())
 
-class iso _TestSpecialValuesF32 is UnitTest
+class \nodoc\ iso _TestSpecialValuesF32 is UnitTest
   """
   Test whether a F32 is infinite or NaN.
   """
@@ -683,7 +683,7 @@ class iso _TestSpecialValuesF32 is UnitTest
     h.assert_false(F32(0.0 / 0.0).infinite())
     h.assert_true(F32(0.0 / 0.0).nan())
 
-class iso _TestSpecialValuesF64 is UnitTest
+class \nodoc\ iso _TestSpecialValuesF64 is UnitTest
   """
   Test whether a F64 is infinite or NaN.
   """
@@ -715,7 +715,7 @@ class iso _TestSpecialValuesF64 is UnitTest
     h.assert_false(F64(0.0 / 0.0).infinite())
     h.assert_true(F64(0.0 / 0.0).nan())
 
-class iso _TestStringReplace is UnitTest
+class \nodoc\ iso _TestStringReplace is UnitTest
   """
   Test String.replace
   """
@@ -726,7 +726,7 @@ class iso _TestStringReplace is UnitTest
     s.replace("is a", "is not a")
     h.assert_eq[String box](s, "this is not a robbery, this is not a stickup")
 
-class iso _TestStringSplit is UnitTest
+class \nodoc\ iso _TestStringSplit is UnitTest
   """
   Test String.split
   """
@@ -763,7 +763,7 @@ class iso _TestStringSplit is UnitTest
     h.assert_eq[String](r(2)?, "")
     h.assert_eq[String](r(3)?, "3,, 4")
 
-class iso _TestStringSplitBy is UnitTest
+class \nodoc\ iso _TestStringSplitBy is UnitTest
   """
   Test String.split_by
   """
@@ -824,7 +824,7 @@ class iso _TestStringSplitBy is UnitTest
     h.assert_eq[String](r(0)?, "try with trailing ")
     h.assert_eq[String](r(1)?, "patternpattern")
 
-class iso _TestStringAdd is UnitTest
+class \nodoc\ iso _TestStringAdd is UnitTest
   """
   Test String.add
   """
@@ -842,7 +842,7 @@ class iso _TestStringAdd is UnitTest
     h.assert_eq[String]("" + "abc".trim(1, 2), "b")
     h.assert_eq[String]("a" + "".trim(1, 1), "a")
 
-class iso _TestStringJoin is UnitTest
+class \nodoc\ iso _TestStringJoin is UnitTest
   """
   Test String.join
   """
@@ -855,7 +855,7 @@ class iso _TestStringJoin is UnitTest
     h.assert_eq[String](" ".join([U32(1); U32(4)].values()), "1 4")
     h.assert_eq[String](" ".join(Array[String].values()), "")
 
-class iso _TestStringCount is UnitTest
+class \nodoc\ iso _TestStringCount is UnitTest
   """
   Test String.count
   """
@@ -875,7 +875,7 @@ class iso _TestStringCount is UnitTest
     h.assert_eq[USize]("atata".count("ata"), 1)
     h.assert_eq[USize]("tttt".count("tt"), 2)
 
-class iso _TestStringCompare is UnitTest
+class \nodoc\ iso _TestStringCompare is UnitTest
   """
   Test comparing strings.
   """
@@ -945,7 +945,7 @@ class iso _TestStringCompare is UnitTest
     h.assert_eq[Compare](Equal, "abc".compare_sub("babc", 4, 1, 2),
       "\"xbc\" == \"xxbc\"")
 
-class iso _TestStringContains is UnitTest
+class \nodoc\ iso _TestStringContains is UnitTest
   fun name(): String => "builtin/String.contains"
 
   fun apply(h: TestHelper) =>
@@ -979,7 +979,7 @@ class iso _TestStringContains is UnitTest
     h.assert_eq[Bool](s.contains(" hello"), false)
     h.assert_eq[Bool](s.contains("?!"), false)
 
-class iso _TestStringReadInt is UnitTest
+class \nodoc\ iso _TestStringReadInt is UnitTest
   """
   Test converting string at given index to integer.
   """
@@ -1026,7 +1026,7 @@ class iso _TestStringReadInt is UnitTest
     u8_misc = "...-0...".read_int[U8](3, 10)?
     h.assert_true((u8_misc._1 == 0) and (u8_misc._2 == 0))
 
-class iso _TestStringUTF32 is UnitTest
+class \nodoc\ iso _TestStringUTF32 is UnitTest
   """
   Test the UTF32 encoding and decoding
   """
@@ -1067,7 +1067,7 @@ class iso _TestStringUTF32 is UnitTest
     h.assert_eq[U8](0x8E, s(3)?)
     h.assert_eq[U32](0x2070E, s.utf32(0)?._1)
 
-class iso _TestStringRFind is UnitTest
+class \nodoc\ iso _TestStringRFind is UnitTest
   fun name(): String => "builtin/String.rfind"
 
   fun apply(h: TestHelper) ? =>
@@ -1076,7 +1076,7 @@ class iso _TestStringRFind is UnitTest
     h.assert_eq[ISize](s.rfind("-", -2)?, 8)
     h.assert_eq[ISize](s.rfind("-bar", 7)?, 4)
 
-class iso _TestStringFromArray is UnitTest
+class \nodoc\ iso _TestStringFromArray is UnitTest
   fun name(): String => "builtin/String.from_array"
 
   fun apply(h: TestHelper) =>
@@ -1088,7 +1088,7 @@ class iso _TestStringFromArray is UnitTest
     h.assert_eq[String](s_no_null, "foo")
     h.assert_eq[USize](s_no_null.size(), 3)
 
-class iso _TestStringFromIsoArray is UnitTest
+class \nodoc\ iso _TestStringFromIsoArray is UnitTest
   fun name(): String => "builtin/String.from_iso_array"
 
   fun apply(h: TestHelper) =>
@@ -1107,7 +1107,7 @@ class iso _TestStringFromIsoArray is UnitTest
     h.assert_eq[USize](s2.size(), 8)
     h.assert_true((s2.space() == 8) xor s2.is_null_terminated())
 
-class iso _TestStringSpace is UnitTest
+class \nodoc\ iso _TestStringSpace is UnitTest
   fun name(): String => "builtin/String.space"
 
   fun apply(h: TestHelper) =>
@@ -1120,7 +1120,7 @@ class iso _TestStringSpace is UnitTest
     h.assert_eq[USize](s.space(), 8)
     h.assert_false(s.is_null_terminated())
 
-class iso _TestStringRecalc is UnitTest
+class \nodoc\ iso _TestStringRecalc is UnitTest
   fun name(): String => "builtin/String.recalc"
 
   fun apply(h: TestHelper) =>
@@ -1147,7 +1147,7 @@ class iso _TestStringRecalc is UnitTest
     h.assert_eq[USize](s3.space(), 7)
     h.assert_true(s3.is_null_terminated())
 
-class iso _TestStringTruncate is UnitTest
+class \nodoc\ iso _TestStringTruncate is UnitTest
   fun name(): String => "builtin/String.truncate"
 
   fun apply(h: TestHelper) =>
@@ -1174,7 +1174,7 @@ class iso _TestStringTruncate is UnitTest
     h.assert_eq[USize](s.size(), 3)
     h.assert_eq[USize](s.space(), 31)
 
-class iso _TestStringChop is UnitTest
+class \nodoc\ iso _TestStringChop is UnitTest
   """
   Test chopping a string
   """
@@ -1200,7 +1200,7 @@ class iso _TestStringChop is UnitTest
     h.assert_eq[String box](expected_left, consume left)
     h.assert_eq[String box](expected_right, consume right)
 
-class iso _TestStringChopWithPush is UnitTest
+class \nodoc\ iso _TestStringChopWithPush is UnitTest
   """
   Test chopping a string then pushing to the left side
   """
@@ -1213,7 +1213,7 @@ class iso _TestStringChopWithPush is UnitTest
     h.assert_eq[String box]("cats", consume cat)
     h.assert_eq[String box]("dog", consume dog)
 
-class iso _TestStringUnchop is UnitTest
+class \nodoc\ iso _TestStringUnchop is UnitTest
   """
   Test unchopping a string
   """
@@ -1277,7 +1277,7 @@ class iso _TestStringUnchop is UnitTest
       error
     end
 
-class iso _TestStringRepeatStr is UnitTest
+class \nodoc\ iso _TestStringRepeatStr is UnitTest
   """
   Test repeating a string
   """
@@ -1295,7 +1295,7 @@ class iso _TestStringRepeatStr is UnitTest
       "123".repeat_str(6, ", "))
     h.assert_eq[String box]("123123123123123123", "123" * 6)
 
-class iso _TestStringConcatOffsetLen is UnitTest
+class \nodoc\ iso _TestStringConcatOffsetLen is UnitTest
   """
   Test String.concat working correctly for non-default offset and len arguments
   """
@@ -1304,7 +1304,7 @@ class iso _TestStringConcatOffsetLen is UnitTest
   fun apply(h: TestHelper) =>
     h.assert_eq[String](recover String.>concat("ABCD".values(), 1, 2) end, "BC")
 
-class iso _TestStringFromCPointer is UnitTest
+class \nodoc\ iso _TestStringFromCPointer is UnitTest
   """
   Test creating a string from a pointer
   """
@@ -1314,7 +1314,7 @@ class iso _TestStringFromCPointer is UnitTest
     let str = String.from_cpointer(Pointer[U8], 1, 1)
     h.assert_eq[USize](0, str.size())
 
-class iso _TestArrayAppend is UnitTest
+class \nodoc\ iso _TestArrayAppend is UnitTest
   fun name(): String => "builtin/Array.append"
 
   fun apply(h: TestHelper) ? =>
@@ -1348,7 +1348,7 @@ class iso _TestArrayAppend is UnitTest
     h.assert_eq[String]("three", a(2)?)
     h.assert_eq[String]("five", a(3)?)
 
-class iso _TestArrayConcat is UnitTest
+class \nodoc\ iso _TestArrayConcat is UnitTest
   fun name(): String => "builtin/Array.concat"
 
   fun apply(h: TestHelper) ? =>
@@ -1382,7 +1382,7 @@ class iso _TestArrayConcat is UnitTest
     h.assert_eq[String]("three", a(2)?)
     h.assert_eq[String]("five", a(3)?)
 
-class iso _TestArraySlice is UnitTest
+class \nodoc\ iso _TestArraySlice is UnitTest
   """
   Test slicing arrays.
   """
@@ -1417,7 +1417,7 @@ class iso _TestArraySlice is UnitTest
     h.assert_eq[String]("three", e(1)?)
     h.assert_eq[String]("one", e(2)?)
 
-class iso _TestArrayTrim is UnitTest
+class \nodoc\ iso _TestArrayTrim is UnitTest
   """
   Test trimming part of a string.
   """
@@ -1436,7 +1436,7 @@ class iso _TestArrayTrim is UnitTest
     h.assert_array_eq[U8](Array[U8], orig.trim(4, 1))
     h.assert_eq[USize](0, orig.trim(4, 1).space())
 
-class iso _TestArrayTrimInPlace is UnitTest
+class \nodoc\ iso _TestArrayTrimInPlace is UnitTest
   """
   Test trimming part of a string in place.
   """
@@ -1470,7 +1470,7 @@ class iso _TestArrayTrimInPlace is UnitTest
       h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())
     end
 
-class iso _TestArrayTrimInPlaceWithAppend is UnitTest
+class \nodoc\ iso _TestArrayTrimInPlaceWithAppend is UnitTest
   """
   Test trimming part of a array in place then append and trim again
 
@@ -1490,7 +1490,7 @@ class iso _TestArrayTrimInPlaceWithAppend is UnitTest
     a.append([0; 10])
     h.assert_array_eq[U8]([0; 10], a)
 
-class iso _TestArrayInsert is UnitTest
+class \nodoc\ iso _TestArrayInsert is UnitTest
   """
   Test inserting new element into array
   """
@@ -1511,7 +1511,7 @@ class iso _TestArrayInsert is UnitTest
 
     h.assert_error({() ? => ["one"; "three"].insert(3, "invalid")? })
 
-class iso _TestArrayValuesRewind is UnitTest
+class \nodoc\ iso _TestArrayValuesRewind is UnitTest
   """
   Test rewinding an ArrayValues object
   """
@@ -1535,12 +1535,12 @@ class iso _TestArrayValuesRewind is UnitTest
     h.assert_eq[U32](4, av.next()?)
     h.assert_eq[Bool](false, av.has_next())
 
-class _FindTestCls
+class \nodoc\ _FindTestCls
   let i: ISize
   new create(i': ISize = 0) => i = i'
   fun eq(other: _FindTestCls box): Bool => i == other.i
 
-class iso _TestArrayFind is UnitTest
+class \nodoc\ iso _TestArrayFind is UnitTest
   """
   Test finding elements in an array.
   """
@@ -1586,7 +1586,7 @@ class iso _TestArrayFind is UnitTest
     h.assert_eq[USize](0, b.find(_FindTestCls where
       predicate = {(l, r) => l == r })?)
 
-class iso _TestArraySwapElements is UnitTest
+class \nodoc\ iso _TestArraySwapElements is UnitTest
   """
   Test swapping array elements
   """
@@ -1622,7 +1622,7 @@ class iso _TestArraySwapElements is UnitTest
       [as I32: 1; 2; 3].swap_elements(3, 4)?
     })
 
-class iso _TestArrayChop is UnitTest
+class \nodoc\ iso _TestArrayChop is UnitTest
   """
   Test chopping an array
   """
@@ -1647,7 +1647,7 @@ class iso _TestArrayChop is UnitTest
     h.assert_array_eq[U8](expected_left, consume left)
     h.assert_array_eq[U8](expected_right, consume right)
 
-class iso _TestArrayChopWithPush is UnitTest
+class \nodoc\ iso _TestArrayChopWithPush is UnitTest
   """
   Test chopping an array with a subsequent push to the left side
   """
@@ -1660,7 +1660,7 @@ class iso _TestArrayChopWithPush is UnitTest
     h.assert_array_eq[U8](['c'; 'a'; 't'; 's'], consume cat)
     h.assert_array_eq[U8](['d'; 'o'; 'g'], consume dog)
 
-class iso _TestArrayUnchop is UnitTest
+class \nodoc\ iso _TestArrayUnchop is UnitTest
   """
   Test unchopping an array
   """
@@ -1733,7 +1733,7 @@ class iso _TestArrayUnchop is UnitTest
       error
     end
 
-class iso _TestArrayFromCPointer is UnitTest
+class \nodoc\ iso _TestArrayFromCPointer is UnitTest
   """
   Test creating an array from a pointer
   """
@@ -1743,7 +1743,7 @@ class iso _TestArrayFromCPointer is UnitTest
     let arr = Array[U8].from_cpointer(Pointer[U8], 1, 1)
     h.assert_eq[USize](0, arr.size())
 
-class iso _TestMath128 is UnitTest
+class \nodoc\ iso _TestMath128 is UnitTest
   """
   Test 128 bit integer math.
   """
@@ -1870,7 +1870,7 @@ class iso _TestMath128 is UnitTest
     h.assert_eq[I128](-5, I128(-13) %% -8)
     h.assert_eq[I128](-28, I128(-40_000_000_028) %% -10_000_000_000)
 
-class iso _TestRem is UnitTest
+class \nodoc\ iso _TestRem is UnitTest
   """
   Test rem on various bit widths.
   """
@@ -1907,7 +1907,7 @@ class iso _TestRem is UnitTest
     test_rem_unsigned[ULong](h)
     test_rem_unsigned[U128](h)
 
-class iso _TestFld is UnitTest
+class \nodoc\ iso _TestFld is UnitTest
   fun name(): String => "builtin/Fld"
 
   fun test_fld_signed[T: (Integer[T] val & Signed)](h: TestHelper, type_name: String) =>
@@ -1953,7 +1953,7 @@ class iso _TestFld is UnitTest
     test_fld_unsigned[USize](h, "USize")
     test_fld_unsigned[U128](h, "U128")
 
-class iso _TestMod is UnitTest
+class \nodoc\ iso _TestMod is UnitTest
   fun name(): String => "builtin/Mod"
 
   fun test_mod_signed[T: (Integer[T] val & Signed)](h: TestHelper, type_name: String) =>
@@ -2035,7 +2035,7 @@ class iso _TestMod is UnitTest
     test_mod_float[F32](h, "F32")?
     test_mod_float[F64](h, "F64")?
 
-trait iso SafeArithmeticTest is UnitTest
+trait \nodoc\ iso SafeArithmeticTest is UnitTest
   fun test[A: (Equatable[A] #read & Stringable #read)](
     h: TestHelper,
     expected: (A, Bool),
@@ -2052,7 +2052,7 @@ trait iso SafeArithmeticTest is UnitTest
   =>
     h.assert_eq[Bool](true, actual._2)
 
-class iso _TestAddc is SafeArithmeticTest
+class \nodoc\ iso _TestAddc is SafeArithmeticTest
   """
   Test addc on various bit widths.
   """
@@ -2118,7 +2118,7 @@ class iso _TestAddc is SafeArithmeticTest
     test[I128](h, (0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, true),
       I128(-0x8000_0000_0000_0000_0000_0000_0000_0000).addc(-1))
 
-class iso _TestSubc is SafeArithmeticTest
+class \nodoc\ iso _TestSubc is SafeArithmeticTest
   """
   Test addc on various bit widths.
   """
@@ -2180,7 +2180,7 @@ class iso _TestSubc is SafeArithmeticTest
     test[I128](h, (0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, true),
       I128(-0x8000_0000_0000_0000_0000_0000_0000_0000).subc( 1))
 
-class iso _TestMulc is SafeArithmeticTest
+class \nodoc\ iso _TestMulc is SafeArithmeticTest
   fun name(): String => "builtin/Mulc"
 
   fun apply(h: TestHelper) =>
@@ -2263,7 +2263,7 @@ class iso _TestMulc is SafeArithmeticTest
     test[I128](h, (0x7fff_ffff_ffff_ffff_ffff_ffff_ffff_fffe,  true),
       I128(0x4000_0000_0000_0000_0000_0000_0000_0001).mulc(-2))
 
-class iso _TestDivc is SafeArithmeticTest
+class \nodoc\ iso _TestDivc is SafeArithmeticTest
   fun name(): String => "builtin/Divc"
 
   fun apply(h: TestHelper) =>
@@ -2320,7 +2320,7 @@ class iso _TestDivc is SafeArithmeticTest
     test_overflow[I128](h, I128(0x40).divc(0))
     test_overflow[I128](h, I128.min_value().divc(I128(-1)))
 
-class iso _TestFldc is SafeArithmeticTest
+class \nodoc\ iso _TestFldc is SafeArithmeticTest
   fun name(): String => "builtin/Fldc"
 
   fun apply(h: TestHelper) =>
@@ -2377,7 +2377,7 @@ class iso _TestFldc is SafeArithmeticTest
     test_overflow[I128](h, I128(0x40).fldc(0))
     test_overflow[I128](h, I128.min_value().fldc(I128(-1)))
 
-class iso _TestRemc is SafeArithmeticTest
+class \nodoc\ iso _TestRemc is SafeArithmeticTest
   fun name(): String => "builtin/Remc"
 
   fun apply(h: TestHelper) =>
@@ -2451,7 +2451,7 @@ class iso _TestRemc is SafeArithmeticTest
     test_overflow[ISize](h, ISize(-0x40).remc(0))
     test_overflow[ISize](h, ISize.min_value().remc(-1))
 
-class iso _TestModc is SafeArithmeticTest
+class \nodoc\ iso _TestModc is SafeArithmeticTest
   fun name(): String => "builtin/Modc"
 
   fun apply(h: TestHelper) =>
@@ -2525,7 +2525,7 @@ class iso _TestModc is SafeArithmeticTest
     test_overflow[ISize](h, ISize(-0x40).modc(0))
     test_overflow[ISize](h, ISize.min_value().modc(-1))
 
-primitive _CommonPartialArithmeticTests[T: (Integer[T] val & Int)]
+primitive \nodoc\ _CommonPartialArithmeticTests[T: (Integer[T] val & Int)]
   fun apply(h: TestHelper)? =>
     //addition
     h.assert_error({()? => T.max_value() +? T(1) })
@@ -2561,7 +2561,7 @@ primitive _CommonPartialArithmeticTests[T: (Integer[T] val & Int)]
     h.assert_eq[T](T(5), divr)
     h.assert_eq[T](T(1), remr)
 
-primitive _UnsignedPartialArithmeticTests[T: (Integer[T] val & Unsigned)]
+primitive \nodoc\ _UnsignedPartialArithmeticTests[T: (Integer[T] val & Unsigned)]
   fun apply(h: TestHelper) =>
     // division
     h.assert_no_error({()? => T.min_value() /? T(-1) })
@@ -2579,7 +2579,7 @@ primitive _UnsignedPartialArithmeticTests[T: (Integer[T] val & Unsigned)]
     // divrem
     h.assert_no_error({()? => T.min_value().divrem_partial(T(-1))? })
 
-primitive _SignedPartialArithmeticTests[T: (Integer[T] val & Signed)]
+primitive \nodoc\ _SignedPartialArithmeticTests[T: (Integer[T] val & Signed)]
   fun apply(h: TestHelper) =>
     // addition
     h.assert_error({()? => T.min_value() +? T(-1) })
@@ -2619,7 +2619,7 @@ primitive _SignedPartialArithmeticTests[T: (Integer[T] val & Signed)]
     // divrem
     h.assert_error({()? => T.min_value().divrem_partial(T(-1))? })
 
-class iso _TestSignedPartialArithmetic is UnitTest
+class \nodoc\ iso _TestSignedPartialArithmetic is UnitTest
   fun name(): String => "builtin/PartialArithmetic/signed"
 
   fun apply(h: TestHelper)? =>
@@ -2638,7 +2638,7 @@ class iso _TestSignedPartialArithmetic is UnitTest
     _CommonPartialArithmeticTests[ISize](h)?
     _SignedPartialArithmeticTests[ISize](h)
 
-class iso _TestUnsignedPartialArithmetic is UnitTest
+class \nodoc\ iso _TestUnsignedPartialArithmetic is UnitTest
   fun name(): String => "builtin/PartialArithmetic/unsigned"
   fun apply(h: TestHelper)? =>
     _CommonPartialArithmeticTests[U8](h)?
@@ -2656,7 +2656,7 @@ class iso _TestUnsignedPartialArithmetic is UnitTest
     _CommonPartialArithmeticTests[USize](h)?
     _UnsignedPartialArithmeticTests[USize](h)
 
-class iso _TestNextPow2 is UnitTest
+class \nodoc\ iso _TestNextPow2 is UnitTest
   """
   Test power of 2 computations.
   """
@@ -2698,7 +2698,7 @@ class iso _TestNextPow2 is UnitTest
     h.assert_eq[U128](1, U128(0).next_pow2())
     h.assert_eq[U128](1, U128.max_value().next_pow2())
 
-class iso _TestNumberConversionSaturation is UnitTest
+class \nodoc\ iso _TestNumberConversionSaturation is UnitTest
   """
   Test saturation semantics for floating point/integer conversions.
   """
@@ -2750,7 +2750,7 @@ struct _TestStruct
   var i: U32 = 0
   new create() => None
 
-class iso _TestNullablePointer is UnitTest
+class \nodoc\ iso _TestNullablePointer is UnitTest
   """
   Test the NullablePointer type.
   """
@@ -2771,7 +2771,7 @@ class iso _TestNullablePointer is UnitTest
     let from_b = b()?
     h.assert_eq[U32](s.i, from_b.i)
 
-class iso _TestLambdaCapture is UnitTest
+class \nodoc\ iso _TestLambdaCapture is UnitTest
   """
   Test free variable capture in lambdas.
   """

--- a/packages/builtin_test/_test_valtrace.pony
+++ b/packages/builtin_test/_test_valtrace.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-class iso _TestValtrace is UnitTest
+class \nodoc\ iso _TestValtrace is UnitTest
   """
   Test val trace optimisation
   """
@@ -10,7 +10,7 @@ class iso _TestValtrace is UnitTest
     _Valtrace.one(h)
     h.long_test(10_000_000_000) // 10 second timeout
 
-actor _Valtrace
+actor \nodoc\ _Valtrace
   var count: U32 = 0
 
   be one(h: TestHelper) =>

--- a/packages/bureaucracy/_test.pony
+++ b/packages/bureaucracy/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -9,7 +9,7 @@ actor Main is TestList
     test(_TestCustodian)
     test(_TestRegistrar)
 
-class iso _TestCustodian is UnitTest
+class \nodoc\ iso _TestCustodian is UnitTest
   """
   Dispose of an actor using a Custodian.
   """
@@ -21,7 +21,7 @@ class iso _TestCustodian is UnitTest
     c(_TestDisposable(h))
     c.dispose()
 
-class iso _TestRegistrar is UnitTest
+class \nodoc\ iso _TestRegistrar is UnitTest
   """
   Register an actor and retrieve it.
   """
@@ -34,7 +34,7 @@ class iso _TestRegistrar is UnitTest
 
     r[_TestDisposable]("test").next[None]({(value) => value.dispose() })
 
-actor _TestDisposable
+actor \nodoc\ _TestDisposable
   let _h: TestHelper
 
   new create(h: TestHelper) =>

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -31,7 +31,7 @@ actor Main is TestList
     test(_TestUnknownLong)
     test(_TestUnknownShort)
 
-class iso _TestMinimal is UnitTest
+class \nodoc\ iso _TestMinimal is UnitTest
   fun name(): String => "ponycli/minimal"
 
   fun apply(h: TestHelper) ? =>
@@ -52,7 +52,7 @@ class iso _TestMinimal is UnitTest
     h.assert_eq[String]("minimal", cmd.fullname())
     h.assert_eq[Bool](true, cmd.option("aflag").bool())
 
-class iso _TestMinimalWithHelp is UnitTest
+class \nodoc\ iso _TestMinimalWithHelp is UnitTest
   fun name(): String => "ponycli/minimal_help"
 
   fun apply(h: TestHelper) ? =>
@@ -65,7 +65,7 @@ class iso _TestMinimalWithHelp is UnitTest
     // test for successful parsing
     let cmdErr = CommandParser(cs).parse(args) as Command
 
-class iso _TestBadName is UnitTest
+class \nodoc\ iso _TestBadName is UnitTest
   fun name(): String => "ponycli/badname"
 
   // Negative test: command names must be alphanum tokens
@@ -75,7 +75,7 @@ class iso _TestBadName is UnitTest
       h.fail("expected error on bad command name: " + cs.name())
     end
 
-class iso _TestUnknownCommand is UnitTest
+class \nodoc\ iso _TestUnknownCommand is UnitTest
   fun name(): String => "ponycli/unknown_command"
 
   // Negative test: unknown command should report
@@ -99,7 +99,7 @@ class iso _TestUnknownCommand is UnitTest
       h.fail("expected syntax error for unknown command: " + cmdErr.string())
     end
 
-class iso _TestUnexpectedArg is UnitTest
+class \nodoc\ iso _TestUnexpectedArg is UnitTest
   fun name(): String => "ponycli/unexpected_arg"
 
   // Negative test: unexpected arg/command token should report
@@ -124,7 +124,7 @@ class iso _TestUnexpectedArg is UnitTest
       h.fail("expected syntax error for unknown command: " + cmdErr.string())
     end
 
-class iso _TestUnknownShort is UnitTest
+class \nodoc\ iso _TestUnknownShort is UnitTest
   fun name(): String => "ponycli/unknown_short"
 
   // Negative test: unknown short option should report
@@ -149,7 +149,7 @@ class iso _TestUnknownShort is UnitTest
         "expected syntax error for unknown short option: " + cmdErr.string())
     end
 
-class iso _TestUnknownLong is UnitTest
+class \nodoc\ iso _TestUnknownLong is UnitTest
   fun name(): String => "ponycli/unknown_long"
 
   // Negative test: unknown long option should report
@@ -175,7 +175,7 @@ class iso _TestUnknownLong is UnitTest
         "expected syntax error for unknown long option: " + cmdErr.string())
     end
 
-class iso _TestHyphenArg is UnitTest
+class \nodoc\ iso _TestHyphenArg is UnitTest
   fun name(): String => "ponycli/hyphen"
 
   // Rule 1
@@ -194,7 +194,7 @@ class iso _TestHyphenArg is UnitTest
     h.assert_eq[String]("minimal", cmd.fullname())
     h.assert_eq[String]("-", cmd.arg("name").string())
 
-class iso _TestBools is UnitTest
+class \nodoc\ iso _TestBools is UnitTest
   fun name(): String => "ponycli/bools"
 
   // Rules 2, 3, 5, 7 w/ Bools
@@ -215,7 +215,7 @@ class iso _TestBools is UnitTest
     h.assert_eq[Bool](true, cmd.option("ccc").bool())
     h.assert_eq[Bool](false, cmd.option("ddd").bool())
 
-class iso _TestDefaults is UnitTest
+class \nodoc\ iso _TestDefaults is UnitTest
   fun name(): String => "ponycli/defaults"
 
   // Rules 2, 3, 5, 6
@@ -238,7 +238,7 @@ class iso _TestDefaults is UnitTest
     h.assert_eq[F64](42.0, cmd.option("floato").f64())
     h.assert_eq[USize](0, cmd.option("stringso").string_seq().size())
 
-class iso _TestShortsAdj is UnitTest
+class \nodoc\ iso _TestShortsAdj is UnitTest
   fun name(): String => "ponycli/shorts_adjacent"
 
   // Rules 2, 3, 5, 6, 8
@@ -278,7 +278,7 @@ class iso _TestShortsAdj is UnitTest
       h.fail("expected syntax error for ambiguous args: " + cmdSyntax.string())
     end
 
-class iso _TestShortsEq is UnitTest
+class \nodoc\ iso _TestShortsEq is UnitTest
   fun name(): String => "ponycli/shorts_eq"
 
   // Rules 2, 3, 5, 7
@@ -306,7 +306,7 @@ class iso _TestShortsEq is UnitTest
     h.assert_eq[String]("aaa", stringso.string_seq()(0)?)
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
 
-class iso _TestShortsNext is UnitTest
+class \nodoc\ iso _TestShortsNext is UnitTest
   fun name(): String => "ponycli/shorts_next"
 
   // Rules 2, 3, 5, 8
@@ -335,7 +335,7 @@ class iso _TestShortsNext is UnitTest
     h.assert_eq[String]("aaa", stringso.string_seq()(0)?)
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
 
-class iso _TestLongsEq is UnitTest
+class \nodoc\ iso _TestLongsEq is UnitTest
   fun name(): String => "ponycli/longs_eq"
 
   // Rules 4, 5, 7
@@ -364,7 +364,7 @@ class iso _TestLongsEq is UnitTest
     h.assert_eq[String]("aaa", stringso.string_seq()(0)?)
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
 
-class iso _TestLongsNext is UnitTest
+class \nodoc\ iso _TestLongsNext is UnitTest
   fun name(): String => "ponycli/longs_next"
 
   // Rules 4, 5, 8
@@ -392,7 +392,7 @@ class iso _TestLongsNext is UnitTest
     h.assert_eq[String]("aaa", stringso.string_seq()(0)?)
     h.assert_eq[String]("bbb", stringso.string_seq()(1)?)
 
-class iso _TestEnvs is UnitTest
+class \nodoc\ iso _TestEnvs is UnitTest
   fun name(): String => "ponycli/envs"
 
   // Rules
@@ -420,7 +420,7 @@ class iso _TestEnvs is UnitTest
     h.assert_eq[U64](47, cmd.option("uintr").u64())
     h.assert_eq[F64](42.0, cmd.option("floatr").f64())
 
-class iso _TestOptionStop is UnitTest
+class \nodoc\ iso _TestOptionStop is UnitTest
   fun name(): String => "ponycli/option_stop"
 
   // Rules 2, 3, 5, 7, 9
@@ -440,7 +440,7 @@ class iso _TestOptionStop is UnitTest
     h.assert_eq[String]("-f=1.0", cmd.arg("words").string())
     h.assert_eq[F64](42.0, cmd.option("floato").f64())
 
-class iso _TestDuplicate is UnitTest
+class \nodoc\ iso _TestDuplicate is UnitTest
   fun name(): String => "ponycli/duplicate"
 
   // Rules 4, 5, 7, 10
@@ -459,7 +459,7 @@ class iso _TestDuplicate is UnitTest
 
     h.assert_eq[String]("newstring", cmd.option("stringr").string())
 
-class iso _TestChat is UnitTest
+class \nodoc\ iso _TestChat is UnitTest
   fun name(): String => "ponycli/chat"
 
   fun apply(h: TestHelper) ? =>
@@ -501,7 +501,7 @@ class iso _TestChat is UnitTest
     h.assert_eq[String]("yo", words(1)?)
     h.assert_eq[String]("hey", words(2)?)
 
-class iso _TestMustBeLeaf is UnitTest
+class \nodoc\ iso _TestMustBeLeaf is UnitTest
   fun name(): String => "ponycli/must_be_leaf"
 
   // Negative test: can't just supply parent command
@@ -524,7 +524,7 @@ class iso _TestMustBeLeaf is UnitTest
       h.fail("expected syntax error for non-leaf command: " + cmdErr.string())
     end
 
-class iso _TestHelp is UnitTest
+class \nodoc\ iso _TestHelp is UnitTest
   fun name(): String => "ponycli/help"
 
   fun apply(h: TestHelper) ? =>
@@ -537,7 +537,7 @@ class iso _TestHelp is UnitTest
     h.log(help)
     h.assert_true(help.contains("Address of the server"))
 
-class iso _TestHelpFalse is UnitTest
+class \nodoc\ iso _TestHelpFalse is UnitTest
   fun name(): String => "ponycli/help-false"
 
   fun apply(h: TestHelper) ? =>
@@ -559,7 +559,7 @@ class iso _TestHelpFalse is UnitTest
       h.fail("--help=false is not handled correctly: " + se.string())
     end
 
-class iso _TestHelpMultipleArgs is UnitTest
+class \nodoc\ iso _TestHelpMultipleArgs is UnitTest
   fun name(): String => "ponycli/help-multiple-args"
 
   fun apply(h: TestHelper) ? =>
@@ -570,7 +570,7 @@ class iso _TestHelpMultipleArgs is UnitTest
     h.assert_true(
       help.contains("simple <words> <argz>"))
 
-class iso _TestMultipleEndOfOptions is UnitTest
+class \nodoc\ iso _TestMultipleEndOfOptions is UnitTest
   fun name(): String => "ponycli/multiple-end-of-options"
 
   fun apply(h: TestHelper) ? =>

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -2,7 +2,7 @@ use "ponytest"
 use "random"
 use "time"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -34,7 +34,7 @@ actor Main is TestList
     test(_TestRing)
     test(_TestSort)
 
-class iso _TestList is UnitTest
+class \nodoc\ iso _TestList is UnitTest
   fun name(): String => "collections/List"
 
   fun apply(h: TestHelper) ? =>
@@ -60,7 +60,7 @@ class iso _TestList is UnitTest
     h.assert_eq[U32](b(3)?, 1)
     h.assert_eq[U32](b(4)?, 2)
 
-class iso _TestListsFrom is UnitTest
+class \nodoc\ iso _TestListsFrom is UnitTest
   fun name(): String => "collections/Lists/from()"
 
   fun apply(h: TestHelper) ? =>
@@ -76,7 +76,7 @@ class iso _TestListsFrom is UnitTest
     let b = List[U32].from(Array[U32])
     h.assert_eq[USize](b.size(), 0)
 
-class iso _TestMap is UnitTest
+class \nodoc\ iso _TestMap is UnitTest
   fun name(): String => "collections/Map"
 
   fun apply(h: TestHelper) ? =>
@@ -148,7 +148,7 @@ class iso _TestMap is UnitTest
     let e = d + ("a", 1)
     h.assert_eq[U32](1, e("a")?)
 
-class iso _TestMapRemove is UnitTest
+class \nodoc\ iso _TestMapRemove is UnitTest
   fun name(): String => "collections/Map.remove"
 
   fun apply(h: TestHelper) ? =>
@@ -166,7 +166,7 @@ class iso _TestMapRemove is UnitTest
     x(11) = "here"
     h.assert_eq[String](x(11)?, "here")
 
-class iso _TestMapUpsert is UnitTest
+class \nodoc\ iso _TestMapUpsert is UnitTest
   fun name(): String => "collections/Map.upsert"
 
   fun apply(h: TestHelper) ? =>
@@ -221,7 +221,7 @@ class iso _TestMapUpsert is UnitTest
     x4.upsert(2, 4, i)
     h.assert_eq[I64](-4, x4(2)?)
 
-class iso _TestMapHashFunc is UnitTest
+class \nodoc\ iso _TestMapHashFunc is UnitTest
   fun name(): String => "collections/Map.hashfunc"
 
   fun apply(h: TestHelper) =>
@@ -245,7 +245,7 @@ class iso _TestMapHashFunc is UnitTest
       h.assert_eq[USize](h2, 17028932028986796913)
     end
 
-class iso _TestRing is UnitTest
+class \nodoc\ iso _TestRing is UnitTest
   fun name(): String => "collections/RingBuffer"
 
   fun apply(h: TestHelper) ? =>
@@ -269,7 +269,7 @@ class iso _TestRing is UnitTest
 
     h.assert_error({() ? => a(6)? }, "Read ring 6")
 
-class iso _TestListsMap is UnitTest
+class \nodoc\ iso _TestListsMap is UnitTest
   fun name(): String => "collections/Lists/map()"
 
   fun apply(h: TestHelper) ? =>
@@ -284,7 +284,7 @@ class iso _TestListsMap is UnitTest
     h.assert_eq[U32](c(1)?, 2)
     h.assert_eq[U32](c(2)?, 4)
 
-class iso _TestListsFlatMap is UnitTest
+class \nodoc\ iso _TestListsFlatMap is UnitTest
   fun name(): String => "collections/Lists/flat_map()"
 
   fun apply(h: TestHelper) ? =>
@@ -302,7 +302,7 @@ class iso _TestListsFlatMap is UnitTest
     h.assert_eq[U32](c(4)?, 2)
     h.assert_eq[U32](c(5)?, 4)
 
-class iso _TestListsFilter is UnitTest
+class \nodoc\ iso _TestListsFilter is UnitTest
   fun name(): String => "collections/Lists/filter()"
 
   fun apply(h: TestHelper) ? =>
@@ -316,7 +316,7 @@ class iso _TestListsFilter is UnitTest
     h.assert_eq[U32](b(0)?, 2)
     h.assert_eq[U32](b(1)?, 3)
 
-class iso _TestListsFold is UnitTest
+class \nodoc\ iso _TestListsFold is UnitTest
   fun name(): String => "collections/Lists/fold()"
 
   fun apply(h: TestHelper) ? =>
@@ -337,7 +337,7 @@ class iso _TestListsFold is UnitTest
     h.assert_eq[U32](resList(2)?, 4)
     h.assert_eq[U32](resList(3)?, 6)
 
-class iso _TestListsEvery is UnitTest
+class \nodoc\ iso _TestListsEvery is UnitTest
   fun name(): String => "collections/Lists/every()"
 
   fun apply(h: TestHelper) =>
@@ -359,7 +359,7 @@ class iso _TestListsEvery is UnitTest
     let empty = b.every(f)
     h.assert_eq[Bool](empty, true)
 
-class iso _TestListsExists is UnitTest
+class \nodoc\ iso _TestListsExists is UnitTest
   fun name(): String => "collections/Lists/exists()"
 
   fun apply(h: TestHelper) =>
@@ -381,7 +381,7 @@ class iso _TestListsExists is UnitTest
     let empty = b.exists(f)
     h.assert_eq[Bool](empty, false)
 
-class iso _TestListsPartition is UnitTest
+class \nodoc\ iso _TestListsPartition is UnitTest
   fun name(): String => "collections/Lists/partition()"
 
   fun apply(h: TestHelper) ? =>
@@ -404,7 +404,7 @@ class iso _TestListsPartition is UnitTest
     h.assert_eq[USize](emptyEvens.size(), 0)
     h.assert_eq[USize](emptyOdds.size(), 0)
 
-class iso _TestListsDrop is UnitTest
+class \nodoc\ iso _TestListsDrop is UnitTest
   fun name(): String => "collections/Lists/drop()"
 
   fun apply(h: TestHelper) ? =>
@@ -428,7 +428,7 @@ class iso _TestListsDrop is UnitTest
     let l = empty.drop(3)
     h.assert_eq[USize](l.size(), 0)
 
-class iso _TestListsTake is UnitTest
+class \nodoc\ iso _TestListsTake is UnitTest
   fun name(): String => "collections/Lists/take()"
 
   fun apply(h: TestHelper) ? =>
@@ -467,7 +467,7 @@ class iso _TestListsTake is UnitTest
     let l = empty.take(3)
     h.assert_eq[USize](l.size(), 0)
 
-class iso _TestListsTakeWhile is UnitTest
+class \nodoc\ iso _TestListsTakeWhile is UnitTest
   fun name(): String => "collections/Lists/take_while()"
 
   fun apply(h: TestHelper) ? =>
@@ -502,7 +502,7 @@ class iso _TestListsTakeWhile is UnitTest
     let l = empty.take_while(g)
     h.assert_eq[USize](l.size(), 0)
 
-class iso _TestListsContains is UnitTest
+class \nodoc\ iso _TestListsContains is UnitTest
   fun name(): String => "collections/Lists/contains()"
 
   fun apply(h: TestHelper) =>
@@ -514,7 +514,7 @@ class iso _TestListsContains is UnitTest
     h.assert_eq[Bool](a.contains(2), true)
     h.assert_eq[Bool](a.contains(3), false)
 
-class iso _TestListsReverse is UnitTest
+class \nodoc\ iso _TestListsReverse is UnitTest
   fun name(): String => "collections/Lists/reverse()"
 
   fun apply(h: TestHelper) ? =>
@@ -533,7 +533,7 @@ class iso _TestListsReverse is UnitTest
     h.assert_eq[U32](b(1)?, 1)
     h.assert_eq[U32](b(2)?, 0)
 
-class iso _TestHashSetContains is UnitTest
+class \nodoc\ iso _TestHashSetContains is UnitTest
   fun name(): String => "collections/HashSet/contains()"
 
   fun apply(h: TestHelper) =>
@@ -558,7 +558,7 @@ class iso _TestHashSetContains is UnitTest
     a.set(0)
     h.assert_true(a.contains(0), not_found_fail)
 
-class iso _TestHashSetIntersect is UnitTest
+class \nodoc\ iso _TestHashSetIntersect is UnitTest
   fun name(): String => "collections/HashSet/intersect()"
 
   fun apply(h: TestHelper) =>
@@ -581,7 +581,7 @@ class iso _TestHashSetIntersect is UnitTest
       end
     end
 
-class iso _TestSort is UnitTest
+class \nodoc\ iso _TestSort is UnitTest
   fun name(): String => "collections/Sort"
 
   fun apply(h: TestHelper) =>
@@ -605,7 +605,7 @@ class iso _TestSort is UnitTest
   =>
     h.assert_array_eq[A](sorted, Sort[Array[A], A](unsorted))
 
-class iso _TestRange is UnitTest
+class \nodoc\ iso _TestRange is UnitTest
   fun name(): String => "collections/Range"
 
   fun apply(h: TestHelper) =>
@@ -687,7 +687,7 @@ class iso _TestRange is UnitTest
     end
     count
 
-class iso _TestHeap is UnitTest
+class \nodoc\ iso _TestHeap is UnitTest
   fun name(): String => "collections/BinaryHeap"
 
   fun apply(t: TestHelper) ? =>
@@ -755,7 +755,7 @@ class iso _TestHeap is UnitTest
       _verify[P](t, h, b)?
     end
 
-class iso _TestFlags is UnitTest
+class \nodoc\ iso _TestFlags is UnitTest
   fun name(): String => "collections/Flags"
 
   fun apply(h: TestHelper) =>
@@ -919,7 +919,7 @@ class iso _TestFlags is UnitTest
     h.assert_true(t(_TestFlagD))
 
 type _TestFlagsFlags is Flags[(_TestFlagA|_TestFlagB|_TestFlagC|_TestFlagD), U8]
-primitive _TestFlagA fun value(): U8 => 1
-primitive _TestFlagB fun value(): U8 => 2
-primitive _TestFlagC fun value(): U8 => 4
-primitive _TestFlagD fun value(): U8 => 8
+primitive \nodoc\ _TestFlagA fun value(): U8 => 1
+primitive \nodoc\ _TestFlagB fun value(): U8 => 2
+primitive \nodoc\ _TestFlagC fun value(): U8 => 4
+primitive \nodoc\ _TestFlagD fun value(): U8 => 8

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -3,7 +3,7 @@ use mut = "collections"
 use "random"
 use "time"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -33,7 +33,7 @@ actor Main is TestList
     test(_TestVec)
     test(_TestVecIterators)
 
-class iso _TestListPrepend is UnitTest
+class \nodoc\ iso _TestListPrepend is UnitTest
   fun name(): String => "collections/persistent/List (prepend)"
 
   fun apply(h: TestHelper) ? =>
@@ -58,7 +58,7 @@ class iso _TestListPrepend is UnitTest
     h.assert_eq[U32](e.head(), 10)
     h.assert_eq[USize](e.tail().size(), 0)
 
-class iso _TestListFrom is UnitTest
+class \nodoc\ iso _TestListFrom is UnitTest
   fun name(): String => "collections/persistent/Lists (from)"
 
   fun apply(h: TestHelper) ? =>
@@ -66,7 +66,7 @@ class iso _TestListFrom is UnitTest
     h.assert_eq[USize](l1.size(), 3)
     h.assert_eq[U32](l1.head()?, 1)
 
-class iso _TestListApply is UnitTest
+class \nodoc\ iso _TestListApply is UnitTest
   fun name(): String => "collections/persistent/List (apply)"
 
   fun apply(h: TestHelper) ? =>
@@ -80,7 +80,7 @@ class iso _TestListApply is UnitTest
     let l2 = Lists[U32].empty()
     h.assert_error({() ? => l2(0)? })
 
-class iso _TestListValues is UnitTest
+class \nodoc\ iso _TestListValues is UnitTest
   fun name(): String => "collections/persistent/List (values)"
 
   fun apply(h: TestHelper) ? =>
@@ -96,7 +96,7 @@ class iso _TestListValues is UnitTest
     h.assert_false(iter.has_next())
     h.assert_false(try iter.next()?; true else false end)
 
-class iso _TestListConcat is UnitTest
+class \nodoc\ iso _TestListConcat is UnitTest
   fun name(): String => "collections/persistent/List (concat)"
 
   fun apply(h: TestHelper) ? =>
@@ -118,14 +118,14 @@ class iso _TestListConcat is UnitTest
     let l9 = l8.reverse()
     h.assert_true(Lists[U32].eq(l9, Lists[U32]([1]))?)
 
-class iso _TestListMap is UnitTest
+class \nodoc\ iso _TestListMap is UnitTest
   fun name(): String => "collections/persistent/Lists (map)"
 
   fun apply(h: TestHelper) ? =>
     let l5 = Lists[U32]([1; 2; 3]).map[U32]({(x) => x * 2 })
     h.assert_true(Lists[U32].eq(l5, Lists[U32]([2; 4; 6]))?)
 
-class iso _TestListFlatMap is UnitTest
+class \nodoc\ iso _TestListFlatMap is UnitTest
   fun name(): String => "collections/persistent/Lists (flat_map)"
 
   fun apply(h: TestHelper) ? =>
@@ -133,7 +133,7 @@ class iso _TestListFlatMap is UnitTest
     let l6 = Lists[U32]([2; 5; 8]).flat_map[U32](f)
     h.assert_true(Lists[U32].eq(l6, Lists[U32]([1; 2; 3; 4; 5; 6; 7; 8; 9]))?)
 
-class iso _TestListFilter is UnitTest
+class \nodoc\ iso _TestListFilter is UnitTest
   fun name(): String => "collections/persistent/Lists (filter)"
 
   fun apply(h: TestHelper) ? =>
@@ -141,7 +141,7 @@ class iso _TestListFilter is UnitTest
     let l7 = Lists[U32]([1; 2; 3; 4; 5; 6; 7; 8]).filter(is_even)
     h.assert_true(Lists[U32].eq(l7, Lists[U32]([2; 4; 6; 8]))?)
 
-class iso _TestListFold is UnitTest
+class \nodoc\ iso _TestListFold is UnitTest
   fun name(): String => "collections/persistent/Lists (fold)"
 
   fun apply(h: TestHelper) ? =>
@@ -156,7 +156,7 @@ class iso _TestListFold is UnitTest
         doubleAndPrepend, Lists[U32].empty())
     h.assert_true(Lists[U32].eq(l8, Lists[U32]([6; 4; 2]))?)
 
-class iso _TestListEveryExists is UnitTest
+class \nodoc\ iso _TestListEveryExists is UnitTest
   fun name(): String => "collections/persistent/Lists (every, exists)"
 
   fun apply(h: TestHelper) =>
@@ -177,7 +177,7 @@ class iso _TestListEveryExists is UnitTest
     h.assert_eq[Bool](l12.exists(is_even), true)
     h.assert_eq[Bool](l13.exists(is_even), false)
 
-class iso _TestListPartition is UnitTest
+class \nodoc\ iso _TestListPartition is UnitTest
   fun name(): String => "collections/persistent/Lists (partition)"
 
   fun apply(h: TestHelper) ? =>
@@ -187,7 +187,7 @@ class iso _TestListPartition is UnitTest
     h.assert_true(Lists[U32].eq(hits, Lists[U32]([2; 4; 6]))?)
     h.assert_true(Lists[U32].eq(misses, Lists[U32]([1; 3; 5]))?)
 
-class iso _TestListDrop is UnitTest
+class \nodoc\ iso _TestListDrop is UnitTest
   fun name(): String => "collections/persistent/List (drop)"
 
   fun apply(h: TestHelper) ? =>
@@ -198,7 +198,7 @@ class iso _TestListDrop is UnitTest
     h.assert_true(Lists[U32].eq(l2.drop(3), Lists[U32].empty())?)
     h.assert_true(Lists[String].eq(empty.drop(3), Lists[String].empty())?)
 
-class iso _TestListDropWhile is UnitTest
+class \nodoc\ iso _TestListDropWhile is UnitTest
   fun name(): String => "collections/persistent/List (drop_while)"
 
   fun apply(h: TestHelper) ? =>
@@ -209,7 +209,7 @@ class iso _TestListDropWhile is UnitTest
       Lists[U32]([1; 3; 4; 6]))?)
     h.assert_true(Lists[U32].eq(empty.drop_while(is_even), Lists[U32].empty())?)
 
-class iso _TestListTake is UnitTest
+class \nodoc\ iso _TestListTake is UnitTest
   fun name(): String => "collections/persistent/List (take)"
 
   fun apply(h: TestHelper) ? =>
@@ -220,7 +220,7 @@ class iso _TestListTake is UnitTest
     h.assert_true(Lists[U32].eq(l2.take(3), Lists[U32]([1; 2]))?)
     h.assert_true(Lists[String].eq(empty.take(3), Lists[String].empty())?)
 
-class iso _TestListTakeWhile is UnitTest
+class \nodoc\ iso _TestListTakeWhile is UnitTest
   fun name(): String => "collections/persistent/List (take_while)"
 
   fun apply(h: TestHelper) ? =>
@@ -230,7 +230,7 @@ class iso _TestListTakeWhile is UnitTest
     h.assert_true(Lists[U32].eq(l.take_while(is_even), Lists[U32]([4; 2; 6]))?)
     h.assert_true(Lists[U32].eq(empty.take_while(is_even), Lists[U32].empty())?)
 
-class iso _TestMap is UnitTest
+class \nodoc\ iso _TestMap is UnitTest
   fun name(): String =>
     "collections/persistent/Map (update, remove, concat, add, sub)"
 
@@ -337,17 +337,17 @@ class iso _TestMap is UnitTest
     end
     ops
 
-type _Map is HashMap[U64, U64, CollisionHash]
+type _Map is HashMap[U64, U64, _CollisionHash]
 
-primitive CollisionHash is mut.HashFunction[U64]
+primitive \nodoc\ _CollisionHash is mut.HashFunction[U64]
   fun hash(x: U64): USize => x.usize() % 100
   fun eq(x: U64, y: U64): Bool => x == y
 
-interface val _TestOp
+interface \nodoc\ val _TestOp
   fun apply(a: _Map, b: mut.Map[U64, U64]): _Map ?
   fun str(): String
 
-class val _OpMapUpdate
+class \nodoc\ val _OpMapUpdate
   let k: U64
   let v: U64
 
@@ -360,9 +360,9 @@ class val _OpMapUpdate
     a(k) = v
 
   fun str(): String =>
-    "".join(["Update("; k; "_"; CollisionHash.hash(k); ", "; v; ")"].values())
+    "".join(["Update("; k; "_"; _CollisionHash.hash(k); ", "; v; ")"].values())
 
-class val _OpMapRemove
+class \nodoc\ val _OpMapRemove
   let k: U64
 
   new val create(k': U64) =>
@@ -375,7 +375,7 @@ class val _OpMapRemove
   fun str(): String =>
     "".join(["Remove("; k; ")"].values())
 
-class iso _TestMapVsMap is UnitTest
+class \nodoc\ iso _TestMapVsMap is UnitTest
   fun name(): String => "collections/persistent/Map (persistent vs mutable)"
 
   fun apply(h: TestHelper) ? =>
@@ -409,7 +409,7 @@ class iso _TestMapVsMap is UnitTest
     h.assert_eq[USize](p_map.size(), c)
     h.assert_eq[USize](m_map.size(), 0)
 
-class iso _TestSet is UnitTest
+class \nodoc\ iso _TestSet is UnitTest
   fun name(): String => "collections/persistent/Set"
 
   fun apply(h: TestHelper) =>
@@ -434,7 +434,7 @@ class iso _TestSet is UnitTest
     h.assert_true(a.without(b) == (Set[USize] + 1))
     h.assert_true(b.without(a) == (Set[USize] + 4))
 
-class iso _TestVec is UnitTest
+class \nodoc\ iso _TestVec is UnitTest
   fun name(): String => "collections/persistent/Vec"
 
   fun apply(h: TestHelper) ? =>
@@ -503,7 +503,7 @@ class iso _TestVec is UnitTest
     h.assert_eq[USize](v(n - 12)?, n - 1)
     h.assert_eq[USize](v.size(), n - 11)
 
-class iso _TestVecIterators is UnitTest
+class \nodoc\ iso _TestVecIterators is UnitTest
   fun name(): String => "collections/persistent/Vec (iterators)"
 
   fun apply(h: TestHelper) ? =>

--- a/packages/encode/base64/_test.pony
+++ b/packages/encode/base64/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "collections"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -12,7 +12,7 @@ actor Main is TestList
     test(_TestBase64EncodeDecode)
     test(_TestBase64Quote)
 
-class iso _TestBase64Encode is UnitTest
+class \nodoc\ iso _TestBase64Encode is UnitTest
   """
   Test base64 encoding.
   Using test examples from RFC 4648.
@@ -28,7 +28,7 @@ class iso _TestBase64Encode is UnitTest
     h.assert_eq[String]("Zm9vYmE=", Base64.encode("fooba"))
     h.assert_eq[String]("Zm9vYmFy", Base64.encode("foobar"))
 
-class iso _TestBase64Decode is UnitTest
+class \nodoc\ iso _TestBase64Decode is UnitTest
   """
   Test base64 decoding. Examples with and without padding are tested.
   Using test examples from RFC 4648.
@@ -52,7 +52,7 @@ class iso _TestBase64Decode is UnitTest
     h.assert_eq[String]("fooba", Base64.decode[String iso]("Zm9vYmE")?)
     h.assert_eq[String]("foobar", Base64.decode[String iso]("Zm9vYmFy")?)
 
-class iso _TestBase64EncodeDecode is UnitTest
+class \nodoc\ iso _TestBase64EncodeDecode is UnitTest
   """
   Test base64 encoding.
   Check encoding then decoding gives back original.
@@ -66,7 +66,7 @@ class iso _TestBase64EncodeDecode is UnitTest
 
     h.assert_eq[String](src, dec)
 
-class iso _TestBase64Quote is UnitTest
+class \nodoc\ iso _TestBase64Quote is UnitTest
   """
   Test base64 encoding.
   Check encoding then decoding something a bit longer.

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -7,7 +7,7 @@ use "time"
 
 use @getuid[U32]() if not windows
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
 
   new make() => None
@@ -61,7 +61,7 @@ actor Main is TestList
       test(_TestSymlink)
     end
 
-primitive _FileHelper
+primitive \nodoc\ _FileHelper
   fun make_files(h: TestHelper, files: Array[String]): FilePath ? =>
     let top = Directory(FilePath.mkdtemp(h.env.root,
       "tmp._FileHelper.")?)?
@@ -82,7 +82,7 @@ primitive _FileHelper
     end
     top.path
 
-trait iso _NonRootTest is UnitTest
+trait \nodoc\ iso _NonRootTest is UnitTest
 
   fun apply_as_non_root(h: TestHelper) ?
 
@@ -108,7 +108,7 @@ trait iso _NonRootTest is UnitTest
       end
     end
 
-class iso _TestMkdtemp is UnitTest
+class \nodoc\ iso _TestMkdtemp is UnitTest
   fun name(): String => "files/FilePath.mkdtemp"
   fun apply(h: TestHelper) ? =>
     let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestMkdtemp.")?
@@ -118,7 +118,7 @@ class iso _TestMkdtemp is UnitTest
       h.assert_true(tmp.remove())
     end
 
-class iso _TestWalk is UnitTest
+class \nodoc\ iso _TestWalk is UnitTest
   fun name(): String => "files/FilePath.walk"
   fun apply(h: TestHelper) ? =>
     let top =
@@ -143,7 +143,7 @@ class iso _TestWalk is UnitTest
       h.assert_true(top.remove())
     end
 
-class iso _TestSymlink is UnitTest
+class \nodoc\ iso _TestSymlink is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>
@@ -189,7 +189,7 @@ class iso _TestSymlink is UnitTest
       target_path.symlink(link_path),
       "could not create symbolic link to: " + target_path.path)
 
-class iso _TestFilePathFileAuth is UnitTest
+class \nodoc\ iso _TestFilePathFileAuth is UnitTest
   """
   _TestFilePathFileAuth checks that it is error-free to produce a filepath
   using `FileAuth` created from `AmbientAuth`.
@@ -200,7 +200,7 @@ class iso _TestFilePathFileAuth is UnitTest
     let filepath = FilePath(FileAuth(h.env.root), path)
     h.assert_no_error({()? => FilePath.from(filepath, path)? })
 
-class iso _TestFilePathFrom is UnitTest
+class \nodoc\ iso _TestFilePathFrom is UnitTest
   """
   _TestFilePathFrom checks that it is error-free to produce a filepath
   using the from constructor to the same path of the provided `FilePath`.
@@ -214,7 +214,7 @@ class iso _TestFilePathFrom is UnitTest
     let filepath = FilePath(h.env.root, path)
     h.assert_no_error({()? => FilePath.from(filepath, path)? })
 
-class iso _TestFilePathFromError is UnitTest
+class \nodoc\ iso _TestFilePathFromError is UnitTest
   """
   _TestFilePathFromError checks that it is an error to produce a filepath
   using the from constructor which is not a subpath of the provided `FilePath`.
@@ -228,7 +228,7 @@ class iso _TestFilePathFromError is UnitTest
     let filepath = FilePath(h.env.root, path)
     h.assert_error({()? => FilePath.from(filepath, "/")? })
 
-class iso _TestDirectoryOpen is UnitTest
+class \nodoc\ iso _TestDirectoryOpen is UnitTest
   fun name(): String => "files/File.open.directory"
   fun apply(h: TestHelper) ? =>
     let tmp = FilePath.mkdtemp(h.env.root, "tmp.TestDiropen.")?
@@ -243,7 +243,7 @@ class iso _TestDirectoryOpen is UnitTest
       h.assert_true(tmp.remove())
     end
 
-class iso _TestDirectoryFileOpen is UnitTest
+class \nodoc\ iso _TestDirectoryFileOpen is UnitTest
   fun name(): String => "files/Directory.open-file"
   fun apply(h: TestHelper) =>
   try
@@ -272,7 +272,7 @@ class iso _TestDirectoryFileOpen is UnitTest
     h.fail("Unhandled error!")
   end
 
-class iso _TestPathClean is UnitTest
+class \nodoc\ iso _TestPathClean is UnitTest
   fun name(): String => "files/Path.clean"
   fun apply(h: TestHelper) =>
     let res1 = Path.clean("//foo/bar///")
@@ -301,7 +301,7 @@ class iso _TestPathClean is UnitTest
       h.assert_eq[String](res7, "/foo/qux")
     end
 
-class iso _TestPathJoin is UnitTest
+class \nodoc\ iso _TestPathJoin is UnitTest
   fun name(): String => "files/Path.join"
   fun apply(h: TestHelper) =>
     let path1 = "//foo/bar///"
@@ -323,13 +323,13 @@ class iso _TestPathJoin is UnitTest
       h.assert_eq[String](res3, "/foo/dir/base.ext")
     end
 
-class iso _TestPathRel is UnitTest
+class \nodoc\ iso _TestPathRel is UnitTest
   fun name(): String => "files/Path.rel"
   fun apply(h: TestHelper) ? =>
     let res = Path.rel("foo/bar", "foo/bar/baz")?
     h.assert_eq[String](res, "baz")
 
-class iso _TestPathSplit is UnitTest
+class \nodoc\ iso _TestPathSplit is UnitTest
   fun name(): String => "files/Path.split"
   fun apply(h: TestHelper) =>
     ifdef windows then
@@ -367,7 +367,7 @@ class iso _TestPathSplit is UnitTest
       end
     end
 
-class iso _TestPathDir is UnitTest
+class \nodoc\ iso _TestPathDir is UnitTest
   fun name(): String => "files/Path.dir"
   fun apply(h: TestHelper) =>
 
@@ -384,7 +384,7 @@ class iso _TestPathDir is UnitTest
       h.assert_eq[String](res2, "/foo/bar/dir")
     end
 
-class iso _TestPathBase is UnitTest
+class \nodoc\ iso _TestPathBase is UnitTest
   fun name(): String => "files/Path.dir"
   fun apply(h: TestHelper) =>
 
@@ -398,7 +398,7 @@ class iso _TestPathBase is UnitTest
     h.assert_eq[String](Path.base(p1, false), "base")
     h.assert_eq[String](Path.base(p2), "")
 
-class iso _TestPathExt is UnitTest
+class \nodoc\ iso _TestPathExt is UnitTest
   fun name(): String => "files/Path.ext"
   fun apply(h: TestHelper) =>
     ifdef windows then
@@ -416,7 +416,7 @@ class iso _TestPathExt is UnitTest
       h.assert_eq[String](res2, "")
     end
 
-class iso _TestPathVolume is UnitTest
+class \nodoc\ iso _TestPathVolume is UnitTest
   fun name(): String => "files/Path.volume"
   fun apply(h: TestHelper) =>
     let res1 = Path.volume("C:\\foo")
@@ -430,7 +430,7 @@ class iso _TestPathVolume is UnitTest
       h.assert_eq[String](res2, "")
     end
 
-class iso _TestPathRoot is UnitTest
+class \nodoc\ iso _TestPathRoot is UnitTest
   fun name(): String => "files/Path.root"
   fun apply(h: TestHelper) =>
     let res1 = Path.abs("/")
@@ -438,7 +438,7 @@ class iso _TestPathRoot is UnitTest
     h.assert_eq[String](res1, "/")
     h.assert_eq[String](res2, "/")
 
-class iso _TestFileEOF is UnitTest
+class \nodoc\ iso _TestFileEOF is UnitTest
   fun name(): String => "files/File.eof-error"
   fun apply(h: TestHelper) =>
     let path = "tmp.eof"
@@ -456,7 +456,7 @@ class iso _TestFileEOF is UnitTest
     end
     filepath.remove()
 
-class iso _TestFileCreate is UnitTest
+class \nodoc\ iso _TestFileCreate is UnitTest
   fun name(): String => "files/File.create"
   fun apply(h: TestHelper) =>
     try
@@ -473,7 +473,7 @@ class iso _TestFileCreate is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileCreateExistsNotWriteable is _NonRootTest
+class \nodoc\ iso _TestFileCreateExistsNotWriteable is _NonRootTest
   fun name(): String => "files/File.create-exists-not-writeable"
   fun apply_as_non_root(h: TestHelper) ? =>
     let content = "unwriteable"
@@ -500,7 +500,7 @@ class iso _TestFileCreateExistsNotWriteable is _NonRootTest
 
     h.assert_true(filepath.remove())
 
-class iso _TestFileCreateDirNotWriteable is _NonRootTest
+class \nodoc\ iso _TestFileCreateDirNotWriteable is _NonRootTest
   fun name(): String => "files/File.create-dir-not-writeable"
   fun apply_as_non_root(h: TestHelper) =>
     ifdef not windows then
@@ -533,7 +533,7 @@ class iso _TestFileCreateDirNotWriteable is _NonRootTest
       end
     end
 
-class iso _TestFileOpenInDirNotWriteable is UnitTest
+class \nodoc\ iso _TestFileOpenInDirNotWriteable is UnitTest
   fun name(): String => "files/File.open-dir-not-writeable"
   fun apply(h: TestHelper) =>
     ifdef not windows then
@@ -566,7 +566,7 @@ class iso _TestFileOpenInDirNotWriteable is UnitTest
       end
     end
 
-class iso _TestFileCreateMissingCaps is UnitTest
+class \nodoc\ iso _TestFileCreateMissingCaps is UnitTest
   fun name(): String => "files/File.create-missing-caps"
   fun apply(h: TestHelper) =>
     let no_create_caps = FileCaps.>all().>unset(FileCreate)
@@ -597,7 +597,7 @@ class iso _TestFileCreateMissingCaps is UnitTest
     h.assert_false(file3.valid())
     h.assert_is[FileErrNo](file3.errno(), FileError)
 
-class iso _TestFileOpen is UnitTest
+class \nodoc\ iso _TestFileOpen is UnitTest
   fun name(): String => "files/File.open"
   fun apply(h: TestHelper) =>
     try
@@ -620,7 +620,7 @@ class iso _TestFileOpen is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileOpenError is UnitTest
+class \nodoc\ iso _TestFileOpenError is UnitTest
   fun name(): String => "files/File.open-error"
   fun apply(h: TestHelper) =>
     let path = "tmp.openerror"
@@ -650,7 +650,7 @@ class _TestFileOpenWrite is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileOpenPermissionDenied is _NonRootTest
+class \nodoc\ iso _TestFileOpenPermissionDenied is _NonRootTest
   fun name(): String => "files/File.open-permission-denied"
   fun apply_as_non_root(h: TestHelper) =>
     ifdef not windows then
@@ -680,7 +680,7 @@ class iso _TestFileOpenPermissionDenied is _NonRootTest
       end
     end
 
-class iso _TestFileLongLine is UnitTest
+class \nodoc\ iso _TestFileLongLine is UnitTest
   fun name(): String => "files/File.longline"
   fun apply(h: TestHelper) =>
     let path = "tmp.longline"
@@ -698,7 +698,7 @@ class iso _TestFileLongLine is UnitTest
     end
     filepath.remove()
 
-class iso _TestFileWrite is UnitTest
+class \nodoc\ iso _TestFileWrite is UnitTest
   fun name(): String => "files/File.write"
   fun apply(h: TestHelper) =>
     try
@@ -716,7 +716,7 @@ class iso _TestFileWrite is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileWritev is UnitTest
+class \nodoc\ iso _TestFileWritev is UnitTest
   fun name(): String => "files/File.writev"
   fun apply(h: TestHelper) =>
     try
@@ -741,7 +741,7 @@ class iso _TestFileWritev is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileQueue is UnitTest
+class \nodoc\ iso _TestFileQueue is UnitTest
   fun name(): String => "files/File.queue"
   fun apply(h: TestHelper) =>
     try
@@ -758,7 +758,7 @@ class iso _TestFileQueue is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileQueuev is UnitTest
+class \nodoc\ iso _TestFileQueuev is UnitTest
   fun name(): String => "files/File.queuev"
   fun apply(h: TestHelper) =>
     try
@@ -780,7 +780,7 @@ class iso _TestFileQueuev is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileMixedWriteQueue is UnitTest
+class \nodoc\ iso _TestFileMixedWriteQueue is UnitTest
   fun name(): String => "files/File.mixedwrite"
   fun apply(h: TestHelper) =>
     try
@@ -830,7 +830,7 @@ class iso _TestFileMixedWriteQueue is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileWritevLarge is UnitTest
+class \nodoc\ iso _TestFileWritevLarge is UnitTest
   fun name(): String => "files/File.writevlarge"
   fun apply(h: TestHelper) =>
     try
@@ -859,7 +859,7 @@ class iso _TestFileWritevLarge is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileFlush is UnitTest
+class \nodoc\ iso _TestFileFlush is UnitTest
   fun name(): String => "files/File.flush"
   fun apply(h: TestHelper) =>
     try
@@ -887,7 +887,7 @@ class iso _TestFileFlush is UnitTest
       h.fail("Unhandled error!")
     end
 
-class iso _TestFileReadMore is UnitTest
+class \nodoc\ iso _TestFileReadMore is UnitTest
   fun name(): String => "files/File.read-more"
   fun apply(h: TestHelper)? =>
     let path = FilePath(h.env.root, "tmp-read-more")
@@ -910,7 +910,7 @@ class iso _TestFileReadMore is UnitTest
     end
     path.remove()
 
-class iso _TestFileRemoveReadOnly is UnitTest
+class \nodoc\ iso _TestFileRemoveReadOnly is UnitTest
   fun name(): String => "files/File.remove-readonly-file"
   fun apply(h: TestHelper) ? =>
     let path = FilePath(h.env.root, "tmp-read-only")
@@ -928,7 +928,7 @@ class iso _TestFileRemoveReadOnly is UnitTest
     h.assert_true(path.chmod(mode))
     h.assert_true(path.remove())
 
-class iso _TestDirectoryRemoveReadOnly is UnitTest
+class \nodoc\ iso _TestDirectoryRemoveReadOnly is UnitTest
   fun name(): String => "files/File.remove-readonly-directory"
 
   fun apply(h: TestHelper) ? =>
@@ -947,7 +947,7 @@ class iso _TestDirectoryRemoveReadOnly is UnitTest
     h.assert_true(path.chmod(mode))
     h.assert_true(path.remove())
 
-class iso _TestFileLinesEmptyFile is UnitTest
+class \nodoc\ iso _TestFileLinesEmptyFile is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>
@@ -973,7 +973,7 @@ class iso _TestFileLinesEmptyFile is UnitTest
       h.assert_eq[USize](lines_returned, 0, "FileLines returned a line for an empty file")
     end
 
-class iso _TestFileLinesSingleLine is UnitTest
+class \nodoc\ iso _TestFileLinesSingleLine is UnitTest
 
   let lines: Array[String] = [ as String:
     "a"
@@ -1041,7 +1041,7 @@ class iso _TestFileLinesSingleLine is UnitTest
       i = i + 1
     end
 
-class _TestFileLinesMultiLine is UnitTest
+class \nodoc\ _TestFileLinesMultiLine is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   let line_endings: Array[String] val = ["\n"; "\r\n"]
@@ -1105,7 +1105,7 @@ class _TestFileLinesMultiLine is UnitTest
       end
     end
 
-class _TestFileLinesMovingCursor is UnitTest
+class \nodoc\ _TestFileLinesMovingCursor is UnitTest
   var tmp_dir: (FilePath | None) = None
 
   fun ref set_up(h: TestHelper) ? =>

--- a/packages/format/_test.pony
+++ b/packages/format/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "collections"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -10,7 +10,7 @@ actor Main is TestList
     test(_TestApply)
     test(_TestInt)
 
-class iso _TestApply is UnitTest
+class \nodoc\ iso _TestApply is UnitTest
   fun name(): String => "format/apply"
 
   fun apply(h: TestHelper) =>
@@ -21,7 +21,7 @@ class iso _TestApply is UnitTest
     h.assert_eq[String]("   fmt   ",
       Format("fmt", FormatDefault, PrefixDefault, -1, 9, AlignCenter))
 
-class iso _TestInt is UnitTest
+class \nodoc\ iso _TestInt is UnitTest
   fun name(): String => "format/int"
 
   fun apply(h: TestHelper) =>

--- a/packages/ini/_test.pony
+++ b/packages/ini/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -8,7 +8,7 @@ actor Main is TestList
     // Tests below function across all systems and are listed alphabetically
     test(_TestIniParse)
 
-class iso _TestIniParse is UnitTest
+class \nodoc\ iso _TestIniParse is UnitTest
   fun name(): String => "ini/IniParse"
 
   fun apply(h: TestHelper) ? =>

--- a/packages/itertools/_test.pony
+++ b/packages/itertools/_test.pony
@@ -2,7 +2,7 @@ use "collections"
 use "ponytest"
 use "time"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -32,7 +32,7 @@ actor Main is TestList
     test(_TestIterTakeWhile)
     test(_TestIterZip)
 
-class iso _TestIterChain is UnitTest
+class \nodoc\ iso _TestIterChain is UnitTest
   fun name(): String => "itertools/Iter.chain"
 
   fun apply(h: TestHelper) =>
@@ -105,7 +105,7 @@ class iso _TestIterChain is UnitTest
       h.fail()
     end
 
-class iso _TestIterRepeatValue is UnitTest
+class \nodoc\ iso _TestIterRepeatValue is UnitTest
   fun name(): String => "itertools/Iter.repeat_value"
 
   fun apply(h: TestHelper) ? =>
@@ -114,7 +114,7 @@ class iso _TestIterRepeatValue is UnitTest
       h.assert_eq[String]("a", repeater.next()?)
     end
 
-class iso _TestIterAll is UnitTest
+class \nodoc\ iso _TestIterAll is UnitTest
   fun name(): String => "itertools/Iter.all"
 
   fun apply(h: TestHelper) ? =>
@@ -124,7 +124,7 @@ class iso _TestIterAll is UnitTest
     input(2)? = -6
     h.assert_false(Iter[I64](input.values()).all(is_positive))
 
-class iso _TestIterAny is UnitTest
+class \nodoc\ iso _TestIterAny is UnitTest
   fun name(): String => "itertools/Iter.any"
 
   fun apply(h: TestHelper) ? =>
@@ -134,7 +134,7 @@ class iso _TestIterAny is UnitTest
     input(2)? = -6
     h.assert_false(Iter[I64](input.values()).any(is_positive))
 
-class iso _TestIterCollect is UnitTest
+class \nodoc\ iso _TestIterCollect is UnitTest
   fun name(): String => "itertools/Iter.collect"
 
   fun apply(h: TestHelper) =>
@@ -143,7 +143,7 @@ class iso _TestIterCollect is UnitTest
       input,
       Iter[I64](input.values()).collect(Array[I64]))
 
-class iso _TestIterCount is UnitTest
+class \nodoc\ iso _TestIterCount is UnitTest
   fun name(): String => "itertools/Iter.count"
 
   fun apply(h: TestHelper) =>
@@ -157,7 +157,7 @@ class iso _TestIterCount is UnitTest
       input2.size(),
       Iter[I64](input2.values()).count())
 
-class iso _TestIterCycle is UnitTest
+class \nodoc\ iso _TestIterCycle is UnitTest
   fun name(): String => "itertools/Iter.cycle"
 
   fun apply(h: TestHelper) =>
@@ -183,7 +183,7 @@ class iso _TestIterCycle is UnitTest
 
     h.assert_array_eq[String](expected, actual)
 
-class iso _TestIterEnum is UnitTest
+class \nodoc\ iso _TestIterEnum is UnitTest
   fun name(): String => "itertools/Iter.enum"
 
   fun apply(h: TestHelper) ? =>
@@ -200,7 +200,7 @@ class iso _TestIterEnum is UnitTest
     end
     h.assert_eq[USize](i, 3)
 
-class iso _TestIterFilter is UnitTest
+class \nodoc\ iso _TestIterFilter is UnitTest
   fun name(): String => "itertools/Iter.filter"
 
   fun apply(h: TestHelper) =>
@@ -233,7 +233,7 @@ class iso _TestIterFilter is UnitTest
 
     h.assert_array_eq[String](actual, expected)
 
-class iso _TestIterFilterMap is UnitTest
+class \nodoc\ iso _TestIterFilterMap is UnitTest
   fun name(): String => "itertools/Iter.filter_map"
 
   fun apply(h: TestHelper) ? =>
@@ -252,7 +252,7 @@ class iso _TestIterFilterMap is UnitTest
     h.assert_eq[I64](2, iter.next()?)
     h.assert_false(iter.has_next())
 
-class iso _TestIterFind is UnitTest
+class \nodoc\ iso _TestIterFind is UnitTest
   fun name(): String => "itertools/Iter.find"
 
   fun apply(h: TestHelper) ? =>
@@ -267,7 +267,7 @@ class iso _TestIterFind is UnitTest
 
     h.assert_eq[I64](5, Iter[I64](input.values()).find({(x) => x > 0 }, 4)?)
 
-class iso _TestIterFlatMap is UnitTest
+class \nodoc\ iso _TestIterFlatMap is UnitTest
   fun name(): String => "itertools/Iter.flat_map"
 
   fun apply(h: TestHelper) ? =>
@@ -301,7 +301,7 @@ class iso _TestIterFlatMap is UnitTest
     h.assert_eq[U8](1, iter.next()?)
     h.assert_false(iter.has_next())
 
-class iso _TestIterFold is UnitTest
+class \nodoc\ iso _TestIterFold is UnitTest
   fun name(): String => "itertools/Iter.fold"
 
   fun apply(h: TestHelper) =>
@@ -314,7 +314,7 @@ class iso _TestIterFold is UnitTest
         .fold_partial[I64](0, {(acc, x) ? => error })?
     })
 
-class iso _TestIterLast is UnitTest
+class \nodoc\ iso _TestIterLast is UnitTest
   fun name(): String => "itertools/Iter.last"
 
   fun apply(h: TestHelper) ? =>
@@ -333,7 +333,7 @@ class iso _TestIterLast is UnitTest
     h.assert_eq[I64](3,
       Iter[I64](input4.values()).last()?)
 
-class iso _TestIterMap is UnitTest
+class \nodoc\ iso _TestIterMap is UnitTest
   fun name(): String => "itertools/Iter.map"
 
   fun apply(h: TestHelper) =>
@@ -347,7 +347,7 @@ class iso _TestIterMap is UnitTest
 
     h.assert_array_eq[String](actual, expected)
 
-class iso _TestIterNextOr is UnitTest
+class \nodoc\ iso _TestIterNextOr is UnitTest
   fun name(): String => "itertools/Iter.next_or"
 
   fun apply(h: TestHelper) =>
@@ -363,7 +363,7 @@ class iso _TestIterNextOr is UnitTest
     h.assert_false(iter.has_next())
     h.assert_eq[U64](1, iter.next_or(1))
 
-class iso _TestIterNth is UnitTest
+class \nodoc\ iso _TestIterNth is UnitTest
   fun name(): String => "itertools/Iter.nth"
 
   fun apply(h: TestHelper) ? =>
@@ -385,7 +385,7 @@ class iso _TestIterNth is UnitTest
           end).nth(6)?
     })
 
-class iso _TestIterRun is UnitTest
+class \nodoc\ iso _TestIterRun is UnitTest
   fun name(): String => "itertools/Iter.run"
 
   fun apply(h: TestHelper) =>
@@ -411,7 +411,7 @@ class iso _TestIterRun is UnitTest
 
     for (_, v) in actions.pairs() do h.assert_true(v) end
 
-class iso _TestIterSkip is UnitTest
+class \nodoc\ iso _TestIterSkip is UnitTest
   fun name(): String => "itertools/Iter.skip"
 
   fun apply(h: TestHelper) ? =>
@@ -428,7 +428,7 @@ class iso _TestIterSkip is UnitTest
 
     h.assert_false(Iter[I64](input.values()).skip(4).has_next())
 
-class iso _TestIterSkipWhile is UnitTest
+class \nodoc\ iso _TestIterSkipWhile is UnitTest
   fun name(): String => "itertools/Iter.skip_while"
 
   fun apply(h: TestHelper) ? =>
@@ -438,7 +438,7 @@ class iso _TestIterSkipWhile is UnitTest
     h.assert_eq[I64](-1,
       Iter[I64](input.values()).skip_while({(x) => x < -2 }).next()?)
 
-class iso _TestIterTake is UnitTest
+class \nodoc\ iso _TestIterTake is UnitTest
   fun name(): String => "itertools/Iter.take"
 
   fun apply(h: TestHelper) =>
@@ -473,7 +473,7 @@ class iso _TestIterTake is UnitTest
 
     h.complete(true)
 
-class iso _TestIterTakeWhile is UnitTest
+class \nodoc\ iso _TestIterTakeWhile is UnitTest
   fun name(): String => "itertools/Iter.take_while"
 
   fun apply(h: TestHelper) ? =>
@@ -502,7 +502,7 @@ class iso _TestIterTakeWhile is UnitTest
     h.assert_eq[USize](1, infinite.next()?)
     h.assert_false(infinite.has_next())
 
-class iso _TestIterZip is UnitTest
+class \nodoc\ iso _TestIterZip is UnitTest
   fun name(): String => "itertools/Iter.zip"
 
   fun apply(h: TestHelper) =>

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "collections"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -24,7 +24,7 @@ actor Main is TestList
     test(_TestPrintObject)
     test(_TestPrintString)
 
-class iso _TestParseBasic is UnitTest
+class \nodoc\ iso _TestParseBasic is UnitTest
   """
   Test Json basic parsing, eg allowing whitespace.
   """
@@ -43,7 +43,7 @@ class iso _TestParseBasic is UnitTest
     h.assert_error({() ? => JsonDoc.parse("   ")? })
     h.assert_error({() ? => JsonDoc.parse("true true")? })
 
-class iso _TestParseKeyword is UnitTest
+class \nodoc\ iso _TestParseKeyword is UnitTest
   """
   Test Json parsing of keywords.
   """
@@ -66,7 +66,7 @@ class iso _TestParseKeyword is UnitTest
     h.assert_error({() ? => JsonDoc.parse("truez")? })
     h.assert_error({() ? => JsonDoc.parse("TRUE")? })
 
-class iso _TestParseNumber is UnitTest
+class \nodoc\ iso _TestParseNumber is UnitTest
   """
   Test Json parsing of numbers.
   """
@@ -116,7 +116,7 @@ class iso _TestParseNumber is UnitTest
     h.assert_error({() ? => JsonDoc.parse("-01")? })
     h.assert_error({() ? => JsonDoc.parse("-012")? })
 
-class iso _TestParseString is UnitTest
+class \nodoc\ iso _TestParseString is UnitTest
   """
   Test Json parsing of strings.
   """
@@ -157,7 +157,7 @@ class iso _TestParseString is UnitTest
     h.assert_error({() ? => JsonDoc.parse(""" "\uD834" """)? })
     h.assert_error({() ? => JsonDoc.parse(""" "\uDD1E" """)? })
 
-class iso _TestParseArray is UnitTest
+class \nodoc\ iso _TestParseArray is UnitTest
   """
   Test Json parsing of arrays.
   """
@@ -209,7 +209,7 @@ class iso _TestParseArray is UnitTest
     h.assert_error({() ? => JsonDoc.parse("[true")? })
     h.assert_error({() ? => JsonDoc.parse("[true,")? })
 
-class iso _TestParseObject is UnitTest
+class \nodoc\ iso _TestParseObject is UnitTest
   """
   Test Json parsing of objects.
   """
@@ -265,7 +265,7 @@ class iso _TestParseObject is UnitTest
     h.assert_error({() ? => JsonDoc.parse("""{"a" true}""")? })
     h.assert_error({() ? => JsonDoc.parse("""{:true}""")? })
 
-class iso _TestParseRFC1 is UnitTest
+class \nodoc\ iso _TestParseRFC1 is UnitTest
   """
   Test Json parsing of first example from RFC7159.
   """
@@ -321,7 +321,7 @@ class iso _TestParseRFC1 is UnitTest
     h.assert_eq[I64](234, array.data(2)? as I64)
     h.assert_eq[I64](38793, array.data(3)? as I64)
 
-class iso _TestParseRFC2 is UnitTest
+class \nodoc\ iso _TestParseRFC2 is UnitTest
   """
   Test Json parsing of second example from RFC7159.
   """
@@ -385,7 +385,7 @@ class iso _TestParseRFC2 is UnitTest
     h.assert_eq[String]("94085", obj2.data("Zip")? as String)
     h.assert_eq[String]("US", obj2.data("Country")? as String)
 
-class iso _TestPrintKeyword is UnitTest
+class \nodoc\ iso _TestPrintKeyword is UnitTest
   """
   Test Json printing of keywords.
   """
@@ -403,7 +403,7 @@ class iso _TestPrintKeyword is UnitTest
     doc.data = None
     h.assert_eq[String]("null", doc.string())
 
-class iso _TestPrintNumber is UnitTest
+class \nodoc\ iso _TestPrintNumber is UnitTest
   """
   Test Json printing of numbers.
   """
@@ -433,7 +433,7 @@ class iso _TestPrintNumber is UnitTest
     // We don't test exponent formatted output because it can be slightly
     // different on different platforms
 
-class iso _TestPrintString is UnitTest
+class \nodoc\ iso _TestPrintString is UnitTest
   """
   Test Json printing of strings.
   """
@@ -463,7 +463,7 @@ class iso _TestPrintString is UnitTest
     doc.data = "Foo\U01D11Ebar"
     h.assert_eq[String](""""Foo\uD834\uDD1Ebar"""", doc.string())
 
-class iso _TestPrintArray is UnitTest
+class \nodoc\ iso _TestPrintArray is UnitTest
   """
   Test Json printing of arrays.
   """
@@ -500,7 +500,7 @@ class iso _TestPrintArray is UnitTest
     h.assert_eq[String]("[\n  true,\n  [\n    52,\n    null\n  ]\n]",
       doc.string("  ", true))
 
-class iso _TestNoPrettyPrintArray is UnitTest
+class \nodoc\ iso _TestNoPrettyPrintArray is UnitTest
   """
   Test Json none-pretty printing of arrays.
   """
@@ -537,7 +537,7 @@ class iso _TestNoPrettyPrintArray is UnitTest
     h.assert_eq[String]("[true,[52,null]]",
       doc.string())
 
-class iso _TestPrintObject is UnitTest
+class \nodoc\ iso _TestPrintObject is UnitTest
   """
   Test Json printing of objects.
   """
@@ -564,7 +564,7 @@ class iso _TestPrintObject is UnitTest
     // We don't test with more fields in the object because we don't know what
     // order they will be printed in
 
-class iso _TestNoPrettyPrintObject is UnitTest
+class \nodoc\ iso _TestNoPrettyPrintObject is UnitTest
   """
   Test Json none-pretty printing of objects.
   """
@@ -591,7 +591,7 @@ class iso _TestNoPrettyPrintObject is UnitTest
     // We don't test with more fields in the object because we don't know what
     // order they will be printed in
 
-class iso _TestParsePrint is UnitTest
+class \nodoc\ iso _TestParsePrint is UnitTest
   """
   Test Json parsing a complex example and then reprinting it.
   """

--- a/packages/logger/_test.pony
+++ b/packages/logger/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "promises"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -13,7 +13,7 @@ actor Main is TestList
     test(_TestObjectLogging)
     test(_TestWarn)
 
-class iso _TestError is _StringLoggerTest
+class \nodoc\ iso _TestError is _StringLoggerTest
   fun name(): String => "logger/error"
 
   fun level(): LogLevel => Error
@@ -27,7 +27,7 @@ class iso _TestError is _StringLoggerTest
     logger(Info) and logger.log("info message")
     logger(Fine) and logger.log("fine message")
 
-class iso _TestWarn is _StringLoggerTest
+class \nodoc\ iso _TestWarn is _StringLoggerTest
   fun name(): String => "logger/warn"
 
   fun level(): LogLevel => Warn
@@ -41,7 +41,7 @@ class iso _TestWarn is _StringLoggerTest
     logger(Info) and logger.log("info message")
     logger(Fine) and logger.log("fine message")
 
-class iso _TestInfo is _StringLoggerTest
+class \nodoc\ iso _TestInfo is _StringLoggerTest
   fun name(): String => "logger/info"
 
   fun level(): LogLevel => Info
@@ -55,7 +55,7 @@ class iso _TestInfo is _StringLoggerTest
     logger(Info) and logger.log("info message")
     logger(Fine) and logger.log("fine message")
 
-class iso _TestFine is _StringLoggerTest
+class \nodoc\ iso _TestFine is _StringLoggerTest
   fun name(): String => "logger/fine"
 
   fun level(): LogLevel => Fine
@@ -69,7 +69,7 @@ class iso _TestFine is _StringLoggerTest
     logger(Info) and logger.log("info message")
     logger(Fine) and logger.log("fine message")
 
-class _TestObjectLogging is _LoggerTest[U64]
+class \nodoc\ _TestObjectLogging is _LoggerTest[U64]
   fun name(): String => "logger/object"
 
   fun logger(
@@ -91,11 +91,11 @@ class _TestObjectLogging is _LoggerTest[U64]
   fun log(logger': Logger[U64]) =>
     logger'(Error) and logger'.log(U64(42))
 
-primitive _TestFormatter is LogFormatter
+primitive \nodoc\ _TestFormatter is LogFormatter
   fun apply(msg: String, loc: SourceLoc): String =>
     msg + "\n"
 
-actor _TestStream is OutStream
+actor \nodoc\ _TestStream is OutStream
   let _output: String ref = String
   let _h: TestHelper
   let _promise: Promise[String]
@@ -129,7 +129,7 @@ actor _TestStream is OutStream
     let s: String = _output.clone()
     _promise(s)
 
-trait _LoggerTest[A] is UnitTest
+trait \nodoc\ _LoggerTest[A] is UnitTest
   fun apply(h: TestHelper) =>
     let promise = Promise[String]
     promise.next[None](recover this~_fulfill(h) end)
@@ -158,7 +158,7 @@ trait _LoggerTest[A] is UnitTest
 
   fun log(logger': Logger[A])
 
-trait _StringLoggerTest is _LoggerTest[String]
+trait \nodoc\ _StringLoggerTest is _LoggerTest[String]
   fun logger(
     level': LogLevel,
     stream': OutStream,

--- a/packages/math/_test.pony
+++ b/packages/math/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "random"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -21,7 +21,7 @@ actor Main is TestList
     test(_MersennePrimeTest[ULong]("ULong"))
     test(_MersennePrimeTest[USize]("USize"))
 
-primitive _IsPrimeTestBuilder[A: (UnsignedInteger[A] val & Unsigned)]
+primitive \nodoc\ _IsPrimeTestBuilder[A: (UnsignedInteger[A] val & Unsigned)]
   """
   All integers (excluding 2 and 3), can be expressed as (6k + i),
   where i = −1, 0, 1, 2, 3, or 4 and k is greater than 0.
@@ -61,7 +61,7 @@ primitive _IsPrimeTestBuilder[A: (UnsignedInteger[A] val & Unsigned)]
         h.assert_false(IsPrime[A](1))
     end
 
-primitive _MersennePrimeTest[A: (UnsignedInteger[A] val & Unsigned)]
+primitive \nodoc\ _MersennePrimeTest[A: (UnsignedInteger[A] val & Unsigned)]
   """
   A Mersenne prime is a prime of the form (2 ^ p) - 1 where p is itself prime
   """

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -1,7 +1,7 @@
 use "files"
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -26,7 +26,7 @@ actor Main is TestList
       test(_TestBroadcast)
     end
 
-class _TestPing is UDPNotify
+class \nodoc\ _TestPing is UDPNotify
   let _h: TestHelper
   let _ip: NetAddress
 
@@ -77,7 +77,7 @@ class _TestPing is UDPNotify
     _h.assert_eq[String box](s, "pong!")
     _h.complete(true)
 
-class _TestPong is UDPNotify
+class \nodoc\ _TestPong is UDPNotify
   let _h: TestHelper
 
   new create(h: TestHelper) =>
@@ -114,7 +114,7 @@ class _TestPong is UDPNotify
       recover val [[U8('p'); U8('o'); U8('n'); U8('g'); U8('!')]] end,
       from)
 
-class iso _TestBroadcast is UnitTest
+class \nodoc\ iso _TestBroadcast is UnitTest
   """
   Test broadcasting with UDP.
   """
@@ -141,7 +141,7 @@ class iso _TestBroadcast is UnitTest
       exclude this test by passing the --exclude="net/Broadcast" option.
     """)
 
-class _TestTCP is TCPListenNotify
+class \nodoc\ _TestTCP is TCPListenNotify
   """
   Run a typical TCP test consisting of a single TCPListener that accepts a
   single TCPConnection as a client, using a dynamic available listen port.
@@ -193,7 +193,7 @@ class _TestTCP is TCPListenNotify
       error
     end
 
-class iso _TestTCPExpect is UnitTest
+class \nodoc\ iso _TestTCPExpect is UnitTest
   """
   Test expecting framed data with TCP.
   """
@@ -209,7 +209,7 @@ class iso _TestTCPExpect is UnitTest
 
     _TestTCP(h)(_TestTCPExpectNotify(h, false), _TestTCPExpectNotify(h, true))
 
-class iso _TestTCPExpectOverBufferSize is UnitTest
+class \nodoc\ iso _TestTCPExpectOverBufferSize is UnitTest
   """
   Test expecting framed data with TCP.
   """
@@ -225,7 +225,7 @@ class iso _TestTCPExpectOverBufferSize is UnitTest
     _TestTCP(h)(_TestTCPExpectOverBufferSizeNotify(h),
       _TestTCPExpectOverBufferSizeNotify(h))
 
-class _TestTCPExpectNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPExpectNotify is TCPConnectionNotify
   let _h: TestHelper
   let _server: Bool
   var _expect: USize = 4
@@ -310,7 +310,7 @@ class _TestTCPExpectNotify is TCPConnectionNotify
     buf.append(data)
     conn.write(consume buf)
 
-class _TestTCPExpectOverBufferSizeNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPExpectOverBufferSizeNotify is TCPConnectionNotify
   let _h: TestHelper
   let _expect: USize = 6_000_000_000
 
@@ -339,7 +339,7 @@ class _TestTCPExpectOverBufferSizeNotify is TCPConnectionNotify
       _h.complete_action("connected")
     end
 
-class iso _TestTCPWritev is UnitTest
+class \nodoc\ iso _TestTCPWritev is UnitTest
   """
   Test writev (and sent/sentv notification).
   """
@@ -352,7 +352,7 @@ class iso _TestTCPWritev is UnitTest
 
     _TestTCP(h)(_TestTCPWritevNotifyClient(h), _TestTCPWritevNotifyServer(h))
 
-class _TestTCPWritevNotifyClient is TCPConnectionNotify
+class \nodoc\ _TestTCPWritevNotifyClient is TCPConnectionNotify
   let _h: TestHelper
 
   new iso create(h: TestHelper) =>
@@ -370,7 +370,7 @@ class _TestTCPWritevNotifyClient is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("client connect failed")
 
-class _TestTCPWritevNotifyServer is TCPConnectionNotify
+class \nodoc\ _TestTCPWritevNotifyServer is TCPConnectionNotify
   let _h: TestHelper
   var _buffer: String iso = recover iso String end
 
@@ -397,7 +397,7 @@ class _TestTCPWritevNotifyServer is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("sender connect failed")
 
-class iso _TestTCPMute is UnitTest
+class \nodoc\ iso _TestTCPMute is UnitTest
   """
   Test that the `mute` behavior stops us from reading incoming data. The
   test assumes that send/recv works correctly and that the absence of
@@ -426,7 +426,7 @@ class iso _TestTCPMute is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(true)
 
-class _TestTCPMuteReceiveNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPMuteReceiveNotify is TCPConnectionNotify
   """
   Notifier to fail a test if we receive data after muting the connection.
   """
@@ -455,7 +455,7 @@ class _TestTCPMuteReceiveNotify is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("receiver connect failed")
 
-class _TestTCPMuteSendNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPMuteSendNotify is TCPConnectionNotify
   """
   Notifier that sends data back when it receives any. Used in conjunction with
   the mute receiver to verify that after muting, we don't get any data on
@@ -485,7 +485,7 @@ class _TestTCPMuteSendNotify is TCPConnectionNotify
      _h.complete_action("sender sent data")
      true
 
-class iso _TestTCPUnmute is UnitTest
+class \nodoc\ iso _TestTCPUnmute is UnitTest
   """
   Test that the `unmute` behavior will allow a connection to start reading
   incoming data again. The test assumes that `mute` works correctly and that
@@ -512,7 +512,7 @@ class iso _TestTCPUnmute is UnitTest
     _TestTCP(h)(_TestTCPMuteSendNotify(h),
       _TestTCPUnmuteReceiveNotify(h))
 
-class _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
   """
   Notifier to test that after muting and unmuting a connection, we get data
   """
@@ -542,7 +542,7 @@ class _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("receiver connect failed")
 
-class iso _TestTCPThrottle is UnitTest
+class \nodoc\ iso _TestTCPThrottle is UnitTest
   """
   Test that when we experience backpressure when sending that the `throttled`
   method is called on our `TCPConnectionNotify` instance.
@@ -569,7 +569,7 @@ class iso _TestTCPThrottle is UnitTest
     _TestTCP(h)(_TestTCPThrottleSendNotify(h),
       _TestTCPThrottleReceiveNotify(h))
 
-class _TestTCPThrottleReceiveNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPThrottleReceiveNotify is TCPConnectionNotify
   """
   Notifier to that mutes itself on startup. We then send data to it in order
   to trigger backpressure on the sender.
@@ -590,7 +590,7 @@ class _TestTCPThrottleReceiveNotify is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("receiver connect failed")
 
-class _TestTCPThrottleSendNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPThrottleSendNotify is TCPConnectionNotify
   """
   Notifier that sends data back when it receives any. Used in conjunction with
   the mute receiver to verify that after muting, we don't get any data on
@@ -632,7 +632,7 @@ class _TestTCPThrottleSendNotify is TCPConnectionNotify
     end
     data
 
-class _TestTCPProxy is UnitTest
+class \nodoc\ _TestTCPProxy is UnitTest
   """
   Check that the proxy callback is called on creation of a TCPConnection.
   """
@@ -646,7 +646,7 @@ class _TestTCPProxy is UnitTest
     _TestTCP(h)(_TestTCPProxyNotify(h),
       _TestTCPProxyNotify(h))
 
-class _TestTCPProxyNotify is TCPConnectionNotify
+class \nodoc\ _TestTCPProxyNotify is TCPConnectionNotify
   let _h: TestHelper
   new iso create(h: TestHelper) =>
     _h = h
@@ -661,7 +661,7 @@ class _TestTCPProxyNotify is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("sender connect failed")
 
-class _TestTCPConnectionFailed is UnitTest
+class \nodoc\ _TestTCPConnectionFailed is UnitTest
   fun name(): String => "net/TCPConnectionFailed"
 
   fun ref apply(h: TestHelper) =>
@@ -686,7 +686,7 @@ class _TestTCPConnectionFailed is UnitTest
     h.long_test(30_000_000_000)
     h.dispose_when_done(connection)
 
-class _TestTCPConnectionToClosedServerFailed is UnitTest
+class \nodoc\ _TestTCPConnectionToClosedServerFailed is UnitTest
   """
   Check that you can't connect to a closed listener.
   """
@@ -731,7 +731,7 @@ class _TestTCPConnectionToClosedServerFailed is UnitTest
     h.dispose_when_done(listener)
     h.long_test(30_000_000_000)
 
-actor _TCPConnectionToClosedServerFailedConnector
+actor \nodoc\ _TCPConnectionToClosedServerFailedConnector
   be connect(h: TestHelper, host: String, port: String) =>
     let connection = TCPConnection(
       h.env.root,

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -7,7 +7,7 @@ use "itertools"
 use "time"
 use "signals"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -28,7 +28,7 @@ actor Main is TestList
     test(_TestWaitingOnClosedProcessTwice)
     test(_TestWritevOrdering)
 
-class _PathResolver
+class \nodoc\ _PathResolver
   let _path: Array[FilePath] val
 
   new create(env_vars: Array[String] val, auth: AmbientAuth) =>
@@ -66,7 +66,7 @@ class _PathResolver
     end
     error
 
-primitive _SleepCommand
+primitive \nodoc\ _SleepCommand
   fun path(path_resolver: _PathResolver): String ? =>
     ifdef windows then
       "C:\\Windows\\System32\\ping.exe"
@@ -81,7 +81,7 @@ primitive _SleepCommand
       ["sleep"; seconds.string()]
     end
 
-primitive _CatCommand
+primitive \nodoc\ _CatCommand
   fun path(path_resolver: _PathResolver): String ? =>
     ifdef windows then
       "C:\\Windows\\System32\\find.exe"
@@ -96,7 +96,7 @@ primitive _CatCommand
       ["cat"]
     end
 
-primitive _EchoPath
+primitive \nodoc\ _EchoPath
   fun apply(path_resolver: _PathResolver): String ? =>
     ifdef windows then
       "C:\\Windows\\System32\\cmd.exe" // Have to use "cmd /c echo ..."
@@ -104,7 +104,7 @@ primitive _EchoPath
       path_resolver.resolve("echo")?.path
     end
 
-primitive _PwdPath
+primitive \nodoc\ _PwdPath
   fun apply(): String =>
     ifdef windows then
       "C:\\Windows\\System32\\cmd.exe" // Have to use "cmd /c cd"
@@ -112,7 +112,7 @@ primitive _PwdPath
       "/bin/pwd"
     end
 
-primitive _PwdArgs
+primitive \nodoc\ _PwdArgs
   fun apply(): Array[String] val =>
     ifdef windows then
       ["cmd"; "/c"; "cd"]
@@ -120,7 +120,7 @@ primitive _PwdArgs
       ["pwd"]
     end
 
-class iso _TestFileExecCapabilityIsRequired is UnitTest
+class \nodoc\ iso _TestFileExecCapabilityIsRequired is UnitTest
   fun name(): String =>
     "process/TestFileExecCapabilityIsRequired"
 
@@ -152,7 +152,7 @@ class iso _TestFileExecCapabilityIsRequired is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestNonExecutablePathResultsInExecveError is UnitTest
+class \nodoc\ iso _TestNonExecutablePathResultsInExecveError is UnitTest
   fun name(): String =>
     "process/_TestNonExecutablePathResultsInExecveError"
 
@@ -201,7 +201,7 @@ class iso _TestNonExecutablePathResultsInExecveError is UnitTest
         _path.remove()
     end end
 
-class iso _TestStdinStdout is UnitTest
+class \nodoc\ iso _TestStdinStdout is UnitTest
   fun name(): String =>
     "process/STDIN-STDOUT"
 
@@ -232,7 +232,7 @@ class iso _TestStdinStdout is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestStderr is UnitTest
+class \nodoc\ iso _TestStderr is UnitTest
   var _pm: (ProcessMonitor | None) = None
 
   fun name(): String =>
@@ -281,7 +281,7 @@ class iso _TestStderr is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestExpect is UnitTest
+class \nodoc\ iso _TestExpect is UnitTest
   fun name(): String =>
     "process/Expect"
 
@@ -347,7 +347,7 @@ class iso _TestExpect is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestWritevOrdering is UnitTest
+class \nodoc\ iso _TestWritevOrdering is UnitTest
   fun name(): String =>
     "process/WritevOrdering"
 
@@ -379,7 +379,7 @@ class iso _TestWritevOrdering is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestPrintvOrdering is UnitTest
+class \nodoc\ iso _TestPrintvOrdering is UnitTest
   fun name(): String =>
     "process/PrintvOrdering"
 
@@ -411,7 +411,7 @@ class iso _TestPrintvOrdering is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestStdinWriteBuf is UnitTest
+class \nodoc\ iso _TestStdinWriteBuf is UnitTest
   var _pm: (ProcessMonitor | None) = None
   let _test_start: U64 = Time.nanos()
 
@@ -465,7 +465,7 @@ class iso _TestStdinWriteBuf is UnitTest
     end
     h.complete(false)
 
-class _TestChdir is UnitTest
+class \nodoc\ _TestChdir is UnitTest
   fun name(): String =>
     "process/Chdir"
 
@@ -490,7 +490,7 @@ class _TestChdir is UnitTest
     h.dispose_when_done(pm)
     h.long_test(30_000_000_000)
 
-class _TestBadChdir is UnitTest
+class \nodoc\ _TestBadChdir is UnitTest
   fun name(): String =>
     "process/BadChdir"
 
@@ -514,7 +514,7 @@ class _TestBadChdir is UnitTest
     h.dispose_when_done(pm)
     h.long_test(30_000_000_000)
 
-class _TestBadExec is UnitTest
+class \nodoc\ _TestBadExec is UnitTest
 
   let _bad_exec_sh_contents: String =
     """
@@ -568,7 +568,7 @@ class _TestBadExec is UnitTest
       h.fail("bad_exec_path not set!")
     end
 
-class iso _TestLongRunningChild is UnitTest
+class \nodoc\ iso _TestLongRunningChild is UnitTest
   fun name(): String => "process/long-running-child"
   fun exclusion_group(): String => "process-monitor"
   fun apply(h: TestHelper) =>
@@ -614,7 +614,7 @@ class iso _TestLongRunningChild is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestKillLongRunningChild is UnitTest
+class \nodoc\ iso _TestKillLongRunningChild is UnitTest
   fun name(): String => "process/kill-long-running-child"
   fun exclusion_group(): String => "process-monitor"
   fun apply(h: TestHelper) =>
@@ -671,7 +671,7 @@ class iso _TestKillLongRunningChild is UnitTest
   fun timed_out(h: TestHelper) =>
     h.complete(false)
 
-class iso _TestWaitingOnClosedProcessTwice is UnitTest
+class \nodoc\ iso _TestWaitingOnClosedProcessTwice is UnitTest
   fun name(): String => "process/wait-on-closed-process-twice"
   fun exclusion_group(): String => "process-monitor"
   fun apply(h: TestHelper) =>
@@ -747,7 +747,7 @@ class iso _TestWaitingOnClosedProcessTwice is UnitTest
       h.fail("process monitor threw an error")
     end
 
-class _ProcessClient is ProcessNotify
+class \nodoc\ _ProcessClient is ProcessNotify
   """
   Notifications for Process connections.
   """

--- a/packages/promises/_test.pony
+++ b/packages/promises/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "time"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -18,7 +18,7 @@ actor Main is TestList
     test(_TestPromisesJoinThenReject)
     test(_TestPromiseTimeout)
 
-class iso _TestPromise is UnitTest
+class \nodoc\ iso _TestPromise is UnitTest
   fun name(): String => "promises/Promise"
 
   fun apply(h: TestHelper) =>
@@ -44,7 +44,7 @@ class iso _TestPromise is UnitTest
 
     p.reject()
 
-class iso _TestPromiseAdd is UnitTest
+class \nodoc\ iso _TestPromiseAdd is UnitTest
   fun name(): String => "promises/Promise.add"
 
   fun apply(h: TestHelper) =>
@@ -81,7 +81,7 @@ class iso _TestPromiseAdd is UnitTest
     p1(2)
     p2.reject()
 
-class iso _TestPromiseSelect is UnitTest
+class \nodoc\ iso _TestPromiseSelect is UnitTest
   fun name(): String => "promises/Promise.select"
 
   fun apply(h: TestHelper) =>
@@ -102,7 +102,7 @@ class iso _TestPromiseSelect is UnitTest
 
     pa("a")
 
-class iso _TestPromiseTimeout is UnitTest
+class \nodoc\ iso _TestPromiseTimeout is UnitTest
   fun name(): String => "promises/Promise.timeout"
 
   fun apply(h: TestHelper) =>
@@ -114,7 +114,7 @@ class iso _TestPromiseTimeout is UnitTest
         FulfillIdentity[None],
         {() => h.complete_action("timeout") } iso)
 
-class iso _TestPromisesJoin is UnitTest
+class \nodoc\ iso _TestPromisesJoin is UnitTest
   fun name(): String => "promises/Promise.join"
 
   fun apply(h: TestHelper) =>
@@ -136,7 +136,7 @@ class iso _TestPromisesJoin is UnitTest
     b("b")
     c("c")
 
-class iso _TestPromisesJoinThenReject is UnitTest
+class \nodoc\ iso _TestPromisesJoinThenReject is UnitTest
   fun name(): String => "promises/Promise.join"
 
   fun apply(h: TestHelper) =>
@@ -151,7 +151,7 @@ class iso _TestPromisesJoinThenReject is UnitTest
     b("b")
     c.reject()
 
-class iso _TestFlattenNextHappyPath is UnitTest
+class \nodoc\ iso _TestFlattenNextHappyPath is UnitTest
   """
   This is the happy path, everything works `flatten_next` test.
 
@@ -181,7 +181,7 @@ class iso _TestFlattenNextHappyPath is UnitTest
 
     start(initial_string)
 
-class iso _TestFlattenNextFirstHasFulfillError is UnitTest
+class \nodoc\ iso _TestFlattenNextFirstHasFulfillError is UnitTest
   """
   Two promises chained `flatten_next` test where the fulfill action for the
   first promise fails.
@@ -215,7 +215,7 @@ class iso _TestFlattenNextFirstHasFulfillError is UnitTest
     start(initial_string)
 
 
-class iso _TestFlattenNextSecondHasFulfillError is UnitTest
+class \nodoc\ iso _TestFlattenNextSecondHasFulfillError is UnitTest
   """
   Two promises chained `flatten_next` test where the fulfill action for the
   second promise fails.
@@ -246,7 +246,7 @@ class iso _TestFlattenNextSecondHasFulfillError is UnitTest
 
     start(initial_string)
 
-class iso _TestFlattenNextRejectFirst is UnitTest
+class \nodoc\ iso _TestFlattenNextRejectFirst is UnitTest
   """
   Two promises chained `flatten_next` test where the first promise is rejected.
 
@@ -278,7 +278,7 @@ class iso _TestFlattenNextRejectFirst is UnitTest
 
     start.reject()
 
-primitive _FlattenNextFirstPromise
+primitive \nodoc\ _FlattenNextFirstPromise
   """
   Callback functions called after fulfilled/reject is called on the 1st
   promise in our `flatten_next` tests.
@@ -317,7 +317,7 @@ primitive _FlattenNextFirstPromise
     h.fail("reject shouldn't have been run on _FlattenNextFirstPromise")
     Promise[String]
 
-primitive _FlattenNextSecondPromise
+primitive \nodoc\ _FlattenNextSecondPromise
   """
   Callback functions called after fulfilled/reject is called on the second
   promise in our `flatten_next` tests.

--- a/packages/random/_test.pony
+++ b/packages/random/_test.pony
@@ -1,7 +1,7 @@
 use "ponytest"
 use "collections"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -14,7 +14,7 @@ actor Main is TestList
     test(_TestXorOshiro128StarStar)
     test(_TestXorShift128Plus)
 
-class iso _TestMT is UnitTest
+class \nodoc\ iso _TestMT is UnitTest
   fun name(): String => "random/MT"
 
   fun apply(h: TestHelper) =>
@@ -226,7 +226,7 @@ class iso _TestMT is UnitTest
     h.assert_eq[U64](mt.next(), 1395685694494152690)
     h.assert_eq[U64](mt.next(), 3117577794082200174)
 
-class iso _TestRandomShuffle is UnitTest
+class \nodoc\ iso _TestRandomShuffle is UnitTest
   fun name(): String => "random/Random.shuffle"
 
   fun apply(h: TestHelper) ? =>
@@ -245,7 +245,7 @@ class iso _TestRandomShuffle is UnitTest
     h.assert_eq[String](words(7)?, "brown")
     h.assert_eq[String](words(8)?, "lazy")
 
-class iso _TestXorOshiro128StarStar is UnitTest
+class \nodoc\ iso _TestXorOshiro128StarStar is UnitTest
   """
   Test against the C reference implementation from
 
@@ -357,7 +357,7 @@ class iso _TestXorOshiro128StarStar is UnitTest
     h.assert_eq[U64](xoroshiro128.next(), 13375816837716530149)
     h.assert_eq[U64](xoroshiro128.next(), 3536320040830893476)
 
-class iso _TestSplitMix64 is UnitTest
+class \nodoc\ iso _TestSplitMix64 is UnitTest
   """
   Testing the first 100 values
   against values from the C reference implementation from
@@ -471,7 +471,7 @@ class iso _TestSplitMix64 is UnitTest
     h.assert_eq[U64](splitmix64.next(), 294447012135918062)
     h.assert_eq[U64](splitmix64.next(), 8011763185713273331)
 
-class iso _TestXorOshiro128Plus is UnitTest
+class \nodoc\ iso _TestXorOshiro128Plus is UnitTest
   """
   Test against the C reference implementation from
 
@@ -586,7 +586,7 @@ class iso _TestXorOshiro128Plus is UnitTest
     h.assert_eq[U64](xoroshiro128.next(), 16201330389507750660)
     h.assert_eq[U64](xoroshiro128.next(), 3565034805594144162)
 
-class iso _TestXorShift128Plus is UnitTest
+class \nodoc\ iso _TestXorShift128Plus is UnitTest
   """
   Test against the C reference implementation from
 

--- a/packages/serialise/_test.pony
+++ b/packages/serialise/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -18,7 +18,7 @@ actor Main is TestList
     test(_TestFailures)
     test(_TestSimple)
 
-class _MachineWords
+class \nodoc\ _MachineWords
   var bool1: Bool = true
   var bool2: Bool = false
   var i8: I8 = 0x3
@@ -44,7 +44,7 @@ class _MachineWords
       and (f32 == that.f32)
       and (f64 == that.f64)
 
-class _StructWords
+class \nodoc\ _StructWords
   var u8: U8 = 0x3
   var u16: U16 = 0xABCD
   var u32: U32 = 0x12345678
@@ -62,7 +62,7 @@ class _StructWords
       and (ulong == that.ulong)
       and (usize == that.usize)
 
-class _Simple
+class \nodoc\ _Simple
   var words1: _MachineWords = _MachineWords
   embed words2: _MachineWords = _MachineWords
   var words3: _StructWords = _StructWords
@@ -107,7 +107,7 @@ class _Simple
       and (a_ref is words1)
       and (that.a_ref is that.words1)
 
-class iso _TestSimple is UnitTest
+class \nodoc\ iso _TestSimple is UnitTest
   """
   Test serialising simple fields.
   """
@@ -124,7 +124,7 @@ class iso _TestSimple is UnitTest
     h.assert_true(x isnt y)
     h.assert_true(x == y)
 
-class iso _TestArrays is UnitTest
+class \nodoc\ iso _TestArrays is UnitTest
   """
   Test serialising arrays.
   """
@@ -189,12 +189,12 @@ class iso _TestArrays is UnitTest
     h.assert_true(x7 isnt y7)
     h.assert_array_eq[U64](x7, y7)
 
-actor _EmptyActor
+actor \nodoc\ _EmptyActor
 
-class _HasActor
+class \nodoc\ _HasActor
   var x: _EmptyActor = _EmptyActor
 
-class iso _TestFailures is UnitTest
+class \nodoc\ iso _TestFailures is UnitTest
   """
   Test serialisation failures.
   """
@@ -206,10 +206,10 @@ class iso _TestFailures is UnitTest
 
     h.assert_error({() ? => Serialised(serialise, _HasActor)? })
 
-class _BoxedWord
+class \nodoc\ _BoxedWord
   var f: Any val = U32(3)
 
-class iso _TestBoxedMachineWord is UnitTest
+class \nodoc\ iso _TestBoxedMachineWord is UnitTest
   """
   Test serialising boxed machine words.
   """

--- a/packages/signals/_test.pony
+++ b/packages/signals/_test.pony
@@ -1,13 +1,13 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
   fun tag tests(test: PonyTest) =>
     test(_TestSignalINT)
 
-class _TestSighupNotify is SignalNotify
+class \nodoc\ _TestSighupNotify is SignalNotify
   let _h: TestHelper
 
   new iso create(h: TestHelper) =>
@@ -17,7 +17,7 @@ class _TestSighupNotify is SignalNotify
     _h.complete(true)
     false
 
-class iso _TestSignalINT is UnitTest
+class \nodoc\ iso _TestSignalINT is UnitTest
   var _signal: (SignalHandler | None) = None
 
   fun name(): String => "signals/INT"

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -44,7 +44,7 @@ use term = "term"
 use time = "time"
 
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 

--- a/packages/strings/_test.pony
+++ b/packages/strings/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -8,7 +8,7 @@ actor Main is TestList
     // Tests below function across all systems and are listed alphabetically
     test(_TestStringsCommonPrefix)
 
-class iso _TestStringsCommonPrefix is UnitTest
+class \nodoc\ iso _TestStringsCommonPrefix is UnitTest
   """
   Test strings/CommonPrefix
   """

--- a/packages/time/_test.pony
+++ b/packages/time/_test.pony
@@ -1,6 +1,6 @@
 use "ponytest"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
@@ -9,7 +9,7 @@ actor Main is TestList
     test(_TestNanos)
     test(_TestPosixDate)
 
-class iso _TestNanos is UnitTest
+class \nodoc\ iso _TestNanos is UnitTest
   fun name(): String => "time/Nanos"
 
   fun apply(h: TestHelper) =>
@@ -21,7 +21,7 @@ class iso _TestNanos is UnitTest
     h.assert_eq[U64](1_230_000, Nanos.from_millis_f(1.23))
     h.assert_eq[U64](1_230, Nanos.from_micros_f(1.23))
 
-class iso _TestPosixDate is UnitTest
+class \nodoc\ iso _TestPosixDate is UnitTest
   fun name(): String => "time/PosixDate"
 
   fun apply(h: TestHelper) =>

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -1327,6 +1327,26 @@ static bool check_annotation_location(pass_opt_t* opt, ast_t* ast,
           "declaration");
         return false;
     }
+  } else if(strcmp(str, "nodoc") == 0) {
+    switch(ast_id(ast_parent(ast)))
+    {
+      case TK_ACTOR:
+      case TK_CLASS:
+      case TK_STRUCT:
+      case TK_PRIMITIVE:
+      case TK_TRAIT:
+      case TK_INTERFACE:
+      case TK_NEW:
+      case TK_FUN:
+      case TK_BE:
+        break;
+
+      default:
+        ast_error(opt->check.errors, loc,
+          "'nodoc' annotation isn't valid here");
+
+        return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
The can be used to control the pony compilers documentation generation,
any structure that can have a docstring (except packages) can be
annotated with \nodoc\ to prevent documentation from being generated.

This replaces a hack I put in years ago to filter out items that
were "for testing" by looking for Test and _Test at the beginning of
the name as well as providing UnitTest or TestList.

All standard library test items have been annotated with \nodoc\ to
keep them continuing to not have documentation generated by our
standard process of creating the standard library documentation site.

ponylang org libraries will need to be updated as well.

Note that the "should we include this package" hack to filter out
packages called "test" and "builtin_test" still exists for the time
being until we have further discussion.

Closes #3332