### PR TITLE
Move tier3 and weekly-checks to midweek nights

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "main"
   schedule:
-    - cron: "0 3 * * 6"
+    - cron: "0 3 * * 3"
 
 concurrency:
   group: ponyc-tier3-${{ github.ref }}

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "main"
   schedule:
-    - cron: "0 3 * * 0"
+    - cron: "0 3 * * 4"
 
 concurrency:
   group: ponyc-weekly-checks-${{ github.ref }}


### PR DESCRIPTION
These heavy jobs were running Friday and Saturday nights (US Eastern),
which conflicts with late-night development work. Move them to
Tuesday and Wednesday nights instead:

- tier3: Saturday 3 AM UTC → Wednesday 3 AM UTC (Tuesday 10 PM ET)
- weekly-checks: Sunday 3 AM UTC → Thursday 3 AM UTC (Wednesday 10 PM ET)