### PR TITLE
Correctly shutdown all scheduler threads

### DIFF
--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1158,8 +1158,11 @@ static void ponyint_sched_shutdown()
 {
   uint32_t start = 0;
 
-  for(uint32_t i = start; i < scheduler_count; i++)
-    ponyint_thread_join(scheduler[i].tid);
+  while(start < scheduler_count)
+  {
+    if (ponyint_thread_join(scheduler[start].tid))
+      start++;
+  }
 
   DTRACE0(RT_END);
   ponyint_cycle_terminate(&this_scheduler->ctx);


### PR DESCRIPTION
Prior to this change, it was possible to not shutdown all scheduler threads. ponyint_thread_join on non-Windows systems calls pthread_join. pthread_join can fail and that failure needs to be handled. In our case here, given that ponyint_thread_join returns a boolean, the response to an error is to try again.

If we encounter a non-recoverable error, this new strategy should result in a hang rather than undefined behavior. If we have hangs that we trace to this changed functionality, we look at more robust error handling and changing the interface from ponyint_thread_join.