### PR TITLE
Fix deprecated createTargetMachine call in host.cc

### DIFF
--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -51,7 +51,7 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
 
   Target* t = reinterpret_cast<Target*>(target);
 
-  TargetMachine* m = t->createTargetMachine(opt->triple, opt->cpu,
+  TargetMachine* m = t->createTargetMachine(Triple(opt->triple), opt->cpu,
     opt->features, options, reloc, std::nullopt, opt_level, false);
 
   return reinterpret_cast<LLVMTargetMachineRef>(m);


### PR DESCRIPTION
Use the Triple-accepting overload of createTargetMachine instead of the deprecated StringRef overload. Same pattern already applied throughout genopt.cc.