### PR TITLE
FreeBSD - Fix build by using recent googletest/benchmark

### DIFF
--- a/benchmark/libponyrt/ds/hash.cc
+++ b/benchmark/libponyrt/ds/hash.cc
@@ -46,7 +46,7 @@ struct hash_elem_t
 
 void HashMapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     // range(0) == initial size of hashmap
     testmap_init(&_map, static_cast<size_t>(st.range(0)));
     // range(1) == # of items to insert
@@ -57,7 +57,7 @@ void HashMapBench::SetUp(const ::benchmark::State& st)
 
 void HashMapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     testmap_destroy(&_map);
   }
 }

--- a/benchmark/libponyrt/mem/heap.cc
+++ b/benchmark/libponyrt/mem/heap.cc
@@ -16,14 +16,14 @@ class HeapBench: public ::benchmark::Fixture
 
 void HeapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_init(&_heap);
   }
 }
 
 void HeapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_destroy(&_heap);
   }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,20 +30,14 @@ endif()
 
 # Libraries
 
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz)
-endif()
+set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.0.tar.gz)
 
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
 )
 
-set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.11.0.tar.gz)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.10.0.tar.gz)
-endif()
+set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz)
 
 ExternalProject_Add(googletest
     URL ${PONYC_GOOGLETEST_URL}


### PR DESCRIPTION
* The build failed due to `-Werror` turning a `-Wunused-but-set-variable` warning into an error.

* The newer version of googletest / benchmark don't exhibit this problem. Actually, only one of these libraries had an issue on FreeBSD (in the pinned version), though updating both to the most recent versions should not cause harm.

* This also removes special casing any of these libraries on FreeBSD.