### PR TITLE
Remove code related to ACTORMSG_DESTROYED and ctx for ponyint_destroy

### DIFF
--- a/examples/dtrace/mbox-size-all-actor-messages.d
+++ b/examples/dtrace/mbox-size-all-actor-messages.d
@@ -11,9 +11,8 @@
  */
 
 inline unsigned int UINT32_MAX = 4294967295;
-inline unsigned int ACTORMSG_APPLICATION_START = (UINT32_MAX - 11); /* -12 */
-inline unsigned int ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 10);      /* -11 */
-inline unsigned int ACTORMSG_DESTROYED = (UINT32_MAX - 9);          /* -10 */
+inline unsigned int ACTORMSG_APPLICATION_START = (UINT32_MAX - 9); /* -10 */
+inline unsigned int ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 8);      /* -9 */
 inline unsigned int ACTORMSG_ISBLOCKED = (UINT32_MAX - 7);          /* -8 */
 inline unsigned int ACTORMSG_BLOCK = (UINT32_MAX - 6);              /* -7 */
 inline unsigned int ACTORMSG_UNBLOCK = (UINT32_MAX - 5);            /* -6 */

--- a/examples/dtrace/telemetry.d
+++ b/examples/dtrace/telemetry.d
@@ -2,11 +2,9 @@
 
 #pragma D option quiet
 
-inline unsigned int UINT32_MAX = -1;
-inline unsigned int ACTORMSG_APPLICATION_START = (UINT32_MAX - 11);
-inline unsigned int ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 10);
-inline unsigned int ACTORMSG_DESTROYED = (UINT32_MAX - 9);
-inline unsigned int ACTORMSG_CREATED = (UINT32_MAX - 8);
+inline unsigned int UINT32_MAX = 4294967295;
+inline unsigned int ACTORMSG_APPLICATION_START = (UINT32_MAX - 9);
+inline unsigned int ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 8);
 inline unsigned int ACTORMSG_ISBLOCKED = (UINT32_MAX - 7);
 inline unsigned int ACTORMSG_BLOCK = (UINT32_MAX - 6);
 inline unsigned int ACTORMSG_UNBLOCK = (UINT32_MAX - 5);
@@ -25,12 +23,6 @@ pony$target:::actor-msg-send
 / (unsigned int)arg1 == (unsigned int)ACTORMSG_CHECKBLOCKED /
 {
   @counts[arg0, "Check Blocked Messages Sent"] = count();
-}
-
-pony$target:::actor-msg-send
-/ (unsigned int)arg1 == (unsigned int)ACTORMSG_DESTROYED /
-{
-  @counts[arg0, "Destroyed Messages Sent"] = count();
 }
 
 pony$target:::actor-msg-send

--- a/examples/systemtap/telemetry.stp
+++ b/examples/systemtap/telemetry.stp
@@ -7,11 +7,9 @@ probe process.mark("actor-msg-send")
         size of unsigned integer in SystemTap. This is needed since
         the message type is calculated from that value. UINT32_MAX
         must be changed on different types of machines */
-    UINT32_MAX = 4294967296;
-    ACTORMSG_APPLICATION_START = (UINT32_MAX - 11);
-    ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 10);
-    ACTORMSG_DESTROYED = (UINT32_MAX - 9);
-    ACTORMSG_CREATED = (UINT32_MAX - 8);
+    UINT32_MAX = 4294967295;
+    ACTORMSG_APPLICATION_START = (UINT32_MAX - 9);
+    ACTORMSG_CHECKBLOCKED = (UINT32_MAX - 8);
     ACTORMSG_ISBLOCKED = (UINT32_MAX - 7);
     ACTORMSG_BLOCK = (UINT32_MAX - 6);
     ACTORMSG_UNBLOCK = (UINT32_MAX - 5);
@@ -25,12 +23,6 @@ probe process.mark("actor-msg-send")
     }
     if ($arg2 == ACTORMSG_CHECKBLOCKED) {
         messages[$arg1, "count_msg_checkblocked"] ++;
-    }
-    if ($arg2 == ACTORMSG_DESTROYED) {
-        messages[$arg1, "count_msg_destroyed"] ++;
-    }
-    if ($arg2 == ACTORMSG_CREATED) {
-        messages[$arg1, "count_msg_created"] ++;
     }
     if ($arg2 == ACTORMSG_ISBLOCKED) {
         messages[$arg1, "count_msg_isblocked"] ++;

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -304,10 +304,9 @@ static void init_runtime(compile_t* c)
   LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, deref_actor_attr);
   LLVMAddAttributeAtIndex(value, LLVMAttributeReturnIndex, align_attr);
 
-  // void ponyint_destroy(i8*, __object*)
+  // void ponyint_destroy(__object*)
   params[0] = c->ptr;
-  params[1] = c->ptr;
-  type = LLVMFunctionType(c->void_type, params, 2, false);
+  type = LLVMFunctionType(c->void_type, params, 1, false);
   value = LLVMAddFunction(c->module, "ponyint_destroy", type);
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,

--- a/src/libponyc/codegen/genexe.c
+++ b/src/libponyc/codegen/genexe.c
@@ -217,9 +217,8 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
     LLVMValueRef final_actor = create_main(c, t_main, ctx);
     LLVMBuildCall2(c->builder, LLVMGlobalGetValueType(c->primitives_final),
       c->primitives_final, NULL, 0, "");
-    args[0] = ctx;
-    args[1] = final_actor;
-    gencall_runtime(c, "ponyint_destroy", args, 2, "");
+    args[0] = final_actor;
+    gencall_runtime(c, "ponyint_destroy", args, 1, "");
   }
 
   args[0] = ctx;

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -463,19 +463,6 @@ static bool handle_message(pony_ctx_t* ctx, pony_actor_t* actor,
       return false;
     }
 
