### PR TITLE
Add textDocument/references for generic type parameters in pony-lsp

### DIFF
--- a/.release-notes/5209.md
+++ b/.release-notes/5209.md
@@ -1,0 +1,3 @@
+## Add `textDocument/references` for generic type parameters in pony-lsp
+
+Placing the cursor on a generic type parameter declaration (e.g., `T` in `class Foo[T]`) and invoking Find All References now returns all occurrences correctly. Previously, zero results were returned because the cursor-side node was not promoted from `tk_id` to `tk_typeparam` before resolution.

--- a/.release-notes/5209.md
+++ b/.release-notes/5209.md
@@ -1,3 +1,6 @@
 ## Add `textDocument/references` for generic type parameters in pony-lsp
 
-Placing the cursor on a generic type parameter declaration (e.g., `T` in `class Foo[T]`) and invoking Find All References now returns all occurrences correctly. Previously, zero results were returned because the cursor-side node was not promoted from `tk_id` to `tk_typeparam` before resolution.
+Placing the cursor on a generic type parameter declaration (e.g., `T` in `class Foo[T]` or `actor Bar[T: Any val]`) and invoking Find All References now returns all occurrences correctly. Two fixes were required:
+
+- **Zero results from declaration site**: the cursor-side `tk_id` node was not promoted to its parent `tk_typeparam` before resolution, so the walker never matched any references.
+- **Phantom results in generic actors**: ponyc synthesizes a nominal return type for constructors and behaviours in generic types, producing an internal `tk_new`/`tk_be` → `tk_nominal` → `tk_typeargs` → `tk_typeparamref` chain. This phantom node resolved to the type parameter and appeared as a spurious reference; it is now filtered in both `textDocument/references` and `textDocument/documentHighlight`.

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -54,6 +54,7 @@ primitive _DocumentHighlightIntegrationTests is TestList
     test(_DocHighlightGenericPairATest.create(server, fixture))
     test(_DocHighlightGenericPairBTest.create(server, fixture))
     test(_DocHighlightConstrainedGenericTTest.create(server, fixture))
+    test(_DocHighlightGenericActorBeTTest.create(server, fixture))
 
 class \nodoc\ iso _DocHighlightFieldTest
   is UnitTest
@@ -1221,6 +1222,35 @@ class \nodoc\ iso _DocHighlightConstrainedGenericTTest is UnitTest
         [ (248, 35, 248, 36, DocumentHighlightKind.text())
           (255, 15, 255, 16, DocumentHighlightKind.text())
           (255, 19, 255, 20, DocumentHighlightKind.text())]))])
+
+class \nodoc\ iso _DocHighlightGenericActorBeTTest is UnitTest
+  """
+  Highlights the type parameter `T` of `_HighlightGenericActor[T: Any val]`.
+  Exercises the tk_be synthesized-node filter: without the filter a phantom
+  tk_typeparamref from the synthesized behaviour return type would appear as
+  a third result.
+  Expects 2 occurrences, all Text kind:
+    line 258 col 29  (T type param declaration in actor [T: Any val])
+    line 262 col 12  (T in parameter type x: T in be run)
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_highlight/integration/generic_actor_be_t"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ (258, 29, _DocHighlightChecker(
+        [ (258, 29, 258, 30, DocumentHighlightKind.text())
+          (262, 12, 262, 13, DocumentHighlightKind.text())]))])
 
 class val _DocHighlightChecker
   let _expected: Array[(I64, I64, I64, I64, I64)] val

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -1231,7 +1231,7 @@ class \nodoc\ iso _DocHighlightGenericActorBeTTest is UnitTest
   a third result.
   Expects 2 occurrences, all Text kind:
     line 258 col 29  (T type param declaration in actor [T: Any val])
-    line 262 col 12  (T in parameter type x: T in be run)
+    line 266 col 12  (T in parameter type x: T in be run)
   """
   let _server: _LspTestServer
   let _fixture: String val
