### PR TITLE
Add support for building libponyc-standalone.a on FreeBSD

### DIFF
--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -151,7 +151,33 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
         COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
         COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
     )
-elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "BSD")
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
+    # add a rule to generate the standalone library if needed
+    add_custom_command(OUTPUT libponyc-standalone.a
+        COMMAND cp `${CMAKE_CXX_COMPILER} --print-file-name='libc++.a'` libcpp.a
+        COMMAND echo "create libponyc-standalone.a" > standalone.mri
+        COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
+        COMMAND echo "addlib libcpp.a" >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "libLLVM*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
+        COMMAND echo "save" >> standalone.mri
+        COMMAND echo "end" >> standalone.mri
+        COMMAND ${CMAKE_AR} -M < standalone.mri
+        DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
+    )
+    # add a separate target that depends on the standalone library file
+    add_custom_target(libponyc-standalone ALL
+        DEPENDS libponyc
+        SOURCES libponyc-standalone.a
+    )
+    # copy the generated file after it is built
+    add_custom_command(TARGET libponyc-standalone POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+    )
+elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
     # TODO
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
     # TODO
@@ -166,7 +192,7 @@ else()
         COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
         COMMAND echo "save" >> standalone.mri
         COMMAND echo "end" >> standalone.mri
-        COMMAND ar -M < standalone.mri
+        COMMAND ${CMAKE_AR} -M < standalone.mri
         DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
     )
     # add a separate target that depends on the standalone library file

--- a/test/libponyc-run/ffi-libponyc-standalone/main.pony
+++ b/test/libponyc-run/ffi-libponyc-standalone/main.pony
@@ -1,11 +1,11 @@
-use "lib:ponyc-standalone" if linux or osx or windows
+use "lib:ponyc-standalone" if freebsd or linux or osx or windows
 use "lib:c++" if osx
 
-use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if linux or osx or windows
-use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if linux or osx or windows
-use @token_free[None](token: TokenStub) if linux or osx or windows
-use @ast_free[None](ast: AstStub) if linux or osx or windows
-use @ast_id[TokenId](ast: AstStub) if linux or osx or windows
+use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if freebsd or linux or osx or windows
+use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if freebsd or linux or osx or windows
+use @token_free[None](token: TokenStub) if freebsd or linux or osx or windows
+use @ast_free[None](ast: AstStub) if freebsd or linux or osx or windows
+use @ast_id[TokenId](ast: AstStub) if freebsd or linux or osx or windows
 
 struct AstStub
 struct TokenStub
@@ -15,7 +15,7 @@ type TokenId is I32
 actor Main
   new create(env: Env) =>
     try
-      ifdef linux or osx or windows then
+      ifdef freebsd or linux or osx or windows then
         let token = @token_new(2)()?
         let ast = @ast_new(token, 2)()?
         if @ast_id(ast) != 2 then

--- a/test/libponyc-run/ffi-libponyc-standalone/main.pony
+++ b/test/libponyc-run/ffi-libponyc-standalone/main.pony
@@ -1,11 +1,11 @@
-use "lib:ponyc-standalone" if freebsd or linux or osx or windows
+use "lib:ponyc-standalone" if not openbsd or dragonfly
 use "lib:c++" if osx
 
-use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if freebsd or linux or osx or windows
-use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if freebsd or linux or osx or windows
-use @token_free[None](token: TokenStub) if freebsd or linux or osx or windows
-use @ast_free[None](ast: AstStub) if freebsd or linux or osx or windows
-use @ast_id[TokenId](ast: AstStub) if freebsd or linux or osx or windows
+use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if not openbsd or dragonfly
+use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if not openbsd or dragonfly
+use @token_free[None](token: TokenStub) if not openbsd or dragonfly
+use @ast_free[None](ast: AstStub) if not openbsd or dragonfly
+use @ast_id[TokenId](ast: AstStub) if not openbsd or dragonfly
 
 struct AstStub
 struct TokenStub
@@ -15,7 +15,7 @@ type TokenId is I32
 actor Main
   new create(env: Env) =>
     try
-      ifdef freebsd or linux or osx or windows then
+      ifdef not openbsd or dragonfly then
         let token = @token_new(2)()?
         let ast = @ast_new(token, 2)()?
         if @ast_id(ast) != 2 then

--- a/test/libponyc-run/ffi-libponyc-standalone/main.pony
+++ b/test/libponyc-run/ffi-libponyc-standalone/main.pony
@@ -1,11 +1,11 @@
-use "lib:ponyc-standalone" if not openbsd or dragonfly
+use "lib:ponyc-standalone" if not (openbsd or dragonfly)
 use "lib:c++" if osx
 
-use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if not openbsd or dragonfly
-use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if not openbsd or dragonfly
-use @token_free[None](token: TokenStub) if not openbsd or dragonfly
-use @ast_free[None](ast: AstStub) if not openbsd or dragonfly
-use @ast_id[TokenId](ast: AstStub) if not openbsd or dragonfly
+use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if not (openbsd or dragonfly)
+use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if not (openbsd or dragonfly)
+use @token_free[None](token: TokenStub) if not (openbsd or dragonfly)
+use @ast_free[None](ast: AstStub) if not (openbsd or dragonfly)
+use @ast_id[TokenId](ast: AstStub) if not (openbsd or dragonfly)
 
 struct AstStub
 struct TokenStub
@@ -15,7 +15,7 @@ type TokenId is I32
 actor Main
   new create(env: Env) =>
     try
-      ifdef not openbsd or dragonfly then
+      ifdef not (openbsd or dragonfly) then
         let token = @token_new(2)()?
         let ast = @ast_new(token, 2)()?
         if @ast_id(ast) != 2 then


### PR DESCRIPTION
* vanilla FreeBSD does not provide a `libstdc++`, but a `libc++`. This is the only real difference to the fallback solution in the else branch. Those should be consolidated at one point.
* `${CMAKE_AR}` resolves to `llvm-ar` which supports mri scripts
* This has been additionally tested by testing and compiling https://github.com/mfelsche/pony-ast