### PR TITLE
Add `style/call-argument-format` lint rule

### DIFF
--- a/tools/pony-lint/_unreachable.pony
+++ b/tools/pony-lint/_unreachable.pony
@@ -12,6 +12,9 @@ primitive _Unreachable
   fun apply(loc: SourceLoc = __loc): None =>
     let url = "https://github.com/ponylang/ponyc/issues"
     let fmt = "Unreachable at %s:%zu\nPlease report: " + url + "\n"
-    @fprintf(@pony_os_stderr(), fmt.cstring(),
-      loc.file().cstring(), loc.line())
+    @fprintf(
+      @pony_os_stderr(),
+      fmt.cstring(),
+      loc.file().cstring(),
+      loc.line())
     @exit(1)

--- a/tools/pony-lint/acronym_casing.pony
+++ b/tools/pony-lint/acronym_casing.pony
@@ -35,10 +35,13 @@ primitive AcronymCasing is ASTRule
         match NamingHelpers.has_lowered_acronym(name)
         | let acronym: String val =>
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "acronym '" + acronym + "' in '" + name
                 + "' should be fully uppercased",
-              source.rel_path, name_node.line(), name_node.pos())]
+              source.rel_path,
+              name_node.line(),
+              name_node.pos())]
           end
         end
       end

--- a/tools/pony-lint/array_literal_format.pony
+++ b/tools/pony-lint/array_literal_format.pony
@@ -49,10 +49,13 @@ primitive ArrayLiteralFormat is ASTRule
       // If it's a hanging indent, report only that and skip spacing checks
       // since the user needs to restructure the line anyway.
       if not _is_first_nonws(line_text, open_col) then
-        diags.push(Diagnostic(id(),
+        diags.push(Diagnostic(
+          id(),
           "opening '[' of multiline array must be the first"
             + " non-whitespace on its line",
-          source.rel_path, open_line, open_col))
+          source.rel_path,
+          open_line,
+          open_col))
         return consume diags
       end
 
@@ -60,9 +63,12 @@ primitive ArrayLiteralFormat is ASTRule
       let after_idx = open_col.usize() // 0-based index after `[`
       if after_idx < line_text.size() then
         if line_text(after_idx)? != ' ' then
-          diags.push(Diagnostic(id(),
+          diags.push(Diagnostic(
+            id(),
             "space required after '[' in multiline array",
-            source.rel_path, open_line, open_col))
+            source.rel_path,
+            open_line,
+            open_col))
         end
       end
     end

--- a/tools/pony-lint/assignment_indent.pony
+++ b/tools/pony-lint/assignment_indent.pony
@@ -51,9 +51,12 @@ primitive AssignmentIndent is ASTRule
     if mlv.max_line > assign_line then
       // Multiline RHS starting on the `=` line — violation
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "multiline assignment RHS should start on the line after '='",
-          source.rel_path, assign_line, node.pos())]
+          source.rel_path,
+          assign_line,
+          node.pos())]
       end
     else
       // Single-line RHS — clean

--- a/tools/pony-lint/blank_lines.pony
+++ b/tools/pony-lint/blank_lines.pony
@@ -73,9 +73,12 @@ primitive BlankLines is ASTRule
       try
         let prev_line = source.lines(first_content_line - 2)?
         if _is_blank(prev_line) then
-          result.push(Diagnostic(id(),
+          result.push(Diagnostic(
+            id(),
             "no blank line before first body content",
-            source.rel_path, first_content_line - 1, 1))
+            source.rel_path,
+            first_content_line - 1,
+            1))
         end
       end
     end
@@ -101,9 +104,12 @@ primitive BlankLines is ASTRule
         if prev_is_field and curr_is_field then
           // No blank lines between consecutive fields
           if blanks > 0 then
-            result.push(Diagnostic(id(),
+            result.push(Diagnostic(
+              id(),
               "no blank lines between fields",
-              source.rel_path, curr_start, curr_member.pos()))
+              source.rel_path,
+              curr_start,
+              curr_member.pos()))
           end
         elseif curr_is_method then
           // One blank line before methods
@@ -113,15 +119,21 @@ primitive BlankLines is ASTRule
           if prev_is_method and prev_one_liner and curr_one_liner then
             // One-liner exception: both methods are one-liners
             if blanks > 1 then
-              result.push(Diagnostic(id(),
+              result.push(Diagnostic(
+                id(),
                 "at most 1 blank line before method",
-                source.rel_path, curr_start, curr_member.pos()))
+                source.rel_path,
+                curr_start,
+                curr_member.pos()))
             end
           else
             if blanks != 1 then
-              result.push(Diagnostic(id(),
+              result.push(Diagnostic(
+                id(),
                 "exactly 1 blank line before method",
-                source.rel_path, curr_start, curr_member.pos()))
+                source.rel_path,
+                curr_start,
+                curr_member.pos()))
             end
           end
         end
@@ -162,15 +174,21 @@ primitive BlankLines is ASTRule
         if a_one_liner and b_one_liner then
           // Both one-liners — 0 or 1 blank lines allowed
           if blanks > 1 then
-            result.push(Diagnostic(id(),
+            result.push(Diagnostic(
+              id(),
               "at most 1 blank line between entities",
-              source.rel_path, b_start, 1))
+              source.rel_path,
+              b_start,
+              1))
           end
         else
           if blanks != 1 then
-            result.push(Diagnostic(id(),
+            result.push(Diagnostic(
+              id(),
               "exactly 1 blank line between entities",
-              source.rel_path, b_start, 1))
+              source.rel_path,
+              b_start,
+              1))
           end
         end
       end

