### PR TITLE
Cause registry_package events to get sent

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PONYLANG_MAIN_WRITE_PACKAGE_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/latest/x86-64-unknown-linux-gnu/build-and-push.bash
       - name: Alert on failure
@@ -57,7 +57,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PONYLANG_MAIN_WRITE_PACKAGE_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/latest/x86-64-unknown-linux-musl/build-and-push.bash
       - name: Alert on failure
@@ -93,7 +93,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PONYLANG_MAIN_WRITE_PACKAGE_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/latest/arm64-unknown-linux-musl/build-and-push.bash
       - name: Alert on failure
@@ -153,7 +153,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PONYLANG_MAIN_WRITE_PACKAGE_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/release/x86-64-unknown-linux-gnu/build-and-push.bash
         env:
@@ -174,7 +174,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PONYLANG_MAIN_WRITE_PACKAGE_TOKEN }}
       - name: Build and push
         run: bash .dockerfiles/release/x86-64-unknown-linux-musl/build-and-push.bash
         env:

--- a/.github/workflows/test-registry-package-dump-event.yml
+++ b/.github/workflows/test-registry-package-dump-event.yml
@@ -5,6 +5,7 @@ on:
     types: [published, updated]
 
 permissions: {}
+
 jobs:
   dump-event:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It appears that if we push an image with the default token, that registry_package events are not sent. This is like how you can't trigger a new workflow from an action using the default github token like using that token to push to main.

This commit updates all our ponyc images that would require multiplatform builds aka all the Linux ones to use a PAT from ponylang-main to push thereby allowing registry_package events to occur.