### PR TITLE
Fix typos in standard library documentation

### DIFF
--- a/packages/backpressure/backpressure.pony
+++ b/packages/backpressure/backpressure.pony
@@ -81,7 +81,7 @@ create deadlocks. Any call to `Backpressure.apply` should be matched by a
 corresponding call to `Backpressure.release`. Authorization via the
 `ApplyReleaseBackpressureAuth` capability is required to apply or release
 backpressure. By requiring that the caller have a token to apply or release a
-backpressure, rouge 3rd party library code can't run wild and unknowingly
+backpressure, rogue 3rd party library code can't run wild and unknowingly
 interfere with the runtime.
 """
 

--- a/packages/builtin/iterator.pony
+++ b/packages/builtin/iterator.pony
@@ -4,7 +4,7 @@ interface Iterator[A]
   Iterators generate a series of values, one value at a time on each call to `next()`.
 
   An Iterator is considered exhausted, once its `has_next()` method returns `false`.
-  Thus every call to `next()` should be preceeded with a call to `has_next()` to
+  Thus every call to `next()` should be preceded with a call to `has_next()` to
   check for exhaustiveness.
 
   ## Usage

--- a/packages/builtin/std_stream.pony
+++ b/packages/builtin/std_stream.pony
@@ -15,7 +15,7 @@ interface val ByteSeqIter
 
 interface tag OutStream
   """
-  Asnychronous access to some output stream.
+  Asynchronous access to some output stream.
   """
   be print(data: ByteSeq)
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -616,7 +616,7 @@ actor Main
   fun repeat_str(num: USize = 1, sep: String = ""): String iso^ =>
     """
     Returns a copy of the string repeated `num` times with an optional
-    separator added inbetween repeats.
+    separator added in between repeats.
     """
     var c = num
     var str = recover String((_size + sep.size()) * c) end

--- a/packages/cli/cli.pony
+++ b/packages/cli/cli.pony
@@ -43,7 +43,7 @@ when parsing a command line or forming syntax help messages.
 
 Options and Args parse values from the command line as one of four Pony types:
 `Bool`, `String`, `I64` and `F64`. Values of each of these types can then be
-retrieved using the corresponding accessor funtions.
+retrieved using the corresponding accessor functions.
 
 In addition, there is a string_seq type that accepts string values from the
 command line and collects them into a sequence which can then be retrieved as

--- a/packages/cli/command_spec.pony
+++ b/packages/cli/command_spec.pony
@@ -145,7 +145,7 @@ class CommandSpec
 
   fun help_string(): String =>
     """
-    Returns a formated help string for this command and all of its arguments.
+    Returns a formatted help string for this command and all of its arguments.
     """
     let s = _name.clone()
     s.append(" ")
@@ -325,7 +325,7 @@ class val OptionSpec
 
   fun help_string(): String =>
     """
-    Returns a formated help string for this option.
+    Returns a formatted help string for this option.
     """
     let s =
       match _short
@@ -473,7 +473,7 @@ class val ArgSpec
 
   fun help_string(): String =>
     """
-    Returns a formated help string for this arg.
+    Returns a formatted help string for this arg.
     """
     "<" + _name + ">"
 

--- a/packages/collections/collections.pony
+++ b/packages/collections/collections.pony
@@ -4,9 +4,9 @@
 The Collections package provides a variety of collection classes, 
 including map, set, range, heap, ring buffer, list, and flags.
 
-`Map` - Hashmap by strutural equality (use `MapIs` for identity equality).
+`Map` - Hashmap by structural equality (use `MapIs` for identity equality).
 
-`Set` - A set built on top of `Map` using structural equility (use `SetIs` for identity equality).
+`Set` - A set built on top of `Map` using structural equality (use `SetIs` for identity equality).
 
 `Range` - Iterate over a range of numbers with optional step size.
 

--- a/packages/collections/flag.pony
+++ b/packages/collections/flag.pony
@@ -173,7 +173,7 @@ class Flags[A: Flag[B] val, B: (Unsigned & Integer[B] val) = U64] is
     """
     Returns true if the flags set on this are a subset of the flags set on
     that or they are the same. Flags is only partially ordered, so le is not
