### PR TITLE
Update docgen to generate source files that are ignored

### DIFF
--- a/.release-notes/src-search-exclude.md
+++ b/.release-notes/src-search-exclude.md
@@ -1,0 +1,9 @@
+## "Exclude source files" from documentation source
+
+In the previous ponyc release, we updated the default theme used by our documentation generation from a custom theme based on mkdocs-material to using the latest mkdocs-material. With the change came the possibility of using all the latests mkdocs-material features. [Mkdocs-material](https://squidfunk.github.io/mkdocs-material/) is a heavily developed theme that has a ton of great features. Some of mkdocs-material's features are only available to [sponsors of the project](https://squidfunk.github.io/mkdocs-material/insiders/).
+
+One of the many excellent insider's features is the ability to exclude some files from the mkdocs search index. We've added support for this feature in the generated documentation so that, **iff** you are a mkdocs-material sponsor, the source code files that we link to from generated documentation will no longer be included in the source index.
+
+If you've used our generated documentation extensively, you know that having the source implementation linked is a great boon, but it is also a pain as it clutters up the search index and you often end up on a source implementation page from a search.
+
+If you are using the built in documentation generation that comes with ponyc, we suggest that you take a look into becoming a sponsor of mkdocs-material as we will be adding support for additional insiders features if folks find them to be useful as part of the generated documentation.

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -846,11 +846,16 @@ static doc_sources_t* copy_source_to_doc_src(docgen_t* docgen, source_t* source,
   FILE* file = fopen(path, "w");
 
   if (file != NULL) {
+    // start front matter
+    fprintf(file, "---\n");
     // tell the mkdocs theme to hide the right sidebar
     // so we have all the space we need for long lines
-    fprintf(file, "---\n");
     fprintf(file, "hide:\n");
     fprintf(file, "  - toc\n");
+    // tell the mkdocs theme not index source files for search
+    fprintf(file, "search:\n");
+    fprintf(file, "  exclude: true\n");
+    // end front matter
     fprintf(file, "---\n");
     // Escape markdown to tell this is Pony code
     // Using multiple '```````'  so hopefully the markdown parser


### PR DESCRIPTION
This feature is currently "sponsors only" so it won't work for regular users. However, we can switch our Pony projects over to using the insiders theme and take advantage of this change.

This will improve the search experience by not including our src files in the search index.

Any users that use mkdocs-material-insiders will also be able to take advantage of this change.