### PR TITLE
Document DragonFly coverage/valgrind limits and fix dtrace platform docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -91,6 +91,11 @@ The sanitizer `use=` build options aren't supported on DragonFly, because the `g
 
 `gmake configure` rejects these uses on DragonFly with an error rather than letting the build fail partway through with a confusing linker message.
 
+`use=coverage` and `use=valgrind` aren't rejected, but neither currently works on DragonFly:
+
+- `use=coverage` — the coverage-instrumented runtime needs `libgcov`, which ponyc's embedded linker doesn't supply, so linking any Pony program fails ([#5434](https://github.com/ponylang/ponyc/issues/5434)).
+- `use=valgrind` — builds, and the Pony programs it compiles link, but DragonFly ships Valgrind 3.15, which is too old to run a Pony program ([#5435](https://github.com/ponylang/ponyc/issues/5435)).
+
 ## Linux
 
 ```bash
@@ -204,7 +209,7 @@ make build
 
 ## dtrace
 
-BSD and Linux based versions of Pony support using DTrace and SystemTap for collecting Pony runtime events. MacOS while being "BSD-like" in places does not support Dtrace due to functionality having been removed by Apple.
+Linux and FreeBSD support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD. No other platform is supported: macOS removed DTrace, and neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool.
 
 DTrace support is enabled by setting `use=dtrace` in the build command line like:
 


### PR DESCRIPTION
Two BUILD.md corrections.

The DragonFly "Unsupported build options" section only covered the sanitizers and said nothing about coverage or valgrind. Neither works on DragonFly: `use=coverage` can't link the Pony programs it compiles because the embedded linker doesn't supply `libgcov` (#5434), and `use=valgrind` builds but DragonFly's Valgrind 3.15 is too old to run a Pony program (#5435). Documents both with links to the tracking issues.

The `## dtrace` section also claimed "BSD and Linux based versions of Pony support using DTrace," which wrongly sweeps in DragonFly and OpenBSD. Only Linux (SystemTap) and FreeBSD (DTrace) support it; macOS removed DTrace and neither DragonFly nor OpenBSD ships a probe-generation tool. This matches the per-platform "Unsupported build options" notes and the website.

Closes #5432