### PR TITLE
Add new repos to nightly dispatch events

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -53,7 +53,9 @@ jobs:
     strategy:
       matrix:
         repo:
+          - ponylang/appdirs
           - ponylang/corral
+          - ponylang/lori
           - ponylang/ponyup
     steps:
       - name: Send
@@ -87,8 +89,11 @@ jobs:
       fail-fast: false
       matrix:
         repo:
+          - ponylang/appdirs
           - ponylang/corral
           - ponylang/http
+          - ponylang/lori
+          - ponylang/regex
     steps:
       - name: Send
         # v2.1.1


### PR DESCRIPTION
Add appdirs and lori to the arm64 macOS nightly dispatch, and appdirs, lori, and regex to the Windows nightly dispatch. These repos now have breakage tests for those platforms.