### PR TITLE
Fix rare silent connection hangs on macOS and BSD

### DIFF
--- a/.release-notes/fix-unchecked-kevent-returns.md
+++ b/.release-notes/fix-unchecked-kevent-returns.md
@@ -1,0 +1,17 @@
+## Fix rare silent connection hangs on macOS and BSD
+
+On macOS and BSD, if the OS failed to fully register an I/O event (due to resource exhaustion or an FD race), the failure was silently ignored. Actors waiting for network events that were never registered would hang indefinitely with no error. This could appear as connections that never complete, listeners that stop accepting, or timers that stop firing — with no indication of what went wrong.
+
+The runtime now detects these registration failures and notifies the affected actor, which tears down cleanly — the same as any other I/O failure. Stdlib consumers like `TCPConnection` and `TCPListener` handle this automatically.
+
+If you implement `AsioEventNotify` outside the stdlib, you can now detect registration failures with the new `AsioEvent.errored` predicate. Without handling it, a failure is silently ignored (the same behavior as before, but now you have the option to detect it):
+
+```pony
+be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
+  if AsioEvent.errored(flags) then
+    // Registration failed — tear down
+    _close()
+    return
+  end
+  // ... normal event handling
+```

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -31,6 +31,14 @@ primitive AsioEvent
     """
     flags == 0
 
+  fun errored(flags: U32): Bool =>
+    """
+    Returns true if the flags contain the error flag, indicating a
+    subscription failure. The event is compromised and the actor should
+    tear down.
+    """
+    (flags and (1 << 4)) != 0
+
   fun oneshotable(flags: U32): Bool =>
     """
     Returns true if the flags contain the oneshot flag.

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -122,6 +122,10 @@ actor Stdin is AsioEventNotify
     """
     if AsioEvent.disposable(flags) then
       @pony_asio_event_destroy(event)
+    elseif (_event is event) and AsioEvent.errored(flags) then
+      _close_event()
+      try (_notify as InputNotify).dispose() end
+      _notify = None
     elseif (_event is event) and AsioEvent.readable(flags) then
       _read()
     end

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -638,6 +638,22 @@ actor TCPConnection is AsioEventNotify
           @pony_os_socket_close(fd)
           _try_shutdown()
         end
+      elseif AsioEvent.errored(flags) then
+        // A subscription failure on a connection attempt.
+        var fd = @pony_asio_event_fd(event)
+        _connect_count = _connect_count - 1
+
+        if not _connected and not _closed then
+          @pony_asio_event_unsubscribe(event)
+          @pony_os_socket_close(fd)
+          _notify_connecting()
+        else
+          if not @pony_asio_event_get_disposable(event) then
+            @pony_asio_event_unsubscribe(event)
+          end
+          @pony_os_socket_close(fd)
+          _try_shutdown()
+        end
       else
         // It's not our event.
         if AsioEvent.disposable(flags) then
@@ -647,6 +663,11 @@ actor TCPConnection is AsioEventNotify
       end
     else
       // At this point, it's our event.
+      if AsioEvent.errored(flags) then
+        hard_close()
+        return
+      end
+
       if AsioEvent.writeable(flags) then
         _writeable = true
         _complete_writes(arg)

--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -150,6 +150,11 @@ actor TCPListener is AsioEventNotify
       return
     end
 
+    if AsioEvent.errored(flags) then
+      close()
+      return
+    end
+
     if AsioEvent.readable(flags) then
       _accept(arg)
     end

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -261,6 +261,11 @@ actor UDPSocket is AsioEventNotify
     end
 
     if not _closed then
+      if AsioEvent.errored(flags) then
+        _close()
+        return
+      end
+
       if AsioEvent.readable(flags) then
         _readable = true
         _complete_reads(arg)

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -221,6 +221,11 @@ actor ProcessMonitor is AsioEventNotify
     """
     Handle the incoming Asio event from one of the pipes.
     """
+    if AsioEvent.errored(flags) then
+      _close()
+      return
+    end
+
     match event
     | _stdin.event =>
       if AsioEvent.writeable(flags) then

--- a/packages/signals/signal_handler.pony
+++ b/packages/signals/signal_handler.pony
@@ -45,6 +45,8 @@ actor SignalHandler is AsioEventNotify
     """
     if AsioEvent.disposable(flags) then
       @pony_asio_event_destroy(event)
+    elseif (event is _event) and AsioEvent.errored(flags) then
+      _dispose()
     elseif event is _event then
       if not _notify(arg) then
         _dispose()

