### PR TITLE
Print libponyc-run test output sequentially even when running in parallel

### DIFF
--- a/test/libponyc-run/runner/_coordinator.pony
+++ b/test/libponyc-run/runner/_coordinator.pony
@@ -11,6 +11,10 @@ actor _Coordinator is _TesterNotify
   let _success: Map[String, Bool]
   let _timers: Timers
 
+  var _cur_output_name: (String | None) = None
+  let _tester_outputs: Map[String, Array[String] ref] =
+    Map[String, Array[String] ref]
+
   new create(env: Env, options: _Options,
     definitions: Array[_TestDefinition] val)
   =>
@@ -65,16 +69,82 @@ actor _Coordinator is _TesterNotify
       end
     end
 
+  be print(tester_name: String, str: String) =>
+    match _cur_output_name
+    | let cur_name: String =>
+      if cur_name == tester_name then
+        _env.out.print(str)
+      else
+        let array = try
+          _tester_outputs(tester_name)?
+        else
+          _tester_outputs.insert(tester_name, Array[String])
+        end
+        array.push(str)
+      end
+    else
+      _cur_output_name = tester_name
+      _flush_outputs(tester_name)
+      _env.out.print(str)
+    end
+
   be succeeded(name: String) =>
+    _finalize_outputs(name)
     _success(name) = true
     _check_done()
 
   be failed(name: String) =>
+    _finalize_outputs(name)
     _success(name) = false
     _check_done()
 
-  fun _check_done(): Bool =>
+  fun ref _finalize_outputs(name: String) =>
+    let pick_new =
+      match _cur_output_name
+      | let cur_name: String if cur_name == name =>
+        true
+      | None =>
+        true
+      else
+        false
+      end
+
+    if pick_new then
+      // flush all finished tests
+      let keys = Array[String](_tester_outputs.size())
+        .>concat(_tester_outputs.keys())
+
+      for key in keys.values() do
+        if _success.contains(key) then
+          _flush_outputs(key)
+        end
+      end
+
+      // pick a new current
+      _cur_output_name =
+        try
+          let next_name = _tester_outputs.keys().next()?
+          _flush_outputs(next_name)
+          next_name
+        end
+    end
+
+  fun ref _flush_outputs(name: String) =>
+    try
+      for str in _tester_outputs(name)?.values() do
+        _env.out.print(str)
+      end
+      _tester_outputs.remove(name)?
+    end
+
+  fun ref _check_done(): Bool =>
     if _success.size() >= _num_to_run then
+      // print buffered outputs
+      for array in _tester_outputs.values() do
+        for str in array.values() do _env.out.print(str) end
+      end
+
+      // collect the number of successes and failures
       (let num_succeeded: USize, let num_failed: USize) =
         Iter[Bool](_success.values())
           .fold[(USize, USize)]((0, 0),
@@ -82,6 +152,7 @@ actor _Coordinator is _TesterNotify
               if s then (sum._1 + 1, sum._2) else (sum._1, sum._2 + 1) end
             })
 
+      // print summary
       _env.out.print(_Colors.info("", true))
       if num_succeeded > 0 then
         _env.out.print(_Colors.pass(num_succeeded.string() + " test(s)."))
@@ -96,6 +167,7 @@ actor _Coordinator is _TesterNotify
         end
       end
 
+      // clean up
       if num_succeeded == _num_to_run then
         _env.exitcode(0)
       else

--- a/test/libponyc-run/runner/_tester.pony
+++ b/test/libponyc-run/runner/_tester.pony
@@ -6,6 +6,7 @@ use "time"
 use "backpressure"
 
 interface tag _TesterNotify
+  be print(name: String, str: String)
   be succeeded(name: String)
   be failed(name: String)
 
@@ -60,7 +61,7 @@ actor _Tester
     _err_buf.append(consume buf)
 
   be start_building() =>
-    _env.out.print(_Colors.run(_definition.name))
+    _notify.print(_definition.name, _Colors.run(_definition.name))
 
     // find ponyc executable
     let ponyc_file_path =
@@ -80,10 +81,11 @@ actor _Tester
         args_join.append(" ")
         args_join.append(arg)
       end
-      _env.out.print(_Colors.info(_definition.name + ": building in: "
-        + _definition.path))
-      _env.out.print(_Colors.info(_definition.name + ": building: "
-        + _options.ponyc + args_join))
+      _notify.print(_definition.name,
+        _Colors.info(_definition.name + ": building in: " + _definition.path))
+      _notify.print(_definition.name,
+        _Colors.info(_definition.name + ": building: " + _options.ponyc
+          + args_join))
     end
 
     // run ponyc to build the test program
@@ -130,8 +132,8 @@ actor _Tester
         end
 
       if _options.verbose then
-        _env.out.print(_Colors.info(_definition.name + ": testing: "
-          + test_fname))
+        _notify.print(_definition.name,
+          _Colors.info(_definition.name + ": testing: " + test_fname))
       end
 
       _out_buf.clear()
@@ -167,7 +169,8 @@ actor _Tester
         if _options.verbose then
           for v in vars.values() do
             if v.contains("DYLD_LIBRARY_PATH") then
-              _env.out.print(_Colors.info(_definition.name + ": testing: " + v))
+              _notify.print(_definition.name,
+                _Colors.info(_definition.name + ": testing: " + v))
             end
           end
         end
@@ -212,7 +215,7 @@ actor _Tester
   fun ref _shutdown_succeeded() =>
     if not (_stage is _Succeeded) then
       _end_ms = Time.millis()
-      _env.out.print(_Colors.ok(_definition.name + " ("
+      _notify.print(_definition.name, _Colors.ok(_definition.name + " ("
         + (_end_ms - _start_ms).string() + " ms)"))
       _timers.cancel(_timer)
       _stage = _Succeeded
@@ -223,7 +226,7 @@ actor _Tester
     if not (_stage is _Failed) then
       _end_ms = Time.millis()
 
-      _env.out.print(_Colors.fail(_definition.name + " ("
+      _notify.print(_definition.name, _Colors.fail(_definition.name + " ("
         + (_end_ms - _start_ms).string() + " ms): " + msg))
 
       match _build_process
@@ -245,10 +248,10 @@ actor _Tester
 
   fun ref _dump_io_streams() =>
     if _out_buf.size() > 0 then
-      _env.out.print(_definition.name + ": STDOUT:\n"
+      _notify.print(_definition.name, _definition.name + ": STDOUT:\n"
         + recover val _out_buf.clone() end)
     end
     if _err_buf.size() > 0 then
-      _env.out.print(_definition.name + ": STDERR\n"
+      _notify.print(_definition.name, _definition.name + ": STDERR\n"
         + recover val _err_buf.clone() end)
     end

--- a/test/libponyc-run/runner/main.pony
+++ b/test/libponyc-run/runner/main.pony
@@ -9,6 +9,7 @@ actor Main
       try
         _CliOptions(env)?
       else
+        env.exitcode(1)
         return
       end
 


### PR DESCRIPTION
This change makes the runner choose a "current" test to show output from.  If that test prints output, it is printed right away. If other tests print, their output is buffered.

Whenever the current test completes, output from all other completed tests is printed, and a new "current" test is chosen from among those not yet complete.

Fixes #4023