### PR TITLE
Add to nightly stress tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -603,6 +603,34 @@ task:
       TARGET: test-stress-debug
     depends_on:
       - "Stress Test: x86-64-unknown-linux-musl [release]"
+  - name: "Stress Test: x86-64-unknown-linux-ubuntu20.04 [cd] [release]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+    environment:
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+      TARGET: test-stress-with-cd-release
+  - name: "Stress Test: x86-64-unknown-linux-ubuntu20.04 [cd] [debug]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+    environment:
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20200830
+      TARGET: test-stress-with-cd-debug
+    depends_on:
+      - "Stress Test: x86-64-unknown-linux-ubuntu20.04 [cd] [release]"
+  - name: "Stress Test: x86-64-unknown-linux-musl [cd] [release]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+    environment:
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      TARGET: test-stress-with-cd-release
+  - name: "Stress Test: x86-64-unknown-linux-musl [cd] [debug]"
+    container:
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+    environment:
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      TARGET: test-stress-with-cd-debug
+    depends_on:
+      - "Stress Test: x86-64-unknown-linux-musl [cd] [release]"
 
   container:
     cpu: 8
@@ -644,6 +672,16 @@ task:
         TARGET: test-stress-debug
       depends_on:
         - "Stress Test: aarch64-unknown-linux-ubuntu20.04 [release]"
+    - name: "Stress Test: aarch64-unknown-linux-ubuntu20.04 [cd] [release]"
+      environment:
+        IMAGE: ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder:20211003
+        TARGET: test-stress-with-cd-release
+    - name: "Stress Test: aarch64-unknown-linux-ubuntu20.04 [cd] [debug]"
+      environment:
+        IMAGE: ponylang/ponyc-ci-aarch64-unknown-linux-ubuntu20.04-builder:20211003
+        TARGET: test-stress-with-cd-debug
+      depends_on:
+        - "Stress Test: aarch64-unknown-linux-ubuntu20.04 [cd] [release]"
 
   libs_cache:
     folder: build/libs

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,12 @@ test-stress-release: all
 test-stress-debug: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../examples/message-ubench && echo Built `pwd`/ubench && $(cross_runner) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoblock --ponynoscale
 
+test-stress-with-cd-release: all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../examples/message-ubench && echo Built `pwd`/ubench && $(cross_runner) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+
+test-stress-with-cd-debug: all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../examples/message-ubench && echo Built `pwd`/ubench && $(cross_runner) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+
 clean:
 	$(SILENT)([ -d '$(buildDir)' ] && cd '$(buildDir)' && cmake --build '$(buildDir)' --config $(config) --target clean) || true
 	$(SILENT)rm -rf $(crossBuildDir)


### PR DESCRIPTION
This commit adds nightly stress tests that run with the cycle
detector active.