### PR TITLE
Protect pony-lint against oversize configuration files

### DIFF
--- a/.release-notes/protect-pony-lint-against-oversize-config.md
+++ b/.release-notes/protect-pony-lint-against-oversize-config.md
@@ -1,0 +1,3 @@
+## Protect pony-lint against oversize configuration files
+
+pony-lint now rejects `.pony-lint.json` files larger than 64 KB. With hierarchical configuration, each directory in a project can have its own config file — an unexpectedly large file could cause excessive memory consumption. Config files that exceed the limit produce a `lint/config-error` diagnostic with the file size and path.

--- a/tools/pony-lint/config.pony
+++ b/tools/pony-lint/config.pony
@@ -250,12 +250,23 @@ primitive ConfigLoader
   =>
     """
     Parse a `.pony-lint.json` file into rule status overrides.
+
+    Rejects files larger than 64 KB to prevent unexpected memory consumption,
+    especially with hierarchical configs where each directory can have its own
+    config file.
     """
     let file = File.open(fp)
     if not file.valid() then
       return ConfigError("could not open config file: " + fp.path)
     end
-    let content: String val = file.read_string(file.size())
+    let size = file.size()
+    if size > _max_config_size() then
+      file.dispose()
+      return ConfigError(
+        "config file too large (" + size.string() + " bytes, max "
+          + _max_config_size().string() + "): " + fp.path)
+    end
+    let content: String val = file.read_string(size)
     file.dispose()
     parse(content)
 
@@ -286,6 +297,8 @@ primitive ConfigLoader
     | let err: json.JsonParseError =>
       ConfigError("malformed JSON in config file: " + err.string())
     end
+
+  fun _max_config_size(): USize => 65_536
 
   fun _parse_rules(rules: json.JsonObject)
     : (Map[String, RuleStatus] val | ConfigError)

--- a/tools/pony-lint/test/_test_config.pony
+++ b/tools/pony-lint/test/_test_config.pony
@@ -486,6 +486,36 @@ class \nodoc\ _TestConfigValidateMultipleUnknown is UnitTest
       h.assert_true(err.message.contains("bogus/two"))
     end
 
+class \nodoc\ _TestConfigParseFileTooLarge is UnitTest
+  """Oversized config file produces ConfigError."""
+  fun name(): String => "Config: oversized file -> error"
+
+  fun apply(h: TestHelper) =>
+    let auth = h.env.root
+    try
+      let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let config_fp =
+        FilePath(
+          FileAuth(auth), Path.join(tmp.path, ".pony-lint.json"))
+      let f = File(config_fp)
+      // Write 65537 bytes — one byte over the 64 KB limit
+      let content = recover val String(65_537) .> append("x" * 65_537) end
+      f.print(content)
+      f.dispose()
+
+      match \exhaustive\ lint.ConfigLoader.parse_file(config_fp)
+      | let _: Map[String, lint.RuleStatus] val =>
+        h.fail("expected ConfigError for oversized file")
+      | let err: lint.ConfigError =>
+        h.assert_true(err.message.contains("too large"))
+      end
+
+      config_fp.remove()
+      tmp.remove()
+    else
+      h.fail("could not create temp directory")
+    end
+
 class \nodoc\ _TestConfigValidateMixedKnownUnknown is UnitTest
   """Validate only reports unknown keys, not known ones."""
   fun name(): String => "Config: validate reports only unknown keys"

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -69,6 +69,7 @@ actor \nodoc\ Main is TestList
     test(_TestConfigValidateEmptyConfig)
     test(_TestConfigValidateMultipleUnknown)
     test(_TestConfigValidateMixedKnownUnknown)
+    test(_TestConfigParseFileTooLarge)
 
     // ConfigResolver tests
     test(_TestConfigResolverNoOverrides)


### PR DESCRIPTION
Rejects `.pony-lint.json` files larger than 64 KB before reading them into memory. With hierarchical config, each directory can have its own config file — this prevents unexpected memory consumption from oversized files. Files over the limit produce a `lint/config-error` diagnostic.

Also filed #5137 for the same pattern in `IgnoreMatcher._load_file`.

Closes #5133