### PR TITLE
Add LSP `textDocument/typeDefinition` support

### DIFF
--- a/.release-notes/add_lsp_type_definition_support.md
+++ b/.release-notes/add_lsp_type_definition_support.md
@@ -1,0 +1,5 @@
+## Add LSP `textDocument/typeDefinition` support
+
+The Pony language server now supports Go to Type Definition. Placing the cursor on any symbol with a known type — a local variable, parameter, or field — and invoking Go to Type Definition in your editor will navigate to the declaration of the symbol's type rather than the symbol itself.
+
+This works for explicitly annotated bindings (`let x: MyClass`) and for bindings whose type is inferred (`let x = MyClass.create()`).

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -149,6 +149,21 @@ actor LanguageServer is (Notifier & RequestSender)
             )
           )
         end
+      | Methods.text_document().type_definition() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .type_definition(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().hover() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -427,6 +442,7 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("save", JsonObject.update("includeText", true)))
                 .update("declarationProvider", true)
                 .update("definitionProvider", true)
+                .update("typeDefinitionProvider", true)
                 .update("referencesProvider", true)
                 .update(
                   "diagnosticProvider",

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -92,6 +92,9 @@ primitive TextDocumentMethods
   fun definition(): String val =>
     "textDocument/definition"
 
+  fun type_definition(): String val =>
+    "textDocument/typeDefinition"
+
   fun diagnostic(): String val =>
     "textDocument/diagnostic"
 

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -210,16 +210,11 @@ class val _DefinitionChecker
     None
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
-    var ok = true
-    let got_count =
-      try JsonNav(res.result).size()? else 0 end
-    if not h.assert_eq[USize](
-      _expected.size(),
-      got_count,
-      "Wrong number of definitions")
-    then
-      ok = false
-    end
+    var ok =
+      h.assert_eq[USize](
+        _expected.size(),
+        try JsonNav(res.result).size()? else 0 end,
+        "Wrong number of definitions")
     for (i, loc) in _expected.pairs() do
       (let file_suffix, let start_pos, let end_pos) = loc
       (let exp_start_line, let exp_start_char) = start_pos
@@ -227,32 +222,17 @@ class val _DefinitionChecker
       try
         let nav = JsonNav(res.result)(i)
         let uri = nav("uri").as_string()?
-        let got_start_line =
-          nav("range")("start")("line").as_i64()?
-        let got_start_char =
-          nav("range")("start")("character").as_i64()?
-        let got_end_line =
-          nav("range")("end")("line").as_i64()?
-        let got_end_char =
-          nav("range")("end")("character").as_i64()?
-        if not h.assert_true(
+        let got_start_line = nav("range")("start")("line").as_i64()?
+        let got_start_char = nav("range")("start")("character").as_i64()?
+        let got_end_line = nav("range")("end")("line").as_i64()?
+        let got_end_char = nav("range")("end")("character").as_i64()?
+        ok = h.assert_true(
           uri.contains(file_suffix),
-          "Expected URI containing '" + file_suffix + "', got: " + uri)
-        then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_start_line, got_start_line) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_start_char, got_start_char) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_end_line, got_end_line) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_end_char, got_end_char) then
-          ok = false
-        end
+          "Expected URI containing '" + file_suffix + "', got: " + uri) and ok
+        ok = h.assert_eq[I64](exp_start_line, got_start_line) and ok
+        ok = h.assert_eq[I64](exp_start_char, got_start_char) and ok
+        ok = h.assert_eq[I64](exp_end_line, got_end_line) and ok
+        ok = h.assert_eq[I64](exp_end_char, got_end_char) and ok
       else
         ok = false
         h.log(

--- a/tools/pony-lsp/test/_type_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_definition_integration_tests.pony
@@ -132,16 +132,11 @@ class val _TypeDefinitionChecker
     None
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
-    var ok = true
-    let got_count =
-      try JsonNav(res.result).size()? else 0 end
-    if not h.assert_eq[USize](
-      _expected.size(),
-      got_count,
-      "Wrong number of type definitions")
-    then
-      ok = false
-    end
+    var ok =
+      h.assert_eq[USize](
+        _expected.size(),
+        try JsonNav(res.result).size()? else 0 end,
+        "Wrong number of type definitions")
     for (i, loc) in _expected.pairs() do
       (let file_suffix, let start_pos, let end_pos) = loc
       (let exp_start_line, let exp_start_char) = start_pos
@@ -153,24 +148,13 @@ class val _TypeDefinitionChecker
         let got_start_char = nav("range")("start")("character").as_i64()?
         let got_end_line = nav("range")("end")("line").as_i64()?
         let got_end_char = nav("range")("end")("character").as_i64()?
-        if not h.assert_true(
+        ok = h.assert_true(
           uri.contains(file_suffix),
-          "Expected URI containing '" + file_suffix + "', got: " + uri)
-        then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_start_line, got_start_line) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_start_char, got_start_char) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_end_line, got_end_line) then
-          ok = false
-        end
-        if not h.assert_eq[I64](exp_end_char, got_end_char) then
-          ok = false
-        end
+          "Expected URI containing '" + file_suffix + "', got: " + uri) and ok
+        ok = h.assert_eq[I64](exp_start_line, got_start_line) and ok
+        ok = h.assert_eq[I64](exp_start_char, got_start_char) and ok
+        ok = h.assert_eq[I64](exp_end_line, got_end_line) and ok
+        ok = h.assert_eq[I64](exp_end_char, got_end_char) and ok
       else
         ok = false
         h.log(

--- a/tools/pony-lsp/test/_type_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_definition_integration_tests.pony
@@ -1,0 +1,183 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+use "collections"
+
+primitive _TypeDefinitionIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_TypeDefinitionLocalVarIntegrationTest.create(server))
+    test(_TypeDefinitionParamIntegrationTest.create(server))
+    test(_TypeDefinitionNoTypeIntegrationTest.create(server))
+    test(_TypeDefinitionInferredIntegrationTest.create(server))
+
+class \nodoc\ iso _TypeDefinitionLocalVarIntegrationTest is UnitTest
+  """
+  Cursor on `obj` in `demo()` (line 28, col 4) — explicitly annotated let.
+  type_definition.pony layout (0-indexed lines/cols):
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 25:  class _TypeDefUser
+    line 26:    fun demo() =>
+    line 27:      let obj: _TypeDefTarget = ...
+    line 28:      obj                            obj at (28,4)
+
+  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_definition/integration/local_var"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "type_definition/type_definition.pony",
+      [ (28, 4, _TypeDefinitionChecker(
+        [("type_definition.pony", (21, 0), (21, 5))]))])
+
+class \nodoc\ iso _TypeDefinitionParamIntegrationTest is UnitTest
+  """
+  Cursor on `target` in `with_param()` (line 31, col 4) — typed parameter.
+  type_definition.pony layout (0-indexed lines/cols):
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 30:    fun with_param(target: _TypeDefTarget) =>
+    line 31:      target                             target at (31,4)
+
+  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_definition/integration/param"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "type_definition/type_definition.pony",
+      [ (31, 4, _TypeDefinitionChecker(
+        [("type_definition.pony", (21, 0), (21, 5))]))])
+
+class \nodoc\ iso _TypeDefinitionNoTypeIntegrationTest is UnitTest
+  """
+  Cursor on the `class` keyword of _TypeDefUser (line 25, col 0) — keywords
+  have no type. Expects an empty result.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_definition/integration/no_type"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "type_definition/type_definition.pony",
+      [(25, 0, _TypeDefinitionChecker([]))])
+
+class \nodoc\ iso _TypeDefinitionInferredIntegrationTest is UnitTest
+  """
+  Cursor on `x` in `inferred_demo()` (line 35, col 4) — type inferred from
+  `_TypeDefTarget.create()`, no explicit annotation.
+  type_definition.pony layout (0-indexed lines/cols):
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 33:    fun inferred_demo() =>
+    line 34:      let x = _TypeDefTarget.create()
+    line 35:      x                              x at (35,4)
+
+  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_definition/integration/inferred"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "type_definition/type_definition.pony",
+      [ (35, 4, _TypeDefinitionChecker(
+        [("type_definition.pony", (21, 0), (21, 5))]))])
+
+class val _TypeDefinitionChecker
+  let _expected: Array[DefinitionExpectation] val
+
+  new val create(expected: Array[DefinitionExpectation] val) =>
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().type_definition()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    let got_count =
+      try JsonNav(res.result).size()? else 0 end
+    if not h.assert_eq[USize](
+      _expected.size(),
+      got_count,
+      "Wrong number of type definitions")
+    then
+      ok = false
+    end
+    for (i, loc) in _expected.pairs() do
+      (let file_suffix, let start_pos, let end_pos) = loc
+      (let exp_start_line, let exp_start_char) = start_pos
+      (let exp_end_line, let exp_end_char) = end_pos
+      try
+        let nav = JsonNav(res.result)(i)
+        let uri = nav("uri").as_string()?
+        let got_start_line = nav("range")("start")("line").as_i64()?
+        let got_start_char = nav("range")("start")("character").as_i64()?
+        let got_end_line = nav("range")("end")("line").as_i64()?
+        let got_end_char = nav("range")("end")("character").as_i64()?
+        if not h.assert_true(
+          uri.contains(file_suffix),
+          "Expected URI containing '" + file_suffix + "', got: " + uri)
+        then
+          ok = false
+        end
+        if not h.assert_eq[I64](exp_start_line, got_start_line) then
+          ok = false
+        end
+        if not h.assert_eq[I64](exp_start_char, got_start_char) then
+          ok = false
+        end
+        if not h.assert_eq[I64](exp_end_line, got_end_line) then
+          ok = false
+        end
+        if not h.assert_eq[I64](exp_end_char, got_end_char) then
+          ok = false
+        end
+      else
+        ok = false
+        h.log(
+          "TypeDefinition [" + i.string() +
+          "] returned null or invalid, expected (" +
+          file_suffix + ":" + exp_start_line.string() +
+          ":" + exp_start_char.string() + ")")
+      end
+    end
+    ok

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -26,6 +26,7 @@ actor Main is TestList
     _DiagnosticTests.make().tests(test)
     _HoverIntegrationTests.make().tests(test)
     _DefinitionIntegrationTests.make().tests(test)
