### PR TITLE
Remove out parameter from `pony_os_stdin_read`

### DIFF
--- a/.release-notes/simplify_stdin_read.md
+++ b/.release-notes/simplify_stdin_read.md
@@ -1,0 +1,12 @@
+## Remove out parameter from `pony_os_stdin_read`
+
+The signature of the `pony_os_stdin_read` function has been simplified to remove the `bool* out_again` parameter.
+
+```diff
+-PONY_API size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
++PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
+```
+
+It is permitted to call the `pony_os_stdin_read` function again in a loop if the return value is greater than zero, and the platform is not windows. Given that those two conditions are enough information to make a decision, the `out_again` parameter is not needed, and can be removed.
+
+Technically this is a breaking change, because the function is prefixed with `pony_` and is thus a public API. But it is unlikely that any code out there is directly using the `pony_os_stdin_read` function, apart from the `Stdin` actor in the standard library, which has been updated in its internal implementation details to match the new signature.

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -447,7 +447,7 @@ PONY_API bool pony_os_stdin_setup()
   return stdin_event_based;
 }
 
-PONY_API size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
+PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
 {
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
@@ -497,7 +497,6 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
   if(len != 0)  // Start listening to stdin notifications again
     ponyint_iocp_resume_stdin();
 
-  *out_again = false;
   return len;
 #else
   struct pollfd pfd;
@@ -508,12 +507,8 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
   int n = poll(&pfd, 1, 0);
 
   if(n != 1)
-  {
-    *out_again = false;
     return -1;
-  }
 
-  *out_again = true;
   return read(STDIN_FILENO, buffer, space);
 #endif
 }


### PR DESCRIPTION
The signature of the `pony_os_stdin_read` function has been simplified to remove the `bool* out_again` parameter.

```diff
-PONY_API size_t pony_os_stdin_read(char* buffer, size_t space, bool* out_again)
+PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
```

It is permitted to call the `pony_os_stdin_read` function again in a loop if the return value is greater than zero, and the platform is not windows. Given that those two conditions are enough information to make a decision, the `out_again` parameter is not needed, and can be removed.

Technically this is a breaking change, because the function is prefixed with `pony_` and is thus a public API. But it is unlikely that any code out there is directly using the `pony_os_stdin_read` function, apart from the `Stdin` actor in the standard library, which has been updated in its internal implementation details to match the new signature.