### PR TITLE
Systematic testing for the runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,11 @@ if(PONY_USE_SCHEDULER_SCALING_PTHREADS)
     add_compile_options(-DUSE_SCHEDULER_SCALING_PTHREADS)
 endif()
 
+if(PONY_USE_SYSTEMATIC_TESTING)
+    set(PONY_OUTPUT_SUFFIX "-systematic_testing")
+    add_compile_options(-DUSE_SYSTEMATIC_TESTING)
+endif()
+
 if(PONY_USE_MEMTRACK_MESSAGES)
     set(PONY_OUTPUT_SUFFIX "-memtrack_messages")
     add_compile_options(-DUSE_MEMTRACK -DUSE_MEMTRACK_MESSAGES)

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,8 @@ define USE_CHECK
     PONY_USES += -DPONY_USE_DTRACE=true
   else ifeq ($1,scheduler_scaling_pthreads)
     PONY_USES += -DPONY_USE_SCHEDULER_SCALING_PTHREADS=true
+  else ifeq ($1,systematic_testing)
+    PONY_USES += -DPONY_USE_SYSTEMATIC_TESTING=true
   else ifeq ($1,memtrack)
     PONY_USES += -DPONY_USE_MEMTRACK=true
   else ifeq ($1,memtrack_messages)

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -46,6 +46,7 @@ set(_c_src
     sched/mutemap.c
     sched/scheduler.c
     sched/start.c
+    sched/systematic_testing.c
 )
 
 set(_ll_except_src "${CMAKE_CURRENT_SOURCE_DIR}/lang/except_try_catch.ll")

--- a/src/libponyrt/asio/asio.c
+++ b/src/libponyrt/asio/asio.c
@@ -7,10 +7,14 @@
 
 #include "asio.h"
 #include "../mem/pool.h"
+#include "../sched/systematic_testing.h"
 
 struct asio_base_t
 {
   pony_thread_id_t tid;
+#if defined(USE_SYSTEMATIC_TESTING)
+  pony_signal_event_t sleep_object;
+#endif
   asio_backend_t* backend;
   PONY_ATOMIC(uint64_t) noisy_count;
 };
@@ -33,6 +37,18 @@ asio_backend_t* ponyint_asio_get_backend()
   return running_base.backend;
 }
 
