### PR TITLE
Correctly find custom-built `llc`

### DIFF
--- a/.release-notes/4537.md
+++ b/.release-notes/4537.md
@@ -1,0 +1,5 @@
+## Correctly find custom-built `llc` during build process
+
+Previously our CMake build was failing to find our custom-built `llc` binary,
+but builds worked by accident if there was a system `llc`.  The build system
+now finds our custom `llc` correctly.

--- a/.release-notes/4537.md
+++ b/.release-notes/4537.md
@@ -1,5 +1,3 @@
 ## Correctly find custom-built `llc` during build process
 
-Previously our CMake build was failing to find our custom-built `llc` binary,
-but builds worked by accident if there was a system `llc`.  The build system
-now finds our custom `llc` correctly.
+Previously our CMake build was failing to find our custom-built `llc` binary, but builds worked by accident if there was a system `llc`.  The build system now finds our custom `llc` correctly.

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -56,7 +56,7 @@ set(_ll_except_obj "${CMAKE_BINARY_DIR}/except_try_catch.o")
 
 find_file(_llc_command
     NAMES llc.exe llc
-    PATHS "${CMAKE_BINARY_DIR}/../../libs/bin" "${CMAKE_BINARY_DIR}/../libs/bin"
+    HINTS "${CMAKE_BINARY_DIR}/../libs/bin"
 )
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -56,7 +56,7 @@ set(_ll_except_obj "${CMAKE_BINARY_DIR}/except_try_catch.o")
 
 find_file(_llc_command
     NAMES llc.exe llc
-    HINTS "${CMAKE_BINARY_DIR}/../libs/bin"
+    HINTS "${CMAKE_BINARY_DIR}/../../libs/bin" "${CMAKE_BINARY_DIR}/../libs/bin"
 )
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
Use `HINTS` instead of `PATHS` in the CMake `find_path` command that tries to find our custom-build `llc`. From the documentation for `find_file` it seems that `PATHS` is searched after the system `PATH`, so if there was a system `llc` that would get picked up first.  Since `HINTS` is searched before `PATH`, our `llc` now gets picked up correctly.