### PR TITLE
Fix an assert in `call.c` when checking an invalid argument for autorecover

### DIFF
--- a/.release-notes/4278.md
+++ b/.release-notes/4278.md
@@ -1,0 +1,3 @@
+## Fix crash when handling parameters with invalid types
+
+Fixes a compiler assert when checking a parameter for autorecovery that has an invalid type.

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -281,7 +281,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
 
     errorframe_t info = NULL;
     ast_t* wp_type = consume_type(p_type, TK_NONE, false);
-    if(check_auto_recover_newref(wp_type, arg))
+    if((wp_type != NULL) && check_auto_recover_newref(wp_type, arg))
     {
       token_id arg_cap = ast_id(cap_fetch(wp_type));
       ast_t* recovered_arg_type = recover_type(arg_type, arg_cap);


### PR DESCRIPTION
The following code crashes the compiler, because `{(ISize)} iso^` is an invalid type, and when we check its arg for autorecovery, there is no type to check:

```
class val Info
  let fn: {(ISize)} iso

  new val create(fn': {(ISize)} iso^) =>
    fn = fn'

  fun call(n: ISize) =>
    fn(n)

actor Main
  new create(env: Env) =>
    let info = Info({(n: ISize) => env.out.print("n = " + n.string()) })
    info.call(123)
```

This PR adds a null check so we won't assert on the invalid parameter type.