### PR TITLE
Remove `ponyint_heap_alloc*_final` functions

### DIFF
--- a/benchmark/libponyrt/mem/heap.cc
+++ b/benchmark/libponyrt/mem/heap.cc
@@ -35,9 +35,9 @@ BENCHMARK_DEFINE_F(HeapBench, HeapAlloc$)(benchmark::State& st) {
   while (st.KeepRunning()) {
     if(alloc_size > HEAP_MAX)
     {
-      ponyint_heap_alloc_large(actor, &_heap, alloc_size);
+      ponyint_heap_alloc_large(actor, &_heap, alloc_size, TRACK_NO_FINALISERS);
     } else {
-      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size));
+      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size), TRACK_NO_FINALISERS);
     }
     st.PauseTiming();
     ponyint_heap_destroy(&_heap);
@@ -58,10 +58,10 @@ BENCHMARK_DEFINE_F(HeapBench, HeapAlloc$_)(benchmark::State& st) {
     if(alloc_size > HEAP_MAX)
     {
       for(int i = 0; i < num_allocs; i++)
-        ponyint_heap_alloc_large(actor, &_heap, alloc_size);
+        ponyint_heap_alloc_large(actor, &_heap, alloc_size, TRACK_NO_FINALISERS);
     } else {
       for(int i = 0; i < num_allocs; i++)
-        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size));
+        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size), TRACK_NO_FINALISERS);
     }
     st.PauseTiming();
     ponyint_heap_destroy(&_heap);
@@ -82,9 +82,9 @@ BENCHMARK_DEFINE_F(HeapBench, HeapDestroy$)(benchmark::State& st) {
     st.PauseTiming();
     ponyint_heap_init(&_heap);
     if(alloc_size > HEAP_MAX)
-      ponyint_heap_alloc_large(actor, &_heap, alloc_size);
+      ponyint_heap_alloc_large(actor, &_heap, alloc_size, TRACK_NO_FINALISERS);
     else
-      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size));
+      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size), TRACK_NO_FINALISERS);
     st.ResumeTiming();
     ponyint_heap_destroy(&_heap);
   }
@@ -105,10 +105,10 @@ BENCHMARK_DEFINE_F(HeapBench, HeapDestroyMultiple$)(benchmark::State& st) {
     ponyint_heap_init(&_heap);
     if(alloc_size > HEAP_MAX)
       for(int i = 0; i < num_allocs; i++)
-        ponyint_heap_alloc_large(actor, &_heap, alloc_size);
+        ponyint_heap_alloc_large(actor, &_heap, alloc_size, TRACK_NO_FINALISERS);
     else
       for(int i = 0; i < num_allocs; i++)
-        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size));
+        ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size), TRACK_NO_FINALISERS);
     st.ResumeTiming();
     ponyint_heap_destroy(&_heap);
   }
@@ -126,9 +126,9 @@ BENCHMARK_DEFINE_F(HeapBench, HeapInitAllocDestroy)(benchmark::State& st) {
   while (st.KeepRunning()) {
     ponyint_heap_init(&_heap);
     if(alloc_size > HEAP_MAX)
-      ponyint_heap_alloc_large(actor, &_heap, alloc_size);
+      ponyint_heap_alloc_large(actor, &_heap, alloc_size, TRACK_NO_FINALISERS);
     else
-      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size));
+      ponyint_heap_alloc_small(actor, &_heap, ponyint_heap_index(alloc_size), TRACK_NO_FINALISERS);
     ponyint_heap_destroy(&_heap);
   }
   st.SetItemsProcessed((int64_t)st.iterations());

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -990,7 +990,8 @@ PONY_API void* pony_alloc(pony_ctx_t* ctx, size_t size)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
-  return ponyint_heap_alloc(ctx->current, &ctx->current->heap, size);
+  return ponyint_heap_alloc(ctx->current, &ctx->current->heap, size,
+    TRACK_NO_FINALISERS);
 }
 
 PONY_API void* pony_alloc_small(pony_ctx_t* ctx, uint32_t sizeclass)
