### PR TITLE
Add `TypeInfo.size_of[T]()` for compile-time type-size queries

### DIFF
--- a/.release-notes/add-typeinfo-size-of.md
+++ b/.release-notes/add-typeinfo-size-of.md
@@ -1,0 +1,25 @@
+## Add `TypeInfo.size_of[T]()` for compile-time type-size queries
+
+A new `TypeInfo` primitive has been added to the `builtin` package, exposing a single compile-intrinsic method:
+
+```pony
+primitive TypeInfo
+  fun tag size_of[T](): USize
+```
+
+`TypeInfo.size_of[T]()` returns the in-memory size, in bytes, of an instance of `T`:
+
+- For machine words (`U8`, `U64`, `F32`, ...) it returns the unboxed primitive size, e.g. `size_of[U64]() == 8`.
+- For tuples it returns the unboxed tuple size, e.g. `size_of[(U64, U64)]() == 16`.
+- For non-machine-word primitives such as `None` it returns the size of the type-descriptor pointer.
+- For classes and actors it returns the size of the heap-allocated structure, including the descriptor pointer (and, for actors, the actor bookkeeping fields).
+- For structs it returns the C-compatible struct size (no descriptor), including support for embedded and packed structs.
+
+```pony
+actor Main
+  new create(env: Env) =>
+    env.out.print(TypeInfo.size_of[U64]().string())          // 8
+    env.out.print(TypeInfo.size_of[(U8, U8, U8)]().string()) // 3
+```
+
+`T` must be a concrete type. Calling `size_of` with a union, intersection, interface, or trait is a compile-time error. Although Pony does not normally allow struct types as type arguments, `TypeInfo.size_of` accepts them as a special case so that struct sizes can be queried directly.

--- a/packages/builtin/type_info.pony
+++ b/packages/builtin/type_info.pony
@@ -1,0 +1,25 @@
+primitive TypeInfo
+  """
+  Compile-time queries about Pony types.
+  """
+
+  fun tag size_of[T](): USize =>
+    """
+    Returns the size, in bytes, of an instance of `T` as it is laid out in
+    memory.
+
+    For machine words such as `U64` or `F32`, this is the size of the
+    primitive value (8 and 4 bytes respectively). For tuples, this is the
+    size of the unboxed tuple. For classes and actors, this is the size of
+    the heap-allocated structure, including the type descriptor pointer
+    (and, for actors, the actor bookkeeping fields). For structs, this is
+    the C-compatible struct size (no descriptor).
+
+    `T` must be a concrete type. Calling `size_of` with a union,
+    intersection, interface, or trait is a compile-time error. Although
+    Pony does not normally allow `struct` types as type arguments,
+    `TypeInfo.size_of` accepts them as a special case — the type parameter
+    is phantom and never used at runtime, so the usual reasons for
+    rejecting structs do not apply.
+    """
+    compile_intrinsic

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -123,6 +123,7 @@ static void init_runtime(compile_t* c)
   c->str_Pointer = stringtab("Pointer");
   c->str_NullablePointer = stringtab("NullablePointer");
   c->str_DoNotOptimise = stringtab("DoNotOptimise");
+  c->str_TypeInfo = stringtab("TypeInfo");
   c->str_Array = stringtab("Array");
   c->str_String = stringtab("String");
   c->str_Platform = stringtab("Platform");

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -125,6 +125,7 @@ typedef struct compile_t
   const char* str_Pointer;
   const char* str_NullablePointer;
   const char* str_DoNotOptimise;
+  const char* str_TypeInfo;
   const char* str_Array;
   const char* str_String;
   const char* str_Platform;

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -621,6 +621,74 @@ void genprim_donotoptimise_methods(compile_t* c, reach_type_t* t)
   BOX_FUNCTION(donotoptimise_observe, t);
 }
 
