### PR TITLE
Print more informative message and backtrace on out of memory error

### DIFF
--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -49,7 +49,8 @@ void* ponyint_virt_alloc(size_t bytes)
 
   if(!ok)
   {
-    fprintf(stderr, "out of memory trying to allocate %zu bytes: %s\n", bytes, strerror(errno));
+    perror("out of memory: "); // print this first without allocating memory - fprintf might allocate
+    fprintf(stderr, "(tried to allocate %zu bytes)\n", bytes);
     pony_assert(0);
     abort();
   }

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -4,6 +4,7 @@
 #include <platform.h>
 #include <string.h>
 #include <stdio.h>
+#include "ponyassert.h"
 
 #ifdef PLATFORM_IS_POSIX_BASED
 #include <sys/mman.h>
@@ -48,8 +49,8 @@ void* ponyint_virt_alloc(size_t bytes)
 
   if(!ok)
   {
-    perror("out of memory: ");
-    abort();
+    fprintf(stderr, "out of memory trying to allocate %zu bytes: %s\n", bytes, strerror(errno));
+    pony_assert(bytes < 0);
   }
 
   return p;

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -50,7 +50,7 @@ void* ponyint_virt_alloc(size_t bytes)
   if(!ok)
   {
     fprintf(stderr, "out of memory trying to allocate %zu bytes: %s\n", bytes, strerror(errno));
-    pony_assert(bytes < 0);
+    pony_assert(0);
   }
 
   return p;

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -51,6 +51,7 @@ void* ponyint_virt_alloc(size_t bytes)
   {
     fprintf(stderr, "out of memory trying to allocate %zu bytes: %s\n", bytes, strerror(errno));
     pony_assert(0);
+    abort();
   }
 
   return p;


### PR DESCRIPTION
Before:

```
out of memory: Cannot allocate memory
```

After:

```
out of memory trying to allocate 18446744073709551615 bytes: Cannot allocate memory
/workspaces/ponyc/src/libponyrt/mem/alloc.c:53: ponyint_virt_alloc: Assertion `bytes < 0` failed.

Backtrace:
  ./ponyc(ponyint_assert_fail+0xb8) [0xc4de3bb213d4]
  ./ponyc(ponyint_virt_alloc+0xcc) [0xc4de3bb2d30c]
  ./ponyc(+0x20a1c) [0xc4de3bb20a1c]
  ./ponyc(+0x20198) [0xc4de3bb20198]
  ./ponyc(ponyint_pool_alloc_size+0x50) [0xc4de3bb2009c]
  ./ponyc(ponyint_heap_alloc_large+0x2d8) [0xc4de3bb1d1d0]
  ./ponyc(ponyint_heap_alloc+0xcc) [0xc4de3bb1cc00]
  ./ponyc(pony_alloc+0x74) [0xc4de3bb13044]
  ./ponyc(Pointer_U8_val_ref__alloc_Zo+0x14) [0xc4de3bb107b0]
  ./ponyc(String_ref_create_Zo+0x40) [0xc4de3bb0f3e4]
  ./ponyc(String_val_repeat_str_Zoo+0x6c) [0xc4de3bb0efd8]
  ./ponyc(String_val_mul_Zo+0x18) [0xc4de3bb0f0ec]
  ./ponyc(Main_tag_create_oo+0x38) [0xc4de3bb0eccc]
  ./ponyc(Main_Dispatch+0x44) [0xc4de3bb0e34c]
  ./ponyc(+0x12100) [0xc4de3bb12100]
  ./ponyc(ponyint_actor_run+0xe4) [0xc4de3bb116c8]
  ./ponyc(+0x231e4) [0xc4de3bb231e4]
  ./ponyc(+0x22438) [0xc4de3bb22438]
  /lib/aarch64-linux-gnu/libc.so.6(+0x8597c) [0xec2b035d597c]
  /lib/aarch64-linux-gnu/libc.so.6(+0xeba4c) [0xec2b0363ba4c]
Aborted
```