### PR TITLE
Remove aarch64 debug codegen workaround

### DIFF
--- a/src/libponyc/codegen/host.cc
+++ b/src/libponyc/codegen/host.cc
@@ -29,20 +29,8 @@ LLVMTargetMachineRef codegen_machine(LLVMTargetRef target, pass_opt_t* opt)
   if(opt->pic)
     reloc = Reloc::PIC_;
 
-  // The Arm debug fix is a "temporary" fix for issues #3874 and #4369.
-  // https://github.com/ponylang/ponyc/issues/3874
-  // https://github.com/ponylang/ponyc/issues/4369
-  // We believe both issues are LLVM issues (probably the same or related).
-  // We invested considerable time in trying to track down "the root cause" but
-  // haven't been able to.
-  // Ideally, debug builds would get CodeGenOpt::None here, however, that when
-  // mixed with other optimization options elsewhere seems to lead to bugs that
-  // related to DWARF info and inlining.
-  // As part of the the #4369 investigation, we came to believe that
-  // CodeGenOpt::None is an infrequently used code path and that we are better
-  // using Default as it is less likely to have bugs.
   CodeGenOptLevel opt_level =
-    opt->release ? CodeGenOptLevel::Aggressive : CodeGenOptLevel::Default;
+    opt->release ? CodeGenOptLevel::Aggressive : CodeGenOptLevel::None;
 
   TargetOptions options;
 


### PR DESCRIPTION
We added this workaround years ago when aarch64 support first landed. Debug builds were segfaulting due to what we believed was an LLVM bug in the `CodeGenOpt::None` code path. The fix was to force `CodeGenOpt::Default` for all debug builds, which papered over the problem but meant debug builds were getting more optimization than they should.

We've upgraded LLVM several times since then. The stdlib debug test suite passes clean with `CodeGenOpt::None` on aarch64 now, so the underlying LLVM bug appears to be fixed. This removes the workaround and lets debug builds use the optimization level they were always meant to use.

Closes #3874