### PR TITLE
Fix `use=dtrace` builds on FreeBSD

### DIFF
--- a/.ci-scripts/freebsd-dtrace-smoke.sh
+++ b/.ci-scripts/freebsd-dtrace-smoke.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# use=dtrace smoke test for the FreeBSD tier-3 job. Runs inside
+# the FreeBSD VM, invoked from .github/workflows/ponyc-tier3.yml. POSIX sh, not
+# bash: FreeBSD's base system has no bash. Expects to run from the ponyc source
+# root with doas configured (the tier-3 install step grants the build user
+# passwordless doas so it can load the dtrace kernel module and run dtrace).
+#
+# Tier-3 otherwise never builds with dtrace, so FreeBSD's illumos dtrace path
+# went uncovered. This builds a clean dtrace runtime and links+runs a program,
+# which exercises both the runtime build (`dtrace -G`) and the
+# `-ldtrace_probes` link path. Then, where the dtrace kernel device can be
+# loaded, it asserts a `pony` provider probe actually fires.
+set -eu
+
+# Build the dtrace runtime from scratch. The earlier non-dtrace config=debug
+# build left a build dir behind, and reconfiguring it in place re-runs the
+# standalone-library rule over a read-only leftover (`libc++.a` is 0444, so the
+# copied `libcpp.a` is too) which fails. `clean` is config-scoped and defaults
+# to release, so pass config=debug to remove the debug build/output dirs; the
+# prebuilt LLVM in build/libs is untouched.
+gmake clean config=debug
+gmake configure config=debug use=dtrace
+gmake build config=debug
+
+smoke=/tmp/dtrace-smoke
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    var i: USize = 0
+    while i < 2000 do
+      Spinner
+      i = i + 1
+    end
+
+actor Spinner
+  be noop() => None
+PONY
+
+PONYPATH="$PWD/packages" ./build/debug-dtrace/ponyc -o "$smoke" "$smoke"
+"$smoke/dtrace-smoke"
+
+# If the VM can load the dtrace device, assert a pony provider probe actually
+# fires. Tolerate a VM that can't load it (environment), but fail on a real
+# regression where the probe is registered yet silent.
+doas kldload dtraceall 2>/dev/null || true
+if doas dtrace -l >/dev/null 2>&1; then
+  out=$(doas dtrace -q -n 'pony*:::actor-alloc { @ = count(); } END { printa("ALLOC=%@u\n", @); }' -c "$smoke/dtrace-smoke" 2>&1)
+  echo "$out"
+  echo "$out" | grep -qE 'ALLOC=[1-9]' || { echo "FAIL: pony dtrace provider did not fire"; exit 1; }
+  echo "pony dtrace provider fired"
+else
+  echo "dtrace device unavailable in CI VM; skipped probe-firing assertion"
+fi

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -132,10 +132,17 @@ jobs:
             "su: Sorry" { puts "su failed - wrong password or nuageinit didn't set it"; exit 1 }
             timeout { puts "Timeout waiting for root shell"; exit 1 }
           }
-          send "pkg install -y cmake gmake libunwind git python3 rsync\r"
+          send "pkg install -y cmake gmake libunwind git python3 rsync doas\r"
           expect {
             "#" {}
             timeout { puts "Timeout during pkg install"; exit 1 }
+          }
+          # Let the freebsd user load the dtrace kernel module and run dtrace
+          # non-interactively for the use=dtrace probe-firing smoke test.
+          send "echo 'permit nopass freebsd' > /usr/local/etc/doas.conf\r"
+          expect {
+            "#" {}
+            timeout { puts "Timeout writing doas.conf"; exit 1 }
           }
           send "exit\r"
           expect eof
@@ -167,6 +174,8 @@ jobs:
           gmake configure config=release
           gmake build config=release
           gmake test-ci-core config=release
+          # use=dtrace smoke test — see the script for details.
+          sh .ci-scripts/freebsd-dtrace-smoke.sh
           EOF
       - name: Shutdown VM
         if: always()

--- a/.release-notes/fix-freebsd-dtrace.md
+++ b/.release-notes/fix-freebsd-dtrace.md
@@ -1,0 +1,7 @@
+## Fix `use=dtrace` builds on FreeBSD
+
+Building ponyc with `use=dtrace` failed on FreeBSD: the runtime build aborted with `dtrace: failed to link script ... No probe sites found for declared provider`, and even past that, programs compiled by a dtrace-enabled ponyc could not be linked.
+
+`use=dtrace` now builds and links correctly on FreeBSD, and dynamically-linked programs expose their `pony` provider probes to DTrace.
+
+`--static` programs build and run but do not expose their probes: FreeBSD registers DTrace USDT probes through the runtime linker, which statically-linked programs don't use.

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,7 @@ install: build
 	@mkdir -p $(ponydir)/lib/$(arch)
 	@mkdir -p $(ponydir)/include/pony/detail
 	$(SILENT)cp $(buildDir)/src/libponyrt/libponyrt.a $(ponydir)/lib/$(arch)
