### PR TITLE
Only include `ponyc.exe` in the `bin` directory of Windows release zip files

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -494,6 +494,8 @@ switch ($Command.ToLower())
         $package = "ponyc-x86-64-pc-windows-msvc.zip"
         Write-Output "Creating $buildDir\..\$package"
 
+        # Remove unneeded files; we do it this way because Compress-Archive cannot add a single file to anything other than the root directory
+        Get-ChildItem -File -Path "$Prefix\bin\*" -Exclude ponyc.exe | Remove-Item
         Compress-Archive -Path "$Prefix\bin", "$Prefix\lib", "$Prefix\packages", "$Prefix\examples" -DestinationPath "$buildDir\..\$package" -Force
         break
     }


### PR DESCRIPTION
Previously the tests and benchmark executables were included, which doubled the size of the zip file.  This PR removes those files before zipping the release archive.

We do it this way because the Powershell command `Compress-Archive` cannot add a single file to a directory other than the root directory of the zip file, so we can't specify just `bin\ponyc.exe` in the list of things to add to the archive; it'll add it to the root directory.  Ponyc expects to find its lib and packages directories one directory below where it is.

Fixes #4272