### PR TITLE
Fix code generation failure for iftype with union return type

### DIFF
--- a/.release-notes/fix-iftype-union-codegen.md
+++ b/.release-notes/fix-iftype-union-codegen.md
@@ -1,0 +1,21 @@
+## Fix code generation failure for iftype with union return type
+
+Previously, using `iftype` in a function that returns a union type caused an internal compiler error during code generation:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    test[U8]()
+
+  fun test[T: U8](): (U8 | None) =>
+    iftype T <: U8 then
+      0
+    end
+```
+
+```
+Error:
+main.pony:5:3: internal failure: code generation failed for method Main_ref_test_U8_val_o
+```
+
+This has been fixed. Functions using `iftype` with union return types now compile and run correctly.

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -177,6 +177,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
 {
+  bool needed = is_result_needed(ast);
   AST_GET_CHILDREN(ast, left, right);
   AST_GET_CHILDREN(left, subtype, supertype, body);
 
@@ -190,10 +191,28 @@ LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
   ast_free_unattached(r_sub);
   ast_free_unattached(r_super);
 
-  if(is_sub)
-    return gen_expr(c, body);
+  ast_t* branch = is_sub ? body : right;
+  LLVMValueRef value = gen_expr(c, branch);
 
-  return gen_expr(c, right);
+  if(value == NULL || value == GEN_NOVALUE || value == GEN_NOTNEEDED)
+    return value;
+
+  // Cast the branch value to the iftype's overall type. Without this,
+  // returning a primitive (e.g. U8) from an iftype with a union result type
+  // (e.g. (U8 | None)) fails in gen_box because it receives the union type
+  // instead of the primitive's own type for boxing.
+  if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+  {
+    ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
+    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type)->c_type;
+
+    ast_t* branch_type = deferred_reify(reify, ast_type(branch), c->opt);
+    value = gen_assign_cast(c, c_t->use_type, value, branch_type);
+    ast_free_unattached(branch_type);
+    ast_free_unattached(type);
+  }
+
+  return value;
 }
 
 LLVMValueRef gen_while(compile_t* c, ast_t* ast)

--- a/test/full-program-tests/regression-3770/main.pony
+++ b/test/full-program-tests/regression-3770/main.pony
@@ -1,0 +1,22 @@
+actor Main
+  new create(env: Env) =>
+    let r1 = test_then[U8]()
+    let r2 = test_else[None]()
+
+    match (r1, r2)
+    | (U8(0), None) => None
+    else
+      env.exitcode(1)
+    end
+
+  fun test_then[T: U8](): (U8 | None) =>
+    iftype T <: U8 then
+      0
+    end
+
+  fun test_else[T: None](): (U8 | None) =>
+    iftype T <: U8 then
+      0
+    else
+      None
+    end


### PR DESCRIPTION
Using `iftype` in a function that returns a union type caused an internal compiler error during code generation. `gen_iftype()` returned the raw branch value without casting it to the overall expression type, so when the iftype's type was a union like `(U8 | None)` but the branch produced a primitive like `U8`, `gen_box()` couldn't find a matching primitive representation for the union type and bailed.

The fix applies the same pattern `gen_if()` uses: cast the selected branch's value from the branch type to the overall iftype expression type via `gen_assign_cast()`.

Closes #3770