### PR TITLE
Expand style/prefer-chaining to flag patterns without trailing reference

### DIFF
--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -256,5 +256,6 @@ actor \nodoc\ Main is TestList
     test(_TestPreferChainingAlreadyChaining)
     test(_TestPreferChainingSingleCall)
     test(_TestPreferChainingNoTrailingRef)
+    test(_TestPreferChainingUsedAfterCalls)
     test(_TestPreferChainingInterspersed)
     test(_TestPreferChainingNormalLet)


### PR DESCRIPTION
The rule previously only fired when 2+ consecutive dot-calls were followed by a bare reference to the variable (i.e. the variable was returned). The pattern without the trailing reference is equally chainable and should also be flagged:

```pony
// Now flagged:
let x = Bar
x.baz(1)
x.qux(2)

// Chains to:
Bar .> baz(1) .> qux(2)
```

Closes #4869