### PR TITLE
Fix compiler crash on `return error`

### DIFF
--- a/.release-notes/return-error-crash.md
+++ b/.release-notes/return-error-crash.md
@@ -1,0 +1,3 @@
+## Fix compiler crash on `return error`
+
+Previously, writing `return error` in a function body would crash the compiler with an assertion failure instead of producing a diagnostic error. The compiler now correctly reports that a return value cannot be a control statement.

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -454,6 +454,13 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
   ast_t* type = ast_childidx(opt->check.frame->method, 4);
   ast_t* body = ast_child(ast);
 
+  if(ast_checkflag(body, AST_FLAG_JUMPS_AWAY))
+  {
+    ast_error(opt->check.errors, body,
+      "return value cannot be a control statement");
+    return false;
+  }
+
   if(!coerce_literals(&body, type, opt))
     return false;
 
@@ -461,13 +468,6 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
 
   if(is_typecheck_error(body_type))
     return false;
-
-  if(ast_checkflag(body, AST_FLAG_JUMPS_AWAY))
-  {
-    ast_error(opt->check.errors, body,
-      "return value cannot be a control statement");
-    return false;
-  }
 
   bool ok = true;
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -189,6 +189,21 @@ TEST_F(BadPonyTest, ParenthesisedReturn)
   TEST_ERRORS_1(src, "use return only to exit early from a method");
 }
 
+TEST_F(BadPonyTest, ReturnError)
+{
+  // From issue #4934
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    _foo(true)\n"
+    "\n"
+    "  fun tag _foo(x: Bool): Bool =>\n"
+    "    if x then return error end\n"
+    "    x";
+
+  TEST_ERRORS_1(src, "return value cannot be a control statement");
+}
+
 TEST_F(BadPonyTest, ParenthesisedReturn2)
 {
   // From issue #1050


### PR DESCRIPTION
Previously, writing `return error` (or any control statement as a return value) crashed the compiler with an assertion failure rather than producing a diagnostic error. The expression pass checked the body's type before checking the `AST_FLAG_JUMPS_AWAY` flag — since `error` never gets a type assigned, the NULL type triggered an early return from `expr_return()` without recording an error message, violating the assertion in `pass_expr` that requires at least one error when a pass fails.

The fix moves the `AST_FLAG_JUMPS_AWAY` check before `coerce_literals` and the type check, matching the pattern already used by `expr_break()`. The compiler now reports: `return value cannot be a control statement`.

Closes #4934