### PR TITLE
Fix wrap/unwrap mismatch at interface dispatch sites

### DIFF
--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -252,6 +252,54 @@ static bool special_case_call(compile_t* c, ast_t* ast, LLVMValueRef* value)
   return false;
 }
 
+// Detect vtable slots that are wrapped on the callee side because they share
+// a vtable index with a partial method elsewhere — see the header doc on
+// `reach_vtable_index_has_partial`. When this returns true, the dispatch
+// method's compiled return type does not match the slot's actual return; the
+// caller must use the wrapped `{T, i1}` return for the LLVM call and then
+// unwrap the always-false error flag. *func_type is rewritten in place to the
+// wrapped type when true. When the dispatch method is itself partial,
+// c_m->func_type already has the wrapped return, the partial-handling block
+// in `gen_call` unwraps it, and this returns false.
+//
+// COUPLING: mirrors the decision made by `method_needs_error_wrap` in
+// gendesc.c. Both sides key off `reach_vtable_index_has_partial` and must
+// stay in lockstep.
+static bool adjust_for_wrapped_vtable_slot(compile_t* c, reach_type_t* t,
+  reach_method_t* m, LLVMTypeRef* func_type)
+{
+  compile_method_t* c_m = (compile_method_t*)m->c_method;
+
+  bool is_vtable_dispatch =
+    (t->underlying == TK_UNIONTYPE) ||
+    (t->underlying == TK_ISECTTYPE) ||
+    (t->underlying == TK_INTERFACE) ||
+    (t->underlying == TK_TRAIT);
+
+  // is_partial/internal short-circuit here on the CURRENT method: a partial
+  // dispatch method is already handled by the partial-handling block in
+  // gen_call, and internal methods aren't wrapped on the callee side.
+  // reach_vtable_index_has_partial then asks about siblings at the same
+  // vtable index.
+  if(!is_vtable_dispatch || c_m->is_partial || m->internal ||
+    !reach_vtable_index_has_partial(c->reach, m->vtable_index))
+    return false;
+
+  // Build the wrapped function type so the call uses the slot's actual
+  // calling convention. Param types are unchanged; only the return is wrapped
+  // with the error flag.
+  LLVMTypeRef ret_type = LLVMGetReturnType(*func_type);
+  LLVMTypeRef wrapped_ret = error_flag_type(c, ret_type);
+  unsigned count = LLVMCountParamTypes(*func_type);
+  size_t params_size = count * sizeof(LLVMTypeRef);
+  LLVMTypeRef* fparams =
+    (LLVMTypeRef*)ponyint_pool_alloc_size(params_size);
+  LLVMGetParamTypes(*func_type, fparams);
+  *func_type = LLVMFunctionType(wrapped_ret, fparams, count, false);
+  ponyint_pool_free_size(params_size, fparams);
+  return true;
+}
+
 static LLVMValueRef dispatch_function(compile_t* c, reach_type_t* t,
   reach_method_t* m, LLVMValueRef l_value)
 {
@@ -824,6 +872,9 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   LLVMValueRef func = dispatch_function(c, t, m, args[0]);
   LLVMTypeRef func_type = ((compile_method_t*)m->c_method)->func_type;
 
+  bool unwrap_nonpartial_slot = adjust_for_wrapped_vtable_slot(c, t, m,
+    &func_type);
+
   bool is_message = false;
 
   if((ast_id(postfix) == TK_NEWBEREF) || (ast_id(postfix) == TK_BEREF) ||
@@ -905,7 +956,22 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       }
 
       compile_method_t* c_m = (compile_method_t*)m->c_method;
-      if(c_m->is_partial)
+      if(unwrap_nonpartial_slot)
+      {
+        // The vtable slot is wrapped (see the slot-wrap detection above)
+        // but the dispatch method we called through is non-partial, so the
+        // error flag is always false. Drop it and keep the value.
+        //
+        // Void returns can't reach here: this branch only runs for
+        // interface/trait/union/isect dispatch, and the only methods with
+        // a void compiled return — bare functions, class constructors,
+        // and `_final` — don't go through that dispatch path. The wrapped
+        // return must therefore be `{T, i1}`, not the void-form `i1`.
+        LLVMTypeRef callee_ret = LLVMGetReturnType(func_type);
+        pony_assert(callee_ret != c->i1);
+        r = unwrap_result(c, r);
+      }
+      else if(c_m->is_partial)
       {
         // Callee returns {T, i1} or i1. Extract the error flag and branch.
         LLVMValueRef error_flag = unwrap_error(c, r);
@@ -1034,8 +1100,12 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
   if(func == NULL)
     return NULL;
 
-  // Call the function. We know it isn't partial.
-  LLVMTypeRef func_type = LLVMGlobalGetValueType(func);
+  // Call the function. `eq` is non-partial. We pull the call type from
+  // c_m->func_type rather than `func`, since `func` is a loaded pointer
+  // (opaque under LLVM's new pointer model) for interface/trait dispatch and
+  // LLVMGlobalGetValueType only returns a meaningful type for globals.
+  LLVMTypeRef func_type = ((compile_method_t*)m->c_method)->func_type;
+
   LLVMValueRef args[2];
   args[0] = l_value;
   args[1] = r_value;

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -156,60 +156,23 @@ static LLVMValueRef make_desc_ptr(compile_t* c, LLVMValueRef func)
   return func == NULL ? LLVMConstNull(c->ptr) : func;
 }
 
-static bool method_needs_error_wrap(reach_type_t* t, reach_method_t* m)
+static bool method_needs_error_wrap(reach_t* r, reach_method_t* m)
 {
-  // Check if a non-partial method needs an error-wrapping vtable entry.
-  // This happens when the method is dispatched through a trait/interface/union
-  // where the same method IS partial. The vtable entry must match the dispatch
-  // type's return type ({T, i1} instead of T).
+  // A non-partial method needs an error-wrapping vtable entry whenever the
+  // painter has put it at the same vtable index as a partial method (same
+  // mangled name, since mangling ignores partiality). The vtable slot then
+  // returns `{T, i1}` regardless of which side called it.
+  //
+  // COUPLING: the interface-dispatch site in gencall.c (gen_call) keys off
+  // the SAME `reach_vtable_index_has_partial` query to decide when to unwrap
+  // the result. If the predicate here changes, the call site must change to
+  // match — see the header comment on `reach_vtable_index_has_partial`.
   compile_method_t* c_m = (compile_method_t*)m->c_method;
 
-  if(c_m->is_partial)
+  if(c_m->is_partial || m->internal)
     return false;
 
-  size_t i = HASHMAP_BEGIN;
-  reach_type_t* st;
-
-  while((st = reach_type_cache_next(&t->subtypes, &i)) != NULL)
-  {
-    // Only check dispatch types. Skip concrete types that appear in subtypes
-    // due to the bidirectional relationship in the reach module.
-    switch(st->underlying)
-    {
-      case TK_UNIONTYPE:
-      case TK_ISECTTYPE:
-      case TK_INTERFACE:
-      case TK_TRAIT:
-        break;
-
-      default:
-        continue;
-    }
-
-    // Look for any method on this dispatch type with the same vtable index
-    // that is partial.
-    size_t j = HASHMAP_BEGIN;
-    reach_method_name_t* mn;
-
-    while((mn = reach_method_names_next(&st->methods, &j)) != NULL)
-    {
-      size_t k = HASHMAP_BEGIN;
-      reach_method_t* sm;
-
-      while((sm = reach_mangled_next(&mn->r_mangled, &k)) != NULL)
-      {
-        if((sm->vtable_index == m->vtable_index) && (sm->fun != NULL))
-        {
-          ast_t* err = ast_childidx(sm->fun->ast, 5);
-
-          if((err != NULL) && (ast_id(err) == TK_QUESTION))
-            return true;
-        }
-      }
-    }
-  }
-
-  return false;
+  return reach_vtable_index_has_partial(r, m->vtable_index);
 }
 
 static LLVMValueRef make_error_wrap_function(compile_t* c,
@@ -486,7 +449,7 @@ static LLVMValueRef make_vtable(compile_t* c, reach_type_t* t)
       pony_assert(vtable[index] == NULL);
       compile_method_t* c_m = (compile_method_t*)m->c_method;
 
-      bool needs_wrap = !m->internal && method_needs_error_wrap(t, m);
+      bool needs_wrap = method_needs_error_wrap(c->reach, m);
 
       if((c_t->primitive != NULL) && !m->internal)
         vtable[index] = make_unbox_function(c, t, m, needs_wrap);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -318,6 +318,14 @@ static const char* make_mangled_name(reach_method_t* m)
   // sender and receiver can cause ORCA GC problems. Functions don't have
   // dispatch cases, and their symbol names may be hard-coded in the runtime
   // (e.g. Main_runtime_override_defaults).
+  //
+  // Partiality is intentionally NOT included: the painter assigns vtable
+  // indices by mangled name, so partial and non-partial methods that match
+  // here share a vtable slot. Codegen reconciles the calling conventions
+  // via the error-flag wrapper — see `reach_vtable_index_has_partial` and
+  // its consumers in gendesc.c and gencall.c. If a future change starts
+  // segregating slots by partiality, the entire wrap mechanism becomes
+  // dead code and should be removed.
   bool include_trace_kind = false;
 
   if(m->fun != NULL)
@@ -1682,6 +1690,53 @@ uint32_t reach_vtable_index(reach_type_t* t, const char* name)
     return (uint32_t)-1;
 
   return m->vtable_index;
+}
+
+bool reach_vtable_index_has_partial(reach_t* r, uint32_t vtable_index)
+{
+  // Walk every reachable method and return true on the first partial method
+  // at this vtable index. See the header for why both sides of the
+  // gendesc.c/gencall.c wrap split rely on this query.
+  //
+  // An unpainted slot (the painter never assigned this index — bare-method
+  // types are skipped, internal methods may not get one) can never have a
+  // partial vtable-shared sibling because it doesn't share a slot with
+  // anything. Reject the sentinel before walking.
+  if(vtable_index == (uint32_t)-1)
+    return false;
+
+  size_t i = HASHMAP_BEGIN;
+  reach_type_t* t;
+
+  while((t = reach_types_next(&r->types, &i)) != NULL)
+  {
+    size_t j = HASHMAP_BEGIN;
+    reach_method_name_t* n;
+
+    while((n = reach_method_names_next(&t->methods, &j)) != NULL)
+    {
+      size_t k = HASHMAP_BEGIN;
+      reach_method_t* m;
+
+      while((m = reach_mangled_next(&n->r_mangled, &k)) != NULL)
+      {
+        // Bare methods don't use the error-flag return convention — a bare
+        // partial function aborts on error rather than returning `{T, i1}` —
+        // so the AST's `?` on a bare method does not mean its vtable slot
+        // is wrapped, and it should not contribute to the wrap decision.
+        if((m->vtable_index == vtable_index) && (m->fun != NULL) &&
+          (m->cap != TK_AT))
+        {
+          ast_t* err = ast_childidx(m->fun->ast, 5);
+
+          if((err != NULL) && (ast_id(err) == TK_QUESTION))
+            return true;
+        }
+      }
+    }
+  }
+
+  return false;
 }
 
 uint32_t reach_max_type_id(reach_t* r)

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -146,6 +146,30 @@ reach_method_name_t* reach_method_name(reach_type_t* t,
 
 uint32_t reach_vtable_index(reach_type_t* t, const char* name);
 
+/** Return true if any reachable method has the given vtable index and is
+ * partial.
+ *
+ * The painter assigns vtable indices by mangled name, and Pony's mangling
+ * does not include partiality, so a partial and a non-partial method with
+ * the same parameter and return types share a vtable index. Codegen needs
+ * to know when such sharing happens so the slot's calling convention is
+ * uniform across both sides:
+ *
+ *   - The vtable population in gendesc.c wraps a non-partial concrete
+ *     method's return as `{T, i1}` whenever this returns true for the
+ *     method's vtable index, so a partial caller through the slot sees
+ *     the wrapped return type it expects.
+ *
+ *   - The interface dispatch in gencall.c (gen_call) unwraps the result
+ *     whenever this returns true for the dispatch method's vtable index,
+ *     so a non-partial caller through the slot sees the unwrapped return
+ *     type it expects.
+ *
+ * Both sides must agree on the same answer for the same vtable index, so
+ * they share this query.
+ */
+bool reach_vtable_index_has_partial(reach_t* r, uint32_t vtable_index);
+
 uint32_t reach_max_type_id(reach_t* r);
 
 void reach_dump(reach_t* r);

--- a/test/full-program-tests/non-partial-interface-dispatch-shared-vtable-with-partial/main.pony
+++ b/test/full-program-tests/non-partial-interface-dispatch-shared-vtable-with-partial/main.pony
@@ -1,0 +1,56 @@
+// Regression test for the interaction between #5002 (error-flag returns)
+// and shared vtable indices for partial and non-partial methods.
+//
+// The painter assigns vtable indices by mangled name, and Pony's mangling
+// does not include partiality, so a partial `apply(T): U ?` and a
+// non-partial `apply(T): U` with otherwise-identical signatures share a
+// vtable slot on any concrete type that implements both. Codegen wraps
+// the slot's return as `{T, i1}` (the partial calling convention) so the
+// slot has one shape. The non-partial interface dispatch site has to
+// unwrap that wrapped return before using it.
+//
+// Before the fix, the non-partial call site used the unwrapped function
+// type. For small returns the bug was invisible (the register layouts
+// the caller and callee disagreed on happened to overlap), but for
+// large returns the disagreement reliably manifested as a crash — on
+// x86_64 the wrapper expected an sret destination buffer in `rdi`, the
+// caller passed the lambda's `this` pointer there, and the wrapper
+// wrote the return into read-only memory.
+//
+// The 3-tuple of `String val` here is large enough to make the caller
+// and callee ABIs noticeably disagree (each `String val` is a pointer,
+// so the unwrapped 24-byte aggregate is already past the 16-byte
+// two-register threshold; the wrapped form adds an i1 flag on top).
+
+actor Main
+  new create(env: Env) =>
+    // Reach the partial lambda interface
+    // `{(String val): (String val, String val, String val) ?}`. The
+    // painter then assigns its `apply` the same vtable index as our
+    // non-partial lambda's `apply` (same mangled name), forcing the
+    // non-partial slot to be wrapped.
+    _call_partial({(s: String val): (String val, String val, String val) ? =>
+      if s == "fail" then error end
+      (s, s, s)
+    })
+
+    // Dispatch through the non-partial lambda interface. The slot is
+    // wrapped, so the call site has to retype the call and unwrap the
+    // result; without that, the wrapper writes the result into the
+    // lambda receiver pointer and segfaults.
+    let f: {(String val): (String val, String val, String val)} box =
+      {(s: String val): (String val, String val, String val) => (s, s, s) }
+
+    (let a, let b, let c) = f("hello")
+
+    if (a != "hello") or (b != "hello") or (c != "hello") then
+      env.exitcode(1)
+    end
+
+  fun _call_partial(
+    p: {(String val): (String val, String val, String val) ?} box)
+  =>
+    try
+      (let x, let y, let z) = p("")?
+      if x.size() == 0 then None end
+    end

--- a/test/full-program-tests/pattern-match-interface-with-eq/main.pony
+++ b/test/full-program-tests/pattern-match-interface-with-eq/main.pony
@@ -1,0 +1,30 @@
+// Regression test for `gen_pattern_eq` not handling vtable dispatch.
+//
+// When a `match` arm is a value whose static type is an interface or trait
+// declaring `eq`, the pattern-matching machinery in `gen_pattern_eq`
+// dispatches `eq` through the vtable. Before the fix, that site derived
+// the call's function type via `LLVMGlobalGetValueType(func)`, but `func`
+// for interface dispatch is a loaded pointer (opaque under LLVM's modern
+// pointer model), not a global — so the returned type was wrong (or
+// `NULL`), and ponyc itself crashed during LLVM IR generation.
+//
+// The fix uses `c_m->func_type` (the cached compile-method type) the same
+// way `gen_call` does.
+
+interface val Eq
+  fun apply(): U64
+  fun eq(other: Eq box): Bool => apply() == other.apply()
+
+class val Box42
+  fun apply(): U64 => 42
+  fun eq(other: Eq box): Bool => apply() == other.apply()
+
+actor Main
+  new create(env: Env) =>
+    let target: Eq = Box42
+    let probe: Eq = Box42
+
+    match target
+    | probe => None
+    else env.exitcode(1)
+    end


### PR DESCRIPTION
A follow-up to #5002. The error-flag wrapper for non-partial concrete methods sharing a vtable slot with a partial method was producing slots whose calling convention didn't match what the non-partial interface call site in `gen_call` was using. For small returns the disagreement was invisible; for returns large enough to need sret on the wrapped side, the wrapper wrote into the lambda's `this` pointer and crashed.

`gen_pattern_eq` had a related, separately latent bug. It pulled the call type from `LLVMGlobalGetValueType(func)`, which doesn't return anything meaningful for the loaded opaque pointer that vtable dispatch produces. Pattern-matching against an interface-typed value with an `eq` method crashed ponyc itself during codegen. `eq` is always non-partial, so `gen_pattern_eq` doesn't need wrap-aware machinery — it just needs the correct function type, pulled from `c_m->func_type` the same way `gen_call` does.

`gen_call` goes through a new `adjust_for_wrapped_vtable_slot` helper that keys off the same `reach_vtable_index_has_partial` predicate the vtable population uses. Two regression tests, both verified to crash on `main` and pass with the fix. Also ran `make` on every Pony library under `ponylang/` (`appdirs`, `crdt`, `courier`, `fork_join`, `glob`, `hobby`, `http`, `http_server`, `livery`, `logger`, `lori`, `mare`, `multipart_mime`, `peg`, `ponyup`, `postgres` unit-tests, `pyrois`, `reactive_streams`, `redis` unit-tests, `regex`, `semver`, `ssl`, `stallion`, `uri`, `valbytes`, `web_link` — `web_link` is where the bug was first noticed); all pass.

Follow-up question parked in #5375: whether to revisit the painter's decision to collapse partial and non-partial methods at the same vtable index, which is what made the calling-convention disagreement possible in the first place.