### PR TITLE
Add OpenBSD 7.8 as a tier 3 CI target

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -177,3 +177,121 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  openbsd:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    name: x86-64 OpenBSD 7.8
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache
+          df -h /
+      - name: Install QEMU
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q qemu-utils qemu-system-x86 genisoimage
+          sudo chmod 666 /dev/kvm
+      - name: Download OpenBSD image
+        run: |
+          curl -L -o openbsd.qcow2 \
+            "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.8_2025-10-22-09-25/openbsd-generic.qcow2"
+          qemu-img resize openbsd.qcow2 60G
+      - name: Prepare VM access
+        run: |
+          ssh-keygen -t ed25519 -f vm_key -N ""
+          PUB_KEY=$(cat vm_key.pub)
+
+          cat > user-data <<USERDATA
+          #cloud-config
+          users:
+          - name: openbsd
+            groups: wheel
+            ssh_authorized_keys:
+            - ${PUB_KEY}
+          write_files:
+          - path: /etc/doas.conf
+            content: |
+              permit nopass keepenv :wheel
+            owner: root:wheel
+            permissions: '0600'
+          USERDATA
+          cat > meta-data <<METADATA
+          instance-id: openbsd-ci
+          local-hostname: openbsd-ci
+          METADATA
+          genisoimage -output seed.iso -volid cidata -joliet -rock user-data meta-data
+      - name: Boot OpenBSD VM
+        run: |
+          qemu-system-x86_64 \
+            -machine pc,accel=kvm \
+            -cpu host \
+            -smp 4 \
+            -m 6G \
+            -drive file=openbsd.qcow2,format=qcow2,if=virtio \
+            -drive file=seed.iso,media=cdrom \
+            -netdev user,id=net0,hostfwd=tcp::2222-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -display none \
+            -daemonize
+      - name: Wait for VM
+        run: |
+          timeout 300 bash -c '
+            while ! ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -i vm_key -p 2222 openbsd@localhost true 2>/dev/null; do
+              sleep 2
+            done
+          '
+          echo "SSH available"
+      - name: Install build dependencies
+        run: |
+          ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost \
+            "doas pkg_add cmake gmake git python%3 rsync--"
+      - name: Raise datasize limit
+        run: |
+          ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost \
+            "doas sed -i 's/datasize-max=1536M/datasize-max=4096M/' /etc/login.conf && doas sed -i 's/datasize-cur=1536M/datasize-cur=4096M/' /etc/login.conf"
+      - name: Copy source to VM
+        run: |
+          rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
+            "$GITHUB_WORKSPACE/" openbsd@localhost:/home/openbsd/ponyc/
+      - name: Build and test
+        run: |
+          ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i vm_key -p 2222 openbsd@localhost <<'EOF'
+          set -e
+          cd /home/openbsd/ponyc
+          gmake libs build_flags=-j4
+          rm -rf build/build_libs
+          gmake configure config=debug
+          gmake build config=debug
+          gmake test-ci-core config=debug
+          gmake test-pony-doc config=debug
+          gmake test-pony-lint config=debug
+          gmake test-pony-lsp config=debug
+          gmake lint-pony-lint config=debug
+          gmake configure config=release
+          gmake build config=release
+          gmake test-ci-core config=release
+          EOF
+      - name: Shutdown VM
+        if: always()
+        run: |
+          pkill -f qemu-system-x86 || true
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.release-notes/add-openbsd-tier3-ci.md
+++ b/.release-notes/add-openbsd-tier3-ci.md
@@ -1,0 +1,7 @@
+## Add OpenBSD 7.8 as a tier 3 CI target
+
+OpenBSD is now a tier 3 (best-effort) platform for ponyc. A weekly CI job builds and tests the compiler, standard library, and tools (pony-doc, pony-lint, pony-lsp) on OpenBSD 7.8.
+
+The tools previously couldn't find the standard library on OpenBSD because they hardcoded their binary name when looking up the executable directory. This works on Linux, macOS, and FreeBSD, which have platform APIs that ignore argv0, but fails on OpenBSD where argv0 is the only mechanism for resolving the executable path. All three tools now pass the real `argv[0]` from the runtime.
+
+`libponyc-standalone` is now built on OpenBSD, so programs can link against the compiler as a library on this platform.

