### PR TITLE
Update rocky8 and ubuntu18 builders

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-rocky8-builder/Dockerfile
@@ -18,8 +18,8 @@ RUN yum install -y \
   && pip3 install cloudsmith-cli
 
 # install a newer cmake
-RUN curl --output cmake-3.15.3-Linux-x86_64.sh https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh \
- && sh cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+RUN curl --output cmake-3.16.9-Linux-x86_64.sh https://cmake.org/files/v3.16/cmake-3.16.9-Linux-x86_64.sh \
+ && sh cmake-3.16.9-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # this broken, incorrect libstdc++.a breaks building libponyc-standalone.a
 # so, let's delete it!

--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu18.04-builder/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update \
  && pip3 install cloudsmith-cli
 
 # install a newer cmake
-RUN curl --output cmake-3.15.3-Linux-x86_64.sh https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.sh \
- && sh cmake-3.15.3-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+RUN curl --output cmake-3.16.9-Linux-x86_64.sh https://cmake.org/files/v3.16/cmake-3.16.9-Linux-x86_64.sh \
+ && sh cmake-3.16.9-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 
 # click is failing for uploads without this.
 ENV LC_ALL C.UTF-8

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -320,9 +320,9 @@ task:
   matrix:
     - name: "nightly: x86-64-unknown-linux-rocky8"
       container:
-        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20221129
       environment:
-        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20221129
         TRIPLE_VENDOR: unknown
         TRIPLE_OS: linux-rocky8
     - name: "nightly: x86-64-unknown-linux-gnu"
@@ -334,9 +334,9 @@ task:
         TRIPLE_OS: linux-gnu
     - name: "nightly: x86-64-unknown-linux-ubuntu18.04"
       container:
-        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20220720
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20221129
       environment:
-        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20220720
+        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20221129
         TRIPLE_VENDOR: unknown
         TRIPLE_OS: linux-ubuntu18.04
     - name: "nightly: x86-64-unknown-linux-ubuntu20.04"
@@ -519,9 +519,9 @@ task:
   matrix:
     - name: "release: x86-64-unknown-linux-rocky8"
       container:
-        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20221129
       environment:
-        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20210707
+        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-rocky8-builder:20221129
         TRIPLE_VENDOR: unknown
         TRIPLE_OS: linux-rocky8
     - name: "release: x86-64-unknown-linux-gnu"
@@ -533,9 +533,9 @@ task:
         TRIPLE_OS: linux-gnu
     - name: "release: x86-64-unknown-linux-ubuntu18.04"
       container:
-        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20220720
+        image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20221129
       environment:
-        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20220720
+        IMAGE: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu18.04-builder:20221129
         TRIPLE_VENDOR: unknown
         TRIPLE_OS: linux-ubuntu18.04
     - name: "release: x86-64-unknown-linux-ubuntu20.04"


### PR DESCRIPTION
Both need newer a newer cmake version to be able to build the googlebench version that we are now using.