### PR TITLE
Add LSP `textDocument/documentHighlight` support

### DIFF
--- a/.release-notes/5111.md
+++ b/.release-notes/5111.md
@@ -1,0 +1,3 @@
+## Add LSP textDocument/documentHighlight support
+
+The Pony language server now handles `textDocument/documentHighlight` requests. Placing the cursor on any symbol highlights all occurrences in the file, covering fields, locals, parameters, constructors, functions, behaviours, and type names.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -15,6 +15,7 @@ For user documentation — installation and editor configuration — see the [po
 | **Hover** | Additional information is shown for: entities, methods, fields, local variables and references. |
 | **Go To Definition** | For most language constructs, you can go from a reference to its definition. |
 | **Document Symbols** | pony-lsp provides a list of available symbols for each opened document. |
+| **Document Highlight** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
 
 New features are actively being added. Contributions are welcome — we are happy to provide help and guidance.
 

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -91,6 +91,23 @@ actor LanguageServer is (Notifier & RequestSender)
       this._channel.log(
         "\n\n<-\n" + r.json().string())
       match \exhaustive\ r.method
+      | Methods.text_document().document_highlight() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri)
+            as WorkspaceManager).document_highlight(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")
+            )
+          )
+        end
       | Methods.text_document().definition() =>
         try
           let document_uri =
@@ -452,6 +469,7 @@ actor LanguageServer is (Notifier & RequestSender)
             .update(
               "capabilities",
               JsonObject
+                .update("documentHighlightProvider", true)
                 .update(
                   "hoverProvider", true)
                 .update(

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -91,6 +91,9 @@ primitive TextDocumentMethods
   fun did_save(): String val =>
     "textDocument/didSave"
 
+  fun document_highlight(): String val =>
+    "textDocument/documentHighlight"
+
   fun document_symbol(): String val =>
     "textDocument/documentSymbol"
 

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -55,7 +55,11 @@ class \nodoc\ iso _DocHighlightFieldTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+      h,
+      action,
+      at,
+      [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
+        (27, 4, 27, 9); (30, 22, 30, 27)])
 
 class \nodoc\ iso _DocHighlightFieldRefTest
   is UnitTest
@@ -81,7 +85,11 @@ class \nodoc\ iso _DocHighlightFieldRefTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+      h,
+      action,
+      at,
+      [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
+        (27, 4, 27, 9); (30, 22, 30, 27)])
 
 class \nodoc\ iso _DocHighlightLocalTest
   is UnitTest
@@ -109,7 +117,8 @@ class \nodoc\ iso _DocHighlightLocalTest
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(30, 8); (31, 4); (31, 13)])
+    _server.test_document_highlight(
+      h, action, at, [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)])
 
 class \nodoc\ iso _DocHighlightFletTest is UnitTest
   """
@@ -136,7 +145,8 @@ class \nodoc\ iso _DocHighlightFletTest is UnitTest
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(80, 6); (85, 4); (90, 4)])
+    _server.test_document_highlight(
+      h, action, at, [(80, 6, 80, 11); (85, 4, 85, 9); (90, 4, 90, 9)])
 
 class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
   """
@@ -163,7 +173,8 @@ class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(81, 8); (86, 4); (91, 4)])
+    _server.test_document_highlight(
+      h, action, at, [(81, 8, 81, 14); (86, 4, 86, 10); (91, 4, 91, 10)])
 
 class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
   """
@@ -191,7 +202,7 @@ class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(51, 6); (86, 20); (91, 20)])
+      h, action, at, [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)])
 
 class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
   """
@@ -220,7 +231,7 @@ class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(94, 10); (102, 15); (107, 12)])
+      h, action, at, [(94, 10, 94, 13); (102, 15, 102, 18); (107, 12, 107, 15)])
 
 class \nodoc\ iso _DocHighlightParamTest is UnitTest
   """
@@ -248,7 +259,7 @@ class \nodoc\ iso _DocHighlightParamTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(94, 14); (95, 18); (96, 4)])
+      h, action, at, [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)])
 
 class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
   """
@@ -277,7 +288,10 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(106, 8); (107, 4); (107, 8); (108, 4)])
+      h,
+      action,
+      at,
+      [(106, 8, 106, 9); (107, 4, 107, 5); (107, 8, 107, 9); (108, 4, 108, 5)])
 
 class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
   """
@@ -303,7 +317,8 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(121, 5); (125, 4)])
+    _server.test_document_highlight(
+      h, action, at, [(121, 5, 121, 8); (125, 4, 125, 7)])
 
 class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
   """
@@ -333,7 +348,10 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(
-      h, action, at, [(33, 6); (81, 16); (86, 13); (91, 13)])
+      h,
+      action,
+      at,
+      [(33, 6, 33, 12); (81, 16, 81, 22); (86, 13, 86, 19); (91, 13, 91, 19)])
 
 class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
   """
@@ -360,7 +378,8 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(54, 6); (98, 22)])
+    _server.test_document_highlight(
+      h, action, at, [(54, 6, 54, 20); (98, 22, 98, 36)])
 
 class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
   """
@@ -416,7 +435,7 @@ class val _PendingDocHighlight
   let file_path: String
   let line: I64
   let character: I64
-  let expected: Array[(I64, I64)] val
+  let expected: Array[(I64, I64, I64, I64)] val
   let h: TestHelper
   let action: String
 
@@ -424,7 +443,7 @@ class val _PendingDocHighlight
     file_path': String,
     line': I64,
     character': I64,
-    expected': Array[(I64, I64)] val,
+    expected': Array[(I64, I64, I64, I64)] val,
     h': TestHelper,
     action': String)
   =>
@@ -466,7 +485,7 @@ actor _DocHighlightLspServer is Channel
     h: TestHelper,
     action: String val,
     at: (I64, I64),
-    expected: Array[(I64, I64)] val)
+    expected: Array[(I64, I64, I64, I64)] val)
   =>
     (let line, let character) = at
     let file_path = _fixture_file
@@ -572,26 +591,32 @@ actor _DocHighlightLspServer is Channel
         "Expected " + want.string() + " highlights, got " + got.string())
       then
         ok = false
-        // Log all actual positions to diagnose unexpected highlights
+        // Log all actual ranges to diagnose unexpected highlights
         for item in arr.values() do
           try
-            let start = JsonNav(item)("range")("start")
-            let l = start("line").as_i64()?
-            let c = start("character").as_i64()?
+            let range = JsonNav(item)("range")
+            let sl = range("start")("line").as_i64()?
+            let sc = range("start")("character").as_i64()?
+            let el = range("end")("line").as_i64()?
+            let ec = range("end")("character").as_i64()?
             pending.h.log(
-              "  actual highlight at (" +
-              l.string() + ", " + c.string() + ")")
+              "  actual highlight (" + sl.string() + ", " + sc.string() +
+              ")–(" + el.string() + ", " + ec.string() + ")")
           end
         end
       end
