### PR TITLE
Refactor LSP integration tests to share server and checker infrastructure

### DIFF
--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -203,7 +203,7 @@ class val _DefinitionChecker
   fun lsp_method(): String =>
     Methods.text_document().definition()
 
-  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     let got_count =
       try JsonNav(res.result).size()? else 0 end

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -9,7 +9,7 @@ primitive _DefinitionIntegrationTests is TestList
 
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
-    let server = _DefinitionLspServer(workspace_dir)
+    let server = _LspTestServer(workspace_dir)
     test(_DefinitionClassIntegrationTest.create(server))
     test(_DefinitionThisIntegrationTest.create(server))
     test(_DefinitionKeywordsIntegrationTest.create(server))
@@ -21,9 +21,9 @@ primitive _DefinitionIntegrationTests is TestList
     test(_DefinitionTypeAliasIntegrationTest.create(server))
 
 class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/class"
@@ -43,16 +43,17 @@ class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
         ((1, 4), [])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionThisIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/this"
@@ -65,16 +66,17 @@ class \nodoc\ iso _DefinitionThisIntegrationTest is UnitTest
         ((13, 4), [("_class.pony", (0, 0), (0, 5))])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionKeywordsIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/keywords"
@@ -93,16 +95,17 @@ class \nodoc\ iso _DefinitionKeywordsIntegrationTest is UnitTest
         ((9, 11), [])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionTraitIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/trait"
@@ -115,16 +118,17 @@ class \nodoc\ iso _DefinitionTraitIntegrationTest is UnitTest
         ((50, 6), [("_trait.pony", (7, 2), (7, 5))])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/union"
@@ -142,16 +146,17 @@ class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
           ])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/cross_file"
@@ -166,16 +171,17 @@ class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
         ((14, 8), [("_cross_target.pony", (13, 2), (13, 5))])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionGenericsIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/generics"
@@ -188,16 +194,17 @@ class \nodoc\ iso _DefinitionGenericsIntegrationTest is UnitTest
         ((19, 22), [("_generics.pony", (19, 12), (19, 16))])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/tuple"
@@ -210,16 +217,17 @@ class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
         ((16, 9), [("_tuple.pony", (15, 4), (15, 7))])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
-  let _server: _DefinitionLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _DefinitionLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "definition/integration/type_alias"
@@ -239,254 +247,76 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
         ((19, 20), [])
       ]
     h.long_test(10_000_000_000)
-    for ((line, character), _) in checks.values() do
+    for ((line, character), expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _DefinitionChecker(expected))
     end
-    _server.test_goto_definition(h, workspace_file, checks)
 
 type DefinitionExpectation is (String val, (I64, I64), (I64, I64))
 type DefinitionCheck is ((I64, I64), Array[DefinitionExpectation] val)
 
-class val _PendingDefinition
-  let file_path: String
-  let line: I64
-  let character: I64
-  let expected: Array[DefinitionExpectation] val
-  let h: TestHelper
-  let action: String
+class val _DefinitionChecker
+  let _expected: Array[DefinitionExpectation] val
 
-  new val create(
-    file_path': String,
-    line': I64,
-    character': I64,
-    expected': Array[DefinitionExpectation] val,
-    h': TestHelper,
-    action': String)
-  =>
-    file_path = file_path'
-    line = line'
-    character = character'
-    expected = expected'
-    h = h'
-    action = action'
+  new val create(expected: Array[DefinitionExpectation] val) =>
+    _expected = expected
 
-actor _DefinitionLspServer is Channel
-  """
-  Shared LSP server for all definition workspace tests.
-  Initializes and compiles once, then dispatches
-  individual definition requests to each test's TestHelper.
-  """
-  let _workspace_dir: String
-  var _server: (BaseProtocol | None)
-  var _ready: Bool
-  var _initialized: Bool
-  let _pending: Array[_PendingDefinition]
-  let _opened: Set[String]
-  let _in_flight: Map[I64, _PendingDefinition]
-  var _next_id: I64
+  fun lsp_method(): String =>
+    Methods.text_document().definition()
 
-  new create(workspace_dir: String) =>
-    _workspace_dir = workspace_dir
-    _server = None
-    _ready = false
-    _initialized = false
-    _pending = Array[_PendingDefinition]
-    _opened = Set[String]
-    _in_flight = Map[I64, _PendingDefinition]
-    _next_id = 2
-
-  be test_goto_definition(
-    h: TestHelper,
-    workspace_file: String,
-    checks: Array[DefinitionCheck] val)
-  =>
-    let file_path = Path.join(_workspace_dir, workspace_file)
-    for ((line, character), expected) in checks.values() do
-      let action: String val =
-        recover
-          val workspace_file + ":" + line.string() + ":" + character.string()
-        end
-      let pending =
-        _PendingDefinition(file_path, line, character, expected, h, action)
-      if _ready then
-        if not _opened.contains(file_path) then
-          _opened.set(file_path)
-          _did_open(file_path)
-        end
-        _dispatch(pending)
-      else
-        _pending.push(pending)
-      end
+  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
+    var ok = true
+    let got_count =
+      try JsonNav(res.result).size()? else 0 end
+    if not h.assert_eq[USize](
+      _expected.size(),
+      got_count,
+      "Wrong number of definitions")
+    then
+      ok = false
     end
-    if not _initialized then
-      _initialized = true
-      let ponyc =
-        try
-          h.env.args(0)?
-        else
-          ""
-        end
-      let proto =
-        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
-      _server = proto
-      proto(LspMsg.initialize(_workspace_dir))
-    end
-
-  fun ref _dispatch(pending: _PendingDefinition) =>
-    let id = _next_id
-    _next_id = id + 1
-    try
-      (_server as BaseProtocol)(
-        RequestMessage(
-          id,
-          Methods.text_document().definition(),
-          JsonObject
-            .update(
-              "textDocument",
-              JsonObject.update("uri", Uris.from_path(pending.file_path)))
-            .update(
-              "position",
-              JsonObject
-                .update("line", pending.line)
-                .update("character", pending.character))
-        ).into_bytes()
-      )
-      _in_flight(id) = pending
-    else
-      pending.h.fail_action(pending.action)
-    end
-
-  be send(msg: Message val) =>
-    match msg
-    | let res: ResponseMessage val =>
+    for (i, loc) in _expected.pairs() do
+      (let file_suffix, let start_pos, let end_pos) = loc
+      (let exp_start_line, let exp_start_char) = start_pos
+      (let exp_end_line, let exp_end_char) = end_pos
       try
-        let id = res.id as RequestId
-        if RequestIds.eq(id, I64(0)) then
-          try
-            (_server as BaseProtocol)(LspMsg.initialized())
-          end
-        else
-          try
-            let id_i64 = id as I64
-            (_, let pending) = _in_flight.remove(id_i64)?
-            var ok = true
-            let got_count =
-              try JsonNav(res.result).size()? else 0 end
-            if not pending.h.assert_eq[USize](
-              pending.expected.size(),
-              got_count,
-              "Wrong number of definitions")
-            then
-              ok = false
-            end
-            for (i, loc) in pending.expected.pairs() do
-              (let file_suffix, let start_pos, let end_pos) = loc
-              (let exp_start_line, let exp_start_char) = start_pos
-              (let exp_end_line, let exp_end_char) = end_pos
-              try
-                let nav = JsonNav(res.result)(i)
-                let uri = nav("uri").as_string()?
-                let got_start_line =
-                  nav("range")("start")("line").as_i64()?
-                let got_start_char =
-                  nav("range")("start")("character").as_i64()?
-                let got_end_line =
-                  nav("range")("end")("line").as_i64()?
-                let got_end_char =
-                  nav("range")("end")("character").as_i64()?
-                if not pending.h.assert_true(
-                  uri.contains(file_suffix),
-                  "Expected URI containing '" + file_suffix + "', got: " + uri)
-                then
-                  ok = false
-                end
-                if not pending.h.assert_eq[I64](
-                  exp_start_line,
-                  got_start_line)
-                then
-                  ok = false
-                end
-                if not pending.h.assert_eq[I64](
-                  exp_start_char,
-                  got_start_char)
-                then
-                  ok = false
-                end
-                if not pending.h.assert_eq[I64](
-                  exp_end_line,
-                  got_end_line)
-                then
-                  ok = false
-                end
-                if not pending.h.assert_eq[I64](
-                  exp_end_char,
-                  got_end_char)
-                then
-                  ok = false
-                end
-              else
-                ok = false
-                pending.h.log(
-                  "Definition [" + i.string() +
-                  "] returned null or invalid, expected (" +
-                  file_suffix + ":" + exp_start_line.string() +
-                  ":" + exp_start_char.string() + ")")
-              end
-            end
-            if ok then
-              pending.h.complete_action(pending.action)
-            else
-              pending.h.fail_action(pending.action)
-            end
-          end
+        let nav = JsonNav(res.result)(i)
+        let uri = nav("uri").as_string()?
+        let got_start_line =
+          nav("range")("start")("line").as_i64()?
+        let got_start_char =
+          nav("range")("start")("character").as_i64()?
+        let got_end_line =
+          nav("range")("end")("line").as_i64()?
+        let got_end_char =
+          nav("range")("end")("character").as_i64()?
+        if not h.assert_true(
+          uri.contains(file_suffix),
+          "Expected URI containing '" + file_suffix + "', got: " + uri)
+        then
+          ok = false
         end
-      end
-    | let req: RequestMessage val =>
-      if req.method == Methods.workspace().configuration() then
-        try
-          let proto = _server as BaseProtocol
-          proto(ResponseMessage(req.id, JsonArray).into_bytes())
-          for p in _pending.values() do
-            if not _opened.contains(p.file_path) then
-              _opened.set(p.file_path)
-              _did_open(p.file_path)
-            end
-          end
+        if not h.assert_eq[I64](exp_start_line, got_start_line) then
+          ok = false
         end
-      end
-    | let n: Notification val =>
-      if n.method == Methods.text_document().publish_diagnostics() then
-        if not _ready then
-          _ready = true
-          for p in _pending.values() do
-            _dispatch(p)
-          end
-          _pending.clear()
+        if not h.assert_eq[I64](exp_start_char, got_start_char) then
+          ok = false
         end
+        if not h.assert_eq[I64](exp_end_line, got_end_line) then
+          ok = false
+        end
+        if not h.assert_eq[I64](exp_end_char, got_end_char) then
+          ok = false
+        end
+      else
+        ok = false
+        h.log(
+          "Definition [" + i.string() +
+          "] returned null or invalid, expected (" +
+          file_suffix + ":" + exp_start_line.string() +
+          ":" + exp_start_char.string() + ")")
       end
     end
-
-  fun ref _did_open(file_path: String) =>
-    try
-      (_server as BaseProtocol)(
-        Notification(
-          Methods.text_document().did_open(),
-          JsonObject.update(
-            "textDocument",
-            JsonObject
-              .update("uri", Uris.from_path(file_path))
-              .update("languageId", "pony")
-              .update("version", I64(1))
-              .update("text", ""))
-          ).into_bytes())
-    end
-
-  be log(data: String val, message_type: MessageType = Debug) =>
-    None
-
-  be set_notifier(notifier: Notifier tag) =>
-    None
-
-  be dispose() =>
-    None
+    ok

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -29,26 +29,19 @@ class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
   fun name(): String => "definition/integration/class"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_class.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // field usages → field declaration (line 4, "let" keyword span)
-        ((7, 4), [("_class.pony", (4, 2), (4, 5))])
-        ((10, 4), [("_class.pony", (4, 2), (4, 5))])
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_class.pony",
+      [ // field usages → field declaration (line 4, "let" keyword span)
+        (7, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 5))]))
+        (10, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 5))]))
         // parameter usage → parameter declaration (line 6, "v: U32" span)
