### PR TITLE
Add LSP `textDocument/foldingRange` support

### DIFF
--- a/.release-notes/lsp-folding-range.md
+++ b/.release-notes/lsp-folding-range.md
@@ -2,6 +2,6 @@
 
 The Pony language server now handles `textDocument/foldingRange` requests, enabling editors to show fold regions for Pony source files.
 
-A fold range is emitted for each top-level type entity (class, actor, struct, primitive, trait, interface) and for each multi-line member (fun, be, new). Within method bodies, fold ranges are also emitted for compound expressions: if, ifdef, while, for, repeat, match, try, object, lambda, and recover blocks. Single-line nodes are excluded since there is nothing to fold.
+A fold range is emitted for each top-level type entity (class, actor, struct, primitive, trait, interface) and for each multi-line member (fun, be, new). Within method bodies, fold ranges are also emitted for compound expressions: if (including ifdef, which is resolved to if by the compiler), while, for, repeat, match, try, and recover blocks. Single-line nodes are excluded since there is nothing to fold.
 
 The server also sends `workspace/foldingRange/refresh` after each compilation when the editor advertises support for it, so that fold regions update automatically when files change.

--- a/.release-notes/lsp-folding-range.md
+++ b/.release-notes/lsp-folding-range.md
@@ -2,6 +2,6 @@
 
 The Pony language server now handles `textDocument/foldingRange` requests, enabling editors to show fold regions for Pony source files.
 
-A fold range is emitted for each top-level type entity (class, actor, struct, primitive, trait, interface) and for each multi-line member (fun, be, new). Within method bodies, fold ranges are also emitted for compound expressions: if (including ifdef, which is resolved to if by the compiler), while, for, repeat, match, try, and recover blocks. Single-line nodes are excluded since there is nothing to fold.
+A fold range is emitted for each top-level type entity (class, actor, struct, primitive, trait, interface) and for each multi-line member (fun, be, new). Within method bodies, fold ranges are also emitted for compound expressions: if (including ifdef, resolved to if by the compiler), while (including for, desugared to while by the compiler), repeat, match, try, and recover blocks. Single-line nodes are excluded since there is nothing to fold.
 
 The server also sends `workspace/foldingRange/refresh` after each compilation when the editor advertises support for it, so that fold regions update automatically when files change.

--- a/.release-notes/lsp-folding-range.md
+++ b/.release-notes/lsp-folding-range.md
@@ -1,0 +1,7 @@
+## Add LSP `textDocument/foldingRange` support
+
+The Pony language server now handles `textDocument/foldingRange` requests, enabling editors to show fold regions for Pony source files.
+
+A fold range is emitted for each top-level type entity (class, actor, struct, primitive, trait, interface) and for each multi-line member (fun, be, new). Within method bodies, fold ranges are also emitted for compound expressions: if, ifdef, while, for, repeat, match, try, object, lambda, and recover blocks. Single-line nodes are excluded since there is nothing to fold.
+
+The server also sends `workspace/foldingRange/refresh` after each compilation when the editor advertises support for it, so that fold regions update automatically when files change.

--- a/tools/pony-lsp/client.pony
+++ b/tools/pony-lsp/client.pony
@@ -15,6 +15,7 @@ class val Client
   let _supports_publish_diagnostic_related_info: Bool
   let _supports_workspace_diagnostic_refresh: Bool
   let _supports_inlay_hint_refresh: Bool
+  let _supports_folding_range_refresh: Bool
   let _supports_window_work_done_progress: Bool
 
   new val from(initialize_params: JsonObject) =>
@@ -98,6 +99,14 @@ class val Client
       else
         false
       end
+    this._supports_folding_range_refresh =
+      try
+        JsonPathParser.compile(
+          "$.workspace.foldingRange.refreshSupport"
+        )?.query_one(this.capabilities) as Bool
+      else
+        false
+      end
     this._supports_window_work_done_progress =
       try
         JsonPathParser.compile(
@@ -146,6 +155,14 @@ class val Client
     request (InlayHintWorkspaceClientCapabilities.refreshSupport).
     """
     this._supports_inlay_hint_refresh
+
+  fun supports_folding_range_refresh(): Bool =>
+    """
+    Returns `true` if the client supports the
+    `workspace/foldingRange/refresh` request
+    (FoldingRangeWorkspaceClientCapabilities.refreshSupport).
+    """
+    this._supports_folding_range_refresh
 
   fun supports_window_work_done_progress(): Bool =>
     """
@@ -196,6 +213,9 @@ class val Client
       end
       if this.supports_inlay_hint_refresh() then
         s.append("\trefreshing inlay hints\r\n")
+      end
+      if this.supports_folding_range_refresh() then
+        s.append("\trefreshing folding ranges\r\n")
       end
       if this.supports_window_work_done_progress() then
         s.append("\tserver-initiated workDoneProgress\r\n")

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -182,6 +182,21 @@ actor LanguageServer is (Notifier & RequestSender)
             )
           )
         end
+      | Methods.text_document().folding_range() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .folding_range(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().diagnostic() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -435,6 +450,7 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("interFileDependencies", true)
                     .update("workspaceDiagnostics", false))
                 .update("documentSymbolProvider", true)
+                .update("foldingRangeProvider", true)
                 .update(
                   "inlayHintProvider",
                   JsonObject.update("resolveProvider", false)))

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -194,7 +194,7 @@ actor LanguageServer is (Notifier & RequestSender)
               None,
               ResponseError(
                 ErrorCodes.internal_error(),
-                "[" + r.method + "] No workspace found for '" +
+                "[" + r.method + "] No workspace found for request '" +
                 r.json().string() + "'")))
         end
       | Methods.text_document().diagnostic() =>

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -62,8 +62,19 @@ primitive WorkspaceMethods
   fun diagnostic(): WorkspaceDiagnosticMethods =>
     WorkspaceDiagnosticMethods
 
+  fun folding_range(): WorkspaceFoldingRangeMethods =>
+    WorkspaceFoldingRangeMethods
+
   fun inlay_hint(): WorkspaceInlayHintMethods =>
     WorkspaceInlayHintMethods
