### PR TITLE
Add JsonPrinter for serializing any JsonValue

### DIFF
--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -162,18 +162,26 @@ Supported JSONPath syntax:
 
 ## Serialization
 
-`JsonObject` and `JsonArray` implement `Stringable`. Compact output
-uses `string()`; indented output uses `pretty_string()`:
+`JsonPrinter` serializes any `JsonValue` — not just objects and arrays —
+to valid JSON. This is the recommended way to produce JSON output:
 
 ```pony
+// Any JsonValue — scalars, objects, arrays
+env.out.print(json.JsonPrinter.print("hello \"world\""))
+// "hello \"world\""
+env.out.print(json.JsonPrinter.print(None))
+// null
+
+// Compact object output
 let obj = json.JsonObject
   .update("a", I64(1))
   .update("b", json.JsonArray.push(I64(2)).push(I64(3)))
 
-env.out.print(obj.string())
+env.out.print(json.JsonPrinter.print(obj))
 // {"a":1,"b":[2,3]}
 
-env.out.print(obj.pretty_string())
+// Pretty-printed output
+env.out.print(json.JsonPrinter.pretty(obj))
 // {
 //   "a": 1,
 //   "b": [
@@ -183,8 +191,12 @@ env.out.print(obj.pretty_string())
 // }
 
 // Custom indent string (default is two spaces)
-env.out.print(obj.pretty_string("\t"))
+env.out.print(json.JsonPrinter.pretty(obj, "\t"))
 ```
+
+`JsonObject` and `JsonArray` also implement `Stringable` via `string()`
+and `pretty_string()` for convenience when you already have an object
+or array in hand.
 
 ## Choosing an Access Pattern
 

--- a/packages/json/json_printer.pony
+++ b/packages/json/json_printer.pony
@@ -1,0 +1,33 @@
+primitive JsonPrinter
+  """
+  Serialize any `JsonValue` to a JSON string.
+
+  `JsonObject` and `JsonArray` already implement `Stringable`, but the other
+  members of the `JsonValue` union — `String`, `I64`, `F64`, `Bool`, and
+  `None` — do not produce valid JSON from their `.string()` methods (e.g.,
+  `None.string()` yields `"None"`, not `"null"`; strings are not escaped or
+  quoted). `JsonPrinter` handles every variant correctly:
+
+  ```pony
+  use json = "json"
+
+  // Compact output
+  json.JsonPrinter.print("hello \"world\"")  // "hello \"world\""
+  json.JsonPrinter.print(None)               // null
+  json.JsonPrinter.print(true)               // true
+
+  // Pretty-printed output (objects and arrays)
+  let obj = json.JsonObject
+    .update("name", "Alice")
+    .update("scores", json.JsonArray.push(I64(1)).push(I64(2)))
+  json.JsonPrinter.pretty(obj)
+  ```
+  """
+
+  fun print(value: JsonValue): String iso^ =>
+    """Compact JSON serialization of any `JsonValue`."""
+    _JsonPrint.compact(value)
+
+  fun pretty(value: JsonValue, indent: String = "  "): String iso^ =>
+    """Pretty-printed JSON serialization of any `JsonValue`."""
+    _JsonPrint.pretty(value, indent)


### PR DESCRIPTION
Demonstration of the approach discussed in ponylang/rfcs#223.

Rather than a `Json` wrapper primitive that re-wraps `JsonParser.parse()` and adds a `print()` method, this exposes a `JsonPrinter` primitive that mirrors `JsonParser`:

- `JsonPrinter.print(value)` — compact JSON serialization of any `JsonValue`
- `JsonPrinter.pretty(value)` — pretty-printed serialization with configurable indent

Both delegate to the existing `_JsonPrint` internal primitive. `JsonParser`, `JsonObject.string()`, and `JsonArray.string()` are unchanged.

This fills the gap where `_JsonPrint` already handles all `JsonValue` variants correctly (proper `null` for `None`, escaped/quoted strings, etc.) but isn't accessible to users.