### PR TITLE
Turn off running debug build Windows tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,12 +181,6 @@ task:
     - ps: .\make.ps1 -Command build -Config Release -Generator "Visual Studio 16 2019"
   release_test_script:
     - ps: .\make.ps1 -Command test -Config Release -Generator "Visual Studio 16 2019"
-  debug_config_script:
-    - ps: .\make.ps1 -Command configure -Config Debug -Generator "Visual Studio 16 2019"
-  debug_build_script:
-    - ps: .\make.ps1 -Command build -Config Debug -Generator "Visual Studio 16 2019"
-  debug_test_script:
-    - ps: .\make.ps1 -Command test -Config Debug -Generator "Visual Studio 16 2019"
 
 task:
   only_if: $CIRRUS_PR != ''


### PR DESCRIPTION
They are failing fairly regularly and we need to look into why some on the runner tests hang. 

Gordon think that it might be related to other Windows failures we've seen lately (which I think are corral related).
Gordon suspects that all the issues might be tied together by an unknown issue in the Windows Process Monitor code.