### PR TITLE
Increase DragonFly BSD VM memory from 6GB to 8GB

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -349,7 +349,7 @@ jobs:
             -machine pc,accel=kvm \
             -cpu host \
             -smp 4 \
-            -m 6G \
+            -m 8G \
             -drive file=dfly.qcow2,format=qcow2,if=virtio \
             -drive file=dfly-data.qcow2,format=qcow2,if=virtio \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \


### PR DESCRIPTION
The DragonFly BSD CI job is getting OOM-killed (exit 137) during the release stdlib link phase. The debug build and tests complete fine, but by the time the release stdlib binary is linked, accumulated memory pressure from the earlier builds exceeds 6GB.

Bumps the QEMU VM memory from 6GB to 8GB. The FreeBSD and OpenBSD VMs remain at 6GB since they aren't hitting this issue.