### PR TITLE
Extract _format_declaration to eliminate duplicated dispatch in pony-lsp hover

### DIFF
--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -294,7 +294,13 @@ class \nodoc\ iso _HoverIntegrationFunctionTest is UnitTest
         _HoverChecker(27, 6, [])
         _HoverChecker(27, 8, [])
         // this reference
-        _HoverChecker(11, 18, [])])
+        _HoverChecker(11, 18, [])
+        // var local declaration and usage
+        _HoverChecker(37, 8, ["var counter: U32 val"])
+        _HoverChecker(38, 17, ["var counter: U32 val"])
+        // no hover on var declaration keyword
+        _HoverChecker(37, 4, [])
+        _HoverChecker(37, 6, [])])
 
 class \nodoc\ iso _HoverIntegrationStructTest is UnitTest
   let _server: _LspTestServer

--- a/tools/pony-lsp/test/workspace/hover/_function.pony
+++ b/tools/pony-lsp/test/workspace/hover/_function.pony
@@ -30,3 +30,11 @@ class _Function
     A method with a ref receiver capability.
     """
     None
+
+  fun with_mutable_local(): U32 =>
+    """
+    A method with a mutable local variable.
+    """
+    var counter: U32 = 0
+    let result = counter + 1
+    result

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -441,52 +441,55 @@ primitive HoverFormatter
       None
     end
 
+  fun _format_declaration(ast: AST box): (String | None) =>
+    """
+    Format a declaration AST node based on its type. Returns None for
+    non-declaration node types.
+    """
+    match ast.id()
+    | TokenIds.tk_class() => _format_entity(ast, "class")
+    | TokenIds.tk_actor() => _format_entity(ast, "actor")
+    | TokenIds.tk_trait() => _format_entity(ast, "trait")
+    | TokenIds.tk_interface() => _format_entity(ast, "interface")
+    | TokenIds.tk_primitive() => _format_entity(ast, "primitive")
+    | TokenIds.tk_type() => _format_entity(ast, "type")
+    | TokenIds.tk_struct() => _format_entity(ast, "struct")
+    | TokenIds.tk_fun() => _format_method(ast, "fun")
+    | TokenIds.tk_be() => _format_method(ast, "be")
+    | TokenIds.tk_new() => _format_method(ast, "new")
+    | TokenIds.tk_flet() => _format_field(ast, "let")
+    | TokenIds.tk_fvar() => _format_field(ast, "var")
+    | TokenIds.tk_embed() => _format_field(ast, "embed")
+    | TokenIds.tk_let() => _format_local_var(ast, "let")
+    | TokenIds.tk_var() => _format_local_var(ast, "var")
+    | TokenIds.tk_param() => _format_param(ast)
+    else
+      None
+    end
+
   fun _format_id(ast: AST box): (String | None) =>
     """
     Format identifier nodes - look at parent to
     get full context, or follow to definition.
     """
-    try
-      let name = ast.token_value() as String
-
-      // First, try to get the parent node to determine if this is a declaration
-      match ast.parent()
-      | let parent: AST =>
-        // Check what kind of declaration this ID belongs to
-        match parent.id()
-        | TokenIds.tk_class() => _format_entity(parent, "class")
-        | TokenIds.tk_actor() => _format_entity(parent, "actor")
-        | TokenIds.tk_trait() => _format_entity(parent, "trait")
-        | TokenIds.tk_interface() =>
-          _format_entity(parent, "interface")
-        | TokenIds.tk_primitive() =>
-          _format_entity(parent, "primitive")
-        | TokenIds.tk_type() => _format_entity(parent, "type")
-        | TokenIds.tk_struct() => _format_entity(parent, "struct")
-        | TokenIds.tk_fun() => _format_method(parent, "fun")
-        | TokenIds.tk_be() => _format_method(parent, "be")
-        | TokenIds.tk_new() => _format_method(parent, "new")
-        | TokenIds.tk_flet() => _format_field(parent, "let")
-        | TokenIds.tk_fvar() => _format_field(parent, "var")
-        | TokenIds.tk_embed() => _format_field(parent, "embed")
-        | TokenIds.tk_let() => _format_local_var(parent, "let")
-        | TokenIds.tk_var() => _format_local_var(parent, "var")
-        | TokenIds.tk_letref() => _format_reference(parent)
-        | TokenIds.tk_varref() => _format_reference(parent)
-        | TokenIds.tk_fletref() => _format_reference(parent)
-        | TokenIds.tk_fvarref() => _format_reference(parent)
-        | TokenIds.tk_embedref() => _format_reference(parent)
-        | TokenIds.tk_paramref() => _format_reference(parent)
-        else
-          // Parent is not a declaration - try to follow to definition
-          _format_from_definition(ast)
-        end
+    match ast.parent()
+    | let parent: AST =>
+      match parent.id()
+      | TokenIds.tk_letref()
+      | TokenIds.tk_varref()
+      | TokenIds.tk_fletref()
+      | TokenIds.tk_fvarref()
+      | TokenIds.tk_embedref()
+      | TokenIds.tk_paramref() =>
+        _format_reference(parent)
       else
-        // No parent - follow to definition
-        _format_from_definition(ast)
+        match \exhaustive\ _format_declaration(parent)
+        | let s: String => s
+        | None => _format_from_definition(ast)
+        end
       end
     else
-      None
+      _format_from_definition(ast)
     end
 
   fun _format_reference(ast: AST box): (String | None) =>
@@ -500,44 +503,13 @@ primitive HoverFormatter
     Follow an identifier or reference to its definition and format that.
     """
     try
