### PR TITLE
Use embedded LLD for native macOS sanitizer builds

### DIFF
--- a/.ci-scripts/macos-sanitizer-smoke.sh
+++ b/.ci-scripts/macos-sanitizer-smoke.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Native sanitizer smoke test for macOS. Invoked from
+# .github/workflows/ponyc-weekly-checks.yml. Expects to run from the ponyc
+# source root with LLVM already built in build/libs.
+#
+# The macOS sanitizer link path through embedded ld64.lld was previously
+# uncovered — native sanitizer builds fell back to the legacy compiler driver.
+# This builds an instrumented ponyc plus the self-hosted tools, then links and
+# runs a small program whose allocations engage AddressSanitizer, asserting a
+# clean exit. The link is the thing under test: a broken splice shows up as
+# undefined sanitizer symbols at link time, not as a runtime surprise.
+#
+# ASAN_OPTIONS/UBSAN_OPTIONS are exported for the build too, not just the run,
+# because the instrumented ponyc executes during its own build (compiling the
+# tools). detect_leaks=0 matches the Linux weekly. detect_container_overflow=0
+# suppresses false-positive container-overflow reports from Apple's libc++
+# container annotations when the instrumented ponyc shares std::vector/
+# std::string with the (non-instrumented) vendored LLVM.
+set -eu
+
+export ASAN_OPTIONS=detect_leaks=0:detect_container_overflow=0
+export UBSAN_OPTIONS=print_stacktrace=0
+if [ -x "$PWD/build/libs/bin/llvm-symbolizer" ]; then
+  ASAN_OPTIONS="$ASAN_OPTIONS:external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer"
+  UBSAN_OPTIONS="$UBSAN_OPTIONS:external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer"
+fi
+
+# Clean + reconfigure debug from scratch. If a prior non-sanitizer
+# config=debug build left a build dir behind, reconfiguring it in place
+# re-runs the standalone-library rule over a read-only leftover (libc++.a is
+# 0444, so the copied libcpp.a is too) which fails. clean is config-scoped
+# and defaults to release, so pass config=debug to remove the debug
+# build/output dirs; the prebuilt LLVM in build/libs is untouched.
+make clean config=debug
+make configure config=debug \
+  use=pool_memalign,address_sanitizer,undefined_behavior_sanitizer
+# Full build: this compiles the instrumented ponyc and links the self-hosted
+# tools (pony-lsp/pony-lint/pony-doc) under sanitizers, exercising the
+# embedded ld64.lld link of programs that bundle the C++ runtime
+# (libponyc-standalone.a).
+make build config=debug
+
+# The sanitizer suffix order is fixed by CMake (address, then undefined, then
+# pool_memalign), independent of the use= order above; derive the output dir
+# rather than hardcode it.
+out=$(find build -maxdepth 1 -type d -name 'debug-*address_sanitizer*pool_memalign' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: sanitizer build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/sanitizer-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    // Allocate enough to exercise the AddressSanitizer-instrumented libponyrt
+    // allocator, then exit clean.
+    let a = Array[U64](4096)
+    var i: USize = 0
+    while i < 4096 do
+      a.push(i.u64())
+      i = i + 1
+    end
+    env.out.print("sanitizer smoke ok size=" + a.size().string())
+PONY
+
+# Link via embedded ld64.lld (the captured sanitizer fragment is spliced here)
+# and run. A broken splice fails at link time with undefined __asan_*/__ubsan_*.
+PONYPATH="$PWD/packages" "$out/ponyc" --debug -o "$smoke" "$smoke"
+out_text=$("$smoke/sanitizer-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "sanitizer smoke ok size=4096"
+
+# The self-hosted tools link libponyc-standalone.a (which bundles libc++ on
+# macOS); confirm one runs clean under the sanitizer runtime, proving the tool
+# link path works and not just that it linked.
+"$out/pony-lint" --version

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -169,3 +169,75 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  arm64_macos_with_sanitizers:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: macos-26
+
+    name: arm64 Apple Darwin sanitizer smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j4
+      - name: Sanitizer Smoke Test
+        run: bash .ci-scripts/macos-sanitizer-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  x86_64_macos_with_sanitizers:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: macos-15-intel
+
+    name: x86-64 Apple Darwin sanitizer smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j2
+      - name: Sanitizer Smoke Test
+        run: bash .ci-scripts/macos-sanitizer-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.release-notes/macos-sanitizer-embedded-lld.md
+++ b/.release-notes/macos-sanitizer-embedded-lld.md
@@ -1,0 +1,3 @@
+## Use embedded LLD for native macOS sanitizer builds
+
+Native macOS sanitizer builds (`use=address_sanitizer`, `use=undefined_behavior_sanitizer`) now link through the embedded ld64.lld linker instead of requiring an external linker.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ endif()
 # through the compiler driver, so it cannot rely on -fsanitize= to pull the
 # runtime in. Instead we ask the driver, at configure time, for the exact link
 # fragment it emits for -fsanitize=${PONY_SANITIZERS_VALUE} and embed it as a
-# generated header that the embedded ELF linker splices in (genexe.cc).
+# generated header that the embedded linker splices in (genexe.cc).
 #
 # Asking the driver (rather than locating the runtime libraries ourselves)
 # avoids re-implementing its per-compiler library selection, ubsan-folding, and
@@ -146,10 +146,12 @@ endif()
 # vs gcc's libasan_preinit.o + shared libasan): the driver emits whatever paths
 # and flags are correct for itself. This works for both clang (whole-archived
 # clang_rt static archives + --dynamic-list) and gcc (preinit object + shared
-# -lasan/-lubsan). The fragment's library paths are absolute on the build
-# machine, which is fine: a sanitizer ponyc is a developer/CI artifact that runs
-# where it was built. Native Linux and native FreeBSD sanitizer builds consume
-# this (see genexe.cc); the splice is gated on !is_cross_compiling.
+# -lasan/-lubsan). On macOS, Apple clang emits the clang_rt dylib by absolute
+# path plus -rpath entries (and folds UBSan into ASan when both are enabled).
+# The fragment's library paths are absolute on the build machine, which is fine:
+# a sanitizer ponyc is a developer/CI artifact that runs where it was built.
+# Native Linux, FreeBSD, and macOS sanitizer builds consume this (see
+# genexe.cc); the splice is gated on !is_cross_compiling.
 
 # Extract the linker subcommand's arguments from a compiler "-###" stderr dump.
 # The link subcommand is the line naming the probe object (clang emits a direct

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -268,8 +268,17 @@ static bool is_cross_compiling(compile_t* c)
   llvm::Triple host(default_triple_str);
   LLVMDisposeMessage(default_triple_str);
 
-  return target.getArch() != host.getArch()
-    || target.getOS() != host.getOS()
+  if(target.getArch() != host.getArch())
+    return true;
+
+  // Darwin and MacOSX are different Triple::OSType enum values but the same
+  // platform. The target triple uses "macosx" (after ponyc normalization)
+  // while LLVMGetDefaultTargetTriple returns "darwin"; comparing OS enums
+  // directly misidentifies every native macOS build as cross-compilation.
+  if(target.isMacOSX() && host.isMacOSX())
+    return false;
+
+  return target.getOS() != host.getOS()
     || target.getEnvironment() != host.getEnvironment();
 }
 
@@ -1312,7 +1321,9 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   // The clang_rt archive paths are absolute on the build machine.
   //
   // This function serves the Linux and FreeBSD branches of link_exe — the
-  // native sanitizer builds that reach embedded LLD. macOS, DragonFly, and
+  // native ELF sanitizer builds that reach embedded LLD. macOS native
+  // sanitizer builds use the same captured fragment but splice it in
+  // link_exe_lld_macho (see that function's sanitizer block). DragonFly and
   // OpenBSD native sanitizer builds still route through the legacy compiler
   // driver (which pulls the runtime in via -fsanitize=), so they never reach
   // this splice; it is gated on the targets explicitly rather than relying on
@@ -1795,6 +1806,22 @@ static bool link_exe_lld_macho(compile_t* c, ast_t* program,
     }
   }
 
