### PR TITLE
Add LSP type hierarchy support

### DIFF
--- a/.release-notes/add-type-hierarchy.md
+++ b/.release-notes/add-type-hierarchy.md
@@ -1,0 +1,14 @@
+## Add LSP type hierarchy support
+
+The Pony language server now supports the LSP type hierarchy protocol:
+
+- `textDocument/prepareTypeHierarchy` — places a cursor on a class, trait,
+  actor, interface, primitive, or struct and returns a `TypeHierarchyItem`
+  describing it.
+- `typeHierarchy/supertypes` — returns items for each type in the entity's
+  `is` (provides) list.
+- `typeHierarchy/subtypes` — cross-package walk that returns items for every
+  entity whose `is` list directly includes the given type.
+
+Editors that support this protocol (VS Code, Neovim, etc.) expose it as
+"Show Type Hierarchy", "Go to Supertypes", and "Go to Subtypes" commands.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -289,6 +289,94 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] No workspace found for '" +
                 r.json().string() + "'")))
         end
+      | Methods.text_document().prepare_type_hierarchy() =>
+        let document_uri =
+          try _get_document_uri(r.params)?
+          else
+            this._channel.send(
+              ResponseMessage.create(
+                r.id,
+                None,
+                ResponseError(
+                  ErrorCodes.invalid_params(),
+                  "[" + r.method + "] missing textDocument.uri")))
+            return
+          end
+        try
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .type_hierarchy_prepare(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                  document_uri + "'")))
+        end
+      | Methods.type_hierarchy().supertypes() =>
+        (let item_uri, let sel_line, let sel_col) =
+          try
+            ( JsonNav(r.params)("item")("uri").as_string()?
+            , JsonNav(r.params)("item")("selectionRange")("start")("line")
+                .as_i64()?
+            , JsonNav(r.params)("item")("selectionRange")("start")("character")
+                .as_i64()? )
+          else
+            this._channel.send(
+              ResponseMessage.create(
+                r.id,
+                None,
+                ResponseError(
+                  ErrorCodes.invalid_params(),
+                  "[" + r.method + "] missing item or selectionRange.start")))
+            return
+          end
+        try
+          (_router.find_workspace(item_uri) as WorkspaceManager)
+            .type_hierarchy_supertypes(item_uri, sel_line, sel_col, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                  item_uri + "'")))
+        end
+      | Methods.type_hierarchy().subtypes() =>
+        (let item_uri, let sel_line, let sel_col) =
+          try
+            ( JsonNav(r.params)("item")("uri").as_string()?
+            , JsonNav(r.params)("item")("selectionRange")("start")("line")
+                .as_i64()?
+            , JsonNav(r.params)("item")("selectionRange")("start")("character")
+                .as_i64()? )
+          else
+            this._channel.send(
+              ResponseMessage.create(
+                r.id,
+                None,
+                ResponseError(
+                  ErrorCodes.invalid_params(),
+                  "[" + r.method + "] missing item or selectionRange.start")))
+            return
+          end
+        try
+          (_router.find_workspace(item_uri) as WorkspaceManager)
+            .type_hierarchy_subtypes(item_uri, sel_line, sel_col, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                  item_uri + "'")))
+        end
       | Methods.workspace().symbol() =>
         let query = try JsonNav(r.params)("query").as_string()? else "" end
         _router.workspace_symbol(query, this._channel, r.id)
