### PR TITLE
Add LSP `textDocument/rename` and `textDocument/prepareRename` support

### DIFF
--- a/.release-notes/add_lsp_rename_support.md
+++ b/.release-notes/add_lsp_rename_support.md
@@ -1,0 +1,11 @@
+## Add LSP `textDocument/rename` and `textDocument/prepareRename` support
+
+The Pony language server now supports symbol rename. Placing the cursor on any renameable identifier — field, method, behaviour, local variable, parameter, type parameter, class, actor, struct, primitive, trait, or interface — and invoking Rename Symbol in your editor will produce a `WorkspaceEdit` replacing every occurrence across all packages in the workspace.
+
+`textDocument/prepareRename` is also implemented, allowing editors to validate that the cursor is on a renameable symbol before prompting for the new name. The server advertises `prepareProvider: true` in its capabilities.
+
+Renames are rejected with an appropriate error when:
+
+- The cursor is on a literal or synthetic expression node.
+- The target symbol is defined outside the workspace (stdlib or external package).
+- The supplied new name is not a valid Pony identifier.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -109,6 +109,36 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] No workspace found for '" +
                 r.json().string() + "'")))
         end
+      | Methods.text_document().prepare_rename() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .prepare_rename(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
+      | Methods.text_document().rename() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .rename(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().document_highlight() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -425,6 +455,9 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("save", JsonObject.update("includeText", true)))
                 .update("definitionProvider", true)
                 .update("referencesProvider", true)
+                .update(
+                  "renameProvider",
+                  JsonObject.update("prepareProvider", true))
                 .update(
                   "diagnosticProvider",
                   JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -116,6 +116,12 @@ primitive TextDocumentMethods
   fun references(): String val =>
     "textDocument/references"
 
+  fun prepare_rename(): String val =>
+    "textDocument/prepareRename"
+
+  fun rename(): String val =>
+    "textDocument/rename"
+
   fun publish_diagnostics(): String val =>
     "textDocument/publishDiagnostics"
 

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -209,6 +209,9 @@ class val _DefinitionChecker
   fun lsp_context(): (None | JsonObject) =>
     None
 
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     let got_count =

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -1267,6 +1267,9 @@ class val _DocHighlightChecker
   fun lsp_context(): (None | JsonObject) =>
     None
 
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     match res.result

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -381,6 +381,9 @@ class val _HoverChecker
   fun lsp_context(): (None | JsonObject) =>
     None
 
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     if _expected.size() == 0 then

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -372,6 +372,9 @@ class val _InlayHintChecker
   fun lsp_context(): (None | JsonObject) =>
     None
 
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     try

--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -86,6 +86,12 @@ actor _LspTestServer is Channel
       | let ctx: JsonObject =>
         params = params.update("context", ctx)
       end
+      match pending.checker.lsp_extra_params()
+      | let extra: JsonObject =>
+        for (k, v) in extra.pairs() do
+          params = params.update(k, v)
+        end
+      end
       (_server as BaseProtocol)(
         RequestMessage(id, pending.checker.lsp_method(), params).into_bytes())
       _in_flight(id) = pending

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -465,6 +465,9 @@ class val _RefsChecker
   fun lsp_context(): (None | JsonObject) =>
     JsonObject.update("includeDeclaration", _include_declaration)
 
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
     match res.result

--- a/tools/pony-lsp/test/_rename_integration_tests.pony
+++ b/tools/pony-lsp/test/_rename_integration_tests.pony
@@ -1,0 +1,807 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+primitive _RenameIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_RenameFieldTest.create(server))
+    test(_RenameFieldFromRefTest.create(server))
+    test(_RenameMethodTest.create(server))
+    test(_RenameMethodFromCallTest.create(server))
+    test(_RenameClassTest.create(server))
+    test(_RenameLiteralTest.create(server))
+    test(_RenameStdlibTest.create(server))
+    test(_RenameMissingNameTest.create(server))
+    test(_RenameClassFromRefTest.create(server))
+    test(_RenameParamTest.create(server))
+    test(_RenameLocalVarTest.create(server))
+    test(_RenameClassTypeParamTest.create(server))
+    test(_RenameClassTypeParamFromRefTest.create(server))
+    test(_RenameFunTypeParamTest.create(server))
+    test(_RenameFunTypeParamFromRefTest.create(server))
+    test(_RenameInvalidNameTest.create(server))
+    test(_RenameActorBeTest.create(server))
+    test(_RenameActorBeFromCallTest.create(server))
+    test(_RenameSingleOccurrenceTest.create(server))
+    test(_PrepareRenameFieldTest.create(server))
+    test(_PrepareRenameLiteralTest.create(server))
+    test(_PrepareRenameStdlibTest.create(server))
+
+class \nodoc\ iso _RenameFieldTest is UnitTest
+  """
+  Rename `_value` from its declaration (line 16, col 6).
+  renameable.pony layout (0-indexed lines/cols):
+    line  0:  class Renameable
+    line  1:    \"\"\"  (docstring start)
+    ...
+    line 15:    \"\"\"  (docstring end)
+    line 16:    var _value: U32 = 0          _value at (16,6)-(16,12)
+    line 19:      _value = v               _value at (19,4)-(19,10)
+    line 22:      _value                   _value at (22,4)-(22,10)
+    line 25:    let result: U32 = x + _value  _value at (25,26)-(25,32)
+
+  Expects 4 edits in renameable.pony: declaration + 3 uses.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/field"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (16, 6, _RenameChecker(
+        "new_value",
+        [ ("renameable.pony", 16, 6, 16, 12)
+          ("renameable.pony", 19, 4, 19, 10)
+          ("renameable.pony", 22, 4, 22, 10)
+          ("renameable.pony", 25, 26, 25, 32)]))])
+
+class \nodoc\ iso _RenameFieldFromRefTest is UnitTest
+  """
+  Rename `_value` from a use site (line 19, col 4) rather than the declaration.
+  Should produce the same 4 edits as _RenameFieldTest.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/field_from_ref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (19, 4, _RenameChecker(
+        "new_value",
+        [ ("renameable.pony", 16, 6, 16, 12)
+          ("renameable.pony", 19, 4, 19, 10)
+          ("renameable.pony", 22, 4, 22, 10)
+          ("renameable.pony", 25, 26, 25, 32)]))])
+
+class \nodoc\ iso _RenameMethodTest is UnitTest
+  """
+  Rename `get_value` from its declaration (line 21, col 6).
+  renameable.pony:
+    line 21:  fun get_value(): U32 =>   get_value at (21,6)-(21,15)
+  rename_user.pony:
+    line 13:    r.get_value()            get_value at (13,6)-(13,15)
+
+  Expects 1 edit in renameable.pony and 1 in rename_user.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/method"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (21, 6, _RenameChecker(
+        "fetch_value",
+        [ ("renameable.pony", 21, 6, 21, 15)
+          ("rename_user.pony", 13, 6, 13, 15)]))])
+
+class \nodoc\ iso _RenameMethodFromCallTest is UnitTest
+  """
+  Rename `get_value` from its call site in rename_user.pony (line 13, col 6)
+  rather than the declaration. Should produce the same 2 edits as
+  _RenameMethodTest.
+  rename_user.pony:
+    line 13:    r.get_value()   get_value at (13,6)-(13,15)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/method_from_call"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/rename_user.pony",
+      [ (13, 6, _RenameChecker(
+        "fetch_value",
+        [ ("renameable.pony", 21, 6, 21, 15)
+          ("rename_user.pony", 13, 6, 13, 15)]))])
+
+class \nodoc\ iso _RenameClassTest is UnitTest
+  """
+  Rename `Renameable` from its declaration (line 0, col 6).
+  renameable.pony:
+    line 0:  class Renameable   Renameable at (0,6)-(0,16)
+  rename_user.pony:
+    line 12:  fun use_it(r: Renameable): U32 =>
+                              Renameable at (12,16)-(12,26)
+
+  Expects 1 edit in renameable.pony and 1 in rename_user.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/class"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (0, 6, _RenameChecker(
+        "RenameTarget",
+        [ ("renameable.pony", 0, 6, 0, 16)
+          ("rename_user.pony", 12, 16, 12, 26)]))])
+
+class \nodoc\ iso _RenameLiteralTest is UnitTest
+  """
+  Rename a literal (`0` at line 16, col 20 of renameable.pony). The server
+  should return an error response — literals have no referenceable identity.
+  renameable.pony:
+    line 16:  var _value: U32 = 0   literal 0 at (16,20)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/literal_error"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 20, _RenameErrorChecker("new_name", ErrorCodes.request_failed()))])
+
+class \nodoc\ iso _RenameStdlibTest is UnitTest
+  """
+  Rename `U32` (a stdlib type) at line 16, col 14 of renameable.pony. The
+  server should return an error response — stdlib symbols are defined outside
+  the workspace.
+  renameable.pony:
+    line 16:  var _value: U32 = 0   U32 at (16,14)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/stdlib_error"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 14, _RenameErrorChecker("MyU32", ErrorCodes.request_failed()))])
+
+class \nodoc\ iso _RenameMissingNameTest is UnitTest
+  """
+  Send a rename request with no `newName` parameter. The server should return
+  an invalid_params error response.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/missing_name_error"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 6, _RenameErrorChecker(None, ErrorCodes.invalid_params()))])
+
+class \nodoc\ iso _RenameInvalidNameTest is UnitTest
+  """
+  Send a rename request with a newName that is not a valid Pony identifier
+  (`"hello world"` contains a space). The server should return an
+  invalid_params error response.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/invalid_name_error"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ ( 16, 6,
+          _RenameErrorChecker("hello world", ErrorCodes.invalid_params()))])
+
+class \nodoc\ iso _RenameClassFromRefTest is UnitTest
+  """
+  Rename `Renameable` from a use site in rename_user.pony (line 12, col 16)
+  rather than the declaration. Should produce the same 2 edits as
+  _RenameClassTest.
+  rename_user.pony:
+    line 12:  fun use_it(r: Renameable): U32 =>
+                              Renameable at (12,16)-(12,26)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/class_from_ref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/rename_user.pony",
+      [ (12, 16, _RenameChecker(
+        "RenameTarget",
+        [ ("renameable.pony", 0, 6, 0, 16)
+          ("rename_user.pony", 12, 16, 12, 26)]))])
+
+class \nodoc\ iso _RenameParamTest is UnitTest
+  """
+  Rename the constructor parameter `v` from its declaration (line 18, col 13).
+  renameable.pony layout (0-indexed lines/cols):
+    line 18:  new create(v: U32) =>   v at (18,13)-(18,14)
+    line 19:    _value = v            v at (19,13)-(19,14)
+
+  Expects 2 edits in renameable.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/param"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (18, 13, _RenameChecker(
+        "val",
+        [ ("renameable.pony", 18, 13, 18, 14)
+          ("renameable.pony", 19, 13, 19, 14)]))])
+
+class \nodoc\ iso _RenameLocalVarTest is UnitTest
+  """
+  Rename the local variable `result` in `compute` from its declaration
+  (line 25, col 8). renameable.pony layout (0-indexed lines/cols):
+    line 24:  fun compute(x: U32): U32 =>
+    line 25:    let result: U32 = x + _value   result at (25,8)-(25,14)
+    line 26:    result                         result at (26,4)-(26,10)
+
+  Expects 2 edits in renameable.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/local_var"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [ (25, 8, _RenameChecker(
+        "value",
+        [ ("renameable.pony", 25, 8, 25, 14)
+          ("renameable.pony", 26, 4, 26, 10)]))])
+
+class \nodoc\ iso _RenameClassTypeParamTest is UnitTest
+  """
+  Rename the class-level type parameter `A` from its declaration (line 0,
+  col 15). generics.pony layout (0-indexed lines/cols):
+    line  0:  class Generics[A: Any val]   A at (0,15)-(0,16)
+    line 13:    var _item: A               A at (13,13)-(13,14)
+    line 15:    new create(item: A) =>     A at (15,19)-(15,20)
+    line 18:    fun get(): A =>            A at (18,13)-(18,14)
+
+  Expects 4 edits in generics.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/class_type_param"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/generics.pony",
+      [ (0, 15, _RenameChecker(
+        "Item",
+        [ ("generics.pony", 0, 15, 0, 16)
+          ("generics.pony", 13, 13, 13, 14)
+          ("generics.pony", 15, 19, 15, 20)
+          ("generics.pony", 18, 13, 18, 14)]))])
+
+class \nodoc\ iso _RenameClassTypeParamFromRefTest is UnitTest
+  """
+  Rename the class-level type parameter `A` from a use site (line 13, col 13)
+  rather than the declaration. Should produce the same 4 edits as
+  _RenameClassTypeParamTest.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/class_type_param_from_ref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/generics.pony",
+      [ (13, 13, _RenameChecker(
+        "Item",
+        [ ("generics.pony", 0, 15, 0, 16)
+          ("generics.pony", 13, 13, 13, 14)
+          ("generics.pony", 15, 19, 15, 20)
+          ("generics.pony", 18, 13, 18, 14)]))])
+
+class \nodoc\ iso _RenameFunTypeParamTest is UnitTest
+  """
+  Rename the function-level type parameter `B` in `transform` from its
+  declaration (line 21, col 16). generics.pony layout (0-indexed):
+    line 21:  fun transform[B: Any val](item: B): B =>
+      B declaration at (21,16)-(21,17)
+      B param type  at (21,34)-(21,35)
+      B return type at (21,38)-(21,39)
+
+  Expects 3 edits in generics.pony.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/fun_type_param"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/generics.pony",
+      [ (21, 16, _RenameChecker(
+        "Elem",
+        [ ("generics.pony", 21, 16, 21, 17)
+          ("generics.pony", 21, 34, 21, 35)
+          ("generics.pony", 21, 38, 21, 39)]))])
+
+class \nodoc\ iso _RenameFunTypeParamFromRefTest is UnitTest
+  """
+  Rename the function-level type parameter `B` from its return-type position
+  (line 21, col 38) rather than the declaration. Should produce the same 3
+  edits as _RenameFunTypeParamTest.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/fun_type_param_from_ref"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/generics.pony",
+      [ (21, 38, _RenameChecker(
+        "Elem",
+        [ ("generics.pony", 21, 16, 21, 17)
+          ("generics.pony", 21, 34, 21, 35)
+          ("generics.pony", 21, 38, 21, 39)]))])
+
+class \nodoc\ iso _RenameActorBeTest is UnitTest
+  """
+  Rename `work` from its declaration (line 12, col 5).
+  actor.pony layout (0-indexed lines/cols):
+    line 12:  be work(value: U32) =>   work at (12,5)-(12,9)
+    line 20:    a.work(0)              work at (20,6)-(20,10)
+
+  Expects 2 edits in actor.pony: declaration + call.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/actor_be"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/actor.pony",
+      [ (12, 5, _RenameChecker(
+        "process",
+        [ ("actor.pony", 12, 5, 12, 9)
+          ("actor.pony", 20, 6, 20, 10)]))])
+
+class \nodoc\ iso _RenameActorBeFromCallTest is UnitTest
+  """
+  Rename `work` from its call site (line 20, col 6) rather than the
+  declaration. Should produce the same 2 edits as _RenameActorBeTest.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/actor_be_from_call"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/actor.pony",
+      [ (20, 6, _RenameChecker(
+        "process",
+        [ ("actor.pony", 12, 5, 12, 9)
+          ("actor.pony", 20, 6, 20, 10)]))])
+
+class \nodoc\ iso _RenameSingleOccurrenceTest is UnitTest
+  """
+  Rename `_tag_only` from its declaration (line 10, col 6). The field is
+  never referenced anywhere, so the server should return exactly 1 edit.
+  actor.pony layout (0-indexed lines/cols):
+    line 10:  var _tag_only: U32 = 0   _tag_only at (10,6)-(10,15)
+
+  Expects 1 edit in actor.pony: only the declaration.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/single_occurrence"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/actor.pony",
+      [ (10, 6, _RenameChecker(
+        "_only",
+        [ ("actor.pony", 10, 6, 10, 15)]))])
+
+class val _RenameErrorChecker
+  """
+  Validates that a textDocument/rename response is an error (not a
+  WorkspaceEdit) with the expected error code. Pass a String new_name to
+  include it in the request params, or None to omit `newName` entirely (to
+  exercise the missing-param path).
+  """
+  let _new_name: (String val | None)
+  let _expected_code: I64
+
+  new val create(new_name: (String val | None), expected_code: I64) =>
+    _new_name = new_name
+    _expected_code = expected_code
+
+  fun lsp_method(): String =>
+    Methods.text_document().rename()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    match \exhaustive\ _new_name
+    | let n: String val => JsonObject.update("newName", n)
+    | None => None
+    end
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match \exhaustive\ res.err
+    | let err: ResponseError val =>
+      h.assert_eq[I64](_expected_code, err.code, "Wrong error code")
+    | None =>
+      h.log("Expected error response but got result: " + res.string())
+      false
+    end
+
+class val _RenameChecker
+  """
+  Validates a textDocument/rename response (WorkspaceEdit) against expected
+  edits. Each expected edit is (filename_basename, start_line, start_char,
+  end_line, end_char). All edits are checked against the `changes` map in the
+  response regardless of which URI they appear in.
+  """
+  let _new_name: String val
+  let _expected: Array[(String, I64, I64, I64, I64)] val
+
+  new val create(
+    new_name: String val,
+    expected: Array[(String, I64, I64, I64, I64)] val)
+  =>
+    _new_name = new_name
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().rename()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    JsonObject.update("newName", _new_name)
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    // Collect all (file_basename, sl, sc, el, ec, newText) from changes.
+    let got: Array[(String, I64, I64, I64, I64, String)] =
+      Array[(String, I64, I64, I64, I64, String)].create()
+    try
+      let changes = JsonNav(res.result)("changes").as_object()?
+      for (uri, edits_val) in changes.pairs() do
+        let file = Path.base(Uris.to_path(uri))
+        let edits = edits_val as JsonArray
+        for edit in edits.values() do
+          let range = JsonNav(edit)("range")
+          let sl = range("start")("line").as_i64()?
+          let sc = range("start")("character").as_i64()?
+          let el = range("end")("line").as_i64()?
+          let ec = range("end")("character").as_i64()?
+          let new_text = JsonNav(edit)("newText").as_string()?
+          got.push((file, sl, sc, el, ec, new_text))
+        end
+      end
+    else
+      h.log("Expected WorkspaceEdit with changes but got: " + res.string())
+      return false
+    end
+
+    let want = _expected.size()
+    let got_count = got.size()
+    if not h.assert_eq[USize](
+      want,
+      got_count,
+      "Expected " + want.string() + " edits, got " + got_count.string())
+    then
+      ok = false
+      for (file, sl, sc, el, ec, new_text) in got.values() do
+        h.log(
+          "  actual edit " + file +
+          " (" + sl.string() + ", " + sc.string() +
+          ")–(" + el.string() + ", " + ec.string() +
+          ") -> '" + new_text + "'")
+      end
+    end
+
+    for (exp_file, exp_sl, exp_sc, exp_el, exp_ec) in _expected.values() do
+      var found = false
+      for (file, sl, sc, el, ec, new_text) in got.values() do
+        if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc)
+          and (el == exp_el) and (ec == exp_ec) and (new_text == _new_name)
+        then
+          found = true
+          break
+        end
+      end
+      if not h.assert_true(
+        found,
+        "Expected edit " + exp_file +
+        " (" + exp_sl.string() + ", " + exp_sc.string() +
+        ")–(" + exp_el.string() + ", " + exp_ec.string() + ") not found")
+      then
+        ok = false
+      end
+    end
+    ok
+
+class val _PrepareRenameChecker
+  """
+  Validates a textDocument/prepareRename response against an expected
+  identifier range.
+  """
+  let _expected_sl: I64
+  let _expected_sc: I64
+  let _expected_el: I64
+  let _expected_ec: I64
+
+  new val create(sl: I64, sc: I64, el: I64, ec: I64) =>
+    _expected_sl = sl
+    _expected_sc = sc
+    _expected_el = el
+    _expected_ec = ec
+
+  fun lsp_method(): String =>
+    Methods.text_document().prepare_rename()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    try
+      let range = JsonNav(res.result)("range")
+      let sl = range("start")("line").as_i64()?
+      let sc = range("start")("character").as_i64()?
+      let el = range("end")("line").as_i64()?
+      let ec = range("end")("character").as_i64()?
+      var ok = true
+      ok = h.assert_eq[I64](_expected_sl, sl, "Wrong start line") and ok
+      ok = h.assert_eq[I64](_expected_sc, sc, "Wrong start character") and ok
+      ok = h.assert_eq[I64](_expected_el, el, "Wrong end line") and ok
+      ok = h.assert_eq[I64](_expected_ec, ec, "Wrong end character") and ok
+      ok
+    else
+      h.log("Expected prepareRename range but got: " + res.string())
+      false
+    end
+
+class val _PrepareRenameErrorChecker
+  """
+  Validates that a textDocument/prepareRename response is an error with the
+  expected error code.
+  """
+  let _expected_code: I64
+
+  new val create(expected_code: I64) =>
+    _expected_code = expected_code
+
+  fun lsp_method(): String =>
+    Methods.text_document().prepare_rename()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match \exhaustive\ res.err
+    | let err: ResponseError val =>
+      h.assert_eq[I64](_expected_code, err.code, "Wrong error code")
+    | None =>
+      h.log("Expected error response but got result: " + res.string())
+      false
+    end
+
+class \nodoc\ iso _PrepareRenameFieldTest is UnitTest
+  """
+  PrepareRename on `_value` at (16, 6) in renameable.pony. Should return the
+  identifier range (16,6)-(16,12) without error.
+  renameable.pony layout (0-indexed lines/cols):
+    line 16:  var _value: U32 = 0   _value at (16,6)-(16,12)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/prepare_rename_field"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 6, _PrepareRenameChecker(16, 6, 16, 12))])
+
+class \nodoc\ iso _PrepareRenameLiteralTest is UnitTest
+  """
+  PrepareRename on the literal `0` at (16, 20) in renameable.pony. Literals
+  are not renameable — expect request_failed().
+  renameable.pony layout (0-indexed lines/cols):
+    line 16:  var _value: U32 = 0   literal `0` at (16,20)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/prepare_rename_literal"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 20, _PrepareRenameErrorChecker(ErrorCodes.request_failed()))])
+
+class \nodoc\ iso _PrepareRenameStdlibTest is UnitTest
+  """
+  PrepareRename on `U32` (stdlib type) at (16, 14) in renameable.pony.
+  Stdlib symbols are outside the workspace — expect request_failed().
+  renameable.pony layout (0-indexed lines/cols):
+    line 16:  var _value: U32 = 0   U32 at (16,14)-(16,17)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "rename/integration/prepare_rename_stdlib"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "rename/renameable.pony",
+      [(16, 14, _PrepareRenameErrorChecker(ErrorCodes.request_failed()))])

