### PR TITLE
Tidy LSP typeHierarchy implementation

### DIFF
--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -20,6 +20,12 @@ use "json"
 // line 0: class _THierE  name (0,6)..(0,13)  full (0,0)..(4,27)
 // (_THierE is the last entity in its file; SiblingBound returns None so
 // ASTSourceSpan includes synthesized constructor tokens, inflating by 2.)
+//
+// Fixture layout — _t_hier_dup_base.pony:
+// line 0: trait _THierDupBase   name (0,6)..(0,19)  full (0,0)..(1,19)
+// line 3: class _THierDupClass  name (3,6)..(3,20)  full (3,0)..(4,29)
+// (_THierDupClass provides _THierDupBase & _THierDupBase — the duplication
+// exercises Set[AST val] dedup in _collect_supertypes.)
 
 primitive _TypeHierarchyIntegrationTests is TestList
   new make() => None
@@ -35,6 +41,8 @@ primitive _TypeHierarchyIntegrationTests is TestList
     test(_TypeHierarchySubtypesLeafTest.create(server))
     test(_TypeHierarchyIsectypeTest.create(server))
     test(_TypeHierarchySubtypesCrossFileTest.create(server))
+    test(_TypeHierarchySubtypesIsectTest.create(server))
+    test(_TypeHierarchySupertypesDedupeTest.create(server))
 
 class \nodoc\ iso _PrepareTypeHierarchyOnEntityTest is UnitTest
   """
@@ -269,6 +277,71 @@ class \nodoc\ iso _TypeHierarchySubtypesCrossFileTest is UnitTest
               t_hier_e,
               (0, 6, 0, 13),
               (0, 0, 4, 27)) ]) ])
+
+class \nodoc\ iso _TypeHierarchySubtypesIsectTest is UnitTest
+  """
+  Subtypes of _THierLeft — expects _THierIsect, verifying the
+  tk_isecttype recursion path in _provides_mentions and the
+  _target_name prefilter in _SubtypeCollector.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/subtypes_isect"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_isect = "type_hierarchy/_t_hier_isect.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_isect,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().subtypes(),
+          workspace_dir,
+          t_hier_isect,
+          (0, 6),
+          [ _THierExpected(
+              "_THierIsect",
+              11,
+              workspace_dir,
+              t_hier_isect,
+              (12, 6, 12, 17),
+              (12, 0, 19, 17)) ]) ])
+
+class \nodoc\ iso _TypeHierarchySupertypesDedupeTest is UnitTest
+  """
+  Supertypes of _THierDupClass (provides _THierDupBase & _THierDupBase) —
+  dedup by AST pointer identity returns one item, not two.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "type_hierarchy/integration/supertypes_dedupe"
+
+  fun apply(h: TestHelper) =>
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let t_hier_dup = "type_hierarchy/_t_hier_dup_base.pony"
+    _RunLspChecks(
+      h,
+      _server,
+      t_hier_dup,
+      [ _THierItemsChecker(
+          Methods.type_hierarchy().supertypes(),
+          workspace_dir,
+          t_hier_dup,
+          (3, 6),
+          [ _THierExpected(
+              "_THierDupBase",
+              11,
+              workspace_dir,
+              t_hier_dup,
+              (0, 6, 0, 19),
+              (0, 0, 1, 19)) ]) ])
 
 class val _THierExpected
   """

--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -201,7 +201,7 @@ class \nodoc\ iso _TypeHierarchyIsectypeTest is UnitTest
   """
   Supertypes of _THierIsect (provides _THierLeft & _THierRight via
   intersection type) — verifies the tk_isecttype recursion path in
-  _collect_provides_defs.
+  _append_provides_defs.
   """
   let _server: _LspTestServer
 

--- a/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_dup_base.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/_t_hier_dup_base.pony
@@ -1,0 +1,5 @@
+trait _THierDupBase
+  fun f_dup(): None
+
+class _THierDupClass is (_THierDupBase & _THierDupBase)
+  fun f_dup(): None => None

--- a/tools/pony-lsp/workspace/type_hierarchy.pony
+++ b/tools/pony-lsp/workspace/type_hierarchy.pony
@@ -72,12 +72,10 @@ primitive TypeHierarchy
     end
 
   fun _is_entity(id: TokenId): Bool =>