+// Intrinsic for `TypeInfo.size_of[T]()`. Returns the in-memory size of T in
+// bytes: the unboxed primitive size for machine words and tuples, the
+// type-descriptor pointer size for non-machine-word primitives, the heap
+// structure size (descriptor + fields, plus actor bookkeeping) for classes
+// and actors, and the C-compatible struct size for structs.
+static void typeinfo_size_of(compile_t* c, reach_type_t* t,
+  reach_method_t* m)
+{
+  m->intrinsic = true;
+  compile_type_t* c_t = (compile_type_t*)t->c_type;
+  compile_method_t* c_m = (compile_method_t*)m->c_method;
+  (void)c_m;
+
+  ast_t* typearg = ast_child(m->typeargs);
+  reach_type_t* t_elem = reach_type(c->reach, typearg);
+  compile_type_t* c_t_elem = (compile_type_t*)t_elem->c_type;
+  compile_type_t* t_result = (compile_type_t*)m->result->c_type;
+
+  start_function(c, t, m, t_result->use_type, &c_t->use_type, 1);
+
+  LLVMTypeRef sized_type = NULL;
+
+  switch(t_elem->underlying)
+  {
+    case TK_PRIMITIVE:
+      sized_type = (c_t_elem->primitive != NULL)
+        ? c_t_elem->primitive
+        : c_t_elem->structure;
+      break;
+
+    case TK_TUPLETYPE:
+      sized_type = c_t_elem->primitive;
+      break;
+
+    case TK_CLASS:
+    case TK_ACTOR:
+    case TK_STRUCT:
+      sized_type = c_t_elem->structure;
+      break;
+
+    default:
+      // Only report the error once per typearg. `fun tag` methods on a
+      // primitive are reified into tag/ref/val/box cap variants; emitting
+      // from a single cap avoids duplicate diagnostics.
+      if(m->cap == TK_TAG)
+      {
+        ast_error(c->opt->check.errors, m->fun->ast,
+          "TypeInfo.size_of[T]() requires T to be a concrete type "
+          "(primitive, class, actor, struct, or tuple); got %s",
+          ast_print_type(typearg));
+      }
+      break;
+  }
+
+  uint64_t size = (sized_type != NULL)
+    ? LLVMABISizeOfType(c->target_data, sized_type)
+    : 0;
+
+  LLVMValueRef result = LLVMConstInt(c->intptr, size, false);
+  genfun_build_ret(c, result);
+  codegen_finishfun(c);
+}
+
+void genprim_typeinfo_methods(compile_t* c, reach_type_t* t)
+{
+  GENERIC_FUNCTION("size_of", typeinfo_size_of);
+}
+
 static void trace_array_elements(compile_t* c, reach_type_t* t,
   LLVMValueRef ctx, LLVMValueRef object, LLVMValueRef pointer)
 {

--- a/src/libponyc/codegen/genprim.h
+++ b/src/libponyc/codegen/genprim.h
@@ -13,6 +13,8 @@ void genprim_nullable_pointer_methods(compile_t* c, reach_type_t* t);
 
 void genprim_donotoptimise_methods(compile_t* c, reach_type_t* t);
 
+void genprim_typeinfo_methods(compile_t* c, reach_type_t* t);
+
 void genprim_array_trace(compile_t* c, reach_type_t* t);
 
 void genprim_array_serialise_trace(compile_t* c, reach_type_t* t);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -656,6 +656,8 @@ static void make_intrinsic_methods(compile_t* c, reach_type_t* t)
       genprim_nullable_pointer_methods(c, t);
     else if(name == c->str_DoNotOptimise)
       genprim_donotoptimise_methods(c, t);
+    else if(name == c->str_TypeInfo)
+      genprim_typeinfo_methods(c, t);
     else if(name == c->str_Platform)
       genprim_platform_methods(c, t);
   }
@@ -821,7 +823,12 @@ bool gentypes(compile_t* c)
       c_t->abi_size = (size_t)LLVMABISizeOfType(c->target_data, c_t->structure);
 
     make_debug_final(c, t);
+
+    size_t prev_errors = errors_get_count(c->opt->check.errors);
     make_intrinsic_methods(c, t);
+
+    if(errors_get_count(c->opt->check.errors) > prev_errors)
+      return false;
 
     if(!genfun_method_sigs(c, t))
       return false;

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -61,7 +61,12 @@ bool method_check_type_params(pass_opt_t* opt, ast_t** astp)
     return false;
   }
 
