### PR TITLE
Add LSP `workspace/symbol` support

### DIFF
--- a/.release-notes/lsp-workspace-symbol.md
+++ b/.release-notes/lsp-workspace-symbol.md
@@ -1,0 +1,7 @@
+## Add LSP `workspace/symbol` support
+
+The Pony language server now handles `workspace/symbol` requests, enabling workspace-wide symbol search (e.g. "Go to Symbol in Workspace" / Cmd+T in VS Code).
+
+Given a query string, the server performs a case-insensitive substring search over all compiled symbols — top-level types (class, actor, struct, primitive, trait, interface) and their members (constructors, functions, behaviours, fields) — across every package in the workspace. An empty query returns all symbols. Results are returned as a flat `SymbolInformation[]` with file URI and source range; member symbols include a `containerName` identifying the enclosing type.
+
+The server advertises `workspaceSymbolProvider: true` in its capabilities.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -274,6 +274,9 @@ actor LanguageServer is (Notifier & RequestSender)
             )
           )
         end
+      | Methods.workspace().symbol() =>
+        let query = try JsonNav(r.params)("query").as_string()? else "" end
+        _router.workspace_symbol(query, this._channel, r.id)
       | Methods.shutdown() =>
         this._state = _ShuttingDown
         this._channel.send(ResponseMessage.create(r.id, None))
@@ -516,6 +519,7 @@ actor LanguageServer is (Notifier & RequestSender)
                 .update("documentSymbolProvider", true)
                 .update("foldingRangeProvider", true)
                 .update("selectionRangeProvider", true)
+                .update("workspaceSymbolProvider", true)
                 .update(
                   "inlayHintProvider",
                   JsonObject.update("resolveProvider", false)))

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -68,6 +68,9 @@ primitive WorkspaceMethods
   fun inlay_hint(): WorkspaceInlayHintMethods =>
     WorkspaceInlayHintMethods
 
