### PR TITLE
Move heap ownership info from chunk to pagemap

### DIFF
--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -11,7 +11,7 @@ use @pony_alloc_final[Pointer[U8]](ctx: Pointer[None], size: USize)
 use @pony_exitcode[None](code: I32)
 use @pony_get_exitcode[I32]()
 use @pony_triggergc[None](ctx: Pointer[None])
-use @ponyint_pagemap_get[Pointer[None]](p: Pointer[None] tag)
+use @ponyint_pagemap_get_chunk[Pointer[None]](p: Pointer[None] tag)
 
 use "pony_test"
 use "collections"
@@ -617,12 +617,12 @@ class \nodoc\ iso _TestStringTrimInPlace is UnitTest
     space: USize = 0)
   =>
     let copy: String ref = orig.clone()
-    let pre_trim_pagemap = @ponyint_pagemap_get(copy.cpointer())
+    let pre_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
     h.assert_eq[USize](space, copy.space())
     h.assert_eq[String box](expected, copy.clone()) // safe to clone
-    let post_trim_pagemap = @ponyint_pagemap_get(copy.cpointer())
+    let post_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     if copy.space() == 0 then
       h.assert_eq[USize](0, post_trim_pagemap.usize())
     else
@@ -1480,11 +1480,11 @@ class \nodoc\ iso _TestArrayTrimInPlace is UnitTest
     space: USize = 0)
   =>
     let copy: Array[U8] ref = orig.clone()
-    let pre_trim_pagemap = @ponyint_pagemap_get(copy.cpointer())
+    let pre_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     copy.trim_in_place(from, to)
     h.assert_eq[USize](space, copy.space())
     h.assert_array_eq[U8](expected, copy)
-    let post_trim_pagemap = @ponyint_pagemap_get(copy.cpointer())
+    let post_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     if copy.space() == 0 then
       h.assert_eq[USize](0, post_trim_pagemap.usize())
     else

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -482,7 +482,8 @@ static void acq_or_rel_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
 void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  pony_actor_t* actor = NULL;
+  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -491,8 +492,6 @@ void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
       recurse(ctx, p, t->trace);
     return;
   }
-
-  pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
     send_local_object(ctx, p, t, mutability);
@@ -503,7 +502,8 @@ void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  pony_actor_t* actor = NULL;
+  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -512,8 +512,6 @@ void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
       recurse(ctx, p, t->trace);
     return;
   }
-
-  pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
     recv_local_object(ctx, p, t, mutability);
@@ -524,7 +522,8 @@ void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  pony_actor_t* actor = NULL;
+  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -533,8 +532,6 @@ void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
       recurse(ctx, p, t->trace);
     return;
   }
-
-  pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
     mark_local_object(ctx, chunk, p, t, mutability);
@@ -545,7 +542,8 @@ void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  pony_actor_t* actor = NULL;
+  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -554,8 +552,6 @@ void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
       recurse(ctx, p, t->trace);
     return;
   }
-
-  pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
     acquire_local_object(ctx, p, t, mutability);
@@ -566,7 +562,8 @@ void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  pony_actor_t* actor = NULL;
+  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
 
   // Don't gc memory that wasn't pony_allocated, but do recurse.
   if(chunk == NULL)
@@ -575,8 +572,6 @@ void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
       recurse(ctx, p, t->trace);
     return;
   }
-
-  pony_actor_t* actor = ponyint_heap_owner(chunk);
 
   if(actor == ctx->current)
     release_local_object(ctx, p, t, mutability);
@@ -665,7 +660,7 @@ void ponyint_gc_markimmutable(pony_ctx_t* ctx, gc_t* gc)
     {
       // Mark in our heap and recurse if it wasn't already marked.
       void* p = obj->address;
-      chunk_t* chunk = ponyint_pagemap_get(p);
+      chunk_t* chunk = ponyint_pagemap_get_chunk(p);
       mark_local_object(ctx, chunk, p, obj->type, PONY_TRACE_IMMUTABLE);
     }
   }

