### PR TITLE
Add LSP `textDocument/signatureHelp` support

### DIFF
--- a/.release-notes/add-lsp-signature-help.md
+++ b/.release-notes/add-lsp-signature-help.md
@@ -1,0 +1,7 @@
+## Add LSP `textDocument/signatureHelp` support
+
+The Pony language server now supports `textDocument/signatureHelp`, providing parameter hints when the cursor is inside a call expression. The popup shows the full method signature with the active parameter highlighted, and includes the method's docstring when present.
+
+Triggered by `(` and `,` characters, consistent with standard LSP conventions.
+
+Signature help is driven by the compiled AST and requires the file to be saved — it is not available mid-keystroke while the file has unsaved edits.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -13,6 +13,7 @@ For user documentation — installation and editor configuration — see the [po
 | ------- | ----------- |
 | **[Diagnostics][spec-diagnostics]** (push, pull, refresh and change notifications) | Ponyc errors and related information is reported as LSP diagnostics. |
 | **[Hover][spec-hover]** | Additional information is shown for: entities, methods, fields, local variables and references. |
+| **[Signature Help][spec-signature-help]** | Parameter hints are shown when the cursor is inside a call expression, with the active parameter highlighted. Includes the method's docstring when present. Requires the file to be saved — signature help is not available while the file has unsaved edits. |
 | **[Go To Definition][spec-definition]** | For most language constructs, you can go from a reference to its definition. |
 | **[Go To Declaration][spec-declaration]** | Navigate from a reference to the declaration site of a symbol. |
 | **[Go To Type Definition][spec-type-definition]** | Navigate to the type definition of the symbol under the cursor. |
@@ -27,6 +28,7 @@ For user documentation — installation and editor configuration — see the [po
 
 [spec-diagnostics]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pull-diagnostics
 [spec-hover]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover-request-leftwards_arrow_with_hook
+[spec-signature-help]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_signatureHelp
 [spec-definition]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-definition-request-leftwards_arrow_with_hook
 [spec-declaration]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-declaration-request-leftwards_arrow_with_hook
 [spec-type-definition]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#goto-type-definition-request-leftwards_arrow_with_hook

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -274,6 +274,21 @@ actor LanguageServer is (Notifier & RequestSender)
             )
           )
         end
+      | Methods.text_document().signature_help() =>
+        try
+          let document_uri = _get_document_uri(r.params)?
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .signature_help(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                r.json().string() + "'")))
+        end
       | Methods.workspace().symbol() =>
         let query = try JsonNav(r.params)("query").as_string()? else "" end
         _router.workspace_symbol(query, this._channel, r.id)
