### PR TITLE
Use British English spelling in pony-lsp comments and docstrings

### DIFF
--- a/tools/pony-lsp/compiler_notify.pony
+++ b/tools/pony-lsp/compiler_notify.pony
@@ -12,7 +12,7 @@ use @ponyint_pool_free_size[None](size: USize, p: Pointer[U8] tag)
 actor PonyCompiler is LspCompiler
   """
   Actor wrapping the pony_compiler `Compiler`
-  primitive to serialize compilation requests
+  primitive to serialise compilation requests
   (libponyc is not fully thread-safe).
 
   Determines the ponyc standard library location
@@ -30,7 +30,7 @@ actor PonyCompiler is LspCompiler
   var _got_settings: Bool
     """
     The compiler will only start compiling after it
-    got initialized by calling `apply_settings`.
+    got initialised by calling `apply_settings`.
     """
   var _run_id_gen: USize
 
@@ -155,10 +155,10 @@ trait tag LspCompiler
 
   be apply_settings(settings: (Settings | None))
     """
-    Provide settings to initialize or reconfigure the compiler.
+    Provide settings to initialise or reconfigure the compiler.
 
     `None` can be provided when no new settings should be applied,
-    but the initialization step should be completed.
+    but the initialisation step should be completed.
     """
 
   be compile(

--- a/tools/pony-lsp/diagnostics.pony
+++ b/tools/pony-lsp/diagnostics.pony
@@ -6,7 +6,7 @@ class val Diagnostic
   LSP diagnostic representing a compiler error or
   warning at a specific location.
   """
-  // only the range is serialized, but useful to keep
+  // only the range is serialised, but useful to keep
   // the actual file around for expanding related info
   let location: LspLocation
   let severity: I64

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -750,7 +750,7 @@ actor LanguageServer is (Notifier & RequestSender)
         "[workspace/didChangeConfiguration] No or invalid pony-lsp settings " +
         "provided.")
       // this is all we got, we still have to
-      // initialize the compiler at least once
+      // initialise the compiler at least once
       this._compiler.apply_settings(None)
     end
 
@@ -768,7 +768,7 @@ actor LanguageServer is (Notifier & RequestSender)
         this._channel.log("[workspace/configuration] No setting provided.")
       end
     // even if we have no valid settings, we still call the compiler,
-    // as it has to be initialized with apply_settings at least once
+    // as it has to be initialised with apply_settings at least once
     this._compiler.apply_settings(maybe_settings)
 
   fun handle_register_capability_response(r: ResponseMessage val) =>

--- a/tools/pony-lsp/message.pony
+++ b/tools/pony-lsp/message.pony
@@ -268,7 +268,7 @@ primitive DocumentHighlightKind
   `textDocument/documentHighlight` response.
 
   The spec says `kind` is optional and defaults to `Text` when omitted, so
-  clients that do not support per-kind coloring are unaffected. Clients that
+  clients that do not support per-kind colouring are unaffected. Clients that
   do support it (e.g. VS Code) colour read and write occurrences differently,
   giving the user a quick visual distinction between where a symbol is read
   and where it is written.

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -91,7 +91,7 @@ class DocumentSymbol
 
   fun to_json(): JsonValue =>
     """
-    Serialize this symbol to JSON.
+    Serialise this symbol to JSON.
     """
     var obj = JsonObject
       .update("name", this.name)

--- a/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
@@ -705,7 +705,7 @@ class val _PrepareKindChecker
   """
   Prepare checker that asserts kind, name, and detail fields.
   Used when the range assertions are secondary to testing kind values
-  (e.g. constructors returning kind=9, behaviors returning kind=6).
+  (e.g. constructors returning kind=9, behaviours returning kind=6).
   """
   let _pos: (I64, I64)
   let _expected_kind: I64

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -61,7 +61,7 @@ class \nodoc\ iso _DocHighlightFieldTest
   """
   Highlights the `count` field from its declaration site.
   Expects all 5 occurrences to be found:
-    line 21 col  6  (var count: U32 = 0 declaration — Write, has initializer)
+    line 21 col  6  (var count: U32 = 0 declaration — Write, has initialiser)
     line 24 col  4  (tick LHS — Write)
     line 24 col 12  (tick RHS — Read)
     line 27 col  4  (value() body — Read)
@@ -126,7 +126,7 @@ class \nodoc\ iso _DocHighlightLocalTest
   """
   Highlights the `result` local variable from its declaration site.
   Expects 3 occurrences:
