### PR TITLE
Fix pony_os_ip_string returning NULL for valid IP addresses

### DIFF
--- a/.release-notes/fix-pony-os-ip-string.md
+++ b/.release-notes/fix-pony-os-ip-string.md
@@ -1,0 +1,5 @@
+## Fix pony_os_ip_string returning NULL for valid IP addresses
+
+The runtime function `pony_os_ip_string` had an inverted check on the result of `inet_ntop`. Since `inet_ntop` returns non-NULL on success, the inverted condition meant the function returned NULL for every valid IP address and only attempted to use the result buffer on failure.
+
+Any code that called `pony_os_ip_string` with a valid IPv4 or IPv6 address got NULL back. The most visible downstream effect was in the `ssl` library, where `X509.all_names()` calls this function to convert IP SANs from certificates into strings. The NULL result produced empty strings, corrupting the names array and breaking hostname verification for certificates that use IP SANs.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -1,6 +1,8 @@
 use "files"
 use "pony_test"
 
+use @pony_os_ip_string[Pointer[U8]](src: Pointer[U8] tag, len: I32)
+
 primitive TimeoutValue
   fun apply(): U64 =>
     ifdef windows then
@@ -16,6 +18,7 @@ actor \nodoc\ Main is TestList
 
   fun tag tests(test: PonyTest) =>
     // Tests below function across all systems and are listed alphabetically
+    test(_TestOsIpString)
     test(_TestTCPConnectionFailed)
     test(_TestTCPExpect)
     test(_TestTCPExpectOverBufferSize)
@@ -837,3 +840,27 @@ actor \nodoc\ _TCPConnectionToClosedServerFailedConnector
       host,
       port)
     h.dispose_when_done(connection)
+
+class \nodoc\ _TestOsIpString is UnitTest
+  """
+  Regression test for https://github.com/ponylang/ponyc/issues/5048.
+
+  pony_os_ip_string had an inverted inet_ntop check that returned NULL
+  for valid IP addresses.
+  """
+  fun name(): String => "net/pony_os_ip_string"
+
+  fun apply(h: TestHelper) =>
+    // IPv4: 127.0.0.1
+    let ipv4 = [as U8: 0x7F; 0x00; 0x00; 0x01]
+    let ipv4_str: String val = recover
+      String.from_cstring(@pony_os_ip_string(ipv4.cpointer(), I32(4)))
+    end
+    h.assert_eq[String](ipv4_str, "127.0.0.1")
+
+    // IPv6: ::1
+    let ipv6 = [as U8: 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 0; 1]
+    let ipv6_str: String val = recover
+      String.from_cstring(@pony_os_ip_string(ipv6.cpointer(), I32(16)))
+    end
+    h.assert_eq[String](ipv6_str, "::1")

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -877,7 +877,7 @@ PONY_API char* pony_os_ip_string(void* src, int len)
   if(family == -1)
     return NULL;
 
-  if(inet_ntop(family, src, dst, INET6_ADDRSTRLEN))
+  if(!inet_ntop(family, src, dst, INET6_ADDRSTRLEN))
     return NULL;
 
   size_t dstlen = strlen(dst);


### PR DESCRIPTION
`pony_os_ip_string` had an inverted `inet_ntop` check that returned NULL on success and fell through on failure. Any code calling it with a valid IP address got NULL back. Downstream, this broke the `ssl` library's `X509.all_names()` hostname verification for certificates with IP SANs.

Adds a regression test that round-trips known IPv4 and IPv6 bytes through the function.

Closes #5048