### PR TITLE
Add assignment-indent lint rule to pony-lint

### DIFF
--- a/tools/pony-lint/assignment_indent.pony
+++ b/tools/pony-lint/assignment_indent.pony
@@ -1,0 +1,61 @@
+use ast = "pony_compiler"
+
+primitive AssignmentIndent is ASTRule
+  """
+  Flags multiline assignment RHS that starts on the same line as the `=`.
+
+  When an assignment's right-hand side spans multiple lines, the Pony style
+  guide requires the RHS to start on the line after the `=`, not on the same
+  line. Single-line assignments are always clean.
+  """
+  fun id(): String val => "style/assignment-indent"
+  fun category(): String val => "style"
+
+  fun description(): String val =>
+    "multiline assignment RHS must start on the line after '='"
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [ast.TokenIds.tk_assign()]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Check whether a multiline RHS begins on the same line as the `=`.
+
+    Gets the RHS (child 1) and compares its start line to the `=` line. If
+    they differ, the RHS already starts on the next line — clean. If they
+    match, uses `_MaxLineVisitor` to determine whether the RHS is multiline.
+    A multiline RHS on the `=` line is a violation.
+    """
+    let assign_line = node.line()
+
+    let rhs =
+      try
+        node(1)?
+      else
+        return recover val Array[Diagnostic val] end
+      end
+
+    // RHS starts on a different line than `=` — already correct
+    if rhs.line() != assign_line then
+      return recover val Array[Diagnostic val] end
+    end
+
+    // RHS starts on the same line — check if it spans multiple lines
+    let mlv = _MaxLineVisitor(assign_line)
+    rhs.visit(mlv)
+
+    if mlv.max_line > assign_line then
+      // Multiline RHS starting on the `=` line — violation
+      recover val
+        [Diagnostic(id(),
+          "multiline assignment RHS should start on the line after '='",
+          source.rel_path, assign_line, node.pos())]
+      end
+    else
+      // Single-line RHS — clean
+      recover val Array[Diagnostic val] end
+    end

--- a/tools/pony-lint/blank_lines.pony
+++ b/tools/pony-lint/blank_lines.pony
@@ -46,9 +46,10 @@ primitive BlankLines is ASTRule
 
     // Find first body content line — docstring (child 6) or first member
     let docstring_line = _docstring_line(node)
-    let members_node = try node(4)? else
-      return recover val Array[Diagnostic val] end
-    end
+    let members_node =
+      try node(4)?
+      else return recover val Array[Diagnostic val] end
+      end
     if members_node.id() != ast.TokenIds.tk_members() then
       return recover val Array[Diagnostic val] end
     end

--- a/tools/pony-lint/config.pony
+++ b/tools/pony-lint/config.pony
@@ -79,13 +79,14 @@ primitive ConfigLoader
     Build a `LintConfig` from CLI disable flags and an optional config file.
     If `config_path` is None, auto-discovers the config file.
     """
-    let disabled = recover val
-      let s = Set[String]
-      for item in cli_disabled.values() do
-        s.set(item)
+    let disabled =
+      recover val
+        let s = Set[String]
+        for item in cli_disabled.values() do
+          s.set(item)
+        end
+        s
       end
-      s
-    end
     let file_rules =
       match config_path
       | let path: String =>

--- a/tools/pony-lint/explain_helpers.pony
+++ b/tools/pony-lint/explain_helpers.pony
@@ -45,15 +45,16 @@ primitive ExplainHelpers
     the heading anchor format used by the website (e.g., `style/dot-spacing`
     becomes `#styledot-spacing`).
     """
-    let anchor = recover val
-      let s = String(id.size())
-      for ch in id.values() do
-        if ch != '/' then
-          s.push(ch)
+    let anchor =
+      recover val
+        let s = String(id.size())
+        for ch in id.values() do
+          if ch != '/' then
+            s.push(ch)
+          end
         end
+        s
       end
-      s
-    end
 
     recover val
       String

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -142,9 +142,9 @@ class val Linter
               let mod_file = mod.file
               try
                 let info = file_info(mod_file)?
-                let dispatcher = _ASTDispatcher(
-                  _registry.enabled_ast_rules(),
-                  info.source, info.magic_lines, info.suppressions)
+                let dispatcher =
+                  _ASTDispatcher(_registry.enabled_ast_rules(),
+                    info.source, info.magic_lines, info.suppressions)
                 mod.ast.visit(dispatcher)
 
                 for d in dispatcher.diagnostics().values() do
@@ -155,8 +155,9 @@ class val Linter
                 if _registry.is_enabled(FileNaming.id(), FileNaming.category(),
                   FileNaming.default_status())
                 then
-                  let file_diags = FileNaming.check_module(
-                    dispatcher.entities(), info.source)
+                  let file_diags =
+                    FileNaming.check_module(
+                      dispatcher.entities(), info.source)
                   for d in file_diags.values() do
                     if info.magic_lines.contains(d.line) then continue end
                     if info.suppressions.is_suppressed(d.line, d.rule_id) then
@@ -170,8 +171,9 @@ class val Linter
                 if _registry.is_enabled(BlankLines.id(),
                   BlankLines.category(), BlankLines.default_status())
                 then
-                  let bl_diags = BlankLines.check_module(
-                    dispatcher.entities(), info.source)
+                  let bl_diags =
+                    BlankLines.check_module(
+                      dispatcher.entities(), info.source)
                   for d in bl_diags.values() do
                     if info.magic_lines.contains(d.line) then continue end
                     if info.suppressions.is_suppressed(d.line, d.rule_id) then
@@ -198,8 +200,9 @@ class val Linter
             if _registry.is_enabled(PackageNaming.id(),
               PackageNaming.category(), PackageNaming.default_status())
             then
-              let pkg_diags = PackageNaming.check_package(
-                Path.base(pkg.path), first_rel)
+              let pkg_diags =
+                PackageNaming.check_package(
+                  Path.base(pkg.path), first_rel)
               for d in pkg_diags.values() do
                 all_diags.push(d)
               end
@@ -212,13 +215,14 @@ class val Linter
             then
               let pkg_base = Path.base(pkg.path)
               // Normalize hyphens to underscores for Pony identifiers
-              let norm_name = recover val
-                let s = String(pkg_base.size())
-                for ch in pkg_base.values() do
-                  if ch == '-' then s.push('_') else s.push(ch) end
+              let norm_name =
+                recover val
+                  let s = String(pkg_base.size())
+                  for ch in pkg_base.values() do
+                    if ch == '-' then s.push('_') else s.push(ch) end
+                  end
+                  s
                 end
-                s
-              end
               let expected_file: String val = norm_name + ".pony"
               var has_pkg_file = false
               var has_docstring = false
@@ -236,8 +240,9 @@ class val Linter
                   break
                 end
               end
-              let pd_diags = PackageDocstring.check_package(
-                norm_name, has_pkg_file, has_docstring, first_rel)
+              let pd_diags =
+                PackageDocstring.check_package(
+                  norm_name, has_pkg_file, has_docstring, first_rel)
               for d in pd_diags.values() do
                 all_diags.push(d)
               end

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -62,16 +62,16 @@ actor Main
     end
 
     // Build rule arrays (needed by --explain and normal linting)
-    let all_rules: Array[TextRule val] val = recover val
-      Array[TextRule val]
+    let all_rules: Array[TextRule val] val =
+      recover val Array[TextRule val]
         .> push(LineLength)
         .> push(TrailingWhitespace)
         .> push(HardTabs)
         .> push(CommentSpacing)
         .> push(IndentationSize)
     end
-    let all_ast_rules: Array[ASTRule val] val = recover val
-      Array[ASTRule val]
+    let all_ast_rules: Array[ASTRule val] val =
+      recover val Array[ASTRule val]
         .> push(TypeNaming)
         .> push(MemberNaming)
         .> push(AcronymCasing)
@@ -89,6 +89,7 @@ actor Main
         .> push(PreferChaining)
         .> push(OperatorSpacing)
         .> push(LambdaSpacing)
+        .> push(AssignmentIndent)
     end
 
     // Handle --explain
@@ -230,9 +231,8 @@ actor Main
     let buf = @ponyint_pool_alloc_size(buf_size)
     if @get_compiler_exe_directory(buf, "pony-lint".cstring())
     then
-      let result = recover val
-        String.copy_cstring(buf)
-      end
+      let result =
+        recover val String.copy_cstring(buf) end
       @ponyint_pool_free_size(buf_size, buf)
       result
     else

--- a/tools/pony-lint/rule_registry.pony
+++ b/tools/pony-lint/rule_registry.pony
@@ -20,26 +20,28 @@ class val RuleRegistry
     _all = rules
     _all_ast = ast_rules
     _config = config
-    _enabled = recover val
-      let result = Array[TextRule val]
-      for rule in rules.values() do
-        match config.rule_status(rule.id(), rule.category(),
-          rule.default_status())
-        | RuleOn => result.push(rule)
+    _enabled =
+      recover val
+        let result = Array[TextRule val]
+        for rule in rules.values() do
+          match config.rule_status(rule.id(), rule.category(),
+            rule.default_status())
+          | RuleOn => result.push(rule)
+          end
         end
+        result
       end
-      result
-    end
-    _enabled_ast = recover val
-      let result = Array[ASTRule val]
-      for rule in ast_rules.values() do
-        match config.rule_status(rule.id(), rule.category(),
-          rule.default_status())
-        | RuleOn => result.push(rule)
+    _enabled_ast =
+      recover val
+        let result = Array[ASTRule val]
+        for rule in ast_rules.values() do
+          match config.rule_status(rule.id(), rule.category(),
+            rule.default_status())
+          | RuleOn => result.push(rule)
+          end
         end
+        result
       end
-      result
-    end
 
   fun enabled_text_rules(): Array[TextRule val] val =>
     """