+pony_thread_id_t ponyint_asio_get_backend_tid()
+{
+  return running_base.tid;
+}
+
+#if defined(USE_SYSTEMATIC_TESTING)
+pony_signal_event_t ponyint_asio_get_backend_sleep_object()
+{
+  return running_base.sleep_object;
+}
+#endif
+
 uint32_t ponyint_asio_get_cpu()
 {
   return asio_cpu;
@@ -42,6 +58,24 @@ void ponyint_asio_init(uint32_t cpu)
 {
   asio_cpu = cpu;
   running_base.backend = ponyint_asio_backend_init();
+
+#if defined(USE_SYSTEMATIC_TESTING)
+#if defined(PLATFORM_IS_WINDOWS)
+    // create wait event objects
+    running_base.sleep_object = CreateEvent(NULL, FALSE, FALSE, NULL);
+#elif defined(USE_SCHEDULER_SCALING_PTHREADS)
+    // TODO: memtrack accounting
+    // create pthread condition object
+    running_base.sleep_object = POOL_ALLOC(pthread_cond_t);
+    int ret = pthread_cond_init(running_base.sleep_object, NULL);
+    if(ret != 0)
+    {
+      // if it failed, set `sleep_object` to `NULL` for error
+      POOL_FREE(pthread_cond_t, running_base.sleep_object);
+      running_base.sleep_object = NULL;
+    }
+#endif
+#endif
 }
 
 bool ponyint_asio_start()
@@ -49,6 +83,12 @@ bool ponyint_asio_start()
   // if the backend wasn't successfully initialized
   if(running_base.backend == NULL)
     return false;
+
+#if defined(USE_SYSTEMATIC_TESTING) && defined(USE_SCHEDULER_SCALING_PTHREADS)
+  // there was an error creating a wait event or a pthread condition object
+  if(running_base.sleep_object == NULL)
+    return false;
+#endif
 
   if(!ponyint_thread_create(&running_base.tid, ponyint_asio_backend_dispatch,
     asio_cpu, running_base.backend))
@@ -65,6 +105,13 @@ bool ponyint_asio_stop()
   if(running_base.backend != NULL)
   {
     ponyint_asio_backend_final(running_base.backend);
+
+#if defined(USE_SYSTEMATIC_TESTING)
+    // wait for asio thread to shut down
+    while(!SYSTEMATIC_TESTING_ASIO_STOPPED())
+      SYSTEMATIC_TESTING_YIELD();
+#endif
+
     ponyint_thread_join(running_base.tid);
 
     running_base.backend = NULL;

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -68,6 +68,18 @@ bool ponyint_asio_start();
  */
 asio_backend_t* ponyint_asio_get_backend();
 
+/** Returns the thread id assigned for the ASIO thread.
+ *
+ */
+pony_thread_id_t ponyint_asio_get_backend_tid();
+
+#if defined(USE_SYSTEMATIC_TESTING)
+/** Returns the sleep object assigned for the ASIO thread.
+ *
+ */
+pony_signal_event_t ponyint_asio_get_backend_sleep_object();
+#endif
+
 /** Returns the cpu assigned for the ASIO thread.
  *
  */

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -9,6 +9,7 @@
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
 #include "../sched/scheduler.h"
+#include "../sched/systematic_testing.h"
 #include "ponyassert.h"
 #include <string.h>
 #include <signal.h>
@@ -125,10 +126,17 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   // 2 => listen on queue wake event and stdin
   int handleCount = 1;
 
+#if defined(USE_SYSTEMATIC_TESTING)
+  // sleep thread until we're ready to start processing
+  SYSTEMATIC_TESTING_WAIT_START(ponyint_asio_get_backend_tid(), ponyint_asio_get_backend_sleep_object());
+#endif
+
   while(!atomic_load_explicit(&b->stop, memory_order_relaxed))
   {
     switch(WaitForMultipleObjectsEx(handleCount, handles, FALSE, -1, TRUE))
     {
+      SYSTEMATIC_TESTING_YIELD();
+
       case WAIT_OBJECT_0:
       {
         // Process all items on our queue.
@@ -246,6 +254,9 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   CloseHandle(b->wakeup);
   ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
+
+  SYSTEMATIC_TESTING_STOP_THREAD();
+
   pony_unregister_thread();
   return NULL;
 }

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -6,8 +6,10 @@
 #include "../mem/pool.h"
 #include "../sched/cpu.h"
 #include "../sched/scheduler.h"
+#include "../sched/systematic_testing.h"
 #include "ponyassert.h"
 #include <sys/event.h>
+#include <sys/time.h>
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -179,9 +181,24 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   struct kevent fired[MAX_EVENTS];
 
+#if defined(USE_SYSTEMATIC_TESTING)
+  // sleep thread until we're ready to start processing
+  SYSTEMATIC_TESTING_WAIT_START(ponyint_asio_get_backend_tid(), ponyint_asio_get_backend_sleep_object());
+#endif
+
   while(b->kq != -1)
   {
-    int count = kevent(b->kq, NULL, 0, fired, MAX_EVENTS, NULL);
+    timespec* timeout = NULL;
+#if defined(USE_SYSTEMATIC_TESTING)
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 10000000;
+    timeout = &ts;
+#endif
+
+    int count = kevent(b->kq, NULL, 0, fired, MAX_EVENTS, timeout);
+
+    SYSTEMATIC_TESTING_YIELD();
 
     for(int i = 0; i < count; i++)
     {
@@ -257,6 +274,9 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
+
+  SYSTEMATIC_TESTING_STOP_THREAD();
+
   pony_unregister_thread();
   return NULL;
 }

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -94,7 +94,12 @@ struct scheduler_t
 };
 
 pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
-  bool pinasio, uint32_t min_threads, uint32_t thread_suspend_threshold);
+  bool pinasio, uint32_t min_threads, uint32_t thread_suspend_threshold
+#if defined(USE_SYSTEMATIC_TESTING)
+  , uint64_t systematic_testing_seed);
+#else
+  );
+#endif
 
 bool ponyint_sched_start(bool library);
 
@@ -107,6 +112,8 @@ void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* rec
 void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor);
 
 bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor);
+
+PONY_API uint32_t pony_active_schedulers();
 
 /** Mark asio as being noisy
  */

