### PR TITLE
Fix LSP symbol range semantics

### DIFF
--- a/.release-notes/lsp-symbol-range.md
+++ b/.release-notes/lsp-symbol-range.md
@@ -1,0 +1,7 @@
+## Fix LSP symbol range semantics
+
+The `textDocument/documentSymbol` response was returning the full declaration range for both the `range` and `selectionRange` fields, losing the identifier-only span that `selectionRange` is meant to carry. Editors use `selectionRange` to position the cursor on the symbol name rather than the start of its declaration.
+
+The `workspace/symbol` response was returning the identifier-only span for `SymbolInformation.location.range`, where the LSP spec expects the full declaration range.
+
+Both endpoints are now spec-compliant and consistent with each other.

--- a/.release-notes/lsp-symbol-range.md
+++ b/.release-notes/lsp-symbol-range.md
@@ -1,7 +1,7 @@
 ## Fix LSP symbol range semantics
 
-The `textDocument/documentSymbol` response was returning the full declaration range for both the `range` and `selectionRange` fields, losing the identifier-only span that `selectionRange` is meant to carry. Editors use `selectionRange` to position the cursor on the symbol name rather than the start of its declaration.
+The `textDocument/documentSymbol` response was returning the keyword-only span for both the `range` and `selectionRange` fields, losing the identifier-only span that `selectionRange` is meant to carry and truncating `range` so that it no longer enclosed the declaration. Editors use `selectionRange` to position the cursor on the symbol name rather than the start of its declaration, and the LSP spec requires `selectionRange` to be contained within `range` — some clients reject the response outright with "selectionRange must be contained in range" when it is not.
 
 The `workspace/symbol` response was returning the identifier-only span for `SymbolInformation.location.range`, where the LSP spec expects the full declaration range.
 
-Both endpoints are now spec-compliant and consistent with each other.
+Both endpoints now return the full declaration range (the entity keyword through the end of its body) as `range`, and the identifier-only span as `selectionRange`, and are consistent with each other.

--- a/.release-notes/lsp-symbol-range.md
+++ b/.release-notes/lsp-symbol-range.md
@@ -1,7 +1,5 @@
-## Fix LSP symbol range semantics
+## Fix LSP symbol ranges
 
-The `textDocument/documentSymbol` response was returning the keyword-only span for both the `range` and `selectionRange` fields, losing the identifier-only span that `selectionRange` is meant to carry and truncating `range` so that it no longer enclosed the declaration. Editors use `selectionRange` to position the cursor on the symbol name rather than the start of its declaration, and the LSP spec requires `selectionRange` to be contained within `range` — some clients reject the response outright with "selectionRange must be contained in range" when it is not.
+LSP clients that use `textDocument/documentSymbol` (the outline/breadcrumb view in most editors) could produce a "selectionRange must be contained in range" error, causing the entire symbol list to be rejected. This is now fixed.
 
-The `workspace/symbol` response was returning the identifier-only span for `SymbolInformation.location.range`, where the LSP spec expects the full declaration range.
-
-Both endpoints now return the full declaration range (the entity keyword through the end of its body) as `range`, and the identifier-only span as `selectionRange`, and are consistent with each other.
+In addition, symbol ranges across both `textDocument/documentSymbol` and `workspace/symbol` now correctly cover the full declaration — from the opening keyword to the end of the body. Previously they covered only the declaration keyword itself, so highlighting a symbol or jumping to it would select just `class`, `fun`, etc. rather than the whole declaration.

--- a/.release-notes/lsp-symbol-range.md
+++ b/.release-notes/lsp-symbol-range.md
@@ -2,4 +2,4 @@
 
 LSP clients that use `textDocument/documentSymbol` (the outline/breadcrumb view in most editors) could produce a "selectionRange must be contained in range" error, causing the entire symbol list to be rejected. This is now fixed.
 
-In addition, symbol ranges across both `textDocument/documentSymbol` and `workspace/symbol` now correctly cover the full declaration — from the opening keyword to the end of the body. Previously they covered only the declaration keyword itself, so highlighting a symbol or jumping to it would select just `class`, `fun`, etc. rather than the whole declaration.
+In addition, symbol ranges across both `textDocument/documentSymbol` and `workspace/symbol` now correctly cover the full declaration — from the opening keyword to the end of the body. Previously, `textDocument/documentSymbol` ranges covered only the declaration keyword (`class`, `fun`, etc.), and `workspace/symbol` ranges covered only the identifier. Highlighting a symbol or jumping to it now selects the whole declaration.

--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -47,10 +47,15 @@ primitive ASTSourceSpan
         var _max: Position = n_end
 
         fun ref visit(child: AST box): VisitResult =>
-          // Exclude descendants from other source files. Note: returning
-          // Continue (not Stop) still descends into the child's subtree;
-          // AST.visit() itself pre-filters children by _from_same_source(),
-          // so this check is defence-in-depth.
+          // Exclude descendants from other source files. This is the
+          // primary filter for nodes that reach here via a synthetic
+          // (None source_file) intermediary: AST.visit()'s own
+          // _from_same_source() returns true when either side is None,
+          // so a chain our_file -> None-source -> other_file can pass
+          // AST.visit()'s check. The explicit test here catches that.
+          // Note: returning Continue still descends into the child's
+          // subtree — only the child's own position is excluded from
+          // the min/max accumulation, not its descendants.
           match child.source_file()
           | let sf: String val =>
             if sf != doc_path then

--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -8,6 +8,13 @@ primitive ASTSourceSpan
   source_file() is a non-empty string that does not match doc_path are
   excluded — this filters trait method bodies merged from other files.
 
+  The optional `max_pos` parameter caps the end of the computed span:
+  only descendants whose end position is strictly less than `max_pos`
+  contribute to `_max`. Pass the start position of the next sibling
+  entity to prevent synthesized constructors (ponyc inserts them for
+  bare primitives, bare classes, etc.) from inflating the entity's range
+  into the next entity's lines.
+
   Seeded with the node's own position and end_pos (if any) so that
   declaration keywords (tk_fun, tk_class, etc.) are included even though
   they are the node's token rather than a child.
