### PR TITLE
Fix failed initialization bug in Process Monitor

### DIFF
--- a/.release-notes/pm-init-error.md
+++ b/.release-notes/pm-init-error.md
@@ -1,0 +1,5 @@
+## Fix failed initialization bug in Process Monitor
+
+Previously, when a process failed to start up, it was possible to get a report
+that the process had started up and exited with the error code 0 which
+normally signals success.

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -165,13 +165,13 @@ interface _Process
   fun ref wait(): _WaitResult
     """
     Only polls, does not actually wait for the process to finish,
-    in order to not block a scheduler thread.
+    in order to notified block a scheduler thread.
     """
 
 
 class _ProcessNone is _Process
   fun kill() => None
-  fun ref wait(): _WaitResult => Exited(0)
+  fun ref wait(): _WaitResult => Exited(255)
 
 class _ProcessPosix is _Process
   let pid: I32

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -165,7 +165,7 @@ interface _Process
   fun ref wait(): _WaitResult
     """
     Only polls, does not actually wait for the process to finish,
-    in order to notified block a scheduler thread.
+    in order to not block a scheduler thread.
     """
 
 

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -199,9 +199,18 @@ actor ProcessMonitor is AsioEventNotify
     """
     Terminate child and close down everything.
     """
-    Backpressure.release(_backpressure_auth)
-    _child.kill()
-    _close()
+    match _child
+    | let never_started: _ProcessNone =>
+      // We never started a child process so do not do any disposal
+      // If we do, some weirdness can happen with dispose getting called
+      // on the notifier which is not supposed to happen if we never started
+      // a child (or haven't started one yet).
+      return
+    else
+      Backpressure.release(_backpressure_auth)
+      _child.kill()
+      _close()
+    end
 
   fun ref expect(qty: USize = 0) =>
     """

--- a/packages/process/process_notify.pony
+++ b/packages/process/process_notify.pony
@@ -36,12 +36,19 @@ interface ProcessNotify
 
   fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
     """
-    Call when ProcessMonitor terminates to cleanup ProcessNotify.
-    We return the exit status of the child process, it can be either an instance of
-    [Exited](process-Exited.md) if the process finished. The childs exit code can be retrieved
-    using [Exited.exit_code()](process-Exited.md#exit_code).
+    Called when ProcessMonitor terminates to cleanup ProcessNotify if a child
+    process was in fact started. `dispose` will not be called if a child process
+    was never started. The notify will know that a process was started and to
+    expect a `dispose` call by having received a `created` call.
 
-    On Posix systems, if the process has been killed by a signal (e.g. through the `kill` command),
-    `child_exit_status` will be an instance of [Signaled](process-Signaled.md) with the signal number
-    that terminated the process available via [Signaled.signal()](process-Signaled.md#signal).
+    `dispose` includes the exit status of the child process. If the process
+    finished, then `child_exist_status` will be an instance of [Exited](process-Exited.md).
+
+    The childs exit code can be retrieved from the `Exited` instance by using
+    [Exited.exit_code()](process-Exited.md#exit_code).
+
+    On Posix systems, if the process has been killed by a signal (e.g. through
+    the `kill` command), `child_exit_status` will be an instance of
+    [Signaled](process-Signaled.md) with the signal number that terminated the
+    process available via [Signaled.signal()](process-Signaled.md#signal).
     """

--- a/packages/process/process_notify.pony
+++ b/packages/process/process_notify.pony
@@ -42,7 +42,7 @@ interface ProcessNotify
     expect a `dispose` call by having received a `created` call.
 
     `dispose` includes the exit status of the child process. If the process
-    finished, then `child_exist_status` will be an instance of [Exited](process-Exited.md).
+    finished, then `child_exit_status` will be an instance of [Exited](process-Exited.md).
 
     The childs exit code can be retrieved from the `Exited` instance by using
     [Exited.exit_code()](process-Exited.md#exit_code).


### PR DESCRIPTION
Previously, when a process failed to start up, it was possible to get a report
that the process had started up and exited with the error code 0 which
normally signals success.

The problem comes from some rather poor state handling in the `process` package.
This commit doesn't fix the larger issue of all kinds of weirdness around state
handling but it does address the specific bug that was most likely to be
triggered in our unit tests.

The flow in its most extreme form was:

- ProcessMonitor is created in test runner
- Long test is setup
- Dispose when done is setup to send dispose to ProcessMonitor
- ProcessMonitor never successfully starts a Process so its child is _ProcessNone
- notify gets called with `failed`
- `dispose` is sent to the ProcessMonitor
- ProcessMonitor extracts exit code from _ProcessNone which was 0 <-- o boy
- "Success exit code" of 0 is passed as argument to `dispose`