### PR TITLE
Fix an issue with infinite loops while typechecking some expressions

### DIFF
--- a/.release-notes/4274.md
+++ b/.release-notes/4274.md
@@ -1,0 +1,21 @@
+## Fix some infinite loops during typechecking
+
+Some recursive constraints could cause the typechecker to go into
+an infinite loop while trying to check subtyping. These infinite
+loops have now been fixed. An example program that demonstrates
+the issue is below:
+
+```
+primitive Foo[T: (Unsigned & UnsignedInteger[T])]
+  fun boom() =>
+    iftype T <: U8 then
+      None
+    end
+
+actor Main
+  new create(env: Env) =>
+    Foo[U8].boom()
+```
+
+The use of T: UnsignedInteger[T] is valid and expected, but wasn't
+being handled correctly in this situation by the typechecker in this context.

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -60,39 +60,15 @@ static bool exact_nominal(ast_t* a, ast_t* b, pass_opt_t* opt)
   return (a_def == b_def) && is_eq_typeargs(a, b, NULL, opt);
 }
 
-static bool check_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
+static ast_t* push_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
 {
-  // Returns true if we have already assumed sub is a subtype of super.
-  if(subtype_assume != NULL)
-  {
-    ast_t* assumption = ast_child(subtype_assume);
-
-    while(assumption != NULL)
-    {
-      AST_GET_CHILDREN(assumption, assume_sub, assume_super);
-
-      if(exact_nominal(sub, assume_sub, opt) &&
-        exact_nominal(super, assume_super, opt))
-        return true;
-
-      assumption = ast_sibling(assumption);
-    }
-  }
-
-  return false;
-}
-
-static bool push_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
-{
-  if(check_assume(sub, super, opt))
-    return true;
-
+  (void)opt;
   if(subtype_assume == NULL)
     subtype_assume = ast_from(sub, TK_NONE);
 
   BUILD(assume, sub, NODE(TK_NONE, TREE(ast_dup(sub)) TREE(ast_dup(super))));
   ast_add(subtype_assume, assume);
-  return false;
+  return assume;
 }
 
 static void pop_assume()
@@ -105,6 +81,43 @@ static void pop_assume()
     ast_free_unattached(subtype_assume);
     subtype_assume = NULL;
   }
+}
+
+static bool check_assume(ast_t* sub, ast_t* super, bool coinductive, pass_opt_t* opt)
+{
+  bool ret = false;
+  // Returns true if we have already assumed sub is a subtype of super.
+  if(subtype_assume != NULL)
+  {
+    ast_t* assumption = ast_child(subtype_assume);
+    ast_t* new_assume = NULL;
+    if (coinductive)
+    {
+      new_assume = push_assume(sub, super, opt);
+    }
+
+    while(assumption != NULL && assumption != new_assume)
+    {
+      AST_GET_CHILDREN(assumption, assume_sub, assume_super);
+
+      if(exact_nominal(sub, assume_sub, opt) &&
+        exact_nominal(super, assume_super, opt))
+      {
+        ret = true;
+        break;
+      }
+
+      assumption = ast_sibling(assumption);
+    }
+    pony_assert(ret || (assumption == NULL));
+    if (new_assume)
+    {
+      pony_assert(ast_child(subtype_assume) == new_assume);
+      pop_assume();
+    }
+  }
+
+  return ret;
 }
 
 static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
