### PR TITLE
Add hierarchical configuration for pony-lint

### DIFF
--- a/.release-notes/add-hierarchical-lint-config.md
+++ b/.release-notes/add-hierarchical-lint-config.md
@@ -1,0 +1,13 @@
+## Add hierarchical configuration for pony-lint
+
+pony-lint now supports `.pony-lint.json` files in subdirectories, not just at the project root. A subdirectory config overrides the root config for all files in that subtree, using the same JSON format.
+
+For example, to turn off the `style/package-docstring` rule for everything under your `examples/` directory, add an `examples/.pony-lint.json`:
+
+```json
+{"rules": {"style/package-docstring": "off"}}
+```
+
+Precedence follows proximity — the nearest directory with a setting wins. Category entries (e.g., `"style": "off"`) override parent rule-specific entries in that category. Omitting a rule from a subdirectory config defers to the parent, not the default.
+
+Malformed subdirectory configs produce a `lint/config-error` diagnostic and fall through to the parent config — the subtree is still linted, just with the parent's rules.

--- a/tools/pony-lint/config.pony
+++ b/tools/pony-lint/config.pony
@@ -40,6 +40,54 @@ class val LintConfig
     _cli_disabled = recover val Set[String] end
     _file_rules = recover val Map[String, RuleStatus] end
 
