### PR TITLE
Fix LSP hover for lambda types

### DIFF
--- a/.release-notes/lsp-fix-lambda-type-hover.md
+++ b/.release-notes/lsp-fix-lambda-type-hover.md
@@ -1,0 +1,15 @@
+## Fix LSP hover for lambda types
+
+Hovering over a field, parameter, or variable with a lambda type annotation now shows the human-readable lambda type instead of a compiler-internal hygienic ID.
+
+Before:
+
+```pony
+let _callback: $0 val
+```
+
+After:
+
+```pony
+let _callback: {(String val): None val} val
+```

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -25,6 +25,7 @@ primitive _HoverIntegrationTests is TestList
     test(_HoverIntegrationLiteralsTest.create(server))
     test(_HoverIntegrationCapKeywordTest.create(server))
     test(_HoverIntegrationFieldDocstringTest.create(server))
+    test(_HoverIntegrationLambdaTest.create(server))
 
 class \nodoc\ iso _HoverIntegrationLiteralsTest is UnitTest
   let _server: _LspTestServer
@@ -643,6 +644,32 @@ class \nodoc\ iso _HoverIntegrationFieldDocstringTest is UnitTest
           11,
           4,
           ["let documented_field: String val"; "Has a docstring."])])
+
+class \nodoc\ iso _HoverIntegrationLambdaTest is UnitTest
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String => "hover/integration/lambda"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "hover/_lambda.pony",
+      [ // field with lambda type
+        _HoverChecker(5, 6, ["let _callback: {(String val): None val} val"])
+        // constructor parameter with lambda type
+        _HoverChecker(7, 13, ["callback: {(String val): None val} val"])
+        // local variable assigned a no-arg lambda (inferred type)
+        _HoverChecker(11, 8, ["let f: {(): String} val"])
+        // local variable assigned a lambda with parameters (inferred type)
+        _HoverChecker(12, 8, ["let add: {(U32, U32): U32} val"])
+        // method parameter with lambda type — declaration site
+        _HoverChecker(15, 24, ["callback: {(U32 val): String val} val"])
+        // method parameter with lambda type — usage site follows to declaration
+        _HoverChecker(16, 4, ["callback: {(U32 val): String val} val"])])
 
 class val _HoverChecker
   let _line: I64

--- a/tools/pony-lsp/test/workspace/hover/_lambda.pony
+++ b/tools/pony-lsp/test/workspace/hover/_lambda.pony
@@ -1,0 +1,17 @@
+class _Lambda
+  """
+  Demonstrates hover on lambda types.
+  """
+
+  let _callback: {(String val): None val} val
+
+  new create(callback: {(String val): None val} val) =>
+    _callback = callback
+
+  fun demo_lambda_local_vars(): String =>
+    let f = {(): String => "hello" }
+    let add = {(a: U32, b: U32): U32 => a + b }
+    f() + add(1, 2).string()
+
+  fun demo_lambda_param(callback: {(U32 val): String val} val): String =>
+    callback(42)

--- a/tools/pony-lsp/workspace/_type_formatter.pony
+++ b/tools/pony-lsp/workspace/_type_formatter.pony
@@ -17,11 +17,25 @@ primitive _TypeFormatter
         let num_children = type_node.num_children()
         if num_children > 1 then
           let type_id = type_node(1)?
-          let base_name =
-            if type_id.id() == TokenIds.tk_id() then
-              type_id.token_value() as String
+          // Lambda literals become anonymous classes with hygienic IDs (e.g.
+          // "$0"). The human-readable form (e.g. "{(): String val}") is stored
+          // as the nice_name on the definition's first child, matching what
+          // ast_print_type does in C.
+          let base_name: String =
+            try
+              let def = type_node.definitions()(0)?
+              let def_name = def.apply(0)?
+              if def_name.id() == TokenIds.tk_id() then
+                def_name.nice_name()
+              else
+                error
+              end
             else
-              extract_type(type_id)
+              if type_id.id() == TokenIds.tk_id() then
+                type_id.token_value() as String
+              else
+                extract_type(type_id)
+              end
             end
 
           // Check for type arguments


### PR DESCRIPTION
## Context

`_TypeFormatter.extract_type` uses `token_value()` to extract the name from a nominal type's ID node. For most types this returns the type name correctly, but lambda literals desugar to anonymous classes with compiler-generated hygienic IDs (e.g. `$0`), so hover shows `$0 val` instead of the human-readable lambda type.

## Changes

- `_TypeFormatter.extract_type`: when processing a nominal type, resolve its definition and use `def.apply(0)?.nice_name()` to get the human-readable name. This matches what `ast_print_type` does in C — the nice name (e.g. `{(String val): None val}`) is stored on the definition's first child ID node. Falls back to the previous `token_value()` path when no definition is available.
- Add hover fixture `tools/pony-lsp/test/workspace/hover/_lambda.pony` with fields, constructor/method parameters, and local variables using lambda types.
- Add `_HoverIntegrationLambdaTest` covering declaration and usage sites for explicit lambda type annotations, and local variables holding lambda literals.

## Considerations

Lambda literals without explicit inner capabilities (e.g. `let f = {(): String => "hello"}`) show types without inferred capabilities (`{(): String} val` rather than `{(): String val} val`). This is a known limitation of when `expr_lambda` builds the nice name string in C, and is left as a follow-up.