-      for (exp_line, exp_char) in pending.expected.values() do
+      for (exp_sl, exp_sc, exp_el, exp_ec) in pending.expected.values() do
         var found = false
         for item in arr.values() do
           try
-            let start = JsonNav(item)("range")("start")
-            let l = start("line").as_i64()?
-            let c = start("character").as_i64()?
-            if (l == exp_line) and (c == exp_char) then
+            let range = JsonNav(item)("range")
+            let sl = range("start")("line").as_i64()?
+            let sc = range("start")("character").as_i64()?
+            let el = range("end")("line").as_i64()?
+            let ec = range("end")("character").as_i64()?
+            if (sl == exp_sl) and (sc == exp_sc) and
+              (el == exp_el) and (ec == exp_ec)
+            then
               found = true
               break
             end
@@ -599,9 +624,8 @@ actor _DocHighlightLspServer is Channel
         end
         if not pending.h.assert_true(
           found,
-          "Expected highlight at line " +
-          exp_line.string() + " col " +
-          exp_char.string() + " not found")
+          "Expected highlight (" + exp_sl.string() + ", " + exp_sc.string() +
+          ")–(" + exp_el.string() + ", " + exp_ec.string() + ") not found")
         then
           ok = false
         end

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -21,7 +21,9 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightParamTest.create(server, fixture))
     test(_DocHighlightVarLocalTest.create(server, fixture))
     test(_DocHighlightBeRefTest.create(server, fixture))
+    test(_DocHighlightClassDeclTest.create(server, fixture))
     test(_DocHighlightClassTypeTest.create(server, fixture))
+    test(_DocHighlightTypeDeclTest.create(server, fixture))
     test(_DocHighlightTypeRefTest.create(server, fixture))
     test(_DocHighlightLiteralTest.create(server, fixture))
     test(_DocHighlightNoneTest.create(server, fixture))
@@ -365,6 +367,65 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
       action,
       at,
       [(33, 6, 33, 12); (81, 16, 81, 22); (86, 13, 86, 19); (91, 13, 91, 19)])
+
+class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
+  """
+  Highlights the `_Inner` class from its declaration site.
+  Expects the same 4 occurrences as _DocHighlightClassTypeTest:
+    line  33 col  6  (class _Inner declaration)
+    line  81 col 16  (embed _inner: _Inner type annotation)
+    line  86 col 13  (_Inner.create() receiver in create)
+    line  91 col 13  (_Inner.create() receiver in other)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/class_decl"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (33, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(33, 6, 33, 12); (81, 16, 81, 22); (86, 13, 86, 19); (91, 13, 91, 19)])
+
+class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
+  """
+  Highlights the `_HighlightMore` class from its declaration site.
+  Expects the same 2 occurrences as _DocHighlightTypeRefTest:
+    line  54 col  6  (class _HighlightMore declaration)
+    line  98 col 22  (_HighlightMore in get_self return type)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/type_decl"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (54, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h, action, at, [(54, 6, 54, 20); (98, 22, 98, 36)])
 
 class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
   """

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -24,6 +24,7 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightClassTypeTest.create(server, fixture))
     test(_DocHighlightTypeRefTest.create(server, fixture))
     test(_DocHighlightLiteralTest.create(server, fixture))
+    test(_DocHighlightNoneTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -282,8 +283,8 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
   """
   Highlights the `run` behaviour from its declaration.
   Expects 2 occurrences:
-    line 117 col  5  (be run declaration)
-    line 121 col  4  (run(1) call in trigger)
+    line 121 col  5  (be run declaration)
+    line 125 col  4  (run(1) call in trigger)
   """
   let _server: _DocHighlightLspServer
   let _fixture: String val
@@ -296,13 +297,13 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
     "document_highlight/integration/be_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (117, 5)
+    let at: (I64, I64) = (121, 5)
     (let line, let character) = at
     let action: String val =
       recover _fixture + ":" + line.string() + ":" + character.string() end
     h.long_test(10_000_000_000)
     h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [(117, 5); (121, 4)])
+    _server.test_document_highlight(h, action, at, [(121, 5); (125, 4)])
 
 class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
   """
@@ -378,6 +379,32 @@ class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
 
   fun apply(h: TestHelper) =>
     let at: (I64, I64) = (85, 12)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightNoneTest is UnitTest
+  """
+  Placing the cursor on `None` (a type-literal expression) should produce no
+  highlights. `None` desugars to `None.create()` synthetically; it has no
+  referenceable identity.
+  Tests `None` on line 122 col 4 (body of be run in _HighlightRunner).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/none_literal"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (122, 4)
     (let line, let character) = at
     let action: String val =
       recover _fixture + ":" + line.string() + ":" + character.string() end

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -9,20 +9,20 @@ primitive _DocumentHighlightIntegrationTests is TestList
 
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
-    let server =
-      _DocHighlightLspServer(workspace_dir, "highlights/highlights.pony")
-    test(_DocHighlightFieldTest.create(server))
-    test(_DocHighlightFieldRefTest.create(server))
-    test(_DocHighlightLocalTest.create(server))
-    test(_DocHighlightFletTest.create(server))
-    test(_DocHighlightEmbedTest.create(server))
-    test(_DocHighlightNewRefTest.create(server))
-    test(_DocHighlightFunRefTest.create(server))
-    test(_DocHighlightParamTest.create(server))
-    test(_DocHighlightVarLocalTest.create(server))
-    test(_DocHighlightBeRefTest.create(server))
-    test(_DocHighlightClassTypeTest.create(server))
-    test(_DocHighlightTypeRefTest.create(server))
+    let fixture = "highlights/highlights.pony"
+    let server = _DocHighlightLspServer(workspace_dir, fixture)
+    test(_DocHighlightFieldTest.create(server, fixture))
+    test(_DocHighlightFieldRefTest.create(server, fixture))
+    test(_DocHighlightLocalTest.create(server, fixture))
+    test(_DocHighlightFletTest.create(server, fixture))
+    test(_DocHighlightEmbedTest.create(server, fixture))
+    test(_DocHighlightNewRefTest.create(server, fixture))
+    test(_DocHighlightFunRefTest.create(server, fixture))
+    test(_DocHighlightParamTest.create(server, fixture))
+    test(_DocHighlightVarLocalTest.create(server, fixture))
+    test(_DocHighlightBeRefTest.create(server, fixture))
+    test(_DocHighlightClassTypeTest.create(server, fixture))
+    test(_DocHighlightTypeRefTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -36,16 +36,24 @@ class \nodoc\ iso _DocHighlightFieldTest
     line 30 col 22  (use_local() body)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/field"
 
   fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (21, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
     _server.test_document_highlight(
-      h, (21, 6), [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+      h, action, at, [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
 
 class \nodoc\ iso _DocHighlightFieldRefTest
   is UnitTest
@@ -54,16 +62,24 @@ class \nodoc\ iso _DocHighlightFieldRefTest
   Expects the same 5 occurrences as when starting from the declaration.
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/field_ref"
 
   fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (27, 4)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
     _server.test_document_highlight(
-      h, (27, 4), [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+      h, action, at, [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
 
 class \nodoc\ iso _DocHighlightLocalTest
   is UnitTest
@@ -75,15 +91,23 @@ class \nodoc\ iso _DocHighlightLocalTest
     line 31 col 13  (second use in result + result)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/local"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (30, 8), [(30, 8); (31, 4); (31, 13)])
+    let at: (I64, I64) = (30, 8)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [(30, 8); (31, 4); (31, 13)])
 
 class \nodoc\ iso _DocHighlightFletTest is UnitTest
   """
