### PR TITLE
Fix epoll backend losing signal counts on eventfd read failure

### DIFF
--- a/.release-notes/5348.md
+++ b/.release-notes/5348.md
@@ -1,0 +1,7 @@
+## Fix epoll backend losing signal counts on eventfd read failure
+
+The epoll ASIO backend could deliver an uninitialized missed-signal count
+to signal handlers when `read()` on the signal eventfd returned an error.
+On read failure, the backend now waits for the next epoll iteration instead
+of waking signal handlers with a misleading zero count, so handlers only run
+with a real signal count.

--- a/packages/signals/_test.pony
+++ b/packages/signals/_test.pony
@@ -14,6 +14,7 @@ class \nodoc\ _TestSighupNotify is SignalNotify
     _h = h
 
   fun ref apply(count: U32): Bool =>
+    _h.assert_true(count >= 1)
     _h.complete(true)
     false
 

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -73,6 +73,23 @@ static void signal_handler(int sig)
   eventfd_write(ev->fd, 1);
 }
 
+static bool read_signal_count(int fd, uint32_t* out_count)
+{
+  uint64_t missed = 0;
+  ssize_t rc = read(fd, &missed, sizeof(uint64_t));
+
+  if(rc != sizeof(uint64_t))
+    return false;
+
+  *out_count = (uint32_t)missed;
+  return true;
+}
+
+bool ponyint_asio_epoll_read_signal_count(int fd, uint32_t* out_count)
+{
+  return read_signal_count(fd, out_count);
+}
+
 #if !defined(USE_SCHEDULER_SCALING_PTHREADS)
 static void empty_signal_handler(int sig)
 {
@@ -288,9 +305,13 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
       {
         if(ep->events & (EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR))
         {
-          uint64_t missed;
+          uint64_t missed = 0;
           ssize_t rc = read(ev->fd, &missed, sizeof(uint64_t));
+          /* missed is intentionally unused for timer events: the ASIO timer
+           * backend does not coalesce based on missed count today.
+           */
           (void)rc;
+          (void)missed;
           flags |= ASIO_TIMER;
         }
       }
@@ -299,11 +320,8 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
       {
         if(ep->events & (EPOLLIN | EPOLLRDHUP | EPOLLHUP | EPOLLERR))
         {
-          uint64_t missed;
-          ssize_t rc = read(ev->fd, &missed, sizeof(uint64_t));
-          (void)rc;
-          flags |= ASIO_SIGNAL;
-          count = (uint32_t)missed;
+          if(read_signal_count(ev->fd, &count))
+            flags |= ASIO_SIGNAL;
         }
       }
 

--- a/test/libponyrt/CMakeLists.txt
+++ b/test/libponyrt/CMakeLists.txt
@@ -4,6 +4,7 @@ project(libponyrt.tests VERSION ${PONYC_PROJECT_VERSION} LANGUAGES C CXX)
 
 add_executable(libponyrt.tests
     util.cc
+    asio_epoll.cc
     ds/fun.cc
     ds/hash.cc
     ds/list.cc

--- a/test/libponyrt/asio_epoll.cc
+++ b/test/libponyrt/asio_epoll.cc
@@ -1,0 +1,65 @@
+#include <platform.h>
+
+#include <gtest/gtest.h>
+
+#include <stdint.h>
+
+#if defined(PLATFORM_IS_LINUX)
+#include <sys/eventfd.h>
+#include <unistd.h>
+
+extern "C" {
+  bool ponyint_asio_epoll_read_signal_count(int fd, uint32_t* out_count);
+}
+
+static void close_eventfd(int fd)
+{
+  int rc = close(fd);
+  ASSERT_EQ(0, rc);
+}
+
+TEST(AsioEpoll, ReadSignalCountReturnsFalseForUnwrittenNonblockingEventfd)
+{
+  int fd = eventfd(0, EFD_NONBLOCK);
+  ASSERT_NE(-1, fd);
+
+  uint32_t count = 123;
+  ASSERT_FALSE(ponyint_asio_epoll_read_signal_count(fd, &count));
+  ASSERT_EQ((uint32_t)123, count);
+
+  close_eventfd(fd);
+}
+
+TEST(AsioEpoll, ReadSignalCountReturnsWrittenValue)
+{
+  int fd = eventfd(0, EFD_NONBLOCK);
+  ASSERT_NE(-1, fd);
+
+  ASSERT_EQ(0, eventfd_write(fd, 7));
+
+  uint32_t count = 0;
+  ASSERT_TRUE(ponyint_asio_epoll_read_signal_count(fd, &count));
+  ASSERT_EQ((uint32_t)7, count);
+
+  close_eventfd(fd);
+}
+
+TEST(AsioEpoll, ReadSignalCountAccumulatesWritesAndDrainsEventfd)
+{
+  int fd = eventfd(0, EFD_NONBLOCK);
+  ASSERT_NE(-1, fd);
+
+  ASSERT_EQ(0, eventfd_write(fd, 3));
+  ASSERT_EQ(0, eventfd_write(fd, 4));
+
+  uint32_t count = 0;
+  ASSERT_TRUE(ponyint_asio_epoll_read_signal_count(fd, &count));
+  ASSERT_EQ((uint32_t)7, count);
+
+  count = 123;
+  ASSERT_FALSE(ponyint_asio_epoll_read_signal_count(fd, &count));
+  ASSERT_EQ((uint32_t)123, count);
+
+  close_eventfd(fd);
+}
+#endif


### PR DESCRIPTION
## Summary
Initializes `missed = 0` and explicitly handles `read()` failure on the eventfd signal-dispatch path in the epoll backend, so a failed read no longer forwards uninitialized stack data as the missed-signal count to subscribers.

## Why this matters
In `src/libponyrt/asio/epoll.c`, the signal-dispatch path around line 318 reads the eventfd to recover the missed-signal count:

```c
uint64_t missed;
ssize_t rc = read(ev->fd, &missed, sizeof(uint64_t));
(void)rc;
flags |= ASIO_SIGNAL;
count = (uint32_t)missed;
```

If `read()` fails (EAGAIN, EINTR, partial), `missed` is uninitialized stack data and that garbage value gets forwarded to the actor's notifier via `pony_asio_event_send`'s `arg`. The timer dispatch path has the same `read()` pattern but discards the value, so it's harmless there. For signals, the count is observable.

Surfaced during review of #5129 (timerfd return checking) and filed as #5152.

## Testing
ASIO signal-delivery timing is impractical to exercise in a unit test without timer manipulation. The fix is small and the failure mode (uninitialized stack data) is what the change addresses directly.

Fixes #5152