+
+primitive WorkspaceFoldingRangeMethods
+  """
+  Collection of workspace/foldingRange related methods.
+  """
+
+  fun refresh(): String val =>
+    "workspace/foldingRange/refresh"
 
 primitive WorkspaceInlayHintMethods
   """
@@ -109,6 +120,9 @@ primitive TextDocumentMethods
 
   fun document_symbol(): String val =>
     "textDocument/documentSymbol"
+
+  fun folding_range(): String val =>
+    "textDocument/foldingRange"
 
   fun hover(): String val =>
     "textDocument/hover"

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -1,0 +1,309 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _FoldingRangeIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_FoldingRangeClassTest.create(server))
+    test(_FoldingRangeEntityTypesTest.create(server))
+    test(_FoldingRangeExpressionsRangesTest.create(server))
+    test(_FoldingRangeTypeRangeTest.create(server))
+    test(_FoldingRangeMoreExpressionsRangesTest.create(server))
+
+class \nodoc\ iso _FoldingRangeClassTest is UnitTest
+  """
+  FoldingRange for foldable.pony. Verifies that the class body and
+  multi-line methods each produce a range, and that a single-line
+  method is excluded.
+
+  folding.pony layout (0-indexed lines):
+    line  0:  class Foldable
+    line  1:    \"\"\"
+    line  2:    A class with members to test folding ranges.
+    line  3:    \"\"\"
+    line  4:    var _x: U32 = 0
+    line  5:    (blank)
+    line  6:    new create(x: U32) =>
+    line  7:      _x = x
+    line  8:    (blank)
+    line  9:    fun get_value(): U32 =>
+    line 10:      _x
+    line 11:    (blank)
+    line 12:    fun single_line(): U32 => _x
+
+  Expected fold ranges:
+    (0, 12) — class Foldable body
+    (6,  7) — new create body
+    (9, 10) — fun get_value body
+    fun single_line is single-line (startLine == endLine) — excluded
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/class"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/foldable.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 12)
+              (6, 7)
+              (9, 10)]))])
+
+class \nodoc\ iso _FoldingRangeEntityTypesTest is UnitTest
+  """
+  FoldingRange for entity_types.pony. Verifies that fold ranges are produced
+  for all entity types (primitive, struct, actor, trait, interface) and their
+  multi-line members, including be behaviors.
+
+  Struct and actor receive explicit single-line constructors so that ponyc
+  does not generate synthetic constructors, which would appear as extra ranges.
+
+  entity_types.pony layout (0-indexed lines):
+    line  0: primitive P                → (0, 2)
+    line  1:   fun value(): U32 =>      → (1, 2)
+    line  4: struct S                   → (4, 9)
+    line  6:   new create() => None     — single-line, excluded
+    line  8:   fun get(): U32 =>        → (8, 9)
+    line 11: actor A                    → (11, 19)
+    line 13:   new create() => _n = 0   — single-line, excluded
+    line 15:   be tick() =>             → (15, 16)
+    line 18:   fun count(): U32 =>      → (18, 19)
+    line 21: trait T                    → (21, 25)
+    line 24:   fun doubled(): U32 =>    → (24, 25)
+    line 27: interface I                → (27, 31)
+    line 30:   fun tripled(): U32 =>    → (30, 31)
+    fun required(): U32 (lines 22, 28) — single-line, excluded
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/entity_types"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/entity_types.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 2)
+              (1, 2)
+              (4, 9)
+              (8, 9)
+              (11, 19)
+              (15, 16)
+              (18, 19)
+              (21, 25)
+              (24, 25)
+              (27, 31)
+              (30, 31)]))])
+
+class \nodoc\ iso _FoldingRangeExpressionsRangesTest is UnitTest
+  """
+  FoldingRange for expressions.pony: verifies all 9 exact (startLine, endLine)
+  pairs — 1 class, 4 methods, and 4 expression-level ranges.
+
+  `end` keywords have no source position in the typechecked AST, so endLine
+  is always the last real statement/expression before `end`.
+
+  expressions.pony layout (0-indexed lines):
+    line  0: class Expressions             → (0, 31)
+    line  5: fun with_if                   → (5, 9)
+    line  6:   if x > 0 then ... end      → (6, 9)   last child: `0` at line 9
+    line 12: fun with_match                → (12, 17)
+    line 13:   match x ... end            → (13, 17)  last child: `"many"` at line 17
+    line 20: fun with_while                → (20, 25)
+    line 22:   while i < x do ... end     → (22, 23)  last child: `i = i + 1` at line 23
+    line 27: fun with_try                  → (27, 31)
+    line 28:   try ... else ... end       → (28, 31)  last child: `0` at line 31
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/expressions_ranges"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/expressions.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 31)
+              (5, 9)
+              (6, 9)
+              (12, 17)
+              (13, 17)
+              (20, 25)
+              (22, 23)
+              (27, 31)
+              (28, 31)]))])
+
+class \nodoc\ iso _FoldingRangeTypeRangeTest is UnitTest
+  """
+  FoldingRange for type_alias.pony: verifies the range spans lines 0–4.
+
+  type_alias.pony layout (0-indexed lines):
+    line 0: type TypeAlias is
+    line 1:   ( U32
+    line 2:   | String
+    line 3:   | None
+    line 4:   )
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/type_range"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/type_alias.pony",
+      [(0, 0, _FoldingRangeChecker([(0, 4)]))])
+
+class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
+  """
+  FoldingRange for more_expressions.pony: verifies all 14 exact
+  (startLine, endLine) pairs — 2 classes, 6 methods, and 6 expression ranges.
+
+  `end` keywords have no source position in the typechecked AST, so endLine
+  is always the last real statement/expression before `end`.
+
+  more_expressions.pony layout (0-indexed lines):
+    line  0: class _D                          → (0, 2)
+    line  4: class MoreExpressions             → (4, 46)
+    line  9: fun with_for                      → (9, 14)
+    line 11:   for i in [...].values() do end  → (11, 12)  last: `sum = sum + i`
+    line 16: fun with_repeat                   → (16, 21)
+    line 18:   repeat...until i >= 3 end       → (18, 20)  last: condition `i >= 3`
+    line 23: fun with_with                     → (23, 25)
+    line 28: fun with_object                   → (28, 33)
+    line 30:   object...end                    → (30, 31)  last: `fun value` body
+    line 35: fun with_lambda                   → (35, 40)
+    line 37:   {(): String =>...}              → (37, 38) × 2  last: `"hello world"`
+    line 42: fun with_recover                  → (42, 46)
+    line 43:   recover...end                   → (43, 46)  last: `consume s`
+  (Lambda produces two ranges: one for tk_lambda, one for the desugared
+   tk_object. Both span the same lines.
+   `with` desugars before the typechecked AST; tk_with never appears, so
+   no expression-level range is produced for with_with.)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/more_expressions_ranges"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/more_expressions.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 2)
+              (4, 46)
+              (9, 14)
+              (11, 12)
+              (16, 21)
+              (18, 20)
+              (23, 25)
+              (28, 33)
+              (30, 31)
+              (35, 40)
+              (37, 38)
+              (37, 38)
+              (42, 46)
+              (43, 46)]))])
+
+class val _FoldingRangeChecker
+  """
+  Validates a textDocument/foldingRange response. Each expected entry is
+  (startLine, endLine). Asserts that every expected range appears in the
+  response and that the total count matches.
+  """
+  let _expected: Array[(I64, I64)] val
+
+  new val create(expected: Array[(I64, I64)] val) =>
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().folding_range()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    try
+      let ranges = res.result as JsonArray
+      if not h.assert_eq[USize](
+        _expected.size(),
+        ranges.size(),
+        "Expected " + _expected.size().string() +
+        " ranges, got " + ranges.size().string())
+      then
+        ok = false
+      end
+      for (exp_sl, exp_el) in _expected.values() do
+        var found = false
+        for range_val in ranges.values() do
+          try
+            let sl = JsonNav(range_val)("startLine").as_i64()?
+            let el = JsonNav(range_val)("endLine").as_i64()?
+            if (sl == exp_sl) and (el == exp_el) then
+              found = true
+              break
+            end
+          end
+        end
+        if not h.assert_true(
+          found,
+          "Expected (" + exp_sl.string() + ", " + exp_el.string() + ") not found")
+        then
+          ok = false
+        end
+      end
+      if not ok then
+        h.log("Actual ranges:")
+        for r in ranges.values() do
+          try
+            let sl = JsonNav(r)("startLine").as_i64()?
+            let el = JsonNav(r)("endLine").as_i64()?
+            h.log("  (" + sl.string() + ", " + el.string() + ")")
+          end
+        end
+      end
+    else
+      h.log(
+        "Expected foldingRange array but got: " + res.string())
+      return false
+    end
+    ok

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -196,7 +196,7 @@ class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
   more_expressions.pony layout (0-indexed lines):
     line  0: class MoreExpressions             → (0, 42)
     line  5: fun with_for                      → (5, 10)
-    line  7:   for i in [...].values() do end  → (7, 8)    last: `sum = sum + i`
+    line  7:   for i in [...].values() do end  → (7, 8)    via tk_while after sugar
     line 12: fun with_repeat                   → (12, 17)
     line 14:   repeat...until i >= 3 end       → (14, 16)  last: `i >= 3`
     line 19: fun with_with                     → (19, 21)

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -16,6 +16,7 @@ primitive _FoldingRangeIntegrationTests is TestList
     test(_FoldingRangeMoreExpressionsRangesTest.create(server))
     test(_FoldingRangeIfdefTest.create(server))
     test(_FoldingRangeNestedExpressionsTest.create(server))
+    test(_FoldingRangeForExpressionsTest.create(server))
 
 class \nodoc\ iso _FoldingRangeClassTest is UnitTest
   """
@@ -393,3 +394,40 @@ class \nodoc\ iso _FoldingRangeNestedExpressionsTest is UnitTest
               (15, 25)
               (17, 20)
               (22, 23)]))])
+
+class \nodoc\ iso _FoldingRangeForExpressionsTest is UnitTest
+  """
+  FoldingRange for for_expressions.pony: verifies that for loops produce
+  fold ranges via the tk_while arm after sugar_for() desugaring.
+
+  Tests a multi-statement for body and a nested if inside a for body.
+
+  for_expressions.pony layout (0-indexed lines):
+    line  0: class ForExpressions                  → (0, 21)
+    line  6:   fun with_multi_statement_for        → (6, 12)
+    line  8:     for i in Range[U32](0, n) do      → (8, 10)  via tk_while
+    line 14:   fun with_nested_for(n: U32): U32    → (14, 21)
+    line 16:     for i in Range[U32](0, n) do      → (16, 19)  via tk_while
+    line 17:       if (i % 2) == 0 then            → (17, 18)  nested inside for
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/for_expressions"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/for_expressions.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 21)
+              (6, 12)
+              (8, 10)
+              (14, 21)
+              (16, 19)
+              (17, 18)]))])

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -196,7 +196,7 @@ class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
   more_expressions.pony layout (0-indexed lines):
     line  0: class MoreExpressions             → (0, 42)
     line  5: fun with_for                      → (5, 10)
-    line  7:   for i in [...].values() do end  → (7, 8)    via tk_while after sugar
+    line  7:   for i in [...].values() do end  → (7, 8)    via tk_while
     line 12: fun with_repeat                   → (12, 17)
     line 14:   repeat...until i >= 3 end       → (14, 16)  last: `i >= 3`
     line 19: fun with_with                     → (19, 21)
@@ -268,6 +268,9 @@ class val _FoldingRangeChecker
     None
 
   fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
     None
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -73,18 +73,18 @@ class \nodoc\ iso _FoldingRangeEntityTypesTest is UnitTest
   entity_types.pony layout (0-indexed lines):
     line  0: primitive P                → (0, 2)
     line  1:   fun value(): U32 =>      → (1, 2)
