### PR TITLE
Add temporary github actions workflow to examine our registry_package events

### DIFF
--- a/.github/workflows/test-registry-package-dump-event.yml
+++ b/.github/workflows/test-registry-package-dump-event.yml
@@ -1,0 +1,14 @@
+name: Registry Package Event Dump
+
+on:
+  registry_package:
+    types: [published, updated]
+
+permissions: {}
+jobs:
+  dump-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub Event Context
+        run: |
+          echo '${{ toJSON(github.event) }}' | jq '.'


### PR DESCRIPTION
I am probably going to use for building multiarch image manifests for so I need to get a good idea of what we are getting.