### PR TITLE
Don't use a new variable intermittently for the same pointer

### DIFF
--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -756,15 +756,13 @@ static pool_item_t* pool_pull(pool_local_t* thread, pool_global_t* global)
   ANNOTATE_HAPPENS_AFTER(&global->central);
 #endif
 
-  pool_item_t* p = (pool_item_t*)top;
-
   pony_assert((top->length > 0) && (top->length <= global->count));
-  TRACK_PULL(p, top->length, global->size);
+  TRACK_PULL((pool_item_t*)top, top->length, global->size);
 
-  thread->pool = p->next;
+  thread->pool = top->next;
   thread->length = top->length - 1;
 
-  return p;
+  return (pool_item_t*)top;
 }
 
 static void* pool_get(pool_local_t* pool, size_t index)


### PR DESCRIPTION
Instead cast at each use with the new type.
One of the commits originally in #4331