### PR TITLE
Upgrade existing OpenBSD packages before installing new ones

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Install build dependencies
         run: |
           ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost \
-            "doas pkg_add cmake gmake git python%3 rsync--"
+            "doas pkg_add -u && doas pkg_add cmake gmake git python%3 rsync--"
       - name: Raise datasize limit
         run: |
           ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost \


### PR DESCRIPTION
The OpenBSD VM image ships with packages from a point-in-time snapshot. When the package repo moves ahead, transitive dependencies can have version skew — e.g., a newer python3 requiring a newer sqlite3 than what's installed. `pkg_add -u` brings existing packages up to the current repo state before installing anything new, preventing this class of failure.

Fixes the current CI failure: https://github.com/ponylang/ponyc/actions/runs/23371333696/job/68017538459

```
Can't install python-3.12.13 because of libraries
|library sqlite3.37.35 not found
| /usr/local/lib/libsqlite3.so.37.34 (sqlite3-3.50.4): minor is too small
```