### PR TITLE
Fix compiler crash related to using tuples as a generic constraint

### DIFF
--- a/.release-notes/fix-3655.md
+++ b/.release-notes/fix-3655.md
@@ -1,0 +1,12 @@
+## Fix compiler crash related to using tuples as a generic constraint
+
+Tuple types aren't legal constraints on generics in Pony and we have a check in an early compiler pass to detect and report that error. However, it was previously possible to "sneak" a tuple type as a generic constraint past the earlier check in the compiler by "smuggling" it in a type alias.
+
+The type aliases aren't flattened into their various components until after the code that disallows tuples as generic constraints which would result in the following code causing ponyc to assert:
+
+```ponyc
+type Blocksize is (U8, U32)
+class Block[T: Blocksize]
+```
+
+We've added an additional check to the compiler in a later pass to report an error on the "smuggled" tuple type as a constraint.

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -79,6 +79,27 @@ ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast)
   ast_t* cap_ast = cap_fetch(ast);
   token_id cap = ast_id(cap_ast);
 
+  ast_t* constraint = typeparam_constraint(ast);
+  if (constraint != NULL && ast_id(constraint) == TK_TUPLETYPE)
+  {
+    // It is possible that we have an illegal constraint using a tuple here.
+    // It can happen due to an ordering of passes. We check for tuples in
+    // constraints in syntax but if the tuple constraint is part of a type
+    // alias, we don't see that tuple until we are in flatten.
+    //
+    // For example:
+    //
+    // type Blocksize is (U8, U32)
+    // class Block[T: Blocksize]
+    //
+    // We handle that case here with the an error message that is similar to
+    // the one used in syntax.
+
+    ast_error(opt->check.errors, constraint,
+      "constraint contains a tuple; tuple types can't be used as type constraints");
+    return AST_ERROR;
+  }
+
   typeparam_set_cap(ast);
 
   token_id set_cap = ast_id(cap_ast);

--- a/test/libponyc/flatten.cc
+++ b/test/libponyc/flatten.cc
@@ -58,6 +58,7 @@ TEST_F(FlattenTest, TypeparamCap)
 
   TEST_ERROR(src);
 }
+
 TEST_F(FlattenTest, SendableParamConstructor)
 {
   const char* src =
@@ -76,4 +77,21 @@ TEST_F(FlattenTest, SendableParamConstructor)
 
   ASSERT_EQ(9, errormsg->line);
   ASSERT_EQ(27, errormsg->pos);
+}
+
+// regression for #3655
+TEST_F(FlattenTest, TupleConstraintInUnion)
+{
+  const char* src =
+    "type Blocksize is (U8, U32)\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
 }


### PR DESCRIPTION
Tuple types aren't legal constraints on generics in Pony and we have a check in
the syntax pass to detect and report that error. However, it was previously
possible to sneak a tuple type as a generic constraint past the syntax check by
smuggling it in a type alias.

Type aliases aren't flattened into their various components until the flatten
pass which follows the syntax pass. This means that the following code would
cause a compiler assertion:

```ponyc
type Blocksize is (U8, U32)
class Block[T: Blocksize]
```

This commit adds an additional check in the flatten pass to report an error on
smuggled tuple types as generic constraints.

Fixes #3655