### PR TITLE
Fix IOCP use-after-free crash

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,9 @@
+## Fix IOCP use-after-free crash
+
+The fix for this issue in 0.62.0 was incomplete. That fix checked for specific Windows error codes (`ERROR_OPERATION_ABORTED` and `ERROR_NETNAME_DELETED`) in the IOCP completion callback to detect orphaned I/O operations. However, Windows can deliver completions with other error codes after the socket is closed, and `ERROR_NETNAME_DELETED` can also arrive from legitimate remote peer disconnects — making error-code matching the wrong approach entirely.
+
+The new fix addresses the root cause: IOCP completion callbacks can fire on Windows thread pool threads after the owning actor has destroyed the ASIO event via `pony_asio_event_destroy`, leaving the callback with a dangling pointer to freed memory.
+
+Each ASIO event now allocates a small shared liveness token (`iocp_token_t`) containing an atomic dead flag and a reference count. Every in-flight IOCP operation holds a pointer to the token and increments the reference count. When `pony_asio_event_destroy` runs, it sets the dead flag (release store) before freeing the event. Completion callbacks check the dead flag (acquire load) before touching the event — if dead, they clean up the IOCP operation struct without accessing the freed event. The last callback to decrement the reference count to zero frees the token.
+
+This correctly handles all error codes and all IOCP operation types (connect, accept, send, recv) without swallowing events the actor needs to see.

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -1,3 +1,5 @@
+#define PONY_WANT_ATOMIC_DEFS
+
 #include "event.h"
 #include "asio.h"
 #include "../actor/actor.h"
@@ -29,6 +31,12 @@ PONY_API asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
   ev->nsec = nsec;
   ev->writeable = false;
   ev->readable = false;
+
+#ifdef PLATFORM_IS_WINDOWS
+  ev->iocp_token = POOL_ALLOC(iocp_token_t);
+  atomic_store_explicit(&ev->iocp_token->dead, false, memory_order_relaxed);
+  atomic_store_explicit(&ev->iocp_token->refcount, 0, memory_order_relaxed);
+#endif
 
   owner->live_asio_events = owner->live_asio_events + 1;
 
@@ -63,6 +71,15 @@ PONY_API void pony_asio_event_destroy(asio_event_t* ev)
 
   ev->flags = ASIO_DESTROYED;
 
+#ifdef PLATFORM_IS_WINDOWS
+  // Grab the token pointer before freeing the event.
+  iocp_token_t* token = ev->iocp_token;
+
+  // Mark the token as dead. Any IOCP callback that hasn't yet checked the
+  // token will see this (acquire/release) and skip the event.
+  atomic_store_explicit(&token->dead, true, memory_order_release);
+#endif
+
   // When we let go of an event, we treat it as if we had received it back from
   // the asio thread.
   pony_ctx_t* ctx = pony_ctx();
@@ -74,6 +91,13 @@ PONY_API void pony_asio_event_destroy(asio_event_t* ev)
   ev->owner->live_asio_events = ev->owner->live_asio_events - 1;
 
   POOL_FREE(asio_event_t, ev);
+
+#ifdef PLATFORM_IS_WINDOWS
+  // Free the token if no IOCP callbacks are outstanding. If callbacks are
+  // still in flight, the last one to complete will free the token.
+  if(atomic_load_explicit(&token->refcount, memory_order_acquire) == 0)
+    POOL_FREE(iocp_token_t, token);
+#endif
 }
 
 PONY_API int pony_asio_event_fd(asio_event_t* ev)

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -8,6 +8,22 @@
 
 PONY_EXTERN_C_BEGIN
 
+#ifdef PLATFORM_IS_WINDOWS
+/** Shared liveness token for IOCP operations.
+ *
+ *  IOCP completion callbacks fire on Windows thread pool threads after the
+ *  owning actor may have destroyed the event. Each in-flight IOCP operation
+ *  holds a pointer to this token. The callback checks the dead flag before
+ *  touching the event; the refcount tracks how many callbacks are outstanding
+ *  so the token itself can be freed when no longer needed.
+ */
+typedef struct iocp_token_t
+{
+  PONY_ATOMIC(bool) dead;
+  PONY_ATOMIC(uint32_t) refcount;
+} iocp_token_t;
+#endif
+
 /** Definiton of an ASIO event.
  *
  *  Used to carry user defined data for event notifications.
@@ -26,6 +42,7 @@ typedef struct asio_event_t
 
 #ifdef PLATFORM_IS_WINDOWS
   HANDLE timer;         /* timer handle */
+  iocp_token_t* iocp_token; /* shared liveness token for IOCP callbacks */
 #endif
 } asio_event_t;
 

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -1,3 +1,5 @@
+#define PONY_WANT_ATOMIC_DEFS
+
 #ifdef __linux__
 #define _GNU_SOURCE
 #endif
