### PR TITLE
Add running our full pony program tests in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,21 @@ test-cross-ci: test-stdlib-debug test-stdlib-release
 test-check-version: all
 	$(SILENT)cd '$(outDir)' && ./ponyc --version
 
-test-core: all
+test-core: all test-libponyrt test-libponyc test-full-programs-release test-full-programs-debug
+
+test-libponyrt: all
 	$(SILENT)cd '$(outDir)' && ./libponyrt.tests --gtest_shuffle
+
+test-libponyc: all
 	$(SILENT)cd '$(outDir)' && ./libponyc.tests --gtest_shuffle
-	$(SILENT)cd '$(outDir)' && $(buildDir)/test/libponyc-run/runner/runner --sequential=true --exclude=runner --ponyc=$(outDir)/ponyc --output=$(outDir) --test_lib=$(outDir)/test_lib $(srcDir)/test/libponyc-run
+
+test-full-programs-release: all
+	@mkdir -p $(outDir)/runner-tests/release
+	$(SILENT)cd '$(outDir)' && $(buildDir)/test/libponyc-run/runner/runner --sequential=true --exclude=runner --ponyc=$(outDir)/ponyc --output=$(outDir)/runner-tests/release --test_lib=$(outDir)/test_lib $(srcDir)/test/libponyc-run
+
+test-full-programs-debug: all
+	@mkdir -p $(outDir)/runner-tests/debug
+	$(SILENT)cd '$(outDir)' && $(buildDir)/test/libponyc-run/runner/runner --sequential=true --exclude=runner --ponyc=$(outDir)/ponyc --debug --output=$(outDir)/runner-tests/debug --test_lib=$(outDir)/test_lib $(srcDir)/test/libponyc-run
 
 test-stdlib-release: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree --verify $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) ./stdlib-release --sequential

--- a/make.ps1
+++ b/make.ps1
@@ -246,11 +246,19 @@ switch ($Command.ToLower())
         if ($err -ne 0) { $failedTestSuites += 'libponyc.tests' }
 
         # libponyc.run.tests
-        $numTestSuitesRun += 1;
-        Write-Output "$buildDir\test\libponyc-run\runner\runner.exe --timeout_s=30 --sequential=true --exclude=runner --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$outDir $srcDir\test\libponyc-run"
-        & $buildDir\test\libponyc-run\runner\runner.exe --sequential=true --timeout_s=30 --exclude=runner --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$outDir $srcDir\test\libponyc-run
-        $err = $LastExitCode
-        if ($err -ne 0) { $failedTestSuites += 'libponyc.run.tests' }
+        foreach ($runConfig in ('debug', 'release'))
+        {
+            $numTestSuitesRun += 1;
+
+            $runOutDir = "$outDir/runner-tests/$runConfig"
+            $debugFlag = if ($runConfig -eq 'debug') { '--debug' } else { '' }
+
+            if (-not (Test-Path $runOutDir)) { New-Item -ItemType Directory -Force -Path $runOutDir }
+            Write-Output "$buildDir\test\libponyc-run\runner\runner.exe --timeout_s=30 --sequential=true --exclude=runner $debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run"
+            & $buildDir\test\libponyc-run\runner\runner.exe --sequential=true --timeout_s=30 --exclude=runner $debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run
+            $err = $LastExitCode
+            if ($err -ne 0) { $failedTestSuites += "libponyc.run.tests.$runConfig" }
+        }
 
         # stdlib-debug
         $numTestSuitesRun += 1;

--- a/test/libponyc-run/runner/_coordinator.pony
+++ b/test/libponyc-run/runner/_coordinator.pony
@@ -31,8 +31,18 @@ actor _Coordinator is _TesterNotify
     _success = Map[String, Bool](_num_to_run)
     _timers = Timers
 
-    _env.out.print(_Colors.info("Running " + _num_to_run.string()
-      + " tests.", true))
+    let start_message = recover val
+      var m: String ref = "Running " + _num_to_run.string() + " tests"
+
+      if _options.debug then
+        m = m + " compiled in debug mode."
+      else
+        m = m + " compiled in release mode."
+      end
+      m
+    end
+
+    _env.out.print(_Colors.info(start_message, true))
 
     if _num_to_run > 0 then
       if _options.sequential then


### PR DESCRIPTION
Not all bugs are seen in release mode. Some require debug mode to
be observed. There are regression tests for example that only happen
in one mode or the other.