### PR TITLE
Add LSP `textDocument/selectionRange` support

### DIFF
--- a/.release-notes/lsp-selection-range.md
+++ b/.release-notes/lsp-selection-range.md
@@ -1,0 +1,5 @@
+## Add LSP `textDocument/selectionRange` support
+
+The Pony language server now handles `textDocument/selectionRange` requests, enabling editors to expand the selection to progressively larger syntactic units (e.g. Alt+Shift+→ in VS Code).
+
+For a given cursor position the server returns a chain of nested ranges — innermost first — walking up the AST from the token under the cursor through its enclosing expressions, function, class body, and finally the whole file. Ancestor nodes whose span is identical to their child are collapsed so that each step in the chain produces a visible selection change. Descendant nodes from other source files (such as trait methods merged into a class by the compiler) are excluded so that the ranges always stay within the current file.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -242,6 +242,21 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] No workspace found for request '" +
                 r.json().string() + "'")))
         end
+      | Methods.text_document().selection_range() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .selection_range(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for request '" +
+                r.json().string() + "'")))
+        end
       | Methods.text_document().diagnostic() =>
         try
           let document_uri = _get_document_uri(r.params)?
@@ -500,6 +515,7 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update("workspaceDiagnostics", false))
                 .update("documentSymbolProvider", true)
                 .update("foldingRangeProvider", true)
+                .update("selectionRangeProvider", true)
                 .update(
                   "inlayHintProvider",
                   JsonObject.update("resolveProvider", false)))

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -127,6 +127,9 @@ primitive TextDocumentMethods
   fun folding_range(): String val =>
     "textDocument/foldingRange"
 
+  fun selection_range(): String val =>
+    "textDocument/selectionRange"
+
   fun hover(): String val =>
     "textDocument/hover"
 