-    line  4: struct S                   → (4, 9)
-    line  6:   new create() => None     — single-line, excluded
-    line  8:   fun get(): U32 =>        → (8, 9)
-    line 11: actor A                    → (11, 19)
-    line 13:   new create() => _n = 0   — single-line, excluded
-    line 15:   be tick() =>             → (15, 16)
-    line 18:   fun count(): U32 =>      → (18, 19)
-    line 21: trait T                    → (21, 25)
-    line 24:   fun doubled(): U32 =>    → (24, 25)
-    line 27: interface I                → (27, 31)
-    line 30:   fun tripled(): U32 =>    → (30, 31)
-    fun required(): U32 (lines 22, 28) — single-line, excluded
+    line  4: struct S                   → (4, 10)
+    line  7:   new create() => None     — single-line, excluded
+    line  9:   fun get(): U32 =>        → (9, 10)
+    line 12: actor A                    → (12, 21)
+    line 15:   new create() => _n = 0   — single-line, excluded
+    line 17:   be tick() =>             → (17, 18)
+    line 20:   fun count(): U32 =>      → (20, 21)
+    line 23: trait T                    → (23, 27)
+    line 26:   fun doubled(): U32 =>    → (26, 27)
+    line 29: interface EntityTypes       → (29, 33)
+    line 32:   fun tripled(): U32 =>    → (32, 33)
+    fun required(): U32 (lines 24, 30) — single-line, excluded
   """
   let _server: _LspTestServer
 
@@ -103,15 +103,15 @@ class \nodoc\ iso _FoldingRangeEntityTypesTest is UnitTest
           _FoldingRangeChecker(
             [ (0, 2)
               (1, 2)
-              (4, 9)
-              (8, 9)
-              (11, 19)
-              (15, 16)
-              (18, 19)
-              (21, 25)
-              (24, 25)
-              (27, 31)
-              (30, 31)]))])
+              (4, 10)
+              (9, 10)
+              (12, 21)
+              (17, 18)
+              (20, 21)
+              (23, 27)
+              (26, 27)
+              (29, 33)
+              (32, 33)]))])
 
 class \nodoc\ iso _FoldingRangeExpressionsRangesTest is UnitTest
   """
@@ -126,9 +126,9 @@ class \nodoc\ iso _FoldingRangeExpressionsRangesTest is UnitTest
     line  5: fun with_if                   → (5, 9)
     line  6:   if x > 0 then ... end      → (6, 9)   last child: `0` at line 9
     line 12: fun with_match                → (12, 17)
-    line 13:   match x ... end            → (13, 17)  last child: `"many"` at line 17
+    line 13:   match x ... end            → (13, 17)  last child:  at line 17
     line 20: fun with_while                → (20, 25)
-    line 22:   while i < x do ... end     → (22, 23)  last child: `i = i + 1` at line 23
+    line 22:   while i < x do ... end     → (22, 23)  last child:  at line 23
     line 27: fun with_try                  → (27, 31)
     line 28:   try ... else ... end       → (28, 31)  last child: `0` at line 31
   """
@@ -185,30 +185,39 @@ class \nodoc\ iso _FoldingRangeTypeRangeTest is UnitTest
 
 class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
   """
-  FoldingRange for more_expressions.pony: verifies all 14 exact
-  (startLine, endLine) pairs — 2 classes, 6 methods, and 6 expression ranges.
+  FoldingRange for more_expressions.pony: verifies all 13 exact
+  (startLine, endLine) pairs — 2 classes, 6 methods, and 5 expression ranges.
 
   `end` keywords have no source position in the typechecked AST, so endLine
   is always the last real statement/expression before `end`.
 
   more_expressions.pony layout (0-indexed lines):
-    line  0: class _D                          → (0, 2)
-    line  4: class MoreExpressions             → (4, 46)
-    line  9: fun with_for                      → (9, 14)
-    line 11:   for i in [...].values() do end  → (11, 12)  last: `sum = sum + i`
-    line 16: fun with_repeat                   → (16, 21)
-    line 18:   repeat...until i >= 3 end       → (18, 20)  last: condition `i >= 3`
-    line 23: fun with_with                     → (23, 25)
-    line 28: fun with_object                   → (28, 33)
-    line 30:   object...end                    → (30, 31)  last: `fun value` body
-    line 35: fun with_lambda                   → (35, 40)
-    line 37:   {(): String =>...}              → (37, 38) × 2  last: `"hello world"`
-    line 42: fun with_recover                  → (42, 46)
-    line 43:   recover...end                   → (43, 46)  last: `consume s`
-  (Lambda produces two ranges: one for tk_lambda, one for the desugared
-   tk_object. Both span the same lines.
-   `with` desugars before the typechecked AST; tk_with never appears, so
-   no expression-level range is produced for with_with.)
+    line  0: class MoreExpressions             → (0, 42)
+    line  5: fun with_for                      → (5, 10)
+    line  7:   for i in [...].values() do end  → (7, 8)    last: `sum = sum + i`
+    line 12: fun with_repeat                   → (12, 17)
+    line 14:   repeat...until i >= 3 end       → (14, 16)  last: `i >= 3`
+    line 19: fun with_with                     → (19, 21)
+    line 24: fun with_object                   → (24, 29)
+    line 26:   object...end                    → (26, 27)  via synthetic class
+    line 31: fun with_lambda                   → (31, 36)
+    line 33:   {(): String =>...}              → (33, 34)  via synthetic class
+    line 38: fun with_recover                  → (38, 42)
+    line 39:   recover...end                   → (39, 42)  last: `consume s`
+    line 45: class _D                          → (45, 47)
+
+  After PassExpr, ponyc replaces `object`/lambda literals in method bodies
+  with constructor calls and appends synthetic entity classes to the module.
+  The synthetic classes carry the source position of the original expression,
+  so we emit fold ranges for them rather than scanning method bodies for
+  tk_object/tk_lambda (which are no longer there after desugaring).
+
+  `with` desugars before the typechecked AST; tk_with never appears, so
+  no expression-level range is produced for with_with.
+
+  The cap approach (next entity's line) prevents synthetic nodes from the
+  desugared `with_with` dispose call (positioned at _D's line) from inflating
+  MoreExpressions' end line past line 42.
   """
   let _server: _LspTestServer
 
@@ -225,20 +234,19 @@ class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
       "folding_range/more_expressions.pony",
       [ ( 0, 0,
           _FoldingRangeChecker(
-            [ (0, 2)
-              (4, 46)
-              (9, 14)
-              (11, 12)
-              (16, 21)
-              (18, 20)
-              (23, 25)
-              (28, 33)
-              (30, 31)
-              (35, 40)
-              (37, 38)
-              (37, 38)
-              (42, 46)
-              (43, 46)]))])
+            [ (0, 42)
+              (5, 10)
+              (7, 8)
+              (12, 17)
+              (14, 16)
+              (19, 21)
+              (24, 29)
+              (26, 27)
+              (31, 36)
+              (33, 34)
+              (38, 42)
+              (39, 42)
+              (45, 47)]))])
 
 class val _FoldingRangeChecker
   """
@@ -286,7 +294,8 @@ class val _FoldingRangeChecker
         end
         if not h.assert_true(
           found,
-          "Expected (" + exp_sl.string() + ", " + exp_el.string() + ") not found")
+          "Expected (" + exp_sl.string() + ", " +
+          exp_el.string() + ") not found")
         then
           ok = false
         end

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -14,6 +14,7 @@ primitive _FoldingRangeIntegrationTests is TestList
     test(_FoldingRangeExpressionsRangesTest.create(server))
     test(_FoldingRangeTypeRangeTest.create(server))
     test(_FoldingRangeMoreExpressionsRangesTest.create(server))
+    test(_FoldingRangeIfdefTest.create(server))
 
 class \nodoc\ iso _FoldingRangeClassTest is UnitTest
   """
@@ -316,3 +317,32 @@ class val _FoldingRangeChecker
       return false
     end
     ok
+
+class \nodoc\ iso _FoldingRangeIfdefTest is UnitTest
+  """
+  FoldingRange for ifdef_expressions.pony: verifies that an ifdef block
+  produces an expression-level folding range.
+
+  ifdef_expressions.pony layout (0-indexed lines):
+    line 0: class IfdefExpressions          → (0, 8)
+    line 4:   fun with_ifdef(x: U32): U32   → (4, 8)
+    line 5:     ifdef debug then ... end    → (5, 8)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/ifdef"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/ifdef_expressions.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 8)
+              (4, 8)
+              (5, 8)]))])

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -251,78 +251,6 @@ class \nodoc\ iso _FoldingRangeMoreExpressionsRangesTest is UnitTest
               (39, 42)
               (45, 47)]))])
 
