### PR TITLE
Close error-path leaks of unparented TK_LITERAL nodes

### DIFF
--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -111,7 +111,10 @@ bool expr_if(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(right, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(right)))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     type = control_type_add_branch(opt, type, right);
   }
@@ -153,7 +156,10 @@ bool expr_iftype(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(right, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(right)))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     type = control_type_add_branch(opt, type, right);
   }
@@ -210,7 +216,10 @@ bool expr_while(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(else_clause)))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     ast_t* prev_type = type;
     type = control_type_add_branch(opt, type, else_clause);
@@ -259,7 +268,10 @@ bool expr_repeat(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(else_clause)))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     ast_t* prev_type = type;
     type = control_type_add_branch(opt, type, else_clause);
@@ -292,7 +304,10 @@ bool expr_try(pass_opt_t* opt, ast_t* ast)
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
     if(is_typecheck_error(ast_type(else_clause)))
+    {
+      ast_free_unattached(type);
       return false;
+    }
 
     type = control_type_add_branch(opt, type, else_clause);
   }
@@ -306,12 +321,16 @@ bool expr_try(pass_opt_t* opt, ast_t* ast)
   ast_t* then_type = ast_type(then_clause);
 
   if(is_typecheck_error(then_type))
+  {
+    ast_free_unattached(type);
     return false;
+  }
 
   if(is_type_literal(then_type))
   {
     ast_error(opt->check.errors, then_clause,
       "Cannot infer type of unused literal");
+    ast_free_unattached(type);
     return false;
   }
 
@@ -346,12 +365,16 @@ bool expr_disposing_block(pass_opt_t* opt, ast_t* ast)
   ast_t* dispose_type = ast_type(dispose_clause);
 
   if(is_typecheck_error(dispose_type))
+  {
+    ast_free_unattached(type);
     return false;
+  }
 
   if(is_type_literal(dispose_type))
   {
     ast_error(opt->check.errors, dispose_clause,
       "Cannot infer type of unused literal");
+    ast_free_unattached(type);
     return false;
   }
 

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -248,6 +248,7 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
         {
           ast_error(opt->check.errors, ast,
             "match marked \\exhaustive\\ is not exhaustive");
+          ast_free_unattached(type);
           return false;
         }
 
@@ -264,7 +265,10 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
         ast_add(else_clause, ref);
 
         if(!expr_typeref(opt, &ref) || !expr_seq(opt, else_clause))
+        {
+          ast_free_unattached(type);
           return false;
+        }
       }
     }
     else
@@ -276,6 +280,7 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
         ast_error(opt->check.errors, ast, "match contains unreachable cases");
         ast_error_continue(opt->check.errors, ast_sibling(exhaustive_at),
           "first unreachable case expression");
+        ast_free_unattached(type);
         return false;
       }
       else if((ast_id(else_clause) != TK_NONE))
@@ -284,6 +289,7 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
           "match is exhaustive, the else clause is unreachable");
         ast_error_continue(opt->check.errors, else_clause,
           "unreachable code");
+        ast_free_unattached(type);
         return false;
       }
     }
@@ -294,7 +300,10 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
     if (!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
     {
       if(is_typecheck_error(ast_type(else_clause)))
+      {
+        ast_free_unattached(type);
         return false;
+      }
 
       type = control_type_add_branch(opt, type, else_clause);
     }

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1735,3 +1735,110 @@ TEST_F(BadPonyTest, MatchTuplePatternFromAliasedTupleUnsound)
     "this capture is unsound",
     "this capture is unsound");
 }
+
+TEST_F(BadPonyTest, IfLiteralBranchWithTypecheckError)
+{
+  // Exercises the error path in expr_if where the first branch
+  // produces a literal type (unparented TK_LITERAL accumulator)
+  // and the second branch has a type error (#5214).
+  const char* src =
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    if true then 1 else Foo.bar(true) end";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}
+
+TEST_F(BadPonyTest, IftypeLiteralBranchWithTypecheckError)
+{
+  // Same pattern for iftype (#5214).
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    _test[C]()\n"
+
+    "  fun _test[A: T]() =>\n"
+    "    iftype A <: C then 1\n"
+    "    else Foo.bar(true) end";
+
+  TEST_ERRORS_1(src,
+    "argument not assignable to parameter");
+}
+
+TEST_F(BadPonyTest, TryLiteralBodyWithTypecheckErrorElse)
+{
+  // Same pattern for try (#5214).
+  const char* src =
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try 1 else Foo.bar(true) end";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}
+
+TEST_F(BadPonyTest, WhileLiteralBodyWithTypecheckErrorElse)
+{
+  // Same pattern for while: the body produces a literal type,
+  // then the else clause has a type error (#5214).
+  const char* src =
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    while true do 1\n"
+    "    else Foo.bar(true) end";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}
+
+TEST_F(BadPonyTest, RepeatLiteralBodyWithTypecheckErrorElse)
+{
+  // Same pattern for repeat (#5214).
+  const char* src =
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    repeat 1 until true\n"
+    "    else Foo.bar(true) end";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}
+
+TEST_F(BadPonyTest, MatchLiteralCaseWithTypecheckErrorElse)
+{
+  // Same pattern for match: case body is a literal, else clause
+  // has a type error. Non-exhaustive match so the else clause
+  // is reached during type checking (#5214).
+  const char* src =
+    "primitive Foo\n"
+    "  fun bar(x: U32): U32 => x\n"
+
+    "class Bar\n"
+    "class Baz\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let b: (Bar | Baz) = Bar\n"
+    "    match b\n"
+    "    | let _: Bar => 1\n"
+    "    else\n"
+    "      Foo.bar(true)\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "argument not assignable to parameter");
+}


### PR DESCRIPTION
When `control_type_add_branch` creates a `TK_LITERAL` wrapper for a literal-typed branch, the result is stored in a local accumulator variable but never parented until `ast_settype` at the end of the function. If a subsequent branch hits `is_typecheck_error` or another error check, the early `return false` leaks that unparented node.

Add `ast_free_unattached(type)` before each early return that can fire after the accumulator has been set. Safe because `ast_free_unattached` is a no-op on NULL and on parented nodes.

Fixed sites:
- `expr_if` (control.c): second-branch typecheck error
- `expr_iftype` (control.c): second-branch typecheck error
- `expr_while` (control.c): else-clause typecheck error
- `expr_repeat` (control.c): else-clause typecheck error
- `expr_try` (control.c): else-clause typecheck error, then-clause typecheck error, then-clause literal type error
- `expr_disposing_block` (control.c): dispose-clause typecheck error, dispose-clause literal type error
- `expr_match` (match.c): exhaustiveness errors, else-clause typecheck error

Closes #5214