### PR TITLE
Fix compiler crash

### DIFF
--- a/.release-notes/4505.md
+++ b/.release-notes/4505.md
@@ -1,0 +1,10 @@
+## Fix: Segmentation fault when ponyc compiles this code
+
+Fix an issue caused by passing a wrong expression to `consume`.
+
+With this change, instead of the compiler generating a
+segmentation fault, it generates the error message: "You cannot
+consume an expression that is not local. Specifically, you can
+only consume a local variable (a single lowercase identifier, without
+a dot) or a this field (this followed by a dot and a single lowercase
+identifier)".

--- a/.release-notes/4505.md
+++ b/.release-notes/4505.md
@@ -13,3 +13,4 @@ struct FFIBytes
 actor Main
   new create(env: Env) =>
     env.out.print("nothing to see here")
+```

--- a/.release-notes/4505.md
+++ b/.release-notes/4505.md
@@ -1,4 +1,4 @@
-## Fix compiler segmentation fault
+## Fix compiler crash
 
 Previously the following code would cause the compiler to crash. Now it will display a helpful error message:
 

--- a/.release-notes/4505.md
+++ b/.release-notes/4505.md
@@ -1,10 +1,15 @@
-## Fix: Segmentation fault when ponyc compiles this code
+## Fix compiler segmentation fault
 
-Fix an issue caused by passing a wrong expression to `consume`.
+Previously the following code would cause the compiler to crash. Now it will display a helpful error message:
 
-With this change, instead of the compiler generating a
-segmentation fault, it generates the error message: "You cannot
-consume an expression that is not local. Specifically, you can
-only consume a local variable (a single lowercase identifier, without
-a dot) or a this field (this followed by a dot and a single lowercase
-identifier)".
+```pony
+struct FFIBytes
+  var ptr: Pointer[U8 val] = Pointer[U8].create()
+  var length: USize = 0
+
+  fun iso string(): String val =>
+    recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end
+
+actor Main
+  new create(env: Env) =>
+    env.out.print("nothing to see here")


### PR DESCRIPTION
Fix #4477

Before this PR this code didn't work and cause segmentation fault as reported in issue #4477:

```pony
struct FFIBytes
    var ptr: Pointer[U8 val] = Pointer[U8].create()
    var length: USize = 0

    fun iso string(): String val =>
        recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end

actor Main
    new create(env: Env) =>
        env.out.print("nothing to see here")
```

Now, with the changes in this PR, here's what the compiler generates as an error:

```
Building builtin -> /home/slacturyx/Programming/Personal/Github/ponyc/packages/builtin
Building ./app -> /home/slacturyx/Programming/Personal/Github/ponyc/app
Error:
/home/slacturyx/Programming/Personal/Github/ponyc/app/app.pony:6:46: You can't consume an expression that isn't local. More specifically, you can only consume a local variable (a single lowercase identifier, with no dots) or a field of this (this followed by a dot and a single lowercase identifier).
        recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end
                                             ^
Error:
/home/slacturyx/Programming/Personal/Github/ponyc/app/app.pony:6:38: consuming a field is only allowed if it is reassigned in the same expression
        recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end
                                     ^
Error:
/home/slacturyx/Programming/Personal/Github/ponyc/app/app.pony:6:68: You can't consume an expression that isn't local. More specifically, you can only consume a local variable (a single lowercase identifier, with no dots) or a field of this (this followed by a dot and a single lowercase identifier).
        recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end
                                                                   ^
Error:
/home/slacturyx/Programming/Personal/Github/ponyc/app/app.pony:6:60: consuming a field is only allowed if it is reassigned in the same expression
        recover String.from_cpointer(consume FFIBytes.ptr, consume FFIBytes.length) end
```