### PR TITLE
Migrate Makefile install target into CMake (issue #3898)

### DIFF
--- a/.release-notes/fix-install-honors-configured-arch.md
+++ b/.release-notes/fix-install-honors-configured-arch.md
@@ -1,0 +1,17 @@
+## Make `make install` honor the architecture chosen at `make configure`
+
+Previously, the Unix Makefile's `install` target built its destination from
+make's `arch` variable, which defaults to `native` on every invocation. The
+build, however, was configured against the `PONY_ARCH` cached by CMake at
+`make configure` time. Running `make configure arch=<non-default>`, `make
+build`, then `make install` (without re-passing `arch=`) installed the runtime
+libraries into `lib/native/` while the compiler — which looks for its runtime
+at `lib/<arch>` using the architecture it was compiled with — searched
+elsewhere, producing an installation that could not find its own libraries.
+
+The `install` target now delegates to `cmake --install`, and the install rules
+place the runtime into `lib/${PONY_ARCH}` (a flat `lib/` on Windows, matching
+the compiler's platform-specific lookup). `PONY_ARCH`, set once at configure
+time, is the single source of truth for both the compiled-in lookup path and
+the install destination, so the install location can no longer drift from what
+the build configured.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,16 +519,38 @@ else()
     add_subdirectory(tools/pony-lint)
     add_subdirectory(tools/pony-doc)
 
+    # The ponyc compiler binary. Test and benchmark binaries are deliberately
+    # NOT installed — they are build artifacts, not part of a user install.
     install(TARGETS
         ponyc
-        libponyc.tests
-        libponyc.benchmarks
-        libponyrt.benchmarks
-        libponyrt.tests
         DESTINATION bin)
+
+    # Static libraries that are real CMake targets; CMake resolves their archive
+    # paths regardless of where they are emitted.
     install(TARGETS
+        libponyc
         libponyrt
         DESTINATION lib)
+
+    # Static libs and crt objects produced by custom build steps into the output
+    # directory. OPTIONAL because which ones exist is platform/config dependent:
+    # libponyrt-pic.a (Linux), libponyc-standalone.a, the crt objects (Linux),
+    # and libdtrace_probes.a (FreeBSD + DTrace).
+    install(FILES
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libponyc-standalone.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libponyrt-pic.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libdtrace_probes.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginS.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
+        DESTINATION lib
+        OPTIONAL)
+
+    # Public headers.
+    install(FILES src/libponyrt/pony.h DESTINATION include)
+    install(FILES src/common/pony/detail/atomics.h DESTINATION include/pony/detail)
+
     install(DIRECTORY packages/ DESTINATION packages)
     install(DIRECTORY examples/ DESTINATION examples PATTERN .gitignore EXCLUDE)
     install(PROGRAMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,16 +525,26 @@ else()
         ponyc
         DESTINATION bin)
 
+    # Where the runtime libraries are installed. The compiler locates its runtime
+    # relative to the ponyc binary via add_exec_dir() in
+    # src/libponyc/pkg/package.c, and that lookup differs by platform:
+    #   * non-Windows: "../lib/<arch>", where <arch> is the compiled-in PONY_ARCH
+    #     (or --link-arch when the user overrides it at compile time). The install
+    #     destination must match PONY_ARCH so the default lookup resolves.
+    #   * Windows: a flat "..\lib" with no arch component.
+    # The destination is gated on platform to stay in sync with both branches.
+    if(WIN32)
+        set(PONY_LIB_DESTINATION lib)
+    else()
+        set(PONY_LIB_DESTINATION lib/${PONY_ARCH})
+    endif()
+
     # Static libraries that are real CMake targets; CMake resolves their archive
-    # paths regardless of where they are emitted. They MUST go in lib/${PONY_ARCH}
-    # because the compiler looks for its runtime at "../lib/<arch>" relative to
-    # the ponyc binary, where <arch> is the compiled-in PONY_ARCH (see
-    # add_exec_dir() in src/libponyc/pkg/package.c). PONY_ARCH is the single
-    # source of truth shared by the compiled binary and this install rule.
+    # paths regardless of where they are emitted.
     install(TARGETS
         libponyc
         libponyrt
-        DESTINATION lib/${PONY_ARCH})
+        DESTINATION ${PONY_LIB_DESTINATION})
 
     # Static libs and crt objects produced by custom build steps into the output
     # directory. OPTIONAL because which ones exist is platform/config dependent:
@@ -548,7 +558,7 @@ else()
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
-        DESTINATION lib/${PONY_ARCH}
+        DESTINATION ${PONY_LIB_DESTINATION}
         OPTIONAL)
 
     # Public headers.
