### PR TITLE
Add safety/exhaustive-match lint rule to pony-lint

### DIFF
--- a/.release-notes/add-exhaustive-match-lint-rule.md
+++ b/.release-notes/add-exhaustive-match-lint-rule.md
@@ -1,0 +1,7 @@
+## Add safety/exhaustive-match lint rule to pony-lint
+
+pony-lint now flags exhaustive `match` expressions that don't use the `\exhaustive\` annotation. Without `\exhaustive\`, adding a new variant to a union type compiles silently — the compiler injects `else None` for missing cases instead of raising an error. The new `safety/exhaustive-match` rule catches these matches so you can add the annotation and get compile-time protection against incomplete case handling.
+
+The rule is enabled by default. To suppress it for a specific match, use `// pony-lint: allow safety/exhaustive-match` on the line before the match, or disable the entire `safety` category with `--disable safety` or in your config file.
+
+This is the first rule in the new `safety` category. It also introduces `CompileSession` to the `pony_compiler` library, enabling resumable compilation (compile to `PassParse`, inspect the AST, then continue to `PassExpr`).

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ test-pony-lint: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/json-ng/ --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-tests ../../tools/pony-lint/test && echo Built `pwd`/pony-lint-tests && PONYPATH=../../packages:$(PONYPATH) ./pony-lint-tests --sequential
 
 lint-pony-lint: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/json-ng/ --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci && ./pony-lint-ci ../../tools/pony-lint/
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/json-ng/ --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../tools/lib/ponylang/json-ng:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lint/
 
 test-cross-stress-release: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-release: debuggercmd=

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/compile_session.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/compile_session.pony
@@ -1,0 +1,109 @@
+use "files"
+
+class CompileSession
+  """
+  Resumable compilation session that owns the `_PassOpt` lifecycle.
+
+  Unlike `Compiler.compile()`, which creates a pass_opt, calls `program_load`,
+  and immediately tears down the pass_opt, `CompileSession` preserves the
+  compilation state so it can be resumed to a higher pass level via
+  `continue_to()`. This enables workflows like: compile to `PassParse` to
+  inspect the AST, then continue to `PassExpr` to get type information.
+
+  Ownership: `CompileSession` owns the `_PassOpt`. `Program` owns the AST
+  (freed in `Program._final()`). The session holds a reference to the
+  `Program val` to prevent it from being GC'd while the session exists.
+
+  Callers must call `dispose()` when done to release the pass_opt resources.
+  Pony's `_final()` runs with a `box` receiver, which prevents passing the
+  `_PassOpt` struct to cleanup FFI functions that require `ref`.
+  """
+  let _pass_opt: _PassOpt
+  var _program: (Program val | None)
+  let _raw: Pointer[_AST] val
+  var _disposed: Bool
+
+  new create(
+    path: FilePath,
+    package_search_paths: (String box | ReadSeq[String val] box) = [],
+    user_flags: ReadSeq[String val] box = [],
+    release: Bool = false,
+    limit: PassId = PassAll,
+    verbosity: VerbosityLevel = VerbosityQuiet)
+  =>
+    """
+    Compile the source at `path` up to `limit`, retaining the pass_opt for
+    later resumption. Arguments mirror `Compiler.compile()`.
+    """
+    _disposed = false
+    _pass_opt = _PassOpt.create()
+    @pass_opt_init(_pass_opt)
+    _pass_opt.verbosity = verbosity()
+    _pass_opt.limit = limit()
+    _pass_opt.release = release
+    for user_flag in user_flags.values() do
+      @define_userflag(_pass_opt.userflags, user_flag.cstring())
+    end
+
+    @codegen_pass_init(_pass_opt)
+    match package_search_paths
+    | let single: String box =>
+      @package_add_paths(single.cstring(), _pass_opt)
+    | let multiple: ReadSeq[String val] box =>
+      for search_path in multiple.values() do
+        @package_add_paths(search_path.cstring(), _pass_opt)
+      end
+    end
+
+    _raw = @program_load(path.path.cstring(), _pass_opt)
+    _program =
+      if _raw.is_null() then
+        None
+      else
+        Program.create(AST(_raw))
+      end
+
+  fun program(): (Program val | None) =>
+    """
+    Returns the compiled program, or `None` if compilation failed.
+    """
+    _program
+
+  fun ref errors(): Array[Error] val =>
+    """
+    Returns compilation errors from the pass_opt's typecheck state.
+
+    Useful when `program()` returns `None` or `continue_to()` fails.
+    """
+    try
+      let errs = _pass_opt.check.errors()?
+      errs.extract()
+    else
+      recover val
+        [Error.message(
+          "Compilation failed but libponyc produced no error messages.")]
+      end
+    end
+
+  fun ref continue_to(limit: PassId): Bool =>
+    """
+    Resume compilation from the current pass level to `limit`.
+
+    Returns `true` on success, `false` on failure. On failure, call
+    `errors()` to retrieve error details.
+    """
+    if _raw.is_null() then return false end
+    _pass_opt.limit = limit()
+    @ast_passes_program(_raw, _pass_opt)
+
+  fun ref dispose() =>
+    """
+    Release pass_opt resources. Must be called when the session is no longer
+    needed. Safe to call multiple times.
+    """
+    if not _disposed then
+      _disposed = true
+      @package_done(_pass_opt)
+      @codegen_pass_cleanup(_pass_opt)
+      @pass_opt_done(_pass_opt)
+    end

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
@@ -1,6 +1,6 @@
 use @pass_opt_init[None](options: _PassOpt)
 use @pass_opt_done[None](options: _PassOpt)
