### PR TITLE
Fix LSP document symbol outline dropping class members after lambda field initialisers

### DIFF
--- a/.release-notes/fix-document-symbol-lambda-class.md
+++ b/.release-notes/fix-document-symbol-lambda-class.md
@@ -1,0 +1,5 @@
+## Fix LSP document symbol outline dropping class members after lambda field initialisers
+
+If a class contained a `let` field whose initialiser was a lambda literal (e.g. `let _f: {(U32): U32} val = {(x: U32): U32 => x}`), all class members declared after that field were silently missing from the document symbol outline (the structure view shown by editors).
+
+The outline now correctly includes all named class members regardless of whether the class contains lambda field initialisers, lambda-typed fields, methods returning lambdas, or methods with lambda-typed parameters.

--- a/tools/pony-lsp/symbols.pony
+++ b/tools/pony-lsp/symbols.pony
@@ -144,7 +144,10 @@ primitive DocumentSymbols
       | TokenIds.tk_class()
       | TokenIds.tk_type()
       | TokenIds.tk_actor()
-      | TokenIds.tk_struct() => entity_starts.push(module_child.position())
+      | TokenIds.tk_struct() =>
+        if not _is_synthetic_entity(module_child) then
+          entity_starts.push(module_child.position())
+        end
       end
     end
     var entity_idx: USize = 0
@@ -163,28 +166,30 @@ primitive DocumentSymbols
         end
       match maybe_kind
       | let kind: I64 =>
-        let max_pos: (Position | None) =
+        if not _is_synthetic_entity(module_child) then
+          let max_pos: (Position | None) =
+            try
+              entity_starts(entity_idx + 1)?
+            else
+              None
+            end
+          entity_idx = entity_idx + 1
           try
-            entity_starts(entity_idx + 1)?
+            let id = module_child(0)?
+            if id.id() == TokenIds.tk_id() then
+              let name = id.token_value() as String
+              (let full_range, let selection_range) =
+                this._symbol_ranges(module_child, id, name, channel, max_pos)?
+              let symbol =
+                DocumentSymbol(name, kind, full_range, selection_range)
+              this.find_members(module_child, symbol, channel, max_pos)
+              symbols.push(symbol)
+            else
+              channel.log("Expecred TK_ID, got " + TokenIds.string(id.id()))
+            end
           else
-            None
+            channel.log("No id node at idx 1")
           end
-        entity_idx = entity_idx + 1
-        try
-          let id = module_child(0)?
-          if id.id() == TokenIds.tk_id() then
-            let name = id.token_value() as String
-            (let full_range, let selection_range) =
-              this._symbol_ranges(module_child, id, name, channel, max_pos)?
-            let symbol =
-              DocumentSymbol(name, kind, full_range, selection_range)
-            this.find_members(module_child, symbol, channel, max_pos)
-            symbols.push(symbol)
-          else
-            channel.log("Expecred TK_ID, got " + TokenIds.string(id.id()))
-          end
-        else
-          channel.log("No id node at idx 1")
         end
       end
     end
@@ -323,6 +328,21 @@ primitive DocumentSymbols
           symbol.push_child(member_symbol)
         end
       end
