### PR TITLE
Document that UDPSocket.writev sends one datagram per ByteSeq

### DIFF
--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -167,7 +167,14 @@ actor UDPSocket is AsioEventNotify
 
   be writev(data: ByteSeqIter, to: NetAddress) =>
     """
-    Write a sequence of sequences of bytes.
+    Write a sequence of byte sequences. Each `ByteSeq` in `data` is sent
+    as a separate UDP datagram; this method does not combine them into a
+    single packet.
+
+    Note that this differs from the POSIX `writev` system call, which
+    for record-based protocols like UDP would produce a single datagram.
+    If you need a single datagram, concatenate the data yourself and call
+    `write`.
     """
     for bytes in data.values() do
       _write(bytes, to)


### PR DESCRIPTION
Clarifies in the `UDPSocket.writev` docstring that each `ByteSeq` in the iterator is sent as its own UDP datagram, and that this differs from the POSIX `writev(2)` system call (which combines into a single datagram for record-based protocols). Points users at `write` with self-concatenated data when they want a single packet.

Closes #991