### PR TITLE
Reject unsupported sanitizer build options on DragonFly

### DIFF
--- a/.ci-scripts/dragonfly-reject-unsupported-builds.sh
+++ b/.ci-scripts/dragonfly-reject-unsupported-builds.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Assert that ponyc rejects the unsupported `use=` build options on DragonFly.
+# Runs inside the DragonFly VM, invoked from .github/workflows/ponyc-tier3.yml.
+# POSIX sh (DragonFly's /bin/sh). Expects to run from the ponyc source root.
+#
+# DragonFly builds ponyc with the gcc13 package, whose toolchain ships no
+# AddressSanitizer/ThreadSanitizer/UndefinedBehaviorSanitizer runtime (GCC's
+# libsanitizer has no DragonFly target), so these use= options can't link there.
+# `gmake configure` rejects them with a clear error at make-parse time, before
+# `gmake libs` runs, so this assertion needs no LLVM build or gcc13 toolchain.
+# Check each fails AND fails for the documented reason: a typo in the OS string
+# would otherwise silently regress to the confusing partway-through build failure
+# the guards exist to prevent. (Only the three sanitizers are rejected: coverage
+# and valgrind do work on DragonFly. use=dtrace is also unavailable, but by its
+# own which-dtrace check with a different message.)
+set -eu
+
+for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer; do
+  if out=$(gmake configure use="$u" 2>&1); then
+    echo "FAIL: use=$u was not rejected on DragonFly"
+    exit 1
+  fi
+  if ! printf '%s\n' "$out" | grep -q "not supported on DragonFly"; then
+    echo "FAIL: use=$u failed for an unexpected reason:"
+    printf '%s\n' "$out"
+    exit 1
+  fi
+done
+echo "unsupported use= options correctly rejected on DragonFly"

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -539,6 +539,13 @@ jobs:
         run: |
           rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
             "$GITHUB_WORKSPACE/" root@localhost:/build/ponyc/
+      - name: Assert unsupported build options are rejected
+        run: |
+          ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 root@localhost /bin/sh <<'EOF'
+          set -e
+          cd /build/ponyc
+          sh .ci-scripts/dragonfly-reject-unsupported-builds.sh
+          EOF
       - name: Build and test
         run: |
           ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i vm_key -p 2222 root@localhost /bin/sh <<'EOF'

--- a/BUILD.md
+++ b/BUILD.md
@@ -81,6 +81,16 @@ sudo gmake install
 
 Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 
+### Unsupported build options
+
+The sanitizer `use=` build options aren't supported on DragonFly, because the `gcc13` toolchain ponyc builds with doesn't ship their runtimes (GCC's libsanitizer has no DragonFly target, so no `libasan`/`libtsan`/`libubsan` is built):
+
+- `use=address_sanitizer` — no AddressSanitizer runtime, so the link fails (`cannot find -lasan`).
+- `use=thread_sanitizer` — no ThreadSanitizer runtime, so the link fails (`cannot find -ltsan`).
+- `use=undefined_behavior_sanitizer` — no UndefinedBehaviorSanitizer runtime, so the link fails (`cannot find -lubsan`).
+
+`gmake configure` rejects these uses on DragonFly with an error rather than letting the build fail partway through with a confusing linker message.
+
 ## Linux
 
 ```bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -55,7 +55,7 @@ doas gmake install
 
 Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 
-### Unsupported build options
+### Unsupported OpenBSD build options
 
 Several `use=` build options aren't supported on OpenBSD, because OpenBSD doesn't ship the runtime, headers, or tooling they depend on:
 
@@ -81,7 +81,7 @@ sudo gmake install
 
 Note that you only need to run `gmake libs` once the first time you build (or if the version of LLVM in the `lib/llvm/src` Git submodule changes).
 
-### Unsupported build options
+### Unsupported DragonFly BSD build options
 
 The sanitizer `use=` build options aren't supported on DragonFly, because the `gcc13` toolchain ponyc builds with doesn't ship their runtimes (GCC's libsanitizer has no DragonFly target, so no `libasan`/`libtsan`/`libubsan` is built):
 

--- a/Makefile
+++ b/Makefile
@@ -134,15 +134,24 @@ define USE_CHECK
     ifeq ($$(HOST_OS),OpenBSD)
       $$(error ThreadSanitizer is not supported on OpenBSD: the base toolchain ships no ThreadSanitizer runtime. See BUILD.md)
     endif
+    ifeq ($$(HOST_OS),DragonFly)
+      $$(error ThreadSanitizer is not supported on DragonFly: the gcc toolchain ships no ThreadSanitizer runtime. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_THREAD_SANITIZER=true
   else ifeq ($1,address_sanitizer)
     ifeq ($$(HOST_OS),OpenBSD)
       $$(error AddressSanitizer is not supported on OpenBSD: the base toolchain ships no AddressSanitizer runtime. See BUILD.md)
     endif
+    ifeq ($$(HOST_OS),DragonFly)
+      $$(error AddressSanitizer is not supported on DragonFly: the gcc toolchain ships no AddressSanitizer runtime. See BUILD.md)
+    endif
     PONY_USES += -DPONY_USE_ADDRESS_SANITIZER=true
   else ifeq ($1,undefined_behavior_sanitizer)
     ifeq ($$(HOST_OS),OpenBSD)
       $$(error UndefinedBehaviorSanitizer is not supported on OpenBSD: the base toolchain ships only the minimal UBSan runtime, not the standalone runtime ponyc links against. See BUILD.md)
+    endif
+    ifeq ($$(HOST_OS),DragonFly)
+      $$(error UndefinedBehaviorSanitizer is not supported on DragonFly: the gcc toolchain ships no UndefinedBehaviorSanitizer runtime. See BUILD.md)
     endif
     PONY_USES += -DPONY_USE_UNDEFINED_BEHAVIOR_SANITIZER=true
   else ifeq ($1,coverage)


### PR DESCRIPTION
DragonFly builds ponyc with the `gcc13` package, whose toolchain ships no AddressSanitizer/ThreadSanitizer/UndefinedBehaviorSanitizer runtime — GCC's libsanitizer has no DragonFly target, so no `libasan`/`libtsan`/`libubsan` is built. `use=address_sanitizer`, `use=thread_sanitizer`, and `use=undefined_behavior_sanitizer` therefore can't link and fail partway through with a confusing linker error.

This rejects those three at configure time with a clear message, mirroring the OpenBSD guards added in #5429. A tier-3 DragonFly CI script asserts each is rejected (and fails for the documented reason), so a regression can't silently restore the confusing failure.

`coverage` and `valgrind` are deliberately left untouched: both work on DragonFly (gcc ships libgcov/gcov13; the `valgrind-lts` port provides the headers and a working binary). Verified on a DragonFly 6.4.2 VM, along with the rejection of all three sanitizers.

Part of phase 7 of #4941 (embedded LLD; removing the legacy linker path).