### PR TITLE
Turn Windows Debug CI back on

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,6 +181,12 @@ task:
     - ps: .\make.ps1 -Command build -Config Release -Generator "Visual Studio 16 2019"
   release_test_script:
     - ps: .\make.ps1 -Command test -Config Release -Generator "Visual Studio 16 2019"
+  debug_config_script:
+    - ps: .\make.ps1 -Command configure -Config Debug -Generator "Visual Studio 16 2019"
+  debug_build_script:
+    - ps: .\make.ps1 -Command build -Config Debug -Generator "Visual Studio 16 2019"
+  debug_test_script:
+    - ps: .\make.ps1 -Command test -Config Debug -Generator "Visual Studio 16 2019"
 
 task:
   only_if: $CIRRUS_PR != ''


### PR DESCRIPTION
I reverted a change that I think might have lead to the debug
build CI tests hanging sometimes. There is however, only one
way to find out.

Test!