### PR TITLE
Fix small memory leak in ponyc.

### DIFF
--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -135,10 +135,6 @@ void pass_opt_done(pass_opt_t* options)
       options->check.stats.stack_alloc
       );
   }
-  if(options->all_args != NULL)
-  {
-    free((void*)options->all_args);
-  }
 }
 
 

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -22,6 +22,7 @@
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
 
+#include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
 
@@ -133,6 +134,10 @@ void pass_opt_done(pass_opt_t* options)
       options->check.stats.heap_alloc,
       options->check.stats.stack_alloc
       );
+  }
+  if(options->all_args != NULL)
+  {
+    free((void*)options->all_args);
   }
 }
 

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -143,6 +143,7 @@ int main(int argc, char* argv[])
 
   ponyc_shutdown(&opt);
   pass_opt_done(&opt);
+  free((void*)opt.all_args);
 
   return ok ? 0 : -1;
 }


### PR DESCRIPTION
Valgrind reported the allocated bytes in `pass_opt_t->all_args` as leaking, as they were allocated but never freed. So I am doing this attempt at freeing them. Valgrind seems to be happy now.