### PR TITLE
Harden _LspTestServer: request-id safety and file-open ordering

### DIFF
--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -6,10 +6,17 @@ use "collections"
 
 actor _LspTestServer is Channel
   """
-  Shared LSP server for integration tests. Initializes and compiles the
-  workspace once, then dispatches individual requests to each test's TestHelper.
+  Test-local LSP server for integration tests. Each suite creates its own
+  instance so that workspace compilation happens independently per suite.
   The response checker supplied with each request handles method-specific
   dispatch and validation.
+
+  Readiness gate: the server buffers all incoming requests in `_pending` until
+  the first `textDocument/publishDiagnostics` notification arrives, which
+  signals that the initial workspace compilation is done. Only then are pending
+  requests dispatched (and any new requests dispatched immediately). The server
+  always sends `publishDiagnostics` after compilation, even for a clean build
+  (with an empty diagnostics array).
   """
   let _workspace_dir: String
   var _server: (BaseProtocol | None)
@@ -28,7 +35,9 @@ actor _LspTestServer is Channel
     _pending = Array[_PendingRequest]
     _opened = Set[String]
     _in_flight = Map[I64, _PendingRequest]
-    _next_id = 2
+    // id 0 = initialize request; ids 1-99 reserved for server-originated
+    // requests (e.g. client/registerCapability, workspace/configuration).
+    _next_id = 100
 
   be request(
     h: TestHelper,
@@ -107,15 +116,21 @@ actor _LspTestServer is Channel
         if RequestIds.eq(id, I64(0)) then
           try (_server as BaseProtocol)(LspMsg.initialized()) end
         else
-          try
-            let id_i64 = id as I64
-            (_, let pending) = _in_flight.remove(id_i64)?
-            let action = pending.pos.action()
-            if pending.checker.check(res, pending.h) then
-              pending.h.complete_action(action)
+          match \exhaustive\ id
+          | let id_i64: I64 =>
+            try
+              (_, let pending) = _in_flight.remove(id_i64)?
+              let action = pending.pos.action()
+              if pending.checker.check(res, pending.h) then
+                pending.h.complete_action(action)
+              else
+                pending.h.fail_action(action)
+              end
             else
-              pending.h.fail_action(action)
+              _fail_all_in_flight()
             end
+          | let _: String =>
+            _fail_all_in_flight()
           end
         end
       end
@@ -137,12 +152,22 @@ actor _LspTestServer is Channel
         if not _ready then
           _ready = true
           for p in _pending.values() do
+            if not _opened.contains(p.file_path) then
+              _opened.set(p.file_path)
+              _did_open(p.file_path)
+            end
             _dispatch(p)
           end
           _pending.clear()
         end
       end
     end
+
+  fun ref _fail_all_in_flight() =>
+    for (_, p) in _in_flight.pairs() do
+      p.h.fail_action(p.pos.action())
+    end
+    _in_flight.clear()
 
   fun ref _did_open(file_path: String) =>
     try


### PR DESCRIPTION
## Context

`_LspTestServer` is the shared actor that drives all pony-lsp integration tests. It maintains two maps — `_pending` (buffered before the workspace is ready) and `_in_flight` (dispatched, awaiting a response) — and drives the LSP protocol lifecycle.

Three latent issues exist in the current implementation:

1. **Request-id overlap.** `_next_id` starts at `2`, which overlaps the id space the language server uses for its own outgoing requests (e.g. `workspace/configuration`). If a server-originated request id collides with a test request id, the response is misrouted.

2. **Silent response-id failure.** The `send` behaviour casts incoming response ids with `id as I64` inside a bare `try … end`. `RequestId` is `(I64 | String)`; a String id causes the cast to fail and the `try` block to exit silently — the test action is never completed or failed, so `pony_test` waits for the full 10 s timeout with no diagnostic output.

3. **Files dispatched before `didOpen`.** When `publishDiagnostics` fires and pending requests are flushed, the code dispatches each request without first checking whether the file has been opened. The `workspace/configuration` branch already has this guard; the `publishDiagnostics` branch is missing it.

## Changes

- **Reserve ids 1–99 for server-originated messages.** `_next_id` now starts at `100`. Id `0` is the `initialize` request; ids `1`–`99` are reserved for any server-side request (e.g. `client/registerCapability`, `workspace/configuration`), eliminating the overlap.

- **Replace the silent try-cast with an explicit match.** The `id as I64` partial cast is replaced with a `match id` on the `(I64 | String)` union. An unknown id or a String id now calls `_fail_all_in_flight()`, immediately failing all in-flight test actions with a visible error instead of hanging.

- **Mirror the `_did_open` guard into the `publishDiagnostics` dispatch loop.** Before dispatching each pending request on readiness, the code now checks `_opened.contains(p.file_path)` and calls `_did_open` if needed — matching the behaviour already present in the `workspace/configuration` branch.

- **Extract `_fail_all_in_flight()`.** The "fail every in-flight request and clear the map" pattern is factored into a helper used by both the String-id and unknown-id branches.

## Considerations

When a response arrives for an id not in `_in_flight`, all in-flight tests are failed rather than just the one that triggered the issue. This is intentional: at that point the server state is unknown, and silently continuing would risk masking further failures or producing misleading passes.