### PR TITLE
Stop sending nightly release events to archived ponylang/http

### DIFF
--- a/.github/workflows/cloudsmith-package-sychronised.yml
+++ b/.github/workflows/cloudsmith-package-sychronised.yml
@@ -91,7 +91,6 @@ jobs:
         repo:
           - ponylang/appdirs
           - ponylang/corral
-          - ponylang/http
           - ponylang/lori
           - ponylang/ponyup
           - ponylang/regex


### PR DESCRIPTION
The ponylang/http repo was archived, so the Windows nightly release event dispatch to it in the cloudsmith-package-synchronised workflow no longer has a live consumer. This removes it from the matrix.

Only ponylang/http was wired up — there was no event send to ponylang/http_server anywhere in the workflows.