### PR TITLE
Enforce documented bounds for --ponycdinterval

### DIFF
--- a/.release-notes/enforce-ponycdinterval-bounds.md
+++ b/.release-notes/enforce-ponycdinterval-bounds.md
@@ -1,0 +1,5 @@
+## Enforce documented bounds for --ponycdinterval
+
+The help text for `--ponycdinterval` has always said the minimum is 10 ms and the maximum is 1000 ms, but the runtime never actually enforced either bound on the command line. You could pass any non-negative value and it would be silently clamped deep in the cycle detector initialization. Values above ~2147 would also overflow during an internal conversion to CPU cycles, producing nonsensical detection intervals.
+
+The documented bounds are now enforced. Passing a value outside [10, 1000] on the command line will produce an error. Values set via `RuntimeOptions` continue to be clamped to the valid range.

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -1236,7 +1236,7 @@ void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t detect_interval, bool force_
   // convert to cycles for use with ponyint_cpu_tick()
   // 1 second = 2000000000 cycles (approx.)
   // based on same scale as ponyint_cpu_core_pause() uses
-  d->detect_interval = detect_interval * 2000000;
+  d->detect_interval = (uint64_t)detect_interval * 2000000;
 
   // initialize last_checked
   d->last_checked = HASHMAP_BEGIN;

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -213,7 +213,12 @@ static int parse_opts(int argc, char** argv, options_t* opt)
         if(opt->thread_suspend_threshold > 1000)
           err_out(id, "can't be more than 1000");
         break;
-      case OPT_CDINTERVAL: if(parse_uint(&opt->cd_detect_interval, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
+      case OPT_CDINTERVAL:
+        if(parse_uint(&opt->cd_detect_interval, 10, s.arg_val))
+          err_out(id, "can't be less than 10");
+        if(opt->cd_detect_interval > 1000)
+          err_out(id, "can't be more than 1000");
+        break;
       case OPT_GCINITIAL: if(parse_size(&opt->gc_initial, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
       case OPT_GCFACTOR: if(parse_udouble(&opt->gc_factor, 1.0, s.arg_val)) err_out(id, "can't be less than 1.0"); break;
       case OPT_NOYIELD: opt->noyield = true; break;


### PR DESCRIPTION
The help text for `--ponycdinterval` has always said min 10 ms / max 1000 ms but the CLI accepted any non-negative value, silently relying on clamping deep in cycle detector initialization. Same treatment as #5061: error on the CLI for out-of-range values, clamp for the `RuntimeOptions` path, cast the multiplication to `uint64_t` defensively.

Closes #5062