### PR TITLE
Fix LSP outline including synthetic and inherited members

### DIFF
--- a/.release-notes/fix-lsp-outline-synthetic-members.md
+++ b/.release-notes/fix-lsp-outline-synthetic-members.md
@@ -1,0 +1,5 @@
+## Fix LSP outline including synthetic and inherited members
+
+Previously, the `textDocument/documentSymbol` response (used by editors to build the outline/symbol tree) included members that were not explicitly written in a class's source file. A bare class that inherited a trait with a default method, or any class without an explicit constructor, would have those synthesized or inherited members appear as children in the outline.
+
+This has been fixed. The outline now shows only members that are explicitly written in the file being viewed.

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -192,6 +192,20 @@ primitive DocumentSymbols
     channel: Channel,
     max_pos: (Position | None) = None)
   =>
+    """
+    Walk the members of `entity` and append a child DocumentSymbol for each
+    explicitly written member (field, constructor, function, or behaviour).
+
+    Two categories of members are filtered out:
+    - Synthesized constructors: ponyc's sugar pass places the default `create`
+      at the entity keyword's own source position (via token_dup). Any
+      explicitly written member must appear after the entity keyword, so
+      members at or before that position are skipped.
+    - Trait-merged methods: ponyc merges trait default method bodies into
+      implementing classes; those merged nodes carry the trait file's
+      source_file(). Members whose source_file() is a non-None string that
+      does not match the entity's source_file() are skipped.
+    """
     let members =
       try
         entity(4)?
@@ -207,13 +221,30 @@ primitive DocumentSymbols
         TokenIds.string(members.id()))
       return
     end
+    let doc_path = entity.source_file()
+    let entity_pos = entity.position()
     for entity_child in members.children() do
-      // Skip members whose position is at or beyond max_pos. ponyc
-      // positions synthesized constructors at the start of the next
-      // entity in the file; max_pos is that entity's start position.
+      // Skip members whose position is at or beyond max_pos.
       match max_pos
       | let m: Position =>
         if entity_child.position() >= m then continue end
+      end
+      // Skip members at or before the entity's keyword position.
+      // ponyc places synthesized constructors (the default `create`
+      // added to bare classes/actors/primitives/structs) at the entity
+      // keyword's own source position via token_dup(). Any explicitly
+      // written member must appear after the entity keyword.
+      if entity_child.position() <= entity_pos then continue end
+      // Skip members from other source files. ponyc merges trait
+      // default method bodies into implementing classes; those merged
+      // nodes carry the trait file's source_file(). Nodes with
+      // source_file() == None are synthetic containers and are kept.
+      match doc_path
+      | let dp: String val =>
+        match entity_child.source_file()
+        | let sf: String val =>
+          if sf != dp then continue end
+        end
       end
       try
         let maybe_kind_and_idx =

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -204,7 +204,10 @@ primitive DocumentSymbols
     - Trait-merged methods: ponyc merges trait default method bodies into
       implementing classes; those merged nodes carry the trait file's
       source_file(). Members whose source_file() is a non-None string that
-      does not match the entity's source_file() are skipped.
+      does not match the entity's source_file() are skipped. (When the
+      trait is defined in the same file as the implementing class, the
+      merged methods share the same source_file() and are instead caught
+      by the position or max_pos filters.)
     """
     let members =
       try

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -20,6 +20,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymMemberKindsTest.create(server))
     test(_DocSymCrossFileTraitTest.create(server))
     test(_DocSymImplNoChildrenTest.create(server))
+    test(_DocSymMixedChildrenTest.create(server))
     test(_DocSymTypeAliasRangeTest.create(server))
     test(_DocSymPrimitiveRangeTest.create(server))
 
@@ -213,6 +214,32 @@ class \nodoc\ iso _DocSymImplNoChildrenTest is UnitTest
       _server,
       "document_symbol/_ds_impl.pony",
       [(0, 0, _DocSymNoChildrenChecker("_DsImpl"))])
+
+class \nodoc\ iso _DocSymMixedChildrenTest is UnitTest
+  """
+  Verifies that the position filter suppresses the synthesized `create`
+  constructor without over-suppressing explicitly written members.
+
+  `_DsMixed` (in `_ds_mixed.pony`) has no explicit `new`, so ponyc's
+  sugar pass synthesizes a `create` at the class keyword's position.
+  It has one explicitly written `fun ds_mixed_method`. The outline must
+  include the explicit method and exclude the synthesized constructor —
+  exactly one child with the right name and kind.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/mixed_children"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_mixed.pony",
+      [(0, 0, _DocSymChildKindsChecker("_DsMixed", [("ds_mixed_method", 6)]))])
 
 class \nodoc\ iso _DocSymTypeAliasRangeTest is UnitTest
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -19,6 +19,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymEntityKindsTest.create(server))
     test(_DocSymMemberKindsTest.create(server))
     test(_DocSymCrossFileTraitTest.create(server))
+    test(_DocSymImplNoChildrenTest.create(server))
     test(_DocSymTypeAliasRangeTest.create(server))
     test(_DocSymPrimitiveRangeTest.create(server))
 
