### PR TITLE
Reject self-referential type parameter constraints

### DIFF
--- a/.release-notes/2497.md
+++ b/.release-notes/2497.md
@@ -1,0 +1,9 @@
+## Reject self-referential type parameter constraints
+
+A generic type parameter whose constraint referred back to itself used to crash the compiler. For example:
+
+```pony
+class A[B: (B | C)]
+```
+
+The compiler now reports a clear error for these constraints instead of crashing.

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -61,9 +61,9 @@ static ast_result_t flatten_isect(pass_opt_t* opt, ast_t* ast)
   return AST_OK;
 }
 
-bool constraint_contains_tuple(ast_t* constraint, ast_t* scan)
+static bool constraint_contains_tuple(ast_t* type)
 {
-  switch(ast_id(scan))
+  switch(ast_id(type))
   {
     case TK_TUPLETYPE:
     {
@@ -72,32 +72,28 @@ bool constraint_contains_tuple(ast_t* constraint, ast_t* scan)
 
     case TK_UNIONTYPE:
     {
-      bool r = false;
-
-      ast_t* child = ast_child(constraint);
-      child = ast_sibling(child);
-
-      while(child != NULL)
+      // Recurse into every member. Members can themselves be unions (a
+      // constraint isn't fully flattened when this runs during the visit
+      // of a contained typeparamref) or type aliases, so we must descend
+      // each one rather than scanning a single level.
+      for(ast_t* child = ast_child(type); child != NULL;
+        child = ast_sibling(child))
       {
-        if(constraint_contains_tuple(constraint, child))
-          r = true;
-        child = ast_sibling(child);
+        if(constraint_contains_tuple(child))
+          return true;
       }
 
-      return r;
+      return false;
     }
 
     case TK_TYPEALIASREF:
     {
-      ast_t* unfolded = typealias_unfold(scan);
+      ast_t* unfolded = typealias_unfold(type);
 
       if(unfolded == NULL)
         return false;
 
-      // Pass unfolded as both constraint and scan: after unfolding, the
-      // concrete type IS the effective constraint. The TK_UNIONTYPE case
-      // iterates constraint's children, which must be the union members.
-      bool r = constraint_contains_tuple(unfolded, unfolded);
+      bool r = constraint_contains_tuple(unfolded);
       ast_free_unattached(unfolded);
       return r;
     }
@@ -106,6 +102,136 @@ bool constraint_contains_tuple(ast_t* constraint, ast_t* scan)
   }
 
   return false;
+}
+
+// Resolve a type parameter to the constraint we should walk, collapsing bare
+// self/mutual chains to NULL the way typeparam_constraint does. A bare
+// typeparamref constraint is the internal form of an unconstrained parameter
+// (`[A]` becomes `A: A`) or a bare chain; typeparam_constraint collapses such
+// self/mutual loops to NULL, so they are not self-referential. A compound
+// constraint is returned as-is. The result is borrowed, not owned.
+static ast_t* effective_constraint(ast_t* def)
+{
+  ast_t* constraint = ast_childidx(def, 1);
+
+  if(ast_id(constraint) == TK_TYPEPARAMREF)
+    return typeparam_constraint(constraint);
+
+  return constraint;
+}
+
+// Walk a type's structure looking for a reference back to 'root' — the type
+// parameter whose constraint we are validating. Descent passes through the
+// structural positions that the subtype checker inlines a constraint into
+// (union/intersection/tuple members, arrow RHS, alias unfolds) but STOPS at
+// TK_NOMINAL: a reference reached behind a constructor (F-bounded
+// polymorphism, e.g. `A: Comparable[A]`) is productive and terminates in the
+// subtype checker via its nominal cycle guard, so it stays legal.
+//
+// '*visited' accumulates every other type parameter whose constraint has been
+// expanded during this walk. A parameter is added the first time it is
+// reached and never removed, so each one is expanded at most once per root.
+// This both bounds the walk (re-encountering a parameter — including a cycle
+// back-edge — ends that branch) and keeps it linear on constraint graphs that
+// fan out, where a path-scoped set would re-walk shared sub-graphs
+// exponentially. Suppressing a re-visit can't hide a real cycle: 'root' is
+// matched before the visited check, and a reachable 'root' returns true on the
+// parameter's first expansion, which short-circuits all the way out.
+//
+// A reported cycle isn't necessarily centred on 'root': a cycle routed through
+// a bare-chain member (collapsed by effective_constraint) may be flagged at a
+// neighbouring parameter instead. Every cycle has at least one member flagged
+// at its own definition, so the constraint is always rejected; an all-compound
+// cycle flags every member.
+static bool constraint_reaches_root(ast_t* root, ast_t* type,
+  astlist_t** visited)
+{
+  switch(ast_id(type))
+  {
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    case TK_TUPLETYPE:
+    {
+      for(ast_t* child = ast_child(type); child != NULL;
+        child = ast_sibling(child))
+      {
+        if(constraint_reaches_root(root, child, visited))
+          return true;
+      }
+
+      return false;
+    }
+
+    case TK_TYPEPARAMREF:
+    {
+      ast_t* def = (ast_t*)ast_data(type);
+
+      if(def == root)
+        return true;
+
+      if(astlist_find(*visited, def) != NULL)
+        return false;
+
+      *visited = astlist_push(*visited, def);
+
+      ast_t* constraint = effective_constraint(def);
+
+      if(constraint == NULL)
+        return false;
+
+      return constraint_reaches_root(root, constraint, visited);
+    }
+
+    case TK_TYPEALIASREF:
+    {
+      ast_t* unfolded = typealias_unfold(type);
+
+      if(unfolded == NULL)
+        return false;
+
+      bool r = constraint_reaches_root(root, unfolded, visited);
+      ast_free_unattached(unfolded);
+      return r;
+    }
+
+    case TK_ARROW:
+      // Arrows are rejected as constraints in the syntax pass, so a directly
+      // written arrow constraint never reaches here; this is only reachable
+      // when an alias unfolds to an arrow. Walk the RHS for completeness.
+      return constraint_reaches_root(root, ast_childidx(type, 1), visited);
+
+    default:
+      // TK_NOMINAL and leaves stop the walk.
+      return false;
+  }
+}
+
+static ast_result_t flatten_typeparam(pass_opt_t* opt, ast_t* ast)
+{
+  ast_t* constraint = effective_constraint(ast);
+
+  if(constraint == NULL)
+    return AST_OK;
+
+  astlist_t* visited = NULL;
+  bool reaches = constraint_reaches_root(ast, constraint, &visited);
+
+  // The list never owns the AST nodes it points at (the astlist free fn is
+  // NULL), so this frees the cells only.
+  astlist_free(visited);
+
+  if(reaches)
+  {
+    ast_t* id = ast_child(ast);
+
+    ast_error(opt->check.errors, ast, "type parameter '%s' can't appear "
+      "directly in its own constraint", ast_name(id));
+    ast_error_continue(opt->check.errors, ast_childidx(ast, 1),
+      "constraint is here");
+    return AST_ERROR;
+  }
+
+  return AST_OK;
 }
 
 ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast)
