### PR TITLE
Mark Pony functions containing FFI calls as noinline

### DIFF
--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -1037,6 +1037,13 @@ void codegen_startfun(compile_t* c, LLVMValueRef fun, LLVMMetadataRef file,
 
 void codegen_finishfun(compile_t* c)
 {
+  if(c->frame->has_ffi_call && c->frame->fun != NULL)
+  {
+    LLVM_DECLARE_ATTRIBUTEREF(noinline_attr, noinline, 0);
+    LLVMAddAttributeAtIndex(c->frame->fun, LLVMAttributeFunctionIndex,
+      noinline_attr);
+  }
+
   pop_frame(c);
 }
 

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -91,6 +91,7 @@ typedef struct compile_frame_t
   bool is_function;
   bool early_termination;
   bool bare_function;
+  bool has_ffi_call;
   deferred_reification_t* reify;
 
   struct compile_frame_t* prev;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -1271,6 +1271,20 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
     arg = ast_sibling(arg);
   }
 
+  // Mark that the enclosing function contains an FFI call.
+  {
+    compile_frame_t* f = c->frame;
+    while(f != NULL)
+    {
+      if(f->is_function)
+      {
+        f->has_ffi_call = true;
+        break;
+      }
+      f = f->prev;
+    }
+  }
+
   // If we can error out and we have an invoke target, generate an invoke
   // instead of a call.
   LLVMValueRef result;

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -890,6 +890,7 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
   LLVMValueRef fun)
 {
   LLVM_DECLARE_ATTRIBUTEREF(noalias_attr, noalias, 0);
+  LLVM_DECLARE_ATTRIBUTEREF(readonly_attr, readonly, 0);
 
   LLVMValueRef param = LLVMGetFirstParam(fun);
   reach_type_t* type = t;
@@ -928,9 +929,12 @@ void genfun_param_attrs(compile_t* c, reach_type_t* t, reach_method_t* m,
 
           case TK_TRN:
           case TK_REF:
-          case TK_TAG:
+            break;
+
           case TK_VAL:
+          case TK_TAG:
           case TK_BOX:
+            LLVMAddAttributeAtIndex(fun, i + offset, readonly_attr);
             break;
 
           default:


### PR DESCRIPTION
Alternative approach to the readonly/FFI optimization bug (#4925). Instead of removing readonly from all capability-derived parameter attributes (#4927), this restores the original readonly logic and marks Pony functions that contain FFI calls as noinline. This prevents LLVM from inlining the wrapper into the caller, which was propagating the readonly attribute to the FFI call site and letting the optimizer eliminate writes made by C code.

Tradeoff: we keep readonly optimizations for pure Pony code but lose inlining for any function containing an FFI call. This is strictly better than losing readonly everywhere.