-    the opposite of te.
+    the opposite of gt.
     """
     ((_value and not that._value) == 0)
 

--- a/packages/constrained_types/constrained_types.pony
+++ b/packages/constrained_types/constrained_types.pony
@@ -104,7 +104,7 @@ On our usage side we have:
 
 Where we use the `MakeUsername` alias that we use to attempt to create a
 `Username` and get back either a `Username` or `ValidationFailure` that should
-have one ore more error messages for us to display.
+have one or more error messages for us to display.
 
 Finally, we have a function that can only be used with a valid `Username`:
 

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -96,7 +96,7 @@ class Directory
 
   new iso _relative(path': FilePath, fd': I32) =>
     """
-    Internal constructor. Capsicum rights are already set by inheritence.
+    Internal constructor. Capsicum rights are already set by inheritance.
     """
     path = path'
     _fd = fd'

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -293,7 +293,7 @@ class val FilePath
     """
     Create a symlink to a file or directory.
 
-    Note that on Windows a program must be running with elevated priviledges to
+    Note that on Windows a program must be running with elevated privileges to
     be able to create symlinks.
     """
     if not caps(FileLink) or not link_name.caps(FileCreate) then

--- a/packages/files/files.pony
+++ b/packages/files/files.pony
@@ -5,7 +5,7 @@ The Files package provides classes for working with files and
 directories.
 
 Files are identified by `FilePath` objects, which represent both the
-path to the file and the capabilites for accessing the file at that
+path to the file and the capabilities for accessing the file at that
 path. `FilePath` objects can be used with the `CreateFile` and
 `OpenFile` primitives and the `File` class to get a reference to a
 file that can be used to write to and/or read from the file. It can

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -209,7 +209,7 @@ actor TCPConnection is AsioEventNotify
   service.
 
   The proxy `TCPConnectionNotify` should decorate another implementation of
-  `TCPConnectionNotify` passing relevent data through.
+  `TCPConnectionNotify` passing relevant data through.
 
   ### Example proxy implementation
 

--- a/packages/pony_bench/benchmark.pony
+++ b/packages/pony_bench/benchmark.pony
@@ -12,7 +12,7 @@ trait iso MicroBenchmark
   single iteration in a sample. Setup and Teardown are defined by the `before`
   and `after` methods respectively. The `before` method runs before a sample
   of benchmarks and `after` runs after the all iterations in the sample have
-  completed. If your benchmark requires setup and/or teardown to occur beween
+  completed. If your benchmark requires setup and/or teardown to occur between
   each iteration of the benchmark, then you can use `before_iteration` and
   `after_iteration` methods respectively that run before/after each iteration.
   """
@@ -33,7 +33,7 @@ trait iso AsyncMicroBenchmark
   Teardown are defined by the `before` and `after` methods respectively. The
   `before` method runs before a sample of benchmarks and `after` runs after
   the all iterations in the sample have completed. If your benchmark requires
-  setup and/or teardown to occur beween each iteration of the benchmark, then
+  setup and/or teardown to occur between each iteration of the benchmark, then
   you can use `before_iteration` and `after_iteration` methods respectively
   that run before/after each iteration.
   """

--- a/packages/pony_check/generator.pony
+++ b/packages/pony_check/generator.pony
@@ -113,7 +113,7 @@ class box Generator[T] is GenObj[T]
 
   When a failing sample is found, the PonyCheck engine is trying to find a
   smaller or more simple sample by shrinking it with `shrink`.
-  If the generator did not provide any shrinked samples
+  If the generator did not provide any shrunk samples
   as a result of `generate`, its `shrink` method is called
   to obtain simpler results. PonyCheck obtains more shrunken samples until
   the property is not failing anymore.
@@ -1265,7 +1265,7 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings withing the given `range`,
+    Create a generator for strings within the given `range`,
     with a minimum length of `min` (default: 0)
     and a maximum length of `max` (default: 100).
     """

