### PR TITLE
Add hover support for receiver capability to LSP

### DIFF
--- a/.release-notes/4798.md
+++ b/.release-notes/4798.md
@@ -1,0 +1,25 @@
+## Add hover support for receiver capability to LSP
+
+The Language Server Protocol (LSP) hover feature now displays receiver capabilities in method signatures.
+
+When hovering over a method reference, the hover information will now show the receiver capability (e.g., `box`, `val`, `ref`, `iso`, `trn`, `tag`) in the method signature. This provides more complete type information at a glance.
+
+### Examples
+
+Previously, hovering over a method would show:
+```pony
+fun boxed_method(): String
+```
+
+Now, it correctly displays:
+```pony
+fun box boxed_method(): String
+```
+
+This applies to all receiver capabilities:
+- `fun box method()` - read-only access
+- `fun ref method()` - mutable reference access  
+- `fun val method()` - immutable value access
+- `fun iso method()` - isolated reference access
+- `fun trn method()` - transition reference access
+- `fun tag method()` - opaque reference access

--- a/.release-notes/4798.md
+++ b/.release-notes/4798.md
@@ -7,16 +7,19 @@ When hovering over a method reference, the hover information will now show the r
 ### Examples
 
 Previously, hovering over a method would show:
+
 ```pony
 fun boxed_method(): String
 ```
 
 Now, it correctly displays:
+
 ```pony
 fun box boxed_method(): String
 ```
 
 This applies to all receiver capabilities:
+
 - `fun box method()` - read-only access
 - `fun ref method()` - mutable reference access  
 - `fun val method()` - immutable value access

--- a/tools/pony-lsp/test/_hover_tests.pony
+++ b/tools/pony-lsp/test/_hover_tests.pony
@@ -25,6 +25,7 @@ primitive _HoverTests is TestList
     test(_HoverFormatFieldWithNestedGenericTypeTest)
     test(_HoverFormatParameterTest)
     test(_HoverFormatParameterWithTypeTest)
+    test(_HoverFormatMethodWithReceiverCapTest)
 
 class \nodoc\ iso _HoverFormatEntityTest is UnitTest
   fun name(): String => "hover/format_entity"
@@ -54,7 +55,7 @@ class \nodoc\ iso _HoverFormatMethodTest is UnitTest
   fun name(): String => "hover/format_method"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "my_method")
+    let info = MethodInfo("fun", "my_method", "")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun my_method()\n```", result)
 
@@ -62,7 +63,7 @@ class \nodoc\ iso _HoverFormatMethodWithReturnTypeTest is UnitTest
   fun name(): String => "hover/format_method_with_return_type"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "get_value", "", "(x: U32)", ": String")
+    let info = MethodInfo("fun", "get_value", "", "", "(x: U32)", ": String")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun get_value(x: U32): String\n```", result)
 
@@ -70,7 +71,7 @@ class \nodoc\ iso _HoverFormatMethodWithDocstringTest is UnitTest
   fun name(): String => "hover/format_method_with_docstring"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("be", "process", "", "(data: Array[U8] val)", "", "Process data asynchronously.")
+    let info = MethodInfo("be", "process", "", "", "(data: Array[U8] val)", "", "Process data asynchronously.")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nbe process(data: Array[U8] val)\n```\n\nProcess data asynchronously.", result)
 
@@ -94,7 +95,7 @@ class \nodoc\ iso _HoverFormatMethodWithTypeParamsTest is UnitTest
   fun name(): String => "hover/format_method_with_type_params"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "map", "[U: Any val]", "(f: {(T): U} val)", ": U")
+    let info = MethodInfo("fun", "map", "", "[U: Any val]", "(f: {(T): U} val)", ": U")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun map[U: Any val](f: {(T): U} val): U\n```", result)
 
@@ -118,7 +119,7 @@ class \nodoc\ iso _HoverFormatMethodWithArrowTypeTest is UnitTest
   fun name(): String => "hover/format_method_with_arrow_type"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "compare", "", "(that: box->T)", ": I32 val")
