### PR TITLE
Remove explicit --platform from end user ponyc Dockerfiles

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -9,11 +9,12 @@ RUN apt-get update \
     curl \
     g++ \
     git \
+    lsb-core \
     make \
   && rm -rf /var/lib/apt/lists/*
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc nightly --platform=ubuntu22.04 \
+ && ponyup update ponyc nightly \
  && ponyup update stable nightly \
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update --no-cache \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc nightly --platform=musl \
+ && ponyup update ponyc nightly \
  && ponyup update stable nightly \
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -9,11 +9,12 @@ RUN apt-get update \
     curl \
     g++ \
     git \
+    lsb-core \
     make \
   && rm -rf /var/lib/apt/lists/*
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc release --platform=ubuntu22.04 \
+ && ponyup update ponyc release \
  && ponyup update stable release \
  && ponyup update corral release \
  && ponyup update changelog-tool release

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update --no-cache \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc release --platform=musl \
+ && ponyup update ponyc release \
  && ponyup update stable release \
  && ponyup update corral release \
  && ponyup update changelog-tool release


### PR DESCRIPTION
Previously, before the latest version of ponyup, when running on Glibc versions of Linux, we could end up installing the wrong ponyc. To correct for this, our Dockerfiles were supplying an explicit platform to use that matched the distribution that formed the image base. This was required for our "gnu" aka "glibc" image but not for musl. We only did it for musl to provide symmetry.

The new version of ponyup will use lsb_release to correctly identify the Glibc distribution and install the correct ponyc.