### PR TITLE
Spike: split builtin Pointer into Pointer and UnsafePointer

### DIFF
--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -1,4 +1,4 @@
-type AsioEventID is Pointer[AsioEvent] tag
+type AsioEventID is UnsafePointer[AsioEvent] tag
 
 trait tag AsioEventNotify
   be _event_notify(event: AsioEventID, flags: U32, arg: U32)

--- a/packages/builtin/env.pony
+++ b/packages/builtin/env.pony
@@ -36,8 +36,8 @@ class val Env
 
   new _create(
     argc: U32,
-    argv: Pointer[Pointer[U8]] val,
-    envp: Pointer[Pointer[U8]] val)
+    argv: UnsafePointer[UnsafePointer[U8]] val,
+    envp: UnsafePointer[UnsafePointer[U8]] val)
   =>
     """
     Builds an environment from the command line. This is done before the Main
@@ -73,7 +73,7 @@ class val Env
     vars = vars'
     exitcode = exitcode'
 
-  fun tag _count_strings(data: Pointer[Pointer[U8]] val): USize =>
+  fun tag _count_strings(data: UnsafePointer[UnsafePointer[U8]] val): USize =>
     if data.is_null() then
       return 0
     end
@@ -89,7 +89,7 @@ class val Env
     i
 
   fun tag _strings_from_pointers(
-    data: Pointer[Pointer[U8]] val,
+    data: UnsafePointer[UnsafePointer[U8]] val,
     len: USize)
     : Array[String] iso^
   =>

--- a/packages/builtin/std_stream.pony
+++ b/packages/builtin/std_stream.pony
@@ -1,9 +1,9 @@
-use @pony_os_stdout[Pointer[U8]]()
-use @pony_os_stderr[Pointer[U8]]()
-use @pony_os_std_flush[None](file: Pointer[None] tag)
-use @pony_os_std_print[None](file: Pointer[None] tag, buffer: Pointer[U8] tag,
+use @pony_os_stdout[UnsafePointer[U8]]()
+use @pony_os_stderr[UnsafePointer[U8]]()
+use @pony_os_std_flush[None](file: UnsafePointer[None] tag)
+use @pony_os_std_print[None](file: UnsafePointer[None] tag, buffer: Pointer[U8] tag,
   size: USize)
-use @pony_os_std_write[None](file: Pointer[None] tag, buffer: Pointer[U8] tag,
+use @pony_os_std_write[None](file: UnsafePointer[None] tag, buffer: Pointer[U8] tag,
   size: USize)
 type ByteSeq is (String | Array[U8] val)
 
@@ -47,7 +47,7 @@ actor StdStream
   Asynchronous access to stdout and stderr. The constructors are private to
   ensure that access is provided only via an environment.
   """
-  var _stream: Pointer[U8]
+  var _stream: UnsafePointer[U8]
 
   new _out() =>
     """

--- a/packages/builtin/string.pony
+++ b/packages/builtin/string.pony
@@ -125,9 +125,11 @@ actor Main
       _ptr = str
     end
 
-  new copy_cpointer(str: Pointer[U8] box, len: USize) =>
+  new copy_cpointer(str: UnsafePointer[U8] box, len: USize) =>
     """
-    Create a string by copying a fixed number of bytes from a pointer.
+    Create a string by copying a fixed number of bytes from a pointer. The
+    source is an `UnsafePointer` because copying is how data from outside Pony's
+    memory-safety guarantees is brought into a Pony-managed `String`.
     """
     if str.is_null() then
       _size = 0
@@ -142,12 +144,14 @@ actor Main
       str._copy_to(_ptr, _size + 1)
     end
 
-  new copy_cstring(str: Pointer[U8] box) =>
+  new copy_cstring(str: UnsafePointer[U8] box) =>
     """
     Create a string by copying a null-terminated C string. Note that
     the scan is unbounded; the pointed to data must be null-terminated
     within the allocated array to preserve memory safety. If a null
-    pointer is given then an empty string is returned.
+    pointer is given then an empty string is returned. The source is an
+    `UnsafePointer` because copying is how data from outside Pony's
+    memory-safety guarantees is brought into a Pony-managed `String`.
     """
     if str.is_null() then
       _size = 0

--- a/packages/builtin/unsafe_pointer.pony
+++ b/packages/builtin/unsafe_pointer.pony
@@ -12,9 +12,15 @@ struct UnsafePointer[A]
   fresh memory and copies). It also should never be exposed in a public
   interface.
 
+  Its API is deliberately a small subset of `Pointer`'s. An `UnsafePointer` is
+  only ever held as an opaque handle (created null, null-checked, inspected as
+  an address for sentinel comparisons) or read so its contents can be copied
+  into Pony-managed memory. It has no allocation, pointer-arithmetic, mutation,
+  or array-manipulation methods — those belong to `Pointer`, which backs
+  Pony-managed memory.
+
   Like `Pointer[A]`, it has no descriptor and thus can't be included in a union
-  or intersection, or be a subtype of any interface. Most functions on an
-  `UnsafePointer[A]` are private to maintain memory safety.
+  or intersection, or be a subtype of any interface.
   """
   new create() =>
     """
@@ -22,73 +28,10 @@ struct UnsafePointer[A]
     """
     compile_intrinsic
 
