### PR TITLE
[Fix] _ast_test_helper.pony cleans up tmpdir per test (issue #5295)

### DIFF
--- a/tools/pony-lint/test/_ast_test_helper.pony
+++ b/tools/pony-lint/test/_ast_test_helper.pony
@@ -9,7 +9,7 @@ primitive \nodoc\ _ASTTestHelper
   in AST rule tests.
 
   Writes the source to a temporary directory, compiles it, and returns the
-  results. The temporary directory persists (acceptable for tiny test files).
+  results. The temporary directory is removed before returning.
 
   The PONYPATH environment variable must be set to locate the builtin
   package (e.g., the ponyc packages/ directory). Tests run from a build
@@ -44,39 +44,47 @@ primitive \nodoc\ _ASTTestHelper
 
     let pony_path = _get_ponypath(h.env.vars)
 
-    match \exhaustive\ pass
-    | ast.PassParse =>
-      match \exhaustive\ ast.Compiler.compile(
-        tmp where package_search_paths = pony_path,
-        limit = ast.PassParse)
-      | let program: ast.Program val =>
-        (program, sf)
-      | let errors: Array[ast.Error] val =>
-        h.fail(_format_errors(errors))
-        error
-      end
-    else
-      let session =
-        ast.CompileSession(
-          tmp where package_search_paths = pony_path,
-          limit = ast.PassParse)
-      match session.program()
-      | let program: ast.Program val =>
-        if not session.continue_to(pass) then
-          let err_msg = _format_errors(session.errors())
-          session.dispose()
-          h.fail(err_msg)
-          error
+    let result =
+      try
+        match \exhaustive\ pass
+        | ast.PassParse =>
+          match \exhaustive\ ast.Compiler.compile(
+            tmp where package_search_paths = pony_path,
+            limit = ast.PassParse)
+          | let program: ast.Program val =>
+            (program, sf)
+          | let errors: Array[ast.Error] val =>
+            h.fail(_format_errors(errors))
+            error
+          end
+        else
+          let session =
+            ast.CompileSession(
+              tmp where package_search_paths = pony_path,
+              limit = ast.PassParse)
+          match session.program()
+          | let program: ast.Program val =>
+            if not session.continue_to(pass) then
+              let err_msg = _format_errors(session.errors())
+              session.dispose()
+              h.fail(err_msg)
+              error
+            end
+            session.dispose()
+            (program, sf)
+          else
+            let err_msg = _format_errors(session.errors())
+            session.dispose()
+            h.fail(err_msg)
+            error
+          end
         end
-        session.dispose()
-        (program, sf)
       else
-        let err_msg = _format_errors(session.errors())
-        session.dispose()
-        h.fail(err_msg)
+        tmp.remove()
         error
       end
-    end
+    tmp.remove()
+    result
 
   fun _format_errors(errors: Array[ast.Error] val): String val =>
     """Format compilation errors into a failure message."""


### PR DESCRIPTION
Each AST rule test calls `_ASTTestHelper.compile`, which `mkdtemp`s a fresh `pony-lint-ast-test*` directory and never removes it. Local development accumulates hundreds of these dirs (issue reports 1200 / 9.4MB after normal use). With #5281's incremental rebuild making `make test-pony-lint` cheap to re-run, the leak rate increases.

This wraps the inner compile match in `try ... else tmp.remove(); error end` and adds a final `tmp.remove()` before returning, so the tmpdir is cleaned up on every path:

- `PassParse` success
- `PassParse` parse failure (h.fail + error)
- post-`PassParse` success
- post-`PassParse` failure (continue_to false, or session.program() else branch)

`SourceFile` (`tools/pony-lint/source_file.pony`) stores the source `content` as an immutable `String val` in memory, so removing the underlying tmpdir after `compile()` does not affect the `(program, sf)` pair the caller already holds. The existing `_test_ignore.pony` and similar tests that use `mkdtemp` for non-AST-test fixtures are untouched.

The "The temporary directory persists" docstring sentence is updated to reflect the new behavior.

Closes #5295

This contribution was developed with AI assistance.