### PR TITLE
Fix broken DTrace support

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
   curl \
   python3-pip \
   wget \
+  systemtap-sdt-dev \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \
  && apt-get -y clean \

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04
             triple-os: linux-ubuntu22.04
             triple-vendor: unknown

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64 Linux glibc
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
@@ -400,3 +400,51 @@ jobs:
           .\make.ps1 -Command build -Config Release
       - name: Test with Release Runtime
         run: .\make.ps1 -Command test -Config Release -Uselldb yes
+
+  use_directives:
+    runs-on: ubuntu-latest
+    needs: x86_64-linux
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
+            debugger: lldb
+            directive: dtrace
+
+    name: use ${{ matrix.directive }}
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
+      - name: Build Debug Runtime
+        run: |
+          make configure arch=x86-64 config=debug use=${{ matrix.directive }}
+          make build config=debug
+      - name: Test with Debug Runtime
+        run: make test-ci config=debug usedebugger='${{ matrix.debugger }}'
+      - name: Build Release Runtime
+        run: |
+          make configure arch=x86-64 config=release use=${{ matrix.directive }}
+
+          make build config=release
+      - name: Test with Release Runtime
+        run: make test-ci config=release usedebugger='${{ matrix.debugger }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04
             triple-os: linux-ubuntu22.04
             triple-vendor: unknown

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -12,19 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04 [release]
             target: test-stress-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04 [debug]
             target: test-stress-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04 [cd] [release]
             target: test-stress-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64-unknown-linux-ubuntu22.04 [cd] [debug]
             target: test-stress-with-cd-debug
             debugger: lldb

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20230830
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
           - image: ghcr.io/ponylang/ponyc-ci-cross-riscv64:20230830

--- a/.release-notes/dtrace.md
+++ b/.release-notes/dtrace.md
@@ -1,0 +1,3 @@
+## Fix broken DTrace support
+
+Quite a while back, we broke the support in our Makefile for building the Pony runtime with support for DTrace. We've fixed that and added tests to assure it builds.

--- a/BUILD.md
+++ b/BUILD.md
@@ -172,6 +172,17 @@ make configure arch=arm7
 make build
 ```
 
+## dtrace
+
+BSD and Linux based versions of Pony support using DTrace and SystemTap for collecting Pony runtime events.
+
+DTrace support is enabled by setting `use=dtrace` in the build command line like:
+
+```bash
+make configure use=dtrace
+make build
+```
+
 ### lto
 
 Link-time optimizations provide a performance improvement. You should strongly consider turning on LTO if you build ponyc from source. It's off by default as it comes with some caveats:

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -64,6 +64,14 @@ add_library(libponyrt STATIC
     ${_ll_except_obj}
 )
 
+if(PONY_USE_DTRACE)
+    add_custom_command(OUTPUT dtrace_probes.o
+        COMMAND dtrace -h -s "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.d" -o "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.h"
+        COMMAND dtrace -G -s "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.d" -o dtrace_probes.o
+    )
+    target_sources(libponyrt PRIVATE dtrace_probes.o)
+endif()
+
 if (NOT MSVC)
     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86-64")
         target_compile_options(libponyrt PUBLIC -mcx16)


### PR DESCRIPTION
Dtrace functionality was missed when converting the build system to cmake.
This PR generates and links dtrace probes into `libponyrt` if the
`use=dtrace` option.

Fixes https://github.com/ponylang/ponyc/issues/4449