-  new _alloc(len: USize) =>
-    """
-    Space for len instances of A.
-    """
-    compile_intrinsic
-
-  fun ref _realloc(len: USize, copy: USize): UnsafePointer[A] =>
-    """
-    Keep the contents, but reserve space for len instances of A.
-    """
-    compile_intrinsic
-
-  fun tag _unsafe(): UnsafePointer[A] ref =>
-    """
-    Unsafe change in reference capability.
-    """
-    compile_intrinsic
-
-  fun _convert[B](): this->UnsafePointer[B] =>
-    """
-    Convert from UnsafePointer[A] to UnsafePointer[B].
-    """
-    compile_intrinsic
-
   fun _apply(i: USize): this->A =>
     """
-    Retrieve index i.
-    """
-    compile_intrinsic
-
-  fun ref _update(i: USize, value: A!): A^ =>
-    """
-    Set index i and return the previous value.
-    """
-    compile_intrinsic
-
-  fun _offset(n: USize): this->UnsafePointer[A] =>
-    """
-    Return a pointer to the n-th element.
-    """
-    compile_intrinsic
-
-  fun tag offset(n: USize): UnsafePointer[A] tag =>
-    """
-    Return a tag pointer to the n-th element.
-    """
-     _unsafe()._offset(n)
-
-  fun tag _element_size(): USize =>
-    """
-    Return the size of a single element in an array of type A.
-    """
-    compile_intrinsic
-
-  fun ref _insert(n: USize, len: USize): UnsafePointer[A] =>
-    """
-    Creates space for n new elements at the head, moving following elements.
-    The array length before this should be len, and the available space should
-    be at least n + len.
-    """
-    compile_intrinsic
-
-  fun ref _delete(n: USize, len: USize): A^ =>
-    """
-    Delete n elements from the head of pointer, compact remaining elements of
-    the underlying array. The array length before this should be n + len.
-    Returns the first deleted element.
+    Retrieve index i. Used by `String.copy_*` to read foreign data on the way
+    to copying it into Pony-managed memory.
     """
     compile_intrinsic
 
@@ -101,7 +44,8 @@ struct UnsafePointer[A]
 
   fun tag usize(): USize =>
     """
-    Convert the pointer into an integer.
+    Convert the pointer into an integer, e.g. to compare a returned handle
+    against a non-null sentinel.
     """
     compile_intrinsic
 
@@ -113,29 +57,7 @@ struct UnsafePointer[A]
 
   fun tag eq(that: UnsafePointer[A] tag): Bool =>
     """
-    Return true if this address is that address.
+    Return true if this address is that address. Enables matching a held handle
+    against another (e.g. dispatching an ASIO event to its owner).
     """
     compile_intrinsic
-
-  fun tag lt(that: UnsafePointer[A] tag): Bool =>
-    """
-    Return true if this address is less than that address.
-    """
-    compile_intrinsic
-
-  fun tag ne(that: UnsafePointer[A] tag): Bool => not eq(that)
-  fun tag le(that: UnsafePointer[A] tag): Bool => lt(that) or eq(that)
-  fun tag ge(that: UnsafePointer[A] tag): Bool => not lt(that)
-  fun tag gt(that: UnsafePointer[A] tag): Bool => not le(that)
-
-  fun tag hash(): USize =>
-    """
-    Returns a hash of the address.
-    """
-    usize().hash()
-
-  fun tag hash64(): U64 =>
-    """
-    Returns a 64-bit hash of the address.
-    """
-    usize().hash64()

