### PR TITLE
Fix cmake dependency for moved test runner

### DIFF
--- a/test/full-program-runner/CMakeLists.txt
+++ b/test/full-program-runner/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(libponyc.tests.runner)
 
-set(RUNNER_EXECUTABLE "runner${CMAKE_EXECUTABLE_SUFFIX}")
+set(RUNNER_EXECUTABLE "full-program-runner${CMAKE_EXECUTABLE_SUFFIX}")
 
 add_custom_target(tests.runner ALL DEPENDS ${RUNNER_EXECUTABLE})
 


### PR DESCRIPTION
When I moved and renamed the test runner, I neglected to update the cmake target executable name.  This means the runner does in fact get built the first time you run `make`, but it won't get incrementally updated if sources change.

This PR updates the name of the executable so cmake can correctly track it.