### PR TITLE
Change stack_depth_t to size_t on OpenBSD

### DIFF
--- a/.release-notes/4575.md
+++ b/.release-notes/4575.md
@@ -1,0 +1,5 @@
+## Change stack_depth_t to size_t on OpenBSD
+
+The definition of stack_depth_t was changed from int to size_t to support compiling on OpenBSD 7.6.
+
+ponyc may not be compilable on earlier versions of OpenBSD.

--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -20,7 +20,7 @@ static PONY_ATOMIC_INIT(bool, assert_guard, false);
 
 #ifdef PLATFORM_IS_POSIX_BASED
 
-#if defined(PLATFORM_IS_BSD) && !defined(PLATFORM_IS_OPENBSD)
+#if defined(PLATFORM_IS_BSD)
 typedef size_t stack_depth_t;
 #else
 typedef int stack_depth_t;


### PR DESCRIPTION
I'm not sure when OpenBSD made this change, but on OpenBSD 7.6, `backtrace` returns a `size_t`. Prior to this change, building pony fails with

```sh
/home/despereaux/build/ponyc/src/libponyrt/platform/ponyassert.c:45:25: error: implicit conversion loses i
nteger precision: 'size_t' (aka 'unsigned long') to 'stack_depth_t' (aka 'int') [-Werror,-Wshorten-64-to-3
2]
  stack_depth_t depth = backtrace(addrs, 256);
                ~~~~~   ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
*** Error 1 in target 'src/libponyrt/CMakeFiles/libponyrt.dir/platform/ponyassert.c.o'
*** Error 1 in . (src/libponyrt/CMakeFiles/libponyrt.dir/build.make:612 'src/libponyrt/CMakeFiles/libponyr
t.dir/platform/ponyassert.c.o': cd...)
*** Error 2 in . (CMakeFiles/Makefile2:371 'src/libponyrt/CMakeFiles/libponyrt.dir/all')
*** Error 2 in /home/despereaux/build/ponyc/build/build_release (Makefile:136 'all': /usr/bin/make -s -f C
MakeFiles/Makefile2 all)
gmake: *** [Makefile:192: build] Error 2
```