--- a/packages/builtin/unsafe_pointer.pony
+++ b/packages/builtin/unsafe_pointer.pony
@@ -1,0 +1,141 @@
+struct UnsafePointer[A]
+  """
+  An UnsafePointer[A] is a raw memory pointer whose target is NOT backed by
+  Pony's memory-safety guarantees. Use it for pointers that originate outside
+  Pony — opaque foreign handles returned from C that are later passed back into
+  C (e.g. `FILE*`, `DIR*`, `addrinfo*`), or raw foreign memory whose validity
+  the FFI author is asserting by hand.
+
+  Unlike `Pointer[A]`, an `UnsafePointer[A]` must never be adopted in place as
+  the backing store of a safe Pony object: the only way to bring its data into
+  Pony-managed memory is to copy it (see `String.copy_cstring`, which allocates
+  fresh memory and copies). It also should never be exposed in a public
+  interface.
+
+  Like `Pointer[A]`, it has no descriptor and thus can't be included in a union
+  or intersection, or be a subtype of any interface. Most functions on an
+  `UnsafePointer[A]` are private to maintain memory safety.
+  """
+  new create() =>
+    """
+    A null pointer.
+    """
+    compile_intrinsic
+
+  new _alloc(len: USize) =>
+    """
+    Space for len instances of A.
+    """
+    compile_intrinsic
+
+  fun ref _realloc(len: USize, copy: USize): UnsafePointer[A] =>
+    """
+    Keep the contents, but reserve space for len instances of A.
+    """
+    compile_intrinsic
+
+  fun tag _unsafe(): UnsafePointer[A] ref =>
+    """
+    Unsafe change in reference capability.
+    """
+    compile_intrinsic
+
+  fun _convert[B](): this->UnsafePointer[B] =>
+    """
+    Convert from UnsafePointer[A] to UnsafePointer[B].
+    """
+    compile_intrinsic
+
+  fun _apply(i: USize): this->A =>
+    """
+    Retrieve index i.
+    """
+    compile_intrinsic
+
+  fun ref _update(i: USize, value: A!): A^ =>
+    """
+    Set index i and return the previous value.
+    """
+    compile_intrinsic
+
+  fun _offset(n: USize): this->UnsafePointer[A] =>
+    """
+    Return a pointer to the n-th element.
+    """
+    compile_intrinsic
+
+  fun tag offset(n: USize): UnsafePointer[A] tag =>
+    """
+    Return a tag pointer to the n-th element.
+    """
+     _unsafe()._offset(n)
+
+  fun tag _element_size(): USize =>
+    """
+    Return the size of a single element in an array of type A.
+    """
+    compile_intrinsic
+
+  fun ref _insert(n: USize, len: USize): UnsafePointer[A] =>
+    """
+    Creates space for n new elements at the head, moving following elements.
+    The array length before this should be len, and the available space should
+    be at least n + len.
+    """
+    compile_intrinsic
+
+  fun ref _delete(n: USize, len: USize): A^ =>
+    """
+    Delete n elements from the head of pointer, compact remaining elements of
+    the underlying array. The array length before this should be n + len.
+    Returns the first deleted element.
+    """
+    compile_intrinsic
+
+  fun _copy_to(that: Pointer[this->A!], n: USize): this->UnsafePointer[A] =>
+    """
+    Copy n elements from this to that. The destination is a `Pointer` because
+    copying is precisely how unsafe data is brought into Pony-managed memory.
+    """
+    compile_intrinsic
+
+  fun tag usize(): USize =>
+    """
+    Convert the pointer into an integer.
+    """
+    compile_intrinsic
+
+  fun tag is_null(): Bool =>
+    """
+    Return true for a null pointer, false for anything else.
+    """
+    compile_intrinsic
+
+  fun tag eq(that: UnsafePointer[A] tag): Bool =>
+    """
+    Return true if this address is that address.
+    """
+    compile_intrinsic
+
+  fun tag lt(that: UnsafePointer[A] tag): Bool =>
+    """
+    Return true if this address is less than that address.
+    """
+    compile_intrinsic
+
+  fun tag ne(that: UnsafePointer[A] tag): Bool => not eq(that)
+  fun tag le(that: UnsafePointer[A] tag): Bool => lt(that) or eq(that)
+  fun tag ge(that: UnsafePointer[A] tag): Bool => not lt(that)
+  fun tag gt(that: UnsafePointer[A] tag): Bool => not le(that)
+
+  fun tag hash(): USize =>
+    """
+    Returns a hash of the address.
+    """
+    usize().hash()
+
+  fun tag hash64(): U64 =>
+    """
+    Returns a 64-bit hash of the address.
+    """
+    usize().hash64()

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -3189,11 +3189,10 @@ class \nodoc\ iso _TestLambdaCapture is UnitTest
 
 class \nodoc\ iso _TestUnsafePointer is UnitTest
   """
-  Exercise the public surface of the builtin UnsafePointer type so that its
-  intrinsic codegen path is actually reached and guarded. The private
-  intrinsics (_alloc, _apply, _update, _copy_to, ...) are package-private to
-  builtin and are exercised by the String.copy_* tests once those signatures
-  take an UnsafePointer.
+  Exercise the public surface of the builtin UnsafePointer type. That surface is
+  deliberately small: a null constructor, is_null, and usize (for sentinel
+  comparisons). The private read/copy intrinsics (_apply, _copy_to) are exercised
+  by the String.copy_* tests.
   """
   fun name(): String => "builtin/UnsafePointer"
 
@@ -3202,24 +3201,6 @@ class \nodoc\ iso _TestUnsafePointer is UnitTest
     let p = UnsafePointer[U8]
     h.assert_true(p.is_null())
     h.assert_eq[USize](p.usize(), 0)
