### PR TITLE
Strength the order for an atomic operation in the IOCP subsystem

### DIFF
--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -131,7 +131,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   SYSTEMATIC_TESTING_WAIT_START(ponyint_asio_get_backend_tid(), ponyint_asio_get_backend_sleep_object());
 #endif
 
-  while(!atomic_load_explicit(&b->stop, memory_order_relaxed))
+  while(!atomic_load_explicit(&b->stop, memory_order_acquire))
   {
     switch(WaitForMultipleObjectsEx(handleCount, handles, FALSE, -1, TRUE))
     {


### PR DESCRIPTION
In PR #4083, I reversed some relaxing of atomic orderings that were introduced in 2016 in #1209. When I was doing that change, I missed an additional strengthing that should have been done in the IOCP subsystem.

If you note the original commit, I made a corresponding change in the EPoll subsystem, but missed doing it in the IOCP system.