### PR TITLE
Revert macOS Intel runner to macos-15-intel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,4 @@
 self-hosted-runner:
   labels:
     - windows-11-arm
-    - macos-26-intel
+    - macos-15-intel

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -170,7 +170,7 @@ jobs:
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
   x86_macos:
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     name: x86-64-apple-darwin
     steps:
@@ -183,7 +183,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2
@@ -194,7 +194,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
       - name: Nightly

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -240,7 +240,7 @@ jobs:
   x86_64-macos:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     name: x86-64 Apple Darwin
     steps:
@@ -255,7 +255,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
     needs:
       - pre-artefact-creation
 
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     name: x86-64-apple-darwin
     steps:
@@ -191,7 +191,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2
@@ -202,7 +202,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Install Cloudsmith
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
       - name: Release

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   x86_64-macos:
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2
@@ -55,7 +55,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   x86_64-macos:
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2
@@ -55,7 +55,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -102,7 +102,7 @@ jobs:
             make libs build_flags=-j8
 
   x86_64-macos:
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
 
     name: x86-64 Apple Darwin
     steps:
@@ -115,7 +115,7 @@ jobs:
           path: |
             build/libs
             lib/llvm/src/compiler-rt/lib/builtins
-          key: libs-x86-macos-26-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: make libs build_flags=-j2


### PR DESCRIPTION
The macos-26-intel runners are highly unstable. Reverting to macos-15-intel until the instability is resolved. Also updates LLVM cache keys to match.