-    h.assert_true(p == UnsafePointer[U8])
-
-    // offset exercises _unsafe and _offset; U8 elements are one byte each.
-    let q = p.offset(8)
-    h.assert_eq[USize](q.usize(), 8)
-    h.assert_false(q.is_null())
-
-    // Address comparison operators.
-    h.assert_false(p == q)
-    h.assert_true(p != q)
-    h.assert_true(p < q)
-    h.assert_true(p <= q)
-    h.assert_true(q > p)
-    h.assert_true(q >= p)
-
-    // hash is derived from the address.
-    h.assert_eq[USize](p.hash(), USize(0).hash())
-    h.assert_eq[U64](p.hash64(), U64(0).hash64())
 
 class \nodoc\ iso _TestStringCopyUnsafePointer is UnitTest
   """

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -12,6 +12,12 @@ use @pony_exitcode[None](code: I32)
 use @pony_get_exitcode[I32]()
 use @pony_triggergc[None](ctx: Pointer[None])
 use @ponyint_pagemap_get_chunk[Pointer[None]](p: Pointer[None] tag)
+// Used to simulate genuinely-foreign (non-pony_alloc'd) memory so that the
+// UnsafePointer copy constructors can be exercised on real data.
+use @malloc[UnsafePointer[U8]](size: USize)
+use @free[None](p: UnsafePointer[U8])
+use @memcpy[Pointer[None]](dst: UnsafePointer[U8], src: Pointer[U8] tag,
+  n: USize)
 
 use "pony_test"
 use "collections"
@@ -32,6 +38,7 @@ actor \nodoc\ Main is TestList
     test(_TestArrayConcat)
     test(_TestArrayFind)
     test(_TestArrayFromCPointer)
+    test(_TestUnsafePointer)
     test(_TestArrayCopyTo)
     test(_TestArrayInsert)
     test(_TestArrayReserveMinAlloc)
@@ -76,6 +83,7 @@ actor \nodoc\ Main is TestList
     test(_TestStringCut)
     test(_TestStringFromArray)
     test(_TestStringFromCPointer)
+    test(_TestStringCopyUnsafePointer)
     test(_TestStringFromIsoArray)
     test(_TestStringIsNullTerminated)
     test(_TestStringJoin)
@@ -3178,3 +3186,79 @@ class \nodoc\ iso _TestLambdaCapture is UnitTest
     let x = "hi"
     let f = {(y: String): String => x + y}
     h.assert_eq[String]("hi there", f(" there"))
+
+class \nodoc\ iso _TestUnsafePointer is UnitTest
+  """
+  Exercise the public surface of the builtin UnsafePointer type so that its
+  intrinsic codegen path is actually reached and guarded. The private
+  intrinsics (_alloc, _apply, _update, _copy_to, ...) are package-private to
+  builtin and are exercised by the String.copy_* tests once those signatures
+  take an UnsafePointer.
+  """
+  fun name(): String => "builtin/UnsafePointer"
+
+  fun apply(h: TestHelper) =>
+    // A default UnsafePointer is null.
+    let p = UnsafePointer[U8]
+    h.assert_true(p.is_null())
+    h.assert_eq[USize](p.usize(), 0)
+    h.assert_true(p == UnsafePointer[U8])
+
+    // offset exercises _unsafe and _offset; U8 elements are one byte each.
+    let q = p.offset(8)
+    h.assert_eq[USize](q.usize(), 8)
+    h.assert_false(q.is_null())
+
+    // Address comparison operators.
+    h.assert_false(p == q)
+    h.assert_true(p != q)
+    h.assert_true(p < q)
+    h.assert_true(p <= q)
+    h.assert_true(q > p)
+    h.assert_true(q >= p)
+
+    // hash is derived from the address.
+    h.assert_eq[USize](p.hash(), USize(0).hash())
+    h.assert_eq[U64](p.hash64(), U64(0).hash64())
+
+class \nodoc\ iso _TestStringCopyUnsafePointer is UnitTest
+  """
+  String.copy_cstring and String.copy_cpointer take an UnsafePointer and copy
+  its bytes into Pony-managed memory. We simulate genuinely-foreign memory with
+  malloc (the honest UnsafePointer source) and confirm the data is copied. This
+  exercises UnsafePointer's private _apply and _copy_to intrinsics on real data.
+  """
+  fun name(): String => "builtin/String.copy_cpointer/copy_cstring(UnsafePointer)"
+
+  fun apply(h: TestHelper) =>
+    // A null UnsafePointer yields an empty string.
+    h.assert_eq[USize](0, String.copy_cstring(UnsafePointer[U8]).size())
+    h.assert_eq[USize](0, String.copy_cpointer(UnsafePointer[U8], 0).size())
+
+    // copy_cstring scans for the null terminator. The foreign buffer is built
+    // and freed inside the recover so the resulting String can be val; the data
+    // is copied, so freeing the buffer afterward is safe.
+    let src = "hello"
+    let copied_cstring =
+      recover val
+        let buf = @malloc(src.size() + 1)
+        @memcpy(buf, src.cstring(), src.size() + 1)
+        let s = String.copy_cstring(buf)
+        @free(buf)
+        s
+      end
+    h.assert_eq[String]("hello", copied_cstring)
+    h.assert_eq[USize](5, copied_cstring.size())
+
+    // copy_cpointer copies a fixed number of bytes (no null scan).
+    let bin = "world"
+    let copied_cpointer =
+      recover val
+        let buf = @malloc(bin.size())
+        @memcpy(buf, bin.cstring(), bin.size())
+        let s = String.copy_cpointer(buf, bin.size())
+        @free(buf)
+        s
+      end
+    h.assert_eq[String]("world", copied_cpointer)
+    h.assert_eq[USize](5, copied_cpointer.size())

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -20,21 +20,21 @@ use @futimesat[I32](fd: I32, path: Pointer[U8] tag,
 use @fchownat[I32](fd: I32, path: Pointer[U8] tag, uid: U32, gid: U32, flags: I32) if linux or bsd
 use @fchmodat[I32](fd: I32, path: Pointer[U8] tag, mode: U32, flag: I32) if linux or bsd
 use @mkdirat[I32](fd: I32, path: Pointer[U8] tag, mode: U32)
-use @fdopendir[Pointer[_DirectoryHandle]](fd: I32) if posix
-use @opendir[Pointer[_DirectoryHandle]](name: Pointer[U8] tag) if posix
-use @closedir[I32](dir: Pointer[_DirectoryHandle] tag) if posix
-use @ponyint_unix_readdir[Pointer[U8] iso^](dir: Pointer[None] tag)
-use @ponyint_windows_find_data[Pointer[_DirectoryEntry]]()
+use @fdopendir[UnsafePointer[_DirectoryHandle]](fd: I32) if posix
+use @opendir[UnsafePointer[_DirectoryHandle]](name: Pointer[U8] tag) if posix
+use @closedir[I32](dir: UnsafePointer[_DirectoryHandle] tag) if posix
+use @ponyint_unix_readdir[Pointer[U8] iso^](dir: UnsafePointer[None] tag)
+use @ponyint_windows_find_data[UnsafePointer[_DirectoryEntry]]()
   if windows
-use @ponyint_windows_find_data_free[None](data: Pointer[_DirectoryEntry])
+use @ponyint_windows_find_data_free[None](data: UnsafePointer[_DirectoryEntry])
   if windows
-use @ponyint_windows_readdir[Pointer[U8] iso^](data: Pointer[_DirectoryEntry])
+use @ponyint_windows_readdir[Pointer[U8] iso^](data: UnsafePointer[_DirectoryEntry])
   if windows
-use @FindFirstFileA[Pointer[_DirectoryHandle]](file_name: Pointer[U8] tag, data: Pointer[_DirectoryEntry])
+use @FindFirstFileA[UnsafePointer[_DirectoryHandle]](file_name: Pointer[U8] tag, data: UnsafePointer[_DirectoryEntry])
   if windows
-use @FindNextFileA[Bool](handle: Pointer[None] tag, data: Pointer[_DirectoryEntry])
+use @FindNextFileA[Bool](handle: UnsafePointer[None] tag, data: UnsafePointer[_DirectoryEntry])
   if windows
-use @FindClose[Bool](handle: Pointer[_DirectoryHandle] tag) if windows
+use @FindClose[Bool](handle: UnsafePointer[_DirectoryHandle] tag) if windows
 
 primitive _DirectoryHandle
 primitive _DirectoryEntry

--- a/packages/net/dns.pony
+++ b/packages/net/dns.pony
@@ -1,8 +1,8 @@
-use @pony_os_addrinfo[Pointer[U8]](family: U32, host: Pointer[U8] tag,
+use @pony_os_addrinfo[UnsafePointer[U8]](family: U32, host: Pointer[U8] tag,
   service: Pointer[U8] tag)
-use @pony_os_getaddr[None](addr: Pointer[None] tag, ipaddr: NetAddress tag)
-use @pony_os_nextaddr[Pointer[U8]](addr: Pointer[None] tag)
-use @freeaddrinfo[None](addr: Pointer[None] tag)
+use @pony_os_getaddr[None](addr: UnsafePointer[None] tag, ipaddr: NetAddress tag)
+use @pony_os_nextaddr[UnsafePointer[U8]](addr: UnsafePointer[None] tag)
+use @freeaddrinfo[None](addr: UnsafePointer[None] tag)
 use @pony_os_host_ip4[Bool](host: Pointer[U8] tag)
 use @pony_os_host_ip6[Bool](host: Pointer[U8] tag)
 

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -120,6 +120,7 @@ static void init_runtime(compile_t* c)
   c->str_F32 = stringtab(c->opt->strtab, "F32");
   c->str_F64 = stringtab(c->opt->strtab, "F64");
   c->str_Pointer = stringtab(c->opt->strtab, "Pointer");
+  c->str_UnsafePointer = stringtab(c->opt->strtab, "UnsafePointer");
   c->str_NullablePointer = stringtab(c->opt->strtab, "NullablePointer");
   c->str_DoNotOptimise = stringtab(c->opt->strtab, "DoNotOptimise");
   c->str_Array = stringtab(c->opt->strtab, "Array");

--- a/src/libponyc/codegen/codegen.h
+++ b/src/libponyc/codegen/codegen.h
@@ -124,6 +124,7 @@ typedef struct compile_t
   const char* str_F32;
   const char* str_F64;
   const char* str_Pointer;
+  const char* str_UnsafePointer;
   const char* str_NullablePointer;
   const char* str_DoNotOptimise;
   const char* str_Array;

--- a/src/libponyc/codegen/gencall.c
+++ b/src/libponyc/codegen/gencall.c
@@ -302,8 +302,8 @@ static bool call_needs_receiver(ast_t* postfix, reach_type_t* t)
       if(((compile_type_t*)t->c_type)->primitive != NULL)
         return false;
 
-      // No receiver if a new Pointer or NullablePointer.
-      if(is_pointer(t->ast) || is_nullable_pointer(t->ast))
+      // No receiver if a new Pointer, UnsafePointer or NullablePointer.
+      if(is_raw_pointer(t->ast) || is_nullable_pointer(t->ast))
         return false;
 
       return true;
@@ -1393,8 +1393,8 @@ LLVMValueRef gencall_alloc(compile_t* c, reach_type_t* t, ast_t* call)
   if(c_t->primitive != NULL)
     return NULL;
 
-  // Do nothing for Pointer and NullablePointer.
-  if(is_pointer(t->ast) || is_nullable_pointer(t->ast))
+  // Do nothing for Pointer, UnsafePointer and NullablePointer.
+  if(is_raw_pointer(t->ast) || is_nullable_pointer(t->ast))
     return NULL;
 
   // Use the global instance if we have one.

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -774,7 +774,8 @@ static bool genfun_allocator(compile_t* c, reach_type_t* t)
   compile_type_t* c_t = (compile_type_t*)t->c_type;
 
   // No allocator for machine word types or pointers.
-  if((c_t->primitive != NULL) || is_pointer(t->ast) || is_nullable_pointer(t->ast))
+  if((c_t->primitive != NULL) || is_raw_pointer(t->ast) ||
+    is_nullable_pointer(t->ast))
     return true;
 
   const char* funname = genname_alloc(t->name, c->opt->strtab);

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -70,7 +70,7 @@ static int print_pointer_type(compile_t* c, printbuf_t* buf, ast_t* type)
   ast_t* typeargs = ast_childidx(type, 2);
   ast_t* elem = ast_child(typeargs);
 
-  if(is_pointer(elem) || is_nullable_pointer(elem))
+  if(is_raw_pointer(elem) || is_nullable_pointer(elem))
     return print_pointer_type(c, buf, elem) + 1;
 
   print_base_type(c, buf, elem);
@@ -79,7 +79,7 @@ static int print_pointer_type(compile_t* c, printbuf_t* buf, ast_t* type)
 
 static void print_type_name(compile_t* c, printbuf_t* buf, ast_t* type)
 {
-  if(is_pointer(type) || is_nullable_pointer(type))
+  if(is_raw_pointer(type) || is_nullable_pointer(type))
   {
     int depth = print_pointer_type(c, buf, type);
 
@@ -239,7 +239,7 @@ static void print_types(compile_t* c, FILE* fp, printbuf_t* buf)
         fprintf(fp, "/*\n%s*/\n", ast_name(docstring));
     }
 
-    if(!is_pointer(t->ast) && !is_nullable_pointer(t->ast) && !is_machine_word(t->ast))
+    if(!is_raw_pointer(t->ast) && !is_nullable_pointer(t->ast) && !is_machine_word(t->ast))
     {
       // Forward declare an opaque type.
       fprintf(fp, "typedef struct %s %s;\n\n", t->name, t->name);

--- a/src/libponyc/codegen/gentype.c
+++ b/src/libponyc/codegen/gentype.c
@@ -146,7 +146,7 @@ static bool make_opaque_struct(compile_t* c, reach_type_t* t)
 
           return true;
         }
-        else if(name == c->str_Pointer)
+        else if((name == c->str_Pointer) || (name == c->str_UnsafePointer))
         {
           c_t->use_type = c->ptr;
           c_t->mem_type = c->ptr;
@@ -649,7 +649,7 @@ static void make_intrinsic_methods(compile_t* c, reach_type_t* t)
 
   if(package == c->str_builtin)
   {
-    if(name == c->str_Pointer)
+    if((name == c->str_Pointer) || (name == c->str_UnsafePointer))
       genprim_pointer_methods(c, t);
     else if(name == c->str_NullablePointer)
       genprim_nullable_pointer_methods(c, t);

--- a/src/libponyc/expr/ffi.c
+++ b/src/libponyc/expr/ffi.c
@@ -12,7 +12,10 @@ bool void_star_param(ast_t* param_type, ast_t* arg_type)
   pony_assert(param_type != NULL);
   pony_assert(arg_type != NULL);
 
-  if(!is_pointer(param_type))
+  bool param_safe = is_pointer(param_type);
+  bool param_unsafe = is_unsafe_pointer(param_type);
+
+  if(!param_safe && !param_unsafe)
     return false;
 
   ast_t* type_args = ast_childidx(param_type, 2);
@@ -20,17 +23,22 @@ bool void_star_param(ast_t* param_type, ast_t* arg_type)
   if(ast_childcount(type_args) != 1 || !is_none(ast_child(type_args)))
     return false;
 
-  // Parameter type is Pointer[None]
-  // If the argument is Pointer[A], NullablePointer[A] or USize, allow it
+  // Parameter type is Pointer[None] or UnsafePointer[None]. A C void* means
+  // nothing to us, so we map it to whichever raw pointer the parameter actually
+  // declares: the two kinds do not interchange. A Pointer[None] param accepts
+  // Pointer[A], NullablePointer[A] or USize; an UnsafePointer[None] param
+  // accepts UnsafePointer[A] or USize. USize is provenance-neutral (a raw
+  // integer address), so it is allowed for either kind.
   while(ast_id(arg_type) == TK_ARROW)
     arg_type = ast_childidx(arg_type, 1);
 
-  if(is_pointer(arg_type) ||
-    is_nullable_pointer(arg_type) ||
-    is_literal(arg_type, "USize"))
+  if(is_literal(arg_type, "USize"))
     return true;
 
-  return false;
+  if(param_safe)
+    return is_pointer(arg_type) || is_nullable_pointer(arg_type);
+
+  return is_unsafe_pointer(arg_type);
 }
 
 static bool declared_ffi(pass_opt_t* opt, ast_t* call, ast_t* decl)

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -959,11 +959,12 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
   ast_t* def = (ast_t*)ast_data(ast);
   pony_assert(def != NULL);
 
-  // Special case: don't check the constraint of a Pointer or an Array. These
-  // builtin types have no contraint on their type parameter, and it is safe
-  // to bind a struct as a type argument (which is not safe on any user defined
-  // type, as that type might then be used for pattern matching).
-  if(is_pointer(ast) || is_literal(ast, "Array"))
+  // Special case: don't check the constraint of a Pointer, an UnsafePointer or
+  // an Array. These builtin types have no contraint on their type parameter,
+  // and it is safe to bind a struct as a type argument (which is not safe on
+  // any user defined type, as that type might then be used for pattern
+  // matching).
+  if(is_raw_pointer(ast) || is_literal(ast, "Array"))
     return true;
 
   ast_t* typeparams = ast_childidx(def, 1);

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -544,7 +544,7 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
 
       if(ok &&
         (ast_id(check_type) != TK_NOMINAL ||
-          is_pointer(check_type) || is_nullable_pointer(check_type)))
+          is_raw_pointer(check_type) || is_nullable_pointer(check_type)))
         ok = false;
 
       if(ok)

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -973,7 +973,7 @@ static bool is_nominal_sub_entity(ast_t* sub, ast_t* super,
   ast_t* super_def = (ast_t*)ast_data(super);
   bool ret = true;
 
-  if(is_bare(sub, opt) && is_pointer(super))
+  if(is_bare(sub, opt) && is_raw_pointer(super))
   {
     ast_t* super_typeargs = ast_childidx(super, 2);
     ast_t* super_typearg = ast_child(super_typeargs);
@@ -2202,6 +2202,16 @@ bool is_literal(ast_t* type, const char* name)
 bool is_pointer(ast_t* type)
 {
   return is_literal(type, "Pointer");
+}
+
+bool is_unsafe_pointer(ast_t* type)
+{
+  return is_literal(type, "UnsafePointer");
+}
+
+bool is_raw_pointer(ast_t* type)
+{
+  return is_pointer(type) || is_unsafe_pointer(type);
 }
 
 bool is_nullable_pointer(ast_t* type)

--- a/src/libponyc/type/subtype.h
+++ b/src/libponyc/type/subtype.h
@@ -31,6 +31,10 @@ bool is_sub_provides(ast_t* type, ast_t* provides, errorframe_t* errorf,
 
 bool is_pointer(ast_t* type);
 
+bool is_unsafe_pointer(ast_t* type);
+
+bool is_raw_pointer(ast_t* type);
+
 bool is_nullable_pointer(ast_t* type);
 
 bool is_none(ast_t* type);

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_source.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_source.pony
@@ -3,7 +3,7 @@ use @source_open_string[NullablePointer[_Source]](source_code: Pointer[U8] tag)
 use @source_close[None](source: _Source)
 
 struct _Source
-  let file: Pointer[U8] val = file.create()
+  let file: UnsafePointer[U8] val = file.create()
     """
     Absolute path to the file of this source.
     """

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
@@ -24,7 +24,7 @@ struct _Symbol
     size_t branch_count;
   } symbol_t;
   """
