### PR TITLE
Reject --runtimebc when ponyc is built with use=dtrace

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -223,6 +223,8 @@ ponyc --runtimebc
 
 This functionality boils down to "super LTO" for the runtime. The Pony compiler will have full knowledge of the runtime and will perform advanced interprocedural optimisations between your Pony code and the runtime. If you're looking for maximum performance, you should consider this option. Note that this can result in very long optimisation times.
 
+`--runtimebc` cannot be combined with a compiler built using `use=dtrace`. The bitcode runtime has no DTrace/SystemTap probes (probe generation works on native object files, not bitcode), so ponyc rejects the combination with an error.
+
 ### systematic testing
 
 Systematic testing allows for running of Pony programs in a deterministic manner. It accomplishes this by coordinating the interleaving of the multiple runtime scheduler threads in a deterministic and reproducible manner instead of allowing them all to run in parallel like happens normally. This ability to reproduce a particular runtime behavior is invaluable for debugging runtime issues.

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -405,5 +405,20 @@ ponyc_opt_process_t ponyc_opt_process(opt_state_t* s, pass_opt_t* opt,
     }
   }
 
+#if defined(USE_DYNAMIC_TRACE)
+  // A compiler built with use=dtrace cannot honour --runtimebc: the bitcode
+  // runtime is compiled without the DTrace/SystemTap probe instrumentation, and
+  // probe generation (`dtrace -G`) operates on native object files rather than
+  // LLVM bitcode, so a --runtimebc binary would carry no probes. On FreeBSD the
+  // combination also fails to link. Reject it up front instead of producing a
+  // probe-free binary or a confusing link error.
+  if(opt->runtimebc)
+  {
+    printf("Error: --runtimebc cannot be used with a compiler built for "
+      "DTrace/SystemTap (use=dtrace); the bitcode runtime has no probes.\n");
+    exit_code = EXIT_255;
+  }
+#endif
+
   return exit_code;
 }


### PR DESCRIPTION
A DTrace-enabled compiler can't produce a working `--runtimebc` binary. The bitcode runtime is compiled without probe instrumentation, and DTrace's probe generation (`dtrace -G`) operates on native object files rather than LLVM bitcode, so the runtime that ends up in a `--runtimebc` binary carries no probes. On FreeBSD the combination additionally fails to link with undefined probe symbols; on other platforms it would link but silently produce a probe-free binary.

This rejects the combination during option processing with a clear error rather than emitting a confusing link failure or a binary that quietly traces nothing. The guard is compiled in only when ponyc itself is built `use=dtrace` (`#if defined(USE_DYNAMIC_TRACE)`), so non-dtrace builds are unaffected.

Reproduced and verified on a FreeBSD 14.3 VM with a `use=dtrace runtime-bitcode=yes` build: `--runtimebc` now prints the error and exits non-zero; a normal compile still works; `--runtimebc --version`/`--help` still short-circuit.

Companion docs PR: ponylang/ponylang-website#1348.

Closes #2915