### PR TITLE
Fix compiler crash when passing an array literal to `OutStream.writev`

### DIFF
--- a/.release-notes/fix-issue-2701-array-infer-values-type-alias.md
+++ b/.release-notes/fix-issue-2701-array-infer-values-type-alias.md
@@ -1,0 +1,14 @@
+## Fix compiler crash when passing an array literal to `OutStream.writev`
+
+Previously, the compiler would crash with an assertion failure when an array literal was passed to `env.out.writev` (or any other call expecting a `ByteSeqIter`):
+
+```pony
+actor Main
+  new create(env: Env) =>
+    env.out.writev([])
+    env.out.writev(["foo"; "bar"])
+```
+
+The compiler's element-type inference for array literals, when the antecedent was an interface whose `values` method returned a type alias (such as `ByteSeqIter`, where `ByteSeq` is `(String | Array[U8] val)`), failed to fully strip viewpoint arrows from the inferred type. The leftover arrows eventually reached code generation and triggered an internal assertion.
+
+This has been fixed. Code of the shape above now compiles and runs correctly.

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -120,11 +120,9 @@ static ast_t* detect_values_element_type(pass_opt_t* opt, ast_t* ast,
   if(ast_id(typeparams) == TK_TYPEPARAMS)
     elem_type = reify(elem_type, typeparams, typeargs, opt, true);
 
-  if((ast_id(elem_type) == TK_ARROW) &&
-    (ast_id(ast_child(elem_type)) == TK_THISTYPE))
-    elem_type = ast_childidx(elem_type, 1);
-
-  return elem_type;
+  // Strip `this->` viewpoint arrows, including any that were distributed
+  // into a union/intersection/tuple when a type alias was expanded.
+  return strip_this_arrow(opt, elem_type);
 }
 
 static void find_possible_element_types(pass_opt_t* opt, ast_t* ast,

--- a/test/full-program-tests/array-infer-from-values-interface-type-alias-element/main.pony
+++ b/test/full-program-tests/array-infer-from-values-interface-type-alias-element/main.pony
@@ -1,0 +1,15 @@
+actor Main
+  new create(env: Env) =>
+    // Regression test for ponylang/ponyc#2701 and ponylang/ponyc#2790.
+    //
+    // `OutStream.writev` takes `ByteSeqIter`, an interface whose
+    // `values()` method returns `Iterator[this->ByteSeq box]` where
+    // `ByteSeq` is the type alias `(String | Array[U8] val)`. Array
+    // literal element-type inference used to crash the compiler when
+    // the element type was extracted from that shape, because a
+    // `this->` arrow survived inside a union produced by alias
+    // expansion and eventually reached code generation.
+    env.out.writev([])
+    env.out.writev(["foo"; "bar"])
+    // Mixed-type array exercising both branches of `ByteSeq`.
+    env.out.writev(["foo"; "bar".array(); "baz"])

--- a/test/full-program-tests/array-infer-from-values-local-interface-type-alias-element/main.pony
+++ b/test/full-program-tests/array-infer-from-values-local-interface-type-alias-element/main.pony
@@ -1,0 +1,25 @@
+// Regression test for ponylang/ponyc#2701 and ponylang/ponyc#2790.
+//
+// Mirrors `array-infer-from-values-interface-type-alias-element` with a
+// locally-declared interface and type alias so the regression is pinned
+// to the shape that triggered the crash, not to the stdlib definitions
+// of `ByteSeqIter`/`ByteSeq`. The shape: an interface whose `values()`
+// method returns `Iterator[this->Alias box]` where `Alias` is a type
+// alias that expands into a union. Element-type inference for array
+// literals with this antecedent must recursively strip `this->` arrows
+// from inside the alias-expanded union before the type reaches code
+// generation.
+
+type _Elem is (String | Array[U8] val)
+
+interface val _Elems
+  fun values(): Iterator[this->_Elem box]
+
+primitive _Sink
+  fun apply(iter: _Elems) => None
+
+actor Main
+  new create(env: Env) =>
+    _Sink([])
+    _Sink(["foo"; "bar"])
+    _Sink(["foo"; "bar".array(); "baz"])


### PR DESCRIPTION
Closes #2701 (and the duplicate #2790).

`detect_values_element_type` previously only stripped a top-level `this->` arrow from the inferred element type. When the element type came from a type alias that expanded into a union (like `ByteSeq = (String | Array[U8] val)` in `ByteSeqIter`), the viewpoint pass distributed the `this->` across the union members, so the top-level check saw a `TK_UNIONTYPE` and left the arrows inside. Those arrows reached code generation and tripped the assertion at `codegen/genname.c:63`.

The fix delegates to the existing `strip_this_arrow` helper, which already recurses through union/intersection/tuple. `detect_apply_element_type` has been using it for the same reason — the values path is now in parity with the apply path.

A second full-program test was added in a follow-up commit with a locally-declared interface and type alias, so the regression is pinned to the shape that triggered the crash rather than to the stdlib's `ByteSeqIter`/`ByteSeq` definitions.