### PR TITLE
Fix silent timer hangs on Linux

### DIFF
--- a/.release-notes/fix-unchecked-timerfd-returns.md
+++ b/.release-notes/fix-unchecked-timerfd-returns.md
@@ -1,0 +1,5 @@
+## Fix silent timer hangs on Linux
+
+On Linux, if a timer system call failed (due to resource exhaustion or other system error), the failure was silently ignored. Actors waiting for timer notifications would hang indefinitely with no error — timers that should fire simply never did.
+
+The runtime now detects timer setup and arming failures and notifies the affected actor, which tears down cleanly — the same as any other I/O failure. Stdlib consumers like `Timers` handle this automatically.

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -346,7 +346,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
   return NULL;
 }
 
-static void timer_set_nsec(int fd, uint64_t nsec)
+static bool timer_set_nsec(int fd, uint64_t nsec)
 {
   struct itimerspec ts;
 
@@ -355,7 +355,7 @@ static void timer_set_nsec(int fd, uint64_t nsec)
   ts.it_value.tv_sec = (time_t)(nsec / 1000000000);
   ts.it_value.tv_nsec = (long)(nsec - (ts.it_value.tv_sec * 1000000000));
 
-  timerfd_settime(fd, 0, &ts, NULL);
+  return timerfd_settime(fd, 0, &ts, NULL) == 0;
 }
 
 PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
@@ -393,7 +393,20 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
   if(ev->flags & ASIO_TIMER)
   {
     ev->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
-    timer_set_nsec(ev->fd, ev->nsec);
+    if(ev->fd == -1)
+    {
+      pony_asio_event_send(ev, ASIO_ERROR, 0);
+      return;
+    }
+
+    if(!timer_set_nsec(ev->fd, ev->nsec))
+    {
+      close(ev->fd);
+      ev->fd = -1;
+      pony_asio_event_send(ev, ASIO_ERROR, 0);
+      return;
+    }
+
     ep.events |= EPOLLIN;
   }
 
@@ -458,7 +471,8 @@ PONY_API void pony_asio_event_setnsec(asio_event_t* ev, uint64_t nsec)
   if(ev->flags & ASIO_TIMER)
   {
     ev->nsec = nsec;
-    timer_set_nsec(ev->fd, nsec);
+    if(!timer_set_nsec(ev->fd, nsec))
+      pony_asio_event_send(ev, ASIO_ERROR, 0);
   }
 }
 


### PR DESCRIPTION
`timerfd_create` and `timerfd_settime` return values were unchecked in the epoll ASIO backend. If either call failed, the timer silently never fired and the actor waited forever for a notification that never came.

Now checks both return values and sends `ASIO_ERROR` to the actor on failure, matching the existing pattern for `epoll_ctl` failures in the same file.