### PR TITLE
Reject unsupported build options on OpenBSD

### DIFF
--- a/.ci-scripts/openbsd-reject-unsupported-builds.sh
+++ b/.ci-scripts/openbsd-reject-unsupported-builds.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Assert that ponyc rejects the unsupported `use=` build options on OpenBSD.
+# Runs inside the OpenBSD VM, invoked from .github/workflows/ponyc-tier3.yml.
+# POSIX sh (OpenBSD's /bin/sh). Expects to run from the ponyc source root.
+#
+# OpenBSD's base toolchain ships no AddressSanitizer/ThreadSanitizer runtime and
+# only the minimal (not standalone) UndefinedBehaviorSanitizer runtime, has an
+# incomplete profiling runtime, and has no Valgrind port, so these use= options
+# can't link or compile there. `gmake configure` rejects them with a clear error
+# at make-parse time, before `gmake libs` runs, so this assertion needs no LLVM
+# build. Check each fails AND fails for the documented reason: a typo in the OS
+# string would otherwise silently regress to the confusing partway-through build
+# failure the guards exist to prevent. (use=dtrace is also rejected on OpenBSD,
+# but by its own which-dtrace check with a different message.)
+set -eu
+
+for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer coverage valgrind; do
+  if out=$(gmake configure use="$u" 2>&1); then
+    echo "FAIL: use=$u was not rejected on OpenBSD"
+    exit 1
+  fi
+  if ! printf '%s\n' "$out" | grep -q "not supported on OpenBSD"; then
+    echo "FAIL: use=$u failed for an unexpected reason:"
+    printf '%s\n' "$out"
+    exit 1
+  fi
+done
+echo "unsupported use= options correctly rejected on OpenBSD"

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -297,6 +297,10 @@ jobs:
         run: |
           rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
             "$GITHUB_WORKSPACE/" openbsd@localhost:/build/ponyc/
+      - name: Assert unsupported build options are rejected
+        run: |
+          ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost \
+            "cd /build/ponyc && sh .ci-scripts/openbsd-reject-unsupported-builds.sh"
       - name: Build and test
         run: |
           ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i vm_key -p 2222 openbsd@localhost <<'EOF'

--- a/BUILD.md
+++ b/BUILD.md
@@ -55,6 +55,18 @@ doas gmake install
 
 Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 
+### Unsupported build options
+
+Several `use=` build options aren't supported on OpenBSD, because OpenBSD doesn't ship the runtime, headers, or tooling they depend on:
+
+- `use=address_sanitizer` and `use=thread_sanitizer` — OpenBSD's base clang rejects `-fsanitize=address`/`-fsanitize=thread`; there is no AddressSanitizer or ThreadSanitizer runtime in base.
+- `use=undefined_behavior_sanitizer` — OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime (`libclang_rt.ubsan_minimal.a`), not the standalone runtime ponyc links against, so the link fails.
+- `use=coverage` — OpenBSD's base profiling runtime (`libclang_rt.profile.a`) is incomplete, so coverage-instrumented builds fail to link.
+- `use=valgrind` — Valgrind has no OpenBSD port, so its development headers aren't available to build against.
+- `use=dtrace` — OpenBSD ships no DTrace-compatible probe-generation tool (its `btrace` is a separate tracer with no USDT support).
+
+`gmake configure` rejects these uses on OpenBSD with an error rather than letting the build fail partway through with a confusing compiler, linker, or missing-tool message.
+
 ## DragonFly
 
 DragonFly BSD's base compiler (GCC 8.3) cannot build the vendored LLVM. Install GCC 13 and the required atomics package, then build with the packaged compiler:

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,10 @@ else ifneq (,$(shell $(CC) --version 2>&1 | grep "Free Software Foundation"))
   endif
 endif
 
+HOST_OS := $(shell uname -s)
+
 # Make sure the compiler gets all relevant search paths on FreeBSD/OpenBSD/DragonFly
