### PR TITLE
Extend alias.c arrow type short-circuit to box and tag

### DIFF
--- a/src/libponyc/type/alias.c
+++ b/src/libponyc/type/alias.c
@@ -287,13 +287,22 @@ ast_t* alias(ast_t* type, pass_opt_t* opt)
       // parameter, and stays the same.
       AST_GET_CHILDREN(type, left, right);
 
-      // A val viewpoint produces only val or tag results for any right-hand
-      // type, and both alias to themselves. Aliasing inside the arrow would
-      // give val->(A!) which differs from (val->A)! when A=iso:
-      // val->(iso!) = val->tag = tag, but (val->iso)! = val! = val.
-      // Return the arrow unchanged to avoid this over-conservative result.
-      if(ast_id(left) == TK_VAL)
-        return type;
+      // For val, box, and tag viewpoints, K->A is self-aliasing for every
+      // instantiation of A, so alias(K->A) = K->A and the arrow is returned
+      // unchanged. These viewpoints yield only self-aliasing caps: val yields
+      // val, tag, or #share; box yields those plus box; tag yields only tag.
+      // Aliasing inside the arrow instead gives K->(A!), an over-conservative
+      // result: e.g. for val with A=iso, val->(iso!) = val->tag = tag, but the
+      // correct (val->iso)! = val! = val.
+      switch(ast_id(left))
+      {
+        case TK_VAL:
+        case TK_BOX:
+        case TK_TAG:
+          return type;
+
+        default: {}
+      }
 
       BUILD(r_type, type,
         NODE(TK_ARROW,

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(libponyc.tests VERSION ${PONYC_PROJECT_VERSION} LANGUAGES C CXX)
 
 add_executable(libponyc.tests
+    alias.cc
     annotations.cc
     array.cc
     badpony.cc

--- a/test/libponyc/alias.cc
+++ b/test/libponyc/alias.cc
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+#include <type/alias.h>
+#include <type/cap.h>
+#include <ast/ast.h>
+
+#include "util.h"
+
+
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+
+
+class AliasTest : public PassTest
+{
+protected:
+  // Alias the arrow type of the named parameter and assert how its right side
+  // was treated. short_circuit == true means alias() must return the input
+  // node unchanged with an un-aliased right side (K->A); short_circuit ==
+  // false means it must return a fresh arrow whose right side is aliased
+  // (K->(A!)). Uses ASSERT, so wrap calls in DO().
+  void check_arrow_alias(const char* name, bool short_circuit)
+  {
+    ast_t* type = type_of(name);
+    // Guard the setup: a NULL or non-arrow type would otherwise make the
+    // un-aliased assertion below pass vacuously.
+    ASSERT_NE((void*)NULL, type);
+    ASSERT_EQ(TK_ARROW, ast_id(type));
+
+    ast_t* aliased = alias(type, &opt);
+    token_id eph = ast_id(ast_sibling(cap_fetch(ast_childidx(aliased, 1))));
+
+    if(short_circuit)
+    {
+      // The arrow is returned unchanged: the same node, right side unmarked.
+      ASSERT_EQ(type, aliased);
+      ASSERT_EQ(TK_NONE, eph);
+    }
+    else
+    {
+      // A fresh arrow whose right side carries the alias marker. Free it so the
+      // unattached node doesn't leak.
+      ASSERT_NE(type, aliased);
+      ASSERT_EQ(TK_ALIASED, eph);
+      ast_free_unattached(aliased);
+    }
+  }
+};
+
+
+// alias() of an arrow type K->A normally aliases the right side, producing
+// K->(A!). For viewpoints that are self-aliasing for every instantiation of
+// A, that is over-conservative: alias(K->A) should be K->A, so the arrow is
+// returned unchanged. A val viewpoint yields val, tag, or #share, a box
+// viewpoint those plus box, and a tag viewpoint only tag; all alias to
+// themselves. iso, trn, and ref viewpoints can yield a non-self-aliasing cap
+// (e.g. ref->iso = iso), so they must still alias the right side.
+//
+// The short-circuit is not observable through ordinary compilation: box->A
+// and box->A! already compare as mutual subtypes (box is see-through, so both
+// reify to equal concrete caps), and tag->A arrow types are independently
+// blocked from binding/return by an unrelated ephemeral subtype check. These
+// tests therefore guard the alias() behaviour directly at the source. See
+// issue #4969 and the val precedent in #4963.
+
+// Each arrow type is exposed via an interface method parameter (the canonical
+// pattern from type_check_subtype.cc / subtype_cache.cc): every parameter has
+// a unique name and a typed annotation, so type_of(name) returns one
+// well-defined arrow AST per call.
+static const char* TEST_SRC =
+  "interface Test[A]\n"
+  "  fun z(a_iso: iso->A, a_trn: trn->A, a_ref: ref->A,\n"
+  "        a_val: val->A, a_box: box->A, a_tag: tag->A)";
+
+
+// val, box, and tag viewpoints are self-aliasing, so alias() leaves the
+// arrow's right side unmarked.
+TEST_F(AliasTest, ArrowSelfAliasingViewpointShortCircuits)
+{
+  TEST_COMPILE(TEST_SRC);
+
+  DO(check_arrow_alias("a_val", true));
+  DO(check_arrow_alias("a_box", true));
+  DO(check_arrow_alias("a_tag", true));
+}
+
+
+// iso, trn, and ref viewpoints can produce a non-self-aliasing cap, so alias()
+// must still alias the right side. This is also the positive control for the
+// test above: it confirms alias() does mark the right side when it should, so
+// the unmarked results for val/box/tag are meaningful rather than vacuous.
+TEST_F(AliasTest, ArrowNonSelfAliasingViewpointAliasesRight)
+{
+  TEST_COMPILE(TEST_SRC);
+
+  DO(check_arrow_alias("a_iso", false));
+  DO(check_arrow_alias("a_trn", false));
+  DO(check_arrow_alias("a_ref", false));
+}


### PR DESCRIPTION
`alias()` returned `val->A` arrow types unchanged because a val viewpoint is self-aliasing for every instantiation of `A` — aliasing inside the arrow gives the over-conservative `val->(A!)` (added in #4963). The same reasoning holds for `box` (a box viewpoint yields only box, val, tag, or #share) and `tag` (yields only tag), so this extends the short-circuit to those viewpoints.

The change is sound but not observable through ordinary compilation, which is worth being explicit about: `box->A` and `box->A!` already compare as mutual subtypes (box is see-through, so both reify to equal concrete caps), and `tag->A` arrow types are independently blocked from binding or return by an unrelated ephemeral subtype check that this change does not touch. There is therefore no Pony program that flips from error to compiling. The behaviour is instead guarded by a direct unit test on `alias()` (`test/libponyc/alias.cc`): val/box/tag short-circuit (the arrow is returned unchanged with an un-aliased right side) while iso/trn/ref still alias the right side, serving as a positive control.

Closes #4969