### PR TITLE
Draft: Add -ld_classic linker option to mac builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,6 @@ endif()
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_SCHEDULER_SCALING_PTHREADS")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    add_link_options(-ld_classic)
 endif()
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ endif()
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_SCHEDULER_SCALING_PTHREADS")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    add_link_options(-ld_classic)
 endif()
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -295,6 +295,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   snprintf(ld_cmd, ld_len,
     "%s -execute -arch %.*s "
     "-o %s %s %s %s "
+    "-ld_classic "
     "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg


### PR DESCRIPTION
## Problem

linking both Pony programs and ponyc fail with `ld: Missing -platform_version option`

## Discussion 

see #4454

## ld versions

@d-led:

```bash
ld -v
@(#)PROGRAM:ld  PROJECT:dyld-1015.7
BUILD 18:48:43 Aug 22 2023
configured to support archs: armv6 armv7 armv7s arm64 arm64e arm64_32 i386 x86_64 x86_64h armv6m armv7k armv7m armv7em
will use ld-classic for: armv6 armv7 armv7s arm64_32 i386 armv6m armv7k armv7m armv7em
LTO support using: LLVM version 15.0.0 (static support for 29, runtime is 29)
TAPI support using: Apple TAPI version 15.0.0 (tapi-1500.0.12.3)
``` 
