### PR TITLE
Add test runner support for spaces in debugger path name

### DIFF
--- a/test/libponyc-run/runner/_find_executable.pony
+++ b/test/libponyc-run/runner/_find_executable.pony
@@ -3,8 +3,15 @@ use "files"
 
 primitive _FindExecutable
   fun apply(env: Env, name: String): FilePath ? =>
-    if Path.is_abs(name) then
-      FilePath(FileAuth(env.root), name)
+    let fname =
+      if try name(0)? == '"' else false end then
+        name.trim(1, name.size() - 1)
+      else
+        name
+      end
+
+    if Path.is_abs(fname) then
+      FilePath(FileAuth(env.root), fname)
     else
       (let vars, let key) =
         ifdef windows then
@@ -19,13 +26,13 @@ primitive _FindExecutable
           ifdef windows then
             var bin_file_path: FilePath
             try
-              bin_file_path = FilePath.from(dir_file_path, name)?
+              bin_file_path = FilePath.from(dir_file_path, fname)?
               if bin_file_path.exists() then return bin_file_path end
             end
-            bin_file_path = FilePath.from(dir_file_path, name + ".exe")?
+            bin_file_path = FilePath.from(dir_file_path, fname + ".exe")?
             if bin_file_path.exists() then return bin_file_path end
           else
-            let bin_file_path = FilePath.from(dir_file_path, name)?
+            let bin_file_path = FilePath.from(dir_file_path, fname)?
             if bin_file_path.exists() then return bin_file_path end
           end
         end

--- a/test/libponyc-run/runner/_tester.pony
+++ b/test/libponyc-run/runner/_tester.pony
@@ -196,7 +196,7 @@ actor _Tester
         _test_process = ProcessMonitor(spa, bpa, _TestProcessNotify(this),
           executable_file_path, args, vars,
           FilePath(FileAuth(_env.root), _definition.path))
-          .>done_writing()
+            .>done_writing()
       else
         _notify.print(_definition.name,
           _Colors.err(_definition.name + ": unable to find debugger"))
@@ -218,11 +218,9 @@ actor _Tester
                 debugger.replace("%22", "\"")
                 debugger.split(" ")
               end
-            let debugger_fname = debugger_split(0)?
-
             var in_quote = false
             var cur_arg = String
-            for fragment in debugger_split.trim(1).values() do
+            for fragment in debugger_split.values() do
               if fragment.size() == 0 then continue end
 
               if in_quote then
@@ -255,10 +253,10 @@ actor _Tester
                 end
               end
             end
-
-            _FindExecutable(_env, debugger_fname)?
+            _FindExecutable(_env, debugger_args(0)?)?
           else
-            _shutdown_failed("unable to find debugger: " + _options.debugger)
+            _shutdown_failed("unable to find debugger: " +
+              try debugger_args(0)? else _options.debugger end)
             error
           end
         end
@@ -280,11 +278,8 @@ actor _Tester
 
       match debugger_file_path
       | let dfp: FilePath =>
-        let args = Array[String]
-        args.push(dfp.path)
-        args.append(debugger_args)
-        args.push(test_fname)
-        (dfp, args)
+        debugger_args.push(test_fname)
+        (dfp, debugger_args)
       else
         (FilePath(FileAuth(_env.root), test_fname), [ test_fname ])
       end


### PR DESCRIPTION
We discovered this bug while working on moving Windows CI from CirrusCI to GitHub Actions when we tried using an LLDB that was installed at a location that had a space in the file path.

This change is extracted from PR #4383.