### PR TITLE
Fix race condition in epoll ASIO system

### DIFF
--- a/.release-notes/asio-race.md
+++ b/.release-notes/asio-race.md
@@ -1,0 +1,3 @@
+## Fix race condition in epoll ASIO system
+
+We've fixed a race condition in the epoll ASIO subsystem that could result in "unexpected behavior" when using one-shot epoll events. At the time the bug was fixed, this means that only the `TCPConnection` actor was impacted part of the standard library.

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -154,6 +154,7 @@ PONY_API void pony_asio_event_resubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DESTROYED) ||
     !(ev->flags & ASIO_ONESHOT))
   {
+    pony_assert(0);
     return;
   }
 
@@ -309,15 +310,6 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
       // to an actor
       if(flags != 0)
       {
-        // if this event hasn't been destroyed or disposed.
-        // to avoid a race condition if destroyed or dispoed events
-        // are resubscribed
-        if((ev->flags != ASIO_DISPOSABLE) && (ev->flags != ASIO_DESTROYED))
-          // if this event is using one shot and should auto resubscribe and
-          // then resubscribe
-          if(ev->flags & ASIO_ONESHOT)
-            pony_asio_event_resubscribe(ev);
-
         // send the event to the actor
         pony_asio_event_send(ev, flags, count);
       }
@@ -355,6 +347,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -440,6 +433,7 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -456,6 +450,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/asio/iocp.c
+++ b/src/libponyrt/asio/iocp.c
@@ -275,6 +275,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -314,6 +315,7 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -107,6 +107,7 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -137,6 +138,7 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -285,6 +287,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -363,6 +366,7 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 
@@ -396,6 +400,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     (ev->flags == ASIO_DISPOSABLE) ||
     (ev->flags == ASIO_DESTROYED))
   {
+    pony_assert(0);
     return;
   }
 


### PR DESCRIPTION
The removed code was accessing an event that was also being modified from other threads. In particular, by the TCP Connection actor that the event belonged to (only TCPConnection currently uses one-shot events).

This could lead to all the hilarity that one can expect from things.

Closes #4639