### PR TITLE
Remove `actor->is_muted` and replace with a flag

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -24,6 +24,23 @@ pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
 
 static bool actor_noblock = false;
 
+enum
+{
+  FLAG_BLOCKED = 1 << 0,
+  FLAG_BLOCKED_SENT = 1 << 1,
+  FLAG_SYSTEM = 1 << 2,
+  FLAG_UNSCHEDULED = 1 << 3,
+  FLAG_CD_CONTACTED = 1 << 4,
+};
+
+enum
+{
+  SYNC_FLAG_PENDINGDESTROY = 1 << 0,
+  SYNC_FLAG_OVERLOADED = 1 << 1,
+  SYNC_FLAG_UNDER_PRESSURE = 1 << 2,
+  SYNC_FLAG_MUTED = 1 << 3,
+};
+
 // The sync flags of a given actor cannot be mutated from more than one actor at
 // once, so these operations need not be atomic RMW.
 static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
@@ -47,7 +64,7 @@ static void unset_sync_flag(pony_actor_t* actor, uint8_t flag)
 
 // The internal flags of a given actor are only ever read or written by a
 // single scheduler at a time and so need not be synchronization safe (atomics).
-bool has_internal_flag(pony_actor_t* actor, uint8_t flag)
+static bool has_internal_flag(pony_actor_t* actor, uint8_t flag)
 {
   return (actor->internal_flags & flag) != 0;
 }
@@ -60,6 +77,91 @@ static void set_internal_flag(pony_actor_t* actor, uint8_t flag)
 static void unset_internal_flag(pony_actor_t* actor, uint8_t flag)
 {
   actor->internal_flags = actor->internal_flags & (uint8_t)~flag;
+}
+
+//
+// Mute/Unmute/Check mute status functions
+//
+// For backpressure related muting and unmuting to work correctly, the following
+// rules have to be maintained.
+//
+// 1. Across schedulers, an actor should never been seen as muted when it is not
+// in fact muted.
+// 2. It's ok for a muted actor to be seen as unmuted in a transient fashion
+// across actors
+//
+// If rule #1 is violated, we might end up deadlocking because an actor was
+// muted for sending to an actor that might never be unmuted (because it isn't
+// muted). The actor muted actor would continue to remain muted and the actor
+// incorrectly seen as muted became actually muted and then unmuted.
+//
+// If rule #2 is violated, then a muted actor will receive from 1 to a few
+// additional messages and the sender won't be muted. As this is a transient
+// situtation that should be shortly rectified, there's no harm done.
+//
+// Our handling of atomic operations in `is_muted`, `mute_actor`
+// and `unmute_actor` are to assure that both rules aren't violated.
+
+static bool is_muted(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_MUTED);
+}
+
+static void mute_actor(pony_actor_t* actor)
+{
+  set_sync_flag(actor, SYNC_FLAG_MUTED);
+  DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
+}
+
+void ponyint_unmute_actor(pony_actor_t* actor)
+{
+  unset_sync_flag(actor, SYNC_FLAG_MUTED);
+  DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
+}
+
+static bool triggers_muting(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
+    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
+    is_muted(actor);
+}
+
+static void actor_setoverloaded(pony_actor_t* actor)
+{
+  pony_assert(!ponyint_is_cycle(actor));
+  set_sync_flag(actor, SYNC_FLAG_OVERLOADED);
+  DTRACE1(ACTOR_OVERLOADED, (uintptr_t)actor);
+}
+
+static void actor_unsetoverloaded(pony_actor_t* actor)
+{
+  pony_ctx_t* ctx = pony_ctx();
+  unset_sync_flag(actor, SYNC_FLAG_OVERLOADED);
+  DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
+  if (!has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE))
+  {
+    ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
+  }
+}
+
+static void maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
+{
+  if(ctx->current != NULL)
+  {
+    // only mute a sender IF:
+    // 1. the receiver is overloaded/under pressure/muted
+    // AND
+    // 2. the sender isn't overloaded or under pressure
+    // AND
+    // 3. we are sending to another actor (as compared to sending to self)
+    if(triggers_muting(to) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
+       ctx->current != to)
+    {
+      ponyint_sched_mute(ctx, ctx->current, to);
+    }
+  }
 }
 
 #ifndef PONY_NDEBUG
@@ -320,36 +422,6 @@ static void try_gc(pony_ctx_t* ctx, pony_actor_t* actor)
   DTRACE1(GC_END, (uintptr_t)ctx->scheduler);
 }
 
-// return true if mute occurs
-static bool maybe_mute(pony_actor_t* actor)
-{
-  // if we become muted as a result of handling a message, bail out now.
-  // we aren't set to "muted" at this point. setting to muted during a
-  // a behavior can lead to race conditions that might result in a
-  // deadlock.
-  // Given that actor's are not run when they are muted, then when we
-  // started out batch, actor->muted would have been 0. If any of our
-  // message sends would result in the actor being muted, that value will
-  // have changed to greater than 0.
-  //
-  // We will then set the actor to "muted". Once set, any actor sending
-  // a message to it will be also be muted unless said sender is marked
-  // as overloaded.
-  //
-  // The key points here is that:
-  //   1. We can't set the actor to "muted" until after its finished running
-  //   a behavior.
-  //   2. We should bail out from running the actor and return false so that
-  //   it won't be rescheduled.
-  if(actor->muted > 0)
-  {
-    ponyint_mute_actor(actor);
-    return true;
-  }
-
-  return false;
-}
-
 static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 {
   if(!has_sync_flag(actor, SYNC_FLAG_OVERLOADED) && !polling)
@@ -358,7 +430,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
     // only if we're not polling from C code.
     // Overloaded actors are allowed to send to other overloaded actors
     // and to muted actors without being muted themselves.
-    ponyint_actor_setoverloaded(actor);
+    actor_setoverloaded(actor);
   }
 
   return true;
@@ -366,7 +438,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
-  pony_assert(!ponyint_is_muted(actor));
+  pony_assert(!is_muted(actor));
   ctx->current = actor;
   size_t batch = PONY_SCHED_BATCH;
 
@@ -388,9 +460,29 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
       app++;
       try_gc(ctx, actor);
 
