### PR TITLE
Update to actions/cache version 4

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -52,7 +52,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -92,7 +92,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -134,7 +134,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -174,7 +174,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -183,7 +183,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -112,7 +112,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -157,7 +157,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -197,7 +197,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -206,7 +206,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -246,7 +246,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -255,7 +255,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -295,7 +295,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -304,7 +304,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -334,7 +334,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -343,7 +343,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -369,7 +369,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -378,7 +378,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -410,7 +410,7 @@ jobs:
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -419,7 +419,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -460,7 +460,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -469,7 +469,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -75,7 +75,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -107,7 +107,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -141,7 +141,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-arm64-macos-14-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -173,7 +173,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -182,7 +182,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -64,7 +64,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -126,7 +126,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -179,7 +179,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -188,7 +188,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -232,7 +232,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -241,7 +241,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Cache Libs
         id: cache-libs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build/libs
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build/libs
           key: libs-x86-macos-13-${{ hashFiles('Makefile', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build/libs
           key: libs-windows-2022-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'libs/CMakeLists.txt') }}


### PR DESCRIPTION
Version 3 contains a deprecated version of node that will cause the actions to stop working in the not so distant future.