### PR TITLE
Support range filtering for `textDocument/inlayHint` in pony-lsp

### DIFF
--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -203,6 +203,9 @@ class val _DefinitionChecker
   fun lsp_method(): String =>
     Methods.text_document().definition()
 
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     let got_count =

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -771,6 +771,9 @@ class val _DocHighlightChecker
   fun lsp_method(): String =>
     Methods.text_document().document_highlight()
 
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     match res.result

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -375,6 +375,9 @@ class val _HoverChecker
   fun lsp_method(): String =>
     Methods.text_document().hover()
 
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     if _expected.size() == 0 then

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -11,7 +11,7 @@ primitive _InlayHintIntegrationTests is TestList
     let server = _LspTestServer(workspace_dir)
     test(_InlayHintDemoTest.create(server))
     test(_InlayHintRangeFirstLineTest.create(server))
-    test(_InlayHintRangeMiddleTest.create(server))
+    test(_InlayHintRangeTwoLineTest.create(server))
     test(_InlayHintRangeEmptyTest.create(server))
 
 class \nodoc\ iso _InlayHintDemoTest is UnitTest
@@ -57,9 +57,9 @@ class \nodoc\ iso _InlayHintRangeFirstLineTest is UnitTest
             [ (15, 23, ": String val") ]
             where range = (15, 0, 16, 0))) ])
 
-class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
+class \nodoc\ iso _InlayHintRangeTwoLineTest is UnitTest
   """
-  Range covering lines 16-17 (inferred_bool only). Expects exactly one hint.
+  Range covering lines 15-17. Expects exactly two hints.
   """
   let _server: _LspTestServer
 
@@ -76,8 +76,9 @@ class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
       "inlay_hint/_inlay_hint.pony",
       [ (0, 0,
           _InlayHintChecker(
-            [ (16, 21, ": Bool") ]
-            where range = (16, 0, 17, 0))) ])
+            [ (15, 23, ": String val")           // inferred_string
+              (16, 21, ": Bool") ]               // inferred_bool
+            where range = (15, 0, 17, 0))) ])
 
 class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
   """

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -33,7 +33,7 @@ class \nodoc\ iso _InlayHintDemoTest is UnitTest
             [ (15, 23, ": String val")           // inferred_string
               (16, 21, ": Bool")                 // inferred_bool
               (18, 22, ": Array[U32 val] ref") ] // inferred_array
-            where expected_count = 3)) ])
+            )) ])
 
 class \nodoc\ iso _InlayHintRangeFirstLineTest is UnitTest
   """
@@ -55,9 +55,7 @@ class \nodoc\ iso _InlayHintRangeFirstLineTest is UnitTest
       [ (0, 0,
           _InlayHintChecker(
             [ (15, 23, ": String val") ]
-            where
-            expected_count = 1,
-            range = (15, 0, 16, 0))) ])
+            where range = (15, 0, 16, 0))) ])
 
 class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
   """
@@ -79,9 +77,7 @@ class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
       [ (0, 0,
           _InlayHintChecker(
             [ (16, 21, ": Bool") ]
-            where
-            expected_count = 1,
-            range = (16, 0, 17, 0))) ])
+            where range = (16, 0, 17, 0))) ])
 
 class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
   """
@@ -103,27 +99,22 @@ class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
       [ (0, 0,
           _InlayHintChecker(
             []
-            where
-            expected_count = 0,
-            range = (0, 0, 15, 0))) ])
+            where range = (0, 0, 15, 0))) ])
 
 class val _InlayHintChecker
   """
-  Checks that an inlayHint response contains exactly the expected set of hints.
-  Each expected hint is (line, character, label_substring).
-  expected_count always asserts the total hint count; use 0 to assert empty.
+  Checks that an inlayHint response contains exactly the expected hints.
+  Each entry is (line, character, label_substring). The total hint count
+  is asserted against the number of expected entries.
   """
   let _expected: Array[(I64, I64, String)] val
-  let _expected_count: USize
   let _range: (None | (I64, I64, I64, I64))
 
   new val create(
     expected: Array[(I64, I64, String)] val,
-    expected_count: USize = 0,
     range: (None | (I64, I64, I64, I64)) = None)
   =>
     _expected = expected
-    _expected_count = expected_count
     _range = range
 
   fun lsp_method(): String =>
@@ -137,9 +128,9 @@ class val _InlayHintChecker
     try
       let hints = res.result as JsonArray
       if not h.assert_eq[USize](
-        _expected_count,
+        _expected.size(),
         hints.size(),
-        "Expected " + _expected_count.string() +
+        "Expected " + _expected.size().string() +
         " hints, got " + hints.size().string())
       then
         ok = false

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -10,6 +10,9 @@ primitive _InlayHintIntegrationTests is TestList
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
     let server = _LspTestServer(workspace_dir)
     test(_InlayHintDemoTest.create(server))
