### PR TITLE
Fix crash when using bare integer literals in array match patterns

### DIFF
--- a/.release-notes/4797.md
+++ b/.release-notes/4797.md
@@ -1,0 +1,28 @@
+## Fix crash when using bare integer literals in array match patterns
+
+Array does not implement the Equatable interface, which queries for structural equality.  Previous to this fix, an error in the type inference logic resulted in the code below resulting in a compiler crash instead of the expected helpful error message:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let arr: Array[U8 val] = [4; 5]
+    match arr
+    | [2; 3] => None
+    else
+      None
+    end
+```
+
+Now, the correct helpful error message is provided:
+
+```quote
+Error:
+main.pony:5:7: couldn't find 'eq' in 'Array'
+    | [2; 3] => None
+      ^
+Error:
+main.pony:5:7: this pattern element doesn't support structural equality
+    | [2; 3] => None
+      ^
+```
+

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -497,10 +497,11 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 }
 
 // Infer the types of any literals in the pattern of the given case
-static bool infer_pattern_type(ast_t* pattern, ast_t* match_expr_type,
+static bool infer_pattern_type(ast_t** astp, ast_t* match_expr_type,
   pass_opt_t* opt)
 {
-  pony_assert(pattern != NULL);
+  pony_assert(astp != NULL);
+  pony_assert(*astp != NULL);
   pony_assert(match_expr_type != NULL);
 
   if(is_type_literal(match_expr_type))
@@ -510,7 +511,7 @@ static bool infer_pattern_type(ast_t* pattern, ast_t* match_expr_type,
     return false;
   }
 
-  return coerce_literals(&pattern, match_expr_type, opt);
+  return coerce_literals(astp, match_expr_type, opt);
 }
 
 bool expr_case(pass_opt_t* opt, ast_t* ast)
@@ -542,7 +543,7 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
     is_typecheck_error(match_type))
     return false;
 
-  if(!infer_pattern_type(pattern, match_type, opt))
+  if(!infer_pattern_type(&pattern, match_type, opt))
     return false;
 
   ast_t* pattern_type = make_pattern_type(opt, pattern);

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1345,3 +1345,23 @@ TEST_F(BadPonyTest, MatchIsoLetWithoutConsume)
 
     TEST_ERRORS_1(src, "this capture violates capabilities");
 }
+
+TEST_F(BadPonyTest, MatchArrayPatternWithBareIntegerLiterals)
+{
+  // From issue #4554
+  // Using bare integer literals in array match patterns used to crash
+  // the compiler. Now it should produce a proper error message.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let arr: Array[U8 val] = [4; 5]\n"
+    "    match arr\n"
+    "    | [2; 3] => None\n"
+    "    else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "couldn't find 'eq' in 'Array'",
+    "this pattern element doesn't support structural equality");
+}


### PR DESCRIPTION
When array literals with untyped integer literals (e.g., `[2; 3]`) were used as match patterns, the compiler would crash with an assertion failure. This was caused by `infer_pattern_type` taking the pattern by value instead of by pointer. When `coerce_literals` transformed the array, the original AST was freed but the caller retained a dangling pointer.

Changed `infer_pattern_type` to take `ast_t**` so pointer updates from AST transformations are properly reflected to the caller.

Fixes #4554 