### PR TITLE
Resurrect pony_always_assert and decouple it from pony_ndebug

### DIFF
--- a/src/common/ponyassert.h
+++ b/src/common/ponyassert.h
@@ -5,11 +5,11 @@
 
 PONY_EXTERN_C_BEGIN
 
-#if !defined(PONY_NDEBUG) && !defined(PONY_ALWAYS_ASSERT) && defined(NDEBUG)
+#if !defined(PONY_NDEBUG) && defined(NDEBUG)
 #  define PONY_NDEBUG
 #endif
 
-#if defined(PONY_NDEBUG)
+#if defined(PONY_NDEBUG) && !defined(PONY_ALWAYS_ASSERT)
 #  define pony_assert(expr) ((void)0)
 #else
 #  define pony_assert(expr) \

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -98,6 +98,10 @@ add_library(libponyc STATIC
     verify/type.c
 )
 
+target_compile_definitions(libponyc PRIVATE
+    PONY_ALWAYS_ASSERT
+)
+
 target_include_directories(libponyc
     PUBLIC ../common
     PRIVATE ../../build/libs/include

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -329,7 +329,9 @@ static bool hasparent(ast_t* ast)
 static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast->parent = parent;
   ast_clearflag(ast, AST_ORPHAN);
@@ -339,7 +341,9 @@ static void set_scope_and_parent(ast_t* ast, ast_t* parent)
 static void set_scope_no_parent(ast_t* ast, ast_t* scope)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast->parent = scope;
   ast_setflag(ast, AST_ORPHAN);
@@ -349,7 +353,9 @@ static void set_scope_no_parent(ast_t* ast, ast_t* scope)
 static void make_orphan_leave_scope(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast_setflag(ast, AST_ORPHAN);
 }
@@ -530,7 +536,9 @@ ast_t* ast_dup_partial(ast_t* ast, bool* dup_child, bool dup_type,
 void ast_scope(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast->symtab = symtab_new();
 }
 
@@ -543,7 +551,9 @@ bool ast_has_scope(ast_t* ast)
 void ast_set_scope(ast_t* ast, ast_t* scope)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   pony_assert(!hasparent(ast));
   set_scope_no_parent(ast, scope);
 }
@@ -553,14 +563,18 @@ symtab_t* ast_get_symtab(ast_t* ast)
   pony_assert(ast != NULL);
   // Allowing direct access to the symtab includes write access, so we forbid
   // any direct access if the AST is immutable.
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   return ast->symtab;
 }
 
 ast_t* ast_setid(ast_t* ast, token_id id)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   token_set_id(ast->t, id);
   return ast;
 }
@@ -568,7 +582,9 @@ ast_t* ast_setid(ast_t* ast, token_id id)
 void ast_setpos(ast_t* ast, source_t* source, size_t line, size_t pos)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   token_set_pos(ast->t, source, line, pos);
 }
 
@@ -607,7 +623,9 @@ void* ast_data(ast_t* ast)
 ast_t* ast_setdata(ast_t* ast, void* data)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast->data = data;
   return ast;
 }
@@ -621,7 +639,9 @@ bool ast_canerror(ast_t* ast)
 void ast_seterror(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast_setflag(ast, AST_FLAG_CAN_ERROR);
 }
 
@@ -634,7 +654,9 @@ bool ast_cansend(ast_t* ast)
 void ast_setsend(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast_setflag(ast, AST_FLAG_CAN_SEND);
 }
 
@@ -647,21 +669,27 @@ bool ast_mightsend(ast_t* ast)
 void ast_setmightsend(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast_setflag(ast, AST_FLAG_MIGHT_SEND);
 }
 
 void ast_clearmightsend(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast_clearflag(ast, AST_FLAG_MIGHT_SEND);
 }
 
 void ast_inheritflags(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   for(ast_t* child = ast->child; child != NULL; child = ast_sibling(child))
     ast_setflag(ast, child->flags & AST_INHERIT_FLAGS);
@@ -679,7 +707,9 @@ void ast_setflag(ast_t* ast, uint32_t flag)
 {
   pony_assert(ast != NULL);
   pony_assert((flag & AST_ALL_FLAGS) == flag);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast->flags |= flag;
 }
@@ -688,7 +718,9 @@ void ast_clearflag(ast_t* ast, uint32_t flag)
 {
   pony_assert(ast != NULL);
   pony_assert((flag & AST_ALL_FLAGS) == flag);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast->flags &= ~flag;
 }
@@ -700,7 +732,9 @@ void ast_resetpass(ast_t* ast, uint32_t flag)
   if(ast == NULL)
     return;
 
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   if(ast_checkflag(ast, AST_FLAG_PRESERVE))
     return;
@@ -747,7 +781,9 @@ size_t ast_name_len(ast_t* ast)
 void ast_set_name(ast_t* ast, const char* name)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   token_set_string(ast->t, name, 0);
 }
 
