### PR TITLE
Use more appropriate arch when doing arm64 builds

### DIFF
--- a/.ci-scripts/arm64-nightly.bash
+++ b/.ci-scripts/arm64-nightly.bash
@@ -28,7 +28,7 @@ TODAY=$(date +%Y%m%d)
 
 # Compiler target parameters
 MACHINE=arm64
-PROCESSOR=armv8
+PROCESSOR=armv8-a
 
 # Triple construction
 TRIPLE=${MACHINE}-${TRIPLE_VENDOR}-${TRIPLE_OS}

--- a/.ci-scripts/arm64-release.bash
+++ b/.ci-scripts/arm64-release.bash
@@ -26,7 +26,7 @@ fi
 
 # Compiler target parameters
 MACHINE=arm64
-PROCESSOR=armv8
+PROCESSOR=armv8-a
 
 # Triple construction
 TRIPLE=${MACHINE}-${TRIPLE_VENDOR}-${TRIPLE_OS}


### PR DESCRIPTION
Our armv8 settings came because that it what was reported as working on m1 macs. However, I had Joe test and armv8-a works fine. -a will be targeted to a more specific set of arm processors including aarch64.

There are "smaller" arm64 processors that are included with armv8 that no one is likely to try to use our prebuilts on so armv8-a is a better floor for us to set.