### PR TITLE
Fix infer_locals assertion using = instead of ==

### DIFF
--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -205,7 +205,7 @@ static bool infer_locals(pass_opt_t* opt, ast_t* left, ast_t* r_type)
     return false;
 
   pony_assert(path_root.next == NULL);
-  pony_assert(path_root.root = &path_root);
+  pony_assert(path_root.root == &path_root);
   return true;
 }
 


### PR DESCRIPTION
## Summary

In `infer_locals`, `path_root.root` was "compared" to `&path_root` with `=` instead of `==`, so the expression always assigned and the assertion did not validate the intended invariant.

## Merge commit message

```
Fix infer_locals assertion using = instead of ==

The pony_assert compared path_root.root to &path_root with assignment,
which always modified path_root.root and defeated the check.
```