--- a/tools/pony-lsp/test/_rename_integration_tests.pony
+++ b/tools/pony-lsp/test/_rename_integration_tests.pony
@@ -693,7 +693,7 @@ class val _PrepareRenameChecker
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     try
-      let range = JsonNav(res.result)("range")
+      let range = JsonNav(res.result)
       let sl = range("start")("line").as_i64()?
       let sc = range("start")("character").as_i64()?
       let el = range("end")("line").as_i64()?

--- a/tools/pony-lsp/test/_response_checker.pony
+++ b/tools/pony-lsp/test/_response_checker.pony
@@ -11,4 +11,5 @@ interface val _ResponseChecker
   fun lsp_method(): String
   fun lsp_range(): (None | (I64, I64, I64, I64))
   fun lsp_context(): (None | JsonObject)
+  fun lsp_extra_params(): (None | JsonObject)
   fun check(res: ResponseMessage val, h: TestHelper): Bool

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -29,6 +29,7 @@ actor Main is TestList
     _DocumentHighlightIntegrationTests.make().tests(test)
     _InlayHintIntegrationTests.make().tests(test)
     _ReferencesIntegrationTests.make().tests(test)
+    _RenameIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/rename/actor.pony
+++ b/tools/pony-lsp/test/workspace/rename/actor.pony
@@ -1,0 +1,21 @@
+actor RenameableActor
+  """
+  Demonstrates rename of actor behaviours and single-occurrence fields.
+
+  Place the cursor on `work` (be declaration at line 12, col 5) and invoke
+  Rename Symbol. Expect 2 edits: the declaration and the call at line 20.
+
+  Place the cursor on `_tag_only` (field declaration at line 10, col 6) and
+  invoke Rename Symbol. Expect 1 edit: only the declaration (unused field).
+  """
+  var _tag_only: U32 = 0
+
+  be work(value: U32) =>
+    None
+
+class ActorUser
+  """
+  Calls behaviours on RenameableActor to provide cross-entity call sites.
+  """
+  fun use_it(a: RenameableActor) =>
+    a.work(0)

