### PR TITLE
Remove unused legacy pass manager namespace

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -30,7 +30,6 @@
 #include "ponyassert.h"
 
 using namespace llvm;
-using namespace llvm::legacy;
 
 static void print_transform(compile_t* c, Instruction* i, const char* s)
 {


### PR DESCRIPTION
The optimization pipeline in genopt.cc was migrated to the new LLVM pass manager but the `using namespace llvm::legacy` declaration was left behind. Nothing in the file references it.

Closes #3841