### PR TITLE
Fix the signature of Iter's map_stateful/map to not require ephemerals

### DIFF
--- a/.release-notes/4026.md
+++ b/.release-notes/4026.md
@@ -1,6 +1,5 @@
 ## Fix the interfaces for Iter's `map` and `map_stateful` methods to be less strict
 
-The `map_stateful` and `map` methods on an Iter (from the itertools package) were
-too strict in what they required, requiring a `B^` in order to produce an `Iter[B]`.
+The `map_stateful` and `map` methods on an Iter (from the itertools package) were too strict in what they required, requiring a `B^` in order to produce an `Iter[B]`.
 
 This change correctly makes them only require `B`.

--- a/.release-notes/4026.md
+++ b/.release-notes/4026.md
@@ -1,0 +1,6 @@
+## Fix the interfaces for Iter's `map` and `map_stateful` methods to be less strict
+
+The `map_stateful` and `map` methods on an Iter (from the itertools package) were
+too strict in what they required, requiring a `B^` in order to produce an `Iter[B]`.
+
+This change correctly makes them only require `B`.

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -117,7 +117,7 @@ class Iter[A] is Iterator[A]
       default
     end
 
-  fun ref map_stateful[B](f: {ref(A!): B^ ?}): Iter[B]^ =>
+  fun ref map_stateful[B](f: {ref(A!): B ?}): Iter[B]^ =>
     """
     Allows stateful transformation of each element from the iterator, similar
     to `map`.
@@ -681,7 +681,7 @@ class Iter[A] is Iterator[A]
     else error
     end
 
-  fun ref map[B](f: {(A!): B^ ?} box): Iter[B]^ =>
+  fun ref map[B](f: {(A!): B ?} box): Iter[B]^ =>
     """
     Return an iterator where each item's value is the application of the given
     function to the value in the original iterator.
@@ -694,7 +694,7 @@ class Iter[A] is Iterator[A]
     ```
     `1 4 9`
     """
-    map_stateful[B]({(a: A!): B^ ? => f(a) ? })
+    map_stateful[B]({(a: A!): B ? => f(a) ? })
 
   fun ref nth(n: USize): A ? =>
     """


### PR DESCRIPTION
This fixes a small stdlib issue discovered during: https://github.com/ponylang/ponyc/pull/4018

The signatures for map and map_stateful in itertools were overly strict, requiring `B^` instead of just `B`, but only returned `Iter[B]`. Thus it had to be instantiated with `iso^` in some cases, exercising a bug with double ephemerals.

This is not a breaking change.