### PR TITLE
Fix possible null dereference

### DIFF
--- a/src/libponyc/type/compattype.c
+++ b/src/libponyc/type/compattype.c
@@ -46,7 +46,7 @@ static bool is_arrow_compat_nominal(ast_t* a, ast_t* b)
   // T1->T2 ~ N k
   ast_t* a_lower = viewpoint_lower(a);
 
-  if(a == NULL)
+  if(a_lower == NULL)
     return false;
 
   bool ok = is_compat_type(a_lower, b);


### PR DESCRIPTION
The return value of the function ```viewpoint_lower()``` is always checked for NULL.
On the other hand, the check ```if(a == NULL)``` was meaningless because the pointer ```a``` was previously dereferenced in ```viewpoint_lower(a)```.
Looks like it was a typo.