### PR TITLE
Fix compilation error with PONY_NDEBUG

### DIFF
--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -1559,7 +1559,9 @@ void ast_free(ast_t* ast)
   if(ast == NULL)
     return;
 
+#ifndef PONY_NDEBUG
   ast->frozen = false;
+#endif
 
   ast_t* child = ast->child;
   ast_t* next;

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -67,7 +67,9 @@ token_t* token_dup(token_t* token)
   token_t* t = POOL_ALLOC(token_t);
   memcpy(t, token, sizeof(token_t));
   t->printed = NULL;
+ #ifndef PONY_NDEBUG
   t->frozen = false;
+#endif
   return t;
 }
 


### PR DESCRIPTION
`frozen` is only available on ast and token if PONY_NDEBUG isn't defined.
However, it was used in two functions regardless of the value of PONY_NDEBUG.

This isn't caught in CI as we currently use PONY_ALWAYS_ASSERT which means that
PONY_NDEBUG isn't on for any of our CI (or any other builds).