### PR TITLE
Close w_type leak on told_type success path in expr_array

### DIFF
--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -511,6 +511,8 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
         ast_free_unattached(w_type);
         return false;
       }
+
+      ast_free_unattached(w_type);
     }
     else
     {


### PR DESCRIPTION
`consume_type` allocates `w_type` at line 488 but it was only freed on the `is_subtype` failure path (line 511). When `is_subtype` succeeds, `w_type` goes out of scope without being freed — one leak per array element for every array literal with an explicit type.

Same severity class as #5213, #5205, and #5199 (compile-time-only).

Closes #5218