@@ -546,7 +634,8 @@ actor LanguageServer is (Notifier & RequestSender)
                       JsonArray.push("(").push(","))
                     .update(
                       "retriggerCharacters",
-                      JsonArray.push("(").push(","))))
+                      JsonArray.push("(").push(",")))
+                .update("typeHierarchyProvider", true))
             .update(
               "serverInfo",
               JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -42,6 +42,12 @@ primitive Methods
     """
     WindowMethods
 
+  fun type_hierarchy(): TypeHierarchyMethods =>
+    """
+    Access typeHierarchy scoped methods.
+    """
+    TypeHierarchyMethods
+
   fun workspace(): WorkspaceMethods =>
     """
     Access workspace scoped methods.
@@ -153,6 +159,20 @@ primitive TextDocumentMethods
 
   fun signature_help(): String val =>
     "textDocument/signatureHelp"
+
+  fun prepare_type_hierarchy(): String val =>
+    "textDocument/prepareTypeHierarchy"
+
+primitive TypeHierarchyMethods
+  """
+  Collection of typeHierarchy scoped methods.
+  """
+
+  fun supertypes(): String val =>
+    "typeHierarchy/supertypes"
+
+  fun subtypes(): String val =>
+    "typeHierarchy/subtypes"
 
 primitive ClientMethods
   """

--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -1,0 +1,479 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+// Fixture layout — _t_hier_b.pony (0-indexed lines, 0-indexed cols):
+// line  0: trait _THierA  name (0,6)..(0,13)   full (0,0)..(4,17)
+// line  6: trait _THierB  name (6,6)..(6,13)   full (6,0)..(11,17)
+// line 13: class _THierC  name (13,6)..(13,13) full (13,0)..(18,25)
+//
+// Fixture layout — _t_hier_isect.pony:
+// line  0: trait _THierLeft   name (0,6)..(0,16)   full (0,0)..(4,17)
+// line  6: trait _THierRight  name (6,6)..(6,17)   full (6,0)..(10,17)
+// line 12: trait _THierIsect  name (12,6)..(12,17) full (12,0)..(19,17)
+//
+// Fixture layout — _t_hier_d.pony:
+// line 0: trait _THierD  name (0,6)..(0,13)  full (0,0)..(6,17)
+//
+// Fixture layout — _t_hier_e.pony:
+// line 0: class _THierE  name (0,6)..(0,13)  full (0,0)..(4,27)
+// (_THierE is the last entity in its file; SiblingBound returns None so
+// ASTSourceSpan includes synthesized constructor tokens, inflating by 2.)
+
+primitive _TypeHierarchyIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_PrepareTypeHierarchyOnEntityTest.create(server))
+    test(_PrepareTypeHierarchyOnNonEntityTest.create(server))
+    test(_TypeHierarchySupertypesTest.create(server))
+    test(_TypeHierarchySupertypesEmptyTest.create(server))
+    test(_TypeHierarchySubtypesTest.create(server))
+    test(_TypeHierarchySubtypesLeafTest.create(server))
+    test(_TypeHierarchyIsectypeTest.create(server))
+    test(_TypeHierarchySubtypesCrossFileTest.create(server))
+
+class \nodoc\ iso _PrepareTypeHierarchyOnEntityTest is UnitTest
+  """
+  Cursor on _THierB name (line 6, col 6) — expects a one-element result
+  with all TypeHierarchyItem fields verified.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/prepare_entity"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_b = "type_hierarchy/_t_hier_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_b,
+      [ _PrepareTypeHierarchyChecker(
+          (6, 6),
+          _THierExpected(
+            "_THierB",
+            11,
+            workspace_dir,
+            t_hier_b,
+            (6, 6, 6, 13),
+            (6, 0, 11, 17))) ])
+
+class \nodoc\ iso _PrepareTypeHierarchyOnNonEntityTest is UnitTest
+  """
+  Cursor on method keyword `fun` (line 4, col 2) — not an entity.
+  Expects null result.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/prepare_non_entity"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "type_hierarchy/_t_hier_b.pony",
+      [_PrepareTypeHierarchyChecker((4, 2), None)])
+
+class \nodoc\ iso _TypeHierarchySupertypesTest is UnitTest
+  """
+  Supertypes of _THierB (provides _THierA) — expects one item with all
+  TypeHierarchyItem fields verified.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/supertypes"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_b = "type_hierarchy/_t_hier_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_b,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().supertypes(),
+          workspace_dir,
+          t_hier_b,
+          (6, 6),
+          [ _THierExpected(
+              "_THierA",
+              11,
+              workspace_dir,
+              t_hier_b,
+              (0, 6, 0, 13),
+              (0, 0, 4, 17)) ]) ])
+
+class \nodoc\ iso _TypeHierarchySupertypesEmptyTest is UnitTest
+  """
+  Supertypes of _THierA (no provides) — expects an empty array (not null).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/supertypes_empty"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_b = "type_hierarchy/_t_hier_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_b,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().supertypes(),
+          workspace_dir,
+          t_hier_b,
+          (0, 6),
+          []) ])
+
+class \nodoc\ iso _TypeHierarchySubtypesTest is UnitTest
+  """
+  Subtypes of _THierA — expects one item: _THierB.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/subtypes"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_b = "type_hierarchy/_t_hier_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_b,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().subtypes(),
+          workspace_dir,
+          t_hier_b,
+          (0, 6),
+          [ _THierExpected(
+              "_THierB",
+              11,
+              workspace_dir,
+              t_hier_b,
+              (6, 6, 6, 13),
+              (6, 0, 11, 17)) ]) ])
+
+class \nodoc\ iso _TypeHierarchySubtypesLeafTest is UnitTest
+  """
+  Subtypes of _THierC (a leaf class) — expects an empty array (not null).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/subtypes_leaf"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_b = "type_hierarchy/_t_hier_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_b,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().subtypes(),
+          workspace_dir,
+          t_hier_b,
+          (13, 6),
+          []) ])
+
+class \nodoc\ iso _TypeHierarchyIsectypeTest is UnitTest
+  """
+  Supertypes of _THierIsect (provides _THierLeft & _THierRight via
+  intersection type) — verifies the tk_isecttype recursion path in
+  _collect_provides_defs.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/supertypes_isecttype"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_isect = "type_hierarchy/_t_hier_isect.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_isect,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().supertypes(),
+          workspace_dir,
+          t_hier_isect,
+          (12, 6),
+          [ _THierExpected(
+              "_THierLeft",
+              11,
+              workspace_dir,
+              t_hier_isect,
+              (0, 6, 0, 16),
+              (0, 0, 4, 17))
+            _THierExpected(
+              "_THierRight",
+              11,
+              workspace_dir,
+              t_hier_isect,
+              (6, 6, 6, 17),
+              (6, 0, 10, 17)) ]) ])
+
+class \nodoc\ iso _TypeHierarchySubtypesCrossFileTest is UnitTest
+  """
+  Subtypes of _THierD — expects _THierE from a different source file,
+  verifying the cross-module walk in _SubtypeCollector.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/subtypes_cross_file"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_d = "type_hierarchy/_t_hier_d.pony"
+    let t_hier_e = "type_hierarchy/_t_hier_e.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_d,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().subtypes(),
+          workspace_dir,
+          t_hier_d,
+          (0, 6),
+          [ _THierExpected(
+              "_THierE",
+              5,
+              workspace_dir,
+              t_hier_e,
+              (0, 6, 0, 13),
+              (0, 0, 4, 27)) ]) ])
+
+class val _THierExpected
+  """
+  Expected TypeHierarchyItem field values for assertion in test checkers.
+  sel: selectionRange (start_line, start_char, end_line, end_char).
+  rng: full range (start_line, start_char, end_line, end_char).
+  """
+  let name: String val
+  let kind: I64
+  let uri: String val
+  let sel: (I64, I64, I64, I64)
+  let rng: (I64, I64, I64, I64)
+
+  new val create(
+    name': String,
+    kind': I64,
+    workspace_dir: String,
+    workspace_file: String,
+    sel': (I64, I64, I64, I64),
+    rng': (I64, I64, I64, I64))
+  =>
+    name = name'
+    kind = kind'
+    uri = Uris.from_path(Path.join(workspace_dir, workspace_file))
+    sel = sel'
+    rng = rng'
+
+class val _PrepareTypeHierarchyChecker
+  """
+  Checker for textDocument/prepareTypeHierarchy.
+  The harness supplies textDocument.uri; lsp_params adds position.
+  Pass None for expected to assert a null result (non-entity cursor).
+  """
+  let _sel_pos: (I64, I64)
+  let _expected: (_THierExpected val | None)
+
+  new val create(
+    sel_pos': (I64, I64),
+    expected: (_THierExpected val | None))
+  =>
+    _sel_pos = sel_pos'
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().prepare_type_hierarchy()
+
+  fun lsp_params(): (None | JsonObject) =>
+    JsonObject.update(
+      "position",
+      JsonObject
+        .update("line", _sel_pos._1)
+        .update("character", _sel_pos._2))
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match \exhaustive\ _expected
+    | None =>
+      match res.result
+      | None => true
+      else
+        h.fail("prepare: expected null for non-entity cursor, got non-null")
+        false
+      end
+    | let exp: _THierExpected val =>
+      match res.result
+      | let arr: JsonArray =>
+        var ok =
+          h.assert_eq[USize](
+            1,
+            try JsonNav(arr).size()? else 0 end,
+            "prepare: expected single item")
+        ok = _THierCheckItem(JsonNav(arr), 0, exp, h) and ok
+        ok
+      | None =>
+        h.fail("prepare: expected item, got null")
+        false
+      else
+        h.fail("prepare: expected array result")
+        false
+      end
+    end
+
+class val _THierItemsChecker
+  """
+  Checker for typeHierarchy/supertypes and typeHierarchy/subtypes.
+  Asserts the result is a JsonArray (not null), verifies item count, and
+  checks all TypeHierarchyItem fields: name, kind, uri, selectionRange,
+  range.
+  """
+  let _method: String
+  let _item_uri: String val
+  let _sel_pos: (I64, I64)
+  let _expected: Array[_THierExpected val] val
+
+  new val create(
+    method': String,
+    workspace_dir: String,
+    item_file: String,
+    sel_pos': (I64, I64),
+    expected: Array[_THierExpected val] val)
+  =>
+    _method = method'
+    _item_uri = Uris.from_path(Path.join(workspace_dir, item_file))
+    _sel_pos = sel_pos'
+    _expected = expected
+
+  fun lsp_method(): String => _method
+
+  fun lsp_params(): (None | JsonObject) =>
+    JsonObject.update(
+      "item",
+      JsonObject
+        .update("uri", _item_uri)
+        .update(
+          "selectionRange",
+          JsonObject.update(
+            "start",
+            JsonObject
+              .update("line", _sel_pos._1)
+              .update("character", _sel_pos._2))))
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | None =>
+      if _expected.size() == 0 then
+        h.fail(_method + ": expected [] not null for empty result")
+      else
+        h.fail(_method + ": expected items, got null")
+      end
+      false
+    | let arr: JsonArray =>
+      let nav = JsonNav(arr)
+      var ok =
+        h.assert_eq[USize](
+          _expected.size(),
+          try nav.size()? else 0 end,
+          _method + ": wrong item count")
+      for (i, exp) in _expected.pairs() do
+        ok = _THierCheckItem(nav, i, exp, h) and ok
+      end
+      ok
+    else
+      h.fail(_method + ": expected array result")
+      false
+    end
+
+primitive _THierCheckItem
+  """
+  Asserts all TypeHierarchyItem fields of the item at index i in nav.
+  """
+  fun apply(
+    nav: JsonNav box,
+    i: USize,
+    exp: _THierExpected val,
+    h: TestHelper): Bool
+  =>
+    try
+      var ok = true
+      ok = h.assert_eq[String](
+        exp.name,
+        nav(i)("name").as_string()?,
+        "item[" + i.string() + "].name") and ok
+      ok = h.assert_eq[I64](
+        exp.kind,
+        nav(i)("kind").as_i64()?,
+        "item[" + i.string() + "].kind") and ok
+      ok = h.assert_eq[String](
+        exp.uri,
+        nav(i)("uri").as_string()?,
+        "item[" + i.string() + "].uri") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._1,
+        nav(i)("selectionRange")("start")("line").as_i64()?,
+        "item[" + i.string() + "].selectionRange.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._2,
+        nav(i)("selectionRange")("start")("character").as_i64()?,
+        "item[" + i.string() + "].selectionRange.start.character") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._3,
+        nav(i)("selectionRange")("end")("line").as_i64()?,
+        "item[" + i.string() + "].selectionRange.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._4,
+        nav(i)("selectionRange")("end")("character").as_i64()?,
+        "item[" + i.string() + "].selectionRange.end.character") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._1,
+        nav(i)("range")("start")("line").as_i64()?,
+        "item[" + i.string() + "].range.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._2,
+        nav(i)("range")("start")("character").as_i64()?,
+        "item[" + i.string() + "].range.start.character") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._3,
+        nav(i)("range")("end")("line").as_i64()?,
+        "item[" + i.string() + "].range.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._4,
+        nav(i)("range")("end")("character").as_i64()?,
+        "item[" + i.string() + "].range.end.character") and ok
+      ok
+    else
+      h.fail(
+        "item[" + i.string() + "] missing or has wrong structure"
+          + " (expected: " + exp.name + ")")
+      false
+    end

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -36,6 +36,7 @@ actor Main is TestList
     _SelectionRangeIntegrationTests.make().tests(test)
     _WorkspaceSymbolIntegrationTests.make().tests(test)
     _SignatureHelpIntegrationTests.make().tests(test)
+    _TypeHierarchyIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_b.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_b.pony
@@ -1,0 +1,19 @@
+trait _THierA
+  """
+  Root of the linear hierarchy chain. No supertypes; subtypes = [_THierB].
+  """
+  fun f_a(): None
+
+trait _THierB is _THierA
+  """
+  Middle of the linear hierarchy chain. Supertypes = [_THierA];
+  subtypes = [_THierC].
+  """
+  fun f_b(): None
+
+class _THierC is _THierB
+  """
+  Leaf of the linear hierarchy chain. Supertypes = [_THierB]; no subtypes.
+  """
+  fun f_a(): None => None
+  fun f_b(): None => None

--- a/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_d.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_d.pony
@@ -1,0 +1,7 @@
+trait _THierD
+  """
+  Supertype half of a cross-file pair (subtype: _THierE in _t_hier_e.pony).
+  Subtypes should return [_THierE] even though it is defined in a separate
+  file, demonstrating that the server walks all modules in the compiled package.
+  """
+  fun f_d(): None

--- a/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_e.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_e.pony
@@ -1,0 +1,5 @@
+class _THierE is _THierD
+  """
+  Subtype half of a cross-file pair (supertype: _THierD in _t_hier_d.pony).
+  """
+  fun f_d(): None => None

--- a/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_isect.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_isect.pony
@@ -1,0 +1,20 @@
+trait _THierLeft
+  """
+  Left branch of the intersection in _THierIsect.
+  """
+  fun f_l(): None
+
+trait _THierRight
+  """
+  Right branch of the intersection in _THierIsect.
+  """
+  fun f_r(): None
+
+trait _THierIsect is (_THierLeft & _THierRight)
+  """
+  Fixture for intersection-type provides traversal. Supertypes should return
+  both _THierLeft and _THierRight, demonstrating that the server recurses
+  through tk_isecttype nodes in the provides clause.
+  """
+  fun f_l(): None
+  fun f_r(): None

--- a/tools/pony-lsp/test/workspace/type_hierarchy/type_hierarchy.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/type_hierarchy.pony
@@ -1,0 +1,28 @@
+"""
+Test fixtures for exercising LSP type hierarchy functionality.
+
+This package provides fixture files for manual and automated testing of the
+three LSP type hierarchy operations (prepareTypeHierarchy,
+typeHierarchy/supertypes, and typeHierarchy/subtypes).
+
+To manually test type hierarchy functionality:
+1. Open the lsp/test/workspace directory as a project in your editor while
+   the Pony language server is active.
+2. Open _t_hier_b.pony and place your cursor on `_THierA`, `_THierB`, or
+   `_THierC`, then invoke "Show Type Hierarchy" from the editor menu or
+   command palette.
+3. Open _t_hier_isect.pony and place your cursor on `_THierIsect` to verify
+   that intersection-type provides clauses expand into both supertypes.
+4. Open _t_hier_d.pony and place your cursor on `_THierD` to verify that
+   subtypes defined in other files are found.
+
+Expected type hierarchy behavior:
+- prepareTypeHierarchy returns a single item when the cursor is on a type
+  name, or null when the cursor is not on a type name
+- typeHierarchy/supertypes returns the types in the entity's provides clause,
+  including both sides of intersection types
+- typeHierarchy/subtypes returns all types in the compiled package that
+  provide the queried type, even when defined in other files
+- Both supertypes and subtypes return an empty array (not null) when there
+  are no results
+"""

--- a/tools/pony-lsp/workspace/type_hierarchy.pony
+++ b/tools/pony-lsp/workspace/type_hierarchy.pony
@@ -1,0 +1,230 @@
+use ".."
+use "collections"
+use "pony_compiler"
+use "json"
+
+primitive TypeHierarchy
+  """
+  Handles textDocument/prepareTypeHierarchy, typeHierarchy/supertypes,
+  and typeHierarchy/subtypes.
+  """
+
+  fun prepare(node: AST box): (JsonArray | None) =>
+    """
+    Resolve the entity at `node` and build a one-element TypeHierarchyItem
+    array, or None if no entity is found at the cursor.
+    """
+    match \exhaustive\ _entity_for_node(node)
+    | let entity: AST val =>
+      match \exhaustive\ _build_item(entity)
+      | let item: JsonObject => JsonArray.push(item)
+      | None => None
+      end
+    | None => None
+    end
+
+  fun supertypes(node: AST box): (JsonArray | None) =>
+    """
+    Resolve the entity at `node` and return TypeHierarchyItems for each
+    type in its provides list (direct supertypes only).
+    """
+    match \exhaustive\ _entity_for_node(node)
+    | let entity: AST val => _collect_supertypes(entity)
+    | None => None
+    end
+
+  fun subtypes(
+    node: AST box,
+    packages: Map[String, PackageState] box): (JsonArray | None)
+  =>
+    """
+    Resolve the entity at `node`, then cross-package walk to collect all
+    entities whose provides list directly references that entity.
+    """
+    match \exhaustive\ _entity_for_node(node)
+    | let entity: AST val =>
+      let collector = _SubtypeCollector(entity)
+      for pkg_state in packages.values() do
+        match pkg_state.package()
+        | let pkg: Package =>
+          for module in pkg.modules() do
+            module.ast.visit(collector)
+          end
+        end
+      end
+      collector.result()
+    | None => None
+    end
+
+  fun _entity_for_node(node: AST box): (AST val | None) =>
+    """
+    Resolve `node` to a canonical entity AST node, or None if the node does
+    not sit on an entity declaration.
+    """
+    match \exhaustive\ _ResolveASTTarget(node)
+    | let resolved: AST val =>
+      if _is_entity(resolved.id()) then
+        resolved
+      else
+        None
+      end
+    | None => None
+    end
+
+  fun _is_entity(id: TokenId): Bool =>
+    (id == TokenIds.tk_class()) or
+    (id == TokenIds.tk_actor()) or
+    (id == TokenIds.tk_trait()) or
+    (id == TokenIds.tk_interface()) or
+    (id == TokenIds.tk_primitive()) or
+    (id == TokenIds.tk_struct())
+
+  fun _symbol_kind(id: TokenId): I64 =>
+    match id
+    | TokenIds.tk_interface()
+    | TokenIds.tk_trait() =>
+      SymbolKinds.sk_interface()
+    | TokenIds.tk_struct() =>
+      SymbolKinds.sk_struct()
+    else
+      // LSP has no dedicated kind for actor or primitive; sk_class is the
+      // nearest semantic equivalent.
+      SymbolKinds.sk_class()
+    end
+
+  fun _build_item(entity: AST box): (JsonObject | None) =>
+    """
+    Build a LSP TypeHierarchyItem JSON object for the given entity AST node.
+    """
+    try
+      let id_node = entity(0)?
+      if id_node.id() != TokenIds.tk_id() then
+        return None
+      end
+      let name = id_node.token_value() as String
+      let kind = _symbol_kind(entity.id())
+      let file = entity.source_file() as String val
+      let uri = Uris.from_path(file)
+
+      // child 0 is tk_id — its span covers only the declared name, which is
+      // what editors highlight when the user selects this item.
+      (let sel_start, let sel_end) = id_node.span()
+      let sel_range =
+        LspPositionRange(
+          LspPosition.from_ast_pos(sel_start),
+          LspPosition.from_ast_pos_end(sel_end))
+
+      // SiblingBound prevents range from bleeding into the next entity.
+      // Fall back to sel_range when ASTClampedRange returns None (last entity
+      // in file with no sibling to cap against).
+      let full_range =
+        match \exhaustive\ ASTClampedRange(entity, file, SiblingBound(entity))
+        | let r: LspPositionRange => r
+        | None => sel_range
+        end
+
+      JsonObject
+        .update("name", name)
+        .update("kind", kind)
+        .update("uri", uri)
+        .update("range", full_range.to_json())
+        .update("selectionRange", sel_range.to_json())
+    else
+      None
+    end
+
+  fun _collect_supertypes(entity: AST box): JsonArray =>
+    """
+    Walk the entity's provides node and build TypeHierarchyItems for each
+    directly referenced supertype.
+    """
+    var result = JsonArray
+    let seen = Set[USize]
+    try
+      // Entity child layout:
+      // [0]=id [1]=type_params [2]=cap [3]=provides [4]=members
+      let provides_node = entity(3)?
+      if provides_node.id() == TokenIds.tk_none() then
+        return result
+      end
+      for def in _provides_defs(provides_node).values() do
+        // Dedup by AST pointer identity — same invariant as _SubtypeCollector.
+        if seen.contains(digestof def) then
+          continue
+        end
+        seen.set(digestof def)
+        match _build_item(def)
+        | let item: JsonObject => result = result.push(item)
+        end
+      end
+    end
+    result
+
+  fun _provides_defs(provides: AST box): Array[AST] =>
+    """
+    Return all entity definitions directly referenced by a provides node.
+    Recursively descends through tk_provides and tk_isecttype wrappers
+    until reaching resolvable type nodes (e.g. tk_nominal).
+    """
+    let result = Array[AST]
+    _append_provides_defs(provides, result)
+    result
+
+  fun _append_provides_defs(provides: AST box, result: Array[AST] ref) =>
+    // Valid provides shapes: tk_none (empty), tk_provides (single or union),
+    // tk_isecttype (intersection &). Anything else is a nominal; resolve it
+    // directly via definitions().
+    let nid = provides.id()
+    if nid == TokenIds.tk_none() then
+      None
+    elseif (nid == TokenIds.tk_provides())
+      or (nid == TokenIds.tk_isecttype()) then
+      for child in provides.children() do
+        _append_provides_defs(child, result)
+      end
+    else
+      for def in provides.definitions().values() do
+        if _is_entity(def.id()) then
+          result.push(def)
+        end
+      end
+    end
+
+class ref _SubtypeCollector is ASTVisitor
+  """
+  AST visitor that collects entities whose provides list directly references
+  the target entity.
+  """
+  let _target: AST val
+  var _result: JsonArray
+
+  new ref create(target: AST val) =>
+    _target = target
+    _result = JsonArray
+
+  fun ref visit(ast: AST box): VisitResult =>
+    if not TypeHierarchy._is_entity(ast.id()) then
+      return Continue
+    end
+    try
+      // Entity child layout:
+      // [0]=id [1]=type_params [2]=cap [3]=provides [4]=members
+      let provides_node = ast(3)?
+      if provides_node.id() == TokenIds.tk_none() then
+        return Continue
+      end
+      for def in TypeHierarchy._provides_defs(provides_node).values() do
+        // Pointer identity is valid here: within a single compile graph each
+        // entity has a unique AST node, so == is an exact match.
+        if def == _target then
+          match TypeHierarchy._build_item(ast)
+          | let item: JsonObject => _result = _result.push(item)
+          end
+          return Continue
+        end
+      end
+    end
+    Continue
+
+  fun ref result(): JsonArray =>
+    _result

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -1159,6 +1159,75 @@ actor WorkspaceManager
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 
+  be type_hierarchy_prepare(
+    document_uri: String,
+    request: RequestMessage val)
+  =>
+    """
+    Handle textDocument/prepareTypeHierarchy request.
+    """
+    this._channel.log("Handling textDocument/prepareTypeHierarchy")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let document_path = Uris.to_path(document_uri)
+    match \exhaustive\ _find_node_and_module(document_path, line, column)
+    | (let node: AST box, _) =>
+      match TypeHierarchy.prepare(node)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
+      end
+    | None => None
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be type_hierarchy_supertypes(
+    document_uri: String,
+    sel_line: I64,
+    sel_col: I64,
+    request: RequestMessage val)
+  =>
+    """
+    Handle typeHierarchy/supertypes request.
+    """
+    this._channel.log("Handling typeHierarchy/supertypes")
+    let document_path = Uris.to_path(document_uri)
+    match \exhaustive\ _find_node_and_module(document_path, sel_line, sel_col)
+    | (let node: AST box, _) =>
+      match TypeHierarchy.supertypes(node)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
+      end
+    | None => None
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be type_hierarchy_subtypes(
+    document_uri: String,
+    sel_line: I64,
+    sel_col: I64,
+    request: RequestMessage val)
+  =>
+    """
+    Handle typeHierarchy/subtypes request.
+    """
+    this._channel.log("Handling typeHierarchy/subtypes")
+    let document_path = Uris.to_path(document_uri)
+    match \exhaustive\ _find_node_and_module(document_path, sel_line, sel_col)
+    | (let node: AST box, _) =>
+      match TypeHierarchy.subtypes(node, this._packages)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
+      end
+    | None => None
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
   be dispose() =>
     for package_state in this._packages.values() do
       package_state.dispose()


### PR DESCRIPTION
## Context

The LSP 3.17 type hierarchy protocol (`textDocument/prepareTypeHierarchy`, `typeHierarchy/supertypes`, `typeHierarchy/subtypes`) lets editors show the supertype and subtype relationships for a named type. pony-lsp has no support for these requests today. This is particularly useful in Pony because traits and interfaces can have many implementors spread across packages, and there is no way to navigate those relationships from the editor without this feature.

Resolves #5183.

## Changes

- **`workspace/type_hierarchy.pony`** — new `TypeHierarchy` primitive implementing all three operations, plus `_SubtypeCollector` (an `ASTVisitor` that cross-walks all compiled packages to find subtypes). Supertypes are resolved by walking the `provides` clause of the entity AST, recursing through `tk_provides` and `tk_isecttype` wrappers. Duplicate supertypes (reachable via intersection type + alias) are deduplicated by AST pointer identity. `TypeHierarchyItem` fields (`name`, `kind`, `uri`, `range`, `selectionRange`) are populated using the existing `ASTClampedRange`/`SiblingBound` infrastructure.

- **`workspace/workspace_manager.pony`** — three new behaviors (`type_hierarchy_prepare`, `type_hierarchy_supertypes`, `type_hierarchy_subtypes`) wired to `TypeHierarchy`. Each splits param parsing (→ `invalid_params`) from workspace lookup (→ `internal_error`). All three matches on `_find_node_and_module` use `\exhaustive\`.

- **`language_server.pony`** — routes the three new LSP methods; advertises `typeHierarchyProvider: true` in server capabilities.

- **`methods.pony`** — adds method string constants for the three requests under `TypeHierarchyMethods`.

- **Test fixtures** (`test/workspace/type_hierarchy/`) — four fixture files covering a linear hierarchy chain (`_THierA ← _THierB ← _THierC`), intersection provides (`_THierIsect is (_THierLeft & _THierRight)`), and a cross-file pair (`_THierD` / `_THierE`).

- **`test/_type_hierarchy_integration_tests.pony`** — eight integration tests verifying all three LSP operations, asserting all `TypeHierarchyItem` fields (`name`, `kind`, `uri`, `selectionRange`, `range`), the null-vs-array distinction for empty results, `tk_isecttype` recursion, and cross-file subtype collection.


https://github.com/user-attachments/assets/d30c06ac-7f4e-443c-942d-8d3f9a23702a



## Considerations

- **Nominal subtypes only.** Pony interfaces are structural — a class that satisfies an interface's methods without declaring `is Interface` is a subtype per the type system but will not appear here. This implementation is nominal-only (explicit `is` clauses), consistent with how `references` works. Structural subtype collection would require a separate approach.

- **`_SubtypeCollector` visits full AST.** `ASTVisitor` has only `Continue`/`Stop`, and `Stop` terminates the entire walk. Since entities appear only at module top level, an optimisation would be to iterate `module.ast.children()` directly instead of using `ast.visit()`. Left as a follow-up; correctness is unaffected.

- **`TypeHierarchyItem.data` not populated.** LSP 3.17 defines `data` for stable entity handles across `prepare`→`supertypes`/`subtypes`. Without it the server re-resolves by `selectionRange.start`. An edit + recompile between calls can in principle return results for the wrong entity. This is shared behaviour with hover, references, and definition, and is left as a server-wide concern.

- **Multi-root workspaces.** The router selects one workspace by `item.uri`. Subtypes defined in a different workspace root will not appear. Consistent with existing cross-workspace behaviour.