@@ -94,15 +118,23 @@ class \nodoc\ iso _DocHighlightFletTest is UnitTest
     line 90 col  4  (assigned false in other)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/flet"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (80, 6), [(80, 6); (85, 4); (90, 4)])
+    let at: (I64, I64) = (80, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [(80, 6); (85, 4); (90, 4)])
 
 class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
   """
@@ -113,15 +145,23 @@ class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
     line 91 col  4  (assigned in other)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/embed"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (81, 8), [(81, 8); (86, 4); (91, 4)])
+    let at: (I64, I64) = (81, 8)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [(81, 8); (86, 4); (91, 4)])
 
 class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
   """
@@ -132,15 +172,24 @@ class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
     line 91 col 20  (_Inner.create() in other body)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/new_ref"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (51, 6), [(51, 6); (86, 20); (91, 20)])
+    let at: (I64, I64) = (51, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h, action, at, [(51, 6); (86, 20); (91, 20)])
 
 class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
   """
@@ -152,16 +201,24 @@ class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
     line 107 col 12  (w = w + add(n) — funref)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/fun_ref"
 
   fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (94, 10)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
     _server.test_document_highlight(
-      h, (94, 10), [(94, 10); (102, 15); (107, 12)])
+      h, action, at, [(94, 10); (102, 15); (107, 12)])
 
 class \nodoc\ iso _DocHighlightParamTest is UnitTest
   """
@@ -172,15 +229,24 @@ class \nodoc\ iso _DocHighlightParamTest is UnitTest
     line 96 col  4  (x — return value)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/param"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (94, 14), [(94, 14); (95, 18); (96, 4)])
+    let at: (I64, I64) = (94, 14)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h, action, at, [(94, 14); (95, 18); (96, 4)])
 
 class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
   """
@@ -192,16 +258,24 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
     line 108 col  4  (w return value)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/var_local"
 
   fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (106, 8)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
     _server.test_document_highlight(
-      h, (106, 8), [(106, 8); (107, 4); (107, 8); (108, 4)])
+      h, action, at, [(106, 8); (107, 4); (107, 8); (108, 4)])
 
 class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
   """
@@ -211,15 +285,23 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
     line 121 col  4  (run(1) call in trigger)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/be_ref"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (117, 5), [(117, 5); (121, 4)])
+    let at: (I64, I64) = (117, 5)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [(117, 5); (121, 4)])
 
 class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
   """
@@ -232,16 +314,24 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
     line  91 col 13  (_Inner.create() receiver in other)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/class_type"
 
   fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (81, 16)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
     _server.test_document_highlight(
-      h, (81, 16), [(33, 6); (81, 16); (86, 13); (91, 13)])
+      h, action, at, [(33, 6); (81, 16); (86, 13); (91, 13)])
 
 class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
   """
