### PR TITLE
Move Windows CI from CirrusCI to GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -361,7 +361,7 @@ jobs:
         run: make test-ci config=release usedebugger=lldb
 
   x86_64-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
 
     name: x86-64 Windows MSVC
     steps:
@@ -376,7 +376,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: build/libs
-          key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+          key: libs-windows-2019-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: .\make.ps1 -Command libs -Generator "Visual Studio 17 2022"
@@ -385,7 +385,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: build/libs
-          key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+          key: libs-windows-2019-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Debug Runtime
         run: |
           .\make.ps1 -Command configure -Config Debug

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -359,3 +359,42 @@ jobs:
           make build config=release
       - name: Test with Release Runtime
         run: make test-ci config=release usedebugger=lldb
+
+  x86_64-windows:
+    runs-on: windows-2022
+
+    name: x86-64 Windows MSVC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        run: |
+          Invoke-WebRequest -Uri 'https://www.python.org/ftp/python/3.10.10/python-3.10.10-embed-amd64.zip' -OutFile .\python_dlls.zip
+          Expand-Archive -Path .\python_dlls.zip -DestinationPath .
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
+        with:
+          path: build/libs
+          key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: .\make.ps1 -Command libs -Generator "Visual Studio 17 2022"
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+      # - name: Build Debug Runtime
+      #   run: |
+      #     .\make.ps1 -Command configure -Config Debug
+      #     .\make.ps1 -Command build -Config Debug
+      # - name: Test with Debug Runtime
+      #   run: .\make.ps1 -Command test -Config Debug
+      - name: Build Release Runtime
+        run: |
+          .\make.ps1 -Command configure -Config Release
+          .\make.ps1 -Command build -Config Release
+      - name: Test with Release Runtime
+        run: .\make.ps1 -Command test -Config Release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -386,12 +386,12 @@ jobs:
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
-      # - name: Build Debug Runtime
-      #   run: |
-      #     .\make.ps1 -Command configure -Config Debug
-      #     .\make.ps1 -Command build -Config Debug
-      # - name: Test with Debug Runtime
-      #   run: .\make.ps1 -Command test -Config Debug
+      - name: Build Debug Runtime
+        run: |
+          .\make.ps1 -Command configure -Config Debug
+          .\make.ps1 -Command build -Config Debug
+      - name: Test with Debug Runtime
+        run: .\make.ps1 -Command test -Config Debug
       - name: Build Release Runtime
         run: |
           .\make.ps1 -Command configure -Config Release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -379,7 +379,7 @@ jobs:
           key: libs-windows-2019-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs -Generator "Visual Studio 17 2022"
+        run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,7 @@ jobs:
 
   validate-windows-docker-latest-image-builds:
     name: Validate Windows Docker image builds
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
       - name: Docker build
@@ -64,7 +64,7 @@ jobs:
 
   validate-windows-docker-release-image-builds:
     name: Validate Windows Docker release image builds
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
       - name: Docker build
@@ -362,6 +362,9 @@ jobs:
 
   x86_64-windows:
     runs-on: windows-2019
+    defaults:
+      run:
+        shell: pwsh
 
     name: x86-64 Windows MSVC
     steps:
@@ -369,8 +372,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Dependencies
         run: |
-          Invoke-WebRequest -Uri 'https://www.python.org/ftp/python/3.10.10/python-3.10.10-embed-amd64.zip' -OutFile .\python_dlls.zip
-          Expand-Archive -Path .\python_dlls.zip -DestinationPath .
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v3
@@ -391,10 +393,10 @@ jobs:
           .\make.ps1 -Command configure -Config Debug
           .\make.ps1 -Command build -Config Debug
       - name: Test with Debug Runtime
-        run: .\make.ps1 -Command test -Config Debug
+        run: .\make.ps1 -Command test -Config Debug -Uselldb yes
       - name: Build Release Runtime
         run: |
           .\make.ps1 -Command configure -Config Release
           .\make.ps1 -Command build -Config Release
       - name: Test with Release Runtime
-        run: .\make.ps1 -Command test -Config Release
+        run: .\make.ps1 -Command test -Config Release -Uselldb yes

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -154,7 +154,7 @@ class \nodoc\ _TestTCP is TCPListenNotify
   new iso create(h: TestHelper) =>
     _h = h
 
-  fun iso apply(c: TCPConnectionNotify iso, s: TCPConnectionNotify iso) =>
+  fun iso apply(c: TCPConnectionNotify iso, s: TCPConnectionNotify iso, port: String) =>
     _client_conn_notify = consume c
     _server_conn_notify = consume s
 
@@ -164,7 +164,7 @@ class \nodoc\ _TestTCP is TCPListenNotify
     h.expect_action("client create")
     h.expect_action("server accept")
 