+    let info = MethodInfo("fun", "compare", "", "", "(that: box->T)", ": I32 val")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun compare(that: box->T): I32 val\n```", result)
 
@@ -142,7 +143,7 @@ class \nodoc\ iso _HoverFormatMethodWithCompleteSignatureTest is UnitTest
   fun name(): String => "hover/format_method_with_complete_signature"
 
   fun apply(h: TestHelper) =>
-    let info = MethodInfo("fun", "transform", "[U: Any val]", "(data: Array[T] ref)", ": Array[U] ref", "Transform elements.")
+    let info = MethodInfo("fun", "transform", "", "[U: Any val]", "(data: Array[T] ref)", ": Array[U] ref", "Transform elements.")
     let result = HoverFormatter.format_method(info)
     h.assert_eq[String]("```pony\nfun transform[U: Any val](data: Array[T] ref): Array[U] ref\n```\n\nTransform elements.", result)
 
@@ -177,3 +178,11 @@ class \nodoc\ iso _HoverFormatParameterWithTypeTest is UnitTest
     let info = FieldInfo("param", "name", ": String")
     let result = HoverFormatter.format_field(info)
     h.assert_eq[String]("```pony\nparam name: String\n```", result)
+
+class \nodoc\ iso _HoverFormatMethodWithReceiverCapTest is UnitTest
+  fun name(): String => "hover/format_method_with_receiver_cap"
+
+  fun apply(h: TestHelper) =>
+    let info = MethodInfo("fun", "boxed_method", "box", "", "()", ": String")
+    let result = HoverFormatter.format_method(info)
+    h.assert_eq[String]("```pony\nfun box boxed_method(): String\n```", result)

--- a/tools/pony-lsp/test/workspace/hover_fixture.pony
+++ b/tools/pony-lsp/test/workspace/hover_fixture.pony
@@ -268,6 +268,33 @@ class GenericUsageDemo
     let result = numbers.with_generic_param[String]("test")  // Hover shows: let result: (U64 val, String val)
     None
 
+class ReceiverCapabilityDemo
+  """
+  Demonstrates that hover displays receiver capabilities in method signatures.
+  """
+
+  fun box boxed_method(): String =>
+    """
+    A boxed method - receiver capability is 'box'.
+    Hover shows 'fun box boxed_method(): String' with the receiver capability.
+    The receiver capability indicates how 'this' can be accessed in the method.
+    """
+    "box"
+
+  fun val valued_method(): String =>
+    """
+    A val method - receiver capability is 'val'.
+    Hover shows 'fun val valued_method(): String' with the receiver capability.
+    """
+    "val"
+
+  fun ref mutable_method() =>
+    """
+    A ref method - receiver capability is 'ref'.
+    Hover shows 'fun ref mutable_method()' with the receiver capability.
+    """
+    None
+
 // ========== Examples of Current Limitations ==========
 
 class LimitationExamples
@@ -276,7 +303,7 @@ class LimitationExamples
   currently provide information but ideally should.
   """
 
-  // Limitation 1: Primitive type documentation
+  // Limitation: Primitive type documentation
   fun demo_primitive_types(): USize =>
     """
     Try hovering over primitive numeric types vs classes.
@@ -290,33 +317,3 @@ class LimitationExamples
     let numbers: Array[U32] = []    // Hover shows full Array documentation
     let value: U32 = 0              // Hover shows just: primitive U32
     text.size() + numbers.size() + value.usize()
-
-  // Limitation 2: Receiver capabilities not shown in signatures
-  fun box boxed_method(): String =>
-    """
-    A boxed method - receiver capability is 'box'.
-
-    EXPECTED: Hover should show 'fun box boxed_method(): String'
-    ACTUAL: Hover shows 'fun boxed_method(): String' (missing 'box')
-
-    The receiver capability indicates how 'this' can be accessed in the method.
-    """
-    "box"
-
-  fun val valued_method(): String =>
-    """
-    A val method - receiver capability is 'val'.
-
-    EXPECTED: Should show 'fun val valued_method(): String'
-    ACTUAL: Shows 'fun valued_method(): String' (missing 'val')
-    """
-    "val"
-
-  fun ref mutable_method() =>
-    """
-    A ref method - receiver capability is 'ref'.
-
-    EXPECTED: Should show 'fun ref mutable_method()'
-    ACTUAL: Shows 'fun mutable_method()' (missing 'ref')
-    """
-    None

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -76,7 +76,6 @@ end
 
 Current implementation does not support:
 - **Primitive type documentation**: Numeric primitives (U32, I64, etc.) show minimal info (just `primitive U32`) without docstrings, while classes like String and Array show full documentation
-- **Receiver capabilities**: Method signatures don't include the receiver capability (shows `fun method()` instead of `fun box method()`, `fun ref method()`, etc.)
 """
 use ".."
 use "ast"
@@ -102,14 +101,16 @@ class val MethodInfo
   """
   let keyword: String
   let name: String
+  let receiver_cap: String
   let type_params: String
   let params: String
   let return_type: String
   let docstring: String
 
-  new val create(keyword': String, name': String, type_params': String = "", params': String = "()", return_type': String = "", docstring': String = "") =>
+  new val create(keyword': String, name': String, receiver_cap': String = "", type_params': String = "", params': String = "()", return_type': String = "", docstring': String = "") =>
     keyword = keyword'
     name = name'
+    receiver_cap = receiver_cap'
     type_params = type_params'
     params = params'
     return_type = return_type'
@@ -147,11 +148,13 @@ primitive HoverFormatter
       code_block
     end
 
-  fun format_method(info: MethodInfo): String =>
+  fun tag format_method(info: MethodInfo): String =>
     """
-    Format method declaration as markdown hover text.
+    Format method information into markdown hover text.
+    Returns a string with signature in a code block and optional docstring.
     """
-    let signature = info.keyword + " " + info.name + info.type_params + info.params + info.return_type
+    let cap_str = if info.receiver_cap.size() > 0 then " " + info.receiver_cap else "" end
+    let signature = info.keyword + cap_str + " " + info.name + info.type_params + info.params + info.return_type
     let code_block = _wrap_code_block(consume signature)
     if info.docstring.size() > 0 then
       code_block + "\n\n" + info.docstring
@@ -295,6 +298,14 @@ primitive HoverFormatter
     Extract method information from AST node.
     """
     try
+      // Extract receiver capability from child(0)
+      let receiver_cap = try
+        let cap = ast(0)?
+        _extract_capability(cap.id())
+      else
+        ""
+      end
+
       let id = ast(1)?
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
@@ -343,7 +354,7 @@ primitive HoverFormatter
           ""
         end
 
-        MethodInfo(keyword, name, type_params_str, params_str, return_type_str, docstring)
+        MethodInfo(keyword, name, receiver_cap, type_params_str, params_str, return_type_str, docstring)
       else
         None
       end

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -148,7 +148,7 @@ primitive HoverFormatter
       code_block
     end
 
-  fun tag format_method(info: MethodInfo): String =>
+  fun format_method(info: MethodInfo): String =>
     """
     Format method information into markdown hover text.
     Returns a string with signature in a code block and optional docstring.


### PR DESCRIPTION
## Context

The LSP hover feature was displaying method signatures without receiver capabilities. When hovering over methods with explicit receiver caps like `fun box method()` or `fun ref method()`, the hover would only show `fun method()`, omitting important type information about how `this` can be accessed within the method.

## Changes

- Modified `HoverFormatter.extract_method()` to extract receiver capability from the first child of method AST nodes
- Updated `MethodInfo` class to include a `receiver_cap` field
- Updated `HoverFormatter.format_method()` to include receiver capability in formatted signatures
- Added test case `_HoverFormatMethodWithReceiverCapTest` to verify receiver cap display
- Updated all existing method info test cases to accommodate the new parameter
- Updated `hover_fixture.pony` to move receiver capability examples from "Limitations" to a working "ReceiverCapabilityDemo" class
- Removed receiver capability limitation from hover.pony documentation

## Consequences

Hover information now provides more complete and accurate type signatures, helping developers better understand method contracts at a glance. The hover text now matches the actual method declaration syntax more closely.

https://github.com/user-attachments/assets/5b4fef97-ef5c-4fdb-8efc-aac16d7a13d9

