### PR TITLE
Fix incorrect exception handling on aarch64

### DIFF
--- a/.release-notes/fix-3874.md
+++ b/.release-notes/fix-3874.md
@@ -1,0 +1,3 @@
+## Fix incorrect exception handling on aarch64
+
+Our exception handling on aarch64 was incorrect and could lead to valid Pony programs segfaulting at runtime. We've fixed the issue and added regression tests to prevent it from reoccuring.

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -27,12 +27,8 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
   if(opt->pic)
     reloc = Reloc::PIC_;
 
-  // The Arm debug fix is a "temporary" fix for issue #3874
-  // https://github.com/ponylang/ponyc/issues/3874
-  // Hopefully we get #3874 figured out in a reasonable amount of time.
   CodeGenOpt::Level opt_level =
-    opt->release ? CodeGenOpt::Aggressive :
-      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::None;
+    opt->release ? CodeGenOpt::Aggressive : CodeGenOpt::None;
 
   TargetOptions options;
 

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -242,8 +242,6 @@ bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
       if(landing_pad == 0)
         return false;
 
-      // Pony doesn't read the type index or look up types. We treat cleanup
-      // landing pads the same as any other landing pad.
       *lp = lsda.landing_pads + landing_pad;
       if(action_index == 0)
         return false;
@@ -251,7 +249,8 @@ bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
       // Convert 1-based byte offset into
       const uint8_t* action = lsda.action_table + (action_index - 1);
       int64_t tti = read_sleb128(&action);
-      ttype_index = (uintptr_t*)&tti;
+      if(tti > 0)
+        ttype_index = (uintptr_t*)&tti;
 
       return true;
     }

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -216,7 +216,7 @@ static bool lsda_init(lsda_t* lsda, exception_context_t* context)
   return true;
 }
 
-bool ponyint_lsda_scan(uintptr_t* ttype_index,
+bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
   exception_context_t* context,
   uintptr_t* lp)
 {

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -216,7 +216,9 @@ static bool lsda_init(lsda_t* lsda, exception_context_t* context)
   return true;
 }
 
