### PR TITLE
LSP: drop behaviour return type from hover and signature help

### DIFF
--- a/.release-notes/drop-be-return-type.md
+++ b/.release-notes/drop-be-return-type.md
@@ -1,0 +1,3 @@
+## LSP: drop behaviour return type from hover and signature help
+
+Hover popups and signature help for `be` behaviours no longer display a return type. Behaviour return types are always `None val` inserted by the compiler and cannot be written explicitly in source, so showing them was unnecessary and did not add information.

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -129,7 +129,17 @@ class \nodoc\ iso _HoverIntegrationActorTest is UnitTest
           6,
           ["actor _Actor"; "A simple actor for exercising LSP hover."])
         _HoverChecker(6, 6, ["new tag create(name': String val)"])
-        _HoverChecker(9, 5, ["be tag do_something(value: U64 val)"])
+        _HoverChecker(
+          9,
+          5,
+          ["be tag do_something(value: U64 val)"],
+          ["): None val"])
+        // beref call site: same signature, no return type
+        _HoverChecker(
+          13,
+          4,
+          ["be tag do_something(value: U64 val)"],
+          ["): None val"])
         // no hover on 'actor' keyword
         _HoverChecker(0, 0, [])
         _HoverChecker(0, 2, [])
@@ -476,13 +486,15 @@ class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
         _HoverChecker(
           91,
           5,
-          [ "be tag update(new_state: T): None val"
-            "Updates the actor's state."])
+          [ "be tag update(new_state: T)"
+            "Updates the actor's state."],
+          ["): None val"])
         _HoverChecker(
           97,
           5,
-          [ "be tag process[U: Any val](data: U): None val"
-            "A generic behavior with its own type parameter."])
+          [ "be tag process[U: Any val](data: U)"
+            "A generic behavior with its own type parameter."],
+          ["): None val"])
         // primitive _GenericHelper
         _HoverChecker(
           104,
@@ -609,15 +621,18 @@ class val _HoverChecker
   let _line: I64
   let _character: I64
   let _expected: Array[String] val
+  let _not_expected: Array[String] val
 
   new val create(
     line': I64,
     character': I64,
-    expected: Array[String] val)
+    expected: Array[String] val,
+    not_expected: Array[String] val = recover val Array[String] end)
   =>
     _line = line'
     _character = character'
     _expected = expected
+    _not_expected = not_expected
 
   fun lsp_method(): String =>
     Methods.text_document().hover()
@@ -629,15 +644,12 @@ class val _HoverChecker
 
   fun check(res: ResponseMessage val, h: TestHelper): Bool =>
     var ok = true
-    if _expected.size() == 0 then
-      try
-        JsonNav(res.result)("contents")("value").as_string()?
+    try
+      let value = JsonNav(res.result)("contents")("value").as_string()?
+      if _expected.size() == 0 then
         ok = false
         h.log("Expected no hover result but got: " + res.string())
-      end
-    else
-      try
-        let value = JsonNav(res.result)("contents")("value").as_string()?
+      else
         for s in _expected.values() do
           if not h.assert_true(
             value.contains(s),
@@ -646,7 +658,17 @@ class val _HoverChecker
             ok = false
           end
         end
-      else
+      end
+      for s in _not_expected.values() do
+        if not h.assert_true(
+          not value.contains(s),
+          "Expected '" + s + "' NOT in hover, got: " + value)
+        then
+          ok = false
+        end
+      end
+    else
+      if _expected.size() > 0 then
         ok = false
         let expected_str: String val =
           recover val

--- a/tools/pony-lsp/test/_signature_help_integration_tests.pony
+++ b/tools/pony-lsp/test/_signature_help_integration_tests.pony
@@ -438,7 +438,13 @@ class \nodoc\ iso _SigHelpBeMethodTest is UnitTest
       h,
       _server,
       "signature_help/signature_help.pony",
-      [_SigHelpChecker(88, 12, "greet", 0)])
+      [ _SigHelpChecker(
+          88,
+          12,
+          "greet",
+          0
+          where expected_full_label' =
+            "be tag greet(name: String val, count: U32 val)")])
 
 class \nodoc\ iso _SigHelpAfterOpenParenMultilineTest is UnitTest
   """

--- a/tools/pony-lsp/test/workspace/hover/_actor.pony
+++ b/tools/pony-lsp/test/workspace/hover/_actor.pony
@@ -9,3 +9,6 @@ actor _Actor
 
   be do_something(value: U64) =>
     None
+
+  be trigger() =>
+    do_something(0)

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -283,11 +283,10 @@ primitive HoverFormatter
             "()"
           end
 
-        // Extract return type (only for fun/be, not new)
+        // Extract return type for fun only; be always returns None val
+        // (compiler-inserted, cannot be written in source)
         let return_type_str =
-          if (token_id == TokenIds.tk_fun()) or
-            (token_id == TokenIds.tk_be())
-          then
+          if token_id == TokenIds.tk_fun() then
             try
               let return_type = ast(4)?
               ": " + _TypeFormatter.extract_type(return_type)

--- a/tools/pony-lsp/workspace/signature_help.pony
+++ b/tools/pony-lsp/workspace/signature_help.pony
@@ -314,7 +314,7 @@ primitive SignatureHelp
       offsets.push((start, label.size()))
     end
     label = label + ")"
-    if (keyword == "fun") or (keyword == "be") then
+    if keyword == "fun" then
       try
         let rt = def(4)?
         let rt_str = _TypeFormatter.extract_type(rt)


### PR DESCRIPTION
## Context

Behaviour return types are always `None val` inserted by the sugar pass. Users cannot write an explicit return type on a `be` definition — it is a compile error. Showing `: None val` in hover or signature help output is noise without information value.

## Changes

Return types are now only shown for `fun` functions in both hover popups and signature help.

- `hover.pony`: restrict return type extraction to `tk_fun` only; `tk_be` and `tk_new` are excluded
- `signature_help.pony`: same condition change in `_build_label`
- `_hover_integration_tests.pony`: extend `_HoverChecker` with a `not_expected` field; update behaviour assertions to assert `": None val"` is absent; add a `beref` call-site hover check
- `_signature_help_integration_tests.pony`: add exact-label assertion to the `be` method test

#### Before

<img width="466" height="119" alt="image" src="https://github.com/user-attachments/assets/3201c733-18cc-4298-a145-a999b3407a21" />

#### After

<img width="472" height="123" alt="image" src="https://github.com/user-attachments/assets/3fef9629-3be8-40ce-a3e8-919cb5426458" />


## Considerations

The inlay hints feature already correctly excludes `be` from return type hints — no change needed there.