### PR TITLE
Fix incorrect "field not initialized" error with try/else

### DIFF
--- a/.release-notes/try-else-initialization.md
+++ b/.release-notes/try-else-initialization.md
@@ -1,0 +1,15 @@
+## Fix incorrect "field not initialized" error with try/else
+
+Previously, due to a bug in the compiler's try/else handling code, the following code would be rejected as not initializing all object fields:
+
+```pony
+actor Main
+  var _s: (String | None)
+
+  new create(env: Env) =>
+    try
+      _s = "".usize()?.string()
+    else
+      _s = None
+    end
+```

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1679,10 +1679,16 @@ static bool refer_try(pass_opt_t* opt, ast_t* ast)
   size_t branch_count = 0;
 
   if(!ast_checkflag(body, AST_FLAG_JUMPS_AWAY))
+  {
     branch_count++;
+    ast_inheritbranch(then_clause, body);
+  }
 
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
+  {
     branch_count++;
+    ast_inheritbranch(then_clause, else_clause);
+  }
 
   if(ast_checkflag(then_clause, AST_FLAG_JUMPS_AWAY))
   {
@@ -1690,6 +1696,8 @@ static bool refer_try(pass_opt_t* opt, ast_t* ast)
       "then clause always terminates the function");
     return false;
   }
+
+  ast_consolidate_branches(then_clause, branch_count);
 
   // If all branches jump away with no value, then we do too.
   if(branch_count == 0)

--- a/test/libponyc-run/try-else-can-initialize-fields/main.pony
+++ b/test/libponyc-run/try-else-can-initialize-fields/main.pony
@@ -1,0 +1,9 @@
+actor Main
+  var _s: (String | None)
+
+  new create(env: Env) =>
+    try
+      _s = "".usize()?.string()
+    else
+      _s = None
+    end

--- a/test/libponyc-run/try-then-can-initialize-fields/main.pony
+++ b/test/libponyc-run/try-then-can-initialize-fields/main.pony
@@ -1,0 +1,9 @@
+actor Main
+  var _s: (String | None)
+
+  new create(env: Env) =>
+    try
+      "".usize()?.string()
+    then
+      _s = "initialized"
+    end

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -900,3 +900,37 @@ TEST_F(ReferTest, MemberAccessWithConsumeLhs)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(ReferTest, TryElseNoFieldInitializationInBody)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      \"\".usize()?.string()\n"
+    "    else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(ReferTest, TryElseNoFieldInitializationInElse)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      _s = \"\".usize()?.string()\n"
+    "    else\n"
+    "      let s: String = \"hello\"\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}


### PR DESCRIPTION
Previously, due to a bug in the compiler's while/else handling code, the
following code would be rejected as not initializing all object fields:

```pony
actor Main
  var _s: (String | None)

  new create(env: Env) =>
    try
      _s = "".usize()?.string()
    else
      _s = None
    end
```

This commit fixes try/else handling in `refer_try` so that it matches the
general shape of `refer_if`, `refer_while`, and `refer_repeat`. It differs from
them because `try` isn't a scope and we want to push everything into the `then`
clause as it can fulfill initialization all on its own or if it doesn't handle
initialization, we can still get it from the try body and the else clause.

Closes #3283