### PR TITLE
Fix spurious pony-lsp inlay hints on primitive types

### DIFF
--- a/.release-notes/lsp-inlay-hints-fix-primitive-synthetic.md
+++ b/.release-notes/lsp-inlay-hints-fix-primitive-synthetic.md
@@ -1,0 +1,3 @@
+## Fix spurious pony-lsp inlay hints on primitive types
+
+Primitive types were showing extra unexpected inlay hints alongside the hints for user-defined methods. This is now fixed.

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -25,6 +25,7 @@ primitive _InlayHintIntegrationTests is TestList
     test(_InlayHintFunctionParamsExplicitTest.create(server))
     test(_InlayHintFunctionParamsGenericTest.create(server))
     test(_InlayHintFunctionParamsFullCapsTest.create(server))
+    test(_InlayHintPrimitiveTest.create(server))
 
 class \nodoc\ iso _InlayHintDemoTest is UnitTest
   let _server: _LspTestServer
@@ -444,6 +445,32 @@ class \nodoc\ iso _InlayHintFunctionParamsFullCapsTest is UnitTest
           [ (12, 5, " box")           // receiver cap only
             (12, 55, ": None val") ]  // return type; no param hints
           where range = (12, 0, 14, 0)) ])
+
+class \nodoc\ iso _InlayHintPrimitiveTest is UnitTest
+  """
+  Verifies that a primitive's user-defined method receives the expected hints
+  and that synthetic compiler-added methods (eq/ne from add_comparable) do
+  not produce spurious extra hints. The exact count of 3 hints would fail if
+  any synthetic method leaked through.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/primitive"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_prim.pony",
+      [ _InlayHintChecker(
+          [ (6, 5, " box")            // greet receiver cap
+            (6, 24, " val")           // name: String cap
+            (6, 31, " val") ]         // None return cap
+          ) ])
 
 class val _InlayHintChecker
   """

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -496,8 +496,8 @@ class \nodoc\ iso _InlayHintPrimitiveNewFirstTest is UnitTest
       _server,
       "inlay_hint/_prim_new_first.pony",
       [ _InlayHintChecker(
-          [ (9, 5, " box")            // greet receiver cap
-            (9, 19, " val") ]         // None return cap
+          [ (10, 5, " box")           // greet receiver cap
+            (10, 19, " val") ]        // None return cap
           ) ])
 
 class \nodoc\ iso _InlayHintPrimitiveEFirstCharTest is UnitTest

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -26,6 +26,9 @@ primitive _InlayHintIntegrationTests is TestList
     test(_InlayHintFunctionParamsGenericTest.create(server))
     test(_InlayHintFunctionParamsFullCapsTest.create(server))
     test(_InlayHintPrimitiveTest.create(server))
+    test(_InlayHintPrimitiveNewFirstTest.create(server))
+    test(_InlayHintPrimitiveEFirstCharTest.create(server))
+    test(_InlayHintPrimitiveEmptyTest.create(server))
 
 class \nodoc\ iso _InlayHintDemoTest is UnitTest
   let _server: _LspTestServer
@@ -471,6 +474,77 @@ class \nodoc\ iso _InlayHintPrimitiveTest is UnitTest
             (6, 24, " val")           // name: String cap
             (6, 31, " val") ]         // None return cap
           ) ])
