### PR TITLE
Don't run GC for zombie actors when they are blocked

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -307,8 +307,13 @@ static void send_block(pony_ctx_t* ctx, pony_actor_t* actor)
   // that eventually trigger a GC which may not happen for a long time
   // (or ever). Do this BEFORE sending the message or else we might be
   // GCing while the CD destroys us.
-  pony_triggergc(ctx);
-  try_gc(ctx, actor);
+  // only if `gc.rc > 0` because if `gc.rc == 0` then the actor is a zombie
+  // and the cycle detector will destroy it upon receiving the block message
+  if(actor->gc.rc > 0)
+  {
+    pony_triggergc(ctx);
+    try_gc(ctx, actor);
+  }
 
   // We're blocked, send block message.
   set_internal_flag(actor, FLAG_BLOCKED_SENT);


### PR DESCRIPTION
Prior to this commit, if the cycle detector was enabled all actors would run a GC cycle before sending a block message to the cycle detector. This is helpful for actors that are waiting for additional work to be able to release some memory that they don't need but wasteful for zombie actors that the cycle detector will destroy as soon as it receives the block message for them.

This commit changes the logic so that the GC cycle no longer run for zombie actors when they block because the cycle detector will destroy the actor soon anyway.