### PR TITLE
Fix LSP tests: log server error responses before checker validation

### DIFF
--- a/tools/pony-lsp/test/_lsp_test_server.pony
+++ b/tools/pony-lsp/test/_lsp_test_server.pony
@@ -99,6 +99,13 @@ actor _LspTestServer is Channel
             try
               (_, let pending) = _in_flight.remove(id_i64)?
               let action = pending.action
+              match res.err
+              | let e: ResponseError val =>
+                pending.h.log(
+                  pending.checker.lsp_method() +
+                  ": server error " + e.code.string() +
+                  ": " + e.message)
+              end
               if pending.checker.check(res, pending.h) then
                 pending.h.complete_action(action)
               else


### PR DESCRIPTION
## Context

Success-path checkers in the pony-lsp integration test harness skip straight to `JsonNav(res.result)` without inspecting `res.err`. When the server returns an error response (e.g. `internal_error: workspace not found`), the `JsonNav` probes silently fail inside `try` blocks and the checker reports a misleading failure like "expected hover, got null" rather than surfacing the real error code and message.

## Changes

When the LSP server returns a response with `res.err` set, the harness now logs the error code and message before calling the checker. Success-path checkers that receive an unexpected error produce a diagnostic line explaining what the server returned, instead of a silent assertion failure. Error-expecting checkers (`_RenameErrorChecker`, `_PrepareRenameErrorChecker`) are unaffected — they inspect `res.err` themselves and the log line is an additive aid.