@@ -23,7 +30,8 @@ primitive ASTSourceSpan
 
   fun tag apply(
     n: AST box,
-    doc_path: String val)
+    doc_path: String val,
+    max_pos: (Position | None) = None)
     : ((Position, Position) | None)
   =>
     """
@@ -71,7 +79,16 @@ primitive ASTSourceSpan
             | let ep: Position => ep
             | None => pos
             end
-          if child_ep > _max then
+          // Only extend _max if child_ep is within the allowed bound.
+          // This prevents synthesized constructors (whose body tokens
+          // ponyc positions at the start of the next sibling entity)
+          // from inflating the span past the current entity's content.
+          let ep_in_bounds =
+            match \exhaustive\ max_pos
+            | None => true
+            | let m: Position => child_ep < m
+            end
+          if ep_in_bounds and (child_ep > _max) then
             _max = child_ep
           end
           Continue

--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -1,0 +1,91 @@
+use "pony_compiler"
+
+primitive ASTSourceSpan
+  """
+  Computes the true source span of an AST node, including all descendants
+  whose `source_file()` is None (synthetic container nodes) or matches
+  `doc_path` (leaf tokens from the current file). Descendants whose
+  source_file() is a non-empty string that does not match doc_path are
+  excluded — this filters trait method bodies merged from other files.
+
+  Seeded with the node's own position and end_pos (if any) so that
+  declaration keywords (tk_fun, tk_class, etc.) are included even though
+  they are the node's token rather than a child.
+
+  Note: AST.span() short-circuits on keyword tokens returning only the
+  keyword extent; this helper always scans children to get the full body
+  range. Required by any LSP response that quotes a "full declaration
+  range" for entity or member declarations.
+
+  Returns None when the computed span is inverted (should not occur for
+  well-formed AST nodes).
+  """
+
+  fun tag apply(
+    n: AST box,
+    doc_path: String val)
+    : ((Position, Position) | None)
+  =>
+    """
+    Compute the span of `n`, returning `(start, end)` in ponyc's native
+    `Position` units (1-based line, 1-based column, end inclusive), or
+    `None` if the computed span is inverted.
+    """
+    // Seed with this node's own extent. Declaration nodes like tk_fun and
+    // tk_class have end_pos() set to their keyword's last column — include
+    // that so the keyword itself is covered even if no children are visited.
+    let n_start = n.position()
+    let n_end =
+      match \exhaustive\ n.end_pos()
+      | let ep: Position => ep
+      | None => n_start
+      end
+
+    let visitor =
+      object ref is ASTVisitor
+        var _min: Position = n_start
+        var _max: Position = n_end
+
+        fun ref visit(child: AST box): VisitResult =>
+          // Exclude descendants from other source files. Note: returning
+          // Continue (not Stop) still descends into the child's subtree;
+          // AST.visit() itself pre-filters children by _from_same_source(),
+          // so this check is defence-in-depth.
+          match child.source_file()
+          | let sf: String val =>
+            if sf != doc_path then
+              return Continue
+            end
+          end
+          let pos = child.position()
+          if pos < _min then
+            _min = pos
+          end
+          let child_ep =
+            match \exhaustive\ child.end_pos()
+            | let ep: Position => ep
+            | None => pos
+            end
+          if child_ep > _max then
+            _max = child_ep
+          end
+          Continue
+
+        fun ref leave(child: AST box): VisitResult =>
+          Continue
+
+        fun min(): Position =>
+          _min
+
+        fun max(): Position =>
+          _max
+      end
+    n.visit(visitor)
+
+    let min = visitor.min()
+    let max = visitor.max()
+    if min <= max then
+      (min, max)
+    else
+      None
+    end

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -97,7 +97,7 @@ class DocumentSymbol
       .update("name", this.name)
       .update("kind", this.kind)
       .update("range", this.range.to_json())
-      .update("selectionRange", this.range.to_json())
+      .update("selectionRange", this.selection_range.to_json())
     if this.detail isnt None then
       obj = obj.update("detail", detail)
     end

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -147,33 +147,8 @@ primitive DocumentSymbols
           let id = module_child(0)?
           if id.id() == TokenIds.tk_id() then
             let name = id.token_value() as String
-            let doc_path =
-              try
-                module_child.source_file() as String val
-              else
-                channel.log(
-                  "No source_file for " +
-                  TokenIds.string(module_child.id()) + " '" + name + "'")
-                error
-              end
-            (let start_pos, let end_pos) =
-              match \exhaustive\ ASTSourceSpan(module_child, doc_path)
-              | (let s: Position, let e: Position) => (s, e)
-              | None =>
-                channel.log(
-                  "Inverted source span for " +
-                  TokenIds.string(module_child.id()) + " '" + name + "'")
-                error
-              end
-            let full_range =
-              LspPositionRange(
-                LspPosition.from_ast_pos(start_pos),
-                LspPosition.from_ast_pos_end(end_pos))
-            (let id_start, let id_end) = id.span()
-            let selection_range =
-              LspPositionRange(
-                LspPosition.from_ast_pos(id_start),
-                LspPosition.from_ast_pos_end(id_end))
+            (let full_range, let selection_range) =
+              this._symbol_ranges(module_child, id, name, channel)?
             let symbol =
               DocumentSymbol(name, kind, full_range, selection_range)
             this.find_members(module_child, symbol, channel)
@@ -230,36 +205,53 @@ primitive DocumentSymbols
             TokenIds.string(entity_child.id()) +
             ", got " + TokenIds.string(id.id()))?
           let name = id.token_value() as String
-          let doc_path =
-            try
-              entity_child.source_file() as String val
-            else
-              channel.log(
-                "No source_file for " +
-                TokenIds.string(entity_child.id()) + " '" + name + "'")
-              error
-            end
-          (let start_pos, let end_pos) =
-            match \exhaustive\ ASTSourceSpan(entity_child, doc_path)
-            | (let s: Position, let e: Position) => (s, e)
-            | None =>
-              channel.log(
-                "Inverted source span for " +
-                TokenIds.string(entity_child.id()) + " '" + name + "'")
-              error
-            end
-          let full_range =
-            LspPositionRange(
-              LspPosition.from_ast_pos(start_pos),
-              LspPosition.from_ast_pos_end(end_pos))
-          (let id_start, let id_end) = id.span()
-          let selection_range =
-            LspPositionRange(
-              LspPosition.from_ast_pos(id_start),
-              LspPosition.from_ast_pos_end(id_end))
+          (let full_range, let selection_range) =
+            this._symbol_ranges(entity_child, id, name, channel)?
           let member_symbol =
             DocumentSymbol(name, kind, full_range, selection_range)
           symbol.push_child(member_symbol)
         end
       end
     end
+
+  fun tag _symbol_ranges(
+    node: AST box,
+    id: AST box,
+    name: String,
+    channel: Channel)
+    : (LspPositionRange, LspPositionRange) ?
+  =>
+    """
+    Compute the full declaration range and the identifier selection range
+    for an entity or member AST node. Raises error (logging to `channel`)
+    if `source_file()` is absent or if `ASTSourceSpan` returns an inverted
+    span — callers inside a `try` block will skip the symbol on failure.
+    """
+    let doc_path =
+      try
+        node.source_file() as String val
+      else
+        channel.log(
+          "No source_file for " +
+          TokenIds.string(node.id()) + " '" + name + "'")
+        error
+      end
+    (let start_pos, let end_pos) =
+      match \exhaustive\ ASTSourceSpan(node, doc_path)
+      | (let s: Position, let e: Position) => (s, e)
+      | None =>
+        channel.log(
+          "Inverted source span for " +
+          TokenIds.string(node.id()) + " '" + name + "'")
+        error
+      end
+    let full_range =
+      LspPositionRange(
+        LspPosition.from_ast_pos(start_pos),
+        LspPosition.from_ast_pos_end(end_pos))
+    (let id_start, let id_end) = id.span()
+    let selection_range =
+      LspPositionRange(
+        LspPosition.from_ast_pos(id_start),
+        LspPosition.from_ast_pos_end(id_end))
+    (full_range, selection_range)

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -208,14 +208,14 @@ primitive DocumentSymbols
       return
     end
     for entity_child in members.children() do
+      // Skip members whose position is at or beyond max_pos. ponyc
+      // positions synthesized constructors at the start of the next
+      // entity in the file; max_pos is that entity's start position.
+      match max_pos
+      | let m: Position =>
+        if entity_child.position() >= m then continue end
+      end
       try
-        // Skip members whose position is at or beyond max_pos. ponyc
-        // positions synthesized constructors at the start of the next
-        // entity in the file; max_pos is that entity's start position.
-        match max_pos
-        | let m: Position =>
-          Fact(entity_child.position() < m, "member position out of bounds")?
-        end
         let maybe_kind_and_idx =
           match entity_child.id()
           | TokenIds.tk_new() => (SymbolKinds.constructor(), USize(1))

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -127,7 +127,27 @@ primitive DocumentSymbols
     module: Module,
     channel: Channel): Array[DocumentSymbol] ref
   =>
+    """
+    Build DocumentSymbol trees for every top-level entity in the module.
+    """
     let symbols: Array[DocumentSymbol] ref = Array[DocumentSymbol].create(4)
+    // Collect entity start positions for look-ahead. Each entity's range
+    // is bounded by the next entity's start — this prevents synthesized
+    // constructors (which ponyc positions at the next entity's line) from
+    // inflating the entity's span.
+    let entity_starts = Array[Position].create()
+    for module_child in module.ast.children() do
+      match module_child.id()
+      | TokenIds.tk_interface()
+      | TokenIds.tk_trait()
+      | TokenIds.tk_primitive()
+      | TokenIds.tk_class()
+      | TokenIds.tk_type()
+      | TokenIds.tk_actor()
+      | TokenIds.tk_struct() => entity_starts.push(module_child.position())
+      end
+    end
+    var entity_idx: USize = 0
     for module_child in module.ast.children() do
       let maybe_kind =
         match module_child.id()
@@ -143,15 +163,18 @@ primitive DocumentSymbols
         end
       match maybe_kind
       | let kind: I64 =>
+        let max_pos: (Position | None) =
+          try entity_starts(entity_idx + 1)? else None end
+        entity_idx = entity_idx + 1
         try
           let id = module_child(0)?
           if id.id() == TokenIds.tk_id() then
             let name = id.token_value() as String
             (let full_range, let selection_range) =
-              this._symbol_ranges(module_child, id, name, channel)?
+              this._symbol_ranges(module_child, id, name, channel, max_pos)?
             let symbol =
               DocumentSymbol(name, kind, full_range, selection_range)
-            this.find_members(module_child, symbol, channel)
+            this.find_members(module_child, symbol, channel, max_pos)
             symbols.push(symbol)
           else
             channel.log("Expecred TK_ID, got " + TokenIds.string(id.id()))
@@ -166,7 +189,8 @@ primitive DocumentSymbols
   fun tag find_members(
     entity: AST,
     symbol: DocumentSymbol ref,
-    channel: Channel)
+    channel: Channel,
+    max_pos: (Position | None) = None)
   =>
     let members =
       try
@@ -185,6 +209,13 @@ primitive DocumentSymbols
     end
     for entity_child in members.children() do
       try
+        // Skip members whose position is at or beyond max_pos. ponyc
+        // positions synthesized constructors at the start of the next
+        // entity in the file; max_pos is that entity's start position.
+        match max_pos
+        | let m: Position =>
+          Fact(entity_child.position() < m, "member position out of bounds")?
+        end
         let maybe_kind_and_idx =
           match entity_child.id()
           | TokenIds.tk_new() => (SymbolKinds.constructor(), USize(1))
@@ -206,7 +237,7 @@ primitive DocumentSymbols
             ", got " + TokenIds.string(id.id()))?
           let name = id.token_value() as String
           (let full_range, let selection_range) =
-            this._symbol_ranges(entity_child, id, name, channel)?
+            this._symbol_ranges(entity_child, id, name, channel, max_pos)?
           let member_symbol =
             DocumentSymbol(name, kind, full_range, selection_range)
           symbol.push_child(member_symbol)
@@ -218,7 +249,8 @@ primitive DocumentSymbols
     node: AST box,
     id: AST box,
     name: String,
-    channel: Channel)
+    channel: Channel,
+    max_pos: (Position | None) = None)
     : (LspPositionRange, LspPositionRange) ?
   =>
     """
@@ -237,7 +269,7 @@ primitive DocumentSymbols
         error
       end
     (let start_pos, let end_pos) =
-      match \exhaustive\ ASTSourceSpan(node, doc_path)
+      match \exhaustive\ ASTSourceSpan(node, doc_path, max_pos)
       | (let s: Position, let e: Position) => (s, e)
       | None =>
         channel.log(

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -147,16 +147,33 @@ primitive DocumentSymbols
           let id = module_child(0)?
           if id.id() == TokenIds.tk_id() then
             let name = id.token_value() as String
-            (let start_pos, let end_pos) = module_child.span()
+            let doc_path =
+              try
+                module_child.source_file() as String val
+              else
+                channel.log(
+                  "No source_file for " +
+                  TokenIds.string(module_child.id()) + " '" + name + "'")
+                error
+              end
+            (let start_pos, let end_pos) =
+              match \exhaustive\ ASTSourceSpan(module_child, doc_path)
+              | (let s: Position, let e: Position) => (s, e)
+              | None =>
+                channel.log(
+                  "Inverted source span for " +
+                  TokenIds.string(module_child.id()) + " '" + name + "'")
+                error
+              end
             let full_range =
               LspPositionRange(
                 LspPosition.from_ast_pos(start_pos),
-                LspPosition.from_ast_pos(end_pos))
+                LspPosition.from_ast_pos_end(end_pos))
             (let id_start, let id_end) = id.span()
             let selection_range =
               LspPositionRange(
                 LspPosition.from_ast_pos(id_start),
-                LspPosition.from_ast_pos(id_end))
+                LspPosition.from_ast_pos_end(id_end))
             let symbol =
               DocumentSymbol(name, kind, full_range, selection_range)
             this.find_members(module_child, symbol, channel)
@@ -213,16 +230,33 @@ primitive DocumentSymbols
             TokenIds.string(entity_child.id()) +
             ", got " + TokenIds.string(id.id()))?
           let name = id.token_value() as String
-          (let start_pos, let end_pos) = entity_child.span()
+          let doc_path =
+            try
+              entity_child.source_file() as String val
+            else
+              channel.log(
+                "No source_file for " +
+                TokenIds.string(entity_child.id()) + " '" + name + "'")
+              error
+            end
+          (let start_pos, let end_pos) =
+            match \exhaustive\ ASTSourceSpan(entity_child, doc_path)
+            | (let s: Position, let e: Position) => (s, e)
+            | None =>
+              channel.log(
+                "Inverted source span for " +
+                TokenIds.string(entity_child.id()) + " '" + name + "'")
+              error
+            end
           let full_range =
             LspPositionRange(
               LspPosition.from_ast_pos(start_pos),
-              LspPosition.from_ast_pos(end_pos))
+              LspPosition.from_ast_pos_end(end_pos))
           (let id_start, let id_end) = id.span()
           let selection_range =
             LspPositionRange(
               LspPosition.from_ast_pos(id_start),
-              LspPosition.from_ast_pos(id_end))
+              LspPosition.from_ast_pos_end(id_end))
           let member_symbol =
             DocumentSymbol(name, kind, full_range, selection_range)
           symbol.push_child(member_symbol)

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -245,9 +245,17 @@ primitive DocumentSymbols
           TokenIds.string(node.id()) + " '" + name + "'")
         error
       end
