### PR TITLE
Use the correct LLVM intrinsics for `powi` on *nix.

### DIFF
--- a/.release-notes/4481.md
+++ b/.release-notes/4481.md
@@ -1,0 +1,3 @@
+## Use the correct LLVM intrinsics for `powi` on *nix.
+
+We were using outdated LLVM intrinsics `llvm.powi.f32`j and `llvm.powi.f64`; updated to use `llvm.powi.f32.i32` and `llvm.powi.f64.i32`.

--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -18,8 +18,8 @@ use @logbf[F32](x: F32)
 use @logb[F64](x: F64)
 use @"llvm.pow.f32"[F32](x: F32, y: F32)
 use @"llvm.pow.f64"[F64](x: F64, y: F64)
-use @"llvm.powi.f32"[F32](x: F32, y: I32) if not windows
-use @"llvm.powi.f64"[F64](x: F64, y: I32) if not windows
+use @"llvm.powi.f32.i32"[F32](x: F32, y: I32) if not windows
+use @"llvm.powi.f64.i32"[F64](x: F64, y: I32) if not windows
 use @"llvm.sqrt.f32"[F32](x: F32)
 use @"llvm.sqrt.f64"[F64](x: F64)
 use @cbrtf[F32](x: F32)
@@ -217,7 +217,7 @@ primitive F32 is FloatingPoint[F32]
     ifdef windows then
       pow(y.f32())
     else
-      @"llvm.powi.f32"(this, y)
+      @"llvm.powi.f32.i32"(this, y)
     end
 
   fun sqrt(): F32 =>
@@ -434,7 +434,7 @@ primitive F64 is FloatingPoint[F64]
     ifdef windows then
       pow(y.f64())
     else
-      @"llvm.powi.f64"(this, y)
+      @"llvm.powi.f64.i32"(this, y)
     end
 
   fun sqrt(): F64 =>

--- a/test/full-program-tests/regression-4480/main.pony
+++ b/test/full-program-tests/regression-4480/main.pony
@@ -1,0 +1,9 @@
+actor Main
+  new create(env: Env) =>
+    let a: F64 = 3.14
+    let b: F64 = a.powi(-2)
+    env.out.print("B is now " + b.string())
+
+    let c: F32 = 3.14
+    let d: F32 = c.powi(-3)
+    env.out.print("D is now " + d.string())


### PR DESCRIPTION
Fixes #4480 