### PR TITLE
Fix compiler crash related to using tuples in a union as a generic constraint

### DIFF
--- a/.release-notes/tuples-in-unions-constraint.md
+++ b/.release-notes/tuples-in-unions-constraint.md
@@ -1,0 +1,12 @@
+## Fix compiler crash related to using tuples in a union as a generic constraint
+
+Tuple types aren't legal constraints on generics in Pony and we have a check in an early compiler pass to detect and report that error. However, it was previously possible to "sneak" a tuple type as a generic constraint past the earlier check in the compiler by "smuggling" it in a type union in a type alias.
+
+The type aliases aren't flattened into their various components until after the code that disallows tuples as generic constraints which would result in the following code causing ponyc to assert:
+
+```ponyc
+type Blocksize is (U64 | (U8, U32))
+class Block[T: Blocksize]
+```
+
+We've added an additional check to the compiler in a later pass to report an error on the "smuggled" tuple type as a constraint.

--- a/test/libponyc/flatten.cc
+++ b/test/libponyc/flatten.cc
@@ -80,10 +80,44 @@ TEST_F(FlattenTest, SendableParamConstructor)
 }
 
 // regression for #3655
-TEST_F(FlattenTest, TupleConstraintInUnion)
+TEST_F(FlattenTest, TupleConstraintInAlias)
 {
   const char* src =
     "type Blocksize is (U8, U32)\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
+// regression for #4016
+TEST_F(FlattenTest, TupleConstraintInUnion)
+{
+  const char* src =
+    "type Blocksize is (U8 | (U8, U32))\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
+// regression for #4016
+TEST_F(FlattenTest, MultipleTuplesConstraintInUnion)
+{
+  const char* src =
+    "type Blocksize is (U8 | (U8, U32) | (String, U64))\n"
     "class Block[T: Blocksize]";
 
   TEST_ERRORS_1(


### PR DESCRIPTION
Tuple types aren't legal constraints on generics in Pony and we have a check in
an early compiler pass to detect and report that error. However, it was
previously possible to "sneak" a tuple type as a generic constraint past the
earlier check in the compiler by "smuggling" it in a type union in a type
alias.

The type aliases aren't flattened into their various components until after the
code that disallows tuples as generic constraints which would result in the
following code causing ponyc to assert:

```ponyc
type Blocksize is (U64 | (U8, U32))
class Block[T: Blocksize]
```

We've added an additional check to the compiler in a later pass to report an
error on the "smuggled" tuple type as a constraint.

Fixes #4016