### PR TITLE
Update Docker image base to Alpine 3.23

### DIFF
--- a/.dockerfiles/nightly/Dockerfile
+++ b/.dockerfiles/nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 

--- a/.dockerfiles/release/Dockerfile
+++ b/.dockerfiles/release/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.23
 
 LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 

--- a/.release-notes/update-docker-image-base-to-alpine-3.23.md
+++ b/.release-notes/update-docker-image-base-to-alpine-3.23.md
@@ -1,0 +1,3 @@
+## Update Docker image base to Alpine 3.23
+
+The `ponylang/ponyc:nightly` and `ponylang/ponyc:release` Docker images now use Alpine 3.23 as their base image, updated from Alpine 3.21.


### PR DESCRIPTION
The nightly and release Dockerfiles were still using Alpine 3.21 as the base image, but the build-nightly-image and build-release-image workflows were updated to trigger on alpine3.23 package names. This mismatch caused ponyup inside the container to detect the platform as alpine3.21 and fail to find the corresponding package on Cloudsmith.