### PR TITLE
Make pony-lsp version dynamic to match ponyc version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _ReSharper.*
 src/common/dtrace_probes.h
 packages/stdlib/stdlib
 /stdlib-docs/
+tools/pony-lsp/version.pony
 
 # Allow these paths
 !src/libponyrt/lang/except_try_catch.ll

--- a/.release-notes/4830.md
+++ b/.release-notes/4830.md
@@ -1,0 +1,3 @@
+## Make pony-lsp version dynamic to match ponyc version
+
+Previously, the version of pony-lsp was hardcoded in the source code. Now it is dynamically generated from the ponyc version.

--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -7,14 +7,28 @@ if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../${CMAKE_BUILD_TYPE})
 endif()
 
+# Generate version.pony in build dir, then copy to source dir during compilation
+# (.gitignore prevents it from dirtying the git tree)
+set(VERSION_PONY_FILE "${CMAKE_CURRENT_BINARY_DIR}/version.pony")
+add_custom_command(
+  OUTPUT ${VERSION_PONY_FILE}
+  COMMAND ${CMAKE_COMMAND} -E echo "primitive PonyLspVersion" > ${VERSION_PONY_FILE}
+  COMMAND ${CMAKE_COMMAND} -E echo "  fun version_string(): String => \"${PONYC_VERSION}\"" >> ${VERSION_PONY_FILE}
+  DEPENDS ${CMAKE_SOURCE_DIR}/VERSION
+  COMMENT "Generating version.pony with version ${PONYC_VERSION}"
+  VERBATIM
+)
+
 add_custom_target(tools.pony-lsp ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE})
 
 # TODO STA: --path entries are temporary until a ponyc bug is fixed.
 file(GLOB_RECURSE LSP_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE}
   COMMAND echo "Building pony-lsp..."
+  COMMAND ${CMAKE_COMMAND} -E copy ${VERSION_PONY_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/version.pony
   COMMAND $<TARGET_FILE:ponyc> --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/peg/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-ast/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-binarysearch/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-immutable-json/ -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
+    ${VERSION_PONY_FILE}
     ${LSP_SOURCES}
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -253,7 +253,7 @@ actor LanguageServer is Notifier
           )(
             "serverInfo", Obj(
               "name", "Pony Language Server")(
-              "version", "0.2.1"
+              "version", PonyLspVersion.version_string()
             ).build()
           ).build()
         )


### PR DESCRIPTION
## Context

The pony-lsp version was hardcoded as "0.2.1" and did not match the ponyc version. When running `ponyc --version` it reports "0.60.6-71ecb352 [release]", but the language server reported an outdated version to LSP clients.

<img width="601" height="416" alt="Screenshot 2026-02-12 at 8 12 58 am" src="https://github.com/user-attachments/assets/067406a3-bebd-417a-9896-b530374e93ec" />


## Changes

- Generate `version.pony` at build time with the actual ponyc version from the `PONYC_VERSION` CMake variable
- Update `language_server.pony` to use `PonyLspVersion.version_string()` instead of a hardcoded string
- Add `tools/pony-lsp/version.pony` to `.gitignore`

<img width="667" height="422" alt="Screenshot 2026-02-12 at 8 16 27 am" src="https://github.com/user-attachments/assets/54232511-5075-44bc-af7f-23f4bbb7a6c2" />


## Considerations

The generated `version.pony` file remains in the source directory after build but is ignored by git. This approach is simpler and more robust than attempting to clean up the file, avoiding issues with interrupted or failed builds.