### PR TITLE
Enforce documented maximum for --ponysuspendthreshold

### DIFF
--- a/.release-notes/enforce-ponysuspendthreshold-max.md
+++ b/.release-notes/enforce-ponysuspendthreshold-max.md
@@ -1,0 +1,5 @@
+## Enforce documented maximum for --ponysuspendthreshold
+
+The help text for `--ponysuspendthreshold` has always said the maximum value is 1000 ms, but the runtime never actually enforced it. You could pass any value and it would be accepted. Values above ~4294 would silently overflow during an internal conversion to CPU cycles, producing nonsensical thresholds.
+
+The documented maximum of 1000 ms is now enforced. Passing a value above 1000 on the command line will produce an error. Values set via `RuntimeOptions` are clamped to 1000.

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1658,9 +1658,11 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
 
   use_yield = !noyield;
 
-  // if thread suspend threshold is less then 1, then ensure it is 1
+  // clamp thread suspend threshold to documented range [1, 1000] ms
   if(thread_suspend_threshold < 1)
     thread_suspend_threshold = 1;
+  if(thread_suspend_threshold > 1000)
+    thread_suspend_threshold = 1000;
 
   // If no thread count is specified, use the available physical core count.
   if(threads == 0)
@@ -1673,7 +1675,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
   // convert to cycles for use with ponyint_cpu_tick()
   // 1 second = 2000000000 cycles (approx.)
   // based on same scale as ponyint_cpu_core_pause() uses
-  scheduler_suspend_threshold = thread_suspend_threshold * 1000000;
+  scheduler_suspend_threshold = (uint64_t)thread_suspend_threshold * 1000000;
 
   scheduler_count = threads;
   min_scheduler_count = min_threads;

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -207,7 +207,12 @@ static int parse_opts(int argc, char** argv, options_t* opt)
       case OPT_MAXTHREADS: if(parse_uint(&opt->threads, 1, s.arg_val)) err_out(id, "can't be less than 1"); break;
       case OPT_MINTHREADS: if(parse_uint(&opt->min_threads, 0, s.arg_val)) err_out(id, "can't be less than 0"); minthreads_set = true; break;
       case OPT_NOSCALE: opt->noscale = true; break;
-      case OPT_SUSPENDTHRESHOLD: if(parse_uint(&opt->thread_suspend_threshold, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
+      case OPT_SUSPENDTHRESHOLD:
+        if(parse_uint(&opt->thread_suspend_threshold, 1, s.arg_val))
+          err_out(id, "can't be less than 1");
+        if(opt->thread_suspend_threshold > 1000)
+          err_out(id, "can't be more than 1000");
+        break;
       case OPT_CDINTERVAL: if(parse_uint(&opt->cd_detect_interval, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
       case OPT_GCINITIAL: if(parse_size(&opt->gc_initial, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
       case OPT_GCFACTOR: if(parse_udouble(&opt->gc_factor, 1.0, s.arg_val)) err_out(id, "can't be less than 1.0"); break;


### PR DESCRIPTION
The help string for `--ponysuspendthreshold` has always said "max 1000 ms" but the runtime never enforced it. Values above ~4294 would silently overflow during the internal conversion to CPU cycles, producing nonsensical thresholds.

The CLI now errors on values outside [1, 1000]. Values set via `RuntimeOptions` are clamped to the same range. The multiplication is also cast to `uint64_t` to prevent overflow defensively.

Closes #3987