### PR TITLE
Fix incorrectly implemented PR #4243

### DIFF
--- a/.release-notes/fix-4243.md
+++ b/.release-notes/fix-4243.md
@@ -1,0 +1,9 @@
+## Fix "Don't include 'home file' in documentation search"
+
+[PR #4243](https://github.com/ponylang/ponyc/pull/4243) incorrectly implemented the "don't include 'home file' in documentation search". It has been fixed.
+
+The original release notes are now accurate (before it wasn't working!):
+
+We've updated the documentation generation to not include the "home file" that lists the packages in the search index. The "exclude from search engine" functionality is only available in the `mkdocs-material-insiders` theme.
+
+The home file is extra noise in the index that provides no value. For anyone using the insiders theme, this will be an improvement in the search experience.

--- a/src/libponyc/pass/docgen.c
+++ b/src/libponyc/pass/docgen.c
@@ -1374,12 +1374,14 @@ void generate_docs(ast_t* program, pass_opt_t* options)
     ast_t* package = ast_child(program);
     const char* name = package_filename(package);
 
-    fprintf(docgen.home_file, "Packages\n\n");
     // tell the mkdocs theme not index the home file for search
     fprintf(docgen.home_file, "---\n");
     fprintf(docgen.home_file, "search:\n");
     fprintf(docgen.home_file, "  exclude: true\n");
     fprintf(docgen.home_file, "---\n");
+
+    // Print the only known content for the home file
+    fprintf(docgen.home_file, "Packages\n\n");
 
     fprintf(docgen.index_file, "site_name: %s\n", name);
     fprintf(docgen.index_file, "theme:\n");


### PR DESCRIPTION
I messed up implenting Don't include "home file" in documentation search. The front matter wasn't the first thing in the file where I added it.