@@ -198,6 +200,7 @@ typedef struct iocp_t
   iocp_op_t op;
   int from_len;
   asio_event_t* ev;
+  iocp_token_t* token;
 } iocp_t;
 
 typedef struct iocp_accept_t
@@ -214,12 +217,35 @@ static iocp_t* iocp_create(iocp_op_t op, asio_event_t* ev)
   iocp->op = op;
   iocp->ev = ev;
 
+  if(ev != NULL)
+  {
+    iocp->token = ev->iocp_token;
+    atomic_fetch_add_explicit(&iocp->token->refcount, 1, memory_order_relaxed);
+  } else {
+    iocp->token = NULL;
+  }
+
   return iocp;
+}
+
+static void iocp_release_token(iocp_token_t* token)
+{
+  if(atomic_fetch_sub_explicit(&token->refcount, 1, memory_order_acq_rel) == 1)
+  {
+    // We were the last outstanding operation. If the event has been destroyed,
+    // nobody else will free the token — we do it.
+    if(atomic_load_explicit(&token->dead, memory_order_acquire))
+      POOL_FREE(iocp_token_t, token);
+  }
 }
 
 static void iocp_destroy(iocp_t* iocp)
 {
+  iocp_token_t* token = iocp->token;
   POOL_FREE(iocp_t, iocp);
+
+  if(token != NULL)
+    iocp_release_token(token);
 }
 
 static iocp_accept_t* iocp_accept_create(SOCKET s, asio_event_t* ev)
@@ -228,6 +254,9 @@ static iocp_accept_t* iocp_accept_create(SOCKET s, asio_event_t* ev)
   memset(&iocp->iocp.ov, 0, sizeof(OVERLAPPED));
   iocp->iocp.op = IOCP_ACCEPT;
   iocp->iocp.ev = ev;
+  iocp->iocp.token = ev->iocp_token;
+  atomic_fetch_add_explicit(&iocp->iocp.token->refcount, 1,
+    memory_order_relaxed);
   iocp->ns = s;
 
   return iocp;
@@ -235,19 +264,23 @@ static iocp_accept_t* iocp_accept_create(SOCKET s, asio_event_t* ev)
 
 static void iocp_accept_destroy(iocp_accept_t* iocp)
 {
+  iocp_token_t* token = iocp->iocp.token;
   POOL_FREE(iocp_accept_t, iocp);
+
+  if(token != NULL)
+    iocp_release_token(token);
 }
 
 static void CALLBACK iocp_callback(DWORD err, DWORD bytes, OVERLAPPED* ov)
 {
   iocp_t* iocp = (iocp_t*)ov;
+  iocp_token_t* token = iocp->token;
 
-  // When CancelIoEx cancels pending I/O, the completion fires with
-  // ERROR_OPERATION_ABORTED. When closesocket closes a handle with pending
-  // I/O, the completion fires with ERROR_NETNAME_DELETED. In both cases the
-  // owning actor is tearing down — don't touch iocp->ev because the event
-  // or its owner may already be freed. Just clean up and return.
-  if(err == ERROR_OPERATION_ABORTED || err == ERROR_NETNAME_DELETED)
+  // Check whether the event has been destroyed. If so, the event and its
+  // owning actor may already be freed — don't touch iocp->ev.
+  // token is NULL for IOCP_NOP (e.g. UDP sendto) which has no event.
+  if((token != NULL) &&
+    atomic_load_explicit(&token->dead, memory_order_acquire))
   {
     if(iocp->op == IOCP_ACCEPT)
     {
@@ -257,9 +290,11 @@ static void CALLBACK iocp_callback(DWORD err, DWORD bytes, OVERLAPPED* ov)
     } else {
       iocp_destroy(iocp);
     }
+
     return;
   }
 
+  // Event is alive — proceed normally.
   switch(iocp->op)
   {
     case IOCP_CONNECT:


### PR DESCRIPTION
The 0.62.0 fix for this was incomplete — it matched specific error codes (`ERROR_OPERATION_ABORTED` and `ERROR_NETNAME_DELETED`) but missed others, and `ERROR_NETNAME_DELETED` can also arrive from legitimate remote peer disconnects, making error-code matching the wrong approach.

This replaces the error-code approach with a shared liveness token. Each ASIO event allocates an `iocp_token_t` with an atomic dead flag and reference count. Every in-flight IOCP operation holds a pointer to the token and increments the refcount. When `pony_asio_event_destroy` runs, it sets the dead flag (release store) before freeing the event. Completion callbacks check the dead flag (acquire load) before touching the event — if dead, they clean up the IOCP struct without accessing freed memory. The last callback to decrement the refcount to zero frees the token.

This correctly handles all error codes and all IOCP operation types without swallowing events the actor needs to see.

Tested locally: lori test suite passes 72/72 with the fix; crashes reliably on unpatched ponyc. 30-minute stress loop in progress.