### PR TITLE
Fix runtime segfault

### DIFF
--- a/.release-notes/fix-4284.md
+++ b/.release-notes/fix-4284.md
@@ -1,0 +1,5 @@
+## Fix runtime segfault
+
+A segfault was introduced in ["Fix segfault caused by unsafe garbage collection optimization"](https://github.com/ponylang/ponyc/pull/4256). `tag` objects were being incorrectly traced which could eventually result in a segfault.
+
+If you are using Pony version 0.52.3 to 0.52.5, we recommend upgrading as soon as possible.

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -322,6 +322,9 @@ static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->rc--;
   }
 
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
+
   if(mutability == PONY_TRACE_MUTABLE || might_reference_actor(t))
     recurse(ctx, p, t->trace);
 }
@@ -442,6 +445,9 @@ static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     obj->rc += GC_INC_MORE;
     acquire_object(ctx, actor, p, obj->immutable);
   }
+
+  if(mutability == PONY_TRACE_OPAQUE)
+    return;
 
   if(mutability == PONY_TRACE_MUTABLE || might_reference_actor(t))
     recurse(ctx, p, t->trace);

--- a/test/libponyc-run/regression-4284/main.pony
+++ b/test/libponyc-run/regression-4284/main.pony
@@ -1,0 +1,45 @@
+use "pony_test"
+
+
+// As long as #4284 is fixed, this program will run to completion and
+// _TestIssue4284 will pass. If a regression is introduced, this
+// program will crash.
+
+actor Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestIssue4284)
+
+class iso _TestIssue4284 is UnitTest
+  fun name(): String => "_TestIssue4284"
+
+  fun apply(h: TestHelper) =>
+    let mutable = MutableState
+
+    var i: USize = 0
+    while i < 10 do i = i + 1
+      SomeActor.trace(HasOpaqueReferenceToMutableState(mutable), 100_000)
+    end
+
+    h.long_test(1_000_000_000)
+    h.complete(true)
+
+class MutableState
+  let _inner: ImmutableStateInner = ImmutableStateInner
+  new create() => None
+
+class val ImmutableStateInner
+  let _data: Array[String] = []
+  new val create() => None
+
+class val HasOpaqueReferenceToMutableState
+  let _opaque: MutableState tag
+  new val create(opaque: MutableState tag) => _opaque = opaque
+
+actor SomeActor
+  be trace(immutable: HasOpaqueReferenceToMutableState, count: USize) =>
+    if count > 1 then
+      trace(immutable, count - 1)
+    end


### PR DESCRIPTION
When I implemented turning off the unsafe "don't trace immutable objects" optimization in PR #4256, I incorrectly caused opaque objects to be traced in a couple of scenarios.

Tracing opaque objects will result in a segfault like the one discovered by Gordon.

Fixes #4284