### PR TITLE
Fix DragonFly BSD CI SSL certificate lookup

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -492,6 +492,7 @@ jobs:
           set -e
           export CC=/usr/local/bin/gcc13
           export CXX=/usr/local/bin/g++13
+          export SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
           cd /build/ponyc
           gmake libs build_flags=-j4
           rm -rf build/build_libs


### PR DESCRIPTION
PR #5022 installed `ca_root_nss` to provide CA certificates on DragonFly BSD, but CMake's internal curl doesn't search `/usr/local/share/certs/` by default. The build fails downloading gbenchmark/gtest with "SSL certificate problem: unable to get local issuer certificate."

Setting `SSL_CERT_FILE` points curl to the installed CA bundle. FreeBSD doesn't need this because it ships `/etc/ssl/cert.pem` in the base system.