### PR TITLE
Remove primitive type documentation from limitations

### DIFF
--- a/tools/pony-lsp/test/workspace/hover_fixture.pony
+++ b/tools/pony-lsp/test/workspace/hover_fixture.pony
@@ -294,26 +294,3 @@ class ReceiverCapabilityDemo
     Hover shows 'fun ref mutable_method()' with the receiver capability.
     """
     None
-
-// ========== Examples of Current Limitations ==========
-
-class LimitationExamples
-  """
-  This class demonstrates hover limitations - cases where hover doesn't
-  currently provide information but ideally should.
-  """
-
-  // Limitation: Primitive type documentation
-  fun demo_primitive_types(): USize =>
-    """
-    Try hovering over primitive numeric types vs classes.
-    Classes (String, Array): Show full documentation with docstrings
-    Primitives (U32, I64, etc.): Show minimal info, just 'primitive U32'
-
-    This is because primitives in the stdlib may lack docstrings or they
-    aren't being extracted properly from the builtin package.
-    """
-    let text: String = ""           // Hover shows full String documentation
-    let numbers: Array[U32] = []    // Hover shows full Array documentation
-    let value: U32 = 0              // Hover shows just: primitive U32
-    text.size() + numbers.size() + value.usize()

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -71,11 +71,6 @@ match hover_text
 | None => // No hover info available
 end
 ```
-
-## Limitations
-
-Current implementation does not support:
-- **Primitive type documentation**: Numeric primitives (U32, I64, etc.) show minimal info (just `primitive U32`) without docstrings, while classes like String and Array show full documentation
 """
 use ".."
 use "ast"


### PR DESCRIPTION
Primitive types (`U32`, `I64`, etc.) don't have docstrings in the stdlib, so LSP showing minimal info is correct behavior, not a limitation.

Remove the documentation that states it's a limitation. (I incorrectly assumed it was the LSP).

<img width="533" height="223" alt="image" src="https://github.com/user-attachments/assets/447ddb0d-3f9f-4ac4-a4bb-74c0b25f11fc" />
