### PR TITLE
Fix Windows process crash when a UDP socket fails to listen

### DIFF
--- a/.release-notes/fix-udp-listen-failure-windows-crash.md
+++ b/.release-notes/fix-udp-listen-failure-windows-crash.md
@@ -1,0 +1,3 @@
+## Fix Windows process crash when a UDP socket fails to listen
+
+On Windows, a `UDPSocket` that failed to start listening — for example because its host address could not be resolved — would crash the entire process immediately after reporting the failure through `not_listening`. The failure is now reported and your program keeps running, matching the behavior on other platforms.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -32,6 +32,7 @@ actor \nodoc\ Main is TestList
     test(_TestTCPProxy)
     test(_TestTCPUnmute)
     test(_TestTCPWritev)
+    test(_TestUDPListenFailure)
     test(_TestUnicastIP6Loopback)
 
     // Tests below run only on linux and are listed alphabetically
@@ -44,7 +45,6 @@ actor \nodoc\ Main is TestList
     ifdef not windows then
       test(_TestTCPConnectionToClosedServerFailed)
       test(_TestTCPThrottle)
-      test(_TestUDPListenFailure)
     end
 
     // Tests below run only on linux and freebsd
@@ -956,10 +956,12 @@ class \nodoc\ iso _TestUDPListenFailure is UnitTest
   added intentionally, this test fails loudly (listening fires) and must
   be updated -- that is the pin working as intended, not flake.
 
-  Not on Windows: a failed UDP listen there crashes the process before
-  anything could be observed (issue #5474). No exclusion_group: neither
-  arm ever binds successfully or emits a datagram, so there is no
-  interference surface.
+  Runs on Windows too: a failed UDP listen there used to crash the process
+  before anything could be observed (issue #5474), which is now fixed -- the
+  runtime's IOCP recv path guards the null event a failed listen leaves
+  behind instead of dereferencing it. No exclusion_group: neither arm ever
+  binds successfully or emits a datagram, so there is no interference
+  surface.
   """
   fun name(): String => "net/UDPListenFailure"
 

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -378,6 +378,12 @@ actor UDPSocket is AsioEventNotify
     This is used only with IOCP on Windows.
     """
     ifdef windows then
+      // On a failed listen `_event` is null; the constructors still call us
+      // unconditionally right after `_notify_listening`. Passing the null
+      // event to `pony_os_recvfrom` is safe -- the runtime guards it and
+      // returns an error (issue #5474) -- which lands in the error arm
+      // below and closes the already-dead socket.
+      //
       // `count` is unused on this path: Windows IOCP `pony_os_recvfrom`
       // returns OK with count=0 because the actual byte count arrives
       // asynchronously via `_complete_reads`. The local is required by

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -432,6 +432,12 @@ static bool iocp_accept(asio_event_t* ev)
 
 static bool iocp_recv(asio_event_t* ev, char* data, size_t len)
 {
+  // Uphold the same null-event contract as iocp_recvfrom (see issue #5474):
+  // a null event means the socket never came up, so report failure instead
+  // of dereferencing it and crashing the process.
+  if(ev == NULL)
+    return false;
+
   SOCKET s = (SOCKET)ev->fd;
   iocp_t* iocp = iocp_create(IOCP_RECV, ev);
   DWORD received;
@@ -483,6 +489,13 @@ static bool iocp_sendto(int fd, const char* data, size_t len,
 static bool iocp_recvfrom(asio_event_t* ev, char* data, size_t len,
   ipaddress_t* ipaddr)
 {
+  // A failed UDP listen leaves the Pony-side socket with a null event
+  // (pony_os_listen_udp* returns NULL; see issue #5474). Dereferencing it
+  // here would crash the process, so report failure instead and let the
+  // caller close.
+  if(ev == NULL)
+    return false;
+
   SOCKET s = (SOCKET)ev->fd;
   iocp_t* iocp = iocp_create(IOCP_RECV, ev);
   DWORD flags = 0;


### PR DESCRIPTION
On Windows, a `UDPSocket` whose listen failed — for example because the host address could not be resolved — took the whole process down immediately after reporting `not_listening`.

A failed UDP listen leaves the Pony-side socket with a null ASIO event. The runtime's `iocp_recvfrom` dereferenced that event with no null guard, so when a `UDPSocket` constructor drove its first receive after a failed listen, the process crashed. The fix guards `iocp_recv` and `iocp_recvfrom` in `src/libponyrt/lang/socket.c` to return an error on a null event instead of dereferencing it. Reporting an error lets the existing stdlib error path close the already-dead socket cleanly.

The `net/UDPListenFailure` test — previously excluded on Windows precisely because the crash would take down the whole suite — now runs on every platform, so the Windows runner drives the formerly-crashing path and fails loudly if the guard regresses.

Closes #5474