### PR TITLE
Add hover support for generic types in LSP

### DIFF
--- a/.release-notes/4793.md
+++ b/.release-notes/4793.md
@@ -1,0 +1,14 @@
+## Add hover support for generic types in LSP
+
+The LSP server now provides hover information for generic types, including type parameters, type arguments, and capabilities.
+
+Hover displays:
+- Type parameters on classes and traits (e.g., `class Container[T: Any val]`)
+- Type parameters on methods (e.g., `fun map[U: Any val](f: {(T): U} val): U`)
+- Type arguments in instantiated types (e.g., `let items: Array[String val] ref`)
+- Capabilities on all types (val, ref, box, iso, trn, tag)
+- Nested generic types (e.g., `Array[Array[String val] ref] ref`)
+- Viewpoint adaptation/arrow types (e.g., `fun compare(that: box->T): I32`)
+- Constructor calls with type arguments (e.g., `GenericPair[String, U32](...)`)
+
+When hovering on variable declarations, the full inferred type is now shown including all generic type arguments and capabilities, making it easier to understand the exact types in your code.

--- a/tools/pony-lsp/test/_hover_tests.pony
+++ b/tools/pony-lsp/test/_hover_tests.pony
@@ -12,8 +12,17 @@ primitive _HoverTests is TestList
     test(_HoverFormatMethodTest)
     test(_HoverFormatMethodWithReturnTypeTest)
     test(_HoverFormatMethodWithDocstringTest)
+    test(_HoverFormatMethodWithTypeParamsTest)
     test(_HoverFormatFieldTest)
     test(_HoverFormatFieldWithTypeTest)
+    test(_HoverFormatEntityWithMultipleTypeParamsTest)
+    test(_HoverFormatFieldWithGenericTypeTest)
+    test(_HoverFormatMethodWithArrowTypeTest)
+    test(_HoverFormatFieldWithUnionTypeTest)
+    test(_HoverFormatFieldWithTupleTypeTest)
+    test(_HoverFormatMethodWithCompleteSignatureTest)
+    test(_HoverFormatEntityWithTypeParamsAndDocstringTest)
+    test(_HoverFormatFieldWithNestedGenericTypeTest)
 
 class \nodoc\ iso _HoverFormatEntityTest is UnitTest
   fun name(): String => "hover/format_entity"
@@ -51,7 +60,7 @@ class \nodoc\ iso _HoverFormatMethodWithReturnTypeTest is UnitTest
   fun name(): String => "hover/format_method_with_return_type"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "get_value", "(x: U32)", ": String")
+    let info = MethodInfo("fun", "get_value", "", "(x: U32)", ": String")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun get_value(x: U32): String\n```", result)
 
@@ -59,7 +68,7 @@ class \nodoc\ iso _HoverFormatMethodWithDocstringTest is UnitTest
   fun name(): String => "hover/format_method_with_docstring"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("be", "process", "(data: Array[U8] val)", "", "Process data asynchronously.")
+    let info = MethodInfo("be", "process", "", "(data: Array[U8] val)", "", "Process data asynchronously.")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nbe process(data: Array[U8] val)\n```\n\nProcess data asynchronously.", result)
 
