### PR TITLE
Set LLVM libs build parallelism to each runner's core count

### DIFF
--- a/.ci-scripts/arm64-apple-darwin-nightly.bash
+++ b/.ci-scripts/arm64-apple-darwin-nightly.bash
@@ -37,7 +37,6 @@ CPU=apple-m1
 TRIPLE=${MACHINE}-apple-darwin
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 PONY_VERSION="nightly-${TODAY}"
@@ -57,7 +56,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${PROCESSOR} cpu=${CPU} build_flags=-j${MAKE_PARALLELISM} \
+make configure arch=${PROCESSOR} cpu=${CPU} \
   version="${PONY_VERSION}"
 make build version="${PONY_VERSION}"
 make install arch=${PROCESSOR} prefix="${BUILD_PREFIX}" symlink=no version="${PONY_VERSION}"

--- a/.ci-scripts/arm64-apple-darwin-release.bash
+++ b/.ci-scripts/arm64-apple-darwin-release.bash
@@ -33,7 +33,6 @@ CPU=apple-m1
 TRIPLE=${MACHINE}-apple-darwin
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 
@@ -52,7 +51,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${PROCESSOR} cpu=${CPU} build_flags=-j${MAKE_PARALLELISM}
+make configure arch=${PROCESSOR} cpu=${CPU}
 make build
 make install arch=${PROCESSOR} prefix="${BUILD_PREFIX}" symlink=no
 

--- a/.ci-scripts/arm64-unknown-linux-nightly.bash
+++ b/.ci-scripts/arm64-unknown-linux-nightly.bash
@@ -43,7 +43,6 @@ CPU=generic
 TRIPLE=${MACHINE}-unknown-${TRIPLE_OS}
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 PONY_VERSION="nightly-${TODAY}"
@@ -63,7 +62,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${PROCESSOR} cpu=${CPU} build_flags=-j${MAKE_PARALLELISM} \
+make configure arch=${PROCESSOR} cpu=${CPU} \
   version="${PONY_VERSION}"
 make build version="${PONY_VERSION}"
 make install arch=${PROCESSOR} prefix="${BUILD_PREFIX}" symlink=no version="${PONY_VERSION}"

--- a/.ci-scripts/arm64-unknown-linux-release.bash
+++ b/.ci-scripts/arm64-unknown-linux-release.bash
@@ -39,7 +39,6 @@ CPU=generic
 TRIPLE=${MACHINE}-unknown-${TRIPLE_OS}
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 
@@ -58,7 +57,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${PROCESSOR} cpu=${CPU} build_flags=-j${MAKE_PARALLELISM}
+make configure arch=${PROCESSOR} cpu=${CPU}
 make build
 make install arch=${PROCESSOR} prefix="${BUILD_PREFIX}" symlink=no
 

--- a/.ci-scripts/x86-64-nightly.bash
+++ b/.ci-scripts/x86-64-nightly.bash
@@ -47,7 +47,6 @@ ARCH=x86-64
 TRIPLE=${ARCH}-${TRIPLE_VENDOR}-${TRIPLE_OS}
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 PONY_VERSION="nightly-${TODAY}"
@@ -67,7 +66,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} cpu=${ARCH} build_flags=-j${MAKE_PARALLELISM} \
+make configure arch=${ARCH} cpu=${ARCH} \
   version="${PONY_VERSION}"
 make build version="${PONY_VERSION}"
 make install arch=${ARCH} prefix="${BUILD_PREFIX}" symlink=no version="${PONY_VERSION}"

--- a/.ci-scripts/x86-64-release.bash
+++ b/.ci-scripts/x86-64-release.bash
@@ -43,7 +43,6 @@ ARCH=x86-64
 TRIPLE=${ARCH}-${TRIPLE_VENDOR}-${TRIPLE_OS}
 
 # Build parameters
-MAKE_PARALLELISM=8
 BUILD_PREFIX=$(mktemp -d)
 DESTINATION=${BUILD_PREFIX}/lib/pony
 
@@ -62,7 +61,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyc"
 
 # Build pony installation
 echo "Building ponyc installation..."
-make configure arch=${ARCH} cpu=${ARCH} build_flags=-j${MAKE_PARALLELISM}
+make configure arch=${ARCH} cpu=${ARCH}
 make build
 make install arch=${ARCH} prefix="${BUILD_PREFIX}" symlink=no
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -62,7 +62,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -153,7 +153,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -204,7 +204,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -251,7 +251,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -70,7 +70,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure config=debug
@@ -136,7 +136,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure config=debug
@@ -202,7 +202,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure config=debug
@@ -261,7 +261,7 @@ jobs:
           key: libs-ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug
@@ -313,7 +313,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug
@@ -397,7 +397,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           docker run --rm \

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -83,7 +83,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug use=${{ matrix.directives }}
@@ -145,7 +145,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           ASAN_OPTIONS=detect_leaks=0:external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer UBSAN_OPTIONS=external_symbolizer_path=$PWD/build/libs/bin/llvm-symbolizer make configure arch=x86-64 config=debug use=${{ matrix.directives }}
@@ -191,7 +191,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Sanitizer Smoke Test
         run: bash .ci-scripts/macos-sanitizer-smoke.sh
       - name: Send alert on failure
