### PR TITLE
Add partial support for Windows on Arm64

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Configuration related to self-hosted runner.
+self-hosted-runner:
+  labels:
+    - windows-11-arm

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -211,3 +211,53 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  arm64-windows:
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: pwsh
+
+    name: x86-64-pc-windows-msvc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Install Dependencies
+        run: |
+          python.exe -m pip install --upgrade cloudsmith-cli
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v4
+        with:
+          path: build/libs
+          key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: .\make.ps1 -Command libs
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/libs
+          key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt') }}
+      - name: Configure
+        run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version nightly
+      - name: Build
+        run: .\make.ps1 -Command build -Config Release -Prefix "build\install\release" -Version nightly
+      - name: Install
+        run: .\make.ps1 -Command install -Config Release -Prefix "build\install\release"
+      - name: Package
+        run: .\make.ps1 -Command package -Config Release -Prefix "build\install\release" -Version nightly
+      - name: Upload
+        run: $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key ${{ secrets.CLOUDSMITH_API_KEY }} --summary "Pony compiler" --description "https://github.com/ponylang/ponyc" ponylang/nightlies build\ponyc-arm64-pc-windows-msvc.zip
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -437,6 +437,46 @@ jobs:
       - name: Build examples
         run: .\make.ps1 -Command build-examples
 
+  arm64-windows:
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: pwsh
+
+    name: arm64 Windows MSVC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v4
+        with:
+          path: build/libs
+          key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: .\make.ps1 -Command libs
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/libs
+          key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt') }}
+      - name: Build Debug Runtime
+        run: |
+          .\make.ps1 -Command configure -Config Debug
+          .\make.ps1 -Command build -Config Debug
+      - name: Test with Debug Runtime
+        run: .\make.ps1 -Command test -Config Debug
+      - name: Build Release Runtime
+        run: |
+          .\make.ps1 -Command configure -Config Release
+          .\make.ps1 -Command build -Config Release
+      - name: Test with Release Runtime
+        run: .\make.ps1 -Command test -Config Release
+      - name: Build examples
+        run: .\make.ps1 -Command build-examples
+
   use_directives:
     runs-on: ubuntu-latest
     needs: x86_64-linux


### PR DESCRIPTION
This adds checking on PR for Windows on Arm64. I haven't been able to get LLDB working correctly for tests so that is off.

This also adds building nightlies so we can see if there are issues in that workflow.

No changelog entry yet as this is an exploratory change with others to follow if this works out.