### PR TITLE
Add Multiplatform Nightly Docker Image

### DIFF
--- a/.dockerfiles/nightly/Dockerfile
+++ b/.dockerfiles/nightly/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:3.21
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+ENV PATH="/root/.local/share/ponyup/bin:$PATH"
+
+RUN apk add --update --no-cache \
+    clang \
+    curl \
+    build-base \
+    binutils-gold \
+    git
+
+RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
+ && ponyup update ponyc nightly \
+ && ponyup update corral nightly \
+ && ponyup update changelog-tool nightly
+
+WORKDIR /src/main
+
+CMD ["ponyc"]

--- a/.dockerfiles/nightly/build-and-push.bash
+++ b/.dockerfiles/nightly/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
+#
+
+DOCKERFILE_DIR="$(dirname "$0")"
+NAME="ghcr.io/ponylang/ponyc:nightly"
+BUILDER="ponyc-nightly-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-nightly-musl-image.yml
+++ b/.github/workflows/build-nightly-musl-image.yml
@@ -1,0 +1,85 @@
+name: Build Nightly musl Image
+
+on:
+  repository_dispatch:
+    types:
+      - cloudsmith-package-synchronised
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-nightly-docker-image:
+    if: |
+      github.event.client_payload.data.repository == 'nightlies' &&
+      (github.event.client_payload.data.name == 'ponyc-x86-64-unknown-linux-musl.tar.gz' ||
+       github.event.client_payload.data.name == 'ponyc-arm64-unknown-linux-musl.tar.gz')
+
+    concurrency:
+      group: build-nightly-image
+      cancel-in-progress: true
+
+    name: Build nightly  image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .dockerfiles/nightly/build-and-push.bash
+      - name: Alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  send-repository-dispatch-event:
+    needs:
+      - build-nightly-docker-image
+
+    name: Send
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - ponylang/library-documentation-action-v2
+          - ponylang/shared-docker
+    steps:
+      - name: Send
+        # v2.1.1
+        uses: peter-evans/repository-dispatch@8324ecf35877f9b02961dd5aaf43ed7be7db9373
+        with:
+          token: ${{ secrets.PONYLANG_MAIN_API_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: ponyc-musl-nightly-released
+          client-payload: '{"version": "${{ github.event.client_payload.data.version }}"}'
+      - name: Alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,20 @@ jobs:
           VALIDATE_MD: true
           VALIDATE_YAML: true
 
+  validate-nightly-image-builds:
+    name: Validate nightly image builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+      - name: Docker build
+        run: |
+          docker buildx create --name multiplatform --driver docker-container --use --bootstrap
+          docker buildx build --platform linux/amd64,linux/arm64 --pull --file=.dockerfiles/nightly/Dockerfile .
+
   validate-x86_64-musl-docker-latest-image-builds:
     name: Validate x86_64 musl Docker image builds
     runs-on: ubuntu-latest

--- a/.release-notes/musl-nightly-mp.md
+++ b/.release-notes/musl-nightly-mp.md
@@ -1,0 +1,7 @@
+## Add Multiplatform Nightly Docker Images
+
+We've added new nightly images with support multiple architectures. The images support both arm64 and amd64. The images will be available with the tag `nightly`. They will be available for GitHub Container Registry the same as our [other ponyc images](https://github.com/ponylang/ponyc/pkgs/container/ponyc).
+
+The images are based on Alpine 3.21. Every few months, we will be updating the base image to a newer version of Alpine Linux. At the moment, we generally add support for new Alpine version about 2 times a year.
+
+We will be dropping the `alpine` tag in favor of the new `nightly` tag. However, that isn't happening now but will in the not so distant future. You should switch any usage you have of those tags to `nightly` now to avoid disruption later.


### PR DESCRIPTION
This introduces a number of changes for our container image building.

It introduces the eventual deprecation of `latest` as a tag. At the moment, our use of `latest` is misleading. That is supposed to be "most recent" but we don't use it as such. For us it is "most recently nightly".

This commit will be the start of us having "nightly" images that are explicitly a nightly build. Additionally, our tags will have a qualifier for the libc version. In the case of this musl image the tag would be "musl-nightly". When we do the same for GNU libc, the tag would be "gnu-nightly".

This same name scheme will end up being carried over to releases: "musl-release" and "gnu-release" as well as "by version" tags "musl-0.60.0" and "gnu-0.60.0". The older tags will be dropped as this rolls out.

We can if we want then start using a variation on latest with "musl-latest" and "gnu-latest" should we want, or for ponyc images we can ditch the entire concept of "latest" as "nightly" and "release" versions will always be for a given library the latest nightly and latest release.

In addition the tag name changes, this also is our first multiplatform image. The build process for this is as simple as I could make it. We have a new workflow for building the nightly image. It is set to have a concurrency of 1 so, as events arrive from Cloudsmith, we will build a new version of the image with whatever is the latest nightly arm64 and latest nightly am64 version of ponyc that is available in Cloudsmith.

This means that as we upload to Cloudsmith each night we will create the image twice. If the arm64 synchronized message arrives first and then the amd64 one we will have the following happen:

- arm64 message arrives
- Build a new "nightly image" with today's arm64 and yesterday's amd64
- amd64 message arrives
- Build a new "nightly image" with today's arm64 and today's arm64

The same pattern would be applied to releases.

At the time the message arrives, the image will be built using the most recent version of ponyc for each platform that is available. This has a couple nice qualities to it:

- If one failed to build, we still make the one that succeeded available.
- It makes our configuration relatively simple

Without this "cross over", we would need to wait for each message to have arrived and then build the final image. That is some tricky yaml that we should want to avoid doing if possible.