@@ -227,7 +227,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Sanitizer Smoke Test
         run: bash .ci-scripts/macos-sanitizer-smoke.sh
       - name: Send alert on failure
@@ -263,7 +263,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: DTrace Smoke Test
         run: bash .ci-scripts/macos-dtrace-smoke.sh
       - name: Send alert on failure
@@ -299,7 +299,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: DTrace Smoke Test
         run: bash .ci-scripts/macos-dtrace-smoke.sh
       - name: Send alert on failure

--- a/.github/workflows/pr-pony-compiler.yml
+++ b/.github/workflows/pr-pony-compiler.yml
@@ -36,7 +36,7 @@ jobs:
           key: libs-ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build
         run: |
           make configure config=debug
@@ -62,7 +62,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Build
         run: |
           make configure arch=armv8 config=debug

--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -54,7 +54,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure arch=x86-64 config=debug
@@ -86,7 +86,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Build Debug Runtime
         run: |
           make configure arch=armv8 config=debug

--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -41,7 +41,7 @@ jobs:
           key: libs-ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build
         run: |
           make configure config=debug
@@ -77,7 +77,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Build
         run: |
           make configure arch=armv8 config=debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -182,7 +182,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -224,7 +224,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -264,7 +264,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -75,7 +75,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -181,7 +181,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -47,7 +47,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -108,7 +108,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -75,7 +75,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -180,7 +180,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -47,7 +47,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3
@@ -108,7 +108,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
       - name: Save Libs Cache
         if: steps.restore-libs.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5.0.3

--- a/.github/workflows/test-with-latest-tools.yml
+++ b/.github/workflows/test-with-latest-tools.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Build Libs
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
           make configure config=debug

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -49,7 +49,7 @@ jobs:
           key: libs-${{ matrix.image }}-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j8
+        run: make libs llvm_tools=false build_flags=-j4
 
   # Currently, Github actions supplied by GH like checkout and cache do not work
   # in musl libc environments on arm64. We can work around this by running
@@ -104,7 +104,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make libs llvm_tools=false build_flags=-j8
+            make libs llvm_tools=false build_flags=-j4
 
   x86_64-macos:
     runs-on: macos-15-intel
@@ -123,7 +123,7 @@ jobs:
           key: libs-x86-macos-15-intel-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j2
+        run: make libs llvm_tools=false build_flags=-j4
 
   arm64-macos:
     runs-on: macos-26
@@ -142,7 +142,7 @@ jobs:
           key: libs-arm64-macos-26-${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
       - name: Build Libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: make libs llvm_tools=false build_flags=-j4
+        run: make libs llvm_tools=false build_flags=-j3
 
   x86_64-windows:
     runs-on: windows-2025-vs2026

--- a/make.ps1
+++ b/make.ps1
@@ -185,8 +185,8 @@ switch ($Command.ToLower())
         if ($err -ne 0) { throw "Error: exit code $err" }
 
         # Write-Output "Building libraries..."
-        Write-Output "cmake.exe --build `"$libsBuildDir`" --target install --config Release"
-        & cmake.exe --build "$libsBuildDir" --target install --config Release
+        Write-Output "cmake.exe --build `"$libsBuildDir`" --target install --config Release --parallel 4"
+        & cmake.exe --build "$libsBuildDir" --target install --config Release --parallel 4
         $err = $LastExitCode
         if ($err -ne 0) { throw "Error: exit code $err" }
         break


### PR DESCRIPTION
The libs build `-j` values had drifted into a stale grab-bag: Linux at `-j8` (oversubscribing the 4-core standard runners), macOS Intel at `-j2`, and the Windows libs build with no parallelism flag at all. This sets each to the core count of its runner — Linux/cross and macOS Intel to `-j4`, macOS Apple Silicon to `-j3` (3-core runners), and the Windows libs build to `--parallel 4`. The FreeBSD/OpenBSD VMs already ran `-j4` against their `-smp 4` hosts, so they're unchanged.

Only the libs build is parallelized; the ponyc build, `make configure`, and the Makefile default are left as-is.

Also drops the dead `MAKE_PARALLELISM` from the release/nightly scripts — it was passed to `make configure`, which ignores `build_flags`, so it never reached any build.

Two things worth knowing:

- The only cache-key input that changed is `make.ps1`, which is hashed solely in the Windows libs cache keys. So this busts only the Windows libs cache; the Linux, macOS, and BSD caches stay warm.
- `macos-15-intel` going `-j2` → `-j4` is the one to watch — if the macOS Intel libs build regresses, it's the LLVM link-memory cliff, and the fix is `LLVM_PARALLEL_LINK_JOBS`. Local Windows `make.ps1 libs` builds also go from serial to 4-way.
