### PR TITLE
Add includes necessary for Visual Studio 2022 v17.7.0

### DIFF
--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -13,6 +13,7 @@
 #include "../libponyrt/mem/pool.h"
 #include <platform.h>
 
+#include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/libponyrt/lang/time.c
+++ b/src/libponyrt/lang/time.c
@@ -1,6 +1,7 @@
 #include <platform.h>
 #include <pony.h>
 #include <time.h>
+#include <stdlib.h>
 #include <string.h>
 
 PONY_EXTERN_C_BEGIN


### PR DESCRIPTION
The latest version of Visual Studio 2022 (17.7.0) makes some header changes that require including `<stdlib.h>` in a couple of places.