--- a/BUILD.md
+++ b/BUILD.md
@@ -43,6 +43,18 @@ sudo gmake install
 
 Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 
+## OpenBSD
+
+```bash
+pkg_add cmake gmake git python%3
+gmake libs
+gmake configure
+gmake build
+doas gmake install
+```
+
+Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
+
 ## DragonFly
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
   endif
 endif
 
-# Make sure the compiler gets all relevant search paths on FreeBSD
-ifeq ($(shell uname -s),FreeBSD)
+# Make sure the compiler gets all relevant search paths on FreeBSD/OpenBSD
+ifneq (,$(filter FreeBSD OpenBSD,$(shell uname -s)))
   ifeq (,$(findstring /usr/local/include,$(shell echo $CPATH)))
     export CPATH = /usr/local/include:$CPATH
   endif
@@ -238,9 +238,7 @@ test-libponyrt: all
 test-libponyc: all
 	$(SILENT)cd '$(outDir)' && $(debuggercmd) ./libponyc.tests --gtest_shuffle $(testextras)
 
-ifeq ($(shell uname -s),FreeBSD)
-  num_cores := `sysctl -n hw.ncpu`
-else ifeq ($(shell uname -s),Darwin)
+ifneq (,$(filter FreeBSD OpenBSD Darwin,$(shell uname -s)))
   num_cores := `sysctl -n hw.ncpu`
 else
   num_cores := `nproc --all`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Best-effort platforms are operating systems where Pony _should_ work, but with l
 
 * DragonFlyBSD (x86 only)
 * FreeBSD (x86 only)
+* OpenBSD (x86 only)
 * Windows 10 (x86 only)
 
 ## More Information

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -189,7 +189,32 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
         COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
     )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
-    # TODO
+    # add a rule to generate the standalone library if needed
+    add_custom_command(OUTPUT libponyc-standalone.a
+        COMMAND cp `${CMAKE_CXX_COMPILER} --print-file-name='libc++.a'` libcpp.a
+        COMMAND echo "create libponyc-standalone.a" > standalone.mri
+        COMMAND echo "addlib ${PROJECT_SOURCE_DIR}/../../build/libs/lib/libblake2.a" >> standalone.mri
+        COMMAND echo "addlib libcpp.a" >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "libLLVM*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND find ${PROJECT_SOURCE_DIR}/../../build/libs/ -name "liblld*.a" | xargs -I % -n 1 echo 'addlib %' >> standalone.mri
+        COMMAND echo "addlib $<TARGET_FILE:libponyc>" >> standalone.mri
+        COMMAND echo "save" >> standalone.mri
+        COMMAND echo "end" >> standalone.mri
+        COMMAND ${CMAKE_AR} -M < standalone.mri
+        DEPENDS $<TARGET_FILE:libponyc> ${STANDALONE_ARCHIVES}
+    )
+    # add a separate target that depends on the standalone library file
+    add_custom_target(libponyc-standalone ALL
+        DEPENDS libponyc
+        SOURCES libponyc-standalone.a
+    )
+    # copy the generated file after it is built
+    add_custom_command(TARGET libponyc-standalone POST_BUILD
+        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
+        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+    )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
     # TODO
 else()

--- a/test/full-program-tests/ffi-libponyc-standalone/main.pony
+++ b/test/full-program-tests/ffi-libponyc-standalone/main.pony
@@ -1,12 +1,12 @@
-use "lib:ponyc-standalone" if not (openbsd or dragonfly)
+use "lib:ponyc-standalone" if not dragonfly
 use "lib:z" if not (windows or openbsd or dragonfly)
 use "lib:c++" if osx
 
