### PR TITLE
Fix LSP hover showing on declaration keywords

### DIFF
--- a/.release-notes/fix-lsp-hover-on-declaration-keywords.md
+++ b/.release-notes/fix-lsp-hover-on-declaration-keywords.md
@@ -1,0 +1,3 @@
+## Fix LSP hover showing on declaration keywords
+
+Hovering over a declaration keyword (`class`, `actor`, `trait`, `interface`, `primitive`, `type`, `struct`, `fun`, `be`, `new`, `let`, `var`, or `embed`) incorrectly showed a hover popup for the entity, method, or field being declared. Hover information now only appears when hovering over the declaration name itself.

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -16,6 +16,7 @@ primitive _HoverIntegrationTests is TestList
     test(_HoverIntegrationInterfaceTest.create(server))
     test(_HoverIntegrationPrimitiveTest.create(server))
     test(_HoverIntegrationTraitTest.create(server))
+    test(_HoverIntegrationStructTest.create(server))
     test(_HoverIntegrationTypeInferenceTest.create(server))
     test(_HoverIntegrationReceiverCapabilityTest.create(server))
     test(_HoverIntegrationComplexTypesTest.create(server))
@@ -81,6 +82,13 @@ class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
           6,
           8,
           ["embed embedded_field: Array[String val] ref"])
+        // no hover on field declaration keywords
+        _HoverChecker(4, 2, [])
+        _HoverChecker(4, 4, [])
+        _HoverChecker(5, 2, [])
+        _HoverChecker(5, 4, [])
+        _HoverChecker(6, 2, [])
+        _HoverChecker(6, 6, [])
         // constructor declaration
         _HoverChecker(8, 6, ["new ref create(name: String val)"])
         // field usages
@@ -88,6 +96,12 @@ class \nodoc\ iso _HoverIntegrationClassTest is UnitTest
         _HoverChecker(10, 4, ["var mutable_field: U32 val"])
         _HoverChecker(16, 4, ["let field_name: String val"])
         _HoverChecker(28, 4, ["var mutable_field: U32 val"])
+        // no hover on 'class' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 2, [])
+        // no hover on 'new' keyword
+        _HoverChecker(8, 2, [])
+        _HoverChecker(8, 4, [])
         // no hover on docstring or blank line
         _HoverChecker(1, 2, [])
         _HoverChecker(2, 4, [])
@@ -111,7 +125,16 @@ class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
           6,
           ["actor _Actor"; "A simple actor for exercising LSP hover."])
         _HoverChecker(6, 6, ["new tag create(name': String val)"])
-        _HoverChecker(9, 5, ["be tag do_something(value: U64 val)"])])
+        _HoverChecker(9, 5, ["be tag do_something(value: U64 val)"])
+        // no hover on 'actor' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 2, [])
+        // no hover on 'new' keyword
+        _HoverChecker(6, 2, [])
+        _HoverChecker(6, 4, [])
+        // no hover on 'be' keyword
+        _HoverChecker(9, 2, [])
+        _HoverChecker(9, 3, [])])
 
 class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
   let _server: _LspTestServer
@@ -129,7 +152,10 @@ class \nodoc\ iso _HoverIntegrationAliasTest is UnitTest
       [ _HoverChecker(
           0,
           5,
-          ["type _Alias"; "A simple alias for exercising LSP hover."])])
+          ["type _Alias"; "A simple alias for exercising LSP hover."])
+        // no hover on 'type' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 2, [])])
 
 class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
   let _server: _LspTestServer
@@ -148,7 +174,10 @@ class \nodoc\ iso _HoverIntegrationInterfaceTest is UnitTest
           0,
           10,
           [ "interface _Interface"
-            "A simple interface for exercising LSP hover."])])
+            "A simple interface for exercising LSP hover."])
+        // no hover on 'interface' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 4, [])])
 
 class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
   let _server: _LspTestServer
@@ -167,7 +196,10 @@ class \nodoc\ iso _HoverIntegrationPrimitiveTest is UnitTest
           0,
           10,
           [ "primitive _Primitive"
-            "A simple primitive for exercising LSP hover."])])
+            "A simple primitive for exercising LSP hover."])
+        // no hover on 'primitive' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 4, [])])
 
 class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
   let _server: _LspTestServer
@@ -185,7 +217,10 @@ class \nodoc\ iso _HoverIntegrationTraitTest is UnitTest
       [ _HoverChecker(
           0,
           6,
-          ["trait _Trait"; "A simple trait for exercising LSP hover."])])
+          ["trait _Trait"; "A simple trait for exercising LSP hover."])
+        // no hover on 'trait' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 2, [])])
 
 class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
   let _server: _LspTestServer
@@ -224,6 +259,11 @@ class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
             "Method with multiple parameters for testing."])
         _HoverChecker(11, 8, ["let result1: String val"])
         _HoverChecker(12, 8, ["let result2: String val"])
+        // no hover on local variable declaration keywords
+        _HoverChecker(11, 4, [])
+        _HoverChecker(11, 6, [])
+        _HoverChecker(12, 4, [])
+        _HoverChecker(12, 6, [])
         // parameter declarations
         _HoverChecker(15, 20, ["input: String val"])
         _HoverChecker(21, 34, ["x: U32 val"])
