### PR TITLE
Fix compiler crash introduced in #4283

### DIFF
--- a/.release-notes/4287.md
+++ b/.release-notes/4287.md
@@ -1,0 +1,5 @@
+## Fix compiler crash when attempting to mutate a val field
+
+In Pony 0.52.4 we fixed an unsoundness bug that had been introduced over the summer. While fixing that bug, an error case was missed and as a result, a compiler crash was created where an error message should have been generated.
+
+We've fixed the crash and it now displays a "left side is immutable" error message.

--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -216,6 +216,10 @@ bool safe_to_mutate(ast_t* ast)
       AST_GET_CHILDREN(ast, left, right);
       ast_t* l_type = ast_type(left);
 
+      // Any viewpoint adapted type will not be safe to write to.
+      if(ast_id(l_type) != TK_NOMINAL)
+        return false;
+
       token_id l_cap = cap_single(l_type);
       return cap_mutable(l_cap);
     }

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -181,3 +181,16 @@ TEST_F(CapSafetyTest, WriteValToIso)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(CapSafetyTest, NoWriteArrow)
+{
+  const char* src =
+    "actor Main"
+    "  var f: U64 = 1"
+    "  new create(env: Env) =>"
+    "    _start()"
+    "  fun _start() =>"
+    "    f = 2";
+
+  TEST_ERROR(src);
+}


### PR DESCRIPTION
Fixes a missed case in #4283 (arrow types). Instead of displaying an error message, the user who was attempting to do an unsafe mutation of a val was greeted by a compiler crash.

Fixes #4287