### PR TITLE
Add ponyup and ssl to Windows nightly dispatch

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -93,7 +93,9 @@ jobs:
           - ponylang/corral
           - ponylang/http
           - ponylang/lori
+          - ponylang/ponyup
           - ponylang/regex
+          - ponylang/ssl
     steps:
       - name: Send
         # v2.1.1


### PR DESCRIPTION
Both repos now have Windows breakage tests triggered by the ponyc Windows nightly release event.