### PR TITLE
Add LSP `textDocument/references` support

### DIFF
--- a/.release-notes/5165.md
+++ b/.release-notes/5165.md
@@ -1,0 +1,3 @@
+## Add LSP `textDocument/references` support
+
+The Pony language server now handles `textDocument/references` requests. References searches across all packages in the workspace, and supports the `includeDeclaration` option to optionally include the definition site in the results.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -17,6 +17,7 @@ For user documentation — installation and editor configuration — see the [po
 | **Document Symbols** | pony-lsp provides a list of available symbols for each opened document. |
 | **Document Highlight** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
 | **Inlay Hints** | Inferred types are shown inline after the variable name for `let` and `var` declarations with no explicit type annotation. |
+| **Find References** | All references to the symbol under the cursor are returned, with optional inclusion of the declaration site. |
 
 New features are actively being added. Contributions are welcome — we are happy to provide help and guidance.
 

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -94,6 +94,21 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] No workspace found for '" +
                 r.json().string() + "'")))
         end
+      | Methods.text_document().references() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .references(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().document_highlight() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -409,6 +424,7 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("openClose", true)
                     .update("save", JsonObject.update("includeText", true)))
                 .update("definitionProvider", true)
+                .update("referencesProvider", true)
                 .update(
                   "diagnosticProvider",
                   JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -102,6 +102,9 @@ primitive TextDocumentMethods
   fun inlay_hint(): String val =>
     "textDocument/inlayHint"
 
+  fun references(): String val =>
+    "textDocument/references"
+
   fun publish_diagnostics(): String val =>
     "textDocument/publishDiagnostics"
 

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -206,6 +206,9 @@ class val _DefinitionChecker
   fun lsp_range(): (None | (I64, I64, I64, I64)) =>
     None
 
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     let got_count =

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -774,6 +774,9 @@ class val _DocHighlightChecker
   fun lsp_range(): (None | (I64, I64, I64, I64)) =>
     None
 
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     match res.result

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -378,6 +378,9 @@ class val _HoverChecker
   fun lsp_range(): (None | (I64, I64, I64, I64)) =>
     None
 
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     if _expected.size() == 0 then

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -124,6 +124,9 @@ class val _InlayHintChecker
   fun lsp_range(): (None | (I64, I64, I64, I64)) =>
     _range
 
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     try

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -82,6 +82,10 @@ actor _LspTestServer is Channel
                 "end",
                 JsonObject.update("line", el).update("character", ec)))
       end
+      match pending.checker.lsp_context()
+      | let ctx: JsonObject =>
+        params = params.update("context", ctx)
+      end
       (_server as BaseProtocol)(
         RequestMessage(id, pending.checker.lsp_method(), params).into_bytes())
       _in_flight(id) = pending

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -18,6 +18,7 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsIncrementCrossFileTest.create(server, fixture))
     test(_RefsTypeNameTest.create(server, fixture))
     test(_RefsLiteralTest.create(server, fixture))
