### PR TITLE
Fix use=dtrace builds on macOS

### DIFF
--- a/.ci-scripts/macos-dtrace-smoke.sh
+++ b/.ci-scripts/macos-dtrace-smoke.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# use=dtrace smoke test for macOS. Invoked from
+# .github/workflows/ponyc-weekly-checks.yml. Expects to run from the ponyc
+# source root with LLVM already built in build/libs.
+#
+# macOS dtrace has no `-G` flag — the LLD MachO linker resolves
+# __dtrace_probe$ symbols natively, so no probe object is needed. This builds
+# a dtrace-enabled ponyc and links+runs a small program, exercising the
+# `dtrace -h` header generation and the embedded ld64.lld link path.
+#
+# This does NOT test that probes actually fire at runtime. Observing probes
+# with `dtrace` requires System Integrity Protection (SIP) to permit DTrace,
+# and GitHub Actions macOS runners have SIP fully enabled. The FreeBSD tier-3
+# smoke can test probe firing because it controls the VM; here we can only
+# validate the build and link path.
+set -eu
+
+# Clean + reconfigure debug from scratch. If a prior non-dtrace config=debug
+# build left a build dir behind, reconfiguring it in place re-runs the
+# standalone-library rule over a read-only leftover (libc++.a is 0444, so the
+# copied libcpp.a is too) which fails. clean is config-scoped and defaults to
+# release, so pass config=debug to remove the debug build/output dirs; the
+# prebuilt LLVM in build/libs is untouched.
+make clean config=debug
+make configure config=debug use=dtrace
+make build config=debug
+
+# Derive the output directory rather than hardcode the suffix.
+out=$(find build -maxdepth 1 -type d -name 'debug-dtrace' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: dtrace build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/dtrace-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    var i: USize = 0
+    while i < 2000 do
+      Spinner
+      i = i + 1
+    end
+    env.out.print("dtrace smoke ok")
+
+actor Spinner
+  be noop() => None
+PONY
+
+# Link at -V 3 (VERBOSITY_TOOL_INFO) so the linker invocation is printed, and
+# assert it went through embedded LLD. The grep target is `ld64.lld` (the
+# MachO LLD argv[0], distinct from the ELF `ld.lld` the FreeBSD smoke checks).
+PONYPATH="$PWD/packages" "$out/ponyc" -V 3 -o "$smoke" "$smoke" \
+  2>"$smoke/link.log"
+grep -q 'ld64\.lld' "$smoke/link.log" || {
+  echo "FAIL: dtrace link did not route through embedded LLD (no ld64.lld)"; exit 1; }
+echo "dtrace link routed through embedded LLD"
+out_text=$("$smoke/dtrace-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "dtrace smoke ok"

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -241,3 +241,75 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  arm64_macos_dtrace_smoke:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: macos-26
+
+    name: arm64 Apple Darwin dtrace smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j4
+      - name: DTrace Smoke Test
+        run: bash .ci-scripts/macos-dtrace-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  x86_64_macos_dtrace_smoke:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: macos-15-intel
+
+    name: x86-64 Apple Darwin dtrace smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Restore Libs Cache
+        id: restore-libs
+        uses: actions/cache/restore@v5.0.3
+        with:
+          path: |
+            build/libs
+            lib/llvm/src/compiler-rt/lib/builtins
+          key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+      - name: Build Libs
+        if: steps.restore-libs.outputs.cache-hit != 'true'
+        run: make libs build_flags=-j2
+      - name: DTrace Smoke Test
+        run: bash .ci-scripts/macos-dtrace-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.release-notes/fix-macos-dtrace.md
+++ b/.release-notes/fix-macos-dtrace.md
@@ -1,0 +1,5 @@
+## Fix use=dtrace builds on macOS
+
+Building ponyc with `use=dtrace` failed on macOS because the build tried to run `dtrace -G`, a flag that macOS dtrace has never supported. macOS's linker resolves DTrace probe symbols natively, so the `-G` step was never needed — only the `dtrace -h` header generation step is required.
+
+`use=dtrace` now builds and links correctly on macOS. Programs compiled by a dtrace-enabled ponyc expose their `pony` provider probes to DTrace. Actually tracing a running program requires System Integrity Protection (SIP) to permit DTrace; see the examples/dtrace README for details.

--- a/BUILD.md
+++ b/BUILD.md
@@ -209,7 +209,9 @@ make build
 
 ## dtrace
 
-Linux and FreeBSD support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD. No other platform is supported: macOS removed DTrace, and neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool.
+Linux, FreeBSD, and macOS support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD and macOS. Neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool.
+
+On macOS, actually tracing a running program with `dtrace` requires System Integrity Protection (SIP) to permit DTrace. See the [examples/dtrace README](examples/dtrace/README.md) for details.
 
 DTrace support is enabled by setting `use=dtrace` in the build command line like:
 

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -73,10 +73,10 @@ if(PONY_USE_DTRACE)
 
     # The runtime sources include the generated dtrace_probes.h (via dtrace.h),
     # so it must exist before they compile. Generate it into the build tree (not
-    # the source tree) and make libponyrt depend on it. Both the SystemTap
-    # dtrace on Linux and the illumos-derived dtrace on FreeBSD emit the header
-    # the same way with `dtrace -h`; only the object-generation step below
-    # differs between them.
+    # the source tree) and make libponyrt depend on it. The macOS, SystemTap
+    # (Linux), and illumos-derived (FreeBSD) dtrace all emit the header the
+    # same way with `dtrace -h`; only the object-generation step below differs
+    # between them.
     set(_dtrace_header "${libponyrt_BINARY_DIR}/dtrace_probes.h")
     add_custom_command(OUTPUT "${_dtrace_header}"
         COMMAND dtrace -h -s "${_dtrace_d}" -o "${_dtrace_header}"
@@ -129,7 +129,11 @@ if(PONY_USE_DTRACE)
                     "${CMAKE_AR}"
             VERBATIM
         )
-    else()
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        # macOS: `dtrace -h` (above) is sufficient. The macOS dtrace has no
+        # `-G` flag; instead, the LLD MachO linker resolves __dtrace_probe$
+        # and __dtrace_isenabled$ symbols natively — no probe object needed.
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         # SystemTap (Linux): `dtrace -G` builds the probe object from the .d
         # alone; fold it straight into libponyrt.
         add_custom_command(OUTPUT dtrace_probes.o
@@ -137,6 +141,8 @@ if(PONY_USE_DTRACE)
             DEPENDS "${_dtrace_d}"
         )
         target_sources(libponyrt PRIVATE dtrace_probes.o)
+    else()
+        message(WARNING "use=dtrace: no probe-generation support for ${CMAKE_SYSTEM_NAME}; probes will be no-ops")
     endif()
 endif()
 


### PR DESCRIPTION
macOS dtrace has no `-G` flag, but doesn't need one: the LLD MachO linker resolves `__dtrace_probe$` and `__dtrace_isenabled$` symbols natively. The build previously failed immediately because the non-FreeBSD DTrace path tried to run `dtrace -G`.

This adds a Darwin branch in the CMake dtrace block that skips `-G` (only `dtrace -h` is needed), makes the Linux branch explicit instead of a catch-all else, and warns on unsupported platforms.

Weekly CI smoke tests on arm64 and x86-64 macOS follow the same pattern as the existing sanitizer smoke tests. The smoke validates build, embedded-LLD link routing, and program execution. Probe firing cannot be tested on CI because SIP prevents dtrace from attaching.

Verified locally on arm64 macOS: `use=dtrace` build succeeds, links through embedded LLD, and the compiled program runs correctly.

Closes #4758