### PR TITLE
Fix compiler hang and crash on recursive generic types

### DIFF
--- a/.release-notes/fix-infinite-compile-recursive-interface.md
+++ b/.release-notes/fix-infinite-compile-recursive-interface.md
@@ -1,0 +1,21 @@
+## Fix compiler hang and crash on recursive generic types
+
+Previously, the compiler would hang or crash on two shapes of recursive generic type. Both now compile or produce a normal type error.
+
+A recursive generic interface whose method return type references the same interface with strictly larger type arguments would hang the compiler indefinitely:
+
+```pony
+// Drifting via tuple typeargs (ponylang/ponyc#1216).
+interface Iter[A]
+  fun enum[B](): Iter[(B, A)] => this
+```
+
+A type parameter whose constraint references the parameter itself would crash the compiler with a stack overflow:
+
+```pony
+// Recursive type parameter constraint (ponylang/ponyc#3930).
+fun flatten[A: Array[Array[A]] #read](arrayin: Array[Array[A]]): Array[A] =>
+  ...
+```
+
+The root cause was that `exact_nominal` in the structural subtype checker compared typeargs via `is_eq_typeargs`, which calls back into the subtype machinery and re-enters `check_assume` on the same recursive shapes. Replacing that with a structural AST equality check that compares definition pointers directly — without re-entering the subtype check — eliminates the re-entry while preserving semantic identity (two type parameters that share a source name in different scopes are correctly distinguished). Red Davies originally authored a fix along these lines for ponylang/ponyc#3930. Combined with the new `SAME_DEF_LIMIT` divergence guard in `is_nominal_sub_nominal`, which bounds the depth of any single drifting recursion chain, the compiler now terminates on both shapes above.

--- a/packages/pony_check/generator.pony
+++ b/packages/pony_check/generator.pony
@@ -40,6 +40,19 @@ class CountdownIter[T: (Int & Integer[T] val) = USize] is Iterator[T]
     _cur = res
     res
 
+// NOTE: The structural shape of `GenObj[T]` — combined with
+// `GenerateResult[T]` above and uses like `shuffled_iter[T]():
+// Generator[Iterator[this->T!]]` below — anchors the divergence
+// guard `SAME_DEF_LIMIT` in ponyc's subtype checker
+// (src/libponyc/type/subtype.c, see ponylang/ponyc#1216). During
+// that fix's investigation, pony_check's generator chains were
+// empirically shown to require SAME_DEF_LIMIT >= 3: at K = 2 the
+// guard falsely rejected legitimate compositions here. If you
+// restructure `GenObj` or `GenerateResult` (changing method return
+// types, introducing deeper nesting, or altering which methods are
+// declared versus defaulted), rebuild ponyc and rerun `make test`
+// to confirm pony_check still type-checks. If it does not, the
+// guard's K value may need to be raised.
 trait box GenObj[T]
   fun generate(rnd: Randomness): GenerateResult[T] ?
 

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -50,15 +50,118 @@ static void struct_cant_be_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
     ast_print_type(sub), ast_print_type(super), entity);
 }
 