+    test(_RefsSyntheticNewrefTest.create(server, fixture))
 
 class \nodoc\ iso _RefsCountDeclIncludedTest is UnitTest
   """
@@ -216,6 +217,26 @@ class \nodoc\ iso _RefsLiteralTest is UnitTest
       _server,
       _fixture,
       [(16, 20, _RefsChecker([], true))])
+
+class \nodoc\ iso _RefsSyntheticNewrefTest is UnitTest
+  """
+  Requesting references for a `None` type-literal expression (line 26, col 4)
+  returns no results. `None` is desugared by the compiler into a synthetic
+  tk_newref inside a tk_call at the same position; the guard in
+  References.collect detects this pattern and returns early with [].
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/synthetic_newref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(h, _server, _fixture, [(26, 4, _RefsChecker([], true))])
 
 class val _RefsChecker
   """

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -1,0 +1,279 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+primitive _ReferencesIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let fixture = "references/referenced_class.pony"
+    let server = _LspTestServer(workspace_dir)
+    test(_RefsCountDeclIncludedTest.create(server, fixture))
+    test(_RefsCountDeclExcludedTest.create(server, fixture))
+    test(_RefsCountRefIncludedTest.create(server, fixture))
+    test(_RefsIncrementCrossFileTest.create(server, fixture))
+    test(_RefsTypeNameTest.create(server, fixture))
+    test(_RefsLiteralTest.create(server, fixture))
+
+class \nodoc\ iso _RefsCountDeclIncludedTest is UnitTest
+  """
+  Find references to `_count` field from its declaration site,
+  with includeDeclaration = true. Expects 5 locations:
+    referenced_class.pony (16, 6)-(16,12)   declaration
+    referenced_class.pony (19, 4)-(19,10)   in create
+    referenced_class.pony (22, 4)-(22,10)   first in increment
+    referenced_class.pony (22,13)-(22,19)   second in increment
+    referenced_class.pony (23, 4)-(23,10)   return
+
+  referenced_class.pony layout (0-indexed lines/cols):
+    line  0:    class ReferencedClass
+    line  1-15: docstring
+    line 16:      var _count: U32 = 0     _count at (16,6)-(16,12)
+    line 18:      new create() =>
+    line 19:        _count = 0            _count at (19,4)-(19,10)
+    line 21:      fun ref increment(): U32 =>   increment at (21,10)-(21,19)
+    line 22:        _count = _count + 1
+                            _count at (22,4)-(22,10) and (22,13)-(22,19)
+    line 23:        _count                _count at (23,4)-(23,10)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/count_decl_included"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (16, 6, _RefsChecker(
+        [ ("referenced_class.pony", 16, 6, 16, 12)
+          ("referenced_class.pony", 19, 4, 19, 10)
+          ("referenced_class.pony", 22, 4, 22, 10)
+          ("referenced_class.pony", 22, 13, 22, 19)
+          ("referenced_class.pony", 23, 4, 23, 10)], true))])
+
+class \nodoc\ iso _RefsCountDeclExcludedTest is UnitTest
+  """
+  Find references to `_count` field from its declaration site,
+  with includeDeclaration = false. Expects 4 locations (no declaration).
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/count_decl_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (16, 6, _RefsChecker(
+        [ ("referenced_class.pony", 19, 4, 19, 10)
+          ("referenced_class.pony", 22, 4, 22, 10)
+          ("referenced_class.pony", 22, 13, 22, 19)
+          ("referenced_class.pony", 23, 4, 23, 10)], false))])
+
+class \nodoc\ iso _RefsCountRefIncludedTest is UnitTest
+  """
+  Find references to `_count` field from a reference site (line 23, col 4),
+  with includeDeclaration = true. Expects the same 5 locations as from
+  the declaration.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/count_ref_included"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (23, 4, _RefsChecker(
+        [ ("referenced_class.pony", 16, 6, 16, 12)
+          ("referenced_class.pony", 19, 4, 19, 10)
+          ("referenced_class.pony", 22, 4, 22, 10)
+          ("referenced_class.pony", 22, 13, 22, 19)
+          ("referenced_class.pony", 23, 4, 23, 10)], true))])
+
+class \nodoc\ iso _RefsIncrementCrossFileTest is UnitTest
+  """
+  Find references to `increment` method from its declaration site,
+  with includeDeclaration = true. Expects 2 locations:
+    referenced_class.pony (21,10)-(21,19)  declaration
+    references_user.pony  (12, 8)-(12,17)  reference in ReferencesUser.use_it
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/increment_cross_file"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (21, 10, _RefsChecker(
+        [ ("referenced_class.pony", 21, 10, 21, 19)
+          ("references_user.pony", 12, 8, 12, 17)], true))])
+
+class \nodoc\ iso _RefsTypeNameTest is UnitTest
+  """
+  Find references to `ReferencedClass` from its declaration name (line 0,
+  col 6), with includeDeclaration = true. Expects 2 locations:
+    referenced_class.pony (0, 6)-(0,21)   class declaration
+    references_user.pony  (11,18)-(11,33)  type annotation in use_it param
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/type_name"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (0, 6, _RefsChecker(
+        [ ("referenced_class.pony", 0, 6, 0, 21)
+          ("references_user.pony", 11, 18, 11, 33)], true))])
+
+class \nodoc\ iso _RefsLiteralTest is UnitTest
+  """
+  Requesting references for a literal value (the `0` on line 16)
+  returns no results.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/literal"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [(16, 20, _RefsChecker([], true))])
+
+class val _RefsChecker
+  """
+  Validates a textDocument/references response against expected locations.
+  Each expected location is (filename_basename, start_line, start_char,
+  end_line, end_char).
+  """
+  let _expected: Array[(String, I64, I64, I64, I64)] val
+  let _include_declaration: Bool
+
+  new val create(
+    expected: Array[(String, I64, I64, I64, I64)] val,
+    include_declaration: Bool = true)
+  =>
+    _expected = expected
+    _include_declaration = include_declaration
+
+  fun lsp_method(): String =>
+    Methods.text_document().references()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    JsonObject.update("includeDeclaration", _include_declaration)
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    match res.result
+    | let arr: JsonArray =>
+      let got = arr.size()
+      let want = _expected.size()
+      if not h.assert_eq[USize](
+        want,
+        got,
+        "Expected " + want.string() + " references, got " + got.string())
+      then
+        ok = false
+        for item in arr.values() do
+          try
+            let uri = JsonNav(item)("uri").as_string()?
+            let file = Path.base(Uris.to_path(uri))
+            let range = JsonNav(item)("range")
+            let sl = range("start")("line").as_i64()?
+            let sc = range("start")("character").as_i64()?
+            let el = range("end")("line").as_i64()?
+            let ec = range("end")("character").as_i64()?
+            h.log(
+              "  actual ref " + file +
+              " (" + sl.string() + ", " + sc.string() +
+              ")–(" + el.string() + ", " + ec.string() + ")")
+          end
+        end
+      end
+      for (exp_file, exp_sl, exp_sc, exp_el, exp_ec) in _expected.values() do
+        var found = false
+        for item in arr.values() do
+          try
+            let uri = JsonNav(item)("uri").as_string()?
+            let file = Path.base(Uris.to_path(uri))
+            let range = JsonNav(item)("range")
+            let sl = range("start")("line").as_i64()?
+            let sc = range("start")("character").as_i64()?
+            let el = range("end")("line").as_i64()?
+            let ec = range("end")("character").as_i64()?
+            if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc)
+              and (el == exp_el) and (ec == exp_ec)
+            then
+              found = true
+              break
+            end
+          end
+        end
+        if not h.assert_true(
+          found,
+          "Expected ref " + exp_file +
+          " (" + exp_sl.string() + ", " + exp_sc.string() +
+          ")–(" + exp_el.string() + ", " + exp_ec.string() + ") not found")
+        then
+          ok = false
+        end
+      end
+    else
+      if _expected.size() > 0 then
+        ok = false
+        h.log("Expected references but got null/non-array")
+      end
+    end
+    ok

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -16,7 +16,9 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsCountRefIncludedTest.create(server, fixture))
     test(_RefsCountRefExcludedTest.create(server, fixture))
     test(_RefsIncrementCrossFileTest.create(server, fixture))
+    test(_RefsIncrementDeclExcludedTest.create(server, fixture))
     test(_RefsTypeNameTest.create(server, fixture))
+    test(_RefsTypeNameDeclExcludedTest.create(server, fixture))
     test(_RefsLiteralTest.create(server, fixture))
     test(_RefsSyntheticNewrefTest.create(server, fixture))
 
@@ -170,6 +172,33 @@ class \nodoc\ iso _RefsIncrementCrossFileTest is UnitTest
         [ ("referenced_class.pony", 21, 10, 21, 19)
           ("references_user.pony", 12, 8, 12, 17)], true))])
 
+class \nodoc\ iso _RefsIncrementDeclExcludedTest is UnitTest
+  """
+  Find references to `increment` method from its declaration site,
+  with includeDeclaration = false. Expects 1 location (no declaration):
+    references_user.pony  (12, 8)-(12,17)  reference in ReferencesUser.use_it
+  Exercises the tk_id promotion path: the cursor lands on the tk_id child
+  of the tk_fun node, which is promoted to tk_fun before the exclusion key
+  is computed.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/increment_decl_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (21, 10, _RefsChecker(
+        [("references_user.pony", 12, 8, 12, 17)], false))])
+
 class \nodoc\ iso _RefsTypeNameTest is UnitTest
   """
   Find references to `ReferencedClass` from its declaration name (line 0,
@@ -195,6 +224,33 @@ class \nodoc\ iso _RefsTypeNameTest is UnitTest
       [ (0, 6, _RefsChecker(
         [ ("referenced_class.pony", 0, 6, 0, 21)
           ("references_user.pony", 11, 18, 11, 33)], true))])
+
+class \nodoc\ iso _RefsTypeNameDeclExcludedTest is UnitTest
+  """
+  Find references to `ReferencedClass` from its declaration name (line 0,
+  col 6), with includeDeclaration = false. Expects 1 location (no declaration):
+    references_user.pony  (11,18)-(11,33)  type annotation in use_it param
+  Exercises the tk_id promotion path for entity declarations: the cursor
+  lands on the tk_id child of tk_class, which is promoted to tk_class before
+  the exclusion key is computed.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/type_name_decl_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (0, 6, _RefsChecker(
+        [("references_user.pony", 11, 18, 11, 33)], false))])
 
 class \nodoc\ iso _RefsLiteralTest is UnitTest
   """

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -14,6 +14,7 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsCountDeclIncludedTest.create(server, fixture))
     test(_RefsCountDeclExcludedTest.create(server, fixture))
     test(_RefsCountRefIncludedTest.create(server, fixture))
+    test(_RefsCountRefExcludedTest.create(server, fixture))
     test(_RefsIncrementCrossFileTest.create(server, fixture))
     test(_RefsTypeNameTest.create(server, fixture))
     test(_RefsLiteralTest.create(server, fixture))
@@ -114,6 +115,33 @@ class \nodoc\ iso _RefsCountRefIncludedTest is UnitTest
           ("referenced_class.pony", 22, 4, 22, 10)
           ("referenced_class.pony", 22, 13, 22, 19)
           ("referenced_class.pony", 23, 4, 23, 10)], true))])
+
+class \nodoc\ iso _RefsCountRefExcludedTest is UnitTest
+  """
+  Find references to `_count` field from a reference site (line 23, col 4),
+  with includeDeclaration = false. Expects 4 locations (no declaration),
+  same as _RefsCountDeclExcludedTest but starting from a reference site.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "references/integration/count_ref_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (23, 4, _RefsChecker(
+        [ ("referenced_class.pony", 19, 4, 19, 10)
+          ("referenced_class.pony", 22, 4, 22, 10)
+          ("referenced_class.pony", 22, 13, 22, 19)
+          ("referenced_class.pony", 23, 4, 23, 10)], false))])
 
 class \nodoc\ iso _RefsIncrementCrossFileTest is UnitTest
   """

--- a/tools/pony-lsp/test/_response_checker.pony
+++ b/tools/pony-lsp/test/_response_checker.pony
@@ -1,4 +1,5 @@
 use ".."
+use "json"
 use "pony_test"
 
 interface val _ResponseChecker
@@ -9,4 +10,5 @@ interface val _ResponseChecker
   """
   fun lsp_method(): String
   fun lsp_range(): (None | (I64, I64, I64, I64))
