### PR TITLE
Fix armhf cross-compile error from uint64_t cast

### DIFF
--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -1236,7 +1236,7 @@ void ponyint_cycle_create(pony_ctx_t* ctx, uint32_t detect_interval, bool force_
   // convert to cycles for use with ponyint_cpu_tick()
   // 1 second = 2000000000 cycles (approx.)
   // based on same scale as ponyint_cpu_core_pause() uses
-  d->detect_interval = (uint64_t)detect_interval * 2000000;
+  d->detect_interval = detect_interval * 2000000;
 
   // initialize last_checked
   d->last_checked = HASHMAP_BEGIN;


### PR DESCRIPTION
The defensive cast to `uint64_t` added in #5065 produces a 64-bit result assigned to `detect_interval` which is `size_t` — 32-bit on armhf. This triggers `-Werror=conversion` on the armhf cross-compile.

The cast is unnecessary since `detect_interval` is clamped to [10, 1000] just above, so `1000 * 2000000 = 2,000,000,000` fits comfortably in `uint32_t`.