### PR TITLE
Add --static smoke test to DragonFly Tier-3 job

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -520,6 +520,15 @@ jobs:
           rm -rf build/build_libs
           gmake configure config=debug
           gmake build config=debug
+          # Smoke-test the --static embedded-LLD link path; the test targets
+          # below only exercise dynamic linking. Covers actor init plus
+          # exception unwinding through DragonFly's static recipe (no
+          # crtbeginT.o, pkg-gcc CRT directory resolution).
+          mkdir -p /build/static-smoke
+          printf 'actor Main\n  new create(env: Env) =>\n    try error else env.out.print("static ok") end\n' > /build/static-smoke/main.pony
+          PONYPATH="$PWD/packages" ./build/debug/ponyc --static -o /build/static-smoke /build/static-smoke
+          file /build/static-smoke/static-smoke | grep -q 'statically linked'
+          /build/static-smoke/static-smoke
           gmake test-ci-core config=debug
           gmake test-pony-doc config=debug
           gmake test-pony-lint config=debug


### PR DESCRIPTION
The FreeBSD Tier-3 job smoke-tests the `--static` link path because the regular test targets only exercise dynamic linking. DragonFly's static recipe has DragonFly-specific choices (no `crtbeginT.o`, pkg-gcc CRT directory resolution) that the dynamic recipe doesn't cover, so a regression there would go uncaught until a user hit it.

This mirrors FreeBSD's smoke test into the DragonFly job, adjusted for DragonFly: the smoke files live on the `/build` disk (the root partition is only ~1.8 GB and the job already builds there), and the existing gcc13/SSL env in the build step covers the test.

Closes #5382