### PR TITLE
Fix intermittent crashes when compiling on multiple threads at once

### DIFF
--- a/.release-notes/fix-concurrent-compilation-crash.md
+++ b/.release-notes/fix-concurrent-compilation-crash.md
@@ -1,0 +1,5 @@
+## Fix intermittent crashes when compiling on multiple threads at once
+
+The compiler could crash intermittently when more than one compilation ran at the same time within a single process, as the Pony language server does while you edit. Because the failure depended on thread timing, it appeared as occasional, hard-to-reproduce crashes rather than a consistent error.
+
+Concurrent compilations no longer share state that simultaneous access could corrupt, so these crashes no longer happen.

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -420,14 +420,14 @@ ast_t* ast_from(ast_t* ast, token_id id)
   return new_ast;
 }
 
-ast_t* ast_from_string(ast_t* ast, const char* name)
+ast_t* ast_from_string(ast_t* ast, const char* name, strtable_t* strtab)
 {
   if(name == NULL)
     return ast_from(ast, TK_NONE);
 
   token_t* t = token_dup(ast->t);
   token_set_id(t, TK_ID);
-  token_set_string(t, name, 0);
+  token_set_string(t, name, 0, strtab);
 
   ast_t* new_ast = ast_token(t);
   set_scope_no_parent(new_ast, ast->parent);
@@ -768,22 +768,23 @@ size_t ast_name_len(ast_t* ast)
   return token_string_len(ast->t);
 }
 
-void ast_set_name(ast_t* ast, const char* name)
+void ast_set_name(ast_t* ast, const char* name, strtable_t* strtab)
 {
   pony_assert(ast != NULL);
 #ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
 #endif
-  token_set_string(ast->t, name, 0);
+  token_set_string(ast->t, name, 0, strtab);
 }
 
-void ast_set_name_len(ast_t* ast, const char* name, size_t len)
+void ast_set_name_len(ast_t* ast, const char* name, size_t len,
+  strtable_t* strtab)
 {
   pony_assert(ast != NULL);
 #ifndef PONY_NDEBUG
   pony_assert(!ast->frozen);
 #endif
-  token_set_string(ast->t, name, len);
+  token_set_string(ast->t, name, len, strtab);
 }
 
 double ast_float(ast_t* ast)
@@ -935,7 +936,7 @@ ast_t* ast_consumeannotation(ast_t* ast)
   return prev_annotation;
 }
 
-bool ast_has_annotation(ast_t* ast, const char* name)
+bool ast_has_annotation(ast_t* ast, const char* name, strtable_t* strtab)
 {
   pony_assert(ast != NULL);
 
@@ -943,7 +944,7 @@ bool ast_has_annotation(ast_t* ast, const char* name)
 
   if((annotation != NULL) && (ast_id(annotation) == TK_ANNOTATION))
   {
-    const char* strtab_name = stringtab(name);
+    const char* strtab_name = stringtab(strtab, name);
     ast_t* elem = ast_child(annotation);
     while(elem != NULL)
     {
@@ -1139,7 +1140,8 @@ ast_t* ast_get(ast_t* ast, const char* name, sym_status_t* status)
   return NULL;
 }
 
-ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status)
+ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status,
+  strtable_t* strtab)
 {
   // Same as ast_get, but is partially case insensitive. That is, type names
   // are compared as uppercase and other symbols are compared as lowercase.
@@ -1151,7 +1153,8 @@ ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status)
     if(ast->symtab != NULL)
     {
       sym_status_t status2;
-      ast_t* value = (ast_t*)symtab_find_case(ast->symtab, name, &status2);
+      ast_t* value = (ast_t*)symtab_find_case(ast->symtab, name, &status2,
+        strtab);
 
       if((status != NULL) && (*status == SYM_NONE))
         *status = status2;
@@ -1167,7 +1170,7 @@ ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status)
 }
 
 bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
-  bool allow_shadowing)
+  bool allow_shadowing, strtable_t* strtab)
 {
   pony_assert(ast != NULL);
 
@@ -1182,10 +1185,10 @@ bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
   if(allow_shadowing)
   {
     // Only check the local scope.
-    find = symtab_find_case(ast->symtab, name, NULL);
+    find = symtab_find_case(ast->symtab, name, NULL, strtab);
   } else {
     // Check the local scope and all parent scopes.
-    find = ast_get_case(ast, name, NULL);
+    find = ast_get_case(ast, name, NULL, strtab);
   }
 
   // Pretend we succeeded if the mapping in the symbol table wouldn't change.
@@ -1195,7 +1198,7 @@ bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
   if(find != NULL)
     return false;
 
-  return symtab_add(ast->symtab, name, value, status);
+  return symtab_add(ast->symtab, name, value, status, strtab);
 }
 
 void ast_setstatus(ast_t* ast, const char* name, sym_status_t status)
@@ -1269,31 +1272,6 @@ void ast_consolidate_branches(ast_t* ast, size_t count)
       }
     }
   }
-}
-
-bool ast_canmerge(ast_t* dst, ast_t* src)
-{
-  pony_assert(dst != NULL);
-  pony_assert(src != NULL);
-
-  while(dst->symtab == NULL)
-    dst = dst->parent;
-
-  return symtab_can_merge_public(dst->symtab, src->symtab);
-}
-
-bool ast_merge(ast_t* dst, ast_t* src)
-{
-  pony_assert(dst != NULL);
-  pony_assert(src != NULL);
-
-  while(dst->symtab == NULL)
-    dst = dst->parent;
-
-#ifndef PONY_NDEBUG
-  pony_assert(!dst->frozen);
-#endif
-  return symtab_merge_public(dst->symtab, src->symtab);
 }
 
 bool ast_within_scope(ast_t* outer, ast_t* inner, const char* name)
@@ -1904,23 +1882,23 @@ static void print_type(printbuf_t* buffer, ast_t* type, bool print_cap)
   }
 }
 
-const char* ast_print_type(ast_t* type)
+const char* ast_print_type(ast_t* type, strtable_t* strtab)
 {
   printbuf_t* buffer = printbuf_new();
   print_type(buffer, type, true);
 
-  const char* s = stringtab(buffer->m);
+  const char* s = stringtab(strtab, buffer->m);
   printbuf_free(buffer);
 
   return s;
 }
 
-const char* ast_print_type_no_cap(ast_t* type)
+const char* ast_print_type_no_cap(ast_t* type, strtable_t* strtab)
 {
   printbuf_t* buffer = printbuf_new();
   print_type(buffer, type, false);
 
-  const char* s = stringtab(buffer->m);
+  const char* s = stringtab(strtab, buffer->m);
   printbuf_free(buffer);
 
   return s;

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -55,7 +55,7 @@ ast_t* ast_new(token_t* t, token_id id);
 ast_t* ast_blank(token_id id);
 ast_t* ast_token(token_t* t);
 ast_t* ast_from(ast_t* ast, token_id id);
-ast_t* ast_from_string(ast_t* ast, const char* name);
+ast_t* ast_from_string(ast_t* ast, const char* name, strtable_t* strtab);
 ast_t* ast_from_int(ast_t* ast, uint64_t value);
 ast_t* ast_from_float(ast_t* ast, double value);
 ast_t* ast_dup(ast_t* ast);
@@ -92,8 +92,9 @@ const char* ast_get_print(ast_t* ast);
 const char* ast_name(ast_t* ast);
 const char* ast_nice_name(ast_t* ast);
 size_t ast_name_len(ast_t* ast);
-void ast_set_name(ast_t* ast, const char* name);
-void ast_set_name_len(ast_t* ast, const char* name, size_t len);
+void ast_set_name(ast_t* ast, const char* name, strtable_t* strtab);
+void ast_set_name_len(ast_t* ast, const char* name, size_t len,
+  strtable_t* strtab);
 double ast_float(ast_t* ast);
 lexint_t* ast_int(ast_t* ast);
 ast_t* ast_type(ast_t* ast);
@@ -101,7 +102,7 @@ void ast_settype(ast_t* ast, ast_t* type);
 ast_t* ast_annotation(ast_t* ast);
 void ast_setannotation(ast_t* ast, ast_t* annotation);
 ast_t* ast_consumeannotation(ast_t* ast);
-bool ast_has_annotation(ast_t* ast, const char* name);
+bool ast_has_annotation(ast_t* ast, const char* name, strtable_t* strtab);
 void ast_erase(ast_t* ast);
 
 ast_t* ast_nearest(ast_t* ast, token_id id);
@@ -117,15 +118,14 @@ ast_t* ast_previous(ast_t* ast);
 size_t ast_index(ast_t* ast);
 
 ast_t* ast_get(ast_t* ast, const char* name, sym_status_t* status);
-ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status);
+ast_t* ast_get_case(ast_t* ast, const char* name, sym_status_t* status,
+  strtable_t* strtab);
 bool ast_set(ast_t* ast, const char* name, ast_t* value, sym_status_t status,
-  bool allow_shadowing);
+  bool allow_shadowing, strtable_t* strtab);
 void ast_setstatus(ast_t* ast, const char* name, sym_status_t status);
 void ast_inheritstatus(ast_t* dst, ast_t* src);
 void ast_inheritbranch(ast_t* dst, ast_t* src);
 void ast_consolidate_branches(ast_t* ast, size_t count);
-bool ast_canmerge(ast_t* dst, ast_t* src);
-bool ast_merge(ast_t* dst, ast_t* src);
 bool ast_within_scope(ast_t* outer, ast_t* inner, const char* name);
 bool ast_all_consumes_in_scope(ast_t* outer, ast_t* inner,
   errorframe_t* errorf);
@@ -152,8 +152,8 @@ void ast_print(ast_t* ast, size_t width);
 void ast_printverbose(ast_t* ast);
 void ast_fprint(FILE* fp, ast_t* ast, size_t width);
 void ast_fprintverbose(FILE* fp, ast_t* ast);
-const char* ast_print_type(ast_t* type);
-const char* ast_print_type_no_cap(ast_t* type);
+const char* ast_print_type(ast_t* type, strtable_t* strtab);
+const char* ast_print_type_no_cap(ast_t* type, strtable_t* strtab);
 
 void ast_error(errors_t* errors, ast_t* ast, const char* fmt, ...)
   __attribute__((format(printf, 3, 4)));

--- a/src/libponyc/ast/astbuild.h
+++ b/src/libponyc/ast/astbuild.h
@@ -101,16 +101,21 @@
 /// Add a TK_NONE node with no children
 #define NONE TREE(ast_from(basis_ast, TK_NONE));
 
+// NOTE: ID, NICE_ID and STRING intern their text, so they require a
+// `pass_opt_t* opt` to be in scope at the BUILD/REPLACE site. Every current
+// user is pass/expr/type/codegen code that already has one.
+
 /// Add a TK_ID node with the given ID name
-#define ID(name) TREE(ast_from_string(basis_ast, name));
+#define ID(name) TREE(ast_from_string(basis_ast, name, opt->strtab));
 
 /// Add a TK_ID node with the given ID name and nice name
 #define NICE_ID(name, nice) \
-  TREE(ast_setdata(ast_from_string(basis_ast, name), (void*)stringtab(nice)));
+  TREE(ast_setdata(ast_from_string(basis_ast, name, opt->strtab), \
+    (void*)stringtab(opt->strtab, nice)));
 
 /// Add a TK_STRING node with the given string value
 #define STRING(value) \
-  TREE(ast_setid(ast_from_string(basis_ast, value), TK_STRING));
+  TREE(ast_setid(ast_from_string(basis_ast, value, opt->strtab), TK_STRING));
 
 /// Add a TK_INT node with the given integer value
 #define INT(value) TREE(ast_from_int(basis_ast, value));

--- a/src/libponyc/ast/error.c
+++ b/src/libponyc/ast/error.c
@@ -1,5 +1,4 @@
 #include "error.h"
-#include "stringtab.h"
 #include "../../libponyrt/mem/pool.h"
 #include "ponyassert.h"
 #include <stdlib.h>
@@ -7,6 +6,32 @@
 #include <string.h>
 
 #define LINE_LEN 1024
+
+// Error messages own their strings. Each is a private pool-allocated copy freed
+// in error_free, so an error's strings live exactly as long as the error does
+// and are reclaimed with the errors collection (at pass_opt_done). Error text is
+// only ever printed, never interned or pointer-compared, so it deliberately does
+// not go through the interned-string table.
+static const char* error_strdup(const char* s)
+{
+  if(s == NULL)
+    return NULL;
+
+  size_t size = strlen(s) + 1;
+  char* dst = (char*)ponyint_pool_alloc_size(size);
+  memcpy(dst, s, size);
+  return dst;
+}
+
+static void error_strfree(const char* s)
+{
+  if(s == NULL)
+    return;
+
+  // s was allocated NUL-terminated by error_strdup, so strlen + 1 recovers the
+  // exact size class it was allocated with.
+  ponyint_pool_free_size(strlen(s) + 1, (void*)s);
+}
 
 
 typedef struct errors_t
@@ -31,6 +56,9 @@ static void error_free(errormsg_t* e)
   while(e != NULL)
   {
     errormsg_t* next = e->frame;
+    error_strfree(e->file);
+    error_strfree(e->msg);
+    error_strfree(e->source);
     POOL_FREE(errormsg_t, e);
     e = next;
   }
@@ -189,11 +217,11 @@ static errormsg_t* make_errorv(source_t* source, size_t line, size_t pos,
   errormsg_t* e = error_alloc();
 
   if(source != NULL)
-    e->file = source->file;
+    e->file = error_strdup(source->file);
 
   e->line = line;
   e->pos = pos;
-  e->msg = stringtab(buf);
+  e->msg = error_strdup(buf);
 
   if((source != NULL) && (line != 0))
   {
@@ -220,7 +248,7 @@ static errormsg_t* make_errorv(source_t* source, size_t line, size_t pos,
 
     memcpy(buf, &source->m[start], len);
     buf[len] = '\0';
-    e->source = stringtab(buf);
+    e->source = error_strdup(buf);
   }
 
   return e;
@@ -288,8 +316,8 @@ static errormsg_t* make_errorfv(const char* file, const char* fmt, va_list ap)
 
   errormsg_t* e = error_alloc();
 
-  e->file = stringtab(file);
-  e->msg = stringtab(buf);
+  e->file = error_strdup(file);
+  e->msg = error_strdup(buf);
   return e;
 }
 

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -15,6 +15,8 @@ struct lexer_t
 {
   source_t* source;
   errors_t* errors;
+  strtable_t* strtab; // Interned-string table for this compilation; identifier
+                      // and string-literal token text is interned into it.
   bool allow_test_symbols;
 
   // Information about next unused character in file
@@ -384,11 +386,13 @@ static token_t* make_token_with_text(lexer_t* lexer, token_id id)
 {
   token_t* t = make_token(lexer, id);
 
-  if(lexer->buffer == NULL) // No text for token
-    token_set_string(t, stringtab(""), 0);
+  // An empty token (no buffer, or a zero-length buffer) must intern the empty
+  // string explicitly: passing a 0 length to token_set_string would make it
+  // fall back to strlen() over the (possibly stale, non-terminated) buffer.
+  if(lexer->buffer == NULL || lexer->buflen == 0)
+    token_set_string(t, "", 0, lexer->strtab);
   else
-    token_set_string(t, stringtab_len(lexer->buffer, lexer->buflen),
-      lexer->buflen);
+    token_set_string(t, lexer->buffer, lexer->buflen, lexer->strtab);
 
   return t;
 }
@@ -1271,7 +1275,7 @@ static token_t* symbol(lexer_t* lexer)
 }
 
 
-lexer_t* lexer_open(source_t* source, errors_t* errors,
+lexer_t* lexer_open(source_t* source, errors_t* errors, strtable_t* strtab,
   bool allow_test_symbols)
 {
   pony_assert(source != NULL);
@@ -1281,6 +1285,7 @@ lexer_t* lexer_open(source_t* source, errors_t* errors,
 
   lexer->source = source;
   lexer->errors = errors;
+  lexer->strtab = strtab;
   lexer->allow_test_symbols = allow_test_symbols;
   lexer->len = source->len - 1; // because we don't want the null terminator to be parsed.
   lexer->line = 1;

--- a/src/libponyc/ast/lexer.h
+++ b/src/libponyc/ast/lexer.h
@@ -10,12 +10,15 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct lexer_t lexer_t;
 typedef struct errors_t errors_t;
+typedef struct strtable_t strtable_t;
 
 /** Create a new lexer to handle the given source.
+ * Identifier and string-literal token text is interned into the given strtab,
+ * which must outlive every token the lexer produces.
  * The created lexer must be freed later with lexer_close().
  * Never returns NULL.
  */
-lexer_t* lexer_open(source_t* source, errors_t* errors,
+lexer_t* lexer_open(source_t* source, errors_t* errors, strtable_t* strtab,
   bool allow_test_symbols);
 
 /** Free a previously opened lexer.

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -1273,10 +1273,10 @@ DEF(module);
 
 // external API
 bool pass_parse(ast_t* package, source_t* source, errors_t* errors,
-  bool allow_test_symbols, bool trace)
+  strtable_t* strtab, bool allow_test_symbols, bool trace)
 {
   return parse(package, source, module, "class, actor, primitive or trait",
-    errors, allow_test_symbols, trace);
+    errors, strtab, allow_test_symbols, trace);
 }
 
 #endif

--- a/src/libponyc/ast/parser.h
+++ b/src/libponyc/ast/parser.h
@@ -5,6 +5,6 @@
 #include "source.h"
 
 bool pass_parse(ast_t* package, source_t* source, errors_t* errors,
-  bool allow_test_symbols, bool trace);
+  strtable_t* strtab, bool allow_test_symbols, bool trace);
 
 #endif

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -602,14 +602,14 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state)
 // Top level functions
 
 bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
-  errors_t* errors, bool allow_test_symbols, bool trace)
+  errors_t* errors, strtable_t* strtab, bool allow_test_symbols, bool trace)
 {
   pony_assert(package != NULL);
   pony_assert(source != NULL);
   pony_assert(expected != NULL);
 
   // Open the lexer
-  lexer_t* lexer = lexer_open(source, errors, allow_test_symbols);
+  lexer_t* lexer = lexer_open(source, errors, strtab, allow_test_symbols);
 
   if(lexer == NULL)
     return false;

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -136,7 +136,7 @@ ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state);
  * failure.
  */
 bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
-  errors_t* errors, bool allow_test_symbols, bool trace);
+  errors_t* errors, strtable_t* strtab, bool allow_test_symbols, bool trace);
 
 
 /* The API for parser rules starts here */

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -6,7 +6,8 @@
 #include <string.h>
 #include <stdio.h>
 
-source_t* source_open(const char* file, const char** error_msgp)
+source_t* source_open(const char* file, const char** error_msgp,
+  strtable_t* strtab)
 {
   FILE* fp = fopen(file, "rb");
 
@@ -29,7 +30,7 @@ source_t* source_open(const char* file, const char** error_msgp)
   fseek(fp, 0, SEEK_SET);
 
   source_t* source = POOL_ALLOC(source_t);
-  source->file = stringtab(file);
+  source->file = stringtab(strtab, file);
   source->m = (char*)ponyint_pool_alloc_size(size + 1);
   source->len = size + 1;
 

--- a/src/libponyc/ast/source.h
+++ b/src/libponyc/ast/source.h
@@ -6,6 +6,8 @@
 
 PONY_EXTERN_C_BEGIN
 
+typedef struct strtable_t strtable_t;
+
 typedef struct source_t
 {
   const char* file;  // NULL => from string, not file
@@ -14,10 +16,13 @@ typedef struct source_t
 } source_t;
 
 /** Open the file with the given path.
+ * The file path is interned into the given strtab, which must outlive the
+ * returned source.
  * Returns the opened source which must be closed later,
  * NULL on failure.
  */
-source_t* source_open(const char* file, const char** error_msgp);
+source_t* source_open(const char* file, const char** error_msgp,
+  strtable_t* strtab);
 
 /** Create a source based on the given string of code.
  * Intended for testing purposes only.

--- a/src/libponyc/ast/stringtab.c
+++ b/src/libponyc/ast/stringtab.c
@@ -14,12 +14,12 @@ static bool ptr_cmp(const char* a, const char* b)
 
 DEFINE_LIST(strlist, strlist_t, const char, ptr_cmp, NULL);
 
-typedef struct stringtab_entry_t
+struct stringtab_entry_t
 {
   const char* str;
   size_t len;
   size_t buf_size;
-} stringtab_entry_t;
+};
 
 static size_t stringtab_hash(stringtab_entry_t* a)
 {
@@ -31,39 +31,47 @@ static bool stringtab_cmp(stringtab_entry_t* a, stringtab_entry_t* b)
   return (a->len == b->len) && (memcmp(a->str, b->str, a->len) == 0);
 }
 
-static void stringtab_free(stringtab_entry_t* a)
+static void stringtab_entry_free(stringtab_entry_t* a)
 {
   ponyint_pool_free_size(a->buf_size, (char*)a->str);
   POOL_FREE(stringtab_entry_t, a);
 }
 
-DECLARE_HASHMAP(strtable, strtable_t, stringtab_entry_t);
 DEFINE_HASHMAP(strtable, strtable_t, stringtab_entry_t, stringtab_hash,
-  stringtab_cmp, stringtab_free);
+  stringtab_cmp, stringtab_entry_free);
 
-static strtable_t table;
-
-void stringtab_init()
+strtable_t* stringtab_new()
 {
-  strtable_init(&table, 4096);
+  strtable_t* table = POOL_ALLOC(strtable_t);
+  strtable_init(table, 4096);
+  return table;
 }
 
-const char* stringtab(const char* string)
+void stringtab_free(strtable_t* table)
+{
+  if(table == NULL)
+    return;
+
+  strtable_destroy(table);
+  POOL_FREE(strtable_t, table);
+}
+
+const char* stringtab(strtable_t* table, const char* string)
 {
   if(string == NULL)
     return NULL;
 
-  return stringtab_len(string, strlen(string));
+  return stringtab_len(table, string, strlen(string));
 }
 
-const char* stringtab_len(const char* string, size_t len)
+const char* stringtab_len(strtable_t* table, const char* string, size_t len)
 {
   if(string == NULL)
     return NULL;
 
   stringtab_entry_t key = {string, len, 0};
   size_t index = HASHMAP_UNKNOWN;
-  stringtab_entry_t* n = strtable_get(&table, &key, &index);
+  stringtab_entry_t* n = strtable_get(table, &key, &index);
 
   if(n != NULL)
     return n->str;
@@ -79,11 +87,12 @@ const char* stringtab_len(const char* string, size_t len)
 
   // didn't find it in the map but index is where we can put the
   // new one without another search
-  strtable_putindex(&table, n, index);
+  strtable_putindex(table, n, index);
   return n->str;
 }
 
-const char* stringtab_consume(const char* string, size_t buf_size)
+const char* stringtab_consume(strtable_t* table, const char* string,
+  size_t buf_size)
 {
   if(string == NULL)
     return NULL;
@@ -91,7 +100,7 @@ const char* stringtab_consume(const char* string, size_t buf_size)
   size_t len = strlen(string);
   stringtab_entry_t key = {string, len, 0};
   size_t index = HASHMAP_UNKNOWN;
-  stringtab_entry_t* n = strtable_get(&table, &key, &index);
+  stringtab_entry_t* n = strtable_get(table, &key, &index);
 
   if(n != NULL)
   {
@@ -106,12 +115,6 @@ const char* stringtab_consume(const char* string, size_t buf_size)
 
   // didn't find it in the map but index is where we can put the
   // new one without another search
-  strtable_putindex(&table, n, index);
+  strtable_putindex(table, n, index);
   return n->str;
-}
-
-void stringtab_done()
-{
-  strtable_destroy(&table);
-  memset(&table, 0, sizeof(strtable_t));
 }

--- a/src/libponyc/ast/stringtab.h
+++ b/src/libponyc/ast/stringtab.h
@@ -3,6 +3,7 @@
 
 #include <platform.h>
 #include "../../libponyrt/ds/list.h"
+#include "../../libponyrt/ds/hash.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -10,16 +11,27 @@ DECLARE_LIST(strlist, strlist_t, const char);
 
 typedef struct pony_ctx_t pony_ctx_t;
 
-void stringtab_init();
-const char* stringtab(const char* string);
-const char* stringtab_len(const char* string, size_t len);
+typedef struct stringtab_entry_t stringtab_entry_t;
+
+DECLARE_HASHMAP(strtable, strtable_t, stringtab_entry_t);
+
+// Create a new, empty table of interned strings. Owned by the caller; free it
+// with stringtab_free when the strings it holds are no longer referenced.
+strtable_t* stringtab_new();
+
+// Destroy a table created with stringtab_new, freeing every interned string in
+// it. Any pointer previously returned by an interning function for this table
+// becomes dangling.
+void stringtab_free(strtable_t* table);
+
+const char* stringtab(strtable_t* table, const char* string);
+const char* stringtab_len(strtable_t* table, const char* string, size_t len);
 
 // Must be called with a string allocated by ponyint_pool_alloc_size, which the
 // function takes control of. The function is responsible for freeing this
 // string and it must not be accessed again after the call returns.
-const char* stringtab_consume(const char* string, size_t buf_size);
-
-void stringtab_done();
+const char* stringtab_consume(strtable_t* table, const char* string,
+  size_t buf_size);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/ast/symtab.c
+++ b/src/libponyc/ast/symtab.c
@@ -33,7 +33,7 @@ static void sym_free(symbol_t* sym)
 
 DEFINE_HASHMAP(symtab, symtab_t, symbol_t, sym_hash, sym_cmp, sym_free);
 
-static const char* name_without_case(const char* name)
+static const char* name_without_case(const char* name, strtable_t* strtab)
 {
   size_t len = strlen(name) + 1;
   char* buf = (char*)ponyint_pool_alloc_size(len);
@@ -47,7 +47,7 @@ static const char* name_without_case(const char* name)
       buf[i] = (char)tolower(name[i]);
   }
 
-  return stringtab_consume(buf, len);
+  return stringtab_consume(strtab, buf, len);
 }
 
 symtab_t* symtab_new()
@@ -81,9 +81,9 @@ void symtab_free(symtab_t* symtab)
 }
 
 bool symtab_add(symtab_t* symtab, const char* name, ast_t* def,
-  sym_status_t status)
+  sym_status_t status, strtable_t* strtab)
 {
-  const char* no_case = name_without_case(name);
+  const char* no_case = name_without_case(name, strtab);
 
   if(no_case != name)
   {
@@ -136,7 +136,7 @@ ast_t* symtab_find(symtab_t* symtab, const char* name, sym_status_t* status)
 }
 
 ast_t* symtab_find_case(symtab_t* symtab, const char* name,
-  sym_status_t* status)
+  sym_status_t* status, strtable_t* strtab)
 {
   // Same as symtab_get, but is partially case insensitive. That is, type names
   // are compared as uppercase and other symbols are compared as lowercase.
@@ -152,10 +152,10 @@ ast_t* symtab_find_case(symtab_t* symtab, const char* name,
     return s2->def;
   }
 
-  const char* no_case = name_without_case(name);
+  const char* no_case = name_without_case(name, strtab);
 
   if(no_case != name)
-    return symtab_find_case(symtab, no_case, status);
+    return symtab_find_case(symtab, no_case, status, strtab);
 
   if(status != NULL)
     *status = SYM_NONE;
@@ -254,7 +254,7 @@ void symtab_inherit_branch(symtab_t* dst, symtab_t* src)
   }
 }
 
-bool symtab_can_merge_public(symtab_t* dst, symtab_t* src)
+bool symtab_can_merge_public(symtab_t* dst, symtab_t* src, strtable_t* strtab)
 {
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
@@ -266,14 +266,14 @@ bool symtab_can_merge_public(symtab_t* dst, symtab_t* src)
       !strcmp(sym->name, "Main"))
       continue;
 
-    if(symtab_find_case(dst, sym->name, NULL) != NULL)
+    if(symtab_find_case(dst, sym->name, NULL, strtab) != NULL)
       return false;
   }
 
   return true;
 }
 
-bool symtab_merge_public(symtab_t* dst, symtab_t* src)
+bool symtab_merge_public(symtab_t* dst, symtab_t* src, strtable_t* strtab)
 {
   size_t i = HASHMAP_BEGIN;
   symbol_t* sym;
@@ -285,7 +285,7 @@ bool symtab_merge_public(symtab_t* dst, symtab_t* src)
       !strcmp(sym->name, "Main"))
       continue;
 
-    if(!symtab_add(dst, sym->name, sym->def, sym->status))
+    if(!symtab_add(dst, sym->name, sym->def, sym->status, strtab))
       return false;
   }
 

--- a/src/libponyc/ast/symtab.h
+++ b/src/libponyc/ast/symtab.h
@@ -8,6 +8,7 @@ PONY_EXTERN_C_BEGIN
 
 typedef struct ast_t ast_t;
 typedef struct errors_t errors_t;
+typedef struct strtable_t strtable_t;
 
 typedef enum
 {
@@ -40,12 +41,12 @@ symtab_t* symtab_dup(symtab_t* symtab);
 void symtab_free(symtab_t* symtab);
 
 bool symtab_add(symtab_t* symtab, const char* name, ast_t* def,
-  sym_status_t status);
+  sym_status_t status, strtable_t* strtab);
 
 ast_t* symtab_find(symtab_t* symtab, const char* name, sym_status_t* status);
 
 ast_t* symtab_find_case(symtab_t* symtab, const char* name,
-  sym_status_t* status);
+  sym_status_t* status, strtable_t* strtab);
 
 sym_status_t symtab_get_status(symtab_t* symtab, const char* name);
 
@@ -56,9 +57,9 @@ void symtab_inherit_status(symtab_t* dst, symtab_t* src);
 
 void symtab_inherit_branch(symtab_t* dst, symtab_t* src);
 
-bool symtab_can_merge_public(symtab_t* dst, symtab_t* src);
+bool symtab_can_merge_public(symtab_t* dst, symtab_t* src, strtable_t* strtab);
 
-bool symtab_merge_public(symtab_t* dst, symtab_t* src);
+bool symtab_merge_public(symtab_t* dst, symtab_t* src, strtable_t* strtab);
 
 bool symtab_check_all_defined(symtab_t* symtab, errors_t* errors);
 

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -293,7 +293,8 @@ void token_set_id(token_t* token, token_id id)
 }
 
 
-void token_set_string(token_t* token, const char* value, size_t length)
+void token_set_string(token_t* token, const char* value, size_t length,
+  strtable_t* strtab)
 {
   pony_assert(token != NULL);
   pony_assert(token->id == TK_STRING || token->id == TK_ID);
@@ -305,7 +306,7 @@ void token_set_string(token_t* token, const char* value, size_t length)
   if(length == 0)
     length = strlen(value);
 
-  token->string = stringtab_len(value, length);
+  token->string = stringtab_len(strtab, value, length);
   token->str_length = length;
 }
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -370,7 +370,8 @@ void token_set_id(token_t* token, token_id id);
   * If the given string is nul terminated then 0 may be passed for length, in
   * which case strlen will be called on the string.
   */
-void token_set_string(token_t* token, const char* value, size_t length);
+void token_set_string(token_t* token, const char* value, size_t length,
+  strtable_t* strtab);
 
 /// Set the given token's literal value. Only valid for TK_FLOAT tokens.
 void token_set_float(token_t* token, double value);

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -101,72 +101,72 @@ static LLVMTargetMachineRef make_machine(pass_opt_t* opt)
 
 static void init_runtime(compile_t* c)
 {
-  c->str_builtin = stringtab("$0");
-  c->str_Bool = stringtab("Bool");
-  c->str_I8 = stringtab("I8");
-  c->str_I16 = stringtab("I16");
-  c->str_I32 = stringtab("I32");
-  c->str_I64 = stringtab("I64");
-  c->str_I128 = stringtab("I128");
-  c->str_ILong = stringtab("ILong");
-  c->str_ISize = stringtab("ISize");
-  c->str_U8 = stringtab("U8");
-  c->str_U16 = stringtab("U16");
-  c->str_U32 = stringtab("U32");
-  c->str_U64 = stringtab("U64");
-  c->str_U128 = stringtab("U128");
-  c->str_ULong = stringtab("ULong");
-  c->str_USize = stringtab("USize");
-  c->str_F32 = stringtab("F32");
-  c->str_F64 = stringtab("F64");
-  c->str_Pointer = stringtab("Pointer");
-  c->str_NullablePointer = stringtab("NullablePointer");
-  c->str_DoNotOptimise = stringtab("DoNotOptimise");
-  c->str_Array = stringtab("Array");
-  c->str_String = stringtab("String");
-  c->str_Platform = stringtab("Platform");
-  c->str_Main = stringtab("Main");
-  c->str_Env = stringtab("Env");
+  c->str_builtin = stringtab(c->opt->strtab, "$0");
+  c->str_Bool = stringtab(c->opt->strtab, "Bool");
+  c->str_I8 = stringtab(c->opt->strtab, "I8");
+  c->str_I16 = stringtab(c->opt->strtab, "I16");
+  c->str_I32 = stringtab(c->opt->strtab, "I32");
+  c->str_I64 = stringtab(c->opt->strtab, "I64");
+  c->str_I128 = stringtab(c->opt->strtab, "I128");
+  c->str_ILong = stringtab(c->opt->strtab, "ILong");
+  c->str_ISize = stringtab(c->opt->strtab, "ISize");
+  c->str_U8 = stringtab(c->opt->strtab, "U8");
+  c->str_U16 = stringtab(c->opt->strtab, "U16");
+  c->str_U32 = stringtab(c->opt->strtab, "U32");
+  c->str_U64 = stringtab(c->opt->strtab, "U64");
+  c->str_U128 = stringtab(c->opt->strtab, "U128");
+  c->str_ULong = stringtab(c->opt->strtab, "ULong");
+  c->str_USize = stringtab(c->opt->strtab, "USize");
+  c->str_F32 = stringtab(c->opt->strtab, "F32");
+  c->str_F64 = stringtab(c->opt->strtab, "F64");
+  c->str_Pointer = stringtab(c->opt->strtab, "Pointer");
+  c->str_NullablePointer = stringtab(c->opt->strtab, "NullablePointer");
+  c->str_DoNotOptimise = stringtab(c->opt->strtab, "DoNotOptimise");
+  c->str_Array = stringtab(c->opt->strtab, "Array");
+  c->str_String = stringtab(c->opt->strtab, "String");
+  c->str_Platform = stringtab(c->opt->strtab, "Platform");
+  c->str_Main = stringtab(c->opt->strtab, "Main");
+  c->str_Env = stringtab(c->opt->strtab, "Env");
 
-  c->str_add = stringtab("add");
-  c->str_sub = stringtab("sub");
-  c->str_mul = stringtab("mul");
-  c->str_div = stringtab("div");
-  c->str_rem = stringtab("rem");
-  c->str_neg = stringtab("neg");
-  c->str_add_unsafe = stringtab("add_unsafe");
-  c->str_sub_unsafe = stringtab("sub_unsafe");
-  c->str_mul_unsafe = stringtab("mul_unsafe");
-  c->str_div_unsafe = stringtab("div_unsafe");
-  c->str_rem_unsafe = stringtab("rem_unsafe");
-  c->str_neg_unsafe = stringtab("neg_unsafe");
-  c->str_and = stringtab("op_and");
-  c->str_or = stringtab("op_or");
-  c->str_xor = stringtab("op_xor");
-  c->str_not = stringtab("op_not");
-  c->str_shl = stringtab("shl");
-  c->str_shr = stringtab("shr");
-  c->str_shl_unsafe = stringtab("shl_unsafe");
-  c->str_shr_unsafe = stringtab("shr_unsafe");
-  c->str_eq = stringtab("eq");
-  c->str_ne = stringtab("ne");
-  c->str_lt = stringtab("lt");
-  c->str_le = stringtab("le");
-  c->str_ge = stringtab("ge");
-  c->str_gt = stringtab("gt");
-  c->str_eq_unsafe = stringtab("eq_unsafe");
-  c->str_ne_unsafe = stringtab("ne_unsafe");
-  c->str_lt_unsafe = stringtab("lt_unsafe");
-  c->str_le_unsafe = stringtab("le_unsafe");
-  c->str_ge_unsafe = stringtab("ge_unsafe");
-  c->str_gt_unsafe = stringtab("gt_unsafe");
+  c->str_add = stringtab(c->opt->strtab, "add");
+  c->str_sub = stringtab(c->opt->strtab, "sub");
+  c->str_mul = stringtab(c->opt->strtab, "mul");
+  c->str_div = stringtab(c->opt->strtab, "div");
+  c->str_rem = stringtab(c->opt->strtab, "rem");
+  c->str_neg = stringtab(c->opt->strtab, "neg");
+  c->str_add_unsafe = stringtab(c->opt->strtab, "add_unsafe");
+  c->str_sub_unsafe = stringtab(c->opt->strtab, "sub_unsafe");
+  c->str_mul_unsafe = stringtab(c->opt->strtab, "mul_unsafe");
+  c->str_div_unsafe = stringtab(c->opt->strtab, "div_unsafe");
+  c->str_rem_unsafe = stringtab(c->opt->strtab, "rem_unsafe");
+  c->str_neg_unsafe = stringtab(c->opt->strtab, "neg_unsafe");
+  c->str_and = stringtab(c->opt->strtab, "op_and");
+  c->str_or = stringtab(c->opt->strtab, "op_or");
+  c->str_xor = stringtab(c->opt->strtab, "op_xor");
+  c->str_not = stringtab(c->opt->strtab, "op_not");
+  c->str_shl = stringtab(c->opt->strtab, "shl");
+  c->str_shr = stringtab(c->opt->strtab, "shr");
+  c->str_shl_unsafe = stringtab(c->opt->strtab, "shl_unsafe");
+  c->str_shr_unsafe = stringtab(c->opt->strtab, "shr_unsafe");
+  c->str_eq = stringtab(c->opt->strtab, "eq");
+  c->str_ne = stringtab(c->opt->strtab, "ne");
+  c->str_lt = stringtab(c->opt->strtab, "lt");
+  c->str_le = stringtab(c->opt->strtab, "le");
+  c->str_ge = stringtab(c->opt->strtab, "ge");
+  c->str_gt = stringtab(c->opt->strtab, "gt");
+  c->str_eq_unsafe = stringtab(c->opt->strtab, "eq_unsafe");
+  c->str_ne_unsafe = stringtab(c->opt->strtab, "ne_unsafe");
+  c->str_lt_unsafe = stringtab(c->opt->strtab, "lt_unsafe");
+  c->str_le_unsafe = stringtab(c->opt->strtab, "le_unsafe");
+  c->str_ge_unsafe = stringtab(c->opt->strtab, "ge_unsafe");
+  c->str_gt_unsafe = stringtab(c->opt->strtab, "gt_unsafe");
 
-  c->str_this = stringtab("this");
-  c->str_create = stringtab("create");
-  c->str__create = stringtab("_create");
-  c->str__init = stringtab("_init");
-  c->str__final = stringtab("_final");
-  c->str__event_notify = stringtab("_event_notify");
+  c->str_this = stringtab(c->opt->strtab, "this");
+  c->str_create = stringtab(c->opt->strtab, "create");
+  c->str__create = stringtab(c->opt->strtab, "_create");
+  c->str__init = stringtab(c->opt->strtab, "_init");
+  c->str__final = stringtab(c->opt->strtab, "_final");
+  c->str__event_notify = stringtab(c->opt->strtab, "_event_notify");
 
   LLVMTypeRef type;
   LLVMTypeRef params[5];
@@ -224,7 +224,7 @@ static void init_runtime(compile_t* c)
 
   // descriptor, opaque version
   // We need this in order to build our own structure.
-  const char* desc_name = genname_descriptor(NULL);
+  const char* desc_name = genname_descriptor(NULL, c->opt->strtab);
   c->descriptor_type = LLVMStructCreateNamed(c->context, desc_name);
 
   // field descriptor
@@ -1262,5 +1262,5 @@ const char* suffix_filename(compile_t* c, const char* dir, const char* prefix,
     return NULL;
   }
 
-  return stringtab_consume(filename, len);
+  return stringtab_consume(c->opt->strtab, filename, len);
 }

--- a/src/libponyc/codegen/genbox.c
+++ b/src/libponyc/codegen/genbox.c
@@ -13,7 +13,7 @@ LLVMValueRef gen_box(compile_t* c, ast_t* type, LLVMValueRef value)
   if(LLVMGetTypeKind(l_type) == LLVMPointerTypeKind)
     return value;
 
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
@@ -40,7 +40,7 @@ LLVMValueRef gen_unbox(compile_t* c, ast_t* type, LLVMValueRef object)
   if(LLVMGetTypeKind(l_type) != LLVMPointerTypeKind)
     return object;
 
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -465,12 +465,12 @@ LLVMValueRef gen_funptr(compile_t* c, ast_t* ast)
 
   // Get the receiver type.
   ast_t* type = deferred_reify(c->frame->reify, ast_type(receiver), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
 
   const char* name = ast_name(method);
   token_id cap = cap_dispatch(type);
-  reach_method_t* m = reach_method(t, cap, name, typeargs);
+  reach_method_t* m = reach_method(t, cap, name, typeargs, c->opt);
   LLVMValueRef funptr = dispatch_function(c, t, m, value);
 
   ast_free_unattached(type);
@@ -647,7 +647,7 @@ static bool contains_boxable(ast_t* type)
 }
 
 static bool can_inline_message_send(reach_type_t* t, reach_method_t* m,
-  const char* method_name)
+  const char* method_name, compile_t* c)
 {
   switch(t->underlying)
   {
@@ -666,7 +666,7 @@ static bool can_inline_message_send(reach_type_t* t, reach_method_t* m,
   reach_type_t* sub;
   while((sub = reach_type_cache_next(&t->subtypes, &i)) != NULL)
   {
-    reach_method_t* m_sub = reach_method(sub, m->cap, method_name, m->typeargs);
+    reach_method_t* m_sub = reach_method(sub, m->cap, method_name, m->typeargs, c->opt);
 
     if(m_sub == NULL)
       continue;
@@ -751,11 +751,11 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
   // Get the receiver type.
   const char* method_name = ast_name(method);
   ast_t* type = deferred_reify(reify, ast_type(receiver), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
 
   token_id cap = cap_dispatch(type);
-  reach_method_t* m = reach_method(t, cap, method_name, typeargs);
+  reach_method_t* m = reach_method(t, cap, method_name, typeargs, c->opt);
 
   ast_free_unattached(type);
   ast_free_unattached(typeargs);
@@ -840,7 +840,7 @@ LLVMValueRef gen_call(compile_t* c, ast_t* ast)
       case TK_INTERFACE:
       case TK_TRAIT:
         if(m->cap == TK_TAG)
-          is_message = can_inline_message_send(t, m, method_name);
+          is_message = can_inline_message_send(t, m, method_name, c);
         break;
 
       default: {}
@@ -1021,12 +1021,12 @@ LLVMValueRef gen_pattern_eq(compile_t* c, ast_t* pattern, LLVMValueRef r_value)
     return NULL;
   }
 
-  reach_type_t* t = reach_type(c->reach, pattern_type);
+  reach_type_t* t = reach_type(c->reach, pattern_type, c->opt);
   pony_assert(t != NULL);
 
   // Static or virtual dispatch.
   token_id cap = cap_dispatch(pattern_type);
-  reach_method_t* m = reach_method(t, cap, c->str_eq, NULL);
+  reach_method_t* m = reach_method(t, cap, c->str_eq, NULL, c->opt);
   LLVMValueRef func = dispatch_function(c, t, m, l_value);
 
   ast_free_unattached(pattern_type);
@@ -1125,7 +1125,7 @@ static LLVMValueRef declare_ffi(compile_t* c, const char* f_name,
         p_type = ast_childidx(arg, 1);
 
       p_type = deferred_reify(reify, p_type, c->opt);
-      reach_type_t* pt = reach_type(c->reach, p_type);
+      reach_type_t* pt = reach_type(c->reach, p_type, c->opt);
       pony_assert(pt != NULL);
       f_params[param_count++] = ((compile_type_t*)pt->c_type)->use_type;
       ast_free_unattached(p_type);
@@ -1212,7 +1212,7 @@ LLVMValueRef gen_ffi(compile_t* c, ast_t* ast)
 
   // Get the return type.
   ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   ast_free_unattached(type);
 
@@ -1369,7 +1369,7 @@ LLVMValueRef gencall_create(compile_t* c, reach_type_t* t, ast_t* call)
   // reference to the new actor, because the result value of the constructor
   // call is discarded at the immediate syntax level, we can make certain
   // optimizations related to the actor reference count and the cycle detector.
-  bool no_inc_rc = call && !is_result_needed(call);
+  bool no_inc_rc = call && !is_result_needed(call, c->opt);
 
   LLVMValueRef args[3];
   args[0] = codegen_ctx(c);

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -31,7 +31,7 @@ LLVMValueRef gen_seq(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, cond, left, right);
 
   LLVMValueRef c_value = gen_expr(c, cond);
@@ -47,7 +47,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -75,7 +75,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 
   LLVMValueRef br = LLVMBuildCondBr(c->builder, c_value, then_block, else_block);
 
-  handle_branch_prediction_default(c->context, br, ast);
+  handle_branch_prediction_default(c->context, br, ast, c);
 
   // Left branch.
   LLVMPositionBuilderAtEnd(c->builder, then_block);
@@ -177,7 +177,7 @@ LLVMValueRef gen_if(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, left, right);
   AST_GET_CHILDREN(left, subtype, supertype, body);
 
@@ -204,7 +204,7 @@ LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
 
     ast_t* branch_type = deferred_reify(reify, ast_type(branch), c->opt);
     value = gen_assign_cast(c, c_t->use_type, value, branch_type);
@@ -217,7 +217,7 @@ LLVMValueRef gen_iftype(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_while(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, cond, body, else_clause);
 
   deferred_reification_t* reify = c->frame->reify;
@@ -227,7 +227,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -259,7 +259,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
 
   LLVMValueRef br = LLVMBuildCondBr(c->builder, i_value, body_block, else_block);
 
-  handle_branch_prediction_default(c->context, br, ast);
+  handle_branch_prediction_default(c->context, br, ast, c);
 
   // Body.
   LLVMPositionBuilderAtEnd(c->builder, body_block);
@@ -291,7 +291,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
     body_from = LLVMGetInsertBlock(c->builder);
     br = LLVMBuildCondBr(c->builder, c_value, body_block, post_block);
 
-    handle_branch_prediction_default(c->context, br, ast);
+    handle_branch_prediction_default(c->context, br, ast, c);
   }
 
   // Don't need loop status for the else block.
@@ -344,7 +344,7 @@ LLVMValueRef gen_while(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, body, cond, else_clause);
 
   deferred_reification_t* reify = c->frame->reify;
@@ -354,7 +354,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -406,7 +406,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
     LLVMValueRef br = LLVMBuildCondBr(c->builder, c_value, post_block,
       body_block);
 
-    handle_branch_prediction_default(c->context, br, cond);
+    handle_branch_prediction_default(c->context, br, cond, c);
   }
 
   // cond block
@@ -418,7 +418,7 @@ LLVMValueRef gen_repeat(compile_t* c, ast_t* ast)
 
   LLVMValueRef br = LLVMBuildCondBr(c->builder, i_value, else_block, body_block);
 
-  handle_branch_prediction_default(c->context, br, cond);
+  handle_branch_prediction_default(c->context, br, cond, c);
 
   // Don't need loop status for the else block.
   codegen_poploop(c);
@@ -474,12 +474,12 @@ LLVMValueRef gen_recover(compile_t* c, ast_t* ast)
   ast_t* body = ast_childidx(ast, 1);
   LLVMValueRef ret = gen_expr(c, body);
 
-  if(is_result_needed(ast))
+  if(is_result_needed(ast, c->opt))
   {
     deferred_reification_t* reify = c->frame->reify;
 
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    compile_type_t* c_t = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
 
     type = deferred_reify(reify, ast_type(body), c->opt);
@@ -653,7 +653,7 @@ LLVMValueRef gen_return(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_try(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, body, else_clause, then_clause);
 
   deferred_reification_t* reify = c->frame->reify;
@@ -664,7 +664,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -753,7 +753,7 @@ LLVMValueRef gen_try(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_disposing_block_can_error(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, body, dispose_clause);
 
   deferred_reification_t* reify = c->frame->reify;
@@ -764,7 +764,7 @@ LLVMValueRef gen_disposing_block_can_error(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -834,7 +834,7 @@ LLVMValueRef gen_disposing_block_can_error(compile_t* c, ast_t* ast)
 
 LLVMValueRef gen_disposing_block_cant_error(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, body, dispose_clause);
 
   deferred_reification_t* reify = c->frame->reify;
@@ -845,7 +845,7 @@ LLVMValueRef gen_disposing_block_cant_error(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    phi_type = (compile_type_t*)reach_type(c->reach, type)->c_type;
+    phi_type = (compile_type_t*)reach_type(c->reach, type, c->opt)->c_type;
     ast_free_unattached(type);
   }
 
@@ -1001,14 +1001,14 @@ void attach_branchweights_metadata(LLVMContextRef ctx, LLVMValueRef branch,
 }
 
 void handle_branch_prediction_default(LLVMContextRef ctx, LLVMValueRef branch,
-  ast_t* ast)
+  ast_t* ast, compile_t* c)
 {
-  if(ast_has_annotation(ast, "likely"))
+  if(ast_has_annotation(ast, "likely", c->opt->strtab))
   {
     unsigned int weights[] =
       {PONY_BRANCHWEIGHT_LIKELY, PONY_BRANCHWEIGHT_UNLIKELY};
     attach_branchweights_metadata(ctx, branch, weights, 2);
-  } else if(ast_has_annotation(ast, "unlikely")) {
+  } else if(ast_has_annotation(ast, "unlikely", c->opt->strtab)) {
     unsigned int weights[] =
       {PONY_BRANCHWEIGHT_UNLIKELY, PONY_BRANCHWEIGHT_LIKELY};
     attach_branchweights_metadata(ctx, branch, weights, 2);

--- a/src/libponyc/codegen/gencontrol.h
+++ b/src/libponyc/codegen/gencontrol.h
@@ -34,7 +34,7 @@ void attach_branchweights_metadata(LLVMContextRef ctx, LLVMValueRef branch,
    unsigned int weights[], unsigned int count);
 
 void handle_branch_prediction_default(LLVMContextRef ctx, LLVMValueRef branch,
-  ast_t* ast);
+  ast_t* ast, compile_t* c);
 
 // Numbers from Clang's __builtin_expect()
 #define PONY_BRANCHWEIGHT_LIKELY 2000

--- a/src/libponyc/codegen/gendesc.c
+++ b/src/libponyc/codegen/gendesc.c
@@ -68,7 +68,7 @@ static LLVMValueRef make_unbox_function(compile_t* c, reach_type_t* t,
   // function) by the mangled name.
   LLVMTypeRef unbox_ret_type = ret_type;
 
-  const char* unbox_name = genname_unbox(m->full_name);
+  const char* unbox_name = genname_unbox(m->full_name, c->opt->strtab);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   if(ast_id(m->fun->ast) != TK_NEW)
@@ -210,7 +210,7 @@ static LLVMValueRef make_trait_bitmap(compile_t* c, reach_type_t* t)
   ponyint_pool_free_size(c->trait_bitmap_size * sizeof(LLVMValueRef), bitmap);
 
   // Create a global to hold the array.
-  const char* name = genname_traitmap(t->name);
+  const char* name = genname_traitmap(t->name, c->opt->strtab);
   LLVMValueRef global = LLVMAddGlobal(c->module, map_type, name);
   LLVMSetGlobalConstant(global, true);
   LLVMSetLinkage(global, LLVMPrivateLinkage);
@@ -316,7 +316,7 @@ static LLVMValueRef make_field_list(compile_t* c, reach_type_t* t)
   LLVMValueRef field_array = LLVMConstArray(c->field_descriptor, list, count);
 
   // Create a global to hold the array.
-  const char* name = genname_fieldlist(t->name);
+  const char* name = genname_fieldlist(t->name, c->opt->strtab);
   LLVMValueRef global = LLVMAddGlobal(c->module, field_type, name);
   LLVMSetGlobalConstant(global, true);
   LLVMSetLinkage(global, LLVMPrivateLinkage);
@@ -410,7 +410,7 @@ void gendesc_type(compile_t* c, reach_type_t* t)
       return;
   }
 
-  const char* desc_name = genname_descriptor(t->name);
+  const char* desc_name = genname_descriptor(t->name, c->opt->strtab);
   uint32_t vtable_size = t->vtable_size;
 
   if(t->underlying != TK_TUPLETYPE)
@@ -453,7 +453,7 @@ void gendesc_init(compile_t* c, reach_type_t* t)
     return;
 
   // Initialise the global descriptor.
-  uint32_t event_notify_index = reach_vtable_index(t, c->str__event_notify);
+  uint32_t event_notify_index = reach_vtable_index(t, c->str__event_notify, c->opt);
 
   LLVMValueRef args[DESC_LENGTH];
   args[DESC_ID] = LLVMConstInt(c->i32, t->type_id, false);
@@ -622,7 +622,7 @@ LLVMValueRef gendesc_isnominal(compile_t* c, LLVMValueRef desc, ast_t* type)
 
 LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
 {
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   LLVMValueRef trait_id = LLVMConstInt(c->intptr, t->type_id, false);
 
@@ -660,7 +660,7 @@ LLVMValueRef gendesc_istrait(compile_t* c, LLVMValueRef desc, ast_t* type)
 
 LLVMValueRef gendesc_isentity(compile_t* c, LLVMValueRef desc, ast_t* type)
 {
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
 
   if(t == NULL)
     return GEN_NOVALUE;

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -134,7 +134,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   LLVMValueRef main_actor = create_main(c, t_main, ctx);
 
   // Create an Env on the main actor's heap.
-  reach_method_t* m = reach_method(t_env, TK_NONE, c->str__create, NULL);
+  reach_method_t* m = reach_method(t_env, TK_NONE, c->str__create, NULL, c->opt);
 
   LLVMValueRef env_args[4];
   env_args[0] = gencall_alloc(c, t_env, NULL);
@@ -161,7 +161,7 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
     false);
 
   // Allocate the message, setting its size and ID.
-  uint32_t index = reach_vtable_index(t_main, c->str_create);
+  uint32_t index = reach_vtable_index(t_main, c->str_create, c->opt);
   size_t msg_size = (size_t)LLVMABISizeOfType(c->target_data, msg_type);
   args[0] = LLVMConstInt(c->i32, ponyint_pool_index(msg_size), false);
   args[1] = LLVMConstInt(c->i32, index, false);
@@ -428,7 +428,7 @@ static const char* system_triple(compile_t* c)
   std::string result = std::string(triple.getArchName()) + "-"
     + std::string(triple.getOSName()) + "-"
     + std::string(triple.getEnvironmentName());
-  return stringtab(result.c_str());
+  return stringtab(c->opt->strtab, result.c_str());
 }
 
 static uint16_t expected_elf_machine(compile_t* c)
@@ -482,7 +482,7 @@ static bool elf_matches_target(const char* path, uint16_t target_machine)
 }
 
 static const char* find_libc_crt_dir(const char* sysroot,
-  const char* sys_triple, uint16_t target_machine)
+  const char* sys_triple, uint16_t target_machine, strtable_t* strtab)
 {
   // Search candidate paths for libc CRT objects.
   // The lib64 candidates cover Fedora, RHEL, and other distros that
@@ -503,22 +503,22 @@ static const char* find_libc_crt_dir(const char* sysroot,
   char buf[PATH_MAX];
 
   snprintf(buf, sizeof(buf), "%s/usr/lib/%s", sysroot, sys_triple);
-  candidates[0] = stringtab(buf);
+  candidates[0] = stringtab(strtab, buf);
 
   snprintf(buf, sizeof(buf), "%s/usr/lib", sysroot);
-  candidates[1] = stringtab(buf);
+  candidates[1] = stringtab(strtab, buf);
 
   snprintf(buf, sizeof(buf), "%s/lib/%s", sysroot, sys_triple);
-  candidates[2] = stringtab(buf);
+  candidates[2] = stringtab(strtab, buf);
 
   snprintf(buf, sizeof(buf), "%s/lib", sysroot);
-  candidates[3] = stringtab(buf);
+  candidates[3] = stringtab(strtab, buf);
 
   snprintf(buf, sizeof(buf), "%s/usr/lib64", sysroot);
-  candidates[4] = stringtab(buf);
+  candidates[4] = stringtab(strtab, buf);
 
   snprintf(buf, sizeof(buf), "%s/lib64", sysroot);
-  candidates[5] = stringtab(buf);
+  candidates[5] = stringtab(strtab, buf);
 
   static const char* sentinels[] = { "crt1.o", "crt0.o" };
 
@@ -577,7 +577,7 @@ static const char* find_ponyc_crt_dir(ast_t* program, compile_t* c)
 // return contract changes the call site in link_exe_lld_elf must change
 // in lockstep.
 static const char* find_dragonfly_gcc_lib_dir(const char* sysroot,
-  const char* arch_prefix)
+  const char* arch_prefix, strtable_t* strtab)
 {
   char buf[PATH_MAX];
 
@@ -657,7 +657,7 @@ static const char* find_dragonfly_gcc_lib_dir(const char* sysroot,
               triple_dir, ver_entry->d_name);
             if(n < 0 || (size_t)n >= sizeof(result))
               continue;
-            best_dir = stringtab(result);
+            best_dir = stringtab(strtab, result);
           }
         }
         closedir(ver_dir);
@@ -706,7 +706,7 @@ static const char* find_dragonfly_gcc_lib_dir(const char* sysroot,
           sysroot, entry->d_name);
         if(n < 0 || (size_t)n >= sizeof(result))
           continue;
-        best_dir = stringtab(result);
+        best_dir = stringtab(strtab, result);
       }
     }
     closedir(base_dir);
@@ -725,7 +725,7 @@ static const char* find_dragonfly_gcc_lib_dir(const char* sysroot,
 }
 
 static const char* find_gcc_lib_dir(const char* sysroot,
-  const char* arch_prefix)
+  const char* arch_prefix, strtable_t* strtab)
 {
   // Search for GCC runtime library directory containing libgcc.a.
   // Check multiple base paths and pick the highest version.
@@ -824,7 +824,7 @@ static const char* find_gcc_lib_dir(const char* sysroot,
           char result[PATH_MAX];
           snprintf(result, sizeof(result), "%s/%s",
             triple_dir, ver_entry->d_name);
-          best_dir = stringtab(result);
+          best_dir = stringtab(strtab, result);
         }
       }
 
@@ -845,7 +845,7 @@ static const char* resolve_sysroot(compile_t* c, const char* sys_triple,
   // If user specified --sysroot, validate it.
   if(c->opt->sysroot != NULL && c->opt->sysroot[0] != '\0')
   {
-    if(find_libc_crt_dir(c->opt->sysroot, sys_triple, target_machine) != NULL)
+    if(find_libc_crt_dir(c->opt->sysroot, sys_triple, target_machine, c->opt->strtab) != NULL)
       return c->opt->sysroot;
 
     errorf(errors, NULL,
@@ -873,20 +873,20 @@ static const char* resolve_sysroot(compile_t* c, const char* sys_triple,
   char buf[PATH_MAX];
 
   snprintf(buf, sizeof(buf), "/usr/%s", sys_triple);
-  candidates[0] = stringtab(buf);
+  candidates[0] = stringtab(c->opt->strtab, buf);
 
   snprintf(buf, sizeof(buf), "/usr/local/%s", sys_triple);
-  candidates[1] = stringtab(buf);
+  candidates[1] = stringtab(c->opt->strtab, buf);
 
   snprintf(buf, sizeof(buf), "/usr/%s/libc", sys_triple);
-  candidates[2] = stringtab(buf);
+  candidates[2] = stringtab(c->opt->strtab, buf);
 
   snprintf(buf, sizeof(buf), "/usr/local/%s/libc", sys_triple);
-  candidates[3] = stringtab(buf);
+  candidates[3] = stringtab(c->opt->strtab, buf);
 
   for(int i = 0; i < 4; i++)
   {
-    if(find_libc_crt_dir(candidates[i], sys_triple, target_machine) != NULL)
+    if(find_libc_crt_dir(candidates[i], sys_triple, target_machine, c->opt->strtab) != NULL)
       return candidates[i];
   }
 
@@ -955,7 +955,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   // Find CRT directories.
   uint16_t target_machine = expected_elf_machine(c);
   const char* libc_crt_dir = find_libc_crt_dir(sysroot, sys_triple,
-    target_machine);
+    target_machine, c->opt->strtab);
   if(libc_crt_dir == NULL)
   {
     errorf(errors, NULL,
@@ -988,7 +988,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   else if(is_dragonfly)
   {
     compiler_crt_dir = find_dragonfly_gcc_lib_dir(sysroot,
-      arch_prefix.c_str());
+      arch_prefix.c_str(), c->opt->strtab);
     if(compiler_crt_dir == NULL)
     {
       errorf(errors, NULL,
@@ -1022,7 +1022,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   }
   else
   {
-    gcc_lib_dir = find_gcc_lib_dir(sysroot, arch_prefix.c_str());
+    gcc_lib_dir = find_gcc_lib_dir(sysroot, arch_prefix.c_str(), c->opt->strtab);
   }
 
   if(c->opt->link_ldcmd != NULL)
@@ -1068,7 +1068,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   // Our patched LLD falls back to the original path when the
   // sysroot-prefixed path doesn't exist, matching GNU ld behavior.
   snprintf(buf, sizeof(buf), "--sysroot=%s", sysroot);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   if(c->opt->staticbin)
   {
@@ -1110,25 +1110,25 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     // DragonFly's Scrt1.o/crt1.o naming.
     const char* startup = c->opt->staticbin ? "rcrt0.o" : "crt0.o";
     snprintf(buf, sizeof(buf), "%s/%s", libc_crt_dir, startup);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else if(pie)
   {
     // PIE startup: prefer Scrt1.o, fall back to crt1.o.
     snprintf(buf, sizeof(buf), "%s/Scrt1.o", libc_crt_dir);
     if(file_exists(buf))
-      args.push_back(stringtab(buf));
+      args.push_back(stringtab(c->opt->strtab, buf));
     else
     {
       snprintf(buf, sizeof(buf), "%s/crt1.o", libc_crt_dir);
-      args.push_back(stringtab(buf));
+      args.push_back(stringtab(c->opt->strtab, buf));
     }
   }
   else
   {
     // Static or non-PIE dynamic (FreeBSD/DragonFly): plain crt1.o startup.
     snprintf(buf, sizeof(buf), "%s/crt1.o", libc_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // OpenBSD doesn't ship crti.o/crtn.o — its CRT model uses crt0.o (or
@@ -1137,7 +1137,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   if(!is_openbsd)
   {
     snprintf(buf, sizeof(buf), "%s/crti.o", libc_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   if(is_openbsd)
@@ -1147,34 +1147,34 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     // /usr/lib but base cc -v never selects it; the static-PIE path picks
     // up the same crtbegin.o as the dynamic-PIE path.
     snprintf(buf, sizeof(buf), "%s/crtbegin.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else if(c->opt->staticbin && !is_dragonfly)
   {
     snprintf(buf, sizeof(buf), "%s/crtbeginT.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else if(pie)
   {
     snprintf(buf, sizeof(buf), "%s/crtbeginS.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else
   {
     // Non-PIE dynamic (FreeBSD), or static on DragonFly (no crtbeginT.o
     // exists; gcc's own -static link uses plain crtbegin.o here).
     snprintf(buf, sizeof(buf), "%s/crtbegin.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // Library search paths: sysroot dirs first, then GCC, then ponyc/user.
   snprintf(buf, sizeof(buf), "-L%s", libc_crt_dir);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   if(gcc_lib_dir != NULL)
   {
     snprintf(buf, sizeof(buf), "-L%s", gcc_lib_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
 
     if(is_dragonfly)
     {
@@ -1200,9 +1200,9 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
       if(file_exists(check))
       {
         snprintf(buf, sizeof(buf), "-L%s", gcc_root_dir);
-        args.push_back(stringtab(buf));
+        args.push_back(stringtab(c->opt->strtab, buf));
         args.push_back("-rpath");
-        args.push_back(stringtab(gcc_root_dir));
+        args.push_back(stringtab(c->opt->strtab, gcc_root_dir));
       }
     }
     else
@@ -1220,7 +1220,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
         && S_ISDIR(gcc_target_stat.st_mode))
       {
         snprintf(buf, sizeof(buf), "-L%s", gcc_target_lib);
-        args.push_back(stringtab(buf));
+        args.push_back(stringtab(c->opt->strtab, buf));
       }
     }
   }
@@ -1231,7 +1231,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   {
     const char* path = program_lib_path_at(program, i);
     snprintf(buf, sizeof(buf), "-L%s", path);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
 
     if(!c->opt->staticbin)
     {
@@ -1272,7 +1272,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
       {
         char lbuf[PATH_MAX];
         snprintf(lbuf, sizeof(lbuf), "-L%s", buf);
-        args.push_back(stringtab(lbuf));
+        args.push_back(stringtab(c->opt->strtab, lbuf));
       }
     }
   }
@@ -1333,7 +1333,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     else
     {
       snprintf(buf, sizeof(buf), "-l%s", lib);
-      args.push_back(stringtab(buf));
+      args.push_back(stringtab(c->opt->strtab, buf));
     }
   }
 
@@ -1358,7 +1358,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
       snprintf(buf, sizeof(buf), "%s/%s", ponyc_crt_dir, rt_name);
       if(file_exists(buf))
       {
-        args.push_back(stringtab(buf));
+        args.push_back(stringtab(c->opt->strtab, buf));
       }
       else
       {
@@ -1493,25 +1493,25 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     // crtbegin.o choice above; base cc -v never selects crtendS.o on
     // OpenBSD even though the S variant exists in /usr/lib).
     snprintf(buf, sizeof(buf), "%s/crtend.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else if(pie)
   {
     snprintf(buf, sizeof(buf), "%s/crtendS.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
   else
   {
     // Static or non-PIE dynamic (FreeBSD/DragonFly): plain crtend.o.
     snprintf(buf, sizeof(buf), "%s/crtend.o", compiler_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // OpenBSD doesn't ship crtn.o — see the crti.o skip earlier.
   if(!is_openbsd)
   {
     snprintf(buf, sizeof(buf), "%s/crtn.o", libc_crt_dir);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   args.push_back("-o");
@@ -1555,13 +1555,19 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   return true;
 }
 
-static const char* find_macos_sdk_path()
+static const char* find_macos_sdk_path(strtable_t* strtab)
 {
-  static const char* cached = NULL;
+  // Cache the discovered path as a raw string (not interned) so the expensive
+  // xcrun probe runs only once per process, but intern into the caller's table
+  // on every call. Each compilation has its own interned-string table, so
+  // caching an interned pointer would dangle once the first compilation's table
+  // is freed.
+  static char cached_path[PATH_MAX];
   static bool searched = false;
+  static bool found = false;
 
   if(searched)
-    return cached;
+    return found ? stringtab(strtab, cached_path) : NULL;
   searched = true;
 
   char sdk_path[PATH_MAX];
@@ -1583,9 +1589,11 @@ static const char* find_macos_sdk_path()
       struct stat st;
       if(stat(lib_path, &st) == 0 && S_ISDIR(st.st_mode))
       {
-        cached = stringtab(lib_path);
+        strncpy(cached_path, lib_path, sizeof(cached_path) - 1);
+        cached_path[sizeof(cached_path) - 1] = '\0';
+        found = true;
         pclose(f);
-        return cached;
+        return stringtab(strtab, cached_path);
       }
     }
     pclose(f);
@@ -1598,8 +1606,10 @@ static const char* find_macos_sdk_path()
   struct stat st;
   if(stat(fallback, &st) == 0 && S_ISDIR(st.st_mode))
   {
-    cached = stringtab(fallback);
-    return cached;
+    strncpy(cached_path, fallback, sizeof(cached_path) - 1);
+    cached_path[sizeof(cached_path) - 1] = '\0';
+    found = true;
+    return stringtab(strtab, cached_path);
   }
 
   return NULL;
@@ -1631,7 +1641,7 @@ static const char* macho_platform_version(compile_t* c)
 
   char buf[32];
   snprintf(buf, sizeof(buf), "%u.%u.%u", major, minor, micro);
-  return stringtab(buf);
+  return stringtab(c->opt->strtab, buf);
 }
 
 static bool link_exe_lld_macho(compile_t* c, ast_t* program,
@@ -1664,7 +1674,7 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
     return false;
   }
 
-  const char* sdk_lib_path = find_macos_sdk_path();
+  const char* sdk_lib_path = find_macos_sdk_path(c->opt->strtab);
   if(sdk_lib_path == NULL)
   {
     errorf(errors, NULL,
@@ -1696,7 +1706,7 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
 
   // SDK library path.
   snprintf(buf, sizeof(buf), "-L%s", sdk_lib_path);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   // Ponyc lib paths and user lib paths.
   size_t path_count = program_lib_path_count(program);
@@ -1704,7 +1714,7 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
   {
     const char* path = program_lib_path_at(program, i);
     snprintf(buf, sizeof(buf), "-L%s", path);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // Standard library fallback paths for Homebrew and other system
@@ -1723,7 +1733,7 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
       if(stat(fallback_dirs[i], &st) == 0 && S_ISDIR(st.st_mode))
       {
         snprintf(buf, sizeof(buf), "-L%s", fallback_dirs[i]);
-        args.push_back(stringtab(buf));
+        args.push_back(stringtab(c->opt->strtab, buf));
       }
     }
   }
@@ -1743,7 +1753,7 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
     else
     {
       snprintf(buf, sizeof(buf), "-l%s", lib);
-      args.push_back(stringtab(buf));
+      args.push_back(stringtab(c->opt->strtab, buf));
     }
   }
 
@@ -1860,12 +1870,12 @@ static bool link_exe_lld_coff(compile_t* c, ast_t* program,
   args.push_back("/NOLOGO");
 
   snprintf(buf, sizeof(buf), "/MACHINE:%s", arch);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   args.push_back("/ignore:4099");
 
   snprintf(buf, sizeof(buf), "/OUT:%s", file_exe);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   // Object file.
   args.push_back(file_o);
@@ -1874,16 +1884,16 @@ static bool link_exe_lld_coff(compile_t* c, ast_t* program,
   if(strlen(vcvars.ucrt) > 0)
   {
     snprintf(buf, sizeof(buf), "/LIBPATH:%s", vcvars.ucrt);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // Windows SDK kernel32 path.
   snprintf(buf, sizeof(buf), "/LIBPATH:%s", vcvars.kernel32);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   // MSVC runtime lib path.
   snprintf(buf, sizeof(buf), "/LIBPATH:%s", vcvars.msvcrt);
-  args.push_back(stringtab(buf));
+  args.push_back(stringtab(c->opt->strtab, buf));
 
   // User library search paths.
   size_t path_count = program_lib_path_count(program);
@@ -1891,7 +1901,7 @@ static bool link_exe_lld_coff(compile_t* c, ast_t* program,
   {
     const char* path = program_lib_path_at(program, i);
     snprintf(buf, sizeof(buf), "/LIBPATH:%s", path);
-    args.push_back(stringtab(buf));
+    args.push_back(stringtab(c->opt->strtab, buf));
   }
 
   // User libraries (append .lib suffix for non-absolute paths).
@@ -1906,7 +1916,7 @@ static bool link_exe_lld_coff(compile_t* c, ast_t* program,
     else
     {
       snprintf(buf, sizeof(buf), "%s.lib", lib);
-      args.push_back(stringtab(buf));
+      args.push_back(stringtab(c->opt->strtab, buf));
     }
   }
 
@@ -1920,7 +1930,7 @@ static bool link_exe_lld_coff(compile_t* c, ast_t* program,
   char* tok = strtok(default_libs_copy, " ");
   while(tok != NULL)
   {
-    args.push_back(stringtab(tok));
+    args.push_back(stringtab(c->opt->strtab, tok));
     tok = strtok(NULL, " ");
   }
 
@@ -2329,7 +2339,7 @@ bool genexe(compile_t* c, ast_t* program)
   if(c->opt->verbosity >= VERBOSITY_INFO)
     fprintf(stderr, " Reachability\n");
   reach(c->reach, main_ast, c->str_create, NULL, c->opt);
-  reach(c->reach, main_ast, stringtab("runtime_override_defaults"), NULL, c->opt);
+  reach(c->reach, main_ast, stringtab(c->opt->strtab, "runtime_override_defaults"), NULL, c->opt);
   reach(c->reach, env_ast, c->str__create, NULL, c->opt);
 
   // reach() can't signal failure through its void return. If it aborted on an
@@ -2373,8 +2383,8 @@ bool genexe(compile_t* c, ast_t* program)
   if(c->opt->verbosity >= VERBOSITY_ALL)
     reach_dump(c->reach);
 
-  reach_type_t* t_main = reach_type(c->reach, main_ast);
-  reach_type_t* t_env = reach_type(c->reach, env_ast);
+  reach_type_t* t_main = reach_type(c->reach, main_ast, c->opt);
+  reach_type_t* t_env = reach_type(c->reach, env_ast, c->opt);
 
   ast_free(main_ast);
   ast_free(env_ast);

--- a/src/libponyc/codegen/genexpr.c
+++ b/src/libponyc/codegen/genexpr.c
@@ -263,7 +263,7 @@ static LLVMValueRef assign_to_tuple(compile_t* c, LLVMTypeRef l_type,
 static LLVMValueRef assign_union_to_tuple(compile_t* c, LLVMTypeRef l_type,
   LLVMValueRef r_value, ast_t* type)
 {
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   pony_assert(t->underlying == TK_UNIONTYPE);
 

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -294,7 +294,7 @@ static void make_prototype(compile_t* c, reach_type_t* t,
     LLVMGetParamTypes(c_m->func_type, tparams);
 
     // Generate the sender prototype.
-    const char* sender_name = genname_be(m->full_name);
+    const char* sender_name = genname_be(m->full_name, c->opt->strtab);
     c_m->func = codegen_addfun(c, sender_name, c_m->func_type, true);
     genfun_param_attrs(c, t, m, c_m->func);
 
@@ -354,7 +354,7 @@ static void add_get_behavior_name_case(compile_t* c, reach_type_t* t,
   LLVMPositionBuilderAtEnd(c->builder, block);
 
   // hack to get the behavior name since it's always a "tag_" prefix
-  const char* name = genname_behavior_name(t->name, be_name + 4);
+  const char* name = genname_behavior_name(t->name, be_name + 4, c->opt->strtab);
 
   LLVMValueRef ret = codegen_string(c, name, strlen(name));
   genfun_build_ret(c, ret);
@@ -784,7 +784,7 @@ static bool genfun_allocator(compile_t* c, reach_type_t* t)
   if((c_t->primitive != NULL) || is_pointer(t->ast) || is_nullable_pointer(t->ast))
     return true;
 
-  const char* funname = genname_alloc(t->name);
+  const char* funname = genname_alloc(t->name, c->opt->strtab);
   LLVMTypeRef ftype = LLVMFunctionType(c_t->use_type, NULL, 0, false);
   LLVMValueRef fun = codegen_addfun(c, funname, ftype, true);
   if(t->underlying != TK_PRIMITIVE)
@@ -835,7 +835,7 @@ static bool genfun_forward(compile_t* c, reach_type_t* t,
   compile_method_t* c_m = (compile_method_t*)m->c_method;
   pony_assert(c_m->func != NULL);
 
-  reach_method_t* m2 = reach_method(t, m->cap, n->name, m->typeargs);
+  reach_method_t* m2 = reach_method(t, m->cap, n->name, m->typeargs, c->opt);
   pony_assert(m2 != NULL);
   pony_assert(m2 != m);
   compile_method_t* c_m2 = (compile_method_t*)m2->c_method;
@@ -1232,7 +1232,7 @@ static void primitive_call(compile_t* c, const char* method)
     if(t->underlying != TK_PRIMITIVE)
       continue;
 
-    reach_method_t* m = reach_method(t, TK_NONE, method, NULL);
+    reach_method_t* m = reach_method(t, TK_NONE, method, NULL, c->opt);
 
     if(m == NULL)
       continue;
@@ -1254,7 +1254,7 @@ void genfun_primitive_calls(compile_t* c)
   if(need_primitive_call(c, c->str__init))
   {
     fn_type = LLVMFunctionType(c->void_type, NULL, 0, false);
-    const char* fn_name = genname_program_fn(c->filename, "primitives_init");
+    const char* fn_name = genname_program_fn(c->filename, "primitives_init", c->opt->strtab);
     c->primitives_init = LLVMAddFunction(c->module, fn_name, fn_type);
 
     codegen_startfun(c, c->primitives_init, NULL, NULL, NULL, false);
@@ -1267,7 +1267,7 @@ void genfun_primitive_calls(compile_t* c)
   {
     if(fn_type == NULL)
       fn_type = LLVMFunctionType(c->void_type, NULL, 0, false);
-    const char* fn_name = genname_program_fn(c->filename, "primitives_final");
+    const char* fn_name = genname_program_fn(c->filename, "primitives_final", c->opt->strtab);
     c->primitives_final = LLVMAddFunction(c->module, fn_name, fn_type);
 
     codegen_startfun(c, c->primitives_final, NULL, NULL, NULL, false);

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -53,7 +53,7 @@ static void print_base_type(compile_t* c, printbuf_t* buf, ast_t* type)
 {
   if(ast_id(type) == TK_NOMINAL)
   {
-    const char* name = genname_type(type);
+    const char* name = genname_type(type, c->opt->strtab);
     const char* c_name = c_type_name(c, name);
 
     if(c_name != NULL)

--- a/src/libponyc/codegen/genident.c
+++ b/src/libponyc/codegen/genident.c
@@ -62,9 +62,9 @@ static LLVMValueRef tuple_is(compile_t* c, ast_t* left_type, ast_t* right_type,
 
     // Test the element.
     compile_type_t* c_t_left =
-      (compile_type_t*)reach_type(c->reach, left_child)->c_type;
+      (compile_type_t*)reach_type(c->reach, left_child, c->opt)->c_type;
     compile_type_t* c_t_right =
-      (compile_type_t*)reach_type(c->reach, right_child)->c_type;
+      (compile_type_t*)reach_type(c->reach, right_child, c->opt)->c_type;
     LLVMValueRef l_elem = LLVMBuildExtractValue(c->builder, l_value, i, "");
     LLVMValueRef r_elem = LLVMBuildExtractValue(c->builder, r_value, i, "");
     l_elem = gen_assign_cast(c, c_t_left->use_type, l_elem, left_child);
@@ -163,7 +163,7 @@ static LLVMValueRef tuple_element_is_box_unboxed_element(compile_t* c,
     case SUBTYPE_KIND_NUMERIC:
     {
       compile_type_t* c_t_left =
-        (compile_type_t*)reach_type(c->reach, l_field_type)->c_type;
+        (compile_type_t*)reach_type(c->reach, l_field_type, c->opt)->c_type;
       LLVMValueRef l_desc = c_t_left->desc;
       LLVMValueRef same_type = LLVMBuildICmp(c->builder, LLVMIntEQ, l_desc,
         r_field_desc, "");
@@ -414,7 +414,7 @@ static LLVMValueRef tuple_is_box(compile_t* c, ast_t* left_type,
 
   while(l_child != NULL)
   {
-    reach_type_t* t = reach_type(c->reach, l_child);
+    reach_type_t* t = reach_type(c->reach, l_child, c->opt);
     compile_type_t* c_t = (compile_type_t*)t->c_type;
 
     LLVMValueRef l_elem = LLVMBuildExtractValue(c->builder, l_value, i, "");
@@ -567,8 +567,8 @@ static LLVMValueRef box_is_box(compile_t* c, reach_type_t* left_type,
 
     // Call the type-specific __is function, which will unbox the LHS.
     LLVMPositionBuilderAtEnd(c->builder, bothtuple_block);
-    reach_method_t* is_fn = reach_method(left_type, TK_BOX, stringtab("__is"),
-      NULL);
+    reach_method_t* is_fn = reach_method(left_type, TK_BOX, stringtab(c->opt->strtab, "__is"),
+      NULL, c->opt);
     pony_assert(is_fn != NULL);
 
     LLVMValueRef func = gendesc_vtable(c, l_desc, is_fn->vtable_index);
@@ -664,7 +664,7 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
           return tuple_is(c, left_type, right_type, l_value, r_value);
       } else if(right_null || !is_known(right_type)) {
         // If right_type is an abstract type, check if r_value is a boxed tuple.
-        reach_type_t* r_right = reach_type(c->reach, right_type);
+        reach_type_t* r_right = reach_type(c->reach, right_type, c->opt);
         return tuple_is_box(c, left_type, r_right, l_value, r_value, NULL,
           true, true);
       }
@@ -680,9 +680,9 @@ static LLVMValueRef gen_is_value(compile_t* c, ast_t* left_type,
 
       bool left_known = is_known(left_type);
       bool right_known = !right_null && is_known(right_type);
-      reach_type_t* r_left = reach_type(c->reach, left_type);
+      reach_type_t* r_left = reach_type(c->reach, left_type, c->opt);
       reach_type_t* r_right = !right_null ?
-        reach_type(c->reach, right_type) : NULL;
+        reach_type(c->reach, right_type, c->opt) : NULL;
 
       if(!left_known && !right_known)
       {
@@ -780,7 +780,7 @@ void gen_is_tuple_fun(compile_t* c, reach_type_t* t)
 {
   pony_assert(t->underlying == TK_TUPLETYPE);
 
-  reach_method_t* m = reach_method(t, TK_BOX, stringtab("__is"), NULL);
+  reach_method_t* m = reach_method(t, TK_BOX, stringtab(c->opt->strtab, "__is"), NULL, c->opt);
 
   if(m == NULL)
     return;

--- a/src/libponyc/codegen/genmatch.c
+++ b/src/libponyc/codegen/genmatch.c
@@ -64,7 +64,11 @@ static ast_t* eq_param_type(compile_t* c, ast_t* pattern)
 {
   ast_t* pattern_type = deferred_reify(c->frame->reify, ast_type(pattern),
     c->opt);
-  deferred_reification_t* fun = lookup(NULL, pattern, pattern_type, c->str_eq);
+  // Pass from=NULL so lookup skips its private-access checks (which are gated on
+  // from != NULL && opt != NULL). Codegen must not re-enforce access control,
+  // which is why this historically passed a NULL opt; but opt is now needed so
+  // the subtype machinery (is_bare) can intern into this compilation's table.
+  deferred_reification_t* fun = lookup(c->opt, NULL, pattern_type, c->str_eq);
 
   AST_GET_CHILDREN(fun->ast, cap, id, typeparams, params, result, partial);
   ast_t* param = ast_child(params);
@@ -236,7 +240,7 @@ static bool check_type(compile_t* c, LLVMValueRef ptr, LLVMValueRef desc,
 static bool check_value(compile_t* c, ast_t* pattern, ast_t* param_type,
   LLVMValueRef value, LLVMBasicBlockRef next_block)
 {
-  reach_type_t* t = reach_type(c->reach, param_type);
+  reach_type_t* t = reach_type(c->reach, param_type, c->opt);
   LLVMValueRef r_value = gen_assign_cast(c,
     ((compile_type_t*)t->c_type)->use_type, value, param_type);
 
@@ -255,7 +259,7 @@ static bool check_value(compile_t* c, ast_t* pattern, ast_t* param_type,
   LLVMValueRef br = LLVMBuildCondBr(c->builder, result, continue_block,
     next_block);
 
-  handle_branch_prediction_default(c->context, br, ast_parent(pattern));
+  handle_branch_prediction_default(c->context, br, ast_parent(pattern), c);
 
   LLVMPositionBuilderAtEnd(c->builder, continue_block);
   return true;
@@ -409,7 +413,7 @@ static bool dynamic_tuple_ptr(compile_t* c, LLVMValueRef ptr,
 static LLVMValueRef load_tuple_field_value(compile_t* c, LLVMValueRef ptr,
   LLVMValueRef desc, ast_t* pattern_type)
 {
-  reach_type_t* t = reach_type(c->reach, pattern_type);
+  reach_type_t* t = reach_type(c->reach, pattern_type, c->opt);
   LLVMTypeRef use_type = ((compile_type_t*)t->c_type)->use_type;
 
   if(LLVMGetTypeKind(use_type) != LLVMPointerTypeKind)
@@ -460,9 +464,9 @@ static bool dynamic_value_ptr(compile_t* c, LLVMValueRef ptr,
 
   ast_t* the_case = ast_parent(pattern);
   match_weight_t weight;
-  if(ast_has_annotation(the_case, "likely"))
+  if(ast_has_annotation(the_case, "likely", c->opt->strtab))
     weight = WEIGHT_LIKELY;
-  else if(ast_has_annotation(the_case, "unlikely"))
+  else if(ast_has_annotation(the_case, "unlikely", c->opt->strtab))
     weight = WEIGHT_UNLIKELY;
   else
     weight = WEIGHT_NONE;
@@ -485,9 +489,9 @@ static bool dynamic_capture_ptr(compile_t* c, LLVMValueRef ptr,
 
   ast_t* the_case = ast_parent(pattern);
   match_weight_t weight;
-  if(ast_has_annotation(the_case, "likely"))
+  if(ast_has_annotation(the_case, "likely", c->opt->strtab))
     weight = WEIGHT_LIKELY;
-  else if(ast_has_annotation(the_case, "unlikely"))
+  else if(ast_has_annotation(the_case, "unlikely", c->opt->strtab))
     weight = WEIGHT_UNLIKELY;
   else
     weight = WEIGHT_NONE;
@@ -552,9 +556,9 @@ static bool dynamic_value_object(compile_t* c, LLVMValueRef object,
 
   ast_t* the_case = ast_parent(pattern);
   match_weight_t weight;
-  if(ast_has_annotation(the_case, "likely"))
+  if(ast_has_annotation(the_case, "likely", c->opt->strtab))
     weight = WEIGHT_LIKELY;
-  else if(ast_has_annotation(the_case, "unlikely"))
+  else if(ast_has_annotation(the_case, "unlikely", c->opt->strtab))
     weight = WEIGHT_UNLIKELY;
   else
     weight = WEIGHT_NONE;
@@ -578,9 +582,9 @@ static bool dynamic_capture_object(compile_t* c, LLVMValueRef object,
 
   ast_t* the_case = ast_parent(pattern);
   match_weight_t weight;
-  if(ast_has_annotation(the_case, "likely"))
+  if(ast_has_annotation(the_case, "likely", c->opt->strtab))
     weight = WEIGHT_LIKELY;
-  else if(ast_has_annotation(the_case, "unlikely"))
+  else if(ast_has_annotation(the_case, "unlikely", c->opt->strtab))
     weight = WEIGHT_UNLIKELY;
   else
     weight = WEIGHT_NONE;
@@ -835,7 +839,7 @@ static bool case_body(compile_t* c, ast_t* body,
   if(body_value == GEN_NOVALUE)
     return true;
 
-  if(is_result_needed(body))
+  if(is_result_needed(body, c->opt))
   {
     ast_t* body_type = deferred_reify(c->frame->reify, ast_type(body), c->opt);
     body_value = gen_assign_cast(c, phi_type, body_value, body_type);
@@ -855,7 +859,7 @@ static bool case_body(compile_t* c, ast_t* body,
 
 LLVMValueRef gen_match(compile_t* c, ast_t* ast)
 {
-  bool needed = is_result_needed(ast);
+  bool needed = is_result_needed(ast, c->opt);
   AST_GET_CHILDREN(ast, match_expr, cases, else_expr);
 
   // We will have no type if all cases jump away.
@@ -866,7 +870,7 @@ LLVMValueRef gen_match(compile_t* c, ast_t* ast)
   if(needed && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-    reach_type_t* t_phi = reach_type(c->reach, type);
+    reach_type_t* t_phi = reach_type(c->reach, type, c->opt);
     phi_type = ((compile_type_t*)t_phi->c_type)->use_type;
     ast_free_unattached(type);
   }

--- a/src/libponyc/codegen/genname.c
+++ b/src/libponyc/codegen/genname.c
@@ -146,14 +146,14 @@ static void types_append(printbuf_t* buf, ast_t* elements)
   }
 }
 
-static const char* stringtab_buf(printbuf_t* buf)
+static const char* stringtab_buf(printbuf_t* buf, strtable_t* strtab)
 {
-  const char* r = stringtab(buf->m);
+  const char* r = stringtab(strtab, buf->m);
   printbuf_free(buf);
   return r;
 }
 
-static const char* stringtab_two(const char* a, const char* b)
+static const char* stringtab_two(const char* a, const char* b, strtable_t* strtab)
 {
   if(a == NULL)
     a = "_";
@@ -161,75 +161,75 @@ static const char* stringtab_two(const char* a, const char* b)
   pony_assert(b != NULL);
   printbuf_t* buf = printbuf_new();
   printbuf(buf, "%s_%s", a, b);
-  return stringtab_buf(buf);
+  return stringtab_buf(buf, strtab);
 }
 
-const char* genname_type(ast_t* ast)
+const char* genname_type(ast_t* ast, strtable_t* strtab)
 {
   // package_Type[_Arg1_Arg2]
   printbuf_t* buf = printbuf_new();
   type_append(buf, ast, true);
-  return stringtab_buf(buf);
+  return stringtab_buf(buf, strtab);
 }
 
-const char* genname_type_and_cap(ast_t* ast)
+const char* genname_type_and_cap(ast_t* ast, strtable_t* strtab)
 {
   // package_Type[_Arg1_Arg2]_cap
   printbuf_t* buf = printbuf_new();
   type_append(buf, ast, false);
-  return stringtab_buf(buf);
+  return stringtab_buf(buf, strtab);
 }
 
-const char* genname_alloc(const char* type)
+const char* genname_alloc(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Alloc");
+  return stringtab_two(type, "Alloc", strtab);
 }
 
-const char* genname_traitmap(const char* type)
+const char* genname_traitmap(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Traits");
+  return stringtab_two(type, "Traits", strtab);
 }
 
-const char* genname_fieldlist(const char* type)
+const char* genname_fieldlist(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Fields");
+  return stringtab_two(type, "Fields", strtab);
 }
 
-const char* genname_trace(const char* type)
+const char* genname_trace(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Trace");
+  return stringtab_two(type, "Trace", strtab);
 }
 
-const char* genname_dispatch(const char* type)
+const char* genname_dispatch(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Dispatch");
+  return stringtab_two(type, "Dispatch", strtab);
 }
 
 #if defined(USE_RUNTIME_TRACING)
-const char* genname_get_behavior_name(const char* type)
+const char* genname_get_behavior_name(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "GetBehaviourName");
+  return stringtab_two(type, "GetBehaviourName", strtab);
 }
 
-const char* genname_behavior_name(const char* type, const char* name)
+const char* genname_behavior_name(const char* type, const char* name, strtable_t* strtab)
 {
   printbuf_t* buf = printbuf_new();
   printbuf(buf, "%s.%s", type, name);
-  return stringtab_buf(buf);
+  return stringtab_buf(buf, strtab);
 }
 #endif
 
-const char* genname_descriptor(const char* type)
+const char* genname_descriptor(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Desc");
+  return stringtab_two(type, "Desc", strtab);
 }
 
-const char* genname_instance(const char* type)
+const char* genname_instance(const char* type, strtable_t* strtab)
 {
-  return stringtab_two(type, "Inst");
+  return stringtab_two(type, "Inst", strtab);
 }
 
-const char* genname_fun(token_id cap, const char* name, ast_t* typeargs)
+const char* genname_fun(token_id cap, const char* name, ast_t* typeargs, strtable_t* strtab)
 {
   // cap_name[_Arg1_Arg2]
   printbuf_t* buf = printbuf_new();
@@ -238,30 +238,30 @@ const char* genname_fun(token_id cap, const char* name, ast_t* typeargs)
   else
     printbuf(buf, "%s_%s", lexer_print(cap), name);
   types_append(buf, typeargs);
-  return stringtab_buf(buf);
+  return stringtab_buf(buf, strtab);
 }
 
-const char* genname_be(const char* name)
+const char* genname_be(const char* name, strtable_t* strtab)
 {
-  return stringtab_two(name, "_send");
+  return stringtab_two(name, "_send", strtab);
 }
 
-const char* genname_box(const char* name)
+const char* genname_box(const char* name, strtable_t* strtab)
 {
-  return stringtab_two(name, "Box");
+  return stringtab_two(name, "Box", strtab);
 }
 
-const char* genname_unbox(const char* name)
+const char* genname_unbox(const char* name, strtable_t* strtab)
 {
-  return stringtab_two(name, "Unbox");
+  return stringtab_two(name, "Unbox", strtab);
 }
 
-const char* genname_unsafe(const char* name)
+const char* genname_unsafe(const char* name, strtable_t* strtab)
 {
-  return stringtab_two(name, "unsafe");
+  return stringtab_two(name, "unsafe", strtab);
 }
 
-const char* genname_program_fn(const char* program, const char* name)
+const char* genname_program_fn(const char* program, const char* name, strtable_t* strtab)
 {
-  return stringtab_two(program, name);
+  return stringtab_two(program, name, strtab);
 }

--- a/src/libponyc/codegen/genname.h
+++ b/src/libponyc/codegen/genname.h
@@ -6,41 +6,44 @@
 
 PONY_EXTERN_C_BEGIN
 
-const char* genname_type(ast_t* ast);
+const char* genname_type(ast_t* ast, strtable_t* strtab);
 
-const char* genname_type_and_cap(ast_t* ast);
+const char* genname_type_and_cap(ast_t* ast, strtable_t* strtab);
 
-const char* genname_alloc(const char* type);
+const char* genname_alloc(const char* type, strtable_t* strtab);
 
-const char* genname_traitmap(const char* type);
+const char* genname_traitmap(const char* type, strtable_t* strtab);
 
-const char* genname_fieldlist(const char* type);
+const char* genname_fieldlist(const char* type, strtable_t* strtab);
 
-const char* genname_trace(const char* type);
+const char* genname_trace(const char* type, strtable_t* strtab);
 
-const char* genname_dispatch(const char* type);
+const char* genname_dispatch(const char* type, strtable_t* strtab);
 
 #if defined(USE_RUNTIME_TRACING)
-const char* genname_get_behavior_name(const char* type);
+const char* genname_get_behavior_name(const char* type, strtable_t* strtab);
 
-const char* genname_behavior_name(const char* type, const char* name);
+const char* genname_behavior_name(const char* type, const char* name,
+  strtable_t* strtab);
 #endif
 
-const char* genname_descriptor(const char* type);
+const char* genname_descriptor(const char* type, strtable_t* strtab);
 
-const char* genname_instance(const char* type);
+const char* genname_instance(const char* type, strtable_t* strtab);
 
-const char* genname_fun(token_id cap, const char* name, ast_t* typeargs);
+const char* genname_fun(token_id cap, const char* name, ast_t* typeargs,
+  strtable_t* strtab);
 
-const char* genname_be(const char* name);
+const char* genname_be(const char* name, strtable_t* strtab);
 
-const char* genname_box(const char* name);
+const char* genname_box(const char* name, strtable_t* strtab);
 
-const char* genname_unbox(const char* name);
+const char* genname_unbox(const char* name, strtable_t* strtab);
 
-const char* genname_unsafe(const char* name);
+const char* genname_unsafe(const char* name, strtable_t* strtab);
 
-const char* genname_program_fn(const char* program, const char* name);
+const char* genname_program_fn(const char* program, const char* name,
+  strtable_t* strtab);
 
 PONY_EXTERN_C_END
 

--- a/src/libponyc/codegen/genoperator.c
+++ b/src/libponyc/codegen/genoperator.c
@@ -306,7 +306,7 @@ static LLVMValueRef make_short_circuit(compile_t* c, ast_t* left, ast_t* right,
 static LLVMValueRef assign_local(compile_t* c, LLVMValueRef l_value,
   LLVMValueRef r_value, ast_t* l_type, ast_t* r_type)
 {
-  reach_type_t* t = reach_type(c->reach, l_type);
+  reach_type_t* t = reach_type(c->reach, l_type, c->opt);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   LLVMValueRef result = LLVMBuildLoad2(c->builder,
@@ -328,7 +328,7 @@ static LLVMValueRef assign_local(compile_t* c, LLVMValueRef l_value,
 static LLVMValueRef assign_field(compile_t* c, LLVMValueRef l_value,
   LLVMValueRef r_value, ast_t* l_type, ast_t* r_type)
 {
-  reach_type_t* t = reach_type(c->reach, l_type);
+  reach_type_t* t = reach_type(c->reach, l_type, c->opt);
   pony_assert(t != NULL);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 

--- a/src/libponyc/codegen/genprim.c
+++ b/src/libponyc/codegen/genprim.c
@@ -16,8 +16,8 @@
 #include <string.h>
 
 #define FIND_METHOD(name, cap) \
-  const char* strtab_name = stringtab(name); \
-  reach_method_t* m = reach_method(t, cap, strtab_name, NULL); \
+  const char* strtab_name = stringtab(c->opt->strtab, name); \
+  reach_method_t* m = reach_method(t, cap, strtab_name, NULL, c->opt); \
   if(m == NULL) return; \
   m->intrinsic = true; \
   compile_type_t* c_t = (compile_type_t*)t->c_type; \
@@ -31,7 +31,7 @@
   gen(c, gen_data, TK_VAL);
 
 #define GENERIC_FUNCTION(name, gen) \
-  generic_function(c, t, stringtab(name), gen);
+  generic_function(c, t, stringtab(c->opt->strtab, name), gen);
 
 typedef void (*generate_gen_fn)(compile_t*, reach_type_t*, reach_method_t*);
 
@@ -428,7 +428,7 @@ void genprim_pointer_methods(compile_t* c, reach_type_t* t)
 {
   ast_t* typeargs = ast_childidx(t->ast, 2);
   ast_t* typearg = ast_child(typeargs);
-  reach_type_t* t_elem = reach_type(c->reach, typearg);
+  reach_type_t* t_elem = reach_type(c->reach, typearg, c->opt);
   compile_type_t* c_t_elem = (compile_type_t*)t_elem->c_type;
 
   void* box_args[2];
@@ -531,7 +531,7 @@ void genprim_nullable_pointer_methods(compile_t* c, reach_type_t* t)
   ast_t* typeargs = ast_childidx(t->ast, 2);
   ast_t* typearg = ast_child(typeargs);
   compile_type_t* t_elem =
-    (compile_type_t*)reach_type(c->reach, typearg)->c_type;
+    (compile_type_t*)reach_type(c->reach, typearg, c->opt)->c_type;
 
   void* box_args[2];
   box_args[0] = t;
@@ -552,7 +552,7 @@ static void donotoptimise_apply(compile_t* c, reach_type_t* t,
 
   ast_t* typearg = ast_child(m->typeargs);
   compile_type_t* t_elem =
-    (compile_type_t*)reach_type(c->reach, typearg)->c_type;
+    (compile_type_t*)reach_type(c->reach, typearg, c->opt)->c_type;
   compile_type_t* t_result = (compile_type_t*)m->result->c_type;
 
   LLVMTypeRef params[2];
@@ -632,7 +632,7 @@ static void trace_array_elements(compile_t* c, reach_type_t* t,
   if(!gentrace_needed(c, typearg, typearg))
     return;
 
-  reach_type_t* t_elem = reach_type(c->reach, typearg);
+  reach_type_t* t_elem = reach_type(c->reach, typearg, c->opt);
   compile_type_t* c_t_elem = (compile_type_t*)t_elem->c_type;
 
   LLVMBasicBlockRef entry_block = LLVMGetInsertBlock(c->builder);
@@ -925,7 +925,7 @@ typedef struct num_conv_t
 
 static void number_value(compile_t* c, num_conv_t* type, token_id cap)
 {
-  reach_type_t* t = reach_type_name(c->reach, type->type_name);
+  reach_type_t* t = reach_type_name(c->reach, type->type_name, c->opt);
 
   if(t == NULL)
     return;
@@ -1163,7 +1163,7 @@ static void number_conversion(compile_t* c, void** data, token_id cap)
     return;
   }
 
-  reach_type_t* t = reach_type_name(c->reach, from->type_name);
+  reach_type_t* t = reach_type_name(c->reach, from->type_name, c->opt);
 
   if(t == NULL)
     return;
@@ -1235,12 +1235,12 @@ static void unsafe_number_conversion(compile_t* c, void** data, token_id cap)
     return;
   }
 
-  reach_type_t* t = reach_type_name(c->reach, from->type_name);
+  reach_type_t* t = reach_type_name(c->reach, from->type_name, c->opt);
 
   if(t == NULL)
     return;
 
-  const char* name = genname_unsafe(to->fun_name);
+  const char* name = genname_unsafe(to->fun_name, c->opt->strtab);
 
   FIND_METHOD(name, cap);
   start_function(c, t, m, to->type, &from->type, 1);
@@ -1493,7 +1493,7 @@ static void fp_intrinsics(compile_t* c)
 {
   reach_type_t* t;
 
-  if((t = reach_type_name(c->reach, "F32")) != NULL)
+  if((t = reach_type_name(c->reach, "F32", c->opt)) != NULL)
   {
     f32__nan(c, t);
     f32__inf(c, t);
@@ -1501,7 +1501,7 @@ static void fp_intrinsics(compile_t* c)
     BOX_FUNCTION(f32_bits, t);
   }
 
-  if((t = reach_type_name(c->reach, "F64")) != NULL)
+  if((t = reach_type_name(c->reach, "F64", c->opt)) != NULL)
   {
     f64__nan(c, t);
     f64__inf(c, t);

--- a/src/libponyc/codegen/genreference.c
+++ b/src/libponyc/codegen/genreference.c
@@ -76,7 +76,7 @@ static LLVMValueRef make_fieldptr(compile_t* c, LLVMValueRef l_value,
   if(ast_id(def) == TK_ACTOR)
     index++;
 
-  reach_type_t* l_t = reach_type(c->reach, l_type);
+  reach_type_t* l_t = reach_type(c->reach, l_type, c->opt);
   pony_assert(l_t != NULL);
   compile_type_t* l_c_t = (compile_type_t*)l_t->c_type;
 
@@ -127,7 +127,7 @@ LLVMValueRef gen_fieldload(compile_t* c, ast_t* ast)
   deferred_reification_t* reify = c->frame->reify;
 
   ast_t* type = deferred_reify(reify, ast_type(right), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
@@ -170,7 +170,7 @@ LLVMValueRef gen_tupleelemptr(compile_t* c, ast_t* ast)
   deferred_reification_t* reify = c->frame->reify;
 
   ast_t* type = deferred_reify(reify, ast_type(ast), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   pony_assert(t != NULL);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
@@ -199,7 +199,7 @@ LLVMValueRef gen_tuple(compile_t* c, ast_t* ast)
     return GEN_NOTNEEDED;
   }
 
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
   int count = LLVMCountStructElementTypes(c_t->primitive);
@@ -254,7 +254,7 @@ LLVMValueRef gen_localdecl(compile_t* c, ast_t* ast)
     return GEN_NOVALUE;
 
   ast_t* type = deferred_reify(c->frame->reify, ast_type(id), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
@@ -312,7 +312,7 @@ LLVMValueRef gen_localload(compile_t* c, ast_t* ast)
     return NULL;
 
   ast_t* type = deferred_reify(c->frame->reify, ast_type(ast), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
@@ -373,7 +373,7 @@ static LLVMValueRef gen_digestof_box(compile_t* c, reach_type_t* type,
 
   // Call the type-specific __digestof function, which will unbox the value.
   reach_method_t* digest_fn = reach_method(type, TK_BOX,
-    stringtab("__digestof"), NULL);
+    stringtab(c->opt->strtab, "__digestof"), NULL, c->opt);
   pony_assert(digest_fn != NULL);
   LLVMValueRef func = gendesc_vtable(c, desc, digest_fn->vtable_index);
   LLVMTypeRef fn_type = LLVMFunctionType(c->intptr, &c->ptr, 1, false);
@@ -488,7 +488,7 @@ static LLVMValueRef gen_digestof_value(compile_t* c, ast_t* type,
     case LLVMPointerTypeKind:
       if(!is_known(type))
       {
-        reach_type_t* t = reach_type(c->reach, type);
+        reach_type_t* t = reach_type(c->reach, type, c->opt);
         int sub_kind = subtype_kind(t);
 
         if((sub_kind & SUBTYPE_KIND_BOXED) != 0)
@@ -518,7 +518,7 @@ void gen_digestof_fun(compile_t* c, reach_type_t* t)
 {
   pony_assert(t->can_be_boxed);
 
-  reach_method_t* m = reach_method(t, TK_BOX, stringtab("__digestof"), NULL);
+  reach_method_t* m = reach_method(t, TK_BOX, stringtab(c->opt->strtab, "__digestof"), NULL, c->opt);
 
   if(m == NULL)
     return;
@@ -540,7 +540,7 @@ void gen_digestof_fun(compile_t* c, reach_type_t* t)
 LLVMValueRef gen_int(compile_t* c, ast_t* ast)
 {
   ast_t* type = deferred_reify(c->frame->reify, ast_type(ast), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
@@ -563,7 +563,7 @@ LLVMValueRef gen_int(compile_t* c, ast_t* ast)
 LLVMValueRef gen_float(compile_t* c, ast_t* ast)
 {
   ast_t* type = deferred_reify(c->frame->reify, ast_type(ast), c->opt);
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   ast_free_unattached(type);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
@@ -584,7 +584,7 @@ LLVMValueRef gen_string(compile_t* c, ast_t* ast)
 
   ast_t* type = ast_type(ast);
   pony_assert(is_literal(type, "String"));
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   size_t len = ast_name_len(ast);

--- a/src/libponyc/codegen/gentrace.c
+++ b/src/libponyc/codegen/gentrace.c
@@ -42,7 +42,7 @@ typedef enum
 static void trace_dynamic(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   ast_t* type, ast_t* orig, ast_t* tuple, LLVMBasicBlockRef next_block);
 
-static trace_t trace_type(ast_t* type);
+static trace_t trace_type(ast_t* type, compile_t* c);
 
 static trace_t trace_union_machine_word(trace_t a)
 {
@@ -179,7 +179,7 @@ static trace_t trace_union_tag(trace_t a)
   return TRACE_NONE;
 }
 
-static trace_t trace_type_union(ast_t* type)
+static trace_t trace_type_union(ast_t* type, compile_t* c)
 {
   trace_t trace = TRACE_NONE;
 
@@ -187,7 +187,7 @@ static trace_t trace_type_union(ast_t* type)
     child != NULL;
     child = ast_sibling(child))
   {
-    trace_t t = trace_type(child);
+    trace_t t = trace_type(child, c);
 
     switch(trace)
     {
@@ -237,7 +237,7 @@ static trace_t trace_type_union(ast_t* type)
   return trace;
 }
 
-static trace_t trace_type_isect(ast_t* type)
+static trace_t trace_type_isect(ast_t* type, compile_t* c)
 {
   trace_t trace = TRACE_DYNAMIC;
 
@@ -245,7 +245,7 @@ static trace_t trace_type_isect(ast_t* type)
     child != NULL;
     child = ast_sibling(child))
   {
-    trace_t t = trace_type(child);
+    trace_t t = trace_type(child, c);
 
     switch(t)
     {
@@ -290,9 +290,9 @@ static trace_t trace_type_isect(ast_t* type)
   return trace;
 }
 
-static trace_t trace_type_nominal(ast_t* type)
+static trace_t trace_type_nominal(ast_t* type, compile_t* c)
 {
-  if(is_bare(type))
+  if(is_bare(type, c->opt))
   {
     return TRACE_PRIMITIVE;
   }
@@ -351,21 +351,21 @@ static trace_t trace_type_nominal(ast_t* type)
   return TRACE_NONE;
 }
 
-static trace_t trace_type(ast_t* type)
+static trace_t trace_type(ast_t* type, compile_t* c)
 {
   switch(ast_id(type))
   {
     case TK_UNIONTYPE:
-      return trace_type_union(type);
+      return trace_type_union(type, c);
 
     case TK_ISECTTYPE:
-      return trace_type_isect(type);
+      return trace_type_isect(type, c);
 
     case TK_TUPLETYPE:
       return TRACE_TUPLE;
 
     case TK_NOMINAL:
-      return trace_type_nominal(type);
+      return trace_type_nominal(type, c);
 
     case TK_TYPEALIASREF:
     {
@@ -380,7 +380,7 @@ static trace_t trace_type(ast_t* type)
         return TRACE_DYNAMIC;
       }
 
-      trace_t result = trace_type(unfolded);
+      trace_t result = trace_type(unfolded, c);
       ast_free_unattached(unfolded);
       return result;
     }
@@ -511,7 +511,7 @@ static void trace_nullable_pointer(compile_t* c, LLVMValueRef ctx,
 static void trace_known(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
   ast_t* type, int mutability)
 {
-  reach_type_t* t = reach_type(c->reach, type);
+  reach_type_t* t = reach_type(c->reach, type, c->opt);
 
   LLVMValueRef args[4];
   args[0] = ctx;
@@ -732,7 +732,7 @@ static void trace_dynamic_tuple(compile_t* c, LLVMValueRef ctx,
 
   while(child != NULL)
   {
-    switch(trace_type(child))
+    switch(trace_type(child, c))
     {
       case TRACE_MACHINE_WORD:
       case TRACE_PRIMITIVE:
@@ -1036,7 +1036,7 @@ static void trace_dynamic(compile_t* c, LLVMValueRef ctx, LLVMValueRef object,
 
 bool gentrace_needed(compile_t* c, ast_t* src_type, ast_t* dst_type)
 {
-  switch(trace_type(src_type))
+  switch(trace_type(src_type, c))
   {
     case TRACE_NONE:
       pony_assert(0);
@@ -1173,7 +1173,7 @@ void gentrace_prototype(compile_t* c, reach_type_t* t)
     return;
 
   ((compile_type_t*)t->c_type)->trace_fn = codegen_addfun(c,
-    genname_trace(t->name), c->trace_fn, true);
+    genname_trace(t->name, c->opt->strtab), c->trace_fn, true);
 }
 
 void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,
@@ -1200,10 +1200,10 @@ void gentrace(compile_t* c, LLVMValueRef ctx, LLVMValueRef src_value,
       dst_type = dst_unfolded;
   }
 
-  trace_t trace_method = trace_type(src_type);
+  trace_t trace_method = trace_type(src_type, c);
   if(src_type != dst_type)
   {
-    trace_method = trace_type_dst_cap(trace_method, trace_type(dst_type),
+    trace_method = trace_type_dst_cap(trace_method, trace_type(dst_type, c),
       src_type);
   }
 

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -296,7 +296,7 @@ static void make_box_type(compile_t* c, reach_type_t* t)
   if(c_t->primitive == NULL)
     return;
 
-  const char* box_name = genname_box(t->name);
+  const char* box_name = genname_box(t->name, c->opt->strtab);
   c_t->structure = LLVMStructCreateNamed(c->context, box_name);
 
   LLVMTypeRef elements[2];
@@ -323,7 +323,7 @@ static void make_global_instance(compile_t* c, reach_type_t* t)
     return;
 
   // Create a unique global instance.
-  const char* inst_name = genname_instance(t->name);
+  const char* inst_name = genname_instance(t->name, c->opt->strtab);
   LLVMValueRef value = LLVMConstNamedStruct(c_t->structure, &c_t->desc, 1);
   c_t->instance = LLVMAddGlobal(c->module, c_t->structure, inst_name);
   LLVMSetInitializer(c_t->instance, value);
@@ -340,7 +340,7 @@ static void make_get_behavior_name(compile_t* c, reach_type_t* t)
 
   // Create a dispatch function.
   compile_type_t* c_t = (compile_type_t*)t->c_type;
-  const char* get_behavior_name_name = genname_get_behavior_name(t->name);
+  const char* get_behavior_name_name = genname_get_behavior_name(t->name, c->opt->strtab);
   c_t->get_behavior_name_fn = codegen_addfun(c, get_behavior_name_name, c->get_behavior_name_fn, true);
   LLVMSetFunctionCallConv(c_t->get_behavior_name_fn, LLVMCCallConv);
   LLVMSetLinkage(c_t->get_behavior_name_fn, LLVMExternalLinkage);
@@ -357,7 +357,7 @@ static void make_get_behavior_name(compile_t* c, reach_type_t* t)
 
   // Mark the default case as unreachable.
   LLVMPositionBuilderAtEnd(c->builder, default_block);
-  const char* name = genname_behavior_name(t->name, "*UNKNOWN*");
+  const char* name = genname_behavior_name(t->name, "*UNKNOWN*", c->opt->strtab);
   LLVMValueRef ret = codegen_string(c, name, strlen(name));
   genfun_build_ret(c, ret);
 
@@ -373,7 +373,7 @@ static void make_dispatch(compile_t* c, reach_type_t* t)
 
   // Create a dispatch function.
   compile_type_t* c_t = (compile_type_t*)t->c_type;
-  const char* dispatch_name = genname_dispatch(t->name);
+  const char* dispatch_name = genname_dispatch(t->name, c->opt->strtab);
   c_t->dispatch_fn = codegen_addfun(c, dispatch_name, c->dispatch_fn, true);
   LLVMSetFunctionCallConv(c_t->dispatch_fn, LLVMCCallConv);
   LLVMSetLinkage(c_t->dispatch_fn, LLVMExternalLinkage);
@@ -428,7 +428,7 @@ static bool make_struct(compile_t* c, reach_type_t* t)
 
       type = c_t->structure;
       ast_t* def = (ast_t*)ast_data(t->ast);
-      if(ast_has_annotation(def, "packed"))
+      if(ast_has_annotation(def, "packed", c->opt->strtab))
         packed = true;
 
       break;
@@ -802,7 +802,7 @@ bool gentypes(compile_t* c)
 
   // Cache the instance of None, which is used as the return value for
   // behaviour calls.
-  t = reach_type_name(c->reach, "None");
+  t = reach_type_name(c->reach, "None", c->opt);
   pony_assert(t != NULL);
   compile_type_t* c_t = (compile_type_t*)t->c_type;
   c->none_instance = c_t->instance;

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -62,7 +62,7 @@ static ast_t* strip_this_arrow(pass_opt_t* opt, ast_t* ast)
 static ast_t* detect_apply_element_type(pass_opt_t* opt, ast_t* ast, ast_t* def)
 {
   // The interface must have an apply method for us to find it.
-  ast_t* apply = ast_get(def, stringtab("apply"), NULL);
+  ast_t* apply = ast_get(def, stringtab(opt->strtab, "apply"), NULL);
   if((apply == NULL) || (ast_id(apply) != TK_FUN))
     return NULL;
 
@@ -77,7 +77,7 @@ static ast_t* detect_apply_element_type(pass_opt_t* opt, ast_t* ast, ast_t* def)
 
   ast_t* param = ast_child(params);
   ast_t* param_type = ast_childidx(param, 1);
-  if(ast_name(ast_childidx(param_type, 1)) != stringtab("USize"))
+  if(ast_name(ast_childidx(param_type, 1)) != stringtab(opt->strtab, "USize"))
     return NULL;
 
   // Based on the return type we try to figure out the element type.
@@ -95,7 +95,7 @@ static ast_t* detect_values_element_type(pass_opt_t* opt, ast_t* ast,
   ast_t* def)
 {
   // The interface must have an apply method for us to find it.
-  ast_t* values = ast_get(def, stringtab("values"), NULL);
+  ast_t* values = ast_get(def, stringtab(opt->strtab, "values"), NULL);
   if((values == NULL) || (ast_id(values) != TK_FUN))
     return NULL;
 
@@ -109,7 +109,7 @@ static ast_t* detect_values_element_type(pass_opt_t* opt, ast_t* ast,
     return NULL;
 
   if((ast_id(ret_type) != TK_NOMINAL) ||
-    (ast_name(ast_childidx(ret_type, 1)) != stringtab("Iterator")) ||
+    (ast_name(ast_childidx(ret_type, 1)) != stringtab(opt->strtab, "Iterator")) ||
     (ast_childcount(ast_childidx(ret_type, 2)) != 1))
     return NULL;
 
@@ -136,7 +136,7 @@ static void find_possible_element_types(pass_opt_t* opt, ast_t* ast,
       AST_GET_CHILDREN(ast, package, name, typeargs, cap, eph);
 
       // If it's an actual Array type, note it as a possibility and move on.
-      if(stringtab("Array") == ast_name(name))
+      if(stringtab(opt->strtab, "Array") == ast_name(name))
       {
         *list = astlist_push(*list, ast_child(typeargs));
         return;
@@ -223,7 +223,7 @@ static void find_possible_iterator_element_types(pass_opt_t* opt, ast_t* ast,
     {
       AST_GET_CHILDREN(ast, package, name, typeargs, cap, eph);
 
-      if(stringtab("Iterator") == ast_name(name))
+      if(stringtab(opt->strtab, "Iterator") == ast_name(name))
       {
         *list = astlist_push(*list, ast_child(typeargs));
       }
@@ -278,7 +278,7 @@ static bool infer_element_type(pass_opt_t* opt, ast_t* ast,
     // If the ast parent is a call to values() and the antecedent of that call
     // is an Iterator, then we can get possible element types that way.
     if((ast_id(ast_parent(ast)) == TK_DOT) &&
-      (ast_name(ast_sibling(ast)) == stringtab("values")))
+      (ast_name(ast_sibling(ast)) == stringtab(opt->strtab, "values")))
     {
       ast_t* dot = ast_parent(ast);
       antecedent_type = find_antecedent_type(opt, dot, NULL);
@@ -495,7 +495,7 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
       {
         ast_error_frame(&frame, ele,
           "invalid specified array element type: %s",
-          ast_print_type(type));
+          ast_print_type(type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         return false;
@@ -505,9 +505,9 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
         ast_error_frame(&frame, ele,
           "array element not a subtype of specified array type");
         ast_error_frame(&frame, type_spec, "array type: %s",
-          ast_print_type(type));
+          ast_print_type(type, opt->strtab));
         ast_error_frame(&frame, c_type, "element type: %s",
-          ast_print_type(c_type));
+          ast_print_type(c_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ast_free_unattached(w_type);

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -46,7 +46,7 @@ static bool insert_apply(pass_opt_t* opt, ast_t** astp)
   AST_GET_CHILDREN(ast, lhs, positional, namedargs, question);
 
   ast_t* dot = ast_from(ast, TK_DOT);
-  ast_add(dot, ast_from_string(ast, "apply"));
+  ast_add(dot, ast_from_string(ast, "apply", opt->strtab));
   ast_swap(lhs, dot);
   ast_add(dot, lhs);
 
@@ -195,7 +195,7 @@ static bool apply_default_arg(pass_opt_t* opt, ast_t* param, ast_t** argp)
   {
     // Default argument is __loc. Expand call location.
     ast_t* arg = *argp;
-    ast_t* location = expand_location(arg);
+    ast_t* location = expand_location(arg, opt);
     ast_add(arg, location);
     ast_setid(arg, TK_SEQ);
 
@@ -324,7 +324,7 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not assignable to parameter");
       ast_error_frame(&frame, param, "parameter type is illegal: %s",
-                      ast_print_type(p_type));
+                      ast_print_type(p_type, opt->strtab));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
 
@@ -335,9 +335,9 @@ static bool check_arg_types(pass_opt_t* opt, ast_t* params, ast_t* positional,
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not assignable to parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
-                      ast_print_type(arg_type));
+                      ast_print_type(arg_type, opt->strtab));
       ast_error_frame(&frame, param, "parameter type requires %s",
-                      ast_print_type(wp_type));
+                      ast_print_type(wp_type, opt->strtab));
 
       if (ast_childcount(arg) > 1)
         ast_error_frame(&frame, arg,
@@ -392,7 +392,7 @@ static bool auto_recover_call(ast_t* ast, ast_t* receiver_type, pass_opt_t* opt,
   // arguments are safe and the result is either safe or unused.
   // The result of a chained method is always unused.
   ast_t* call = ast_parent(ast);
-  if(is_result_needed(call) && !safe_to_autorecover(receiver_type, result, EXTRACT, opt))
+  if(is_result_needed(call, opt) && !safe_to_autorecover(receiver_type, result, EXTRACT, opt))
     return false;
 
   ast_t* arg = ast_child(positional);
@@ -513,16 +513,16 @@ static bool check_receiver_cap(pass_opt_t* opt, ast_t* ast, bool* recovered)
     switch (ast_id(a_type)) { // provide better information if the refcap is `this->*`
       case TK_ARROW:
         ast_error_frame(&frame, ast_child(lhs),
-          "receiver type: %s (which becomes '%s' in this context)", ast_print_type(a_type), ast_print_type(viewpoint_upper(a_type, opt)));
+          "receiver type: %s (which becomes '%s' in this context)", ast_print_type(a_type, opt->strtab), ast_print_type(viewpoint_upper(a_type, opt), opt->strtab));
         break;
 
       default:
         ast_error_frame(&frame, ast_child(lhs),
-          "receiver type: %s", ast_print_type(a_type));
+          "receiver type: %s", ast_print_type(a_type, opt->strtab));
     }
 
     ast_error_frame(&frame, cap,
-      "target type: %s", ast_print_type(t_type));
+      "target type: %s", ast_print_type(t_type, opt->strtab));
     errorframe_append(&frame, &info);
 
     if(ast_checkflag(ast_type(method_receiver(lhs)), AST_FLAG_INCOMPLETE))
@@ -838,7 +838,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
     apply_cap = partial_application_cap(opt, type, receiver, positional);
 
   token_id can_error = ast_id(ast_childidx(method_ast, 5));
-  const char* recv_name = package_hygienic_id(t);
+  const char* recv_name = package_hygienic_id(t, opt);
 
   // Build lambda expression.
   ast_t* call_receiver = NULL;
@@ -858,7 +858,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
     }
 
     ast_t* receiver_type = ast_type(receiver);
-    if(is_bare(receiver_type))
+    if(is_bare(receiver_type, opt))
     {
       // Partial application on a bare object, simply return the object itself.
       ast_replace(astp, receiver);
@@ -872,13 +872,13 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
 
     ast_t* module = ast_nearest(ast, TK_MODULE);
     ast_t* package = ast_parent(module);
-    ast_t* pkg_id = package_id(package);
+    ast_t* pkg_id = package_id(package, opt);
     const char* pkg_str = ast_name(pkg_id);
 
     const char* pkg_alias = NULL;
 
     if(recv_package_str != pkg_str)
-      pkg_alias = package_alias_from_id(module, recv_package_str);
+      pkg_alias = package_alias_from_id(module, recv_package_str, opt);
 
     ast_free_unattached(pkg_id);
 
@@ -910,13 +910,13 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
 
     ast_t* module = ast_nearest(ast, TK_MODULE);
     ast_t* package = ast_parent(module);
-    ast_t* pkg_id = package_id(package);
+    ast_t* pkg_id = package_id(package, opt);
     const char* pkg_str = ast_name(pkg_id);
 
     const char* pkg_alias = NULL;
 
     if(recv_package_str != pkg_str)
-      pkg_alias = package_alias_from_id(module, recv_package_str);
+      pkg_alias = package_alias_from_id(module, recv_package_str, opt);
 
     ast_free_unattached(pkg_id);
 
@@ -986,7 +986,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
       BUILD(lambda_param, target_param,
         NODE(TK_PARAM,
           TREE(p_id)
-          TREE(sanitise_type(p_type))
+          TREE(sanitise_type(p_type, opt))
           TREE(p_default)));
 
       // ISSUE-2480: the default argument was already typed at the method
@@ -1060,7 +1060,7 @@ static bool partial_application(pass_opt_t* opt, ast_t** astp)
       NONE  // Lambda type params.
       TREE(lambda_params)
       TREE(captures)
-      TREE(sanitise_type(result))
+      TREE(sanitise_type(result, opt))
       NODE(can_error)
       NODE(TK_SEQ,
         NODE(TK_CALL,

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -425,7 +425,7 @@ bool expr_recover(pass_opt_t* opt, ast_t* ast)
   {
     ast_error(opt->check.errors, ast, "can't recover to this capability");
     ast_error_continue(opt->check.errors, expr, "expression type is %s",
-      ast_print_type(type));
+      ast_print_type(type, opt->strtab));
     return false;
   }
 
@@ -566,9 +566,9 @@ bool expr_return(pass_opt_t* opt, ast_t* ast)
         ast_t* last = ast_childlast(body);
         ast_error_frame(&frame, last, "returned value isn't the return type");
         ast_error_frame(&frame, type, "function return type: %s",
-          ast_print_type(type));
+          ast_print_type(type, opt->strtab));
         ast_error_frame(&frame, body_type, "returned value type: %s",
-          ast_print_type(body_type));
+          ast_print_type(body_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ok = false;

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -77,9 +77,9 @@ static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)
       errorframe_t frame = NULL;
       ast_error_frame(&frame, arg, "argument not a assignable to parameter");
       ast_error_frame(&frame, arg, "argument type is %s",
-                      ast_print_type(a_type));
+                      ast_print_type(a_type, opt->strtab));
       ast_error_frame(&frame, param, "parameter type requires %s",
-                      ast_print_type(p_type));
+                      ast_print_type(p_type, opt->strtab));
       errorframe_append(&frame, &info);
       errorframe_report(&frame, opt->check.errors);
       ast_free_unattached(a_type);

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -124,7 +124,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
       {
         ast_error_frame(&frame, type,
           "invalid parameter type: %s",
-          ast_print_type(type));
+          ast_print_type(type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ast_free_unattached(p_type);
@@ -134,9 +134,9 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
       {
         ast_error_frame(&frame, value, "argument not assignable to parameter");
         ast_error_frame(&frame, value, "argument type is %s",
-                        ast_print_type(v_type));
+                        ast_print_type(v_type, opt->strtab));
         ast_error_frame(&frame, id_node, "parameter type requires %s",
-                        ast_print_type(p_type));
+                        ast_print_type(p_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ast_free_unattached(p_type);
@@ -156,7 +156,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
     return true;
   }
 
-  type = sanitise_type(type);
+  type = sanitise_type(type, opt);
 
   BUILD(field, id_node,
     NODE(TK_FVAR,
@@ -509,13 +509,13 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
     else
       printbuf(buf, ", ");
 
-    printbuf(buf, "%s", ast_print_type(ast_childidx(p, 1)));
+    printbuf(buf, "%s", ast_print_type(ast_childidx(p, 1), opt->strtab));
   }
 
   printbuf(buf, ")");
 
   if(ast_id(ret_type) != TK_NONE)
-    printbuf(buf, ": %s", ast_print_type(ret_type));
+    printbuf(buf, ": %s", ast_print_type(ret_type, opt->strtab));
 
   if(ast_id(raises) != TK_NONE)
     printbuf(buf, " ?");
@@ -524,7 +524,7 @@ bool expr_lambda(pass_opt_t* opt, ast_t** astp)
 
   // Replace lambda with object literal
   REPLACE(astp,
-    NODE(TK_OBJECT, DATA(stringtab(buf->m))
+    NODE(TK_OBJECT, DATA(stringtab(opt->strtab, buf->m))
       TREE(obj_cap)
       NONE  // Provides list
       TREE(members)));
@@ -616,7 +616,7 @@ static bool capture_from_reference(pass_opt_t* opt, ast_t* ctx, ast_t* ast,
   if(is_typecheck_error(type))
     return false;
 
-  type = sanitise_type(type);
+  type = sanitise_type(type, opt);
 
   BUILD(field, ast,
     NODE(TK_FVAR,
@@ -700,7 +700,7 @@ static void add_field_to_object(pass_opt_t* opt, ast_t* field,
   ast_t* call_args)
 {
   AST_GET_CHILDREN(field, id, type, init);
-  ast_t* p_id = ast_from_string(id, package_hygienic_id(&opt->check));
+  ast_t* p_id = ast_from_string(id, package_hygienic_id(&opt->check, opt), opt->strtab);
 
   // The param is: $0: type
   BUILD(param, field,
@@ -805,11 +805,11 @@ bool expr_object(pass_opt_t* opt, ast_t** astp)
   ast_clearflag(members, AST_FLAG_PRESERVE);
 
   ast_t* annotation = ast_consumeannotation(ast);
-  const char* c_id = package_hygienic_id(&opt->check);
+  const char* c_id = package_hygienic_id(&opt->check, opt);
 
   ast_t* t_params;
   ast_t* t_args;
-  collect_type_params(ast, &t_params, &t_args);
+  collect_type_params(ast, &t_params, &t_args, opt);
 
   const char* nice_id = (const char*)ast_data(ast);
 
@@ -952,7 +952,7 @@ bool expr_object(pass_opt_t* opt, ast_t** astp)
   }
 
   if(ast_id(def) != TK_PRIMITIVE)
-    pony_assert(!ast_has_annotation(def, "ponyint_bare"));
+    pony_assert(!ast_has_annotation(def, "ponyint_bare", opt->strtab));
 
   // Reset constructor to pick up the correct defaults.
   ast_setid(ast_child(create), cap_id);

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -69,7 +69,7 @@ static bool case_expr_matches_type_alone(pass_opt_t* opt, ast_t* case_expr)
   if((def == NULL) || (ast_id(def) != TK_PRIMITIVE) || is_machine_word(type))
     return false;
 
-  ast_t* eq_def = ast_get(def, stringtab("eq"), NULL);
+  ast_t* eq_def = ast_get(def, stringtab(opt->strtab, "eq"), NULL);
   pony_assert(ast_id(eq_def) == TK_FUN);
 
   ast_t* eq_params = ast_childidx(eq_def, 3);
@@ -354,12 +354,12 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
     return false;
   }
 
-  if(is_bare(expr_type))
+  if(is_bare(expr_type, opt))
   {
     ast_error(opt->check.errors, expr,
       "a match operand cannot have a bare type");
     ast_error_continue(opt->check.errors, expr_type,
-      "type is %s", ast_print_type(expr_type));
+      "type is %s", ast_print_type(expr_type, opt->strtab));
     return false;
   }
 
@@ -394,7 +394,7 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
       // match might not be exhaustive
       if ((ast_id(else_clause) == TK_NONE))
       {
-        if(ast_has_annotation(ast, "exhaustive"))
+        if(ast_has_annotation(ast, "exhaustive", opt->strtab))
         {
           ast_error(opt->check.errors, ast,
             "match marked \\exhaustive\\ is not exhaustive");
@@ -526,12 +526,12 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
   if(is_typecheck_error(pattern_type))
     return NULL;
 
-  if(is_bare(pattern_type))
+  if(is_bare(pattern_type, opt))
   {
     ast_error(opt->check.errors, pattern,
       "a match pattern cannot have a bare type");
     ast_error_continue(opt->check.errors, pattern_type,
-      "type is %s", ast_print_type(pattern_type));
+      "type is %s", ast_print_type(pattern_type, opt->strtab));
     return NULL;
   }
 
@@ -591,7 +591,7 @@ static ast_t* make_pattern_type(pass_opt_t* opt, ast_t* pattern)
 
   // Structural equality, pattern.eq(match).
   deferred_reification_t* fun = lookup(opt, pattern, pattern_type,
-    stringtab("eq"));
+    stringtab(opt->strtab, "eq"));
 
   if(fun == NULL)
   {
@@ -849,9 +849,9 @@ static bool check_capture_soundness(pass_opt_t* opt, ast_t* pattern,
           "this capture is unsound: the capture type can grant capabilities "
           "that require consuming the match expression");
         ast_error_frame(&frame, pattern, "capture type: %s",
-          ast_print_type(capture_type));
+          ast_print_type(capture_type, opt->strtab));
         ast_error_frame(&frame, match_expr, "match type: %s",
-          ast_print_type(match_type));
+          ast_print_type(match_type, opt->strtab));
         ast_error_frame(&frame, pattern,
           "if you need to capture with this capability, "
           "consume the match expression");
@@ -973,10 +973,10 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
         errorframe_t frame = NULL;
         ast_error_frame(&frame, pattern, "this pattern can never match");
         ast_error_frame(&frame, match_type, "match type: %s",
-          ast_print_type(match_type));
+          ast_print_type(match_type, opt->strtab));
         // TODO report unaliased type when body is consume !
         ast_error_frame(&frame, pattern, "pattern type: %s",
-          ast_print_type(pattern_type));
+          ast_print_type(pattern_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
 
@@ -994,9 +994,9 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
         ast_error_frame(&frame, match_type, "the match type allows for more than "
           "one possibility with the same type as pattern type, but different "
           "capabilities. match type: %s",
-          ast_print_type(match_type));
+          ast_print_type(match_type, opt->strtab));
         ast_error_frame(&frame, pattern, "pattern type: %s",
-          ast_print_type(pattern_type));
+          ast_print_type(pattern_type, opt->strtab));
         errorframe_append(&frame, &info);
         ast_error_frame(&frame, match_expr,
           "the match expression with the inadequate capability is here");
@@ -1012,12 +1012,12 @@ bool expr_case(pass_opt_t* opt, ast_t* ast)
         ast_error_frame(&frame, pattern,
           "this capture cannot match, since the type %s "
           "is a struct and lacks a type descriptor",
-          ast_print_type(pattern_type));
+          ast_print_type(pattern_type, opt->strtab));
         ast_error_frame(&frame, match_type,
           "a struct cannot be part of a union type. match type: %s",
-          ast_print_type(match_type));
+          ast_print_type(match_type, opt->strtab));
         ast_error_frame(&frame, pattern, "pattern type: %s",
-          ast_print_type(pattern_type));
+          ast_print_type(pattern_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
         ok = false;

--- a/src/libponyc/expr/operator.c
+++ b/src/libponyc/expr/operator.c
@@ -644,7 +644,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
   if(wl_type == NULL)
   {
     ast_error_frame(&frame, ast, "Invalid type for field of assignment: %s",
-        ast_print_type(fl_type));
+        ast_print_type(fl_type, opt->strtab));
 
     if(ast_checkflag(ast_type(right), AST_FLAG_INCOMPLETE))
       ast_error_frame(&frame, right,
@@ -689,7 +689,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
           "can't destructure a union using assignment, use pattern matching "
           "instead");
         ast_error_continue(opt->check.errors, right,
-          "inferred type of expression: %s", ast_print_type(r_type));
+          "inferred type of expression: %s", ast_print_type(r_type, opt->strtab));
         break;
 
       case TK_ISECTTYPE:
@@ -697,7 +697,7 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
           "can't destructure an intersection using assignment, use pattern "
           "matching instead");
         ast_error_continue(opt->check.errors, right,
-          "inferred type of expression: %s", ast_print_type(r_type));
+          "inferred type of expression: %s", ast_print_type(r_type, opt->strtab));
         break;
 
       default:
@@ -755,11 +755,11 @@ bool expr_assign(pass_opt_t* opt, ast_t* ast)
     ast_error(opt->check.errors, ast,
       "not safe to write right side to left side");
     ast_error_continue(opt->check.errors, wl_type, "right side type: %s",
-      ast_print_type(wl_type));
+      ast_print_type(wl_type, opt->strtab));
     if(ast_child(left) != NULL)
     {
       ast_error_continue(opt->check.errors, ast_child(left), "left side type: %s",
-      ast_print_type(ast_type(ast_child(left))));
+      ast_print_type(ast_type(ast_child(left)), opt->strtab));
     }
     ast_free_unattached(wl_type);
     return false;
@@ -819,7 +819,7 @@ static bool add_as_type(pass_opt_t* opt, ast_t* ast, ast_t* expr,
 
     default:
     {
-      const char* name = package_hygienic_id(&opt->check);
+      const char* name = package_hygienic_id(&opt->check, opt);
 
       ast_t* expr_type = ast_type(expr);
       errorframe_t info = NULL;
@@ -830,9 +830,9 @@ static bool add_as_type(pass_opt_t* opt, ast_t* ast, ast_t* expr,
         ast_error_frame(&frame, ast,
           "this capture violates capabilities");
         ast_error_frame(&frame, type,
-          "match type: %s", ast_print_type(type));
+          "match type: %s", ast_print_type(type, opt->strtab));
         ast_error_frame(&frame, expr,
-          "pattern type: %s", ast_print_type(expr_type));
+          "pattern type: %s", ast_print_type(expr_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
 
@@ -842,12 +842,12 @@ static bool add_as_type(pass_opt_t* opt, ast_t* ast, ast_t* expr,
         ast_error_frame(&frame, ast,
           "matching variable of type %s with %s is not possible, "
           "since a struct lacks a type descriptor",
-          ast_print_type(expr_type), ast_print_type(type));
+          ast_print_type(expr_type, opt->strtab), ast_print_type(type, opt->strtab));
         ast_error_frame(&frame, type,
-          "match type: %s", ast_print_type(type));
+          "match type: %s", ast_print_type(type, opt->strtab));
         ast_error_frame(&frame, expr,
           "a struct cannot be part of a union type. "
-          "pattern type: %s", ast_print_type(expr_type));
+          "pattern type: %s", ast_print_type(expr_type, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
 
@@ -901,13 +901,13 @@ bool expr_as(pass_opt_t* opt, ast_t** astp)
     {
       ast_error(opt->check.errors, ast, "Cannot cast to same type");
       ast_error_continue(opt->check.errors, expr,
-        "Expression is already of type %s", ast_print_type(type));
+        "Expression is already of type %s", ast_print_type(type, opt->strtab));
     }
     else
     {
       ast_error(opt->check.errors, ast, "Cannot cast to subtype");
       ast_error_continue(opt->check.errors, expr,
-        "%s is a subtype of this Expression. 'as' is not needed here.", ast_print_type(type));
+        "%s is a subtype of this Expression. 'as' is not needed here.", ast_print_type(type, opt->strtab));
     }
     return false;
   }
@@ -984,7 +984,7 @@ bool expr_consume(pass_opt_t* opt, ast_t* ast)
   {
     ast_error(opt->check.errors, ast, "can't consume to this capability");
     ast_error_continue(opt->check.errors, term, "expression type is %s",
-      ast_print_type(type));
+      ast_print_type(type, opt->strtab));
     return false;
   }
 

--- a/src/libponyc/expr/postfix.c
+++ b/src/libponyc/expr/postfix.c
@@ -60,19 +60,19 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
         case TK_TYPE:
           ast_error(opt->check.errors, ast,
             "can't call a constructor on a type alias: %s",
-            ast_print_type(type));
+            ast_print_type(type, opt->strtab));
           return false;
 
         case TK_INTERFACE:
           ast_error(opt->check.errors, ast,
             "can't call a constructor on an interface: %s",
-            ast_print_type(type));
+            ast_print_type(type, opt->strtab));
           return false;
 
         case TK_TRAIT:
           ast_error(opt->check.errors, ast,
             "can't call a constructor on a trait: %s",
-            ast_print_type(type));
+            ast_print_type(type, opt->strtab));
           return false;
 
         default:
@@ -120,7 +120,7 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
     {
       ast_error(opt->check.errors, ast,
         "can't call a constructor on a type union: %s",
-        ast_print_type(type));
+        ast_print_type(type, opt->strtab));
       return false;
     }
 
@@ -128,7 +128,7 @@ static bool constructor_type(pass_opt_t* opt, ast_t* ast, token_id cap,
     {
       ast_error(opt->check.errors, ast,
         "can't call a constructor on a type intersection: %s",
-        ast_print_type(type));
+        ast_print_type(type, opt->strtab));
       return false;
     }
 
@@ -250,7 +250,7 @@ static bool type_access(pass_opt_t* opt, ast_t** astp)
       }
 
       ast_t* dot = ast_from(ast, TK_DOT);
-      ast_add(dot, ast_from_string(ast, "create"));
+      ast_add(dot, ast_from_string(ast, "create", opt->strtab));
       ast_swap(left, dot);
       ast_add(dot, left);
 
@@ -483,7 +483,7 @@ bool expr_qualify(pass_opt_t* opt, ast_t** astp)
 
   // Otherwise, sugar as qualified call to .apply()
   ast_t* dot = ast_from(left, TK_DOT);
-  ast_add(dot, ast_from_string(left, "apply"));
+  ast_add(dot, ast_from_string(left, "apply", opt->strtab));
   ast_swap(left, dot);
   ast_add(dot, left);
 

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -179,7 +179,7 @@ bool expr_param(pass_opt_t* opt, ast_t* ast)
     {
       ast_error_frame(&err2, declared_type,
         "invalid parameter type for a parameter with a default argument: %s",
-        ast_print_type(declared_type));
+        ast_print_type(declared_type, opt->strtab));
       errorframe_append(&err2, &err);
       errorframe_report(&err2, opt->check.errors);
       ok = false;
@@ -268,7 +268,7 @@ bool expr_fieldref(pass_opt_t* opt, ast_t* ast, ast_t* find, token_id tid)
     if(upper == NULL)
     {
       ast_error(opt->check.errors, ast, "can't read a field through %s",
-        ast_print_type(l_type));
+        ast_print_type(l_type, opt->strtab));
       return false;
     }
 
@@ -335,7 +335,7 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
     const char* name = ast_name(id);
     const char* package_name =
       (ast_id(package) != TK_NONE) ? ast_name(ast_child(package)) : NULL;
-    type = type_sugar_args(ast, package_name, name, typeargs);
+    type = type_sugar_args(ast, package_name, name, typeargs, opt);
     ast_settype(ast, type);
 
     if(is_typecheck_error(type))
@@ -365,7 +365,7 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
     {
       // Transform to a default constructor.
       ast_t* dot = ast_from(ast, TK_DOT);
-      ast_add(dot, ast_from_string(ast, "create"));
+      ast_add(dot, ast_from_string(ast, "create", opt->strtab));
       ast_swap(ast, dot);
       *astp = dot;
       ast_add(dot, ast);
@@ -409,7 +409,7 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
 
           // Add a dot node.
           ast_t* apply = ast_from(call, TK_DOT);
-          ast_add(apply, ast_from_string(call, "apply"));
+          ast_add(apply, ast_from_string(call, "apply", opt->strtab));
           ast_swap(call, apply);
           *astp = apply;
           ast_add(apply, call);
@@ -429,7 +429,7 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
     {
       // Transform to a default constructor.
       ast_t* dot = ast_from(ast, TK_DOT);
-      ast_add(dot, ast_from_string(ast, "create"));
+      ast_add(dot, ast_from_string(ast, "create", opt->strtab));
       ast_swap(ast, dot);
       ast_add(dot, ast);
 
@@ -465,7 +465,7 @@ bool expr_dontcareref(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_DONTCAREREF);
 
-  if(is_result_needed(ast) && !is_legal_dontcare_read(ast))
+  if(is_result_needed(ast, opt) && !is_legal_dontcare_read(ast))
   {
     ast_error(opt->check.errors, ast, "can't read from '_'");
     return false;
@@ -1025,7 +1025,7 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
       ast_error(opt->check.errors, ast,
         "%s is not allowed: "
         "the type argument to NullablePointer must be a struct",
-        ast_print_type(ast));
+        ast_print_type(ast, opt->strtab));
 
       return false;
     }
@@ -1062,9 +1062,9 @@ static bool check_return_type(pass_opt_t* opt, ast_t* ast)
     ast_t* last = ast_childlast(body);
     ast_error_frame(&frame, last, "function body isn't the result type");
     ast_error_frame(&frame, type, "function return type: %s",
-      ast_print_type(type));
+      ast_print_type(type, opt->strtab));
     ast_error_frame(&frame, body_type, "function body type: %s",
-      ast_print_type(body_type));
+      ast_print_type(body_type, opt->strtab));
     errorframe_append(&frame, &info);
     errorframe_report(&frame, opt->check.errors);
     ok = false;

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -16,29 +16,29 @@
 #include "../type/reify.h"
 #include "ponyassert.h"
 
-static bool is_numeric_primitive(const char* name)
+static bool is_numeric_primitive(const char* name, pass_opt_t* opt)
 {
-  if(name == stringtab("U8") ||
-     name == stringtab("I8") ||
-     name == stringtab("U16") ||
-     name == stringtab("I16") ||
-     name == stringtab("U32") ||
-     name == stringtab("I32") ||
-     name == stringtab("U64") ||
-     name == stringtab("I64") ||
-     name == stringtab("U128") ||
-     name == stringtab("I128") ||
-     name == stringtab("ULong") ||
-     name == stringtab("ILong") ||
-     name == stringtab("USize") ||
-     name == stringtab("ISize") ||
-     name == stringtab("F32") ||
-     name == stringtab("F64"))
+  if(name == stringtab(opt->strtab, "U8") ||
+     name == stringtab(opt->strtab, "I8") ||
+     name == stringtab(opt->strtab, "U16") ||
+     name == stringtab(opt->strtab, "I16") ||
+     name == stringtab(opt->strtab, "U32") ||
+     name == stringtab(opt->strtab, "I32") ||
+     name == stringtab(opt->strtab, "U64") ||
+     name == stringtab(opt->strtab, "I64") ||
+     name == stringtab(opt->strtab, "U128") ||
+     name == stringtab(opt->strtab, "I128") ||
+     name == stringtab(opt->strtab, "ULong") ||
+     name == stringtab(opt->strtab, "ILong") ||
+     name == stringtab(opt->strtab, "USize") ||
+     name == stringtab(opt->strtab, "ISize") ||
+     name == stringtab(opt->strtab, "F32") ||
+     name == stringtab(opt->strtab, "F64"))
     return true;
   return false;
 }
 
-bool is_result_needed(ast_t* ast)
+bool is_result_needed(ast_t* ast, pass_opt_t* opt)
 {
   ast_t* parent = ast_parent(ast);
 
@@ -49,7 +49,7 @@ bool is_result_needed(ast_t* ast)
       if(ast_sibling(ast) != NULL)
         return false;
 
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_IF:
     case TK_IFDEF:
@@ -59,28 +59,28 @@ bool is_result_needed(ast_t* ast)
       if(ast_child(parent) == ast)
         return true;
 
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_IFTYPE:
       // Sub/supertype not needed, body needed only if parent needed.
       if((ast_child(parent) == ast) || (ast_childidx(parent, 1) == ast))
         return false;
 
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_REPEAT:
       // Cond needed, body/else needed only if parent needed.
       if(ast_childidx(parent, 1) == ast)
         return true;
 
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_CASE:
       // Pattern, guard needed, body needed only if parent needed
       if(ast_childidx(parent, 2) != ast)
         return true;
 
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_CASES:
     case TK_IFTYPE_SET:
@@ -89,7 +89,7 @@ bool is_result_needed(ast_t* ast)
     case TK_RECOVER:
     case TK_DISPOSING_BLOCK:
       // Only if parent needed.
-      return is_result_needed(parent);
+      return is_result_needed(parent, opt);
 
     case TK_NEW:
     {
@@ -98,8 +98,8 @@ bool is_result_needed(ast_t* ast)
       pony_assert(ast_id(type) == TK_NOMINAL);
       const char* pkg_name = ast_name(ast_child(type));
       const char* type_name = ast_name(ast_childidx(type, 1));
-      if(pkg_name == stringtab("$0")) // Builtin package.
-        return is_numeric_primitive(type_name);
+      if(pkg_name == stringtab(opt->strtab, "$0")) // Builtin package.
+        return is_numeric_primitive(type_name, opt);
       return false;
     }
 
@@ -112,7 +112,7 @@ bool is_result_needed(ast_t* ast)
       // Result of the receiver expression is needed if the chain result is
       // needed
       if(ast_childidx(parent, 0) == ast)
-        return is_result_needed(parent);
+        return is_result_needed(parent, opt);
 
       // Result of a chained method isn't needed.
       return false;
@@ -341,7 +341,7 @@ ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered)
       if(ast_id(funtype) != TK_FUNTYPE)
       {
         deferred_reification_t* fun = lookup(opt, receiver, funtype,
-          stringtab("apply"));
+          stringtab(opt->strtab, "apply"));
 
         if(fun == NULL)
           return NULL;

--- a/src/libponyc/pass/expr.h
+++ b/src/libponyc/pass/expr.h
@@ -7,7 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
-bool is_result_needed(ast_t* ast);
+bool is_result_needed(ast_t* ast, pass_opt_t* opt);
 
 bool is_method_result(typecheck_t* t, ast_t* ast);
 

--- a/src/libponyc/pass/finalisers.c
+++ b/src/libponyc/pass/finalisers.c
@@ -256,7 +256,7 @@ static bool package_finalisers(pass_opt_t* opt, ast_t* package,
 bool pass_finalisers(ast_t* program, pass_opt_t* options)
 {
   ast_t* package = ast_child(program);
-  const char* final = stringtab("_final");
+  const char* final = stringtab(options->strtab, "_final");
   bool ok = true;
 
   while(package != NULL)

--- a/src/libponyc/pass/import.c
+++ b/src/libponyc/pass/import.c
@@ -45,10 +45,11 @@ static bool import_use(pass_opt_t* opt, ast_t* ast)
       (strcmp(sym->name, "Main") == 0))
       continue;
 
-    ast_t* existing = symtab_find_case(pkg_symtab, sym->name, NULL);
+    ast_t* existing = symtab_find_case(pkg_symtab, sym->name, NULL,
+      opt->strtab);
 
     if(existing == NULL)
-      existing = symtab_find_case(mod_symtab, sym->name, NULL);
+      existing = symtab_find_case(mod_symtab, sym->name, NULL, opt->strtab);
 
     if(existing != NULL)
     {
@@ -79,7 +80,7 @@ static bool import_use(pass_opt_t* opt, ast_t* ast)
     else
     {
       // OK to add symbol.
-      symtab_add(mod_symtab, sym->name, sym->def, sym->status);
+      symtab_add(mod_symtab, sym->name, sym->def, sym->status, opt->strtab);
     }
 
   }

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -125,7 +125,7 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
 
   // We keep the actual package id for printing out in errors, etc.
   ast_append(ast, package);
-  ast_replace(&package, package_id(def));
+  ast_replace(&package, package_id(def, opt));
 
   // Store our definition for later use.
   ast_setdata(ast, def);

--- a/src/libponyc/pass/pass.c
+++ b/src/libponyc/pass/pass.c
@@ -101,9 +101,11 @@ void pass_opt_init(pass_opt_t* options)
   memset(options, 0, sizeof(pass_opt_t));
   options->limit = PASS_ALL;
   options->verbosity = VERBOSITY_INFO;
+  // The interned-string table must exist before anything that interns into it.
+  options->strtab = stringtab_new();
   options->check.errors = errors_alloc();
   options->ast_print_width = 80;
-  options->user_flags = userflags_create();
+  options->user_flags = userflags_create(options->strtab);
   frame_push(&options->check, NULL);
 }
 
@@ -139,6 +141,12 @@ void pass_opt_done(pass_opt_t* options)
       options->check.stats.stack_alloc
       );
   }
+
+  // Free the interned-string table last: every interned pointer handed out
+  // during this compilation (including those inside the AST) dangles after
+  // this, so nothing that holds one may be used past here.
+  stringtab_free(options->strtab);
+  options->strtab = NULL;
 }
 
 
@@ -192,7 +200,7 @@ static bool visit_pass(ast_t** astp, pass_opt_t* options, pass_id last_pass,
 
 bool module_passes(ast_t* package, pass_opt_t* options, source_t* source)
 {
-  if(!pass_parse(package, source, options->check.errors,
+  if(!pass_parse(package, source, options->check.errors, options->strtab,
     options->allow_test_symbols, options->parse_trace))
     return false;
 

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -312,6 +312,14 @@ typedef struct pass_opt_t
   userflags_t* user_flags;
 
   void* data; // User-defined data for unit test callbacks.
+
+  // Interned-string table for this compilation. Owns every interned string
+  // produced while this pass_opt is live (lexer identifiers, scope names,
+  // package paths, generated names, ...). Created in pass_opt_init and freed in
+  // pass_opt_done, so it must outlive any AST or symtab built under this opt.
+  // Appended last to keep the Pony-side _PassOpt mirror's existing field offsets
+  // (tools/.../pony_compiler/pass.pony).
+  strtable_t* strtab;
 } pass_opt_t;
 
 /** Limit processing to the specified pass. All passes up to and including the

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -141,7 +141,7 @@ static const char* generate_multi_dot_name(pass_opt_t *opt, ast_t* ast, ast_t** 
     default:
     {
       if (def == NULL)
-        return stringtab("");
+        return stringtab(opt->strtab, "");
       else if (in_consume_ctx) {
         pony_assert(has_consume_error);
 
@@ -153,7 +153,7 @@ static const char* generate_multi_dot_name(pass_opt_t *opt, ast_t* ast, ast_t** 
                   " single lowercase identifier, with no dots) or a field"
                   " of this (this followed by a dot and a single lowercase"
                   " identifier).");
-         return stringtab("");
+         return stringtab(opt->strtab, "");
       }
 
       pony_assert(0);
@@ -164,7 +164,7 @@ static const char* generate_multi_dot_name(pass_opt_t *opt, ast_t* ast, ast_t** 
   {
     *def_found = def;
     if(def == NULL)
-      return stringtab("");
+      return stringtab(opt->strtab, "");
   }
 
   // for the \0 at the end
@@ -193,7 +193,7 @@ static const char* generate_multi_dot_name(pass_opt_t *opt, ast_t* ast, ast_t** 
   pony_assert((offset + 1) == len);
   buf[offset] = '\0';
 
-  return stringtab_consume(buf, len);
+  return stringtab_consume(opt->strtab, buf, len);
 }
 
 static bool is_matching_assign_lhs(pass_opt_t *opt, ast_t* a, ast_t* b)
@@ -233,7 +233,7 @@ static bool is_assigned_to(pass_opt_t *opt, ast_t* ast, bool check_result_needed
           return true;
 
         // The result of that assignment can't be used.
-        return !is_result_needed(parent);
+        return !is_result_needed(parent, opt);
       }
 
       case TK_SEQ:
@@ -374,7 +374,8 @@ static bool valid_reference(pass_opt_t* opt, ast_t* ast, sym_status_t status)
   return false;
 }
 
-static const char* suggest_alt_name(ast_t* ast, const char* name)
+static const char* suggest_alt_name(ast_t* ast, const char* name,
+  pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
   pony_assert(name != NULL);
@@ -384,7 +385,7 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
   if(is_name_private(name))
   {
     // Try without leading underscore
-    const char* try_name = stringtab(name + 1);
+    const char* try_name = stringtab(opt->strtab, name + 1);
 
     if(ast_get(ast, try_name, NULL) != NULL)
       return try_name;
@@ -395,14 +396,14 @@ static const char* suggest_alt_name(ast_t* ast, const char* name)
     char* buf = (char*)ponyint_pool_alloc_size(name_len + 2);
     buf[0] = '_';
     memcpy(buf + 1, name, name_len + 1);
-    const char* try_name = stringtab_consume(buf, name_len + 2);
+    const char* try_name = stringtab_consume(opt->strtab, buf, name_len + 2);
 
     if(ast_get(ast, try_name, NULL) != NULL)
       return try_name;
   }
 
   // Try with a different case (without crossing type/value boundary)
-  ast_t* case_ast = ast_get_case(ast, name, NULL);
+  ast_t* case_ast = ast_get_case(ast, name, NULL, opt->strtab);
   if(case_ast != NULL)
   {
     ast_t* id = case_ast;
@@ -443,7 +444,7 @@ static bool refer_this(pass_opt_t* opt, ast_t* ast)
 
   // Can only use a this reference if it hasn't been consumed yet.
   sym_status_t status;
-  ast_get(ast, stringtab("this"), &status);
+  ast_get(ast, stringtab(opt->strtab, "this"), &status);
 
   if((status == SYM_CONSUMED) || (status == SYM_CONSUMED_SAME_EXPR))
   {
@@ -482,7 +483,7 @@ bool refer_reference(pass_opt_t* opt, ast_t** astp)
   // If nothing was found, we fail, but also try to suggest an alternate name.
   if(def == NULL)
   {
-    const char* alt_name = suggest_alt_name(ast, name);
+    const char* alt_name = suggest_alt_name(ast, name, opt);
 
     if(alt_name == NULL)
       ast_error(opt->check.errors, ast, "can't find declaration of '%s'", name);
@@ -645,7 +646,7 @@ static bool refer_this_dot(pass_opt_t* opt, ast_t* ast)
   // If nothing was found, we fail, but also try to suggest an alternate name.
   if(def == NULL)
   {
-    const char* alt_name = suggest_alt_name(ast, name);
+    const char* alt_name = suggest_alt_name(ast, name, opt);
 
     if(alt_name == NULL)
       ast_error(opt->check.errors, ast, "can't find declaration of '%s'", name);
@@ -764,7 +765,7 @@ bool refer_qualify(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-static void error_check_used_decl(errorframe_t* frame, ast_t* ast)
+static void error_check_used_decl(errorframe_t* frame, ast_t* ast, pass_opt_t* opt)
 {
   // Prints an info about why the lvalue is needed
   ast_t* parent = ast_parent(ast);
@@ -772,7 +773,7 @@ static void error_check_used_decl(errorframe_t* frame, ast_t* ast)
   token_id parent_id = ast_id(parent);
 
   if (parent_id == TK_VAR || parent_id == TK_LET) {
-    ast_error_frame(frame, parent, "the previous value of '%s' is used because you are trying to use the resulting value of this %s declaration", ast_print_type(ast), ast_print_type(parent));
+    ast_error_frame(frame, parent, "the previous value of '%s' is used because you are trying to use the resulting value of this %s declaration", ast_print_type(ast, opt->strtab), ast_print_type(parent, opt->strtab));
   }
 }
 
@@ -783,7 +784,7 @@ static void error_consumed_but_used(pass_opt_t* opt, ast_t* ast)
   ast_error_frame(&frame, ast,
     "the left side is consumed but its value is used");
 
-  error_check_used_decl(&frame, ast);
+  error_check_used_decl(&frame, ast, opt);
 
   errorframe_report(&frame, opt->check.errors);
 }
@@ -795,7 +796,7 @@ static void error_undefined_but_used(pass_opt_t* opt, ast_t* ast)
   ast_error_frame(&frame, ast,
     "the left side is undefined but its value is used");
 
-  error_check_used_decl(&frame, ast);
+  error_check_used_decl(&frame, ast, opt);
 
   errorframe_report(&frame, opt->check.errors);
 }
@@ -1069,7 +1070,7 @@ static bool refer_assign(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast_id(ast) == TK_ASSIGN);
   AST_GET_CHILDREN(ast, left, right);
 
-  switch(is_lvalue(opt, left, is_result_needed(ast)))
+  switch(is_lvalue(opt, left, is_result_needed(ast, opt)))
   {
     case NOT_LVALUE:
       if(ast_id(left) == TK_DONTCAREREF)
@@ -1190,7 +1191,7 @@ static bool refer_consume(pass_opt_t* opt, ast_t* ast)
 
     case TK_THIS:
     {
-      name = stringtab("this");
+      name = stringtab(opt->strtab, "this");
       break;
     }
 

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -58,10 +58,10 @@ static bool set_scope(pass_opt_t* opt, ast_t* scope, ast_t* name, ast_t* value,
       return false;
   }
 
-  if(!ast_set(scope, s, value, status, allow_shadowing))
+  if(!ast_set(scope, s, value, status, allow_shadowing, opt->strtab))
   {
     ast_t* prev = ast_get(scope, s, NULL);
-    ast_t* prev_nocase = ast_get_case(scope, s, NULL);
+    ast_t* prev_nocase = ast_get_case(scope, s, NULL, opt->strtab);
 
     ast_error(opt->check.errors, name, "can't reuse name '%s'", s);
     ast_error_continue(opt->check.errors, prev_nocase,
@@ -245,7 +245,7 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
         ast_error(opt->check.errors, subtype, "iftype subtype is a tuple but "
           "supertype isn't");
         ast_error_continue(opt->check.errors, supertype, "Supertype is %s",
-          ast_print_type(supertype));
+          ast_print_type(supertype, opt->strtab));
         ast_free_unattached(typeparams);
         return AST_ERROR;
       }

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -17,7 +17,7 @@
 #include <string.h>
 
 
-static ast_t* make_runtime_override_defaults(ast_t* ast)
+static ast_t* make_runtime_override_defaults(ast_t* ast, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
 
@@ -39,7 +39,7 @@ static ast_t* make_runtime_override_defaults(ast_t* ast)
   return runtime_override_defaults;
 }
 
-static ast_t* make_create(ast_t* ast)
+static ast_t* make_create(ast_t* ast, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
 
@@ -72,9 +72,9 @@ static ast_t* make_create(ast_t* ast)
 }
 
 
-bool has_member(ast_t* members, const char* name)
+bool has_member(ast_t* members, const char* name, pass_opt_t* opt)
 {
-  name = stringtab(name);
+  name = stringtab(opt->strtab, name);
   ast_t* member = ast_child(members);
 
   while(member != NULL)
@@ -104,27 +104,28 @@ bool has_member(ast_t* members, const char* name)
 }
 
 
-static void add_default_runtime_override_defaults_method(ast_t* ast)
+static void add_default_runtime_override_defaults_method(ast_t* ast,
+  pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
   ast_t* members = ast_childidx(ast, 4);
 
   // If have no @runtime_override_defaults method, add one.
-  if(has_member(members, "runtime_override_defaults"))
+  if(has_member(members, "runtime_override_defaults", opt))
     return;
 
-  ast_append(members, make_runtime_override_defaults(ast));
+  ast_append(members, make_runtime_override_defaults(ast, opt));
 }
 
 
-static void add_default_constructor(ast_t* ast)
+static void add_default_constructor(ast_t* ast, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
   ast_t* members = ast_childidx(ast, 4);
 
   // If we have no constructors and no "create" member, add a "create"
   // constructor.
-  if(has_member(members, "create"))
+  if(has_member(members, "create", opt))
     return;
 
   ast_t* member = ast_child(members);
@@ -142,7 +143,7 @@ static void add_default_constructor(ast_t* ast)
     member = ast_sibling(member);
   }
 
-  ast_append(members, make_create(ast));
+  ast_append(members, make_create(ast, opt));
 }
 
 
@@ -160,7 +161,7 @@ static ast_result_t sugar_module(pass_opt_t* opt, ast_t* ast)
     BUILD(builtin, ast,
       NODE(TK_USE,
       NONE
-      STRING(stringtab("builtin"))
+      STRING(stringtab(opt->strtab, "builtin"))
       NONE));
 
     ast_add(ast, builtin);
@@ -213,15 +214,13 @@ static void sugar_docstring(ast_t* ast)
 static ast_result_t sugar_entity(pass_opt_t* opt, ast_t* ast, bool add_create,
   token_id def_def_cap)
 {
-  (void)opt;
-
   AST_GET_CHILDREN(ast, id, typeparams, defcap, traits, members);
 
-  if(ast_name(id) == stringtab("Main"))
-    add_default_runtime_override_defaults_method(ast);
+  if(ast_name(id) == stringtab(opt->strtab, "Main"))
+    add_default_runtime_override_defaults_method(ast, opt);
 
   if(add_create)
-    add_default_constructor(ast);
+    add_default_constructor(ast, opt);
 
   if(ast_id(defcap) == TK_NONE)
     ast_setid(defcap, def_def_cap);
@@ -407,7 +406,7 @@ static ast_result_t sugar_be(pass_opt_t* opt, ast_t* ast)
   if(ast_id(result) == TK_NONE)
   {
     // Return type is None.
-    ast_t* type = type_sugar(ast, NULL, "None");
+    ast_t* type = type_sugar(ast, NULL, "None", opt);
     ast_replace(&result, type);
   }
 
@@ -416,7 +415,7 @@ static ast_result_t sugar_be(pass_opt_t* opt, ast_t* ast)
 }
 
 
-void fun_defaults(ast_t* ast)
+void fun_defaults(ast_t* ast, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
   AST_GET_CHILDREN(ast, cap, id, typeparams, params, result, can_error, body,
@@ -429,7 +428,7 @@ void fun_defaults(ast_t* ast)
   // If the return value is not specified, set it to None.
   if(ast_id(result) == TK_NONE)
   {
-    ast_t* type = type_sugar(ast, NULL, "None");
+    ast_t* type = type_sugar(ast, NULL, "None", opt);
     ast_replace(&result, type);
   }
 
@@ -450,14 +449,14 @@ void fun_defaults(ast_t* ast)
 
 static ast_result_t sugar_fun(pass_opt_t* opt, ast_t* ast)
 {
-  fun_defaults(ast);
+  fun_defaults(ast, opt);
   sugar_docstring(ast);
   return check_method(opt, ast);
 }
 
 
 // If the given tree is a TK_NONE expand it to a source None
-static void expand_none(ast_t* ast, bool is_scope)
+static void expand_none(ast_t* ast, bool is_scope, pass_opt_t* opt)
 {
   if(ast_id(ast) != TK_NONE)
     return;
@@ -480,22 +479,22 @@ static ast_result_t sugar_return(pass_opt_t* opt, ast_t* ast)
     pony_assert(ast_id(return_value) == TK_NONE);
     ast_setid(return_value, TK_THIS);
   } else {
-    expand_none(return_value, false);
+    expand_none(return_value, false, opt);
   }
 
   return AST_OK;
 }
 
 
-static ast_result_t sugar_else(ast_t* ast, size_t index)
+static ast_result_t sugar_else(ast_t* ast, size_t index, pass_opt_t* opt)
 {
   ast_t* else_clause = ast_childidx(ast, index);
-  expand_none(else_clause, true);
+  expand_none(else_clause, true, opt);
   return AST_OK;
 }
 
 
-static ast_result_t sugar_try(ast_t* ast)
+static ast_result_t sugar_try(ast_t* ast, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(ast, ignore, else_clause, then_clause);
 
@@ -503,8 +502,8 @@ static ast_result_t sugar_try(ast_t* ast)
     // Then without else means we don't require a throwable in the try block
     ast_setid(ast, TK_TRY_NO_CHECK);
 
-  expand_none(else_clause, true);
-  expand_none(then_clause, true);
+  expand_none(else_clause, true, opt);
+  expand_none(then_clause, true, opt);
 
   return AST_OK;
 }
@@ -515,8 +514,8 @@ static ast_result_t sugar_for(pass_opt_t* opt, ast_t** astp)
   AST_EXTRACT_CHILDREN(*astp, for_idseq, for_iter, for_body, for_else);
   ast_t* annotation = ast_consumeannotation(*astp);
 
-  expand_none(for_else, true);
-  const char* iter_name = package_hygienic_id(&opt->check);
+  expand_none(for_else, true, opt);
+  const char* iter_name = package_hygienic_id(&opt->check, opt);
 
   BUILD(try_next, for_iter,
     NODE(TK_TRY_NO_CHECK,
@@ -530,7 +529,7 @@ static ast_result_t sugar_for(pass_opt_t* opt, ast_t** astp)
         NODE(TK_BREAK, NONE))
       NONE));
 
-  sugar_try(try_next);
+  sugar_try(try_next, opt);
 
   REPLACE(astp,
     NODE(TK_SEQ,
@@ -624,7 +623,7 @@ static ast_result_t sugar_with(pass_opt_t* opt, ast_t** astp)
   {
     pony_assert(ast_id(p) == TK_SEQ);
     AST_GET_CHILDREN(p, idseq, init);
-    const char* init_name = package_hygienic_id(&opt->check);
+    const char* init_name = package_hygienic_id(&opt->check, opt);
 
     BUILD(assign, idseq,
       NODE(TK_ASSIGN,
@@ -744,7 +743,7 @@ static ast_result_t sugar_case(pass_opt_t* opt, ast_t* ast)
 }
 
 
-static ast_result_t sugar_update(ast_t** astp)
+static ast_result_t sugar_update(ast_t** astp, pass_opt_t* opt)
 {
   ast_t* ast = *astp;
   pony_assert(ast_id(ast) == TK_ASSIGN);
@@ -813,7 +812,8 @@ static ast_result_t sugar_as(pass_opt_t* opt, ast_t** astp)
 }
 
 
-static ast_result_t sugar_binop(ast_t** astp, const char* fn_name, const char* fn_name_partial)
+static ast_result_t sugar_binop(ast_t** astp, const char* fn_name,
+  const char* fn_name_partial, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(*astp, left, right, question);
 
@@ -849,7 +849,8 @@ static ast_result_t sugar_binop(ast_t** astp, const char* fn_name, const char* f
 }
 
 
-static ast_result_t sugar_unop(ast_t** astp, const char* fn_name)
+static ast_result_t sugar_unop(ast_t** astp, const char* fn_name,
+  pass_opt_t* opt)
 {
   AST_GET_CHILDREN(*astp, expr);
 
@@ -885,7 +886,7 @@ static ast_result_t sugar_ffi(pass_opt_t* opt, ast_t* ast)
   memcpy(new_name + 1, name, len);
   new_name[len + 1] = '\0';
 
-  ast_t* new_id = ast_from_string(id, stringtab_consume(new_name, len + 2));
+  ast_t* new_id = ast_from_string(id, stringtab_consume(opt->strtab, new_name, len + 2), opt->strtab);
   ast_replace(&id, new_id);
 
   return AST_OK;
@@ -939,7 +940,7 @@ static ast_result_t sugar_ifdef(pass_opt_t* opt, ast_t* ast)
     return AST_ERROR;
   }
 
-  return sugar_else(ast, 2);
+  return sugar_else(ast, 2, opt);
 }
 
 
@@ -995,7 +996,7 @@ static bool contains_thistype(ast_t* ast)
 }
 
 
-static void replace_thistype(ast_t* ast)
+static void replace_thistype(ast_t* ast, pass_opt_t* opt)
 {
   if(ast == NULL)
     return;
@@ -1012,7 +1013,7 @@ static void replace_thistype(ast_t* ast)
           NONE
           NONE));
     } else {
-      replace_thistype(child);
+      replace_thistype(child, opt);
     }
   }
 }
@@ -1062,15 +1063,15 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
     entity_t_params_ast = ast_childidx(entity, 1);
 
     // Replace this-> with $This-> in params and ret_type.
-    replace_thistype(params);
-    replace_thistype(ret_type);
+    replace_thistype(params, opt);
+    replace_thistype(ret_type, opt);
   }
 
-  const char* i_name = package_hygienic_id(&opt->check);
+  const char* i_name = package_hygienic_id(&opt->check, opt);
 
   ast_t* interface_t_params;
   ast_t* t_args;
-  collect_type_params(ast, NULL, &t_args);
+  collect_type_params(ast, NULL, &t_args, opt);
 
   if(has_thistype)
   {
@@ -1123,7 +1124,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
 
   // Fetch the interface type parameters after we replace the ast, so that if
   // we are an interface type parameter, we get ourselves as the constraint.
-  collect_type_params(ast, &interface_t_params, NULL);
+  collect_type_params(ast, &interface_t_params, NULL, opt);
 
   if(has_thistype)
   {
@@ -1170,7 +1171,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   if(ast_id(apply_cap) == TK_AT)
     printbuf(buf, "@{(");
   else if(ast_id(apply_cap) != TK_NONE)
-    printbuf(buf, "{%s(", ast_print_type(apply_cap));
+    printbuf(buf, "{%s(", ast_print_type(apply_cap, opt->strtab));
   else
     printbuf(buf, "{(");
 
@@ -1181,7 +1182,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
     if(p_no > 1)
       printbuf(buf, ", ");
 
-    printbuf(buf, "%s", ast_print_type(p));
+    printbuf(buf, "%s", ast_print_type(p, opt->strtab));
 
     char name[12];
     snprintf(name, sizeof(name), "p%d", p_no);
@@ -1198,7 +1199,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   printbuf(buf, ")");
 
   if(ast_id(ret_type) != TK_NONE)
-    printbuf(buf, ": %s", ast_print_type(ret_type));
+    printbuf(buf, ": %s", ast_print_type(ret_type, opt->strtab));
 
   if(ast_id(error) != TK_NONE)
     printbuf(buf, " ?");
@@ -1211,7 +1212,7 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
     fn_name = ast_name(apply_name);
 
   // Attach the nice name to the original lambda.
-  ast_setdata(ast_childidx(ast, 1), (void*)stringtab(buf->m));
+  ast_setdata(ast_childidx(ast, 1), (void*)stringtab(opt->strtab, buf->m));
 
   // Create a new anonymous type.
   BUILD(def, ast,
@@ -1278,7 +1279,7 @@ static ast_result_t sugar_barelambda(pass_opt_t* opt, ast_t* ast)
 }
 
 
-ast_t* expand_location(ast_t* location)
+ast_t* expand_location(ast_t* location, pass_opt_t* opt)
 {
   pony_assert(location != NULL);
 
@@ -1366,7 +1367,7 @@ static ast_result_t sugar_location(pass_opt_t* opt, ast_t** astp)
     // Location is a default argument, do not expand yet.
     return AST_OK;
 
-  ast_t* location = expand_location(ast);
+  ast_t* location = expand_location(ast, opt);
   ast_replace(astp, location);
 
   // Sugar the expanded object.
@@ -1379,7 +1380,7 @@ static ast_result_t sugar_location(pass_opt_t* opt, ast_t** astp)
 
 // If the given AST is a desugared .add() call with a single TK_STRING
 // positional argument, return that argument node. Otherwise return NULL.
-static ast_t* get_add_string_arg(ast_t* call)
+static ast_t* get_add_string_arg(ast_t* call, pass_opt_t* opt)
 {
   pony_assert(ast_id(call) == TK_CALL);
 
@@ -1392,7 +1393,8 @@ static ast_t* get_add_string_arg(ast_t* call)
     return NULL;
 
   const char* name = ast_name(method);
-  if((name != stringtab("add")) && (name != stringtab("add_partial")))
+  if((name != stringtab(opt->strtab, "add")) &&
+    (name != stringtab(opt->strtab, "add_partial")))
     return NULL;
 
   ast_t* pos_args = ast_childidx(call, 1);
@@ -1413,7 +1415,7 @@ static ast_t* get_add_string_arg(ast_t* call)
 }
 
 
-static bool fold_string_concat(ast_t** astp)
+static bool fold_string_concat(ast_t** astp, pass_opt_t* opt)
 {
   AST_GET_CHILDREN(*astp, left, right, question);
 
@@ -1431,11 +1433,11 @@ static bool fold_string_concat(ast_t** astp)
     memcpy(buf + left_len, right_str, right_len);
     buf[total_len] = '\0';
 
-    const char* interned = stringtab_len(buf, total_len);
+    const char* interned = stringtab_len(opt->strtab, buf, total_len);
     ponyint_pool_free_size(total_len + 1, buf);
 
     ast_t* result = ast_from(*astp, TK_STRING);
-    ast_set_name_len(result, interned, total_len);
+    ast_set_name_len(result, interned, total_len, opt->strtab);
     ast_replace(astp, result);
     return true;
   }
@@ -1445,7 +1447,7 @@ static bool fold_string_concat(ast_t** astp)
   // x + "a" + "b" becoming x.add("ab") instead of x.add("a").add("b").
   if((ast_id(right) == TK_STRING) && (ast_id(left) == TK_CALL))
   {
-    ast_t* call_arg = get_add_string_arg(left);
+    ast_t* call_arg = get_add_string_arg(left, opt);
     if(call_arg == NULL)
       return false;
 
@@ -1460,11 +1462,11 @@ static bool fold_string_concat(ast_t** astp)
     memcpy(buf + call_len, right_str, right_len);
     buf[total_len] = '\0';
 
-    const char* interned = stringtab_len(buf, total_len);
+    const char* interned = stringtab_len(opt->strtab, buf, total_len);
     ponyint_pool_free_size(total_len + 1, buf);
 
     ast_t* new_arg = ast_from(call_arg, TK_STRING);
-    ast_set_name_len(new_arg, interned, total_len);
+    ast_set_name_len(new_arg, interned, total_len, opt->strtab);
     ast_swap(call_arg, new_arg);
     ast_free(call_arg);
     ast_replace(astp, left);
@@ -1496,48 +1498,48 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
     case TK_RETURN:              return sugar_return(options, ast);
     case TK_IF:
     case TK_WHILE:
-    case TK_REPEAT:              return sugar_else(ast, 2);
-    case TK_IFTYPE_SET:          return sugar_else(ast, 1);
-    case TK_TRY:                 return sugar_try(ast);
+    case TK_REPEAT:              return sugar_else(ast, 2, options);
+    case TK_IFTYPE_SET:          return sugar_else(ast, 1, options);
+    case TK_TRY:                 return sugar_try(ast, options);
     case TK_FOR:                 return sugar_for(options, astp);
     case TK_WITH:                return sugar_with(options, astp);
     case TK_CASE:                return sugar_case(options, ast);
-    case TK_ASSIGN:              return sugar_update(astp);
+    case TK_ASSIGN:              return sugar_update(astp, options);
     case TK_AS:                  return sugar_as(options, astp);
     // TK_PLUS handled in pass_sugar_post for compile-time string folding
-    case TK_MINUS:               return sugar_binop(astp, "sub", "sub_partial");
-    case TK_MULTIPLY:            return sugar_binop(astp, "mul", "mul_partial");
-    case TK_DIVIDE:              return sugar_binop(astp, "div", "div_partial");
-    case TK_REM:                 return sugar_binop(astp, "rem", "rem_partial");
-    case TK_MOD:                 return sugar_binop(astp, "mod", "mod_partial");
-    case TK_PLUS_TILDE:          return sugar_binop(astp, "add_unsafe", NULL);
-    case TK_MINUS_TILDE:         return sugar_binop(astp, "sub_unsafe", NULL);
-    case TK_MULTIPLY_TILDE:      return sugar_binop(astp, "mul_unsafe", NULL);
-    case TK_DIVIDE_TILDE:        return sugar_binop(astp, "div_unsafe", NULL);
-    case TK_REM_TILDE:           return sugar_binop(astp, "rem_unsafe", NULL);
-    case TK_MOD_TILDE:           return sugar_binop(astp, "mod_unsafe", NULL);
-    case TK_LSHIFT:              return sugar_binop(astp, "shl", NULL);
-    case TK_RSHIFT:              return sugar_binop(astp, "shr", NULL);
-    case TK_LSHIFT_TILDE:        return sugar_binop(astp, "shl_unsafe", NULL);
-    case TK_RSHIFT_TILDE:        return sugar_binop(astp, "shr_unsafe", NULL);
-    case TK_AND:                 return sugar_binop(astp, "op_and", NULL);
-    case TK_OR:                  return sugar_binop(astp, "op_or", NULL);
-    case TK_XOR:                 return sugar_binop(astp, "op_xor", NULL);
-    case TK_EQ:                  return sugar_binop(astp, "eq", NULL);
-    case TK_NE:                  return sugar_binop(astp, "ne", NULL);
-    case TK_LT:                  return sugar_binop(astp, "lt", NULL);
-    case TK_LE:                  return sugar_binop(astp, "le", NULL);
-    case TK_GE:                  return sugar_binop(astp, "ge", NULL);
-    case TK_GT:                  return sugar_binop(astp, "gt", NULL);
-    case TK_EQ_TILDE:            return sugar_binop(astp, "eq_unsafe", NULL);
-    case TK_NE_TILDE:            return sugar_binop(astp, "ne_unsafe", NULL);
-    case TK_LT_TILDE:            return sugar_binop(astp, "lt_unsafe", NULL);
-    case TK_LE_TILDE:            return sugar_binop(astp, "le_unsafe", NULL);
-    case TK_GE_TILDE:            return sugar_binop(astp, "ge_unsafe", NULL);
-    case TK_GT_TILDE:            return sugar_binop(astp, "gt_unsafe", NULL);
-    case TK_UNARY_MINUS:         return sugar_unop(astp, "neg");
-    case TK_UNARY_MINUS_TILDE:   return sugar_unop(astp, "neg_unsafe");
-    case TK_NOT:                 return sugar_unop(astp, "op_not");
+    case TK_MINUS:               return sugar_binop(astp, "sub", "sub_partial", options);
+    case TK_MULTIPLY:            return sugar_binop(astp, "mul", "mul_partial", options);
+    case TK_DIVIDE:              return sugar_binop(astp, "div", "div_partial", options);
+    case TK_REM:                 return sugar_binop(astp, "rem", "rem_partial", options);
+    case TK_MOD:                 return sugar_binop(astp, "mod", "mod_partial", options);
+    case TK_PLUS_TILDE:          return sugar_binop(astp, "add_unsafe", NULL, options);
+    case TK_MINUS_TILDE:         return sugar_binop(astp, "sub_unsafe", NULL, options);
+    case TK_MULTIPLY_TILDE:      return sugar_binop(astp, "mul_unsafe", NULL, options);
+    case TK_DIVIDE_TILDE:        return sugar_binop(astp, "div_unsafe", NULL, options);
+    case TK_REM_TILDE:           return sugar_binop(astp, "rem_unsafe", NULL, options);
+    case TK_MOD_TILDE:           return sugar_binop(astp, "mod_unsafe", NULL, options);
+    case TK_LSHIFT:              return sugar_binop(astp, "shl", NULL, options);
+    case TK_RSHIFT:              return sugar_binop(astp, "shr", NULL, options);
+    case TK_LSHIFT_TILDE:        return sugar_binop(astp, "shl_unsafe", NULL, options);
+    case TK_RSHIFT_TILDE:        return sugar_binop(astp, "shr_unsafe", NULL, options);
+    case TK_AND:                 return sugar_binop(astp, "op_and", NULL, options);
+    case TK_OR:                  return sugar_binop(astp, "op_or", NULL, options);
+    case TK_XOR:                 return sugar_binop(astp, "op_xor", NULL, options);
+    case TK_EQ:                  return sugar_binop(astp, "eq", NULL, options);
+    case TK_NE:                  return sugar_binop(astp, "ne", NULL, options);
+    case TK_LT:                  return sugar_binop(astp, "lt", NULL, options);
+    case TK_LE:                  return sugar_binop(astp, "le", NULL, options);
+    case TK_GE:                  return sugar_binop(astp, "ge", NULL, options);
+    case TK_GT:                  return sugar_binop(astp, "gt", NULL, options);
+    case TK_EQ_TILDE:            return sugar_binop(astp, "eq_unsafe", NULL, options);
+    case TK_NE_TILDE:            return sugar_binop(astp, "ne_unsafe", NULL, options);
+    case TK_LT_TILDE:            return sugar_binop(astp, "lt_unsafe", NULL, options);
+    case TK_LE_TILDE:            return sugar_binop(astp, "le_unsafe", NULL, options);
+    case TK_GE_TILDE:            return sugar_binop(astp, "ge_unsafe", NULL, options);
+    case TK_GT_TILDE:            return sugar_binop(astp, "gt_unsafe", NULL, options);
+    case TK_UNARY_MINUS:         return sugar_unop(astp, "neg", options);
+    case TK_UNARY_MINUS_TILDE:   return sugar_unop(astp, "neg_unsafe", options);
+    case TK_NOT:                 return sugar_unop(astp, "op_not", options);
     case TK_FFIDECL:
     case TK_FFICALL:             return sugar_ffi(options, ast);
     case TK_IFDEF:               return sugar_ifdef(options, ast);
@@ -1554,13 +1556,11 @@ ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options)
 
 ast_result_t pass_sugar_post(ast_t** astp, pass_opt_t* options)
 {
-  (void)options;
-
   switch(ast_id(*astp))
   {
     case TK_PLUS:
-      if(!fold_string_concat(astp))
-        return sugar_binop(astp, "add", "add_partial");
+      if(!fold_string_concat(astp, options))
+        return sugar_binop(astp, "add", "add_partial", options);
       return AST_OK;
 
     default:

--- a/src/libponyc/pass/sugar.h
+++ b/src/libponyc/pass/sugar.h
@@ -8,15 +8,15 @@
 PONY_EXTERN_C_BEGIN
 
 // Report whether the given member list contains a member with the given name.
-bool has_member(ast_t* members, const char* name);
+bool has_member(ast_t* members, const char* name, pass_opt_t* opt);
 
 // Apply default receiver capability and return value, if needed, for the given
 // function.
-void fun_defaults(ast_t* ast);
+void fun_defaults(ast_t* ast, pass_opt_t* opt);
 
 // Create expanded location information about the given node.
 // The resulting tree must be caught up with passes and freed by the caller.
-ast_t* expand_location(ast_t* location);
+ast_t* expand_location(ast_t* location, pass_opt_t* opt);
 
 ast_result_t pass_sugar(ast_t** astp, pass_opt_t* options);
 

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -363,7 +363,7 @@ static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
   AST_GET_CHILDREN(ast, id, typeparams, defcap, provides, members, c_api);
 
   // Check if we're called Main
-  if(ast_name(id) == stringtab("Main"))
+  if(ast_name(id) == stringtab(opt->strtab, "Main"))
   {
     if(ast_id(typeparams) != TK_NONE)
     {
@@ -404,7 +404,7 @@ static ast_result_t syntax_entity(pass_opt_t* opt, ast_t* ast,
     // Check referenced traits
     if(ast_id(provides) != TK_NONE)
     {
-      if(ast_has_annotation(ast, "nosupertype"))
+      if(ast_has_annotation(ast, "nosupertype", opt->strtab))
       {
         ast_error(opt->check.errors, provides,
           "a 'nosupertype' type cannot specify a provides list");
@@ -1173,7 +1173,7 @@ static ast_result_t syntax_lambda(pass_opt_t* opt, ast_t* ast)
     case TK_TAG:
     {
       ast_error(opt->check.errors, ret_type, "lambda return type: %s",
-        ast_print_type(ret_type));
+        ast_print_type(ret_type, opt->strtab));
       ast_error_continue(opt->check.errors, ret_type, "lambda return type "
         "cannot be capability");
       r = false;
@@ -1264,7 +1264,7 @@ static ast_result_t syntax_fun(pass_opt_t* opt, ast_t* ast)
     case TK_TAG:
     {
       ast_error(opt->check.errors, type, "function return type: %s",
-        ast_print_type(type));
+        ast_print_type(type, opt->strtab));
       ast_error_continue(opt->check.errors, type, "function return type "
         "cannot be capability");
       return AST_ERROR;

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -345,7 +345,7 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
   }
 
   // Check for clash with existing method.
-  ast_t* case_clash = ast_get_case(entity, name, NULL);
+  ast_t* case_clash = ast_get_case(entity, name, NULL, opt->strtab);
 
   if(case_clash != NULL)
   {
@@ -384,13 +384,13 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
   // Ignore docstring.
   if(ast_id(doc) == TK_STRING)
   {
-    ast_set_name(doc, "");
+    ast_set_name(doc, "", opt->strtab);
     ast_setid(doc, TK_NONE);
     ast_settype(doc, NULL);
   }
 
   ast_t* local = ast_append(ast_childidx(entity, 4), basis_method);
-  ast_set(entity, name, local, SYM_DEFINED, false);
+  ast_set(entity, name, local, SYM_DEFINED, false, opt->strtab);
   ast_t* body_donor = (ast_t*)ast_data(basis_method);
   method_t* info = attach_method_t(local);
   info->trait_ref = trait_ref;
@@ -405,7 +405,6 @@ static ast_t* add_method(ast_t* entity, ast_t* trait_ref, ast_t* basis_method,
 // Sort out symbol table for copied method body.
 static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
 {
-  (void)options;
   ast_t* ast = *astp;
 
   if(ast_has_scope(ast))
@@ -420,7 +419,8 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
     case TK_MATCH_CAPTURE:
     {
       pony_assert(ast_child(ast) != NULL);
-      ast_set(ast, ast_name(ast_child(ast)), ast, SYM_DEFINED, true);
+      ast_set(ast, ast_name(ast_child(ast)), ast, SYM_DEFINED, true,
+        options->strtab);
       break;
     }
 
@@ -428,7 +428,8 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
     case TK_VAR:
     {
       pony_assert(ast_child(ast) != NULL);
-      ast_set(ast, ast_name(ast_child(ast)), ast, SYM_UNDEFINED, true);
+      ast_set(ast, ast_name(ast_child(ast)), ast, SYM_UNDEFINED, true,
+        options->strtab);
       break;
     }
 
@@ -438,7 +439,8 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
       while(typeparam != NULL)
       {
         pony_assert(ast_child(typeparam) != NULL);
-        ast_set(ast, ast_name(ast_child(typeparam)), typeparam, SYM_DEFINED, true);
+        ast_set(ast, ast_name(ast_child(typeparam)), typeparam, SYM_DEFINED,
+          true, options->strtab);
 
         typeparam = ast_sibling(typeparam);
       }
@@ -516,10 +518,10 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
       method_name);
     ast_error_continue(opt->check.errors, trait_ref,
       "provided here, type: %s",
-      ast_print_type(method));
+      ast_print_type(method, opt->strtab));
     ast_error_continue(opt->check.errors, info->trait_ref,
       "and here, type: %s",
-      ast_print_type(existing_method));
+      ast_print_type(existing_method, opt->strtab));
 
     info->failed = true;
     return false;
@@ -791,7 +793,7 @@ static void local_types(ast_t* ast)
 
 
 // Add eq() and ne() functions to the given entity.
-static bool add_comparable(ast_t* ast, pass_opt_t* options)
+static bool add_comparable(ast_t* ast, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
 
@@ -808,7 +810,7 @@ static bool add_comparable(ast_t* ast, pass_opt_t* options)
     ast_setid(typeargs, TK_TYPEARGS);
   }
 
-  if(!has_member(members, "eq"))
+  if(!has_member(members, "eq", opt))
   {
     BUILD(eq, members,
       NODE(TK_FUN, AST_SCOPE
@@ -833,13 +835,14 @@ static bool add_comparable(ast_t* ast, pass_opt_t* options)
     // processed that type.
     ast_setdata(eq, ast);
     ast_append(members, eq);
-    ast_set(ast, stringtab("eq"), eq, SYM_DEFINED, false);
+    ast_set(ast, stringtab(opt->strtab, "eq"), eq, SYM_DEFINED, false,
+      opt->strtab);
 
-    if(!ast_passes_subtree(&eq, options, PASS_TRAITS))
+    if(!ast_passes_subtree(&eq, opt, PASS_TRAITS))
       r = false;
   }
 
-  if(!has_member(members, "ne"))
+  if(!has_member(members, "ne", opt))
   {
     BUILD(ne, members,
       NODE(TK_FUN, AST_SCOPE
@@ -864,9 +867,10 @@ static bool add_comparable(ast_t* ast, pass_opt_t* options)
     // processed that type.
     ast_setdata(ne, ast);
     ast_append(members, ne);
-    ast_set(ast, stringtab("ne"), ne, SYM_DEFINED, false);
+    ast_set(ast, stringtab(opt->strtab, "ne"), ne, SYM_DEFINED, false,
+      opt->strtab);
 
-    if(!ast_passes_subtree(&ne, options, PASS_TRAITS))
+    if(!ast_passes_subtree(&ne, opt, PASS_TRAITS))
       r = false;
   }
 

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -121,7 +121,7 @@ DEFINE_HASHMAP(consume_funs, consume_funs_t, ast_t, funref_hash,
 // being consumed for tracking its `consume`d status via the ast `symtab`. It is
 // used to ensure that no parent (e.g. `a.b.c`) of a consumed field
 // (e.g. `a.b.c.d.e`) is consumed.
-static const char* get_multi_ref_name(ast_t* ast)
+static const char* get_multi_ref_name(ast_t* ast, pass_opt_t* opt)
 {
   ast_t* def = NULL;
   size_t len = 0;
@@ -214,7 +214,7 @@ static const char* get_multi_ref_name(ast_t* ast)
   pony_assert((offset + 1) == len);
   buf[offset] = '\0';
 
-  return stringtab_consume(buf, len);
+  return stringtab_consume(opt->strtab, buf, len);
 }
 
 static ast_t* get_fun_def(pass_opt_t* opt, ast_t* ast)
@@ -361,7 +361,7 @@ static bool verify_fun_field_not_referenced(pass_opt_t* opt, ast_t* ast,
       // ensure we're in the same object type as original consume
       if((ctype_name != NULL) && (ctype_name == origin_type_name))
       {
-        const char* cname = get_multi_ref_name(cfield);
+        const char* cname = get_multi_ref_name(cfield, opt);
 
         if(strncmp(cname, consumed_field_full_name, strlen(cname)) == 0)
         {
@@ -411,7 +411,7 @@ static bool verify_consume_field_not_referenced(pass_opt_t* opt,
     ast_t* consumed_type = ast_type(ast_child(cfield));
     const char* consumed_field = ast_name(ast_sibling(ast_child(cfield)));
 
-    const char* cname = get_multi_ref_name(cfield);
+    const char* cname = get_multi_ref_name(cfield, opt);
 
     const char* origin_type_name = ast_name(ast_child(opt->check.frame->type));
 
@@ -705,7 +705,7 @@ static bool verify_not_disjoint_concrete(pass_opt_t* opt, ast_t* ast,
     ast_error(opt->check.errors, ast,
       "identity comparison between disjoint concrete types %s and %s will"
       " always be false",
-      ast_print_type(l_type), ast_print_type(r_type));
+      ast_print_type(l_type, opt->strtab), ast_print_type(r_type, opt->strtab));
     ok = false;
   }
 

--- a/src/libponyc/pkg/buildflagset.c
+++ b/src/libponyc/pkg/buildflagset.c
@@ -47,32 +47,12 @@ static const char* _endian_flags[] =
   NULL  // Terminator.
 };
 
-static bool _stringtabed = false;
-
-
-// Replace all the strings in the _{os,arch,size,endian}_flags
-// arrays with stringtab'ed versions the first time this is called.
-// This method of initialisation is obviously not at all concurrency safe, but
-// it works with unit tests trivially.
-static void stringtab_mutexgroups()
-{
-  if(_stringtabed)
-    return;
-
-  for(size_t i = 0; _os_flags[i] != NULL; i++)
-    _os_flags[i] = stringtab(_os_flags[i]);
-
-  for(size_t i = 0; _arch_flags[i] != NULL; i++)
-    _arch_flags[i] = stringtab(_arch_flags[i]);
-
-  for(size_t i = 0; _size_flags[i] != NULL; i++)
-    _size_flags[i] = stringtab(_size_flags[i]);
-
-  for(size_t i = 0; _endian_flags[i] != NULL; i++)
-    _endian_flags[i] = stringtab(_endian_flags[i]);
-
-  _stringtabed = true;
-}
+// The _{os,arch,size,endian}_flags arrays stay as raw string literals. The
+// mutually-exclusive-group checks below compare against them with strcmp rather
+// than interned-pointer identity, so there is no process-global interned cache
+// to mutate (the old approach was, per its own comment, "not at all concurrency
+// safe"). User flags stored in a buildflagset's flagtab still use interned
+// pointers supplied by the caller, all from one compilation's table.
 
 
 typedef struct flag_t
@@ -175,10 +155,8 @@ static ssize_t os_index(const char* flag)
 {
   pony_assert(flag != NULL);
 
-  stringtab_mutexgroups();
-
   for(size_t i = 0; _os_flags[i] != NULL; i++)
-    if(flag == _os_flags[i])  // Match found.
+    if(strcmp(flag, _os_flags[i]) == 0)  // Match found.
       return i;
 
   // Match not found.
@@ -192,10 +170,8 @@ static ssize_t arch_index(const char* flag)
 {
   pony_assert(flag != NULL);
 
-  stringtab_mutexgroups();
-
   for(size_t i = 0; _arch_flags[i] != NULL; i++)
-    if(flag == _arch_flags[i])  // Match found.
+    if(strcmp(flag, _arch_flags[i]) == 0)  // Match found.
       return i;
 
   // Match not found.
@@ -209,10 +185,8 @@ static ssize_t size_index(const char* flag)
 {
   pony_assert(flag != NULL);
 
-  stringtab_mutexgroups();
-
   for(size_t i = 0; _size_flags[i] != NULL; i++)
-    if(flag == _size_flags[i])  // Match found.
+    if(strcmp(flag, _size_flags[i]) == 0)  // Match found.
       return i;
 
   // Match not found.
@@ -226,10 +200,8 @@ static ssize_t endian_index(const char* flag)
 {
   pony_assert(flag != NULL);
 
-  stringtab_mutexgroups();
-
   for(size_t i = 0; _endian_flags[i] != NULL; i++)
-    if(flag == _endian_flags[i])  // Match found.
+    if(strcmp(flag, _endian_flags[i]) == 0)  // Match found.
       return i;
 
   // Match not found.
@@ -577,13 +549,18 @@ const char* buildflagset_print(buildflagset_t* set)
 // just a thin wrapper around the private flagtab_t
 typedef struct userflags_t {
   flagtab_t inner;
+  // Interned-string table for this compilation. User flag names are interned
+  // into it so the flagtab's pointer-identity comparison works; all access to a
+  // given userflags_t happens within one compilation, so one table suffices.
+  strtable_t* strtab;
 } userflags_t;
 
-userflags_t* userflags_create()
+userflags_t* userflags_create(strtable_t* strtab)
 {
   userflags_t* u = POOL_ALLOC(userflags_t);
   pony_assert(u != NULL);
   flagtab_init(&(u->inner), 4);
+  u->strtab = strtab;
   return u;
 }
 
@@ -592,7 +569,9 @@ void userflags_free(userflags_t *flags)
   if(flags != NULL)
   {
     flagtab_destroy(&flags->inner);
-    POOL_FREE(flagtab_t, flags);
+    // Must free as userflags_t, not flagtab_t: POOL_FREE derives the size class
+    // from the type, and userflags_t (flagtab_t + strtab pointer) is larger.
+    POOL_FREE(userflags_t, flags);
   }
 }
 
@@ -601,7 +580,7 @@ bool define_userflag(userflags_t* flags, const char* name)
   pony_assert(flags != NULL);
   pony_assert(name != NULL);
 
-  flag_t f1 = {stringtab(name), false};
+  flag_t f1 = {stringtab(flags->strtab, name), false};
   size_t index = HASHMAP_UNKNOWN;
   flag_t* f2 = flagtab_get(&(flags->inner), &f1, &index);
 
@@ -624,7 +603,7 @@ bool remove_userflags(userflags_t* flags, const char* flags_to_remove[])
   size_t removed = 0;
   for(const char** next = flags_to_remove; *next != NULL; next += 1)
   {
-    flag_t f1 = {stringtab(*next), false};
+    flag_t f1 = {stringtab(flags->strtab, *next), false};
     flag_t* found = flagtab_remove(&(flags->inner), &f1);
     if(found != NULL)
     {
@@ -642,7 +621,7 @@ bool is_userflag_defined(userflags_t* flags, const char* name)
   pony_assert(flags != NULL);
   pony_assert(name != NULL);
 
-  flag_t f1 = { stringtab(name), false };
+  flag_t f1 = { stringtab(flags->strtab, name), false };
   size_t index = HASHMAP_UNKNOWN;
   flag_t* f2 = flagtab_get(&(flags->inner), &f1, &index);
 

--- a/src/libponyc/pkg/buildflagset.h
+++ b/src/libponyc/pkg/buildflagset.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <platform.h>
 
+typedef struct strtable_t strtable_t;
+
 PONY_EXTERN_C_BEGIN
 
 /* A build flag set records the platform and user build flags required for some
@@ -80,7 +82,7 @@ const char* buildflagset_print(buildflagset_t* set);
 // code options with ifdef expressions.
 typedef struct userflags_t userflags_t;
 
-userflags_t* userflags_create();
+userflags_t* userflags_create(strtable_t* strtab);
 
 void userflags_free(userflags_t* flags);
 

--- a/src/libponyc/pkg/ifdef.c
+++ b/src/libponyc/pkg/ifdef.c
@@ -12,7 +12,7 @@
 
 
 // Normalise the given ifdef condition.
-static void cond_normalise(ast_t** astp)
+static void cond_normalise(ast_t** astp, pass_opt_t* opt)
 {
   pony_assert(astp != NULL);
 
@@ -28,8 +28,8 @@ static void cond_normalise(ast_t** astp)
       AST_GET_CHILDREN(ast, left, right, question);
       pony_assert(ast_id(question) == TK_NONE);
       ast_remove(question);
-      cond_normalise(&left);
-      cond_normalise(&right);
+      cond_normalise(&left, opt);
+      cond_normalise(&right, opt);
       break;
     }
 
@@ -40,8 +40,8 @@ static void cond_normalise(ast_t** astp)
       AST_GET_CHILDREN(ast, left, right, question);
       pony_assert(ast_id(question) == TK_NONE);
       ast_remove(question);
-      cond_normalise(&left);
-      cond_normalise(&right);
+      cond_normalise(&left, opt);
+      cond_normalise(&right, opt);
       break;
     }
 
@@ -50,7 +50,7 @@ static void cond_normalise(ast_t** astp)
       ast_setid(ast, TK_IFDEFNOT);
 
       AST_GET_CHILDREN(ast, child);
-      cond_normalise(&child);
+      cond_normalise(&child, opt);
       break;
     }
 
@@ -90,7 +90,7 @@ static void cond_normalise(ast_t** astp)
       ast_t* child = ast_pop(ast);
       pony_assert(child != NULL);
 
-      cond_normalise(&child);
+      cond_normalise(&child, opt);
       ast_replace(astp, child);
       break;
     }
@@ -308,7 +308,7 @@ static bool find_decl_for_config(ast_t* call, ast_t* package,
               // messages later. We stringtab it because the version we are
               // given is in a temporary buffer.
               decl_info->decl = decl;
-              decl_info->config = stringtab(buildflagset_print(config));
+              decl_info->config = stringtab(opt->strtab, buildflagset_print(config));
             }
           }
         }
@@ -415,7 +415,7 @@ bool ifdef_cond_normalise(ast_t** astp, pass_opt_t* opt)
   if(ast_id(*astp) == TK_NONE)  // No condition to normalise.
     return true;
 
-  cond_normalise(astp);
+  cond_normalise(astp, opt);
 
   // Check whether condition can ever be true.
   buildflagset_t* config = buildflagset_create();
@@ -480,12 +480,12 @@ bool ffi_get_decl(typecheck_t* t, ast_t* ast, ast_t** out_decl,
     if(!find_ffi_decl(ast, t->frame->package, t->frame->ifdef_cond, &decl, opt))
     {
       // That went wrong. Record that so we don't try again.
-      symtab_add(symtab, ffi_name, NULL, SYM_ERROR);
+      symtab_add(symtab, ffi_name, NULL, SYM_ERROR, opt->strtab);
       return false;
     }
 
     // Store declaration found for next time, including if we found nothing.
-    symtab_add(symtab, ffi_name, decl, SYM_FFIDECL);
+    symtab_add(symtab, ffi_name, decl, SYM_FFIDECL, opt->strtab);
   }
 
   *out_decl = decl;

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -126,7 +126,7 @@ static bool parse_source_file(ast_t* package, const char* file_path,
     printf("Opening %s\n", file_path);
 
   const char* error_msg = NULL;
-  source_t* source = source_open(file_path, &error_msg);
+  source_t* source = source_open(file_path, &error_msg, opt->strtab);
 
   if(source == NULL)
   {
@@ -227,7 +227,7 @@ static bool parse_files_in_dir(ast_t* package, const char* dir_path,
   {
     // Handle only files with the specified extension that don't begin with
     // a dot. This avoids including UNIX hidden files in a build.
-    const char* name = stringtab(pony_dir_info_name(d));
+    const char* name = stringtab(opt->strtab, pony_dir_info_name(d));
 
     if(name[0] == '.')
       continue;
@@ -272,7 +272,7 @@ static bool parse_files_in_dir(ast_t* package, const char* dir_path,
 // @return The resulting directory path, which should not be deleted and is
 // valid indefinitely. NULL is directory cannot be found.
 static const char* try_path(const char* base, const char* path,
-  bool* out_found_notdir)
+  bool* out_found_notdir, pass_opt_t* opt)
 {
   char composite[FILENAME_MAX];
   char file[FILENAME_MAX];
@@ -296,7 +296,7 @@ static const char* try_path(const char* base, const char* path,
     return NULL;
   }
 
-  return stringtab(file);
+  return stringtab(opt->strtab, file);
 }
 
 
@@ -325,7 +325,7 @@ static bool is_root(const char* path)
 // Try base/../pony_packages/path, and keep adding .. to look another level up
 // until we are looking in /pony_packages/path
 static const char* try_package_path(const char* base, const char* path,
-  bool* out_found_notdir)
+  bool* out_found_notdir, pass_opt_t* opt)
 {
   char path1[FILENAME_MAX];
   char path2[FILENAME_MAX];
@@ -340,7 +340,7 @@ static const char* try_package_path(const char* base, const char* path,
 
     path_cat(path1, "pony_packages", path2);
 
-    const char* result = try_path(path2, path, out_found_notdir);
+    const char* result = try_path(path2, path, out_found_notdir, opt);
 
     if(result != NULL)
       return result;
@@ -364,7 +364,7 @@ static const char* find_path(ast_t* from, const char* path,
 
   // First check for an absolute path
   if(is_path_absolute(path))
-    return try_path(NULL, path, out_found_notdir);
+    return try_path(NULL, path, out_found_notdir, opt);
 
   // Get the base directory
   const char* base;
@@ -379,7 +379,7 @@ static const char* find_path(ast_t* from, const char* path,
   }
 
   // Try a path relative to the base
-  const char* result = try_path(base, path, out_found_notdir);
+  const char* result = try_path(base, path, out_found_notdir, opt);
 
   if(result != NULL)
   {
@@ -395,7 +395,7 @@ static const char* find_path(ast_t* from, const char* path,
     // Check ../pony_packages and further up the tree
     if(base != NULL)
     {
-      result = try_package_path(base, path, out_found_notdir);
+      result = try_package_path(base, path, out_found_notdir, opt);
 
       if(result != NULL)
         return result;
@@ -407,7 +407,7 @@ static const char* find_path(ast_t* from, const char* path,
         package_t* pkg = (package_t*)ast_data(target);
         base = pkg->path;
 
-        result = try_package_path(base, path, out_found_notdir);
+        result = try_package_path(base, path, out_found_notdir, opt);
 
         if(result != NULL)
           return result;
@@ -418,7 +418,7 @@ static const char* find_path(ast_t* from, const char* path,
     for(strlist_t* p = opt->package_search_paths; p != NULL;
       p = strlist_next(p))
     {
-      result = try_path(strlist_data(p), path, out_found_notdir);
+      result = try_path(strlist_data(p), path, out_found_notdir, opt);
 
       if(result != NULL)
         return result;
@@ -431,7 +431,7 @@ static const char* find_path(ast_t* from, const char* path,
 
 // Convert the given ID to a hygenic string. The resulting string should not be
 // deleted and is valid indefinitely.
-static const char* id_to_string(const char* prefix, size_t id)
+static const char* id_to_string(const char* prefix, size_t id, pass_opt_t* opt)
 {
   if(prefix == NULL)
     prefix = "";
@@ -440,7 +440,7 @@ static const char* id_to_string(const char* prefix, size_t id)
   size_t buf_size = len + 32;
   char* buffer = (char*)ponyint_pool_alloc_size(buf_size);
   snprintf(buffer, buf_size, "%s$" __zu, prefix, id);
-  return stringtab_consume(buffer, buf_size);
+  return stringtab_consume(opt->strtab, buffer, buf_size);
 }
 
 
@@ -462,7 +462,7 @@ static bool symbol_in_use(ast_t* program, const char* symbol)
 }
 
 
-static const char* string_to_symbol(const char* string)
+static const char* string_to_symbol(const char* string, pass_opt_t* opt)
 {
   bool prefix = false;
 
@@ -499,29 +499,31 @@ static const char* string_to_symbol(const char* string)
     }
   }
 
-  return stringtab_consume(buf, buf_size);
+  return stringtab_consume(opt->strtab, buf, buf_size);
 }
 
 
-static const char* symbol_suffix(const char* symbol, size_t suffix)
+static const char* symbol_suffix(const char* symbol, size_t suffix,
+  pass_opt_t* opt)
 {
   size_t len = strlen(symbol);
   size_t buf_size = len + 32;
   char* buf = (char*)ponyint_pool_alloc_size(buf_size);
   snprintf(buf, buf_size, "%s" __zu, symbol, suffix);
 
-  return stringtab_consume(buf, buf_size);
+  return stringtab_consume(opt->strtab, buf, buf_size);
 }
 
 
-static const char* create_package_symbol(ast_t* program, const char* filename)
+static const char* create_package_symbol(ast_t* program, const char* filename,
+  pass_opt_t* opt)
 {
-  const char* symbol = string_to_symbol(filename);
+  const char* symbol = string_to_symbol(filename, opt);
   size_t suffix = 1;
 
   while(symbol_in_use(program, symbol))
   {
-    symbol = symbol_suffix(symbol, suffix);
+    symbol = symbol_suffix(symbol, suffix, opt);
     suffix++;
   }
 
@@ -539,7 +541,7 @@ ast_t* create_package(ast_t* program, const char* name,
   package_t* pkg = POOL_ALLOC(package_t);
   pkg->path = name;
   pkg->qualified_name = qualified_name;
-  pkg->id = id_to_string(NULL, pkg_id);
+  pkg->id = id_to_string(NULL, pkg_id, opt);
 
   const char* p = strrchr(pkg->path, PATH_SLASH);
 
@@ -548,10 +550,10 @@ ast_t* create_package(ast_t* program, const char* name,
   else
     p = p + 1;
 
-  pkg->filename = stringtab(p);
+  pkg->filename = stringtab(opt->strtab, p);
 
   if(pkg_id > 1)
-    pkg->symbol = create_package_symbol(program, pkg->filename);
+    pkg->symbol = create_package_symbol(program, pkg->filename, opt);
   else
     pkg->symbol = NULL;
 
@@ -565,8 +567,8 @@ ast_t* create_package(ast_t* program, const char* name,
 
   ast_scope(package);
   ast_append(program, package);
-  ast_set(program, pkg->path, package, SYM_NONE, false);
-  ast_set(program, pkg->id, package, SYM_NONE, false);
+  ast_set(program, pkg->path, package, SYM_NONE, false, opt->strtab);
+  ast_set(program, pkg->id, package, SYM_NONE, false, opt->strtab);
 
   strlist_t* safe = opt->safe_packages;
 
@@ -604,7 +606,7 @@ static bool add_path(const char* path, pass_opt_t* opt)
 
   if((err != -1) && S_ISDIR(s.st_mode))
   {
-    path = stringtab(path);
+    path = stringtab(opt->strtab, path);
     strlist_t* search = opt->package_search_paths;
 
     if(strlist_find(search, path) == NULL)
@@ -631,7 +633,7 @@ static bool add_relative_path(const char* path, const char* relpath,
 
 static bool add_safe(const char* path, pass_opt_t* opt)
 {
-  path = stringtab(path);
+  path = stringtab(opt->strtab, path);
   strlist_t* safe = opt->safe_packages;
 
   if(strlist_find(safe, path) == NULL)
@@ -863,7 +865,7 @@ bool package_add_safe(const char* paths, pass_opt_t* opt)
 void package_add_magic_src(const char* path, const char* src, pass_opt_t* opt)
 {
   magic_package_t* n = POOL_ALLOC(magic_package_t);
-  n->path = stringtab(path);
+  n->path = stringtab(opt->strtab, path);
   n->src = src;
   n->mapped_path = NULL;
   n->next = opt->magic_packages;
@@ -875,9 +877,9 @@ void package_add_magic_path(const char* path, const char* mapped_path,
   pass_opt_t* opt)
 {
   magic_package_t* n = POOL_ALLOC(magic_package_t);
-  n->path = stringtab(path);
+  n->path = stringtab(opt->strtab, path);
   n->src = NULL;
-  n->mapped_path = stringtab(mapped_path);
+  n->mapped_path = stringtab(opt->strtab, mapped_path);
   n->next = opt->magic_packages;
   opt->magic_packages = n;
 }
@@ -906,7 +908,7 @@ ast_t* program_load(const char* path, pass_opt_t* opt)
   opt->program_pass = PASS_PARSE;
 
   // Always load builtin package first, then the specified one.
-  if(package_load(program, stringtab("builtin"), opt) == NULL ||
+  if(package_load(program, stringtab(opt->strtab, "builtin"), opt) == NULL ||
     package_load(program, path, opt) == NULL)
   {
     ast_free(program);
@@ -1002,7 +1004,7 @@ ast_t* package_load(ast_t* from, const char* path, pass_opt_t* opt)
         q_name[base_name_len] = '/';
         memcpy(q_name + base_name_len + 1, package_path, package_path_len);
         q_name[len - 1] = '\0';
-        qualified_name = stringtab_consume(q_name, len);
+        qualified_name = stringtab_consume(opt->strtab, q_name, len);
       }
     }
 
@@ -1086,9 +1088,9 @@ const char* package_name(ast_t* ast)
 }
 
 
-ast_t* package_id(ast_t* ast)
+ast_t* package_id(ast_t* ast, pass_opt_t* opt)
 {
-  return ast_from_string(ast, package_name(ast));
+  return ast_from_string(ast, package_name(ast), opt->strtab);
 }
 
 
@@ -1134,13 +1136,13 @@ const char* package_symbol(ast_t* package)
 }
 
 
-const char* package_hygienic_id(typecheck_t* t)
+const char* package_hygienic_id(typecheck_t* t, pass_opt_t* opt)
 {
   pony_assert(t->frame->package != NULL);
   package_t* pkg = (package_t*)ast_data(t->frame->package);
   size_t id = pkg->next_hygienic_id++;
 
-  return id_to_string(pkg->id, id);
+  return id_to_string(pkg->id, id, opt);
 }
 
 
@@ -1152,11 +1154,12 @@ bool package_allow_ffi(typecheck_t* t)
 }
 
 
-const char* package_alias_from_id(ast_t* module, const char* id)
+const char* package_alias_from_id(ast_t* module, const char* id,
+  pass_opt_t* opt)
 {
   pony_assert(ast_id(module) == TK_MODULE);
 
-  const char* strtab_id = stringtab(id);
+  const char* strtab_id = stringtab(opt->strtab, id);
 
   ast_t* use = ast_child(module);
   while(ast_id(use) == TK_USE)

--- a/src/libponyc/pkg/package.h
+++ b/src/libponyc/pkg/package.h
@@ -111,7 +111,7 @@ const char* package_name(ast_t* ast);
  * Gets an AST ID node with a string set to the unique ID of the packaged. The
  * first package loaded will be $0, the second $1, etc.
  */
-ast_t* package_id(ast_t* ast);
+ast_t* package_id(ast_t* ast, pass_opt_t* opt);
 
 /**
  * Gets the package path.
@@ -138,7 +138,7 @@ const char* package_symbol(ast_t* package);
  * per-package basis. The first one will be $0, the second $1, etc.
  * The returned string will be a string table entry and should not be freed.
  */
-const char* package_hygienic_id(typecheck_t* t);
+const char* package_hygienic_id(typecheck_t* t, pass_opt_t* opt);
 
 /**
  * Returns true if the current package is allowed to do C FFI.
@@ -155,7 +155,7 @@ bool package_allow_ffi(typecheck_t* t);
  * `package_alias_from_id(current_module_ast, "$2")` will return the string
  * "foo".
  */
-const char* package_alias_from_id(ast_t* module, const char* id);
+const char* package_alias_from_id(ast_t* module, const char* id, pass_opt_t* opt);
 
 /**
  * Adds a package to the dependency list of another package.

--- a/src/libponyc/pkg/program.cc
+++ b/src/libponyc/pkg/program.cc
@@ -131,7 +131,7 @@ static const char* quoted_locator(pass_opt_t* opt, ast_t* use,
   quoted[len + 1] = '"';
   quoted[len + 2] = '\0';
 
-  return stringtab_consume(quoted, len + 3);
+  return stringtab_consume(opt->strtab, quoted, len + 3);
 }
 
 /// Process a "lib:" scheme use command.
@@ -284,7 +284,7 @@ const char* program_lib_args(ast_t* program)
 
 
 // Strip the surrounding quotes added by quoted_locator().
-static const char* unquote(const char* quoted)
+static const char* unquote(const char* quoted, pass_opt_t* opt)
 {
   pony_assert(quoted != NULL);
 
@@ -298,7 +298,7 @@ static const char* unquote(const char* quoted)
   memcpy(buf, quoted + 1, unquoted_len);
   buf[unquoted_len] = '\0';
 
-  return stringtab_consume(buf, unquoted_len + 1);
+  return stringtab_consume(opt->strtab, buf, unquoted_len + 1);
 }
 
 
@@ -332,14 +332,14 @@ void program_lib_build_args_embedded(ast_t* program, pass_opt_t* opt)
 
     size_t i = 0;
     for(strlist_t* p = data->libpaths; p != NULL; p = strlist_next(p))
-      data->embedded_paths[i++] = unquote(strlist_data(p));
+      data->embedded_paths[i++] = unquote(strlist_data(p), opt);
 
     for(strlist_t* p = opt->package_search_paths; p != NULL;
       p = strlist_next(p))
     {
       const char* quoted = quoted_locator(opt, NULL, strlist_data(p));
       if(quoted != NULL)
-        data->embedded_paths[i++] = unquote(quoted);
+        data->embedded_paths[i++] = unquote(quoted, opt);
     }
   }
 
@@ -357,7 +357,7 @@ void program_lib_build_args_embedded(ast_t* program, pass_opt_t* opt)
 
     size_t i = 0;
     for(strlist_t* p = data->libs; p != NULL; p = strlist_next(p))
-      data->embedded_libs[i++] = unquote(strlist_data(p));
+      data->embedded_libs[i++] = unquote(strlist_data(p), opt);
   }
 }
 

--- a/src/libponyc/pkg/use.c
+++ b/src/libponyc/pkg/use.c
@@ -69,7 +69,7 @@ static int find_handler(pass_opt_t* opt, ast_t* uri, const char** out_locator)
   if(colon == NULL)
   {
     // No scheme specified, use default
-    *out_locator = stringtab(text);
+    *out_locator = stringtab(opt->strtab, text);
     return 0;
   }
 
@@ -85,7 +85,7 @@ static int find_handler(pass_opt_t* opt, ast_t* uri, const char** out_locator)
         break;
 
       // Matching scheme found
-      *out_locator = stringtab(colon + 1);
+      *out_locator = stringtab(opt->strtab, colon + 1);
       return i;
     }
   }

--- a/src/libponyc/plugin/plugin.c
+++ b/src/libponyc/plugin/plugin.c
@@ -80,7 +80,7 @@ static bool load_plugin(const char* path, pass_opt_t* opt)
 
   plugin_t* p = POOL_ALLOC(plugin_t);
   p->handle = handle;
-  p->path = stringtab(path);
+  p->path = stringtab(opt->strtab, path);
   p->user_data = NULL;
 
   p->init_fn = (plugin_init_fn)PLUGIN_SYMBOL(handle, "pony_plugin_init");

--- a/src/libponyc/ponyc.c
+++ b/src/libponyc/ponyc.c
@@ -23,5 +23,7 @@ void ponyc_shutdown(pass_opt_t* options)
   package_done(options);
   codegen_pass_cleanup(options);
   codegen_llvm_shutdown();
-  stringtab_done();
+  // The interned-string table is freed by pass_opt_done, which the caller runs
+  // after this; it must stay live through the cleanup above (error printing,
+  // package teardown) since those still read interned strings.
 }

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -279,7 +279,7 @@ static reach_method_t* reach_rmethod(reach_method_name_t* n, const char* name)
 }
 
 static reach_method_name_t* add_method_name(reach_type_t* t, const char* name,
-  bool internal)
+  bool internal, pass_opt_t* opt)
 {
   reach_method_name_t* n = reach_method_name(t, name);
 
@@ -297,7 +297,7 @@ static reach_method_name_t* add_method_name(reach_type_t* t, const char* name,
       n->cap = TK_BOX;
       n->internal = true;
     } else {
-      deferred_reification_t* fun = lookup(NULL, NULL, t->ast, name);
+      deferred_reification_t* fun = lookup(opt, NULL, t->ast, name);
       ast_t* fun_ast = fun->ast;
       n->id = ast_id(fun_ast);
       n->cap = ast_id(ast_child(fun_ast));
@@ -444,7 +444,7 @@ static void trace_kind_append(printbuf_t* buf, ast_t* type)
   }
 }
 
-static const char* make_mangled_name(reach_method_t* m)
+static const char* make_mangled_name(reach_method_t* m, pass_opt_t* opt)
 {
   // Generate the mangled name.
   // cap_name[_Arg1_Arg2]_[<trace_kind>]<args>_result
@@ -527,18 +527,18 @@ static const char* make_mangled_name(reach_method_t* m)
   if(is_partial)
     printbuf(buf, "_p");
 
-  const char* name = stringtab(buf->m);
+  const char* name = stringtab(opt->strtab, buf->m);
   printbuf_free(buf);
   return name;
 }
 
-static const char* make_full_name(reach_type_t* t, reach_method_t* m)
+static const char* make_full_name(reach_type_t* t, reach_method_t* m, pass_opt_t* opt)
 {
   // Generate the full mangled name.
   // pkg_Type[_Arg1_Arg2]_cap_name[_Arg1_Arg2]_[<trace_kind>]<args>_result
   printbuf_t* buf = printbuf_new();
   printbuf(buf, "%s_%s", t->name, m->mangled_name);
-  const char* name = stringtab(buf->m);
+  const char* name = stringtab(opt->strtab, buf->m);
   printbuf_free(buf);
   return name;
 }
@@ -547,7 +547,7 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
   reach_method_name_t* n, reach_method_t* m, pass_opt_t* opt)
 {
   // Add the method to the type if it isn't already there.
-  reach_method_name_t* n2 = add_method_name(t, n->name, false);
+  reach_method_name_t* n2 = add_method_name(t, n->name, false, opt);
   add_rmethod(r, t, n2, m->cap, m->typeargs, opt, false);
 
   // Add this mangling to the type if it isn't already there.
@@ -562,7 +562,7 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
 
   mangled->name = m->name;
   mangled->mangled_name = m->mangled_name;
-  mangled->full_name = make_full_name(t, mangled);
+  mangled->full_name = make_full_name(t, mangled, opt);
 
   mangled->cap = m->cap;
   mangled->fun = deferred_reify_dup(m->fun);
@@ -651,7 +651,7 @@ static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
   if(!((n->id == TK_FUN) && ((n->cap == TK_BOX) || (n->cap == TK_TAG))))
     cap = n->cap;
 
-  const char* name = genname_fun(cap, n->name, typeargs);
+  const char* name = genname_fun(cap, n->name, typeargs, opt->strtab);
   reach_method_t* m = reach_rmethod(n, name);
 
   if(m != NULL)
@@ -668,7 +668,7 @@ static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
   if(!internal)
   {
     ast_t* r_ast = set_cap_and_ephemeral(t->ast, cap, TK_NONE);
-    deferred_reification_t* fun = lookup(NULL, NULL, r_ast, n->name);
+    deferred_reification_t* fun = lookup(opt, NULL, r_ast, n->name);
     pony_assert(fun != NULL);
 
     // The typeargs and thistype are in the scope of r_ast but we're going to
@@ -691,8 +691,8 @@ static reach_method_t* add_rmethod(reach_t* r, reach_type_t* t,
     set_method_types(r, m, opt);
   }
 
-  m->mangled_name = make_mangled_name(m);
-  m->full_name = make_full_name(t, m);
+  m->mangled_name = make_mangled_name(m, opt);
+  m->full_name = make_full_name(t, m, opt);
 
   // Add to both tables.
   reach_methods_put(&n->r_methods, m);
@@ -756,8 +756,8 @@ static void add_methods_to_type(reach_t* r, reach_type_t* from,
 static void add_internal(reach_t* r, reach_type_t* t, const char* name,
   pass_opt_t* opt)
 {
-  name = stringtab(name);
-  reach_method_name_t* n = add_method_name(t, name, true);
+  name = stringtab(opt->strtab, name);
+  reach_method_name_t* n = add_method_name(t, name, true, opt);
   add_rmethod(r, t, n, TK_BOX, NULL, opt, true);
 }
 
@@ -906,7 +906,7 @@ static void add_traits_to_type(reach_t* r, reach_type_t* t,
 static void add_special(reach_t* r, reach_type_t* t, ast_t* type,
   const char* special, pass_opt_t* opt)
 {
-  special = stringtab(special);
+  special = stringtab(opt->strtab, special);
   deferred_reification_t* find = lookup_try(NULL, NULL, type, special, false);
 
   if(find != NULL)
@@ -990,7 +990,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
   member = ast_child(members);
   size_t index = 0;
 
-  const char* str_final = stringtab("_final");
+  const char* str_final = stringtab(opt->strtab, "_final");
   bool has_finaliser = ast_get(def, str_final, NULL) != NULL;
   bool needs_finaliser = false;
 
@@ -1002,7 +1002,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
       case TK_FLET:
       case TK_EMBED:
       {
-        deferred_reification_t* member_lookup = lookup(NULL, NULL, t->ast,
+        deferred_reification_t* member_lookup = lookup(opt, NULL, t->ast,
           ast_name(ast_child(member)));
         pony_assert(member_lookup != NULL);
 
@@ -1038,7 +1038,7 @@ static void add_fields(reach_t* r, reach_type_t* t, pass_opt_t* opt)
 
   if(!has_finaliser && needs_finaliser)
   {
-    reach_method_name_t* n = add_method_name(t, stringtab("_final"), true);
+    reach_method_name_t* n = add_method_name(t, stringtab(opt->strtab, "_final"), true, opt);
     add_rmethod(r, t, n, TK_BOX, NULL, opt, true);
   }
 }
@@ -1073,12 +1073,12 @@ static uint32_t get_new_tuple_id(reach_t* r)
   return (r->tuple_type_count++ * 4) + 2;
 }
 
-static reach_type_t* add_reach_type(reach_t* r, ast_t* type)
+static reach_type_t* add_reach_type(reach_t* r, ast_t* type, pass_opt_t* opt)
 {
   reach_type_t* t = POOL_ALLOC(reach_type_t);
   memset(t, 0, sizeof(reach_type_t));
 
-  t->name = genname_type(type);
+  t->name = genname_type(type, opt->strtab);
   t->mangle = "o";
   t->ast = set_cap_and_ephemeral(type, TK_REF, TK_NONE);
   t->ast_cap = ast_dup(type);
@@ -1097,12 +1097,12 @@ static reach_type_t* add_reach_type(reach_t* r, ast_t* type)
 static reach_type_t* add_isect_or_union(reach_t* r, ast_t* type,
   pass_opt_t* opt)
 {
-  reach_type_t* t = reach_type(r, type);
+  reach_type_t* t = reach_type(r, type, opt);
 
   if(t != NULL)
     return t;
 
-  t = add_reach_type(r, type);
+  t = add_reach_type(r, type, opt);
 
   // Stop recursing once a runaway instantiation has been detected (here or on a
   // sibling branch of a fan-out); otherwise the blow-up keeps expanding through
@@ -1134,12 +1134,12 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
   if(contains_dontcare(type))
     return NULL;
 
-  reach_type_t* t = reach_type(r, type);
+  reach_type_t* t = reach_type(r, type, opt);
 
   if(t != NULL)
     return t;
 
-  t = add_reach_type(r, type);
+  t = add_reach_type(r, type, opt);
 
   // Stop recursing once a runaway instantiation has been detected; returning
   // before the field allocation below leaves a usable stub with no fields, and
@@ -1185,19 +1185,19 @@ static reach_type_t* add_tuple(reach_t* r, ast_t* type, pass_opt_t* opt)
     child = ast_sibling(child);
   }
 
-  t->mangle = stringtab(mangle->m);
+  t->mangle = stringtab(opt->strtab, mangle->m);
   printbuf_free(mangle);
   return t;
 }
 
 static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
 {
-  reach_type_t* t = reach_type(r, type);
+  reach_type_t* t = reach_type(r, type, opt);
 
   if(t != NULL)
     return t;
 
-  t = add_reach_type(r, type);
+  t = add_reach_type(r, type, opt);
   ast_t* def = (ast_t*)ast_data(type);
   t->underlying = ast_id(def);
 
@@ -1269,7 +1269,7 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
 
   bool bare = false;
 
-  if(is_bare(type))
+  if(is_bare(type, opt))
   {
     bare = true;
 
@@ -1295,7 +1295,7 @@ static reach_type_t* add_nominal(reach_t* r, ast_t* type, pass_opt_t* opt)
     AST_GET_CHILDREN(bare_method, cap, name, typeparams);
     pony_assert(ast_id(typeparams) == TK_NONE);
 
-    reach_method_name_t* n = add_method_name(t, ast_name(name), false);
+    reach_method_name_t* n = add_method_name(t, ast_name(name), false, opt);
     t->bare_method = add_rmethod(r, t, n, TK_AT, NULL, opt, false);
   }
 
@@ -1436,7 +1436,7 @@ static void reachable_pattern(reach_t* r, deferred_reification_t* reify,
       if(ast_id(type) != TK_DONTCARETYPE)
       {
         // type will be reified in reachable_method
-        reachable_method(r, reify, type, stringtab("eq"), NULL, opt);
+        reachable_method(r, reify, type, stringtab(opt->strtab, "eq"), NULL, opt);
         reachable_expr(r, reify, ast, opt);
       }
       break;
@@ -1566,7 +1566,7 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
 
         // type will be reified in reachable_method
         if(type != NULL)
-          reachable_method(r, reify, type, stringtab("create"), NULL, opt);
+          reachable_method(r, reify, type, stringtab(opt->strtab, "create"), NULL, opt);
 
         break;
       }
@@ -1611,7 +1611,7 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
         pony_assert(ast_id(cond) == TK_SEQ);
         cond = ast_child(cond);
 
-        if(is_result_needed(ast) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+        if(is_result_needed(ast, opt) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
         {
           ast_t* type = deferred_reify(reify, ast_type(ast), opt);
           add_type(r, type, opt);
@@ -1639,7 +1639,7 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
         AST_GET_CHILDREN(ast, left_clause, right);
         AST_GET_CHILDREN(left_clause, sub, super, left);
 
-        if(is_result_needed(ast) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+        if(is_result_needed(ast, opt) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
         {
           ast_t* type = deferred_reify(reify, ast_type(ast), opt);
           add_type(r, type, opt);
@@ -1668,7 +1668,7 @@ static void reachable_expr(reach_t* r, deferred_reification_t* reify,
       case TK_DISPOSING_BLOCK:
       case TK_RECOVER:
       {
-        if(is_result_needed(ast) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
+        if(is_result_needed(ast, opt) && !ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
         {
           ast_t* type = deferred_reify(reify, ast_type(ast), opt);
           add_type(r, type, opt);
@@ -1741,12 +1741,12 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
     t = add_type(r, type, opt);
   }
 
-  reach_method_name_t* n = add_method_name(t, name, false);
+  reach_method_name_t* n = add_method_name(t, name, false, opt);
   reach_method_t* m = add_rmethod(r, t, n, n->cap, typeargs, opt, false);
 
   if((n->id == TK_FUN) && ((n->cap == TK_BOX) || (n->cap == TK_TAG)))
   {
-    if(name == stringtab("_final"))
+    if(name == stringtab(opt->strtab, "_final"))
     {
       // If the method is a finaliser, don't mark the ref and val versions as
       // reachable.
@@ -1837,7 +1837,7 @@ void reach(reach_t* r, ast_t* type, const char* name, ast_t* typeargs,
   handle_method_stack(r, opt);
 }
 
-reach_type_t* reach_type(reach_t* r, ast_t* type)
+reach_type_t* reach_type(reach_t* r, ast_t* type, pass_opt_t* opt)
 {
   pony_assert(type != NULL);
 
@@ -1853,7 +1853,7 @@ reach_type_t* reach_type(reach_t* r, ast_t* type)
   }
 
   reach_type_t k;
-  k.name = genname_type(type);
+  k.name = genname_type(type, opt->strtab);
 
   if(unfolded != NULL)
     ast_free_unattached(unfolded);
@@ -1862,16 +1862,16 @@ reach_type_t* reach_type(reach_t* r, ast_t* type)
   return reach_types_get(&r->types, &k, &index);
 }
 
-reach_type_t* reach_type_name(reach_t* r, const char* name)
+reach_type_t* reach_type_name(reach_t* r, const char* name, pass_opt_t* opt)
 {
   reach_type_t k;
-  k.name = stringtab(name);
+  k.name = stringtab(opt->strtab, name);
   size_t index = HASHMAP_UNKNOWN;
   return reach_types_get(&r->types, &k, &index);
 }
 
 reach_method_t* reach_method(reach_type_t* t, token_id cap,
-  const char* name, ast_t* typeargs)
+  const char* name, ast_t* typeargs, pass_opt_t* opt)
 {
   reach_method_name_t* n = reach_method_name(t, name);
 
@@ -1899,7 +1899,7 @@ reach_method_t* reach_method(reach_type_t* t, token_id cap,
     cap = n->cap;
   }
 
-  name = genname_fun(cap, n->name, typeargs);
+  name = genname_fun(cap, n->name, typeargs, opt->strtab);
   return reach_rmethod(n, name);
 }
 
@@ -1911,9 +1911,9 @@ reach_method_name_t* reach_method_name(reach_type_t* t, const char* name)
   return reach_method_names_get(&t->methods, &k, &index);
 }
 
-uint32_t reach_vtable_index(reach_type_t* t, const char* name)
+uint32_t reach_vtable_index(reach_type_t* t, const char* name, pass_opt_t* opt)
 {
-  reach_method_t* m = reach_method(t, TK_NONE, name, NULL);
+  reach_method_t* m = reach_method(t, TK_NONE, name, NULL, opt);
 
   if(m == NULL)
     return (uint32_t)-1;

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -138,17 +138,17 @@ void reach_free(reach_t* r);
 void reach(reach_t* r, ast_t* type, const char* name, ast_t* typeargs,
   pass_opt_t* opt);
 
-reach_type_t* reach_type(reach_t* r, ast_t* type);
+reach_type_t* reach_type(reach_t* r, ast_t* type, pass_opt_t* opt);
 
-reach_type_t* reach_type_name(reach_t* r, const char* name);
+reach_type_t* reach_type_name(reach_t* r, const char* name, pass_opt_t* opt);
 
 reach_method_t* reach_method(reach_type_t* t, token_id cap,
-  const char* name, ast_t* typeargs);
+  const char* name, ast_t* typeargs, pass_opt_t* opt);
 
 reach_method_name_t* reach_method_name(reach_type_t* t,
   const char* name);
 
-uint32_t reach_vtable_index(reach_type_t* t, const char* name);
+uint32_t reach_vtable_index(reach_type_t* t, const char* name, pass_opt_t* opt);
 
 /** Return true if reachability analysis aborted because a generic instantiation
  * exceeded the maximum type depth or size.

--- a/src/libponyc/type/assemble.c
+++ b/src/libponyc/type/assemble.c
@@ -153,7 +153,7 @@ static ast_t* type_typeexpr(pass_opt_t* opt, token_id t, ast_t* l_type,
 }
 
 static ast_t* type_base(ast_t* from, const char* package, const char* name,
-  ast_t* typeargs)
+  ast_t* typeargs, pass_opt_t* opt)
 {
   if(typeargs == NULL)
     typeargs = ast_from(from, TK_NONE);
@@ -177,7 +177,7 @@ ast_t* type_builtin(pass_opt_t* opt, ast_t* from, const char* name)
 ast_t* type_builtin_args(pass_opt_t* opt, ast_t* from, const char* name,
   ast_t* typeargs)
 {
-  ast_t* ast = type_base(from, NULL, name, typeargs);
+  ast_t* ast = type_base(from, NULL, name, typeargs, opt);
 
   if(!names_nominal(opt, from, &ast, false))
   {
@@ -205,7 +205,7 @@ ast_t* type_pointer_to(pass_opt_t* opt, ast_t* to)
   if(!names_nominal(opt, to, &pointer, false))
   {
     ast_error(opt->check.errors, to, "unable to create Pointer[%s]",
-      ast_print_type(to));
+      ast_print_type(to, opt->strtab));
     ast_free(pointer);
     return NULL;
   }
@@ -213,15 +213,15 @@ ast_t* type_pointer_to(pass_opt_t* opt, ast_t* to)
   return pointer;
 }
 
-ast_t* type_sugar(ast_t* from, const char* package, const char* name)
+ast_t* type_sugar(ast_t* from, const char* package, const char* name, pass_opt_t* opt)
 {
-  return type_base(from, package, name, NULL);
+  return type_base(from, package, name, NULL, opt);
 }
 
 ast_t* type_sugar_args(ast_t* from, const char* package, const char* name,
-  ast_t* typeargs)
+  ast_t* typeargs, pass_opt_t* opt)
 {
-  return type_base(from, package, name, typeargs);
+  return type_base(from, package, name, typeargs, opt);
 }
 
 ast_t* control_type_add_branch(pass_opt_t* opt, ast_t* control_type,
@@ -315,7 +315,7 @@ ast_t* type_for_class(pass_opt_t* opt, ast_t* def, ast_t* ast,
     while(typeparam != NULL)
     {
       ast_t* typeparam_id = ast_child(typeparam);
-      ast_t* typearg = type_sugar(ast, NULL, ast_name(typeparam_id));
+      ast_t* typearg = type_sugar(ast, NULL, ast_name(typeparam_id), opt);
       ast_append(typeargs, typearg);
 
       if(expr)

--- a/src/libponyc/type/assemble.h
+++ b/src/libponyc/type/assemble.h
@@ -29,14 +29,14 @@ ast_t* type_pointer_to(pass_opt_t* opt, ast_t* to);
  * Creates an AST node for a package and type.
  * Does not validate the type.
  */
-ast_t* type_sugar(ast_t* from, const char* package, const char* name);
+ast_t* type_sugar(ast_t* from, const char* package, const char* name, pass_opt_t* opt);
 
 /**
  * Same as above, but with typeargs.
  * Does not validate the type.
  */
 ast_t* type_sugar_args(ast_t* from, const char* package, const char* name,
-  ast_t* typeargs);
+  ast_t* typeargs, pass_opt_t* opt);
 
 /**
 * Add a branch type to a control structure type.

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -218,7 +218,7 @@ static deferred_reification_t* lookup_nominal(pass_opt_t* opt, ast_t* from,
         return NULL;
     }
 
-    if(name == stringtab("_final"))
+    if(name == stringtab(opt->strtab, "_final"))
     {
       switch(ast_id(find))
       {
@@ -233,7 +233,7 @@ static deferred_reification_t* lookup_nominal(pass_opt_t* opt, ast_t* from,
 
         default: {}
       }
-    } else if((name == stringtab("_init")) && (ast_id(def) == TK_PRIMITIVE)) {
+    } else if((name == stringtab(opt->strtab, "_init")) && (ast_id(def) == TK_PRIMITIVE)) {
       switch(ast_id(find))
       {
         case TK_NEW:
@@ -356,7 +356,7 @@ static deferred_reification_t* lookup_union(pass_opt_t* opt, ast_t* from,
       if(errors)
       {
         ast_error(opt->check.errors, from, "couldn't find %s in %s",
-          name, ast_print_type(child));
+          name, ast_print_type(child, opt->strtab));
       }
 
       ok = false;
@@ -370,7 +370,7 @@ static deferred_reification_t* lookup_union(pass_opt_t* opt, ast_t* from,
           {
             ast_error(opt->check.errors, from,
               "can't lookup field %s in %s in a union type",
-              name, ast_print_type(child));
+              name, ast_print_type(child, opt->strtab));
           }
 
           deferred_reify_free(r);

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -62,14 +62,14 @@ static matchtype_t is_union_match_x(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(ok == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern, "no element of %s can match %s",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -127,14 +127,14 @@ static matchtype_t is_isect_match_x(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(ok == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern, "not every element of %s can match %s",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -192,14 +192,14 @@ static matchtype_t is_x_match_union(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(ok == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern, "%s cannot match any element of %s",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -257,14 +257,14 @@ static matchtype_t is_x_match_isect(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(ok == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern, "%s cannot match every element of %s",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -281,7 +281,7 @@ static matchtype_t is_tuple_match_tuple(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: they have a different number of elements",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
 
     return MATCHTYPE_REJECT;
@@ -338,14 +338,14 @@ static matchtype_t is_tuple_match_tuple(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(ok == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern, "%s cannot pairwise match %s",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -363,7 +363,7 @@ static matchtype_t is_nominal_match_tuple(ast_t* operand, ast_t* pattern,
 
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: the pattern type is a tuple",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
       ast_error_frame(errorf, operand_def, "this might be possible if the "
         "match type were an empty interface, such as the Any type");
     }
@@ -384,7 +384,7 @@ static matchtype_t is_nominal_match_tuple(ast_t* operand, ast_t* pattern,
       {
         ast_error_frame(errorf, pattern,
           "matching %s with %s could violate capabilities",
-          ast_print_type(operand), ast_print_type(pattern));
+          ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
       }
 
       return r;
@@ -393,7 +393,7 @@ static matchtype_t is_nominal_match_tuple(ast_t* operand, ast_t* pattern,
       {
         ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
       }
 
       return r;
@@ -439,17 +439,17 @@ static matchtype_t is_typeparam_match_typeparam(ast_t* operand, ast_t* pattern,
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities: "
         "%s%s isn't a bound subcap of %s%s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type(o_cap), ast_print_type(o_eph),
-        ast_print_type(p_cap), ast_print_type(p_eph));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type(o_cap, opt->strtab), ast_print_type(o_eph, opt->strtab),
+        ast_print_type(p_cap, opt->strtab), ast_print_type(p_eph, opt->strtab));
     } else if (r == MATCHTYPE_DENY_NODESC) {
       ast_error_frame(errorf, pattern,
         "matching %s with %s is not possible, since a struct lacks a type descriptor",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     } else if(report_reject) {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: they are different type parameters",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
   }
 
@@ -511,7 +511,7 @@ static matchtype_t is_arrow_match_x(ast_t* operand, ast_t* pattern,
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities: "
         "the match type has no lower bounds",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
 
     return MATCHTYPE_DENY_CAP;
@@ -582,8 +582,8 @@ static matchtype_t is_nominal_match_entity(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: %s isn't a subtype of %s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type_no_cap(pattern), ast_print_type_no_cap(operand));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type_no_cap(pattern, opt->strtab), ast_print_type_no_cap(operand, opt->strtab));
     }
 
     return MATCHTYPE_REJECT;
@@ -599,9 +599,9 @@ static matchtype_t is_nominal_match_entity(ast_t* operand, ast_t* pattern,
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities: "
         "%s%s isn't a subcap of %s%s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type(o_cap), ast_print_type(o_eph),
-        ast_print_type(p_cap), ast_print_type(p_eph));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type(o_cap, opt->strtab), ast_print_type(o_eph, opt->strtab),
+        ast_print_type(p_cap, opt->strtab), ast_print_type(p_eph, opt->strtab));
 
         if(is_cap_sub_cap(ast_id(o_cap), TK_EPHEMERAL, ast_id(p_cap),
           ast_id(p_eph)))
@@ -634,7 +634,7 @@ static matchtype_t is_nominal_match_struct(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: the pattern type is a struct",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
       ast_error_frame(errorf, pattern,
         "since a struct has no type descriptor, pattern matching at runtime "
         "would be impossible");
@@ -662,8 +662,8 @@ static matchtype_t is_entity_match_trait(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: %s isn't a subtype of %s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type_no_cap(operand), ast_print_type_no_cap(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type_no_cap(operand, opt->strtab), ast_print_type_no_cap(pattern, opt->strtab));
     }
 
     return MATCHTYPE_REJECT;
@@ -679,9 +679,9 @@ static matchtype_t is_entity_match_trait(ast_t* operand, ast_t* pattern,
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities: "
         "%s%s isn't a subcap of %s%s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type(o_cap), ast_print_type(o_eph),
-        ast_print_type(p_cap), ast_print_type(p_eph));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type(o_cap, opt->strtab), ast_print_type(o_eph, opt->strtab),
+        ast_print_type(p_cap, opt->strtab), ast_print_type(p_eph, opt->strtab));
     }
 
     return MATCHTYPE_DENY_CAP;
@@ -708,9 +708,9 @@ static matchtype_t is_trait_match_trait(ast_t* operand, ast_t* pattern,
       ast_error_frame(errorf, pattern,
         "matching %s with %s could violate capabilities: "
         "%s%s isn't a subcap of %s%s",
-        ast_print_type(operand), ast_print_type(pattern),
-        ast_print_type(o_cap), ast_print_type(o_eph),
-        ast_print_type(p_cap), ast_print_type(p_eph));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab),
+        ast_print_type(o_cap, opt->strtab), ast_print_type(o_eph, opt->strtab),
+        ast_print_type(p_cap, opt->strtab), ast_print_type(p_eph, opt->strtab));
     }
 
     return MATCHTYPE_DENY_CAP;
@@ -784,7 +784,7 @@ static matchtype_t is_tuple_match_nominal(ast_t* operand, ast_t* pattern,
   {
     ast_error_frame(errorf, pattern,
       "%s cannot match %s: the match type is a tuple",
-      ast_print_type(operand), ast_print_type(pattern));
+      ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
   }
 
   return MATCHTYPE_REJECT;
@@ -913,7 +913,7 @@ static matchtype_t is_x_match_arrow(ast_t* operand, ast_t* pattern,
     {
       ast_error_frame(errorf, pattern,
         "%s cannot match %s: the pattern type has no upper bounds",
-        ast_print_type(operand), ast_print_type(pattern));
+        ast_print_type(operand, opt->strtab), ast_print_type(pattern, opt->strtab));
     }
 
     return MATCHTYPE_REJECT;

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -431,7 +431,7 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
 
   while(typeparam != NULL)
   {
-    if(is_bare(typearg))
+    if(is_bare(typearg, opt))
     {
       if(report_errors)
       {
@@ -523,9 +523,9 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
         ast_error_frame(&frame, orig,
           "type argument is outside its constraint");
         ast_error_frame(&frame, typearg,
-          "argument: %s", ast_print_type(typearg));
+          "argument: %s", ast_print_type(typearg, opt->strtab));
         ast_error_frame(&frame, typeparam,
-          "constraint: %s", ast_print_type(r_constraint));
+          "constraint: %s", ast_print_type(r_constraint, opt->strtab));
         errorframe_append(&frame, &info);
         errorframe_report(&frame, opt->check.errors);
       }
@@ -544,9 +544,9 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
         ast_error(opt->check.errors, orig, "a constructable constraint can "
           "only be fulfilled by a concrete type argument");
         ast_error_continue(opt->check.errors, typearg, "argument: %s",
-          ast_print_type(typearg));
+          ast_print_type(typearg, opt->strtab));
         ast_error_continue(opt->check.errors, typeparam, "constraint: %s",
-          ast_print_type(constraint));
+          ast_print_type(constraint, opt->strtab));
       }
 
       return false;

--- a/src/libponyc/type/sanitise.c
+++ b/src/libponyc/type/sanitise.c
@@ -1,10 +1,11 @@
 #include "sanitise.h"
 #include "../ast/astbuild.h"
+#include "../pass/pass.h"
 #include "ponyassert.h"
 
 
 // Collect the given type parameter
-static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args)
+static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args, pass_opt_t* opt)
 {
   pony_assert(orig_param != NULL);
 
@@ -12,7 +13,7 @@ static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args)
   AST_GET_CHILDREN(orig_param, id, constraint, deflt);
   const char* name = ast_name(id);
 
-  constraint = sanitise_type(constraint);
+  constraint = sanitise_type(constraint, opt);
   pony_assert(constraint != NULL);
 
   // New type parameter has the same constraint as the old one (sanitised)
@@ -49,7 +50,7 @@ static void collect_type_param(ast_t* orig_param, ast_t* params, ast_t* args)
 }
 
 
-void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
+void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args, pass_opt_t* opt)
 {
   pony_assert(ast != NULL);
 
@@ -84,7 +85,7 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
     ast_t* entity_t_params = ast_childidx(entity, 1);
 
     for(ast_t* p = ast_child(entity_t_params); p != NULL; p = ast_sibling(p))
-      collect_type_param(p, params, args);
+      collect_type_param(p, params, args, opt);
   }
 
   // Collect type parameters defined on the method (if within a method)
@@ -93,7 +94,7 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
     ast_t* method_t_params = ast_childidx(method, 2);
 
     for(ast_t* p = ast_child(method_t_params); p != NULL; p = ast_sibling(p))
-      collect_type_param(p, params, args);
+      collect_type_param(p, params, args, opt);
   }
 
   if(out_params != NULL)
@@ -105,7 +106,7 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args)
 
 
 // Sanitise the given type (sub)AST, which has already been copied
-static void sanitise(ast_t** astp)
+static void sanitise(ast_t** astp, pass_opt_t* opt)
 {
   pony_assert(astp != NULL);
 
@@ -147,7 +148,7 @@ static void sanitise(ast_t** astp)
     ast_t* typeargs = ast_childidx(type, 1);
 
     for(ast_t* p = ast_child(typeargs); p != NULL; p = ast_sibling(p))
-      sanitise(&p);
+      sanitise(&p, opt);
 
     REPLACE(astp,
       NODE(TK_NOMINAL,
@@ -162,15 +163,15 @@ static void sanitise(ast_t** astp)
 
   // Process all our children
   for(ast_t* p = ast_child(type); p != NULL; p = ast_sibling(p))
-    sanitise(&p);
+    sanitise(&p, opt);
 }
 
 
-ast_t* sanitise_type(ast_t* type)
+ast_t* sanitise_type(ast_t* type, pass_opt_t* opt)
 {
   pony_assert(type != NULL);
 
   ast_t* new_type = ast_dup(type);
-  sanitise(&new_type);
+  sanitise(&new_type, opt);
   return new_type;
 }

--- a/src/libponyc/type/sanitise.h
+++ b/src/libponyc/type/sanitise.h
@@ -4,6 +4,8 @@
 #include <platform.h>
 #include "../ast/ast.h"
 
+typedef struct pass_opt_t pass_opt_t;
+
 PONY_EXTERN_C_BEGIN
 
 
@@ -27,7 +29,7 @@ PONY_EXTERN_C_BEGIN
  * there are no type parameters in scope, then both produced nodes will be
  * TK_NONEs, which keeps our AST consistent.
  */
-void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args);
+void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args, pass_opt_t* opt);
 
 /** Produce a copy of the given type that is safe to use in an internally
 * created AST that will be run through passes again.
@@ -36,7 +38,7 @@ void collect_type_params(ast_t* ast, ast_t** out_params, ast_t** out_args);
 * between goes. If this is not done type parameter references can point at the
 * wrong definitions.
 */
-ast_t* sanitise_type(ast_t* type);
+ast_t* sanitise_type(ast_t* type, pass_opt_t* opt);
 
 
 PONY_EXTERN_C_END

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -41,14 +41,14 @@ static bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
   errorframe_t* errorf, pass_opt_t* opt);
 
 static void struct_cant_be_x(ast_t* sub, ast_t* super, errorframe_t* errorf,
-  const char* entity)
+  const char* entity, pass_opt_t* opt)
 {
   if(errorf == NULL)
     return;
 
   ast_error_frame(errorf, sub,
     "%s is not a subtype of %s: a struct can't be a subtype of %s",
-    ast_print_type(sub), ast_print_type(super), entity);
+    ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab), entity);
 }
 
 static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
@@ -76,9 +76,9 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: %s%s is not a subcap of %s%s",
-          ast_print_type(sub), ast_print_type(super),
-          ast_print_type(sub_cap), ast_print_type(sub_eph),
-          ast_print_type(super_cap), ast_print_type(super_eph));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
+          ast_print_type(sub_cap, opt->strtab), ast_print_type(sub_eph, opt->strtab),
+          ast_print_type(super_cap, opt->strtab), ast_print_type(super_eph, opt->strtab));
 
         if(is_cap_sub_cap(ast_id(sub_cap), TK_EPHEMERAL, ast_id(super_cap),
           ast_id(super_eph)))
@@ -100,7 +100,7 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
           ast_error_frame(errorf, sub_cap,
             "%s is a generic capability standing for {%s}; a capability is a "
             "subcap of it only if it is a subcap of every one of those",
-            ast_print_type(super_cap), generic);
+            ast_print_type(super_cap, opt->strtab), generic);
       }
 
       return false;
@@ -116,9 +116,9 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, sub,
           "%s is not in constraint %s: %s%s is not in constraint %s%s",
-          ast_print_type(sub), ast_print_type(super),
-          ast_print_type(sub_cap), ast_print_type(sub_eph),
-          ast_print_type(super_cap), ast_print_type(super_eph));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
+          ast_print_type(sub_cap, opt->strtab), ast_print_type(sub_eph, opt->strtab),
+          ast_print_type(super_cap, opt->strtab), ast_print_type(super_eph, opt->strtab));
       }
 
       return false;
@@ -134,9 +134,9 @@ static bool is_sub_cap_and_eph(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, sub,
           "%s is not a bound subtype of %s: %s%s is not a bound subcap of %s%s",
-          ast_print_type(sub), ast_print_type(super),
-          ast_print_type(sub_cap), ast_print_type(sub_eph),
-          ast_print_type(super_cap), ast_print_type(super_eph));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
+          ast_print_type(sub_cap, opt->strtab), ast_print_type(sub_eph, opt->strtab),
+          ast_print_type(super_cap, opt->strtab), ast_print_type(super_eph, opt->strtab));
       }
 
       return false;
@@ -171,10 +171,10 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
   {
     ast_error_frame(errorf, a,
       "%s has different type arguments than %s (the type arguments must be equivalent, not covariant nor contravariant)",
-      ast_print_type(a), ast_print_type(b));
+      ast_print_type(a, opt->strtab), ast_print_type(b, opt->strtab));
     ast_error_frame(errorf, a,
       "this might be possible if either %s or %s were an interface rather than a concrete type",
-      ast_print_type(a), ast_print_type(b));
+      ast_print_type(a, opt->strtab), ast_print_type(b, opt->strtab));
   }
 
   // Make sure we had the same number of typeargs.
@@ -184,7 +184,7 @@ static bool is_eq_typeargs(ast_t* a, ast_t* b, errorframe_t* errorf,
     {
       ast_error_frame(errorf, a,
         "%s has a different number of type arguments than %s",
-        ast_print_type(a), ast_print_type(b));
+        ast_print_type(a, opt->strtab), ast_print_type(b, opt->strtab));
     }
 
     ret = false;
@@ -213,7 +213,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         {
           ast_error_frame(errorf, sub,
             "%s constructor is not a subtype of %s constructor",
-            ast_print_type(sub_cap), ast_print_type(super_cap));
+            ast_print_type(sub_cap, opt->strtab), ast_print_type(super_cap, opt->strtab));
         }
 
         return false;
@@ -228,7 +228,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         {
           ast_error_frame(errorf, sub,
             "constructor result %s is not a subtype of %s",
-            ast_print_type(sub_result), ast_print_type(super_result));
+            ast_print_type(sub_result, opt->strtab), ast_print_type(super_result, opt->strtab));
         }
 
         return false;
@@ -250,7 +250,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         {
           ast_error_frame(errorf, sub,
             "%s method is not a subtype of %s method",
-            ast_print_type(sub_cap), ast_print_type(super_cap));
+            ast_print_type(sub_cap, opt->strtab), ast_print_type(super_cap, opt->strtab));
         }
 
         return false;
@@ -274,7 +274,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
         {
           ast_error_frame(errorf, sub,
             "method result %s is not a subtype of %s",
-            ast_print_type(sub_result), ast_print_type(super_result));
+            ast_print_type(sub_result, opt->strtab), ast_print_type(super_result, opt->strtab));
         }
 
         return false;
@@ -304,7 +304,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       {
         ast_error_frame(errorf, sub,
           "type parameter constraint %s is not a supertype of %s",
-          ast_print_type(sub_constraint), ast_print_type(super_constraint));
+          ast_print_type(sub_constraint, opt->strtab), ast_print_type(super_constraint, opt->strtab));
       }
 
       return false;
@@ -338,7 +338,7 @@ static bool is_reified_fun_sub_fun(ast_t* sub, ast_t* super,
       if(errorf != NULL)
       {
         ast_error_frame(errorf, sub, "parameter %s is not a supertype of %s",
-          ast_print_type(sub_type), ast_print_type(super_type));
+          ast_print_type(sub_type, opt->strtab), ast_print_type(super_type, opt->strtab));
       }
 
       ast_free_unattached(sub_type);
@@ -511,7 +511,7 @@ static bool is_x_sub_isect(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, sub,
           "%s is not a subtype of every element of %s",
-          ast_print_type(sub), ast_print_type(super));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
       }
 
       return false;
@@ -713,7 +713,7 @@ static bool is_x_sub_union(ast_t* sub, ast_t* super, check_cap_t check_cap,
     }
 
     ast_error_frame(errorf, sub, "%s is not a subtype of any element of %s",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return false;
@@ -736,7 +736,7 @@ static bool is_union_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, child,
           "not every element of %s is a subtype of %s",
-          ast_print_type(sub), ast_print_type(super));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
       }
 
       return false;
@@ -815,7 +815,7 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
   if(errorf != NULL)
   {
     ast_error_frame(errorf, sub, "no element of %s is a subtype of %s",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return false;
@@ -834,7 +834,7 @@ static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, check_cap_t check_cap,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: they have a different number of elements",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -856,7 +856,7 @@ static bool is_tuple_sub_tuple(ast_t* sub, ast_t* super, check_cap_t check_cap,
   if(!ret && errorf != NULL)
   {
     ast_error_frame(errorf, sub, "%s is not a pairwise subtype of %s",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return ret;
@@ -872,7 +872,7 @@ static bool is_single_sub_tuple(ast_t* sub, ast_t* super, check_cap_t check_cap,
   {
     ast_error_frame(errorf, sub,
       "%s is not a subtype of %s: the supertype is a tuple",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return false;
@@ -893,8 +893,8 @@ static bool is_tuple_sub_nominal(ast_t* sub, ast_t* super,
         {
           ast_error_frame(errorf, child,
             "%s is not a subtype of %s: %s is not a subtype of %s",
-            ast_print_type(sub), ast_print_type(super),
-            ast_print_type(child), ast_print_type(super));
+            ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
+            ast_print_type(child, opt->strtab), ast_print_type(super, opt->strtab));
         }
         return false;
       }
@@ -909,7 +909,7 @@ static bool is_tuple_sub_nominal(ast_t* sub, ast_t* super,
 
     ast_error_frame(errorf, sub,
       "%s is not a subtype of %s: the subtype is a tuple",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     ast_error_frame(errorf, super_def, "this might be possible if the supertype"
       " were an empty interface, such as the Any type.");
   }
@@ -973,7 +973,7 @@ static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
   ast_t* super_def = (ast_t*)ast_data(super);
   bool ret = true;
 
-  if(is_bare(sub) && is_pointer(super))
+  if(is_bare(sub, opt) && is_pointer(super))
   {
     ast_t* super_typeargs = ast_childidx(super, 2);
     ast_t* super_typearg = ast_child(super_typeargs);
@@ -988,7 +988,7 @@ static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
     if(errorf != NULL)
     {
       ast_error_frame(errorf, sub, "%s is not a subtype of %s",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1020,25 +1020,25 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
   pony_assert((sub_pass >= PASS_TRAITS) && (super_pass >= PASS_TRAITS));
   (void)sub_pass; (void)super_pass;
 
-  if(ast_has_annotation(sub_def, "nosupertype"))
+  if(ast_has_annotation(sub_def, "nosupertype", opt->strtab))
   {
     if(errorf != NULL)
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: it is marked 'nosupertype'",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
   }
 
-  if(is_bare(sub) != is_bare(super))
+  if(is_bare(sub, opt) != is_bare(super, opt))
   {
     if(errorf != NULL)
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: their bareness differ",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1068,7 +1068,7 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
       {
         ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: it has no method '%s'",
-          ast_print_type(sub), ast_print_type(super),
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
           ast_name(super_member_id));
       }
 
@@ -1101,7 +1101,7 @@ static bool is_nominal_sub_structural(ast_t* sub, ast_t* super,
         ast_error_frame(errorf, sub_member,
           "%s is not a subtype of %s: "
           "method '%s' has an incompatible signature",
-          ast_print_type(sub), ast_print_type(super),
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
           ast_name(super_member_id));
       }
     }
@@ -1122,7 +1122,7 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
 
   if(ast_id(sub_def) == TK_STRUCT)
   {
-    struct_cant_be_x(sub, super, errorf, "an interface");
+    struct_cant_be_x(sub, super, errorf, "an interface", opt);
     ret = false;
   }
 
@@ -1138,14 +1138,14 @@ static bool is_nominal_sub_interface(ast_t* sub, ast_t* super,
 static bool nominal_provides_trait(ast_t* type, ast_t* trait,
   check_cap_t check_cap, errorframe_t* errorf, pass_opt_t* opt)
 {
-  pony_assert(!is_bare(trait));
-  if(is_bare(type))
+  pony_assert(!is_bare(trait, opt));
+  if(is_bare(type, opt))
   {
     if(errorf != NULL)
     {
       ast_error_frame(errorf, type,
         "%s is not a subtype of %s: their bareness differ",
-        ast_print_type(type), ast_print_type(trait));
+        ast_print_type(type, opt->strtab), ast_print_type(trait, opt->strtab));
     }
 
     return false;
@@ -1187,7 +1187,7 @@ static bool nominal_provides_trait(ast_t* type, ast_t* trait,
   if(errorf != NULL)
   {
     ast_error_frame(errorf, type, "%s does not implement trait %s",
-      ast_print_type(type), ast_print_type(trait));
+      ast_print_type(type, opt->strtab), ast_print_type(trait, opt->strtab));
   }
 
   return false;
@@ -1209,9 +1209,9 @@ static bool is_entity_sub_trait(ast_t* sub, ast_t* super,
   return true;
 }
 
-static bool is_struct_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errorf)
+static bool is_struct_sub_trait(ast_t* sub, ast_t* super, errorframe_t* errorf, pass_opt_t* opt)
 {
-  struct_cant_be_x(sub, super, errorf, "a trait");
+  struct_cant_be_x(sub, super, errorf, "a trait", opt);
   return false;
 }
 
@@ -1243,7 +1243,7 @@ static bool is_trait_sub_trait(ast_t* sub, ast_t* super, check_cap_t check_cap,
 }
 
 static bool is_interface_sub_trait(ast_t* sub, ast_t* super,
-  check_cap_t check_cap, errorframe_t* errorf)
+  check_cap_t check_cap, errorframe_t* errorf, pass_opt_t* opt)
 {
   (void)check_cap;
 
@@ -1251,7 +1251,7 @@ static bool is_interface_sub_trait(ast_t* sub, ast_t* super,
   {
     ast_error_frame(errorf, sub,
       "%s is not a subtype of %s: an interface can't be a subtype of a trait",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return false;
@@ -1272,13 +1272,13 @@ static bool is_nominal_sub_trait(ast_t* sub, ast_t* super,
       return is_entity_sub_trait(sub, super, check_cap, errorf, opt);
 
     case TK_STRUCT:
-      return is_struct_sub_trait(sub, super, errorf);
+      return is_struct_sub_trait(sub, super, errorf, opt);
 
     case TK_TRAIT:
       return is_trait_sub_trait(sub, super, check_cap, errorf, opt);
 
     case TK_INTERFACE:
-      return is_interface_sub_trait(sub, super, check_cap, errorf);
+      return is_interface_sub_trait(sub, super, check_cap, errorf, opt);
 
     default: {}
   }
@@ -1329,7 +1329,7 @@ static bool is_x_sub_typeparam(ast_t* sub, ast_t* super,
       {
         ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: the type parameter has no constraint",
-          ast_print_type(sub), ast_print_type(super));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
       }
 
       return false;
@@ -1349,7 +1349,7 @@ static bool is_x_sub_typeparam(ast_t* sub, ast_t* super,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the type parameter has no lower bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1386,7 +1386,7 @@ static bool is_x_sub_arrow(ast_t* sub, ast_t* super,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1409,11 +1409,11 @@ static bool is_nominal_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
 
       if(ast_id(def) == TK_STRUCT)
       {
-        struct_cant_be_x(sub, super, errorf, "a union type");
+        struct_cant_be_x(sub, super, errorf, "a union type", opt);
         return false;
       }
 
-      if(is_bare(sub))
+      if(is_bare(sub, opt))
       {
         if(errorf != NULL)
         {
@@ -1431,11 +1431,11 @@ static bool is_nominal_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
 
       if(ast_id(def) == TK_STRUCT)
       {
-        struct_cant_be_x(sub, super, errorf, "an intersection type");
+        struct_cant_be_x(sub, super, errorf, "an intersection type", opt);
         return false;
       }
 
-      if(is_bare(sub))
+      if(is_bare(sub, opt))
       {
         if(errorf != NULL)
         {
@@ -1511,7 +1511,7 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
   {
     ast_error_frame(errorf, sub,
       "%s is not a subtype of %s: they are different type parameters",
-      ast_print_type(sub), ast_print_type(super));
+      ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
   }
 
   return false;
@@ -1559,7 +1559,7 @@ static bool is_typeparam_sub_arrow(ast_t* sub, ast_t* super,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1630,7 +1630,7 @@ static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
       {
         ast_error_frame(errorf, sub,
           "%s is not a subtype of %s: the subtype has no constraint",
-          ast_print_type(sub), ast_print_type(super));
+          ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
       }
 
       return false;
@@ -1650,7 +1650,7 @@ static bool is_typeparam_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no constraint",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1686,7 +1686,7 @@ static bool is_arrow_sub_nominal(ast_t* sub, ast_t* super,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no upper bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     return false;
@@ -1778,7 +1778,7 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, check_cap_t check_cap,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the subtype has no upper bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     ok = false;
@@ -1790,7 +1790,7 @@ static bool is_arrow_sub_arrow(ast_t* sub, ast_t* super, check_cap_t check_cap,
     {
       ast_error_frame(errorf, sub,
         "%s is not a subtype of %s: the supertype has no lower bounds",
-        ast_print_type(sub), ast_print_type(super));
+        ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab));
     }
 
     ok = false;
@@ -2003,7 +2003,7 @@ static bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
             "typeargs that grow at each level. The "
             "recursion-divergence guard aborted after %zu same-def "
             "frames (ponylang/ponyc#1216).",
-            ast_print_type(sub), ast_print_type(super), SAME_DEF_LIMIT);
+            ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab), SAME_DEF_LIMIT);
         }
 
         // Mark the subtree as poisoned so neither this frame nor any
@@ -2495,8 +2495,14 @@ bool is_known(ast_t* type)
   return false;
 }
 
-bool is_bare(ast_t* type)
+bool is_bare(ast_t* type, pass_opt_t* opt)
 {
+  // opt must be non-NULL: the TK_NOMINAL case interns "ponyint_bare" into
+  // opt->strtab. Lookup paths that deliberately pass opt == NULL to skip
+  // access-control checks must pass from == NULL instead (see genmatch.c), which
+  // keeps the checks off without starving the subtype machinery of a table.
+  pony_assert(opt != NULL);
+
   if(type == NULL)
     return false;
 
@@ -2509,7 +2515,7 @@ bool is_bare(ast_t* type)
       ast_t* child = ast_child(type);
       while(child != NULL)
       {
-        if(is_bare(child))
+        if(is_bare(child, opt))
           return true;
 
         child = ast_sibling(child);
@@ -2521,18 +2527,18 @@ bool is_bare(ast_t* type)
     case TK_NOMINAL:
     {
       ast_t* def = (ast_t*)ast_data(type);
-      return ast_has_annotation(def, "ponyint_bare");
+      return ast_has_annotation(def, "ponyint_bare", opt->strtab);
     }
 
     case TK_ARROW:
-      return is_bare(ast_childidx(type, 1));
+      return is_bare(ast_childidx(type, 1), opt);
 
     case TK_TYPEALIASREF:
     {
       ast_t* unfolded = typealias_unfold(type);
       if(unfolded == NULL)
         return false;
-      bool ok = is_bare(unfolded);
+      bool ok = is_bare(unfolded, opt);
       ast_free_unattached(unfolded);
       return ok;
     }

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -55,7 +55,7 @@ bool is_concrete(ast_t* type);
 
 bool is_known(ast_t* type);
 
-bool is_bare(ast_t* type);
+bool is_bare(ast_t* type, pass_opt_t* opt);
 
 bool is_top_type(ast_t* type, bool ignore_cap, pass_opt_t* opt);
 

--- a/src/libponyc/verify/type.c
+++ b/src/libponyc/verify/type.c
@@ -30,7 +30,7 @@ static bool embed_struct_field_has_finaliser(pass_opt_t* opt, ast_t* field,
 
   ast_t* def = (ast_t*)ast_data(type);
 
-  ast_t* final = ast_get(def, stringtab("_final"), NULL);
+  ast_t* final = ast_get(def, stringtab(opt->strtab, "_final"), NULL);
 
   if(final != NULL)
   {

--- a/src/ponyc/main.c
+++ b/src/ponyc/main.c
@@ -71,8 +71,6 @@ static bool compile_package(const char* path, pass_opt_t* opt,
 
 int main(int argc, char* argv[])
 {
-  stringtab_init();
-
   pass_opt_t opt;
   pass_opt_init(&opt);
 

--- a/test/libponyc/annotations.cc
+++ b/test/libponyc/annotations.cc
@@ -39,11 +39,11 @@ TEST_F(AnnotationsTest, AnnotationsArePresent)
   ast = ast_child(ast);
 
   ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ID) &&
-    (ast_name(ast) == stringtab("a")));
+    (ast_name(ast) == stringtab(opt.strtab, "a")));
   ast = ast_sibling(ast);
 
   ASSERT_TRUE((ast != NULL) && (ast_id(ast) == TK_ID) &&
-    (ast_name(ast) == stringtab("b")));
+    (ast_name(ast) == stringtab(opt.strtab, "b")));
 }
 
 TEST_F(AnnotationsTest, AnnotateSugar)
@@ -70,16 +70,16 @@ TEST_F(AnnotationsTest, AnnotateSugar)
   ast_t* ast = lookup_in(c_type, "test_for");
   ast = ast_childidx(ast_child(ast_childidx(ast, 6)), 1);
 
-  ASSERT_TRUE(ast_has_annotation(ast, "a"));
-  ASSERT_FALSE(ast_has_annotation(ast, "b"));
-  ASSERT_TRUE(ast_has_annotation(ast_childidx(ast, 2), "b"));
+  ASSERT_TRUE(ast_has_annotation(ast, "a", opt.strtab));
+  ASSERT_FALSE(ast_has_annotation(ast, "b", opt.strtab));
+  ASSERT_TRUE(ast_has_annotation(ast_childidx(ast, 2), "b", opt.strtab));
 
   // Get the sugared `with` node.
   ast = lookup_in(c_type, "test_with");
   ast = ast_childidx(ast_child(ast_childidx(ast, 6)), 1);
 
-  ASSERT_TRUE(ast_has_annotation(ast, "a"));
-  ASSERT_FALSE(ast_has_annotation(ast, "b"));
+  ASSERT_TRUE(ast_has_annotation(ast, "a", opt.strtab));
+  ASSERT_FALSE(ast_has_annotation(ast, "b", opt.strtab));
 }
 
 TEST_F(AnnotationsTest, AnnotateLambda)
@@ -94,10 +94,10 @@ TEST_F(AnnotationsTest, AnnotateLambda)
   // Get the type of the lambda.
   ast_t* ast = lookup_type("$1$0");
 
-  ASSERT_FALSE(ast_has_annotation(ast, "a"));
+  ASSERT_FALSE(ast_has_annotation(ast, "a", opt.strtab));
   ast = lookup_in(ast, "apply");
 
-  ASSERT_TRUE(ast_has_annotation(ast, "a"));
+  ASSERT_TRUE(ast_has_annotation(ast, "a", opt.strtab));
 }
 
 TEST_F(AnnotationsTest, InternalAnnotation)

--- a/test/libponyc/buildflagset.cc
+++ b/test/libponyc/buildflagset.cc
@@ -6,10 +6,15 @@
 
 
 class BuildFlagSetTest: public testing::Test
-{};
+{
+protected:
+  strtable_t* tab;
+  void SetUp() override { tab = stringtab_new(); }
+  void TearDown() override { stringtab_free(tab); }
+};
 
 
-TEST(BuildFlagSetTest, PrintEmpty)
+TEST_F(BuildFlagSetTest, PrintEmpty)
 {
   buildflagset_t* set = buildflagset_create();
   ASSERT_NE((void*)NULL, set);
@@ -26,7 +31,7 @@ TEST(BuildFlagSetTest, PrintEmpty)
 }
 
 
-TEST(BuildFlagSetTest, EmptyHas1Config)
+TEST_F(BuildFlagSetTest, EmptyHas1Config)
 {
   buildflagset_t* set = buildflagset_create();
   ASSERT_NE((void*)NULL, set);
@@ -37,12 +42,12 @@ TEST(BuildFlagSetTest, EmptyHas1Config)
 }
 
 
-TEST(BuildFlagSetTest, Flag)
+TEST_F(BuildFlagSetTest, Flag)
 {
   buildflagset_t* set = buildflagset_create();
   ASSERT_NE((void*)NULL, set);
 
-  buildflagset_add(set, stringtab("foo"));
+  buildflagset_add(set, stringtab(tab, "foo"));
   ASSERT_EQ(2, buildflagset_configcount(set));
 
   buildflagset_startenum(set);
@@ -55,7 +60,7 @@ TEST(BuildFlagSetTest, Flag)
   {
     count++;
 
-    if(buildflagset_get(set, stringtab("foo")))
+    if(buildflagset_get(set, stringtab(tab, "foo")))
     {
       had_true = true;
       ASSERT_STREQ("foo", buildflagset_print(set));
@@ -75,12 +80,12 @@ TEST(BuildFlagSetTest, Flag)
 }
 
 
-TEST(BuildFlagSetTest, PlatformOS)
+TEST_F(BuildFlagSetTest, PlatformOS)
 {
   buildflagset_t* set = buildflagset_create();
   ASSERT_NE((void*)NULL, set);
 
-  buildflagset_add(set, stringtab("windows"));
+  buildflagset_add(set, stringtab(tab, "windows"));
   ASSERT_LT(2, buildflagset_configcount(set));
 
   // Check we get at least "windows" and "linux" configs. Don't check for all
@@ -107,14 +112,14 @@ TEST(BuildFlagSetTest, PlatformOS)
   buildflagset_free(set);
 }
 
-TEST(BuildFlagSetTest, MultipleFlags)
+TEST_F(BuildFlagSetTest, MultipleFlags)
 {
   buildflagset_t* set = buildflagset_create();
   ASSERT_NE((void*)NULL, set);
 
-  buildflagset_add(set, stringtab("a"));
-  buildflagset_add(set, stringtab("b"));
-  buildflagset_add(set, stringtab("c"));
+  buildflagset_add(set, stringtab(tab, "a"));
+  buildflagset_add(set, stringtab(tab, "b"));
+  buildflagset_add(set, stringtab(tab, "c"));
   ASSERT_EQ(8, buildflagset_configcount(set));
 
   buildflagset_startenum(set);
@@ -127,9 +132,9 @@ TEST(BuildFlagSetTest, MultipleFlags)
     count++;
     int config = 0;
 
-    if(buildflagset_get(set, stringtab("a"))) config += 1;
-    if(buildflagset_get(set, stringtab("b"))) config += 2;
-    if(buildflagset_get(set, stringtab("c"))) config += 4;
+    if(buildflagset_get(set, stringtab(tab, "a"))) config += 1;
+    if(buildflagset_get(set, stringtab(tab, "b"))) config += 2;
+    if(buildflagset_get(set, stringtab(tab, "c"))) config += 4;
 
     ASSERT_FALSE(had[config]);
     had[config] = true;

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -36,7 +36,7 @@ TEST_F(CodegenTest, PackedStructIsPacked)
   TEST_COMPILE(src);
 
   reach_t* reach = compile->reach;
-  reach_type_t* foo = reach_type_name(reach, "Foo");
+  reach_type_t* foo = reach_type_name(reach, "Foo", &opt);
   ASSERT_TRUE(foo != NULL);
 
   LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;
@@ -58,7 +58,7 @@ TEST_F(CodegenTest, NonPackedStructIsntPacked)
   TEST_COMPILE(src);
 
   reach_t* reach = compile->reach;
-  reach_type_t* foo = reach_type_name(reach, "Foo");
+  reach_type_t* foo = reach_type_name(reach, "Foo", &opt);
   ASSERT_TRUE(foo != NULL);
 
   LLVMTypeRef type = ((compile_type_t*)foo->c_type)->structure;

--- a/test/libponyc/id.cc
+++ b/test/libponyc/id.cc
@@ -11,11 +11,11 @@
 
 static void test_id(const char* id, bool expect_pass, int spec)
 {
-  ast_t* node = ast_blank(TK_ID);
-  ast_set_name(node, id);
-
   pass_opt_t opt;
   pass_opt_init(&opt);
+
+  ast_t* node = ast_blank(TK_ID);
+  ast_set_name(node, id, opt.strtab);
 
   bool r = check_id(&opt, node, "test", spec);
 

--- a/test/libponyc/lexer.cc
+++ b/test/libponyc/lexer.cc
@@ -5,6 +5,7 @@
 #include <ast/lexer.h>
 #include <ast/source.h>
 #include <ast/token.h>
+#include <ast/stringtab.h>
 
 #include "util.h"
 
@@ -14,10 +15,17 @@ class LexerTest : public testing::Test
 {
 protected:
   string _expected;
+  strtable_t* _strtab;
 
   virtual void SetUp()
   {
     _expected = "";
+    _strtab = stringtab_new();
+  }
+
+  virtual void TearDown()
+  {
+    stringtab_free(_strtab);
   }
 
   // Add an expected token to our list
@@ -36,7 +44,7 @@ protected:
   {
     errors_t* errors = errors_alloc();
     source_t* source = source_open_string(src);
-    lexer_t* lexer = lexer_open(source, errors, false);
+    lexer_t* lexer = lexer_open(source, errors, _strtab, false);
     token_id id = TK_LEX_ERROR;
     string actual;
 

--- a/test/libponyc/paint.cc
+++ b/test/libponyc/paint.cc
@@ -13,23 +13,26 @@ class PaintTest: public testing::Test
 protected:
   reach_t* _set;
   reach_type_t* _current_type;
+  strtable_t* _strtab;
 
   virtual void SetUp()
   {
     _set = reach_new();
     _current_type = NULL;
+    _strtab = stringtab_new();
   }
 
   virtual void TearDown()
   {
     reach_free(_set);
+    stringtab_free(_strtab);
   }
 
   void add_type(const char* name)
   {
     _current_type = POOL_ALLOC(reach_type_t);
     memset(_current_type, 0, sizeof(reach_type_t));
-    _current_type->name = stringtab(name);
+    _current_type->name = stringtab(_strtab, name);
     _current_type->ast = NULL;
     reach_method_names_init(&_current_type->methods, 0);
     reach_type_cache_init(&_current_type->subtypes, 0);
@@ -42,7 +45,7 @@ protected:
   {
     reach_method_name_t* n = POOL_ALLOC(reach_method_name_t);
     memset(n, 0, sizeof(reach_method_name_t));
-    n->name = stringtab(name);
+    n->name = stringtab(_strtab, name);
     reach_methods_init(&n->r_methods, 0);
     reach_mangled_init(&n->r_mangled, 0);
 
@@ -50,7 +53,7 @@ protected:
 
     reach_method_t* method = POOL_ALLOC(reach_method_t);
     memset(method, 0, sizeof(reach_method_t));
-    method->name = stringtab(name);
+    method->name = stringtab(_strtab, name);
     method->mangled_name = method->name;
     method->fun = NULL;
     method->typeargs = NULL;
@@ -69,7 +72,7 @@ protected:
     uint32_t max_expected, uint32_t* actual)
   {
     reach_type_t t;
-    t.name = stringtab(name);
+    t.name = stringtab(_strtab, name);
     size_t index = HASHMAP_UNKNOWN;
     reach_type_t* type = reach_types_get(&_set->types, &t, &index);
     ASSERT_NE((void*)NULL, type);
@@ -112,14 +115,14 @@ protected:
     while((type = reach_types_next(&_set->types, &i)) != NULL)
     {
       reach_method_name_t m1;
-      m1.name = stringtab(name);
+      m1.name = stringtab(_strtab, name);
       reach_method_name_t* n = reach_method_names_get(&type->methods, &m1, &index);
 
       if(n != NULL)
       {
         reach_method_t m2;
         memset(&m2, 0, sizeof(reach_method_t));
-        m2.name = stringtab(name);
+        m2.name = stringtab(_strtab, name);
         reach_method_t* method = reach_methods_get(&n->r_methods, &m2, &index);
 
         ASSERT_NE((void*)NULL, method);

--- a/test/libponyc/reach.cc
+++ b/test/libponyc/reach.cc
@@ -41,7 +41,7 @@ TEST_F(ReachTest, IsectHasSubtypes)
   ASSERT_NE(ab_ast, (void*)NULL);
 
   reach_t* reach = compile->reach;
-  reach_type_t* ab_reach = reach_type(reach, ab_ast);
+  reach_type_t* ab_reach = reach_type(reach, ab_ast, &opt);
   ASSERT_NE(ab_reach, (void*)NULL);
 
   size_t i = HASHMAP_BEGIN;
@@ -50,7 +50,7 @@ TEST_F(ReachTest, IsectHasSubtypes)
   bool found = false;
   while((subtype = reach_type_cache_next(&ab_reach->subtypes, &i)) != NULL)
   {
-    if(subtype->name == stringtab("Main"))
+    if(subtype->name == stringtab(opt.strtab, "Main"))
     {
       found = true;
       break;
@@ -330,7 +330,7 @@ TEST_F(ReachTest, UnionReachedMethod)
   ASSERT_NE(p_ast, (void*)NULL);
 
   reach_t* reach = compile->reach;
-  reach_type_t* p_reach = reach_type(reach, p_ast);
+  reach_type_t* p_reach = reach_type(reach, p_ast, &opt);
   ASSERT_NE(p_reach, (void*)NULL);
 
   bool found = false;
@@ -338,7 +338,7 @@ TEST_F(ReachTest, UnionReachedMethod)
   reach_method_name_t* n;
   while((n = reach_method_names_next(&p_reach->methods, &i)) != NULL)
   {
-    if(n->name == stringtab("example"))
+    if(n->name == stringtab(opt.strtab, "example"))
     {
       found = true;
       break;
@@ -360,14 +360,15 @@ TEST_F(ReachTest, UnionReachedMethod)
 // relationships, both invariant across the cap variants. Do not use this to
 // assert a full mangled string.
 static const char* any_mangled_name(reach_t* r, const char* type_name,
-  const char* method_name)
+  const char* method_name, pass_opt_t* opt)
 {
-  reach_type_t* t = reach_type_name(r, type_name);
+  reach_type_t* t = reach_type_name(r, type_name, opt);
 
   if(t == NULL)
     return NULL;
 
-  reach_method_name_t* n = reach_method_name(t, stringtab(method_name));
+  reach_method_name_t* n = reach_method_name(t, stringtab(opt->strtab,
+    method_name));
 
   if(n == NULL)
     return NULL;
@@ -416,8 +417,8 @@ TEST_F(ReachTest, PartialAndNonPartialMangleDistinctly)
 
   reach_t* reach = compile->reach;
 
-  const char* partial = any_mangled_name(reach, "C1", "f");
-  const char* non_partial = any_mangled_name(reach, "C2", "f");
+  const char* partial = any_mangled_name(reach, "C1", "f", &opt);
+  const char* non_partial = any_mangled_name(reach, "C2", "f", &opt);
 
   ASSERT_NE(partial, (void*)NULL);
   ASSERT_NE(non_partial, (void*)NULL);
@@ -453,8 +454,8 @@ TEST_F(ReachTest, BareMethodsNotSplitByPartiality)
 
   reach_t* reach = compile->reach;
 
-  const char* bare_partial = any_mangled_name(reach, "P1", "g");
-  const char* bare_non_partial = any_mangled_name(reach, "P2", "g");
+  const char* bare_partial = any_mangled_name(reach, "P1", "g", &opt);
+  const char* bare_non_partial = any_mangled_name(reach, "P2", "g", &opt);
 
   ASSERT_NE(bare_partial, (void*)NULL);
   ASSERT_NE(bare_non_partial, (void*)NULL);
@@ -524,7 +525,7 @@ TEST_F(ReachTest, NonPartialMangleNeverEndsInMarker)
 
   for(size_t i = 0; i < (sizeof(cases) / sizeof(cases[0])); i++)
   {
-    const char* mangled = any_mangled_name(reach, "R", cases[i].method);
+    const char* mangled = any_mangled_name(reach, "R", cases[i].method, &opt);
     ASSERT_NE(mangled, (void*)NULL) << "method " << cases[i].method;
 
     size_t len = strlen(mangled);
@@ -614,8 +615,8 @@ TEST_F(ReachTest, InteriorTraceKindMarkerDoesNotCollide)
 
   reach_t* reach = compile->reach;
 
-  const char* non_partial = any_mangled_name(reach, "C", "safe");
-  const char* partial = any_mangled_name(reach, "C", "risky");
+  const char* non_partial = any_mangled_name(reach, "C", "safe", &opt);
+  const char* partial = any_mangled_name(reach, "C", "risky", &opt);
 
   ASSERT_NE(non_partial, (void*)NULL);
   ASSERT_NE(partial, (void*)NULL);

--- a/test/libponyc/scope.cc
+++ b/test/libponyc/scope.cc
@@ -340,7 +340,7 @@ TEST_F(ScopeTest, Use)
   // Use imported types go in the module symbol table
   ast_t* module = find_sub_tree(ast, TK_MODULE);
   symtab_t* module_symtab = ast_get_symtab(module);
-  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab("Foo"), NULL));
+  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab(opt.strtab, "Foo"), NULL));
 }
 
 
@@ -361,8 +361,8 @@ TEST_F(ScopeTest, UseAs)
   // Use imported types go in the module symbol table
   ast_t* module = find_sub_tree(ast, TK_MODULE);
   symtab_t* module_symtab = ast_get_symtab(module);
-  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab("bar"), NULL));
-  ASSERT_EQ((void*)NULL, symtab_find(module_symtab, stringtab("Foo"), NULL));
+  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab(opt.strtab, "bar"), NULL));
+  ASSERT_EQ((void*)NULL, symtab_find(module_symtab, stringtab(opt.strtab, "Foo"), NULL));
 }
 
 
@@ -383,7 +383,7 @@ TEST_F(ScopeTest, UseConditionTrue)
   // Use imported types go in the module symbol table
   ast_t* module = find_sub_tree(ast, TK_MODULE);
   symtab_t* module_symtab = ast_get_symtab(module);
-  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab("Foo"), NULL));
+  ASSERT_NE((void*)NULL, symtab_find(module_symtab, stringtab(opt.strtab, "Foo"), NULL));
 }
 
 
@@ -404,6 +404,6 @@ TEST_F(ScopeTest, UseConditionFalse)
   // Nothing should be imported
   ast_t* module = find_sub_tree(ast, TK_MODULE);
   symtab_t* module_symtab = ast_get_symtab(module);
-  ASSERT_EQ((void*)NULL, symtab_find(module_symtab, stringtab("Foo"), NULL));
+  ASSERT_EQ((void*)NULL, symtab_find(module_symtab, stringtab(opt.strtab, "Foo"), NULL));
 }
 */

--- a/test/libponyc/symtab.cc
+++ b/test/libponyc/symtab.cc
@@ -6,108 +6,138 @@
 #include <ast/stringtab.h>
 
 class SymtabTest: public testing::Test
-{};
+{
+protected:
+  strtable_t* tab;
+
+  void SetUp() override { tab = stringtab_new(); }
+  void TearDown() override { stringtab_free(tab); }
+};
 
 
-TEST(SymtabTest, AddGet)
+TEST_F(SymtabTest, AddGet)
 {
   symtab_t* symtab = symtab_new();
 
-  ASSERT_TRUE(symtab_add(symtab, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab("foo"), NULL));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab(tab, "foo"), NULL));
 
   symtab_free(symtab);
 }
 
 
-TEST(SymtabTest, InitiallyNotPresent)
+TEST_F(SymtabTest, InitiallyNotPresent)
 {
   symtab_t* symtab = symtab_new();
 
-  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab, stringtab("foo"), NULL));
+  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab, stringtab(tab, "foo"), NULL));
 
   symtab_free(symtab);
 }
 
 
-TEST(SymtabTest, RepeatAddBlocked)
+TEST_F(SymtabTest, RepeatAddBlocked)
 {
   symtab_t* symtab = symtab_new();
 
-  ASSERT_TRUE(symtab_add(symtab, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_FALSE(symtab_add(symtab, stringtab("foo"), (ast_t*)15, SYM_NONE));
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab("foo"), NULL));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_FALSE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)15, SYM_NONE, tab));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab(tab, "foo"), NULL));
 
   symtab_free(symtab);
 }
 
 
-TEST(SymtabTest, AddAfterGetFail)
+TEST_F(SymtabTest, AddAfterGetFail)
 {
   symtab_t* symtab = symtab_new();
 
-  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab, stringtab("foo"), NULL));
-  ASSERT_TRUE(symtab_add(symtab, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab("foo"), NULL));
+  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab, stringtab(tab, "foo"), NULL));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab(tab, "foo"), NULL));
 
   symtab_free(symtab);
 }
 
 
-TEST(SymtabTest, Multiple)
+TEST_F(SymtabTest, Multiple)
 {
   symtab_t* symtab = symtab_new();
 
-  ASSERT_TRUE(symtab_add(symtab, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_TRUE(symtab_add(symtab, stringtab("bar"), (ast_t*)15, SYM_NONE));
-  ASSERT_TRUE(symtab_add(symtab, stringtab("wombat"), (ast_t*)16, SYM_NONE));
-  ASSERT_FALSE(symtab_add(symtab, stringtab("foo"), (ast_t*)17, SYM_NONE));
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab("foo"), NULL));
-  ASSERT_EQ((ast_t*)15, symtab_find(symtab, stringtab("bar"), NULL));
-  ASSERT_EQ((ast_t*)16, symtab_find(symtab, stringtab("wombat"), NULL));
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab("foo"), NULL));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "bar"), (ast_t*)15, SYM_NONE, tab));
+  ASSERT_TRUE(symtab_add(symtab, stringtab(tab, "wombat"), (ast_t*)16, SYM_NONE, tab));
+  ASSERT_FALSE(symtab_add(symtab, stringtab(tab, "foo"), (ast_t*)17, SYM_NONE, tab));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab(tab, "foo"), NULL));
+  ASSERT_EQ((ast_t*)15, symtab_find(symtab, stringtab(tab, "bar"), NULL));
+  ASSERT_EQ((ast_t*)16, symtab_find(symtab, stringtab(tab, "wombat"), NULL));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab, stringtab(tab, "foo"), NULL));
 
   symtab_free(symtab);
 }
 
 
-TEST(SymtabTest, TwoTables)
+TEST_F(SymtabTest, TwoTables)
 {
   symtab_t* symtab1 = symtab_new();
   symtab_t* symtab2 = symtab_new();
 
-  ASSERT_TRUE(symtab_add(symtab1, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_TRUE(symtab_add(symtab2, stringtab("bar"), (ast_t*)15, SYM_NONE));
+  ASSERT_TRUE(symtab_add(symtab1, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_TRUE(symtab_add(symtab2, stringtab(tab, "bar"), (ast_t*)15, SYM_NONE, tab));
 
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab("foo"), NULL));
-  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab1, stringtab("bar"), NULL));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab(tab, "foo"), NULL));
+  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab1, stringtab(tab, "bar"), NULL));
 
-  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab2, stringtab("foo"), NULL));
-  ASSERT_EQ((ast_t*)15, symtab_find(symtab2, stringtab("bar"), NULL));
+  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab2, stringtab(tab, "foo"), NULL));
+  ASSERT_EQ((ast_t*)15, symtab_find(symtab2, stringtab(tab, "bar"), NULL));
 
   symtab_free(symtab1);
   symtab_free(symtab2);
 }
 
 
-TEST(SymtabTest, Merge)
+TEST_F(SymtabTest, Merge)
 {
   symtab_t* symtab1 = symtab_new();
   symtab_t* symtab2 = symtab_new();
 
-  ASSERT_TRUE(symtab_add(symtab1, stringtab("foo"), (ast_t*)14, SYM_NONE));
-  ASSERT_TRUE(symtab_add(symtab2, stringtab("bar"), (ast_t*)15, SYM_NONE));
+  ASSERT_TRUE(symtab_add(symtab1, stringtab(tab, "foo"), (ast_t*)14, SYM_NONE, tab));
+  ASSERT_TRUE(symtab_add(symtab2, stringtab(tab, "bar"), (ast_t*)15, SYM_NONE, tab));
 
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab("foo"), NULL));
-  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab1, stringtab("bar"), NULL));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab(tab, "foo"), NULL));
+  ASSERT_EQ((ast_t*)NULL, symtab_find(symtab1, stringtab(tab, "bar"), NULL));
 
-  ASSERT_TRUE(symtab_merge_public(symtab1, symtab2));
+  ASSERT_TRUE(symtab_merge_public(symtab1, symtab2, tab));
 
-  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab("foo"), NULL));
-  ASSERT_EQ((ast_t*)15, symtab_find(symtab2, stringtab("bar"), NULL));
+  ASSERT_EQ((ast_t*)14, symtab_find(symtab1, stringtab(tab, "foo"), NULL));
+  ASSERT_EQ((ast_t*)15, symtab_find(symtab2, stringtab(tab, "bar"), NULL));
 
-  ASSERT_FALSE(symtab_merge_public(symtab1, symtab2));
+  ASSERT_FALSE(symtab_merge_public(symtab1, symtab2, tab));
 
   symtab_free(symtab1);
   symtab_free(symtab2);
+}
+
+
+// Interning into the same table is stable: equal strings get one canonical
+// pointer. This underpins the symtab's pointer-identity comparisons.
+TEST_F(SymtabTest, StringtabSameTableInternsStable)
+{
+  ASSERT_EQ(stringtab(tab, "foo"), stringtab(tab, "foo"));
+  ASSERT_NE(stringtab(tab, "foo"), stringtab(tab, "bar"));
+}
+
+
+// Each table is independent: interning the same content into two different
+// tables yields distinct pointers. This is the core property of the move off a
+// process-global table (issue #5273) — a regression to a shared/global table
+// would make these pointers equal.
+TEST_F(SymtabTest, StringtabTablesAreIndependent)
+{
+  strtable_t* tab2 = stringtab_new();
+
+  ASSERT_NE(stringtab(tab, "foo"), stringtab(tab2, "foo"));
+  ASSERT_EQ(stringtab(tab2, "foo"), stringtab(tab2, "foo"));
+
+  stringtab_free(tab2);
 }

--- a/test/libponyc/token.cc
+++ b/test/libponyc/token.cc
@@ -2,12 +2,13 @@
 #include <platform.h>
 
 #include <ast/token.h>
+#include <ast/stringtab.h>
 #include "../../src/libponyrt/mem/pool.h"
 
 
 #define TEST_TOKEN_PRINT_ESCAPED(str, str_len, expected) \
   { token_t* token = token_new(TK_STRING); \
-    token_set_string(token, str, str_len); \
+    token_set_string(token, str, str_len, tab); \
     char* escaped = token_print_escaped(token); \
     EXPECT_TRUE(strcmp(expected, escaped) == 0) \
       << "Actual escaped string: " << escaped; \
@@ -16,10 +17,15 @@
 
 
 class TokenTest: public testing::Test
-{};
+{
+protected:
+  strtable_t* tab;
+  void SetUp() override { tab = stringtab_new(); }
+  void TearDown() override { stringtab_free(tab); }
+};
 
 
-TEST(TokenTest, PrintEscapedString)
+TEST_F(TokenTest, PrintEscapedString)
 {
   TEST_TOKEN_PRINT_ESCAPED(
     "foo", 3,
@@ -27,7 +33,7 @@ TEST(TokenTest, PrintEscapedString)
 }
 
 
-TEST(TokenTest, PrintEscapedStringContainingDoubleQuotes)
+TEST_F(TokenTest, PrintEscapedStringContainingDoubleQuotes)
 {
   TEST_TOKEN_PRINT_ESCAPED(
     "foo\"bar\"baz", 11,
@@ -35,7 +41,7 @@ TEST(TokenTest, PrintEscapedStringContainingDoubleQuotes)
 }
 
 
-TEST(TokenTest, PrintEscapedStringContainingBackslashes)
+TEST_F(TokenTest, PrintEscapedStringContainingBackslashes)
 {
   TEST_TOKEN_PRINT_ESCAPED(
     "foo\\bar\\baz", 11,
@@ -43,7 +49,7 @@ TEST(TokenTest, PrintEscapedStringContainingBackslashes)
 }
 
 
-TEST(TokenTest, PrintEscapedStringContainingNullBytes)
+TEST_F(TokenTest, PrintEscapedStringContainingNullBytes)
 {
   TEST_TOKEN_PRINT_ESCAPED(
     "foo\0bar\0baz", 11,

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -582,12 +582,12 @@ TEST_F(SubTypeTest, IsSubTypeNosupertypeInterface)
 
   TEST_COMPILE(src);
 
-  pass_opt_t opt;
-  pass_opt_init(&opt);
-
+  // Use the same pass_opt (and so the same interned-string table) that compiled
+  // the code. is_subtype checks the `nosupertype` annotation by interning that
+  // name and comparing it by pointer identity against the annotation already on
+  // the AST. A fresh pass_opt would have a different table, so the comparison
+  // would never match.
   ASSERT_FALSE(is_subtype(type_of("p"), type_of("a"), NULL, &opt));
-
-  pass_opt_init(&opt);
 }
 
 

--- a/test/libponyc/userflags.cc
+++ b/test/libponyc/userflags.cc
@@ -2,13 +2,19 @@
 #include <platform.h>
 
 #include <pkg/buildflagset.h>
+#include <ast/stringtab.h>
 
 class UserFlagsTest: public testing::Test
-{};
-
-TEST(UserFlagsTest, UserFlagNoneDefined)
 {
-  userflags_t* flags = userflags_create();
+protected:
+  strtable_t* tab;
+  void SetUp() override { tab = stringtab_new(); }
+  void TearDown() override { stringtab_free(tab); }
+};
+
+TEST_F(UserFlagsTest, UserFlagNoneDefined)
+{
+  userflags_t* flags = userflags_create(tab);
 
   define_userflag(flags, "foo");
   clear_userflags(flags);
@@ -17,9 +23,9 @@ TEST(UserFlagsTest, UserFlagNoneDefined)
 }
 
 
-TEST(UserFlagsTest, UserFlagDefined)
+TEST_F(UserFlagsTest, UserFlagDefined)
 {
-  userflags_t* flags = userflags_create();
+  userflags_t* flags = userflags_create(tab);
   define_userflag(flags, "foo");
 
   ASSERT_TRUE(is_userflag_defined(flags, "foo"));
@@ -27,9 +33,9 @@ TEST(UserFlagsTest, UserFlagDefined)
 }
 
 
-TEST(UserFlagsTest, UserFlagNotDefined)
+TEST_F(UserFlagsTest, UserFlagNotDefined)
 {
-  userflags_t* flags = userflags_create();
+  userflags_t* flags = userflags_create(tab);
   define_userflag(flags, "foo");
 
   ASSERT_TRUE(is_userflag_defined(flags, "foo"));
@@ -38,9 +44,9 @@ TEST(UserFlagsTest, UserFlagNotDefined)
 }
 
 
-TEST(UserFlagsTest, UserFlagCaseSensitive)
+TEST_F(UserFlagsTest, UserFlagCaseSensitive)
 {
-  userflags_t* flags = userflags_create();
+  userflags_t* flags = userflags_create(tab);
   define_userflag(flags, "foo");
 
   ASSERT_TRUE(is_userflag_defined(flags, "foo"));
@@ -49,9 +55,9 @@ TEST(UserFlagsTest, UserFlagCaseSensitive)
 }
 
 
-TEST(UserFlagsTest, UserFlagMultiple)
+TEST_F(UserFlagsTest, UserFlagMultiple)
 {
-  userflags_t* flags = userflags_create();
+  userflags_t* flags = userflags_create(tab);
   define_userflag(flags, "foo");
   define_userflag(flags, "BAR");
   define_userflag(flags, "Wombat");

--- a/test/libponyc/util.cc
+++ b/test/libponyc/util.cc
@@ -332,7 +332,7 @@ size_t PassTest::ref_count(ast_t* ast, const char* name)
   size_t count = 0;
   symtab_t* symtab = ast_get_symtab(ast);
 
-  if(symtab != NULL && symtab_find(symtab, stringtab(name), NULL) != NULL)
+  if(symtab != NULL && symtab_find(symtab, stringtab(opt.strtab, name), NULL) != NULL)
     count = 1;
 
   for(ast_t* p = ast_child(ast); p != NULL; p = ast_sibling(p))
@@ -488,7 +488,7 @@ ast_t* PassTest::lookup_in(ast_t* ast, const char* name)
   symtab_t* symtab = ast_get_symtab(ast);
   pony_assert(symtab != NULL);
 
-  return symtab_find(symtab, stringtab(name), NULL);
+  return symtab_find(symtab, stringtab(opt.strtab, name), NULL);
 }
 
 
@@ -552,7 +552,7 @@ void PassTest::build_package(const char* pass, const char* src,
     package_add_magic_src(package_name, src, &opt);
 
     limit_passes(&opt, pass);
-    program = program_load(stringtab(package_name), &opt);
+    program = program_load(stringtab(opt.strtab, package_name), &opt);
 
     if((program != NULL) && (opt.limit >= PASS_REACH))
     {

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_definition_resolver.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_definition_resolver.pony
@@ -23,7 +23,7 @@ primitive DefinitionResolver
     if ptr.is_null() then
       [as AST:]
     else
-      [AST(ptr)]
+      [AST(ptr, ast.strtab)]
     end
 
   fun _find_in_type(ttype: AST, name: String box, result: Array[AST]): Array[AST] ? =>

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_source.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_source.pony
@@ -1,4 +1,4 @@
-use @source_open[NullablePointer[_Source]](file: Pointer[U8] tag, error_msgp: NullablePointer[Pointer[U8]])
+use @source_open[NullablePointer[_Source]](file: Pointer[U8] tag, error_msgp: NullablePointer[Pointer[U8]], strtab: Pointer[_StrTable] tag)
 use @source_open_string[NullablePointer[_Source]](source_code: Pointer[U8] tag)
 use @source_close[None](source: _Source)
 

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_stringtab.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_stringtab.pony
@@ -1,32 +1,30 @@
-use @stringtab_init[None]()
-use @stringtab_done[None]()
+use @stringtab_len[Pointer[U8] ref](table: Pointer[_StrTable] tag,
+  string: Pointer[U8] tag, len: USize)
 
-use @stringtab[Pointer[U8] ref](string: Pointer[U8] tag)
-use @stringtab_len[Pointer[U8] ref](string: Pointer[U8] tag, len: USize)
+// Free an interned-string table. Takes the table pointer by value, so it is
+// callable from a box receiver (e.g. Program._final), unlike pass_opt_done
+// which needs a ref _PassOpt.
+use @stringtab_free[None](table: Pointer[_StrTable] tag)
 
 
 primitive StringTab
   """
-  The pony string table for interned strings during compilation.
+  Interns a string into a specific compilation's interned-string table.
+
+  libponyc no longer keeps a process-global table: each compilation owns its
+  table (pass_opt.strtab), so interning a query name for an AST lookup must use
+  that same table for the resulting pointer to match the names already interned
+  in the AST. Pass the `strtab` carried by the `AST` you are querying.
   """
-  fun _init() =>
-    @stringtab_init()
-
-  fun _final() =>
-    @stringtab_done()
-
-  fun apply(string: String box): String val =>
+  fun apply(table: Pointer[_StrTable] tag, string: String box): String val =>
     """
-    Stores the given string in the stringtab if it is not yet stored.
-    And returns a reference to the stored string.
-    This string will live as long as the primitive (the whole program lifetime
-    usually).
-
-    Might only fail if we can't alloc anything anymore.
+    Interns the given string into the given table and returns a reference to the
+    stored copy. The returned string lives as long as the table does (until its
+    pass_opt is disposed).
     """
     let len = string.size()
     let str_ptr = string.cpointer()
     recover
-      let ptr = @stringtab_len(str_ptr, len)
+      let ptr = @stringtab_len(table, str_ptr, len)
       String.from_cpointer(ptr, len)
     end

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
@@ -1,7 +1,7 @@
 use @symtab_new[Pointer[_Symtab] ref]()
 use @symtab_free[None](symtab: Pointer[_Symtab] box) // box is needed as this is
 // called in a finalizer
-use @symtab_add[Bool](symtab: Pointer[_Symtab] ref, name: Pointer[U8] tag, def: Pointer[_AST] box, status: NullablePointer[SymStatus])
+use @symtab_add[Bool](symtab: Pointer[_Symtab] ref, name: Pointer[U8] tag, def: Pointer[_AST] box, status: NullablePointer[SymStatus], strtab: Pointer[_StrTable] tag)
 use @symtab_find[Pointer[_AST] val](symtab: Pointer[_Symtab] box, name: Pointer[U8] tag, status: NullablePointer[SymStatus])
 use @symtab_init[None](symtab: Pointer[_Symtab] ref, size: USize)
 use @symtab_destroy[None](symtab: Pointer[_Symtab] ref)
@@ -68,15 +68,20 @@ primitive SymStati
 
 class ref SymbolTable
   let ptr: Pointer[_Symtab]
+  // Interned-string table of the owning compilation, carried so AST nodes
+  // looked up here can be wrapped with the same table (see AST.strtab).
+  let strtab: Pointer[_StrTable] tag
   let _owned_alloc: Bool
 
-  new from_pointer(ptr': Pointer[_Symtab]) =>
+  new from_pointer(ptr': Pointer[_Symtab], strtab': Pointer[_StrTable] tag) =>
     ptr = ptr'
+    strtab = strtab'
     _owned_alloc = false
 
-  new iso create(size': USize = 0) =>
+  new iso create(strtab': Pointer[_StrTable] tag, size': USize = 0) =>
     ptr = @symtab_new()
     @symtab_init(ptr, size')
+    strtab = strtab'
     _owned_alloc = true
 
   fun box apply(name: String box): (AST | None) =>
@@ -85,7 +90,7 @@ class ref SymbolTable
     if ptr'.is_null() then
       None
     else
-      AST(ptr')
+      AST(ptr', strtab)
     end
 
   fun box size(): USize =>
@@ -131,4 +136,4 @@ class _SymbolTableIter[S: SymbolTable #read] is Iterator[(String, AST)]
       recover val
         String.copy_cstring(symbol.name)
       end
-    (symbol_name, AST(symbol.def))
+    (symbol_name, AST(symbol.def, _table.strtab))

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
@@ -22,7 +22,7 @@ use @ast_name[Pointer[U8] val](ast: Pointer[_AST] box)
 use @ast_name_len[USize](ast: Pointer[_AST] box)
 use @ast_nice_name[Pointer[U8] val](ast: Pointer[_AST] box)
 use @ast_type[Pointer[_AST] val](ast: Pointer[_AST] box)
-use @ast_print_type[Pointer[U8] val](ast: Pointer[_AST] box)
+use @ast_print_type[Pointer[U8] val](ast: Pointer[_AST] box, strtab: Pointer[_StrTable] tag)
 use @ast_print[Pointer[U8] val](ast: Pointer[_AST] box, width: USize)
 // mark the given AST as having its own scope
 //use @ast_scope[None](ast: _AST ref)
@@ -37,7 +37,7 @@ use @ast_childidx[Pointer[_AST] val](ast: Pointer[_AST] box, idx: USize)
 use @ast_childcount[USize](ast: Pointer[_AST] box)
 use @ast_data[Pointer[None]](ast: Pointer[_AST] box)
 use @ast_index[USize](ast: Pointer[_AST] box)
-use @ast_has_annotation[Bool](ast: Pointer[_AST] box, name: Pointer[U8] tag)
+use @ast_has_annotation[Bool](ast: Pointer[_AST] box, name: Pointer[U8] tag, strtab: Pointer[_StrTable] tag)
 use @ast_get_print[Pointer[U8] val](ast: Pointer[_AST] box)
 
 
@@ -51,9 +51,16 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
   Wraps the C-type `*ast_t`.
   """
   let raw: Pointer[_AST] val
+  // Interned-string table of the compilation this node belongs to. Needed to
+  // intern query names (for ast_get / has_annotation) into the same table the
+  // AST was built with, so pointer-identity lookups match. Travels with the
+  // node through navigation. Must stay valid as long as this AST is used, which
+  // the owning Program/CompileSession guarantees by keeping its pass_opt alive.
+  let strtab: Pointer[_StrTable] tag
 
-  new val create(ast': Pointer[_AST] val) =>
+  new val create(ast': Pointer[_AST] val, strtab': Pointer[_StrTable] tag) =>
     raw = ast'
+    strtab = strtab'
 
   fun box id(): TokenId =>
     @ast_id(raw)
@@ -89,7 +96,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if sibl.is_null() then
       None
     else
-      AST(sibl)
+      AST(sibl, strtab)
     end
 
   fun box prev(): (AST | None) =>
@@ -97,7 +104,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if p.is_null() then
       None
     else
-      AST(p)
+      AST(p, strtab)
     end
 
   fun box first_sibling(): (AST | None) =>
@@ -113,7 +120,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if c.is_null() then
       None
     else
-      AST(c)
+      AST(c, strtab)
     end
 
   fun box last_child(): (AST | None ) =>
@@ -121,7 +128,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if lc.is_null() then
       None
     else
-      AST(lc)
+      AST(lc, strtab)
     end
 
   fun box apply(child_idx: USize): AST ? =>
@@ -132,7 +139,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if ci.is_null() then
       error
     else
-      AST(ci)
+      AST(ci, strtab)
     end
 
   fun box parent(): (AST | None) =>
@@ -140,7 +147,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if p.is_null() then
       None
     else
-      AST(p)
+      AST(p, strtab)
     end
 
   fun box num_parents(): USize =>
@@ -172,7 +179,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     Returns true if this AST node has the given annotation.
     Used for checking `\nodoc\` and similar annotations.
     """
-    @ast_has_annotation(raw, name.cstring())
+    @ast_has_annotation(raw, name.cstring(), strtab)
 
   fun box get_print(): String val =>
     """
@@ -260,7 +267,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if t.is_null() then
       None
     else
-      AST(t)
+      AST(t, strtab)
     end
 
   fun ast_type_string(): (String | None) =>
@@ -270,7 +277,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     """
     try
       let type_ast = ast_type() as AST
-      let type_str_ptr = @ast_print_type(type_ast.raw)
+      let type_str_ptr = @ast_print_type(type_ast.raw, type_ast.strtab)
       recover val String.copy_cstring(type_str_ptr) end
     end
 
@@ -278,7 +285,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     """
     Prints this AST node representing a type. e.g. obtained with `ast_type()`
     """
-    let type_str_ptr = @ast_print_type(raw)
+    let type_str_ptr = @ast_print_type(raw, strtab)
     recover val String.copy_cstring(type_str_ptr) end
 
   fun box infix_node(): Bool =>
@@ -320,11 +327,11 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     If all you want to do is searching the scope of this node alone,
     not traversing upwards into parent scopes, have a look at `find_in_scope`.
     """
-    let ptr = @ast_get(raw, StringTab(name).cstring(), NullablePointer[SymStatus].none())
+    let ptr = @ast_get(raw, StringTab(strtab, name).cstring(), NullablePointer[SymStatus].none())
     if ptr.is_null() then
       None
     else
-      AST(ptr)
+      AST(ptr, strtab)
     end
 
   // TODO: reason about the proper return type cap
@@ -336,7 +343,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     if ptr.is_null() then
       None
     else
-      SymbolTable.from_pointer(ptr)
+      SymbolTable.from_pointer(ptr, strtab)
     end
 
   fun box find_in_scope(name: String box): (AST | None) =>
@@ -345,7 +352,7 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     """
     try
       let scope = this.symbol_table() as SymbolTable
-      let interned_name = StringTab(name)
+      let interned_name = StringTab(strtab, name)
       scope(interned_name)
     end
 

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/compile_session.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/compile_session.pony
@@ -60,7 +60,7 @@ class CompileSession
       if _raw.is_null() then
         None
       else
-        Program.create(AST(_raw))
+        Program.create(AST(_raw, _pass_opt.strtab))
       end
 
   fun program(): (Program val | None) =>
@@ -105,5 +105,15 @@ class CompileSession
       _disposed = true
       @package_done(_pass_opt)
       @codegen_pass_cleanup(_pass_opt)
+      // If a Program was produced, it owns the interned-string table and frees
+      // it in its _final, so detach it here before pass_opt_done so the table
+      // is not freed while the Program's AST still references its strings. (It
+      // is held by the AST until then; resumable passes (continue_to) needed it
+      // on the pass_opt, which is why this happens at dispose rather than at
+      // creation.) If compilation failed there is no Program to own it, so
+      // leave it attached and let pass_opt_done free it, else it would leak.
+      match _program
+      | let _: Program val => _pass_opt.strtab = Pointer[_StrTable]
+      end
       @pass_opt_done(_pass_opt)
     end

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/compiler.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/compiler.pony
@@ -63,7 +63,12 @@ primitive Compiler
             end
           end
         else
-          Program.create(AST(program_ast))
+          let p = Program.create(AST(program_ast, pass_opt.strtab))
+          // Hand the interned-string table to the Program (it frees it in
+          // _final). Detach it from the pass_opt so pass_opt_done below does
+          // not free it while the returned AST still references its strings.
+          pass_opt.strtab = Pointer[_StrTable]
+          p
         end
 
     @package_done(pass_opt)

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
@@ -43,6 +43,9 @@ primitive _MagicPackage
 primitive _Plugins
   """STUB"""
 
+struct _StrTable
+  """Opaque mirror of libponyc's strtable_t (the interned-string table)."""
+
 struct _PassOpt
   var limit: I32 = PassParse()
   var programm_pass: I32 = PassParse()
@@ -78,7 +81,8 @@ struct _PassOpt
   var link_ldcmd: Pointer[U8] ref = link_ldcmd.create()
   var sysroot: Pointer[U8] ref = sysroot.create()
 
-  // this field is only present in debug builds
+  // Mirrors pass_opt_t.llvm_args (pass.h), which is unconditional; this field
+  // must stay present in all builds to keep the struct layout matching C.
   var llvm_args: Pointer[U8] val = recover val llvm_args.create() end
 
   var triple: Pointer[U8] ref = triple.create()
@@ -91,5 +95,9 @@ struct _PassOpt
   var userflags: Pointer[_UserFlags] ref = userflags.create()
     """user-provided defines"""
   var data: Pointer[None] ref = data.create() // user-defined data for unit test callbacks
+  // Interned-string table for this compilation. Mirrors the strtab field
+  // appended to pass_opt_t (src/libponyc/pass/pass.h); kept last so the offsets
+  // of every field above are unchanged.
+  var strtab: Pointer[_StrTable] ref = strtab.create()
 
   new ref create() => None

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/program.pony
@@ -51,6 +51,13 @@ class val Program
     Package.create(this, package_ast)?
 
   fun _final() =>
+    // The Program owns both the AST and its interned-string table. The table
+    // is detached from the pass_opt at construction time (so pass_opt_done does
+    // not free it while the AST is still in use) and freed here, once the AST
+    // that references its interned strings is gone.
     if not ast.raw.is_null() then
       @ast_free(ast.raw)
+    end
+    if not ast.strtab.is_null() then
+      @stringtab_free(ast.strtab)
     end

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/types.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/types.pony
@@ -10,7 +10,7 @@ primitive Types
       | TokenIds.tk_letref() | TokenIds.tk_varref() | TokenIds.tk_match_capture() =>
         let def: Pointer[_AST] val = @ast_data[Pointer[_AST] val](ast.raw)
         if not def.is_null() then
-          AST(def).ast_type_string()
+          AST(def, ast.strtab).ast_type_string()
         end
       | TokenIds.tk_beref() =>
         // hard-coding to implicit return type of a behavior

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/userflags.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/userflags.pony
@@ -1,4 +1,4 @@
-use @userflags_create[Pointer[_UserFlags] val]()
+use @userflags_create[Pointer[_UserFlags] val](strtab: Pointer[_StrTable] tag)
 use @userflags_free[None](userflags: Pointer[_UserFlags] box)
 use @define_userflag[Bool](userflags: Pointer[_UserFlags] box, name: Pointer[U8] tag)
 use @is_userflag_defined[Bool](userflags: Pointer[_UserFlags] box, name: Pointer[U8] tag)

--- a/tools/pony-lsp/workspace/_resolve_ast_target.pony
+++ b/tools/pony-lsp/workspace/_resolve_ast_target.pony
@@ -68,8 +68,8 @@ primitive _ResolveASTTarget
     let defs = node'.definitions()
     if defs.size() > 0 then
       try
-        AST(defs(0)?.raw)
+        AST(defs(0)?.raw, defs(0)?.strtab)
       end
     else
-      AST(node'.raw)
+      AST(node'.raw, node'.strtab)
     end

--- a/tools/pony-lsp/workspace/call_hierarchy.pony
+++ b/tools/pony-lsp/workspace/call_hierarchy.pony
@@ -102,7 +102,7 @@ primitive CallHierarchy
     let nid = node.id()
 
     if _is_method(nid) then
-      result.push(AST(node.raw))
+      result.push(AST(node.raw, node.strtab))
       return result
     end
 
@@ -355,7 +355,7 @@ class ref _IncomingCallCollector is ASTVisitor
       var cur = node.parent() as AST box
       while true do
         if CallHierarchy._is_method(cur.id()) then
-          return AST(cur.raw)
+          return AST(cur.raw, cur.strtab)
         end
         cur = cur.parent() as AST box
       end

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -93,12 +93,12 @@ primitive DocumentHighlights
     let target: AST val =
       if defs.size() > 0 then
         try
-          AST(defs(0)?.raw)
+          AST(defs(0)?.raw, defs(0)?.strtab)
         else
           return []
         end
       else
-        AST(node'.raw)
+        AST(node'.raw, node'.strtab)
       end
 
     let collector = _HighlightCollector(target)


### PR DESCRIPTION
libponyc kept interned strings in a single process-global hashmap with no synchronization. That is safe for the `ponyc` executable (single front-end thread) but not when multiple compilations run concurrently in one process, as pony-lsp does — concurrent interning could insert duplicate entries that collapse on a table resize and trip an assertion, intermittently crashing the compiler (the language-server crashes in #5154).

The interned-string table now lives in `pass_opt_t`: each compilation owns its own, created in `pass_opt_init` and freed in `pass_opt_done`, threaded explicitly to every interning site. Concurrent compilations no longer share mutable state, and a long-running host reclaims a compilation's strings when it ends rather than holding them for the process's life.

Error messages no longer go through the table (they are never compared by identity, so they become owned copies freed with the error). The buildflagset platform-flag cache and the macOS SDK-path cache — also process-global interned state — are de-globalised the same way.

The pony_compiler tooling library (pony-lsp, pony-lint, pony-doc) is updated to match: the `pass_opt_t` mirror and FFI bindings carry the table, the `AST` wrapper carries it so post-compile lookups intern into the right table, and the `Program` owns the table and frees it once its AST is no longer used.

Closes #5273