### PR TITLE
Fix LSP definition and type-definition ranges

### DIFF
--- a/.release-notes/fix-lsp-definition-ranges.md
+++ b/.release-notes/fix-lsp-definition-ranges.md
@@ -1,0 +1,5 @@
+## Fix LSP definition and type-definition ranges
+
+`textDocument/definition` and `textDocument/typeDefinition` responses now return a range that covers the full declaration — from the opening keyword to the end of the body. Previously the range covered only the declaration keyword (`class`, `fun`, etc.).
+
+Range computation now also correctly handles the last type declaration in a file. Previously the compiler's synthesized default constructors could cause the final entity's range to extend to an incorrect position; this no longer occurs.

--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -111,3 +111,31 @@ primitive ASTSourceSpan
     else
       None
     end
+
+primitive ASTClampedRange
+  """
+  Computes a clamped `LspPositionRange` from an AST node.
+
+  Calls `ASTSourceSpan(node, doc_path, max_pos)` to get the full source
+  extent, then clamps the start to `node.position()`. The clamp prevents
+  positions from referenced types earlier in the file (e.g. in `type`
+  aliases) from pulling the start before the declaration keyword.
+
+  Returns `None` when `ASTSourceSpan` returns an inverted span.
+  """
+  fun tag apply(
+    node: AST box,
+    doc_path: String val,
+    max_pos: (Position | None) = None)
+    : (LspPositionRange | None)
+  =>
+    match \exhaustive\ ASTSourceSpan(node, doc_path, max_pos)
+    | (let s: Position, let e: Position) =>
+      let n_pos = node.position()
+      let clamped_start = if s < n_pos then n_pos else s end
+      LspPositionRange(
+        LspPosition.from_ast_pos(clamped_start),
+        LspPosition.from_ast_pos_end(e))
+    | None =>
+      None
+    end

--- a/tools/pony-lsp/sibling_bound.pony
+++ b/tools/pony-lsp/sibling_bound.pony
@@ -1,0 +1,51 @@
+use "pony_compiler"
+
+primitive SiblingBound
+  """
+  Returns the start position of the AST sibling that immediately follows `n`
+  within `n`'s parent's children list, or None if `n` is the last child or
+  has no parent.
+
+  Pass as `max_pos` to `ASTSourceSpan` to cap span computation at the next
+  sibling's start. This prevents synthesized-constructor end-bleed: ponyc
+  positions synthesized default constructors at the start of the next entity,
+  so capping at the sibling start excludes those tokens from the current
+  node's computed span.
+  """
+  fun apply(n: AST box): (Position | None) =>
+    let n_source =
+      match \exhaustive\ n.source_file()
+      | let sf: String val => sf
+      | None => return None
+      end
+    match n.parent()
+    | let parent: AST box =>
+      var past_n = false
+      for child in parent.children() do
+        if child == n then
+          past_n = true
+        elseif past_n then
+          return _sibling_pos(child, n, n_source)
+        end
+      end
+    end
+    None
+
+  fun _sibling_pos(
+    child: AST box,
+    n: AST box,
+    n_source: String val)
+    : (Position | None)
+  =>
+    """
+    Returns `child.position()` if `child` is from the same source file as `n`
+    and its position strictly follows `n`'s position, otherwise None.
+    """
+    let child_pos = child.position()
+    if child_pos <= n.position() then
+      return None
+    end
+    match \exhaustive\ child.source_file()
+    | let sf: String val if sf == n_source => child_pos
+    | let _: (String val | None) => None
+    end

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -256,7 +256,7 @@ primitive DocumentSymbols
     """
     Compute the full declaration range and the identifier selection range
     for an entity or member AST node. Raises error (logging to `channel`)
-    if `source_file()` is absent or if `ASTSourceSpan` returns an inverted
+    if `source_file()` is absent or if `ASTClampedRange` returns an inverted
     span — callers inside a `try` block will skip the symbol on failure.
     """
     let doc_path =
@@ -268,27 +268,15 @@ primitive DocumentSymbols
           TokenIds.string(node.id()) + " '" + name + "'")
         error
       end
