### PR TITLE
Exclude .gitignore and .markdownlintignore from PR validation paths

### DIFF
--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -10,6 +10,8 @@ on:
       - '!**/*.yml'
       - '!.dockerfiles/**'
       - '!.ci-dockerfiles/**'
+      - '!.gitignore'
+      - '!.markdownlintignore'
       - '.github/workflows/pr-ponyc.yml'
 
 concurrency:

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -9,6 +9,8 @@ on:
       - '!**/*.yml'
       - '!.dockerfiles/**'
       - '!.ci-dockerfiles/**'
+      - '!.gitignore'
+      - '!.markdownlintignore'
       - '.github/workflows/pr-tools.yml'
 
 concurrency:


### PR DESCRIPTION
The `pr-ponyc` and `pr-tools` workflows already exclude `**/*.md` so docs-only changes don't trigger full PR validation runs. `.gitignore` and `.markdownlintignore` are the same kind of repo-meta change but don't match `**/*.md`, so they were still kicking off the build matrices. Adds them to the path exclusion lists for both workflows.

Closes #5254