### PR TITLE
Fix compiler crash in HeapToStack optimization pass

### DIFF
--- a/.release-notes/4059.md
+++ b/.release-notes/4059.md
@@ -1,0 +1,3 @@
+## Fixed bug that caused the compiler to crash
+
+We've fixed a [bug](https://github.com/ponylang/ponyc/issues/4059) that caused a compiler crash.

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -190,15 +190,6 @@ public:
       invoke->getUnwindDest()->removePredecessor(call.getParent());
     }
 
-    CallGraphWrapperPass* cg_pass =
-      getAnalysisIfAvailable<CallGraphWrapperPass>();
-    CallGraph* cg = cg_pass ? &cg_pass->getCallGraph() : nullptr;
-    CallGraphNode* cg_node = cg ? (*cg)[&f] : nullptr;
-    if (cg_node)
-    {
-      cg_node->removeCallEdgeFor(call);
-    }
-
     inst->eraseFromParent();
 
     for(auto new_call: new_calls)

--- a/test/libponyc-run/regression-4059/main.pony
+++ b/test/libponyc-run/regression-4059/main.pony
@@ -1,0 +1,13 @@
+actor Main
+  new create(env: Env) =>
+    let p: HtmlNode = P
+    p.apply()
+
+class P is HtmlNode
+  fun apply(): None  =>
+    for f in [as HtmlNode:].values() do
+      None
+    end
+
+interface HtmlNode
+  fun apply(): None


### PR DESCRIPTION
This is a good one. One the March 22, 2022 development sync,
we collectively debugged issue #4059. We finally arrived at
the conclusion that our call graph usage was incorrect.

Originally during the call, Joe realized that while we were
using, we weren't doing it correctly. The initial assumption
was that the incorrect usage was innocous, however, it was
determined shortly thereafter that something about the incorrect
usage was in fact causing issue 4059.

This commit removes the offending code.

Gordon reported during the call that when the call graph code
was added as part the (now years ago) addition of LLVM 4 support
that the code was cribbed from the Dlang compiler and he posited,
probably not correctly.

Fixes #4059