### PR TITLE
Fix pony-lsp lint failure: line exceeds 80 columns

### DIFF
--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -1194,7 +1194,8 @@ class \nodoc\ iso _DocHighlightGenericClassTRefTest is UnitTest
 
 class \nodoc\ iso _DocHighlightConstrainedGenericTTest is UnitTest
   """
-  Highlights the type parameter `T` of `_HighlightConstrainedGeneric[T: Stringable]`.
+  Highlights the type parameter `T` of
+  `_HighlightConstrainedGeneric[T: Stringable]`.
   The constraint (`Stringable`) should NOT appear as a highlight.
   Expects 3 occurrences, all Text kind:
     line 248 col 35  (T type param declaration in [T: Stringable])


### PR DESCRIPTION
Wrap a docstring line in `_DocHighlightConstrainedGenericTTest` that was 85 characters, causing the `lint-pony-lsp` CI step to fail on main. Introduced in #5190.