### PR TITLE
Reorder fields to reduce `sizeof(asio_event_t)` to 40 bytes

### DIFF
--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -20,10 +20,10 @@ typedef struct asio_event_t
   int fd;               /* file descriptor */
   uint32_t flags;       /* event filter flags */
   bool noisy;           /* prevents termination? */
-  uint64_t nsec;        /* nanoseconds for timers */
-
   bool readable;        /* is fd readable? */
   bool writeable;       /* is fd writeable? */
+  uint64_t nsec;        /* nanoseconds for timers */
+
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE timer;         /* timer handle */
 #endif


### PR DESCRIPTION
Reduces `sizeof(struct asio_event_t)` from 48 bytes to 40 bytes on 64-bit x86 Linux/FreeBSD. The `noisy` field was talking up 3 bytes due to aligment of the following 64-bit value `nsecs` at a word boundary (offset 32).  The two other flags `readable` and `writable` fit in the alignment hole and no longer waste 8 bytes to align the whole struct at word boundaries again.

Note that the offset of `nsecs` is not changed. It still lives at offset 32.