### PR TITLE
Add workflow to manually update the lib cache

### DIFF
--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -1,0 +1,36 @@
+name: Manually update lib cache
+
+on:
+  workflow_dispatch
+
+concurrency:
+  group: "update-lib-cache"
+
+jobs:
+  x86_64-linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230806
+            name: x86-64 Ubuntu 22.04
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20230807
+            name: x86-64 Ubuntu 20.04
+
+    name: ${{ matrix.name }}
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Cache Libs
+        id: cache-libs
+        uses: actions/cache@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+      - name: Build Libs
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j8


### PR DESCRIPTION
We cache `lib` in order to speed up our builds as building all of LLVM takes a long long time. Once an update to any of the files that would invalidate the cached libs is done, until a new cached version is done on "main", it won't apply to new PRs.

This workflow allows us to update (if needed) the lib cache for any given branch. In general, this would usually only be used on `main`.