### PR TITLE
Fix pony-lsp document symbols showing spurious eq/ne for bare primitives

### DIFF
--- a/.release-notes/fix-lsp-primitive-document-symbols.md
+++ b/.release-notes/fix-lsp-primitive-document-symbols.md
@@ -1,0 +1,3 @@
+## Fix pony-lsp document symbols showing spurious eq/ne for bare primitives
+
+The document symbol outline (textDocument/documentSymbol) incorrectly included `eq` and `ne` entries for bare primitives that appeared last in their file. These methods are synthesized by the compiler and should not appear in the outline. They now correctly have no children.

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -216,9 +216,9 @@ primitive DocumentSymbols
       file where max_pos is None. They are identified by the structural
       property of BUILD-constructed AST nodes: ponyc's BUILD macro gives every
       node in the subtree the same source position (inherited from the basis).
-      For any user-written member the keyword token (fun/be/new/var/let/embed)
-      and the name identifier appear at different source columns; for a
-      synthesized member they share the same position.
+      For any user-written method the keyword token (fun/be/new) and the name
+      identifier appear at different source columns; for a synthesized method
+      they share the same position.
     """
     let members =
       try
@@ -268,15 +268,11 @@ primitive DocumentSymbols
       // node.
       let is_synthesized: Bool =
         match entity_child.id()
-        | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be() =>
+        | TokenIds.tk_new()
+        | TokenIds.tk_fun()
+        | TokenIds.tk_be() =>
           try
             entity_child(1)?.position() == entity_child.position()
-          else
-            false
-          end
-        | TokenIds.tk_flet() | TokenIds.tk_fvar() | TokenIds.tk_embed() =>
-          try
-            entity_child(0)?.position() == entity_child.position()
           else
             false
           end

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -196,7 +196,7 @@ primitive DocumentSymbols
     Walk the members of `entity` and append a child DocumentSymbol for each
     explicitly written member (field, constructor, function, or behaviour).
 
-    Two categories of members are filtered out:
+    Three categories of members are filtered out:
     - Synthesized constructors: ponyc's sugar pass places the default `create`
       at the entity keyword's own source position (via token_dup). Any
       explicitly written member must appear after the entity keyword, so
@@ -208,6 +208,17 @@ primitive DocumentSymbols
       trait is defined in the same file as the implementing class, the
       merged methods share the same source_file() and are instead caught
       by the position or max_pos filters.)
+    - Comparable methods synthesized by add_comparable: ponyc's traits pass
+      appends synthesized eq/ne to every primitive. These are built with the
+      members node as the BUILD basis, so their position equals the members
+      node's position (at or after the first real member). The position-based
+      filters do not reliably catch them, especially for the last entity in a
+      file where max_pos is None. They are identified by the structural
+      property of BUILD-constructed AST nodes: ponyc's BUILD macro gives every
+      node in the subtree the same source position (inherited from the basis).
+      For any user-written member the keyword token (fun/be/new/var/let/embed)
+      and the name identifier appear at different source columns; for a
+      synthesized member they share the same position.
     """
     let members =
       try
@@ -248,6 +259,32 @@ primitive DocumentSymbols
         | let sf: String val =>
           if sf != dp then continue end
         end
+      end
+      // Skip fully-synthesized members. ponyc's BUILD macro gives every node
+      // in a constructed subtree the same source position (inherited from the
+      // BUILD basis). Real members always place their keyword before their
+      // name identifier; synthesized ones share a single position for both.
+      // This catches add_comparable's eq/ne, whose BUILD basis is the members
+      // node.
+      let is_synthesized: Bool =
+        match entity_child.id()
+        | TokenIds.tk_new() | TokenIds.tk_fun() | TokenIds.tk_be() =>
+          try
+            entity_child(1)?.position() == entity_child.position()
+          else
+            false
+          end
+        | TokenIds.tk_flet() | TokenIds.tk_fvar() | TokenIds.tk_embed() =>
+          try
+            entity_child(0)?.position() == entity_child.position()
+          else
+            false
+          end
+        else
+          false
+        end
+      if is_synthesized then
+        continue
       end
       try
         let maybe_kind_and_idx =

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -23,6 +23,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymMixedChildrenTest.create(server))
     test(_DocSymTypeAliasRangeTest.create(server))
     test(_DocSymPrimitiveRangeTest.create(server))
+    test(_DocSymPrimitiveNoChildrenTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -302,6 +303,37 @@ class \nodoc\ iso _DocSymPrimitiveRangeTest is UnitTest
           None,
           (17, 0, 17, 25),
           (17, 10, 17, 25))])
