### PR TITLE
Extract `_WorkspaceWalk` primitive for cross-package AST walks in pony-lsp

### DIFF
--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -26,6 +26,7 @@ primitive _ReferencesIntegrationTests is TestList
     test(_RefsGenericTypeparamRefIncludedTest.create(server))
     test(_RefsGenericTypeparamRefExcludedTest.create(server))
     test(_RefsGenericActorBeIncludedTest.create(server))
+    test(_RefsCrossPackageTest.create(server))
 
 class \nodoc\ iso _RefsCountDeclIncludedTest is UnitTest
   """
@@ -477,6 +478,49 @@ class \nodoc\ iso _RefsGenericActorBeIncludedTest is UnitTest
           19,
           [ ("generic_actor.pony", 0, 19, 0, 20)
             ("generic_actor.pony", 8, 12, 8, 13)],
+          true)])
+
+class \nodoc\ iso _RefsCrossPackageTest is UnitTest
+  """
+  Find references to `RefBase` from its type-annotation usage in
+  `ref_base_user.pony` (line 7, col 18), with includeDeclaration = true.
+  Expects 2 locations across two different packages:
+    ref_base.pony      (4, 6)-(4, 13)   class declaration (ref_base/ package)
+    ref_base_user.pony (7, 18)-(7, 25)  type annotation   (references/ package)
+
+  `ref_base_user.pony` uses "ref_base", so ponyc compiles both packages in
+  one run. WorkspaceWalk must traverse both packages to find both locations.
+
+  ref_base.pony layout (0-indexed):
+    lines 0-2:  package docstring
+    line 4:     class RefBase                        RefBase at (4,6)-(4,13)
+    lines 5-7:  class docstring
+    line 8:     fun value(): U32 => 42
+  ref_base_user.pony layout (0-indexed):
+    line 0:     use "ref_base"
+    line 2:     class RefBaseUser
+    lines 3-6:  class docstring
+    line 7:     fun use_it(obj: RefBase): U32 =>    RefBase at (7,18)-(7,25)
+    line 8:       obj.value()
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "references/integration/cross_package"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "references/ref_base_user.pony",
+      [ _RefsChecker(
+          7,
+          18,
+          [ ("ref_base.pony", 4, 6, 4, 13)
+            ("ref_base_user.pony", 7, 18, 7, 25)],
           true)])
 
 class val _RefsChecker

--- a/tools/pony-lsp/test/workspace/references/ref_base/ref_base.pony
+++ b/tools/pony-lsp/test/workspace/references/ref_base/ref_base.pony
@@ -1,0 +1,9 @@
+"""
+Test fixture: base class in a sub-package for cross-package reference tests.
+"""
+
+class RefBase
+  """
+  Used by ref_base_user.pony to exercise cross-package WorkspaceWalk.
+  """
+  fun value(): U32 => 42

--- a/tools/pony-lsp/test/workspace/references/ref_base_user.pony
+++ b/tools/pony-lsp/test/workspace/references/ref_base_user.pony
@@ -1,0 +1,9 @@
+use "ref_base"
+
+class RefBaseUser
+  """
+  Uses RefBase from the ref_base sub-package for cross-package reference
+  tests.
+  """
+  fun use_it(obj: RefBase): U32 =>
+    obj.value()

--- a/tools/pony-lsp/workspace/_workspace_walk.pony
+++ b/tools/pony-lsp/workspace/_workspace_walk.pony
@@ -1,0 +1,30 @@
+use ".."
+use "collections"
+use "pony_compiler"
+
+primitive _WorkspaceWalk
+  """
+  Walks every compiled module AST across all tracked packages, applying an
+  ASTVisitor to each.
+
+  Four things to know:
+
+  - **Uncompiled packages are skipped.** Packages whose `PackageState.package()`
+    returns None (not yet compiled) are silently omitted.
+  - **Foreign-source children are filtered.** `AST.visit` does not descend into
+    children whose source differs from the visited module — grafted trait bodies
+    and inlined type aliases are not re-visited here.
+  - **Module order is undefined.** Packages are stored in a hash map; do not
+    rely on visit order across modules.
+  - **`Stop` is module-scoped.** Returning `Stop` from the visitor aborts the
+    current module's traversal only; the walk continues with the next module.
+  """
+  fun apply(packages: Map[String, PackageState] box, visitor: ASTVisitor ref) =>
+    for pkg_state in packages.values() do
+      match pkg_state.package()
+      | let pkg: Package =>
+        for module in pkg.modules() do
+          module.ast.visit(visitor)
+        end
+      end
+    end