--- a/src/libponyrt/sched/systematic_testing.c
+++ b/src/libponyrt/sched/systematic_testing.c
@@ -1,0 +1,195 @@
+#include "systematic_testing.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include "cpu.h"
+#include "ponyassert.h"
+
+typedef struct systematic_testing_thread_t
+{
+  pony_thread_id_t tid;
+  pony_signal_event_t sleep_object;
+  bool stopped;
+} systematic_testing_thread_t;
+
+static systematic_testing_thread_t* active_thread = NULL;
+static systematic_testing_thread_t* threads_to_track = NULL;
+static uint32_t total_threads = 0;
+static uint32_t stopped_threads = 0;
+
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+static pthread_mutex_t systematic_testing_mut;
+
+static pthread_once_t systematic_testing_mut_once = PTHREAD_ONCE_INIT;
+
+void systematic_testing_mut_init()
+{
+  pthread_mutex_init(&systematic_testing_mut, NULL);
+}
+#endif
+
+void ponyint_systematic_testing_init(uint64_t random_seed, uint32_t max_threads)
+{
+  #if defined(USE_SCHEDULER_SCALING_PTHREADS)
+  pthread_once(&systematic_testing_mut_once, systematic_testing_mut_init);
+#endif
+
+  if(0 == random_seed)
+    random_seed = ponyint_cpu_tick();
+
+  SYSTEMATIC_TESTING_PRINTF("Systematic testing using seed: %lu...\n", random_seed);
+  SYSTEMATIC_TESTING_PRINTF("(rerun with `<app> --ponysystematictestingseed %lu` to reproduce)\n", random_seed);
+
+  // TODO: maybe replace with better RNG?
+  srand((int)random_seed);
+
+  // initialize thead tracking array (should be max_threads + 1 to account for asio)
+  // TODO: memtrack tracking for these allocations
+  total_threads = max_threads + 1;
+  threads_to_track = (systematic_testing_thread_t*)ponyint_pool_alloc_size(
+    total_threads * sizeof(systematic_testing_thread_t));;
+  memset(threads_to_track, 0, total_threads * sizeof(systematic_testing_thread_t));
+
+  active_thread = threads_to_track;
+}
+
+static uint32_t get_thread_index(uint32_t index)
+{
+  uint32_t i = index + 1;
+  if (index < 0)
+    i = 0; // make sure asio gets put at the beginning of the array
+
+  pony_assert(i < total_threads);
+
+  return i;
+}
+
+void ponyint_systematic_testing_wait_start(pony_thread_id_t thread, pony_signal_event_t signal)
+{
+  SYSTEMATIC_TESTING_PRINTF("thread %lu: waiting to start...\n", thread);
+
+  // sleep until it is this threads turn to do some work
+  while(0 == pthread_equal(active_thread->tid, thread))
+  {
+    SYSTEMATIC_TESTING_PRINTF("thread %lu: still waiting for it's turn... active thread: %lu\n", thread, active_thread->tid);
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+    ponyint_thread_suspend(signal, &systematic_testing_mut);
+#else
+    ponyint_thread_suspend(signal);
+#endif
+  }
+
+  SYSTEMATIC_TESTING_PRINTF("thread %lu: started...\n", thread);
+}
+
+void ponyint_systematic_testing_start(uint32_t index, scheduler_t* schedulers, pony_thread_id_t asio_thread, pony_signal_event_t asio_signal)
+{
+  threads_to_track[0].tid = asio_thread;
+  threads_to_track[0].sleep_object = asio_signal;
+  threads_to_track[0].stopped = false;
+
+  for(uint32_t i = 1; i < total_threads; i++)
+  {
+    threads_to_track[i].tid = schedulers[i-1].tid;
+    threads_to_track[i].sleep_object = schedulers[i-1].sleep_object;
+    threads_to_track[i].stopped = false;
+  }
+
+
+  uint32_t i = get_thread_index(index);
+  active_thread = &threads_to_track[i];
+
+  SYSTEMATIC_TESTING_PRINTF("Starting systematic testing with thread %lu...\n", active_thread->tid);
+
+  ponyint_thread_wake(active_thread->tid, active_thread->sleep_object);
+}
+
+static uint32_t get_next_index()
+{
+  uint32_t active_scheduler_count = pony_active_schedulers();
+  uint32_t active_count = active_scheduler_count + 1; // account for asio
+  uint32_t next_index = 0;
+  do
+  {
+    next_index = rand() % active_count;
+    pony_assert(next_index <= total_threads);
+  }
+  while (threads_to_track[next_index].stopped);
+
+  return next_index;
+}
+
+
+void ponyint_systematic_testing_yield()
+{
+  if(stopped_threads == total_threads)
+  {
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+    pthread_mutex_unlock(&systematic_testing_mut);
+#endif
+    return;
+  }
+
+  uint32_t next_index = get_next_index();
+
+  systematic_testing_thread_t *next_thread = &threads_to_track[next_index];
+  systematic_testing_thread_t *current_thread = active_thread;
+
+  if(0 == pthread_equal(active_thread->tid, next_thread->tid))
+  {
+    active_thread = next_thread;
+
+    SYSTEMATIC_TESTING_PRINTF("thread %lu: yielding to thread: %lu.. next_index: %u\n", current_thread->tid, active_thread->tid, next_index);
+
+    ponyint_thread_wake(active_thread->tid, active_thread->sleep_object);
+
+    if(!current_thread->stopped)
+    {
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+      ponyint_thread_suspend(current_thread->sleep_object, &systematic_testing_mut);
+#else
+      ponyint_thread_suspend(current_thread->sleep_object);
+#endif
+    }
+    else
+    {
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+      pthread_mutex_unlock(&systematic_testing_mut);
+#endif
+    }
+  }
+}
+
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+void ponyint_systematic_testing_suspend(pthread_mutex_t* mut)
+#else
+void ponyint_systematic_testing_suspend()
+#endif
+{
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+  // unlock mutex as `pthread_suspend` would before suspend
+  pthread_mutex_unlock(mut);
+#endif
+
+  ponyint_systematic_testing_yield();
+
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+  // lock mutex as `pthread_suspend` would after resume
+  pthread_mutex_lock(mut);
+#endif
+}
+
+bool ponyint_systematic_testing_asio_stopped()
+{
+  // asio is always the first thread
+  return threads_to_track[0].stopped;
+}
+
+void ponyint_systematic_testing_stop_thread()
+{
+  active_thread->stopped = true;
+  stopped_threads++;
+  SYSTEMATIC_TESTING_PRINTF("thread %lu: stopped...\n", active_thread->tid);
+
+  ponyint_systematic_testing_yield();
+}

