### PR TITLE
Add LSP call hierarchy support

### DIFF
--- a/.release-notes/add-lsp-call-hierarchy.md
+++ b/.release-notes/add-lsp-call-hierarchy.md
@@ -1,0 +1,9 @@
+## Add LSP call hierarchy support
+
+The Pony language server now supports the LSP call hierarchy protocol:
+
+- `textDocument/prepareCallHierarchy` — when the cursor is on a method or constructor, returns a `CallHierarchyItem` describing it.
+- `callHierarchy/incomingCalls` — returns items for all methods in the workspace that call the given method, with the specific call sites within each caller.
+- `callHierarchy/outgoingCalls` — returns items for all methods called by the given method, with the specific call sites within it.
+
+Editors that support this protocol (VS Code, Neovim, etc.) expose it as "Show Call Hierarchy", "Show Incoming Calls", and "Show Outgoing Calls" commands.

--- a/tools/pony-lsp/README.md
+++ b/tools/pony-lsp/README.md
@@ -25,6 +25,8 @@ For user documentation — installation and editor configuration — see the [po
 | **[Rename][spec-rename]** | Rename a symbol and all its references across the workspace. |
 | **[Folding Range][spec-folding-range]** | Code folding ranges are provided for blocks, methods, classes, and other structured constructs. |
 | **[Selection Range][spec-selection-range]** | Smart expand/shrink selection based on the AST structure of the document. |
+| **[Type Hierarchy][spec-type-hierarchy]** | Navigate the type hierarchy of Pony entities. `prepareTypeHierarchy` identifies the entity under the cursor; `supertypes` returns the types in its `is` clause; `subtypes` returns all types across the compiled package that directly provide it. |
+| **[Call Hierarchy][spec-call-hierarchy]** | Navigate the call hierarchy of Pony methods. `prepareCallHierarchy` identifies the method under the cursor; `incomingCalls` returns all callers across the workspace with their call sites; `outgoingCalls` returns all callees with their call sites within the method. |
 
 [spec-diagnostics]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#pull-diagnostics
 [spec-hover]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover-request-leftwards_arrow_with_hook
@@ -40,6 +42,8 @@ For user documentation — installation and editor configuration — see the [po
 [spec-rename]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#rename-request-leftwards_arrow_with_hook
 [spec-folding-range]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#folding-range-request-leftwards_arrow_with_hook
 [spec-selection-range]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#selection-range-request-leftwards_arrow_with_hook
+[spec-type-hierarchy]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareTypeHierarchy
+[spec-call-hierarchy]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy
 
 New features are actively being added. Contributions are welcome — we are happy to provide help and guidance.
 

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -59,6 +59,14 @@ actor LanguageServer is (Notifier & RequestSender)
   ): String ? =>
     JsonNav(params)("textDocument")("uri").as_string()?
 
+  fun tag _get_item_uri_and_sel(
+    params: (JsonObject | JsonArray | None)
+  ): (String, I64, I64) ? =>
+    ( JsonNav(params)("item")("uri").as_string()?
+    , JsonNav(params)("item")("selectionRange")("start")("line").as_i64()?
+    , JsonNav(params)("item")("selectionRange")("start")("character")
+        .as_i64()? )
+
   be handle_parse_error(err: ParseError val) =>
     this._channel.log("Parse Error: " + err.string(), Warning)
 
@@ -289,9 +297,66 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] No workspace found for '" +
                 r.json().string() + "'")))
         end
-      | Methods.text_document().prepare_type_hierarchy() =>
+      | Methods.text_document().prepare_call_hierarchy() =>
         let document_uri =
           try _get_document_uri(r.params)?
+          else
+            this._channel.send(
+              ResponseMessage.create(
+                r.id,
+                None,
+                ResponseError(
+                  ErrorCodes.invalid_params(),
+                  "[" + r.method + "] missing textDocument.uri")))
+            return
+          end
+        try
+          (_router.find_workspace(document_uri) as WorkspaceManager)
+            .call_hierarchy_prepare(document_uri, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.internal_error(),
+                "[" + r.method + "] No workspace found for '" +
+                  document_uri + "'")))
+        end
+      | Methods.call_hierarchy().incoming_calls() =>
+        try
+          (let item_uri, let sel_line, let sel_col) =
+            _get_item_uri_and_sel(r.params)?
+          (_router.find_workspace(item_uri) as WorkspaceManager)
+            .call_hierarchy_incoming_calls(item_uri, sel_line, sel_col, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.invalid_params(),
+                "[" + r.method + "] missing item or selectionRange.start")))
+        end
+      | Methods.call_hierarchy().outgoing_calls() =>
+        try
+          (let item_uri, let sel_line, let sel_col) =
+            _get_item_uri_and_sel(r.params)?
+          (_router.find_workspace(item_uri) as WorkspaceManager)
+            .call_hierarchy_outgoing_calls(item_uri, sel_line, sel_col, r)
+        else
+          this._channel.send(
+            ResponseMessage.create(
+              r.id,
+              None,
+              ResponseError(
+                ErrorCodes.invalid_params(),
+                "[" + r.method + "] missing item or selectionRange.start")))
+        end
+      | Methods.text_document().prepare_type_hierarchy() =>
+        let document_uri =
+          try
+            _get_document_uri(r.params)?
           else
             this._channel.send(
               ResponseMessage.create(
@@ -316,24 +381,9 @@ actor LanguageServer is (Notifier & RequestSender)
                   document_uri + "'")))
         end
       | Methods.type_hierarchy().supertypes() =>
-        (let item_uri, let sel_line, let sel_col) =
-          try
-            ( JsonNav(r.params)("item")("uri").as_string()?
-            , JsonNav(r.params)("item")("selectionRange")("start")("line")
-                .as_i64()?
-            , JsonNav(r.params)("item")("selectionRange")("start")("character")
-                .as_i64()? )
-          else
-            this._channel.send(
-              ResponseMessage.create(
-                r.id,
-                None,
-                ResponseError(
-                  ErrorCodes.invalid_params(),
-                  "[" + r.method + "] missing item or selectionRange.start")))
-            return
-          end
         try
+          (let item_uri, let sel_line, let sel_col) =
+            _get_item_uri_and_sel(r.params)?
           (_router.find_workspace(item_uri) as WorkspaceManager)
             .type_hierarchy_supertypes(item_uri, sel_line, sel_col, r)
         else
@@ -342,29 +392,13 @@ actor LanguageServer is (Notifier & RequestSender)
               r.id,
               None,
               ResponseError(
-                ErrorCodes.internal_error(),
-                "[" + r.method + "] No workspace found for '" +
-                  item_uri + "'")))
+                ErrorCodes.invalid_params(),
+                "[" + r.method + "] missing item or selectionRange.start")))
         end
       | Methods.type_hierarchy().subtypes() =>
-        (let item_uri, let sel_line, let sel_col) =
-          try
-            ( JsonNav(r.params)("item")("uri").as_string()?
-            , JsonNav(r.params)("item")("selectionRange")("start")("line")
-                .as_i64()?
-            , JsonNav(r.params)("item")("selectionRange")("start")("character")
-                .as_i64()? )
-          else
-            this._channel.send(
-              ResponseMessage.create(
-                r.id,
-                None,
-                ResponseError(
-                  ErrorCodes.invalid_params(),
-                  "[" + r.method + "] missing item or selectionRange.start")))
-            return
-          end
         try
+          (let item_uri, let sel_line, let sel_col) =
+            _get_item_uri_and_sel(r.params)?
           (_router.find_workspace(item_uri) as WorkspaceManager)
             .type_hierarchy_subtypes(item_uri, sel_line, sel_col, r)
         else
@@ -373,9 +407,8 @@ actor LanguageServer is (Notifier & RequestSender)
               r.id,
               None,
               ResponseError(
-                ErrorCodes.internal_error(),
-                "[" + r.method + "] No workspace found for '" +
-                  item_uri + "'")))
+                ErrorCodes.invalid_params(),
+                "[" + r.method + "] missing item or selectionRange.start")))
         end
       | Methods.workspace().symbol() =>
         let query = try JsonNav(r.params)("query").as_string()? else "" end
@@ -635,7 +668,8 @@ actor LanguageServer is (Notifier & RequestSender)
                     .update(
                       "retriggerCharacters",
                       JsonArray.push("(").push(",")))
