### PR TITLE
Fix incorrect "field not initialized" error with while/else

### DIFF
--- a/.release-notes/while-else-initialize.md
+++ b/.release-notes/while-else-initialize.md
@@ -1,0 +1,17 @@
+## Fix incorrect "field not initialized" error with while/else
+
+Previously, due to a bug in the compiler's while/else handling code, the following code would be rejected as not initializing all object fields:
+
+```pony
+actor Main
+  var _s: (String | None)
+
+  new create(env: Env) =>
+    var i: USize = 0
+    while i < 5 do
+       _s = i.string()
+       i = i + 1
+    else
+      _s = ""
+    end
+```

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1523,21 +1523,19 @@ static bool refer_while(pass_opt_t* opt, ast_t* ast)
   }
 
   size_t branch_count = 0;
-
-  // No symbol status is inherited from the loop body. Nothing from outside the
-  // loop body can be consumed, and definitions in the body may not occur.
   if(!ast_checkflag(body, AST_FLAG_JUMPS_AWAY))
+  {
     branch_count++;
+    ast_inheritbranch(ast, body);
+  }
 
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     branch_count++;
-    ast_inheritbranch(ast, body);
-
-    // Use a branch count of two instead of one. This means we will pick up any
-    // consumes, but not any definitions, since definitions may not occur.
-    ast_consolidate_branches(ast, 2);
+    ast_inheritbranch(ast, else_clause);
   }
+
+  ast_consolidate_branches(ast, branch_count);
 
   // If all branches jump away with no value, then we do too.
   if(branch_count == 0)

--- a/test/libponyc-run/while-else-can-initialize-fields/main.pony
+++ b/test/libponyc-run/while-else-can-initialize-fields/main.pony
@@ -1,0 +1,11 @@
+actor Main
+  var _s: (String | None)
+
+  new create(env: Env) =>
+    var i: USize = 0
+    while i < 5 do
+       _s = i.string()
+       i = i + 1
+    else
+      _s = ""
+    end

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -900,3 +900,58 @@ TEST_F(ReferTest, MemberAccessWithConsumeLhs)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(ReferTest, WhileElseNoFieldInitializationInBody)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "new create(env: Env) =>\n"
+    "  var i: USize = 0\n"
+    "  while i < 5 do\n"
+    "    i = i + 1\n"
+    "  else\n"
+    "    _s = \"else\"\n"
+    "  end";
+
+    TEST_ERRORS_2(src,
+      "field left undefined in constructor",
+      "constructor with undefined fields is here");
+}
+
+TEST_F(ReferTest, WhileElseNoFieldInitializationInElse)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "new create(env: Env) =>\n"
+    "  var i: USize = 0\n"
+    "  while i < 5 do\n"
+    "    _s = \"body\"\n"
+    "    i = i + 1\n"
+    "  else\n"
+    "    None\n"
+    "  end";
+
+    TEST_ERRORS_2(src,
+      "field left undefined in constructor",
+      "constructor with undefined fields is here");
+}
+
+TEST_F(ReferTest, WhileElseNoFieldInitialization)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "new create(env: Env) =>\n"
+    "  var i: USize = 0\n"
+    "  while i < 5 do\n"
+    "    i = i + 1\n"
+    "  else\n"
+    "    None\n"
+    "  end";
+
+    TEST_ERRORS_2(src,
+      "field left undefined in constructor",
+      "constructor with undefined fields is here");
+}


### PR DESCRIPTION
Previously, due to a bug in the compile's while/else handling code, the
following code would be rejected as not initializing all object fields:

```pony
actor Main
  var _s: (String | None)

  new create(env: Env) =>
    var i: USize = 0
    while i < 5 do
       _s = i.string()
       i = i + 1
    else
      _s = ""
    end
```

This commit fixes while/else handling in `refer_while` so that it matches the
correct logic as seen in `refer_if`.

Partially addresses a series of related bugs in #3283.