--- a/tools/pony-lint/suppressions.pony
+++ b/tools/pony-lint/suppressions.pony
@@ -80,8 +80,8 @@ class val Suppressions
             source.rel_path, line_num, 1))
         elseif trimmed.at("// pony-lint:") then
           magic.set(line_num)
-          let directive = trimmed.substring(
-            "// pony-lint:".size().isize())
+          let directive =
+            trimmed.substring("// pony-lint:".size().isize())
           let directive_str: String val = consume directive
           let directive_trimmed = directive_str.clone()
           directive_trimmed.strip()

--- a/tools/pony-lint/test/_ast_test_helper.pony
+++ b/tools/pony-lint/test/_ast_test_helper.pony
@@ -21,16 +21,18 @@ primitive \nodoc\ _ASTTestHelper
     : (ast.Program val, lint.SourceFile val) ?
   =>
     let auth = h.env.root
-    let tmp = FilePath.mkdtemp(
-      FileAuth(auth), "pony-lint-ast-test")?
-    let pony_file = FilePath(
-      FileAuth(auth), Path.join(tmp.path, filename))
+    let tmp =
+      FilePath.mkdtemp(
+        FileAuth(auth), "pony-lint-ast-test")?
+    let pony_file =
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, filename))
     let file = File(pony_file)
     file.write(source)
     file.dispose()
 
-    let sf = lint.SourceFile(
-      pony_file.path, source, tmp.path)
+    let sf =
+      lint.SourceFile(pony_file.path, source, tmp.path)
 
     let pony_path = _get_ponypath(h.env.vars)
 
@@ -40,15 +42,16 @@ primitive \nodoc\ _ASTTestHelper
     | let program: ast.Program val =>
       (program, sf)
     | let errors: Array[ast.Error] val =>
-      let msg = recover val
-        let s = String
-        s.append("AST compilation failed:")
-        for err in errors.values() do
-          s.append("\n  ")
-          s.append(err.msg)
+      let msg =
+        recover val
+          let s = String
+          s.append("AST compilation failed:")
+          for err in errors.values() do
+            s.append("\n  ")
+            s.append(err.msg)
+          end
+          s
         end
-        s
-      end
       h.fail(msg)
       error
     end

--- a/tools/pony-lint/test/_test_assignment_indent.pony
+++ b/tools/pony-lint/test/_test_assignment_indent.pony
@@ -1,0 +1,252 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestAssignmentIndentSingleLine is UnitTest
+  """Single-line assignment produces no diagnostics."""
+  fun name(): String => "AssignmentIndent: single-line assignment is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): U32 =>\n" +
+      "    let x: U32 = U32(42)\n" +
+      "    x\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentRHSNextLine is UnitTest
+  """RHS starting on the line after '=' produces no diagnostics."""
+  fun name(): String => "AssignmentIndent: RHS on next line is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): U32 =>\n" +
+      "    let y =\n" +
+      "      if x > 0 then\n" +
+      "        x\n" +
+      "      else\n" +
+      "        U32(0)\n" +
+      "      end\n" +
+      "    y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentMultiLineNextLine is UnitTest
+  """Multiline recover starting on the line after '=' is clean."""
+  fun name(): String => "AssignmentIndent: recover on next line is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): Array[U8] val =>\n" +
+      "    let output =\n" +
+      "      recover val\n" +
+      "        Array[U8]\n" +
+      "      end\n" +
+      "    output\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentViolation is UnitTest
+  """Multiline if starting on the '=' line produces 1 diagnostic."""
+  fun name(): String => "AssignmentIndent: multiline if on '=' line flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): U32 =>\n" +
+      "    var y: U32 = if x > 0 then\n" +
+      "      x\n" +
+      "    else\n" +
+      "      U32(0)\n" +
+      "    end\n" +
+      "    y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentRecoverViolation is UnitTest
+  """Multiline recover starting on the '=' line produces 1 diagnostic."""
+  fun name(): String => "AssignmentIndent: recover on '=' line flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): Array[U8] val =>\n" +
+      "    let arr = recover val\n" +
+      "      Array[U8]\n" +
+      "    end\n" +
+      "    arr\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentReassignment is UnitTest
+  """Multiline reassignment (no let/var) produces 1 diagnostic."""
+  fun name(): String => "AssignmentIndent: reassignment flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): U32 =>\n" +
+      "    var y: U32 = 0\n" +
+      "    y = if x > 0 then\n" +
+      "      x\n" +
+      "    else\n" +
+      "      U32(0)\n" +
+      "    end\n" +
+      "    y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentMultipleViolations is UnitTest
+  """Two multiline assignments on '=' lines produce 2 diagnostics."""
+  fun name(): String => "AssignmentIndent: multiple violations"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): U32 =>\n" +
+      "    var a: U32 = if x > 0 then\n" +
+      "      x\n" +
+      "    else\n" +
+      "      U32(0)\n" +
+      "    end\n" +
+      "    let b: U32 = if a > 1 then\n" +
+      "      a\n" +
+      "    else\n" +
+      "      U32(1)\n" +
+      "    end\n" +
+      "    b\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](2, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end

