### PR TITLE
Fix pony-lsp diagnostic test failure on OpenBSD

### DIFF
--- a/tools/pony-lsp/test/_diagnostics_tests.pony
+++ b/tools/pony-lsp/test/_diagnostics_tests.pony
@@ -19,7 +19,7 @@ class \nodoc\ iso _DiagnosticTest is UnitTest
     let workspace_dir = Path.join(Path.dir(__loc.file()), "error_workspace")
     let harness = TestHarness.create(
       h,
-      PonyCompiler(""),
+      PonyCompiler("", try h.env.args(0)? else "" end),
       object iso is MessageHandler
         var received_diagnostics: USize = 0
         let expected_messages: Array[String] val = [


### PR DESCRIPTION
On OpenBSD, `get_compiler_exe_path` relies entirely on argv0 to find the executable — there's no `/proc/self/exe` or `KERN_PROC_PATHNAME` sysctl available. The diagnostic test was passing an empty string for argv0, so the compiler couldn't locate the `builtin` package and failed with "couldn't locate this path" instead of producing the expected type errors.

Other platforms (Linux, macOS, FreeBSD) use OS-specific mechanisms that ignore argv0 entirely, which masked the bug.

The fix passes the actual argv0 from `h.env.args(0)?` to `PonyCompiler`, matching what `main.pony` already does in production.