### PR TITLE
Update supported FreeBSD to 13.1

### DIFF
--- a/.ci-scripts/x86-64-unknown-freebsd-13.1-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-13.1-nightly.bash
@@ -19,7 +19,7 @@ ARCH=x86-64
 
 # Triple construction
 VENDOR=unknown
-OS=freebsd-13.0
+OS=freebsd-13.1
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters

--- a/.ci-scripts/x86-64-unknown-freebsd-13.1-release.bash
+++ b/.ci-scripts/x86-64-unknown-freebsd-13.1-release.bash
@@ -17,7 +17,7 @@ ARCH=x86-64
 
 # Triple construction
 VENDOR=unknown
-OS=freebsd-13.0
+OS=freebsd-13.1
 TRIPLE=${ARCH}-${VENDOR}-${OS}
 
 # Build parameters

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,7 +87,7 @@ task:
   timeout_in: 120m
 
   freebsd_instance:
-    image: freebsd-13-0-release-amd64
+    image: freebsd-13-1-release-amd64
     cpu: 8
     memory: 24
 
@@ -102,7 +102,7 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.0 20210710"
+    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.1 20210710"
     populate_script: gmake libs build_flags=-j8
   upload_caches:
     - libs
@@ -385,11 +385,11 @@ task:
   timeout_in: 120m
 
   freebsd_instance:
-    image: freebsd-13-0-release-amd64
+    image: freebsd-13-1-release-amd64
     cpu: 8
     memory: 24
 
-  name: "nightly: x86-64-unknown-freebsd-13.0"
+  name: "nightly: x86-64-unknown-freebsd-13.1"
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
@@ -402,13 +402,13 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.0 20210710"
+    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.1 20210710"
     populate_script: gmake libs build_flags=-j8
   upload_caches:
     - libs
 
   nightly_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd-13.0-nightly.bash
+    - bash .ci-scripts/x86-64-unknown-freebsd-13.1-nightly.bash
 
 task:
   only_if: $CIRRUS_CRON == "nightly"
@@ -585,11 +585,11 @@ task:
   timeout_in: 120m
 
   freebsd_instance:
-    image: freebsd-13-0-release-amd64
+    image: freebsd-13-1-release-amd64
     cpu: 8
     memory: 24
 
-  name: "release: x86-64-unknown-freebsd-13.0"
+  name: "release: x86-64-unknown-freebsd-13.1"
 
   environment:
     CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
@@ -602,13 +602,13 @@ task:
 
   libs_cache:
     folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.0 20210710"
+    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` freebsd-13.1 20210710"
     populate_script: gmake libs build_flags=-j8
   upload_caches:
     - libs
 
   release_script:
-    - bash .ci-scripts/x86-64-unknown-freebsd-13.0-release.bash
+    - bash .ci-scripts/x86-64-unknown-freebsd-13.1-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'

--- a/.release-notes/4185.md
+++ b/.release-notes/4185.md
@@ -1,0 +1,5 @@
+## Update supported FreeBSD to 13.1
+
+Prebuilt FreeBSD ponyc binaries are now built for FreeBSD 13.1. All CI is also done using FreeBSD 13.1. We will make a "best effort" attempt to not break FreeBSD 13.0, but the only supported version of FreeBSD going forward is 13.1.
+
+Previously built ponyc versions targeting FreeBSD 13.0 will continue to be available.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -46,7 +46,7 @@ Package names will be:
 
 * ponyc-arm64-apple-darwin.tar.gz
 * ponyc-x86-64-apple-darwin.tar.gz
-* ponyc-x86-64-unknown-freebsd-13.0.tar.gz
+* ponyc-x86-64-unknown-freebsd-13.1.tar.gz
 * ponyc-x86-64-pc-windows-msvc.zip
 * ponyc-x86-64-unknown-linux-gnu.tar.gz
 * ponyc-x86-64-unknown-linux-musl.tar.gz

--- a/benchmark/libponyrt/ds/hash.cc
+++ b/benchmark/libponyrt/ds/hash.cc
@@ -46,7 +46,7 @@ struct hash_elem_t
 
 void HashMapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     // range(0) == initial size of hashmap
     testmap_init(&_map, static_cast<size_t>(st.range(0)));
     // range(1) == # of items to insert
@@ -57,7 +57,7 @@ void HashMapBench::SetUp(const ::benchmark::State& st)
 
 void HashMapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     testmap_destroy(&_map);
   }
 }

--- a/benchmark/libponyrt/mem/heap.cc
+++ b/benchmark/libponyrt/mem/heap.cc
@@ -16,14 +16,14 @@ class HeapBench: public ::benchmark::Fixture
 
 void HeapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_init(&_heap);
   }
 }
 
 void HeapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_destroy(&_heap);
   }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 # Libraries
 
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.0.tar.gz)
+set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.1.tar.gz)
 
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,10 +30,7 @@ endif()
 
 # Libraries
 
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz)
-endif()
+set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.0.tar.gz)
 
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}


### PR DESCRIPTION
Updates our supported FreeBSD to 13.1. 

All other changes herein were required to get everything passing. Google benchmark was particularly problematic as only the 1.7 series works on FreeBSD 13.1 but benchmark 1.7.0 didn't work on Windows.