+    // Clamp start to the node's own keyword position. Nominal references
+    // in `type` aliases store the definition-site position of the
+    // referenced type (same file, earlier line), which ASTSourceSpan's
+    // min-walk would otherwise include, pulling the start before the
+    // declaration keyword.
+    let n_pos = node.position()
+    let clamped_start =
+      if start_pos < n_pos then n_pos else start_pos end
     let full_range =
       LspPositionRange(
-        LspPosition.from_ast_pos(start_pos),
+        LspPosition.from_ast_pos(clamped_start),
         LspPosition.from_ast_pos_end(end_pos))
     (let id_start, let id_end) = id.span()
     let selection_range =

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -1,0 +1,285 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _DocumentSymbolIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    let fixture = "references/referenced_class.pony"
+    test(_DocSymContainmentTest.create(server, fixture))
+    test(_DocSymRangeTest.create(server, fixture))
+
+class \nodoc\ iso _DocSymContainmentTest is UnitTest
+  """
+  Regression guard for #5240 follow-up: every symbol's selectionRange must
+  be contained within its range. Checks the top-level symbols and all
+  nested children recursively.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_symbol/integration/containment"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [(0, 0, _DocSymContainmentChecker)])
+
+class \nodoc\ iso _DocSymRangeTest is UnitTest
+  """
+  "class ReferencedClass" — full `range` should span from the `class`
+  keyword on line 0 past the class body (at least through line 21 where
+  `fun ref increment` is declared), distinguishing it from the
+  keyword-only span that would end at column 5.
+
+  "fun ref increment" — full `range` should span from the `fun` keyword
+  on line 21 through the method body (at least line 22).
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "document_symbol/integration/range"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _DocSymRangeChecker(
+            "ReferencedClass",
+            None,
+            // range.start (line, char); selectionRange.start (line, char)
+            (0, 0, 0, 6),
+            21))
+        ( 0, 0,
+          _DocSymRangeChecker(
+            "increment",
+            "ReferencedClass",
+            (21, 2, 21, 10),
+            22))])
+
+class val _DocSymContainmentChecker
+  """
+  Validates that every DocumentSymbol (and every nested child) in a
+  textDocument/documentSymbol response has selectionRange contained
+  within range.
+  """
+  new val create() => None
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      var ok = true
+      for item in arr.values() do
+        ok = _check_symbol(item, h) and ok
+      end
+      ok
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      false
+    end
+
+  fun _check_symbol(item: JsonValue, h: TestHelper): Bool =>
+    var ok = true
+    try
+      let name = JsonNav(item)("name").as_string()?
+      let r_sl = JsonNav(item)("range")("start")("line").as_i64()?
+      let r_sc = JsonNav(item)("range")("start")("character").as_i64()?
+      let r_el = JsonNav(item)("range")("end")("line").as_i64()?
+      let r_ec = JsonNav(item)("range")("end")("character").as_i64()?
+      let s_sl = JsonNav(item)("selectionRange")("start")("line").as_i64()?
+      let s_sc = JsonNav(item)("selectionRange")("start")("character").as_i64()?
+      let s_el = JsonNav(item)("selectionRange")("end")("line").as_i64()?
+      let s_ec = JsonNav(item)("selectionRange")("end")("character").as_i64()?
+
+      // selectionRange.start must be >= range.start
+      let start_ok =
+        (s_sl > r_sl) or ((s_sl == r_sl) and (s_sc >= r_sc))
+      if not h.assert_true(
+        start_ok,
+        "documentSymbol '" + name +
+        "': selectionRange.start (" + s_sl.string() + ":" + s_sc.string() +
+        ") must be >= range.start (" + r_sl.string() + ":" + r_sc.string() +
+        ")")
+      then
+        ok = false
+      end
+
+      // selectionRange.end must be <= range.end
+      let end_ok =
+        (s_el < r_el) or ((s_el == r_el) and (s_ec <= r_ec))
+      if not h.assert_true(
+        end_ok,
+        "documentSymbol '" + name +
+        "': selectionRange.end (" + s_el.string() + ":" + s_ec.string() +
+        ") must be <= range.end (" + r_el.string() + ":" + r_ec.string() +
+        ")")
+      then
+        ok = false
+      end
+
+      // Recurse into children if present.
+      try
+        let children = JsonNav(item)("children").as_array()?
+        for child in children.values() do
+          ok = _check_symbol(child, h) and ok
+        end
+      end
+    else
+      h.fail("documentSymbol: malformed symbol entry")
+      ok = false
+    end
+    ok
+
+class val _DocSymRangeChecker
+  """
+  Validates range/selectionRange for a named symbol (optionally nested
+  under a parent) in a documentSymbol response.
+
+  - positions: (range.start.line, range.start.char,
+      selectionRange.start.line, selectionRange.start.char)
+  - min_end_line: asserts range.end.line >= this value, proving the full
+    declaration is covered rather than just the keyword.
+  """
+  let _symbol_name: String
+  let _parent_name: (String | None)
+  let _positions: (I64, I64, I64, I64)
+  let _min_end_line: I64
+
+  new val create(
+    symbol_name: String,
+    parent_name: (String | None),
+    positions: (I64, I64, I64, I64),
+    min_end_line: I64)
+  =>
+    _symbol_name = symbol_name
+    _parent_name = parent_name
+    _positions = positions
+    _min_end_line = min_end_line
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      let found = _find(arr, _symbol_name, _parent_name)
+      match found
+      | None =>
+        h.fail(
+          "documentSymbol: symbol '" + _symbol_name +
+          "' not found in response")
+        false
+      else
+        _assert_ranges(found, h)
+      end
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      false
+    end
+
+  fun _find(
+    arr: JsonArray,
+    name: String,
+    parent: (String | None))
+    : JsonValue
+  =>
+    for item in arr.values() do
+      try
+        let item_name = JsonNav(item)("name").as_string()?
+        match \exhaustive\ parent
+        | None =>
+          if item_name == name then return item end
+        | let p: String =>
+          if item_name == p then
+            try
+              let children = JsonNav(item)("children").as_array()?
+              for child in children.values() do
+                try
+                  if JsonNav(child)("name").as_string()? == name then
+                    return child
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    None
+
+  fun _assert_ranges(item: JsonValue, h: TestHelper): Bool =>
+    (let exp_r_sl, let exp_r_sc, let exp_s_sl, let exp_s_sc) = _positions
+    var ok = true
+    try
+      let r_sl = JsonNav(item)("range")("start")("line").as_i64()?
+      let r_sc = JsonNav(item)("range")("start")("character").as_i64()?
+      let r_el = JsonNav(item)("range")("end")("line").as_i64()?
+      let s_sl = JsonNav(item)("selectionRange")("start")("line").as_i64()?
+      let s_sc = JsonNav(item)("selectionRange")("start")("character").as_i64()?
+
+      ok = h.assert_eq[I64](
+        exp_r_sl,
+        r_sl,
+        _symbol_name + ": range.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp_r_sc,
+        r_sc,
+        _symbol_name + ": range.start.character") and ok
+      ok = h.assert_eq[I64](
+        exp_s_sl,
+        s_sl,
+        _symbol_name + ": selectionRange.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp_s_sc,
+        s_sc,
+        _symbol_name + ": selectionRange.start.character") and ok
+      ok = h.assert_true(
+        r_el >= _min_end_line,
+        _symbol_name +
+        ": range.end.line (" + r_el.string() +
+        ") should be >= " + _min_end_line.string() +
+        " (full declaration, not keyword-only)") and ok
+    else
+      h.fail(_symbol_name + ": malformed symbol entry")
+      ok = false
+    end
+    ok

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -19,6 +19,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymEntityKindsTest.create(server))
     test(_DocSymMemberKindsTest.create(server))
     test(_DocSymCrossFileTraitTest.create(server))
+    test(_DocSymTypeAliasRangeTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -184,6 +185,42 @@ class \nodoc\ iso _DocSymCrossFileTraitTest is UnitTest
       "document_symbol/_ds_impl.pony",
       [ ( 0, 0,
           _DocSymMaxEndLineChecker("_DsImpl", 15))])
+
+class \nodoc\ iso _DocSymTypeAliasRangeTest is UnitTest
+  """
+  Verifies that a `type` alias has a range covering the entire
+  declaration — from the `type` keyword to the end of the nominal
+  reference — and a selectionRange covering only the identifier.
+
+  Regression guard for cross-entity bleed: type aliases hold usage-site
+  positions for the nominal reference, so `ASTSourceSpan` must not drift
+  into the referenced entity's tokens.
+
+  Exact positions are derived from `_ds_ent_interface.pony` line 23
+  (1-based) = line 22 (0-based):
+    `type _DsEntType is _DsEntClass`
+     ^0                            ^30
+          ^5        ^15
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/type_alias_range"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_ent_interface.pony",
+      [ ( 0, 0,
+          _DocSymRangeChecker(
+            "_DsEntType",
+            None,
+            (22, 0, 22, 30),
+            (22, 5, 22, 15)))])
 
 class val _DocSymContainmentChecker
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -97,7 +97,7 @@ class \nodoc\ iso _DocSymEntityKindsTest is UnitTest
     struct                         → sk_struct (23)
 
   Regression guard against silent edits to the `tk_*` → SymbolKind
-  match table at `tools/pony-lsp/symbols.pony:134-143`.
+  match table at `tools/pony-lsp/symbols.pony:153-163`.
   """
   let _server: _LspTestServer
 

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -78,6 +78,106 @@ class \nodoc\ iso _DocSymRangeTest is UnitTest
             (13, 2, 13, 10),
             14))])
 
+class \nodoc\ iso _DocSymEntityKindsTest is UnitTest
+  """
+  Asserts that every Pony entity token surfaces as a top-level
+  DocumentSymbol with the LSP SymbolKind it is mapped to by
+  `DocumentSymbols.from_module`:
+    class, actor, primitive, type  → sk_class (5)
+    trait, interface               → sk_interface (11)
+    struct                         → sk_struct (23)
+
+  Regression guard against silent edits to the `tk_*` → SymbolKind
+  match table at `tools/pony-lsp/symbols.pony:134-143`.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/entity_kinds"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_ent_interface.pony",
+      [ ( 0, 0,
+          _DocSymTopLevelKindsChecker(
+            [ ("_DsEntClass", 5)
+              ("_DsEntActor", 5)
+              ("_DsEntTrait", 11)
+              ("_DsEntInterface", 11)
+              ("_DsEntPrimitive", 5)
+              ("_DsEntStruct", 23)
+              ("_DsEntType", 5)]))])
+
+class \nodoc\ iso _DocSymMemberKindsTest is UnitTest
+  """
+  Asserts that every member token surfaces as a child DocumentSymbol
+  under its enclosing entity with the LSP SymbolKind it is mapped to
+  by `DocumentSymbols.find_members`:
+    tk_new                         → constructor (9)
+    tk_fun, tk_be                  → method (6)
+    tk_flet, tk_fvar, tk_embed     → field (8)
+
+  Regression guard against silent edits to the member `tk_*` →
+  SymbolKind match table at `tools/pony-lsp/symbols.pony:214-220`.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/member_kinds"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_member_host.pony",
+      [ ( 0, 0,
+          _DocSymChildKindsChecker(
+            "_DsMemberHost",
+            [ ("_let_field", 8)
+              ("_var_field", 8)
+              ("_embed_field", 8)
+              ("create", 9)
+              ("ds_fun", 6)
+              ("ds_be", 6)]))])
+
+class \nodoc\ iso _DocSymCrossFileTraitTest is UnitTest
+  """
+  Regression guard for the source-file filter in `ASTSourceSpan`.
+
+  `_DsImpl` (in `_ds_impl.pony`) inherits `ds_default_method` from
+  `_DsTrait` (in `_ds_trait.pony`) without overriding it. ponyc merges
+  the trait's default body into the impl's AST, but the merged tokens
+  carry the trait file's `source_file()`. `ASTSourceSpan` filters those
+  descendants out when computing the impl's span.
+
+  If the filter regresses, `_DsImpl.range.end.line` would jump to a line
+  in the trait file (past line 20). The assertion below caps end.line
+  well below that, so any drift into the trait file is detected.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/cross_file_trait"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_impl.pony",
+      [ ( 0, 0,
+          _DocSymMaxEndLineChecker("_DsImpl", 15))])
+
 class val _DocSymContainmentChecker
   """
   Validates that every DocumentSymbol (and every nested child) in a
@@ -286,106 +386,6 @@ class val _DocSymRangeChecker
       ok = false
     end
     ok
