### PR TITLE
Add live asio event tracking for debugging

### DIFF
--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -662,6 +662,7 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
   {
     if (actor->gc.rc == 0)
     {
+      pony_assert(actor->live_asio_events == 0);
       // Here, we is what we know to be true:
       //
       // - the actor is blocked

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -61,6 +61,7 @@ typedef struct pony_actor_t
   size_t muted; // 4/8 bytes
   // internal flags are only ever accessed from a single scheduler thread
   uint8_t internal_flags; // 4/8 bytes (after alignment)
+  uint32_t live_asio_events;
 #ifdef USE_RUNTIMESTATS
   actorstats_t actorstats; // 64/128 bytes
 #endif
@@ -73,7 +74,7 @@ typedef struct pony_actor_t
 /** Padding for actor types.
  *
  * Size of pony_actor_t minus the padding at the end and the pony_type_t* at the beginning.
- * 
+ *
  */
 #define PONY_ACTOR_PAD_SIZE (offsetof(pony_actor_t, gc) + sizeof(gc_t) - sizeof(pony_type_t*))
 

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -30,6 +30,8 @@ PONY_API asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
   ev->writeable = false;
   ev->readable = false;
 
+  owner->live_asio_events = owner->live_asio_events + 1;
+
   // The event is effectively being sent to another thread, so mark it here.
   pony_ctx_t* ctx = pony_ctx();
   pony_gc_send(ctx);
@@ -60,6 +62,9 @@ PONY_API void pony_asio_event_destroy(asio_event_t* ev)
   }
 
   ev->flags = ASIO_DESTROYED;
+
+  pony_assert(ev->owner->live_asio_events > 0);
+  ev->owner->live_asio_events = ev->owner->live_asio_events - 1;
 
   // When we let go of an event, we treat it as if we had received it back from
   // the asio thread.


### PR DESCRIPTION
This might not live on in this fashion for a long time. This at the moment exists for the pony_asserts. However, to make the cycle detector work better, we do want to know if an actor has any live asio events. If it does, we should never mark it as blocked as it isn't. A live asio event means that the actor is capable of getting messages and should never be evaluated for being in a cycle. That change however, is for another day.