### PR TITLE
Create libponyc-standalone on MacOS

### DIFF
--- a/.release-notes/4303.md
+++ b/.release-notes/4303.md
@@ -1,0 +1,6 @@
+## Enable building of libponyc-standalone on macos
+
+With this change we now produce the static library `libponyc-standalone.a` also on macos.
+As on osx it is hard to statically link `libc++`, it needs to be linked dynamically
+when building a final binary with this library.
+

--- a/.release-notes/4303.md
+++ b/.release-notes/4303.md
@@ -2,3 +2,13 @@
 
 We now ship a "standalone" version of libponyc for MacOS. libponyc-standalone allows applications to use Pony compiler functionality as a library. The standalone version contains "all dependencies" needed in a single library. On MacOS, sadly "all dependencies" means "all that can be statically linked", so unlike Linux, dynamically linking to C++ standard library is required on MacOS.
 
+An example pony program linking against it would need to look like this:
+
+```pony
+use "lib:ponyc-standalone" if posix or osx
+use "lib:c++" if osx
+
+actor Main
+  new create(env: Env) =>
+    None
+```

--- a/.release-notes/4303.md
+++ b/.release-notes/4303.md
@@ -1,6 +1,4 @@
 ## Enable building of libponyc-standalone on MacOS
 
-With this change we now produce the static library `libponyc-standalone.a` also on macos.
-As on osx it is hard to statically link `libc++`, it needs to be linked dynamically
-when building a final binary with this library.
+We now ship a "standalone" version of libponyc for MacOS. libponyc-standalone allows applications to use Pony compiler functionality as a library. The standalone version contains "all dependencies" needed in a single library. On MacOS, sadly "all dependencies" means "all that can be statically linked", so unlike Linux, dynamically linking to C++ standard library is required on MacOS.
 

--- a/.release-notes/4303.md
+++ b/.release-notes/4303.md
@@ -1,4 +1,4 @@
-## Enable building of libponyc-standalone on macos
+## Enable building of libponyc-standalone on MacOS
 
 With this change we now produce the static library `libponyc-standalone.a` also on macos.
 As on osx it is hard to statically link `libc++`, it needs to be linked dynamically

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -152,7 +152,7 @@ else()
         COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
         COMMAND echo "save" >> standalone.mri
         COMMAND echo "end" >> standalone.mri
-        COMMAND ${CMAKE_AR} -M < standalone.mri
+        COMMAND ar -M < standalone.mri
         DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
     )
     # add a separate target that depends on the standalone library file

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -121,9 +121,22 @@ endif (NOT MSVC)
 # build a standalone version of libponyc.a with all needed dependencies linked statically
 if (MSVC)
     # TODO
-    #file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/build_libs/llvm/src/llvm/Release/lib/*.lib")
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
-    # TODO
+    # on macos we dont have no static libc++
+    # so when we want to use this lib
+    # we need to additionally link libc++ and libz (for llvm)
+    file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/build_libs/llvm/src/llvm//lib/libLLVM*.a")
+    add_custom_target(libponyc-standalone ALL
+        COMMAND libtool -static -o libponyc-standalone.a $<TARGET_FILE:libponyc> ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a ${LLVM_OBJS}
+        DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
+    )
+    # copy the generated file after it is built
+    add_custom_command(TARGET libponyc-standalone POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug/
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release/
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo/
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel/
+    )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "BSD")
     # TODO
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
@@ -139,7 +152,7 @@ else()
         COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
         COMMAND echo "save" >> standalone.mri
         COMMAND echo "end" >> standalone.mri
-        COMMAND ar -M < standalone.mri
+        COMMAND ${CMAKE_AR} -M < standalone.mri
         DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
     )
     # add a separate target that depends on the standalone library file


### PR DESCRIPTION
It will not link libstdc++ statically, as this is not available on MacOS. When linking against libponyc-standalone one also needs to link against libc++, but at least we have all the LLVM symbols in there.

An example pony program linking against it would need to look like this:

```pony
use "lib:ponyc-standalone" if posix or osx
use "lib:c++" if osx
```

While i think this is acceptable, as those libs are always available on MacOS, i would be happy about any hint on how to include those in `libponyc-standalone`.

I was not able to test this on an M1 mac.