### PR TITLE
Skip tools PR jobs on draft PRs

### DIFF
--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -33,6 +33,7 @@ jobs:
             target: test-pony-doc
           - name: Test pony-lint
             target: test-pony-lint
+    if: github.event.pull_request.draft == false
     name: ${{ matrix.name }}
     container:
       image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201


### PR DESCRIPTION
The tools PR workflow can trigger an expensive LLVM rebuild when the libs cache misses. Skip running on draft PRs by adding a `draft == false` condition to the tools job, matching the existing pr-ponyc behavior.