@@ -557,13 +567,18 @@ else()
 
     install(DIRECTORY packages/ DESTINATION packages)
     install(DIRECTORY examples/ DESTINATION examples PATTERN .gitignore EXCLUDE)
+    # OPTIONAL mirrors the old Makefile's "if [ -f ... ]" guards: a build that
+    # excludes a tool binary should skip it, not fail the whole install.
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-lsp${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-lint${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-doc${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,11 +526,15 @@ else()
         DESTINATION bin)
 
     # Static libraries that are real CMake targets; CMake resolves their archive
-    # paths regardless of where they are emitted.
+    # paths regardless of where they are emitted. They MUST go in lib/${PONY_ARCH}
+    # because the compiler looks for its runtime at "../lib/<arch>" relative to
+    # the ponyc binary, where <arch> is the compiled-in PONY_ARCH (see
+    # add_exec_dir() in src/libponyc/pkg/package.c). PONY_ARCH is the single
+    # source of truth shared by the compiled binary and this install rule.
     install(TARGETS
         libponyc
         libponyrt
-        DESTINATION lib)
+        DESTINATION lib/${PONY_ARCH})
 
     # Static libs and crt objects produced by custom build steps into the output
     # directory. OPTIONAL because which ones exist is platform/config dependent:
@@ -544,7 +548,7 @@ else()
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
-        DESTINATION lib
+        DESTINATION lib/${PONY_ARCH}
         OPTIONAL)
 
     # Public headers.

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
 install: all
-	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
+	$(SILENT)cd '$(buildDir)' && env DESTDIR= CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -453,12 +453,13 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
 	$(SILENT)cmake_arch=`grep '^PONY_ARCH:' '$(buildDir)/CMakeCache.txt' | cut -d= -f2`; \
-	libdir=$(ponydir)/lib/$$cmake_arch; \
-	if [ -f $$libdir/libponyc.a ]; then ln -s -f $$libdir/libponyc.a $(prefix)/lib/libponyc.a; fi; \
-	if [ -f $$libdir/libponyc-standalone.a ]; then ln -s -f $$libdir/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi; \
-	if [ -f $$libdir/libponyrt.a ]; then ln -s -f $$libdir/libponyrt.a $(prefix)/lib/libponyrt.a; fi; \
-	if [ -f $$libdir/libponyrt-pic.a ]; then ln -s -f $$libdir/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi; \
-	if [ -f $$libdir/libdtrace_probes.a ]; then ln -s -f $$libdir/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	if [ -z "$$cmake_arch" ]; then echo "install: could not read PONY_ARCH from $(buildDir)/CMakeCache.txt; run 'make configure' first" >&2; exit 1; fi; \
+	libdir="$(ponydir)/lib/$$cmake_arch"; \
+	if [ -f "$$libdir/libponyc.a" ]; then ln -s -f "$$libdir/libponyc.a" "$(prefix)/lib/libponyc.a"; fi; \
+	if [ -f "$$libdir/libponyc-standalone.a" ]; then ln -s -f "$$libdir/libponyc-standalone.a" "$(prefix)/lib/libponyc-standalone.a"; fi; \
+	if [ -f "$$libdir/libponyrt.a" ]; then ln -s -f "$$libdir/libponyrt.a" "$(prefix)/lib/libponyrt.a"; fi; \
+	if [ -f "$$libdir/libponyrt-pic.a" ]; then ln -s -f "$$libdir/libponyrt-pic.a" "$(prefix)/lib/libponyrt-pic.a"; fi; \
+	if [ -f "$$libdir/libdtrace_probes.a" ]; then ln -s -f "$$libdir/libdtrace_probes.a" "$(prefix)/lib/libdtrace_probes.a"; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
 install: all