-
-class \nodoc\ iso _DocSymEntityKindsTest is UnitTest
-  """
-  Asserts that every Pony entity token surfaces as a top-level
-  DocumentSymbol with the LSP SymbolKind it is mapped to by
-  `DocumentSymbols.from_module`:
-    class, actor, primitive, type  → sk_class (5)
-    trait, interface               → sk_interface (11)
-    struct                         → sk_struct (23)
-
-  Regression guard against silent edits to the `tk_*` → SymbolKind
-  match table at `tools/pony-lsp/symbols.pony:134-143`.
-  """
-  let _server: _LspTestServer
-
-  new iso create(server: _LspTestServer) =>
-    _server = server
-
-  fun name(): String =>
-    "document_symbol/integration/entity_kinds"
-
-  fun apply(h: TestHelper) =>
-    _RunLspChecks(
-      h,
-      _server,
-      "document_symbol/_ds_ent_interface.pony",
-      [ ( 0, 0,
-          _DocSymTopLevelKindsChecker(
-            [ ("_DsEntClass", 5)
-              ("_DsEntActor", 5)
-              ("_DsEntTrait", 11)
-              ("_DsEntInterface", 11)
-              ("_DsEntPrimitive", 5)
-              ("_DsEntStruct", 23)
-              ("_DsEntType", 5)]))])
-
-class \nodoc\ iso _DocSymMemberKindsTest is UnitTest
-  """
-  Asserts that every member token surfaces as a child DocumentSymbol
-  under its enclosing entity with the LSP SymbolKind it is mapped to
-  by `DocumentSymbols.find_members`:
-    tk_new                         → constructor (9)
-    tk_fun, tk_be                  → method (6)
-    tk_flet, tk_fvar, tk_embed     → field (8)
-
-  Regression guard against silent edits to the member `tk_*` →
-  SymbolKind match table at `tools/pony-lsp/symbols.pony:214-220`.
-  """
-  let _server: _LspTestServer
-
-  new iso create(server: _LspTestServer) =>
-    _server = server
-
-  fun name(): String =>
-    "document_symbol/integration/member_kinds"
-
-  fun apply(h: TestHelper) =>
-    _RunLspChecks(
-      h,
-      _server,
-      "document_symbol/_ds_member_host.pony",
-      [ ( 0, 0,
-          _DocSymChildKindsChecker(
-            "_DsMemberHost",
-            [ ("_let_field", 8)
-              ("_var_field", 8)
-              ("_embed_field", 8)
-              ("create", 9)
-              ("ds_fun", 6)
-              ("ds_be", 6)]))])
-
-class \nodoc\ iso _DocSymCrossFileTraitTest is UnitTest
-  """
-  Regression guard for the source-file filter in `ASTSourceSpan`.
-
-  `_DsImpl` (in `_ds_impl.pony`) inherits `ds_default_method` from
-  `_DsTrait` (in `_ds_trait.pony`) without overriding it. ponyc merges
-  the trait's default body into the impl's AST, but the merged tokens
-  carry the trait file's `source_file()`. `ASTSourceSpan` filters those
-  descendants out when computing the impl's span.
-
-  If the filter regresses, `_DsImpl.range.end.line` would jump to a line
-  in the trait file (past line 20). The assertion below caps end.line
-  well below that, so any drift into the trait file is detected.
-  """
-  let _server: _LspTestServer
-
-  new iso create(server: _LspTestServer) =>
-    _server = server
-
-  fun name(): String =>
-    "document_symbol/integration/cross_file_trait"
-
-  fun apply(h: TestHelper) =>
-    _RunLspChecks(
-      h,
-      _server,
-      "document_symbol/_ds_impl.pony",
-      [ ( 0, 0,
-          _DocSymMaxEndLineChecker("_DsImpl", 15))])
 
 class val _DocSymTopLevelKindsChecker
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -20,6 +20,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymMemberKindsTest.create(server))
     test(_DocSymCrossFileTraitTest.create(server))
     test(_DocSymTypeAliasRangeTest.create(server))
+    test(_DocSymPrimitiveRangeTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -221,6 +222,39 @@ class \nodoc\ iso _DocSymTypeAliasRangeTest is UnitTest
             None,
             (22, 0, 22, 30),
             (22, 5, 22, 15)))])
+
+class \nodoc\ iso _DocSymPrimitiveRangeTest is UnitTest
+  """
+  Verifies that a bare `primitive` (no explicit body) has a range
+  covering only the declaration line — from the `primitive` keyword to
+  the end of the identifier — and a selectionRange covering only the
+  identifier.
+
+  Exact positions are derived from `_ds_ent_interface.pony` line 18
+  (1-based) = line 17 (0-based):
+    `primitive _DsEntPrimitive`
+     ^0                       ^25
+               ^10            ^25
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/primitive_range"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_ent_interface.pony",
+      [ ( 0, 0,
+          _DocSymRangeChecker(
+            "_DsEntPrimitive",
+            None,
+            (17, 0, 17, 25),
+            (17, 10, 17, 25)))])
 
 class val _DocSymContainmentChecker
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -9,9 +9,16 @@ primitive _DocumentSymbolIntegrationTests is TestList
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
     let server = _LspTestServer(workspace_dir)
-    let fixture = "references/referenced_class.pony"
-    test(_DocSymContainmentTest.create(server, fixture))
-    test(_DocSymRangeTest.create(server, fixture))
+    // All fixtures live under workspace/document_symbol/ so the whole
+    // suite compiles a single package once (the test server's first-
+    // `publish_diagnostics` gate only drains pending requests on the
+    // initial compile — a mid-suite package switch would race the new
+    // compile and hand documentSymbol requests an empty module).
+    test(_DocSymContainmentTest.create(server))
+    test(_DocSymRangeTest.create(server))
+    test(_DocSymEntityKindsTest.create(server))
+    test(_DocSymMemberKindsTest.create(server))
+    test(_DocSymCrossFileTraitTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -20,11 +27,9 @@ class \nodoc\ iso _DocSymContainmentTest is UnitTest
   nested children recursively.
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "document_symbol/integration/containment"
@@ -33,25 +38,23 @@ class \nodoc\ iso _DocSymContainmentTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "document_symbol/_ds_containment.pony",
       [(0, 0, _DocSymContainmentChecker)])
 
 class \nodoc\ iso _DocSymRangeTest is UnitTest
   """
-  "class ReferencedClass" — full `range` should span from the `class`
-  keyword on line 0 past the class body (at least through line 21 where
+  "class _DsContainment" — full `range` should span from the `class`
+  keyword on line 0 past the class body (at least through line 13 where
   `fun ref increment` is declared), distinguishing it from the
   keyword-only span that would end at column 5.
 
   "fun ref increment" — full `range` should span from the `fun` keyword
-  on line 21 through the method body (at least line 22).
+  on line 13 through the method body (at least line 14).
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "document_symbol/integration/range"
@@ -60,20 +63,20 @@ class \nodoc\ iso _DocSymRangeTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "document_symbol/_ds_containment.pony",
       [ ( 0, 0,
           _DocSymRangeChecker(
-            "ReferencedClass",
+            "_DsContainment",
             None,
             // range.start (line, char); selectionRange.start (line, char)
             (0, 0, 0, 6),
-            21))
+            13))
         ( 0, 0,
           _DocSymRangeChecker(
             "increment",
-            "ReferencedClass",
-            (21, 2, 21, 10),
-            22))])
+            "_DsContainment",
+            (13, 2, 13, 10),
+            14))])
 
 class val _DocSymContainmentChecker
   """
@@ -283,3 +286,287 @@ class val _DocSymRangeChecker
       ok = false
     end
     ok
+
+class \nodoc\ iso _DocSymEntityKindsTest is UnitTest
+  """
+  Asserts that every Pony entity token surfaces as a top-level
+  DocumentSymbol with the LSP SymbolKind it is mapped to by
+  `DocumentSymbols.from_module`:
+    class, actor, primitive, type  → sk_class (5)
+    trait, interface               → sk_interface (11)
+    struct                         → sk_struct (23)
+
+  Regression guard against silent edits to the `tk_*` → SymbolKind
+  match table at `tools/pony-lsp/symbols.pony:134-143`.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/entity_kinds"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_ent_interface.pony",
+      [ ( 0, 0,
+          _DocSymTopLevelKindsChecker(
+            [ ("_DsEntClass", 5)
+              ("_DsEntActor", 5)
+              ("_DsEntTrait", 11)
+              ("_DsEntInterface", 11)
+              ("_DsEntPrimitive", 5)
+              ("_DsEntStruct", 23)
+              ("_DsEntType", 5)]))])
+
+class \nodoc\ iso _DocSymMemberKindsTest is UnitTest
+  """
+  Asserts that every member token surfaces as a child DocumentSymbol
+  under its enclosing entity with the LSP SymbolKind it is mapped to
+  by `DocumentSymbols.find_members`:
+    tk_new                         → constructor (9)
+    tk_fun, tk_be                  → method (6)
+    tk_flet, tk_fvar, tk_embed     → field (8)
+
+  Regression guard against silent edits to the member `tk_*` →
+  SymbolKind match table at `tools/pony-lsp/symbols.pony:214-220`.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/member_kinds"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_member_host.pony",
+      [ ( 0, 0,
+          _DocSymChildKindsChecker(
+            "_DsMemberHost",
+            [ ("_let_field", 8)
+              ("_var_field", 8)
+              ("_embed_field", 8)
+              ("create", 9)
+              ("ds_fun", 6)
+              ("ds_be", 6)]))])
+
+class \nodoc\ iso _DocSymCrossFileTraitTest is UnitTest
+  """
+  Regression guard for the source-file filter in `ASTSourceSpan`.
+
+  `_DsImpl` (in `_ds_impl.pony`) inherits `ds_default_method` from
+  `_DsTrait` (in `_ds_trait.pony`) without overriding it. ponyc merges
+  the trait's default body into the impl's AST, but the merged tokens
+  carry the trait file's `source_file()`. `ASTSourceSpan` filters those
+  descendants out when computing the impl's span.
+
+  If the filter regresses, `_DsImpl.range.end.line` would jump to a line
+  in the trait file (past line 20). The assertion below caps end.line
+  well below that, so any drift into the trait file is detected.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/cross_file_trait"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_impl.pony",
+      [ ( 0, 0,
+          _DocSymMaxEndLineChecker("_DsImpl", 15))])
+
+class val _DocSymTopLevelKindsChecker
+  """
+  Validates that the documentSymbol response contains exactly the
+  expected list of top-level (name, kind) pairs, in any order.
+  """
+  let _expected: Array[(String, I64)] val
+
+  new val create(expected: Array[(String, I64)] val) =>
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    match res.result
+    | let arr: JsonArray =>
+      ok = h.assert_eq[USize](
+        _expected.size(),
+        arr.size(),
+        "documentSymbol: top-level count") and ok
+      for (exp_name, exp_kind) in _expected.values() do
+        var found = false
+        for item in arr.values() do
+          try
+            let n = JsonNav(item)("name").as_string()?
+            let k = JsonNav(item)("kind").as_i64()?
+            if (n == exp_name) and (k == exp_kind) then
+              found = true
+              break
+            end
+          end
+        end
+        ok = h.assert_true(
+          found,
+          "documentSymbol: expected top-level symbol '" + exp_name +
+          "' with kind " + exp_kind.string() + " not found") and ok
+      end
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      ok = false
+    end
+    ok
+
+class val _DocSymChildKindsChecker
+  """
+  Finds `_parent_name` at the top level of the documentSymbol response,
+  then validates that its `children` array contains exactly the
+  expected list of (name, kind) pairs, in any order.
+  """
+  let _parent_name: String
+  let _expected: Array[(String, I64)] val
+
+  new val create(
+    parent_name: String,
+    expected: Array[(String, I64)] val)
+  =>
+    _parent_name = parent_name
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      for item in arr.values() do
+        try
+          if JsonNav(item)("name").as_string()? == _parent_name then
+            return _check_children(item, h)
+          end
+        end
+      end
+      h.fail(
+        "documentSymbol: parent '" + _parent_name + "' not found")
+      false
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      false
+    end
+
+  fun _check_children(parent: JsonValue, h: TestHelper): Bool =>
+    var ok = true
+    try
+      let children = JsonNav(parent)("children").as_array()?
+      ok = h.assert_eq[USize](
+        _expected.size(),
+        children.size(),
+        "documentSymbol '" + _parent_name + "': children count") and ok
+      for (exp_name, exp_kind) in _expected.values() do
+        var found = false
+        for child in children.values() do
+          try
+            let n = JsonNav(child)("name").as_string()?
+            let k = JsonNav(child)("kind").as_i64()?
+            if (n == exp_name) and (k == exp_kind) then
+              found = true
+              break
+            end
+          end
+        end
+        ok = h.assert_true(
+          found,
+          "documentSymbol '" + _parent_name +
+          "': expected child '" + exp_name + "' with kind " +
+          exp_kind.string() + " not found") and ok
+      end
+    else
+      h.fail(
+        "documentSymbol '" + _parent_name +
+        "': children array missing")
+      ok = false
+    end
+    ok
+
+class val _DocSymMaxEndLineChecker
+  """
+  Asserts that a named top-level symbol's range.end.line is strictly
+  less than `_max_end_line`. Used to detect source-file filter
+  regressions where the range inflates to include descendants from
+  other files.
+  """
+  let _symbol_name: String
+  let _max_end_line: I64
+
+  new val create(symbol_name: String, max_end_line: I64) =>
+    _symbol_name = symbol_name
+    _max_end_line = max_end_line
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      for item in arr.values() do
+        try
+          if JsonNav(item)("name").as_string()? == _symbol_name then
+            let end_line =
+              JsonNav(item)("range")("end")("line").as_i64()?
+            return h.assert_true(
+              end_line < _max_end_line,
+              _symbol_name +
+              ": range.end.line (" + end_line.string() +
+              ") should be < " + _max_end_line.string() +
+              " (source-file filter)")
+          end
+        end
+      end
+      h.fail(
+        "documentSymbol: symbol '" + _symbol_name + "' not found")
+      false
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      false
+    end

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -43,13 +43,19 @@ class \nodoc\ iso _DocSymContainmentTest is UnitTest
 
 class \nodoc\ iso _DocSymRangeTest is UnitTest
   """
-  "class _DsContainment" — full `range` should span from the `class`
-  keyword on line 0 past the class body (at least through line 13 where
-  `fun ref increment` is declared), distinguishing it from the
-  keyword-only span that would end at column 5.
+  Verifies that documentSymbol returns the full declaration range for
+  two representative symbols, asserting all four coordinates of both
+  `range` and `selectionRange` exactly.
 
-  "fun ref increment" — full `range` should span from the `fun` keyword
-  on line 13 through the method body (at least line 14).
+  "_DsContainment" — `range` must span from the `class` keyword to the
+  end of the class body; `selectionRange` covers the identifier only.
+
+  "increment" — `range` must span from the `fun` keyword to the end of
+  the method body; `selectionRange` covers the identifier only.
+
+  Exact position tuples are derived from the fixture layout in
+  `document_symbol/_ds_containment.pony`. Reformatting that file
+  invalidates the tuples below.
   """
   let _server: _LspTestServer
 