-      // maybe mute actor; returns true if mute occurs
-      if(maybe_mute(actor))
+      // if we become muted as a result of handling a message, bail out now.
+      // we aren't set to "muted" at this point. setting to muted during a
+      // a behavior can lead to race conditions that might result in a
+      // deadlock.
+      // Given that actor's are not run when they are muted, then when we
+      // started out batch, actor->muted would have been 0. If any of our
+      // message sends would result in the actor being muted, that value will
+      // have changed to greater than 0.
+      //
+      // We will then set the actor to "muted". Once set, any actor sending
+      // a message to it will be also be muted unless said sender is marked
+      // as overloaded.
+      //
+      // The key points here is that:
+      //   1. We can't set the actor to "muted" until after its finished running
+      //   a behavior.
+      //   2. We should bail out from running the actor and return false so that
+      //   it won't be rescheduled.
+      if(actor->muted > 0)
+      {
+        mute_actor(actor);
         return false;
+      }
 
       // if we've reached our batch limit
       // or if we're polling where we want to stop after one app message
@@ -407,7 +499,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   // We didn't hit our app message batch limit. We now believe our queue to be
   // empty, but we may have received further messages.
   pony_assert(app < batch);
-  pony_assert(!ponyint_is_muted(actor));
+  pony_assert(!is_muted(actor));
 
   if(has_sync_flag(actor, SYNC_FLAG_OVERLOADED))
   {
@@ -416,7 +508,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
     // 1- sending to this actor is no longer grounds for an actor being muted
     // 2- this actor can no longer send to other actors free from muting should
     //    the receiver be overloaded or muted
-    ponyint_actor_unsetoverloaded(actor);
+    actor_unsetoverloaded(actor);
   }
 
   try_gc(ctx, actor);
@@ -776,7 +868,7 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   }
 
   if(has_app_msg)
-    ponyint_maybe_mute(ctx, to);
+    maybe_mute(ctx, to);
 
   if(ponyint_actor_messageq_push(&to->q, first, last
 #ifdef USE_DYNAMIC_TRACE
@@ -819,7 +911,7 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   }
 
   if(has_app_msg)
-    ponyint_maybe_mute(ctx, to);
+    maybe_mute(ctx, to);
 
   if(ponyint_actor_messageq_push_single(&to->q, first, last
 #ifdef USE_DYNAMIC_TRACE
@@ -832,26 +924,6 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
       // if the receiving actor is currently not unscheduled AND it's not
       // muted, schedule it.
       ponyint_sched_add(ctx, to);
-    }
-  }
-}
-
-void ponyint_maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
-{
-  if(ctx->current != NULL)
-  {
-    // only mute a sender IF:
-    // 1. the receiver is overloaded/under pressure/muted
-    // AND
-    // 2. the sender isn't overloaded or under pressure
-    // AND
-    // 3. we are sending to another actor (as compared to sending to self)
-    if(ponyint_triggers_muting(to) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
-       ctx->current != to)
-    {
-      ponyint_sched_mute(ctx, ctx->current, to);
     }
   }
 }
@@ -980,29 +1052,6 @@ PONY_API void pony_poll(pony_ctx_t* ctx)
   ponyint_actor_run(ctx, ctx->current, true);
 }
 
-void ponyint_actor_setoverloaded(pony_actor_t* actor)
-{
-  pony_assert(!ponyint_is_cycle(actor));
-  set_sync_flag(actor, SYNC_FLAG_OVERLOADED);
-  DTRACE1(ACTOR_OVERLOADED, (uintptr_t)actor);
-}
-
-bool ponyint_actor_overloaded(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED);
-}
-
-void ponyint_actor_unsetoverloaded(pony_actor_t* actor)
-{
-  pony_ctx_t* ctx = pony_ctx();
-  unset_sync_flag(actor, SYNC_FLAG_OVERLOADED);
-  DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
-  if (!has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE))
-  {
-    ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
-  }
-}
-
 PONY_API void pony_apply_backpressure()
 {
   pony_ctx_t* ctx = pony_ctx();
@@ -1017,53 +1066,6 @@ PONY_API void pony_release_backpressure()
   DTRACE1(ACTOR_PRESSURE_RELEASED, (uintptr_t)ctx->current);
   if (!has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED))
     ponyint_sched_start_global_unmute(ctx->scheduler->index, ctx->current);
-}
-
-bool ponyint_triggers_muting(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
-    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
-    ponyint_is_muted(actor);
-}
-
-//
-// Mute/Unmute/Check mute status functions
-//
-// For backpressure related muting and unmuting to work correctly, the following
-// rules have to be maintained.
-//
-// 1. Across schedulers, an actor should never been seen as muted when it is not
-// in fact muted.
-// 2. It's ok for a muted actor to be seen as unmuted in a transient fashion
-// across actors
-//
-// If rule #1 is violated, we might end up deadlocking because an actor was
-// muted for sending to an actor that might never be unmuted (because it isn't
-// muted). The actor muted actor would continue to remain muted and the actor
-// incorrectly seen as muted became actually muted and then unmuted.
-//
-// If rule #2 is violated, then a muted actor will receive from 1 to a few
-// additional messages and the sender won't be muted. As this is a transient
-// situtation that should be shortly rectified, there's no harm done.
-//
-// Our handling of atomic operations in `ponyint_is_muted`, `ponyint_mute_actor`
-// and `ponyint_unmute_actor` are to assure that both rules aren't violated.
-
-bool ponyint_is_muted(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_MUTED);
-}
-
-void ponyint_mute_actor(pony_actor_t* actor)
-{
-  set_sync_flag(actor, SYNC_FLAG_MUTED);
-  DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
-}
-
-void ponyint_unmute_actor(pony_actor_t* actor)
-{
-  unset_sync_flag(actor, SYNC_FLAG_MUTED);
-  DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
 }
 
 #ifdef USE_MEMTRACK

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -24,23 +24,6 @@ pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
 
 static bool actor_noblock = false;
 
-enum
-{
-  FLAG_BLOCKED = 1 << 0,
-  FLAG_BLOCKED_SENT = 1 << 1,
-  FLAG_SYSTEM = 1 << 2,
-  FLAG_UNSCHEDULED = 1 << 3,
-  FLAG_CD_CONTACTED = 1 << 4,
-};
-
-enum
-{
-  SYNC_FLAG_PENDINGDESTROY = 1 << 0,
-  SYNC_FLAG_OVERLOADED = 1 << 1,
-  SYNC_FLAG_UNDER_PRESSURE = 1 << 2,
-  SYNC_FLAG_MUTED = 1 << 3,
-};
-
 // The sync flags of a given actor cannot be mutated from more than one actor at
 // once, so these operations need not be atomic RMW.
 static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
