### PR TITLE
Make sure the test runner gets rebuilt whenever ponyc gets rebuilt

### DIFF
--- a/test/libponyc-run/runner/CMakeLists.txt
+++ b/test/libponyc-run/runner/CMakeLists.txt
@@ -17,4 +17,5 @@ add_custom_command(OUTPUT ${RUNNER_EXECUTABLE}
     _test_process_notify.pony
     _tester_timer_notify.pony
     _tester.pony
+    $<TARGET_FILE:ponyc>
 )


### PR DESCRIPTION
Prior to this commit, a call to `make build` would not rebuild the test `runner` whenever `ponyc` would get rebuilt. This could cause some confusion, especially if `libponyrt` changed, as one would expect `make build` to ensure the `runner` is built using the latest version of the runtime and compiler.

This commit ensures that the runner will get rebuilt whenever `ponyc` gets rebuilt by adding `ponyc` as an explicit dependency to the `runner` build command.