### PR TITLE
Only run libponyc.run.tests in debug mode

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -290,7 +290,7 @@ switch ($Command.ToLower())
         # libponyc.run.tests
         $cpuPhysicalCount, $cpuLogicalCount = ($cpuInfo = Get-CimInstance -ClassName Win32_Processor).NumberOfCores, $cpuInfo.NumberOfLogicalProcessors
 
-        foreach ($runConfig in ('debug', 'release'))
+        foreach ($runConfig in ('debug'))
         {
             $numTestSuitesRun += 1;
 


### PR DESCRIPTION
Currently for both release ande debug runtimes, we compile the test programs both with and without --debug. This commit changes to only build with --debug.

This change is because currently tests are taking a really long time with the release version of the runtime. This is a hopefully temporary fix to speed things up.