-  if(!check_constraints(lhs, typeparams, typeargs, true, opt))
+  // Pony forbids structs as type arguments to ordinary generic methods, but
+  // `TypeInfo.size_of` accepts them as a special case so struct sizes can be
+  // queried directly. `intrinsic_allows_struct_typearg` recognises that one
+  // call site and relaxes the struct-rejection branch in `check_constraints`.
+  if(!check_constraints(lhs, typeparams, typeargs, true,
+    intrinsic_allows_struct_typearg(lhs), opt))
   {
     ast_free_unattached(typeargs);
     return false;

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -297,7 +297,7 @@ static int uifset_formal_param(pass_opt_t* opt, ast_t* type_param_ref,
     BUILD(params, type_param, NODE(TK_TYPEPARAMS, TREE(ast_dup(type_param))));
     BUILD(args, type_param, NODE(TK_TYPEARGS, TREE(uif)));
 
-    if(check_constraints(NULL, params, args, false, opt))
+    if(check_constraints(NULL, params, args, false, false, opt))
       uif_set |= (1 << i);
 
     ast_free(args);

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -462,7 +462,8 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
       if(!reify_defaults(typeparams, right, true, opt))
         return false;
 
-      if(!check_constraints(left, typeparams, right, true, opt))
+      if(!check_constraints(left, typeparams, right, true,
+        intrinsic_allows_struct_typearg(left), opt))
         return false;
 
       type = reify(type, typeparams, right, opt, true);

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -1023,7 +1023,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
     return true;
   }
 
-  return check_constraints(typeargs, typeparams, typeargs, true, opt);
+  return check_constraints(typeargs, typeparams, typeargs, true, false, opt);
 }
 
 static bool check_return_type(pass_opt_t* opt, ast_t* ast)

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -593,7 +593,8 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
         break;
       }
 
-      r = check_constraints(typeargs, typeparams, typeargs, true, options);
+      r = check_constraints(typeargs, typeparams, typeargs, true, false,
+        options);
       break;
     }
     case TK_FVAR:

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -83,7 +83,7 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
 
   if(expr)
   {
-    if(!check_constraints(typeargs, typeparams, typeargs, true, opt))
+    if(!check_constraints(typeargs, typeparams, typeargs, true, false, opt))
       return false;
   }
 

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -233,6 +233,21 @@ static void set_method_types(reach_t* r, reach_method_t* m,
   ast_t* r_result = deferred_reify(m->fun, result, opt);
   m->result = add_type(r, r_result, opt);
   ast_free_unattached(r_result);
+
+  // Reach method-level type arguments. Most type arguments also appear in
+  // params or result and are reached above, but some intrinsics (e.g.
+  // `TypeInfo.size_of[T]()`) only mention T in the type-arg list, and codegen
+  // needs to look up their reach_type.
+  if(m->typeargs != NULL)
+  {
+    ast_t* typearg = ast_child(m->typeargs);
+
+    while(typearg != NULL)
+    {
+      add_type(r, typearg, opt);
+      typearg = ast_sibling(typearg);
+    }
+  }
 }
 
 static void trace_kind_append(printbuf_t* buf, ast_t* type)

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -5,6 +5,7 @@
 #include "assemble.h"
 #include "alias.h"
 #include "../ast/token.h"
+#include "../pkg/package.h"
 #include "../../libponyrt/gc/serialise.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
@@ -424,8 +425,70 @@ void deferred_reify_free(deferred_reification_t* deferred)
   }
 }
 
