### PR TITLE
Deterministic serialisation for cross binary communication

### DIFF
--- a/.release-notes/4567.md
+++ b/.release-notes/4567.md
@@ -1,3 +1,0 @@
-## Deterministic serialisation for cross binary communication
-
-Pony built-in serialisation can now be used between binaries compiled with the same version of the pony compiler (this would likely result in segfaults previously). Cross binary serialisation will only work for binaries of the same bit width (32 bit vs 64 bit), data model (ilp32, lp64, or llp64), and endianness (big endian or little endian) but is not limited to a single platform (for example: one can mix and match x86_64 linux and aarch64 linux because they have the same bitwidth, data model, and endianness).

--- a/.release-notes/4567.md
+++ b/.release-notes/4567.md
@@ -1,3 +1,3 @@
-## Deterministic cerealisation for cross binary communication
+## Deterministic serialisation for cross binary communication
 
 Pony built-in serialisation can now be used between binaries compiled with the same version of the pony compiler (this would likely result in segfaults previously). Cross binary serialisation will only work for binaries of the same bit width (32 bit vs 64 bit), data model (ilp32, lp64, or llp64), and endianness (big endian or little endian) but is not limited to a single platform (for example: one can mix and match x86_64 linux and aarch64 linux because they have the same bitwidth, data model, and endianness).

--- a/.release-notes/4567.md
+++ b/.release-notes/4567.md
@@ -1,0 +1,3 @@
+## Deterministic cerealisation for cross binary communication
+
+Pony built-in serialisation can now be used between binaries compiled with the same version of the pony compiler (this would likely result in segfaults previously). Cross binary serialisation will only work for binaries of the same bit width (32 bit vs 64 bit), data model (ilp32, lp64, or llp64), and endianness (big endian or little endian) but is not limited to a single platform (for example: one can mix and match x86_64 linux and aarch64 linux because they have the same bitwidth, data model, and endianness).

--- a/packages/serialise/serialise.pony
+++ b/packages/serialise/serialise.pony
@@ -15,16 +15,18 @@ invariants. However, if only "trusted" data (i.e. data produced by Pony
 serialisation from the same binary) is deserialised, it will always maintain a
 well-formed heap and all object invariants.
 
