### PR TITLE
Apply file-target incremental rebuild to test-pony-* targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 - **pony-doc**: `tools/pony-doc/` — Pony documentation generator
 
 ## Make Commands
-All test commands are slow (full rebuild + test run). Run each command at most once per code change — never re-run a command if the code has not changed since the last run.
+On Linux/macOS (via `make`), the first invocation of each command rebuilds its test or lint binary from Pony source (~60s); subsequent invocations skip the rebuild when nothing under the binary's source tree has changed and just run the binary, so re-running on unchanged code is cheap. The Windows `make.ps1` path always rebuilds from source.
 
 - `make test-pony-compiler`
 - `make test-pony-lsp` / `make lint-pony-lsp`

--- a/Makefile
+++ b/Makefile
@@ -210,9 +210,6 @@ pony-lint:
 pony-doc:
 	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --build '$(buildDir)' --config $(config) --target tools.pony-doc -- $(build_flags)
 
-test-pony-doc: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-doc-tests ../../tools/pony-doc/test && echo Built `pwd`/pony-doc-tests && ./pony-doc-tests --sequential
-
 crossBuildDir := $(srcDir)/build/$(arch)/build_$(config)
 
 cross-libponyrt:
@@ -265,25 +262,67 @@ test-examples: all
 test-validate-grammar: all
 	$(SILENT)cd '$(outDir)' && ./ponyc --antlr >> pony.g.new && diff ../../pony.g pony.g.new
 
-# TODO STA: --path entries are temporary until a ponyc bug is fixed.
-test-pony-lsp: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/peg --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lsp-tests ../../tools && echo Built `pwd`/pony-lsp-tests && ./pony-lsp-tests --sequential
+# File-target rules below provide incremental rebuild for the five
+# Pony-source binaries this Makefile builds outside cmake:
+# `pony-lint-ci` and the four `pony-*-tests` test binaries.
+# Order-only `| all` lets cmake build and refresh ponyc without
+# forcing the file rule stale on every invocation. Order-only doesn't
+# propagate mtime, so each rule also carries regular prereqs on
+# `ponyc-bin-srcs` and `stdlib-srcs` -- otherwise
+# `touch src/foo.c && make test-pony-doc` would miss the rebuild.
+# Directory lists are prereqs alongside file lists so `find` notices
+# file deletions (a directory's mtime updates on add/remove; surviving
+# files' mtimes don't move).
 
-test-pony-lint: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-tests ../../tools/pony-lint/test && echo Built `pwd`/pony-lint-tests && PONYPATH=../../packages:$(PONYPATH) ./pony-lint-tests --sequential
+# pony_compiler library -- shared by pony-lint-ci and every
+# pony-*-tests binary.
+compiler-lib-srcs := $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony' -not -name '.*')
+compiler-lib-dirs := $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -type d -not -name '.*')
 
-# Build the lint binary once across the three lint-pony-* targets.
-# Order-only `| all` so cmake builds (and refreshes) ponyc but `all`
-# being .PHONY doesn't mark this rule stale every invocation. Each
-# directory list is a prereq alongside its source list so `find`
-# notices file deletions via mtime changes on the parent directory.
-# `ponyc-bin-srcs` is necessary -- without it, a `touch src/foo.c &&
-# make lint-pony-lint` would miss the rebuild because order-only edges
-# are mtime-opaque by design.
+# pony-lint-ci sources -- the lint binary shared by all three
+# lint-pony-* targets. Sources are the lint tool minus its test/
+# sub-package; the pruned subtree is the entry for pony-lint-tests
+# below, where it is included rather than pruned.
 lint-bin-srcs := $(shell find $(srcDir)/tools/pony-lint -path $(srcDir)/tools/pony-lint/test -prune -o -name '*.pony' -not -name '.*' -print) \
