### PR TITLE
Fix broken readline package

### DIFF
--- a/.release-notes/ansi-erase.md
+++ b/.release-notes/ansi-erase.md
@@ -1,0 +1,7 @@
+## Reverts Ansi.erase to erase to the right, not the left
+
+With the release of 0.49.0, we changed `Ansi.erase` to be erasing left rather than right. This made sense based on the comment on the `Ansi.erase` method. However, the actual usage in the standard library of `Ansi.erase` was expecting it to erase to the right. Because of this change, since 0.49.0, the readline support in the `term` package has been broken.
+
+We've reverted the changes from the [original PR](https://github.com/ponylang/ponyc/pull/4022) and updated the comment on `Ansi.erase` to note that it erases to right, not the left.
+
+We would welcome an RFC to discuss supporting both left and right erasure as part of the `Ansi` primitive.

--- a/packages/term/ansi.pony
+++ b/packages/term/ansi.pony
@@ -62,9 +62,9 @@ primitive ANSI
 
   fun erase(): String =>
     """
-    Erases everything to the left of the cursor on the line the cursor is on.
+    Erases everything to the right of the cursor on the line the cursor is on.
     """
-    "\x1B[1K"
+    "\x1B[0K"
 
   fun reset(): String =>
     """


### PR DESCRIPTION
With the release of 0.49.0, we changed `Ansi.erase` to be erasing left rather than right. This made sense based on the comment on the `Ansi.erase` method. However, the actual usage in the standard library of `Ansi.erase` was expecting it to erase to the right. Because of this change, since 0.49.0, the readline support in the `term` package has been broken.

This commit switches erase back to erasing to the right and in the process fixes the readline package. The commment on `erase` has been updated to reflect what it actually does.

Supporting erasing to both the left and the right seems valuable but, I'm not addressing that here and instead am leaving that to an RFC.