### PR TITLE
Fix soundness bug introduced in Pony 0.51.2

### DIFF
--- a/.release-notes/4283.md
+++ b/.release-notes/4283.md
@@ -1,0 +1,3 @@
+# Fix a major bug which allowed mutating fields of a val object
+
+A bug was introduced in 0.51.2 which caused some checks to allow mutating fields of a val object due to changes to some operations on capabilities. This bug is fixed: immutability is now checked separately from other properties.

--- a/.release-notes/4283.md
+++ b/.release-notes/4283.md
@@ -1,3 +1,5 @@
 # Fix a major bug which allowed mutating fields of a val object
 
 A bug was introduced in 0.51.2 which caused some checks to allow mutating fields of a val object due to changes to some operations on capabilities. This bug is fixed: immutability is now checked separately from other properties.
+
+If you are using Pony 0.51.2 to 0.52.3, you should upgrade to the 0.52.4 release that contains this fix as soon as possible.

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -443,6 +443,15 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     return false;
   }
 
+  bool ok_mutable = safe_to_mutate(left);
+  if(!ok_mutable)
+  {
+    ast_error(opt->check.errors, ast,
+      "left side is immutable");
+    ast_free_unattached(wl_type);
+    return false;
+  }
+
   bool ok_safe = safe_to_move(left, r_type, WRITE);
 
   if(!ok_safe)

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -999,6 +999,31 @@ bool cap_sendable(token_id cap)
   return false;
 }
 
