### PR TITLE
Make actor scheduling when unscheduled a tiny bit more efficient

### DIFF
--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -96,6 +96,32 @@ typedef struct pony_actor_pad_t
  */
 void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor);
 
+/** Send a message to an actor and add to the inject queue if it is not currently
+ * scheduled.
+ */
+void ponyint_sendv_inject(pony_actor_t* to, pony_msg_t* msg);
+
+/** Convenience function to send a message with no arguments and add the actor
+ * to the inject queue if it is not currently scheduled.
+ *
+ * The dispatch function receives a pony_msg_t.
+ */
+void ponyint_send_inject(pony_actor_t* to, uint32_t id);
+
+/** Convenience function to send a pointer argument in a message and add the actor
+ * to the inject queue if it is not currently scheduled.
+ *
+ * The dispatch function receives a pony_msgp_t.
+ */
+void ponyint_sendp_inject(pony_actor_t* to, uint32_t id, void* p);
+
+/** Convenience function to send an integer argument in a message and add the actor
+ * to the inject queue if it is not currently scheduled.
+ *
+ * The dispatch function receives a pony_msgi_t.
+ */
+void ponyint_sendi_inject(pony_actor_t* to, uint32_t id, intptr_t i);
+
 bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
 
 void ponyint_actor_destroy(pony_actor_t* actor);

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -127,10 +127,10 @@ PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
   m->flags = flags;
   m->arg = arg;
 
-  // ASIO messages technically are application messages, but since they have no
-  // sender they aren't covered by backpressure. We pass false for an early
-  // bailout in the backpressure code.
-  pony_sendv(pony_ctx(), ev->owner, &m->msg, &m->msg, false);
+  // ASIO messages technically are application messages, but they are not
+  // covered by backpressure. We send the message via a mechanism that will put
+  // an unscheduled actor onto the global inject queue for any actor to pick up.
+  ponyint_sendv_inject(ev->owner, &m->msg);
 
   // maybe wake up a scheduler thread if they've all fallen asleep
   ponyint_sched_maybe_wakeup_if_all_asleep(-1);

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -21,7 +21,7 @@ void ponyint_cycle_unblock(pony_actor_t* actor);
 
 void ponyint_cycle_ack(size_t token);
 
-void ponyint_cycle_terminate();
+void ponyint_cycle_terminate(pony_ctx_t* ctx);
 
 bool ponyint_is_cycle(pony_actor_t* actor);
 

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -122,6 +122,10 @@ void ponyint_sched_stop();
 
 void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor);
 
+void ponyint_sched_add_inject_or_sched(pony_ctx_t* ctx, pony_actor_t* actor);
+
+void ponyint_sched_add_inject(pony_actor_t* actor);
+
 void ponyint_sched_mute(pony_ctx_t* ctx, pony_actor_t* sender, pony_actor_t* recv);
 
 void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor);
@@ -148,10 +152,6 @@ void ponyint_sched_maybe_wakeup(int32_t current_scheduler_id);
 // Try and wake up a sleeping scheduler thread only if all scheduler
 // threads are asleep
 void ponyint_sched_maybe_wakeup_if_all_asleep(int32_t current_scheduler_id);
-
-// Retrieves the global main thread context for scheduling
-// special actors on the inject queue.
-pony_ctx_t* ponyint_sched_get_inject_context();
 
 #ifdef USE_RUNTIMESTATS
 uint64_t ponyint_sched_cpu_used(pony_ctx_t* ctx);


### PR DESCRIPTION
Prior to this commit, when an actor was sent a message (from another actor or from the ASIO thread), it might get scheduled on the inject queue or the sending actor's scheduler thread depending on whether the context of the sending thread was a runtime scheduler thread or not. This was required to ensure that sending from the ASIO thread would add the actor to the inject queue. The same behavior was relied on during the runtime startup to ensure actors created before the scheduler threads were started were put on the inject queue. This made it hard to ensure that the cycle detector always ended up on the inject queue instead of the sending actor's scheduler thread. it was also less efficient than necessary for the majority of scenarios when an unscheduled actor might need to be scheduled due to a message send due to the extra branch.

This commit changes things to be more explicit.

The ASIO thread will now always add unscheduled actors to the inject queue. All message sends to the cycle detector will always add the cycle detector to the inject queue if it is unscheduled. All other message sends will always schedule unscheduled actors onto the sending actor's scheduler threadi (except for actor constructor messages which will keep using the old behavior). New functionality has been added and existing functionality has been modified to support this more explicit behavior.

New functionality has been added to send messages to actors and the add them to the inject queue if they are not scheduled. The existing functionality to send messages to actors has been modified to always add unscheduled actors to the sending actor's scheduler thread. The old behavior of relying on whether the context of the sending thread was a runtime scheduler thread or not is only retained for when actors are sent their constructors (and is only required during runtime startup) via `pony_sendv_single`.