### PR TITLE
Use hw.ncpu on macOS instead of nproc

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,9 +130,6 @@ task:
 
   name: "x86-64 Apple Darwin"
 
-  install_script:
-    - brew install coreutils
-
   libs_cache:
     folder: build/libs
     fingerprint_script: echo "`md5 lib/CMakeLists.txt` macos monterey-xcode-13.2 20210710"
@@ -162,9 +159,6 @@ task:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
 
   name: "arm64 Apple Darwin"
-
-  install_script:
-    - brew install coreutils
 
   libs_cache:
     folder: build/libs
@@ -409,7 +403,7 @@ task:
     - libs
 
   install_script:
-    - brew install coreutils python
+    - brew install python
     - pip3 install --upgrade cloudsmith-cli
 
   nightly_script:
@@ -439,7 +433,7 @@ task:
     - libs
 
   install_script:
-    - brew install coreutils python
+    - brew install python
     - pip3 install --upgrade cloudsmith-cli
 
   nightly_script:
@@ -608,7 +602,7 @@ task:
     - libs
 
   install_script:
-    - brew install coreutils python
+    - brew install python
     - pip3 install --upgrade cloudsmith-cli
 
   release_script:
@@ -638,7 +632,7 @@ task:
     - libs
 
   install_script:
-    - brew install coreutils python
+    - brew install python
     - pip3 install --upgrade cloudsmith-cli
 
   nightly_script:

--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ test-libponyc: all
 
 ifeq ($(shell uname -s),FreeBSD)
   num_cores := `sysctl -n hw.ncpu`
+else ifeq ($(shell uname -s),Darwin)
+  num_cores := `sysctl -n hw.ncpu`
 else
   num_cores := `nproc --all`
 endif


### PR DESCRIPTION
This doesn't hit us on CI since we install the `coreutils` package, which
installs `nproc` for us. If that isn't installed, however, this line will fail.
The appropriate substitute is the same as for FreeBSD.