### PR TITLE
Fix base64 decode over-allocating the output buffer

### DIFF
--- a/packages/encode/base64/base64.pony
+++ b/packages/encode/base64/base64.pony
@@ -140,7 +140,11 @@ primitive Base64
     not an error. Non-base64 data, other than whitespace (which can appear at
     any time), is an error.
     """
-    let len = (data.size() * 4) / 3
+    // Upper bound on the decoded size: every 4 input characters yield at most
+    // 3 output bytes, so the decoded data is ceil(data.size() * 3 / 4) bytes.
+    // Whitespace and padding only reduce the output, so this never
+    // under-allocates (and over-allocates by at most one byte).
+    let len = ((data.size() * 3) + 3) / 4
     let out = recover A(len) end
 
     var state = U8(0)


### PR DESCRIPTION
`Base64.decode` sized its output buffer with `(data.size() * 4) / 3` — about 1.33x the input length. Decoded base64 is only ~0.75x the input (4 input characters yield 3 output bytes), so this over-allocated by roughly 1.78x the actual decoded size.

The fix uses `ceil(data.size() * 3 / 4)`, a tight upper bound on the decoded size. It never under-allocates (verified across every input-length residue class, including the lenient decoder's missing-padding and single-trailing-character cases) and over-allocates by at most one byte, so `push()` never has to reallocate.

This is a pure memory optimization: decode output is byte-identical regardless of the initial allocation, since `Array.push` reallocates on demand. The existing round-trip tests already cover correctness across all length classes, so no new test is added.

Closes #4051