--- a/tools/pony-lsp/workspace/call_hierarchy.pony
+++ b/tools/pony-lsp/workspace/call_hierarchy.pony
@@ -42,14 +42,7 @@ primitive CallHierarchy
     match \exhaustive\ _method_for_node(node)
     | let target: AST val =>
       let collector = _IncomingCallCollector(target)
-      for pkg_state in packages.values() do
-        match pkg_state.package()
-        | let pkg: Package =>
-          for module in pkg.modules() do
-            module.ast.visit(collector)
-          end
-        end
-      end
+      _WorkspaceWalk(packages, collector)
       collector.result()
     | None => None
     end

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -41,15 +41,7 @@ primitive References
       end
     end
 
-    for pkg_state in packages.values() do
-      match pkg_state.package()
-      | let pkg: Package =>
-        for module in pkg.modules() do
-          collector.set_file(module.file)
-          module.ast.visit(collector)
-        end
-      end
-    end
+    _WorkspaceWalk(packages, collector)
     collector.locations()
 
 class ref _ReferenceCollector is ASTVisitor
@@ -58,18 +50,13 @@ class ref _ReferenceCollector is ASTVisitor
   given target definition AST node, across all modules.
   """
   let _target: AST val
-  var _current_file: String
   let _results: Array[LspLocation] ref
   let _seen: Set[String]
 
   new ref create(target: AST val) =>
     _target = target
-    _current_file = ""
     _results = Array[LspLocation].create()
     _seen = Set[String].create()
-
-  fun ref set_file(file: String) =>
-    _current_file = file
 
   fun ref exclude(key: String) =>
     """
@@ -118,18 +105,35 @@ class ref _ReferenceCollector is ASTVisitor
 
       let hl_node = ASTIdentifier.identifier_node(ast)
       (let start_pos, let end_pos) = hl_node.span()
-      // Deduplicate: include file in key since multiple modules share
-      // line numbers. Pre-excluded keys (declaration site) are in _seen.
+      // AST.visit's _from_same_source filter ensures every node visited
+      // during a module's traversal carries that module's source or None.
+      // Nodes with a NULL file pointer (source_open_string paths, reachable
+      // via mixed-source grafting) produce an empty string from
+      // String.copy_cstring rather than None, so we guard both cases.
+      let file: String val =
+        try
+          hl_node.source_file() as String val
+        else
+          return Continue
+        end
+      if file.size() == 0 then
+        return Continue
+      end
+      // Deduplicate using the node's own source file (not the walking module's
+      // file): a grafted node retains its original source, so this key is
+      // stable across packages. Pre-excluded keys (declaration site) are in
+      // _seen; file is included because modules across packages share line
+      // numbers.
       let key: String val =
         recover val
-          _current_file + ":" + start_pos.line().string() +
+          file + ":" + start_pos.line().string() +
           ":" + start_pos.column().string()
         end
       if not _seen.contains(key) then
         _seen.set(key)
         _results.push(
           LspLocation(
-            Uris.from_path(_current_file),
+            Uris.from_path(file),
             LspPositionRange(
               LspPosition.from_ast_pos(start_pos),
               LspPosition.from_ast_pos_end(end_pos))))

--- a/tools/pony-lsp/workspace/type_hierarchy.pony
+++ b/tools/pony-lsp/workspace/type_hierarchy.pony
@@ -44,14 +44,7 @@ primitive TypeHierarchy
     match \exhaustive\ _entity_for_node(node)
     | let entity: AST val =>
       let collector = _SubtypeCollector(entity)
-      for pkg_state in packages.values() do
-        match pkg_state.package()
-        | let pkg: Package =>
-          for module in pkg.modules() do
-            module.ast.visit(collector)
-          end
-        end
-      end
+      _WorkspaceWalk(packages, collector)
       collector.result()
     | None => None
     end


### PR DESCRIPTION
## Context

`references.pony`, `call_hierarchy.pony`, and `type_hierarchy.pony` each contain an identical loop iterating over every compiled module AST across all tracked packages.

## Changes

This PR extracts that loop into a single `_WorkspaceWalk` primitive:

- Add `_WorkspaceWalk` primitive (`workspace/_workspace_walk.pony`) with a documented `apply` that walks all compiled modules across all packages in the workspace
- Replace the duplicated loop in `References`, `CallHierarchy`, and `TypeHierarchy` with calls to `_WorkspaceWalk`
- Add a cross-package references integration test (`_RefsCrossPackageTest`) with a two-file fixture (`ref_base/` sub-package + `ref_base_user.pony`) to verify `_WorkspaceWalk` traverses both packages

## Considerations

- `Stop` returned by a visitor is module-scoped — it aborts the current module's traversal but the walk continues with the next module. This is documented in `_WorkspaceWalk`'s docstring and is pre-existing behaviour, not introduced by this PR.