-ifneq (,$(filter FreeBSD OpenBSD DragonFly,$(shell uname -s)))
+ifneq (,$(filter FreeBSD OpenBSD DragonFly,$(HOST_OS)))
   ifeq (,$(findstring /usr/local/include,$(shell echo $CPATH)))
     export CPATH = /usr/local/include:$CPATH
   endif
@@ -124,14 +126,29 @@ space:= $(empty) $(empty)
 define USE_CHECK
   $$(info Enabling use option: $1)
   ifeq ($1,valgrind)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error Valgrind is not supported on OpenBSD: Valgrind has no OpenBSD port, so its development headers aren't available. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_VALGRIND=true
   else ifeq ($1,thread_sanitizer)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error ThreadSanitizer is not supported on OpenBSD: the base toolchain ships no ThreadSanitizer runtime. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_THREAD_SANITIZER=true
   else ifeq ($1,address_sanitizer)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error AddressSanitizer is not supported on OpenBSD: the base toolchain ships no AddressSanitizer runtime. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_ADDRESS_SANITIZER=true
   else ifeq ($1,undefined_behavior_sanitizer)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error UndefinedBehaviorSanitizer is not supported on OpenBSD: the base toolchain ships only the minimal UBSan runtime, not the standalone runtime ponyc links against. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_UNDEFINED_BEHAVIOR_SANITIZER=true
   else ifeq ($1,coverage)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error Coverage instrumentation is not supported on OpenBSD: the base toolchain's profiling runtime is incomplete, so coverage builds fail to link. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_COVERAGE=true
   else ifeq ($1,pooltrack)
     PONY_USES += -DPONY_USE_POOLTRACK=true
@@ -236,7 +253,7 @@ test-libponyrt: all
 test-libponyc: all
 	$(SILENT)cd '$(outDir)' && $(debuggercmd) ./libponyc.tests --gtest_shuffle $(testextras)
 
-ifneq (,$(filter FreeBSD OpenBSD DragonFly Darwin,$(shell uname -s)))
+ifneq (,$(filter FreeBSD OpenBSD DragonFly Darwin,$(HOST_OS)))
   num_cores := `sysctl -n hw.ncpu`
 else
   num_cores := `nproc --all`


### PR DESCRIPTION
OpenBSD's base toolchain doesn't ship the runtimes, headers, or tooling that several `use=` build options depend on, so those builds fail partway through with a confusing compiler or linker error. This rejects them at `make configure` time with a clear, explanatory error instead — mirroring how `use=dtrace` already fails fast when no DTrace tool is present.

Rejected on OpenBSD (verified empirically on an OpenBSD 7.8 VM, base clang 19.1.7):

- `address_sanitizer` / `thread_sanitizer` — base clang rejects `-fsanitize=address`/`-fsanitize=thread`; there is no ASan/TSan runtime in base.
- `undefined_behavior_sanitizer` — OpenBSD ships only `libclang_rt.ubsan_minimal.a`, not the standalone runtime ponyc links against, so the link fails.
- `coverage` — the base `libclang_rt.profile.a` is incomplete (undefined `__llvm_profile_*_bitmap`), so coverage builds fail to link.
- `valgrind` — Valgrind has no OpenBSD port, so `valgrind/valgrind.h` isn't available to build against.

`use=dtrace` was already rejected by its own `which dtrace` check; it's listed in BUILD.md alongside the others for completeness. The eight remaining `use=` options are internal runtime `#ifdef` defines with no external dependency and are unaffected.

A tier-3 OpenBSD CI step asserts each option is rejected for the documented reason, so a future regression (e.g. a typo'd OS string) can't silently restore the confusing partway-through failure. The `$(error)` fires at make-parse time, before `gmake libs`, so the assertion needs no LLVM build.

Companion website PR (ponylang/ponylang-website) documents the same on the custom-ponyc-builds and building-ponyc-from-source pages; its link to `BUILD.md#unsupported-build-options` resolves once this PR merges.