--- a/src/libponyrt/gc/objectmap.c
+++ b/src/libponyrt/gc/objectmap.c
@@ -71,7 +71,7 @@ void ponyint_objectmap_sweep(objectmap_t* map)
 
     if(obj->rc > 0)
     {
-      chunk_t* chunk = ponyint_pagemap_get(p);
+      chunk_t* chunk = ponyint_pagemap_get_chunk(p);
       ponyint_heap_mark_shallow(chunk, p);
     } else {
       ponyint_objectmap_clearindex(map, i);

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -10,9 +10,6 @@
 
 typedef struct chunk_t
 {
-  // immutable
-  pony_actor_t* actor;
-
   // used for pointer tagging
   // bit 0 (lowest bit) for keeping track of chunk type (1 = small; 0 = large)
   // bit 1 for keeping track of chunks to be cleared
@@ -238,9 +235,9 @@ static char* get_m(chunk_t* chunk)
   return (char*)((uintptr_t)chunk->m & CHUNK_M_BITMASK);
 }
 
-static void large_pagemap(char* m, size_t size, chunk_t* chunk)
+static void large_pagemap(char* m, size_t size, chunk_t* chunk, pony_actor_t* actor)
 {
-  ponyint_pagemap_set_bulk(m, chunk, size);
+  ponyint_pagemap_set_bulk(m, chunk, actor, size);
 }
 
 static void maybe_clear_chunk(chunk_t* chunk)
@@ -326,7 +323,7 @@ static void destroy_small(small_chunk_t* chunk, uint32_t mark)
   final_small(chunk, FORCE_ALL_FINALISERS);
 
   char* m = get_m((chunk_t*)chunk);
-  ponyint_pagemap_set(m, NULL);
+  ponyint_pagemap_set(m, NULL, NULL);
   POOL_FREE(block_t, m);
   POOL_FREE(small_chunk_t, chunk);
 }
@@ -340,7 +337,7 @@ static void destroy_large(large_chunk_t* chunk, uint32_t mark)
   final_large(chunk, mark);
 
   char* m = get_m((chunk_t*)chunk);
-  large_pagemap(m, chunk->size, NULL);
+  large_pagemap(m, chunk->size, NULL, NULL);
 
   if(m != NULL)
     ponyint_pool_free_size(chunk->size, m);
