### PR TITLE
Fix MergeMessageSend deprecation warnings

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -760,7 +760,7 @@ public:
       while(1)
       {
         auto prev = std::prev(src);
-        src->moveBefore(&(*dst));
+        src->moveBefore(dst);
 
         if(prev->getMetadata("pony.msgsend") == NULL)
           break;
@@ -785,7 +785,7 @@ public:
       while(iter != first.trace)
       {
         auto& inst = (*iter++);
-        inst.moveBefore(&(*next.alloc));
+        inst.moveBefore(next.alloc);
       }
 
       if(next_kind == MsgNoTrace)
@@ -796,7 +796,7 @@ public:
         {
           auto& inst = *(iter++);
           if(inst.getOpcode() == Instruction::Call)
-            inst.moveBefore(&(*next.send));
+            inst.moveBefore(next.send);
         }
 
         next.trace = first.trace;
@@ -807,7 +807,7 @@ public:
         {
           auto& inst = *(iter++);
           if(inst.getOpcode() == Instruction::Call)
-            inst.moveBefore(&(*next.trace));
+            inst.moveBefore(next.trace);
         }
 
         iter++;
@@ -825,7 +825,7 @@ public:
         {
           auto& inst = *(iter++);
           if(inst.getOpcode() == Instruction::Call)
-            inst.moveBefore(&(*next_done_post));
+            inst.moveBefore(next_done_post);
         }
 
         next.trace = first.trace;
@@ -887,7 +887,7 @@ public:
           is_single = true;
 
         auto chain_call = CallInst::Create(msg_chain_fn, {prev_msg, next_msg},
-          "", *iter);
+          "", (*iter)->getIterator());
         chain_call->setTailCall();
         (*iter)->eraseFromParent();
 


### PR DESCRIPTION
Phase 2 of #4921 — fixes all 6 remaining deprecation warnings in the MergeMessageSend pass.

**`moveBefore(Instruction*)` (5 warnings, lines 763/788/799/810/828):** The `MsgFnGroup` fields are already `BasicBlock::iterator`, but each call site unwrapped via `&(*iter)` to get an `Instruction*`, hitting the deprecated overload. Removed the unnecessary round-trip.

**`InsertPosition` from `Instruction*` (1 warning, line 890):** `CallInst::Create` was passed `*iter` (a `CallInst*`). Changed to `(*iter)->getIterator()`.