### PR TITLE
Fix failing CI tests that were run in LLDB 14 not reporting failures

### DIFF
--- a/test/libponyc-run/runner/_tester.pony
+++ b/test/libponyc-run/runner/_tester.pony
@@ -303,6 +303,16 @@ actor _Tester
             i = i + 1
           end
           exit_code' = num.i32()?
+        else
+          // Some versions of lldb such as lldb 14 don't do "exited with status"
+          // but they do do "stop reason =". Unlike with "exited with status",
+          // we only get the stop reason if there was an error.
+          // We know this impacts lldb 14 and 15. 17 works like earlier lldb
+          // versions. We haven't tested with lldb 16.
+          try
+            let idx1 = _out_buf.find("stop reason =")?
+            exit_code' = -1
+          end
         end
       end
 


### PR DESCRIPTION
LLDB 14 and 15 (perhaps 16, we didn't test) has some issues.

It doesn't run "on crash" scripts if the crash occurred in any thread but "the main thread". Additionally, it doesn't give us the back up exit status message we would search for.

The result? CI tests run in LLDB 14 or 15 would fail but the runner would report them as having passed.

This patch is from Gordon Tisher.