@@ -1122,12 +1135,15 @@ static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
 static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
   check_cap_t check_cap, errorframe_t* errorf, pass_opt_t* opt)
 {
-  // Add an assumption: sub <: super
-  if(push_assume(sub, super, opt))
-    return true;
-
   // N k <: N' k'
+
   ast_t* super_def = (ast_t*)ast_data(super);
+  bool coinductive = ast_id(super_def) == TK_INTERFACE;
+  if(check_assume(sub, super, coinductive, opt))
+    return true;
+  // Add an assumption: sub <: super
+  push_assume(sub, super, opt);
+
   bool ret = false;
 
   switch(ast_id(super_def))

--- a/test/libponyc-run/regression-3658/main.pony
+++ b/test/libponyc-run/regression-3658/main.pony
@@ -4,6 +4,8 @@ primitive Foo[T: (Unsigned & UnsignedInteger[T])]
       None
     end
   // more cases
+  // note that these method bodies are checked at their definition
+  // site so there's no need to call them
   fun baam1[S: (Unsigned & UnsignedInteger[S] & U8)](t: S): U32 =>
     t.u32()
   fun baam2[S: (U8 & Unsigned & UnsignedInteger[S])](t: S): U32 =>

--- a/test/libponyc-run/regression-3658/main.pony
+++ b/test/libponyc-run/regression-3658/main.pony
@@ -4,9 +4,9 @@ primitive Foo[T: (Unsigned & UnsignedInteger[T])]
       None
     end
   // more cases
-  fun baam1[T: (Unsigned & UnsignedInteger[T] & U8)](t: T): U32 =>
+  fun baam1[S: (Unsigned & UnsignedInteger[S] & U8)](t: S): U32 =>
     t.u32()
-  fun baam2[T: (U8 & Unsigned & UnsignedInteger[T])](t: T): U32 =>
+  fun baam2[S: (U8 & Unsigned & UnsignedInteger[S])](t: S): U32 =>
     t.u32()
 
 actor Main

--- a/test/libponyc-run/regression-3658/main.pony
+++ b/test/libponyc-run/regression-3658/main.pony
@@ -1,0 +1,14 @@
+primitive Foo[T: (Unsigned & UnsignedInteger[T])]
+  fun boom() =>
+    iftype T <: U8 then
+      None
+    end
+  // more cases
+  fun baam1[T: (Unsigned & UnsignedInteger[T] & U8)](t: T): U32 =>
+    t.u32()
+  fun baam2[T: (U8 & Unsigned & UnsignedInteger[T])](t: T): U32 =>
+    t.u32()
+
+actor Main
+  new create(env: Env) =>
+    Foo[U8].boom()

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -263,28 +263,20 @@ TEST_F(SubTypeTest, IsSubTypePrimitiveTrait)
   pass_opt_init(&opt);
 }
 
-TEST_F(SubTypeTest, IsSubFBoundedTraitAndConcrete)
+TEST_F(SubTypeTest, FBoundedTraitDecided)
 {
   const char* src =
     "trait T1[T: T1[T]]\n"
     "primitive P1 is T1[P1]\n"
     "class X[A: (T1[A] & P1), B: T1[A]]\n"
-    "  fun f(p1: P1, a: A, t1a: T1[A], b: B) => \n"
-    "     iftype A <: P1 then None else None end\n"
-    " ";
+    "  fun baam1[T: (Unsigned & UnsignedInteger[T] & U8)](t: T): U32 =>\n"
+    "      t.u32()\n"
+    "  fun baam2[T: (U8 & Unsigned & UnsignedInteger[T])](t: T): U32 =>\n"
+    "      t.u32()";
 
+  // This is just a regression. Without proper checks for infinite regressions
+  // this results in an infinite loop in typechecking
   TEST_COMPILE(src);
-
-  pass_opt_t opt;
-  pass_opt_init(&opt);
-
-  // if the subtyping implementation were much smarter, we could actually prove:
-  // P1 == (A: (T1[A] & P1))
-  // but it's not currently.
-  //
-  // Mostly, this is just a regression for catching an infinite loop
-  // when trying to check T1[A] vs P1
-  ASSERT_TRUE(is_subtype(type_of("a"), type_of("p1"), NULL, &opt));
 }
 
 TEST_F(SubTypeTest, IsSubTypeUnion)

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -263,6 +263,26 @@ TEST_F(SubTypeTest, IsSubTypePrimitiveTrait)
   pass_opt_init(&opt);
 }
 
