### PR TITLE
Fix waiting on Windows to be sure I/O events can still come in.

### DIFF
--- a/.release-notes/4325.md
+++ b/.release-notes/4325.md
@@ -1,0 +1,3 @@
+## Fix waiting on Windows to properly admit I/O events
+
+Previously, on Windows, we were calling `WaitForSingleObject` rather than `WaitForSingleObjectEx` when putting scheduler threads to sleep. This could have caused Windows I/O events to be missed.


### PR DESCRIPTION
Prior to this commit we were using a mechanism on Windows called `WaitForSingleObject` when we wanted to put a thread to sleep until we activated a signal to wake it up later.

Now we use `WaitForSingleObjectEx` instead, so we can be sure that the thread is kept in an "alertable" state if there is an APC (Async Procedure Call) that needs to be run during the wait period.

We use APCs for socket I/O completion callbacks, and they can only arrive on the thread that initiated them, so it's important to allow such callbacks to run even if the scheduler thread is suspended.

Note that the callbacks we use for sockets will not run any Pony code - they will only dispatch a message via the ASIO subsystem, so running those APCs is safe even if the actor has been work-stealed to another thread and is running there. In such a situation, the ASIO event will just go into the actor's queue and they'll process the message later, as normal. We just need to make sure the APC actually will get run, hence we need to ensure even suspended threads will stay "alertable".

Note that this fixes a similar problem to one of the problems that was fixed in PR #3816, wherein some calls to `Sleep` were migrated to `SleepEx` for the same reason - to stay "alertable".