+  fun lsp_context(): (None | JsonObject)
   fun check(res: ResponseMessage val, h: TestHelper): Bool

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -27,6 +27,7 @@ actor Main is TestList
     _DefinitionIntegrationTests.make().tests(test)
     _DocumentHighlightIntegrationTests.make().tests(test)
     _InlayHintIntegrationTests.make().tests(test)
+    _ReferencesIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/references/referenced_class.pony
+++ b/tools/pony-lsp/test/workspace/references/referenced_class.pony
@@ -1,0 +1,24 @@
+class ReferencedClass
+  """
+  Demonstrates same-file and cross-file references.
+
+  Place the cursor on `_count` (on the `var` line, in `create`, or anywhere
+  in `increment`) and invoke Find All References. Expect 5 locations: the
+  field declaration and the four uses in `create` and `increment`.
+
+  Place the cursor on `increment` (on the `fun ref` line) and invoke Find All
+  References. Expect 2 locations: the declaration here and the call in
+  references_user.pony.
+
+  Place the cursor on `ReferencedClass` (the class name on line 1) and invoke
+  Find All References. Expect locations in both files: the declaration here
+  and the parameter type annotation in references_user.pony.
+  """
+  var _count: U32 = 0
+
+  new create() =>
+    _count = 0
+
+  fun ref increment(): U32 =>
+    _count = _count + 1
+    _count

