### PR TITLE
Drop fun tag from primitive methods in pony-lsp

### DIFF
--- a/tools/pony-lsp/ast_source_span.pony
+++ b/tools/pony-lsp/ast_source_span.pony
@@ -34,7 +34,7 @@ primitive ASTSourceSpan
   well-formed AST nodes).
   """
 
-  fun tag apply(
+  fun apply(
     n: AST box,
     doc_path: String val,
     max_pos: (Position | None) = None)
@@ -122,7 +122,7 @@ primitive ASTSourceSpan
       None
     end
 
-  fun tag _cap_to_line_length(src: String box, pos: Position): Position =>
+  fun _cap_to_line_length(src: String box, pos: Position): Position =>
     """
     Cap pos.column() to the number of characters on that line in src.
     Guards against synthesized-node end_pos() overshoots past line end.
@@ -169,7 +169,7 @@ primitive ASTClampedRange
 
   Returns `None` when `ASTSourceSpan` returns an inverted span.
   """
-  fun tag apply(
+  fun apply(
     node: AST box,
     doc_path: String val,
     max_pos: (Position | None) = None)

--- a/tools/pony-lsp/diagnostics.pony
+++ b/tools/pony-lsp/diagnostics.pony
@@ -118,10 +118,10 @@ primitive DiagnosticSeverities
   """
   LSP diagnostic severity constants.
   """
-  fun tag err(): I64 => 1
-  fun tag warning(): I64 => 2
-  fun tag information(): I64 => 3
-  fun tag hint(): I64 => 4
+  fun err(): I64 => 1
+  fun warning(): I64 => 2
+  fun information(): I64 => 3
+  fun hint(): I64 => 4
 
 class val DiagnosticRelatedInformation
   """

--- a/tools/pony-lsp/message.pony
+++ b/tools/pony-lsp/message.pony
@@ -28,35 +28,35 @@ primitive Err
   """
   Error message type (severity 1).
   """
-  fun tag apply(): I64 => 1
+  fun apply(): I64 => 1
   fun string(): String => "ERROR"
 
 primitive Warning
   """
   Warning message type (severity 2).
   """
-  fun tag apply(): I64 => 2
+  fun apply(): I64 => 2
   fun string(): String => "WARNING"
 
 primitive Info
   """
   Info message type (severity 3).
   """
-  fun tag apply(): I64 => 3
+  fun apply(): I64 => 3
   fun string(): String => "INFO"
 
 primitive Log
   """
   Log message type (severity 4).
   """
-  fun tag apply(): I64 => 4
+  fun apply(): I64 => 4
   fun string(): String => "LOG"
 
 primitive Debug
   """
   Debug message type (severity 5).
   """
-  fun tag apply(): I64 => 5
+  fun apply(): I64 => 5
   fun string(): String => "DEBUG"
 
 type MessageType is (Err | Warning | Info | Log | Debug)

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -7,38 +7,38 @@ primitive SymbolKinds
   """
   LSP document symbol kind constants.
   """
-  fun tag file(): I64 => 1
-  fun tag module(): I64 => 2
-  fun tag namespace(): I64 => 3
-  fun tag package(): I64 => 4
-  fun tag sk_class(): I64 => 5
-  fun tag method(): I64 => 6
-  fun tag property(): I64 => 7
-  fun tag field(): I64 => 8
-  fun tag constructor(): I64 => 9
-  fun tag enum(): I64 => 10
-  fun tag sk_interface(): I64 => 11
-  fun tag function(): I64 => 12
-  fun tag variable(): I64 => 13
-  fun tag constant(): I64 => 14
-  fun tag string(): I64 => 15
-  fun tag number(): I64 => 16
-  fun tag boolean(): I64 => 17
-  fun tag array(): I64 => 8
-  fun tag sk_object(): I64 => 19
-  fun tag key(): I64 => 20
-  fun tag null(): I64 => 21
-  fun tag enum_member(): I64 => 22
-  fun tag sk_struct(): I64 => 23
-  fun tag event(): I64 => 24
-  fun tag operator(): I64 => 25
-  fun tag type_parameter(): I64 => 26
+  fun file(): I64 => 1
+  fun module(): I64 => 2
+  fun namespace(): I64 => 3
+  fun package(): I64 => 4
+  fun sk_class(): I64 => 5
+  fun method(): I64 => 6
+  fun property(): I64 => 7
+  fun field(): I64 => 8
+  fun constructor(): I64 => 9
+  fun enum(): I64 => 10
+  fun sk_interface(): I64 => 11
+  fun function(): I64 => 12
+  fun variable(): I64 => 13
+  fun constant(): I64 => 14
+  fun string(): I64 => 15
+  fun number(): I64 => 16
+  fun boolean(): I64 => 17
+  fun array(): I64 => 8
+  fun sk_object(): I64 => 19
+  fun key(): I64 => 20
+  fun null(): I64 => 21
+  fun enum_member(): I64 => 22
+  fun sk_struct(): I64 => 23
+  fun event(): I64 => 24
+  fun operator(): I64 => 25
+  fun type_parameter(): I64 => 26
 
 primitive SymbolTags
   """
   LSP document symbol tag constants.
   """
-  fun tag deprecated(): I64 => 1
+  fun deprecated(): I64 => 1
 
 class DocumentSymbol
   """
@@ -123,7 +123,7 @@ primitive DocumentSymbols
   Extracts document symbols from a compiled module.
   """
 
