### PR TITLE
Fail loudly when a vendored-LLD patch can't be verified

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -121,7 +121,33 @@ if(GIT_FOUND)
                 message(FATAL_ERROR "Unable to apply ${PATCH}")
             endif()
         else()
-            message("    Already applied ${PATCH}")
+            # The forward check failed. That means either the patch is
+            # already applied, or `git apply` could not evaluate it at all.
+            # The latter happens when lib/llvm/src has a dangling submodule
+            # gitlink: a `.git` file pointing at a `.git/modules/...` target
+            # that isn't present (e.g. the tree was copied or rsynced without
+            # the parent's `.git/modules`). In that case `git apply` aborts
+            # with "fatal: not a git repository" and a non-zero exit. Note
+            # this loop runs unconditionally inside `if(GIT_FOUND)`, even when
+            # the `EXISTS ../.git` submodule-update guard above is false, so
+            # the dangling-gitlink tree reaches this point unchecked.
+            #
+            # Distinguish the two with a reverse check: if the patch
+            # reverse-applies cleanly it is genuinely in the tree and we skip
+            # it; otherwise fail loudly rather than silently build an
+            # unpatched source tree.
+            execute_process(COMMAND ${GIT_EXECUTABLE} apply --reverse --check -p 1 --ignore-whitespace --whitespace=nowarn ${PATCH}
+                            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/llvm/src"
+                            ERROR_VARIABLE _reverse_err_out
+                            RESULT_VARIABLE git_apply_reverse_check_result)
+            if(git_apply_reverse_check_result EQUAL "0")
+                message("    Already applied ${PATCH}")
+            else()
+                message(FATAL_ERROR "Unable to apply or verify ${PATCH}.\n"
+                        "The patch does not apply and is not already applied; the source tree may be missing its git metadata (e.g. a dangling submodule gitlink).\n"
+                        "Forward check error:\n${_err_out}\n"
+                        "Reverse check error:\n${_reverse_err_out}")
+            endif()
         endif()
     endforeach()
 else()


### PR DESCRIPTION
The vendored-LLD patch-apply loop in `lib/CMakeLists.txt` interpreted any non-zero `git apply --check` exit as "already applied". When `lib/llvm/src` has a dangling submodule gitlink (a `.git` file pointing at a `.git/modules/...` target that isn't present — e.g. the tree was copied or rsynced without the parent's `.git/modules`), `git apply` aborts with "fatal: not a git repository" (exit 128). CMake then printed "Already applied" and built an unpatched LLD source tree, producing a broken linker — the failure mode that surfaced during the OpenBSD embedded-LLD work.

The fix distinguishes "already applied" from "could not evaluate the patch" by running `git apply --reverse --check` in the else branch: if the patch reverse-applies cleanly it is genuinely in the tree and we skip it; otherwise the build fails with both the forward and reverse `git` error messages instead of silently building an unpatched tree. Because `git apply` is atomic, a partially-applied patch fails both checks and is reported rather than skipped.

This keeps the existing git-based toolchain (the issue's suggested approach 1) rather than switching to `patch`, which isn't a standard tool on the Windows build path that also runs this loop.

Verified empirically (git 2.54.0) across all four states — valid/unapplied → apply, already-applied → skip, dangling gitlink → fatal, broken patch → fatal — and against the two real patches on the actual submodule tree.

Behavior note: a tree that has a dangling gitlink *and* already has the patch applied now fails the build instead of silently proceeding. This is intentional and matches the issue's stated fix (fail loudly when neither forward nor reverse applies) — git genuinely cannot verify patch state without its metadata. ponyc CI is unaffected: the libs cache stores build output, not the patched source tree, and the patch loop runs only on a fresh, healthy checkout.

Closes #5383