### PR TITLE
Fix LSP range end positions overshooting past source line ends

### DIFF
--- a/.release-notes/fix-lsp-range-end-line-overshoot.md
+++ b/.release-notes/fix-lsp-range-end-line-overshoot.md
@@ -1,0 +1,3 @@
+## Fix LSP range end positions overshooting past source line ends
+
+Go-to-definition, document symbols, workspace symbols, type hierarchy, call hierarchy, and selection ranges could highlight text past the end of the declaration line. Editors that rely on this range for highlighting or cursor placement would overshoot into whitespace or the next token. This is now fixed.

--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -15,6 +15,12 @@ primitive ASTSourceSpan
   bare primitives, bare classes, etc.) from inflating the entity's range
   into the next entity's lines.
 
+  A second guard caps the final `_max` column to the actual length of
+  that source line. Synthesized constructors for entities with explicit
+  members and desugared value expressions (e.g. `None => None`) can
+  produce `end_pos()` values past the actual line end. Reading the
+  source text caps the column to a position that exists in the file.
+
   Seeded with the node's own position and end_pos (if any) so that
   declaration keywords (tk_fun, tk_class, etc.) are included even though
   they are the node's token rather than a child.
@@ -105,11 +111,51 @@ primitive ASTSourceSpan
     n.visit(visitor)
 
     let min = visitor.min()
-    let max = visitor.max()
+    let max =
+      match \exhaustive\ n.source_contents()
+      | let src: String box => _cap_to_line_length(src, visitor.max())
+      | None => visitor.max()
+      end
     if min <= max then
       (min, max)
     else
       None
+    end
+
+  fun tag _cap_to_line_length(src: String box, pos: Position): Position =>
+    """
+    Cap pos.column() to the number of characters on that line in src.
+    Guards against synthesized-node end_pos() overshoots past line end.
+    """
+    if pos.line() == 0 then
+      return pos
+    end
+    try
+      let tgt = pos.line()
+      let line_len: USize =
+        if tgt <= 1 then
+          try
+            src.find("\n")?.usize()
+          else
+            src.size()
+          end
+        else
+          // nth=k finds the (k+1)th newline (0-indexed)
+          let prev_nl = src.find("\n" where nth = (tgt - 2))?.usize()
+          let ls = prev_nl + 1
+          try
+            src.find("\n" where nth = (tgt - 1))?.usize() - ls
+          else
+            src.size() - ls
+          end
+        end
+      if (line_len > 0) and (pos.column() > line_len) then
+        Position(tgt, line_len)
+      else
+        pos
+      end
+    else
+      pos
     end
 
 primitive ASTClampedRange

--- a/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
@@ -5,7 +5,7 @@ use "json"
 
 // Fixture layout (0-indexed lines, 0-indexed cols):
 // _t_call_a.pony  class _TCallA
-// f_a  name (1,6)..(1,9)  full (1,2)..(1,27)  [end inflated: None desugars]
+// f_a  name (1,6)..(1,9)  full (1,2)..(1,25)
 // _t_call_b.pony  class _TCallB
 // f_b  name (1,6)..(1,9)  full (1,2)..(2,10)  [end at '(' - ')' not tracked]
 // a.f_a()  call site f_a (2,6)..(2,9)
@@ -22,16 +22,13 @@ use "json"
 // act  be, name (4,5)..(4,8)  full (4,2)..(5,10)
 // a.f_a()  call site f_a (5,6)..(5,9)
 // _t_call_lambda.pony  class _TCallLambda
-// f_lambda  name (1,6)..(1,14)  full (1,2)..(9,10)
-// [end inflated: None desugars]
+// f_lambda  name (1,6)..(1,14)  full (1,2)..(9,8)
 // a.f_a()  first call site f_a (2,6)..(2,9)
 // a.f_a()  second call site f_a (8,6)..(8,9) — after the object literal
 // object literal g() has no calls  [nested method; excluded by _nested_depth]
 // _t_poly.pony  _TPolyA, _TPolyB, _TPolyUser (same-name method, two entities)
-// _TPolyA.poly_method  name (1,6)..(1,17)  full (1,2)..(1,35)
-// [end inflated: None desugars]
-// _TPolyB.poly_method  name (4,6)..(4,17)  full (4,2)..(4,35)
-// [end inflated: None desugars]
+// _TPolyA.poly_method  name (1,6)..(1,17)  full (1,2)..(1,33)
+// _TPolyB.poly_method  name (4,6)..(4,17)  full (4,2)..(4,33)
 // _TPolyUser.call_a  name (7,6)..(7,12)  full (7,2)..(8,18)
 // a.poly_method() call site poly_method (8,6)..(8,17)
 // _TPolyUser.call_b  name (10,6)..(10,12)  full (10,2)..(11,18)