+    end
+
+  fun _is_synthetic_entity(entity: AST box): Bool =>
+    """
+    Returns true if `entity` is a compiler-generated anonymous entity.
+    ponyc desugars lambda and object literals to anonymous classes appended
+    to the module AST; those classes have hygienic names beginning with '$'
+    (e.g. `$0`, `$1`). They must be excluded from `entity_starts` and from
+    symbol generation so they neither appear in the outline nor corrupt the
+    entity-boundary tracking used to compute `max_pos`.
+    """
+    match try entity(0)?.token_value() else None end
+    | let n: String => try n(0)? == '$' else false end
+    else
+      false
     end
 
   fun _symbol_ranges(

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -25,6 +25,7 @@ primitive _DocumentSymbolIntegrationTests is TestList
     test(_DocSymPrimitiveRangeTest.create(server))
     test(_DocSymPrimitiveNoChildrenTest.create(server))
     test(_DocSymPrimitivePartialSynthesisTest.create(server))
+    test(_DocSymLambdaMembersTest.create(server))
 
 class \nodoc\ iso _DocSymContainmentTest is UnitTest
   """
@@ -363,6 +364,45 @@ class \nodoc\ iso _DocSymPrimitivePartialSynthesisTest is UnitTest
       _server,
       "document_symbol/_ds_compare_user_eq.pony",
       [_DocSymChildKindsChecker("_DsCompareUserEq", [("eq", 6)])])
+
+class \nodoc\ iso _DocSymLambdaMembersTest is UnitTest
+  """
+  Regression guard for lambda-related expressions not leaking into the outline.
+
+  `_DsLambda` (in `_ds_lambda.pony`) has six explicitly written members:
+    - `_callback`: a `let` field whose type is a lambda type → field (8)
+    - `ds_no_lambda`: a plain method → method (6)
+    - `ds_with_lambda`: a method with a lambda literal in its body → method (6)
+    - `ds_returns_lambda`: a method with a lambda return type → method (6)
+    - `ds_lambda_arg`: a method with a lambda-typed parameter → method (6)
+    - `ds_local_lambda_type`: a method with a lambda-typed local
+      variable → method (6)
+
+  Lambda type annotations and lambda literals must not appear as extra child
+  symbols. The children array must contain exactly these six members.
+  """
+  let _server: _LspTestServer
+
+  new iso create(server: _LspTestServer) =>
+    _server = server
+
+  fun name(): String =>
+    "document_symbol/integration/lambda_members"
+
+  fun apply(h: TestHelper) =>
+    _RunLspChecks(
+      h,
+      _server,
+      "document_symbol/_ds_lambda.pony",
+      [ _DocSymTopLevelKindsChecker([("_DsLambda", 5)])
+        _DocSymChildKindsChecker(
+          "_DsLambda",
+          [ ("_callback", 8)
+            ("ds_no_lambda", 6)
+            ("ds_with_lambda", 6)
+            ("ds_returns_lambda", 6)
+            ("ds_lambda_arg", 6)
+            ("ds_local_lambda_type", 6)])])
 
 class val _DocSymContainmentChecker
   """

--- a/tools/pony-lsp/test/workspace/document_symbol/_ds_lambda.pony
+++ b/tools/pony-lsp/test/workspace/document_symbol/_ds_lambda.pony
@@ -1,0 +1,32 @@
+// Fixture for `document_symbol/integration/lambda_members`.
+//
+// `_DsLambda` exercises lambda-related members:
+// - `_callback`: a `let` field whose type is a lambda type
+// - `ds_no_lambda`: a plain method with no lambda involvement
+// - `ds_with_lambda`: a method whose body creates a lambda literal
+// - `ds_returns_lambda`: a method whose return type is a lambda type
+// - `ds_lambda_arg`: a method that accepts a lambda-typed parameter
+// - `ds_local_lambda_type`: a method with a lambda-typed local variable
+//
+// None of the lambda type expressions or literals must appear as child
+// symbols — `_DsLambda`'s outline must contain exactly the six named
+// members above with their correct SymbolKinds.
+
+class _DsLambda
+  let _callback: {(U32): U32} val = {(x: U32): U32 => x }
+
+  fun ds_no_lambda(): U32 => 0
+
+  fun ds_with_lambda(): U32 =>
+    let f = {(x: U32): U32 => x + 1 }
+    f(0)
+
+  fun ds_returns_lambda(): {(U32): U32} val =>
+    {(x: U32): U32 => x + 1 }
+
+  fun ds_lambda_arg(f: {(U32): U32} box): U32 =>
+    f(0)
+
+  fun ds_local_lambda_type(): U32 =>
+    let f: {(U32): U32} val = {(x: U32): U32 => x }
+    f(0)


### PR DESCRIPTION
## Context

ponyc desugars lambda and object literals into anonymous classes that are appended to the module AST as siblings of user-written entities. These synthetic classes carry hygienic names beginning with `$` (e.g. `$0`, `$1`). `DocumentSymbols.from_module` is including them in `entity_starts`, which causes `max_pos` for the enclosing user class to be set to the position of the lambda literal rather than the position of the next real entity. Any class member declared after the first lambda field initialiser is filtered out and missing from the outline.

## Changes

- `DocumentSymbols._is_synthetic_entity` — new helper that returns `true` for any module-level entity whose raw name starts with `$`
- `DocumentSymbols.from_module` — applies `_is_synthetic_entity` in both the `entity_starts` collection loop and the symbol generation loop, keeping both in sync so `entity_idx` is never advanced for synthetic entities
- New integration test `document_symbol/integration/lambda_members` with fixture `_ds_lambda.pony` covering: field of lambda type, method returning a lambda, method with a lambda-typed parameter, method with a lambda literal in its body, method with a lambda-typed local variable

## Considerations

The `$`-prefix check is consistent with ponyc's `package_hygienic_id()` convention for compiler-generated names; user identifiers cannot begin with `$` in Pony, so there is no false-positive risk.