### PR TITLE
Fix false positive file-naming for _test.pony with Main actor

### DIFF
--- a/tools/pony-lint/file_naming.pony
+++ b/tools/pony-lint/file_naming.pony
@@ -11,6 +11,9 @@ primitive FileNaming is ASTRule
      trait/interface is the principal type.
   3. Otherwise — no principal type; the rule does not flag the file.
 
+  Exception: `_test.pony` files with a `Main` actor are never flagged. This is
+  the standard Pony convention for library test runner packages.
+
   The expected filename is the principal type name converted to snake_case,
   plus `.pony`. Private types (leading `_`) produce filenames with the leading
   underscore preserved: `_MyType` becomes `_my_type.pony`.
@@ -58,6 +61,12 @@ primitive FileNaming is ASTRule
 
     let expected = NamingHelpers.to_snake_case(principal)
     let actual = _filename_stem(source.path)
+
+    // _test.pony with a Main actor is the standard Pony test runner
+    // convention — not a naming violation.
+    if (actual == "_test") and (principal == "Main") then
+      return recover val Array[Diagnostic val] end
+    end
 
     if expected != actual then
       recover val

--- a/tools/pony-lint/test/_test_file_naming.pony
+++ b/tools/pony-lint/test/_test_file_naming.pony
@@ -70,6 +70,21 @@ class \nodoc\ _TestFileNamingMultipleEntitiesSkipped is UnitTest
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
+class \nodoc\ _TestFileNamingTestPonyMain is UnitTest
+  """_test.pony with a Main actor is the standard test runner convention."""
+  fun name(): String => "FileNaming: _test.pony with Main is clean"
+
+  fun apply(h: TestHelper) =>
+    let sf = lint.SourceFile(
+      "_test.pony", "actor Main is TestList\n", ".")
+    let entities = recover val
+      let a = Array[(String val, ast.TokenId, USize)]
+      a.push(("Main", ast.TokenIds.tk_actor(), 1))
+      a
+    end
+    let diags = lint.FileNaming.check_module(entities, sf)
+    h.assert_eq[USize](0, diags.size())
+
 class \nodoc\ _TestFileNamingPrivateType is UnitTest
   """Private type preserves leading underscore in filename."""
   fun name(): String => "FileNaming: private type -> _snake_case filename"

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -143,6 +143,7 @@ actor \nodoc\ Main is TestList
     test(_TestFileNamingMatchingName)
     test(_TestFileNamingTraitPrincipal)
     test(_TestFileNamingMultipleEntitiesSkipped)
+    test(_TestFileNamingTestPonyMain)
     test(_TestFileNamingPrivateType)
 
     // PackageNaming tests


### PR DESCRIPTION
The file-naming rule's single-entity heuristic flagged `_test.pony` files because the sole entity `Main` maps to `main.pony`. This is the standard Pony convention for library test runner packages and should not be flagged.

Adds an exception: when the filename is `_test.pony` and the principal type is `Main`, the diagnostic is skipped.

Closes #4851