@@ -68,15 +74,16 @@ class \nodoc\ iso _DocSymRangeTest is UnitTest
           _DocSymRangeChecker(
             "_DsContainment",
             None,
-            // range.start (line, char); selectionRange.start (line, char)
-            (0, 0, 0, 6),
-            13))
-        ( 0, 0,
+                      // range: (start_line, start_char, end_line, end_char)
+            (0, 0, 18, 10),
+            // selectionRange: (start_line, start_char, end_line, end_char)
+            (0, 6, 0, 20)))
+        ( 0, 1,
           _DocSymRangeChecker(
             "increment",
             "_DsContainment",
-            (13, 2, 13, 10),
-            14))])
+            (13, 2, 15, 10),
+            (13, 10, 13, 19)))])
 
 class \nodoc\ iso _DocSymEntityKindsTest is UnitTest
   """
@@ -265,29 +272,27 @@ class val _DocSymContainmentChecker
 
 class val _DocSymRangeChecker
   """
-  Validates range/selectionRange for a named symbol (optionally nested
-  under a parent) in a documentSymbol response.
-
-  - positions: (range.start.line, range.start.char,
-      selectionRange.start.line, selectionRange.start.char)
-  - min_end_line: asserts range.end.line >= this value, proving the full
-    declaration is covered rather than just the keyword.
+  Validates that a named symbol (optionally nested under a named parent)
+  in a documentSymbol response has the expected exact `range` and
+  `selectionRange` coordinates. Asserting all four coordinates of both
+  fields catches regressions that collapse a range to `{0,0}-{0,0}` or
+  that set `range` to a keyword-only span.
   """
   let _symbol_name: String
   let _parent_name: (String | None)
-  let _positions: (I64, I64, I64, I64)
-  let _min_end_line: I64
+  let _range: (I64, I64, I64, I64)
+  let _selection_range: (I64, I64, I64, I64)
 
   new val create(
     symbol_name: String,
     parent_name: (String | None),
-    positions: (I64, I64, I64, I64),
-    min_end_line: I64)
+    range': (I64, I64, I64, I64),
+    selection_range': (I64, I64, I64, I64))
   =>
     _symbol_name = symbol_name
     _parent_name = parent_name
-    _positions = positions
-    _min_end_line = min_end_line
+    _range = range'
+    _selection_range = selection_range'
 
   fun lsp_method(): String =>
     Methods.text_document().document_symbol()
@@ -350,37 +355,37 @@ class val _DocSymRangeChecker
     None
 
   fun _assert_ranges(item: JsonValue, h: TestHelper): Bool =>
-    (let exp_r_sl, let exp_r_sc, let exp_s_sl, let exp_s_sc) = _positions
+    (let exp_r_sl, let exp_r_sc, let exp_r_el, let exp_r_ec) = _range
+    (let exp_s_sl, let exp_s_sc, let exp_s_el, let exp_s_ec) = _selection_range
     var ok = true
     try
       let r_sl = JsonNav(item)("range")("start")("line").as_i64()?
       let r_sc = JsonNav(item)("range")("start")("character").as_i64()?
       let r_el = JsonNav(item)("range")("end")("line").as_i64()?
+      let r_ec = JsonNav(item)("range")("end")("character").as_i64()?
       let s_sl = JsonNav(item)("selectionRange")("start")("line").as_i64()?
       let s_sc = JsonNav(item)("selectionRange")("start")("character").as_i64()?
+      let s_el = JsonNav(item)("selectionRange")("end")("line").as_i64()?
+      let s_ec = JsonNav(item)("selectionRange")("end")("character").as_i64()?
 
       ok = h.assert_eq[I64](
-        exp_r_sl,
-        r_sl,
-        _symbol_name + ": range.start.line") and ok
+        exp_r_sl, r_sl, _symbol_name + ": range.start.line") and ok
       ok = h.assert_eq[I64](
-        exp_r_sc,
-        r_sc,
-        _symbol_name + ": range.start.character") and ok
+        exp_r_sc, r_sc, _symbol_name + ": range.start.character") and ok
       ok = h.assert_eq[I64](
-        exp_s_sl,
-        s_sl,
-        _symbol_name + ": selectionRange.start.line") and ok
+        exp_r_el, r_el, _symbol_name + ": range.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp_r_ec, r_ec, _symbol_name + ": range.end.character") and ok
+      ok = h.assert_eq[I64](
+        exp_s_sl, s_sl, _symbol_name + ": selectionRange.start.line") and ok
       ok = h.assert_eq[I64](
         exp_s_sc,
         s_sc,
         _symbol_name + ": selectionRange.start.character") and ok
-      ok = h.assert_true(
-        r_el >= _min_end_line,
-        _symbol_name +
-        ": range.end.line (" + r_el.string() +
-        ") should be >= " + _min_end_line.string() +
-        " (full declaration, not keyword-only)") and ok
+      ok = h.assert_eq[I64](
+        exp_s_el, s_el, _symbol_name + ": selectionRange.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp_s_ec, s_ec, _symbol_name + ": selectionRange.end.character") and ok
     else
       h.fail(_symbol_name + ": malformed symbol entry")
       ok = false

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -17,6 +17,7 @@ primitive _WorkspaceSymbolIntegrationTests is TestList
     test(_WsSymMemberTest.create(server, fixture))
     test(_WsSymNoMatchTest.create(server, fixture))
     test(_WsSymEmptyQueryTest.create(server, fixture))
+    test(_WsSymRangeTest.create(server, fixture))
 
 class \nodoc\ iso _WsSymExactMatchTest is UnitTest
   """
@@ -287,3 +288,96 @@ class val _WsSymChecker
       end
     end
     ok
+
+class \nodoc\ iso _WsSymRangeTest is UnitTest
+  """
+  Verifies that workspace/symbol returns the full declaration range for
+  SymbolInformation.location.range, not the identifier-only span.
+
+  "class ReferencedClass" — full declaration starts at char 0 (the
+  "class" keyword); the identifier span would start at char 6.
+
+  "  fun ref increment" — full declaration starts at char 2 (the "fun"
+  keyword); the identifier span would start at char 10.
+  """
+  let _server: _LspTestServer
+  let _fixture: String val
+
+  new iso create(server: _LspTestServer, fixture: String val) =>
+    _server = server
+    _fixture = fixture
+
+  fun name(): String =>
+    "workspace_symbol/integration/range"
+
+  fun apply(h: TestHelper) =>
+    // Query "ReferencedClass": top-level class declared as
+    // "class ReferencedClass" — full range starts at char 0, not char 6.
+    // Query "increment": member declared as "  fun ref increment" —
+    // full range starts at char 2, not char 10.
+    _RunLspChecks(
+      h,
+      _server,
+      _fixture,
+      [ ( 0, 0,
+          _WsSymRangeChecker(
+            "ReferencedClass", "ReferencedClass", 0))
+        ( 0, 0,
+          _WsSymRangeChecker("increment", "increment", 2))])
+
+class val _WsSymRangeChecker
+  """
+  Validates that a named symbol in a workspace/symbol response has a
+  location.range.start.character equal to the expected value.
+  """
+  let _query: String
+  let _symbol_name: String
+  let _expected_start_char: I64
+
+  new val create(
+    query: String,
+    symbol_name: String,
+    expected_start_char: I64)
+  =>
+    _query = query
+    _symbol_name = symbol_name
+    _expected_start_char = expected_start_char
+
+  fun lsp_method(): String =>
+    Methods.workspace().symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    JsonObject.update("query", _query)
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      for item in arr.values() do
+        try
+          if JsonNav(item)("name").as_string()? == _symbol_name then
+            let start_char =
+              JsonNav(item)("location")("range")("start")("character").as_i64()?
+            return h.assert_eq[I64](
+              _expected_start_char,
+              start_char,
+              _symbol_name +
+              ": location.range.start.character should be " +
+              _expected_start_char.string())
+          end
+        end
+      end
+      h.fail(
+        "workspace/symbol '" + _query +
+        "': expected symbol '" + _symbol_name + "' not found")
+      false
+    else
+      h.fail(
+        "workspace/symbol '" + _query + "': expected array result, got null")
+      false
+    end

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -186,6 +186,69 @@ class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
               ("_WsSymInner", 5, "_ws_sym_host.pony", None)
               ("create", 9, "_ws_sym_host.pony", "_WsSymInner")]))])
 
+class \nodoc\ iso _WsSymRangeTest is UnitTest
+  """
+  Verifies that workspace/symbol returns the full declaration range for
+  every member and top-level token kind. Each check asserts the exact
+  LSP range (start_line, start_char, end_line, end_char), not just the
+  start column — a degenerate `{0,0}-{0,0}` response would pass a one-
+  coordinate check.
+
+  Exact position tuples are derived from the fixture layout in
+  `workspace_symbol/_ws_sym_host.pony`; see the comment at the top of
+  that file for the coupling note.
+
+  Coverage map (symbol → token kind asserted):
+    _WsSymHost   → tk_actor
+    _count       → tk_fvar
+    _name        → tk_flet
+    _inner       → tk_embed
+    create       → tk_new
+    increment    → tk_fun
+    ping         → tk_be
+    _WsSymInner  → tk_class
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "workspace_symbol/integration/range"
+
+  fun apply(h: TestHelper) =>
+    // Distinct dummy (line, character) per check so the pony_test
+    // action strings are unique — failure diagnostics will point at the
+    // specific assertion rather than all sharing one action id.
+    _RunLspChecks(
+      h,
+      _server,
+      "workspace_symbol/_ws_sym_host.pony",
+      [ ( 0, 0,
+          _WsSymRangeChecker(
+            "_WsSymHost", "_WsSymHost", (5, 0, 18, 10)))
+        ( 0, 1,
+          _WsSymRangeChecker(
+            "_count", "_count", (6, 2, 6, 17)))
+        ( 0, 2,
+          _WsSymRangeChecker(
+            "_name", "_name", (7, 2, 7, 19)))
+        ( 0, 3,
+          _WsSymRangeChecker(
+            "_inner", "_inner", (8, 2, 8, 27)))
+        ( 0, 4,
+          _WsSymRangeChecker(
+            "create", "create", (5, 0, 11, 14)))
+        ( 0, 5,
+          _WsSymRangeChecker(
+            "increment", "increment", (13, 2, 15, 10)))
+        ( 0, 6,
+          _WsSymRangeChecker(
+            "ping", "ping", (17, 2, 18, 10)))
+        ( 0, 7,
+          _WsSymRangeChecker(
+            "_WsSymInner", "_WsSymInner", (20, 0, 20, 17)))])
+
 class val _WsSymChecker
   """
   Validates a workspace/symbol response.