-    case ACTORMSG_DESTROYED:
-    {
-#ifdef USE_RUNTIMESTATS_MESSAGES
-      ctx->schedulerstats.mem_used_inflight_messages -= sizeof(pony_msgp_t);
-      ctx->schedulerstats.mem_allocated_inflight_messages -= POOL_ALLOC_SIZE(pony_msgp_t);
-#endif
-
-      pony_assert(ponyint_is_cycle(actor));
-      DTRACE3(ACTOR_MSG_RUN, (uintptr_t)ctx->scheduler, (uintptr_t)actor, msg->id);
-      actor->type->dispatch(ctx, actor, msg);
-      return false;
-    }
-
     case ACTORMSG_CHECKBLOCKED:
     {
 #ifdef USE_RUNTIMESTATS_MESSAGES
@@ -925,9 +912,8 @@ PONY_API pony_actor_t* pony_create(pony_ctx_t* ctx, pony_type_t* type,
 //
 // as a result, this does not need to be concurrency safe
 // or tell the cycle detector of what it is doing
-PONY_API void ponyint_destroy(pony_ctx_t* ctx, pony_actor_t* actor)
+PONY_API void ponyint_destroy(pony_actor_t* actor)
 {
-  (void)ctx;
   // This destroys an actor immediately.
   // The finaliser is not called.
 

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -17,9 +17,8 @@ PONY_EXTERN_C_BEGIN
 // Reminder: When adding new types, please also update
 // examples/dtrace/telemetry.d
 
-#define ACTORMSG_APPLICATION_START (UINT32_MAX - 11)
-#define ACTORMSG_CHECKBLOCKED (UINT32_MAX - 10)
-#define ACTORMSG_DESTROYED (UINT32_MAX - 9)
+#define ACTORMSG_APPLICATION_START (UINT32_MAX - 9)
+#define ACTORMSG_CHECKBLOCKED (UINT32_MAX - 8)
 #define ACTORMSG_ISBLOCKED (UINT32_MAX - 7)
 #define ACTORMSG_BLOCK (UINT32_MAX - 6)
 #define ACTORMSG_UNBLOCK (UINT32_MAX - 5)
@@ -158,7 +157,7 @@ PONY_API actorstats_t* pony_actor_stats();
 
 void ponyint_unmute_actor(pony_actor_t* actor);
 
-PONY_API void ponyint_destroy(pony_ctx_t* ctx, pony_actor_t* actor);
+PONY_API void ponyint_destroy(pony_actor_t* actor);
 
 #ifdef USE_RUNTIMESTATS
 size_t ponyint_actor_mem_size(pony_actor_t* actor);

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -847,24 +847,6 @@ static void check_blocked(pony_ctx_t* ctx, detector_t* d)
   deferred(ctx, d);
 }
 
-static void actor_destroyed(detector_t* d, pony_actor_t* actor)
-{
-  // this would only called by a manual destroy of an actor
-  // if that was possible. It is currently unused.
-  // used to clean up the dangling reference to this actor
-  // in the cycle detector to avoid a crash
-
-  // get view for actor
-  view_t* view = get_view(d, actor, false);
-
-  if(view)
-  {
-    // remove and free view
-    ponyint_viewmap_remove(&d->views, view);
-    view_free(view);
-  }
-}
-
 static void block(detector_t* d, pony_ctx_t* ctx, pony_actor_t* actor,
   size_t rc, deltamap_t* map)
 {
@@ -1175,13 +1157,6 @@ static void cycle_dispatch(pony_ctx_t* ctx, pony_actor_t* self,
       break;
     }
 
-    case ACTORMSG_DESTROYED:
-    {
-      pony_msgp_t* m = (pony_msgp_t*)msg;
-      actor_destroyed(d, (pony_actor_t*)m->p);
-      break;
-    }
-
     case ACTORMSG_BLOCK:
     {
 #ifdef USE_RUNTIMESTATS_MESSAGES
@@ -1282,16 +1257,6 @@ bool ponyint_cycle_check_blocked(uint64_t tsc, uint64_t tsc2)
   return false;
 }
 
-void ponyint_cycle_actor_destroyed(pony_actor_t* actor)
-{
-  // this will only be false during the creation of the cycle detector
-  // and after the runtime has been shut down or if the cycle detector
-  // is being destroyed
-  if(cycle_detector && !ponyint_is_cycle(actor)) {
-    ponyint_sendp_inject(cycle_detector, ACTORMSG_DESTROYED, actor);
-  }
-}
-
 void ponyint_cycle_block(pony_actor_t* actor, gc_t* gc)
 {
   pony_assert(&actor->gc == gc);
@@ -1321,7 +1286,7 @@ void ponyint_cycle_terminate(pony_ctx_t* ctx)
 {
   ponyint_become(ctx, cycle_detector);
   final(ctx, cycle_detector);
-  ponyint_destroy(ctx, cycle_detector);
+  ponyint_destroy(cycle_detector);
   ponyint_become(ctx, NULL);
   cycle_detector = NULL;
 }

--- a/src/libponyrt/gc/cycle.h
+++ b/src/libponyrt/gc/cycle.h
@@ -13,8 +13,6 @@ void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t detect_interval);
 
 bool ponyint_cycle_check_blocked(uint64_t tsc, uint64_t tsc2);
 
-void ponyint_cycle_actor_destroyed(pony_actor_t* actor);
-
 void ponyint_cycle_block(pony_actor_t* actor, gc_t* gc);
 
 void ponyint_cycle_unblock(pony_actor_t* actor);


### PR DESCRIPTION
code referring to ACTORMSG_DESTROYED, ACTORMSG_CREATED and the ctx argument to ponyint_destroy are no longer used as the logic has evolved over time and can be removed.