### PR TITLE
Use cirrus compute credits when doing releases

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -472,6 +472,7 @@ task:
 
 task:
   only_if: $CIRRUS_CRON == "nightly"
+  use_compute_credits: true
 
   timeout_in: 120m
 
@@ -512,6 +513,7 @@ task:
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+  use_compute_credits: true
 
   timeout_in: 120m
 
@@ -579,6 +581,7 @@ task:
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+  use_compute_credits: true
 
   timeout_in: 120m
 
@@ -610,6 +613,7 @@ task:
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+  use_compute_credits: true
 
   timeout_in: 120m
 
@@ -640,6 +644,7 @@ task:
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+  use_compute_credits: true
 
   timeout_in: 120m
 
@@ -670,6 +675,7 @@ task:
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
+  use_compute_credits: true
 
   timeout_in: 120m
 


### PR DESCRIPTION
Compute credits are detailed here: https://cirrus-ci.org/pricing/#compute-credits

Using compute credits will allow us to prevent release tasks for ponyc from getting pre-empted. Currently, if pre-empted at "just the wrong" time, can create issues that are hard for the average Pony releasers to sort out.

Pretty much anyone but me might get flummoxed. For what we believe will be a small yearly cost, we can avoid the problem by using compute credits for releases.

To make sure I set this up correctly, I have added the use of compute credits on a single nightly release task, Once I've determined that works correctly and feel good about the regular release setup, I'll remove the use of compute credits for the nightly job.

This change as discussed at the October 25, 2022 sync and we got a quorom of core team members (myself and Joe) signing off on this change.