### PR TITLE
fix `names_typeparam` to prevent access to an AST node that was just replaced

### DIFF
--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -199,6 +199,8 @@ static bool names_typeparam(pass_opt_t* opt, ast_t** astp, ast_t* def)
       TREE(cap)
       TREE(ephemeral)));
 
+  ast = *astp;
+
   if(opt->check.frame->iftype_body != NULL)
     def = ast_get(ast, name, NULL);
 


### PR DESCRIPTION
This was flagged by either the memory sanitizer or the undefined behavior sanitizer.

Prior to this commit, the AST node is replaced and then the call to `ast_get` tries to access the old node that has already been freed.

This commit ensures that the call to `ast_get` will correctly access the newly AST node.