### PR TITLE
Add LSP go-to-definition for type aliases

### DIFF
--- a/.release-notes/lsp-typealiasref.md
+++ b/.release-notes/lsp-typealiasref.md
@@ -1,0 +1,5 @@
+## Add LSP go-to-definition for type aliases
+
+The Pony language server now supports go-to-definition on type alias names. For example, placing the cursor on `Map` in `Map[String, U32]` and invoking go-to-definition navigates to the `type Map` declaration in the standard library. Previously, go-to-definition only worked on the type arguments (`String`, `U32`) but not on the alias name itself.
+
+This also works for local type aliases defined in the same package.

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_definition_resolver.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_definition_resolver.pony
@@ -121,6 +121,9 @@ primitive DefinitionResolver
     | TokenIds.tk_typeref() =>
       // typerefs have their definition set in their data field
       _data_ast(ast)
+    | TokenIds.tk_typealiasref() =>
+      // type alias refs have their definition set in their data field
+      _data_ast(ast)
     | TokenIds.tk_typeparamref() =>
       // type param refs have their definition set in their data field
       _data_ast(ast)

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
@@ -410,7 +410,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
       | TokenIds.tk_trait() | TokenIds.tk_interface() | TokenIds.tk_type() // entities
       | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be() // method constructs
       | TokenIds.tk_fvar() | TokenIds.tk_flet() | TokenIds.tk_embed() // fields
-      | TokenIds.tk_nominal() // types
+      | TokenIds.tk_nominal() | TokenIds.tk_typealiasref() // types
       | TokenIds.tk_param()
       => true
       else
@@ -508,6 +508,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     | TokenIds.tk_reference()
     | TokenIds.tk_packageref()
     | TokenIds.tk_typeref()
+    | TokenIds.tk_typealiasref()
     | TokenIds.tk_typeparamref()
     // those correspond to the member access dot
     //| TokenIds.tk_newref()

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
@@ -94,7 +94,7 @@ class val PositionIndex
     | TokenIds.tk_trait() | TokenIds.tk_interface() | TokenIds.tk_type()
     | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be()
     | TokenIds.tk_fvar() | TokenIds.tk_flet() | TokenIds.tk_embed()
-    | TokenIds.tk_nominal() | TokenIds.tk_param()
+    | TokenIds.tk_nominal() | TokenIds.tk_typealiasref() | TokenIds.tk_param()
     => true
     else
       false
@@ -181,7 +181,7 @@ class val PositionIndex
         match parent'.id()
         | TokenIds.tk_fun() | TokenIds.tk_be() | TokenIds.tk_new()
         | TokenIds.tk_use()
-        | TokenIds.tk_nominal() =>
+        | TokenIds.tk_nominal() | TokenIds.tk_typealiasref() =>
           return parent'
         end
       end
@@ -194,6 +194,7 @@ class val PositionIndex
         | TokenIds.tk_funref() | TokenIds.tk_beref() | TokenIds.tk_newref() | TokenIds.tk_newberef() // reference to function
         | TokenIds.tk_funchain() | TokenIds.tk_bechain()
         | TokenIds.tk_typeref() // reference to type
+        | TokenIds.tk_typealiasref() // reference to type alias
         | TokenIds.tk_typeparamref() // reference to generic type parameter
         | TokenIds.tk_nominal() // name of a type
         | TokenIds.tk_flet() | TokenIds.tk_fvar() | TokenIds.tk_embed() // fields
@@ -219,7 +220,7 @@ class val PositionIndex
         match parent'.id()
         | TokenIds.tk_actor() | TokenIds.tk_class() | TokenIds.tk_struct()
         | TokenIds.tk_primitive() | TokenIds.tk_trait() | TokenIds.tk_interface()
-        | TokenIds.tk_nominal()
+        | TokenIds.tk_nominal() | TokenIds.tk_typealiasref()
         | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be() =>
           return parent'
         end

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -181,7 +181,9 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
       h,
       _server,
       "definition/_type_alias.pony",