-  let name: Pointer[U8] val = name.create()
+  let name: UnsafePointer[U8] val = name.create()
   let def: Pointer[_AST] val = def.create()
   let status: SymStatus = status.create()
   let branch_count: USize = 0

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
@@ -18,12 +18,12 @@ use @ast_free[None](ast: Pointer[_AST] box)
 // only free the AST if it has no parent
 use @ast_free_unattached[None](ast: Pointer[_AST])
 // only for string or id
-use @ast_name[Pointer[U8] val](ast: Pointer[_AST] box)
+use @ast_name[UnsafePointer[U8] val](ast: Pointer[_AST] box)
 use @ast_name_len[USize](ast: Pointer[_AST] box)
-use @ast_nice_name[Pointer[U8] val](ast: Pointer[_AST] box)
+use @ast_nice_name[UnsafePointer[U8] val](ast: Pointer[_AST] box)
 use @ast_type[Pointer[_AST] val](ast: Pointer[_AST] box)
-use @ast_print_type[Pointer[U8] val](ast: Pointer[_AST] box, strtab: Pointer[_StrTable] tag)
-use @ast_print[Pointer[U8] val](ast: Pointer[_AST] box, width: USize)
+use @ast_print_type[UnsafePointer[U8] val](ast: Pointer[_AST] box, strtab: Pointer[_StrTable] tag)
+use @ast_print[UnsafePointer[U8] val](ast: Pointer[_AST] box, width: USize)
 // mark the given AST as having its own scope
 //use @ast_scope[None](ast: _AST ref)
 use @ast_get[Pointer[_AST] val](ast: Pointer[_AST] box, name: Pointer[U8] tag, status: NullablePointer[SymStatus])
