### PR TITLE
Avoid clearing chunks at start of GC

### DIFF
--- a/.release-notes/4143.md
+++ b/.release-notes/4143.md
@@ -1,0 +1,6 @@
+## More efficient actor heap garbage collection
+
+We have improved the actor heap garbage collection process
+to make it more efficient by deferring some initialization
+work and handling as part of the normal garbage collection
+mark and sweep passes.

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -94,11 +94,6 @@ bool ponyint_heap_mark(chunk_t* chunk, void* p);
 void ponyint_heap_mark_shallow(chunk_t* chunk, void* p);
 
 /**
- * Returns true if the address is marked (allocated).
- */
-bool ponyint_heap_ismarked(chunk_t* chunk, void* p);
-
-/**
  * Forcibly free this address.
  */
 void ponyint_heap_free(chunk_t* chunk, void* p);


### PR DESCRIPTION
Prior to this commit, at the start of GC, the heap clears all
`chunks` by setting them all to `empty` in `ponyint_heap_startgc`.
This is an expensive operation as it requires visiting all
`chunks` and updating their `chunk->slots` and `chunk->shallow`
values regardless of whether they are still in use or not.
`chunk->shallow` is only ever used as part of the GC process.

The old logic for heap GC was:

* mark all slots in all chunks as empty so they can all be freed by GC (`clear chunks`)
* recursively trace all roots and mark any slots still in use as not empty so they don't get freed by GC
* sweep all chunks freeing (and running finalisers) any slots that are empty

This commit uses the `chunk->shallow` with a `sentinel`
value to avoid clearing chunks for every sizeclass except
for sizeclass 0 which is still cleared and makes sure that
the mark and sweep steps clear the chunk if
`chunk->shallow` has the `sentinel` value and needs to be
cleared. Additionally, `ponyint_heap_ismarked` is removed
as it is not used.

The new logic for heap GC is:

* only mark all slots in sizeclass 0 chunks as empty so they can all be freed by GC (`clear chunks`)
  * chunks in all other sizeclasses will already have their `chunk->shallow` set to a `sentinel` value to indicate that they need to be cleared as part of trace/sweep
* recursively trace all roots and mark any slots still in use as not empty so they don't get freed by GC
  * As part of mark, clear the chunk if the `chunk->shallow` has the `sentinel` value (to preserve the illusion that the chunk was cleared before GC was started) before proceeding with normal marking logic
* sweep all chunks freeing (and running finalisers) any slots that are empty
  * As part of sweep, clear the chunk if the `chunk->shallow` has the `sentinel` value (to preserve the illusion that the chunk was cleared before GC was started) before proceeding with normal sweeping logic
  * Also as part of sweep, set `chunk->shallow` to the `sentinel` value in prep for the next GC iteration
* modify `ponyint_heap_alloc*` functions to set `chunk->shallow` to the `sentinel` value in prep for the next GC iteration for all newly allocated chunks
