### PR TITLE
A minor tidy in the pony-lsp codebase

### DIFF
--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -411,7 +411,12 @@ actor LanguageServer is (Notifier & RequestSender)
                 "[" + r.method + "] missing item or selectionRange.start")))
         end
       | Methods.workspace().symbol() =>
-        let query = try JsonNav(r.params)("query").as_string()? else "" end
+        let query =
+          try
+            JsonNav(r.params)("query").as_string()?
+          else
+            ""
+          end
         _router.workspace_symbol(query, this._channel, r.id)
       | Methods.shutdown() =>
         this._state = _ShuttingDown

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -164,7 +164,11 @@ primitive DocumentSymbols
       match maybe_kind
       | let kind: I64 =>
         let max_pos: (Position | None) =
-          try entity_starts(entity_idx + 1)? else None end
+          try
+            entity_starts(entity_idx + 1)?
+          else
+            None
+          end
         entity_idx = entity_idx + 1
         try
           let id = module_child(0)?
@@ -241,14 +245,20 @@ primitive DocumentSymbols
       // Skip members whose position is at or beyond max_pos.
       match max_pos
       | let m: Position =>
-        if entity_child.position() >= m then continue end
+        if entity_child.position() >= m then
+          continue
+        end
       end
+
       // Skip members at or before the entity's keyword position.
       // ponyc places synthesized constructors (the default `create`
       // added to bare classes/actors/primitives/structs) at the entity
       // keyword's own source position via token_dup(). Any explicitly
       // written member must appear after the entity keyword.
-      if entity_child.position() <= entity_pos then continue end
+      if entity_child.position() <= entity_pos then
+        continue
+      end
+
       // Skip members from other source files. ponyc merges trait
       // default method bodies into implementing classes; those merged
       // nodes carry the trait file's source_file(). Nodes with
@@ -257,9 +267,12 @@ primitive DocumentSymbols
       | let dp: String val =>
         match entity_child.source_file()
         | let sf: String val =>
-          if sf != dp then continue end
+          if sf != dp then
+            continue
+          end
         end
       end
+
       // Skip fully-synthesized members. ponyc's BUILD macro gives every node
       // in a constructed subtree the same source position (inherited from the
       // BUILD basis). Real members always place their keyword before their

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -234,7 +234,9 @@ primitive FoldingRanges
         var _max: USize = 0
         fun ref visit(n: AST box): VisitResult =>
           let l = n.line()
-          if (l > _max) and (l < cap) then _max = l end
+          if (l > _max) and (l < cap) then
+            _max = l
+          end
           Continue
         fun max(): USize => _max
       end

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -163,7 +163,8 @@ class ref _InlayHintCollector is ASTVisitor
       var has_targs = false
       for child in targs.children() do
         if child.id() != TokenIds.tk_none() then
-          has_targs = true; break
+          has_targs = true
+          break
         end
       end
 
@@ -275,7 +276,9 @@ class ref _InlayHintCollector is ASTVisitor
     """
     try
       let type_node = param(1)?
-      if type_node.id() == TokenIds.tk_none() then return end
+      if type_node.id() == TokenIds.tk_none() then
+        return
+      end
       _add_nominal_hints(type_node, src)
     end
 

--- a/tools/pony-lsp/workspace/inlay_hint_source.pony
+++ b/tools/pony-lsp/workspace/inlay_hint_source.pony
@@ -14,7 +14,12 @@ primitive InlayHintSource
     | ('i', 's', 'o') | ('t', 'r', 'n') | ('r', 'e', 'f')
     | ('v', 'a', 'l') | ('b', 'o', 'x') | ('t', 'a', 'g')
     =>
-      let next = try src(j + 3)? else return true end
+      let next =
+        try
+          src(j + 3)?
+        else
+          return true
+        end
       not ((next >= 'a') and (next <= 'z'))
     else
       false

--- a/tools/pony-lsp/workspace/rename.pony
+++ b/tools/pony-lsp/workspace/rename.pony
@@ -73,7 +73,9 @@ primitive _IsValidPonyIdentifier
   first character must be [a-zA-Z_], subsequent characters [a-zA-Z0-9_'].
   """
   fun apply(name: String): Bool =>
-    if name.size() == 0 then return false end
+    if name.size() == 0 then
+      return false
+    end
     var first = true
     for c in name.values() do
       if first then

--- a/tools/pony-lsp/workspace/selection_ranges.pony
+++ b/tools/pony-lsp/workspace/selection_ranges.pony
@@ -65,7 +65,12 @@ primitive SelectionRanges
     var i = chain.size()
     while i > 0 do
       i = i - 1