@@ -281,69 +344,6 @@ class val _WsSymChecker
       end
     end
     ok
-
-class \nodoc\ iso _WsSymRangeTest is UnitTest
-  """
-  Verifies that workspace/symbol returns the full declaration range for
-  every member and top-level token kind. Each check asserts the exact
-  LSP range (start_line, start_char, end_line, end_char), not just the
-  start column — a degenerate `{0,0}-{0,0}` response would pass a one-
-  coordinate check.
-
-  Exact position tuples are derived from the fixture layout in
-  `workspace_symbol/_ws_sym_host.pony`; see the comment at the top of
-  that file for the coupling note.
-
-  Coverage map (symbol → token kind asserted):
-    _WsSymHost   → tk_actor
-    _count       → tk_fvar
-    _name        → tk_flet
-    _inner       → tk_embed
-    create       → tk_new
-    increment    → tk_fun
-    ping         → tk_be
-    _WsSymInner  → tk_class
-  """
-  let _server: _LspTestServer
-
-  new iso create(server: _LspTestServer) =>
-    _server = server
-
-  fun name(): String =>
-    "workspace_symbol/integration/range"
-
-  fun apply(h: TestHelper) =>
-    // Distinct dummy (line, character) per check so the pony_test
-    // action strings are unique — failure diagnostics will point at the
-    // specific assertion rather than all sharing one action id.
-    _RunLspChecks(
-      h,
-      _server,
-      "workspace_symbol/_ws_sym_host.pony",
-      [ ( 0, 0,
-          _WsSymRangeChecker(
-            "_WsSymHost", "_WsSymHost", (5, 0, 18, 10)))
-        ( 0, 1,
-          _WsSymRangeChecker(
-            "_count", "_count", (6, 2, 6, 17)))
-        ( 0, 2,
-          _WsSymRangeChecker(
-            "_name", "_name", (7, 2, 7, 19)))
-        ( 0, 3,
-          _WsSymRangeChecker(
-            "_inner", "_inner", (8, 2, 8, 27)))
-        ( 0, 4,
-          _WsSymRangeChecker(
-            "create", "create", (5, 0, 11, 14)))
-        ( 0, 5,
-          _WsSymRangeChecker(
-            "increment", "increment", (13, 2, 15, 10)))
-        ( 0, 6,
-          _WsSymRangeChecker(
-            "ping", "ping", (17, 2, 18, 10)))
-        ( 0, 7,
-          _WsSymRangeChecker(
-            "_WsSymInner", "_WsSymInner", (20, 0, 20, 17)))])
 
 class val _WsSymRangeChecker
   """

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -312,36 +312,45 @@ class \nodoc\ iso _WsSymRangeTest is UnitTest
 
   fun apply(h: TestHelper) =>
     // Query "ReferencedClass": top-level class declared as
-    // "class ReferencedClass" — full range starts at char 0, not char 6.
+    // "class ReferencedClass" — full range starts at char 0, not char 6,
+    // and extends past line 22 (the class body contains at least that
+    // many lines of members).
     // Query "increment": member declared as "  fun ref increment" —
-    // full range starts at char 2, not char 10.
+    // full range starts at char 2, not char 10, and covers the method
+    // body through at least line 23.
     _RunLspChecks(
       h,
       _server,
       _fixture,
       [ ( 0, 0,
           _WsSymRangeChecker(
-            "ReferencedClass", "ReferencedClass", 0))
+            "ReferencedClass", "ReferencedClass", 0, 22))
         ( 0, 0,
-          _WsSymRangeChecker("increment", "increment", 2))])
+          _WsSymRangeChecker("increment", "increment", 2, 23))])
 
 class val _WsSymRangeChecker
   """
   Validates that a named symbol in a workspace/symbol response has a
-  location.range.start.character equal to the expected value.
+  location.range.start.character equal to the expected value, and
+  that location.range.end.line reaches at least `expected_min_end_line`
+  — proving the range covers the full declaration, not just the
+  keyword.
   """
   let _query: String
   let _symbol_name: String
   let _expected_start_char: I64
+  let _expected_min_end_line: I64
 
   new val create(
     query: String,
     symbol_name: String,
-    expected_start_char: I64)
+    expected_start_char: I64,
+    expected_min_end_line: I64)
   =>
     _query = query
     _symbol_name = symbol_name
     _expected_start_char = expected_start_char
+    _expected_min_end_line = expected_min_end_line
 
   fun lsp_method(): String =>
     Methods.workspace().symbol()
@@ -363,12 +372,22 @@ class val _WsSymRangeChecker
           if JsonNav(item)("name").as_string()? == _symbol_name then
             let start_char =
               JsonNav(item)("location")("range")("start")("character").as_i64()?
-            return h.assert_eq[I64](
-              _expected_start_char,
-              start_char,
+            let end_line =
+              JsonNav(item)("location")("range")("end")("line").as_i64()?
+            var ok =
+              h.assert_eq[I64](
+                _expected_start_char,
+                start_char,
+                _symbol_name +
+                ": location.range.start.character should be " +
+                _expected_start_char.string())
+            ok = h.assert_true(
+              end_line >= _expected_min_end_line,
               _symbol_name +
-              ": location.range.start.character should be " +
-              _expected_start_char.string())
+              ": location.range.end.line (" + end_line.string() +
+              ") should be >= " + _expected_min_end_line.string() +
+              " (full declaration, not keyword-only)") and ok
+            return ok
           end
         end
       end

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -9,27 +9,26 @@ primitive _WorkspaceSymbolIntegrationTests is TestList
   fun tag tests(test: PonyTest) =>
     let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
     let server = _LspTestServer(workspace_dir)
-    let fixture = "references/referenced_class.pony"
-    test(_WsSymExactMatchTest.create(server, fixture))
-    test(_WsSymSubstringMatchTest.create(server, fixture))
-    test(_WsSymSubstringInMiddleTest.create(server, fixture))
-    test(_WsSymCaseInsensitiveTest.create(server, fixture))
-    test(_WsSymMemberTest.create(server, fixture))
-    test(_WsSymNoMatchTest.create(server, fixture))
-    test(_WsSymEmptyQueryTest.create(server, fixture))
-    test(_WsSymRangeTest.create(server, fixture))
+    // All fixtures live under workspace/workspace_symbol/ so the suite
+    // compiles a single package once.
+    test(_WsSymExactMatchTest.create(server))
+    test(_WsSymSubstringMatchTest.create(server))
+    test(_WsSymSubstringInMiddleTest.create(server))
+    test(_WsSymCaseInsensitiveTest.create(server))
+    test(_WsSymMemberTest.create(server))
+    test(_WsSymNoMatchTest.create(server))
+    test(_WsSymEmptyQueryTest.create(server))
+    test(_WsSymRangeTest.create(server))
 
 class \nodoc\ iso _WsSymExactMatchTest is UnitTest
   """
-  Query "ReferencedClass" → exactly 1 top-level result named "ReferencedClass"
-  with symbol kind 5 (class).
+  Query "_WsSymHost" → exactly 1 top-level result named "_WsSymHost"
+  with symbol kind 5 (class; actors are reported as sk_class).
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/exact_match"
@@ -38,22 +37,21 @@ class \nodoc\ iso _WsSymExactMatchTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
-            "ReferencedClass",
-            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+            "_WsSymHost",
+            [("_WsSymHost", 5, "_ws_sym_host.pony", None)]))])
 
 class \nodoc\ iso _WsSymSubstringMatchTest is UnitTest
   """
-  Query "Referenced" → matches "ReferencedClass" only (prefix substring).
+  Query "_WsSym" → prefix substring matches both top-level entities
+  `_WsSymHost` (actor) and `_WsSymInner` (class).
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/substring_match"
@@ -62,23 +60,22 @@ class \nodoc\ iso _WsSymSubstringMatchTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
-            "Referenced",
-            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+            "_WsSym",
+            [ ("_WsSymHost", 5, "_ws_sym_host.pony", None)
+              ("_WsSymInner", 5, "_ws_sym_host.pony", None)]))])
 
 class \nodoc\ iso _WsSymSubstringInMiddleTest is UnitTest
   """
-  Query "Class" → matches "ReferencedClass" via substring in the middle.
+  Query "Host" → matches `_WsSymHost` via substring in the middle.
   Distinguishes substring matching from prefix-only matching.
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/substring_in_middle"
@@ -87,22 +84,20 @@ class \nodoc\ iso _WsSymSubstringInMiddleTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
-            "Class",
-            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+            "Host",
+            [("_WsSymHost", 5, "_ws_sym_host.pony", None)]))])
 
 class \nodoc\ iso _WsSymCaseInsensitiveTest is UnitTest
   """
-  Query "referencedclass" (all lower-case) → still matches "ReferencedClass".
+  Query "_wssymhost" (all lower-case) → still matches `_WsSymHost`.
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/case_insensitive"
@@ -111,23 +106,21 @@ class \nodoc\ iso _WsSymCaseInsensitiveTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
-            "referencedclass",
-            [("ReferencedClass", 5, "referenced_class.pony", None)]))])
+            "_wssymhost",
+            [("_WsSymHost", 5, "_ws_sym_host.pony", None)]))])
 
 class \nodoc\ iso _WsSymMemberTest is UnitTest
   """
-  Query "increment" → matches the method "increment" inside "ReferencedClass",
-  which should appear with containerName "ReferencedClass".
+  Query "increment" → matches the method `increment` inside `_WsSymHost`,
+  which should appear with containerName "_WsSymHost".
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/member_match"
@@ -136,23 +129,21 @@ class \nodoc\ iso _WsSymMemberTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
             "increment",
-            [ ("increment", 6, "referenced_class.pony",
-                "ReferencedClass")]))])
+            [ ("increment", 6, "_ws_sym_host.pony",
+                "_WsSymHost")]))])
 
 class \nodoc\ iso _WsSymNoMatchTest is UnitTest
   """
   Query "zzznomatch" → empty result array.
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/no_match"
@@ -161,20 +152,18 @@ class \nodoc\ iso _WsSymNoMatchTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [(0, 0, _WsSymChecker("zzznomatch", []))])
 
 class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
   """
-  Empty query → all symbols from the fixture file are returned: the
-  top-level class, its field, constructor, and two methods.
+  Empty query → all symbols from the fixture: the top-level actor and
+  class, plus every member (var/let/embed fields, constructor, fun, be).
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/empty_query"
@@ -183,15 +172,19 @@ class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymChecker(
             "",
-            [ ("ReferencedClass", 5, "referenced_class.pony", None)
-              ("_count", 8, "referenced_class.pony", "ReferencedClass")
-              ("create", 9, "referenced_class.pony", "ReferencedClass")
-              ("increment", 6, "referenced_class.pony", "ReferencedClass")
-              ("maybe", 6, "referenced_class.pony", "ReferencedClass")]))])
+            [ ("_WsSymHost", 5, "_ws_sym_host.pony", None)
+              ("_count", 8, "_ws_sym_host.pony", "_WsSymHost")
+              ("_name", 8, "_ws_sym_host.pony", "_WsSymHost")
+              ("_inner", 8, "_ws_sym_host.pony", "_WsSymHost")
+              ("create", 9, "_ws_sym_host.pony", "_WsSymHost")
+              ("increment", 6, "_ws_sym_host.pony", "_WsSymHost")
+              ("ping", 6, "_ws_sym_host.pony", "_WsSymHost")
+              ("_WsSymInner", 5, "_ws_sym_host.pony", None)
+              ("create", 9, "_ws_sym_host.pony", "_WsSymInner")]))])
 
 class val _WsSymChecker
   """
@@ -292,65 +285,87 @@ class val _WsSymChecker
 class \nodoc\ iso _WsSymRangeTest is UnitTest
   """
   Verifies that workspace/symbol returns the full declaration range for
