### PR TITLE
Remove unneeded extra `box` in `fun box` definitions

### DIFF
--- a/packages/buffered/reader.pony
+++ b/packages/buffered/reader.pony
@@ -602,140 +602,140 @@ class Reader
     end
     r
 
-  fun box peek_u8(offset: USize = 0): U8 ? =>
+  fun peek_u8(offset: USize = 0): U8 ? =>
     """
     Peek at a U8 at the given offset. Raise an error if there isn't enough
     data.
     """
     _peek_byte(offset)?
 
-  fun box peek_i8(offset: USize = 0): I8 ? =>
+  fun peek_i8(offset: USize = 0): I8 ? =>
     """
     Peek at an I8.
     """
     peek_u8(offset)?.i8()
 
-  fun box peek_u16_be(offset: USize = 0): U16 ? =>
+  fun peek_u16_be(offset: USize = 0): U16 ? =>
     """
     Peek at a big-endian U16.
     """
     (peek_u8(offset)?.u16() << 8) or peek_u8(offset + 1)?.u16()
 
-  fun box peek_u16_le(offset: USize = 0): U16 ? =>
+  fun peek_u16_le(offset: USize = 0): U16 ? =>
     """
     Peek at a little-endian U16.
     """
     peek_u8(offset)?.u16() or (peek_u8(offset + 1)?.u16() << 8)
 
-  fun box peek_i16_be(offset: USize = 0): I16 ? =>
+  fun peek_i16_be(offset: USize = 0): I16 ? =>
     """
     Peek at a big-endian I16.
     """
     peek_u16_be(offset)?.i16()
 
-  fun box peek_i16_le(offset: USize = 0): I16 ? =>
+  fun peek_i16_le(offset: USize = 0): I16 ? =>
     """
     Peek at a little-endian I16.
     """
     peek_u16_le(offset)?.i16()
 
-  fun box peek_u32_be(offset: USize = 0): U32 ? =>
+  fun peek_u32_be(offset: USize = 0): U32 ? =>
     """
     Peek at a big-endian U32.
     """
     (peek_u16_be(offset)?.u32() << 16) or peek_u16_be(offset + 2)?.u32()
 
-  fun box peek_u32_le(offset: USize = 0): U32 ? =>
+  fun peek_u32_le(offset: USize = 0): U32 ? =>
     """
     Peek at a little-endian U32.
     """
     peek_u16_le(offset)?.u32() or (peek_u16_le(offset + 2)?.u32() << 16)
 
-  fun box peek_i32_be(offset: USize = 0): I32 ? =>
+  fun peek_i32_be(offset: USize = 0): I32 ? =>
     """
     Peek at a big-endian I32.
     """
     peek_u32_be(offset)?.i32()
 
-  fun box peek_i32_le(offset: USize = 0): I32 ? =>
+  fun peek_i32_le(offset: USize = 0): I32 ? =>
     """
     Peek at a little-endian I32.
     """
     peek_u32_le(offset)?.i32()
 
-  fun box peek_u64_be(offset: USize = 0): U64 ? =>
+  fun peek_u64_be(offset: USize = 0): U64 ? =>
     """
     Peek at a big-endian U64.
     """
     (peek_u32_be(offset)?.u64() << 32) or peek_u32_be(offset + 4)?.u64()
 
-  fun box peek_u64_le(offset: USize = 0): U64 ? =>
+  fun peek_u64_le(offset: USize = 0): U64 ? =>
     """
     Peek at a little-endian U64.
     """
     peek_u32_le(offset)?.u64() or (peek_u32_le(offset + 4)?.u64() << 32)
 
-  fun box peek_i64_be(offset: USize = 0): I64 ? =>
+  fun peek_i64_be(offset: USize = 0): I64 ? =>
     """
     Peek at a big-endian I64.
     """
     peek_u64_be(offset)?.i64()
 
-  fun box peek_i64_le(offset: USize = 0): I64 ? =>
+  fun peek_i64_le(offset: USize = 0): I64 ? =>
     """
     Peek at a little-endian I64.
     """
     peek_u64_le(offset)?.i64()
 
-  fun box peek_u128_be(offset: USize = 0): U128 ? =>
+  fun peek_u128_be(offset: USize = 0): U128 ? =>
     """
     Peek at a big-endian U128.
     """
     (peek_u64_be(offset)?.u128() << 64) or peek_u64_be(offset + 8)?.u128()
 
-  fun box peek_u128_le(offset: USize = 0): U128 ? =>
+  fun peek_u128_le(offset: USize = 0): U128 ? =>
     """
     Peek at a little-endian U128.
     """
     peek_u64_le(offset)?.u128() or (peek_u64_le(offset + 8)?.u128() << 64)
 
-  fun box peek_i128_be(offset: USize = 0): I128 ? =>
+  fun peek_i128_be(offset: USize = 0): I128 ? =>
     """
     Peek at a big-endian I129.
     """
     peek_u128_be(offset)?.i128()
 
-  fun box peek_i128_le(offset: USize = 0): I128 ? =>
+  fun peek_i128_le(offset: USize = 0): I128 ? =>
     """
     Peek at a little-endian I128.
     """
     peek_u128_le(offset)?.i128()
 
