### PR TITLE
Always include llvm_args in the pass_opt_t struct

### DIFF
--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -307,9 +307,7 @@ typedef struct pass_opt_t
   char* link_arch;
   char* linker;
   char* link_ldcmd;
-#ifndef NDEBUG
   const char* llvm_args;
-#endif
 
   char* triple;
   char* abi;


### PR DESCRIPTION
Always include the field `llvm_args` in the `pass_opt_t` struct, otherwise, when linking against libponyc from pony we cannot reliably use the fields coming after that, as their offset is moved by a pointers width in debug mode. And thus in ffi we don't know if the field is present or not. And we cannot conditionally exclude or include a field in a struct in pony.

When libponyc/ponyc is compiled in release mode, this field will never be used and will remain a NULL pointer.