-use @ast_passes_program[Bool](program: Pointer[_AST], options: _PassOpt)
+use @ast_passes_program[Bool](program: Pointer[_AST] val, options: _PassOpt)
 
 type PassId is (
   PassParse      | PassSyntax         | PassSugar        | PassScope  |

--- a/tools/pony-lint/ast_rule.pony
+++ b/tools/pony-lint/ast_rule.pony
@@ -2,12 +2,15 @@ use ast = "pony_compiler"
 
 trait val ASTRule
   """
-  An AST-based lint rule that checks parsed syntax tree nodes.
+  An AST-based lint rule that checks syntax tree nodes.
 
   Unlike `TextRule` which examines raw source text, AST rules operate on the
-  parsed syntax tree produced by pony_compiler. Each rule declares which token
-  types it is interested in via `node_filter()`, and the dispatcher only calls
-  `check()` for matching nodes.
+  syntax tree produced by pony_compiler. Each rule declares which token types
+  it is interested in via `node_filter()`, and the dispatcher only calls
+  `check()` for matching nodes. Rules also declare their `required_pass()`
+  — the minimum compilation pass needed for the AST to have the information
+  the rule depends on (e.g., `PassParse` for syntax-only rules, `PassExpr`
+  for rules that need type information).
 
   Rules are stateless primitives. Each receives a single AST node and the
   corresponding `SourceFile`, returning diagnostics without side effects.
@@ -37,6 +40,15 @@ trait val ASTRule
     Token types this rule wants to inspect. The dispatcher only calls `check()`
     for nodes whose `id()` appears in this list.
     """
+
+  fun required_pass(): ast.PassId =>
+    """
+    The minimum compilation pass level needed for this rule to operate
+    correctly. Rules that only need the parsed syntax tree return
+    `PassParse` (the default). Rules that need type information return
+    a later pass such as `PassExpr`.
+    """
+    ast.PassParse
 
   fun check(node: ast.AST box, source: SourceFile val)
     : Array[Diagnostic val] val

--- a/tools/pony-lint/exhaustive_match.pony
+++ b/tools/pony-lint/exhaustive_match.pony
@@ -1,0 +1,48 @@
+use ast = "pony_compiler"
+
+primitive ExhaustiveMatch is ASTRule
+  """
+  Flags exhaustive `match` expressions that lack the `\exhaustive\` annotation.
+
+  The `\exhaustive\` annotation is a compiler assertion that demands explicit
+  handling of all cases in a match. Without it, if a new variant is later added
+  to a union type, the compiler silently injects `else None` instead of
+  flagging the missing case. This rule encourages annotating exhaustive matches
+  for that future protection.
+
+  Detection relies on the compiler's own exhaustiveness analysis: after
+  `PassExpr`, the else child (index 2) of a `TK_MATCH` node remains `TK_NONE`
+  when the compiler confirmed exhaustiveness and no injection was needed.
+  """
+  fun id(): String val => "safety/exhaustive-match"
+  fun category(): String val => "safety"
+
+  fun description(): String val =>
+    "exhaustive match should use \\exhaustive\\ annotation"
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun required_pass(): ast.PassId => ast.PassExpr
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [ast.TokenIds.tk_match()]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    if not node.has_annotation("exhaustive") then
+      try
+        let else_clause = node(2)?
+        if else_clause.id() == ast.TokenIds.tk_none() then
+          return recover val
+            [ Diagnostic(
+              id(),
+              "exhaustive match should use \\exhaustive\\ annotation",
+              source.rel_path,
+              node.line(),
+              node.pos()) ]
+          end
+        end
+      end
+    end
+    recover val Array[Diagnostic val] end

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -12,9 +12,10 @@ class val Linter
   1. **Text phase** — for each discovered .pony file, load the source, parse
      suppressions, and run enabled text rules with suppression filtering.
   2. **AST phase** — group files by directory (package), compile each package
-     at PassParse via pony_compiler, then dispatch enabled AST rules against the
-     parsed syntax tree. Module-level and package-level rules (file-naming,
-     package-naming) run after the per-node dispatch.
+     via pony_compiler using `CompileSession`. Parse-level rules run after
+     `PassParse`, then compilation continues to `PassExpr` for rules that need
+     type information (e.g., safety rules). Module-level and package-level
+     rules (file-naming, package-naming) run after the per-node dispatch.
 
   File discovery recursively finds .pony files in given targets, skipping
   _corral/, _repos/, and directories starting with a dot. When inside a git
@@ -118,7 +119,10 @@ class val Linter
     end
 
     // --- AST phase ---
-    if _registry.enabled_ast_rules().size() > 0 then
+    let parse_rules = _registry.enabled_parse_ast_rules()
+    let expr_rules = _registry.enabled_expr_ast_rules()
+
+    if (parse_rules.size() > 0) or (expr_rules.size() > 0) then
       // Group files by directory (package)
       let packages = Map[String, Array[String val]]
       for path in pony_files.values() do
@@ -137,62 +141,70 @@ class val Linter
       // Compile each package and run AST rules
       for (pkg_dir, pkg_file_paths) in packages.pairs() do
         let pkg_fp = FilePath(_file_auth, pkg_dir)
-        match ast.Compiler.compile(
-          pkg_fp where package_search_paths = _package_paths,
-          limit = ast.PassParse)
+        let session =
+          ast.CompileSession(
+            pkg_fp where package_search_paths = _package_paths,
+            limit = ast.PassParse)
+        match session.program()
         | let program: ast.Program val =>
           match program.package()
           | let pkg: ast.Package val =>
-            // Run per-module AST rules
-            for mod in pkg.modules() do
-              let mod_file = mod.file
-              try
-                let info = file_info(mod_file)?
-                let dispatcher =
-                  _ASTDispatcher(
-                    _registry.enabled_ast_rules(),
-                    info.source,
-                    info.magic_lines,
-                    info.suppressions)
-                mod.ast.visit(dispatcher)
+            // Parse-level dispatch (style rules)
+            if parse_rules.size() > 0 then
+              for mod in pkg.modules() do
+                let mod_file = mod.file
+                try
+                  let info = file_info(mod_file)?
+                  let dispatcher =
+                    _ASTDispatcher(
+                      parse_rules,
+                      info.source,
+                      info.magic_lines,
+                      info.suppressions)
+                  mod.ast.visit(dispatcher)
 
-                for d in dispatcher.diagnostics().values() do
-                  all_diags.push(d)
-                end
-
-                // File-naming check (module-level)
-                if _registry.is_enabled(
-                  FileNaming.id(),
-                  FileNaming.category(),
-                  FileNaming.default_status())
-                then
-                  let file_diags =
-                    FileNaming.check_module(
-                      dispatcher.entities(), info.source)
-                  for d in file_diags.values() do
-                    if info.magic_lines.contains(d.line) then continue end
-                    if info.suppressions.is_suppressed(d.line, d.rule_id) then
-                      continue
-                    end
+                  for d in dispatcher.diagnostics().values() do
                     all_diags.push(d)
                   end
-                end
 
-                // Blank-lines between-entity check (module-level)
-                if _registry.is_enabled(
-                  BlankLines.id(),
-                  BlankLines.category(),
-                  BlankLines.default_status())
-                then
-                  let bl_diags =
-                    BlankLines.check_module(
-                      dispatcher.entities(), info.source)
-                  for d in bl_diags.values() do
-                    if info.magic_lines.contains(d.line) then continue end
-                    if info.suppressions.is_suppressed(d.line, d.rule_id) then
-                      continue
+                  // File-naming check (module-level)
+                  if _registry.is_enabled(
+                    FileNaming.id(),
+                    FileNaming.category(),
+                    FileNaming.default_status())
+                  then
+                    let file_diags =
+                      FileNaming.check_module(
+                        dispatcher.entities(), info.source)
+                    for d in file_diags.values() do
+                      if info.magic_lines.contains(d.line) then continue end
+                      if info.suppressions.is_suppressed(
+                        d.line, d.rule_id)
+                      then
+                        continue
+                      end
+                      all_diags.push(d)
                     end
-                    all_diags.push(d)
+                  end
+
+                  // Blank-lines between-entity check (module-level)
+                  if _registry.is_enabled(
+                    BlankLines.id(),
+                    BlankLines.category(),
+                    BlankLines.default_status())
+                  then
+                    let bl_diags =
+                      BlankLines.check_module(
+                        dispatcher.entities(), info.source)
+                    for d in bl_diags.values() do
+                      if info.magic_lines.contains(d.line) then continue end
+                      if info.suppressions.is_suppressed(
+                        d.line, d.rule_id)
+                      then
+                        continue
+                      end
+                      all_diags.push(d)
+                    end
                   end
                 end
               end
@@ -223,7 +235,8 @@ class val Linter
               end
             end
 
-            // Package-docstring check (once per package)
+            // Package-docstring check (once per package, before
+            // PassExpr which can transform the docstring AST node)
             if _registry.is_enabled(
               PackageDocstring.id(),
               PackageDocstring.category(),
@@ -263,11 +276,57 @@ class val Linter
                 all_diags.push(d)
               end
             end
+
+            // Expr-level dispatch (safety rules)
+            if expr_rules.size() > 0 then
+              if session.continue_to(ast.PassExpr) then
+                for mod in pkg.modules() do
+                  let mod_file = mod.file
+                  try
+                    let info = file_info(mod_file)?
+                    let dispatcher =
+                      _ASTDispatcher(
+                        expr_rules,
+                        info.source,
+                        info.magic_lines,
+                        info.suppressions)
+                    mod.ast.visit(dispatcher)
+
+                    for d in dispatcher.diagnostics().values() do
+                      all_diags.push(d)
+                    end
+                  end
+                end
+              else
+                // PassExpr failed — report errors so safety rules aren't
+                // silently skipped
+                has_error = true
+                let rel_dir =
+                  try Path.rel(_cwd, pkg_dir)? else pkg_dir end
+                let errors = session.errors()
+                for err in errors.values() do
+                  let err_file =
+                    match err.file
+                    | let f: String val =>
+                      try Path.rel(_cwd, f)? else f end
+                    else
+                      rel_dir
+                    end
+                  all_diags.push(Diagnostic(
+                    "lint/ast-error",
+                    err.msg,
+                    err_file,
+                    err.position.line(),
+                    err.position.column()))
+                end
+              end
+            end
           end
-        | let errors: Array[ast.Error] val =>
-          // AST compilation failed — report as lint/ast-error
+        else
+          // Compilation failed — report as lint/ast-error
           has_error = true
           let rel_dir = try Path.rel(_cwd, pkg_dir)? else pkg_dir end
+          let errors = session.errors()
           for err in errors.values() do
             let err_file =
               match err.file
@@ -284,6 +343,7 @@ class val Linter
               err.position.column()))
           end
         end
