### PR TITLE
Pin cloudsmith-cli below 1.19.0 on arm64 Windows CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -383,7 +383,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v5.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,12 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
       - name: Restore Libs Cache
         id: restore-libs
         uses: actions/cache/restore@v5.0.3


### PR DESCRIPTION
cloudsmith-cli 1.19.0 added a PyJWT[crypto] dependency that pulls in cryptography, which has no prebuilt win_arm64 wheel. pip then builds it from source on the windows-11-arm runners, which needs OpenSSL and fails. That broke the arm64 Windows nightly at the `Install Dependencies` step and would break the arm64 release the same way.

Pin below 1.19.0 — which resolves to 1.18.0, the last release without the crypto extra — on the arm64 Windows steps only. x86 Windows, Linux, and macOS install the latest fine, so they're left untouched.