### PR TITLE
Make `extract_entity_info` and `extract_method_info` private in pony-lsp

### DIFF
--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -170,12 +170,12 @@ primitive HoverFormatter
     """
     Format entity declarations.
     """
-    match \exhaustive\ extract_entity_info(ast)
+    match \exhaustive\ _extract_entity_info(ast)
     | let info: EntityInfo => format_entity(info)
     | None => None
     end
 
-  fun extract_entity_info(ast: AST box): (EntityInfo | None) =>
+  fun _extract_entity_info(ast: AST box): (EntityInfo | None) =>
     """
     Extract entity information from AST node.
     """
@@ -229,12 +229,12 @@ primitive HoverFormatter
     """
     Format method declarations.
     """
-    match \exhaustive\ extract_method_info(ast)
+    match \exhaustive\ _extract_method_info(ast)
     | let info: MethodInfo => format_method(info)
     | None => None
     end
 
-  fun extract_method_info(ast: AST box): (MethodInfo | None) =>
+  fun _extract_method_info(ast: AST box): (MethodInfo | None) =>
     """
     Extract method information from AST node.
     """


### PR DESCRIPTION
## Context

`extract_entity_info` and `extract_method_info` on `HoverFormatter` are public but have no callers outside `hover.pony`. Their sibling extractors (`_extract_field_info`, `_extract_local_var_info`, `_extract_param_info`) are already private. The inconsistency was flagged during review of #5313.

## Changes

- Rename `extract_entity_info` → `_extract_entity_info`
- Rename `extract_method_info` → `_extract_method_info`

## Considerations

No behaviour change. All callers are within `hover.pony`.