+        session.dispose()
       end
     end
 

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -100,6 +100,7 @@ actor Main
         .> push(MethodDeclarationFormat)
         .> push(TypeParameterFormat)
         .> push(CallArgumentFormat)
+        .> push(ExhaustiveMatch)
     end
 
     // Handle --explain

--- a/tools/pony-lint/rule_registry.pony
+++ b/tools/pony-lint/rule_registry.pony
@@ -1,3 +1,5 @@
+use ast = "pony_compiler"
+
 class val RuleRegistry
   """
   Registry of all lint rules, filtered by configuration.
@@ -10,6 +12,8 @@ class val RuleRegistry
   let _all: Array[TextRule val] val
   let _enabled_ast: Array[ASTRule val] val
   let _all_ast: Array[ASTRule val] val
+  let _enabled_parse_ast: Array[ASTRule val] val
+  let _enabled_expr_ast: Array[ASTRule val] val
   let _config: LintConfig
 
   new val create(
@@ -46,6 +50,27 @@ class val RuleRegistry
         end
         result
       end
+    _enabled_parse_ast =
+      recover val
+        let result = Array[ASTRule val]
+        for rule in _enabled_ast.values() do
+          match rule.required_pass()
+          | ast.PassParse => result.push(rule)
+          end
+        end
+        result
+      end
+    _enabled_expr_ast =
+      recover val
+        let result = Array[ASTRule val]
+        for rule in _enabled_ast.values() do
+          match rule.required_pass()
+          | ast.PassParse => None
+          else result.push(rule)
+          end
+        end
+        result
+      end
 
   fun enabled_text_rules(): Array[TextRule val] val =>
     """