@@ -252,15 +342,23 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
     line  98 col 22  (_HighlightMore in get_self return type)
   """
   let _server: _DocHighlightLspServer
+  let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer) =>
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
     _server = server
+    _fixture = fixture
 
   fun name(): String =>
     "document_highlight/integration/type_ref"
 
   fun apply(h: TestHelper) =>
-    _server.test_document_highlight(h, (98, 22), [(54, 6); (98, 22)])
+    let at: (I64, I64) = (98, 22)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [(54, 6); (98, 22)])
 
 class val _PendingDocHighlight
   let file_path: String
@@ -314,18 +412,12 @@ actor _DocHighlightLspServer is Channel
 
   be test_document_highlight(
     h: TestHelper,
+    action: String val,
     at: (I64, I64),
     expected: Array[(I64, I64)] val)
   =>
     (let line, let character) = at
     let file_path = _fixture_file
-    h.long_test(10_000_000_000)
-    let action: String val =
-      recover
-        file_path.trim(_workspace_dir.size() + 1) +
-        ":" + line.string() + ":" + character.string()
-      end
-    h.expect_action(action)
     let pending =
       _PendingDocHighlight(file_path, line, character, expected, h, action)
     if _ready then

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -25,6 +25,19 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightTypeRefTest.create(server, fixture))
     test(_DocHighlightLiteralTest.create(server, fixture))
     test(_DocHighlightNoneTest.create(server, fixture))
+    test(_DocHighlightInnerXFieldTest.create(server, fixture))
+    test(_DocHighlightValFieldTest.create(server, fixture))
+    test(_DocHighlightDoWorkParamTest.create(server, fixture))
+    test(_DocHighlightDoWorkLetTest.create(server, fixture))
+    test(_DocHighlightLetRefTest.create(server, fixture))
+    test(_DocHighlightVarRefTest.create(server, fixture))
+    test(_DocHighlightParamRefTest.create(server, fixture))
+    test(_DocHighlightNewRefCallTest.create(server, fixture))
+    test(_DocHighlightIntLiteralTest.create(server, fixture))
+    test(_DocHighlightFloatLiteralTest.create(server, fixture))
+    test(_DocHighlightStringLiteralTest.create(server, fixture))
+    test(_DocHighlightWhitespaceTest.create(server, fixture))
+    test(_DocHighlightOutOfBoundsTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -424,6 +437,384 @@ class \nodoc\ iso _DocHighlightNoneTest is UnitTest
 
   fun apply(h: TestHelper) =>
     let at: (I64, I64) = (122, 4)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
+  """
+  Highlights the `x` fvar field of _Inner from its declaration.
+  Expects 2 occurrences:
+    line 49 col 6  (var x declaration in _Inner)
+    line 52 col 4  (x = 0 assignment in create)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/inner_x_field"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (49, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(49, 6, 49, 7); (52, 4, 52, 5)])
+
+class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
+  """
+  Highlights the `_val` fvar field of _HighlightMore from its declaration.
+  Expects 5 occurrences:
+    line 82 col  6  (_val declaration)
+    line 87 col  4  (_val = 0 in create)
+    line 92 col  4  (_val = 1 in other)
+    line 95 col  4  (_val = ... LHS in add)
+    line 95 col 11  (... + _val RHS in add)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/val_field"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (82, 6)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [ (82, 6, 82, 10); (87, 4, 87, 8); (92, 4, 92, 8)
+        (95, 4, 95, 8); (95, 11, 95, 15)])
+
+class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
+  """
+  Highlights the `n` parameter of do_work from its declaration.
+  Expects 3 occurrences:
+    line 104 col 18  (n param declaration in do_work)
+    line 105 col 17  (let v: U32 = n)
+    line 107 col 16  (w = w + add(n))
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/do_work_param"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (104, 18)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(104, 18, 104, 19); (105, 17, 105, 18); (107, 16, 107, 17)])
+
+class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
+  """
+  Highlights the `v` let local of do_work from its declaration.
+  Expects 2 occurrences:
+    line 105 col  8  (let v declaration in do_work)
+    line 106 col 17  (var w: U32 = v)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/do_work_let"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (105, 8)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(105, 8, 105, 9); (106, 17, 106, 18)])
+
+class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
+  """
+  Highlights `result` from a letref site (line 31 col 4).
+  Verifies that starting from a reference produces the same highlights
+  as starting from the declaration (_DocHighlightLocalTest).
+  Expects 3 occurrences:
+    line 30 col  8  (let result declaration)
+    line 31 col  4  (first use in result + result)
+    line 31 col 13  (second use in result + result)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/let_ref"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (31, 4)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)])
+
+class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
+  """
+  Highlights `w` from a varref site (line 107 col 4).
+  Verifies that starting from a reference produces the same highlights
+  as starting from the declaration (_DocHighlightVarLocalTest).
+  Expects 4 occurrences:
+    line 106 col 8  (var w declaration)
+    line 107 col 4  (w = w + ... LHS)
+    line 107 col 8  (w = w + ... RHS)
+    line 108 col 4  (w return value)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/var_ref"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (107, 4)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(106, 8, 106, 9); (107, 4, 107, 5); (107, 8, 107, 9); (108, 4, 108, 5)])
+
+class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
+  """
+  Highlights `x` from a paramref site (line 95 col 18).
+  Verifies that starting from a reference produces the same highlights
+  as starting from the declaration (_DocHighlightParamTest).
+  Expects 3 occurrences:
+    line 94 col 14  (x param declaration in add)
+    line 95 col 18  (_val = _val + x — body use)
+    line 96 col  4  (x — return value)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/param_ref"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (95, 18)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)])
+
+class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
+  """
+  Highlights `create` from a call site (_Inner.create() on line 86 col 20).
+  Verifies that starting from a newref reference produces the same highlights
+  as starting from the declaration (_DocHighlightNewRefTest).
+  Expects 3 occurrences:
+    line 51 col  6  (new create declaration in _Inner)
+    line 86 col 20  (_Inner.create() in _HighlightMore.create body)
+    line 91 col 20  (_Inner.create() in _HighlightMore.other body)
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/new_ref_call"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (86, 20)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(
+      h,
+      action,
+      at,
+      [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)])
+
+class \nodoc\ iso _DocHighlightIntLiteralTest is UnitTest
+  """
+  Placing the cursor on an integer literal should produce no highlights.
+  Tests `0` on line 87 col 11 (_val = 0 in _HighlightMore.create).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/int_literal"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (87, 11)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightFloatLiteralTest is UnitTest
+  """
+  Placing the cursor on a float literal should produce no highlights.
+  Tests `3.14` on line 132 col 16 (let _f: F64 = 3.14 in _LiteralExamples).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/float_literal"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (132, 16)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightStringLiteralTest is UnitTest
+  """
+  Placing the cursor on a string literal should produce no highlights.
+  Tests `"hello"` on line 133 col 23 (in _LiteralExamples).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/string_literal"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (133, 23)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightWhitespaceTest is UnitTest
+  """
+  Placing the cursor on a blank line should produce no highlights.
+  Tests line 22 col 0 (blank line between count field and tick method).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/whitespace"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (22, 0)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
+
+class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
+  """
+  Placing the cursor past the end of a line should produce no highlights.
+  Tests line 21 col 100 (past end of `  var count: U32 = 0`).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/out_of_bounds"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (21, 100)
     (let line, let character) = at
     let action: String val =
       recover _fixture + ":" + line.string() + ":" + character.string() end

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -1,0 +1,499 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+primitive _DocumentHighlightIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server =
+      _DocHighlightLspServer(workspace_dir, "highlights/highlights.pony")
+    test(_DocHighlightFieldTest.create(server))
+    test(_DocHighlightFieldRefTest.create(server))
+    test(_DocHighlightLocalTest.create(server))
+    test(_DocHighlightFletTest.create(server))
+    test(_DocHighlightEmbedTest.create(server))
+    test(_DocHighlightNewRefTest.create(server))
+    test(_DocHighlightFunRefTest.create(server))
+    test(_DocHighlightParamTest.create(server))
+    test(_DocHighlightVarLocalTest.create(server))
+    test(_DocHighlightBeRefTest.create(server))
+    test(_DocHighlightClassTypeTest.create(server))
+    test(_DocHighlightTypeRefTest.create(server))
+
+class \nodoc\ iso _DocHighlightFieldTest
+  is UnitTest
+  """
+  Highlights the `count` field from its declaration site.
+  Expects all 5 occurrences to be found:
+    line 21 col  6  (var count declaration)
+    line 24 col  4  (tick LHS)
+    line 24 col 12  (tick RHS)
+    line 27 col  4  (value() body)
+    line 30 col 22  (use_local() body)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/field"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(
+      h, (21, 6), [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+
+class \nodoc\ iso _DocHighlightFieldRefTest
+  is UnitTest
+  """
+  Highlights the `count` field from a reference site (line 27 col 4).
+  Expects the same 5 occurrences as when starting from the declaration.
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/field_ref"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(
+      h, (27, 4), [(21, 6); (24, 4); (24, 12); (27, 4); (30, 22)])
+
+class \nodoc\ iso _DocHighlightLocalTest
+  is UnitTest
+  """
+  Highlights the `result` local variable from its declaration site.
+  Expects 3 occurrences:
+    line 30 col  8  (let result declaration)
+    line 31 col  4  (first use in result + result)
+    line 31 col 13  (second use in result + result)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/local"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (30, 8), [(30, 8); (31, 4); (31, 13)])
+
+class \nodoc\ iso _DocHighlightFletTest is UnitTest
+  """
+  Highlights the `_flag` let field from its declaration.
+  Expects 3 occurrences:
+    line 80 col  6  (_flag declaration)
+    line 85 col  4  (assigned true in create)
+    line 90 col  4  (assigned false in other)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/flet"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (80, 6), [(80, 6); (85, 4); (90, 4)])
+
+class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
+  """
+  Highlights the `_inner` embed field from its declaration.
+  Expects 3 occurrences:
+    line 81 col  8  (_inner embed declaration)
+    line 86 col  4  (assigned in create)
+    line 91 col  4  (assigned in other)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/embed"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (81, 8), [(81, 8); (86, 4); (91, 4)])
+
+class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
+  """
+  Highlights `create` constructor of _Inner from its declaration.
+  Expects 3 occurrences:
+    line 51 col  6  (new create declaration in _Inner)
+    line 86 col 20  (_Inner.create() in create body)
+    line 91 col 20  (_Inner.create() in other body)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/new_ref"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (51, 6), [(51, 6); (86, 20); (91, 20)])
+
+class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
+  """
+  Highlights `add` from its declaration, covering tk_fun,
+  tk_funref (direct call), and tk_funchain (chained call).
+  Expects 3 occurrences:
+    line 94 col 10  (fun ref add declaration)
+    line 102 col 15  (get_self().add(1) — funchain)
+    line 107 col 12  (w = w + add(n) — funref)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/fun_ref"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(
+      h, (94, 10), [(94, 10); (102, 15); (107, 12)])
+
+class \nodoc\ iso _DocHighlightParamTest is UnitTest
+  """
+  Highlights the `x` parameter of `add` from its declaration.
+  Expects 3 occurrences:
+    line 94 col 14  (x param declaration in add)
+    line 95 col 18  (_val = _val + x — body use)
+    line 96 col  4  (x — return value)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/param"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (94, 14), [(94, 14); (95, 18); (96, 4)])
+
+class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
+  """
+  Highlights the `w` var local from its declaration.
+  Expects 4 occurrences:
+    line 106 col  8  (var w declaration)
+    line 107 col  4  (w = w + ... LHS)
+    line 107 col  8  (w = w + ... RHS)
+    line 108 col  4  (w return value)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/var_local"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(
+      h, (106, 8), [(106, 8); (107, 4); (107, 8); (108, 4)])
+
+class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
+  """
+  Highlights the `run` behaviour from its declaration.
+  Expects 2 occurrences:
+    line 117 col  5  (be run declaration)
+    line 121 col  4  (run(1) call in trigger)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/be_ref"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (117, 5), [(117, 5); (121, 4)])
+
+class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
+  """
+  Highlights the `_Inner` class from a reference site,
+  covering tk_class and all tk_nominal/tk_typeref references.
+  Expects 4 occurrences:
+    line  33 col  6  (class _Inner declaration)
+    line  81 col 16  (embed _inner: _Inner type annotation)
+    line  86 col 13  (_Inner.create() receiver in create)
+    line  91 col 13  (_Inner.create() receiver in other)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/class_type"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(
+      h, (81, 16), [(33, 6); (81, 16); (86, 13); (91, 13)])
+
+class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
+  """
+  Highlights the `_HighlightMore` class from a reference site,
+  covering tk_class and tk_nominal in a return type annotation.
+  Expects 2 occurrences:
+    line  54 col  6  (class _HighlightMore declaration)
+    line  98 col 22  (_HighlightMore in get_self return type)
+  """
+  let _server: _DocHighlightLspServer
+
+  new iso create(server: _DocHighlightLspServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_highlight/integration/type_ref"
+
+  fun apply(h: TestHelper) =>
+    _server.test_document_highlight(h, (98, 22), [(54, 6); (98, 22)])
+
+class val _PendingDocHighlight
+  let file_path: String
+  let line: I64
+  let character: I64
+  let expected: Array[(I64, I64)] val
+  let h: TestHelper
+  let action: String
+
+  new val create(
+    file_path': String,
+    line': I64,
+    character': I64,
+    expected': Array[(I64, I64)] val,
+    h': TestHelper,
+    action': String)
+  =>
+    file_path = file_path'
+    line = line'
+    character = character'
+    expected = expected'
+    h = h'
+    action = action'
+
+actor _DocHighlightLspServer is Channel
+  """
+  Shared LSP server for all document highlight integration tests.
+  Initializes and compiles the workspace once, then dispatches
+  individual documentHighlight requests.
+  """
+  let _workspace_dir: String
+  let _fixture_file: String
+  var _server: (BaseProtocol | None)
+  var _ready: Bool
+  var _initialized: Bool
+  let _pending: Array[_PendingDocHighlight]
+  let _opened: Set[String]
+  let _in_flight: Map[I64, _PendingDocHighlight]
+  var _next_id: I64
+
+  new create(workspace_dir: String, fixture: String) =>
+    _workspace_dir = workspace_dir
+    _fixture_file = Path.join(workspace_dir, fixture)
+    _server = None
+    _ready = false
+    _initialized = false
+    _pending = Array[_PendingDocHighlight]
+    _opened = Set[String]
+    _in_flight = Map[I64, _PendingDocHighlight]
+    _next_id = 2
+
+  be test_document_highlight(
+    h: TestHelper,
+    at: (I64, I64),
+    expected: Array[(I64, I64)] val)
+  =>
+    (let line, let character) = at
+    let file_path = _fixture_file
+    h.long_test(10_000_000_000)
+    let action: String val =
+      recover
+        file_path.trim(_workspace_dir.size() + 1) +
+        ":" + line.string() + ":" + character.string()
+      end
+    h.expect_action(action)
+    let pending =
+      _PendingDocHighlight(file_path, line, character, expected, h, action)
+    if _ready then
+      if not _opened.contains(file_path) then
+        _opened.set(file_path)
+        _did_open(file_path)
+      end
+      _dispatch(pending)
+    else
+      _pending.push(pending)
+    end
+    if not _initialized then
+      _initialized = true
+      let ponyc = try h.env.args(0)? else "" end
+      let proto =
+        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
+      _server = proto
+      proto(LspMsg.initialize(_workspace_dir))
+    end
+
+  fun ref _dispatch(pending: _PendingDocHighlight) =>
+    let id = _next_id
+    _next_id = id + 1
+    try
+      (_server as BaseProtocol)(
+        RequestMessage(
+          id,
+          Methods.text_document().document_highlight(),
+          JsonObject
+            .update(
+              "textDocument",
+              JsonObject
+                .update("uri", Uris.from_path(pending.file_path)))
+            .update(
+              "position",
+              JsonObject
+                .update("line", pending.line)
+                .update("character", pending.character))
+        ).into_bytes()
+      )
+      _in_flight(id) = pending
+    else
+      pending.h.fail_action(pending.action)
+    end
+
+  be send(msg: Message val) =>
+    match msg
+    | let res: ResponseMessage val =>
+      try
+        let id = res.id as RequestId
+        if RequestIds.eq(id, I64(0)) then
+          try
+            (_server as BaseProtocol)(LspMsg.initialized())
+          end
+        else
+          try
+            let id_i64 = id as I64
+            (_, let pending) = _in_flight.remove(id_i64)?
+            _check_response(res, pending)
+          end
+        end
+      end
+    | let req: RequestMessage val =>
+      if req.method == Methods.workspace().configuration() then
+        try
+          let proto = _server as BaseProtocol
+          proto(ResponseMessage(req.id, JsonArray).into_bytes())
+          for p in _pending.values() do
+            if not _opened.contains(p.file_path) then
+              _opened.set(p.file_path)
+              _did_open(p.file_path)
+            end
+          end
+        end
+      end
+    | let n: Notification val =>
+      if n.method == Methods.text_document().publish_diagnostics() then
+        if not _ready then
+          _ready = true
+          for p in _pending.values() do
+            _dispatch(p)
+          end
+          _pending.clear()
+        end
+      end
+    end
+
+  fun ref _check_response(
+    res: ResponseMessage val,
+    pending: _PendingDocHighlight)
+  =>
+    var ok = true
+    match res.result
+    | let arr: JsonArray =>
+      let got = arr.size()
+      let want = pending.expected.size()
+      if not pending.h.assert_eq[USize](
+        want,
+        got,
+        "Expected " + want.string() + " highlights, got " + got.string())
+      then
+        ok = false
+        // Log all actual positions to diagnose unexpected highlights
+        for item in arr.values() do
+          try
+            let start = JsonNav(item)("range")("start")
+            let l = start("line").as_i64()?
+            let c = start("character").as_i64()?
+            pending.h.log(
+              "  actual highlight at (" +
+              l.string() + ", " + c.string() + ")")
+          end
+        end
+      end
+      for (exp_line, exp_char) in pending.expected.values() do
+        var found = false
+        for item in arr.values() do
+          try
+            let start = JsonNav(item)("range")("start")
+            let l = start("line").as_i64()?
+            let c = start("character").as_i64()?
+            if (l == exp_line) and (c == exp_char) then
+              found = true
+              break
+            end
+          end
+        end
+        if not pending.h.assert_true(
+          found,
+          "Expected highlight at line " +
+          exp_line.string() + " col " +
+          exp_char.string() + " not found")
+        then
+          ok = false
+        end
+      end
+    else
+      if pending.expected.size() > 0 then
+        ok = false
+        pending.h.log("Expected highlights but got null")
+      end
+    end
+    if ok then
+      pending.h.complete_action(pending.action)
+    else
+      pending.h.fail_action(pending.action)
+    end
+
+  fun ref _did_open(file_path: String) =>
+    try
+      (_server as BaseProtocol)(
+        Notification(
+          Methods.text_document().did_open(),
+          JsonObject.update(
+            "textDocument",
+            JsonObject
+              .update("uri", Uris.from_path(file_path))
+              .update("languageId", "pony")
+              .update("version", I64(1))
+              .update("text", ""))
+        ).into_bytes())
+    end
+
+  be log(data: String val, message_type: MessageType = Debug) =>
+    None
+
+  be set_notifier(notifier: Notifier tag) =>
+    None
+
+  be dispose() =>
+    None

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -23,6 +23,7 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightBeRefTest.create(server, fixture))
     test(_DocHighlightClassTypeTest.create(server, fixture))
     test(_DocHighlightTypeRefTest.create(server, fixture))
+    test(_DocHighlightLiteralTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -359,6 +360,30 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
     h.long_test(10_000_000_000)
     h.expect_action(action)
     _server.test_document_highlight(h, action, at, [(54, 6); (98, 22)])
+
+class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
+  """
+  Placing the cursor on a literal value should produce no highlights.
+  Tests `true` on line 85 col 12 (_flag = true in create).
+  """
+  let _server: _DocHighlightLspServer
+  let _fixture: String val
+
+  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/literal"
+
+  fun apply(h: TestHelper) =>
+    let at: (I64, I64) = (85, 12)
+    (let line, let character) = at
+    let action: String val =
+      recover _fixture + ":" + line.string() + ":" + character.string() end
+    h.long_test(10_000_000_000)
+    h.expect_action(action)
+    _server.test_document_highlight(h, action, at, [])
 
 class val _PendingDocHighlight
   let file_path: String

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -25,6 +25,7 @@ actor Main is TestList
     _DiagnosticTests.make().tests(test)
     _HoverIntegrationTests.make().tests(test)
     _DefinitionIntegrationTests.make().tests(test)
+    _DocumentHighlightIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -1,0 +1,122 @@
+"""
+Test fixtures for exercising LSP document highlight functionality.
+
+Open this file in an LSP-aware editor while the Pony language server
+is active. Place the cursor on any symbol described in the class
+docstrings below. The editor should highlight all occurrences of that
+symbol in the file simultaneously. Placing the cursor on a declaration
+or any reference produces the same set of highlights.
+"""
+
+class Highlights
+  """
+  Demonstrates fvar field and let local highlights.
+
+  Place the cursor on `count` to see all 5 occurrences highlighted:
+  the field declaration, both sides of the assignment in tick, the
+  return value in value, and the right-hand side in use_local.
+
+  Place the cursor on `result` to see 3 occurrences highlighted:
+  the let declaration and both uses in the expression below it.
+  """
+  var count: U32 = 0
+
+  fun ref tick() =>
+    count = count + 1
+
+  fun box value(): U32 =>
+    count
+
+  fun box use_local(): U32 =>
+    let result: U32 = count
+    result + result
+
+class _Inner
+  """
+  Demonstrates class-type, fvar field, and constructor highlights.
+  This class is embedded inside _HighlightMore.
+
+  Place the cursor on the `_Inner` class name to see all 4
+  occurrences highlighted: the declaration here, the embed type
+  annotation in _HighlightMore, and both _Inner.create() receiver
+  expressions in _HighlightMore's constructors.
+
+  Place the cursor on `x` to see both occurrences: the field
+  declaration and the assignment in create.
+
+  Place the cursor on `create` to see all 3 occurrences: the
+  constructor declaration here and both call sites in _HighlightMore.
+  """
+  var x: U32 = 0
+
+  new create() =>
+    x = 0
+
+class _HighlightMore
+  """
+  Demonstrates flet, embed, fun/funref/funchain, param, and var
+  local highlights. Also demonstrates class-type highlights for
+  _HighlightMore itself.
+
+  Place the cursor on `_HighlightMore` (the class name) to see
+  both occurrences: the declaration and the return type of get_self.
+
+  Place the cursor on `_flag` to see all 3 occurrences: the flet
+  declaration and its assignment in each constructor.
+
+  Place the cursor on `_inner` to see all 3 occurrences: the embed
+  declaration and its assignment in each constructor.
+
+  Place the cursor on `add` to see all 3 occurrences, exercising
+  three call forms: the fun declaration, a chained call via
+  get_self().add(1) (tk_funchain), and a direct call in do_work
+  (tk_funref).
+
+  Place the cursor on the `x` parameter of add to see all 3
+  occurrences: the parameter declaration and both uses in the body.
+
+  Place the cursor on `w` in do_work to see all 3 occurrences: the
+  var declaration and both sides of the assignment below it.
+  """
+  let _flag: Bool
+  embed _inner: _Inner
+  var _val: U32
+
+  new create() =>
+    _flag = true
+    _inner = _Inner.create()
+    _val = 0
+
+  new other() =>
+    _flag = false
+    _inner = _Inner.create()
+    _val = 1
+
+  fun ref add(x: U32): U32 =>
+    _val = _val + x
+    x
+
+  fun ref get_self(): _HighlightMore ref =>
+    this
+
+  fun ref chain_add(): U32 =>
+    get_self().add(1)
+
+  fun ref do_work(n: U32): U32 =>
+    let v: U32 = n
+    var w: U32 = v
+    w = w + add(n)
+    w
+
+actor _HighlightRunner
+  """
+  Demonstrates behaviour and beref highlights.
+
+  Place the cursor on `run` to see both occurrences: the behaviour
+  declaration and the call site in trigger.
+  """
+  be run(n: U32) =>
+    None
+
+  fun ref trigger() =>
+    run(1)

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -75,8 +75,8 @@ class _HighlightMore
   Place the cursor on the `x` parameter of add to see all 3
   occurrences: the parameter declaration and both uses in the body.
 
-  Place the cursor on `w` in do_work to see all 3 occurrences: the
-  var declaration and both sides of the assignment below it.
+  Place the cursor on `w` in do_work to see all 4 occurrences: the var
+  declaration, both sides of the assignment below it, and the return expression.
   """
   let _flag: Bool
   embed _inner: _Inner

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -114,6 +114,10 @@ actor _HighlightRunner
 
   Place the cursor on `run` to see both occurrences: the behaviour
   declaration and the call site in trigger.