-    (let start_pos, let end_pos) =
-      match \exhaustive\ ASTSourceSpan(node, doc_path, max_pos)
-      | (let s: Position, let e: Position) => (s, e)
+    let full_range =
+      match \exhaustive\ ASTClampedRange(node, doc_path, max_pos)
+      | let r: LspPositionRange => r
       | None =>
         channel.log(
           "Inverted source span for " +
           TokenIds.string(node.id()) + " '" + name + "'")
         error
       end
-    // Clamp start to the node's own keyword position. Nominal references
-    // in `type` aliases store the definition-site position of the
-    // referenced type (same file, earlier line), which ASTSourceSpan's
-    // min-walk would otherwise include, pulling the start before the
-    // declaration keyword.
-    let n_pos = node.position()
-    let clamped_start =
-      if start_pos < n_pos then n_pos else start_pos end
-    let full_range =
-      LspPositionRange(
-        LspPosition.from_ast_pos(clamped_start),
-        LspPosition.from_ast_pos_end(end_pos))
     (let id_start, let id_end) = id.span()
     let selection_range =
       LspPositionRange(

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -19,6 +19,7 @@ primitive _DefinitionIntegrationTests is TestList
     test(_DefinitionGenericsIntegrationTest.create(server))
     test(_DefinitionTupleIntegrationTest.create(server))
     test(_DefinitionTypeAliasIntegrationTest.create(server))
+    test(_DefinitionLastEntityBarePrimTest.create(server))
 
 class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -33,13 +34,13 @@ class \nodoc\ iso _DefinitionClassIntegrationTest is UnitTest
       h,
       _server,
       "definition/_class.pony",
-      [ // field usages → field declaration (line 4, "let" keyword span)
-        (7, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 5))]))
-        (10, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 5))]))
+      [ // field usages → field declaration
+        (7, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 17))]))
+        (10, 4, _DefinitionChecker([("_class.pony", (4, 2), (4, 17))]))
         // parameter usage → parameter declaration (line 6, "v: U32" span)
         (7, 13, _DefinitionChecker([("_class.pony", (6, 13), (6, 19))]))
-        // method call → method declaration (line 9, "fun" keyword span)
-        (13, 9, _DefinitionChecker([("_class.pony", (9, 2), (9, 5))]))
+        // method call → method declaration
+        (13, 9, _DefinitionChecker([("_class.pony", (9, 2), (10, 10))]))
         // no definition on docstring content
         (1, 4, _DefinitionChecker([]))])
 
@@ -56,8 +57,8 @@ class \nodoc\ iso _DefinitionThisIntegrationTest is UnitTest
       h,
       _server,
       "definition/_class.pony",
-      [ // `this` in method body → enclosing class declaration (line 0)
-        (13, 4, _DefinitionChecker([("_class.pony", (0, 0), (0, 5))]))])
+      [ // `this` in method body → enclosing class declaration
+        (13, 4, _DefinitionChecker([("_class.pony", (0, 0), (13, 13))]))])
 
 class \nodoc\ iso _DefinitionKeywordsIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -95,7 +96,7 @@ class \nodoc\ iso _DefinitionTraitIntegrationTest is UnitTest
       _server,
       "definition/_trait.pony",
       [ // call via trait-typed receiver → trait method declaration (line 7)
-        (50, 6, _DefinitionChecker([("_trait.pony", (7, 2), (7, 5))]))])
+        (50, 6, _DefinitionChecker([("_trait.pony", (7, 2), (7, 25))]))])
 
 class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -113,8 +114,8 @@ class \nodoc\ iso _DefinitionUnionIntegrationTest is UnitTest
       [ // call via union-typed receiver → one definition per union member
         // _DefLeft.shared (line 29) and _DefRight.shared (line 35)
         (53, 6, _DefinitionChecker(
-          [ ("_trait.pony", (29, 2), (29, 5))
-            ("_trait.pony", (35, 2), (35, 5))]))])
+          [ ("_trait.pony", (29, 2), (29, 24))
+            ("_trait.pony", (35, 2), (35, 24))]))])
 
 class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -130,10 +131,10 @@ class \nodoc\ iso _DefinitionCrossFileIntegrationTest is UnitTest
       _server,
       "definition/_cross_usage.pony",
       [ // type reference in parameter → class declaration in other file
-        (13, 16, _DefinitionChecker([("_cross_target.pony", (0, 0), (0, 5))]))
+        (13, 16, _DefinitionChecker([("_cross_target.pony", (0, 0), (13, 21))]))
         // method call → method declaration in other file (line 13)
         (14, 8, _DefinitionChecker(
-          [("_cross_target.pony", (13, 2), (13, 5))]))])
+          [("_cross_target.pony", (13, 2), (13, 21))]))])
 
 class \nodoc\ iso _DefinitionGenericsIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -166,7 +167,7 @@ class \nodoc\ iso _DefinitionTupleIntegrationTest is UnitTest
       _server,
       "definition/_tuple.pony",
       [ // `_1` tuple element access → `let pair` declaration
-        (16, 9, _DefinitionChecker([("_tuple.pony", (15, 4), (15, 7))]))])
+        (16, 9, _DefinitionChecker([("_tuple.pony", (15, 4), (15, 26))]))])
 
 class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
   let _server: _LspTestServer
