### PR TITLE
Fix _Unreachable misuse in pony-lsp Uris.to_path

### DIFF
--- a/tools/pony-lsp/test/_uris_tests.pony
+++ b/tools/pony-lsp/test/_uris_tests.pony
@@ -1,0 +1,70 @@
+use "pony_test"
+use ".."
+
+primitive _URITests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_URIToPathTest)
+    test(_URIToPathNoSchemeTest)
+    test(_URIFromPathTest)
+    test(_URIFromPathAlreadyURITest)
+
+class \nodoc\ iso _URIToPathTest is UnitTest
+  fun name(): String => "uris/to_path"
+
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.assert_eq[String](
+        "D:\\foo\\bar.pony",
+        Uris.to_path("file:///D:/foo/bar.pony"))
+      h.assert_eq[String](
+        "\\foo\\bar.pony",
+        Uris.to_path("file:///foo/bar.pony"))
+      h.assert_eq[String](
+        "\\",
+        Uris.to_path("file:///"))
+    else
+      h.assert_eq[String]("/foo/bar.pony", Uris.to_path("file:///foo/bar.pony"))
+    end
+
+class \nodoc\ iso _URIToPathNoSchemeTest is UnitTest
+  """
+  When no "://" separator is present, split_by returns the whole string
+  as a single element and to_path returns it unchanged.
+  """
+  fun name(): String => "uris/to_path/no_scheme"
+
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.assert_eq[String](
+        "C:\\foo\\bar.pony",
+        Uris.to_path("C:\\foo\\bar.pony"))
+    else
+      h.assert_eq[String](
+        "/foo/bar.pony",
+        Uris.to_path("/foo/bar.pony"))
+    end
+
+class \nodoc\ iso _URIFromPathTest is UnitTest
+  fun name(): String => "uris/from_path"
+
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.assert_eq[String](
+        "file:///D:/foo/bar.pony",
+        Uris.from_path("D:\\foo\\bar.pony"))
+    else
+      h.assert_eq[String](
+        "file:///foo/bar.pony",
+        Uris.from_path("/foo/bar.pony"))
+    end
+
+class \nodoc\ iso _URIFromPathAlreadyURITest is UnitTest
+  fun name(): String => "uris/from_path/already_uri"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      "file:///foo/bar.pony",
+      Uris.from_path("file:///foo/bar.pony"))

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -23,6 +23,7 @@ actor Main is TestList
     test(_PrepareMissingURITest)
     _WorkspaceTests.make().tests(test)
     _InlayHintSourceTests.make().tests(test)
+    _URITests.make().tests(test)
     _SymbolKindsTests.make().tests(test)
     _HoverFormatterTests.make().tests(test)
     _DiagnosticTests.make().tests(test)

--- a/tools/pony-lsp/uris.pony
+++ b/tools/pony-lsp/uris.pony
@@ -18,8 +18,7 @@ primitive Uris
       try
         result(result.size() - 1)?
       else
-        _Unreachable()
-        return uri
+        uri
       end
     ifdef windows then
       // file:///D:/path -> /D:/path after stripping scheme; remove leading /


### PR DESCRIPTION
## Context

`Uris.to_path` uses `String.split_by("://", 2)` which always returns ≥1 element, so the `else` branch after `result(result.size() - 1)?` is unreachable. The original code calls `_Unreachable()` (which exits the process) then falls through to `return uri` — contradictory stances on the same unreachable branch.

## Changes

- Replace `_Unreachable() / return uri` with a plain `else uri end`, matching the "trust the invariant, use a sensible fallback" stance
- Add `_URITests` covering `to_path` and `from_path` in both Unix and Windows code paths

## Considerations

No user-visible behaviour change — the `else` branch is never reachable. No release notes.