### PR TITLE
Fix delivery of zero-byte UDP datagrams

### DIFF
--- a/.release-notes/5347.md
+++ b/.release-notes/5347.md
@@ -1,0 +1,6 @@
+## Fix delivery of zero-byte UDP datagrams
+
+UDP sockets now deliver zero-byte datagrams to `UDPNotify.received` with an
+empty payload instead of treating them as an error. This preserves valid UDP
+uses such as heartbeat, keepalive, and presence datagrams without changing TCP
+zero-byte read handling.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -27,6 +27,7 @@ actor \nodoc\ Main is TestList
     test(_TestTCPProxy)
     test(_TestTCPUnmute)
     test(_TestTCPWritev)
+    test(_TestUDPZeroByteDatagram)
 
     // Tests below exclude windows and are listed alphabetically
     ifdef not windows then
@@ -154,6 +155,79 @@ class \nodoc\ iso _TestBroadcast is UnitTest
       If it does, try re-running the tests with the firewall de-activated, or
       exclude this test by passing the --exclude="net/Broadcast" option.
     """)
+
+class \nodoc\ _TestUDPZeroByteDatagramReceiver is UDPNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref not_listening(sock: UDPSocket ref) =>
+    _h.fail_action("receiver listen")
+
+  fun ref listening(sock: UDPSocket ref) =>
+    _h.complete_action("receiver listen")
+
+    let ip = sock.local_address()
+    let h = _h
+    if ip.ip4() then
+      _h.dispose_when_done(
+        UDPSocket.ip4(UDPAuth(h.env.root),
+          recover _TestUDPZeroByteDatagramSender(h, ip) end))
+    else
+      _h.dispose_when_done(
+        UDPSocket.ip6(UDPAuth(h.env.root),
+          recover _TestUDPZeroByteDatagramSender(h, ip) end))
+    end
+
+  fun ref received(
+    sock: UDPSocket ref,
+    data: Array[U8] iso,
+    from: NetAddress)
+  =>
+    _h.complete_action("receiver receive")
+    _h.assert_eq[USize](0, data.size())
+    _h.complete(true)
+
+class \nodoc\ _TestUDPZeroByteDatagramSender is UDPNotify
+  let _h: TestHelper
+  let _ip: NetAddress
+
+  new create(h: TestHelper, ip: NetAddress) =>
+    _h = h
+    _ip = ip
+
+  fun ref not_listening(sock: UDPSocket ref) =>
+    _h.fail_action("sender listen")
+
+  fun ref listening(sock: UDPSocket ref) =>
+    _h.complete_action("sender listen")
+    sock.write("", _ip)
+
+  fun ref received(
+    sock: UDPSocket ref,
+    data: Array[U8] iso,
+    from: NetAddress)
+  =>
+    _h.fail("sender received unexpected datagram")
+
+class \nodoc\ iso _TestUDPZeroByteDatagram is UnitTest
+  """
+  Test receiving an empty UDP datagram.
+  """
+  fun name(): String => "net/UDPZeroByteDatagram"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver listen")
+    h.expect_action("sender listen")
+    h.expect_action("receiver receive")
+
+    h.dispose_when_done(
+      UDPSocket(UDPAuth(h.env.root),
+        recover _TestUDPZeroByteDatagramReceiver(h) end))
+
+    h.long_test(TimeoutValue())
 
 class \nodoc\ _TestTCP is TCPListenNotify
   """

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -216,6 +216,7 @@ class \nodoc\ iso _TestUDPZeroByteDatagram is UnitTest
   Test receiving an empty UDP datagram.
   """
   fun name(): String => "net/UDPZeroByteDatagram"
+  fun label(): String => "unreliable-appveyor-osx"
   fun exclusion_group(): String => "network"
 
   fun ref apply(h: TestHelper) =>

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -290,9 +290,11 @@ actor UDPSocket is AsioEventNotify
 
   fun ref _pending_reads() =>
     """
-    Read while data is available, guessing the next packet length as we go. If
-    we read 4 kb of data, send ourself a resume message and stop reading, to
-    avoid starving other actors.
+    Read while data is available, guessing the next packet length as we go.
+    After roughly 4 KB worth of read work, send ourself a resume message and
+    stop reading, to avoid starving other actors. Zero-byte datagrams count as
+    1 byte against this budget so a stream of empty datagrams cannot keep this
+    loop running forever.
     """
     ifdef not windows then
       try
@@ -314,6 +316,9 @@ actor UDPSocket is AsioEventNotify
           data.truncate(len)
           _notify.received(this, consume data, consume from)
 
+          // .max(1) charges 1 byte against the budget for a zero-byte
+          // datagram, preventing this loop from starving other actors on a
+          // stream of empty datagrams.
           sum = sum + len.max(1)
 
           if sum > (1 << 12) then

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -306,7 +306,7 @@ actor UDPSocket is AsioEventNotify
             @pony_os_recvfrom(_event, data.cpointer(), data.space(),
               from) ?
 
-          if len == 0 then
+          if len == USize.max_value() then
             _readable = false
             return
           end
@@ -314,7 +314,7 @@ actor UDPSocket is AsioEventNotify
           data.truncate(len)
           _notify.received(this, consume data, consume from)
 
-          sum = sum + len
+          sum = sum + len.max(1)
 
           if sum > (1 << 12) then
             _read_again()

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -1119,10 +1119,8 @@ PONY_API size_t pony_os_recvfrom(asio_event_t* ev, char* buf, size_t len,
   if(recvd < 0)
   {
     if(errno == EWOULDBLOCK || errno == EAGAIN)
-      return 0;
+      return (size_t)-1;
 
-    pony_error();
-  } else if(recvd == 0) {
     pony_error();
   }
 


### PR DESCRIPTION
## Summary
`pony_os_recvfrom` no longer treats a zero-byte POSIX `recvfrom` as an error. Zero-byte UDP datagrams are now delivered to `UDPNotify.received` with an empty payload, matching RFC 768. TCP `pony_os_recv` behavior is unchanged.

## Why this matters
RFC 768 says UDP datagrams "may be of any length greater than or equal to zero." Before this change, applications using zero-byte UDP datagrams as heartbeats, keepalives, or presence pings saw the socket torn down because the runtime called `pony_error()` on `recvd == 0`.

Maintainer @SeanTAllen called out the fix shape in the issue thread:
> ...in POSIX `pony_os_recvfrom`, when `received == 0`, return `PONY_SOCKET_OK` with `count_out = 0` instead of falling into the `recv`-style peer-closed branch.

A note on the implementation: `pony_os_recvfrom` still returns `size_t` in this tree (no `PONY_SOCKET_*` enum visible in `src/libponyrt/lang/socket.c`). To match the existing `pony_os_recv` calling convention used elsewhere, this patch uses the existing `(size_t)-1` / `SIZE_MAX` sentinel for "would block / no data" and lets `recvd == 0` fall through as a normal `len == 0` read. `udp_socket.pony` checks `len == USize.max_value()` to mean "no data yet" (replacing the prior `len == 0` check, which now legitimately means "empty datagram"). If the three-state enum design has actually landed somewhere I missed, happy to rewrite to use it.

## Testing
New PonyTest case `_TestUDPZeroByteDatagram` round-trips a zero-byte datagram through a bound UDP socket and asserts the notifier receives `data.size() == 0`. Existing TCP suite is untouched.

Fixes #5289