@@ -186,6 +187,32 @@ class \nodoc\ iso _DocSymCrossFileTraitTest is UnitTest
       "document_symbol/_ds_impl.pony",
       [ ( 0, 0,
           _DocSymMaxEndLineChecker("_DsImpl", 15))])
+
+class \nodoc\ iso _DocSymImplNoChildrenTest is UnitTest
+  """
+  Regression guard for synthesized and trait-merged members leaking into
+  the outline.
+
+  `_DsImpl` (in `_ds_impl.pony`) has no explicitly written members: it
+  inherits `ds_default_method` from `_DsTrait` (merged by ponyc) and
+  receives a synthesized `create` from the sugar pass. Both must be
+  filtered out by `DocumentSymbols.find_members`; the symbol's children
+  array must be empty.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/impl_no_children"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_impl.pony",
+      [(0, 0, _DocSymNoChildrenChecker("_DsImpl"))])
 
 class \nodoc\ iso _DocSymTypeAliasRangeTest is UnitTest
   """
@@ -641,6 +668,55 @@ class val _DocSymMaxEndLineChecker
       end
       h.fail(
         "documentSymbol: symbol '" + _symbol_name + "' not found")
+      false
+    else
+      h.fail("documentSymbol: expected array result, got null")
+      false
+    end
+
+class val _DocSymNoChildrenChecker
+  """
+  Asserts that a named top-level symbol has no children in the
+  documentSymbol response. Used to verify that synthesized constructors
+  (ponyc sugar) and trait-merged methods are not included in the outline.
+  """
+  let _symbol_name: String
+
+  new val create(symbol_name: String) =>
+    _symbol_name = symbol_name
+
+  fun lsp_method(): String =>
+    Methods.text_document().document_symbol()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      for item in arr.values() do
+        try
+          if JsonNav(item)("name").as_string()? == _symbol_name then
+            // children key is omitted from JSON when the array is empty;
+            // if present it must be empty.
+            try
+              let children = JsonNav(item)("children").as_array()?
+              return h.assert_eq[USize](
+                0,
+                children.size(),
+                _symbol_name + ": expected no children in outline")
+            end
+            return true
+          end
+        end
+      end
+      h.fail("documentSymbol: symbol '" + _symbol_name + "' not found")
       false
     else
       h.fail("documentSymbol: expected array result, got null")

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -158,7 +158,10 @@ class \nodoc\ iso _WsSymNoMatchTest is UnitTest
 class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
   """
   Empty query → all symbols from the fixture: the top-level actor and
-  class, plus every member (var/let/embed fields, constructor, fun, be).
+  class, plus every explicitly written member (var/let/embed fields,
+  constructor, fun, be). Synthesized constructors on bare classes are
+  excluded — `_WsSymInner` has no explicit `new` so its ponyc-generated
+  `create` does not appear.
   """
   let _server: _LspTestServer
 
@@ -183,8 +186,7 @@ class \nodoc\ iso _WsSymEmptyQueryTest is UnitTest
               ("create", 9, "_ws_sym_host.pony", "_WsSymHost")
               ("increment", 6, "_ws_sym_host.pony", "_WsSymHost")
               ("ping", 6, "_ws_sym_host.pony", "_WsSymHost")
-              ("_WsSymInner", 5, "_ws_sym_host.pony", None)
-              ("create", 9, "_ws_sym_host.pony", "_WsSymInner")]))])
+              ("_WsSymInner", 5, "_ws_sym_host.pony", None)]))])
 
 class \nodoc\ iso _WsSymRangeTest is UnitTest
   """

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_mixed.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_mixed.pony
@@ -1,0 +1,10 @@
+// Fixture for `document_symbol/integration/mixed_children`.
+//
+// `_DsMixed` has no explicit `new`, so ponyc's sugar pass synthesizes a
+// `create` constructor at the class keyword's source position. It has one
+// explicitly written `fun`. The position filter in `find_members` must
+// suppress the synthesized constructor (at the class keyword's position)
+// without suppressing the explicit method (at a later position).
+
+class _DsMixed
+  fun ds_mixed_method(): U32 => 0


### PR DESCRIPTION
## Context

`textDocument/documentSymbol` (the LSP request editors use to build the outline/symbol tree) includes members that are not explicitly written in a class's source file. A bare class that inherits a trait with a default method has that inherited method appear as a child in the outline. Any class without an explicit constructor has a synthesized `create` appear as a child.

## Changes

Two filters added to `DocumentSymbols.find_members`:

- **Position filter**: ponyc's sugar pass places the synthesized `create` at the entity keyword's own source position (via `token_dup` / memcpy of the class token). Any explicitly written member must appear after the entity keyword, so members at or before that position are skipped.
- **Source-file filter**: ponyc merges trait default method bodies into implementing classes; those merged nodes carry the trait file's `source_file()`. Members whose `source_file()` is a non-None string that doesn't match the entity's file are skipped — the same pattern used by `ASTSourceSpan` for range computation.

Also adds a docstring to `find_members`, a new `_DocSymImplNoChildrenTest` test, and a `_DocSymNoChildrenChecker` helper.

## Consequences

The outline now shows only members explicitly written in the file being viewed.