@@ -182,15 +183,48 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
       _server,
       "definition/_type_alias.pony",
       [ // `Map` type alias in `Map[String, U32]` → Map type alias declaration
-        (17, 13, _DefinitionChecker([("map.pony", (3, 0), (3, 4))]))
+        (17, 13, _DefinitionChecker([("map.pony", (3, 0), (7, 7))]))
         // `String` type arg in `Map[String, U32]` → String class declaration
-        (17, 17, _DefinitionChecker([("string.pony", (8, 0), (8, 5))]))
+        (17, 17, _DefinitionChecker([("string.pony", (8, 0), (1682, 25))]))
         // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
         (17, 25, _DefinitionChecker(
-          [("unsigned.pony", (185, 0), (185, 9))]))
+          [("unsigned.pony", (185, 0), (255, 60))]))
         // `_Alias` usage → type alias declaration (line 2)
         (19, 20, _DefinitionChecker(
-          [("_type_alias.pony", (2, 0), (2, 4))]))])
+          [("_type_alias.pony", (2, 0), (2, 18))]))])
+
+class \nodoc\ iso _DefinitionLastEntityBarePrimTest is UnitTest
+  """
+  goto_definition from the return-type annotation `_DefLastBarePrim` on line 1.
+  The cursor is on a `tk_nominal` in the return type, so `DefinitionResolver`
+  resolves directly to the `tk_primitive` entity node. `SiblingBound(node)`
+  returns `None` for this last entity, so `ASTClampedRange` runs without a
+  `max_pos` cap. This test guards against synthesized-constructor tokens
+  inflating the range end past the identifier when there is no next sibling.
+
+  _bare_prim.pony layout (0-indexed):
+    line 0: class _DefUsesBarePrim
+    line 1:   fun get(): _DefLastBarePrim =>
+    line 2:     _DefLastBarePrim
+    line 3: (blank)
+    line 4: primitive _DefLastBarePrim
+
+  Cursor at (1, 13) — `_DefLastBarePrim` as a return type. Expected definition
+  range: (4, 0)-(4, 26), the full `primitive _DefLastBarePrim` declaration.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "definition/integration/last_entity_bare_prim"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "definition/_bare_prim.pony",
+      [ (1, 13, _DefinitionChecker([("_bare_prim.pony", (4, 0), (4, 26))]))])
 
 type DefinitionExpectation is (String val, (I64, I64), (I64, I64))
 

--- a/tools/pony-lsp/test/_selection_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_selection_range_integration_tests.pony
@@ -15,6 +15,8 @@ primitive _SelectionRangeIntegrationTests is TestList
     test(_SelectionRangeKeywordTest.create(server))
     test(_SelectionRangePositionsArrayTest.create(server))
     test(_SelectionRangeEmptyPositionsTest.create(server))
+    test(_SelectionRangePrimitiveBoundTest.create(server))
+    test(_SelectionRangeCrossFileTraitTest.create(server))
 
 class \nodoc\ iso _SelectionRangeTokenTest is UnitTest
   """
@@ -359,3 +361,85 @@ class val _SelectionRangeChecker
       "(" + sl.string() + ":" + sc.string() +
       ")-(" + el.string() + ":" + ec.string() + ")"
     end
