### PR TITLE
Corrections to examples in documentaton for debug and net

### DIFF
--- a/packages/debug/debug.pony
+++ b/packages/debug/debug.pony
@@ -10,6 +10,8 @@ debug configured, pass the `-d` flag to `ponyc` when compiling e.g.:
 ## Example code
 
 ```pony
+use "debug"
+
 actor Main
   new create(env: Env) =>
     Debug.out("This will only be seen when configured for debug info")

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -38,10 +38,8 @@ actor TCPListener is AsioEventNotify
 
   actor Main
     new create(env: Env) =>
-      try
-        TCPListener(TCPListenAuth(env.root),
-          recover MyTCPListenNotify end, "", "8989")
-      end
+      TCPListener(TCPListenAuth(env.root),
+        recover MyTCPListenNotify end, "", "8989")
   ```
   """
   var _notify: TCPListenNotify

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -45,10 +45,8 @@ actor UDPSocket is AsioEventNotify
 
   actor Main
     new create(env: Env) =>
-      try
-        UDPSocket(UDPAuth(env.root),
-          MyUDPNotify, "", "8989")
-      end
+      UDPSocket(UDPAuth(env.root),
+        MyUDPNotify, "", "8989")
   ```
 
   The client is implemented like this:


### PR DESCRIPTION
* debug/debug.pony: Missing "use \"debug\"" in the example.
* net/tcp_listener.pony and net/udp_socket.pony: try…end blocks
  are no longer required.

(Note - no corrections were needed for debug in the end as the example wasn't designed to compile)