### PR TITLE
Run musl CI tests using LLDB

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update \
   curl \
   py3-pip \
   gdb \
+  lldb \
 && pip install cloudsmith-cli
 
 # add user pony in order to not run tests as root

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -20,7 +20,7 @@ jobs:
             name: x86-64-unknown-linux-ubuntu20.04
             triple-os: linux-ubuntu20.04
             triple-vendor: unknown
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,9 +90,9 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
             name: x86-64 Linux glibc
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64 Linux musl
-            debugger: gdb
+            debugger: lldb
 
     name: ${{ matrix.name }}
     container:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
             name: x86-64-unknown-linux-ubuntu20.04
             triple-os: linux-ubuntu20.04
             triple-vendor: unknown
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -28,22 +28,22 @@ jobs:
             name: x86-64-unknown-linux-ubuntu22.04 [cd] [debug]
             target: test-stress-with-cd-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl [release]
             target: test-stress-release
-            debugger: gdb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+            debugger: lldb
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl [debug]
             target: test-stress-debug
-            debugger: gdb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+            debugger: lldb
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl [cd] [release]
             target: test-stress-with-cd-release
-            debugger: gdb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+            debugger: lldb
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
             name: x86-64-unknown-linux-musl [cd] [debug]
             target: test-stress-with-cd-debug
-            debugger: gdb
+            debugger: lldb
 
     name: ${{ matrix.name }}
     container:

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu20.04-builder:20230830
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20230830
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-musl-builder:20231003
           - image: ghcr.io/ponylang/ponyc-ci-cross-riscv64:20230830
           - image: ghcr.io/ponylang/ponyc-ci-cross-arm:20230830
           - image: ghcr.io/ponylang/ponyc-ci-cross-armhf:20230830


### PR DESCRIPTION
We updated our alpine version so I decided to see if we could use LLDB
instead of GDB for our debugger. And yes, we can now without a hanging.

I'm leaving GDB in the image for now in case we need to switch back.

Closes #4176