### PR TITLE
Upgrade docker actions to v4

### DIFF
--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -34,12 +34,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -57,12 +57,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -80,12 +80,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -103,12 +103,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -126,12 +126,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -149,12 +149,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -172,12 +172,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -195,12 +195,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -218,12 +218,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -241,12 +241,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -264,12 +264,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -30,12 +30,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -59,12 +59,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -90,12 +90,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -295,7 +295,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
       - name: Docker build
         run: |
           docker buildx create --name multiplatform --driver docker-container --use --bootstrap
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Set up Docker Buildx
         # v3.10.0
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+        uses: docker/setup-buildx-action@v4
       - name: Docker build
         run: |
           docker buildx create --name multiplatform --driver docker-container --use --bootstrap

--- a/.github/workflows/rebuild-stdlib-builder.yml
+++ b/.github/workflows/rebuild-stdlib-builder.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -158,7 +158,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-with-latest-tools.yml
+++ b/.github/workflows/test-with-latest-tools.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Login to GitHub Container Registry
         # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -84,7 +84,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Login to GitHub Container Registry
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
The v3 line of both docker/login-action and docker/setup-buildx-action uses Node.js 20, which is deprecated by GitHub Actions. This upgrades all occurrences of both actions to v4, which uses Node.js 24.

- `docker/login-action` — upgraded from pinned SHA (`5139682d...`) and `@v3` to `@v4`
- `docker/setup-buildx-action` — upgraded from pinned SHA (`b5ca5143...`) and `@v3` to `@v4`

45 occurrences across 12 workflow files.