+
+class \nodoc\ iso _SelectionRangePrimitiveBoundTest is UnitTest
+  """
+  Regression test for synthesized-constructor end-bleed in SelectionRanges.
+
+  ponyc inserts a synthesized `create` constructor for bare primitives and
+  positions its tokens at the start of the next entity. Without the
+  SiblingBound cap, ASTSourceSpan would include those tokens when computing
+  the primitive's span, inflating the range into the next entity's lines.
+
+  Fixture: `selection_range/_sr_edge_cases.pony`
+    line 0: primitive _SrPrimA
+    line 1: primitive _SrPrimB
+
+  Cursor at (0, 0) — the `primitive` keyword of `_SrPrimA`.  The innermost
+  SelectionRange entry is the `tk_primitive` node.  With the SiblingBound cap
+  (max_pos = start of _SrPrimB), the synthesized constructor tokens are
+  excluded and the span correctly ends at (0, 18) — the last char of
+  `_SrPrimA`.  Without the cap, the span's end would bleed onto line 1.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/primitive_bound"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/_sr_edge_cases.pony",
+      [ (0, 0,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (0, 0, 2, (0, 0, 0, 18))]
+        end))])
+
+class \nodoc\ iso _SelectionRangeCrossFileTraitTest is UnitTest
+  """
+  Regression test for SiblingBound guard 2 (cross-source-file sibling).
+
+  ponyc merges default trait methods into implementing classes. The merged
+  node appears as a sibling in tk_members with the trait file's source_file().
+  SiblingBound._sibling_pos must return None (guard 2) rather than returning
+  the trait-file position as max_pos.
+
+  Fixture: _sr_cross_impl.pony implements _SrCrossTrait from
+  _sr_cross_trait.pony.
+  sr_own_method is on 1-indexed line 3 of the impl file; the merged
+  sr_cross_default is on 1-indexed line 4 of the trait file.
+  sr_cross_default.line (4) > sr_own_method.line (3), so guard 1
+  (child_pos <= n.position()) does NOT fire; guard 2 fires instead.
+
+  Without guard 2, max_pos would be (line=4, col=3) from the trait file.
+  The body token `42` is on impl line 4 at columns 5-6. ep_in_bounds =
+  (4, 6) < (4, 3) is false, so the body would be excluded from the method's
+  span. The method range would shrink to just the fun header, and the `42`
+  token's range (on the next line) would fail the LSP containment check.
+
+  _sr_cross_impl.pony layout (0-indexed):
+    line 1: class _SrCrossImpl is _SrCrossTrait
+    line 2:   fun sr_own_method(): U32 =>
+    line 3:     42                              <- cursor here (3, 4)
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "selection_range/integration/cross_file_trait"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "selection_range/_sr_cross_impl.pony",
+      [ (3, 4,
+        _SelectionRangeChecker(recover val
+          [as _SrCheck: (3, 4, 3, None)]
+        end))])

--- a/tools/pony-lsp/test/_type_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_definition_integration_tests.pony
@@ -19,13 +19,13 @@ class \nodoc\ iso _TypeDefinitionLocalVarIntegrationTest is UnitTest
   """
   Cursor on `obj` in `demo()` (line 28, col 4) — explicitly annotated let.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
     line 25:  class _TypeDefUser
     line 26:    fun demo() =>
     line 27:      let obj: _TypeDefTarget = ...
     line 28:      obj                            obj at (28,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
   """
   let _server: _LspTestServer
 
@@ -40,17 +40,17 @@ class \nodoc\ iso _TypeDefinitionLocalVarIntegrationTest is UnitTest
       _server,
       "type_definition/type_definition.pony",
       [ (28, 4, _TypeDefinitionChecker(
-        [("type_definition.pony", (21, 0), (21, 5))]))])
+        [("type_definition.pony", (21, 0), (23, 10))]))])
 
 class \nodoc\ iso _TypeDefinitionParamIntegrationTest is UnitTest
   """
   Cursor on `target` in `with_param()` (line 31, col 4) — typed parameter.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
     line 30:    fun with_param(target: _TypeDefTarget) =>
     line 31:      target                             target at (31,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
   """
   let _server: _LspTestServer
 
