### PR TITLE
Extend Windows CI pin to lldb's runtime dependencies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -279,24 +279,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -114,24 +114,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
       - name: Restore Libs Cache
         id: restore-libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,24 +291,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -43,24 +43,30 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -43,24 +43,30 @@ jobs:
         with:
           ref: ${{ github.event.inputs.sha || 'main' }}
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -20,24 +20,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
-        # Pin mingw-w64 LLVM family to 22.1.4-1.
+        # Pin mingw-w64 LLVM family and the runtime dependencies lldb
+        # imports against.
         #
-        # mingw-w64-x86_64-lldb-22.1.4-2 (msys2 PKGBUILD pkgrel bump on
-        # 2026-05-03, "llvm: emutls rebuild") crashes in liblldb.dll with
-        # 0xC0000005 when wrapping Pony test executables on windows-2025.
-        # The crash reproduces across multiple unrelated branches; see
-        # ponylang/ponyc Discussion #5007.
+        # History:
+        # (1) 2026-05-03: lldb-22.1.4-2 ("llvm: emutls rebuild") crashed
+        #     in liblldb.dll with 0xC0000005. Pinned llvm-libs,
+        #     clang-libs, lldb to 22.1.4-1.
+        # (2) 2026-05-11: msys2 bumped unpinned dependencies (gcc-libs
+        #     16.1.0-2 -> -3, plus expat/mpdecimal/python pkgrel bumps).
+        #     The pinned lldb 22.1.4-1 then failed to load with
+        #     0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND — the rebuilt deps
+        #     had shifted symbols out from under lldb. Extended the pin
+        #     to those deps.
         #
-        # lldb, clang-libs, and llvm-libs share one PKGBUILD and must
-        # version-match. Installed via `pacman -U` from explicit URLs so
-        # subsequent mirror upgrades cannot re-introduce 22.1.4-2.
+        # See Discussion #5007. Installed via `pacman -U` from explicit
+        # URLs so the initial `-Syuu` can't re-introduce a broken
+        # combination.
         run: |
           function msys() { C:\msys64\usr\bin\bash.exe @('-lc') + @Args }
           msys ' '
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -Syuu'
           msys 'pacman --noconfirm -S --needed base-devel'
-          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst'
+          msys 'pacman --noconfirm -U https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-lldb-22.1.4-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-expat-2.8.0-1-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpdecimal-4.0.1-2-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-python-3.14.4-2-any.pkg.tar.zst'
           msys 'pacman --noconfirm -Scc'
           python.exe -m pip install --upgrade cloudsmith-cli
       - name: Restore Libs Cache


### PR DESCRIPTION
The earlier pin (#5308) covered `llvm-libs`, `clang-libs`, and `lldb` but not the packages `lldb` imports against at load time. On 2026-05-11 msys2 bumped `gcc-libs` from `16.1.0-2` to `-3` (pkgrel bump, "llvm: emutls rebuild" pattern again) plus `expat`/`mpdecimal`/`python` pkgrel bumps. The pinned `lldb 22.1.4-1` then failed to load with `0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND` — symbol resolution against the rebuilt deps no longer found expected entry points. Every `full-program-test` crashed at startup under the lldb wrapper.

Pin `gcc-libs`, `expat`, `mpdecimal`, and `python` to the versions installed during the last passing run (PR #5317, 2026-05-10). Same pattern as the prior pin — explicit URLs via `pacman -U` so the initial `-Syuu` can't pull a broken combination back in.

Fix verified on a feature branch where the pin was applied to `pr-ponyc.yml` only and Windows CI passed. This PR applies the same change to all six workflow files that had the original pin.