### PR TITLE
Scope Docker image build validation to .dockerfiles/ changes

### DIFF
--- a/.github/workflows/pr-docker-image-validation.yml
+++ b/.github/workflows/pr-docker-image-validation.yml
@@ -1,0 +1,46 @@
+name: Docker Image Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.dockerfiles/**'
+      - '.github/workflows/pr-docker-image-validation.yml'
+
+concurrency:
+  group: pr-docker-image-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  validate-nightly-image-builds:
+    if: github.event.pull_request.draft == false
+    name: Nightly Builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+      - name: Docker build
+        run: |
+          docker buildx create --name multiplatform --driver docker-container --use --bootstrap
+          docker buildx build --platform linux/amd64,linux/arm64 --pull --file=.dockerfiles/nightly/Dockerfile .
+
+  validate-release-image-builds:
+    if: github.event.pull_request.draft == false
+    name: Release Builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+      - name: Docker build
+        run: |
+          docker buildx create --name multiplatform --driver docker-container --use --bootstrap
+          docker buildx build --platform linux/amd64,linux/arm64 --pull --file=.dockerfiles/release/Dockerfile .

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -25,34 +25,6 @@ jobs:
           VALIDATE_MD: true
           VALIDATE_YAML: true
 
-  validate-nightly-image-builds:
-    name: Validate nightly image builds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-      - name: Set up Docker Buildx
-        # v3.10.0
-        uses: docker/setup-buildx-action@v4
-      - name: Docker build
-        run: |
-          docker buildx create --name multiplatform --driver docker-container --use --bootstrap
-          docker buildx build --platform linux/amd64,linux/arm64 --pull --file=.dockerfiles/nightly/Dockerfile .
-
-  validate-release-image-builds:
-    name: Validate release image builds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-      - name: Set up Docker Buildx
-        # v3.10.0
-        uses: docker/setup-buildx-action@v4
-      - name: Docker build
-        run: |
-          docker buildx create --name multiplatform --driver docker-container --use --bootstrap
-          docker buildx build --platform linux/amd64,linux/arm64 --pull --file=.dockerfiles/release/Dockerfile .
-
   verify-changelog:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moves the `validate-nightly-image-builds` and `validate-release-image-builds` jobs out of `pr-repo-hygiene.yml` into a dedicated `pr-docker-image-validation.yml` workflow, triggered only when `.dockerfiles/**` (or the workflow file itself) changes. The multi-platform image builds can't produce different results unless one of those files changes, so running them on every PR wastes CI time.

The new workflow also skips draft PRs, matching the pattern used by `pr-tools.yml` and `pr-ponyc.yml`.

Dockerfile linting still runs on every PR via the `superlinter` job, which remains in `pr-repo-hygiene.yml`.