### PR TITLE
Remove unneeded debug gating in find_kernel32

### DIFF
--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -225,9 +225,7 @@ static bool find_kernel32(vcvars_t* vcvars, errors_t* errors)
   vcvars->ucrt[0] = '\0';
   strcpy(vcvars->default_libs,
     "kernel32.lib "
-#if !defined(DEBUG)
     "msvcrt.lib "
-#endif
     "Ws2_32.lib advapi32.lib vcruntime.lib "
     "legacy_stdio_definitions.lib dbghelp.lib");
 


### PR DESCRIPTION
Gordon originally added this gating. He stated that he believed that
it fixed a link error. However, the link error possibility is addressed
via CMake and $<$<CONFIG:Debug>:/MD> as a compilation option.