### PR TITLE
Fix with tuple only processing first binding in build_with_dispose

### DIFF
--- a/.release-notes/fix-with-tuple-dispose.md
+++ b/.release-notes/fix-with-tuple-dispose.md
@@ -1,0 +1,21 @@
+## Fix with tuple only processing first binding in build_with_dispose
+
+When using a `with` block with a tuple pattern, only the first binding was processed for dispose-call generation and `_` validation. Later bindings were silently skipped, which meant dispose was never called on them and `_` in a later position was not rejected.
+
+For example, the following code compiled without error even though `_` is not allowed in a `with` block:
+
+```pony
+class D
+  new create() => None
+  fun dispose() => None
+
+actor Main
+  new create(env: Env) =>
+    with (a, _) = (D.create(), D.create()) do
+      None
+    end
+```
+
+This now correctly produces an error: `_ isn't allowed for a variable in a with block`.
+
+Additionally, valid tuple patterns like `with (a, b) = (D.create(), D.create()) do ... end` now correctly generate dispose calls for all bindings, not just the first.

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -588,14 +588,17 @@ static bool build_with_dispose(pass_opt_t* opt, ast_t* dispose_clause, ast_t* id
   // We have a list of variables
   pony_assert(ast_id(idseq) == TK_TUPLE);
 
+  bool r = true;
+
   for(ast_t* p = ast_child(idseq); p != NULL; p = ast_sibling(p))
   {
     pony_assert(ast_id(p) == TK_SEQ);
     ast_t* let = ast_child(p);
-    return build_with_dispose(opt, dispose_clause, let);
+    if(!build_with_dispose(opt, dispose_clause, let))
+      r = false;
   }
 
-  return true;
+  return r;
 }
 
 

--- a/test/libponyc/with.cc
+++ b/test/libponyc/with.cc
@@ -10,6 +10,10 @@
   { const char* errs[] = {err1, NULL}; \
     DO(test_expected_errors(src, "expr", errs)); }
 
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
 class WithTest : public PassTest
 {};
 
@@ -30,4 +34,58 @@ TEST_F(WithTest, NoEarlyReturnFromWith)
 
   TEST_ERRORS_1(src,
     "use return only to exit early from a with block, not at the end");
+}
+
+TEST_F(WithTest, DontcareInTupleSecondBindingIsRejected)
+{
+  // Regression: build_with_dispose must recurse through every tuple element.
+  // A prior bug returned after the first element, so `_` in a later position
+  // was not diagnosed.
+  const char* src =
+    "class D\n"
+    "  new create() => None\n"
+    "  fun dispose() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    with (a, _) = (D.create(), D.create()) do\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "_ isn't allowed for a variable in a with block");
+}
+
+TEST_F(WithTest, BothDontcareInTupleIsRejected)
+{
+  // Error accumulation: both `_` bindings should be reported, not just the
+  // first one.
+  const char* src =
+    "class D\n"
+    "  new create() => None\n"
+    "  fun dispose() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    with (_, _) = (D.create(), D.create()) do\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "_ isn't allowed for a variable in a with block",
+    "_ isn't allowed for a variable in a with block");
+}
+
+TEST_F(WithTest, TwoElementTupleWithCompiles)
+{
+  // Happy path: both bindings get dispose calls. The tuple loop must process
+  // every element (regression for early-return bug).
+  const char* src =
+    "class D\n"
+    "  new create() => None\n"
+    "  fun dispose() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    with (a, b) = (D.create(), D.create()) do\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
 }


### PR DESCRIPTION
The loop in `build_with_dispose` returned on the first recursive call, so only the first tuple element was processed. Later `_` patterns were not diagnosed as errors, and dispose calls were only emitted for the first binding.

Uses the error accumulation pattern (matching `sugar_match_capture`) so every element is walked and all diagnostics are reported at once.

Adds three libponyc regression tests: dontcare in second position (1 error), both dontcare (2 errors, verifying accumulation), and a happy-path two-element tuple compile.

Replaces #5077.