--- a/tools/pony-lsp/test/workspace/references/referenced_class.pony
+++ b/tools/pony-lsp/test/workspace/references/referenced_class.pony
@@ -22,3 +22,6 @@ class ReferencedClass
   fun ref increment(): U32 =>
     _count = _count + 1
     _count
+
+  fun maybe(): (U32 | None) =>
+    None

--- a/tools/pony-lsp/test/workspace/references/references.pony
+++ b/tools/pony-lsp/test/workspace/references/references.pony
@@ -1,0 +1,14 @@
+"""
+Test fixtures for exercising LSP find-references functionality.
+
+Open referenced_class.pony or references_user.pony in an LSP-aware editor
+while the Pony language server is active. Place the cursor on any symbol
+described in the class docstrings below and invoke Find All References.
+
+The editor should show all locations where that symbol is used across the
+workspace, including both files. Placing the cursor on a declaration or any
+reference to the same symbol produces the same set of locations.
+
+To test `includeDeclaration` behaviour: some editors expose this as an option.
+When disabled, the declaration site should not appear in the results list.
+"""

--- a/tools/pony-lsp/test/workspace/references/references_user.pony
+++ b/tools/pony-lsp/test/workspace/references/references_user.pony
@@ -1,0 +1,13 @@
+class ReferencesUser
+  """
+  Uses ReferencedClass to demonstrate cross-file reference discovery.
+
+  Place the cursor on `increment` (on the call line) and invoke Find All
+  References. Expect 2 locations: the call here and the declaration in
+  referenced_class.pony.
+
+  Place the cursor on `ReferencedClass` (the parameter type annotation) and
+  invoke Find All References. Expect locations in both files.
+  """
+  fun use_it(obj: ReferencedClass): U32 =>
+    obj.increment()

