### PR TITLE
Fix incorrect code returned by ANSI.erase

### DIFF
--- a/.release-notes/4022.md
+++ b/.release-notes/4022.md
@@ -1,0 +1,4 @@
+## Change ANSI.escape to return the correct escape code
+
+The erase function states that it erases the line to the left of the cursor, but the escape code it was returning erased to the right of the cursor instead.  
+This fix makes it so that it correctly erases the line to the left of the cursor.

--- a/.release-notes/4022.md
+++ b/.release-notes/4022.md
@@ -1,4 +1,3 @@
-## Change ANSI.escape to return the correct escape code
+## Fix incorrect code returned by `ANSI.erase`
 
-The erase function states that it erases the line to the left of the cursor, but the escape code it was returning erased to the right of the cursor instead.  
-This fix makes it so that it correctly erases the line to the left of the cursor.
+`erase` was intended to erase all characters to the left of the cursor but was instead returning the code to erase all characters to the right.

--- a/packages/term/ansi.pony
+++ b/packages/term/ansi.pony
@@ -64,7 +64,7 @@ primitive ANSI
     """
     Erases everything to the left of the cursor on the line the cursor is on.
     """
-    "\x1B[0K"
+    "\x1B[1K"
 
   fun reset(): String =>
     """


### PR DESCRIPTION
The `erase` function states that it erases to the left of the cursor, but the escape code it returns uses the value for erasing to the right of the cursor.

```pony
fun erase(): String =>
  """
  Erases everything to the left of the cursor on the line the cursor is on.
  """
  "\x1B[0K"
```

Fixes #4021