-bool ponyint_lsda_scan(exception_context_t* context, uintptr_t* lp)
+bool ponyint_lsda_scan(uintptr_t* ttype_index,
+  exception_context_t* context,
+  uintptr_t* lp)
 {
   lsda_t lsda;
 
@@ -231,8 +233,11 @@ bool ponyint_lsda_scan(exception_context_t* context, uintptr_t* lp)
     uintptr_t length = read_encoded_ptr(&p, lsda.call_site_encoding);
     uintptr_t landing_pad = read_encoded_ptr(&p, lsda.call_site_encoding);
 
-    // Pony ignores the action index, since it uses only cleanup landing pads.
-    read_uleb128(&p);
+    uintptr_t action_index = read_uleb128(&p);
+
+    const uint8_t* action = lsda.action_table + (action_index - 1);
+    int64_t tti = read_sleb128(&action);
+    ttype_index = (uintptr_t*)&tti;
 
     if((start <= lsda.ip_offset) && (lsda.ip_offset < (start + length)))
     {

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -226,7 +226,7 @@ bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
     return false;
 
   const uint8_t* p = lsda.call_site_table;
-  uintptr_t ip = lsda.ip;
+  //uintptr_t ip = lsda.ip;
 
   while(p < lsda.action_table)
   {

--- a/src/libponyrt/lang/lsda.c
+++ b/src/libponyrt/lang/lsda.c
@@ -246,13 +246,23 @@ bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
       if(action_index == 0)
         return false;
 
-      // Convert 1-based byte offset into
-      const uint8_t* action = lsda.action_table + (action_index - 1);
-      int64_t tti = read_sleb128(&action);
-      if(tti > 0)
-        ttype_index = (uintptr_t*)&tti;
+      while(true)
+      {
+        // Convert 1-based byte offset into
+        const uint8_t* action = lsda.action_table + (action_index - 1);
+        int64_t tti = read_sleb128(&action);
+        if(tti > 0 || tti < 0) {
+          ttype_index = (uintptr_t*)&tti;
+          return true;
+        }
 
-      return true;
+        const uint8_t* temp = action;
+        int64_t action_offset = read_sleb128(&temp);
+        if(action_offset == 0)
+          return false;
+
+        action += action_offset;
+      }
     }
   }
 

--- a/src/libponyrt/lang/lsda.h
+++ b/src/libponyrt/lang/lsda.h
@@ -18,7 +18,9 @@ typedef struct _Unwind_Context exception_context_t;
 typedef DISPATCHER_CONTEXT exception_context_t;
 #endif
 
-bool ponyint_lsda_scan(exception_context_t* context, uintptr_t* lp);
+bool ponyint_lsda_scan(uintptr_t* ttype_index,
+  exception_context_t* context,
+  uintptr_t* lp);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyrt/lang/lsda.h
+++ b/src/libponyrt/lang/lsda.h
@@ -18,7 +18,7 @@ typedef struct _Unwind_Context exception_context_t;
 typedef DISPATCHER_CONTEXT exception_context_t;
 #endif
 
-bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
+bool ponyint_lsda_scan(uintptr_t* ttype_index,
   exception_context_t* context,
   uintptr_t* lp);
 

--- a/src/libponyrt/lang/lsda.h
+++ b/src/libponyrt/lang/lsda.h
@@ -18,7 +18,7 @@ typedef struct _Unwind_Context exception_context_t;
 typedef DISPATCHER_CONTEXT exception_context_t;
 #endif
 
-bool ponyint_lsda_scan(uintptr_t* ttype_index,
+bool ponyint_lsda_scan(uintptr_t* ttype_index __attribute__ ((unused)),
   exception_context_t* context,
   uintptr_t* lp);
 

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -107,7 +107,7 @@ PONY_API _Unwind_Reason_Code ponyint_personality_v0(_Unwind_State state,
 
         // No need to search again, just set the registers.
         uintptr_t ignored;
-        set_registers(&ignored, exception, context);
+        set_registers(0, exception, context);
         return _URC_INSTALL_CONTEXT;
       }
 

--- a/src/libponyrt/lang/posix_except.c
+++ b/src/libponyrt/lang/posix_except.c
@@ -106,7 +106,8 @@ PONY_API _Unwind_Reason_Code ponyint_personality_v0(_Unwind_State state,
         landing_pad = exception->barrier_cache.bitpattern[3];
 
         // No need to search again, just set the registers.
-        set_registers(exception, context);
+        uintptr_t ignored;
+        set_registers(&ignored, exception, context);
         return _URC_INSTALL_CONTEXT;
       }
 

--- a/src/libponyrt/lang/win_except.c
+++ b/src/libponyrt/lang/win_except.c
@@ -93,7 +93,8 @@ PONY_API EXCEPTION_DISPOSITION ponyint_personality_v0(
   if(!(ExcRecord->ExceptionFlags &
     (EXCEPTION_UNWINDING | EXCEPTION_EXIT_UNWIND)))
   {
-    if(!ponyint_lsda_scan(DispatcherContext, &landing_pad))
+    uintptr_t ignore;
+    if(!ponyint_lsda_scan(&ignore, DispatcherContext, &landing_pad))
       return ExceptionContinueSearch;
 
     RtlUnwindEx(EstablisherFrame, (PVOID)landing_pad, ExcRecord,

--- a/test/libponyc-run/regression-3874-case-1/main.pony
+++ b/test/libponyc-run/regression-3874-case-1/main.pony
@@ -1,0 +1,14 @@
+actor Main
+  new create(env: Env) =>
+    foo("hello")
+
+  fun foo(s: String) =>
+    try
+      one(s)
+      error
+    else
+      one(s)
+    end
+
+  fun one(s: String) =>
+    s.clone()

--- a/test/libponyc-run/regression-3874-case-2/main.pony
+++ b/test/libponyc-run/regression-3874-case-2/main.pony
@@ -1,0 +1,17 @@
+actor Main
+  let _out: OutStream
+
+  new create(env: Env) =>
+    _out = env.out
+    foo("hello")
+
+  fun foo(s: String) =>
+    try
+      one("h")
+      error
+    else
+      one("e")
+    end
+
+  fun one(s: String) =>
+    _out.print(s)


### PR DESCRIPTION
Our exception handling on aarch64 was incorrect and could lead to valid Pony
programs segfaulting at runtime. This was the result of us never having done an
aarch64 port. A Pony user got us compiling on aarch64 and tests passed, but
there were situations where the incorrect exception handling would cause us to
crash.

In general, the crash was being hidden because the inliner would remove one of
the conditions needed to trigger the problem.

This commit was manually validated on a Raspbian 64-bit installation to verify
the fix.

Fixes #3874