### PR TITLE
Remove invalid asserts from ASIO system

### DIFF
--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -154,7 +154,6 @@ PONY_API void pony_asio_event_resubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DESTROYED) ||
     !(ev->flags & ASIO_ONESHOT))
   {
-    pony_assert(0);
     return;
   }
 
@@ -356,7 +355,6 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -442,7 +440,6 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -459,7 +456,6 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -275,7 +275,6 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -315,7 +314,6 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -107,7 +107,6 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -138,7 +137,6 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -287,7 +285,6 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -366,7 +363,6 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 
@@ -400,7 +396,6 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
-    pony_assert(0);
     return;
   }
 


### PR DESCRIPTION
There's an ABA condition that can exist with how the ASIO system works in the runtime. There's guard
conditions in various functions to ditch early for scenarios where this is encountered.

A few years ago, some asserts were added to those guard clauses. Unfortunately, that defeats the purpose of the guards and will eventually result in assertions being triggered under load with a debug runtime.

Without completely rewriting how the ASIO system works to be ABA friendly, these asserts are a bad idea. I don't feel up to doing a rewrite at this time, so I am removing the asserts.