### PR TITLE
Add style/docstring-leading-blank lint rule

### DIFF
--- a/.release-notes/add-docstring-leading-blank.md
+++ b/.release-notes/add-docstring-leading-blank.md
@@ -1,0 +1,20 @@
+## Add style/docstring-leading-blank lint rule
+
+pony-lint now flags docstrings where a blank line immediately follows the opening `"""`. The first line of content should begin on the line right after the opening delimiter.
+
+```pony
+// Flagged — blank line after opening """
+class Foo
+  """
+
+  Foo docstring.
+  """
+
+// Clean — content starts on the next line
+class Foo
+  """
+  Foo docstring.
+  """
+```
+
+Types and methods annotated with `\nodoc\` are exempt, consistent with `style/docstring-format`.

--- a/tools/pony-lint/docstring_leading_blank.pony
+++ b/tools/pony-lint/docstring_leading_blank.pony
@@ -1,0 +1,185 @@
+use ast = "pony_compiler"
+
+primitive DocstringLeadingBlank is ASTRule
+  """
+  Flags docstrings where the opening `\"\"\"` is immediately followed by a
+  blank line.
+
+  A leading blank line wastes vertical space and can confuse the
+  `style/blank-lines` rule's entity-boundary counting. The first line of
+  content should begin on the line immediately after the opening `\"\"\"`.
+
+  Types and methods annotated with `\nodoc\` are exempt, as are methods
+  inside `\nodoc\`-annotated entities — consistent with
+  `style/docstring-format`.
+  """
+  fun id(): String val => "style/docstring-leading-blank"
+  fun category(): String val => "style"
+
+  fun description(): String val =>
+    "no blank line after opening \"\"\""
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [
+      ast.TokenIds.tk_class(); ast.TokenIds.tk_actor()
+      ast.TokenIds.tk_primitive(); ast.TokenIds.tk_struct()
+      ast.TokenIds.tk_trait(); ast.TokenIds.tk_interface()
+      ast.TokenIds.tk_fun(); ast.TokenIds.tk_new(); ast.TokenIds.tk_be()
+    ]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Check that a docstring does not have a blank line immediately after
+    the opening `\"\"\"`. Skips `\nodoc\`-annotated nodes and methods
+    inside `\nodoc\`-annotated entities.
+    """
+    let token_id = node.id()
+    let is_method =
+      (token_id == ast.TokenIds.tk_fun())
+        or (token_id == ast.TokenIds.tk_new())
+        or (token_id == ast.TokenIds.tk_be())
+
+    // Skip \nodoc\-annotated nodes
+    if node.has_annotation("nodoc") then
+      return recover val Array[Diagnostic val] end
+    end
+
+    if is_method then
+      // Skip methods inside \nodoc\-annotated entities
+      try
+        let entity =
+          (node.parent() as ast.AST).parent() as ast.AST
+        if entity.has_annotation("nodoc") then
+          return recover val Array[Diagnostic val] end
+        end
+      end
+    end
+
+    // Find the docstring node
+    let doc_node: ast.AST box =
+      if is_method then
+        let found =
+          try
+            let c7 = node(7)?
+            if c7.id() == ast.TokenIds.tk_string() then
+              c7
+            else
+              try
+                let body = node(6)?
+                if body.id() != ast.TokenIds.tk_none() then
+                  let b0 = body(0)?
+                  if b0.id() == ast.TokenIds.tk_string() then
+                    b0
+                  else
+                    return recover val Array[Diagnostic val] end
+                  end
+                else
+                  return recover val Array[Diagnostic val] end
+                end
+              else
+                return recover val Array[Diagnostic val] end
+              end
+            end
+          else
+            return recover val Array[Diagnostic val] end
+          end
+        found
+      else
+        try
+          let c6 = node(6)?
+          if c6.id() == ast.TokenIds.tk_none() then
+            return recover val Array[Diagnostic val] end
+          end
+          c6
+        else
+          return recover val Array[Diagnostic val] end
+        end
+      end
+
+    // We have a docstring — check for a leading blank line
+    let start_line = doc_node.line()
+    if start_line == 0 then
+      return recover val Array[Diagnostic val] end
+    end
+
+    _check_leading_blank(source, start_line)
+
+  fun _check_leading_blank(source: SourceFile val, start_line: USize)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Check whether the line after the opening `\"\"\"` at `start_line`
+    (1-based) is blank. Only fires when the opening `\"\"\"` is on its
+    own line (multi-line docstring).
+    """
+    let open_idx = start_line - 1
+    let open_line =
+      try source.lines(open_idx)?
+      else return recover val Array[Diagnostic val] end
+      end
+
+    // Only check multi-line docstrings where """ is on its own line
+    if not _is_only_triple_quote(open_line) then
+      return recover val Array[Diagnostic val] end
+    end
+
+    // Check if the next line is blank
+    try
+      let next_line = source.lines(open_idx + 1)?
+      if _is_blank(next_line) then
+        return recover val
+          [ Diagnostic(
+            id(),
+            "no blank line after opening \"\"\"",
+            source.rel_path,
+            start_line + 1,
+            1)]
+        end
+      end
+    end
+    recover val Array[Diagnostic val] end
+
+  fun _is_only_triple_quote(line: String val): Bool =>
+    """
+    Check if a line contains only whitespace and a single `\"\"\"`.
+    """
+    var found_quote = false
+    var i: USize = 0
+    let size = line.size()
+    while i < size do
+      try
+        let ch = line(i)?
+        if (ch == '"') and ((i + 3) <= size)
+          and (line(i + 1)? == '"') and (line(i + 2)? == '"')
+        then
+          if found_quote then return false end
+          found_quote = true
+          i = i + 3
+        elseif (ch != ' ') and (ch != '\t') then
+          return false
+        else
+          i = i + 1
+        end
+      else
+        i = i + 1
+      end
+    end
+    found_quote
+
+  fun _is_blank(line: String val): Bool =>
+    """
+    Check if a line is blank (empty or all whitespace).
+    """
+    var i: USize = 0
+    while i < line.size() do
+      try
+        let ch = line(i)?
+        if (ch != ' ') and (ch != '\t') then return false end
+      end
+      i = i + 1
+    end
+    true

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -88,6 +88,7 @@ actor Main
         .> push(DotSpacing)
         .> push(BlankLines)
         .> push(DocstringFormat)
