### PR TITLE
Exempt unsplittable string literals from line length rule

### DIFF
--- a/.release-notes/line-length-string-exemptions.md
+++ b/.release-notes/line-length-string-exemptions.md
@@ -1,0 +1,22 @@
+## Exempt unsplittable string literals from line length rule
+
+The `style/line-length` lint rule no longer flags lines where the only reason for exceeding 80 columns is a string literal that contains no spaces. Strings without spaces — URLs, file paths, qualified identifiers — cannot be meaningfully split across lines, so flagging them produced noise with no actionable fix.
+
+Strings that contain spaces are still flagged because they can be split at space boundaries using compile-time string concatenation at zero runtime cost:
+
+```pony
+// Before: flagged, and splitting is awkward
+let url = "https://github.com/ponylang/ponyc/blob/main/packages/builtin/string.pony"
+
+// After: no longer flagged — the string has no spaces and can't be split
+
+// Strings with spaces can still be split, so they remain flagged:
+let msg = "This is a very long error message that should be split across multiple lines"
+
+// Fix by splitting at spaces:
+let msg =
+  "This is a very long error message that should be split "
+  + "across multiple lines"
+```
+
+Lines inside triple-quoted strings (docstrings) and lines containing `"""` delimiters are not eligible for this exemption — docstring content should be wrapped regardless of whether it contains spaces.

--- a/tools/pony-lint/line_length.pony
+++ b/tools/pony-lint/line_length.pony
@@ -6,6 +6,21 @@ primitive LineLength is TextRule
   uses `String.codepoints()` so multi-byte UTF-8 characters count as one
   codepoint each. Note that compound emoji (e.g., flag sequences) may count
   as multiple codepoints.
+
+  Lines containing a string literal with no spaces that crosses column 80 are
+  exempt. Such strings (URLs, file paths, identifiers) cannot be meaningfully
+  split, so flagging them produces noise. Strings that contain spaces are not
+  exempt because they can be split at space boundaries using compile-time
+  string concatenation (`+` on string literals) at zero runtime cost.
+
+  Lines inside triple-quoted strings (docstrings) and lines containing triple-
+  quote delimiters are not eligible for exemption — docstring content should be
+  wrapped regardless.
+
+  Known limitations:
+  - Does not handle escaped backslashes before quotes. A string ending in a
+    literal backslash (e.g., "path\\") may cause incorrect string boundary
+    detection. This limitation is shared with `CommentSpacing`.
   """
   fun id(): String val => "style/line-length"
   fun category(): String val => "style"
@@ -15,16 +30,116 @@ primitive LineLength is TextRule
   fun check(source: SourceFile val): Array[Diagnostic val] val =>
     recover val
       let result = Array[Diagnostic val]
+      var in_docstring = false
       for (idx, line) in source.lines.pairs() do
+        let triple_count = _count_triple_quotes(line)
+        let was_in_docstring = in_docstring
+        if (triple_count % 2) == 1 then
+          in_docstring = not in_docstring
+        end
+
         let cp_count = line.codepoints()
         if cp_count > 80 then
-          result.push(Diagnostic(
-            id(),
-            "line exceeds 80 columns (" + cp_count.string() + ")",
-            source.rel_path,
-            idx + 1,
-            81))
+          let eligible =
+            (not was_in_docstring) and (triple_count == 0)
+          let exempt =
+            if eligible then
+              _has_exempt_string(line)
+            else
+              false
+            end
+          if not exempt then
+            result.push(Diagnostic(
+              id(),
+              "line exceeds 80 columns (" + cp_count.string() + ")",
+              source.rel_path,
+              idx + 1,
+              81))
+          end
         end
       end
       result
     end
+
+  fun _count_triple_quotes(line: String val): USize =>
+    """
+    Count non-overlapping occurrences of `\"\"\"` on a line, scanning
+    left to right.
+    """
+    var count: USize = 0
+    var i: USize = 0
+    let size = line.size()
+    while (i + 2) < size do
+      try
+        if (line(i)? == '"') and (line(i + 1)? == '"')
+          and (line(i + 2)? == '"')
+        then
+          count = count + 1
+          i = i + 3
+        else
+          i = i + 1
+        end
+      else
+        _Unreachable()
+        i = i + 1
+      end
+    end
+    count
+
+  fun _has_exempt_string(line: String val): Bool =>
+    """
+    Check whether the line contains a string literal with no spaces that
+    crosses column 80 (starts at or before column 80, ends after column 80).
+
+    Scans byte-by-byte, tracking codepoint position (1-indexed) and toggling
+    an in-string flag on each unescaped double-quote. Triple-quote sequences
+    are defensively skipped (caller already filters triple-quote lines).
+    """
+    var in_string = false
+    var i: USize = 0
+    let size = line.size()
+    var cp_pos: USize = 0
+    var string_start_cp: USize = 0
+    var string_has_space: Bool = false
+
+    while i < size do
+      try
+        let byte = line(i)?
+
+        // Track codepoint position: increment on each codepoint-start byte
+        if (byte and 0xC0) != 0x80 then
+          cp_pos = cp_pos + 1
+        end
+
+        if byte == '"' then
+          if (i == 0) or (line(i - 1)? != '\\') then
+            if not in_string then
+              // Defensive triple-quote skip
+              if ((i + 2) < size) and (line(i + 1)? == '"')
+                and (line(i + 2)? == '"')
+              then
+                i = i + 3
+                continue
+              end
+              in_string = true
+              string_start_cp = cp_pos
+              string_has_space = false
+            else
+              // String closing
+              if (string_start_cp <= 80) and (cp_pos > 80)
+                and (not string_has_space)
+              then
+                return true
+              end
+              in_string = false
+            end
+          end
+        elseif in_string and (byte == ' ') then
+          string_has_space = true
+        end
+      else
+        _Unreachable()
+      end
+      i = i + 1
+    end
+    false

--- a/tools/pony-lint/test/_test_line_length.pony
+++ b/tools/pony-lint/test/_test_line_length.pony
@@ -55,7 +55,8 @@ class \nodoc\ _TestLineLengthEmptyLine is UnitTest
 class \nodoc\ _TestLineLengthProperty is UnitTest
   """
   Property: lines <= 80 codepoints never produce diagnostics;
