### PR TITLE
Don't call "sleep" for schedulers that shouldn't yield

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -330,14 +330,14 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
   if(diff < 10000000)
     return;
 
-#ifdef PLATFORM_IS_WINDOWS
-  DWORD ts = 0;
-#else
-  struct timespec ts = {0, 0};
-#endif
-
   if(yield)
   {
+#ifdef PLATFORM_IS_WINDOWS
+    DWORD ts = 0;
+#else
+    struct timespec ts = {0, 0};
+#endif
+
     // A billion cycles is roughly half a second, depending on clock speed.
     if(diff > 10000000000)
     {
@@ -372,14 +372,14 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
       ts.tv_nsec = 100000;
 #endif
     }
-  }
 
 #ifdef PLATFORM_IS_WINDOWS
-  SleepEx(ts, true);
+    SleepEx(ts, true);
 #else
-  DTRACE1(CPU_NANOSLEEP, ts.tv_nsec);
-  nanosleep(&ts, NULL);
+    DTRACE1(CPU_NANOSLEEP, ts.tv_nsec);
+    nanosleep(&ts, NULL);
 #endif
+  }
 }
 
 void ponyint_cpu_relax()


### PR DESCRIPTION
Prior to this change, scheduler threads that been waiting for work
for 10000000 or more cycles would always call SleepEx/nanosleep
regardless of the value of `yield`.

When the number of cycles was at least 10000000 and no more than
10000000000, this would have sleep called with a zero value. On
both Windows and Posix, calling with a 0 value causes the thread
to yield.

We were yielding regardless of `yield` value. Yield was only
controlling if we would yield for more than our timeslice. It
wasn't preventing the scheduler thread from giving up its current
timeslice and being rescheduled at the kernel's leisure.

The code has been updated to only call sleep when yields are
requested.