+#if defined(PONY_SANITIZER)
+  // Sanitizer runtime. The fragment captured at configure time
+  // (PONY_SANITIZER_LINK_ARGS) contains the Apple clang driver's sanitizer
+  // additions: an absolute path to the clang_rt dylib plus -rpath entries.
+  // Apple clang folds UBSan into ASan when both are enabled, so
+  // -fsanitize=address,undefined produces the same fragment as address alone.
+  // The fragment uses Mach-O linker flags compatible with ld64.lld.
+  // Only splice for native builds — the host-arch-absolute paths are wrong
+  // for cross links.
+  if(target_is_macosx(c->opt->triple) && !is_cross_compiling(c))
+  {
+    for(size_t i = 0; i < PONY_SANITIZER_LINK_ARGS_COUNT; i++)
+      args.push_back(PONY_SANITIZER_LINK_ARGS[i]);
+  }
+#endif
+
   // System library and Pony runtime.
   args.push_back("-lSystem");
 
@@ -2023,10 +2050,10 @@ static bool link_exe(compile_t* c, ast_t* program,
   errors_t* errors = c->opt->check.errors;
 
   // Use embedded LLD for Linux, macOS, and Windows targets unless --linker
-  // escape hatch is specified. On Linux and FreeBSD, native sanitizer builds
-  // use embedded LLD too: link_exe_lld_elf links the sanitizer runtime
-  // explicitly from a fragment captured at ponyc build time. On macOS,
-  // DragonFly, and OpenBSD, native sanitizer builds still fall back to the
+  // escape hatch is specified. On Linux, FreeBSD, and macOS, native sanitizer
+  // builds use embedded LLD too: the ELF and Mach-O link functions splice
+  // the sanitizer runtime from a fragment captured at ponyc build time.
+  // DragonFly and OpenBSD native sanitizer builds still fall back to the
   // system compiler driver (which links the runtime via -fsanitize=);
   // cross-compilation always uses LLD.
 #ifdef PLATFORM_IS_POSIX_BASED
@@ -2037,11 +2064,7 @@ static bool link_exe(compile_t* c, ast_t* program,
   }
 
   if(c->opt->linker == NULL
-    && target_is_macosx(c->opt->triple)
-#if defined(PONY_SANITIZER)
-    && is_cross_compiling(c)
-#endif
-    )
+    && target_is_macosx(c->opt->triple))
   {
     return link_exe_lld_macho(c, program, file_o);
   }


### PR DESCRIPTION
Route native macOS sanitizer builds through the embedded ld64.lld linker. The captured sanitizer link fragment (clang_rt dylib + rpath entries from Apple clang) is now spliced into the Mach-O linker args, matching the approach used for Linux (#5409) and FreeBSD (#5426).

Also fixes `is_cross_compiling` returning true for every native macOS build — the target triple uses "macosx" (after ponyc normalization) while LLVM's default triple uses "darwin", which are different `Triple::OSType` enum values for the same platform.

Adds a macOS sanitizer smoke test to the weekly checks workflow, modeled on the FreeBSD tier-3 smoke test.

Design: #4941