### PR TITLE
Document release notes conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ All test commands are slow (full rebuild + test run). Run each command at most o
 - `make test-pony-lint` / `make lint-pony-lint`
 - `make test-pony-doc` / `make lint-pony-doc`
 
+## Release Notes
+
+Use the `/pony-release-notes` skill if available. Otherwise: create `.release-notes/<slug>.md` (e.g., `fix-foo.md`). Do NOT edit `next-release.md` directly — CI aggregates the individual files. Format: `## Title` (matching the PR title exactly) followed by a user-facing description. Include code examples for new API; include before/after for breaking changes.
+
 ## Known Couplings
 
 Non-obvious dependencies between areas of the codebase. When changing code in one of these areas, run the listed test suites before opening a PR — failures here won't be caught by tests local to the area you changed.


### PR DESCRIPTION
## Context

`CONTRIBUTING.md` explains the changelog label mechanic but does not describe where to put the release notes file or what format to use.

## Changes

Add a Release Notes section to `CLAUDE.md` that points to the `/pony-release-notes` skill if available, with the essential mechanics as a fallback.

## Consequences

Claude knows to create `.release-notes/<slug>.md` per PR rather than editing `next-release.md` directly.