+bool intrinsic_allows_struct_typearg(ast_t* funref)
+{
+  if(funref == NULL)
+    return false;
+
+  switch(ast_id(funref))
+  {
+    case TK_FUNREF:
+    case TK_BEREF:
+    case TK_NEWREF:
+    case TK_NEWBEREF:
+    case TK_FUNAPP:
+    case TK_BEAPP:
+    case TK_NEWAPP:
+    case TK_FUNCHAIN:
+    case TK_BECHAIN:
+      break;
+
+    default:
+      return false;
+  }
+
+  // funref children: receiver, method-id-or-qualify
+  ast_t* receiver = ast_child(funref);
+  if(receiver == NULL)
+    return false;
+
+  ast_t* method_node = ast_sibling(receiver);
+  if(method_node == NULL)
+    return false;
+
+  // After expr_qualify rewrites, the method id may be wrapped in a typeargs
+  // or shifted; tolerate either shape by recovering the leading TK_ID.
+  ast_t* method_id = method_node;
+  if(ast_id(method_id) != TK_ID)
+    method_id = ast_child(method_id);
+  if((method_id == NULL) || (ast_id(method_id) != TK_ID))
+    return false;
+  if(ast_name(method_id) != stringtab("size_of"))
+    return false;
+
+  // Receiver type tells us the owning entity. For `TypeInfo.size_of[T]` the
+  // receiver is a TK_TYPEREF to TypeInfo, whose type is the nominal form.
+  ast_t* recv_type = ast_type(receiver);
+  if((recv_type == NULL) || (ast_id(recv_type) != TK_NOMINAL))
+    return false;
+
+  ast_t* entity = (ast_t*)ast_data(recv_type);
+  if((entity == NULL) || (ast_id(entity) != TK_PRIMITIVE))
+    return false;
+
+  ast_t* entity_id = ast_child(entity);
+  if(ast_name(entity_id) != stringtab("TypeInfo"))
+    return false;
+
+  ast_t* package = ast_nearest(entity, TK_PACKAGE);
+  if(package == NULL)
+    return false;
+
+  return package_filename(package) == stringtab("builtin");
+}
+
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
-  bool report_errors, pass_opt_t* opt)
+  bool report_errors, bool allow_struct_typeargs, pass_opt_t* opt)
 {
   ast_t* typeparam = ast_child(typeparams);
   ast_t* typearg = ast_child(typeargs);
@@ -449,7 +512,7 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
       {
         ast_t* def = (ast_t*)ast_data(typearg);
 
-        if(ast_id(def) == TK_STRUCT)
+        if((ast_id(def) == TK_STRUCT) && !allow_struct_typeargs)
         {
           if(report_errors)
           {
@@ -486,7 +549,8 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
           {
             ast_t* def = (ast_t*)ast_data(unfolded);
 
-            if((def != NULL) && (ast_id(def) == TK_STRUCT))
+            if((def != NULL) && (ast_id(def) == TK_STRUCT)
+              && !allow_struct_typeargs)
             {
               ast_free_unattached(unfolded);
 

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -43,7 +43,14 @@ deferred_reification_t* deferred_reify_dup(deferred_reification_t* deferred);
 void deferred_reify_free(deferred_reification_t* deferred);
 
 bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
-  bool report_errors, pass_opt_t* opt);
+  bool report_errors, bool allow_struct_typeargs, pass_opt_t* opt);
+
+// True if `funref` (a TK_FUNREF/TK_BEREF/etc.) refers to an intrinsic that
+// is allowed to take a struct as a type argument. Currently this is just
+// `builtin.TypeInfo.size_of`, whose type parameter is phantom (only used at
+// compile time to query layout) and so doesn't need the descriptor that the
+// general struct-typearg restriction protects.
+bool intrinsic_allows_struct_typearg(ast_t* funref);
 
 pony_type_t* deferred_reification_pony_type();
 

--- a/test/full-program-tests/typeinfo-size-of/main.pony
+++ b/test/full-program-tests/typeinfo-size-of/main.pony
@@ -1,0 +1,110 @@
+"""
+TypeInfo.size_of[T]() returns the in-memory size of an instance of T.
+
+Only architecture-independent sizes are asserted directly; sizes that
+depend on pointer width are derived from `USize(0).bytewidth()`.
+"""
+use "pony_test"
+
+class _ClassTwoU64
+  let a: U64 = 0
+  let b: U64 = 0
+
+struct _StructTwoU64
+  var a: U64 = 0
+  var b: U64 = 0
+
+struct \packed\ _StructU8U64Packed
+  var a: U8 = 0
+  var b: U64 = 0
+
+struct _StructU8U64
+  var a: U8 = 0
+  var b: U64 = 0
+
+struct _StructEmbeds
+  embed a: _StructTwoU64 = _StructTwoU64
+  embed b: _StructU8U64 = _StructU8U64
+
+actor \nodoc\ Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestMachineWords)
+    test(_TestTuples)
+    test(_TestPrimitive)
+    test(_TestClass)
+    test(_TestStructs)
+
+class \nodoc\ iso _TestMachineWords is UnitTest
+  """
+  Machine words report their unboxed primitive size, never the boxed
+  representation.
+  """
+  fun name(): String => "TypeInfo/size_of/machine-words"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](1, TypeInfo.size_of[U8]())
+    h.assert_eq[USize](2, TypeInfo.size_of[U16]())
+    h.assert_eq[USize](4, TypeInfo.size_of[U32]())
+    h.assert_eq[USize](8, TypeInfo.size_of[U64]())
+    h.assert_eq[USize](16, TypeInfo.size_of[U128]())
+    h.assert_eq[USize](1, TypeInfo.size_of[I8]())
+    h.assert_eq[USize](8, TypeInfo.size_of[I64]())
+    h.assert_eq[USize](4, TypeInfo.size_of[F32]())
+    h.assert_eq[USize](8, TypeInfo.size_of[F64]())
+
+class \nodoc\ iso _TestTuples is UnitTest
+  """
+  Tuples are unboxed: a `(U8, U8, U8)` packs to 3 bytes, two `U64`s to 16.
+  """
+  fun name(): String => "TypeInfo/size_of/tuples"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](3, TypeInfo.size_of[(U8, U8, U8)]())
+    h.assert_eq[USize](16, TypeInfo.size_of[(U64, U64)]())
+    h.assert_eq[USize](16, TypeInfo.size_of[(F32, F32, F32, F32)]())
+
+class \nodoc\ iso _TestPrimitive is UnitTest
+  """
+  A non-machine-word primitive is just a type-descriptor pointer.
+  """
+  fun name(): String => "TypeInfo/size_of/primitive"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](USize(0).bytewidth(), TypeInfo.size_of[None]())
+
+class \nodoc\ iso _TestClass is UnitTest
+  """
+  A class is a descriptor pointer plus its fields. With two `U64` fields the
+  layout is 24 bytes on every supported architecture: on lp64 a pointer (8)
+  plus the two fields (16); on 32-bit a 4-byte pointer plus 4 bytes of
+  alignment padding plus 16 bytes of fields = 24.
+  """
+  fun name(): String => "TypeInfo/size_of/class"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](24, TypeInfo.size_of[_ClassTwoU64]())
+
+class \nodoc\ iso _TestStructs is UnitTest
+  """
+  Structs use C-compatible layout with no descriptor. Two `U64`s pack to 16.
+  A `U8` followed by a `U64` pads to 16 (1 + 7 padding + 8). Embedded
+  structs nest in place without any extra header.
+
+  Note that structs cannot be passed through a generic helper because Pony
+  forbids them as type arguments to ordinary generic methods; only
+  `TypeInfo.size_of` accepts them as a special case, so each call uses a
+  literal type.
+  """
+  fun name(): String => "TypeInfo/size_of/structs"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](16, TypeInfo.size_of[_StructTwoU64]())
+    h.assert_eq[USize](16, TypeInfo.size_of[_StructU8U64]())
+    h.assert_eq[USize](9, TypeInfo.size_of[_StructU8U64Packed]())
+    h.assert_eq[USize](32, TypeInfo.size_of[_StructEmbeds]())

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -15,6 +15,10 @@
 
 #define TEST_COMPILE(src) DO(test_compile(src, "ir"))
 
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
 
 class CodegenTest : public PassTest
 {
@@ -153,6 +157,44 @@ TEST_F(CodegenTest, DoNotOptimiseApplyPrimitive)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    DoNotOptimise[I64](0)";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(CodegenTest, TypeInfoSizeOfPrimitive)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let _ = TypeInfo.size_of[U64]()\n"
+    "    let _ = TypeInfo.size_of[(U8, U8, U8)]()\n"
+    "    let _ = TypeInfo.size_of[None]()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(CodegenTest, TypeInfoSizeOfAbstractTypeFails)
+{
+  const char* src =
+    "interface Shape\n"
+    "  fun area(): F64\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let _ = TypeInfo.size_of[Shape]()";
+
+  TEST_ERRORS_1(src,
+    "TypeInfo.size_of[T]() requires T to be a concrete type "
+    "(primitive, class, actor, struct, or tuple); got Shape ref");
+}
+
+TEST_F(CodegenTest, TypeInfoSizeOfStruct)
+{
+  const char* src =
+    "struct S\n"
+    "  var x: U64 = 0\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let _ = TypeInfo.size_of[S]()";
 
   TEST_COMPILE(src);
 }

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -116,6 +116,8 @@ static const char* const _builtin =
   "  fun ref next(): A ?\n"
   "primitive DoNotOptimise\n"
   "  fun apply[A](obj: A) => compile_intrinsic\n"
+  "primitive TypeInfo\n"
+  "  fun tag size_of[T](): USize => compile_intrinsic\n"
   "struct NullablePointer[A]\n"
   "  new create(that: A) => compile_intrinsic\n"
   "struct RuntimeOptions\n";


### PR DESCRIPTION
Introduces a `TypeInfo` primitive in `builtin` with a single `size_of[T](): USize` compile-intrinsic that returns the in-memory size of an instance of `T`:
- machine words: unboxed primitive size
- tuples: unboxed tuple size
- non-machine-word primitives: type-descriptor pointer size
- classes/actors: heap structure size (descriptor + fields)
- structs: C-compatible struct size

Abstract types (unions, intersections, interfaces, traits) produce a compile-time error. Structs are normally rejected as type arguments to generic methods; `TypeInfo.size_of` accepts them via a _narrow carve-out_™ in `check_constraints`, threaded through callers via `intrinsic_allows_struct_typearg`.