-                 $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -name '*.pony' -not -name '.*')
-lint-bin-dirs := $(shell find $(srcDir)/tools/pony-lint -path $(srcDir)/tools/pony-lint/test -prune -o -type d -print) \
-                 $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/pony_compiler -type d)
+                 $(compiler-lib-srcs)
+lint-bin-dirs := $(shell find $(srcDir)/tools/pony-lint -path $(srcDir)/tools/pony-lint/test -prune -o -type d -not -name '.*' -print) \
+                 $(compiler-lib-dirs)
+
+# pony-doc-tests / pony-lint-tests sources -- each binary builds
+# tools/<tool>/test, and the test code uses ".." to pull the parent
+# package source in. Recursive find covers both. We don't prune the
+# test entry (unlike lint-bin-srcs above) -- for the test binary, the
+# test entry IS the build entry.
+doc-test-srcs := $(shell find $(srcDir)/tools/pony-doc -name '*.pony' -not -name '.*')
+doc-test-dirs := $(shell find $(srcDir)/tools/pony-doc -type d -not -name '.*')
+lint-test-srcs := $(shell find $(srcDir)/tools/pony-lint -name '*.pony' -not -name '.*')
+lint-test-dirs := $(shell find $(srcDir)/tools/pony-lint -type d -not -name '.*')
+
+# pony-compiler-tests sources -- builds tools/.../tests; the test code
+# uses "../pony_compiler" so the library comes in via compiler-lib-*
+# in the file-target rule. Recursive find also sweeps in runtime
+# fixtures (compile_errors_*/, simple/, constructs/) loaded at
+# runtime, not compile time. Editing a fixture triggers an
+# unnecessary rebuild -- accepted trade-off (simpler rule; a future
+# contributor adding a real `use`d sub-package gets correct tracking
+# for free).
+compiler-test-srcs := $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/tests -name '*.pony' -not -name '.*')
+compiler-test-dirs := $(shell find $(srcDir)/tools/lib/ponylang/pony_compiler/tests -type d -not -name '.*')
+
+# pony-lsp-tests sources -- the build entry is tools/, which compiles
+# tools/_test.pony and transitively pulls tools/pony-lsp via
+# `use lsp = "pony-lsp/test"`. -maxdepth 1 picks up tools/_test.pony
+# without recursing into pony-doc/ or pony-lint/ (which the lsp build
+# does not compile). Listing $(srcDir)/tools as a directory prereq
+# means top-of-tools/ adds invalidate this binary; acceptable since
+# tools/ rarely gains files. Recursive find sweeps in runtime fixtures
+# under test/workspace/<feature>/ and test/error_workspace/ -- same
+# trade-off as compiler-test-srcs above.
+lsp-test-srcs := $(shell find $(srcDir)/tools -maxdepth 1 -name '*.pony' -not -name '.*') \
+                 $(shell find $(srcDir)/tools/pony-lsp -name '*.pony' -not -name '.*')
+lsp-test-dirs := $(srcDir)/tools \
+                 $(shell find $(srcDir)/tools/pony-lsp -type d -not -name '.*')
+
 ponyc-bin-srcs := $(shell find $(srcDir)/src -type f \( -name '*.c' -o -name '*.h' -o -name '*.cc' -o -name '*.hh' -o -name '*.ll' -o -name '*.d' \) -not -name '.*')
 ponyc-bin-dirs := $(shell find $(srcDir)/src -type d -not -name '.*')
 stdlib-srcs := $(shell find $(srcDir)/packages -name '*.pony' -not -name '.*')
@@ -306,8 +345,29 @@ lint-pony-doc: $(outDir)/pony-lint-ci
 lint-pony-lsp: $(outDir)/pony-lint-ci
 	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:$(PONYPATH) ./pony-lint-ci ../../tools/pony-lsp/
 
-test-pony-compiler: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-compiler-tests ../../tools/lib/ponylang/pony_compiler/tests && echo Built `pwd`/pony-compiler-tests && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../packages:$(PONYPATH) ./pony-compiler-tests --sequential
+$(outDir)/pony-doc-tests: $(doc-test-srcs) $(doc-test-dirs) $(compiler-lib-srcs) $(compiler-lib-dirs) $(ponyc-bin-srcs) $(ponyc-bin-dirs) $(stdlib-srcs) $(stdlib-dirs) $(outDir)/ponyc | all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-doc-tests ../../tools/pony-doc/test && echo Built `pwd`/pony-doc-tests
+
+$(outDir)/pony-lsp-tests: $(lsp-test-srcs) $(lsp-test-dirs) $(compiler-lib-srcs) $(compiler-lib-dirs) $(ponyc-bin-srcs) $(ponyc-bin-dirs) $(stdlib-srcs) $(stdlib-dirs) $(outDir)/ponyc | all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lsp-tests ../../tools && echo Built `pwd`/pony-lsp-tests
+
+$(outDir)/pony-lint-tests: $(lint-test-srcs) $(lint-test-dirs) $(compiler-lib-srcs) $(compiler-lib-dirs) $(ponyc-bin-srcs) $(ponyc-bin-dirs) $(stdlib-srcs) $(stdlib-dirs) $(outDir)/ponyc | all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-lint-tests ../../tools/pony-lint/test && echo Built `pwd`/pony-lint-tests
+
+$(outDir)/pony-compiler-tests: $(compiler-test-srcs) $(compiler-test-dirs) $(compiler-lib-srcs) $(compiler-lib-dirs) $(ponyc-bin-srcs) $(ponyc-bin-dirs) $(stdlib-srcs) $(stdlib-dirs) $(outDir)/ponyc | all
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc --path ../../tools/lib/ponylang/pony_compiler/ -b pony-compiler-tests ../../tools/lib/ponylang/pony_compiler/tests && echo Built `pwd`/pony-compiler-tests
+
+test-pony-doc: $(outDir)/pony-doc-tests
+	$(SILENT)cd '$(outDir)' && ./pony-doc-tests --sequential
+
+test-pony-lsp: $(outDir)/pony-lsp-tests
+	$(SILENT)cd '$(outDir)' && ./pony-lsp-tests --sequential
+
+test-pony-lint: $(outDir)/pony-lint-tests
+	$(SILENT)cd '$(outDir)' && PONYPATH=../../packages:$(PONYPATH) ./pony-lint-tests --sequential
+
+test-pony-compiler: $(outDir)/pony-compiler-tests
+	$(SILENT)cd '$(outDir)' && PONYPATH=../../tools/lib/ponylang/pony_compiler:../../packages:$(PONYPATH) ./pony-compiler-tests --sequential
 
 test-cross-stress-release: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-release: debuggercmd=