-      let n = try chain(i)? else continue end
+      let n =
+        try
+          chain(i)?
+        else
+          continue
+        end
       match \exhaustive\ ASTSourceSpan(n, doc_path, SiblingBound(n))
       | (let s: Position, let e: Position) =>
         // Note: no clamped-start correction here, unlike _symbol_ranges and
@@ -108,4 +113,3 @@ primitive SelectionRanges
       end
     end
     result
-

--- a/tools/pony-lsp/workspace/signature_help.pony
+++ b/tools/pony-lsp/workspace/signature_help.pony
@@ -160,12 +160,20 @@ primitive SignatureHelp
           pos_arg_child = current
         elseif pid == TokenIds.tk_call() then
           let from_callee: Bool =
-            try current == parent(0)? else false end
+            try
+              current == parent(0)?
+            else
+              false
+            end
 
           if from_callee then
             // Zero-arg call: cursor is naturally on the callee — show sig.
             let is_zero_args: Bool =
-              try parent(1)?.child() is None else true end
+              try
+                parent(1)?.child() is None
+              else
+                true
+              end
             if is_zero_args then
               try
                 return (parent, parent(0)?, 0)
@@ -201,7 +209,9 @@ primitive SignatureHelp
                     let args = parent(1)?
                     var idx: USize = 0
                     for arg in args.children() do
-                      if arg == fc then break end
+                      if arg == fc then
+                        break
+                      end
                       idx = idx + 1
                     end
                     idx

--- a/tools/pony-lsp/workspace/signature_help_source.pony
+++ b/tools/pony-lsp/workspace/signature_help_source.pony
@@ -50,7 +50,9 @@ primitive SignatureHelpSource
           scan_col = scan_col + 1
           while byte_offset < src.size() do
             try
-              if src(byte_offset)? == '\n' then break end
+              if src(byte_offset)? == '\n' then
+                break
+              end
               byte_offset = byte_offset + 1
               scan_col = scan_col + 1
             else

--- a/tools/pony-lsp/workspace/workspace_data.pony
+++ b/tools/pony-lsp/workspace/workspace_data.pony
@@ -86,7 +86,9 @@ class val WorkspaceData
         )?
       end
       let parent = Path.dir(doc_path)
-      if parent == doc_path then break end // hit filesystem root
+      if parent == doc_path then
+        break // hit filesystem root
+      end
       doc_path = parent
     end
     None

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -192,15 +192,13 @@ actor WorkspaceManager
           end
           if requires_another_compilation then
             this._channel.log(
-              program_dir.path +
-              " needs another compilation...")
+              program_dir.path + " needs another compilation...")
             this._compile(program_dir)
           end
         end
       | let errors: Array[Error val] val =>
         this._channel.log(
-          "Compilation failed with " +
-          errors.size().string() + " errors")
+          "Compilation failed with " + errors.size().string() + " errors")
 
         let diag_iter =
           Iter[Error](errors.values())
@@ -783,8 +781,7 @@ actor WorkspaceManager
           json_arr = json_arr.push(loc.to_json())
         | None =>
           this._channel.log(
-            "No source file found for definition: " +
-              ast_definition.debug())
+            "No source file found for definition: " + ast_definition.debug())
         end
       end
       this._channel.send(ResponseMessage(request.id, json_arr))
@@ -820,8 +817,7 @@ actor WorkspaceManager
             json_arr = json_arr.push(loc.to_json())
           | None =>
             this._channel.log(
-              "No source file found for type definition: " +
-                type_def.debug())
+              "No source file found for type definition: " + type_def.debug())
           end
         end
       end
@@ -892,9 +888,7 @@ actor WorkspaceManager
                     "location",
                     JsonObject
                       .update("uri", file_uri)
-                      .update(
-                        "range",
-                        symbol.range.to_json())))
+                      .update("range", symbol.range.to_json())))
           end
           for child in symbol.children.values() do
             if _symbol_matches(child.name, query_lower) then
@@ -908,9 +902,7 @@ actor WorkspaceManager
                       "location",
                       JsonObject
                         .update("uri", file_uri)
-                        .update(
-                          "range",
-                          child.range.to_json())))
+                        .update("range", child.range.to_json())))
             end
           end
         end


### PR DESCRIPTION
## Context

pony-lsp contains several instances of single-line `if` and `try/else` expressions that are harder to read at a glance. No behavior is changed.

## Changes

- Expand single-line `if ... then ... end` guards to multi-line form
- Expand inline `try ... else ... end` expressions to multi-line form
- Remove trailing blank line in `selection_ranges.pony`
- Tighten multi-line string concatenations in `workspace_manager.pony` that were split at the `+` operator

## Considerations

Pure style changes; all existing tests should pass unchanged.