### PR TITLE
Add support for complex type formatting in LSP hover

### DIFF
--- a/.release-notes/4785.md
+++ b/.release-notes/4785.md
@@ -1,0 +1,9 @@
+## Add support for complex type formatting in LSP hover
+
+The Pony Language Server now properly formats complex types in hover information. Previously, hovering over variables with union types, tuple types, intersection types, or arrow types would display internal token names like `TK_UNIONTYPE` instead of the actual type signature.
+
+Now, the language server correctly displays formatted types such as:
+- Union types: `(String | U32 | None)`
+- Tuple types: `(String, U32, Bool)`
+- Intersection types: `(ReadSeq[U8] & Hashable)`
+- Arrow types: function signatures

--- a/tools/pony-lsp/test/workspace/hover_fixture.pony
+++ b/tools/pony-lsp/test/workspace/hover_fixture.pony
@@ -115,6 +115,21 @@ class FunctionCallHoverDemo
     """Method with multiple parameters for testing."""
     y
 
+class ComplexTypesDemo
+  """
+  Demonstrates that hover works on complex type expressions.
+  Union types, tuple types, and intersection types are formatted correctly.
+  """
+
+  fun demo_complex_types(): String =>
+    """
+    Hover over the variable names on their declaration lines to see formatted types.
+    Hover shows 'let union_type: (String | U32 | None)' and similar.
+    """
+    let union_type: (String | U32 | None) = "test"
+    let tuple_type: (String, U32, Bool) = ("test", U32(42), true)
+    union_type.string() + tuple_type._1.string()
+
 // ========== Examples of Current Limitations ==========
 
 class LimitationExamples
@@ -138,18 +153,7 @@ class LimitationExamples
     let upper_name = name.upper()
     let sum = count + doubled
 
-  // Limitation 2: Complex type expressions
-  fun demo_complex_types(): String =>
-    """
-    Try hovering over these complex type expressions.
-    EXPECTED: Should show formatted type (e.g., '(String | U32 | None)')
-    ACTUAL: May not format complex types correctly
-    """
-    let union_type: (String | U32 | None) = "test"
-    let tuple_type: (String, U32, Bool) = ("test", U32(42), true)
-    union_type.string() + tuple_type._1.string()
-
-  // Limitation 3: Primitive type documentation
+  // Limitation 2: Primitive type documentation
   fun demo_primitive_types(): USize =>
     """
     Try hovering over primitive numeric types vs classes.
@@ -164,7 +168,7 @@ class LimitationExamples
     let value: U32 = 0              // Hover shows just: primitive U32
     text.size() + numbers.size() + value.usize()
 
-  // Limitation 4: Receiver capabilities not shown in signatures
+  // Limitation 3: Receiver capabilities not shown in signatures
   fun box boxed_method(): String =>
     """
     A boxed method - receiver capability is 'box'.


### PR DESCRIPTION
Implemented formatting for union types, tuple types, intersection types, and arrow types in hover information. Previously these showed token names like 'TK_UNIONTYPE' - now they display properly formatted types like '(String | U32 | None)'.

### Before


https://github.com/user-attachments/assets/2f121847-d7fc-4092-bffc-f915871b53ed



### After


https://github.com/user-attachments/assets/ce18b8ae-ae9d-45b5-b3e1-abff97940c43

