### PR TITLE
Add Alpine 3.22 as a supported platform

### DIFF
--- a/.ci-dockerfiles/alpine3.22-builder/Dockerfile
+++ b/.ci-dockerfiles/alpine3.22-builder/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.22
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+RUN apk update \
+  && apk upgrade \
+  && apk add --update --no-cache \
+  alpine-sdk \
+  binutils-gold \
+  clang \
+  clang-dev \
+  coreutils \
+  linux-headers \
+  cmake \
+  git \
+  zlib-dev \
+  bash \
+  curl \
+  py3-pip \
+  gdb \
+  lldb \
+  py3-lldb \
+&& pip install --break-system-packages cloudsmith-cli
+
+# add user pony in order to not run tests as root
+RUN adduser -D -u 1001 -s /bin/sh -h /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/alpine3.22-builder/build-and-push.bash
+++ b/.ci-dockerfiles/alpine3.22-builder/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-alpine3.22-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="alpine3.22-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -8,6 +8,7 @@ on:
         required: true
         type: choice
         options:
+          - alpine3.22-builder
           - arm64-unknown-linux-alpine3.21-builder
           - arm64-unknown-linux-ubuntu24.04-builder
           - cross-arm
@@ -22,6 +23,29 @@ permissions:
   packages: write
 
 jobs:
+  alpine3_22-builder:
+    if: ${{ github.event.inputs.builder-name == 'alpine3.22-builder' }}
+    runs-on: ubuntu-latest
+
+    name: alpine3.22-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/alpine3.22-builder/build-and-push.bash
+
   arm64-unknown-linux-alpine3_21-builder:
     if: ${{ github.event.inputs.builder-name == 'arm64-unknown-linux-alpine3.21-builder' }}
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -35,6 +35,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.21
             triple-os: linux-alpine3.21
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
+            name: x86-64-unknown-linux-alpine3.22
+            triple-os: linux-alpine3.22
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:
@@ -96,6 +100,10 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
             name: arm64-unknown-linux-alpine3.21
             triple-os: linux-alpine3.21
+            triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
+            name: arm64-unknown-linux-alpine3.22
+            triple-os: linux-alpine3.22
             triple-vendor: unknown
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
             name: arm64-unknown-linux-ubuntu24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.21
             triple-os: linux-alpine3.21
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
+            name: x86-64-unknown-linux-alpine3.22
+            triple-os: linux-alpine3.22
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:
@@ -111,6 +115,10 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
             name: arm64-unknown-linux-alpine3.21
             triple-os: linux-alpine3.21
+            triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
+            name: arm64-unknown-linux-alpine3.22
+            triple-os: linux-alpine3.22
             triple-vendor: unknown
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
             name: arm64-unknown-linux-ubuntu24.04

--- a/.release-notes/alpine3.22.md
+++ b/.release-notes/alpine3.22.md
@@ -1,0 +1,3 @@
+## Add Alpine 3.22 as a supported platform
+
+We've added arm64 and amd64 builds for Alpine Linux 3.22.  We'll be building ponyc releases for it until it stops receiving security updates in 2027. At that point, we'll stop building releases for it.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -44,11 +44,13 @@ Package names will be:
 
 * ponyc-arm64-apple-darwin.tar.gz
 * ponyc-arm64-unknown-linux-alpine3.21.tar.gz
+* ponyc-arm64-unknown-linux-alpine3.22.tar.gz
 * ponyc-arm64-unknown-linux-ubuntu24.04.tar.gz
 * ponyc-x86-64-apple-darwin.tar.gz
 * ponyc-x86-64-pc-windows-msvc.zip
 * ponyc-x86-64-unknown-linux-alpine3.20.tar.gz
 * ponyc-x86-64-unknown-linux-alpine3.21.tar.gz
+* ponyc-x86-64-unknown-linux-alpine3.22.tar.gz
 * ponyc-x86-64-unknown-linux-fedora41.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu22.04.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu24.04.tar.gz


### PR DESCRIPTION
Adds Alpine 3.22 nightly and release builds. It doesn't switch off of Alpine 3.21 as our primary Alpine version. That will happen in 1 or more commits to come in the future.

Closes #4755