### PR TITLE
Update PosixDate.format doc string

### DIFF
--- a/packages/time/posix_date.pony
+++ b/packages/time/posix_date.pony
@@ -44,6 +44,8 @@ class PosixDate
   fun format(fmt: String): String ? =>
     """
     Format the time as for strftime.
+
+    Will return an empty string if the format string is "%p" or "%P".
     """
     recover
       String.from_cstring(@ponyint_formattime(this, fmt.cstring())?)


### PR DESCRIPTION
Note the "not at all obvious" caveat where we normalize %p and %P handling. Some locales will return an empty string for those format strings which if they are the only thing in the format string makes it impossible to know if there was success or failure from the format so we short-circuit those and make all locales return empty string if either formatting option is the only one in the format string.