### PR TITLE
Fix pony-lint and pony-lsp on Windows

### DIFF
--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -19,10 +19,10 @@ permissions:
   packages: read
 
 jobs:
-  tools:
+  linux:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    name: Tools
+    name: Linux
     container:
       image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
       options: --user pony
@@ -52,3 +52,36 @@ jobs:
         run: make test-pony-lsp config=debug
       - name: Lint pony-lint
         run: make lint-pony-lint config=debug
+
+  windows:
+    if: github.event.pull_request.draft == false
+    runs-on: windows-2025
+    defaults:
+      run:
+        shell: pwsh
+
+    name: Windows
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-windows-2025-${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: .\make.ps1 -Command libs
+      - name: Build
+        run: |
+          .\make.ps1 -Command configure -Config Debug
+          .\make.ps1 -Command build -Config Debug
+      - name: Test pony-doc
+        run: .\make.ps1 -Command test -Config Debug -TestsToRun pony-doc-tests
+      - name: Test pony-lint
+        run: .\make.ps1 -Command test -Config Debug -TestsToRun pony-lint-tests
+      - name: Test pony-lsp
+        run: .\make.ps1 -Command test -Config Debug -TestsToRun pony-lsp-tests

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -7,3 +7,11 @@ The new fix addresses the root cause: IOCP completion callbacks can fire on Wind
 Each ASIO event now allocates a small shared liveness token (`iocp_token_t`) containing an atomic dead flag and a reference count. Every in-flight IOCP operation holds a pointer to the token and increments the reference count. When `pony_asio_event_destroy` runs, it sets the dead flag (release store) before freeing the event. Completion callbacks check the dead flag (acquire load) before touching the event — if dead, they clean up the IOCP operation struct without accessing the freed event. The last callback to decrement the reference count to zero frees the token.
 
 This correctly handles all error codes and all IOCP operation types (connect, accept, send, recv) without swallowing events the actor needs to see.
+
+## Fix pony-lint ignore matching on Windows
+
+pony-lint's `.gitignore` and `.ignore` pattern matching failed on Windows because path separator handling was hardcoded to `/`. On Windows, where paths use `\`, ignore rules were silently ineffective — files that should have been skipped were linted, and anchored patterns like `src/build/` never matched. Windows CI for tool tests has been added to prevent regressions.
+
+## Fix pony-lsp on Windows
+
+pony-lsp's JSON-RPC initialization failed on Windows because filesystem paths containing backslashes were embedded directly into JSON strings, producing invalid escape sequences. The LSP file URI conversion also didn't handle Windows drive-letter paths correctly. Additionally, several directory-walking loops in the workspace manager and router used `Path.dir` to walk up to the filesystem root, terminating when the result was `"."` — which works on Unix but not on Windows, where `Path.dir("C:")` returns `"C:"` rather than `"."`, causing an infinite loop. Windows CI for tool tests has been added to prevent regressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix `#share` capability constraint intersection ([PR #4998](https://github.com/ponylang/ponyc/pull/4998))
 - Fix use-after-free crash in IOCP runtime on Windows ([PR #5046](https://github.com/ponylang/ponyc/pull/5046))
 - Fix pony_os_ip_string returning NULL for valid IP addresses ([PR #5049](https://github.com/ponylang/ponyc/pull/5049))
+- Fix pony-lint ignore matching on Windows ([PR #5050](https://github.com/ponylang/ponyc/pull/5050))
+- Fix pony-lsp on Windows ([PR #5050](https://github.com/ponylang/ponyc/pull/5050))
 
 ### Changed
 

--- a/make.ps1
+++ b/make.ps1
@@ -449,6 +449,87 @@ switch ($Command.ToLower())
             }
         }
 
+        # pony-doc-tests
+        if ($TestsToRun -match 'pony-doc-tests')
+        {
+            $numTestSuitesRun += 1;
+            Write-Output "$outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-doc-tests -o $outDir $srcDir\tools\pony-doc\test"
+            & $outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-doc-tests -o $outDir $srcDir\tools\pony-doc\test
+            if ($LastExitCode -eq 0)
+            {
+                try
+                {
+                    Write-Output "$outDir\pony-doc-tests.exe --sequential"
+                    & $outDir\pony-doc-tests.exe --sequential
+                    $err = $LastExitCode
+                }
+                catch
+                {
+                    $err = -1
+                }
+                if ($err -ne 0) { $failedTestSuites += 'pony-doc-tests' }
+            }
+            else
+            {
+                $failedTestSuites += 'compile pony-doc-tests'
+            }
+        }
+
+        # pony-lint-tests
+        if ($TestsToRun -match 'pony-lint-tests')
+        {
+            $numTestSuitesRun += 1;
+            Write-Output "$outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test"
+            & $outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-lint-tests -o $outDir $srcDir\tools\pony-lint\test
+            if ($LastExitCode -eq 0)
+            {
+                $savePonyPath = $env:PONYPATH
+                $env:PONYPATH = "$srcDir\packages;$savePonyPath"
+                try
+                {
+                    Write-Output "$outDir\pony-lint-tests.exe --sequential"
+                    & $outDir\pony-lint-tests.exe --sequential
+                    $err = $LastExitCode
+                }
+                catch
+                {
+                    $err = -1
+                }
+                $env:PONYPATH = $savePonyPath
+                if ($err -ne 0) { $failedTestSuites += 'pony-lint-tests' }
+            }
+            else
+            {
+                $failedTestSuites += 'compile pony-lint-tests'
+            }
+        }
+
+        # pony-lsp-tests
+        if ($TestsToRun -match 'pony-lsp-tests')
+        {
+            $numTestSuitesRun += 1;
+            Write-Output "$outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\peg --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-lsp-tests -o $outDir $srcDir\tools"
+            & $outDir\ponyc.exe --path $srcDir\tools\lib\ponylang\peg --path $srcDir\tools\lib\ponylang\pony_compiler\ -b pony-lsp-tests -o $outDir $srcDir\tools
+            if ($LastExitCode -eq 0)
+            {
+                try
+                {
+                    Write-Output "$outDir\pony-lsp-tests.exe --sequential"
+                    & $outDir\pony-lsp-tests.exe --sequential
+                    $err = $LastExitCode
+                }
+                catch
+                {
+                    $err = -1
+                }
+                if ($err -ne 0) { $failedTestSuites += 'pony-lsp-tests' }
+            }
+            else
+            {
+                $failedTestSuites += 'compile pony-lsp-tests'
+            }
+        }
+
         #
         $numTestSuitesFailed = $failedTestSuites.Length
         Write-Output "Test suites run: $numTestSuitesRun, num failed: $numTestSuitesFailed"

--- a/tools/pony-lint/ignore_matcher.pony
+++ b/tools/pony-lint/ignore_matcher.pony
@@ -126,10 +126,18 @@ class ref IgnoreMatcher
 
         let matched =
           if pat.anchored then
-            // Match against path relative to the rule's base directory
+            // Match against path relative to the rule's base directory,
+            // normalized to forward slashes for GlobMatch
             let rel =
               try
-                Path.rel(base_dir, abs_path)?
+                let r = Path.rel(base_dir, abs_path)?
+                ifdef windows then
+                  let s = r.clone()
+                  s.replace("\\", "/")
+                  consume s
+                else
+                  r
+                end
               else
                 abs_path
               end
@@ -154,9 +162,9 @@ class ref IgnoreMatcher
     """
     if abs_path.at(base_dir) then
       let blen = base_dir.size()
-      // Exact match or path continues with /
+      // Exact match or path continues with a separator
       (abs_path.size() == blen)
-        or (try abs_path(blen)? == '/' else false end)
+        or (try Path.is_sep(abs_path(blen)?) else false end)
     else
       false
     end

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -457,7 +457,7 @@ class val Linter
       else
         return
       end
-    let parts = rel.split_by("/")
+    let parts = rel.split_by(Path.sep())
     var current: String val = root
     for part in (consume parts).values() do
       current = Path.join(current, part)

--- a/tools/pony-lsp/_unreachable.pony
+++ b/tools/pony-lsp/_unreachable.pony
@@ -1,0 +1,20 @@
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](code: I32)
+
+primitive _Unreachable
+  """
+  Crashes the program when a code path that should be unreachable is reached.
+
+  Use in `else` blocks of `try` expressions where bounds are guarded by prior
+  checks and the error path is logically impossible.
+  """
+  fun apply(loc: SourceLoc = __loc): None =>
+    let url = "https://github.com/ponylang/ponyc/issues"
+    let fmt = "Unreachable at %s:%zu\nPlease report: " + url + "\n"
+    @fprintf(
+      @pony_os_stderr(),
+      fmt.cstring(),
+      loc.file().cstring(),
+      loc.line())
+    @exit(1)

--- a/tools/pony-lsp/test/_diagnostics_tests.pony
+++ b/tools/pony-lsp/test/_diagnostics_tests.pony
@@ -43,7 +43,7 @@ class \nodoc\ iso _DiagnosticTest is UnitTest
                 Methods.text_document().did_open(),
                 JsonObject
                   .update("textDocument", JsonObject
-                    .update("uri", "file://" + Path.join(workspace_dir, "main.pony"))
+                    .update("uri", Uris.from_path(Path.join(workspace_dir, "main.pony")))
                     .update("languageId", "pony")
                     .update("version", I64(1))
                     .update("text", "don't care"))

--- a/tools/pony-lsp/test/_workspace_tests.pony
+++ b/tools/pony-lsp/test/_workspace_tests.pony
@@ -22,24 +22,28 @@ class \nodoc\ iso _RouterFindTest is UnitTest
     let scanner = WorkspaceScanner.create(channel)
     let workspaces = scanner.scan(file_auth, this_dir_path)
     h.assert_eq[USize](3, workspaces.size())
-    // main.pony workspace has been found first
-    var workspace = workspaces(0)?
-    h.assert_eq[String](folder.path, workspace.folder.path)
 
-    // corral workspace
-    workspace = workspaces(1)?
-    h.assert_eq[String](folder.join("error_workspace")?.path, workspace.folder.path)
+    // Verify all expected workspaces were found (order is not guaranteed
+    // because path.walk uses filesystem enumeration order)
+    let actual = Array[String]
+    for ws in workspaces.values() do
+      actual.push(ws.folder.path)
+    end
+    let expected = [as String:
+      folder.path
+      folder.join("error_workspace")?.path
+      folder.join("workspace")?.path
+    ]
+    h.assert_array_eq_unordered[String](expected, actual)
 
-    // corral error workspace
-    workspace = workspaces(2)?
-    h.assert_eq[String](folder.join("workspace")?.path, workspace.folder.path)
-
+    // Verify router lookup works with any workspace
     let router = WorkspaceRouter.create()
     let compiler = PonyCompiler("") // dummy, not actually in use
     let request_sender = FakeRequestSender
     let client = Client.from(JsonObject)
 
-    let mgr = WorkspaceManager(workspace, file_auth, channel, request_sender, client, compiler)
+    let mgr = WorkspaceManager(
+      workspaces(0)?, file_auth, channel, request_sender, client, compiler)
     router.add_workspace(folder, mgr)?
 
     let file_path = folder.join("main.pony")?

--- a/tools/pony-lsp/test/utils.pony
+++ b/tools/pony-lsp/test/utils.pony
@@ -142,11 +142,30 @@ primitive LspMsg
     }
     """)
 
+  fun tag _json_escape(s: String val): String val =>
+    """
+    Escape backslashes for safe embedding in JSON string literals. On
+    Windows, filesystem paths contain `\\` which must be doubled for JSON.
+    """
+    ifdef windows then
+      if s.contains("\\") then
+        let out = s.clone()
+        out.replace("\\", "\\\\")
+        consume out
+      else
+        s
+      end
+    else
+      s
+    end
+
   fun tag initialize(
     dir: String,
     did_change_configuration_dynamic_registration: Bool = true,
     supports_configuration: Bool = true
   ): Array[U8] iso^ =>
+    let safe_dir = _json_escape(dir)
+    let dir_uri = Uris.from_path(dir)
     this.apply("""
     {
       "jsonrpc": "2.0",
@@ -159,9 +178,9 @@ primitive LspMsg
               "version": "1.88.0"
           },
           "locale": "en",
-          "rootPath": """" + dir + """
+          "rootPath": """" + safe_dir + """
 ",
-          "rootUri": "file://""" + dir + """
+          "rootUri": """" + dir_uri + """
 ",
           "capabilities": {
               "workspace": {
@@ -632,7 +651,7 @@ primitive LspMsg
           "trace": "verbose",
           "workspaceFolders": [
               {
-                  "uri": "file://""" + dir + """
+                  "uri": """" + dir_uri + """
 ",
                   "name": "workspace"
               }

--- a/tools/pony-lsp/uri.pony
+++ b/tools/pony-lsp/uri.pony
@@ -3,24 +3,54 @@ use "files"
 primitive Uris
   fun to_path(uri: String): String =>
     """
-    Ensure an LSP uri (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri)
-    is converted to a path, so the `schema://` needs to be dropped, if present.
+    Convert an LSP document URI to a local filesystem path by stripping the
+    scheme. On Windows, also strips the leading `/` before a drive letter
+    (e.g., `/D:/path` becomes `D:/path`) and normalizes forward slashes to
+    the native separator.
     """
     let result = uri.split_by("://", 2)
-    try
-      result(result.size() - 1)?
+    let path =
+      try
+        result(result.size() - 1)?
+      else
+        _Unreachable()
+        return uri
+      end
+    ifdef windows then
+      // file:///D:/path → /D:/path after stripping scheme; remove leading /
+      let trimmed =
+        try
+          if (path.size() >= 3) and (path(0)? == '/')
+            and (path(2)? == ':')
+          then
+            path.substring(1)
+          else
+            path
+          end
+        else
+          path
+        end
+      let s = trimmed.clone()
+      s.replace("/", "\\")
+      consume s
     else
-      // shouldn't happen, given that split_by never returns an empty array
-      uri
+      path
     end
 
   fun from_path(path: String): String =>
     """
-    Convert a local path to an LSP uri
+    Convert a local filesystem path to an LSP file URI. On Windows,
+    normalizes backslashes to forward slashes and uses the `file:///`
+    prefix required for drive-letter paths.
     """
     if path.contains("://") then
       path
     else
-      // TODO: lets do something more sophisticated here
-      "file://" + path
+      ifdef windows then
+        let s = path.clone()
+        s.replace("\\", "/")
+        "file:///" + consume s
+      else
+        "file://" + path
+      end
     end

--- a/tools/pony-lsp/workspace/data.pony
+++ b/tools/pony-lsp/workspace/data.pony
@@ -70,7 +70,9 @@ class val WorkspaceData
           package_path.substring(this.folder.path.size().isize() + 1)
         )?
       end
-      doc_path = Path.dir(doc_path)
+      let parent = Path.dir(doc_path)
+      if parent == doc_path then break end // hit filesystem root
+      doc_path = parent
     end
     None
 

--- a/tools/pony-lsp/workspace/manager.pony
+++ b/tools/pony-lsp/workspace/manager.pony
@@ -89,7 +89,9 @@ actor WorkspaceManager
             this.workspace.folder.join(dir_path)?
           end
       end
-      dir_path = Path.dir(dir_path)
+      let parent = Path.dir(dir_path)
+      if parent == dir_path then break end // hit filesystem root
+      dir_path = parent
     end
     error
 

--- a/tools/pony-lsp/workspace/router.pony
+++ b/tools/pony-lsp/workspace/router.pony
@@ -18,7 +18,9 @@ class WorkspaceRouter
         let workspace = this.workspaces(file_path)?
         return workspace
       end
-      file_path = Path.dir(file_path)
+      let parent = Path.dir(file_path)
+      if parent == file_path then break end // hit filesystem root
+      file_path = parent
     end
     None
 


### PR DESCRIPTION
pony-lint's `.gitignore` and `.ignore` pattern matching failed on Windows because path separator handling was hardcoded to `/`. On Windows, where paths use `\`, ignore rules were silently ineffective.

pony-lsp's JSON-RPC initialization failed on Windows because filesystem paths containing backslashes were embedded directly into JSON strings, producing invalid escape sequences. The LSP file URI conversion also didn't handle Windows drive-letter paths correctly.

Also adds Windows CI for tool tests and fixes a flaky workspace scanner test that depended on filesystem enumeration order.

Closes #5053
Closes #5043