### PR TITLE
Fix with tuple only processing first binding in build_with_dispose

### DIFF
--- a/.release-notes/5077.md
+++ b/.release-notes/5077.md
@@ -1,0 +1,5 @@
+## Fix `with` tuple: process every binding in dispose generation
+
+The compiler walked only the first element of a tuple pattern in `with` when building dispose calls and checking for invalid `_` bindings. Later elements were skipped, so some programs compiled incorrectly (missing dispose for later bindings, or no error for `_` in a later position).
+
+Tuple patterns now walk every element. Programs using multi-binding `with` get correct cleanup and diagnostics.

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -592,9 +592,8 @@ static bool build_with_dispose(pass_opt_t* opt, ast_t* dispose_clause, ast_t* id
   {
     pony_assert(ast_id(p) == TK_SEQ);
     ast_t* let = ast_child(p);
-    if(!build_with_dispose(opt, dispose_clause, let)){
+    if(!build_with_dispose(opt, dispose_clause, let))
       return false;
-    }
   }
 
   return true;

--- a/test/libponyc/with.cc
+++ b/test/libponyc/with.cc
@@ -51,3 +51,20 @@ TEST_F(WithTest, DontcareInTupleSecondBindingIsRejected)
 
   TEST_ERRORS_1(src, "_ isn't allowed for a variable in a with block");
 }
+
+TEST_F(WithTest, TwoElementTupleWithCompiles)
+{
+  // Happy path: both bindings get dispose calls; tuple loop must process every
+  // element (regression for early-return bug that only handled the first).
+  const char* src =
+    "class D\n"
+    "  new create() => None\n"
+    "  fun dispose() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    with (a, b) = (D.create(), D.create()) do\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
## Summary

The loop in `build_with_dispose` returned on the first recursive call, so only the first tuple element was processed. Later `_` patterns were not diagnosed as errors, and `dispose` calls were only added for the first binding.

## Changes

- Fix the tuple branch to iterate all elements and propagate failure.
- Add `WithTest.DontcareInTupleSecondBindingIsRejected` in `test/libponyc/with.cc`.

## Merge commit message

```
Fix with tuple only processing first binding in build_with_dispose

The loop returned on the first recursive call, so later tuple elements
were skipped: `_` in a later position was not rejected, and dispose
calls were only emitted for the first binding.

Walk every element and propagate failure. Add a libponyc regression test.
```