### PR TITLE
Make the concurrency group for PR workflow more scoped

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR
 on: pull_request
 
 concurrency:
-  group: ${{ github.ref }}
+  group: pr-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Having it just be the ref can accidentally conflict with other workflows that set the same and run on the same events and have them operate serially (unintentionally).