### PR TITLE
Explain this-> viewpoint capability errors

### DIFF
--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -22,6 +22,23 @@
 #include "../type/viewpoint.h"
 #include "ponyassert.h"
 
+static bool type_contains_thistype(ast_t* ast)
+{
+  if(ast == NULL)
+    return false;
+
+  if(ast_id(ast) == TK_THISTYPE)
+    return true;
+
+  for(ast_t* child = ast_child(ast); child != NULL; child = ast_sibling(child))
+  {
+    if(type_contains_thistype(child))
+      return true;
+  }
+
+  return false;
+}
+
 static bool insert_apply(pass_opt_t* opt, ast_t** astp)
 {
   // Sugar .apply()
@@ -333,6 +350,18 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       if(ast_checkflag(ast_type(arg), AST_FLAG_INCOMPLETE))
         ast_error_frame(&frame, arg,
           "this might be possible if all fields were already defined");
+
+      // Only explain the 'this->' viewpoint when it is actually the cause: the
+      // reified requirement still carries the arrow (so it genuinely depends on
+      // the receiver), and the argument would be assignable if capabilities
+      // were ignored (so the failure is about the capability, not the entity).
+      if(type_contains_thistype(wp_type) &&
+        is_subtype_ignore_cap(arg_type, wp_type, NULL, opt))
+        ast_error_frame(&frame, param,
+          "this parameter's type is adapted through the receiver's "
+          "viewpoint (the 'this->' arrow), so the capability it requires "
+          "depends on how the receiver is viewed, not just the capability "
+          "written in the type");
 
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -85,6 +85,22 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
           ast_error_frame(errorf, sub_cap,
             "this would be possible if the subcap were more ephemeral. "
             "Perhaps you meant to consume this variable");
+
+        const char* generic = NULL;
+        switch(ast_id(super_cap))
+        {
+          case TK_CAP_READ:  generic = "ref, val, box"; break;
+          case TK_CAP_SEND:  generic = "iso, val, tag"; break;
+          case TK_CAP_SHARE: generic = "val, tag"; break;
+          case TK_CAP_ANY:   generic = "iso, trn, ref, val, box, tag"; break;
+          default: break;
+        }
+
+        if(generic != NULL)
+          ast_error_frame(errorf, sub_cap,
+            "%s is a generic capability standing for {%s}; a capability is a "
+            "subcap of it only if it is a subcap of every one of those",
+            ast_print_type(super_cap), generic);
       }
 
       return false;

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -194,3 +194,63 @@ TEST_F(CapSafetyTest, NoWriteArrow)
 
   TEST_ERROR(src);
 }
+
+// When a 'this->' viewpoint parameter can't accept the argument because the
+// receiver's capability reduces it to a generic cap (here #read), the error is
+// accompanied by two explanatory frames: one describing the 'this->' viewpoint
+// dependency, and one describing what the generic cap means.
+TEST_F(CapSafetyTest, ThisArrowGenericCapHints)
+{
+  const char* src =
+    "class Item\n"
+    "class Wrap[A]\n"
+    "  fun get(alt: this->A): this->A => alt\n"
+    "actor Main\n"
+    "  let w: Wrap[Item] = Wrap[Item]\n"
+    "  new create(env: Env) => None\n"
+    "  fun use_it(i: Item): None =>\n"
+    "    w.get(i)\n"
+    "    None\n";
+
+  const char* errs[] = { "argument not assignable to parameter", NULL };
+  const char* frame0[] = {
+    "argument type is",
+    "parameter type requires",
+    "this parameter's type is adapted through the receiver's",
+    "is not a subcap of #read",
+    "#read is a generic capability standing for",
+    NULL
+  };
+  const char** frames[] = { frame0, NULL };
+
+  DO(test_expected_error_frames(src, "expr", errs, frames));
+}
+
+// The 'this->' viewpoint hint must NOT appear when the failure is a nominal
+// (entity) mismatch rather than a capability one: here the argument is the
+// wrong type entirely (Other vs Item) and both caps are ref. The exact frame
+// count (3) catches the hint firing spuriously.
+TEST_F(CapSafetyTest, ThisArrowHintAbsentForNominalMismatch)
+{
+  const char* src =
+    "class Item\n"
+    "class Other\n"
+    "class Wrap[A]\n"
+    "  fun get(alt: this->A): None => None\n"
+    "actor Main\n"
+    "  let w: Wrap[Item] = Wrap[Item]\n"
+    "  new create(env: Env) => None\n"
+    "  fun use_it(o: Other): None =>\n"
+    "    w.get(o)\n";
+
+  const char* errs[] = { "argument not assignable to parameter", NULL };
+  const char* frame0[] = {
+    "argument type is",
+    "parameter type requires",
+    "Other ref is not a subtype of Item",
+    NULL
+  };
+  const char** frames[] = { frame0, NULL };
+
+  DO(test_expected_error_frames(src, "expr", errs, frames));
+}


### PR DESCRIPTION
When an argument fails to satisfy a parameter whose type uses a `this->` viewpoint, the receiver's capability can reduce the requirement to a generic capability such as `#read`. The resulting `ref is not a subcap of #read` doesn't explain what `#read` means or where it came from — `#read` is not a capability the user wrote, and the reporter of #3568 was specifically confused by the difference between being a subtype of `#read` and being within its constraint.

This adds two explanatory error frames:

- In `subtype.c`, when a failed subcap check has a generic capability on the supertype side, a frame names what that generic capability stands for (e.g. `#read` is `{ref, val, box}`) and states the rule: a capability is a subcap of it only if it is a subcap of every one of those.
- In `call.c`, when a `this->` viewpoint parameter is involved, a frame notes that the required capability depends on how the receiver is viewed, not just the capability written in the type.

The viewpoint frame is gated so it only appears when the viewpoint is actually the cause: the reified requirement still carries the arrow (the requirement genuinely depends on the receiver) and the argument would be assignable if capabilities were ignored (the failure is about the capability, not the entity). This keeps it from misfiring on nominal type mismatches or when the viewpoint resolves to a concrete capability.

The rejection itself is correct behavior — this only improves the diagnostic.

## Example

```pony
use "collections"

actor Main
  let mymap: Map[String, List[USize]] = mymap.create()
  new create(env: Env) => None
  fun get_items(key: String): List[USize] =>
    mymap.get_or_else(key, List[USize])
```

Before:

```
main.pony:7:28: argument not assignable to parameter
    argument type is List[USize val] ref^
    parameter type requires this->List[USize val] ref^
    List[USize val] ref^ is not a subtype of List[USize val] #read: ref^ is not a subcap of #read
```

After:

```
main.pony:7:28: argument not assignable to parameter
    argument type is List[USize val] ref^
    parameter type requires this->List[USize val] ref^
    this parameter's type is adapted through the receiver's viewpoint (the 'this->' arrow), so the capability it requires depends on how the receiver is viewed, not just the capability written in the type
    List[USize val] ref^ is not a subtype of List[USize val] #read: ref^ is not a subcap of #read
    #read is a generic capability standing for {ref, val, box}; a capability is a subcap of it only if it is a subcap of every one of those
```

## Known minor limitation

A tuple argument repeats the generic-capability explanation once per failing element, since that frame is emitted from the per-element subcap check. The explanation lives there deliberately so it also covers non-call generic-capability failures (return types, constraints); de-duplicating would cost that generality. Left as-is given it's cosmetic.

Closes #3568