### PR TITLE
Add test-pony-compiler to .PHONY in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else ifneq ($(strip $(usedebugger)),)
 endif
 
 .DEFAULT_GOAL := build
-.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint pony-doc test-pony-doc
+.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint pony-doc test-pony-doc test-pony-compiler
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'


### PR DESCRIPTION
The `test-pony-compiler` target (Makefile:284) runs a build-and-test command but produces no file named `test-pony-compiler`. Without `.PHONY`, a stray file or directory with that name in the repo root would make Make think the target is up-to-date and skip it.

Added `test-pony-compiler` to the `.PHONY` declaration at line 181, consistent with the other `test-*` targets already listed there.

Closes #5235