### PR TITLE
Fix tuple descriptor using non-zero vtable array length

### DIFF
--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -405,7 +405,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
   }
 
   const char* desc_name = genname_descriptor(t->name);
-  uint32_t vtable_size = t->vtable_size;
+  uint32_t vtable_size = 0;
 
   if(t->underlying != TK_TUPLETYPE)
     vtable_size = t->vtable_size;


### PR DESCRIPTION
## Summary

`gendesc_type` built the descriptor struct with `LLVMArrayType(c->ptr, vtable_size)` using `t->vtable_size` for every allowed underlying type. Tuple types should use a zero-length vtable array; only non-tuple types should take `vtable_size` from the reach type.

## Merge commit message

```
Fix tuple descriptor using non-zero vtable array length

gendesc_type used t->vtable_size for DESC_VTABLE unconditionally. Tuple
types should use a zero-length vtable array; only set vtable_size from
the reach type when the underlying is not TK_TUPLETYPE.
```