### PR TITLE
Add missing NULL checks for gen_expr results in gencall.c

### DIFF
--- a/.release-notes/fix-null-checks-gen-funptr-gen-pattern-eq.md
+++ b/.release-notes/fix-null-checks-gen-funptr-gen-pattern-eq.md
@@ -1,0 +1,3 @@
+## Add missing NULL checks for gen_expr results in gencall.c
+
+Two additional code paths in the compiler could crash instead of reporting errors when a receiver sub-expression encountered a codegen error. These are the same class of bug as the recently fixed crash when calling methods on invalid shift expressions, but in the `gen_funptr` and `gen_pattern_eq` code paths. These are harder to trigger in practice but could cause segfaults in the LLVM optimizer if encountered.

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -481,6 +481,9 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
   // Generate the receiver.
   LLVMValueRef value = gen_expr(c, receiver);
 
+  if(value == NULL)
+    return NULL;
+
   // Get the receiver type.
   ast_t* type = deferred_reify(c->frame->reify, ast_type(receiver), c->opt);
   reach_type_t* t = reach_type(c->reach, type);
@@ -983,6 +986,13 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
 
   // Generate the receiver.
   LLVMValueRef l_value = gen_expr(c, pattern);
+
+  if(l_value == NULL)
+  {
+    ast_free_unattached(pattern_type);
+    return NULL;
+  }
+
   reach_type_t* t = reach_type(c->reach, pattern_type);
   pony_assert(t != NULL);
 


### PR DESCRIPTION
gen_funptr() and gen_pattern_eq() both pass gen_expr receiver results to dispatch_function without checking for NULL. If the receiver sub-expression encounters a codegen error and returns NULL, the code continues building malformed LLVM IR instead of propagating the error, which can crash the LLVM optimizer.

Same class of bug as the gen_call() fix in #5063.

Closes #5064