### PR TITLE
Update supported OpenBSD version to 7.9

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -201,7 +201,7 @@ jobs:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'
     runs-on: ubuntu-latest
-    name: x86-64 OpenBSD 7.8
+    name: x86-64 OpenBSD 7.9
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -221,7 +221,7 @@ jobs:
       - name: Download OpenBSD image
         run: |
           curl -L -o openbsd.qcow2 \
-            "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.8_2025-10-22-09-25/openbsd-generic.qcow2"
+            "https://github.com/hcartiaux/openbsd-cloud-image/releases/download/v7.9_2026-06-03-20-46/openbsd-generic.qcow2"
           # Build-workspace disk. OpenBSD's default disklabel confines the
           # build to /home (~10.8G), which the LLVM 22 build overflows, so
           # build on a dedicated disk instead, mirroring the DragonFly job.

--- a/.release-notes/openbsd-7.9.md
+++ b/.release-notes/openbsd-7.9.md
@@ -1,0 +1,5 @@
+## Update supported OpenBSD version to 7.9
+
+The supported version of OpenBSD is now 7.9. Our continuous integration builds and tests ponyc against OpenBSD 7.9.
+
+We won't intentionally break OpenBSD 7.8, but we are no longer actively maintaining support for it. If you need ponyc on OpenBSD, we recommend running 7.9.


### PR DESCRIPTION
Bumps the CI OpenBSD VM image from 7.8 to 7.9 (sourced from the hcartiaux/openbsd-cloud-image 7.9 release) and updates the tier3 job name to match. OpenBSD 7.9 is now the supported version; we won't intentionally break 7.8, but it's no longer actively maintained.

The `OpenBSD 7.8` references in `src/libponyc/codegen/genexe.cc` were intentionally left untouched — they cite 7.8 as the source where the base `cc -v` link recipe was confirmed, which is historical evidence, not a supported-version claim.