### PR TITLE
Fix segfault when matching tuple elements against unions or interfaces via Any

### DIFF
--- a/.release-notes/fix-tuple-match-union-via-any.md
+++ b/.release-notes/fix-tuple-match-union-via-any.md
@@ -1,0 +1,17 @@
+## Fix segfault when matching tuple elements against unions or interfaces via Any
+
+Matching a tuple element against a union or interface type when the tuple was accessed through `Any val` caused a segfault at runtime:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let x: Any val = ("a", U8(1))
+    match x
+    | (let a: String, let b: (U8 | U16)) =>
+      env.out.print(b.string())  // segfault
+    end
+```
+
+The same crash happened when matching against an interface like `Stringable` instead of a union. Matching against concrete types (e.g., `let b: U8`) was unaffected.
+
+This has been fixed. Tuple elements that are unboxed primitives are now correctly boxed when the match pattern requires a pointer representation.

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -238,8 +238,22 @@ static LLVMValueRef make_field_count(compile_t* c, reach_type_t* t)
 
 static LLVMValueRef make_field_offset(compile_t* c, reach_type_t* t)
 {
+  compile_type_t* c_t = (compile_type_t*)t->c_type;
+
   if(t->field_count == 0)
+  {
+    if(c_t->primitive != NULL)
+    {
+      // Boxable numeric type: the value is at element 1 of the boxed struct
+      // (element 0 is the descriptor pointer).  We need this offset for
+      // boxing raw tuple fields during dynamic match — see genmatch.c
+      // box_field_with_descriptor().
+      return LLVMConstInt(c->i32,
+        LLVMOffsetOfElement(c->target_data, c_t->structure, 1), false);
+    }
+
     return LLVMConstInt(c->i32, 0, false);
+  }
 
   int index = 0;
 
@@ -249,7 +263,6 @@ static LLVMValueRef make_field_offset(compile_t* c, reach_type_t* t)
   if(t->underlying == TK_ACTOR)
     index++;
 
-  compile_type_t* c_t = (compile_type_t*)t->c_type;
   return LLVMConstInt(c->i32,
     LLVMOffsetOfElement(c->target_data, c_t->structure, index), false);
 }
@@ -681,6 +694,16 @@ LLVMValueRef gendesc_fieldload(compile_t* c, LLVMValueRef ptr,
 LLVMValueRef gendesc_fielddesc(compile_t* c, LLVMValueRef field_info)
 {
   return LLVMBuildExtractValue(c->builder, field_info, 1, "");
+}
+
+LLVMValueRef gendesc_size(compile_t* c, LLVMValueRef desc)
+{
+  return desc_field(c, desc, DESC_SIZE);
+}
+
+LLVMValueRef gendesc_fieldoffset(compile_t* c, LLVMValueRef desc)
+{
+  return desc_field(c, desc, DESC_FIELD_OFFSET);
 }
 
 LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* type)

--- a/src/libponyc/codegen/gendesc.h
+++ b/src/libponyc/codegen/gendesc.h
@@ -43,6 +43,20 @@ LLVMValueRef gendesc_fieldload(compile_t* c, LLVMValueRef ptr,
 
 LLVMValueRef gendesc_fielddesc(compile_t* c, LLVMValueRef field_info);
 
+/**
+ * Return the DESC_SIZE field from the descriptor (the ABI size of the boxed
+ * object, as an i32).
+ */
+LLVMValueRef gendesc_size(compile_t* c, LLVMValueRef desc);
+
+/**
+ * Return the DESC_FIELD_OFFSET field from the descriptor (the byte offset
+ * from the start of the object to the first data field, as an i32).  For
+ * boxable numeric types this is the offset to the primitive value; for tuples
+ * it is the offset to the first tuple element.
+ */
+LLVMValueRef gendesc_fieldoffset(compile_t* c, LLVMValueRef desc);
+
 LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* trait);
 
 LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type);

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -5,6 +5,7 @@
 #include "genfun.h"
 #include "genexpr.h"
 #include "genoperator.h"
+#include "genopt.h"
 #include "genreference.h"
 #include "../pass/expr.h"
 #include "../type/subtype.h"
@@ -249,6 +250,46 @@ static bool check_value(compile_t* c, ast_t* pattern, ast_t* param_type,
   return true;
 }
 
+// Box a raw unboxed value (numeric primitive or inline tuple) into a heap-
+// allocated object using the value's runtime descriptor.  field_ptr points to
+// the raw data inside a tuple's fields area; field_desc is the descriptor for
+// that field's concrete type.
+//
+// Type-id encoding (see reach.c type_id assignment):
+//   odd  → object (class/actor), stored as a pointer — never needs this path
+//   even → numeric primitive or tuple, stored as raw inline data
+static LLVMValueRef box_field_with_descriptor(compile_t* c,
+  LLVMValueRef field_ptr, LLVMValueRef field_desc)
+{
+  // Read the object size from the descriptor.
+  LLVMValueRef size = gendesc_size(c, field_desc);
+  LLVMValueRef size_ext = LLVMBuildZExt(c->builder, size, c->intptr, "");
+
+  // Allocate a new object.
+  LLVMValueRef alloc_args[2];
+  alloc_args[0] = codegen_ctx(c);
+  alloc_args[1] = size_ext;
+  LLVMValueRef object = gencall_runtime(c, "pony_alloc", alloc_args, 2, "");
+
+  // Store the descriptor at offset 0.
+  LLVMValueRef desc_ptr = LLVMBuildStructGEP2(c->builder, c->object_type,
+    object, 0, "");
+  LLVMBuildStore(c->builder, field_desc, desc_ptr);
+
+  // Copy the raw data into the object's value area.  DESC_FIELD_OFFSET gives
+  // the byte offset from the object start to the value/fields area, respecting
+  // alignment (e.g. I128 on x86-64 has the value at offset 16, not 8).
+  LLVMValueRef obj_data = gendesc_ptr_to_fields(c, object, field_desc);
+  LLVMValueRef field_offset = gendesc_fieldoffset(c, field_desc);
+  LLVMValueRef field_offset_ext = LLVMBuildZExt(c->builder, field_offset,
+    c->intptr, "");
+  LLVMValueRef copy_size = LLVMBuildSub(c->builder, size_ext,
+    field_offset_ext, "");
+  gencall_memcpy(c, obj_data, field_ptr, copy_size);
+
+  return object;
+}
+
 static bool dynamic_tuple_element(compile_t* c, LLVMValueRef ptr,
   LLVMValueRef desc, ast_t* pattern, LLVMBasicBlockRef next_block, int elem)
 {
@@ -336,6 +377,70 @@ static bool dynamic_tuple_ptr(compile_t* c, LLVMValueRef ptr,
   return true;
 }
 
+// Load the value of a tuple field whose concrete type is described by desc,
+// using pattern_type to determine the expected LLVM representation.
+//
+// The field at ptr may be a raw inline value or an object pointer, depending
+// on the runtime type_id from the descriptor:
+//   odd  type_id → object (class/actor), data at ptr is a pointer
+//   even type_id → numeric or tuple, data at ptr is raw inline data
+// See reach.c for the type_id assignment scheme.
+//
+// When pattern_type's use_type is a pointer (union, interface, trait, or
+// class), the actual field data may still be a raw unboxed primitive (e.g. a
+// U8 matched against (U8 | U16)). In that case we must box the raw value
+// into a heap object so the caller sees a uniform pointer representation.
+// We branch on the type_id to either load the pointer directly or box the
+// raw value before merging.
+//
+// When pattern_type's use_type is not a pointer (concrete primitive type),
+// we load directly with the pattern type's representation.
+static LLVMValueRef load_tuple_field_value(compile_t* c, LLVMValueRef ptr,
+  LLVMValueRef desc, ast_t* pattern_type)
+{
+  reach_type_t* t = reach_type(c->reach, pattern_type);
+  LLVMTypeRef use_type = ((compile_type_t*)t->c_type)->use_type;
+
+  if(LLVMGetTypeKind(use_type) != LLVMPointerTypeKind)
+    return LLVMBuildLoad2(c->builder, use_type, ptr, "");
+
+  // The pattern expects a pointer. Check the runtime type_id to determine
+  // whether the field data is an object pointer (odd type_id) or raw inline
+  // data (even type_id).
+  LLVMValueRef type_id = gendesc_typeid(c, desc);
+  LLVMValueRef is_odd = LLVMBuildAnd(c->builder, type_id,
+    LLVMConstInt(c->i32, 1, false), "");
+  LLVMValueRef is_object = LLVMBuildICmp(c->builder, LLVMIntNE, is_odd,
+    LLVMConstInt(c->i32, 0, false), "");
+
+  LLVMBasicBlockRef object_block = codegen_block(c, "value_is_object");
+  LLVMBasicBlockRef raw_block = codegen_block(c, "value_is_raw");
+  LLVMBasicBlockRef merge_block = codegen_block(c, "value_merge");
+  LLVMBuildCondBr(c->builder, is_object, object_block, raw_block);
+
+  // Object: load the pointer directly.
+  LLVMPositionBuilderAtEnd(c->builder, object_block);
+  LLVMValueRef object_value = LLVMBuildLoad2(c->builder, c->ptr, ptr, "");
+  LLVMBuildBr(c->builder, merge_block);
+  LLVMBasicBlockRef object_from = LLVMGetInsertBlock(c->builder);
+
+  // Raw value: box it into a heap-allocated object.
+  LLVMMoveBasicBlockAfter(raw_block, object_from);
+  LLVMPositionBuilderAtEnd(c->builder, raw_block);
+  LLVMValueRef boxed_value = box_field_with_descriptor(c, ptr, desc);
+  LLVMBuildBr(c->builder, merge_block);
+  LLVMBasicBlockRef raw_from = LLVMGetInsertBlock(c->builder);
+
+  // Merge.
+  LLVMMoveBasicBlockAfter(merge_block, raw_from);
+  LLVMPositionBuilderAtEnd(c->builder, merge_block);
+  LLVMValueRef value = LLVMBuildPhi(c->builder, c->ptr, "");
+  LLVMValueRef values[2] = {object_value, boxed_value};
+  LLVMBasicBlockRef blocks[2] = {object_from, raw_from};
+  LLVMAddIncoming(value, values, blocks, 2);
+  return value;
+}
+
 static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
   LLVMValueRef desc, ast_t* pattern, LLVMBasicBlockRef next_block)
 {
@@ -356,13 +461,7 @@ static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
   if(!check_type(c, ptr, desc, param_type, next_block, weight))
     return false;
 
-  // We now know that ptr points to something of type pattern_type, and that
-  // it isn't a boxed primitive, as that would go through the other path, ie
-  // dynamic_match_object(). We also know it isn't an unboxed tuple. We can
-  // load from ptr with a type based on the static type of the pattern.
-  reach_type_t* t = reach_type(c->reach, param_type);
-  LLVMTypeRef use_type = ((compile_type_t*)t->c_type)->use_type;
-  LLVMValueRef value = LLVMBuildLoad2(c->builder, use_type, ptr, "");
+  LLVMValueRef value = load_tuple_field_value(c, ptr, desc, param_type);
 
   return check_value(c, pattern, param_type, value, next_block);
 }
@@ -370,8 +469,6 @@ static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
 static bool dynamic_capture_ptr(compile_t* c, LLVMValueRef ptr,
   LLVMValueRef desc, ast_t* pattern, LLVMBasicBlockRef next_block)
 {
-  // Here, ptr is a pointer to a tuple field. It could be a primitive, an
-  // object, or a nested tuple.
   ast_t* pattern_type = deferred_reify(c->frame->reify, ast_type(pattern),
     c->opt);
 
@@ -392,13 +489,7 @@ static bool dynamic_capture_ptr(compile_t* c, LLVMValueRef ptr,
     return false;
   }
 
-  // We now know that ptr points to something of type pattern_type, and that
-  // it isn't a boxed primitive or tuple, as that would go through the other
-  // path, ie dynamic_match_object(). We also know it isn't an unboxed tuple.
-  // We can load from ptr with a type based on the static type of the pattern.
-  reach_type_t* t = reach_type(c->reach, pattern_type);
-  LLVMTypeRef use_type = ((compile_type_t*)t->c_type)->use_type;
-  LLVMValueRef value = LLVMBuildLoad2(c->builder, use_type, ptr, "");
+  LLVMValueRef value = load_tuple_field_value(c, ptr, desc, pattern_type);
 
   LLVMValueRef r = gen_assign_value(c, pattern, value, pattern_type);
 

--- a/test/full-program-tests/regression-4507-i128/main.pony
+++ b/test/full-program-tests/regression-4507-i128/main.pony
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/4507
+//
+// Tests a wider primitive type (I128) to exercise the alignment-aware boxing
+// in box_field_with_descriptor.  I128 has 16-byte alignment on x86-64, so the
+// value sits at offset 16 in the boxed struct rather than offset 8.
+
+actor Main
+  new create(env: Env) =>
+    let x: Any val = ("a", I128(42))
+    match x
+    | (let a: String, let b: (I128 | U128)) =>
+      if b.string() != "42" then
+        env.exitcode(1)
+      end
+    else
+      env.exitcode(1)
+    end

--- a/test/full-program-tests/regression-4507-interface/main.pony
+++ b/test/full-program-tests/regression-4507-interface/main.pony
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/4507
+//
+// Matching a boxed tuple (via Any val) against a pattern with an interface-
+// typed element segfaulted for the same reason as the union case: the codegen
+// loaded the unboxed primitive as a pointer.
+
+actor Main
+  new create(env: Env) =>
+    let x: Any val = ("a", U8(1))
+    match x
+    | (let a: String, let b: Stringable) =>
+      if b.string() != "1" then
+        env.exitcode(1)
+      end
+    else
+      env.exitcode(1)
+    end

--- a/test/full-program-tests/regression-4507-nested-tuple/main.pony
+++ b/test/full-program-tests/regression-4507-nested-tuple/main.pony
@@ -1,0 +1,21 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/4507
+//
+// Tests that an inline nested tuple in a boxed tuple is correctly boxed when
+// captured as a pointer type (Any val).  The nested tuple has an even type_id
+// with (type_id & 3) == 2, exercising the tuple branch of the boxing path.
+
+actor Main
+  new create(env: Env) =>
+    let inner: (U8, U16) = (U8(1), U16(2))
+    let x: Any val = ("a", inner)
+    match x
+    | (let a: String, let b: Any val) =>
+      match b
+      | (let c: U8, let d: U16) =>
+        if (c == 1) and (d == 2) then
+          return
+        end
+      end
+    end
+
+    env.exitcode(1)

--- a/test/full-program-tests/regression-4507-no-double-box/main.pony
+++ b/test/full-program-tests/regression-4507-no-double-box/main.pony
@@ -1,0 +1,49 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/4507
+//
+// Ensures that the boxing fix does not double-box values that are already
+// object pointers.  A prior fix attempt (PR #4787) caused Container("1234")
+// to appear as Container(Container(1234)) due to double-boxing.
+
+class val Container
+  var data: Any val
+  new val create(data': Any val) =>
+    data = data'
+
+primitive GetStringable
+  fun val apply(p: Container): String =>
+    "Container(" +
+      match p.data
+      | let s: Stringable => s.string()
+      | let p': Container => GetStringable(p')
+      else
+        "Non-Stringable"
+      end +
+    ")"
+
+actor Main
+  new create(env: Env) =>
+    let arg = Container((
+        "abcd",
+        Container("1234")
+      ))
+
+    match arg.data
+    | (let s: String, let p: (Container | None)) =>
+      if s != "abcd" then
+        env.exitcode(1)
+        return
+      end
+
+      let inner =
+        match p
+        | let p_cv: Container => GetStringable(consume p_cv)
+        else
+          "non-Container"
+        end
+
+      if inner != "Container(1234)" then
+        env.exitcode(1)
+      end
+    else
+      env.exitcode(1)
+    end

--- a/test/full-program-tests/regression-4507-union/main.pony
+++ b/test/full-program-tests/regression-4507-union/main.pony
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/4507
+//
+// Matching a boxed tuple (via Any val) against a pattern with a union-typed
+// element segfaulted because the codegen loaded the unboxed primitive as a
+// pointer.
+
+actor Main
+  new create(env: Env) =>
+    let x: Any val = ("a", U8(1))
+    match x
+    | (let a: String, let b: (U8 | U16)) =>
+      if b.string() != "1" then
+        env.exitcode(1)
+      end
+    else
+      env.exitcode(1)
+    end


### PR DESCRIPTION
When pattern matching a boxed tuple (via `Any val`), unboxed numeric elements were loaded as pointers when the match pattern expected a union or interface type. The raw byte value got interpreted as a memory address and the program segfaulted.

The codegen for `dynamic_capture_ptr` and `dynamic_value_ptr` now checks the runtime type_id to distinguish object pointers (odd type_id, load directly) from raw inline data (even type_id, box into a heap object first). The boxing helper allocates via `pony_alloc`, stores the descriptor, and memcpys the data at the correct alignment-aware offset. This uses the same type_id encoding that `gentrace.c` already relies on.

The fix also corrects `make_field_offset` to return the actual struct offset for boxable numeric types. It was returning 0 for all types with `field_count == 0`, which would put the value at the wrong offset for types like I128/U128 where alignment padding pushes the value past the pointer-sized offset.

Five regression tests cover: union-typed element, interface-typed element, the no-double-boxing scenario from PR #4787's regression, I128 alignment, and nested inline tuples.

**Note:** The `dynamic_value_ptr` fix mirrors `dynamic_capture_ptr` but has no dedicated test. I think the pointer-type branch there is probably unreachable in practice since value patterns resolve to concrete `eq()` parameter types rather than unions or interfaces. The code is defensive.

Closes #4507