### PR TITLE
Fix primitive value hover in LSP

### DIFF
--- a/.release-notes/4799.md
+++ b/.release-notes/4799.md
@@ -1,0 +1,3 @@
+## Fix primitive value hover in LSP
+
+When hovering over primitive values like `None`, the LSP now shows the primitive definition (e.g., `primitive None`) instead of the implicit constructor (`new val create()`). This fixes confusing hover behavior where primitives displayed their internal constructor rather than the primitive type itself.

--- a/tools/pony-lsp/test/workspace/hover_fixture.pony
+++ b/tools/pony-lsp/test/workspace/hover_fixture.pony
@@ -294,26 +294,3 @@ class ReceiverCapabilityDemo
     Hover shows 'fun ref mutable_method()' with the receiver capability.
     """
     None
-
-// ========== Examples of Current Limitations ==========
-
-class LimitationExamples
-  """
-  This class demonstrates hover limitations - cases where hover doesn't
-  currently provide information but ideally should.
-  """
-
-  // Limitation: Primitive type documentation
-  fun demo_primitive_types(): USize =>
-    """
-    Try hovering over primitive numeric types vs classes.
-    Classes (String, Array): Show full documentation with docstrings
-    Primitives (U32, I64, etc.): Show minimal info, just 'primitive U32'
-
-    This is because primitives in the stdlib may lack docstrings or they
-    aren't being extracted properly from the builtin package.
-    """
-    let text: String = ""           // Hover shows full String documentation
-    let numbers: Array[U32] = []    // Hover shows full Array documentation
-    let value: U32 = 0              // Hover shows just: primitive U32
-    text.size() + numbers.size() + value.usize()


### PR DESCRIPTION

## Context

When hovering over primitive values like `None`, the hover displayed the implicit constructor (`new val create()`) instead of the primitive definition. This was confusing and inconsistent with how other types are displayed.

## Changes

Modified the hover formatter to detect when hovering resolves to a primitive's constructor. When detected, the formatter now traverses up the AST to show the parent primitive definition instead.

<img width="460" height="283" alt="image" src="https://github.com/user-attachments/assets/9a2fdedf-b085-436d-90be-d1b1a9fd9355" />


## Consequences

Hovering over primitive values like `None` now displays `primitive None` with its documentation, providing a more intuitive and consistent hover experience.
