### PR TITLE
Fix FreeBSD tier 3 CI cloud-init race condition

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -89,7 +89,7 @@ jobs:
             - sudo
             - rsync
           runcmd:
-            - echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /usr/local/etc/sudoers.d/wheel
+            - echo 'freebsd ALL=(ALL) NOPASSWD: ALL' > /usr/local/etc/sudoers.d/freebsd
           USERDATA
           cat > meta-data <<METADATA
           instance-id: freebsd-ci
@@ -116,9 +116,9 @@ jobs:
               sleep 2
             done
           '
-          echo "SSH available, waiting for sudo to be installed by cloud-init..."
-          timeout 120 bash -c '
-            while ! ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 freebsd@localhost "which sudo" 2>/dev/null; do
+          echo "SSH available, waiting for cloud-init to finish..."
+          timeout 300 bash -c '
+            while ! ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 freebsd@localhost "test -f /var/lib/cloud/instance/boot-finished" 2>/dev/null; do
               sleep 5
             done
           '


### PR DESCRIPTION
Both FreeBSD jobs in the tier 3 weekly CI run are failing because the "Wait for VM" step polls for the `sudo` binary instead of waiting for cloud-init to fully complete. This causes two different failure modes:

- **FreeBSD 14.3**: `pkg` catalog update + package install exceeds the 120s timeout — sudo is never found.
- **FreeBSD 15.0**: sudo is installed (packages phase done) but the `runcmd` phase hasn't finished yet, so the passwordless sudoers rule isn't in place. The next step fails with "a password is required."

Fixes:
- Wait for `/var/lib/cloud/instance/boot-finished` instead of polling for a single binary, ensuring all cloud-init phases (packages *and* runcmd) are complete before proceeding. Timeout raised from 120s to 300s.
- Target the `freebsd` user directly in the sudoers rule instead of relying on `%wheel` group membership.