### PR TITLE
Apply default options for a CLI parent command when a sub command is parsed

### DIFF
--- a/.release-notes/4593.md
+++ b/.release-notes/4593.md
@@ -1,0 +1,3 @@
+## Apply default options for a CLI parent command when a sub command is parsed
+
+In the CLI package's parser, a default option for a parent command was ignored when a subcommand was present. This fix makes sure that parents' defaults are applied before handling the sub command.

--- a/packages/cli/_test.pony
+++ b/packages/cli/_test.pony
@@ -10,6 +10,7 @@ actor \nodoc\ Main is TestList
     test(_TestBools)
     test(_TestChat)
     test(_TestDefaults)
+    test(_TestDefaultWithSub)
     test(_TestDuplicate)
     test(_TestEnvs)
     test(_TestHelp)
@@ -237,6 +238,17 @@ class \nodoc\ iso _TestDefaults is UnitTest
     h.assert_eq[U64](47, cmd.option("uinto").u64())
     h.assert_eq[F64](42.0, cmd.option("floato").f64())
     h.assert_eq[USize](0, cmd.option("stringso").string_seq().size())
+
+class \nodoc\ iso _TestDefaultWithSub is UnitTest
+  fun name(): String => "cli/default_with_sub"
+
+  fun apply(h: TestHelper) ? =>
+    let cs = _Fixtures.default_with_sub_spec()?
+    h.assert_true(cs.is_parent())
+
+    let cmd = CommandParser(cs).parse([ "cmd"; "sub" ]) as Command
+
+    h.assert_eq[String]("foo", cmd.option("arg").string())
 
 class \nodoc\ iso _TestShortsAdj is UnitTest
   fun name(): String => "cli/shorts_adjacent"
@@ -668,3 +680,14 @@ primitive _Fixtures
           ArgSpec.string_seq("args", "Arguments to run.")
         ])?
     ])?
+
+  fun default_with_sub_spec(): CommandSpec box ? =>
+    let root = CommandSpec.parent(
+      "cmd",
+      "Main command",
+      [ OptionSpec.string("arg", "an arg" where default' = "foo") ])?
+    let sub = CommandSpec.leaf("sub", "Sub command")?
+
+    root.add_command(sub)?
+    root.add_help()?
+    root


### PR DESCRIPTION
Prior to this fix, parsing a sub-command proceeded before assigning defaults to the parent's options.  This fix factors out the default processing so it can occur before parsing a sub command.

Fixes #4580 