### PR TITLE
ubsan: fix "call to function through pointer to incorrect function type"

### DIFF
--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -28,25 +28,13 @@
   (void)c_m;
 
 #define BOX_FUNCTION(gen, gen_data) \
-  box_function(c, gen, gen_data);
-
-#define BOX_VOID_FUNCTION(gen, gen_data) \
-  box_void_function(c, gen, gen_data);
-
-#define BOX_VOIDPTR_FUNCTION(gen, gen_data) \
-  box_voidptr_function(c, gen, gen_data);
-
-#define BOX_NUMCONV_FUNCTION(gen, gen_data) \
-  box_numconv_function(c, gen, gen_data);
+  gen(c, gen_data, TK_BOX); \
+  gen(c, gen_data, TK_REF); \
+  gen(c, gen_data, TK_VAL);
 
 #define GENERIC_FUNCTION(name, gen) \
   generic_function(c, t, stringtab(name), gen);
 
-typedef struct num_conv_t num_conv_t;
-typedef void (*generate_box_fn)(compile_t*, reach_type_t*, token_id);
-typedef void (*generate_box_void_fn)(compile_t*, void*, token_id);
-typedef void (*generate_box_voidptr_fn)(compile_t*, void**, token_id);
-typedef void (*generate_box_numconv_fn)(compile_t*, num_conv_t*, token_id);
 typedef void (*generate_gen_fn)(compile_t*, reach_type_t*, reach_method_t*);
 
 static void start_function(compile_t* c, reach_type_t* t, reach_method_t* m,
@@ -57,34 +45,6 @@ static void start_function(compile_t* c, reach_type_t* t, reach_method_t* m,
   c_m->func = codegen_addfun(c, m->full_name, c_m->func_type, true);
   genfun_param_attrs(c, t, m, c_m->func);
   codegen_startfun(c, c_m->func, NULL, NULL, NULL, false);
-}
-
-static void box_function(compile_t* c, generate_box_fn gen, void* gen_data)
-{
-  gen(c, gen_data, TK_BOX);
-  gen(c, gen_data, TK_REF);
-  gen(c, gen_data, TK_VAL);
-}
-
-static void box_void_function(compile_t* c, generate_box_void_fn gen, void* gen_data)
-{
-  gen(c, gen_data, TK_BOX);
-  gen(c, gen_data, TK_REF);
-  gen(c, gen_data, TK_VAL);
-}
-
-static void box_voidptr_function(compile_t* c, generate_box_voidptr_fn gen, void* gen_data)
-{
-  gen(c, gen_data, TK_BOX);
-  gen(c, gen_data, TK_REF);
-  gen(c, gen_data, TK_VAL);
-}
-
-static void box_numconv_function(compile_t* c, generate_box_numconv_fn gen, void* gen_data)
-{
-  gen(c, gen_data, TK_BOX);
-  gen(c, gen_data, TK_REF);
-  gen(c, gen_data, TK_VAL);
 }
 
 static void generic_function(compile_t* c, reach_type_t* t, const char* name,
@@ -495,13 +455,13 @@ void genprim_pointer_methods(compile_t* c, reach_type_t* t)
   pointer_realloc(c, t, c_t_elem);
   pointer_unsafe(c, t);
   GENERIC_FUNCTION("_convert", pointer_convert);
-  BOX_VOID_FUNCTION(pointer_apply, box_args);
+  BOX_FUNCTION(pointer_apply, box_args);
   pointer_update(c, t, t_elem);
-  BOX_VOID_FUNCTION(pointer_offset, c_box_args);
+  BOX_FUNCTION(pointer_offset, c_box_args);
   pointer_element_size(c, t, c_t_elem);
   pointer_insert(c, t, c_t_elem);
   pointer_delete(c, t, t_elem);
-  BOX_VOID_FUNCTION(pointer_copy_to, c_box_args);
+  BOX_FUNCTION(pointer_copy_to, c_box_args);
   pointer_usize(c, t);
   pointer_is_null(c, t);
   pointer_eq(c, t);
@@ -581,7 +541,7 @@ void genprim_nullable_pointer_methods(compile_t* c, reach_type_t* t)
 
   nullable_pointer_create(c, t, t_elem);
   nullable_pointer_none(c, t);
-  BOX_VOID_FUNCTION(nullable_pointer_apply, box_args);
+  BOX_FUNCTION(nullable_pointer_apply, box_args);
   BOX_FUNCTION(nullable_pointer_is_none, t);
 }
 
@@ -1805,13 +1765,13 @@ static void number_conversions(compile_t* c)
 
   for(num_conv_t* from = conv; from->type_name != NULL; from++)
   {
-    BOX_NUMCONV_FUNCTION(number_value, from);
+    BOX_FUNCTION(number_value, from);
     data[0] = from;
     for(num_conv_t* to = conv; to->type_name != NULL; to++)
     {
       data[1] = to;
-      BOX_VOIDPTR_FUNCTION(number_conversion, data);
-      BOX_VOIDPTR_FUNCTION(unsafe_number_conversion, data);
+      BOX_FUNCTION(number_conversion, data);
+      BOX_FUNCTION(unsafe_number_conversion, data);
     }
   }
 }

