### PR TITLE
Fix pony-lsp hanging after shutdown and exit

### DIFF
--- a/.release-notes/fix-lsp-exit-hang.md
+++ b/.release-notes/fix-lsp-exit-hang.md
@@ -1,0 +1,3 @@
+## Fix pony-lsp hanging after shutdown and exit
+
+pony-lsp would hang indefinitely after receiving the LSP `shutdown` request followed by the `exit` notification. The process had to be killed manually. The exit handler now properly disposes all actors, allowing the runtime to shut down cleanly.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -259,7 +259,7 @@ actor LanguageServer is (Notifier & RequestSender)
       handle_initialized(n)
     | Methods.exit() =>
       this._channel.log("Exiting.")
-      this._channel.dispose()
+      this.dispose()
       this._env.exitcode(
         if this._state is _ShuttingDown then
           0


### PR DESCRIPTION
The exit notification handler only disposed the channel (stdin), leaving workspace managers and other actors alive. This caused the pony-lsp process to hang indefinitely after receiving the LSP `shutdown` request followed by the `exit` notification.

The fix calls `LanguageServer.dispose()` instead of `_channel.dispose()`, which disposes the router (cascading to all workspace managers) and the channel, allowing the runtime to shut down cleanly.

Closes #5169