-        ((7, 13), [("_class.pony", (6, 13), (6, 19))])
+        (7, 13, _DefinitionChecker([("_class.pony", (6, 13), (6, 19))]))
         // method call → method declaration (line 9, "fun" keyword span)
-        ((13, 9), [("_class.pony", (9, 2), (9, 5))])
+        (13, 9, _DefinitionChecker([("_class.pony", (9, 2), (9, 5))]))
         // no definition on docstring content
-        ((1, 4), [])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+        (1, 4, _DefinitionChecker([]))])
 
 class \nodoc\ iso _DefinitionThisIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -59,19 +52,12 @@ class \nodoc\ iso _DefinitionThisIntegrationTest is UnitTest
   fun name(): String => "definition/integration/this"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_class.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // `this` in method body → enclosing class declaration (line 0)
-        ((13, 4), [("_class.pony", (0, 0), (0, 5))])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_class.pony",
+      [ // `this` in method body → enclosing class declaration (line 0)
+        (13, 4, _DefinitionChecker([("_class.pony", (0, 0), (0, 5))]))])
 
 class \nodoc\ iso _DefinitionKeywordsIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -82,25 +68,18 @@ class \nodoc\ iso _DefinitionKeywordsIntegrationTest is UnitTest
   fun name(): String => "definition/integration/keywords"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_class.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // `class` keyword in a declaration → no definition
-        ((0, 0), [])
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_class.pony",
+      [ // `class` keyword in a declaration → no definition
+        (0, 0, _DefinitionChecker([]))
         // `new` keyword in a constructor declaration → no definition
-        ((6, 2), [])
+        (6, 2, _DefinitionChecker([]))
         // `fun` keyword in a method declaration → no definition
-        ((9, 2), [])
+        (9, 2, _DefinitionChecker([]))
         // `:` type annotation separator → no definition
-        ((9, 11), [])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+        (9, 11, _DefinitionChecker([]))])
 
 class \nodoc\ iso _DefinitionTraitIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -111,19 +90,12 @@ class \nodoc\ iso _DefinitionTraitIntegrationTest is UnitTest
   fun name(): String => "definition/integration/trait"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_trait.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // call via trait-typed receiver → trait method declaration (line 7)
-        ((50, 6), [("_trait.pony", (7, 2), (7, 5))])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_trait.pony",
+      [ // call via trait-typed receiver → trait method declaration (line 7)
+        (50, 6, _DefinitionChecker([("_trait.pony", (7, 2), (7, 5))]))])
 
 class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -134,24 +106,15 @@ class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
   fun name(): String => "definition/integration/union"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_trait.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // call via union-typed receiver → one definition per union member
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_trait.pony",
+      [ // call via union-typed receiver → one definition per union member
         // _DefLeft.shared (line 29) and _DefRight.shared (line 35)
-        ((53, 6),
-          [
-            ("_trait.pony", (29, 2), (29, 5))
-            ("_trait.pony", (35, 2), (35, 5))
-          ])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+        (53, 6, _DefinitionChecker(
+          [ ("_trait.pony", (29, 2), (29, 5))
+            ("_trait.pony", (35, 2), (35, 5))]))])
 
 class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -162,21 +125,15 @@ class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
   fun name(): String => "definition/integration/cross_file"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_cross_usage.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // type reference in parameter → class declaration in other file
-        ((13, 16), [("_cross_target.pony", (0, 0), (0, 5))])
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_cross_usage.pony",
+      [ // type reference in parameter → class declaration in other file
+        (13, 16, _DefinitionChecker([("_cross_target.pony", (0, 0), (0, 5))]))
         // method call → method declaration in other file (line 13)
-        ((14, 8), [("_cross_target.pony", (13, 2), (13, 5))])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+        (14, 8, _DefinitionChecker(
+          [("_cross_target.pony", (13, 2), (13, 5))]))])
 
 class \nodoc\ iso _DefinitionGenericsIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -187,19 +144,13 @@ class \nodoc\ iso _DefinitionGenericsIntegrationTest is UnitTest
   fun name(): String => "definition/integration/generics"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_generics.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // `T` in return type → type parameter declaration in method header
-        ((19, 22), [("_generics.pony", (19, 12), (19, 16))])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_generics.pony",
+      [ // `T` in return type → type parameter declaration in method header
+        (19, 22, _DefinitionChecker(
+          [("_generics.pony", (19, 12), (19, 16))]))])
 
 class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -210,19 +161,12 @@ class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
   fun name(): String => "definition/integration/tuple"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_tuple.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // `_1` tuple element access → `let pair` declaration
-        ((16, 9), [("_tuple.pony", (15, 4), (15, 7))])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_tuple.pony",
+      [ // `_1` tuple element access → `let pair` declaration
+        (16, 9, _DefinitionChecker([("_tuple.pony", (15, 4), (15, 7))]))])
 
 class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -233,29 +177,22 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
   fun name(): String => "definition/integration/type_alias"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "definition/_type_alias.pony"
-    let checks: Array[DefinitionCheck] val =
-      [
-        // `String` type arg in `Map[String, U32]` → String class declaration
-        ((17, 17), [("string.pony", (8, 0), (8, 5))])
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_type_alias.pony",
+      [ // `String` type arg in `Map[String, U32]` → String class declaration
+        (17, 17, _DefinitionChecker([("string.pony", (8, 0), (8, 5))]))
         // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
-        ((17, 25), [("unsigned.pony", (185, 0), (185, 9))])
+        (17, 25, _DefinitionChecker(
+          [("unsigned.pony", (185, 0), (185, 9))]))
         // `_Alias` usage — after reification the alias is replaced with its
         // expansion (U8), so the original alias identity is lost and goto
         // definition returns no result. Fixing this requires first-class type
         // aliases (ponylang/ponyc#5007).
-        ((19, 20), [])
-      ]
-    h.long_test(10_000_000_000)
-    for ((line, character), expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _DefinitionChecker(expected))
-    end
+        (19, 20, _DefinitionChecker([]))])
 
 type DefinitionExpectation is (String val, (I64, I64), (I64, I64))
-type DefinitionCheck is ((I64, I64), Array[DefinitionExpectation] val)
 
 class val _DefinitionChecker
   let _expected: Array[DefinitionExpectation] val

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -771,7 +771,7 @@ class val _DocHighlightChecker
   fun lsp_method(): String =>
     Methods.text_document().document_highlight()
 
-  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     match res.result
     | let arr: JsonArray =>

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -10,7 +10,7 @@ primitive _DocumentHighlightIntegrationTests is TestList
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
     let fixture = "highlights/highlights.pony"
-    let server = _DocHighlightLspServer(workspace_dir, fixture)
+    let server = _LspTestServer(workspace_dir)
     test(_DocHighlightFieldTest.create(server, fixture))
     test(_DocHighlightFieldRefTest.create(server, fixture))
     test(_DocHighlightLocalTest.create(server, fixture))
@@ -52,10 +52,10 @@ class \nodoc\ iso _DocHighlightFieldTest
     line 27 col  4  (value() body)
     line 30 col 22  (use_local() body)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -63,18 +63,18 @@ class \nodoc\ iso _DocHighlightFieldTest
     "document_highlight/integration/field"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (21, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 21
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
-        (27, 4, 27, 9); (30, 22, 30, 27)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
+          (27, 4, 27, 9); (30, 22, 30, 27)]))
 
 class \nodoc\ iso _DocHighlightFieldRefTest
   is UnitTest
@@ -82,10 +82,10 @@ class \nodoc\ iso _DocHighlightFieldRefTest
   Highlights the `count` field from a reference site (line 27 col 4).
   Expects the same 5 occurrences as when starting from the declaration.
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -93,18 +93,18 @@ class \nodoc\ iso _DocHighlightFieldRefTest
     "document_highlight/integration/field_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (27, 4)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 27
+    let character: I64 = 4
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
-        (27, 4, 27, 9); (30, 22, 30, 27)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
+          (27, 4, 27, 9); (30, 22, 30, 27)]))
 
 class \nodoc\ iso _DocHighlightLocalTest
   is UnitTest
@@ -115,10 +115,10 @@ class \nodoc\ iso _DocHighlightLocalTest
     line 31 col  4  (first use in result + result)
     line 31 col 13  (second use in result + result)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -126,14 +126,17 @@ class \nodoc\ iso _DocHighlightLocalTest
     "document_highlight/integration/local"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (30, 8)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 30
+    let character: I64 = 8
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))
 
 class \nodoc\ iso _DocHighlightFletTest is UnitTest
   """
@@ -143,10 +146,10 @@ class \nodoc\ iso _DocHighlightFletTest is UnitTest
     line 85 col  4  (assigned true in create)
     line 90 col  4  (assigned false in other)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -154,14 +157,16 @@ class \nodoc\ iso _DocHighlightFletTest is UnitTest
     "document_highlight/integration/flet"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (80, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 80
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(80, 6, 80, 11); (85, 4, 85, 9); (90, 4, 90, 9)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(80, 6, 80, 11); (85, 4, 85, 9); (90, 4, 90, 9)]))
 
 class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
   """
@@ -171,10 +176,10 @@ class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
     line 86 col  4  (assigned in create)
     line 91 col  4  (assigned in other)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -182,14 +187,16 @@ class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
     "document_highlight/integration/embed"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (81, 8)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 81
+    let character: I64 = 8
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(81, 8, 81, 14); (86, 4, 86, 10); (91, 4, 91, 10)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(81, 8, 81, 14); (86, 4, 86, 10); (91, 4, 91, 10)]))
 
 class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
   """
@@ -199,10 +206,10 @@ class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
     line 86 col 20  (_Inner.create() in create body)
     line 91 col 20  (_Inner.create() in other body)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -210,14 +217,17 @@ class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
     "document_highlight/integration/new_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (51, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 51
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))
 
 class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
   """
@@ -228,10 +238,10 @@ class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
     line 102 col 15  (get_self().add(1) — funchain)
     line 107 col 12  (w = w + add(n) — funref)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -239,14 +249,17 @@ class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
     "document_highlight/integration/fun_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (94, 10)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 94
+    let character: I64 = 10
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(94, 10, 94, 13); (102, 15, 102, 18); (107, 12, 107, 15)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(94, 10, 94, 13); (102, 15, 102, 18); (107, 12, 107, 15)]))
 
 class \nodoc\ iso _DocHighlightParamTest is UnitTest
   """
@@ -256,10 +269,10 @@ class \nodoc\ iso _DocHighlightParamTest is UnitTest
     line 95 col 18  (_val = _val + x — body use)
     line 96 col  4  (x — return value)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -267,14 +280,17 @@ class \nodoc\ iso _DocHighlightParamTest is UnitTest
     "document_highlight/integration/param"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (94, 14)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 94
+    let character: I64 = 14
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))
 
 class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
   """
@@ -285,10 +301,10 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
     line 107 col  8  (w = w + ... RHS)
     line 108 col  4  (w return value)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -296,17 +312,18 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
     "document_highlight/integration/var_local"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (106, 8)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 106
+    let character: I64 = 8
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(106, 8, 106, 9); (107, 4, 107, 5); (107, 8, 107, 9); (108, 4, 108, 5)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (106, 8, 106, 9); (107, 4, 107, 5)
+          (107, 8, 107, 9); (108, 4, 108, 5)]))
 
 class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
   """
@@ -315,10 +332,10 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
     line 121 col  5  (be run declaration)
     line 125 col  4  (run(1) call in trigger)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -326,14 +343,16 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
     "document_highlight/integration/be_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (121, 5)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 121
+    let character: I64 = 5
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(121, 5, 121, 8); (125, 4, 125, 7)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(121, 5, 121, 8); (125, 4, 125, 7)]))
 
 class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
   """
