### PR TITLE
Fix OpenBSD Tier 3 build by disabling LLVM plugin infrastructure

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -138,6 +138,12 @@ set(LLVM_ENABLE_OCAMLDOC OFF CACHE BOOL "ponyc specific override of LLVM cache e
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(LLVM_ENABLE_PIC OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 endif()
+# We statically link LLVM and don't use its plugin infrastructure. Disable
+# explicitly so it doesn't track LLVM_ENABLE_PIC: on OpenBSD that pulls in
+# the Bye example, whose include of llvm/CodeGen/GenVT.inc resolves to the
+# base-system header in /usr/include/llvm before tablegen has generated the
+# in-tree one, producing a macro-signature mismatch.
+set(LLVM_ENABLE_PLUGINS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_TERMINFO OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_WARNINGS OFF CACHE BOOL "ponyc specific override of LLVM cache entry")
 set(LLVM_ENABLE_Z3_SOLVER OFF CACHE BOOL "ponyc specific override of LLVM cache entry")


### PR DESCRIPTION
ponyc statically links LLVM and never uses LLVM's plugin (loadable module) infrastructure. LLVM defaults `LLVM_ENABLE_PLUGINS` to whatever `LLVM_ENABLE_PIC` is on non-Windows platforms; PR #5263 enabled PIC on non-Darwin platforms to fix Fedora's PIE-default linking, which had the side effect of also enabling plugins on OpenBSD.

With plugins enabled, LLVM stops skipping the `Bye` example pass plugin (`Bye ignored -- Loadable modules not supported on this platform`). The Bye target's CMakeLists declares only `DEPENDS intrinsics_gen`, so it compiles before tablegen has generated `llvm/CodeGen/GenVT.inc`. The local include path falls through; on OpenBSD the base system ships LLVM headers in `/usr/include/llvm/`, where an older `GenVT.inc` defines `GET_VT_ATTR` with 9 parameters. The vendored LLVM 21 header expects 12, producing a cascade of "too few arguments" / "missing ',' between enumerators" errors.

Set `LLVM_ENABLE_PLUGINS=OFF` explicitly. PIC stays enabled on non-Darwin so Fedora linking continues to work.

Failing OpenBSD Tier 3 run: https://github.com/ponylang/ponyc/actions/runs/25090529480/job/73515479021