### PR TITLE
Unionize actor heap large and small chunks

### DIFF
--- a/src/libponyrt/mem/heap.h
+++ b/src/libponyrt/mem/heap.h
@@ -15,17 +15,23 @@ PONY_EXTERN_C_BEGIN
 #define HEAP_MIN (1 << HEAP_MINBITS)
 #define HEAP_MAX (1 << HEAP_MAXBITS)
 
+// The number of size classes for recycling. The last size class is for anything bigger than (HEAP_RECYCLE_MIXED_SIZE << (HEAP_RECYCLE_SIZECLASSES = 2))
+#define HEAP_RECYCLE_SIZECLASSES 4
+#define HEAP_RECYCLE_MIXED 0
+#define HEAP_RECYCLE_MIXED_SIZE 1024
+#define HEAP_RECYCLE_LARGE_OVERFLOW (HEAP_RECYCLE_SIZECLASSES - 1)
+
+// check HEAP_RECYCLE_SIZECLASSES size
+pony_static_assert(HEAP_RECYCLE_LARGE_OVERFLOW > HEAP_RECYCLE_MIXED, "Too few HEAP_RECYCLE_SIZECLASSES! There must be at least 2!");
+
 typedef struct chunk_t chunk_t;
-typedef struct small_chunk_t small_chunk_t;
-typedef struct large_chunk_t large_chunk_t;
 
 typedef struct heap_t
 {
-  small_chunk_t* small_free[HEAP_SIZECLASSES];
-  small_chunk_t* small_full[HEAP_SIZECLASSES];
-  large_chunk_t* large;
-  small_chunk_t* small_recyclable;
-  large_chunk_t* large_recyclable;
+  chunk_t* small_free[HEAP_SIZECLASSES];
+  chunk_t* small_full[HEAP_SIZECLASSES];
+  chunk_t* large;
+  chunk_t* recyclable[HEAP_RECYCLE_SIZECLASSES];
 
   size_t used;
   size_t next_gc;

--- a/src/libponyrt/mem/heap_chunk_sorting.h
+++ b/src/libponyrt/mem/heap_chunk_sorting.h
@@ -3,6 +3,9 @@
 
 #include "heap.h"
 
+// declare function defined later in heap.c
+static bool get_chunk_is_small_chunk(chunk_t* chunk);
+
 /*
  * Shamelessly stolen/adapted from Simon Tatham from:
  * https://www.chiark.greenend.org.uk/~sgtatham/algorithms/listsort.c
@@ -30,9 +33,9 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-static large_chunk_t* sort_large_chunk_list_by_size(large_chunk_t *list)
+static chunk_t* sort_large_chunk_list_by_size(chunk_t *list)
 {
-  large_chunk_t *p, *q, *e, *tail;
+  chunk_t *p, *q, *e, *tail;
   int32_t insize, nmerges, psize, qsize, i;
 
   /*
@@ -75,22 +78,31 @@ static large_chunk_t* sort_large_chunk_list_by_size(large_chunk_t *list)
         /* decide whether next element of merge comes from p or q */
         if (psize == 0)
         {
+          pony_assert(!get_chunk_is_small_chunk(q));
+
           /* p is empty; e must come from q. */
           e = q;
           q = q->next;
           qsize--;
         } else if (qsize == 0 || !q) {
+          pony_assert(!get_chunk_is_small_chunk(p));
+
           /* q is empty; e must come from p. */
           e = p;
           p = p->next;
           psize--;
-        } else if (p->size <= q->size) {
+        } else if (p->large.size <= q->large.size) {
+          pony_assert(!get_chunk_is_small_chunk(p));
+          pony_assert(!get_chunk_is_small_chunk(q));
+
           /* First element of p is lower (or same);
           * e must come from p. */
           e = p;
           p = p->next;
           psize--;
         } else {
+          pony_assert(!get_chunk_is_small_chunk(q));
+
           /* First element of q is lower; e must come from q. */
           e = q;
           q = q->next;

--- a/test/libponyrt/mem/heap.cc
+++ b/test/libponyrt/mem/heap.cc
@@ -7,11 +7,9 @@
 
 #include <gtest/gtest.h>
 
-#define SMALL_CHUNK_T_SIZE 32
-#define SMALL_CHUNK_T_ALLOC 32
+#define CHUNK_T_SIZE 32
+#define CHUNK_T_ALLOC 32
 #define SMALL_CHUNK_BLOCK_SIZE 1024
-#define LARGE_CHUNK_T_SIZE 24
-#define LARGE_CHUNK_T_ALLOC 32
 
 TEST(Heap, Init)
 {
@@ -32,8 +30,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)1, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)0, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(128 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(128 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   pony_actor_t* pagemap_actor = NULL;
@@ -51,8 +49,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)2, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)0, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(256 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(256 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   heap.next_gc = 0;
@@ -78,8 +76,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)2, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(128 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(128 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   void* p3 = ponyint_heap_alloc(actor, &heap, 107, TRACK_NO_FINALISERS);
@@ -89,8 +87,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)3, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(256 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(256 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   ponyint_heap_used(&heap, 1024);
@@ -100,8 +98,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)3, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(256 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(256 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   heap.next_gc = 0;
@@ -126,8 +124,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)3, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(128 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(128 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   void* p4 = ponyint_heap_alloc(actor, &heap, 67, TRACK_NO_FINALISERS);
@@ -137,8 +135,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)4, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(256 + SMALL_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(256 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE), actor->actorstats.heap_mem_allocated);
 #endif
 
   size_t large_size = (1 << 22) - 7;
@@ -150,8 +148,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)5, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)3, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)2, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(256 + SMALL_CHUNK_T_SIZE + 4194304 + LARGE_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(SMALL_CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE + 4194304 + LARGE_CHUNK_T_ALLOC), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(256 + CHUNK_T_SIZE + 4194304 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(CHUNK_T_ALLOC + SMALL_CHUNK_BLOCK_SIZE + 4194304 + CHUNK_T_ALLOC), actor->actorstats.heap_mem_allocated);
 #endif
 
   size_t adjust_size = ponyint_pool_adjust_size(large_size);
@@ -198,8 +196,8 @@ TEST(Heap, Init)
   ASSERT_EQ((size_t)5, actor->actorstats.heap_alloc_counter);
   ASSERT_EQ((size_t)1, actor->actorstats.heap_num_allocated);
   ASSERT_EQ((size_t)4, actor->actorstats.heap_free_counter);
-  ASSERT_EQ((size_t)(4194304 + LARGE_CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
-  ASSERT_EQ((size_t)(4194304 + LARGE_CHUNK_T_ALLOC), actor->actorstats.heap_mem_allocated);
+  ASSERT_EQ((size_t)(4194304 + CHUNK_T_SIZE), actor->actorstats.heap_mem_used);
+  ASSERT_EQ((size_t)(4194304 + CHUNK_T_ALLOC), actor->actorstats.heap_mem_allocated);
 #endif
 
   ponyint_heap_destroy(&heap);


### PR DESCRIPTION
So they can better fight for their rights..

Prior to this commit, small_chunk_t and large_chunk_t were distinct types. This was great for correctness but prevented a useful optimization.

This commit changes things so that small_chunk_t and large_chunk_t have been combined into chunk_t which has a union in it for the small/large chunk specific fields. There are now a lot of assertions added in the relevant functions that deal with small and large chunks to ensure that the received chunk is of the right type because the compiler can no longer help enforce correctness.

This allows for small and large chunk recycling to take advantage of the fact that the block backing a small chunk is the same size as the block backing the smallest large chunk size allowed so they both now use the same recycled chunk list.

The large chunk recycling has also been enhanced to take advantage of the long tail distribution of allocation sizes and there are now multiple size specific chunk lists for large chunk recycling with one extra large chunk list for recycling that has all chunks bigger than the largest size specific list that is kept sorted and searched/used as the old large chunk recycling list was.