--- a/tools/pony-lint/test/_test_blank_lines.pony
+++ b/tools/pony-lint/test/_test_blank_lines.pony
@@ -354,19 +354,21 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesOneBlank is UnitTest
   fun name(): String => "BlankLines: 1 blank between entities is clean"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "test.pony",
-      "class Foo\n" +
-      "  fun apply(): None => None\n" +
-      "\n" +
-      "class Bar\n" +
-      "  fun apply(): None => None\n",
-      ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-        .> push(("Bar", ast.TokenIds.tk_class(), 4, 5))
-    end
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +
+        "  fun apply(): None => None\n" +
+        "\n" +
+        "class Bar\n" +
+        "  fun apply(): None => None\n",
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_class(), 4, 5))
+      end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -375,18 +377,20 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesNoBlank is UnitTest
   fun name(): String => "BlankLines: 0 blanks between entities flagged"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "test.pony",
-      "class Foo\n" +
-      "  fun apply(): None => None\n" +
-      "class Bar\n" +
-      "  fun apply(): None => None\n",
-      ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-        .> push(("Bar", ast.TokenIds.tk_class(), 3, 4))
-    end
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +
+        "  fun apply(): None => None\n" +
+        "class Bar\n" +
+        "  fun apply(): None => None\n",
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_class(), 3, 4))
+      end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](1, diags.size())
     try
@@ -400,20 +404,22 @@ class \nodoc\ _TestBlankLinesBetweenEntitiesTooMany is UnitTest
   fun name(): String => "BlankLines: 2+ blanks between entities flagged"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "test.pony",
-      "class Foo\n" +
-      "  fun apply(): None => None\n" +
-      "\n" +
-      "\n" +
-      "class Bar\n" +
-      "  fun apply(): None => None\n",
-      ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
-        .> push(("Bar", ast.TokenIds.tk_class(), 5, 6))
-    end
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +
+        "  fun apply(): None => None\n" +
+        "\n" +
+        "\n" +
+        "class Bar\n" +
+        "  fun apply(): None => None\n",
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_class(), 5, 6))
+      end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](1, diags.size())
 
@@ -422,18 +428,20 @@ class \nodoc\ _TestBlankLinesOneLinerEntitiesNoBlank is UnitTest
   fun name(): String => "BlankLines: one-liner entities 0 blanks is clean"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "test.pony",
-      "primitive Red\n" +
-      "primitive Green\n" +
-      "primitive Blue\n",
-      ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Red", ast.TokenIds.tk_primitive(), 1, 1))
-        .> push(("Green", ast.TokenIds.tk_primitive(), 2, 2))
-        .> push(("Blue", ast.TokenIds.tk_primitive(), 3, 3))
-    end
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "primitive Red\n" +
+        "primitive Green\n" +
+        "primitive Blue\n",
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Red", ast.TokenIds.tk_primitive(), 1, 1))
+          .> push(("Green", ast.TokenIds.tk_primitive(), 2, 2))
+          .> push(("Blue", ast.TokenIds.tk_primitive(), 3, 3))
+      end
     let diags = lint.BlankLines.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 

--- a/tools/pony-lint/test/_test_comment_spacing.pony
+++ b/tools/pony-lint/test/_test_comment_spacing.pony
@@ -49,8 +49,11 @@ class \nodoc\ _TestCommentSpacingInsideString is UnitTest
 
   fun apply(h: TestHelper) =>
     // pony-lint: off style/comment-spacing
-    let sf = lint.SourceFile("/tmp/t.pony",
-      """let x = "http://example.com" """.clone() .> strip(), "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony",
+        """let x = "http://example.com" """.clone() .> strip(),
+        "/tmp")
     // pony-lint: on style/comment-spacing
     let diags = lint.CommentSpacing.check(sf)
     h.assert_eq[USize](0, diags.size())
@@ -80,8 +83,9 @@ class \nodoc\ _TestCommentSpacingAfterCode is UnitTest
   fun name(): String => "CommentSpacing: after code with proper spacing"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "let x = 1 // a number", "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony", "let x = 1 // a number", "/tmp")
     let diags = lint.CommentSpacing.check(sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -90,8 +94,9 @@ class \nodoc\ _TestCommentSpacingAfterCodeBadSpacing is UnitTest
   fun name(): String => "CommentSpacing: after code bad spacing"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "let x = 1 //a number", "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony", "let x = 1 //a number", "/tmp")
     let diags = lint.CommentSpacing.check(sf)
     h.assert_eq[USize](1, diags.size())
     try
@@ -105,8 +110,8 @@ class \nodoc\ _TestCommentSpacingNoComment is UnitTest
   fun name(): String => "CommentSpacing: no comment"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "let x = 1 / 2", "/tmp")
+    let sf =
+      lint.SourceFile("/tmp/t.pony", "let x = 1 / 2", "/tmp")
     let diags = lint.CommentSpacing.check(sf)
     h.assert_eq[USize](0, diags.size())
 

--- a/tools/pony-lint/test/_test_config.pony
+++ b/tools/pony-lint/test/_test_config.pony
@@ -18,11 +18,12 @@ class \nodoc\ _TestConfigCLIDisableRule is UnitTest
   fun name(): String => "Config: CLI disable overrides everything"
 
   fun apply(h: TestHelper) =>
-    let disabled = recover val
-      let s = Set[String]
-      s.set("style/line-length")
-      s
-    end
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("style/line-length")
+        s
+      end
     let file_rules = recover val Map[String, lint.RuleStatus] end
     let config = lint.LintConfig(disabled, file_rules)
     match config.rule_status("style/line-length", "style", lint.RuleOn)
