### PR TITLE
Add generic type parameter highlights to pony-lsp

### DIFF
--- a/.release-notes/5190.md
+++ b/.release-notes/5190.md
@@ -1,0 +1,3 @@
+## Add generic type parameter highlights to pony-lsp
+
+Placing the cursor on a generic type parameter (e.g., `T` in `class Foo[T]` or `fun apply[T](...)`) now highlights all occurrences of that parameter across the method or class body. Both the declaration site and every use site are returned as `Text` (kind 1) highlights.

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -48,6 +48,12 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightTupleElemRefTest.create(server, fixture))
     test(_DocHighlightBeRefExprTest.create(server, fixture))
     test(_DocHighlightNewBeRefTest.create(server, fixture))
+    test(_DocHighlightGenericMethodTTest.create(server, fixture))
+    test(_DocHighlightGenericClassTTest.create(server, fixture))
+    test(_DocHighlightGenericClassTRefTest.create(server, fixture))
+    test(_DocHighlightGenericPairATest.create(server, fixture))
+    test(_DocHighlightGenericPairBTest.create(server, fixture))
+    test(_DocHighlightConstrainedGenericTTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -1040,6 +1046,180 @@ class \nodoc\ iso _DocHighlightEmbedRefTest is UnitTest
           (86, 4, 86, 10, DocumentHighlightKind.write())
           (91, 4, 91, 10, DocumentHighlightKind.write())
           (114, 4, 114, 10, DocumentHighlightKind.read())]))])