@@ -1250,7 +1250,7 @@ class \nodoc\ iso _DocHighlightGenericActorBeTTest is UnitTest
       _fixture,
       [ (258, 29, _DocHighlightChecker(
         [ (258, 29, 258, 30, DocumentHighlightKind.text())
-          (262, 12, 262, 13, DocumentHighlightKind.text())]))])
+          (266, 12, 266, 13, DocumentHighlightKind.text())]))])
 
 class val _DocHighlightChecker
   let _expected: Array[(I64, I64, I64, I64, I64)] val

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -21,6 +21,8 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsTypeNameDeclExcludedTest.create(server, fixture))
     test(_RefsLiteralTest.create(server, fixture))
     test(_RefsSyntheticNewrefTest.create(server, fixture))
+    test(_RefsGenericTypeparamDeclIncludedTest.create(server))
+    test(_RefsGenericTypeparamDeclExcludedTest.create(server))
 
 class \nodoc\ iso _RefsCountDeclIncludedTest is UnitTest
   """
@@ -293,6 +295,62 @@ class \nodoc\ iso _RefsSyntheticNewrefTest is UnitTest
 
   fun apply(h: TestHelper) =>
     _RunLspChecks(h, _server, _fixture, [(26, 4, _RefsChecker([], true))])
+
+class \nodoc\ iso _RefsGenericTypeparamDeclIncludedTest is UnitTest
+  """
+  Find references to type parameter `T` of `GenericRefs[T]` from its
+  declaration site (line 0, col 18), with includeDeclaration = true.
+  Expects 3 locations — the declaration and both type annotations in id:
+    generic_refs.pony (0, 18)-(0, 19)   T declaration in class [T]
+    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
+    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+
+  generic_refs.pony layout (0-indexed):
+    line 0:  class GenericRefs[T]    T at (0,18)
+    line 4:    fun id(x: T): T =>    T at (4,12) and (4,16)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/generic_typeparam_decl_included"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/generic_refs.pony",
+      [ (0, 18, _RefsChecker(
+        [ ("generic_refs.pony", 0, 18, 0, 19)
+          ("generic_refs.pony", 4, 12, 4, 13)
+          ("generic_refs.pony", 4, 16, 4, 17)], true))])
+
+class \nodoc\ iso _RefsGenericTypeparamDeclExcludedTest is UnitTest
+  """
+  Find references to type parameter `T` of `GenericRefs[T]` from its
+  declaration site (line 0, col 18), with includeDeclaration = false.
+  Expects 2 locations (no declaration):
+    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
+    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/generic_typeparam_decl_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/generic_refs.pony",
+      [ (0, 18, _RefsChecker(
+        [ ("generic_refs.pony", 4, 12, 4, 13)
+          ("generic_refs.pony", 4, 16, 4, 17)], false))])
 
 class val _RefsChecker
   """

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -23,6 +23,9 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsSyntheticNewrefTest.create(server, fixture))
     test(_RefsGenericTypeparamDeclIncludedTest.create(server))
     test(_RefsGenericTypeparamDeclExcludedTest.create(server))