@@ -35,11 +36,12 @@ class \nodoc\ _TestConfigCLIDisableCategory is UnitTest
   fun name(): String => "Config: CLI disable category"
 
   fun apply(h: TestHelper) =>
-    let disabled = recover val
-      let s = Set[String]
-      s.set("style")
-      s
-    end
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("style")
+        s
+      end
     let file_rules = recover val Map[String, lint.RuleStatus] end
     let config = lint.LintConfig(disabled, file_rules)
     match config.rule_status("style/line-length", "style", lint.RuleOn)
@@ -53,11 +55,12 @@ class \nodoc\ _TestConfigFileRuleOverride is UnitTest
 
   fun apply(h: TestHelper) =>
     let disabled = recover val Set[String] end
-    let file_rules = recover val
-      let m = Map[String, lint.RuleStatus]
-      m("style/line-length") = lint.RuleOff
-      m
-    end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m
+      end
     let config = lint.LintConfig(disabled, file_rules)
     match config.rule_status("style/line-length", "style", lint.RuleOn)
     | lint.RuleOff => h.assert_true(true)
@@ -70,11 +73,12 @@ class \nodoc\ _TestConfigFileCategoryDefault is UnitTest
 
   fun apply(h: TestHelper) =>
     let disabled = recover val Set[String] end
-    let file_rules = recover val
-      let m = Map[String, lint.RuleStatus]
-      m("style") = lint.RuleOff
-      m
-    end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style") = lint.RuleOff
+        m
+      end
     let config = lint.LintConfig(disabled, file_rules)
     match config.rule_status("style/line-length", "style", lint.RuleOn)
     | lint.RuleOff => h.assert_true(true)
@@ -86,16 +90,18 @@ class \nodoc\ _TestConfigCLIOverridesFile is UnitTest
   fun name(): String => "Config: CLI overrides file config"
 
   fun apply(h: TestHelper) =>
-    let disabled = recover val
-      let s = Set[String]
-      s.set("style/line-length")
-      s
-    end
-    let file_rules = recover val
-      let m = Map[String, lint.RuleStatus]
-      m("style/line-length") = lint.RuleOn
-      m
-    end
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("style/line-length")
+        s
+      end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOn
+        m
+      end
     let config = lint.LintConfig(disabled, file_rules)
     match config.rule_status("style/line-length", "style", lint.RuleOn)
     | lint.RuleOff => h.assert_true(true)

--- a/tools/pony-lint/test/_test_diagnostic.pony
+++ b/tools/pony-lint/test/_test_diagnostic.pony
@@ -5,8 +5,9 @@ class \nodoc\ _TestDiagnosticString is UnitTest
   fun name(): String => "Diagnostic.string() format"
 
   fun apply(h: TestHelper) =>
-    let d = lint.Diagnostic("style/line-length",
-      "line exceeds 80 columns (95)", "src/main.pony", 10, 81)
+    let d =
+      lint.Diagnostic("style/line-length",
+        "line exceeds 80 columns (95)", "src/main.pony", 10, 81)
     let expected: String val =
       "src/main.pony:10:81: error[style/line-length]: "
         + "line exceeds 80 columns (95)"
@@ -16,8 +17,9 @@ class \nodoc\ _TestDiagnosticStringSpecialChars is UnitTest
   fun name(): String => "Diagnostic.string() with path containing special chars"
 
   fun apply(h: TestHelper) =>
-    let d = lint.Diagnostic("style/hard-tabs", "use spaces",
-      "path with spaces/file.pony", 1, 1)
+    let d =
+      lint.Diagnostic("style/hard-tabs", "use spaces",
+        "path with spaces/file.pony", 1, 1)
     h.assert_eq[String](
       "path with spaces/file.pony:1:1: error[style/hard-tabs]: use spaces",
       d.string())

--- a/tools/pony-lint/test/_test_explain.pony
+++ b/tools/pony-lint/test/_test_explain.pony
@@ -6,10 +6,11 @@ class \nodoc\ _TestExplainFormatEnabled is UnitTest
   fun name(): String => "ExplainHelpers: format enabled rule"
 
   fun apply(h: TestHelper) =>
-    let output = lint.ExplainHelpers.format(
-      "style/dot-spacing",
-      "no spaces around '.'; '.>' spaced as infix operator",
-      lint.RuleOn)
+    let output =
+      lint.ExplainHelpers.format(
+        "style/dot-spacing",
+        "no spaces around '.'; '.>' spaced as infix operator",
+        lint.RuleOn)
 
     h.assert_true(output.contains("style/dot-spacing"))
     h.assert_true(output.contains("enabled by default"))
@@ -26,10 +27,11 @@ class \nodoc\ _TestExplainFormatDisabled is UnitTest
   fun name(): String => "ExplainHelpers: format disabled rule"
 
   fun apply(h: TestHelper) =>
-    let output = lint.ExplainHelpers.format(
-      "style/some-rule",
-      "checks something",
-      lint.RuleOff)
+    let output =
+      lint.ExplainHelpers.format(
+        "style/some-rule",
+        "checks something",
+        lint.RuleOff)
 
     h.assert_true(output.contains("style/some-rule"))
     h.assert_true(output.contains("disabled by default"))

--- a/tools/pony-lint/test/_test_file_naming.pony
+++ b/tools/pony-lint/test/_test_file_naming.pony
@@ -9,11 +9,12 @@ class \nodoc\ _TestFileNamingSingleEntity is UnitTest
   fun apply(h: TestHelper) =>
     // File named "test.pony" but principal type is "Foo" -> expects "foo.pony"
     let sf = lint.SourceFile("test.pony", "class Foo\n", ".")
-    let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 0, 0))
-      a
-    end
+    let entities =
+      recover val
+        let a = Array[(String val, ast.TokenId, USize, USize)]
+        a.push(("Foo", ast.TokenIds.tk_class(), 0, 0))
+        a
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     // test.pony != foo.pony
     h.assert_eq[USize](1, diags.size())
@@ -30,11 +31,12 @@ class \nodoc\ _TestFileNamingMatchingName is UnitTest
   fun apply(h: TestHelper) =>
     // File named "foo.pony" with class Foo -> matches
     let sf = lint.SourceFile("foo.pony", "class Foo\n", ".")
-    let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Foo", ast.TokenIds.tk_class(), 0, 0))
-      a
-    end
+    let entities =
+      recover val
+        let a = Array[(String val, ast.TokenId, USize, USize)]
+        a.push(("Foo", ast.TokenIds.tk_class(), 0, 0))
+        a
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -43,13 +45,15 @@ class \nodoc\ _TestFileNamingTraitPrincipal is UnitTest
   fun name(): String => "FileNaming: trait is principal with subordinates"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "runnable.pony", "trait Runnable\nclass Runner\n", ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Runnable", ast.TokenIds.tk_trait(), 0, 0))
