### PR TITLE
Fix memory leak in Windows networking subsystem

### DIFF
--- a/.release-notes/fix-iocp-writev-send-leak.md
+++ b/.release-notes/fix-iocp-writev-send-leak.md
@@ -1,0 +1,3 @@
+## Fix memory leak in Windows networking subsystem
+
+Fixed a memory leak on Windows where an IOCP token's reference count was not decremented when a network send operation encountered backpressure. Over time, this could cause memory to grow unboundedly in programs with sustained network traffic.

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -986,6 +986,7 @@ PONY_API size_t pony_os_writev(asio_event_t* ev, LPWSABUF wsa, int wsacnt)
       case WSA_IO_PENDING:
         return wsacnt;
       case WSAEWOULDBLOCK :
+        iocp_destroy(iocp);
         return 0;
       default:
         iocp_destroy(iocp);
@@ -1031,6 +1032,7 @@ PONY_API size_t pony_os_send(asio_event_t* ev, const char* buf, size_t len)
       case WSA_IO_PENDING:
         return len;
       case WSAEWOULDBLOCK :
+        iocp_destroy(iocp);
         return 0;
       default:
         iocp_destroy(iocp);


### PR DESCRIPTION
Both `pony_os_writev` and `pony_os_send` allocate an `iocp_t` via `iocp_create` before calling `WSASend`. If `WSASend` fails with `WSAEWOULDBLOCK`, the functions returned without calling `iocp_destroy`, leaking the allocation and permanently elevating the IOCP token's refcount. Over time this could cause unbounded memory growth.

The fix adds the missing `iocp_destroy(iocp)` call to the `WSAEWOULDBLOCK` case in both functions, matching the cleanup already done in the `default` error case.

Closes #5090