+    test(_RefsGenericTypeparamRefIncludedTest.create(server))
+    test(_RefsGenericTypeparamRefExcludedTest.create(server))
+    test(_RefsGenericActorBeIncludedTest.create(server))
 
 class \nodoc\ iso _RefsCountDeclIncludedTest is UnitTest
   """
@@ -351,6 +354,92 @@ class \nodoc\ iso _RefsGenericTypeparamDeclExcludedTest is UnitTest
       [ (0, 18, _RefsChecker(
         [ ("generic_refs.pony", 4, 12, 4, 13)
           ("generic_refs.pony", 4, 16, 4, 17)], false))])
+
+class \nodoc\ iso _RefsGenericTypeparamRefIncludedTest is UnitTest
+  """
+  Find references to type parameter `T` of `GenericRefs[T]` from a usage site
+  (line 4, col 12, the `T` in `x: T`), with includeDeclaration = true.
+  Expects the same 3 locations as querying from the declaration site — verifies
+  that the reverse lookup via definitions() on tk_typeparamref resolves
+  correctly.
+
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/generic_typeparam_ref_included"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/generic_refs.pony",
+      [ (4, 12, _RefsChecker(
+        [ ("generic_refs.pony", 0, 18, 0, 19)
+          ("generic_refs.pony", 4, 12, 4, 13)
+          ("generic_refs.pony", 4, 16, 4, 17)], true))])
+
+class \nodoc\ iso _RefsGenericTypeparamRefExcludedTest is UnitTest
+  """
+  Find references to type parameter `T` of `GenericRefs[T]` from a usage site
+  (line 4, col 12, the `T` in `x: T`), with includeDeclaration = false.
+  Expects 2 locations (the two type annotation usages, no declaration):
+    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
+    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/generic_typeparam_ref_excluded"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/generic_refs.pony",
+      [ (4, 12, _RefsChecker(
+        [ ("generic_refs.pony", 4, 12, 4, 13)
+          ("generic_refs.pony", 4, 16, 4, 17)], false))])
+
+class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
+  """
+  Find references to type parameter `T` of `GenericActor[T]` from its
+  declaration site (line 0, col 19), with includeDeclaration = true.
+  Expects 2 locations — declaration and the behaviour parameter:
+    generic_actor.pony (0, 19)-(0, 20)   T declaration in actor [T]
+    generic_actor.pony (4, 12)-(4, 13)   T in parameter type x: T
+
+  This test exercises the tk_be synthesized-node filter: ponyc generates
+  a nominal return type for behaviours in generic actors forming the chain
+  tk_be -> tk_nominal -> tk_typeargs -> tk_typeparamref. Without the filter
+  a third phantom result would appear.
+
+  generic_actor.pony layout (0-indexed):
+    line 0:  actor GenericActor[T]    T at (0,19)
+    line 4:    be run(x: T) =>        T at (4,12)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/generic_actor_be_included"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/generic_actor.pony",
+      [ (0, 19, _RefsChecker(
+        [ ("generic_actor.pony", 0, 19, 0, 20)
+          ("generic_actor.pony", 4, 12, 4, 13)], true))])
 
 class val _RefsChecker
   """

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -305,12 +305,12 @@ class \nodoc\ iso _RefsGenericTypeparamDeclIncludedTest is UnitTest
   declaration site (line 0, col 18), with includeDeclaration = true.
   Expects 3 locations — the declaration and both type annotations in id:
     generic_refs.pony (0, 18)-(0, 19)   T declaration in class [T]
-    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
-    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+    generic_refs.pony (14, 12)-(14, 13)  T in parameter type x: T
+    generic_refs.pony (14, 16)-(14, 17)  T in return type ): T
 
   generic_refs.pony layout (0-indexed):
-    line 0:  class GenericRefs[T]    T at (0,18)
-    line 4:    fun id(x: T): T =>    T at (4,12) and (4,16)
+    line 0:   class GenericRefs[T]    T at (0,18)
+    line 14:    fun id(x: T): T =>    T at (14,12) and (14,16)
   """
   let _server: _LspTestServer
 
@@ -327,16 +327,16 @@ class \nodoc\ iso _RefsGenericTypeparamDeclIncludedTest is UnitTest
       "references/generic_refs.pony",
       [ (0, 18, _RefsChecker(
         [ ("generic_refs.pony", 0, 18, 0, 19)
-          ("generic_refs.pony", 4, 12, 4, 13)
-          ("generic_refs.pony", 4, 16, 4, 17)], true))])
+          ("generic_refs.pony", 14, 12, 14, 13)
+          ("generic_refs.pony", 14, 16, 14, 17)], true))])
 
 class \nodoc\ iso _RefsGenericTypeparamDeclExcludedTest is UnitTest
   """
   Find references to type parameter `T` of `GenericRefs[T]` from its
   declaration site (line 0, col 18), with includeDeclaration = false.
   Expects 2 locations (no declaration):
-    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
-    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+    generic_refs.pony (14, 12)-(14, 13)  T in parameter type x: T
+    generic_refs.pony (14, 16)-(14, 17)  T in return type ): T
   """
   let _server: _LspTestServer
 
@@ -352,17 +352,16 @@ class \nodoc\ iso _RefsGenericTypeparamDeclExcludedTest is UnitTest
       _server,
       "references/generic_refs.pony",
       [ (0, 18, _RefsChecker(
-        [ ("generic_refs.pony", 4, 12, 4, 13)
-          ("generic_refs.pony", 4, 16, 4, 17)], false))])
+        [ ("generic_refs.pony", 14, 12, 14, 13)
+          ("generic_refs.pony", 14, 16, 14, 17)], false))])
 
 class \nodoc\ iso _RefsGenericTypeparamRefIncludedTest is UnitTest
   """
   Find references to type parameter `T` of `GenericRefs[T]` from a usage site
-  (line 4, col 12, the `T` in `x: T`), with includeDeclaration = true.
+  (line 14, col 12, the `T` in `x: T`), with includeDeclaration = true.
   Expects the same 3 locations as querying from the declaration site — verifies
   that the reverse lookup via definitions() on tk_typeparamref resolves
   correctly.
-
   """
   let _server: _LspTestServer
 