+  fun symbol(): String val =>
+    "workspace/symbol"
+
 primitive WorkspaceFoldingRangeMethods
   """
   Collection of workspace/foldingRange related methods.

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -1306,14 +1306,14 @@ class val _DocHighlightChecker
       end
       for (exp_sl, exp_sc, exp_el, exp_ec, exp_kind) in _expected.values() do
         var found = false
-        for item in arr.values() do
+        for candidate in arr.values() do
           try
-            let range = JsonNav(item)("range")
+            let range = JsonNav(candidate)("range")
             let sl = range("start")("line").as_i64()?
             let sc = range("start")("character").as_i64()?
             let el = range("end")("line").as_i64()?
             let ec = range("end")("character").as_i64()?
-            let kind = JsonNav(item)("kind").as_i64()?
+            let kind = JsonNav(candidate)("kind").as_i64()?
             if (sl == exp_sl) and (sc == exp_sc) and
               (el == exp_el) and (ec == exp_ec) and (kind == exp_kind)
             then

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -1,0 +1,289 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _WorkspaceSymbolIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    let fixture = "references/referenced_class.pony"
+    test(_WsSymExactMatchTest.create(server, fixture))
+    test(_WsSymSubstringMatchTest.create(server, fixture))
+    test(_WsSymSubstringInMiddleTest.create(server, fixture))
+    test(_WsSymCaseInsensitiveTest.create(server, fixture))
+    test(_WsSymMemberTest.create(server, fixture))
+    test(_WsSymNoMatchTest.create(server, fixture))
+    test(_WsSymEmptyQueryTest.create(server, fixture))
+
+class \nodoc\ iso _WsSymExactMatchTest is UnitTest
+  """
+  Query "ReferencedClass" → exactly 1 top-level result named "ReferencedClass"
+  with symbol kind 5 (class).
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/exact_match"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "ReferencedClass",
+            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+
+class \nodoc\ iso _WsSymSubstringMatchTest is UnitTest
+  """
+  Query "Referenced" → matches "ReferencedClass" only (prefix substring).
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/substring_match"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "Referenced",
+            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+
+class \nodoc\ iso _WsSymSubstringInMiddleTest is UnitTest
+  """
+  Query "Class" → matches "ReferencedClass" via substring in the middle.
+  Distinguishes substring matching from prefix-only matching.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/substring_in_middle"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "Class",
+            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+
+class \nodoc\ iso _WsSymCaseInsensitiveTest is UnitTest
+  """
+  Query "referencedclass" (all lower-case) → still matches "ReferencedClass".
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/case_insensitive"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "referencedclass",
+            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+
+class \nodoc\ iso _WsSymMemberTest is UnitTest
+  """
+  Query "increment" → matches the method "increment" inside "ReferencedClass",
+  which should appear with containerName "ReferencedClass".
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/member_match"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "increment",
+            [ ("increment", 6, "referenced_class.pony",
+                "ReferencedClass")]))])
+
+class \nodoc\ iso _WsSymNoMatchTest is UnitTest
+  """
+  Query "zzznomatch" → empty result array.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/no_match"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [(0, 0, _WsSymChecker("zzznomatch", []))])
+
+class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
+  """
+  Empty query → all symbols from the fixture file are returned: the
+  top-level class, its field, constructor, and two methods.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/empty_query"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymChecker(
+            "",
+            [ ("ReferencedClass", 5, "referenced_class.pony", None)
+              ("_count", 8, "referenced_class.pony", "ReferencedClass")
+              ("create", 9, "referenced_class.pony", "ReferencedClass")
+              ("increment", 6, "referenced_class.pony", "ReferencedClass")
+              ("maybe", 6, "referenced_class.pony", "ReferencedClass")]))])
+
+class val _WsSymChecker
+  """
+  Validates a workspace/symbol response.
+
+  Each expected entry is (name, kind, filename_basename, containerName|None).
+  The checker verifies that each expected symbol appears in the response and
+  that the total count matches.
+  """
+  let _query: String
+  let _expected: Array[(String, I64, String, (String | None))] val
+
+  new val create(
+    query: String,
+    expected: Array[(String, I64, String, (String | None))] val)
+  =>
+    _query = query
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.workspace().symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    JsonObject.update("query", _query)
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    match res.result
+    | let arr: JsonArray =>
+      let got = arr.size()
+      let want = _expected.size()
+      if not h.assert_eq[USize](
+        want,
+        got,
+        "workspace/symbol '" + _query + "': expected " +
+        want.string() + " result(s), got " + got.string())
+      then
+        ok = false
+        for item in arr.values() do
+          try
+            let n = JsonNav(item)("name").as_string()?
+            let k = JsonNav(item)("kind").as_i64()?
+            let uri = JsonNav(item)("location")("uri").as_string()?
+            let file = Path.base(Uris.to_path(uri))
+            h.log("  actual: " + n + " (kind " + k.string() + ") in " + file)
+          end
+        end
+      end
+      for (exp_name, exp_kind, exp_file, exp_container) in _expected.values() do
+        var found = false
+        for item in arr.values() do
+          try
+            let n = JsonNav(item)("name").as_string()?
+            let k = JsonNav(item)("kind").as_i64()?
+            let uri = JsonNav(item)("location")("uri").as_string()?
+            let file = Path.base(Uris.to_path(uri))
+            let container: (String | None) =
+              try JsonNav(item)("containerName").as_string()? else None end
+            let container_ok =
+              match (exp_container, container)
+              | (None, None) => true
+              | (let a: String, let b: String) => a == b
+              else false
+              end
+            if (n == exp_name) and (k == exp_kind) and
+              (file == exp_file) and container_ok
+            then
+              found = true
+              break
+            end
+          end
+        end
+        if not h.assert_true(
+          found,
+          "workspace/symbol '" + _query + "': expected symbol '" +
+          exp_name + "' (kind " + exp_kind.string() + ") in " +
+          exp_file + " not found")
+        then
+          ok = false
+        end
+      end
+    else
+      if _expected.size() > 0 then
+        ok = false
+        h.log(
+          "workspace/symbol '" + _query +
+          "': expected results but got null/non-array")
+      end
+    end
+    ok

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -33,6 +33,7 @@ actor Main is TestList
     _RenameIntegrationTests.make().tests(test)
     _FoldingRangeIntegrationTests.make().tests(test)
     _SelectionRangeIntegrationTests.make().tests(test)
