### PR TITLE
Use embedded LLD for native Linux sanitizer builds

### DIFF
--- a/.release-notes/embedded-lld-native-linux-sanitizer.md
+++ b/.release-notes/embedded-lld-native-linux-sanitizer.md
@@ -1,0 +1,3 @@
+## Use embedded LLD for native Linux sanitizer builds
+
+When ponyc is built with sanitizers (such as `address_sanitizer` or `undefined_behavior_sanitizer`) on Linux, it now links the programs it compiles with its built-in LLD linker, the same as every other build, instead of falling back to your system C compiler to perform the link. Sanitizer-enabled native Linux compilation no longer depends on having an external compiler driver present and usable as a linker.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,167 @@ if(NOT DEFINED PONY_ARCH)
     set(PONY_ARCH "native")
 endif()
 
+# Sanitizer link fragment capture.
+#
+# When ponyc is built with sanitizers, libponyrt's C code is instrumented, so
+# every executable ponyc links references the sanitizer runtime (__asan_* etc.)
+# and must link it. ponyc links natively via embedded LLD, which does not go
+# through the compiler driver, so it cannot rely on -fsanitize= to pull the
+# runtime in. Instead we ask the driver, at configure time, for the exact link
+# fragment it emits for -fsanitize=${PONY_SANITIZERS_VALUE} and embed it as a
+# generated header that the embedded ELF linker splices in (genexe.cc).
+#
+# Asking the driver (rather than locating the runtime libraries ourselves)
+# avoids re-implementing its per-compiler library selection, ubsan-folding, and
+# wrapping rules, and avoids depending on a compiler's runtime-directory layout
+# (clang's libclang_rt.asan-<arch>.a vs per-target lib/<triple>/libclang_rt.asan.a
+# vs gcc's libasan_preinit.o + shared libasan): the driver emits whatever paths
+# and flags are correct for itself. This works for both clang (whole-archived
+# clang_rt static archives + --dynamic-list) and gcc (preinit object + shared
+# -lasan/-lubsan). The fragment's library paths are absolute on the build
+# machine, which is fine: a sanitizer ponyc is a developer/CI artifact that runs
+# where it was built. Linux native sanitizer builds are the only ones that
+# consume this today (see genexe.cc); the splice is gated on !is_cross_compiling.
+
+# Extract the linker subcommand's arguments from a compiler "-###" stderr dump.
+# The link subcommand is the line naming the probe object (clang emits a direct
+# ld line, gcc a collect2 line; both name the object). Tokenize it respecting
+# shell quoting via separate_arguments — clang double-quotes every token, gcc
+# leaves most bare, and separate_arguments handles both. Drop volatile tokens:
+# gcc's LTO plugin injects "-plugin-opt=-fresolution=<tmp>.res" with a fresh
+# temp path on every invocation, which otherwise differs between the baseline
+# and sanitized probe runs and desyncs the ordered diff below.
+function(_pony_sanitizer_link_tokens raw outvar)
+    string(REGEX MATCH "[^\n]*pony_sanitizer_probe\\.o[^\n]*" _line "${raw}")
+    separate_arguments(_toks UNIX_COMMAND "${_line}")
+    set(_out "")
+    foreach(_t IN LISTS _toks)
+        if(NOT _t MATCHES "fresolution=" AND NOT _t MATCHES "\\.res$")
+            list(APPEND _out "${_t}")
+        endif()
+    endforeach()
+    set(${outvar} "${_out}" PARENT_SCOPE)
+endfunction()
+
+if(PONY_SANITIZERS_ENABLED)
+    set(_san_probe_c "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.c")
+    set(_san_probe_o "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.o")
+    set(_san_probe_bin "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.bin")
+    file(WRITE "${_san_probe_c}" "int main(void){return 0;}\n")
+
+    # -### prints the link command without running it, but only for an input
+    # that exists, so compile a real (uninstrumented) object first. No -march or
+    # other arch flag is passed to any probe: the sanitizer runtime the driver
+    # selects depends on the target (the driver's default target == this native
+    # host, which is what we link for), not on -march, so an arch flag would only
+    # add an unrelated way for the probe to fail.
+    execute_process(
+        COMMAND ${CMAKE_C_COMPILER} -c ${_san_probe_c} -o ${_san_probe_o}
+        RESULT_VARIABLE _san_probe_rc
+        OUTPUT_QUIET ERROR_QUIET)
+    if(NOT _san_probe_rc EQUAL 0)
+        message(FATAL_ERROR "sanitizer link capture: failed to compile probe object")
+    endif()
+
+    # Capture the driver's link line with and without -fsanitize=. -### writes
+    # the subcommands to stderr. Check the exit codes: if the driver can't emit
+    # a link line at all (e.g. an unrecognized -fsanitize= value), fail here with
+    # the real cause rather than letting it surface downstream as a confusing
+    # "not a supersequence" error. (A mutually-exclusive combo like
+    # thread,address is accepted by -### but rejected later when libponyrt
+    # compiles with those flags, so it fails loudly there - not caught here.)
+    execute_process(
+        COMMAND ${CMAKE_C_COMPILER} "-###" ${_san_probe_o} -o ${_san_probe_bin}
+        RESULT_VARIABLE _san_baseline_rc
+        ERROR_VARIABLE _san_baseline_raw OUTPUT_QUIET)
+    execute_process(
+        COMMAND ${CMAKE_C_COMPILER} -fsanitize=${PONY_SANITIZERS_VALUE} "-###" ${_san_probe_o} -o ${_san_probe_bin}
+        RESULT_VARIABLE _san_sanitized_rc
+        ERROR_VARIABLE _san_sanitized_raw OUTPUT_QUIET)
+    if(NOT _san_baseline_rc EQUAL 0 OR NOT _san_sanitized_rc EQUAL 0)
+        message(FATAL_ERROR
+            "sanitizer link capture: ${CMAKE_C_COMPILER} failed to emit a link "
+            "line for -fsanitize=${PONY_SANITIZERS_VALUE} (-### exited non-zero)")
+    endif()
+
+    _pony_sanitizer_link_tokens("${_san_baseline_raw}" _san_base_toks)
+    _pony_sanitizer_link_tokens("${_san_sanitized_raw}" _san_san_toks)
+
+    # Ordered diff. The sanitized link line is a supersequence of the baseline
+    # (-fsanitize only inserts arguments, never removes or reorders existing
+    # ones, once the volatile LTO token is filtered out). A two-pointer scan
+    # over the sanitized tokens, advancing the baseline pointer on each match,
+    # collects exactly the inserted arguments in driver order: clang's
+    # whole-archive/clang_rt/--dynamic-list block plus extra syslibs, or gcc's
+    # libasan_preinit.o + -lasan/-lubsan. Nothing is hardcoded. If the baseline
+    # is not fully consumed in order the supersequence assumption is violated (a
+    # new volatile token, or a driver that reorders existing args); we stop with
+    # a clear error rather than emit a fragment we can't trust.
+    list(LENGTH _san_base_toks _san_base_len)
+    set(_san_j 0)
+    set(_san_fragment "")
+    foreach(_t IN LISTS _san_san_toks)
+        set(_san_matched FALSE)
+        if(_san_j LESS _san_base_len)
+            list(GET _san_base_toks ${_san_j} _san_bt)
+            if(_t STREQUAL _san_bt)
+                math(EXPR _san_j "${_san_j} + 1")
+                set(_san_matched TRUE)
+            endif()
+        endif()
+        if(NOT _san_matched)
+            list(APPEND _san_fragment "${_t}")
+        endif()
+    endforeach()
+
+    if(NOT _san_j EQUAL _san_base_len)
+        message(FATAL_ERROR
+            "sanitizer link capture: the -fsanitize link line is not a "
+            "supersequence of the baseline after filtering volatile tokens "
+            "(a new non-deterministic token, or a driver that reorders existing "
+            "arguments). See discussion ponylang/ponyc#5399.")
+    endif()
+
+    # Sanity: the captured fragment must reference a sanitizer runtime, or the
+    # extraction silently produced nothing useful. clang names it libclang_rt.*,
+    # gcc names it libasan/-lasan/libubsan/libtsan; matching the sanitizer
+    # substrings covers both.
+    string(REGEX MATCH "asan|ubsan|tsan" _san_has_rt "${_san_fragment}")
+    if(_san_has_rt STREQUAL "")
+        message(FATAL_ERROR
+            "sanitizer link capture: no sanitizer runtime (asan/ubsan/tsan) "
+            "found in the captured fragment for -fsanitize=${PONY_SANITIZERS_VALUE}")
+    endif()
+
+    # Emit each token as a C string literal, escaping backslash then quote so a
+    # toolchain path containing either can't break out of the literal. (Linux
+    # toolchain paths don't normally contain these, but a malformed header is a
+    # confusing failure mode worth closing off.)
+    set(_san_array "")
+    foreach(_a IN LISTS _san_fragment)
+        string(REPLACE "\\" "\\\\" _a_esc "${_a}")
+        string(REPLACE "\"" "\\\"" _a_esc "${_a_esc}")
+        string(APPEND _san_array "  \"${_a_esc}\",\n")
+    endforeach()
+
+    set(_san_gen_dir "${CMAKE_BINARY_DIR}/pony_generated")
+    file(MAKE_DIRECTORY "${_san_gen_dir}")
+    file(WRITE "${_san_gen_dir}/sanitizer_link_args.h"
+"// Generated by CMake (PONY_SANITIZERS_ENABLED block in the top-level\n"
+"// CMakeLists.txt). Do not edit. The sanitizer runtime link fragment captured\n"
+"// from the compiler driver for -fsanitize=${PONY_SANITIZERS_VALUE}.\n"
+"#pragma once\n"
+"#include <stddef.h>\n"
+"static const char* const PONY_SANITIZER_LINK_ARGS[] = {\n${_san_array}};\n"
+"static const size_t PONY_SANITIZER_LINK_ARGS_COUNT =\n"
+"  sizeof(PONY_SANITIZER_LINK_ARGS) / sizeof(PONY_SANITIZER_LINK_ARGS[0]);\n")
+    message("-- Captured sanitizer link fragment for "
+        "-fsanitize=${PONY_SANITIZERS_VALUE}")
+
+    # The probe scratch files have served their purpose at configure time.
+    file(REMOVE "${_san_probe_c}" "${_san_probe_o}" "${_san_probe_bin}")
+endif()
+
 if(DEFINED PONY_CPU AND NOT PONY_CPU STREQUAL "")
     set(PONY_CPU_FLAG --cpu ${PONY_CPU})
 else()

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -111,6 +111,13 @@ target_include_directories(libponyc
     PRIVATE ../../lib/blake2
 )
 
