### PR TITLE
Drop macOS on Apple Silicon as a fully supported platform

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,38 +1,6 @@
 #
 # Pull Request Tasks
 #
-task:
-  only_if: $CIRRUS_PR != ''
-
-  timeout_in: 120m
-
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.3
-
-  name: "arm64 Apple Darwin"
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` arm64 ghcr.io/cirruslabs/macos-ventura-xcode:14.3 20220511"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  install_script:
-    - brew update --force --quiet
-    - brew install llvm
-  debug_configure_script:
-    - make configure arch=armv8 config=debug
-  debug_build_script:
-    - make build arch=armv8 config=debug
-  debug_test_script:
-    - make test-ci config=debug usedebugger=/opt/homebrew/opt/llvm/bin/lldb
-  release_configure_script:
-    - make configure arch=armv8 config=release
-  release_build_script:
-    - make build arch=armv8 config=release
-  release_test_script:
-    - make test-ci config=release usedebugger=/opt/homebrew/opt/llvm/bin/lldb
 
 task:
   only_if: $CIRRUS_PR != ''
@@ -78,36 +46,6 @@ task:
 
   timeout_in: 120m
 
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.3
-
-  name: "nightly: arm64-apple-darwin"
-
-  environment:
-    TRIPLE_VENDOR: apple
-    TRIPLE_OS: darwin
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` arm64 ghcr.io/cirruslabs/macos-ventura-xcode:14.3 20220511"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  install_script:
-    - brew install python
-    - pip3 install --upgrade cloudsmith-cli
-
-  nightly_script:
-    - export TZ=utc
-    - bash .ci-scripts/arm64-nightly.bash
-
-task:
-  only_if: $CIRRUS_CRON == "nightly"
-
-  timeout_in: 120m
-
   windows_container:
     image: ponylang/ponyc-ci-x86-64-pc-windows-msvc-builder:20220803
     os_version: 2019
@@ -142,37 +80,6 @@ task:
 #
 # Release build tasks
 #
-
-task:
-  only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'
-  use_compute_credits: true
-
-  timeout_in: 120m
-
-  macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.3
-
-  name: "release: arm64-apple-darwin"
-
-  environment:
-    TRIPLE_VENDOR: apple
-    TRIPLE_OS: darwin
-    CLOUDSMITH_API_KEY: ENCRYPTED[!2cb1e71c189cabf043ac3a9030b3c7708f9c4c983c86d07372ae58ad246a07c54e40810d038d31c3cf3ed8888350caca!]
-
-  libs_cache:
-    folder: build/libs
-    fingerprint_script: echo "`md5 Makefile` `md5 CMakeLists.txt` `md5 lib/CMakeLists.txt` arm64 ghcr.io/cirruslabs/macos-ventura-xcode:14.3 20220511"
-    populate_script: make libs build_flags=-j12
-  upload_caches:
-    - libs
-
-  install_script:
-    - brew install python
-    - pip3 install --upgrade cloudsmith-cli
-
-  nightly_script:
-    - export TZ=utc
-    - bash .ci-scripts/arm64-release.bash
 
 task:
   only_if: $CIRRUS_TAG =~ '^\d+\.\d+\.\d+$'

--- a/.release-notes/no-arm-macos.md
+++ b/.release-notes/no-arm-macos.md
@@ -1,0 +1,13 @@
+## Drop macOS on Apple Silicon as a fully supported platform
+
+We've dropped macOS on Apple Silicon as a fully supported platform.
+
+At the moment, we don't have access to a CI environment with macOS on Apple Silicon. Until we have one, we can no longer maintain macOS as a fully supported platform.
+
+We expect that we can start offering full macOS support on Apple Silicon in Q4 of 2023. This assumes that GitHub rolls out their delayed macOS on Apple Silicon hosted CI runners in Q4.
+
+As of Pony 0.56.0, we are no longer providing prebuilt Apple Silicon builds of ponyc. You can [still build from source](https://github.com/ponylang/ponyc/blob/main/BUILD.md#macos). And, existing prebuilt release and nightly macOS binaries will remain available via `ponyup` and Cloudsmith.
+
+Our plan is to maintain `corral` and `ponyup` on Apple Silicon as we don't expect any breaking changes to `ponyc` before GitHub offers Apple Silicon runners.
+
+We will be doing our best to not break macOS on Apple Silicon during the transition. Hopefully, our macOS on Intel and Linux on aarch64 CI coverage will keep any accidental breakage from impacting on macOS on Apple Silicon. We can not guarantee that, so, community support in the form of PRs to keep macOS on Apple Silicon working are greatly appreciated.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,7 +67,7 @@ If you get that error, it means that the Glibc we compiled ponyc with isn't comp
 
 ## macOS
 
-Prebuilt macOS packages are available via [ponyup](https://github.com/ponylang/ponyup). You can also install nightly builds using ponyup.
+Prebuilt macOS packages are available for macOS on Intel via [ponyup](https://github.com/ponylang/ponyup). You can also install nightly builds using ponyup.
 
 To install the most recent ponyc on macOS:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pony is still pre-1.0 and as such, semi-regularly introduces breaking changes. T
 ### Operating Systems
 
 * Linux
-* macOS
+* macOS (x86 only)
 * Windows 10
 
 ### CPUs
@@ -28,6 +28,7 @@ Best effort platforms mean that there is support for the platform in the codebas
 
 * DragonFlyBSD (x86 only)
 * FreeBSD (x86 only)
+* macOS (Apple Silicon only)
 
 ## More Information
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -44,7 +44,6 @@ You can verify that the release artifacts were successfully built and uploaded b
 
 Package names will be:
 
-* ponyc-arm64-apple-darwin.tar.gz
 * ponyc-x86-64-apple-darwin.tar.gz
 * ponyc-x86-64-pc-windows-msvc.zip
 * ponyc-x86-64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
With our move off of CirrusCI, we don't have a Apple Silicon CI environment. Hopefully, we'll get one soon as GitHub is saying that they should have one sometime in Q4 of 2023.