-        .> push(("Runner", ast.TokenIds.tk_class(), 0, 0))
-    end
+    let sf =
+      lint.SourceFile(
+        "runnable.pony", "trait Runnable\nclass Runner\n", ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Runnable", ast.TokenIds.tk_trait(), 0, 0))
+          .> push(("Runner", ast.TokenIds.tk_class(), 0, 0))
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -59,13 +63,15 @@ class \nodoc\ _TestFileNamingMultipleEntitiesSkipped is UnitTest
     "FileNaming: multiple unrelated entities skipped"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "helpers.pony", "class Foo\nclass Bar\n", ".")
-    let entities = recover val
-      Array[(String val, ast.TokenId, USize, USize)]
-        .> push(("Foo", ast.TokenIds.tk_class(), 0, 0))
-        .> push(("Bar", ast.TokenIds.tk_class(), 0, 0))
-    end
+    let sf =
+      lint.SourceFile(
+        "helpers.pony", "class Foo\nclass Bar\n", ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 0, 0))
+          .> push(("Bar", ast.TokenIds.tk_class(), 0, 0))
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -74,13 +80,15 @@ class \nodoc\ _TestFileNamingTestPonyMain is UnitTest
   fun name(): String => "FileNaming: _test.pony with Main is clean"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "_test.pony", "actor Main is TestList\n", ".")
-    let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("Main", ast.TokenIds.tk_actor(), 0, 0))
-      a
-    end
+    let sf =
+      lint.SourceFile(
+        "_test.pony", "actor Main is TestList\n", ".")
+    let entities =
+      recover val
+        let a = Array[(String val, ast.TokenId, USize, USize)]
+        a.push(("Main", ast.TokenIds.tk_actor(), 0, 0))
+        a
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())
 
@@ -89,12 +97,14 @@ class \nodoc\ _TestFileNamingPrivateType is UnitTest
   fun name(): String => "FileNaming: private type -> _snake_case filename"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile(
-      "_my_helper.pony", "primitive _MyHelper\n", ".")
-    let entities = recover val
-      let a = Array[(String val, ast.TokenId, USize, USize)]
-      a.push(("_MyHelper", ast.TokenIds.tk_primitive(), 0, 0))
-      a
-    end
+    let sf =
+      lint.SourceFile(
+        "_my_helper.pony", "primitive _MyHelper\n", ".")
+    let entities =
+      recover val
+        let a = Array[(String val, ast.TokenId, USize, USize)]
+        a.push(("_MyHelper", ast.TokenIds.tk_primitive(), 0, 0))
+        a
+      end
     let diags = lint.FileNaming.check_module(entities, sf)
     h.assert_eq[USize](0, diags.size())

--- a/tools/pony-lint/test/_test_ignore.pony
+++ b/tools/pony-lint/test/_test_ignore.pony
@@ -160,12 +160,13 @@ class \nodoc\ _TestIgnoreMatcherGitignore is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
       // Create .git dir to simulate a git repo
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // Create .gitignore
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("build/")
       gitignore.print("*.o")
       gitignore.dispose()
@@ -205,8 +206,9 @@ class \nodoc\ _TestIgnoreMatcherIgnoreFile is UnitTest
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
       // No .git dir — not a git repo
       // Create .ignore
-      let ignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".ignore")))
+      let ignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".ignore")))
       ignore.print("build/")
       ignore.dispose()
 
@@ -236,17 +238,19 @@ class \nodoc\ _TestIgnoreMatcherIgnoreOverridesGitignore is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // .gitignore ignores build/
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("build/")
       gitignore.dispose()
       // .ignore negates build/
-      let ignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".ignore")))
+      let ignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".ignore")))
       ignore.print("!build/")
       ignore.dispose()
 
@@ -275,12 +279,13 @@ class \nodoc\ _TestIgnoreMatcherNegation is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // .gitignore: ignore all .o, but keep important.o
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.print("!important.o")
       gitignore.dispose()
@@ -313,8 +318,9 @@ class \nodoc\ _TestIgnoreMatcherNonGitIgnoresGitignore is UnitTest
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
       // No .git dir
       // Create .gitignore (should be ignored since not in git repo)
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.dispose()
 
@@ -341,20 +347,22 @@ class \nodoc\ _TestIgnoreMatcherHierarchical is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // Root .gitignore ignores all .o files
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.dispose()
       // Subdirectory .gitignore un-ignores .o files
-      let sub_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "src"))
+      let sub_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, "src"))
       sub_dir.mkdir()
-      let sub_gitignore = File(FilePath(FileAuth(auth),
-        Path.join(sub_dir.path, ".gitignore")))
+      let sub_gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(sub_dir.path, ".gitignore")))
       sub_gitignore.print("!*.o")
       sub_gitignore.dispose()
 
@@ -388,17 +396,18 @@ class \nodoc\ _TestIgnoreMatcherAnchoredPattern is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "ignore-test")?
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // Anchored pattern: src/build (contains /)
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(FilePath(FileAuth(auth),
+          Path.join(tmp.path, ".gitignore")))
       gitignore.print("src/build/")
       gitignore.dispose()
       // Create directory structure
-      let src_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "src"))
+      let src_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, "src"))
       src_dir.mkdir()
 
       let matcher = lint.IgnoreMatcher(FileAuth(auth), tmp.path)

--- a/tools/pony-lint/test/_test_line_length.pony
+++ b/tools/pony-lint/test/_test_line_length.pony
@@ -35,9 +35,10 @@ class \nodoc\ _TestLineLengthMultiByteUTF8 is UnitTest
   fun apply(h: TestHelper) =>
     // 80 characters where some are multi-byte (e.g., é = 2 bytes)
     // "é" is 2 bytes but 1 codepoint
-    let line: String val = recover val
-      String .> append("a".mul(79)) .> append("é")
-    end
+    let line: String val =
+      recover val
+        String .> append("a".mul(79)) .> append("é")
+      end
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
     let diags = lint.LineLength.check(sf)
     h.assert_eq[USize](0, diags.size())
@@ -80,8 +81,8 @@ class \nodoc\ _TestLineLengthProperty is UnitTest
         range = ASCIILetters) end, h)(
       {(content: String, ph: PropertyHelper) =>
         // ASCIILetters has no whitespace, so no newlines or \r
-        let sf = lint.SourceFile(
-          "/tmp/t.pony", content, "/tmp")
+        let sf =
+          lint.SourceFile("/tmp/t.pony", content, "/tmp")
         let diags = lint.LineLength.check(sf)
         ph.assert_eq[USize](1, diags.size())
       })?

--- a/tools/pony-lint/test/_test_linter.pony
+++ b/tools/pony-lint/test/_test_linter.pony
@@ -16,18 +16,19 @@ class \nodoc\ _TestLinterSingleFile is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
-      let pony_file = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "test.pony"))
+      let pony_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let file = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
       file.print(long_line)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
