### PR TITLE
Add LSP `textDocument/inlayHint` support

### DIFF
--- a/.release-notes/5159.md
+++ b/.release-notes/5159.md
@@ -1,0 +1,3 @@
+## Add LSP `textDocument/inlayHint` support
+
+`pony-lsp` now supports inlay hints. Editors that request `textDocument/inlayHint` will receive inline type annotations after the variable name for `let` and `var` declarations whose type is inferred rather than explicitly written.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -16,6 +16,7 @@ For user documentation — installation and editor configuration — see the [po
 | **Go To Definition** | For most language constructs, you can go from a reference to its definition. |
 | **Document Symbols** | pony-lsp provides a list of available symbols for each opened document. |
 | **Document Highlight** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
+| **Inlay Hints** | Inferred types are shown inline after the variable name for `let` and `var` declarations with no explicit type annotation. |
 
 New features are actively being added. Contributions are welcome — we are happy to provide help and guidance.
 

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -79,6 +79,21 @@ actor LanguageServer is (Notifier & RequestSender)
     | _Initialized =>
       this._channel.log("\n\n<-\n" + r.json().string())
       match \exhaustive\ r.method
+      | Methods.text_document().inlay_hint() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .inlay_hint(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().document_highlight() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -400,7 +415,10 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("identifier", "pony-lsp")
                     .update("interFileDependencies", true)
                     .update("workspaceDiagnostics", false))
-                .update("documentSymbolProvider", true))
+                .update("documentSymbolProvider", true)
+                .update(
+                  "inlayHintProvider",
+                  JsonObject.update("resolveProvider", false)))
             .update(
               "serverInfo",
               JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -99,6 +99,9 @@ primitive TextDocumentMethods
   fun hover(): String val =>
     "textDocument/hover"
 
+  fun inlay_hint(): String val =>
+    "textDocument/inlayHint"
+
   fun publish_diagnostics(): String val =>
     "textDocument/publishDiagnostics"
 

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -1,0 +1,99 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _InlayHintIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_InlayHintDemoTest.create(server))
+
+class \nodoc\ iso _InlayHintDemoTest is UnitTest
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "inlay_hint/integration"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_inlay_hint.pony",
+      [ (0, 0,
+          _InlayHintChecker(
+            [ (15, 23, ": String val")           // inferred_string
+              (16, 21, ": Bool")                 // inferred_bool
+              (18, 22, ": Array[U32 val] ref") ] // inferred_array
+            where expected_count = 3)) ])
+
+class val _InlayHintChecker
+  """
+  Checks that an inlayHint response contains exactly the expected set of hints.
+  Each expected hint is (line, character, label_substring).
+  expected_count asserts the total number of hints matches (validates negative
+  cases: hints should not be emitted for explicitly-typed declarations).
+  """
+  let _expected: Array[(I64, I64, String)] val
+  let _expected_count: USize
+
+  new val create(
+    expected: Array[(I64, I64, String)] val,
+    expected_count: USize = 0)
+  =>
+    _expected = expected
+    _expected_count = expected_count
+
+  fun lsp_method(): String =>
+    Methods.text_document().inlay_hint()
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    try
+      let hints = res.result as JsonArray
+      if (_expected_count > 0) and
+        not h.assert_eq[USize](
+          _expected_count,
+          hints.size(),
+          "Expected " + _expected_count.string() +
+          " hints, got " + hints.size().string())
+      then
+        ok = false
+      end
+      for (exp_line, exp_char, exp_label) in _expected.values() do
+        var found = false
+        for hint_val in hints.values() do
+          try
+            let hint = hint_val as JsonObject
+            let hint_line = JsonNav(hint)("position")("line").as_i64()?
+            let hint_char = JsonNav(hint)("position")("character").as_i64()?
+            if (hint_line == exp_line) and (hint_char == exp_char) then
+              let label = JsonNav(hint)("label").as_string()?
+              if not h.assert_true(
+                label.contains(exp_label),
+                "At " + exp_line.string() + ":" + exp_char.string() +
+                " expected label to contain '" + exp_label +
+                "', got: '" + label + "'")
+              then
+                ok = false
+              end
+              found = true
+              break
+            end
+          end
+        end
+        if not found then
+          h.log(
+            "No hint found at " + exp_line.string() + ":" + exp_char.string())
+          ok = false
+        end
+      end
+    else
+      h.log("Failed to parse inlay hint response: " + res.string())
+      ok = false
+    end
+    ok

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -26,6 +26,7 @@ actor Main is TestList
     _HoverIntegrationTests.make().tests(test)
     _DefinitionIntegrationTests.make().tests(test)
     _DocumentHighlightIntegrationTests.make().tests(test)
+    _InlayHintIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/inlay_hint/_inlay_hint.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_inlay_hint.pony
@@ -1,0 +1,21 @@
+class _InlayHint
+  """
+  Manual testing: open this file with pony-lsp active. Inlay hints should
+  appear after the variable name on inferred declarations (no explicit `:Type`),
+  and should be absent on explicit declarations.
+
+  Expected hints:
+    let inferred_string = "hello"    →  ": String val"
+    var inferred_bool = true         →  ": Bool"
+    let inferred_array = Array[U32]  →  ": Array[U32 val] ref"
+
+  No hint expected:
+    let explicit_string: String = "world"
+  """
+  fun demo(): String =>
+    let inferred_string = "hello"
+    var inferred_bool = true
+    let explicit_string: String = "world"
+    let inferred_array = Array[U32]
+    inferred_string + inferred_bool.string() + explicit_string +
+      inferred_array.size().string()