--- a/packages/time/timers.pony
+++ b/packages/time/timers.pony
@@ -81,6 +81,13 @@ actor Timers is AsioEventNotify
     """
     if AsioEvent.disposable(flags) then
       @pony_asio_event_destroy(event)
+    elseif (event is _event) and AsioEvent.errored(flags) then
+      for wheel in _wheel.values() do
+        wheel.clear()
+      end
+      _map.clear()
+      @pony_asio_event_unsubscribe(_event)
+      _event = AsioEvent.none()
     elseif event is _event then
       _advance()
     end

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -32,6 +32,7 @@ enum
   ASIO_WRITE = 1 << 1,
   ASIO_TIMER = 1 << 2,
   ASIO_SIGNAL = 1 << 3,
+  ASIO_ERROR = 1 << 4,
   ASIO_ONESHOT = 1 << 8,
   ASIO_DESTROYED = (uint32_t)-1
 };

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -30,6 +30,27 @@ struct asio_backend_t
   messageq_t q;
 };
 
+// Returns true if any entry in EV_RECEIPT results represents a real error.
+// With EV_RECEIPT, every result has EV_ERROR in flags; the distinguishing
+// factor is whether data is zero (success) or non-zero (errno).
+// Ignores EPIPE on macOS — the kernel delivers events despite the error.
+static bool kevent_receipt_has_error(struct kevent* results, int count)
+{
+  for(int i = 0; i < count; i++)
+  {
+    if(results[i].data != 0)
+    {
+#ifdef PLATFORM_IS_MACOSX
+      if(results[i].data == EPIPE)
+        continue;
+#endif
+      return true;
+    }
+  }
+
+  return false;
+}
+
 #if !defined(USE_SCHEDULER_SCALING_PTHREADS)
 static void empty_signal_handler(int sig)
 {
@@ -47,17 +68,33 @@ asio_backend_t* ponyint_asio_backend_init()
 
   if(b->kq == -1)
   {
+    ponyint_messageq_destroy(&b->q, true);
     POOL_FREE(asio_backend_t, b);
     return NULL;
   }
 
-  pipe(b->wakeup);
+  if(pipe(b->wakeup) == -1)
+  {
+    close(b->kq);
+    ponyint_messageq_destroy(&b->q, true);
+    POOL_FREE(asio_backend_t, b);
+    return NULL;
+  }
 
   struct kevent new_event;
   EV_SET(&new_event, b->wakeup[0], EVFILT_READ, EV_ADD, 0, 0, NULL);
 
   struct timespec t = {0, 0};
-  kevent(b->kq, &new_event, 1, NULL, 0, &t);
+
+  if(kevent(b->kq, &new_event, 1, NULL, 0, &t) == -1)
+  {
+    close(b->kq);
+    close(b->wakeup[0]);
+    close(b->wakeup[1]);
+    ponyint_messageq_destroy(&b->q, true);
+    POOL_FREE(asio_backend_t, b);
+    return NULL;
+  }
 
 #if !defined(USE_SCHEDULER_SCALING_PTHREADS)
   // Make sure we ignore signals related to scheduler sleeping/waking
@@ -121,13 +158,18 @@ PONY_API void pony_asio_event_resubscribe_read(asio_event_t* ev)
   kevent_flag_t kqueue_flags = ev->flags & ASIO_ONESHOT ? EV_ONESHOT : EV_CLEAR;
   if((ev->flags & ASIO_READ) && !ev->readable)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_READ, EV_ADD | kqueue_flags, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_READ,
+      EV_ADD | EV_RECEIPT | kqueue_flags, 0, 0, ev);
     i++;
   } else {
     return;
   }
 
-  kevent(b->kq, event, i, NULL, 0, NULL);
+  struct kevent results[1];
+  int rc = kevent(b->kq, event, i, results, i, NULL);
+
+  if((rc == -1) || kevent_receipt_has_error(results, i))
+    pony_asio_event_send(ev, ASIO_ERROR, 0);
 
   if(ev->fd == STDIN_FILENO)
     retry_loop(b);
@@ -152,13 +194,18 @@ PONY_API void pony_asio_event_resubscribe_write(asio_event_t* ev)
   kevent_flag_t kqueue_flags = ev->flags & ASIO_ONESHOT ? EV_ONESHOT : EV_CLEAR;
   if((ev->flags & ASIO_WRITE) && !ev->writeable)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_WRITE, EV_ADD | kqueue_flags, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_WRITE,
+      EV_ADD | EV_RECEIPT | kqueue_flags, 0, 0, ev);
     i++;
   } else {
     return;
   }
 
-  kevent(b->kq, event, i, NULL, 0, NULL);
+  struct kevent results[1];
+  int rc = kevent(b->kq, event, i, results, i, NULL);
+
+  if((rc == -1) || kevent_receipt_has_error(results, i))
+    pony_asio_event_send(ev, ASIO_ERROR, 0);
 
   if(ev->fd == STDIN_FILENO)
     retry_loop(b);
@@ -219,9 +266,6 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
         }
       } else {
         asio_event_t* ev = ep->udata;
-
-        if(ep->flags & EV_ERROR)
-          continue;
 
         switch(ep->filter)
         {
@@ -311,24 +355,26 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
   kevent_flag_t flags = ev->flags & ASIO_ONESHOT ? EV_ONESHOT : EV_CLEAR;
   if(ev->flags & ASIO_READ)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_READ, EV_ADD | flags, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_READ,
+      EV_ADD | EV_RECEIPT | flags, 0, 0, ev);
     i++;
   }
 
   if(ev->flags & ASIO_WRITE)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_WRITE, EV_ADD | flags, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_WRITE,
+      EV_ADD | EV_RECEIPT | flags, 0, 0, ev);
     i++;
   }
 
   if(ev->flags & ASIO_TIMER)
   {
 #ifdef PLATFORM_IS_BSD
-    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER, EV_ADD | EV_ONESHOT,
-      0, ev->nsec / 1000000, ev);
+    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
+      EV_ADD | EV_RECEIPT | EV_ONESHOT, 0, ev->nsec / 1000000, ev);
 #else
-    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER, EV_ADD | EV_ONESHOT,
-      NOTE_NSECONDS, ev->nsec, ev);
+    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
+      EV_ADD | EV_RECEIPT | EV_ONESHOT, NOTE_NSECONDS, ev->nsec, ev);
 #endif
     i++;
   }
@@ -351,11 +397,16 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
 
     sigaction((int)ev->nsec, &new_action, NULL);
 
-    EV_SET(&event[i], ev->nsec, EVFILT_SIGNAL, EV_ADD | EV_CLEAR, 0, 0, ev);
+    EV_SET(&event[i], ev->nsec, EVFILT_SIGNAL,
+      EV_ADD | EV_RECEIPT | EV_CLEAR, 0, 0, ev);
     i++;
   }
 
-  kevent(b->kq, event, i, NULL, 0, NULL);
+  struct kevent results[4];
+  int rc = kevent(b->kq, event, i, results, i, NULL);
+
+  if((rc == -1) || kevent_receipt_has_error(results, i))
+    pony_asio_event_send(ev, ASIO_ERROR, 0);
 
   if(ev->fd == STDIN_FILENO)
     retry_loop(b);
@@ -383,16 +434,20 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
     ev->nsec = nsec;
 
 #ifdef PLATFORM_IS_BSD
-    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER, EV_ADD | EV_ONESHOT,
-      0, ev->nsec / 1000000, ev);
+    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
+      EV_ADD | EV_RECEIPT | EV_ONESHOT, 0, ev->nsec / 1000000, ev);
 #else
-    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER, EV_ADD | EV_ONESHOT,
-      NOTE_NSECONDS, ev->nsec, ev);
+    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
+      EV_ADD | EV_RECEIPT | EV_ONESHOT, NOTE_NSECONDS, ev->nsec, ev);
 #endif
     i++;
   }
 
-  kevent(b->kq, event, i, NULL, 0, NULL);
+  struct kevent results[1];
+  int rc = kevent(b->kq, event, i, results, i, NULL);
+
+  if((rc == -1) || kevent_receipt_has_error(results, i))
+    pony_asio_event_send(ev, ASIO_ERROR, 0);
 }
 
 PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
@@ -414,19 +469,20 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
 
   if(ev->flags & ASIO_READ)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_READ, EV_DELETE, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_READ, EV_DELETE | EV_RECEIPT, 0, 0, ev);
     i++;
   }
 
   if(ev->flags & ASIO_WRITE)
   {
-    EV_SET(&event[i], ev->fd, EVFILT_WRITE, EV_DELETE, 0, 0, ev);
+    EV_SET(&event[i], ev->fd, EVFILT_WRITE, EV_DELETE | EV_RECEIPT, 0, 0, ev);
     i++;
   }
 
   if(ev->flags & ASIO_TIMER)
   {
-    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER, EV_DELETE, 0, 0, ev);
+    EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
+      EV_DELETE | EV_RECEIPT, 0, 0, ev);
     i++;
   }
 
@@ -448,11 +504,16 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
 
     sigaction((int)ev->nsec, &new_action, NULL);
 
-    EV_SET(&event[i], ev->nsec, EVFILT_SIGNAL, EV_DELETE, 0, 0, ev);
+    EV_SET(&event[i], ev->nsec, EVFILT_SIGNAL,
+      EV_DELETE | EV_RECEIPT, 0, 0, ev);
     i++;
   }
 
-  kevent(b->kq, event, i, NULL, 0, NULL);
+  // EV_RECEIPT ensures all EV_DELETE entries are processed regardless of
+  // individual failures. We don't send ASIO_ERROR here — the actor is
+  // tearing down, and ENOENT/EBADF on EV_DELETE is expected and benign.
+  struct kevent results[4];
+  kevent(b->kq, event, i, results, i, NULL);
 
   ev->flags = ASIO_DISPOSABLE;
 


### PR DESCRIPTION
The kqueue backend silently ignored failures when registering event filters. With a NULL eventlist, kevent stops on the first changelist failure, leaving partial registrations and no actor notification. Actors that thought they were subscribed would wait forever.

Use EV_RECEIPT so all changelist entries are processed regardless of individual failures, and send ASIO_ERROR to the owning actor on subscription failure. All seven stdlib AsioEventNotify consumers handle the new flag by tearing down through their existing fatal-error paths.

Also fixes unchecked pipe() and kevent() returns in `ponyint_asio_backend_init`, removes dead EV_ERROR code from the dispatch loop, and adds missing `ponyint_messageq_destroy` on kqueue() failure.

Follow-up issue for lori: ponylang/lori#275

Design: #5051