+    test(_InlayHintRangeFirstLineTest.create(server))
+    test(_InlayHintRangeMiddleTest.create(server))
+    test(_InlayHintRangeEmptyTest.create(server))
 
 class \nodoc\ iso _InlayHintDemoTest is UnitTest
   let _server: _LspTestServer
@@ -17,7 +20,8 @@ class \nodoc\ iso _InlayHintDemoTest is UnitTest
   new iso create(server: _LspTestServer) =>
     _server = server
 
-  fun name(): String => "inlay_hint/integration"
+  fun name(): String =>
+    "inlay_hint/integration/full_file"
 
   fun apply(h: TestHelper) =>
     _RunLspChecks(
@@ -31,36 +35,112 @@ class \nodoc\ iso _InlayHintDemoTest is UnitTest
               (18, 22, ": Array[U32 val] ref") ] // inferred_array
             where expected_count = 3)) ])
 
+class \nodoc\ iso _InlayHintRangeFirstLineTest is UnitTest
+  """
+  Range covering only line 15 (inferred_string). Expects exactly one hint.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/range_first_line"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_inlay_hint.pony",
+      [ (0, 0,
+          _InlayHintChecker(
+            [ (15, 23, ": String val") ]
+            where
+            expected_count = 1,
+            range = (I64(15), I64(0), I64(16), I64(0)))) ])
+
+class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
+  """
+  Range covering lines 16-17 (inferred_bool only). Expects exactly one hint.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/range_middle"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_inlay_hint.pony",
+      [ (0, 0,
+          _InlayHintChecker(
+            [ (16, 21, ": Bool") ]
+            where
+            expected_count = 1,
+            range = (I64(16), I64(0), I64(17), I64(0)))) ])
+
+class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
+  """
+  Range covering only the class docstring (lines 0-14). No hints expected.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/range_empty"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_inlay_hint.pony",
+      [ (0, 0,
+          _InlayHintChecker(
+            []
+            where
+            expected_count = 0,
+            range = (I64(0), I64(0), I64(15), I64(0)))) ])
+
 class val _InlayHintChecker
   """
   Checks that an inlayHint response contains exactly the expected set of hints.
   Each expected hint is (line, character, label_substring).
-  expected_count asserts the total number of hints matches (validates negative
-  cases: hints should not be emitted for explicitly-typed declarations).
+  expected_count always asserts the total hint count; use 0 to assert empty.
   """
   let _expected: Array[(I64, I64, String)] val
   let _expected_count: USize
+  let _range: (None | (I64, I64, I64, I64))
 
   new val create(
     expected: Array[(I64, I64, String)] val,
-    expected_count: USize = 0)
+    expected_count: USize = 0,
+    range: (None | (I64, I64, I64, I64)) = None)
   =>
     _expected = expected
     _expected_count = expected_count
+    _range = range
 
   fun lsp_method(): String =>
     Methods.text_document().inlay_hint()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    _range
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     try
       let hints = res.result as JsonArray
-      if (_expected_count > 0) and
-        not h.assert_eq[USize](
-          _expected_count,
-          hints.size(),
-          "Expected " + _expected_count.string() +
-          " hints, got " + hints.size().string())
+      if not h.assert_eq[USize](
+        _expected_count,
+        hints.size(),
+        "Expected " + _expected_count.string() +
+        " hints, got " + hints.size().string())
       then
         ok = false
       end

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -57,7 +57,7 @@ class \nodoc\ iso _InlayHintRangeFirstLineTest is UnitTest
             [ (15, 23, ": String val") ]
             where
             expected_count = 1,
-            range = (I64(15), I64(0), I64(16), I64(0)))) ])
+            range = (15, 0, 16, 0))) ])
 
 class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
   """
@@ -81,7 +81,7 @@ class \nodoc\ iso _InlayHintRangeMiddleTest is UnitTest
             [ (16, 21, ": Bool") ]
             where
             expected_count = 1,
-            range = (I64(16), I64(0), I64(17), I64(0)))) ])
+            range = (16, 0, 17, 0))) ])
 
 class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
   """
@@ -105,7 +105,7 @@ class \nodoc\ iso _InlayHintRangeEmptyTest is UnitTest
             []
             where
             expected_count = 0,
-            range = (I64(0), I64(0), I64(15), I64(0)))) ])
+            range = (0, 0, 15, 0))) ])
 
 class val _InlayHintChecker
   """

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -59,21 +59,31 @@ actor _LspTestServer is Channel
     let id = _next_id
     _next_id = id + 1
     try