-    line 30 col  8  (let result: U32 = count — Write, has initializer)
+    line 30 col  8  (let result: U32 = count — Write, has initialiser)
     line 31 col  4  (first use in result + result)
     line 31 col 13  (second use in result + result)
   """
@@ -311,7 +311,7 @@ class \nodoc\ iso _DocHighlightVarLocalTest is UnitTest
   """
   Highlights the `w` var local from its declaration.
   Expects 4 occurrences:
-    line 106 col  8  (var w: U32 = v — Write, has initializer)
+    line 106 col  8  (var w: U32 = v — Write, has initialiser)
     line 107 col  4  (w = w + ... LHS)
     line 107 col  8  (w = w + ... RHS)
     line 108 col  4  (w return value)
@@ -531,7 +531,7 @@ class \nodoc\ iso _DocHighlightInnerXFieldTest is UnitTest
   """
   Highlights the `x` fvar field of _Inner from its declaration.
   Expects 2 occurrences:
-    line 49 col 6  (var x: U32 = 0 — Write, has inline initializer)
+    line 49 col 6  (var x: U32 = 0 — Write, has inline initialiser)
     line 52 col 4  (x = 0 assignment in create — Write)
   """
   let _server: _LspTestServer
@@ -623,7 +623,7 @@ class \nodoc\ iso _DocHighlightDoWorkLetTest is UnitTest
   """
   Highlights the `v` let local of do_work from its declaration.
   Expects 2 occurrences:
-    line 105 col  8  (let v: U32 = n — Write, has initializer)
+    line 105 col  8  (let v: U32 = n — Write, has initialiser)
     line 106 col 17  (var w: U32 = v)
   """
   let _server: _LspTestServer
@@ -869,7 +869,7 @@ class \nodoc\ iso _DocHighlightOutOfBoundsTest is UnitTest
 
 class \nodoc\ iso _DocHighlightUninitLocalTest is UnitTest
   """
-  Highlights `acc` — a local var declared without an initializer.
+  Highlights `acc` — a local var declared without an initialiser.
   Expects 3 occurrences:
     line 148 col  8  (var acc: U32 — Write, declaration)
     line 149 col  4  (acc = 0 LHS — Write)
@@ -901,7 +901,7 @@ class \nodoc\ iso _DocHighlightTupleAssignATest is UnitTest
   """
   Highlights `ta` in a tuple destructuring assignment.
   Expects 3 occurrences:
-    line 163 col  8  (var ta: U32 = 0 — Write, has initializer)
+    line 163 col  8  (var ta: U32 = 0 — Write, has initialiser)
     line 165 col  5  ((ta, tb) = ... LHS — Write, tuple destructuring)
     line 166 col  4  (ta + tb — Read)
   """
@@ -931,7 +931,7 @@ class \nodoc\ iso _DocHighlightTupleAssignBTest is UnitTest
   """
   Highlights `tb` in a tuple destructuring assignment.
   Expects 3 occurrences:
-    line 164 col  8  (var tb: U32 = 0 — Write, has initializer)
+    line 164 col  8  (var tb: U32 = 0 — Write, has initialiser)
     line 165 col  9  ((ta, tb) = ... LHS — Write, tuple destructuring)
     line 166 col  9  (ta + tb — Read)
   """
@@ -963,7 +963,7 @@ class \nodoc\ iso _DocHighlightTupleElemRefTest is UnitTest
   The resolver follows the receiver, so this highlights all occurrences of
   `pair`. Crucially, the tk_tupleelemref itself must be kind=Read (not Text).
   Expects 2 occurrences:
-    line 175 col  8  (let pair declaration — Write, has initializer)
+    line 175 col  8  (let pair declaration — Write, has initialiser)
     line 176 col  4  (pair._1 full expression — Read, tk_tupleelemref)
   """
   let _server: _LspTestServer

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -67,7 +67,7 @@ class \nodoc\ iso _FoldingRangeEntityTypesTest is UnitTest
   """
   FoldingRange for entity_types.pony. Verifies that fold ranges are produced
   for all entity types (primitive, struct, actor, trait, interface) and their
-  multi-line members, including be behaviors.
+  multi-line members, including be behaviours.
 
   Struct and actor receive explicit single-line constructors so that ponyc
   does not generate synthetic constructors, which would appear as extra ranges.
@@ -254,7 +254,7 @@ class \nodoc\ iso _FoldingRangeIfdefTest is UnitTest
 
   `ifdef` is resolved to `if` by resolve_ifdef() during the expr pass, so the
   fold range is produced by the tk_if arm, not a tk_ifdef arm. The test
-  verifies the correct user-facing behavior regardless of the internal token.
+  verifies the correct user-facing behaviour regardless of the internal token.
 
   ifdef_expressions.pony layout (0-indexed lines):
     line 0: class IfdefExpressions          → (0, 8)

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -493,7 +493,7 @@ class \nodoc\ iso _HoverIntegrationGenericsTest is UnitTest
           97,
           5,
           [ "be tag process[U: Any val](data: U)"
-            "A generic behavior with its own type parameter."],
+            "A generic behaviour with its own type parameter."],
           ["): None val"])
         // primitive _GenericHelper
         _HoverChecker(

--- a/tools/pony-lsp/test/_signature_help_integration_tests.pony
+++ b/tools/pony-lsp/test/_signature_help_integration_tests.pony
@@ -421,7 +421,7 @@ class \nodoc\ iso _SigHelpMultilineArg2Test is UnitTest
 
 class \nodoc\ iso _SigHelpBeMethodTest is UnitTest
   """
