### PR TITLE
Fix TCPListener accept loop spin on persistent errors

### DIFF
--- a/.release-notes/fix-tcp-listener-accept-spin.md
+++ b/.release-notes/fix-tcp-listener-accept-spin.md
@@ -1,0 +1,5 @@
+## Fix TCPListener accept loop spin on persistent errors
+
+The `pony_os_accept` FFI function returns a signed `int`, but `TCPListener` declared the return type as `U32`. When `accept` returned `-1` to signal a persistent error (e.g., EMFILE — out of file descriptors), the accept loop treated it as "try again" and spun indefinitely, starving other actors of CPU time.
+
+The FFI declaration now correctly uses `I32`, and the accept loop bails out on `-1` instead of retrying. The ASIO event will re-notify the listener when the socket becomes readable, so no connections are lost.

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -1,4 +1,4 @@
-use @pony_os_accept[U32](event: AsioEventID)
+use @pony_os_accept[I32](event: AsioEventID)
 use @pony_os_listen_tcp[AsioEventID](owner: AsioEventNotify, host: Pointer[U8] tag,
   service: Pointer[U8] tag)
 use @pony_os_listen_tcp4[AsioEventID](owner: AsioEventNotify, host: Pointer[U8] tag,
@@ -207,13 +207,14 @@ actor TCPListener is AsioEventNotify
 
         match fd
         | -1 =>
-          // Something other than EWOULDBLOCK, try again.
-          None
+          // Something other than EWOULDBLOCK, bail out. The ASIO event
+          // will re-notify when the socket is readable.
+          return
         | 0 =>
           // EWOULDBLOCK, don't try again.
           return
         else
-          _spawn(fd)
+          _spawn(fd.u32())
         end
       end
 


### PR DESCRIPTION
`pony_os_accept` returns `int` (signed) but the FFI declaration used `U32`, so `-1` (persistent error like EMFILE) was never matched correctly. The `-1` branch also continued the loop instead of bailing out, causing an infinite spin that starved other actors.

Fixes the FFI return type to `I32` and returns on `-1` — the ASIO event will re-notify when the socket becomes readable.

Closes #4906