### PR TITLE
Fix for infinite Ranges

### DIFF
--- a/.release-notes/4127.md
+++ b/.release-notes/4127.md
@@ -1,0 +1,13 @@
+## Fix for infinite Ranges
+
+Even though all Range objects that contain NaN parameters are considered infinite, some did not iterate at all or produced an error after the first iteration. For example, the code from the Range documentation: 
+
+```pony
+  // this Range will produce 0 at first, then infinitely NaN
+  let nan: F64 = F64(0) / F64(0)
+  for what_am_i in Range[F64](0, 1000, nan) do
+    wild_guess(what_am_i)
+  end 
+```
+
+did in fact not run as expected, but prodcued an error on the first iteration. This is now fixed, and .next() calls on the above `Range[F64](0, 1000, nan)` now first yields 0 and subsequently indefinetely NaN values.

--- a/.release-notes/4127.md
+++ b/.release-notes/4127.md
@@ -1,6 +1,6 @@
 ## Fix for infinite Ranges
 
-Even though all Range objects that contain NaN parameters are considered infinite, some did not iterate at all or produced an error after the first iteration. For example, the code from the Range documentation: 
+Even though all Range objects that contain NaN parameters or a zero step parameter are considered infinite, some did not iterate at all or produced an error after the first iteration. For example, the code from the Range documentation: 
 
 ```pony
   // this Range will produce 0 at first, then infinitely NaN
@@ -10,4 +10,4 @@ Even though all Range objects that contain NaN parameters are considered infinit
   end 
 ```
 
-did not run as expected, but rather produced an error on the first iteration. This is now fixed, and .next() calls on the above `Range[F64](0, 1000, nan)` now first yields 0 and subsequently indefinetely NaN values.
+did not run as expected, but rather produced an error on the first iteration. This is now fixed, and .next() calls on the above `Range[F64](0, 1000, nan)` now first yields 0 and subsequently indefinetely NaN values. Likewise, `Range(10, 10, 0)` will now indefinitely yield `10`.

--- a/.release-notes/4127.md
+++ b/.release-notes/4127.md
@@ -10,4 +10,4 @@ Even though all Range objects that contain NaN parameters are considered infinit
   end 
 ```
 
-did in fact not run as expected, but prodcued an error on the first iteration. This is now fixed, and .next() calls on the above `Range[F64](0, 1000, nan)` now first yields 0 and subsequently indefinetely NaN values.
+did not run as expected, but rather produced an error on the first iteration. This is now fixed, and .next() calls on the above `Range[F64](0, 1000, nan)` now first yields 0 and subsequently indefinetely NaN values.

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -663,7 +663,17 @@ class \nodoc\ iso _TestRange is UnitTest
     let range: Range[N] = Range[N](min, max, step)
     let range_str = "Range(" + min.string() + ", " + max.string() + ", " + step.string() + ")"
 
-    h.assert_true(range.is_infinite(), range_str + " should be infinite")
+    h.assert_true(range.is_infinite(), range_str + " should be infinite")    
+    try
+      range.next()?
+    else
+      h.fail(range_str + ".next(): first call should not fail but should produce " + min.string())
+    end
+    try
+      range.next()?
+    else
+      h.fail(range_str + ".next(): subsequent call should not fail")
+    end
 
   fun _assert_range[N: (Real[N] val & Number)](
     h: TestHelper,

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -652,8 +652,6 @@ class \nodoc\ iso _TestRange is UnitTest
     _assert_infinite[F64](h, 0, 10, p_inf)
     _assert_infinite[F64](h, 100, 10, n_inf)
 
-
-
   fun _assert_infinite[N: (Real[N] val & Number)](
     h: TestHelper,
     min: N,
@@ -665,7 +663,8 @@ class \nodoc\ iso _TestRange is UnitTest
 
     h.assert_true(range.is_infinite(), range_str + " should be infinite")    
     try
-      range.next()?
+      let nextval = range.next()?
+      h.assert_eq[N](nextval, min)
     else
       h.fail(range_str + ".next(): first call should not fail but should produce " + min.string())
     end

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -93,11 +93,12 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
         or ((_min > _max) and (_inc > 0))
 
   fun has_next(): Bool =>
-    if _forward then
-      _idx < _max
-    else
-      _idx > _max
-    end
+    _infinite or
+      if _forward then
+        _idx < _max
+      else
+        _idx > _max
+      end
 
   fun ref next(): A ? =>
     if has_next() then

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -93,12 +93,14 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
         or ((_min > _max) and (_inc > 0))
 
   fun has_next(): Bool =>
-    _infinite or
-      if _forward then
-        _idx < _max
-      else
-        _idx > _max
-      end
+    if _infinite then
+      return true
+    end
+    if _forward then
+      _idx < _max
+    else
+      _idx > _max
+    end
 
   fun ref next(): A ? =>
     if has_next() then


### PR DESCRIPTION
The `has_next()` function in `Range` relies entirely on the variable `_forward` to decide whether or not another iteration exists. However, `_forward` is too narrowly defined to properly cover some or some `_infinite == true` cases. Currently some cases of `step` being 0 or NaN depending on `min > or < max` were broken (ie. not infinite)