### PR TITLE
Disable buildx binary caching in image-build workflows

### DIFF
--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -61,6 +62,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -84,6 +86,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -107,6 +110,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -130,6 +134,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -153,6 +158,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -176,6 +182,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -199,6 +206,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -222,6 +230,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -245,6 +254,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -268,6 +278,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -291,6 +302,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4

--- a/.github/workflows/build-release-image.yml
+++ b/.github/workflows/build-release-image.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -62,6 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4
@@ -93,6 +95,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
         with:
           version: v0.23.0
+          cache-binary: false
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@v4

--- a/.github/workflows/pr-docker-image-validation.yml
+++ b/.github/workflows/pr-docker-image-validation.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
       - name: Docker build
         run: |
           docker buildx create --name multiplatform --driver docker-container --use --bootstrap
@@ -40,6 +42,8 @@ jobs:
       - name: Set up Docker Buildx
         # v3.10.0
         uses: docker/setup-buildx-action@v4
+        with:
+          cache-binary: false
       - name: Docker build
         run: |
           docker buildx create --name multiplatform --driver docker-container --use --bootstrap


### PR DESCRIPTION
The LLVM libs cache puts the repo right up against GitHub's per-repo Actions cache size limit. The buildx binary cache (`buildx-dl-bin-*`) is a relatively unimportant cached item, but under that pressure it competes for space and can trigger LRU eviction of an entry that actually matters — such as the LLVM libs cache a release build depends on.

This turns it off (`cache-binary: false`) on every `setup-buildx-action` step across the image-build workflows. The cost is negligible: each run re-downloads the small buildx binary instead of restoring it from cache, removing the eviction risk.