@@ -53,23 +54,26 @@ class \nodoc\ _TestLinterCleanFile is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
-      let pony_file = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "test.pony"))
+      let pony_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let file = File(pony_file)
       file.print("actor Main")
       file.print("  new create(env: Env) =>")
       file.print("    None")
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        Array[lint.TextRule val]
-          .> push(lint.LineLength)
-          .> push(lint.TrailingWhitespace)
-          .> push(lint.HardTabs)
-          .> push(lint.CommentSpacing)
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val
+          Array[lint.TextRule val]
+            .> push(lint.LineLength)
+            .> push(lint.TrailingWhitespace)
+            .> push(lint.HardTabs)
+            .> push(lint.CommentSpacing)
+        end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
@@ -95,21 +99,23 @@ class \nodoc\ _TestLinterSkipsCorral is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create _corral subdirectory with a .pony file
-      let corral_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "_corral"))
+      let corral_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "_corral"))
       corral_dir.mkdir()
-      let corral_file = FilePath(FileAuth(auth),
-        Path.join(corral_dir.path, "dep.pony"))
+      let corral_file =
+        FilePath(
+          FileAuth(auth), Path.join(corral_dir.path, "dep.pony"))
       let file = File(corral_file)
       let long_line = recover val String .> append("a".mul(100)) end
       file.print(long_line)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
@@ -130,8 +136,9 @@ class \nodoc\ _TestLinterSuppressedDiagnosticsFiltered is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
-      let pony_file = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "test.pony"))
+      let pony_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let file = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
       let content: String val =
@@ -139,11 +146,11 @@ class \nodoc\ _TestLinterSuppressedDiagnosticsFiltered is UnitTest
       file.write(content)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
@@ -164,24 +171,26 @@ class \nodoc\ _TestLinterDiagnosticsSorted is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create two files with violations — sorted order by filename
-      let file_b = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "b.pony"))
+      let file_b =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "b.pony"))
       let fb = File(file_b)
       let long_line = recover val String .> append("a".mul(100)) end
       fb.print(long_line)
       fb.dispose()
 
-      let file_a = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "a.pony"))
+      let file_a =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "a.pony"))
       let fa = File(file_a)
       fa.print(long_line)
       fa.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
@@ -206,16 +215,15 @@ class \nodoc\ _TestLinterNonExistentTarget is UnitTest
 
   fun apply(h: TestHelper) =>
     let auth = h.env.root
-    let rules: Array[lint.TextRule val] val = recover val
-      [as lint.TextRule val: lint.LineLength]
-    end
-    let registry = lint.RuleRegistry(
-      rules, _NoASTRules(), lint.LintConfig.default())
+    let rules: Array[lint.TextRule val] val =
+      recover val [as lint.TextRule val: lint.LineLength] end
+    let registry =
+      lint.RuleRegistry(
+        rules, _NoASTRules(), lint.LintConfig.default())
     let cwd = Path.cwd()
     let linter = lint.Linter(registry, FileAuth(auth), cwd)
-    let targets = recover val
-      [as String val: "no_such_file_or_dir_xyzzy"]
-    end
+    let targets =
+      recover val [as String val: "no_such_file_or_dir_xyzzy"] end
     (let diags, let exit_code) = linter.run(targets)
     h.assert_true(diags.size() > 0)
     try
@@ -239,37 +247,43 @@ class \nodoc\ _TestLinterRespectsGitignore is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create .git dir to simulate a git repo
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // Create .gitignore that ignores the "generated" directory
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(
+          FilePath(
+            FileAuth(auth), Path.join(tmp.path, ".gitignore")))
       gitignore.print("generated/")
       gitignore.dispose()
       // Create a "generated" directory with a .pony file containing a
       // violation
-      let gen_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "generated"))
+      let gen_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "generated"))
       gen_dir.mkdir()
-      let gen_file = FilePath(FileAuth(auth),
-        Path.join(gen_dir.path, "gen.pony"))
+      let gen_file =
+        FilePath(
+          FileAuth(auth), Path.join(gen_dir.path, "gen.pony"))
       let gf = File(gen_file)
       let long_line = recover val String .> append("a".mul(100)) end
       gf.print(long_line)
       gf.dispose()
       // Create a non-ignored .pony file that is clean
-      let clean_file = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "clean.pony"))
+      let clean_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "clean.pony"))
       let cf = File(clean_file)
       cf.print("actor Main")
       cf.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
@@ -285,8 +299,8 @@ class \nodoc\ _TestLinterRespectsGitignore is UnitTest
       gen_file.remove()
       gen_dir.remove()
       clean_file.remove()
-      FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")).remove()
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
     else
@@ -303,40 +317,45 @@ class \nodoc\ _TestLinterExplicitFileBypassesIgnore is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create .git dir to simulate a git repo
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // Create .gitignore that ignores *.pony
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(
+          FilePath(
+            FileAuth(auth), Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.pony")
       gitignore.dispose()
       // Create a .pony file with a violation
-      let pony_file = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "test.pony"))
+      let pony_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let f = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
       f.print(long_line)
       f.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
       // Target the file directly, not the directory
-      let targets = recover val
-        [as String val: Path.join(tmp.path, "test.pony")]
-      end
+      let targets =
+        recover val
+          [as String val: Path.join(tmp.path, "test.pony")]
+        end
       (let diags, _) = linter.run(targets)
       // File should be linted despite matching .gitignore
       h.assert_true(diags.size() > 0)
 
       // Cleanup
       pony_file.remove()
-      FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")).remove()
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
     else
@@ -353,40 +372,47 @@ class \nodoc\ _TestLinterRespectsGitignoreFromParent is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create .git dir at root
-      let git_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".git"))
+      let git_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, ".git"))
       git_dir.mkdir()
       // .gitignore at root ignores "generated/" directory
-      let gitignore = File(FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")))
+      let gitignore =
+        File(
+          FilePath(
+            FileAuth(auth), Path.join(tmp.path, ".gitignore")))
       gitignore.print("generated/")
       gitignore.dispose()
       // Create src/ subdirectory as the lint target
-      let src_dir = FilePath(FileAuth(auth),
-        Path.join(tmp.path, "src"))
+      let src_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "src"))
       src_dir.mkdir()
       // Create generated/ under src/ with a violation
-      let gen_dir = FilePath(FileAuth(auth),
-        Path.join(src_dir.path, "generated"))
+      let gen_dir =
+        FilePath(
+          FileAuth(auth), Path.join(src_dir.path, "generated"))
       gen_dir.mkdir()
-      let gen_file = FilePath(FileAuth(auth),
-        Path.join(gen_dir.path, "gen.pony"))
+      let gen_file =
+        FilePath(
+          FileAuth(auth), Path.join(gen_dir.path, "gen.pony"))
       let gf = File(gen_file)
       let long_line = recover val String .> append("a".mul(100)) end
       gf.print(long_line)
       gf.dispose()
       // Create a clean file in src/