-    (id == TokenIds.tk_class()) or
-    (id == TokenIds.tk_actor()) or
-    (id == TokenIds.tk_trait()) or
-    (id == TokenIds.tk_interface()) or
-    (id == TokenIds.tk_primitive()) or
-    (id == TokenIds.tk_struct())
+    // Delegate to the compiler library so new entity tokens are picked up
+    // automatically. tk_object (anonymous object literals) is excluded: they
+    // have no declared name and aren't meaningful as hierarchy nodes.
+    TokenIds.is_entity(id) and (id != TokenIds.tk_object())
 
   fun _symbol_kind(id: TokenId): I64 =>
     match id
@@ -139,7 +137,7 @@ primitive TypeHierarchy
     directly referenced supertype.
     """
     var result = JsonArray
-    let seen = Set[USize]
+    let seen = Set[AST val]
     try
       // Entity child layout:
       // [0]=id [1]=type_params [2]=cap [3]=provides [4]=members
@@ -149,10 +147,10 @@ primitive TypeHierarchy
       end
       for def in _provides_defs(provides_node).values() do
         // Dedup by AST pointer identity — same invariant as _SubtypeCollector.
-        if seen.contains(digestof def) then
+        if seen.contains(def) then
           continue
         end
-        seen.set(digestof def)
+        seen.set(def)
         match _build_item(def)
         | let item: JsonObject => result = result.push(item)
         end
@@ -160,20 +158,47 @@ primitive TypeHierarchy
     end
     result
 
-  fun _provides_defs(provides: AST box): Array[AST] =>
+  fun _provides_mentions(provides: AST box, name: String): Bool =>
+    """
+    Return true if any nominal in the provides subtree has an identifier
+    matching `name`. Cheap identifier-only walk; does not call definitions().
+    """
+    let nid = provides.id()
+    if nid == TokenIds.tk_none() then
+      false
+    elseif
+      (nid == TokenIds.tk_provides()) or (nid == TokenIds.tk_isecttype())
+    then
+      for child in provides.children() do
+        if _provides_mentions(child, name) then
+          return true
+        end
+      end
+      false
+    else
+      try
+        (ASTIdentifier.identifier_node(provides).token_value() as String)
+          == name
+      else
+        true  // unknown nominal shape — don't filter it out
+      end
+    end
+
+  fun _provides_defs(provides: AST box): Array[AST val] =>
     """
     Return all entity definitions directly referenced by a provides node.
     Recursively descends through tk_provides and tk_isecttype wrappers
     until reaching resolvable type nodes (e.g. tk_nominal).
     """
-    let result = Array[AST]
+    let result = Array[AST val]
     _append_provides_defs(provides, result)
     result
 
-  fun _append_provides_defs(provides: AST box, result: Array[AST] ref) =>
-    // Valid provides shapes: tk_none (empty), tk_provides (single or union),
-    // tk_isecttype (intersection &). Anything else is a nominal; resolve it
-    // directly via definitions().
+  fun _append_provides_defs(provides: AST box, result: Array[AST val] ref) =>
+    // Valid provides shapes: tk_none (empty), tk_provides (wrapper around the
+    // provides type), tk_isecttype (intersection &). The parser rejects | at
+    // the top of a provides clause, so tk_uniontype never appears here.
+    // Anything else is a nominal; resolve it directly via definitions().
     let nid = provides.id()
     if nid == TokenIds.tk_none() then
       None
@@ -196,10 +221,20 @@ class ref _SubtypeCollector is ASTVisitor
   the target entity.
   """
   let _target: AST val
+  // Name prefilter: _provides_defs calls definitions() which is an expensive
+  // recursive type-table descent. Skip it when no nominal in the provides
+  // clause even mentions the target name. Mirrors _IncomingCallCollector.
+  let _target_name: String val
   var _result: JsonArray
 
   new ref create(target: AST val) =>
     _target = target
+    _target_name =
+      try
+        target(0)?.token_value() as String val
+      else
+        ""
+      end
     _result = JsonArray
 
   fun ref visit(ast: AST box): VisitResult =>
