### PR TITLE
Add pony-doc and pony-lint to Windows distribution

### DIFF
--- a/.release-notes/add-pony-doc-and-pony-lint-to-windows-distribution.md
+++ b/.release-notes/add-pony-doc-and-pony-lint-to-windows-distribution.md
@@ -1,0 +1,3 @@
+## Add pony-doc and pony-lint to Windows distribution
+
+pony-doc and pony-lint were accidentally left out of the Windows distribution packages. Both tools were being compiled during the Windows build but then removed during packaging. They are now included alongside ponyc and pony-lsp.

--- a/make.ps1
+++ b/make.ps1
@@ -592,7 +592,7 @@ switch ($Command.ToLower())
         Write-Output "Creating $buildDir\..\$package"
 
         # Remove unneeded files; we do it this way because Compress-Archive cannot add a single file to anything other than the root directory
-        Get-ChildItem -File -Path "$Prefix\bin\*" | Where-Object { $_.Name -notin 'ponyc.exe','pony-lsp.exe' } | Remove-Item
+        Get-ChildItem -File -Path "$Prefix\bin\*" | Where-Object { $_.Name -notin 'ponyc.exe','pony-doc.exe','pony-lint.exe','pony-lsp.exe' } | Remove-Item
         Compress-Archive -Path "$Prefix\bin", "$Prefix\lib", "$Prefix\packages", "$Prefix\examples" -DestinationPath "$buildDir\..\$package" -Force
         break
     }
@@ -602,7 +602,7 @@ switch ($Command.ToLower())
         Write-Output "Creating $buildDir\..\$package"
 
         # Remove unneeded files; we do it this way because Compress-Archive cannot add a single file to anything other than the root directory
-        Get-ChildItem -File -Path "$Prefix\bin\*" | Where-Object { $_.Name -notin 'ponyc.exe','pony-lsp.exe' } | Remove-Item
+        Get-ChildItem -File -Path "$Prefix\bin\*" | Where-Object { $_.Name -notin 'ponyc.exe','pony-doc.exe','pony-lint.exe','pony-lsp.exe' } | Remove-Item
         Compress-Archive -Path "$Prefix\bin", "$Prefix\lib", "$Prefix\packages", "$Prefix\examples" -DestinationPath "$buildDir\..\$package" -Force
         break
     }


### PR DESCRIPTION
pony-doc and pony-lint were being compiled during the Windows build but the packaging script in make.ps1 filtered them out, keeping only ponyc.exe and pony-lsp.exe. This adds both tools to the x86-64 and arm64 Windows packages.