### PR TITLE
Embedded LLD Phase 1: Build infrastructure + CRT objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # We require LLVM, Google Test and Google Benchmark
 if(NOT PONY_CROSS_LIBPONYRT)
     find_package(LLVM REQUIRED CONFIG PATHS "build/libs/lib/cmake/llvm" "build/libs/lib64/cmake/llvm" NO_DEFAULT_PATH)
+    find_package(LLD REQUIRED CONFIG PATHS "build/libs/lib/cmake/lld" "build/libs/lib64/cmake/lld" NO_DEFAULT_PATH)
     find_package(GTest REQUIRED CONFIG PATHS "build/libs/lib/cmake/GTest" "build/libs/lib64/cmake/GTest" NO_DEFAULT_PATH)
     find_package(benchmark REQUIRED CONFIG PATHS "build/libs/lib/cmake/benchmark" "build/libs/lib64/cmake/benchmark" NO_DEFAULT_PATH)
 endif()
@@ -215,6 +216,8 @@ if(NOT PONY_CROSS_LIBPONYRT)
 
     llvm_map_components_to_libnames(PONYC_LLVM_LIBS ${LLVM_COMPONENTS})
     # message("PONYC_LLVM_LIBS: ${PONYC_LLVM_LIBS}")
+
+    set(PONYC_LLD_LIBS lldELF lldMachO lldCOFF lldWasm lldMinGW lldCommon)
 endif()
 
 # Required definitions.  We use these generators so that the defines are correct for both *nix (where the config applies at configuration time) and Windows (where the config applies at build time).
@@ -294,6 +297,9 @@ set(CMAKE_STATIC_LIBRARY_PREFIX "")
 
 if (PONY_CROSS_LIBPONYRT)
     add_subdirectory(src/libponyrt)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_subdirectory(src/crt)
+    endif()
     install(TARGETS libponyrt)
 else()
     add_subdirectory(src/libponyc)
@@ -307,6 +313,10 @@ else()
 
     add_subdirectory(benchmark/libponyc)
     add_subdirectory(benchmark/libponyrt)
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        add_subdirectory(src/crt)
+    endif()
 
     add_subdirectory(tools/pony-lsp)
     add_subdirectory(tools/pony-lint)

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ crossBuildDir := $(srcDir)/build/$(arch)/build_$(config)
 cross-libponyrt:
 	$(SILENT)mkdir -p $(crossBuildDir)
 	$(SILENT)cd '$(crossBuildDir)' && env CC=$(CC) CXX=$(CXX) cmake -B '$(crossBuildDir)' -S '$(srcDir)' -DCMAKE_CROSSCOMPILING=true -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=$(arch) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DPONY_CROSS_LIBPONYRT=true -DCMAKE_BUILD_TYPE=$(config) -DCMAKE_C_FLAGS="$(cross_cflags)" -DCMAKE_CXX_FLAGS="$(cross_cflags)" -DPONY_ARCH=$(arch) -DPONYC_VERSION=$(version) -DLL_FLAGS="$(cross_llc_flags)"  $(CMAKE_FLAGS)
-	$(SILENT)cd '$(crossBuildDir)' && env CC=$(CC) CXX=$(CXX) cmake --build '$(crossBuildDir)' --config $(config) --target libponyrt -- $(build_flags)
+	$(SILENT)cd '$(crossBuildDir)' && env CC=$(CC) CXX=$(CXX) cmake --build '$(crossBuildDir)' --config $(config) --target libponyrt crt_objects -- $(build_flags)
 
 test: all test-core test-stdlib-release test-examples
 
@@ -325,6 +325,10 @@ install: build
 	$(SILENT)if [ -f $(outDir)/libponyc.a ]; then cp $(outDir)/libponyc.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyc-standalone.a ]; then cp $(outDir)/libponyc-standalone.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyrt-pic.a ]; then cp $(outDir)/libponyrt-pic.a $(ponydir)/lib/$(arch); fi
+	$(SILENT)if [ -f $(outDir)/crtbeginS.o ]; then cp $(outDir)/crtbeginS.o $(ponydir)/lib/$(arch); fi
+	$(SILENT)if [ -f $(outDir)/crtendS.o ]; then cp $(outDir)/crtendS.o $(ponydir)/lib/$(arch); fi
+	$(SILENT)if [ -f $(outDir)/crtbeginT.o ]; then cp $(outDir)/crtbeginT.o $(ponydir)/lib/$(arch); fi
+	$(SILENT)if [ -f $(outDir)/crtend.o ]; then cp $(outDir)/crtend.o $(ponydir)/lib/$(arch); fi
 	$(SILENT)cp $(outDir)/ponyc $(ponydir)/bin
 	$(SILENT)if [ -f $(outDir)/pony-lsp ]; then cp $(outDir)/pony-lsp $(ponydir)/bin; fi
 	$(SILENT)if [ -f $(outDir)/pony-lint ]; then cp $(outDir)/pony-lint $(ponydir)/bin; fi

