### PR TITLE
Improve error message for generic subtyping.

### DIFF
--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -219,6 +219,9 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
     ast_error_frame(errorf, a,
       "%s has different type arguments than %s (the type arguments must be equivalent, not covariant nor contravariant)",
       ast_print_type(a), ast_print_type(b));
+    ast_error_frame(errorf, a,
+      "this might be possible if either %s or %s were an interface rather than a concrete type",
+      ast_print_type(a), ast_print_type(b));
   }
 
   // Make sure we had the same number of typeargs.

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -216,7 +216,8 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
 
   if(!ret && errorf != NULL)
   {
-    ast_error_frame(errorf, a, "%s has different type arguments than %s",
+    ast_error_frame(errorf, a,
+      "%s has different type arguments than %s (the type arguments must be equivalent, not covariant nor contravariant)",
       ast_print_type(a), ast_print_type(b));
   }
 


### PR DESCRIPTION
This make the error message a bit more helpful in cases like those seen in #4514.

Resolves #4514