### PR TITLE
Only need to wait for a single scheduler thread to become active

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1469,7 +1469,7 @@ void ponyint_sched_maybe_wakeup_if_all_asleep(int32_t current_scheduler_id)
     {
       // wait for sleeping threads to wake and update check variable
       // to ensure that we have at least one fully awake scheduler thread
-      while (get_active_scheduler_count() != get_active_scheduler_count_check())
+      while (get_active_scheduler_count_check() == 0)
       {
         // send signals to all scheduler threads that should be awake
         // this is somewhat wasteful if a scheduler thread is already awake


### PR DESCRIPTION
Prior to this commit, ponyint_sched_maybe_wakeup_if_all_asleep would wait until the number of active scheduler check variable matched the active schedule count variable. This could potentially cause it to unnecessarily wait for more than 1 scheduler thread to become fully active.

This commit changes the logic to only wait until the active scheduler check variable indicates that there is at least one fully active scheduler.