### PR TITLE
Fix type system soundness hole

### DIFF
--- a/.release-notes/fix-aliased-subtype-soundness.md
+++ b/.release-notes/fix-aliased-subtype-soundness.md
@@ -1,0 +1,23 @@
+## Fix type system soundness hole
+
+The compiler incorrectly accepted aliased type parameters (`X!`) as subtypes of their unaliased form when used inside arrow types. This allowed code that could duplicate `iso` references, breaking reference capability guarantees. For example, a function could take an aliased (tag) reference and return it as its original capability (potentially iso), giving you two references to something that should be unique.
+
+Code that relied on this — likely by accident — will now get a type error. The most common pattern affected is reading a field into a local variable and returning it from a method with a `this->A` return type:
+
+```pony
+// Before: compiled but was unsound
+class Container[A]
+  var inner: A
+  fun get(): this->A =>
+    let tmp = inner
+    consume tmp
+
+// After: return the field directly instead of going through a local
+class Container[A]
+  var inner: A
+  fun get(): this->A => inner
+```
+
+The intermediate `let` binding auto-aliases the type to `this->A!`, and consuming doesn't undo the alias. Returning the field directly avoids the aliasing entirely.
+
+The persistent list in the `collections/persistent` package had four signatures using `val->A!` that relied on this bug. These have been changed to `val->A`. If you had code implementing the same interfaces with explicit `val->A!` types, change them to `val->A`.

--- a/packages/collections/persistent/list.pony
+++ b/packages/collections/persistent/list.pony
@@ -108,7 +108,7 @@ primitive Nil[A] is ReadSeq[val->A]
     """
     object ref is Iterator[val->A]
       fun has_next(): Bool => false
-      fun ref next(): val->A! ? => error
+      fun ref next(): val->A ? => error
     end
 
   fun is_empty(): Bool =>
@@ -141,7 +141,7 @@ primitive Nil[A] is ReadSeq[val->A]
     """
     this
 
-  fun prepend(a: val->A!): Cons[A] =>
+  fun prepend(a: val->A): Cons[A] =>
     """
     Builds a new list with an element added to the front of this list.
     """
@@ -267,7 +267,7 @@ class val Cons[A] is ReadSeq[val->A]
     object is Iterator[val->A]
       var _list: List[A] box = this
       fun has_next(): Bool => _list isnt Nil[A]
-      fun ref next(): val->A! ? => (_list = _list.tail()?).head()?
+      fun ref next(): val->A ? => (_list = _list.tail()?).head()?
     end
 
   fun is_empty(): Bool =>
@@ -310,7 +310,7 @@ class val Cons[A] is ReadSeq[val->A]
       acc
     end
 
-  fun val prepend(a: val->A!): Cons[A] =>
+  fun val prepend(a: val->A): Cons[A] =>
     """
     Builds a new list with an element added to the front of this list.
     """

--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -271,6 +271,14 @@ ast_t* alias(ast_t* type)
       // parameter, and stays the same.
       AST_GET_CHILDREN(type, left, right);
 
