### PR TITLE
Install ca_root_nss on DragonFly BSD CI

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -478,7 +478,7 @@ jobs:
           # Install packages (now goes to /build disk via symlink)
           ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 root@localhost /bin/sh <<'EOF'
           set -e
-          pkg install -y cmake gmake git python3 cxx_atomics rsync gcc13
+          pkg install -y cmake gmake git python3 cxx_atomics rsync gcc13 ca_root_nss
           pkg clean -ay
           git config --global --add safe.directory /build/ponyc
           EOF


### PR DESCRIPTION
The DragonFly BSD tier 3 CI job fails to download googletest and gbenchmark during `make libs` because CMake's curl can't verify GitHub's TLS certificate — DragonFly doesn't ship CA certificates in the base system.

The fix is to install `ca_root_nss` (Mozilla's CA bundle) alongside the other build dependencies. OpenBSD doesn't need this — it ships `/etc/ssl/cert.pem` in base since 5.7.