-      // Use definitions() to find where this is defined
       let defs = ast.definitions()
       if defs.size() > 0 then
-        // Get the first definition
-        let definition = defs(0)?
-        _format_from_found_definition(definition)
+        _format_declaration(defs(0)?)
       else
         None
       end
     else
-      None
-    end
-
-  fun _format_from_found_definition(definition: AST box): (String | None) =>
-    """
-    Format a definition AST node based on its type.
-    """
-    match definition.id()
-    | TokenIds.tk_class() => _format_entity(definition, "class")
-    | TokenIds.tk_actor() => _format_entity(definition, "actor")
-    | TokenIds.tk_trait() => _format_entity(definition, "trait")
-    | TokenIds.tk_interface() =>
-      _format_entity(definition, "interface")
-    | TokenIds.tk_primitive() =>
-      _format_entity(definition, "primitive")
-    | TokenIds.tk_type() => _format_entity(definition, "type")
-    | TokenIds.tk_struct() => _format_entity(definition, "struct")
-    | TokenIds.tk_fun() => _format_method(definition, "fun")
-    | TokenIds.tk_be() => _format_method(definition, "be")
-    | TokenIds.tk_new() => _format_method(definition, "new")
-    | TokenIds.tk_flet() => _format_field(definition, "let")
-    | TokenIds.tk_fvar() => _format_field(definition, "var")
-    | TokenIds.tk_embed() => _format_field(definition, "embed")
-    | TokenIds.tk_let() => _format_local_var(definition, "let")
-    | TokenIds.tk_var() => _format_local_var(definition, "var")
-    | TokenIds.tk_param() => _format_param(definition)
-    else
-      // Unknown definition type
       None
     end
 


### PR DESCRIPTION
## Context

`_format_id` and `_format_from_found_definition` both contain identical match arms mapping declaration token IDs to format helpers (`_format_entity`, `_format_method`, `_format_field`, `_format_local_var`, `_format_param`). Adding support for a new declaration node type requires updating both.

## Changes

- Extract `_format_declaration` containing the shared dispatch
- Simplify `_format_id` to handle only the ref-type arms explicitly, delegating everything else to `_format_declaration(parent)` and falling back to `_format_from_definition` if the parent is not a declaration
- Remove the dead `name` binding and its `try` wrapper from `_format_id`
- Remove `_format_from_found_definition` — it became a one-liner with no independent purpose; `_format_from_definition` now calls `_format_declaration` directly

## Considerations

No behaviour change. All 288 pony-lsp tests pass, lint is clean.