--- a/src/libponyrt/ds/hash.h
+++ b/src/libponyrt/ds/hash.h
@@ -160,43 +160,48 @@ void ponyint_hashmap_deserialise(pony_ctx_t* ctx, void* object,
   typedef bool (*name##_cmp_fn)(type* a, type* b); \
   typedef void (*name##_free_fn)(type* a); \
   \
+  static void name##_freef(void* data) \
+  { \
+    name##_free_fn freef = free_elem; \
+    freef((type*)data); \
+  } \
+  static bool name##_cmpf(void* a, void* b) \
+  { \
+    name##_cmp_fn cmpf = cmp; \
+    return cmpf((type*)a, (type*)b); \
+  } \
   void name##_init(name_t* map, size_t size) \
   { \
     ponyint_hashmap_init((hashmap_t*)map, size); \
   } \
   void name##_destroy(name_t* map) \
   { \
-    name##_free_fn freef = free_elem; \
-    ponyint_hashmap_destroy((hashmap_t*)map, (free_fn)freef); \
+    free_fn free_f = free_elem?name##_freef:NULL; \
+    ponyint_hashmap_destroy((hashmap_t*)map, free_f); \
   } \
   void name##_optimize(name_t* map) \
   { \
-    name##_cmp_fn cmpf = cmp; \
-    return ponyint_hashmap_optimize((hashmap_t*)map, (cmp_fn)cmpf); \
+    return ponyint_hashmap_optimize((hashmap_t*)map, name##_cmpf); \
   } \
   type* name##_get(name_t* map, type* key, size_t* index) \
   { \
-    name##_cmp_fn cmpf = cmp; \
     return (type*)ponyint_hashmap_get((hashmap_t*)map, (void*)key, \
-      hash(key), (cmp_fn)cmpf, index); \
+      hash(key), name##_cmpf, index); \
   } \
   type* name##_put(name_t* map, type* entry) \
   { \
-    name##_cmp_fn cmpf = cmp; \
     return (type*)ponyint_hashmap_put((hashmap_t*)map, (void*)entry, \
-      hash(entry), (cmp_fn)cmpf); \
+      hash(entry), name##_cmpf); \
   } \
   void name##_putindex(name_t* map, type* entry, size_t index) \
   { \
-    name##_cmp_fn cmpf = cmp; \
     ponyint_hashmap_putindex((hashmap_t*)map, (void*)entry, \
-      hash(entry), (cmp_fn)cmpf, index); \
+      hash(entry), name##_cmpf, index); \
   } \
   type* name##_remove(name_t* map, type* entry) \
   { \
-    name##_cmp_fn cmpf = cmp; \
     return (type*)ponyint_hashmap_remove((hashmap_t*) map, (void*)entry, \
-      hash(entry), (cmp_fn)cmpf); \
+      hash(entry), name##_cmpf); \
   } \
   void name##_removeindex(name_t* map, size_t index) \
   { \

--- a/src/libponyrt/ds/hash.h
+++ b/src/libponyrt/ds/hash.h
@@ -176,7 +176,9 @@ void ponyint_hashmap_deserialise(pony_ctx_t* ctx, void* object,
   } \
   void name##_destroy(name_t* map) \
   { \
-    free_fn free_f = free_elem?name##_freef:NULL; \
+    free_fn free_f = NULL; \
+    if (free_elem != NULL) \
+      free_f = name##_freef; \
     ponyint_hashmap_destroy((hashmap_t*)map, free_f); \
   } \
   void name##_optimize(name_t* map) \

--- a/src/libponyrt/ds/list.h
+++ b/src/libponyrt/ds/list.h
@@ -147,7 +147,9 @@ void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
   } \
   void name##_free(name_t* list) \
   { \
-    free_fn free_fn = freef?name##_freef:NULL; \
+    free_fn free_fn = NULL; \
+    if (freef != NULL) \
+      free_fn = name##_freef; \
     ponyint_list_free((list_t*)list, free_fn); \
   } \
 

--- a/src/libponyrt/ds/list.h
+++ b/src/libponyrt/ds/list.h
@@ -83,6 +83,16 @@ void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
 #define DEFINE_LIST(name, name_t, elem, cmpf, freef) \
   struct name_t {list_t contents;}; \
   \
+  static void name##_freef(void* data) \
+  { \
+    name##_free_fn freefn = freef; \
+    freefn((elem*)data); \
+  } \
+  static bool name##_cmpf(void* a, void* b) \
+  { \
+    name##_cmp_fn cmpfn = cmpf; \
+    return cmpfn((elem*)a, (elem*)b); \
+  } \
   name_t* name##_pop(name_t* list, elem** data) \
   { \
     return (name_t*)ponyint_list_pop((list_t*)list, (void**)data); \
@@ -109,23 +119,19 @@ void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
   } \
   elem* name##_find(name_t* list, elem* data) \
   { \
-    name##_cmp_fn cmp = cmpf; \
-    return (elem*)ponyint_list_find((list_t*)list, (cmp_fn)cmp, (void*)data); \
+    return (elem*)ponyint_list_find((list_t*)list, name##_cmpf, (void*)data); \
   } \
   ssize_t name##_findindex(name_t* list, elem* data) \
   { \
-    name##_cmp_fn cmp = cmpf; \
-    return ponyint_list_findindex((list_t*)list, (cmp_fn)cmp, (void*)data); \
+    return ponyint_list_findindex((list_t*)list, name##_cmpf, (void*)data); \
   } \
   bool name##_subset(name_t* a, name_t* b) \
   { \
-    name##_cmp_fn cmp = cmpf; \
-    return ponyint_list_subset((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
+    return ponyint_list_subset((list_t*)a, (list_t*)b, name##_cmpf); \
   } \
   bool name##_equals(name_t* a, name_t* b) \
   { \
-    name##_cmp_fn cmp = cmpf; \
-    return ponyint_list_equals((list_t*)a, (list_t*)b, (cmp_fn)cmp); \
+    return ponyint_list_equals((list_t*)a, (list_t*)b, name##_cmpf); \
   } \
   name_t* name##_map(name_t* list, name##_map_fn f, void* arg) \
   { \
@@ -141,8 +147,8 @@ void ponyint_list_deserialise(pony_ctx_t* ctx, void* object,
   } \
   void name##_free(name_t* list) \
   { \
-    name##_free_fn free = freef; \
-    ponyint_list_free((list_t*)list, (free_fn)free); \
+    free_fn free_fn = freef?name##_freef:NULL; \
+    ponyint_list_free((list_t*)list, free_fn); \
   } \
 
 #define DEFINE_LIST_SERIALISE(name, name_t, elem, cmpf, freef, elem_type) \


### PR DESCRIPTION
ubsan doesn't like call's through function pointers of incorrect function types. This is used in both hash/list stuff along with in genprim. This commit fixes things to make ubsan happy.

Makes ubsan runtime errors such as the following go away:

`runtime error: call to function flag_free through pointer to incorrect function type 'void (*)(void *)'`