### PR TITLE
Don't mark tag parameters as LLVM readonly

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -929,10 +929,10 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
 
           case TK_TRN:
           case TK_REF:
+          case TK_TAG:
             break;
 
           case TK_VAL:
-          case TK_TAG:
           case TK_BOX:
             LLVMAddAttributeAtIndex(fun, i + offset, readonly_attr);
             break;


### PR DESCRIPTION
Temporary fix for #4925. Moves TK_TAG from the readonly attribute group to the no-attribute group in `genfun_param_attrs`. This prevents LLVM 21's optimizer from incorrectly eliminating loads from memory that was written through FFI calls via tag pointers.