### PR TITLE
Don't allow --path to override standard library

### DIFF
--- a/.release-notes/dont-allow-path-to-override-stdlib.md
+++ b/.release-notes/dont-allow-path-to-override-stdlib.md
@@ -1,0 +1,7 @@
+## Don't allow --path to override standard library
+
+Previously, directories passed via `--path` on the ponyc command line were searched before the standard library when resolving package names. This meant a `--path` directory could contain a subdirectory that shadows a stdlib package. For example, `--path /usr/lib` would cause `/usr/lib/debug/` to shadow the stdlib `debug` package, breaking any code that depends on it.
+
+The standard library is now always searched first, before any `--path` entries. This is the same fix that was applied to `PONYPATH` in [#3779](https://github.com/ponylang/ponyc/issues/3779).
+
+If you were relying on `--path` to override a standard library package, that will no longer work.

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -738,17 +738,33 @@ static bool add_exec_dir(pass_opt_t* opt)
 
 bool package_init(pass_opt_t* opt)
 {
-  // package_add_paths for command line paths has already been done.
-  // Here, we add the package paths that are relative to the compiler location
-  // on disk. Then we append the paths from an optional environment variable
-  // PONYPATH. Previously we did PONYPATH before the compiler relative location,
-  // however, that allows packages to silently override the builtin module.
-  // See https://github.com/ponylang/ponyc/issues/3779
+  // Command line --path entries have already been added to
+  // package_search_paths during option parsing. We need the standard library
+  // paths to come first so that --path directories cannot shadow stdlib
+  // packages. This is the same approach used to fix PONYPATH shadowing in
+  // https://github.com/ponylang/ponyc/issues/3779 — save the existing paths,
+  // add stdlib paths first, then re-append the saved paths after.
+  strlist_t* cmdline_paths = opt->package_search_paths;
+  opt->package_search_paths = NULL;
+
   if(!add_exec_dir(opt))
   {
+    strlist_free(cmdline_paths);
     errorf(opt->check.errors, NULL, "Error adding package paths relative to ponyc binary location");
     return false;
   }
+
+  // Re-append command line paths after the standard library paths.
+  for(strlist_t* p = cmdline_paths; p != NULL; p = strlist_next(p))
+  {
+    const char* path = strlist_data(p);
+
+    if(strlist_find(opt->package_search_paths, path) == NULL)
+      opt->package_search_paths = strlist_append(opt->package_search_paths,
+        path);
+  }
+  strlist_free(cmdline_paths);
+
   package_add_paths(getenv("PONYPATH"), opt);
 
   // Finally we add OS specific paths.


### PR DESCRIPTION
The `--path` flag was searched before the standard library when resolving package names. This meant a `--path` directory could shadow stdlib packages. PR #5039 hit this on Alpine's musl CI where `--path /usr/lib` caused `/usr/lib/debug/` to shadow the stdlib `debug` package, cascading into build failures for `pony_check`, `json`, and `pony-lsp`.

Same fix as #3779 for `PONYPATH`: save command-line paths, add stdlib first, re-append command-line paths after.

This is a breaking change. If anyone was relying on `--path` to override a standard library package, that will no longer work.