### PR TITLE
Remove binutils-gold from nightly and release Docker images

### DIFF
--- a/.ci-dockerfiles/alpine3.22-builder/Dockerfile
+++ b/.ci-dockerfiles/alpine3.22-builder/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
   alpine-sdk \
-  binutils-gold \
   clang \
   clang-dev \
   coreutils \

--- a/.ci-dockerfiles/alpine3.23-builder/Dockerfile
+++ b/.ci-dockerfiles/alpine3.23-builder/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
   alpine-sdk \
-  binutils-gold \
   clang \
   clang-dev \
   coreutils \

--- a/.ci-dockerfiles/arm64-unknown-linux-alpine3.21-builder/Dockerfile
+++ b/.ci-dockerfiles/arm64-unknown-linux-alpine3.21-builder/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
   alpine-sdk \
-  binutils-gold \
   clang \
   clang-dev \
   coreutils \

--- a/.ci-dockerfiles/x86-64-unknown-linux-alpine3.21-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-alpine3.21-builder/Dockerfile
@@ -6,7 +6,6 @@ RUN apk update \
   && apk upgrade \
   && apk add --update --no-cache \
   alpine-sdk \
-  binutils-gold \
   clang \
   clang-dev \
   coreutils \

--- a/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/Dockerfile
@@ -3,7 +3,6 @@ FROM fedora:43
 LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 
 RUN dnf install -y \
-      binutils-gold \
       clang \
       cmake \
       compiler-rt \

--- a/.dockerfiles/nightly/Dockerfile
+++ b/.dockerfiles/nightly/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --update --no-cache \
     clang \
     curl \
     build-base \
-    binutils-gold \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \

--- a/.dockerfiles/release/Dockerfile
+++ b/.dockerfiles/release/Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --update --no-cache \
     clang \
     curl \
     build-base \
-    binutils-gold \
     git
 
 RUN sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)" \

--- a/.release-notes/remove-binutils-gold-from-docker-images.md
+++ b/.release-notes/remove-binutils-gold-from-docker-images.md
@@ -1,0 +1,5 @@
+## Remove binutils-gold from nightly and release Docker images
+
+The `binutils-gold` package has been removed from the `ponylang/ponyc` nightly and release Docker images. Nothing in ponyc uses the gold linker, and gold is upstream-deprecated and being phased out of distro repositories.
+
+If your build inside one of these images relies on `binutils-gold` being present, you will need to install it explicitly with `apk add binutils-gold`.


### PR DESCRIPTION
Nothing in ponyc invokes the gold linker, and gold is upstream-deprecated and being phased out of distro repositories. Drop the package from the nightly and release distribution images and from the CI builder images where it had been carried as dead weight.

The CI builder images themselves do not need to be rebuilt or republished as part of this change — the next routine rebuild will pick up the new Dockerfiles.

Closes #5265