### PR TITLE
Fix LLVM IR verification error found via PonyCheck

### DIFF
--- a/.release-notes/fix_llvm_call_receiver_type_cast.md
+++ b/.release-notes/fix_llvm_call_receiver_type_cast.md
@@ -1,0 +1,5 @@
+## Fix call receiver type casting in LLVM IR
+
+In some rare cases (such as in the PonyCheck library), `ponyc` was generating LLVM that did not use the correct pointer types for call site receiver arguments. This did not result in unsafe code at runtime, but it was still a violation of the LLVM type system, and it caused the "Verification" step of compilation to fail when enabled.
+
+To fix this issue, we introduced an LLVM bitcast at such call sites to cast the receiver pointer to the correct LLVM type.

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -868,6 +868,19 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
     LLVMTypeRef* params = (LLVMTypeRef*)ponyint_pool_alloc_size(buf_size);
     LLVMGetParamTypes(f_type, params + (bare ? 1 : 0));
 
+    // For non-bare functions, ensure that we cast the receiver arg type
+    // to match the param type of the function.
+    if(!bare)
+    {
+      LLVMTypeRef func_receiver_type = params[0];
+      LLVMTypeRef call_receiver_type = LLVMTypeOf(args[0]);
+
+      if (func_receiver_type != call_receiver_type)
+        args[0] = LLVMBuildBitCast(c->builder, args[0], func_receiver_type, "");
+    }
+
+    // We also need to cast the rest of the arguments, using the same casting
+    // semantics as assignment.
     arg = ast_child(positional);
     i = 1;
 


### PR DESCRIPTION
This patch was done by @jemc.