### PR TITLE
Fix pony-lsp failures with some code constructs

### DIFF
--- a/.release-notes/fix-pony-lsp-type-alias-args.md
+++ b/.release-notes/fix-pony-lsp-type-alias-args.md
@@ -1,0 +1,3 @@
+## Fix pony-lsp failures with some code constructs
+
+Fixed go-to-definition failing for type arguments inside generic type aliases. For example, go-to-definition on `String` or `U32` in `Map[String, U32]` now correctly navigates to their definitions. Previously, these positions returned no result.

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
@@ -80,8 +80,59 @@ class val PositionIndex
   new val create(module: Module val) =>
     _module = module
     let visitor = _PositionIndexBuilder
-    _module.ast.visit(visitor)
+    _build_index(_module.ast, visitor, _module.file)
     _index = visitor.index()
+
+  fun tag _is_filter_none_parent(ast_id: TokenId): Bool =>
+    """
+    Should TK_NONE children of this node type be skipped during traversal?
+    Matches the filter_none logic in AST.visit().
+    """
+    match ast_id
+    | TokenIds.tk_call() | TokenIds.tk_typeref() | TokenIds.tk_use()
+    | TokenIds.tk_actor() | TokenIds.tk_class() | TokenIds.tk_struct()
+    | TokenIds.tk_trait() | TokenIds.tk_interface() | TokenIds.tk_type()
+    | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be()
+    | TokenIds.tk_fvar() | TokenIds.tk_flet() | TokenIds.tk_embed()
+    | TokenIds.tk_nominal() | TokenIds.tk_param()
+    => true
+    else
+      false
+    end
+
+  fun tag _build_index(
+    ast: AST box,
+    visitor: _PositionIndexBuilder ref,
+    module_file: String val)
+  =>
+    """
+    Custom traversal for building the position index.
+
+    Unlike AST.visit(), which filters children by the parent's source file,
+    this checks each node against the module's source file and always recurses
+    into children. This is necessary because several compiler transformations
+    create mixed-source trees via ast_dup: type alias reification grafts
+    definition nodes (TK_TYPEARGS, TK_ID) that retain the stdlib source, and
+    default trait method bodies are copied into implementing classes. In both
+    cases, user-authored nodes appear as descendants of foreign-source parents.
+    The parent-relative filter in AST.visit() skips the foreign parent and
+    never reaches the user's nodes underneath.
+    """
+    let filter_none = _is_filter_none_parent(ast.id())
+    for child' in ast.children() do
+      if filter_none and (child'.id() == TokenIds.tk_none()) then
+        None // skip TK_NONE children of certain parent types
+      else
+        let from_module = match child'.source_file()
+          | let sf: String val => sf == module_file
+          else true
+          end
+        if from_module then visitor.visit(child') end
+        // Always recurse regardless of source, so we reach user nodes
+        // inside mixed-source subtrees
+        _build_index(child', visitor, module_file)
+      end
+    end
 
   fun debug(out: OutStream) =>
     for entry in _index.values() do

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -18,6 +18,7 @@ primitive _DefinitionIntegrationTests is TestList
     test(_DefinitionCrossFileIntegrationTest.create(server))
     test(_DefinitionGenericsIntegrationTest.create(server))
     test(_DefinitionTupleIntegrationTest.create(server))
+    test(_DefinitionTypeAliasIntegrationTest.create(server))
 
 class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
   let _server: _DefinitionLspServer
@@ -207,6 +208,35 @@ class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
       [
         // `_1` tuple element access → `let pair` declaration
         ((16, 9), [("_tuple.pony", (15, 4), (15, 7))])
+      ]
+    h.long_test(10_000_000_000)
+    for ((line, character), _) in checks.values() do
+      h.expect_action(
+        workspace_file + ":" + line.string() + ":" + character.string())
+    end
+    _server.test_goto_definition(h, workspace_file, checks)
+
+class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
+  let _server: _DefinitionLspServer
+
+  new iso create(server: _DefinitionLspServer) =>
+    _server = server
+
+  fun name(): String => "definition/integration/type_alias"
+
+  fun apply(h: TestHelper) =>
+    let workspace_file = "definition/_type_alias.pony"
+    let checks: Array[DefinitionCheck] val =
+      [
+        // `String` type arg in `Map[String, U32]` → String class declaration
+        ((17, 17), [("string.pony", (8, 0), (8, 5))])
+        // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
+        ((17, 25), [("unsigned.pony", (185, 0), (185, 9))])
+        // `_Alias` usage — after reification the alias is replaced with its
+        // expansion (U8), so the original alias identity is lost and goto
+        // definition returns no result. Fixing this requires first-class type
+        // aliases (ponylang/ponyc#5007).
+        ((19, 20), [])
       ]
     h.long_test(10_000_000_000)
     for ((line, character), _) in checks.values() do

--- a/tools/pony-lsp/test/workspace/definition/_type_alias.pony
+++ b/tools/pony-lsp/test/workspace/definition/_type_alias.pony
@@ -1,0 +1,25 @@
+use "collections"
+
+type _Alias is U8
+
+class _TypeAliasFields
+  """
+  Test fixture for goto definition on type arguments inside type aliases.
+
+  `Map` is a type alias for `HashMap[K, V, HashEq[K]]`. After the compiler's
+  name resolution pass, the alias is expanded and the original `Map` reference
+  is replaced. The type arguments (`String`, `U32`) are substituted into the
+  expanded tree but must remain reachable by the position index for goto
+  definition to work.
+
+  `_Alias` is a simple type alias defined in this file, testing whether goto
+  definition works on a local type alias usage.
+  """
+  let _data: Map[String, U32] val
+  let _name: String
+  let _alias_field: _Alias
+
+  new create() =>
+    _data = recover val Map[String, U32] end
+    _name = ""
+    _alias_field = 0


### PR DESCRIPTION
When ponyc resolves type aliases, `reify()` duplicates the definition's AST and substitutes user type arguments. The duplicated structural nodes (`TK_TYPEARGS`, `TK_ID` for the type name) retain the definition's source file, while substituted type args keep the user's source file. The same mixed-source pattern occurs anywhere `ast_dup` grafts nodes from one source file into a tree rooted in another — including default trait/interface method bodies copied into implementing classes.

`AST.visit()` filters children by comparing their source file to the parent's. This cascading filter means that when a parent node has source file A but a child has source file B (from `ast_dup`), the child and all its descendants are skipped — even if some of those descendants have source file A (e.g., user type arguments substituted into a duplicated definition tree).

This replaces the generic `AST.visit()` traversal in `PositionIndex` with a custom `_build_index` that checks each node against the module's source file (not the parent's) and always recurses into children regardless of source. This reaches user nodes inside mixed-source subtrees while still excluding nodes from other source files.

The most visible effect is that pony-lsp go-to-definition now works for type arguments inside generic type aliases (e.g., both `String` in `Map[String, String]`). Go-to-definition on the alias name itself (`Map`) still doesn't work — that requires preserving alias identity in the compiler (ponylang/ponyc#745, ponylang/ponyc#5007).