### PR TITLE
Fix mpmcq use-after-free bug

### DIFF
--- a/src/libponyrt/sched/mpmcq.h
+++ b/src/libponyrt/sched/mpmcq.h
@@ -24,6 +24,8 @@ void ponyint_mpmcq_init(mpmcq_t* q);
 
 void ponyint_mpmcq_destroy(mpmcq_t* q);
 
+void ponyint_mpmcq_cleanup();
+
 void ponyint_mpmcq_push(mpmcq_t* q, void* data);
 
 void ponyint_mpmcq_push_single(mpmcq_t* q, void* data);

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1125,6 +1125,8 @@ static DECLARE_THREAD_FN(run_thread)
 #endif
 
   run(sched);
+
+  ponyint_mpmcq_cleanup();
   ponyint_pool_thread_cleanup();
 
   return 0;


### PR DESCRIPTION
according to address sanitizer, prior to this commit, the mpmcq node free could cause a use-after-free error from another thread that might still be reading from `tail->next`. This was technically safe in this context since the logic will end up looping due to the CAS failing in the while condition due to the aba counter being out of sync.

This commit defers freeing of the nodes and instead recycles them for future pushes onto the mpmcq from the same thread to ensure that there are no use-after-free concerns any longer.