@@ -70,6 +95,18 @@ class val RuleRegistry
     Returns all registered AST rules regardless of configuration.
     """
     _all_ast
+
+  fun enabled_parse_ast_rules(): Array[ASTRule val] val =>
+    """
+    Returns enabled AST rules that operate at `PassParse`.
+    """
+    _enabled_parse_ast
+
+  fun enabled_expr_ast_rules(): Array[ASTRule val] val =>
+    """
+    Returns enabled AST rules that require a pass beyond `PassParse`.
+    """
+    _enabled_expr_ast
 
   fun is_enabled(rule_id: String, category: String, default: RuleStatus)
     : Bool

--- a/tools/pony-lint/test/_ast_test_helper.pony
+++ b/tools/pony-lint/test/_ast_test_helper.pony
@@ -5,8 +5,8 @@ use lint = ".."
 
 primitive \nodoc\ _ASTTestHelper
   """
-  Compiles a Pony source string at PassParse and returns the Program and
-  SourceFile for use in AST rule tests.
+  Compiles a Pony source string and returns the Program and SourceFile for use
+  in AST rule tests.
 
   Writes the source to a temporary directory, compiles it, and returns the
   results. The temporary directory persists (acceptable for tiny test files).
@@ -15,11 +15,17 @@ primitive \nodoc\ _ASTTestHelper
   package (e.g., the ponyc packages/ directory). Tests run from a build
   directory, not an installed location, so executable-relative discovery
   is not used here.
