### PR TITLE
Stop putting `stable` in ponyc Docker images

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc nightly \
- && ponyup update stable nightly \
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly
 

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --update --no-cache \
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc nightly \
- && ponyup update stable nightly \
  && ponyup update corral nightly \
  && ponyup update changelog-tool nightly
 

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update \
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc release \
- && ponyup update stable release \
  && ponyup update corral release \
  && ponyup update changelog-tool release
 

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --update --no-cache \
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
  && ponyup update ponyc release \
- && ponyup update stable release \
  && ponyup update corral release \
  && ponyup update changelog-tool release
 

--- a/.release-notes/stable.md
+++ b/.release-notes/stable.md
@@ -1,0 +1,3 @@
+## Remove `stable` from Docker images
+
+Previously, we were including our very old and very deprecated dependency management tool `stable` in our `ponyc` Docker images. We've stopped.


### PR DESCRIPTION
It has been deprecated for ages and ages.