### PR TITLE
Fix linking failures on Fedora and other RPM-based distributions

### DIFF
--- a/.release-notes/fix-fedora-lib64-crt-search.md
+++ b/.release-notes/fix-fedora-lib64-crt-search.md
@@ -1,0 +1,10 @@
+## Fix linking failures on Fedora and other RPM-based distributions
+
+Starting with ponyc 0.61.1, attempting to link a Pony program on Fedora (and other RPM-based distributions such as RHEL, CentOS, Rocky, and openSUSE) failed with:
+
+```
+Error:
+could not find libc CRT objects in sysroot ''
+```
+
+ponyc now locates the C runtime startup objects on these distributions, and linking succeeds.

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -381,7 +381,10 @@ static const char* find_libc_crt_dir(const char* sysroot,
   const char* sys_triple)
 {
   // Search candidate paths for libc CRT objects (crt1.o).
-  const char* candidates[4];
+  // The lib64 candidates cover Fedora, RHEL, and other distros that
+  // place 64-bit libc startup objects in /usr/lib64 rather than
+  // /usr/lib/<triple> or /usr/lib.
+  const char* candidates[6];
   char buf[PATH_MAX];
 
   snprintf(buf, sizeof(buf), "%s/usr/lib/%s", sysroot, sys_triple);
@@ -396,7 +399,13 @@ static const char* find_libc_crt_dir(const char* sysroot,
   snprintf(buf, sizeof(buf), "%s/lib", sysroot);
   candidates[3] = stringtab(buf);
 
-  for(int i = 0; i < 4; i++)
+  snprintf(buf, sizeof(buf), "%s/usr/lib64", sysroot);
+  candidates[4] = stringtab(buf);
+
+  snprintf(buf, sizeof(buf), "%s/lib64", sysroot);
+  candidates[5] = stringtab(buf);
+
+  for(size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
   {
     snprintf(buf, sizeof(buf), "%s/crt1.o", candidates[i]);
     if(file_exists(buf))
@@ -597,11 +606,14 @@ static const char* resolve_sysroot(compile_t* c, const char* sys_triple,
 
     errorf(errors, NULL,
       "sysroot '%s' does not contain libc CRT objects (crt1.o)\n"
-      "  Searched: %s/usr/lib/%s/, %s/usr/lib/, %s/lib/%s/, %s/lib/",
+      "  Searched: %s/usr/lib/%s/, %s/usr/lib/, %s/lib/%s/, %s/lib/,\n"
+      "            %s/usr/lib64/, %s/lib64/",
       c->opt->sysroot,
       c->opt->sysroot, sys_triple,
       c->opt->sysroot,
       c->opt->sysroot, sys_triple,
+      c->opt->sysroot,
+      c->opt->sysroot,
       c->opt->sysroot);
     return NULL;
   }


### PR DESCRIPTION
ponyc 0.61.1 introduced an embedded LLD that took over CRT discovery. The pre-link search in `find_libc_crt_dir` only covered Debian/Ubuntu locations, so on Fedora and other RPM-based distros (RHEL, CentOS, Rocky, openSUSE) `crt1.o` (which lives in `/usr/lib64`) went unfound and linking failed with `could not find libc CRT objects in sysroot ''`.

Adds `/usr/lib64` and `/lib64` to the candidate list and updates the matching error message in `resolve_sysroot`.

Verified empirically by building ponyc from source on Fedora 43 and successfully compiling + linking a hello-world Pony program. Reported on Zulip: [Fedora issues after 0.63.x](https://ponylang.zulipchat.com/#narrow/channel/189985-beginner-help/topic/Fedora.20issues.20after.200.2E63.2Ex).

A follow-up issue (#5261) tracks a related multilib edge case (wrong-arch `crt1.o` selection on hosts with `glibc-devel.i686` installed) — out of scope for this PR.