### PR TITLE
Remove non-standard format comment

### DIFF
--- a/src/libponyc/pkg/platformfuns.h
+++ b/src/libponyc/pkg/platformfuns.h
@@ -27,10 +27,6 @@ PONY_EXTERN_C_BEGIN
 #define OS_RUNTIMESTATS_NAME "runtimestats"
 #define OS_RUNTIMESTATSMESSAGES_NAME "runtimestatsmessages"
 
-/** Report whether the named platform attribute is true
- * @param out_is true if the specified attribute is set, false otherwise
- * @return true on success, false is specified attribute does not exist
- */
 bool os_is_target(const char* attribute, bool release, bool* out_is_target, pass_opt_t* options);
 
 PONY_EXTERN_C_END


### PR DESCRIPTION
From ages ago, this comment was added. Doxygen was run by someone and it flagged the comment as having params that weren't in the function signature.

I took a look a decided that:

- We don't use this comment format so it should be changed
- The commment provides no value so it should be removed