@@ -40,12 +37,10 @@ use "json"
 // cross_call  name (3,6)..(3,16)  full (3,2)..(4,20)
 // c.callee_method() call site callee_method (4,6)..(4,19)
 // callee/t_callee.pony  TCallee (public; sub-package; no ".." import; no cycle)
-// callee_method  name (4,6)..(4,19)  full (4,2)..(4,37)
-// [end inflated: None desugars]
+// callee_method  name (4,6)..(4,19)  full (4,2)..(4,35)
 // _t_call_constructor.pony  classes _TConstructed, _TCallConstructorCaller,
 // _TConstructorWithBody
-// _TConstructed.create  new, name (1,6)..(1,12)  full (1,2)..(1,24)
-// [end inflated: None desugars]
+// _TConstructed.create  new, name (1,6)..(1,12)  full (1,2)..(1,22)
 // _TCallConstructorCaller.f_new_explicit  name (4,6)..(4,20)
 // _TConstructed.create()  create at (5,18)..(5,24)
 // _TConstructorWithBody.create  new, name (9,6)..(9,12)  full (9,2)..(10,10)
@@ -412,7 +407,7 @@ class \nodoc\ iso _PrepareCallHierarchyOnMethodTest is UnitTest
             workspace_dir,
             t_call_a,
             (1, 6, 1, 9),
-            (1, 2, 1, 27))) ])
+            (1, 2, 1, 25))) ])
 
 class \nodoc\ iso _PrepareCallHierarchyOnNonMethodTest is UnitTest
   """
@@ -517,7 +512,7 @@ class \nodoc\ iso _IncomingCallsForFaTest is UnitTest
                 workspace_dir,
                 t_call_lambda,
                 (1, 6, 1, 14),
-                (1, 2, 9, 10)),
+                (1, 2, 9, 8)),
               [(2, 6, 2, 9); (8, 6, 8, 9)])
             _CHierExpected(
               _CHierItem(
@@ -618,7 +613,7 @@ class \nodoc\ iso _OutgoingCallsForFbTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(2, 6, 2, 9)]) ]) ])
 
 class \nodoc\ iso _OutgoingCallsForFcTest is UnitTest
@@ -655,7 +650,7 @@ class \nodoc\ iso _OutgoingCallsForFcTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(2, 6, 2, 9)])
             _CHierExpected(
               _CHierItem(
@@ -703,7 +698,7 @@ class \nodoc\ iso _OutgoingCallsForFdTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(2, 6, 2, 9); (3, 6, 3, 9)]) ]) ])
 
 class val _PrepareKindChecker
@@ -834,7 +829,7 @@ class \nodoc\ iso _OutgoingCallsForActTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(5, 6, 5, 9)]) ]) ])
 
 class \nodoc\ iso _PrepareFromCallRefTest is UnitTest
@@ -867,7 +862,7 @@ class \nodoc\ iso _PrepareFromCallRefTest is UnitTest
             workspace_dir,
             t_call_a,
             (1, 6, 1, 9),
-            (1, 2, 1, 27))) ])
+            (1, 2, 1, 25))) ])
 
 class \nodoc\ iso _OutgoingCallsNoLambdaCallsTest is UnitTest
   """
@@ -911,7 +906,7 @@ class \nodoc\ iso _OutgoingCallsNoLambdaCallsTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(2, 6, 2, 9); (8, 6, 8, 9)]) ]) ])
 
 class \nodoc\ iso _IncomingCallsPolyATest is UnitTest
@@ -1038,7 +1033,7 @@ class \nodoc\ iso _OutgoingCallsCrossPackageTest is UnitTest
                 workspace_dir,
                 "call_hierarchy/callee/t_callee.pony",
                 (4, 6, 4, 19),
-                (4, 2, 4, 37)),
+                (4, 2, 4, 35)),
               [(4, 6, 4, 19)]) ]) ])
 
 class \nodoc\ iso _OutgoingCallsForFNewExplicitTest is UnitTest
@@ -1077,7 +1072,7 @@ class \nodoc\ iso _OutgoingCallsForFNewExplicitTest is UnitTest
                 workspace_dir,
                 t_ctor,
                 (1, 6, 1, 12),
-                (1, 2, 1, 24)),
+                (1, 2, 1, 22)),
               [(5, 18, 5, 24)]) ]) ])
 
 class \nodoc\ iso _OutgoingCallsFromConstructorTest is UnitTest
