### PR TITLE
Fix `FloatingPoint.frexp` returning unsigned exponent

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -103,3 +103,17 @@ Shuffle applies to all scheduling modes. For CI environments that run tests sequ
 
 The `style/blank-lines` rule incorrectly counted blank lines inside multi-line docstrings as blank lines between members. A method or field whose docstring contained blank lines (e.g., between paragraphs) would be flagged for having too many blank lines before the next member. The rule now correctly identifies where a docstring ends rather than using only its start line.
 
+## Fix `FloatingPoint.frexp` returning unsigned exponent
+
+`FloatingPoint.frexp` (and its implementations on `F32` and `F64`) returned the exponent as `U32` when C's `frexp` writes a signed `int`. Negative exponents were silently reinterpreted as large positive values.
+
+The return type is now `(A, I32)` instead of `(A, U32)`. If you destructure the result and type the exponent, update it:
+
+```pony
+// Before
+(let mantissa, let exp: U32) = my_float.frexp()
+
+// After
+(let mantissa, let exp: I32) = my_float.frexp()
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix spurious error when assigning to a field on an `as` cast in a try block ([PR #5070](https://github.com/ponylang/ponyc/pull/5070))
 - Fix segfault when using Generator.map with PonyCheck shrinking ([PR #5006](https://github.com/ponylang/ponyc/pull/5006))
 - Fix pony-lint blank-lines rule false positives on multi-line docstrings ([PR #5109](https://github.com/ponylang/ponyc/pull/5109))
+- Fix `FloatingPoint.frexp` returning unsigned exponent ([PR #5113](https://github.com/ponylang/ponyc/pull/5113))
 
 ### Added
 
@@ -21,6 +22,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 - Remove support for Alpine 3.20 ([PR #5094](https://github.com/ponylang/ponyc/pull/5094))
 - Remove docgen pass ([PR #5097](https://github.com/ponylang/ponyc/pull/5097))
+- Change `FloatingPoint.frexp` exponent return type from `U32` to `I32` ([PR #5113](https://github.com/ponylang/ponyc/pull/5113))
 
 ## [0.62.1] - 2026-03-28
 

--- a/packages/builtin/float.pony
+++ b/packages/builtin/float.pony
@@ -56,7 +56,7 @@ use @asinh[F64](x: F64)
 use @atanh[F64](x: F64)
 use @"llvm.copysign.f32"[F32](x: F32, sign: F32)
 use @"llvm.copysign.f64"[F64](x: F64, sign: F64)
-use @frexp[F64](value: F64, exponent: Pointer[U32])
+use @frexp[F64](value: F64, exponent: Pointer[I32])
 use @ldexpf[F32](value: F32, exponent: I32)
 use @ldexp[F64](value: F64, exponent: I32)
 
@@ -202,8 +202,8 @@ primitive F32 is FloatingPoint[F32]
   fun ldexp(x: F32, exponent: I32): F32 =>
     @ldexpf(x, exponent)
 
-  fun frexp(): (F32, U32) =>
-    var exponent: U32 = 0
+  fun frexp(): (F32, I32) =>
+    var exponent: I32 = 0
     var mantissa = @frexp(f64(), addressof exponent)
     (mantissa.f32(), exponent)
 
@@ -419,8 +419,8 @@ primitive F64 is FloatingPoint[F64]
   fun ldexp(x: F64, exponent: I32): F64 =>
     @ldexp(x, exponent)
 
-  fun frexp(): (F64, U32) =>
-    var exponent: U32 = 0
+  fun frexp(): (F64, I32) =>
+    var exponent: I32 = 0
     var mantissa = @frexp(this, addressof exponent)
     (mantissa, exponent)
 

--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -668,7 +668,7 @@ trait val FloatingPoint[A: FloatingPoint[A] val] is Real[A]
   fun nan(): Bool
 
   fun ldexp(x: A, exponent: I32): A
-  fun frexp(): (A, U32)
+  fun frexp(): (A, I32)
   fun log(): A
   fun log2(): A
   fun log10(): A


### PR DESCRIPTION
C's `frexp` writes a signed `int` for the exponent. The Pony wrapper declared it as `U32`, silently reinterpreting negative exponents as large positive values. Changed to `I32` across the FFI declaration, the `FloatingPoint` trait, and the `F32`/`F64` implementations.

Closes #5103