### PR TITLE
Install LLDB 19 in Ubuntu 22 builder image

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
@@ -17,11 +17,21 @@ RUN apt-get update \
   zlib1g-dev \
   curl \
   python3-pip \
-  lldb \
+  wget \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \
  && apt-get -y clean \
  && pip3 install cloudsmith-cli
+
+## lldb-14 is buggy, we need to get 17.
+RUN echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" >> /etc/apt/sources.list \
+ && wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends lldb-17 \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && ln -s /usr/lib/llvm-17/bin/lldb /usr/bin
 
 # needed for GitHub actions
 RUN git config --global --add safe.directory /__w/ponyc/ponyc


### PR DESCRIPTION
LLDB 14 is broken and doesn't run our "usedebugger" scripts correctly. This can result in failing tests not being reported correctly as failing.

False passing is a bad bad thing.