--- a/src/libponyrt/sched/systematic_testing.h
+++ b/src/libponyrt/sched/systematic_testing.h
@@ -1,0 +1,60 @@
+#ifndef sched_systematic_testing_h
+#define sched_systematic_testing_h
+
+#include <platform.h>
+#include "scheduler.h"
+
+#if defined(USE_SYSTEMATIC_TESTING)
+#if !defined(PLATFORM_IS_WINDOWS) && !defined(USE_SCHEDULER_SCALING_PTHREADS)
+pony_static_assert(false, "Systematic testing requires pthreads (USE_SCHEDULER_SCALING_PTHREADS) to be enabled!");
+#endif
+
+#include <stdio.h>
+
+PONY_EXTERN_C_BEGIN
+
+void ponyint_systematic_testing_init(uint64_t random_seed, uint32_t max_threads);
+void ponyint_systematic_testing_start(uint32_t index, scheduler_t* schedulers, pony_thread_id_t asio_thread, pony_signal_event_t asio_signal);
+void ponyint_systematic_testing_wait_start(pony_thread_id_t thread, pony_signal_event_t signal);
+void ponyint_systematic_testing_yield();
+bool ponyint_systematic_testing_asio_stopped();
+void ponyint_systematic_testing_stop_thread();
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+void ponyint_systematic_testing_suspend(pthread_mutex_t* mut);
+#else
+void ponyint_systematic_testing_suspend();
+#endif
+
+#define SYSTEMATIC_TESTING_PRINTF(f_, ...) fprintf(stderr, (f_), ##__VA_ARGS__)
+#define SYSTEMATIC_TESTING_INIT(RANDOM_SEED, MAX_THREADS) ponyint_systematic_testing_init(RANDOM_SEED, MAX_THREADS)
+#define SYSTEMATIC_TESTING_START(INDEX, SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT) ponyint_systematic_testing_start(INDEX, SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT)
+#define SYSTEMATIC_TESTING_WAIT_START(THREAD, SIGNAL) ponyint_systematic_testing_wait_start(THREAD, SIGNAL)
+#define SYSTEMATIC_TESTING_YIELD() ponyint_systematic_testing_yield()
+#define SYSTEMATIC_TESTING_ASIO_STOPPED() ponyint_systematic_testing_asio_stopped()
+#define SYSTEMATIC_TESTING_STOP_THREAD() ponyint_systematic_testing_stop_thread()
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+#define SYSTEMATIC_TESTING_SUSPEND(MUT) ponyint_systematic_testing_suspend(MUT)
+#else
+#define SYSTEMATIC_TESTING_SUSPEND() ponyint_systematic_testing_suspend()
+#endif
+
+PONY_EXTERN_C_END
+
+#else
+
+#define SYSTEMATIC_TESTING_PRINTF(f_, ...)
+#define SYSTEMATIC_TESTING_INIT(RANDOM_SEED, MAX_THREADS)
+#define SYSTEMATIC_TESTING_START(INDEX, SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT)
+#define SYSTEMATIC_TESTING_WAIT_START(THREAD, SIGNAL)
+#define SYSTEMATIC_TESTING_YIELD()
+#define SYSTEMATIC_TESTING_ASIO_STOPPED()
+#define SYSTEMATIC_TESTING_STOP_THREAD()
+#if defined(USE_SCHEDULER_SCALING_PTHREADS)
+#define SYSTEMATIC_TESTING_SUSPEND(MUT)
+#else
+#define SYSTEMATIC_TESTING_SUSPEND()
+#endif
+
+#endif
+
+#endif


### PR DESCRIPTION
The overall idea and some details of the implementation for systematic
testing has been shamelessly stolen from the `Verona` runtime (see:
https://github.com/microsoft/verona/blob/master/docs/explore.md#systematic-testing
for details). This implementation doesn't include replayable runtime
unit tests like `Verona`, but it sets a foundation for allowing
replayable runs of programs (and probably tests) for debugging
runtime issues such as backpressure/etc.