### PR TITLE
Auto-recover constructor expressions

### DIFF
--- a/.ci-scripts/x86-64-release.bash
+++ b/.ci-scripts/x86-64-release.bash
@@ -52,7 +52,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 echo "Building ponyc installation..."
 make configure arch=${ARCH} build_flags=-j${MAKE_PARALLELISM}
 make build
-make install arch=${ARCH} prefix="${BUILD_PREFIX}" symlink=no arch=${ARCH}
+make install arch=${ARCH} prefix="${BUILD_PREFIX}" symlink=no
 
 # Package it all up
 echo "Creating .tar.gz of ponyc installation..."

--- a/.release-notes/4124.md
+++ b/.release-notes/4124.md
@@ -2,7 +2,7 @@
 
 Previously for the following code:
 
-```
+```pony
 actor Main
   new create(env: Env) =>
     Bar.take_foo(Foo(88))

--- a/.release-notes/4124.md
+++ b/.release-notes/4124.md
@@ -1,0 +1,22 @@
+## Allow constructor expressions to be auto-recovered in assignments or arguments
+
+Previously for the following code:
+
+```
+actor Main
+  new create(env: Env) =>
+    Bar.take_foo(Foo(88))
+    let bar: Foo iso = Foo(88)
+
+class Foo
+  new create(v: U8) =>
+    None
+
+primitive Bar
+  fun take_foo(foo: Foo iso) =>
+    None
+```
+
+You'd get compilation errors `argument not assignable to parameter` and `right side must be a subtype of left side` for the two lines in `Main.create()`.
+
+We've added checks to see if the constructor expressions can be implicitly auto-recovered, and if they can, no compilation error is generated.

--- a/.release-notes/4124.md
+++ b/.release-notes/4124.md
@@ -20,3 +20,5 @@ primitive Bar
 You'd get compilation errors "argument not assignable to parameter" and "right side must be a subtype of left side" for the two lines in `Main.create()`.
 
 We've added checks to see if the constructor expressions can be implicitly auto-recovered, and if they can, no compilation error is generated.
+
+This only applies to cases where the type of the parameter (or the `let` binding) is a simple type, i.e. not a union, intersection or tuple type.