@@ -998,7 +999,8 @@ PONY_API void* pony_alloc_small(pony_ctx_t* ctx, uint32_t sizeclass)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, HEAP_MIN << sizeclass);
 
-  return ponyint_heap_alloc_small(ctx->current, &ctx->current->heap, sizeclass);
+  return ponyint_heap_alloc_small(ctx->current, &ctx->current->heap, sizeclass,
+    TRACK_NO_FINALISERS);
 }
 
 PONY_API void* pony_alloc_large(pony_ctx_t* ctx, size_t size)
@@ -1006,7 +1008,8 @@ PONY_API void* pony_alloc_large(pony_ctx_t* ctx, size_t size)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
-  return ponyint_heap_alloc_large(ctx->current, &ctx->current->heap, size);
+  return ponyint_heap_alloc_large(ctx->current, &ctx->current->heap, size,
+    TRACK_NO_FINALISERS);
 }
 
 PONY_API void* pony_realloc(pony_ctx_t* ctx, void* p, size_t size)
@@ -1022,7 +1025,8 @@ PONY_API void* pony_alloc_final(pony_ctx_t* ctx, size_t size)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
-  return ponyint_heap_alloc_final(ctx->current, &ctx->current->heap, size);
+  return ponyint_heap_alloc(ctx->current, &ctx->current->heap, size,
+    TRACK_ALL_FINALISERS);
 }
 
 void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
@@ -1030,8 +1034,8 @@ void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, HEAP_MIN << sizeclass);
 
-  return ponyint_heap_alloc_small_final(ctx->current, &ctx->current->heap,
-    sizeclass);
+  return ponyint_heap_alloc_small(ctx->current, &ctx->current->heap,
+    sizeclass, TRACK_ALL_FINALISERS);
 }
 
 void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
@@ -1039,8 +1043,8 @@ void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
   pony_assert(ctx->current != NULL);
   DTRACE2(HEAP_ALLOC, (uintptr_t)ctx->scheduler, size);
 
-  return ponyint_heap_alloc_large_final(ctx->current, &ctx->current->heap,
-    size);
+  return ponyint_heap_alloc_large(ctx->current, &ctx->current->heap,
+    size, TRACK_ALL_FINALISERS);
 }
 
 PONY_API void pony_triggergc(pony_ctx_t* ctx)

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -31,6 +31,12 @@ typedef struct heap_t
 #endif
 } heap_t;
 
+enum
+{
+  TRACK_NO_FINALISERS = 0,
+  TRACK_ALL_FINALISERS = 0xFFFFFFFF,
+};
+
 uint32_t ponyint_heap_index(size_t size);
 
 void ponyint_heap_setinitialgc(size_t size);
@@ -44,34 +50,22 @@ void ponyint_heap_destroy(heap_t* heap);
 void ponyint_heap_final(heap_t* heap);
 
 __pony_spec_malloc__(
-  void* ponyint_heap_alloc(pony_actor_t* actor, heap_t* heap, size_t size)
+  void* ponyint_heap_alloc(pony_actor_t* actor, heap_t* heap, size_t size,
+    uint32_t track_finalisers_mask)
   );
 
 __pony_spec_malloc__(
 void* ponyint_heap_alloc_small(pony_actor_t* actor, heap_t* heap,
-  uint32_t sizeclass)
+  uint32_t sizeclass, uint32_t track_finalisers_mask)
   );
 
 __pony_spec_malloc__(
-void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size)
+void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size,
+  uint32_t track_finalisers_mask)
   );
 
 void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
   size_t size);
