### PR TITLE
Close expr_array is_typecheck_error early return leak

### DIFF
--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -476,7 +476,10 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
 
     ast_t* c_type = ast_type(ele);
     if(is_typecheck_error(c_type))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     if(told_type)
     {


### PR DESCRIPTION
When `is_typecheck_error(c_type)` fires after the accumulator loop has run at least one iteration, `type` may be a freshly-allocated orphan tree from a prior `type_union` call. The adjacent `AST_FLAG_JUMPS_AWAY` exit correctly calls `ast_free_unattached(type)` before returning, but the `is_typecheck_error` path did not.

During review, a pre-existing leak of `w_type` (from `consume_type`) on the `told_type` success path was found — freed on the `!is_subtype` error path but not when `is_subtype` succeeds. Filed as #5218.

Closes #5212