### PR TITLE
Upgrade actions/cache to v5.0.3

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -61,7 +61,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -132,7 +132,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -149,7 +149,7 @@ jobs:
             make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -187,7 +187,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -198,7 +198,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -244,7 +244,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -286,7 +286,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -297,7 +297,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -340,7 +340,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -351,7 +351,7 @@ jobs:
         run: .\make.ps1 -Command libs -Arch ARM64
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -62,7 +62,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -122,7 +122,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -182,7 +182,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -232,7 +232,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -304,7 +304,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -383,7 +383,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -75,7 +75,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -114,7 +114,7 @@ jobs:
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -84,7 +84,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -147,7 +147,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -164,7 +164,7 @@ jobs:
             make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -194,7 +194,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -205,7 +205,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -232,7 +232,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -243,7 +243,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -277,7 +277,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -288,7 +288,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -323,7 +323,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -334,7 +334,7 @@ jobs:
         run: .\make.ps1 -Command libs -Arch ARM64
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -78,7 +78,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -167,7 +167,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -184,7 +184,7 @@ jobs:
             make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -50,7 +50,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -100,7 +100,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -111,7 +111,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -46,7 +46,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -57,7 +57,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -67,7 +67,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -78,7 +78,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -166,7 +166,7 @@ jobs:
         run: docker pull ${{ matrix.image }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -183,7 +183,7 @@ jobs:
             make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -39,7 +39,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -50,7 +50,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs
@@ -100,7 +100,7 @@ jobs:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -111,7 +111,7 @@ jobs:
         run: make libs build_flags=-j8
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -46,7 +46,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -57,7 +57,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -23,7 +23,7 @@ jobs:
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5.0.3
         with:
           path: |
             build/libs
@@ -34,7 +34,7 @@ jobs:
         run: .\make.ps1 -Command libs
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5.0.3
         with:
           path: |
             build/libs

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: cache-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: cache-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs
@@ -130,7 +130,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs
@@ -149,7 +149,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: |
             build/libs


### PR DESCRIPTION
actions/cache v4 is deprecated. Upgrades all 14 workflow files to v5.0.3.

The only breaking change in v5 is the Node.js 24 upgrade, which requires
Actions Runner >= 2.327.1 — satisfied by all our GitHub-hosted runners.