-use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if not (openbsd or dragonfly)
-use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if not (openbsd or dragonfly)
-use @token_free[None](token: TokenStub) if not (openbsd or dragonfly)
-use @ast_free[None](ast: AstStub) if not (openbsd or dragonfly)
-use @ast_id[TokenId](ast: AstStub) if not (openbsd or dragonfly)
+use @token_new[NullablePointer[TokenStub]](token_id: TokenId) if not dragonfly
+use @ast_new[NullablePointer[AstStub]](token: TokenStub, token_id: TokenId) if not dragonfly
+use @token_free[None](token: TokenStub) if not dragonfly
+use @ast_free[None](ast: AstStub) if not dragonfly
+use @ast_id[TokenId](ast: AstStub) if not dragonfly
 
 struct AstStub
 struct TokenStub
@@ -16,7 +16,7 @@ type TokenId is I32
 actor Main
   new create(env: Env) =>
     try
-      ifdef not (openbsd or dragonfly) then
+      ifdef not dragonfly then
         let token = @token_new(2)()?
         let ast = @ast_new(token, 2)()?
         if @ast_id(ast) != 2 then

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -245,9 +245,12 @@ static bool compare_asts(ast_t* expected, ast_t* actual, errors_t *errors)
 
 // class PassTest
 
+extern const char* test_argv0;
+
 void PassTest::SetUp()
 {
   pass_opt_init(&opt);
+  opt.argv0 = test_argv0;
   codegen_pass_init(&opt);
   package_init(&opt);
   program = NULL;
@@ -697,8 +700,12 @@ void Environment::TearDown()
 }
 
 
+// Stored for OpenBSD, which needs argv0 to locate the executable path.
+const char* test_argv0 = NULL;
+
 int main(int argc, char** argv)
 {
+  test_argv0 = argv[0];
   testing::InitGoogleTest(&argc, argv);
   testing::AddGlobalTestEnvironment(new Environment());
   return RUN_ALL_TESTS();

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
@@ -1,4 +1,4 @@
-use "lib:ponyc-standalone" if not (openbsd or dragonfly)
+use "lib:ponyc-standalone" if not dragonfly
 use "lib:z" if not (windows or openbsd or dragonfly)
 use "lib:c++" if osx
 use "files"

--- a/tools/pony-doc/main.pony
+++ b/tools/pony-doc/main.pony
@@ -68,7 +68,8 @@ actor Main
     let include_private = cmd.option("include-private").bool()
 
     // Build package search paths
-    let package_paths = _build_package_paths(env.vars)
+    let argv0 = try env.args(0)? else "" end
+    let package_paths = _build_package_paths(env.vars, argv0)
 
     // Compile the target package
     let file_auth = FileAuth(env.root)
@@ -101,7 +102,8 @@ actor Main
     end
 
   fun _build_package_paths(
-    vars: (Array[String val] val | None))
+    vars: (Array[String val] val | None),
+    argv0: String val)
     : Array[String val] val
   =>
     """
@@ -117,7 +119,7 @@ actor Main
     recover val
       let paths = Array[String val]
       // Installation paths first
-      match _find_exe_directory()
+      match _find_exe_directory(argv0)
       | let dir: String val =>
         paths.push(Path.join(dir, "../packages"))
         paths.push(Path.join(dir, "../../packages"))
@@ -146,14 +148,14 @@ actor Main
     end
     recover val Array[String val] end
 
-  fun _find_exe_directory(): (String val | None) =>
+  fun _find_exe_directory(argv0: String val): (String val | None) =>
     """
     Find the directory containing the currently running executable
     using the same platform-specific mechanism as ponyc.
     """
     let buf_size: USize = 4096
     let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, "pony-doc".cstring())
+    if @get_compiler_exe_directory(buf, argv0.cstring())
     then
       let result = recover val
         String.copy_cstring(buf)

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -169,7 +169,8 @@ actor Main
     // Build package search paths: installation paths first (prevents
     // PONYPATH from overriding builtin, per ponylang/ponyc#3779),
     // then PONYPATH.
-    let package_paths = _build_package_paths(env.vars)
+    let argv0 = try env.args(0)? else "" end
+    let package_paths = _build_package_paths(env.vars, argv0)
 
     // Run linter
     let cwd = Path.cwd()
@@ -184,7 +185,8 @@ actor Main
     env.exitcode(exit_code())
 
   fun _build_package_paths(
-    vars: (Array[String val] val | None))
+    vars: (Array[String val] val | None),
+    argv0: String val)
     : Array[String val] val
   =>
     """
