### PR TITLE
Simplify pony-lsp version generation using CMake `configure_file`

### DIFF
--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -7,17 +7,9 @@ if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../${CMAKE_BUILD_TYPE})
 endif()
 
-# Generate version.pony in build dir, then copy to source dir during compilation
-# (.gitignore prevents it from dirtying the git tree)
-set(VERSION_PONY_FILE "${CMAKE_CURRENT_BINARY_DIR}/version.pony")
-add_custom_command(
-  OUTPUT ${VERSION_PONY_FILE}
-  COMMAND ${CMAKE_COMMAND} -E echo "primitive PonyLspVersion" > ${VERSION_PONY_FILE}
-  COMMAND ${CMAKE_COMMAND} -E echo "  fun version_string(): String => \"${PONYC_VERSION}\"" >> ${VERSION_PONY_FILE}
-  DEPENDS ${CMAKE_SOURCE_DIR}/VERSION
-  COMMENT "Generating version.pony with version ${PONYC_VERSION}"
-  VERBATIM
-)
+# Generate version.pony from template
+# (.gitignore prevents version.pony from dirtying the git tree)
+configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-lsp ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE})
 
@@ -25,10 +17,8 @@ add_custom_target(tools.pony-lsp ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$
 file(GLOB_RECURSE LSP_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE}
   COMMAND echo "Building pony-lsp..."
-  COMMAND ${CMAKE_COMMAND} -E copy ${VERSION_PONY_FILE} ${CMAKE_CURRENT_SOURCE_DIR}/version.pony
   COMMAND $<TARGET_FILE:ponyc> --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/peg/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-ast/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-binarysearch/ --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/mfelsche/pony-immutable-json/ -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
-    ${VERSION_PONY_FILE}
     ${LSP_SOURCES}
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tools/pony-lsp/version.pony.in
+++ b/tools/pony-lsp/version.pony.in
@@ -1,0 +1,12 @@
+// version.pony is generated from version.pony.in by CMake's configure_file().
+// CMake variables (like PONYC_VERSION enclosed in @ symbols) are replaced at configure time.
+// To modify version.pony, edit version.pony.in instead.
+
+primitive PonyLspVersion
+  """
+  Provides version information for the Pony Language Server.
+  The version matches the ponyc compiler version.
+  """
+  fun version_string(): String =>
+    """Returns the ponyc compiler version string."""
+    "@PONYC_VERSION@"


### PR DESCRIPTION
## Context

The initial implementation in #4830 used CMake custom commands to generate `version.pony` by echoing lines to a file in the build directory, then copying it to the source directory during compilation. This approach was verbose, complex, and non-standard.

## Changes

- Replace custom commands with `configure_file()` using a `version.pony.in` template
- Template uses `@PONYC_VERSION@` placeholder that CMake replaces at configure time