@@ -78,3 +87,75 @@ class \nodoc\ iso _HoverFormatFieldWithTypeTest is UnitTest
     let info = FieldInfo("var", "count", ": U32")
     let result = HoverFormatter.format_field(info)
     h.assert_eq[String]("```pony\nvar count: U32\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithTypeParamsTest is UnitTest
+  fun name(): String => "hover/format_method_with_type_params"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "map", "[U: Any val]", "(f: {(T): U} val)", ": U")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun map[U: Any val](f: {(T): U} val): U\n```", result)
+
+class \nodoc\ iso _HoverFormatEntityWithMultipleTypeParamsTest is UnitTest
+  fun name(): String => "hover/format_entity_with_multiple_type_params"
+
+  fun apply(h: TestHelper) =>
+    let info = EntityInfo("class", "Pair", "[A: Any val, B: Any val]")
+    let result = HoverFormatter.format_entity(info)
+    h.assert_eq[String]("```pony\nclass Pair[A: Any val, B: Any val]\n```", result)
+
+class \nodoc\ iso _HoverFormatFieldWithGenericTypeTest is UnitTest
+  fun name(): String => "hover/format_field_with_generic_type"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "items", ": Array[String val] ref")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nlet items: Array[String val] ref\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithArrowTypeTest is UnitTest
+  fun name(): String => "hover/format_method_with_arrow_type"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "compare", "", "(that: box->T)", ": I32 val")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun compare(that: box->T): I32 val\n```", result)
+
+class \nodoc\ iso _HoverFormatFieldWithUnionTypeTest is UnitTest
+  fun name(): String => "hover/format_field_with_union_type"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "value", ": (String val | U32 val | None val)")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nlet value: (String val | U32 val | None val)\n```", result)
+
+class \nodoc\ iso _HoverFormatFieldWithTupleTypeTest is UnitTest
+  fun name(): String => "hover/format_field_with_tuple_type"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "pair", ": (String val, U32 val)")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nlet pair: (String val, U32 val)\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithCompleteSignatureTest is UnitTest
+  fun name(): String => "hover/format_method_with_complete_signature"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "transform", "[U: Any val]", "(data: Array[T] ref)", ": Array[U] ref", "Transform elements.")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun transform[U: Any val](data: Array[T] ref): Array[U] ref\n```\n\nTransform elements.", result)
+
+class \nodoc\ iso _HoverFormatEntityWithTypeParamsAndDocstringTest is UnitTest
+  fun name(): String => "hover/format_entity_with_type_params_and_docstring"
+
+  fun apply(h: TestHelper) =>
+    let info = EntityInfo("class", "Container", "[T: Any val]", "A generic container.")
+    let result = HoverFormatter.format_entity(info)
+    h.assert_eq[String]("```pony\nclass Container[T: Any val]\n```\n\nA generic container.", result)
+
+class \nodoc\ iso _HoverFormatFieldWithNestedGenericTypeTest is UnitTest
+  fun name(): String => "hover/format_field_with_nested_generic_type"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "nested", ": Array[Array[String val] ref] ref")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String]("```pony\nlet nested: Array[Array[String val] ref] ref\n```", result)

--- a/tools/pony-lsp/test/workspace/hover_fixture.pony
+++ b/tools/pony-lsp/test/workspace/hover_fixture.pony
@@ -130,6 +130,144 @@ class ComplexTypesDemo
     let tuple_type: (String, U32, Bool) = ("test", U32(42), true)
     union_type.string() + tuple_type._1.string()
 