-    h.dispose_when_done(TCPListener(TCPListenAuth(h.env.root), consume this))
+    h.dispose_when_done(TCPListener(TCPListenAuth(h.env.root), consume this, "", port))
     h.complete_action("server create")
 
     h.long_test(30_000_000_000)
@@ -209,7 +209,7 @@ class \nodoc\ iso _TestTCPExpect is UnitTest
     h.expect_action("server receive")
     h.expect_action("expect received")
 
-    _TestTCP(h)(_TestTCPExpectNotify(h, false), _TestTCPExpectNotify(h, true))
+    _TestTCP(h)(_TestTCPExpectNotify(h, false), _TestTCPExpectNotify(h, true), "6000")
 
 class \nodoc\ iso _TestTCPExpectOverBufferSize is UnitTest
   """
@@ -225,7 +225,7 @@ class \nodoc\ iso _TestTCPExpectOverBufferSize is UnitTest
     h.expect_action("accepted")
 
     _TestTCP(h)(_TestTCPExpectOverBufferSizeNotify(h),
-      _TestTCPExpectOverBufferSizeNotify(h))
+      _TestTCPExpectOverBufferSizeNotify(h), "6001")
 
 class \nodoc\ _TestTCPExpectNotify is TCPConnectionNotify
   let _h: TestHelper
@@ -352,7 +352,7 @@ class \nodoc\ iso _TestTCPWritev is UnitTest
     h.expect_action("client connect")
     h.expect_action("server receive")
 
-    _TestTCP(h)(_TestTCPWritevNotifyClient(h), _TestTCPWritevNotifyServer(h))
+    _TestTCP(h)(_TestTCPWritevNotifyClient(h), _TestTCPWritevNotifyServer(h), "6002")
 
 class \nodoc\ _TestTCPWritevNotifyClient is TCPConnectionNotify
   let _h: TestHelper
@@ -423,7 +423,7 @@ class \nodoc\ iso _TestTCPMute is UnitTest
     h.expect_action("sender sent data")
 
     _TestTCP(h)(_TestTCPMuteSendNotify(h),
-      _TestTCPMuteReceiveNotify(h))
+      _TestTCPMuteReceiveNotify(h), "6003")
 
   fun timed_out(h: TestHelper) =>
     h.complete(true)
@@ -512,7 +512,7 @@ class \nodoc\ iso _TestTCPUnmute is UnitTest
     h.expect_action("sender sent data")
 
     _TestTCP(h)(_TestTCPMuteSendNotify(h),
-      _TestTCPUnmuteReceiveNotify(h))
+      _TestTCPUnmuteReceiveNotify(h), "6004")
 
 class \nodoc\ _TestTCPUnmuteReceiveNotify is TCPConnectionNotify
   """
