### PR TITLE
Fix compiler crash when object literal implements enclosing trait

### DIFF
--- a/.release-notes/fix-object-literal-enclosing-trait-crash.md
+++ b/.release-notes/fix-object-literal-enclosing-trait-crash.md
@@ -1,0 +1,14 @@
+## Fix compiler crash when object literal implements enclosing trait
+
+The compiler crashed with an assertion failure when an object literal inside a trait method implemented the same trait. This code would crash the compiler regardless of whether the trait was used:
+
+```pony
+trait Printer
+  fun double(): Printer =>
+    object ref is Printer
+      fun apply() => None
+    end
+  fun apply() => None
+```
+
+This is now accepted. The object literal correctly creates an anonymous class that implements the enclosing trait, and inherited methods that reference the object literal work as expected.

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -655,7 +655,7 @@ static void add_field_to_object(pass_opt_t* opt, ast_t* field,
 }
 
 
-static bool catch_up_provides(pass_opt_t* opt, ast_t* provides)
+static bool catch_up_provides(pass_opt_t* opt, ast_t* provides, ast_t* obj_ast)
 {
   // Make sure all traits have been through the expr pass before proceeding.
   // We run into dangling ast_data pointer problems when we inherit methods from
@@ -670,8 +670,26 @@ static bool catch_up_provides(pass_opt_t* opt, ast_t* provides)
 
     ast_t* def = (ast_t*)ast_data(child);
 
-    if(def != NULL && !ast_passes_type(&def, opt, PASS_EXPR))
-      return false;
+    if(def != NULL)
+    {
+      // If the provided type definition is an ancestor of the original object
+      // literal, we are inside the type we're trying to provide (e.g., an
+      // object literal inside a trait method that implements that trait).
+      // Skip catching it up to avoid re-entrant expression pass processing
+      // on nodes that haven't been through name resolution yet.
+      bool is_ancestor = false;
+      for(ast_t* p = obj_ast; p != NULL; p = ast_parent(p))
+      {
+        if(p == def)
+        {
+          is_ancestor = true;
+          break;
+        }
+      }
+
+      if(!is_ancestor && !ast_passes_type(&def, opt, PASS_EXPR))
+        return false;
+    }
 
     child = ast_sibling(child);
   }
@@ -847,19 +865,31 @@ bool expr_object(pass_opt_t* opt, ast_t** astp)
     type_for_class(opt, def, result, cap_id, TK_EPHEMERAL, false));
 
   // Catch up provides before catching up the entire type.
-  if(!catch_up_provides(opt, provides))
+  if(!catch_up_provides(opt, provides, ast))
+    return false;
+
+  // Replace object..end with $0.create(...) before type-checking the
+  // anonymous type. This must happen first so that if the anonymous type
+  // inherits methods from its provided traits (during PASS_TRAITS), those
+  // methods see the replacement call rather than the raw object literal
+  // (whose children have had PRESERVE cleared and haven't been through
+  // name resolution). Process the call through PASS_REFER so inherited
+  // copies have resolved references; PASS_EXPR is deferred until after
+  // the anonymous type is fully processed.
+  ast_replace(astp, call);
+
+  if(ast_visit(astp, pass_syntax, NULL, opt, PASS_SYNTAX) != AST_OK)
+    return false;
+
+  if(!ast_passes_subtree(astp, opt, PASS_REFER))
     return false;
 
   // Type check the anonymous type.
   if(!ast_passes_type(&def, opt, PASS_EXPR))
     return false;
 
-  // Replace object..end with $0.create(...)
-  ast_replace(astp, call);
-
-  if(ast_visit(astp, pass_syntax, NULL, opt, PASS_SYNTAX) != AST_OK)
-    return false;
-
+  // Finish processing the replacement call through the expression pass,
+  // now that the anonymous type is fully type-checked.
   if(!ast_passes_subtree(astp, opt, PASS_EXPR))
     return false;
 

--- a/test/libponyc/object.cc
+++ b/test/libponyc/object.cc
@@ -122,3 +122,30 @@ TEST_F(ObjectTest, ObjectProvidesNestedUnionTypeAliasProvides)
   TEST_ERRORS_1(src, "invalid provides type. Can only be interfaces, traits and intersects of those.");
 }
 
+TEST_F(ObjectTest, ObjectProvidesEnclosingTrait)
+{
+  // From issue #4451: object literal inside a trait method that implements
+  // the same trait should compile without crashing.
+  const char* src =
+    "trait Printer\n"
+    "  fun double(): Printer =>\n"
+    "    object ref is Printer\n"
+    "      fun apply() => None\n"
+    "    end\n"
+    "  fun apply() => None\n";
+  TEST_COMPILE(src);
+}
+
+TEST_F(ObjectTest, ObjectProvidesEnclosingTraitWithTypeParams)
+{
+  // Variant of issue #4451 with type parameters on the trait.
+  const char* src =
+    "trait Printer[A]\n"
+    "  fun double(): Printer[A] =>\n"
+    "    object ref is Printer[A]\n"
+    "      fun apply() => None\n"
+    "    end\n"
+    "  fun apply() => None\n";
+  TEST_COMPILE(src);
+}
+


### PR DESCRIPTION
When an object literal inside a trait method implements the same trait, the compiler crashes with an assertion failure (`errors_get_count(options->check.errors) > 0` in `pass_expr`). This happens because `expr_object` clears PRESERVE on the object literal's children, then creates an anonymous class that inherits the trait's methods via PASS_TRAITS. The inherited method body still contains the raw object literal with PRESERVE cleared and children not through name resolution, causing a crash during PASS_EXPR.

Two changes fix this:

1. In `catch_up_provides`, skip `ast_passes_type` when the provided type definition is an ancestor of the object literal, preventing re-entrant expression pass processing on the enclosing trait.

2. In `expr_object`, replace the object literal with the `$0.create(...)` call and process it through PASS_REFER before `ast_passes_type`. When PASS_TRAITS copies methods from the trait into the anonymous class, the copied method body has the resolved replacement call instead of the raw object literal. PASS_EXPR processing of the call is deferred until after the anonymous type is fully type-checked.

Closes #4451