### PR TITLE
Add use= flags to --version and --ponyversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,10 @@ add_compile_definitions(
     $<$<CONFIG:Release>:NDEBUG>
     $<$<CONFIG:RelWithDebInfo>:NDEBUG>
     $<$<CONFIG:MinSizeRel>:NDEBUG>
-    $<$<CONFIG:Debug>:PONY_VERSION_STR="${PONYC_VERSION} [debug]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:Release>:PONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:RelWithDebInfo>:PONY_VERSION_STR="${PONYC_VERSION} [relwithdebinfo]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:MinSizeRel>:PONY_VERSION_STR="${PONYC_VERSION} [minsizerel]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
+    $<$<CONFIG:Debug>:PONY_VERSION_STR="${PONYC_VERSION} [debug${PONY_OUTPUT_SUFFIX}]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
+    $<$<CONFIG:Release>:PONY_VERSION_STR="${PONYC_VERSION} [release${PONY_OUTPUT_SUFFIX}]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
+    $<$<CONFIG:RelWithDebInfo>:PONY_VERSION_STR="${PONYC_VERSION} [relwithdebinfo${PONY_OUTPUT_SUFFIX}]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
+    $<$<CONFIG:MinSizeRel>:PONY_VERSION_STR="${PONYC_VERSION} [minsizerel${PONY_OUTPUT_SUFFIX}]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM}
 )
 


### PR DESCRIPTION
When you are developing with multiple versions of pony with different use= options, you can forget which version of the compiler you compiled your application with.

This PR adds the missing details to `ponyc --version`, and `yourapp --ponyversion`.

For example:
```
red@ampere:~$ ponyc --version
0.61.0-3e660c93 [debug-valgrind-coverage-pooltrack]
Compiled with: LLVM 18.1.8 -- Clang-18.1.3-x86_64
Defaults: pic=true

red@ampere:~$ ./my_pony_app --ponyversion
0.61.0-3e660c93 [debug-valgrind-coverage-pooltrack]
Compiled with: LLVM 18.1.8 -- Clang-18.1.3-x86_64
```