### PR TITLE
Fix LSP parameter hover to show valid Pony syntax

### DIFF
--- a/.release-notes/fix-param-hover-syntax.md
+++ b/.release-notes/fix-param-hover-syntax.md
@@ -1,0 +1,3 @@
+## Fix LSP parameter hover to show valid Pony syntax
+
+Hovering over a method parameter in the LSP previously showed `param name: String` — a `param` keyword that does not exist in Pony. It now shows `name: String`, which is the correct representation of a parameter.

--- a/tools/pony-lsp/test/_hover_formatter_tests.pony
+++ b/tools/pony-lsp/test/_hover_formatter_tests.pony
@@ -25,6 +25,9 @@ primitive _HoverFormatterTests is TestList
     test(_HoverFormatFieldWithNestedGenericTypeTest)
     test(_HoverFormatParameterTest)
     test(_HoverFormatParameterWithTypeTest)
+    test(_HoverFormatParameterWithGenericTypeTest)
+    test(_HoverFormatLocalVarTest)
+    test(_HoverFormatLocalVarWithTypeTest)
     test(_HoverFormatMethodWithReceiverCapTest)
 
 class \nodoc\ iso _HoverFormatEntityTest
@@ -256,18 +259,44 @@ class \nodoc\ iso _HoverFormatParameterTest is UnitTest
   fun name(): String => "hover/formatter/parameter"
 
   fun apply(h: TestHelper) =>
-    let info = FieldInfo("param", "value")
-    let result = HoverFormatter.format_field(info)
-    h.assert_eq[String]("```pony\nparam value\n```", result)
+    let info = ParamInfo("value")
+    let result = HoverFormatter.format_param(info)
+    h.assert_eq[String]("```pony\nvalue\n```", result)
 
 class \nodoc\ iso _HoverFormatParameterWithTypeTest is UnitTest
   fun name(): String =>
     "hover/formatter/parameter_with_type"
 
   fun apply(h: TestHelper) =>
-    let info = FieldInfo("param", "name", ": String")
-    let result = HoverFormatter.format_field(info)
-    h.assert_eq[String]("```pony\nparam name: String\n```", result)
+    let info = ParamInfo("name", ": String")
+    let result = HoverFormatter.format_param(info)
+    h.assert_eq[String]("```pony\nname: String\n```", result)
+
+class \nodoc\ iso _HoverFormatParameterWithGenericTypeTest is UnitTest
+  fun name(): String =>
+    "hover/formatter/parameter_with_generic_type"
+
+  fun apply(h: TestHelper) =>
+    let info = ParamInfo("items", ": Array[String val] ref")
+    let result = HoverFormatter.format_param(info)
+    h.assert_eq[String]("```pony\nitems: Array[String val] ref\n```", result)
+
+class \nodoc\ iso _HoverFormatLocalVarTest is UnitTest
+  fun name(): String => "hover/formatter/local_var"
+
+  fun apply(h: TestHelper) =>
+    let info = LocalVarInfo("let", "x")
+    let result = HoverFormatter.format_local_var(info)
+    h.assert_eq[String]("```pony\nlet x\n```", result)
+
+class \nodoc\ iso _HoverFormatLocalVarWithTypeTest is UnitTest
+  fun name(): String =>
+    "hover/formatter/local_var_with_type"
+
+  fun apply(h: TestHelper) =>
+    let info = LocalVarInfo("var", "count", ": U32")
+    let result = HoverFormatter.format_local_var(info)
+    h.assert_eq[String]("```pony\nvar count: U32\n```", result)
 
 class \nodoc\ iso _HoverFormatMethodWithReceiverCapTest is UnitTest
   fun name(): String =>

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -51,7 +51,7 @@ class val MethodInfo
 
 class val FieldInfo
   """
-  Information about a field declaration.
+  Information about a class field declaration (let, var, or embed).
   """
   let keyword: String
   let name: String
@@ -61,6 +61,30 @@ class val FieldInfo
     keyword = keyword'
     name = name'
     field_type = field_type'
