### PR TITLE
Fix use-after-free crash in IOCP runtime on Windows

### DIFF
--- a/.release-notes/fix-iocp-use-after-free.md
+++ b/.release-notes/fix-iocp-use-after-free.md
@@ -1,0 +1,3 @@
+## Fix use-after-free crash in IOCP runtime on Windows
+
+When a Pony actor closed a TCP connection on Windows, pending I/O completions could fire after the connection's ASIO event and owning actor were already freed, causing an intermittent access violation crash. The runtime now detects these orphaned completions and cleans them up safely without touching freed memory.

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -242,6 +242,24 @@ static void CALLBACK iocp_callback(DWORD err, DWORD bytes, OVERLAPPED* ov)
 {
   iocp_t* iocp = (iocp_t*)ov;
 
+  // When CancelIoEx cancels pending I/O, the completion fires with
+  // ERROR_OPERATION_ABORTED. When closesocket closes a handle with pending
+  // I/O, the completion fires with ERROR_NETNAME_DELETED. In both cases the
+  // owning actor is tearing down — don't touch iocp->ev because the event
+  // or its owner may already be freed. Just clean up and return.
+  if(err == ERROR_OPERATION_ABORTED || err == ERROR_NETNAME_DELETED)
+  {
+    if(iocp->op == IOCP_ACCEPT)
+    {
+      iocp_accept_t* acc = (iocp_accept_t*)iocp;
+      closesocket(acc->ns);
+      iocp_accept_destroy(acc);
+    } else {
+      iocp_destroy(iocp);
+    }
+    return;
+  }
+
   switch(iocp->op)
   {
     case IOCP_CONNECT:


### PR DESCRIPTION
When a Pony actor closes a TCP connection on Windows, `pony_os_socket_close` calls `CancelIoEx` followed by `closesocket`. Both cause pending IOCP operations to complete asynchronously on thread pool threads. The completion callback (`iocp_callback`) then dereferences `iocp->ev->owner` to message the owning actor — but by the time the callback fires, the ASIO event and owning actor may already be freed.

The fix intercepts `ERROR_OPERATION_ABORTED` and `ERROR_NETNAME_DELETED` at the top of `iocp_callback` and cleans up the `iocp_t` struct without touching `iocp->ev`. For accept operations, the pre-created accept socket is closed before destroying the struct.

Reported as ponylang/lori#237.