### PR TITLE
Fix compiler crash when a generic with a constructable union constraint is instantiated with a union

### DIFF
--- a/.release-notes/fix-generic-union-constructable-constraint-crash.md
+++ b/.release-notes/fix-generic-union-constructable-constraint-crash.md
@@ -1,0 +1,27 @@
+## Fix compiler crash when a generic with a constructable union constraint is instantiated with a union
+
+Previously, instantiating a generic whose type parameter had a *constructable union constraint* — a union whose members can all be constructed, such as `(Default val | None val)` — with a non-concrete type argument like another union crashed the compiler with an assertion failure:
+
+```pony
+primitive A
+primitive B
+
+interface val Default
+  new val create()
+
+class Generic[T: (Default val | None val)]
+  let x: T = T.create()
+  fun get(): T => x
+
+actor Main
+  new create(env: Env) =>
+    // Crashed the compiler.
+    let bad = Generic[(A | B)].get()
+```
+
+The compiler now rejects this at compile time with a clear error instead of crashing:
+
+```
+Error:
+a constructable constraint can only be fulfilled by a concrete type argument
+```

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -2264,6 +2264,24 @@ bool is_constructable(ast_t* type)
   switch(ast_id(type))
   {
     case TK_UNIONTYPE:
+    {
+      // A union is constructable only if every member is constructable. A
+      // constructor call dispatched through the union must resolve on all
+      // members, so a single non-constructable member makes the union
+      // non-constructable.
+      ast_t* child = ast_child(type);
+
+      while(child != NULL)
+      {
+        if(!is_constructable(child))
+          return false;
+
+        child = ast_sibling(child);
+      }
+
+      return true;
+    }
+
     case TK_TUPLETYPE:
       return false;
 


### PR DESCRIPTION
Instantiating a generic whose type parameter has a constructable union constraint — a union whose members can all be constructed, such as `(Default val | None val)` — with a non-concrete type argument like another union crashed the compiler with an assertion failure (`ast_error_frame: Assertion 'ast != NULL' failed`) during the reachability pass.

`is_constructable()` treated every union type as non-constructable, so the guard in `check_constraints()` that requires a concrete type argument for a constructable constraint was skipped. The bad instantiation passed constraint checking and later tripped the assertion instead of being rejected.

A union is now constructable when every member is constructable (mirroring how a constructor call dispatched through a union must resolve on all members), so the existing constraint check fires and rejects the instantiation with the intended error:

```
a constructable constraint can only be fulfilled by a concrete type argument
```

This matches the fix direction agreed on in the issue.

No automated regression test is included. The crash only manifests in a full compile (it surfaces in the reachability pass with the real `builtin` package); the `libponyc.tests` unit harness rejects the same program earlier, at the expr pass, so a unit test there passes both before and after this change and cannot guard against a regression. Flagging this for maintainers — a `full-program-test`-style expected-compile-failure case may be the right vehicle if one is wanted.

Closes #4096
