### PR TITLE
Ubuntu 26.04 added as a supported platform

### DIFF
--- a/.ci-dockerfiles/ubuntu26.04-builder/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:26.04
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+# Keep annoying tzdata prompt from coming up
+# Thanks cmake!
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  build-essential \
+  clang \
+  cmake \
+  git \
+  libclang-rt-dev \
+  lldb \
+  make \
+  xz-utils \
+  zlib1g-dev \
+  curl \
+  python3-pip \
+  wget \
+  systemtap-sdt-dev \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get -y autoremove --purge \
+ && apt-get -y clean \
+ && pip3 install --break-system-packages cloudsmith-cli
+
+# needed for GitHub actions
+RUN git config --global --add safe.directory /__w/ponyc/ponyc
+
+# add user pony in order to not run tests as root
+RUN useradd -u 1001 -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ubuntu26.04-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -15,6 +15,7 @@ on:
           - cross-arm
           - cross-armhf
           - cross-riscv64
+          - ubuntu26.04-builder
           - x86-64-unknown-linux-alpine3.21-builder
           - x86-64-unknown-linux-ubuntu22.04-builder
           - x86-64-unknown-linux-ubuntu24.04-builder
@@ -183,6 +184,29 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/cross-riscv64/build-and-push.bash
+
+  ubuntu26_04-builder:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder/build-and-push.bash
 
   x86-64-unknown-linux-alpine3_21-builder:
     if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-alpine3.21-builder' }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -35,6 +35,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04
+            triple-os: linux-ubuntu26.04
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:
@@ -109,6 +113,9 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
             name: arm64-unknown-linux-ubuntu24.04
             triple-os: linux-ubuntu24.04
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04
+            triple-os: linux-ubuntu26.04
 
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04
+            triple-os: linux-ubuntu26.04
+            triple-vendor: unknown
 
     name: ${{ matrix.name }}
     container:
@@ -139,6 +143,9 @@ jobs:
             name: arm64-unknown-linux-ubuntu24.04
             triple-os: linux-ubuntu24.04
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04
+            triple-os: linux-ubuntu26.04
 
     name: ${{ matrix.name }}
     steps:

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -25,6 +25,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
           - image: ghcr.io/ponylang/ponyc-ci-cross-arm:20250223
           - image: ghcr.io/ponylang/ponyc-ci-cross-armhf:20250223
           - image: ghcr.io/ponylang/ponyc-ci-cross-riscv64:20240427
@@ -68,6 +69,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
 
     name: ${{ matrix.image }}
     steps:

--- a/.release-notes/add-ubuntu-26.04.md
+++ b/.release-notes/add-ubuntu-26.04.md
@@ -1,0 +1,3 @@
+## Ubuntu 26.04 added as a supported platform
+
+We've added arm64 and amd64 builds for Ubuntu 26.04. We'll be building ponyc releases for it until it stops receiving security updates in 2031. At that point, we'll stop building releases for it.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ Currently, we have packages for the following Glibc based distributions:
 
 - Linux Mint 19, 20, 21
 - Pop!_OS 22.04, 24.04
-- Ubuntu 22.04, 24.04
+- Ubuntu 22.04, 24.04, 26.04
 
 ### Supported Alpine versions
 
@@ -51,6 +51,8 @@ Pop!_OS 24.04 | arm-linux-ubuntu24.04
 Ubuntu 22.04 | x86_64-linux-ubuntu22.04
 Ubuntu 24.04 amd64 | x86_64-linux-ubuntu24.04
 Ubuntu 24.04 arm64 | arm-linux-ubuntu24.04
+Ubuntu 26.04 amd64 | x86_64-linux-ubuntu26.04
+Ubuntu 26.04 arm64 | arm-linux-ubuntu26.04
 
 ### Install the latest release
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -48,6 +48,7 @@ Package names will be:
 * ponyc-arm64-unknown-linux-alpine3.22.tar.gz
 * ponyc-arm64-unknown-linux-alpine3.23.tar.gz
 * ponyc-arm64-unknown-linux-ubuntu24.04.tar.gz
+* ponyc-arm64-unknown-linux-ubuntu26.04.tar.gz
 * ponyc-x86-64-apple-darwin.tar.gz
 * ponyc-x86-64-pc-windows-msvc.zip
 * ponyc-x86-64-unknown-linux-alpine3.21.tar.gz
@@ -55,6 +56,7 @@ Package names will be:
 * ponyc-x86-64-unknown-linux-alpine3.23.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu22.04.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu24.04.tar.gz
+* ponyc-x86-64-unknown-linux-ubuntu26.04.tar.gz
 
 and should have a version field listing that matches the current release e.g. `0.3.1`.
 


### PR DESCRIPTION
Adds Ubuntu 26.04 as a supported release target. Builder image, release/nightly/lib-cache workflow entries, INSTALL/RELEASE_PROCESS docs, and a release note are all included.