+
+class val LocalVarInfo
+  """
+  Information about a local variable declaration (let or var in a method body).
+  """
+  let keyword: String
+  let name: String
+  let var_type: String
+
+  new val create(keyword': String, name': String, var_type': String = "") =>
+    keyword = keyword'
+    name = name'
+    var_type = var_type'
+
+class val ParamInfo
+  """
+  Information about a method parameter.
+  """
+  let name: String
+  let param_type: String
+
+  new val create(name': String, param_type': String = "") =>
+    name = name'
+    param_type = param_type'
 
 primitive HoverFormatter
   """
@@ -107,6 +131,20 @@ primitive HoverFormatter
     Format field declaration as markdown hover text.
     """
     let declaration = info.keyword + " " + info.name + info.field_type
+    _wrap_code_block(consume declaration)
+
+  fun format_local_var(info: LocalVarInfo): String =>
+    """
+    Format local variable declaration as markdown hover text.
+    """
+    let declaration = info.keyword + " " + info.name + info.var_type
+    _wrap_code_block(consume declaration)
+
+  fun format_param(info: ParamInfo): String =>
+    """
+    Format parameter declaration as markdown hover text.
+    """
+    let declaration = info.name + info.param_type
     _wrap_code_block(consume declaration)
 
   // ======= AST Extraction and Dispatch =======
@@ -351,7 +389,6 @@ primitive HoverFormatter
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
 
-        // Extract type annotation
         let type_str =
           try
             let field_type = ast(1)?
@@ -373,11 +410,11 @@ primitive HoverFormatter
     Format local variable declarations.
     """
     match \exhaustive\ _extract_local_var_info(ast)
-    | let info: FieldInfo => format_field(info)
+    | let info: LocalVarInfo => format_local_var(info)
     | None => None
     end
 
-  fun _extract_local_var_info(ast: AST box): (FieldInfo | None) =>
+  fun _extract_local_var_info(ast: AST box): (LocalVarInfo | None) =>
     """
     Extract local variable information from AST node.
     """
@@ -393,7 +430,6 @@ primitive HoverFormatter
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
 
-        // Extract type annotation if present
         let type_str =
           try
             let var_type = ast(1)?
@@ -406,7 +442,7 @@ primitive HoverFormatter
             ""
           end
 
-        FieldInfo(keyword, name, type_str)
+        LocalVarInfo(keyword, name, type_str)
       else
         None
       end
@@ -419,20 +455,23 @@ primitive HoverFormatter
     Format parameter declarations.
     """
     match \exhaustive\ _extract_param_info(ast)
-    | let info: FieldInfo => format_field(info)
+    | let info: ParamInfo => format_param(info)
     | None => None
     end
 
-  fun _extract_param_info(ast: AST box): (FieldInfo | None) =>
+  fun _extract_param_info(ast: AST box): (ParamInfo | None) =>
     """
     Extract parameter information from AST node.
     """
+    if ast.id() != TokenIds.tk_param() then
+      return None
+    end
+
     try
       let id = ast(0)?
       if id.id() == TokenIds.tk_id() then
         let name = id.token_value() as String
 
-        // Extract type annotation
         let type_str =
           try
             let param_type = ast(1)?
@@ -445,7 +484,7 @@ primitive HoverFormatter
             ""
           end
 
-        FieldInfo("param", name, type_str)
+        ParamInfo(name, type_str)
       else
         None
       end


### PR DESCRIPTION
## Context

Parameter hover in the LSP shows `param name: String` — a `param` keyword that does not exist in Pony. The correct representation of a parameter is `name: String`.

<img width="609" height="166" alt="image" src="https://github.com/user-attachments/assets/ca53e253-ece8-4f90-9b80-f2a2866e31e4" />


## Changes

The overloaded `FieldInfo` type is split into three distinct types — one per concept — each with its own formatter function.

- Introduce `LocalVarInfo` and `ParamInfo` alongside `FieldInfo`. Each type has its own formatter function (`format_local_var`, `format_param`).
- `format_param` omits the keyword prefix, producing valid Pony syntax for parameter hover.
- Formatter tests for parameters updated to assert correct output and use the new `ParamInfo` type.

<img width="619" height="175" alt="image" src="https://github.com/user-attachments/assets/16b81094-b1c3-4b75-add7-82bbee7b6d67" />

## Considerations

`FieldInfo` was previously used for class fields, local variables, and parameters — three concepts with different semantics. The type split enforces this distinction at compile time, making it impossible to accidentally format a parameter as a field or vice versa. Field docstring support (fields can carry docstrings per the grammar) is a natural follow-on now that `FieldInfo` is its own type.