### PR TITLE
Fix infinite loop in compiler

### DIFF
--- a/.release-notes/4291-hang.md
+++ b/.release-notes/4291-hang.md
@@ -1,0 +1,37 @@
+## Fix infinite loop in compiler
+
+The following program used to cause an infinite loop in the compiler:
+
+```pony
+type Message is (String, String, None)
+
+interface tag Manager
+  be handle_message(msg: Message val)
+
+actor Main
+  new create(env: Env) =>
+    Foo(env, recover tag this end)
+
+  be handle_message(msg: Message val) =>
+    None
+
+actor Foo
+  var manager: Manager
+
+  new create(env: Env, manager': Manager) =>
+    manager = manager'
+    let notifier = InputNotifier(this)
+    env.input(consume notifier)
+
+  be handle_data(data: String) =>
+    manager.handle_message(("","",None))
+
+class InputNotifier is InputNotify
+  let parent: Foo
+
+  new iso create(parent': Foo) =>
+    parent = parent'
+
+  fun ref apply(data': Array[U8 val] iso) =>
+    parent.handle_data("")
+```

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -717,6 +717,8 @@ static bool can_inline_message_send(reach_type_t* t, reach_method_t* m,
           {
             if(contains_boxable(child))
               return false;
+
+            child = ast_sibling(child);
           }
         }
       }


### PR DESCRIPTION
The following program used to cause an infinite loop in the compiler:

```pony
type Message is (String, String, None)

interface tag Manager
  be handle_message(msg: Message val)

actor Main
  new create(env: Env) =>
    Foo(env, recover tag this end)

  be handle_message(msg: Message val) =>
    None

actor Foo
  var manager: Manager

  new create(env: Env, manager': Manager) =>
    manager = manager'
    let notifier = InputNotifier(this)
    env.input(consume notifier)

  be handle_data(data: String) =>
    manager.handle_message(("","",None))

class InputNotifier is InputNotify
  let parent: Foo

  new iso create(parent': Foo) =>
    parent = parent'

  fun ref apply(data': Array[U8 val] iso) =>
    parent.handle_data("")
```

Fixes #4291