### PR TITLE
Fix USE_VALGRIND ifdef typo in mpmcq pop

### DIFF
--- a/src/libponyrt/sched/mpmcq.c
+++ b/src/libponyrt/sched/mpmcq.c
@@ -151,7 +151,7 @@ void* ponyint_mpmcq_pop(mpmcq_t* q)
   // This is a standalone fence instead of a synchronised compare_exchange
   // operation because the latter would result in unnecessary synchronisation
   // on each loop iteration.
-#ifdef USE_VALGRID
+#ifdef USE_VALGRIND
   atomic_thread_fence(memory_order_acquire);
   ANNOTATE_HAPPENS_AFTER(&tail->next);
   ANNOTATE_HAPPENS_BEFORE(&next->data);


### PR DESCRIPTION
## Summary

`ponyint_mpmcq_pop` guarded Valgrind-related code with `#ifdef USE_VALGRID` instead of `USE_VALGRIND`, so the macro never matched the actual build flag and the fence/annotations were omitted when building with Valgrind support.

## Merge commit message

```
Fix USE_VALGRIND ifdef typo in mpmcq pop

The guard used USE_VALGRID, which never matched the USE_VALGRIND build
define, so the acquire fence and helgrind annotations were skipped.
```