### PR TITLE
Fix a runtime fault for Windows IOCP w/ memtrack messages.

### DIFF
--- a/.release-notes/fix_windows_iocp_memtrack.md
+++ b/.release-notes/fix_windows_iocp_memtrack.md
@@ -1,0 +1,13 @@
+## Fix a runtime fault for Windows IOCP w/ memtrack messages.
+
+When the runtime is compiled with `-DUSE_MEMTRACK_MESSAGES` on
+Windows, the code path for asynchronous I/O events wasn't
+initializing the pony context prior to its first use,
+which would likely cause a runtime crash or other undesirable
+behavior.
+
+The `-DUSE_MEMTRACK_MESSAGES` feature is rarely used, and has
+perhaps never been used on Windows, so that explains why
+we haven't had a crash reported for this code path.
+
+Now that path has been fixed by rearranging the order of the code.

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -115,17 +115,17 @@ PONY_API uint64_t pony_asio_event_nsec(asio_event_t* ev)
 PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
   uint32_t arg)
 {
-  asio_msg_t* m = (asio_msg_t*)pony_alloc_msg(POOL_INDEX(sizeof(asio_msg_t)),
-    ev->msg_id);
-  m->event = ev;
-  m->flags = flags;
-  m->arg = arg;
-
 #ifdef PLATFORM_IS_WINDOWS
   // On Windows, this can be called from an IOCP callback thread, which may
   // not have a pony_ctx() associated with it yet.
   pony_register_thread();
 #endif
+
+  asio_msg_t* m = (asio_msg_t*)pony_alloc_msg(POOL_INDEX(sizeof(asio_msg_t)),
+    ev->msg_id);
+  m->event = ev;
+  m->flags = flags;
+  m->arg = arg;
 
   // ASIO messages technically are application messages, but since they have no
   // sender they aren't covered by backpressure. We pass false for an early


### PR DESCRIPTION
When the runtime is compiled with `-DUSE_MEMTRACK_MESSAGES` on
Windows, the code path for asynchronous I/O events wasn't
initializing the pony context prior to its first use,
which would likely cause a runtime crash or other undesirable
behavior.

The `-DUSE_MEMTRACK_MESSAGES` feature is rarely used, and has
perhaps never been used on Windows, so that explains why
we haven't had a crash reported for this code path.

Now that path has been fixed by rearranging the order of the code.

---

See [this Zulip thread](https://ponylang.zulipchat.com/#narrow/stream/190365-runtime/topic/pony_register_thread.20in.20windows.20ASIO/near/278501067) for additional discussion.