### PR TITLE
Adding a missing backtick in the documentation.

### DIFF
--- a/packages/constrained_types/constrained_types.pony
+++ b/packages/constrained_types/constrained_types.pony
@@ -100,7 +100,7 @@ On our usage side we have:
     | let e: ValidationFailure =>
       print_errors(e)
     end
-``
+```
 
 Where we use the `MakeUsername` alias that we use to attempt to create a
 `Username` and get back either a `Username` or `ValidationFailure` that should


### PR DESCRIPTION
There is a missing backtick in the documentation which causes a formatting issue in the documentation.  This PR fixes this.