@@ -377,18 +376,18 @@ class \nodoc\ iso _RefsGenericTypeparamRefIncludedTest is UnitTest
       h,
       _server,
       "references/generic_refs.pony",
-      [ (4, 12, _RefsChecker(
+      [ (14, 12, _RefsChecker(
         [ ("generic_refs.pony", 0, 18, 0, 19)
-          ("generic_refs.pony", 4, 12, 4, 13)
-          ("generic_refs.pony", 4, 16, 4, 17)], true))])
+          ("generic_refs.pony", 14, 12, 14, 13)
+          ("generic_refs.pony", 14, 16, 14, 17)], true))])
 
 class \nodoc\ iso _RefsGenericTypeparamRefExcludedTest is UnitTest
   """
   Find references to type parameter `T` of `GenericRefs[T]` from a usage site
-  (line 4, col 12, the `T` in `x: T`), with includeDeclaration = false.
+  (line 14, col 12, the `T` in `x: T`), with includeDeclaration = false.
   Expects 2 locations (the two type annotation usages, no declaration):
-    generic_refs.pony (4, 12)-(4, 13)   T in parameter type x: T
-    generic_refs.pony (4, 16)-(4, 17)   T in return type ): T
+    generic_refs.pony (14, 12)-(14, 13)  T in parameter type x: T
+    generic_refs.pony (14, 16)-(14, 17)  T in return type ): T
   """
   let _server: _LspTestServer
 
@@ -403,9 +402,9 @@ class \nodoc\ iso _RefsGenericTypeparamRefExcludedTest is UnitTest
       h,
       _server,
       "references/generic_refs.pony",
-      [ (4, 12, _RefsChecker(
-        [ ("generic_refs.pony", 4, 12, 4, 13)
-          ("generic_refs.pony", 4, 16, 4, 17)], false))])
+      [ (14, 12, _RefsChecker(
+        [ ("generic_refs.pony", 14, 12, 14, 13)
+          ("generic_refs.pony", 14, 16, 14, 17)], false))])
 
 class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
   """
@@ -413,7 +412,7 @@ class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
   declaration site (line 0, col 19), with includeDeclaration = true.
   Expects 2 locations — declaration and the behaviour parameter:
     generic_actor.pony (0, 19)-(0, 20)   T declaration in actor [T]
-    generic_actor.pony (4, 12)-(4, 13)   T in parameter type x: T
+    generic_actor.pony (8, 12)-(8, 13)   T in parameter type x: T
 
   This test exercises the tk_be synthesized-node filter: ponyc generates
   a nominal return type for behaviours in generic actors forming the chain
@@ -421,8 +420,8 @@ class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
   a third phantom result would appear.
 
   generic_actor.pony layout (0-indexed):
-    line 0:  actor GenericActor[T]    T at (0,19)
-    line 4:    be run(x: T) =>        T at (4,12)
+    line 0:  actor GenericActor[T: Any val]    T at (0,19)
+    line 8:    be run(x: T) =>                 T at (8,12)
   """
   let _server: _LspTestServer
 
@@ -439,7 +438,7 @@ class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
       "references/generic_actor.pony",
       [ (0, 19, _RefsChecker(
         [ ("generic_actor.pony", 0, 19, 0, 20)
-          ("generic_actor.pony", 4, 12, 4, 13)], true))])
+          ("generic_actor.pony", 8, 12, 8, 13)], true))])
 
 class val _RefsChecker
   """

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -258,7 +258,11 @@ class _HighlightConstrainedGeneric[T: Stringable]
 
 actor _HighlightGenericActor[T: Any val]
   """
-  Generic actor for testing the tk_be synthesized-node filter.
+  Demonstrates Document Highlight on a generic actor type parameter.
+
+  Place the cursor on `T` in `actor _HighlightGenericActor[T: Any val]`
+  and invoke Document Highlight. Expect 2 occurrences: the declaration
+  and the type annotation in the `run` behaviour parameter.
   """
   be run(x: T) =>
     None

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -255,3 +255,10 @@ class _HighlightConstrainedGeneric[T: Stringable]
   """
   fun apply(x: T): T =>
     x