+  new val merge(parent: LintConfig, child_rules: Map[String, RuleStatus] val)
+  =>
+    """
+    Create a config that layers child overrides on top of a parent config.
+    CLI-disabled rules carry forward from the parent unchanged.
+
+    Category-cleaning: when the child has a category entry (key with no `/`),
+    all parent rule-specific entries in that category are removed before
+    layering. This ensures a child's `"style": "off"` overrides a parent's
+    `"style/line-length": "on"`.
+
+    A child config with both `"style": "off"` and `"style/line-length": "on"`
+    results in `style/line-length` being on and all other style rules off,
+    because `rule_status()` checks rule-specific before category.
+
+    Rule-specific child entries do NOT remove parent category entries.
+    """
+    _cli_disabled = parent._cli_disabled
+    _file_rules =
+      recover val
+        let merged = Map[String, RuleStatus]
+        // Copy parent entries
+        for (k, v) in parent._file_rules.pairs() do
+          merged(k) = v
+        end
+        // Category cleaning: for each category key in child,
+        // remove parent rule-specific entries in that category
+        for child_key in child_rules.keys() do
+          if not child_key.contains("/") then
+            let prefix: String val = child_key + "/"
+            let to_remove = Array[String val]
+            for k in merged.keys() do
+              if k.at(prefix) then
+                to_remove.push(k)
+              end
+            end
+            for k in to_remove.values() do
+              try merged.remove(k)? end
+            end
+          end
+        end
+        // Layer child entries on top
+        for (k, v) in child_rules.pairs() do
+          merged(k) = v
+        end
+        merged
+      end
+
   fun rule_status(
     rule_id: String,
     category: String,
@@ -68,16 +116,21 @@ class val LintConfig
 primitive ConfigLoader
   """
   Loads lint configuration from CLI arguments and/or a `.pony-lint.json` file.
+
+  `parse_file` is public so that subdirectory configs can be parsed during the
+  file-discovery walk (see `_FileCollector._load_config`).
   """
   fun from_cli(
     cli_disabled: Array[String] val,
     config_path: (String | None),
     file_auth: FileAuth)
-    : (LintConfig | ConfigError)
+    : ((LintConfig, String val) | ConfigError)
   =>
     """
     Build a `LintConfig` from CLI disable flags and an optional config file.
-    If `config_path` is None, auto-discovers the config file.
+    If `config_path` is None, auto-discovers the config file. Returns the
+    config and the hierarchy root directory (used by `ConfigResolver` to
+    anchor subdirectory config walks).
     """
     let disabled =
       recover val
@@ -87,41 +140,46 @@ primitive ConfigLoader
         end
         s
       end
-    let file_rules =
-      match \exhaustive\ config_path
-      | let path: String =>
-        let fp = FilePath(file_auth, path)
-        if not fp.exists() then
-          return ConfigError("config file not found: " + path)
-        end
-        match \exhaustive\ _load_file(fp)
-        | let rules: Map[String, RuleStatus] val => rules
-        | let err: ConfigError => return err
-        end
-      | None =>
-        match \exhaustive\ _discover(file_auth)
-        | let fp: FilePath =>
-          match \exhaustive\ _load_file(fp)
-          | let rules: Map[String, RuleStatus] val => rules
-          | let err: ConfigError => return err
-          end
-        | None =>
-          recover val Map[String, RuleStatus] end
-        end
+    match \exhaustive\ config_path
+    | let path: String =>
+      let fp = FilePath(file_auth, path)
+      if not fp.exists() then
+        return ConfigError("config file not found: " + path)
       end
-    LintConfig(disabled, file_rules)
+      match \exhaustive\ parse_file(fp)
+      | let rules: Map[String, RuleStatus] val =>
+        (LintConfig(disabled, rules), Path.dir(fp.path))
+      | let err: ConfigError => err
+      end
+    | None =>
+      match \exhaustive\ _discover(file_auth)
+      | (let fp: FilePath, let root_dir: String val) =>
+        match \exhaustive\ parse_file(fp)
+        | let rules: Map[String, RuleStatus] val =>
+          (LintConfig(disabled, rules), root_dir)
+        | let err: ConfigError => err
+        end
+      | let root_dir: String val =>
+        (LintConfig(disabled, recover val Map[String, RuleStatus] end),
+          root_dir)
+      end
+    end
 
-  fun _discover(file_auth: FileAuth): (FilePath | None) =>
+  fun _discover(file_auth: FileAuth)
+    : ((FilePath, String val) | String val)
+  =>
     """
     Discover `.pony-lint.json` by checking CWD first, then walking up
-    to find `corral.json` and checking its directory.
+    to find `corral.json` and checking its directory. Always returns a
+    hierarchy root directory — either the directory containing the config
+    file, the `corral.json` directory, or CWD.
     """
     let cwd = Path.cwd()
     // Check CWD first
     let cwd_config = Path.join(cwd, ".pony-lint.json")
     let cwd_fp = FilePath(file_auth, cwd_config)
     if cwd_fp.exists() then
-      return cwd_fp
+      return (cwd_fp, cwd)
     end
     // Walk up looking for corral.json
     var dir = cwd
@@ -129,12 +187,12 @@ primitive ConfigLoader
       let corral_path = Path.join(dir, "corral.json")
       let corral_fp = FilePath(file_auth, corral_path)
       if corral_fp.exists() then
-        let config_path = Path.join(dir, ".pony-lint.json")
-        let config_fp = FilePath(file_auth, config_path)
+        let config_path' = Path.join(dir, ".pony-lint.json")
+        let config_fp = FilePath(file_auth, config_path')
         if config_fp.exists() then
-          return config_fp
+          return (config_fp, dir)
         end
-        return None
+        return dir
       end
       let parent = Path.dir(dir)
       if parent == dir then
@@ -142,9 +200,11 @@ primitive ConfigLoader
       end
       dir = parent
     end
-    None
+    cwd
 
-  fun _load_file(fp: FilePath): (Map[String, RuleStatus] val | ConfigError) =>
+  fun parse_file(fp: FilePath)
+    : (Map[String, RuleStatus] val | ConfigError)
+  =>
     """
     Parse a `.pony-lint.json` file into rule status overrides.
     """

--- a/tools/pony-lint/config_resolver.pony
+++ b/tools/pony-lint/config_resolver.pony
@@ -1,0 +1,78 @@
+use "collections"
+use "files"
+
+class ref ConfigResolver
+  """
+  Resolves per-directory rule status by merging the config hierarchy.
+
+  Accumulates per-directory overrides during the file-discovery walk via
+  `add_directory()`, then resolves the effective config for any directory
+  via `config_for()`. The hierarchy root is the directory containing the
+  root config file (or CWD if no root config exists).
+
+  Invariant: omission in a directory config means "defer to parent,"
+  not "reset to default."
+  """
+  let _root_config: LintConfig
+  let _dir_overrides: Map[String, Map[String, RuleStatus] val]
+  let _root_dir: String val
+  let _cache: Map[String, LintConfig val]
+
+  new ref create(root_config: LintConfig, root_dir: String val) =>
+    _root_config = root_config
+    _dir_overrides = Map[String, Map[String, RuleStatus] val]
+    _root_dir = root_dir
+    _cache = Map[String, LintConfig val]
+
+  fun ref add_directory(
+    dir: String val,
+    rules: Map[String, RuleStatus] val)
+  =>
+    """
+    Register an override config for a directory. Takes pre-parsed config
+    data — the caller handles I/O and parsing.
+
+    Skips the hierarchy root directory (its config is already in the root
+    LintConfig) and skips directories already registered (idempotent).
+    This guard is centralized here rather than in each caller to prevent
+    double-loading the root's config, which would corrupt rule-specific
+    entries via category cleaning.
+    """
+    if (dir == _root_dir) or _dir_overrides.contains(dir) then return end
+    _dir_overrides(dir) = rules
+
+  fun ref config_for(dir: String val): LintConfig val =>
+    """
+    Return the effective LintConfig for a directory by merging the
+    hierarchy from root to the given directory. Results are cached
+    per directory path.
+    """
+    try return _cache(dir)? end
+    // Walk up from dir to root, collecting ancestor directories
+    // that have overrides (in leaf-to-root order)
+    let ancestors = Array[String val]
+    var current = dir
+    while true do
+      if _dir_overrides.contains(current) then
+        ancestors.push(current)
+      end
+      if current == _root_dir then break end
+      let parent = Path.dir(current)
+      if parent == current then break end
+      current = parent
+    end
+    // Merge root-to-leaf: start with root config,
+    // then merge each ancestor's overrides in root-to-leaf order
+    var merged: LintConfig val = _root_config
+    // ancestors is leaf-to-root, so iterate in reverse
+    var i = ancestors.size()
+    while i > 0 do
+      i = i - 1
+      try
+        let ancestor_dir = ancestors(i)?
+        let overrides = _dir_overrides(ancestor_dir)?
+        merged = LintConfig.merge(merged, overrides)
+      end
+    end
+    _cache(dir) = merged
+    merged

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -11,11 +11,14 @@ class val Linter
 
   1. **Text phase** — for each discovered .pony file, load the source, parse
      suppressions, and run enabled text rules with suppression filtering.
+     Each file's rules are resolved from the directory-specific config via
+     `ConfigResolver`.
   2. **AST phase** — group files by directory (package), compile each package
      via pony_compiler using `CompileSession`. Parse-level rules run after
      `PassParse`, then compilation continues to `PassExpr` for rules that need
      type information (e.g., safety rules). Module-level and package-level
      rules (file-naming, package-naming) run after the per-node dispatch.
+     Each package's rules are resolved from its directory's config.
 
   File discovery recursively finds .pony files in given targets, skipping
   _corral/, _repos/, and directories starting with a dot. When inside a git
@@ -23,23 +26,32 @@ class val Linter
   always respected regardless of git context. Hardcoded skips (`_corral/`,
   `_repos/`, dot-prefix) are unconditional and cannot be overridden by
   negation patterns in ignore files.
+
+  Subdirectory `.pony-lint.json` files are discovered during the walk
+  alongside ignore files. The `ConfigResolver` merges subdirectory overrides
+  with the root config using proximity-first precedence.
   """
   let _registry: RuleRegistry
   let _file_auth: FileAuth
   let _cwd: String val
   let _package_paths: Array[String val] val
+  let _root_dir: String val
 
   new val create(
     registry: RuleRegistry,
     file_auth: FileAuth,
     cwd: String val,
     package_paths: Array[String val] val = recover val
-      Array[String val] end)
+      Array[String val] end,
+    root_dir: String val = "")
+      // Empty `root_dir` disables hierarchical config discovery.
+      // Always pass the value from `ConfigLoader.from_cli()` in production.
   =>
     _registry = registry
     _file_auth = file_auth
     _cwd = cwd
     _package_paths = package_paths
+    _root_dir = root_dir
 
   fun run(targets: Array[String val] val)
     : (Array[Diagnostic val] ref, ExitCode)
@@ -47,6 +59,10 @@ class val Linter
     """
     Run all enabled rules against the given target paths (files or
     directories). Returns sorted diagnostics and the appropriate exit code.
+
+    Creates a `ConfigResolver` to manage hierarchical configuration. The
+    resolver is populated during file discovery and used in both lint phases
+    to select per-directory rule registries.
     """
     let all_diags = Array[Diagnostic val]
     var has_error = false
@@ -71,7 +87,15 @@ class val Linter
       end
     end
 
-    let pony_files = _discover(targets)
+    let resolver = ConfigResolver(_registry.config(), _root_dir)
+    let config_errors = Array[Diagnostic val]
+    let pony_files = _discover(targets, resolver, config_errors)
+
+    // Surface config errors from subdirectory configs
+    for err in config_errors.values() do
+      all_diags.push(err)
+      has_error = true
+    end
 
     // Per-file metadata indexed by absolute path, for reuse in AST phase
     let file_info = Map[String, _FileInfo val]
@@ -100,7 +124,8 @@ class val Linter
       file_info(path) = _FileInfo(source, sup, magic_lines)
 
       // Collect rule diagnostics, filtering suppressed ones
-      for rule in _registry.enabled_text_rules().values() do
+      let file_registry = _registry_for(Path.dir(path), resolver, _registry)
+      for rule in file_registry.enabled_text_rules().values() do
         let rule_diags = rule.check(source)
         for diag in rule_diags.values() do
           // Skip diagnostics on magic comment lines
@@ -119,10 +144,10 @@ class val Linter
     end
 
     // --- AST phase ---
-    let parse_rules = _registry.enabled_parse_ast_rules()
-    let expr_rules = _registry.enabled_expr_ast_rules()
-
-    if (parse_rules.size() > 0) or (expr_rules.size() > 0) then
+    // Use all_ast_rules size for the outer guard: a subdirectory config
+    // might enable rules that are off at root, so we can't skip based on
+    // the root config's enabled count alone.
+    if _registry.all_ast_rules().size() > 0 then
       // Group files by directory (package)
       let packages = Map[String, Array[String val]]
       for path in pony_files.values() do
@@ -140,6 +165,14 @@ class val Linter
 
       // Compile each package and run AST rules
       for (pkg_dir, pkg_file_paths) in packages.pairs() do
+        let pkg_registry = _registry_for(pkg_dir, resolver, _registry)
+        let parse_rules = pkg_registry.enabled_parse_ast_rules()
+        let expr_rules = pkg_registry.enabled_expr_ast_rules()
+
+        if (parse_rules.size() == 0) and (expr_rules.size() == 0) then
+          continue
+        end
+
         let pkg_fp = FilePath(_file_auth, pkg_dir)
         let session =
           ast.CompileSession(
@@ -168,7 +201,7 @@ class val Linter
                   end
 
                   // File-naming check (module-level)
-                  if _registry.is_enabled(
+                  if pkg_registry.is_enabled(
                     FileNaming.id(),
                     FileNaming.category(),
                     FileNaming.default_status())
@@ -188,7 +221,7 @@ class val Linter
                   end
 
                   // Blank-lines between-entity check (module-level)
-                  if _registry.is_enabled(
+                  if pkg_registry.is_enabled(
                     BlankLines.id(),
                     BlankLines.category(),
                     BlankLines.default_status())
@@ -222,7 +255,7 @@ class val Linter
               end
 
             // Package-naming check (once per package)
-            if _registry.is_enabled(
+            if pkg_registry.is_enabled(
               PackageNaming.id(),
               PackageNaming.category(),
               PackageNaming.default_status())
@@ -237,7 +270,7 @@ class val Linter
 
             // Package-docstring check (once per package, before
             // PassExpr which can transform the docstring AST node)
-            if _registry.is_enabled(
+            if pkg_registry.is_enabled(
               PackageDocstring.id(),
               PackageDocstring.category(),
               PackageDocstring.default_status())
@@ -362,11 +395,41 @@ class val Linter
 
     (all_diags, exit_code)
 
-  fun _discover(targets: Array[String val] val): Array[String val] val =>
+  fun _registry_for(
+    dir: String val,
+    resolver: ConfigResolver ref,
+    default_registry: RuleRegistry)
+    : RuleRegistry
+  =>
+    """
+    Return a directory-specific registry. If the directory has no config
+    overrides in its ancestry, the resolved config is the same object as the
+    root config — reuse the default registry. Otherwise build a new registry
+    from the resolved config and the full rule arrays.
+    """
+    let config = resolver.config_for(dir)
+    if config is default_registry.config() then
+      default_registry
+    else
+      RuleRegistry(
+        default_registry.all_text_rules(),
+        default_registry.all_ast_rules(),
+        config)
+    end
+
+  fun _discover(
+    targets: Array[String val] val,
+    resolver: ConfigResolver ref,
+    config_errors: Array[Diagnostic val])
+    : Array[String val] val
+  =>
     """
     Find all .pony files in the given targets. If a target is a file, include
     it directly. If a directory, walk it recursively. Respects `.gitignore`
     (when inside a git repo) and `.ignore` files for path exclusion.
+
+    Also discovers subdirectory `.pony-lint.json` files during the walk and
+    registers them with the `ConfigResolver`.
     """
     // Find git repo root from first target's directory
     let root: (String val | None) =
@@ -417,7 +480,32 @@ class val Linter
       end
     end
 
-    let collector = _FileCollector(_file_auth, _cwd, matcher)
+    // Pre-load subdirectory configs from hierarchy root through intermediate
+    // directories to each target. Uses _root_dir (config hierarchy root),
+    // not the git root.
+    if _root_dir.size() > 0 then
+      for target in targets.values() do
+        let abs_target =
+          if Path.is_abs(target) then
+            target
+          else
+            Path.join(_cwd, target)
+          end
+        let target_dir =
+          try
+            let fp' = FilePath(_file_auth, abs_target)
+            let fi = FileInfo(fp')?
+            if fi.directory then abs_target else Path.dir(abs_target) end
+          else
+            abs_target
+          end
+        _load_intermediate_configs(
+          resolver, _root_dir, target_dir, config_errors)
+      end
+    end
+
+    let collector =
+      _FileCollector(_file_auth, _cwd, matcher, resolver)
     for target in targets.values() do
       let abs_target =
         if Path.is_abs(target) then
@@ -431,11 +519,23 @@ class val Linter
         if info.file then
           // Explicit file targets are linted regardless of extension
           collector.add(abs_target)
+          // Load config for the file's directory — no walk occurs for
+          // file targets, so _FileCollector._load_config won't run.
+          if _root_dir.size() > 0 then
+            _load_config_for_dir(
+              resolver, Path.dir(abs_target), config_errors)
+          end
         elseif info.directory then
           fp.walk(collector)
         end
       end
     end
+
+    // Transfer config errors from collector
+    for err in collector.config_errors().values() do
+      config_errors.push(err)
+    end
+
     collector.files()
 
   fun _load_intermediate_ignores(
@@ -465,6 +565,61 @@ class val Linter
       matcher.load_directory(current)
     end
 
+  fun _load_intermediate_configs(
+    resolver: ConfigResolver ref,
+    root: String val,
+    target_dir: String val,
+    config_errors: Array[Diagnostic val])
+  =>
+    """
+    Load subdirectory `.pony-lint.json` files for directories from the
+    config hierarchy root through intermediate directories down to (but not
+    including) the target directory. Mirrors `_load_intermediate_ignores`.
+
+    The target directory itself is loaded during the walk via
+    `_FileCollector._load_config`.
+    """
+    if root == target_dir then return end
+    _load_config_for_dir(resolver, root, config_errors)
+    let rel =
+      try
+        Path.rel(root, target_dir)?
+      else
+        return
+      end
+    let parts = rel.split_by(Path.sep())
+    var current: String val = root
+    for part in (consume parts).values() do
+      current = Path.join(current, part)
+      if current == target_dir then break end
+      _load_config_for_dir(resolver, current, config_errors)
+    end
+
+  fun _load_config_for_dir(
+    resolver: ConfigResolver ref,
+    dir: String val,
+    config_errors: Array[Diagnostic val])
+  =>
+    """
+    If a `.pony-lint.json` exists in the given directory, parse it and
+    register the overrides with the config resolver. Parse errors are
+    reported via `config_errors`.
+    """
+    let config_path = Path.join(dir, ".pony-lint.json")
+    let fp = FilePath(_file_auth, config_path)
+    if not fp.exists() then return end
+    match \exhaustive\ ConfigLoader.parse_file(fp)
+    | let rules: Map[String, RuleStatus] val =>
+      resolver.add_directory(dir, rules)
+    | let err: ConfigError =>
+      config_errors.push(Diagnostic(
+        "lint/config-error",
+        err.message,
+        try Path.rel(_cwd, config_path)? else config_path end,
+        0,
+        0))
+    end
+
 class val _FileInfo
   """
   Per-file metadata stored during text phase for reuse in AST phase.
@@ -485,22 +640,32 @@ class val _FileInfo
 class ref _FileCollector is WalkHandler
   """
   Collects .pony file paths during directory walking, respecting hardcoded
-  skip rules and `.gitignore`/`.ignore` patterns.
+  skip rules and `.gitignore`/`.ignore` patterns. Also discovers subdirectory
+  `.pony-lint.json` config files and registers them with the `ConfigResolver`.
+
+  Config files are loaded by constructing the path directly via `FilePath`
+  rather than checking `dir_entries`, because `_should_skip()` filters
+  dot-prefixed entries and would hide `.pony-lint.json`.
   """
   let _file_auth: FileAuth
   let _cwd: String val
   let _matcher: IgnoreMatcher ref
+  let _resolver: ConfigResolver ref
   let _files: Array[String val]
+  let _config_errors: Array[Diagnostic val]
 
   new ref create(
     file_auth: FileAuth,
     cwd: String val,
-    matcher: IgnoreMatcher ref)
+    matcher: IgnoreMatcher ref,
+    resolver: ConfigResolver ref)
   =>
     _file_auth = file_auth
     _cwd = cwd
     _matcher = matcher
+    _resolver = resolver
     _files = Array[String val]
+    _config_errors = Array[Diagnostic val]
 
   fun ref add(path: String val) =>
     _files.push(path)
@@ -508,6 +673,9 @@ class ref _FileCollector is WalkHandler
   fun ref apply(dir_path: FilePath, dir_entries: Array[String] ref) =>
     // Load ignore files for this directory
     _matcher.load_directory(dir_path.path)
+
+    // Load subdirectory config if present
+    _load_config(dir_path.path)
 
     // Filter out entries we should skip
     var i: USize = 0
@@ -540,6 +708,31 @@ class ref _FileCollector is WalkHandler
       end
     end
 
+  fun ref _load_config(dir_path: String val) =>
+    """
+    If a `.pony-lint.json` exists in this directory, parse it and register
+    the overrides with the config resolver. Constructs the path directly
+    (not from dir_entries) since `_should_skip()` filters dot-prefixed
+    entries and would hide `.pony-lint.json`.
+
+    The root-directory skip guard is centralized in
+    `ConfigResolver.add_directory()`.
+    """
+    let config_path = Path.join(dir_path, ".pony-lint.json")
+    let fp = FilePath(_file_auth, config_path)
+    if not fp.exists() then return end
+    match \exhaustive\ ConfigLoader.parse_file(fp)
+    | let rules: Map[String, RuleStatus] val =>
+      _resolver.add_directory(dir_path, rules)
+    | let err: ConfigError =>
+      _config_errors.push(Diagnostic(
+        "lint/config-error",
+        err.message,
+        try Path.rel(_cwd, config_path)? else config_path end,
+        0,
+        0))
+    end
+
   fun _should_skip(name: String): Bool =>
     """
     Skip entries named _corral, _repos, or starting with a dot. This
@@ -548,6 +741,17 @@ class ref _FileCollector is WalkHandler
     """
     (name == "_corral") or (name == "_repos") or
       (try name(0)? == '.' else false end)
+
+  fun ref config_errors(): Array[Diagnostic val] val =>
+    """
+    Return config errors accumulated during the walk. Call after the walk
+    is complete.
+    """
+    let result = recover iso Array[Diagnostic val] end
+    for err in _config_errors.values() do
+      result.push(err)
+    end
+    consume result
 
   fun ref files(): Array[String val] iso^ =>
     let result = recover iso Array[String val] end

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -154,10 +154,10 @@ actor Main
     let config_path: (String | None) =
       if cp.size() > 0 then cp else None end
 
-    let config =
+    (let config, let root_dir) =
       match \exhaustive\
         ConfigLoader.from_cli(cli_disabled, config_path, file_auth)
-      | let c: LintConfig => c
+      | (let c: LintConfig, let r: String val) => (c, r)
       | let err: ConfigError =>
         env.err.print("error: " + err.message)
         env.exitcode(ExitError())
@@ -175,7 +175,8 @@ actor Main
 
     // Run linter
     let cwd = Path.cwd()
-    let linter = Linter(registry, file_auth, cwd, package_paths)
+    let linter =
+      Linter(registry, file_auth, cwd, package_paths, root_dir)
     (let diags, let exit_code) = linter.run(targets)
 
     // Output diagnostics to stdout

--- a/tools/pony-lint/rule_registry.pony
+++ b/tools/pony-lint/rule_registry.pony
@@ -19,16 +19,16 @@ class val RuleRegistry
   new val create(
     rules: Array[TextRule val] val,
     ast_rules: Array[ASTRule val] val,
-    config: LintConfig)
+    config': LintConfig)
   =>
     _all = rules
     _all_ast = ast_rules
-    _config = config
+    _config = config'
     _enabled =
       recover val
         let result = Array[TextRule val]
         for rule in rules.values() do
-          match config.rule_status(
+          match config'.rule_status(
             rule.id(),
             rule.category(),
             rule.default_status())
@@ -41,7 +41,7 @@ class val RuleRegistry
       recover val
         let result = Array[ASTRule val]
         for rule in ast_rules.values() do
-          match config.rule_status(
+          match config'.rule_status(
             rule.id(),
             rule.category(),
             rule.default_status())
@@ -71,6 +71,14 @@ class val RuleRegistry
         end
         result
       end
+
+  fun config(): LintConfig =>
+    """
+    Returns the config used to build this registry. Used by `_registry_for()`
+    to check identity — when the resolved config is the same object as the
+    root config, the root registry is reused.
+    """
+    _config
 
   fun enabled_text_rules(): Array[TextRule val] val =>
     """

--- a/tools/pony-lint/test/_test_config.pony
+++ b/tools/pony-lint/test/_test_config.pony
@@ -1,5 +1,6 @@
 use "pony_test"
 use "collections"
+use "files"
 use lint = ".."
 
 class \nodoc\ _TestConfigDefaultAllEnabled is UnitTest
@@ -148,6 +149,223 @@ class \nodoc\ _TestConfigParseNoRules is UnitTest
     match \exhaustive\ lint.ConfigLoader.parse("{}")
     | let rules: Map[String, lint.RuleStatus] val =>
       h.assert_eq[USize](0, rules.size())
+    | let err: lint.ConfigError =>
+      h.fail("unexpected error: " + err.message)
+    end
+
+class \nodoc\ _TestConfigMergeRuleOverride is UnitTest
+  """Child rule-specific entry overrides parent."""
+  fun name(): String => "Config: merge rule override"
+
+  fun apply(h: TestHelper) =>
+    let parent_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOn
+        m
+      end
+    let parent =
+      lint.LintConfig(recover val Set[String] end, parent_rules)
+    let child_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m
+      end
+    let merged = lint.LintConfig.merge(parent, child_rules)
+    match \exhaustive\
+      merged.rule_status("style/line-length", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected child override to win")
+    end
+
+class \nodoc\ _TestConfigMergeCategoryCleaning is UnitTest
+  """Child category entry removes parent rule-specific entries."""
+  fun name(): String => "Config: merge category cleaning"
+
+  fun apply(h: TestHelper) =>
+    let parent_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOn
+        m("style/hard-tabs") = lint.RuleOn
+        m
+      end
+    let parent =
+      lint.LintConfig(recover val Set[String] end, parent_rules)
+    let child_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style") = lint.RuleOff
+        m
+      end
+    let merged = lint.LintConfig.merge(parent, child_rules)
+    // Both style rules should now be off
+    match \exhaustive\
+      merged.rule_status("style/line-length", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected line-length off after category clean")
+    end
+    match \exhaustive\
+      merged.rule_status("style/hard-tabs", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected hard-tabs off after category clean")
+    end
+
+class \nodoc\ _TestConfigMergeOmissionDefers is UnitTest
+  """Omitted rule in child defers to parent."""
+  fun name(): String => "Config: merge omission defers to parent"
+
+  fun apply(h: TestHelper) =>
+    let parent_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m("style/hard-tabs") = lint.RuleOn
+        m
+      end
+    let parent =
+      lint.LintConfig(recover val Set[String] end, parent_rules)
+    // Child only mentions hard-tabs
+    let child_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/hard-tabs") = lint.RuleOff
+        m
+      end
+    let merged = lint.LintConfig.merge(parent, child_rules)
+    // line-length should still be off (from parent)
+    match \exhaustive\
+      merged.rule_status("style/line-length", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected parent setting to carry forward")
+    end
+
+class \nodoc\ _TestConfigMergeCLICarriesForward is UnitTest
+  """CLI-disabled rules are unaffected by merge."""
+  fun name(): String => "Config: merge CLI carries forward"
+
+  fun apply(h: TestHelper) =>
+    let parent =
+      lint.LintConfig(
+        recover val Set[String] .> set("style/line-length") end,
+        recover val Map[String, lint.RuleStatus] end)
+    let child_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOn
+        m
+      end
+    let merged = lint.LintConfig.merge(parent, child_rules)
+    // CLI disable should win over child override
+    match \exhaustive\
+      merged.rule_status("style/line-length", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected CLI disable to win")
+    end
+
+class \nodoc\ _TestConfigMergeRuleSpecificNoCleanCategory is UnitTest
+  """Child rule-specific entry does NOT clean parent category entry."""
+  fun name(): String =>
+    "Config: merge rule-specific does not clean category"
+
+  fun apply(h: TestHelper) =>
+    let parent_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style") = lint.RuleOn
+        m
+      end
+    let parent =
+      lint.LintConfig(recover val Set[String] end, parent_rules)
+    let child_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m
+      end
+    let merged = lint.LintConfig.merge(parent, child_rules)
+    // line-length overridden by child
+    match \exhaustive\
+      merged.rule_status("style/line-length", "style", lint.RuleOn)
+    | lint.RuleOff => h.assert_true(true)
+    | lint.RuleOn => h.fail("expected child rule to override")
+    end
+    // Other style rules still governed by parent category "on"
+    match \exhaustive\
+      merged.rule_status("style/hard-tabs", "style", lint.RuleOff)
+    | lint.RuleOn => h.assert_true(true)
+    | lint.RuleOff => h.fail("expected parent category to still apply")
+    end
+
+class \nodoc\ _TestConfigFromCLIExplicitConfigRootDir is UnitTest
+  """Explicit --config returns the config file's parent as root dir."""
+  fun name(): String => "Config: from_cli explicit config root dir"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let sub_dir =
+        FilePath(FileAuth(auth), Path.join(tmp.path, "sub"))
+      sub_dir.mkdir()
+      let config_fp =
+        FilePath(
+          FileAuth(auth), Path.join(sub_dir.path, ".pony-lint.json"))
+      let f = File(config_fp)
+      f.print("""{"rules": {"style/line-length": "off"}}""")
+      f.dispose()
+
+      let no_disabled = recover val Array[String] end
+      match \exhaustive\
+        lint.ConfigLoader.from_cli(
+          no_disabled, config_fp.path, FileAuth(auth))
+      | (let _: lint.LintConfig, let root_dir: String val) =>
+        // Root dir should be the config file's parent directory
+        h.assert_eq[String](sub_dir.path, root_dir)
+      | let err: lint.ConfigError =>
+        h.fail("unexpected error: " + err.message)
+      end
+
+      config_fp.remove()
+      sub_dir.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigFromCLIExplicitConfigNotFound is UnitTest
+  """Explicit --config with non-existent file returns ConfigError."""
+  fun name(): String => "Config: from_cli explicit config not found"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    let no_disabled = recover val Array[String] end
+    match \exhaustive\
+      lint.ConfigLoader.from_cli(
+        no_disabled, "/no/such/config.json", FileAuth(auth))
+    | (let _: lint.LintConfig, let _: String val) =>
+      h.fail("expected ConfigError")
+    | let err: lint.ConfigError =>
+      h.assert_true(err.message.contains("not found"))
+    end
+
+class \nodoc\ _TestConfigFromCLIAutoDiscoverRootDir is UnitTest
+  """Auto-discovery with no config returns CWD as root dir."""
+  fun name(): String => "Config: from_cli auto-discover root dir"
+
+  fun apply(h: TestHelper) =>
+    // This test runs from a directory that (almost certainly) has no
+    // .pony-lint.json in CWD. If the ponyc repo's root .pony-lint.json
+    // is found via corral.json, the root dir will be the corral.json
+    // directory. Either way, we verify the return type is a tuple with
+    // a non-empty root dir string.
+    let auth = h.env.root
+    let no_disabled = recover val Array[String] end
+    match \exhaustive\
+      lint.ConfigLoader.from_cli(no_disabled, None, FileAuth(auth))
+    | (let _: lint.LintConfig, let root_dir: String val) =>
+      h.assert_true(root_dir.size() > 0)
     | let err: lint.ConfigError =>
       h.fail("unexpected error: " + err.message)
     end

--- a/tools/pony-lint/test/_test_config_resolver.pony
+++ b/tools/pony-lint/test/_test_config_resolver.pony
@@ -1,0 +1,221 @@
+use "pony_test"
+use "collections"
+use "files"
+use lint = ".."
+
+class \nodoc\ _TestConfigResolverNoOverrides is UnitTest
+  """Returns root config unchanged when no overrides exist."""
+  fun name(): String => "ConfigResolver: no overrides returns root config"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let sub = Path.join(tmp.path, "sub")
+
+      let config = lint.LintConfig.default()
+      let resolver = lint.ConfigResolver(config, tmp.path)
+      let result = resolver.config_for(sub)
+      h.assert_true(result is config)
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigResolverSingleOverride is UnitTest
+  """Subdirectory override applies to that directory."""
+  fun name(): String => "ConfigResolver: single override applies"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let examples = Path.join(tmp.path, "examples")
+
+      let root_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOn
+          m
+        end
+      let root_config =
+        lint.LintConfig(recover val Set[String] end, root_rules)
+      let resolver = lint.ConfigResolver(root_config, tmp.path)
+
+      let child_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOff
+          m
+        end
+      resolver.add_directory(examples, child_rules)
+
+      let result = resolver.config_for(examples)
+      // Should NOT be the same object as root
+      h.assert_false(result is root_config)
+      match \exhaustive\
+        result.rule_status("style/line-length", "style", lint.RuleOn)
+      | lint.RuleOff => h.assert_true(true)
+      | lint.RuleOn => h.fail("expected RuleOff in subdirectory")
+      end
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigResolverNestedOverrides is UnitTest
+  """Nearest ancestor override wins."""
+  fun name(): String => "ConfigResolver: nearest ancestor wins"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let examples = Path.join(tmp.path, "examples")
+      let sub = Path.join(examples, "sub")
+
+      let root_config = lint.LintConfig.default()
+      let resolver = lint.ConfigResolver(root_config, tmp.path)
+
+      // Parent turns off style
+      let parent_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style") = lint.RuleOff
+          m
+        end
+      resolver.add_directory(examples, parent_rules)
+
+      // Child turns line-length back on
+      let child_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOn
+          m
+        end
+      resolver.add_directory(sub, child_rules)
+
+      let result = resolver.config_for(sub)
+      // line-length should be on (child override)
+      match \exhaustive\
+        result.rule_status("style/line-length", "style", lint.RuleOn)
+      | lint.RuleOn => h.assert_true(true)
+      | lint.RuleOff => h.fail("expected RuleOn from child override")
+      end
+      // Other style rules should be off (parent category override)
+      match \exhaustive\
+        result.rule_status(
+          "style/trailing-whitespace", "style", lint.RuleOn)
+      | lint.RuleOff => h.assert_true(true)
+      | lint.RuleOn => h.fail("expected RuleOff from parent category")
+      end
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigResolverCaching is UnitTest
+  """Second call returns same object (identity check)."""
+  fun name(): String => "ConfigResolver: caching returns same object"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let sub = Path.join(tmp.path, "sub")
+
+      let config = lint.LintConfig.default()
+      let resolver = lint.ConfigResolver(config, tmp.path)
+
+      let child_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style") = lint.RuleOff
+          m
+        end
+      resolver.add_directory(sub, child_rules)
+
+      let first = resolver.config_for(sub)
+      let second = resolver.config_for(sub)
+      h.assert_true(first is second)
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigResolverRootSkipped is UnitTest
+  """add_directory for root dir is a no-op."""
+  fun name(): String => "ConfigResolver: root directory skipped"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      let config = lint.LintConfig.default()
+      let resolver = lint.ConfigResolver(config, tmp.path)
+
+      // Try to add an override for the root — should be ignored
+      let root_override =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style") = lint.RuleOff
+          m
+        end
+      resolver.add_directory(tmp.path, root_override)
+
+      let result = resolver.config_for(tmp.path)
+      // Should still be the original root config
+      h.assert_true(result is config)
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestConfigResolverDuplicateSkipped is UnitTest
+  """add_directory for same dir twice is idempotent."""
+  fun name(): String => "ConfigResolver: duplicate add is idempotent"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let sub = Path.join(tmp.path, "sub")
+
+      let root_config = lint.LintConfig.default()
+      let resolver = lint.ConfigResolver(root_config, tmp.path)
+
+      let first_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOff
+          m
+        end
+      resolver.add_directory(sub, first_rules)
+
+      // Second add with different data — should be ignored
+      let second_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOn
+          m
+        end
+      resolver.add_directory(sub, second_rules)
+
+      let result = resolver.config_for(sub)
+      // Should use first_rules (line-length off)
+      match \exhaustive\
+        result.rule_status("style/line-length", "style", lint.RuleOn)
+      | lint.RuleOff => h.assert_true(true)
+      | lint.RuleOn => h.fail("expected first add to win")
+      end
+
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end

--- a/tools/pony-lint/test/_test_linter.pony
+++ b/tools/pony-lint/test/_test_linter.pony
@@ -439,3 +439,446 @@ class \nodoc\ _TestLinterRespectsGitignoreFromParent is UnitTest
     else
       h.fail("could not create temp directory")
     end
+
+class \nodoc\ _TestLinterSubdirConfigDisablesRule is UnitTest
+  """Subdirectory .pony-lint.json disables a rule for that subtree."""
+  fun name(): String =>
+    "Linter: subdir config disables rule"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Root file with a long line (violation)
+      let root_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "root.pony"))
+      let rf = File(root_file)
+      let long_line = recover val String .> append("a".mul(100)) end
+      rf.print(long_line)
+      rf.dispose()
+
+      // Create examples/ subdirectory
+      let examples_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "examples"))
+      examples_dir.mkdir()
+
+      // examples/.pony-lint.json disables line-length
+      let config_file =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(examples_dir.path, ".pony-lint.json")))
+      config_file.print(
+        """{"rules": {"style/line-length": "off"}}""")
+      config_file.dispose()
+
+      // examples/ file with a long line (should NOT be flagged)
+      let ex_file =
+        FilePath(
+          FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
+      let ef = File(ex_file)
+      ef.print(long_line)
+      ef.dispose()
+
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path
+          where root_dir = tmp.path)
+      let targets = recover val [as String val: tmp.path] end
+      (let diags, _) = linter.run(targets)
+
+      // Only root.pony should have a violation
+      h.assert_eq[USize](1, diags.size())
+      try
+        h.assert_true(diags(0)?.file.contains("root.pony"))
+      else
+        h.fail("could not access diagnostic")
+      end
+
+      // Cleanup
+      ex_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(examples_dir.path, ".pony-lint.json")).remove()
+      examples_dir.remove()
+      root_file.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestLinterSubdirConfigEnablesRule is UnitTest
+  """Subdirectory config enables a rule disabled by root config."""
+  fun name(): String =>
+    "Linter: subdir config enables rule"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Root .pony-lint.json disables line-length
+      let root_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(tmp.path, ".pony-lint.json")))
+      root_config.print(
+        """{"rules": {"style/line-length": "off"}}""")
+      root_config.dispose()
+
+      // Root file with a long line (should NOT be flagged)
+      let root_file =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "root.pony"))
+      let rf = File(root_file)
+      let long_line = recover val String .> append("a".mul(100)) end
+      rf.print(long_line)
+      rf.dispose()
+
+      // Create strict/ subdirectory
+      let strict_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "strict"))
+      strict_dir.mkdir()
+
+      // strict/.pony-lint.json re-enables line-length
+      let strict_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(strict_dir.path, ".pony-lint.json")))
+      strict_config.print(
+        """{"rules": {"style/line-length": "on"}}""")
+      strict_config.dispose()
+
+      // strict/ file with a long line (SHOULD be flagged)
+      let strict_file =
+        FilePath(
+          FileAuth(auth), Path.join(strict_dir.path, "strict.pony"))
+      let sf = File(strict_file)
+      sf.print(long_line)
+      sf.dispose()
+
+      // Load root config manually since test creates its own
+      let file_auth = FileAuth(auth)
+      let root_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOff
+          m
+        end
+      let config =
+        lint.LintConfig(recover val Set[String] end, root_rules)
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry = lint.RuleRegistry(rules, _NoASTRules(), config)
+      let linter =
+        lint.Linter(
+          registry, file_auth, tmp.path
+          where root_dir = tmp.path)
+      let targets = recover val [as String val: tmp.path] end
+      (let diags, _) = linter.run(targets)
+
+      // Only strict.pony should have a violation
+      h.assert_eq[USize](1, diags.size())
+      try
+        h.assert_true(diags(0)?.file.contains("strict.pony"))
+      else
+        h.fail("could not access diagnostic")
+      end
+
+      // Cleanup
+      strict_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(strict_dir.path, ".pony-lint.json")).remove()
+      strict_dir.remove()
+      root_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(tmp.path, ".pony-lint.json")).remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestLinterSubdirConfigError is UnitTest
+  """Malformed subdirectory config produces lint/config-error diagnostic."""
+  fun name(): String =>
+    "Linter: subdir config error"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Create sub/ directory with malformed config
+      let sub_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "sub"))
+      sub_dir.mkdir()
+
+      let bad_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(sub_dir.path, ".pony-lint.json")))
+      bad_config.print("{not valid json}")
+      bad_config.dispose()
+
+      // A clean file in sub/
+      let sub_file =
+        FilePath(
+          FileAuth(auth), Path.join(sub_dir.path, "test.pony"))
+      let sf = File(sub_file)
+      sf.print("actor Main")
+      sf.dispose()
+
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path
+          where root_dir = tmp.path)
+      let targets = recover val [as String val: tmp.path] end
+      (let diags, let exit_code) = linter.run(targets)
+
+      // Should have a config-error diagnostic
+      var found_config_error = false
+      for d in diags.values() do
+        if d.rule_id == "lint/config-error" then
+          found_config_error = true
+          h.assert_true(d.message.contains("malformed JSON"))
+        end
+      end
+      h.assert_true(found_config_error)
+      match exit_code
+      | lint.ExitError => h.assert_true(true)
+      else
+        h.fail("expected ExitError")
+      end
+
+      // Cleanup
+      sub_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(sub_dir.path, ".pony-lint.json")).remove()
+      sub_dir.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestLinterSubdirConfigCategoryCleaning is UnitTest
+  """Child category off overrides parent rule-specific on."""
+  fun name(): String =>
+    "Linter: subdir config category cleaning"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Root config enables line-length explicitly
+      let root_rules =
+        recover val
+          let m = Map[String, lint.RuleStatus]
+          m("style/line-length") = lint.RuleOn
+          m
+        end
+      let config =
+        lint.LintConfig(recover val Set[String] end, root_rules)
+
+      // Create examples/ with category-off config
+      let examples_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "examples"))
+      examples_dir.mkdir()
+
+      let ex_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(examples_dir.path, ".pony-lint.json")))
+      ex_config.print("""{"rules": {"style": "off"}}""")
+      ex_config.dispose()
+
+      // Long line in examples/ (should NOT be flagged)
+      let ex_file =
+        FilePath(
+          FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
+      let ef = File(ex_file)
+      let long_line = recover val String .> append("a".mul(100)) end
+      ef.print(long_line)
+      ef.dispose()
+
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry = lint.RuleRegistry(rules, _NoASTRules(), config)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path
+          where root_dir = tmp.path)
+      let targets =
+        recover val [as String val: examples_dir.path] end
+      (let diags, _) = linter.run(targets)
+
+      // No violations — category cleaning removed rule-specific "on"
+      h.assert_eq[USize](0, diags.size())
+
+      // Cleanup
+      ex_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(examples_dir.path, ".pony-lint.json")).remove()
+      examples_dir.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestLinterExplicitFileSubdirConfig is UnitTest
+  """Explicit file target respects config in its directory."""
+  fun name(): String =>
+    "Linter: explicit file target uses subdir config"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Create examples/ with config disabling line-length
+      let examples_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "examples"))
+      examples_dir.mkdir()
+
+      let ex_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(examples_dir.path, ".pony-lint.json")))
+      ex_config.print(
+        """{"rules": {"style/line-length": "off"}}""")
+      ex_config.dispose()
+
+      // Long line in examples/ — should NOT be flagged
+      let ex_file =
+        FilePath(
+          FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
+      let ef = File(ex_file)
+      let long_line = recover val String .> append("a".mul(100)) end
+      ef.print(long_line)
+      ef.dispose()
+
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path
+          where root_dir = tmp.path)
+      // Target the file directly, not the directory
+      let targets =
+        recover val
+          [ as String val:
+            Path.join(examples_dir.path, "ex.pony")
+          ]
+        end
+      (let diags, _) = linter.run(targets)
+
+      // No violations — subdir config disables line-length
+      h.assert_eq[USize](0, diags.size())
+
+      // Cleanup
+      ex_file.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(examples_dir.path, ".pony-lint.json")).remove()
+      examples_dir.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
+class \nodoc\ _TestLinterIntermediateConfigLoading is UnitTest
+  """Intermediate config between root and target is loaded."""
+  fun name(): String =>
+    "Linter: intermediate config loading"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+
+      // Create mid/ with config disabling line-length
+      let mid_dir =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, "mid"))
+      mid_dir.mkdir()
+
+      let mid_config =
+        File(
+          FilePath(
+            FileAuth(auth),
+            Path.join(mid_dir.path, ".pony-lint.json")))
+      mid_config.print(
+        """{"rules": {"style/line-length": "off"}}""")
+      mid_config.dispose()
+
+      // Create mid/sub/ as the lint target
+      let sub_dir =
+        FilePath(
+          FileAuth(auth), Path.join(mid_dir.path, "sub"))
+      sub_dir.mkdir()
+
+      // Long line in sub/ — should NOT be flagged (inherits mid/ config)
+      let sub_file =
+        FilePath(
+          FileAuth(auth), Path.join(sub_dir.path, "test.pony"))
+      let sf = File(sub_file)
+      let long_line = recover val String .> append("a".mul(100)) end
+      sf.print(long_line)
+      sf.dispose()
+
+      let rules: Array[lint.TextRule val] val =
+        recover val [as lint.TextRule val: lint.LineLength] end
+      let registry =
+        lint.RuleRegistry(
+          rules, _NoASTRules(), lint.LintConfig.default())
+      // Target is sub/, so mid/ is an intermediate directory
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path
+          where root_dir = tmp.path)
+      let targets = recover val [as String val: sub_dir.path] end
+      (let diags, _) = linter.run(targets)
+
+      // No violations — mid/ config disables line-length
+      h.assert_eq[USize](0, diags.size())
+
+      // Cleanup
+      sub_file.remove()
+      sub_dir.remove()
+      FilePath(
+        FileAuth(auth),
+        Path.join(mid_dir.path, ".pony-lint.json")).remove()
+      mid_dir.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -55,6 +55,22 @@ actor \nodoc\ Main is TestList
     test(_TestConfigParseMalformedJSON)
     test(_TestConfigParseInvalidStatus)
     test(_TestConfigParseNoRules)
