### PR TITLE
Make heap small chunk size setting logic more precise/correct

### DIFF
--- a/.release-notes/4527.md
+++ b/.release-notes/4527.md
@@ -1,0 +1,3 @@
+## Fix actor heap chunk size tracking bug that could cause a segfault
+
+The [0.55.1](https://github.com/ponylang/ponyc/releases/tag/0.55.1) release included some internal actor heap implementation optimizations. Unfortunately, there was a small bug that could potentially cause a segfault due to not properly clearing some bits before setting them for some heap chunks. This change corrects that oversight to ensure the relevant bits are properly cleared before being set to ensure they final result can never be incorrect.

--- a/src/libponyrt/mem/heap.c
+++ b/src/libponyrt/mem/heap.c
@@ -212,7 +212,7 @@ static void set_small_chunk_size(small_chunk_t* chunk, size_t size)
 
   // left shift size to get bits in the right spot for OR'ing into `chunk->m`
   size = size << SMALL_CHUNK_SIZECLASS_SHIFT;
-  ((chunk_t*)chunk)->m = (char*)((uintptr_t)((chunk_t*)chunk)->m | (size & SMALL_CHUNK_SIZECLASS_BITMASK));
+  ((chunk_t*)chunk)->m = (char*)(((uintptr_t)((chunk_t*)chunk)->m & ~SMALL_CHUNK_SIZECLASS_BITMASK) | (size & SMALL_CHUNK_SIZECLASS_BITMASK));
 }
 
 static bool get_chunk_needs_clearing(chunk_t* chunk)


### PR DESCRIPTION
Prior to this commit, the heap small chunk size setting logic would bitwise-or in the size into the appropriate bits of the small chunk but this is technically incorrect as it doesn't clear out the bits first.

This commit changes the logic to ensure the relevant bits are cleared first before the new size is bitwise-or'd in.