### PR TITLE
Improve the "ponynoblock" help message

### DIFF
--- a/packages/builtin/runtime_options.pony
+++ b/packages/builtin/runtime_options.pony
@@ -89,7 +89,7 @@ struct RuntimeOptions
 
   var ponynoblock: Bool = false
     """
-    Do not send block messages to the cycle detector.
+    Do not send block messages to the cycle detector. Setting to to true will disable the cycle detector.
     """
 
   var ponypin: Bool = false

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -90,6 +90,7 @@
   "                   point value. Defaults to 2.0.\n" \
   "  --ponynoyield    Do not yield the CPU when no work is available.\n" \
   "  --ponynoblock    Do not send block messages to the cycle detector.\n" \
+  "                   Turning this on with disable the cycle detector.\n" \
   "  --ponypin        Pin scheduler threads to CPU cores. The ASIO thread\n" \
   "                   can also be pinned if `--ponypinasio` is set.\n" \
   "  --ponypinasio    Pin the ASIO thread to a CPU the way scheduler\n" \


### PR DESCRIPTION
It isn't obvious to people just getting started that not sending block messages will disable the cycle detector.

This change makes that relationship explicit.