+# In sanitizer builds, genexe.cc includes the generated sanitizer_link_args.h
+# (the captured sanitizer runtime link fragment; see the PONY_SANITIZERS_ENABLED
+# block in the top-level CMakeLists.txt).
+if(PONY_SANITIZERS_ENABLED)
+    target_include_directories(libponyc PRIVATE ${CMAKE_BINARY_DIR}/pony_generated)
+endif()
+
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_OSX_DEPLOYMENT_TARGET ${PONY_OSX_PLATFORM})
 endif()

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -35,6 +35,13 @@ LLD_HAS_DRIVER(wasm)
 #  include <llvm/TargetParser/Triple.h>
 #endif
 
+#if defined(PONY_SANITIZER)
+// Generated at configure time (top-level CMakeLists.txt, PONY_SANITIZERS_ENABLED
+// block): the sanitizer runtime link fragment captured from the compiler driver.
+// Exists only in sanitizer builds, so the include is guarded to match.
+#  include "sanitizer_link_args.h"
+#endif
+
 #define STR(x) STR2(x)
 #define STR2(x) #x
 
@@ -1291,6 +1298,47 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     }
   }
 
+#if defined(PONY_SANITIZER)
+  // Sanitizer runtime. When ponyc is built with sanitizers, libponyrt's C code
+  // is instrumented, so the executable references __asan_*/ubsan symbols and
+  // must link the sanitizer runtime. PONY_SANITIZER_LINK_ARGS is the exact
+  // fragment the compiler driver emits for -fsanitize=<PONY_SANITIZER>, captured
+  // at ponyc build time (see the PONY_SANITIZERS_ENABLED block in the top-level
+  // CMakeLists.txt). Its contents are compiler-specific (clang: whole-archived
+  // clang_rt static archives + --dynamic-list + a few syslibs; gcc:
+  // libasan_preinit.o + shared -lasan/-lubsan) and its library paths are
+  // absolute on the build machine.
+  //
+  // This function serves both the Linux and the BSD branches of link_exe.
+  // Native sanitizer linking via embedded LLD has only been done and verified
+  // for Linux; there is no native-ASan support for the BSDs yet. So the splice
+  // is gated on target_is_linux explicitly, rather than relying on the BSD
+  // branch of link_exe continuing to route native sanitizer builds to the
+  // legacy driver. The !is_cross_compiling gate additionally keeps the
+  // host-arch-absolute fragment out of any cross link routed here.
+  //
+  // The fragment is spliced as one contiguous block immediately before file_o.
+  // That order is correct for every piece: objects and static archives that
+  // provide symbols (clang's whole-archived clang_rt, gcc's preinit object)
+  // must precede the instrumented object/runtime so their members are pulled
+  // in, and shared libraries (gcc's -lasan/-lubsan, clang's -lrt/-lresolv) are
+  // position-insensitive (DT_NEEDED), so emitting them here rather than after
+  // the object is harmless. Any linker-state flags in the fragment (clang emits
+  // --no-as-needed) only re-assert the ELF linker's default state, so they have
+  // no lasting effect on the libraries ponyc emits afterward. Pieces ponyc also
+  // emits after the object (e.g. -lpthread) simply appear twice, harmlessly.
+  //
+  // gcc's fragment carries bare -lasan/-lubsan (not absolute paths); they
+  // resolve via the -L search paths ponyc already emits earlier in this
+  // function (the gcc lib dir and the standard system fallbacks), so don't drop
+  // those without accounting for the sanitizer runtime.
+  if(target_is_linux(c->opt->triple) && !is_cross_compiling(c))
+  {
+    for(size_t i = 0; i < PONY_SANITIZER_LINK_ARGS_COUNT; i++)
+      args.push_back(PONY_SANITIZER_LINK_ARGS[i]);
+  }
+#endif
+
   // Object file.
   args.push_back(file_o);
 
