### PR TITLE
Build pony-lint-ci once across the three lint-pony-* CI targets

### DIFF
--- a/.release-notes/dedupe-pony-lint-ci-build.md
+++ b/.release-notes/dedupe-pony-lint-ci-build.md
@@ -1,7 +1,0 @@
-## Build pony-lint-ci once across the three lint-pony-* CI targets
-
-The `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` Makefile targets each rebuilt the `pony-lint-ci` binary from Pony source before running it against their respective directories. The Pony compilation took roughly 60 seconds, so the redundant work added about two minutes to every PR's lint job.
-
-`pony-lint-ci` is now a real file target with the lint tool source as its only regular prereq (`tools/pony-lint/*.pony` plus the pony_compiler library). The three lint targets depend on the file rather than each producing it, so the second and third invocations in CI skip the rebuild and reuse the binary from the first. The order-only prereq on `all` keeps the existing requirement that `ponyc` itself must be built first, without forcing a rebuild every time `all` is touched.
-
-The change affects only the Linux PR-tools job; macOS and Windows do not run lint steps in CI.

--- a/.release-notes/dedupe-pony-lint-ci-build.md
+++ b/.release-notes/dedupe-pony-lint-ci-build.md
@@ -1,0 +1,7 @@
+## Build pony-lint-ci once across the three lint-pony-* CI targets
+
+The `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` Makefile targets each rebuilt the `pony-lint-ci` binary from Pony source before running it against their respective directories. The Pony compilation took roughly 60 seconds, so the redundant work added about two minutes to every PR's lint job.
+
+`pony-lint-ci` is now a real file target with the lint tool source as its only regular prereq (`tools/pony-lint/*.pony` plus the pony_compiler library). The three lint targets depend on the file rather than each producing it, so the second and third invocations in CI skip the rebuild and reuse the binary from the first. The order-only prereq on `all` keeps the existing requirement that `ponyc` itself must be built first, without forcing a rebuild every time `all` is touched.
+
+The change affects only the Linux PR-tools job; macOS and Windows do not run lint steps in CI.

--- a/BUILD.md
+++ b/BUILD.md
@@ -251,6 +251,6 @@ To ease development and support LSP tools like [clangd](https://clangd.llvm.org)
 
 Now [clangd](https://clangd.llvm.org) will pick up the generated file and will be able to respond much quicker than without `compile_commands.json` file.
 
-### Re-running `make lint-pony-*` after compiler changes
+### Re-running `make lint-pony-*` after compiler or stdlib changes
 
-The `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` targets share a single `pony-lint-ci` binary that is rebuilt only when files under `tools/pony-lint/` (excluding its `test/` sub-package) or `tools/lib/ponylang/pony_compiler/pony_compiler/` change. Editing `ponyc` itself (`src/`) does not invalidate `pony-lint-ci`, so an iterative loop of "tweak the compiler, then `make lint-pony-lint`" will lint with the previously built binary. Delete `build/<config>/pony-lint-ci` (or `make clean`) to force a rebuild against the updated compiler. CI is unaffected because each run starts in a clean workspace.
+The `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` targets share a single `pony-lint-ci` binary that is rebuilt only when files under `tools/pony-lint/` (excluding its `test/` sub-package) or `tools/lib/ponylang/pony_compiler/pony_compiler/` change. Edits anywhere else, including `src/`, `packages/`, and the runtime, do not invalidate the binary, so iterating on the compiler or stdlib and re-running `make lint-pony-lint` will lint with the previously built binary. Run `make clean` to force a rebuild, or delete `build/<config>/pony-lint-ci` if you only need the lint binary refreshed. CI is unaffected because each run starts in a clean workspace.

--- a/BUILD.md
+++ b/BUILD.md
@@ -250,3 +250,7 @@ To ease development and support LSP tools like [clangd](https://clangd.llvm.org)
   Replace `build_debug` with `build_release` is you are using a release configuration for compilation.
 
 Now [clangd](https://clangd.llvm.org) will pick up the generated file and will be able to respond much quicker than without `compile_commands.json` file.
+
+### Re-running `make lint-pony-*` after compiler changes
+
+The `lint-pony-lint`, `lint-pony-doc`, and `lint-pony-lsp` targets share a single `pony-lint-ci` binary that is rebuilt only when files under `tools/pony-lint/` (excluding its `test/` sub-package) or `tools/lib/ponylang/pony_compiler/pony_compiler/` change. Editing `ponyc` itself (`src/`) does not invalidate `pony-lint-ci`, so an iterative loop of "tweak the compiler, then `make lint-pony-lint`" will lint with the previously built binary. Delete `build/<config>/pony-lint-ci` (or `make clean`) to force a rebuild against the updated compiler. CI is unaffected because each run starts in a clean workspace.

--- a/Makefile
+++ b/Makefile
@@ -281,10 +281,10 @@ test-pony-lint: all
 # subpackages, and listing the directories means the binary rebuilds when
 # a source is deleted (directory mtime updates on add/remove, the
 # remaining files' mtimes do not).
-lint-bin-srcs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -name '*.pony' -print) \
-                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony')
-lint-bin-dirs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -type d -print) \
-                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -type d)
+lint-bin-srcs := $(shell find $(srcDir)/tools/pony-lint -path $(srcDir)/tools/pony-lint/test -prune -o -name '*.pony' -not -name '.*' -print) \
+                 $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony' -not -name '.*')
+lint-bin-dirs := $(shell find $(srcDir)/tools/pony-lint -path $(srcDir)/tools/pony-lint/test -prune -o -type d -print) \
+                 $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -type d)
 $(outDir)/pony-lint-ci: $(lint-bin-srcs) $(lint-bin-dirs) | all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci
 