+
+class \nodoc\ iso _InlayHintPrimitiveNewFirstTest is UnitTest
+  """
+  Verifies suppression when a primitive's first member is a constructor.
+  Synthetic ne inherits the position of 'n' in 'new', matching ne's own
+  first character. Without the boundary-byte check, ne would leak a
+  spurious : Bool val hint. The exact count of 2 hints would fail if it did.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/primitive/new_first"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_prim_new_first.pony",
+      [ _InlayHintChecker(
+          [ (9, 5, " box")            // greet receiver cap
+            (9, 19, " val") ]         // None return cap
+          ) ])
+
+class \nodoc\ iso _InlayHintPrimitiveEFirstCharTest is UnitTest
+  """
+  Verifies that a user-defined method starting with 'e' is not suppressed
+  by the synthetic-method guard. 'e' is also the first character of synthetic
+  eq; the boundary-byte check must not fire for the user method (its name
+  ends at '(', a non-identifier character).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/primitive/e_first_char"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_prim_e_first_char.pony",
+      [ _InlayHintChecker(
+          [ (7, 5, " box")            // engage receiver cap
+            (7, 20, " val") ]         // None return cap
+          ) ])
+
+class \nodoc\ iso _InlayHintPrimitiveEmptyTest is UnitTest
+  """
+  Verifies that a primitive with no user-defined methods produces no inlay
+  hints. Synthetic eq and ne are the only members and must be suppressed.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "inlay_hint/integration/primitive/empty"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "inlay_hint/_prim_empty.pony",
+      [ _InlayHintChecker(
+          recover val Array[(I64, I64, String)].create() end) ])
 
 class val _InlayHintChecker
   """

--- a/tools/pony-lsp/test/workspace/inlay_hint/_prim.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_prim.pony
@@ -1,0 +1,8 @@
+primitive _Prim
+  """
+  Fixture for verifying that synthetic compiler-added methods (eq/ne from
+  add_comparable) produce no spurious hints alongside user-defined methods.
+  """
+  // hints: " box" (receiver), " val" (name: String), " val" (None return)
+  fun greet(name: String): None =>
+    None

--- a/tools/pony-lsp/test/workspace/inlay_hint/_prim_e_first_char.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_prim_e_first_char.pony
@@ -1,0 +1,9 @@
+primitive _PrimEFirstChar
+  """
+  Fixture for a primitive whose user method starts with 'e', the same first
+  character as synthetic eq. The boundary-byte guard must not suppress the
+  user method.
+  """
+  // hints: " box" (receiver), " val" (None return)
+  fun engage(): None =>
+    None

--- a/tools/pony-lsp/test/workspace/inlay_hint/_prim_empty.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_prim_empty.pony
@@ -1,0 +1,5 @@
+primitive _PrimEmpty
+  """
+  Fixture for a primitive with no user-defined methods. Synthetic eq and ne
+  are the only members; neither should produce any inlay hints.
+  """

--- a/tools/pony-lsp/test/workspace/inlay_hint/_prim_new_first.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_prim_new_first.pony
@@ -6,6 +6,7 @@ primitive _PrimNewFirst
   """
   new create() =>
     None
+
   // hints: " box" (receiver), " val" (None return)
   fun greet(): None =>
     None

--- a/tools/pony-lsp/test/workspace/inlay_hint/_prim_new_first.pony
+++ b/tools/pony-lsp/test/workspace/inlay_hint/_prim_new_first.pony
@@ -1,0 +1,11 @@
+primitive _PrimNewFirst
+  """
+  Fixture for the case where a primitive's first member is a constructor.
+  Synthetic ne inherits position at 'n' of 'new', coinciding with ne's own
+  first char. The boundary-byte guard must distinguish them.
+  """
+  new create() =>
+    None
+  // hints: " box" (receiver), " val" (None return)
+  fun greet(): None =>
+    None

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -216,9 +216,18 @@ class ref _InlayHintCollector is ASTVisitor
       let name_off = _byte_offset(src, line, col)?
       // A synthetic method (e.g. eq/ne appended by add_comparable on
       // primitives) inherits its source position from a different node.
-      // The character at that position won't match the method name.
+      // Verify first char and that the following byte is not an identifier
+      // character (distinguishing e.g. "ne" at the start of "new"). Any
+      // error here means the position is stale — skip the method.
       try
-        if src(name_off)? != name(0)? then return end
+        if src(name_off)? != name(0)? then
+          return
+        end
+        if _is_ident_char(src(name_off + name.size())?) then
+          return
+        end
+      else
+        return
       end
       let start = name_off + name.size()
       var hint_line: USize = 0
@@ -302,11 +311,17 @@ class ref _InlayHintCollector is ASTVisitor
 
       let src = id_node.source_contents() as String box
       let name_start = _byte_offset(src, line, col)?
-      // Same synthetic method guard as _try_add_return_type_hint: if the
-      // source character at the claimed position doesn't match the method
-      // name, the position is stale and the method is synthetic.
+      // Same synthetic method guard as _try_add_return_type_hint: verify
+      // first char and trailing non-identifier byte. Fail closed on error.
       try
-        if src(name_start)? != name(0)? then return end
+        if src(name_start)? != name(0)? then
+          return
+        end
+        if _is_ident_char(src(name_start + name.size())?) then
+          return
+        end
+      else
+        return
       end
       if InlayHintSource.has_explicit_receiver_cap(src, name_start) then
         return
@@ -374,3 +389,7 @@ class ref _InlayHintCollector is ASTVisitor
     (id == TokenIds.tk_iso()) or (id == TokenIds.tk_trn())
       or (id == TokenIds.tk_ref()) or (id == TokenIds.tk_val())
       or (id == TokenIds.tk_box()) or (id == TokenIds.tk_tag())
+
+  fun _is_ident_char(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z')) or ((c >= 'A') and (c <= 'Z'))
+      or ((c >= '0') and (c <= '9')) or (c == '_')

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -213,7 +213,14 @@ class ref _InlayHintCollector is ASTVisitor
       end
 
       let src = id_node.source_contents() as String box
-      let start = _byte_offset(src, line, col)? + name.size()
+      let name_off = _byte_offset(src, line, col)?
+      // A synthetic method (e.g. eq/ne appended by add_comparable on
+      // primitives) inherits its source position from a different node.
+      // The character at that position won't match the method name.
+      try
+        if src(name_off)? != name(0)? then return end
+      end
+      let start = name_off + name.size()
       var hint_line: USize = 0
       var hint_col: USize = 0
       var close_j: USize = 0
@@ -266,7 +273,11 @@ class ref _InlayHintCollector is ASTVisitor
   fun ref _try_add_receiver_cap_hint(node: AST box) =>
     """
     Emits a receiver capability hint after 'fun' when no explicit capability
