### PR TITLE
Remove defective `Settings.to_json()`

### DIFF
--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -345,11 +345,11 @@ actor LanguageServer is (Notifier & RequestSender)
     end
 
   fun ref handle_did_change_configuration(params: JsonObject val) =>
-    // example output: for settings: {"pony-lsp":{"defines":["FOO","BAR"]}}
+    // example params: {"pony-lsp":{"defines":["FOO","BAR"]}}
     try
       let pony_lsp_settings = params("pony-lsp")? as JsonObject
       let settings = Settings.from_json(pony_lsp_settings)
-      this._channel.log("Received didChangeConfiguration response: " + settings.to_json().string())
+      this._channel.log("Received didChangeConfiguration response: " + params.string())
       this._compiler.apply_settings(settings)
     else
       this._channel.log("Invalid didChangeConfiguration response")

--- a/tools/pony-lsp/settings.pony
+++ b/tools/pony-lsp/settings.pony
@@ -1,5 +1,4 @@
 use "json"
-use pc = "collections/persistent"
 
 class val Settings
   """
@@ -62,16 +61,6 @@ class val Settings
       else
         []
       end
-
-  fun val to_json(): JsonObject =>
-    var defs = JsonArray
-    for def in this._defines.values() do
-      defs = defs.push(def)
-    end
-    var pp = JsonArray(pc.Vec[JsonValue].concat(defs.values()))
-    JsonObject
-      .update("defines", defs)
-      .update("ponypath", pp)
 
   fun val defines(): Array[String] val =>
     this._defines


### PR DESCRIPTION
### Context

`Settings.to_json()` is only used to format settings in a log line in `handle_did_change_configuration`. It contains a defect where the `ponypath` array is built by iterating over `_defines` instead of `_ponypath`, so the logged output is incorrect.

### Changes

Remove `Settings.to_json()` and the now-unused `collections/persistent` import. The log line will log the raw params object instead.

### Consequences

The defective serialisation will be gone. There will be no loss of useful behaviour since `to_json()` is never used to produce output sent to the client or compiler.