### PR TITLE
Update environment for musl runtime stress tests

### DIFF
--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -38,19 +38,19 @@ jobs:
             name: x86-64-unknown-linux-ubuntu24.04 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
@@ -130,19 +130,19 @@ jobs:
             name: arm64-unknown-linux-ubuntu24.04 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -38,19 +38,19 @@ jobs:
             name: x86-64-unknown-linux-ubuntu24.04 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [release]
             target: test-stress-ubench-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: x86-64-unknown-linux-alpine3.21 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
@@ -130,19 +130,19 @@ jobs:
             name: arm64-unknown-linux-ubuntu24.04 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [release]
             target: test-stress-ubench-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.21 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb


### PR DESCRIPTION
This commit updates from running stress tests in an Alpine 3.21 environment to a Alpine 3.23 environment.