--- a/packages/pony_test/test_helper.pony
+++ b/packages/pony_test/test_helper.pony
@@ -103,7 +103,7 @@ class val TestHelper
     : Bool
   =>
     """
-    Assert that the gived test function does not throw an error when run.
+    Assert that the given test function does not throw an error when run.
     """
     try
       test()?

--- a/packages/process/_pipe.pony
+++ b/packages/process/_pipe.pony
@@ -142,7 +142,7 @@ class _Pipe
   fun ref close_far() =>
     """
     Close the far end of the pipe--the end that the other process will be
-    using. This is used to cleanup this process' handles that it wont use.
+    using. This is used to cleanup this process' handles that it won't use.
     """
     if far_fd != -1 then
       @close(far_fd)

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -315,7 +315,7 @@ class _ProcessPosix is _Process
 
 primitive _WaitPidStatus
   """
-  Pure Pony implementaton of C macros for investigating
+  Pure Pony implementation of C macros for investigating
   the status returned by `waitpid()`.
   """
 

--- a/packages/process/process_notify.pony
+++ b/packages/process/process_notify.pony
@@ -44,7 +44,7 @@ interface ProcessNotify
     `dispose` includes the exit status of the child process. If the process
     finished, then `child_exit_status` will be an instance of [Exited](process-Exited.md).
 
-    The childs exit code can be retrieved from the `Exited` instance by using
+    The child's exit code can be retrieved from the `Exited` instance by using
     [Exited.exit_code()](process-Exited.md#exit_code).
 
     On Posix systems, if the process has been killed by a signal (e.g. through

--- a/packages/promises/promises.pony
+++ b/packages/promises/promises.pony
@@ -14,7 +14,7 @@ fulfill handler do not have to be the same, so a chain of fulfill
 handlers can transform the original value into something new.
 
 Fulfill and reject handlers can either be specified as classes that
-implment the `Fulfill` and `Reject` interfaces, or as functions with
+implement the `Fulfill` and `Reject` interfaces, or as functions with
 the same signatures as the `apply` methods in `Fulfill` and `Reject`.
 
 In the following code, the fulfillment of the `Promise` causes the

--- a/packages/random/splitmix64.pony
+++ b/packages/random/splitmix64.pony
@@ -6,7 +6,7 @@ class SplitMix64 is Random
   http://xoshiro.di.unimi.it/ and http://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
 
   Using [XorOshiro128StarStar](random-XorOshiro128StarStar.md) or [XorOshiro128Plus](random-XorOshiro128Plus.md)
-  should be prefered unless using only 64 bit of state is a requirement.
+  should be preferred unless using only 64 bit of state is a requirement.
   """
   // state
   var _x: U64

--- a/tools/pony-lsp/diagnostics.pony
+++ b/tools/pony-lsp/diagnostics.pony
@@ -75,8 +75,8 @@ class val Diagnostic
 
   fun val expand_related(): Array[Diagnostic] val =>
     """
-    Turn all related informations in to their own
-    Diagnostic items pointing at the same place as the
+    Turn each piece of related information into its own
+    Diagnostic item pointing at the same place as the
     root diagnostic.
 
     This is necessary for some clients (e.g. neovim), as


### PR DESCRIPTION
Spelling errors and typos corrected in docstrings across the backpressure, builtin, cli, collections, constrained_types, files, net, pony_bench, pony_check, pony_test, process, promises, and random packages, and the pony-lsp tool.

The fix in collections.Flags.le also corrects a stale cross-reference: the docstring previously said "le is not the opposite of te," referring to a function name that does not exist. It now correctly says "le is not the opposite of gt," matching the parallel note on Flags.gt.