### PR TITLE
Fix missing "runtime_info" package documentation

### DIFF
--- a/.release-notes/4476.md
+++ b/.release-notes/4476.md
@@ -1,0 +1,3 @@
+## Fix missing "runtime_info" package documentation
+
+The documentation for the "runtime_info" package wasn't being generated. We've fixed that oversight.

--- a/packages/runtime_info/_test.pony
+++ b/packages/runtime_info/_test.pony
@@ -1,0 +1,8 @@
+use "pony_test"
+
+actor \nodoc\ Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    None

--- a/packages/stdlib/_test.pony
+++ b/packages/stdlib/_test.pony
@@ -36,6 +36,7 @@ use pony_check = "pony_check"
 use process = "process"
 use promises = "promises"
 use random = "random"
+use runtime_info = "runtime_info"
 use serialise = "serialise"
 use signals = "signals"
 use strings = "strings"
@@ -66,6 +67,7 @@ actor \nodoc\ Main is TestList
     process.Main.make().tests(test)
     promises.Main.make().tests(test)
     random.Main.make().tests(test)
+    runtime_info.Main.make().tests(test)
     serialise.Main.make().tests(test)
     strings.Main.make().tests(test)
     time.Main.make().tests(test)


### PR DESCRIPTION
It wasn't being built as part of testing/documentation for standard library.