### PR TITLE
Update to basing musl images off of Alpine 3.16

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 

--- a/.release-notes/musl-docker-alpine-3-16.md
+++ b/.release-notes/musl-docker-alpine-3-16.md
@@ -1,0 +1,3 @@
+## Update to basing musl images off of Alpine 3.12
+
+We supply nightly and release Docker images for ponyc based on Alpine Linux. We've updated the version of Alpine we use from 3.12 which recently reached it's end of life to Alpine 3.16 which is supported until 2024.


### PR DESCRIPTION
Previously our images were based on Alpine 3.12 that has reached
it's support end-of-life. Alpine 3.16 is the latest stable release
and is going to be supported until 2024.