### PR TITLE
Upgrade Fedora builder from 43 to 44

### DIFF
--- a/.ci-dockerfiles/x86-64-unknown-linux-fedora44-builder/Dockerfile
+++ b/.ci-dockerfiles/x86-64-unknown-linux-fedora44-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:44
 
 LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 

--- a/.ci-dockerfiles/x86-64-unknown-linux-fedora44-builder/build-and-push.bash
+++ b/.ci-dockerfiles/x86-64-unknown-linux-fedora44-builder/build-and-push.bash
@@ -7,7 +7,7 @@ set -o nounset
 # *** You should already be logged in to GHCR when you run this ***
 #
 
-NAME="ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder"
+NAME="ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora44-builder"
 TODAY=$(date +%Y%m%d)
 DOCKERFILE_DIR="$(dirname "$0")"
 

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -18,7 +18,7 @@ on:
           - cross-riscv64
           - ubuntu26.04-builder
           - x86-64-unknown-linux-alpine3.21-builder
-          - x86-64-unknown-linux-fedora43-builder
+          - x86-64-unknown-linux-fedora44-builder
           - x86-64-unknown-linux-ubuntu22.04-builder
           - x86-64-unknown-linux-ubuntu24.04-builder
 
@@ -266,11 +266,11 @@ jobs:
       - name: Build and push
         run: bash .ci-dockerfiles/x86-64-unknown-linux-alpine3.21-builder/build-and-push.bash
 
-  x86-64-unknown-linux-fedora43-builder:
-    if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-fedora43-builder' }}
+  x86-64-unknown-linux-fedora44-builder:
+    if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-fedora44-builder' }}
     runs-on: ubuntu-latest
 
-    name: x86-64-unknown-linux-fedora43-builder
+    name: x86-64-unknown-linux-fedora44-builder
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -288,7 +288,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        run: bash .ci-dockerfiles/x86-64-unknown-linux-fedora43-builder/build-and-push.bash
+        run: bash .ci-dockerfiles/x86-64-unknown-linux-fedora44-builder/build-and-push.bash
 
   x86-64-unknown-linux-ubuntu22_04-builder:
     if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-ubuntu22.04-builder' }}

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -50,7 +50,7 @@ jobs:
         include:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
             name: x86-64 Linux glibc deb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora44-builder:20260614
             name: x86-64 Linux glibc rpm
 
     name: ${{ matrix.name }}

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -23,7 +23,7 @@ jobs:
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu22.04-builder:20230924
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-alpine3.21-builder:20250510
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora43-builder:20260427
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora44-builder:20260614
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.22-builder:20251022
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.24-builder:20260611


### PR DESCRIPTION
Replace the Fedora 43 CI builder image with Fedora 44. The new image has been built and pushed to GHCR as `ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora44-builder:20260614`.