### PR TITLE
Update pr-tools.yml trigger to skip irrelevant changes

### DIFF
--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -1,6 +1,15 @@
 name: Tools
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**'
+      - '!**/*.md'
+      - '!**/*.yml'
+      - '!.dockerfiles/**'
+      - '!.ci-dockerfiles/**'
+      - '.github/workflows/pr-tools.yml'
 
 concurrency:
   group: pr-tools-${{ github.ref }}


### PR DESCRIPTION
The tools workflow was triggering on every PR event, including changes to markdown, CI YAML, and Docker files that can't affect tool compilation or behavior. Now it only runs when source code changes, with a self-include so changes to the workflow itself still trigger it.