-static bool exact_nominal(ast_t* a, ast_t* b, pass_opt_t* opt)
+// Structural AST equality on type expressions, used by check_assume to
+// recognize when the current (sub, super) pair has already been pushed
+// onto the assume stack. This must NOT call back into the subtype
+// machinery: the original is_eq_typeargs path went is_eqtype ->
+// is_subtype -> check_assume, which on recursive generic shapes
+// stack-overflowed (ponylang/ponyc#3930), hung indefinitely
+// (ponylang/ponyc#5198), or produced exponential fan-out that hid the
+// SAME_DEF_LIMIT divergence guard from itself (ponylang/ponyc#1216).
+//
+// We compare semantic identity, not source-name identity. For nominals
+// and type parameter references that means comparing the definition
+// AST by pointer (ast_data), with the same dig-through-aliases walk
+// is_typeparam_sub_typeparam uses. Two types that share a source name
+// but live in different namespaces — public types not `use`d together,
+// private types in different packages, or type parameters with the
+// same name from different scopes — are correctly distinguished. A
+// previous iteration of this fix used ast_print_type for the
+// comparison, which collapsed those cases together and was therefore
+// unsound: the printer emits `T` for a type parameter regardless of
+// scope, so a coinductive proof could close on a pair that only looked
+// the same by name.
+static bool exact_type(ast_t* a, ast_t* b)
 {
-  AST_GET_CHILDREN(a, a_pkg, a_id, a_typeargs, a_cap, a_eph);
-  AST_GET_CHILDREN(b, b_pkg, b_id, b_typeargs, b_cap, b_eph);
+  if(a == b)
+    return true;
 
-  ast_t* a_def = (ast_t*)ast_data(a);
-  ast_t* b_def = (ast_t*)ast_data(b);
+  if(ast_id(a) != ast_id(b))
+    return false;
 
-  return (a_def == b_def) && is_eq_typeargs(a, b, NULL, opt);
+  switch(ast_id(a))
+  {
+    case TK_NOMINAL:
+    {
+      // Definition pointer is the type's identity. Package and id
+      // children are redundant given the def and can confusingly print
+      // the same for distinct defs in different namespaces.
+      if(ast_data(a) != ast_data(b))
+        return false;
+
+      // Children of TK_NOMINAL: package, id, typeargs, cap, ephemeral.
+      return exact_type(ast_childidx(a, 2), ast_childidx(b, 2))
+        && (ast_id(ast_childidx(a, 3)) == ast_id(ast_childidx(b, 3)))
+        && (ast_id(ast_childidx(a, 4)) == ast_id(ast_childidx(b, 4)));
+    }
+
+    case TK_TYPEPARAMREF:
+    {
+      // Same dig-through-aliases walk as is_typeparam_sub_typeparam.
+      // Two type parameters with the same source name in different
+      // scopes have different defs and are distinct here.
+      ast_t* a_def = (ast_t*)ast_data(a);
+      ast_t* b_def = (ast_t*)ast_data(b);
+      while((ast_data(a_def) != NULL) && (a_def != ast_data(a_def)))
+        a_def = (ast_t*)ast_data(a_def);
+      while((ast_data(b_def) != NULL) && (b_def != ast_data(b_def)))
+        b_def = (ast_t*)ast_data(b_def);
+      if(a_def != b_def)
+        return false;
+
+      // Children of TK_TYPEPARAMREF: id, cap, ephemeral.
+      return (ast_id(ast_childidx(a, 1)) == ast_id(ast_childidx(b, 1)))
+        && (ast_id(ast_childidx(a, 2)) == ast_id(ast_childidx(b, 2)));
+    }
+
+    case TK_TYPEALIASREF:
+    {
+      // Type aliases are normally unfolded before subtype checking, so
+      // this case is unlikely to fire in practice — but if one ever
+      // reaches here, definition-pointer equality is the right
+      // semantic identity check (the same reasoning as TK_NOMINAL).
+      if(ast_data(a) != ast_data(b))
+        return false;
+
+      // Children of TK_TYPEALIASREF: id, typeargs, cap, ephemeral.
+      return exact_type(ast_childidx(a, 1), ast_childidx(b, 1))
+        && (ast_id(ast_childidx(a, 2)) == ast_id(ast_childidx(b, 2)))
+        && (ast_id(ast_childidx(a, 3)) == ast_id(ast_childidx(b, 3)));
+    }
+
+    default:
+    {
+      // Default walk: compare children pairwise. Compound type forms
+      // (TK_ARROW, TK_TUPLETYPE, TK_UNIONTYPE, TK_ISECTTYPE,
+      // TK_TYPEARGS) descend into their children. Leaf nodes (caps
+      // like TK_REF/TK_VAL/TK_BOX, TK_THISTYPE, TK_DONTCARETYPE,
+      // TK_NONE, etc.) have no children and pass once their kinds
+      // matched the ast_id check above.
+      //
+      // This is safe because nodes whose identity is carried by
+      // payload data (TK_NOMINAL, TK_TYPEPARAMREF, TK_TYPEALIASREF
+      // and similar) are explicitly handled in their own cases
+      // above. Anything that arrives here is either a structural
+      // composite or a kind-only leaf.
+      ast_t* a_child = ast_child(a);
+      ast_t* b_child = ast_child(b);
+      while((a_child != NULL) && (b_child != NULL))
+      {
+        if(!exact_type(a_child, b_child))
+          return false;
+        a_child = ast_sibling(a_child);
+        b_child = ast_sibling(b_child);
+      }
+      return (a_child == NULL) && (b_child == NULL);
+    }
+  }
+}
+
+static bool exact_nominal(ast_t* a, ast_t* b)
+{
+  pony_assert(ast_id(a) == TK_NOMINAL);
+  pony_assert(ast_id(b) == TK_NOMINAL);
+  return exact_type(a, b);
 }
 
 static ast_t* push_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
