### PR TITLE
Fix Scheduler Stats output for memory usage

### DIFF
--- a/.release-notes/4916.md
+++ b/.release-notes/4916.md
@@ -1,0 +1,3 @@
+## Fix scheduler stats output for memory usage
+
+Applications compiled against the runtime which prints periodic scheduler statistics will now display the correct memory usage values per scheduler and for messages "in-flight".

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -66,8 +66,8 @@ static size_t print_stats_interval;
 void print_scheduler_stats(scheduler_t* sched)
 {
   printf("Scheduler stats for index: %d, "
-        "total memory allocated: %" PRIu64 ", "
-        "total memory used: %" PRIu64 ", "
+        "total memory allocated: %" PRId64 ", "
+        "total memory used: %" PRId64 ", "
         "created actors counter: %lu, "
         "destroyed actors counter: %lu, "
         "actors app cpu: %lu, "
@@ -76,9 +76,9 @@ void print_scheduler_stats(scheduler_t* sched)
         "actors system cpu: %lu, "
         "scheduler msgs cpu: %lu, "
         "scheduler misc cpu: %lu, "
-        "memory used inflight messages: %" PRIu64 ", "
-        "memory allocated inflight messages: %" PRIu64 ", "
-        "number of inflight messages: %" PRIu64 "\n",
+        "memory used inflight messages: %" PRId64 ", "
+        "memory allocated inflight messages: %" PRId64 ", "
+        "number of inflight messages: %" PRId64 "\n",
         sched->index,
         sched->ctx.schedulerstats.mem_used + sched->ctx.schedulerstats.mem_used_actors,
         sched->ctx.schedulerstats.mem_allocated + sched->ctx.schedulerstats.mem_allocated_actors,


### PR DESCRIPTION
The scheduler stats memory allocation and used values can result in negative values in cases where memory is allocated on a different scheduler.

This is expected behaviour.

However, the printf format specifier is mistakenly unsigned, resulting in improbably large positive numbers instead of the correct negative values.

For example:
```
Scheduler stats for index: 13, total memory allocated: 18446744073709408560, total memory used: 18446744073709453440,
```

This PR corrects the printf specifier to be the signed 64 bit value.