+    test(_TestConfigMergeRuleOverride)
+    test(_TestConfigMergeCategoryCleaning)
+    test(_TestConfigMergeOmissionDefers)
+    test(_TestConfigMergeCLICarriesForward)
+    test(_TestConfigMergeRuleSpecificNoCleanCategory)
+    test(_TestConfigFromCLIExplicitConfigRootDir)
+    test(_TestConfigFromCLIExplicitConfigNotFound)
+    test(_TestConfigFromCLIAutoDiscoverRootDir)
+
+    // ConfigResolver tests
+    test(_TestConfigResolverNoOverrides)
+    test(_TestConfigResolverSingleOverride)
+    test(_TestConfigResolverNestedOverrides)
+    test(_TestConfigResolverCaching)
+    test(_TestConfigResolverRootSkipped)
+    test(_TestConfigResolverDuplicateSkipped)
 
     // Registry tests
     test(_TestRegistryDefaultAllEnabled)
@@ -157,6 +173,12 @@ actor \nodoc\ Main is TestList
     test(_TestLinterRespectsGitignore)
     test(_TestLinterExplicitFileBypassesIgnore)
     test(_TestLinterRespectsGitignoreFromParent)
+    test(_TestLinterSubdirConfigDisablesRule)
+    test(_TestLinterSubdirConfigEnablesRule)
+    test(_TestLinterSubdirConfigError)
+    test(_TestLinterSubdirConfigCategoryCleaning)
+    test(_TestLinterExplicitFileSubdirConfig)
+    test(_TestLinterIntermediateConfigLoading)
 
     // ExplainHelpers tests
     test(_TestExplainFormatEnabled)


### PR DESCRIPTION
pony-lint now supports `.pony-lint.json` files in subdirectories, not just at the project root. A subdirectory config overrides the root config for all files in that subtree, using the same JSON format and proximity-first precedence.

New types: `ConfigResolver` resolves per-directory rule status by merging the config hierarchy. `LintConfig.merge()` layers child overrides on parent configs with category-cleaning semantics.

Config discovery piggybacks on the existing file-discovery walk alongside `.gitignore`/`.ignore` loading. Intermediate configs between the hierarchy root and walk targets are pre-loaded, and explicit file targets load their directory's config directly.

Malformed subdirectory configs produce `lint/config-error` diagnostics and fall through to the parent config.

Design: #5028

### Things to note

1. **Uncached RuleRegistry per file in text phase** — `_registry_for()` constructs a new `RuleRegistry` for every file in an overridden directory. The config is cached but the registry is not. Negligible for a CLI tool; easy to add a registry cache later if needed.

2. **Walk-discovered configs ignore empty `root_dir` sentinel** — `_FileCollector._load_config` runs unconditionally during the walk regardless of whether hierarchical config is enabled (empty `root_dir`). No practical impact since `main.pony` always passes a non-empty `root_dir`.