### PR TITLE
Fix early quiescence/termination bug

### DIFF
--- a/.release-notes/4550.md
+++ b/.release-notes/4550.md
@@ -1,0 +1,5 @@
+## Fix early quiescence/termination bug
+
+Previously, the logic to detect quiescence had a race condition in relation to dynamic scheduler scaling and it was possible for the runtime to incorrectly detect quiescence and termninate early if a scheduler thread suspended at just the right time.
+
+We have now changed the quiescence logic to keep an accurate track of exactly how many scheduler threads are active at the time the quiescence detection protocol begins so it can ensure that any scheduler threads suspending or unsuspending can no longer cause an incorrect determination that might lead to early termination of the runtime.


### PR DESCRIPTION
Prior to this commit, the logic to detect quiescence had a race condition in relation to dynamic scheduler scaling and it was possible for the runtime to incorrectly detect quiescence and termninate early if a scheduler thread suspended at just the right time.

This commit changes the quiescence logic to keep an accurate track of exactly how many scheduler threads are active at the time the quiescence detection protocol begins so it can ensure that any scheduler threads suspending or unsuspending can no longer cause an incorrect determination that might lead to early termination of the runtime.