### PR TITLE
Add container image pruning for nightly and stdlib-builder images

### DIFF
--- a/.dockerfiles/nightly/build-and-push.bash
+++ b/.dockerfiles/nightly/build-and-push.bash
@@ -7,6 +7,10 @@ set -o nounset
 # *** You should already be logged in to GitHub Container Registry when you run
 #     this ***
 #
+# The tag name used here (nightly) must stay in sync with the
+# prune-untagged-nightly-images job in build-nightly-image.yml, which inspects
+# this tag's manifest to collect child SHAs for skip-shas protection.
+#
 
 DOCKERFILE_DIR="$(dirname "$0")"
 NAME="ghcr.io/ponylang/ponyc:nightly"

--- a/.dockerfiles/release/build-and-push.bash
+++ b/.dockerfiles/release/build-and-push.bash
@@ -4,6 +4,10 @@
 # ** You should already be logged in to GitHub Container Registry when you run
 #    this **
 #
+# The tag name used here (release) must stay in sync with the
+# prune-untagged-nightly-images job in build-nightly-image.yml, which inspects
+# this tag's manifest to collect child SHAs for skip-shas protection.
+#
 
 set -o errexit
 set -o nounset

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -104,6 +104,81 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  prune-untagged-nightly-images:
+    needs:
+      - build-nightly-docker-image
+
+    name: Prune untagged nightly images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch multi-platform image SHAs to preserve
+        id: multi-arch-digests
+        run: |
+          shas=""
+          for tag in nightly release; do
+            digests=$(docker manifest inspect "ghcr.io/ponylang/ponyc:${tag}" 2>/dev/null | jq -r '.manifests[].digest' | paste -s -d ',' - || true)
+            if [ -n "$digests" ]; then
+              shas="${shas:+${shas},}${digests}"
+            fi
+          done
+          echo "skip-shas=${shas}" >> $GITHUB_OUTPUT
+      - name: Prune
+        # v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        with:
+          account: ponylang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ponyc
+          tag-selection: untagged
+          cut-off: 1d
+          skip-shas: ${{ steps.multi-arch-digests.outputs.skip-shas }}
+      - name: Alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  prune-untagged-stdlib-builders:
+    needs:
+      - update-stdlib-builder-image-on-nightly
+
+    name: Prune untagged stdlib builders
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune
+        # v3.0.1
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        with:
+          account: ponylang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ponyc-ci-stdlib-builder
+          tag-selection: untagged
+          cut-off: 1d
+      - name: Alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   send-nightly-image-pushed-event:
     needs:
       - build-nightly-docker-image


### PR DESCRIPTION
Re-add container image pruning using snok/container-retention-policy, which safely handles multiplatform images. The previous pruning using actions/delete-package-versions was removed in 94401272 because it deletes untagged per-platform child images that multiplatform manifests depend on.

For the multiplatform ponyc image: before pruning, inspect the nightly and release manifests to collect per-platform child SHAs, then pass them to skip-shas so they're preserved during cleanup.

For the single-arch ponyc-ci-stdlib-builder image: use snok without skip-shas for consistency with the multiplatform pruning approach.