-class val _FoldingRangeChecker
-  """
-  Validates a textDocument/foldingRange response. Each expected entry is
-  (startLine, endLine). Asserts that every expected range appears in the
-  response and that the total count matches.
-  """
-  let _expected: Array[(I64, I64)] val
-
-  new val create(expected: Array[(I64, I64)] val) =>
-    _expected = expected
-
-  fun lsp_method(): String =>
-    Methods.text_document().folding_range()
-
-  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
-    None
-
-  fun lsp_context(): (None | JsonObject) =>
-    None
-
-  fun lsp_extra_params(): (None | JsonObject) =>
-    None
-
-  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
-    var ok = true
-    try
-      let ranges = res.result as JsonArray
-      if not h.assert_eq[USize](
-        _expected.size(),
-        ranges.size(),
-        "Expected " + _expected.size().string() +
-        " ranges, got " + ranges.size().string())
-      then
-        ok = false
-      end
-      for (exp_sl, exp_el) in _expected.values() do
-        var found = false
-        for range_val in ranges.values() do
-          try
-            let sl = JsonNav(range_val)("startLine").as_i64()?
-            let el = JsonNav(range_val)("endLine").as_i64()?
-            if (sl == exp_sl) and (el == exp_el) then
-              found = true
-              break
-            end
-          end
-        end
-        if not h.assert_true(
-          found,
-          "Expected (" + exp_sl.string() + ", " +
-          exp_el.string() + ") not found")
-        then
-          ok = false
-        end
-      end
-      if not ok then
-        h.log("Actual ranges:")
-        for r in ranges.values() do
-          try
-            let sl = JsonNav(r)("startLine").as_i64()?
-            let el = JsonNav(r)("endLine").as_i64()?
-            h.log("  (" + sl.string() + ", " + el.string() + ")")
-          end
-        end
-      end
-    else
-      h.log(
-        "Expected foldingRange array but got: " + res.string())
-      return false
-    end
-    ok
-
 class \nodoc\ iso _FoldingRangeIfdefTest is UnitTest
   """
   FoldingRange for ifdef_expressions.pony: verifies that an ifdef block
@@ -431,3 +359,74 @@ class \nodoc\ iso _FoldingRangeForExpressionsTest is UnitTest
               (14, 21)
               (16, 19)
               (17, 18)]))])
+
+class val _FoldingRangeChecker
+  """
+  Validates a textDocument/foldingRange response. Each expected entry is
+  (startLine, endLine). Asserts that every expected range appears in the
+  response and that the total count matches.
+  """
+  let _expected: Array[(I64, I64)] val
+
+  new val create(expected: Array[(I64, I64)] val) =>
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().folding_range()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    try
+      let ranges = res.result as JsonArray
+      if not h.assert_eq[USize](
+        _expected.size(),
+        ranges.size(),
+        "Expected " + _expected.size().string() +
+        " ranges, got " + ranges.size().string())
+      then
+        ok = false
+      end
+      for (exp_sl, exp_el) in _expected.values() do
+        var found = false
+        for range_val in ranges.values() do
+          try
+            let sl = JsonNav(range_val)("startLine").as_i64()?
+            let el = JsonNav(range_val)("endLine").as_i64()?
+            if (sl == exp_sl) and (el == exp_el) then
+              found = true
+              break
+            end
+          end
+        end
+        if not h.assert_true(
+          found,
+          "Expected (" + exp_sl.string() + ", " +
+          exp_el.string() + ") not found")
+        then
+          ok = false
+        end
+      end
+      if not ok then
+        h.log("Actual ranges:")
+        for r in ranges.values() do
+          try
+            let sl = JsonNav(r)("startLine").as_i64()?
+            let el = JsonNav(r)("endLine").as_i64()?
+            h.log("  (" + sl.string() + ", " + el.string() + ")")
+          end
+        end
+      end
+    else
+      h.log("Expected foldingRange array but got: " + res.string())
+      return false
+    end
+    ok

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -15,6 +15,7 @@ primitive _FoldingRangeIntegrationTests is TestList
     test(_FoldingRangeTypeRangeTest.create(server))
     test(_FoldingRangeMoreExpressionsRangesTest.create(server))
     test(_FoldingRangeIfdefTest.create(server))
+    test(_FoldingRangeNestedExpressionsTest.create(server))
 
 class \nodoc\ iso _FoldingRangeClassTest is UnitTest
   """
@@ -323,10 +324,14 @@ class \nodoc\ iso _FoldingRangeIfdefTest is UnitTest
   FoldingRange for ifdef_expressions.pony: verifies that an ifdef block
   produces an expression-level folding range.
 
+  `ifdef` is resolved to `if` by resolve_ifdef() during the expr pass, so the
+  fold range is produced by the tk_if arm, not a tk_ifdef arm. The test
+  verifies the correct user-facing behavior regardless of the internal token.
+
   ifdef_expressions.pony layout (0-indexed lines):
     line 0: class IfdefExpressions          → (0, 8)
     line 4:   fun with_ifdef(x: U32): U32   → (4, 8)
-    line 5:     ifdef debug then ... end    → (5, 8)
+    line 5:     ifdef debug then ... end    → (5, 8)  via tk_if after resolution
   """
   let _server: _LspTestServer
 
@@ -346,3 +351,42 @@ class \nodoc\ iso _FoldingRangeIfdefTest is UnitTest
             [ (0, 8)
               (4, 8)
               (5, 8)]))])
+
+class \nodoc\ iso _FoldingRangeNestedExpressionsTest is UnitTest
+  """
+  FoldingRange for nested_expressions.pony: verifies that compound expressions
+  nested within other compound expressions each produce their own fold range,
+  and that sequential compound expressions in a single method body both produce
+  fold ranges.
+
+  nested_expressions.pony layout (0-indexed lines):
+    line  0: class NestedExpressions             → (0, 25)
+    line  4:   fun with_nested(n: U32): U32 =>   → (4, 13)
+    line  6:     while i < n do                  → (6, 11)  last: if's `end`
+    line  7:       if (i % 2) == 0 then          → (7, 10)  nested inside while
+    line 15:   fun with_sequential(n: U32): U32  → (15, 25)
+    line 17:     if n > 0 then                   → (17, 20)  first sequential
+    line 22:     while result > 0 do             → (22, 23)  second sequential
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "folding_range/integration/nested_expressions"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "folding_range/nested_expressions.pony",
+      [ ( 0, 0,
+          _FoldingRangeChecker(
+            [ (0, 25)
+              (4, 13)
+              (6, 11)
+              (7, 10)
+              (15, 25)
+              (17, 20)
+              (22, 23)]))])

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -29,6 +29,7 @@ actor Main is TestList
     _DocumentHighlightIntegrationTests.make().tests(test)
     _InlayHintIntegrationTests.make().tests(test)
     _ReferencesIntegrationTests.make().tests(test)
+    _FoldingRangeIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/folding_range/entity_types.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/entity_types.pony
@@ -1,16 +1,18 @@
-primitive P
+primitive \nodoc\ P
   fun value(): U32 =>
     42
 
-struct S
+struct \nodoc\ S
   var x: U32 = 0
+
   new create() => None
 
   fun get(): U32 =>
     x
 
-actor A
+actor \nodoc\ A
   var _n: U32 = 0
+
   new create() => _n = 0
 
   be tick() =>
@@ -19,14 +21,14 @@ actor A
   fun count(): U32 =>
     _n
 
-trait T
-  fun required(): U32
+trait \nodoc\ T
+  fun \nodoc\ required(): U32
 
   fun doubled(): U32 =>
     required() * 2
 
-interface I
-  fun required(): U32
+interface \nodoc\ EntityTypes
+  fun \nodoc\ required(): U32
 
   fun tripled(): U32 =>
     required() * 3

--- a/tools/pony-lsp/test/workspace/folding_range/entity_types.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/entity_types.pony
@@ -1,0 +1,32 @@
+primitive P
+  fun value(): U32 =>
+    42
+
+struct S
+  var x: U32 = 0
+  new create() => None
+
+  fun get(): U32 =>
+    x
+
+actor A
+  var _n: U32 = 0
+  new create() => _n = 0
+
+  be tick() =>
+    _n = _n + 1
+
+  fun count(): U32 =>
+    _n
+
+trait T
+  fun required(): U32
+
+  fun doubled(): U32 =>
+    required() * 2
+
+interface I
+  fun required(): U32
+
+  fun tripled(): U32 =>
+    required() * 3

--- a/tools/pony-lsp/test/workspace/folding_range/expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/expressions.pony
@@ -1,0 +1,33 @@
+class Expressions
+  """
+  Test fixture for expression-level folding ranges.
+  Contains one method per compound expression type.
+  """
+  fun with_if(x: U32): U32 =>
+    if x > 0 then
+      x + 1
+    else
+      0
+    end
+
+  fun with_match(x: U32): String =>
+    match x
+    | 0 => "zero"
+    | 1 => "one"
+    else
+      "many"
+    end
+
+  fun with_while(x: U32): U32 =>
+    var i: U32 = 0
+    while i < x do
+      i = i + 1
+    end
+    i
+
+  fun with_try(arr: Array[U32] box): U32 =>
+    try
+      arr(0)?
+    else
+      0
+    end

--- a/tools/pony-lsp/test/workspace/folding_range/foldable.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/foldable.pony
@@ -1,0 +1,13 @@
+class Foldable
+  """
+  A class with members to test folding ranges.
+  """
+  var _x: U32 = 0
+
+  new create(x: U32) =>
+    _x = x
+
+  fun get_value(): U32 =>
+    _x
+
+  fun single_line(): U32 => _x