@@ -1948,16 +1996,14 @@ static bool link_exe(compile_t* c, ast_t* program,
   errors_t* errors = c->opt->check.errors;
 
   // Use embedded LLD for Linux, macOS, and Windows targets unless --linker
-  // escape hatch is specified. Sanitizer builds fall back to the system
-  // compiler driver for native compilation since sanitizer runtime libraries
-  // need compiler-specific link logic; cross-compilation still uses LLD.
+  // escape hatch is specified. On Linux, native sanitizer builds use embedded
+  // LLD too: link_exe_lld_elf links the sanitizer runtime explicitly from a
+  // fragment captured at ponyc build time. On macOS and the BSDs, native
+  // sanitizer builds still fall back to the system compiler driver (which
+  // links the runtime via -fsanitize=); cross-compilation always uses LLD.
 #ifdef PLATFORM_IS_POSIX_BASED
   if(c->opt->linker == NULL
-    && target_is_linux(c->opt->triple)
-#if defined(PONY_SANITIZER)
-    && is_cross_compiling(c)
-#endif
-    )
+    && target_is_linux(c->opt->triple))
   {
     return link_exe_lld_elf(c, program, file_o);
   }


### PR DESCRIPTION
Native Linux sanitizer builds were the last thing routing to the legacy `system()` linker on their own (without `--linker`), which blocks removing that legacy path. libponyrt is instrumented under sanitizers, so linked executables reference the sanitizer runtime, and embedded LLD doesn't go through the compiler driver that would otherwise pull it in — so those builds fell back to the driver.

This captures the sanitizer runtime's link fragment from the compiler driver at ponyc build time — querying it for whatever `-fsanitize=` the build uses, rather than hardcoding per-compiler library names and wrapping — and splices it into the embedded ELF link. It works for both clang (whole-archived `clang_rt` archives + `--dynamic-list`) and gcc (`libasan_preinit.o` + shared `-lasan`/`-lubsan`). Verified locally on both compilers: full builds plus the core suite under ASan/UBSan.

Scope is native Linux only. macOS, the BSDs, FreeBSD `dtrace`, and the legacy linker's removal itself remain separate follow-ups.

Design: #5399
