### PR TITLE
Fix pony-lsp hanging on startup on Windows

### DIFF
--- a/.release-notes/fix-lsp-windows-stdout.md
+++ b/.release-notes/fix-lsp-windows-stdout.md
@@ -1,0 +1,5 @@
+## Fix pony-lsp hanging on startup on Windows
+
+pony-lsp was unresponsive on Windows when launched by an editor. The LSP base protocol uses explicit `\r\n` sequences in message headers, but Windows opens stdout in text mode by default, which translates every `\n` to `\r\n`. This turned the header separator `\r\n\r\n` into `\r\r\n\r\r\n` on the wire — a sequence that LSP clients don't recognize, causing them to wait forever for the end of the headers.
+
+pony-lsp now sets stdout to binary mode on Windows at startup, so `\r\n` is written to the pipe unchanged.

--- a/tools/pony-lsp/main.pony
+++ b/tools/pony-lsp/main.pony
@@ -2,8 +2,18 @@ use "path:../lib/ponylang/pony_compiler/"
 use "files"
 use "pony_compiler"
 
+// FFI declarations for setting stdout to binary mode on Windows.
+// The LSP base protocol uses explicit \r\n in headers; Windows text mode
+// translates \n to \r\n, producing \r\r\n on the wire which breaks clients.
+use @pony_os_stdout[Pointer[None]]()
+use @_fileno[I32](stream: Pointer[None] tag) if windows
+use @_setmode[I32](fd: I32, mode: I32) if windows
+
 actor Main
   new create(env: Env) =>
+    ifdef windows then
+      @_setmode(@_fileno(@pony_os_stdout()), 0x8000)
+    end
     let channel = Stdio(env.out, env.input)
     let pony_path =
       match \exhaustive\ PonyPath(env)


### PR DESCRIPTION
Windows opens stdout in text mode by default, which translates `\n` to `\r\n`. Since the LSP base protocol uses explicit `\r\n` in message headers, this produced `\r\r\n` on the wire — a sequence that LSP clients (e.g., vscode-languageclient) don't recognize as the header/body separator, causing them to wait forever for the end of headers.

The fix sets stdout to binary mode via `_setmode()` FFI at pony-lsp startup, before any output is written.

Verified empirically: before the fix, raw bytes on the wire showed `0x0D 0x0D 0x0A` (`\r\r\n`); after the fix, `0x0D 0x0A` (`\r\n`) as expected.