### PR TITLE
Reject use=dtrace at configure time on DragonFly and OpenBSD

### DIFF
--- a/.ci-scripts/dragonfly-reject-unsupported-builds.sh
+++ b/.ci-scripts/dragonfly-reject-unsupported-builds.sh
@@ -5,17 +5,17 @@
 #
 # DragonFly builds ponyc with the gcc13 package, whose toolchain ships no
 # AddressSanitizer/ThreadSanitizer/UndefinedBehaviorSanitizer runtime (GCC's
-# libsanitizer has no DragonFly target), so these use= options can't link there.
-# `gmake configure` rejects them with a clear error at make-parse time, before
-# `gmake libs` runs, so this assertion needs no LLVM build or gcc13 toolchain.
-# Check each fails AND fails for the documented reason: a typo in the OS string
-# would otherwise silently regress to the confusing partway-through build failure
-# the guards exist to prevent. (Only the three sanitizers are rejected: coverage
-# and valgrind do work on DragonFly. use=dtrace is also unavailable, but by its
-# own which-dtrace check with a different message.)
+# libsanitizer has no DragonFly target), so those use= options can't link there;
+# and DragonFly can't build a working dtrace-instrumented runtime, so use=dtrace
+# is rejected too. `gmake configure` rejects them with a clear error at
+# make-parse time, before `gmake libs` runs, so this assertion needs no LLVM
+# build or gcc13 toolchain. Check each fails AND fails for the documented reason:
+# a typo in the OS string would otherwise silently regress to the confusing
+# partway-through build failure the guards exist to prevent. (coverage and
+# valgrind aren't rejected on DragonFly.)
 set -eu
 
-for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer; do
+for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer dtrace; do
   if out=$(gmake configure use="$u" 2>&1); then
     echo "FAIL: use=$u was not rejected on DragonFly"
     exit 1

--- a/.ci-scripts/openbsd-reject-unsupported-builds.sh
+++ b/.ci-scripts/openbsd-reject-unsupported-builds.sh
@@ -5,16 +5,16 @@
 #
 # OpenBSD's base toolchain ships no AddressSanitizer/ThreadSanitizer runtime and
 # only the minimal (not standalone) UndefinedBehaviorSanitizer runtime, has an
-# incomplete profiling runtime, and has no Valgrind port, so these use= options
-# can't link or compile there. `gmake configure` rejects them with a clear error
-# at make-parse time, before `gmake libs` runs, so this assertion needs no LLVM
+# incomplete profiling runtime, and has no Valgrind port; and OpenBSD ships no
+# DTrace-compatible probe-generation tool. So these use= options can't link,
+# compile, or run there. `gmake configure` rejects them with a clear error at
+# make-parse time, before `gmake libs` runs, so this assertion needs no LLVM
 # build. Check each fails AND fails for the documented reason: a typo in the OS
 # string would otherwise silently regress to the confusing partway-through build
-# failure the guards exist to prevent. (use=dtrace is also rejected on OpenBSD,
-# but by its own which-dtrace check with a different message.)
+# failure the guards exist to prevent.
 set -eu
 
-for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer coverage valgrind; do
+for u in address_sanitizer thread_sanitizer undefined_behavior_sanitizer coverage valgrind dtrace; do
   if out=$(gmake configure use="$u" 2>&1); then
     echo "FAIL: use=$u was not rejected on OpenBSD"
     exit 1

--- a/.release-notes/reject-use-dtrace-on-dragonfly-and-openbsd.md
+++ b/.release-notes/reject-use-dtrace-on-dragonfly-and-openbsd.md
@@ -1,0 +1,3 @@
+## Reject use=dtrace at configure time on DragonFly and OpenBSD
+
+DTrace isn't supported on DragonFly BSD or OpenBSD. `make configure use=dtrace` now rejects the option on those platforms with a clear, platform-specific message rather than a confusing build failure or a generic error.

--- a/BUILD.md
+++ b/BUILD.md
@@ -63,7 +63,7 @@ Several `use=` build options aren't supported on OpenBSD, because OpenBSD doesn'
 - `use=undefined_behavior_sanitizer` — OpenBSD ships only the minimal UndefinedBehaviorSanitizer runtime (`libclang_rt.ubsan_minimal.a`), not the standalone runtime ponyc links against, so the link fails.
 - `use=coverage` — OpenBSD's base profiling runtime (`libclang_rt.profile.a`) is incomplete, so coverage-instrumented builds fail to link.
 - `use=valgrind` — Valgrind has no OpenBSD port, so its development headers aren't available to build against.
