### PR TITLE
Fix incorrect rejection and crashes for iftype conditions inside lambdas and object literals

### DIFF
--- a/.release-notes/5422.md
+++ b/.release-notes/5422.md
@@ -1,0 +1,26 @@
+## Fix incorrect rejection and crashes for iftype conditions inside lambdas and object literals
+
+An `iftype` condition behaved differently inside a lambda or object literal than it does at method scope, in two ways that are now fixed.
+
+A condition that narrows a type parameter and then uses that narrowed parameter in the `then` branch compiled at method scope but was wrongly rejected inside a lambda or object literal. This was most visible with a recursively-constrained trait — for example `trait T[X: T[X]]` with the condition `iftype A <: T[A]`, which failed with "type argument is outside its constraint" — but it affected any narrowing condition whose narrowed parameter was used in the branch.
+
+A `let` or `var` binding in the `then` branch of such a condition crashed the compiler with an internal assertion failure instead of compiling.
+
+Both now behave inside a lambda or object literal exactly as they do at method scope. The following program previously failed to compile but now works:
+
+```pony
+trait T[X: T[X] #any]
+  fun tag m(): X
+
+class val C is T[C]
+  fun tag m(): C => C.create()
+
+actor Main
+  new create(env: Env) =>
+    let f = {[A](x': A) =>
+      var x = x'
+      iftype A <: T[A] then
+        x = x.m()
+      end}
+    f[C](C)
+```

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -689,7 +689,11 @@ static bool capture_from_type(pass_opt_t* opt, ast_t* ctx, ast_t** def,
     }
   }
 
-  // Reset the scope.
+  // Reset the scope. This empties every symtab in the subtree, so the scope
+  // pass re-runs over it during the catch up. Passes that establish scope
+  // bindings must therefore be idempotent on re-entry and must re-establish
+  // those bindings here — see scope_iftype, which re-installs the narrowed
+  // type parameters its first run parked in typeparam_store.
   ast_clear(*def);
   return ok;
 }

--- a/src/libponyc/pass/scope.c
+++ b/src/libponyc/pass/scope.c
@@ -208,12 +208,42 @@ static ast_result_t scope_iftype(pass_opt_t* opt, ast_t* ast)
   pony_assert(ast_id(ast) == TK_IFTYPE);
 
   AST_GET_CHILDREN(ast, subtype, supertype, body, typeparam_store);
-  // Prevent this from running again, if, for example, the iftype
-  // occurs inside an object literal (or lambda). In those cases,
-  // a "catch up" will take place and the compiler will try to run
-  // this pass again.
+  // When the iftype occurs inside an object literal (or lambda), this pass
+  // runs again during the "catch up" that processes the anonymous type. We've
+  // already built the synthetic narrowed type parameters on the first run and
+  // parked them in typeparam_store, so we don't rebuild them. But the catch up
+  // empties this node's symbol table (capture_from_type clears every symtab in
+  // the subtree via ast_clear), which drops the scope binding set_scope
+  // established on the first run. Without it, references to the narrowed type
+  // parameter in the supertype and body bind back to the original, un-narrowed
+  // parameter, so a narrowing condition — including a valid F-bounded one such
+  // as `iftype A <: T[A]` against `trait T[X: T[X]]` — fails to type-check.
+  // Re-install the stored parameters so name resolution finds them again,
+  // exactly as at method scope.
   if(ast_id(typeparam_store) != TK_NONE)
-    return AST_IGNORE;
+  {
+    for(ast_t* typeparam = ast_child(typeparam_store); typeparam != NULL;
+      typeparam = ast_sibling(typeparam))
+    {
+      // Re-install the stored node itself, never a copy. The symtab was just
+      // emptied, so this is a fresh add; but the AST_OK descent below visits
+      // typeparam_store and runs set_scope on these same nodes again, where
+      // set_scope no-ops because the name already maps to this exact node. A
+      // copy would be a different node and would error as a name clash there.
+      if(!set_scope(opt, ast, ast_child(typeparam), typeparam, true))
+        return AST_ERROR;
+    }
+
+    // Return AST_OK, not AST_IGNORE, so the scope pass still descends into
+    // the children on the catch up, exactly as the first run does. This
+    // matters for a nested iftype in the then branch: its own scope_iftype
+    // must run here to re-install its narrowed parameter. AST_IGNORE would
+    // skip the descent, so the inner condition would never be re-scoped and
+    // its references would bind to the un-narrowed parameter — the same bug
+    // this fix addresses, one level in. It also leaves the then branch's own
+    // local bindings unscoped, which crashes a later pass (see #5441).
+    return AST_OK;
+  }
 
   ast_t* typeparams = ast_from(ast, TK_TYPEPARAMS);
 

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -249,6 +249,220 @@ TEST_F(IftypeTest, Tuple_MutuallyRecursiveConstraint)
 }
 
 
