### PR TITLE
Fix runtime crash with iso in mixed-capability union type

### DIFF
--- a/.release-notes/fix-runtime-crash-with-iso-in-mixed-capability-union-type.md
+++ b/.release-notes/fix-runtime-crash-with-iso-in-mixed-capability-union-type.md
@@ -1,0 +1,30 @@
+## Fix runtime crash with iso in mixed-capability union type
+
+Matching on a destructively read `iso` field would crash at runtime with a segfault in the GC when the field's union type also contained a `val` member. For example, this program would crash:
+
+```pony
+class A
+  var v: Any val
+  new create(v': Any val) =>
+    v = consume v'
+
+class B
+
+actor Foo
+  var _x: (A iso | B val | None)
+
+  new create(x': (A iso | B val | None)) =>
+    _x = consume x'
+
+  be f() =>
+    match (_x = None)
+    | let a: A iso => None
+    end
+
+actor Main
+  new create(env: Env) =>
+    let f = Foo(recover A("hello".string()) end)
+    f.f()
+```
+
+The crash occurred because the GC traced the `iso` object incorrectly, leading to a reference count imbalance and use-after-free. This has been fixed.

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -541,6 +541,24 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
 
   token_id orig_cap = ast_id(cap);
 
+  // Strip ephemeral before the matchtype probes below. Tracing is a
+  // receiver-side question ("could a receiver match-extract this as cap
+  // X?"), and ephemerality is a sender-side consume-semantic concern the
+  // receiver never sees. The call sites are asymmetric: gencall.c (send
+  // side) passes the call-site expression type, which is ephemeral when
+  // the argument came from a consume, recover, or destructive read.
+  // genfun.c (receive side) passes the parameter AST, which is never
+  // ephemeral. Without the strip, the strict ephemeral check in
+  // is_cap_sub_cap (tightened as the soundness fix for #4588, codified
+  // at test/libponyc/matchtype.cc:466-477) makes the iso probe fail, the
+  // tag probe wins, and the sender emits PONY_TRACE_OPAQUE while the
+  // receiver emits PONY_TRACE_MUTABLE. The recursion mismatch crashes
+  // the GC. See #4807.
+  ast_t* eph = ast_sibling(cap);
+  token_id orig_eph = ast_id(eph);
+  if(orig_eph == TK_EPHEMERAL)
+    ast_setid(eph, TK_NONE);
+
   // We can have a non-sendable rcap if we're tracing a field in a type's trace
   // function. In this case we must always recurse and we have to trace the
   // field as mutable.
@@ -549,6 +567,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
     case TK_TRN:
     case TK_REF:
     case TK_BOX:
+      ast_setid(eph, orig_eph);
       return PONY_TRACE_MUTABLE;
 
     default: {}
@@ -561,6 +580,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
   {
     if(is_matchtype(orig, type, NULL, opt) == MATCHTYPE_ACCEPT)
     {
+      ast_setid(eph, orig_eph);
       return PONY_TRACE_MUTABLE;
     } else {
       ast_setid(cap, TK_VAL);
@@ -572,6 +592,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
     if(is_matchtype(orig, type, NULL, opt) == MATCHTYPE_ACCEPT)
     {
       ast_setid(cap, orig_cap);
+      ast_setid(eph, orig_eph);
       return PONY_TRACE_IMMUTABLE;
     } else {
       ast_setid(cap, TK_TAG);
@@ -585,6 +606,7 @@ static int trace_cap_nominal(pass_opt_t* opt, ast_t* type, ast_t* orig,
     ret = PONY_TRACE_OPAQUE;
 
   ast_setid(cap, orig_cap);
+  ast_setid(eph, orig_eph);
   return ret;
 }
 

--- a/test/full-program-tests/codegen-trace-iso-in-dynamic-union/main.pony
+++ b/test/full-program-tests/codegen-trace-iso-in-dynamic-union/main.pony
@@ -1,0 +1,22 @@
+class A
+  var v: Any val
+  new create(v': Any val) =>
+    v = consume v'
+
+class B
+
+actor Foo
+  var _x: (A iso | B val | None)
+
+  new create(x': (A iso | B val | None)) =>
+    _x = consume x'
+
+  be f() =>
+    match (_x = None)
+    | let a: A iso => None
+    end
+
+actor Main
+  new create(env: Env) =>
+    let f = Foo(recover A("hello".string()) end)
+    f.f()


### PR DESCRIPTION
trace_cap_nominal() has two call sites with an asymmetry in the types they pass: the send side (gencall.c) passes the call-site expression type, which is ephemeral when the argument came from a consume, recover, or destructive read; the receive side (genfun.c) passes the parameter AST, which is never ephemeral. The matchtype probes inside trace_cap_nominal() gave different answers for the two shapes because the strict ephemerality check in is_cap_sub_cap (the soundness fix from #4588) made the iso probe fail on the ephemeral form. The tag probe won instead, so the sender emitted PONY_TRACE_OPAQUE while the receiver emitted PONY_TRACE_MUTABLE. The recursion mismatch caused a GC reference count imbalance leading to use-after-free.

Strip the ephemeral marker before the matchtype probes so the function asks the same question on both sides. Tracing is a receiver-side question ("could a receiver match-extract this as cap X?"), and ephemerality is a sender-side consume-semantic concern the receiver never sees. This is the smallest change that resolves the asymmetry without loosening the is_cap_sub_cap check that #4588 tightened for soundness.

The larger cleanup of trace_cap_nominal's mutate-and-restore pattern is tracked in #5189.

Fixes #4807