### PR TITLE
Fix buffer out of bounds access issue

### DIFF
--- a/.release-notes/4540.md
+++ b/.release-notes/4540.md
@@ -1,0 +1,3 @@
+## Fix minor buffer out of bounds access bug in compiler
+
+Previously, the compiler error reporting had a minor buffer out of bounds access bug where it read one byte past the end of a buffer as part of an if condition before checking that the offset was smaller than the buffer length. This was fixed by switching the order of the if condition checks so that the check that the offset is smaller than the buffer length happens before reading the value from the buffer to prefer the out of bounds access issue.

--- a/src/libponyc/ast/error.c
+++ b/src/libponyc/ast/error.c
@@ -206,7 +206,7 @@ static errormsg_t* make_errorv(source_t* source, size_t line, size_t pos,
 
     size_t start = tpos;
 
-    while((source->m[tpos] != '\n') && (tpos < source->len))
+    while((tpos < source->len) && (source->m[tpos] != '\n'))
       tpos++;
 
     size_t len = tpos - start;


### PR DESCRIPTION
Address sanitizer prefers that the length check happen first.