### PR TITLE
Update supported Alpine version to 3.17 and later

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk update \
   && apk upgrade \
@@ -7,8 +7,6 @@ RUN apk update \
   binutils-gold \
   clang \
   clang-dev \
-  libexecinfo-dev \
-  libexecinfo-static \
   coreutils \
   linux-headers \
   cmake \

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.18
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
@@ -7,8 +7,6 @@ RUN apk add --update --no-cache \
     curl \
     build-base \
     binutils-gold \
-    libexecinfo-dev \
-    libexecinfo-static \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.18
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
@@ -7,8 +7,6 @@ RUN apk add --update --no-cache \
     curl \
     build-base \
     binutils-gold \
-    libexecinfo-dev \
-    libexecinfo-static \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -20,7 +20,7 @@ jobs:
             name: x86-64-unknown-linux-ubuntu20.04
             triple-os: linux-ubuntu20.04
             triple-vendor: unknown
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,7 +90,7 @@ jobs:
           - image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230806
             name: x86-64 Linux glibc
             debugger: lldb
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64 Linux musl
             debugger: gdb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             name: x86-64-unknown-linux-ubuntu20.04
             triple-os: linux-ubuntu20.04
             triple-vendor: unknown
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -28,19 +28,19 @@ jobs:
             name: x86-64-unknown-linux-ubuntu22.04 [cd] [debug]
             target: test-stress-with-cd-debug
             debugger: lldb
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl [release]
             target: test-stress-release
             debugger: gdb
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl [debug]
             target: test-stress-debug
             debugger: gdb
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl [cd] [release]
             target: test-stress-with-cd-release
             debugger: gdb
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
             name: x86-64-unknown-linux-musl [cd] [debug]
             target: test-stress-with-cd-debug
             debugger: gdb

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230806
           - image: ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20230807
-          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230808
+          - image: ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230822
           - image: ponylang/ponyc-ci-cross-riscv64:20230808
           - image: ponylang/ponyc-ci-cross-arm:20230809
           - image: ponylang/ponyc-ci-cross-armhf:20230809

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,3 +1,13 @@
+## Update Pony musl Docker images to Alpine 3.18
+
+We've updated our `ponylang/ponyc:latest-alpine`, `ponylang/ponyc:release-alpine`, and `ponylang/ponyc:x.y.z-alpine` images to be based on Alpine 3.18. Previously, we were using Alpine 3.16 as the base.
+
+## Drop support for Alpine versions prior to 3.17
+
+We've dropped support for Alpine versions prior to 3.17. The ponyc compiler that we supply will not work on earlier Alpine versions. If you need to use on 3.16 or earlier, you'll need to patch the compiler and build from source.
+
+The change is relatively straightforward and can be reverse engineered from the [pull request that dropped 3.16 support](https://github.com/ponylang/ponyc/pull/4407).
+
 ## FreeBSD is no longer a supported platform
 
 We no longer have access to hardware that we can test FreeBSD on as part of our regular Continous Integration and Release cycles. As such, we are removing FreeBSD as a supported platform. We will make best effort attempts to not break FreeBSD, however, it is likely to fall behind and need maintenance from interested community members.

--- a/BUILD.md
+++ b/BUILD.md
@@ -64,7 +64,7 @@ Additional Requirements:
 
 Distribution | Requires
 --- | ---
-Alpine | binutils-gold, clang, clang-dev, cmake, libexecinfo-dev, libexecinfo-static, make
+Alpine 3.17+ | binutils-gold, clang, clang-dev, cmake, make
 CentOS 8 | clang, cmake, diffutils, libatomic, libstdc++-static, make, zlib-devel
 Fedora | clang, cmake, libatomic, libstdc++-static, make
 OpenSuse Leap | binutils-gold, cmake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- Drop support for Alpine versions prior to 3.17 ([PR #4407](https://github.com/ponylang/ponyc/pull/4407))
+- Update Pony musl Docker images to Alpine 3.18 ([PR #4407](https://github.com/ponylang/ponyc/pull/4407))
 - Drop FreeBSD as a supported platform ([PR #4382](https://github.com/ponylang/ponyc/pull/4382))
 - Drop macOS on Apple Silicon as a fully supported platform ([PR #4403](https://github.com/ponylang/ponyc/pull/4403))
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,6 +24,10 @@ Currently, we have packages for the following Glibc based distributions:
 - Pop!_OS 20.04, 22.04
 - Ubuntu 20.04, 22.04
 
+### Supported Alpine versions
+
+Starting with Pony version 0.56.0, only Alpine 3.17 and later are supported. Pomyup will happily 0.56.0 on Alpine 3.16, but you won't be able to link programs. By the same token, installing version of Pony prior to 0.56.0 on Alpine 3.17 will also fail to link.
+
 ### Manually selecting your Linux platform
 
 To manually set your platform if ponyup is unable to identify it:

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -360,8 +360,7 @@ static bool link_exe(compile_t* c, ast_t* program,
     "";
 #endif
   const char* lexecinfo =
-#if (defined(PLATFORM_IS_LINUX) && !defined(__GLIBC__)) || \
-    defined(PLATFORM_IS_BSD)
+#if (defined(PLATFORM_IS_BSD))
    "-lexecinfo";
 #else
     "";


### PR DESCRIPTION
With Alpine 3.17, Alpine stopped supporting libexecinfo. In the process,
the backtrace functionality was moved into musl directly. This makes it
very hard to support both pre and post 3.17 Alpine with the compiler.

We decided to not support 3.16 and earlier as it is a decent amount of
work to support both and 3.16 is EOL in about 9 months.

As part of the change, we are updating our public docker images to be
compatiable with the change. Our public Alpine images are now based off
of Alpine 3.18.