### PR TITLE
Remove redundant pony-doc CMake test target

### DIFF
--- a/tools/pony-doc/CMakeLists.txt
+++ b/tools/pony-doc/CMakeLists.txt
@@ -24,19 +24,3 @@ add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABL
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
-
-# Test target: compiles the test/ subdirectory with --path to access the
-# parent pony-doc package and the pony_compiler dependency.
-set(PONY_DOC_TEST_EXECUTABLE "pony-doc-tests${CMAKE_EXECUTABLE_SUFFIX}")
-
-add_custom_target(tools.pony-doc-tests DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_TEST_EXECUTABLE})
-
-add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_TEST_EXECUTABLE}
-  COMMAND_EXPAND_LISTS
-  COMMAND echo "Building pony-doc-tests..."
-  COMMAND $<TARGET_FILE:ponyc> --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -b ${PONY_DOC_TEST_EXECUTABLE} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}/test
-  DEPENDS
-    ${DOC_SOURCES}
-    $<TARGET_FILE:ponyc>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)


### PR DESCRIPTION
pony-lint and pony-lsp run tests exclusively via Makefile targets. pony-doc had an extra CMake test target (`tools.pony-doc-tests`) that was inconsistent with the other tools. Tests continue to run via the `test-pony-doc` Makefile target.

Closes #5044