+TEST_F(IftypeTest, RecursiveConstraintInLambda)
+{
+  // The RecursiveConstraint case (a valid F-bounded iftype condition) inside a
+  // lambda. The lambda's body is processed through the object-literal "catch
+  // up" path, which empties the iftype node's scope; the narrowed type
+  // parameter must be re-installed so the condition's `T[A]` and the narrowed
+  // `x.m()` call both resolve, exactly as at method scope. This compiled at
+  // method scope but was wrongly rejected here (ponylang/ponyc#5422).
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x': A) =>\n"
+    "      var x = x'\n"
+    "      iftype A <: T[A] then\n"
+    "        x = x.m()\n"
+    "      end}\n"
+    "    f[C](C)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, RecursiveConstraintInObjectLiteral)
+{
+  // The same valid F-bounded condition inside an object literal's method.
+  // Object literals share the lambda catch-up path (ponylang/ponyc#5422).
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let o = object\n"
+    "      fun foo[A](x': A) =>\n"
+    "        var x = x'\n"
+    "        iftype A <: T[A] then\n"
+    "          x = x.m()\n"
+    "        end\n"
+    "    end\n"
+    "    o.foo[C](C)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, RecursiveConstraintInNestedLambda)
+{
+  // The valid F-bounded condition is two catch-up copies deep: a lambda nested
+  // inside another lambda. The narrowed parameter must be re-installed at each
+  // level (ponylang/ponyc#5422).
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let outer = {() =>\n"
+    "      let inner = {[A](x': A) =>\n"
+    "        var x = x'\n"
+    "        iftype A <: T[A] then\n"
+    "          x = x.m()\n"
+    "        end}\n"
+    "      inner[C](C)}\n"
+    "    outer()";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, RecursiveConstraintTupleInLambda)
+{
+  // A valid F-bounded tuple condition inside a lambda. The catch-up must
+  // re-install both narrowed parameters (ponylang/ponyc#5422). The then branch
+  // calls the narrowed method on both `x` (A) and `y` (B), so a fix that
+  // re-installed only the first parameter would fail to resolve `y.m()`.
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A, B](x': A, y': B) =>\n"
+    "      var x = x'\n"
+    "      var y = y'\n"
+    "      iftype (A, B) <: (T[A], T[B]) then\n"
+    "        x = x.m()\n"
+    "        y = y.m()\n"
+    "      end}\n"
+    "    f[C, C](C, C)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, RecursiveConstraintNestedIftypeInLambda)
+{
+  // A second iftype nested in the then branch of the first, inside a lambda.
+  // The catch-up must descend into the outer then branch so the inner iftype's
+  // own narrowing is re-established; otherwise the inner `T[B]` reference binds
+  // to the un-narrowed `B` and fails its constraint check (ponylang/ponyc
+  // #5422). This is the case that requires scope_iftype to return AST_OK rather
+  // than AST_IGNORE on the catch-up.
+  const char* src =
+    "trait T[X: T[X] #any]\n"
+    "  fun tag m(): X\n"
+
+    "class val C is T[C]\n"
+    "  fun tag m(): C => C.create()\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A, B](x': A, y': B) =>\n"
+    "      var x = x'\n"
+    "      var y = y'\n"
+    "      iftype A <: T[A] then\n"
+    "        iftype B <: T[B] then\n"
+    "          x = x.m()\n"
+    "          y = y.m()\n"
+    "        end\n"
+    "      end}\n"
+    "    f[C, C](C, C)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, NarrowedTypeparamUsedInLambdaBody)
+{
+  // The fix is not specific to F-bounded constraints: any narrowing condition
+  // whose narrowed parameter is used in the then branch was rejected inside a
+  // lambda and compiles at method scope. Here `hello()` only resolves once `A`
+  // is narrowed to `Speak`, so this exercises the same re-install path with a
+  // plain (non-recursive) constraint (ponylang/ponyc#5422).
+  const char* src =
+    "trait Speak\n"
+    "  fun tag hello(): None\n"
+
+    "class val Dog is Speak\n"
+    "  fun tag hello(): None => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x': A) =>\n"
+    "      iftype A <: Speak then\n"
+    "        x'.hello()\n"
+    "      end}\n"
+    "    f[Dog](Dog)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, LocalBindingInLambdaIftypeThenBranch)
+{
+  // A local binding in the then branch of an iftype inside a lambda. Before
+  // the catch-up re-scoped the branch, the binding's symbol status was never
+  // set and a later pass asserted on it. Returning AST_OK so the scope pass
+  // descends into the branch fixes this (ponylang/ponyc#5441).
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x': A) =>\n"
+    "      iftype A <: U8 then\n"
+    "        let z = x'\n"
+    "        None\n"
+    "      end}\n"
+    "    f[U8](0)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(IftypeTest, ElseClause_NoTypeConstraintInLambda)
+{
+  // The re-installed narrowing must not leak into the else branch: in the
+  // else clause `A` is not narrowed, so the narrowed method does not resolve.
+  // Mirrors ElseClause_NoTypeConstraint on the lambda catch-up path
+  // (ponylang/ponyc#5422).
+  const char* src =
+    "trait Speak\n"
+    "  fun tag hello(): None\n"
+
+    "class val Dog is Speak\n"
+    "  fun tag hello(): None => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[A](x': A) =>\n"
+    "      iftype A <: Speak then\n"
+    "        None\n"
+    "      else\n"
+    "        x'.hello()\n"
+    "      end}\n"
+    "    f[Dog](Dog)";
+
+  TEST_ERROR(src, "couldn't find 'hello' in 'A'");
+}
+
+
 TEST_F(IftypeTest, SelfReferentialSubtypeConstraint)
 {
   // An iftype whose subtype bound names the tested parameter through a
@@ -328,6 +542,14 @@ TEST_F(IftypeTest, SelfReferentialSubtypeConstraintIntersectionInLambda)
   // The self-referential supertype reaches the synthetic parameter through an
   // intersection member rather than a union, inside a lambda (ponylang/ponyc
   // #5404).
+  //
+  // This produces the same diagnostics as the equivalent method-scope
+  // condition (parity restored by ponylang/ponyc#5422, which re-installs the
+  // narrowed parameter on the lambda catch-up path). An intersection whose
+  // members can't agree on a capability yields three "no valid capability"
+  // errors in addition to the self-reference error; both method and lambda
+  // scope emit all four. (A union supertype, as in the tests above, does not
+  // hit the capability error and so reports only the self-reference error.)
   const char* src =
     "trait Tr\n"
     "actor Main\n"
@@ -336,7 +558,14 @@ TEST_F(IftypeTest, SelfReferentialSubtypeConstraintIntersectionInLambda)
     "      iftype A <: (A & Tr) then None end}\n"
     "    f[U8](0)";
 
-  TEST_ERROR(src, "can't appear directly in its own constraint");
+  const char* errs[] = {
+    "type parameter constraint has no valid capability",
+    "type parameter constraint has no valid capability",
+    "type parameter constraint has no valid capability",
+    "type parameter 'A' can't appear directly in its own constraint",
+    NULL
+  };
+  DO(test_expected_errors(src, "ir", errs));
 }
 
 


### PR DESCRIPTION
An `iftype` condition behaved differently inside a lambda or object literal than at method scope. The lambda/object-literal "catch up" re-runs the scope pass over the anonymous type after `capture_from_type` clears every symtab in the subtree; `scope_iftype` had already parked its synthetic narrowed type parameters in `typeparam_store`, so on the catch up it returned `AST_IGNORE` without re-installing them and without descending into the iftype's children. Two symptoms followed — references to the narrowed parameter bound back to the original, un-narrowed parameter (so a valid condition like `iftype A <: T[A]` was rejected), and a local binding in the then branch was never scoped (so a later pass asserted and crashed).

The fix re-installs the stored parameters on the catch up and returns `AST_OK` so the scope pass descends into the children exactly as on the first run, which also lets a nested iftype's own `scope_iftype` re-run. The params themselves are not rebuilt: `make_iftype_typeparam` needs the pre-name-resolution AST shape (its subtype is still a `TK_NOMINAL`), which no longer holds on the catch up, so the one-time build is cached in `typeparam_store` and only the symtab registration the clear destroyed is redone.

Closes #5422 (incorrect rejection) and #5441 (crash on a local binding in the then branch) — both are symptoms of the same root cause.

Stacked on #5423 (base branch `fix-self-referential-iftype-in-lambda`); retarget to `main` once that merges. `scope.c` is untouched by #5423, so there is no overlap.