### PR TITLE
Add style/prefer-chaining lint rule

### DIFF
--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -86,6 +86,7 @@ actor Main
         .> push(BlankLines)
         .> push(DocstringFormat)
         .> push(PackageDocstring)
+        .> push(PreferChaining)
     end
 
     // Handle --explain

--- a/tools/pony-lint/prefer_chaining.pony
+++ b/tools/pony-lint/prefer_chaining.pony
@@ -1,0 +1,143 @@
+use ast = "pony_compiler"
+
+primitive PreferChaining is ASTRule
+  """
+  Flags patterns where a value is bound to a local variable, methods are
+  called on it repeatedly, and it is returned — when `.>` chaining would
+  be cleaner.
+
+  Anti-pattern:
+  ```pony
+  let r = Array[U32]
+  r.push(1)
+  r.push(2)
+  r
+  ```
+
+  Preferred:
+  ```pony
+  Array[U32]
+    .> push(1)
+    .> push(2)
+  ```
+  """
+  fun id(): String val => "style/prefer-chaining"
+  fun category(): String val => "style"
+
+  fun description(): String val =>
+    "local variable can be replaced with .> chaining"
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [ast.TokenIds.tk_let(); ast.TokenIds.tk_var()]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Check whether a `let` or `var` binding is only used to call methods
+    and then returned, which `.>` chaining can express more concisely.
+    """
+    // Extract variable name from child 0 (TK_ID)
+    let var_name: String val =
+      try
+        let name_node = node(0)?
+        match name_node.token_value()
+        | let name: String val => name
+        else
+          return recover val Array[Diagnostic val] end
+        end
+      else
+        return recover val Array[Diagnostic val] end
+      end
+
+    // Navigate to parent — must be TK_ASSIGN
+    let assign_node: ast.AST box =
+      match node.parent()
+      | let p: ast.AST box if p.id() == ast.TokenIds.tk_assign() => p
+      else
+        return recover val Array[Diagnostic val] end
+      end
+
+    // Walk siblings of the TK_ASSIGN, counting consecutive dot-calls
+    // on our variable
+    var call_count: USize = 0
+    var current: (ast.AST box | None) = assign_node.sibling()
+
+    while true do
+      match current
+      | let sib: ast.AST box if _is_dot_call_on(sib, var_name) =>
+        call_count = call_count + 1
+        current = sib.sibling()
+      else
+        break
+      end
+    end
+
+    // Need at least 2 consecutive calls
+    if call_count < 2 then
+      return recover val Array[Diagnostic val] end
+    end
+
+    // Next sibling must be a bare reference to the variable with no
+    // further siblings (i.e. it is the return value of the sequence)
+    match current
+    | let ref_node: ast.AST box
+      if _is_bare_reference(ref_node, var_name)
+    =>
+      match ref_node.sibling()
+      | let _: ast.AST box =>
+        // There are more statements after the reference — not a
+        // simple return pattern
+        return recover val Array[Diagnostic val] end
+      end
+      return recover val
+        [Diagnostic(id(),
+          "'" + var_name + "' can be replaced with .> chaining",
+          source.rel_path, node.line(), node.pos())]
+      end
+    end
+
+    recover val Array[Diagnostic val] end
+
+  fun _is_dot_call_on(node: ast.AST box, var_name: String val): Bool =>
+    """
+    Check whether `node` is a `TK_CALL` whose receiver is a dot-access
+    on a `TK_REFERENCE` matching `var_name`:
+    `TK_CALL(TK_DOT(TK_REFERENCE(TK_ID(var_name)), ...), ...)`.
+    """
+    if node.id() != ast.TokenIds.tk_call() then return false end
+    try
+      let dot = node(0)?
+      if dot.id() != ast.TokenIds.tk_dot() then return false end
+      let ref_node = dot(0)?
+      if ref_node.id() != ast.TokenIds.tk_reference() then return false end
+      let id_node = ref_node(0)?
+      if id_node.id() != ast.TokenIds.tk_id() then return false end
+      match id_node.token_value()
+      | let name: String val => name == var_name
+      else
+        false
+      end
+    else
+      false
+    end
+
+  fun _is_bare_reference(node: ast.AST box, var_name: String val): Bool =>
+    """
+    Check whether `node` is a bare `TK_REFERENCE` to `var_name`:
+    `TK_REFERENCE(TK_ID(var_name))`.
+    """
+    if node.id() != ast.TokenIds.tk_reference() then return false end
+    try
+      let id_node = node(0)?
+      if id_node.id() != ast.TokenIds.tk_id() then return false end
+      match id_node.token_value()
+      | let name: String val => name == var_name
+      else
+        false
+      end
+    else
+      false
+    end

--- a/tools/pony-lint/test/_test_blank_lines.pony
+++ b/tools/pony-lint/test/_test_blank_lines.pony
@@ -363,10 +363,9 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesOneBlank is UnitTest
       "  fun apply(): None => None\n",
       ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-      a.push(("Bar", ast.TokenIds.tk_class(), 4, 5))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+        .> push(("Bar", ast.TokenIds.tk_class(), 4, 5))
     end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
@@ -384,10 +383,9 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesNoBlank is UnitTest
       "  fun apply(): None => None\n",
       ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-      a.push(("Bar", ast.TokenIds.tk_class(), 3, 4))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+        .> push(("Bar", ast.TokenIds.tk_class(), 3, 4))
     end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](1, diags.size())
@@ -412,10 +410,9 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesTooMany is UnitTest
       "  fun apply(): None => None\n",
       ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-      a.push(("Bar", ast.TokenIds.tk_class(), 5, 6))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+        .> push(("Bar", ast.TokenIds.tk_class(), 5, 6))
     end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](1, diags.size())
@@ -432,11 +429,10 @@ class \nodoc\ _TestBlankLinesOneLinerEntitiesNoBlank is UnitTest
       "primitive Blue\n",
       ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Red", ast.TokenIds.tk_primitive(), 1, 1))
-      a.push(("Green", ast.TokenIds.tk_primitive(), 2, 2))
-      a.push(("Blue", ast.TokenIds.tk_primitive(), 3, 3))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Red", ast.TokenIds.tk_primitive(), 1, 1))
+        .> push(("Green", ast.TokenIds.tk_primitive(), 2, 2))
+        .> push(("Blue", ast.TokenIds.tk_primitive(), 3, 3))
     end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())

--- a/tools/pony-lint/test/_test_file_naming.pony
+++ b/tools/pony-lint/test/_test_file_naming.pony
@@ -46,10 +46,9 @@ class \nodoc\ _TestFileNamingTraitPrincipal is UnitTest
     let sf = lint.SourceFile(
       "runnable.pony", "trait Runnable\nclass Runner\n", ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Runnable", ast.TokenIds.tk_trait(), 0, 0))
-      a.push(("Runner", ast.TokenIds.tk_class(), 0, 0))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Runnable", ast.TokenIds.tk_trait(), 0, 0))
+        .> push(("Runner", ast.TokenIds.tk_class(), 0, 0))
     end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
@@ -63,10 +62,9 @@ class \nodoc\ _TestFileNamingMultipleEntitiesSkipped is UnitTest
     let sf = lint.SourceFile(
       "helpers.pony", "class Foo\nclass Bar\n", ".")
     let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 0, 0))
-      a.push(("Bar", ast.TokenIds.tk_class(), 0, 0))
-      a
+      Array[(String val, ast.TokenId, USize, USize)]
+        .> push(("Foo", ast.TokenIds.tk_class(), 0, 0))
+        .> push(("Bar", ast.TokenIds.tk_class(), 0, 0))
     end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())

--- a/tools/pony-lint/test/_test_linter.pony
+++ b/tools/pony-lint/test/_test_linter.pony
@@ -62,12 +62,11 @@ class \nodoc\ _TestLinterCleanFile is UnitTest
       file.dispose()
 
       let rules: Array[lint.TextRule val] val = recover val
-        let r = Array[lint.TextRule val]
-        r.push(lint.LineLength)
-        r.push(lint.TrailingWhitespace)
-        r.push(lint.HardTabs)
-        r.push(lint.CommentSpacing)
-        r
+        Array[lint.TextRule val]
+          .> push(lint.LineLength)
+          .> push(lint.TrailingWhitespace)
+          .> push(lint.HardTabs)
+          .> push(lint.CommentSpacing)
       end
       let registry = lint.RuleRegistry(
         rules, _NoASTRules(), lint.LintConfig.default())

--- a/tools/pony-lint/test/_test_prefer_chaining.pony
+++ b/tools/pony-lint/test/_test_prefer_chaining.pony
@@ -1,0 +1,228 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestPreferChainingViolation is UnitTest
+  """Basic let-push-return pattern with 2+ calls is flagged."""
+  fun name(): String => "PreferChaining: basic pattern flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1))\n" +
+      "    x.qux(U32(2))\n" +
+      "    x\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String]("style/prefer-chaining",
+              diags(0)?.rule_id)
+            h.assert_true(diags(0)?.message.contains("x"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingVarViolation is UnitTest
+  """Var binding with let-push-return pattern is also flagged."""
+  fun name(): String => "PreferChaining: var pattern flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    var x = Bar\n" +
+      "    x.baz(U32(1))\n" +
+      "    x.qux(U32(2))\n" +
+      "    x\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String]("style/prefer-chaining",
+              diags(0)?.rule_id)
+            h.assert_true(diags(0)?.message.contains("x"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingAlreadyChaining is UnitTest
+  """Code already using .> chaining produces no diagnostics."""
+  fun name(): String => "PreferChaining: already chaining is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    Bar .> baz(U32(1)) .> qux(U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingSingleCall is UnitTest
+  """Single call below threshold produces no diagnostics."""
+  fun name(): String => "PreferChaining: single call is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1))\n" +
+      "    x\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingNoTrailingRef is UnitTest
+  """Calls without trailing variable reference produces no diagnostics."""
+  fun name(): String => "PreferChaining: no trailing ref is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1))\n" +
+      "    x.qux(U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingInterspersed is UnitTest
+  """Non-consecutive calls on the variable produces no diagnostics."""
+  fun name(): String => "PreferChaining: interspersed statements is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1))\n" +
+      "    None\n" +
+      "    x.qux(U32(2))\n" +
+      "    x\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestPreferChainingNormalLet is UnitTest
+  """Normal let usage with a single call produces no diagnostics."""
+  fun name(): String => "PreferChaining: normal let usage is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz()\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end

--- a/tools/pony-lint/test/_test_registry.pony
+++ b/tools/pony-lint/test/_test_registry.pony
@@ -83,10 +83,9 @@ class \nodoc\ _TestRegistryAllAlwaysComplete is UnitTest
     end
     let no_ast = recover val Array[lint.ASTRule val] end
     let disabled = recover val
-      let s = Set[String]
-      s.set("test/dummy")
-      s.set("test/dummy2")
-      s
+      Set[String]
+        .> set("test/dummy")
+        .> set("test/dummy2")
     end
     let config = lint.LintConfig(disabled,
       recover val Map[String, lint.RuleStatus] end)

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -249,3 +249,12 @@ actor \nodoc\ Main is TestList
     test(_TestPackageDocstringNoFile)
     test(_TestPackageDocstringNoDocstring)
     test(_TestPackageDocstringHyphenated)
+
+    // PreferChaining tests
+    test(_TestPreferChainingViolation)
+    test(_TestPreferChainingVarViolation)
+    test(_TestPreferChainingAlreadyChaining)
+    test(_TestPreferChainingSingleCall)
+    test(_TestPreferChainingNoTrailingRef)
+    test(_TestPreferChainingInterspersed)
+    test(_TestPreferChainingNormalLet)


### PR DESCRIPTION
Adds a new `style/prefer-chaining` pony-lint rule that flags the pattern of binding a value to a local variable, calling methods on it repeatedly, and returning it — when `.>` chaining would be cleaner. Triggers on both `let` and `var` bindings with 2+ consecutive dot-calls followed by a trailing bare reference.

Refactors existing instances of this anti-pattern in pony-lint's own test files to use `.>` chaining.

Closes #4867