### PR TITLE
Increase full-program test timeout for debug builds in weekly checks

### DIFF
--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -89,7 +89,7 @@ jobs:
           make configure arch=x86-64 config=debug use=${{ matrix.directives }}
           make build config=debug
       - name: Test with Debug Runtime
-        run: make test-ci-core config=debug usedebugger='${{ matrix.debugger }}'
+        run: make test-ci-core config=debug usedebugger='${{ matrix.debugger }}' test_full_program_timeout=120
       - name: Build Release Runtime
         run: |
           make configure arch=x86-64 config=release use=${{ matrix.directives }}


### PR DESCRIPTION
The debug pool_memalign build runs regression-1118 in ~43s, which is close enough to the default 60s timeout that normal CI runner variance can push it over. Last week passed at 43.5s; this week it timed out.

Bumps the debug test timeout to 120s in the `use_directives` job, matching how the `with_sanitizers` job already uses a higher timeout (300s) for its slower builds.

Fixes the failure in https://github.com/ponylang/ponyc/actions/runs/23700901845/job/69044282866