-  SymbolInformation.location.range, not the identifier-only span.
+  every member and top-level token kind. Each check asserts the exact
+  LSP range (start_line, start_char, end_line, end_char), not just the
+  start column — a degenerate `{0,0}-{0,0}` response would pass a one-
+  coordinate check.
 
-  "class ReferencedClass" — full declaration starts at char 0 (the
-  "class" keyword); the identifier span would start at char 6.
+  Exact position tuples are derived from the fixture layout in
+  `workspace_symbol/_ws_sym_host.pony`; see the comment at the top of
+  that file for the coupling note.
 
-  "  fun ref increment" — full declaration starts at char 2 (the "fun"
-  keyword); the identifier span would start at char 10.
+  Coverage map (symbol → token kind asserted):
+    _WsSymHost   → tk_actor
+    _count       → tk_fvar
+    _name        → tk_flet
+    _inner       → tk_embed
+    create       → tk_new
+    increment    → tk_fun
+    ping         → tk_be
+    _WsSymInner  → tk_class
   """
   let _server: _LspTestServer
-  let _fixture: String val
 
-  new iso create(server: _LspTestServer, fixture: String val) =>
+  new iso create(server: _LspTestServer) =>
     _server = server
-    _fixture = fixture
 
   fun name(): String =>
     "workspace_symbol/integration/range"
 
   fun apply(h: TestHelper) =>
-    // Query "ReferencedClass": top-level class declared as
-    // "class ReferencedClass" — full range starts at char 0, not char 6,
-    // and extends past line 22 (the class body contains at least that
-    // many lines of members).
-    // Query "increment": member declared as "  fun ref increment" —
-    // full range starts at char 2, not char 10, and covers the method
-    // body through at least line 23.
+    // Distinct dummy (line, character) per check so the pony_test
+    // action strings are unique — failure diagnostics will point at the
+    // specific assertion rather than all sharing one action id.
     _RunLspChecks(
       h,
       _server,
-      _fixture,
+      "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymRangeChecker(
-            "ReferencedClass", "ReferencedClass", 0, 22))
-        ( 0, 0,
-          _WsSymRangeChecker("increment", "increment", 2, 23))])
+            "_WsSymHost", "_WsSymHost", (5, 0, 18, 10)))
+        ( 0, 1,
+          _WsSymRangeChecker(
+            "_count", "_count", (6, 2, 6, 17)))
+        ( 0, 2,
+          _WsSymRangeChecker(
+            "_name", "_name", (7, 2, 7, 19)))
+        ( 0, 3,
+          _WsSymRangeChecker(
+            "_inner", "_inner", (8, 2, 8, 27)))
+        ( 0, 4,
+          _WsSymRangeChecker(
+            "create", "create", (5, 0, 11, 14)))
+        ( 0, 5,
+          _WsSymRangeChecker(
+            "increment", "increment", (13, 2, 15, 10)))
+        ( 0, 6,
+          _WsSymRangeChecker(
+            "ping", "ping", (17, 2, 18, 10)))
+        ( 0, 7,
+          _WsSymRangeChecker(
+            "_WsSymInner", "_WsSymInner", (20, 0, 20, 17)))])
 
 class val _WsSymRangeChecker
   """
   Validates that a named symbol in a workspace/symbol response has a
-  location.range.start.character equal to the expected value, and
-  that location.range.end.line reaches at least `expected_min_end_line`
-  — proving the range covers the full declaration, not just the
-  keyword.
+  location.range equal to the expected (start_line, start_char, end_line,
+  end_char) tuple. Asserting all four coordinates catches regressions
+  that collapse the range to `{0,0}-{0,0}` or any other degenerate span
+  — a single-coordinate check would be silently satisfied by several
+  wrong values.
   """
   let _query: String
   let _symbol_name: String
-  let _expected_start_char: I64
-  let _expected_min_end_line: I64
+  let _expected: (I64, I64, I64, I64)
 
   new val create(
     query: String,
     symbol_name: String,
-    expected_start_char: I64,
-    expected_min_end_line: I64)
+    expected: (I64, I64, I64, I64))
   =>
     _query = query
     _symbol_name = symbol_name
-    _expected_start_char = expected_start_char
-    _expected_min_end_line = expected_min_end_line
+    _expected = expected
 
   fun lsp_method(): String =>
     Methods.workspace().symbol()
@@ -365,28 +380,26 @@ class val _WsSymRangeChecker
     JsonObject.update("query", _query)
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    (let exp_sl, let exp_sc, let exp_el, let exp_ec) = _expected
     match res.result
     | let arr: JsonArray =>
       for item in arr.values() do
         try
           if JsonNav(item)("name").as_string()? == _symbol_name then
-            let start_char =
-              JsonNav(item)("location")("range")("start")("character").as_i64()?
-            let end_line =
-              JsonNav(item)("location")("range")("end")("line").as_i64()?
+            let r = JsonNav(item)("location")("range")
+            let sl = r("start")("line").as_i64()?
+            let sc = r("start")("character").as_i64()?
+            let el = r("end")("line").as_i64()?
+            let ec = r("end")("character").as_i64()?
             var ok =
               h.assert_eq[I64](
-                _expected_start_char,
-                start_char,
-                _symbol_name +
-                ": location.range.start.character should be " +
-                _expected_start_char.string())
-            ok = h.assert_true(
-              end_line >= _expected_min_end_line,
-              _symbol_name +
-              ": location.range.end.line (" + end_line.string() +
-              ") should be >= " + _expected_min_end_line.string() +
-              " (full declaration, not keyword-only)") and ok
+                exp_sl, sl, _symbol_name + ": range.start.line")
+            ok = h.assert_eq[I64](
+              exp_sc, sc, _symbol_name + ": range.start.character") and ok
+            ok = h.assert_eq[I64](
+              exp_el, el, _symbol_name + ": range.end.line") and ok
+            ok = h.assert_eq[I64](
+              exp_ec, ec, _symbol_name + ": range.end.character") and ok
             return ok
           end
         end

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -226,28 +226,28 @@ class \nodoc\ iso _WsSymRangeTest is UnitTest
       "workspace_symbol/_ws_sym_host.pony",
       [ ( 0, 0,
           _WsSymRangeChecker(
-            "_WsSymHost", "_WsSymHost", (5, 0, 18, 10)))
+            "_WsSymHost", "_WsSymHost", None, (5, 0, 18, 10)))
         ( 0, 1,
           _WsSymRangeChecker(
-            "_count", "_count", (6, 2, 6, 17)))
+            "_count", "_count", "_WsSymHost", (6, 2, 6, 17)))
         ( 0, 2,
           _WsSymRangeChecker(
-            "_name", "_name", (7, 2, 7, 19)))
+            "_name", "_name", "_WsSymHost", (7, 2, 7, 19)))
         ( 0, 3,
           _WsSymRangeChecker(
-            "_inner", "_inner", (8, 2, 8, 27)))
+            "_inner", "_inner", "_WsSymHost", (8, 2, 8, 27)))
         ( 0, 4,
           _WsSymRangeChecker(
-            "create", "create", (5, 0, 11, 14)))
+            "create", "create", "_WsSymHost", (5, 0, 11, 14)))
         ( 0, 5,
           _WsSymRangeChecker(
-            "increment", "increment", (13, 2, 15, 10)))
+            "increment", "increment", "_WsSymHost", (13, 2, 15, 10)))
         ( 0, 6,
           _WsSymRangeChecker(
-            "ping", "ping", (17, 2, 18, 10)))
+            "ping", "ping", "_WsSymHost", (17, 2, 18, 10)))
         ( 0, 7,
           _WsSymRangeChecker(
-            "_WsSymInner", "_WsSymInner", (20, 0, 20, 17)))])
+            "_WsSymInner", "_WsSymInner", None, (20, 0, 20, 17)))])
 
 class val _WsSymChecker
   """
@@ -353,18 +353,25 @@ class val _WsSymRangeChecker
   that collapse the range to `{0,0}-{0,0}` or any other degenerate span
   — a single-coordinate check would be silently satisfied by several
   wrong values.