@@ -238,8 +278,35 @@ class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
           10,
           [ "fun ref mutable_method(value: U32 val)"
             "A method with a ref receiver capability."])
+        // no hover on 'fun' keyword
+        _HoverChecker(15, 2, [])
+        _HoverChecker(15, 4, [])
+        _HoverChecker(27, 2, [])
+        _HoverChecker(27, 3, [])
+        _HoverChecker(27, 4, [])
         // this reference
         _HoverChecker(11, 18, [])])
+
+class \nodoc\ iso _HoverIntegrationStructTest is UnitTest
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/struct"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_struct.pony",
+      [ _HoverChecker(
+          0,
+          7,
+          ["struct _Struct"; "A simple struct for exercising LSP hover."])
+        // no hover on 'struct' keyword
+        _HoverChecker(0, 0, [])
+        _HoverChecker(0, 5, [])])
 
 class \nodoc\ iso _HoverIntegrationTypeInferenceTest is UnitTest
   let _server: _LspTestServer

--- a/tools/pony-lsp/test/workspace/hover/_struct.pony
+++ b/tools/pony-lsp/test/workspace/hover/_struct.pony
@@ -1,0 +1,10 @@
+struct _Struct
+  """
+  A simple struct for exercising LSP hover.
+  """
+  var x: I32
+  var y: I32
+
+  new create(x': I32, y': I32) =>
+    x = x'
+    y = y'

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -117,15 +117,6 @@ primitive HoverFormatter
     None if no hover info available.
     """
     match ast.id()
-    // Entity types
-    | TokenIds.tk_class() => _format_entity(ast, "class", channel)
-    | TokenIds.tk_actor() => _format_entity(ast, "actor", channel)
-    | TokenIds.tk_trait() => _format_entity(ast, "trait", channel)
-    | TokenIds.tk_interface() => _format_entity(ast, "interface", channel)
-    | TokenIds.tk_primitive() => _format_entity(ast, "primitive", channel)
-    | TokenIds.tk_type() => _format_entity(ast, "type", channel)
-    | TokenIds.tk_struct() => _format_entity(ast, "struct", channel)
-
     // Method types
     | TokenIds.tk_fun() => _format_method(ast, "fun", channel)
     | TokenIds.tk_be() => _format_method(ast, "be", channel)

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -452,6 +452,34 @@ actor WorkspaceManager
     | (let hover_node: AST box, _) =>
       this._channel.log("Found AST node: " + hover_node.debug())
 
+      // Suppress hover when the cursor lands directly on a declaration keyword
+      // (fun/be/new, let/var/embed for fields, let/var for locals).
+      // _refine_node promotes the name tk_id to its parent keyword node, so
+      // compare the cursor column against the keyword span to distinguish
+      // "on keyword" (suppress) from "on name".
+      let keyword_len: USize =
+        match hover_node.id()
+        | TokenIds.tk_fun() | TokenIds.tk_new()
+        | TokenIds.tk_flet() | TokenIds.tk_let()
+        | TokenIds.tk_fvar() | TokenIds.tk_var() => 3
+        | TokenIds.tk_be() => 2
+        | TokenIds.tk_embed() => 5
+        else 0
+        end
+      if keyword_len > 0 then
+        let node_line = hover_node.position().line()
+        let node_col = hover_node.position().column()
+        let cursor_line = USize.from[I64](line + 1)
+        let cursor_col = USize.from[I64](column + 1)
+        if (cursor_line == node_line) and
+          (cursor_col >= node_col) and
+          (cursor_col <= ((node_col + keyword_len) - 1))
+        then
+          this._channel.send(ResponseMessage.create(request.id, None))
+          return
+        end
+      end
+
       // Extract hover information and build response
       match \exhaustive\ HoverFormatter.create_hover(hover_node, this._channel)
       | let hover_text: String =>


### PR DESCRIPTION
## Context

Hovering over a declaration keyword (`class`, `actor`, `trait`, `interface`, `primitive`, `type`, `struct`, `fun`, `be`, `new`, `let`, `var`, or `embed`) incorrectly shows a hover popup for the entity, method, or field being declared. Hover information should only appear when hovering over the declaration name itself.

## Changes

- **Entity keywords** (`class`, `actor`, `trait`, `interface`, `primitive`, `type`, `struct`): Removes the keyword dispatch arms from `HoverFormatter.create_hover`. These arms are only reachable when the cursor is directly on the keyword token — entity name hover continues to work via the existing `tk_id` → `_format_id` → parent lookup path.
- **Method, field, and local-variable keywords** (`fun`, `be`, `new`, `let`, `var`, `embed`): Adds a cursor-column range check in `WorkspaceManager.hover` before calling `create_hover`. This is necessary because `_refine_node` promotes name `tk_id` nodes to their parent keyword nodes for all of these types, making keyword and name positions indistinguishable at the `create_hover` level; the column comparison distinguishes them.
- Adds `_struct.pony` fixture and `_HoverIntegrationStructTest` (struct had no keyword-hover coverage).
- Extends keyword-suppression assertions across all entity, method, field, and local-variable declaration tests.

## Considerations

The two fix mechanisms are asymmetric because `_refine_node` treats entity types differently from method/field/local-var types. Entity keyword suppression relies on removed dispatch arms; all other keyword suppression relies on a column-range check. Both are needed because of how `_refine_node` works.