@@ -345,10 +364,10 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
     line  86 col 13  (_Inner.create() receiver in create)
     line  91 col 13  (_Inner.create() receiver in other)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -356,17 +375,18 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
     "document_highlight/integration/class_type"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (81, 16)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 81
+    let character: I64 = 16
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(33, 6, 33, 12); (81, 16, 81, 22); (86, 13, 86, 19); (91, 13, 91, 19)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (33, 6, 33, 12); (81, 16, 81, 22)
+          (86, 13, 86, 19); (91, 13, 91, 19)]))
 
 class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
   """
@@ -377,10 +397,10 @@ class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
     line  86 col 13  (_Inner.create() receiver in create)
     line  91 col 13  (_Inner.create() receiver in other)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -388,17 +408,18 @@ class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
     "document_highlight/integration/class_decl"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (33, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 33
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(33, 6, 33, 12); (81, 16, 81, 22); (86, 13, 86, 19); (91, 13, 91, 19)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (33, 6, 33, 12); (81, 16, 81, 22)
+          (86, 13, 86, 19); (91, 13, 91, 19)]))
 
 class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
   """
@@ -407,10 +428,10 @@ class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
     line  54 col  6  (class _HighlightMore declaration)
     line  98 col 22  (_HighlightMore in get_self return type)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -418,14 +439,16 @@ class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
     "document_highlight/integration/type_decl"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (54, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 54
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(54, 6, 54, 20); (98, 22, 98, 36)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(54, 6, 54, 20); (98, 22, 98, 36)]))
 
 class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
   """
@@ -435,10 +458,10 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
     line  54 col  6  (class _HighlightMore declaration)
     line  98 col 22  (_HighlightMore in get_self return type)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -446,24 +469,26 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
     "document_highlight/integration/type_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (98, 22)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 98
+    let character: I64 = 22
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
-      h, action, at, [(54, 6, 54, 20); (98, 22, 98, 36)])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
+      h,
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(54, 6, 54, 20); (98, 22, 98, 36)]))
 
 class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
   """
   Placing the cursor on a literal value should produce no highlights.
   Tests `true` on line 85 col 12 (_flag = true in create).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -471,13 +496,11 @@ class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
     "document_highlight/integration/literal"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (85, 12)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 85
+    let character: I64 = 12
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightNoneTest is UnitTest
   """
@@ -486,10 +509,10 @@ class \nodoc\ iso _DocHighlightNoneTest is UnitTest
   referenceable identity.
   Tests `None` on line 122 col 4 (body of be run in _HighlightRunner).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -497,13 +520,11 @@ class \nodoc\ iso _DocHighlightNoneTest is UnitTest
     "document_highlight/integration/none_literal"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (122, 4)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 122
+    let character: I64 = 4
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
   """
@@ -512,10 +533,10 @@ class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
     line 49 col 6  (var x declaration in _Inner)
     line 52 col 4  (x = 0 assignment in create)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -523,17 +544,16 @@ class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
     "document_highlight/integration/inner_x_field"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (49, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 49
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(49, 6, 49, 7); (52, 4, 52, 5)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(49, 6, 49, 7); (52, 4, 52, 5)]))
 
 class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
   """
@@ -545,10 +565,10 @@ class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
     line 95 col  4  (_val = ... LHS in add)
     line 95 col 11  (... + _val RHS in add)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -556,18 +576,18 @@ class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
     "document_highlight/integration/val_field"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (82, 6)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 82
+    let character: I64 = 6
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [ (82, 6, 82, 10); (87, 4, 87, 8); (92, 4, 92, 8)
-        (95, 4, 95, 8); (95, 11, 95, 15)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (82, 6, 82, 10); (87, 4, 87, 8); (92, 4, 92, 8)
+          (95, 4, 95, 8); (95, 11, 95, 15)]))
 
 class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
   """
@@ -577,10 +597,10 @@ class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
     line 105 col 17  (let v: U32 = n)
     line 107 col 16  (w = w + add(n))
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -588,17 +608,17 @@ class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
     "document_highlight/integration/do_work_param"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (104, 18)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 104
+    let character: I64 = 18
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(104, 18, 104, 19); (105, 17, 105, 18); (107, 16, 107, 17)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(104, 18, 104, 19); (105, 17, 105, 18); (107, 16, 107, 17)]))
 
 class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
   """
@@ -607,10 +627,10 @@ class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
     line 105 col  8  (let v declaration in do_work)
     line 106 col 17  (var w: U32 = v)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -618,17 +638,16 @@ class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
     "document_highlight/integration/do_work_let"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (105, 8)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 105
+    let character: I64 = 8
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(105, 8, 105, 9); (106, 17, 106, 18)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker([(105, 8, 105, 9); (106, 17, 106, 18)]))
 
 class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
   """
@@ -640,10 +659,10 @@ class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
     line 31 col  4  (first use in result + result)
     line 31 col 13  (second use in result + result)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -651,17 +670,17 @@ class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
     "document_highlight/integration/let_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (31, 4)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 31
+    let character: I64 = 4
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))
 
 class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
   """
@@ -674,10 +693,10 @@ class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
     line 107 col 8  (w = w + ... RHS)
     line 108 col 4  (w return value)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -685,17 +704,18 @@ class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
     "document_highlight/integration/var_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (107, 4)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 107
+    let character: I64 = 4
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(106, 8, 106, 9); (107, 4, 107, 5); (107, 8, 107, 9); (108, 4, 108, 5)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [ (106, 8, 106, 9); (107, 4, 107, 5)
+          (107, 8, 107, 9); (108, 4, 108, 5)]))
 
 class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
   """
@@ -707,10 +727,10 @@ class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
     line 95 col 18  (_val = _val + x — body use)
     line 96 col  4  (x — return value)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -718,17 +738,17 @@ class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
     "document_highlight/integration/param_ref"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (95, 18)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 95
+    let character: I64 = 18
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))
 
 class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
   """
@@ -740,10 +760,10 @@ class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
     line 86 col 20  (_Inner.create() in _HighlightMore.create body)
     line 91 col 20  (_Inner.create() in _HighlightMore.other body)
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -751,27 +771,27 @@ class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
     "document_highlight/integration/new_ref_call"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (86, 20)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 86
+    let character: I64 = 20
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(
       h,
-      action,
-      at,
-      [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)])
+      _fixture,
+      line,
+      character,
+      _DocHighlightChecker(
+        [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))
 
 class \nodoc\ iso _DocHighlightIntLiteralTest is UnitTest
   """
   Placing the cursor on an integer literal should produce no highlights.
   Tests `0` on line 87 col 11 (_val = 0 in _HighlightMore.create).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -779,23 +799,21 @@ class \nodoc\ iso _DocHighlightIntLiteralTest is UnitTest
     "document_highlight/integration/int_literal"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (87, 11)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 87
+    let character: I64 = 11
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightFloatLiteralTest is UnitTest
   """
   Placing the cursor on a float literal should produce no highlights.
   Tests `3.14` on line 132 col 16 (let _f: F64 = 3.14 in _LiteralExamples).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -803,23 +821,21 @@ class \nodoc\ iso _DocHighlightFloatLiteralTest is UnitTest
     "document_highlight/integration/float_literal"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (132, 16)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 132
+    let character: I64 = 16
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightStringLiteralTest is UnitTest
   """
   Placing the cursor on a string literal should produce no highlights.
   Tests `"hello"` on line 133 col 23 (in _LiteralExamples).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -827,23 +843,21 @@ class \nodoc\ iso _DocHighlightStringLiteralTest is UnitTest
     "document_highlight/integration/string_literal"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (133, 23)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 133
