### PR TITLE
Update the base image for our ponyc images

### DIFF
--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
@@ -9,7 +9,7 @@ RUN apt-get update \
     curl \
     g++ \
     git \
-    lsb-core \
+    lsb-release \
     make \
   && rm -rf /var/lib/apt/lists/*
 

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV PATH "/root/.local/share/ponyup/bin:$PATH"
 
@@ -9,7 +9,7 @@ RUN apt-get update \
     curl \
     g++ \
     git \
-    lsb-core \
+    lsb-release \
     make \
   && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -15,7 +15,7 @@ jobs:
   build-latest-gnu-docker-image:
     if: |
       github.event.client_payload.data.repository == 'nightlies' &&
-      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-ubuntu22.04.tar.gz'
+      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-ubuntu24.04.tar.gz'
 
     name: Build latest GNU Docker image
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
   build-release-gnu-docker-image:
     if: |
       github.event.client_payload.data.repository == 'releases' &&
-      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-ubuntu22.04.tar.gz'
+      github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-ubuntu24.04.tar.gz'
 
     name: Build release GNU Docker image
     runs-on: ubuntu-latest

--- a/.release-notes/ubuntu24-images.md
+++ b/.release-notes/ubuntu24-images.md
@@ -1,0 +1,3 @@
+## Update the base image for our ponyc images
+
+Our Docker images have had their base image updated from Ubuntu 22.04 to Ubuntu 24.04.


### PR DESCRIPTION
Our Docker images have had their base image updated from Ubuntu 22.04 to Ubuntu 24.04.