### PR TITLE
Fix compiler crash on partial application of method with literal-call default

### DIFF
--- a/.release-notes/fix-2480.md
+++ b/.release-notes/fix-2480.md
@@ -1,0 +1,21 @@
+## Fix compiler crash when partially applying a method with a literal-call default argument
+
+Partial application of a method whose default argument desugared to a single call on a literal (for example, `USize = -1`, which the sugar pass rewrites as `(1).neg()`) used to crash the compiler with an internal assertion. The simplest reproducer was the one from the original report:
+
+```pony
+use "format"
+
+actor Main
+  new create(env: Env) =>
+    Format~apply()
+```
+
+That produced something like:
+
+```
+src/libponyc/type/lookup.c:606: lookup_base: Assertion `0` failed.
+```
+
+The crash is gone. Code that partially applies methods with this kind of default (including binary-op defaults like `USize = 1 + 1` and constructor partials with literal defaults) now compiles and runs.
+
+Note: nested literal-method-call defaults like `USize = (-1).abs()` still crash with a different assertion. That is a related-but-distinct bug tracked as #5342.

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -958,6 +958,13 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
       AST_GET_CHILDREN(target_param, p_id, p_type, p_default);
 
       // Parameter: `b: B = b_default`
+      // p_default is dup'd from the target method's already-coerced
+      // default. After this lambda is lifted to an anonymous class by
+      // expr_object (in expr/lambda.c), ast_resetpass strips pass flags
+      // on the dup'd subtree and expr re-runs on it. make_literal_type
+      // in expr/literal.c guards against retyping the leaf literals back
+      // to TK_LITERAL; keep that invariant in mind if you change how the
+      // default is propagated here.
       BUILD(lambda_param, target_param,
         NODE(TK_PARAM,
           TREE(p_id)

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -917,6 +917,14 @@ bool expr_object(pass_opt_t* opt, ast_t** astp)
   }
 
   ast_free_unattached(captures);
+
+  // Resetting pass flags on the whole def causes the expr pass to
+  // re-walk subtrees that were duplicated from already-processed code
+  // (notably parameter defaults dup'd by partial_application in
+  // expr/call.c). Re-walking nodes whose types have already been
+  // coerced is what make_literal_type's idempotency guard in
+  // expr/literal.c exists to tolerate. If you change this reset, make
+  // sure callers downstream still cope with already-typed leaves.
   ast_resetpass(def, PASS_SUGAR);
 
   // Handle capability and whether the anonymous type is a class, primitive or

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -126,6 +126,20 @@ bool expr_literal(pass_opt_t* opt, ast_t* ast, const char* name)
 
 void make_literal_type(ast_t* ast)
 {
+  // Don't overwrite a previously-coerced concrete type. The expr pass
+  // can re-run on an already-typed node when defaults are duplicated
+  // into a partial-application lambda that gets lifted to an anonymous
+  // class whose pass flags are reset (see partial_application in
+  // expr/call.c and expr_object in expr/lambda.c). Overwriting a
+  // concrete type with TK_LITERAL leaves the enclosing expression
+  // inconsistent with its children and trips an assertion later in
+  // `lookup`. TK_INFERTYPE is the one re-type request we honour: it is
+  // set deliberately by on-demand default-arg typing in `lookup` to ask
+  // for re-typing.
+  ast_t* existing = ast_type(ast);
+  if(existing != NULL && ast_id(existing) != TK_INFERTYPE)
+    return;
+
   ast_t* type = ast_from(ast, TK_LITERAL);
   ast_settype(ast, type);
 }

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -673,15 +673,9 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
 
     case TK_INT:
     case TK_FLOAT:
-      // Integer literals can be integers or floats. Skip if a concrete
-      // type was already assigned: the expr pass can re-run on a literal
-      // whose type was previously coerced (e.g. a default expression
-      // duplicated into a partial-application lambda that gets lifted to
-      // an anonymous class whose pass flags are reset). Overwriting that
-      // type with TK_LITERAL leaves the enclosing call inconsistent with
-      // its receiver and trips an assertion later in `lookup`.
-      if(ast_type(ast) == NULL)
-        make_literal_type(ast);
+      // Integer literals can be integers or floats. make_literal_type
+      // handles the "already coerced" case internally.
+      make_literal_type(ast);
       break;
 
     case TK_STRING:

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -672,12 +672,16 @@ ast_result_t pass_expr(ast_t** astp, pass_opt_t* options)
       break;
 
     case TK_INT:
-      // Integer literals can be integers or floats
-      make_literal_type(ast);
-      break;
-
     case TK_FLOAT:
-      make_literal_type(ast);
+      // Integer literals can be integers or floats. Skip if a concrete
+      // type was already assigned: the expr pass can re-run on a literal
+      // whose type was previously coerced (e.g. a default expression
+      // duplicated into a partial-application lambda that gets lifted to
+      // an anonymous class whose pass flags are reset). Overwriting that
+      // type with TK_LITERAL leaves the enclosing call inconsistent with
+      // its receiver and trips an assertion later in `lookup`.
+      if(ast_type(ast) == NULL)
+        make_literal_type(ast);
       break;
 
     case TK_STRING:

--- a/test/full-program-tests/partial-application-method-literal-default/main.pony
+++ b/test/full-program-tests/partial-application-method-literal-default/main.pony
@@ -1,0 +1,57 @@
+// Regression test for issue #2480.
+//
+// Partial application of a method whose default argument contains a call
+// on a literal (e.g. `USize = -1`, which sugars to `(1).neg()`) used to
+// crash the compiler with an internal assertion. The default expression
+// was duplicated into the synthesized lambda's apply method, that lambda
+// was lifted to an anonymous class whose pass flags got reset, and
+// re-running expr on the literal overwrote its coerced USize type with
+// TK_LITERAL, leaving the enclosing call's funref inconsistent with its
+// receiver.
+//
+// If the bug ever returns, this test will fail to compile.
+//
+// Note: nested literal-method-call defaults like `(-1).abs()` still
+// crash the compiler with a separate `uifset` assertion. That is a
+// related-but-distinct bug tracked as #5342.
+
+primitive _Int2480
+  fun apply(x: USize = -1): USize => x
+
+primitive _Float2480
+  fun apply(x: F64 = -1.0): F64 => x
+
+primitive _IntBinaryOp2480
+  fun apply(x: USize = 1 + 1): USize => x
+
+primitive _FloatBinaryOp2480
+  fun apply(x: F64 = 1.0 + 1.0): F64 => x
+
+class _Class2480
+  let v: USize
+  new create(v': USize = -1) =>
+    v = v'
+
+actor Main
+  new create(env: Env) =>
+    let i = _Int2480~apply()
+    let f = _Float2480~apply()
+    let bi = _IntBinaryOp2480~apply()
+    let bf = _FloatBinaryOp2480~apply()
+
+    // The constructor partial is exercised at compile time. The resulting
+    // lambda value is awkward to invoke (val lambda over a ref method),
+    // but the partial_application code path is the same one the bug hit
+    // and it's what we need to compile cleanly.
+    let ctor_partial = _Class2480~create()
+
+    // Build a bitmask so any combination of failures is observable. Using
+    // a single shared `env.exitcode` call (last-write-wins) would hide a
+    // lower-numbered failure when a higher-numbered one also fires.
+    var fails: I32 = 0
+    if i() != USize.max_value() then fails = fails or 1 end
+    if f() != -1.0 then fails = fails or 2 end
+    if bi() != 2 then fails = fails or 4 end
+    if bf() != 2.0 then fails = fails or 8 end
+
+    env.exitcode(fails)


### PR DESCRIPTION
## Summary

Partially applying a method whose default desugars to a single call on a literal (e.g. `USize = -1` → `(1).neg()`) crashed the compiler with an assertion in `lookup_base`. The duplicated default got re-walked after pass flags were reset on the lifted lambda's anonymous class, and `make_literal_type` clobbered the previously-coerced concrete type. Fix is a guard inside `make_literal_type` so it doesn't overwrite an already-set type (except `TK_INFERTYPE`, which is the explicit "please re-type me" marker that `lookup`'s on-demand default-arg typing uses).

This is a targeted fix at the symptom site rather than a principled fix at the `ast_resetpass`-then-rewalk cycle that creates the inconsistent state. The first commit's message explains the trade-off. The follow-up commit centralizes the guard (it now covers all five callers of `make_literal_type`, not just the `TK_INT`/`TK_FLOAT` case in `pass_expr`) and adds pointer comments at the two sites that create the hazard.

Closes #2480
Closes #3727

## Related

The fix doesn't cover all sibling crashes. Nested literal-method-call defaults like `USize = (-1).abs()` still crash with a different assertion (`uifset:484`). Filed as #5342.