--- a/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
@@ -1,0 +1,77 @@
+"""
+Test fixtures for exercising LSP textDocument/foldingRange functionality.
+
+A fold range is emitted for each multi-line top-level entity (class, actor,
+struct, primitive, trait, interface, type alias), each multi-line member
+(fun, be, new), and each multi-line compound expression within a method body
+(if, ifdef, while, for, repeat, match, try, object, lambda, recover).
+Single-line nodes are excluded since there is nothing to fold.
+
+Note: `with` desugars to `try_no_check` before typechecking, so fold ranges
+for `with` expressions are produced via the try arm rather than a dedicated
+`with` arm.
+
+To manually test folding range functionality:
+1. Open the lsp/test/workspace directory as a project in your editor.
+2. Open the files in the folding_range directory while the Pony language
+   server is active.
+3. Verify that fold indicators appear in the gutter at the expected lines and
+   that collapsing each region hides the correct content.
+
+Expected fold regions per file:
+
+  foldable.pony — class body and multi-line members; single-line excluded
+    - `class Foldable` (line 1) → folds the entire class body
+    - `new create(x: U32) =>` (line 7) → folds through `_x = x`
+    - `fun get_value(): U32 =>` (line 10) → folds through `_x`
+    - `fun single_line(): U32 => _x` — single-line, no fold indicator
+
+  expressions.pony — class, methods, and expression-level ranges
+    - `class Expressions` (line 1) → folds entire class
+    - `fun with_if` (line 6) → folds method body
+    - `if x > 0 then` (line 7) → folds through `0` (the else branch)
+    - `fun with_match` (line 13) → folds method body
+    - `match x` (line 14) → folds through `"many"`
+    - `fun with_while` (line 21) → folds method body
+    - `while i < x do` (line 23) → folds through `i = i + 1`
+    - `fun with_try` (line 28) → folds method body
+    - `try` (line 29) → folds through `0` (the else branch)
+
+  more_expressions.pony — for, repeat, with, object, lambda, recover
+    - `class _D` (line 1) → folds through `fun dispose`
+    - `class MoreExpressions` (line 5) → folds entire class
+    - `fun with_for` (line 10) → folds method body
+    - `for i in ...` (line 12) → folds through `sum = sum + i`
+    - `fun with_repeat` (line 17) → folds method body
+    - `repeat` (line 19) → folds through `until i >= 3`
+    - `fun with_with` (line 24) → folds method body
+      (`with` desugars to try — no separate expression-level fold)
+    - `fun with_object` (line 29) → folds method body
+    - `object` (line 31) → folds through `fun value`
+    - `fun with_lambda` (line 36) → folds method body
+    - `{(): String =>` (line 38) → folds through `"hello world"` (two
+      overlapping indicators: one for tk_lambda, one for the desugared
+      tk_object)
+    - `fun with_recover` (line 43) → folds method body
+    - `recover` (line 44) → folds through `consume s`
+
+  type_alias.pony — multi-line type alias
+    - `type TypeAlias is` (line 1) → folds through the closing `)`
+
+  entity_types.pony — all entity kinds and be behaviors
+    - `primitive P` (line 1) → folds through `42`
+    - `fun value(): U32 =>` (line 2) → folds through `42`
+    - `struct S` (line 5) → folds through `x`
+    - `new create() => None` — single-line, no fold indicator
+    - `fun get(): U32 =>` (line 9) → folds through `x`
+    - `actor A` (line 12) → folds entire actor body
+    - `new create() => _n = 0` — single-line, no fold indicator
+    - `be tick() =>` (line 16) → folds through `_n = _n + 1`
+    - `fun count(): U32 =>` (line 19) → folds through `_n`
+    - `trait T` (line 22) → folds through `required() * 2`
+    - `fun required(): U32` — single-line (abstract), no fold indicator
+    - `fun doubled(): U32 =>` (line 25) → folds through `required() * 2`
+    - `interface I` (line 28) → folds through `required() * 3`
+    - `fun required(): U32` — single-line, no fold indicator
+    - `fun tripled(): U32 =>` (line 31) → folds through `required() * 3`
+"""

--- a/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
@@ -56,10 +56,22 @@ Expected fold regions per file:
   type_alias.pony — multi-line type alias
     - `type TypeAlias is` (line 1) → folds through the closing `)`
 
+  nested_expressions.pony — nested and sequential compound expressions
+    - `class NestedExpressions` (line 1) → folds entire class
+    - `fun with_nested` (line 5) → folds method body
+    - `while i < n do` (line 7) → folds through `end` of nested if (line 12)
+    - `if (i % 2) == 0 then` (line 8) → folds through `i = i + 1`
+        (nested inside while)
+    - `fun with_sequential` (line 16) → folds method body
+    - `if n > 0 then` (line 18) → folds through `result = 0`
+    - `while result > 0 do` (line 23) → folds through `result = result - 1`
+
   ifdef_expressions.pony — ifdef expression-level range
+      (`ifdef` is resolved to `if` by the compiler; range comes from the if arm)
     - `class IfdefExpressions` (line 1) → folds entire class
     - `fun with_ifdef` (line 5) → folds method body
     - `ifdef debug then` (line 6) → folds through the else branch value
+        (via tk_if after compiler resolution)
 
   entity_types.pony — all entity kinds and be behaviors
     - `primitive P` (line 1) → folds through `42`

--- a/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
@@ -38,22 +38,20 @@ Expected fold regions per file:
     - `try` (line 29) → folds through `0` (the else branch)
 
   more_expressions.pony — for, repeat, with, object, lambda, recover
-    - `class _D` (line 1) → folds through `fun dispose`
-    - `class MoreExpressions` (line 5) → folds entire class
-    - `fun with_for` (line 10) → folds method body
-    - `for i in ...` (line 12) → folds through `sum = sum + i`
-    - `fun with_repeat` (line 17) → folds method body
-    - `repeat` (line 19) → folds through `until i >= 3`
-    - `fun with_with` (line 24) → folds method body
+    - `class MoreExpressions` (line 1) → folds entire class
+    - `fun with_for` (line 6) → folds method body
+    - `for i in ...` (line 8) → folds through `sum = sum + i`
+    - `fun with_repeat` (line 13) → folds method body
+    - `repeat` (line 15) → folds through `i >= 3` (the until condition)
+    - `fun with_with` (line 20) → folds method body
       (`with` desugars to try — no separate expression-level fold)
-    - `fun with_object` (line 29) → folds method body
-    - `object` (line 31) → folds through `fun value`
-    - `fun with_lambda` (line 36) → folds method body
-    - `{(): String =>` (line 38) → folds through `"hello world"` (two
-      overlapping indicators: one for tk_lambda, one for the desugared
-      tk_object)
-    - `fun with_recover` (line 43) → folds method body
-    - `recover` (line 44) → folds through `consume s`
+    - `fun with_object` (line 25) → folds method body
+    - `object` (line 27) → folds through `fun value` body
+    - `fun with_lambda` (line 32) → folds method body
+    - `{(): String =>` (line 34) → folds through `"hello world"`
+    - `fun with_recover` (line 39) → folds method body
+    - `recover` (line 40) → folds through `consume s`
+    - `class _D` (line 46) → folds through `fun dispose`
 
   type_alias.pony — multi-line type alias
     - `type TypeAlias is` (line 1) → folds through the closing `)`
@@ -63,15 +61,15 @@ Expected fold regions per file:
     - `fun value(): U32 =>` (line 2) → folds through `42`
     - `struct S` (line 5) → folds through `x`
     - `new create() => None` — single-line, no fold indicator
-    - `fun get(): U32 =>` (line 9) → folds through `x`
-    - `actor A` (line 12) → folds entire actor body
+    - `fun get(): U32 =>` (line 10) → folds through `x`
+    - `actor A` (line 13) → folds entire actor body
     - `new create() => _n = 0` — single-line, no fold indicator
-    - `be tick() =>` (line 16) → folds through `_n = _n + 1`
-    - `fun count(): U32 =>` (line 19) → folds through `_n`
-    - `trait T` (line 22) → folds through `required() * 2`
+    - `be tick() =>` (line 18) → folds through `_n = _n + 1`
+    - `fun count(): U32 =>` (line 21) → folds through `_n`
+    - `trait T` (line 24) → folds through `required() * 2`
     - `fun required(): U32` — single-line (abstract), no fold indicator
-    - `fun doubled(): U32 =>` (line 25) → folds through `required() * 2`
-    - `interface I` (line 28) → folds through `required() * 3`
+    - `fun doubled(): U32 =>` (line 27) → folds through `required() * 2`
+    - `interface EntityTypes` (line 30) → folds through `required() * 3`
     - `fun required(): U32` — single-line, no fold indicator