+
+  Place the cursor on `None` in the body of run to see no highlights:
+  None is a type-literal expression that the compiler desugars to an
+  implicit None.create() call and has no referenceable identity.
   """
   be run(n: U32) =>
     None

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -124,3 +124,11 @@ actor _HighlightRunner
 
   fun ref trigger() =>
     run(1)
+
+class _LiteralExamples
+  """
+  Provides float and string literal expressions for testing that
+  cursor-on-literal produces no highlights.
+  """
+  let _f: F64 = 3.14
+  let _s: String val = "hello"

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -39,10 +39,38 @@ primitive DocumentHighlights
       end
     end
 
+    // When the cursor lands on the name identifier of an entity declaration
+    // (tk_class, tk_actor, etc.), _refine_node returns the bare tk_id rather
+    // than the enclosing entity node. Promote to the entity node so that
+    // references to the type (which resolve to tk_class, not its tk_id child)
+    // are found by the walker.
+    let node' =
+      if nid == TokenIds.tk_id() then
+        try
+          let par = node.parent() as AST box
+          match par.id()
+          | TokenIds.tk_class()
+          | TokenIds.tk_actor()
+          | TokenIds.tk_struct()
+          | TokenIds.tk_primitive()
+          | TokenIds.tk_trait()
+          | TokenIds.tk_interface()
+          | TokenIds.tk_type() =>
+            par
+          else
+            node
+          end
+        else
+          node
+        end
+      else
+        node
+      end
+
     // Determine the canonical target definition.
     // If the node has no definitions it IS the
     // definition; use it directly as the target.
-    let defs = node.definitions()
+    let defs = node'.definitions()
     let target: AST val =
       if defs.size() > 0 then
         try
@@ -51,7 +79,7 @@ primitive DocumentHighlights
           return []
         end
       else
-        AST(node.raw)
+        AST(node'.raw)
       end
 
     let collector = _HighlightCollector(target)

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -22,6 +22,23 @@ primitive DocumentHighlights
       return []
     end
 
+    // Type-literal expressions such as `None` are desugared by the compiler
+    // into implicit constructor calls `TypeName.create()`. The resulting
+    // tk_newref and its enclosing tk_call are both placed at the same source
+    // position (the marker ponyc uses for synthetic, position-less nodes).
+    // These have no referenceable identity the user can navigate — do not
+    // highlight them.
+    if nid == TokenIds.tk_newref() then
+      try
+        let par = node.parent() as AST box
+        if (par.id() == TokenIds.tk_call()) and
+          (par.position() == node.position())
+        then
+          return []
+        end
+      end
+    end
+
     // Determine the canonical target definition.
     // If the node has no definitions it IS the
     // definition; use it directly as the target.

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -13,6 +13,15 @@ primitive DocumentHighlights
     Walk the module AST and return the source ranges of all nodes that resolve
     to the same definition as `node`. Includes the definition site itself.
     """