+	$(SILENT)if [ -f $(buildDir)/src/libponyrt/libdtrace_probes.a ]; then cp $(buildDir)/src/libponyrt/libdtrace_probes.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyc.a ]; then cp $(outDir)/libponyc.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyc-standalone.a ]; then cp $(outDir)/libponyc-standalone.a $(ponydir)/lib/$(arch); fi
 	$(SILENT)if [ -f $(outDir)/libponyrt-pic.a ]; then cp $(outDir)/libponyrt-pic.a $(ponydir)/lib/$(arch); fi
@@ -441,6 +442,7 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt.a $(prefix)/lib/libponyrt.a; fi
 	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif
@@ -453,6 +455,7 @@ uninstall:
 	-$(SILENT)rm -f $(prefix)/bin/pony-doc ||:
 	-$(SILENT)rm -f $(prefix)/lib/libponyc*.a ||:
 	-$(SILENT)rm -f $(prefix)/lib/libponyrt*.a ||:
+	-$(SILENT)rm -f $(prefix)/lib/libdtrace_probes.a ||:
 	-$(SILENT)rm -rf $(prefix)/lib/pony ||:
 	-$(SILENT)rm -f $(prefix)/include/pony.h ||:
 	-$(SILENT)rm -rf $(prefix)/include/pony ||:

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(libponyrt VERSION ${PONYC_PROJECT_VERSION} LANGUAGES C CXX)
 
