### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -31,7 +31,7 @@ jobs:
     name: alpine3.22-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -54,7 +54,7 @@ jobs:
     name: alpine3.23-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -77,7 +77,7 @@ jobs:
     name: arm64-unknown-linux-alpine3.21-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -100,7 +100,7 @@ jobs:
     name: arm64-unknown-linux-ubuntu24.04-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -123,7 +123,7 @@ jobs:
     name: cross-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -146,7 +146,7 @@ jobs:
     name: cross-armhf
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -169,7 +169,7 @@ jobs:
     name: cross-riscv64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -192,7 +192,7 @@ jobs:
     name: x86-64-unknown-linux-alpine3.20-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -215,7 +215,7 @@ jobs:
     name: x86-64-unknown-linux-alpine3.21-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -238,7 +238,7 @@ jobs:
     name: x86-64-unknown-linux-ubuntu22.04-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -261,7 +261,7 @@ jobs:
     name: x86-64-unknown-linux-ubuntu24.04-builder
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -58,7 +58,7 @@ jobs:
     name: Update stdlib-builder Docker image with nightly ponyc version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -89,7 +89,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:nightly
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build
         run: "bash .ci-scripts/build-stdlib-documentation.bash"
       - name: Alert on failure

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -117,7 +117,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -142,7 +142,7 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -177,7 +177,7 @@ jobs:
     name: Update stdlib-builder Docker image with newly released ponyc version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -201,7 +201,7 @@ jobs:
       image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Build
         run: "bash .ci-scripts/build-stdlib-documentation.bash"
       - name: Setup Pages
@@ -223,7 +223,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -24,7 +24,7 @@ jobs:
       image: ghcr.io/ponylang/ponyc-ci-stdlib-builder:release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Build
         run: "bash .ci-scripts/build-stdlib-documentation.bash"
       - name: Setup Pages

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -121,7 +121,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -184,7 +184,7 @@ jobs:
     name: x86-64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -230,7 +230,7 @@ jobs:
     name: arm64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -279,7 +279,7 @@ jobs:
     name: x86-64-pc-windows-msvc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
@@ -334,7 +334,7 @@ jobs:
     name: arm64-pc-windows-msvc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -24,7 +24,7 @@ jobs:
       has-changes: ${{ steps.check.outputs.has-changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
@@ -117,7 +117,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
@@ -177,7 +177,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
@@ -227,7 +227,7 @@ jobs:
     name: x86-64 Apple Darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
@@ -291,7 +291,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Login to GitHub Container Registry
@@ -378,7 +378,7 @@ jobs:
     name: arm64 Windows MSVC
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -24,7 +24,7 @@ jobs:
       has-changes: ${{ steps.check.outputs.has-changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Free disk space
@@ -186,7 +186,7 @@ jobs:
     name: x86-64 OpenBSD 7.8
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Free disk space
@@ -304,7 +304,7 @@ jobs:
     name: x86-64 DragonFly BSD 6.4.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Free disk space

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -24,7 +24,7 @@ jobs:
       has-changes: ${{ steps.check.outputs.has-changes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
@@ -127,7 +127,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -41,7 +41,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -73,7 +73,7 @@ jobs:
     name: arm64 Apple Darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -108,7 +108,7 @@ jobs:
     name: x86-64 Windows MSVC
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
@@ -57,7 +57,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Verify CHANGELOG
         uses: docker://ghcr.io/ponylang/changelog-tool:release
         with:

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -28,7 +28,7 @@ jobs:
       options: --user pony
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/rebuild-stdlib-builder.yml
+++ b/.github/workflows/rebuild-stdlib-builder.yml
@@ -23,6 +23,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Build and push
         run: bash .ci-dockerfiles/stdlib-builder/build-and-push.bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -136,7 +136,7 @@ jobs:
     name: ${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -191,7 +191,7 @@ jobs:
     name: x86-64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -229,7 +229,7 @@ jobs:
     name: arm64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v4
@@ -270,7 +270,7 @@ jobs:
     name: x86-64-pc-windows-msvc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
@@ -317,7 +317,7 @@ jobs:
     name: arm64-pc-windows-msvc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
@@ -154,7 +154,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Login to GitHub Container Registry

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -34,7 +34,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
@@ -95,7 +95,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -37,7 +37,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
@@ -153,7 +153,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Login to GitHub Container Registry

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -34,7 +34,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
@@ -95,7 +95,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -37,7 +37,7 @@ jobs:
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -16,7 +16,7 @@ jobs:
     name: x86-64-pc-windows-msvc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'

--- a/.github/workflows/test-with-latest-tools.yml
+++ b/.github/workflows/test-with-latest-tools.yml
@@ -23,7 +23,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Build and Push
         run: bash .ci-dockerfiles/x86-64-unknown-linux-arch-builder/build-and-push.bash
       - name: Send alert on failure
@@ -48,7 +48,7 @@ jobs:
       options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Build Libs
         run: make libs build_flags=-j8
       - name: Build Debug Runtime

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -36,7 +36,7 @@ jobs:
       options: --user pony
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: cache-libs
         uses: actions/cache@v4
@@ -73,7 +73,7 @@ jobs:
     name: ${{ matrix.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: cache-libs
         uses: actions/cache@v4
@@ -108,7 +108,7 @@ jobs:
     name: x86-64 Apple Darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
         uses: actions/cache@v4
@@ -127,7 +127,7 @@ jobs:
     name: arm64 Apple Darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
         uses: actions/cache@v4
@@ -146,7 +146,7 @@ jobs:
     name: x86-64 Windows MSVC
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
         uses: actions/cache@v4
@@ -165,7 +165,7 @@ jobs:
     name: arm64 Windows MSVC
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
         uses: actions/cache@v4


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.