### PR TITLE
Add pony-lsp inlay hints for function parameter types

### DIFF
--- a/.release-notes/lsp-inlay-hints-parameter-types.md
+++ b/.release-notes/lsp-inlay-hints-parameter-types.md
@@ -1,0 +1,13 @@
+## Add pony-lsp inlay hints for function parameter types
+
+pony-lsp now shows capability hints on function parameter type annotations where the capability is omitted from source.
+
+```diff
+-fun box greet(name: String, items: Array[String]): None val =>
++fun box greet(name: String val, items: Array[String val] ref): None val =>
+   None
+```
+
+Hints appear after each type name (and after `]` for generic types). Parameters with explicit capabilities are unaffected — no hint is shown when the capability is already written out.
+
+Type parameter references (e.g. `T` in `Array[T]`) have no fixed capability, so they produce no hint.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -20,7 +20,7 @@ For user documentation — installation and editor configuration — see the [po
 | **[Document Symbols][spec-document-symbols]** | pony-lsp provides a list of available symbols for each opened document. |
 | **[Workspace Symbols][spec-workspace-symbols]** | Fuzzy search over all symbols across the entire workspace. |
 | **[Document Highlight][spec-document-highlight]** | All occurrences of the symbol under the cursor are highlighted simultaneously across the document. |
-| **[Inlay Hints][spec-inlay-hints]** | Inferred types are shown inline after the variable name for `let` and `var` declarations with no explicit type annotation. |
+| **[Inlay Hints][spec-inlay-hints]** | Three kinds of hints are shown inline. For `let`, `var`, and field declarations with no type annotation, the full inferred type appears after the variable name. For annotated types where the capability is omitted — in variable and field declarations, function parameter types, generic type arguments, and union and tuple members — the missing capability keyword appears after the type name. For `fun` declarations, the implicit receiver capability appears before the function name and the implicit return type appears after the closing parenthesis. |
 | **[Find References][spec-references]** | All references to the symbol under the cursor are returned, with optional inclusion of the declaration site. |
 | **[Rename][spec-rename]** | Rename a symbol and all its references across the workspace. |
 | **[Folding Range][spec-folding-range]** | Code folding ranges are provided for blocks, methods, classes, and other structured constructs. |

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -21,6 +21,10 @@ primitive _InlayHintIntegrationTests is TestList
     test(_InlayHintBeNewExclusionTest.create(server))
     test(_InlayHintExplicitReceiverCapTest.create(server))
     test(_InlayHintSyntheticNameExclusionTest.create(server))
+    test(_InlayHintFunctionParamsFullTest.create(server))
+    test(_InlayHintFunctionParamsExplicitTest.create(server))
+    test(_InlayHintFunctionParamsGenericTest.create(server))
+    test(_InlayHintFunctionParamsFullCapsTest.create(server))
 
 class \nodoc\ iso _InlayHintDemoTest is UnitTest
   let _server: _LspTestServer
@@ -270,7 +274,7 @@ class \nodoc\ iso _InlayHintUnionTupleTest is UnitTest
 class \nodoc\ iso _InlayHintBeNewExclusionTest is UnitTest
   """
   Verifies that behaviours (be) and constructors (new) produce no hints —
-  neither receiver cap hints nor return type hints.
+  neither receiver cap hints, return type hints, nor parameter type hints.
   """
   let _server: _LspTestServer
 
@@ -334,6 +338,112 @@ class \nodoc\ iso _InlayHintSyntheticNameExclusionTest is UnitTest
       [ _InlayHintChecker(
           [ (37, 12, ": String val") ] // item hint; no hint for $iterator
           where range = (37, 0, 39, 0)) ])
