### PR TITLE
Cache compiler-rt builtins source alongside LLVM libs

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -52,7 +52,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -61,7 +63,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Nightly
         run: bash .ci-scripts/x86-64-nightly.bash
@@ -130,7 +134,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -145,7 +151,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Nightly
         run: |
@@ -181,7 +189,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -190,7 +200,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
@@ -223,7 +235,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -232,7 +246,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --upgrade --break-system-packages cloudsmith-cli
@@ -272,7 +288,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -281,7 +299,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version nightly
@@ -322,7 +342,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -331,7 +353,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version nightly -Arch ARM64

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -64,7 +64,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -122,7 +124,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -180,7 +184,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -251,7 +257,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -306,7 +314,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -46,7 +46,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -102,7 +104,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -162,7 +166,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -192,7 +198,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -228,7 +236,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -263,7 +273,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -33,7 +33,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -84,7 +86,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Release
         run: bash .ci-scripts/x86-64-release.bash
@@ -145,7 +149,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -160,7 +166,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Release
         run: |
@@ -188,7 +196,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -197,7 +207,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
@@ -222,7 +234,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -231,7 +245,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --upgrade --break-system-packages cloudsmith-cli
@@ -263,7 +279,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -272,7 +290,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version (Get-Content .\VERSION)
@@ -305,7 +325,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -314,7 +336,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version (Get-Content .\VERSION) -Arch ARM64

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -69,7 +69,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -78,7 +80,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
@@ -165,7 +169,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -180,7 +186,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -41,7 +41,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -50,7 +52,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
@@ -98,7 +102,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -107,7 +113,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -48,7 +48,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -57,7 +59,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Debug

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -69,7 +69,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -78,7 +80,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
@@ -164,7 +168,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -179,7 +185,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -41,7 +41,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -50,7 +52,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
@@ -98,7 +102,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -107,7 +113,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -48,7 +48,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -57,7 +59,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Debug

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -25,7 +25,9 @@ jobs:
         id: restore-libs
         uses: actions/cache/restore@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -34,7 +36,9 @@ jobs:
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Configure
         run: .\make.ps1 -Command configure -Config Release -Prefix "build\install\release" -Version nightly

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -41,7 +41,9 @@ jobs:
         id: cache-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -65,6 +67,7 @@ jobs:
         include:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
 
     name: ${{ matrix.image }}
     steps:
@@ -74,7 +77,9 @@ jobs:
         id: cache-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Login to GitHub Container Registry
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -107,7 +112,9 @@ jobs:
         id: restore-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -124,7 +131,9 @@ jobs:
         id: restore-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-arm64-macos-15-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -141,7 +150,9 @@ jobs:
         id: restore-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
@@ -158,7 +169,9 @@ jobs:
         id: restore-libs
         uses: actions/cache@v4
         with:
-          path: build/libs
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
           key: libs-windows-11-arm-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'


### PR DESCRIPTION
Phase 1 (PR #4945) added CRT object compilation to `make build`, referencing source files in the LLVM submodule (`lib/llvm/src/compiler-rt/lib/builtins/`). The submodule is only checked out during `make libs`, which is skipped when the libs cache hits. This leaves the CRT source files missing and breaks the build.

Adds the compiler-rt builtins source directory to the cache path in all CI workflows so the source files are available even when `make libs` is skipped.

Existing caches need to be manually busted so new caches are saved with both paths.