### PR TITLE
Use a constant for unknown scheduler index

### DIFF
--- a/src/libponyrt/actor/messageq.c
+++ b/src/libponyrt/actor/messageq.c
@@ -128,7 +128,7 @@ bool ponyint_actor_messageq_push(messageq_t* q, pony_msg_t* first,
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
     pony_msg_t* m = first;
-    int32_t index = (sched == NULL) ? UNKNOWN_SCHEDULER : sched->index;
+    int32_t index = (sched == NULL) ? PONY_UNKNOWN_SCHEDULER_INDEX : sched->index;
 
     while(m != last)
     {
@@ -186,7 +186,7 @@ bool ponyint_actor_messageq_push_single(messageq_t* q,
   if(DTRACE_ENABLED(ACTOR_MSG_PUSH))
   {
     pony_msg_t* m = first;
-    int32_t index = (sched == NULL) ? UNKNOWN_SCHEDULER : sched->index;
+    int32_t index = (sched == NULL) ? PONY_UNKNOWN_SCHEDULER_INDEX : sched->index;
 
     while(m != last)
     {

--- a/src/libponyrt/actor/messageq.h
+++ b/src/libponyrt/actor/messageq.h
@@ -12,8 +12,6 @@ typedef struct messageq_t
 #include "../sched/scheduler.h"
 #include <platform.h>
 
-#define UNKNOWN_SCHEDULER -1
-
 PONY_EXTERN_C_BEGIN
 
 void ponyint_messageq_init(messageq_t* q);

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -476,7 +476,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
       ponyint_sched_unnoisy_asio(SPECIAL_THREADID_EPOLL);
 
       // maybe wake up a scheduler thread if they've all fallen asleep
-      ponyint_sched_maybe_wakeup_if_all_asleep(-1);
+      ponyint_sched_maybe_wakeup_if_all_asleep(PONY_UNKNOWN_SCHEDULER_INDEX);
     }
 
     ev->noisy = false;

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -133,5 +133,5 @@ PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
   pony_sendv(pony_ctx(), ev->owner, &m->msg, &m->msg, false);
 
   // maybe wake up a scheduler thread if they've all fallen asleep
-  ponyint_sched_maybe_wakeup_if_all_asleep(-1);
+  ponyint_sched_maybe_wakeup_if_all_asleep(PONY_UNKNOWN_SCHEDULER_INDEX);
 }

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -350,7 +350,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
       ponyint_sched_unnoisy_asio(SPECIAL_THREADID_IOCP);
 
       // maybe wake up a scheduler thread if they've all fallen asleep
-      ponyint_sched_maybe_wakeup_if_all_asleep(-1);
+      ponyint_sched_maybe_wakeup_if_all_asleep(PONY_UNKNOWN_SCHEDULER_INDEX);
     }
 
     ev->noisy = false;

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -417,7 +417,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
       ponyint_sched_unnoisy_asio(SPECIAL_THREADID_KQUEUE);
 
       // maybe wake up a scheduler thread if they've all fallen asleep
-      ponyint_sched_maybe_wakeup_if_all_asleep(-1);
+      ponyint_sched_maybe_wakeup_if_all_asleep(PONY_UNKNOWN_SCHEDULER_INDEX);
     }
 
     ev->noisy = false;

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -369,24 +369,29 @@ static bool read_msg(scheduler_t* sched)
     {
       case SCHED_SUSPEND:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
         maybe_start_cnf_ack_cycle(sched);
         break;
       }
 
       case SCHED_BLOCK:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
         handle_sched_block(sched);
         break;
       }
 
       case SCHED_UNBLOCK:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
         handle_sched_unblock(sched);
         break;
       }
 
       case SCHED_CNF:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
+
         // Echo the token back as ACK(token).
         send_msg(sched->index, 0, SCHED_ACK, m->i);
         break;
@@ -394,6 +399,8 @@ static bool read_msg(scheduler_t* sched)
 
       case SCHED_ACK:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
+
         // If it's the current token, increment the ack count.
         if(m->i == sched->ack_token)
           sched->ack_count++;
@@ -402,12 +409,15 @@ static bool read_msg(scheduler_t* sched)
 
       case SCHED_TERMINATE:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
         sched->terminate = true;
         break;
       }
 
       case SCHED_UNMUTE_ACTOR:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
+
         if (ponyint_sched_unmute_senders(&sched->ctx, (pony_actor_t*)m->i))
           run_queue_changed = true;
 
@@ -416,6 +426,8 @@ static bool read_msg(scheduler_t* sched)
 
       case SCHED_NOISY_ASIO:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
+
         // mark asio as being noisy
         sched->asio_noisy = true;
         break;
@@ -423,6 +435,8 @@ static bool read_msg(scheduler_t* sched)
 
       case SCHED_UNNOISY_ASIO:
       {
+        pony_assert(PONY_UNKNOWN_SCHEDULER_INDEX != sched->index);
+
         // mark asio as not being noisy
         sched->asio_noisy = false;
         break;
@@ -1394,7 +1408,7 @@ PONY_API void pony_register_thread()
   this_scheduler = POOL_ALLOC(scheduler_t);
   memset(this_scheduler, 0, sizeof(scheduler_t));
   this_scheduler->tid = ponyint_thread_self();
-  this_scheduler->index = -1;
+  this_scheduler->index = PONY_UNKNOWN_SCHEDULER_INDEX;
 }
 
 PONY_API void pony_unregister_thread()

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -18,6 +18,7 @@ typedef struct scheduler_t scheduler_t;
 #define SPECIAL_THREADID_KQUEUE   -10
 #define SPECIAL_THREADID_IOCP     -11
 #define SPECIAL_THREADID_EPOLL    -12
+#define PONY_UNKNOWN_SCHEDULER_INDEX -1
 
 #if !defined(PLATFORM_IS_WINDOWS) && !defined(USE_SCHEDULER_SCALING_PTHREADS)
 // Signal to use for suspending/resuming threads via `sigwait`/`pthread_kill`


### PR DESCRIPTION
this is much easier to understand and maintain instead of having to remember that `-1` is an unknown scheduler everywhere it is used