@@ -98,8 +201,8 @@ static bool check_assume(ast_t* sub, ast_t* super, pass_opt_t* opt)
     {
       AST_GET_CHILDREN(assumption, assume_sub, assume_super);
 
-      if(exact_nominal(sub, assume_sub, opt) &&
-        exact_nominal(super, assume_super, opt))
+      if(exact_nominal(sub, assume_sub) &&
+        exact_nominal(super, assume_super))
       {
         ret = true;
         break;
@@ -267,7 +370,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         return false;
       }
 
-      // Covariant result.
+      // Covariant result. See the coupling note on the TK_FUN/TK_BE
+      // branch below about divergence on recursive generic interfaces
+      // and the is_nominal_sub_nominal divergence guard.
       if(!is_subtype(sub_result, super_result, errorf, opt))
       {
         if(errorf != NULL)
@@ -303,6 +408,17 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       }
 
       // Covariant result.
+      // NOTE: is_reified_fun_sub_fun recurses into subtype checks at
+      // four sites — the TK_NEW covariant result above, this
+      // TK_FUN/TK_BE covariant result, the contravariant type parameter
+      // constraints below, and the contravariant parameter types below.
+      // Any of these can produce drifting same-def chains on
+      // structurally-recursive generic interfaces (e.g. an interface
+      // method whose return type, parameter type, or type-parameter
+      // constraint references the same interface with strictly larger
+      // type arguments). Termination relies on the divergence guard in
+      // is_nominal_sub_nominal. If you change how any of these four
+      // recursions work, revisit that guard. See ponylang/ponyc#1216.
       if(!is_subtype(sub_result, super_result, errorf, opt))
       {
         if(errorf != NULL)
@@ -329,6 +445,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
     ast_t* sub_constraint = ast_childidx(sub_typeparam, 1);
     ast_t* super_constraint = ast_childidx(super_typeparam, 1);
 
+    // Contravariant recursion. See the coupling note on the TK_FUN/TK_BE
+    // covariant-result branch above about divergence on recursive
+    // generic interfaces and the is_nominal_sub_nominal divergence guard.
     if(!is_x_sub_x(super_constraint, sub_constraint, CHECK_CAP_EQ, errorf,
       opt))
     {
@@ -362,6 +481,9 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
     }
 
     // Contravariant: the super type must be a subtype of the sub type.
+    // See the coupling note on the TK_FUN/TK_BE covariant-result branch
+    // above about divergence on recursive generic interfaces and the
+    // is_nominal_sub_nominal divergence guard.
     if(!is_x_sub_x(super_type, sub_type, CHECK_CAP_SUB, errorf, opt))
     {
       if(errorf != NULL)
@@ -1320,9 +1442,92 @@ static bool is_nominal_sub_nominal(ast_t* sub, ast_t* super,
   check_cap_t check_cap, errorframe_t* errorf, pass_opt_t* opt)
 {
   // N k <: N' k'
+  ast_t* sub_def = (ast_t*)ast_data(sub);
   ast_t* super_def = (ast_t*)ast_data(super);
   if(check_assume(sub, super, opt))
     return true;
+
+  // Guard against structural divergence on recursive generic interfaces.
+  // The coinductive mechanism above (check_assume / exact_nominal) closes
+  // a proof when the same (sub, super) pair recurs with equal type args.
+  // It does not close when the same def pair recurs with drifting type
+  // args, because exact_nominal requires exact structural equality and
+  // drifting typeargs are not structurally equal — so each new frame
+  // fails to match any earlier one on the assume stack. In that case
+  // the recursion grows without bound (see ponylang/ponyc#1216: the
+  // covariant result recursion in is_reified_fun_sub_fun can drive this
+  // via methods like `fun f[B](): I[(B, A)]` on `interface I[A]`).
+  //
+  // If the same (sub_def, super_def) pair has already accumulated
+  // SAME_DEF_LIMIT entries on the assume stack without any of them
+  // matching exactly, the chain is diverging and bailing with `false`
+  // is sound: a convergent proof would have closed through check_assume
+  // by now. Worst case if that reasoning is wrong: programs that should
+  // type check get a spurious "not a subtype" error, still preferable
+  // to a hang. When bailing, we write an ast_error_frame naming the
+  // guard so a user who trips it knows to report it (rather than
+  // assuming their code has a real subtype error).
+  //
+  // SAME_DEF_LIMIT was chosen empirically. The real-world regression
+  // surface is packages/pony_check/generator.pony: the `GenObj[T]`
+  // trait combined with `type GenerateResult[T2] is (T2^ |
+  // ValueAndShrink[T2])` and uses like `shuffled_iter[T]():
+  // Generator[Iterator[this->T!]]` produce drifting same-def chains
+  // during structural subtype checks. K = 2 was empirically refuted:
+  // it rejected pony_check shapes that need more than one drifting
+  // round to reach a closing frame, so the real-world minimum
+  // observed is K >= 3. K = 4 is the current value and leaves one
+  // round of headroom above the observed floor. Validation
+  // procedure if you change K: rebuild ponyc and confirm that
+  // `make test` still cleanly compiles pony_check — if pony_check
+  // fails to type-check, K is too low. Raising K is always safe;
+  // lowering it requires empirical re-verification against
+  // pony_check and any other stdlib shape that might have grown
+  // since. If you restructure GenObj or GenerateResult in
+  // pony_check, rerun the same validation — there is a back-pointer
+  // comment on GenObj in packages/pony_check/generator.pony.
+  //
+  // Coupled to is_reified_fun_sub_fun's covariant-result is_subtype
+  // recursion; if that recursion changes, revisit this guard.
+  {
+    const int SAME_DEF_LIMIT = 4;
+    int count = 0;
+    if(subtype_assume != NULL)
+    {
+      for(ast_t* a = ast_child(subtype_assume); a != NULL; a = ast_sibling(a))
+      {
+        AST_GET_CHILDREN(a, a_sub, a_super);
+        if(((ast_t*)ast_data(a_sub) == sub_def) &&
+           ((ast_t*)ast_data(a_super) == super_def))
+        {
+          if(++count >= SAME_DEF_LIMIT)
+          {
+            // NOTE: The "recursion-divergence guard" substring below is
+            // the marker that BadPonyTest.
+            // RecursiveGenericInterfaceEmitsGuardDiagnostic asserts on.
+            // If you rename it, update that test.
+            if(errorf != NULL)
+            {
+              ast_error_frame(errorf, sub,
+                "%s is not a subtype of %s: the structural subtype "
+                "check was aborted by the recursion-divergence guard "
+                "after %d drifting same-def frames. This is a compiler "
+                "safeguard against unbounded recursion on "
+                "structurally-recursive generic interfaces "
+                "(ponylang/ponyc#1216). If you believe this program "
+                "should type-check, please report it with a minimal "
+                "reproducer so the guard's SAME_DEF_LIMIT can be "
+                "re-evaluated.",
+                ast_print_type(sub), ast_print_type(super),
+                SAME_DEF_LIMIT);
+            }
+            return false;
+          }
+        }
+      }
+    }
+  }
+
   // Add an assumption: sub <: super
   push_assume(sub, super, opt);
 
@@ -1981,6 +2186,11 @@ bool is_subtype_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
 bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt)
 {
   return is_subtype(a, b, errorf, opt) && is_subtype(b, a, errorf, opt);
+}
+
+bool is_exact_type(ast_t* a, ast_t* b)
+{
+  return exact_type(a, b);
 }
 
 bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -26,6 +26,15 @@ bool is_subtype_fun(ast_t* sub, ast_t* super, errorframe_t* errorf,
 
 bool is_eqtype(ast_t* a, ast_t* b, errorframe_t* errorf, pass_opt_t* opt);
 
+// Structural AST equality on type expressions: same kind, same definition
+// pointer for nominals/typeparamrefs, same caps and ephemerality, recursing
+// into typeargs and other compound forms. Cheaper than is_eqtype (does not
+// re-enter is_subtype) and stricter on identity (distinguishes types that
+// share a source name but live in different scopes or namespaces). Used
+// internally to recognize previously-pushed assume-stack entries; exposed
+// here for testing.
+bool is_exact_type(ast_t* a, ast_t* b);
+
 bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,
   pass_opt_t* opt);
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1842,3 +1842,195 @@ TEST_F(BadPonyTest, MatchLiteralCaseWithTypecheckErrorElse)
 
   TEST_ERRORS_1(src, "argument not assignable to parameter");
 }
+
+TEST_F(BadPonyTest, RecursiveGenericInterfaceDoesNotHang)
+{
+  // Regression test for ponylang/ponyc#1216. A recursive generic
+  // interface whose method return type references the same interface
+  // with strictly larger type arguments caused the compiler to hang
+  // indefinitely in the structural subtype check. The divergence guard
+  // in is_nominal_sub_nominal now terminates the check and produces a
+  // normal type error.
+  //
+  // The specific message matched below is incidental — the critical
+  // property under test is that compilation terminates with a diagnostic
+  // rather than hanging. If the error text is refactored, update the
+  // match; the test still serves its purpose as long as it asserts
+  // bounded-time failure on this source.
+  const char* src =
+    "interface Iter[A]\n"
+    "  fun enum[B](): Iter[(B, A)] => this\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+
+TEST_F(BadPonyTest, RecursiveGenericInterfaceEmitsGuardDiagnostic)
+{
+  // Companion to RecursiveGenericInterfaceDoesNotHang: when the
+  // divergence guard in is_nominal_sub_nominal bails on a drifting
+  // recursion it must write an ast_error_frame naming the guard, so a
+  // user who trips it knows they hit a compiler safeguard rather than
+  // a real subtype error. Without this diagnostic breadcrumb, bug
+  // reports from guard-tripping stdlib authors would be
+  // incomprehensible — they would see only a generic "not a subtype"
+  // error with no indication it came from SAME_DEF_LIMIT.
+  const char* src =
+    "interface Iter[A]\n"
+    "  fun enum[B](): Iter[(B, A)] => this\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  const char* errs[] = {"function body isn't the result type", NULL};
+  DO(test_expected_errors(src, "ir", errs));
+
+  // Walk all error frames looking for the guard's diagnostic text.
+  // The exact count and ordering of frames is incidental — what
+  // matters is that somewhere in the error tree the guard's message
+  // is visible. If the text below is refactored in subtype.c, update
+  // this match too; the two are deliberately coupled.
+  bool found_guard_frame = false;
+  for(errormsg_t* e = errors_get_first(opt.check.errors);
+    (e != NULL) && !found_guard_frame; e = e->next)
+  {
+    for(errormsg_t* ef = e->frame; ef != NULL; ef = ef->frame)
+    {
+      if(strstr(ef->msg, "recursion-divergence guard") != NULL)
+      {
+        found_guard_frame = true;
+        break;
+      }
+    }
+  }
+  ASSERT_TRUE(found_guard_frame)
+    << "Expected the divergence guard diagnostic frame to be present in "
+    << "the error output, but it was not found. The guard in "
+    << "is_nominal_sub_nominal (src/libponyc/type/subtype.c) must call "
+    << "ast_error_frame when it bails so users know they hit "
+    << "SAME_DEF_LIMIT rather than a real subtype error.";
+}
+
+TEST_F(BadPonyTest, RecursiveGenericInterfaceNestedWrappingDoesNotHang)
+{
+  // Project-level regression guard for ponylang/ponyc#5198. The
+  // original issue report describes a hang on this program — drifting
+  // by wrapping the interface around itself (I[A] -> I[I[A]]) rather
+  // than via tuple typeargs as in #1216 — but the program already
+  // terminates cleanly with type errors on the parent of this PR's
+  // first commit. Some earlier change incidentally fixed it. This
+  // test is kept as a guard against the shape regressing in future
+  // work, not as proof that this PR is what fixes #5198.
+  //
+  // The specific error messages below are incidental — the critical
+  // property under test is bounded-time failure with diagnostics.
+  // Unlike the tupling drift shape, the nested-wrapping shape also
+  // fails the typearg-constraint check on the wrapped I[A], so two
+  // errors are emitted.
+  const char* src =
+    "interface I[A]\n"
+    "  fun f(): I[I[A]] => this\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERRORS_2(src,
+    "type argument is outside its constraint",
+    "function body isn't the result type");
+}
+
+TEST_F(BadPonyTest, RecursiveTypeParameterConstraintCompiles)
+{
+  // Regression test for ponylang/ponyc#3930. A type parameter whose
+  // constraint references the parameter itself
+  // (`A: Array[Array[A]]`) previously caused a stack overflow in
+  // exact_nominal's semantic typearg equality, crashing the compiler.
+  //
+  // This test lives alongside the recursive-interface regression
+  // tests because the underlying fix is shared: both symptoms come
+  // from exact_nominal calling is_eq_typeargs, which re-enters the
+  // subtype checker and eventually re-enters check_assume for the
+  // same pair — unbounded at depth for recursive type parameter
+  // constraints, and exponentially at each guard-capped chain for
+  // nested-wrapping interfaces.
+  //
+  // Unlike the other recursive-shape tests in this file, this source
+  // is well-formed and must compile successfully.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+
+    "  fun flatten[A: Array[Array[A]] #read](arrayin: Array[Array[A]])\n"
+    "    : Array[A]\n"
+    "  =>\n"
+    "    let rv: Array[A] = Array[A]\n"
+    "    for f in arrayin.values() do\n"
+    "      for g in f.values() do\n"
+    "        rv.push(g)\n"
+    "      end\n"
+    "    end\n"
+    "    rv";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, FBoundedInterfaceWithIntersectionCompiles)
+{
+  // Project-level regression guard for ponylang/ponyc#2399. The
+  // original issue report describes a segfault on this program, but
+  // the program already compiles cleanly on the parent of this PR's
+  // first commit — some earlier change incidentally fixed it. This
+  // test is kept as a guard against the shape regressing in future
+  // work, not as proof that this PR is what fixes #2399.
+  //
+  // The program is well-formed and must compile successfully.
+  const char* src =
+    "interface val X[Y: X[Y]]\n"
+    "  fun apply(y: X[Y])\n"
+
+    "type C is ((A | B) & X[(A | B)])\n"
+
+    "primitive A is X[C]\n"
+    "  fun apply(y: X[C]) => None\n"
+
+    "primitive B is X[C]\n"
+    "  fun apply(y: X[C]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, FBoundedTraitWithSelfApplyEmitsConstraintError)
+{
+  // Project-level regression guard for ponylang/ponyc#2562. The
+  // original issue report describes a segfault on this program, but
+  // the program already produces clean type errors on the parent of
+  // this PR's first commit — some earlier change incidentally fixed
+  // it. This test is kept as a guard against the shape regressing in
+  // future work, not as proof that this PR is what fixes #2562.
+  //
+  // The program is ill-formed: the `apply[X[A]](this)` call produces
+  // a cap mismatch between the inferred argument type and the method
+  // type parameter's constraint. The critical property under test is
+  // bounded-time failure with a diagnostic — the exact wording is
+  // incidental.
+  const char* src =
+    "trait X[A: X[A] box]\n"
+    "  fun apply[B: X[B] box](a: B) =>\n"
+    "    None\n"
+    "  fun f() =>\n"
+    "    apply[X[A]](this)\n"
+
+    "class C is X[C box]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERRORS_2(src,
+    "type argument is outside its constraint",
+    "type argument is outside its constraint");
+}

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1236,3 +1236,284 @@ TEST_F(SubTypeTest, ConsumeRefNotIso)
 
   TEST_ERRORS_1(src, "right side must be a subtype of left side");
 }
+
+TEST_F(SubTypeTest, RecursiveInterfaceCompiles)
+{
+  // Guards against the ponylang/ponyc#1216 fix being too aggressive.
+  // Self-referential interfaces must still type-check via the existing
+  // exact_nominal path, independent of the divergence guard in
+  // is_nominal_sub_nominal.
+  const char* src =
+    "interface I\n"
+    "  fun ref f(): I\n"
+
+    "interface J[A]\n"
+    "  fun ref g(): J[A]\n"
+
+    "class C is I\n"
+    "  fun ref f(): I => this\n"
+
+    "class D[A] is J[A]\n"
+    "  fun ref g(): J[A] => this\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let c: I = C\n"
+    "    let d: J[U32] = D[U32]";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(SubTypeTest, MutuallyRecursiveInterfacesCompile)
+{
+  // Additional ponylang/ponyc#1216 guardrail: mutually-recursive
+  // interfaces where each interface's method returns the other must
+  // still type-check. The subtype check recurses through B's
+  // structural check and back to A, closing the proof via
+  // check_assume/exact_nominal across def-pair boundaries rather than
+  // inside a single def.
+  const char* src =
+    "interface A\n"
+    "  fun ref get_b(): B\n"
+
+    "interface B\n"
+    "  fun ref get_a(): A\n"
+
+    "class ConcreteA is A\n"
+    "  new create() => None\n"
+    "  fun ref get_b(): B => ConcreteB\n"
+
+    "class ConcreteB is B\n"
+    "  new create() => None\n"
+    "  fun ref get_a(): A => ConcreteA\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: A = ConcreteA\n"
+    "    let b: B = ConcreteB";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(SubTypeTest, IsExactTypeDistinguishesTypeParamScopes)
+{
+  // Soundness regression covering jemc's review of the
+  // ponylang/ponyc#1216 / #5198 / #3930 fix. An earlier iteration of
+  // exact_nominal compared assume-stack entries with ast_print_type,
+  // which collapses type parameters that share a source name across
+  // distinct scopes — `_W[T]` on a parameter of one class and `_W[T]`
+  // on a parameter of another class print identically even though
+  // each `T` references its own typeparam definition. With that
+  // comparison, a coinductive proof in check_assume could close on a
+  // pair that only matched by name; that is unsoundness, since the
+  // current pair would not actually have been proved.
+  //
+  // is_exact_type compares definitions by pointer (semantic identity),
+  // so it correctly distinguishes the two cases. The test asserts both
+  // halves of the soundness story:
+  //   1. ast_print_type produces identical strings for the two types
+  //      (proving the previous comparison was wrong on this input).
+  //   2. is_exact_type returns false (proving the new comparison is
+  //      right).
+  // Without (1), the test could not distinguish the new fix from the
+  // old one — it is the counterfactual that turns this into a
+  // regression test for the soundness gap rather than just a behavior
+  // check.
+  const char* src =
+    "class _W[X]\n"
+
+    "class _C1[T]\n"
+    "  fun ref method_c1(p_in_c1: _W[T]) => None\n"
+
+    "class _C2[T]\n"
+    "  fun ref method_c2(p_in_c2: _W[T]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_c1 = type_of("p_in_c1");
+  ast_t* t_c2 = type_of("p_in_c2");
+  ASSERT_NE((void*)NULL, t_c1);
+  ASSERT_NE((void*)NULL, t_c2);
+
+  ASSERT_STREQ(ast_print_type(t_c1), ast_print_type(t_c2));
+
+  ASSERT_FALSE(is_exact_type(t_c1, t_c2));
+}
+
+TEST_F(SubTypeTest, IsExactTypeDistinguishesMethodTypeParamScopes)
+{
+  // Companion to IsExactTypeDistinguishesTypeParamScopes covering the
+  // method-scope collision, which is the more common shape in real
+  // code: two methods on the same class each declare their own type
+  // parameter `T`. The two `T`s are distinct typeparam definitions
+  // and their uses in identically-shaped types must not be conflated.
+  const char* src =
+    "class _W[X]\n"
+
+    "class _C\n"
+    "  fun ref method_a[T](p_in_a: _W[T]) => None\n"
+    "  fun ref method_b[T](p_in_b: _W[T]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_in_a");
+  ast_t* t_b = type_of("p_in_b");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+
+  ASSERT_STREQ(ast_print_type(t_a), ast_print_type(t_b));
+
+  ASSERT_FALSE(is_exact_type(t_a, t_b));
+}
+
+TEST_F(SubTypeTest, IsExactTypeMatchesSameTypeParamRef)
+{
+  // Control case: two uses of the same type parameter from the same
+  // scope must compare exactly equal. Without this guarantee
+  // check_assume could not close legitimate coinductive proofs, and
+  // the existing recursive-interface tests would regress.
+  const char* src =
+    "class _W[X]\n"
+
+    "class _C[T]\n"
+    "  fun ref method_a(p_a: _W[T]) => None\n"
+    "  fun ref method_b(p_b: _W[T]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+}
+
+TEST_F(SubTypeTest, IsExactTypeMatchesIdenticalConcreteNominals)
+{
+  // Control case: identical fully-concrete nominals must compare equal.
+  const char* src =
+    "class _W[X]\n"
+    "primitive _Tag\n"
+
+    "class _C\n"
+    "  fun ref method_a(p_a: _W[_Tag]) => None\n"
+    "  fun ref method_b(p_b: _W[_Tag]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+}
+
+TEST_F(SubTypeTest, IsExactTypeWalksTupleTypes)
+{
+  // Covers the default walk in exact_type for TK_TUPLETYPE: identical
+  // tuple types compare equal; tuples differing in element type or
+  // element order compare unequal. The recursive-interface tests
+  // exercise this implicitly via `Iter[(B, A)]`, but a direct unit
+  // test gives explicit coverage of the compound-walk branch and
+  // matches the rigor of the typeparam-scope tests above.
+  const char* src =
+    "class _C\n"
+    "  fun ref method_a(p_a: (U32, String)) => None\n"
+    "  fun ref method_b(p_b: (U32, String)) => None\n"
+    "  fun ref method_c(p_c: (String, U32)) => None\n"
+    "  fun ref method_d(p_d: (U32, U32)) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ast_t* t_c = type_of("p_c");
+  ast_t* t_d = type_of("p_d");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+  ASSERT_NE((void*)NULL, t_c);
+  ASSERT_NE((void*)NULL, t_d);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+  ASSERT_FALSE(is_exact_type(t_a, t_c));
+  ASSERT_FALSE(is_exact_type(t_a, t_d));
+}
+
+TEST_F(SubTypeTest, IsExactTypeWalksUnionTypes)
+{
+  // Covers the default walk in exact_type for TK_UNIONTYPE: unions
+  // with the same members compare equal; unions with a different
+  // member compare unequal. exact_type compares positionally rather
+  // than as sets — for the assume-stack use case the same source AST
+  // shape always produces the same member order, so positional
+  // comparison is correct.
+  const char* src =
+    "class _C\n"
+    "  fun ref method_a(p_a: (U32 | String)) => None\n"
+    "  fun ref method_b(p_b: (U32 | String)) => None\n"
+    "  fun ref method_c(p_c: (U32 | I32)) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ast_t* t_c = type_of("p_c");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+  ASSERT_NE((void*)NULL, t_c);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+  ASSERT_FALSE(is_exact_type(t_a, t_c));
+}
+
+TEST_F(SubTypeTest, IsExactTypeWalksIntersectionTypes)
+{
+  // Covers the default walk in exact_type for TK_ISECTTYPE:
+  // intersections with the same members compare equal; intersections
+  // with a different member compare unequal. Custom traits avoid any
+  // dependence on the exact intersection behavior of stdlib types.
+  const char* src =
+    "trait _T1\n"
+    "trait _T2\n"
+    "trait _T3\n"
+
+    "class _C\n"
+    "  fun ref method_a(p_a: (_T1 & _T2)) => None\n"
+    "  fun ref method_b(p_b: (_T1 & _T2)) => None\n"
+    "  fun ref method_c(p_c: (_T1 & _T3)) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+
+  ast_t* t_a = type_of("p_a");
+  ast_t* t_b = type_of("p_b");
+  ast_t* t_c = type_of("p_c");
+  ASSERT_NE((void*)NULL, t_a);
+  ASSERT_NE((void*)NULL, t_b);
+  ASSERT_NE((void*)NULL, t_c);
+
+  ASSERT_TRUE(is_exact_type(t_a, t_b));
+  ASSERT_FALSE(is_exact_type(t_a, t_c));
+}


### PR DESCRIPTION
Fixes two compiler bugs on recursive generic types:

- ponylang/ponyc#1216 — `interface Iter[A] fun enum[B](): Iter[(B, A)] => this` (tupling drift) hangs indefinitely.
- ponylang/ponyc#3930 — `fun flatten[A: Array[Array[A]] #read](...)` crashes with a stack overflow.

Also adds project-level regression guard tests for three related shapes (#5198, #2399, #2562) that already terminate cleanly on `main` without this PR's changes — kept as guards against the shapes being broken again by future work. Those three issues are closed separately as already-fixed.

## Root cause

`exact_nominal` in `src/libponyc/type/subtype.c` compared typeargs via `is_eq_typeargs`, which calls `is_eqtype` → `is_subtype` → back into `check_assume` on the same recursive shapes. The re-entry stack-overflowed on #3930 and produced residual exponential fan-out that made the `SAME_DEF_LIMIT` divergence guard unreachable in practice for #1216.

The fix replaces `is_eq_typeargs` in `exact_nominal` with a structural AST equality function (`exact_type`) that compares definition pointers (`ast_data`) for nominals, type parameter references, and type alias references, and walks children for compound forms. It does not call back into the subtype machinery, so the recursion characteristics are preserved while the comparison correctly distinguishes typeparams that share a source name across scopes.

The conceptual fix — avoiding re-entry from `exact_nominal` into the subtype machinery — was originally authored by Red Davies on branch `origin/issue_3930`. An earlier iteration of this PR used `ast_print_type` string comparison; jemc's review identified that as unsound (the printer collapses typeparams sharing a source name across scopes), and the structural AST equality version replaced it. The release notes credit Red in prose, because the cherry-pick will not survive squash-merge as a distinct commit.

## Coverage of each shape

- **#1216:** The `SAME_DEF_LIMIT` guard in `is_nominal_sub_nominal` already bounded the coinductive recursion, but the upstream fan-out kept the compiler CPU-bound past the guard's limit. With `exact_nominal` no longer re-entering the subtype checker, the guard terminates the drift chain immediately.
- **#3930:** Red's fix directly prevents the stack overflow.

Closes #1216
Closes #3930