@@ -783,7 +819,9 @@ ast_t* ast_type(ast_t* ast)
 static void settype(ast_t* ast, ast_t* type, bool allow_free)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   // An annotation may never have a type.
   if(ast_id(ast) == TK_ANNOTATION)
@@ -839,7 +877,9 @@ ast_t* ast_annotation(ast_t* ast)
 void setannotation(ast_t* ast, ast_t* annotation, bool allow_free)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   // An annotation may never be annotated.
   if(ast_id(ast) == TK_ANNOTATION)
@@ -920,7 +960,9 @@ bool ast_has_annotation(ast_t* ast, const char* name)
 void ast_erase(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast_t* child = ast->child;
 
@@ -1133,7 +1175,9 @@ bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
   while(ast->symtab == NULL)
     ast = ast->parent;
 
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   ast_t* find;
 
   if(allow_shadowing)
@@ -1162,7 +1206,9 @@ void ast_setstatus(ast_t* ast, const char* name, sym_status_t status)
   while(ast->symtab == NULL)
     ast = ast->parent;
 
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
   symtab_set_status(ast->symtab, name, status);
 }
 
@@ -1176,7 +1222,9 @@ void ast_inheritstatus(ast_t* dst, ast_t* src)
   while(dst->symtab == NULL)
     dst = dst->parent;
 
+#ifndef PONY_NDEBUG
   pony_assert(!dst->frozen);
+#endif
   symtab_inherit_status(dst->symtab, src->symtab);
 }
 
@@ -1195,7 +1243,9 @@ void ast_consolidate_branches(ast_t* ast, size_t count)
   pony_assert(ast != NULL);
   pony_assert(hasparent(ast));
   pony_assert(ast->symtab != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
@@ -1241,7 +1291,9 @@ bool ast_merge(ast_t* dst, ast_t* src)
   while(dst->symtab == NULL)
     dst = dst->parent;
 
+#ifndef PONY_NDEBUG
   pony_assert(!dst->frozen);
+#endif
   return symtab_merge_public(dst->symtab, src->symtab);
 }
 
