### PR TITLE
Exclude net/Broadcast tests on the riscv64 cross leg

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -74,16 +74,22 @@ jobs:
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_llc_flags="-march=riscv64"
+      # net/Broadcast and net/BroadcastReceive are excluded here only: under
+      # qemu-riscv64 a datagram sent to the limited-broadcast address is not
+      # delivered to a 255.255.255.255-bound socket, so net/BroadcastReceive
+      # times out. The other cross legs (arm/armhf) deliver it and keep running
+      # both tests. See _TestBroadcastReceive in packages/net/_test.pony.
       - name: Test with Debug Cross-Compiled Runtime
-        run: make test-cross-ci config=debug PONYPATH=../rv64gc/debug cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_sysroot=/usr/riscv64-linux-gnu cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
+        run: make test-cross-ci config=debug PONYPATH=../rv64gc/debug cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_sysroot=/usr/riscv64-linux-gnu cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" stdlib_test_excludes='--exclude=net/Broadcast'
       - name: Build Release Runtime
         run: |
           make configure config=release
           make build config=release
       - name: Build Release Cross-Compiled Runtime
         run: make cross-libponyrt config=release CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_llc_flags="-march=riscv64"
+      # See the debug step above for why net/Broadcast is excluded on riscv64.
       - name: Test with Release Cross-Compiled Runtime
-        run: make test-cross-ci config=release PONYPATH=../rv64gc/release cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_sysroot=/usr/riscv64-linux-gnu cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/"
+        run: make test-cross-ci config=release PONYPATH=../rv64gc/release cross_triple=riscv64-unknown-linux-gnu cross_arch=rv64gc cross_cpu=generic-rv64 cross_sysroot=/usr/riscv64-linux-gnu cross_ponyc_args='--abi=lp64d --features=+m,+a,+f,+d,+c' cross_runner="qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" stdlib_test_excludes='--exclude=net/Broadcast'
       - name: Test pony-doc
         run: make test-pony-doc config=debug
       - name: Test pony-lint

--- a/Makefile
+++ b/Makefile
@@ -333,11 +333,16 @@ test-full-programs-debug: all
 	@mkdir -p $(outDir)/full-program-tests/debug
 	$(SILENT)cd '$(outDir)' && $(buildDir)/test/full-program-runner/full-program-runner --debugger='$(debuggercmd)' --timeout_s=$(test_full_program_timeout) --max_parallel=1 --compiler=$(outDir)/ponyc --debug --output=$(outDir)/full-program-tests/debug --test_lib=$(outDir)/test_lib $(srcDir)/test/full-program-tests
 
+# stdlib_test_excludes is appended to the stdlib test runner invocation and is
+# empty by default. Set it on the make command line (e.g.
+# stdlib_test_excludes='--exclude=net/Broadcast') to skip environment-sensitive
+# tests on a specific CI leg without affecting any other leg. See the riscv64
+# job in .github/workflows/ponyc-tier3.yml.
 test-stdlib-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) $(debuggercmd) ./stdlib-release --sequential
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) $(debuggercmd) ./stdlib-release --sequential $(stdlib_test_excludes)
 
 test-stdlib-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b stdlib-debug --pic --strip --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-debug && $(cross_runner) $(debuggercmd) ./stdlib-debug --sequential
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b stdlib-debug --pic --strip --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-debug && $(cross_runner) $(debuggercmd) ./stdlib-debug --sequential $(stdlib_test_excludes)
 
 test-examples: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) find ../../examples/*/* -name '*.pony' -print | xargs -n 1 dirname | sort -u | grep -v ffi- | xargs -n 1 -I {} ./ponyc -d -s --checktree -o {} {}

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -432,7 +432,11 @@ class \nodoc\ iso _TestBroadcastReceive is UnitTest
   net/Broadcast already makes set_broadcast load-bearing on these legs via
   its send side; what this test adds is the receive-side discrimination.
   Linux-only: bind-to-broadcast semantics are Linux-verified; BSD differs
-  and macOS/Windows are unverified.
+  and macOS/Windows are unverified. The riscv64 cross leg additionally
+  excludes this test (and net/Broadcast) at the CI runner level, because
+  under qemu-riscv64 the broadcast datagram is not delivered to the
+  255.255.255.255-bound socket; see the riscv64 job in
+  .github/workflows/ponyc-tier3.yml.
   """
   fun name(): String => "net/BroadcastReceive"
   fun exclusion_group(): String => "network"


### PR DESCRIPTION
`net/BroadcastReceive` (added in #5475) binds its receiver to `255.255.255.255` to prove broadcast-discriminating delivery. Under `qemu-riscv64` that datagram is not delivered to the bound socket, so the test times out and the riscv64 tier-2 job fails. The failure is riscv64-only — the arm/armhf/arm64 cross legs deliver the broadcast and pass both tests, as do all the native legs.

There is no compile-time signal that distinguishes the cross/qemu environment (the target is still `linux`), so the exclusion is applied at the test-runner level: a new empty-by-default `stdlib_test_excludes` make variable is wired into the stdlib test recipes and set to `--exclude=net/Broadcast` only in the riscv64 job. That prefix skips `net/Broadcast` and `net/BroadcastReceive` while keeping `net/DNSBroadcastIP4`/`IP6`, which do no broadcast I/O. Every other CI leg is unaffected.