### PR TITLE
Speed up runtime on Windows

### DIFF
--- a/src/libponyrt/sched/cpu.c
+++ b/src/libponyrt/sched/cpu.c
@@ -365,8 +365,10 @@ void ponyint_cpu_core_pause(uint64_t tsc, uint64_t tsc2, bool yield)
     else
     {
 #ifdef PLATFORM_IS_WINDOWS
-      // Otherwise, pause for 1 ms (minimum on windows)
-      ts = 1;
+      // Windows minimum for pause is 1 millisecond which is a long time
+      // compared to what we want. Instead, let's not yield. But to go a little
+      // too fast then 10x too slow for waking up.
+      ts = 0;
 #else
       // Otherwise, pause for 100 microseconds
       ts.tv_nsec = 100000;


### PR DESCRIPTION
Currently, the windows "lowest CPU yield time" is set to 1 millisecond which is 10x longer than on other platforms. Windows, particularly when running tests, is also noticeably slower than other platforms. I think this regular 10x longer pause can, over time, roll up into things taking much much longer on windows.

I believe it is better to yield "too little" rather than "too much".