+    let character: I64 = 23
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightWhitespaceTest is UnitTest
   """
   Placing the cursor on a blank line should produce no highlights.
   Tests line 22 col 0 (blank line between count field and tick method).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -851,23 +865,21 @@ class \nodoc\ iso _DocHighlightWhitespaceTest is UnitTest
     "document_highlight/integration/whitespace"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (22, 0)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 22
+    let character: I64 = 0
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
 class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
   """
   Placing the cursor past the end of a line should produce no highlights.
   Tests line 21 col 100 (past end of `  var count: U32 = 0`).
   """
-  let _server: _DocHighlightLspServer
+  let _server: _LspTestServer
   let _fixture: String val
 
-  new iso create(server: _DocHighlightLspServer, fixture: String val) =>
+  new iso create(server: _LspTestServer, fixture: String val) =>
     _server = server
     _fixture = fixture
 
@@ -875,169 +887,28 @@ class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
     "document_highlight/integration/out_of_bounds"
 
   fun apply(h: TestHelper) =>
-    let at: (I64, I64) = (21, 100)
-    (let line, let character) = at
-    let action: String val =
-      recover _fixture + ":" + line.string() + ":" + character.string() end
+    let line: I64 = 21
+    let character: I64 = 100
     h.long_test(10_000_000_000)
-    h.expect_action(action)
-    _server.test_document_highlight(h, action, at, [])
+    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
+    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
 
-class val _PendingDocHighlight
-  let file_path: String
-  let line: I64
-  let character: I64
-  let expected: Array[(I64, I64, I64, I64)] val
-  let h: TestHelper
-  let action: String
+class val _DocHighlightChecker
+  let _expected: Array[(I64, I64, I64, I64)] val
 
-  new val create(
-    file_path': String,
-    line': I64,
-    character': I64,
-    expected': Array[(I64, I64, I64, I64)] val,
-    h': TestHelper,
-    action': String)
-  =>
-    file_path = file_path'
-    line = line'
-    character = character'
-    expected = expected'
-    h = h'
-    action = action'
+  new val create(expected: Array[(I64, I64, I64, I64)] val) =>
+    _expected = expected
 
-actor _DocHighlightLspServer is Channel
-  """
-  Shared LSP server for all document highlight integration tests.
-  Initializes and compiles the workspace once, then dispatches
-  individual documentHighlight requests.
-  """
-  let _workspace_dir: String
-  let _fixture_file: String
-  var _server: (BaseProtocol | None)
-  var _ready: Bool
-  var _initialized: Bool
-  let _pending: Array[_PendingDocHighlight]
-  let _opened: Set[String]
-  let _in_flight: Map[I64, _PendingDocHighlight]
-  var _next_id: I64
+  fun lsp_method(): String =>
+    Methods.text_document().document_highlight()
 
-  new create(workspace_dir: String, fixture: String) =>
-    _workspace_dir = workspace_dir
-    _fixture_file = Path.join(workspace_dir, fixture)
-    _server = None
-    _ready = false
-    _initialized = false
-    _pending = Array[_PendingDocHighlight]
-    _opened = Set[String]
-    _in_flight = Map[I64, _PendingDocHighlight]
-    _next_id = 2
-
-  be test_document_highlight(
-    h: TestHelper,
-    action: String val,
-    at: (I64, I64),
-    expected: Array[(I64, I64, I64, I64)] val)
-  =>
-    (let line, let character) = at
-    let file_path = _fixture_file
-    let pending =
-      _PendingDocHighlight(file_path, line, character, expected, h, action)
-    if _ready then
-      if not _opened.contains(file_path) then
-        _opened.set(file_path)
-        _did_open(file_path)
-      end
-      _dispatch(pending)
-    else
-      _pending.push(pending)
-    end
-    if not _initialized then
-      _initialized = true
-      let ponyc = try h.env.args(0)? else "" end
-      let proto =
-        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
-      _server = proto
-      proto(LspMsg.initialize(_workspace_dir))
-    end
-
-  fun ref _dispatch(pending: _PendingDocHighlight) =>
-    let id = _next_id
-    _next_id = id + 1
-    try
-      (_server as BaseProtocol)(
-        RequestMessage(
-          id,
-          Methods.text_document().document_highlight(),
-          JsonObject
-            .update(
-              "textDocument",
-              JsonObject
-                .update("uri", Uris.from_path(pending.file_path)))
-            .update(
-              "position",
-              JsonObject
-                .update("line", pending.line)
-                .update("character", pending.character))
-        ).into_bytes()
-      )
-      _in_flight(id) = pending
-    else
-      pending.h.fail_action(pending.action)
-    end
-
-  be send(msg: Message val) =>
-    match msg
-    | let res: ResponseMessage val =>
-      try
-        let id = res.id as RequestId
-        if RequestIds.eq(id, I64(0)) then
-          try
-            (_server as BaseProtocol)(LspMsg.initialized())
-          end
-        else
-          try
-            let id_i64 = id as I64
-            (_, let pending) = _in_flight.remove(id_i64)?
-            _check_response(res, pending)
-          end
-        end
-      end
-    | let req: RequestMessage val =>
-      if req.method == Methods.workspace().configuration() then
-        try
-          let proto = _server as BaseProtocol
-          proto(ResponseMessage(req.id, JsonArray).into_bytes())
-          for p in _pending.values() do
-            if not _opened.contains(p.file_path) then
-              _opened.set(p.file_path)
-              _did_open(p.file_path)
-            end
-          end
-        end
-      end
-    | let n: Notification val =>
-      if n.method == Methods.text_document().publish_diagnostics() then
-        if not _ready then
-          _ready = true
-          for p in _pending.values() do
-            _dispatch(p)
-          end
-          _pending.clear()
-        end
-      end
-    end
-
-  fun ref _check_response(
-    res: ResponseMessage val,
-    pending: _PendingDocHighlight)
-  =>
+  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
     var ok = true
     match res.result
     | let arr: JsonArray =>
       let got = arr.size()
-      let want = pending.expected.size()
-      if not pending.h.assert_eq[USize](
+      let want = _expected.size()
+      if not h.assert_eq[USize](
         want,
         got,
         "Expected " + want.string() + " highlights, got " + got.string())
@@ -1051,13 +922,13 @@ actor _DocHighlightLspServer is Channel
             let sc = range("start")("character").as_i64()?
             let el = range("end")("line").as_i64()?
             let ec = range("end")("character").as_i64()?
-            pending.h.log(
+            h.log(
               "  actual highlight (" + sl.string() + ", " + sc.string() +
               ")–(" + el.string() + ", " + ec.string() + ")")
           end
         end
       end
-      for (exp_sl, exp_sc, exp_el, exp_ec) in pending.expected.values() do
+      for (exp_sl, exp_sc, exp_el, exp_ec) in _expected.values() do
         var found = false
         for item in arr.values() do
           try
@@ -1074,7 +945,7 @@ actor _DocHighlightLspServer is Channel
             end
           end
         end
-        if not pending.h.assert_true(
+        if not h.assert_true(
           found,
           "Expected highlight (" + exp_sl.string() + ", " + exp_sc.string() +
           ")–(" + exp_el.string() + ", " + exp_ec.string() + ") not found")
@@ -1083,37 +954,9 @@ actor _DocHighlightLspServer is Channel
         end
       end
     else
-      if pending.expected.size() > 0 then
+      if _expected.size() > 0 then
         ok = false
-        pending.h.log("Expected highlights but got null")
+        h.log("Expected highlights but got null")
       end
     end
-    if ok then
-      pending.h.complete_action(pending.action)
-    else
-      pending.h.fail_action(pending.action)
-    end
-
-  fun ref _did_open(file_path: String) =>
-    try
-      (_server as BaseProtocol)(
-        Notification(
-          Methods.text_document().did_open(),
-          JsonObject.update(
-            "textDocument",
-            JsonObject
-              .update("uri", Uris.from_path(file_path))
-              .update("languageId", "pony")
-              .update("version", I64(1))
-              .update("text", ""))
-        ).into_bytes())
-    end
-
-  be log(data: String val, message_type: MessageType = Debug) =>
-    None
-
-  be set_notifier(notifier: Notifier tag) =>
-    None
-
-  be dispose() =>
-    None
+    ok

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -63,18 +63,13 @@ class \nodoc\ iso _DocHighlightFieldTest
     "document_highlight/integration/field"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 21
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (21, 6, _DocHighlightChecker(
         [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
-          (27, 4, 27, 9); (30, 22, 30, 27)]))
+          (27, 4, 27, 9); (30, 22, 30, 27)]))])
 
 class \nodoc\ iso _DocHighlightFieldRefTest
   is UnitTest
@@ -93,18 +88,13 @@ class \nodoc\ iso _DocHighlightFieldRefTest
     "document_highlight/integration/field_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 27
-    let character: I64 = 4
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (27, 4, _DocHighlightChecker(
         [ (21, 6, 21, 11); (24, 4, 24, 9); (24, 12, 24, 17)
-          (27, 4, 27, 9); (30, 22, 30, 27)]))
+          (27, 4, 27, 9); (30, 22, 30, 27)]))])
 
 class \nodoc\ iso _DocHighlightLocalTest
   is UnitTest
@@ -126,17 +116,12 @@ class \nodoc\ iso _DocHighlightLocalTest
     "document_highlight/integration/local"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 30
-    let character: I64 = 8
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))
+      [ (30, 8, _DocHighlightChecker(
+        [ (30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))])
 
 class \nodoc\ iso _DocHighlightFletTest is UnitTest
   """
@@ -157,16 +142,12 @@ class \nodoc\ iso _DocHighlightFletTest is UnitTest
     "document_highlight/integration/flet"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 80
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(80, 6, 80, 11); (85, 4, 85, 9); (90, 4, 90, 9)]))
+      [ (80, 6, _DocHighlightChecker(
+        [ (80, 6, 80, 11); (85, 4, 85, 9); (90, 4, 90, 9)]))])
 
 class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
   """
@@ -187,16 +168,12 @@ class \nodoc\ iso _DocHighlightEmbedTest is UnitTest
     "document_highlight/integration/embed"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 81
-    let character: I64 = 8
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(81, 8, 81, 14); (86, 4, 86, 10); (91, 4, 91, 10)]))
+      [ (81, 8, _DocHighlightChecker(
+        [ (81, 8, 81, 14); (86, 4, 86, 10); (91, 4, 91, 10)]))])
 
 class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
   """
@@ -217,17 +194,12 @@ class \nodoc\ iso _DocHighlightNewRefTest is UnitTest
     "document_highlight/integration/new_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 51
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))
+      [ (51, 6, _DocHighlightChecker(
+        [ (51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))])
 
 class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
   """
@@ -249,17 +221,12 @@ class \nodoc\ iso _DocHighlightFunRefTest is UnitTest
     "document_highlight/integration/fun_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 94
-    let character: I64 = 10
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(94, 10, 94, 13); (102, 15, 102, 18); (107, 12, 107, 15)]))
+      [ (94, 10, _DocHighlightChecker(
+        [ (94, 10, 94, 13); (102, 15, 102, 18); (107, 12, 107, 15)]))])
 
 class \nodoc\ iso _DocHighlightParamTest is UnitTest
   """
@@ -280,17 +247,12 @@ class \nodoc\ iso _DocHighlightParamTest is UnitTest
     "document_highlight/integration/param"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 94
-    let character: I64 = 14
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))
+      [ (94, 14, _DocHighlightChecker(
+        [ (94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))])
 
 class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
   """
@@ -312,18 +274,13 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
     "document_highlight/integration/var_local"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 106
-    let character: I64 = 8
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (106, 8, _DocHighlightChecker(
         [ (106, 8, 106, 9); (107, 4, 107, 5)
-          (107, 8, 107, 9); (108, 4, 108, 5)]))
+          (107, 8, 107, 9); (108, 4, 108, 5)]))])
 
 class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
   """
@@ -343,16 +300,12 @@ class \nodoc\ iso _DocHighlightBeRefTest is UnitTest
     "document_highlight/integration/be_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 121
-    let character: I64 = 5
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(121, 5, 121, 8); (125, 4, 125, 7)]))
+      [ (121, 5, _DocHighlightChecker(
+        [ (121, 5, 121, 8); (125, 4, 125, 7)]))])
 
 class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
   """
@@ -375,18 +328,13 @@ class \nodoc\ iso _DocHighlightClassTypeTest is UnitTest
     "document_highlight/integration/class_type"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 81
-    let character: I64 = 16
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (81, 16, _DocHighlightChecker(
         [ (33, 6, 33, 12); (81, 16, 81, 22)
-          (86, 13, 86, 19); (91, 13, 91, 19)]))
+          (86, 13, 86, 19); (91, 13, 91, 19)]))])
 
 class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
   """
@@ -408,18 +356,13 @@ class \nodoc\ iso _DocHighlightClassDeclTest is UnitTest
     "document_highlight/integration/class_decl"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 33
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (33, 6, _DocHighlightChecker(
         [ (33, 6, 33, 12); (81, 16, 81, 22)
-          (86, 13, 86, 19); (91, 13, 91, 19)]))
+          (86, 13, 86, 19); (91, 13, 91, 19)]))])
 
 class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
   """
@@ -439,16 +382,12 @@ class \nodoc\ iso _DocHighlightTypeDeclTest is UnitTest
     "document_highlight/integration/type_decl"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 54
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(54, 6, 54, 20); (98, 22, 98, 36)]))
+      [ (54, 6, _DocHighlightChecker(
+        [ (54, 6, 54, 20); (98, 22, 98, 36)]))])
 
 class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
   """
@@ -469,16 +408,12 @@ class \nodoc\ iso _DocHighlightTypeRefTest is UnitTest
     "document_highlight/integration/type_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 98
-    let character: I64 = 22
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(54, 6, 54, 20); (98, 22, 98, 36)]))
+      [ (98, 22, _DocHighlightChecker(
+        [ (54, 6, 54, 20); (98, 22, 98, 36)]))])
 
 class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
   """
@@ -496,11 +431,7 @@ class \nodoc\ iso _DocHighlightLiteralTest is UnitTest
     "document_highlight/integration/literal"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 85
-    let character: I64 = 12
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(85, 12, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightNoneTest is UnitTest
   """
@@ -520,11 +451,7 @@ class \nodoc\ iso _DocHighlightNoneTest is UnitTest
     "document_highlight/integration/none_literal"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 122
-    let character: I64 = 4
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(122, 4, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
   """
@@ -544,16 +471,12 @@ class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
     "document_highlight/integration/inner_x_field"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 49
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(49, 6, 49, 7); (52, 4, 52, 5)]))
+      [ (49, 6, _DocHighlightChecker(
+        [ (49, 6, 49, 7); (52, 4, 52, 5)]))])
 
 class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
   """
@@ -576,18 +499,13 @@ class \nodoc\ iso _DocHighlightValFieldTest is UnitTest
     "document_highlight/integration/val_field"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 82
-    let character: I64 = 6
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (82, 6, _DocHighlightChecker(
         [ (82, 6, 82, 10); (87, 4, 87, 8); (92, 4, 92, 8)
-          (95, 4, 95, 8); (95, 11, 95, 15)]))
+          (95, 4, 95, 8); (95, 11, 95, 15)]))])
 
 class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
   """
@@ -608,17 +526,12 @@ class \nodoc\ iso _DocHighlightDoWorkParamTest is UnitTest
     "document_highlight/integration/do_work_param"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 104
-    let character: I64 = 18
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(104, 18, 104, 19); (105, 17, 105, 18); (107, 16, 107, 17)]))
+      [ (104, 18, _DocHighlightChecker(
+        [ (104, 18, 104, 19); (105, 17, 105, 18); (107, 16, 107, 17)]))])
 
 class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
   """
