### PR TITLE
Fix bug when serializing bare lambdas

### DIFF
--- a/.release-notes/4479.md
+++ b/.release-notes/4479.md
@@ -1,0 +1,7 @@
+## Fix esoteric bug with serializing bare lambdas
+
+Almost no one uses bare lambdas. And even fewer folks end up passing them through the Pony serialization code. So, of course, Red Davies did just that. And of course, he found a bug.
+
+When we switched to LLVM 15 in 0.54.1, we had to account for a rather large change with how LLVM handles pointer and types. In the process of doing that update, a mistake was made and serializing of bare lambdas was broken.
+
+We've made the fix and introduced a regression test. Enjoy your fix Red!

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -290,7 +290,7 @@ static void deserialise_bare_interface(compile_t* c, LLVMValueRef ptr)
 
   LLVMValueRef desc = LLVMBuildInBoundsGEP2(c->builder,
     LLVMArrayType(c->ptr, 0), c->desc_table, args, 2, "");
-  desc = LLVMBuildLoad2(c->builder, c->descriptor_type, desc, "");
+  desc = LLVMBuildLoad2(c->builder, c->ptr, desc, "");
   LLVMValueRef func = gendesc_instance(c, desc);
   LLVMBuildStore(c->builder, func, ptr);
 }

--- a/test/full-program-tests/regression-4479/main.pony
+++ b/test/full-program-tests/regression-4479/main.pony
@@ -1,0 +1,9 @@
+actor Main
+  new create(env: Env) => None
+    let cb: Callbacks = Callbacks
+
+class Callbacks
+  var cbi: @{(): None}
+
+  new create() =>
+    cbi = @{() => None}


### PR DESCRIPTION
A bug in the handling of serializing bare lambdas was introduced when we updated to LLVM 15. This commit contains the fix.

Joe wrote the fix during a sync call after I identified the offending function during triage of a Red reported issue.

Closes #4479