### PR TITLE
Update to Google benchmark 1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT PONY_CROSS_LIBPONYRT)
     find_package(LLVM REQUIRED CONFIG PATHS "build/libs/lib/cmake/llvm" "build/libs/lib64/cmake/llvm" NO_DEFAULT_PATH)
     find_package(GTest REQUIRED CONFIG PATHS "build/libs/lib/cmake/GTest" "build/libs/lib64/cmake/GTest" NO_DEFAULT_PATH)
-    find_package(benchmark REQUIRED CONFIG PATHS "build/libs/lib/cmake/benchmark" "build/libs/lib64/cmake/benchmark" NO_DEFAULT_PATH)
+    if(DEFINED PONYC_GBENCHMARK_URL)
+        find_package(benchmark REQUIRED CONFIG PATHS "build/libs/lib/cmake/benchmark" "build/libs/lib64/cmake/benchmark" NO_DEFAULT_PATH)
+    endif()
 endif()
 
 # Uses
@@ -281,8 +283,10 @@ else()
     add_subdirectory(test/libponyc-run/runner)
     add_subdirectory(test/libponyrt)
 
-    add_subdirectory(benchmark/libponyc)
-    add_subdirectory(benchmark/libponyrt)
+    if(DEFINED PONYC_GBENCHMARK_URL)
+        add_subdirectory(benchmark/libponyc)
+        add_subdirectory(benchmark/libponyrt)
+    endif()
 
     install(TARGETS
         ponyc

--- a/benchmark/libponyrt/ds/hash.cc
+++ b/benchmark/libponyrt/ds/hash.cc
@@ -46,7 +46,7 @@ struct hash_elem_t
 
 void HashMapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     // range(0) == initial size of hashmap
     testmap_init(&_map, static_cast<size_t>(st.range(0)));
     // range(1) == # of items to insert
@@ -57,7 +57,7 @@ void HashMapBench::SetUp(const ::benchmark::State& st)
 
 void HashMapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     testmap_destroy(&_map);
   }
 }

--- a/benchmark/libponyrt/mem/heap.cc
+++ b/benchmark/libponyrt/mem/heap.cc
@@ -16,14 +16,14 @@ class HeapBench: public ::benchmark::Fixture
 
 void HeapBench::SetUp(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_init(&_heap);
   }
 }
 
 void HeapBench::TearDown(const ::benchmark::State& st)
 {
-  if (st.thread_index == 0) {
+  if (st.thread_index() == 0) {
     ponyint_heap_destroy(&_heap);
   }
 }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,16 +29,13 @@ if(NOT MSVC)
 endif()
 
 # Libraries
-
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.6.tar.gz)
-if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-    set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.5.3.tar.gz)
+if((NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD") AND (NOT MSVC))
+    set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.7.0.tar.gz)
+    ExternalProject_Add(gbenchmark
+        URL ${PONYC_GBENCHMARK_URL}
+        CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
+    )
 endif()
-
-ExternalProject_Add(gbenchmark
-    URL ${PONYC_GBENCHMARK_URL}
-    CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
-)
 
 set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/archive/release-1.12.1.tar.gz)
 


### PR DESCRIPTION
Google benchmark 1.7.0 isn't correctly compiling for us on Windows and FreeBSD 13.0 so we are turning it off for now on each platform.

Generally, "the next version" of benchmark will fix these sorts of issues and we can turn Windows and FreeBSD back on.