@@ -64,7 +47,7 @@ static void unset_sync_flag(pony_actor_t* actor, uint8_t flag)
 
 // The internal flags of a given actor are only ever read or written by a
 // single scheduler at a time and so need not be synchronization safe (atomics).
-static bool has_internal_flag(pony_actor_t* actor, uint8_t flag)
+bool has_internal_flag(pony_actor_t* actor, uint8_t flag)
 {
   return (actor->internal_flags & flag) != 0;
 }
@@ -77,91 +60,6 @@ static void set_internal_flag(pony_actor_t* actor, uint8_t flag)
 static void unset_internal_flag(pony_actor_t* actor, uint8_t flag)
 {
   actor->internal_flags = actor->internal_flags & (uint8_t)~flag;
-}
-
-//
-// Mute/Unmute/Check mute status functions
-//
-// For backpressure related muting and unmuting to work correctly, the following
-// rules have to be maintained.
-//
-// 1. Across schedulers, an actor should never been seen as muted when it is not
-// in fact muted.
-// 2. It's ok for a muted actor to be seen as unmuted in a transient fashion
-// across actors
-//
-// If rule #1 is violated, we might end up deadlocking because an actor was
-// muted for sending to an actor that might never be unmuted (because it isn't
-// muted). The actor muted actor would continue to remain muted and the actor
-// incorrectly seen as muted became actually muted and then unmuted.
-//
-// If rule #2 is violated, then a muted actor will receive from 1 to a few
-// additional messages and the sender won't be muted. As this is a transient
-// situtation that should be shortly rectified, there's no harm done.
-//
-// Our handling of atomic operations in `is_muted`, `mute_actor`
-// and `unmute_actor` are to assure that both rules aren't violated.
-
-static bool is_muted(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_MUTED);
-}
-
-static void mute_actor(pony_actor_t* actor)
-{
-  set_sync_flag(actor, SYNC_FLAG_MUTED);
-  DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
-}
-
-void ponyint_unmute_actor(pony_actor_t* actor)
-{
-  unset_sync_flag(actor, SYNC_FLAG_MUTED);
-  DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
-}
-
-static bool triggers_muting(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
-    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
-    is_muted(actor);
-}
-
-static void actor_setoverloaded(pony_actor_t* actor)
-{
-  pony_assert(!ponyint_is_cycle(actor));
-  set_sync_flag(actor, SYNC_FLAG_OVERLOADED);
-  DTRACE1(ACTOR_OVERLOADED, (uintptr_t)actor);
-}
-
-static void actor_unsetoverloaded(pony_actor_t* actor)
-{
-  pony_ctx_t* ctx = pony_ctx();
-  unset_sync_flag(actor, SYNC_FLAG_OVERLOADED);
-  DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
-  if (!has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE))
-  {
-    ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
-  }
-}
-
-static void maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
-{
-  if(ctx->current != NULL)
-  {
-    // only mute a sender IF:
-    // 1. the receiver is overloaded/under pressure/muted
-    // AND
-    // 2. the sender isn't overloaded or under pressure
-    // AND
-    // 3. we are sending to another actor (as compared to sending to self)
-    if(triggers_muting(to) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
-       ctx->current != to)
-    {
-      ponyint_sched_mute(ctx, ctx->current, to);
-    }
-  }
 }
 
 #ifndef PONY_NDEBUG
@@ -422,6 +320,36 @@ static void try_gc(pony_ctx_t* ctx, pony_actor_t* actor)
   DTRACE1(GC_END, (uintptr_t)ctx->scheduler);
 }
 
+// return true if mute occurs
+static bool maybe_mute(pony_actor_t* actor)
+{
+  // if we become muted as a result of handling a message, bail out now.
+  // we aren't set to "muted" at this point. setting to muted during a
+  // a behavior can lead to race conditions that might result in a
+  // deadlock.
+  // Given that actor's are not run when they are muted, then when we
+  // started out batch, actor->muted would have been 0. If any of our
+  // message sends would result in the actor being muted, that value will
+  // have changed to greater than 0.
+  //
+  // We will then set the actor to "muted". Once set, any actor sending
+  // a message to it will be also be muted unless said sender is marked
+  // as overloaded.
+  //
+  // The key points here is that:
+  //   1. We can't set the actor to "muted" until after its finished running
+  //   a behavior.
+  //   2. We should bail out from running the actor and return false so that
+  //   it won't be rescheduled.
+  if(actor->muted > 0)
+  {
+    ponyint_mute_actor(actor);
+    return true;
+  }
+
+  return false;
+}
+
 static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 {
   if(!has_sync_flag(actor, SYNC_FLAG_OVERLOADED) && !polling)
@@ -430,7 +358,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
     // only if we're not polling from C code.
     // Overloaded actors are allowed to send to other overloaded actors
     // and to muted actors without being muted themselves.
-    actor_setoverloaded(actor);
+    ponyint_actor_setoverloaded(actor);
   }
 
   return true;
@@ -438,7 +366,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
-  pony_assert(!is_muted(actor));
+  pony_assert(!ponyint_is_muted(actor));
   ctx->current = actor;
   size_t batch = PONY_SCHED_BATCH;
 
@@ -460,29 +388,9 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
       app++;
       try_gc(ctx, actor);
 
-      // if we become muted as a result of handling a message, bail out now.
-      // we aren't set to "muted" at this point. setting to muted during a
-      // a behavior can lead to race conditions that might result in a
-      // deadlock.
-      // Given that actor's are not run when they are muted, then when we
-      // started out batch, actor->muted would have been 0. If any of our
-      // message sends would result in the actor being muted, that value will
-      // have changed to greater than 0.
-      //
-      // We will then set the actor to "muted". Once set, any actor sending
-      // a message to it will be also be muted unless said sender is marked
-      // as overloaded.
-      //
-      // The key points here is that:
-      //   1. We can't set the actor to "muted" until after its finished running
-      //   a behavior.
-      //   2. We should bail out from running the actor and return false so that
-      //   it won't be rescheduled.
-      if(actor->muted > 0)
-      {
-        mute_actor(actor);
+      // maybe mute actor; returns true if mute occurs
+      if(maybe_mute(actor))
         return false;
-      }
 
       // if we've reached our batch limit
       // or if we're polling where we want to stop after one app message
@@ -499,7 +407,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   // We didn't hit our app message batch limit. We now believe our queue to be
   // empty, but we may have received further messages.
   pony_assert(app < batch);
