### PR TITLE
Declare ponyint_color_t as a typedef not a global

### DIFF
--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -193,7 +193,7 @@ static size_t viewrefmap_total_alloc_size(viewrefmap_t* map)
 }
 #endif
 
-enum
+typedef enum
 {
   COLOR_BLACK,
   COLOR_GREY,


### PR DESCRIPTION
One of the commits originally in #4331