### PR TITLE
Add http to Windows nightly dispatch matrix

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -88,6 +88,7 @@ jobs:
       matrix:
         repo:
           - ponylang/corral
+          - ponylang/http
     steps:
       - name: Send
         # v2.1.1


### PR DESCRIPTION
The http repo has a Windows breakage test workflow (`breakage-against-windows-ponyc-latest.yml`) that listens for `ponyc-windows-nightly-released` repository dispatch events, but `ponylang/http` was never added to the dispatch matrix in `cloudsmith-package-sychronised.yml`. The Windows breakage test has never triggered.

Closes ponylang/http#124