### PR TITLE
LSP now shows docstrings for class fields on hover

### DIFF
--- a/.release-notes/lsp-field-docstring-hover.md
+++ b/.release-notes/lsp-field-docstring-hover.md
@@ -1,0 +1,3 @@
+## LSP now shows docstrings for class fields on hover
+
+Docstrings on class fields are now shown when you hover over a field in your editor, consistent with how docstrings on classes, actors, primitives, and methods are already displayed.

--- a/tools/pony-lsp/test/_hover_formatter_tests.pony
+++ b/tools/pony-lsp/test/_hover_formatter_tests.pony
@@ -15,6 +15,7 @@ primitive _HoverFormatterTests is TestList
     test(_HoverFormatMethodWithTypeParamsTest)
     test(_HoverFormatFieldTest)
     test(_HoverFormatFieldWithTypeTest)
+    test(_HoverFormatFieldWithDocstringTest)
     test(_HoverFormatEntityWithMultipleTypeParamsTest)
     test(_HoverFormatFieldWithGenericTypeTest)
     test(_HoverFormatMethodWithArrowTypeTest)
@@ -125,6 +126,16 @@ class \nodoc\ iso _HoverFormatFieldWithTypeTest is UnitTest
     let info = FieldInfo("var", "count", ": U32")
     let result = HoverFormatter.format_field(info)
     h.assert_eq[String]("```pony\nvar count: U32\n```", result)
+
+class \nodoc\ iso _HoverFormatFieldWithDocstringTest is UnitTest
+  fun name(): String =>
+    "hover/formatter/field_with_docstring"
+
+  fun apply(h: TestHelper) =>
+    let info = FieldInfo("let", "name", ": String", "Has a docstring.")
+    let result = HoverFormatter.format_field(info)
+    h.assert_eq[String](
+      "```pony\nlet name: String\n```\n\nHas a docstring.", result)
 
 class \nodoc\ iso _HoverFormatMethodWithTypeParamsTest is UnitTest
   fun name(): String =>

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -24,6 +24,7 @@ primitive _HoverIntegrationTests is TestList
     test(_HoverIntegrationGenericsTest.create(server))
     test(_HoverIntegrationLiteralsTest.create(server))
     test(_HoverIntegrationCapKeywordTest.create(server))
+    test(_HoverIntegrationFieldDocstringTest.create(server))
 
 class \nodoc\ iso _HoverIntegrationLiteralsTest is UnitTest
   let _server: _LspTestServer
@@ -616,6 +617,32 @@ class \nodoc\ iso _HoverIntegrationCapKeywordTest is UnitTest
         _HoverChecker(25, 10, ["fun iso iso_method(): None"])
         _HoverChecker(28, 10, ["fun trn trn_method(): None"])
         _HoverChecker(31, 10, ["fun tag tag_method(): None"])])
+
+class \nodoc\ iso _HoverIntegrationFieldDocstringTest is UnitTest
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/field_docstring"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_field_docstring.pony",
+      [ // declaration site: let field with docstring
+        _HoverChecker(
+          1,
+          6,
+          ["let documented_field: String val"; "Has a docstring."])
+        // declaration site: var field with default value and docstring
+        _HoverChecker(5, 6, ["var counter: U32 val"; "Has a default value."])
+        // usage site: docstring shown at reference
+        _HoverChecker(
+          11,
+          4,
+          ["let documented_field: String val"; "Has a docstring."])])
 
 class val _HoverChecker
   let _line: I64

--- a/tools/pony-lsp/test/workspace/hover/_field_docstring.pony
+++ b/tools/pony-lsp/test/workspace/hover/_field_docstring.pony
@@ -1,0 +1,12 @@
+class _FieldDocstring
+  let documented_field: String
+    """
+    Has a docstring.
+    """
+  var counter: U32 = 0
+    """
+    Has a default value.
+    """
+
+  new create() =>
+    documented_field = ""

--- a/tools/pony-lsp/workspace/hover.pony
+++ b/tools/pony-lsp/workspace/hover.pony
@@ -56,11 +56,18 @@ class val FieldInfo
   let keyword: String
   let name: String
   let field_type: String
+  let docstring: String
 
-  new val create(keyword': String, name': String, field_type': String = "") =>
+  new val create(
+    keyword': String,
+    name': String,
+    field_type': String = "",
+    docstring': String = "")
+  =>
     keyword = keyword'
     name = name'
     field_type = field_type'
+    docstring = docstring'
 
 class val LocalVarInfo
   """
@@ -131,7 +138,12 @@ primitive HoverFormatter
     Format field declaration as markdown hover text.
     """
     let declaration = info.keyword + " " + info.name + info.field_type
-    _wrap_code_block(consume declaration)
+    let code_block = _wrap_code_block(consume declaration)
+    if info.docstring.size() > 0 then
+      code_block + "\n\n" + info.docstring
+    else
+      code_block
+    end
 
   fun format_local_var(info: LocalVarInfo): String =>
     """
@@ -397,7 +409,19 @@ primitive HoverFormatter
             ""
           end
 
-        FieldInfo(keyword, name, type_str)
+        let docstring: String =
+          try
+            let doc_node = ast(3)?
+            if doc_node.id() == TokenIds.tk_string() then
+              doc_node.token_value() as String
+            else
+              ""
+            end
+          else
+            ""
+          end
+
+        FieldInfo(keyword, name, type_str, docstring)
       else
         None
       end


### PR DESCRIPTION
## Context

Pony's grammar allows class fields to carry docstrings, but hovering over a field only shows the field declaration. Docstrings are silently dropped.

<img width="568" height="197" alt="image" src="https://github.com/user-attachments/assets/21cf3228-4493-40f6-aceb-e0aa98523bec" />



## Changes

Extends `FieldInfo` with a `docstring` field and updates `_extract_field_info` to read the docstring from AST child 3 (the fixed position per the field grammar, regardless of whether a default value is present). `format_field` now appends the docstring below the code block when present, consistent with how entity and method hover already behave.

<img width="559" height="192" alt="image" src="https://github.com/user-attachments/assets/da1349f1-18fe-4d9f-9822-f9c918e6058f" />

Tests added:
- Formatter unit test asserting the exact markdown layout (`code block + "\n\n" + docstring`)
- Integration test covering a `let` field with docstring (declaration and usage sites)
- Integration test covering a `var` field with both a default value and a docstring

## Considerations

The docstring field belongs only on `FieldInfo` — class fields are the only one of the three declaration types (`FieldInfo`, `LocalVarInfo`, `ParamInfo`) that the Pony grammar allows to carry docstrings.