--- a/tools/pony-lsp/test/workspace/rename/generics.pony
+++ b/tools/pony-lsp/test/workspace/rename/generics.pony
@@ -1,0 +1,23 @@
+class Generics[A: Any val]
+  """
+  Demonstrates rename of type parameters at the class and function level.
+
+  Place the cursor on `A` (the class-level type parameter) anywhere it
+  appears and invoke Rename Symbol. Expect 4 edits: the declaration in
+  `[A: Any val]`, the field type, the constructor parameter type, and the
+  return type of `get`.
+
+  Place the cursor on `B` (the function-level type parameter in `transform`)
+  anywhere it appears and invoke Rename Symbol. Expect 3 edits: the
+  declaration in `[B: Any val]`, the parameter type, and the return type.
+  """
+  var _item: A
+
+  new create(item: A) =>
+    _item = item
+
+  fun get(): A =>
+    _item
+
+  fun transform[B: Any val](item: B): B =>
+    item

--- a/tools/pony-lsp/test/workspace/rename/rename.pony
+++ b/tools/pony-lsp/test/workspace/rename/rename.pony
@@ -1,0 +1,14 @@
+"""
+Test fixtures for exercising LSP rename functionality.
+
+Open renameable.pony or rename_user.pony in an LSP-aware editor while the
+Pony language server is active. Place the cursor on any symbol described in
+the class docstrings and invoke Rename Symbol (typically F2).
+
+The editor should prompt for a new name, then apply edits across every file
+in the workspace that references that symbol. The WorkspaceEdit covers both
+the declaration site and all use sites.
+
+Symbols defined in the stdlib or outside the workspace are rejected: the
+server returns an error and no edits are applied.
+"""

