### PR TITLE
Fix false positive comment-spacing on // in docstring URLs

### DIFF
--- a/tools/pony-lint/comment_spacing.pony
+++ b/tools/pony-lint/comment_spacing.pony
@@ -5,10 +5,10 @@ primitive CommentSpacing is TextRule
 
   Scans left-to-right, tracking double-quote characters to skip string
   literals (toggling an in-string flag on each unescaped double-quote).
+  Triple-quoted strings (docstrings) are tracked across lines and skipped
+  entirely, including delimiter lines.
 
   Known limitations:
-  - Does not handle triple-quoted strings. A // inside a triple-quoted
-    string spanning multiple lines may produce a false positive.
   - Does not handle escaped backslashes before quotes. A string ending
     in a literal backslash (e.g., "path\\") may cause a subsequent //
     comment to be missed.
@@ -22,15 +22,48 @@ primitive CommentSpacing is TextRule
   fun check(source: SourceFile val): Array[Diagnostic val] val =>
     recover val
       let result = Array[Diagnostic val]
+      var in_docstring = false
       for (idx, line) in source.lines.pairs() do
-        match _find_comment(line)
-        | let col: USize =>
-          result.push(Diagnostic(id(), "expected one space after //",
-            source.rel_path, idx + 1, col))
+        let triple_count = _count_triple_quotes(line)
+        if in_docstring or (triple_count > 0) then
+          // Inside a docstring or on a delimiter line — skip comment checking
+          if (triple_count % 2) == 1 then
+            in_docstring = not in_docstring
+          end
+        else
+          match _find_comment(line)
+          | let col: USize =>
+            result.push(Diagnostic(id(), "expected one space after //",
+              source.rel_path, idx + 1, col))
+          end
         end
       end
       result
     end
+
+  fun _count_triple_quotes(line: String val): USize =>
+    """
+    Count non-overlapping occurrences of `\"\"\"` on a line, scanning
+    left to right.
+    """
+    var count: USize = 0
+    var i: USize = 0
+    let size = line.size()
+    while (i + 2) < size do
+      try
+        if (line(i)? == '"') and (line(i + 1)? == '"')
+          and (line(i + 2)? == '"')
+        then
+          count = count + 1
+          i = i + 3
+        else
+          i = i + 1
+        end
+      else
+        i = i + 1
+      end
+    end
+    count
 
   fun _find_comment(line: String val): (USize | None) =>
     """

--- a/tools/pony-lint/test/_test_comment_spacing.pony
+++ b/tools/pony-lint/test/_test_comment_spacing.pony
@@ -55,6 +55,26 @@ class \nodoc\ _TestCommentSpacingInsideString is UnitTest
     let diags = lint.CommentSpacing.check(sf)
     h.assert_eq[USize](0, diags.size())
 
+class \nodoc\ _TestCommentSpacingDocstringURL is UnitTest
+  """// in a URL inside a triple-quoted docstring is not flagged."""
+  fun name(): String => "CommentSpacing: // in docstring URL"
+
+  fun apply(h: TestHelper) =>
+    let src = "\"\"\"\nA library built on\n[lori](https://github.com/ponylang/lori).\n\"\"\""
+    let sf = lint.SourceFile("/tmp/t.pony", src, "/tmp")
+    let diags = lint.CommentSpacing.check(sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestCommentSpacingAfterDocstring is UnitTest
+  """A // comment after a docstring is still checked."""
+  fun name(): String => "CommentSpacing: comment after docstring"
+
+  fun apply(h: TestHelper) =>
+    let src = "\"\"\"\nSome docstring.\n\"\"\"\n//bad"
+    let sf = lint.SourceFile("/tmp/t.pony", src, "/tmp")
+    let diags = lint.CommentSpacing.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
 class \nodoc\ _TestCommentSpacingAfterCode is UnitTest
   """Comment after code with proper spacing is OK."""
   fun name(): String => "CommentSpacing: after code with proper spacing"

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -91,6 +91,8 @@ actor \nodoc\ Main is TestList
     test(_TestCommentSpacingNoSpace)
     test(_TestCommentSpacingTwoSpaces)
     test(_TestCommentSpacingInsideString)
+    test(_TestCommentSpacingDocstringURL)
+    test(_TestCommentSpacingAfterDocstring)
     test(_TestCommentSpacingAfterCode)
     test(_TestCommentSpacingAfterCodeBadSpacing)
     test(_TestCommentSpacingNoComment)


### PR DESCRIPTION
The comment-spacing rule scanned each line independently, so `//` inside multi-line triple-quoted strings (docstrings) was flagged as a badly spaced comment — e.g., `https://github.com/...` in a docstring.

Now tracks docstring state across lines via `"""` counting and skips comment checking for lines inside docstrings and on delimiter lines. Lines after a docstring closes are still checked normally.

Closes #4850