-    - `fun tripled(): U32 =>` (line 31) → folds through `required() * 3`
+    - `fun tripled(): U32 =>` (line 33) → folds through `required() * 3`
 """

--- a/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
@@ -56,6 +56,11 @@ Expected fold regions per file:
   type_alias.pony — multi-line type alias
     - `type TypeAlias is` (line 1) → folds through the closing `)`
 
+  ifdef_expressions.pony — ifdef expression-level range
+    - `class IfdefExpressions` (line 1) → folds entire class
+    - `fun with_ifdef` (line 5) → folds method body
+    - `ifdef debug then` (line 6) → folds through the else branch value
+
   entity_types.pony — all entity kinds and be behaviors
     - `primitive P` (line 1) → folds through `42`
     - `fun value(): U32 =>` (line 2) → folds through `42`

--- a/tools/pony-lsp/test/workspace/folding_range/for_expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/for_expressions.pony
@@ -1,0 +1,22 @@
+class \nodoc\ ForExpressions
+  """
+  Test fixture for for-loop expression-level folding ranges.
+  Verifies that fold ranges work for for loops with multi-statement bodies
+  and nested expressions, via the tk_while arm after sugar_for() desugaring.
+  """
+  fun with_multi_statement_for(arr: Array[U32] box): U32 =>
+    var sum: U32 = 0
+    for item in arr.values() do
+      let doubled = item * 2
+      sum = sum + doubled
+    end
+    sum
+
+  fun with_nested_for(arr: Array[U32] box): U32 =>
+    var result: U32 = 0
+    for item in arr.values() do
+      if (item % 2) == 0 then
+        result = result + item
+      end
+    end
+    result

--- a/tools/pony-lsp/test/workspace/folding_range/ifdef_expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/ifdef_expressions.pony
@@ -1,0 +1,10 @@
+class \nodoc\ IfdefExpressions
+  """
+  Test fixture for ifdef expression-level folding ranges.
+  """
+  fun with_ifdef(x: U32): U32 =>
+    ifdef debug then
+      x + 1
+    else
+      x
+    end

--- a/tools/pony-lsp/test/workspace/folding_range/more_expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/more_expressions.pony
@@ -1,0 +1,48 @@
+class _D
+  new create() => None
+  fun dispose(): None => None
+
+class MoreExpressions
+  """
+  Test fixture for additional expression-level folding ranges.
+  One method per compound expression type not covered by expressions.pony.
+  """
+  fun with_for(): U32 =>
+    var sum: U32 = 0
+    for i in [as U32: 1; 2; 3].values() do
+      sum = sum + i
+    end
+    sum
+
+  fun with_repeat(): U32 =>
+    var i: U32 = 0
+    repeat
+      i = i + 1
+    until i >= 3 end
+    i
+
+  fun with_with(): None =>
+    with d = _D do
+      None
+    end
+
+  fun with_object(): String =>
+    let obj =
+      object
+        fun value(): String => "hello"
+      end
+    obj.value()
+
+  fun with_lambda(): String =>
+    let f =
+      {(): String =>
+        "hello world"
+      }
+    f()
+
+  fun with_recover(): String val =>
+    recover
+      let s = String.create()
+      s.append("hello")
+      consume s
+    end

--- a/tools/pony-lsp/test/workspace/folding_range/more_expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/more_expressions.pony
@@ -1,7 +1,3 @@
-class _D
-  new create() => None
-  fun dispose(): None => None
-
 class MoreExpressions
   """
   Test fixture for additional expression-level folding ranges.
@@ -46,3 +42,7 @@ class MoreExpressions
       s.append("hello")
       consume s
     end
+
+class _D
+  new create() => None
+  fun dispose(): None => None

--- a/tools/pony-lsp/test/workspace/folding_range/nested_expressions.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/nested_expressions.pony
@@ -1,0 +1,26 @@
+class \nodoc\ NestedExpressions
+  """
+  Test fixture for nested and sequential compound expression folding ranges.
+  """
+  fun with_nested(n: U32): U32 =>
+    var i: U32 = 0
+    while i < n do
+      if (i % 2) == 0 then
+        i = i + 2
+      else
+        i = i + 1
+      end
+    end
+    i
+
+  fun with_sequential(n: U32): U32 =>
+    var result: U32 = 0
+    if n > 0 then
+      result = n
+    else
+      result = 0
+    end
+    while result > 0 do
+      result = result - 1
+    end
+    result

--- a/tools/pony-lsp/test/workspace/folding_range/type_alias.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/type_alias.pony
@@ -1,0 +1,5 @@
+type TypeAlias is
+  ( U32
+  | String
+  | None
+  )

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -15,6 +15,27 @@ primitive FoldingRanges
   Note: `with` is desugared to `tk_try_no_check` before typechecking, so
   `tk_with` never appears in the AST that the LSP processes. Fold ranges for
   `with` expressions are produced via the `tk_try_no_check` arm.
+
+  End-line calculation uses a `cap` equal to the next sibling's start line.
+  This prevents synthetic nodes introduced by desugaring (e.g. the constructor
+  call injected by `with` sugar) from inflating a fold range past the entity
+  or member boundary where it logically ends.
+
+  Synthetic entity detection relies on source-line monotonicity: user-defined
+  entities appear in `module.ast.children()` in ascending source-line order,
+  while compiler-generated entities (desugared `object`/lambda classes,
+  dispatch helpers, etc.) may appear non-monotonically. Any entity whose line
+  does not strictly exceed the running maximum is treated as synthetic.
+
+  Known limitation: this heuristic misclassifies a desugared `object` or
+  lambda class as a real entity when it appears in a file where the entity
+  containing the expression is the last entity by start line, because the
+  synthetic class's source position (inside the entity body) exceeds the
+  entity's start line and passes the monotonicity check. In practice this
+  only affects folding ranges for files where either: (a) there is exactly
+  one top-level entity and it contains an `object`/lambda literal, or (b)
+  the last top-level entity by start line contains an `object`/lambda and
+  there is no subsequent entity with a higher start line to act as a sentinel.
   """
   fun collect(module: Module val): Array[JsonValue] =>
     """
@@ -22,6 +43,9 @@ primitive FoldingRanges
     their members, and multi-line expressions within method bodies.
     """
     let ranges: Array[JsonValue] ref = Array[JsonValue].create()
+    let entities: Array[AST box] = Array[AST box]
+    let synthetic_entities: Array[AST box] = Array[AST box]
+    var max_entity_line: USize = 0
     for node in module.ast.children() do
       match node.id()
       | TokenIds.tk_class()
@@ -29,38 +53,93 @@ primitive FoldingRanges
       | TokenIds.tk_struct()
       | TokenIds.tk_primitive()
       | TokenIds.tk_trait()
-      | TokenIds.tk_interface() =>
-        _push_range(node, ranges)
-        _collect_members(node, ranges)
+      | TokenIds.tk_interface()
       | TokenIds.tk_type() =>
-        _push_range(node, ranges)
+        let node_line = node.line()
+        if node_line > max_entity_line then
+          entities.push(node)
+          max_entity_line = node_line
+        else
+          synthetic_entities.push(node)
+        end
       end
+    end
+    for i in entities.keys() do
+      try
+        let node = entities(i)?
+        let cap =
+          try entities(i + 1)?.line()
+          else USize.max_value()
+          end
+        match node.id()
+        | TokenIds.tk_class()
+        | TokenIds.tk_actor()
+        | TokenIds.tk_struct()
+        | TokenIds.tk_primitive()
+        | TokenIds.tk_trait()
+        | TokenIds.tk_interface() =>
+          _push_range(node, ranges, cap)
+          _collect_members(node, ranges, cap)
+        | TokenIds.tk_type() =>
+          _push_range(node, ranges, cap)
+        end
+      end
+    end
+    for node in synthetic_entities.values() do
+      _push_range(node, ranges)
     end
     ranges
 
-  fun _collect_members(entity: AST box, ranges: Array[JsonValue] ref) =>
+  fun _collect_members(
+    entity: AST box,
+    ranges: Array[JsonValue] ref,
+    entity_cap: USize)
+  =>
     """
     Walks the members node (raw child index 4) of an entity and pushes a
     folding range for each fun, be, and new member. Also collects expression-
     level ranges from within each member's body.
+
+    Members are filtered to exclude synthetic nodes: we skip any member whose
+    line equals the entity's line (synthetic default constructors injected by
+    ponyc) and any member whose body does not extend past its declaration line
+    (synthetic single-line methods such as eq, ne, hash added for primitives).
     """
     try
       let members = entity(4)?
       if members.id() != TokenIds.tk_members() then
         return
       end
+      let entity_line = entity.line()
+      let real_members: Array[AST box] = Array[AST box]
       for member in members.children() do
         match member.id()
         | TokenIds.tk_fun()
         | TokenIds.tk_be()
         | TokenIds.tk_new() =>
-          _push_range(member, ranges)
-          _collect_body(member, ranges)
+          if (member.line() > entity_line) and
+            (_end_line(member) > member.line())
+          then
+            real_members.push(member)
+          end
         end
+      end
+      for i in real_members.keys() do
+        let member = real_members(i)?
+        let member_cap =
+          try real_members(i + 1)?.line()
+          else entity_cap
+          end
+        _push_range(member, ranges, member_cap)
+        _collect_body(member, ranges, member_cap)
       end
     end
 
-  fun _collect_body(node: AST box, ranges: Array[JsonValue] ref) =>
+  fun _collect_body(
+    node: AST box,
+    ranges: Array[JsonValue] ref,
+    cap: USize)
+  =>
     """
     Walks all descendants of node and pushes folding ranges for multi-line
     compound expressions: if, ifdef, while, for, repeat, match, try,
@@ -77,7 +156,7 @@ primitive FoldingRanges
           | TokenIds.tk_object() | TokenIds.tk_lambda()
           | TokenIds.tk_barelambda() | TokenIds.tk_recover() =>
             let sl = n.line().i64() - 1
-            let el = FoldingRanges._end_line(n).i64() - 1
+            let el = FoldingRanges._end_line(n, cap).i64() - 1
             if el > sl then
               ranges.push(
                 JsonObject.update("startLine", sl).update("endLine", el))
@@ -87,29 +166,37 @@ primitive FoldingRanges
       end
     node.visit(collector)
 
-  fun _push_range(node: AST box, ranges: Array[JsonValue] ref) =>
+  fun _push_range(
+    node: AST box,
+    ranges: Array[JsonValue] ref,
+    cap: USize = USize.max_value())
+  =>
     """
     Pushes a folding range for node if it spans more than one line.
     """
     let sl: I64 = node.line().i64() - 1
