### PR TITLE
Fix cap_isect_constraint returning incorrect capability for empty intersections

### DIFF
--- a/.release-notes/fix-cap-isect-empty-intersection.md
+++ b/.release-notes/fix-cap-isect-empty-intersection.md
@@ -1,0 +1,5 @@
+## Fix cap_isect_constraint returning incorrect capability for empty intersections
+
+When a type parameter was constrained by an intersection of types with incompatible capabilities (e.g., `ref` and `val`), the compiler incorrectly computed the effective capability as `#any` (the universal set) instead of recognizing that no capability satisfies both constraints. This could cause the compiler to silently accept type parameter constraints that have no valid capability, rather than reporting an error.
+
+The compiler now correctly detects empty capability intersections and reports "type parameter constraint has no valid capability" when the intersection of capabilities in a type parameter's constraint is empty. This also fixes incorrect results for `iso` intersected with `#share` and `#share` intersected with concrete capabilities outside its set, which were caused by missing `break` statements and an incorrect case in the capability intersection logic.

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -127,6 +127,15 @@ ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast)
 
   token_id set_cap = ast_id(cap_ast);
 
+  if(set_cap == TK_NONE)
+  {
+    ast_error(opt->check.errors, constraint,
+      "type parameter constraint has no valid capability");
+    ast_error_continue(opt->check.errors, (ast_t*)ast_data(ast),
+      "type parameter definition is here");
+    return AST_ERROR;
+  }
+
   if((cap != TK_NONE) && (cap != set_cap))
   {
     ast_t* def = (ast_t*)ast_data(ast);

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -14,6 +14,14 @@ static token_id cap_union_constraint(token_id a, token_id b)
   if(a == b)
     return a;
 
+  // If one side is empty (TK_NONE), return the other side.
+  // Empty is the identity element for union.
+  if(a == TK_NONE)
+    return b;
+
+  if(b == TK_NONE)
+    return a;
+
   // If we're in a set together, return the set. Otherwise, use #any.
   switch(a)
   {
@@ -161,14 +169,18 @@ static token_id cap_isect_constraint(token_id a, token_id b)
   if(b == TK_CAP_ANY)
     return a;
 
-  // If we're in a set, extract us from the set. Otherwise, use #any.
+  // If one side is empty (TK_NONE), the intersection stays empty.
+  if(a == TK_NONE || b == TK_NONE)
+    return TK_NONE;
+
+  // If we're in a set, extract us from the set. Otherwise, return TK_NONE
+  // (empty intersection — no capability is in both sets).
   switch(a)
   {
     case TK_ISO:
       switch(b)
       {
         case TK_CAP_SEND:
-        case TK_CAP_SHARE:
           return TK_ISO;
 
         default: {}
@@ -205,6 +217,18 @@ static token_id cap_isect_constraint(token_id a, token_id b)
         case TK_CAP_READ:
         case TK_CAP_ALIAS:
           return TK_BOX;
+
+        default: {}
+      }
+      break;
+
+    case TK_TAG:
+      switch(b)
+      {
+        case TK_CAP_SEND:
+        case TK_CAP_SHARE:
+        case TK_CAP_ALIAS:
+          return TK_TAG;
 
         default: {}
       }
@@ -264,6 +288,7 @@ static token_id cap_isect_constraint(token_id a, token_id b)
 
         default: {}
       }
+      break;
 
     case TK_CAP_ALIAS:
       switch(b)
@@ -283,11 +308,12 @@ static token_id cap_isect_constraint(token_id a, token_id b)
 
         default: {}
       }
+      break;
 
     default: {}
   }
 
-  return TK_CAP_ANY;
+  return TK_NONE;
 }
 
 static token_id cap_from_constraint(ast_t* type)


### PR DESCRIPTION
`cap_isect_constraint` returned `TK_CAP_ANY` (the universal set) when two capabilities had an empty intersection (e.g., `ref ∩ val`). This is the opposite of the correct answer — the function now returns `TK_NONE` to indicate that no capability satisfies both constraints. `flatten_typeparamref` detects this and reports "type parameter constraint has no valid capability."

Three categories of bugs fixed in `cap_isect_constraint`:

1. The default return was `TK_CAP_ANY` instead of `TK_NONE`. Any unhandled capability pair (including all concrete∩concrete where a ≠ b) now correctly returns empty.

2. Missing `break` statements after `TK_CAP_SHARE` and `TK_CAP_ALIAS` caused fallthrough to the next case — e.g., `#share ∩ ref` fell through to `TK_CAP_ALIAS` and returned `TK_REF`, but `{val, tag} ∩ {ref}` is empty.

3. `TK_CAP_SHARE` was listed under `TK_ISO`, so `iso ∩ #share` returned `TK_ISO`, but `{iso} ∩ {val, tag}` is empty.

Additionally: `TK_TAG` was missing from the outer switch, `cap_union_constraint` now handles `TK_NONE` as the identity element for nested structures like `(A & B) | C`.

Closes #4988