### PR TITLE
Fix compiler assertion failure when assigning error to a variable

### DIFF
--- a/.release-notes/3823.md
+++ b/.release-notes/3823.md
@@ -1,0 +1,3 @@
+## Fix compiler assertion failure when assigning error to a variable
+
+This release fixes a compiler assertion failure being triggered when one attempted to assign an error expression surrounded by parenthesis to a variable.

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -333,7 +333,11 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   ast_t* r_type = ast_type(right);
 
   if(is_typecheck_error(r_type))
+  {
+    ast_error(opt->check.errors, ast,
+      "right side must be something that can be assigned");
     return false;
+  }
 
   if(ast_checkflag(right, AST_FLAG_JUMPS_AWAY))
   {
@@ -343,7 +347,13 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   }
 
   if(!infer_locals(opt, left, r_type))
+  {
+    /*
+    TODO: maybe add an ast_error here too, but I don't
+    know what error would happen here ~ mateus-md
+    */
     return false;
+  }
 
   // Inferring locals may have changed the left type.
   l_type = ast_type(left);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -334,8 +334,10 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
   if(is_typecheck_error(r_type))
   {
-    ast_error(opt->check.errors, ast,
-      "right side must be something that can be assigned");
+    if(errors_get_count(opt->check.errors) == 0){
+      ast_error(opt->check.errors, ast,
+        "right side must be something that can be assigned");
+    }
     return false;
   }
 
@@ -347,13 +349,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   }
 
   if(!infer_locals(opt, left, r_type))
-  {
-    /*
-    TODO: maybe add an ast_error here too, but I don't
-    know what error would happen here ~ mateus-md
-    */
     return false;
-  }
 
   // Inferring locals may have changed the left type.
   l_type = ast_type(left);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -335,7 +335,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   if(is_typecheck_error(r_type))
   {
     if(errors_get_count(opt->check.errors) == 0){
-      ast_error(opt->check.errors, ast,
+      ast_error(opt->check.errors, right,
         "right side must be something that can be assigned");
     }
     return false;

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1113,3 +1113,15 @@ TEST_F(BadPonyTest, InterfacesCantHavePrivateMethods)
   TEST_ERRORS_1(src,
     "interfaces can't have private methods, only traits can")
 }
+
+TEST_F(BadPonyTest, CantAssignErrorExpression)
+{
+  // From issue #3823
+  const char* src =
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let x: String = (error)";
+
+  TEST_ERRORS_1(src,
+    "right side must be something that can be assigned")
+}


### PR DESCRIPTION
Builds upon @mateus-md work on #3894, fixes #3823.

When this is squashed and merged, the commit message should be "Fix compiler assertion failure when assigning error to a variable"
