### PR TITLE
Remove unused LSP `FromCompilerRun.apply()` that bypasses staleness check

### DIFF
--- a/tools/pony-lsp/workspace/state.pony
+++ b/tools/pony-lsp/workspace/state.pony
@@ -243,6 +243,3 @@ class ref FromCompilerRun[T: Any #read]
     else
       None
     end
-
-  fun apply(): this->T ? =>
-    this._thing as this->T


### PR DESCRIPTION
## Context

`FromCompilerRun[T]` wraps a value together with the compiler run ID that produced it. Its `get(run_id)` method enforces a freshness check — returning `None` unless the caller supplies the exact matching run ID. `apply()` bypasses this check entirely, returning the raw `_thing` without any run-ID validation.

The method is unused — all six `FromCompilerRun` fields in `state.pony` access their values exclusively through `get`. It also misuses the Pony `apply()` convention (which signals a callable object) as an unwrap shorthand.

## Changes

- Remove `fun apply(): this->T ?` from `FromCompilerRun`

## Considerations

Two pre-existing issues in surrounding code were identified during review but are out of scope here:

- `compiler_run_id` is a public `var` field — any `ref` holder can corrupt the run-ID/value pairing (High)
- The `update`/`update_with` vs `get` staleness contract (`>=` vs `==`) is undocumented and surprising (Medium)