### PR TITLE
fix `normalise_string` to prevent issues when `lexer->buflen` == 0

### DIFF
--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -607,7 +607,7 @@ static void normalise_string(lexer_t* lexer)
 
   // Trim trailing empty line
   size_t trim = 0;
-  for (size_t i = (lexer->buflen - 1); i>0; i--)
+  for (ssize_t i = (lexer->buflen - 1); i>0; i--)
   {
     char c = lexer->buffer[i];
     if (c == '\n')


### PR DESCRIPTION
This was flagged by either the memory sanitizer or the undefined behavior sanitizer as an issue.

This commit changes the datatype of `i` to be `ssize_t` so that `lexer->buflen - 1` becomes less than 0 when `lexer->buflen` == 0.