### PR TITLE
Fix multicast socket-option plumbing

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -262,3 +262,15 @@ These objects are now correctly aligned in optimized builds, and the crash no lo
 
 We've added arm64 and amd64 builds for Alpine Linux 3.24. We'll be building ponyc releases for it until it stops receiving security updates in 2028. At that point, we'll stop building releases for it.
 
+## Fix `UDPSocket.set_multicast_interface` not setting the interface
+
+`UDPSocket.set_multicast_interface` never actually set the interface used for outgoing multicast. It handed the operating system the address of an internal pointer rather than the resolved interface address, so the kernel received meaningless bytes and the socket's multicast interface was left unchanged, on both IPv4 and IPv6.
+
+It now sets the interface correctly. For an IPv4 interface, pass the interface's IPv4 address. For an IPv6 interface, the interface is taken from the scope id of the resolved address, so a scoped address such as `"fe80::1%eth0"` is needed to select an interface.
+
+## Fix `UDPSocket.set_multicast_loopback` and `set_multicast_ttl` having no effect
+
+`UDPSocket.set_multicast_loopback` and `set_multicast_ttl` did not change a socket's IPv4 multicast loopback or TTL behavior. They applied the options at the wrong socket level, so the request either failed or set an unrelated option, leaving the multicast loopback and TTL at their defaults.
+
+Both now take effect for IPv4 multicast.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Reject self-referential iftype constraints inside lambdas and object literals ([PR #5423](https://github.com/ponylang/ponyc/pull/5423))
 - Fix incorrect rejection and crashes for iftype conditions inside lambdas and object literals ([PR #5443](https://github.com/ponylang/ponyc/pull/5443))
 - Fix runtime crash in optimized builds for types with 128-bit fields ([PR #5464](https://github.com/ponylang/ponyc/pull/5464))
+- Fix `UDPSocket.set_multicast_interface` not setting the interface ([PR #5481](https://github.com/ponylang/ponyc/pull/5481))
+- Fix `UDPSocket.set_multicast_loopback` and `set_multicast_ttl` having no effect ([PR #5481](https://github.com/ponylang/ponyc/pull/5481))
 
 ### Added
 

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -40,6 +40,14 @@ actor \nodoc\ Main is TestList
       test(_TestBroadcast)
     end
 
+    // Tests below exclude osx and bsd and are listed alphabetically.
+    // They read IPv4 multicast options back with getsockopt_u32, which
+    // expects a 4-byte value; osx and bsd return these options as a 1-byte
+    // u_char, so the read-back fails there regardless of correctness.
+    ifdef (not osx) and (not bsd) then
+      test(_TestMulticastSockopt)
+    end
+
 class \nodoc\ _TestPing is UDPNotify
   let _h: TestHelper
   let _ip: NetAddress
@@ -127,6 +135,58 @@ class \nodoc\ _TestPong is UDPNotify
     sock.writev(
       recover val [[U8('p'); U8('o'); U8('n'); U8('g'); U8('!')]] end,
       from)
+
+class \nodoc\ _TestMulticastNotify is UDPNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref not_listening(sock: UDPSocket ref) =>
+    _h.fail_action("multicast listen")
+
+  fun ref listening(sock: UDPSocket ref) =>
+    _h.complete_action("multicast listen")
+
+    // Round-trip the IPv4 multicast TTL and loopback options. These are
+    // IPPROTO_IP-level options; setting them at the wrong level (the prior
+    // SOL_SOCKET bug) either fails or fails to take effect, so the value
+    // read back would not match what was set.
+    sock.set_ip_multicast_ttl(7)
+    (let ttl_err: U32, let ttl: U32) =
+      sock.getsockopt_u32(OSSockOpt.ipproto_ip(), OSSockOpt.ip_multicast_ttl())
+    _h.assert_eq[U32](ttl_err, 0, "getsockopt IP_MULTICAST_TTL failed")
+    _h.assert_eq[U32](ttl, 7, "IP_MULTICAST_TTL did not round-trip")
+
+    sock.set_ip_multicast_loop(false)
+    (let loop_err: U32, let loop: U32) =
+      sock.getsockopt_u32(OSSockOpt.ipproto_ip(),
+        OSSockOpt.ip_multicast_loop())
+    _h.assert_eq[U32](loop_err, 0, "getsockopt IP_MULTICAST_LOOP failed")
+    _h.assert_eq[U32](loop, 0, "IP_MULTICAST_LOOP did not round-trip")
+
+    _h.complete(true)
+
+  fun ref received(
+    sock: UDPSocket ref,
+    data: Array[U8] iso,
+    from: NetAddress)
+  =>
+    None
+
+class \nodoc\ iso _TestMulticastSockopt is UnitTest
+  """
+  Verify UDPSocket applies the IPv4 multicast TTL and loopback options at the
+  IPPROTO_IP level by setting each and reading the value back.
+  """
+  fun name(): String => "net/MulticastSockopt"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("multicast listen")
+    h.dispose_when_done(
+      UDPSocket.ip4(UDPAuth(h.env.root), recover _TestMulticastNotify(h) end))
+    h.long_test(TimeoutValue())
 
 class \nodoc\ iso _TestSocketResultDecoder is UnitTest
   """

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -201,8 +201,14 @@ actor UDPSocket is AsioEventNotify
   be set_multicast_interface(from: String = "") =>
     """
     By default, the OS will choose which address is used to send packets bound
-    for multicast addresses. This can be used to force a specific interface. To
-    revert to allowing the OS to choose, call with an empty string.
+    for multicast addresses. This can be used to force a specific interface.
+
+    For an IPv4 interface, pass the interface's IPv4 address. For an IPv6
+    interface, the interface is taken from the scope id of the resolved
+    address, so only a scoped address such as `"fe80::1%eth0"` selects an
+    interface; a plain IPv6 address does not.
+
+    Calling with an empty string currently has no effect.
     """
     if not _closed then
       @pony_os_multicast_interface(_fd, from.cstring())
@@ -578,18 +584,18 @@ actor UDPSocket is AsioEventNotify
 
   fun ref set_ip_multicast_loop(loopback: Bool): U32 =>
     """
-    Wrapper for the FFI call `setsockopt(fd, SOL_SOCKET, IP_MULTICAST_LOOP, ...)`
+    Wrapper for the FFI call `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, ...)`
     """
     var word: Array[U8] ref =
       _OSSocket.u32_to_bytes4(if loopback then 1 else 0 end)
-    _OSSocket.setsockopt(_fd, OSSockOpt.sol_socket(), OSSockOpt.ip_multicast_loop(), word)
+    _OSSocket.setsockopt(_fd, OSSockOpt.ipproto_ip(), OSSockOpt.ip_multicast_loop(), word)
 
   fun ref set_ip_multicast_ttl(ttl: U8): U32 =>
     """
-    Wrapper for the FFI call `setsockopt(fd, SOL_SOCKET, IP_MULTICAST_TTL, ...)`
+    Wrapper for the FFI call `setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, ...)`
     """
     var word: Array[U8] ref = _OSSocket.u32_to_bytes4(ttl.u32())
-    _OSSocket.setsockopt(_fd, OSSockOpt.sol_socket(), OSSockOpt.ip_multicast_ttl(), word)
+    _OSSocket.setsockopt(_fd, OSSockOpt.ipproto_ip(), OSSockOpt.ip_multicast_ttl(), word)
 
   fun ref set_so_broadcast(state: Bool): U32 =>
     """

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -1341,12 +1341,40 @@ PONY_API void pony_os_multicast_interface(int fd, const char* from)
   // Use the first reported address.
   struct addrinfo* p = os_addrinfo_intern(AF_UNSPEC, 0, 0, from, NULL, true);
 
-  if(p != NULL)
+  if(p == NULL)
+    return;
+
+  SOCKET s = (SOCKET)fd;
+
+  switch(p->ai_family)
   {
-    setsockopt((SOCKET)fd, IPPROTO_IP, IP_MULTICAST_IF,
-      (const char*)&p->ai_addr, (int)p->ai_addrlen);
-    freeaddrinfo(p);
+    case AF_INET:
+    {
+      // IP_MULTICAST_IF takes the interface's IPv4 address as a struct
+      // in_addr.
+      struct in_addr addr = ((struct sockaddr_in*)p->ai_addr)->sin_addr;
+
+      setsockopt(s, IPPROTO_IP, IP_MULTICAST_IF, (const char*)&addr,
+        sizeof(addr));
+      break;
+    }
+
+    case AF_INET6:
+    {
+      // IPV6_MULTICAST_IF takes an interface index, not an address. The
+      // index comes from the resolved address's scope id, which is only
+      // non-zero for scoped (e.g. link-local) addresses.
+      uint32_t index = ((struct sockaddr_in6*)p->ai_addr)->sin6_scope_id;
+
+      setsockopt(s, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char*)&index,
+        sizeof(index));
+      break;
+    }
+
+    default: {}
   }
+
+  freeaddrinfo(p);
 }
 
 // API deprecated: use UDPSocket.set_ip_multicast_loop


### PR DESCRIPTION
Two related defects in the multicast socket-option plumbing.

`UDPSocket.set_multicast_interface` passed the address of the resolved `addrinfo`'s `ai_addr` pointer field instead of the interface address it points to, so the kernel interpreted the pointer's own bytes as the option value — the interface was never actually set, on IPv4 or IPv6. It now reads the resolved address and uses the correct option and level for each address family (`IP_MULTICAST_IF` for IPv4, `IPV6_MULTICAST_IF` for IPv6).

`UDPSocket.set_multicast_loopback` and `set_multicast_ttl` set `IP_MULTICAST_LOOP` and `IP_MULTICAST_TTL` at the `SOL_SOCKET` level rather than `IPPROTO_IP`, so the calls either failed or set an unrelated socket-level option. Both now use `IPPROTO_IP`, matching the deprecated C functions they replaced.

A round-trip test (`net/MulticastSockopt`) sets the IPv4 TTL and loopback options and reads them back to confirm the level fix. It excludes macOS and BSD, where these options are read back as a single byte rather than a four-byte value.

Full IPv6 support for the loopback and TTL options, an active reset when `set_multicast_interface` is called with an empty string, and IPv6 interface selection from a non-scoped address remain unimplemented and are tracked in #5480.

Closes #5473