### PR TITLE
Clarify install-time requirements in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,13 +2,11 @@
 
 Prebuilt Pony binaries are available on a number of platforms. They are built using a very generic CPU instruction set and as such, will not provide maximum performance. If you need to get the best performance possible from your Pony program, we strongly recommend [building from source](BUILD.md).
 
-Prebuilt Pony installations will use clang as the default C compiler and clang++ as the default C++ compiler. If you prefer to use different compilers, such as gcc and g++, these defaults can be overridden by setting the `$CC` and `$CXX` environment variables to your compiler of choice.
-
 ## Linux
 
 Prebuilt Linux packages are available via [ponyup](https://github.com/ponylang/ponyup) for Glibc and musl libc based Linux distribution. You can install nightly builds as well as official releases using ponyup.
 
-If you are running on a supported Linux platform, ponyup should correctly select it so long as you have `cc` and `lsb_release` installed. 
+If you are running on a supported Linux platform, ponyup should correctly select it so long as you have `cc` and `lsb_release` installed.
 
 If we aren't creating packages for your distribution and you would like us to, please stop by the [release stream](https://ponylang.zulipchat.com/#narrow/stream/190364-release) in the [ponylang Zulip](https://ponylang.zulipchat.com) to discuss adding support. Please note, we are almost assuredly going to ask you to help support your distribution.
 
@@ -21,9 +19,11 @@ At the moment, we support all supported LTS Ubuntu versions and any distribution
 ponyup update ponyc release
 ```
 
-### Additional requirements
+### Linux additional requirements
 
-All ponyc Linux installations need to have a C compiler such as clang installed. Compilers other than clang might work, but clang is the officially supported C compiler.
+Install your distribution's libc development package — for example `libc6-dev` on Debian/Ubuntu-based systems or `musl-dev` on Alpine. Installing a C compiler package also works since it pulls these in as dependencies.
+
+ponyc bundles its own linker, so you don't need a C or C++ compiler. What it links against is the system C library and the standard CRT startup objects from your libc-dev package.
 
 ## macOS
 
@@ -35,12 +35,24 @@ To install the most recent ponyc on macOS:
 ponyup update ponyc release
 ```
 
+### macOS additional requirements
+
+ponyc bundles its own linker but uses the macOS SDK that ships with the Xcode Command Line Tools to find the system libraries it links your program against. If you don't already have them installed, run:
+
+```bash
+xcode-select --install
+```
+
+The full Xcode install also satisfies this requirement.
+
 ## Windows
 
-Windows users will need to install:
+To use ponyc on Windows, install one of:
 
-- Visual Studio 2022 or 2019 (available [here](https://www.visualstudio.com/vs/community/)) or the Microsoft C++ Build Tools (available [here](https://visualstudio.microsoft.com/visual-cpp-build-tools/)).
-  - Install the `Desktop Development with C++` workload, along with the latest `Windows 11 SDK (11.x.x.x) for Desktop` individual component.
+- Visual Studio 2022 or 2019 (available [here](https://www.visualstudio.com/vs/community/))
+- Microsoft C++ Build Tools (available [here](https://visualstudio.microsoft.com/visual-cpp-build-tools/))
+
+When installing either, select the `Desktop Development with C++` workload along with the latest `Windows 11 SDK (11.x.x.x) for Desktop` individual component. ponyc bundles its own linker but links your program against the Windows SDK (UCRT, kernel32) and MSVC runtime libraries from this install.
 
 Once you have installed the prerequisites, you can get prebuilt release or nightly builds via [ponyup](https://github.com/ponylang/ponyup).  To install the most recent ponyc on Windows:
 


### PR DESCRIPTION
ponyc bundles its own linker (lld) and links directly against the system C library and runtime objects. The previous text claimed users needed a C compiler installed and described `$CC`/`$CXX` as overrides; neither matches current behavior. `$CXX` has not been read by the source for some time, and ponyc only shells out to a system compiler driver on the `--linker` escape hatch (intentionally not surfaced to end users).

Changes:
- Removed the `$CC`/`$CXX` paragraph from the file preamble.
- Linux "Additional requirements": replaced "install a C compiler" with "install your distribution's libc-dev package" and a brief explanation of why.
- macOS: added an "Additional requirements" subsection covering Xcode Command Line Tools (which provide the SDK ponyc locates via `xcrun --show-sdk-path`).
- Windows: reframed to lead with the install action; brief explanation of which pieces of the VS / Build Tools install ponyc actually consumes (Windows SDK + MSVC runtime libraries).

## Pre-existing gaps surfaced during review (not addressed here)

Worth filing as separate issues:

- Windows ARM64 release artifacts exist but INSTALL.md doesn't mention ARM64 Windows; the manual ZIP link is hardcoded to `ponyc-x86-64-pc-windows-msvc.zip`. Worth checking whether ponyup actually installs an arm64 Windows ponyc.