### PR TITLE
Fix incorrect atomics usage

### DIFF
--- a/.release-notes/4159.md
+++ b/.release-notes/4159.md
@@ -1,0 +1,10 @@
+## Fix "incorrect" atomics usage
+
+When reviewing other code, we noticed that an old PR that was porting code from one atomics system to another changed the semantics of some atomics. The changes would have no impact on X86, but could have an impact on CPUs with weaker memory models like Arm.
+
+The changes would be tricky to easily evaluate if the changes (all weaken the semantics) are ok. Given that we do not have the time to evaluate the changes fully at the moment, we are switched to having stronger semantics.
+
+This change might fix incorrect atomics usage and memory issues on Arm and RISC-V. It will definitely cause some amount of slowdown on those platforms.
+
+If anyone wants to do a thorough review of various atomics and prove that we can
+weaken any safely, we will happily accept PRs that contain proof of the safety.

--- a/src/common/pony/detail/atomics.h
+++ b/src/common/pony/detail/atomics.h
@@ -167,7 +167,7 @@ namespace ponyint_atomics
 #    define bigatomic_store_explicit(PTR, VAL, MO) \
       ponyint_atomics::big_store(PTR, VAL)
 
-#    define bigatomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
+#    define bigatomic_compare_exchange_strong_explicit(PTR, EXP, DES, SUCC, FAIL) \
       ponyint_atomics::big_cas(PTR, EXP, DES)
 
 #    pragma warning(pop)
@@ -184,10 +184,10 @@ namespace ponyint_atomics
         __atomic_store_n(&(PTR)->raw, (VAL).raw, MO); \
       })
 
-#    define bigatomic_compare_exchange_weak_explicit(PTR, EXP, DES, SUCC, FAIL) \
+#    define bigatomic_compare_exchange_strong_explicit(PTR, EXP, DES, SUCC, FAIL) \
       ({ \
         _Static_assert(sizeof(*(PTR)) == (2 * sizeof(void*)), ""); \
-        __atomic_compare_exchange_n(&(PTR)->raw, &(EXP)->raw, (DES).raw, true, \
+        __atomic_compare_exchange_n(&(PTR)->raw, &(EXP)->raw, (DES).raw, false, \
           SUCC, FAIL); \
       })
 #  endif

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -260,7 +260,7 @@ static void track_init()
 
   track.init = true;
   track.thread_id = atomic_fetch_add_explicit(&track_global_thread_id, 1,
-    memory_order_relaxed);
+    memory_order_seq_cst);
   track_global_info[track.thread_id] = &track;
 
   // Force the symbol to be linked.
@@ -720,7 +720,7 @@ static void pool_push(pool_local_t* thread, pool_global_t* global)
     ANNOTATE_HAPPENS_BEFORE(&global->central);
 #endif
   }
-  while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
+  while(!bigatomic_compare_exchange_strong_explicit(&global->central, &cmp,
     xchg, memory_order_acq_rel, memory_order_acquire));
 }
 
@@ -747,7 +747,7 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
     xchg.object = next;
     xchg.counter = cmp.counter + 1;
   }
-  while(!bigatomic_compare_exchange_weak_explicit(&global->central, &cmp,
+  while(!bigatomic_compare_exchange_strong_explicit(&global->central, &cmp,
     xchg, memory_order_acq_rel, memory_order_acquire));
 
   // We need to synchronise twice on global->central to make sure we see every

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -138,7 +138,7 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
     xchg.object = next;
     xchg.counter = cmp.counter + 1;
   }
-  while(!bigatomic_compare_exchange_weak_explicit(&q->tail, &cmp, xchg,
+  while(!bigatomic_compare_exchange_strong_explicit(&q->tail, &cmp, xchg,
     memory_order_acq_rel, memory_order_acquire));
 
   // Synchronise on tail->next to ensure we see the write to next->data from


### PR DESCRIPTION
I was looking at https://github.com/ponylang/ponyc/pull/1206 and noticed
that when Benoit did the porting, that in a few places, he changed the
atomics usage unintentionally from what it was previously.

This commit reverts those (almost assuredly) inadvertent changes.

I can't guarantee that there are no other bits that were incorrect
in that commit, but I know these bits where.

I believe from a cursory glance that these could do "very bad things"
on weakly ordered memory platforms like Arm.