### PR TITLE
ubsan: fix buildflagset "applying non-zero offset to null pointer"

### DIFF
--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -146,8 +146,9 @@ buildflagset_t* buildflagset_create()
   p->started_enum = false;
   p->flags = POOL_ALLOC(flagtab_t);
   flagtab_init(p->flags, 8);
-  p->text_buffer = NULL;
-  p->buffer_size = 0;
+  p->text_buffer = (char*)ponyint_pool_alloc_size(1);
+  p->buffer_size = 1;
+  p->text_buffer[0] = '\0';
 
   return p;
 }


### PR DESCRIPTION
ubsan doesn't like that buildflagset adds offsets to null pointers. This commit fixes things to ensure that buildflagset always has a valid text buffer to work with.

Makes ubsan runtime errors such as the following go away:

`runtime error: applying non-zero offset 11 to null pointer`