### PR TITLE
Fix cross LLC flags variable name in tier-2 CI

### DIFF
--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -76,7 +76,7 @@ jobs:
           make configure config=debug
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
-        run: make cross-libponyrt config=debug CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"
+        run: make cross-libponyrt config=debug CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_llc_flags="-march=riscv64"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../rv64gc/debug cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_linker=riscv64-linux-gnu-gcc-10 cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c --link-ldcmd=bfd' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
       - name: Build Release Runtime
@@ -84,7 +84,7 @@ jobs:
           make configure config=release
           make build config=release
       - name: Build Release Cross-Compiled Runtime
-        run: make cross-libponyrt config=release CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_lflags="-march=riscv64"
+        run: make cross-libponyrt config=release CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_llc_flags="-march=riscv64"
       - name: Test with Release Cross-Compiled Runtime
         run: make test-cross-ci config=release PONYPATH=../rv64gc/release cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_linker=riscv64-linux-gnu-gcc-10 cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c --link-ldcmd=bfd' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
       - name: Send alert on failure
@@ -136,7 +136,7 @@ jobs:
           make configure config=debug
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
-        run: make cross-libponyrt config=debug CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
+        run: make cross-libponyrt config=debug CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../armv7-a/debug cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc cross_ponyc_args='--link-ldcmd=gold' cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc"
       - name: Build Release Runtime
@@ -144,7 +144,7 @@ jobs:
           make configure config=release
           make build config=release
       - name: Build Release Cross-Compiled Runtime
-        run: make cross-libponyrt config=release CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
+        run: make cross-libponyrt config=release CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
       - name: Test with Release Cross-Compiled Runtime
         run: make test-cross-ci config=release PONYPATH=../armv7-a/release cross_triple=arm-unknown-linux-gnueabi cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabi-gcc cross_ponyc_args='--link-ldcmd=gold' cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc"
       - name: Send alert on failure
@@ -196,7 +196,7 @@ jobs:
           make configure config=debug
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
-        run: make cross-libponyrt config=debug CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
+        run: make cross-libponyrt config=debug CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
       - name: Test with Debug Cross-Compiled Runtime
         run: make test-cross-ci config=debug PONYPATH=../armv7-a/debug cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc cross_ponyc_args='--link-ldcmd=gold' cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc"
       - name: Build Release Runtime
@@ -204,7 +204,7 @@ jobs:
           make configure config=release
           make build config=release
       - name: Build Release Cross-Compiled Runtime
-        run: make cross-libponyrt config=release CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_lflags="-O3;-march=arm"
+        run: make cross-libponyrt config=release CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
       - name: Test with Release Cross-Compiled Runtime
         run: make test-cross-ci config=release PONYPATH=../armv7-a/release cross_triple=arm-unknown-linux-gnueabihf cross_arch=armv7-a cross_cpu=cortex-a9 cross_linker=arm-linux-gnueabihf-gcc cross_ponyc_args='--link-ldcmd=gold' cross_runner="qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc"
       - name: Send alert on failure


### PR DESCRIPTION
The tier-2 CI workflow was passing `cross_lflags` but the Makefile's `cross-libponyrt` target references `$(cross_llc_flags)`. This mismatch meant LLC flags were silently dropped for riscv64 and arm cross builds. The builds still succeeded because `llc` infers the target architecture from `CMAKE_SYSTEM_PROCESSOR`, but the explicit flags were never applied.

Renames `cross_lflags` to `cross_llc_flags` in the 6 places it appears in `ponyc-tier2.yml`.

Closes #4979