--- a/tools/pony-lsp/workspace/ast_identifier.pony
+++ b/tools/pony-lsp/workspace/ast_identifier.pony
@@ -1,0 +1,81 @@
+use "pony_compiler"
+
+primitive ASTIdentifier
+  """
+  Maps an AST node to the sub-node whose source span should be used as its
+  highlight or reference span — usually the identifier token.
+  """
+  fun identifier_node(ast: AST box): AST box =>
+    """
+    Return the identifier child node of a compound AST node — the tk_id token
+    that carries the symbol's name and source span. Returns `ast` itself if no
+    such child is found.
+    """
+    match ast.id()
+    | TokenIds.tk_class()
+    | TokenIds.tk_actor()
+    | TokenIds.tk_trait()
+    | TokenIds.tk_interface()
+    | TokenIds.tk_primitive()
+    | TokenIds.tk_type()
+    | TokenIds.tk_struct()
+    | TokenIds.tk_flet()
+    | TokenIds.tk_fvar()
+    | TokenIds.tk_embed()
+    | TokenIds.tk_let()
+    | TokenIds.tk_var()
+    | TokenIds.tk_param() =>
+      // Declarations: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fun()
+    | TokenIds.tk_be()
+    | TokenIds.tk_new()
+    | TokenIds.tk_nominal()
+    | TokenIds.tk_typeref() =>
+      // Methods/types: identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fvarref()
+    | TokenIds.tk_fletref()
+    | TokenIds.tk_embedref() =>
+      // Field references: field name identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_funref()
+    | TokenIds.tk_beref()
+    | TokenIds.tk_newref()
+    | TokenIds.tk_newberef()
+    | TokenIds.tk_funchain()
+    | TokenIds.tk_bechain() =>
+      // Method call references: method name is the sibling of
+      // the receiver child
+      try
+        let receiver = ast.child() as AST
+        let method = receiver.sibling() as AST
+        if method.id() == TokenIds.tk_id() then
+          return method
+        end
+      end
+    | TokenIds.tk_reference() =>
+      // Variable references: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    end
+    ast

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -121,7 +121,7 @@ class ref _HighlightCollector is ASTVisitor
     end
 
     if matches then
-      let hl_node = _node_to_highlight(ast)
+      let hl_node = ASTIdentifier.identifier_node(ast)
       (let start_pos, let end_pos) = hl_node.span()
       // Deduplicate: skip if this start position was already added
       // (e.g. declaration node and its tk_id child can both resolve
@@ -142,77 +142,3 @@ class ref _HighlightCollector is ASTVisitor
 
   fun ref highlights(): Array[LspPositionRange] =>
     _highlights
-
-  fun _node_to_highlight(ast: AST box): AST box =>
-    """
-    Return the sub-node whose source span should be highlighted — usually the
-    identifier token.
-    """
-    match ast.id()
-    | TokenIds.tk_class()
-    | TokenIds.tk_actor()
-    | TokenIds.tk_trait()
-    | TokenIds.tk_interface()
-    | TokenIds.tk_primitive()
-    | TokenIds.tk_type()
-    | TokenIds.tk_struct()
-    | TokenIds.tk_flet()
-    | TokenIds.tk_fvar()
-    | TokenIds.tk_embed()
-    | TokenIds.tk_let()
-    | TokenIds.tk_var()
-    | TokenIds.tk_param() =>
-      // Declarations: identifier at child(0)
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_fun()
-    | TokenIds.tk_be()
-    | TokenIds.tk_new()
-    | TokenIds.tk_nominal()
-    | TokenIds.tk_typeref() =>
-      // Methods/types: identifier at child(1)
-      try
-        let id = ast(1)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_fvarref()
-    | TokenIds.tk_fletref()
-    | TokenIds.tk_embedref() =>
-      // Field references: field name identifier at child(1)
-      try
-        let id = ast(1)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_funref()
-    | TokenIds.tk_beref()
-    | TokenIds.tk_newref()
-    | TokenIds.tk_newberef()
-    | TokenIds.tk_funchain()
-    | TokenIds.tk_bechain() =>
-      // Method call references: method name is
-      // the sibling of the receiver child
-      try
-        let receiver = ast.child() as AST
-        let method = receiver.sibling() as AST
-        if method.id() == TokenIds.tk_id() then
-          return method
-        end
-      end
-    | TokenIds.tk_reference() =>
-      // Variable references: identifier at child(0)
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    end
-    ast

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -88,7 +88,7 @@ primitive References
       // are all blocked from appearing in the results.
       try
         let decl_file = target.source_file() as String val
