### PR TITLE
Fix compiler bug that allows an unsafe data access pattern

### DIFF
--- a/.release-notes/issue-4244.md
+++ b/.release-notes/issue-4244.md
@@ -1,0 +1,28 @@
+## Fix compiler bug that allows an unsafe data access pattern
+
+In November of last year, core team member Gordon Tisher identified a bug in the type system implementation that allowed sharing of data that shouldn't be shareable.
+
+The following code should not compile:
+
+```pony
+class Foo
+  let s: String box
+
+  new create(s': String box) =>
+    s = s'
+
+  fun get_s(): String val =>
+    // this is unsafe and shouldn't be allowed
+    recover val s end
+
+actor Main
+  new create(env: Env) =>
+    let s = String
+    s.append("world")
+    let foo = Foo(s)
+    env.out.print("hello " + foo.get_s())
+```
+
+Upon investigation, we found that this bug goes back about 8 or 9 years to the when viewpoint adaptation was introduced into the Pony compiler.
+
+We've fixed the logic flaw and added tests to verify that it can't be reintroduced.

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -638,13 +638,13 @@ bool sendable(ast_t* type)
 
     case TK_ARROW:
     {
-      ast_t* lower = viewpoint_lower(type);
+      ast_t* upper = viewpoint_upper(type);
 
-      if(lower == NULL)
+      if(upper == NULL)
         return false;
 
-      bool ok = sendable(lower);
-      ast_free_unattached(lower);
+      bool ok = sendable(upper);
+      ast_free_unattached(upper);
       return ok;
     }
 

--- a/test/libponyc/recover.cc
+++ b/test/libponyc/recover.cc
@@ -293,6 +293,49 @@ TEST_F(RecoverTest, CantAccess_NonSendableField)
   TEST_ERRORS_1(src, "can't access non-sendable field of non-sendable object");
 }
 
+// Issue #4244
+TEST_F(RecoverTest, CantRecover_BoxFieldToVal_V1)
+{
+  const char* src =
+    "class Foo\n"
+    "class Bar\n"
+    "  let f: Foo box\n"
+    "  new create(f': Foo box) => f = f'\n"
+    "  fun get_f(): Foo val => recover val f end\n";
+
+  TEST_ERRORS_1(src, "can't access non-sendable field of non-sendable object inside of a recover expression");
+}
+
+// Issue #4244
+TEST_F(RecoverTest, CantRecover_BoxFieldToVal_V2)
+{
+  const char* src =
+    "class Foo\n"
+    "class Bar\n"
+    "  let f: Foo box\n"
+    "  new create(f': Foo box) => f = f'\n"
+    "  fun get_f(): Foo val =>\n"
+    "    let b: this->(Bar box) = this\n"
+    "    recover val b.f end\n";
+
+  TEST_ERRORS_1(src, "can't access non-sendable field of non-sendable object inside of a recover expression");
+}
+
+// Issue #4244
+TEST_F(RecoverTest, CantRecover_BoxFieldToVal_V3)
+{
+  const char* src =
+    "class Foo\n"
+    "class Bar\n"
+    "  let f: Foo box\n"
+    "  new create(f': Foo box) => f = f'\n"
+    "  fun get_f(): Foo val =>\n"
+    "    let b: Bar box = this\n"
+    "    recover val b.f end\n";
+
+  TEST_ERRORS_1(src, "can't access non-sendable field of non-sendable object inside of a recover expression");
+}
+
 TEST_F(RecoverTest, CantAccess_AssignedField)
 {
   const char* src =


### PR DESCRIPTION
Last November, Gordon identified that the compiler was allowing code to recover a `val` from a `box` field. This is unsafe and very "doh".

After investigation, it was determined that this bug has existed since Sylvan introduced viewpoint adaptation to the compiler almost a decade ago.

I came up with a fix, but after talking with Sylvan, we changed to this fix as it is the "proper pure theory fix".

Fixes #4244