### PR TITLE
Make cycle detector test less likely to time out again

### DIFF
--- a/test/full-program-tests/cycle-detector/main.pony
+++ b/test/full-program-tests/cycle-detector/main.pony
@@ -73,6 +73,10 @@ actor Main
     setup_ring()
     Watcher((_ring_size * _ring_count).i32())
 
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+    rto.ponycdinterval = 10
+    rto.ponymaxthreads = 1
+
   fun setup_ring() =>
     var j: U32 = 0
     while true do


### PR DESCRIPTION
make cycle detector run more often and make the program only use a single pony thread to reduce contention..

also, don't pause cycle detector during shutdown anymore.. instead run it without unblocking scheduler 0 so it can do what it needs to do without interrupting the CNF/ACK shutdown process..