### PR TITLE
Actor should be unmuted even if it is unscheduled

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1488,10 +1488,10 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
     {
       needs_unmuting = ponyint_actorstack_pop(needs_unmuting, &to_unmute);
 
+      ponyint_unmute_actor(to_unmute);
+
       if(!has_flag(to_unmute, FLAG_UNSCHEDULED))
       {
-        ponyint_unmute_actor(to_unmute);
-
         ponyint_sched_add(ctx, to_unmute);
         DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);
         actors_rescheduled++;


### PR DESCRIPTION
Currently, an actor is not unmuted if it is unscheduled. This is an
issue because `pony_schedule` will not reschedule an actor if it is
currently muted. The current logic would result in unscheduled and
muted actors never being unmuted and rescheduled.

This commit changes the logic in `ponyint_sched_unmute_senders` to
always unmute actors that should be unmuted but to only redschedule
them if they were not unscheduled.