### PR TITLE
Add py3-lldb to musl ci builder

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-musl-builder/Dockerfile
@@ -18,6 +18,7 @@ RUN apk update \
   py3-pip \
   gdb \
   lldb \
+  py3-lldb \
 && pip install cloudsmith-cli
 
 # add user pony in order to not run tests as root


### PR DESCRIPTION
because a lot of lldb functionality requires it