### PR TITLE
Fix Windows TCP connection silently leaking state on IOCP errors

### DIFF
--- a/.release-notes/fix-tcp-connection-windows-iocp-error-swallowing.md
+++ b/.release-notes/fix-tcp-connection-windows-iocp-error-swallowing.md
@@ -1,0 +1,5 @@
+## Fix Windows TCP connection silently leaking state on IOCP errors
+
+When a Windows TCP connection's underlying socket failed during an IOCP write, or when the IOCP completion bookkeeping became inconsistent, the connection would silently leak its pending write state instead of closing. Subsequent writes would accumulate on a dead socket.
+
+The connection now closes non-gracefully when these errors occur, matching the POSIX behavior.

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -450,7 +450,8 @@ actor TCPConnection is AsioEventNotify
   be writev(data: ByteSeqIter) =>
     """
     Write a sequence of sequences of bytes. Data will be silently discarded if
-    the connection has not yet been established though.
+    the connection has not yet been established though. On an error, close
+    the connection.
     """
     if _connected and not _closed then
       _in_sent = true
@@ -483,6 +484,9 @@ actor TCPConnection is AsioEventNotify
           else
             _pending_sent = _pending_sent + len
           end
+        else
+          // Non-graceful shutdown on error.
+          hard_close()
         end
       else
         for bytes in _notify.sentv(this, data).values() do
@@ -728,6 +732,9 @@ actor TCPConnection is AsioEventNotify
           else
             _pending_sent = _pending_sent + len
           end
+        else
+          // Non-graceful shutdown on error.
+          hard_close()
         end
       else
         _pending_writev_posix .> push((data.cpointer(), data.size()))
@@ -739,7 +746,7 @@ actor TCPConnection is AsioEventNotify
   fun ref _complete_writes(len: U32) =>
     """
     The OS has informed us that `len` bytes of pending writes have completed.
-    This occurs only with IOCP on Windows.
+    This occurs only with IOCP on Windows. On an error, close the connection.
     """
     ifdef windows then
       if len == 0 then
@@ -751,6 +758,10 @@ actor TCPConnection is AsioEventNotify
       try
         _manage_pending_buffer(len.usize(),
           _pending_writev_total, _pending_writev_windows.size())?
+      else
+        // Non-graceful shutdown on error.
+        hard_close()
+        return
       end
 
       if _pending_sent < 16 then


### PR DESCRIPTION
Three Windows-only `try` blocks on the IOCP write/completion path in `TCPConnection` swallowed errors silently because they had no `else` arm. When an IOCP write failed or completion bookkeeping went inconsistent, the connection didn't close — queued bytes piled up on a dead socket. The POSIX sibling in `_pending_writes` already handled the same condition with `else hard_close()` and a `// Non-graceful shutdown on error.` comment. The Windows path was the missing-`else` outlier.

This adds the same `else hard_close()` arm to all three sites (`writev`, `write_final`, `_complete_writes`). The third site also needs an explicit `return` to skip the post-`try` `_release_backpressure()` call — without it, `unthrottled` would fire on the user's notify after `closed`, matching neither POSIX behavior nor the function's own `len == 0` early-return pattern just above.

Closes #5287

## Verification

`make test-stdlib-release` passes on Linux (449 tests). The change is entirely inside `ifdef windows then`, so existing tests don't exercise it on Linux. Windows CI on this PR will exercise the happy paths but not the error paths — verifying the error paths requires either FFI failure injection or socket-level error production on Windows, neither of which exists in the `packages/net/_test.pony` infrastructure today.