--- a/tools/pony-lint/call_argument_format.pony
+++ b/tools/pony-lint/call_argument_format.pony
@@ -1,0 +1,200 @@
+use ast = "pony_compiler"
+
+primitive CallArgumentFormat is ASTRule
+  """
+  Checks formatting of multiline function call arguments per the style guide.
+
+  For calls with two or more positional arguments that span multiple lines,
+  checks:
+
+  - No arguments start on the `(` line — arguments should begin on the
+    next line.
+  - Arguments are either all on one continuation line, or each on its own
+    line.
+
+  Single-line calls, single-argument calls, and named-argument-only calls
+  are not checked. The `where` clause is allowed on its own line and is not
+  subject to layout checks.
+
+  This rule does not check whether all-on-one-line arguments fit within the
+  80-column limit — `style/line-length` catches that separately.
+
+  These rules apply to both regular calls and FFI calls.
+  """
+  fun id(): String val => "style/call-argument-format"
+  fun category(): String val => "style"
+
+  fun description(): String val =>
+    "multiline call argument formatting"
+      + " (argument layout and placement)"
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [ ast.TokenIds.tk_call()
+      ast.TokenIds.tk_fficall() ]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Check formatting of multiline call arguments.
+    """
+    let is_fficall = node.id() == ast.TokenIds.tk_fficall()
+
+    // Get TK_POSITIONALARGS: child 1 for TK_CALL, child 2 for TK_FFICALL
+    let pos_args_idx: USize = if is_fficall then 2 else 1 end
+    let pos_args =
+      try
+        let child = node(pos_args_idx)?
+        if child.id() == ast.TokenIds.tk_none() then
+          return recover val Array[Diagnostic val] end
+        end
+        if child.id() != ast.TokenIds.tk_positionalargs() then
+          return recover val Array[Diagnostic val] end
+        end
+        child
+      else
+        return recover val Array[Diagnostic val] end
+      end
+
+    let num_args = pos_args.num_children()
+    if num_args < 2 then
+      return recover val Array[Diagnostic val] end
+    end
+
+    // Find the '(' line and column
+    (let open_line, let open_col) =
+      _find_open_paren(node, source)
+
+    // Determine if multiline using _MaxLineVisitor seeded with '(' line
+    let mlv = _MaxLineVisitor(open_line)
+    node.visit(mlv)
+    if mlv.max_line == open_line then
+      // Single-line call
+      return recover val Array[Diagnostic val] end
+    end
+
+    let diags = recover iso Array[Diagnostic val] end
+
+    // Collect start lines for each positional arg
+    let arg_lines = Array[USize](num_args)
+    var i: USize = 0
+    while i < num_args do
+      try
+        arg_lines.push(_arg_start_line(pos_args(i)?))
+      else _Unreachable()
+      end
+      i = i + 1
+    end
+
+    // Check 1: no arg should start on the '(' line
+    for arg_line in arg_lines.values() do
+      if arg_line == open_line then
+        diags.push(Diagnostic(
+          id(),
+          "in a multiline call, arguments should start"
+            + " on the line after '('",
+          source.rel_path,
+          open_line,
+          open_col))
+        break // one diagnostic for this check
+      end
+    end
+
+    // Check 2: all on one line or each on own line
+    let distinct = _count_distinct(arg_lines)
+    if (distinct != 1) and (distinct != arg_lines.size()) then
+      diags.push(Diagnostic(
+        id(),
+        "multiline call arguments must all be on one line"
+          + " or each on its own line",
+        source.rel_path,
+        open_line,
+        open_col))
+    end
+
+    consume diags
+
+  fun _find_open_paren(
+    node: ast.AST box,
+    source: SourceFile val)
+    : (USize, USize)
+  =>
+    """
+    Return the `(1-based line, 1-based col)` of the `(` for a call.
+
+    For TK_CALL the node position is at `(` (INFIX_BUILD). For TK_FFICALL
+    the node position is at `@`, so we scan forward through source text to
+    find the first `(` character.
+    """
+    if node.id() == ast.TokenIds.tk_call() then
+      return (node.line(), node.pos())
+    end
+
+    // TK_FFICALL: scan forward from '@' to find '('
+    let start_line_idx = node.line() - 1 // 0-based
+    var line_idx = start_line_idx
+    while line_idx < source.lines.size() do
+      try
+        let line_text = source.lines(line_idx)?
+        let col_start: USize =
+          if line_idx == start_line_idx then
+            node.pos() // 1-based col of '@', so 0-based index after '@'
+          else
+            0
+          end
+        var j: USize = col_start
+        while j < line_text.size() do
+          if line_text(j)? == '(' then
+            return (line_idx + 1, j + 1) // convert to 1-based
+          end
+          j = j + 1
+        end
+      end
+      line_idx = line_idx + 1
+    end
+    (node.line(), node.pos()) // fallback
+
+  fun _arg_start_line(node: ast.AST box): USize =>
+    """
+    Find the visual start line of an argument expression.
+
+    Arguments are wrapped in TK_SEQ nodes, and the actual expression may be
+    an infix-built node (like TK_CALL or TK_DOT) whose position is at the
+    operator rather than the visual start. This function unwraps to find
+    the leftmost source position.
+    """
+    if node.id() == ast.TokenIds.tk_seq() then
+      try return _arg_start_line(node(0)?) end
+    end
+    if node.infix_node() then
+      try return _arg_start_line(node(0)?) end
+    end
+    node.line()
+
+  fun _count_distinct(lines: Array[USize]): USize =>
+    """
+    Count distinct values in an array of line numbers.
+    """
+    var count: USize = 0
+    var i: USize = 0
+    while i < lines.size() do
+      try
+        let line = lines(i)?
+        var seen = false
+        var j: USize = 0
+        while j < i do
+          try
+            if lines(j)? == line then
+              seen = true
+              break
+            end
+          end
+          j = j + 1
+        end
+        if not seen then count = count + 1 end
+      end
+      i = i + 1
+    end
+    count

--- a/tools/pony-lint/comment_spacing.pony
+++ b/tools/pony-lint/comment_spacing.pony
@@ -33,8 +33,12 @@ primitive CommentSpacing is TextRule
         else
           match _find_comment(line)
           | let col: USize =>
-            result.push(Diagnostic(id(), "expected one space after //",
-              source.rel_path, idx + 1, col))
+            result.push(Diagnostic(
+              id(),
+              "expected one space after //",
+              source.rel_path,
+              idx + 1,
+              col))
           end
         end
       end

--- a/tools/pony-lint/control_structure_alignment.pony
+++ b/tools/pony-lint/control_structure_alignment.pony
@@ -139,15 +139,24 @@ primitive ControlStructureAlignment is ASTRule
         if else_clause.id() == ast.TokenIds.tk_if() then
           let actual_col = else_clause.pos()
           if actual_col != expected_col then
-            result.push(_misalignment_diag("elseif", opening,
-              expected_col, source.rel_path, else_clause.line(),
+            result.push(_misalignment_diag(
+              "elseif",
+              opening,
+              expected_col,
+              source.rel_path,
+              else_clause.line(),
               actual_col))
           end
           current = else_clause
         elseif else_clause.id() != ast.TokenIds.tk_none() then
           let d =
-            _find_keyword_above(source, else_clause.line(), "else",
-              current.line(), expected_col, opening)
+            _find_keyword_above(
+              source,
+              else_clause.line(),
+              "else",
+              current.line(),
+              expected_col,
+              opening)
           match d
           | let diag: Diagnostic val => result.push(diag)
           end
@@ -190,15 +199,24 @@ primitive ControlStructureAlignment is ASTRule
         if else_clause.id() == ast.TokenIds.tk_ifdef() then
           let actual_col = else_clause.pos()
           if actual_col != expected_col then
-            result.push(_misalignment_diag("elseif", opening,
-              expected_col, source.rel_path, else_clause.line(),
+            result.push(_misalignment_diag(
+              "elseif",
+              opening,
+              expected_col,
+              source.rel_path,
+              else_clause.line(),
               actual_col))
           end
           current = else_clause
         elseif else_clause.id() != ast.TokenIds.tk_none() then
           let d =
-            _find_keyword_above(source, else_clause.line(), "else",
-              current.line(), expected_col, opening)
+            _find_keyword_above(
+              source,
+              else_clause.line(),
+              "else",
+              current.line(),
+              expected_col,
+              opening)
           match d
           | let diag: Diagnostic val => result.push(diag)
           end
@@ -236,8 +254,13 @@ primitive ControlStructureAlignment is ASTRule
       let else_clause = node(2)?
       if else_clause.id() != ast.TokenIds.tk_none() then
         let d =
-          _find_keyword_above(source, else_clause.line(), "else",
-            node.line(), expected_col, opening)
+          _find_keyword_above(
+            source,
+            else_clause.line(),
+            "else",
+            node.line(),
+            expected_col,
+            opening)
         match d
         | let diag: Diagnostic val => result.push(diag)
         end
@@ -269,8 +292,13 @@ primitive ControlStructureAlignment is ASTRule
       let else_clause = node(3)?
       if else_clause.id() != ast.TokenIds.tk_none() then
         let d =
-          _find_keyword_above(source, else_clause.line(), "else",
-            node.line(), expected_col, opening)
+          _find_keyword_above(
+            source,
+            else_clause.line(),
+            "else",
+            node.line(),
+            expected_col,
+            opening)
         match d
         | let diag: Diagnostic val => result.push(diag)
         end
@@ -302,8 +330,13 @@ primitive ControlStructureAlignment is ASTRule
       let until_cond = node(1)?
       if until_cond.id() != ast.TokenIds.tk_none() then
         let d =
-          _find_keyword_above(source, until_cond.line(), "until",
-            node.line(), expected_col, opening)
+          _find_keyword_above(
+            source,
+            until_cond.line(),
+            "until",
+            node.line(),
+            expected_col,
+            opening)
         match d
         | let diag: Diagnostic val => result.push(diag)
         end
@@ -316,8 +349,13 @@ primitive ControlStructureAlignment is ASTRule
         try
           let until_cond = node(1)?
           let d =
-            _find_keyword_above(source, else_clause.line(), "else",
-              until_cond.line(), expected_col, opening)
+            _find_keyword_above(
+              source,
+              else_clause.line(),
+              "else",
+              until_cond.line(),
+              expected_col,
+              opening)
           match d
           | let diag: Diagnostic val => result.push(diag)
           end
@@ -350,8 +388,13 @@ primitive ControlStructureAlignment is ASTRule
       let else_clause = node(1)?
       if else_clause.id() != ast.TokenIds.tk_none() then
         let d =
-          _find_keyword_above(source, else_clause.line(), "else",
-            node.line(), expected_col, opening)
+          _find_keyword_above(
+            source,
+            else_clause.line(),
+            "else",
+            node.line(),
+            expected_col,
+            opening)
         match d
         | let diag: Diagnostic val => result.push(diag)
         end
@@ -365,15 +408,25 @@ primitive ControlStructureAlignment is ASTRule
           let else_clause = node(1)?
           if else_clause.id() != ast.TokenIds.tk_none() then
             let d =
-              _find_keyword_above(source, then_clause.line(), "then",
-                else_clause.line(), expected_col, opening)
+              _find_keyword_above(
+                source,
+                then_clause.line(),
+                "then",
+                else_clause.line(),
+                expected_col,
+                opening)
             match d
             | let diag: Diagnostic val => result.push(diag)
             end
           else
             let d =
-              _find_keyword_above(source, then_clause.line(), "then",
-                node.line(), expected_col, opening)
+              _find_keyword_above(
+                source,
+                then_clause.line(),
+                "then",
+                node.line(),
+                expected_col,
+                opening)
             match d
             | let diag: Diagnostic val => result.push(diag)
             end
@@ -401,10 +454,13 @@ primitive ControlStructureAlignment is ASTRule
     """
     Create a diagnostic for a misaligned keyword.
     """
-    Diagnostic(id(),
+    Diagnostic(
+      id(),
       "'" + keyword + "' should align with '" + opening
         + "' keyword (column " + expected_col.string() + ")",
-      file, line, actual_col)
+      file,
+      line,
+      actual_col)
 
   fun _find_keyword_above(
     source: SourceFile val,
@@ -427,8 +483,13 @@ primitive ControlStructureAlignment is ASTRule
         (let word, let col) = _first_nonws_word(line_text)
         if word == keyword then
           if col != expected_col then
-            return _misalignment_diag(keyword, opening, expected_col,
-              source.rel_path, line_num, col)
+            return _misalignment_diag(
+              keyword,
+              opening,
+              expected_col,
+              source.rel_path,
+              line_num,
+              col)
           end
           return None
         end
@@ -481,8 +542,13 @@ primitive ControlStructureAlignment is ASTRule
             // The matching end is on this line
             if word == "end" then
               if col != expected_col then
-                return _misalignment_diag("end", opening, expected_col,
-                  source.rel_path, line_num, col)
+                return _misalignment_diag(
+                  "end",
+                  opening,
+                  expected_col,
+                  source.rel_path,
+                  line_num,
+                  col)
               end
             end
             return None
@@ -544,7 +610,8 @@ primitive ControlStructureAlignment is ASTRule
       i = i + 1
     end
 
-    (recover val line.substring(ISize.from[USize](start),
+    (recover val line.substring(
+      ISize.from[USize](start),
       ISize.from[USize](i)) end, col)
 
   fun _line_depth_delta(line: String val): ISize =>
@@ -591,7 +658,8 @@ primitive ControlStructureAlignment is ASTRule
           end
           let word =
             recover val
-              line.substring(ISize.from[USize](word_start),
+              line.substring(
+                ISize.from[USize](word_start),
                 ISize.from[USize](i))
             end
           if _is_block_opener(word) then delta = delta + 1 end

--- a/tools/pony-lint/docstring_format.pony
+++ b/tools/pony-lint/docstring_format.pony
@@ -140,9 +140,12 @@ primitive DocstringFormat is ASTRule
         // content on the opening line of a multi-line string, so
         // this is the only reachable case.
         recover val
-          [ Diagnostic(id(),
+          [ Diagnostic(
+            id(),
             "opening \"\"\" should be on its own line",
-            source.rel_path, start_line, 1)]
+            source.rel_path,
+            start_line,
+            1)]
         end
       else
         // Opening """ is on its own line — check closing