-  fun box peek_f32_be(offset: USize = 0): F32 ? =>
+  fun peek_f32_be(offset: USize = 0): F32 ? =>
     """
     Peek at a big-endian F32.
     """
     F32.from_bits(peek_u32_be(offset)?)
 
-  fun box peek_f32_le(offset: USize = 0): F32 ? =>
+  fun peek_f32_le(offset: USize = 0): F32 ? =>
     """
     Peek at a little-endian F32.
     """
     F32.from_bits(peek_u32_le(offset)?)
 
-  fun box peek_f64_be(offset: USize = 0): F64 ? =>
+  fun peek_f64_be(offset: USize = 0): F64 ? =>
     """
     Peek at a big-endian F64.
     """
     F64.from_bits(peek_u64_be(offset)?)
 
-  fun box peek_f64_le(offset: USize = 0): F64 ? =>
+  fun peek_f64_le(offset: USize = 0): F64 ? =>
     """
     Peek at a little-endian F64.
     """
     F64.from_bits(peek_u64_le(offset)?)
 
-  fun box _peek_byte(offset: USize = 0): U8 ? =>
+  fun _peek_byte(offset: USize = 0): U8 ? =>
     """
     Get the byte at the given offset without moving the cursor forward.
     Raise an error if the given offset is not yet available.

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -179,7 +179,7 @@ class Array[A] is Seq[A]
       _ptr = _ptr._realloc(_alloc)
     end
 
-  fun box _element_size(): USize =>
+  fun _element_size(): USize =>
     """
     Element size in bytes for an element.
     """
@@ -210,7 +210,7 @@ class Array[A] is Seq[A]
     reserve(len)
     _size = len
 
-  fun box read_u8[B: (A & Real[B] val & U8) = A](offset: USize): U8 ? =>
+  fun read_u8[B: (A & Real[B] val & U8) = A](offset: USize): U8 ? =>
     """
     Reads a U8 from offset. This is only allowed for an array of U8s.
     """
@@ -220,7 +220,7 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun box read_u16[B: (A & Real[B] val & U8) = A](offset: USize): U16 ? =>
+  fun read_u16[B: (A & Real[B] val & U8) = A](offset: USize): U16 ? =>
     """
     Reads a U16 from offset. This is only allowed for an array of U8s.
     """
@@ -231,7 +231,7 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun box read_u32[B: (A & Real[B] val & U8) = A](offset: USize): U32 ? =>
+  fun read_u32[B: (A & Real[B] val & U8) = A](offset: USize): U32 ? =>
     """
     Reads a U32 from offset. This is only allowed for an array of U8s.
     """
@@ -242,7 +242,7 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun box read_u64[B: (A & Real[B] val & U8) = A](offset: USize): U64 ? =>
+  fun read_u64[B: (A & Real[B] val & U8) = A](offset: USize): U64 ? =>
     """
     Reads a U64 from offset. This is only allowed for an array of U8s.
     """
@@ -253,7 +253,7 @@ class Array[A] is Seq[A]
       error
     end
 
-  fun box read_u128[B: (A & Real[B] val & U8) = A](offset: USize): U128 ? =>
+  fun read_u128[B: (A & Real[B] val & U8) = A](offset: USize): U128 ? =>
     """
     Reads a U128 from offset. This is only allowed for an array of U8s.
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -206,7 +206,7 @@ actor Main
     end
     _set(_size, 0)
 