+    // Literals have no referenceable identity — do not highlight.
+    let nid = node.id()
+    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
+      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
+      or (nid == TokenIds.tk_string())
+    then
+      return []
+    end
+
     // Determine the canonical target definition.
     // If the node has no definitions it IS the
     // definition; use it directly as the target.

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -56,7 +56,7 @@ class ref _HighlightCollector is ASTVisitor
 
     // Check if this node IS the target definition
     // or resolves to it via DefinitionResolver
-    var matches = (AST(ast.raw) == _target)
+    var matches = (ast == _target)
     if not matches then
       for def in ast.definitions().values() do
         if def == _target then

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -1,0 +1,164 @@
+use ".."
+use "collections"
+use "pony_compiler"
+
+primitive DocumentHighlights
+  """
+  Collects document highlight ranges for a given AST node within a module, by
+  walking the module AST and finding all nodes that resolve to the same
+  definition.
+  """
+  fun collect(node: AST box, module: Module val): Array[LspPositionRange] =>
+    """
+    Walk the module AST and return the source ranges of all nodes that resolve
+    to the same definition as `node`. Includes the definition site itself.
+    """
+    // Determine the canonical target definition.
+    // If the node has no definitions it IS the
+    // definition; use it directly as the target.
+    let defs = node.definitions()
+    let target: AST val =
+      if defs.size() > 0 then
+        try
+          AST(defs(0)?.raw)
+        else
+          return []
+        end
+      else
+        AST(node.raw)
+      end
+
+    let collector = _HighlightCollector(target)
+    module.ast.visit(collector)
+    collector.highlights()
+
+class ref _HighlightCollector is ASTVisitor
+  """
+  AST visitor that collects the source ranges of all nodes that resolve to a
+  given target definition AST node.
+  """
+  let _target: AST val
+  let _highlights: Array[LspPositionRange] ref
+  let _seen: Set[String]
+
+  new ref create(target: AST val) =>
+    _target = target
+    _highlights = Array[LspPositionRange].create()
+    _seen = Set[String].create()
+
+  fun ref visit(ast: AST box): VisitResult =>
+    // Skip synthetic tk_this nodes: their definitions() resolve to the
+    // enclosing class entity, causing all implicit receivers inside a
+    // class to spuriously match when targeting that class.
+    if ast.id() == TokenIds.tk_this() then
+      return Continue
+    end
+
+    // Check if this node IS the target definition
+    // or resolves to it via DefinitionResolver
+    var matches = (AST(ast.raw) == _target)
+    if not matches then
+      for def in ast.definitions().values() do
+        if def == _target then
+          matches = true
+          break
+        end
+      end
+    end
+
+    if matches then
+      let hl_node = _node_to_highlight(ast)
+      (let start_pos, let end_pos) = hl_node.span()
+      // Deduplicate: skip if this start position was already added
+      // (e.g. declaration node and its tk_id child can both resolve
+      // to the same target and produce the same highlight span).
+      let key: String val =
+        recover val
+          start_pos.line().string() + ":" + start_pos.column().string()
+        end
+      if not _seen.contains(key) then
+        _seen.set(key)
+        _highlights.push(
+          LspPositionRange(
+            LspPosition.from_ast_pos(start_pos),
+            LspPosition.from_ast_pos_end(end_pos)))
+      end
+    end
+    Continue
+
+  fun ref highlights(): Array[LspPositionRange] =>
+    _highlights
+
+  fun _node_to_highlight(ast: AST box): AST box =>
+    """
+    Return the sub-node whose source span should be highlighted — usually the
+    identifier token.
+    """
+    match ast.id()
+    | TokenIds.tk_class()
+    | TokenIds.tk_actor()
+    | TokenIds.tk_trait()
+    | TokenIds.tk_interface()
+    | TokenIds.tk_primitive()
+    | TokenIds.tk_type()
+    | TokenIds.tk_struct()
+    | TokenIds.tk_flet()
+    | TokenIds.tk_fvar()
+    | TokenIds.tk_embed()
+    | TokenIds.tk_let()
+    | TokenIds.tk_var()
+    | TokenIds.tk_param() =>
+      // Declarations: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fun()
+    | TokenIds.tk_be()
+    | TokenIds.tk_new()
+    | TokenIds.tk_nominal()
+    | TokenIds.tk_typeref() =>
+      // Methods/types: identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fvarref()
+    | TokenIds.tk_fletref()
+    | TokenIds.tk_embedref() =>
+      // Field references: field name identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_funref()
+    | TokenIds.tk_beref()
+    | TokenIds.tk_newref()
+    | TokenIds.tk_newberef()
+    | TokenIds.tk_funchain()
+    | TokenIds.tk_bechain() =>
+      // Method call references: method name is
+      // the sibling of the receiver child
+      try
+        let receiver = ast.child() as AST
+        let method = receiver.sibling() as AST
+        if method.id() == TokenIds.tk_id() then
+          return method
+        end
+      end
+    | TokenIds.tk_reference() =>
+      // Variable references: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    end
+    ast

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -725,10 +725,64 @@ actor WorkspaceManager
       .update("contents", hover_contents)
       .update("range", hover_range.to_json())
 