-      let clean_file = FilePath(FileAuth(auth),
-        Path.join(src_dir.path, "clean.pony"))
+      let clean_file =
+        FilePath(
+          FileAuth(auth), Path.join(src_dir.path, "clean.pony"))
       let cf = File(clean_file)
       cf.print("actor Main")
       cf.dispose()
 
-      let rules: Array[lint.TextRule val] val = recover val
-        [as lint.TextRule val: lint.LineLength]
-      end
-      let registry = lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
       // Target is src/, not the repo root — tests that _GitRepoFinder
       // walks up to find .git and that _load_intermediate_ignores loads
       // root's .gitignore for the subdirectory target
@@ -406,8 +432,8 @@ class \nodoc\ _TestLinterRespectsGitignoreFromParent is UnitTest
       gen_dir.remove()
       clean_file.remove()
       src_dir.remove()
-      FilePath(FileAuth(auth),
-        Path.join(tmp.path, ".gitignore")).remove()
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
     else

--- a/tools/pony-lint/test/_test_package_docstring.pony
+++ b/tools/pony-lint/test/_test_package_docstring.pony
@@ -6,8 +6,9 @@ class \nodoc\ _TestPackageDocstringClean is UnitTest
   fun name(): String => "PackageDocstring: has file and docstring"
 
   fun apply(h: TestHelper) =>
-    let diags = lint.PackageDocstring.check_package(
-      "my_package", true, true, "my_package/foo.pony")
+    let diags =
+      lint.PackageDocstring.check_package(
+        "my_package", true, true, "my_package/foo.pony")
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestPackageDocstringNoFile is UnitTest
@@ -15,8 +16,9 @@ class \nodoc\ _TestPackageDocstringNoFile is UnitTest
   fun name(): String => "PackageDocstring: no package file flagged"
 
   fun apply(h: TestHelper) =>
