### PR TITLE
Fix incorrect printing of runtime stats

### DIFF
--- a/.release-notes/4620.md
+++ b/.release-notes/4620.md
@@ -1,0 +1,3 @@
+## Fix incorrect printing of runtime stats
+
+When the runtime was compiled with the runtime stats option on, some stats were being printed to standard out without them having been requested. We've fixed the issue so stats will only be printed if the option is turned on by the user.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -769,7 +769,8 @@ void ponyint_actor_destroy(pony_actor_t* actor)
   ctx->schedulerstats.mem_used_actors -= actor->type->size;
   ctx->schedulerstats.mem_allocated_actors -= ponyint_pool_used_size(actor->type->size);
   ctx->schedulerstats.destroyed_actors_counter++;
-  print_actor_stats(actor);
+  if (ponyint_sched_print_stats())
+    print_actor_stats(actor);
 #endif
 
   // Free variable sized actors correctly.

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -157,6 +157,8 @@ void ponyint_sched_maybe_wakeup(int32_t current_scheduler_id);
 void ponyint_sched_maybe_wakeup_if_all_asleep(int32_t current_scheduler_id);
 
 #ifdef USE_RUNTIMESTATS
+bool ponyint_sched_print_stats();
+
 uint64_t ponyint_sched_cpu_used(pony_ctx_t* ctx);
 
 /** Get the static memory used by the scheduler subsystem.


### PR DESCRIPTION
Some scheduler and actor runtime stat printing weren't properly gated by the "should print" check and thus would always print.

Closes #4619