### PR TITLE
Avoid hangs in async pony_check properties when using actions

### DIFF
--- a/.release-notes/4405.md
+++ b/.release-notes/4405.md
@@ -1,0 +1,3 @@
+Due to a logical flaw in the `pony_check` package regarding how the `_PropertyRunner` handles `expect_action(...)` and `complete_action(...)`/`fail_action(...)` calls, it was possible for lingering executions of previous runs to call into the `_PropertyRunner` instance that was already handling another run, completing or failing some actions of the current run. This has resulted in occasional hangs in CI.
+
+With this change the hangs could not be reproduces locally or in CI.


### PR DESCRIPTION
This should fix issue #4391 for very slow execution environments.

[update]

After first assuming it was a timeout issue, i.e. that a slow execution environment did not finish within the default 60 secs timeout.
It turned out to be a logical flaw in how the `_PropertyRunner` handles expecting and completing actions. It was possible to have stray actors from old property runs call into the `_PropertyRunner` instance that was already dealing with another run, thus disturbing the current run. The async Property handling with `complete` and `fail` already had such a safeguard, the `expect_action` and `complete_action`/`fail_action` calls did not yet have this.

[/update]


After investigating #4391 i was not able to find a logical flaw in the `PropertyRunner` or in the way the `UnitTest` timeout and the `TestHelper.long_test()` feature is being used by pony_check. After looking at the logs, the best explanation for the spurious failures is that the timeout of 1 minute per property by default, was just too low for the specific qemu execution environment. The log lines are all expected and there should be 4 of them per property execution for a default of 100 samples. But the logs are short some of those, so the test simply didn't finish in the given 60 seconds.

Hence this PR is changing the timeout for the tests to 5 minutes. There is no test actually checking for this timeout explicitly, so there will be no increase in testing time, coming from this change.