### PR TITLE
Fix "lambda in object literal" missing apply() in vtable.

### DIFF
--- a/test/full-program-tests/lambda-in-object-in-generic-class-and-method/main.pony
+++ b/test/full-program-tests/lambda-in-object-in-generic-class-and-method/main.pony
@@ -1,0 +1,39 @@
+"""
+Regression test for type parameter reification with a lambda inside an object
+literal inside a generic method that has multiple type parameters. This tests
+that all type parameters (A and B) from the method are correctly reified
+through two levels of type parameter copying.
+
+See also: lambda-in-object-in-generic-method
+"""
+use @pony_exitcode[None](code: I32)
+
+primitive Mapper
+  fun map[A: Any val, B: Any val](arr: Array[A] val,
+    fn: {(A): B^} box): Array[B]
+  =>
+    let result = Array[B](arr.size())
+    // Object literal inside generic method - level 1 copy of A, B
+    let mapper =
+      object
+        fun do_map(a: Array[A] val, f: {(A): B^} box, out: Array[B]) =>
+          for v in a.values() do
+            // Lambda inside object inside generic method - level 2 copy
+            let apply_fn = {(x: A): B^ => f(x) }
+            out.push(apply_fn(v))
+          end
+      end
+    mapper.do_map(arr, fn, result)
+    result
+
+actor Main
+  new create(env: Env) =>
+    let arr: Array[U32] val = [1; 2; 3]
+    let result = Mapper.map[U32, String](arr,
+      {(n: U32): String^ => n.string()})
+    try
+      if result(0)? != "1" then error end
+      if result(1)? != "2" then error end
+      if result(2)? != "3" then error end
+      @pony_exitcode(1)
+    end

--- a/test/full-program-tests/lambda-in-object-in-generic-method-different-types/main.pony
+++ b/test/full-program-tests/lambda-in-object-in-generic-method-different-types/main.pony
@@ -1,0 +1,34 @@
+"""
+Regression test for type parameter reification in nested lambdas where the
+mapping changes the type (U32 -> String). This ensures that both the source
+type T and the target type U are correctly reified through multiple levels
+of type parameter copying.
+
+See also: lambda-in-object-in-generic-method
+"""
+use @pony_exitcode[None](code: I32)
+use "pony_check"
+
+actor Main
+  new create(env: Env) =>
+    // Map U32 to String - T and U are different types
+    let gen = recover val
+      Generators.u32().map[String]({(n: U32): String^ => n.string()})
+    end
+    let rnd = Randomness(42)
+    try
+      match gen.generate(rnd)?
+      | (let v: String, let shrinks: Iterator[String^]) =>
+        if v.size() == 0 then error end
+        var count: USize = 0
+        while shrinks.has_next() and (count < 5) do
+          let s = shrinks.next()?
+          if s.size() == 0 then error end
+          count = count + 1
+        end
+        if count == 0 then error end
+        @pony_exitcode(1)
+      | let v: String =>
+        @pony_exitcode(1)
+      end
+    end

--- a/test/full-program-tests/lambda-in-object-in-generic-method/main.pony
+++ b/test/full-program-tests/lambda-in-object-in-generic-method/main.pony
@@ -1,0 +1,37 @@
+"""
+Regression test for a bug where a lambda inside an object literal inside a
+generic method had its type parameters not properly reified during subtype
+checking. This caused the lambda's apply method to be missing from its vtable,
+resulting in a segfault at runtime when iterating shrink values from a mapped
+pony_check Generator.
+
+The root cause was that collect_type_params() creates copies of type parameters
+at each nesting level, but reify_typeparamref() only followed the ast_data
+chain one level instead of to the root.
+"""
+use @pony_exitcode[None](code: I32)
+use "pony_check"
+
+actor Main
+  new create(env: Env) =>
+    let gen = recover val
+      Generators.u32().map[U32]({(n: U32): U32^ => n + 1})
+    end
+    let rnd = Randomness(42)
+    try
+      match gen.generate(rnd)?
+      | (let v: U32, let shrinks: Iterator[U32^]) =>
+        if v == 0 then error end
+        // Iterating shrink values is where the segfault occurred,
+        // because the lambda's apply method was missing from the vtable.
+        var count: USize = 0
+        while shrinks.has_next() and (count < 5) do
+          shrinks.next()?
+          count = count + 1
+        end
+        if count == 0 then error end
+        @pony_exitcode(1)
+      | let v: U32 =>
+        @pony_exitcode(1)
+      end
+    end

--- a/test/full-program-tests/triple-nested-lambda-in-generic/main.pony
+++ b/test/full-program-tests/triple-nested-lambda-in-generic/main.pony
@@ -1,0 +1,47 @@
+"""
+Regression test for type parameter reification with three levels of nesting:
+generic method -> object literal -> object literal -> lambda. This creates
+three levels of type parameter copies, testing that reify_typeparamref follows
+the ast_data chain all the way to the root, not just one or two levels.
+
+See also: lambda-in-object-in-generic-method
+"""
+use @pony_exitcode[None](code: I32)
+
+primitive Processor
+  fun transform[U: Any val](arr: Array[U32] val,
+    fn: {(U32): U} box): Array[U]
+  =>
+    let result = Array[U](arr.size())
+    // Level 1: object literal inside generic method
+    let outer =
+      object
+        fun process(a: Array[U32] val, f: {(U32): U} box, out: Array[U]) =>
+          // Level 2: another object literal
+          let inner =
+            object
+              fun apply_all(a': Array[U32] val, f': {(U32): U} box,
+                out': Array[U])
+              =>
+                for v in a'.values() do
+                  // Level 3: lambda inside object inside object inside
+                  // generic method - three levels of type param copying
+                  let apply_fn = {(x: U32): U => f'(x) }
+                  out'.push(apply_fn(v))
+                end
+            end
+          inner.apply_all(a, f, out)
+      end
+    outer.process(arr, fn, result)
+    result
+
+actor Main
+  new create(env: Env) =>
+    let arr: Array[U32] val = [5; 10; 15]
+    let result = Processor.transform[U32](arr, {(n: U32): U32 => n * 2})
+    try
+      if result(0)? != 10 then error end
+      if result(1)? != 20 then error end
+      if result(2)? != 30 then error end
+      @pony_exitcode(1)
+    end


### PR DESCRIPTION
The old code in reify_typeparamref() followed the ast_data chain only to one level. When they don't match, the type parameters are not substituted during subtype checking causing is_subtype() to incorrectly return false. In this case, the lambda's apply() function isn't marked as reachable resulting in a missing vtable entry and consequent runtime segfault.

Fixes: #4838 