### PR TITLE
Sets default vendored LLVM triples to the value of $(CC) -dumpmachine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ endif
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'
-	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(libsBuildDir)' -S '$(libsSrcDir)' -DPONY_PIC_FLAG=$(pic_flag) -DCMAKE_INSTALL_PREFIX="$(libsOutDir)" -DCMAKE_BUILD_TYPE="$(llvm_config)" -DLLVM_TARGETS_TO_BUILD="$(llvm_archs)" $(CMAKE_FLAGS)
+	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake -B '$(libsBuildDir)' -S '$(libsSrcDir)' -DPONY_PIC_FLAG=$(pic_flag) -DCMAKE_INSTALL_PREFIX="$(libsOutDir)" -DCMAKE_BUILD_TYPE="$(llvm_config)" -DLLVM_TARGETS_TO_BUILD="$(llvm_archs)" $(CMAKE_FLAGS) -DLLVM_HOST_TRIPLE=$(shell $(CC) -dumpmachine) -DLLVM_DEFAULT_TARGET_TRIPLE=$(shell $(CC) -dumpmachine)
 	$(SILENT)cd '$(libsBuildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --build '$(libsBuildDir)' --target install --config $(llvm_config) -- $(build_flags)
 
 cleanlibs:


### PR DESCRIPTION
The work we've been doing to integrate lld has exposed that the triple that is being returned by our vendored llvm was the generic default, even when it should be something else.

This hasn't come up before, as we've not tested for things like target_is_musl() until this point.

As we require a "system compiler" to compile llvm, we can use this to set the default value of LLVM_HOST_TRIPLE and LLVM_DEFAULT_TARGET_TRIPLE.