+    _WorkspaceSymbolIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -855,6 +855,75 @@ actor WorkspaceManager
     // send a null-response in every failure case
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be workspace_symbol(
+    query: String val,
+    aggregator: WorkspaceSymbolAggregator)
+  =>
+    """
+    Handle workspace/symbol request.
+    Collects symbols matching the query across all packages
+    in this workspace.
+    """
+    this._channel.log("Handling workspace/symbol: '" + query + "'")
+    let query_lower: String val = query.lower()
+    var results = JsonArray
+    for pkg_state in this._packages.values() do
+      for doc_state in pkg_state.documents.values() do
+        let file_uri = Uris.from_path(doc_state.path)
+        let top_symbols = doc_state.document_symbols()
+        for symbol in top_symbols.values() do
+          if _symbol_matches(symbol.name, query_lower) then
+            results =
+              results.push(
+                JsonObject
+                  .update("name", symbol.name)
+                  .update("kind", symbol.kind)
+                  .update(
+                    "location",
+                    JsonObject
+                      .update("uri", file_uri)
+                      .update(
+                        "range",
+                        symbol.selection_range.to_json())))
+          end
+          for child in symbol.children.values() do
+            if _symbol_matches(child.name, query_lower) then
+              results =
+                results.push(
+                  JsonObject
+                    .update("name", child.name)
+                    .update("kind", child.kind)
+                    .update("containerName", symbol.name)
+                    .update(
+                      "location",
+                      JsonObject
+                        .update("uri", file_uri)
+                        .update(
+                          "range",
+                          child.selection_range.to_json())))
+            end
+          end
+        end
+      end
+    end
+    aggregator.add_results(results)
+
+  fun _symbol_matches(name: String, query_lower: String): Bool =>
+    """
+    Returns true if `name` matches `query_lower` (already lowercased).
+    An empty query matches everything; otherwise a case-insensitive substring
+    match is performed.
+    """
+    if query_lower.size() == 0 then
+      return true
+    end
+    try
+      name.lower().find(query_lower)?
+      true
+    else
+      false
+    end
+
   be document_diagnostic(document_uri: String, request: RequestMessage val) =>
     """
     Handle textDocument/diagnostic request.

--- a/tools/pony-lsp/workspace/workspace_router.pony
+++ b/tools/pony-lsp/workspace/workspace_router.pony
@@ -1,5 +1,6 @@
 use "collections"
 use "files"
+use "json"
 use ".."
 
 class WorkspaceRouter
@@ -43,6 +44,24 @@ class WorkspaceRouter
     end
     this.min_workspace_path_len =
       this.min_workspace_path_len.min(abs_folder.size())
+
+  fun workspace_symbol(
+    query: String,
+    channel: Channel,
+    request_id: RequestId)
+  =>
+    """
+    Broadcast a workspace/symbol request to all workspace managers.
+    """
+    let count = workspaces.size()
+    if count == 0 then
+      channel.send(ResponseMessage.create(request_id, JsonArray))
+    else
+      let agg = WorkspaceSymbolAggregator(channel, request_id, count)
+      for mgr in workspaces.values() do
+        mgr.workspace_symbol(query, agg)
+      end
+    end
 
   fun ref dispose() =>
     for mgr in this.workspaces.values() do

--- a/tools/pony-lsp/workspace/workspace_symbol_aggregator.pony
+++ b/tools/pony-lsp/workspace/workspace_symbol_aggregator.pony
@@ -1,0 +1,27 @@
+use "json"
+use ".."
+
+actor WorkspaceSymbolAggregator
+  """
+  Collects workspace/symbol results from multiple WorkspaceManager actors
+  and sends a single aggregated response once all workspaces have replied.
+  """
+  let _channel: Channel
+  let _request_id: RequestId
+  var _remaining: USize
+  var _results: JsonArray
+
+  new create(channel: Channel, request_id: RequestId, workspace_count: USize) =>
+    _channel = channel
+    _request_id = request_id
+    _remaining = workspace_count
+    _results = JsonArray
+
+  be add_results(symbols: JsonArray) =>
+    for s in symbols.values() do
+      _results = _results.push(s)
+    end
+    _remaining = _remaining - 1
+    if _remaining == 0 then
+      _channel.send(ResponseMessage(_request_id, _results))
+    end


### PR DESCRIPTION
## Context

The Pony language server implements the LSP protocol and handles document-scoped requests (hover, references, rename, etc.) by routing them to the `WorkspaceManager` responsible for the file's package. `workspace/symbol` is a workspace-scoped request — it has no document URI and must search across all packages in all open workspaces.

The server already builds a two-level `DocumentSymbol` tree per document (top-level types and their members) via `DocumentSymbols.from_module()`, used by `textDocument/documentSymbol`. This change reuses that infrastructure for the workspace-wide search.

## Changes

- **`WorkspaceSymbolAggregator` actor** (`workspace/workspace_symbol_aggregator.pony`): collects `JsonArray` results from N `WorkspaceManager` actors and sends a single merged response once all workspaces have replied.
- **`WorkspaceManager.workspace_symbol`** behavior: walks all packages and documents, performs a case-insensitive substring match against symbol names, and builds a flat `SymbolInformation[]` response. Top-level types and their members are both included; members carry a `containerName`.
- **`WorkspaceRouter.workspace_symbol`**: handles the zero-workspace edge case directly, otherwise creates an aggregator and broadcasts to all managers.
- **`LanguageServer`**: routes `workspace/symbol` requests to the router and advertises `workspaceSymbolProvider: true` in the server capabilities.

Resolves #5174

## Considerations

Two pre-existing issues were identified during review and are out of scope for this PR:

- `DocumentState.document_symbols()` unconditionally recomputes the full AST traversal on every call, ignoring the cache populated at compile time (`state.pony`). This PR amplifies the impact since every `workspace/symbol` query iterates all documents.
- `DocumentSymbol.to_json()` writes `this.range` into both the `range` and `selectionRange` JSON fields, losing the identifier-only span (`symbols.pony`). As a result, `workspace/symbol` (which uses `selection_range` directly) and `textDocument/documentSymbol` return inconsistent range values.