### PR TITLE
Fix compiler crash when combining `iftype` and `as`

### DIFF
--- a/.release-notes/fix-iftype-as-crash.md
+++ b/.release-notes/fix-iftype-as-crash.md
@@ -1,0 +1,21 @@
+## Fix compiler crash when combining `iftype` and `as`
+
+Previously, applying `as` to the result of an `iftype` expression that contained a method call on a narrowed type parameter would crash the compiler with an internal assertion failure (ponylang/ponyc#2042):
+
+```pony
+class LitString
+interface AST
+interface HasDocs
+  fun val docs(): (LitString | None)
+
+actor Main
+  new create(env: Env) => None
+  fun foo[A: AST val](node: A) =>
+    try
+      iftype A <: HasDocs
+      then node.docs()
+      end as LitString
+    end
+```
+
+The compiler now compiles this code correctly.

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -930,6 +930,12 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
   ast_t* pattern = ast_pop(ast_child(pattern_root));
   ast_free(pattern_root);
 
+  // Detach expr from ast so REPLACE reuses it directly rather than
+  // duplicating it. Duplicating would leave AST data pointers in expr
+  // (e.g. typeparamref data pointing into an iftype's typeparam_store)
+  // pointing at the original subtree, which ast_replace then frees.
+  ast_pop(ast);
+
   REPLACE(astp,
     NODE(TK_MATCH, AST_SCOPE
       NODE(TK_SEQ, TREE(expr))

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -308,3 +308,95 @@ TEST_F(IftypeTest, InsideLambda)
 
     TEST_COMPILE(src);
 }
+
+TEST_F(IftypeTest, AsAroundIftypeWithNarrowedCall)
+{
+  // Regression test for #2042: `as` wrapping an `iftype` whose body calls a
+  // method on a narrowed type parameter previously crashed the compiler with
+  // a use-after-free during AST replacement in expr_as.
+  const char* src =
+    "class LitString\n"
+    "interface AST\n"
+    "interface HasDocs\n"
+    "  fun val docs(): (LitString | None)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun foo[A: AST val](node: A) =>\n"
+    "    try\n"
+    "      iftype A <: HasDocs\n"
+    "      then node.docs()\n"
+    "      end as LitString\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(IftypeTest, AsAroundIftypeTupleTypeparam)
+{
+  // Variant of #2042 with a tuple typeparam constraint that narrows two
+  // type parameters at once.
+  const char* src =
+    "class LitString\n"
+    "interface AST\n"
+    "interface HasDocs\n"
+    "  fun val docs(): (LitString | None)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun foo[A: AST val, B: AST val](a: A, b: B) =>\n"
+    "    try\n"
+    "      iftype (A, B) <: (HasDocs, HasDocs)\n"
+    "      then a.docs()\n"
+    "      end as LitString\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(IftypeTest, AsAroundNestedIftypeWithNarrowedCall)
+{
+  // Variant of #2042 with a doubly-nested iftype that narrows the same
+  // type parameter further before the method call.
+  const char* src =
+    "class LitString\n"
+    "interface AST\n"
+    "interface HasText\n"
+    "interface HasDocs is HasText\n"
+    "  fun val docs(): (LitString | None)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun foo[A: AST val](node: A) =>\n"
+    "    try\n"
+    "      iftype A <: HasText then\n"
+    "        iftype A <: HasDocs\n"
+    "        then node.docs()\n"
+    "        end\n"
+    "      end as LitString\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(IftypeTest, AsTupleAroundIftypeWithNarrowedCall)
+{
+  // Variant of #2042 with a tuple target type, exercising add_as_type's
+  // tuple-recursion branch.
+  const char* src =
+    "class LitString\n"
+    "interface AST\n"
+    "interface HasDocs\n"
+    "  fun val docs(): (LitString, LitString)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun foo[A: AST val](node: A) =>\n"
+    "    try\n"
+    "      iftype A <: HasDocs\n"
+    "      then node.docs()\n"
+    "      end as (LitString, LitString)\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
Wrapping an `iftype` expression with `as` would crash the compiler with an internal assertion (`ast != NULL`) when the iftype body called a method on a narrowed type parameter. The crash dated to PR #1981, which changed `as` to desugar via `match`.

Root cause: `expr_as`'s `REPLACE` ran `TREE(expr)` while `expr` was still parented to the original `TK_AS` node. `ast_add` therefore duplicated `expr` via `ast_dup`, which copies node `data` pointers verbatim. The duplicate's typeparamref nodes kept their `data` pointers aimed at the original iftype's `typeparam_store`. `ast_replace` then freed the original `TK_AS` subtree, including those typeparam definitions, leaving the in-tree duplicates pointing at pool-freed memory. The verify pass dereferenced one of those dangling pointers via `lookup_typeparam` and crashed.

Fix: detach `expr` from the old `TK_AS` (via `ast_pop`) before `REPLACE`, so it is reused in place rather than duplicated.

Test coverage: four regression tests in `test/libponyc/iftype.cc` — the original repro from #2042 plus three shape variants (tuple typeparam constraint, doubly-nested iftype, tuple target type). Each was counterfactual-verified to crash on this commit's parent and pass on this commit.

Closes #2042