### PR TITLE
Fix bug in `StdStream.print`

### DIFF
--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -4,4 +4,4 @@ When printing via `StdStream.print` strings containing the null terminator, the 
 
 That behavior was introduced in release 0.12.0, fixing a left-over from when Pony strings were null terminated.
 
-Now the `print` function is effectively printing every character in the string plus an ending newline character.
+Now  `Stdstream.print` is effectively printing every character in the string plus an ending newline character.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -1,4 +1,4 @@
-## Fix unwanted indentation in `StdStream.print`
+## Fix bug in `StdStream.print`
 
 When printing via `StdStream.print` strings containing null bytes, the standard library was printing the string until the first null byte and then padding the printed string with space characters until the string size was reached.
 

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -1,9 +1,6 @@
 ## Fix unwanted indentation in `StdStream.print`
 
-When printing via `StdStream.print` strings containing the null terminator, the
-standard library was printing the string until the null terminator and then
-padding the printed string with space characters until the string size was
-reached.
+When printing via `StdStream.print` strings containing the null terminator, the standard library was printing the string until the null terminator and then padding the printed string with space characters until the string size was reached.
 
 That behavior was introduced in release 0.12.0, fixing a left-over from when
 Pony strings were null terminated.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -1,6 +1,6 @@
 ## Fix unwanted indentation in `StdStream.print`
 
-When printing via `StdStream.print` strings containing the null terminator, the standard library was printing the string until the null terminator and then padding the printed string with space characters until the string size was reached.
+When printing via `StdStream.print` strings containing null bytes, the standard library was printing the string until the first null byte and then padding the printed string with space characters until the string size was reached.
 
 This bug was introduced in Pony 0.12.0 while fixing a different printing bug.
 

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -2,6 +2,6 @@
 
 When printing via `StdStream.print` strings containing the null terminator, the standard library was printing the string until the null terminator and then padding the printed string with space characters until the string size was reached.
 
-That behavior was introduced in release 0.12.0, fixing a left-over from when Pony strings were null terminated.
+This bug was introduced in Pony 0.12.0 while fixing a different printing bug.
 
 Now  `Stdstream.print` is effectively printing every character in the string plus an ending newline character.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -4,4 +4,4 @@ When printing via `StdStream.print` strings containing null bytes, the standard 
 
 This bug was introduced in Pony 0.12.0 while fixing a different printing bug.
 
-Now  `Stdstream.print` is effectively printing every character in the string plus an ending newline character.
+We've fixed the bug so that printing strings with null bytes works as expected.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -1,0 +1,12 @@
+## Fix unwanted indentation in `StdStream.print`
+
+When printing via `StdStream.print` strings containing the null terminator, the
+standard library was printing the string until the null terminator and then
+padding the printed string with space characters until the string size was
+reached.
+
+That behavior was introduced in release 0.12.0, fixing a left-over from when
+Pony strings were null terminated.
+
+Now the `print` function is effectively printing every character in the string
+plus an ending newline character.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -5,5 +5,4 @@ When printing via `StdStream.print` strings containing the null terminator, the 
 That behavior was introduced in release 0.12.0, fixing a left-over from when
 Pony strings were null terminated.
 
-Now the `print` function is effectively printing every character in the string
-plus an ending newline character.
+Now the `print` function is effectively printing every character in the string plus an ending newline character.

--- a/.release-notes/4180.md
+++ b/.release-notes/4180.md
@@ -2,7 +2,6 @@
 
 When printing via `StdStream.print` strings containing the null terminator, the standard library was printing the string until the null terminator and then padding the printed string with space characters until the string size was reached.
 
-That behavior was introduced in release 0.12.0, fixing a left-over from when
-Pony strings were null terminated.
+That behavior was introduced in release 0.12.0, fixing a left-over from when Pony strings were null terminated.
 
 Now the `print` function is effectively printing every character in the string plus an ending newline character.

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -515,10 +515,8 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
 
 PONY_API void pony_os_std_print(FILE* fp, char* buffer, size_t len)
 {
-  if(len == 0)
-    fprintf(fp, "\n");
-  else
-    fprintf(fp, "%*.*s\n", (int)len, (int)len, buffer);
+  fwrite(buffer, len, 1, fp);
+  fprintf(fp, "\n");
 }
 
 PONY_API void pony_os_std_write(FILE* fp, char* buffer, size_t len)


### PR DESCRIPTION
When printing via `StdStream.print` strings containing the null
terminator, we were just printing the string until the null terminator
and replacing the unprinted characters by padding the printed string
with space characters.

This behavior made `String.size()` inconsistent with what `fprintf` was
really printing.

This behavior has been introduced in #1768, which ensure we respected
the buffer size.

Closes #4171