### PR TITLE
Fix pony-doc link failure on OpenBSD due to missing zlib

### DIFF
--- a/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
@@ -1,5 +1,5 @@
 use "lib:ponyc-standalone"
-use "lib:z" if not (windows or openbsd)
+use "lib:z" if not windows
 use "lib:c++" if osx
 use "files"
 


### PR DESCRIPTION
When OpenBSD was added as a tier 3 target, libponyc-standalone was enabled but the `use "lib:z"` directive in pony_compiler kept OpenBSD excluded under the assumption that the system linker would resolve zlib automatically. It doesn't — LLVM's lld code in libponyc-standalone references zlib symbols (`adler32`, `deflate`, `compress2`, `crc32`) for ELF section compression, and they need explicit `-lz` on OpenBSD just like every other POSIX platform.

Removes `openbsd` from the zlib exclusion guard so pony-doc (and pony-lint, pony-lsp) link successfully on OpenBSD.