### PR TITLE
Remove redundant `this.` prefixes from LSP `state.pony`

### DIFF
--- a/tools/pony-lsp/workspace/state.pony
+++ b/tools/pony-lsp/workspace/state.pony
@@ -24,9 +24,9 @@ class PackageState
     _compiler_run_id = 0
 
   fun debug(): String val =>
-    "Package " + this.path.path + " (" + (
+    "Package " + path.path + " (" + (
       try
-        (this.package() as Package).qualified_name
+        (package() as Package).qualified_name
       else
         ""
       end
@@ -43,15 +43,15 @@ class PackageState
     )
 
   fun package(): (Package | None) =>
-    this._package.get(this._compiler_run_id)
+    _package.get(_compiler_run_id)
 
   fun get_document(document_path: String): (this->DocumentState | None) =>
     try
-      this._documents(document_path)?
+      _documents(document_path)?
     end
 
   fun has_document(document_path: String): Bool =>
-    this._documents.contains(document_path)
+    _documents.contains(document_path)
 
   fun document_paths(): Iterator[String val]^ =>
     _documents.keys()
@@ -66,24 +66,24 @@ class PackageState
     """
     Insert a new module by the given `document_path` into this package.
     """
-    let doc_state = DocumentState.create(document_path, this._channel)
+    let doc_state = DocumentState.create(document_path, _channel)
 
     try
       // populate the document from the last compilation result if available
-      let pkg = this.package() as Package
+      let pkg = package() as Package
       let module = pkg.find_module(document_path) as Module
-      doc_state.update(this._compiler_run_id, module)
+      doc_state.update(_compiler_run_id, module)
     end
-    this._documents.insert(document_path, doc_state)
+    _documents.insert(document_path, doc_state)
 
   fun ref ensure_document(document_path: String): DocumentState =>
     """
     Returns the document state in a tuple together with a boolean,
     denoting whether this documents needs compilation.
     """
-    match \exhaustive\ this.get_document(document_path)
+    match \exhaustive\ get_document(document_path)
     | let d: DocumentState => d
-    | None => this.insert_new(document_path)
+    | None => insert_new(document_path)
     end
 
   fun ref update(result: Package val, run_id: USize) =>
@@ -91,30 +91,30 @@ class PackageState
     Update the current package state with the result
     of the compilation run identified by `run_id`.
     """
-    if run_id >= this._compiler_run_id then
-      this._compiler_run_id = run_id
-      this._package.update(run_id, result)
-      this._channel.log("Updating package " + result.path)
-      this._channel.log(this.debug())
+    if run_id >= _compiler_run_id then
+      _compiler_run_id = run_id
+      _package.update(run_id, result)
+      _channel.log("Updating package " + result.path)
+      _channel.log(debug())
       // for each open document, update the
       // document state if we have a module for it
-      for (doc_path, doc_state) in this._documents.pairs() do
+      for (doc_path, doc_state) in _documents.pairs() do
         // TODO: ensure both module and package-state paths are normalised
         match \exhaustive\ result.find_module(doc_path)
         | let m: Module val => doc_state.update(run_id, m)
-        | None => this._channel.log("No module found for " + doc_path)
+        | None => _channel.log("No module found for " + doc_path)
         end
       end
     end
 
   fun ref add_diagnostic(run_id: USize, diagnostic: Diagnostic) =>
-    if run_id >= this._compiler_run_id then
-      this._compiler_run_id = run_id
+    if run_id >= _compiler_run_id then
+      _compiler_run_id = run_id
       // TODO:
     end
 
   fun dispose() =>
-    for doc_state in this._documents.values() do
+    for doc_state in _documents.values() do
       doc_state.dispose()
     end
 
@@ -142,25 +142,25 @@ class DocumentState
     _compiler_run_id = 0
 
   fun ref update(run_id: USize, module': Module val) =>
-    if run_id >= this._compiler_run_id then
-      this._compiler_run_id = run_id
+    if run_id >= _compiler_run_id then
+      _compiler_run_id = run_id
       // clear out diagnostics
-      this._module.update(run_id, module')
-      this._position_index =
+      _module.update(run_id, module')
+      _position_index =
         FromCompilerRun[PositionIndex val]
           .create(run_id, module'.create_position_index())
-      this._document_symbols =
+      _document_symbols =
         FromCompilerRun[Array[DocumentSymbol]]
-          .create(run_id, DocumentSymbols.from_module(module', this._channel))
-      this._hash.update(run_id, module'.hash())
+          .create(run_id, DocumentSymbols.from_module(module', _channel))
+      _hash.update(run_id, module'.hash())
     end
 
   fun ref add_diagnostic(run_id: USize, diagnostic: Diagnostic) =>
     // also accept diagnostics from the last/current run,
     // as they trickle in one after the other
-    if run_id == this._compiler_run_id then
+    if run_id == _compiler_run_id then
       // same run, update diagnostics
-      this._diagnostics.update_with(
+      _diagnostics.update_with(
         run_id,
         {
           (diags: (Array[Diagnostic] | None)): Array[Diagnostic] =>
@@ -172,38 +172,38 @@ class DocumentState
               [diagnostic]
             end
         })
-    elseif run_id > this._compiler_run_id then
+    elseif run_id > _compiler_run_id then
       // new run, discard old diagnostics
-      this._diagnostics.update(run_id, [diagnostic])
+      _diagnostics.update(run_id, [diagnostic])
     end
 
   fun box needs_compilation(): Bool =>
-    (this.module() is None) and (this.diagnostics() is None)
+    (module() is None) and (diagnostics() is None)
 
   fun box module(): (Module val | None) =>
-    this._module.get(_compiler_run_id)
+    _module.get(_compiler_run_id)
 
   fun box diagnostics(): (Array[Diagnostic] box | None) =>
-    this._diagnostics.get(_compiler_run_id)
+    _diagnostics.get(_compiler_run_id)
 
   fun box position_index(): (PositionIndex val | None) =>
-    this._position_index.get(_compiler_run_id)
+    _position_index.get(_compiler_run_id)
 
   fun box module_hash(): (USize | None) =>
-    this._hash.get(_compiler_run_id)
+    _hash.get(_compiler_run_id)
 
   fun ref document_symbols(): Array[DocumentSymbol] =>
     """
     Get or create the current document symbols.
     """
-    match this.module()
+    match module()
     | let mod: Module val =>
-      let created = DocumentSymbols.from_module(mod, this._channel)
-      this._document_symbols.update(this._compiler_run_id, created)
+      let created = DocumentSymbols.from_module(mod, _channel)
+      _document_symbols.update(_compiler_run_id, created)
       created
     else
       // no module available yet, no documentsymbols available yet
-      this._channel.log("No module available yet for " + this.path)
+      _channel.log("No module available yet for " + path)
       []
     end
 
@@ -232,37 +232,34 @@ class ref FromCompilerRun[T: Any #read]
   var _compiler_run_id: USize
 
   new ref empty() =>
-    this._compiler_run_id = 0
-    this._thing = None
+    _compiler_run_id = 0
+    _thing = None
 
   new ref create(compiler_run_id': USize, thing': T) =>
-    this._compiler_run_id = compiler_run_id'
-    this._thing = thing'
+    _compiler_run_id = compiler_run_id'
+    _thing = thing'
 
   fun ref update(compiler_run_id': USize, new_thing: (T | None)) =>
     // ignore update if the compiler_run_id' is old
-    if compiler_run_id' >= this._compiler_run_id then
-      this._compiler_run_id = compiler_run_id'
-      this._thing = new_thing
+    if compiler_run_id' >= _compiler_run_id then
+      _compiler_run_id = compiler_run_id'
+      _thing = new_thing
     end
 
   fun ref update_with(
-    compiler_run_id': USize,
-    closure:
-      {((T | None)): (T^ | None)})
-  =>
+    compiler_run_id': USize, closure: {((T | None)): (T^ | None)}) =>
     """
     Execute the given closure on the current state
     of the encapsulated thing, which might be `None`.
     """
-    if compiler_run_id' >= this._compiler_run_id then
-      this._compiler_run_id = compiler_run_id'
-      this._thing = closure.apply(this._thing)
+    if compiler_run_id' >= _compiler_run_id then
+      _compiler_run_id = compiler_run_id'
+      _thing = closure.apply(_thing)
     end
 
   fun get(current_run_id: USize): (this->T | None) =>
     if current_run_id == _compiler_run_id then
-      this._thing
+      _thing
     else
       None
     end


### PR DESCRIPTION
## Context

`state.pony` uses `this.` on field and method accesses throughout `PackageState`, `DocumentState`, and `FromCompilerRun`. In Pony, `this.` is never required — bare field and method names resolve to the receiver without it.

## Changes

Remove all redundant `this.` prefixes across all three classes in `state.pony`. No behaviour change.