@@ -1117,5 +1112,5 @@ class \nodoc\ iso _OutgoingCallsFromConstructorTest is UnitTest
                 workspace_dir,
                 t_call_a,
                 (1, 6, 1, 9),
-                (1, 2, 1, 27)),
+                (1, 2, 1, 25)),
               [(10, 6, 10, 9)]) ]) ])

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -189,7 +189,7 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
       _server,
       "definition/_type_alias.pony",
       [ // `Map` type alias in `Map[String, U32]` → Map type alias declaration
-        _DefinitionChecker(17, 13, [("map.pony", (3, 0), (7, 7))])
+        _DefinitionChecker(17, 13, [("map.pony", (3, 0), (7, 5))])
         // `String` type arg in `Map[String, U32]` → String class declaration
         _DefinitionChecker(17, 17, [("string.pony", (8, 0), (1682, 25))])
         // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
@@ -201,7 +201,7 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
         _DefinitionChecker(
           19,
           20,
-          [("_type_alias.pony", (2, 0), (2, 18))])])
+          [("_type_alias.pony", (2, 0), (2, 17))])])
 
 class \nodoc\ iso _DefinitionLastEntityBarePrimTest is UnitTest
   """

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -80,7 +80,7 @@ class \nodoc\ iso _DocSymRangeTest is UnitTest
             "_DsContainment",
             None,
                       // range: (start_line, start_char, end_line, end_char)
-            (0, 0, 18, 10),
+            (0, 0, 18, 8),
             // selectionRange: (start_line, start_char, end_line, end_char)
             (0, 6, 0, 20))
         _DocSymRangeChecker(

--- a/tools/pony-lsp/test/_type_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_definition_integration_tests.pony
@@ -19,13 +19,13 @@ class \nodoc\ iso _TypeDefinitionLocalVarIntegrationTest is UnitTest
   """
   Cursor on `obj` in `demo()` (line 28, col 4) — explicitly annotated let.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,8)
     line 25:  class _TypeDefUser
     line 26:    fun demo() =>
     line 27:      let obj: _TypeDefTarget = ...
     line 28:      obj                            obj at (28,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,8).
   """
   let _server: _LspTestServer
 
@@ -42,17 +42,17 @@ class \nodoc\ iso _TypeDefinitionLocalVarIntegrationTest is UnitTest
       [ _TypeDefinitionChecker(
           28,
           4,
-          [("type_definition.pony", (21, 0), (23, 10))])])
+          [("type_definition.pony", (21, 0), (23, 8))])])
 
 class \nodoc\ iso _TypeDefinitionParamIntegrationTest is UnitTest
   """
   Cursor on `target` in `with_param()` (line 31, col 4) — typed parameter.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,8)
     line 30:    fun with_param(target: _TypeDefTarget) =>
     line 31:      target                             target at (31,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,8).
   """
   let _server: _LspTestServer
 
@@ -69,7 +69,7 @@ class \nodoc\ iso _TypeDefinitionParamIntegrationTest is UnitTest
       [ _TypeDefinitionChecker(
           31,
           4,
-          [("type_definition.pony", (21, 0), (23, 10))])])
+          [("type_definition.pony", (21, 0), (23, 8))])])
 
 class \nodoc\ iso _TypeDefinitionNoTypeIntegrationTest is UnitTest
   """
@@ -95,12 +95,12 @@ class \nodoc\ iso _TypeDefinitionInferredIntegrationTest is UnitTest
   Cursor on `x` in `inferred_demo()` (line 35, col 4) — type inferred from
   `_TypeDefTarget.create()`, no explicit annotation.
   type_definition.pony layout (0-indexed lines/cols):
-    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,10)
+    line 21:  class _TypeDefTarget          target declaration (21,0)-(23,8)
     line 33:    fun inferred_demo() =>
     line 34:      let x = _TypeDefTarget.create()
     line 35:      x                              x at (35,4)
 