@@ -152,9 +155,12 @@ primitive DocstringFormat is ASTRule
             let close_line = source.lines(close_line_idx)?
             if not _is_only_triple_quote(close_line) then
               return recover val
-                [ Diagnostic(id(),
+                [ Diagnostic(
+                  id(),
                   "closing \"\"\" should be on its own line",
-                  source.rel_path, close_line_idx + 1, 1)]
+                  source.rel_path,
+                  close_line_idx + 1,
+                  1)]
               end
             end
           end

--- a/tools/pony-lint/dot_spacing.pony
+++ b/tools/pony-lint/dot_spacing.pony
@@ -51,9 +51,12 @@ primitive DotSpacing is ASTRule
         try
           if line_text((dot_col - 2).usize())? == ' ' then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "no space before '.'",
-                source.rel_path, dot_line, dot_col)]
+                source.rel_path,
+                dot_line,
+                dot_col)]
             end
           end
         end
@@ -64,9 +67,12 @@ primitive DotSpacing is ASTRule
         let after = line_text(dot_col.usize())?
         if after == ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "no space after '.'",
-              source.rel_path, dot_line, dot_col)]
+              source.rel_path,
+              dot_line,
+              dot_col)]
           end
         end
       end
@@ -91,9 +97,12 @@ primitive DotSpacing is ASTRule
         try
           if line_text((chain_col - 2).usize())? != ' ' then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "space required before '.>'",
-                source.rel_path, chain_line, chain_col)]
+                source.rel_path,
+                chain_line,
+                chain_col)]
             end
           end
         end
@@ -105,9 +114,12 @@ primitive DotSpacing is ASTRule
         let after = line_text(after_idx)?
         if after != ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "space required after '.>'",
-              source.rel_path, chain_line, chain_col)]
+              source.rel_path,
+              chain_line,
+              chain_col)]
           end
         end
       end

--- a/tools/pony-lint/file_naming.pony
+++ b/tools/pony-lint/file_naming.pony
@@ -72,10 +72,13 @@ primitive FileNaming is ASTRule
 
     if expected != actual then
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "file '" + _filename_stem(source.path) + ".pony' should be named '"
             + expected + ".pony' (principal type: " + principal + ")",
-          source.rel_path, 1, 1)]
+          source.rel_path,
+          1,
+          1)]
       end
     else
       recover val Array[Diagnostic val] end

--- a/tools/pony-lint/hard_tabs.pony
+++ b/tools/pony-lint/hard_tabs.pony
@@ -17,9 +17,12 @@ primitive HardTabs is TextRule
         var col: USize = 1
         for byte in line.values() do
           if byte == '\t' then
-            result.push(Diagnostic(id(),
+            result.push(Diagnostic(
+              id(),
               "use spaces for indentation, not tabs",
-              source.rel_path, idx + 1, col))
+              source.rel_path,
+              idx + 1,
+              col))
           end
           col = col + 1
         end

--- a/tools/pony-lint/indentation_size.pony
+++ b/tools/pony-lint/indentation_size.pony
@@ -29,9 +29,12 @@ primitive IndentationSize is TextRule
         else
           let spaces = _count_leading_spaces(line)
           if (spaces > 0) and ((spaces % 2) != 0) then
-            result.push(Diagnostic(id(),
+            result.push(Diagnostic(
+              id(),
               "indentation should be a multiple of 2 spaces",
-              source.rel_path, idx + 1, 1))
+              source.rel_path,
+              idx + 1,
+              1))
           end
         end
       end

--- a/tools/pony-lint/lambda_spacing.pony
+++ b/tools/pony-lint/lambda_spacing.pony
@@ -51,9 +51,12 @@ primitive LambdaSpacing is ASTRule
       try
         if line_text(after_brace_idx)? == ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "no space after '{' in lambda",
-              source.rel_path, op_line, brace_col)]
+              source.rel_path,
+              op_line,
+              brace_col)]
           end
         end
       end
@@ -64,7 +67,9 @@ primitive LambdaSpacing is ASTRule
         if is_type then
           // Lambda types: no space before `}`
           _check_no_space_before_brace(
-            source, close_line, close_col,
+            source,
+            close_line,
+            close_col,
             "no space before '}' in lambda type")
         else
           // Lambda expressions: space before `}` only on single-line
@@ -75,7 +80,9 @@ primitive LambdaSpacing is ASTRule
           if single_line then
             // Single-line: must have space before `}`
             _check_space_before_brace(
-              source, close_line, close_col)
+              source,
+              close_line,
+              close_col)
           else
             // Multi-line: no space before `}`, unless `}` is first on its
             // line (indented on its own line is fine)
@@ -83,7 +90,9 @@ primitive LambdaSpacing is ASTRule
               let close_text = source.lines(close_line - 1)?
               if not _is_first_nonws(close_text, close_col) then
                 _check_no_space_before_brace(
-                  source, close_line, close_col,
+                  source,
+                  close_line,
+                  close_col,
                   "no space before '}' in multi-line lambda")
               else
                 recover val Array[Diagnostic val] end
@@ -115,9 +124,12 @@ primitive LambdaSpacing is ASTRule
         try
           if close_text((close_col - 2).usize())? != ' ' then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "space required before '}' in single-line lambda",
-                source.rel_path, close_line, close_col)]
+                source.rel_path,
+                close_line,
+                close_col)]
             end
           end
         end
@@ -141,8 +153,12 @@ primitive LambdaSpacing is ASTRule
         try
           if close_text((close_col - 2).usize())? == ' ' then
             return recover val
-              [ Diagnostic(id(), msg,
-                source.rel_path, close_line, close_col)]
+              [ Diagnostic(
+                id(),
+                msg,
+                source.rel_path,
+                close_line,
+                close_col)]
             end
           end
         end

--- a/tools/pony-lint/line_length.pony
+++ b/tools/pony-lint/line_length.pony
@@ -18,9 +18,12 @@ primitive LineLength is TextRule
       for (idx, line) in source.lines.pairs() do
         let cp_count = line.codepoints()
         if cp_count > 80 then
-          result.push(Diagnostic(id(), "line exceeds 80 columns ("
-            + cp_count.string() + ")",
-            source.rel_path, idx + 1, 81))
+          result.push(Diagnostic(
+            id(),
+            "line exceeds 80 columns (" + cp_count.string() + ")",
+            source.rel_path,
+            idx + 1,
+            81))
         end
       end
       result

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -60,9 +60,12 @@ class val Linter
         end
       let fp = FilePath(_file_auth, abs_target)
       if not fp.exists() then
-        all_diags.push(Diagnostic("lint/io-error",
+        all_diags.push(Diagnostic(
+          "lint/io-error",
           "target not found: " + target,
-          target, 0, 0))
+          target,
+          0,
+          0))
         has_error = true
       end
     end
@@ -77,9 +80,12 @@ class val Linter
       let fp = FilePath(_file_auth, path)
       let file = File.open(fp)
       if not file.valid() then
-        all_diags.push(Diagnostic("lint/io-error",
+        all_diags.push(Diagnostic(
+          "lint/io-error",
           "could not read file: " + path,
-          try Path.rel(_cwd, path)? else path end, 0, 0))
+          try Path.rel(_cwd, path)? else path end,
+          0,
+          0))
         has_error = true
         continue
       end
@@ -143,8 +149,11 @@ class val Linter
               try
                 let info = file_info(mod_file)?
                 let dispatcher =
-                  _ASTDispatcher(_registry.enabled_ast_rules(),
-                    info.source, info.magic_lines, info.suppressions)
+                  _ASTDispatcher(
+                    _registry.enabled_ast_rules(),
+                    info.source,
+                    info.magic_lines,
+                    info.suppressions)
                 mod.ast.visit(dispatcher)
 
                 for d in dispatcher.diagnostics().values() do
@@ -152,7 +161,9 @@ class val Linter
                 end
 
                 // File-naming check (module-level)
