### PR TITLE
Split Windows runner tests apart in time

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -287,22 +287,18 @@ switch ($Command.ToLower())
         }
         if ($err -ne 0) { $failedTestSuites += 'libponyc.tests' }
 
-        # libponyc.run.tests
+        # libponyc.run.tests debug
         $cpuPhysicalCount, $cpuLogicalCount = ($cpuInfo = Get-CimInstance -ClassName Win32_Processor).NumberOfCores, $cpuInfo.NumberOfLogicalProcessors
 
-        foreach ($runConfig in ('debug', 'release'))
-        {
-            $numTestSuitesRun += 1;
+        $numTestSuitesRun += 1;
 
-            $runOutDir = "$outDir\runner-tests\$runConfig"
-            $debugFlag = if ($runConfig -eq 'debug') { '--debug' } else { '' }
+        $runOutDir = "$outDir\runner-tests\debug"
 
-            if (-not (Test-Path $runOutDir)) { New-Item -ItemType Directory -Force -Path $runOutDir }
-            Write-Output "$buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner $debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run"
-            & $buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner $debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run
-            $err = $LastExitCode
-            if ($err -ne 0) { $failedTestSuites += "libponyc.run.tests.$runConfig" }
-        }
+        if (-not (Test-Path $runOutDir)) { New-Item -ItemType Directory -Force -Path $runOutDir }
+        Write-Output "$buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner --debug --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run"
+        & $buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner --debug --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run
+        $err = $LastExitCode
+        if ($err -ne 0) { $failedTestSuites += "libponyc.run.tests.debug" }
 
         # stdlib-debug
         $numTestSuitesRun += 1;
@@ -335,6 +331,17 @@ switch ($Command.ToLower())
         {
             $failedTestSuites += 'compile stdlib-debug'
         }
+
+        # more...
+        $numTestSuitesRun += 1;
+
+        $runOutDir = "$outDir\runner-tests\release"
+
+        if (-not (Test-Path $runOutDir)) { New-Item -ItemType Directory -Force -Path $runOutDir }
+        Write-Output "$buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run"
+        & $buildDir\test\libponyc-run\runner\runner.exe --timeout_s=60 --max_parallel=$cpuLogicalCount --exclude=runner --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\libponyc-run
+        $err = $LastExitCode
+        if ($err -ne 0) { $failedTestSuites += "libponyc.run.tests.release" }
 
         # stdlib-release
         $numTestSuitesRun += 1;


### PR DESCRIPTION
Through testing, it seems like running the runner tests back to back
ends up with us hitting problems where the machine seems to hang.

From some initial testing it looks like splitting them apart so
they run with a gap between them might solve the issue. More testing
is needed but if this change passes another bit of testing it
is probably worth trying this out for a bit and see if it continues
to make the tests run and not hang.