### PR TITLE
Avoid fairly easy to trigger overflow in Windows Time.nanos code

### DIFF
--- a/.release-notes/nanos-overflow.md
+++ b/.release-notes/nanos-overflow.md
@@ -1,0 +1,3 @@
+## Fixed an overflow in Time.nanos() values on Windows
+
+Based on how were were calculating nanos based of the QueryPerformanceCounter and QueryPerformanceFrequency on Windows, it was quite likely that we would eventually overflow the U64 we used to represent nanos and "go backwards in time".

--- a/packages/time/time.pony
+++ b/packages/time/time.pony
@@ -94,8 +94,7 @@ primitive Time
       var ts = _clock_gettime(_ClockMonotonic)
       ((ts._1 * 1000) + (ts._2 / 1000000)).u64()
     elseif windows then
-      (let qpc, let qpf) = _query_performance_counter()
-      (qpc * 1000) / qpf
+      _subseconds_from_query_performance_counter(1000)
     else
       compile_error "unsupported platform"
     end
@@ -110,8 +109,7 @@ primitive Time
       var ts = _clock_gettime(_ClockMonotonic)
       ((ts._1 * 1000000) + (ts._2 / 1000)).u64()
     elseif windows then
-      (let qpc, let qpf) = _query_performance_counter()
-      (qpc * 1000000) / qpf
+      _subseconds_from_query_performance_counter(1000000)
     else
       compile_error "unsupported platform"
     end
@@ -126,8 +124,7 @@ primitive Time
       var ts = _clock_gettime(_ClockMonotonic)
       ((ts._1 * 1000000000) + ts._2).u64()
     elseif windows then
-      (let qpc, let qpf) = _query_performance_counter()
-      (qpc * 1000000000) / qpf
+      _subseconds_from_query_performance_counter(1000000000)
     else
       compile_error "unsupported platform"
     end
@@ -182,6 +179,15 @@ primitive Time
     else
       compile_error "no clock_gettime"
     end
+
+  fun _subseconds_from_query_performance_counter(subseconds: U64): U64 =>
+      (let qpc, let qpf) = _query_performance_counter()
+      if qpf <= subseconds then
+        qpc * (subseconds / qpf)
+      else
+        (qpc * subseconds) / qpf
+      end
+
 
   fun _query_performance_counter(): (U64 /* qpc */, U64 /* qpf */) =>
     """


### PR DESCRIPTION
For millis, micros, and nanos support on Windows, we use the QueryPerformanceCounter as a monotonically increasing "source of time". Given the counter is 64-bits, for an imaginary 2ghz processor that probably gives us about 290ish years of ticks before we would wrap around and our monotonic nature would be broken. All this means, its an excellent "source of time".

To turn the result from the QueryPerformanceCounter into seconds, you divide its value by the QueryPerformanceFrequency. One my computer, the qpf value is 10_000_000.

The previous code for determining nanos on Windows was unfortunately, far more prone to wrapping around than the QueryPerformanceCounter. Previously, we did the following for nanos:

(qpc * 1_000_000_000) / qpf

Because we were multiplying the qpc (a 64 bit integer) by a large integer (1_000_000_000), we were greatly increasing the chance of wraparound.

I discovered this was happening in the wild because we had timers that would "hang" on Windows. It turns out they weren't hanging. What would happen is that eventually, the value from nanos would wrap around and based on the logic in Timers, this would take a 30 second timer and turn it into a 30 minute timer. (Numbers not exact, given more for a feel of the change). This looked like a runtime hang or otherwise a runtime bug, when in actuality, the timer was "doing the correct" thing based on the values it was given.

The change made to millis, micros, and nanos in this commit will greatly decrease our overflow chance with nanos as we are no longer doing the "first multiple by really big number".

Note that we change our algo to use based on whether the qpf value is greater than then number of subseconds to calculate. It is important that we do this so that we don't start returning incorrect values. If we
didn't do that we could end up with a situation like this for millis:

QPC * (1_000 / 10_000_000) which for integer math is

QPC * 0

aka "not good"