### PR TITLE
Fix compiler crash in HeapToStack optimization pass on Windows

### DIFF
--- a/.release-notes/fix-heap-to-stack-crash.md
+++ b/.release-notes/fix-heap-to-stack-crash.md
@@ -1,0 +1,5 @@
+## Fix compiler crash in HeapToStack optimization pass on Windows
+
+The compiler could crash during optimization when compiling programs that trigger the HeapToStack pass (which converts heap allocations to stack allocations). The crash was non-deterministic and most commonly observed on Windows, though it could theoretically occur on any platform.
+
+The root cause was that HeapToStack was registered as a function-level optimization pass but performed operations (force-inlining constructors) that are only safe from a call-graph-level pass. This violated LLVM's pass pipeline contract and could cause use-after-free of internal compiler data structures.

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -12,6 +12,8 @@
 
 #include <llvm/IR/PassManager.h>
 #include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Analysis/CGSCCPassManager.h>
+#include <llvm/Analysis/LazyCallGraph.h>
 #include <llvm/Passes/OptimizationLevel.h>
 #include <llvm/Passes/PassBuilder.h>
 
@@ -86,26 +88,80 @@ public:
     c = compiler;
   }
 
-  PreservedAnalyses run(Function &f, FunctionAnalysisManager &am)
+  PreservedAnalyses run(LazyCallGraph::SCC &C, CGSCCAnalysisManager &AM,
+    LazyCallGraph &CG, CGSCCUpdateResult &UR)
   {
-    DominatorTree& dt = am.getResult<DominatorTreeAnalysis>(f);
-    BasicBlock& entry = f.getEntryBlock();
-    IRBuilder<> builder(&entry, entry.begin());
+    auto &FAM =
+      AM.getResult<FunctionAnalysisManagerCGSCCProxy>(C, CG).getManager();
 
     bool changed = false;
 
-    for(auto block = f.begin(), end = f.end(); block != end; ++block)
-    {
-      for(auto iter = block->begin(), end = block->end(); iter != end; )
-      {
-        Instruction* inst = &(*(iter++));
+    // Collect functions upfront to avoid iterator invalidation if
+    // updateCGAndAnalysisManagerForCGSCCPass splits the SCC.
+    SmallVector<Function*, 4> functions;
+    for(LazyCallGraph::Node &N : C)
+      functions.push_back(&N.getFunction());
 
-        if(runOnInstruction(builder, inst, dt, f))
-          changed = true;
-      }
+    for(Function *fp : functions)
+    {
+      if(fp->isDeclaration())
+        continue;
+
+      if(runOnFunction(*fp, FAM, CG, AM, UR))
+        changed = true;
     }
 
     return changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+  }
+
+  bool runOnFunction(Function &f, FunctionAnalysisManager &FAM,
+    LazyCallGraph &CG, CGSCCAnalysisManager &AM, CGSCCUpdateResult &UR)
+  {
+    bool changed = false;
+    bool restart;
+
+    do
+    {
+      restart = false;
+      DominatorTree& dt = FAM.getResult<DominatorTreeAnalysis>(f);
+      BasicBlock& entry = f.getEntryBlock();
+      IRBuilder<> builder(&entry, entry.begin());
+
+      for(auto block = f.begin(); block != f.end(); ++block)
+      {
+        for(auto iter = block->begin(); iter != block->end();)
+        {
+          Instruction* inst = &(*iter);
+
+          if(runOnInstruction(builder, inst, dt, f))
+          {
+            changed = restart = true;
+
+            FAM.invalidate(f, PreservedAnalyses::none());
+
+            auto *FN = CG.lookup(f);
+            if(FN)
+            {
+              auto *FC = CG.lookupSCC(*FN);
+              if(FC)
+              {
+                updateCGAndAnalysisManagerForCGSCCPass(
+                  CG, *FC, *FN, AM, UR, FAM);
+              }
+            }
+
+            break;
+          }
+
+          ++iter;
+        }
+
+        if(restart)
+          break;
+      }
+    } while(restart);
+
+    return changed;
   }
 
   bool runOnInstruction(IRBuilder<>& builder, Instruction* inst,
@@ -462,10 +518,6 @@ public:
     return false;
   }
 
-  void getAnalysisUsage(AnalysisUsage& use) const
-  {
-    use.addRequired<DominatorTreeWrapperPass>();
-  }
 };
 
 // Pass to replace pony_ctx calls in a dispatch function by the context passed
@@ -958,10 +1010,10 @@ static void optimise(compile_t* c, bool pony_specific)
   // Wire in the Pony-specific passes if requested.
   if(pony_specific)
   {
-    PB.registerPeepholeEPCallback(
-      [&](FunctionPassManager &fpm, OptimizationLevel level) {
+    PB.registerCGSCCOptimizerLateEPCallback(
+      [&](CGSCCPassManager &cgpm, OptimizationLevel level) {
         if(level.getSpeedupLevel() >= 2) {
-          fpm.addPass(HeapToStack(c));
+          cgpm.addPass(HeapToStack(c));
         }
       }
     );


### PR DESCRIPTION
HeapToStack was registered as a function pass but called `InlineFunction` to force-inline constructors after converting heap allocations to stack. This had three correctness problems:

1. **CGSCC contract violation**: function passes can't introduce new call graph edges, but `InlineFunction` copies callee instructions into the caller, creating new edges. In release builds this silently corrupts the call graph.

2. **Iterator invalidation**: the early-increment pattern (`iter++`) advanced past the `pony_alloc` instruction to the next one (often the constructor call). `InlineFunction` then erased that constructor call, leaving a dangling iterator. On Windows, freed memory is zeroed aggressively, so dereferencing the dangling iterator causes an access violation. On Linux, stale memory often still looks valid, masking the bug.

3. **Stale DominatorTree**: obtained once at function entry, but `InlineFunction` restructures the CFG. Subsequent `canStackAlloc` calls used stale dominance data.

Converts HeapToStack from a function pass (`registerPeepholeEPCallback`) to a CGSCC pass (`registerCGSCCOptimizerLateEPCallback`), making `InlineFunction` legal. A restart loop re-fetches the DominatorTree and rescans from the block beginning after each successful transformation, eliminating the iterator and stale-analysis problems.

Closes #4933