### PR TITLE
Fix typecheck assertion failure on loops whose branches all jump away

### DIFF
--- a/.release-notes/fix-loop-jumps-away-in-separate-function.md
+++ b/.release-notes/fix-loop-jumps-away-in-separate-function.md
@@ -1,0 +1,22 @@
+## Fix typecheck assertion failure on loops whose branches all jump away
+
+Previously, defining a loop whose body and else clause both jump away (for example, a `while` with `break` in the body and `return` in the else) inside a function other than `create` triggered an internal compiler assertion:
+
+```pony
+actor Main
+  fun a() =>
+    while true do
+      break
+    else
+      return
+    end
+
+  new create(env: Env) =>
+    a()
+```
+
+```
+src/libponyc/pass/expr.c:698: pass_expr: Assertion `errors_get_count(options->check.errors) > 0` failed.
+```
+
+This has been fixed. Loops whose branches all jump away now compile correctly.

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -31,6 +31,12 @@ bool expr_seq(pass_opt_t* opt, ast_t* ast)
 
     if(is_typecheck_error(p_type))
     {
+      // An expression that jumps away with no value legitimately has a NULL
+      // type — that's not a typecheck error. Skip it without flagging,
+      // otherwise we set ok=false and return false without registering an
+      // error, tripping the "errors must be > 0" assertion in pass_expr.
+      if(ast_checkflag(p, AST_FLAG_JUMPS_AWAY))
+        continue;
       ok = false;
     } else if(is_type_literal(p_type)) {
       ast_error(opt->check.errors, p, "Cannot infer type of unused literal");

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -2034,3 +2034,91 @@ TEST_F(BadPonyTest, FBoundedTraitWithSelfApplyEmitsConstraintError)
     "type argument is outside its constraint",
     "type argument is outside its constraint");
 }
+
+TEST_F(BadPonyTest, WhileBodyAndElseJumpAwayInSeparateFunction)
+{
+  // From issue #2792 (first example). A while loop whose body and else
+  // both jump away (break + return) used to trigger a typecheck assertion
+  // when the loop appeared in a separate function rather than directly in
+  // create. expr_seq tried to type the jumps-away while and reported a
+  // typecheck error without registering an actual error message,
+  // tripping the "errors must be > 0" assertion in pass_expr.
+  const char* src =
+    "actor Main\n"
+    "  fun a() =>\n"
+    "    while true do\n"
+    "      break\n"
+    "    else\n"
+    "      return\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    a()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, RepeatBodyAndElseJumpAwayInSeparateFunction)
+{
+  // Same shape as WhileBodyAndElseJumpAwayInSeparateFunction but for
+  // repeat. The fix in expr_seq is loop-agnostic; this guards against a
+  // future regression that special-cases one loop kind.
+  const char* src =
+    "actor Main\n"
+    "  fun a() =>\n"
+    "    repeat\n"
+    "      break\n"
+    "    until true\n"
+    "    else\n"
+    "      return\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    a()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, WhileWithLiteralBreakValueAndJumpsAwayElse)
+{
+  // Regression test for the literal-break-value variant of #2792. A while
+  // whose body breaks with a literal value and whose else jumps away
+  // gives the loop a literal type. The fix for #2792 must not skip the
+  // unused-literal check on jumps-away children, otherwise the literal
+  // type propagates to codegen and trips a reach.c assertion.
+  const char* src =
+    "actor Main\n"
+    "  fun a(): U32 =>\n"
+    "    while true do\n"
+    "      break 5\n"
+    "    else\n"
+    "      return 6\n"
+    "    end\n"
+    "    7\n"
+
+    "  new create(env: Env) =>\n"
+    "    a()";
+
+  TEST_ERRORS_1(src, "Cannot infer type of unused literal");
+}
+
+TEST_F(BadPonyTest, RepeatWithLiteralBreakValueAndJumpsAwayElse)
+{
+  // Same shape as WhileWithLiteralBreakValueAndJumpsAwayElse but for
+  // repeat.
+  const char* src =
+    "actor Main\n"
+    "  fun a(): U32 =>\n"
+    "    repeat\n"
+    "      break 5\n"
+    "    until true\n"
+    "    else\n"
+    "      return 6\n"
+    "    end\n"
+    "    7\n"
+
+    "  new create(env: Env) =>\n"
+    "    a()";
+
+  TEST_ERRORS_1(src, "Cannot infer type of unused literal");
+}


### PR DESCRIPTION
A `while` or `repeat` loop with body and else clauses that both jump away triggered a `pass_expr.c:698` assertion failure when the loop appeared in a function other than `create`:

```pony
actor Main
  fun a() =>
    while true do
      break
    else
      return
    end

  new create(env: Env) =>
    a()
```

`expr_seq` treated the jumps-away loop's NULL type as a typecheck error, set `ok=false`, and returned without registering a diagnostic — tripping the "errors must be > 0" assertion.

The fix skips the typecheck-error path for jumps-away children. The unused-literal check is preserved, so a loop carrying a literal type from a `break LITERAL` body (e.g. `break 5` in a fully-jumping loop) still produces a clean "Cannot infer type of unused literal" diagnostic instead of propagating the literal type to codegen and asserting in reach.c.

Based on the diff jemc proposed in [a comment on #2792](https://github.com/ponylang/ponyc/issues/2792#issuecomment-405574486), narrowed during review to keep the unused-literal check firing.

The "ghost unreachable code" variant of #2792 (the second example in that issue — a synthesized implicit `None` is reported as unreachable, with the carat pointing at unrelated user code) is split out as #5331 and not addressed here.

Design: #2792