@@ -38,7 +38,7 @@ use @ast_childcount[USize](ast: Pointer[_AST] box)
 use @ast_data[Pointer[None]](ast: Pointer[_AST] box)
 use @ast_index[USize](ast: Pointer[_AST] box)
 use @ast_has_annotation[Bool](ast: Pointer[_AST] box, name: Pointer[U8] tag, strtab: Pointer[_StrTable] tag)
-use @ast_get_print[Pointer[U8] val](ast: Pointer[_AST] box)
+use @ast_get_print[UnsafePointer[U8] val](ast: Pointer[_AST] box)
 
 
 primitive _AST

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/errors.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/errors.pony
@@ -111,11 +111,11 @@ class val Error
 
 
 struct val _ErrorMsg
-  var file: Pointer[U8] val = recover val file.create() end
+  var file: UnsafePointer[U8] val = recover val file.create() end
   var line: USize = 0
   var pos: USize = 0
-  var msg: Pointer[U8] val = recover val msg.create() end
-  var source: Pointer[U8] val = recover val source.create() end
+  var msg: UnsafePointer[U8] val = recover val msg.create() end
+  var source: UnsafePointer[U8] val = recover val source.create() end
   var frame: NullablePointer[_ErrorMsg] val = frame.none()
   var next: NullablePointer[_ErrorMsg] val = next.none()
 

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/package.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/package.pony
@@ -77,17 +77,17 @@ primitive _PackageGroup
   """STUB"""
 
 struct _Package
