### PR TITLE
Fix compiler crashes from control expressions that jump away in value positions

### DIFF
--- a/.release-notes/fix-jumps-away-crashes.md
+++ b/.release-notes/fix-jumps-away-crashes.md
@@ -1,0 +1,29 @@
+## Fix compiler crashes involving control expressions that jump away
+
+A control expression that "jumps away" with no value — `error`, `return`,
+`break`, or `continue` — has no type. Using one in several positions crashed the
+compiler instead of compiling or reporting a clear error.
+
+A `repeat` loop whose `else` clause jumps away now compiles correctly:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    try let x: U8 = repeat 1 until false else error end end
+```
+
+Using a jump-away expression where a value is required now produces a clear
+compile error instead of crashing the compiler. This covers many positions,
+including conditions, `match` operands and guards, `recover` operands, call and
+FFI arguments, method receivers, `as` and identity (`is`/`isnt`) operands,
+default arguments, lambda captures, and tuple elements:
+
+```pony
+// each of these now reports an error rather than crashing the compiler
+if error then U8(1) else U8(2) end
+match error | let y: U8 => y else U8(0) end
+recover error end
+let n: U8 = some_function(error)
+(error).string()
+let t: (U8, U8) = (1, (error))
+```

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -430,18 +430,20 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   LLVMValueRef else_value = gen_expr(c, else_clause);
   LLVMBasicBlockRef else_from = NULL;
 
-  if(else_value == NULL)
-    return NULL;
-
-  if(needed)
-  {
-    ast_t* else_type = deferred_reify(reify, ast_type(else_clause), c->opt);
-    else_value = gen_assign_cast(c, phi_type->use_type, else_value, else_type);
-    ast_free_unattached(else_type);
-  }
-
+  // If the else clause jumps away (e.g. `error`), it produces no value and has
+  // no type to reify, so skip the cast entirely. Mirrors gen_while.
   if(else_value != GEN_NOVALUE)
   {
+    if(else_value == NULL)
+      return NULL;
+
+    if(needed)
+    {
+      ast_t* else_type = deferred_reify(reify, ast_type(else_clause), c->opt);
+      else_value = gen_assign_cast(c, phi_type->use_type, else_value, else_type);
+      ast_free_unattached(else_type);
+    }
+
     else_from = LLVMGetInsertBlock(c->builder);
     LLVMBuildBr(c->builder, post_block);
   }

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -284,17 +284,13 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
 
     coerce_tuple_to_target(opt, arg, p_type);
 
+    if(jumps_away_no_value(opt, arg, "an argument"))
+      return false;
+
     ast_t* arg_type = ast_type(arg);
 
     if(is_typecheck_error(arg_type))
       return false;
-
-    if(ast_checkflag(arg, AST_FLAG_JUMPS_AWAY))
-    {
-      ast_error(opt->check.errors, arg,
-        "can't use a control expression in an argument");
-      return false;
-    }
 
     errorframe_t info = NULL;
     ast_t* wp_type = consume_type(p_type, TK_NONE, false, opt);

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -92,6 +92,9 @@ bool expr_if(pass_opt_t* opt, ast_t* ast)
 
   if(ast_id(ast) == TK_IF)
   {
+    if(jumps_away_no_value(opt, cond, "a condition"))
+      return false;
+
     ast_t* cond_type = ast_type(cond);
 
     if(is_typecheck_error(cond_type))
@@ -190,6 +193,9 @@ bool expr_while(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast_id(ast) == TK_WHILE);
   AST_GET_CHILDREN(ast, cond, body, else_clause);
 
+  if(jumps_away_no_value(opt, cond, "a condition"))
+    return false;
+
   ast_t* cond_type = ast_type(cond);
 
   if(is_typecheck_error(cond_type))
@@ -244,6 +250,9 @@ bool expr_repeat(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_REPEAT);
   AST_GET_CHILDREN(ast, body, cond, else_clause);
+
+  if(jumps_away_no_value(opt, cond, "a condition"))
+    return false;
 
   ast_t* cond_type = ast_type(cond);
 
@@ -395,6 +404,10 @@ bool expr_recover(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_RECOVER);
   AST_GET_CHILDREN(ast, cap, expr);
+
+  if(jumps_away_no_value(opt, expr, "a recover operand"))
+    return false;
+
   ast_t* type = ast_type(expr);
 
   if(is_typecheck_error(type))

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -54,6 +54,9 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
     if(!coerce_literals(&arg, p_type, opt))
       return false;
 
+    if(jumps_away_no_value(opt, arg, "an argument"))
+      return false;
+
     ast_t* arg_type = ast_type(arg);
 
     if(is_typecheck_error(arg_type))
@@ -102,6 +105,9 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
 
   for(; arg != NULL; arg = ast_sibling(arg))
   {
+    if(jumps_away_no_value(opt, arg, "an argument"))
+      return false;
+
     ast_t* a_type = ast_type(arg);
 
     if((a_type != NULL) && is_type_literal(a_type))

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -39,6 +39,12 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
   // x = y -> capture expression y, type inferred from expression type
   // x: T = y -> capture expression y, type T
 
+  // The two `= y` forms capture an arbitrary expression, which can't jump away
+  // with no value. (The bare `x` form has a TK_NONE value, which the helper
+  // ignores.)
+  if(jumps_away_no_value(opt, value, "a lambda capture"))
+    return false;
+
   if(ast_id(value) == TK_NONE)
   {
     // Variable capture

--- a/src/libponyc/expr/literal.c
+++ b/src/libponyc/expr/literal.c
@@ -951,6 +951,9 @@ bool literal_call(ast_t* ast, pass_opt_t* opt)
 
   AST_GET_CHILDREN(ast, receiver, positional_args, named_args, question);
 
+  if(jumps_away_no_value(opt, receiver, "a receiver"))
+    return false;
+
   ast_t* recv_type = ast_type(receiver);
 
   if(is_typecheck_error(recv_type))
@@ -1015,6 +1018,10 @@ bool literal_is(ast_t* ast, pass_opt_t* opt)
   pony_assert(ast_id(ast) == TK_IS || ast_id(ast) == TK_ISNT);
 
   AST_GET_CHILDREN(ast, left, right);
+
+  if(jumps_away_no_value(opt, left, "an operand of an identity comparison") ||
+    jumps_away_no_value(opt, right, "an operand of an identity comparison"))
+    return false;
 
   ast_t* l_type = ast_type(left);
   ast_t* r_type = ast_type(right);

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -337,6 +337,9 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast_id(ast) == TK_MATCH);
   AST_GET_CHILDREN(ast, expr, cases, else_clause);
 
+  if(jumps_away_no_value(opt, expr, "a match operand"))
+    return false;
+
   // A literal match expression should have been caught by the cases, but check
   // again to avoid an assert if we've missed a case
   ast_t* expr_type = ast_type(expr);
@@ -922,8 +925,13 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
   ast_t* match_expr = ast_child(match);
   ast_t* match_type = ast_type(match_expr);
 
-  if(ast_checkflag(match_expr, AST_FLAG_JUMPS_AWAY) ||
-    is_typecheck_error(match_type))
+  // If the match operand jumps away (no value), the match is invalid and
+  // expr_match reports it once. Skip this case rather than reporting here too,
+  // which would duplicate the error once per case.
+  if(ast_checkflag(match_expr, AST_FLAG_JUMPS_AWAY))
+    return true;
+
+  if(is_typecheck_error(match_type))
     return false;
 
   if(!infer_pattern_type(&pattern, match_type, opt))
@@ -1019,6 +1027,9 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
 
     if(ast_id(guard) != TK_NONE)
     {
+      if(jumps_away_no_value(opt, guard, "a match guard"))
+        return false;
+
       ast_t* guard_type = ast_type(guard);
 
       if(is_typecheck_error(guard_type))

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -882,6 +882,9 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
   pony_assert(ast_id(ast) == TK_AS);
   AST_GET_CHILDREN(ast, expr, type);
 
+  if(jumps_away_no_value(opt, expr, "a cast operand"))
+    return false;
+
   ast_t* expr_type = ast_type(expr);
   if(is_typecheck_error(expr_type))
     return false;

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -437,8 +437,12 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
   ast_t* ast = *astp;
   pony_assert(ast_id(ast) == TK_QUALIFY);
   AST_GET_CHILDREN(ast, left, right);
-  ast_t* type = ast_type(left);
   pony_assert(ast_id(right) == TK_TYPEARGS);
+
+  if(jumps_away_no_value(opt, left, "a receiver"))
+    return false;
+
+  ast_t* type = ast_type(left);
 
   if(is_typecheck_error(type))
     return false;
@@ -503,6 +507,9 @@ static bool entity_access(pass_opt_t* opt, ast_t** astp)
 
     default: {}
   }
+
+  if(jumps_away_no_value(opt, left, "a receiver"))
+    return false;
 
   ast_t* type = ast_type(left);
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -162,6 +162,9 @@ bool expr_param(pass_opt_t* opt, ast_t* ast)
     if(!coerce_literals(&init, type, opt))
       return false;
 
+    if(jumps_away_no_value(opt, init, "a default argument"))
+      return false;
+
     ast_t* init_type = ast_type(init);
 
     if(is_typecheck_error(init_type))
@@ -888,15 +891,22 @@ bool expr_tuple(pass_opt_t* opt, ast_t* ast)
   } else {
     type = ast_from(ast, TK_TUPLETYPE);
 
-    while(child != NULL)
+    // A tuple can't contain an expression that jumps away with no value. Check
+    // every child up front: the literal short-circuit below returns before the
+    // type-building loop visits later children, so an earlier literal element
+    // would otherwise hide a later jumps-away element.
+    for(ast_t* c = child; c != NULL; c = ast_sibling(c))
     {
-      if(ast_checkflag(child, AST_FLAG_JUMPS_AWAY))
+      if(ast_checkflag(c, AST_FLAG_JUMPS_AWAY))
       {
-        ast_error(opt->check.errors, child,
+        ast_error(opt->check.errors, c,
           "a tuple can't contain an expression that jumps away with no value");
         return false;
       }
+    }
 
+    while(child != NULL)
+    {
       ast_t* c_type = ast_type(child);
 
       if((c_type == NULL) || (ast_id(c_type) == TK_ERRORTYPE))

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -219,6 +219,16 @@ bool is_typecheck_error(ast_t* type)
   return false;
 }
 
+bool jumps_away_no_value(pass_opt_t* opt, ast_t* ast, const char* what)
+{
+  if(!ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+    return false;
+
+  ast_error(opt->check.errors, ast,
+    "%s can't be an expression that jumps away with no value", what);
+  return true;
+}
+
 static ast_t* find_tuple_type(pass_opt_t* opt, ast_t* ast, size_t child_count)
 {
   if((ast_id(ast) == TK_TUPLETYPE) && (ast_childcount(ast) == child_count))

--- a/src/libponyc/pass/expr.h
+++ b/src/libponyc/pass/expr.h
@@ -15,6 +15,18 @@ bool is_method_return(typecheck_t* t, ast_t* ast);
 
 bool is_typecheck_error(ast_t* type);
 
+// Returns true (and reports an error) if `ast` is a control expression that
+// jumps away with no value (`error`, `return`, `break`, `continue`), which
+// can't be used in a value-operand position described by `what` (e.g. "a
+// condition", "an argument"). Call this BEFORE is_typecheck_error at such
+// positions: a jump-away expression has a NULL type, which is_typecheck_error
+// reports as an error even though none was raised, so bailing on it without
+// this check trips the "errors must be > 0" assertion in pass_expr.
+// Only use this at value-operand positions. Do not call it on branch or tail
+// positions (an `if`/`match` branch, a loop body, the last expression of a
+// sequence) where jumping away is legal — those skip a jump-away child instead.
+bool jumps_away_no_value(pass_opt_t* opt, ast_t* ast, const char* what);
+
 ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered);
 
 ast_result_t pass_pre_expr(ast_t** astp, pass_opt_t* options);

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -2914,3 +2914,288 @@ TEST_F(BadPonyTest, RepeatWithLiteralBreakValueAndJumpsAwayElse)
 
   TEST_ERRORS_1(src, "Cannot infer type of unused literal");
 }
+
+// A control expression that jumps away with no value (`error`, `return`,
+// `break`, `continue`) has no type. Used in a value-operand position it must
+// produce a clean error, not crash the compiler. These were all assertion
+// crashes in the expr pass; uncovered while investigating issue #3326.
+
+TEST_F(BadPonyTest, IfConditionJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = if error then U8(1) else U8(2) end end";
+
+  TEST_ERRORS_1(src,
+    "a condition can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, WhileConditionJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = while error do U8(1) else U8(2) end end";
+
+  TEST_ERRORS_1(src,
+    "a condition can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, RepeatConditionJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = repeat U8(1) until error else U8(2) end end";
+
+  TEST_ERRORS_1(src,
+    "a condition can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, RecoverOperandJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = recover error end end";
+
+  TEST_ERRORS_1(src,
+    "a recover operand can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, MatchOperandJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = match error | let y: U8 => y else U8(0) end end";
+
+  TEST_ERRORS_1(src,
+    "a match operand can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, MatchOperandJumpsAwayMultipleCases)
+{
+  // The operand is checked per-case and once at the match; with multiple cases
+  // the error must be reported exactly once (TEST_ERRORS_1 enforces the count).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try\n"
+    "      let x: U8 = match error\n"
+    "      | let y: U8 => y\n"
+    "      | let z: U16 => U8(0)\n"
+    "      else U8(0) end\n"
+    "    end";
+
+  TEST_ERRORS_1(src,
+    "a match operand can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, MatchGuardJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = match U8(1) | let y: U8 if error => y else U8(0) end "
+    "end";
+
+  TEST_ERRORS_1(src,
+    "a match guard can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, FunctionArgumentJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  fun f(n: U8): U8 => n\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: U8 = f(error) end";
+
+  TEST_ERRORS_1(src,
+    "an argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, ArgumentReturnsAway)
+{
+  // The guard keys on AST_FLAG_JUMPS_AWAY, which `return` sets just like
+  // `error`; confirm a non-error jump is rejected the same way.
+  const char* src =
+    "actor Main\n"
+    "  fun f(n: U8): U8 => n\n"
+    "  new create(env: Env) =>\n"
+    "    let x: U8 = f(return)";
+
+  TEST_ERRORS_1(src,
+    "an argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, ConstructorArgumentJumpsAway)
+{
+  const char* src =
+    "class C\n"
+    "  new create(n: U8) => None\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: C = C(error) end";
+
+  TEST_ERRORS_1(src,
+    "an argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, MethodReceiverJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: String = (error).string() end";
+
+  TEST_ERRORS_1(src,
+    "a receiver can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, QualifiedReceiverJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x = (error)[U8] end";
+
+  TEST_ERRORS_1(src,
+    "a receiver can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, AsOperandJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x = (error) as U8 end";
+
+  TEST_ERRORS_1(src,
+    "a cast operand can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, IsOperandJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: Bool = (error) is U8(1) end";
+
+  TEST_ERRORS_1(src,
+    "an operand of an identity comparison can't be an expression that jumps "
+    "away with no value");
+}
+
+TEST_F(BadPonyTest, IsntRightOperandJumpsAway)
+{
+  // Jump-away on the right operand, exercising the second `||` clause that the
+  // left-operand tests above can't reach.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x: Bool = U8(1) isnt (error) end";
+
+  TEST_ERRORS_1(src,
+    "an operand of an identity comparison can't be an expression that jumps "
+    "away with no value");
+}
+
+TEST_F(BadPonyTest, FFIArgumentJumpsAway)
+{
+  const char* src =
+    "use @exit[None](code: I32)\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try @exit(error) end";
+
+  TEST_ERRORS_1(src,
+    "an argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, FFIVariadicArgumentJumpsAway)
+{
+  // Exercises the second FFI argument loop (variadic args past the declared
+  // parameters), a separate guard from the declared-parameter loop above.
+  const char* src =
+    "use @f[None](a: U8, ...)\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try @f(U8(1), error) end";
+
+  TEST_ERRORS_1(src,
+    "an argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, CallReceiverJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let x = (error)(U8(1)) end";
+
+  TEST_ERRORS_1(src,
+    "a receiver can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, DefaultArgumentJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  fun f(a: U8 = (error)): U8 => a\n"
+    "  new create(env: Env) =>\n"
+    "    None";
+
+  TEST_ERRORS_1(src,
+    "a default argument can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, LambdaCaptureJumpsAway)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let l = {()(x = (error)) => x}";
+
+  TEST_ERRORS_1(src,
+    "a lambda capture can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, LambdaDontcareCaptureJumpsAway)
+{
+  // A typed capture into `_` takes a different branch (a subtype check) than
+  // the untyped capture above; both must reject a jump-away value.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let l = {()(_: U8 = (error)) => None}";
+
+  TEST_ERRORS_1(src,
+    "a lambda capture can't be an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, TupleElementJumpsAwayAfterLiteral)
+{
+  // The jumps-away element follows a literal element, which used to take a
+  // short-circuit that skipped the later element's check.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try let t: (U8, U8) = (1, (error)) end";
+
+  TEST_ERRORS_1(src,
+    "a tuple can't contain an expression that jumps away with no value");
+}
+
+TEST_F(BadPonyTest, TuplePatternElementJumpsAwayAfterLiteral)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    try match (U8(1), U8(2)) | (1, (error)) => None end end";
+
+  TEST_ERRORS_1(src,
+    "a tuple can't contain an expression that jumps away with no value");
+}

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -370,6 +370,18 @@ TEST_F(CodegenTest, RepeatLoopBreakOnlyInBranches)
   TEST_COMPILE(src);
 }
 
+TEST_F(CodegenTest, RepeatLoopElseClauseJumpsAway)
+{
+  // From issue #3326
+  // The else clause `error` jumps away and so has no type. gen_repeat must not
+  // try to reify that absent type, which previously crashed the compiler.
+  const char* src =
+    "actor Main\n"
+      "new create(env: Env) =>\n"
+        "try let x: U8 = repeat 1 until false else error end end";
+
+  TEST_COMPILE(src);
+}
 
 TEST_F(CodegenTest, LifetimeIntrinsicsHaveSinglePointerArgument)
 {


### PR DESCRIPTION
A control expression that "jumps away" with no value — `error`, `return`, `break`, or `continue` — has no type. Using one in a value-requiring position crashed the compiler instead of compiling or reporting a clear error. This fixes the whole class.

The original report (#3326) was a `repeat … else error` codegen crash; investigating it surfaced a broader bug class in the type-check (expr) pass. Two parts:

1. **Codegen** (`gen_repeat`): a `repeat` loop whose `else` clause jumps away now compiles correctly, mirroring how `gen_while` already handles it.

2. **Type-check pass**: a shared `jumps_away_no_value` helper now rejects, with a clear error, a jump-away expression used where a value is required — conditions, `match` operands and guards, `recover` operands, call and FFI arguments, method/call/qualified receivers, `as` and identity (`is`/`isnt`) operands, default arguments, lambda captures, and tuple elements. Previously these tripped a `pass_expr` assertion. The root cause was checking `is_typecheck_error` (which treats a jump-away's NULL type as an error) before checking for jump-away, so the handler bailed without reporting an error. Jumping away in a branch or tail position, where it is legal, is unaffected.

The complete set of reachable positions was confirmed by an exhaustive audit of the expr pass.

Closes #3326