### PR TITLE
Fix crash with exhaustive match and generics

### DIFF
--- a/.release-notes/3447.md
+++ b/.release-notes/3447.md
@@ -1,0 +1,3 @@
+## Fix compiler crash with exhaustive match in generics
+
+Previously, there was an interesting edge case in our handling of exhaustive match with generics that could result in a compiler crash. It's been fixed.

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -821,8 +821,13 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
 
     if(match != MATCHTYPE_ACCEPT)
     {
-      // If there's no possible match, jump directly to the next block.
-      LLVMBuildBr(c->builder, next_block);
+      if (next_block != NULL)
+      {
+        // If there's no possible match, jump directly to the next block.
+        LLVMBuildBr(c->builder, next_block);
+      } else {
+        LLVMBuildUnreachable(c->builder);
+      }
     } else {
       // Check the pattern.
       ok = static_match(c, match_value, match_type, pattern, next_block);

--- a/test/libponyc-run/regression-3447/main.pony
+++ b/test/libponyc-run/regression-3447/main.pony
@@ -1,0 +1,10 @@
+actor Main
+  new create(env: Env) =>
+    Dealer.from[U8](0)
+
+class Dealer
+  new from[U: (U8 | Dealer val)](u: U val) =>
+    match u
+    | let u': U8 => None
+    | let u': Dealer val => None
+    end


### PR DESCRIPTION
We previously had a compiler crash caused by trying to jump to a
next block in a match that might not exist because it had been
removed from the particular reification of a generic.

Fixes #3447