+class GenericsDemo[T: Any val]
+  """
+  Demonstrates hover on generic classes with type parameters.
+  Hover over the class name shows the full signature with type parameters.
+  """
+  let _value: T
+
+  new create(value: T) =>
+    _value = value
+
+  fun get(): T =>
+    """Returns the stored value."""
+    _value
+
+  fun with_generic_param[U: Any val](other: U): (T, U) =>
+    """
+    A generic method with its own type parameter.
+    Hover shows both the class type parameter T and method type parameter U.
+    """
+    (_value, other)
+
+class GenericPair[A: Any val, B: Any val]
+  """
+  Demonstrates multiple type parameters.
+  Hover shows 'class GenericPair[A: Any val, B: Any val]'
+  """
+  let first: A
+  let second: B
+
+  new create(a: A, b: B) =>
+    first = a
+    second = b
+
+  fun get_first(): A =>
+    """Returns the first element."""
+    first
+
+  fun get_second(): B =>
+    """Returns the second element."""
+    second
+
+trait MyComparable[T: MyComparable[T] box]
+  """
+  A trait demonstrating recursive type constraints.
+  Used for testing hover on constrained generics.
+  """
+  fun compare(that: box->T): I32
+
+class GenericContainer[T: Stringable val]
+  """
+  Demonstrates type constraints on generic parameters.
+  Hover shows 'class GenericContainer[T: Stringable val]'
+  """
+  let _items: Array[T]
+
+  new create() =>
+    _items = Array[T]
+
+  fun ref add(item: T) =>
+    """Add an item to the container."""
+    _items.push(item)
+
+  fun get_strings(): Array[String] =>
+    """
+    Returns string representations of all items.
+    Works because T is constrained to Stringable.
+    """
+    let result = Array[String]
+    for item in _items.values() do
+      result.push(item.string())
+    end
+    result
+
+actor GenericActor[T: Any val]
+  """
+  Demonstrates generic actors.
+  Hover shows 'actor GenericActor[T: Any val]'
+  """
+  var _state: T
+
+  new create(initial: T) =>
+    _state = initial
+
+  be update(new_state: T) =>
+    """Updates the actor's state."""
+    _state = new_state
+
+  be process[U: Any val](data: U) =>
+    """
+    A generic behavior with its own type parameter.
+    Demonstrates that behaviors can be generic too.
+    """
+    None
+
+primitive GenericHelper
+  """
+  Demonstrates generic methods in primitives.
+  """
+  fun identity[T: Any val](value: T): T =>
+    """
+    A generic identity function.
+    Hover shows 'fun identity[T: Any val](value: T): T'
+    """
+    value
+
+  fun create_pair[A: Any val, B: Any val](a: A, b: B): (A, B) =>
+    """Creates a tuple from two values of different types."""
+    (a, b)
+
+  fun apply[T: Any val](): Array[T] =>
+    """
+    Creates an empty array of any type.
+    Hover shows the generic return type Array[T].
+    """
+    Array[T]
+
+class GenericUsageDemo
+  """
+  Demonstrates hover on instantiated generic types.
+  """
+  fun demo_generic_instantiation() =>
+    """
+    Try hovering over the variable names (pair, container, numbers).
+    Hover shows the variable declaration with fully instantiated generic types
+    like 'let pair: GenericPair[String val, U32 val]'.
+
+    Note: Hovering on the type names themselves (GenericPair, GenericsDemo) will
+    follow to the class definition and show the type parameters instead.
+    """
+    let pair: GenericPair[String, U32] = GenericPair[String, U32]("hello", 42)
+    let container: GenericContainer[String] = GenericContainer[String]
+    let numbers: GenericsDemo[U64] = GenericsDemo[U64](100)
+
+    // Hover over method calls with generic types
+    let first = pair.get_first()  // Hover shows: let first: String val
+    let result = numbers.with_generic_param[String]("test")  // Hover shows: let result: (U64 val, String val)
+    None
+
 // ========== Examples of Current Limitations ==========
 
 class LimitationExamples

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -103,13 +103,15 @@ class val MethodInfo
   """
   let keyword: String
   let name: String
+  let type_params: String
   let params: String
   let return_type: String
   let docstring: String
 
-  new val create(keyword': String, name': String, params': String = "()", return_type': String = "", docstring': String = "") =>
+  new val create(keyword': String, name': String, type_params': String = "", params': String = "()", return_type': String = "", docstring': String = "") =>
     keyword = keyword'
     name = name'
+    type_params = type_params'
     params = params'
     return_type = return_type'
     docstring = docstring'
@@ -150,7 +152,7 @@ primitive HoverFormatter
     """
     Format method declaration as markdown hover text.
     """
-    let signature = info.keyword + " " + info.name + info.params + info.return_type
+    let signature = info.keyword + " " + info.name + info.type_params + info.params + info.return_type
     let code_block = _wrap_code_block(consume signature)
     if info.docstring.size() > 0 then
       code_block + "\n\n" + info.docstring
@@ -198,6 +200,7 @@ primitive HoverFormatter
 
     // Type references - try to follow to definition
     | TokenIds.tk_reference() => _format_reference(ast, channel)
+    | TokenIds.tk_typeref() => _format_reference(ast, channel)
     | TokenIds.tk_nominal() => _format_reference(ast, channel)
 
     // Function/method/constructor calls - follow to definition
@@ -236,16 +239,18 @@ primitive HoverFormatter
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
 
-        // Try to extract type parameters
-        let type_params_str = try
-          let type_params = ast(3)?
-          if type_params.id() == TokenIds.tk_typeparams() then
-            _extract_type_params(type_params, channel)
-          else
-            ""
+        // Extract type parameters
+        var type_params_str: String = ""
+        var idx: USize = 1
+        while idx < ast.num_children() do
+          try
+            let child = ast(idx)?
+            if child.id() == TokenIds.tk_typeparams() then
+              type_params_str = _extract_type_params(child, channel)
+              break
+            end
           end
-        else
-          ""
+          idx = idx + 1
         end
 
         // Extract docstring from child 6
@@ -288,6 +293,18 @@ primitive HoverFormatter
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
 
+        // Extract type parameters
+        let type_params_str = try
+          let type_params = ast(2)?
+          if type_params.id() == TokenIds.tk_typeparams() then
+            _extract_type_params(type_params, channel)
+          else
+            ""
+          end
+        else
+          ""
+        end
+
         // Extract parameters
         let params_str = try
           let params = ast(3)?
@@ -320,7 +337,7 @@ primitive HoverFormatter
           ""
         end
 
-        MethodInfo(keyword, name, params_str, return_type_str, docstring)
+        MethodInfo(keyword, name, type_params_str, params_str, return_type_str, docstring)
       else
         None
       end
@@ -601,17 +618,40 @@ primitive HoverFormatter
     match node_id
     | TokenIds.tk_nominal() =>
       // Nominal type - try to get the type name
-      // TK_NOMINAL structure: child(0) = package id ($0 for builtin), child(1) = type name
+      // TK_NOMINAL structure: child(0) = package id ($0 for builtin), child(1) = type name,
+      // child(2+) = capability (optional), type args (optional)
       try
         let num_children = type_node.num_children()
         if num_children > 1 then
           let type_id = type_node(1)?
-          if type_id.id() == TokenIds.tk_id() then
+          let base_name = if type_id.id() == TokenIds.tk_id() then
             type_id.token_value() as String
           else
             // Try to recursively extract from child
             _extract_type(type_id, channel)
           end
+
+          // Check for capability and type arguments
+          var capability_str: String = ""
+          var type_args_str: String = ""
+          var idx: USize = 2
+          while idx < num_children do
+            try
+              let child = type_node(idx)?
+              if child.id() == TokenIds.tk_typeargs() then
+                type_args_str = _extract_typeargs(child, channel)
+              else
+                let cap = _extract_capability(child.id())
+                if cap != "" then
+                  capability_str = cap
+                end
+              end
+            end
+            idx = idx + 1
+          end
+
+          let cap_str = if capability_str.size() > 0 then " " + capability_str else "" end
+          base_name + type_args_str + cap_str
         else
           "?"
         end
@@ -625,6 +665,23 @@ primitive HoverFormatter
       else
         "?"
       end
+    | TokenIds.tk_typeparamref() =>
+      // Type parameter reference (like T, U in generic types)
+      // Structure: may have child(0) = id or have token value
+      try
+        let child = type_node(0)?
+        if child.id() == TokenIds.tk_id() then
+          child.token_value() as String
+        else
+          type_node.token_value() as String
+        end
+      else
+        try
+          type_node.token_value() as String
+        else
+          "?"
+        end
+      end
     | TokenIds.tk_uniontype() =>
       // Union type: (Type1 | Type2 | Type3)
       _extract_composite_type(type_node, " | ", channel)
@@ -636,15 +693,52 @@ primitive HoverFormatter
       _extract_composite_type(type_node, ", ", channel)
     | TokenIds.tk_arrow() =>
       // Arrow type: left->right (viewpoint adaptation)
-      // For display purposes, just show the right side (the actual type)
       try
-        _extract_type(type_node(1)?, channel)
+        let left_child = type_node(0)?
+        let left_cap = _extract_capability(left_child.id())
+        let right = _extract_type(type_node(1)?, channel)
+        if left_cap.size() > 0 then
+          left_cap + "->" + right
+        else
+          right
+        end
       else
         "?"
       end
     else
       // For other type node types, return a placeholder
       TokenIds.string(node_id)
+    end
+
+  fun tag _extract_capability(node_id: I32): String =>
+    """
+    Extract capability string from a capability token ID.
+    Returns capability name like "val" or empty string if not a capability.
+    """
+    match node_id
+    | TokenIds.tk_iso() => "iso"
+    | TokenIds.tk_trn() => "trn"
+    | TokenIds.tk_ref() => "ref"
+    | TokenIds.tk_val() => "val"
+    | TokenIds.tk_box() => "box"
+    | TokenIds.tk_tag() => "tag"
+    else
+      ""
+    end
+
+  fun tag _extract_typeargs(typeargs_node: AST box, channel: Channel): String =>
+    """
+    Extract type arguments from a tk_typeargs node.
+    Returns formatted string like "[T1, T2]" or empty string if no args.
+    """
+    let arg_strs = Array[String]
+    for arg in typeargs_node.children() do
+      arg_strs.push(_extract_type(arg, channel))
+    end
+    if arg_strs.size() > 0 then
+      "[" + ", ".join(arg_strs.values()) + "]"
+    else
+      ""
     end
 
   fun tag _extract_composite_type(type_node: AST box, separator: String, channel: Channel): String =>


### PR DESCRIPTION
### Context

The Pony LSP hover functionality previously did not display type parameters, type arguments, or capabilities in hover tooltips. When hovering on generic types like `Array[U32]` or class declarations like `class Container[T: Any val]`, only the base type name was shown without the generic information. This made it difficult to understand the full type signatures in code using generics.

### Changes

- Extract and display type parameters on classes, traits, and methods (e.g., `[T: Any val]`)
- Extract and display type arguments in instantiated types (e.g., `Array[U32 val]`)
- Extract and display capabilities on all types (val, ref, box, iso, trn, tag)
- Handle type parameter references (`tk_typeparamref`)
- Handle type references in constructor calls (`tk_typeref`)
- Support viewpoint adaptation/arrow types (e.g., `box->T`)
- Add test fixtures for manual testing of generics hover

### Consequences

Hover tooltips now show complete type information including all generic type parameters and arguments, making it significantly easier for developers to understand complex type signatures. The explicit display of capabilities (like `I32 val`, `String val`) shows what the compiler inferred, which may differ from idiomatic source code that omits default capabilities.



https://github.com/user-attachments/assets/de956e42-240e-44e0-b851-f54dae4593d0


