### PR TITLE
Fix TCPConnection writeable state after hard close on Windows

### DIFF
--- a/.release-notes/5346.md
+++ b/.release-notes/5346.md
@@ -1,0 +1,6 @@
+## Fix TCPConnection writeable state after hard close on Windows
+
+Late IOCP completion notifications can no longer mark a `TCPConnection` as
+readable or writeable after `hard_close`. The flags are now updated only when
+the connection is still connected and not closed, preventing further read and
+write attempts from being scheduled on a closed connection.

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,3 +1,7 @@
+## Fix TCPConnection writeable state after hard close on Windows
+
+Late IOCP completion notifications can no longer mark a `TCPConnection` as readable or writeable after `hard_close`.
+
 ## Fix IOCP use-after-free crash
 
 The fix for this issue in 0.62.0 was incomplete. That fix checked for specific Windows error codes (`ERROR_OPERATION_ABORTED` and `ERROR_NETNAME_DELETED`) in the IOCP completion callback to detect orphaned I/O operations. However, Windows can deliver completions with other error codes after the socket is closed, and `ERROR_NETNAME_DELETED` can also arrive from legitimate remote peer disconnects — making error-code matching the wrong approach entirely.

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,7 +1,3 @@
-## Fix TCPConnection writeable state after hard close on Windows
-
-Late IOCP completion notifications can no longer mark a `TCPConnection` as readable or writeable after `hard_close`.
-
 ## Fix IOCP use-after-free crash
 
 The fix for this issue in 0.62.0 was incomplete. That fix checked for specific Windows error codes (`ERROR_OPERATION_ABORTED` and `ERROR_NETNAME_DELETED`) in the IOCP completion callback to detect orphaned I/O operations. However, Windows can deliver completions with other error codes after the socket is closed, and `ERROR_NETNAME_DELETED` can also arrive from legitimate remote peer disconnects — making error-code matching the wrong approach entirely.

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -648,7 +648,9 @@ actor TCPConnection is AsioEventNotify
     else
       // At this point, it's our event.
       if AsioEvent.writeable(flags) then
-        _writeable = true
+        if _connected and not _closed then
+          _writeable = true
+        end
         _complete_writes(arg)
         ifdef not windows then
           if _pending_writes() then
@@ -659,7 +661,9 @@ actor TCPConnection is AsioEventNotify
       end
 
       if AsioEvent.readable(flags) then
-        _readable = true
+        if _connected and not _closed then
+          _readable = true
+        end
         _complete_reads(arg)
         _pending_reads()
       end


### PR DESCRIPTION
## Summary
Guards `_writeable = true` and `_readable = true` in `TCPConnection._event_notify` (Windows IOCP path) on `_connected and not _closed`, so late-arriving IOCP cancellation completions can't resurrect the flags after `hard_close`.

## Why this matters
`hard_close` sets `_writeable = false`, calls `@pony_asio_event_unsubscribe(_event)`, then `@pony_os_socket_close(_fd)` which cancels outstanding IOCP operations. Those cancellations deliver completion notifications, and any that race in to `_event_notify` before teardown completes would flip the flag back to `true`. That violates the documented post-condition of `hard_close` (the connection is dead and not writeable).

Today this is latent. No code in `tcp_connection.pony` reads `_writeable` after `_connected = false`, so nothing observably misbehaves. Any future change that adds a read on that path would silently misbehave.

Surfaced during review of #5317 (the missing-`else` IOCP fix) and filed as #5318. The POSIX path doesn't have the same race shape, so the guard is Windows-only.

## Testing
Existing PonyTest TCP suite (`packages/net/_test.pony`) passes. The bug is unobservable without a future code path that reads `_writeable` post-`hard_close`, so no new regression test is included.

Fixes #5318