### PR TITLE
Use overwrite redirect in test-validate-grammar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ test-examples: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) find ../../examples/*/* -name '*.pony' -print | xargs -n 1 dirname | sort -u | grep -v ffi- | xargs -n 1 -I {} ./ponyc -d -s --checktree -o {} {}
 
 test-validate-grammar: all
-	$(SILENT)cd '$(outDir)' && ./ponyc --antlr >> pony.g.new && diff ../../pony.g pony.g.new
+	$(SILENT)cd '$(outDir)' && ./ponyc --antlr > pony.g.new && diff ../../pony.g pony.g.new
 
 # File-target rules below provide incremental rebuild for the five
 # Pony-source binaries this Makefile builds outside cmake:


### PR DESCRIPTION
The `test-validate-grammar` rule used `>>` (append), so on re-runs in a non-fresh build directory the generated grammar gets appended to the prior copy and the diff against `pony.g` fails with what looks like a grammar regression. CI always starts clean, so only iterative local runs hit it.

Closes #5381