### PR TITLE
Fixed typo 'echo Build' -> 'echo Built' in test-pony-compiler recipe (issue #5283)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ lint-pony-lsp: $(outDir)/pony-lint-ci
 	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lsp/
 
 test-pony-compiler: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-compiler-tests ../../tools/lib/ponylang/pony_compiler/tests && echo Build `pwd`/pony-compiler-tests && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../packages:$(PONYPATH) ./pony-compiler-tests --sequential
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-compiler-tests ../../tools/lib/ponylang/pony_compiler/tests && echo Built `pwd`/pony-compiler-tests && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../packages:$(PONYPATH) ./pony-compiler-tests --sequential
 
 test-cross-stress-release: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-release: debuggercmd=


### PR DESCRIPTION
## Summary

Fix one-character typo in `Makefile` line 310 of the `test-pony-compiler` recipe: `echo Build` becomes `echo Built` to match the convention every other test recipe in the file uses.

## Why this matters

Issue #5283 surfaced this during review of the local-dev invalidation fix that landed in #5284 (the follow-up to #5252). Every other `test-*` recipe in `Makefile` echoes `Built <pwd>/<binary>` once the test binary has been produced (lines 214, 257, 260, 270, 273, 334). The `test-pony-compiler` recipe was the lone outlier with `Build`, which reads as either a typo or a half-finished refactor when scanning build output.

## Changes

`Makefile` line 310, `test-pony-compiler` recipe: `echo Build` -> `echo Built`. No other text affected.

## Testing

`grep -n "echo Build " Makefile` returns no matches after the change. `grep -c "echo Built" Makefile` goes from 14 to 15.

The Makefile change only affects the echo output during `make test-pony-compiler` and has no functional impact on the build or the test run itself.

Fixes #5283