@@ -522,7 +537,16 @@ actor LanguageServer is (Notifier & RequestSender)
                 .update("workspaceSymbolProvider", true)
                 .update(
                   "inlayHintProvider",
-                  JsonObject.update("resolveProvider", false)))
+                  JsonObject.update("resolveProvider", false))
+                .update(
+                  "signatureHelpProvider",
+                  JsonObject
+                    .update(
+                      "triggerCharacters",
+                      JsonArray.push("(").push(","))
+                    .update(
+                      "retriggerCharacters",
+                      JsonArray.push("(").push(","))))
             .update(
               "serverInfo",
               JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -151,6 +151,9 @@ primitive TextDocumentMethods
   fun publish_diagnostics(): String val =>
     "textDocument/publishDiagnostics"
 
+  fun signature_help(): String val =>
+    "textDocument/signatureHelp"
+
 primitive ClientMethods
   """
   Collection of client scoped methods.

--- a/tools/pony-lsp/test/_signature_help_integration_tests.pony
+++ b/tools/pony-lsp/test/_signature_help_integration_tests.pony
@@ -1,0 +1,752 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+primitive _SignatureHelpIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_SigHelpSimpleParam0Test.create(server))
+    test(_SigHelpFullLabelTest.create(server))
+    test(_SigHelpMultiParam0Test.create(server))
+    test(_SigHelpMultiParam1Test.create(server))
+    test(_SigHelpMultiParam2Test.create(server))
+    test(_SigHelpNotInCallTest.create(server))
+    test(_SigHelpNoArgsTest.create(server))
+    test(_SigHelpConstructorTest.create(server))
+    test(_SigHelpConstructorOpenParenTest.create(server))
+    test(_SigHelpConstructorCloseParenTest.create(server))
+    test(_SigHelpCalleeTest.create(server))
+    test(_SigHelpDocstringTest.create(server))
+    test(_SigHelpParamTextTest.create(server))
+    test(_SigHelpAfterCommaTest.create(server))
+    test(_SigHelpAfterCommaMultilineTest.create(server))
+    test(_SigHelpAfterOpenParenMultilineTest.create(server))
+    test(_SigHelpMultilineArg0Test.create(server))
+    test(_SigHelpMultilineArg1Test.create(server))
+    test(_SigHelpMultilineArg2Test.create(server))
+    test(_SigHelpBeMethodTest.create(server))
+    test(_SigHelpNestedTest.create(server))
+    test(_SigHelpGenericTest.create(server))
+    test(_SigHelpNamedArgTest.create(server))
+
+class \nodoc\ iso _SigHelpSimpleParam0Test is UnitTest
+  """
+  Cursor on `4` in `42` (line 62, col 25) inside `_SigTarget(0).simple(42)`.
+  Expects signature for `simple` with activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/simple_param0"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(62, 25, _SigHelpChecker("simple", 0))])
+
+class \nodoc\ iso _SigHelpFullLabelTest is UnitTest
+  """
+  Cursor on `4` in `42` (line 62, col 25) inside `_SigTarget(0).simple(42)`.
+  Asserts the exact label "fun box simple(x: U32 val): U32 val", catching
+  regressions in capability, parentheses, parameter list, or return type.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/full_label"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [ (62, 25,
+        _SigHelpChecker(
+          "simple",
+          0
+          where expected_full_label' = "fun box simple(x: U32 val): U32 val"))])
+
+class \nodoc\ iso _SigHelpMultiParam0Test is UnitTest
+  """
+  Cursor on `1` (line 63, col 24) inside `multi(1, ...)` — first argument.
+  Expects signature for `multi` with activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multi_param0"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(63, 24, _SigHelpChecker("multi", 0))])
+
+class \nodoc\ iso _SigHelpMultiParam1Test is UnitTest
+  """
+  Cursor on `h` in `"hello"` (line 63, col 28) — second argument of `multi`.
+  Expects signature for `multi` with activeParameter=1.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multi_param1"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(63, 28, _SigHelpChecker("multi", 1))])
+
+class \nodoc\ iso _SigHelpMultiParam2Test is UnitTest
+  """
+  Cursor on `t` in `true` (line 63, col 36) — third argument of `multi`.
+  Expects signature for `multi` with activeParameter=2.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multi_param2"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(63, 36, _SigHelpChecker("multi", 2))])
+
+class \nodoc\ iso _SigHelpNotInCallTest is UnitTest
+  """
+  Cursor on `s` in `simple` (line 48, col 10) — method declaration, not a call.
+  Not inside a call expression — expects null / no signatures.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/not_in_call"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(48, 10, _SigHelpChecker(None, 0))])
+
+class \nodoc\ iso _SigHelpNoArgsTest is UnitTest
+  """
+  Cursor on `s` in `no_args` (line 64, col 24) — call with no parameters.
+  Expects signature for `no_args` with no activeParameter field (omitted for
+  zero-param signatures per LSP 3.17 spec).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/no_args"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(64, 24, _SigHelpChecker("no_args", None))])
+
+class \nodoc\ iso _SigHelpConstructorTest is UnitTest
+  """
+  Cursor on `0` (line 62, col 15) in `_SigTarget(0)` — a constructor call.
+  Expects signature for `create` with activeParameter=0.
+  Exercises the tk_new keyword branch in SignatureHelp.collect.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/constructor"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(62, 15, _SigHelpChecker("create", 0, None, "v:"))])
+
+class \nodoc\ iso _SigHelpConstructorOpenParenTest is UnitTest
+  """
+  Cursor on `(` (line 62, col 14) in `_SigTarget(0)` — the open paren is
+  before the first argument, so no signature help is returned.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/constructor_open_paren"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(62, 14, _SigHelpChecker(None))])
+
+class \nodoc\ iso _SigHelpConstructorCloseParenTest is UnitTest
+  """
+  Cursor on `)` (line 62, col 16) in `_SigTarget(0).simple(42)` — the close
+  paren is past the last argument of `_SigTarget(0)`, so no signature help
+  is returned.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/constructor_close_paren"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(62, 16, _SigHelpChecker(None))])
+
+class \nodoc\ iso _SigHelpCalleeTest is UnitTest
+  """
+  Four cursor positions on the callee of `.simple(42)` in line 62 — none
+  inside the argument list, so all expect null / no signatures.
+
+  (62, 17) — `.`          the dot before the method name
+  (62, 18) — `s`          first character of method name
+  (62, 23) — `e`          last  character of method name
+  (62, 24) — `(`          open paren, before any argument
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/callee"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [ (62, 17, _SigHelpChecker(None))
+        (62, 18, _SigHelpChecker(None))
+        (62, 23, _SigHelpChecker(None))
+        (62, 24, _SigHelpChecker(None)) ])
+
+class \nodoc\ iso _SigHelpDocstringTest is UnitTest
+  """
+  Cursor on `4` in `42` (line 62, col 25) inside `simple(42)`.
+  Verifies that signatures[0].documentation.value contains the
+  method's docstring ("Returns x plus the stored value.").
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/docstring"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(62, 25, _SigHelpChecker("simple", 0, "Returns x plus"))])
+
+class \nodoc\ iso _SigHelpParamTextTest is UnitTest
+  """
+  Cursor on `h` in `"hello"` (line 63, col 28) — second arg of `multi`.
+  Verifies that the activeParameter's label offsets into signatures[0].label
+  point to text containing "b:" (the second parameter name).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/param_text"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(63, 28, _SigHelpChecker("multi", 1, None, "b:"))])
+
+class \nodoc\ iso _SigHelpAfterCommaTest is UnitTest
+  """
+  Cursor on the space at (line 63, col 26) — immediately after the first `,`
+  in `multi(1, "hello", true)`. This is where the cursor sits when VS Code
+  triggers signatureHelp on the `,` character.
+
+  The server scans forward from whitespace to the next argument token so
+  the popup shows the correct parameter highlighted.
+  Expects signature for `multi` with activeParameter=1.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/after_comma"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(63, 26, _SigHelpChecker("multi", 1))])
+
+class \nodoc\ iso _SigHelpAfterCommaMultilineTest is UnitTest
+  """
+  Cursor at (line 66, col 8) — one past the trailing `,` on `      1,`,
+  in the multi-line `multi(...)` call. The next argument `"hello"` is
+  on the following line (line 67, col 6).
+  Expects signature for `multi` with activeParameter=1.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/after_comma_multiline"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(66, 8, _SigHelpChecker("multi", 1))])
+
+class \nodoc\ iso _SigHelpMultilineArg0Test is UnitTest
+  """
+  Cursor directly on `1` (line 66, col 6) — first arg of the multi-line call.
+  Expects signature for `multi` with activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multiline_arg0"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(66, 6, _SigHelpChecker("multi", 0))])
+
+class \nodoc\ iso _SigHelpMultilineArg1Test is UnitTest
+  """
+  Cursor directly on `"` in `"hello"` (line 67, col 6) — second arg of the
+  multi-line call. Expects signature for `multi` with activeParameter=1.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multiline_arg1"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(67, 6, _SigHelpChecker("multi", 1))])
+
+class \nodoc\ iso _SigHelpMultilineArg2Test is UnitTest
+  """
+  Cursor directly on `t` in `true)` (line 68, col 6) — third arg of the
+  multi-line call. Expects signature for `multi` with activeParameter=2.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/multiline_arg2"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(68, 6, _SigHelpChecker("multi", 2))])
+
+class \nodoc\ iso _SigHelpBeMethodTest is UnitTest
+  """
+  Cursor on `"` in `"hello"` (line 88, col 12) — first arg of `greet` behavior.
+  Exercises the tk_be branch in SignatureHelp.collect.
+  Expects signature for `greet` with activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/be_method"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(88, 12, _SigHelpChecker("greet", 0))])
+
+class \nodoc\ iso _SigHelpAfterOpenParenMultilineTest is UnitTest
+  """
+  Cursor at (line 65, col 24) — one past the `(` on `    _SigTarget(0).multi(`.
+  The `(` trigger character fires here; the first argument is on the next line.
+  Expects signature for `multi` with activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/after_open_paren_multiline"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(65, 24, _SigHelpChecker("multi", 0))])
+
+class \nodoc\ iso _SigHelpNestedTest is UnitTest
+  """
+  Three cursor positions inside
+  `_SigTarget(_SigTarget(0).simple(1)).multi(2, "nested", false)`
+  (line 69, 0-indexed).
+
+  Verifies that the server resolves the innermost enclosing call at each
+  cursor position, and that positions on a callee or open-paren of an inner
+  call fall through to the surrounding outer call's signature.
+
+  (69, 15) — `_` of inner `_SigTarget`, first token of the outer
+    constructor's argument: expects `create` (outer constructor),
+    activeParameter=0.
+  (69, 26) — `0` inside the innermost `_SigTarget(0)` constructor:
+    expects `create` (inner constructor), activeParameter=0.
+  (69, 28) — `.` before `simple`, the callee of `simple(1)`:
+    inner call is skipped; enclosing outer constructor gives
+    `create`, activeParameter=0.
+  (69, 34) — `e`, last character of `simple` (still on the callee):
+    same skip behaviour; `create`, activeParameter=0.
+  (69, 35) — `(` of `simple(1)`, before its first argument:
+    gate rejects `simple(1)`; outer constructor gives
+    `create`, activeParameter=0.
+  (69, 36) — `1` inside `simple(1)` (the outer constructor's argument):
+    expects `simple`, activeParameter=0.
+  (69, 46) — `2`, the first argument of the outermost `multi(...)` call:
+    expects `multi`, activeParameter=0.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/nested"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [ (69, 15, _SigHelpChecker("create", 0))
+        (69, 26, _SigHelpChecker("create", 0))
+        (69, 28, _SigHelpChecker("create", 0))
+        (69, 34, _SigHelpChecker("create", 0))
+        (69, 35, _SigHelpChecker("create", 0))
+        (69, 36, _SigHelpChecker("simple", 0))
+        (69, 46, _SigHelpChecker("multi", 0)) ])
+
+class \nodoc\ iso _SigHelpGenericTest is UnitTest
+  """
+  Cursor on first `_n` (line 108, col 36) inside
+  `_GenericSigPrimitive.typed[U32](_n, _n)`.
+  Exercises the type-parameter path in _build_label: "typed[" verifies that
+  type params are included in the label.
+  Explicit type args are required because Pony cannot infer method-level type
+  parameters. After typecheck, expr_qualify transforms TK_QUALIFY into a
+  TK_FUNREF node whose child(0) is the original inner TK_FUNREF; the
+  implementation detects this and descends to the inner ref for definitions().
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/generic"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [(109, 36, _SigHelpChecker("typed[", 0))])
+
+class \nodoc\ iso _SigHelpNamedArgTest is UnitTest
+  """
+  Four cursor positions across two named-arg calls in `_NamedArgUser.apply`.
+
+  After typecheck the compiler resolves named args into positional order, so
+  named-arg VALUES behave exactly like positional args and activeParameter is
+  correct. Named-arg NAMES (the identifiers before `=`) are not in any arg
+  slot and return no signature help.
+
+  Line 133 (0-indexed): all-named —
+    `multi(where a = U8(1), b = "hello", c = false)`
+    (133, 41) — `b`, a named-arg name: expects no signature help.
+    (133, 45) — `"hello"`, a named-arg value: expects `multi`,
+      activeParameter=1.
+
+  Line 134 (0-indexed): mixed — `multi(1 where b = "hello", c = false)`
+    (134, 36) — `"hello"`, named-arg value for `b`: expects `multi`,
+      activeParameter=1.
+    (134, 32) — `b`, a named-arg name: expects no signature help.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "signature_help/integration/named_arg"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "signature_help/signature_help.pony",
+      [ (133, 41, _SigHelpChecker(None))
+        (133, 45, _SigHelpChecker("multi", 1))
+        (134, 36, _SigHelpChecker("multi", 1))
+        (134, 32, _SigHelpChecker(None)) ])
+
+class val _SigHelpChecker
+  """
+  Validates a textDocument/signatureHelp response.
+  When expected_label_fragment is None, expects a null result (no call context).
+  Otherwise checks that signatures[0].label contains the fragment and that
+  activeParameter equals expected_active_param.
+
+  Optional: expected_doc_fragment checks that
+  signatures[0].documentation.value contains the given string.
+
+  Optional: expected_param_text checks that the byte offsets in
+  signatures[0].parameters[activeParameter].label point to text
+  in the label containing the given string.
+
+  Optional: expected_full_label asserts exact label equality, catching
+  regressions in capability, parentheses, parameter list, or return type.
+  """
+  let _expected_label_fragment: (String val | None)
+  let _expected_active_param: (I64 | None)
+  let _expected_doc_fragment: (String val | None)
+  let _expected_param_text: (String val | None)
+  let _expected_full_label: (String val | None)
+
+  new val create(
+    expected_label_fragment': (String val | None),
+    expected_active_param': (I64 | None) = 0,
+    expected_doc_fragment': (String val | None) = None,
+    expected_param_text': (String val | None) = None,
+    expected_full_label': (String val | None) = None)
+  =>
+    _expected_label_fragment = expected_label_fragment'
+    _expected_active_param = expected_active_param'
+    _expected_doc_fragment = expected_doc_fragment'
+    _expected_param_text = expected_param_text'
+    _expected_full_label = expected_full_label'
+
+  fun lsp_method(): String =>
+    Methods.text_document().signature_help()
+
+  fun lsp_range(): (None | (I64, I64, I64, I64)) =>
+    None
+
+  fun lsp_context(): (None | JsonObject) =>
+    None
+
+  fun lsp_extra_params(): (None | JsonObject) =>
+    None
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    var ok = true
+    match \exhaustive\ _expected_label_fragment
+    | None =>
+      // Expect no signatures (null result or empty signatures array)
+      try
+        let sigs = JsonNav(res.result)("signatures").as_array()?
+        if sigs.size() > 0 then
+          ok = false
+          h.log("Expected no signature help but got: " + res.string())
+        end
+      end
+    | let expected_label: String val =>
+      let sigs =
+        try JsonNav(res.result)("signatures").as_array()?
+        else
+          h.fail(
+            "signatureHelp response missing signatures[] for '" +
+            expected_label + "': " + res.string())
+          return false
+        end
+      if not h.assert_true(sigs.size() > 0, "Expected signatures array") then
+        return false
+      end
+      let label =
+        try JsonNav(sigs(0)?)("label").as_string()?
+        else
+          h.fail(
+            "signatureHelp response missing signatures[0].label for '" +
+            expected_label + "': " + res.string())
+          return false
+        end
+      if not h.assert_true(
+        label.contains(expected_label),
+        "Expected label to contain '" + expected_label + "', got: " + label)
+      then
+        ok = false
+      end
+      match \exhaustive\ _expected_full_label
+      | let full_label: String val =>
+        if not h.assert_eq[String](
+          full_label,
+          label,
+          "Expected exact label '" + full_label + "', got: " + label)
+        then
+          ok = false
+        end
+      | None => None
+      end
+      match \exhaustive\ _expected_active_param
+      | None =>
+        // Zero-param signature: activeParameter must be absent.
+        try
+          let unexpected_active =
+            JsonNav(res.result)("activeParameter").as_i64()?
+          if not h.assert_true(
+            false,
+            "Expected activeParameter absent for zero-param signature, got: " +
+            unexpected_active.string())
+          then
+            ok = false
+          end
+        end
+      | let expected_active: I64 =>
+        let active =
+          try JsonNav(res.result)("activeParameter").as_i64()?
+          else
+            h.fail(
+              "signatureHelp response missing activeParameter for '" +
+              expected_label + "': " + res.string())
+            return false
+          end
+        if not h.assert_eq[I64](
+          expected_active,
+          active,
+          "activeParameter: expected " + expected_active.string() +
+          ", got " + active.string())
+        then
+          ok = false
+        end
+      end
+      match \exhaustive\ _expected_doc_fragment
+      | let expected_doc: String val =>
+        try
+          let doc_val =
+            JsonNav(sigs(0)?)("documentation")("value").as_string()?
+          if not h.assert_true(
+            doc_val.contains(expected_doc),
+            "Expected doc to contain '" + expected_doc +
+            "', got: " + doc_val)
+          then
+            ok = false
+          end
+        else
+          ok = false
+          h.log("Expected documentation field in: " + res.string())
+        end
+      | None => None
+      end
+      match \exhaustive\ _expected_param_text
+      | let expected_text: String val =>
+        try
+          let params_arr =
+            JsonNav(sigs(0)?)("parameters").as_array()?
+          let active_idx =
+            JsonNav(res.result)("activeParameter").as_i64()?.usize()
+          let param_offsets =
+            JsonNav(params_arr(active_idx)?)("label").as_array()?
+          let p_start = JsonNav(param_offsets(0)?).as_i64()?
+          let p_end = JsonNav(param_offsets(1)?).as_i64()?
+          let param_text: String val =
+            label.substring(p_start.isize(), p_end.isize())
+          if not h.assert_true(
+            param_text.contains(expected_text),
+            "Expected param text to contain '" + expected_text +
+            "', got: '" + param_text + "'")
+          then
+            ok = false
+          end
+        else
+          ok = false
+          h.log(
+            "Expected parameter offsets for '" + expected_text +
+            "' in: " + res.string())
+        end
+      | None => None
+      end
+    end
+    ok

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -35,6 +35,7 @@ actor Main is TestList
     _FoldingRangeIntegrationTests.make().tests(test)
     _SelectionRangeIntegrationTests.make().tests(test)
     _WorkspaceSymbolIntegrationTests.make().tests(test)
+    _SignatureHelpIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/signature_help/signature_help.pony
+++ b/tools/pony-lsp/test/workspace/signature_help/signature_help.pony
@@ -1,0 +1,135 @@
+"""
+Test fixtures for exercising LSP signature help functionality.
+
+This module provides test cases for manual and automated testing of
+textDocument/signatureHelp provided by the Pony language server. Signature
+help shows a method's parameter list with the active parameter highlighted
+as you type arguments inside a call expression.
+
+To manually test signature help:
+1. Open the lsp/test/workspace directory as a project in your editor.
+2. Save this file to ensure the language server has compiled it.
+3. Open this file while the Pony language server is active.
+4. Place your cursor inside any of the call expressions in `_SigUser.apply`
+   and trigger signature help (typically via a keyboard shortcut or by typing
+   `(` or `,`).
+
+Expected signature help behaviour per call in `_SigUser.apply`:
+
+  `_SigTarget(0)` — constructor call
+    - Signature: `new create(v: U32)`
+    - Cursor on `0`: activeParameter=0, parameter `v: U32` highlighted
+
+  `_SigTarget(0).simple(42)` — single-parameter method with docstring
+    - Signature: `fun box simple(x: U32): U32`
+    - Cursor on `42`: activeParameter=0, parameter `x: U32` highlighted
+    - Documentation popup shows: "Returns x plus the stored value."
+
+  `_SigTarget(0).multi(1, "hello", true)` — multi-parameter method
+    - Signature: `fun box multi(a: U8, b: String val, c: Bool): None`
+    - Cursor on `1`: activeParameter=0, parameter `a: U8` highlighted
+    - Cursor on `"hello"`: activeParameter=1, `b: String val` highlighted
+    - Cursor on `true`: activeParameter=2, parameter `c: Bool` highlighted
+
+  `_SigTarget(0).no_args()` — zero-parameter method
+    - Signature: `fun box no_args(): U32`
+    - No parameter highlighted (empty parameters list)
+
+Note: because the server compiles on save (not on every keystroke), signature
+help reflects the last saved state of the file. The popup will not appear
+until the file has been saved at least once after opening.
+"""
+
+class _SigTarget
+  let _value: U32
+
+  new create(v: U32) =>
+    _value = v
+
+  fun box simple(x: U32): U32 =>
+    """
+    Returns x plus the stored value.
+    """
+    x + _value
+
+  fun box multi(a: U8, b: String val, c: Bool): None =>
+    None
+
+  fun box no_args(): U32 =>
+    _value
+
+class _SigUser
+  fun apply() =>
+    _SigTarget(0).simple(42)
+    _SigTarget(0).multi(1, "hello", true)
+    _SigTarget(0).no_args()
+    _SigTarget(0).multi( // a multi line call
+      1,
+      "hello",
+      true)
+    _SigTarget(_SigTarget(0).simple(1)).multi(2, "nested", false)
+
+actor _SigActor
+  be greet(name: String, count: U32) =>
+    None
+
+class _BeUser
+  """
+  Exercises signature help on a `be` (behaviour) call.
+
+  To test: place the cursor inside `a.greet("hello", 1)` and trigger
+  signature help (keyboard shortcut or type `(` or `,`).
+
+  Expected for `a.greet("hello", 1)`:
+    - Signature: `be greet(name: String val, count: U32 val)`
+    - Cursor on `"hello"`: activeParameter=0, `name: String val` highlighted
+    - Cursor on `1`: activeParameter=1, `count: U32 val` highlighted
+  """
+  fun apply(a: _SigActor tag) =>
+    a.greet("hello", 1)
+
+primitive _GenericSigPrimitive
+  fun box typed[T: Any val](x: T, y: T): T =>
+    x
+
+class _GenericSigUser
+  """
+  Exercises signature help on a generic method call with explicit type args.
+
+  To test: place the cursor on either `_n` inside
+  `_GenericSigPrimitive.typed[U32](_n, _n)` and trigger signature help.
+
+  Expected for `typed[U32](_n, _n)`:
+    - Signature: `fun box typed[T: Any val](x: T, y: T): T`
+    - Cursor on first `_n`: activeParameter=0, `x: T` highlighted
+    - Cursor on second `_n`: activeParameter=1, `y: T` highlighted
+  """
+  let _n: U32 = 1
+
+  fun apply() =>
+    _GenericSigPrimitive.typed[U32](_n, _n)
+
+class _NamedArgUser
+  """
+  Exercises signature help with named arguments (`where` syntax).
+
+  To test: place the cursor inside either call in `apply` and trigger
+  signature help.
+
+  After typecheck the compiler resolves named args into positional order, so
+  named-arg VALUES behave like positional args and get correct highlighting.
+  Named-arg NAMES (the identifiers before `=`) return no signature help.
+
+  Expected:
+    `_SigTarget(0).multi(where a = U8(1), b = "hello", c = false)`:
+      - Cursor on `b` (named-arg name): no signature help.
+      - Cursor on `"hello"` (value for `b`): activeParameter=1,
+        `b: String val` highlighted.
+    `_SigTarget(0).multi(1 where b = "hello", c = false)`:
+      - Cursor on `"hello"` (value for `b`): activeParameter=1,
+        `b: String val` highlighted.
+      - Cursor on `b` (named-arg name): no signature help.
+  """
+  fun apply() =>
+    _SigTarget(0).multi(where a = U8(1), b = "hello", c = false)
+    _SigTarget(0).multi(1 where b = "hello", c = false)

--- a/tools/pony-lsp/workspace/_type_formatter.pony
+++ b/tools/pony-lsp/workspace/_type_formatter.pony
@@ -1,0 +1,262 @@
+use ".."
+use "pony_compiler"
+
+primitive _TypeFormatter
+  """
+  Pure AST-to-string type formatting utilities shared across LSP features.
+  """
+
+  fun extract_type(type_node: AST box, channel: Channel): String =>
+    """
+    Extract type information from a type node.
+    """
+    let node_id = type_node.id()
+    match node_id
+    | TokenIds.tk_nominal() =>
+      // Nominal type
+      try
+        let num_children = type_node.num_children()
+        if num_children > 1 then
+          let type_id = type_node(1)?
+          let base_name =
+            if type_id.id() == TokenIds.tk_id() then
+              type_id.token_value() as String
+            else
+              extract_type(type_id, channel)
+            end
+
+          // Check for type arguments
+          let type_args_str =
+            match \exhaustive\
+              _find_child_by_type(
+                type_node,
+                TokenIds.tk_typeargs(),
+                2)
+            | let ta: AST box => _extract_typeargs(ta, channel)
+            | None => ""
+            end
+
+          // Check for capability
+          var capability_str: String = ""
+          var idx: USize = 2
+          while idx < num_children do
+            try
+              let child = type_node(idx)?
+              let cap = extract_capability(child.id())
+              if cap != "" then
+                capability_str = cap
+                break
+              end
+            end
+            idx = idx + 1
+          end
+
+          let cap_str =
+            if capability_str.size() > 0 then
+              " " + capability_str
+            else
+              ""
+            end
+          base_name + type_args_str + cap_str
+        else
+          "?"
+        end
+      else
+        "?"
+      end
+    | TokenIds.tk_typealiasref() =>
+      // Type alias reference: children are (id, typeargs, cap, eph)
+      try
+        let num_children = type_node.num_children()
+        let type_id = type_node(0)?
+        let base_name =
+          if type_id.id() == TokenIds.tk_id() then
+            type_id.token_value() as String
+          else
+            extract_type(type_id, channel)
+          end
+
+        // Check for type arguments at child(1)
+        let type_args_str =
+          match \exhaustive\
+            _find_child_by_type(
+              type_node,
+              TokenIds.tk_typeargs(),
+              1)
+          | let ta: AST box => _extract_typeargs(ta, channel)
+          | None => ""
+          end
+
+        // Check for capability starting at child(2)
+        var capability_str: String = ""
+        var idx: USize = 2
+        while idx < num_children do
+          try
+            let child = type_node(idx)?
+            let cap = extract_capability(child.id())
+            if cap != "" then
+              capability_str = cap
+              break
+            end
+          end
+          idx = idx + 1
+        end
+
+        let cap_str =
+          if capability_str.size() > 0 then
+            " " + capability_str
+          else
+            ""
+          end
+        base_name + type_args_str + cap_str
+      else
+        "?"
+      end
+    | TokenIds.tk_id() =>
+      // Direct ID node
+      try
+        type_node.token_value() as String
+      else
+        "?"
+      end
+    | TokenIds.tk_typeparamref() =>
+      // Type parameter reference
+      try
+        let child = type_node(0)?
+        if child.id() == TokenIds.tk_id() then
+          child.token_value() as String
+        else
+          type_node.token_value() as String
+        end
+      else
+        try
+          type_node.token_value() as String
+        else
+          "?"
+        end
+      end
+    | TokenIds.tk_uniontype() =>
+      // Union type: (Type1 | Type2 | Type3)
+      _extract_composite_type(type_node, " | ", channel)
+    | TokenIds.tk_isecttype() =>
+      // Intersection type
+      _extract_composite_type(type_node, " & ", channel)
+    | TokenIds.tk_tupletype() =>
+      // Tuple type: (Type1, Type2, Type3)
+      _extract_composite_type(type_node, ", ", channel)
+    | TokenIds.tk_arrow() =>
+      // Arrow type: left->right
+      try
+        let left_child = type_node(0)?
+        let left_cap = extract_capability(left_child.id())
+        let right = extract_type(type_node(1)?, channel)
+        if left_cap.size() > 0 then
+          left_cap + "->" + right
+        else
+          right
+        end
+      else
+        "?"
+      end
+    else
+      // For other type node types
+      TokenIds.string(node_id)
+    end
+
+  fun extract_capability(node_id: I32): String =>
+    """
+    Extract capability string from a capability token ID.
+    """
+    match node_id
+    | TokenIds.tk_iso() => "iso"
+    | TokenIds.tk_trn() => "trn"
+    | TokenIds.tk_ref() => "ref"
+    | TokenIds.tk_val() => "val"
+    | TokenIds.tk_box() => "box"
+    | TokenIds.tk_tag() => "tag"
+    else
+      ""
+    end
+
+  fun extract_type_params(
+    type_params: AST box,
+    channel: Channel): String
+  =>
+    """
+    Extract type parameters from typeparams node.
+    """
+    let type_param_strs = Array[String]
+    for type_param in type_params.children() do
+      try
+        let tp_id = type_param(0)?
+        if tp_id.id() == TokenIds.tk_id() then
+          let tp_name = tp_id.token_value() as String
+          let constraint =
+            try
+              let constraint_node = type_param(1)?
+              ": " + extract_type(constraint_node, channel)
+            else
+              ""
+            end
+          type_param_strs.push(tp_name + constraint)
+        end
+      end
+    end
+    if type_param_strs.size() > 0 then
+      "[" + ", ".join(type_param_strs.values()) + "]"
+    else
+      ""
+    end
+
+  fun _extract_typeargs(typeargs_node: AST box, channel: Channel): String =>
+    """
+    Extract type arguments from a tk_typeargs node.
+    """
+    let arg_strs = Array[String]
+    for arg in typeargs_node.children() do
+      arg_strs.push(extract_type(arg, channel))
+    end
+    if arg_strs.size() > 0 then
+      "[" + ", ".join(arg_strs.values()) + "]"
+    else
+      ""
+    end
+
+  fun _extract_composite_type(
+    type_node: AST box,
+    separator: String,
+    channel: Channel): String
+  =>
+    """
+    Extract composite types (union, intersection, tuple) by recursively
+    extracting children.
+    """
+    let type_strs = Array[String]
+    for child in type_node.children() do
+      type_strs.push(extract_type(child, channel))
+    end
+    if type_strs.size() > 0 then
+      "(" + separator.join(type_strs.values()) + ")"
+    else
+      "?"
+    end
+
+  fun _find_child_by_type(
+    ast: AST box,
+    token_id: I32,
+    start_index: USize = 0): (AST box | None)
+  =>
+    """
+    Search for a child node with a specific token type.
+    """
+    var idx = start_index
+    while idx < ast.num_children() do
+      try
+        let child = ast(idx)?
+        if child.id() == token_id then
+          return child
+        end
+      end
+      idx = idx + 1
+    end
+    None

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -205,9 +205,9 @@ primitive HoverFormatter
 
         // Extract type parameters
         let type_params_str =
-          match \exhaustive\ _find_child_by_type(
+          match \exhaustive\ _TypeFormatter._find_child_by_type(
             ast, TokenIds.tk_typeparams(), 1)
-          | let tp: AST box => _extract_type_params(tp, channel)
+          | let tp: AST box => _TypeFormatter.extract_type_params(tp, channel)
           | None => ""
           end
 
@@ -258,7 +258,7 @@ primitive HoverFormatter
       let receiver_cap =
         try
           let cap = ast(0)?
-          _extract_capability(cap.id())
+          _TypeFormatter.extract_capability(cap.id())
         else
           ""
         end
@@ -272,7 +272,7 @@ primitive HoverFormatter
           try
             let type_params = ast(2)?
             if type_params.id() == TokenIds.tk_typeparams() then
-              _extract_type_params(type_params, channel)
+              _TypeFormatter.extract_type_params(type_params, channel)
             else
               ""
             end
@@ -294,7 +294,7 @@ primitive HoverFormatter
           if (keyword == "fun") or (keyword == "be") then
             try
               let return_type = ast(4)?
-              ": " + _extract_type(return_type, channel)
+              ": " + _TypeFormatter.extract_type(return_type, channel)
             else
               ""
             end
@@ -360,7 +360,7 @@ primitive HoverFormatter
         let type_str =
           try
             let field_type = ast(1)?
-            ": " + _extract_type(field_type, channel)
+            ": " + _TypeFormatter.extract_type(field_type, channel)
           else
             ""
           end
@@ -404,7 +404,7 @@ primitive HoverFormatter
           try
             let var_type = ast(1)?
             if var_type.id() != TokenIds.tk_none() then
-              ": " + _extract_type(var_type, channel)
+              ": " + _TypeFormatter.extract_type(var_type, channel)
             else
               ""
             end
@@ -446,7 +446,7 @@ primitive HoverFormatter
           try
             let param_type = ast(1)?
             if param_type.id() != TokenIds.tk_none() then
-              ": " + _extract_type(param_type, channel)
+              ": " + _TypeFormatter.extract_type(param_type, channel)
             else
               ""
             end
@@ -582,7 +582,7 @@ primitive HoverFormatter
             let param_type =
               try
                 let ptype = param(1)?
-                ": " + _extract_type(ptype, channel)
+                ": " + _TypeFormatter.extract_type(ptype, channel)
               else
                 ""
               end
@@ -595,263 +595,9 @@ primitive HoverFormatter
       "()"
     end
 
-  fun tag _extract_type_params(
-    type_params: AST box,
-    channel: Channel): String
-  =>
-    """
-    Extract type parameters from typeparams node.
-    """
-    let type_param_strs = Array[String]
-    for type_param in type_params.children() do
-      try
-        let tp_id = type_param(0)?
-        if tp_id.id() == TokenIds.tk_id() then
-          let tp_name = tp_id.token_value() as String
-          let constraint =
-            try
-              let constraint_node = type_param(1)?
-              ": " + _extract_type(constraint_node, channel)
-            else
-              ""
-            end
-          type_param_strs.push(tp_name + constraint)
-        end
-      end
-    end
-    if type_param_strs.size() > 0 then
-      "[" + ", ".join(type_param_strs.values()) + "]"
-    else
-      ""
-    end
-
-  fun tag _extract_type(type_node: AST box, channel: Channel): String =>
-    """
-    Extract type information from a type node.
-    """
-    let node_id = type_node.id()
-    match node_id
-    | TokenIds.tk_nominal() =>
-      // Nominal type
-      try
-        let num_children = type_node.num_children()
-        if num_children > 1 then
-          let type_id = type_node(1)?
-          let base_name =
-            if type_id.id() == TokenIds.tk_id() then
-              type_id.token_value() as String
-            else
-              _extract_type(type_id, channel)
-            end
-
-          // Check for type arguments
-          let type_args_str =
-            match \exhaustive\
-              _find_child_by_type(
-                type_node,
-                TokenIds.tk_typeargs(),
-                2)
-            | let ta: AST box => _extract_typeargs(ta, channel)
-            | None => ""
-            end
-
-          // Check for capability
-          var capability_str: String = ""
-          var idx: USize = 2
-          while idx < num_children do
-            try
-              let child = type_node(idx)?
-              let cap = _extract_capability(child.id())
-              if cap != "" then
-                capability_str = cap
-                break
-              end
-            end
-            idx = idx + 1
-          end
-
-          let cap_str =
-            if capability_str.size() > 0 then
-              " " + capability_str
-            else
-              ""
-            end
-          base_name + type_args_str + cap_str
-        else
-          "?"
-        end
-      else
-        "?"
-      end
-    | TokenIds.tk_typealiasref() =>
-      // Type alias reference: children are (id, typeargs, cap, eph)
-      try
-        let num_children = type_node.num_children()
-        let type_id = type_node(0)?
-        let base_name =
-          if type_id.id() == TokenIds.tk_id() then
-            type_id.token_value() as String
-          else
-            _extract_type(type_id, channel)
-          end
-
-        // Check for type arguments at child(1)
-        let type_args_str =
-          match \exhaustive\
-            _find_child_by_type(
-              type_node,
-              TokenIds.tk_typeargs(),
-              1)
-          | let ta: AST box => _extract_typeargs(ta, channel)
-          | None => ""
-          end
-
-        // Check for capability starting at child(2)
-        var capability_str: String = ""
-        var idx: USize = 2
-        while idx < num_children do
-          try
-            let child = type_node(idx)?
-            let cap = _extract_capability(child.id())
-            if cap != "" then
-              capability_str = cap
-              break
-            end
-          end
-          idx = idx + 1
-        end
-
-        let cap_str =
-          if capability_str.size() > 0 then
-            " " + capability_str
-          else
-            ""
-          end
-        base_name + type_args_str + cap_str
-      else
-        "?"
-      end
-    | TokenIds.tk_id() =>
-      // Direct ID node
-      try
-        type_node.token_value() as String
-      else
-        "?"
-      end
-    | TokenIds.tk_typeparamref() =>
-      // Type parameter reference
-      try
-        let child = type_node(0)?
-        if child.id() == TokenIds.tk_id() then
-          child.token_value() as String
-        else
-          type_node.token_value() as String
-        end
-      else
-        try
-          type_node.token_value() as String
-        else
-          "?"
-        end
-      end
-    | TokenIds.tk_uniontype() =>
-      // Union type: (Type1 | Type2 | Type3)
-      _extract_composite_type(type_node, " | ", channel)
-    | TokenIds.tk_isecttype() =>
-      // Intersection type
-      _extract_composite_type(type_node, " & ", channel)
-    | TokenIds.tk_tupletype() =>
-      // Tuple type: (Type1, Type2, Type3)
-      _extract_composite_type(type_node, ", ", channel)
-    | TokenIds.tk_arrow() =>
-      // Arrow type: left->right
-      try
-        let left_child = type_node(0)?
-        let left_cap = _extract_capability(left_child.id())
-        let right = _extract_type(type_node(1)?, channel)
-        if left_cap.size() > 0 then
-          left_cap + "->" + right
-        else
-          right
-        end
-      else
-        "?"
-      end
-    else
-      // For other type node types
-      TokenIds.string(node_id)
-    end
-
-  fun tag _extract_capability(node_id: I32): String =>
-    """
-    Extract capability string from a capability token ID.
-    """
-    match node_id
-    | TokenIds.tk_iso() => "iso"
-    | TokenIds.tk_trn() => "trn"
-    | TokenIds.tk_ref() => "ref"
-    | TokenIds.tk_val() => "val"
-    | TokenIds.tk_box() => "box"
-    | TokenIds.tk_tag() => "tag"
-    else
-      ""
-    end
-
-  fun tag _extract_typeargs(typeargs_node: AST box, channel: Channel): String =>
-    """
-    Extract type arguments from a tk_typeargs node.
-    """
-    let arg_strs = Array[String]
-    for arg in typeargs_node.children() do
-      arg_strs.push(_extract_type(arg, channel))
-    end
-    if arg_strs.size() > 0 then
-      "[" + ", ".join(arg_strs.values()) + "]"
-    else
-      ""
-    end
-
-  fun tag _extract_composite_type(
-    type_node: AST box,
-    separator: String,
-    channel: Channel): String
-  =>
-    """
-    Extract composite types (union, intersection,
-    tuple) by recursively extracting children.
-    """
-    let type_strs = Array[String]
-    for child in type_node.children() do
-      type_strs.push(_extract_type(child, channel))
-    end
-    if type_strs.size() > 0 then
-      "(" + separator.join(type_strs.values()) + ")"
-    else
-      "?"
-    end
-
   fun tag _wrap_code_block(content: String): String =>
     """
     Wrap content in a Pony code block for markdown formatting.
     """
     "```pony\n" + content + "\n```"
 
-  fun tag _find_child_by_type(
-    ast: AST box,
-    token_id: I32,
-    start_index: USize = 0
-  ): (AST box | None) =>
-    """
-    Search for a child node with a specific token type.
-    """
-    var idx = start_index
-    while idx < ast.num_children() do
-      try
-        let child = ast(idx)?
-        if child.id() == token_id then
-          return child
-        end
-      end
-      idx = idx + 1
-    end
-    None

--- a/tools/pony-lsp/workspace/signature_help.pony
+++ b/tools/pony-lsp/workspace/signature_help.pony
@@ -1,0 +1,319 @@
+use ".."
+use "pony_compiler"
+use "json"
+
+primitive SignatureHelp
+  """
+  Resolves signature help (parameter hints) for a call expression under
+  the cursor.  Walks up from the cursor node to find the enclosing
+  tk_call, resolves the callee to its definition, extracts per-parameter
+  information, and returns the LSP SignatureHelp JSON object.
+  """
+
+  fun collect(
+    node: AST box,
+    cursor_line: USize,
+    cursor_col: USize,
+    channel: Channel): (JsonObject | None)
+  =>
+    match \exhaustive\ _find_enclosing_call(node, cursor_line, cursor_col)
+    | (_, let callee: AST box, let active_param: USize) =>
+      try
+        // After typecheck, expr_qualify transforms
+        // TK_QUALIFY(inner_funref, TK_TYPEARGS) into a node with the same ID
+        // as the inner ref (e.g. TK_FUNREF) but retaining the original
+        // children: child(0) = inner funref, child(1) = TK_TYPEARGS.
+        // definitions() on the outer node fails because it sees a funref
+        // child where it expects a receiver expression. Detect this by
+        // checking whether child(0) is itself a function reference.
+        let resolved_callee: AST box =
+          try
+            let c = callee(0)?
+            let cid = c.id()
+            if (cid == TokenIds.tk_funref()) or
+              (cid == TokenIds.tk_beref()) or
+              (cid == TokenIds.tk_newref()) or
+              (cid == TokenIds.tk_newberef())
+            then
+              c
+            else
+              callee
+            end
+          else
+            callee
+          end
+        let defs = resolved_callee.definitions()
+        if defs.size() == 0 then
+          return None
+        end
+        let def = defs(0)?
+
+        let keyword: String val =
+          match def.id()
+          | TokenIds.tk_fun() => "fun"
+          | TokenIds.tk_be() => "be"
+          | TokenIds.tk_new() => "new"
+          else
+            return None
+          end
+
+        let param_strs: Array[String] =
+          try
+            _extract_param_list(def(3)?, channel)
+          else
+            Array[String]
+          end
+
+        (let label, let offsets) =
+          _build_label(def, keyword, param_strs, channel)
+
+        var params_json = JsonArray
+        for (p_start, p_end) in offsets.values() do
+          params_json =
+            params_json.push(
+              JsonObject.update(
+                "label",
+                JsonArray
+                  .push(I64.from[USize](p_start))
+                  .push(I64.from[USize](p_end))))
+        end
+
+        let base_sig = JsonObject
+          .update("label", label)
+          .update("parameters", params_json)
+
+        let sig =
+          try
+            let doc_node = def(7)?
+            if doc_node.id() == TokenIds.tk_string() then
+              let docstring = doc_node.token_value() as String
+              if docstring.size() > 0 then
+                base_sig.update(
+                  "documentation",
+                  JsonObject
+                    .update("kind", "markdown")
+                    .update("value", docstring))
+              else
+                base_sig
+              end
+            else
+              base_sig
+            end
+          else
+            base_sig
+          end
+
+        // Omit activeParameter for zero-param signatures: index 0 into an
+        // empty parameters array is out of range per LSP 3.17 spec.
+        let base_result = JsonObject
+          .update("signatures", JsonArray.push(sig))
+          .update("activeSignature", I64(0))
+        if param_strs.size() > 0 then
+          base_result.update("activeParameter", I64.from[USize](active_param))
+        else
+          base_result
+        end
+      else
+        None
+      end
+    | None =>
+      None
+    end
+
+  fun _find_enclosing_call(
+    node: AST box,
+    cursor_line: USize,
+    cursor_col: USize): ((AST box, AST box, USize) | None)
+  =>
+    """
+    Walks up the AST from `node` looking for the innermost tk_call whose
+    argument list contains the cursor.  Returns (call_node, callee_ref,
+    active_param_index) on success.
+
+    When a tk_call is encountered that does not contain the cursor in its
+    argument list, it is skipped and the walk continues upward — this lets
+    a position on the callee of an inner call still resolve to the
+    surrounding outer call's signature.
+
+    Two skip conditions:
+    - Callee check: arrived via child(0) of tk_call and the call has args —
+      cursor is on the callee expression, not inside the arg list.  For
+      zero-arg calls the cursor is on the callee by definition, so the
+      signature is returned immediately.
+    - Position gate: cursor is on the same line as the first arg but before
+      it (i.e. at the open paren of a same-line call).
+
+    Named arguments: after typecheck the compiler resolves named args into
+    positional order, so named-arg values are indistinguishable from
+    positional args in the AST and activeParameter is reported correctly.
+    Named-arg name tokens (the identifiers before `=`) are not part of any
+    arg slot; find_node_at returns None for them and no signature is shown.
+    """
+    var current: AST box = node
+    var pos_arg_child: (AST box | None) = None
+
+    while true do
+      match current.parent()
+      | let parent: AST box =>
+        let pid = parent.id()
+        if pid == TokenIds.tk_positionalargs() then
+          pos_arg_child = current
+        elseif pid == TokenIds.tk_call() then
+          let from_callee: Bool =
+            try current == parent(0)? else false end
+
+          if from_callee then
+            // Zero-arg call: cursor is naturally on the callee — show sig.
+            let is_zero_args: Bool =
+              try parent(1)?.child() is None else true end
+            if is_zero_args then
+              try
+                return (parent, parent(0)?, 0)
+              end
+              break
+            end
+            // Has args and cursor is on the callee — skip this call.
+            pos_arg_child = None
+          else
+            // Check position gate: cursor before first arg on same line.
+            let before_first_arg: Bool =
+              try
+                let first_seq = parent(1)?.child() as AST box
+                let first_arg = first_seq.child() as AST box
+                // Use span() so complex first args (e.g. a method call
+                // whose AST node sits at the dot, not at the leftmost
+                // token) are correctly bounded.
+                (let arg_start, _) = first_arg.span()
+                (cursor_line == arg_start.line()) and
+                  (cursor_col < arg_start.column())
+              else
+                false
+              end
+
+            if before_first_arg then
+              // Cursor is at the open paren — skip this call.
+              pos_arg_child = None
+            else
+              let active: USize =
+                match \exhaustive\ pos_arg_child
+                | let fc: AST box =>
+                  try
+                    let args = parent(1)?
+                    var idx: USize = 0
+                    for arg in args.children() do
+                      if arg == fc then break end
+                      idx = idx + 1
+                    end
+                    idx
+                  else
+                    0
+                  end
+                | None => 0
+                end
+              try
+                return (parent, parent(0)?, active)
+              end
+              break
+            end
+          end
+        end
+        current = parent
+      else
+        break
+      end
+    end
+    None
+
+  fun _extract_param_list(params: AST box, channel: Channel): Array[String] =>
+    """
+    Returns one string per parameter in the form "name: Type".
+    """
+    let result = Array[String]
+    if params.id() == TokenIds.tk_params() then
+      for param in params.children() do
+        try
+          let pid = param(0)?
+          if pid.id() == TokenIds.tk_id() then
+            let name = pid.token_value() as String
+            let type_str =
+              try
+                let ptype = param(1)?
+                if ptype.id() != TokenIds.tk_none() then
+                  ": " + _TypeFormatter.extract_type(ptype, channel)
+                else
+                  ""
+                end
+              else
+                ""
+              end
+            result.push(name + type_str)
+          end
+        end
+      end
+    end
+    result
+
+  fun _build_label(
+    def: AST box,
+    keyword: String val,
+    param_strs: Array[String] box,
+    channel: Channel): (String, Array[(USize, USize)])
+  =>
+    """
+    Builds the full signature label string and computes per-parameter
+    byte-offset pairs [start, end) into that string.
+    Uses string concatenation (not mutation) so the label is String val.
+    """
+    let offsets = Array[(USize, USize)]
+
+    // Build prefix via concatenation so the result is String iso^ -> val
+    var label: String val = keyword
+    try
+      let cap = _TypeFormatter.extract_capability(def(0)?.id())
+      if cap.size() > 0 then
+        label = label + " " + cap
+      end
+    end
+    label = label + " "
+    try
+      let name_node = def(1)?
+      if name_node.id() == TokenIds.tk_id() then
+        label = label + (name_node.token_value() as String)
+      end
+    end
+    try
+      let tp = def(2)?
+      if tp.id() == TokenIds.tk_typeparams() then
+        label = label + _TypeFormatter.extract_type_params(tp, channel)
+      end
+    end
+    label = label + "("
+    // Offsets are byte positions into `label`. LSP 3.17 specifies parameter
+    // label offsets in the negotiated encoding (default: UTF-16 code units).
+    // Pony identifiers and type names are ASCII-only, so byte offsets and
+    // UTF-16 code unit offsets are equivalent. If non-ASCII ever appears in
+    // a label (e.g. a unicode identifier), these offsets would be wrong.
+    var first = true
+    for param_str in param_strs.values() do
+      let sep: String val =
+        if first then
+          ""
+        else
+          ", "
+        end
+      first = false
+      let start: USize = label.size() + sep.size()
+      label = label + sep + param_str
+      offsets.push((start, label.size()))
+    end
+    label = label + ")"
+    if (keyword == "fun") or (keyword == "be") then
+      try
+        let rt = def(4)?
+        let rt_str = _TypeFormatter.extract_type(rt, channel)
+        if rt_str.size() > 0 then
+          label = label + ": " + rt_str
+        end
+      end
+    end
+    (label, offsets)

--- a/tools/pony-lsp/workspace/signature_help_source.pony
+++ b/tools/pony-lsp/workspace/signature_help_source.pony
@@ -1,0 +1,67 @@
+primitive SignatureHelpSource
+  """
+  Pure source-text operations for signature help.
+  All functions operate on raw String content and integer positions.
+  """
+
+  fun scan_to_token(
+    src: String box,
+    start_line: USize,
+    start_col: USize): (USize, USize)
+  =>
+    """
+    Advances through src from (start_line, start_col) (both 1-based),
+    skipping whitespace, commas, and line comments (`//`), and returns
+    the (line, col) of the first non-skipped character.  Used to jump
+    over the space after a trigger character (`,` or `(`) to reach the
+    next real token so that `find_node_at` can be called exactly once.
+    """
+    var byte_offset: USize = 0
+    var cur_line: USize = 1
+    // Advance byte_offset to the start of start_line.
+    while (cur_line < start_line) and (byte_offset < src.size()) do
+      try
+        if src(byte_offset)? == '\n' then
+          cur_line = cur_line + 1
+        end
+      end
+      byte_offset = byte_offset + 1
+    end
+    // Advance to the cursor column (1-based → skip start_col-1 bytes).
+    byte_offset = byte_offset + (start_col - 1)
+    // Scan forward, skipping whitespace, commas, and line comments.
+    var scan_line: USize = start_line
+    var scan_col: USize = start_col
+    while byte_offset < src.size() do
+      try
+        let ch = src(byte_offset)?
+        if ch == '\n' then
+          scan_line = scan_line + 1
+          scan_col = 1
+          byte_offset = byte_offset + 1
+        elseif (ch == ' ') or (ch == '\t') or (ch == '\r') or (ch == ',') then
+          scan_col = scan_col + 1
+          byte_offset = byte_offset + 1
+        elseif
+          (ch == '/') and (try src(byte_offset + 1)? == '/' else false end)
+        then
+          // Line comment: advance to the '\n' so the outer loop handles it.
+          byte_offset = byte_offset + 1
+          scan_col = scan_col + 1
+          while byte_offset < src.size() do
+            try
+              if src(byte_offset)? == '\n' then break end
+              byte_offset = byte_offset + 1
+              scan_col = scan_col + 1
+            else
+              break
+            end
+          end
+        else
+          break
+        end
+      else
+        break
+      end
+    end
+    (scan_line, scan_col)

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -508,21 +508,32 @@ actor WorkspaceManager
     Returns None if the document or package is not found,
     or no node exists at that position.
     """
+    match _get_index_and_module(document_path)
+    | (let index: PositionIndex val, let module: Module val) =>
+      match index.find_node_at(
+        USize.from[I64](line + 1),
+        USize.from[I64](column + 1))
+      | let node: AST box => (node, module)
+      end
+    end
+
+  fun ref _get_index_and_module(
+    document_path: String): ((PositionIndex val, Module val) | None)
+  =>
+    """
+    Returns the position index and compiled module for the given document
+    path, or None if the document is not in any workspace, has not yet
+    been compiled, or its index is not yet available.
+    """
     try
       let package: FilePath = this._find_workspace_package(document_path)?
-
       match \exhaustive\ this._get_package(package)
       | let pkg_state: PackageState =>
         match \exhaustive\ pkg_state.get_document(document_path)
         | let doc: DocumentState =>
           match (doc.position_index(), doc.module())
-          | (let index: PositionIndex, let module: Module val) =>
-            match \exhaustive\ index.find_node_at(
-              USize.from[I64](line + 1),
-              USize.from[I64](column + 1))
-            | let node: AST box => (node, module)
-            | None => None
-            end
+          | (let index: PositionIndex val, let module: Module val) =>
+            (index, module)
           else
             this._channel.log(
               "No index or module available for " + document_path)
@@ -1107,6 +1118,46 @@ actor WorkspaceManager
       return
     end
     this._channel.send(ResponseMessage(request.id, out))
+
+  be signature_help(document_uri: String, request: RequestMessage val) =>
+    """
+    Handle textDocument/signatureHelp request.
+    """
+    this._channel.log("Handling textDocument/signatureHelp")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let document_path = Uris.to_path(document_uri)
+    // Convert LSP 0-based cursor to 1-based AST coordinates.
+    let cursor_line = USize.from[I64](line + 1)
+    let cursor_col  = USize.from[I64](column + 1)
+    match _get_index_and_module(document_path)
+    | (let index: PositionIndex val, let module: Module val) =>
+      // Scan the source text forward from the cursor, skipping whitespace
+      // and commas, to find the next real token.  This handles the case
+      // where the cursor is on a separator character or trailing whitespace
+      // where no AST node exists — without magic column limits.
+      (let tok_line, let tok_col) =
+        match \exhaustive\ module.ast.source_contents()
+        | let src: String box =>
+          SignatureHelpSource.scan_to_token(src, cursor_line, cursor_col)
+        | None =>
+          (cursor_line, cursor_col)
+        end
+      match index.find_node_at(tok_line, tok_col)
+      | let node: AST box =>
+        match \exhaustive\ SignatureHelp.collect(
+          node, tok_line, tok_col, this._channel)
+        | let result: JsonObject =>
+          this._channel.send(ResponseMessage(request.id, result))
+          return
+        | None => None
+        end
+      end
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
 
   be dispose() =>
     for package_state in this._packages.values() do


### PR DESCRIPTION
## Context

The Pony language server does not currently provide signature help (parameter hints). Editors trigger this feature when the user types `(` or `,` inside a call expression, showing the method signature with the active parameter highlighted. Docstrings are shown alongside the signature when present.

## Changes

- Implements `textDocument/signatureHelp` — walks the AST from the cursor to find the enclosing call, resolves the callee to its definition, and builds an LSP `SignatureHelp` response with per-parameter character offsets
- Extracts shared type-formatting logic from `hover.pony` into a new `_TypeFormatter` primitive used by both hover and signature help
- Uses `_scan_to_token` to read raw source text forward from the cursor, skipping whitespace, commas, and `//` line comments, then calls `find_node_at` exactly once — avoiding the need for magic column limits
- Adds `_get_index_and_module` as the shared document lookup helper; `_find_node_and_module` now delegates to it, eliminating duplicated traversal logic
- Adds 24 integration tests covering: constructor calls, single/multi-param methods, zero-arg methods, behaviours, docstring population, cursor-on-callee (no hint), cursor-at-`(` (no hint), after-comma, multiline calls with trailing comments, and nested calls

Resolves #5173

## Considerations

- Cursor at `(` and cursor on the callee both return no signature. This matches the position-gate and callee-skip logic in `_find_enclosing_call`: the cursor is not yet inside the argument list, so there is no active parameter to highlight. Editors typically re-trigger on the next keystroke once the user begins typing an argument.