### PR TITLE
Add Fedora 39 builder

### DIFF
--- a/.ci-dockerfiles/x64-64-unknown-linux-fedora39-buiilder/Dockerfile
+++ b/.ci-dockerfiles/x64-64-unknown-linux-fedora39-buiilder/Dockerfile
@@ -1,0 +1,20 @@
+FROM fedora:39
+
+RUN dnf install -y clang \
+  cmake \
+  git \
+  make \
+  zlib \
+  curl \
+  python3-pip \
+  lldb \
+  libstdc++-static \
+ && pip3 install cloudsmith-cli
+
+# needed for GitHub actions
+RUN git config --global --add safe.directory /__w/ponyc/ponyc
+
+# add user pony in order to not run tests as root
+RUN useradd -u 1001 -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x64-64-unknown-linux-fedora39-buiilder/build-and-push.bash
+++ b/.ci-dockerfiles/x64-64-unknown-linux-fedora39-buiilder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora39-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,6 +24,10 @@ jobs:
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora39-builder:20240128
+            name: x86-64-unknown-linux-fedora39
+            triple-os: linux-fedora39
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,10 @@ jobs:
             name: x86-64-unknown-linux-musl
             triple-os: linux-musl
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora39-builder:20240128
+            name: x86-64-unknown-linux-fedora39
+            triple-os: linux-fedora39
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:


### PR DESCRIPTION
The builder will be used to build nightly and release versions of ponyc targetting Fedora 39.

No release notes are being added at this time, nor is RELEASE_PROCESS.md being updated as until a nightly runs, we can't be sure this will fully work.

The docker image created for the builder can almost certainly be trimmed down in size, but I am not a Fedora/DNF expert. I am looking to the requester of Fedora 39 support to assist with trimming the image down.