### PR TITLE
Remove ambiguity from "not safe to write" compiler error message

### DIFF
--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -1,3 +1,3 @@
-## Fix vague error message when it is not safe to write
+## Remove ambiguity from "not safe to write" compiler error message
 
 Added left side type to a "not safe to write" error message.

--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -1,7 +1,7 @@
 ## Remove ambiguity from "not safe to write" compiler error message
 
 Currently, when it is not safe to write, the error message only talks about the right side, not the left side, nor the reason for the failure of safety.
-As an example, when trying to write to a field from an iso class instance, we get:
+As an example, when trying to write to a field in an iso class instance, we get:
 
 ```
 Error:

--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -1,3 +1,32 @@
 ## Remove ambiguity from "not safe to write" compiler error message
 
-Added left side type to a "not safe to write" error message.
+Currently, when it is not safe to write, the error message only talks about the right side, not the left side, nor the reason for the failure of safety.
+As an example, when trying to write to a field from an iso class instance, we get:
+
+```
+Error:
+/Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:10:11: not safe to write right side to left side
+    x.foo = foo
+          ^
+    Info:
+    /Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:9:14: right side type: Foo ref
+        let foo: Foo ref = Foo
+                 ^
+```
+
+
+With this change, the error becomes:
+
+```
+Error:
+/Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:10:11: not safe to write right side to left side
+    x.foo = foo
+          ^
+    Info:
+    /Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:9:14: right side type: Foo ref
+        let foo: Foo ref = Foo
+                 ^
+    /Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:10:5: left side type: X iso
+        x.foo = foo
+        ^
+```

--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -1,6 +1,6 @@
 ## Remove ambiguity from "not safe to write" compiler error message
 
-Currently, when it is not safe to write, the error message only talks about the right side, not the left side, nor the reason for the failure of safety.
+Previously, when displaying the "not safe to write" error message, the information provided was incomplete in a way that lead to ambiguity. A "not safe to write" error involves two components, the left side type being assigned to and the right side type being assigned to the left side. We were only displaying the right side, not the left side type, thus making it somewhat difficult to know exactly what the error was.
 As an example, when trying to write to a field in an iso class instance, we get:
 
 ```

--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -14,8 +14,7 @@ Error:
                  ^
 ```
 
-
-With this change, the error becomes:
+The updated error message is now in the format:
 
 ```
 Error:

--- a/.release-notes/4299.md
+++ b/.release-notes/4299.md
@@ -1,0 +1,3 @@
+## Fix vague error message when it is not safe to write
+
+Added left side type to a "not safe to write" error message.

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -484,8 +484,8 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     {
       ast_error(opt->check.errors, ast,
         "not safe to write right side to left side");
-      ast_error_continue(opt->check.errors, wl_type, "right side type: %s",
-        ast_print_type(wl_type));
+      ast_error_continue(opt->check.errors, r_type, "right side type: %s",
+        ast_print_type(r_type));
       ast_error_continue(opt->check.errors, ast_child(left), "left side type: %s",
         ast_print_type(ast_type(ast_child(left))));
       ast_free_unattached(wl_type);

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -480,6 +480,18 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
       }
     }
 
+    if(ast_child(left) != NULL)
+    {
+      ast_error(opt->check.errors, ast,
+        "not safe to write right side to left side");
+      ast_error_continue(opt->check.errors, wl_type, "right side type: %s",
+        ast_print_type(wl_type));
+      ast_error_continue(opt->check.errors, ast_child(left), "left side type: %s",
+        ast_print_type(ast_type(ast_child(left))));
+      ast_free_unattached(wl_type);
+      return false;
+    }
+
     ast_error(opt->check.errors, ast,
       "not safe to write right side to left side");
     ast_error_continue(opt->check.errors, wl_type, "right side type: %s",

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -480,22 +480,15 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
       }
     }
 
-    if(ast_child(left) != NULL)
-    {
-      ast_error(opt->check.errors, ast,
-        "not safe to write right side to left side");
-      ast_error_continue(opt->check.errors, r_type, "right side type: %s",
-        ast_print_type(r_type));
-      ast_error_continue(opt->check.errors, ast_child(left), "left side type: %s",
-        ast_print_type(ast_type(ast_child(left))));
-      ast_free_unattached(wl_type);
-      return false;
-    }
-
     ast_error(opt->check.errors, ast,
       "not safe to write right side to left side");
     ast_error_continue(opt->check.errors, wl_type, "right side type: %s",
       ast_print_type(wl_type));
+    if(ast_child(left) != NULL)
+    {
+      ast_error_continue(opt->check.errors, ast_child(left), "left side type: %s",
+      ast_print_type(ast_type(ast_child(left))));
+    }
     ast_free_unattached(wl_type);
     return false;
   }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1287,3 +1287,21 @@ TEST_F(BadPonyTest, CantAssignErrorExpression)
   TEST_ERRORS_1(src,
     "right side must be something that can be assigned")
 }
+
+TEST_F(BadPonyTest, NotSafeToWrite)
+{
+  // From issue #4290
+  const char* src =
+    "class Foo\n"
+    "class X\n"
+      "var foo: Foo ref = Foo\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let x = X\n"
+        "let foo: Foo ref = Foo\n"
+        "x.foo = foo";
+
+  TEST_ERRORS_1(src,
+    "not safe to write right side to left side")
+}

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1302,6 +1302,13 @@ TEST_F(BadPonyTest, NotSafeToWrite)
         "let foo: Foo ref = Foo\n"
         "x.foo = foo";
 
-  TEST_ERRORS_1(src,
-    "not safe to write right side to left side")
+  {
+      const char* errs[] =
+        {"not safe to write right side to left side", NULL};
+      const char* frame1[] = {
+        "right side type: Foo ref^", 
+        "left side type: X iso", NULL};
+      const char** frames[] = {frame1, NULL};
+      DO(test_expected_error_frames(src, "verify", errs, frames));
+  }
 }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1309,6 +1309,6 @@ TEST_F(BadPonyTest, NotSafeToWrite)
         "right side type: Foo ref^", 
         "left side type: X iso", NULL};
       const char** frames[] = {frame1, NULL};
-      DO(test_expected_error_frames(src, "verify", errs, frames));
+      DO(test_expected_error_frames(src, "badpony", errs, frames));
   }
 }


### PR DESCRIPTION
Fixes #4290 

With this change, the error becomes:

```
Error:
/Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:10:11: not safe to write right side to left side
    x.foo = foo
          ^
    Info:
    /Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:9:14: right side type: Foo ref
        let foo: Foo ref = Foo
                 ^
    /Users/jairocaro-accinoviciana/issues-pony-4290/demo.pony:10:5: left side type: X iso
        x.foo = foo
        ^
```

(First time contributing to ponyc + first time contributing in C) triple check the change please 😅