### PR TITLE
Fix `assignment-indent` to require RHS indented relative to assignment

### DIFF
--- a/.release-notes/fix-assignment-indent-indentation-depth-check.md
+++ b/.release-notes/fix-assignment-indent-indentation-depth-check.md
@@ -1,0 +1,19 @@
+## Fix `assignment-indent` to require RHS indented relative to assignment
+
+The `style/assignment-indent` lint rule previously only checked that multiline assignment RHS started on the line after the `=`. It did not verify that the RHS was actually indented beyond the assignment line. Code like this was incorrectly accepted:
+
+```pony
+    let chunk =
+    recover val
+      Array[U8]
+    end
+```
+
+The rule now flags RHS that starts on the next line but is not indented relative to the assignment. The correct form is:
+
+```pony
+    let chunk =
+      recover val
+        Array[U8]
+      end
+```

--- a/tools/pony-lint/assignment_indent.pony
+++ b/tools/pony-lint/assignment_indent.pony
@@ -2,17 +2,25 @@ use ast = "pony_compiler"
 
 primitive AssignmentIndent is ASTRule
   """
-  Flags multiline assignment RHS that starts on the same line as the `=`.
+  Flags assignment RHS with incorrect line placement or insufficient
+  indentation.
 
-  When an assignment's right-hand side spans multiple lines, the Pony style
-  guide requires the RHS to start on the line after the `=`, not on the same
-  line. Single-line assignments are always clean.
+  Two checks are performed:
+
+  1. When an assignment's right-hand side spans multiple lines, the Pony style
+     guide requires the RHS to start on the line after the `=`, not on the same
+     line.
+  2. When the RHS starts on the line after the `=`, it must be indented beyond
+     the assignment line. Code at the same column or further left is a
+     violation.
+
+  Single-line assignments where the RHS is on the `=` line are always clean.
   """
   fun id(): String val => "style/assignment-indent"
   fun category(): String val => "style"
 
   fun description(): String val =>
-    "multiline assignment RHS must start on the line after '='"
+    "assignment RHS must start on the line after '=' and be indented"
 
   fun default_status(): RuleStatus => RuleOn
 
@@ -23,12 +31,16 @@ primitive AssignmentIndent is ASTRule
     : Array[Diagnostic val] val
   =>
     """
-    Check whether a multiline RHS begins on the same line as the `=`.
+    Check whether an assignment RHS has correct placement and indentation.
 
-    Gets the RHS (child 1) and compares its start line to the `=` line. If
-    they differ, the RHS already starts on the next line — clean. If they
-    match, uses `_MaxLineVisitor` to determine whether the RHS is multiline.
-    A multiline RHS on the `=` line is a violation.
+    Gets the RHS (child 1) and compares its start line to the `=` line.
+
+    If the RHS starts on a different line, verifies that it is indented beyond
+    the assignment line — the RHS column must exceed the first non-whitespace
+    column of the assignment line.
+
+    If they are on the same line, uses `_MaxLineVisitor` to determine whether
+    the RHS is multiline. A multiline RHS on the `=` line is a violation.
     """
     let assign_line = node.line()
 
@@ -39,8 +51,24 @@ primitive AssignmentIndent is ASTRule
         return recover val Array[Diagnostic val] end
       end
 
-    // RHS starts on a different line than `=` — already correct
     if rhs.line() != assign_line then
+      // RHS starts on a different line — verify sufficient indentation
+      let assign_indent =
+        try
+          _count_leading_spaces(source.lines(assign_line - 1)?)
+        else
+          return recover val Array[Diagnostic val] end
+        end
+      if rhs.pos() <= (assign_indent + 1) then
+        return recover val
+          [ Diagnostic(
+            id(),
+            "assignment RHS must be indented relative to the assignment",
+            source.rel_path,
+            rhs.line(),
+            rhs.pos())]
+        end
+      end
       return recover val Array[Diagnostic val] end
     end
 
@@ -62,3 +90,23 @@ primitive AssignmentIndent is ASTRule
       // Single-line RHS — clean
       recover val Array[Diagnostic val] end
     end
+
+  fun _count_leading_spaces(line: String val): USize =>
+    """
+    Count the number of leading space characters on a line.
+    """
+    var count: USize = 0
+    var i: USize = 0
+    while i < line.size() do
+      try
+        if line(i)? == ' ' then
+          count = count + 1
+        else
+          return count
+        end
+      else
+        return count
+      end
+      i = i + 1
+    end
+    count

--- a/tools/pony-lint/test/_test_assignment_indent.pony
+++ b/tools/pony-lint/test/_test_assignment_indent.pony
@@ -213,6 +213,129 @@ class \nodoc\ _TestAssignmentIndentReassignment is UnitTest
       h.fail("compilation failed")
     end
 
+class \nodoc\ _TestAssignmentIndentRHSNotIndented is UnitTest
+  """Multiline RHS on next line at same indentation produces 1 diagnostic."""
+  fun name(): String =>
+    "AssignmentIndent: RHS on next line not indented flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): Array[U8] val =>\n" +
+      "    let chunk =\n" +
+      "    recover val\n" +
+      "      Array[U8]\n" +
+      "    end\n" +
+      "    chunk\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentReassignmentNotIndented is UnitTest
+  """Reassignment RHS on next line at same indentation produces 1 diagnostic."""
+  fun name(): String =>
+    "AssignmentIndent: reassignment RHS not indented flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(x: U32): U32 =>\n" +
+      "    var y: U32 = 0\n" +
+      "    y =\n" +
+      "    if x > 0 then\n" +
+      "      x\n" +
+      "    else\n" +
+      "      U32(0)\n" +
+      "    end\n" +
+      "    y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestAssignmentIndentRHSDedented is UnitTest
+  """RHS on next line indented less than assignment produces 1 diagnostic."""
+  fun name(): String =>
+    "AssignmentIndent: RHS dedented below assignment flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): Array[U8] val =>\n" +
+      "    let chunk =\n" +
+      "  recover val\n" +
+      "    Array[U8]\n" +
+      "  end\n" +
+      "    chunk\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.AssignmentIndent)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/assignment-indent", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
 class \nodoc\ _TestAssignmentIndentMultipleViolations is UnitTest
   """Two multiline assignments on '=' lines produce 2 diagnostics."""
   fun name(): String => "AssignmentIndent: multiple violations"

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -330,6 +330,9 @@ actor \nodoc\ Main is TestList
     test(_TestAssignmentIndentRecoverViolation)
     test(_TestAssignmentIndentReassignment)
     test(_TestAssignmentIndentMultipleViolations)
+    test(_TestAssignmentIndentRHSNotIndented)
+    test(_TestAssignmentIndentReassignmentNotIndented)
+    test(_TestAssignmentIndentRHSDedented)
 
     // PreferChaining tests
     test(_TestPreferChainingViolation)


### PR DESCRIPTION
The `style/assignment-indent` rule checked that multiline RHS started on the line after `=`, but never verified the RHS was actually indented beyond the assignment line. Code like this passed silently:

```pony
    let chunk =
    recover val
      Array[U8]
    end
```

Added an indentation depth check: when the RHS starts on a different line, the rule now compares its column to the leading whitespace of the assignment line and emits a diagnostic if the RHS isn't indented beyond it.

Closes #4896