-  let _path: Pointer[U8] val = _path.create()
+  let _path: UnsafePointer[U8] val = _path.create()
     """absolute path"""
-  let _qualified_name: Pointer[U8] val = _qualified_name.create()
+  let _qualified_name: UnsafePointer[U8] val = _qualified_name.create()
     """
     For pretty printing, eg "builtin"
     """
-  let _id: Pointer[U8] val = _id.create()
+  let _id: UnsafePointer[U8] val = _id.create()
     """hygienic identifier"""
-  let _filename: Pointer[U8] val = _filename.create()
+  let _filename: UnsafePointer[U8] val = _filename.create()
     """directory name"""
-  let symbol: Pointer[U8] val = symbol.create()
+  let symbol: UnsafePointer[U8] val = symbol.create()
     """Wart to use for symbol names"""
   let ast: Pointer[_AST] = ast.create()
   let dependencies: Pointer[_PackageSet] = dependencies.create()

--- a/tools/lib/ponylang/pony_compiler/tests/main.pony
+++ b/tools/lib/ponylang/pony_compiler/tests/main.pony
@@ -229,7 +229,7 @@ class \nodoc\ _DefinitionTest is UnitTest
     (Position.create(7, 20), [Position.create(4, 1)], TokenIds.tk_class()) // nominal reference to type in a different file
     (Position.create(8, 5), [Position.create(5, 3)], TokenIds.tk_fvar())
     (Position.create(10, 16), [Position.create(54, 3)], TokenIds.tk_new()) // reference to constructor in a different file
-    (Position.create(10, 30), [Position.create(926, 3)], TokenIds.tk_fun()) // reference to function in a different file
+    (Position.create(10, 30), [Position.create(930, 3)], TokenIds.tk_fun()) // reference to function in a different file
     (Position.create(12, 6), [Position.create(7, 14)], TokenIds.tk_param())
     (Position.create(12, 10), [Position.create(19, 3)], TokenIds.tk_flet()) // reference to behavior in a different file
     (Position.create(12, 15), [Position.create(20, 3)], TokenIds.tk_be()) // reference to behavior in a different file

--- a/tools/pony-doc/main.pony
+++ b/tools/pony-doc/main.pony
@@ -6,9 +6,7 @@ use ast = "pony_compiler"
 use @get_compiler_exe_directory[Bool](
   output_path: Pointer[U8] tag,
   argv0: Pointer[U8] tag)
