### PR TITLE
Don't run test in debugger on Arm

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,13 +73,13 @@ task:
   debug_build_script:
     - make build config=debug
   debug_test_script:
-    - make test-ci config=debug usedebugger=lldb
+    - make test-ci config=debug
   release_configure_script:
     - make configure arch=armv8-a config=release
   release_build_script:
     - make build config=release
   release_test_script:
-    - make test-ci config=release usedebugger=lldb
+    - make test-ci config=release
 
 task:
   only_if: $CIRRUS_PR != ''
@@ -714,7 +714,7 @@ task:
   build_script:
     - make build config=debug
   stress_test_script:
-    - make ${TARGET} config=debug usedebugger=lldb
+    - make ${TARGET} config=debug
 
 task:
   only_if: $CIRRUS_CRON == "stress"


### PR DESCRIPTION
CirrusCI moved the Arm infrastructure from AWS to Google's cloud. In the process, the security setup for Docker containers changed and we no longer have the permissions required to "debug C++ code" in containers on Arm.

Cirrus is unable "for security reasons" to change the configuration of the GKE to accomodate our needs.

The error in question happens when you try to run a program started up in the debugger. We get:

"'A' packet returned an error: 8"

According to a posting on StackOverflow, this can be addressed by adding "--cap-add=SYS_PTRACE --security-opt seccomp=unconfined" to the "docker run" command.

According to CirrusCI they added NET_RAW and SYS_PTRACE capabilities in an attempt to address the problem. However, that didn't work as we continued to get errors. Cirrus says they would have to weaken the seccomp setting for their entire cluster to address, something they aren't comfortable doing. They said we could run the workloads in privileged containers on dedicated virtual machines. That is a decent amount of work to set up and administer and adds some additional overhead money-wise. If we really need to turn this back on, we could consider going down that route.