### PR TITLE
Use embedded LLD for native FreeBSD sanitizer builds

### DIFF
--- a/.ci-scripts/freebsd-sanitizer-smoke.sh
+++ b/.ci-scripts/freebsd-sanitizer-smoke.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Native sanitizer smoke test for the FreeBSD tier-3 job. Runs inside the
+# FreeBSD VM, invoked from .github/workflows/ponyc-tier3.yml. POSIX sh, not
+# bash: FreeBSD's base system has no bash. Expects to run from the ponyc source
+# root.
+#
+# Tier-3 otherwise never builds with sanitizers, so the native FreeBSD
+# sanitizer link path (embedded LLD splicing the captured -fsanitize= runtime
+# fragment, see genexe.cc) went uncovered. This builds an instrumented ponyc
+# plus the self-hosted tools, then links and runs a small program whose
+# allocations engage AddressSanitizer, asserting a clean exit. The link is the
+# thing under test: a broken splice shows up as undefined sanitizer symbols at
+# link time, not as a runtime surprise.
+#
+# ASAN_OPTIONS/UBSAN_OPTIONS are exported for the build too, not just the run,
+# because the instrumented ponyc executes during its own build (compiling the
+# tools). detect_leaks=0 matches the Linux weekly and sidesteps FreeBSD's
+# spotty LeakSanitizer support. detect_container_overflow=0 is FreeBSD-specific:
+# the base system C++ runtime is libc++, whose container annotations produce
+# false-positive container-overflow reports when the instrumented ponyc shares
+# std::vector/std::string with the (non-instrumented) vendored LLVM. The Linux
+# weekly uses libstdc++ and doesn't need it.
+set -eu
+
+export ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
+export UBSAN_OPTIONS=print_stacktrace=0
+if [ -x "$PWD/build/libs/bin/llvm-symbolizer" ]; then
+  ASAN_OPTIONS="$ASAN_OPTIONS:external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer"
+  UBSAN_OPTIONS="$UBSAN_OPTIONS:external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer"
+fi
+
+# Clean + reconfigure debug from scratch. The earlier non-sanitizer config=debug
+# build left a build dir behind, and reconfiguring it in place re-runs the
+# standalone-library rule over a read-only leftover (`libc++.a` is 0444, so the
+# copied `libcpp.a` is too) which fails. `clean` is config-scoped and defaults
+# to release, so pass config=debug to remove the debug build/output dirs; the
+# prebuilt LLVM in build/libs is untouched. This runs before the dtrace smoke,
+# which performs the same clean+reconfigure, so the order is deliberate.
+gmake clean config=debug
+gmake configure config=debug \
+  use=pool_memalign,address_sanitizer,undefined_behavior_sanitizer
+# Full build: this compiles the instrumented ponyc and links the self-hosted
+# tools (pony-lsp/pony-lint/pony-doc) under sanitizers, exercising the embedded
+# LLD link of programs that bundle the C++ runtime (libponyc-standalone.a).
+gmake build config=debug
+
+# The sanitizer suffix order is fixed by CMake (address, then undefined, then
+# pool_memalign), independent of the use= order above; derive the output dir
+# rather than hardcode it.
+out=$(find build -maxdepth 1 -type d -name 'debug-*address_sanitizer*pool_memalign' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: sanitizer build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/sanitizer-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    // Allocate enough to exercise the AddressSanitizer-instrumented libponyrt
+    // allocator, then exit clean.
+    let a = Array[U64](4096)
+    var i: USize = 0
+    while i < 4096 do
+      a.push(i.u64())
+      i = i + 1
+    end
+    env.out.print("sanitizer smoke ok size=" + a.size().string())
+PONY
+
+# Link via embedded LLD (the captured sanitizer fragment is spliced here) and
+# run. A broken splice fails at link time with undefined __asan_*/__ubsan_*.
+PONYPATH="$PWD/packages" "$out/ponyc" --debug -o "$smoke" "$smoke"
+out_text=$("$smoke/sanitizer-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "sanitizer smoke ok size=4096"
+
+# The self-hosted tools link libponyc-standalone.a (which bundles libc++/libcxxrt
+# on FreeBSD); confirm one runs clean under the sanitizer runtime, proving the
+# tool link path works and not just that it linked.
+"$out/pony-lint" --version

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -102,7 +102,7 @@ jobs:
             -machine pc,accel=kvm \
             -cpu host \
             -smp 4 \
-            -m 6G \
+            -m 12G \
             -drive file=freebsd.qcow2,format=qcow2,if=virtio \
             -drive file=seed.img,format=raw,if=virtio \
             -netdev user,id=net0,hostfwd=tcp::2222-:22 \
@@ -174,6 +174,10 @@ jobs:
           gmake configure config=release
           gmake build config=release
           gmake test-ci-core config=release
+          # native sanitizer link smoke test — see the script for details. Runs
+          # before the dtrace smoke: both clean and reconfigure the debug build,
+          # so the order is deliberate.
+          sh .ci-scripts/freebsd-sanitizer-smoke.sh
           # use=dtrace smoke test — see the script for details.
           sh .ci-scripts/freebsd-dtrace-smoke.sh
           EOF

--- a/.release-notes/use-embedded-lld-for-native-freebsd-sanitizer-builds.md
+++ b/.release-notes/use-embedded-lld-for-native-freebsd-sanitizer-builds.md
@@ -1,0 +1,3 @@
+## Use embedded LLD for native FreeBSD sanitizer builds
+
+When ponyc is built with sanitizers (such as `address_sanitizer` or `undefined_behavior_sanitizer`) on FreeBSD, it now links the programs it compiles with its built-in LLD linker, the same as every other build, instead of falling back to your system C compiler to perform the link. Sanitizer-enabled native FreeBSD compilation no longer depends on having an external compiler driver present and usable as a linker.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,8 +148,8 @@ endif()
 # clang_rt static archives + --dynamic-list) and gcc (preinit object + shared
 # -lasan/-lubsan). The fragment's library paths are absolute on the build
 # machine, which is fine: a sanitizer ponyc is a developer/CI artifact that runs
-# where it was built. Linux native sanitizer builds are the only ones that
-# consume this today (see genexe.cc); the splice is gated on !is_cross_compiling.
+# where it was built. Native Linux and native FreeBSD sanitizer builds consume
+# this (see genexe.cc); the splice is gated on !is_cross_compiling.
 
 # Extract the linker subcommand's arguments from a compiler "-###" stderr dump.
 # The link subcommand is the line naming the probe object (clang emits a direct

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -1051,6 +1051,25 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   args.push_back("--build-id");
   args.push_back("--eh-frame-hdr");
 
+#if defined(PONY_SANITIZER)
+  // FreeBSD: the self-hosted tools link libponyc-standalone.a, which bundles
+  // the base system libc++.a — and FreeBSD's libc++.a carries libcxxrt (the
+  // C++ ABI) as members (cxxrt_exception.o etc.). The sanitizer fragment
+  // spliced below whole-archives libclang_rt.asan, which provides its own
+  // __cxa_throw / __cxa_rethrow_primary_exception interceptors; those collide
+  // with libcxxrt's, which gets pulled in to satisfy the other C++ ABI symbols
+  // (__cxa_begin_catch etc.) the bundled LLVM/lld code references. Allow the
+  // duplicate so the asan interceptor (emitted first) wins. Which copy wins is
+  // immaterial in practice: the vendored LLVM/lld are built with exceptions
+  // disabled (LLVM_ENABLE_EH OFF), so nothing actually throws through
+  // __cxa_throw here — the collision is a pure ABI-completeness artifact, not a
+  // live unwinding path. Programs that don't bundle a C++ ABI statically — the
+  // common case, including any normal Pony program linking only libponyrt —
+  // have no duplicate and are unaffected.
+  if(is_freebsd)
+    args.push_back("--allow-multiple-definition");
+#endif
+
   // OpenBSD's libc CRT defines the program entry point as `__start`
   // (double underscore). lld defaults to `_start` (single underscore) on
   // ELF, so without an explicit override the link fails with an
@@ -1283,35 +1302,43 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   // must link the sanitizer runtime. PONY_SANITIZER_LINK_ARGS is the exact
   // fragment the compiler driver emits for -fsanitize=<PONY_SANITIZER>, captured
   // at ponyc build time (see the PONY_SANITIZERS_ENABLED block in the top-level
-  // CMakeLists.txt). Its contents are compiler-specific (clang: whole-archived
-  // clang_rt static archives + --dynamic-list + a few syslibs; gcc:
-  // libasan_preinit.o + shared -lasan/-lubsan) and its library paths are
-  // absolute on the build machine.
+  // CMakeLists.txt). Its contents are compiler- and platform-specific:
+  //   - Linux clang: whole-archived clang_rt static archives + --dynamic-list
+  //     + a few syslibs.
+  //   - Linux gcc: libasan_preinit.o + shared -lasan/-lubsan.
+  //   - FreeBSD base clang: the asan_static + asan clang_rt archives, each
+  //     whole-archived, then --export-dynamic and
+  //     --no-as-needed -lpthread -lrt -lm -lexecinfo.
+  // The clang_rt archive paths are absolute on the build machine.
   //
-  // This function serves both the Linux and the BSD branches of link_exe.
-  // Native sanitizer linking via embedded LLD has only been done and verified
-  // for Linux; there is no native-ASan support for the BSDs yet. So the splice
-  // is gated on target_is_linux explicitly, rather than relying on the BSD
-  // branch of link_exe continuing to route native sanitizer builds to the
-  // legacy driver. The !is_cross_compiling gate additionally keeps the
-  // host-arch-absolute fragment out of any cross link routed here.
+  // This function serves the Linux and FreeBSD branches of link_exe — the
+  // native sanitizer builds that reach embedded LLD. macOS, DragonFly, and
+  // OpenBSD native sanitizer builds still route through the legacy compiler
+  // driver (which pulls the runtime in via -fsanitize=), so they never reach
+  // this splice; it is gated on the targets explicitly rather than relying on
+  // link_exe's routing alone. The !is_cross_compiling gate additionally keeps
+  // the host-arch-absolute fragment out of any cross link routed here.
   //
   // The fragment is spliced as one contiguous block immediately before file_o.
-  // That order is correct for every piece: objects and static archives that
-  // provide symbols (clang's whole-archived clang_rt, gcc's preinit object)
-  // must precede the instrumented object/runtime so their members are pulled
-  // in, and shared libraries (gcc's -lasan/-lubsan, clang's -lrt/-lresolv) are
-  // position-insensitive (DT_NEEDED), so emitting them here rather than after
-  // the object is harmless. Any linker-state flags in the fragment (clang emits
-  // --no-as-needed) only re-assert the ELF linker's default state, so they have
-  // no lasting effect on the libraries ponyc emits afterward. Pieces ponyc also
-  // emits after the object (e.g. -lpthread) simply appear twice, harmlessly.
+  // That order is correct for every piece on both platforms: objects and static
+  // archives that provide symbols (clang's whole-archived clang_rt, gcc's
+  // preinit object) must precede the instrumented object/runtime so their
+  // members are pulled in, and shared libraries (gcc's -lasan/-lubsan, FreeBSD
+  // clang's -lrt/-lpthread/-lm/-lexecinfo) are position-insensitive (DT_NEEDED),
+  // so emitting them here rather than after the object is harmless. Any
+  // linker-state flags in the fragment (clang's --no-as-needed, FreeBSD clang's
+  // --export-dynamic) either re-assert the ELF linker's default state or set a
+  // whole-link property the sanitizer runtime needs, so their position in the
+  // fragment is immaterial. Pieces ponyc also emits after the object (FreeBSD's
+  // -lpthread/-lm/-lexecinfo) simply appear twice, harmlessly.
   //
-  // gcc's fragment carries bare -lasan/-lubsan (not absolute paths); they
-  // resolve via the -L search paths ponyc already emits earlier in this
-  // function (the gcc lib dir and the standard system fallbacks), so don't drop
-  // those without accounting for the sanitizer runtime.
-  if(target_is_linux(c->opt->triple) && !is_cross_compiling(c))
+  // Bare -l fragments (gcc's -lasan/-lubsan, FreeBSD's -lrt/-lpthread/-lm/
+  // -lexecinfo — not absolute paths) resolve via the -L search paths ponyc
+  // already emits earlier in this function: on Linux the gcc lib dir and the
+  // standard system fallbacks, on FreeBSD the -L<libc_crt_dir> (/usr/lib) push.
+  // Don't drop those without accounting for the sanitizer runtime.
+  if((target_is_linux(c->opt->triple) || target_is_freebsd(c->opt->triple))
+    && !is_cross_compiling(c))
   {
     for(size_t i = 0; i < PONY_SANITIZER_LINK_ARGS_COUNT; i++)
       args.push_back(PONY_SANITIZER_LINK_ARGS[i]);
@@ -1975,11 +2002,12 @@ static bool link_exe(compile_t* c, ast_t* program,
   errors_t* errors = c->opt->check.errors;
 
   // Use embedded LLD for Linux, macOS, and Windows targets unless --linker
-  // escape hatch is specified. On Linux, native sanitizer builds use embedded
-  // LLD too: link_exe_lld_elf links the sanitizer runtime explicitly from a
-  // fragment captured at ponyc build time. On macOS and the BSDs, native
-  // sanitizer builds still fall back to the system compiler driver (which
-  // links the runtime via -fsanitize=); cross-compilation always uses LLD.
+  // escape hatch is specified. On Linux and FreeBSD, native sanitizer builds
+  // use embedded LLD too: link_exe_lld_elf links the sanitizer runtime
+  // explicitly from a fragment captured at ponyc build time. On macOS,
+  // DragonFly, and OpenBSD, native sanitizer builds still fall back to the
+  // system compiler driver (which links the runtime via -fsanitize=);
+  // cross-compilation always uses LLD.
 #ifdef PLATFORM_IS_POSIX_BASED
   if(c->opt->linker == NULL
     && target_is_linux(c->opt->triple))
@@ -2003,13 +2031,21 @@ static bool link_exe(compile_t* c, ast_t* program,
   // dtrace_probes/libelf libs available — use=dtrace builds for those
   // targets are already broken; the guard preserves that failure mode
   // rather than introducing a new one.)
+  //
+  // In a sanitizer build, native FreeBSD also routes here: link_exe_lld_elf
+  // splices in the captured sanitizer fragment (see the splice above), and the
+  // capture has been verified against FreeBSD base clang. Native DragonFly and
+  // OpenBSD sanitizer builds stay on the legacy driver — their fragment shapes
+  // are unverified — so the sanitizer sub-gate admits only native FreeBSD (and
+  // any cross link, whose runtime is host-arch-absolute and handled by the
+  // !is_cross_compiling gate at the splice).
 #if !defined(USE_DYNAMIC_TRACE)
   if(c->opt->linker == NULL
     && (target_is_freebsd(c->opt->triple)
         || target_is_dragonfly(c->opt->triple)
         || target_is_openbsd(c->opt->triple))
 #if defined(PONY_SANITIZER)
-    && is_cross_compiling(c)
+    && (is_cross_compiling(c) || target_is_freebsd(c->opt->triple))
 #endif
     )
   {


### PR DESCRIPTION
Native FreeBSD sanitizer builds previously fell back to the system compiler driver to link. This routes them through embedded LLD like every other build, splicing the `-fsanitize` runtime fragment captured at ponyc build time. The CMake capture already worked unmodified against FreeBSD base clang, so this opens the two genexe gates (the fragment splice and the `link_exe` routing) to native FreeBSD, leaving DragonFly and OpenBSD on the legacy driver.

Linking the self-hosted tools (pony-lsp/lint/doc) under sanitizers additionally needs `--allow-multiple-definition` on FreeBSD: the asan runtime's `__cxa_throw` interceptor collides with the libcxxrt copy bundled into `libponyc-standalone.a` via FreeBSD's `libc++.a`. The vendored LLVM/lld are built `-fno-exceptions`, so nothing is thrown through that symbol — the collision is a pure ABI-completeness artifact. With this, FreeBSD reaches parity with the Linux sanitizer weekly: a full `gmake build` plus `test-ci-core` pass under ASan/UBSan (verified on FreeBSD 14.3 / base clang 19.1.7).

A tier-3 CI smoke (`.ci-scripts/freebsd-sanitizer-smoke.sh`) builds an instrumented ponyc and tools, then links and runs an ASan-engaging program. It runs before the dtrace smoke because both clean and reconfigure the debug build.

Known limitations (both pre-existing and unchanged by this PR): static (`--static`) sanitizer builds and cross-target sanitizer linking remain unsupported on FreeBSD — both fail cleanly at link, the latter consistent with Linux.

Follow-up: sanitizer builds require platform-specific `ASAN_OPTIONS` (`detect_leaks=0` on Linux; additionally `detect_container_overflow=0` on FreeBSD for a libc++ false positive) that live only in CI. Documenting them in BUILD.md is tracked in #5425.

Design: #5424