-use @ponyint_pool_alloc_size[Pointer[U8] val](size: USize)
-use @ponyint_pool_free_size[None](
-  size: USize, p: Pointer[U8] tag)
+use @strlen[USize](s: Pointer[U8] tag)
 
 actor Main
   """
@@ -162,17 +160,12 @@ actor Main
     Find the directory containing the currently running executable
     using the same platform-specific mechanism as ponyc.
     """
-    let buf_size: USize = 4096
-    let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, argv0.cstring())
-    then
-      let result =
-        recover val
-          String.copy_cstring(buf)
-        end
-      @ponyint_pool_free_size(buf_size, buf)
-      result
+    // Hand C a Pony-allocated buffer to fill, then keep it as the result
+    // String: it is a Pony object start to finish, never foreign memory.
+    let buf = recover Array[U8] .> undefined(USize(4096)) end
+    if @get_compiler_exe_directory(buf.cpointer(), argv0.cstring()) then
+      buf.truncate(@strlen(buf.cpointer()))
+      String.from_array(consume buf)
     else
-      @ponyint_pool_free_size(buf_size, buf)
       None
     end

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -6,9 +6,7 @@ use "path:../lib/ponylang/pony_compiler/"
 use @get_compiler_exe_directory[Bool](
   output_path: Pointer[U8] tag,
   argv0: Pointer[U8] tag)
-use @ponyint_pool_alloc_size[Pointer[U8] val](size: USize)
-use @ponyint_pool_free_size[None](
-  size: USize, p: Pointer[U8] tag)
+use @strlen[USize](s: Pointer[U8] tag)
 
 actor Main
   """
@@ -347,15 +345,12 @@ actor Main
     Find the directory containing the currently running executable
     using the same platform-specific mechanism as ponyc.
     """
-    let buf_size: USize = 4096
-    let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, argv0.cstring())
-    then
-      let result =
-        recover val String.copy_cstring(buf) end
-      @ponyint_pool_free_size(buf_size, buf)
-      result
+    // Hand C a Pony-allocated buffer to fill, then keep it as the result
+    // String: it is a Pony object start to finish, never foreign memory.
+    let buf = recover Array[U8] .> undefined(USize(4096)) end
+    if @get_compiler_exe_directory(buf.cpointer(), argv0.cstring()) then
+      buf.truncate(@strlen(buf.cpointer()))
+      String.from_array(consume buf)
     else
-      @ponyint_pool_free_size(buf_size, buf)
       None
     end

--- a/tools/pony-lsp/compiler_notify.pony
+++ b/tools/pony-lsp/compiler_notify.pony
@@ -6,8 +6,7 @@ use "files"
 use @get_compiler_exe_directory[Bool](
   output_path: Pointer[U8] tag,
   argv0: Pointer[U8] tag)
-use @ponyint_pool_alloc_size[Pointer[U8] val](size: USize)
-use @ponyint_pool_free_size[None](size: USize, p: Pointer[U8] tag)
+use @strlen[USize](s: Pointer[U8] tag)
 
 actor PonyCompiler is LspCompiler
   """
@@ -78,17 +77,13 @@ actor PonyCompiler is LspCompiler
     Find the directory containing the currently running executable
     using the same platform-specific mechanism as ponyc.
     """
-    let buf_size: USize = 4096
-    let buf = @ponyint_pool_alloc_size(buf_size)
-    if @get_compiler_exe_directory(buf, argv0.cstring()) then
-      let result =
-        recover
-          val String.copy_cstring(buf)
-        end
-      @ponyint_pool_free_size(buf_size, buf)
-      result
+    // Hand C a Pony-allocated buffer to fill, then keep it as the result
+    // String: it is a Pony object start to finish, never foreign memory.
+    let buf = recover Array[U8] .> undefined(USize(4096)) end
+    if @get_compiler_exe_directory(buf.cpointer(), argv0.cstring()) then
+      buf.truncate(@strlen(buf.cpointer()))
+      String.from_array(consume buf)
     else
-      @ponyint_pool_free_size(buf_size, buf)
       None
     end
 

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -191,7 +191,7 @@ class \nodoc\ iso _DefinitionTypeAliasIntegrationTest is UnitTest
       [ // `Map` type alias in `Map[String, U32]` → Map type alias declaration
         _DefinitionChecker(13, 13, [("map.pony", (3, 0), (7, 5))])
         // `String` type arg in `Map[String, U32]` → String class declaration
-        _DefinitionChecker(13, 17, [("string.pony", (8, 0), (1687, 25))])
+        _DefinitionChecker(13, 17, [("string.pony", (8, 0), (1691, 25))])
         // `U32` type arg in `Map[String, U32]` → U32 primitive declaration
         _DefinitionChecker(
           13,


### PR DESCRIPTION
This splits the one `Pointer` we have today into two: `Pointer` for memory Pony allocates and manages, and `UnsafePointer` for foreign memory that came across the C-FFI boundary. The codegen is identical. The difference lives entirely in the type system and in where each one is allowed: a `Pointer` can be adopted in place as the backing store of a `String` or `Array`, while an `UnsafePointer` can only get its bytes into a safe Pony object by being copied. It grew out of #4925, where the capabilities on FFI pointers turned out to be a Pony-side fiction and LLVM 21 started deleting reads based on it.

It covers the compiler, the standard library, and the libponyc-wrapping tools, and `UnsafePointer` is trimmed to the six methods anything actually calls on a foreign handle.

This is a spike for Joe and me to review, not a merge. The lint rule, release notes, and a couple of completeness sweeps are still outstanding. The full design, the decisions we settled, and what's left are in the discussion.

Design: #5427
