### PR TITLE
Delete untagged stdlib builder images

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -289,6 +289,34 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ github.job }}  failed.
 
+  prune-untagged-stdlib-builders:
+    needs:
+      - update-stdlib-builder-image-on-nightly
+      - update-stdlib-builder-image-on-release
+
+    name: Prune untagged stdlib builders
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: 'ponyc-ci-stdlib-builder'
+          package-type: 'container'
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: 'true'
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   send-macos-nightly-release-event:
     if: |
       github.event.client_payload.data.repository == 'nightlies' &&


### PR DESCRIPTION
This commit adds a steps that runs after each update for the tagged standard library builder images. The update will delete all untagged builders.

Based on how we use the builder (build, push, use) we shouldn't ever need any of the untagged builders. They are noise for us in the UI of things that will never be used and waste storage for GitHub.