@@ -65,7 +65,7 @@ class \nodoc\ iso _TypeDefinitionParamIntegrationTest is UnitTest
       _server,
       "type_definition/type_definition.pony",
       [ (31, 4, _TypeDefinitionChecker(
-        [("type_definition.pony", (21, 0), (21, 5))]))])
+        [("type_definition.pony", (21, 0), (23, 10))]))])
 
 class \nodoc\ iso _TypeDefinitionNoTypeIntegrationTest is UnitTest
   """
@@ -91,12 +91,12 @@ class \nodoc\ iso _TypeDefinitionInferredIntegrationTest is UnitTest
   Cursor on `x` in `inferred_demo()` (line 35, col 4) — type inferred from
   `_TypeDefTarget.create()`, no explicit annotation.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(21,5)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
     line 33:    fun inferred_demo() =>
     line 34:      let x = _TypeDefTarget.create()
     line 35:      x                              x at (35,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(21,5).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
   """
   let _server: _LspTestServer
 
@@ -111,7 +111,7 @@ class \nodoc\ iso _TypeDefinitionInferredIntegrationTest is UnitTest
       _server,
       "type_definition/type_definition.pony",
       [ (35, 4, _TypeDefinitionChecker(
-        [("type_definition.pony", (21, 0), (21, 5))]))])
+        [("type_definition.pony", (21, 0), (23, 10))]))])
 
 class val _TypeDefinitionChecker
   let _expected: Array[DefinitionExpectation] val

--- a/tools/pony-lsp/test/workspace/definition/_bare_prim.pony
+++ b/tools/pony-lsp/test/workspace/definition/_bare_prim.pony
@@ -1,0 +1,5 @@
+class _DefUsesBarePrim
+  fun get(): _DefLastBarePrim =>
+    _DefLastBarePrim
+
+primitive _DefLastBarePrim

--- a/tools/pony-lsp/test/workspace/selection_range/_sr_cross_impl.pony
+++ b/tools/pony-lsp/test/workspace/selection_range/_sr_cross_impl.pony
@@ -1,0 +1,4 @@
+// Fixture for SiblingBound cross-source-file guard (guard 2) test.
+class _SrCrossImpl is _SrCrossTrait
+  fun sr_own_method(): U32 =>
+    42

--- a/tools/pony-lsp/test/workspace/selection_range/_sr_cross_trait.pony
+++ b/tools/pony-lsp/test/workspace/selection_range/_sr_cross_trait.pony
@@ -1,0 +1,5 @@
+// Fixture for SiblingBound cross-source-file guard (guard 2) test.
+// Pairs with _sr_cross_impl.pony.
+trait _SrCrossTrait
+  fun sr_cross_default(): U32 =>
+    0

--- a/tools/pony-lsp/test/workspace/selection_range/_sr_edge_cases.pony
+++ b/tools/pony-lsp/test/workspace/selection_range/_sr_edge_cases.pony
@@ -1,0 +1,2 @@
+primitive _SrPrimA
+primitive _SrPrimB

--- a/tools/pony-lsp/workspace/selection_ranges.pony
+++ b/tools/pony-lsp/workspace/selection_ranges.pony
@@ -66,8 +66,15 @@ primitive SelectionRanges
     while i > 0 do
       i = i - 1
       let n = try chain(i)? else continue end
-      match \exhaustive\ ASTSourceSpan(n, doc_path)
+      match \exhaustive\ ASTSourceSpan(n, doc_path, SiblingBound(n))
       | (let s: Position, let e: Position) =>
+        // Note: no clamped-start correction here, unlike _symbol_ranges and
+        // _node_location. Selection ranges must grow outward — an ancestor's
+        // range legitimately starts before n.position() when real descendants
+        // (e.g. earlier tokens in a sequence) extend the span backwards.
+        // Clamping to n.position() would move a parent's start forward past
+        // its own child's start, breaking the LSP containment requirement.
+        //
         // Deduplicate: skip if this span is identical to the last emitted.
         let sl = s.line()
         let sc = s.column()

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -754,20 +754,13 @@ actor WorkspaceManager
       this._channel.log(ast.debug())
       var json_arr = JsonArray
       for ast_definition in ast.definitions().values() do