-	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config) --strip
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -452,11 +452,13 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lsp ]; then ln -s -f $(ponydir)/bin/pony-lsp $(prefix)/bin/pony-lsp; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyc.a ]; then ln -s -f $(ponydir)/lib/libponyc.a $(prefix)/lib/libponyc.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyrt.a ]; then ln -s -f $(ponydir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	$(SILENT)cmake_arch=`grep '^PONY_ARCH:' '$(buildDir)/CMakeCache.txt' | cut -d= -f2`; \
+	libdir=$(ponydir)/lib/$$cmake_arch; \
+	if [ -f $$libdir/libponyc.a ]; then ln -s -f $$libdir/libponyc.a $(prefix)/lib/libponyc.a; fi; \
+	if [ -f $$libdir/libponyc-standalone.a ]; then ln -s -f $$libdir/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi; \
+	if [ -f $$libdir/libponyrt.a ]; then ln -s -f $$libdir/libponyrt.a $(prefix)/lib/libponyrt.a; fi; \
+	if [ -f $$libdir/libponyrt-pic.a ]; then ln -s -f $$libdir/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi; \
+	if [ -f $$libdir/libdtrace_probes.a ]; then ln -s -f $$libdir/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif

--- a/Makefile
+++ b/Makefile
@@ -442,26 +442,8 @@ clean:
 distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
-install: build
-	@mkdir -p $(ponydir)/bin
-	@mkdir -p $(ponydir)/lib/$(arch)
-	@mkdir -p $(ponydir)/include/pony/detail
-	$(SILENT)cp $(buildDir)/src/libponyrt/libponyrt.a $(ponydir)/lib/$(arch)
-	$(SILENT)if [ -f $(buildDir)/src/libponyrt/libdtrace_probes.a ]; then cp $(buildDir)/src/libponyrt/libdtrace_probes.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyc.a ]; then cp $(outDir)/libponyc.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyc-standalone.a ]; then cp $(outDir)/libponyc-standalone.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyrt-pic.a ]; then cp $(outDir)/libponyrt-pic.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtbeginS.o ]; then cp $(outDir)/crtbeginS.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtendS.o ]; then cp $(outDir)/crtendS.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtbeginT.o ]; then cp $(outDir)/crtbeginT.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtend.o ]; then cp $(outDir)/crtend.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)cp $(outDir)/ponyc $(ponydir)/bin
-	$(SILENT)if [ -f $(outDir)/pony-lsp ]; then cp $(outDir)/pony-lsp $(ponydir)/bin; fi
-	$(SILENT)if [ -f $(outDir)/pony-lint ]; then cp $(outDir)/pony-lint $(ponydir)/bin; fi
-	$(SILENT)if [ -f $(outDir)/pony-doc ]; then cp $(outDir)/pony-doc $(ponydir)/bin; fi
-	$(SILENT)cp src/libponyrt/pony.h $(ponydir)/include
-	$(SILENT)cp src/common/pony/detail/atomics.h $(ponydir)/include/pony/detail
-	$(SILENT)cp -r packages $(ponydir)/
+install: all
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config) --strip
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -470,11 +452,11 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lsp ]; then ln -s -f $(ponydir)/bin/pony-lsp $(prefix)/bin/pony-lsp; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc.a $(prefix)/lib/libponyc.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt.a $(prefix)/lib/libponyrt.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyc.a ]; then ln -s -f $(ponydir)/lib/libponyc.a $(prefix)/lib/libponyc.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyrt.a ]; then ln -s -f $(ponydir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif


### PR DESCRIPTION
# Migrate Makefile `install` target into CMake (issue #3898)

Fixes #3898.

## Problem

`make install` ignored the architecture chosen at `make configure` time. The
old Unix Makefile `install` target was shell `cp` logic that built its
destination from make's `arch` variable (`arch ?= native`), which re-defaults
to `native` on every invocation. The build, however, was configured against the
`PONY_ARCH` cached by CMake at `configure` time.

So `make configure arch=<non-default> && make build && make install` (without
re-passing `arch=`) installed the runtime into `lib/native/`, while the compiler
— which looks for its runtime at `lib/<arch>` using its compiled-in `PONY_ARCH`
(`add_exec_dir()` in `src/libponyc/pkg/package.c`) — searched a different
directory. The result was an installation that could not find its own libraries.

## Fix

Move install ownership into CMake so a single source of truth drives it:

- The Makefile `install` target is now a thin `cmake --install` wrapper.
- CMake `install()` rules place the runtime into `lib/${PONY_ARCH}` on
  non-Windows (flat `lib` on Windows, matching the compiler's platform-specific
  lookup), install the headers, packages, `ponyc`, and the auxiliary tools, and
  use `OPTIONAL` for artifacts whose existence is platform/config dependent.
- The `symlink=yes` block reads `PONY_ARCH` from `CMakeCache.txt` rather than
  make's `$(arch)`, so its symlinks point at the same per-arch directory.

`PONY_ARCH`, set once at configure time, is now the single source of truth for
both the compiled-in lookup path and the install destination, so the install
location can no longer drift from what the build configured.

Also in this change:

- Removed the test/benchmark binaries from the `bin` install (the old shell
  install never shipped them).
- Dropped `--strip` (the old install never stripped; stripping static archives
  and crt objects removes symbols the linker needs).

## Files

- `Makefile` — `install` target rewritten as a `cmake --install` wrapper;
  symlink block reads the cached `PONY_ARCH`.
- `CMakeLists.txt` — completed `install()` rules (libs into `lib/${PONY_ARCH}`,
  headers, OPTIONAL generated artifacts and tools; platform-gated destination).
- `.release-notes/fix-install-honors-configured-arch.md` — release note.

## Verification status (please read)

I want to be upfront: this change has been verified by **static analysis,
sandbox reproduction, and an ensemble code review — but it has NOT been built
and installed end-to-end.**

- A full local build requires `make libs` (compiles LLVM from scratch, multiple
  hours), which I did not have a build box to run.
- No PR CI workflow runs `make install` (only the release/nightly scripts do,
  and they don't assert artifact placement), so PR CI won't exercise this path
  either.

What *was* done:

- Reproduced the original bug with a sandbox script that runs the real `install`
  recipe against a stubbed configured cache + artifacts.
- Ran ponylang's `pony-code-review` (8-persona full mode). It caught two real
  regressions in an earlier version of this change, both now fixed:
  - **Windows:** a per-arch `lib/${PONY_ARCH}` destination broke Windows, where
    the compiler searches a flat `..\lib` and `make.ps1` doesn't set
    `PONY_ARCH`. Now platform-gated.
  - **DESTDIR:** the Makefile folds `DESTDIR` into `--prefix`, but
    `cmake --install` also honors `$DESTDIR`, double-staging into
    `$DESTDIR/$DESTDIR`. Now cleared in the cmake environment.
- Confirmed `make -n install` parses/resolves and the CMake install block is
  well-formed.

Still needs a maintainer or a dedicated build to confirm before merge:

- [ ] `make libs && make configure arch=<non-default> && make build && make install`
  → libraries land in `lib/<arch>` and the installed `ponyc` links a sample program.
- [ ] `symlink=yes`, `DESTDIR` staging, and `uninstall` paths.

## Parked / for discussion

- **Install smoke-test:** this bug class is silent (install succeeds; breakage
  shows up downstream). A CI step that installs with a non-default arch and
  asserts `lib/<arch>/libponyrt.a` exists would verify this fix and prevent
  regression. Happy to add it if maintainers want it in this PR.
- **`--link-arch` at compile time** names a runtime dir the default install
  doesn't populate. Pre-existing behavior, not changed here.
- **`BUILD.md`** documents `make install arch=armv8-a`; that arg is now inert
  (arch is fixed at configure time). Can update in this PR if desired.

## AI assistance disclosure

This contribution was AI-assisted, and I want to be transparent about how:

- It explained that I can't realistically build this locally to verify it the
  ideal way — a full build requires compiling LLVM from scratch (`make libs`),
  which takes hours and needs a build box I don't have. That is the honest
  reason this PR is not built end-to-end.
- In place of a full build, it set me up with two cheaper verifications: a
  `make -n install` **dry run** (which prints the exact commands the target
  would run, exposing the arch drift directly), and a **sandbox script** that
  stubs the configured CMake cache + build artifacts and runs the *real*
  `install` recipe into a throwaway directory — reproducing the bug against the
  old code and confirming the fix's behavior, all without LLVM.

I have reviewed every change and can speak to the rationale behind each hopefully