-  Expects type definition at class _TypeDefTarget (21,0)-(23,10).
+  Expects type definition at class _TypeDefTarget (21,0)-(23,8).
   """
   let _server: _LspTestServer
 
@@ -117,7 +117,7 @@ class \nodoc\ iso _TypeDefinitionInferredIntegrationTest is UnitTest
       [ _TypeDefinitionChecker(
           35,
           4,
-          [("type_definition.pony", (21, 0), (23, 10))])])
+          [("type_definition.pony", (21, 0), (23, 8))])])
 
 class val _TypeDefinitionChecker
   let _line: I64

--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -6,9 +6,8 @@ use "json"
 // Fixture layout — _t_hier_kind_iface.pony (0-indexed lines, 0-indexed cols):
 // line  0: interface _THierKindIface   name (0,10)..(0,25)  full (0,0)..(1,15)
 // line  3: struct _THierKindStruct     name (3,7)..(3,23)   full (3,0)..(4,17)
-// line  6: actor _THierKindActor    name (6,6)..(6,21)   full (6,0)..(7,25)*
-// line  9: primitive _THierKindPrim name (9,10)..(9,24)  full (9,0)..(10,25)*
-// * col 25 exceeds 23-char source line; end_pos from `=> expr` AST body node
+// line  6: actor _THierKindActor    name (6,6)..(6,21)   full (6,0)..(7,23)
+// line  9: primitive _THierKindPrim name (9,10)..(9,24)  full (9,0)..(10,23)
 //
 // Fixture layout — _t_hier_ref_user.pony:
 // line 0: class _THierRefUser
@@ -28,9 +27,10 @@ use "json"
 // line 0: trait _THierD  name (0,6)..(0,13)  full (0,0)..(6,17)
 //
 // Fixture layout — _t_hier_e.pony:
-// line 0: class _THierE  name (0,6)..(0,13)  full (0,0)..(4,27)
+// line 0: class _THierE  name (0,6)..(0,13)  full (0,0)..(4,25)
 // (_THierE is the last entity in its file; SiblingBound returns None so
-// ASTSourceSpan includes synthesized constructor tokens, inflating by 2.)
+// ASTSourceSpan walks synthesized constructor tokens; _cap_to_line_length
+// then clamps the end column to the actual line length.)
 //
 // Fixture layout — _t_hier_dup_base.pony:
 // line 0: trait _THierDupBase   name (0,6)..(0,19)  full (0,0)..(1,19)
@@ -291,7 +291,7 @@ class \nodoc\ iso _TypeHierarchySubtypesCrossFileTest is UnitTest
               workspace_dir,
               t_hier_e,
               (0, 6, 0, 13),
-              (0, 0, 4, 27)) ]) ])
+              (0, 0, 4, 25)) ]) ])
 
 class \nodoc\ iso _TypeHierarchySubtypesIsectTest is UnitTest
   """
@@ -660,14 +660,14 @@ class \nodoc\ iso _TypeHierarchyKindSubtypesTest is UnitTest
               workspace_dir,
               t_hier_kind_iface,
               (6, 6, 6, 21),
-              (6, 0, 7, 25))
+              (6, 0, 7, 23))
             _THierExpected(
               "_THierKindPrim",
               5,
               workspace_dir,
               t_hier_kind_iface,
               (9, 10, 9, 24),
-              (9, 0, 10, 25)) ]) ])
+              (9, 0, 10, 23)) ]) ])
 
 class \nodoc\ iso _TypeHierarchyRefCursorTest is UnitTest
   """

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -218,7 +218,7 @@ class \nodoc\ iso _WsSymRangeTest is UnitTest
       _server,
       "workspace_symbol/_ws_sym_host.pony",
       [ _WsSymRangeChecker(
-          "_WsSymHost", "_WsSymHost", None, (5, 0, 18, 10))
+          "_WsSymHost", "_WsSymHost", None, (5, 0, 18, 8))
         _WsSymRangeChecker(
           "_count", "_count", "_WsSymHost", (6, 2, 6, 17))
         _WsSymRangeChecker(
@@ -230,7 +230,7 @@ class \nodoc\ iso _WsSymRangeTest is UnitTest
         _WsSymRangeChecker(
           "increment", "increment", "_WsSymHost", (13, 2, 15, 10))
         _WsSymRangeChecker(
-          "ping", "ping", "_WsSymHost", (17, 2, 18, 10))
+          "ping", "ping", "_WsSymHost", (17, 2, 18, 8))
         _WsSymRangeChecker(
           "_WsSymInner", "_WsSymInner", None, (20, 0, 20, 17))])
 


### PR DESCRIPTION
## Context

LSP responses that include a declaration range (go-to-definition, document symbols, workspace symbols, type hierarchy, call hierarchy, selection ranges) return `end.character` values past the actual end of the source line. Editors that rely on this range for highlighting or cursor placement overshoot into whitespace or the next token.

## Changes

- `ASTSourceSpan._cap_to_line_length`: reads the source text to cap the final end column to the actual character count of that line, preventing synthesized constructor nodes and desugared value expressions (`None => None`) from inflating the range end past the line's last character
- Adds a `pos.line() == 0` early-return guard and a `line_len > 0` guard before capping