### PR DESCRIPTION
The four `test-pony-*` Makefile targets unconditionally rebuilt their Pony test binaries on every invocation (~60s each). With these tests already running quickly, the rebuild was the dominant cost on re-runs after no source change. This converts each to a file-target rule so rebuilds happen only when relevant sources change, mirroring the pattern PR #5252 + #5284 established for `pony-lint-ci`.

## Lessons from #5252 / #5284 baked in upfront

PR #5252 went through several review cycles before landing the right shape; #5284 then patched the cross-area invalidation gap. This change applies every correction up front:

- Recursive `find` over each binary's source tree (not flat globs), so files in current and future subpackages are picked up.
- Directory lists as prereqs alongside file lists, so file deletions are caught via parent-directory mtime.
- `$(srcDir)` prefix on every `find` path, invariant to `make` invocation cwd.
- AppleDouble exclusion (`-not -name '.*'`) on every find.
- Order-only `| all` plus regular prereqs on `ponyc-bin-srcs` and `stdlib-srcs`, so in-invocation `src/` and `packages/` edits propagate.
- `$(outDir)/ponyc` as a regular prereq (with the existing empty-recipe rule), catching cross-invocation ponyc rebuilds.

## Scope notes

- A small refactor extracts a shared `compiler-lib-srcs` / `compiler-lib-dirs` so the four new test binaries plus `pony-lint-ci` consume one definition rather than five inline copies.
- `lint-bin-dirs` and the new `compiler-lib-dirs` use `-not -name '.*'` on the `-type d` find, matching the existing `ponyc-bin-dirs` / `stdlib-dirs` convention. PR #5252's original `lint-bin-dirs` did not exclude on dirs; aligning all dir finds here as a small consistency fix during the refactor.
- Parse-time tax: `~+50ms` per `make` invocation from the additional `find` calls. Break-even is one no-op save covers ~1200 unrelated invocations of 50ms; clear net win.
- Prereq list sizes (~300-400 per test binary) are in the same regime as the existing `pony-lint-ci` rule (~666 files), already in production.
- The dead `--path .../peg` arg + obsolete TODO STA comment are dropped from `$(outDir)/pony-lsp-tests`. The peg package was removed in PR #5019; ponyc had been silently tolerating the missing directory.
- `make.ps1` is intentionally not updated in this PR. Windows builds still rebuild from source on every invocation; the project CLAUDE.md was qualified to call this out.
- A pre-existing leak in the lint test helper (stale `pony-lint-ast-test*` tmpdirs in `build/release/`) was surfaced during review and filed as #5295.

## Validation

End-to-end on `test-pony-doc`:
- Clean rebuild: built and ran (~120s, 41 tests).
- No-op rerun: ~1s, no rebuild, no `Built ...` line.
- `touch tools/pony-doc/main.pony && make test-pony-doc`: rebuilt and ran.
- `touch src/libponyc/codegen/genopt.cc && make test-pony-doc`: rebuilt and ran (proves `ponyc-bin-srcs` is wired).
- `touch packages/builtin/array.pony && make test-pony-doc`: rebuilt and ran (proves `stdlib-srcs` is wired).
- Deletion of a test source file: rebuild attempted (file restored after).

End-to-end on each of the other three:
- `make test-pony-lint`: built + 392 tests.
- `make test-pony-lsp`: built + 254 tests.
- `make test-pony-compiler`: built + 7 tests.
- No-op rerun on each: ~1s, no rebuild.

Targeted invalidation probes:
- `touch tools/_test.pony && make test-pony-lsp`: rebuilt (proves `lsp-test-srcs` `-maxdepth 1` clause is wired).
- `touch tools/lib/ponylang/pony_compiler/tests/main.pony && make test-pony-compiler`: rebuilt (proves `compiler-test-srcs`).
- `touch tools/lib/ponylang/pony_compiler/pony_compiler/compiler.pony && make test-pony-lint`: rebuilt (proves shared `compiler-lib-srcs` invalidates non-doc binaries).

Refactor regression check: `make -pn lint-pony-lint` prereq line for `pony-lint-ci` has the same set of files before and after the `compiler-lib-*` extraction (modulo the new `-not -name '.*'` on dir finds, which only excludes hidden directories that don't currently exist).

After dropping the peg `--path` arg, re-validated `pony-lsp-tests` builds and all 254 tests pass.

Closes #5281