@@ -597,7 +594,6 @@ void* ponyint_heap_alloc_small(pony_actor_t* actor, heap_t* heap,
     }
   } else {
     small_chunk_t* n = (small_chunk_t*) POOL_ALLOC(small_chunk_t);
-    n->base.actor = actor;
     n->base.m = (char*) POOL_ALLOC(block_t);
     set_small_chunk_size(n, sizeclass);
 #ifdef USE_RUNTIMESTATS
@@ -617,7 +613,7 @@ void* ponyint_heap_alloc_small(pony_actor_t* actor, heap_t* heap,
 
     set_chunk_needs_clearing((chunk_t*)n);
 
-    ponyint_pagemap_set(get_m((chunk_t*)n), (chunk_t*)n);
+    ponyint_pagemap_set(get_m((chunk_t*)n), (chunk_t*)n, actor);
 
     heap->small_free[sizeclass] = n;
     chunk = n;
@@ -648,7 +644,6 @@ void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size,
   size = ponyint_pool_adjust_size(size);
 
   large_chunk_t* chunk = (large_chunk_t*) POOL_ALLOC(large_chunk_t);
-  chunk->base.actor = actor;
   chunk->size = size;
   chunk->base.m = (char*) ponyint_pool_alloc_size(size);
 #ifdef USE_RUNTIMESTATS
@@ -666,7 +661,7 @@ void* ponyint_heap_alloc_large(pony_actor_t* actor, heap_t* heap, size_t size,
   // note if a finaliser needs to run or not
   set_large_chunk_finaliser(chunk, (track_finalisers_mask & 1));
 
-  large_pagemap(get_m((chunk_t*)chunk), size, (chunk_t*)chunk);
+  large_pagemap(get_m((chunk_t*)chunk), size, (chunk_t*)chunk, actor);
 
   chunk->next = heap->large;
   heap->large = chunk;
@@ -685,7 +680,7 @@ void* ponyint_heap_realloc(pony_actor_t* actor, heap_t* heap, void* p,
   actor->actorstats.heap_realloc_counter++;
 #endif
 
-  chunk_t* chunk = ponyint_pagemap_get(p);
+  chunk_t* chunk = ponyint_pagemap_get_chunk(p);
 
   // We can't realloc memory that wasn't pony_alloc'ed since we can't know how
   // much to copy from the previous location.
@@ -906,18 +901,6 @@ void ponyint_heap_endgc(heap_t* heap
 
   if(heap->next_gc < heap_initialgc)
     heap->next_gc = heap_initialgc;
-}
-
-pony_actor_t* ponyint_heap_owner(chunk_t* chunk)
-{
-  // FIX: false sharing
-  // reading from something that will never be written
-  // but is on a cache line that will often be written
-  // called during tracing
-  // actual chunk only needed for GC tracing
-  // all other tracing only needs the owner
-  // so the owner needs the chunk and everyone else just needs the owner
-  return chunk->actor;
 }
 
 size_t ponyint_heap_size(chunk_t* chunk)

--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -102,8 +102,6 @@ void ponyint_heap_endgc(heap_t* heap
   );
 #endif
 
-pony_actor_t* ponyint_heap_owner(chunk_t* chunk);
-
 size_t ponyint_heap_size(chunk_t* chunk);
 
 #ifdef USE_RUNTIMESTATS

--- a/src/libponyrt/mem/pagemap.h
+++ b/src/libponyrt/mem/pagemap.h
@@ -6,12 +6,15 @@
 PONY_EXTERN_C_BEGIN
 
 typedef struct chunk_t chunk_t;
+typedef struct pony_actor_t pony_actor_t;
 
-chunk_t* ponyint_pagemap_get(const void* addr);
+chunk_t* ponyint_pagemap_get_chunk(const void* addr);
 
-void ponyint_pagemap_set(const void* addr, chunk_t* chunk);
+chunk_t* ponyint_pagemap_get(const void* addr, pony_actor_t** actor);
 
-void ponyint_pagemap_set_bulk(const void* addr, chunk_t* chunk, size_t size);
+void ponyint_pagemap_set(const void* addr, chunk_t* chunk, pony_actor_t* actor);
+
+void ponyint_pagemap_set_bulk(const void* addr, chunk_t* chunk, pony_actor_t* actor, size_t size);
 
 #ifdef USE_RUNTIMESTATS
 /** Get the memory used by the pagemap.

--- a/test/libponyrt/mem/heap.cc
+++ b/test/libponyrt/mem/heap.cc
@@ -30,8 +30,9 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)(64 + 1024), actor->actorstats.heap_mem_allocated);
 #endif
 
-  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p);
-  ASSERT_EQ(actor, ponyint_heap_owner(chunk));
+  pony_actor_t* pagemap_actor = NULL;
+  chunk_t* chunk = (chunk_t*)ponyint_pagemap_get(p, &pagemap_actor);
+  ASSERT_EQ(actor, pagemap_actor);
 
   size_t size = ponyint_heap_size(chunk);
   ASSERT_EQ(size, (size_t)128);
@@ -136,8 +137,8 @@ TEST(Heap, Init)
 
   size_t large_size = (1 << 22) - 7;
   void* p5 = ponyint_heap_alloc(actor, &heap, large_size, TRACK_NO_FINALISERS);
-  chunk_t* chunk5 = (chunk_t*)ponyint_pagemap_get(p5);
-  ASSERT_EQ(actor, ponyint_heap_owner(chunk5));
+  chunk_t* chunk5 = (chunk_t*)ponyint_pagemap_get(p5, &pagemap_actor);
+  ASSERT_EQ(actor, pagemap_actor);
 
 #ifdef USE_RUNTIMESTATS
   ASSERT_EQ((size_t)5, actor->actorstats.heap_alloc_counter);
@@ -156,12 +157,14 @@ TEST(Heap, Init)
 
   while(p5_curr < p5_end)
   {
-    p5_chunk = (chunk_t*)ponyint_pagemap_get(p5_curr);
+    p5_chunk = (chunk_t*)ponyint_pagemap_get(p5_curr, &pagemap_actor);
     p5_curr += POOL_ALIGN;
     ASSERT_EQ(chunk5, p5_chunk);
+    ASSERT_EQ(actor, pagemap_actor);
   }
-  p5_chunk = (chunk_t*)ponyint_pagemap_get(p5_end);
+  p5_chunk = (chunk_t*)ponyint_pagemap_get(p5_end, &pagemap_actor);
   ASSERT_NE(chunk5, p5_chunk);
+  ASSERT_NE(actor, pagemap_actor);
 
   size_t size5 = ponyint_heap_size(chunk5);
   ASSERT_EQ(adjust_size, size5);

--- a/test/libponyrt/mem/pagemap.cc
+++ b/test/libponyrt/mem/pagemap.cc
@@ -6,64 +6,86 @@
 
 TEST(Pagemap, UnmappedIsNull)
 {
-  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x0));
-  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x7623432D));
-  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0xFFFFFFFFFFFFFFFF));
+  pony_actor_t* actor = NULL;
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x0, &actor));
+  ASSERT_EQ(NULL, actor);
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0x7623432D, &actor));
+  ASSERT_EQ(NULL, actor);
+  ASSERT_EQ(NULL, ponyint_pagemap_get((void*)0xFFFFFFFFFFFFFFFF, &actor));
+  ASSERT_EQ(NULL, actor);
 }
 
 TEST(Pagemap, SetAndUnset)
 {
   char* m = (char*)(44 << 12);
+  pony_actor_t* actor = (pony_actor_t*)0xABCD;
+  pony_actor_t* pagemap_actor = NULL;
 
-  ponyint_pagemap_set(m, (chunk_t*)m);
-  ASSERT_EQ(m, (char*)ponyint_pagemap_get(m));
+  ponyint_pagemap_set(m, (chunk_t*)m, actor);
+  ASSERT_EQ(m, (char*)ponyint_pagemap_get(m, &pagemap_actor));
+  ASSERT_EQ(actor, pagemap_actor);
+  ASSERT_EQ(m, (char*)ponyint_pagemap_get_chunk(m));
 
-  ponyint_pagemap_set(m, NULL);
-  ASSERT_EQ(NULL, ponyint_pagemap_get(m));
+  ponyint_pagemap_set(m, NULL, NULL);
+  ASSERT_EQ(NULL, ponyint_pagemap_get(m, &pagemap_actor));
+  ASSERT_EQ(NULL, pagemap_actor);
+  ASSERT_EQ(NULL, ponyint_pagemap_get_chunk(m));
 }
 
 TEST(Pagemap, SubAddressing)
 {
   char* m = (char*)(99 << 12);
-  ponyint_pagemap_set(m, (chunk_t*)m);
+  ponyint_pagemap_set(m, (chunk_t*)m, (pony_actor_t*)0xABCD);
 
   char* p = m;
   char* end = p + 1024;
+  pony_actor_t* actor = NULL;
 
   while(p < end)
   {
-    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p));
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p, &actor));
+    ASSERT_EQ((pony_actor_t*)0xABCD, actor);
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get_chunk((chunk_t*)p));
     p += 64;
   }
 
-  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end, &actor));
+  ASSERT_EQ(NULL, actor);
+  ASSERT_EQ(NULL, ponyint_pagemap_get_chunk((chunk_t*)end));
 }
 
 TEST(Pagemap, SetAndUnsetBulk)
 {
   char* m = (char*)(155 << 12);
-  size_t size = 65536;
+  size_t size = 8388608;
 
-  ponyint_pagemap_set_bulk(m, (chunk_t*)m, size);
+  ponyint_pagemap_set_bulk(m, (chunk_t*)m, (pony_actor_t*)0xABCD, size);
 
   char* p = m;
   char* end = p + size;
+  pony_actor_t* actor = NULL;
 
   while(p < end)
   {
-    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p));
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get((chunk_t*)p, &actor));
+    ASSERT_EQ((pony_actor_t*)0xABCD, actor);
+    ASSERT_EQ(m, (char*)ponyint_pagemap_get_chunk((chunk_t*)p));
     p += 1024;
   }
 
-  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end));
+  ASSERT_EQ(NULL, ponyint_pagemap_get((chunk_t*)end, &actor));
+  ASSERT_EQ(NULL, actor);
+  ASSERT_EQ(NULL, ponyint_pagemap_get_chunk((chunk_t*)end));
 
-  ponyint_pagemap_set_bulk(m, NULL, size);
+  ponyint_pagemap_set_bulk(m, NULL, NULL, size);
 
   p = m;
 
   while(p < end)
   {
-    ASSERT_EQ(NULL, (char*)ponyint_pagemap_get((chunk_t*)p));
+    ASSERT_EQ(NULL, (char*)ponyint_pagemap_get((chunk_t*)p, &actor));
+    ASSERT_EQ(NULL, actor);
+    ASSERT_EQ(NULL, (char*)ponyint_pagemap_get_chunk((chunk_t*)p));
     p += 1024;
   }
 }


### PR DESCRIPTION
Prior to this commit, the chunk kept track of the heap ownership info in the `chunk->actor` field. This worked but was not ideal as noted in the `ponyint_heap_owner` function that this is a case of false sharing where the chunk owner needs the chunk but all other actors only need the chunk owner only. This led to lots of pointer chasing as the pagemap was used to retrieve the chunk pointerand then the chunk had to be loaded to retrieve the owning actor pointer.

This commit removes the `chunk->actor` field further slimming down both the `small_chunk` and `large_chunk` so both now fit within 32 bytes (on 64 bit architectures). The chunk ownership information is now kept in the lowest level of the pagemap next to the chunk information. This removes the previous pointer chasing because the chunk owning actor pointer is retrieved at the same time as the chunk pointer without needing to load the chunk itself. This is a fairly standard tradeoff of memory for performance where we're now storing more data in the pagemap to minimize pointer chasing. The expectation is that this will have a net positive impact on performance but no benchmarks have been run to validate this assumption.