@@ -638,16 +551,12 @@ class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
     "document_highlight/integration/do_work_let"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 105
-    let character: I64 = 8
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker([(105, 8, 105, 9); (106, 17, 106, 18)]))
+      [ (105, 8, _DocHighlightChecker(
+        [ (105, 8, 105, 9); (106, 17, 106, 18)]))])
 
 class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
   """
@@ -670,17 +579,12 @@ class \nodoc\ iso _DocHighlightLetRefTest is UnitTest
     "document_highlight/integration/let_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 31
-    let character: I64 = 4
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))
+      [ (31, 4, _DocHighlightChecker(
+        [ (30, 8, 30, 14); (31, 4, 31, 10); (31, 13, 31, 19)]))])
 
 class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
   """
@@ -704,18 +608,13 @@ class \nodoc\ iso _DocHighlightVarRefTest is UnitTest
     "document_highlight/integration/var_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 107
-    let character: I64 = 4
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
+      [ (107, 4, _DocHighlightChecker(
         [ (106, 8, 106, 9); (107, 4, 107, 5)
-          (107, 8, 107, 9); (108, 4, 108, 5)]))
+          (107, 8, 107, 9); (108, 4, 108, 5)]))])
 
 class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
   """
@@ -738,17 +637,12 @@ class \nodoc\ iso _DocHighlightParamRefTest is UnitTest
     "document_highlight/integration/param_ref"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 95
-    let character: I64 = 18
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))
+      [ (95, 18, _DocHighlightChecker(
+        [ (94, 14, 94, 15); (95, 18, 95, 19); (96, 4, 96, 5)]))])
 
 class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
   """
@@ -771,17 +665,12 @@ class \nodoc\ iso _DocHighlightNewRefCallTest is UnitTest
     "document_highlight/integration/new_ref_call"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 86
