### PR TITLE
Fix CMake CMP0135 warnings for ExternalProject downloads

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,6 +5,10 @@ project(ponyclibs VERSION ${PONYC_PROJECT_VERSION} LANGUAGES C CXX)
 
 include(ExternalProject)
 
+if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
 if(NOT DEFINED PONYC_LIBS_BUILD_TYPE)
     set(PONYC_LIBS_BUILD_TYPE Release)
 endif()
@@ -33,7 +37,6 @@ endif()
 set(PONYC_GBENCHMARK_URL https://github.com/google/benchmark/archive/v1.9.5.tar.gz)
 ExternalProject_Add(gbenchmark
     URL ${PONYC_GBENCHMARK_URL}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_WERROR=OFF -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} --no-warn-unused-cli
 )
 
@@ -41,7 +44,6 @@ set(PONYC_GOOGLETEST_URL https://github.com/google/googletest/releases/download/
 
 ExternalProject_Add(googletest
     URL ${PONYC_GOOGLETEST_URL}
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${PONYC_LIBS_BUILD_TYPE} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_CXX_FLAGS=${PONY_PIC_FLAG} -Dgtest_force_shared_crt=ON --no-warn-unused-cli
 )
 


### PR DESCRIPTION
Sets `cmake_policy(SET CMP0135 NEW)` in `lib/CMakeLists.txt` so that
`ExternalProject_Add` URL downloads use extraction-time timestamps instead
of archive timestamps. This silences both dev warnings from the gbenchmark
and googletest downloads reported in #4852.

The `NEW` behavior is the recommended default since CMake 3.24 and ensures
that code depending on extracted contents is correctly rebuilt when the URL
changes.

Fixes #4852