### PR TITLE
Fix for running tests with `use=` flags enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,12 @@ endif
 
 srcDir := $(shell dirname '$(subst /Volumes/Macintosh HD/,/,$(realpath $(lastword $(MAKEFILE_LIST))))')
 buildDir := $(srcDir)/build/build_$(config)
-outDir := $(srcDir)/build/$(config)
+
+# get outDir from CMake install file or fall back to default if the file doesn't exist
+outDir := $(subst /libponyrt.tests,,$(shell grep -o -s '$(srcDir)\/build\/$(config).*\/libponyrt.tests' $(buildDir)/cmake_install.cmake))
+ifeq ($(outDir),)
+  outDir := $(srcDir)/build/$(config)
+endif
 
 libsSrcDir := $(srcDir)/lib
 libsBuildDir := $(srcDir)/build/build_libs


### PR DESCRIPTION
Prior to this commit, running `make test` after running `make configure use=use_flag` would fail because the `Makefile` would look for the test binaries in the wrong directory (i.e. in `build/debug` instead of `build/debug-runtimestats`).

This commit updates the `Makefile` to try and determine the `use` output directory from the CMake configure generated `cmake_install.cmake` file so that tests can be run successfully. It will fall back to the current behavior and use the default build directory if it the file doesn't exist or it is unable to extract the directory path.