+
+actor _HighlightGenericActor[T: Any val]
+  """
+  Generic actor for testing the tk_be synthesized-node filter.
+  """
+  be run(x: T) =>
+    None

--- a/tools/pony-lsp/test/workspace/references/generic_actor.pony
+++ b/tools/pony-lsp/test/workspace/references/generic_actor.pony
@@ -1,6 +1,10 @@
 actor GenericActor[T: Any val]
   """
-  Test fixture: generic actor type parameter references.
+  Demonstrates Find All References on a generic actor type parameter.
+
+  Place the cursor on `T` in `actor GenericActor[T: Any val]` and invoke
+  Find All References. Expect 2 locations: the declaration and the type
+  annotation in the `run` behaviour parameter.
   """
   be run(x: T) =>
     None

--- a/tools/pony-lsp/test/workspace/references/generic_actor.pony
+++ b/tools/pony-lsp/test/workspace/references/generic_actor.pony
@@ -1,0 +1,6 @@
+actor GenericActor[T: Any val]
+  """
+  Test fixture: generic actor type parameter references.
+  """
+  be run(x: T) =>
+    None

--- a/tools/pony-lsp/test/workspace/references/generic_refs.pony
+++ b/tools/pony-lsp/test/workspace/references/generic_refs.pony
@@ -1,0 +1,6 @@
+class GenericRefs[T]
+  """
+  Test fixture for generic type parameter references.
+  """
+  fun id(x: T): T =>
+    x

--- a/tools/pony-lsp/test/workspace/references/generic_refs.pony
+++ b/tools/pony-lsp/test/workspace/references/generic_refs.pony
@@ -1,6 +1,16 @@
 class GenericRefs[T]
   """
-  Test fixture for generic type parameter references.
+  Demonstrates Find All References on a generic type parameter.
+
+  Place the cursor on `T` in `class GenericRefs[T]` and invoke Find All
+  References. Expect 3 locations: the declaration and both type annotations
+  in `id` (the parameter type `x: T` and the return type `): T`).
+
+  With includeDeclaration disabled, expect 2 locations: both type
+  annotations in `id` only.
+
+  Placing the cursor on either type annotation in `id` instead of the
+  declaration produces the same set of locations.
   """
   fun id(x: T): T =>
     x

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -150,17 +150,18 @@ class ref _HighlightCollector is ASTVisitor
 
     if matches then
       // ponyc synthesizes a nominal self-type as the return type of
-      // auto-generated constructors in generic classes, forming the chain:
-      // tk_new -> tk_nominal -> tk_typeargs -> tk_typeparamref
+      // auto-generated constructors (tk_new) and behaviours (tk_be) in generic
+      // classes and actors, forming the chain:
+      // tk_new/tk_be -> tk_nominal -> tk_typeargs -> tk_typeparamref
       // This internal node resolves to the class's type param but is not a
       // user-visible occurrence — skip it.
       try
         let p = ast.parent() as AST    // tk_typeargs?
         let gp = p.parent() as AST     // tk_nominal?
-        let ggp = gp.parent() as AST   // tk_new?
+        let ggp = gp.parent() as AST   // tk_new or tk_be?
         if (p.id() == TokenIds.tk_typeargs()) and
           (gp.id() == TokenIds.tk_nominal()) and
-          (ggp.id() == TokenIds.tk_new())
+          ((ggp.id() == TokenIds.tk_new()) or (ggp.id() == TokenIds.tk_be()))
         then
           return Continue
         end

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -41,9 +41,10 @@ primitive References
       end
     end
 
-    // When the cursor lands on the name identifier of an entity declaration,
-    // promote to the entity node so that type references (which resolve to
-    // tk_class, not its tk_id child) are found by the walker.
+    // When the cursor lands on the name identifier of an entity declaration
+    // (tk_class, tk_actor, etc.) or type parameter declaration (tk_typeparam),
+    // promote to the enclosing node so that references (which resolve to
+    // tk_class or tk_typeparam, not their tk_id child) are found by the walker.
     let node' =
       if nid == TokenIds.tk_id() then
         try