+
+  The optional `pass` parameter controls the compilation pass level.
+  When `PassParse` (the default), uses `Compiler.compile()` directly. For
+  later passes, uses `CompileSession` to compile to `PassParse` first, then
+  resumes to the requested level.
   """
   fun compile(
     h: TestHelper,
     source: String val,
-    filename: String val = "test.pony")
+    filename: String val = "test.pony",
+    pass: ast.PassId = ast.PassParse)
     : (ast.Program val, lint.SourceFile val) ?
   =>
     let auth = h.env.root
@@ -38,24 +44,50 @@ primitive \nodoc\ _ASTTestHelper
 
     let pony_path = _get_ponypath(h.env.vars)
 
-    match \exhaustive\ ast.Compiler.compile(
-      tmp where package_search_paths = pony_path,
-      limit = ast.PassParse)
-    | let program: ast.Program val =>
-      (program, sf)
-    | let errors: Array[ast.Error] val =>
-      let msg =
-        recover val
-          let s = String
-          s.append("AST compilation failed:")
-          for err in errors.values() do
-            s.append("\n  ")
-            s.append(err.msg)
-          end
-          s
+    match \exhaustive\ pass
+    | ast.PassParse =>
+      match \exhaustive\ ast.Compiler.compile(
+        tmp where package_search_paths = pony_path,
+        limit = ast.PassParse)
+      | let program: ast.Program val =>
+        (program, sf)
+      | let errors: Array[ast.Error] val =>
+        h.fail(_format_errors(errors))
+        error
+      end
+    else
+      let session =
+        ast.CompileSession(
+          tmp where package_search_paths = pony_path,
+          limit = ast.PassParse)
+      match session.program()
+      | let program: ast.Program val =>
+        if not session.continue_to(pass) then
+          let err_msg = _format_errors(session.errors())
+          session.dispose()
+          h.fail(err_msg)
+          error
         end
-      h.fail(msg)
-      error
+        session.dispose()
+        (program, sf)
+      else
+        let err_msg = _format_errors(session.errors())
+        session.dispose()
+        h.fail(err_msg)
+        error
+      end
+    end
+
+  fun _format_errors(errors: Array[ast.Error] val): String val =>
+    """Format compilation errors into a failure message."""
+    recover val
+      let s = String
+      s.append("AST compilation failed:")
+      for err in errors.values() do
+        s.append("\n  ")
+        s.append(err.msg)
+      end
+      s
     end
 
   fun _get_ponypath(

--- a/tools/pony-lint/test/_test_exhaustive_match.pony
+++ b/tools/pony-lint/test/_test_exhaustive_match.pony
@@ -1,0 +1,173 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestExhaustiveMatchFlagged is UnitTest
+  """Exhaustive match without \exhaustive\ annotation is flagged."""
+  fun name(): String => "ExhaustiveMatch: missing annotation flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "type Color is (Red | Green | Blue)\n" +
+      "primitive Red\n" +
+      "primitive Green\n" +
+      "primitive Blue\n" +
+      "\n" +
+      "primitive Foo\n" +
+      "  fun apply(c: Color): String =>\n" +
+      "    match c\n" +
+      "    | Red => \"red\"\n" +
+      "    | Green => \"green\"\n" +
+      "    | Blue => \"blue\"\n" +
+      "    end\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source where pass = ast.PassExpr)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.ExhaustiveMatch)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "safety/exhaustive-match", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestExhaustiveMatchAnnotated is UnitTest
+  """Exhaustive match with \exhaustive\ annotation is clean."""
+  fun name(): String => "ExhaustiveMatch: annotated match is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "type Color is (Red | Green | Blue)\n" +
+      "primitive Red\n" +
+      "primitive Green\n" +
+      "primitive Blue\n" +
+      "\n" +
+      "primitive Foo\n" +
+      "  fun apply(c: Color): String =>\n" +
+      "    match \\exhaustive\\ c\n" +
+      "    | Red => \"red\"\n" +
+      "    | Green => \"green\"\n" +
+      "    | Blue => \"blue\"\n" +
+      "    end\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source where pass = ast.PassExpr)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.ExhaustiveMatch)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestExhaustiveMatchNonExhaustive is UnitTest
+  """Non-exhaustive match without annotation is not flagged."""
+  fun name(): String => "ExhaustiveMatch: non-exhaustive match clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "type Color is (Red | Green | Blue)\n" +
+      "primitive Red\n" +
+      "primitive Green\n" +
+      "primitive Blue\n" +
+      "\n" +
+      "primitive Foo\n" +
+      "  fun apply(c: Color): (String | None) =>\n" +
+      "    match c\n" +
+      "    | Red => \"red\"\n" +
+      "    | Green => \"green\"\n" +
+      "    end\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source where pass = ast.PassExpr)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.ExhaustiveMatch)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestExhaustiveMatchExplicitElse is UnitTest
+  """Match with explicit else clause is not flagged."""
+  fun name(): String => "ExhaustiveMatch: explicit else clause clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): String =>\n" +
+      "    match x\n" +
+      "    | 1 => \"one\"\n" +
+      "    | 2 => \"two\"\n" +
+      "    else \"other\"\n" +
+      "    end\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source where pass = ast.PassExpr)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.ExhaustiveMatch)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestExhaustiveMatchMetadata is UnitTest
+  """Rule metadata is correct for suppression and registry integration."""
+  fun name(): String => "ExhaustiveMatch: metadata"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("safety/exhaustive-match", lint.ExhaustiveMatch.id())
+    h.assert_eq[String]("safety", lint.ExhaustiveMatch.category())
+    match lint.ExhaustiveMatch.required_pass()
+    | ast.PassExpr => None
+    else
+      h.fail("required_pass should be PassExpr")
+    end
+    match lint.ExhaustiveMatch.default_status()
+    | lint.RuleOn => None
+    else
+      h.fail("default_status should be RuleOn")
+    end

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -422,6 +422,13 @@ actor \nodoc\ Main is TestList
     test(_TestTypeParamFormatIsMisaligned)
     test(_TestTypeParamFormatMultipleViolations)
 
+    // ExhaustiveMatch tests
+    test(_TestExhaustiveMatchFlagged)
+    test(_TestExhaustiveMatchAnnotated)
+    test(_TestExhaustiveMatchNonExhaustive)
+    test(_TestExhaustiveMatchExplicitElse)
+    test(_TestExhaustiveMatchMetadata)
+
     // CallArgumentFormat tests
     test(_TestCallArgFmtSingleLine)
     test(_TestCallArgFmtAllOnNextLine)


### PR DESCRIPTION
Introduces `CompileSession` to the `pony_compiler` library for resumable compilation, enabling pony-lint to compile at `PassParse` for style rules then continue to `PassExpr` for safety rules that need type information.

The `safety/exhaustive-match` rule flags match expressions where the compiler confirmed exhaustiveness (else child stays `TK_NONE` after `PassExpr`) but the `\exhaustive\` annotation is missing. Without the annotation, adding a new variant to a union type compiles silently — the compiler injects `else None` for missing cases instead of raising an error.

Key changes:
- `CompileSession` class owns the `_PassOpt` lifecycle, allowing compile-to-`PassParse` then continue-to-`PassExpr` without recreating state
- `ASTRule` trait gains `required_pass()` (default `PassParse`) so rules can declare what compilation level they need
- `RuleRegistry` partitions rules by pass level for two-phase dispatch
- Linter uses `CompileSession` with parse-level and expr-level dispatch, reports `lint/ast-error` when `PassExpr` fails (not silent skip)
- Package-level checks (`PackageDocstring`) run before `PassExpr` since the expression pass transforms docstring AST nodes
- Existing exhaustive matches in pony-lint source annotated with `\exhaustive\`
- Makefile `lint-pony-lint` target sets PONYPATH for library resolution needed by `PassExpr`

Closes #4898