-    let el: I64 = _end_line(node).i64() - 1
+    let el: I64 = _end_line(node, cap).i64() - 1
     if el > sl then
       ranges.push(JsonObject.update("startLine", sl).update("endLine", el))
     end
 
-  fun _end_line(node: AST box): USize =>
+  fun _end_line(node: AST box, cap: USize = USize.max_value()): USize =>
     """
-    Returns the maximum source line number among the node and all its
-    descendants. Uses visit() rather than span() because span() short-
-    circuits on keyword tokens (tk_class, tk_fun, etc.), returning only
-    the keyword's own line and never scanning the body.
+    Returns the maximum source line number (1-indexed) among all descendants
+    of node that fall before `cap`. The cap is the start line of the
+    next sibling entity or member, preventing synthetic nodes introduced by
+    desugaring from inflating the range past the logical boundary.
+
+    Uses visit() rather than span() because span() short-circuits on keyword
+    tokens (tk_class, tk_fun, etc.), returning only the keyword's own line and
+    never scanning the body.
     """
     let v =
       object ref is ASTVisitor
         var _max: USize = 0
         fun ref visit(n: AST box): VisitResult =>
           let l = n.line()
-          if l > _max then _max = l end
+          if (l > _max) and (l < cap) then _max = l end
           Continue
         fun max(): USize => _max
       end

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -118,7 +118,7 @@ primitive FoldingRanges
         | TokenIds.tk_be()
         | TokenIds.tk_new() =>
           if (member.line() > entity_line) and
-            (_end_line(member) > member.line())
+            (_end_line(member, entity_cap) > member.line())
           then
             real_members.push(member)
           end
@@ -142,9 +142,13 @@ primitive FoldingRanges
   =>
     """
     Walks all descendants of node and pushes folding ranges for multi-line
-    compound expressions: if, ifdef, while, for, repeat, match, try,
-    object, lambda, barelambda, and recover blocks. tk_try_no_check covers
-    desugared `with` expressions.
+    compound expressions: if, ifdef, while, for, repeat, match, try, and
+    recover blocks. tk_try_no_check covers desugared `with` expressions.
+
+    Note: tk_object, tk_lambda, and tk_barelambda are not matched here
+    because PassExpr replaces those literals with constructor calls before
+    the AST reaches the LSP. Fold ranges for object/lambda expressions are
+    produced via the synthetic entity classes appended to the module.
     """
     let collector =
       object ref is ASTVisitor
@@ -153,8 +157,7 @@ primitive FoldingRanges
           | TokenIds.tk_if() | TokenIds.tk_ifdef() | TokenIds.tk_while()
           | TokenIds.tk_for() | TokenIds.tk_repeat() | TokenIds.tk_match()
           | TokenIds.tk_try() | TokenIds.tk_try_no_check()
-          | TokenIds.tk_object() | TokenIds.tk_lambda()
-          | TokenIds.tk_barelambda() | TokenIds.tk_recover() =>
+          | TokenIds.tk_recover() =>
             let sl = n.line().i64() - 1
             let el = FoldingRanges._end_line(n, cap).i64() - 1
             if el > sl then

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -9,7 +9,7 @@ primitive FoldingRanges
   Returns one FoldingRange per top-level type entity (class, actor, struct,
   trait, interface, primitive, type alias) and one per member (fun, be, new).
   Also returns ranges for multi-line compound expressions within method bodies
-  (if, while, for, repeat, match, try, and recover blocks).
+  (if, while, repeat, match, try, and recover blocks).
   Single-line nodes are skipped since there is nothing to fold.
 
   Note: `with` is desugared to `tk_try_no_check` before typechecking, so
@@ -20,6 +20,11 @@ primitive FoldingRanges
   (`src/libponyc/expr/control.c`), so `tk_ifdef` never appears in the AST that
   the LSP processes. Fold ranges for `ifdef` expressions are produced via the
   `tk_if` arm.
+
+  Note: `for` is desugared to a `let` binding and a `while` loop by
+  `sugar_for()` in `src/libponyc/pass/sugar.c`, so `tk_for` never appears in
+  the AST that the LSP processes. Fold ranges for `for` expressions are
+  produced via the `tk_while` arm.
 
   End-line calculation uses a `cap` equal to the next sibling's start line.
   This prevents synthetic nodes introduced by desugaring (e.g. the constructor
@@ -160,8 +165,8 @@ primitive FoldingRanges
   =>
     """
     Walks all descendants of node and pushes folding ranges for multi-line
-    compound expressions: if, while, for, repeat, match, try, and recover
-    blocks. tk_try_no_check covers desugared `with` expressions.
+    compound expressions: if, while, repeat, match, try, and recover blocks.
+    tk_try_no_check covers desugared `with` expressions.
 
     Note: tk_object, tk_lambda, and tk_barelambda are not matched here
     because PassExpr replaces those literals with constructor calls before
@@ -171,6 +176,11 @@ primitive FoldingRanges
     Note: tk_ifdef is not matched here because resolve_ifdef() converts it
     to tk_if during the expr pass. Fold ranges for ifdef expressions are
     produced via the tk_if arm.
+
+    Note: tk_for is not matched here because sugar_for() in
+    src/libponyc/pass/sugar.c replaces the for node with a let binding
+    and a while loop before the AST reaches the LSP. Fold ranges for for
+    expressions are produced via the tk_while arm.
     """
     let collector =
       object ref is ASTVisitor
@@ -178,7 +188,6 @@ primitive FoldingRanges
           match n.id()
           | TokenIds.tk_if()
           | TokenIds.tk_while()
-          | TokenIds.tk_for()
           | TokenIds.tk_repeat()
           | TokenIds.tk_match()
           | TokenIds.tk_try()

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -104,6 +104,13 @@ primitive FoldingRanges
     line equals the entity's line (synthetic default constructors injected by
     ponyc) and any member whose body does not extend past its declaration line
     (synthetic single-line methods such as eq, ne, hash added for primitives).
