### PR TITLE
Fix building ponyc from source on Fedora and other RPM-based distributions

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/Dockerfile
@@ -1,0 +1,36 @@
+FROM fedora:43
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+RUN dnf install -y \
+      binutils-gold \
+      clang \
+      cmake \
+      compiler-rt \
+      curl \
+      diffutils \
+      findutils \
+      gcc \
+      gcc-c++ \
+      git \
+      libatomic \
+      libstdc++-static \
+      lldb \
+      make \
+      python3-lldb \
+      python3-pip \
+      systemtap-sdt-devel \
+      wget \
+      which \
+      xz \
+      zlib-devel \
+ && dnf clean all \
+ && pip3 install --break-system-packages cloudsmith-cli
+
+# needed for GitHub actions
+RUN git config --global --add safe.directory /__w/ponyc/ponyc
+
+# add user pony in order to not run tests as root
+RUN useradd -u 1001 -ms /bin/bash -d /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker push "${NAME}:${TODAY}"

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -17,6 +17,7 @@ on:
           - cross-riscv64
           - ubuntu26.04-builder
           - x86-64-unknown-linux-alpine3.21-builder
+          - x86-64-unknown-linux-fedora43-builder
           - x86-64-unknown-linux-ubuntu22.04-builder
           - x86-64-unknown-linux-ubuntu24.04-builder
 
@@ -230,6 +231,29 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/x86-64-unknown-linux-alpine3.21-builder/build-and-push.bash
+
+  x86-64-unknown-linux-fedora43-builder:
+    if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-fedora43-builder' }}
+    runs-on: ubuntu-latest
+
+    name: x86-64-unknown-linux-fedora43-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/build-and-push.bash
 
   x86-64-unknown-linux-ubuntu22_04-builder:
     if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-ubuntu22.04-builder' }}

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -237,6 +237,61 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  x86_64-linux-fedora:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+
+    name: x86-64 Linux Fedora
+    container:
+      image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427
+      options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j8
+      - name: Build Debug Runtime
+        run: |
+          make configure arch=x86-64 config=debug
+          make build config=debug
+      - name: Test with Debug Runtime
+        run: make test-ci-core config=debug
+      - name: Build Release Runtime
+        run: |
+          make configure arch=x86-64 config=release
+          make build config=release
+      - name: Test with Release Runtime
+        run: make test-ci-core config=release
+      - name: Test pony-doc
+        run: make test-pony-doc config=debug
+      - name: Test pony-lint
+        run: make test-pony-lint config=debug
+      - name: Test pony-lsp
+        run: make test-pony-lsp config=debug
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   x86_64-macos:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -23,6 +23,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
           - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425

--- a/.release-notes/fix-fedora-build-from-source.md
+++ b/.release-notes/fix-fedora-build-from-source.md
@@ -1,0 +1,11 @@
+## Fix building ponyc from source on Fedora and other RPM-based distributions
+
+Building ponyc from source on Fedora (and other RPM-based distributions such as RHEL, CentOS, Rocky, and openSUSE) failed during the link of `pony-lsp` and `pony-lint`:
+
+```
+Error:
+unable to link: ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC
+>>> defined in build/release/libponyc-standalone.a(...)
+```
+
+ponyc now builds successfully on these platforms.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -132,7 +132,12 @@ message("Building targets: ${LLVM_TARGETS_TO_BUILD}")
 
 set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_OCAMLDOC OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
-set(LLVM_ENABLE_PIC OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
+# Historically disabled on macOS to fix an LLVM build failure there. On
+# other platforms keep LLVM's default (ON) so PIE-default distributions
+# can link the resulting static libs into pony-lsp and pony-lint.
+if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
+    set(LLVM_ENABLE_PIC OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
+endif()
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_WARNINGS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_Z3_SOLVER OFF CACHE BOOL "ponyc specific override of LLVM cache entry")


### PR DESCRIPTION
Building ponyc from source on Fedora (and other RPM-based distributions) failed during the link of `pony-lsp` and `pony-lint`:

```
Error:
unable to link: ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in build/release/libponyc-standalone.a(...)
```

The vendored LLVM static libraries were built without position-independent code, which conflicts with the position-independent executable link these distributions perform by default. The PIC override was originally added in 2020 to work around a macOS LLVM build failure (#3504); this scopes that workaround to Apple platforms and lets non-Apple builds use LLVM's default (PIC enabled).

Stacked on top of #5262 (libc CRT search fix). Will be rebased onto `main` once #5262 merges.

## Files

- `lib/CMakeLists.txt` — scope `LLVM_ENABLE_PIC OFF` to `if(APPLE)`. On non-Apple platforms, LLVM's default (PIC ON) applies.
- `.release-notes/fix-fedora-build-from-source.md` — release note.
- `.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/` (new) and the corresponding entries in `.github/workflows/build-builder-image.yml`, `.github/workflows/pr-ponyc.yml`, and `.github/workflows/update-lib-cache.yml` — Fedora 43 added to tier 1 PR validation so this class of regression is caught in CI.

The Fedora PR-validation job verified the failure before the fix; this PR adds both the CI infrastructure that exposes the bug and the fix that resolves it.