### PR TITLE
Rename the --ponyc option to the full-program-runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,11 +230,11 @@ endif
 
 test-full-programs-release: all
 	@mkdir -p $(outDir)/full-program-tests/release
-	$(SILENT)cd '$(outDir)' && $(buildDir)/test/full-program-runner/full-program-runner --debugger='$(debuggercmd)' --timeout_s=120 --max_parallel=$(num_cores) --ponyc=$(outDir)/ponyc --output=$(outDir)/full-program-tests/release --test_lib=$(outDir)/test_lib $(srcDir)/test/full-program-tests
+	$(SILENT)cd '$(outDir)' && $(buildDir)/test/full-program-runner/full-program-runner --debugger='$(debuggercmd)' --timeout_s=120 --max_parallel=$(num_cores) --compiler=$(outDir)/ponyc --output=$(outDir)/full-program-tests/release --test_lib=$(outDir)/test_lib $(srcDir)/test/full-program-tests
 
 test-full-programs-debug: all
 	@mkdir -p $(outDir)/full-program-tests/debug
-	$(SILENT)cd '$(outDir)' && $(buildDir)/test/full-program-runner/full-program-runner --debugger='$(debuggercmd)' --timeout_s=120 --max_parallel=$(num_cores) --ponyc=$(outDir)/ponyc --debug --output=$(outDir)/full-program-tests/debug --test_lib=$(outDir)/test_lib $(srcDir)/test/full-program-tests
+	$(SILENT)cd '$(outDir)' && $(buildDir)/test/full-program-runner/full-program-runner --debugger='$(debuggercmd)' --timeout_s=120 --max_parallel=$(num_cores) --compiler=$(outDir)/ponyc --debug --output=$(outDir)/full-program-tests/debug --test_lib=$(outDir)/test_lib $(srcDir)/test/full-program-tests
 
 test-stdlib-release: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) $(debuggercmd) ./stdlib-release --sequential

--- a/make.ps1
+++ b/make.ps1
@@ -322,8 +322,8 @@ switch ($Command.ToLower())
                 }
 
                 if (-not (Test-Path $runOutDir)) { New-Item -ItemType Directory -Force -Path $runOutDir }
-                Write-Output "$buildDir\test\full-program-runner\full-program-runner.exe --debug=$debugFlag --debugger=$debuggercmd --timeout_s=60 --max_parallel=1 --debug=$debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\full-program-tests"
-                & $buildDir\test\full-program-runner\full-program-runner.exe --debugger=$debuggercmd --timeout_s=60 --max_parallel=1 --debug=$debugFlag --test_lib=$outDir\test_lib --ponyc=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\full-program-tests
+                Write-Output "$buildDir\test\full-program-runner\full-program-runner.exe --debug=$debugFlag --debugger=$debuggercmd --timeout_s=60 --max_parallel=1 --debug=$debugFlag --test_lib=$outDir\test_lib --compiler=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\full-program-tests"
+                & $buildDir\test\full-program-runner\full-program-runner.exe --debugger=$debuggercmd --timeout_s=60 --max_parallel=1 --debug=$debugFlag --test_lib=$outDir\test_lib --compiler=$outDir\ponyc.exe --output=$runOutDir $srcDir\test\full-program-tests
                 $err = $LastExitCode
                 if ($err -ne 0) { $failedTestSuites += "libponyc.run.tests.$runConfig" }
             }

--- a/test/full-program-runner/_cli_options.pony
+++ b/test/full-program-runner/_cli_options.pony
@@ -3,7 +3,7 @@ use "collections"
 
 class val _Options
   let test_path: String
-  let ponyc: String
+  let compiler_path: String
   let output: String
   let pony_path: String
   let test_lib: String
@@ -18,7 +18,7 @@ class val _Options
   new create(command: Command) =>
     test_path = command.arg(_CliOptions._str_test_path()).string()
 
-    ponyc = command.option(_CliOptions._str_ponyc()).string()
+    compiler_path = command.option(_CliOptions._compiler_path()).string()
     output = command.option(_CliOptions._str_output()).string()
     pony_path = command.option(_CliOptions._str_pony_path()).string()
     test_lib = command.option(_CliOptions._str_test_lib()).string()
@@ -45,7 +45,7 @@ class val _Options
 
 primitive _CliOptions
   fun _str_test_path(): String => "test_path"
-  fun _str_ponyc(): String => "ponyc"
+  fun _compiler_path(): String => "compiler"
   fun _str_output(): String => "output"
   fun _str_pony_path(): String => "pony_path"
   fun _str_test_lib(): String => "test_lib"
@@ -61,7 +61,7 @@ primitive _CliOptions
     let spec =
       recover val
         CommandSpec.leaf("runner", "Test runner for Pony compiler tests", [
-          OptionSpec.string(_str_ponyc(), "Path to the ponyc binary"
+          OptionSpec.string(_compiler_path(), "Path to the ponyc binary"
             where short' = 'c', default' = "ponyc")
           OptionSpec.string(_str_output(), "Output directory for test programs"
             where short' = 'o', default' = ".")

--- a/test/full-program-runner/_tester.pony
+++ b/test/full-program-runner/_tester.pony
@@ -66,9 +66,9 @@ actor _Tester
     // find ponyc executable
     let ponyc_file_path =
       try
-        _FindExecutable(_env, _options.ponyc)?
+        _FindExecutable(_env, _options.compiler_path)?
       else
-        _shutdown_failed("unable to find executable: " + _options.ponyc)
+        _shutdown_failed("unable to find executable: " + _options.compiler_path)
         return
       end
 


### PR DESCRIPTION
All runtime options start with --pony so using --ponyc as an option for the program could result in a naming conflict later.

This renames from `--ponyc` to `--compiler`.