-                if _registry.is_enabled(FileNaming.id(), FileNaming.category(),
+                if _registry.is_enabled(
+                  FileNaming.id(),
+                  FileNaming.category(),
                   FileNaming.default_status())
                 then
                   let file_diags =
@@ -168,8 +179,10 @@ class val Linter
                 end
 
                 // Blank-lines between-entity check (module-level)
-                if _registry.is_enabled(BlankLines.id(),
-                  BlankLines.category(), BlankLines.default_status())
+                if _registry.is_enabled(
+                  BlankLines.id(),
+                  BlankLines.category(),
+                  BlankLines.default_status())
                 then
                   let bl_diags =
                     BlankLines.check_module(
@@ -197,8 +210,10 @@ class val Linter
               end
 
             // Package-naming check (once per package)
-            if _registry.is_enabled(PackageNaming.id(),
-              PackageNaming.category(), PackageNaming.default_status())
+            if _registry.is_enabled(
+              PackageNaming.id(),
+              PackageNaming.category(),
+              PackageNaming.default_status())
             then
               let pkg_diags =
                 PackageNaming.check_package(
@@ -209,7 +224,8 @@ class val Linter
             end
 
             // Package-docstring check (once per package)
-            if _registry.is_enabled(PackageDocstring.id(),
+            if _registry.is_enabled(
+              PackageDocstring.id(),
               PackageDocstring.category(),
               PackageDocstring.default_status())
             then
@@ -260,8 +276,12 @@ class val Linter
               else
                 rel_dir
               end
-            all_diags.push(Diagnostic("lint/ast-error",
-              err.msg, err_file, err.position.line(), err.position.column()))
+            all_diags.push(Diagnostic(
+              "lint/ast-error",
+              err.msg,
+              err_file,
+              err.position.line(),
+              err.position.column()))
           end
         end
       end

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -23,14 +23,18 @@ actor Main
           "pony-lint",
           "A linter for Pony source files",
           [
-            OptionSpec.string_seq("disable",
+            OptionSpec.string_seq(
+              "disable",
               "Disable a rule or category (repeatable)"
               where short' = 'd')
-            OptionSpec.string("config",
+            OptionSpec.string(
+              "config",
               "Path to config file" where short' = 'c', default' = "")
-            OptionSpec.bool("version",
+            OptionSpec.bool(
+              "version",
               "Print version and exit" where short' = 'V', default' = false)
-            OptionSpec.string("explain",
+            OptionSpec.string(
+              "explain",
               "Print rule description and documentation URL"
               where default' = "")
           ],
@@ -95,6 +99,7 @@ actor Main
         .> push(ArrayLiteralFormat)
         .> push(MethodDeclarationFormat)
         .> push(TypeParameterFormat)
+        .> push(CallArgumentFormat)
     end
 
     // Handle --explain

--- a/tools/pony-lint/match_case_indent.pony
+++ b/tools/pony-lint/match_case_indent.pony
@@ -46,10 +46,13 @@ primitive MatchCaseIndent is ASTRule
               let line_text = source.lines(case_node.line() - 1)?
               if _is_first_nonws(line_text, case_col) then
                 if case_col != match_col then
-                  result.push(Diagnostic(id(),
+                  result.push(Diagnostic(
+                    id(),
                     "'|' should align with 'match' keyword (column "
                       + match_col.string() + ")",
-                    source.rel_path, case_node.line(), case_col))
+                    source.rel_path,
+                    case_node.line(),
+                    case_col))
                 end
               end
             end

--- a/tools/pony-lint/match_single_line.pony
+++ b/tools/pony-lint/match_single_line.pony
@@ -31,9 +31,12 @@ primitive MatchSingleLine is ASTRule
     node.visit(mlv)
     if mlv.max_line == match_line then
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "match expression should span multiple lines",
-          source.rel_path, match_line, node.pos())]
+          source.rel_path,
+          match_line,
+          node.pos())]
       end
     else
       recover val Array[Diagnostic val] end

--- a/tools/pony-lint/member_naming.pony
+++ b/tools/pony-lint/member_naming.pony
@@ -57,9 +57,12 @@ primitive MemberNaming is ASTRule
         end
         if not NamingHelpers.is_snake_case(name) then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "member name '" + name + "' should be snake_case",
-              source.rel_path, name_node.line(), name_node.pos())]
+              source.rel_path,
+              name_node.line(),
+              name_node.pos())]
           end
         end
       end

--- a/tools/pony-lint/method_declaration_format.pony
+++ b/tools/pony-lint/method_declaration_format.pony
@@ -62,10 +62,13 @@ primitive MethodDeclarationFormat is ASTRule
                 let param_node = params(i)?
                 let param_l = _param_line(param_node)
                 if param_l == prev_line then
-                  diags.push(Diagnostic(id(),
+                  diags.push(Diagnostic(
+                    id(),
                     "each parameter should be on its own line"
                       + " in a multiline declaration",
-                    source.rel_path, param_l, param_node.pos()))
+                    source.rel_path,
+                    param_l,
+                    param_node.pos()))
                 end
                 prev_line = param_l
                 i = i + 1
@@ -89,11 +92,14 @@ primitive MethodDeclarationFormat is ASTRule
               let expected_col = keyword_col + 2
               let actual_col = first_col + 1 // convert 0-based to 1-based
               if actual_col != expected_col then
-                diags.push(Diagnostic(id(),
+                diags.push(Diagnostic(
+                  id(),
                   "':' should align at column "
                     + expected_col.string()
                     + " (indented from '" + keyword_name + "')",
-                  source.rel_path, ret_line, actual_col))
+                  source.rel_path,
+                  ret_line,
+                  actual_col))
               end
             end
           end
@@ -117,11 +123,14 @@ primitive MethodDeclarationFormat is ASTRule
               if word == "=>" then
                 let actual_col = word_col
                 if actual_col != keyword_col then
-                  diags.push(Diagnostic(id(),
+                  diags.push(Diagnostic(
+                    id(),
                     "'=>' should align with '" + keyword_name
                       + "' keyword (column "
                       + keyword_col.string() + ")",
-                    source.rel_path, scan_line, actual_col))
+                    source.rel_path,
+                    scan_line,
+                    actual_col))
                 end
                 break
               end
@@ -219,5 +228,6 @@ primitive MethodDeclarationFormat is ASTRule
       i = i + 1
     end
 
-    (recover val line.substring(ISize.from[USize](start),
+    (recover val line.substring(
+      ISize.from[USize](start),
       ISize.from[USize](i)) end, col)

--- a/tools/pony-lint/operator_spacing.pony
+++ b/tools/pony-lint/operator_spacing.pony
@@ -90,9 +90,12 @@ primitive OperatorSpacing is ASTRule
         try
           if line_text((op_col - 2).usize())? != ' ' then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "space required before '" + symbol + "'",
-                source.rel_path, op_line, op_col)]
+                source.rel_path,
+                op_line,
+                op_col)]
             end
           end
         end
@@ -103,9 +106,12 @@ primitive OperatorSpacing is ASTRule
       try
         if line_text(after_idx)? != ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "space required after '" + symbol + "'",
-              source.rel_path, op_line, op_col)]
+              source.rel_path,
+              op_line,
+              op_col)]
           end
         end
       end
@@ -133,9 +139,12 @@ primitive OperatorSpacing is ASTRule
       try
         if line_text(after_idx)? == ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "no space after unary '" + symbol + "'",
-              source.rel_path, op_line, op_col)]
+              source.rel_path,
+              op_line,
+              op_col)]
           end
         end
       end
@@ -163,9 +172,12 @@ primitive OperatorSpacing is ASTRule
           let before = line_text((op_col - 2).usize())?
           if (before != ' ') and _is_alphanum(before) then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "space required before 'not'",
-                source.rel_path, op_line, op_col)]
+                source.rel_path,
+                op_line,
+                op_col)]
             end
           end
         end
@@ -176,9 +188,12 @@ primitive OperatorSpacing is ASTRule
       try
         if line_text(after_idx)? != ' ' then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "space required after 'not'",
-              source.rel_path, op_line, op_col)]
+              source.rel_path,
+              op_line,
+              op_col)]
           end
         end
       end

--- a/tools/pony-lint/package_docstring.pony
+++ b/tools/pony-lint/package_docstring.pony
@@ -49,15 +49,21 @@ primitive PackageDocstring is ASTRule
     """
     if not has_pkg_file then
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "package has no '" + pkg_name + ".pony' file",
-          first_file_rel, 0, 0)]
+          first_file_rel,
+          0,
+          0)]
       end
     elseif not has_docstring then
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "'" + pkg_name + ".pony' should have a package docstring",
-          first_file_rel, 0, 0)]
+          first_file_rel,
+          0,
+          0)]
       end
     else
       recover val Array[Diagnostic val] end

--- a/tools/pony-lint/package_naming.pony
+++ b/tools/pony-lint/package_naming.pony
@@ -41,9 +41,12 @@ primitive PackageNaming is ASTRule
     """
     if not NamingHelpers.is_snake_case(dir_name) then
       recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "package directory '" + dir_name + "' should be snake_case",
-          first_file_rel, 0, 0)]
+          first_file_rel,
+          0,
+          0)]
       end
     else
       recover val Array[Diagnostic val] end

