### PR TITLE
Update snok/container-retention-policy to v3.1.0, switch to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -131,11 +131,11 @@ jobs:
           done
           echo "skip-shas=${shas}" >> $GITHUB_OUTPUT
       - name: Prune
-        # v3.0.1
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        # v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53
         with:
           account: ponylang
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ponyc
           tag-selection: untagged
           cut-off: 1d
@@ -160,11 +160,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prune
-        # v3.0.1
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        # v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53
         with:
           account: ponylang
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: ponyc-ci-stdlib-builder
           tag-selection: untagged
           cut-off: 1d

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -378,11 +378,11 @@ jobs:
       - arm64-windows
     steps:
       - name: Prune
-        # v3.0.1
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        # v3.1.0
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53
         with:
           account: ponylang
-          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "nightly/ponyc-*"
           tag-selection: tagged
           cut-off: 90d


### PR DESCRIPTION
v3.1.0 fixes the token-validation regex that rejected GitHub's `ghs_` JWT format, so the three nightly prune steps in `build-nightly-image.yml` and `nightlies.yml` can switch back from `DELETE_PACKAGES_TOKEN` to `GITHUB_TOKEN`. `DELETE_PACKAGES_TOKEN` is no longer used in this repo.