### PR TITLE
Push images to GitHub Container Registry in addition to DockerHub

### DIFF
--- a/.dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
+++ b/.dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
@@ -1,7 +1,15 @@
-# You should already be logged in to DockerHub when you run this.
+# You should already be logged in to DockerHub and GitHub Container Registry
+# when you run this.
 $ErrorActionPreference = 'Stop'
 
 $dockerfileDir = Split-Path $script:MyInvocation.MyCommand.Path
 
+## DockerHub
+
 docker build --pull -t "ponylang/ponyc:windows" $dockerfileDir
 docker push "ponylang/ponyc:windows"
+
+## GitHub Container Registry
+
+docker build --pull -t "ghcr.io/ponylang/ponyc:windows" $dockerfileDir
+docker push "ghcr.io/ponylang/ponyc:windows"

--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/build-and-push.bash
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/build-and-push.bash
@@ -4,10 +4,18 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+# and GitHub Container Registery when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 docker build --pull -t "ponylang/ponyc:latest" "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc:latest"
+
+## GitHub Container Registry
+
+docker build --pull -t "ghcr.io/ponylang/ponyc:latest" "${DOCKERFILE_DIR}"
+docker push "ghcr.io/ponylang/ponyc:latest"

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/build-and-push.bash
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/build-and-push.bash
@@ -4,10 +4,18 @@ set -o errexit
 set -o nounset
 
 #
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to DockerHub
+# and GitHub Container Registery when you run this ***
 #
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 docker build --pull -t "ponylang/ponyc:alpine" "${DOCKERFILE_DIR}"
 docker push "ponylang/ponyc:alpine"
+
+## GitHub Container Registry
+
+docker build --pull -t "ghcr.io/ponylang/ponyc:alpine" "${DOCKERFILE_DIR}"
+docker push "ghcr.io/ponylang/ponyc:alpine"

--- a/.dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
+++ b/.dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
@@ -1,4 +1,5 @@
-# You should already be logged in to DockerHub when you run this.
+# You should already be logged in to DockerHub and GitHub Container Registry
+# when you run this.
 $ErrorActionPreference = 'Stop'
 
 if ([string]::IsNullOrWhitespace($env:VERSION))
@@ -13,10 +14,22 @@ if ([string]::IsNullOrWhitespace($env:GITHUB_REPOSITORY))
 
 $dockerfileDir = Split-Path $script:MyInvocation.MyCommand.Path
 
+## DockerHub
+
 $dockerTag = $env:GITHUB_REPOSITORY + ':' + $env:VERSION + '-windows'
 docker build --pull -t "$dockerTag" "$dockerfileDir"
 docker push "$dockerTag"
 
 $dockerTag = $env:GITHUB_REPOSITORY + ':release-windows'
+docker build --pull -t "$dockerTag" "$dockerfileDir"
+docker push "$dockerTag"
+
+## GitHub Container Registry
+
+$dockerTag = "ghcr.io/" + $env:GITHUB_REPOSITORY + ':' + $env:VERSION + '-windows'
+docker build --pull -t "$dockerTag" "$dockerfileDir"
+docker push "$dockerTag"
+
+$dockerTag = "ghcr.io" + $env:GITHUB_REPOSITORY + ':release-windows'
 docker build --pull -t "$dockerTag" "$dockerfileDir"
 docker push "$dockerTag"

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/build-and-push.bash
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/build-and-push.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# *** You should already be logged in to DockerHub when you run this ***
+# ** You should already be logged in to DockerHub and GHCR when you run this **
 #
 # Builds docker release images with two tags:
 #
@@ -41,12 +41,26 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 # Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
-DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}"
+DOCKER_TAG="${GITHUB_REPOSITORY}:${VERSION}"
 docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponylang/ponyup:release
-DOCKER_TAG=${GITHUB_REPOSITORY}:release
+DOCKER_TAG="${GITHUB_REPOSITORY}:release"
+docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
+docker push "${DOCKER_TAG}"
+
+## GitHub Container Registry
+
+# Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
+DOCKER_TAG="ghcr.io/${GITHUB_REPOSITORY}:${VERSION}"
+docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
+docker push "${DOCKER_TAG}"
+
+# Build and push "release" tag e.g. ponylang/ponyup:release
+DOCKER_TAG="ghcr.io/${GITHUB_REPOSITORY}:release"
 docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
 docker push "${DOCKER_TAG}"

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/build-and-push.bash
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/build-and-push.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# *** You should already be logged in to DockerHub when you run this ***
+# ** You should already be logged in to DockerHub and GHCR when you run this **
 #
 # Builds docker release images with two tags:
 #
@@ -41,12 +41,26 @@ set -o nounset
 
 DOCKERFILE_DIR="$(dirname "$0")"
 
+## DockerHub
+
 # Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1-alpine
-DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}-alpine"
+DOCKER_TAG="${GITHUB_REPOSITORY}:${VERSION}-alpine"
 docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponylang/ponyup:release-alpine
