### PR TITLE
Make cycle detector test less likely to time out

### DIFF
--- a/test/full-program-tests/cycle-detector/main.pony
+++ b/test/full-program-tests/cycle-detector/main.pony
@@ -65,8 +65,8 @@ class WatcherWaker is TimerNotify
     true
 
 actor Main
-  var _ring_size: U32 = 100
-  var _ring_count: U32 = 100
+  var _ring_size: U32 = 10
+  var _ring_count: U32 = 10
   var _pass: USize = 10
 
   new create(env: Env) =>


### PR DESCRIPTION
by decreasing the size and number of rings that need to be collected