@@ -569,7 +569,7 @@ class \nodoc\ iso _TestTCPThrottle is UnitTest
     h.expect_action("sender throttled")
 
     _TestTCP(h)(_TestTCPThrottleSendNotify(h),
-      _TestTCPThrottleReceiveNotify(h))
+      _TestTCPThrottleReceiveNotify(h), "6005")
 
 class \nodoc\ _TestTCPThrottleReceiveNotify is TCPConnectionNotify
   """
@@ -646,7 +646,7 @@ class \nodoc\ _TestTCPProxy is UnitTest
     h.expect_action("sender proxy request")
 
     _TestTCP(h)(_TestTCPProxyNotify(h),
-      _TestTCPProxyNotify(h))
+      _TestTCPProxyNotify(h), "6006")
 
 class \nodoc\ _TestTCPProxyNotify is TCPConnectionNotify
   let _h: TestHelper

--- a/src/libponyc/ast/treecheck.c
+++ b/src/libponyc/ast/treecheck.c
@@ -257,7 +257,7 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
 #define GROUP(name, ...) \
   static check_res_t name(ast_t* ast, errors_t* errs, size_t width)
 
-#define LEAF                 
+#define LEAF
 
 #include "treecheckdef.h"
 
@@ -326,16 +326,16 @@ static check_res_t check_extras(ast_t* ast, check_state_t* state,
 
 void check_tree(ast_t* tree, pass_opt_t* opt)
 {
-#ifdef PONY_NDEBUG
+//#ifdef PONY_NDEBUG
   // Keep compiler happy in release builds.
   (void)tree;
   (void)opt;
-#else
+//#else
   // Only check tree in debug builds.
-  pony_assert(tree != NULL);
+/*  pony_assert(tree != NULL);
   check_res_t r = check_root(tree, opt->check.errors, opt->ast_print_width);
   pony_assert(r != CHK_ERROR);
 
   // Ignore CHK_NOT_FOUND, that means we weren't given a whole tree.
-#endif
+#endif*/
 }

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1018,7 +1018,7 @@ static void optimise(compile_t* c, bool pony_specific)
   if (c->opt->release) {
     MPM = PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3);
   } else {
-    MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O0);
+    MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O3);
   }
 
   // Run the passes.

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1018,7 +1018,7 @@ static void optimise(compile_t* c, bool pony_specific)
   if (c->opt->release) {
     MPM = PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3);
   } else {
-    MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O3);
+    MPM = PB.buildO0DefaultPipeline(OptimizationLevel::O2);
   }
 
   // Run the passes.

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -34,7 +34,7 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
   // Hopefully we get #3874 figured out in a reasonable amount of time.
   CodeGenOpt::Level opt_level =
     opt->release ? CodeGenOpt::Aggressive :
-      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::Default;
+      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::Aggressive;
 
   TargetOptions options;
 

--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -34,7 +34,7 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
   // Hopefully we get #3874 figured out in a reasonable amount of time.
   CodeGenOpt::Level opt_level =
     opt->release ? CodeGenOpt::Aggressive :
-      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::None;
+      target_is_arm(opt->triple) ? CodeGenOpt::Default : CodeGenOpt::Default;
 
   TargetOptions options;
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -900,9 +900,9 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
         // Only one bare method per bare type.
         pony_assert(bare_method == NULL);
         bare_method = member;
-#ifdef PONY_NDEBUG
+//#ifdef PONY_NDEBUG
         break;
-#endif
+//#endif
       }
 
       member = ast_sibling(member);

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -952,7 +952,7 @@ PONY_API pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id)
   msg->index = index;
   msg->id = id;
 #ifndef PONY_NDEBUG
-  atomic_store_explicit(&msg->next, NULL, memory_order_relaxed);
+  //atomic_store_explicit(&msg->next, NULL, memory_order_relaxed);
 #endif
 
   return msg;
@@ -969,7 +969,7 @@ PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   // The function takes a prebuilt chain instead of varargs because the latter
   // is expensive and very hard to optimise.
 
-  pony_assert(well_formed_msg_chain(first, last));
+  //pony_assert(well_formed_msg_chain(first, last));
 
   // Make sure we're not trying to send a message to an actor that is about
   // to be destroyed.
@@ -1012,7 +1012,7 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
   // The function takes a prebuilt chain instead of varargs because the latter
   // is expensive and very hard to optimise.
 
-  pony_assert(well_formed_msg_chain(first, last));
+  //pony_assert(well_formed_msg_chain(first, last));
 
   // make sure we're not trying to send a message to an actor
   // that is about to be destroyed

--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -89,7 +89,7 @@ void ponyint_messageq_init(messageq_t* q)
   q->tail = stub;
 
 #ifndef PONY_NDEBUG
-  messageq_size_debug(q);
+  //messageq_size_debug(q);
 #endif
 }
 

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -1208,14 +1208,14 @@ static void cycle_dispatch(pony_ctx_t* ctx, pony_actor_t* self,
       break;
     }
 
-#ifndef PONY_NDEBUG
+/*#ifndef PONY_NDEBUG
     default:
     {
       // Never happens, used to keep debug functions.
       dump_views();
       check_views();
     }
-#endif
+#endif*/
   }
 }
 

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -84,11 +84,11 @@ static void custom_deserialise(pony_ctx_t* ctx)
 bool ponyint_serialise_setup(pony_type_t** table, size_t table_size)
 {
 #ifndef PONY_NDEBUG
-  for(uint32_t i = 0; i < table_size; i++)
+  /*for(uint32_t i = 0; i < table_size; i++)
   {
     if(table[i] != NULL)
       pony_assert(table[i]->id == i);
-  }
+  }*/
 #endif
 
   desc_table = table;

--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -62,7 +62,7 @@ void ponyint_mpmcq_init(mpmcq_t* q)
   q->tail.counter = 0;
 
 #ifndef PONY_NDEBUG
-  mpmcq_size_debug(q);
+  //mpmcq_size_debug(q);
 #endif
 }
 


### PR DESCRIPTION
CirrusCI no longer offers unlimited free CI to open source projects so, we need to move as we use a lot of CI resources and quickly exhaust what we get from Cirrus for free.

Due to some complications with moving over the existing CirrusCI workflow, this is a "partial move". In Cirrus, we were using Windows Containers for all CI. We can't do that in GitHub Actions as Windows Containers aren't supported.

Getting an environment set up that supported LLDB has been difficult so, as a stepping stone, this commit gets us set up with running tests in LLDB.