### PR TITLE
Make actor pad automagically calculated

### DIFF
--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -72,27 +72,10 @@ typedef struct pony_actor_t
 
 /** Padding for actor types.
  *
- * 56 bytes: initial header, not including the type descriptor
- * 52/104 bytes: heap
- * 4/8 bytes: muted counter
- * 4/8 bytes: internal flags (after alignment)
- * 64/128 bytes: actorstats (if enabled)
- * 48/88 bytes: gc
- * 24/56 bytes: padding to 64 bytes, ignored
+ * Size of pony_actor_t minus the padding at the end and the pony_type_t* at the beginning.
+ * 
  */
-#if INTPTR_MAX == INT64_MAX
-#ifdef USE_RUNTIMESTATS
-#  define PONY_ACTOR_PAD_SIZE 392
-#else
-#  define PONY_ACTOR_PAD_SIZE 264
-#endif
-#elif INTPTR_MAX == INT32_MAX
-#ifdef USE_RUNTIMESTATS
-#  define PONY_ACTOR_PAD_SIZE 232
-#else
-#  define PONY_ACTOR_PAD_SIZE 168
-#endif
-#endif
+#define PONY_ACTOR_PAD_SIZE (offsetof(pony_actor_t, gc) + sizeof(gc_t) - sizeof(pony_type_t*))
 
 typedef struct pony_actor_pad_t
 {

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -68,6 +68,9 @@ typedef struct pony_actor_t
   actorstats_t actorstats; // 64/128 bytes
 #endif
   gc_t gc; // 48/88 bytes
+  // if you add more members here, you need to update the PONY_ACTOR_PAD_SIZE
+  // calculation below and the pony_static_assert at the top of actor.c, to
+  // reference the final member, its offset, and size
 } pony_actor_t;
 
 /** Padding for actor types.


### PR DESCRIPTION
Prior to this commit, we had to manually update the actor pad size if the size of pony_actor_t changed.

This commit makes it so that the actor pad size is now automagically calculated by the compiler so it doesn't have to be manually maintained any longer.