--- a/tools/pony-lsp/test/workspace/rename/rename_user.pony
+++ b/tools/pony-lsp/test/workspace/rename/rename_user.pony
@@ -1,0 +1,14 @@
+class RenameUser
+  """
+  Uses Renameable to demonstrate cross-file rename.
+
+  Place the cursor on `Renameable` (the type annotation) and invoke Rename
+  Symbol. Expect 2 edits across both files: the declaration in
+  renameable.pony and the type annotation here.
+
+  Place the cursor on `get_value` (the call) and invoke Rename Symbol.
+  Expect 2 edits across both files: the declaration in renameable.pony
+  and the call here.
+  """
+  fun use_it(r: Renameable): U32 =>
+    r.get_value()

--- a/tools/pony-lsp/test/workspace/rename/renameable.pony
+++ b/tools/pony-lsp/test/workspace/rename/renameable.pony
@@ -1,0 +1,27 @@
+class Renameable
+  """
+  Demonstrates same-file and cross-file rename.
+
+  Place the cursor on `_value` (field declaration on the `var` line, in
+  `create`, or in `get_value`) and invoke Rename Symbol. Expect 3 edits
+  in this file: the field declaration and both uses.
+
+  Place the cursor on `get_value` (the `fun` line) and invoke Rename Symbol.
+  Expect 2 edits across both files: the declaration here and the call in
+  rename_user.pony.
+
+  Place the cursor on `Renameable` (the class name) and invoke Rename Symbol.
+  Expect 2 edits across both files: the declaration here and the type
+  annotation in rename_user.pony.
+  """
+  var _value: U32 = 0
+
+  new create(v: U32) =>
+    _value = v
+
+  fun get_value(): U32 =>
+    _value
+
+  fun compute(x: U32): U32 =>
+    let result: U32 = x + _value
+    result