+      var params =
+        JsonObject
+          .update(
+            "textDocument",
+            JsonObject.update("uri", Uris.from_path(pending.file_path)))
+          .update(
+            "position",
+            JsonObject
+              .update("line", pending.pos.line)
+              .update("character", pending.pos.character))
+      match pending.checker.lsp_range()
+      | (let sl: I64, let sc: I64, let el: I64, let ec: I64) =>
+        params =
+          params.update(
+            "range",
+            JsonObject
+              .update(
+                "start",
+                JsonObject.update("line", sl).update("character", sc))
+              .update(
+                "end",
+                JsonObject.update("line", el).update("character", ec)))
+      end
       (_server as BaseProtocol)(
-        RequestMessage(
-          id,
-          pending.checker.lsp_method(),
-          JsonObject
-            .update(
-              "textDocument",
-              JsonObject.update("uri", Uris.from_path(pending.file_path)))
-            .update(
-              "position",
-              JsonObject
-                .update("line", pending.pos.line)
-                .update("character", pending.pos.character))
-        ).into_bytes()
-      )
+        RequestMessage(id, pending.checker.lsp_method(), params).into_bytes())
       _in_flight(id) = pending
     else
       pending.h.fail_action(pending.pos.action())

--- a/tools/pony-lsp/test/_response_checker.pony
+++ b/tools/pony-lsp/test/_response_checker.pony
@@ -8,4 +8,5 @@ interface val _ResponseChecker
   the shared test server.
   """
   fun lsp_method(): String
+  fun lsp_range(): (None | (I64, I64, I64, I64))
   fun check(res: ResponseMessage val, h: TestHelper): Bool

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -7,16 +7,22 @@ primitive InlayHints
   Collects inlay hints for a module: type hints for let/var declarations
   that have no explicit type annotation.
   """
-  fun collect(module: Module val): Array[JsonValue] =>
-    let collector = _InlayHintCollector.create()
+  fun collect(
+    module: Module val,
+    range: (None | (I64, I64, I64, I64)) = None)
+    : Array[JsonValue]
+  =>
+    let collector = _InlayHintCollector.create(range)
     module.ast.visit(collector)
     collector.hints()
 
 class ref _InlayHintCollector is ASTVisitor
   let _hints: Array[JsonValue] ref
+  let _range: (None | (I64, I64, I64, I64))
 
-  new ref create() =>
+  new ref create(range: (None | (I64, I64, I64, I64)) = None) =>
     _hints = Array[JsonValue].create()
+    _range = range
 
   fun ref visit(node: AST box): VisitResult =>
     match node.id()
@@ -42,13 +48,22 @@ class ref _InlayHintCollector is ASTVisitor
       end
       let type_str = node.ast_type_string() as String
       // LSP positions are 0-based; AST positions are 1-based
+      let hint_line = (l - 1).i64()
+      let hint_char = ((col - 1) + name.size()).i64()
+      match _range
+      | (let sl: I64, let sc: I64, let el: I64, let ec: I64) =>
+        if hint_line < sl then return end
+        if hint_line > el then return end
+        if (hint_line == sl) and (hint_char < sc) then return end
+        if (hint_line == el) and (hint_char >= ec) then return end
+      end
       _hints.push(
         JsonObject
           .update(
             "position",
             JsonObject
-              .update("line", (l - 1).i64())
-              .update("character", ((col - 1) + name.size()).i64()))
+              .update("line", hint_line)
+              .update("character", hint_char))
           .update("label", ": " + type_str)
           .update("kind", I64(1)))
     end

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -709,7 +709,18 @@ actor WorkspaceManager
         | let doc: DocumentState =>
           match \exhaustive\ doc.module()
           | let module: Module val =>
-            let hints = InlayHints.collect(module)
+            let range: (None | (I64, I64, I64, I64)) =
+              try
+                let p = request.params
+                let sl = JsonNav(p)("range")("start")("line").as_i64()?
+                let sc = JsonNav(p)("range")("start")("character").as_i64()?
+                let el = JsonNav(p)("range")("end")("line").as_i64()?
+                let ec = JsonNav(p)("range")("end")("character").as_i64()?
+                (sl, sc, el, ec)
+              else
+                None
+              end
+            let hints = InlayHints.collect(module, range)
             var json_arr = JsonArray
             for hint in hints.values() do
               json_arr = json_arr.push(hint)


### PR DESCRIPTION
## Context

Continuing with the `testDocument/inlayHint` work from #5159…

The LSP `textDocument/inlayHint` request includes a required `range` parameter that scopes hints to a region of the document. pony-lsp ignores this parameter and always returns hints for the entire file.

## Changes

- `InlayHints.collect()` accepts an optional range and passes it to the collector
- `_InlayHintCollector` filters hints to those whose position falls within the range; a missing range returns all hints
- `workspace_manager` extracts the range from request params via `JsonNav` and passes it through
- `_ResponseChecker` gains an `lsp_range()` method; the test server includes it in the request when non-`None`
- Adds three range-specific integration tests: first line only, middle line only, and a range containing no inferred declarations (asserts empty result)