### PR TITLE
Improve TCP backpressure handling on Windows

### DIFF
--- a/.release-notes/4081.md
+++ b/.release-notes/4081.md
@@ -1,0 +1,15 @@
+## Improve TCP Backpressure on Windows
+
+Our prior setting of backpressure for TCP writes on Windows was naive. It was  based purely on the number of buffers currently outstanding on an IOCP socket. The amount of data didn't matter at all. Whether more data could be accepted or not, also wasn't taken into consideration. We've enhanced the backpressure support at both the Pony level in `TCPConnection` and in the runtime API.
+
+Two runtime API methods have been updated on Windows.
+
+### pony_os_writev
+
+The Windows version of `pony_os_writev` will now return the number of buffers accepted or zero if backpressure is encountered. All other errors still cause an error that must be handled on the Pony side of the API via a `try` block.
+
+### pony_os_send
+
+The Windows version of `pony_os_send` will now return the number of bytes accepted or zero if backpressure is encountered. All other errors still cause an error that must be handled on the Pony side of the API via a `try` block.
+
+The changes are considered non-breaking as previously, the return values from both functions had no meaning.

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -392,9 +392,10 @@ static size_t iocp_send(asio_event_t* ev, const char* data, size_t len)
       default:
         iocp_destroy(iocp);
         pony_error();
-        return 0;
     }
   }
+
+  return 0;
 }
 
 static bool iocp_recv(asio_event_t* ev, char* data, size_t len)
@@ -958,9 +959,10 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, LPWSABUF wsa, int wsacnt)
       default:
         iocp_destroy(iocp);
         pony_error();
-        return 0;
     }
   }
+
+  return 0;
 }
 #else
 PONY_API size_t pony_os_writev(asio_event_t* ev, const struct iovec *iov, int iovcnt)

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -383,7 +383,7 @@ static size_t iocp_send(asio_event_t* ev, const char* data, size_t len)
 
   if(WSASend(s, &buf, 1, &sent, 0, &iocp->ov, NULL) != 0)
   {
-    switch GetLastError()
+    switch (GetLastError())
     {
       case WSA_IO_PENDING:
         return len;
@@ -948,7 +948,7 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, LPWSABUF wsa, int wsacnt)
 
   if(WSASend(s, wsa, wsacnt, &sent, 0, &iocp->ov, NULL) != 0)
   {
-    switch GetLastError()
+    switch (GetLastError())
     {
       case WSA_IO_PENDING:
         return wsacnt;

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -371,33 +371,6 @@ static bool iocp_accept(asio_event_t* ev)
   return true;
 }
 
-static size_t iocp_send(asio_event_t* ev, const char* data, size_t len)
-{
-  SOCKET s = (SOCKET)ev->fd;
-  iocp_t* iocp = iocp_create(IOCP_SEND, ev);
-  DWORD sent;
-
-  WSABUF buf;
-  buf.buf = (char*)data;
-  buf.len = (u_long)len;
-
-  if(WSASend(s, &buf, 1, &sent, 0, &iocp->ov, NULL) != 0)
-  {
-    switch (GetLastError())
-    {
-      case WSA_IO_PENDING:
-        return len;
-      case WSAEWOULDBLOCK :
-        return 0;
-      default:
-        iocp_destroy(iocp);
-        pony_error();
-    }
-  }
-
-  return 0;
-}
-
 static bool iocp_recv(asio_event_t* ev, char* data, size_t len)
 {
   SOCKET s = (SOCKET)ev->fd;
@@ -984,8 +957,27 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, const struct iovec *iov, int io
 PONY_API size_t pony_os_send(asio_event_t* ev, const char* buf, size_t len)
 {
 #ifdef PLATFORM_IS_WINDOWS
-  if(!iocp_send(ev, buf, len))
-    pony_error();
+  SOCKET s = (SOCKET)ev->fd;
+  iocp_t* iocp = iocp_create(IOCP_SEND, ev);
+  DWORD sent;
+
+  WSABUF b;
+  b.buf = (char*)buf;
+  b.len = (u_long)len;
+
+  if(WSASend(s, &b, 1, &sent, 0, &iocp->ov, NULL) != 0)
+  {
+    switch (GetLastError())
+    {
+      case WSA_IO_PENDING:
+        return len;
+      case WSAEWOULDBLOCK :
+        return 0;
+      default:
+        iocp_destroy(iocp);
+        pony_error();
+    }
+  }
 
   return 0;
 #else

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -392,6 +392,7 @@ static size_t iocp_send(asio_event_t* ev, const char* data, size_t len)
       default:
         iocp_destroy(iocp);
         pony_error();
+        return 0;
     }
   }
 }
@@ -957,6 +958,7 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, LPWSABUF wsa, int wsacnt)
       default:
         iocp_destroy(iocp);
         pony_error();
+        return 0;
     }
   }
 }

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -932,10 +932,11 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, LPWSABUF wsa, int wsacnt)
       default:
         iocp_destroy(iocp);
         pony_error();
+        return 0;
     }
   }
 
-  return 0;
+  return wsacnt;
 }
 #else
 PONY_API size_t pony_os_writev(asio_event_t* ev, const struct iovec *iov, int iovcnt)
@@ -976,10 +977,11 @@ PONY_API size_t pony_os_send(asio_event_t* ev, const char* buf, size_t len)
       default:
         iocp_destroy(iocp);
         pony_error();
+        return 0;
     }
   }
 
-  return 0;
+  return sent;
 #else
   ssize_t sent = send(ev->fd, buf, len, 0);
 


### PR DESCRIPTION
Our prior setting of backpressure for TCP writes on Windows was naive. It was based purely on the number of buffers currently outstanding on an IOCP socket. The amount of data didn't matter at all. Whether more data could be accepted or not, also wasn't taken into consideration. This commit greatly improves the situation by only applying backpressure when Windows tells us that it is applying backpressure.

No more guessing.

Two runtime API methods have been updated on Windows.

The Windows version of `pony_os_writev` will now return the number of buffers accepted or zero if backpressure is encountered. All other errors still cause an error that must be handled on the Pony side of the API via a `try` block.

The Windows version of `pony_os_send` will now return the number of bytes accepted or zero if backpressure is encountered. All other errors still cause an error that must be handled on the Pony side of the API via a `try` block.

I consider these changes  non-breaking as previously, the return values from both functions had no meaning.

Closes #4081