@@ -1320,7 +1372,9 @@ bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner, errorframe_t* errorf)
 void ast_clear(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   if(ast->symtab != NULL)
   {
@@ -1340,7 +1394,9 @@ void ast_clear(ast_t* ast)
 void ast_clear_local(ast_t* ast)
 {
   pony_assert(ast != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   if(ast->symtab != NULL)
   {
@@ -1354,12 +1410,16 @@ ast_t* ast_add(ast_t* parent, ast_t* child)
   pony_assert(parent != NULL);
   pony_assert(parent != child);
   pony_assert(parent->child != child);
+#ifndef PONY_NDEBUG
   pony_assert(!parent->frozen);
+#endif
 
   if(hasparent(child))
     child = ast_dup(child);
+#ifndef PONY_NDEBUG
   else
     pony_assert(!child->frozen);
+#endif
 
   set_scope_and_parent(child, parent);
   child->sibling = parent->child;
@@ -1373,12 +1433,16 @@ ast_t* ast_add_sibling(ast_t* older_sibling, ast_t* new_sibling)
   pony_assert(new_sibling != NULL);
   pony_assert(older_sibling != new_sibling);
   pony_assert(hasparent(older_sibling));
+#ifndef PONY_NDEBUG
   pony_assert(!older_sibling->parent->frozen);
+#endif
 
   if(hasparent(new_sibling))
     new_sibling = ast_dup(new_sibling);
+#ifndef PONY_NDEBUG
   else
     pony_assert(!new_sibling->frozen);
+#endif
 
   pony_assert(new_sibling->sibling == NULL);
 
@@ -1391,7 +1455,9 @@ ast_t* ast_add_sibling(ast_t* older_sibling, ast_t* new_sibling)
 ast_t* ast_pop(ast_t* parent)
 {
   pony_assert(parent != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!parent->frozen);
+#endif
 
   ast_t* child = parent->child;
 
@@ -1410,12 +1476,16 @@ ast_t* ast_append(ast_t* parent, ast_t* child)
   pony_assert(parent != NULL);
   pony_assert(child != NULL);
   pony_assert(parent != child);
+#ifndef PONY_NDEBUG
   pony_assert(!parent->frozen);
+#endif
 
   if(hasparent(child))
     child = ast_dup(child);
+#ifndef PONY_NDEBUG
   else
   pony_assert(!child->frozen);
+#endif
 
   set_scope_and_parent(child, parent);
 
@@ -1461,16 +1531,22 @@ void ast_remove(ast_t* ast)
 {
   pony_assert(ast != NULL);
   pony_assert(hasparent(ast));
+#ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
+#endif
 
   ast_t* last = ast_previous(ast);
 
   if(last != NULL)
   {
+#ifndef PONY_NDEBUG
     pony_assert(!last->frozen);
+#endif
     last->sibling = ast->sibling;
   } else {
+#ifndef PONY_NDEBUG
     pony_assert(!ast->parent->frozen);
+#endif
     ast->parent->child = ast->sibling;
   }
 
@@ -1483,16 +1559,22 @@ void ast_swap(ast_t* prev, ast_t* next)
 {
   pony_assert(prev != NULL);
   pony_assert(prev != next);
+#ifndef PONY_NDEBUG
   pony_assert(!prev->frozen);
+#endif
 
   ast_t* parent = ast_parent(prev);
   pony_assert(parent != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!parent->frozen);
+#endif
 
   if(hasparent(next))
     next = ast_dup(next);
+#ifndef PONY_NDEBUG
   else
     pony_assert(!next->frozen);
+#endif
 
   if(ast_type(parent) == prev)
   {
@@ -1516,7 +1598,9 @@ void ast_swap(ast_t* prev, ast_t* next)
 
 void ast_replace(ast_t** prev, ast_t* next)
 {
+#ifndef PONY_NDEBUG
   pony_assert(!(*prev)->frozen);
+#endif
 
   if(*prev == next)
     return;

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -305,7 +305,9 @@ size_t token_line_position(token_t* token)
 void token_set_id(token_t* token, token_id id)
 {
   pony_assert(token != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!token->frozen);
+#endif
   token->id = id;
 }
 
@@ -314,7 +316,9 @@ void token_set_string(token_t* token, const char* value, size_t length)
 {
   pony_assert(token != NULL);
   pony_assert(token->id == TK_STRING || token->id == TK_ID);
+#ifndef PONY_NDEBUG
   pony_assert(!token->frozen);
+#endif
   pony_assert(value != NULL);
 
   if(length == 0)
@@ -329,7 +333,9 @@ void token_set_float(token_t* token, double value)
 {
   pony_assert(token != NULL);
   pony_assert(token->id == TK_FLOAT);
+#ifndef PONY_NDEBUG
   pony_assert(!token->frozen);
+#endif
   token->real = value;
 }
 
@@ -338,7 +344,9 @@ void token_set_int(token_t* token, lexint_t* value)
 {
   pony_assert(token != NULL);
   pony_assert(token->id == TK_INT);
+#ifndef PONY_NDEBUG
   pony_assert(!token->frozen);
+#endif
   token->integer = *value;
 }
 
@@ -346,7 +354,9 @@ void token_set_int(token_t* token, lexint_t* value)
 void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos)
 {
   pony_assert(token != NULL);
+#ifndef PONY_NDEBUG
   pony_assert(!token->frozen);
+#endif
 
   if(source != NULL)
     token->source = source;

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -55,6 +55,10 @@ add_executable(libponyc.tests
     with.cc
 )
 
+target_compile_definitions(libponyc.tests PRIVATE
+    PONY_ALWAYS_ASSERT
+)
+
 target_include_directories(libponyc.tests
     PRIVATE ../../src/common
     PRIVATE ../../src/libponyc


### PR DESCRIPTION
pony_always_assert was added at some point to help always get backtraces from assertions from ponyc (even in release builds) but it was disabled because it was including debug code in release builds unnecessarily.

this commit ensures that pony_always_assert now only impacts pony_assert (and only for libponyc not libponyrt) to make sure that debug code will not be included in release builds and also only enables pony_always_assert for libponyc and libponyc.tests (and not libponyrt).