+      // A val viewpoint produces only val or tag results for any right-hand
+      // type, and both alias to themselves. Aliasing inside the arrow would
+      // give val->(A!) which differs from (val->A)! when A=iso:
+      // val->(iso!) = val->tag = tag, but (val->iso)! = val! = val.
+      // Return the arrow unchanged to avoid this over-conservative result.
+      if(ast_id(left) == TK_VAL)
+        return type;
+
       BUILD(r_type, type,
         NODE(TK_ARROW,
           TREE(left)

--- a/src/libponyc/type/viewpoint.c
+++ b/src/libponyc/type/viewpoint.c
@@ -421,9 +421,43 @@ static void replace_typeparam(ast_t* tuple, ast_t* type, ast_t* typeparamref,
   ast_append(tuple, r_type);
 }
 
+// Find the first typeparamref in ast that refers to the same type parameter
+// definition as target. Returns NULL if not found.
+static ast_t* find_typeparamref_in(ast_t* ast, ast_t* target)
+{
+  if(ast_id(ast) == TK_TYPEPARAMREF)
+  {
+    if(ast_data(ast) == ast_data(target))
+      return ast;
+    return NULL;
+  }
+
+  ast_t* child = ast_child(ast);
+  while(child != NULL)
+  {
+    ast_t* found = find_typeparamref_in(child, target);
+    if(found != NULL)
+      return found;
+    child = ast_sibling(child);
+  }
+  return NULL;
+}
+
 ast_t* viewpoint_reifytypeparam(ast_t* type, ast_t* typeparamref)
 {
   pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+
+  // When type contains the same type parameter, use the version found in
+  // type to get the correct ephemeral marker. The typeparamref argument may
+  // come from a different context (e.g., the other side of a subtype check)
+  // and carry a different ephemeral marker, which would produce an incorrect
+  // reification. Only override when the cap constraint matches to avoid
+  // changing the expansion basis. See #1798.
+  ast_t* local_tp = find_typeparamref_in(type, typeparamref);
+  if((local_tp != NULL) &&
+    (ast_id(ast_childidx(local_tp, 1)) == ast_id(ast_childidx(typeparamref, 1))))
+    typeparamref = local_tp;
+
   AST_GET_CHILDREN(typeparamref, id, cap, eph);
 
   switch(ast_id(cap))
@@ -515,14 +549,19 @@ bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b)
   pony_assert(ast_id(a) == TK_ARROW);
   pony_assert(ast_id(b) == TK_ARROW);
 
-  // Find the first left side that needs reification.
-  ast_t* test = a;
+  // Walk both arrows in parallel to find the first element that needs
+  // reification. Each side must use its own typeparamref so the correct
+  // ephemeral marker is used for each reification. Using a's typeparamref
+  // for b would apply a's alias/ephemeral semantics to b's expansion,
+  // which is unsound when the markers differ (see #1798).
+  ast_t* test_a = a;
+  ast_t* test_b = b;
 
-  while(ast_id(test) == TK_ARROW)
+  while(ast_id(test_a) == TK_ARROW)
   {
-    AST_GET_CHILDREN(test, left, right);
+    AST_GET_CHILDREN(test_a, left_a, right_a);
 
-    switch(ast_id(left))
+    switch(ast_id(left_a))
     {
       case TK_THISTYPE:
       {
@@ -535,31 +574,53 @@ bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b)
       case TK_TYPEPARAMREF:
       {
         // If we can reify a, we can reify b.
-        ast_t* r = viewpoint_reifytypeparam(a, left);
+        ast_t* r = viewpoint_reifytypeparam(a, left_a);
 
         if(r == NULL)
           break;
 
         *r_a = r;
-        *r_b = viewpoint_reifytypeparam(b, left);
+
+        // Use b's own typeparamref at the corresponding position if it
+        // refers to the same type parameter.
+        ast_t* left_b = left_a;
+        if(ast_id(test_b) == TK_ARROW)
+        {
+          ast_t* candidate = ast_child(test_b);
+          if((ast_id(candidate) == TK_TYPEPARAMREF) &&
+            (ast_data(candidate) == ast_data(left_a)))
+            left_b = candidate;
+        }
+
+        *r_b = viewpoint_reifytypeparam(b, left_b);
         return true;
       }
 
       default: {}
     }
 
-    test = right;
+    test_a = right_a;
+    if(ast_id(test_b) == TK_ARROW)
+      test_b = ast_childidx(test_b, 1);
   }
 
-  if(ast_id(test) == TK_TYPEPARAMREF)
+  if(ast_id(test_a) == TK_TYPEPARAMREF)
   {
-    ast_t* r = viewpoint_reifytypeparam(a, test);
+    ast_t* r = viewpoint_reifytypeparam(a, test_a);
 
     if(r == NULL)
       return false;
 
     *r_a = r;
-    *r_b = viewpoint_reifytypeparam(b, test);
+
+    // Use b's own typeparamref at the corresponding position if it
+    // refers to the same type parameter.
+    ast_t* tp_b = test_a;
+    if((ast_id(test_b) == TK_TYPEPARAMREF) &&
+      (ast_data(test_b) == ast_data(test_a)))
+      tp_b = test_b;
+
+    *r_b = viewpoint_reifytypeparam(b, tp_b);
     return true;
   }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -514,6 +514,20 @@ TEST_F(BadPonyTest, CapSubtypeInConstrainSubtyping)
     "type does not implement its provides list");
 }
 