-  lines > 80 codepoints always do.
+  lines > 80 codepoints always do (when the line contains no string
+  literals — the ASCIILetters generator never produces `"`).
   """
   fun name(): String =>
     "LineLength: property - short lines OK, long lines flagged"
@@ -83,6 +84,257 @@ class \nodoc\ _TestLineLengthProperty is UnitTest
         // ASCIILetters has no whitespace, so no newlines or \r
         let sf =
           lint.SourceFile("/tmp/t.pony", content, "/tmp")
+        let diags = lint.LineLength.check(sf)
+        ph.assert_eq[USize](1, diags.size())
+      })?
+
+class \nodoc\ _TestLineLengthStringExemptNoSpaces is UnitTest
+  """No-space string crossing column 80 is exempt."""
+  fun name(): String =>
+    "LineLength: no-space string crossing col 80 -> exempt"
+
+  fun apply(h: TestHelper) =>
+    // 4 spaces + `let x = "` = 13 chars prefix, then 70 'a's + `"`
+    // String starts at col 14, ends at col 84. No spaces -> exempt.
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"")
+          .> append("a".mul(70))
+          .> append("\"")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestLineLengthStringNotExemptSpaces is UnitTest
+  """String with spaces crossing column 80 is not exempt."""
+  fun name(): String =>
+    "LineLength: string with spaces crossing col 80 -> flagged"
+
+  fun apply(h: TestHelper) =>
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"")
+          .> append("a".mul(30))
+          .> append(" ")
+          .> append("a".mul(39))
+          .> append("\"")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthStringBeforeCol80 is UnitTest
+  """String ends before col 80; line is long from trailing content."""
+  fun name(): String =>
+    "LineLength: string before col 80 -> flagged"
+
+  fun apply(h: TestHelper) =>
+    // Short string at beginning, then lots of trailing code
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"short\"")
+          .> append(" + ")
+          .> append("a".mul(70))
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthStringAfterCol80 is UnitTest
+  """String starts after col 80 (doesn't cross the boundary)."""
+  fun name(): String =>
+    "LineLength: string starts after col 80 -> flagged"
+
+  fun apply(h: TestHelper) =>
+    // 82 chars of code, then a short string
+    let line: String val =
+      recover val
+        String
+          .> append("a".mul(82))
+          .> append("\"url\"")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthStringEndsAtCol80 is UnitTest
+  """No-space string ending exactly at col 80 on an over-80 line."""
+  fun name(): String =>
+    "LineLength: string ends at col 80 -> flagged"
+
+  fun apply(h: TestHelper) =>
+    // 13 chars prefix + 66 'a's + closing quote at col 80 + trailing
+    // String covers cols 14..80. Does not cross col 80 -> not exempt.
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"")
+          .> append("a".mul(66))
+          .> append("\" + more_stuff_here")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthDocstringNoExempt is UnitTest
+  """Long line inside a docstring is not eligible for exemption."""
+  fun name(): String =>
+    "LineLength: long line inside docstring -> flagged"
+
+  fun apply(h: TestHelper) =>
+    // Three lines: opening """, long content with a no-space "string",
+    // closing """
+    let content: String val =
+      recover val
+        String
+          .> append("  \"\"\"\n")
+          .> append("  let x = \"")
+          .> append("a".mul(75))
+          .> append("\"\n")
+          .> append("  \"\"\"")
+      end
+    let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthMultipleStringsOneExempt is UnitTest
+  """Two strings on one line; second one qualifies for exemption."""
+  fun name(): String =>
+    "LineLength: second string qualifies -> exempt"
+
+  fun apply(h: TestHelper) =>
+    // Short string with spaces, then a long no-space string crossing 80
+    let line: String val =
+      recover val
+        String
+          .> append("    f(\"a b\", \"")
+          .> append("x".mul(70))
+          .> append("\")")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestLineLengthEscapedQuotes is UnitTest
+  """String with escaped quotes inside, crossing col 80."""
+  fun name(): String =>
+    "LineLength: escaped quotes in string -> exempt"
+
+  fun apply(h: TestHelper) =>
+    // String contains \" inside but no spaces, crosses col 80
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"abc\\\"def")
+          .> append("g".mul(60))
+          .> append("\"")
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestLineLengthTripleQuoteLineNoExempt is UnitTest
+  """Long line containing triple-quote delimiter is not eligible."""
+  fun name(): String =>
+    "LineLength: triple-quote delimiter line -> flagged"
+
+  fun apply(h: TestHelper) =>
+    let line: String val =
+      recover val
+        String
+          .> append("  \"\"\"")
+          .> append("a".mul(80))
+      end
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](1, diags.size())
+
+class \nodoc\ _TestLineLengthStringExemptUTF8 is UnitTest
+  """Multi-byte UTF-8 in string; codepoint counting is correct."""
+  fun name(): String =>
+    "LineLength: UTF-8 string crossing col 80 -> exempt"
+
+  fun apply(h: TestHelper) =>
+    // 13 prefix + string with multi-byte chars crossing col 80
+    // "é" is 2 bytes but 1 codepoint
+    let line: String val =
+      recover val
+        String
+          .> append("    let x = \"")
+          .> append("é".mul(35))
+          .> append("a".mul(35))
+          .> append("\"")
+      end
+    // 13 + 35 + 35 + 1 = 84 codepoints
+    h.assert_true(line.codepoints() > 80)
+    let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+    let diags = lint.LineLength.check(sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestLineLengthStringExemptProperty is UnitTest
+  """
+  Property: a line with a no-space string crossing column 80 is always
+  exempt. String length ranges from 67 to 200, ensuring the string
+  always crosses column 80 (prefix is 14 codepoints including quotes).
+  """
+  fun name(): String =>
+    "LineLength: property - no-space strings always exempt"
+
+  fun apply(h: TestHelper) ? =>
+    let gen =
+      recover val Generators.usize(where min = 67, max = 200) end
+    PonyCheck.for_all[USize](gen, h)(
+      {(str_len: USize, ph: PropertyHelper) =>
+        let line: String val =
+          recover val
+            String
+              .> append("    let x = \"")
+              .> append("a".mul(str_len))
+              .> append("\"")
+          end
+        let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
+        let diags = lint.LineLength.check(sf)
+        ph.assert_eq[USize](0, diags.size())
+      })?
+
+class \nodoc\ _TestLineLengthStringFlaggedProperty is UnitTest
+  """
+  Property: a line with a space-containing string crossing column 80 is
+  always flagged. Same construction as the exempt property but one
+  character is replaced with a space.
+  """
+  fun name(): String =>
+    "LineLength: property - space strings always flagged"
+
+  fun apply(h: TestHelper) ? =>
+    let gen =
+      recover val Generators.usize(where min = 67, max = 200) end
+    PonyCheck.for_all[USize](gen, h)(
+      {(str_len: USize, ph: PropertyHelper) =>
+        // Put a space in the middle of the string
+        let half = str_len / 2
+        let line: String val =
+          recover val
+            String
+              .> append("    let x = \"")
+              .> append("a".mul(half))
+              .> append(" ")
+              .> append("a".mul(str_len - half - 1))
+              .> append("\"")
+          end
+        let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
         let diags = lint.LineLength.check(sf)
         ph.assert_eq[USize](1, diags.size())
       })?

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -69,6 +69,18 @@ actor \nodoc\ Main is TestList
     test(_TestLineLengthMultiByteUTF8)
     test(_TestLineLengthEmptyLine)
     test(_TestLineLengthProperty)
+    test(_TestLineLengthStringExemptNoSpaces)
+    test(_TestLineLengthStringNotExemptSpaces)
+    test(_TestLineLengthStringBeforeCol80)
+    test(_TestLineLengthStringAfterCol80)
+    test(_TestLineLengthStringEndsAtCol80)
+    test(_TestLineLengthDocstringNoExempt)
+    test(_TestLineLengthMultipleStringsOneExempt)
+    test(_TestLineLengthEscapedQuotes)
+    test(_TestLineLengthTripleQuoteLineNoExempt)
+    test(_TestLineLengthStringExemptUTF8)
+    test(_TestLineLengthStringExemptProperty)
+    test(_TestLineLengthStringFlaggedProperty)
 
     // TrailingWhitespace tests
     test(_TestTrailingWhitespaceSpace)


### PR DESCRIPTION
The line-length lint rule now exempts lines where a string literal with no spaces crosses column 80. Such strings (URLs, file paths, qualified identifiers) cannot be meaningfully split, so flagging them was noise. Strings containing spaces remain flagged — they can be split at space boundaries using compile-time string concatenation at zero runtime cost.

Lines inside docstrings and triple-quote delimiter lines are not eligible for exemption.

Design: #4899