### PR TITLE
Add workaround for compiler assertion failure in Promise.flatten_next

### DIFF
--- a/.release-notes/3991.md
+++ b/.release-notes/3991.md
@@ -1,0 +1,6 @@
+## Add workaround for compiler assertion failure in Promise.flatten_next
+
+Under certain conditions a specific usage of `Promise.flatten_next` and `Promise.next` could
+trigger a compiler assertion, whose root-cause is still to be investigated. 
+
+This change avoid the code-path triggering the assertion entirely, and is thus only a workaround, not a full solution, but it increases stability of the stdlib and the promises package.

--- a/.release-notes/3991.md
+++ b/.release-notes/3991.md
@@ -1,6 +1,5 @@
 ## Add workaround for compiler assertion failure in Promise.flatten_next
 
-Under certain conditions a specific usage of `Promise.flatten_next` and `Promise.next` could
-trigger a compiler assertion, whose root-cause is still to be investigated. 
+Under certain conditions a specific usage of `Promise.flatten_next` and `Promise.next` could trigger a compiler assertion, whose root-cause is still under investigation. 
 
 This change avoid the code-path triggering the assertion entirely, and is thus only a workaround, not a full solution, but it increases stability of the stdlib and the promises package.

--- a/.release-notes/3991.md
+++ b/.release-notes/3991.md
@@ -2,4 +2,4 @@
 
 Under certain conditions a specific usage of `Promise.flatten_next` and `Promise.next` could trigger a compiler assertion, whose root-cause is still under investigation. 
 
-This change avoid the code-path triggering the assertion entirely, and is thus only a workaround, not a full solution, but it increases stability of the stdlib and the promises package.
+The workaround avoids the code-path that triggers the assertion. We still need a full solution.

--- a/packages/promises/promise.pony
+++ b/packages/promises/promise.pony
@@ -203,7 +203,7 @@ actor Promise[A: Any #share]
       let p: Promise[B] = outer
 
       fun ref apply(value: A) =>
-        let fulfill' = f = _PendingFulFill[A, B]
+        let fulfill' = f = _PromiseFulFill[A, B]
 
         try
           let inner = (consume fulfill').apply(value)?
@@ -421,9 +421,9 @@ actor _Join[A: Any #share]
 primitive _None
 
 
-class iso _PendingFulFill[A: Any #share, B: Any #share] is Fulfill[A, Promise[B]]
+class iso _PromiseFulFill[A: Any #share, B: Any #share] is Fulfill[A, Promise[B]]
   """
-  Fulfill returning a promise that is never fulfilled.
+  Fulfill discarding its input value of `A` and returning a promise of type `B`.
   """
   new iso create() => None
   fun ref apply(value: A): Promise[B] => Promise[B]

--- a/packages/promises/promise.pony
+++ b/packages/promises/promise.pony
@@ -203,7 +203,7 @@ actor Promise[A: Any #share]
       let p: Promise[B] = outer
 
       fun ref apply(value: A) =>
-        let fulfill' = f = {(value: A) => Promise[B]}
+        let fulfill' = f = _PendingFulFill[A, B]
 
         try
           let inner = (consume fulfill').apply(value)?
@@ -419,3 +419,11 @@ actor _Join[A: Any #share]
     end
 
 primitive _None
+
+
+class iso _PendingFulFill[A: Any #share, B: Any #share] is Fulfill[A, Promise[B]]
+  """
+  Fulfill returning a promise that is never fulfilled.
+  """
+  new iso create() => None
+  fun ref apply(value: A): Promise[B] => Promise[B]

--- a/test/libponyc-run/promise-flatten-next-regression-3856/main.pony
+++ b/test/libponyc-run/promise-flatten-next-regression-3856/main.pony
@@ -1,0 +1,24 @@
+use "promises"
+
+actor FlattenNextProbe
+  new create(handler: Handler iso) =>
+    let promise = Promise[String]
+    // We need a call to next to be present with a call to flatten_next to trigger the issue during reachability analysis
+    promise.next[Any tag](recover this~behaviour() end)
+    (consume handler)(recover String end, promise)
+
+  be behaviour(value: String) =>
+    None
+
+
+class Handler
+  fun ref apply(line: String, prompt: Promise[String]) =>
+    let p = Promise[String]
+    // BUG: Can't change the flatten_next
+    p.flatten_next[String]({ (x: String) => Promise[String] })
+
+
+actor Main
+  new create(env: Env) =>
+    // BUG: Can't change this
+    let term = FlattenNextProbe(Handler)


### PR DESCRIPTION
This fixes #3856 with only a workaround and explicitly without actually solving the underlying issue, but hey, it's something.

Somehow the replaced lambda, or to be exact, the hygienic type created for it, wasn't properly reified and remained as a generic type. The hygienic type generates was:

```
promises_$2$7_String_val_String_val
```
which seems correct, but this is the type that failed the reachability, namely the part where the methods from the interface `Fulfill` have been applied to the type:

```
type: {(A): Promise[B #share] tag}[String val, String val] ref
```