### PR TITLE
Make the net/Broadcast test robust against UDP datagram loss

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -1,5 +1,6 @@
 use "files"
 use "pony_test"
+use "time"
 
 use @pony_os_ip_string[Pointer[U8]](src: Pointer[U8] tag, len: I32)
 
@@ -51,18 +52,10 @@ class \nodoc\ _TestPing is UDPNotify
       let auth = DNSAuth(h.env.root)
       (_, let service) = ip.name()?
 
-      let list = if ip.ip4() then
-        ifdef bsd then
-          DNS.ip4(auth, "", service)
-        else
-          DNS.broadcast_ip4(auth, service)
-        end
+      let list = ifdef bsd then
+        DNS.ip4(auth, "", service)
       else
-        ifdef bsd then
-          DNS.ip6(auth, "", service)
-        else
-          DNS.broadcast_ip6(auth, service)
-        end
+        DNS.broadcast_ip4(auth, service)
       end
 
       list(0)?
@@ -79,6 +72,25 @@ class \nodoc\ _TestPing is UDPNotify
 
     sock.set_broadcast(true)
     sock.write("ping!", _ip)
+
+    // UDP is best-effort, so a one-shot ping fails the test on any dropped
+    // datagram. Retransmit until the test completes: passing still requires
+    // a successful send to the broadcast address and a reply. Duplicate
+    // replies are harmless - completing an already-completed action is a
+    // no-op. The timer is disposed at test teardown; a firing that races
+    // teardown either sends one last harmless datagram or writes to the
+    // closed socket, which drops it.
+    let udp: UDPSocket tag = sock
+    let to = _ip
+    let timers = Timers
+    timers(Timer(
+      object iso is TimerNotify
+        fun ref apply(timer: Timer, count: U64): Bool =>
+          udp.write("ping!", to)
+          true
+      end,
+      250_000_000, 250_000_000))
+    _h.dispose_when_done(timers)
 
   fun ref received(
     sock: UDPSocket ref,
@@ -107,13 +119,8 @@ class \nodoc\ _TestPong is UDPNotify
     let ip = sock.local_address()
 
     let h = _h
-    if ip.ip4() then
-      _h.dispose_when_done(
-        UDPSocket.ip4(UDPAuth(h.env.root), recover _TestPing(h, ip) end))
-    else
-      _h.dispose_when_done(
-        UDPSocket.ip6(UDPAuth(h.env.root), recover _TestPing(h, ip) end))
-    end
+    _h.dispose_when_done(
+      UDPSocket.ip4(UDPAuth(h.env.root), recover _TestPing(h, ip) end))
 
   fun ref received(
     sock: UDPSocket ref,
@@ -165,7 +172,20 @@ class \nodoc\ iso _TestSocketResultDecoder is UnitTest
 
 class \nodoc\ iso _TestBroadcast is UnitTest
   """
-  Test broadcasting with UDP.
+  Test broadcasting with UDP. A pong socket listens; a ping socket sends
+  "ping!" to the IPv4 broadcast address at the pong socket's port (except on
+  BSD, where the destination is a local address instead) and the pong socket
+  replies "pong!" to the ping socket's address by ordinary unicast. Passing
+  proves a successful send to the broadcast address with SO_BROADCAST set,
+  plus the reply; the receiving socket is bound to INADDR_ANY, so reception
+  itself is not broadcast-specific.
+
+  Both sockets are explicitly IPv4. The default UDPSocket constructor binds
+  whichever address family getaddrinfo returns first, and IPv6 has no
+  broadcast - that path sent to all-nodes multicast (FF02::1) instead, which
+  is unreliable on multi-interface hosts. The ping is retransmitted on a
+  timer until the test completes, since UDP delivery is best-effort and a
+  single dropped datagram would otherwise fail the test.
   """
   fun name(): String => "net/Broadcast"
   fun label(): String => "unreliable-appveyor-osx"
@@ -180,7 +200,7 @@ class \nodoc\ iso _TestBroadcast is UnitTest
     h.expect_action("ping receive")
 
     h.dispose_when_done(
-      UDPSocket(UDPAuth(h.env.root), recover _TestPong(h) end))
+      UDPSocket.ip4(UDPAuth(h.env.root), recover _TestPong(h) end))
 
     h.long_test(TimeoutValue())
 


### PR DESCRIPTION
net/Broadcast is timing-sensitive and flakes in slow environments, particularly Windows CI. This addresses the two structural causes rather than adjusting timeouts.

The test sent a single "ping!" datagram, so any drop failed it by timeout - but UDP makes no delivery guarantee, even host-locally, so zero loss was never something the test could rightly demand. The ping is now retransmitted every 250ms until the test completes. Passing still requires a successful send to the broadcast address (verified by counterfactual: disabling `set_broadcast` fails the test) plus the reply; retries only stop in-spec datagram loss from failing the test. The retransmit path was also verified by counterfactual: with the initial send disabled, the timer alone carries the test to a pass.

The pong socket used the default `UDPSocket` constructor, which binds whichever address family getaddrinfo returns first. When that came up IPv6, the test exercised all-nodes multicast (FF02::1) instead of broadcast - IPv6 has no broadcast - and link-local multicast egress/join interface selection on multi-interface CI VMs is a plausible mechanism for the observed flakiness. Both sockets are now pinned to `UDPSocket.ip4`, so the test deterministically exercises IPv4 broadcast, which is what its name claims.

One limitation worth stating: retransmission mitigates probabilistic datagram loss; it cannot fix deterministic non-delivery (a runner whose firewall drops 255.255.255.255 outright will now fail slower, not less often). If a runner still fails after this change, look at environmental reachability, not timing.

The IPv6 multicast path the old test exercised nondeterministically loses its accidental coverage; #5470 tracks adding a deterministic replacement along with two pre-existing coverage gaps surfaced during review.