+TEST_F(BadPonyTest, AliasedTypeParamNotSubtypeOfUnaliased)
+{
+  // From issue #1798
+  // X! should not be a subtype of ref->X: this would allow duplicating iso
+  // references by taking an aliased (tag) reference and returning it as iso.
+  const char* src =
+    "class Foo\n"
+    "  fun alias[X](x: X!) : X^ =>\n"
+    "    let y : ref->X = consume x\n"
+    "    consume y\n";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
 TEST_F(BadPonyTest, ObjectInheritsLaterTraitMethodWithParameter)
 {
   // From issue #1715
@@ -1249,6 +1263,8 @@ TEST_F(BadPonyTest, DisallowPointerAndMaybePointerInEmbeddedType)
 
 TEST_F(BadPonyTest, AllowAliasForNonEphemeralReturn)
 {
+  // Direct field reads return the viewpoint-adapted type (this->A)
+  // without auto-aliasing, so the return type matches.
   const char* src =
     "class iso Inner\n"
     "  new iso create() => None\n"
@@ -1256,16 +1272,38 @@ TEST_F(BadPonyTest, AllowAliasForNonEphemeralReturn)
     "class Container[A: Inner #any]\n"
     "  var inner: A\n"
     "  new create(inner': A) => inner = consume inner'\n"
-    "  fun get_1(): this->A => inner                        // works\n"
-    "  fun get_2(): this->A => let tmp = inner; consume tmp // also works\n"
+    "  fun get_1(): this->A => inner\n"
 
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    let o = Container[Inner iso](Inner)\n"
-    "    let i_1 : Inner tag = o.get_1()\n"
-    "    let i_2 : Inner tag = o.get_2()";
+    "    let i_1 : Inner tag = o.get_1()";
 
   TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, AliasedFieldReadNotSubtypeOfViewpointReturn)
+{
+  // Reading a field into a local auto-aliases: the local has type this->A!.
+  // Consuming the local doesn't strip the alias marker. The resulting
+  // this->A! is not a subtype of this->A because for some instantiations
+  // (e.g. A=iso, receiver=ref) the aliased cap (tag) is not a subcap of
+  // the original (iso). See #1798.
+  const char* src =
+    "class iso Inner\n"
+    "  new iso create() => None\n"
+
+    "class Container[A: Inner #any]\n"
+    "  var inner: A\n"
+    "  new create(inner': A) => inner = consume inner'\n"
+    "  fun get_2(): this->A => let tmp = inner; consume tmp\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let o = Container[Inner iso](Inner)\n"
+    "    let i_2 : Inner tag = o.get_2()";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
 }
 
 TEST_F(BadPonyTest, AllowNestedTupleAccess)


### PR DESCRIPTION
The subtype checker's arrow type reification had a bug: when comparing two arrow types like `this->X!` and `this->X`, `viewpoint_reifypair` used the left side's typeparamref to reify both sides. Since the typeparamref carries the ephemeral marker, both sides were reified identically, making `this->X!` and `this->X` appear equal during pairwise comparison.

This allowed unsound code where an aliased (tag) reference could be returned as its original capability (potentially iso), enabling duplication of unique references.

Three fixes work together:

1. `viewpoint_reifypair` now walks both arrow types in parallel so each side uses its own typeparamref with the correct ephemeral marker.

2. `viewpoint_reifytypeparam` now searches within the type being reified for the matching typeparamref, preferring the local version's ephemeral marker. This covers call sites in `subtype.c` and `compattype.c` that pass one side's typeparamref to reify the other.

3. `alias()` now short-circuits for `val->A` arrow types. A val viewpoint always produces val or tag (both self-aliasing), so aliasing inside the arrow is over-conservative. The stdlib's persistent list had four signatures using `val->A!` that relied on the old behavior; these are changed to `val->A`.

This is a breaking change for code that relied on the bug. The most common affected pattern is reading a field into a local variable and returning it from a method with a `this->A` return type — the local auto-aliases to `this->A!` which is no longer accepted as a subtype of `this->A`. Returning the field directly avoids the aliasing.

Closes #1798