### PR TITLE
Add LSP hover integration tests

### DIFF
--- a/tools/pony-lsp/test/_hover_formatter_tests.pony
+++ b/tools/pony-lsp/test/_hover_formatter_tests.pony
@@ -1,7 +1,7 @@
 use "pony_test"
 use "../workspace"
 
-primitive _HoverTests is TestList
+primitive _HoverFormatterTests is TestList
   new make() =>
     None
 
@@ -33,7 +33,7 @@ primitive _HoverTests is TestList
 
 class \nodoc\ iso _HoverFormatEntityTest
   is UnitTest
-  fun name(): String => "hover/format_entity"
+  fun name(): String => "hover/formatter/entity"
 
   fun apply(h: TestHelper) =>
     let info = EntityInfo("class", "MyClass")
@@ -46,7 +46,7 @@ class \nodoc\ iso
   _HoverFormatEntityWithTypeParamsTest
   is UnitTest
   fun name(): String =>
-    "hover/format_entity_with_type_params"
+    "hover/formatter/entity_with_type_params"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -62,7 +62,7 @@ class \nodoc\ iso
   _HoverFormatEntityWithDocstringTest
   is UnitTest
   fun name(): String =>
-    "hover/format_entity_with_docstring"
+    "hover/formatter/entity_with_docstring"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -80,7 +80,7 @@ class \nodoc\ iso
 
 class \nodoc\ iso _HoverFormatMethodTest
   is UnitTest
-  fun name(): String => "hover/format_method"
+  fun name(): String => "hover/formatter/method"
 
   fun apply(h: TestHelper) =>
     let info = MethodInfo("fun", "my_method", "")
@@ -93,7 +93,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithReturnTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_return_type"
+    "hover/formatter/method_with_return_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -115,7 +115,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithDocstringTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_docstring"
+    "hover/formatter/method_with_docstring"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -137,7 +137,7 @@ class \nodoc\ iso
 
 class \nodoc\ iso _HoverFormatFieldTest
   is UnitTest
-  fun name(): String => "hover/format_field"
+  fun name(): String => "hover/formatter/field"
 
   fun apply(h: TestHelper) =>
     let info = FieldInfo("let", "name")
@@ -150,7 +150,7 @@ class \nodoc\ iso
   _HoverFormatFieldWithTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_field_with_type"
+    "hover/formatter/field_with_type"
 
   fun apply(h: TestHelper) =>
     let info = FieldInfo("var", "count", ": U32")
@@ -163,7 +163,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithTypeParamsTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_type_params"
+    "hover/formatter/method_with_type_params"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -186,7 +186,7 @@ class \nodoc\ iso
   _HoverFormatEntityWithMultipleTypeParamsTest
   is UnitTest
   fun name(): String =>
-    "hover/format_entity_with_multiple_type_params"
+    "hover/formatter/entity_with_multiple_type_params"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -205,7 +205,7 @@ class \nodoc\ iso
   _HoverFormatFieldWithGenericTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_field_with_generic_type"
+    "hover/formatter/field_with_generic_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -224,7 +224,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithArrowTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_arrow_type"
+    "hover/formatter/method_with_arrow_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -246,7 +246,7 @@ class \nodoc\ iso
   _HoverFormatFieldWithUnionTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_field_with_union_type"
+    "hover/formatter/field_with_union_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -266,7 +266,7 @@ class \nodoc\ iso
   _HoverFormatFieldWithTupleTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_field_with_tuple_type"
+    "hover/formatter/field_with_tuple_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -285,7 +285,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithCompleteSignatureTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_complete_signature"
+    "hover/formatter/method_with_complete_signature"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -311,7 +311,7 @@ class \nodoc\ iso
   _HoverFormatEntityWithTypeParamsAndDocstringTest
   is UnitTest
   fun name(): String =>
-    "hover/format_entity_with_" +
+    "hover/formatter/entity_with_" +
     "type_params_and_docstring"
 
   fun apply(h: TestHelper) =>
@@ -333,7 +333,7 @@ class \nodoc\ iso
   _HoverFormatFieldWithNestedGenericTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_field_with_nested_generic_type"
+    "hover/formatter/field_with_nested_generic_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -351,7 +351,7 @@ class \nodoc\ iso
 
 class \nodoc\ iso _HoverFormatParameterTest
   is UnitTest