+    _TypeDefinitionIntegrationTests.make().tests(test)
     _DocumentHighlightIntegrationTests.make().tests(test)
     _InlayHintIntegrationTests.make().tests(test)
     _ReferencesIntegrationTests.make().tests(test)

--- a/tools/pony-lsp/test/workspace/type_definition/type_definition.pony
+++ b/tools/pony-lsp/test/workspace/type_definition/type_definition.pony
@@ -1,0 +1,36 @@
+"""
+Test fixtures for exercising LSP Go to Type Definition functionality.
+
+Open this file in an LSP-aware editor while the Pony language server is active.
+Place the cursor on any of the symbols below and invoke Go to Type Definition
+(typically bound to a right-click menu option or a keyboard shortcut such as
+Ctrl+F12 / Cmd+F12 in VS Code).
+
+The editor should navigate to the declaration of the *type* of the symbol,
+not the symbol itself:
+
+  - `obj` in `demo()` — explicitly annotated `let`; navigates to
+    `_TypeDefTarget`
+  - `target` in `with_param()` — parameter; navigates to `_TypeDefTarget`
+  - `x` in `inferred_demo()` — inferred type, no annotation; navigates to
+    `_TypeDefTarget`
+
+Placing the cursor on a keyword such as `class` or `fun` returns no results,
+because keywords have no type.
+"""
+
+class _TypeDefTarget
+  new create() =>
+    None
+
+class _TypeDefUser
+  fun demo() =>
+    let obj: _TypeDefTarget = _TypeDefTarget.create()
+    obj
+
+  fun with_param(target: _TypeDefTarget) =>
+    target
+
+  fun inferred_demo() =>
+    let x = _TypeDefTarget.create()
+    x

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -657,6 +657,51 @@ actor WorkspaceManager
     // send a null-response in every failure case
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be type_definition(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/typeDefinition request.
+
+    Finds the definition of the type of the symbol at the cursor position.
+    E.g. for a local variable `x: MyClass`, this navigates to `MyClass`.
+    """
+    this._channel.log("handling textDocument/typeDefinition")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let document_path = Uris.to_path(document_uri)
+    match \exhaustive\ _find_node_and_module(document_path, line, column)
+    | (let ast: AST box, _) =>
+      this._channel.log(ast.debug())
+      var json_arr = JsonArray
+      match ast.ast_type()
+      | let type_ast: AST =>
+        for type_def in type_ast.definitions().values() do
+          (let start_pos, let end_pos) = type_def.span()
+          try
+            json_arr =
+              json_arr.push(
+                LspLocation(
+                  Uris.from_path(type_def.source_file() as String val),
+                  LspPositionRange(
+                    LspPosition.from_ast_pos(start_pos),
+                    LspPosition.from_ast_pos_end(end_pos))
+                ).to_json()
+              )
+          else
+            this._channel.log(
+              "No source file found for type definition: " + type_def.debug())
+          end
+        end
+      end
+      this._channel.send(ResponseMessage(request.id, json_arr))
+      return
+    | None => None
+    end
+    // send a null-response in every failure case
+    this._channel.send(ResponseMessage.create(request.id, None))
+
   be document_symbols(document_uri: String, request: RequestMessage val) =>
     """
     Handle textDocument/documentSymbol request.


### PR DESCRIPTION
## Context

The Pony LSP does not implement `textDocument/typeDefinition`, so editors that invoke Go to Type Definition receive no response. This is distinct from Go to Definition: where definition navigates to where a symbol is declared, type definition navigates to the declaration of the symbol's *type*.

## Changes

- Adds `be type_definition` in `workspace/workspace_manager.pony` that resolves the type of the AST node at the cursor via `ast.ast_type()`, then navigates to the type's declaration via `DefinitionResolver.resolve()`.
- Wires up `textDocument/typeDefinition` routing in `language_server.pony` and `methods.pony`, and advertises `typeDefinitionProvider: true` in server capabilities.
- Adds integration tests covering explicitly annotated locals, typed parameters, inferred types (no annotation), and the no-result case for nodes without a type.

Resolves #5177.

https://github.com/user-attachments/assets/04a4d271-9b11-4aa8-b45c-0bc534cd4525


## Considerations

Union, intersection, arrow, tuple, and function types return an empty result because `DefinitionResolver.resolve()` has no cases for compound type nodes (`tk_uniontype`, `tk_isecttype`, etc.) — they fall through to `else => []`. An empty array is valid per the LSP spec. Resolving compound types would require extending `DefinitionResolver` and is left as a follow-up.