### PR TITLE
Add `make ponyc` for building just ponyc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,9 @@ all: build
 build:
 	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --build '$(buildDir)' --config $(config) --target all -- $(build_flags)
 
+ponyc:
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --build '$(buildDir)' --config $(config) --target ponyc -- $(build_flags)
+
 crossBuildDir := $(srcDir)/build/$(arch)/build_$(config)
 
 cross-libponyrt:


### PR DESCRIPTION
Sometimes while working on a compiler bug, it's annoying to rebuild lots of tests/runners/etc when just trying to make a new version of the compiler to do some manual testing with it.

This PR adds `make ponyc` which only uses the `ponyc` CMake target, rather than the `all` target. Everything else in the invocation is the same as it is for `make build`.