+
+    The end-line scan uses entity_cap in the first pass so the result can be
+    cached and reused for the range push, eliminating a second traversal. For
+    real methods, _end_line(member, entity_cap) == _end_line(member, member_cap)
+    since a method's body content does not extend past the next method's start
+    line. member_cap is still passed to _collect_body for expression-level
+    ranges within the body.
     """
     try
       let members = entity(4)?
@@ -111,26 +118,32 @@ primitive FoldingRanges
         return
       end
       let entity_line = entity.line()
-      let real_members: Array[AST box] = Array[AST box]
+      let real_members: Array[(AST box, USize)] = Array[(AST box, USize)]
       for member in members.children() do
         match member.id()
         | TokenIds.tk_fun()
         | TokenIds.tk_be()
         | TokenIds.tk_new() =>
-          if (member.line() > entity_line) and
-            (_end_line(member, entity_cap) > member.line())
-          then
-            real_members.push(member)
+          let sl = member.line()
+          if sl > entity_line then
+            let el = _end_line(member, entity_cap)
+            if el > sl then
+              real_members.push((member, el))
+            end
           end
         end
       end
       for i in real_members.keys() do
-        let member = real_members(i)?
+        (let member, let el) = real_members(i)?
         let member_cap =
-          try real_members(i + 1)?.line()
+          try real_members(i + 1)?._1.line()
           else entity_cap
           end
-        _push_range(member, ranges, member_cap)
+        let sl = member.line()
+        ranges.push(
+          JsonObject
+            .update("startLine", sl.i64() - 1)
+            .update("endLine", el.i64() - 1))
         _collect_body(member, ranges, member_cap)
       end
     end

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -1,0 +1,117 @@
+use ".."
+use "json"
+use "pony_compiler"
+
+primitive FoldingRanges
+  """
+  Collects textDocument/foldingRange results for a module.
+
+  Returns one FoldingRange per top-level type entity (class, actor, struct,
+  trait, interface, primitive, type alias) and one per member (fun, be, new).
+  Also returns ranges for multi-line compound expressions within method bodies
+  (if, ifdef, while, for, repeat, match, try, object, lambda, recover).
+  Single-line nodes are skipped since there is nothing to fold.
+
+  Note: `with` is desugared to `tk_try_no_check` before typechecking, so
+  `tk_with` never appears in the AST that the LSP processes. Fold ranges for
+  `with` expressions are produced via the `tk_try_no_check` arm.
+  """
+  fun collect(module: Module val): Array[JsonValue] =>
+    """
+    Returns an array of folding range objects for all top-level entities,
+    their members, and multi-line expressions within method bodies.
+    """
+    let ranges: Array[JsonValue] ref = Array[JsonValue].create()
+    for node in module.ast.children() do
+      match node.id()
+      | TokenIds.tk_class()
+      | TokenIds.tk_actor()
+      | TokenIds.tk_struct()
+      | TokenIds.tk_primitive()
+      | TokenIds.tk_trait()
+      | TokenIds.tk_interface() =>
+        _push_range(node, ranges)
+        _collect_members(node, ranges)
+      | TokenIds.tk_type() =>
+        _push_range(node, ranges)
+      end
+    end
+    ranges
+
+  fun _collect_members(entity: AST box, ranges: Array[JsonValue] ref) =>
+    """
+    Walks the members node (raw child index 4) of an entity and pushes a
+    folding range for each fun, be, and new member. Also collects expression-
+    level ranges from within each member's body.
+    """
+    try
+      let members = entity(4)?
+      if members.id() != TokenIds.tk_members() then
+        return
+      end
+      for member in members.children() do
+        match member.id()
+        | TokenIds.tk_fun()
+        | TokenIds.tk_be()
+        | TokenIds.tk_new() =>
+          _push_range(member, ranges)
+          _collect_body(member, ranges)
+        end
+      end
+    end
+
+  fun _collect_body(node: AST box, ranges: Array[JsonValue] ref) =>
+    """
+    Walks all descendants of node and pushes folding ranges for multi-line
+    compound expressions: if, ifdef, while, for, repeat, match, try,
+    object, lambda, barelambda, and recover blocks. tk_try_no_check covers
+    desugared `with` expressions.
+    """
+    let collector =
+      object ref is ASTVisitor
+        fun ref visit(n: AST box): VisitResult =>
+          match n.id()
+          | TokenIds.tk_if() | TokenIds.tk_ifdef() | TokenIds.tk_while()
+          | TokenIds.tk_for() | TokenIds.tk_repeat() | TokenIds.tk_match()
+          | TokenIds.tk_try() | TokenIds.tk_try_no_check()
+          | TokenIds.tk_object() | TokenIds.tk_lambda()
+          | TokenIds.tk_barelambda() | TokenIds.tk_recover() =>
+            let sl = n.line().i64() - 1
+            let el = FoldingRanges._end_line(n).i64() - 1
+            if el > sl then
+              ranges.push(
+                JsonObject.update("startLine", sl).update("endLine", el))
+            end
+          end
+          Continue
+      end
+    node.visit(collector)
+
+  fun _push_range(node: AST box, ranges: Array[JsonValue] ref) =>
+    """
+    Pushes a folding range for node if it spans more than one line.
+    """
+    let sl: I64 = node.line().i64() - 1
+    let el: I64 = _end_line(node).i64() - 1
+    if el > sl then
+      ranges.push(JsonObject.update("startLine", sl).update("endLine", el))
+    end
+
+  fun _end_line(node: AST box): USize =>
+    """
+    Returns the maximum source line number among the node and all its
+    descendants. Uses visit() rather than span() because span() short-
+    circuits on keyword tokens (tk_class, tk_fun, etc.), returning only
+    the keyword's own line and never scanning the body.
+    """
+    let v =
+      object ref is ASTVisitor
+        var _max: USize = 0
+        fun ref visit(n: AST box): VisitResult =>
+          let l = n.line()
+          if l > _max then _max = l end
+          Continue
+        fun max(): USize => _max
+      end
+    node.visit(v)
+    v.max()

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -9,12 +9,17 @@ primitive FoldingRanges
   Returns one FoldingRange per top-level type entity (class, actor, struct,
   trait, interface, primitive, type alias) and one per member (fun, be, new).
   Also returns ranges for multi-line compound expressions within method bodies
-  (if, ifdef, while, for, repeat, match, try, object, lambda, recover).
+  (if, while, for, repeat, match, try, and recover blocks).
   Single-line nodes are skipped since there is nothing to fold.
 
   Note: `with` is desugared to `tk_try_no_check` before typechecking, so
   `tk_with` never appears in the AST that the LSP processes. Fold ranges for
   `with` expressions are produced via the `tk_try_no_check` arm.
+
+  Note: `ifdef` is resolved to `if` by `resolve_ifdef()` during the expr pass
+  (`src/libponyc/expr/control.c`), so `tk_ifdef` never appears in the AST that
+  the LSP processes. Fold ranges for `ifdef` expressions are produced via the
+  `tk_if` arm.
 
   End-line calculation uses a `cap` equal to the next sibling's start line.
   This prevents synthetic nodes introduced by desugaring (e.g. the constructor
@@ -155,21 +160,29 @@ primitive FoldingRanges
   =>
     """
     Walks all descendants of node and pushes folding ranges for multi-line
-    compound expressions: if, ifdef, while, for, repeat, match, try, and
-    recover blocks. tk_try_no_check covers desugared `with` expressions.
+    compound expressions: if, while, for, repeat, match, try, and recover
+    blocks. tk_try_no_check covers desugared `with` expressions.
 
     Note: tk_object, tk_lambda, and tk_barelambda are not matched here
     because PassExpr replaces those literals with constructor calls before
     the AST reaches the LSP. Fold ranges for object/lambda expressions are
     produced via the synthetic entity classes appended to the module.
+
+    Note: tk_ifdef is not matched here because resolve_ifdef() converts it
+    to tk_if during the expr pass. Fold ranges for ifdef expressions are
+    produced via the tk_if arm.
     """
     let collector =
       object ref is ASTVisitor
         fun ref visit(n: AST box): VisitResult =>
           match n.id()
-          | TokenIds.tk_if() | TokenIds.tk_ifdef() | TokenIds.tk_while()
-          | TokenIds.tk_for() | TokenIds.tk_repeat() | TokenIds.tk_match()
-          | TokenIds.tk_try() | TokenIds.tk_try_no_check()
+          | TokenIds.tk_if()
+          | TokenIds.tk_while()
+          | TokenIds.tk_for()
+          | TokenIds.tk_repeat()
+          | TokenIds.tk_match()
+          | TokenIds.tk_try()
+          | TokenIds.tk_try_no_check()
           | TokenIds.tk_recover() =>
             let sl = n.line().i64() - 1
             let el = FoldingRanges._end_line(n, cap).i64() - 1

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -288,11 +288,14 @@ actor WorkspaceManager
           None)
       end
       if this._client.supports_inlay_hint_refresh() then
-        // tell the client to re-request inlay hints
-        // for all open documents
+        // tell the client to re-request inlay hints for all open documents
         this._request_sender.send_request(
-          Methods.workspace().inlay_hint().refresh(),
-          None)
+          Methods.workspace().inlay_hint().refresh(), None)
+      end
+      if this._client.supports_folding_range_refresh() then
+        // tell the client to re-request folding ranges for all open documents
+        this._request_sender.send_request(
+          Methods.workspace().folding_range().refresh(), None)
       end
     else
       this._channel.log(
@@ -779,6 +782,44 @@ actor WorkspaceManager
       | None =>
         this._channel.log(
           "No package state available for " + document_path)
+      end
+    else
+      this._channel.log("document not in workspace: " + document_path)
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be folding_range(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/foldingRange request.
+    """
+    this._channel.log("Handling " + request.method)
+    let document_path = Uris.to_path(document_uri)
+    try
+      let package: FilePath = this._find_workspace_package(document_path)?
+      match \exhaustive\ this._get_package(package)
+      | let pkg_state: PackageState =>
+        match \exhaustive\ pkg_state.get_document(document_path)
+        | let doc: DocumentState =>
+          match \exhaustive\ doc.module()
+          | let module: Module val =>
+            let fold_ranges = FoldingRanges.collect(module)
+            var json_arr = JsonArray
+            for range in fold_ranges.values() do
+              json_arr = json_arr.push(range)
+            end
+            this._channel.send(ResponseMessage(request.id, json_arr))
+            return
+          | None =>
+            this._channel.log(
+              "No module available for " + document_path)
+          end
+        | None =>
+          this._channel.log(
+            "No document state available for " + document_path)
+        end
+      | None =>
+        this._channel.log(
+          "No package state available for package: " + package.path)
       end
     else
       this._channel.log("document not in workspace: " + document_path)

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -792,7 +792,7 @@ actor WorkspaceManager
     """
     Handle textDocument/foldingRange request.
     """
-    this._channel.log("Handling " + request.method)
+    this._channel.log("Handling textDocument/foldingRange")
     let document_path = Uris.to_path(document_uri)
     try
       let package: FilePath = this._find_workspace_package(document_path)?
@@ -819,7 +819,7 @@ actor WorkspaceManager
         end
       | None =>
         this._channel.log(
-          "No package state available for package: " + package.path)
+          "No package state available for " + document_path)
       end
     else
       this._channel.log("document not in workspace: " + document_path)


### PR DESCRIPTION
## Context

The Pony LSP does not implement `textDocument/foldingRange`, so editors that request folding ranges receive no response and show no fold indicators in the gutter.

## Changes

- Adds `FoldingRanges` in `workspace/folding_ranges.pony` that walks the typechecked AST and returns one fold range per multi-line top-level entity (class, actor, struct, primitive, trait, interface, type alias) and one per multi-line member (fun, be, new). Single-line nodes are excluded.
- Also collects expression-level ranges for compound expressions within method bodies: if, ifdef, while, for, repeat, match, try, recover, and desugared `with` (via tk_try_no_check).
- Uses a visitor-based end-line scan with a cap equal to the next sibling's start line to prevent desugared synthetic nodes from inflating ranges past entity/member boundaries.
- Wires up `textDocument/foldingRange` routing in `language_server.pony`, `methods.pony`, and `client.pony`.

Resolves #5184.

## Considerations

Synthetic entity detection relies on source-line monotonicity: user-defined entities appear in `module.ast.children()` in ascending source-line order while compiler-generated ones may not. This misclassifies a desugared `object`/lambda class as a real entity when the containing entity is the last one by start line (documented in the `FoldingRanges` docstring). A fix requires distinguishing object/lambda synthetics from structural synthetics with `\<anonymous\>` names, which needs further investigation of ponyc internals.