-                .update("typeHierarchyProvider", true))
+                .update("typeHierarchyProvider", true)
+                .update("callHierarchyProvider", true))
             .update(
               "serverInfo",
               JsonObject

--- a/tools/pony-lsp/methods.pony
+++ b/tools/pony-lsp/methods.pony
@@ -42,6 +42,12 @@ primitive Methods
     """
     WindowMethods
 
+  fun call_hierarchy(): CallHierarchyMethods =>
+    """
+    Access callHierarchy scoped methods.
+    """
+    CallHierarchyMethods
+
   fun type_hierarchy(): TypeHierarchyMethods =>
     """
     Access typeHierarchy scoped methods.
@@ -162,6 +168,20 @@ primitive TextDocumentMethods
 
   fun prepare_type_hierarchy(): String val =>
     "textDocument/prepareTypeHierarchy"
+
+  fun prepare_call_hierarchy(): String val =>
+    "textDocument/prepareCallHierarchy"
+
+primitive CallHierarchyMethods
+  """
+  Collection of callHierarchy scoped methods.
+  """
+
+  fun incoming_calls(): String val =>
+    "callHierarchy/incomingCalls"
+
+  fun outgoing_calls(): String val =>
+    "callHierarchy/outgoingCalls"
 
 primitive TypeHierarchyMethods
   """

--- a/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
@@ -1,0 +1,1121 @@
+use ".."
+use "pony_test"
+use "files"
+use "json"
+
+// Fixture layout (0-indexed lines, 0-indexed cols):
+// _t_call_a.pony  class _TCallA
+// f_a  name (1,6)..(1,9)  full (1,2)..(1,27)  [end inflated: None desugars]
+// _t_call_b.pony  class _TCallB
+// f_b  name (1,6)..(1,9)  full (1,2)..(2,10)  [end at '(' - ')' not tracked]
+// a.f_a()  call site f_a (2,6)..(2,9)
+// _t_call_c.pony  class _TCallC
+// f_c  name (1,6)..(1,9)  full (1,2)..(3,11)  [end at last arg, not ')']
+// a.f_a()  call site f_a (2,6)..(2,9)
+// b.f_b(a)  call site f_b (3,6)..(3,9)
+// _t_call_d.pony  class _TCallD
+// f_d  name (1,6)..(1,9)  full (1,2)..(3,10)
+// a.f_a()  first call site f_a (2,6)..(2,9)
+// a.f_a()  second call site f_a (3,6)..(3,9)
+// _t_call_actor.pony  actor _TCallActor
+// create  new, name (1,6)..(1,12)  kind=9 (constructor)
+// act  be, name (4,5)..(4,8)  full (4,2)..(5,10)
+// a.f_a()  call site f_a (5,6)..(5,9)
+// _t_call_lambda.pony  class _TCallLambda
+// f_lambda  name (1,6)..(1,14)  full (1,2)..(9,10)
+// [end inflated: None desugars]
+// a.f_a()  first call site f_a (2,6)..(2,9)
+// a.f_a()  second call site f_a (8,6)..(8,9) — after the object literal
+// object literal g() has no calls  [nested method; excluded by _nested_depth]
+// _t_poly.pony  _TPolyA, _TPolyB, _TPolyUser (same-name method, two entities)
+// _TPolyA.poly_method  name (1,6)..(1,17)  full (1,2)..(1,35)
+// [end inflated: None desugars]
+// _TPolyB.poly_method  name (4,6)..(4,17)  full (4,2)..(4,35)
+// [end inflated: None desugars]
+// _TPolyUser.call_a  name (7,6)..(7,12)  full (7,2)..(8,18)
+// a.poly_method() call site poly_method (8,6)..(8,17)
+// _TPolyUser.call_b  name (10,6)..(10,12)  full (10,2)..(11,18)
+// b.poly_method() call site poly_method (11,6)..(11,17)
+// _t_cross_caller.pony  class _TCrossCaller (uses "callee" sub-package)
+// cross_call  name (3,6)..(3,16)  full (3,2)..(4,20)
+// c.callee_method() call site callee_method (4,6)..(4,19)
+// callee/t_callee.pony  TCallee (public; sub-package; no ".." import; no cycle)
+// callee_method  name (4,6)..(4,19)  full (4,2)..(4,37)
+// [end inflated: None desugars]
+// _t_call_constructor.pony  classes _TConstructed, _TCallConstructorCaller,
+// _TConstructorWithBody
+// _TConstructed.create  new, name (1,6)..(1,12)  full (1,2)..(1,24)
+// [end inflated: None desugars]
+// _TCallConstructorCaller.f_new_explicit  name (4,6)..(4,20)
+// _TConstructed.create()  create at (5,18)..(5,24)
+// _TConstructorWithBody.create  new, name (9,6)..(9,12)  full (9,2)..(10,10)
+// a.f_a()  call site f_a (10,6)..(10,9)
+
+primitive _CallHierarchyIntegrationTests is TestList
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let server = _LspTestServer(workspace_dir)
+    test(_PrepareCallHierarchyOnMethodTest.create(server))
+    test(_PrepareCallHierarchyOnNonMethodTest.create(server))
+    test(_IncomingCallsForFaTest.create(server))
+    test(_IncomingCallsEmptyTest.create(server))
+    test(_OutgoingCallsEmptyTest.create(server))
+    test(_OutgoingCallsForFbTest.create(server))
+    test(_OutgoingCallsForFcTest.create(server))
+    test(_OutgoingCallsForFdTest.create(server))
+    test(_PrepareConstructorKindTest.create(server))
+    test(_PrepareBeKindTest.create(server))
+    test(_OutgoingCallsForActTest.create(server))
+    test(_PrepareFromCallRefTest.create(server))
+    test(_OutgoingCallsNoLambdaCallsTest.create(server))
+    test(_IncomingCallsPolyATest.create(server))
+    test(_IncomingCallsPolyBTest.create(server))
+    test(_OutgoingCallsCrossPackageTest.create(server))
+    test(_OutgoingCallsForFNewExplicitTest.create(server))
+    test(_OutgoingCallsFromConstructorTest.create(server))
+
+class val _CHierItem
+  """
+  Expected fields of a CallHierarchyItem.
+  sel: selectionRange (sl, sc, el, ec); rng: full range (sl, sc, el, ec).
+  """
+  let name: String val
+  let kind: I64
+  let detail: String val
+  let uri: String val
+  let sel: (I64, I64, I64, I64)
+  let rng: (I64, I64, I64, I64)
+
+  new val create(
+    name': String,
+    kind': I64,
+    detail': String,
+    workspace_dir: String,
+    workspace_file: String,
+    sel': (I64, I64, I64, I64),
+    rng': (I64, I64, I64, I64))
+  =>
+    name = name'
+    kind = kind'
+    detail = detail'
+    uri = Uris.from_path(Path.join(workspace_dir, workspace_file))
+    sel = sel'
+    rng = rng'
+
+class val _CHierExpected
+  """
+  Expected caller or callee entry in an incoming/outgoing call result.
+  """
+  let item: _CHierItem val
+  let from_ranges: Array[(I64, I64, I64, I64)] val
+
+  new val create(
+    item': _CHierItem val,
+    from_ranges': Array[(I64, I64, I64, I64)] val)
+  =>
+    item = item'
+    from_ranges = from_ranges'
+
+primitive _CHierCheckItem
+  """
+  Asserts all CallHierarchyItem fields from `item_nav` — a JsonNav pointing
+  directly at the item object (not an array element).
+  """
+  fun apply(
+    item_nav: JsonNav,
+    exp: _CHierItem val,
+    label: String val,
+    h: TestHelper): Bool
+  =>
+    try
+      var ok = true
+      ok = h.assert_eq[String](
+        exp.name,
+        item_nav("name").as_string()?,
+        label + ".name") and ok
+      ok = h.assert_eq[I64](
+        exp.kind,
+        item_nav("kind").as_i64()?,
+        label + ".kind") and ok
+      ok = h.assert_eq[String](
+        exp.uri,
+        item_nav("uri").as_string()?,
+        label + ".uri") and ok
+      ok = h.assert_eq[String](
+        exp.detail,
+        try item_nav("detail").as_string()? else "" end,
+        label + ".detail") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._1,
+        item_nav("selectionRange")("start")("line").as_i64()?,
+        label + ".selectionRange.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._2,
+        item_nav("selectionRange")("start")("character").as_i64()?,
+        label + ".selectionRange.start.character") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._3,
+        item_nav("selectionRange")("end")("line").as_i64()?,
+        label + ".selectionRange.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp.sel._4,
+        item_nav("selectionRange")("end")("character").as_i64()?,
+        label + ".selectionRange.end.character") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._1,
+        item_nav("range")("start")("line").as_i64()?,
+        label + ".range.start.line") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._2,
+        item_nav("range")("start")("character").as_i64()?,
+        label + ".range.start.character") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._3,
+        item_nav("range")("end")("line").as_i64()?,
+        label + ".range.end.line") and ok
+      ok = h.assert_eq[I64](
+        exp.rng._4,
+        item_nav("range")("end")("character").as_i64()?,
+        label + ".range.end.character") and ok
+      ok
+    else
+      h.fail(
+        label + " missing or has wrong structure (expected: "
+          + exp.name + ")")
+      false
+    end
+
+primitive _CHierFindByPos
+  """
+  Find the index in `nav` whose `item_key.uri` and
+  `item_key.selectionRange.start` match `exp`. Returns None if not found.
+  Using (uri, selectionRange.start) as identity rather than name avoids false
+  matches when two entries share a name (e.g. same-named methods in different
+  classes).
+  """
+  fun apply(
+    nav: JsonNav, item_key: String, exp: _CHierItem val): (USize | None) =>
+    try
+      let n = nav.size()?
+      var i: USize = 0
+      while i < n do
+        try
+          let entry = nav(i)(item_key)
+          let sel = entry("selectionRange")("start")
+          if
+            (entry("uri").as_string()? == exp.uri) and
+            (sel("line").as_i64()? == exp.sel._1) and
+            (sel("character").as_i64()? == exp.sel._2)
+          then
+            return i
+          end
+        end
+        i = i + 1
+      end
+    end
+    None
+
+primitive _CHierCheckEntry
+  """
+  Find an entry in the call hierarchy result array by name, check its item
+  fields and fromRanges. `item_key` is "from" for incoming, "to" for outgoing.
+  """
+  fun apply(
+    nav: JsonNav,
+    item_key: String,
+    exp: _CHierExpected val,
+    h: TestHelper): Bool
+  =>
+    let i =
+      match \exhaustive\ _CHierFindByPos(nav, item_key, exp.item)
+      | let idx: USize => idx
+      | None =>
+        h.fail(item_key + " entry '" + exp.item.name + "' not found")
+        return false
+      end
+    let label: String val = item_key + "['" + exp.item.name + "']"
+    var ok = _CHierCheckItem(nav(i)(item_key), exp.item, label, h)
+    try
+      let ranges_nav = nav(i)("fromRanges")
+      let expected_count = exp.from_ranges.size()
+      ok = h.assert_eq[USize](
+        expected_count,
+        try ranges_nav.size()? else 0 end,
+        label + " fromRanges count") and ok
+      for (ri, rng) in exp.from_ranges.pairs() do
+        let rl: String val = label + " fromRanges[" + ri.string() + "]"
+        ok = h.assert_eq[I64](
+          rng._1,
+          ranges_nav(ri)("start")("line").as_i64()?,
+          rl + ".start.line") and ok
+        ok = h.assert_eq[I64](
+          rng._2,
+          ranges_nav(ri)("start")("character").as_i64()?,
+          rl + ".start.character") and ok
+        ok = h.assert_eq[I64](
+          rng._3,
+          ranges_nav(ri)("end")("line").as_i64()?,
+          rl + ".end.line") and ok
+        ok = h.assert_eq[I64](
+          rng._4,
+          ranges_nav(ri)("end")("character").as_i64()?,
+          rl + ".end.character") and ok
+      end
+    else
+      h.fail(label + " fromRanges missing or malformed")
+      ok = false
+    end
+    ok
+
+class val _PrepareCHierChecker
+  """
+  Checker for textDocument/prepareCallHierarchy.
+  Pass None for expected to assert a null result (non-method cursor).
+  """
+  let _pos: (I64, I64)
+  let _expected: (_CHierItem val | None)
+
+  new val create(pos': (I64, I64), expected: (_CHierItem val | None)) =>
+    _pos = pos'
+    _expected = expected
+
+  fun lsp_method(): String =>
+    Methods.text_document().prepare_call_hierarchy()
+
+  fun lsp_params(): (None | JsonObject) =>
+    JsonObject.update(
+      "position",
+      JsonObject
+        .update("line", _pos._1)
+        .update("character", _pos._2))
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match \exhaustive\ _expected
+    | None =>
+      match res.result
+      | None => true
+      else
+        h.fail("prepare: expected null for non-method cursor, got non-null")
+        false
+      end
+    | let exp: _CHierItem val =>
+      match res.result
+      | let arr: JsonArray =>
+        let nav = JsonNav(arr)
+        var ok =
+          h.assert_eq[USize](
+            1,
+            try nav.size()? else 0 end,
+            "prepare: expected single item")
+        ok = _CHierCheckItem(nav(0), exp, "item[0]", h) and ok
+        ok
+      | None =>
+        h.fail("prepare: expected item, got null")
+        false
+      else
+        h.fail("prepare: expected array result")
+        false
+      end
+    end
+
+class val _CHierCallsChecker
+  """
+  Checker for callHierarchy/incomingCalls and callHierarchy/outgoingCalls.
+  `item_key` is "from" for incoming, "to" for outgoing.
+  """
+  let _method: String
+  let _item_key: String
+  let _item_uri: String val
+  let _sel_pos: (I64, I64)
+  let _expected: Array[_CHierExpected val] val
+
+  new val create(
+    method': String,
+    item_key': String,
+    item_uri': String,
+    sel_pos': (I64, I64),
+    expected: Array[_CHierExpected val] val)
+  =>
+    _method = method'
+    _item_key = item_key'
+    _item_uri = item_uri'
+    _sel_pos = sel_pos'
+    _expected = expected
+
+  fun lsp_method(): String => _method
+
+  fun lsp_params(): (None | JsonObject) =>
+    JsonObject.update(
+      "item",
+      JsonObject
+        .update("uri", _item_uri)
+        .update(
+          "selectionRange",
+          JsonObject.update(
+            "start",
+            JsonObject
+              .update("line", _sel_pos._1)
+              .update("character", _sel_pos._2))))
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | None =>
+      if _expected.size() == 0 then
+        h.fail(_method + ": expected [] not null for empty result")
+      else
+        h.fail(_method + ": expected items, got null")
+      end
+      false
+    | let arr: JsonArray =>
+      let nav = JsonNav(arr)
+      var ok =
+        h.assert_eq[USize](
+          _expected.size(),
+          try nav.size()? else 0 end,
+          _method + ": wrong entry count")
+      for exp in _expected.values() do
+        ok = _CHierCheckEntry(nav, _item_key, exp, h) and ok
+      end
+      ok
+    else
+      h.fail(_method + ": expected array result")
+      false
+    end
+
+class \nodoc\ iso _PrepareCallHierarchyOnMethodTest is UnitTest
+  """
+  Cursor on f_a name (line 1, col 6) — expects a one-element result
+  with all CallHierarchyItem fields verified.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/prepare_method"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_a,
+      [ _PrepareCHierChecker(
+          (1, 6),
+          _CHierItem(
+            "f_a",
+            6,
+            "_TCallA",
+            workspace_dir,
+            t_call_a,
+            (1, 6, 1, 9),
+            (1, 2, 1, 27))) ])
+
+class \nodoc\ iso _PrepareCallHierarchyOnNonMethodTest is UnitTest
+  """
+  Cursor on class name _TCallA (line 0, col 6) — not a method.
+  Expects null result.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/prepare_non_method"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "call_hierarchy/_t_call_a.pony",
+      [_PrepareCHierChecker((0, 6), None)])
+
+class \nodoc\ iso _IncomingCallsForFaTest is UnitTest
+  """
+  Incoming calls for f_a — f_b, f_c, f_lambda call f_a once each; f_d calls
+  it twice; act calls it once; _TConstructorWithBody.create calls it once. The
+  f_d entry verifies that two call sites from the same caller are grouped into
+  one entry with two fromRanges (not two separate entries). f_lambda verifies
+  that a caller in a different file with a nested object literal is correctly
+  attributed. The create entry verifies that a `new` constructor is correctly
+  identified as a caller (tk_newref call sites collected as incoming calls).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/incoming_calls"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_b = "call_hierarchy/_t_call_b.pony"
+    let t_call_c = "call_hierarchy/_t_call_c.pony"
+    let t_call_d = "call_hierarchy/_t_call_d.pony"
+    let t_call_actor = "call_hierarchy/_t_call_actor.pony"
+    let t_call_lambda = "call_hierarchy/_t_call_lambda.pony"
+    let t_call_constructor = "call_hierarchy/_t_call_constructor.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_a))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_a,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().incoming_calls(),
+          "from",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_b",
+                6,
+                "_TCallB",
+                workspace_dir,
+                t_call_b,
+                (1, 6, 1, 9),
+                (1, 2, 2, 10)),
+              [(2, 6, 2, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "f_c",
+                6,
+                "_TCallC",
+                workspace_dir,
+                t_call_c,
+                (1, 6, 1, 9),
+                (1, 2, 3, 11)),
+              [(2, 6, 2, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "f_d",
+                6,
+                "_TCallD",
+                workspace_dir,
+                t_call_d,
+                (1, 6, 1, 9),
+                (1, 2, 3, 10)),
+              [(2, 6, 2, 9); (3, 6, 3, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "act",
+                6,
+                "_TCallActor",
+                workspace_dir,
+                t_call_actor,
+                (4, 5, 4, 8),
+                (4, 2, 5, 10)),
+              [(5, 6, 5, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "f_lambda",
+                6,
+                "_TCallLambda",
+                workspace_dir,
+                t_call_lambda,
+                (1, 6, 1, 14),
+                (1, 2, 9, 10)),
+              [(2, 6, 2, 9); (8, 6, 8, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "create",
+                9,
+                "_TConstructorWithBody",
+                workspace_dir,
+                t_call_constructor,
+                (9, 6, 9, 12),
+                (9, 2, 10, 10)),
+              [(10, 6, 10, 9)]) ]) ])
+
+class \nodoc\ iso _IncomingCallsEmptyTest is UnitTest
+  """
+  Incoming calls for f_c — f_c is never called in the fixture.
+  Expects empty array (not null).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/incoming_calls_empty"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_c = "call_hierarchy/_t_call_c.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_c))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_c,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().incoming_calls(),
+          "from",
+          item_uri,
+          (1, 6),
+          []) ])
+
+class \nodoc\ iso _OutgoingCallsEmptyTest is UnitTest
+  """
+  Outgoing calls for f_a — f_a's body is `None` (a type literal). Expects
+  empty array (not null). Also exercises the synthetic tk_newref filter:
+  without it, the desugared None.create would appear as a spurious entry.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/outgoing_calls_empty"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_a))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_a,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (1, 6),
+          []) ])
+
+class \nodoc\ iso _OutgoingCallsForFbTest is UnitTest
+  """
+  Outgoing calls for f_b — calls f_a once. Expects one entry.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/outgoing_calls_single"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_b = "call_hierarchy/_t_call_b.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_b))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_b,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(2, 6, 2, 9)]) ]) ])
+
+class \nodoc\ iso _OutgoingCallsForFcTest is UnitTest
+  """
+  Outgoing calls for f_c — calls f_a and f_b once each. Expects two entries.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/outgoing_calls_multiple"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_b = "call_hierarchy/_t_call_b.pony"
+    let t_call_c = "call_hierarchy/_t_call_c.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_c))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_c,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(2, 6, 2, 9)])
+            _CHierExpected(
+              _CHierItem(
+                "f_b",
+                6,
+                "_TCallB",
+                workspace_dir,
+                t_call_b,
+                (1, 6, 1, 9),
+                (1, 2, 2, 10)),
+              [(3, 6, 3, 9)]) ]) ])
+
+class \nodoc\ iso _OutgoingCallsForFdTest is UnitTest
+  """
+  Outgoing calls for f_d — calls f_a twice from separate sites. Expects one
+  entry for f_a with two fromRanges, verifying the multi-call-site grouping
+  path in _OutgoingCallCollector.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/outgoing_calls_multi_site"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_d = "call_hierarchy/_t_call_d.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_d))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_d,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(2, 6, 2, 9); (3, 6, 3, 9)]) ]) ])
+
+class val _PrepareKindChecker
+  """
+  Prepare checker that asserts kind, name, and detail fields.
+  Used when the range assertions are secondary to testing kind values
+  (e.g. constructors returning kind=9, behaviors returning kind=6).
+  """
+  let _pos: (I64, I64)
+  let _expected_kind: I64
+  let _expected_name: String
+  let _expected_detail: String
+
+  new val create(
+    pos': (I64, I64),
+    expected_kind: I64,
+    expected_name: String,
+    expected_detail: String)
+  =>
+    _pos = pos'
+    _expected_kind = expected_kind
+    _expected_name = expected_name
+    _expected_detail = expected_detail
+
+  fun lsp_method(): String =>
+    Methods.text_document().prepare_call_hierarchy()
+
+  fun lsp_params(): (None | JsonObject) =>
+    JsonObject.update(
+      "position",
+      JsonObject
+        .update("line", _pos._1)
+        .update("character", _pos._2))
+
+  fun check(res: ResponseMessage val, h: TestHelper): Bool =>
+    match res.result
+    | let arr: JsonArray =>
+      try
+        let item = JsonNav(arr)(0)
+        let ok_kind =
+          h.assert_eq[I64](
+            _expected_kind, item("kind").as_i64()?, "prepare: kind")
+        let ok_name =
+          h.assert_eq[String](
+            _expected_name, item("name").as_string()?, "prepare: name")
+        let ok_detail =
+          h.assert_eq[String](
+            _expected_detail, item("detail").as_string()?, "prepare: detail")
+        ok_kind and ok_name and ok_detail
+      else
+        h.fail("prepare: missing fields in result")
+        false
+      end
+    | None =>
+      h.fail("prepare: expected array, got null")
+      false
+    else
+      h.fail("prepare: expected array result")
+      false
+    end
+
+class \nodoc\ iso _PrepareConstructorKindTest is UnitTest
+  """
+  Cursor on `new create` — expects kind=9 (constructor).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/prepare_constructor_kind"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "call_hierarchy/_t_call_actor.pony",
+      [_PrepareKindChecker((1, 6), 9, "create", "_TCallActor")])
+
+class \nodoc\ iso _PrepareBeKindTest is UnitTest
+  """
+  Cursor on `be act` — expects kind=6 (method).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/prepare_be_kind"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "call_hierarchy/_t_call_actor.pony",
+      [_PrepareKindChecker((4, 5), 6, "act", "_TCallActor")])
+
+class \nodoc\ iso _OutgoingCallsForActTest is UnitTest
+  """
+  Outgoing calls for `act` — calls f_a once. Exercises the tk_be code path.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/outgoing_calls_be"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_actor = "call_hierarchy/_t_call_actor.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_actor))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_actor,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (4, 5),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(5, 6, 5, 9)]) ]) ])
+
+class \nodoc\ iso _PrepareFromCallRefTest is UnitTest
+  """
+  Cursor on the `f_a` call site in f_b's body (line 2, col 6 in
+  _t_call_b.pony) — expects prepare to resolve to f_a in _t_call_a.pony.
+  Exercises Case 3 of _method_for_node (cursor on a call reference).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "call_hierarchy/integration/prepare_from_call_ref"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_b = "call_hierarchy/_t_call_b.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_b,
+      [ _PrepareCHierChecker(
+          (2, 6),
+          _CHierItem(
+            "f_a",
+            6,
+            "_TCallA",
+            workspace_dir,
+            t_call_a,
+            (1, 6, 1, 9),
+            (1, 2, 1, 27))) ])
+
+class \nodoc\ iso _OutgoingCallsNoLambdaCallsTest is UnitTest
+  """
+  Outgoing calls for f_lambda — the method body calls f_a twice (before and
+  after an object literal containing g) and g has no calls of its own.
+  Both outer calls to f_a must appear; no calls from inside g must appear.
+
+  Regression test for the _OutgoingCallCollector nested-method fix: without
+  the _nested_depth / leave() guard, returning Stop on a nested method node
+  aborts the entire traversal — so the second a.f_a() (after the object
+  literal) is silently dropped. With the fix both call sites are recorded and
+  calls inside g are excluded.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/outgoing_calls_no_lambda_calls"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let t_call_lambda = "call_hierarchy/_t_call_lambda.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_call_lambda))
+    _RunLspChecks(
+      h,
+      _server,
+      t_call_lambda,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(2, 6, 2, 9); (8, 6, 8, 9)]) ]) ])
+
+class \nodoc\ iso _IncomingCallsPolyATest is UnitTest
+  """
+  Incoming calls for _TPolyA.poly_method — only call_a calls it directly;
+  call_b calls _TPolyB.poly_method instead.
+
+  Regression test for H1: verifies that incomingCalls routed via an item
+  pointing to _TPolyA.poly_method (selectionRange in _t_poly.pony at line 1)
+  correctly resolves to _TPolyA.poly_method and returns only its callers,
+  not _TPolyB.poly_method's callers. Both classes live in the same file so
+  only the position distinguishes them — the strongest possible disambiguation.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/incoming_calls_poly_a"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_poly = "call_hierarchy/_t_poly.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_poly))
+    _RunLspChecks(
+      h,
+      _server,
+      t_poly,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().incoming_calls(),
+          "from",
+          item_uri,
+          (1, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "call_a",
+                6,
+                "_TPolyUser",
+                workspace_dir,
+                t_poly,
+                (7, 6, 7, 12),
+                (7, 2, 8, 18)),
+              [(8, 6, 8, 17)]) ]) ])
+
+class \nodoc\ iso _IncomingCallsPolyBTest is UnitTest
+  """
+  Incoming calls for _TPolyB.poly_method — only call_b calls it directly;
+  call_a calls _TPolyA.poly_method instead.
+
+  Counterpart to _IncomingCallsPolyATest: item points to line 4 in the same
+  file. Result must be {call_b}, not {call_a}. Together the two tests prove
+  that position-based routing correctly distinguishes between two same-named
+  methods in the same file.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/incoming_calls_poly_b"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_poly = "call_hierarchy/_t_poly.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_poly))
+    _RunLspChecks(
+      h,
+      _server,
+      t_poly,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().incoming_calls(),
+          "from",
+          item_uri,
+          (4, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "call_b",
+                6,
+                "_TPolyUser",
+                workspace_dir,
+                t_poly,
+                (10, 6, 10, 12),
+                (10, 2, 11, 18)),
+              [(11, 6, 11, 17)]) ]) ])
+
+class \nodoc\ iso _OutgoingCallsCrossPackageTest is UnitTest
+  """
+  Outgoing calls for _TCrossCaller.cross_call, where the callee
+  (_TCallee.callee_method) lives in the call_hierarchy/callee sub-package.
+  Exercises the cross-package definition resolution in _OutgoingCallCollector:
+  `definitions()` on `c.callee_method()` resolves to a method in a package
+  different from the one containing cross_call.
+  `_t_cross_caller.pony` uses "callee", so the sub-package is compiled as a
+  dependency in the same ponyc run — no separate compilation or timing concern.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/outgoing_calls_cross_package"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_cross_caller = "call_hierarchy/_t_cross_caller.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_cross_caller))
+    _RunLspChecks(
+      h,
+      _server,
+      t_cross_caller,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (3, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "callee_method",
+                6,
+                "TCallee",
+                workspace_dir,
+                "call_hierarchy/callee/t_callee.pony",
+                (4, 6, 4, 19),
+                (4, 2, 4, 37)),
+              [(4, 6, 4, 19)]) ]) ])
+
+class \nodoc\ iso _OutgoingCallsForFNewExplicitTest is UnitTest
+  """
+  Outgoing calls for _TCallConstructorCaller.f_new_explicit, which calls
+  _TConstructed.create() using the explicit constructor syntax. Expects one
+  entry for `create` in `_TConstructed` — verifies that _is_synthetic_newref
+  does NOT filter explicit constructor calls (Foo.create() form).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/outgoing_calls_explicit_constructor"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_ctor = "call_hierarchy/_t_call_constructor.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_ctor))
+    _RunLspChecks(
+      h,
+      _server,
+      t_ctor,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (4, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "create",
+                9,
+                "_TConstructed",
+                workspace_dir,
+                t_ctor,
+                (1, 6, 1, 12),
+                (1, 2, 1, 24)),
+              [(5, 18, 5, 24)]) ]) ])
+
+class \nodoc\ iso _OutgoingCallsFromConstructorTest is UnitTest
+  """
+  Outgoing calls for _TConstructorWithBody.create — a constructor whose body
+  calls a.f_a(). Expects one entry for f_a in _TCallA, verifying that
+  _OutgoingCallCollector works when the source method is a `new` (not just
+  fun or be).
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "call_hierarchy/integration/outgoing_calls_from_constructor"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_ctor = "call_hierarchy/_t_call_constructor.pony"
+    let t_call_a = "call_hierarchy/_t_call_a.pony"
+    let item_uri = Uris.from_path(Path.join(workspace_dir, t_ctor))
+    _RunLspChecks(
+      h,
+      _server,
+      t_ctor,
+      [ _CHierCallsChecker(
+          Methods.call_hierarchy().outgoing_calls(),
+          "to",
+          item_uri,
+          (9, 6),
+          [ _CHierExpected(
+              _CHierItem(
+                "f_a",
+                6,
+                "_TCallA",
+                workspace_dir,
+                t_call_a,
+                (1, 6, 1, 9),
+                (1, 2, 1, 27)),
+              [(10, 6, 10, 9)]) ]) ])

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -37,6 +37,7 @@ actor Main is TestList
     _WorkspaceSymbolIntegrationTests.make().tests(test)
     _SignatureHelpIntegrationTests.make().tests(test)
     _TypeHierarchyIntegrationTests.make().tests(test)
+    _CallHierarchyIntegrationTests.make().tests(test)
 
 class \nodoc\ iso _InitializeTest is UnitTest
   fun name(): String => "initialize"

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_a.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_a.pony
@@ -1,0 +1,2 @@
+class _TCallA
+  fun f_a(): None => None

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_actor.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_actor.pony
@@ -1,0 +1,6 @@
+actor _TCallActor
+  new create() =>
+    None
+
+  be act(a: _TCallA val) =>
+    a.f_a()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_b.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_b.pony
@@ -1,0 +1,3 @@
+class _TCallB
+  fun f_b(a: _TCallA): None =>
+    a.f_a()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_c.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_c.pony
@@ -1,0 +1,4 @@
+class _TCallC
+  fun f_c(a: _TCallA, b: _TCallB): None =>
+    a.f_a()
+    b.f_b(a)

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_constructor.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_constructor.pony
@@ -1,0 +1,11 @@
+class _TConstructed
+  new create() => None
+
+class _TCallConstructorCaller
+  fun f_new_explicit(): None =>
+    _TConstructed.create()
+    None
+
+class _TConstructorWithBody
+  new create(a: _TCallA) =>
+    a.f_a()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_d.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_d.pony
@@ -1,0 +1,4 @@
+class _TCallD
+  fun f_d(a: _TCallA): None =>
+    a.f_a()
+    a.f_a()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_lambda.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_call_lambda.pony
@@ -1,0 +1,10 @@
+class _TCallLambda
+  fun f_lambda(a: _TCallA): None =>
+    a.f_a()
+    let _ =
+      object
+        fun g(): None =>
+          None
+      end
+    a.f_a()
+    None

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_cross_caller.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_cross_caller.pony
@@ -1,0 +1,5 @@
+use "callee"
+
+class _TCrossCaller
+  fun cross_call(c: TCallee): None =>
+    c.callee_method()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/_t_poly.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/_t_poly.pony
@@ -1,0 +1,12 @@
+class _TPolyA
+  fun poly_method(): None => None
+
+class _TPolyB
+  fun poly_method(): None => None
+
+class _TPolyUser
+  fun call_a(a: _TPolyA): None =>
+    a.poly_method()
+
+  fun call_b(b: _TPolyB): None =>
+    b.poly_method()

--- a/tools/pony-lsp/test/workspace/call_hierarchy/call_hierarchy.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/call_hierarchy.pony
@@ -1,0 +1,87 @@
+"""
+Test fixtures for exercising LSP call hierarchy functionality.
+
+This package provides fixture files for manual and automated testing of the
+three LSP call hierarchy operations (prepareCallHierarchy,
+callHierarchy/incomingCalls, and callHierarchy/outgoingCalls).
+
+Fixture layout:
+- _TCallA declares f_a() which is called by f_b, f_c, f_d, and f_lambda.
+- _TCallB declares f_b() which calls f_a() and is called by f_c.
+- _TCallC declares f_c() which calls both f_a() and f_b().
+- _TCallD declares f_d() which calls f_a() twice from separate call sites.
+- _TCallActor (actor) declares new create() and be act(), where act calls f_a.
+- _TCallLambda declares f_lambda() which calls f_a() twice — once before an
+  embedded object literal and once after, exercising the nested-method guard.
+- _TPolyA and _TPolyB both declare poly_method(); _TPolyUser calls each via
+  a typed receiver, exercising position-based disambiguation for same-named
+  methods in the same file.
+- _TCrossCaller declares cross_call() which calls TCallee.callee_method() from
+  the callee/ sub-package, exercising cross-package outgoing-call resolution.
+  callee/ uses a public type (no underscore) so it is accessible cross-package.
+- _TConstructed declares new create(). _TCallConstructorCaller.f_new_explicit()
+  calls _TConstructed.create() explicitly, exercising that _is_synthetic_newref
+  does not filter user-written Foo.create() constructor calls.
+- _TConstructorWithBody declares new create(a: _TCallA) that calls a.f_a(),
+  exercising outgoing call collection when the source method is a `new`.
+
+To manually test call hierarchy functionality:
+1. Open the lsp/test/workspace directory as a project in your editor.
+2. Open one of the fixture files while the Pony language server is active.
+3. Place your cursor on a method name and invoke Show Call Hierarchy
+   (in VS Code: right-click → Show Call Hierarchy, or Shift+Alt+H).
+
+Expected call hierarchy behaviour:
+
+  `f_a` in `_TCallA`:
+    - Prepare: one item for `f_a` with detail `_TCallA`
+    - Incoming calls: `f_b` (once), `f_c` (once), `f_d` (twice, grouped),
+      `f_lambda` (twice, grouped), `act` (once)
+    - Outgoing calls: none
+
+  `f_b` in `_TCallB`:
+    - Prepare: one item for `f_b` with detail `_TCallB`
+    - Incoming calls: `f_c` (one call site)
+    - Outgoing calls: `f_a` (one call site)
+
+  `f_c` in `_TCallC`:
+    - Prepare: one item for `f_c` with detail `_TCallC`
+    - Incoming calls: none
+    - Outgoing calls: `f_a` (one call site) and `f_b` (one call site)
+
+  `f_d` in `_TCallD`:
+    - Prepare: one item for `f_d` with detail `_TCallD`
+    - Incoming calls: none
+    - Outgoing calls: `f_a` (two call sites — grouped into one entry)
+
+  `create` in `_TCallActor`:
+    - Prepare: one item for `create` with kind=constructor (9)
+
+  `act` in `_TCallActor`:
+    - Prepare: one item for `act` with kind=method (6)
+    - Outgoing calls: `f_a` (one call site)
+
+  `f_lambda` in `_TCallLambda`:
+    - Prepare: one item for `f_lambda` with detail `_TCallLambda`
+    - Incoming calls: none
+    - Outgoing calls: `f_a` (two call sites — call inside nested object is
+      excluded; only the two outer calls appear)
+
+  `poly_method` in `_TPolyA` (cursor on line 2):
+    - Incoming calls: `call_a` in `_TPolyUser` (one call site)
+
+  `poly_method` in `_TPolyB` (cursor on line 5):
+    - Incoming calls: `call_b` in `_TPolyUser` (one call site)
+
+  `cross_call` in `_TCrossCaller`:
+    - Outgoing calls: `callee_method` in `TCallee` (callee/ sub-package)
+
+  `f_new_explicit` in `_TCallConstructorCaller`:
+    - Outgoing calls: `create` in `_TConstructed` (one call site) — verifies
+      that _is_synthetic_newref does not filter user-written Foo.create() calls
+
+  `create` in `_TConstructorWithBody`:
+    - Prepare: one item for `create` with kind=constructor (9)
+    - Outgoing calls: `f_a` (one call site) — verifies _OutgoingCallCollector
+      works when the source method is a `new`, not just `fun` or `be`
+"""

--- a/tools/pony-lsp/test/workspace/call_hierarchy/callee/callee.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/callee/callee.pony
@@ -1,0 +1,3 @@
+"""
+Callee sub-package fixture for cross-package call hierarchy tests.
+"""

--- a/tools/pony-lsp/test/workspace/call_hierarchy/callee/t_callee.pony
+++ b/tools/pony-lsp/test/workspace/call_hierarchy/callee/t_callee.pony
@@ -1,0 +1,5 @@
+class TCallee
+  """
+  Cross-package callee fixture for call hierarchy tests.
+  """
+  fun callee_method(): None => None

--- a/tools/pony-lsp/workspace/call_hierarchy.pony
+++ b/tools/pony-lsp/workspace/call_hierarchy.pony
@@ -1,0 +1,510 @@
+use ".."
+use "collections"
+use "pony_compiler"
+use "json"
+
+primitive CallHierarchy
+  """
+  Handles textDocument/prepareCallHierarchy, callHierarchy/incomingCalls,
+  and callHierarchy/outgoingCalls.
+  """
+
+  fun prepare(node: AST box): (JsonArray | None) =>
+    """
+    Resolve the method at `node` and build a CallHierarchyItem array.
+    Returns one item for a declaration or one item per definition for a
+    polymorphic call site. Returns None if no method is found.
+    """
+    var found = false
+    var arr = JsonArray
+    for method in _methods_for_node(node).values() do
+      match \exhaustive\ _build_item(method)
+      | let item: JsonObject =>
+        arr = arr.push(item)
+        found = true
+      | None => None
+      end
+    end
+    if found then
+      arr
+    else
+      None
+    end
+
+  fun incoming_calls(
+    node: AST box,
+    packages: Map[String, PackageState] box): (JsonArray | None)
+  =>
+    """
+    Resolve the method at `node`, then cross-package walk to collect all
+    call sites, grouped by their enclosing method (the callers).
+    """
+    match \exhaustive\ _method_for_node(node)
+    | let target: AST val =>
+      let collector = _IncomingCallCollector(target)
+      for pkg_state in packages.values() do
+        match pkg_state.package()
+        | let pkg: Package =>
+          for module in pkg.modules() do
+            module.ast.visit(collector)
+          end
+        end
+      end
+      collector.result()
+    | None => None
+    end
+
+  fun outgoing_calls(
+    node: AST box,
+    packages: Map[String, PackageState] box): (JsonArray | None)
+  =>
+    """
+    Resolve the method at `node`, then walk its AST body to collect all
+    methods it calls directly.
+    """
+    match \exhaustive\ _method_for_node(node)
+    | let method: AST val =>
+      let method_file =
+        try
+          method.source_file() as String val
+        else
+          ""
+        end
+      let collector = _OutgoingCallCollector(method_file)
+      method.visit(collector)
+      collector.result()
+    | None => None
+    end
+
+  fun _is_synthetic_newref(ast: AST box): Bool =>
+    """
+    Returns true when `ast` is a synthetic tk_newref desugared from a
+    type-literal expression such as `None` — identified by having a tk_call
+    parent at the same source position.
+    """
+    if ast.id() != TokenIds.tk_newref() then
+      return false
+    end
+    try
+      let par = ast.parent() as AST box
+      (par.id() == TokenIds.tk_call()) and (par.position() == ast.position())
+    else
+      false
+    end
+
+  fun _methods_for_node(node: AST box): Array[AST val] =>
+    """
+    Resolve `node` to all candidate method AST nodes. Returns:
+    - [method] when the cursor is on a method node (Module._refine_node
+      already promotes a tk_id method-name to the enclosing method before
+      the node reaches here).
+    - All method definitions when the cursor is on a call reference (for
+      polymorphic dispatch one item is emitted per concrete definition).
+    - Empty array when no method is found.
+
+    The returned methods may be in a different file from `node` (e.g. when
+    the cursor is on a call-ref to a method defined in another module).
+    """
+    let result = Array[AST val]
+    let nid = node.id()
+
+    if _is_method(nid) then
+      result.push(AST(node.raw))
+      return result
+    end
+
+    for def in node.definitions().values() do
+      if _is_method(def.id()) then
+        result.push(def)
+      end
+    end
+
+    result
+
+  fun _method_for_node(node: AST box): (AST val | None) =>
+    """
+    Resolve `node` to the canonical method AST node. Returns the first
+    match from `_methods_for_node`, or None if no method is found.
+    See `_methods_for_node` for full resolution semantics.
+    """
+    try
+      _methods_for_node(node)(0)?
+    else
+      None
+    end
+
+  fun _is_method(id: TokenId): Bool =>
+    (id == TokenIds.tk_fun()) or
+    (id == TokenIds.tk_be()) or
+    (id == TokenIds.tk_new())
+
+  fun _is_call_ref(id: TokenId): Bool =>
+    // Partial-application variants (tk_funapp, tk_beapp, tk_newapp) are
+    // intentionally excluded: definitions() always returns empty for them.
+    (id == TokenIds.tk_funref()) or
+    (id == TokenIds.tk_funchain()) or
+    (id == TokenIds.tk_beref()) or
+    (id == TokenIds.tk_bechain()) or
+    (id == TokenIds.tk_newref()) or
+    (id == TokenIds.tk_newberef())
+
+  fun _symbol_kind(id: TokenId): I64 =>
+    if id == TokenIds.tk_new() then
+      SymbolKinds.constructor()
+    else
+      SymbolKinds.method()
+    end
+
+  fun _entity_name(method: AST box): String =>
+    """
+    Return the name of the entity (class/actor/etc.) enclosing `method`,
+    or an empty string if the parent chain does not resolve to an entity.
+    """
+    try
+      // Method lives inside tk_members, which lives inside the entity node.
+      // Entity: [0]=id [1]=type_params [2]=cap [3]=provides [4]=members
+      let members = method.parent() as AST box
+      let entity = members.parent() as AST box
+      let id_node = entity(0)?
+      id_node.token_value() as String
+    else
+      ""
+    end
+
+  fun _build_item(method: AST box): (JsonObject | None) =>
+    """
+    Build a LSP CallHierarchyItem JSON object for the given method AST node.
+    """
+    try
+      // Method child layout: [0]=annotation/cap [1]=name(tk_id) ...
+      let id_node = method(1)?
+      if id_node.id() != TokenIds.tk_id() then
+        return None
+      end
+      let name = id_node.token_value() as String
+      let detail = _entity_name(method)
+      let kind = _symbol_kind(method.id())
+      let file = method.source_file() as String val
+      let uri = Uris.from_path(file)
+
+      // child 1 is tk_id — its span covers only the declared name.
+      (let sel_start, let sel_end) = id_node.span()
+      let sel_range =
+        LspPositionRange(
+          LspPosition.from_ast_pos(sel_start),
+          LspPosition.from_ast_pos_end(sel_end))
+
+      // SiblingBound prevents the range from bleeding into the next member.
+      // Fall back to sel_range when there is no next sibling.
+      let full_range =
+        match \exhaustive\ ASTClampedRange(method, file, SiblingBound(method))
+        | let r: LspPositionRange => r
+        | None => sel_range
+        end
+
+      var obj =
+        JsonObject
+          .update("name", name)
+          .update("kind", kind)
+          .update("uri", uri)
+          .update("range", full_range.to_json())
+          .update("selectionRange", sel_range.to_json())
+      if detail.size() > 0 then
+        obj = obj.update("detail", detail)
+      end
+      obj
+    else
+      None
+    end
+
+class ref _IncomingCallCollector is ASTVisitor
+  """
+  AST visitor that collects all call sites of a target method across all
+  modules, grouped by the enclosing caller method.
+  """
+  // FilePosition-based identity rather than pointer equality so that trait
+  // default bodies grafted onto concrete types (different AST pointers,
+  // same file+position) are correctly matched.
+  let _target_id: FilePosition val
+  // Name prefilter: definitions() is expensive (recursive type-table descent,
+  // uncached). Skip it when the call-ref identifier name doesn't match the
+  // target method name.
+  let _target_name: String val
+  // Maps caller method identity (file+position) to (method_ast, call_ranges).
+  let _callers: Map[String, (AST val, Array[LspPositionRange] ref)]
+  let _seen_ranges: Set[String]
+
+  new ref create(target: AST val) =>
+    let target_file =
+      try
+        target.source_file() as String val
+      else
+        ""
+      end
+    _target_id = FilePosition(target.position(), target_file)
+    _target_name =
+      try
+        target(1)?.token_value() as String val
+      else
+        ""
+      end
+    _callers = Map[String, (AST val, Array[LspPositionRange] ref)].create()
+    _seen_ranges = Set[String].create()
+
+  fun ref visit(ast: AST box): VisitResult =>
+    if not CallHierarchy._is_call_ref(ast.id()) then
+      return Continue
+    end
+
+    if CallHierarchy._is_synthetic_newref(ast) then
+      return Continue
+    end
+
+    // Name prefilter: skip definitions() when the call-ref identifier doesn't
+    // match the target. ASTIdentifier.identifier_node is cheap; definitions()
+    // is not.
+    if _target_name.size() > 0 then
+      let ident = ASTIdentifier.identifier_node(ast)
+      let call_name =
+        try
+          ident.token_value() as String
+        else
+          ""
+        end
+      if call_name != _target_name then
+        return Continue
+      end
+    end
+
+    var matches = false
+    for def in ast.definitions().values() do
+      let def_file =
+        try
+          def.source_file() as String val
+        else
+          ""
+        end
+      if FilePosition(def.position(), def_file) == _target_id then
+        matches = true
+        break
+      end
+    end
+    if not matches then
+      return Continue
+    end
+
+    let caller =
+      match \exhaustive\ _enclosing_method(ast)
+      | let m: AST val => m
+      | None => return Continue
+      end
+
+    // Get the call site range (position of the method name identifier).
+    let hl_node = ASTIdentifier.identifier_node(ast)
+    (let start_pos, let end_pos) = hl_node.span()
+    let node_file =
+      try
+        hl_node.source_file() as String val
+      else
+        ""
+      end
+    // Start position alone is sufficient for deduplication: two syntactically
+    // distinct call expressions cannot start at the same file/line/column.
+    let range_key: String val =
+      recover val
+        String
+          .> append(node_file)
+          .> push(':')
+          .> append(start_pos.line().string())
+          .> push(':')
+          .> append(start_pos.column().string())
+      end
+    if _seen_ranges.contains(range_key) then
+      return Continue
+    end
+    _seen_ranges.set(range_key)
+
+    let range =
+      LspPositionRange(
+        LspPosition.from_ast_pos(start_pos),
+        LspPosition.from_ast_pos_end(end_pos))
+
+    let caller_key: String val =
+      recover val
+        let f =
+          try
+            caller.source_file() as String val
+          else
+            ""
+          end
+        let pos = caller.position()
+        String
+          .> append(f)
+          .> push(':')
+          .> append(pos.line().string())
+          .> push(':')
+          .> append(pos.column().string())
+      end
+    try
+      (_callers(caller_key)?)._2.push(range)
+    else
+      let ranges = Array[LspPositionRange].create()
+      ranges.push(range)
+      _callers(caller_key) = (caller, ranges)
+    end
+
+    Continue
+
+  fun ref _enclosing_method(node: AST box): (AST val | None) =>
+    // Walk up via parent() until a method node is found.
+    // Returns None when parent() returns None (top of tree, no method found).
+    try
+      var cur = node.parent() as AST box
+      while true do
+        if CallHierarchy._is_method(cur.id()) then
+          return AST(cur.raw)
+        end
+        cur = cur.parent() as AST box
+      end
+    end
+    None
+
+  fun ref result(): JsonArray =>
+    var arr = JsonArray
+    for (caller, ranges) in _callers.values() do
+      match CallHierarchy._build_item(caller)
+      | let item: JsonObject =>
+        var from_ranges = JsonArray
+        for r in ranges.values() do
+          from_ranges = from_ranges.push(r.to_json())
+        end
+        arr =
+          arr.push(
+            JsonObject
+              .update("from", item)
+              .update("fromRanges", from_ranges))
+      end
+    end
+    arr
+
+class ref _OutgoingCallCollector is ASTVisitor
+  """
+  AST visitor that collects all methods called within a target method's body,
+  grouped by callee and recording the call site ranges within the caller.
+
+  Note: calls inside inherited trait default bodies are not visible here
+  because AST.visit filters cross-source children (grafted bodies retain the
+  trait's source file). This is intentional — those calls belong to the
+  trait's own hierarchy, not the concrete method's.
+  """
+  let _method_file: String
+  // Maps callee method identity (file+position) to (method_ast, call_ranges).
+  let _callees: Map[String, (AST val, Array[LspPositionRange] ref)]
+  let _seen_ranges: Set[String]
+  // Depth of nested method declarations (object literals, lambdas). Call
+  // sites inside nested methods belong to those methods' own hierarchies,
+  // not the outer method's. We use visit/leave to track entry and exit so
+  // that siblings after a nested declaration are still visited (returning
+  // Stop would abort the entire traversal, not just the subtree).
+  var _nested_depth: USize = 0
+
+  new ref create(method_file: String) =>
+    _method_file = method_file
+    _callees = Map[String, (AST val, Array[LspPositionRange] ref)].create()
+    _seen_ranges = Set[String].create()
+
+  fun ref visit(ast: AST box): VisitResult =>
+    if CallHierarchy._is_method(ast.id()) then
+      _nested_depth = _nested_depth + 1
+      return Continue
+    end
+
+    if _nested_depth > 0 then
+      return Continue
+    end
+
+    if not CallHierarchy._is_call_ref(ast.id()) then
+      return Continue
+    end
+
+    if CallHierarchy._is_synthetic_newref(ast) then
+      return Continue
+    end
+
+    // Deduplicate by call site before iterating definitions.
+    let hl_node = ASTIdentifier.identifier_node(ast)
+    (let start_pos, let end_pos) = hl_node.span()
+    let range_key: String val =
+      recover val
+        String
+          .> append(_method_file)
+          .> push(':')
+          .> append(start_pos.line().string())
+          .> push(':')
+          .> append(start_pos.column().string())
+      end
+    if _seen_ranges.contains(range_key) then
+      return Continue
+    end
+    _seen_ranges.set(range_key)
+
+    let range =
+      LspPositionRange(
+        LspPosition.from_ast_pos(start_pos),
+        LspPosition.from_ast_pos_end(end_pos))
+
+    // Record an edge for every concrete definition (handles polymorphic
+    // dispatch where one call site resolves to multiple implementations).
+    for def in ast.definitions().values() do
+      if CallHierarchy._is_method(def.id()) then
+        let callee_key: String val =
+          recover val
+            let f =
+              try
+                def.source_file() as String val
+              else
+                ""
+              end
+            let pos = def.position()
+            String
+              .> append(f)
+              .> push(':')
+              .> append(pos.line().string())
+              .> push(':')
+              .> append(pos.column().string())
+          end
+        try
+          (_callees(callee_key)?)._2.push(range)
+        else
+          let ranges = Array[LspPositionRange].create()
+          ranges.push(range)
+          _callees(callee_key) = (def, ranges)
+        end
+      end
+    end
+
+    Continue
+
+  fun ref leave(ast: AST box): VisitResult =>
+    if CallHierarchy._is_method(ast.id()) then
+      _nested_depth = _nested_depth - 1
+    end
+    Continue
+
+  fun ref result(): JsonArray =>
+    var arr = JsonArray
+    for (callee, ranges) in _callees.values() do
+      match CallHierarchy._build_item(callee)
+      | let item: JsonObject =>
+        var from_ranges = JsonArray
+        for r in ranges.values() do
+          from_ranges = from_ranges.push(r.to_json())
+        end
+        arr =
+          arr.push(
+            JsonObject
+              .update("to", item)
+              .update("fromRanges", from_ranges))
+      end
+    end
+    arr

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -28,7 +28,6 @@ actor WorkspaceManager
   let _packages: Map[String, PackageState]
   let _global_errors: Array[Diagnostic val]
   var _compile_run: USize = 0
-  var _current_request: (RequestMessage val | None) = None
   var _compiling: Bool = false
   var _awaiting_compilation_for: Map[String, (USize | None)] =
     _awaiting_compilation_for.create()
@@ -441,8 +440,6 @@ actor WorkspaceManager
     """
     Handling the textDocument/hover request.
     """
-    this._current_request = request
-
     // Parse position from request params
     (let line, let column) =
       match \exhaustive\ _parse_hover_position(request)
@@ -515,6 +512,23 @@ actor WorkspaceManager
         USize.from[I64](column + 1))
       | let node: AST box => (node, module)
       end
+    end
+
+  fun ref _find_method_node(
+    document_path: String,
+    sel_line: I64,
+    sel_col: I64): (AST box | None)
+  =>
+    """
+    Resolve the method AST node at the given position. Returns None when the
+    document has not been compiled or no method node is found at that position.
+    """
+    if (sel_line < 0) or (sel_col < 0) then
+      return None
+    end
+    match _find_node_and_module(document_path, sel_line, sel_col)
+    | (let node: AST box, _) =>
+      CallHierarchy._method_for_node(node)
     end
 
   fun ref _get_index_and_module(
@@ -753,7 +767,6 @@ actor WorkspaceManager
     Handling the textDocument/definition request.
     """
     this._channel.log("handling " + request.method)
-    this._current_request = request
     (let line, let column) =
       match \exhaustive\ _parse_hover_position(request)
       | (let l: I64, let c: I64) => (l, c)
@@ -1155,6 +1168,73 @@ actor WorkspaceManager
           return
         | None => None
         end
+      end
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be call_hierarchy_prepare(
+    document_uri: String,
+    request: RequestMessage val)
+  =>
+    """
+    Handle textDocument/prepareCallHierarchy request.
+    """
+    this._channel.log("Handling textDocument/prepareCallHierarchy")
+    (let line, let column) =
+      match \exhaustive\ _parse_hover_position(request)
+      | (let l: I64, let c: I64) => (l, c)
+      | None => return
+      end
+    let document_path = Uris.to_path(document_uri)
+    match \exhaustive\ _find_node_and_module(document_path, line, column)
+    | (let node: AST box, _) =>
+      match CallHierarchy.prepare(node)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
+      end
+    | None => None
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be call_hierarchy_incoming_calls(
+    document_uri: String,
+    sel_line: I64,
+    sel_col: I64,
+    request: RequestMessage val)
+  =>
+    """
+    Handle callHierarchy/incomingCalls request.
+    """
+    this._channel.log("Handling callHierarchy/incomingCalls")
+    let document_path = Uris.to_path(document_uri)
+    match _find_method_node(document_path, sel_line, sel_col)
+    | let node: AST box =>
+      match CallHierarchy.incoming_calls(node, this._packages)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
+      end
+    end
+    this._channel.send(ResponseMessage.create(request.id, None))
+
+  be call_hierarchy_outgoing_calls(
+    document_uri: String,
+    sel_line: I64,
+    sel_col: I64,
+    request: RequestMessage val)
+  =>
+    """
+    Handle callHierarchy/outgoingCalls request.
+    """
+    this._channel.log("Handling callHierarchy/outgoingCalls")
+    let document_path = Uris.to_path(document_uri)
+    match _find_method_node(document_path, sel_line, sel_col)
+    | let node: AST box =>
+      match CallHierarchy.outgoing_calls(node, this._packages)
+      | let result: JsonArray =>
+        this._channel.send(ResponseMessage(request.id, result))
+        return
       end
     end
     this._channel.send(ResponseMessage.create(request.id, None))


### PR DESCRIPTION
## Context

The Pony language server supports go-to-definition, find references, rename, hover, and type hierarchy, but has no call hierarchy support. Editors that implement the LSP call hierarchy protocol (VS Code, Neovim, Helix) expose it as "Show Call Hierarchy", giving users a tree view of who calls a method and what it calls.

## Changes

- Adds `workspace/call_hierarchy.pony` with a `CallHierarchy` primitive that implements the three operations. `_IncomingCallCollector` walks all loaded packages to find call sites of the target method; `_OutgoingCallCollector` walks the method body with a nested-method depth guard to exclude calls inside object literals and lambdas. Both handle polymorphic dispatch by resolving call refs to all concrete definitions.
- Wires up `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, and `callHierarchy/outgoingCalls` in `language_server.pony` and `workspace_manager.pony`.
- Extracts a `_get_item_uri_and_sel` helper in `language_server.pony`, collapsing duplicated item URI + selection range extraction shared by all four hierarchy handlers (call and type).
- Adds 18 integration tests covering: prepare on `fun`/`be`/`new`, incoming and outgoing calls with single and multiple call sites, cross-package resolution, polymorphic dispatch disambiguation by file position, lambda nested-method exclusion, and constructors as both callers and callees.

Resolves #5182.

## Considerations

- Incoming calls walk all packages including stdlib and transitive dependencies, matching the scope of `callHierarchy/incomingCalls` in other language servers. This is a deliberate choice — the alternative (workspace-only scope) would silently omit callers in packages the user didn't author.
- The `_is_synthetic_newref` guard filters `tk_newref` nodes desugared from type-literal expressions like `None` (identified by matching parent position), preventing spurious `create` entries in call results. Explicit `Foo.create()` calls are not affected.