### PR TITLE
Don't mark val or box parameters as LLVM readonly

### DIFF
--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -890,7 +890,6 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   LLVMValueRef fun)
 {
   LLVM_DECLARE_ATTRIBUTEREF(noalias_attr, noalias, 0);
-  LLVM_DECLARE_ATTRIBUTEREF(readonly_attr, readonly, 0);
 
   LLVMValueRef param = LLVMGetFirstParam(fun);
   reach_type_t* type = t;
@@ -930,11 +929,8 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
           case TK_TRN:
           case TK_REF:
           case TK_TAG:
-            break;
-
           case TK_VAL:
           case TK_BOX:
-            LLVMAddAttributeAtIndex(fun, i + offset, readonly_attr);
             break;
 
           default:


### PR DESCRIPTION
The tag-only fix in #4926 wasn't sufficient. The same problem applies to val and box: any Pony function that passes a val or box pointer to an FFI call that writes through it will have those writes optimized away by LLVM 21. The capability on an FFI parameter is a Pony-side fiction — the C code doesn't honor it.

This disables readonly on all capability-derived parameter attributes as a temporary fix until we can do something more targeted (e.g., detecting FFI calls in the function body and only skipping readonly for parameters that flow to them).

Closes #4925