-
-__pony_spec_malloc__(
-  void* ponyint_heap_alloc_final(pony_actor_t* actor, heap_t* heap, size_t size)
-  );
-
-__pony_spec_malloc__(
-void* ponyint_heap_alloc_small_final(pony_actor_t* actor, heap_t* heap,
-  uint32_t sizeclass)
-  );
-
-__pony_spec_malloc__(
-void* ponyint_heap_alloc_large_final(pony_actor_t* actor, heap_t* heap,
-  size_t size)
-  );
 
 /**
  * Adds to the used memory figure kept by the heap. This allows objects

--- a/test/libponyrt/mem/heap.cc
+++ b/test/libponyrt/mem/heap.cc
@@ -13,7 +13,7 @@ TEST(Heap, Init)
   heap_t heap;
   ponyint_heap_init(&heap);
 
-  void* p = ponyint_heap_alloc(actor, &heap, 127);
+  void* p = ponyint_heap_alloc(actor, &heap, 127, TRACK_NO_FINALISERS);
   ASSERT_EQ((size_t)128, heap.used);
 
   chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
@@ -22,7 +22,7 @@ TEST(Heap, Init)
   size_t size = ponyint_heap_size(chunk);
   ASSERT_EQ(size, (size_t)128);
 
-  void* p2 = ponyint_heap_alloc(actor, &heap, 99);
+  void* p2 = ponyint_heap_alloc(actor, &heap, 99, TRACK_NO_FINALISERS);
   ASSERT_NE(p, p2);
   ASSERT_EQ((size_t)256, heap.used);
 
@@ -32,7 +32,7 @@ TEST(Heap, Init)
   ponyint_heap_endgc(&heap);
   ASSERT_EQ((size_t)128, heap.used);
 
-  void* p3 = ponyint_heap_alloc(actor, &heap, 107);
+  void* p3 = ponyint_heap_alloc(actor, &heap, 107, TRACK_NO_FINALISERS);
   ASSERT_EQ(p2, p3);
 
   ponyint_heap_used(&heap, 1024);
@@ -44,11 +44,11 @@ TEST(Heap, Init)
   ponyint_heap_endgc(&heap);
   ASSERT_EQ((size_t)128, heap.used);
 
-  void* p4 = ponyint_heap_alloc(actor, &heap, 67);
+  void* p4 = ponyint_heap_alloc(actor, &heap, 67, TRACK_NO_FINALISERS);
   ASSERT_EQ(p, p4);
 
   size_t large_size = (1 << 22) - 7;
-  void* p5 = ponyint_heap_alloc(actor, &heap, large_size);
+  void* p5 = ponyint_heap_alloc(actor, &heap, large_size, TRACK_NO_FINALISERS);
   chunk_t* chunk5 = (chunk_t*)ponyint_pagemap_get(p5);
   ASSERT_EQ(actor, ponyint_heap_owner(chunk5));
 


### PR DESCRIPTION
Prior to this commit, there were a number of heap allocation
functions for finalisers where the only difference from the
normal heap allocation functions was that the finaliser
functions kept track of which finalisers needed to be run
in the `chunk->finalisers` bitmap.

This commit combines the finaliser heap allocation functions
with their counterpart normal heap allocations functions.
It accomplishes this by adding in an extra argument called
`track_finalisers_mask` that can only be `0xFFFFFFFF` to
signify that finalisers should be tracked or `0` to signify
that finalisers shouldn't be tracked via a branchless bitwise
AND operation. This lowers the maintenance burden as now a
change to heap allocation logic will not need to be made
in two places at the same time and might even result in a
tiny performance increase due to the ever so slightly smaller
binary size.

The `track_finalisers_mask` is a bitmask instead of a `boolean`
to be able to keep the logic branchless:

```c
    chunk->finalisers |= (track_finalisers_mask & ((uint32_t)1 << bit));
```

If it was a `boolean` then the logic would need an if statement
instead:

```c
    if(track_finalisers_mask)
      chunk->finalisers |= ((uint32_t)1 << bit);
```