-  Cursor on `"` in `"hello"` (line 88, col 12) — first arg of `greet` behavior.
+  Cursor on `"` in `"hello"` (line 88, col 12) — first arg of `greet` behaviour.
   Exercises the tk_be branch in SignatureHelp.collect.
   Expects signature for `greet` with activeParameter=0.
   """

--- a/tools/pony-lsp/test/workspace/definition/definition.pony
+++ b/tools/pony-lsp/test/workspace/definition/definition.pony
@@ -14,7 +14,7 @@ To manually test goto definition functionality:
    - `get` in the `demo` method body — navigates to the method declaration
    - `this` in the `demo` method body — navigates to the class declaration
 
-Expected goto definition behavior:
+Expected goto definition behaviour:
 - Navigate to the declaration of the symbol under the cursor
 - Return no result when the cursor is on a docstring, a keyword (`class`,
   `fun`, `new`), an operator, or any other non-symbol token

--- a/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
+++ b/tools/pony-lsp/test/workspace/folding_range/folding_range.pony
@@ -73,7 +73,7 @@ Expected fold regions per file:
     - `ifdef debug then` (line 6) → folds through the else branch value
         (via tk_if after compiler resolution)
 
-  entity_types.pony — all entity kinds and be behaviors
+  entity_types.pony — all entity kinds and be behaviours
     - `primitive P` (line 1) → folds through `42`
     - `fun value(): U32 =>` (line 2) → folds through `42`
     - `struct S` (line 5) → folds through `x`

--- a/tools/pony-lsp/test/workspace/highlights/highlights.pony
+++ b/tools/pony-lsp/test/workspace/highlights/highlights.pony
@@ -141,7 +141,7 @@ class _LiteralExamples
 
 class _UninitLocal
   """
-  Demonstrates a local variable declared without an inline initializer.
+  Demonstrates a local variable declared without an inline initialiser.
   `acc` is declared as `var acc: U32` (no `= expr`). All declarations are
   Write kind; the `acc = 0` assignment below is also Write; the return is Read.
   """
@@ -156,7 +156,7 @@ class _TupleAssign
   LHS elements of a tuple assignment are Write kind.
 
   Place the cursor on `ta` to see both occurrences:
-    the var declaration (Write — has initializer)
+    the var declaration (Write — has initialiser)
     the LHS of the tuple assign (Write)
     the use in ta + tb (Read)
   """

--- a/tools/pony-lsp/test/workspace/hover/_generics.pony
+++ b/tools/pony-lsp/test/workspace/hover/_generics.pony
@@ -97,8 +97,8 @@ actor _GenericActor[T: Any val]
 
   be process[U: Any val](data: U) =>
     """
-    A generic behavior with its own type parameter.
-    Demonstrates that behaviors can be generic too.
+    A generic behaviour with its own type parameter.
+    Demonstrates that behaviours can be generic too.
     """
     None
 

--- a/tools/pony-lsp/test/workspace/hover/hover.pony
+++ b/tools/pony-lsp/test/workspace/hover/hover.pony
@@ -4,7 +4,7 @@ Test fixtures for exercising LSP hover functionality.
 This module provides test cases for manual and automated testing of hover
 functionality provided by the Pony language server (LSP). It contains various
 Pony entities (classes, actors, traits, methods, fields) with docstrings and
-type annotations to validate hover behavior.
+type annotations to validate hover behaviour.
 
 To manually test hover functionality:
 1. Open the lsp/test/workspace directory as a project in your editor.
