### PR TITLE
Reject tuple types hidden in an intersection within a type constraint

### DIFF
--- a/.release-notes/fix-tuple-in-intersection-constraint.md
+++ b/.release-notes/fix-tuple-in-intersection-constraint.md
@@ -1,0 +1,14 @@
+## Reject tuple types hidden in an intersection within a type constraint
+
+Tuple types can't be used as generic type constraints. The compiler already rejected a tuple smuggled into a constraint through a type alias, including when it was hidden inside a union. It did not, however, catch a tuple hidden inside an intersection, so the following incorrectly compiled:
+
+```pony
+type R is (U8 & (U8, U32))
+class Block[T: R]
+```
+
+The compiler now rejects this with the same error it already gives for tuples in unions:
+
+```
+constraint contains a tuple; tuple types can't be used as type constraints
+```

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -71,11 +71,14 @@ static bool constraint_contains_tuple(ast_t* type)
     }
 
     case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
     {
-      // Recurse into every member. Members can themselves be unions (a
-      // constraint isn't fully flattened when this runs during the visit
-      // of a contained typeparamref) or type aliases, so we must descend
-      // each one rather than scanning a single level.
+      // Recurse into every member. Members can themselves be unions,
+      // intersections (a constraint isn't fully flattened when this runs
+      // during the visit of a contained typeparamref) or type aliases, so we
+      // must descend each one rather than scanning a single level. A tuple in
+      // any member of an intersection still makes the constraint contain a
+      // tuple, so intersections descend the same way unions do.
       for(ast_t* child = ast_child(type); child != NULL;
         child = ast_sibling(child))
       {

--- a/test/libponyc/flatten.cc
+++ b/test/libponyc/flatten.cc
@@ -149,6 +149,65 @@ TEST_F(FlattenTest, TupleConstraintFirstInUnion)
   ASSERT_EQ(16, errormsg->pos);
 }
 
+// regression for #5405
+TEST_F(FlattenTest, TupleConstraintInIsect)
+{
+  // The tuple is hidden inside an intersection within an aliased constraint.
+  // The constraint-tuple scan must descend intersections as well as unions;
+  // an earlier version only descended unions, letting this compile.
+  const char* src =
+    "type Blocksize is (U8 & (U8, U32))\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
+// regression for #5405
+TEST_F(FlattenTest, TupleConstraintInIsectWithinUnion)
+{
+  // The tuple is nested inside an intersection that is itself a member of a
+  // union. The scan must descend through both compound types to reach it.
+  const char* src =
+    "type Blocksize is (U8 | (U32 & (U8, U32)))\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
+// regression for #5405
+TEST_F(FlattenTest, TupleConstraintInUnionWithinIsect)
+{
+  // The tuple is nested inside a union that is itself a member of an
+  // intersection. The scan must descend from the intersection into the union
+  // to reach it — the mirror of TupleConstraintInIsectWithinUnion.
+  const char* src =
+    "type Blocksize is (U8 & (U8 | (U8, U32)))\n"
+    "class Block[T: Blocksize]";
+
+  TEST_ERRORS_1(
+    src,
+    "constraint contains a tuple; tuple types can't be used as type constraints"
+  );
+  errormsg_t* errormsg = errors_get_first(opt.check.errors);
+
+  ASSERT_EQ(2, errormsg->line);
+  ASSERT_EQ(16, errormsg->pos);
+}
+
 TEST_F(FlattenTest, TupleConstraintInNestedUnion)
 {
   // The tuple is nested inside a union within a union. The scan used to


### PR DESCRIPTION
Tuple types can't be used as generic type constraints. The flatten pass's `constraint_contains_tuple` scan already caught a tuple smuggled into a constraint through a type alias, including when hidden inside a union, but it never descended intersections. So a tuple hidden inside an intersection in an aliased constraint — e.g. `type R is (U8 & (U8, U32))` — slipped through and the constraint was wrongly accepted.

Intersection members are structured identically to union members for this scan, so the new `TK_ISECTTYPE` arm shares the existing union member-recursion loop. The compiler now rejects the intersection case with the same error it already gives for tuples in unions.

Found during review of PR #5403.

Closes #5405