### PR TITLE
Use atomic store in `ponyint_release_cycle_detector_critical` function

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -1262,5 +1262,5 @@ bool ponyint_acquire_cycle_detector_critical(pony_actor_t* actor)
 
 void ponyint_release_cycle_detector_critical(pony_actor_t* actor)
 {
-  actor->cycle_detector_critical = 0;
+  atomic_store_explicit(&actor->cycle_detector_critical, 0, memory_order_release);
 }


### PR DESCRIPTION
Prior to this commit the `ponyint_release_cycle_detector_critical` function wrote 0 to the `actor->cycle_detector_critical` field without using atomic instructions even though the `ponyint_acquire_cycle_detector_critical` function uses an atomic compare exchange on the same field.

This commit updates the `ponyint_release_cycle_detector_critical` function to use an atomic instruction with `memory_order_release` memory order to store 0 into the `actor->cycle_detector_critical` field.