@@ -12,7 +12,7 @@ To manually test hover functionality:
    is active.
 3. Hover your cursor over various code elements to see hover information.
 
-Expected hover behavior:
+Expected hover behaviour:
 - Display the declaration signature in a code block
 - Include docstrings where present
 - Show type information for fields and variables

--- a/tools/pony-lsp/test/workspace/my_comparable.pony
+++ b/tools/pony-lsp/test/workspace/my_comparable.pony
@@ -237,7 +237,7 @@ actor GenericActor[T: Any val]
 
   be process[U: Any val](data: U) =>
     """
-    A generic behavior with its own type parameter.
+    A generic behaviour with its own type parameter.
     """
     None
 

--- a/tools/pony-lsp/test/workspace/type_hierarchy/type_hierarchy.pony
+++ b/tools/pony-lsp/test/workspace/type_hierarchy/type_hierarchy.pony
@@ -16,7 +16,7 @@ To manually test type hierarchy functionality:
 4. Open _t_hier_d.pony and place your cursor on `_THierD` to verify that
    subtypes defined in other files are found.
 
-Expected type hierarchy behavior:
+Expected type hierarchy behaviour:
 - prepareTypeHierarchy returns a single item when the cursor is on a type
   name, or null when the cursor is not on a type name
 - typeHierarchy/supertypes returns the types in the entity's provides clause,

--- a/tools/pony-lsp/uris.pony
+++ b/tools/pony-lsp/uris.pony
@@ -10,7 +10,7 @@ primitive Uris
     """
     Convert an LSP document URI to a local filesystem path by stripping the
     scheme. On Windows, also strips the leading `/` before a drive letter
-    (e.g., `/D:/path` becomes `D:/path`) and normalizes forward slashes to
+    (e.g., `/D:/path` becomes `D:/path`) and normalises forward slashes to
     the native separator.
     """
     let result = uri.split_by("://", 2)
@@ -42,7 +42,7 @@ primitive Uris
 
   fun from_path(path: String): String =>
     """
-    Convert a local filesystem path to an LSP file URI. On Windows, normalizes
+    Convert a local filesystem path to an LSP file URI. On Windows, normalises
     backslashes to forward slashes and uses the `file:///` prefix required for
     drive-letter paths.
     """

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -170,7 +170,7 @@ class ref _HighlightCollector is ASTVisitor
       let kind: I64 =
         if _is_assign_lhs(ast) then
           // LHS of any assignment — covers regular writes,
-          // local decl-with-initializer (tk_assign(tk_let/tk_var, expr)),
+          // local decl-with-initialiser (tk_assign(tk_let/tk_var, expr)),
           // and tuple destructuring LHS (tk_assign(tk_tuple(...), ...)).
           DocumentHighlightKind.write()
         else

--- a/tools/pony-lsp/workspace/state.pony
+++ b/tools/pony-lsp/workspace/state.pony
@@ -90,7 +90,7 @@ class PackageState
       // for each open document, update the
       // document state if we have a module for it
       for (doc_path, doc_state) in this.documents.pairs() do
-        // TODO: ensure both module and package-state paths are normalized
+        // TODO: ensure both module and package-state paths are normalised
         match \exhaustive\ result.find_module(doc_path)
         | let m: Module val => doc_state.update(run_id, m)
         | None => this._channel.log("No module found for " + doc_path)


### PR DESCRIPTION
## Context

The ponyc project uses British English spelling throughout its public API and implementation (e.g. `serialise`, `colour`, `behaviour`). The pony-lsp tool had drifted to US spellings in comments, docstrings, and inline annotations.

## Changes

Replaces US spellings with British equivalents across 20 files in `tools/pony-lsp/`:

- `serialise`/`serialised` (was `serialize`/`serialized`) — `compiler_notify.pony`, `diagnostics.pony`, `symbols.pony`
- `initialise`/`initialised`/`initialisation` (was `initialize`/`initialized`/`initialization`) — `compiler_notify.pony`, `language_server.pony`, `workspace/document_highlight.pony`, and several test files
- `behaviour`/`behaviours` (was `behavior`/`behaviors`) — multiple test files and workspace fixtures
- `normalise`/`normalised` (was `normalize`/`normalized`) — `uris.pony`, `workspace/state.pony`
- `colouring` (was `coloring`) — `message.pony`
- `initialiser` (was `initializer`) — `workspace/document_highlight.pony`, test files

LSP protocol-mandated spellings (`"initialize"`, `"initialized"` method name strings and the identifiers that wrap them) are left unchanged.

## Considerations

None — purely cosmetic, no behaviour changes.