### PR TITLE
Small fixes to CMake code for cross-compiling runtime bitcode.

### DIFF
--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -127,12 +127,15 @@ if(PONY_RUNTIME_BITCODE)
         message(FATAL_ERROR "You can only use runtime-bitcode with Clang.")
     endif()
 
+    set(_c_flags ${CMAKE_C_FLAGS})
+    separate_arguments(_c_flags)
+
     set(_ll_src_all ${_c_src})
     foreach(_src_file ${_ll_src_all})
         #message("${libponyrt_SOURCE_DIR}/${_src_file} -> ${libponyrt_BINARY_DIR}/${_src_file}.bc")
         get_filename_component(_src_dir ${_src_file} DIRECTORY)
         add_custom_command(
-            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_ALWAYS_ASSERT -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -DPONY_VERSION="${PONYC_VERSION}" -DPONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${CMAKE_C_COMPILER_ARCHITECTURE_ID}" -fexceptions -std=gnu11 -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall -I. -I../common -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
+            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_ALWAYS_ASSERT -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -DPONY_VERSION="${PONYC_VERSION}" -DPONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${CMAKE_C_COMPILER_ARCHITECTURE_ID}" -fexceptions -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall ${_c_flags} -I. -I../common -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
             WORKING_DIRECTORY ${libponyrt_SOURCE_DIR}
             DEPENDS "${libponyrt_SOURCE_DIR}/${_src_file}"
             OUTPUT "${libponyrt_BINARY_DIR}/${_src_file}.bc"


### PR DESCRIPTION
This change contains some small fixes that make it possible to
further tweak the way the runtime bitcode is compiled, making
it possible to do things relating to cross-compilation.

- We remove the `-std=gnu11` flag, which is not actually necessary
  on native Linux and breaks when trying to cross-compile to Windows.

- We respect whatever `CFLAGS` are set by adding `CMAKE_C_FLAGS`
  into the clang invocation (which we must convert to a list first).

---

Note that after this change, it is possible to cross-compile
the runtime bitcode for a Windows target from a Linux host,
provided that the Linux host has obtained a copy of the Windows headers,
which can be done conveniently on non-Windows platforms using
[`xwin`](https://github.com/Jake-Shadle/xwin).

The commands for doing so (assuming the windows headers are unpacked at
a directory called `/tmp/xwin`) are:

```
mkdir src/libponyrt/build

env CC=clang++ CXX=clang++ \
  CFLAGS="-w -mcx16 -D_CRT_USE_BUILTIN_OFFSETOF -I/tmp/xwin/sdk/include/ucrt -I/tmp/xwin/crt/include -I/tmp/xwin/sdk/include/um -I/tmp/xwin/sdk/include/shared -I/tmp/xwin/sdk/include/shared" \
  cmake -S src/libponyrt -B src/libponyrt/build -DPONY_RUNTIME_BITCODE=true \
    -DCMAKE_C_COMPILER_TARGET=x86_64-windows-msvc \
    -DCMAKE_C_COMPILER_WORKS=true

cmake --build src/libponyrt/build --target libponyrt_bc
```

Note that a few hacks in the invocation here are still neccessary:

- We pretend that `clang++` is a C compiler (`CC=clang++`)

- We suppress CMake's compiler check (`-DCMAKE_C_COMPILER_WORKS=true`)
  because we don't want to care about proving the linker or libs
  (and because `clang++` isn't actually a C compiler).

- We work around a bug in Windows' implementation of `offsetof`
  (they don't implement it as a valid constant expression)
  by telling Windows to use the builtin version of `offsetof`
  (`-D_CRT_USE_BUILTIN_OFFSETOF`).

- We suppress all ignorable diagnostics in clang (`-w`)
  because there are otherwise a lot of other compilation errors
  (or rather, warnings being treated as errors) in Windows' own headers...
  
  EDIT: The blanket `-w` can be avoided by adding all these explicit flags:
  
  ```
  -fms-extensions -fms-compatibility -Wno-microsoft-cast -Wno-deprecated -Wno-nonportable-include-path -Wno-ignored-pragma-intrinsic -Wno-pragma-pack -Wno-unknown-pragmas -Wno-ignored-attributes -Wno-unused-local-typedef -Wno-missing-field-initializers -Wno-missing-braces -Wno-implicit-int-conversion -Wno-int-in-bool-context -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable
  ```