### PR TITLE
Fix `SymbolKinds.array()` returning wrong LSP symbol kind constant

### DIFF
--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -24,7 +24,7 @@ primitive SymbolKinds
   fun string(): I64 => 15
   fun number(): I64 => 16
   fun boolean(): I64 => 17
-  fun array(): I64 => 8
+  fun array(): I64 => 18
   fun sk_object(): I64 => 19
   fun key(): I64 => 20
   fun null(): I64 => 21

--- a/tools/pony-lsp/test/_symbol_kinds_tests.pony
+++ b/tools/pony-lsp/test/_symbol_kinds_tests.pony
@@ -1,0 +1,15 @@
+use "pony_test"
+use ".."
+
+primitive _SymbolKindsTests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_SymbolKindsArrayTest)
+
+class \nodoc\ iso _SymbolKindsArrayTest is UnitTest
+  fun name(): String => "symbol_kinds/array"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[I64](18, SymbolKinds.array())

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -23,6 +23,7 @@ actor Main is TestList
     test(_PrepareMissingURITest)
     _WorkspaceTests.make().tests(test)
     _InlayHintSourceTests.make().tests(test)
+    _SymbolKindsTests.make().tests(test)
     _HoverFormatterTests.make().tests(test)
     _DiagnosticTests.make().tests(test)
     _HoverIntegrationTests.make().tests(test)


### PR DESCRIPTION
## Context

`SymbolKinds.array()` in `tools/pony-lsp/symbols.pony` returns `8`, which is the LSP `Field` constant. The correct value per the [LSP `SymbolKind` specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind) is `18` (`Array`). The constant `field()` already correctly returns `8` on line 17, making `array()` a duplicate of the wrong kind.

Nothing in the codebase currently calls `SymbolKinds.array()`, so this is a latent bug — but it's a wrong value in a public API.

## Changes

- Corrects `SymbolKinds.array()` from `8` to `18`
- Adds a `symbol_kinds/array` unit test asserting the correct value

## Considerations

No behaviour change to the running LSP server — no existing code path calls this constant. The fix prevents the wrong value from being used if a caller is added in future.