-      [ // `String` type arg in `Map[String, U32]` → String class declaration
+      [ // `Map` type alias in `Map[String, U32]` → Map type alias declaration
+        (17, 13, _DefinitionChecker([("map.pony", (3, 0), (3, 4))]))
+        // `String` type arg in `Map[String, U32]` → String class declaration
         (17, 17, _DefinitionChecker([("string.pony", (8, 0), (8, 5))]))
         // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
         (17, 25, _DefinitionChecker(

--- a/tools/pony-lsp/workspace/ast_identifier.pony
+++ b/tools/pony-lsp/workspace/ast_identifier.pony
@@ -44,6 +44,14 @@ primitive ASTIdentifier
           return id
         end
       end
+    | TokenIds.tk_typealiasref() =>
+      // Type alias references: identifier at child(0) (no package prefix)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
     | TokenIds.tk_fvarref()
     | TokenIds.tk_fletref()
     | TokenIds.tk_embedref() =>

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -146,6 +146,7 @@ primitive HoverFormatter
     // Type references - follow to definition
     | TokenIds.tk_reference() => _format_reference(ast, channel)
     | TokenIds.tk_typeref() => _format_reference(ast, channel)
+    | TokenIds.tk_typealiasref() => _format_reference(ast, channel)
     | TokenIds.tk_nominal() => _format_reference(ast, channel)
 
     // Function/method/constructor calls
@@ -679,6 +680,54 @@ primitive HoverFormatter
         else
           "?"
         end
+      else
+        "?"
+      end
+    | TokenIds.tk_typealiasref() =>
+      // Type alias reference: children are (id, typeargs, cap, eph)
+      try
+        let num_children = type_node.num_children()
+        let type_id = type_node(0)?
+        let base_name =
+          if type_id.id() == TokenIds.tk_id() then
+            type_id.token_value() as String
+          else
+            _extract_type(type_id, channel)
+          end
+
+        // Check for type arguments at child(1)
+        let type_args_str =
+          match \exhaustive\
+            _find_child_by_type(
+              type_node,
+              TokenIds.tk_typeargs(),
+              1)
+          | let ta: AST box => _extract_typeargs(ta, channel)
+          | None => ""
+          end
+
+        // Check for capability starting at child(2)
+        var capability_str: String = ""
+        var idx: USize = 2
+        while idx < num_children do
+          try
+            let child = type_node(idx)?
+            let cap = _extract_capability(child.id())
+            if cap != "" then
+              capability_str = cap
+              break
+            end
+          end
+          idx = idx + 1
+        end
+
+        let cap_str =
+          if capability_str.size() > 0 then
+            " " + capability_str
+          else
+            ""
+          end
+        base_name + type_args_str + cap_str
       else
         "?"
       end


### PR DESCRIPTION
The TK_TYPEALIASREF token introduced in #5145 preserves type alias identity through the compiler pipeline, but the LSP tooling didn't know about it. This adds TK_TYPEALIASREF handling across the LSP so go-to-definition works on type alias names.

For example, go-to-definition on `Map` in `let x: Map[String, U32] val` now navigates to the `type Map` declaration. Previously only the type arguments (`String`, `U32`) resolved — the alias name itself returned no result.

Changes:
- **Definition resolver**: resolve TK_TYPEALIASREF via its data field (same pattern as TK_TYPEREF)
- **Position index**: filter TK_NONE children, refine TK_ID/cap nodes to parent TK_TYPEALIASREF
- **AST identifier helper**: extract identifier from child(0) (no package prefix, unlike TK_TYPEREF which uses child(1)); this feeds document highlight, references, and related features
- **Hover**: format references and extract type info with adjusted child offsets
- **Tests**: added Map go-to-definition test, updated _Alias test from expecting empty to expecting the declaration

Design: #5007