### PR TITLE
Make pony assertions print backtraces on macos

### DIFF
--- a/src/libponyrt/platform/ponyassert.c
+++ b/src/libponyrt/platform/ponyassert.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef PLATFORM_IS_POSIX_BASED
-#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX)
+#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX) || defined(PLATFORM_IS_MACOSX)
 #  include <execinfo.h>
 #endif
 #  include <unistd.h>
@@ -40,7 +40,7 @@ void ponyint_assert_fail(const char* expr, const char* file, size_t line,
   fprintf(stderr, "%s:" __zu ": %s: Assertion `%s` failed.\n\n", file, line,
     func, expr);
 
-#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX)
+#if defined(__GLIBC__) || defined(PLATFORM_IS_BSD) || defined(ALPINE_LINUX) || defined(PLATFORM_IS_MACOSX)
   void* addrs[256];
   stack_depth_t depth = backtrace(addrs, 256);
   char** strings = backtrace_symbols(addrs, depth);


### PR DESCRIPTION
Prior to this commit, when a pony_assert failed, it would print a message saying "Backtrace functionality not available" on macos.

This commit makes it so macos will now print backtraces on pony_assert failures similar to other platforms.