### PR TITLE
Fix incorrect array element type inference for union types

### DIFF
--- a/.release-notes/4794.md
+++ b/.release-notes/4794.md
@@ -1,0 +1,26 @@
+## Fix incorrect array element type inference for union types
+
+Due to a small bug in the type system implementation, the following correct code would fail to compile.  We have fixed this bug so it will now compiler.
+
+```pony
+type Foo is (Bar box | Baz box | Bool)
+
+class Bar
+  embed _items: Array[Foo] = _items.create()
+
+  new create(items: ReadSeq[Foo]) =>
+    for item in items.values() do
+      _items.push(item)
+    end
+
+class Baz
+
+actor Main
+  new create(env: Env) =>
+    let bar = Bar([
+      true
+      Bar([ false ])
+    ])
+    env.out.print("done")
+```
+

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -37,14 +37,22 @@ static ast_t* strip_this_arrow(pass_opt_t* opt, ast_t* ast)
     (ast_id(ast_child(ast)) == TK_THISTYPE))
     return ast_childidx(ast, 1);
 
-  if(ast_id(ast) == TK_TUPLETYPE)
+  switch(ast_id(ast))
   {
-    ast_t* new_ast = ast_from(ast, TK_TUPLETYPE);
+    case TK_TUPLETYPE:
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    {
+      ast_t* new_ast = ast_from(ast, ast_id(ast));
 
-    for(ast_t* c = ast_child(ast); c != NULL; c = ast_sibling(c))
-      ast_append(new_ast, strip_this_arrow(opt, c));
+      for(ast_t* c = ast_child(ast); c != NULL; c = ast_sibling(c))
+        ast_append(new_ast, strip_this_arrow(opt, c));
 
-    return new_ast;
+      return new_ast;
+    }
+
+    default:
+      break;
   }
 
   return ast;

--- a/test/full-program-tests/regression-4281/main.pony
+++ b/test/full-program-tests/regression-4281/main.pony
@@ -1,0 +1,23 @@
+// Regression test for issue #4281: Incorrect array inference
+// When a union type like (Bar box | Baz box | Bool) is used as an element type
+// of ReadSeq, the array inference should correctly strip the this-> viewpoint
+// from union members when checking if array elements are subtypes.
+
+type Foo is (Bar box | Baz box | Bool)
+
+class Bar
+  embed _items: Array[Foo] = _items.create()
+
+  new create(items: ReadSeq[Foo]) =>
+    for item in items.values() do
+      _items.push(item)
+    end
+
+class Baz
+
+actor Main
+  new create(env: Env) =>
+    let bar = Bar([
+      true
+      Bar([ false ])
+    ])


### PR DESCRIPTION
The strip_this_arrow function in array.c was not handling union and intersection types when removing this-> viewpoint prefixes from element types inferred from ReadSeq interfaces. This caused array element subtype checks to fail incorrectly when the element type was a union containing class types with box capability.

For example, with `type Foo is (Bar box | Baz box | Bool)`, passing `Bar([false])` to an array expecting `Foo` elements would fail because the inferred type `(this->Bar box | this->Baz box | Bool)` was not being stripped of its this-> prefixes, causing the subtype check to compare against the viewpoint lower bound (Bar val) instead of Bar box.

Fixes #4281