### PR TITLE
Fix being unable to compile programs that use runtime info on Windows

### DIFF
--- a/.release-notes/a.md
+++ b/.release-notes/a.md
@@ -1,0 +1,3 @@
+## Fix being unable to compile programs that use runtime info on Windows
+
+We accidentally weren't properly exporting the Pony runtime methods needed by the "runtime_info" package so that they could be linked on Windows.

--- a/packages/runtime_info/_test.pony
+++ b/packages/runtime_info/_test.pony
@@ -5,4 +5,36 @@ actor \nodoc\ Main is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    None
+    test(_TestActorStatsLinks)
+    test(_TestSchedulerLinks)
+    test(_TestSchedulerStatsLinks)
+
+class \nodoc\ iso _TestSchedulerLinks is UnitTest
+  """
+  The only point of this test is to verify that
+  each platform can link to the exported symbols.
+  """
+  fun name(): String => "runtime_info/SchedulerLinks"
+
+  fun apply(h: TestHelper) =>
+    Scheduler.schedulers(SchedulerInfoAuth(h.env.root))
+
+class \nodoc\ iso _TestSchedulerStatsLinks is UnitTest
+  """
+  The only point of this test is to verify that
+  each platform can link to the exported symbols.
+  """
+  fun name(): String => "runtime_info/SchedulerStatsLinks"
+
+  fun apply(h: TestHelper) =>
+    SchedulerStats.total_mem_allocated(SchedulerStatsAuth(h.env.root))
+
+class \nodoc\ iso _TestActorStatsLinks is UnitTest
+  """
+  The only point of this test is to verify that
+  each platform can link to the exported symbols.
+  """
+  fun name(): String => "runtime_info/ActorStatsLinks"
+
+  fun apply(h: TestHelper) =>
+    ActorStats.heap_mem_allocated(ActorStatsAuth(h.env.root))

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -22,6 +22,8 @@
 // default actor batch size
 #define PONY_SCHED_BATCH 100
 
+PONY_EXTERN_C_BEGIN
+
 // Ignore padding at the end of the type.
 pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
    sizeof(pony_actor_pad_t), "Wrong actor pad size!");
@@ -1281,3 +1283,5 @@ size_t ponyint_actor_total_alloc_size(pony_actor_t* actor)
     + POOL_ALLOC_SIZE(pony_msg_t);
 }
 #endif
+
+PONY_EXTERN_C_END

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -20,6 +20,8 @@
 
 #define PONY_SCHED_BLOCK_THRESHOLD 1000000
 
+PONY_EXTERN_C_BEGIN
+
 static DECLARE_THREAD_FN(run_thread);
 
 typedef enum
@@ -2158,3 +2160,5 @@ PONY_API int32_t pony_sched_index(pony_ctx_t* ctx)
 {
   return ctx->scheduler->index;
 }
+
+PONY_EXTERN_C_END


### PR DESCRIPTION
Note this would have been caught much earlier if we were building examples on Windows as part of CI as there is a runtime info example that would fail on Windows.

Closes #4624