### PR TITLE
add `.cache` directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ output/
 _ReSharper.*
 .vscode/
 .clangd/
+# clangd cache and index
+/.cache/
 src/common/dtrace_probes.h
 packages/stdlib/stdlib
 /stdlib-docs/


### PR DESCRIPTION
it is used by clangd to store some caching and its index