### PR TITLE
Upgrade Alpine version used for CI to 3.16

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 RUN apk update \
   && apk upgrade \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,9 +15,9 @@ task:
       IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20220426
   - name: "x86-64 Linux musl"
     container:
-      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
     environment:
-      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
 
   container:
     cpu: 8
@@ -324,9 +324,9 @@ task:
         TRIPLE_OS: linux-ubuntu22.04
     - name: "nightly: x86-64-unknown-linux-musl"
       container:
-        image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
       environment:
-        CACHE_BUSTER: 20210224
+        CACHE_BUSTER: 20220611
         TRIPLE_VENDOR: unknown
         TRIPLE_OS: linux-musl
 
@@ -698,15 +698,15 @@ task:
       - "Stress Test: x86-64-unknown-linux-ubuntu22.04 [release]"
   - name: "Stress Test: x86-64-unknown-linux-musl [release]"
     container:
-      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
     environment:
-      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
       TARGET: test-stress-release
   - name: "Stress Test: x86-64-unknown-linux-musl [debug]"
     container:
-      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
     environment:
-      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
       TARGET: test-stress-debug
     depends_on:
       - "Stress Test: x86-64-unknown-linux-musl [release]"
@@ -726,15 +726,15 @@ task:
       - "Stress Test: x86-64-unknown-linux-ubuntu22.04 [cd] [release]"
   - name: "Stress Test: x86-64-unknown-linux-musl [cd] [release]"
     container:
-      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
     environment:
-      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
       TARGET: test-stress-with-cd-release
   - name: "Stress Test: x86-64-unknown-linux-musl [cd] [debug]"
     container:
-      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
     environment:
-      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20210420
+      IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20220611
       TARGET: test-stress-with-cd-debug
     depends_on:
       - "Stress Test: x86-64-unknown-linux-musl [cd] [release]"


### PR DESCRIPTION
We were using 3.12 which reached end of life on May 1st of this year.
This gets up to using the newest alpine release that will be supported
until May of 2024.

If this all passes CI and stress tests run as usual, I'll open a
PR to update the user facing Alpine based images.