### PR TITLE
Fix _TestTCPConnectionFailed hang on WSL2

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -757,7 +757,7 @@ class \nodoc\ _TestTCPConnectionFailed is UnitTest
   fun ref apply(h: TestHelper) =>
     h.expect_action("connection failed")
 
-    let host = "127.0.0.1"
+    let host = ifdef linux then "127.0.0.2" else "127.0.0.1" end
     let port = "7669"
 
     let connection = TCPConnection(


### PR DESCRIPTION
WSL2 mirrored networking has a Hyper-V bug (Microsoft WSL issue #10855) where connecting to 127.0.0.1 on an unoccupied port hangs indefinitely instead of getting connection refused. Use 127.0.0.2 on Linux to bypass the buggy Hyper-V path.