-  fun name(): String => "hover/format_parameter"
+  fun name(): String => "hover/formatter/parameter"
 
   fun apply(h: TestHelper) =>
     let info = FieldInfo("param", "value")
@@ -364,7 +364,7 @@ class \nodoc\ iso
   _HoverFormatParameterWithTypeTest
   is UnitTest
   fun name(): String =>
-    "hover/format_parameter_with_type"
+    "hover/formatter/parameter_with_type"
 
   fun apply(h: TestHelper) =>
     let info =
@@ -378,7 +378,7 @@ class \nodoc\ iso
   _HoverFormatMethodWithReceiverCapTest
   is UnitTest
   fun name(): String =>
-    "hover/format_method_with_receiver_cap"
+    "hover/formatter/method_with_receiver_cap"
 
   fun apply(h: TestHelper) =>
     let info =

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -1,0 +1,486 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+primitive _HoverIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _HoverWorkspaceServer(workspace_dir)
+    test(_HoverWorkspaceClassTest.create(server))
+    test(_HoverWorkspaceActorTest.create(server))
+    test(_HoverWorkspaceAliasTest.create(server))
+    test(_HoverWorkspaceInterfaceTest.create(server))
+    test(_HoverWorkspacePrimitiveTest.create(server))
+    test(_HoverWorkspaceTraitTest.create(server))
+    test(_HoverWorkspaceTypeInferenceTest.create(server))
+    test(_HoverWorkspaceReceiverCapabilityTest.create(server))
+    test(_HoverWorkspaceComplexTypesTest.create(server))
+    test(_HoverWorkspaceFunctionTest.create(server))
+    test(_HoverWorkspaceGenericsTest.create(server))
+
+class \nodoc\ iso _HoverWorkspaceClassTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/class"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_class.pony",
+      [(0, 6, ["class _Class"; "A simple class for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspaceActorTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/actor"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_actor.pony",
+      [(0, 6, ["actor _Actor"; "A simple actor for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspaceAliasTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/alias"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_alias.pony",
+      [(0, 5, ["type _Alias"; "A simple alias for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspaceInterfaceTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/interface"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_interface.pony",
+      [ (0, 10,
+        [ "interface _Interface"
+          "A simple interface for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspacePrimitiveTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/primitive"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_primitive.pony",
+      [ (0, 10,
+        [ "primitive _Primitive"
+          "A simple primitive for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspaceTraitTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/trait"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_trait.pony",
+      [(0, 6, ["trait _Trait"; "A simple trait for exercising LSP hover."])])
+
+class \nodoc\ iso _HoverWorkspaceFunctionTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/function"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_function.pony",
+      [ (15, 6,
+        [ "fun box helper_method(input: String val): String val"
+          "A helper method that processes input."])
+        (21, 6,
+        [ "fun box method_with_multiple_params" +
+          "(x: U32 val, y: String val, flag: Bool val): String val"
+          "Method with multiple parameters for testing."])
+        (11, 23,
+        [ "fun box helper_method(input: String val): String val"
+          "A helper method that processes input."])
+        (12, 23,
+          [ "fun box method_with_multiple_params" +
+            "(x: U32 val, y: String val, flag: Bool val): String val"
+            "Method with multiple parameters for testing."])
+        (11, 8, ["let result1: String val"])
+        (12, 8, ["let result2: String val"])])
+
+class \nodoc\ iso _HoverWorkspaceTypeInferenceTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/type_inference"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_type_inference.pony",
+      [ (19, 8, ["let inferred_string: String val"])
+        (22, 8, ["let inferred_bool: Bool"])
+        (25, 8, ["let inferred_array: Array[U32 val] ref"])
+        (27, 4, ["let inferred_string: String val"])
+        (27, 22, ["let inferred_bool: Bool"])
+        (27, 47, ["let inferred_array: Array[U32 val] ref"])])
+
+class \nodoc\ iso _HoverWorkspaceReceiverCapabilityTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/receiver_capability"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_receiver_capability.pony",
+      [ (5, 10, ["fun box boxed_method(): String val"])
+        (13, 10, ["fun val valued_method(): String val"])
+        (20, 10, ["fun ref mutable_method()"])])
+
+class \nodoc\ iso _HoverWorkspaceComplexTypesTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/complex_types"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_complex_types.pony",
+      [ (11, 8, ["let union_type: (String val | U32 val | None val)"])
+        (12, 8, ["let tuple_type: (String val, U32 val, Bool val)"])
+        (13, 4, ["let union_type: (String val | U32 val | None val)"])
+        (13, 26, ["let tuple_type: (String val, U32 val, Bool val)"])])
+
+class \nodoc\ iso _HoverWorkspaceGenericsTest is UnitTest
+  let _server: _HoverWorkspaceServer
+
+  new iso create(server: _HoverWorkspaceServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/generics"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+    _server.hover(
+      h,
+      "hover/_generics.pony",
+      [ // trait _Generics
+        (0, 6,
+        [ "trait _Generics[T: _Generics[T] box]"
+          "A trait demonstrating recursive type constraints."])
+        (5, 6, ["fun box compare(that: box->T): I32 val"])
+        // class _GenericsDemo
+        (7, 6,
+        [ "class _GenericsDemo[T: Any val]"
+          "Demonstrates hover on generic classes with type parameters."])
+        (12, 6, ["let _value: T"])
+        (17, 6,
+        [ "fun box get(): T"
+          "Returns the stored value."])
+        (23, 6,
+        [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
+          "A generic method with its own type parameter."])
+        // class _GenericPair
+        (30, 6,
+        [ "class _GenericPair[A: Any val, B: Any val]"
+          "Demonstrates multiple type parameters."])
+        (35, 6, ["let first: A"])
+        (36, 6, ["let second: B"])
+        (42, 6,
+        [ "fun box get_first(): A"
+          "Returns the first element."])
+        (48, 6,
+        [ "fun box get_second(): B"
+          "Returns the second element."])
+        // class _GenericContainer
+        (54, 6,
+        [ "class _GenericContainer[T: Stringable val]"
+          "Demonstrates type constraints on generic parameters."])
+        (59, 6, ["let _items: Array[T] ref"])
+        (64, 10,
+        [ "fun ref add(item: T)"
+          "Add an item to the container."])
+        (70, 6,
+        [ "fun box get_strings(): Array[String val] ref"
+          "Returns string representations of all items."])
+        (75, 8, ["let result: Array[String val] ref"])
+        // actor _GenericActor
+        (81, 6,
+        [ "actor _GenericActor[T: Any val]"
+          "Demonstrates generic actors."])
+        (86, 6, ["var _state: T"])
+        (91, 5,
+        [ "be tag update(new_state: T): None val"
+          "Updates the actor's state."])
+        (97, 5,
+        [ "be tag process[U: Any val](data: U): None val"
+          "A generic behavior with its own type parameter."])
+        // primitive _GenericHelper
+        (104, 10,
+        [ "primitive _GenericHelper"
+          "Demonstrates generic methods in primitives."])
+        (108, 6,
+        [ "fun box identity[T: Any val](value: T): T"
+          "A generic identity function."])
+        (115, 6,
+        [ "fun box create_pair[A: Any val, B: Any val](a: A, b: B): (A, B)"
+          "Creates a tuple from two values of different types."])
+        (121, 6,
+        [ "fun box apply[T: Any val](): Array[T] ref"
+          "Creates an empty array of any type."])
+        // class _GenericUsageDemo - instantiated generics
+        (128, 6,
+        [ "class _GenericUsageDemo"
+          "Demonstrates hover on instantiated generic types."])
+        (141, 8, ["let pair: _GenericPair[String val, U32 val] ref"])
+        (142, 8, ["let container: _GenericContainer[String val] ref"])
+        (143, 8, ["let numbers: _GenericsDemo[U64 val] ref"])
+        (148, 8, ["let first: String val"])
+        (148, 21, ["fun box get_first(): A"; "Returns the first element."])
+        (151, 8, ["let result: (U64 val, String val)"])
+        (151, 25,
+        [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
+          "A generic method with its own type parameter."])])
+
+type HoverCheck is (I64, I64, Array[String] val)
+
+class val _PendingHover
+  let file_path: String
+  let line: I64
+  let character: I64
+  let expected: Array[String] val
+  let h: TestHelper
+  let action: String
+
+  new val create(
+    file_path': String,
+    line': I64,
+    character': I64,
+    expected': Array[String] val,
+    h': TestHelper,
+    action': String)
+  =>
+    file_path = file_path'
+    line = line'
+    character = character'
+    expected = expected'
+    h = h'
+    action = action'
+
+actor _HoverWorkspaceServer is Channel
+  """
+  Shared LSP server for all hover workspace tests.
+  Initializes and compiles once, then dispatches
+  individual hover requests to each test's TestHelper.
+  """
+  let _workspace_dir: String
+  var _server: (BaseProtocol | None)
+  var _ready: Bool
+  var _initialized: Bool
+  let _pending: Array[_PendingHover]
+  let _opened: Set[String]
+  let _in_flight: Map[I64, _PendingHover]
+  var _next_id: I64
+
+  new create(workspace_dir: String) =>
+    _workspace_dir = workspace_dir
+    _server = None
+    _ready = false
+    _initialized = false
+    _pending = Array[_PendingHover]
+    _opened = Set[String]
+    _in_flight = Map[I64, _PendingHover]
+    _next_id = 2
+
+  be hover(
+    h: TestHelper,
+    workspace_file: String,
+    checks: Array[HoverCheck] val)
+  =>
+    let file_path = Path.join(_workspace_dir, workspace_file)
+    for (line, character, expected) in checks.values() do
+      let action: String val =
+        recover
+          val workspace_file + ":" + line.string() + ":" + character.string()
+        end
+      h.expect_action(action)
+      let pending =
+        _PendingHover(file_path, line, character, expected, h, action)
+      if _ready then
+        if not _opened.contains(file_path) then
+          _opened.set(file_path)
+          _did_open(file_path)
+        end
+        _dispatch(pending)
+      else
+        _pending.push(pending)
+      end
+    end
+    if not _initialized then
+      _initialized = true
+      let ponyc = try h.env.args(0)? else "" end
+      let proto =
+        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
+      _server = proto
+      proto(LspMsg.initialize(_workspace_dir))
+    end
+
+  fun ref _dispatch(pending: _PendingHover) =>
+    let id = _next_id
+    _next_id = id + 1
+    try
+      (_server as BaseProtocol)(
+        RequestMessage(
+          id,
+          Methods.text_document().hover(),
+          JsonObject
+            .update(
+              "textDocument",
+              JsonObject.update(
+                "uri", Uris.from_path(pending.file_path)))
+            .update(
+              "position",
+              JsonObject
+                .update("line", pending.line)
+                .update("character", pending.character))
+        ).into_bytes()
+      )
+      _in_flight(id) = pending
+    else
+      pending.h.fail_action(pending.action)
+    end
+
+  be send(msg: Message val) =>
+    match msg
+    | let res: ResponseMessage val =>
+      try
+        let id = res.id as RequestId
+        if RequestIds.eq(id, I64(0)) then
+          try (_server as BaseProtocol)(LspMsg.initialized()) end
+        else
+          try
+            let id_i64 = id as I64
+            (_, let pending) = _in_flight.remove(id_i64)?
+            var ok = true
+            try
+              let value =
+                JsonNav(res.result)("contents")("value").as_string()?
+              for s in pending.expected.values() do
+                if not pending.h.assert_true(
+                  value.contains(s),
+                  "Expected '" + s + "' in hover, got: " + value)
+                then
+                  ok = false
+                end
+              end
+            else
+              ok = false
+              pending.h.log(
+                "Could not parse hover response: " + res.string())
+            end
+            if ok then
+              pending.h.complete_action(pending.action)
+            else
+              pending.h.fail_action(pending.action)
+            end
+          end
+        end
+      end
+    | let req: RequestMessage val =>
+      if req.method == Methods.workspace().configuration() then
+        try
+          let proto = _server as BaseProtocol
+          proto(ResponseMessage(req.id, JsonArray).into_bytes())
+          for p in _pending.values() do
+            if not _opened.contains(p.file_path) then
+              _opened.set(p.file_path)
+              _did_open(p.file_path)
+            end
+          end
+        end
+      end
+    | let n: Notification val =>
+      if n.method == Methods.text_document().publish_diagnostics() then
+        if not _ready then
+          _ready = true
+          for p in _pending.values() do
+            _dispatch(p)
+          end
+          _pending.clear()
+        end
+      end
+    end
+
+  fun ref _did_open(file_path: String) =>
+    try
+      (_server as BaseProtocol)(
+        Notification(
+          Methods.text_document().did_open(),
+          JsonObject.update(
+            "textDocument",
+            JsonObject
+              .update("uri", Uris.from_path(file_path))
+              .update("languageId", "pony")
+              .update("version", I64(1))
+              .update("text", ""))
+        ).into_bytes())
+    end
+
+  be log(data: String val, message_type: MessageType = Debug) =>
+    None
+
+  be set_notifier(notifier: Notifier tag) =>
+    None
+
+  be dispose() =>
+    None

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -21,8 +21,9 @@ actor Main is TestList
     test(_DidChangeConfigurationTest)
     test(_DidChangeConfigurationNullTest)
     _WorkspaceTests.make().tests(test)
-    _HoverTests.make().tests(test)
+    _HoverFormatterTests.make().tests(test)
     _DiagnosticTests.make().tests(test)
+    _HoverIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/hover/_actor.pony
+++ b/tools/pony-lsp/test/workspace/hover/_actor.pony
@@ -1,0 +1,11 @@
+actor _Actor
+  """
+  A simple actor for exercising LSP hover.
+  """
+  let _name: String
+
+  new create(name': String) =>
+    _name = name'
+
+  be do_something(value: U64) =>
+    None

--- a/tools/pony-lsp/test/workspace/hover/_alias.pony
+++ b/tools/pony-lsp/test/workspace/hover/_alias.pony
@@ -1,0 +1,4 @@
+type _Alias is (String | U32 | None)
+  """
+  A simple alias for exercising LSP hover.
+  """

--- a/tools/pony-lsp/test/workspace/hover/_class.pony
+++ b/tools/pony-lsp/test/workspace/hover/_class.pony
@@ -1,0 +1,29 @@
+class _Class
+  """
+  A simple class for exercising LSP hover.
+  """
+  let field_name: String
+  var mutable_field: U32
+  embed embedded_field: Array[String] = Array[String]
+
+  new create(name: String) =>
+    field_name = name
+    mutable_field = 0
+
+  fun simple_method(): String =>
+    """
+    Returns the field name.
+    """
+    field_name
+
+  fun method_with_params(x: U32, y: String): Bool =>
+    """
+    A method with parameters.
+    """
+    x > 0
+
+  fun ref update_field(count: USize) =>
+    """
+    Update the mutable field.
+    """
+    mutable_field = count.u32()

--- a/tools/pony-lsp/test/workspace/hover/_complex_types.pony
+++ b/tools/pony-lsp/test/workspace/hover/_complex_types.pony
@@ -1,0 +1,14 @@
+class _ComplexTypes
+  """
+  Demonstrates that hover works on complex type expressions.
+  Union types, tuple types, and intersection types are formatted correctly.
+  """
+
+  fun demo_complex_types(): String =>
+    """
+    Hover over the variable names on their declaration lines to see formatted
+    types. Hover shows 'let union_type: (String | U32 | None)' and similar.
+    """
+    let union_type: (String | U32 | None) = "test"
+    let tuple_type: (String, U32, Bool) = ("test", U32(42), true)
+    union_type.string() + tuple_type._1.string()

--- a/tools/pony-lsp/test/workspace/hover/_function.pony
+++ b/tools/pony-lsp/test/workspace/hover/_function.pony
@@ -1,0 +1,26 @@
+class _Function
+  """
+  Demonstrates that hover works on function calls.
+  Hovering over a method name in a call shows its signature and docstring.
+  """
+
+  fun demo_function_calls(): String =>
+    """
+    Try hovering over the method names in the function calls below.
+    Hover will show the method signature with parameters and docstring.
+    """
+    let result1 = this.helper_method("test")
+    let result2 = this.method_with_multiple_params(42, "hello", true)
+    result1 + result2
+
+  fun helper_method(input: String): String =>
+    """
+    A helper method that processes input.
+    """
+    input.upper()
+
+  fun method_with_multiple_params(x: U32, y: String, flag: Bool): String =>
+    """
+    Method with multiple parameters for testing.
+    """
+    y

--- a/tools/pony-lsp/test/workspace/hover/_generics.pony
+++ b/tools/pony-lsp/test/workspace/hover/_generics.pony
@@ -1,0 +1,154 @@
+trait _Generics[T: _Generics[T] box]
+  """
+  A trait demonstrating recursive type constraints.
+  Used for testing hover on constrained generics.
+  """
+  fun compare(that: box->T): I32
+
+class _GenericsDemo[T: Any val]
+  """
+  Demonstrates hover on generic classes with type parameters.
+  Hover over the class name shows the full signature with type parameters.
+  """
+  let _value: T
+
+  new create(value: T) =>
+    _value = value
+
+  fun get(): T =>
+    """
+    Returns the stored value.
+    """
+    _value
+
+  fun with_generic_param[U: Any val](other: U): (T, U) =>
+    """
+    A generic method with its own type parameter.
+    Hover shows both the class type parameter T and method type parameter U.
+    """
+    (_value, other)
+
+class _GenericPair[A: Any val, B: Any val]
+  """
+  Demonstrates multiple type parameters.
+  Hover shows 'class GenericPair[A: Any val, B: Any val]'
+  """
+  let first: A
+  let second: B
+
+  new create(a: A, b: B) =>
+    first = a
+    second = b
+
+  fun get_first(): A =>
+    """
+    Returns the first element.
+    """
+    first
+
+  fun get_second(): B =>
+    """
+    Returns the second element.
+    """
+    second
+
+class _GenericContainer[T: Stringable val]
+  """
+  Demonstrates type constraints on generic parameters.
+  Hover shows 'class GenericContainer[T: Stringable val]'
+  """
+  let _items: Array[T]
+
+  new create() =>
+    _items = Array[T]
+
+  fun ref add(item: T) =>
+    """
+    Add an item to the container.
+    """
+    _items.push(item)
+
+  fun get_strings(): Array[String] =>
+    """
+    Returns string representations of all items.
+    Works because T is constrained to Stringable.
+    """
+    let result = Array[String]
+    for item in _items.values() do
+      result.push(item.string())
+    end
+    result
+
+actor _GenericActor[T: Any val]
+  """
+  Demonstrates generic actors.
+  Hover shows 'actor GenericActor[T: Any val]'
+  """
+  var _state: T
+
+  new create(initial: T) =>
+    _state = initial
+
+  be update(new_state: T) =>
+    """
+    Updates the actor's state.
+    """
+    _state = new_state
+
+  be process[U: Any val](data: U) =>
+    """
+    A generic behavior with its own type parameter.
+    Demonstrates that behaviors can be generic too.
+    """
+    None
+
+primitive _GenericHelper
+  """
+  Demonstrates generic methods in primitives.
+  """
+  fun identity[T: Any val](value: T): T =>
+    """
+    A generic identity function.
+    Hover shows 'fun identity[T: Any val](value: T): T'
+    """
+    value
+
+  fun create_pair[A: Any val, B: Any val](a: A, b: B): (A, B) =>
+    """
+    Creates a tuple from two values of different types.
+    """
+    (a, b)
+
+  fun apply[T: Any val](): Array[T] =>
+    """
+    Creates an empty array of any type.
+    Hover shows the generic return type Array[T].
+    """
+    Array[T]
+
+class _GenericUsageDemo
+  """
+  Demonstrates hover on instantiated generic types.
+  """
+  fun demo_generic_instantiation() =>
+    """
+    Try hovering over the variable names (pair, container, numbers).
+    Hover shows the variable declaration with fully instantiated generic types
+    like 'let pair: GenericPair[String val, U32 val]'.
+
+    Note: Hovering on the type names themselves (GenericPair, GenericsDemo) will
+    follow to the class definition and show the type parameters instead.
+    """
+    let pair: _GenericPair[String, U32] = _GenericPair[String, U32]("hello", 42)
+    let container: _GenericContainer[String] = _GenericContainer[String]
+    let numbers: _GenericsDemo[U64] = _GenericsDemo[U64](100)
+
+    // Hover over method calls with generic types
+
+    // Hover shows: let first: String val
+    let first = pair.get_first()
+
+    // Hover shows: let result: (U64 val, String val)
+    let result = numbers.with_generic_param[String]("test")
+
+    None

--- a/tools/pony-lsp/test/workspace/hover/_interface.pony
+++ b/tools/pony-lsp/test/workspace/hover/_interface.pony
@@ -1,0 +1,5 @@
+interface _Interface
+  """
+  A simple interface for exercising LSP hover.
+  """
+  fun interface_method(): None val

--- a/tools/pony-lsp/test/workspace/hover/_primitive.pony
+++ b/tools/pony-lsp/test/workspace/hover/_primitive.pony
@@ -1,0 +1,5 @@
+primitive _Primitive
+  """
+  A simple primitive for exercising LSP hover.
+  """
+  fun apply(): String => "test"

--- a/tools/pony-lsp/test/workspace/hover/_receiver_capability.pony
+++ b/tools/pony-lsp/test/workspace/hover/_receiver_capability.pony
@@ -1,0 +1,26 @@
+class _ReceiverCapability
+  """
+  Demonstrates that hover displays receiver capabilities in method signatures.
+  """
+
+  fun box boxed_method(): String =>
+    """
+    A boxed method - receiver capability is 'box'.
+    Hover shows 'fun box boxed_method(): String' with the receiver capability.
+    The receiver capability indicates how 'this' can be accessed in the method.
+    """
+    "box"
+
+  fun val valued_method(): String =>
+    """
+    A val method - receiver capability is 'val'.
+    Hover shows 'fun val valued_method(): String' with the receiver capability.
+    """
+    "val"
+
+  fun ref mutable_method() =>
+    """
+    A ref method - receiver capability is 'ref'.
+    Hover shows 'fun ref mutable_method()' with the receiver capability.
+    """
+    None

--- a/tools/pony-lsp/test/workspace/hover/_trait.pony
+++ b/tools/pony-lsp/test/workspace/hover/_trait.pony
@@ -1,0 +1,5 @@
+trait _Trait
+  """
+  A simple trait for exercising LSP hover.
+  """
+  fun trait_method(): String

--- a/tools/pony-lsp/test/workspace/hover/_type_inference.pony
+++ b/tools/pony-lsp/test/workspace/hover/_type_inference.pony
@@ -1,0 +1,28 @@
+
+class _TypeInference
+  """
+  Demonstrates that type inference works in hover.
+
+  Hover shows inferred types on variable declarations even without explicit
+  annotations.
+  """
+
+  fun demo_type_inference(): String =>
+    """
+    Hover shows inferred types on variable DECLARATIONS!
+    Try hovering over the variable names on their declaration lines.
+
+    ACTUAL: Hover shows 'let inferred_bool: Bool' even without explicit type
+    This works because the type-checked AST contains inferred type info.
+    """
+
+    // Hover shows: let inferred_string: String val
+    let inferred_string = "test"
+
+    // Hover shows: let inferred_bool: Bool
+    let inferred_bool = true
+
+    // Hover shows: let inferred_array: Array[U32] ref
+    let inferred_array = Array[U32]
+
+    inferred_string + inferred_bool.string() + inferred_array.size().string()

--- a/tools/pony-lsp/test/workspace/hover/hover.pony
+++ b/tools/pony-lsp/test/workspace/hover/hover.pony
@@ -1,0 +1,19 @@
+"""
+Test fixtures for exercising LSP hover functionality.
+
+This module provides test cases for manual and automated testing of hover
+functionality provided by the Pony language server (LSP). It contains various
+Pony entities (classes, actors, traits, methods, fields) with docstrings and
+type annotations to validate hover behavior.
+
+To manually test hover functionality:
+1. Open the lsp/test/workspace directory as a project in your editor.
+2. Open the various files n the hover directory while the Pony language server
+   is active.
+3. Hover your cursor over various code elements to see hover information.
+
+Expected hover behavior:
+- Display the declaration signature in a code block
+- Include docstrings where present
+- Show type information for fields and variables
+"""


### PR DESCRIPTION
## Context

The `pony-lsp` tool provides LSP hover functionality but has no integration tests that exercise the full server lifecycle — only unit tests for the hover formatter exist.

## Changes

- Adds `_hover_integration_tests.pony`: end-to-end hover tests covering classes, actors, traits, interfaces, primitives, aliases, type inference, receiver capabilities, complex types (union/tuple), generic types, and function signatures
- Adds workspace fixture files under `test/workspace/hover/` used by the integration tests
- Renames `_hover_tests.pony` → `_hover_formatter_tests.pony` (and `_HoverTests` → `_HoverFormatterTests`) to distinguish the formatter unit tests from the new integration tests
- Updates test name prefixes: formatter tests use `hover/formatter/*`, integration tests use `hover/integration/*`

## Considerations

All integration tests share a single `_HoverWorkspaceServer` actor that initializes and compiles the workspace once, then dispatches individual hover requests to each test's `TestHelper`. This avoids repeated compilation overhead but means tests run sequentially through one server instance.