-    let diags = lint.PackageDocstring.check_package(
-      "my_package", false, false, "my_package/foo.pony")
+    let diags =
+      lint.PackageDocstring.check_package(
+        "my_package", false, false, "my_package/foo.pony")
     h.assert_eq[USize](1, diags.size())
     try
       h.assert_eq[String](
@@ -32,8 +34,9 @@ class \nodoc\ _TestPackageDocstringNoDocstring is UnitTest
   fun name(): String => "PackageDocstring: no docstring flagged"
 
   fun apply(h: TestHelper) =>
-    let diags = lint.PackageDocstring.check_package(
-      "my_package", true, false, "my_package/foo.pony")
+    let diags =
+      lint.PackageDocstring.check_package(
+        "my_package", true, false, "my_package/foo.pony")
     h.assert_eq[USize](1, diags.size())
     try
       h.assert_eq[String](
@@ -51,6 +54,7 @@ class \nodoc\ _TestPackageDocstringHyphenated is UnitTest
   fun apply(h: TestHelper) =>
     // The linter normalizes hyphens to underscores before calling
     // check_package, so we test with the already-normalized name
-    let diags = lint.PackageDocstring.check_package(
-      "pony_lint", true, true, "pony-lint/foo.pony")
+    let diags =
+      lint.PackageDocstring.check_package(
+        "pony_lint", true, true, "pony-lint/foo.pony")
     h.assert_eq[USize](0, diags.size())

--- a/tools/pony-lint/test/_test_package_naming.pony
+++ b/tools/pony-lint/test/_test_package_naming.pony
@@ -6,8 +6,9 @@ class \nodoc\ _TestPackageNamingClean is UnitTest
   fun name(): String => "PackageNaming: snake_case directory is clean"
 
   fun apply(h: TestHelper) =>
-    let diags = lint.PackageNaming.check_package(
-      "my_package", "my_package/foo.pony")
+    let diags =
+      lint.PackageNaming.check_package(
+        "my_package", "my_package/foo.pony")
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestPackageNamingViolation is UnitTest
@@ -15,8 +16,9 @@ class \nodoc\ _TestPackageNamingViolation is UnitTest
   fun name(): String => "PackageNaming: non-snake_case directory flagged"
 
   fun apply(h: TestHelper) =>
-    let diags = lint.PackageNaming.check_package(
-      "MyPackage", "MyPackage/foo.pony")
+    let diags =
+      lint.PackageNaming.check_package(
+        "MyPackage", "MyPackage/foo.pony")
     h.assert_eq[USize](1, diags.size())
     try
       h.assert_eq[String]("style/package-naming", diags(0)?.rule_id)

--- a/tools/pony-lint/test/_test_registry.pony
+++ b/tools/pony-lint/test/_test_registry.pony
@@ -25,9 +25,8 @@ class \nodoc\ _TestRegistryDefaultAllEnabled is UnitTest
   fun name(): String => "Registry: default config -> all enabled"
 
   fun apply(h: TestHelper) =>
-    let rules: Array[lint.TextRule val] val = recover val
-      [as lint.TextRule val: _DummyRule; _DummyRule2]
-    end
+    let rules: Array[lint.TextRule val] val =
+      recover val [as lint.TextRule val: _DummyRule; _DummyRule2] end
     let no_ast = recover val Array[lint.ASTRule val] end
     let registry = lint.RuleRegistry(rules, no_ast, lint.LintConfig.default())
     h.assert_eq[USize](2, registry.enabled_text_rules().size())
@@ -38,17 +37,19 @@ class \nodoc\ _TestRegistryDisableRule is UnitTest
   fun name(): String => "Registry: disable rule"
 
   fun apply(h: TestHelper) =>
-    let rules: Array[lint.TextRule val] val = recover val
-      [as lint.TextRule val: _DummyRule; _DummyRule2]
-    end
+    let rules: Array[lint.TextRule val] val =
+      recover val [as lint.TextRule val: _DummyRule; _DummyRule2] end
     let no_ast = recover val Array[lint.ASTRule val] end
-    let disabled = recover val
-      let s = Set[String]
-      s.set("test/dummy")
-      s
-    end
-    let config = lint.LintConfig(disabled,
-      recover val Map[String, lint.RuleStatus] end)
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("test/dummy")
+        s
+      end
+    let config =
+      lint.LintConfig(
+        disabled,
+        recover val Map[String, lint.RuleStatus] end)
     let registry = lint.RuleRegistry(rules, no_ast, config)
     h.assert_eq[USize](1, registry.enabled_text_rules().size())
     h.assert_eq[USize](2, registry.all_text_rules().size())
@@ -58,17 +59,19 @@ class \nodoc\ _TestRegistryDisableCategory is UnitTest
   fun name(): String => "Registry: disable category"
 
   fun apply(h: TestHelper) =>
-    let rules: Array[lint.TextRule val] val = recover val
-      [as lint.TextRule val: _DummyRule; _DummyRule2]
-    end
+    let rules: Array[lint.TextRule val] val =
+      recover val [as lint.TextRule val: _DummyRule; _DummyRule2] end
     let no_ast = recover val Array[lint.ASTRule val] end
-    let disabled = recover val
-      let s = Set[String]
-      s.set("test")
-      s
-    end
-    let config = lint.LintConfig(disabled,
-      recover val Map[String, lint.RuleStatus] end)
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("test")
+        s
+      end
+    let config =
+      lint.LintConfig(
+        disabled,
+        recover val Map[String, lint.RuleStatus] end)
     let registry = lint.RuleRegistry(rules, no_ast, config)
     h.assert_eq[USize](0, registry.enabled_text_rules().size())
     h.assert_eq[USize](2, registry.all_text_rules().size())
@@ -78,17 +81,19 @@ class \nodoc\ _TestRegistryAllAlwaysComplete is UnitTest
   fun name(): String => "Registry: all_text_rules always complete"
 
   fun apply(h: TestHelper) =>
-    let rules: Array[lint.TextRule val] val = recover val
-      [as lint.TextRule val: _DummyRule; _DummyRule2]
-    end
+    let rules: Array[lint.TextRule val] val =
+      recover val [as lint.TextRule val: _DummyRule; _DummyRule2] end
     let no_ast = recover val Array[lint.ASTRule val] end
-    let disabled = recover val
-      Set[String]
-        .> set("test/dummy")
-        .> set("test/dummy2")
-    end
-    let config = lint.LintConfig(disabled,
-      recover val Map[String, lint.RuleStatus] end)
+    let disabled =
+      recover val
+        Set[String]
+          .> set("test/dummy")
+          .> set("test/dummy2")
+      end
+    let config =
+      lint.LintConfig(
+        disabled,
+        recover val Map[String, lint.RuleStatus] end)
     let registry = lint.RuleRegistry(rules, no_ast, config)
     h.assert_eq[USize](0, registry.enabled_text_rules().size())
     h.assert_eq[USize](2, registry.all_text_rules().size())
@@ -99,22 +104,26 @@ class \nodoc\ _TestRegistryASTRules is UnitTest
 
   fun apply(h: TestHelper) =>
     let no_text = recover val Array[lint.TextRule val] end
-    let ast_rules: Array[lint.ASTRule val] val = recover val
-      [as lint.ASTRule val: lint.TypeNaming; lint.MemberNaming]
-    end
+    let ast_rules: Array[lint.ASTRule val] val =
+      recover val
+        [as lint.ASTRule val: lint.TypeNaming; lint.MemberNaming]
+      end
     let no_ast_disabled = lint.LintConfig.default()
     let registry = lint.RuleRegistry(no_text, ast_rules, no_ast_disabled)
     h.assert_eq[USize](2, registry.enabled_ast_rules().size())
     h.assert_eq[USize](2, registry.all_ast_rules().size())
 
     // Disable one rule
-    let disabled = recover val
-      let s = Set[String]
-      s.set("style/type-naming")
-      s
-    end
-    let config = lint.LintConfig(disabled,
-      recover val Map[String, lint.RuleStatus] end)
+    let disabled =
+      recover val
+        let s = Set[String]
+        s.set("style/type-naming")
+        s
+      end
+    let config =
+      lint.LintConfig(
+        disabled,
+        recover val Map[String, lint.RuleStatus] end)
     let registry2 = lint.RuleRegistry(no_text, ast_rules, config)
     h.assert_eq[USize](1, registry2.enabled_ast_rules().size())
     h.assert_eq[USize](2, registry2.all_ast_rules().size())

--- a/tools/pony-lint/test/_test_source_file.pony
+++ b/tools/pony-lint/test/_test_source_file.pony
@@ -87,8 +87,9 @@ class \nodoc\ _TestSourceFileCRLF is UnitTest
   fun name(): String => "SourceFile: CRLF normalization"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/test.pony",
-      "line1\r\nline2\r\nline3", "/tmp")
+    let sf =
+      lint.SourceFile("/tmp/test.pony",
+        "line1\r\nline2\r\nline3", "/tmp")
     h.assert_eq[USize](3, sf.lines.size())
     try
       h.assert_eq[String]("line1", sf.lines(0)?)

--- a/tools/pony-lint/test/_test_suppression.pony
+++ b/tools/pony-lint/test/_test_suppression.pony
@@ -130,8 +130,11 @@ class \nodoc\ _TestSuppressionMalformed is UnitTest
   fun name(): String => "Suppression: malformed directive error"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "// pony-lint: bogus style/line-length\n", "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony",
+        "// pony-lint: bogus style/line-length\n",
+        "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_eq[USize](1, sup.errors().size())
     try
@@ -183,8 +186,9 @@ class \nodoc\ _TestSuppressionEmptyDirective is UnitTest
   fun name(): String => "Suppression: empty directive error"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "// pony-lint:\n", "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony", "// pony-lint:\n", "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_eq[USize](1, sup.errors().size())
     try
@@ -263,8 +267,9 @@ class \nodoc\ _TestSuppressionNoSpaceAfterSlashes is UnitTest
     "Suppression: no space after // is malformed"
 
   fun apply(h: TestHelper) =>
-    let sf = lint.SourceFile("/tmp/t.pony",
-      "//pony-lint: off style\n", "/tmp")
+    let sf =
+      lint.SourceFile(
+        "/tmp/t.pony", "//pony-lint: off style\n", "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_eq[USize](1, sup.errors().size())
     try

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -322,6 +322,15 @@ actor \nodoc\ Main is TestList
     test(_TestLambdaSpacingBareLambdaSpaceAfterOpen)
     test(_TestLambdaSpacingBareLambdaTypeClean)
 
+    // AssignmentIndent tests
+    test(_TestAssignmentIndentSingleLine)
+    test(_TestAssignmentIndentRHSNextLine)
+    test(_TestAssignmentIndentMultiLineNextLine)
+    test(_TestAssignmentIndentViolation)
+    test(_TestAssignmentIndentRecoverViolation)
+    test(_TestAssignmentIndentReassignment)
+    test(_TestAssignmentIndentMultipleViolations)
+
     // PreferChaining tests
     test(_TestPreferChainingViolation)
     test(_TestPreferChainingVarViolation)


### PR DESCRIPTION
Adds the `style/assignment-indent` lint rule (Phase 3, PR 2 from Discussion #4844).

When an assignment's RHS spans multiple lines, the style guide requires the RHS to start on the line after the `=`, not on the same line. The rule checks `TK_ASSIGN` nodes: if the RHS starts on the `=` line and extends further, it's flagged.

This establishes the "detect multiline construct, check position" pattern for later multiline formatting rules.

All existing violations in pony-lint's own source (~100 occurrences across source and test files) are fixed in this PR.