### PR TITLE
Fix unaligned read in fun.c siphash

### DIFF
--- a/src/libponyrt/ds/fun.c
+++ b/src/libponyrt/ds/fun.c
@@ -48,7 +48,8 @@ static uint32_t halfsiphash24(const unsigned char* key, const unsigned char* in,
 
   for (; in != end; in += 4)
   {
-    uint32_t m = *(uint32_t*)in;
+    uint32_t m;
+    memcpy(&m, in, sizeof(uint32_t));
     v3 ^= m;
     SIPROUND32;
     SIPROUND32;
@@ -101,7 +102,8 @@ static uint64_t siphash24(const unsigned char* key, const unsigned char* in, siz
 
   for(; in != end; in += 8)
   {
-    uint64_t m = *(uint64_t*)in;
+    uint64_t m;
+    memcpy(&m, in, sizeof(uint64_t));
     v3 ^= m;
     SIPROUND64;
     SIPROUND64;


### PR DESCRIPTION
ubsan doesn't like it when unaligned reads happen. this commit fixes things to make ubsan happy.

NOTE: fix uses `memcpy` which at least some compilers optimize well.
See: https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html

Makes ubsan runtime errors such as the following go away:

`runtime error: load of misaligned address 0xb2af29174143 for type 'uint64_t' (aka 'unsigned long'), which requires 8 byte alignment`