### PR TITLE
Save libs/LLVM cache immediately after building it

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -29,15 +29,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache Libs
-        id: cache-libs
-        uses: actions/cache@v3
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
-        if: steps.cache-libs.outputs.cache-hit != 'true'
+        if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Nightly
         run: bash .ci-scripts/x86-64-nightly.bash
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,15 +93,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache Libs
-        id: cache-libs
-        uses: actions/cache@v3
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
-        if: steps.cache-libs.outputs.cache-hit != 'true'
+        if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Configure Debug Runtime
         run: make configure arch=x86-64 config=debug
       - name: Build Debug Runtime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache Libs
-        id: cache-libs
-        uses: actions/cache@v3
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
-        if: steps.cache-libs.outputs.cache-hit != 'true'
+        if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Release
         run: bash .ci-scripts/x86-64-release.bash
         env:

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -33,15 +33,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Cache Libs
-        id: cache-libs
-        uses: actions/cache@v3
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
-        if: steps.cache-libs.outputs.cache-hit != 'true'
+        if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Configure Debug Runtime
         run: make configure config=debug
       - name: Build Debug Runtime


### PR DESCRIPTION
Prior to this change, if a subsequent job after we built the libs/LLVM cache failed then the LLVM that we spent a ton of time building would not be saved and the process would have to be repeated again.