### PR TITLE
Fix embedded linker missing standard system library search paths

### DIFF
--- a/.release-notes/fix-embedded-lld-library-paths.md
+++ b/.release-notes/fix-embedded-lld-library-paths.md
@@ -1,5 +1,0 @@
-## Fix embedded linker missing standard system library search paths
-
-The embedded LLD linker did not search standard system library directories beyond where libc CRT objects are installed. Libraries in `/usr/local/lib` (common for libraries built from source, such as OpenSSL), `/usr/local/lib64` (OpenSSL on x86_64 Linux), or `/lib` (on systems that haven't done the /usr merge, such as Alpine Linux 3.20 and earlier) could not be found, causing "unable to find library" link errors.
-
-The embedded linker now includes `/lib`, `/usr/local/lib`, `/lib64`, `/usr/lib64`, and `/usr/local/lib64` as fallback search paths on Linux, and `/opt/homebrew/lib` and `/usr/local/lib` on macOS.


### PR DESCRIPTION
The embedded LLD linker only added `-L` paths for the libc CRT directory, GCC lib directories, and user-specified paths. Standard system library directories that `cc` would include automatically were missing, causing link failures for libraries installed in those locations.

Three CI failures after merging the Linux embedded linker work:

- **Alpine 3.20 ponyc nightly**: `unable to find library -lz` — Alpine 3.20 hasn't done the `/usr` merge, so `libz.so` lives in `/lib/` (separate from `/usr/lib/`)
- **ssl/http/github_rest_api (OpenSSL 3.x)**: `unable to find library -lssl` / `-lcrypto` — OpenSSL built from source installs to `/usr/local/lib64/`

Adds fallback search paths:
- **ELF**: `/lib`, `/usr/local/lib`, `/lib64`, `/usr/lib64`, `/usr/local/lib64` (sysroot-relative for cross-compilation)
- **Mach-O**: `/opt/homebrew/lib`, `/usr/local/lib`

Paths are stat-checked and only added when the directory exists.