-DOCKER_TAG=${GITHUB_REPOSITORY}:release-alpine
+DOCKER_TAG="${GITHUB_REPOSITORY}:release-alpine"
+docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
+docker push "${DOCKER_TAG}"
+
+## GitHub Container Registry
+
+# Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1-alpine
+DOCKER_TAG="ghcr.io/${GITHUB_REPOSITORY}:${VERSION}-alpine"
+docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
+docker push "${DOCKER_TAG}"
+
+# Build and push "release" tag e.g. ponylang/ponyup:release-alpine
+DOCKER_TAG="ghcr.io/${GITHUB_REPOSITORY}:release-alpine"
 docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
 docker push "${DOCKER_TAG}"

--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -21,11 +21,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/latest/x86-64-unknown-linux-gnu/build-and-push.bash
       - name: Alert on failure
@@ -49,11 +56,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/latest/x86-64-unknown-linux-musl/build-and-push.bash
       - name: Alert on failure
@@ -77,11 +91,18 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
-        run: "docker login -u $env:DOCKER_USERNAME -p $env:DOCKER_PASSWORD"
+      - name: Login to DockerHub
+        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: .dockerfiles/latest/x86-64-pc-windows-msvc/build-and-push.ps1
       - name: Alert on failure
@@ -105,11 +126,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/release/x86-64-unknown-linux-gnu/build-and-push.bash
         env:
@@ -124,11 +152,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/release/x86-64-unknown-linux-musl/build-and-push.bash
         env:
@@ -143,11 +178,18 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
-        run: "docker login -u $env:DOCKER_USERNAME -p $env:DOCKER_PASSWORD"
+      - name: Login to DockerHub
+        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: .dockerfiles/release/x86-64-pc-windows-msvc/build-and-push.ps1
         env:
@@ -428,3 +470,30 @@ jobs:
           repository: ${{ matrix.repo }}
           event-type: ponyc-musl-released
           client-payload: '{"version": "${{ github.event.client_payload.data.version }}"}'
+
+  prune-untagged-images:
+    needs:
+      - build-latest-musl-docker-image
+
+    name: Prune untagged images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v4.1.1
+        uses: actions/delete-package-versions@0d39a63126868f5eefaa47169615edd3c0f61e20
+        with:
+          package-name: 'ponyc'
+          package-type: 'container'
+          min-versions-to-keep: 1
+          delete-only-untagged-versions: 'true'
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -9,11 +9,14 @@ This document is aimed at members of the Pony team who might be cutting a releas
 
 ### Validate external services are functional
 
-We rely on Cloudsmith, DockerHub, and GitHub Actions as part of our release process. All  need to be up and functional in order to do a release. Check the status of each before starting a release. If any are reporting issues, push the release back a day or until whenever they are all reporting no problems.
+We rely on Cloudsmith and GitHub Actions as part of our release process. Both need to be up and functional in order to do a release. Check the status of each before starting a release. If any are reporting issues, push the release back a day or until whenever they are all reporting no problems.
 
 * [Cloudsmith](https://status.cloudsmith.io/)
-* [DockerHub](https://status.docker.com/)
 * [GitHub](https://www.githubstatus.com/)
+
+We are in the process of migrating off of DockerHub, while that migration is going on, we are also relying on it, so you need to make sure it is functional before doing a release.
+
+* [DockerHub](https://status.docker.com/)
 
 ## Releasing
 
@@ -63,11 +66,11 @@ As part of every release, 6 Docker images are built:
 * Alpine images
   * release-alpine
   * 0.3.1-alpine
-* Windows imags
+* Windows images
   * release-windows
   * 0.3.1-windows
 
-The images are built via GitHub action after Linux releases have been uploaded to Cloudsmith. Cloudsmith sends an event to GitHub that triggers Docker images builds in the ["Handle External Events" workflow](https://github.com/ponylang/ponyc/actions?query=workflow%3A%22Handle+external+events%22).You can track the progress of the builds (including failures) there. You can validate that all the images have been pushed by checking the [tag page](https://hub.docker.com/r/ponylang/ponyc/tags) of the [ponyc DockerHub repository](https://hub.docker.com/r/ponylang/ponyc/).
+The images are built via GitHub action after Linux releases have been uploaded to Cloudsmith. Cloudsmith sends an event to GitHub that triggers Docker images builds in the ["Handle External Events" workflow](https://github.com/ponylang/ponyc/actions?query=workflow%3A%22Handle+external+events%22).You can track the progress of the builds (including failures) there. You can validate that all the images have been pushed by checking the tags of the [ponylang/ponyc package](https://github.com/ponylang/ponyc/pkgs/container/ponyc).
 
 ### Verify that the Pony Playground updated to the new version
 


### PR DESCRIPTION
We are transitioning from DockerHub to GitHub Container Registry and while we are migrating, we will push images to both registries.