@@ -211,6 +246,13 @@ class ref _SubtypeCollector is ASTVisitor
       // [0]=id [1]=type_params [2]=cap [3]=provides [4]=members
       let provides_node = ast(3)?
       if provides_node.id() == TokenIds.tk_none() then
+        return Continue
+      end
+      // Name prefilter: cheap identifier-only walk before the expensive
+      // definitions() call inside _provides_defs.
+      if (_target_name.size() > 0)
+        and not TypeHierarchy._provides_mentions(provides_node, _target_name)
+      then
         return Continue
       end
       for def in TypeHierarchy._provides_defs(provides_node).values() do

--- a/tools/pony-lsp/workspace/type_hierarchy.pony
+++ b/tools/pony-lsp/workspace/type_hierarchy.pony
@@ -180,7 +180,7 @@ primitive TypeHierarchy
         (ASTIdentifier.identifier_node(provides).token_value() as String)
           == name
       else
-        true  // unknown nominal shape — don't filter it out
+        true  // non-nominal type form — allow through
       end
     end
 

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -529,6 +529,23 @@ actor WorkspaceManager
       CallHierarchy._method_for_node(node)
     end
 
+  fun ref _find_entity_node(
+    document_path: String,
+    sel_line: I64,
+    sel_col: I64): (AST box | None)
+  =>
+    """
+    Resolve the entity AST node at the given position. Returns None when the
+    document has not been compiled or no entity node is found at that position.
+    """
+    if (sel_line < 0) or (sel_col < 0) then
+      return None
+    end
+    match _find_node_and_module(document_path, sel_line, sel_col)
+    | (let node: AST box, _) =>
+      TypeHierarchy._entity_for_node(node)
+    end
+
   fun ref _get_index_and_module(
     document_path: String): ((PositionIndex val, Module val) | None)
   =>
@@ -1267,14 +1284,13 @@ actor WorkspaceManager
     """
     this._channel.log("Handling typeHierarchy/supertypes")
     let document_path = Uris.to_path(document_uri)
-    match \exhaustive\ _find_node_and_module(document_path, sel_line, sel_col)
-    | (let node: AST box, _) =>
+    match _find_entity_node(document_path, sel_line, sel_col)
+    | let node: AST box =>
       match TypeHierarchy.supertypes(node)
       | let result: JsonArray =>
         this._channel.send(ResponseMessage(request.id, result))
         return
       end
-    | None => None
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 
@@ -1289,14 +1305,13 @@ actor WorkspaceManager
     """
     this._channel.log("Handling typeHierarchy/subtypes")
     let document_path = Uris.to_path(document_uri)
-    match \exhaustive\ _find_node_and_module(document_path, sel_line, sel_col)
-    | (let node: AST box, _) =>
+    match _find_entity_node(document_path, sel_line, sel_col)
+    | let node: AST box =>
       match TypeHierarchy.subtypes(node, this._packages)
       | let result: JsonArray =>
         this._channel.send(ResponseMessage(request.id, result))
         return
       end
-    | None => None
     end
     this._channel.send(ResponseMessage.create(request.id, None))
 


### PR DESCRIPTION
## Context

Fixes several issues in the typeHierarchy feature added in #5297.

## Changes

- Fix supertype dedup: replace `Set[USize]`/`digestof` with `Set[AST val]` so deduplication uses raw pointer identity via `AST.hash()`/`eq()`, matching the invariant stated in the comment
- Add name prefilter to `_SubtypeCollector` to skip the expensive `definitions()` call when no nominal in the provides clause matches the target entity name, mirroring `_IncomingCallCollector` in call_hierarchy
- Add `_find_entity_node` helper to `WorkspaceManager`, paralleling `_find_method_node`: negative-coord guard + entity resolution at the workspace boundary; use it in `type_hierarchy_supertypes`/`type_hierarchy_subtypes`
- Delegate `_is_entity` to `TokenIds.is_entity`, excluding `tk_object`, so new compiler entity tokens are picked up automatically
- Annotate `_provides_defs` return type as `Array[AST val]`
- Correct stale function name in isectype test docstring
- Correct misleading comment about `tk_uniontype` in `_append_provides_defs`

## Considerations

None of these changes affect observable LSP behaviour for valid inputs. The dedup fix technically changes output for `class C is (A & A)` (supertypes no longer returns `A` twice), but that is malformed source.