### PR TITLE
Surface tmpdir cleanup failures in _ast_test_helper.pony

### DIFF
--- a/tools/pony-lint/test/_ast_test_helper.pony
+++ b/tools/pony-lint/test/_ast_test_helper.pony
@@ -9,7 +9,8 @@ primitive \nodoc\ _ASTTestHelper
   in AST rule tests.
 
   Writes the source to a temporary directory, compiles it, and returns the
-  results. The temporary directory is removed before returning.
+  results. The temporary directory is always cleaned up before this method
+  returns or raises.
 
   The PONYPATH environment variable must be set to locate the builtin
   package (e.g., the ponyc packages/ directory). Tests run from a build
@@ -80,10 +81,10 @@ primitive \nodoc\ _ASTTestHelper
           end
         end
       else
-        tmp.remove()
+        h.assert_true(tmp.remove(), "tmpdir cleanup failed")
         error
       end
-    tmp.remove()
+    h.assert_true(tmp.remove(), "tmpdir cleanup failed")
     result
 
   fun _format_errors(errors: Array[ast.Error] val): String val =>


### PR DESCRIPTION
A followup to #5299. Replace bare `tmp.remove()` with `h.assert_true(tmp.remove(), "tmpdir cleanup failed")` so that silent removal failures surface as test failures rather than going undetected. Updates the docstring to accurately describe cleanup on both return and error paths.

Parked for your input:

- Adversarial review flagged that asserting on `tmp.remove()` could produce flaky red CI on Windows+antivirus or NFS-backed runners, where transient post-`dispose` locks make `remove()` return `false` despite the test logic being correct. If we ever see that, including `tmp.path` in the failure message would help debug it.
- The same leak-prone pattern (bare `tmp.remove()` as the last statement of a `try` body) exists in `_test_config_resolver.pony`, `_test_config.pony`, and `_test_linter.pony` (~22 sites). None are actually leaking today (verified empirically: 0 leftover `pony-lint-test*`/`ignore-test*` dirs after a full test run). I attempted a defensive `try ... then h.assert_true(tmp.remove(), ...) end` wrapper for `_test_ignore.pony` first, but Pony's `try ... then ... end` (no `else`) silently swallows errors when the body raises — so the obvious defense actively masks future bugs. The clean alternative `try ... else error then ... end` is rejected by the compiler when the body has no partial expression. I don't have a clean hardening pattern to recommend for those sites, so I left them untouched.