--- a/tools/pony-lsp/workspace/_resolve_ast_target.pony
+++ b/tools/pony-lsp/workspace/_resolve_ast_target.pony
@@ -1,0 +1,75 @@
+use "pony_compiler"
+
+primitive _ResolveASTTarget
+  """
+  Validates that `node` is referenceable and resolves it to its canonical
+  definition AST node.
+
+  Returns the canonical target `AST val`, or `None` if:
+  - the node is a literal (tk_true/false/int/float/string)
+  - the node is a synthetic newref inside a same-position tk_call
+    (desugared type-literal expressions such as `None`)
+  - definition resolution fails
+  """
+  fun apply(node: AST box): (AST val | None) =>
+    let nid = node.id()
+
+    // Literals have no referenceable identity.
+    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
+      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
+      or (nid == TokenIds.tk_string())
+    then
+      return None
+    end
+
+    // Synthetic tk_newref inside a tk_call at the same position (desugared
+    // type-literal expressions such as `None`) have no referenceable identity.
+    if nid == TokenIds.tk_newref() then
+      try
+        let par = node.parent() as AST box
+        if (par.id() == TokenIds.tk_call()) and
+          (par.position() == node.position())
+        then
+          return None
+        end
+      end
+    end
+
+    // When the cursor lands on the name identifier of an entity declaration
+    // (tk_class, tk_actor, etc.) or type parameter declaration (tk_typeparam),
+    // promote to the enclosing node so that references (which resolve to
+    // tk_class or tk_typeparam, not their tk_id child) are found by the walker.
+    let node' =
+      if nid == TokenIds.tk_id() then
+        try
+          let par = node.parent() as AST box
+          match par.id()
+          | TokenIds.tk_class()
+          | TokenIds.tk_actor()
+          | TokenIds.tk_struct()
+          | TokenIds.tk_primitive()
+          | TokenIds.tk_trait()
+          | TokenIds.tk_interface()
+          | TokenIds.tk_type()
+          | TokenIds.tk_typeparam() =>
+            par
+          else
+            node
+          end
+        else
+          node
+        end
+      else
+        node
+      end
+
+    // Resolve the canonical target definition.
+    // If the node has no definitions it IS the definition.
+    let defs = node'.definitions()
+    if defs.size() > 0 then
+      try
+        AST(defs(0)?.raw)
+      end
+    else
+      AST(node'.raw)
+    end

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -18,69 +18,10 @@ primitive References
     all nodes that resolve to the same definition as `node`. Pass
     `include_declaration = false` to exclude the definition site itself.
     """
-    // Literals have no referenceable identity — no references.
-    let nid = node.id()
-    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
-      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
-      or (nid == TokenIds.tk_string())
-    then
-      return []
-    end
-
-    // Type-literal expressions such as `None` are desugared by the compiler
-    // into implicit constructor calls. The synthetic tk_newref inside a tk_call
-    // at the same position has no referenceable identity — no references.
-    if nid == TokenIds.tk_newref() then
-      try
-        let par = node.parent() as AST box
-        if (par.id() == TokenIds.tk_call()) and
-          (par.position() == node.position())
-        then
-          return []
-        end
-      end
-    end
-
-    // When the cursor lands on the name identifier of an entity declaration
-    // (tk_class, tk_actor, etc.) or type parameter declaration (tk_typeparam),
-    // promote to the enclosing node so that references (which resolve to
-    // tk_class or tk_typeparam, not their tk_id child) are found by the walker.
-    let node' =
-      if nid == TokenIds.tk_id() then
-        try
-          let par = node.parent() as AST box
-          match par.id()
-          | TokenIds.tk_class()
-          | TokenIds.tk_actor()
-          | TokenIds.tk_struct()
-          | TokenIds.tk_primitive()
-          | TokenIds.tk_trait()
-          | TokenIds.tk_interface()
-          | TokenIds.tk_type()
-          | TokenIds.tk_typeparam() =>
-            par
-          else
-            node
-          end
-        else
-          node
-        end
-      else
-        node
-      end
-
-    // Determine the canonical target definition.
-    // If the node has no definitions it IS the definition.
-    let defs = node'.definitions()
     let target: AST val =
-      if defs.size() > 0 then
-        try
-          AST(defs(0)?.raw)
-        else
-          return []
-        end
-      else
-        AST(node'.raw)
+      match \exhaustive\ _ResolveASTTarget(node)
+      | let t: AST val => t
+      | None => return []
       end
 
     let collector = _ReferenceCollector(target)

--- a/tools/pony-lsp/workspace/rename.pony
+++ b/tools/pony-lsp/workspace/rename.pony
@@ -1,0 +1,97 @@
+use ".."
+use "collections"
+use "files"
+use "json"
+use "pony_compiler"
+
+primitive Rename
+  """
+  Builds a WorkspaceEdit for renaming all occurrences of a symbol across all
+  packages in the workspace.
+  """
+  fun collect(
+    node: AST box,
+    packages: Map[String, PackageState] box,
+    workspace_folder: String,
+    new_name: String): (JsonObject val | String val)
+  =>
+    """
+    Walk all module ASTs across all packages and return a WorkspaceEdit mapping
+    each file URI to the TextEdit[] needed to rename every occurrence of the
+    symbol at `node` to `new_name`.
+
+    Returns a String error message if the symbol cannot be renamed (literal,
+    synthetic node, or defined outside the workspace).
+    """
+    let target: AST val =
+      match \exhaustive\ _ResolveASTTarget(node)
+      | let t: AST val => t
+      | None => return "Cannot rename: symbol is not referenceable"
+      end
+
+    // Reject renames targeting symbols defined outside the workspace.
+    let target_file: String val =
+      try
+        target.source_file() as String val
+      else
+        return "Cannot rename: symbol has no source location"
+      end
+    if not target_file.at(workspace_folder + Path.sep(), 0) then
+      return "Cannot rename: symbol is defined outside the workspace"
+    end
+
+    // Collect all occurrences including the declaration.
+    let locations = References.collect(node, packages, true)
+
+    // Group TextEdit objects by file URI and build the WorkspaceEdit.
+    let by_uri = Map[String, Array[LspLocation]]
+    for loc in locations.values() do
+      try
+        by_uri(loc.uri)?.push(loc)
+      else
+        by_uri(loc.uri) = Array[LspLocation].create() .> push(loc)
+      end
+    end
+
+    var changes = JsonObject
+    for (uri, locs) in by_uri.pairs() do
+      var edits = JsonArray
+      for loc in locs.values() do
+        edits =
+          edits.push(
+            JsonObject
+              .update("range", loc.range.to_json())
+              .update("newText", new_name))
+      end
+      changes = changes.update(uri, edits)
+    end
+    JsonObject.update("changes", changes)
+
+primitive _IsValidPonyIdentifier
+  """
+  Returns true if `name` is a syntactically valid Pony identifier:
+  first character must be [a-zA-Z_], subsequent characters [a-zA-Z0-9_'].
+  """
+  fun apply(name: String): Bool =>
+    if name.size() == 0 then return false end
+    var first = true
+    for c in name.values() do
+      if first then
+        first = false
+        if not (((c >= 'a') and (c <= 'z')) or
+                ((c >= 'A') and (c <= 'Z')) or
+                (c == '_'))
+        then
+          return false
+        end
+      else
+        if not (((c >= 'a') and (c <= 'z')) or
+                ((c >= 'A') and (c <= 'Z')) or
+                ((c >= '0') and (c <= '9')) or
+                (c == '_') or (c == '\''))
+        then
+          return false
+        end
+      end
+    end
+    true

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -675,9 +675,7 @@ actor WorkspaceManager
         LspPositionRange(
           LspPosition.from_ast_pos(start_pos),
           LspPosition.from_ast_pos_end(end_pos))
-      this._channel.send(
-        ResponseMessage(
-          request.id, JsonObject.update("range", range.to_json())))
+      this._channel.send(ResponseMessage(request.id, range.to_json()))
       return
     end
     this._channel.send(ResponseMessage.create(request.id, None))

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -617,6 +617,125 @@ actor WorkspaceManager
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be prepare_rename(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/prepareRename request.
+
+    Validates that the symbol at the given position can be renamed and returns
+    its identifier range. The client uses this range to pre-select text in the
+    rename dialog. Returns an error if the symbol is not renameable (literal,
+    synthetic node, or defined outside the workspace).
+    """
+    this._channel.log("Handling textDocument/prepareRename")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let document_path = Uris.to_path(document_uri)
+    match _find_node_and_module(document_path, line, column)
+    | (let node: AST box, _) =>
+      let target: AST val =
+        match \exhaustive\ _ResolveASTTarget(node)
+        | let t: AST val => t
+        | None =>
+          this._channel.send(
+            ResponseMessage.create(
+              request.id,
+              None,
+              ResponseError(
+                ErrorCodes.request_failed(), "Symbol is not renameable")))
+          return
+        end
+      let target_file: String val =
+        try
+          target.source_file() as String val
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              request.id,
+              None,
+              ResponseError(
+                ErrorCodes.request_failed(), "Symbol has no source location")))
+          return
+        end
+      if not target_file.at(workspace.folder.path + Path.sep(), 0) then
+        this._channel.send(
+          ResponseMessage.create(
+            request.id,
+            None,
+            ResponseError(
+              ErrorCodes.request_failed(),
+              "Symbol is defined outside the workspace")))
+        return
+      end
+      let ident_node = ASTIdentifier.identifier_node(node)
+      (let start_pos, let end_pos) = ident_node.span()
+      let range =
+        LspPositionRange(
+          LspPosition.from_ast_pos(start_pos),
+          LspPosition.from_ast_pos_end(end_pos))
+      this._channel.send(
+        ResponseMessage(
+          request.id, JsonObject.update("range", range.to_json())))
+      return
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be rename(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/rename request.
+    """
+    this._channel.log("Handling textDocument/rename")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let new_name: String val =
+      try
+        JsonNav(request.params)("newName").as_string()?
+      else
+        this._channel.send(
+          ResponseMessage.create(
+            request.id,
+            None,
+            ResponseError(
+              ErrorCodes.invalid_params(),
+              "Missing or invalid newName")))
+        return
+      end
+    if not _IsValidPonyIdentifier(new_name) then
+      this._channel.send(
+        ResponseMessage.create(
+          request.id,
+          None,
+          ResponseError(
+            ErrorCodes.invalid_params(),
+            "newName is not a valid Pony identifier")))
+      return
+    end
+    let document_path = Uris.to_path(document_uri)
+    match _find_node_and_module(document_path, line, column)
+    | (let node: AST box, _) =>
+      match \exhaustive\ Rename.collect(
+        node,
+        this._packages,
+        workspace.folder.path,
+        new_name)
+      | let workspace_edit: JsonObject val =>
+        this._channel.send(ResponseMessage(request.id, workspace_edit))
+      | let err_msg: String val =>
+        this._channel.send(
+          ResponseMessage.create(
+            request.id,
+            None,
+            ResponseError(ErrorCodes.request_failed(), err_msg)))
+      end
+      return
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
   be goto_definition(document_uri: String, request: RequestMessage val) =>
     """
     Handling the textDocument/definition request.


### PR DESCRIPTION
## Context

The Pony LSP supports navigation (go-to-definition, find-references, document-highlight) but has no rename support, requiring users to find and replace occurrences manually.

## Changes

- Implements `textDocument/rename`: collects all occurrences via the existing cross-package references walk and returns a `WorkspaceEdit` mapping file URIs to `TextEdit[]`.
- Implements `textDocument/prepareRename`: validates the cursor position before the editor prompts for a new name. Advertises `prepareProvider: true` in server capabilities.
- Extracts `_ResolveASTTarget` from the duplicate resolution logic in both `rename.pony` and `references.pony`.
- Rejects renames on literals and synthetic nodes (`request_failed`), on symbols defined outside the workspace (`request_failed`), and on invalid new names (`invalid_params`).
- Adds integration tests covering field, method, behaviour, class, type parameter, local variable, and parameter rename from both declaration and call sites, plus all three `prepareRename` cases.

Resolves #5172.

https://github.com/user-attachments/assets/7bb92d53-7b7a-4745-b9f0-443d21c4fbbe


https://github.com/user-attachments/assets/126e9660-2407-45ce-90d5-0dfe6ead8c19


https://github.com/user-attachments/assets/3c4a9586-8180-444f-b21d-f7781357cb7d


## Considerations

Trait method rename does not propagate to implementing classes — each implementing type's method is treated as a separate entity. Cross-package rename (symbols defined in-workspace but used by an external package not loaded into the server) is similarly out of scope. Both are known limitations.