### PR TITLE
Prevent memory explosion when using ponynoblock in some programs

### DIFF
--- a/.release-notes/4666.md
+++ b/.release-notes/4666.md
@@ -1,0 +1,77 @@
+## Prevent meory explosion when using ponynoblock in some programs
+
+We have enhanced the runtime to prevent memory explosion in some programs when `--ponynnoblock` is used.
+
+The following is an example of such a program:
+
+```pony
+use "collections"
+use "random"
+use "time"
+
+class Notify is TimerNotify
+  let _a: A
+  var _m: Main
+
+  new iso create(a: A, m: Main) =>
+    _a = a
+    _m = m
+
+  fun ref apply(timer: Timer, count: U64): Bool =>
+    _a.done(_m)
+    false
+
+actor A
+  new create(m: Main, n: USize) =>
+    let timers = Timers
+    let timer = Timer(Notify(this, m), n.u64() * 1_000_000)
+    timers(consume timer)
+
+  be done(m: Main) =>
+    m.done(this)
+
+actor Main
+  let n: USize = 100000
+  var e: USize = 0
+  let max_num_oustanding: USize = 13
+  var num_outstanding: USize = 0
+  let s: SetIs[A] = s.create()
+  let rand: Random
+
+  new create(env: Env) =>
+    let t = Time.seconds()
+    rand = Rand(t.u64())
+    spawn()
+
+  be spawn() =>
+    if e < n then
+      while num_outstanding < max_num_oustanding do
+        let i = rand.int[USize](2)
+        let a = A(this, i)
+        s.set(a)
+        e = e + 1
+        num_outstanding = num_outstanding + 1
+      end
+    end
+
+  be done(a: A) =>
+    s.unset(a)
+    num_outstanding = num_outstanding - 1
+    spawn()
+```
+
+before:
+
+```
+root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./before --ponynoblock
+35.91user 7.08system 0:05.91elapsed 727%CPU (0avgtext+0avgdata 1716480maxresident)k
+0inputs+0outputs (3major+428831minor)pagefaults 0swaps
+```
+
+after:
+
+```
+root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./after --ponynoblock
+41.16user 2.73system 0:05.89elapsed 744%CPU (0avgtext+0avgdata 13440maxresident)k
+0inputs+0outputs (3major+3137minor)pagefaults 0swaps
+```

--- a/.release-notes/4666.md
+++ b/.release-notes/4666.md
@@ -19,14 +19,48 @@ class Notify is TimerNotify
 
   fun ref apply(timer: Timer, count: U64): Bool =>
     _a.done(_m)
+
+    // returning false from apply in a TimerNotify
+    // instructs the runtime that the timer should be
+    // cancelled which allows for the owning Timers
+    // actor to potentially be reaped if there are no
+    // references to it and/or if the cycle detector
+    // decides it is safe to be reaped
     false
 
 actor A
+  // acquires a reference to the Main actor via an ORCA
+  // message to prevent the Main actor from being reaped
+  // until after this actor is done with the reference to
+  // it. This reference will be released the next time GC
+  // runs for this actor since this actor doesn't keep a
+  // reference to it
   new create(m: Main, n: USize) =>
+    // acquires a reference to the Timers actor implicitly
+    // because this actor creates it. The reference will
+    // be freed after the next GC of this actor since this
+    // actor doesn't keep a reference to it
     let timers = Timers
+
+    // passing a reference to the Main and A actors via the
+    // Notify class delays/prevents them from being reaped
+    // until after the references are no longer used either
+    // because the Notify object is destroyed or the Timers
+    // actor is reaped
     let timer = Timer(Notify(this, m), n.u64() * 1_000_000)
     timers(consume timer)
 
+  // acquires a reference to the Main actor via an ORCA
+  // message (if the previous reference has already been
+  // released) to prevent the Main actor from being reaped
+  // until after this actor is done with the reference to
+  // it. This reference will be released the next time GC
+  // runs for this actor since this actor doesn't keep a
+  // reference to it
+  // After this behavior completes, this actor can
+  // potentially be reaped if there are no references to it
+  // and/or if the cycle detector decides it is safe to be
+  // reaped
   be done(m: Main) =>
     m.done(this)
 
@@ -47,7 +81,16 @@ actor Main
     if e < n then
       while num_outstanding < max_num_oustanding do
         let i = rand.int[USize](2)
+
+        // passing a reference to the Main actor
+        // delays/prevents it from being reaped
+        // until after the reference is no longer
+        // used
         let a = A(this, i)
+
+        // saving references to A actors in the set
+        // delays/prevents them from being reaped
+        // until after the reference has been deleted
         s.set(a)
         e = e + 1
         num_outstanding = num_outstanding + 1
@@ -55,6 +98,10 @@ actor Main
     end
 
   be done(a: A) =>
+    // deletes a reference to an A actor but the actor
+    // can only be reaped after GC is run for the Main
+    // actor as that is when the ORCA message releasing
+    // the reference is sent
     s.unset(a)
     num_outstanding = num_outstanding - 1
     spawn()


### PR DESCRIPTION
Prior to this commit, the following program would result in huge memory usage when `--ponynnoblock` was used.

```pony
use "collections"
use "random"
use "time"

class Notify is TimerNotify
  let _a: A
  var _m: Main

  new iso create(a: A, m: Main) =>
    _a = a
    _m = m

  fun ref apply(timer: Timer, count: U64): Bool =>
    _a.done(_m)
    false

actor A
  new create(m: Main, n: USize) =>
    let timers = Timers
    let timer = Timer(Notify(this, m), n.u64() * 1_000_000)
    timers(consume timer)

  be done(m: Main) =>
    m.done(this)

actor Main
  let n: USize = 100000
  var e: USize = 0
  let max_num_oustanding: USize = 13
  var num_outstanding: USize = 0
  let s: SetIs[A] = s.create()
  let rand: Random

  new create(env: Env) =>
    let t = Time.seconds()
    rand = Rand(t.u64())
    spawn()

  be spawn() =>
    if e < n then
      while num_outstanding < max_num_oustanding do
        let i = rand.int[USize](2)
        let a = A(this, i)
        s.set(a)
        e = e + 1
        num_outstanding = num_outstanding + 1
      end
    end

  be done(a: A) =>
    s.unset(a)
    num_outstanding = num_outstanding - 1
    spawn()
```

```
root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./before
40.48user 2.64system 0:05.86elapsed 734%CPU (0avgtext+0avgdata 25344maxresident)k
0inputs+0outputs (3major+6068minor)pagefaults 0swaps
root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./before --ponynoblock
35.91user 7.08system 0:05.91elapsed 727%CPU (0avgtext+0avgdata 1716480maxresident)k
0inputs+0outputs (3major+428831minor)pagefaults 0swaps
```

This commit changes the runtime to force a GC for blocked actors if the actor gc.rc > 0 to maybe free no longer used references to other actors which might eventually result in the actors gc.rc == 0 so that it can also be destroyed.

```
root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./after
41.78user 2.50system 0:05.97elapsed 741%CPU (0avgtext+0avgdata 24704maxresident)k
0inputs+0outputs (3major+5975minor)pagefaults 0swaps
root@5babe01f566f:/workspaces/ponyc# /usr/bin/time ./after --ponynoblock
41.16user 2.73system 0:05.89elapsed 744%CPU (0avgtext+0avgdata 13440maxresident)k
0inputs+0outputs (3major+3137minor)pagefaults 0swaps
```