### PR TITLE
Remove macOS on Intel as a supported platform

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,36 +125,6 @@ task:
 
   timeout_in: 120m
 
-  osx_instance:
-    image: monterey-xcode-13.2
-
-  name: "x86-64 Apple Darwin"
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` macos monterey-xcode-13.2 20210710"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  debug_configure_script:
-    - make configure arch=x86-64 config=debug
-  debug_build_script:
-    - make build config=debug
-  debug_test_script:
-    - make test-ci config=debug usedebugger=lldb
-  release_configure_script:
-    - make configure arch=x86-64 config=release
-  release_build_script:
-    - make build config=release
-  release_test_script:
-    - make test-ci config=release usedebugger=lldb
-
-task:
-  only_if: $CIRRUS_PR != ''
-
-  timeout_in: 120m
-
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
 
@@ -408,36 +378,6 @@ task:
 
   timeout_in: 120m
 
-  osx_instance:
-    image: monterey-xcode-13.2
-
-  name: "nightly: x86-64-apple-darwin"
-
-  environment:
-    TRIPLE_VENDOR: apple
-    TRIPLE_OS: darwin
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` macos monterey-xcode-13.2 20210710"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  install_script:
-    - brew install python
-    - pip3 install --upgrade cloudsmith-cli
-
-  nightly_script:
-    - export TZ=utc
-    - bash .ci-scripts/x86-64-nightly.bash
-
-task:
-  only_if: $CIRRUS_CRON == "nightly"
-
-  timeout_in: 120m
-
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
 
@@ -595,37 +535,6 @@ task:
 
   release_script:
     - bash .ci-scripts/x86-64-unknown-freebsd-13.1-release.bash
-
-task:
-  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
-  use_compute_credits: true
-
-  timeout_in: 120m
-
-  osx_instance:
-    image: monterey-xcode-13.2
-
-  name: "release: x86-64-apple-darwin"
-
-  environment:
-    TRIPLE_VENDOR: apple
-    TRIPLE_OS: darwin
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` macos monterey-xcode-13.2 20210710"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  install_script:
-    - brew install python
-    - pip3 install --upgrade cloudsmith-cli
-
-  release_script:
-    - export TZ=utc
-    - bash .ci-scripts/x86-64-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'

--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -289,38 +289,6 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
-  send-macos-nightly-release-event:
-    if: |
-      github.event.client_payload.data.repository == 'nightlies' &&
-      github.event.client_payload.data.name == 'ponyc-x86-64-apple-darwin.tar.gz'
-
-    name: Send macos nightly release event
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo:
-          - ponylang/corral
-          - ponylang/ponyup
-    steps:
-      - name: Send
-        uses: ponylang-main/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4
-        with:
-          token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
-          repository: ${{ matrix.repo }}
-          event-type: ponyc-macos-nightly-released
-          client-payload: '{"version": "${{ github.event.client_payload.data.version }}"}'
-      - name: Alert on failure
-        if: ${{ failure() }}
-        uses: zulip/github-actions-zulip@35d7ad8e98444f894dcfe1d4e17332581d28ebeb
-        with:
-          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
-          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
-          organization-url: 'https://ponylang.zulipchat.com/'
-          to: notifications
-          type: stream
-          topic: ${{ github.repository }} scheduled job failure
-          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
-
   send-musl-nightly-release-event:
     needs: [build-latest-musl-docker-image]
 

--- a/.release-notes/bye-intel-macos.md
+++ b/.release-notes/bye-intel-macos.md
@@ -1,0 +1,3 @@
+## Deprecate macOS on Intel support
+
+We have moved macOS on Intel from being a fully supported platform to a best effort platform. We are no longer providing prebuilt ponyc binaries for macOS on Intel. We also no longer do any CI testing using macOS on Intel. We are not planning on intentionally breaking macOS on Intel but supporting it is no longer a priority.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,7 @@ If you get that error, it means that the Glibc we compiled ponyc with isn't comp
 
 ## macOS
 
-Prebuilt macOS packages are available via [ponyup](https://github.com/ponylang/ponyup). You can also install nightly builds using ponyup.
+Prebuilt macOS packages for Apple Silicon are available via [ponyup](https://github.com/ponylang/ponyup). You can also install nightly builds using ponyup.
 
 To install the most recent ponyc on macOS:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pony is still pre-1.0 and as such, semi-regularly introduces breaking changes. T
 
 * FreeBSD
 * Linux
-* macOS
+* macOS (Apple Silicon only)
 * Windows 10
 
 ### CPUs

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -45,7 +45,6 @@ You can verify that the release artifacts were successfully built and uploaded b
 Package names will be:
 
 * ponyc-arm64-apple-darwin.tar.gz
-* ponyc-x86-64-apple-darwin.tar.gz
 * ponyc-x86-64-unknown-freebsd-13.1.tar.gz
 * ponyc-x86-64-pc-windows-msvc.zip
 * ponyc-x86-64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
CirrusCI will be removing Intel MacOS runners at the end of 2022. It isn't worth our time to try to support another CI provider for building ponyc.