-  pony_assert(!is_muted(actor));
+  pony_assert(!ponyint_is_muted(actor));
 
   if(has_sync_flag(actor, SYNC_FLAG_OVERLOADED))
   {
@@ -508,7 +416,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
     // 1- sending to this actor is no longer grounds for an actor being muted
     // 2- this actor can no longer send to other actors free from muting should
     //    the receiver be overloaded or muted
-    actor_unsetoverloaded(actor);
+    ponyint_actor_unsetoverloaded(actor);
   }
 
   try_gc(ctx, actor);
@@ -868,7 +776,7 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   }
 
   if(has_app_msg)
-    maybe_mute(ctx, to);
+    ponyint_maybe_mute(ctx, to);
 
   if(ponyint_actor_messageq_push(&to->q, first, last
 #ifdef USE_DYNAMIC_TRACE
@@ -911,7 +819,7 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   }
 
   if(has_app_msg)
-    maybe_mute(ctx, to);
+    ponyint_maybe_mute(ctx, to);
 
   if(ponyint_actor_messageq_push_single(&to->q, first, last
 #ifdef USE_DYNAMIC_TRACE
@@ -924,6 +832,26 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
       // if the receiving actor is currently not unscheduled AND it's not
       // muted, schedule it.
       ponyint_sched_add(ctx, to);
+    }
+  }
+}
+
+void ponyint_maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
+{
+  if(ctx->current != NULL)
+  {
+    // only mute a sender IF:
+    // 1. the receiver is overloaded/under pressure/muted
+    // AND
+    // 2. the sender isn't overloaded or under pressure
+    // AND
+    // 3. we are sending to another actor (as compared to sending to self)
+    if(ponyint_triggers_muting(to) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
+       ctx->current != to)
+    {
+      ponyint_sched_mute(ctx, ctx->current, to);
     }
   }
 }
@@ -1052,6 +980,29 @@ PONY_API void pony_poll(pony_ctx_t* ctx)
   ponyint_actor_run(ctx, ctx->current, true);
 }
 
+void ponyint_actor_setoverloaded(pony_actor_t* actor)
+{
+  pony_assert(!ponyint_is_cycle(actor));
+  set_sync_flag(actor, SYNC_FLAG_OVERLOADED);
+  DTRACE1(ACTOR_OVERLOADED, (uintptr_t)actor);
+}
+
+bool ponyint_actor_overloaded(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED);
+}
+
+void ponyint_actor_unsetoverloaded(pony_actor_t* actor)
+{
+  pony_ctx_t* ctx = pony_ctx();
+  unset_sync_flag(actor, SYNC_FLAG_OVERLOADED);
+  DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
+  if (!has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE))
+  {
+    ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
+  }
+}
+
 PONY_API void pony_apply_backpressure()
 {
   pony_ctx_t* ctx = pony_ctx();
@@ -1066,6 +1017,53 @@ PONY_API void pony_release_backpressure()
   DTRACE1(ACTOR_PRESSURE_RELEASED, (uintptr_t)ctx->current);
   if (!has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED))
     ponyint_sched_start_global_unmute(ctx->scheduler->index, ctx->current);
+}
+
+bool ponyint_triggers_muting(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
+    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
+    ponyint_is_muted(actor);
+}
+
+//
+// Mute/Unmute/Check mute status functions
+//
+// For backpressure related muting and unmuting to work correctly, the following
+// rules have to be maintained.
+//
+// 1. Across schedulers, an actor should never been seen as muted when it is not
+// in fact muted.
+// 2. It's ok for a muted actor to be seen as unmuted in a transient fashion
+// across actors
+//
+// If rule #1 is violated, we might end up deadlocking because an actor was
+// muted for sending to an actor that might never be unmuted (because it isn't
+// muted). The actor muted actor would continue to remain muted and the actor
+// incorrectly seen as muted became actually muted and then unmuted.
+//
+// If rule #2 is violated, then a muted actor will receive from 1 to a few
+// additional messages and the sender won't be muted. As this is a transient
+// situtation that should be shortly rectified, there's no harm done.
+//
+// Our handling of atomic operations in `ponyint_is_muted`, `ponyint_mute_actor`
+// and `ponyint_unmute_actor` are to assure that both rules aren't violated.
+
+bool ponyint_is_muted(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_MUTED);
+}
+
+void ponyint_mute_actor(pony_actor_t* actor)
+{
+  set_sync_flag(actor, SYNC_FLAG_MUTED);
+  DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
+}
+
+void ponyint_unmute_actor(pony_actor_t* actor)
+{
+  unset_sync_flag(actor, SYNC_FLAG_MUTED);
+  DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
 }
 
 #ifdef USE_MEMTRACK

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -43,15 +43,10 @@ enum
 
 // The sync flags of a given actor cannot be mutated from more than one actor at
 // once, so these operations need not be atomic RMW.
-static bool has_sync_flag_any(pony_actor_t* actor, uint8_t check_flags)
-{
-  uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
-  return (flags & check_flags) != 0;
-}
-
 static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
 {
-  return has_sync_flag_any(actor, flag);
+  uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
+  return (flags & flag) != 0;
 }
 
 static void set_sync_flag(pony_actor_t* actor, uint8_t flag)
@@ -104,8 +99,13 @@ static void unset_internal_flag(pony_actor_t* actor, uint8_t flag)
 // additional messages and the sender won't be muted. As this is a transient
 // situtation that should be shortly rectified, there's no harm done.
 //
-// Our handling of atomic operations in `mute_actor`
+// Our handling of atomic operations in `is_muted`, `mute_actor`
 // and `unmute_actor` are to assure that both rules aren't violated.
+
+static bool is_muted(pony_actor_t* actor)
+{
+  return has_sync_flag(actor, SYNC_FLAG_MUTED);
+}
 
 static void mute_actor(pony_actor_t* actor)
 {
@@ -121,8 +121,9 @@ void ponyint_unmute_actor(pony_actor_t* actor)
 
 static bool triggers_muting(pony_actor_t* actor)
 {
-  return has_sync_flag_any(actor, SYNC_FLAG_OVERLOADED |
-    SYNC_FLAG_UNDER_PRESSURE | SYNC_FLAG_MUTED);
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
+    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
+    is_muted(actor);
 }
 
 static void actor_setoverloaded(pony_actor_t* actor)
@@ -154,9 +155,9 @@ static void maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
     // AND
     // 3. we are sending to another actor (as compared to sending to self)
     if(triggers_muting(to) &&
-      !has_sync_flag_any(ctx->current, SYNC_FLAG_OVERLOADED |
-        SYNC_FLAG_UNDER_PRESSURE) &&
-      ctx->current != to)
+       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
+       ctx->current != to)
     {
       ponyint_sched_mute(ctx, ctx->current, to);
     }