+
+class \nodoc\ iso _DocSymPrimitiveNoChildrenTest is UnitTest
+  """
+  Regression guard for synthesized `eq`/`ne` leaking into the outline of a
+  primitive that is the last entity in its file.
+
+  `_DsComparable` (in `_ds_comparable.pony`) is a bare primitive with no
+  explicit members, and it is the last entity in the file. When `find_members`
+  processes it, `max_pos` is `None`, so the max-pos filter does not apply.
+  ponyc's traits pass synthesizes `eq` and `ne` via `add_comparable` using the
+  members node as the BUILD basis, giving them the members-node position (> the
+  primitive keyword's position and >= any hypothetical max_pos). They are caught
+  by the BUILD-position filter: ponyc's BUILD macro gives every node in a
+  constructed subtree the same source position, so the synthesized method's
+  keyword node and name identifier share the same position. User-written members
+  always place the keyword before the identifier.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/primitive_no_children"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_comparable.pony",
+      [_DocSymNoChildrenChecker("_DsComparable")])
 
 class val _DocSymContainmentChecker
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -24,6 +24,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymTypeAliasRangeTest.create(server))
     test(_DocSymPrimitiveRangeTest.create(server))
     test(_DocSymPrimitiveNoChildrenTest.create(server))
+    test(_DocSymPrimitivePartialSynthesisTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -334,6 +335,34 @@ class \nodoc\ iso _DocSymPrimitiveNoChildrenTest is UnitTest
       _server,
       "document_symbol/_ds_comparable.pony",
       [_DocSymNoChildrenChecker("_DsComparable")])
+
+class \nodoc\ iso _DocSymPrimitivePartialSynthesisTest is UnitTest
+  """
+  Regression guard for the partial-synthesis case: a primitive that defines
+  `eq` explicitly receives only a synthesized `ne` from `add_comparable`.
+
+  `_DsCompareUserEq` (in `_ds_partial_comparable.pony`) is the last entity in
+  its file, so `max_pos` is `None` and the max-pos filter does not apply.
+  ponyc synthesizes `ne` (but not `eq`, since `has_member("eq")` is true) using
+  the members node as the BUILD basis. The synthesized `ne` shares its keyword
+  position with its name identifier and is caught by the BUILD-position filter.
+  The user-written `eq` has its keyword at a different column from its name and
+  must survive — the symbol must have exactly one child.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/primitive_partial_synthesis"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_compare_user_eq.pony",
+      [_DocSymChildKindsChecker("_DsCompareUserEq", [("eq", 6)])])
 
 class val _DocSymContainmentChecker
   """

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_comparable.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_comparable.pony
@@ -4,4 +4,9 @@
 // (document symbol) panel. `_DsComparable` should appear with no children.
 // A regression shows `eq` and `ne` nested under it.
 
+// IMPORTANT: do not add entities below this primitive. The
+// primitive_no_children test depends on it being the last entity in the
+// file (max_pos is None); adding an entity below would provide a max_pos
+// that culls synthesized eq/ne even without the BUILD-position filter,
+// causing the test to pass with the filter removed.
 primitive _DsComparable

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_comparable.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_comparable.pony
@@ -1,0 +1,7 @@
+// Fixture for `document_symbol/integration/primitive_no_children`.
+//
+// Open this file in an editor with pony-lsp running and check the outline
+// (document symbol) panel. `_DsComparable` should appear with no children.
+// A regression shows `eq` and `ne` nested under it.
+
+primitive _DsComparable

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_compare_user_eq.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_compare_user_eq.pony
@@ -1,0 +1,13 @@
+// Fixture for `document_symbol/integration/primitive_partial_synthesis`.
+//
+// Open this file in an editor with pony-lsp running and check the outline
+// (document symbol) panel. `_DsCompareUserEq` should appear with exactly
+// one child: `eq`. The synthesized `ne` must not appear.
+// A regression shows `ne` nested under it.
+//
+// IMPORTANT: do not add entities below this primitive. The
+// primitive_partial_synthesis test depends on it being the last entity in
+// the file (max_pos is None).
+
+primitive _DsCompareUserEq
+  fun eq(that: _DsCompareUserEq box): Bool => this is that

--- a/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
@@ -21,4 +21,8 @@ Each file in this package targets a specific slice of `DocumentSymbols`:
     a non-overriding implementer. Regression guard for the source-file
     filter in `ASTSourceSpan`: if the filter drops, the impl class's
     range.end.line inflates into the trait file's lines.
+
+  _ds_comparable.pony — bare primitive as the last entity in its file.
+    Regression guard for synthesized `eq`/`ne` (from `add_comparable`)
+    leaking into the outline when `max_pos` is `None`.
 """

--- a/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/document_symbol.pony
@@ -25,4 +25,9 @@ Each file in this package targets a specific slice of `DocumentSymbols`:
   _ds_comparable.pony — bare primitive as the last entity in its file.
     Regression guard for synthesized `eq`/`ne` (from `add_comparable`)
     leaking into the outline when `max_pos` is `None`.
+
+  _ds_compare_user_eq.pony — primitive with user-written `eq` as the last
+    entity in its file. Regression guard for the partial-synthesis case:
+    ponyc skips synthesizing `eq` (already present) but still synthesizes
+    `ne`; the BUILD-position filter must suppress `ne` while preserving `eq`.
 """


### PR DESCRIPTION
## Context

ponyc's traits pass synthesizes `eq` and `ne` on every primitive via `add_comparable`. For non-last entities these are caught by the max-pos filter (their position equals the next entity's start). For the last entity in a file, `max_pos` is `None` so the filter doesn't apply and the synthesized methods leak into the document symbol outline.

## Changes

- Adds a structural filter in `DocumentSymbols.find_members`: ponyc's BUILD macro gives every node in a constructed subtree the same source position (inherited from the BUILD basis), so a synthesized method's keyword node and name identifier share the same position. User-written members always place the keyword before the identifier. Any member where these positions match is skipped.
- Adds fixture `_ds_comparable.pony` — a bare primitive as the last entity in its file — and regression test `document_symbol/integration/primitive_no_children`.

## Consequences

The outline for bare primitives (and any entity with only synthesized members) no longer shows spurious `eq`/`ne` children.

### Before

<img width="1077" height="340" alt="image" src="https://github.com/user-attachments/assets/17f66328-7f1a-4cc1-a641-5d7f16e968b3" />

### After

<img width="1106" height="323" alt="image" src="https://github.com/user-attachments/assets/3f894779-c12c-46e8-92e2-8b43f74fe41d" />
