### PR TITLE
Reject self-referential iftype constraints inside lambdas and object literals

### DIFF
--- a/.release-notes/5404.md
+++ b/.release-notes/5404.md
@@ -1,0 +1,13 @@
+## Reject self-referential iftype constraints inside lambdas and object literals
+
+A self-referential `iftype` subtype condition — one whose subtype check refers back to the tested type parameter through a union, intersection, or tuple — is meaningless and is rejected when written in a method. The same condition inside a lambda or object literal was silently accepted. It is now rejected everywhere with the same error.
+
+The following program previously compiled but now reports a clear error:
+
+```pony
+actor Main
+  new create(env: Env) =>
+    let f = {[A](x: A) =>
+      iftype A <: (A | None) then None end}
+    f[U8](0)
+```

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -166,7 +166,14 @@ static bool constraint_reaches_root(ast_t* root, ast_t* type,
     {
       ast_t* def = (ast_t*)ast_data(type);
 
-      if(def == root)
+      // Match on canonical type-parameter identity, not AST node identity.
+      // A self-reference in the constraint can bind to a different AST node
+      // than 'root' yet denote the same type parameter: an iftype condition
+      // desugars to a synthetic parameter whose constraint reference binds to
+      // the synthetic node at method scope but back to the original it
+      // narrows on the lambda/object-literal catch-up path.
+      // typeparam_root collapses these copies to one identity.
+      if(typeparam_root(def) == typeparam_root(root))
         return true;
 
       if(astlist_find(*visited, def) != NULL)

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -414,10 +414,8 @@ static matchtype_t is_typeparam_match_typeparam(ast_t* operand, ast_t* pattern,
 
   // Dig through defs if there are multiple layers of directly-bound
   // type params (created through the collect_type_params function).
-  while((ast_data(operand_def) != NULL) && (operand_def != ast_data(operand_def)))
-    operand_def = (ast_t*)ast_data(operand_def);
-  while((ast_data(pattern_def) != NULL) && (pattern_def != ast_data(pattern_def)))
-    pattern_def = (ast_t*)ast_data(pattern_def);
+  operand_def = typeparam_root(operand_def);
+  pattern_def = typeparam_root(pattern_def);
 
   ast_t* o_cap = cap_fetch(operand);
   ast_t* o_eph = ast_sibling(o_cap);

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -1,6 +1,7 @@
 #include "reify.h"
 #include "subtype.h"
 #include "typealias.h"
+#include "typeparam.h"
 #include "viewpoint.h"
 #include "assemble.h"
 #include "alias.h"
@@ -18,25 +19,17 @@ static ast_t* find_typearg(pass_opt_t* opt, ast_t* ast, ast_t* typeparams, ast_t
       if(ref_def == NULL)
         return NULL;
 
-      // Follow the ast_data chain to the root for TK_TYPEPARAM nodes,
+      // Resolve to the root of the ast_data chain for TK_TYPEPARAM nodes,
       // same as the TK_TYPEPARAMREF case below.
       if(ast_id(ref_def) == TK_TYPEPARAM)
-      {
-        while((ast_t*)ast_data(ref_def) != ref_def)
-          ref_def = (ast_t*)ast_data(ref_def);
-      }
+        ref_def = typeparam_root(ref_def);
 
       break;
 
     case TK_TYPEPARAMREF:
       ref_def = (ast_t*)ast_data(ast);
       pony_assert(ref_def != NULL);
-      // Follow the ast_data chain to the root (self-referential node set
-      // during the scope pass). A single-level follow is insufficient when
-      // type parameters are copied multiple times, e.g. a lambda inside an
-      // object literal inside a generic method.
-      while((ast_t*)ast_data(ref_def) != ref_def)
-        ref_def = (ast_t*)ast_data(ref_def);
+      ref_def = typeparam_root(ref_def);
       break;
 
     default:
@@ -52,8 +45,7 @@ static ast_t* find_typearg(pass_opt_t* opt, ast_t* ast, ast_t* typeparams, ast_t
   {
     ast_t* param_def = (ast_t*)ast_data(typeparam);
     pony_assert(param_def != NULL);
-    while((ast_t*)ast_data(param_def) != param_def)
-      param_def = (ast_t*)ast_data(param_def);
+    param_def = typeparam_root(param_def);
 
     if(ref_def == param_def)
       return typearg;

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1499,10 +1499,8 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
 
   // Dig through defs if there are multiple layers of directly-bound
   // type params (created through the collect_type_params function).
-  while((ast_data(sub_def) != NULL) && (sub_def != ast_data(sub_def)))
-    sub_def = (ast_t*)ast_data(sub_def);
-  while((ast_data(super_def) != NULL) && (super_def != ast_data(super_def)))
-    super_def = (ast_t*)ast_data(super_def);
+  sub_def = typeparam_root(sub_def);
+  super_def = typeparam_root(super_def);
 
   if(sub_def == super_def)
     return is_sub_cap_and_eph(sub, super, check_cap, errorf, opt);

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -634,6 +634,15 @@ ast_t* typeparam_constraint(ast_t* typeparamref)
   return constraint;
 }
 
+ast_t* typeparam_root(ast_t* def)
+{
+  while((def != NULL) && (ast_data(def) != NULL) &&
+    ((ast_t*)ast_data(def) != def))
+    def = (ast_t*)ast_data(def);
+
+  return def;
+}
+
 ast_t* typeparam_upper(ast_t* typeparamref)
 {
   pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);

--- a/src/libponyc/type/typeparam.h
+++ b/src/libponyc/type/typeparam.h
@@ -11,6 +11,17 @@ PONY_EXTERN_C_BEGIN
 // The raw constraint. Returns null if unconstrained.
 ast_t* typeparam_constraint(ast_t* typeparamref);
 
+// Resolve a type-parameter definition (TK_TYPEPARAM) to the canonical root of
+// its ast_data chain. Every TK_TYPEPARAM's data points one step toward the
+// original definition set during the scope pass; copies — made via ast_dup or
+// collect_type_params — retain that link, so a parameter bound through several
+// layers (e.g. an iftype condition in a lambda inside a generic method) forms
+// a chain that a single dereference would not fully resolve. Comparing two
+// roots tests whether the parameters denote the same type variable. A null
+// input or a null link stops the walk, so the result is null only when 'def'
+// is.
+ast_t* typeparam_root(ast_t* def);
+
 /**
  * If the upper bounds of a typeparamref is a subtype of a type T, then every
  * possible binding of the typeparamref is a subtype of T.

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -268,6 +268,97 @@ TEST_F(IftypeTest, SelfReferentialSubtypeConstraint)
 }
 
 
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraintInLambda)
+{
+  // Same self-referential iftype constraint as above, but inside a lambda.
+  // The lambda's body is processed through the object-literal catch-up
+  // path, where the constraint's reference binds back to the original type
+  // parameter rather than the synthetic iftype one. The self-reference
+  // check must recognize both bindings, so this is rejected just like the
+  // method-scope case (ponylang/ponyc#5404).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x: A) =>\n"
+    "      iftype A <: (A | None) then None end}\n"
+    "    f[U8](0)";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraintInObjectLiteral)
+{
+  // The same self-referential iftype constraint inside an object literal's
+  // method. Object literals share the lambda catch-up path, so this must be
+  // rejected too (ponylang/ponyc#5404).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let o = object\n"
+    "      fun foo[A](x: A) =>\n"
+    "        iftype A <: (A | None) then None end\n"
+    "    end\n"
+    "    o.foo[U8](0)";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraintTupleInLambda)
+{
+  // A tuple iftype condition whose first element's supertype names that
+  // element through a union, inside a lambda. The self-reference reaches the
+  // synthetic parameter through a tuple member rather than a bare union, so
+  // it exercises a distinct branch of the constraint walk (ponylang/ponyc
+  // #5404).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A, B](x: A, y: B) =>\n"
+    "      iftype (A, B) <: ((A | None), B) then None end}\n"
+    "    f[U8, U8](0, 0)";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraintIntersectionInLambda)
+{
+  // The self-referential supertype reaches the synthetic parameter through an
+  // intersection member rather than a union, inside a lambda (ponylang/ponyc
+  // #5404).
+  const char* src =
+    "trait Tr\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x: A) =>\n"
+    "      iftype A <: (A & Tr) then None end}\n"
+    "    f[U8](0)";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
+TEST_F(IftypeTest, SelfReferentialSubtypeConstraintInNestedLambda)
+{
+  // The self-referential iftype is two catch-up copies deep — a lambda nested
+  // inside another lambda. Resolving the parameter to the root of its
+  // ast_data chain must still collapse both copies to one identity so this is
+  // rejected like the single-level cases (ponylang/ponyc#5404).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let outer = {() =>\n"
+    "      let inner = {[A](x: A) =>\n"
+    "        iftype A <: (A | None) then None end}\n"
+    "      inner[U8](0)}\n"
+    "    outer()";
+
+  TEST_ERROR(src, "can't appear directly in its own constraint");
+}
+
+
 TEST_F(IftypeTest, NestedCond)
 {
   const char* src =


### PR DESCRIPTION
A self-referential `iftype` subtype condition (e.g. `iftype A <: (A | None)`) desugars to a synthetic type parameter whose constraint references itself. The flatten-pass check added in #5403 rejects these at method scope but matched on AST node identity, so it missed the same condition inside a lambda or object literal: those are processed through the object-literal catch-up path, where the constraint binds back to the original type parameter rather than the synthetic node. The meaningless constraint compiled silently.

The check now matches on canonical type-parameter identity, resolving both sides through the `ast_data` chain to their root the way `reify.c`, `matchtype.c`, and `subtype.c` already do. This catches the lambda and object-literal cases (and nested ones) without affecting recursive generic types, recursive type aliases, or F-bounded polymorphism — the constraint walk still stops at `TK_NOMINAL`.

Tests cover the lambda and object-literal cases plus the tuple-member, intersection-member, and nested-lambda variants.

A second commit factors the chain-follow idiom — previously duplicated across `reify.c`, `matchtype.c`, `subtype.c`, and this check — into a shared `typeparam_root` helper. No behavior change; the full compiler and tool (lint/lsp/doc) suites pass.

During review, a related pre-existing inconsistency was found and filed as #5422: an F-bounded `iftype A <: T[A]` compiles at method scope but is rejected inside a lambda (the opposite symptom — wrongly rejecting valid code). It is independent of this change.

Closes #5404