--- a/tools/pony-lint/partial_call_spacing.pony
+++ b/tools/pony-lint/partial_call_spacing.pony
@@ -40,9 +40,12 @@ primitive PartialCallSpacing is ASTRule
           try
             if line_text((q_col - 2).usize())? == ' ' then
               return recover val
-                [ Diagnostic(id(),
+                [ Diagnostic(
+                  id(),
                   "'?' at call site should immediately follow ')'",
-                  source.rel_path, q_line, q_col)]
+                  source.rel_path,
+                  q_line,
+                  q_col)]
               end
             end
           end

--- a/tools/pony-lint/partial_spacing.pony
+++ b/tools/pony-lint/partial_spacing.pony
@@ -58,9 +58,12 @@ primitive PartialSpacing is ASTRule
           end
         if (not before_ok) or (not after_ok) then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "'?' in method declaration should have surrounding spaces",
-              source.rel_path, q_line, q_col)]
+              source.rel_path,
+              q_line,
+              q_col)]
           end
         end
       end

--- a/tools/pony-lint/prefer_chaining.pony
+++ b/tools/pony-lint/prefer_chaining.pony
@@ -120,9 +120,12 @@ primitive PreferChaining is ASTRule
 
     if should_flag then
       return recover val
-        [ Diagnostic(id(),
+        [ Diagnostic(
+          id(),
           "'" + var_name + "' can be replaced with .> chaining",
-          source.rel_path, node.line(), node.pos())]
+          source.rel_path,
+          node.line(),
+          node.pos())]
       end
     end
 

--- a/tools/pony-lint/public_docstring.pony
+++ b/tools/pony-lint/public_docstring.pony
@@ -122,9 +122,12 @@ primitive PublicDocstring is ASTRule
           // - Concrete methods: first expression of body (child 6)
           if not _method_has_docstring(node) then
             return recover val
-              [ Diagnostic(id(),
+              [ Diagnostic(
+                id(),
                 "public method '" + name + "' should have a docstring",
-                source.rel_path, name_node.line(), name_node.pos())]
+                source.rel_path,
+                name_node.line(),
+                name_node.pos())]
             end
           end
         else
@@ -133,9 +136,12 @@ primitive PublicDocstring is ASTRule
             let doc_node = node(6)?
             if doc_node.id() == ast.TokenIds.tk_none() then
               return recover val
-                [ Diagnostic(id(),
+                [ Diagnostic(
+                  id(),
                   "public type '" + name + "' should have a docstring",
-                  source.rel_path, name_node.line(), name_node.pos())]
+                  source.rel_path,
+                  name_node.line(),
+                  name_node.pos())]
               end
             end
           end

--- a/tools/pony-lint/rule_registry.pony
+++ b/tools/pony-lint/rule_registry.pony
@@ -24,7 +24,9 @@ class val RuleRegistry
       recover val
         let result = Array[TextRule val]
         for rule in rules.values() do