--- a/tools/pony-lsp/test/workspace/inlay_hint/inlay_hint.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/inlay_hint.pony
@@ -1,0 +1,3 @@
+"""
+Test fixtures for exercising LSP inlay hint functionality.
+"""

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -1,0 +1,96 @@
+use ".."
+use "json"
+use "pony_compiler"
+
+primitive InlayHints
+  """
+  Collects inlay hints for a module: type hints for let/var declarations
+  that have no explicit type annotation.
+  """
+  fun collect(module: Module val): Array[JsonValue] =>
+    let collector = _InlayHintCollector.create()
+    module.ast.visit(collector)
+    collector.hints()
+
+class ref _InlayHintCollector is ASTVisitor
+  let _hints: Array[JsonValue] ref
+
+  new ref create() =>
+    _hints = Array[JsonValue].create()
+
+  fun ref visit(node: AST box): VisitResult =>
+    match node.id()
+    | TokenIds.tk_let() | TokenIds.tk_var() =>
+      _try_add_hint(node)
+    end
+    Continue
+
+  fun ref _try_add_hint(node: AST box) =>
+    try
+      let id_node = node(0)?
+      if id_node.id() != TokenIds.tk_id() then
+        return
+      end
+      let name = id_node.token_value() as String
+      let l = id_node.line()
+      let col = id_node.pos()
+      if (l == 0) or (col == 0) then
+        return // synthetic node
+      end
+      if _has_explicit_type(id_node, name, l, col) then
+        return
+      end
+      let type_str = node.ast_type_string() as String
+      // LSP positions are 0-based; AST positions are 1-based
+      _hints.push(
+        JsonObject
+          .update(
+            "position",
+            JsonObject
+              .update("line", (l - 1).i64())
+              .update("character", ((col - 1) + name.size()).i64()))
+          .update("label", ": " + type_str)
+          .update("kind", I64(1)))
+    end
+
+  fun ref hints(): Array[JsonValue] =>
+    _hints
+
+  fun _has_explicit_type(
+    id_node: AST box,
+    name: String,
+    l: USize,
+    col: USize)
+    : Bool
+  =>
+    """
+    Scan source text to detect whether the let/var declaration has an
+    explicit type annotation (a ':' between the name and '=').
+    Callers guarantee l >= 1 and col >= 1.
+    """
+    try
+      let src = id_node.source_contents() as String box
+      // Find byte offset of the first character of the identifier
+      let base_offset: USize =
+        if l == 1 then
+          col - 1
+        else
+          let line_idx = src.find("\n" where nth = l - 2)?
+          USize(line_idx.usize() + col)
+        end
+      // Scan from the character right after the identifier
+      var j = base_offset + name.size()
+      while j < src.size() do
+        match src(j)?
+        | ':' => return true  // explicit type annotation
+        | '=' | '\n' => return false // no annotation
+        | ' ' | '\t' => None // skip whitespace
+        else
+          return false // unexpected character
+        end
+        j = j + 1
+      end
+      false
+    else
+      false
+    end

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -695,6 +695,44 @@ actor WorkspaceManager
       )
     )
 
+  be inlay_hint(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/inlayHint request.
+    """
+    this._channel.log("Handling textDocument/inlayHint")
+    let document_path = Uris.to_path(document_uri)
+    try
+      let package: FilePath = this._find_workspace_package(document_path)?
+      match \exhaustive\ this._get_package(package)
+      | let pkg_state: PackageState =>
+        match \exhaustive\ pkg_state.get_document(document_path)
+        | let doc: DocumentState =>
+          match \exhaustive\ doc.module()
+          | let module: Module val =>
+            let hints = InlayHints.collect(module)
+            var json_arr = JsonArray
+            for hint in hints.values() do
+              json_arr = json_arr.push(hint)
+            end
+            this._channel.send(ResponseMessage(request.id, json_arr))
+            return
+          | None =>
+            this._channel.log(
+              "No module available for " + document_path)
+          end
+        | None =>
+          this._channel.log(
+            "No document state available for " + document_path)
+        end
+      | None =>
+        this._channel.log(
+          "No package state available for " + document_path)
+      end
+    else
+      this._channel.log("document not in workspace: " + document_path)
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
   fun _get_node_for_highlight(ast: AST box): AST box =>
     """
     Get the appropriate node for hover highlighting.


### PR DESCRIPTION
## Context

pony-lsp has no support for `textDocument/inlayHint`. Editors that request inlay hints receive no response, leaving users without inline type information for inferred variable declarations.

## Changes

- Adds `textDocument/inlayHint`: emits a type hint after the variable name on `let`/`var` declarations that carry no explicit type annotation
- Detects explicit annotations by scanning source text for `:` between the identifier and `=`, skipping declarations the user has already typed
- Wires the method through `methods.pony`, `language_server.pony`, and `workspace_manager.pony` following existing patterns
- Advertises `inlayHintProvider` capability in the initialize response
- Adds an integration test with a fixture covering both inferred and explicit declarations

https://github.com/user-attachments/assets/7de80813-e3f4-44f3-be91-ec95375c0a7a


## Considerations

Source text scanning is used to distinguish inferred from explicit declarations because ponyc replaces the type node in the AST during compilation — the AST alone cannot distinguish the two after type-checking completes.