### PR TITLE
Report error when pony-lint encounters unknown rules in configuration

### DIFF
--- a/.release-notes/lint-config-unknown-keys.md
+++ b/.release-notes/lint-config-unknown-keys.md
@@ -1,0 +1,3 @@
+## Report error when pony-lint encounters unknown rules in configuration
+
+pony-lint now reports an error when a `.pony-lint.json` config file contains rule IDs or categories that don't match any known rule. Previously, a typo like `"stlye/line-length"` was silently ignored, leaving the rule in its default state with no indication that the config entry had no effect.

--- a/tools/pony-lint/config.pony
+++ b/tools/pony-lint/config.pony
@@ -88,6 +88,49 @@ class val LintConfig
         merged
       end
 
+  fun validate(known: Set[String] val): (None | ConfigError) =>
+    """
+    Check that every key in the config file matches a known rule ID or
+    category. Returns `ConfigError` listing all unrecognized keys, or
+    `None` when everything is valid.
+    """
+    let unknown = _unknown_keys(known)
+    if unknown.size() > 0 then
+      return ConfigError(_format_unknown(unknown))
+    end
+
+  fun _unknown_keys(known: Set[String] val): Array[String] val =>
+    """
+    Returns config file keys that don't appear in the known set.
+    """
+    recover val
+      let u = Array[String]
+      for key in _file_rules.keys() do
+        if not known.contains(key) then
+          u.push(key)
+        end
+      end
+      u
+    end
+
+  fun _format_unknown(keys: Array[String] val): String iso^ =>
+    """
+    Format unrecognized keys into an error message.
+    """
+    recover iso
+      let s = String
+      s.append("unrecognized config keys: ")
+      var first = true
+      for key in keys.values() do
+        if not first then s.append(", ") end
+        s.append("'")
+        s.append(key)
+        s.append("'")
+        first = false
+      end
+      s
+    end
+
   fun rule_status(
     rule_id: String,
     category: String,

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -164,6 +164,27 @@ actor Main
         return
       end
 
+    // Validate config keys against known rules
+    let known_keys =
+      recover val
+        let s = Set[String]
+        for rule in all_rules.values() do
+          s.set(rule.id())
+          s.set(rule.category())
+        end
+        for rule in all_ast_rules.values() do
+          s.set(rule.id())
+          s.set(rule.category())
+        end
+        s
+      end
+    match config.validate(known_keys)
+    | let err: ConfigError =>
+      env.err.print("error: " + err.message)
+      env.exitcode(ExitError())
+      return
+    end
+
     // Build rule registry
     let registry = RuleRegistry(all_rules, all_ast_rules, config)
 

--- a/tools/pony-lint/test/_test_config.pony
+++ b/tools/pony-lint/test/_test_config.pony
@@ -369,3 +369,146 @@ class \nodoc\ _TestConfigFromCLIAutoDiscoverRootDir is UnitTest
     | let err: lint.ConfigError =>
       h.fail("unexpected error: " + err.message)
     end
+
+class \nodoc\ _TestConfigValidateKnownKeys is UnitTest
+  """Validate passes when all config keys are known rule IDs or categories."""
+  fun name(): String => "Config: validate passes for known keys"
+
+  fun apply(h: TestHelper) =>
+    let disabled = recover val Set[String] end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m("style") = lint.RuleOn
+        m
+      end
+    let config = lint.LintConfig(disabled, file_rules)
+    let known =
+      recover val
+        Set[String]
+          .> set("style/line-length")
+          .> set("style/trailing-whitespace")
+          .> set("style")
+      end
+    match config.validate(known)
+    | let err: lint.ConfigError =>
+      h.fail("unexpected error: " + err.message)
+    end
+
+class \nodoc\ _TestConfigValidateUnknownRule is UnitTest
+  """Validate fails when config has an unrecognized rule ID."""
+  fun name(): String => "Config: validate fails for unknown rule"
+
+  fun apply(h: TestHelper) =>
+    let disabled = recover val Set[String] end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("stlye/line-length") = lint.RuleOff
+        m
+      end
+    let config = lint.LintConfig(disabled, file_rules)
+    let known =
+      recover val
+        Set[String]
+          .> set("style/line-length")
+          .> set("style")
+      end
+    match \exhaustive\ config.validate(known)
+    | None => h.fail("expected ConfigError")
+    | let err: lint.ConfigError =>
+      h.assert_true(err.message.contains("stlye/line-length"))
+    end
+
+class \nodoc\ _TestConfigValidateUnknownCategory is UnitTest
+  """Validate fails when config has an unrecognized category."""
+  fun name(): String => "Config: validate fails for unknown category"
+
+  fun apply(h: TestHelper) =>
+    let disabled = recover val Set[String] end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("stlye") = lint.RuleOff
+        m
+      end
+    let config = lint.LintConfig(disabled, file_rules)
+    let known =
+      recover val
+        Set[String]
+          .> set("style/line-length")
+          .> set("style")
+      end
+    match \exhaustive\ config.validate(known)
+    | None => h.fail("expected ConfigError")
+    | let err: lint.ConfigError =>
+      h.assert_true(err.message.contains("stlye"))
+    end
+
+class \nodoc\ _TestConfigValidateEmptyConfig is UnitTest
+  """Validate passes when config has no file rules."""
+  fun name(): String => "Config: validate passes for empty config"
+
+  fun apply(h: TestHelper) =>
+    let config = lint.LintConfig.default()
+    let known =
+      recover val Set[String] .> set("style/line-length") end
+    match config.validate(known)
+    | let err: lint.ConfigError =>
+      h.fail("unexpected error: " + err.message)
+    end
+
+class \nodoc\ _TestConfigValidateMultipleUnknown is UnitTest
+  """Validate reports all unrecognized keys, not just the first."""
+  fun name(): String => "Config: validate reports multiple unknown keys"
+
+  fun apply(h: TestHelper) =>
+    let disabled = recover val Set[String] end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("bogus/one") = lint.RuleOff
+        m("bogus/two") = lint.RuleOff
+        m
+      end
+    let config = lint.LintConfig(disabled, file_rules)
+    let known =
+      recover val
+        Set[String]
+          .> set("style/line-length")
+          .> set("style")
+      end
+    match \exhaustive\ config.validate(known)
+    | None => h.fail("expected ConfigError")
+    | let err: lint.ConfigError =>
+      h.assert_true(err.message.contains("bogus/one"))
+      h.assert_true(err.message.contains("bogus/two"))
+    end
+
+class \nodoc\ _TestConfigValidateMixedKnownUnknown is UnitTest
+  """Validate only reports unknown keys, not known ones."""
+  fun name(): String => "Config: validate reports only unknown keys"
+
+  fun apply(h: TestHelper) =>
+    let disabled = recover val Set[String] end
+    let file_rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style/line-length") = lint.RuleOff
+        m("bogus/rule") = lint.RuleOn
+        m
+      end
+    let config = lint.LintConfig(disabled, file_rules)
+    let known =
+      recover val
+        Set[String]
+          .> set("style/line-length")
+          .> set("style")
+      end
+    match \exhaustive\ config.validate(known)
+    | None => h.fail("expected ConfigError")
+    | let err: lint.ConfigError =>
+      h.assert_true(err.message.contains("bogus/rule"))
+      h.assert_false(err.message.contains("style/line-length"))
+    end

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -63,6 +63,12 @@ actor \nodoc\ Main is TestList
     test(_TestConfigFromCLIExplicitConfigRootDir)
     test(_TestConfigFromCLIExplicitConfigNotFound)
     test(_TestConfigFromCLIAutoDiscoverRootDir)
+    test(_TestConfigValidateKnownKeys)
+    test(_TestConfigValidateUnknownRule)
+    test(_TestConfigValidateUnknownCategory)
+    test(_TestConfigValidateEmptyConfig)
+    test(_TestConfigValidateMultipleUnknown)
+    test(_TestConfigValidateMixedKnownUnknown)
 
     // ConfigResolver tests
     test(_TestConfigResolverNoOverrides)


### PR DESCRIPTION
A typo like `"stlye/line-length"` in `.pony-lint.json` silently does nothing because it doesn't match any known rule. This gets worse with hierarchical config (#5028) — more config files means more typo surface.

After loading config, all keys are now validated against known rule IDs and categories. Unrecognized keys produce a hard error (exit code 2) listing all offending keys.

Closes #5132