-    let character: I64 = 20
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(
+    _RunLspChecks(
       h,
+      _server,
       _fixture,
-      line,
-      character,
-      _DocHighlightChecker(
-        [(51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))
+      [ (86, 20, _DocHighlightChecker(
+        [ (51, 6, 51, 12); (86, 20, 86, 26); (91, 20, 91, 26)]))])
 
 class \nodoc\ iso _DocHighlightIntLiteralTest is UnitTest
   """
@@ -799,11 +688,7 @@ class \nodoc\ iso _DocHighlightIntLiteralTest is UnitTest
     "document_highlight/integration/int_literal"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 87
-    let character: I64 = 11
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(87, 11, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightFloatLiteralTest is UnitTest
   """
@@ -821,11 +706,7 @@ class \nodoc\ iso _DocHighlightFloatLiteralTest is UnitTest
     "document_highlight/integration/float_literal"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 132
-    let character: I64 = 16
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(132, 16, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightStringLiteralTest is UnitTest
   """
@@ -843,11 +724,7 @@ class \nodoc\ iso _DocHighlightStringLiteralTest is UnitTest
     "document_highlight/integration/string_literal"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 133
-    let character: I64 = 23
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(133, 23, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightWhitespaceTest is UnitTest
   """
@@ -865,11 +742,7 @@ class \nodoc\ iso _DocHighlightWhitespaceTest is UnitTest
     "document_highlight/integration/whitespace"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 22
-    let character: I64 = 0
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(22, 0, _DocHighlightChecker([]))])
 
 class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
   """
@@ -887,11 +760,7 @@ class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
     "document_highlight/integration/out_of_bounds"
 
   fun apply(h: TestHelper) =>
-    let line: I64 = 21
-    let character: I64 = 100
-    h.long_test(10_000_000_000)
-    h.expect_action(_fixture + ":" + line.string() + ":" + character.string())
-    _server.request(h, _fixture, line, character, _DocHighlightChecker([]))
+    _RunLspChecks(h, _server, _fixture, [(21, 100, _DocHighlightChecker([]))])
 
 class val _DocHighlightChecker
   let _expected: Array[(I64, I64, I64, I64)] val

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -375,7 +375,7 @@ class val _HoverChecker
   fun lsp_method(): String =>
     Methods.text_document().hover()
 
-  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     if _expected.size() == 0 then
       try

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -9,7 +9,7 @@ primitive _HoverIntegrationTests is TestList
 
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
-    let server = _HoverLspServer(workspace_dir)
+    let server = _LspTestServer(workspace_dir)
     test(_HoverIntegrationClassTest.create(server))
     test(_HoverIntegrationActorTest.create(server))
     test(_HoverIntegrationAliasTest.create(server))
@@ -24,9 +24,9 @@ primitive _HoverIntegrationTests is TestList
     test(_HoverIntegrationLiteralsTest.create(server))
 
 class \nodoc\ iso _HoverIntegrationLiteralsTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/literals"
@@ -55,16 +55,17 @@ class \nodoc\ iso _HoverIntegrationLiteralsTest is UnitTest
         (18, 27, [])
         (19, 33, [])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/class"
@@ -89,16 +90,17 @@ class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
         (2, 4, [])
         (7, 0, [])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/actor"
@@ -110,16 +112,17 @@ class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
         (6, 6, ["new tag create(name': String val)"])
         (9, 5, ["be tag do_something(value: U64 val)"])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/alias"
@@ -129,16 +132,17 @@ class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
     let checks: Array[HoverCheck] val =
       [(0, 5, ["type _Alias"; "A simple alias for exercising LSP hover."])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/interface"
@@ -150,16 +154,17 @@ class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
         [ "interface _Interface"
           "A simple interface for exercising LSP hover."])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/primitive"
@@ -171,16 +176,17 @@ class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
         [ "primitive _Primitive"
           "A simple primitive for exercising LSP hover."])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/trait"
@@ -190,16 +196,17 @@ class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
     let checks: Array[HoverCheck] val =
       [(0, 6, ["trait _Trait"; "A simple trait for exercising LSP hover."])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/function"
@@ -238,16 +245,17 @@ class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
         // this reference
         (11, 18, [])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationTypeInferenceTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/type_inference"
@@ -262,16 +270,17 @@ class \nodoc\ iso _HoverIntegrationTypeInferenceTest is UnitTest
         (26, 22, ["let inferred_bool: Bool"])
         (26, 47, ["let inferred_array: Array[U32 val] ref"])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationReceiverCapabilityTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/receiver_capability"
@@ -283,16 +292,17 @@ class \nodoc\ iso _HoverIntegrationReceiverCapabilityTest is UnitTest
         (13, 10, ["fun val valued_method(): String val"])
         (20, 10, ["fun ref mutable_method()"])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationComplexTypesTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/complex_types"
@@ -305,16 +315,17 @@ class \nodoc\ iso _HoverIntegrationComplexTypesTest is UnitTest
         (13, 4, ["let union_type: (String val | U32 val | None val)"])
         (13, 26, ["let tuple_type: (String val, U32 val, Bool val)"])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
-  let _server: _HoverLspServer
+  let _server: _LspTestServer
 
-  new iso create(server: _HoverLspServer) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
 
   fun name(): String => "hover/integration/generics"
@@ -400,218 +411,55 @@ class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
         [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
           "A generic method with its own type parameter."])]
     h.long_test(10_000_000_000)
-    for (line, character, _) in checks.values() do
+    for (line, character, expected) in checks.values() do
       h.expect_action(
         workspace_file + ":" + line.string() + ":" + character.string())
+      _server.request(
+        h, workspace_file, line, character, _HoverChecker(expected))
     end
-    _server.hover(h, workspace_file, checks)
 
 type HoverCheck is (I64, I64, Array[String] val)
 
-class val _PendingHover
-  let file_path: String
-  let line: I64
-  let character: I64
-  let expected: Array[String] val
-  let h: TestHelper
-  let action: String
+class val _HoverChecker
+  let _expected: Array[String] val
 
-  new val create(
-    file_path': String,
-    line': I64,
-    character': I64,
-    expected': Array[String] val,
-    h': TestHelper,
-    action': String)
-  =>
-    file_path = file_path'
-    line = line'
-    character = character'
-    expected = expected'
-    h = h'
-    action = action'
+  new val create(expected: Array[String] val) =>
+    _expected = expected
 
-actor _HoverLspServer is Channel
-  """
-  Shared LSP server for all hover workspace tests.
-  Initializes and compiles once, then dispatches
-  individual hover requests to each test's TestHelper.
-  """
-  let _workspace_dir: String
-  var _server: (BaseProtocol | None)
-  var _ready: Bool
-  var _initialized: Bool
-  let _pending: Array[_PendingHover]
-  let _opened: Set[String]
-  let _in_flight: Map[I64, _PendingHover]
-  var _next_id: I64
+  fun lsp_method(): String =>
+    Methods.text_document().hover()
 
-  new create(workspace_dir: String) =>
-    _workspace_dir = workspace_dir
-    _server = None
-    _ready = false
-    _initialized = false
-    _pending = Array[_PendingHover]
-    _opened = Set[String]
-    _in_flight = Map[I64, _PendingHover]
-    _next_id = 2
-
-  be hover(
-    h: TestHelper,
-    workspace_file: String,
-    checks: Array[HoverCheck] val)
-  =>
-    let file_path = Path.join(_workspace_dir, workspace_file)
-    for (line, character, expected) in checks.values() do
-      let action: String val =
-        recover
-          val workspace_file + ":" + line.string() + ":" + character.string()
-        end
-      let pending =
-        _PendingHover(file_path, line, character, expected, h, action)
-      if _ready then
-        if not _opened.contains(file_path) then
-          _opened.set(file_path)
-          _did_open(file_path)
-        end
-        _dispatch(pending)
-      else
-        _pending.push(pending)
-      end
-    end
-    if not _initialized then
-      _initialized = true
-      let ponyc = try h.env.args(0)? else "" end
-      let proto =
-        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
-      _server = proto
-      proto(LspMsg.initialize(_workspace_dir))
-    end
-
-  fun ref _dispatch(pending: _PendingHover) =>
-    let id = _next_id
-    _next_id = id + 1
-    try
-      (_server as BaseProtocol)(
-        RequestMessage(
-          id,
-          Methods.text_document().hover(),
-          JsonObject
-            .update(
-              "textDocument",
-              JsonObject.update(
-                "uri", Uris.from_path(pending.file_path)))
-            .update(
-              "position",
-              JsonObject
-                .update("line", pending.line)
-                .update("character", pending.character))
-        ).into_bytes()
-      )
-      _in_flight(id) = pending
-    else
-      pending.h.fail_action(pending.action)
-    end
-
-  be send(msg: Message val) =>
-    match msg
-    | let res: ResponseMessage val =>
+  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool =>
+    var ok = true
+    if _expected.size() == 0 then
       try
-        let id = res.id as RequestId
-        if RequestIds.eq(id, I64(0)) then
-          try (_server as BaseProtocol)(LspMsg.initialized()) end
-        else
-          try
-            let id_i64 = id as I64
-            (_, let pending) = _in_flight.remove(id_i64)?
-            var ok = true
-            if pending.expected.size() == 0 then
-              try
-                JsonNav(res.result)("contents")("value").as_string()?
-                ok = false
-                pending.h.log(
-                  "Expected no hover result but got: " + res.string())
-              end
-            else
-              try
-                let value =
-                  JsonNav(res.result)("contents")("value").as_string()?
-                for s in pending.expected.values() do
-                  if not pending.h.assert_true(
-                    value.contains(s),
-                    "Expected '" + s + "' in hover, got: " + value)
-                  then
-                    ok = false
-                  end
-                end
-              else
-                ok = false
-                var expected_str =
-                  recover val
-                    let s = String
-                    for e in pending.expected.values() do
-                      if s.size() > 0 then s.append(", ") end
-                      s.append("'"); s.append(e); s.append("'")
-                    end
-                    s
-                  end
-                pending.h.log(
-                  "Hover returned null, expected: " + expected_str)
-              end
-            end
-            if ok then
-              pending.h.complete_action(pending.action)
-            else
-              pending.h.fail_action(pending.action)
-            end
-          end
-        end
+        JsonNav(res.result)("contents")("value").as_string()?
+        ok = false
+        h.log("Expected no hover result but got: " + res.string())
       end
-    | let req: RequestMessage val =>
-      if req.method == Methods.workspace().configuration() then
-        try
-          let proto = _server as BaseProtocol
-          proto(ResponseMessage(req.id, JsonArray).into_bytes())
-          for p in _pending.values() do
-            if not _opened.contains(p.file_path) then
-              _opened.set(p.file_path)
-              _did_open(p.file_path)
+    else
+      try
+        let value = JsonNav(res.result)("contents")("value").as_string()?
+        for s in _expected.values() do
+          if not h.assert_true(
+            value.contains(s),
+            "Expected '" + s + "' in hover, got: " + value)
+          then
+            ok = false
+          end
+        end
+      else
+        ok = false
+        let expected_str: String val =
+          recover val
+            let s = String
+            for e in _expected.values() do
+              if s.size() > 0 then s.append(", ") end
+              s.append("'"); s.append(e); s.append("'")
             end
+            s
           end
-        end
-      end
-    | let n: Notification val =>
-      if n.method == Methods.text_document().publish_diagnostics() then
-        if not _ready then
-          _ready = true
-          for p in _pending.values() do
-            _dispatch(p)
-          end
-          _pending.clear()
-        end
+        h.log("Hover returned null, expected: " + expected_str)
       end
     end
-
-  fun ref _did_open(file_path: String) =>
-    try
-      (_server as BaseProtocol)(
-        Notification(
-          Methods.text_document().did_open(),
-          JsonObject.update(
-            "textDocument",
-            JsonObject
-              .update("uri", Uris.from_path(file_path))
-              .update("languageId", "pony")
-              .update("version", I64(1))
-              .update("text", ""))
-        ).into_bytes())
-    end
-
-  be log(data: String val, message_type: MessageType = Debug) =>
-    None
-
-  be set_notifier(notifier: Notifier tag) =>
-    None
-
-  be dispose() =>
-    None
+    ok

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -32,35 +32,30 @@ class \nodoc\ iso _HoverIntegrationLiteralsTest is UnitTest
   fun name(): String => "hover/integration/literals"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_literals.pony"
-    let checks: Array[HoverCheck] val =
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_literals.pony",
       [ // variable declarations show their types
-        (11, 8, ["let integer: U32 val"])
-        (12, 8, ["let hex: U32 val"])
-        (13, 8, ["let binary: U32 val"])
-        (14, 8, ["let float_val: F64 val"])
-        (15, 8, ["let string_val: String val"])
-        (16, 8, ["let char_val: U32 val"])
-        (17, 8, ["let bool_true: Bool val"])
-        (18, 8, ["let bool_false: Bool val"])
-        (19, 8, ["let array_val: Array[U32 val] ref"])
+        (11, 8, _HoverChecker(["let integer: U32 val"]))
+        (12, 8, _HoverChecker(["let hex: U32 val"]))
+        (13, 8, _HoverChecker(["let binary: U32 val"]))
+        (14, 8, _HoverChecker(["let float_val: F64 val"]))
+        (15, 8, _HoverChecker(["let string_val: String val"]))
+        (16, 8, _HoverChecker(["let char_val: U32 val"]))
+        (17, 8, _HoverChecker(["let bool_true: Bool val"]))
+        (18, 8, _HoverChecker(["let bool_false: Bool val"]))
+        (19, 8, _HoverChecker(["let array_val: Array[U32 val] ref"]))
         // no hover on literal values
-        (11, 23, [])
-        (12, 19, [])
-        (13, 22, [])
-        (14, 25, [])
-        (15, 29, [])
-        (16, 24, [])
-        (17, 26, [])
-        (18, 27, [])
-        (19, 33, [])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+        (11, 23, _HoverChecker([]))
+        (12, 19, _HoverChecker([]))
+        (13, 22, _HoverChecker([]))
+        (14, 25, _HoverChecker([]))
+        (15, 29, _HoverChecker([]))
+        (16, 24, _HoverChecker([]))
+        (17, 26, _HoverChecker([]))
+        (18, 27, _HoverChecker([]))
+        (19, 33, _HoverChecker([]))])
 
 class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
   let _server: _LspTestServer
@@ -71,31 +66,28 @@ class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
   fun name(): String => "hover/integration/class"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_class.pony"
-    let checks: Array[HoverCheck] val =
-      [ (0, 6, ["class _Class"; "A simple class for exercising LSP hover."])
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_class.pony",
+      [ (0, 6, _HoverChecker(
+          ["class _Class"; "A simple class for exercising LSP hover."]))
         // field declarations
-        (4, 6, ["let field_name: String val"])
-        (5, 6, ["var mutable_field: U32 val"])
-        (6, 8, ["embed embedded_field: Array[String val] ref"])
+        (4, 6, _HoverChecker(["let field_name: String val"]))
+        (5, 6, _HoverChecker(["var mutable_field: U32 val"]))
+        (6, 8, _HoverChecker(
+          ["embed embedded_field: Array[String val] ref"]))
         // constructor declaration
-        (8, 6, ["new ref create(name: String val)"])
+        (8, 6, _HoverChecker(["new ref create(name: String val)"]))
         // field usages
-        (9, 4, ["let field_name: String val"])
-        (10, 4, ["var mutable_field: U32 val"])
-        (16, 4, ["let field_name: String val"])
-        (28, 4, ["var mutable_field: U32 val"])
+        (9, 4, _HoverChecker(["let field_name: String val"]))
+        (10, 4, _HoverChecker(["var mutable_field: U32 val"]))
+        (16, 4, _HoverChecker(["let field_name: String val"]))
+        (28, 4, _HoverChecker(["var mutable_field: U32 val"]))
         // no hover on docstring or blank line
-        (1, 2, [])
-        (2, 4, [])
-        (7, 0, [])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+        (1, 2, _HoverChecker([]))
+        (2, 4, _HoverChecker([]))
+        (7, 0, _HoverChecker([]))])
 
 class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
   let _server: _LspTestServer
@@ -106,18 +98,14 @@ class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
   fun name(): String => "hover/integration/actor"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_actor.pony"
-    let checks: Array[HoverCheck] val =
-      [ (0, 6, ["actor _Actor"; "A simple actor for exercising LSP hover."])
-        (6, 6, ["new tag create(name': String val)"])
-        (9, 5, ["be tag do_something(value: U64 val)"])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_actor.pony",
+      [ (0, 6, _HoverChecker(
+          ["actor _Actor"; "A simple actor for exercising LSP hover."]))
+        (6, 6, _HoverChecker(["new tag create(name': String val)"]))
+        (9, 5, _HoverChecker(["be tag do_something(value: U64 val)"]))])
 
 class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
   let _server: _LspTestServer
@@ -128,16 +116,12 @@ class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
   fun name(): String => "hover/integration/alias"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_alias.pony"
-    let checks: Array[HoverCheck] val =
-      [(0, 5, ["type _Alias"; "A simple alias for exercising LSP hover."])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_alias.pony",
+      [ (0, 5, _HoverChecker(
+        ["type _Alias"; "A simple alias for exercising LSP hover."]))])
 
 class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
   let _server: _LspTestServer
@@ -148,18 +132,13 @@ class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
   fun name(): String => "hover/integration/interface"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_interface.pony"
-    let checks: Array[HoverCheck] val =
-      [ (0, 10,
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_interface.pony",
+      [ (0, 10, _HoverChecker(
         [ "interface _Interface"
-          "A simple interface for exercising LSP hover."])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+          "A simple interface for exercising LSP hover."]))])
 
 class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
   let _server: _LspTestServer
@@ -170,18 +149,13 @@ class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
   fun name(): String => "hover/integration/primitive"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_primitive.pony"
-    let checks: Array[HoverCheck] val =
-      [ (0, 10,
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_primitive.pony",
+      [ (0, 10, _HoverChecker(
         [ "primitive _Primitive"
-          "A simple primitive for exercising LSP hover."])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+          "A simple primitive for exercising LSP hover."]))])
 
 class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
   let _server: _LspTestServer
@@ -192,16 +166,12 @@ class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
   fun name(): String => "hover/integration/trait"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_trait.pony"
-    let checks: Array[HoverCheck] val =
-      [(0, 6, ["trait _Trait"; "A simple trait for exercising LSP hover."])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_trait.pony",
+      [ (0, 6, _HoverChecker(
+        ["trait _Trait"; "A simple trait for exercising LSP hover."]))])
 
 class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
   let _server: _LspTestServer
@@ -212,45 +182,40 @@ class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
   fun name(): String => "hover/integration/function"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_function.pony"
-    let checks: Array[HoverCheck] val =
-      [ (15, 6,
-        [ "fun box helper_method(input: String val): String val"
-          "A helper method that processes input."])
-        (21, 6,
-        [ "fun box method_with_multiple_params" +
-          "(x: U32 val, y: String val, flag: Bool val): String val"
-          "Method with multiple parameters for testing."])
-        (11, 23,
-        [ "fun box helper_method(input: String val): String val"
-          "A helper method that processes input."])
-        (12, 23,
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_function.pony",
+      [ (15, 6, _HoverChecker(
+          [ "fun box helper_method(input: String val): String val"
+            "A helper method that processes input."]))
+        (21, 6, _HoverChecker(
           [ "fun box method_with_multiple_params" +
             "(x: U32 val, y: String val, flag: Bool val): String val"
-            "Method with multiple parameters for testing."])
-        (11, 8, ["let result1: String val"])
-        (12, 8, ["let result2: String val"])
+            "Method with multiple parameters for testing."]))
+        (11, 23, _HoverChecker(
+          [ "fun box helper_method(input: String val): String val"
+            "A helper method that processes input."]))
+        (12, 23, _HoverChecker(
+          [ "fun box method_with_multiple_params" +
+            "(x: U32 val, y: String val, flag: Bool val): String val"
+            "Method with multiple parameters for testing."]))
+        (11, 8, _HoverChecker(["let result1: String val"]))
+        (12, 8, _HoverChecker(["let result2: String val"]))
         // parameter declarations
-        (15, 20, ["input: String val"])
-        (21, 34, ["x: U32 val"])
-        (21, 42, ["y: String val"])
-        (21, 53, ["flag: Bool val"])
+        (15, 20, _HoverChecker(["input: String val"]))
+        (21, 34, _HoverChecker(["x: U32 val"]))
+        (21, 42, _HoverChecker(["y: String val"]))
+        (21, 53, _HoverChecker(["flag: Bool val"]))
         // parameter usages
-        (19, 4, ["input: String val"])
-        (25, 4, ["y: String val"])
+        (19, 4, _HoverChecker(["input: String val"]))
+        (25, 4, _HoverChecker(["y: String val"]))
         // ref receiver method
-        (27, 10,
-        [ "fun ref mutable_method(value: U32 val)"
-          "A method with a ref receiver capability."])
+        (27, 10, _HoverChecker(
+          [ "fun ref mutable_method(value: U32 val)"
+            "A method with a ref receiver capability."]))
         // this reference
-        (11, 18, [])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+        (11, 18, _HoverChecker([]))])
 
 class \nodoc\ iso _HoverIntegrationTypeInferenceTest is UnitTest
   let _server: _LspTestServer
@@ -261,21 +226,16 @@ class \nodoc\ iso _HoverIntegrationTypeInferenceTest is UnitTest
   fun name(): String => "hover/integration/type_inference"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_type_inference.pony"
-    let checks: Array[HoverCheck] val =
-      [ (18, 8, ["let inferred_string: String val"])
-        (21, 8, ["let inferred_bool: Bool"])
-        (24, 8, ["let inferred_array: Array[U32 val] ref"])
-        (26, 4, ["let inferred_string: String val"])
-        (26, 22, ["let inferred_bool: Bool"])
-        (26, 47, ["let inferred_array: Array[U32 val] ref"])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_type_inference.pony",
+      [ (18, 8, _HoverChecker(["let inferred_string: String val"]))
+        (21, 8, _HoverChecker(["let inferred_bool: Bool"]))
+        (24, 8, _HoverChecker(["let inferred_array: Array[U32 val] ref"]))
+        (26, 4, _HoverChecker(["let inferred_string: String val"]))
+        (26, 22, _HoverChecker(["let inferred_bool: Bool"]))
+        (26, 47, _HoverChecker(["let inferred_array: Array[U32 val] ref"]))])
 
 class \nodoc\ iso _HoverIntegrationReceiverCapabilityTest is UnitTest
   let _server: _LspTestServer
@@ -286,18 +246,13 @@ class \nodoc\ iso _HoverIntegrationReceiverCapabilityTest is UnitTest
   fun name(): String => "hover/integration/receiver_capability"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_receiver_capability.pony"
-    let checks: Array[HoverCheck] val =
-      [ (5, 10, ["fun box boxed_method(): String val"])
-        (13, 10, ["fun val valued_method(): String val"])
-        (20, 10, ["fun ref mutable_method()"])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_receiver_capability.pony",
+      [ (5, 10, _HoverChecker(["fun box boxed_method(): String val"]))
+        (13, 10, _HoverChecker(["fun val valued_method(): String val"]))
+        (20, 10, _HoverChecker(["fun ref mutable_method()"]))])
 
 class \nodoc\ iso _HoverIntegrationComplexTypesTest is UnitTest
   let _server: _LspTestServer
@@ -308,19 +263,18 @@ class \nodoc\ iso _HoverIntegrationComplexTypesTest is UnitTest
   fun name(): String => "hover/integration/complex_types"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_complex_types.pony"
-    let checks: Array[HoverCheck] val =
-      [ (11, 8, ["let union_type: (String val | U32 val | None val)"])
-        (12, 8, ["let tuple_type: (String val, U32 val, Bool val)"])
-        (13, 4, ["let union_type: (String val | U32 val | None val)"])
-        (13, 26, ["let tuple_type: (String val, U32 val, Bool val)"])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_complex_types.pony",
+      [ (11, 8, _HoverChecker(
+          ["let union_type: (String val | U32 val | None val)"]))
+        (12, 8, _HoverChecker(
+          ["let tuple_type: (String val, U32 val, Bool val)"]))
+        (13, 4, _HoverChecker(
+          ["let union_type: (String val | U32 val | None val)"]))
+        (13, 26, _HoverChecker(
+          ["let tuple_type: (String val, U32 val, Bool val)"]))])
 
 class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
   let _server: _LspTestServer
@@ -331,94 +285,86 @@ class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
   fun name(): String => "hover/integration/generics"
 
   fun apply(h: TestHelper) =>
-    let workspace_file = "hover/_generics.pony"
-    let checks: Array[HoverCheck] val =
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_generics.pony",
       [ // trait _Generics
-        (0, 6,
-        [ "trait _Generics[T: _Generics[T] box]"
-          "A trait demonstrating recursive type constraints."])
-        (5, 6, ["fun box compare(that: box->T): I32 val"])
+        (0, 6, _HoverChecker(
+          [ "trait _Generics[T: _Generics[T] box]"
+            "A trait demonstrating recursive type constraints."]))
+        (5, 6, _HoverChecker(["fun box compare(that: box->T): I32 val"]))
         // class _GenericsDemo
-        (7, 6,
-        [ "class _GenericsDemo[T: Any val]"
-          "Demonstrates hover on generic classes with type parameters."])
-        (12, 6, ["let _value: T"])
-        (17, 6,
-        [ "fun box get(): T"
-          "Returns the stored value."])
-        (23, 6,
-        [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
-          "A generic method with its own type parameter."])
+        (7, 6, _HoverChecker(
+          [ "class _GenericsDemo[T: Any val]"
+            "Demonstrates hover on generic classes with type parameters."]))
+        (12, 6, _HoverChecker(["let _value: T"]))
+        (17, 6, _HoverChecker(
+          ["fun box get(): T"; "Returns the stored value."]))
+        (23, 6, _HoverChecker(
+          [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
+            "A generic method with its own type parameter."]))
         // class _GenericPair
-        (30, 6,
-        [ "class _GenericPair[A: Any val, B: Any val]"
-          "Demonstrates multiple type parameters."])
-        (35, 6, ["let first: A"])
-        (36, 6, ["let second: B"])
-        (42, 6,
-        [ "fun box get_first(): A"
-          "Returns the first element."])
-        (48, 6,
-        [ "fun box get_second(): B"
-          "Returns the second element."])
+        (30, 6, _HoverChecker(
+          [ "class _GenericPair[A: Any val, B: Any val]"
+            "Demonstrates multiple type parameters."]))
+        (35, 6, _HoverChecker(["let first: A"]))
+        (36, 6, _HoverChecker(["let second: B"]))
+        (42, 6, _HoverChecker(
+          ["fun box get_first(): A"; "Returns the first element."]))
+        (48, 6, _HoverChecker(
+          ["fun box get_second(): B"; "Returns the second element."]))
         // class _GenericContainer
-        (54, 6,
-        [ "class _GenericContainer[T: Stringable val]"
-          "Demonstrates type constraints on generic parameters."])
-        (59, 6, ["let _items: Array[T] ref"])
-        (64, 10,
-        [ "fun ref add(item: T)"
-          "Add an item to the container."])
-        (70, 6,
-        [ "fun box get_strings(): Array[String val] ref"
-          "Returns string representations of all items."])
-        (75, 8, ["let result: Array[String val] ref"])
+        (54, 6, _HoverChecker(
+          [ "class _GenericContainer[T: Stringable val]"
+            "Demonstrates type constraints on generic parameters."]))
+        (59, 6, _HoverChecker(["let _items: Array[T] ref"]))
+        (64, 10, _HoverChecker(
+          ["fun ref add(item: T)"; "Add an item to the container."]))
+        (70, 6, _HoverChecker(
+          [ "fun box get_strings(): Array[String val] ref"
+            "Returns string representations of all items."]))
+        (75, 8, _HoverChecker(["let result: Array[String val] ref"]))
         // actor _GenericActor
-        (81, 6,
-        [ "actor _GenericActor[T: Any val]"
-          "Demonstrates generic actors."])
-        (86, 6, ["var _state: T"])
-        (91, 5,
-        [ "be tag update(new_state: T): None val"
-          "Updates the actor's state."])
-        (97, 5,
-        [ "be tag process[U: Any val](data: U): None val"
-          "A generic behavior with its own type parameter."])
+        (81, 6, _HoverChecker(
+          [ "actor _GenericActor[T: Any val]"
+            "Demonstrates generic actors."]))
+        (86, 6, _HoverChecker(["var _state: T"]))
+        (91, 5, _HoverChecker(
+          [ "be tag update(new_state: T): None val"
+            "Updates the actor's state."]))
+        (97, 5, _HoverChecker(
+          [ "be tag process[U: Any val](data: U): None val"
+            "A generic behavior with its own type parameter."]))
         // primitive _GenericHelper
-        (104, 10,
-        [ "primitive _GenericHelper"
-          "Demonstrates generic methods in primitives."])
-        (108, 6,
-        [ "fun box identity[T: Any val](value: T): T"
-          "A generic identity function."])
-        (115, 6,
-        [ "fun box create_pair[A: Any val, B: Any val](a: A, b: B): (A, B)"
-          "Creates a tuple from two values of different types."])
-        (121, 6,
-        [ "fun box apply[T: Any val](): Array[T] ref"
-          "Creates an empty array of any type."])
+        (104, 10, _HoverChecker(
+          [ "primitive _GenericHelper"
+            "Demonstrates generic methods in primitives."]))
+        (108, 6, _HoverChecker(
+          [ "fun box identity[T: Any val](value: T): T"
+            "A generic identity function."]))
+        (115, 6, _HoverChecker(
+          [ "fun box create_pair[A: Any val, B: Any val](a: A, b: B): (A, B)"
+            "Creates a tuple from two values of different types."]))
+        (121, 6, _HoverChecker(
+          [ "fun box apply[T: Any val](): Array[T] ref"
+            "Creates an empty array of any type."]))
         // class _GenericUsageDemo - instantiated generics
-        (128, 6,
-        [ "class _GenericUsageDemo"
-          "Demonstrates hover on instantiated generic types."])
-        (141, 8, ["let pair: _GenericPair[String val, U32 val] ref"])
-        (142, 8, ["let container: _GenericContainer[String val] ref"])
-        (143, 8, ["let numbers: _GenericsDemo[U64 val] ref"])
-        (148, 8, ["let first: String val"])
-        (148, 21, ["fun box get_first(): A"; "Returns the first element."])
-        (151, 8, ["let result: (U64 val, String val)"])
-        (151, 25,
-        [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
-          "A generic method with its own type parameter."])]
-    h.long_test(10_000_000_000)
-    for (line, character, expected) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      _server.request(
-        h, workspace_file, line, character, _HoverChecker(expected))
-    end
-
-type HoverCheck is (I64, I64, Array[String] val)
+        (128, 6, _HoverChecker(
+          [ "class _GenericUsageDemo"
+            "Demonstrates hover on instantiated generic types."]))
+        (141, 8, _HoverChecker(
+          ["let pair: _GenericPair[String val, U32 val] ref"]))
+        (142, 8, _HoverChecker(
+          ["let container: _GenericContainer[String val] ref"]))
+        (143, 8, _HoverChecker(["let numbers: _GenericsDemo[U64 val] ref"]))
+        (148, 8, _HoverChecker(["let first: String val"]))
+        (148, 21, _HoverChecker(
+          ["fun box get_first(): A"; "Returns the first element."]))
+        (151, 8, _HoverChecker(["let result: (U64 val, String val)"]))
+        (151, 25, _HoverChecker(
+          [ "fun box with_generic_param[U: Any val](other: U): (T, U)"
+            "A generic method with its own type parameter."]))])
 
 class val _HoverChecker
   let _expected: Array[String] val

--- a/tools/pony-lsp/test/_lsp_position.pony
+++ b/tools/pony-lsp/test/_lsp_position.pony
@@ -1,0 +1,21 @@
+class val _LspPosition
+  """
+  A position within a workspace file, identified by filename, line, and
+  character offset. Encapsulates the action string used by pony_test to
+  track individual LSP request/response pairs.
+  """
+  let workspace_file: String val
+  let line: I64
+  let character: I64
+
+  new val create(
+    workspace_file': String val,
+    line': I64,
+    character': I64)
+  =>
+    workspace_file = workspace_file'
+    line = line'
+    character = character'
+
+  fun action(): String val =>
+    workspace_file + ":" + line.string() + ":" + character.string()

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -1,0 +1,187 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+interface val _ResponseChecker
+  """
+  Encapsulates the LSP method name and response validation for a single
+  pending request. Implement this to integrate a new LSP feature into
+  the shared test server.
+  """
+  fun lsp_method(): String
+  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool
+
+class val _PendingRequest
+  let file_path: String
+  let line: I64
+  let character: I64
+  let h: TestHelper
+  let action: String
+  let checker: _ResponseChecker val
+
+  new val create(
+    file_path': String,
+    line': I64,
+    character': I64,
+    h': TestHelper,
+    action': String,
+    checker': _ResponseChecker val)
+  =>
+    file_path = file_path'
+    line = line'
+    character = character'
+    h = h'
+    action = action'
+    checker = checker'
+
+actor _LspTestServer is Channel
+  """
+  Shared LSP server for integration tests. Initializes and compiles the
+  workspace once, then dispatches individual requests to each test's TestHelper.
+  The response checker supplied with each request handles method-specific
+  dispatch and validation.
+  """
+  let _workspace_dir: String
+  var _server: (BaseProtocol | None)
+  var _ready: Bool
+  var _initialized: Bool
+  let _pending: Array[_PendingRequest]
+  let _opened: Set[String]
+  let _in_flight: Map[I64, _PendingRequest]
+  var _next_id: I64
+
+  new create(workspace_dir: String) =>
+    _workspace_dir = workspace_dir
+    _server = None
+    _ready = false
+    _initialized = false
+    _pending = Array[_PendingRequest]
+    _opened = Set[String]
+    _in_flight = Map[I64, _PendingRequest]
+    _next_id = 2
+
+  be request(
+    h: TestHelper,
+    workspace_file: String,
+    line: I64,
+    character: I64,
+    checker: _ResponseChecker val)
+  =>
+    let file_path = Path.join(_workspace_dir, workspace_file)
+    let action: String val =
+      recover
+        val workspace_file + ":" + line.string() + ":" + character.string()
+      end
+    let pending =
+      _PendingRequest(file_path, line, character, h, action, checker)
+    if _ready then
+      if not _opened.contains(file_path) then
+        _opened.set(file_path)
+        _did_open(file_path)
+      end
+      _dispatch(pending)
+    else
+      _pending.push(pending)
+    end
+    if not _initialized then
+      _initialized = true
+      let ponyc = try h.env.args(0)? else "" end
+      let proto =
+        BaseProtocol(LanguageServer(this, h.env, PonyCompiler("", ponyc)))
+      _server = proto
+      proto(LspMsg.initialize(_workspace_dir))
+    end
+
+  fun ref _dispatch(pending: _PendingRequest) =>
+    let id = _next_id
+    _next_id = id + 1
+    try
+      (_server as BaseProtocol)(
+        RequestMessage(
+          id,
+          pending.checker.lsp_method(),
+          JsonObject
+            .update(
+              "textDocument",
+              JsonObject.update("uri", Uris.from_path(pending.file_path)))
+            .update(
+              "position",
+              JsonObject
+                .update("line", pending.line)
+                .update("character", pending.character))
+        ).into_bytes()
+      )
+      _in_flight(id) = pending
+    else
+      pending.h.fail_action(pending.action)
+    end
+
+  be send(msg: Message val) =>
+    match msg
+    | let res: ResponseMessage val =>
+      try
+        let id = res.id as RequestId
+        if RequestIds.eq(id, I64(0)) then
+          try (_server as BaseProtocol)(LspMsg.initialized()) end
+        else
+          try
+            let id_i64 = id as I64
+            (_, let pending) = _in_flight.remove(id_i64)?
+            if pending.checker.check(res, pending.h, pending.action) then
+              pending.h.complete_action(pending.action)
+            else
+              pending.h.fail_action(pending.action)
+            end
+          end
+        end
+      end
+    | let req: RequestMessage val =>
+      if req.method == Methods.workspace().configuration() then
+        try
+          let proto = _server as BaseProtocol
+          proto(ResponseMessage(req.id, JsonArray).into_bytes())
+          for p in _pending.values() do
+            if not _opened.contains(p.file_path) then
+              _opened.set(p.file_path)
+              _did_open(p.file_path)
+            end
+          end
+        end
+      end
+    | let n: Notification val =>
+      if n.method == Methods.text_document().publish_diagnostics() then
+        if not _ready then
+          _ready = true
+          for p in _pending.values() do
+            _dispatch(p)
+          end
+          _pending.clear()
+        end
+      end
+    end
+
+  fun ref _did_open(file_path: String) =>
+    try
+      (_server as BaseProtocol)(
+        Notification(
+          Methods.text_document().did_open(),
+          JsonObject.update(
+            "textDocument",
+            JsonObject
+              .update("uri", Uris.from_path(file_path))
+              .update("languageId", "pony")
+              .update("version", I64(1))
+              .update("text", ""))
+        ).into_bytes())
+    end
+
+  be log(data: String val, message_type: MessageType = Debug) =>
+    None
+
+  be set_notifier(notifier: Notifier tag) =>
+    None
+
+  be dispose() =>
+    None

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -4,38 +4,6 @@ use "files"
 use "json"
 use "collections"
 
-interface val _ResponseChecker
-  """
-  Encapsulates the LSP method name and response validation for a single
-  pending request. Implement this to integrate a new LSP feature into
-  the shared test server.
-  """
-  fun lsp_method(): String
-  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool
-
-class val _PendingRequest
-  let file_path: String
-  let line: I64
-  let character: I64
-  let h: TestHelper
-  let action: String
-  let checker: _ResponseChecker val
-
-  new val create(
-    file_path': String,
-    line': I64,
-    character': I64,
-    h': TestHelper,
-    action': String,
-    checker': _ResponseChecker val)
-  =>
-    file_path = file_path'
-    line = line'
-    character = character'
-    h = h'
-    action = action'
-    checker = checker'
-
 actor _LspTestServer is Channel
   """
   Shared LSP server for integration tests. Initializes and compiles the
@@ -185,3 +153,40 @@ actor _LspTestServer is Channel
 
   be dispose() =>
     None
+
+class val _PendingRequest
+  let file_path: String
+  let line: I64
+  let character: I64
+  let h: TestHelper
+  let action: String
+  let checker: _ResponseChecker val
+
+  new val create(
+    file_path': String,
+    line': I64,
+    character': I64,
+    h': TestHelper,
+    action': String,
+    checker': _ResponseChecker val)
+  =>
+    file_path = file_path'
+    line = line'
+    character = character'
+    h = h'
+    action = action'
+    checker = checker'
+
+primitive _RunLspChecks
+  fun apply(
+    h: TestHelper,
+    server: _LspTestServer,
+    workspace_file: String,
+    checks: Array[(I64, I64, _ResponseChecker val)] val)
+  =>
+    h.long_test(10_000_000_000)
+    for (line, character, checker) in checks.values() do
+      h.expect_action(
+        workspace_file + ":" + line.string() + ":" + character.string())
+      server.request(h, workspace_file, line, character, checker)
+    end

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -91,7 +91,7 @@ actor _LspTestServer is Channel
             let id_i64 = id as I64
             (_, let pending) = _in_flight.remove(id_i64)?
             let action = pending.pos.action()
-            if pending.checker.check(res, pending.h, action) then
+            if pending.checker.check(res, pending.h) then
               pending.h.complete_action(action)
             else
               pending.h.fail_action(action)

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -32,18 +32,11 @@ actor _LspTestServer is Channel
 
   be request(
     h: TestHelper,
-    workspace_file: String,
-    line: I64,
-    character: I64,
+    pos: _LspPosition val,
     checker: _ResponseChecker val)
   =>
-    let file_path = Path.join(_workspace_dir, workspace_file)
-    let action: String val =
-      recover
-        val workspace_file + ":" + line.string() + ":" + character.string()
-      end
-    let pending =
-      _PendingRequest(file_path, line, character, h, action, checker)
+    let file_path = Path.join(_workspace_dir, pos.workspace_file)
+    let pending = _PendingRequest(file_path, pos, h, checker)
     if _ready then
       if not _opened.contains(file_path) then
         _opened.set(file_path)
@@ -77,13 +70,13 @@ actor _LspTestServer is Channel
             .update(
               "position",
               JsonObject
-                .update("line", pending.line)
-                .update("character", pending.character))
+                .update("line", pending.pos.line)
+                .update("character", pending.pos.character))
         ).into_bytes()
       )
       _in_flight(id) = pending
     else
