### PR TITLE
Add LSP spec links to pony-lsp README feature table

### DIFF
--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -11,19 +11,33 @@ For user documentation — installation and editor configuration — see the [po
 
 | **Feature** | **Description** |
 | ------- | ----------- |
-| **Diagnostics** (push, pull, refresh and change notifications) | Ponyc errors and related information is reported as LSP diagnostics. |
-| **Hover** | Additional information is shown for: entities, methods, fields, local variables and references. |
-| **Go To Definition** | For most language constructs, you can go from a reference to its definition. |
-| **Go To Declaration** | Navigate from a reference to the declaration site of a symbol. |
-| **Go To Type Definition** | Navigate to the type definition of the symbol under the cursor. |
-| **Document Symbols** | pony-lsp provides a list of available symbols for each opened document. |
-| **Workspace Symbols** | Fuzzy search over all symbols across the entire workspace. |
-| **Document Highlight** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
-| **Inlay Hints** | Inferred types are shown inline after the variable name for `let` and `var` declarations with no explicit type annotation. |
-| **Find References** | All references to the symbol under the cursor are returned, with optional inclusion of the declaration site. |
-| **Rename** | Rename a symbol and all its references across the workspace. |
-| **Folding Range** | Code folding ranges are provided for blocks, methods, classes, and other structured constructs. |
-| **Selection Range** | Smart expand/shrink selection based on the AST structure of the document. |
+| **[Diagnostics][spec-diagnostics]** (push, pull, refresh and change notifications) | Ponyc errors and related information is reported as LSP diagnostics. |
+| **[Hover][spec-hover]** | Additional information is shown for: entities, methods, fields, local variables and references. |
+| **[Go To Definition][spec-definition]** | For most language constructs, you can go from a reference to its definition. |
+| **[Go To Declaration][spec-declaration]** | Navigate from a reference to the declaration site of a symbol. |
+| **[Go To Type Definition][spec-type-definition]** | Navigate to the type definition of the symbol under the cursor. |
+| **[Document Symbols][spec-document-symbols]** | pony-lsp provides a list of available symbols for each opened document. |
+| **[Workspace Symbols][spec-workspace-symbols]** | Fuzzy search over all symbols across the entire workspace. |
+| **[Document Highlight][spec-document-highlight]** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
+| **[Inlay Hints][spec-inlay-hints]** | Inferred types are shown inline after the variable name for `let` and `var` declarations with no explicit type annotation. |
+| **[Find References][spec-references]** | All references to the symbol under the cursor are returned, with optional inclusion of the declaration site. |
+| **[Rename][spec-rename]** | Rename a symbol and all its references across the workspace. |
+| **[Folding Range][spec-folding-range]** | Code folding ranges are provided for blocks, methods, classes, and other structured constructs. |
+| **[Selection Range][spec-selection-range]** | Smart expand/shrink selection based on the AST structure of the document. |
+
+[spec-diagnostics]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pull-diagnostics
+[spec-hover]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover-request-leftwards_arrow_with_hook
+[spec-definition]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-definition-request-leftwards_arrow_with_hook
+[spec-declaration]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-declaration-request-leftwards_arrow_with_hook
+[spec-type-definition]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-type-definition-request-leftwards_arrow_with_hook
+[spec-document-symbols]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#document-symbols-request-leftwards_arrow_with_hook
+[spec-workspace-symbols]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace-symbols-request-leftwards_arrow_with_hook
+[spec-document-highlight]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#document-highlights-request-leftwards_arrow_with_hook
+[spec-inlay-hints]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlay-hint-request-leftwards_arrow_with_hook
+[spec-references]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#find-references-request-leftwards_arrow_with_hook
+[spec-rename]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#rename-request-leftwards_arrow_with_hook
+[spec-folding-range]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#folding-range-request-leftwards_arrow_with_hook
+[spec-selection-range]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#selection-range-request-leftwards_arrow_with_hook
 
 New features are actively being added. Contributions are welcome — we are happy to provide help and guidance.
 


### PR DESCRIPTION
## Context

The pony-lsp README feature table lists each supported LSP feature but provides no links to the spec. Readers who want to understand what a feature does or how it works must search the LSP specification manually.

## Changes

Each feature name in the Feature Support table is now linked directly to its section in the LSP 3.17 specification.