+bool cap_mutable(token_id cap)
+{
+  switch(cap)
+  {
+    case TK_VAL:
+    case TK_BOX:
+    case TK_TAG:
+    case TK_CAP_SEND:
+    case TK_CAP_SHARE:
+    case TK_CAP_READ:
+    case TK_CAP_ALIAS:
+    case TK_CAP_ANY:
+      return false;
+
+    case TK_ISO:
+    case TK_TRN:
+    case TK_REF:
+      return true;
+
+    default:
+      pony_assert(0);
+      return false;
+  }
+}
+
 bool cap_immutable_or_opaque(token_id cap)
 {
   switch(cap)

--- a/src/libponyc/type/cap.h
+++ b/src/libponyc/type/cap.h
@@ -96,6 +96,8 @@ bool cap_sendable(token_id cap);
 
 bool cap_immutable_or_opaque(token_id cap);
 
+bool cap_mutable(token_id cap);
+
 /**
  * For a temporary capability (iso/trn), returns
  * the capability with no isolation constraints

--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -192,3 +192,61 @@ bool safe_to_autorecover(ast_t* receiver_type, ast_t* type, direction direction)
   pony_assert(0);
   return false;
 }
+
+bool safe_to_mutate(ast_t* ast)
+{
+  switch (ast_id(ast))
+  {
+    case TK_VAR:
+    case TK_LET:
+    case TK_VARREF:
+    case TK_DONTCARE:
+    case TK_DONTCAREREF:
+      return true;
+
+    case TK_TUPLEELEMREF:
+      return true; // this isn't actually allowed, but it will be caught later.
+
+    case TK_FVARREF:
+    case TK_FLETREF:
+    case TK_EMBEDREF:
+    {
+      // If the ast is x.f, we need the type of x, which will be a nominal
+      // type or an arrow type, since we were able to lookup a field on it.
+      AST_GET_CHILDREN(ast, left, right);
+      ast_t* l_type = ast_type(left);
+
+      token_id l_cap = cap_single(l_type);
+      return cap_mutable(l_cap);
+    }
+
+    case TK_TUPLE:
+    {
+      ast_t* child = ast_child(ast);
+
+      while(child != NULL)
+      {
+        if(!safe_to_mutate(child))
+          return false;
+
+        child = ast_sibling(child);
+      }
+      return true;
+    }
+
+    case TK_SEQ:
+    {
+      // Occurs when there is a tuple on the left. Each child of the tuple will
+      // be a sequence, but only sequences with a single writeable child are
+      // valid. Other types won't appear here.
+      return safe_to_mutate(ast_child(ast));
+    }
+
+    default: {}
+  }
+
+  pony_assert(0);
+  return false;
+
+
+}

--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -247,6 +247,4 @@ bool safe_to_mutate(ast_t* ast)
 
   pony_assert(0);
   return false;
-
-
 }

--- a/src/libponyc/type/safeto.h
+++ b/src/libponyc/type/safeto.h
@@ -8,6 +8,7 @@
 PONY_EXTERN_C_BEGIN
 
 bool safe_to_move(ast_t* ast, ast_t* type, direction direction);
+bool safe_to_mutate(ast_t* ast);
 
 bool safe_to_autorecover(ast_t* receiver, ast_t* type, direction direction);
 

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(libponyc.tests
     bare.cc
     buildflagset.cc
     cap.cc
+    cap_safety.cc
     chain.cc
     codegen.cc
     codegen_ffi.cc

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+#include "util.h"
+
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_ERROR(src) DO(test_error(src, "expr"))
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
+//
+// A list of test cases for fundamental cap safety requirements.
+// Each test here should be as simple as possible.
+//
+class CapSafetyTest: public PassTest
+{};
+
+TEST_F(CapSafetyTest, NoWriteToVal)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X val = recover X end\n"
+    "    x.y = Y\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, NoWriteToBox)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X box = X\n"
+    "    x.y = Y\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, WriteToRef)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X ref = X\n"
+    "    x.y = Y\n";
+  TEST_COMPILE(src);
+}
+TEST_F(CapSafetyTest, NoCallRefOnVal)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun ref mutateme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X val = recover X end\n"
+    "    x.mutate()\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, NoCallRefOnBox)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun ref mutateme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X box = X\n"
+    "    x.mutateme()\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, CallRefOnRef)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun ref mutateme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X ref = X\n"
+    "    x.mutateme()\n";
+  TEST_COMPILE(src);
+}
+TEST_F(CapSafetyTest, CallValOnVal)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun val shareme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X val = recover X end\n"
+    "    x.shareme()\n";
+  TEST_COMPILE(src);
+}
+TEST_F(CapSafetyTest, NoCallValOnBox)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun val shareme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X box = X\n"
+    "    x.shareme()\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, NoCallValOnRef)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  fun val shareme() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X ref = X\n"
+    "    x.shareme()\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, NoWriteRefToIso)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X iso = recover X end\n"
+    "    let y: Y ref = Y\n"
+    "    x.y = y\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, NoWriteBoxToIso)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y box = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X iso = recover X end\n"
+    "    let y: Y box = Y\n"
+    "    x.y = y\n";
+  TEST_ERROR(src);
+}
+TEST_F(CapSafetyTest, WriteValToIso)
+{
+  const char* src =
+    "class Y\n"
+    "class X\n"
+    "  var y: Y val = Y\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: X iso = recover X end\n"
+    "    let y: Y val = Y\n"
+    "    x.y = y\n";
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -3,9 +3,6 @@
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
 #define TEST_ERROR(src) DO(test_error(src, "expr"))
-#define TEST_ERRORS_1(src, err1) \
-  { const char* errs[] = {err1, NULL}; \
-    DO(test_expected_errors(src, "expr", errs)); }
 
 //
 // A list of test cases for fundamental cap safety requirements.
@@ -59,7 +56,7 @@ TEST_F(CapSafetyTest, NoCallRefOnVal)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    let x: X val = recover X end\n"
-    "    x.mutate()\n";
+    "    x.mutateme()\n";
   TEST_ERROR(src);
 }
 TEST_F(CapSafetyTest, NoCallRefOnBox)

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -21,8 +21,10 @@ TEST_F(CapSafetyTest, NoWriteToVal)
     "  new create(env: Env) =>\n"
     "    let x: X val = recover X end\n"
     "    x.y = Y\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, NoWriteToBox)
 {
   const char* src =
@@ -33,8 +35,10 @@ TEST_F(CapSafetyTest, NoWriteToBox)
     "  new create(env: Env) =>\n"
     "    let x: X box = X\n"
     "    x.y = Y\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, WriteToRef)
 {
   const char* src =
@@ -45,8 +49,10 @@ TEST_F(CapSafetyTest, WriteToRef)
     "  new create(env: Env) =>\n"
     "    let x: X ref = X\n"
     "    x.y = Y\n";
+
   TEST_COMPILE(src);
 }
+
 TEST_F(CapSafetyTest, NoCallRefOnVal)
 {
   const char* src =
@@ -57,8 +63,10 @@ TEST_F(CapSafetyTest, NoCallRefOnVal)
     "  new create(env: Env) =>\n"
     "    let x: X val = recover X end\n"
     "    x.mutateme()\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, NoCallRefOnBox)
 {
   const char* src =
@@ -69,8 +77,10 @@ TEST_F(CapSafetyTest, NoCallRefOnBox)
     "  new create(env: Env) =>\n"
     "    let x: X box = X\n"
     "    x.mutateme()\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, CallRefOnRef)
 {
   const char* src =
@@ -81,8 +91,10 @@ TEST_F(CapSafetyTest, CallRefOnRef)
     "  new create(env: Env) =>\n"
     "    let x: X ref = X\n"
     "    x.mutateme()\n";
+
   TEST_COMPILE(src);
 }
+
 TEST_F(CapSafetyTest, CallValOnVal)
 {
   const char* src =
@@ -93,8 +105,10 @@ TEST_F(CapSafetyTest, CallValOnVal)
     "  new create(env: Env) =>\n"
     "    let x: X val = recover X end\n"
     "    x.shareme()\n";
+
   TEST_COMPILE(src);
 }
+
 TEST_F(CapSafetyTest, NoCallValOnBox)
 {
   const char* src =
@@ -105,8 +119,10 @@ TEST_F(CapSafetyTest, NoCallValOnBox)
     "  new create(env: Env) =>\n"
     "    let x: X box = X\n"
     "    x.shareme()\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, NoCallValOnRef)
 {
   const char* src =
@@ -117,8 +133,10 @@ TEST_F(CapSafetyTest, NoCallValOnRef)
     "  new create(env: Env) =>\n"
     "    let x: X ref = X\n"
     "    x.shareme()\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, NoWriteRefToIso)
 {
   const char* src =
@@ -130,8 +148,10 @@ TEST_F(CapSafetyTest, NoWriteRefToIso)
     "    let x: X iso = recover X end\n"
     "    let y: Y ref = Y\n"
     "    x.y = y\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, NoWriteBoxToIso)
 {
   const char* src =
@@ -143,8 +163,10 @@ TEST_F(CapSafetyTest, NoWriteBoxToIso)
     "    let x: X iso = recover X end\n"
     "    let y: Y box = Y\n"
     "    x.y = y\n";
+
   TEST_ERROR(src);
 }
+
 TEST_F(CapSafetyTest, WriteValToIso)
 {
   const char* src =
@@ -156,5 +178,6 @@ TEST_F(CapSafetyTest, WriteValToIso)
     "    let x: X iso = recover X end\n"
     "    let y: Y val = Y\n"
     "    x.y = y\n";
+
   TEST_COMPILE(src);
 }


### PR DESCRIPTION
This fixes #4282
and adds a set of simple "obviously-correct" tests of soundness / some completeness.

The bug was introduced because the change to safe_to_move in https://github.com/ponylang/ponyc/pull/4124/commits/c5113e74cd96bf0fb528a301b9e45534c3a63494 was correct from an isolation standpoint, but not from the standpoint of checking mutability, which is what the operator code was using it for. I.e. the change was valid only for the case of auto-recovering a constructor, and not mutating an existing object.

Now, mutability is checked before checking safety. This allows a better error message for the user in addition to fixing the bug.