@@ -132,7 +258,7 @@ ast_result_t flatten_typeparamref(pass_opt_t* opt, ast_t* ast)
   // the one used in syntax.
   ast_t* constraint = typeparam_constraint(ast);
   if(constraint != NULL
-    && constraint_contains_tuple(constraint, constraint))
+    && constraint_contains_tuple(constraint))
   {
     ast_error(opt->check.errors, constraint,
       "constraint contains a tuple; tuple types can't be used as type constraints");
@@ -380,6 +506,9 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
 
     case TK_ARROW:
       return flatten_arrow(options, astp);
+
+    case TK_TYPEPARAM:
+      return flatten_typeparam(options, ast);
 
     case TK_TYPEPARAMREF:
       return flatten_typeparamref(options, ast);

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -2827,6 +2827,170 @@ TEST_F(BadPonyTest, FBoundedTraitWithSelfApplyEmitsConstraintError)
     "type argument is outside its constraint");
 }
 
+TEST_F(BadPonyTest, SelfReferentialConstraintInUnionErrors)
+{
+  // Regression test for ponylang/ponyc#2497. A type parameter that
+  // references itself as a member of a union in its own constraint used
+  // to crash the compiler with a stack overflow: the subtype checker
+  // replaces the parameter with its constraint and re-decomposes the
+  // union back into the parameter forever (is_typeparam_sub_x in
+  // src/libponyc/type/subtype.c, which has no cycle guard for
+  // typeparamref pairs). It must now be a clean compile error.
+  const char* src =
+    "class C\n"
+    "class A[B: (B | C)]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "type parameter 'B' can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, SelfReferentialConstraintInUnionReversedErrors)
+{
+  // The same illegal shape as SelfReferentialConstraintInUnionErrors with
+  // the union members reversed. This order happened to compile before the
+  // fix (the crash was evaluation-order dependent), so it guards against
+  // the order-sensitive half-fix.
+  const char* src =
+    "class C\n"
+    "class A[B: (C | B)]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "type parameter 'B' can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, SelfReferentialConstraintInIntersectionErrors)
+{
+  // The self-reference sits in an intersection member rather than a union
+  // member. The intersection is itself a union member so the constraint
+  // resolves a capability (otherwise the "no valid capability" check fires
+  // first); this exercises the intersection arm of the cycle walk.
+  const char* src =
+    "trait T\n"
+    "class A[B: (None | (B & T))]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "type parameter 'B' can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, MutuallyRecursiveConstraintInUnionErrors)
+{
+  // Mutual recursion through compound constraints (Praetonus's example in
+  // ponylang/ponyc#2497): A's constraint names B, B's names A. Each is
+  // self-referential as a cycle, so it must be rejected. Bare mutual
+  // chains (`[A: B, B: A]`) collapse to "unconstrained" and stay legal;
+  // this case does not, because the references are union members.
+  const char* src =
+    "class C\n"
+    "  fun foo[A: (B | None), B: (A | None)]() =>\n"
+    "    None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  // Both A and B sit in the cycle, so each is flagged at its own definition.
+  TEST_ERRORS_2(src,
+    "type parameter 'A' can't appear directly in its own constraint",
+    "type parameter 'B' can't appear directly in its own constraint");
+}
+
+TEST_F(BadPonyTest, TransitiveSelfReferentialConstraintErrors)
+{
+  // The self-reference is reached transitively: X is constrained by Y,
+  // and Y's constraint names X as a union member. typeparam_constraint
+  // resolves X's effective constraint to Y's `(X | None)`, which contains
+  // X, so the cycle must be rejected.
+  const char* src =
+    "class A[X: Y, Y: (X | None)]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, NestedSelfReferentialConstraintInUnionErrors)
+{
+  // The self-reference is nested one level deeper than
+  // SelfReferentialConstraintInUnionErrors. Reaching it depends on the
+  // constraint-tuple scan in the flatten pass terminating on nested
+  // unions (it previously recursed forever on the inner union, crashing
+  // before this check could run). It must produce the same clean error.
+  const char* src =
+    "class C\n"
+    "class A[B: (B | (C | B))]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "type parameter 'B' can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, SelfReferentialConstraintViaParameterizedAliasErrors)
+{
+  // The self-reference is revealed by unfolding a parameterized type
+  // alias: `MyU[B]` expands to `(B | None)`, so B appears as a bare union
+  // member of its own constraint. This exercises the alias-unfold arm of
+  // the cycle walk and must be rejected.
+  const char* src =
+    "type MyU[X] is (X | None)\n"
+    "class A[B: MyU[B]]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERROR_WITH_NOTE(src,
+    "type parameter 'B' can't appear directly in its own constraint",
+    "constraint is here");
+}
+
+TEST_F(BadPonyTest, SelfReferenceBehindNominalConstraintCompiles)
+{
+  // The carve-out for ponylang/ponyc#2497: a type parameter may reference
+  // itself when the reference is behind a constructor (a nominal typearg).
+  // Here B appears only inside `Array[B]`, a union member, so the subtype
+  // checker terminates via its nominal cycle guard. This is well-formed
+  // and must compile.
+  const char* src =
+    "class A[B: (None | Array[B])]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, UnconstrainedTypeParameterCompiles)
+{
+  // Guard against the #2497 fix over-reaching. An unconstrained type
+  // parameter `[A]` is sugared to `A: A` and resolves to a self-
+  // referential typeparamref, which typeparam_constraint collapses to
+  // "no constraint". This must not be mistaken for an illegal self-
+  // referential constraint.
+  const char* src =
+    "class A[B]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(BadPonyTest, WhileBodyAndElseJumpAwayInSeparateFunction)
 {
   // From issue #2792 (first example). A while loop whose body and else

--- a/test/libponyc/flatten.cc
+++ b/test/libponyc/flatten.cc
@@ -129,3 +129,41 @@ TEST_F(FlattenTest, MultipleTuplesConstraintInUnion)
   ASSERT_EQ(2, errormsg->line);
   ASSERT_EQ(16, errormsg->pos);
 }
+
+TEST_F(FlattenTest, TupleConstraintFirstInUnion)
+{
+  // The tuple is the first member of the union. The constraint-tuple scan
+  // must check every member, including the first; an earlier version
+  // skipped the leading member, letting this compile.
+  const char* src =
+    "type Blocksize is ((U8, U32) | U8)\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
+TEST_F(FlattenTest, TupleConstraintInNestedUnion)
+{
+  // The tuple is nested inside a union within a union. The scan used to
+  // recurse on the wrong node and loop forever on such nested unions,
+  // crashing the compiler; it must terminate and report the tuple.
+  const char* src =
+    "type Blocksize is (U8 | (U32 | (U8, U32)))\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -249,6 +249,25 @@ TEST_F(IftypeTest, Tuple_MutuallyRecursiveConstraint)
 }
 
 
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraint)
+{
+  // An iftype whose subtype bound names the tested parameter through a
+  // union desugars to a synthetic type parameter whose constraint
+  // references itself. That self-referential constraint used to crash the
+  // compiler (same recursion as ponylang/ponyc#2497); it must now be a
+  // clean error.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[U8](0)\n"
+
+    "  fun foo[A](x: A) =>\n"
+    "    iftype A <: (A | None) then None end";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
 TEST_F(IftypeTest, NestedCond)
 {
   const char* src =


### PR DESCRIPTION
A type parameter whose constraint refers back to itself through a union, intersection, or tuple — for example `class A[B: (B | C)]` — crashed the compiler with a stack overflow. Depending on union member order and nesting depth, the same shape sometimes compiled instead, even though the constraint was meaningless.

These constraints are now rejected in the flatten pass with a clear error, before the recursion in the subtype checker is reached. Coverage includes direct, reversed, mutually recursive, transitive, nested, intersection-position, parameterized-alias, and `iftype` self-references. F-bounded polymorphism (a self-reference behind a type constructor, e.g. `class A[B: Comparable[B]]`) and unconstrained type parameters remain legal.

This also fixes a pre-existing bug in the flatten pass's tuple-in-constraint scan that was reached by the nested case: it walked the wrong AST node and recursed forever on a nested union inside an aliased constraint, and it skipped the first union member (missing a tuple in the leading position of an aliased union constraint).

Closes #2497