### PR TITLE
Use ponyup retries and longer API timeout in Dockerfiles

### DIFF
--- a/.dockerfiles/nightly/Dockerfile
+++ b/.dockerfiles/nightly/Dockerfile
@@ -12,9 +12,9 @@ RUN apk add --update --no-cache \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc nightly \
- && ponyup update corral nightly \
- && ponyup update changelog-tool nightly
+ && ponyup --api-timeout 30 update ponyc nightly --retries 3 \
+ && ponyup --api-timeout 30 update corral nightly --retries 3 \
+ && ponyup --api-timeout 30 update changelog-tool nightly --retries 3
 
 WORKDIR /src/main
 

--- a/.dockerfiles/release/Dockerfile
+++ b/.dockerfiles/release/Dockerfile
@@ -12,9 +12,9 @@ RUN apk add --update --no-cache \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \
- && ponyup update ponyc release \
- && ponyup update corral release \
- && ponyup update changelog-tool release
+ && ponyup --api-timeout 30 update ponyc release --retries 3 \
+ && ponyup --api-timeout 30 update corral release --retries 3 \
+ && ponyup --api-timeout 30 update changelog-tool release --retries 3
 
 WORKDIR /src/main
 


### PR DESCRIPTION
The nightly image build failed because ponyup timed out querying Cloudsmith for changelog-tool. ponyup 0.14.0 added `--api-timeout` and 0.15.1 added `--retries`. This bumps the API timeout from the default 15s to 30s and retries up to 3 times (with 3s waits between attempts) to handle transient Cloudsmith issues.

Updates both the nightly and release Dockerfiles.