### PR TITLE
Change error message

### DIFF
--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -10,5 +10,4 @@ actor Main
                 my_test_class.x= 1
 ```
 
-was changed from "not safe to write right side to left side" to
-"cannot write to a field in a box function. If you are trying to change state in a function use fun ref."
+was changed from "not safe to write right side to left side" to "cannot write to a field in a box function. If you are trying to change state in a function use fun ref."

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -4,11 +4,13 @@ The error message when assigning to a field of a field in box functions was fixe
 
 ```pony
 actor Main
-        let my_test_class: TestClass= TestClass
-        new create(env: Env) =>
-                """placeholder"""
-        fun test() =>
-                my_test_class.x= 1
+  let my_test_class: TestClass = TestClass
+        
+   new create(env: Env) =>
+      None 
+                
+    fun test() =>
+      my_test_class.x = 1
 ```
 
 was changed from "not safe to write right side to left side" to "cannot write to a field in a box function. If you are trying to change state in a function use fun ref."

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -3,6 +3,9 @@
 The error message when assigning to a field of a field in box functions was fixed to reflect that the function should be a fun ref. This affects code like the below:
 
 ```pony
+class TestClass
+  var x: ISize
+
 actor Main
   let my_test_class: TestClass = TestClass
         

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,5 +1,6 @@
-## change error message
+## Change error message
 error message in the situation:
+
 ```pony
 actor Main
         let my_test_class: TestClass= TestClass
@@ -8,5 +9,6 @@ actor Main
         fun test() =>
                 my_test_class.x= 1
 ```
-was changed from ```not safe to write right side to left side``` to 
-```cannot write to a field in a box function. If you are trying to change state in a function use fun ref.```
+
+was changed from "not safe to write right side to left side" to
+"cannot write to a field in a box function. If you are trying to change state in a function use fun ref."

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,6 +1,6 @@
 ## change error message
 error message in the situation:
-```
+```pony
 actor Main
         let my_test_class: TestClass= TestClass
         new create(env: Env) =>

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,0 +1,12 @@
+## change error message
+error message in the situation:
+```
+actor Main
+        let my_test_class: TestClass= TestClass
+        new create(env: Env) =>
+                """placeholder"""
+        fun test() =>
+                my_test_class.x= 1
+```
+was changed from ```not safe to write right side to left side``` to 
+```cannot write to a field in a box function. If you are trying to change state in a function use fun ref.```

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,4 +1,5 @@
 ## Change error message
+
 error message in the situation:
 
 ```pony

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,6 +1,6 @@
 ## Change error message
 
-error message in the situation:
+The error message when assigning to a field of a field in box functions was fixed to reflect that the function should be a fun ref. This affects code like the below:
 
 ```pony
 actor Main

--- a/.release-notes/4147.md
+++ b/.release-notes/4147.md
@@ -1,5 +1,7 @@
 ## Change error message
 
+Previously when assigning to a field of a field in box functions you recieved "not safe to write right side to left side"
+
 The error message when assigning to a field of a field in box functions was fixed to reflect that the function should be a fun ref. This affects code like the below:
 
 ```pony
@@ -16,4 +18,4 @@ actor Main
       my_test_class.x = 1
 ```
 
-was changed from "not safe to write right side to left side" to "cannot write to a field in a box function. If you are trying to change state in a function use fun ref."
+This was changed  to "cannot write to a field in a box function. If you are trying to change state in a function use fun ref." to improve understanding of the error.

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -441,7 +441,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     ast_t *left_lastchild = left;
     while(ast_child(left_lastchild) != NULL)
     {
-      left_lastchild= ast_child(left_lastchild);
+      left_lastchild = ast_child(left_lastchild);
     }
     if(ast_id(left) == TK_FVARREF && ast_child(left) != NULL &&
       ast_id(left_lastchild) == TK_THIS)

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -438,8 +438,13 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
   if(!ok_safe)
   {
+    ast_t *left_lastchild= left;
+    while(ast_child(left_lastchild) != NULL)
+    {
+      left_lastchild= ast_child(left_lastchild);
+    }
     if(ast_id(left) == TK_FVARREF && ast_child(left) != NULL &&
-      ast_id(ast_child(left)) == TK_THIS)
+      ast_id(left_lastchild) == TK_THIS)
     {
       // We are writing to a field in this
       ast_t* fn = ast_nearest(left, TK_FUN);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -438,7 +438,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
 
   if(!ok_safe)
   {
-    ast_t *left_lastchild= left;
+    ast_t *left_lastchild = left;
     while(ast_child(left_lastchild) != NULL)
     {
       left_lastchild= ast_child(left_lastchild);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -443,7 +443,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     {
       left_lastchild = ast_child(left_lastchild);
     }
-    if(ast_id(left) == TK_FVARREF && ast_child(left) != NULL &&
+    if(ast_id(left) == TK_FVARREF &&
       ast_id(left_lastchild) == TK_THIS)
     {
       // We are writing to a field in this


### PR DESCRIPTION
changes error message when assigning to a variable in a class from ```not safe to write right side to left side``` to ```cannot write to a field in a box function. If you are trying to change state in a function use fun ref``` by making the ```if``` statement compare the last child instead of the immediate one

Fixes #4148