### PR TITLE
Encapsulate LSP `PackageState.documents` field behind accessor methods

### DIFF
--- a/tools/pony-lsp/test/_workspace_tests.pony
+++ b/tools/pony-lsp/test/_workspace_tests.pony
@@ -10,6 +10,10 @@ primitive _WorkspaceTests is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_RouterFindTest)
+    test(_PackageStateRemoveDocumentTest)
+    test(_PackageStateRemoveDocumentMissingTest)
+    test(_PackageStateDocumentPathsTest)
+    test(_PackageStateDocumentStatesTest)
 
 class \nodoc\ iso _RouterFindTest is UnitTest
   fun name(): String => "router/find"
@@ -58,6 +62,70 @@ class \nodoc\ iso _RouterFindTest is UnitTest
     let file_path = folder.join("main.pony")?
     let found = router.find_workspace(file_path.path)
     h.assert_isnt[(WorkspaceManager | None)](None, found)
+
+class \nodoc\ iso _PackageStateRemoveDocumentTest is UnitTest
+  fun name(): String => "package_state/remove_document"
+
+  fun apply(h: TestHelper) ? =>
+    let file_auth = FileAuth(h.env.root)
+    let path = FilePath(file_auth, "/fake/path")
+    let pkg = PackageState.create(path, FakeChannel)
+    let doc_path = "/fake/path/main.pony"
+    pkg.ensure_document(doc_path)
+    h.assert_true(pkg.has_document(doc_path))
+    pkg.remove_document(doc_path)?
+    h.assert_false(pkg.has_document(doc_path))
+
+class \nodoc\ iso _PackageStateRemoveDocumentMissingTest is UnitTest
+  fun name(): String => "package_state/remove_document/missing"
+
+  fun apply(h: TestHelper) =>
+    let file_auth = FileAuth(h.env.root)
+    let path = FilePath(file_auth, "/fake/path")
+    let pkg = PackageState.create(path, FakeChannel)
+    var errored = false
+    try
+      pkg.remove_document("/fake/path/missing.pony")?
+    else
+      errored = true
+    end
+    h.assert_true(errored)
+
+class \nodoc\ iso _PackageStateDocumentPathsTest is UnitTest
+  fun name(): String => "package_state/document_paths"
+
+  fun apply(h: TestHelper) =>
+    let file_auth = FileAuth(h.env.root)
+    let path = FilePath(file_auth, "/fake/path")
+    let pkg = PackageState.create(path, FakeChannel)
+    pkg.ensure_document("/fake/path/a.pony")
+    pkg.ensure_document("/fake/path/b.pony")
+    let paths = Array[String]
+    for p in pkg.document_paths() do
+      paths.push(p)
+    end
+    h.assert_eq[USize](2, paths.size())
+    h.assert_array_eq_unordered[String](
+      ["/fake/path/a.pony"; "/fake/path/b.pony"],
+      paths)
+
+class \nodoc\ iso _PackageStateDocumentStatesTest is UnitTest
+  fun name(): String => "package_state/document_states"
+
+  fun apply(h: TestHelper) =>
+    let file_auth = FileAuth(h.env.root)
+    let path = FilePath(file_auth, "/fake/path")
+    let pkg = PackageState.create(path, FakeChannel)
+    pkg.ensure_document("/fake/path/a.pony")
+    pkg.ensure_document("/fake/path/b.pony")
+    let state_paths = Array[String]
+    for s in pkg.document_states() do
+      state_paths.push(s.path)
+    end
+    h.assert_eq[USize](2, state_paths.size())
+    h.assert_array_eq_unordered[String](
+      ["/fake/path/a.pony"; "/fake/path/b.pony"],
+      state_paths)
 
 class tag FakeRequestSender is RequestSender
   """

--- a/tools/pony-lsp/workspace/state.pony
+++ b/tools/pony-lsp/workspace/state.pony
@@ -11,7 +11,7 @@ class PackageState
   State of a compiled package, containing its modules and document states.
   """
   let path: FilePath
-  let documents: Map[String, DocumentState]
+  let _documents: Map[String, DocumentState]
   let _channel: Channel
   var _package: FromCompilerRun[Package]
   var _compiler_run_id: USize
