### PR TITLE
Make pony programs exit on an unrecognized pony runtime option

### DIFF
--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -76,6 +76,15 @@ static const opt_arg_t* find_match(opt_state_t* s)
     }
   }
 
+  // if we didn't find a match
+  if(match == NULL)
+  {
+    // and the option starts with "pony",
+    // complain
+    if(!strncmp("pony", s->opt_start, 4))
+      return (opt_arg_t*)2;
+  }
+
   return match;
 }
 
@@ -212,6 +221,11 @@ int ponyint_opt_next(opt_state_t* s)
   else if(m == (opt_arg_t*)1)
   {
     printf("%s: '%s' option is ambiguous!\n", s->argv[0], s->argv[s->idx]);
+    return -2;
+  }
+  else if(m == (opt_arg_t*)2)
+  {
+    printf("%s: Unrecognised pony runtime option: '%s'!\nRun '%s --ponyhelp' for available pony runtime options.\n", s->argv[0], s->argv[s->idx], s->argv[0]);
     return -2;
   }
 

--- a/src/libponyrt/options/options.c
+++ b/src/libponyrt/options/options.c
@@ -225,7 +225,7 @@ int ponyint_opt_next(opt_state_t* s)
   }
   else if(m == (opt_arg_t*)2)
   {
-    printf("%s: Unrecognised pony runtime option: '%s'!\nRun '%s --ponyhelp' for available pony runtime options.\n", s->argv[0], s->argv[s->idx], s->argv[0]);
+    printf("%s: Unrecognised pony runtime option: '%s'!\nRun '%s --ponyhelp' for available pony runtime options.\nIf you're trying to use this as an application argument, you'll need to rename it to not include the '--pony' prefix.\n", s->argv[0], s->argv[s->idx], s->argv[0]);
     return -2;
   }
 


### PR DESCRIPTION
Prior to this commit, if someone passed an unrecognized pony runtime option (due to a typo or otherwise), the pony program would silently ignore the argument and keep running without the operator knowing that the intended pony runtime option wasn't applied.

```
root@5babe01f566f:/workspaces/ponyc# ./helloworld --ponyblah
Hello, world.
root@5babe01f566f:/workspaces/ponyc#
```

This commit changes things so that pony programs will now print out an error message and exit with a non-zero exit code when an unrecognized pony runtime option is supplied:

```
root@5babe01f566f:/workspaces/ponyc# ./helloworld --ponyblah
./helloworld: Unrecognised pony runtime option: '--ponyblah'!
Run './helloworld --ponyhelp' for available pony runtime options.
root@5babe01f566f:/workspaces/ponyc#
```