### PR TITLE
Fix crashes in optimized builds for objects with 128-bit integer fields

### DIFF
--- a/.release-notes/fix-128-bit-field-alignment-crash.md
+++ b/.release-notes/fix-128-bit-field-alignment-crash.md
@@ -1,0 +1,5 @@
+## Fix crashes in optimized builds for objects with 128-bit integer fields
+
+Programs that used objects containing a `U128` or `I128` field could crash at runtime when compiled normally, even though the exact same program ran correctly when compiled with `--debug` (`-d`). For example, a small value type wrapping a `U128` that was created and compared inside a loop would segfault in an optimized build.
+
+These crashes no longer occur. Objects with 128-bit integer fields are now correctly aligned in all build configurations.

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -242,6 +242,18 @@ static void init_runtime(compile_t* c)
 
   unsigned int align_value = target_is_ilp32(c->opt->triple) ? 4 : 8;
 
+  // The runtime allocators hand back memory aligned to at least the largest
+  // fundamental alignment any Pony value can require (e.g. U128/I128 fields
+  // need 16-byte alignment). The pointer-sized `align_value` understates this;
+  // declaring it as the alignment of allocations lets LLVM build an
+  // under-aligned stack slot when it promotes a heap allocation to the stack,
+  // after which an aligned 128-bit store into that slot faults. Advertise the
+  // ABI alignment of the most-aligned scalar instead.
+  unsigned int alloc_align_value =
+    (unsigned int)LLVMABIAlignmentOfType(c->target_data, c->i128);
+  if(alloc_align_value < align_value)
+    alloc_align_value = align_value;
+
   LLVM_DECLARE_ATTRIBUTEREF(nounwind_attr, nounwind, 0);
   LLVM_DECLARE_ATTRIBUTEREF(readnone_attr, readnone, 0);
   LLVM_DECLARE_ATTRIBUTEREF(readonly_attr, readonly, 0);
@@ -254,7 +266,7 @@ static void init_runtime(compile_t* c)
   LLVM_DECLARE_ATTRIBUTEREF(noreturn_attr, noreturn, 0);
   LLVM_DECLARE_ATTRIBUTEREF(deref_actor_attr, dereferenceable,
     PONY_ACTOR_PAD_SIZE + align_value);
-  LLVM_DECLARE_ATTRIBUTEREF(align_attr, align, align_value);
+  LLVM_DECLARE_ATTRIBUTEREF(align_attr, align, alloc_align_value);
   LLVM_DECLARE_ATTRIBUTEREF(deref_or_null_alloc_attr, dereferenceable_or_null,
     HEAP_MIN);
   LLVM_DECLARE_ATTRIBUTEREF(deref_alloc_small_attr, dereferenceable, HEAP_MIN);

--- a/test/full-program-tests/u128-field-stack-promotion-alignment/main.pony
+++ b/test/full-program-tests/u128-field-stack-promotion-alignment/main.pony
@@ -1,0 +1,32 @@
+// Regression test for a codegen alignment bug.
+//
+// An object with a U128 field requires 16-byte alignment, but the runtime
+// allocator functions were declared to LLVM as returning only 8-byte-aligned
+// memory. When the optimizer promoted such a heap allocation to the stack it
+// produced an 8-byte-aligned slot, and the aligned 128-bit store into that
+// slot faulted at runtime in optimized (non-debug) builds.
+
+class val Dec
+  let _m: U128
+  new val create(m: U128) => _m = m
+  fun value(): U128 => _m
+  fun gt(o: Dec): Bool => _m > o._m
+
+actor Worker
+  let _env: Env
+  new create(env: Env) => _env = env
+  be go() =>
+    var acc = Dec(0)
+    var i: U128 = 0
+    while i < 50 do
+      let d = Dec(i * 7)
+      if d.gt(acc) then acc = d end
+      i = i + 1
+    end
+    if acc.value() != 343 then
+      _env.exitcode(1)
+    end
+
+actor Main
+  new create(env: Env) =>
+    Worker(env).go()


### PR DESCRIPTION
The runtime allocator functions were declared to LLVM as returning only 8-byte-aligned memory. Objects containing a U128/I128 field require 16-byte alignment, and when the optimizer promoted such a heap allocation to the stack it produced an 8-byte-aligned slot, causing the aligned 128-bit store into that slot to fault at runtime in non-debug builds.

Declare the allocator return values with the ABI alignment of the most-aligned scalar (i128, 16 bytes on 64-bit targets) instead of the pointer alignment. This matches what the runtime allocators actually provide (small slots sit at HEAP_MIN multiples; large/pool allocations are pool-aligned), so LLVM builds correctly-aligned stack slots when it promotes an allocation. No type's ABI alignment or layout changes.

Fixes #5462