+
+class \nodoc\ iso _DocHighlightGenericMethodTTest is UnitTest
+  """
+  Highlights the type parameter `T` of `apply[T]` in _HighlightGenericMethod.
+  Expects 3 occurrences, all Text kind:
+    line 217 col 12  (T type param declaration in [T])
+    line 217 col 18  (T in parameter type x: T)
+    line 217 col 22  (T in return type ): T)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_method_t"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (217, 12, _DocHighlightChecker(
+        [ (217, 12, 217, 13, DocumentHighlightKind.text())
+          (217, 18, 217, 19, DocumentHighlightKind.text())
+          (217, 22, 217, 23, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightGenericClassTTest is UnitTest
+  """
+  Highlights the type parameter `T` of `_HighlightGenericClass[T]`.
+  Expects 3 occurrences, all Text kind:
+    line 220 col 29  (T type param declaration in class [T])
+    line 228 col 12  (T in parameter type x: T in id)
+    line 228 col 16  (T in return type ): T in id)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_class_t"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (220, 29, _DocHighlightChecker(
+        [ (220, 29, 220, 30, DocumentHighlightKind.text())
+          (228, 12, 228, 13, DocumentHighlightKind.text())
+          (228, 16, 228, 17, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightGenericPairATest is UnitTest
+  """
+  Highlights the type parameter `A` of `_HighlightGenericPair[A, B]`.
+  Expects 4 occurrences, all Text kind:
+    line 231 col 28  (A type param declaration in class [A, B])
+    line 242 col 15  (A in first parameter a: A)
+    line 242 col 25  (A in first return type ): A)
+    line 245 col 16  (A in second parameter a: A)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_pair_a"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (231, 28, _DocHighlightChecker(
+        [ (231, 28, 231, 29, DocumentHighlightKind.text())
+          (242, 15, 242, 16, DocumentHighlightKind.text())
+          (242, 25, 242, 26, DocumentHighlightKind.text())
+          (245, 16, 245, 17, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightGenericPairBTest is UnitTest
+  """
+  Highlights the type parameter `B` of `_HighlightGenericPair[A, B]`.
+  Expects 4 occurrences, all Text kind, independent of the A occurrences:
+    line 231 col 31  (B type param declaration in class [A, B])
+    line 242 col 21  (B in first parameter b: B)
+    line 245 col 22  (B in second parameter b: B)
+    line 245 col 26  (B in second return type ): B)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_pair_b"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (231, 31, _DocHighlightChecker(
+        [ (231, 31, 231, 32, DocumentHighlightKind.text())
+          (242, 21, 242, 22, DocumentHighlightKind.text())
+          (245, 22, 245, 23, DocumentHighlightKind.text())
+          (245, 26, 245, 27, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightGenericClassTRefTest is UnitTest
+  """
+  Highlights the type parameter `T` of `_HighlightGenericClass[T]`,
+  with cursor placed on a USE site (the `T` in `x: T` on line 228 col 12).
+  Expects the same 3 occurrences as _DocHighlightGenericClassTTest:
+    line 220 col 29  (T type param declaration in class [T])
+    line 228 col 12  (T in parameter type x: T in id)
+    line 228 col 16  (T in return type ): T in id)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_class_t_ref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (228, 12, _DocHighlightChecker(
+        [ (220, 29, 220, 30, DocumentHighlightKind.text())
+          (228, 12, 228, 13, DocumentHighlightKind.text())
+          (228, 16, 228, 17, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightConstrainedGenericTTest is UnitTest
+  """
+  Highlights the type parameter `T` of `_HighlightConstrainedGeneric[T: Stringable]`.
+  The constraint (`Stringable`) should NOT appear as a highlight.
+  Expects 3 occurrences, all Text kind:
+    line 248 col 35  (T type param declaration in [T: Stringable])
+    line 255 col 15  (T in parameter type x: T in apply)
+    line 255 col 19  (T in return type ): T in apply)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/constrained_generic_t"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (248, 35, _DocHighlightChecker(
+        [ (248, 35, 248, 36, DocumentHighlightKind.text())
+          (255, 15, 255, 16, DocumentHighlightKind.text())
+          (255, 19, 255, 20, DocumentHighlightKind.text())]))])
 
 class val _DocHighlightChecker
   let _expected: Array[(I64, I64, I64, I64, I64)] val

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -206,3 +206,52 @@ class _NewBeRefExample
   """
   fun ref work(): _BeChainActor tag =>
     _BeChainActor.create()
+
+class _HighlightGenericMethod
+  """
+  Demonstrates type parameter highlights in a generic method.
+
+  Place the cursor on `T` in `apply[T]` to see all 3 occurrences:
+  the type parameter declaration and both type annotations for the
+  parameter and return type.
+  """
+  fun apply[T](x: T): T =>
+    x
+
+class _HighlightGenericClass[T]
+  """
+  Demonstrates type parameter highlights on a generic class.
+
+  Place the cursor on `T` to see all 3 occurrences: the class-level
+  type parameter declaration and both type annotations in the
+  parameter and return type of `id`.
+  """
+  fun id(x: T): T =>
+    x
+
+class _HighlightGenericPair[A, B]
+  """
+  Demonstrates independent type parameter highlights on a class
+  with two type parameters.
+
+  Place the cursor on `A` to see its 4 occurrences: the declaration
+  in `[A, B]` and the three type annotations in `first` and `second`.
+  Place the cursor on `B` to see its 4 independent occurrences: the
+  declaration in `[A, B]` and the three type annotations in `first`
+  and `second`.
+  """
+  fun first(a: A, b: B): A =>
+    a
+
+  fun second(a: A, b: B): B =>
+    b
+
+class _HighlightConstrainedGeneric[T: Stringable]
+  """
+  Demonstrates highlights for a constrained type parameter. The constraint
+  Stringable should not be highlighted when placing the cursor on T.
+  Expects 3 occurrences: the declaration in [T: Stringable] and both type
+  annotations in apply.
+  """
+  fun apply(x: T): T =>
+    x

--- a/tools/pony-lsp/workspace/ast_identifier.pony
+++ b/tools/pony-lsp/workspace/ast_identifier.pony
@@ -24,8 +24,10 @@ primitive ASTIdentifier
     | TokenIds.tk_embed()
     | TokenIds.tk_let()
     | TokenIds.tk_var()
-    | TokenIds.tk_param() =>
-      // Declarations: identifier at child(0)
+    | TokenIds.tk_param()
+    | TokenIds.tk_typeparam()
+    | TokenIds.tk_typeparamref() =>
+      // Identifier at child(0)
       try
         let id = ast(0)?
         if id.id() == TokenIds.tk_id() then

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -58,10 +58,10 @@ primitive DocumentHighlights
     end
 
     // When the cursor lands on the name identifier of an entity declaration
-    // (tk_class, tk_actor, etc.), _refine_node returns the bare tk_id rather
-    // than the enclosing entity node. Promote to the entity node so that
-    // references to the type (which resolve to tk_class, not its tk_id child)
-    // are found by the walker.
+    // (tk_class, tk_actor, etc.) or type parameter declaration (tk_typeparam),
+    // _refine_node returns the bare tk_id rather than the enclosing node.
+    // Promote to the enclosing node so that references (which resolve to
+    // tk_class or tk_typeparam, not their tk_id child) are found by the walker.
     let node' =
       if nid == TokenIds.tk_id() then
         try
@@ -73,7 +73,8 @@ primitive DocumentHighlights
           | TokenIds.tk_primitive()
           | TokenIds.tk_trait()
           | TokenIds.tk_interface()
-          | TokenIds.tk_type() =>
+          | TokenIds.tk_type()
+          | TokenIds.tk_typeparam() =>
             par
           else
             node
@@ -148,6 +149,23 @@ class ref _HighlightCollector is ASTVisitor
     end
 
     if matches then
+      // ponyc synthesizes a nominal self-type as the return type of
+      // auto-generated constructors in generic classes, forming the chain:
+      // tk_new -> tk_nominal -> tk_typeargs -> tk_typeparamref
+      // This internal node resolves to the class's type param but is not a
+      // user-visible occurrence — skip it.
+      try
+        let p = ast.parent() as AST    // tk_typeargs?
+        let gp = p.parent() as AST     // tk_nominal?
+        let ggp = gp.parent() as AST   // tk_new?
+        if (p.id() == TokenIds.tk_typeargs()) and
+          (gp.id() == TokenIds.tk_nominal()) and
+          (ggp.id() == TokenIds.tk_new())
+        then
+          return Continue
+        end
+      end
+
       let kind: I64 =
         if _is_assign_lhs(ast) then
           // LHS of any assignment — covers regular writes,


### PR DESCRIPTION
## Context

The pony-lsp `textDocument/documentHighlight` feature does not recognise type parameter declarations or references. Placing the cursor on `T` in `fun apply[T]` or `class Foo[T]` produces no or incorrect highlights.

## Changes

- `collect()` promotes a cursor-landed `tk_id` to its enclosing `tk_typeparam`, so the walker can match `tk_typeparamref` nodes that resolve to it
- `ASTIdentifier.identifier_node()` maps `tk_typeparam` and `tk_typeparamref` to their `tk_id` child (at index 0) for span computation
- `_HighlightCollector.visit()` filters the synthetic `tk_typeparamref` ponyc inserts as the return type of auto-generated constructors for generic classes (`tk_new → tk_nominal → tk_typeargs → tk_typeparamref`), which would otherwise produce a spurious highlight at the class keyword
- Adds fixture classes and integration tests covering method-level type params, class-level type params, and a two-param generic class

<img width="680" height="284" alt="image" src="https://github.com/user-attachments/assets/cf3a74c0-c9c7-478e-b1c1-316d94073f78" />
