### PR TITLE
Add macOS arm64 tools testing to PR CI

### DIFF
--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -53,11 +53,11 @@ jobs:
       - name: Lint pony-lint
         run: make lint-pony-lint config=debug
 
-  arm64-macos:
+  macos:
     if: github.event.pull_request.draft == false
     runs-on: macos-26
 
-    name: arm64 Apple Darwin
+    name: macOS
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2


### PR DESCRIPTION
The pr-tools workflow tested pony-doc, pony-lint, and pony-lsp on Linux and Windows but not macOS. This adds an arm64 Apple Darwin job matching the tier 1 macOS coverage in pr-ponyc.