-        (let start_pos, let end_pos) = ast_definition.span()
-        try
-          json_arr =
-            json_arr.push(
-              LspLocation(
-                Uris.from_path(ast_definition.source_file() as String val),
-                LspPositionRange(
-                  LspPosition.from_ast_pos(start_pos),
-                  LspPosition.from_ast_pos_end(end_pos))
-              ).to_json()
-            )
-        else
+        match \exhaustive\ _node_location(ast_definition)
+        | let loc: LspLocation val =>
+          json_arr = json_arr.push(loc.to_json())
+        | None =>
           this._channel.log(
-            "No source file found for definition: " + ast_definition.debug())
+            "No source file found for definition: " +
+              ast_definition.debug())
         end
       end
       this._channel.send(ResponseMessage(request.id, json_arr))
@@ -798,20 +791,13 @@ actor WorkspaceManager
       match ast.ast_type()
       | let type_ast: AST =>
         for type_def in type_ast.definitions().values() do
-          (let start_pos, let end_pos) = type_def.span()
-          try
-            json_arr =
-              json_arr.push(
-                LspLocation(
-                  Uris.from_path(type_def.source_file() as String val),
-                  LspPositionRange(
-                    LspPosition.from_ast_pos(start_pos),
-                    LspPosition.from_ast_pos_end(end_pos))
-                ).to_json()
-              )
-          else
+          match \exhaustive\ _node_location(type_def)
+          | let loc: LspLocation val =>
+            json_arr = json_arr.push(loc.to_json())
+          | None =>
             this._channel.log(
-              "No source file found for type definition: " + type_def.debug())
+              "No source file found for type definition: " +
+                type_def.debug())
           end
         end
       end
@@ -907,6 +893,25 @@ actor WorkspaceManager
       end
     end
     aggregator.add_results(results)
+
+  fun _node_location(node: AST box): (LspLocation val | None) =>
+    """
+    Builds an `LspLocation` for `node`.
+
+    Returns `None` if the node has no source file (e.g. synthesised nodes)
+    or if the computed source span is inverted.
+    """
+    try
+      let doc_path = node.source_file() as String val
+      let range =
+        match \exhaustive\ ASTClampedRange(node, doc_path, SiblingBound(node))
+        | let r: LspPositionRange => r
+        | None => error
+        end
+      LspLocation(Uris.from_path(doc_path), range)
+    else
+      None
+    end
 
   fun _symbol_matches(name: String, query_lower: String): Bool =>
     """


### PR DESCRIPTION
## Context

`textDocument/definition` and `textDocument/typeDefinition` responses return a range covering only the declaration keyword (`class`, `fun`, etc.) rather than the full declaration. This is because `AST.span()` short-circuits on `end_pos()`, which for keyword tokens points to the end of the keyword itself. LSP clients use this range to highlight the definition — a keyword-only range is visually misleading.

For the last type declaration in a file, the compiler's synthesized default constructors are positioned at the start of the next entity (or at an arbitrary position when there is no next entity), causing the range to extend beyond the declaration's actual content.

## Changes

- Extract `ASTClampedRange` primitive to compute correct full-declaration ranges, replacing direct `AST.span()` calls
- Add `SiblingBound` to cap span computation at the next sibling's start position, preventing synthesized-constructor tokens from inflating the range
- Extract `_node_location` helper in `WorkspaceManager` to deduplicate goto/type-definition range logic
- Add integration tests covering: last-entity bare primitive, cross-file trait method merging (SiblingBound guard 2), and synthesized-constructor end-bleed

## Consequences

- **Peek Definition / hover-to-preview** — editors that show the definition inline (VS Code's peek view, for example) will now display the full declaration body rather than a single keyword line
- **`selectionRange ⊄ range` client errors** — LSP clients that validate documentSymbol containment were rejecting responses because `selectionRange` (the identifier) fell outside `range` (the keyword-only span); this is now resolved
- **Last-entity range stability** — the final declaration in any file no longer has its range inflated by synthesized constructors, so range-dependent features (folding, breadcrumbs, outline) are stable regardless of file position