-- `use=dtrace` — OpenBSD ships no DTrace-compatible probe-generation tool (its `btrace` is a separate tracer with no USDT support).
+- `use=dtrace` — not supported on OpenBSD.
 
 `gmake configure` rejects these uses on OpenBSD with an error rather than letting the build fail partway through with a confusing compiler, linker, or missing-tool message.
 
@@ -90,6 +90,8 @@ The sanitizer `use=` build options aren't supported on DragonFly, because the `g
 - `use=undefined_behavior_sanitizer` — no UndefinedBehaviorSanitizer runtime, so the link fails (`cannot find -lubsan`).
 
 `gmake configure` rejects these uses on DragonFly with an error rather than letting the build fail partway through with a confusing linker message.
+
+`use=dtrace` isn't supported on DragonFly either, and `gmake configure` rejects it.
 
 `use=coverage` and `use=valgrind` aren't rejected, but neither currently works on DragonFly:
 
@@ -209,7 +211,7 @@ make build
 
 ## dtrace
 
-Linux, FreeBSD, and macOS support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD and macOS. Neither DragonFly BSD nor OpenBSD ships a DTrace-compatible probe-generation tool.
+Linux, FreeBSD, and macOS support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD and macOS. DTrace isn't supported on DragonFly BSD or OpenBSD.
 
 On macOS, actually tracing a running program with `dtrace` requires System Integrity Protection (SIP) to permit DTrace. See the [examples/dtrace README](examples/dtrace/README.md) for details.
 

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ define USE_CHECK
   else ifeq ($1,pooltrack)
     PONY_USES += -DPONY_USE_POOLTRACK=true
   else ifeq ($1,dtrace)
+    ifeq ($$(HOST_OS),OpenBSD)
+      $$(error DTrace is not supported on OpenBSD. See BUILD.md)
+    endif
+    ifeq ($$(HOST_OS),DragonFly)
+      $$(error DTrace is not supported on DragonFly. See BUILD.md)
+    endif
     DTRACE ?= $(shell which dtrace)
     ifeq (, $$(DTRACE))
       $$(error No dtrace compatible user application static probe generation tool found)

--- a/examples/README.md
+++ b/examples/README.md
@@ -150,7 +150,7 @@ Simulates gravitational interaction among five planetary bodies (Sun, Jupiter, S
 
 ### [dtrace](dtrace/)
 
-Example DTrace scripts for tracing Pony runtime behavior on macOS/BSD, including GC events, actor scheduling, and message throughput. Demonstrates the Pony runtime's DTrace provider interface with probes for garbage collection, scheduling, and telemetry aggregation.
+Example DTrace scripts for tracing Pony runtime behavior on macOS and FreeBSD, including GC events, actor scheduling, and message throughput. Demonstrates the Pony runtime's DTrace provider interface with probes for garbage collection, scheduling, and telemetry aggregation.
 
 ### [runtime_info](runtime_info/)
 

--- a/examples/dtrace/README.md
+++ b/examples/dtrace/README.md
@@ -5,7 +5,7 @@ tracing of events. This document describes the implementation of DTrace within
 the Pony compiler. In particular, it focuses on how to use and extend the DTrace
 implementation within Pony.
 
-DTrace is only available for MacOS and BSD. For Linux there is an alternative
+DTrace is only available for macOS and FreeBSD. For Linux there is an alternative
 called [SystemTap](https://sourceware.org/systemtap/). SystemTap uses the same
 resources as DTrace, but uses different scripts. You will find more information
 on using SystemTap within the Pony compiler [here](../systemtap/README.md).
@@ -22,9 +22,9 @@ We can also execute a script using the dtrace command. This is necessary if the
 script does not contain a "Shebang". We can do it using the following command:
 `dtrace -s [script] -c [binary]`.
 
-### MacOS 10.11+
+### macOS 10.11+
 
-MacOS El Capitan for the first time included "System Integrity Protection". This
+macOS El Capitan for the first time included "System Integrity Protection". This
 feature does not allow for all DTrace features to be used. This includes custom
 DTrace providers. To get around this problem, the following steps can be
 followed:


### PR DESCRIPTION
DTrace isn't supported on DragonFly BSD or OpenBSD: neither can build a working dtrace-instrumented runtime. The `dtrace` use option was gated only by a generic `which dtrace` check, so on DragonFly — which ships the `dtrace` tool — a `use=dtrace` build got past configure and then failed confusingly later.

`make configure use=dtrace` now rejects the option at configure time on both platforms with a clear, OS-specific message, matching how the sanitizers and coverage are already rejected. The tier-3 reject-unsupported-builds CI scripts assert the new guards.

Closes #5447