### PR TITLE
Fix `#share` capability constraint intersection

### DIFF
--- a/.release-notes/fix-share-constraint-intersection.md
+++ b/.release-notes/fix-share-constraint-intersection.md
@@ -1,0 +1,3 @@
+## Fix `#share` capability constraint intersection
+
+When intersecting a `#share` generic constraint with capabilities outside the `#share` set (like `ref` or `box`), the compiler incorrectly reported a non-empty intersection instead of recognizing that the capabilities are disjoint. This did not affect type safety — full subtyping checks always ran afterward — but the internal function returned incorrect intermediate results.

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -264,6 +264,7 @@ static token_id cap_isect_constraint(token_id a, token_id b)
 
         default: {}
       }
+      break;
 
     case TK_CAP_ALIAS:
       switch(b)
@@ -283,6 +284,7 @@ static token_id cap_isect_constraint(token_id a, token_id b)
 
         default: {}
       }
+      break;
 
     default: {}
   }


### PR DESCRIPTION
The `TK_CAP_SHARE` case in `cap_isect_constraint` was missing a `break` after its inner switch, causing fallthrough into `TK_CAP_ALIAS`. This made `cap_isect_constraint(TK_CAP_SHARE, TK_REF)` return `TK_REF` instead of empty — reporting that `#share` and `ref` intersect when they don't. Also added a missing `break` on the `TK_CAP_ALIAS` case for consistency.

All callers run full subtyping checks afterward, so this didn't affect soundness.

Closes #4989