-  fun tag from_module(
+  fun from_module(
     module: Module,
     channel: Channel): Array[DocumentSymbol] ref
   =>
@@ -190,7 +190,7 @@ primitive DocumentSymbols
     end
     symbols
 
-  fun tag find_members(
+  fun find_members(
     entity: AST,
     symbol: DocumentSymbol ref,
     channel: Channel,
@@ -325,7 +325,7 @@ primitive DocumentSymbols
       end
     end
 
-  fun tag _symbol_ranges(
+  fun _symbol_ranges(
     node: AST box,
     id: AST box,
     name: String,

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -110,7 +110,7 @@ primitive HoverFormatter
     _wrap_code_block(consume declaration)
 
   // ======= AST Extraction and Dispatch =======
-  fun tag create_hover(ast: AST box): (String | None) =>
+  fun create_hover(ast: AST box): (String | None) =>
     """
     Main entry point. Returns markdown string or
     None if no hover info available.
@@ -167,7 +167,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_entity(
+  fun _format_entity(
     ast: AST box,
     keyword: String): (String | None)
   =>
@@ -179,7 +179,7 @@ primitive HoverFormatter
     | None => None
     end
 
-  fun tag extract_entity_info(
+  fun extract_entity_info(
     ast: AST box,
     keyword: String): (EntityInfo | None)
   =>
@@ -220,7 +220,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_method(
+  fun _format_method(
     ast: AST box,
     keyword: String): (String | None)
   =>
@@ -232,7 +232,7 @@ primitive HoverFormatter
     | None => None
     end
 
-  fun tag extract_method_info(
+  fun extract_method_info(
     ast: AST box,
     keyword: String): (MethodInfo | None)
   =>
@@ -316,7 +316,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_field(
+  fun _format_field(
     ast: AST box,
     keyword: String): (String | None)
   =>
@@ -328,7 +328,7 @@ primitive HoverFormatter
     | None => None
     end
 
-  fun tag _extract_field_info(
+  fun _extract_field_info(
     ast: AST box,
     keyword: String): (FieldInfo | None)
   =>
@@ -357,7 +357,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_local_var(
+  fun _format_local_var(
     ast: AST box,
     keyword: String): (String | None)
   =>
@@ -369,7 +369,7 @@ primitive HoverFormatter
     | None => None
     end
 
-  fun tag _extract_local_var_info(
+  fun _extract_local_var_info(
     ast: AST box,
     keyword: String): (FieldInfo | None)
   =>
@@ -402,7 +402,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_param(ast: AST box): (String | None) =>
+  fun _format_param(ast: AST box): (String | None) =>
     """
     Format parameter declarations.
     """
@@ -411,7 +411,7 @@ primitive HoverFormatter
     | None => None
     end
 
-  fun tag _extract_param_info(ast: AST box): (FieldInfo | None) =>
+  fun _extract_param_info(ast: AST box): (FieldInfo | None) =>
     """
     Extract parameter information from AST node.
     """
@@ -441,7 +441,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_id(ast: AST box): (String | None) =>
+  fun _format_id(ast: AST box): (String | None) =>
     """
     Format identifier nodes - look at parent to
     get full context, or follow to definition.
@@ -489,13 +489,13 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_reference(ast: AST box): (String | None) =>
+  fun _format_reference(ast: AST box): (String | None) =>
     """
     Format type reference nodes by following to their definition.
     """
     _format_from_definition(ast)
 
-  fun tag _format_from_definition(ast: AST box): (String | None) =>
+  fun _format_from_definition(ast: AST box): (String | None) =>
     """
     Follow an identifier or reference to its definition and format that.
     """
@@ -513,7 +513,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _format_from_found_definition(definition: AST box): (String | None) =>
+  fun _format_from_found_definition(definition: AST box): (String | None) =>
     """
     Format a definition AST node based on its type.
     """
@@ -541,7 +541,7 @@ primitive HoverFormatter
       None
     end
 
-  fun tag _extract_params(params: AST box): String =>
+  fun _extract_params(params: AST box): String =>
     """
     Extract parameter list from params node.
     """
@@ -568,7 +568,7 @@ primitive HoverFormatter
       "()"
     end
 
-  fun tag _wrap_code_block(content: String): String =>
+  fun _wrap_code_block(content: String): String =>
     """
     Wrap content in a Pony code block for markdown formatting.
     """


### PR DESCRIPTION
## Context

`fun tag` on a primitive pointlessly weakens the receiver to `tag`, which can't read fields. The default `box` is correct — primitives are `val` and `val <: box`, so all call sites work without the annotation. The annotation misleads readers into thinking opaque identity access is intentional.

## Changes

Remove `fun tag` from all primitive methods across:

- `workspace/hover.pony` — `HoverFormatter`
- `diagnostics.pony` — `DiagnosticSeverities`
- `message.pony` — `Err`, `Warning`, `Info`, `Log`, `Debug`
- `ast_source_span.pony` — `ASTSourceSpan`, `ASTClampedRange`
- `symbols.pony` — `SymbolKinds`, `SymbolTags`, `DocumentSymbols`

## Considerations

No behaviour change. All 288 pony-lsp tests pass, lint is clean.