-Note that serialised data is not usable between different Pony binaries. This is
-due to the use of type identifiers rather than a heavy-weight self-describing
-serialisation schema. This also means it isn't safe to deserialise something
-serialised by the same program compiled for a different platform.
+Note that serialised data can be used between binaries compiled with the same
+version of the pony compiler. Cross binary serialisation will only work for
+binaries of the same bit width (32 bit vs 64 bit), data model (ilp32, lp64, or
+llp64), and endianness (big endian or little endian) but is not limited to a
+single platform (for example: one can mix and match x86_64 linux and aarch64
+linux because they have the same bitwidth, data model, and endianness).
 
 The [Serialise.signature](serialise-Serialise.md#signature) method is provided
 for the purposes of comparing communicating Pony binaries to determine if they
-are the same. Confirming this before deserialising data can help mitigate the
-risk of accidental serialisation across different Pony binaries, but does not on
-its own address the security issues of accepting data from untrusted sources.
+are compatible. Confirming this before deserialising data can help mitigate the
+risk of accidental serialisation across incompatible Pony binaries, but does not
+on its own address the security issues of accepting data from untrusted sources.
 """
 
 use @"internal.signature"[Array[U8] val]()

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -2013,6 +2013,7 @@ static pony_type_t ast_signature_pony =
   sizeof(ast_signature_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   ast_signature_serialise_trace,
@@ -2090,6 +2091,7 @@ static pony_type_t ast_nominal_pkg_id_signature_pony =
 {
   0,
   sizeof(ast_signature_t),
+  0,
   0,
   0,
   NULL,
@@ -2353,6 +2355,7 @@ static pony_type_t ast_pony =
 {
   0,
   sizeof(ast_t),
+  0,
   0,
   0,
   NULL,

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -114,6 +114,7 @@ static pony_type_t source_pony =
   sizeof(source_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   source_serialise_trace,

--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -134,6 +134,7 @@ static __pony_thread_local struct _pony_type_t string_pony =
   0,
   0,
   0,
+  0,
   NULL,
   NULL,
   NULL,
@@ -218,6 +219,7 @@ static pony_type_t strlist_pony =
 {
   0,
   sizeof(strlist_t),
+  0,
   0,
   0,
   NULL,

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -389,6 +389,7 @@ static pony_type_t symbol_pony =
   sizeof(symbol_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   symbol_serialise_trace,

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -404,6 +404,7 @@ static pony_type_t token_signature_pony =
   sizeof(token_signature_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   token_signature_serialise_trace,
@@ -456,6 +457,7 @@ static pony_type_t token_docstring_signature_pony =
 {
   0,
   sizeof(token_signature_t),
+  0,
   0,
   0,
   NULL,
@@ -544,6 +546,7 @@ static pony_type_t token_pony =
 {
   0,
   sizeof(token_t),
+  0,
   0,
   0,
   NULL,

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -172,6 +172,7 @@ typedef struct compile_t
   LLVMValueRef primitives_init;
   LLVMValueRef primitives_final;
   LLVMValueRef desc_table;
+  LLVMValueRef desc_table_offset_lookup_fn;
   LLVMValueRef numeric_sizes;
 
   LLVMTypeRef void_type;
@@ -187,6 +188,8 @@ typedef struct compile_t
 
   LLVMTypeRef ptr;
   LLVMTypeRef descriptor_type;
+  LLVMTypeRef descriptor_offset_lookup_type;
+  LLVMTypeRef descriptor_offset_lookup_fn;
   LLVMTypeRef field_descriptor;
   LLVMTypeRef object_type;
   LLVMTypeRef msg_type;

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -14,6 +14,8 @@ void gendesc_init(compile_t* c, reach_type_t* t);
 
 void gendesc_table(compile_t* c);
 
+void gendesc_table_lookup(compile_t* c);
+
 LLVMValueRef gendesc_fetch(compile_t* c, LLVMValueRef object);
 
 LLVMValueRef gendesc_typeid(compile_t* c, LLVMValueRef desc);

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -52,14 +52,16 @@ static LLVMValueRef make_lang_features_init(compile_t* c)
     boolean = c->i8;
 
   uint32_t desc_table_size = reach_max_type_id(c->reach);
+  LLVMValueRef desc_table_lookup_fn = c->desc_table_offset_lookup_fn;
 
-  LLVMTypeRef f_params[4];
+  LLVMTypeRef f_params[5];
   f_params[0] = boolean;
   f_params[1] = boolean;
   f_params[2] = c->ptr;
   f_params[3] = c->intptr;
+  f_params[4] = c->descriptor_offset_lookup_fn;
 
-  LLVMTypeRef lfi_type = LLVMStructTypeInContext(c->context, f_params, 4,
+  LLVMTypeRef lfi_type = LLVMStructTypeInContext(c->context, f_params, 5,
     false);
 
   LLVMBasicBlockRef this_block = LLVMGetInsertBlock(c->builder);
@@ -88,6 +90,10 @@ static LLVMValueRef make_lang_features_init(compile_t* c)
   field = LLVMBuildStructGEP2(c->builder, lfi_type, lfi_object, 3, "");
   LLVMBuildStore(c->builder, LLVMConstInt(c->intptr, desc_table_size, false),
     field);
+
+  field = LLVMBuildStructGEP2(c->builder, lfi_type, lfi_object, 4, "");
+  LLVMBuildStore(c->builder, LLVMBuildBitCast(c->builder, desc_table_lookup_fn,
+    c->descriptor_offset_lookup_fn, ""), field);
 
   return lfi_object;
 }

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -199,3 +199,10 @@ const char* genname_program_fn(const char* program, const char* name)
 {
   return stringtab_two(program, name);
 }
+
+const char* genname_type_with_id(const char* type, uint64_t type_id)
+{
+  printbuf_t* buf = printbuf_new();
+  printbuf(buf, "%s_%" PRIu64, type, type_id);
+  return stringtab_buf(buf);
+}

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -42,6 +42,8 @@ const char* genname_unsafe(const char* name);
 
 const char* genname_program_fn(const char* program, const char* name);
 
+const char* genname_type_with_id(const char* type, uint64_t type_id);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -776,7 +776,7 @@ void genprim_array_serialise(compile_t* c, reach_type_t* t)
   LLVMValueRef offset_addr = LLVMBuildInBoundsGEP2(c->builder, c->i8, addr,
     &offset, 1, "");
 
-  genserialise_typeid(c, t, offset_addr);
+  genserialise_serialiseid(c, t, offset_addr);
 
   // Don't serialise our contents if we are opaque.
   LLVMBasicBlockRef body_block = codegen_block(c, "body");
@@ -890,7 +890,7 @@ void genprim_array_deserialise(compile_t* c, reach_type_t* t)
 
   LLVMValueRef ctx = LLVMGetParam(c_t->deserialise_fn, 0);
   LLVMValueRef object = LLVMGetParam(c_t->deserialise_fn, 1);
-  gendeserialise_typeid(c, c_t, object);
+  gendeserialise_serialiseid(c, c_t, object);
 
   // Deserialise the array contents.
   LLVMValueRef alloc = field_value(c, c_t->structure, object, 2);
@@ -1010,7 +1010,7 @@ void genprim_string_serialise(compile_t* c, reach_type_t* t)
   LLVMValueRef offset_addr = LLVMBuildInBoundsGEP2(c->builder, c->i8, addr,
     &offset, 1, "");
 
-  genserialise_typeid(c, t, offset_addr);
+  genserialise_serialiseid(c, t, offset_addr);
 
   // Don't serialise our contents if we are opaque.
   LLVMBasicBlockRef body_block = codegen_block(c, "body");
@@ -1069,7 +1069,7 @@ void genprim_string_deserialise(compile_t* c, reach_type_t* t)
   LLVMValueRef ctx = LLVMGetParam(c_t->deserialise_fn, 0);
   LLVMValueRef object = LLVMGetParam(c_t->deserialise_fn, 1);
 
-  gendeserialise_typeid(c, c_t, object);
+  gendeserialise_serialiseid(c, c_t, object);
 
   // Deserialise the string contents.
   LLVMValueRef alloc = field_value(c, c_t->structure, object, 2);

--- a/src/libponyc/codegen/genserialise.c
+++ b/src/libponyc/codegen/genserialise.c
@@ -3,6 +3,7 @@
 #include "gendesc.h"
 #include "genfun.h"
 #include "genname.h"
+#include "genopt.h"
 #include "genprim.h"
 #include "ponyassert.h"
 #include "../../libponyrt/mem/pool.h"
@@ -19,7 +20,7 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
   {
     case TK_PRIMITIVE:
     {
-      genserialise_typeid(c, t, offset);
+      genserialise_serialiseid(c, t, offset);
 
       if(c_t->primitive != NULL)
       {
@@ -37,7 +38,7 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
 
     case TK_CLASS:
     {
-      genserialise_typeid(c, t, offset);
+      genserialise_serialiseid(c, t, offset);
       extra++;
       break;
     }
@@ -45,7 +46,7 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     case TK_ACTOR:
     {
       // Skip the actor pad.
-      genserialise_typeid(c, t, offset);
+      genserialise_serialiseid(c, t, offset);
       extra += 2;
       break;
     }
@@ -54,7 +55,7 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     {
       if(!is_bare_tuple)
       {
-        genserialise_typeid(c, t, offset);
+        genserialise_serialiseid(c, t, offset);
         object = LLVMBuildStructGEP2(c->builder, c_t->structure, object, 1, "");
         LLVMValueRef size = LLVMConstInt(c->intptr,
           LLVMOffsetOfElement(c->target_data, structure, 1), false);
@@ -103,10 +104,10 @@ static void serialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
   }
 }
 
-void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset)
+void genserialise_serialiseid(compile_t* c, reach_type_t* t, LLVMValueRef offset)
 {
-  // Write the type id instead of the descriptor.
-  LLVMValueRef value = LLVMConstInt(c->intptr, t->type_id, false);
+  // Write the serialise id instead of the descriptor.
+  LLVMValueRef value = LLVMConstInt(target_is_ilp32(c->opt->triple) ? c->i32 : c->i64, t->serialise_id, false);
   LLVMBuildStore(c->builder, value, offset);
 }
 
@@ -136,7 +137,7 @@ static void serialise_bare_interface(compile_t* c, reach_type_t* t,
     LLVMValueRef test = LLVMBuildICmp(c->builder, LLVMIntEQ, obj,
       ((compile_type_t*)sub->c_type)->instance, "");
     LLVMBuildCondBr(c->builder, test, post_block, next_block);
-    LLVMValueRef value = LLVMConstInt(c->intptr, sub->type_id, false);
+    LLVMValueRef value = LLVMConstInt(target_is_ilp32(c->opt->triple) ? c->i32 : c->i64, sub->serialise_id, false);
     LLVMAddIncoming(phi, &value, &current_block, 1);
     LLVMPositionBuilderAtEnd(c->builder, next_block);
     sub = next;
@@ -145,7 +146,7 @@ static void serialise_bare_interface(compile_t* c, reach_type_t* t,
   }
 
   LLVMBuildBr(c->builder, post_block);
-  LLVMValueRef value = LLVMConstInt(c->intptr, sub->type_id, false);
+  LLVMValueRef value = LLVMConstInt(target_is_ilp32(c->opt->triple) ? c->i32 : c->i64, sub->serialise_id, false);
   LLVMAddIncoming(phi, &value, &current_block, 1);
 
   LLVMMoveBasicBlockAfter(post_block, current_block);
@@ -168,12 +169,12 @@ void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
     LLVMValueRef value = LLVMBuildLoad2(c->builder, c_t->mem_type, ptr, "");
     LLVMBuildStore(c->builder, value, offset);
   } else if(t->bare_method != NULL) {
-    // Bare object, either write the type id directly if it is a concrete object
-    // or compute the type id based on the object value and write it if it isn't.
+    // Bare object, either write the serialise_id id directly if it is a concrete object
+    // or compute the serialise_id id based on the object value and write it if it isn't.
     switch(t->underlying)
     {
       case TK_PRIMITIVE:
-        genserialise_typeid(c, t, offset);
+        genserialise_serialiseid(c, t, offset);
         break;
 
       case TK_INTERFACE:
@@ -237,7 +238,7 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     case TK_PRIMITIVE:
     case TK_CLASS:
     {
-      gendeserialise_typeid(c, c_t, object);
+      gendeserialise_serialiseid(c, c_t, object);
       extra++;
       break;
     }
@@ -245,7 +246,7 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     case TK_ACTOR:
     {
       // Skip the actor pad.
-      gendeserialise_typeid(c, c_t, object);
+      gendeserialise_serialiseid(c, c_t, object);
       extra += 2;
       break;
     }
@@ -254,7 +255,7 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
     {
       if(!is_bare_tuple)
       {
-        gendeserialise_typeid(c, c_t, object);
+        gendeserialise_serialiseid(c, c_t, object);
         object = LLVMBuildStructGEP2(c->builder, c_t->structure, object, 1, "");
       }
 
@@ -274,9 +275,9 @@ static void deserialise(compile_t* c, reach_type_t* t, LLVMValueRef ctx,
   }
 }
 
-void gendeserialise_typeid(compile_t* c, compile_type_t* t, LLVMValueRef object)
+void gendeserialise_serialiseid(compile_t* c, compile_type_t* t, LLVMValueRef object)
 {
-  // Write the descriptor instead of the type id.
+  // Write the descriptor instead of the serialiseid id.
   LLVMValueRef desc_ptr = LLVMBuildStructGEP2(c->builder, t->structure, object,
     0, "");
   LLVMBuildStore(c->builder, t->desc, desc_ptr);

--- a/src/libponyc/codegen/genserialise.h
+++ b/src/libponyc/codegen/genserialise.h
@@ -11,9 +11,9 @@ typedef struct compile_type_t compile_type_t;
 void genserialise_element(compile_t* c, reach_type_t* t, bool embed,
   LLVMValueRef ctx, LLVMValueRef ptr, LLVMValueRef offset);
 
-void genserialise_typeid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
+void genserialise_serialiseid(compile_t* c, reach_type_t* t, LLVMValueRef offset);
 
-void gendeserialise_typeid(compile_t* c, compile_type_t* t, LLVMValueRef offset);
+void gendeserialise_serialiseid(compile_t* c, compile_type_t* t, LLVMValueRef offset);
 
 void gendeserialise_element(compile_t* c, reach_type_t* t, bool embed,
   LLVMValueRef ctx, LLVMValueRef ptr);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -744,6 +744,7 @@ bool gentypes(compile_t* c)
   }
 
   gendesc_table(c);
+  gendesc_table_lookup(c);
 
   c->numeric_sizes = gen_numeric_size_table(c);
 

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -313,6 +313,7 @@ typedef struct pass_opt_t
   char* abi;
   char* cpu;
   char* features;
+  unsigned char* serialise_id_hash_key;
 
   typecheck_t check;
 

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -1430,6 +1430,7 @@ static pony_type_t package_dep_signature_pony =
   sizeof(package_signature_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   package_dep_signature_serialise_trace,
@@ -1457,6 +1458,7 @@ static pony_type_t package_signature_pony =
 {
   0,
   sizeof(package_signature_t),
+  0,
   0,
   0,
   NULL,
@@ -1537,6 +1539,7 @@ static pony_type_t package_group_dep_signature_pony =
   sizeof(const char*),
   0,
   0,
+  0,
   NULL,
   NULL,
   package_group_dep_signature_serialise_trace,
@@ -1564,6 +1567,7 @@ static pony_type_t package_group_signature_pony =
 {
   0,
   sizeof(const char*),
+  0,
   0,
   0,
   NULL,
@@ -1715,6 +1719,7 @@ static pony_type_t package_pony =
   sizeof(package_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   package_serialise_trace,
@@ -1786,6 +1791,7 @@ static pony_type_t package_group_pony =
 {
   0,
   sizeof(package_group_t),
+  0,
   0,
   0,
   NULL,

--- a/src/libponyc/pkg/program.c
+++ b/src/libponyc/pkg/program.c
@@ -425,6 +425,7 @@ static pony_type_t program_pony =
   sizeof(program_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   program_serialise_trace,

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -99,6 +99,7 @@ struct reach_type_t
   reach_type_cache_t subtypes;
   uint32_t type_id;
   uint32_t vtable_size;
+  uint64_t serialise_id;
   bool can_be_boxed;
   bool is_trait;
 

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -561,6 +561,7 @@ static pony_type_t deferred_reification_pony =
   sizeof(deferred_reification_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   deferred_reification_serialise_trace,

--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -9,8 +9,6 @@ static const unsigned char the_key[16] = {
 };
 
 
-#ifdef PLATFORM_IS_ILP32
-
 #define ROTL32(x, b) (uint32_t)(((x) << (b)) | ((x) >> (32 - (b))))
 
 #define SIPROUND32 \
@@ -76,7 +74,6 @@ static uint32_t halfsiphash24(const unsigned char* key, const unsigned char* in,
 
   return v0 ^ v1 ^ v2 ^ v3;
 }
-#endif
 
 #define ROTL64(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 
@@ -147,6 +144,16 @@ PONY_API size_t ponyint_hash_block(const void* p, size_t len)
 PONY_API uint64_t ponyint_hash_block64(const void* p, size_t len)
 {
   return siphash24(the_key, (const unsigned char*)p, len);
+}
+
+uint32_t ponyint_hash_str_custom_key32(const unsigned char* key, const char* str)
+{
+  return halfsiphash24((const unsigned char *)key, (const unsigned char *)str, strlen(str));
+}
+
+uint64_t ponyint_hash_str_custom_key64(const unsigned char* key, const char* str)
+{
+  return siphash24((const unsigned char *)key, (const unsigned char *)str, strlen(str));
 }
 
 size_t ponyint_hash_str(const char* str)

--- a/src/libponyrt/ds/fun.h
+++ b/src/libponyrt/ds/fun.h
@@ -25,6 +25,10 @@ PONY_API size_t ponyint_hash_block(const void* p, size_t len);
 
 PONY_API uint64_t ponyint_hash_block64(const void* p, size_t len);
 
+uint32_t ponyint_hash_str_custom_key32(const unsigned char* key, const char* str);
+
+uint64_t ponyint_hash_str_custom_key64(const unsigned char* key, const char* str);
+
 size_t ponyint_hash_str(const char* str);
 
 size_t ponyint_hash_ptr(const void* p);

--- a/src/libponyrt/ds/hash.h
+++ b/src/libponyrt/ds/hash.h
@@ -251,6 +251,7 @@ void ponyint_hashmap_deserialise(pony_ctx_t* ctx, void* object,
     sizeof(name_t), \
     0, \
     0, \
+    0, \
     NULL, \
     NULL, \
     name##_serialise_trace, \

--- a/src/libponyrt/ds/list.h
+++ b/src/libponyrt/ds/list.h
@@ -167,6 +167,7 @@ void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
     sizeof(name_t), \
     0, \
     0, \
+    0, \
     NULL, \
     NULL, \
     name##_serialise_trace, \

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -1225,6 +1225,7 @@ static pony_type_t cycle_type =
   sizeof(detector_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   NULL,

--- a/src/libponyrt/gc/serialise.c
+++ b/src/libponyrt/gc/serialise.c
@@ -108,7 +108,7 @@ static pony_type_t* get_descriptor(size_t serialise_id)
   uint32_t offset = desc_table_offset_lookup_fn(serialise_id);
 
   // fail even in release builds because this is unrecoverable
-  if(offset >= desc_table_size || offset < 0)
+  if(offset >= desc_table_size)
     ponyint_assert_fail("deserialise offset invalid", __FILE__, __LINE__, __func__);
 
   return desc_table[offset];

--- a/src/libponyrt/gc/serialise.h
+++ b/src/libponyrt/gc/serialise.h
@@ -23,7 +23,8 @@ typedef struct serialise_t serialise_t;
 
 DECLARE_HASHMAP(ponyint_serialise, ponyint_serialise_t, serialise_t);
 
-bool ponyint_serialise_setup(pony_type_t** table, size_t table_size);
+bool ponyint_serialise_setup(pony_type_t** table, size_t table_size,
+  desc_offset_lookup_fn desc_table_offset_lookup);
 
 void ponyint_serialise_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -134,6 +134,7 @@ typedef const struct _pony_type_t
 {
   uint32_t id;
   uint32_t size;
+  size_t serialise_id;
   uint32_t field_count;
   uint32_t field_offset;
   void* instance;
@@ -151,6 +152,12 @@ typedef const struct _pony_type_t
   void* fields;
   void* vtable;
 } pony_type_t;
+
+/** Desc table lookup function.
+ *
+ * A function to convert `serialise_id`s to offsets in the desc table
+ */
+typedef uint32_t (*desc_offset_lookup_fn)(size_t serialise_id);
 
 /** Language feature initialiser.
  *
@@ -178,6 +185,9 @@ typedef struct pony_language_features_init_t
 
   /// The total size of the descriptor_table array.
   size_t descriptor_table_size;
+
+  /// The function to translate `serialise_id`s to offsets in the desc_table
+  desc_offset_lookup_fn desc_table_offset_lookup;
 } pony_language_features_init_t;
 
 /// The currently executing context.

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -334,7 +334,8 @@ PONY_API bool pony_start(bool library, int* exit_code,
 
     if(language_init.init_serialisation &&
       !ponyint_serialise_setup(language_init.descriptor_table,
-        language_init.descriptor_table_size))
+        language_init.descriptor_table_size,
+        language_init.desc_table_offset_lookup))
     {
       atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
       return false;

--- a/test/libponyrt/ds/hash.cc
+++ b/test/libponyrt/ds/hash.cc
@@ -72,6 +72,7 @@ static pony_type_t hash_elem_pony =
   sizeof(hash_elem_t),
   0,
   0,
+  0,
   NULL,
   NULL,
   hash_elem_serialise_trace,


### PR DESCRIPTION
Prior to this commit, serialisation used the `type_id` of the types that it serialised and the `type_id`s assigned to types can vary depending on the program being compiled. This makes it impossible for cross binary serialisation even if the same pony version and types are used.

This commit changes things so that serialisation now uses a determnistically assigned `serialise_id` instead of the `type_id`. This new `serialise_id` is guaranteed to be the same for the same pony version and type (see details for caveats).

The changes include:

* adding a `size_t` size `serialise_id` to `pony_type_t`
* hashes the reach_type_t->name to generate either a 63 bit or 31 bit `serialise_id` depending on target platform
* the hash for the `serialise_id` uses a `key` that is based on the blake2 encoding of the pony version, the target data model, and the endianness (i.e. `pony-0.58.7-ac1c51b69-lp64-le`). This is to ensure that only programs with the same `key` will have the same `serialise_id` to prevent silent data corruption during deserialisation due to subtle differences in platforms. This means that cross binary serialisation will only work for binaries of the same bit width (32 bit vs 64 bit), data model (ilp32, lp64, or llp64), and endianness (big endian or little endian)
* serialisation now uses the `serialise_id` instead of the `type_id`
* deserialisation now uses the `serialise_id` to look up the `type_id` to get the entry in the descriptor table instead of looking up the entry in the descriptor table directly based on `type_id`

---------

yes, this is a ressurrection of https://github.com/ponylang/ponyc/pull/2949