### PR TITLE
Fix compiler crash when calling methods on invalid shift expressions

### DIFF
--- a/.release-notes/fix-compiler-crash-chained-shift.md
+++ b/.release-notes/fix-compiler-crash-chained-shift.md
@@ -1,0 +1,3 @@
+## Fix compiler crash when calling methods on invalid shift expressions
+
+The compiler would crash with a segmentation fault when a method call was chained onto a bit-shift expression with an oversized shift amount. For example, `y.shr(33).string()` where `y` is a `U32` would crash instead of reporting the "shift amount greater than type width" error. The shift amount error was detected internally but the crash occurred before it could be reported. Standalone shift expressions like `y.shr(33)` were not affected and correctly produced an error message.

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -810,6 +810,13 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       case TK_BECHAIN:
       case TK_FUNCHAIN:
         args[0] = gen_expr(c, receiver);
+
+        if(args[0] == NULL)
+        {
+          ponyint_pool_free_size(buf_size, args);
+          return NULL;
+        }
+
         break;
 
       default:


### PR DESCRIPTION
When a method call is chained onto a bit-shift expression with an oversized shift amount (e.g., `y.shr(33).string()` where `y` is `U32`), the compiler crashed with a segfault in LLVM's IPSCCP pass instead of reporting the "shift amount greater than type width" error.

`gen_call()` didn't check for NULL after generating the receiver expression. The inner `shr` call correctly detected the error and returned NULL, but the outer `.string()` call continued building LLVM IR with that NULL as the receiver argument. The malformed IR then crashed LLVM before the error could be reported.

The fix adds a NULL check for the receiver, matching the existing pattern used for argument expressions.

Closes #3336