### PR TITLE
Use a fixed Windows version for GitHub actions

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -55,7 +55,7 @@ jobs:
       github.event.client_payload.data.name == 'ponyc-x86-64-pc-windows-msvc.zip'
 
     name: Build latest Windows Docker image
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Docker login
@@ -110,7 +110,7 @@ jobs:
       github.event.client_payload.data.name == 'ponyc-x86-64-pc-windows-msvc.zip'
 
     name: Build release Windows Docker image
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Docker login

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,7 +36,7 @@ jobs:
 
   validate-windows-docker-latest-image-builds:
     name: Validate Windows Docker image builds
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Docker build
@@ -60,7 +60,7 @@ jobs:
 
   validate-windows-docker-release-image-builds:
     name: Validate Windows Docker release image builds
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Docker build


### PR DESCRIPTION
Sadly, Windows containers need to use the same environment as the
host OS. This means that we want to control which Windows version
is being used in our actions so we can control the upgrade.