### PR TITLE
Add Alpine 3.24 as a supported platform

### DIFF
--- a/.ci-dockerfiles/alpine3.24-builder/Dockerfile
+++ b/.ci-dockerfiles/alpine3.24-builder/Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:3.24
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+RUN apk update \
+  && apk upgrade \
+  && apk add --update --no-cache \
+  alpine-sdk \
+  clang \
+  clang-dev \
+  coreutils \
+  linux-headers \
+  cmake \
+  git \
+  zlib-dev \
+  bash \
+  curl \
+  py3-pip \
+  gdb \
+  lldb \
+  py3-lldb \
+&& pip install --break-system-packages cloudsmith-cli
+
+# add user pony in order to not run tests as root
+RUN adduser -D -u 1001 -s /bin/sh -h /home/pony -g root pony
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/alpine3.24-builder/build-and-push.bash
+++ b/.ci-dockerfiles/alpine3.24-builder/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-alpine3.24-builder"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="alpine3.24-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -10,6 +10,7 @@ on:
         options:
           - alpine3.22-builder
           - alpine3.23-builder
+          - alpine3.24-builder
           - arm64-unknown-linux-alpine3.21-builder
           - arm64-unknown-linux-ubuntu24.04-builder
           - cross-arm
@@ -72,6 +73,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/alpine3.23-builder/build-and-push.bash
+
+  alpine3_24-builder:
+    if: ${{ github.event.inputs.builder-name == 'alpine3.24-builder' }}
+    runs-on: ubuntu-latest
+
+    name: alpine3.24-builder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/alpine3.24-builder/build-and-push.bash
 
   arm64-unknown-linux-alpine3_21-builder:
     if: ${{ github.event.inputs.builder-name == 'arm64-unknown-linux-alpine3.21-builder' }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -35,6 +35,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
+            name: x86-64-unknown-linux-alpine3.24
+            triple-os: linux-alpine3.24
+            triple-vendor: unknown
           - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             name: x86-64-unknown-linux-ubuntu26.04
             triple-os: linux-ubuntu26.04
@@ -111,6 +115,9 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
+            name: arm64-unknown-linux-alpine3.24
+            triple-os: linux-alpine3.24
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
             name: arm64-unknown-linux-ubuntu24.04
             triple-os: linux-ubuntu24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
             name: x86-64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
             triple-vendor: unknown
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
+            name: x86-64-unknown-linux-alpine3.24
+            triple-os: linux-alpine3.24
+            triple-vendor: unknown
           - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             name: x86-64-unknown-linux-ubuntu26.04
             triple-os: linux-ubuntu26.04
@@ -139,6 +143,9 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64-unknown-linux-alpine3.23
             triple-os: linux-alpine3.23
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
+            name: arm64-unknown-linux-alpine3.24
+            triple-os: linux-alpine3.24
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
             name: arm64-unknown-linux-ubuntu24.04
             triple-os: linux-ubuntu24.04

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -26,6 +26,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
           - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
           - image: ghcr.io/ponylang/ponyc-ci-cross-arm:20250223
           - image: ghcr.io/ponylang/ponyc-ci-cross-armhf:20250223
@@ -70,6 +71,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-alpine3.21-builder:20250510
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
+          - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611
           - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
 
     name: ${{ matrix.image }}

--- a/.release-notes/alpine3.24.md
+++ b/.release-notes/alpine3.24.md
@@ -1,0 +1,3 @@
+## Add Alpine 3.24 as a supported platform
+
+We've added arm64 and amd64 builds for Alpine Linux 3.24. We'll be building ponyc releases for it until it stops receiving security updates in 2028. At that point, we'll stop building releases for it.

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -47,6 +47,7 @@ Package names will be:
 * ponyc-arm64-unknown-linux-alpine3.21.tar.gz
 * ponyc-arm64-unknown-linux-alpine3.22.tar.gz
 * ponyc-arm64-unknown-linux-alpine3.23.tar.gz
+* ponyc-arm64-unknown-linux-alpine3.24.tar.gz
 * ponyc-arm64-unknown-linux-ubuntu24.04.tar.gz
 * ponyc-arm64-unknown-linux-ubuntu26.04.tar.gz
 * ponyc-x86-64-apple-darwin.tar.gz
@@ -54,6 +55,7 @@ Package names will be:
 * ponyc-x86-64-unknown-linux-alpine3.21.tar.gz
 * ponyc-x86-64-unknown-linux-alpine3.22.tar.gz
 * ponyc-x86-64-unknown-linux-alpine3.23.tar.gz
+* ponyc-x86-64-unknown-linux-alpine3.24.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu22.04.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu24.04.tar.gz
 * ponyc-x86-64-unknown-linux-ubuntu26.04.tar.gz


### PR DESCRIPTION
Adds Alpine Linux 3.24 as a supported release target, mirroring the existing `alpine3.23` multi-platform builder. Includes the builder image (Dockerfile + `build-and-push.bash`), `release.yml`/`nightlies.yml`/`update-lib-cache.yml` matrix entries for amd64 and arm64, the `RELEASE_PROCESS.md` package names, and a release note.

The multi-arch builder image is already built and pushed: `ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611`.