### PR TITLE
Don't include "home file" in documentation search

### DIFF
--- a/.release-notes/docgen-search-home-file.md
+++ b/.release-notes/docgen-search-home-file.md
@@ -1,0 +1,5 @@
+## Don't include generated documentation "home file" in search index
+
+We've updated the documentation generation to not include the "home file" that lists the packages in the search index. The "exclude from search engine" functionality is only available in the `mkdocs-material-insiders` theme.
+
+The home file is extra noise in the index that provides no value. For anyone using the insiders theme, this will be an improvement in the search experience.

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1375,6 +1375,11 @@ void generate_docs(ast_t* program, pass_opt_t* options)
     const char* name = package_filename(package);
 
     fprintf(docgen.home_file, "Packages\n\n");
+    // tell the mkdocs theme not index the home file for search
+    fprintf(docgen.home_file, "---\n");
+    fprintf(docgen.home_file, "search:\n");
+    fprintf(docgen.home_file, "  exclude: true\n");
+    fprintf(docgen.home_file, "---\n");
 
     fprintf(docgen.index_file, "site_name: %s\n", name);
     fprintf(docgen.index_file, "theme:\n");


### PR DESCRIPTION
The "home file" is only a list of the packages on the site. It ends up being extra noise in search results where it provides no value.

This commit adds front matter to the home file that will remove it from the search index when the mkdocs-material-insiders theme is removed.