### PR TITLE
Fix incorrect CLOCK_MONOTONIC value on OpenBSD

### DIFF
--- a/.release-notes/fix-openbsd-clock-monotonic.md
+++ b/.release-notes/fix-openbsd-clock-monotonic.md
@@ -1,0 +1,5 @@
+## Fix incorrect CLOCK_MONOTONIC value on OpenBSD
+
+On OpenBSD, `CLOCK_MONOTONIC` is defined as `3`, not `4` like on FreeBSD and DragonFly BSD. Pony's `time` package was using `4` for all BSDs, which meant that on OpenBSD, every call to `Time.nanos()`, `Time.millis()`, and `Time.micros()` was actually reading `CLOCK_THREAD_CPUTIME_ID` — the CPU time consumed by the calling thread — instead of monotonic wall-clock time.
+
+The practical result is that the `Timers` system, which relies on `Time.nanos()` for scheduling, would misfire on OpenBSD. Timers set for wall-clock durations would instead fire based on how much CPU time the scheduler thread had burned. For a mostly-idle program, a 60-second timer could take far longer than 60 seconds to fire. Any other code that depends on monotonic time would see similarly wrong values. Hilarity ensues.

--- a/packages/time/time.pony
+++ b/packages/time/time.pony
@@ -37,6 +37,8 @@ primitive _ClockMonotonic
   fun apply(): U32 =>
     ifdef linux then
       1
+    elseif openbsd then
+      3
     elseif bsd then
       4
     else


### PR DESCRIPTION
On OpenBSD, `CLOCK_MONOTONIC` is `3`, not `4` like FreeBSD and DragonFly BSD. The `_ClockMonotonic` primitive in the `time` package used `4` for all BSDs, so on OpenBSD every call to `Time.nanos()`, `Time.millis()`, and `Time.micros()` was reading `CLOCK_THREAD_CPUTIME_ID` instead of monotonic wall-clock time.

This breaks the `Timers` system and anything else that depends on monotonic time. A 60-second timer would fire based on how much CPU time the scheduler thread had burned, not how much wall time had passed. For a mostly-idle program, that could be a very long wait.