@@ -437,7 +438,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
-  pony_assert(!has_sync_flag(actor, SYNC_FLAG_MUTED));
+  pony_assert(!is_muted(actor));
   ctx->current = actor;
   size_t batch = PONY_SCHED_BATCH;
 
@@ -498,7 +499,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   // We didn't hit our app message batch limit. We now believe our queue to be
   // empty, but we may have received further messages.
   pony_assert(app < batch);
-  pony_assert(!has_sync_flag(actor, SYNC_FLAG_MUTED));
+  pony_assert(!is_muted(actor));
 
   if(has_sync_flag(actor, SYNC_FLAG_OVERLOADED))
   {

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -19,31 +19,47 @@
 #define PONY_SCHED_BATCH 100
 
 // Ignore padding at the end of the type.
-pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t) + sizeof(size_t)) ==
+pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
    sizeof(pony_actor_pad_t), "Wrong actor pad size!");
 
 static bool actor_noblock = false;
 
-// The flags of a given actor cannot be mutated from more than one actor at
+// The sync flags of a given actor cannot be mutated from more than one actor at
 // once, so these operations need not be atomic RMW.
-
-bool has_flag(pony_actor_t* actor, uint16_t flag)
+static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
 {
-  uint16_t flags = atomic_load_explicit(&actor->flags, memory_order_relaxed);
+  uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
   return (flags & flag) != 0;
 }
 
-static void set_flag(pony_actor_t* actor, uint16_t flag)
+static void set_sync_flag(pony_actor_t* actor, uint8_t flag)
 {
-  uint16_t flags = atomic_load_explicit(&actor->flags, memory_order_relaxed);
-  atomic_store_explicit(&actor->flags, flags | flag, memory_order_relaxed);
+  uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
+  atomic_store_explicit(&actor->sync_flags, flags | flag, memory_order_release);
 }
 
-static void unset_flag(pony_actor_t* actor, uint16_t flag)
+static void unset_sync_flag(pony_actor_t* actor, uint8_t flag)
 {
-  uint16_t flags = atomic_load_explicit(&actor->flags, memory_order_relaxed);
-  atomic_store_explicit(&actor->flags, flags & (uint16_t)~flag,
-    memory_order_relaxed);
+  uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
+  atomic_store_explicit(&actor->sync_flags, flags & (uint8_t)~flag,
+    memory_order_release);
+}
+
+// The internal flags of a given actor are only ever read or written by a
+// single scheduler at a time and so need not be synchronization safe (atomics).
+bool has_internal_flag(pony_actor_t* actor, uint8_t flag)
+{
+  return (actor->internal_flags & flag) != 0;
+}
+
+static void set_internal_flag(pony_actor_t* actor, uint8_t flag)
+{
+  actor->internal_flags = actor->internal_flags | flag;
+}
+
+static void unset_internal_flag(pony_actor_t* actor, uint8_t flag)
+{
+  actor->internal_flags = actor->internal_flags & (uint8_t)~flag;
 }
 
 #ifndef PONY_NDEBUG
@@ -86,7 +102,7 @@ static bool well_formed_msg_chain(pony_msg_t* first, pony_msg_t* last)
 static void send_unblock(pony_actor_t* actor)
 {
   // Send unblock before continuing.
-  unset_flag(actor, FLAG_BLOCKED | FLAG_BLOCKED_SENT);
+  unset_internal_flag(actor, FLAG_BLOCKED | FLAG_BLOCKED_SENT);
   ponyint_cycle_unblock(actor);
 }
 
