### PR TITLE
Return memory to the OS when freeing large pool allocations

### DIFF
--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -432,6 +432,9 @@ jobs:
             directives: pool_memalign
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
             debugger: lldb
+            directives: pool_retain
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+            debugger: lldb
             directives: runtimestats
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
             debugger: lldb

--- a/.release-notes/decommit-freed-pool-blocks.md
+++ b/.release-notes/decommit-freed-pool-blocks.md
@@ -1,0 +1,7 @@
+## Return memory to the OS when freeing large pool allocations
+
+The pool allocator now returns physical memory to the OS when freeing allocations larger than 1 MB. Previously, freed blocks were kept on the free list with their physical pages committed, meaning the RSS never decreased even after the memory was no longer needed. Now, the page-aligned interior of freed blocks is decommitted via `madvise(MADV_DONTNEED)` on POSIX or `VirtualAlloc(MEM_RESET)` on Windows. The virtual address space is preserved, so pages fault back in transparently on reuse.
+
+This primarily benefits programs that make large temporary allocations (the compiler during compilation, programs with large arrays or strings). Programs whose memory usage is dominated by small allocations (< 1 MB) will see little change — per-size-class caching is a separate mechanism.
+
+To preserve the old behavior (never decommit), build with `make configure use=pool_retain`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ if(PONY_USE_POOL_MEMALIGN)
     add_compile_options(-DUSE_POOL_MEMALIGN)
 endif()
 
+if(PONY_USE_POOL_RETAIN)
+    set(PONY_OUTPUT_SUFFIX "${PONY_OUTPUT_SUFFIX}-pool_retain")
+    add_compile_options(-DUSE_POOL_RETAIN)
+endif()
+
 if(PONY_USE_RUNTIME_TRACING)
     set(PONY_OUTPUT_SUFFIX "${PONY_OUTPUT_SUFFIX}-runtime_tracing")
     add_compile_options(-DUSE_RUNTIME_TRACING)

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,8 @@ define USE_CHECK
     PONY_USES += -DPONY_USE_RUNTIMESTATS_MESSAGES=true
   else ifeq ($1,pool_memalign)
     PONY_USES += -DPONY_USE_POOL_MEMALIGN=true
+  else ifeq ($1,pool_retain)
+    PONY_USES += -DPONY_USE_POOL_RETAIN=true
   else ifeq ($1,runtime_tracing)
     PONY_USES += -DPONY_USE_RUNTIME_TRACING=true
   else

--- a/src/libponyrt/mem/alloc.c
+++ b/src/libponyrt/mem/alloc.c
@@ -8,6 +8,7 @@
 
 #ifdef PLATFORM_IS_POSIX_BASED
 #include <sys/mman.h>
+#include <unistd.h>
 #endif
 
 #if defined(PLATFORM_IS_MACOSX)
@@ -65,4 +66,31 @@ void ponyint_virt_free(void* p, size_t bytes)
 #elif defined(PLATFORM_IS_POSIX_BASED)
   munmap(p, bytes);
 #endif
+}
+
+void ponyint_virt_decommit(void* p, size_t bytes)
+{
+#if defined(PLATFORM_IS_WINDOWS)
+  VirtualAlloc(p, bytes, MEM_RESET, PAGE_READWRITE);
+#elif defined(PLATFORM_IS_POSIX_BASED)
+  madvise(p, bytes, MADV_DONTNEED);
+#endif
+}
+
+size_t ponyint_page_size()
+{
+  static size_t page_size = 0;
+
+  if(page_size == 0)
+  {
+#if defined(PLATFORM_IS_WINDOWS)
+    SYSTEM_INFO si;
+    GetSystemInfo(&si);
+    page_size = si.dwPageSize;
+#elif defined(PLATFORM_IS_POSIX_BASED)
+    page_size = (size_t)sysconf(_SC_PAGESIZE);
+#endif
+  }
+
+  return page_size;
 }

--- a/src/libponyrt/mem/alloc.h
+++ b/src/libponyrt/mem/alloc.h
@@ -12,4 +12,19 @@ void* ponyint_virt_alloc(size_t bytes);
  */
 void ponyint_virt_free(void* p, size_t bytes);
 
+/**
+ * Advises the OS that the given memory range is no longer needed, allowing
+ * it to reclaim the physical pages. The virtual address range remains valid
+ * and accessible — pages are transparently faulted back in on next access.
+ * Silently continues on failure since this is a memory optimization, not a
+ * correctness requirement.
+ */
+void ponyint_virt_decommit(void* p, size_t bytes);
+
+/**
+ * Returns the system page size in bytes. The value is cached after the first
+ * call.
+ */
+size_t ponyint_page_size();
+
 #endif

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -698,10 +698,15 @@ static void* pool_alloc_pages(size_t size)
 
 static void pool_free_pages(void* p, size_t size)
 {
-  if(pool_block_header.total_size >= POOL_MMAP)
+#ifndef USE_POOL_RETAIN
   {
-    // TODO: ???
+    size_t pg = ponyint_page_size();
+    uintptr_t start = ((uintptr_t)p + pg - 1) & ~(pg - 1);
+    uintptr_t end = ((uintptr_t)p + size) & ~(pg - 1);
+    if(end > start)
+      ponyint_virt_decommit((void*)start, end - start);
   }
+#endif
 
 #ifdef USE_ADDRESS_SANITIZER
   ASAN_UNPOISON_MEMORY_REGION(p, sizeof(pool_block_t));


### PR DESCRIPTION
The pool allocator's `pool_free_pages` had a 10-year-old TODO where it should have been returning physical pages to the OS. Freed blocks (>1 MB) were kept on the free list with physical pages committed, so RSS never decreased even after the memory was no longer needed.

Now decommits the page-aligned interior of freed blocks via `madvise(MADV_DONTNEED)` on POSIX / `VirtualAlloc(MEM_RESET)` on Windows. The virtual address range is preserved so pages fault back in transparently on reuse.

This primarily helps programs with large temporary allocations (the compiler, programs with large arrays/strings). Programs whose memory is dominated by small allocations (< 1 MB) will see little change since per-size-class caching is a separate mechanism.

The old behavior (never decommit) can be restored with `make configure use=pool_retain`.