--- a/.release-notes/4124.md
+++ b/.release-notes/4124.md
@@ -17,6 +17,6 @@ primitive Bar
     None
 ```
 
-You'd get compilation errors `argument not assignable to parameter` and `right side must be a subtype of left side` for the two lines in `Main.create()`.
+You'd get compilation errors "argument not assignable to parameter" and "right side must be a subtype of left side" for the two lines in `Main.create()`.
 
 We've added checks to see if the constructor expressions can be implicitly auto-recovered, and if they can, no compilation error is generated.

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -196,10 +196,10 @@ static bool apply_default_arg(pass_opt_t* opt, ast_t* param, ast_t** argp)
 
 static ast_t* method_receiver_type(ast_t* method);
 
-bool check_auto_recover_newref(ast_t* param_type, ast_t* ast)
+bool check_auto_recover_newref(ast_t* dest_type, ast_t* ast)
 {
   // we're not going to try auto-recovering to a complex type
-  if (ast_id(param_type) != TK_NOMINAL)
+  if (ast_id(dest_type) != TK_NOMINAL)
     return false;
 
   while (ast != NULL && ast_id(ast) != TK_CALL)
@@ -230,7 +230,7 @@ bool check_auto_recover_newref(ast_t* param_type, ast_t* ast)
       return false;
 
     ast_t* arg_type_aliased = alias(arg_type);
-    bool ok = safe_to_autorecover(param_type, arg_type_aliased, WRITE);
+    bool ok = safe_to_autorecover(dest_type, arg_type_aliased, WRITE);
     ast_free_unattached(arg_type_aliased);
 
     if (!ok)

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -239,8 +239,8 @@ bool check_auto_recover_newref(ast_t* ast)
   return false;
 }
 
-static bool check_arg_types(pass_opt_t* opt, ast_t* r_type, ast_t* params,
-  ast_t* positional, bool partial)
+static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
+  bool partial)
 {
   // Check positional args vs params.
   ast_t* param = ast_child(params);
@@ -629,8 +629,7 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
   if(!apply_named_args(opt, params, positional, namedargs))
     return false;
 
-  ast_t* r_type = method_receiver_type(lhs);
-  if(!check_arg_types(opt, r_type, params, positional, partial))
+  if(!check_arg_types(opt, params, positional, partial))
     return false;
 
   switch(ast_id(lhs))

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -198,6 +198,10 @@ static ast_t* method_receiver_type(ast_t* method);
 
 bool check_auto_recover_newref(ast_t* param_type, ast_t* ast)
 {
+  // we're not going to try auto-recovering to a complex type
+  if (ast_id(param_type) != TK_NOMINAL)
+    return false;
+
   while (ast != NULL && ast_id(ast) != TK_CALL)
     ast = ast_child(ast);
 
@@ -208,7 +212,7 @@ bool check_auto_recover_newref(ast_t* param_type, ast_t* ast)
   if (ast_id(newref) != TK_NEWREF)
     return false;
 
-  // sometimes newrefs are nested?
+  // sometimes for assignments there's a nested newref
   ast_t* child = ast_child(newref);
   if (child != NULL && ast_id(child) == TK_NEWREF)
     newref = child;

--- a/src/libponyc/expr/call.h
+++ b/src/libponyc/expr/call.h
@@ -8,6 +8,7 @@
 PONY_EXTERN_C_BEGIN
 
 bool method_check_type_params(pass_opt_t* opt, ast_t** astp);
+bool check_auto_recover_newref(ast_t* ast);
 
 bool expr_call(pass_opt_t* opt, ast_t** astp);
 

--- a/src/libponyc/expr/call.h
+++ b/src/libponyc/expr/call.h
@@ -8,7 +8,7 @@
 PONY_EXTERN_C_BEGIN
 
 bool method_check_type_params(pass_opt_t* opt, ast_t** astp);
-bool check_auto_recover_newref(ast_t* param_type, ast_t* ast);
+bool check_auto_recover_newref(ast_t* dest_type, ast_t* ast);
 
 bool expr_call(pass_opt_t* opt, ast_t** astp);
 

--- a/src/libponyc/expr/call.h
+++ b/src/libponyc/expr/call.h
@@ -8,7 +8,7 @@
 PONY_EXTERN_C_BEGIN
 
 bool method_check_type_params(pass_opt_t* opt, ast_t** astp);
-bool check_auto_recover_newref(ast_t* ast);
+bool check_auto_recover_newref(ast_t* param_type, ast_t* ast);
 
 bool expr_call(pass_opt_t* opt, ast_t** astp);
 

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -3,6 +3,7 @@
 #include "postfix.h"
 #include "control.h"
 #include "reference.h"
+#include "call.h"
 #include "../ast/astbuild.h"
 #include "../ast/id.h"
 #include "../ast/lexer.h"
@@ -373,7 +374,16 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
     default: {}
   }
-  ast_t* wl_type = consume_type(fl_type, TK_NONE, false);
+
+  ast_t* wl_type;
+  if(check_auto_recover_newref(right))
+  {
+    wl_type = unisolated(fl_type);
+  }
+  else
+  {
+    wl_type = consume_type(fl_type, TK_NONE, false);
+  }
 
   // Assignment is based on the alias of the right hand side.
   errorframe_t info = NULL;

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -375,14 +375,13 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     default: {}
   }
 
-  ast_t* wl_type;
-  if(check_auto_recover_newref(right))
+  ast_t* wl_type = consume_type(fl_type, TK_NONE, false);
+  if(check_auto_recover_newref(fl_type, right))
   {
-    wl_type = unisolated(fl_type);
-  }
-  else
-  {
-    wl_type = consume_type(fl_type, TK_NONE, false);
+    token_id left_cap = ast_id(cap_fetch(wl_type));
+    ast_t* recovered_left_type = recover_type(r_type, left_cap);
+    if (recovered_left_type)
+      r_type = recovered_left_type;
   }
 
   // Assignment is based on the alias of the right hand side.

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -1012,15 +1012,13 @@ bool cap_immutable_or_opaque(token_id cap)
   return false;
 }
 
-
-
 static ast_t* modified_cap_single(ast_t* type, cap_mutation* mutation)
 {
   ast_t* cap = cap_fetch(type);
   ast_t* ephemeral = ast_sibling(cap);
 
   token_id cap_token = ast_id(cap);
-  token_id eph_token = ast_id(cap);
+  token_id eph_token = ast_id(ephemeral);
 
   if (mutation(&cap_token, &eph_token))
   {
@@ -1153,4 +1151,3 @@ ast_t* unisolated(ast_t* type)
 {
   return modified_cap(type, unisolated_mod);
 }
-

--- a/test/libponyc-run/ctor-autorecover/main.pony
+++ b/test/libponyc-run/ctor-autorecover/main.pony
@@ -1,0 +1,12 @@
+actor Main
+  new create(env: Env) =>
+    Bar.take_foo(Foo(88))
+    let bar: Foo iso = Foo(88)
+
+class Foo
+  new create(v: U8) =>
+    None
+
+primitive Bar
+  fun take_foo(foo: Foo iso) =>
+    None

--- a/test/libponyc-run/ctor-autorecover/main.pony
+++ b/test/libponyc-run/ctor-autorecover/main.pony
@@ -1,10 +1,31 @@
 actor Main
   new create(env: Env) =>
-    Bar.take_foo(Foo(88))
-    let bar: Foo iso = Foo(88)
+    // zero-parameter constructor as argument and assignment
+    Bar.take_foo(Foo)
+    let qux: Foo iso = Foo
+
+    // sendable-parameter constructor as argument and assignment
+    Bar.take_foo(Foo.from_u8(88))
+    let bar: Foo iso = Foo.from_u8(88)
+
+    // non-sendable parameter ctor and assignment must fail
+    // see RecoverTest.CantAutoRecover_CtorArgWithNonSendableArg
+    // and RecoverTest.CantAutoRecover_CtorAssignmentWithNonSendableArg
+
+    //let s: String ref = String
+    //Bar.take_foo(Foo.from_str(s)) -> argument not assignable to parameter
+    //let baz: Foo iso = Foo.from_str(s) -> right side must be a subtype of left side
+
+    // verify that inheritance hasn't broken
+    let x = String
+    let y: String ref = x
 
 class Foo
-  new create(v: U8) =>
+  new create() =>
+    None
+  new ref from_u8(v: U8) =>
+    None
+  new ref from_str(s: String ref) =>
     None
 
 primitive Bar

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -738,3 +738,19 @@ TEST_F(RecoverTest, CanWriteTrn_TrnAutoRecovery)
 
   TEST_COMPILE(src);
 }
+TEST_F(RecoverTest, CanAutorecover_Newref)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.take_foo(Foo(88))\n"
+    "    let bar: Foo iso = Foo(88)\n"
+    "class Foo\n"
+    "  new create(v: U8) =>\n"
+    "    None\n"
+    "primitive Bar\n"
+    "  fun take_foo(foo: Foo iso) =>\n"
+    "    None\n";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -738,3 +738,43 @@ TEST_F(RecoverTest, CanWriteTrn_TrnAutoRecovery)
 
   TEST_COMPILE(src);
 }
+TEST_F(RecoverTest, CantAutoRecover_CtorArgWithNonSendableArg)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let s: String ref = String\n"
+    "    Bar.take_foo(Foo.from_str(s))\n"
+
+    "class Foo\n"
+    "  new from_u8(v: U8) =>\n"
+    "    None\n"
+    "  new from_str(s: String ref) =>\n"
+    "    None\n"
+
+    "primitive Bar\n"
+    "  fun take_foo(foo: Foo iso) =>\n"
+    "    None\n";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}
+TEST_F(RecoverTest, CantAutoRecover_CtorAssignmentWithNonSendableArg)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let s: String ref = String\n"
+    "    let bar: Foo iso = Foo.from_str(s)\n"
+
+    "class Foo\n"
+    "  new from_u8(v: U8) =>\n"
+    "    None\n"
+    "  new from_str(s: String ref) =>\n"
+    "    None\n"
+
+    "primitive Bar\n"
+    "  fun take_foo(foo: Foo iso) =>\n"
+    "    None\n";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -778,3 +778,22 @@ TEST_F(RecoverTest, CantAutoRecover_CtorAssignmentWithNonSendableArg)
 
   TEST_ERRORS_1(src, "right side must be a subtype of left side");
 }
+TEST_F(RecoverTest, CantAutoRecover_CtorParamToComplexTypeWithNonSendableArg)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let bar: (Foo iso | String ref) = Foo.from_u8(123)\n"
+
+    "class Foo\n"
+    "  new from_u8(v: U8) =>\n"
+    "    None\n"
+    "  new from_str(s: String ref) =>\n"
+    "    None\n"
+
+    "primitive Bar\n"
+    "  fun take_foo(foo: Foo iso) =>\n"
+    "    None\n";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -738,19 +738,3 @@ TEST_F(RecoverTest, CanWriteTrn_TrnAutoRecovery)
 
   TEST_COMPILE(src);
 }
-TEST_F(RecoverTest, CanAutorecover_Newref)
-{
-  const char* src =
-    "actor Main\n"
-    "  new create(env: Env) =>\n"
-    "    Bar.take_foo(Foo(88))\n"
-    "    let bar: Foo iso = Foo(88)\n"
-    "class Foo\n"
-    "  new create(v: U8) =>\n"
-    "    None\n"
-    "primitive Bar\n"
-    "  fun take_foo(foo: Foo iso) =>\n"
-    "    None\n";
-
-  TEST_COMPILE(src);
-}


### PR DESCRIPTION
This PR adds checks when assigning a constructor expression or passing one as a parameter to see if it can be auto-recovered, and if so, does not output a subtyping error.  E.g. for the following code:

```
actor Main
  new create(env: Env) =>
    Bar.take_foo(Foo(88))
    let bar: Foo iso = Foo(88)

class Foo
  new create(v: U8) =>
    None

primitive Bar
  fun take_foo(foo: Foo iso) =>
    None
```

We'd previously get errors on both lines in `Main.create()`; whereas with this PR they are now accepted.

Fixes #702