### PR TITLE
Make `UDPSocket.set_broadcast` a no-op on IPv6 sockets

### DIFF
--- a/.release-notes/set-broadcast-ipv6-noop.md
+++ b/.release-notes/set-broadcast-ipv6-noop.md
@@ -1,0 +1,5 @@
+## Make `UDPSocket.set_broadcast` a no-op on IPv6 sockets
+
+`UDPSocket.set_broadcast` promises to enable or disable broadcasting from a socket. On IPv4 sockets it does: it sets the `SO_BROADCAST` socket option to the value you pass. On IPv6 sockets it instead ignored its argument and joined the FF02::1 all-nodes multicast group — `set_broadcast(false)` joined the group too, and the group was never left.
+
+IPv6 has no broadcast, and sending to a multicast address such as the all-nodes group (`DNS.broadcast_ip6`) requires no permission, so there is nothing for `set_broadcast` to enable on an IPv6 socket. It is now a documented no-op on IPv6 sockets. The removed join had no observable effect in practice — every IPv6 node is automatically a member of the all-nodes group — so existing programs should see no change in behavior. To receive traffic for a multicast group, use `multicast_join`.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -283,10 +283,10 @@ class \nodoc\ iso _TestBroadcast is UnitTest
 
   Both sockets are explicitly IPv4. The default UDPSocket constructor binds
   whichever address family getaddrinfo returns first, and IPv6 has no
-  broadcast - that path sent to all-nodes multicast (FF02::1) instead, which
-  is unreliable on multi-interface hosts. The ping is retransmitted on a
-  timer until the test completes, since UDP delivery is best-effort and a
-  single dropped datagram would otherwise fail the test.
+  broadcast - on an IPv6 socket set_broadcast is a no-op and the test would
+  have nothing to exercise. The ping is retransmitted on a timer until the
+  test completes, since UDP delivery is best-effort and a single dropped
+  datagram would otherwise fail the test.
   """
   fun name(): String => "net/Broadcast"
   fun label(): String => "unreliable-appveyor-osx"
@@ -591,14 +591,6 @@ class \nodoc\ _TestMulticastIP6Notify is UDPNotify
     _h.complete_action("multicast listen")
 
     _h.assert_true(sock.local_address().ip6())
-
-    // Execution-only smoke for set_broadcast's IPv6 arm: it joins FF02::1
-    // on an unpinned interface and ignores its argument (issue #5472).
-    // Delivery in this test does not depend on this call, and no assertion
-    // targets its effect -- kernel auto-membership in the all-nodes group
-    // makes the join unobservable from here. The IPv6 arm is NOT
-    // behaviorally covered.
-    sock.set_broadcast(true)
 
     // Join on the interface carried by the scoped literal's zone id. The
     // `to` argument is resolved by the runtime and its sin6_scope_id

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -107,7 +107,9 @@ actor UDPSocket is AsioEventNotify
     size: USize = 1024)
   =>
     """
-    Listens for both IPv4 and IPv6 datagrams.
+    Listens for datagrams. The address family is whichever the resolver
+    returns first for `host`/`service`, so it depends on the environment;
+    use `ip4` or `ip6` to pin a specific family.
     """
     _notify = consume notify
     _event =
@@ -188,13 +190,22 @@ actor UDPSocket is AsioEventNotify
 
   be set_broadcast(state: Bool) =>
     """
-    Enable or disable broadcasting from this socket.
+    Enable or disable broadcasting from this socket. This sets the
+    `SO_BROADCAST` socket option, a sender-side permission to send to
+    IPv4 broadcast addresses (see `DNS.broadcast_ip4`).
+
+    On an IPv6 socket this is a no-op: IPv6 has no broadcast. Sending to
+    a multicast address such as the all-nodes group (see
+    `DNS.broadcast_ip6`) requires no permission; to receive traffic for
+    a multicast group, use `multicast_join`.
+
+    The default constructor binds whichever address family the resolver
+    returns first, so construct the socket with `ip4` if you need
+    broadcast; otherwise `set_broadcast` may silently be a no-op.
     """
     if not _closed then
       if _ip.ip4() then
         set_so_broadcast(state)
-      elseif _ip.ip6() then
-        @pony_os_multicast_join(_fd, "FF02::1".cstring(), "".cstring())
       end
     end
 


### PR DESCRIPTION
`UDPSocket.set_broadcast` promised to enable or disable broadcasting. On an IPv4 socket it did exactly that, setting `SO_BROADCAST`. On an IPv6 socket it ignored the argument entirely and joined the FF02::1 all-nodes multicast group on an unpinned interface, never leaving it. `set_broadcast(false)` joined the group too.

IPv6 has no broadcast, and sending to a multicast address needs no permission, so there's nothing for `set_broadcast` to enable on an IPv6 socket. The IPv4 `SO_BROADCAST` toggle has no IPv6 analogue. This removes the IPv6 arm and documents `set_broadcast` as a no-op there. The removed join was unobservable from the outside since every IPv6 node already belongs to the all-nodes group, so no behavior changes for existing programs.

While here, the docstring now points broadcast users at the `ip4` constructor, since the default constructor binds whichever family the resolver returns first and that can silently turn `set_broadcast` into a no-op. The `create` docstring is corrected as well: it claimed to listen on both IPv4 and IPv6 when it actually binds a single resolver-chosen family.

Closes #5472