-          match config.rule_status(rule.id(), rule.category(),
+          match config.rule_status(
+            rule.id(),
+            rule.category(),
             rule.default_status())
           | RuleOn => result.push(rule)
           end
@@ -35,7 +37,9 @@ class val RuleRegistry
       recover val
         let result = Array[ASTRule val]
         for rule in ast_rules.values() do
-          match config.rule_status(rule.id(), rule.category(),
+          match config.rule_status(
+            rule.id(),
+            rule.category(),
             rule.default_status())
           | RuleOn => result.push(rule)
           end

--- a/tools/pony-lint/suppressions.pony
+++ b/tools/pony-lint/suppressions.pony
@@ -75,9 +75,12 @@ class val Suppressions
         trimmed.lstrip()
         if trimmed.at("//pony-lint:") then
           magic.set(line_num)
-          errs.push(Diagnostic("lint/malformed-suppression",
+          errs.push(Diagnostic(
+            "lint/malformed-suppression",
             "missing space after '//'",
-            source.rel_path, line_num, 1))
+            source.rel_path,
+            line_num,
+            1))
         elseif trimmed.at("// pony-lint:") then
           magic.set(line_num)
           let directive =
@@ -114,9 +117,12 @@ class val Suppressions
                 end
               end
               if active_offs.contains(target) then
-                errs.push(Diagnostic("lint/malformed-suppression",
+                errs.push(Diagnostic(
+                  "lint/malformed-suppression",
                   "duplicate 'off' for '" + target + "'",
-                  source.rel_path, line_num, 1))
+                  source.rel_path,
+                  line_num,
+                  1))
               else
                 active_offs(target) = line_num
               end
@@ -146,24 +152,33 @@ class val Suppressions
                 _Unreachable()
               end
             else
-              errs.push(Diagnostic("lint/malformed-suppression",
+              errs.push(Diagnostic(
+                "lint/malformed-suppression",
                 "unknown directive '" + action + "'",
-                source.rel_path, line_num, 1))
+                source.rel_path,
+                line_num,
+                1))
             end
           else
-            errs.push(Diagnostic("lint/malformed-suppression",
+            errs.push(Diagnostic(
+              "lint/malformed-suppression",
               "empty directive",
-              source.rel_path, line_num, 1))
+              source.rel_path,
+              line_num,
+              1))
           end
         end
       end
 
       // Report unclosed regions
       for (target, start_line) in active_offs.pairs() do
-        errs.push(Diagnostic("lint/unclosed-suppression",
+        errs.push(Diagnostic(
+          "lint/unclosed-suppression",
           "suppression for '" + target + "' opened at line "
             + start_line.string() + " was never closed",
-          source.rel_path, start_line, 1))
+          source.rel_path,
+          start_line,
+          1))
       end
 
       (suppressed, overrides, magic, errs)

--- a/tools/pony-lint/test/_test_array_literal_format.pony
+++ b/tools/pony-lint/test/_test_array_literal_format.pony
@@ -148,7 +148,9 @@ class \nodoc\ _TestArrayLiteralFormatHangingIndent is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.ArrayLiteralFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for hanging indent")
           try
             h.assert_true(
@@ -189,7 +191,9 @@ class \nodoc\ _TestArrayLiteralFormatNoSpaceAfterOpen is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.ArrayLiteralFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for missing space after '['")
           try
             h.assert_true(

--- a/tools/pony-lint/test/_test_call_argument_format.pony
+++ b/tools/pony-lint/test/_test_call_argument_format.pony
@@ -1,0 +1,385 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestCallArgFmtSingleLine is UnitTest
+  """Single-line call with multiple args produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: single-line clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1), U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtAllOnNextLine is UnitTest
+  """All args on one continuation line produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: all on next line clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(\n" +
+      "      U32(1), U32(2), U32(3))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtEachOnOwnLine is UnitTest
+  """Each arg on its own line produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: each on own line clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(\n" +
+      "      U32(1),\n" +
+      "      U32(2),\n" +
+      "      U32(3))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtWhereClauseOwnLine is UnitTest
+  """Where clause on own line with positional args produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: where on own line clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun bar(x: U32, y: U32 = 0) => None\n" +
+      "\n" +
+      "  fun apply(): None =>\n" +
+      "    bar(\n" +
+      "      U32(1)\n" +
+      "      where y = U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtSingleArgMultiline is UnitTest
+  """Single arg on next line (multiline due to arg complexity) is skipped."""
+  fun name(): String => "CallArgumentFormat: single arg multiline skipped"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(\n" +
+      "      U32(1))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtNoArgs is UnitTest
+  """Call with no args produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: no args clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz()\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtPartialSplit is UnitTest
+  """First arg on '(' line, rest on continuation — flagged."""
+  fun name(): String => "CallArgumentFormat: partial split flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1),\n" +
+      "      U32(2), U32(3))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_true(
+            diags.size() >= 1,
+            "expected at least 1 diagnostic for partial split")
+          try
+            let has_start_msg =
+              diags(0)?.message.contains("start on the line after")
+            h.assert_true(
+              has_start_msg,
+              "message should mention starting after '('")
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtMixedLayout is UnitTest
+  """Some args sharing a line, others alone — flagged."""
+  fun name(): String => "CallArgumentFormat: mixed layout flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(\n" +
+      "      U32(1), U32(2),\n" +
+      "      U32(3))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](
+            1,
+            diags.size(),
+            "expected 1 diagnostic for mixed layout")
+          try
+            h.assert_true(
+              diags(0)?.message.contains(
+                "all be on one line or each on its own"),
+              "message should mention layout requirement")
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtBothViolations is UnitTest
+  """Arg on '(' line and mixed continuation layout — two diagnostics."""
+  fun name(): String => "CallArgumentFormat: both violations"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    let x = Bar\n" +
+      "    x.baz(U32(1),\n" +
+      "      U32(2),\n" +
+      "      U32(3), U32(4))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](
+            2,
+            diags.size(),
+            "expected 2 diagnostics for both violations")
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtFFIClean is UnitTest
+  """FFI call with each arg on own line produces no diagnostics."""
+  fun name(): String => "CallArgumentFormat: FFI clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use @pony_os_errno[I32]()\n" +
+      "\n" +
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    @pony_os_errno(\n" +
+      "      U32(1),\n" +
+      "      U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestCallArgFmtFFIPartialSplit is UnitTest
+  """FFI call with partial split — flagged."""
+  fun name(): String => "CallArgumentFormat: FFI partial split flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use @pony_os_errno[I32]()\n" +
+      "\n" +
+      "class Foo\n" +
+      "  fun apply(): None =>\n" +
+      "    @pony_os_errno(U32(1),\n" +
+      "      U32(2))\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.CallArgumentFormat)
+          h.assert_true(
+            diags.size() >= 1,
+            "expected at least 1 diagnostic for FFI partial split")
+          try
+            h.assert_true(
+              diags(0)?.message.contains("start on the line after"),
+              "message should mention starting after '('")
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end

--- a/tools/pony-lint/test/_test_control_structure_alignment.pony
+++ b/tools/pony-lint/test/_test_control_structure_alignment.pony
@@ -328,7 +328,9 @@ class \nodoc\ _TestCtrlAlignElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned else")
           try
             h.assert_eq[String](
@@ -373,7 +375,9 @@ class \nodoc\ _TestCtrlAlignElseifMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned elseif")
           try
             h.assert_true(
@@ -413,7 +417,9 @@ class \nodoc\ _TestCtrlAlignEndMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned end")
           try
             h.assert_true(
@@ -453,7 +459,9 @@ class \nodoc\ _TestCtrlAlignForEndMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned for end")
           try
             h.assert_true(
@@ -498,7 +506,9 @@ class \nodoc\ _TestCtrlAlignTryElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned try else")
           try
             h.assert_true(
@@ -541,7 +551,9 @@ class \nodoc\ _TestCtrlAlignRepeatUntilMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned until")
           try
             h.assert_true(
@@ -582,7 +594,9 @@ class \nodoc\ _TestCtrlAlignWithEndMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned with end")
           try
             h.assert_true(
@@ -627,7 +641,9 @@ class \nodoc\ _TestCtrlAlignIfdefElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned ifdef else")
           try
             h.assert_true(
@@ -672,7 +688,9 @@ class \nodoc\ _TestCtrlAlignMultipleMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](2, diags.size(),
+          h.assert_eq[USize](
+            2,
+            diags.size(),
             "expected 2 diagnostics for else + end misaligned")
         else
           h.fail("no module")
@@ -707,7 +725,9 @@ class \nodoc\ _TestCtrlAlignWhileElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned while else")
           try
             h.assert_true(
@@ -752,7 +772,9 @@ class \nodoc\ _TestCtrlAlignForElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned for else")
           try
             h.assert_true(
@@ -798,7 +820,9 @@ class \nodoc\ _TestCtrlAlignRepeatElseMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned repeat else")
           try
             h.assert_true(
@@ -842,7 +866,9 @@ class \nodoc\ _TestCtrlAlignTryThenMisaligned is UnitTest
           let diags =
             _CollectRuleDiags(
               mod, sf, lint.ControlStructureAlignment)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for misaligned try then")
           try
             h.assert_true(

--- a/tools/pony-lint/test/_test_diagnostic.pony
+++ b/tools/pony-lint/test/_test_diagnostic.pony
@@ -6,8 +6,12 @@ class \nodoc\ _TestDiagnosticString is UnitTest
 
   fun apply(h: TestHelper) =>
     let d =
-      lint.Diagnostic("style/line-length",
-        "line exceeds 80 columns (95)", "src/main.pony", 10, 81)
+      lint.Diagnostic(
+        "style/line-length",
+        "line exceeds 80 columns (95)",
+        "src/main.pony",
+        10,
+        81)
     let expected: String val =
       "src/main.pony:10:81: error[style/line-length]: "
         + "line exceeds 80 columns (95)"
@@ -18,8 +22,12 @@ class \nodoc\ _TestDiagnosticStringSpecialChars is UnitTest
 
   fun apply(h: TestHelper) =>
     let d =
-      lint.Diagnostic("style/hard-tabs", "use spaces",
-        "path with spaces/file.pony", 1, 1)
+      lint.Diagnostic(
+        "style/hard-tabs",
+        "use spaces",
+        "path with spaces/file.pony",
+        1,
+        1)
     h.assert_eq[String](
       "path with spaces/file.pony:1:1: error[style/hard-tabs]: use spaces",
       d.string())

--- a/tools/pony-lint/test/_test_ignore.pony
+++ b/tools/pony-lint/test/_test_ignore.pony
@@ -165,8 +165,10 @@ class \nodoc\ _TestIgnoreMatcherGitignore is UnitTest
       git_dir.mkdir()
       // Create .gitignore
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("build/")
       gitignore.print("*.o")
       gitignore.dispose()
@@ -175,20 +177,25 @@ class \nodoc\ _TestIgnoreMatcherGitignore is UnitTest
       matcher.load_directory(tmp.path)
 
       // Directory "build" should be ignored (dir_only pattern)
-      h.assert_true(matcher.is_ignored(
-        Path.join(tmp.path, "build"), "build", true))
+      h.assert_true(
+        matcher.is_ignored(
+          Path.join(tmp.path, "build"), "build", true))
       // File "build" should NOT be ignored (dir_only pattern)
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "build"), "build", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "build"), "build", false))
       // .o file should be ignored
-      h.assert_true(matcher.is_ignored(
-        Path.join(tmp.path, "foo.o"), "foo.o", false))
+      h.assert_true(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.o"), "foo.o", false))
       // .pony file should not be ignored
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "foo.pony"), "foo.pony", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.pony"), "foo.pony", false))
 
       // Cleanup
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
@@ -207,8 +214,10 @@ class \nodoc\ _TestIgnoreMatcherIgnoreFile is UnitTest
       // No .git dir — not a git repo
       // Create .ignore
       let ignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".ignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".ignore")))
       ignore.print("build/")
       ignore.dispose()
 
@@ -217,13 +226,16 @@ class \nodoc\ _TestIgnoreMatcherIgnoreFile is UnitTest
       matcher.load_directory(tmp.path)
 
       // Directory "build" should be ignored via .ignore
-      h.assert_true(matcher.is_ignored(
-        Path.join(tmp.path, "build"), "build", true))
+      h.assert_true(
+        matcher.is_ignored(
+          Path.join(tmp.path, "build"), "build", true))
       // File should not be ignored
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "foo.pony"), "foo.pony", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.pony"), "foo.pony", false))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".ignore")).remove()
       tmp.remove()
     else
@@ -243,14 +255,18 @@ class \nodoc\ _TestIgnoreMatcherIgnoreOverridesGitignore is UnitTest
       git_dir.mkdir()
       // .gitignore ignores build/
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("build/")
       gitignore.dispose()
       // .ignore negates build/
       let ignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".ignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".ignore")))
       ignore.print("!build/")
       ignore.dispose()
 
@@ -258,12 +274,15 @@ class \nodoc\ _TestIgnoreMatcherIgnoreOverridesGitignore is UnitTest
       matcher.load_directory(tmp.path)
 
       // build/ should NOT be ignored because .ignore negates it
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "build"), "build", true))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "build"), "build", true))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".ignore")).remove()
       git_dir.remove()
       tmp.remove()
@@ -284,8 +303,10 @@ class \nodoc\ _TestIgnoreMatcherNegation is UnitTest
       git_dir.mkdir()
       // .gitignore: ignore all .o, but keep important.o
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.print("!important.o")
       gitignore.dispose()
@@ -294,13 +315,16 @@ class \nodoc\ _TestIgnoreMatcherNegation is UnitTest
       matcher.load_directory(tmp.path)
 
       // Regular .o file should be ignored
-      h.assert_true(matcher.is_ignored(
-        Path.join(tmp.path, "foo.o"), "foo.o", false))
+      h.assert_true(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.o"), "foo.o", false))
       // important.o should NOT be ignored (negated)
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "important.o"), "important.o", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "important.o"), "important.o", false))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
@@ -319,8 +343,10 @@ class \nodoc\ _TestIgnoreMatcherNonGitIgnoresGitignore is UnitTest
       // No .git dir
       // Create .gitignore (should be ignored since not in git repo)
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.dispose()
 
@@ -329,10 +355,12 @@ class \nodoc\ _TestIgnoreMatcherNonGitIgnoresGitignore is UnitTest
       matcher.load_directory(tmp.path)
 
       // .o file should NOT be ignored (no git repo, .gitignore not loaded)
-      h.assert_false(matcher.is_ignored(
-        Path.join(tmp.path, "foo.o"), "foo.o", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.o"), "foo.o", false))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
       tmp.remove()
     else
@@ -352,8 +380,10 @@ class \nodoc\ _TestIgnoreMatcherHierarchical is UnitTest
       git_dir.mkdir()
       // Root .gitignore ignores all .o files
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("*.o")
       gitignore.dispose()
       // Subdirectory .gitignore un-ignores .o files
@@ -361,8 +391,10 @@ class \nodoc\ _TestIgnoreMatcherHierarchical is UnitTest
         FilePath(FileAuth(auth), Path.join(tmp.path, "src"))
       sub_dir.mkdir()
       let sub_gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(sub_dir.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(sub_dir.path, ".gitignore")))
       sub_gitignore.print("!*.o")
       sub_gitignore.dispose()
 
@@ -371,16 +403,20 @@ class \nodoc\ _TestIgnoreMatcherHierarchical is UnitTest
       matcher.load_directory(sub_dir.path)
 
       // .o file at root should be ignored
-      h.assert_true(matcher.is_ignored(
-        Path.join(tmp.path, "foo.o"), "foo.o", false))
+      h.assert_true(
+        matcher.is_ignored(
+          Path.join(tmp.path, "foo.o"), "foo.o", false))
       // .o file in src/ should NOT be ignored (subdirectory negation)
-      h.assert_false(matcher.is_ignored(
-        Path.join(sub_dir.path, "foo.o"), "foo.o", false))
+      h.assert_false(
+        matcher.is_ignored(
+          Path.join(sub_dir.path, "foo.o"), "foo.o", false))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(sub_dir.path, ".gitignore")).remove()
       sub_dir.remove()
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
       git_dir.remove()
       tmp.remove()
@@ -401,8 +437,10 @@ class \nodoc\ _TestIgnoreMatcherAnchoredPattern is UnitTest
       git_dir.mkdir()
       // Anchored pattern: src/build (contains /)
       let gitignore =
-        File(FilePath(FileAuth(auth),
-          Path.join(tmp.path, ".gitignore")))
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".gitignore")))
       gitignore.print("src/build/")
       gitignore.dispose()
       // Create directory structure
@@ -420,7 +458,8 @@ class \nodoc\ _TestIgnoreMatcherAnchoredPattern is UnitTest
       let other_build = Path.join(Path.join(tmp.path, "other"), "build")
       h.assert_false(matcher.is_ignored(other_build, "build", true))
 
-      FilePath(FileAuth(auth),
+      FilePath(
+        FileAuth(auth),
         Path.join(tmp.path, ".gitignore")).remove()
       src_dir.remove()
       git_dir.remove()

--- a/tools/pony-lint/test/_test_method_declaration_format.pony
+++ b/tools/pony-lint/test/_test_method_declaration_format.pony
@@ -184,7 +184,9 @@ class \nodoc\ _TestMethodDeclFormatParamsSharingLine is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.MethodDeclarationFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for params sharing a line")
           try
             h.assert_true(
@@ -226,7 +228,9 @@ class \nodoc\ _TestMethodDeclFormatColonMisaligned is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.MethodDeclarationFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for ':' misalignment")
           try
             h.assert_true(
@@ -267,7 +271,9 @@ class \nodoc\ _TestMethodDeclFormatArrowMisaligned is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.MethodDeclarationFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for '=>' misalignment")
           try
             h.assert_true(
@@ -309,7 +315,9 @@ class \nodoc\ _TestMethodDeclFormatMultipleViolations is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.MethodDeclarationFormat)
-          h.assert_eq[USize](2, diags.size(),
+          h.assert_eq[USize](
+            2,
+            diags.size(),
             "expected 2 diagnostics for ':' and '=>' misalignment")
         else
           h.fail("no module")

--- a/tools/pony-lint/test/_test_naming.pony
+++ b/tools/pony-lint/test/_test_naming.pony
@@ -76,16 +76,20 @@ class \nodoc\ _TestHasLoweredAcronym is UnitTest
 
   fun apply(h: TestHelper) =>
     // Lowered form should be detected
-    h.assert_eq[String]("JSON",
+    h.assert_eq[String](
+      "JSON",
       try lint.NamingHelpers.has_lowered_acronym("JsonDoc") as String
       else "" end)
-    h.assert_eq[String]("HTTP",
+    h.assert_eq[String](
+      "HTTP",
       try lint.NamingHelpers.has_lowered_acronym("HttpClient") as String
       else "" end)
-    h.assert_eq[String]("URL",
+    h.assert_eq[String](
+      "URL",
       try lint.NamingHelpers.has_lowered_acronym("UrlParser") as String
       else "" end)
-    h.assert_eq[String]("TCP",
+    h.assert_eq[String](
+      "TCP",
       try lint.NamingHelpers.has_lowered_acronym("TcpConnection") as String
       else "" end)
     // Properly uppercased should NOT be detected
@@ -102,25 +106,35 @@ class \nodoc\ _TestToSnakeCase is UnitTest
   fun name(): String => "NamingHelpers: to_snake_case"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("ssl_context",
+    h.assert_eq[String](
+      "ssl_context",
       lint.NamingHelpers.to_snake_case("SSLContext"))
-    h.assert_eq[String]("url_encode",
+    h.assert_eq[String](
+      "url_encode",
       lint.NamingHelpers.to_snake_case("URLEncode"))
-    h.assert_eq[String]("contents_log",
+    h.assert_eq[String](
+      "contents_log",
       lint.NamingHelpers.to_snake_case("ContentsLog"))
-    h.assert_eq[String]("_client_connection",
+    h.assert_eq[String](
+      "_client_connection",
       lint.NamingHelpers.to_snake_case("_ClientConnection"))
-    h.assert_eq[String]("foo",
+    h.assert_eq[String](
+      "foo",
       lint.NamingHelpers.to_snake_case("Foo"))
-    h.assert_eq[String]("foo_bar",
+    h.assert_eq[String](
+      "foo_bar",
       lint.NamingHelpers.to_snake_case("FooBar"))
-    h.assert_eq[String]("http_client",
+    h.assert_eq[String](
+      "http_client",
       lint.NamingHelpers.to_snake_case("HTTPClient"))
-    h.assert_eq[String]("json_parser",
+    h.assert_eq[String](
+      "json_parser",
       lint.NamingHelpers.to_snake_case("JSONParser"))
-    h.assert_eq[String]("a",
+    h.assert_eq[String](
+      "a",
       lint.NamingHelpers.to_snake_case("A"))
-    h.assert_eq[String]("_a",
+    h.assert_eq[String](
+      "_a",
       lint.NamingHelpers.to_snake_case("_A"))
 
 // --- Property tests ---

--- a/tools/pony-lint/test/_test_prefer_chaining.pony
+++ b/tools/pony-lint/test/_test_prefer_chaining.pony
@@ -24,7 +24,8 @@ class \nodoc\ _TestPreferChainingViolation is UnitTest
           let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
           h.assert_eq[USize](1, diags.size())
           try
-            h.assert_eq[String]("style/prefer-chaining",
+            h.assert_eq[String](
+              "style/prefer-chaining",
               diags(0)?.rule_id)
             h.assert_true(diags(0)?.message.contains("x"))
           else
@@ -62,7 +63,8 @@ class \nodoc\ _TestPreferChainingVarViolation is UnitTest
           let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
           h.assert_eq[USize](1, diags.size())
           try
-            h.assert_eq[String]("style/prefer-chaining",
+            h.assert_eq[String](
+              "style/prefer-chaining",
               diags(0)?.rule_id)
             h.assert_true(diags(0)?.message.contains("x"))
           else
@@ -130,7 +132,8 @@ class \nodoc\ _TestPreferChainingSingleCallTrailingRef is UnitTest
           let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
           h.assert_eq[USize](1, diags.size())
           try
-            h.assert_eq[String]("style/prefer-chaining",
+            h.assert_eq[String](
+              "style/prefer-chaining",
               diags(0)?.rule_id)
             h.assert_true(diags(0)?.message.contains("x"))
           else
@@ -201,7 +204,8 @@ class \nodoc\ _TestPreferChainingNoTrailingRef is UnitTest
           let diags = _CollectRuleDiags(mod, sf, lint.PreferChaining)
           h.assert_eq[USize](1, diags.size())
           try
-            h.assert_eq[String]("style/prefer-chaining",
+            h.assert_eq[String](
+              "style/prefer-chaining",
               diags(0)?.rule_id)
             h.assert_true(diags(0)?.message.contains("x"))
           else

--- a/tools/pony-lint/test/_test_source_file.pony
+++ b/tools/pony-lint/test/_test_source_file.pony
@@ -33,7 +33,8 @@ class \nodoc\ _TestSourceFileNoCR is UnitTest
       {(content: String, ph: PropertyHelper) =>
         let sf = lint.SourceFile("/tmp/test.pony", content, "/tmp")
         for line in sf.lines.values() do
-          ph.assert_false(line.contains("\r"),
+          ph.assert_false(
+            line.contains("\r"),
             "line should not contain \\r: " + line)
         end
       })?
@@ -88,8 +89,10 @@ class \nodoc\ _TestSourceFileCRLF is UnitTest
 
   fun apply(h: TestHelper) =>
     let sf =
-      lint.SourceFile("/tmp/test.pony",
-        "line1\r\nline2\r\nline3", "/tmp")
+      lint.SourceFile(
+        "/tmp/test.pony",
+        "line1\r\nline2\r\nline3",
+        "/tmp")
     h.assert_eq[USize](3, sf.lines.size())
     try
       h.assert_eq[String]("line1", sf.lines(0)?)

--- a/tools/pony-lint/test/_test_suppression.pony
+++ b/tools/pony-lint/test/_test_suppression.pony
@@ -192,7 +192,8 @@ class \nodoc\ _TestSuppressionEmptyDirective is UnitTest
     let sup = lint.Suppressions(sf)
     h.assert_eq[USize](1, sup.errors().size())
     try
-      h.assert_eq[String]("lint/malformed-suppression",
+      h.assert_eq[String](
+        "lint/malformed-suppression",
         sup.errors()(0)?.rule_id)
     else
       h.fail("could not access error")

--- a/tools/pony-lint/test/_test_type_alias_format.pony
+++ b/tools/pony-lint/test/_test_type_alias_format.pony
@@ -195,7 +195,9 @@ class \nodoc\ _TestTypeAliasFormatHangingIndent is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeAliasFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for hanging indent")
           try
             h.assert_true(
@@ -233,7 +235,9 @@ class \nodoc\ _TestTypeAliasFormatNoSpaceAfterOpen is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeAliasFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for missing space after '('")
           try
             h.assert_true(
@@ -271,7 +275,9 @@ class \nodoc\ _TestTypeAliasFormatNoSpaceAfterPipe is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeAliasFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for missing space after '|'")
           try
             h.assert_true(
@@ -309,7 +315,9 @@ class \nodoc\ _TestTypeAliasFormatNoSpaceBeforeClose is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeAliasFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for missing space before ')'")
           try
             h.assert_true(

--- a/tools/pony-lint/test/_test_type_parameter_format.pony
+++ b/tools/pony-lint/test/_test_type_parameter_format.pony
@@ -138,7 +138,9 @@ class \nodoc\ _TestTypeParamFormatBracketWrongLine is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeParameterFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for '[' on wrong line")
           try
             h.assert_true(
@@ -176,7 +178,9 @@ class \nodoc\ _TestTypeParamFormatSharingLine is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeParameterFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for type params sharing a line")
           try
             h.assert_true(
@@ -216,7 +220,9 @@ class \nodoc\ _TestTypeParamFormatIsMisaligned is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeParameterFormat)
-          h.assert_eq[USize](1, diags.size(),
+          h.assert_eq[USize](
+            1,
+            diags.size(),
             "expected 1 diagnostic for 'is' misalignment")
           try
             h.assert_true(
@@ -256,7 +262,9 @@ class \nodoc\ _TestTypeParamFormatMultipleViolations is UnitTest
         | let mod: ast.Module val =>
           let diags =
             _CollectRuleDiags(mod, sf, lint.TypeParameterFormat)
-          h.assert_eq[USize](2, diags.size(),
+          h.assert_eq[USize](
+            2,
+            diags.size(),
             "expected 2 diagnostics for sharing + misaligned 'is'")
         else
           h.fail("no module")

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -406,3 +406,16 @@ actor \nodoc\ Main is TestList
     test(_TestTypeParamFormatSharingLine)
     test(_TestTypeParamFormatIsMisaligned)
     test(_TestTypeParamFormatMultipleViolations)
+
+    // CallArgumentFormat tests
+    test(_TestCallArgFmtSingleLine)
+    test(_TestCallArgFmtAllOnNextLine)
+    test(_TestCallArgFmtEachOnOwnLine)
+    test(_TestCallArgFmtWhereClauseOwnLine)
+    test(_TestCallArgFmtSingleArgMultiline)
+    test(_TestCallArgFmtNoArgs)
+    test(_TestCallArgFmtPartialSplit)
+    test(_TestCallArgFmtMixedLayout)
+    test(_TestCallArgFmtBothViolations)
+    test(_TestCallArgFmtFFIClean)
+    test(_TestCallArgFmtFFIPartialSplit)

--- a/tools/pony-lint/trailing_whitespace.pony
+++ b/tools/pony-lint/trailing_whitespace.pony
@@ -28,8 +28,12 @@ primitive TrailingWhitespace is TextRule
         // If last_non_ws < size-1, there's trailing whitespace
         if last_non_ws < (line.size() - 1).isize() then
           let col = (last_non_ws + 2).usize()
-          result.push(Diagnostic(id(), "trailing whitespace",
-            source.rel_path, idx + 1, col))
+          result.push(Diagnostic(
+            id(),
+            "trailing whitespace",
+            source.rel_path,
+            idx + 1,
+            col))
         end
       end
       result

--- a/tools/pony-lint/type_alias_format.pony
+++ b/tools/pony-lint/type_alias_format.pony
@@ -93,9 +93,12 @@ primitive TypeAliasFormat is ASTRule
     try
       let open_text = source.lines(open_line - 1)?
       if not _is_first_nonws(open_text, open_col) then
-        diags.push(Diagnostic(id(),
+        diags.push(Diagnostic(
+          id(),
           "opening '(' of multiline type must not be on the 'type ... is' line",
-          source.rel_path, open_line, open_col))
+          source.rel_path,
+          open_line,
+          open_col))
         return consume diags
       end
     end
@@ -106,9 +109,12 @@ primitive TypeAliasFormat is ASTRule
       let after_idx = open_col.usize() // 0-based index after `(`
       if after_idx < open_text.size() then
         if open_text(after_idx)? != ' ' then
-          diags.push(Diagnostic(id(),
+          diags.push(Diagnostic(
+            id(),
             "space required after '(' in multiline type",
-            source.rel_path, open_line, open_col))
+            source.rel_path,
+            open_line,
+            open_col))
         end
       end
     end
@@ -129,9 +135,12 @@ primitive TypeAliasFormat is ASTRule
           let after_sep = first_col + 1
           if after_sep < line_text.size() then
             if line_text(after_sep)? != ' ' then
-              diags.push(Diagnostic(id(),
+              diags.push(Diagnostic(
+                id(),
                 "space required after '" + sep_str + "' in multiline type",
-                source.rel_path, line_idx + 1, (first_col + 1).usize()))
+                source.rel_path,
+                line_idx + 1,
+                (first_col + 1).usize()))
             end
           end
         end
@@ -145,9 +154,12 @@ primitive TypeAliasFormat is ASTRule
       if close_col > 1 then
         let before_idx = (close_col - 2).usize()
         if close_text(before_idx)? != ' ' then
-          diags.push(Diagnostic(id(),
+          diags.push(Diagnostic(
+            id(),
             "space required before ')' in multiline type",
-            source.rel_path, close_line, close_col))
+            source.rel_path,
+            close_line,
+            close_col))
         end
       end
     end

--- a/tools/pony-lint/type_naming.pony
+++ b/tools/pony-lint/type_naming.pony
@@ -31,9 +31,12 @@ primitive TypeNaming is ASTRule
       | let name: String val =>
         if not NamingHelpers.is_camel_case(name) then
           return recover val
-            [ Diagnostic(id(),
+            [ Diagnostic(
+              id(),
               "type name '" + name + "' should be CamelCase",
-              source.rel_path, name_node.line(), name_node.pos())]
+              source.rel_path,
+              name_node.line(),
+              name_node.pos())]
           end
         end
       end

--- a/tools/pony-lint/type_parameter_format.pony
+++ b/tools/pony-lint/type_parameter_format.pony
@@ -72,9 +72,12 @@ primitive TypeParameterFormat is ASTRule
     let tp_line = _typeparams_line(typeparams)
     let name_line = name_node.line()
     if (tp_line > 0) and (tp_line != name_line) then
-      diags.push(Diagnostic(id(),
+      diags.push(Diagnostic(
+        id(),
         "'[' should be on the same line as the name",
-        source.rel_path, tp_line, typeparams.pos()))
+        source.rel_path,
+        tp_line,
+        typeparams.pos()))
       // Further checks are meaningless if '[' is misplaced
       return consume diags
     end
@@ -94,10 +97,13 @@ primitive TypeParameterFormat is ASTRule
             let tp_node = typeparams(i)?
             let tp_l = _typeparam_line(tp_node)
             if tp_l == prev_line then
-              diags.push(Diagnostic(id(),
+              diags.push(Diagnostic(
+                id(),
                 "each type parameter should be on its own line"
                   + " in a multiline declaration",
-                source.rel_path, tp_l, tp_node.pos()))
+                source.rel_path,
+                tp_l,
+                tp_node.pos()))
             end
             prev_line = tp_l
             i = i + 1
@@ -132,12 +138,15 @@ primitive TypeParameterFormat is ASTRule
               if word == "is" then
                 let expected_col = keyword_col + 2
                 if word_col != expected_col then
-                  diags.push(Diagnostic(id(),
+                  diags.push(Diagnostic(
+                    id(),
                     "'is' should align at column "
                       + expected_col.string()
                       + " (indented from '"
                       + _keyword_name(token_id) + "')",
-                    source.rel_path, prov_line, word_col))
+                    source.rel_path,
+                    prov_line,
+                    word_col))
                 end
               end
             end
@@ -242,5 +251,6 @@ primitive TypeParameterFormat is ASTRule
       i = i + 1
     end
 
-    (recover val line.substring(ISize.from[USize](start),
+    (recover val line.substring(
+      ISize.from[USize](start),
       ISize.from[USize](i)) end, col)


### PR DESCRIPTION
Phase 3, PR 6 from the pony-lint design (Discussion #4844).

Implements the call argument formatting rule from the style guide (STYLE_GUIDE.md lines 436-464). For multiline calls with 2+ positional arguments, the rule checks:

1. No arguments start on the `(` line — they should begin on the next line
2. Arguments are either all on one continuation line, or each on its own line

Handles both regular calls (TK_CALL) and FFI calls (TK_FFICALL). Named/where arguments are not subject to layout checks per the style guide. Single-line calls, single-argument calls, and named-argument-only calls are skipped.

Also reformats all existing pony-lint multiline call patterns (primarily `Diagnostic(...)` calls) to comply with the new rule — verified via `make lint-pony-lint`.