+TEST_F(SubTypeTest, IsSubFBoundedTraitAndConcrete)
+{
+  const char* src =
+    "trait T1[T: T1[T]]\n"
+    "primitive P1\n"
+    "class X[A: (T1[A] & P1), B: T1[A]]\n"
+    "  fun f(p1: P1, a: A, t1a: T1[A], b: B) => None";
+
+  TEST_COMPILE(src);
+
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+
+  ASSERT_TRUE(is_subtype(type_of("p1"), type_of("t1a"), NULL, &opt));
+  //ASSERT_TRUE(is_subtype(type_of("A"), type_of("B"), NULL, &opt));
+  // assuming the compiler doesn't try to be too smart
+  //ASSERT_FALSE(is_subtype(type_of("B"), type_of("A"), NULL, &opt));
+
+  //ASSERT_FALSE(is_subtype(type_of("C"), type_of("A"), NULL, &opt));
+}
 
 TEST_F(SubTypeTest, IsSubTypeUnion)
 {

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -267,11 +267,11 @@ TEST_F(SubTypeTest, FBoundedTraitDecided)
 {
   const char* src =
     "trait T1[T: T1[T]]\n"
-    "primitive P1 is T1[P1]\n"
-    "class X[A: (T1[A] & P1), B: T1[A]]\n"
-    "  fun baam1[T: (Unsigned & UnsignedInteger[T] & U8)](t: T): U32 =>\n"
+    "  fun u32(): U32 => 0\n"
+    "class X\n"
+    "  fun baam1[T: (Unsigned & T1[T] & U8)](t: T): U32 =>\n"
     "      t.u32()\n"
-    "  fun baam2[T: (U8 & Unsigned & UnsignedInteger[T])](t: T): U32 =>\n"
+    "  fun baam2[T: (U8 & Unsigned & T1[T])](t: T): U32 =>\n"
     "      t.u32()";
 
   // This is just a regression. Without proper checks for infinite regressions

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -263,22 +263,6 @@ TEST_F(SubTypeTest, IsSubTypePrimitiveTrait)
   pass_opt_init(&opt);
 }
 
-TEST_F(SubTypeTest, FBoundedTraitDecided)
-{
-  const char* src =
-    "trait T1[T: T1[T]]\n"
-    "  fun u32(): U32 => 0\n"
-    "class X\n"
-    "  fun baam1[T: (Unsigned & T1[T] & U8)](t: T): U32 =>\n"
-    "      t.u32()\n"
-    "  fun baam2[T: (U8 & Unsigned & T1[T])](t: T): U32 =>\n"
-    "      t.u32()";
-
-  // This is just a regression. Without proper checks for infinite regressions
-  // this results in an infinite loop in typechecking
-  TEST_COMPILE(src);
-}
-
 TEST_F(SubTypeTest, IsSubTypeUnion)
 {
   const char* src =

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -267,21 +267,24 @@ TEST_F(SubTypeTest, IsSubFBoundedTraitAndConcrete)
 {
   const char* src =
     "trait T1[T: T1[T]]\n"
-    "primitive P1\n"
+    "primitive P1 is T1[P1]\n"
     "class X[A: (T1[A] & P1), B: T1[A]]\n"
-    "  fun f(p1: P1, a: A, t1a: T1[A], b: B) => None";
+    "  fun f(p1: P1, a: A, t1a: T1[A], b: B) => \n"
+    "     iftype A <: P1 then None else None end\n"
+    " ";
 
   TEST_COMPILE(src);
 
   pass_opt_t opt;
   pass_opt_init(&opt);
 
-  ASSERT_TRUE(is_subtype(type_of("p1"), type_of("t1a"), NULL, &opt));
-  //ASSERT_TRUE(is_subtype(type_of("A"), type_of("B"), NULL, &opt));
-  // assuming the compiler doesn't try to be too smart
-  //ASSERT_FALSE(is_subtype(type_of("B"), type_of("A"), NULL, &opt));
-
-  //ASSERT_FALSE(is_subtype(type_of("C"), type_of("A"), NULL, &opt));
+  // if the subtyping implementation were much smarter, we could actually prove:
+  // P1 == (A: (T1[A] & P1))
+  // but it's not currently.
+  //
+  // Mostly, this is just a regression for catching an infinite loop
+  // when trying to check T1[A] vs P1
+  ASSERT_TRUE(is_subtype(type_of("a"), type_of("p1"), NULL, &opt));
 }
 
 TEST_F(SubTypeTest, IsSubTypeUnion)


### PR DESCRIPTION
Some recursive constraints in type signatures could result in infinite loops while typechecking in cases where the typechecking should have succeeded.

This fixes those cases.

Fixes https://github.com/ponylang/ponyc/issues/3658

The fix works by making these cases more coinductive: pushing the assumption before typechecking equality of expressions.