--- a/tools/pony-lsp/test/_selection_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_selection_range_integration_tests.pony
@@ -1,0 +1,361 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _SelectionRangeIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_SelectionRangeTokenTest.create(server))
+    test(_SelectionRangeMethodTest.create(server))
+    test(_SelectionRangeWhitespaceTest.create(server))
+    test(_SelectionRangeKeywordTest.create(server))
+    test(_SelectionRangePositionsArrayTest.create(server))
+    test(_SelectionRangeEmptyPositionsTest.create(server))
+
+class \nodoc\ iso _SelectionRangeTokenTest is UnitTest
+  """
+  Cursor on `x` (body expression) at line 27, character 4 (0-indexed) in
+  `fun value(x: U32): U32 => x`. Expects a chain of at least 3 SelectionRange
+  entries with monotonically expanding ranges, innermost exactly (27,4)-(27,5).
+
+  selection_range.pony layout (0-indexed):
+    line 0-20:  package docstring
+    line 21:    (blank)
+    line 22:    class SelectionRange
+    line 23-25: class docstring
+    line 26:      fun value(x: U32): U32 =>
+    line 27:        x
+    line 28:    (blank)
+    line 29:      fun compute(a: U32, b: U32): U32 =>
+    line 30:        a + b
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/token"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (27, 4,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (27, 4, 3, (27, 4, 27, 5))]
+        end))])
+
+class \nodoc\ iso _SelectionRangeMethodTest is UnitTest
+  """
+  Cursor on `a` at line 30, character 4 (0-indexed) in `fun compute(...)`.
+  Expects a chain of at least 3 SelectionRange entries, innermost exactly
+  (30,4)-(30,5).
+
+  selection_range.pony layout (0-indexed):
+    line 30:     a + b
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/method"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (30, 4,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (30, 4, 3, (30, 4, 30, 5))]
+        end))])
+
+class \nodoc\ iso _SelectionRangeWhitespaceTest is UnitTest
+  """
+  Cursor on blank line 28, character 0 (0-indexed). No AST node at that
+  position — expects a JSON null entry in the response array.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/whitespace"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (28, 0,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (28, 0, 0, None)]
+        end))])
+
+class \nodoc\ iso _SelectionRangeKeywordTest is UnitTest
+  """
+  Cursor on the `fun` keyword at line 26, character 2 (0-indexed) in
+  `  fun value(x: U32): U32 =>`. The cursor is on a keyword token rather
+  than an identifier or expression — exercises the keyword-node code path.
+  Expects a chain of at least 3 SelectionRange entries (fun → class → module).
+  The innermost range is not pinned: declaration keyword nodes use end_pos()
+  for their extent and the exact LSP span depends on ponyc AST internals.
+
+  selection_range.pony layout (0-indexed):
+    line 26:      fun value(x: U32): U32 =>
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/keyword"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (26, 2,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (26, 2, 3, None)]
+        end))])
+
+class \nodoc\ iso _SelectionRangePositionsArrayTest is UnitTest
+  """
+  Sends two positions in a single textDocument/selectionRange request.
+
+  Position 0: cursor on `x` at line 27, character 4 → expects a non-null
+  SelectionRange chain (the production code path).
+  Position 1: cursor on blank line 28, character 0 → expects JSON null.
+
+  This exercises:
+  - The `"positions"` array parsing branch in
+    workspace_manager.be selection_range
+  - The parallel response array (one entry per input position, in order)
+  - That a no-node position produces null without dropping the entry
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/positions_array"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (27, 4,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (27, 4, 3, (27, 4, 27, 5)); (28, 0, 0, None)]
+        end))])
+
+class \nodoc\ iso _SelectionRangeEmptyPositionsTest is UnitTest
+  """
+  Sends an empty `"positions"` array. Expects an empty response array `[]`.
+
+  Exercises the zero-position path in workspace_manager.be selection_range:
+  the positions loop runs zero iterations and the response is an empty
+  JsonArray rather than null.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/empty_positions"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/selection_range.pony",
+      [ (0, 0,
+        _SelectionRangeChecker(recover val
+          Array[_SrCheck]
+        end))])
+
+// (line, character, min_depth, expected_innermost)
+// min_depth = 0: expect a null response entry (no AST node at this position)
+// min_depth > 0: expect a chain of >= min_depth entries with optional
+// exact innermost (startLine, startChar, endLine, endChar)
+type _SrCheck is (I64, I64, USize, (None | (I64, I64, I64, I64)))
+
+class val _SelectionRangeChecker
+  """
+  Validates a textDocument/selectionRange response.
+
+  Each entry in `_checks` corresponds to one requested position. Positions are
+  sent via `lsp_extra_params()` and responses are validated in order:
+  - min_depth = 0: expect a null entry (no AST node at that position).
+  - min_depth > 0: expect a SelectionRange chain of at least that depth, with
+    monotonically expanding ranges and an optional exact innermost check.
+  """
+  let _checks: Array[_SrCheck] val
+
+  new val create(checks': Array[_SrCheck] val) =>
+    _checks = checks'
+
+  fun lsp_method(): String =>
+    Methods.text_document().selection_range()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    var positions = JsonArray
+    for c in _checks.values() do
+      positions =
+        positions.push(
+          JsonObject.update("line", c._1).update("character", c._2))
+    end
+    JsonObject.update("positions", positions)
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    try
+      let result_arr = res.result as JsonArray
+      if not h.assert_true(
+        result_arr.size() == _checks.size(),
+        "expected " + _checks.size().string() + " response entries, got " +
+        result_arr.size().string())
+      then
+        return false
+      end
+      var ok = true
+      for (i, entry_check) in _checks.pairs() do
+        let entry = result_arr(i)?
+        let min_depth = entry_check._3
+        if min_depth == 0 then
+          // Expect null — no AST node at this position.
+          if not h.assert_true(
+            entry is None,
+            "positions[" + i.string() + "]: expected null, got: " +
+            entry.string())
+          then
+            ok = false
+          end
+        else
+          // Expect a SelectionRange chain.
+          let chain = _flatten_chain(entry)
+          if not h.assert_true(
+            chain.size() >= min_depth,
+            "positions[" + i.string() + "]: expected chain depth >= " +
+            min_depth.string() + ", got " + chain.size().string() +
+            "\n" + _describe_chain(chain))
+          then
+            ok = false
+          end
+          // Innermost range: verify the exact token extent when expected.
+          match entry_check._4
+          | (let esl: I64, let esc: I64, let eel: I64, let eec: I64) =>
+            try
+              let inner = chain(0)?
+              if not h.assert_true(
+                (inner._1 == esl) and (inner._2 == esc) and
+                (inner._3 == eel) and (inner._4 == eec),
+                "positions[" + i.string() + "]: expected innermost " +
+                _range_str(esl, esc, eel, eec) +
+                ", got " + _range_str(inner._1, inner._2, inner._3, inner._4))
+              then
+                ok = false
+              end
+            end
+          end
+          // Monotonic containment: each inner range must fit inside its parent.
+          var j: USize = 0
+          while (j + 1) < chain.size() do
+            try
+              let inner = chain(j)?
+              let outer = chain(j + 1)?
+              let start_ok =
+                (outer._1 < inner._1) or
+                ((outer._1 == inner._1) and (outer._2 <= inner._2))
+              let end_ok =
+                (outer._3 > inner._3) or
+                ((outer._3 == inner._3) and (outer._4 >= inner._4))
+              if not h.assert_true(
+                start_ok and end_ok,
+                "positions[" + i.string() + "] range " + j.string() +
+                " not contained in parent " + (j + 1).string() + ": " +
+                _range_str(inner._1, inner._2, inner._3, inner._4) +
+                " vs " + _range_str(outer._1, outer._2, outer._3, outer._4))
+              then
+                ok = false
+              end
+              // Deduplication: each entry must differ from its parent.
+              if not h.assert_true(
+                (inner._1 != outer._1) or (inner._2 != outer._2) or
+                (inner._3 != outer._3) or (inner._4 != outer._4),
+                "positions[" + i.string() + "] range " + j.string() +
+                " has identical span to parent " + (j + 1).string() + ": " +
+                _range_str(inner._1, inner._2, inner._3, inner._4))
+              then
+                ok = false
+              end
+            end
+            j = j + 1
+          end
+        end
+      end
+      ok
+    else
+      h.fail("Expected selectionRange JsonArray, got: " + res.string())
+      false
+    end
+
+  fun _flatten_chain(val': JsonValue): Array[(I64, I64, I64, I64)] =>
+    """
+    Walk the linked-list { range, parent? } structure and return a flat array
+    of (startLine, startChar, endLine, endChar) tuples, innermost first.
+    """
+    let result: Array[(I64, I64, I64, I64)] = Array[(I64, I64, I64, I64)]
+    var current: JsonValue = val'
+    while true do
+      match current
+      | let obj: JsonObject =>
+        try
+          let sl = JsonNav(obj)("range")("start")("line").as_i64()?
+          let sc = JsonNav(obj)("range")("start")("character").as_i64()?
+          let el = JsonNav(obj)("range")("end")("line").as_i64()?
+          let ec = JsonNav(obj)("range")("end")("character").as_i64()?
+          result.push((sl, sc, el, ec))
+          current = obj("parent")?
+        else
+          break
+        end
+      else
+        break
+      end
+    end
+    result
+
+  fun _describe_chain(chain: Array[(I64, I64, I64, I64)]): String val =>
+    var s: String val = ""
+    for (i, entry) in chain.pairs() do
+      s = s + "  [" + i.string() + "] " +
+        _range_str(entry._1, entry._2, entry._3, entry._4) + "\n"
+    end
+    s
+
+  fun _range_str(sl: I64, sc: I64, el: I64, ec: I64): String val =>
+    recover val
+      "(" + sl.string() + ":" + sc.string() +
+      ")-(" + el.string() + ":" + ec.string() + ")"
+    end

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -32,6 +32,7 @@ actor Main is TestList
     _ReferencesIntegrationTests.make().tests(test)
     _RenameIntegrationTests.make().tests(test)
     _FoldingRangeIntegrationTests.make().tests(test)
+    _SelectionRangeIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/selection_range/selection_range.pony
+++ b/tools/pony-lsp/test/workspace/selection_range/selection_range.pony
@@ -1,0 +1,31 @@
+"""
+Test fixture for exercising LSP textDocument/selectionRange functionality.
+
+Selection range returns a chain of progressively wider ranges enclosing the
+cursor — used by editors to implement "expand selection" (e.g. Ctrl+Shift+→).
+Each step in the chain must contain the previous step's range.
+
+To manually test selection range functionality:
+1. Open the lsp/test/workspace directory as a project in your editor.
+2. Open selection_range/selection_range.pony while the Pony language
+   server is active.
+3. Place the cursor on any identifier or keyword and trigger "Expand
+   Selection" (VS Code: Alt+Shift+→). Verify that each key-press selects
+   a progressively larger syntactic unit: token → expression → function
+   body → function → class body → class → file.
+4. Place the cursor on a blank line and verify that Expand Selection does
+   nothing (no range to expand to).
+
+Expected expansion sequence for cursor on `x` in `fun value` (line 27):
+  `x` → function body → `fun value` → `class SelectionRange` → file
+"""
+
+class SelectionRange
+  """
+  A simple class used to test selection range expansion.
+  """
+  fun value(x: U32): U32 =>
+    x
+
+  fun compute(a: U32, b: U32): U32 =>
+    a + b

--- a/tools/pony-lsp/workspace/selection_ranges.pony
+++ b/tools/pony-lsp/workspace/selection_ranges.pony
@@ -1,0 +1,184 @@
+use ".."
+use "json"
+use "pony_compiler"
+
+primitive SelectionRanges
+  """
+  Builds a textDocument/selectionRange response for a single cursor position.
+
+  The result is a linked-list SelectionRange object — innermost range first,
+  with each `parent` field pointing to the next wider ancestor — or None
+  (JSON null) if the cursor is not on any AST node.
+
+  Ancestor nodes with identical spans are collapsed: when a parent produces
+  the same (start, end) as its child, it is skipped. This eliminates
+  duplicate ranges produced by thin wrapper nodes such as single-child
+  `tk_seq` without needing to enumerate specific token ids.
+
+  Span computation uses a source-file-filtered visitor that excludes
+  descendants from other files (e.g. trait methods merged into the class
+  AST by ponyc). This prevents positions from stdlib or trait source files
+  from inflating the ranges of the user's own nodes.
+
+  The parent walk stops before `tk_package` and `tk_program` nodes, which
+  span the entire compiled program rather than a single file. `tk_module`
+  nodes are included — their span covers the whole current file, producing
+  a useful "select all" outermost range.
+  """
+
+  fun collect(node: AST box, doc_path: String val): JsonValue =>
+    """
+    Build the SelectionRange chain starting at `node` and walking to the
+    root via `parent()`. Returns the innermost SelectionRange with ancestors
+    embedded in successive `parent` fields, or None if no span is found.
+    """
+    // 1. Collect the ancestor chain, innermost first.
+    let chain: Array[AST box] = Array[AST box].create(16)
+    var current: (AST box | None) = node
+    while current isnt None do
+      match \exhaustive\ current
+      | let n: AST box =>
+        let nid = n.id()
+        // Stop before nodes that span the whole program.
+        if (nid == TokenIds.tk_package()) or (nid == TokenIds.tk_program()) then
+          break
+        end
+        chain.push(n)
+        current = n.parent()
+      | None =>
+        break
+      end
+    end
+
+    // 2. Build the JSON linked list from outermost to innermost, nesting as
+    // we go. Walk `chain` in reverse (index chain.size()-1 down to 0).
+    var result: JsonValue = None
+    var last_sl: USize = 0
+    var last_sc: USize = 0
+    var last_el: USize = 0
+    var last_ec: USize = 0
+
+    // TODO(perf): _source_span traverses each ancestor's entire subtree, so
+    // total work is O(sum of subtree sizes) ≈ O(depth * module_node_count).
+    // A bottom-up approach — one full traversal recording spans by node, then
+    // reading cached values per chain entry — would reduce this to O(N).
+    var i = chain.size()
+    while i > 0 do
+      i = i - 1
+      let n = try chain(i)? else continue end
+      match \exhaustive\ _source_span(n, doc_path)
+      | (let s: Position, let e: Position) =>
+        // Deduplicate: skip if this span is identical to the last emitted.
+        let sl = s.line()
+        let sc = s.column()
+        let el = e.line()
+        let ec = e.column()
+        if (sl == last_sl) and (sc == last_sc)
+          and (el == last_el) and (ec == last_ec)
+        then
+          continue
+        end
+        last_sl = sl
+        last_sc = sc
+        last_el = el
+        last_ec = ec
+        let range_json =
+          LspPositionRange(
+            LspPosition.from_ast_pos(s),
+            LspPosition.from_ast_pos_end(e))
+          .to_json()
+        result =
+          match \exhaustive\ result
+          | None =>
+            JsonObject.update("range", range_json)
+          | let parent_json: JsonValue =>
+            JsonObject
+              .update("range", range_json)
+              .update("parent", parent_json)
+          end
+      | None =>
+        None  // inverted or empty span — skip this ancestor
+      end
+    end
+    result
+
+  fun _source_span(
+    n: AST box,
+    doc_path: String val)
+    : ((Position, Position) | None)
+  =>
+    """
+    Compute the source span of AST node `n`, including all descendants
+    whose `source_file()` is None (synthetic container nodes) or matches
+    `doc_path` (leaf tokens from the current file). Descendants whose
+    source_file() is a non-empty string that does not match doc_path are
+    excluded — this filters trait method bodies merged from other files.
+
+    Seeded with the node's own position and end_pos (if any) so that
+    declaration keywords (tk_fun, tk_class, etc.) are included even though
+    they are the node's token rather than a child.
+
+    Note: span() short-circuits on keyword tokens returning only the keyword
+    extent; this visitor always scans children to get the full body range.
+
+    Returns None when the computed span is inverted (should not occur for
+    well-formed AST nodes).
+    """
+    // Seed with this node's own extent. Declaration nodes like tk_fun and
+    // tk_class have end_pos() set to their keyword's last column — include
+    // that so the keyword itself is covered even if no children are visited.
+    let n_start = n.position()
+    let n_end =
+      match \exhaustive\ n.end_pos()
+      | let ep: Position => ep
+      | None => n_start
+      end
+
+    let visitor =
+      object ref is ASTVisitor
+        var _min: Position = n_start
+        var _max: Position = n_end
+
+        fun ref visit(child: AST box): VisitResult =>
+          // Exclude descendants from other source files. Note: returning
+          // Continue (not Stop) still descends into the child's subtree;
+          // AST.visit() itself pre-filters children by _from_same_source(),
+          // so this check is defence-in-depth.
+          match child.source_file()
+          | let sf: String val =>
+            if sf != doc_path then
+              return Continue
+            end
+          end
+          let pos = child.position()
+          if pos < _min then
+            _min = pos
+          end
+          let child_ep =
+            match \exhaustive\ child.end_pos()
+            | let ep: Position => ep
+            | None => pos
+            end
+          if child_ep > _max then
+            _max = child_ep
+          end
+          Continue
+
+        fun ref leave(child: AST box): VisitResult =>
+          Continue
+
+        fun min(): Position =>
+          _min
+
+        fun max(): Position =>
+          _max
+      end
+    n.visit(visitor)
+
+    let min = visitor.min()
+    let max = visitor.max()
+    if min <= max then
+      (min, max)
+    else
+      None
+    end

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -988,6 +988,52 @@ actor WorkspaceManager
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be selection_range(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/selectionRange request.
+
+    Parses the `positions` array from the request params. For each position,
+    finds the AST node under the cursor and builds a SelectionRange linked list
+    from innermost to outermost. The response is a JsonArray parallel to the
+    request positions array; entries are null when no node is found at a
+    position. Returns null if the request has no valid `positions` array.
+    """
+    this._channel.log("Handling textDocument/selectionRange")
+    let document_path = Uris.to_path(document_uri)
+
+    // Each position maps to one response entry (null when no node found), so
+    // the output array is always parallel to the input positions array.
+    var out = JsonArray
+    try
+      let arr = JsonNav(request.params)("positions").as_array()?
+      for pos_val in arr.values() do
+        let entry: JsonValue =
+          try
+            let l = JsonNav(pos_val)("line").as_i64()?
+            let c = JsonNav(pos_val)("character").as_i64()?
+            match _find_node_and_module(document_path, l, c)
+            | (let node: AST box, _) =>
+              SelectionRanges.collect(node, document_path)
+            else
+              None
+            end
+          else
+            None // malformed position entry — keep array parallel
+          end
+        out = out.push(entry)
+      end
+    else
+      this._channel.send(
+        ResponseMessage.create(
+          request.id,
+          None,
+          ResponseError(
+            ErrorCodes.invalid_params(),
+            "Missing or invalid 'positions' array in selectionRange request")))
+      return
+    end
+    this._channel.send(ResponseMessage(request.id, out))
+
   be dispose() =>
     for package_state in this._packages.values() do
       package_state.dispose()


### PR DESCRIPTION
## Context

The Pony LSP does not implement `textDocument/selectionRange`, so editors that invoke Expand Selection (e.g. Alt+Shift+→ in VS Code) receive no response.

## Changes

- Adds `SelectionRanges` primitive in `workspace/selection_ranges.pony` that walks the AST parent chain from the node under the cursor to the root, building a linked-list SelectionRange response (innermost range first, each with a `parent` field pointing to the next wider ancestor). Ancestor nodes with identical spans are collapsed so each expand step produces a visible selection change. Descendants from other source files (e.g. trait methods merged into a class by ponyc) are excluded so ranges always stay within the current file.
- Adds `be selection_range` in `workspace/workspace_manager.pony` that parses the `"positions"` array from the request, resolves the AST node at each position, and returns a parallel response array (null entries for positions with no AST node).
- Wires up `textDocument/selectionRange` routing in `language_server.pony` and `methods.pony`, and advertises `selectionRangeProvider: true` in server capabilities.
- Adds integration tests covering a token position, a method body position, a blank-line position (null response), a keyword position, a multi-position request, and an empty positions array.

Resolves #5185.