### PR TITLE
Fix ffi-libponyc-standalone link failure on OpenBSD

### DIFF
--- a/test/full-program-tests/ffi-libponyc-standalone/main.pony
+++ b/test/full-program-tests/ffi-libponyc-standalone/main.pony
@@ -1,5 +1,5 @@
 use "lib:ponyc-standalone"
-use "lib:z" if not (windows or openbsd)
+use "lib:z" if not windows
 use "lib:c++" if osx
 
 use @token_new[NullablePointer[TokenStub]](token_id: TokenId)


### PR DESCRIPTION
PR #5026 fixed the identical missing zlib issue in pony-doc but missed the `ffi-libponyc-standalone` full-program test, which has the same `use "lib:z" if not (windows or openbsd)` guard. LLVM's lld references zlib symbols (`adler32`, `adler32_combine`) for ELF section compression, so OpenBSD needs explicit `-lz` just like other POSIX platforms.