### PR TITLE
Add a pony primitive that exposes scheduler information

### DIFF
--- a/.release-notes/3984.md
+++ b/.release-notes/3984.md
@@ -1,0 +1,12 @@
+# Add a pony primitive that exposes via Pony code information about the scheduler
+
+Previously, when users wanted to optimize the parallelizing work based on the maximum number of actors that can be run at a single time, we were pointing them to using the private runtime method `@ponyint_sched_cores()`.
+
+This was problematic for two reasons:
+
+1. We were pointing users at an internal implementation method that we hadn't promised not to change.
+2. We were requiring users to muck about with FFI for something that has become somewhat common for users wanting to maximize performance want to know.
+
+We've now exposed some information about scheduler threads via a new package `runtime_info` thereby resolving both of the problems mentioned above.
+
+Pony users should expect to see additional information added to the `runtime_info` package moving forward.

--- a/.release-notes/3984.md
+++ b/.release-notes/3984.md
@@ -1,4 +1,4 @@
-# Add a pony primitive that exposes via Pony code information about the scheduler
+# Add a pony primitive that exposes scheduler information
 
 Previously, when users wanted to optimize the parallelizing work based on the maximum number of actors that can be run at a single time, we were pointing them to using the private runtime method `@ponyint_sched_cores()`.
 

--- a/.release-notes/3984.md
+++ b/.release-notes/3984.md
@@ -11,4 +11,4 @@ We've now exposed some information about scheduler threads via a new package `ru
 
 Pony users should expect to see additional information added to the `runtime_info` package moving forward.
 
-Anyone who was using the internal `ponyint_sched_cores()` FFI call will need to update to using `runtime_info` as `ponyint_sched_cores()` has been removed.
+Anyone who was using the internal `ponyint_sched_cores()` FFI call will need to update to using `runtime_info` as the internal function has been removed.

--- a/.release-notes/3984.md
+++ b/.release-notes/3984.md
@@ -10,3 +10,5 @@ This was problematic for two reasons:
 We've now exposed some information about scheduler threads via a new package `runtime_info` thereby resolving both of the problems mentioned above.
 
 Pony users should expect to see additional information added to the `runtime_info` package moving forward.
+
+Anyone who was using the internal `ponyint_sched_cores()` FFI call will need to update to using `runtime_info` as `ponyint_sched_cores()` has been removed.

--- a/packages/runtime_info/auth.pony
+++ b/packages/runtime_info/auth.pony
@@ -1,0 +1,4 @@
+type RuntimeInfoAuth is (AmbientAuth | SchedulerInfoAuth)
+
+primitive SchedulerInfoAuth
+  new create(auth: AmbientAuth) => None

--- a/packages/runtime_info/runtime_info.pony
+++ b/packages/runtime_info/runtime_info.pony
@@ -1,0 +1,26 @@
+"""
+# Runtime Info package
+
+The runtime information package exposes information about the Pony runtime that
+can be queried at runtime. The most common usage at this time is limiting the
+number of work based on the number of available schedulers.
+
+For example, in an application that is doing parallel processing and wants to
+limit the number of processing actors to the maximum number that could be run
+at one time, you can use `Scheduler.schedulers` to get the scheduler
+information.
+
+```pony
+use "collections"
+use "runtime_info"
+
+actor Processor
+
+actor Main
+  new create(env: Env) =>
+    let s = Scheduler.schedulers(SchedulerInfoAuth(env.root))
+    for i in Range(0, s) do
+      Processor
+    end
+```
+"""

--- a/packages/runtime_info/scheduler.pony
+++ b/packages/runtime_info/scheduler.pony
@@ -2,8 +2,26 @@ use @pony_schedulers[U32]()
 use @pony_active_schedulers[U32]()
 
 primitive Scheduler
-  fun schedulers(): U32 =>
+  """
+  Provides functions that expose information about runtime schedulers.
+  """
+
+  fun schedulers(auth: RuntimeInfoAuth): U32 =>
+    """
+    Returns the maximum number of schedulers available to run actors.
+    """
     @pony_schedulers()
 
-  fun active_schedulers(): U32 =>
+  fun active_schedulers(auth: RuntimeInfoAuth): U32 =>
+    """
+    Returns the number of schedulers currently available to run actors.
+    """
     @pony_active_schedulers()
+
+  fun sleeping_schedulers(auth: RuntimeInfoAuth): U32 =>
+    """
+    Returns the number of schedulers that are currently sleeping and not
+    available run actors. Schedulers are put to sleep if there isn't enough
+    work to keep all of the possible schedulers busy.
+    """
+    @pony_schedulers() - @pony_active_schedulers()

--- a/packages/runtime_info/scheduler.pony
+++ b/packages/runtime_info/scheduler.pony
@@ -1,0 +1,9 @@
+use @pony_schedulers[U32]()
+use @pony_active_schedulers[U32]()
+
+primitive Scheduler
+  fun schedulers(): U32 =>
+    @pony_schedulers()
+
+  fun active_schedulers(): U32 =>
+    @pony_active_schedulers()

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1205,12 +1205,12 @@ void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor)
   }
 }
 
-uint32_t ponyint_sched_cores()
+PONY_API uint32_t pony_schedulers()
 {
   return scheduler_count;
 }
 
-uint32_t ponyint_active_sched_count()
+PONY_API uint32_t pony_active_schedulers()
 {
   return get_active_scheduler_count();
 }

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -102,8 +102,6 @@ void ponyint_sched_stop();
 
 void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor);
 
-uint32_t ponyint_sched_cores();
-
 void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* recv);
 
 void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor);


### PR DESCRIPTION
Previously, when users wanted to optimize the parallelizing work based on the maximum number of actors that can be run at a single time, we were pointing them to using the private runtime method `@ponyint_sched_cores()`.

This was problematic for two reasons:

1. We were pointing users at an internal implementation method that we hadn't promised not to change.
2. We were requiring users to muck about with FFI for something that has become somewhat common for users wanting to maximize performance want to know.

We've now exposed some information about scheduler threads via a new package `runtime_info` thereby resolving both of the problems mentioned above.

Pony users should expect to see additional information added to the `runtime_info` package moving forward.

Anyone who was using the internal `ponyint_sched_cores()` FFI call will need to update to using `runtime_info` as `ponyint_sched_cores()` has been removed.

Closes #3985 