@@ -117,7 +133,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
 #endif
 
       if(ponyint_gc_acquire(&actor->gc, (actorref_t*)m->p) &&
-        has_flag(actor, FLAG_BLOCKED_SENT))
+        has_internal_flag(actor, FLAG_BLOCKED_SENT))
       {
         // send unblock if we've sent a block
         send_unblock(actor);
@@ -144,7 +160,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
 #endif
 
       if(ponyint_gc_release(&actor->gc, (actorref_t*)m->p) &&
-        has_flag(actor, FLAG_BLOCKED_SENT))
+        has_internal_flag(actor, FLAG_BLOCKED_SENT))
       {
         // send unblock if we've sent a block
         send_unblock(actor);
@@ -174,7 +190,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
 #endif
 
       pony_assert(!ponyint_is_cycle(actor));
-      if(has_flag(actor, FLAG_BLOCKED_SENT))
+      if(has_internal_flag(actor, FLAG_BLOCKED_SENT))
       {
         // We've sent a block message, send confirm.
         pony_msgi_t* m = (pony_msgi_t*)msg;
@@ -198,8 +214,8 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
       pony_assert(!ponyint_actor_pendingdestroy(actor));
 
       pony_assert(!ponyint_is_cycle(actor));
-      if(has_flag(actor, FLAG_BLOCKED)
-        && !has_flag(actor, FLAG_BLOCKED_SENT)
+      if(has_internal_flag(actor, FLAG_BLOCKED)
+        && !has_internal_flag(actor, FLAG_BLOCKED_SENT)
         && (actor->gc.rc > 0))
       {
         // We're blocked, send block message if:
@@ -208,7 +224,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
         //
         // Sending multiple "i'm blocked" messages to the cycle detector
         // will result in actor potentially being freed more than once.
-        set_flag(actor, FLAG_BLOCKED_SENT);
+        set_internal_flag(actor, FLAG_BLOCKED_SENT);
         pony_assert(ctx->current == actor);
         ponyint_cycle_block(actor, &actor->gc);
       }
@@ -273,7 +289,7 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
 #endif
 
       pony_assert(!ponyint_is_cycle(actor));
-      if(has_flag(actor, FLAG_BLOCKED_SENT))
+      if(has_internal_flag(actor, FLAG_BLOCKED_SENT))
       {
         // send unblock if we've sent a block
         send_unblock(actor);
@@ -336,7 +352,7 @@ static bool maybe_mute(pony_actor_t* actor)
 
 static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 {
-  if(!has_flag(actor, FLAG_OVERLOADED) && !polling)
+  if(!has_sync_flag(actor, SYNC_FLAG_OVERLOADED) && !polling)
   {
     // If we hit our batch size, consider this actor to be overloaded
     // only if we're not polling from C code.
@@ -393,7 +409,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   pony_assert(app < batch);
   pony_assert(!ponyint_is_muted(actor));
 
-  if(has_flag(actor, FLAG_OVERLOADED))
+  if(has_sync_flag(actor, SYNC_FLAG_OVERLOADED))
   {
     // if we were overloaded and didn't process a full batch, set ourselves as
     // no longer overloaded. Once this is done:
@@ -410,13 +426,13 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
     return true;
 
   // note that we're logically blocked
-  if(!has_flag(actor, FLAG_BLOCKED | FLAG_SYSTEM | FLAG_BLOCKED_SENT))
+  if(!has_internal_flag(actor, FLAG_BLOCKED | FLAG_SYSTEM | FLAG_BLOCKED_SENT))
   {
-    set_flag(actor, FLAG_BLOCKED);
+    set_internal_flag(actor, FLAG_BLOCKED);
 
     if(!actor_noblock
       && (actor->gc.rc > 0)
-      && !has_flag(actor, FLAG_CD_CONTACTED)
+      && !has_internal_flag(actor, FLAG_CD_CONTACTED)
     )
     {
       // The cycle detector (CD) doesn't know we exist so it won't try
@@ -424,14 +440,14 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
       // in the future we will wait for the CD to reach out and ask
       // if we're blocked or not.
       // But, only if gc.rc > 0 because if gc.rc == 0 we are a zombie.
-      set_flag(actor, FLAG_BLOCKED_SENT);
-      set_flag(actor, FLAG_CD_CONTACTED);
+      set_internal_flag(actor, FLAG_BLOCKED_SENT);
+      set_internal_flag(actor, FLAG_CD_CONTACTED);
       ponyint_cycle_block(actor, &actor->gc);
     }
 
   }
 
-  if ((actor->gc.rc == 0) && has_flag(actor, FLAG_BLOCKED))
+  if ((actor->gc.rc == 0) && has_internal_flag(actor, FLAG_BLOCKED))
   {
     // Here, we is what we know to be true:
     //
@@ -467,7 +483,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
       // cycle detector isn't holding a reference to the actor. If we have never
       // sent a reference to the cycle detector (FLAG_CD_CONTACTED), then this
       // is perfectly safe to do.
-      if (actor_noblock || !has_flag(actor, FLAG_CD_CONTACTED))
+      if (actor_noblock || !has_internal_flag(actor, FLAG_CD_CONTACTED))
       {
         // mark the queue as empty or else destroy will hang
         bool empty = ponyint_messageq_markempty(&actor->q);
@@ -499,7 +515,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
           // need to undo set pending destroy because the cycle detector
           // sent the actor a message and it is not safe to destroy this
           // actor as a result.
-          unset_flag(actor, FLAG_PENDINGDESTROY);
+          unset_sync_flag(actor, SYNC_FLAG_PENDINGDESTROY);
 
           // If we mark the queue as empty, then it is no longer safe to do any
           // operations on this actor that aren't concurrency safe so make
@@ -520,7 +536,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
         // It's possible this might be a source of bug. If it is, then the
         // solution is probably to make this an if that encloses the remaining
         // logic in this block.
-        pony_assert(!has_flag(actor, FLAG_BLOCKED_SENT));
+        pony_assert(!has_internal_flag(actor, FLAG_BLOCKED_SENT));
 
         // Tell cycle detector that this actor is a zombie and will not get
         // any more messages/work and can be reaped.
@@ -537,7 +553,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
         // unblocked (which would create a race condition) and we've also
         // ensured that the cycle detector will not send this actor any more
         // messages (which would also create a race condition).
-        set_flag(actor, FLAG_BLOCKED_SENT);
+        set_internal_flag(actor, FLAG_BLOCKED_SENT);
         ponyint_cycle_block(actor, &actor->gc);
 
         // mark the queue as empty or else destroy will hang
@@ -561,7 +577,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 
 void ponyint_actor_destroy(pony_actor_t* actor)
 {
-  pony_assert(has_flag(actor, FLAG_PENDINGDESTROY));
+  pony_assert(has_sync_flag(actor, SYNC_FLAG_PENDINGDESTROY));
 
   // Make sure the actor being destroyed has finished marking its queue
   // as empty. Otherwise, it may spuriously see that tail and head are not
@@ -604,7 +620,7 @@ heap_t* ponyint_actor_heap(pony_actor_t* actor)
 
 bool ponyint_actor_pendingdestroy(pony_actor_t* actor)
 {
-  return has_flag(actor, FLAG_PENDINGDESTROY);
+  return has_sync_flag(actor, SYNC_FLAG_PENDINGDESTROY);
 }
 
 void ponyint_actor_setpendingdestroy(pony_actor_t* actor)
@@ -614,7 +630,7 @@ void ponyint_actor_setpendingdestroy(pony_actor_t* actor)
   // cycle and an actor won't change its flags if it is part of a true cycle.
   // The synchronisation is done through the ACK message sent by the actor to
   // the cycle detector.
-  set_flag(actor, FLAG_PENDINGDESTROY);
+  set_sync_flag(actor, SYNC_FLAG_PENDINGDESTROY);
 }
 
 void ponyint_actor_final(pony_ctx_t* ctx, pony_actor_t* actor)
@@ -642,7 +658,7 @@ void ponyint_actor_sendrelease(pony_ctx_t* ctx, pony_actor_t* actor)
 
 void ponyint_actor_setsystem(pony_actor_t* actor)
 {
-  set_flag(actor, FLAG_SYSTEM);
+  set_internal_flag(actor, FLAG_SYSTEM);
 }
 
 void ponyint_actor_setnoblock(bool state)
@@ -831,8 +847,8 @@ void ponyint_maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
     // AND
     // 3. we are sending to another actor (as compared to sending to self)
     if(ponyint_triggers_muting(to) &&
-       !has_flag(ctx->current, FLAG_OVERLOADED) &&
-       !has_flag(ctx->current, FLAG_UNDER_PRESSURE) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
+       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
        ctx->current != to)
     {
       ponyint_sched_mute(ctx, ctx->current, to);
@@ -967,21 +983,21 @@ PONY_API void pony_poll(pony_ctx_t* ctx)
 void ponyint_actor_setoverloaded(pony_actor_t* actor)
 {
   pony_assert(!ponyint_is_cycle(actor));
-  set_flag(actor, FLAG_OVERLOADED);
+  set_sync_flag(actor, SYNC_FLAG_OVERLOADED);
   DTRACE1(ACTOR_OVERLOADED, (uintptr_t)actor);
 }
 
 bool ponyint_actor_overloaded(pony_actor_t* actor)
 {
-  return has_flag(actor, FLAG_OVERLOADED);
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED);
 }
 
 void ponyint_actor_unsetoverloaded(pony_actor_t* actor)
 {
   pony_ctx_t* ctx = pony_ctx();
-  unset_flag(actor, FLAG_OVERLOADED);
+  unset_sync_flag(actor, SYNC_FLAG_OVERLOADED);
   DTRACE1(ACTOR_OVERLOADED_CLEARED, (uintptr_t)actor);
-  if (!has_flag(actor, FLAG_UNDER_PRESSURE))
+  if (!has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE))
   {
     ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
   }
@@ -990,23 +1006,23 @@ void ponyint_actor_unsetoverloaded(pony_actor_t* actor)
 PONY_API void pony_apply_backpressure()
 {
   pony_ctx_t* ctx = pony_ctx();
-  set_flag(ctx->current, FLAG_UNDER_PRESSURE);
+  set_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE);
   DTRACE1(ACTOR_UNDER_PRESSURE, (uintptr_t)ctx->current);
 }
 
 PONY_API void pony_release_backpressure()
 {
   pony_ctx_t* ctx = pony_ctx();
-  unset_flag(ctx->current, FLAG_UNDER_PRESSURE);
+  unset_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE);
   DTRACE1(ACTOR_PRESSURE_RELEASED, (uintptr_t)ctx->current);
-  if (!has_flag(ctx->current, FLAG_OVERLOADED))
+  if (!has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED))
     ponyint_sched_start_global_unmute(ctx->scheduler->index, ctx->current);
 }
 
 bool ponyint_triggers_muting(pony_actor_t* actor)
 {
-  return has_flag(actor, FLAG_OVERLOADED) ||
-    has_flag(actor, FLAG_UNDER_PRESSURE) ||
+  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
+    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
     ponyint_is_muted(actor);
 }
 
@@ -1035,18 +1051,18 @@ bool ponyint_triggers_muting(pony_actor_t* actor)
 
 bool ponyint_is_muted(pony_actor_t* actor)
 {
-  return has_flag(actor, FLAG_MUTED);
+  return has_sync_flag(actor, SYNC_FLAG_MUTED);
 }
 
 void ponyint_mute_actor(pony_actor_t* actor)
 {
-  set_flag(actor, FLAG_MUTED);
+  set_sync_flag(actor, SYNC_FLAG_MUTED);
   DTRACE1(ACTOR_MUTED, (uintptr_t)actor);
 }
 
 void ponyint_unmute_actor(pony_actor_t* actor)
 {
-  unset_flag(actor, FLAG_MUTED);
+  unset_sync_flag(actor, SYNC_FLAG_MUTED);
   DTRACE1(ACTOR_UNMUTED, (uintptr_t)actor);
 }
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -43,10 +43,15 @@ enum
 
 // The sync flags of a given actor cannot be mutated from more than one actor at
 // once, so these operations need not be atomic RMW.
-static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
+static bool has_sync_flag_any(pony_actor_t* actor, uint8_t check_flags)
 {
   uint8_t flags = atomic_load_explicit(&actor->sync_flags, memory_order_acquire);
-  return (flags & flag) != 0;
+  return (flags & check_flags) != 0;
+}
+
+static bool has_sync_flag(pony_actor_t* actor, uint8_t flag)
+{
+  return has_sync_flag_any(actor, flag);
 }
 
 static void set_sync_flag(pony_actor_t* actor, uint8_t flag)
@@ -99,13 +104,8 @@ static void unset_internal_flag(pony_actor_t* actor, uint8_t flag)
 // additional messages and the sender won't be muted. As this is a transient
 // situtation that should be shortly rectified, there's no harm done.
 //
-// Our handling of atomic operations in `is_muted`, `mute_actor`
+// Our handling of atomic operations in `mute_actor`
 // and `unmute_actor` are to assure that both rules aren't violated.
-
-static bool is_muted(pony_actor_t* actor)
-{
-  return has_sync_flag(actor, SYNC_FLAG_MUTED);
-}
 
 static void mute_actor(pony_actor_t* actor)
 {
@@ -121,9 +121,8 @@ void ponyint_unmute_actor(pony_actor_t* actor)
 
 static bool triggers_muting(pony_actor_t* actor)
 {
-  return has_sync_flag(actor, SYNC_FLAG_OVERLOADED) ||
-    has_sync_flag(actor, SYNC_FLAG_UNDER_PRESSURE) ||
-    is_muted(actor);
+  return has_sync_flag_any(actor, SYNC_FLAG_OVERLOADED |
+    SYNC_FLAG_UNDER_PRESSURE | SYNC_FLAG_MUTED);
 }
 
 static void actor_setoverloaded(pony_actor_t* actor)
@@ -155,9 +154,9 @@ static void maybe_mute(pony_ctx_t* ctx, pony_actor_t* to)
     // AND
     // 3. we are sending to another actor (as compared to sending to self)
     if(triggers_muting(to) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_OVERLOADED) &&
-       !has_sync_flag(ctx->current, SYNC_FLAG_UNDER_PRESSURE) &&
-       ctx->current != to)
+      !has_sync_flag_any(ctx->current, SYNC_FLAG_OVERLOADED |
+        SYNC_FLAG_UNDER_PRESSURE) &&
+      ctx->current != to)
     {
       ponyint_sched_mute(ctx, ctx->current, to);
     }
@@ -438,7 +437,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
 {
-  pony_assert(!is_muted(actor));
+  pony_assert(!has_sync_flag(actor, SYNC_FLAG_MUTED));
   ctx->current = actor;
   size_t batch = PONY_SCHED_BATCH;
 
@@ -499,7 +498,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   // We didn't hit our app message batch limit. We now believe our queue to be
   // empty, but we may have received further messages.
   pony_assert(app < batch);
-  pony_assert(!is_muted(actor));
+  pony_assert(!has_sync_flag(actor, SYNC_FLAG_MUTED));
 
   if(has_sync_flag(actor, SYNC_FLAG_OVERLOADED))
   {

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -89,7 +89,15 @@ enum
   SYNC_FLAG_MUTED = 1 << 3,
 };
 
-bool has_internal_flag(pony_actor_t* actor, uint8_t flag);
+/**
+ * Call this to "become" an actor on a non-scheduler context. It is used by
+ * the compiler code gen to start the `Main` actor and to run finalizers.
+ * It is also used by the `cycle detector` termination function.
+ *
+ * This can be called with NULL to make no actor the "current" actor for a
+ * thread.
+ */
+void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor);
 
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
 

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -32,8 +32,7 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
-  PONY_ATOMIC(uint8_t) flags;
-  PONY_ATOMIC(uint8_t) is_muted;
+  PONY_ATOMIC(uint16_t) flags;
 
   // keep things accessed by other actors on a separate cache line
   alignas(64) heap_t heap; // 52/104 bytes
@@ -78,9 +77,10 @@ enum
   FLAG_OVERLOADED = 1 << 4,
   FLAG_UNDER_PRESSURE = 1 << 5,
   FLAG_CD_CONTACTED = 1 << 6,
+  FLAG_MUTED = 1 << 7,
 };
 
-bool has_flag(pony_actor_t* actor, uint8_t flag);
+bool has_flag(pony_actor_t* actor, uint16_t flag);
 
 /**
  * Call this to "become" an actor on a non-scheduler context. It is used by

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -72,34 +72,6 @@ typedef struct pony_actor_pad_t
   char pad[PONY_ACTOR_PAD_SIZE];
 } pony_actor_pad_t;
 
-enum
-{
-  FLAG_BLOCKED = 1 << 0,
-  FLAG_BLOCKED_SENT = 1 << 1,
-  FLAG_SYSTEM = 1 << 2,
-  FLAG_CD_CONTACTED = 1 << 3,
-};
-
-enum
-{
-  SYNC_FLAG_PENDINGDESTROY = 1 << 0,
-  SYNC_FLAG_OVERLOADED = 1 << 1,
-  SYNC_FLAG_UNDER_PRESSURE = 1 << 2,
-  SYNC_FLAG_MUTED = 1 << 3,
-};
-
-bool has_internal_flag(pony_actor_t* actor, uint8_t flag);
-
-/**
- * Call this to "become" an actor on a non-scheduler context. It is used by
- * the compiler code gen to start the `Main` actor and to run finalizers.
- * It is also used by the `cycle detector` termination function.
- *
- * This can be called with NULL to make no actor the "current" actor for a
- * thread.
- */
-void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor);
-
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
 
 void ponyint_actor_destroy(pony_actor_t* actor);
@@ -122,23 +94,11 @@ void ponyint_actor_setnoblock(bool state);
 
 bool ponyint_actor_getnoblock();
 
-void ponyint_actor_setoverloaded(pony_actor_t* actor);
-
-void ponyint_actor_unsetoverloaded(pony_actor_t* actor);
-
 PONY_API void pony_apply_backpressure();
 
 PONY_API void pony_release_backpressure();
 
-void ponyint_maybe_mute(pony_ctx_t* ctx, pony_actor_t* to);
-
-bool ponyint_triggers_muting(pony_actor_t* actor);
-
-bool ponyint_is_muted(pony_actor_t* actor);
-
 void ponyint_unmute_actor(pony_actor_t* actor);
-
-void ponyint_mute_actor(pony_actor_t* actor);
 
 PONY_API void ponyint_destroy(pony_ctx_t* ctx, pony_actor_t* actor);
 

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -72,6 +72,25 @@ typedef struct pony_actor_pad_t
   char pad[PONY_ACTOR_PAD_SIZE];
 } pony_actor_pad_t;
 
+enum
+{
+  FLAG_BLOCKED = 1 << 0,
+  FLAG_BLOCKED_SENT = 1 << 1,
+  FLAG_SYSTEM = 1 << 2,
+  FLAG_UNSCHEDULED = 1 << 3,
+  FLAG_CD_CONTACTED = 1 << 4,
+};
+
+enum
+{
+  SYNC_FLAG_PENDINGDESTROY = 1 << 0,
+  SYNC_FLAG_OVERLOADED = 1 << 1,
+  SYNC_FLAG_UNDER_PRESSURE = 1 << 2,
+  SYNC_FLAG_MUTED = 1 << 3,
+};
+
+bool has_internal_flag(pony_actor_t* actor, uint8_t flag);
+
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
 
 void ponyint_actor_destroy(pony_actor_t* actor);
@@ -94,11 +113,23 @@ void ponyint_actor_setnoblock(bool state);
 
 bool ponyint_actor_getnoblock();
 
+void ponyint_actor_setoverloaded(pony_actor_t* actor);
+
+void ponyint_actor_unsetoverloaded(pony_actor_t* actor);
+
 PONY_API void pony_apply_backpressure();
 
 PONY_API void pony_release_backpressure();
 
+void ponyint_maybe_mute(pony_ctx_t* ctx, pony_actor_t* to);
+
+bool ponyint_triggers_muting(pony_actor_t* actor);
+
+bool ponyint_is_muted(pony_actor_t* actor);
+
 void ponyint_unmute_actor(pony_actor_t* actor);
+
+void ponyint_mute_actor(pony_actor_t* actor);
 
 PONY_API void ponyint_destroy(pony_ctx_t* ctx, pony_actor_t* actor);
 


### PR DESCRIPTION
`actor->is_muted` is a `uint8_t` but it is always treated as a `boolean`.
It is also always only modified from a single scheduler thread (either to mute
or unmute the actor) but read from other scheduler threads.

This PR removes `actor->is_muted`, splits `actor->flags` into `actor->sync_flags`
and `actor->internal_flags` and adds a new sync flag called `FLAG_MUTED`.
The logic in `ponyint_is_muted`, `ponyint_mute_actor` and `ponyint_unmute_actor`
has been updated to use this new flag. Additionally, the sync flag read/modify
logic has been updated to use acquire/release semantics instead of relaxed
semantics so that it will work correctly on weakly ordered architectures (i.e. arm).

This preserves the existing behavior and makes sure all flags that are used from
multiple scheduler threads (overloaded, under pressure, muted, pending destroy)
are defined as sync flags and fully concurrency safe. The remaining flags
used from only a single scheduler thread are defined as internal flags don't use
atomics any longer which should result in a minor performance boost due to less
use of atomic operations when they aren't required.