### PR TITLE
Change `actor->muted` to no longer be atomic

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -19,7 +19,7 @@
 #define PONY_SCHED_BATCH 100
 
 // Ignore padding at the end of the type.
-pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
+pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t) + sizeof(size_t)) ==
    sizeof(pony_actor_pad_t), "Wrong actor pad size!");
 
 static bool actor_noblock = false;
@@ -325,7 +325,7 @@ static bool maybe_mute(pony_actor_t* actor)
   //   a behavior.
   //   2. We should bail out from running the actor and return false so that
   //   it won't be rescheduled.
-  if(atomic_load_explicit(&actor->muted, memory_order_acquire) > 0)
+  if(actor->muted > 0)
   {
     ponyint_mute_actor(actor);
     return true;

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -32,13 +32,13 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
-  PONY_ATOMIC(size_t) muted;
   PONY_ATOMIC(uint8_t) flags;
   PONY_ATOMIC(uint8_t) is_muted;
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes
   gc_t gc; // 48/88 bytes
+  size_t muted; // 4/8 bytes
 } pony_actor_t;
 
 /** Padding for actor types.
@@ -46,19 +46,20 @@ typedef struct pony_actor_t
  * 56 bytes: initial header, not including the type descriptor
  * 52/104 bytes: heap
  * 48/88 bytes: gc
- * 28/0 bytes: padding to 64 bytes, ignored
+ * 4/8 bytes: muted counter
+ * 24/56 bytes: padding to 64 bytes, ignored
  */
 #if INTPTR_MAX == INT64_MAX
 #ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 280
+#  define PONY_ACTOR_PAD_SIZE 288
 #else
-#  define PONY_ACTOR_PAD_SIZE 248
+#  define PONY_ACTOR_PAD_SIZE 256
 #endif
 #elif INTPTR_MAX == INT32_MAX
 #ifdef USE_MEMTRACK
-#  define PONY_ACTOR_PAD_SIZE 176
+#  define PONY_ACTOR_PAD_SIZE 180
 #else
-#  define PONY_ACTOR_PAD_SIZE 160
+#  define PONY_ACTOR_PAD_SIZE 164
 #endif
 #endif
 

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1411,7 +1411,7 @@ void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* rec
     int64_t old_mset_alloc_size = ponyint_muteset_alloc_size(&mref->value);
 #endif
     ponyint_muteset_putindex(&mref->value, sender, index2);
-    sender->muted--;
+    sender->muted++;
 #ifdef USE_MEMTRACK
     int64_t new_mset_mem_size = ponyint_muteset_mem_size(&mref->value);
     int64_t new_mset_alloc_size = ponyint_muteset_alloc_size(&mref->value);

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1411,7 +1411,7 @@ void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* rec
     int64_t old_mset_alloc_size = ponyint_muteset_alloc_size(&mref->value);
 #endif
     ponyint_muteset_putindex(&mref->value, sender, index2);
-    atomic_fetch_add_explicit(&sender->muted, 1, memory_order_acq_rel);
+    sender->muted--;
 #ifdef USE_MEMTRACK
     int64_t new_mset_mem_size = ponyint_muteset_mem_size(&mref->value);
     int64_t new_mset_alloc_size = ponyint_muteset_alloc_size(&mref->value);
@@ -1467,7 +1467,8 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
     {
       // This is safe because an actor can only ever be in a single scheduler's
       // mutemap
-      size_t muted_count = atomic_fetch_sub_explicit(&muted->muted, 1, memory_order_acq_rel);
+      size_t muted_count = muted->muted;
+      muted->muted--;
       pony_assert(muted_count > 0);
 
       // If muted_count used to be 1 before we decremented it; then the actor

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1467,9 +1467,8 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
     {
       // This is safe because an actor can only ever be in a single scheduler's
       // mutemap
-      size_t muted_count = muted->muted;
+      pony_assert(muted->muted > 0);
       muted->muted--;
-      pony_assert(muted_count > 0);
 
       // If muted_count used to be 1 before we decremented it; then the actor
       // is longer muted

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1470,9 +1470,9 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
       pony_assert(muted->muted > 0);
       muted->muted--;
 
-      // If muted_count used to be 1 before we decremented it; then the actor
+      // If muted->muted is 0 after we decremented it; then the actor
       // is longer muted
-      if(muted_count == 1)
+      if(muted->muted == 0)
       {
         needs_unmuting = ponyint_actorstack_push(needs_unmuting, muted);
       }


### PR DESCRIPTION
`actor->muted` is only ever referenced from a single scheduler thread.
Either while a scheduler is running an actor or if an actor is muted
and in the scheduler's mutemap.

This commit changes `actor->muted` from being an atomic size_t to being a
regular old size_t.