@@ -19,7 +19,7 @@ class PackageState
   new create(path': FilePath, channel: Channel) =>
     path = path'
     _channel = channel
-    documents = documents.create()
+    _documents = _documents.create()
     _package = _package.empty()
     _compiler_run_id = 0
 
@@ -31,7 +31,7 @@ class PackageState
         ""
       end
     ) + "):\n\t" + "\n\t".join(
-      Iter[(String box, DocumentState box)](documents.pairs())
+      Iter[(String box, DocumentState box)](_documents.pairs())
         .map[String]({(kv) =>
           kv._1 + " (" +
             if kv._2.module() isnt None then
@@ -47,11 +47,20 @@ class PackageState
 
   fun get_document(document_path: String): (this->DocumentState | None) =>
     try
-      this.documents(document_path)?
+      this._documents(document_path)?
     end
 
   fun has_document(document_path: String): Bool =>
-    this.documents.contains(document_path)
+    this._documents.contains(document_path)
+
+  fun document_paths(): Iterator[String val]^ =>
+    _documents.keys()
+
+  fun ref document_states(): Iterator[DocumentState ref]^ =>
+    _documents.values()
+
+  fun ref remove_document(document_path: String) ? =>
+    _documents.remove(document_path)?._2.dispose()
 
   fun ref insert_new(document_path: String): DocumentState =>
     """
@@ -65,7 +74,7 @@ class PackageState
       let module = pkg.find_module(document_path) as Module
       doc_state.update(this._compiler_run_id, module)
     end
-    this.documents.insert(document_path, doc_state)
+    this._documents.insert(document_path, doc_state)
 
   fun ref ensure_document(document_path: String): DocumentState =>
     """
@@ -89,7 +98,7 @@ class PackageState
       this._channel.log(this.debug())
       // for each open document, update the
       // document state if we have a module for it
-      for (doc_path, doc_state) in this.documents.pairs() do
+      for (doc_path, doc_state) in this._documents.pairs() do
         // TODO: ensure both module and package-state paths are normalised
         match \exhaustive\ result.find_module(doc_path)
         | let m: Module val => doc_state.update(run_id, m)
@@ -105,7 +114,7 @@ class PackageState
     end
 
   fun dispose() =>
-    for doc_state in this.documents.values() do
+    for doc_state in this._documents.values() do
       doc_state.dispose()
     end
 

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -146,7 +146,7 @@ actor WorkspaceManager
         // pre-fill with empty list of errors for
         // all files for which we have errors now
         for pkg in this._packages.values() do
-          for doc in pkg.documents.keys() do
+          for doc in pkg.document_paths() do
             errors_by_file(doc) = pc.Vec[JsonValue]
           end
         end
@@ -403,8 +403,7 @@ actor WorkspaceManager
       let package: FilePath = this._find_workspace_package(document_path)?
       let package_state = this._ensure_package(package)
       try
-        let document_state = package_state.documents.remove(document_path)?._2
-        document_state.dispose()
+        package_state.remove_document(document_path)?
       end
     else
       _channel.log("document not in workspace: " + document_path)
@@ -938,7 +937,7 @@ actor WorkspaceManager
     let query_lower: String val = query.lower()
     var results = JsonArray
     for pkg_state in this._packages.values() do
-      for doc_state in pkg_state.documents.values() do
+      for doc_state in pkg_state.document_states() do
         let file_uri = Uris.from_path(doc_state.path)
         let top_symbols = doc_state.document_symbols()
         for symbol in top_symbols.values() do


### PR DESCRIPTION
## Context

`PackageState` has a public `documents: Map[String, DocumentState]` field that external callers reach into directly — including one mutation (`documents.remove(...)` in `workspace_manager.pony`) and two read iterations. This leaks the map abstraction and makes it easy to bypass the document lifecycle.

## Changes

- Make `documents` private (`_documents`)
- Add `remove_document(path)` — encapsulates the remove + dispose lifecycle
- Add `document_paths()` — replaces external `documents.keys()` iteration
- Add `document_states()` — replaces external `documents.values()` iteration
- Update both call sites in `WorkspaceManager`
- Add four unit tests covering the happy path and error path for each new method

## Considerations

- `document_paths()` has an implicit `box` receiver (default) since `String val` keys are cap-agnostic
- `document_states()` requires an explicit `ref` receiver so the iterator yields `DocumentState ref`, preserving the ability for callers to invoke `fun ref` methods on each state