### PR TITLE
Configure MacOS networking before running network related stress tests

### DIFF
--- a/.ci-scripts/macOS-configure-networking.bash
+++ b/.ci-scripts/macOS-configure-networking.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Why?
+# See: https://web.archive.org/web/20180129235834/http://danielmendel.github.io/blog/2013/04/07/benchmarkers-beware-the-ephemeral-port-limit/
+
+sudo sysctl -w net.inet.tcp.msl=1000
+sudo sysctl -w net.inet.ip.portrange.first=32768
+sudo sysctl -w net.inet.ip.portrange.hifirst=32768

--- a/.github/workflows/stress-test-runtime.yml
+++ b/.github/workflows/stress-test-runtime.yml
@@ -317,6 +317,8 @@ jobs:
         run: |
           make configure arch=x86-64 config=debug
           make build config=debug
+      - name: Configure networking
+        run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Run Stress Test
         run: make ${{ matrix.target }} config=debug usedebugger=lldb
       - name: Send alert on failure


### PR DESCRIPTION
Otherwise, most connections will fail to be established because of:

https://web.archive.org/web/20180129235834/http://danielmendel.github.io/blog/2013/04/07/benchmarkers-beware-the-ephemeral-port-limit/