@@ -55,7 +56,8 @@ primitive References
           | TokenIds.tk_primitive()
           | TokenIds.tk_trait()
           | TokenIds.tk_interface()
-          | TokenIds.tk_type() =>
+          | TokenIds.tk_type()
+          | TokenIds.tk_typeparam() =>
             par
           else
             node
@@ -155,6 +157,23 @@ class ref _ReferenceCollector is ASTVisitor
     end
 
     if matches then
+      // ponyc synthesizes a nominal self-type as the return type of
+      // auto-generated constructors in generic classes, forming the chain:
+      // tk_new -> tk_nominal -> tk_typeargs -> tk_typeparamref
+      // This internal node resolves to the class's type param but is not a
+      // user-visible occurrence — skip it.
+      try
+        let p = ast.parent() as AST    // tk_typeargs?
+        let gp = p.parent() as AST     // tk_nominal?
+        let ggp = gp.parent() as AST   // tk_new?
+        if (p.id() == TokenIds.tk_typeargs()) and
+          (gp.id() == TokenIds.tk_nominal()) and
+          (ggp.id() == TokenIds.tk_new())
+        then
+          return Continue
+        end
+      end
+
       let hl_node = ASTIdentifier.identifier_node(ast)
       (let start_pos, let end_pos) = hl_node.span()
       // Deduplicate: include file in key since multiple modules share

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -158,17 +158,18 @@ class ref _ReferenceCollector is ASTVisitor
 
     if matches then
       // ponyc synthesizes a nominal self-type as the return type of
-      // auto-generated constructors in generic classes, forming the chain:
-      // tk_new -> tk_nominal -> tk_typeargs -> tk_typeparamref
+      // auto-generated constructors (tk_new) and behaviours (tk_be) in generic
+      // classes and actors, forming the chain:
+      // tk_new/tk_be -> tk_nominal -> tk_typeargs -> tk_typeparamref
       // This internal node resolves to the class's type param but is not a
       // user-visible occurrence — skip it.
       try
         let p = ast.parent() as AST    // tk_typeargs?
         let gp = p.parent() as AST     // tk_nominal?
-        let ggp = gp.parent() as AST   // tk_new?
+        let ggp = gp.parent() as AST   // tk_new or tk_be?
         if (p.id() == TokenIds.tk_typeargs()) and
           (gp.id() == TokenIds.tk_nominal()) and
-          (ggp.id() == TokenIds.tk_new())
+          ((ggp.id() == TokenIds.tk_new()) or (ggp.id() == TokenIds.tk_be()))
         then
           return Continue
         end


### PR DESCRIPTION
## Context

`textDocument/references` returns zero results when the cursor is placed on a generic type parameter declaration (e.g. `T` in `class Foo[T]`). The cursor-side node is a bare `tk_id` child of `tk_typeparam`, but `References.collect()` does not promote it to the enclosing `tk_typeparam` before resolution — so the walker never finds any matching references.

A related gap exists for generic actors: ponyc synthesizes a nominal self-type as the return type of constructors and behaviours in generic types, forming the internal chain `tk_new`/`tk_be` → `tk_nominal` → `tk_typeargs` → `tk_typeparamref`. This phantom node resolves to the type parameter and would appear as a spurious extra reference. The `tk_new` case is already filtered in `documentHighlight` but `tk_be` is not, and neither filter exists yet in `references`.

## Consequences

The `tk_be` phantom filter is also applied to `documentHighlight`, bringing it into parity with the fix in `references` and preventing the same phantom from appearing in highlight results for generic actors.

## Changes

- `references.pony`: add `tk_typeparam` to the entity-promotion match; add phantom-node filter for `tk_new` and `tk_be` synthesized return types.
- `document_highlight.pony`: extend the existing `tk_new` phantom filter to also cover `tk_be`.
- New fixture `generic_refs.pony` (`class GenericRefs[T]`) with 4 integration tests covering all cursor/`includeDeclaration` combinations.
- New fixture `generic_actor.pony` (`actor GenericActor[T: Any val]`) with 1 integration test verifying the `tk_be` phantom filter returns exactly 2 results.
- New highlight integration test `generic_actor_be_t` verifying the `tk_be` filter in `documentHighlight` returns exactly 2 highlights.

Fixes #5209.