+        .> push(DocstringLeadingBlank)
         .> push(PackageDocstring)
         .> push(PreferChaining)
         .> push(OperatorSpacing)

--- a/tools/pony-lint/test/_test_blank_lines.pony
+++ b/tools/pony-lint/test/_test_blank_lines.pony
@@ -716,3 +716,190 @@ class \nodoc\ _TestBlankLinesMultiLineDocEntities is UnitTest
     else
       h.fail("compilation failed")
     end
+
+class \nodoc\ _TestBlankLinesLeadingBlankDocEntitiesClean is UnitTest
+  """
+  Entity with docstring that starts with a blank line after the
+  opening \"\"\", followed by another entity with 1 blank line —
+  should be clean (between-entity check). Regression test for
+  #5120.
+  """
+  fun name(): String =>
+    "BlankLines: leading-blank doc entities 1 blank (AST pipeline)"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  \"\"\"\n" +
+      "\n" +
+      "  Returned by a request interceptor.\n" +
+      "  \"\"\"\n" +
+      "\n" +
+      "class ref Bar\n" +
+      "  fun apply(): None => None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let collector = _TestEntityCollector
+          mod.ast.visit(collector)
+          let entities = collector.entities()
+          // Verify Foo's end_line covers the closing """
+          try
+            (_, _, let foo_start, let foo_end) = entities(0)?
+            h.assert_eq[USize](1, foo_start)
+            h.assert_eq[USize](
+              5,
+              foo_end,
+              "Foo end_line should be line 5 (closing \"\"\")")
+          else
+            h.fail("could not access Foo entity")
+          end
+          let diags = lint.BlankLines.check_module(entities, sf)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestBlankLinesLeadingBlankDocEntitiesNoBlank is UnitTest
+  """
+  Entity with docstring that starts with a blank line after the
+  opening \"\"\", followed by another entity with 0 blank lines —
+  should be flagged. Verifies the leading blank line inside the
+  docstring is not mistakenly counted as a blank line between
+  entities. Regression test for #5120.
+  """
+  fun name(): String =>
+    "BlankLines: leading-blank doc entities 0 blanks flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  \"\"\"\n" +
+      "\n" +
+      "  Returned by a request interceptor.\n" +
+      "  \"\"\"\n" +
+      "class ref Bar\n" +
+      "  fun apply(): None => None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let collector = _TestEntityCollector
+          mod.ast.visit(collector)
+          let entities = collector.entities()
+          let diags = lint.BlankLines.check_module(entities, sf)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_true(
+              diags(0)?.message.contains("between entities"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestBlankLinesLeadingBlankDocMethodClean is UnitTest
+  """
+  Abstract method with docstring that starts with a blank line
+  after the opening \"\"\", followed by another method with
+  1 blank line — should be clean (within-entity check).
+  Regression test for #5120.
+  """
+  fun name(): String =>
+    "BlankLines: leading-blank doc method 1 blank is clean"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "trait Foo\n" +
+      "  fun foo(): None\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "    Foo docs.\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "  fun bar(): None => None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.BlankLines)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestBlankLinesLeadingBlankDocMethodNoBlank is UnitTest
+  """
+  Abstract method with docstring that starts with a blank line
+  after the opening \"\"\", followed by another method with
+  0 blank lines — should be flagged. Regression test for #5120.
+  """
+  fun name(): String =>
+    "BlankLines: leading-blank doc method 0 blanks flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "trait Foo\n" +
+      "  fun foo(): None\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "    Foo docs.\n" +
+      "    \"\"\"\n" +
+      "  fun bar(): None => None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.BlankLines)
+          h.assert_true(diags.size() > 0)
+          try
+            h.assert_true(
+              diags(0)?.message.contains("1 blank line"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end

--- a/tools/pony-lint/test/_test_docstring_leading_blank.pony
+++ b/tools/pony-lint/test/_test_docstring_leading_blank.pony
@@ -1,0 +1,277 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestDocLeadingBlankEntityFlagged is UnitTest
+  """Entity docstring with blank line after opening \"\"\" is flagged."""
+  fun name(): String => "DocLeadingBlank: entity leading blank flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  \"\"\"\n" +
+      "\n" +
+      "  Foo docstring.\n" +
+      "  \"\"\"\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/docstring-leading-blank", diags(0)?.rule_id)
+            h.assert_true(
+              diags(0)?.message.contains("blank line"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankEntityClean is UnitTest
+  """Entity docstring without leading blank is clean."""
+  fun name(): String => "DocLeadingBlank: entity no leading blank clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  \"\"\"\n" +
+      "  Foo docstring.\n" +
+      "  \"\"\"\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankMethodFlagged is UnitTest
+  """Method docstring with blank line after opening \"\"\" is flagged."""
+  fun name(): String => "DocLeadingBlank: method leading blank flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  \"\"\"\n" +
+      "  Foo docstring.\n" +
+      "  \"\"\"\n" +
+      "  fun apply(): None =>\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "    Method docstring.\n" +
+      "    \"\"\"\n" +
+      "    None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[USize](7, diags(0)?.line)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankMethodClean is UnitTest
+  """Method docstring without leading blank is clean."""
+  fun name(): String => "DocLeadingBlank: method no leading blank clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  \"\"\"\n" +
+      "  Foo docstring.\n" +
+      "  \"\"\"\n" +
+      "  fun apply(): None =>\n" +
+      "    \"\"\"\n" +
+      "    Method docstring.\n" +
+      "    \"\"\"\n" +
+      "    None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankAbstractMethodFlagged is UnitTest
+  """Abstract method docstring with leading blank is flagged."""
+  fun name(): String =>
+    "DocLeadingBlank: abstract method leading blank flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "trait Foo\n" +
+      "  fun bar(): None\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "    Bar docs.\n" +
+      "    \"\"\"\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](1, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankSingleLineClean is UnitTest
+  """Single-line docstring does not trigger this rule."""
+  fun name(): String => "DocLeadingBlank: single-line docstring clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  \"\"\"Foo docstring.\"\"\"\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankNodocEntityExempt is UnitTest
+  """\nodoc\ entity with leading blank in docstring is exempt."""
+  fun name(): String => "DocLeadingBlank: \\nodoc\\ entity exempt"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class \\nodoc\\ Foo\n" +
+      "  \"\"\"\n" +
+      "\n" +
+      "  Foo docstring.\n" +
+      "  \"\"\"\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestDocLeadingBlankNodocEntityMethodExempt is UnitTest
+  """Method inside \nodoc\ entity with leading blank is exempt."""
+  fun name(): String =>
+    "DocLeadingBlank: method in \\nodoc\\ entity exempt"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class \\nodoc\\ Foo\n" +
+      "  \"\"\"Foo docstring.\"\"\"\n" +
+      "  fun apply(): None =>\n" +
+      "    \"\"\"\n" +
+      "\n" +
+      "    Method docstring.\n" +
+      "    \"\"\"\n" +
+      "    None\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags =
+            _CollectRuleDiags(mod, sf, lint.DocstringLeadingBlank)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -285,6 +285,10 @@ actor \nodoc\ Main is TestList
     test(_TestBlankLinesOneLinerEntitiesNoBlank)
     test(_TestBlankLinesBetweenDocstringEntities)
     test(_TestBlankLinesMultiLineDocEntities)
+    test(_TestBlankLinesLeadingBlankDocEntitiesClean)
+    test(_TestBlankLinesLeadingBlankDocEntitiesNoBlank)
+    test(_TestBlankLinesLeadingBlankDocMethodClean)
+    test(_TestBlankLinesLeadingBlankDocMethodNoBlank)
 
     // IndentationSize tests
     test(_TestIndentationSizeClean)
@@ -303,6 +307,16 @@ actor \nodoc\ Main is TestList
     test(_TestDocstringFormatNoDocstring)
     test(_TestDocstringFormatNodocEntityExempt)
     test(_TestDocstringFormatNodocEntityMethodExempt)
+
+    // DocstringLeadingBlank tests
+    test(_TestDocLeadingBlankEntityFlagged)
+    test(_TestDocLeadingBlankEntityClean)
+    test(_TestDocLeadingBlankMethodFlagged)
+    test(_TestDocLeadingBlankMethodClean)
+    test(_TestDocLeadingBlankAbstractMethodFlagged)
+    test(_TestDocLeadingBlankSingleLineClean)
+    test(_TestDocLeadingBlankNodocEntityExempt)
+    test(_TestDocLeadingBlankNodocEntityMethodExempt)
 
     // PackageDocstring tests
     test(_TestPackageDocstringClean)


### PR DESCRIPTION
Adds a new lint rule `style/docstring-leading-blank` that flags docstrings where the opening `"""` is immediately followed by a blank line. The first line of content should begin on the line immediately after the opening `"""`.

Also adds regression tests for the `style/blank-lines` rule to verify that a leading blank line inside a docstring is not miscounted as a blank line between entities (the existing `end_pos()` fix from #5109 already handles this correctly).

Closes #5120