--- a/benchmark/libponyc/CMakeLists.txt
+++ b/benchmark/libponyc/CMakeLists.txt
@@ -48,5 +48,5 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(NOT PONY_CROSS_LIBPONYRT)
-    target_link_libraries(libponyc.benchmarks PRIVATE ${PONYC_LLVM_LIBS})
+    target_link_libraries(libponyc.benchmarks PRIVATE ${PONYC_LLVM_LIBS} ${PONYC_LLD_LIBS})
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -144,4 +144,6 @@ if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=10.14")
 endif()
 
+set(LLVM_ENABLE_PROJECTS "lld" CACHE STRING "ponyc: build LLD as an LLVM sub-project")
+
 add_subdirectory(llvm/src/llvm)

--- a/src/crt/CMakeLists.txt
+++ b/src/crt/CMakeLists.txt
@@ -1,0 +1,59 @@
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+
+project(ponyc_crt LANGUAGES C)
+
+set(CRT_SRC_DIR ${CMAKE_SOURCE_DIR}/lib/llvm/src/compiler-rt/lib/builtins)
+set(CRT_COMMON_FLAGS -DCRT_HAS_INITFINI_ARRAY -DEH_USE_FRAME_REGISTRY)
+
+# PIE/shared variants (for dynamic linking — the default)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crtbeginS.o
+    COMMAND ${CMAKE_C_COMPILER} -c ${PONY_PIC_FLAG} ${CRT_COMMON_FLAGS}
+        -o ${CMAKE_CURRENT_BINARY_DIR}/crtbeginS.o
+        ${CRT_SRC_DIR}/crtbegin.c
+    DEPENDS ${CRT_SRC_DIR}/crtbegin.c
+    COMMENT "Compiling crtbeginS.o (PIC)")
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crtendS.o
+    COMMAND ${CMAKE_C_COMPILER} -c ${PONY_PIC_FLAG} ${CRT_COMMON_FLAGS}
+        -o ${CMAKE_CURRENT_BINARY_DIR}/crtendS.o
+        ${CRT_SRC_DIR}/crtend.c
+    DEPENDS ${CRT_SRC_DIR}/crtend.c
+    COMMENT "Compiling crtendS.o (PIC)")
+
+# Static variants (for --static linking)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crtbeginT.o
+    COMMAND ${CMAKE_C_COMPILER} -c ${CRT_COMMON_FLAGS}
+        -o ${CMAKE_CURRENT_BINARY_DIR}/crtbeginT.o
+        ${CRT_SRC_DIR}/crtbegin.c
+    DEPENDS ${CRT_SRC_DIR}/crtbegin.c
+    COMMENT "Compiling crtbeginT.o (static)")
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/crtend.o
+    COMMAND ${CMAKE_C_COMPILER} -c ${CRT_COMMON_FLAGS}
+        -o ${CMAKE_CURRENT_BINARY_DIR}/crtend.o
+        ${CRT_SRC_DIR}/crtend.c
+    DEPENDS ${CRT_SRC_DIR}/crtend.c
+    COMMENT "Compiling crtend.o (static)")
+
+add_custom_target(crt_objects ALL
+    DEPENDS
+        ${CMAKE_CURRENT_BINARY_DIR}/crtbeginS.o
+        ${CMAKE_CURRENT_BINARY_DIR}/crtendS.o
+        ${CMAKE_CURRENT_BINARY_DIR}/crtbeginT.o
+        ${CMAKE_CURRENT_BINARY_DIR}/crtend.o)
+
+# Copy to output directory alongside libponyrt.
+set(CRT_FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/crtbeginS.o
+    ${CMAKE_CURRENT_BINARY_DIR}/crtendS.o
+    ${CMAKE_CURRENT_BINARY_DIR}/crtbeginT.o
+    ${CMAKE_CURRENT_BINARY_DIR}/crtend.o)
+
+foreach(CRT_FILE ${CRT_FILES})
+    add_custom_command(TARGET crt_objects POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+    )
+endforeach()

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(libponyc STATIC
     codegen/gencall.c
     codegen/gencontrol.c
     codegen/gendesc.c
-    codegen/genexe.c
+    codegen/genexe.cc
     codegen/genexpr.c
     codegen/genfun.c
     codegen/genheader.c
@@ -72,7 +72,7 @@ add_library(libponyc STATIC
     pkg/ifdef.c
     pkg/package.c
     pkg/platformfuns.c
-    pkg/program.c
+    pkg/program.cc
     pkg/use.c
     platform/paths.c
     platform/vcvars.c
@@ -130,12 +130,13 @@ endif (NOT MSVC)
 if (MSVC)
     # this will not include LLVM-C.lib as it contains lots of duplicated definitions
     file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/libs/lib/LLVM[!-]*.lib")
+    file(GLOB_RECURSE LLD_OBJS "${PROJECT_SOURCE_DIR}/../../build/libs/lib/lld*.lib")
 
     set(libponyc_standalone_file "${CMAKE_STATIC_LIBRARY_PREFIX}ponyc-standalone${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(libponyc_standalone_path "${CMAKE_BINARY_DIR}/${libponyc_standalone_file}")
     add_custom_target(libponyc-standalone ALL
         # CMAKE_AR finds the appropriate version of lib.exe according to desired target and host architecture
-        COMMAND ${CMAKE_AR} /NOLOGO /VERBOSE /OUT:${libponyc_standalone_path} "$<TARGET_FILE:libponyc>" ${LLVM_OBJS} "${PROJECT_SOURCE_DIR}/../../build/libs/lib/blake2.lib"
+        COMMAND ${CMAKE_AR} /NOLOGO /VERBOSE /OUT:${libponyc_standalone_path} "$<TARGET_FILE:libponyc>" ${LLVM_OBJS} ${LLD_OBJS} "${PROJECT_SOURCE_DIR}/../../build/libs/lib/blake2.lib"
         DEPENDS libponyc)
     add_custom_command(TARGET libponyc-standalone POST_BUILD
         COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/${libponyc_standalone_file}
@@ -148,8 +149,9 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     # so when we want to use this lib
     # we need to additionally link libc++ and libz (for llvm)
     file(GLOB_RECURSE LLVM_OBJS "${PROJECT_SOURCE_DIR}/../../build/libs/lib/libLLVM*.a")
+    file(GLOB_RECURSE LLD_OBJS "${PROJECT_SOURCE_DIR}/../../build/libs/lib/liblld*.a")
     add_custom_target(libponyc-standalone ALL
-        COMMAND libtool -static -o libponyc-standalone.a $<TARGET_FILE:libponyc> ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a ${LLVM_OBJS}
+        COMMAND libtool -static -o libponyc-standalone.a $<TARGET_FILE:libponyc> ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a ${LLVM_OBJS} ${LLD_OBJS}
         DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
     )
     # copy the generated file after it is built
@@ -167,6 +169,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
         COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
         COMMAND echo "addlib libcpp.a" >> standalone.mri
         COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "libLLVM*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "liblld*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
         COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
         COMMAND echo "save" >> standalone.mri
         COMMAND echo "end" >> standalone.mri
@@ -215,6 +218,7 @@ else()
         COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
         COMMAND echo "addlib libstdcpp.a" >> standalone.mri
         COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "libLLVM*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "liblld*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
         COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
         COMMAND echo "save" >> standalone.mri
         COMMAND echo "end" >> standalone.mri

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -1,4 +1,13 @@
 #include "genexe.h"
+
+#include <lld/Common/Driver.h>
+
+LLD_HAS_DRIVER(elf)
+LLD_HAS_DRIVER(macho)
+LLD_HAS_DRIVER(coff)
+LLD_HAS_DRIVER(mingw)
+LLD_HAS_DRIVER(wasm)
+
 #include "gencall.h"
 #include "genfun.h"
 #include "genname.h"

--- a/src/libponyc/pkg/program.cc
+++ b/src/libponyc/pkg/program.cc
@@ -19,6 +19,12 @@ typedef struct program_t
   size_t lib_args_size;
   size_t lib_args_alloced;
   char* lib_args;
+
+  // Embedded LLD support (set by program_lib_build_args_embedded)
+  const char** embedded_paths;
+  size_t embedded_path_count;
+  const char** embedded_libs;
+  size_t embedded_lib_count;
 } program_t;
 
 
@@ -57,6 +63,11 @@ program_t* program_create()
   p->lib_args_size = -1;
   p->lib_args = NULL;
 
+  p->embedded_paths = NULL;
+  p->embedded_path_count = 0;
+  p->embedded_libs = NULL;
+  p->embedded_lib_count = 0;
+
   return p;
 }
 
@@ -75,6 +86,16 @@ void program_free(program_t* program)
 
   if(program->lib_args != NULL)
     ponyint_pool_free_size(program->lib_args_alloced, program->lib_args);
+
+  if(program->embedded_paths != NULL)
+    ponyint_pool_free_size(
+      program->embedded_path_count * sizeof(const char*),
+      program->embedded_paths);
+
+  if(program->embedded_libs != NULL)
+    ponyint_pool_free_size(
+      program->embedded_lib_count * sizeof(const char*),
+      program->embedded_libs);
 
   POOL_FREE(program_t, program);
 }
@@ -189,6 +210,7 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
   program_t* data = (program_t*)ast_data(program);
   pony_assert(data != NULL);
   pony_assert(data->lib_args == NULL); // Not yet built args
+  pony_assert(data->embedded_paths == NULL); // Mutually exclusive
 
   // Start with an arbitrary amount of space
   data->lib_args_alloced = 256;
@@ -265,6 +287,135 @@ const char* program_lib_args(ast_t* program)
   pony_assert(data->lib_args != NULL); // Args have been built
 
   return data->lib_args;
+}
+
+
+// Strip the surrounding quotes added by quoted_locator().
+static const char* unquote(const char* quoted)
+{
+  pony_assert(quoted != NULL);
+
+  size_t len = strlen(quoted);
+  pony_assert(len >= 2);
+  pony_assert(quoted[0] == '"');
+  pony_assert(quoted[len - 1] == '"');
+
+  size_t unquoted_len = len - 2;
+  char* buf = (char*)ponyint_pool_alloc_size(unquoted_len + 1);
+  memcpy(buf, quoted + 1, unquoted_len);
+  buf[unquoted_len] = '\0';
+
+  return stringtab_consume(buf, unquoted_len + 1);
+}
+
+
+void program_lib_build_args_embedded(ast_t* program, pass_opt_t* opt)
+{
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+
+  program_t* data = (program_t*)ast_data(program);
+  pony_assert(data != NULL);
+  pony_assert(data->lib_args == NULL); // Mutually exclusive
+  pony_assert(data->embedded_paths == NULL); // Not yet built
+
+  // Count valid paths from source code and CLI/PONYPATH.
+  // Two-pass: first count valid entries, then allocate exactly.
+  size_t path_count = 0;
+  for(strlist_t* p = data->libpaths; p != NULL; p = strlist_next(p))
+    path_count++;
+  for(strlist_t* p = opt->package_search_paths; p != NULL; p = strlist_next(p))
+  {
+    if(quoted_locator(opt, NULL, strlist_data(p)) != NULL)
+      path_count++;
+  }
+
+  // Allocate and populate path array.
+  if(path_count > 0)
+  {
+    data->embedded_paths = (const char**)ponyint_pool_alloc_size(
+      path_count * sizeof(const char*));
+    data->embedded_path_count = path_count;
+
+    size_t i = 0;
+    for(strlist_t* p = data->libpaths; p != NULL; p = strlist_next(p))
+      data->embedded_paths[i++] = unquote(strlist_data(p));
+
+    for(strlist_t* p = opt->package_search_paths; p != NULL;
+      p = strlist_next(p))
+    {
+      const char* quoted = quoted_locator(opt, NULL, strlist_data(p));
+      if(quoted != NULL)
+        data->embedded_paths[i++] = unquote(quoted);
+    }
+  }
+
+  // Count libraries.
+  size_t lib_count = 0;
+  for(strlist_t* p = data->libs; p != NULL; p = strlist_next(p))
+    lib_count++;
+
+  // Allocate and populate library array.
+  if(lib_count > 0)
+  {
+    data->embedded_libs = (const char**)ponyint_pool_alloc_size(
+      lib_count * sizeof(const char*));
+    data->embedded_lib_count = lib_count;
+
+    size_t i = 0;
+    for(strlist_t* p = data->libs; p != NULL; p = strlist_next(p))
+      data->embedded_libs[i++] = unquote(strlist_data(p));
+  }
+}
+
+
+size_t program_lib_path_count(ast_t* program)
+{
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+
+  program_t* data = (program_t*)ast_data(program);
+  pony_assert(data != NULL);
+
+  return data->embedded_path_count;
+}
+
+
+const char* program_lib_path_at(ast_t* program, size_t index)
+{
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+
+  program_t* data = (program_t*)ast_data(program);
+  pony_assert(data != NULL);
+  pony_assert(index < data->embedded_path_count);
+
+  return data->embedded_paths[index];
+}
+
+
+size_t program_lib_count(ast_t* program)
+{
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+
+  program_t* data = (program_t*)ast_data(program);
+  pony_assert(data != NULL);
+
+  return data->embedded_lib_count;
+}
+
+
+const char* program_lib_at(ast_t* program, size_t index)
+{
+  pony_assert(program != NULL);
+  pony_assert(ast_id(program) == TK_PROGRAM);
+
+  program_t* data = (program_t*)ast_data(program);
+  pony_assert(data != NULL);
+  pony_assert(index < data->embedded_lib_count);
+
+  return data->embedded_libs[index];
 }
 
 