--- a/Makefile
+++ b/Makefile
@@ -274,9 +274,18 @@ test-pony-lint: all
 
 # Build the lint binary once. Order-only dep on `all` so we get a built
 # compiler without forcing a rebuild every time `all` is touched (it's
-# .PHONY). Real prereqs are the lint tool source and the pony_compiler
-# library it links against, so the binary is rebuilt when those change.
-$(outDir)/pony-lint-ci: $(wildcard tools/pony-lint/*.pony) $(wildcard tools/lib/ponylang/pony_compiler/pony_compiler/*.pony) | all
+# .PHONY). Real prereqs are every .pony file in the lint tool tree (minus
+# its `test/` sub-package, which is compiled by `test-pony-lint`) and the
+# pony_compiler library it links against, plus the directories
+# themselves. Recursive `find` covers files in current or future
+# subpackages, and listing the directories means the binary rebuilds when
+# a source is deleted (directory mtime updates on add/remove, the
+# remaining files' mtimes do not).
+lint-bin-srcs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -name '*.pony' -print) \
+                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony')
+lint-bin-dirs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -type d -print) \
+                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -type d)
+$(outDir)/pony-lint-ci: $(lint-bin-srcs) $(lint-bin-dirs) | all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci
 
 lint-pony-lint: $(outDir)/pony-lint-ci

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ else ifneq ($(strip $(usedebugger)),)
 endif
 
 .DEFAULT_GOAL := build
-.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint lint-pony-doc lint-pony-lsp build-pony-lint-ci pony-doc test-pony-doc test-pony-compiler
+.PHONY: all libs cleanlibs configure cross-configure build test test-ci-core test-check-version test-core test-stdlib-debug test-stdlib-release test-examples test-stress test-validate-grammar clean test-pony-lsp pony-lint test-pony-lint lint-pony-lint lint-pony-doc lint-pony-lsp pony-doc test-pony-doc test-pony-compiler
 
 libs:
 	$(SILENT)mkdir -p '$(libsBuildDir)'
@@ -272,16 +272,20 @@ test-pony-lsp: all
 test-pony-lint: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-tests ../../tools/pony-lint/test && echo Built `pwd`/pony-lint-tests && PONYPATH=../../packages:$(PONYPATH) ./pony-lint-tests --sequential
 
-build-pony-lint-ci: all
+# Build the lint binary once. Order-only dep on `all` so we get a built
+# compiler without forcing a rebuild every time `all` is touched (it's
+# .PHONY). Real prereqs are the lint tool source and the pony_compiler
+# library it links against, so the binary is rebuilt when those change.
+$(outDir)/pony-lint-ci: $(wildcard tools/pony-lint/*.pony) $(wildcard tools/lib/ponylang/pony_compiler/pony_compiler/*.pony) | all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-ci ../../tools/pony-lint && echo Built `pwd`/pony-lint-ci
 
-lint-pony-lint: build-pony-lint-ci
+lint-pony-lint: $(outDir)/pony-lint-ci
 	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lint/
 
-lint-pony-doc: build-pony-lint-ci
+lint-pony-doc: $(outDir)/pony-lint-ci
 	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-doc/
 
-lint-pony-lsp: build-pony-lint-ci
+lint-pony-lsp: $(outDir)/pony-lint-ci
 	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lsp/
 
 test-pony-compiler: all


### PR DESCRIPTION
Build pony-lint-ci once across the three lint-pony-* CI targets

Closes #5155

The lint-pony-lint, lint-pony-doc, and lint-pony-lsp Makefile targets each rebuilt the pony-lint-ci binary from Pony source before running it against their target directory. The Pony compilation took roughly 60 seconds, so the redundant work added about two minutes to every PR's lint job (Linux only -- macOS and Windows do not run lint steps in CI).

## Change

`pony-lint-ci` is now a real file target -- `$(outDir)/pony-lint-ci` -- with the lint tool source as its only regular prereqs (every `.pony` file under `tools/pony-lint/` minus the `test/` sub-package, plus everything under `tools/lib/ponylang/pony_compiler/pony_compiler/`, plus the directories themselves). The three lint-pony-* targets depend on the file rather than each producing it:

```makefile
lint-bin-srcs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -name '*.pony' -print) \
                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony')
lint-bin-dirs := $(shell find tools/pony-lint -path tools/pony-lint/test -prune -o -type d -print) \
                 $(shell find tools/lib/ponylang/pony_compiler/pony_compiler -type d)

$(outDir)/pony-lint-ci: $(lint-bin-srcs) $(lint-bin-dirs) | all
	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc \
	  --path ../../tools/lib/ponylang/pony_compiler/ \
	  -b pony-lint-ci ../../tools/pony-lint && \
	  echo Built `pwd`/pony-lint-ci

lint-pony-lint: $(outDir)/pony-lint-ci
	$(SILENT)cd '$(outDir)' && PONYPATH=...:$(PONYPATH) \
	  ./pony-lint-ci ../../tools/pony-lint/

lint-pony-doc: $(outDir)/pony-lint-ci
	... ./pony-lint-ci ../../tools/pony-doc/

lint-pony-lsp: $(outDir)/pony-lint-ci
	... ./pony-lint-ci ../../tools/pony-lsp/
```

## Why an order-only prereq on `all`

`all` is `.PHONY`, so making it a regular prereq of `$(outDir)/pony-lint-ci` would mark the file as out-of-date on every invocation -- defeating the dedupe. Using `| all` (order-only) keeps the existing requirement that `ponyc` itself must be built first without forcing an unnecessary rebuild of the lint binary.

## Why both source dirs are tracked, recursively

The lint binary depends on:

- every `.pony` file under `tools/pony-lint/` (the linter's own source), except the `test/` sub-package which `test-pony-lint` builds separately
- every `.pony` file under `tools/lib/ponylang/pony_compiler/pony_compiler/` -- the pony_compiler library it links via `--path` (the actual sources live one level below `pony_compiler/`, not directly in it; this was caught by `codex review`)

Recursive `find` covers files in current or future subpackages so a new linter rule under, say, `tools/pony-lint/rules/` would invalidate the binary the moment it changes. The directories themselves are also listed as prereqs so file deletion triggers a rebuild: a directory's mtime updates on add/remove even when the surviving files' mtimes don't. A `make -pn lint-pony-lint` after the change confirms 72 source files + 2 directories expand into the dependency line.

## Local-dev behavior change

Before this change every `make lint-pony-*` re-invoked `ponyc` to build the binary, so compiler edits were always reflected immediately. With the order-only dep on `all`, once `pony-lint-ci` exists, edits under `src/` no longer invalidate it -- the binary is only rebuilt when the lint tool sources or pony_compiler library change. A contributor iterating on the compiler who tries to re-lint will get the previously built binary until they `make clean` or delete `build/<config>/pony-lint-ci` by hand. CI is unaffected because each run starts in a clean workspace. This is documented in BUILD.md under Compiler Development.

## Effect across CI invocations

Each pr-tools.yml lint step is a separate `make` invocation but they share the same workspace. With the change:

| Step | File state | Action |
|------|-----------|--------|
| `make lint-pony-lint config=debug` | `pony-lint-ci` does not exist | ponyc builds the binary, then lints `tools/pony-lint/` |
| `make lint-pony-doc config=debug` | binary exists, sources unchanged | skip rebuild, just lint `tools/pony-doc/` |
| `make lint-pony-lsp config=debug` | same | skip rebuild, just lint `tools/pony-lsp/` |

This contribution was developed with AI assistance (Claude Code).
