### PR TITLE
Fix initialization of an atomic variable in `ponyassert.c`.

### DIFF
--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -17,6 +17,7 @@
 #  include <atomic>
 #  define PONY_ATOMIC(T) std::atomic<T>
 #  define PONY_ATOMIC_RVALUE(T) std::atomic<T>
+#  define PONY_ATOMIC_INIT(T, N, V) std::atomic<T> N{V}
 #  ifdef PONY_WANT_ATOMIC_DEFS
 using std::memory_order_relaxed;
 using std::memory_order_consume;
@@ -42,16 +43,19 @@ using std::atomic_thread_fence;
 #      include <atomic>
 #      define PONY_ATOMIC(T) std::atomic<T>
 #      define PONY_ATOMIC_RVALUE(T) std::atomic<T>
+#      define PONY_ATOMIC_INIT(T, N, V) std::atomic<T> N{V}
 #    else
 #      ifdef PONY_WANT_ATOMIC_DEFS
 #        include <stdatomic.h>
 #      endif
 #      define PONY_ATOMIC(T) T _Atomic
 #      define PONY_ATOMIC_RVALUE(T) T _Atomic
+#      define PONY_ATOMIC_INIT(T, N, V) T _Atomic N = V
 #    endif
 #  elif ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((4) << 16) + (7))
 #    define PONY_ATOMIC(T) alignas(sizeof(T)) T
 #    define PONY_ATOMIC_RVALUE(T) T
+#    define PONY_ATOMIC_INIT(T, N, V) T N = V
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use GCC >= 4.7"
@@ -63,9 +67,11 @@ using std::atomic_thread_fence;
 #    endif
 #    define PONY_ATOMIC(T) T _Atomic
 #    define PONY_ATOMIC_RVALUE(T) T _Atomic
+#    define PONY_ATOMIC_INIT(T, N, V) T _Atomic N = V
 #  elif __clang_major__ >= 3 && __clang_minor__ >= 4
 #    define PONY_ATOMIC(T) alignas(sizeof(T)) T
 #    define PONY_ATOMIC_RVALUE(T) T
+#    define PONY_ATOMIC_INIT(T, N, V) T N = V
 #    define PONY_ATOMIC_BUILTINS
 #  else
 #    error "Please use Clang >= 3.4"

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -16,7 +16,7 @@
 
 #include <pony/detail/atomics.h>
 
-static PONY_ATOMIC(bool) assert_guard = false;
+static PONY_ATOMIC_INIT(bool, assert_guard, false);
 
 #ifdef PLATFORM_IS_POSIX_BASED
 


### PR DESCRIPTION
While working on cross-compiling the runtime from Linux to Windows,
I ran into this issue which was causing clang to fail with:

```
src/libponyrt/platform/ponyassert.c:19:26: error: copying variable of type 'std::atomic<bool>' invokes deleted constructor
static PONY_ATOMIC(bool) assert_guard = false;
                         ^              ~~~~~
/tmp/xwin/crt/include/atomic:2276:5: note: 'atomic' has been explicitly marked deleted here
    atomic(const atomic&) = delete;
    ^
```

Apparently the correct way to initialize a `std::atomic` is with
an initializer list, as described in this blog post:
https://onetwobytes.wordpress.com/2021/02/24/std-atomic-defaults/

However, we don't actually use `std::atomic` on all platforms,
and the platforms that don't use it need to keep using the `=` syntax.
So the initializer needs to get moved into a new dedicated macro,
which I have named `PONY_ATOMIC_INIT` and used for this purpose.