-  be goto_definition(
-    document_uri: String,
-    request: RequestMessage val)
-  =>
+  be document_highlight(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/documentHighlight request.
+    """
+    this._channel.log("Handling textDocument/documentHighlight")
+
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+
+    let document_path = Uris.to_path(document_uri)
+
+    try
+      let package: FilePath = this._find_workspace_package(document_path)?
+      match \exhaustive\ this._get_package(package)
+      | let pkg_state: PackageState =>
+        match \exhaustive\ pkg_state.get_document(document_path)
+        | let doc: DocumentState =>
+          let maybe_index = doc.position_index()
+          let maybe_module = doc.module()
+          match (maybe_index, maybe_module)
+          | (let index: PositionIndex, let module: Module val) =>
+            match \exhaustive\ index.find_node_at(
+              USize.from[I64](line + 1),
+              USize.from[I64](column + 1))
+            | let node: AST box =>
+              let ranges = DocumentHighlights.collect(node, module)
+              var json_arr = JsonArray
+              for range in ranges.values() do
+                json_arr =
+                  json_arr.push(JsonObject.update("range", range.to_json()))
+              end
+              this._channel.send(ResponseMessage(request.id, json_arr))
+              return
+            | None =>
+              this._channel.log(
+                "No AST node found @ " + line.string() + ":" + column.string())
+            end
+          else
+            this._channel.log(
+              "No index or module available for " + document_path)
+          end
+        | None =>
+          this._channel.log(
+            "No document state available for " + document_path)
+        end
+      | None =>
+        this._channel.log(
+          "No package state available for package: " + document_path)
+      end
+    else
+      this._channel.log("document not in workspace: " + document_path)
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be goto_definition(document_uri: String, request: RequestMessage val) =>
     """
     Handling the textDocument/definition request.
     """


### PR DESCRIPTION


## Context

The LSP server does not handle `textDocument/documentHighlight` requests. Editors use this to highlight all occurrences of the symbol under the cursor simultaneously.

## Changes

- Adds `DocumentHighlights.collect` which walks the module AST and finds all nodes resolving to the same definition as the cursor node
- Wires up the request in `WorkspaceManager` and routes it through `LanguageServer`
- Adds a highlight fixture and 12 integration tests covering fields, locals, parameters, constructors, functions, behaviours, and class/type names from both declaration and reference sites



https://github.com/user-attachments/assets/7d7f19bc-bbce-44ec-85eb-0f02ce4dd0b8




## Considerations

Synthetic AST nodes introduced by the refer pass (implicit `this` receivers, sugar-generated field initialisations) required explicit handling to avoid spurious highlights.