### PR TITLE
Fix DragonFly BSD CI libstdc++ version mismatch

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -492,6 +492,7 @@ jobs:
           set -e
           export CC=/usr/local/bin/gcc13
           export CXX=/usr/local/bin/g++13
+          export LD_LIBRARY_PATH=/usr/local/lib/gcc13
           export SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
           cd /build/ponyc
           gmake libs build_flags=-j4


### PR DESCRIPTION
DragonFly BSD has both gcc11 (a package dependency) and gcc13 installed. LLVM is built with gcc13, so its tools like `llc` link against gcc13's libstdc++. At runtime, the dynamic linker finds gcc11's `libstdc++.so.6` first, which lacks `GLIBCXX_3.4.30`, causing the build to fail when generating `except_try_catch.o`:

```
/usr/local/lib/gcc11/libstdc++.so.6: version GLIBCXX_3.4.30 required by /build/ponyc/build/libs/bin/llc not found
```

Setting `LD_LIBRARY_PATH=/usr/local/lib/gcc13` ensures the linker finds gcc13's libstdc++.