### PR TITLE
Set MacOS platform version in one place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if(NOT MSVC)
     endif()
 endif()
 
-set(PONY_OSX_PLATFORM "13.0.0")
+set(PONY_OSX_PLATFORM 13.0.0)
 
 # LLVM component setup
 if(NOT PONY_CROSS_LIBPONYRT)
@@ -227,6 +227,7 @@ add_compile_definitions(
     $<$<CONFIG:Release>:PONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     $<$<CONFIG:RelWithDebInfo>:PONY_VERSION_STR="${PONYC_VERSION} [relwithdebinfo]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     $<$<CONFIG:MinSizeRel>:PONY_VERSION_STR="${PONYC_VERSION} [minsizerel]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
+    PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM}
 )
 
 include(CheckIPOSupported)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ if(NOT MSVC)
     endif()
 endif()
 
+set(PONY_OSX_PLATFORM "13.0.0")
+
 # LLVM component setup
 if(NOT PONY_CROSS_LIBPONYRT)
     set(LLVM_COMPONENTS

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -105,7 +105,8 @@ target_include_directories(libponyc
 )
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0.0)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET ${PONY_OSX_PLATFORM})
+    target_compile_definitions(libponyc PUBLIC PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM})
 endif()
 
 if (MSVC)

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -106,7 +106,6 @@ target_include_directories(libponyc
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_OSX_DEPLOYMENT_TARGET ${PONY_OSX_PLATFORM})
-    target_compile_definitions(libponyc PUBLIC PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM})
 endif()
 
 if (MSVC)

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -22,7 +22,8 @@
 #include <llvm-c/Support.h>
 #include <string.h>
 
-#define STRINGIFY(x) #x
+#define STR(x) STR2(x)
+#define STR2(x) #x
 
 struct compile_local_t
 {
@@ -822,10 +823,10 @@ bool codegen_pass_init(pass_opt_t* opt)
   } else {
 #if defined(PLATFORM_IS_MACOSX) && defined(PLATFORM_IS_ARM)
     triple = LLVMCreateMessage("arm64-apple-macosx"
-      STRINGIFY(PONY_OSX_PLATFORM));
+      STR(PONY_OSX_PLATFORM));
 #elif defined(PLATFORM_IS_MACOSX) && !defined(PLATFORM_IS_ARM)
     triple = LLVMCreateMessage("x86_64-apple-macosx"
-      STRINGIFY(PONY_OSX_PLATFORM));
+      STR(PONY_OSX_PLATFORM));
 #else
     triple = LLVMGetDefaultTargetTriple();
 #endif

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -22,6 +22,8 @@
 #include <llvm-c/Support.h>
 #include <string.h>
 
+#define STRINGIFY(x) #x
+
 struct compile_local_t
 {
   const char* name;
@@ -819,9 +821,11 @@ bool codegen_pass_init(pass_opt_t* opt)
     triple = LLVMCreateMessage(opt->triple);
   } else {
 #if defined(PLATFORM_IS_MACOSX) && defined(PLATFORM_IS_ARM)
-    triple = LLVMCreateMessage("arm64-apple-macosx13.0.0");
+    triple = LLVMCreateMessage("arm64-apple-macosx"
+      STRINGIFY(PONY_OSX_PLATFORM));
 #elif defined(PLATFORM_IS_MACOSX) && !defined(PLATFORM_IS_ARM)
-    triple = LLVMCreateMessage("x86_64-apple-macosx13.0.0");
+    triple = LLVMCreateMessage("x86_64-apple-macosx"
+      STRINGIFY(PONY_OSX_PLATFORM));
 #else
     triple = LLVMGetDefaultTargetTriple();
 #endif

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -19,6 +19,8 @@
 #  include <unistd.h>
 #endif
 
+#define STRINGIFY(x) #x
+
 static LLVMValueRef create_main(compile_t* c, reach_type_t* t,
   LLVMValueRef ctx)
 {
@@ -295,7 +297,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   snprintf(ld_cmd, ld_len,
     "%s -execute -arch %.*s "
     "-o %s %s %s %s "
-    "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s -platform_version macos '13.0.0' '0.0.0'",
+    "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s -platform_version macos '" STRINGIFY(PONY_OSX_PLATFORM) "' '0.0.0'",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg
     );

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -19,7 +19,8 @@
 #  include <unistd.h>
 #endif
 
-#define STRINGIFY(x) #x
+#define STR(x) STR2(x)
+#define STR2(x) #x
 
 static LLVMValueRef create_main(compile_t* c, reach_type_t* t,
   LLVMValueRef ctx)
@@ -297,7 +298,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   snprintf(ld_cmd, ld_len,
     "%s -execute -arch %.*s "
     "-o %s %s %s %s "
-    "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s -platform_version macos '" STRINGIFY(PONY_OSX_PLATFORM) "' '0.0.0'",
+    "-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -lSystem %s -platform_version macos '" STR(PONY_OSX_PLATFORM) "' '0.0.0'",
            linker, (int)arch_len, c->opt->triple, file_exe, file_o,
            lib_args, ponyrt, sanitizer_arg
     );

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -60,7 +60,7 @@ find_file(_llc_command
 )
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0.0)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET ${PONY_OSX_PLATFORM})
 endif()
 
 add_library(libponyrt STATIC


### PR DESCRIPTION
This PR specifies the MacOS platform version (currently "13.0.0") in only one place, and uses CMake variables and C/C++ defines to set it appropriately.

Fixes #4469