### PR TITLE
Disable incorrect runtime assert for ASIO thread shutdown.

### DIFF
--- a/.release-notes/fix_runtime_program_termination_assert.md
+++ b/.release-notes/fix_runtime_program_termination_assert.md
@@ -1,0 +1,5 @@
+## Disable incorrect runtime assert for ASIO thread shutdown.
+
+In a rare race condition, a runtime assertion failure related to destruction of the runtime ASIO thread's message queue could be observed during program termination, causing a program crash instead of graceful termination.
+
+This change removes the invalid runtime assertion for that case, because the invariant it was meant to ensure does not apply or hold for the specific case of terminating the runtime ASIO thread, even though it still holds and is still being tested for the more common case of individual actor terminator.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -585,7 +585,7 @@ void ponyint_actor_destroy(pony_actor_t* actor)
   ANNOTATE_HAPPENS_AFTER(&actor->q.head);
 #endif
 
-  ponyint_messageq_destroy(&actor->q);
+  ponyint_messageq_destroy(&actor->q, false);
   ponyint_gc_destroy(&actor->gc);
   ponyint_heap_destroy(&actor->heap);
 

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -18,7 +18,7 @@ PONY_EXTERN_C_BEGIN
 
 void ponyint_messageq_init(messageq_t* q);
 
-void ponyint_messageq_destroy(messageq_t* q);
+void ponyint_messageq_destroy(messageq_t* q, bool maybe_non_empty);
 
 bool ponyint_actor_messageq_push(messageq_t* q,
   pony_msg_t* first, pony_msg_t* last

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -316,7 +316,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   close(b->epfd);
   close(b->wakeup);
-  ponyint_messageq_destroy(&b->q);
+  ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
   pony_unregister_thread();
   return NULL;

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -244,7 +244,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   }
 
   CloseHandle(b->wakeup);
-  ponyint_messageq_destroy(&b->q);
+  ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
   pony_unregister_thread();
   return NULL;

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -255,7 +255,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
     handle_queue(b);
   }
 
-  ponyint_messageq_destroy(&b->q);
+  ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
   pony_unregister_thread();
   return NULL;

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1032,7 +1032,7 @@ static void ponyint_sched_shutdown()
       , i
 #endif
       ) != NULL) { ; }
-    ponyint_messageq_destroy(&scheduler[i].mq);
+    ponyint_messageq_destroy(&scheduler[i].mq, false);
     ponyint_mpmcq_destroy(&scheduler[i].q);
 
 #if defined(PLATFORM_IS_WINDOWS)


### PR DESCRIPTION
When shutting down the ASIO thread and destroying its message queue,
it is possible that there may be some message(s) in flight to it,
meaning that even though we drained the queue before destroying,
the queue may be non-empty by the time we get to destroying it.
Hence, we cannot reliably assert that the queue is non-empty.

However, for actors, we can proved definitively that an actor
is done receiving messages before we destroy its message queue,
so we want to retain the runtime assert for the actor case.

This change updates the assert to be conditional based on
a boolean parameter to the `ponyint_messageq_destroy` function.

For more context, see [this Zulip thread](https://ponylang.zulipchat.com/#narrow/stream/190365-runtime/topic/ponyint_messageq_destroy.20assert.20fail).