### PR TITLE
Specialize heap small and large chunk implementations

### DIFF
--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -16,12 +16,14 @@ PONY_EXTERN_C_BEGIN
 #define HEAP_MAX (1 << HEAP_MAXBITS)
 
 typedef struct chunk_t chunk_t;
+typedef struct small_chunk_t small_chunk_t;
+typedef struct large_chunk_t large_chunk_t;
 
 typedef struct heap_t
 {
-  chunk_t* small_free[HEAP_SIZECLASSES];
-  chunk_t* small_full[HEAP_SIZECLASSES];
-  chunk_t* large;
+  small_chunk_t* small_free[HEAP_SIZECLASSES];
+  small_chunk_t* small_full[HEAP_SIZECLASSES];
+  large_chunk_t* large;
 
   size_t used;
   size_t next_gc;


### PR DESCRIPTION
Prior to this commit, the heap `chunk_t` was generic for both small and large chunks taking up more space than required for either one.

This commit specializes the small and large chunk structures by using pointer tagging on the `chunk->m` field to keep track of the chunk type and large chunk slot/shallow/finaliser and the small chunk sizeclass. This should in theory improve performance as now the `large_chunk_t` is 32 bytes and `small_chunk_t` is 36 bytes on 64 bit platforms (while `chunk_t` was previously 44 bytes.

There are no logic changes other than whatever was required to support the specialization.