### PR TITLE
Install mkdocs-material-insiders in standard library builder image

### DIFF
--- a/.ci-dockerfiles/stdlib-builder/Dockerfile
+++ b/.ci-dockerfiles/stdlib-builder/Dockerfile
@@ -1,6 +1,8 @@
 ARG FROM_TAG=release-alpine
 FROM ponylang/ponyc:${FROM_TAG}
 
+ARG MATERIAL_INSIDERS_ACCESS="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"
+
 RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
@@ -15,4 +17,5 @@ RUN apk update \
   py3-pip \
   tar \
   && pip3 install --upgrade pip \
-  && pip3 install mkdocs mkdocs-material
+  && pip3 install mkdocs \
+  && pip3 install git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git

--- a/.ci-dockerfiles/stdlib-builder/build-and-push.bash
+++ b/.ci-dockerfiles/stdlib-builder/build-and-push.bash
@@ -1,6 +1,15 @@
 #!/bin/bash
 
 set -o errexit
+
+if [[ -z "${MATERIAL_INSIDERS_ACCESS}" ]]; then
+  echo -e "\e[31mMaterial Insiders Access API key needs to be set in MATERIAL_INSIDERS_ACCESS."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+MIA="${MATERIAL_INSIDERS_ACCESS}"
+
 set -o nounset
 
 #
@@ -13,12 +22,14 @@ DOCKERFILE_DIR="$(dirname "$0")"
 FROM_TAG=release-alpine
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
+  --build-arg MATERIAL_INSIDERS_ACCESS="${MIA}" \
+  -t ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
 
 # built from ponyc latest tag
 FROM_TAG=alpine
 TAG_AS=latest
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  -t ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
-docker push ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
+  --build-arg MATERIAL_INSIDERS_ACCESS="${MIA}" \
+  -t ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
+docker push ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"

--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -220,12 +220,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc-ci-stdlib-builder:release
+      image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:release
     steps:
-      - name: Install insiders theme
-        run: pip install git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -269,12 +265,8 @@ jobs:
     name: Test building standard library documentation
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc-ci-stdlib-builder:latest
+      image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:latest
     steps:
-      - name: Install insiders theme
-        run: pip install git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - uses: actions/checkout@v2
       - name: Build
         run: "bash .ci-scripts/build-stdlib-documentation.bash"

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -20,12 +20,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ponylang/ponyc-ci-stdlib-builder:latest
+      image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:latest
     steps:
-      - name: Install insiders theme
-        run: pip install git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/rebuild-stdlib-builder.yml
+++ b/.github/workflows/rebuild-stdlib-builder.yml
@@ -1,0 +1,25 @@
+name: Manually rebuild stdlib-builder
+
+on:
+  workflow_dispatch
+
+concurrency:
+  group: "rebuild-stdlib-builder"
+  cancel-in-progress: true
+
+jobs:
+  rebuild-stdlib-builder:
+    name: Update stdlib-builder Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docker login
+        run: "docker login ghcr.io -u $DOCKER_USERNAME -p $DOCKER_PASSWORD"
+        env:
+          DOCKER_PASSWORD: ${{ github.actor }}
+          DOCKER_USERNAME: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and push
+        run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
+        env:
+          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}


### PR DESCRIPTION
In theory, this is a simple thing to do. However, there's at least a couple additional moving parts here because, we do not want to expost squidfunk's "private insiders code" in a public image on docker hub.

The commit changes our standard library builder image to live in the GitHub container registry where we have marked it as private so only we can access it. By having the builder as private, we can safely install the insiders theme in it and use it for building our standard library docs.

To install in the image, we need to supply the correct access token as part of the build process. The token has been stored in a Ponylang org secret which is supplied at the time we build on GitHub. Because this makes building locally from the command line more complicated, we have also added a workflow_dispatch workflow to rebuild the stdlib-builder in an adhoc fashion via the GitHub UI if an adhoc rebuild is needed.