### PR TITLE
Update Windows version used as the base for Windows images

### DIFF
--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/Dockerfile
@@ -1,6 +1,6 @@
 #escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/Dockerfile
@@ -1,6 +1,6 @@
 #escape=`
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/.release-notes/windows-images.md
+++ b/.release-notes/windows-images.md
@@ -1,0 +1,4 @@
+## Update Windows version for Windows Docker Images
+
+We've moved the base from Windows server 2019 to 2022. The version has to
+match the underlying operating system and GitHub recently updated.


### PR DESCRIPTION
GitHub has updated from 2019 to 2022, so we are doing the same
as you can't have differing versions.