### PR TITLE
Merge the "configure" and "build" pony build steps together

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -116,16 +116,16 @@ jobs:
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      - name: Configure Debug Runtime
-        run: make configure arch=x86-64 config=debug
       - name: Build Debug Runtime
-        run: make build config=debug
+        run: |
+          make configure arch=x86-64 config=debug
+          make build config=debug
       - name: Test with Debug Runtime
         run: make test-ci config=debug usedebugger='${{ matrix.debugger }}'
-      - name: Configure Release Runtime
-        run: make configure arch=x86-64 config=release
       - name: Build Release Runtime
-        run: make build config=release
+        run: |
+          make configure arch=x86-64 config=release
+          make build config=release
       - name: Test with Release Runtime
         run: make test-ci config=release usedebugger='${{ matrix.debugger }}'
 
@@ -161,18 +161,18 @@ jobs:
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      - name: Configure Debug Runtime
-        run: make configure config=debug
       - name: Build Debug Runtime
-        run: make build config=debug
+        run: |
+          make configure config=debug
+          make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../rv64gc/debug cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_linker=riscv64-linux-gnu-gcc-10 cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c --link-ldcmd=bfd' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
-      - name: Configure Release Runtime
-        run: make configure config=release
       - name: Build Release Runtime
-        run: make build config=release
+        run: |
+          make configure config=release
+          make build config=release
       - name: Build Release Cross-Compiled Runtime
         run: make cross-libponyrt config=release CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"
       - name: Test with Release Cross-Compiled Runtime
@@ -210,18 +210,18 @@ jobs:
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      - name: Configure Debug Runtime
-        run: make configure config=debug
       - name: Build Debug Runtime
-        run: make build config=debug
+        run: |
+          make configure config=debug
+          make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../armv7-a/debug cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc"
-      - name: Configure Release Runtime
-        run: make configure config=release
       - name: Build Release Runtime
-        run: make build config=release
+        run: |
+          make configure config=release
+          make build config=release
       - name: Build Release Cross-Compiled Runtime
         run: make cross-libponyrt config=release CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
       - name: Test with Release Cross-Compiled Runtime
@@ -259,18 +259,18 @@ jobs:
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      - name: Configure Debug Runtime
-        run: make configure config=debug
       - name: Build Debug Runtime
-        run: make build config=debug
+        run: |
+          make configure config=debug
+          make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../armv7-a/debug cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc"
-      - name: Configure Release Runtime
-        run: make configure config=release
       - name: Build Release Runtime
-        run: make build config=release
+        run: |
+          make configure config=release
+          make build config=release
       - name: Build Release Cross-Compiled Runtime
         run: make cross-libponyrt config=release CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
       - name: Test with Release Cross-Compiled Runtime

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -68,10 +68,10 @@ jobs:
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      - name: Configure Debug Runtime
-        run: make configure config=debug
       - name: Build Debug Runtime
-        run: make build config=debug
+        run: |
+          make configure config=debug
+          make build config=debug
       - name: Run Stress Test
         run: make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}'
       - name: Send alert on failure


### PR DESCRIPTION
Configure takes no time at all and we don't get anything out of them being different steps. It is fine for the level of detail we need to have them as a single "build" step.