### PR TITLE
Update Google Benchmark from v1.9.1 to v1.9.5

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 # Libraries
 
-set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.9.1.tar.gz)
+set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz)
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_WERROR=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli


### PR DESCRIPTION
The "Test With Latest Tools" CI is failing because Clang 22.1.1 on Arch Linux now warns that `__COUNTER__` is a C2y extension (`-Wc2y-extensions`), which gets promoted to an error. Google Benchmark v1.9.5 includes [PR #2108](https://github.com/google/benchmark/pull/2108) that silences this warning.

Failed run: https://github.com/ponylang/ponyc/actions/runs/23110133307/job/67126108375