### PR TITLE
Add LSP `textDocument/declaration` support

### DIFF
--- a/.release-notes/add_lsp_declaration_support.md
+++ b/.release-notes/add_lsp_declaration_support.md
@@ -1,0 +1,3 @@
+## Add LSP `textDocument/declaration` support
+
+The Pony language server now handles `textDocument/declaration` requests. In Pony there are no separate declaration sites — declaration and definition are always the same location — so the handler routes directly to the existing go-to-definition implementation. The server advertises `declarationProvider: true` in its capabilities.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -126,6 +126,8 @@ actor LanguageServer is (Notifier & RequestSender)
             )
           )
         end
+      // In Pony, declaration and definition are the same location.
+      | Methods.text_document().declaration()
       | Methods.text_document().definition() =>
         try
           let document_uri =
@@ -423,6 +425,7 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("change", I64(0))
                     .update("openClose", true)
                     .update("save", JsonObject.update("includeText", true)))
+                .update("declarationProvider", true)
                 .update("definitionProvider", true)
                 .update("referencesProvider", true)
                 .update(

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -86,6 +86,9 @@ primitive TextDocumentMethods
   Collection of textDocument scoped methods.
   """
 
+  fun declaration(): String val =>
+    "textDocument/declaration"
+
   fun definition(): String val =>
     "textDocument/definition"
 

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -621,7 +621,7 @@ actor WorkspaceManager
     """
     Handling the textDocument/definition request.
     """
-    this._channel.log("handling textDocument/definition")
+    this._channel.log("handling " + request.method)
     this._current_request = request
     (let line, let column) =
       match \exhaustive\ _parse_hover_position(request)


### PR DESCRIPTION
## Context

The Pony LSP supports go-to-definition but does not respond to `textDocument/declaration` requests, causing editors that send declaration requests to receive no result.

## Changes

- Routes `textDocument/declaration` to the existing `goto_definition` handler. In Pony, declaration and definition are always the same location — there are no separate declaration sites.
- Advertises `declarationProvider: true` in server capabilities.
- Updates the `goto_definition` log line to use `request.method` so declaration requests are logged correctly.

Resolves #5176.