### PR TITLE
Fix missing question mark check for partial calls in trait default bodies

### DIFF
--- a/.release-notes/fix-trait-partial-call-question-mark.md
+++ b/.release-notes/fix-trait-partial-call-question-mark.md
@@ -1,0 +1,21 @@
+## Fix missing question mark check for partial calls in trait default bodies
+
+Calling a partial method without `?` inside a trait's default method body now correctly produces a compile error, matching the behavior of primitives and interfaces.
+
+Previously, code like this compiled silently:
+
+```pony
+trait T
+  fun f1() ? => error
+  fun f2() ? => f1()    // missing `?`, but compiler did not complain
+```
+
+The same code in a primitive or interface correctly errored; only traits were affected.
+
+If your code was relying on this missing check, add the `?` to the call site:
+
+```pony
+trait T
+  fun f1() ? => error
+  fun f2() ? => f1()?
+```

--- a/src/libponyc/verify/call.c
+++ b/src/libponyc/verify/call.c
@@ -48,7 +48,8 @@ static bool check_partial_function_call(pass_opt_t* opt, ast_t* ast)
   // from a trait, we don't want to check partiality of the call site here -
   // it should only be checked in the context of the original trait.
   ast_t* body_donor = (ast_t*)ast_data(opt->check.frame->method);
-  if((body_donor != NULL) && (ast_id(body_donor) == TK_TRAIT))
+  if((body_donor != NULL) && (ast_id(body_donor) == TK_TRAIT)
+    && (opt->check.frame->type != body_donor))
     skip_partial_check = true;
 
   // Verify that the call partiality matches that of the method.

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -492,6 +492,93 @@ TEST_F(VerifyTest, InterfaceNonPartialFunctionError)
     "function body can raise an error");
 }
 
+TEST_F(VerifyTest, TraitPartialCallMissingQuestionMark)
+{
+  const char* src =
+    "trait T\n"
+    "  fun f1() ? => error\n"
+    "  fun f2() ? => f1()";
+
+  TEST_ERRORS_1(src, "call is not partial but the method is");
+}
+
+TEST_F(VerifyTest, TraitPartialCallWithQuestionMark)
+{
+  const char* src =
+    "trait T\n"
+    "  fun f1() ? => error\n"
+    "  fun f2() ? => f1()?";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, TraitPartialChainCallMissingQuestionMark)
+{
+  const char* src =
+    "trait T\n"
+    "  fun f1() ? => error\n"
+    "  fun f2() ? => this.>f1()";
+
+  TEST_ERRORS_1(src, "call is not partial but the method is");
+}
+
+TEST_F(VerifyTest, TraitNonPartialCallWithQuestionMark)
+{
+  const char* src =
+    "trait T\n"
+    "  fun f1() => None\n"
+    "  fun f2() => f1()?";
+
+  TEST_ERRORS_1(src, "call is partial but the method is not");
+}
+
+TEST_F(VerifyTest, TraitPartialConstructorCallMissingQuestionMark)
+{
+  const char* src =
+    "class C\n"
+    "  new partial() ? => error\n"
+    "trait T\n"
+    "  fun f() ? => C.partial()";
+
+  TEST_ERRORS_1(src, "call is not partial but the method is");
+}
+
+TEST_F(VerifyTest, TraitInheritsTraitPartialBodyStillCompiles)
+{
+  const char* src =
+    "trait T1\n"
+    "  fun f1() ? => error\n"
+    "  fun f2() ? => f1()?\n"
+    "trait T2 is T1\n"
+    "class C is T2";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, TraitInheritsTraitPartialCallMissingQuestionMark)
+{
+  const char* src =
+    "trait T1\n"
+    "  fun f1() ? => error\n"
+    "trait T2 is T1\n"
+    "  fun f2() ? => f1()";
+
+  TEST_ERRORS_1(src, "call is not partial but the method is");
+}
+
+// Defensive regression: interfaces have always errored correctly here
+// (the trait-skip in verify/call.c only matches TK_TRAIT). This guards
+// against accidentally broadening that skip to interfaces.
+TEST_F(VerifyTest, InterfacePartialCallMissingQuestionMark)
+{
+  const char* src =
+    "interface I\n"
+    "  fun f1() ? => error\n"
+    "  fun f2() ? => f1()";
+
+  TEST_ERRORS_1(src, "call is not partial but the method is");
+}
+
 TEST_F(VerifyTest, IfTypeError)
 {
   const char* src =


### PR DESCRIPTION
Partial method calls inside a trait's own default method body were not required to have `?`. The same code in a primitive or interface correctly errored — only traits let it through silently.

The skip in `src/libponyc/verify/call.c` that suppresses partial-call checking when a body is inherited from a trait was firing both for inheriting types (correct — the trait will be checked) and for the trait itself (wrong — the check never ran anywhere). Adding the third clause `frame->type != body_donor` matches the shape of the analogous skip in `src/libponyc/expr/match.c` and lets the check fire when verifying the donor trait.

Code review surfaced #5332 as a pre-existing duplicate-error bug that this fix newly exposes inside trait default bodies. Tracked separately.

Closes #2266