### PR TITLE
Update Array.from_cpointer documentation

### DIFF
--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -124,7 +124,9 @@ class Array[A] is Seq[A]
   new from_cpointer(ptr: Pointer[A], len: USize, alloc: USize = 0) =>
     """
     Create an array from a C-style pointer and length. The contents are not
-    copied.
+    copied. This must be done only with C-FFI functions that return
+    pony_alloc'd memory. If a null pointer is given then an empty array
+    is returned.
     """
     if ptr.is_null() then
       _size = 0


### PR DESCRIPTION
Over on [Zulip](https://ponylang.zulipchat.com/#narrow/stream/316480-standard-library/topic/Array.20from_cpointer.20vs.20reserve.20.26.20other.20methods.20that.20reserve), Adrian raised a potential issue when using `Array.from_cpointer` that is not covered in the documentation.

When creating an array from a pointer to non-managed memory, we create a situation where any operations on the array that might trigger a reallocation are unsafe. This is because the runtime assumes that a Pony array is always pointing to memory that was previously allocated by calling `pony_alloc`. Although a debug runtime will abort when reallocating, performing a realocation on a release runtime will most probably lead to a segfault at runtime.

The note about calling `from_cpointer` from non-managed memory is already noted in the documentation from [`String.from_cpointer`](https://stdlib.ponylang.org/builtin-String/#from_cpointer), but it was missing from Array.
