### PR TITLE
Use embedded LLD for FreeBSD use=dtrace builds

### DIFF
--- a/.ci-scripts/freebsd-dtrace-smoke.sh
+++ b/.ci-scripts/freebsd-dtrace-smoke.sh
@@ -37,7 +37,20 @@ actor Spinner
   be noop() => None
 PONY
 
-PONYPATH="$PWD/packages" ./build/debug-dtrace/ponyc -o "$smoke" "$smoke"
+# Link at -V 3 (VERBOSITY_TOOL_INFO) so the linker invocation is printed, and
+# assert it went through embedded LLD with the dtrace_probes whole-archive.
+# This pins the routing: the legacy compiler-driver path also links a working
+# dtrace program, so without this assertion a silent regression back to the
+# legacy driver would still build, link, run, and fire probes — passing the
+# rest of this smoke. The grep targets `ld.lld` (embedded LLD's argv[0], never
+# emitted by the legacy `cc` recipe) and the dtrace whole-archive fragment.
+PONYPATH="$PWD/packages" ./build/debug-dtrace/ponyc -V 3 -o "$smoke" "$smoke" \
+  2>"$smoke/link.log"
+grep -q 'ld\.lld' "$smoke/link.log" || {
+  echo "FAIL: dtrace link did not route through embedded LLD (no ld.lld)"; exit 1; }
+grep -q -- '--whole-archive -ldtrace_probes' "$smoke/link.log" || {
+  echo "FAIL: dtrace link missing --whole-archive -ldtrace_probes"; exit 1; }
+echo "dtrace link routed through embedded LLD"
 "$smoke/dtrace-smoke"
 
 # If the VM can load the dtrace device, assert a pony provider probe actually

--- a/.release-notes/use-embedded-lld-freebsd-dtrace.md
+++ b/.release-notes/use-embedded-lld-freebsd-dtrace.md
@@ -1,0 +1,3 @@
+## Use embedded LLD for FreeBSD use=dtrace builds
+
+When ponyc is built with `use=dtrace` on FreeBSD, it previously linked the programs it compiles through the system C compiler driver instead of the embedded LLD linker that other FreeBSD builds use. It now links those programs with embedded LLD as well, so a `use=dtrace` ponyc no longer needs an external C compiler driver to link the programs it builds, and their dtrace probes register and fire exactly as before.

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -1364,6 +1364,27 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
     }
   }
 
+#if defined(USE_DYNAMIC_TRACE)
+  // FreeBSD use=dtrace builds: pull in the DOF object and its probe-
+  // registration constructor. `dtrace -G` on FreeBSD rewrites the probe
+  // sites inside libponyrt's objects and emits the DOF plus a constructor
+  // into a separate libdtrace_probes.a (see src/libponyrt/CMakeLists.txt);
+  // the constructor is otherwise unreferenced, so --whole-archive is what
+  // keeps it in the link. libdtrace_probes.a sits in the same lib dir as
+  // libponyrt.a, so it resolves from the -L paths already pushed above; the
+  // DOF object needs libelf, found on the system -L paths. This mirrors the
+  // legacy path's dtrace_args (placed before -lponyrt there too). Gated on
+  // is_freebsd (target), not the build platform: DragonFly/OpenBSD have no
+  // dtrace_probes/libelf and never route here for dtrace builds.
+  if(is_freebsd)
+  {
+    args.push_back("--whole-archive");
+    args.push_back("-ldtrace_probes");
+    args.push_back("--no-whole-archive");
+    args.push_back("-lelf");
+  }
+#endif
+
   // Pony runtime.
   if(!c->opt->runtimebc)
   {
@@ -2025,12 +2046,14 @@ static bool link_exe(compile_t* c, ast_t* program,
     return link_exe_lld_macho(c, program, file_o);
   }
 
-  // FreeBSD, DragonFly, and OpenBSD route to embedded LLD unless ponyc
-  // was built with dtrace, in which case the external path below handles
-  // the -ldtrace_probes linking. (DragonFly and OpenBSD have no
-  // dtrace_probes/libelf libs available — use=dtrace builds for those
-  // targets are already broken; the guard preserves that failure mode
-  // rather than introducing a new one.)
+  // FreeBSD, DragonFly, and OpenBSD route to embedded LLD. FreeBSD does so
+  // even in a use=dtrace build: link_exe_lld_elf adds the
+  // -ldtrace_probes/-lelf linking that the legacy path below adds via
+  // dtrace_args. DragonFly and OpenBSD route here only when ponyc was NOT
+  // built with dtrace — they have no dtrace_probes/libelf libs available, so
+  // their use=dtrace builds are already broken; excluding them from the gate
+  // keeps them on the legacy path and preserves that failure mode rather than
+  // introducing a new one.
   //
   // In a sanitizer build, native FreeBSD also routes here: link_exe_lld_elf
   // splices in the captured sanitizer fragment (see the splice above), and the
@@ -2039,11 +2062,14 @@ static bool link_exe(compile_t* c, ast_t* program,
   // are unverified — so the sanitizer sub-gate admits only native FreeBSD (and
   // any cross link, whose runtime is host-arch-absolute and handled by the
   // !is_cross_compiling gate at the splice).
+  bool bsd_embed = target_is_freebsd(c->opt->triple)
 #if !defined(USE_DYNAMIC_TRACE)
+    || target_is_dragonfly(c->opt->triple)
+    || target_is_openbsd(c->opt->triple)
+#endif
+    ;
   if(c->opt->linker == NULL
-    && (target_is_freebsd(c->opt->triple)
-        || target_is_dragonfly(c->opt->triple)
-        || target_is_openbsd(c->opt->triple))
+    && bsd_embed
 #if defined(PONY_SANITIZER)
     && (is_cross_compiling(c) || target_is_freebsd(c->opt->triple))
 #endif
@@ -2051,7 +2077,6 @@ static bool link_exe(compile_t* c, ast_t* program,
   {
     return link_exe_lld_elf(c, program, file_o);
   }
-#endif
 #endif
 
 #ifdef PLATFORM_IS_WINDOWS


### PR DESCRIPTION
use=dtrace was the last FreeBSD build configuration still linking the programs it compiles through the legacy system compiler driver, after native and sanitizer FreeBSD builds moved to embedded LLD. It stayed on the legacy path only so the recipe could add the dtrace_probes/libelf linking; the embedded LLD path now does that itself.

`link_exe_lld_elf` adds `--whole-archive -ldtrace_probes --no-whole-archive -lelf` for FreeBSD when ponyc is built with dtrace, and the BSD routing gate lets FreeBSD reach embedded LLD even in a dtrace build. DragonFly and OpenBSD dtrace builds stay on the legacy path — they ship no dtrace_probes/libelf and their use=dtrace builds are already broken, so excluding them preserves that failure mode rather than introducing a new one.

The FreeBSD tier-3 dtrace smoke now links at `-V 3` and asserts the invocation went through embedded LLD (`ld.lld` plus the dtrace_probes whole-archive), since the legacy driver also links a working dtrace program and would otherwise pass the smoke silently.

Verified on FreeBSD 14.3: a use=dtrace ponyc builds, links, and runs a program, and a `pony` provider probe fires; a `-V 3` link confirms embedded routing with no compiler-driver invocation, and a non-dtrace FreeBSD build still links via embedded LLD with no dtrace args.

Design: #4941