+# NOTE: on FreeBSD with use=dtrace these sources are extracted from libponyrt.a
+# by basename (see dtrace_freebsd_postbuild.sh), so their basenames must stay
+# unique across directories. The postbuild script fails loudly if two collide.
 set(_c_src
     actor/actor.c
     actor/messageq.c
@@ -57,7 +60,60 @@ add_library(libponyrt STATIC
     ${_c_src}
 )
 
-if(PONY_USE_DTRACE)
+if(PONY_USE_DTRACE AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    # FreeBSD ships the illumos-derived dtrace(1), whose `-G` step works very
+    # differently from the SystemTap `dtrace` on Linux and the macOS one:
+    #
+    #   * It does NOT synthesize the probe object from the .d script alone.
+    #     It scans the *compiled* runtime objects for probe call sites,
+    #     rewrites those sites in place (turning the undefined __dtrace_*
+    #     references into resolved absolute symbols), and emits a separate
+    #     object that carries only the DOF plus a constructor that registers
+    #     the probes at process start.
+    #   * Because the call sites are rewritten in the runtime objects, those
+    #     same objects must be the ones archived into libponyrt. The emitted
+    #     DOF object must then be linked separately, whole-archive, so its
+    #     (otherwise unreferenced) registration constructor survives the link.
+    #     genexe.cc already does this via `--whole-archive -ldtrace_probes`.
+    #
+    # So after libponyrt.a is built we extract its (pristine) objects, run
+    # `dtrace -G` over them, re-archive libponyrt.a from the patched objects,
+    # and stash the DOF object in its own libdtrace_probes.a. Doing it in a
+    # POST_BUILD step over the archive keeps CMake's tracked objects pristine,
+    # so every rebuild redoes the rewrite from clean objects (no "dtrace -G over
+    # an already-patched object" hazard) and works under the Makefile generator,
+    # where an OBJECT library's outputs aren't usable as custom-command deps.
+    # The non-FreeBSD path below keeps the simpler scheme: generate the probe
+    # object from the .d alone and fold it straight into libponyrt.
+    set(_dtrace_d "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.d")
+
+    # The runtime sources include the generated dtrace_probes.h (via dtrace.h),
+    # so it must exist before they compile. Generate it into the build tree
+    # (not the source tree) and make libponyrt depend on it.
+    set(_dtrace_header "${libponyrt_BINARY_DIR}/dtrace_probes.h")
+    add_custom_command(OUTPUT "${_dtrace_header}"
+        COMMAND dtrace -h -s "${_dtrace_d}" -o "${_dtrace_header}"
+        DEPENDS "${_dtrace_d}"
+    )
+    add_custom_target(dtrace_probes_header DEPENDS "${_dtrace_header}")
+    add_dependencies(libponyrt dtrace_probes_header)
+    target_include_directories(libponyrt PRIVATE "${libponyrt_BINARY_DIR}")
+
+    # POST_BUILD runs whenever libponyrt.a is (re)built, which covers source
+    # changes. It also produces libdtrace_probes.a as a side effect, so both
+    # archives only regenerate when libponyrt relinks. Two consequences: editing
+    # dtrace_probes.d alone (without touching a .c) won't re-run this, and
+    # deleting libdtrace_probes.a by hand won't recreate it on its own — do a
+    # clean rebuild in either case.
+    add_custom_command(TARGET libponyrt POST_BUILD
+        COMMAND sh "${CMAKE_CURRENT_SOURCE_DIR}/dtrace_freebsd_postbuild.sh"
+                "$<TARGET_FILE:libponyrt>"
+                "${libponyrt_BINARY_DIR}/libdtrace_probes.a"
+                "${_dtrace_d}"
+                "${CMAKE_AR}"
+        VERBATIM
+    )
+elseif(PONY_USE_DTRACE)
     add_custom_command(OUTPUT dtrace_probes.o
         COMMAND dtrace -h -s "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.d" -o "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.h"
         COMMAND dtrace -G -s "${CMAKE_CURRENT_SOURCE_DIR}/../common/dtrace_probes.d" -o dtrace_probes.o
@@ -115,6 +171,19 @@ else()
         COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
         COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
     )
+
+    # On FreeBSD the DOF object lives in its own archive built by the POST_BUILD
+    # script above. Copy it next to libponyrt.a so a ponyc run from the build
+    # dir can resolve `-ldtrace_probes`. This is registered after that script
+    # (both are POST_BUILD on libponyrt, run in order), so the archive exists.
+    if(PONY_USE_DTRACE AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+        add_custom_command(TARGET libponyrt POST_BUILD
+            COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
+            COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
+            COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
+            COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
+        )
+    endif()
 endif (MSVC)
 
 if(PONY_RUNTIME_BITCODE)

--- a/src/libponyrt/dtrace_freebsd_postbuild.sh
+++ b/src/libponyrt/dtrace_freebsd_postbuild.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# POST_BUILD step for libponyrt on FreeBSD when building with use=dtrace.
+# Invoked from src/libponyrt/CMakeLists.txt; see the comment there for the full
+# rationale. In short: FreeBSD's illumos-derived `dtrace -G` rewrites probe-site
+# objects in place and emits a separate DOF object. So we extract libponyrt.a's
+# freshly-compiled objects, run `dtrace -G` over them, re-archive libponyrt.a
+# from the patched objects, and put the DOF object in its own libdtrace_probes.a
+# (linked whole-archive by genexe.cc). Working on extracted copies keeps CMake's
+# tracked objects pristine, so every rebuild redoes this from clean objects.
+#
+#   $1 = libponyrt.a            (rewritten in place from the patched objects)
+#   $2 = libdtrace_probes.a     ((re)created with the DOF object)
+#   $3 = dtrace_probes.d        (the provider script)
+#   $4 = ar                     (the archiver CMake uses; a single executable
+#                                path — CMAKE_AR is never a multi-word command)
+set -eu
+
+archive="$1"
+dtrace_lib="$2"
+dscript="$3"
+ar="$4"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Extract the freshly-compiled (pristine) runtime objects.
+(cd "$tmp" && "$ar" x "$archive")
+
+# Snapshot the object list BEFORE dtrace -G creates dtrace_probes.o, so the DOF
+# object is not mistaken for a runtime object below.
+set -- "$tmp"/*.o
+
+# `ar x` flattens members to their basenames. If two runtime sources ever share
+# a basename (e.g. a future ds/list.c next to the existing one), extraction
+# would silently collapse them and we'd re-archive an incomplete libponyrt.a.
+# Fail loudly instead: the extracted object count must equal the member count.
+members=$("$ar" t "$archive" | wc -l | tr -d ' ')
+if [ "$#" -ne "$members" ]; then
+  echo "dtrace postbuild: extracted $# objects but archive has $members members;" \
+       "runtime source basenames must be unique (see _c_src in CMakeLists.txt)" >&2
+  exit 1
+fi
+
+# Rewrite the probe sites in place and emit the DOF object.
+dtrace -G -s "$dscript" -o "$tmp/dtrace_probes.o" "$@"
+
+# Re-archive both libs by writing a sibling file and renaming into place, so an
+# interrupted run can't leave a truncated archive that a timestamp check would
+# then treat as up to date. The .new files sit next to their targets, so the
+# rename is a same-filesystem atomic replace. libponyrt.a holds the patched
+# runtime objects; libdtrace_probes.a holds only the DOF object.
+"$ar" qcs "${archive}.new" "$@"
+mv -f "${archive}.new" "$archive"
+"$ar" qcs "${dtrace_lib}.new" "$tmp/dtrace_probes.o"
+mv -f "${dtrace_lib}.new" "$dtrace_lib"


### PR DESCRIPTION
FreeBSD's illumos-derived `dtrace -G` finds probe sites by scanning the compiled objects and rewriting them in place, then emits a separate DOF object — unlike the SystemTap/macOS `dtrace`, which builds the probe object from the `.d` script alone. The runtime CMake rule passed it no objects, so `use=dtrace` builds died with "No probe sites found", and no `libdtrace_probes.a` was ever built for the link recipe that already references `-ldtrace_probes`. Tier-3 CI never built `use=dtrace`, so none of this was caught.

On FreeBSD this now runs `dtrace -G` over `libponyrt.a`'s objects in a POST_BUILD step, re-archives from the patched objects, and emits the DOF into its own `libdtrace_probes.a` that the install step ships. A `use=dtrace` smoke test is added to the FreeBSD tier-3 job: build, link, run, and — where the kernel dtrace module is available — assert a `pony` provider probe actually fires.

`--static` programs build and run but do not expose their probes; FreeBSD registers USDT probes through the runtime linker, which statically-linked programs don't use. That limitation is noted in the release notes.

Closes #5367