### PR TITLE
Refactor Makefile to build pony-lint-ci once for all lint targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else ifneq ($(strip $(usedebugger)),)
 endif
 
 .DEFAULT_GOAL := build
-.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint pony-doc test-pony-doc test-pony-compiler
+.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint lint-pony-doc lint-pony-lsp build-pony-lint-ci pony-doc test-pony-doc test-pony-compiler
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'
@@ -272,14 +272,17 @@ test-pony-lsp: all
 test-pony-lint: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-tests ../../tools/pony-lint/test && echo Built `pwd`/pony-lint-tests && PONYPATH=../../packages:$(PONYPATH) ./pony-lint-tests --sequential
 
-lint-pony-lint: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lint/
+build-pony-lint-ci: all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci
 
-lint-pony-doc: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-doc/
+lint-pony-lint: build-pony-lint-ci
+	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lint/
 
-lint-pony-lsp: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lsp/
+lint-pony-doc: build-pony-lint-ci
+	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-doc/
+
+lint-pony-lsp: build-pony-lint-ci
+	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lsp/
 
 test-pony-compiler: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-compiler-tests ../../tools/lib/ponylang/pony_compiler/tests && echo Build `pwd`/pony-compiler-tests && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../packages:$(PONYPATH) ./pony-compiler-tests --sequential


### PR DESCRIPTION
## Summary

Part of #5155. Splits the `pony-lint-ci` binary build out of `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` into a new `build-pony-lint-ci` prerequisite target. Each lint target now has a dependency on the build target and only runs the binary against its own directory.

## Why this matters

Before this change, each of the three lint targets had the same inline build command followed by a different lint run:

```makefile
lint-pony-lint: all
    ... -b pony-lint-ci ../../tools/pony-lint && ... ./pony-lint-ci ../../tools/pony-lint/

lint-pony-doc: all
    ... -b pony-lint-ci ../../tools/pony-lint && ... ./pony-lint-ci ../../tools/pony-doc/

lint-pony-lsp: all
    ... -b pony-lint-ci ../../tools/pony-lint && ... ./pony-lint-ci ../../tools/pony-lsp/
```

`.github/workflows/pr-tools.yml` runs the three targets in sequence on Linux. Since each makes its own inline build, CI rebuilds `pony-lint-ci` three times per PR (~60 seconds each), adding ~2 minutes of redundant work.

With a shared prerequisite target, the build is decoupled from the lint action. Each target can be invoked independently and still produces a correct build, and a future CI follow-up can consolidate the three to a single `make` invocation (e.g. `make lint-pony-lint lint-pony-doc lint-pony-lsp`) to build once and reuse within that invocation.

## Changes

`Makefile`:
- New `build-pony-lint-ci` target containing just the compile step.
- `lint-pony-lint`, `lint-pony-doc`, `lint-pony-lsp` each depend on `build-pony-lint-ci` and only run `pony-lint-ci` against their respective directories.
- Added `build-pony-lint-ci`, `lint-pony-doc`, and `lint-pony-lsp` to the `.PHONY` list (two of those were already de facto phony but hadn't been declared).

## Testing

- `make -n lint-pony-lint config=debug` — dry run shows the correct dep chain: build pony-lint-ci once, then lint `tools/pony-lint/`.
- `make -n lint-pony-doc config=debug` — same pattern for `tools/pony-doc/`.
- `make -n lint-pony-lsp config=debug` — same for `tools/pony-lsp/`.
- Existing per-target invocations in CI (`make lint-pony-lint config=debug` etc.) continue to work unchanged.

## Scope note

This PR sets up the Makefile refactor. Consolidating the CI step into a single `make` invocation (so the three lint targets share one build) is a separable follow-up in `.github/workflows/pr-tools.yml` that can cite this PR once it's merged.

(Part of #5155 - this is the Makefile refactor piece, not the full CI consolidation.)

This contribution was developed with AI assistance (Claude Code).