### PR TITLE
Fix spurious error when assigning to a field on an `as` cast in a try block

### DIFF
--- a/.release-notes/fix-as-field-assign-in-try.md
+++ b/.release-notes/fix-as-field-assign-in-try.md
@@ -1,0 +1,22 @@
+## Fix spurious error when assigning to a field on an `as` cast in a try block
+
+Assigning to a field on the result of an `as` expression inside a `try` block incorrectly produced an error about consumed identifiers:
+
+```pony
+class Wumpus
+  var hunger: USize = 0
+
+actor Main
+  new create(env: Env) =>
+    let a: (Wumpus | None) = Wumpus
+    try
+      (a as Wumpus).hunger = 1
+    end
+```
+
+```
+can't reassign to a consumed identifier in a try expression if there is a
+partial call involved
+```
+
+The workaround was to use a `match` expression instead. This has been fixed. The `as` form now compiles correctly, including when chaining method calls before the field assignment (e.g., `(a as Wumpus).some_method().hunger = 1`).

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1093,7 +1093,10 @@ static bool ast_get_child(pass_opt_t *opt, ast_t* ast, const char* name)
 
   while(child != NULL)
   {
-    if(ast_get_child(opt, child, name))
+    // Don't recurse into children that introduce their own scope (e.g., a match
+    // from `as` desugaring). Variables defined in those scopes are not
+    // assignment targets of the outer expression.
+    if(!ast_has_scope(child) && ast_get_child(opt, child, name))
       return true;
 
     child = ast_sibling(child);

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -787,6 +787,30 @@ TEST_F(VerifyTest, ConsumeVarReassignTrySameExpressionAs)
     " expression if there is a partial call involved");
 }
 
+TEST_F(VerifyTest, AsFieldAssignInTry)
+{
+  // Regression test for https://github.com/ponylang/ponyc/issues/3604
+  // Assigning to a field on the result of `as` inside a try block should not
+  // produce a spurious "can't reassign to a consumed identifier" error.
+  const char* src =
+    "class Wumpus\n"
+    "  var hunger: USize = 0\n"
+    "  fun ref self(): Wumpus => this\n"
+
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "let a: (Wumpus | None) = Wumpus\n"
+        "try\n"
+        "  (a as Wumpus).hunger = 1\n"
+        "end\n"
+        "let b: (Wumpus | None) = Wumpus\n"
+        "try\n"
+        "  (b as Wumpus).self().hunger = 2\n"
+        "end";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(VerifyTest, ConsumeVarFieldReassignTrySameExpressionPartial)
 {
   const char* src =


### PR DESCRIPTION
Assigning to a field on the result of an `as` expression inside a `try` block produced a spurious error about consumed identifiers. The `as` operator desugars to a match with a `consume` of an internal hygienic variable, and the refer pass's `ast_get_child` function searched the entire assignment LHS subtree — including the desugared match's scope — for consumed variable names. This produced a false positive that triggered the verify pass error.

The fix stops `ast_get_child` from recursing into children that introduce their own scope. Variables bound in those scopes (like the match-internal hygienic variable) aren't assignment targets of the outer expression.

Closes #3604