@@ -392,6 +543,11 @@ static void program_serialise(pony_ctx_t* ctx, void* object, void* buf,
   dst->lib_args_size = program->lib_args_size;
   dst->lib_args_alloced = program->lib_args_size + 1;
 
+  dst->embedded_paths = NULL;
+  dst->embedded_path_count = 0;
+  dst->embedded_libs = NULL;
+  dst->embedded_lib_count = 0;
+
   ptr_offset = pony_serialise_offset(ctx, program->lib_args);
   dst->lib_args = (char*)ptr_offset;
 
@@ -416,6 +572,11 @@ static void program_deserialise(pony_ctx_t* ctx, void* object)
     (uintptr_t)program->libs);
   program->lib_args = (char*)pony_deserialise_block(ctx,
     (uintptr_t)program->lib_args, program->lib_args_size + 1);
+
+  program->embedded_paths = NULL;
+  program->embedded_path_count = 0;
+  program->embedded_libs = NULL;
+  program->embedded_lib_count = 0;
 }
 
 

--- a/src/libponyc/pkg/program.h
+++ b/src/libponyc/pkg/program.h
@@ -42,6 +42,27 @@ void program_lib_build_args(ast_t* program, pass_opt_t* opt,
  */
 const char* program_lib_args(ast_t* program);
 
+/** Build library arguments for embedded LLD linking.
+ * Collects all library paths (source-defined and CLI/PONYPATH) and library
+ * names into structured arrays without shell-specific formatting.
+ * Mutually exclusive with program_lib_build_args() — call one or the other.
+ */
+void program_lib_build_args_embedded(ast_t* program, pass_opt_t* opt);
+
+/** Return the number of library search paths.
+ * Only valid after program_lib_build_args_embedded(). */
+size_t program_lib_path_count(ast_t* program);
+
+/** Return a library search path by index (unquoted, no -L prefix). */
+const char* program_lib_path_at(ast_t* program, size_t index);
+
+/** Return the number of user-specified libraries.
+ * Only valid after program_lib_build_args_embedded(). */
+size_t program_lib_count(ast_t* program);
+
+/** Return a library name by index (unquoted, no -l prefix or .lib suffix). */
+const char* program_lib_at(ast_t* program, size_t index);
+
 const char* program_signature(ast_t* program);
 
 void program_dump(ast_t* program);

--- a/src/ponyc/CMakeLists.txt
+++ b/src/ponyc/CMakeLists.txt
@@ -74,5 +74,5 @@ else()
 endif (MSVC)
 
 if(NOT PONY_CROSS_LIBPONYRT)
-    target_link_libraries(ponyc PRIVATE ${PONYC_LLVM_LIBS})
+    target_link_libraries(ponyc PRIVATE ${PONYC_LLVM_LIBS} ${PONYC_LLD_LIBS})
 endif()

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -132,5 +132,5 @@ else()
 endif (MSVC)
 
 if(NOT PONY_CROSS_LIBPONYRT)
-    target_link_libraries(libponyc.tests PRIVATE ${PONYC_LLVM_LIBS})
+    target_link_libraries(libponyc.tests PRIVATE ${PONYC_LLVM_LIBS} ${PONYC_LLD_LIBS})
 endif()


### PR DESCRIPTION
First phase of embedded LLD linking support. Establishes build infrastructure without changing how ponyc links user programs — the legacy `system()` path remains the only active code path.

What's included:
- LLD libraries built as part of the vendored LLVM build
- LLD libraries linked into ponyc, test, and benchmark targets
- libponyc-standalone updated to bundle LLD archives
- compiler-rt CRT objects compiled for the host architecture
- CRT objects compiled during cross-compilation builds
- `genexe.c` and `program.c` converted to C++ for future LLD API access
- New structured API for library arguments (`program_lib_build_args_embedded`)

What's NOT included:
- No LLD functions are called
- No changes to how ponyc links user programs
- No new CLI options

Design: #4942