### PR TITLE
Build ponyc-standalone.lib for windows

### DIFF
--- a/.release-notes/4307.md
+++ b/.release-notes/4307.md
@@ -1,0 +1,15 @@
+## Enable building of libponyc-standalone on Windows
+
+We now ship a "standalone" version of libponyc for Windows. libponyc-standalone allows applications to use Pony compiler functionality as a library. The standalone version contains "all dependencies" needed in a single library. This library doesn't contain C or C++ runtime libs, as those get linked into every Pony program during compilation on Windows.
+
+An example pony program linking against it on Windows would need to look like this:
+
+```pony
+use "lib:ponyc-standalone" if posix or osx or windows
+use "lib:c++" if osx
+
+actor Main
+  new create(env: Env) =>
+    None
+```
+

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -125,7 +125,6 @@ if (MSVC)
 
     set(libponyc_standalone_file "${CMAKE_STATIC_LIBRARY_PREFIX}ponyc-standalone${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(libponyc_standalone_path "${CMAKE_BINARY_DIR}/${libponyc_standalone_file}")
-    # TODO: do we need to get any static libstc++ or other runtime libraries here?
     add_custom_target(libponyc-standalone ALL
         # CMAKE_AR finds the appropriate version of lib.exe acdording to desired target and host architecture 
         COMMAND ${CMAKE_AR} /NOLOGO /VERBOSE /MACHINE:x64 /OUT:${libponyc_standalone_path} "$<TARGET_FILE:libponyc>" ${LLVM_OBJS} "${PROJECT_SOURCE_DIR}/../../build/libs/lib/blake2.lib"

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -104,10 +104,10 @@ target_include_directories(libponyc
     PRIVATE ../../lib/blake2
 )
 
- if (MSVC)
-     file(GLOB_RECURSE CFILES "${PROJECT_SOURCE_DIR}/*.c")
-     set_source_files_properties(${CFILES} PROPERTIES LANGUAGE CXX)
- endif (MSVC)
+if (MSVC)
+    file(GLOB_RECURSE CFILES "${PROJECT_SOURCE_DIR}/*.c")
+    set_source_files_properties(${CFILES} PROPERTIES LANGUAGE CXX)
+endif (MSVC)
 
 if (NOT MSVC)
     add_custom_command(TARGET libponyc POST_BUILD

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -104,10 +104,10 @@ target_include_directories(libponyc
     PRIVATE ../../lib/blake2
 )
 
-if (MSVC)
-    file(GLOB_RECURSE CFILES "${PROJECT_SOURCE_DIR}/*.c")
-    set_source_files_properties(${CFILES} PROPERTIES LANGUAGE CXX)
-endif (MSVC)
+ if (MSVC)
+     file(GLOB_RECURSE CFILES "${PROJECT_SOURCE_DIR}/*.c")
+     set_source_files_properties(${CFILES} PROPERTIES LANGUAGE CXX)
+ endif (MSVC)
 
 if (NOT MSVC)
     add_custom_command(TARGET libponyc POST_BUILD
@@ -120,7 +120,22 @@ endif (NOT MSVC)
 
 # build a standalone version of libponyc.a with all needed dependencies linked statically
 if (MSVC)
-    # TODO
+    # this will not include LLVM-C.lib as it contains lots of duplicated definitions
+    file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/libs/lib/LLVM[!-]*.lib")
+
+    set(libponyc_standalone_file "${CMAKE_STATIC_LIBRARY_PREFIX}ponyc-standalone${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(libponyc_standalone_path "${CMAKE_BINARY_DIR}/${libponyc_standalone_file}")
+    # TODO: do we need to get any static libstc++ or other runtime libraries here?
+    add_custom_target(libponyc-standalone ALL
+        # CMAKE_AR finds the appropriate version of lib.exe acdording to desired target and host architecture 
+        COMMAND ${CMAKE_AR} /NOLOGO /VERBOSE /MACHINE:x64 /OUT:${libponyc_standalone_path} "$<TARGET_FILE:libponyc>" ${LLVM_OBJS} "${PROJECT_SOURCE_DIR}/../../build/libs/lib/blake2.lib"
+        DEPENDS libponyc)
+    add_custom_command(TARGET libponyc-standalone POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/${libponyc_standalone_file}
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/${libponyc_standalone_file}
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO}/${libponyc_standalone_file}
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL}/${libponyc_standalone_file}
+    )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     # on macos we dont have no static libc++
     # so when we want to use this lib

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -12,9 +12,7 @@
 
 #include <platform.h>
 
-#if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)
-extern "C" {
-#endif
+PONY_EXTERN_C_BEGIN
 
 typedef struct ast_t ast_t;
 
@@ -222,8 +220,5 @@ pony_type_t* ast_nominal_pkg_id_signature_pony_type();
 
 pony_type_t* ast_pony_type();
 
-#if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)
-}
-#endif
-
+PONY_EXTERN_C_END
 #endif

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -9,9 +9,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)
-extern "C" {
-#endif
+PONY_EXTERN_C_BEGIN
 
 typedef struct token_t token_t;
 
@@ -393,8 +391,5 @@ void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos);
 /// Set whether debug info should be generated.
 void token_set_debug(token_t* token, bool state);
 
-#if defined(PLATFORM_IS_POSIX_BASED) && defined(__cplusplus)
-}
-#endif
-
+PONY_EXTERN_C_END
 #endif


### PR DESCRIPTION
Build ponyc-standalone.lib for windows as a standalone variant of libponyc. It contains blake2, LLVM libs and libponyc.
It does not (to my knowledge) contain any static system libraries yet, but pony programs linked against it, work fine as is.

Linking to it from a pony program is done in the exact same way as for the other supported platforms:

```pony
use "lib:ponyc-standalone" if linux or osx or windows
use "lib:c++" if osx

actor Main
  new create(env: Env) =>
    None
``` 