### PR TITLE
Track shared library changes for tool rebuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,18 @@ else()
         add_subdirectory(src/crt)
     endif()
 
+    # Stamp file so tools rebuild when shared library sources change.
+    # Adding new shared libraries under tools/lib/ only requires updating
+    # the glob here rather than every tool's CMakeLists.txt.
+    file(GLOB_RECURSE TOOLS_LIB_SOURCES CONFIGURE_DEPENDS "tools/lib/*.pony")
+    set(TOOLS_LIB_STAMP ${CMAKE_BINARY_DIR}/tools_lib.stamp)
+    add_custom_command(OUTPUT ${TOOLS_LIB_STAMP}
+      COMMAND ${CMAKE_COMMAND} -E touch ${TOOLS_LIB_STAMP}
+      DEPENDS ${TOOLS_LIB_SOURCES}
+      COMMENT "Shared tool library sources changed"
+    )
+    add_custom_target(tools_lib_stamp DEPENDS ${TOOLS_LIB_STAMP})
+
     add_subdirectory(tools/pony-lsp)
     add_subdirectory(tools/pony-lint)
     add_subdirectory(tools/pony-doc)

--- a/tools/pony-doc/CMakeLists.txt
+++ b/tools/pony-doc/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-doc ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABLE})
-add_dependencies(tools.pony-doc libponyc-standalone)
+add_dependencies(tools.pony-doc libponyc-standalone tools_lib_stamp)
 
 file(GLOB_RECURSE DOC_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABLE}
@@ -21,6 +21,7 @@ add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_DOC_EXECUTABL
   COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
     ${DOC_SOURCES}
+    ${TOOLS_LIB_STAMP}
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tools/pony-lint/CMakeLists.txt
+++ b/tools/pony-lint/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-lint ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LINT_EXECUTABLE})
-add_dependencies(tools.pony-lint libponyc-standalone)
+add_dependencies(tools.pony-lint libponyc-standalone tools_lib_stamp)
 
 file(GLOB_RECURSE LINT_SOURCES CONFIGURE_DEPENDS "*.pony")
 add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LINT_EXECUTABLE}
@@ -21,6 +21,7 @@ add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LINT_EXECUTAB
   COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
     ${LINT_SOURCES}
+    ${TOOLS_LIB_STAMP}
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
 add_custom_target(tools.pony-lsp ALL DEPENDS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABLE})
-add_dependencies(tools.pony-lsp libponyc-standalone)
+add_dependencies(tools.pony-lsp libponyc-standalone tools_lib_stamp)
 
 # TODO STA: --path entries are temporary until a ponyc bug is fixed.
 file(GLOB_RECURSE LSP_SOURCES CONFIGURE_DEPENDS "*.pony")
@@ -22,6 +22,7 @@ add_custom_command(OUTPUT ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PONY_LSP_EXECUTABL
   COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
     ${LSP_SOURCES}
+    ${TOOLS_LIB_STAMP}
     $<TARGET_FILE:ponyc>
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
Each tool's build command only depended on its own `.pony` files, so changes to the shared `pony_compiler` library under `tools/lib/` didn't trigger tool rebuilds — you had to manually delete the binary or `make clean`.

Adds a CMake stamp file that globs all `.pony` files under `tools/lib/` and have each tool's build command depend on it. Adding new shared libraries under `lib/` only requires updating the glob in the top-level CMakeLists.txt.

Closes #5142