### PR TITLE
Pin mingw-w64 LLDB to 22.1.4-1 in Windows CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -279,8 +279,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -114,8 +114,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v5.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,8 +291,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -43,8 +43,25 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -43,8 +43,25 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -20,8 +20,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
+        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        #
+        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
+        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
+        # 0xC0000005 when wrapping Pony test executables on windows-2025.
+        # The crash reproduces across multiple unrelated branches; see
+        # ponylang/ponyc Discussion #5007.
+        #
+        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
+        # version-match. Installed via `pacman -U` from explicit URLs so
+        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
         run: |
-          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }; msys ' '; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -Syuu'; msys 'pacman --noconfirm -S --needed base-devel mingw-w64-x86_64-lldb'; msys 'pacman --noconfirm -Scc'
+          function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
+          msys ' '
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -Syuu'
+          msys 'pacman --noconfirm -S --needed base-devel'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache
         id: restore-libs


### PR DESCRIPTION
mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with 0xC0000005 when wrapping Pony test executables on the windows-2025 runner image. The crash reproduces across multiple unrelated branches that use `Uselldb yes` (or the unconditional lldb wrappers in `make.ps1`'s `stress-test-*` targets), so it isn't branch-specific codegen tripping lldb — it's the lldb build itself.

Pinning gets PR and stress-test CI back to a known-good lldb until upstream is debugged. The three packages (`lldb`, `clang-libs`, `llvm-libs`) share one PKGBUILD and must version-match.

Pin applied uniformly to every x86_64-windows install step that pulls `mingw-w64-x86_64-lldb`:

- `pr-ponyc.yml` (uses lldb via `Uselldb yes`)
- `stress-test-ubench-windows.yml` (uses lldb unconditionally via `make.ps1` `stress-test-*` targets)
- `stress-test-tcp-open-close-windows.yml` (same)
- `release.yml` x86_64 job (installs lldb but doesn't currently invoke it)
- `test-windows-nightly.yml` (same)
- `nightlies.yml` x86_64 job (same)

The arm64-windows jobs in `release.yml` and `nightlies.yml` install only cloudsmith-cli (no msys2 lldb) so are unchanged.

Caveats: `repo.msys2.org` is rolling and has no SLA on old `.pkg.tar.zst` files. If 22.1.4-1 gets pruned, this pin breaks. Durable answer is to mirror the three files into a ponyc release asset, but that's deferred — immediate goal is unblocking CI.

Design: #5007