### PR TITLE
Update build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,7 +7,7 @@ First of all, you need a compiler with decent C11 support. We officially support
 - MSVC >= 2017
 - GCC >= 4.7
 
-You also need [CMake](https://cmake.org/download/) version 3.15 or higher.
+You also need [CMake](https://cmake.org/download/) version 3.15 or higher. You also need a version of [Python 3](https://www.python.org/downloads/) installed; it's required in order to build LLVM.
 
 ## Clone this repository
 
@@ -140,6 +140,7 @@ Note that you only need to run `make libs` once the first time you build (or if 
 Building on Windows requires the following:
 
 - [CMake](https://cmake.org/download/) version 3.15.0 or higher needs to be in your PATH.
+- [Python 3](https://www.python.org/downloads/)
 - Visual Studio 2019 or 2017 (available [here](https://www.visualstudio.com/vs/community/)) or the Visual C++ Build Tools 2019 or 2017 (available [here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)).
   - If using Visual Studio, install the `Desktop Development with C++` workload.
   - If using Visual C++ Build Tools, install the `Visual C++ build tools` workload, and the `Visual Studio C++ core features` individual component.


### PR DESCRIPTION
Python 3 is required to build LLVM.

Closes #4224