+
+  The optional `container` parameter disambiguates symbols whose names
+  are not unique within a fixture (e.g. two `create` constructors).
+  When `None`, any symbol with the matching name is accepted.
   """
   let _query: String
   let _symbol_name: String
+  let _container: (String | None)
   let _expected: (I64, I64, I64, I64)
 
   new val create(
     query: String,
     symbol_name: String,
+    container: (String | None),
     expected: (I64, I64, I64, I64))
   =>
     _query = query
     _symbol_name = symbol_name
+    _container = container
     _expected = expected
 
   fun lsp_method(): String =>
@@ -385,7 +392,17 @@ class val _WsSymRangeChecker
     | let arr: JsonArray =>
       for item in arr.values() do
         try
-          if JsonNav(item)("name").as_string()? == _symbol_name then
+          let container: (String | None) =
+            try JsonNav(item)("containerName").as_string()? else None end
+          let container_ok =
+            match (_container, container)
+            | (None, None) => true
+            | (let a: String, let b: String) => a == b
+            else false
+            end
+          let name_ok =
+            JsonNav(item)("name").as_string()? == _symbol_name
+          if name_ok and container_ok then
             let r = JsonNav(item)("location")("range")
             let sl = r("start")("line").as_i64()?
             let sc = r("start")("character").as_i64()?

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -238,7 +238,7 @@ class \nodoc\ iso _WsSymRangeTest is UnitTest
             "_inner", "_inner", "_WsSymHost", (8, 2, 8, 27)))
         ( 0, 4,
           _WsSymRangeChecker(
-            "create", "create", "_WsSymHost", (5, 0, 11, 14)))
+            "create", "create", "_WsSymHost", (10, 2, 11, 14)))
         ( 0, 5,
           _WsSymRangeChecker(
             "increment", "increment", "_WsSymHost", (13, 2, 15, 10)))

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -28,6 +28,7 @@ actor Main is TestList
     _DefinitionIntegrationTests.make().tests(test)
     _TypeDefinitionIntegrationTests.make().tests(test)
     _DocumentHighlightIntegrationTests.make().tests(test)
+    _DocumentSymbolIntegrationTests.make().tests(test)
     _InlayHintIntegrationTests.make().tests(test)
     _ReferencesIntegrationTests.make().tests(test)
     _RenameIntegrationTests.make().tests(test)

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_containment.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_containment.pony
@@ -1,0 +1,19 @@
+class _DsContainment
+  """
+  Fixture for `document_symbol/integration/containment` and
+  `document_symbol/integration/range`. Layout mirrors
+  `references/referenced_class.pony` so `fun ref increment` lands on a
+  known line, giving the range test a meaningful min_end_line below the
+  keyword-only span.
+  """
+  var _count: U32 = 0
+
+  new create() =>
+    _count = 0
+
+  fun ref increment(): U32 =>
+    _count = _count + 1
+    _count
+
+  fun maybe(): (U32 | None) =>
+    None

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_ent_interface.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_ent_interface.pony
@@ -3,7 +3,7 @@
 // SymbolKind (class, actor, trait, interface, primitive, struct, type).
 //
 // Regression guard against silent edits to the `tk_*` → SymbolKind match
-// table at `tools/pony-lsp/symbols.pony:134-143`.
+// table at `tools/pony-lsp/symbols.pony:153-163`.
 
 class _DsEntClass
 

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_ent_interface.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_ent_interface.pony
@@ -1,0 +1,23 @@
+// Fixture for `document_symbol/integration/entity_kinds` — exercises every
+// top-level entity token that `DocumentSymbols.from_module` maps to an LSP
+// SymbolKind (class, actor, trait, interface, primitive, struct, type).
+//
+// Regression guard against silent edits to the `tk_*` → SymbolKind match
+// table at `tools/pony-lsp/symbols.pony:134-143`.
+
+class _DsEntClass
+
+actor _DsEntActor
+
+trait _DsEntTrait
+  fun ds_trait_method(): U32
+
+interface _DsEntInterface
+  fun ds_interface_method(): U32
+
+primitive _DsEntPrimitive
+
+struct _DsEntStruct
+  let _f: U32 = 0
+
+type _DsEntType is _DsEntClass

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_impl.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_impl.pony
@@ -1,0 +1,13 @@
+// Fixture for `document_symbol/integration/cross_file_trait` — impl half.
+//
+// `_DsImpl` inherits `ds_default_method` from `_DsTrait` (defined in
+// `_ds_trait.pony`) without overriding it. After ponyc sugar, the default
+// method's body is merged into `_DsImpl`'s AST, but its tokens carry the
+// trait file's `source_file()`. `ASTSourceSpan` filters those out when
+// building the class's documentSymbol `range`.
+//
+// The test asserts that `_DsImpl.range.end.line` stays within this
+// file — a regression in the source-file filter would inflate the end
+// line to match the trait file, well past this file's length.
+
+class _DsImpl is _DsTrait

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_member_host.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_member_host.pony
@@ -1,0 +1,24 @@
+// Fixture for `document_symbol/integration/member_kinds` — exercises every
+// member token that `DocumentSymbols.find_members` maps to an LSP SymbolKind
+// (`tk_new` → constructor; `tk_fun`/`tk_be` → method; `tk_flet`/`tk_fvar`/
+// `tk_embed` → field).
+//
+// Regression guard against silent edits to the member `tk_*` → SymbolKind
+// match table at `tools/pony-lsp/symbols.pony:214-220`. Actor so that
+// behaviours (`be`) are legal.
+
+actor _DsMemberHost
+  let _let_field: U32 = 0
+  var _var_field: U32 = 0
+  embed _embed_field: _DsEmbedTarget = _DsEmbedTarget
+
+  new create() =>
+    None
+
+  fun ref ds_fun(): U32 =>
+    _var_field
+
+  be ds_be() =>
+    None
+
+class _DsEmbedTarget

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_trait.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_trait.pony
@@ -1,0 +1,27 @@
+// Fixture for `document_symbol/integration/cross_file_trait` — trait half.
+//
+// The trait provides a default method body. ponyc merges that default
+// into classes that declare `is _DsTrait` without overriding it, so the
+// implementing class's AST contains descendant tokens whose
+// `source_file()` points *here*, not at the impl file. `ASTSourceSpan`
+// filters those out so the impl class's documentSymbol `range` stays
+// within its own file.
+//
+// The padding lines below push the trait method body past line 20. If
+// the source-file filter in `ASTSourceSpan` regresses, the impl class's
+// `range.end.line` in `_ds_impl.pony` would jump to this file's line
+// numbers — detectable as an end.line past the impl file's actual end.
+//
+// Pairs with `_ds_impl.pony`.
+
+trait _DsTrait
+  """
+  Trait with a default method so ponyc merges its body into
+  non-overriding implementers.
+  """
+
+  fun ds_default_method(): U32 =>
+    let a: U32 = 0
+    let b: U32 = 0
+    let c: U32 = 0
+    a + b + c + 1

--- a/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
@@ -1,0 +1,24 @@
+"""
+Test fixtures for exercising LSP textDocument/documentSymbol functionality.
+
+Each file in this package targets a specific slice of `DocumentSymbols`:
+
+  _ds_containment.pony — layout mirrors the references fixture; drives
+    the containment and range integration tests (selectionRange ⊆ range,
+    full-declaration range spans past the keyword).
+
+  _ds_ent_interface.pony — one of every top-level entity token
+    (`tk_class`, `tk_actor`, `tk_trait`, `tk_interface`, `tk_primitive`,
+    `tk_struct`, `tk_type`) to guard the entity → SymbolKind map in
+    `DocumentSymbols.from_module`.
+
+  member_kinds.pony — one of every member token (`tk_new`, `tk_fun`,
+    `tk_be`, `tk_flet`, `tk_fvar`, `tk_embed`) under an actor so
+    behaviours are legal; guards the member → SymbolKind map in
+    `DocumentSymbols.find_members`.
+
+  _ds_trait.pony / _ds_impl.pony — trait with a default method body and
+    a non-overriding implementer. Regression guard for the source-file
+    filter in `ASTSourceSpan`: if the filter drops, the impl class's
+    range.end.line inflates into the trait file's lines.
+"""

--- a/tools/pony-lsp/test/workspace/workspace_symbol/_ws_sym_host.pony
+++ b/tools/pony-lsp/test/workspace/workspace_symbol/_ws_sym_host.pony
@@ -1,0 +1,21 @@
+// Fixture for workspace/symbol integration tests. Reformatting this
+// file (reindenting, moving members, renaming) invalidates the exact
+// (line, col) tuples asserted by `_WsSymRangeTest` in
+// `_workspace_symbol_integration_tests.pony`. Keep it stable.
+
+actor _WsSymHost
+  var _count: U32 = 0
+  let _name: String = ""
+  embed _inner: Array[U8] = Array[U8]
+
+  new create() =>
+    _count = 0
+
+  fun ref increment(): U32 =>
+    _count = _count + 1
+    _count
+
+  be ping() =>
+    None
+
+class _WsSymInner

--- a/tools/pony-lsp/test/workspace/workspace_symbol/workspace_symbol.pony
+++ b/tools/pony-lsp/test/workspace/workspace_symbol/workspace_symbol.pony
@@ -1,0 +1,9 @@
+"""
+Test fixtures for exercising LSP workspace/symbol functionality.
+
+  _ws_sym_host.pony — an actor + trailing class covering every member
+    token (`tk_new`, `tk_fun`, `tk_be`, `tk_flet`, `tk_fvar`, `tk_embed`)
+    plus two top-level entity tokens (`tk_actor`, `tk_class`). Drives
+    the match-semantics tests (exact / substring / case / container /
+    empty / no-match) and the range test.
+"""

--- a/tools/pony-lsp/workspace/selection_ranges.pony
+++ b/tools/pony-lsp/workspace/selection_ranges.pony
@@ -58,7 +58,7 @@ primitive SelectionRanges
     var last_el: USize = 0
     var last_ec: USize = 0
 
-    // TODO(perf): _source_span traverses each ancestor's entire subtree, so
+    // TODO(perf): ASTSourceSpan traverses each ancestor's entire subtree, so
     // total work is O(sum of subtree sizes) ≈ O(depth * module_node_count).
     // A bottom-up approach — one full traversal recording spans by node, then
     // reading cached values per chain entry — would reduce this to O(N).
@@ -66,7 +66,7 @@ primitive SelectionRanges
     while i > 0 do
       i = i - 1
       let n = try chain(i)? else continue end
-      match \exhaustive\ _source_span(n, doc_path)
+      match \exhaustive\ ASTSourceSpan(n, doc_path)
       | (let s: Position, let e: Position) =>
         // Deduplicate: skip if this span is identical to the last emitted.
         let sl = s.line()
@@ -102,83 +102,3 @@ primitive SelectionRanges
     end
     result
 
-  fun _source_span(
-    n: AST box,
-    doc_path: String val)
-    : ((Position, Position) | None)
-  =>
-    """
-    Compute the source span of AST node `n`, including all descendants
-    whose `source_file()` is None (synthetic container nodes) or matches
-    `doc_path` (leaf tokens from the current file). Descendants whose
-    source_file() is a non-empty string that does not match doc_path are
-    excluded — this filters trait method bodies merged from other files.
-
-    Seeded with the node's own position and end_pos (if any) so that
-    declaration keywords (tk_fun, tk_class, etc.) are included even though
-    they are the node's token rather than a child.
-
-    Note: span() short-circuits on keyword tokens returning only the keyword
-    extent; this visitor always scans children to get the full body range.
-
-    Returns None when the computed span is inverted (should not occur for
-    well-formed AST nodes).
-    """
-    // Seed with this node's own extent. Declaration nodes like tk_fun and
-    // tk_class have end_pos() set to their keyword's last column — include
-    // that so the keyword itself is covered even if no children are visited.
-    let n_start = n.position()
-    let n_end =
-      match \exhaustive\ n.end_pos()
-      | let ep: Position => ep
-      | None => n_start
-      end
-
-    let visitor =
-      object ref is ASTVisitor
-        var _min: Position = n_start
-        var _max: Position = n_end
-
-        fun ref visit(child: AST box): VisitResult =>
-          // Exclude descendants from other source files. Note: returning
-          // Continue (not Stop) still descends into the child's subtree;
-          // AST.visit() itself pre-filters children by _from_same_source(),
-          // so this check is defence-in-depth.
-          match child.source_file()
-          | let sf: String val =>
-            if sf != doc_path then
-              return Continue
-            end
-          end
-          let pos = child.position()
-          if pos < _min then
-            _min = pos
-          end
-          let child_ep =
-            match \exhaustive\ child.end_pos()
-            | let ep: Position => ep
-            | None => pos
-            end
-          if child_ep > _max then
-            _max = child_ep
-          end
-          Continue
-
-        fun ref leave(child: AST box): VisitResult =>
-          Continue
-
-        fun min(): Position =>
-          _min
-
-        fun max(): Position =>
-          _max
-      end
-    n.visit(visitor)
-
-    let min = visitor.min()
-    let max = visitor.max()
-    if min <= max then
-      (min, max)
-    else
-      None
-    end

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -884,7 +884,7 @@ actor WorkspaceManager
                       .update("uri", file_uri)
                       .update(
                         "range",
-                        symbol.selection_range.to_json())))
+                        symbol.range.to_json())))
           end
           for child in symbol.children.values() do
             if _symbol_matches(child.name, query_lower) then
@@ -900,7 +900,7 @@ actor WorkspaceManager
                         .update("uri", file_uri)
                         .update(
                           "range",
-                          child.selection_range.to_json())))
+                          child.range.to_json())))
             end
           end
         end


### PR DESCRIPTION
## Context

The Pony language server's `DocumentSymbol.to_json()` serialises both the `range` and `selectionRange` JSON fields from `this.range`. The `selectionRange` field is meant to carry the identifier-only span (`this.selection_range`); editors use it to position the cursor on the symbol name rather than the start of the declaration body.

As a result, `textDocument/documentSymbol` responses carry the wrong `selectionRange`, and `workspace/symbol` responses carry the wrong `location.range` (identifier span rather than the full declaration range the spec expects). The two endpoints are inconsistent with each other.

## Changes

- `symbols.pony`: `selectionRange` now uses `this.selection_range.to_json()`.
- `workspace_manager.pony`: `SymbolInformation.location.range` now uses `symbol.range` / `child.range` (full declaration span) per the LSP spec.
- Adds a `workspace/symbol` integration test that verifies `location.range` uses the full declaration span, parameterised so the expected character positions are expressed at the call site rather than inside the checker.


Closes #5240

## Considerations

`textDocument/documentSymbol` has no integration test suite. The `selectionRange` fix in `symbols.pony` is exercised indirectly through `workspace/symbol` (both endpoints share `DocumentSymbol`), but is not directly tested.