@@ -201,7 +203,7 @@ actor Main
     recover val
       let paths = Array[String val]
       // Installation paths first
-      match _find_exe_directory()
+      match _find_exe_directory(argv0)
       | let dir: String val =>
         paths.push(Path.join(dir, "../packages"))
         paths.push(
@@ -233,14 +235,14 @@ actor Main
     end
     recover val Array[String val] end
 
-  fun _find_exe_directory(): (String val | None) =>
+  fun _find_exe_directory(argv0: String val): (String val | None) =>
     """
     Find the directory containing the currently running executable
     using the same platform-specific mechanism as ponyc.
     """
     let buf_size: USize = 4096
     let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, "pony-lint".cstring())
+    if @get_compiler_exe_directory(buf, argv0.cstring())
     then
       let result =
         recover val String.copy_cstring(buf) end

--- a/tools/pony-lsp/main.pony
+++ b/tools/pony-lsp/main.pony
@@ -48,5 +48,6 @@ actor Main
       | let p: String => p
       | None => ""
       end
-    let language_server = LanguageServer(channel, env, PonyCompiler(pony_path))
+    let argv0 = try env.args(0)? else "" end
+    let language_server = LanguageServer(channel, env, PonyCompiler(pony_path, argv0))
     // at this point the server should listen to incoming messages via stdin

--- a/tools/pony-lsp/pony_compiler.pony
+++ b/tools/pony-lsp/pony_compiler.pony
@@ -34,9 +34,9 @@ actor PonyCompiler is LspCompiler
     """
   var _run_id_gen: USize
 
-  new create(pony_path': String) =>
+  new create(pony_path': String, argv0: String val = "") =>
     _pony_path = Path.split_list(pony_path')
-    _installation_paths = _find_installation_paths()
+    _installation_paths = _find_installation_paths(argv0)
     _compilation_queue = []
 
     _defines = _defines.create()
@@ -48,14 +48,14 @@ actor PonyCompiler is LspCompiler
     // program start with 0
     _run_id_gen = 1
 
-  fun tag _find_installation_paths(): Array[String val] val =>
+  fun tag _find_installation_paths(argv0: String val): Array[String val] val =>
     """
     Find pony package paths relative to the running executable's directory.
     Since pony-lsp is installed alongside ponyc, the standard library lives
     at `../packages` (installed layout) or `../../packages` (source build
     layout) relative to the executable.
     """
-    match \exhaustive\ _find_exe_directory()
+    match \exhaustive\ _find_exe_directory(argv0)
     | let dir: String val =>
       recover val
         let paths = Array[String val](2)
@@ -67,7 +67,7 @@ actor PonyCompiler is LspCompiler
       recover val Array[String val] end
     end
 
-  fun tag _find_exe_directory(): (String val | None) =>
+  fun tag _find_exe_directory(argv0: String val): (String val | None) =>
     """
     Find the directory containing the currently running executable using the
     same platform-specific mechanism as ponyc (readlink /proc/self/exe on
@@ -75,7 +75,7 @@ actor PonyCompiler is LspCompiler
     """
     let buf_size: USize = 4096
     let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, "pony-lsp".cstring()) then
+    if @get_compiler_exe_directory(buf, argv0.cstring()) then
       let result = recover val String.copy_cstring(buf) end
       @ponyint_pool_free_size(buf_size, buf)
       result


### PR DESCRIPTION
Adds OpenBSD 7.8 as a tier 3 (best-effort) CI target, running weekly alongside FreeBSD. The CI job builds and tests the compiler, standard library, and all tools on OpenBSD 7.8 using QEMU with KVM acceleration.

Fixes a pre-existing bug where pony-doc, pony-lint, and pony-lsp hardcoded their binary name as argv0 for executable directory lookup. This is harmless on platforms with /proc/self/exe or sysctl but fails on OpenBSD where argv0 is the only mechanism for resolving the executable path. Same fix applied to the libponyc test harness where opt.argv0 was never set.

Enables the libponyc-standalone build on OpenBSD.