### PR TITLE
Stop using mkdocs-material insiders builds

### DIFF
--- a/.ci-dockerfiles/stdlib-builder/Dockerfile
+++ b/.ci-dockerfiles/stdlib-builder/Dockerfile
@@ -3,8 +3,6 @@ FROM ghcr.io/ponylang/ponyc:${FROM_TAG}
 
 LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 
-ARG MATERIAL_INSIDERS_ACCESS=fail
-
 RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
@@ -20,4 +18,4 @@ RUN apk update \
   tar \
   && pip3 install --upgrade --break-system-packages pip \
   && pip3 install --break-system-packages mkdocs \
-  && pip3 install --break-system-packages git+https://${MATERIAL_INSIDERS_ACCESS}@github.com/squidfunk/mkdocs-material-insiders.git
+  && pip3 install --break-system-packages mkdocs-material

--- a/.ci-dockerfiles/stdlib-builder/build-and-push.bash
+++ b/.ci-dockerfiles/stdlib-builder/build-and-push.bash
@@ -1,15 +1,6 @@
 #!/bin/bash
 
 set -o errexit
-
-if [[ -z "${MATERIAL_INSIDERS_ACCESS}" ]]; then
-  echo -e "\e[31mMaterial Insiders Access API key needs to be set in MATERIAL_INSIDERS_ACCESS."
-  echo -e "Exiting.\e[0m"
-  exit 1
-fi
-
-MIA="${MATERIAL_INSIDERS_ACCESS}"
-
 set -o nounset
 
 #
@@ -23,7 +14,6 @@ DOCKERFILE_DIR="$(dirname "$0")"
 FROM_TAG=release
 TAG_AS=release
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  --build-arg MATERIAL_INSIDERS_ACCESS="${MIA}" \
   -t ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
 docker push ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
 
@@ -31,6 +21,5 @@ docker push ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"
 FROM_TAG=nightly
 TAG_AS=nightly
 docker build --pull --build-arg FROM_TAG="${FROM_TAG}" \
-  --build-arg MATERIAL_INSIDERS_ACCESS="${MIA}" \
   -t ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}" "${DOCKERFILE_DIR}"
 docker push ghcr.io/ponylang/ponyc-ci-stdlib-builder:"${TAG_AS}"

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -68,8 +68,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - name: Alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -187,8 +187,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
 
   build-and-push-stdlib-documentation:
     needs:

--- a/.github/workflows/rebuild-stdlib-builder.yml
+++ b/.github/workflows/rebuild-stdlib-builder.yml
@@ -26,5 +26,3 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Build and push
         run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash
-        env:
-          MATERIAL_INSIDERS_ACCESS: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}


### PR DESCRIPTION
Everything is now public. See:
https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/