### PR TITLE
Document Zed editor support

### DIFF
--- a/EDITORS.md
+++ b/EDITORS.md
@@ -20,3 +20,4 @@
 * CudaText: lexer in Addon Manager
 * Vis: has a [lexer](https://github.com/martanne/vis/blob/master/lua/lexers/pony.lua) for Pony
 * Kakoune: has [Pony support](https://github.com/mawww/kakoune/blob/master/rc/filetype/pony.kak) in the main repository
+* Zed: [pony-zed](https://github.com/orien/pony-zed)


### PR DESCRIPTION
The [Zed editor](https://zed.dev/) has Pony support via the [pony-zed](https://github.com/orien/pony-zed) project.

Add this fact to the `EDITORS.md` document.