### PR TITLE
Add LSP `workspace/inlayHint/refresh` support

### DIFF
--- a/.release-notes/5224.md
+++ b/.release-notes/5224.md
@@ -1,0 +1,3 @@
+## Add LSP `workspace/inlayHint/refresh` support
+
+After each compilation, pony-lsp now sends a `workspace/inlayHint/refresh` request to the editor, asking it to re-request inlay hints for all open documents. Previously, inlay hints (such as inferred type annotations) would not update after a file was saved and recompiled. This only takes effect when the editor advertises support for `workspace/inlayHint/refresh` in its LSP capabilities (all major editors do).

--- a/tools/pony-lsp/client.pony
+++ b/tools/pony-lsp/client.pony
@@ -14,6 +14,7 @@ class val Client
   let _supports_publish_diagnostics: Bool
   let _supports_publish_diagnostic_related_info: Bool
   let _supports_workspace_diagnostic_refresh: Bool
+  let _supports_inlay_hint_refresh: Bool
   let _supports_window_work_done_progress: Bool
 
   new val from(initialize_params: JsonObject) =>
@@ -89,6 +90,14 @@ class val Client
       else
         false
       end
+    this._supports_inlay_hint_refresh =
+      try
+        JsonPathParser.compile(
+          "$.workspace.inlayHint.refreshSupport"
+        )?.query_one(this.capabilities) as Bool
+      else
+        false
+      end
     this._supports_window_work_done_progress =
       try
         JsonPathParser.compile(
@@ -130,6 +139,13 @@ class val Client
     DiagnosticWorkspaceClientCapabilities.
     """
     this._supports_workspace_diagnostic_refresh
+
+  fun supports_inlay_hint_refresh(): Bool =>
+    """
+    Returns `true` if the client supports the `workspace/inlayHint/refresh`
+    request (InlayHintWorkspaceClientCapabilities.refreshSupport).
+    """
+    this._supports_inlay_hint_refresh
 
   fun supports_window_work_done_progress(): Bool =>
     """
@@ -177,6 +193,9 @@ class val Client
       end
       if this.supports_workspace_diagnostic_refresh() then
         s.append("\trefreshing diagnostics\r\n")
+      end
+      if this.supports_inlay_hint_refresh() then
+        s.append("\trefreshing inlay hints\r\n")
       end
       if this.supports_window_work_done_progress() then
         s.append("\tserver-initiated workDoneProgress\r\n")

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -62,6 +62,17 @@ primitive WorkspaceMethods
   fun diagnostic(): WorkspaceDiagnosticMethods =>
     WorkspaceDiagnosticMethods
 
+  fun inlay_hint(): WorkspaceInlayHintMethods =>
+    WorkspaceInlayHintMethods
+
+primitive WorkspaceInlayHintMethods
+  """
+  Collection of workspace/inlayHint related methods.
+  """
+
+  fun refresh(): String val =>
+    "workspace/inlayHint/refresh"
+
 primitive WorkspaceDiagnosticMethods
   """
   Collection of workspace/diagnostic related methods.

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -287,6 +287,13 @@ actor WorkspaceManager
           Methods.workspace().diagnostic().refresh(),
           None)
       end
+      if this._client.supports_inlay_hint_refresh() then
+        // tell the client to re-request inlay hints
+        // for all open documents
+        this._request_sender.send_request(
+          Methods.workspace().inlay_hint().refresh(),
+          None)
+      end
     else
       this._channel.log(
         "Received compilation result for run " + run.string() +


### PR DESCRIPTION
## Context

After a recompile, VS Code and other LSP clients display stale inlay hints — hints computed before the last edit, pointing at wrong line/column positions. The server never informed clients that hints needed refreshing.

## Changes

- `client.pony`: detect `InlayHintWorkspaceClientCapabilities.refreshSupport` from the initialize request and expose it via `supports_inlay_hint_refresh()`
- `methods.pony`: add `WorkspaceInlayHintMethods` with `refresh()` returning `"workspace/inlayHint/refresh"`, exposed via `WorkspaceMethods.inlay_hint()`
- `workspace_manager.pony`: after every successful recompile, send `workspace/inlayHint/refresh` if the client supports it

Closes #5223