-      pending.h.fail_action(pending.action)
+      pending.h.fail_action(pending.pos.action())
     end
 
   be send(msg: Message val) =>
@@ -97,10 +90,11 @@ actor _LspTestServer is Channel
           try
             let id_i64 = id as I64
             (_, let pending) = _in_flight.remove(id_i64)?
-            if pending.checker.check(res, pending.h, pending.action) then
-              pending.h.complete_action(pending.action)
+            let action = pending.pos.action()
+            if pending.checker.check(res, pending.h, action) then
+              pending.h.complete_action(action)
             else
-              pending.h.fail_action(pending.action)
+              pending.h.fail_action(action)
             end
           end
         end
@@ -156,25 +150,19 @@ actor _LspTestServer is Channel
 
 class val _PendingRequest
   let file_path: String
-  let line: I64
-  let character: I64
+  let pos: _LspPosition val
   let h: TestHelper
-  let action: String
   let checker: _ResponseChecker val
 
   new val create(
     file_path': String,
-    line': I64,
-    character': I64,
+    pos': _LspPosition val,
     h': TestHelper,
-    action': String,
     checker': _ResponseChecker val)
   =>
     file_path = file_path'
-    line = line'
-    character = character'
+    pos = pos'
     h = h'
-    action = action'
     checker = checker'
 
 primitive _RunLspChecks
@@ -186,7 +174,7 @@ primitive _RunLspChecks
   =>
     h.long_test(10_000_000_000)
     for (line, character, checker) in checks.values() do
-      h.expect_action(
-        workspace_file + ":" + line.string() + ":" + character.string())
-      server.request(h, workspace_file, line, character, checker)
+      let pos = _LspPosition(workspace_file, line, character)
+      h.expect_action(pos.action())
+      server.request(h, pos, checker)
     end

--- a/tools/pony-lsp/test/_response_checker.pony
+++ b/tools/pony-lsp/test/_response_checker.pony
@@ -1,0 +1,11 @@
+use ".."
+use "pony_test"
+
+interface val _ResponseChecker
+  """
+  Encapsulates the LSP method name and response validation for a single
+  pending request. Implement this to integrate a new LSP feature into
+  the shared test server.
+  """
+  fun lsp_method(): String
+  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool

--- a/tools/pony-lsp/test/_response_checker.pony
+++ b/tools/pony-lsp/test/_response_checker.pony
@@ -8,4 +8,4 @@ interface val _ResponseChecker
   the shared test server.
   """
   fun lsp_method(): String
-  fun check(res: ResponseMessage val, h: TestHelper, action: String): Bool
+  fun check(res: ResponseMessage val, h: TestHelper): Bool


### PR DESCRIPTION


## Context

The three LSP integration test files (hover, definition, document highlight) each contain a hand-rolled test server, action-string generation, and response-checking logic. This duplication makes each file hard to read and any cross-cutting change (e.g. to the request format) requires touching all three.

## Changes

- Extract a shared `_LspTestServer` actor and move server lifecycle management out of each test file.
- Extract a `_ResponseChecker` interface so checkers can be passed as values across the actor boundary.
- Extract a `_RunLspChecks` primitive that drives `h.long_test`, `h.expect_action`, and `server.request` from a single call site.
- Extract a `_LspPosition` value class to encapsulate `workspace_file`, `line`, and `character`, and to act as the single source of truth for action strings.

## Consequences

Each test `apply` method is now a single `_RunLspChecks(...)` call with an inline array of `(line, character, checker)` tuples. The three test files shrink by ~1,300 lines net.