### PR TITLE
Add aarch64 linux musl nightly builds

### DIFF
--- a/.ci-scripts/aarch64-nightly.bash
+++ b/.ci-scripts/aarch64-nightly.bash
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the CI environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${TRIPLE_VENDOR}" ]]; then
+  echo -e "\e[31mVendor needs to be set in TRIPLE_VENDOR."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${TRIPLE_OS}" ]]; then
+  echo -e "\e[31mOperating system needs to be set in TRIPLE_OS."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+TODAY=$(date +%Y%m%d)
+
+# Compiler target parameters
+MACHINE=armv8-a
+PROCESSOR=aarch64
+
+# Triple construction
+TRIPLE=${MACHINE}-${TRIPLE_VENDOR}-${TRIPLE_OS}
+
+# Build parameters
+MAKE_PARALLELISM=8
+BUILD_PREFIX=$(mktemp -d)
+DESTINATION=${BUILD_PREFIX}/lib/pony
+PONY_VERSION="nightly-${TODAY}"
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=ponyc-${TRIPLE}
+
+# Cloudsmith configuration
+CLOUDSMITH_VERSION=${TODAY}
+ASSET_OWNER=ponylang
+ASSET_REPO=nightlies
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="Pony compiler"
+ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
+
+# Build pony installation
+echo "Building ponyc installation..."
+make configure arch=${PROCESSOR} build_flags=-j${MAKE_PARALLELISM} \
+  version="${PONY_VERSION}"
+make build version="${PONY_VERSION}"
+make install arch=${PROCESSOR} prefix="${BUILD_PREFIX}" symlink=no version="${PONY_VERSION}"
+
+# Package it all up
+echo "Creating .tar.gz of ponyc installation..."
+pushd "${DESTINATION}" || exit 1
+tar -cvzf "${ASSET_FILE}" -- *
+popd || exit 1
+
+# Ship it off to cloudsmith
+echo "Uploading package to cloudsmith..."
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -73,6 +73,83 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  # Currently, Github actions supplied by GH like checkout and cache do not work
+  # in musl libc environments on aarch64. We can work around this by running
+  # those actions on the host and then "manually" doing our work that would
+  # normally be done "in the musl container" by starting the container ourselves
+  # for various steps by invoking docker directly.
+  #
+  # This is not in line with our standard pattern of "just do it all in the
+  # container" but is required to work around the GitHub actions limitation
+  # documented above.
+  aarch64-linux:
+    runs-on: ubuntu-24.04-arm
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/ponylang/ponyc-ci-aarch64-unknown-linux-musl-builder:20250505
+            name: aarch64-unknown-linux-musl
+            triple-os: linux-musl
+            triple-vendor: unknown
+
+    name: ${{ matrix.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull Docker image
+        run: docker pull ${{ matrix.image }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v4
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: |
+          docker run --rm \
+            --user pony \
+            -v ${{ github.workspace }}:/home/pony/project \
+            -w /home/pony/project \
+            ${{ matrix.image }} \
+            make libs build_flags=-j8
+      - name: Save Libs Cache
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/libs
+          key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Nightly
+        run: |
+          docker run --rm \
+          --user pony \
+          -v ${{ github.workspace }}:/home/pony/project \
+          -w /home/pony/project \
+          -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
+          -e TRIPLE_VENDOR=${{ matrix.triple-vendor }} \
+          -e TRIPLE_OS=${{ matrix.triple-os }} \
+          ${{ matrix.image }} \
+          bash -c ".ci-scripts/aarch64-nightly.bash"
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   x86_macos:
     runs-on: macos-13
 


### PR DESCRIPTION
This is an exploratory addition that will help shake out any issues we might have with doing aarch64 builds that get uploaded to Cloudsmith.

We've never done in a Linux aarch64 environment so it is possible this might expose issues that we need to address before we start to provide aarch64 builds and announce them to the world.