### PR TITLE
Fix tool link failures caused by build ordering race

### DIFF
--- a/tools/pony-doc/CMakeLists.txt
+++ b/tools/pony-doc/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-doc ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABLE})
+add_dependencies(tools.pony-doc libponyc-standalone)
 
 file(GLOB_RECURSE DOC_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABLE}

--- a/tools/pony-lint/CMakeLists.txt
+++ b/tools/pony-lint/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-lint ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LINT_EXECUTABLE})
+add_dependencies(tools.pony-lint libponyc-standalone)
 
 file(GLOB_RECURSE LINT_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LINT_EXECUTABLE}

--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-lsp ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE})
+add_dependencies(tools.pony-lsp libponyc-standalone)
 
 # TODO STA: --path entries are temporary until a ponyc bug is fixed.
 file(GLOB_RECURSE LSP_SOURCES CONFIGURE_DEPENDS "*.pony")


### PR DESCRIPTION
The pony-doc, pony-lint, and pony-lsp CMake targets only declared a dependency on the ponyc executable, not on libponyc-standalone. With parallel builds, CMake could start linking a tool before libponyc-standalone had been built, causing `ld: error: unable to find library -lponyc-standalone`.

Adds `add_dependencies` on `libponyc-standalone` to all three tool targets.

Observed on the OpenBSD Tier 3 CI: https://github.com/ponylang/ponyc/actions/runs/23079739683/job/67059483498