### PR TITLE
Run "rebuild libs cache" every day 3 hours before nightlies run

### DIFF
--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -2,6 +2,8 @@ name: Manually update lib cache
 
 on:
   workflow_dispatch
+  schedule:
+    - cron: "0 21 * * *"
 
 concurrency:
   group: "update-lib-cache"


### PR DESCRIPTION
Usually this will quickly exit, however, if anything is out of date 3 hours before nightlies, it will probably be out of date at the time that nightlies happen. Running ahead of time will make the release more efficient. That efficiency is nice because if we hit a problem elsewhere with the release, it will happen "sooner in the evening" with more time for someone to look into it.