### PR TITLE
Fix reachability crash on intersections containing a union member

### DIFF
--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -614,7 +614,12 @@ static void add_rmethod_to_subtypes(reach_t* r, reach_type_t* t,
 
       for(; child != NULL; child = ast_sibling(child))
       {
-        deferred_reification_t* find = lookup_try(NULL, NULL, child, n->name,
+        // Pass from=NULL so lookup skips its private-access checks (which are
+        // gated on from != NULL && opt != NULL). Reachability must not enforce
+        // access control, which is why this historically passed a NULL opt; but
+        // opt is now needed so the subtype machinery (is_bare) can intern into
+        // this compilation's table when child is a union or intersection.
+        deferred_reification_t* find = lookup_try(opt, NULL, child, n->name,
           false);
 
         if(find == NULL)
@@ -907,7 +912,14 @@ static void add_special(reach_t* r, reach_type_t* t, ast_t* type,
   const char* special, pass_opt_t* opt)
 {
   special = stringtab(opt->strtab, special);
-  deferred_reification_t* find = lookup_try(NULL, NULL, type, special, false);
+  // Pass from=NULL so lookup skips its private-access checks (which are gated
+  // on from != NULL && opt != NULL). Reachability must not enforce access
+  // control, which is why this historically passed a NULL opt. Unlike the
+  // union/intersection member lookup in add_rmethod_to_subtypes, `type` here
+  // is always a concrete nominal, so this never reaches the subtype machinery
+  // that requires opt (is_bare); opt is threaded only so that no lookup passes
+  // opt == NULL.
+  deferred_reification_t* find = lookup_try(opt, NULL, type, special, false);
 
   if(find != NULL)
   {

--- a/test/libponyc/reach.cc
+++ b/test/libponyc/reach.cc
@@ -60,6 +60,60 @@ TEST_F(ReachTest, IsectHasSubtypes)
   ASSERT_TRUE(found);
 }
 
+// Reaching a method on an intersection type one of whose members is a union
+// must compile cleanly. add_rmethod_to_subtypes walks an intersection's
+// members and looks the reached method up on each; when a member is a union,
+// that lookup runs is_subtype_fun across the union's arms to reconcile their
+// signatures, and that reconciliation calls is_bare. The member lookup used to
+// pass opt == NULL, but is_bare needs a non-NULL opt (it interns into opt's
+// string table), so the reconciliation aborted. `foo` lives in both arms of the
+// `(T1 | T2)` member, which is what forces the multi-arm reconciliation; the
+// method must reach without crashing.
+TEST_F(ReachTest, IsectMemberUnionMethodReached)
+{
+  const char* src =
+    "trait T1\n"
+    "  fun foo()\n"
+
+    "trait T2\n"
+    "  fun foo()\n"
+
+    "trait Other\n"
+    "  fun bar()\n"
+
+    "class C is (T1 & Other)\n"
+    "  fun foo() => None\n"
+    "  fun bar() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: ((T1 | T2) & Other) = C\n"
+    "    x.foo()";
+
+  TEST_COMPILE(src, "reach");
+
+  ast_t* x_ast = type_of("x");
+  ASSERT_NE(x_ast, (void*)NULL);
+
+  reach_t* reach = compile->reach;
+  reach_type_t* x_reach = reach_type(reach, x_ast, &opt);
+  ASSERT_NE(x_reach, (void*)NULL);
+
+  bool found = false;
+  size_t i = HASHMAP_BEGIN;
+  reach_method_name_t* n;
+  while((n = reach_method_names_next(&x_reach->methods, &i)) != NULL)
+  {
+    if(n->name == stringtab(opt.strtab, "foo"))
+    {
+      found = true;
+      break;
+    }
+  }
+
+  ASSERT_TRUE(found);
+}
+
 // A generic function that instantiates itself with an ever-deeper type
 // argument (Bar.apply[A] calls Bar.apply[Pair[A]]) requires an unbounded number
 // of reachable types/methods. Reachability used to chase this until it ran out


### PR DESCRIPTION
PR #5420 made the interned-string table per-compilation and changed `is_bare`
to take a `pass_opt_t` so it could intern `"ponyint_bare"` into that table,
adding `pony_assert(opt != NULL)`. It threaded `opt` to the interning sites but
missed two `lookup_try` calls in `reach.c` that passed `opt == NULL` to skip
access-control checks. When the looked-up type is a union or intersection, the
lookup runs `is_subtype_fun` across the members, which reaches `is_bare` with
`opt == NULL` and aborts during reachability (`is_bare: Assertion 'opt != NULL'
failed`). Any program that reaches a method on an intersection whose member is a
union triggers it.

The fix threads `opt` into both lookups, keeping `from == NULL` so access
control stays off, matching the convention #5420 established in `genmatch.c`.
The `add_rmethod_to_subtypes` lookup is the live crash; the `add_special` lookup
is latent (its `type` is always a concrete nominal, so it never reaches the
subtype machinery) and is threaded for consistency so no lookup passes
`opt == NULL`. Adds a reachability test for the crashing shape.

Since #5420 is unreleased, no release notes entry is needed.
