### PR TITLE
Fix exhaustive match on tuples of union types

### DIFF
--- a/.release-notes/fix-tuple-union-exhaustiveness.md
+++ b/.release-notes/fix-tuple-union-exhaustiveness.md
@@ -1,0 +1,22 @@
+## Fix exhaustive match on tuples of union types
+
+When using `match \exhaustive\` on a tuple of union types, the compiler rejected matches that used concrete types for the final case even when they covered all remaining possibilities. For example, this was incorrectly rejected:
+
+```pony
+type A is String
+
+actor Main
+  new create(env: Env) =>
+    let x: (A | None) = None
+    let y: (A | None) = None
+
+    match \exhaustive\ (x, y)
+    | (let a: A, _) => env.out.print("1")
+    | (_, let a: A) => env.out.print("2")
+    | (None, None) => env.out.print("3")
+    end
+```
+
+The compiler reported `match marked \exhaustive\ is not exhaustive`, even though the first two cases cover every combination where at least one element is `A`, and the third case covers the only remaining possibility `(None, None)`. Replacing `(None, None)` with `(_, _)` was accepted as a workaround.
+
+The underlying issue was in the subtype checker: a tuple of unions like `((A | None), (A | None))` was not recognized as a subtype of the equivalent union of tuples. This is now fixed by distributing tuples over unions when checking subtype relationships.

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -549,12 +549,131 @@ static bool is_x_sub_isect(ast_t* sub, ast_t* super, check_cap_t check_cap,
   return true;
 }
 
+// Expand a type by distributing tuples over unions into a union of tuples.
+// Returns a TK_UNIONTYPE containing all expanded alternatives, or NULL if
+// the expansion would exceed max_alternatives.
+//
+// For TK_UNIONTYPE: collects alternatives from all members.
+// For TK_TUPLETYPE: computes the cross-product of each element's alternatives.
+// For anything else: returns a 1-element union containing a copy of the type.
+static ast_t* expand_type_alternatives(ast_t* type, size_t max_alternatives)
+{
+  switch(ast_id(type))
+  {
+    case TK_UNIONTYPE:
+    {
+      ast_t* result = ast_from(type, TK_UNIONTYPE);
+
+      for(ast_t* child = ast_child(type);
+        child != NULL;
+        child = ast_sibling(child))
+      {
+        ast_t* child_alts = expand_type_alternatives(child, max_alternatives);
+
+        if(child_alts == NULL)
+        {
+          ast_free_unattached(result);
+          return NULL;
+        }
+
+        for(ast_t* alt = ast_child(child_alts);
+          alt != NULL;
+          alt = ast_sibling(alt))
+        {
+          ast_append(result, ast_dup(alt));
+        }
+
+        ast_free_unattached(child_alts);
+
+        if(ast_childcount(result) > max_alternatives)
+        {
+          ast_free_unattached(result);
+          return NULL;
+        }
+      }
+
+      return result;
+    }
+
+    case TK_TUPLETYPE:
+    {
+      // Start with a single empty tuple.
+      ast_t* result = ast_from(type, TK_UNIONTYPE);
+      ast_append(result, ast_from(type, TK_TUPLETYPE));
+
+      for(ast_t* child = ast_child(type);
+        child != NULL;
+        child = ast_sibling(child))
+      {
+        ast_t* child_alts = expand_type_alternatives(child, max_alternatives);
+
+        if(child_alts == NULL)
+        {
+          ast_free_unattached(result);
+          return NULL;
+        }
+
+        ast_t* new_result = ast_from(type, TK_UNIONTYPE);
+
+        for(ast_t* partial = ast_child(result);
+          partial != NULL;
+          partial = ast_sibling(partial))
+        {
+          for(ast_t* alt = ast_child(child_alts);
+            alt != NULL;
+            alt = ast_sibling(alt))
+          {
+            ast_t* new_tuple = ast_dup(partial);
+            ast_append(new_tuple, ast_dup(alt));
+            ast_append(new_result, new_tuple);
+          }
+        }
+
+        ast_free_unattached(result);
+        ast_free_unattached(child_alts);
+        result = new_result;
+
+        if(ast_childcount(result) > max_alternatives)
+        {
+          ast_free_unattached(result);
+          return NULL;
+        }
+      }
+
+      return result;
+    }
+
+    default:
+    {
+      ast_t* result = ast_from(type, TK_UNIONTYPE);
+      ast_append(result, ast_dup(type));
+      return result;
+    }
+  }
+}
+
+// If type is a tuple containing union elements, expand it into an equivalent
+// union of tuples. Returns the expanded union, or NULL if no expansion is
+// needed or the expansion would be too large.
+static ast_t* expand_tuple_unions(ast_t* type)
+{
+  if(ast_id(type) != TK_TUPLETYPE)
+    return NULL;
+
+  ast_t* expanded = expand_type_alternatives(type, 256);
+
+  if((expanded == NULL) || (ast_childcount(expanded) <= 1))
+  {
+    ast_free_unattached(expanded);
+    return NULL;
+  }
+
+  return expanded;
+}
+
 static bool is_x_sub_union(ast_t* sub, ast_t* super, check_cap_t check_cap,
   errorframe_t* errorf, pass_opt_t* opt)
 {
-  // TODO: a tuple of unions may be a subtype of a union of tuples without
-  // being a subtype of any one element.
-
   // T1 <: T2 or T1 <: T3
   // ---
   // T1 <: (T2 | T3)
@@ -564,6 +683,35 @@ static bool is_x_sub_union(ast_t* sub, ast_t* super, check_cap_t check_cap,
   {
     if(is_x_sub_x(sub, child, check_cap, NULL, opt))
       return true;
+  }
+
+  // A tuple of unions may be a subtype of a union of tuples without being a
+  // subtype of any one element. Expand the tuple into a union of tuples
+  // (cross-product) and check if every alternative is covered.
+  if(ast_id(sub) == TK_TUPLETYPE)
+  {
+    ast_t* expanded = expand_tuple_unions(sub);
+
+    if(expanded != NULL)
+    {
+      bool all_match = true;
+
+      for(ast_t* alt = ast_child(expanded);
+        alt != NULL;
+        alt = ast_sibling(alt))
+      {
+        if(!is_x_sub_x(alt, super, check_cap, NULL, opt))
+        {
+          all_match = false;
+          break;
+        }
+      }
+
+      ast_free_unattached(expanded);
+
+      if(all_match)
+        return true;
+    }
   }
 
   if(errorf != NULL)

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -508,9 +508,8 @@ TEST_F(SubTypeTest, IsSubTypeUnionOfTuple)
   // ((C1, C1) | (C1, C2) | (C2, C1)) <: ((C1 | C2), (C1 | C2))
   ASSERT_TRUE(is_subtype(type_of("uoft3"), type_of("tofu"), NULL, &opt));
 
-  // TODO: Fix this, union of tuples vs tuple of unions
   // ((C1 | C2), (C1 | C2)) <: ((C1, C1) | (C1, C2) | (C2, C1) | (C2, C2))
-  //ASSERT_TRUE(is_subtype(type_of("tofu"), type_of("uoft4"), NULL, &opt));
+  ASSERT_TRUE(is_subtype(type_of("tofu"), type_of("uoft4"), NULL, &opt));
 
   // ((C1 | C2), (C1 | C2)) <!: ((C1, C1) | (C1, C2) | (C2, C1))
   ASSERT_FALSE(is_subtype(type_of("tofu"), type_of("uoft3"), NULL, &opt));


### PR DESCRIPTION
The subtype checker didn't recognize that a tuple of unions is a subtype of the equivalent union of tuples. This caused the exhaustiveness checker to reject valid `match \exhaustive\` on tuples of union types when concrete types were used instead of don't-care patterns.

The fix expands a tuple of unions into the equivalent union of tuples via cross-product distribution in `is_x_sub_union`, then checks if every expanded alternative is covered. This addresses the long-standing TODO at line 555 of subtype.c. A cap of 256 alternatives prevents pathological blowup.

Closes #4937