### PR TITLE
Expose additional scheduler info via the runtime_info package

### DIFF
--- a/.release-notes/3988.md
+++ b/.release-notes/3988.md
@@ -1,0 +1,15 @@
+## Expose additional scheduler information in the runtime_info package
+
+Three additional methods have been added to `SchedulerInfo`.
+
+- minimum_schedulers
+
+Returns the minimum number of schedulers that will be active.
+
+- scaling_is_active
+
+Returns if scheduler scaling is on
+
+- will_yield_cpu
+
+Returns if scheduler threads are yielding the CPU to other processes when they have no work to do.

--- a/packages/runtime_info/scheduler.pony
+++ b/packages/runtime_info/scheduler.pony
@@ -1,5 +1,7 @@
 use @pony_schedulers[U32]()
 use @pony_active_schedulers[U32]()
+use @pony_min_schedulers[U32]()
+use @pony_scheduler_yield[Bool]()
 
 primitive Scheduler
   """
@@ -18,6 +20,13 @@ primitive Scheduler
     """
     @pony_active_schedulers()
 
+  fun minimum_schedulers(auth: RuntimeInfoAuth): U32 =>
+    """
+    Returns the minimum number of schedulers. The active number of schedulers is
+    guaranteed to never drop below this number.
+    """
+    @pony_min_schedulers()
+
   fun sleeping_schedulers(auth: RuntimeInfoAuth): U32 =>
     """
     Returns the number of schedulers that are currently sleeping and not
@@ -25,3 +34,17 @@ primitive Scheduler
     work to keep all of the possible schedulers busy.
     """
     @pony_schedulers() - @pony_active_schedulers()
+
+  fun scaling_is_active(auth: RuntimeInfoAuth): Bool =>
+    """
+    Returns true is scheduler scaling is on and the number of active schedulers
+    can change while the program is running based on load.
+    """
+    schedulers(auth) > minimum_schedulers(auth)
+
+  fun will_yield_cpu(auth: RuntimeInfoAuth): Bool =>
+    """
+    Returns true if schedulers without work will yield the CPU allowing other
+    processes to have access.
+    """
+    @pony_scheduler_yield()

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1215,6 +1215,16 @@ PONY_API uint32_t pony_active_schedulers()
   return get_active_scheduler_count();
 }
 
+PONY_API uint32_t pony_min_schedulers()
+{
+  return min_scheduler_count;
+}
+
+PONY_API bool pony_scheduler_yield()
+{
+  return use_yield;
+}
+
 PONY_API void pony_register_thread()
 {
   if(this_scheduler != NULL)


### PR DESCRIPTION
Adds three additional functions to `SchedulerInfo`. Based on the current state of information available from the runtime, this is pretty much all we would want to expose about the scheduler system at this time.