### PR TITLE
Fix bug in #3993

### DIFF
--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -20,7 +20,8 @@ static void acquire_object(pony_ctx_t* ctx, pony_actor_t* actor, void* address,
   bool immutable)
 {
   actorref_t* aref = ponyint_actormap_getorput(&ctx->acquire, actor, 0);
-  object_t* obj = ponyint_actorref_getorput(aref, address, actor->type, 0);
+  pony_type_t* type = *(pony_type_t**)address;
+  object_t* obj = ponyint_actorref_getorput(aref, address, type, 0);
 
   obj->rc += GC_INC_MORE;
   obj->immutable = immutable;


### PR DESCRIPTION
I was storing the type for the wrong object into the object map
in acquire_object. This led to ponyup going boom.

Other programs would as well, but ponyup exhibited.

I'm going to spend some time thinking about how to test this, but
at the moment I don't know the specific combo of Pony code that
got us here.