-  fun box _copy_to(ptr: Pointer[U8] ref, copy_len: USize,
+  fun _copy_to(ptr: Pointer[U8] ref, copy_len: USize,
     from_offset: USize = 0, to_offset: USize = 0) =>
     """
     Copy `copy_len` bytes from this to that at specified offsets.

--- a/packages/cli/command.pony
+++ b/packages/cli/command.pony
@@ -48,13 +48,13 @@ class box Command
     """
     _fullname
 
-  fun box option(name: String): Option =>
+  fun option(name: String): Option =>
     """
     Returns the Option by name, defaulting to a fake Option if unknown.
     """
     try _options(name)? else Option(OptionSpec.bool(name), false) end
 
-  fun box arg(name: String): Arg =>
+  fun arg(name: String): Arg =>
     """
     Returns the Arg by name, defaulting to a fake Arg if unknown.
     """

--- a/packages/cli/command_help.pony
+++ b/packages/cli/command_help.pony
@@ -48,16 +48,16 @@ class box CommandHelp
     _parent = parent'
     _spec = spec'
 
-  fun box fullname(): String =>
+  fun fullname(): String =>
     match _parent
     | let p: CommandHelp => p.fullname() + " " + _spec.name()
     else
       _spec.name()
     end
 
-  fun box string(): String => fullname()
+  fun string(): String => fullname()
 
-  fun box help_string(): String =>
+  fun help_string(): String =>
     """
     Renders the help message as a String.
     """
@@ -67,7 +67,7 @@ class box CommandHelp
     for bytes in w.done().values() do str.append(bytes) end
     str
 
-  fun box print_help(os: OutStream) =>
+  fun print_help(os: OutStream) =>
     """
     Prints the help message to an OutStream.
     """
@@ -75,7 +75,7 @@ class box CommandHelp
     _write_help(w)
     os.writev(w.done())
 
-  fun box _write_help(w: Writer) =>
+  fun _write_help(w: Writer) =>
     _write_usage(w)
     if _spec.descr().size() > 0 then
       w.write("\n")
@@ -97,7 +97,7 @@ class box CommandHelp
       _write_args(w, args)
     end
 
-  fun box _write_usage(w: Writer) =>
+  fun _write_usage(w: Writer) =>
     w.write("usage: " + fullname())
     if _any_options() then
       w.write(" [<options>]")
@@ -114,19 +114,19 @@ class box CommandHelp
     end
     w.write("\n")
 
-  fun box _write_options(w: Writer, options: Array[OptionSpec box] box) =>
+  fun _write_options(w: Writer, options: Array[OptionSpec box] box) =>
     let cols = Array[(USize,String,String)]()
     for o in options.values() do
       cols.push((2, o.help_string(), o.descr()))
     end
     _Columns.write(w, cols)
 
-  fun box _write_commands(w: Writer) =>
+  fun _write_commands(w: Writer) =>
     let cols = Array[(USize,String,String)]()
     _list_commands(_spec, cols, 1)
     _Columns.write(w, cols)
 
-  fun box _list_commands(
+  fun _list_commands(
     cs: CommandSpec box,
     cols: Array[(USize,String,String)],
     level: USize)
@@ -136,14 +136,14 @@ class box CommandHelp
       _list_commands(c, cols, level + 1)
     end
 
-  fun box _write_args(w: Writer, args: Array[ArgSpec] box) =>
+  fun _write_args(w: Writer, args: Array[ArgSpec] box) =>
     let cols = Array[(USize,String,String)]()
     for a in args.values() do
       cols.push((2, a.help_string(), a.descr()))
     end
     _Columns.write(w, cols)
 
-  fun box _any_options(): Bool =>
+  fun _any_options(): Bool =>
     if _spec.options().size() > 0 then
       true
     else
@@ -154,12 +154,12 @@ class box CommandHelp
       end
     end
 
-  fun box _all_options(): Array[OptionSpec box] =>
+  fun _all_options(): Array[OptionSpec box] =>
     let options = Array[OptionSpec box]()
     _all_options_fill(options)
     options
 
-  fun box _all_options_fill(options: Array[OptionSpec box]) =>
+  fun _all_options_fill(options: Array[OptionSpec box]) =>
     match _parent
     | let p: CommandHelp => p._all_options_fill(options)
     end

--- a/packages/cli/command_parser.pony
+++ b/packages/cli/command_parser.pony
@@ -341,7 +341,7 @@ primitive _ArgParser
     end
 
 primitive _ValueParser
-  fun box parse(typ: _ValueType, arg: String): (_Value | SyntaxError) =>
+  fun parse(typ: _ValueType, arg: String): (_Value | SyntaxError) =>
     try
       typ.value_of(arg)?
     else

--- a/packages/pony_bench/benchmark.pony
+++ b/packages/pony_bench/benchmark.pony
@@ -2,9 +2,9 @@
 type Benchmark is (MicroBenchmark | AsyncMicroBenchmark)
 
 // interface iso _IBenchmark
-//   fun box name(): String
-//   fun box config(): BenchConfig
-//   fun box overhead(): _IBenchmark^
+//   fun name(): String
+//   fun config(): BenchConfig
+//   fun overhead(): _IBenchmark^
 
 trait iso MicroBenchmark
   """
@@ -16,9 +16,9 @@ trait iso MicroBenchmark
   each iteration of the benchmark, then you can use `before_iteration` and
   `after_iteration` methods respectively that run before/after each iteration.
   """
-  fun box name(): String
-  fun box config(): BenchConfig => BenchConfig
-  fun box overhead(): MicroBenchmark^ => OverheadBenchmark
+  fun name(): String
+  fun config(): BenchConfig => BenchConfig
+  fun overhead(): MicroBenchmark^ => OverheadBenchmark
   fun ref before() ? => None
   fun ref before_iteration() ? => None
   fun ref apply() ?
@@ -37,9 +37,9 @@ trait iso AsyncMicroBenchmark
   you can use `before_iteration` and `after_iteration` methods respectively
   that run before/after each iteration.
   """
-  fun box name(): String
-  fun box config(): BenchConfig => BenchConfig
-  fun box overhead(): AsyncMicroBenchmark^ => AsyncOverheadBenchmark
+  fun name(): String
+  fun config(): BenchConfig => BenchConfig
+  fun overhead(): AsyncMicroBenchmark^ => AsyncOverheadBenchmark
   fun ref before(c: AsyncBenchContinue) => c.complete()
   fun ref before_iteration(c: AsyncBenchContinue) => c.complete()
   fun ref apply(c: AsyncBenchContinue) ?


### PR DESCRIPTION
Pretty much all of the standard library leaves the optional `box`
out. These few didn't and have been changed to match the normal
pattern in the standard library.