### PR TITLE
Update documentation for Actor and Scheduler statistics

### DIFF
--- a/packages/runtime_info/actor_stats.pony
+++ b/packages/runtime_info/actor_stats.pony
@@ -2,7 +2,9 @@ use @pony_actor_stats[_ActorStats]()
 
 primitive ActorStats
   """
-  Provides functions that expose statistics about the current actor.
+  Provides functions that expose statistics about the current actor. All
+  methods will return '0' if the runtime used the program wasn't compiled with
+  runtime statistics turned on.
   """
 
   fun heap_mem_allocated(auth: ActorStatsAuth): USize =>

--- a/packages/runtime_info/scheduler_stats.pony
+++ b/packages/runtime_info/scheduler_stats.pony
@@ -2,7 +2,9 @@ use @pony_scheduler_stats[_SchedulerStats]()
 
 primitive SchedulerStats
   """
-  Provides functions that expose statistics about the current scheduler.
+  Provides functions that expose statistics about the current scheduler. All
+  methods will return '0' if the runtime used the program wasn't compiled with
+  runtime statistics turned on.
   """
 
   fun total_mem_allocated(auth: SchedulerStatsAuth): I64 =>


### PR DESCRIPTION
Prior to this change, it wasn't clear without looking at the code that you need a runtime compiled to support runtime statistics otherwise all actor and scheduler stats will be 0.