### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -271,6 +271,8 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
@@ -326,6 +328,8 @@ jobs:
 
     name: arm64-pc-windows-msvc
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -425,6 +425,8 @@ jobs:
 
     name: arm64 Windows MSVC
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -107,6 +107,8 @@ jobs:
 
     name: x86-64 Windows MSVC
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -92,6 +92,8 @@ jobs:
 
     name: Windows
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Restore Libs Cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,8 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
@@ -310,6 +312,8 @@ jobs:
 
     name: arm64-pc-windows-msvc
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -36,6 +36,8 @@ jobs:
 
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -36,6 +36,8 @@ jobs:
 
     name: ${{matrix.target}}:${{ matrix.name }}
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -15,6 +15,8 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -145,6 +145,8 @@ jobs:
 
     name: x86-64 Windows MSVC
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Cache Libs
@@ -164,6 +166,8 @@ jobs:
 
     name: arm64 Windows MSVC
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Cache Libs


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.