### PR TITLE
Fix compiler segfault caused by infinite recursion

### DIFF
--- a/.release-notes/4291-segfault.md
+++ b/.release-notes/4291-segfault.md
@@ -1,0 +1,37 @@
+## Fix compiler segfault caused by infinite recursion
+
+The following program used to cause ponyc to segfault due to infinite recursion:
+
+```pony
+type Message is ((I64 | String), String, None)
+
+interface tag Manager
+  be handle_message(msg: Message val)
+
+actor Main
+  new create(env: Env) =>
+    Foo(env, recover tag this end)
+
+  be handle_message(msg: Message val) =>
+    None
+
+actor Foo
+  var manager: Manager
+
+  new create(env: Env, manager': Manager) =>
+    manager = manager'
+    let notifier = InputNotifier(this)
+    env.input(consume notifier)
+
+  be handle_data(data: String) =>
+    manager.handle_message(("","",None))
+
+class InputNotifier is InputNotify
+  let parent: Foo
+
+  new iso create(parent': Foo) =>
+    parent = parent'
+
+  fun ref apply(data': Array[U8 val] iso) =>
+    parent.handle_data("")
+```

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -641,7 +641,7 @@ static bool contains_boxable(ast_t* type)
       ast_t* child = ast_child(type);
       while(child != NULL)
       {
-        if(contains_boxable(type))
+        if(contains_boxable(child))
           return true;
 
         child = ast_sibling(child);


### PR DESCRIPTION
Fixes segfaulting caused by the following program:

```pony
type Message is ((I64 | String), String, None)

interface tag Manager
  be handle_message(msg: Message val)

actor Main
  new create(env: Env) =>
    Foo(env, recover tag this end)

  be handle_message(msg: Message val) =>
    None

actor Foo
  var manager: Manager

  new create(env: Env, manager': Manager) =>
    manager = manager'
    let notifier = InputNotifier(this)
    env.input(consume notifier)

  be handle_data(data: String) =>
    manager.handle_message(("","",None))

class InputNotifier is InputNotify
    let parent: Foo

    new iso create(parent': Foo) =>
        parent = parent'

    fun ref apply(data': Array[U8 val] iso) =>
      parent.handle_data("")
```