-    keyword appears between 'fun' and the function name in source.
+    keyword appears between 'fun' and the function name in source. Synthetic
+    compiler-generated methods (e.g. eq/ne from add_comparable on primitives)
+    are filtered by checking that the source character at the claimed position
+    matches the method name — synthetic methods inherit a stale position that
+    points into a different method's name.
     """
     try
       let cap_node = node(0)?
@@ -280,6 +291,7 @@ class ref _InlayHintCollector is ASTVisitor
         return
       end
 
+      let name = id_node.token_value() as String
       let line = id_node.line()
       let col = id_node.pos()
       if (line == 0) or (col < 3) then
@@ -290,6 +302,12 @@ class ref _InlayHintCollector is ASTVisitor
 
       let src = id_node.source_contents() as String box
       let name_start = _byte_offset(src, line, col)?
+      // Same synthetic method guard as _try_add_return_type_hint: if the
+      // source character at the claimed position doesn't match the method
+      // name, the position is stale and the method is synthetic.
+      try
+        if src(name_start)? != name(0)? then return end
+      end
       if InlayHintSource.has_explicit_receiver_cap(src, name_start) then
         return
       end


### PR DESCRIPTION
## Context

pony-lsp shows spurious inlay hints on primitive types — extra hints appear alongside the hints for user-defined methods.

## Changes

- Synthetic compiler-generated methods on primitives are detected and skipped during inlay hint collection by verifying that the source at the method's claimed position matches the method name and is followed by a non-identifier character. The boundary-byte check is needed to distinguish synthetic `ne` (which inherits the position of `'n'` in `new`) from a real `ne` method.
- Adds four test fixtures covering: a primitive with a user method, a primitive whose first member is a constructor (the `ne`/`new` collision case), a user method starting with `'e'` (false-positive check), and a primitive with no user-defined methods.

### Before

<img width="808" height="216" alt="image" src="https://github.com/user-attachments/assets/dcc37d86-335f-417b-84a8-fa06fb6bd44b" />

### After

<img width="792" height="223" alt="image" src="https://github.com/user-attachments/assets/9e741713-1a50-4580-8c92-470a413c8e51" />