+
+class \nodoc\ iso _InlayHintFunctionParamsFullTest is UnitTest
+  """
+  Full-file test covering all three functions in _function_params.pony.
+  Verifies capability hints on parameter types (explicit and generic) and
+  that fully-annotated parameters produce no hints.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/function_params/full"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_function_params.pony",
+      [ _InlayHintChecker(
+          [ (8, 5, " box")            // explicit receiver cap
+            (8, 24, " val")           // s: String cap
+            (8, 40, " val")           // arr: Array[U32] — U32 cap
+            (8, 41, " ref")           // arr: Array[U32] — Array cap
+            (8, 42, ": None val")     // explicit inferred return type
+            (12, 5, " box")           // full_caps receiver cap
+            (12, 55, ": None val")    // full_caps return type (no param hints)
+            (16, 5, " box")           // generic receiver cap
+            (16, 49, " ref")          // arr: Array[T] — Array cap
+            (16, 50, ": None val") ]  // generic inferred return type
+          ) ])
+
+class \nodoc\ iso _InlayHintFunctionParamsExplicitTest is UnitTest
+  """
+  Range covering only `fun explicit` (line 9). Verifies that
+  String and Array[U32] parameter types each receive a capability hint.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/function_params/explicit"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_function_params.pony",
+      [ _InlayHintChecker(
+          [ (8, 5, " box")            // receiver cap
+            (8, 24, " val")           // s: String cap
+            (8, 40, " val")           // U32 cap
+            (8, 41, " ref")           // Array cap
+            (8, 42, ": None val") ]   // return type
+          where range = (8, 0, 10, 0)) ])
+
+class \nodoc\ iso _InlayHintFunctionParamsGenericTest is UnitTest
+  """
+  Range covering only `fun generic` (line 17). Verifies that Array[T]
+  receives a capability hint for Array while the typeparamref T is skipped.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/function_params/generic"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_function_params.pony",
+      [ _InlayHintChecker(
+          [ (16, 5, " box")           // receiver cap
+            (16, 49, " ref")          // Array[T] cap
+            (16, 50, ": None val") ]  // return type
+          where range = (16, 0, 18, 0)) ])
+
+class \nodoc\ iso _InlayHintFunctionParamsFullCapsTest is UnitTest
+  """
+  Range covering only `fun full_caps` (line 13). Verifies that explicitly
+  annotated parameter capabilities (String box, Array[U32 val] ref)
+  suppress all parameter hints.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/function_params/full_caps"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_function_params.pony",
+      [ _InlayHintChecker(
+          [ (12, 5, " box")           // receiver cap only
+            (12, 55, ": None val") ]  // return type; no param hints
+          where range = (12, 0, 14, 0)) ])
 
 class val _InlayHintChecker
   """

--- a/tools/pony-lsp/test/workspace/inlay_hint/_function_params.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_function_params.pony
@@ -1,0 +1,18 @@
+class _FunctionParams
+  """
+  Fixture for testing capability inlay hints on function parameter type
+  annotations. Each method demonstrates a distinct case: missing capabilities
+  on concrete types, fully explicit capabilities (no hints), and generic type
+  arguments (Array[T] gets a hint; T itself does not).
+  """
+  // hints: " val" (after String), " val" (after U32), " ref" (after Array ']')
+  fun explicit(s: String, arr: Array[U32]) =>
+    None
+
+  // no hints on parameters — capability is written out for each type
+  fun full_caps(s: String box, arr: Array[U32 val] ref) =>
+    None
+
+  // hint: " ref" (after Array ']'); no hint for T — no fixed cap on type params
+  fun generic[T: Comparable[T] box](arr: Array[T]) =>
+    None

--- a/tools/pony-lsp/test/workspace/inlay_hint/_union_types.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_union_types.pony
@@ -12,8 +12,8 @@ class _UnionTypes
     None
 
 actor _BeNewExclusion
-  be run() =>
+  be run(x: String) =>
     None
 
-  new create() =>
+  new create(x: U32) =>
     None

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -7,7 +7,8 @@ primitive InlayHints
   Collects inlay hints for a module. Three kinds of hints are emitted:
   - Inferred type hints on let/var/field declarations with no type annotation.
   - Capability hints on type annotations where the capability is absent from
-    source (including generic type arguments, union, and tuple members).
+    source (including function parameter types, generic type arguments, union,
+    and tuple members).
   - Receiver capability and return type hints on fun declarations.
   """
   fun collect(
@@ -43,9 +44,11 @@ class ref _InlayHintCollector is ASTVisitor
   fun ref visit(node: AST box): VisitResult =>
     """
     Dispatches let/var/field/embed nodes to the type hint handler and fun nodes
-    to the return type and receiver cap hint handlers. Behaviours (be) and
-    constructors (new) are excluded: be has no receiver cap or return type,
-    and new always returns the constructed type which is unambiguous.
+    to the receiver cap, parameter type, and return type hint handlers.
+    Behaviours (be) and constructors (new) are excluded: be has no receiver cap
+    or return type, and new always returns the constructed type which is
+    unambiguous. Parameter hints are emitted inside _try_add_return_type_hint
+    rather than directly here to preserve the forward-cursor invariant.
 
     Invariant: nodes must be visited in non-decreasing source line order
     for _byte_offset's forward-only cursor to work correctly. This holds
@@ -191,6 +194,10 @@ class ref _InlayHintCollector is ASTVisitor
     """
     After typechecking, child(4) always contains the return type (inferred
     or explicit). Source scanning distinguishes the two cases.
+
+    Parameter type hints are emitted here, between the scan_to_close_paren
+    call and the return-type handling, so the forward cursor advances through
+    param positions before reaching the return type position.
     """
     try
       let id_node = node(1)?
@@ -214,6 +221,8 @@ class ref _InlayHintCollector is ASTVisitor
         InlayHintSource.scan_to_close_paren(
           src, start, line, col + name.size())?
 
+      _try_add_param_hints(node, src)
+
       if InlayHintSource.has_explicit_return_type(src, close_j)? then
         _add_nominal_hints(node(4)?, src)
       else
@@ -225,6 +234,33 @@ class ref _InlayHintCollector is ASTVisitor
           (hint_col - 1).i64(),
           ": " + type_str)
       end
+    end
+
+  fun ref _try_add_param_hints(node: AST box, src: String box) =>
+    """
+    Emits capability hints for each function parameter's type annotation.
+    Called from _try_add_return_type_hint, after scan_to_close_paren has
+    computed the close-paren position (a non-cursor operation) and before
+    the return type is processed. This ordering keeps the forward cursor
+    invariant: params always precede the return type in source.
+    """
+    try
+      for param in node(3)?.children() do
+        _try_add_one_param_hint(param, src)
+      end
+    end
+
+  fun ref _try_add_one_param_hint(param: AST box, src: String box) =>
+    """
+    Delegates a single parameter's type annotation to _add_nominal_hints,
+    which recurses through nominal, union, tuple, and intersection forms to
+    emit capability hints for each type name that lacks an explicit capability
+    in source.
+    """
+    try
+      let type_node = param(1)?
+      if type_node.id() == TokenIds.tk_none() then return end
+      _add_nominal_hints(type_node, src)
     end
 
   fun ref _try_add_receiver_cap_hint(node: AST box) =>


### PR DESCRIPTION
## Context

pony-lsp shows capability inlay hints on type annotations where the capability is omitted from source — for `let`, `var`, and field declarations, return types, and generic type arguments. Function parameter type annotations do not currently receive these hints, so users have no visibility into the inferred capabilities for parameters like `fun greet(name: String)`.

## Changes

- Capability hints are now emitted for function parameter type annotations where the capability is omitted, including generic type arguments (`Array[T]` gets a hint for `Array`; type parameter references like `T` produce no hint as they have no fixed capability)
- Parameters with explicit capabilities are unaffected
- Updated README inlay hints description to cover all three hint kinds
- Updated stale docstrings in the implementation
- Added typed params to the `be`/`new` exclusion test fixture so suppression of param hints on behaviours and constructors is actually verified

<img width="849" height="440" alt="image" src="https://github.com/user-attachments/assets/72a66519-690c-4512-b478-1b27230823bb" />

