### PR TITLE
Remove unused errorframe_has_errors

### DIFF
--- a/src/libponyc/ast/error.c
+++ b/src/libponyc/ast/error.c
@@ -332,12 +332,6 @@ void errorframe_append(errorframe_t* first, errorframe_t* second)
   *second = NULL;
 }
 
-bool errorframe_has_errors(errorframe_t* frame)
-{
-  pony_assert(frame != NULL);
-  return frame != NULL;
-}
-
 void errorframe_report(errorframe_t* frame, errors_t* errors)
 {
   pony_assert(frame != NULL);

--- a/src/libponyc/ast/error.h
+++ b/src/libponyc/ast/error.h
@@ -114,9 +114,6 @@ void errorf_continue(errors_t* errors, const char* file, const char* fmt,
 /// The second frame is left empty.
 void errorframe_append(errorframe_t* first, errorframe_t* second);
 
-/// Check if there are any errors in the given frame.
-bool errorframe_has_errors(errorframe_t* frame);
-
 /// Report all errors (if any) in the given frame.
 /// The frame is left empty.
 void errorframe_report(errorframe_t* frame, errors_t* errors);


### PR DESCRIPTION
## Summary

`errorframe_has_errors` was never called. Per [review feedback](https://github.com/ponylang/ponyc/pull/5080#issuecomment-4142420558), remove it entirely instead of fixing its return value.

## Merge commit message

```
Remove unused errorframe_has_errors

The function was never called; remove it per review feedback instead of
fixing its implementation.
```
