### PR TITLE
Update Dockerfiles to use new ENV format

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu22.04-builder/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:22.04
 
 # Keep annoying tzdata prompt from coming up
 # Thanks cmake!
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/.ci-dockerfiles/x86-64-unknown-linux-ubuntu24.04-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-ubuntu24.04-builder/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:24.04
 
 # Keep annoying tzdata prompt from coming up
 # Thanks cmake!
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ENV PATH "/root/.local/share/ponyup/bin:$PATH"
+ENV PATH="/root/.local/share/ponyup/bin:$PATH"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/latest/x86-64-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-ENV PATH "/root/.local/share/ponyup/bin:$PATH"
+ENV PATH="/root/.local/share/ponyup/bin:$PATH"
 
 RUN apk add --update --no-cache \
     clang \

--- a/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ENV PATH "/root/.local/share/ponyup/bin:$PATH"
+ENV PATH="/root/.local/share/ponyup/bin:$PATH"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
+++ b/.dockerfiles/release/x86-64-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-ENV PATH "/root/.local/share/ponyup/bin:$PATH"
+ENV PATH="/root/.local/share/ponyup/bin:$PATH"
 
 RUN apk add --update --no-cache \
     clang \


### PR DESCRIPTION
The legacy format being replaced results in a warning.