-        (let decl_start, _) = node_to_highlight(target).span()
+        (let decl_start, _) = ASTIdentifier.identifier_node(target).span()
         collector.exclude(
           recover val
             decl_file + ":" +
@@ -108,80 +108,6 @@ primitive References
       end
     end
     collector.locations()
-
-  fun node_to_highlight(ast: AST box): AST box =>
-    """
-    Return the sub-node whose source span should be highlighted — usually the
-    identifier token.
-    """
-    match ast.id()
-    | TokenIds.tk_class()
-    | TokenIds.tk_actor()
-    | TokenIds.tk_trait()
-    | TokenIds.tk_interface()
-    | TokenIds.tk_primitive()
-    | TokenIds.tk_type()
-    | TokenIds.tk_struct()
-    | TokenIds.tk_flet()
-    | TokenIds.tk_fvar()
-    | TokenIds.tk_embed()
-    | TokenIds.tk_let()
-    | TokenIds.tk_var()
-    | TokenIds.tk_param() =>
-      // Declarations: identifier at child(0)
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_fun()
-    | TokenIds.tk_be()
-    | TokenIds.tk_new()
-    | TokenIds.tk_nominal()
-    | TokenIds.tk_typeref() =>
-      // Methods/types: identifier at child(1)
-      try
-        let id = ast(1)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_fvarref()
-    | TokenIds.tk_fletref()
-    | TokenIds.tk_embedref() =>
-      // Field references: field name identifier at child(1)
-      try
-        let id = ast(1)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_funref()
-    | TokenIds.tk_beref()
-    | TokenIds.tk_newref()
-    | TokenIds.tk_newberef()
-    | TokenIds.tk_funchain()
-    | TokenIds.tk_bechain() =>
-      // Method call references: method name is the sibling of
-      // the receiver child
-      try
-        let receiver = ast.child() as AST
-        let method = receiver.sibling() as AST
-        if method.id() == TokenIds.tk_id() then
-          return method
-        end
-      end
-    | TokenIds.tk_reference() =>
-      // Variable references: identifier at child(0)
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    end
-    ast
 
 class ref _ReferenceCollector is ASTVisitor
   """
@@ -229,7 +155,7 @@ class ref _ReferenceCollector is ASTVisitor
     end
 
     if matches then
-      let hl_node = References.node_to_highlight(ast)
+      let hl_node = ASTIdentifier.identifier_node(ast)
       (let start_pos, let end_pos) = hl_node.span()
       // Deduplicate: include file in key since multiple modules share
       // line numbers. Pre-excluded keys (declaration site) are in _seen.

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -1,0 +1,254 @@
+use ".."
+use "collections"
+use "pony_compiler"
+
+primitive References
+  """
+  Collects reference locations for a given AST node across all packages in the
+  workspace, by walking every module AST and finding all nodes that resolve to
+  the same definition.
+  """
+  fun collect(
+    node: AST box,
+    packages: Map[String, PackageState] box,
+    include_declaration: Bool): Array[LspLocation]
+  =>
+    """
+    Walk all module ASTs across all packages and return the source locations of
+    all nodes that resolve to the same definition as `node`. Pass
+    `include_declaration = false` to exclude the definition site itself.
+    """
+    // Literals have no referenceable identity — no references.
+    let nid = node.id()
+    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
+      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
+      or (nid == TokenIds.tk_string())
+    then
+      return []
+    end
+
+    // Type-literal expressions such as `None` are desugared by the compiler
+    // into implicit constructor calls. The synthetic tk_newref inside a tk_call
+    // at the same position has no referenceable identity — no references.
+    if nid == TokenIds.tk_newref() then
+      try
+        let par = node.parent() as AST box
+        if (par.id() == TokenIds.tk_call()) and
+          (par.position() == node.position())
+        then
+          return []
+        end
+      end
+    end
+
+    // When the cursor lands on the name identifier of an entity declaration,
+    // promote to the entity node so that type references (which resolve to
+    // tk_class, not its tk_id child) are found by the walker.
+    let node' =
+      if nid == TokenIds.tk_id() then
+        try
+          let par = node.parent() as AST box
+          match par.id()
+          | TokenIds.tk_class()
+          | TokenIds.tk_actor()
+          | TokenIds.tk_struct()
+          | TokenIds.tk_primitive()
+          | TokenIds.tk_trait()
+          | TokenIds.tk_interface()
+          | TokenIds.tk_type() =>
+            par
+          else
+            node
+          end
+        else
+          node
+        end
+      else
+        node
+      end
+
+    // Determine the canonical target definition.
+    // If the node has no definitions it IS the definition.
+    let defs = node'.definitions()
+    let target: AST val =
+      if defs.size() > 0 then
+        try
+          AST(defs(0)?.raw)
+        else
+          return []
+        end
+      else
+        AST(node'.raw)
+      end
+
+    let collector = _ReferenceCollector(target)
+    if not include_declaration then
+      // Pre-populate the deduplication set with the declaration's key so that
+      // the declaration site and any sub-nodes that produce the same span
+      // are all blocked from appearing in the results.
+      try
+        let decl_file = target.source_file() as String val
+        (let decl_start, _) = node_to_highlight(target).span()
+        collector.exclude(
+          recover val
+            decl_file + ":" +
+            decl_start.line().string() + ":" +
+            decl_start.column().string()
+          end)
+      end
+    end
+
+    for pkg_state in packages.values() do
+      match pkg_state.package()
+      | let pkg: Package =>
+        for module in pkg.modules() do
+          collector.set_file(module.file)
+          module.ast.visit(collector)
+        end
+      end
+    end
+    collector.locations()
+
+  fun node_to_highlight(ast: AST box): AST box =>
+    """
+    Return the sub-node whose source span should be highlighted — usually the
+    identifier token.
+    """
+    match ast.id()
+    | TokenIds.tk_class()
+    | TokenIds.tk_actor()
+    | TokenIds.tk_trait()
+    | TokenIds.tk_interface()
+    | TokenIds.tk_primitive()
+    | TokenIds.tk_type()
+    | TokenIds.tk_struct()
+    | TokenIds.tk_flet()
+    | TokenIds.tk_fvar()
+    | TokenIds.tk_embed()
+    | TokenIds.tk_let()
+    | TokenIds.tk_var()
+    | TokenIds.tk_param() =>
+      // Declarations: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fun()
+    | TokenIds.tk_be()
+    | TokenIds.tk_new()
+    | TokenIds.tk_nominal()
+    | TokenIds.tk_typeref() =>
+      // Methods/types: identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_fvarref()
+    | TokenIds.tk_fletref()
+    | TokenIds.tk_embedref() =>
+      // Field references: field name identifier at child(1)
+      try
+        let id = ast(1)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    | TokenIds.tk_funref()
+    | TokenIds.tk_beref()
+    | TokenIds.tk_newref()
+    | TokenIds.tk_newberef()
+    | TokenIds.tk_funchain()
+    | TokenIds.tk_bechain() =>
+      // Method call references: method name is the sibling of
+      // the receiver child
+      try
+        let receiver = ast.child() as AST
+        let method = receiver.sibling() as AST
+        if method.id() == TokenIds.tk_id() then
+          return method
+        end
+      end
+    | TokenIds.tk_reference() =>
+      // Variable references: identifier at child(0)
+      try
+        let id = ast(0)?
+        if id.id() == TokenIds.tk_id() then
+          return id
+        end
+      end
+    end
+    ast
+
+class ref _ReferenceCollector is ASTVisitor
+  """
+  AST visitor that collects the source locations of all nodes that resolve to a
+  given target definition AST node, across all modules.
+  """
+  let _target: AST val
+  var _current_file: String
+  let _results: Array[LspLocation] ref
+  let _seen: Set[String]
+
+  new ref create(target: AST val) =>
+    _target = target
+    _current_file = ""
+    _results = Array[LspLocation].create()
+    _seen = Set[String].create()
+
+  fun ref set_file(file: String) =>
+    _current_file = file
+
+  fun ref exclude(key: String) =>
+    """
+    Pre-mark a key as seen so that results at that position are suppressed.
+    Used to exclude the declaration site when includeDeclaration = false.
+    """
+    _seen.set(key)
+
+  fun ref visit(ast: AST box): VisitResult =>
+    // Skip synthetic tk_this nodes: their definitions() resolve to the
+    // enclosing class entity, causing all implicit receivers inside a
+    // class to spuriously match when targeting that class.
+    if ast.id() == TokenIds.tk_this() then
+      return Continue
+    end
+
+    // Check if this node IS the target definition or resolves to it.
+    var matches = (ast == _target)
+    if not matches then
+      for def in ast.definitions().values() do
+        if def == _target then
+          matches = true
+          break
+        end
+      end
+    end
+
+    if matches then
+      let hl_node = References.node_to_highlight(ast)
+      (let start_pos, let end_pos) = hl_node.span()
+      // Deduplicate: include file in key since multiple modules share
+      // line numbers. Pre-excluded keys (declaration site) are in _seen.
+      let key: String val =
+        recover val
+          _current_file + ":" + start_pos.line().string() +
+          ":" + start_pos.column().string()
+        end
+      if not _seen.contains(key) then
+        _seen.set(key)
+        _results.push(
+          LspLocation(
+            Uris.from_path(_current_file),
+            LspPositionRange(
+              LspPosition.from_ast_pos(start_pos),
+              LspPosition.from_ast_pos_end(end_pos))))
+      end
+    end
+    Continue
+
+  fun ref locations(): Array[LspLocation] =>
+    _results

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -576,6 +576,36 @@ actor WorkspaceManager
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be references(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/references request.
+    """
+    this._channel.log("Handling textDocument/references")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let include_declaration: Bool =
+      try
+        JsonNav(request.params)("context")("includeDeclaration").as_bool()?
+      else
+        true
+      end
+    let document_path = Uris.to_path(document_uri)
+    match _find_node_and_module(document_path, line, column)
+    | (let node: AST box, _) =>
+      let locations =
+        References.collect(node, this._packages, include_declaration)
+      var json_arr = JsonArray
+      for loc in locations.values() do
+        json_arr = json_arr.push(loc.to_json())
+      end
+      this._channel.send(ResponseMessage(request.id, json_arr))
+      return
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
   be goto_definition(document_uri: String, request: RequestMessage val) =>
     """
     Handling the textDocument/definition request.

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -542,7 +542,7 @@ actor WorkspaceManager
 
     // For declarations, use identifier span;
     // for references, use the whole node
-    let highlight_node = _get_node_for_highlight(ast)
+    let highlight_node = ASTIdentifier.identifier_node(ast)
     (let start_pos, let end_pos) = highlight_node.span()
     let hover_range =
       LspPositionRange(
@@ -773,74 +773,6 @@ actor WorkspaceManager
       this._channel.log("document not in workspace: " + document_path)
     end
     this._channel.send(ResponseMessage.create(request.id, None))
-
-  fun _get_node_for_highlight(ast: AST box): AST box =>
-    """
-    Get the appropriate node for hover highlighting.
-    For declarations (class, fun, let, etc.), return the identifier child.
-    For references and type nodes, find the identifier within them.
-    Otherwise return the original node.
-    """
-    match ast.id()
-    | TokenIds.tk_class()
-    | TokenIds.tk_actor()
-    | TokenIds.tk_trait()
-    | TokenIds.tk_interface()
-    | TokenIds.tk_primitive()
-    | TokenIds.tk_type()
-    | TokenIds.tk_struct()
-    | TokenIds.tk_flet()
-    | TokenIds.tk_fvar()
-    | TokenIds.tk_embed()
-    | TokenIds.tk_let()
-    | TokenIds.tk_var()
-    | TokenIds.tk_param() =>
-      // Declarations with identifier at child(0)
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_fun()
-    | TokenIds.tk_be()
-    | TokenIds.tk_new()
-    | TokenIds.tk_nominal()
-    | TokenIds.tk_typeref() =>
-      // Declarations/types with identifier
-      // at child(1)
-      try
-        let id = ast(1)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    | TokenIds.tk_funref()
-    | TokenIds.tk_beref()
-    | TokenIds.tk_newref()
-    | TokenIds.tk_newberef()
-    | TokenIds.tk_funchain()
-    | TokenIds.tk_bechain() =>
-      // For method/function references, get
-      // the method name (sibling of receiver)
-      try
-        let receiver = ast.child() as AST
-        let method = receiver.sibling() as AST
-        if method.id() == TokenIds.tk_id() then
-          return method
-        end
-      end
-    | TokenIds.tk_reference() =>
-      // For references, try to find the id child
-      try
-        let id = ast(0)?
-        if id.id() == TokenIds.tk_id() then
-          return id
-        end
-      end
-    end
-    // Default: return original node
-    ast
 
   be dispose() =>
     for package_state in this._packages.values() do


### PR DESCRIPTION


## Context

`textDocument/references` is the standard LSP method for finding all usages of a symbol across the workspace. pony-lsp does not yet implement it, so clients fall back to no results for every reference request.

## Changes

- **`workspace/references.pony`** — new `References` primitive and `_ReferenceCollector` visitor. Walks every module AST in all compiled packages and returns `Location[]` for nodes that resolve to the same definition. Guards filter literals and synthetic `tk_newref` nodes. `includeDeclaration = false` is handled by pre-populating the deduplication set with the declaration's position key, which also suppresses sub-nodes (e.g. the `tk_id` child of `tk_fvar`) that would otherwise produce the same span.
- **Wiring** — method constant in `methods.pony`, `be references` behaviour in `workspace_manager.pony`, route and `referencesProvider: true` capability in `language_server.pony`.
- **Test infrastructure** — `_ResponseChecker` gains a `lsp_context()` method so checkers can inject LSP `context` params (e.g. `includeDeclaration`); `_LspTestServer._dispatch` forwards it. Existing checker classes get a `=> None` stub.
- **6 integration tests** — field references from declaration and reference sites (with/without `includeDeclaration`), cross-file method references, type name references, and the literal no-op guard.


https://github.com/user-attachments/assets/953b91d5-9adb-4c7c-b023-44814fd87c1e

