### PR TITLE
Setup CI to use Flight Recorder (#4705)

### DIFF
--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -70,16 +70,16 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug
+          make configure arch=x86-64 config=debug use=runtime_tracing
           make build config=debug
       - name: Test with Debug Runtime
-        run: make test-ci-core config=debug
+        run: make test-ci-core config=debug flight_recorder_ci=yes
       - name: Build Release Runtime
         run: |
-          make configure arch=x86-64 config=release
+          make configure arch=x86-64 config=release use=runtime_tracing
           make build config=release
       - name: Test with Release Runtime
-        run: make test-ci-core config=release
+        run: make test-ci-core config=release flight_recorder_ci=yes
       - name: Test pony-doc
         run: make test-pony-doc config=debug
       - name: Test pony-lint
@@ -116,16 +116,16 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --platform x86-macos-15-intel --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug
+          make configure arch=x86-64 config=debug use=runtime_tracing
           make build config=debug
       - name: Test with Debug Runtime
-        run: make test-ci-core config=debug test_full_program_timeout=180
+        run: make test-ci-core config=debug flight_recorder_ci=yes test_full_program_timeout=180
       - name: Build Release Runtime
         run: |
-          make configure arch=x86-64 config=release
+          make configure arch=x86-64 config=release use=runtime_tracing
           make build config=release
       - name: Test with Release Runtime
-        run: make test-ci-core config=release test_full_program_timeout=180
+        run: make test-ci-core config=release flight_recorder_ci=yes test_full_program_timeout=180
       - name: Test pony-doc
         run: make test-pony-doc config=debug
       - name: Test pony-lint
@@ -203,7 +203,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            bash -c "make configure arch=armv8-a config=debug && make build config=debug"
+            bash -c "make configure arch=armv8-a config=debug use=runtime_tracing && make build config=debug"
       - name: Test with Debug Runtime
         run: |
           docker run --rm \
@@ -213,7 +213,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make test-ci-core config=debug
+            make test-ci-core config=debug flight_recorder_ci=yes
       - name: Build Release Runtime
         run: |
           docker run --rm \
@@ -221,7 +221,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            bash -c "make configure arch=armv8-a config=release && make build config=release"
+            bash -c "make configure arch=armv8-a config=release use=runtime_tracing && make build config=release"
       - name: Test with Release Runtime
         run: |
           docker run --rm \
@@ -231,7 +231,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make test-ci-core config=release
+            make test-ci-core config=release flight_recorder_ci=yes
       - name: Test pony-doc
         run: |
           docker run --rm \
@@ -291,16 +291,16 @@ jobs:
         run: python .ci-scripts/libs-cache/resolve_libs_cache.py --platform windows-11-arm --tag $env:LIBS_TAG '--' pwsh -File make.ps1 -Command libs -LlvmTools false -Arch ARM64
       - name: Build Debug Runtime
         run: |
-          .\make.ps1 -Command configure -Config Debug -Arch ARM64
+          .\make.ps1 -Command configure -Config Debug -Arch ARM64 -Use runtime_tracing
           .\make.ps1 -Command build -Config Debug
       - name: Test with Debug Runtime
-        run: .\make.ps1 -Command test -Config Debug
+        run: .\make.ps1 -Command test -Config Debug -FlightRecorderCi yes
       - name: Build Release Runtime
         run: |
-          .\make.ps1 -Command configure -Config Release -Arch ARM64
+          .\make.ps1 -Command configure -Config Release -Arch ARM64 -Use runtime_tracing
           .\make.ps1 -Command build -Config Release
       - name: Test with Release Runtime
-        run: .\make.ps1 -Command test -Config Release
+        run: .\make.ps1 -Command test -Config Release -FlightRecorderCi yes
       - name: Build examples
         run: .\make.ps1 -Command build-examples
       - name: Test pony-doc

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -70,7 +70,7 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=riscv64-linux-gnu-gcc-10 CXX=riscv64-linux-gnu-g++-10 arch=rv64gc cross_cflags="-march=rv64gc -mtune=rocket" cross_llc_flags="-march=riscv64"
@@ -137,7 +137,7 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
@@ -198,7 +198,7 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Build Debug Cross-Compiled Runtime
         run: make cross-libponyrt config=debug CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ arch=armv7-a cross_cflags="-march=armv7-a -mtune=cortex-a9" cross_llc_flags="-O3;-march=arm"
@@ -353,7 +353,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 freebsd@localhost <<'EOF'
           set -e
           cd /home/freebsd/ponyc
-          gmake configure config=debug
+          gmake configure config=debug use=runtime_tracing
           gmake build config=debug
           # Smoke-test the --static embedded-LLD link path; the test targets
           # below only exercise dynamic linking. Covers actor init plus
@@ -363,13 +363,13 @@ jobs:
           PONYPATH="$PWD/packages" ./build/debug/ponyc --static -o /tmp/static-smoke /tmp/static-smoke
           file /tmp/static-smoke/static-smoke | grep -q 'statically linked'
           /tmp/static-smoke/static-smoke
-          gmake test-ci-core config=debug
+          gmake test-ci-core config=debug flight_recorder_ci=yes
           gmake test-pony-doc config=debug
           gmake test-pony-lint config=debug
           gmake test-pony-lsp config=debug
-          gmake configure config=release
+          gmake configure config=release use=runtime_tracing
           gmake build config=release
-          gmake test-ci-core config=release
+          gmake test-ci-core config=release flight_recorder_ci=yes
           # native sanitizer link smoke test — see the script for details. Runs
           # before the dtrace smoke: both clean and reconfigure the debug build,
           # so the order is deliberate.
@@ -509,7 +509,7 @@ jobs:
           set -e
           cd /build/ponyc
           df -h
-          gmake configure config=debug
+          gmake configure config=debug use=runtime_tracing
           gmake build config=debug
           # Smoke-test the --static embedded-LLD link path; the test
           # targets below only exercise dynamic linking. Covers actor init
@@ -526,13 +526,13 @@ jobs:
           PONYPATH="$PWD/packages" ./build/debug/ponyc --static -o /tmp/static-smoke /tmp/static-smoke
           ! readelf -d /tmp/static-smoke/static-smoke | grep -q '(NEEDED)'
           /tmp/static-smoke/static-smoke | grep -q 'static ok'
-          gmake test-ci-core config=debug
+          gmake test-ci-core config=debug flight_recorder_ci=yes
           gmake test-pony-doc config=debug
           gmake test-pony-lint config=debug
           gmake test-pony-lsp config=debug
-          gmake configure config=release
+          gmake configure config=release use=runtime_tracing
           gmake build config=release
-          gmake test-ci-core config=release
+          gmake test-ci-core config=release flight_recorder_ci=yes
           EOF
       - name: Shutdown VM
         if: always()
@@ -766,7 +766,7 @@ jobs:
           export LD_LIBRARY_PATH=/usr/local/lib/gcc13
           export SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
           cd /build/ponyc
-          gmake configure config=debug
+          gmake configure config=debug use=runtime_tracing
           gmake build config=debug
           # Smoke-test the --static embedded-LLD link path; the test targets
           # below only exercise dynamic linking. Covers actor init plus
@@ -777,13 +777,13 @@ jobs:
           PONYPATH="$PWD/packages" ./build/debug/ponyc --static -o /build/static-smoke /build/static-smoke
           file /build/static-smoke/static-smoke | grep -q 'statically linked'
           /build/static-smoke/static-smoke
-          gmake test-ci-core config=debug
+          gmake test-ci-core config=debug flight_recorder_ci=yes
           gmake test-pony-doc config=debug
           gmake test-pony-lint config=debug
           gmake test-pony-lsp config=debug
-          gmake configure config=release
+          gmake configure config=release use=runtime_tracing
           gmake build config=release
-          gmake test-ci-core config=release
+          gmake test-ci-core config=release flight_recorder_ci=yes
           EOF
       - name: Shutdown VM
         if: always()

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -62,7 +62,7 @@ jobs:
             directives: runtimestats
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
             debugger: lldb
-            directives: runtime_tracing
+            directives: vanilla
 
     name: use ${{ matrix.directives }}
     container:
@@ -81,7 +81,11 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug use=${{ matrix.directives }}
+          if [ "${{ matrix.directives }}" = "vanilla" ]; then
+            make configure arch=x86-64 config=debug
+          else
+            make configure arch=x86-64 config=debug use=${{ matrix.directives }}
+          fi
           make build config=debug
       - name: Verify dtrace build leaves the source tree clean
         if: matrix.directives == 'dtrace'
@@ -92,7 +96,11 @@ jobs:
         run: make test-ci-core config=debug usedebugger='${{ matrix.debugger }}' test_full_program_timeout=120
       - name: Build Release Runtime
         run: |
-          make configure arch=x86-64 config=release use=${{ matrix.directives }}
+          if [ "${{ matrix.directives }}" = "vanilla" ]; then
+            make configure arch=x86-64 config=release
+          else
+            make configure arch=x86-64 config=release use=${{ matrix.directives }}
+          fi
           make build config=release
       - name: Test with Release Runtime
         run: make test-ci-core config=release usedebugger='${{ matrix.debugger }}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,16 +150,16 @@ jobs:
         run: python3 .ci-scripts/libs-cache/pr_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" --pr "$LIBS_PR" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug
+          make configure arch=x86-64 config=debug use=runtime_tracing
           make build config=debug
       - name: Test with Debug Runtime
-        run: make test-ci-core config=debug usedebugger='lldb'
+        run: make test-ci-core config=debug usedebugger='lldb' flight_recorder_ci=yes
       - name: Build Release Runtime
         run: |
-          make configure arch=x86-64 config=release
+          make configure arch=x86-64 config=release use=runtime_tracing
           make build config=release
       - name: Test with Release Runtime
-        run: make test-ci-core config=release usedebugger='lldb'
+        run: make test-ci-core config=release usedebugger='lldb' flight_recorder_ci=yes
 
   ponyc-arm64-macos:
     needs: [changes, maybe-build-macos]
@@ -180,16 +180,16 @@ jobs:
         run: python3 .ci-scripts/libs-cache/pr_libs_cache.py --platform arm64-macos-26 --tag "$LIBS_TAG" --pr "$LIBS_PR" -- make libs llvm_tools=false build_flags=-j3
       - name: Build Debug Runtime
         run: |
-          make configure arch=armv8 config=debug
+          make configure arch=armv8 config=debug use=runtime_tracing
           make build config=debug
       - name: Test with Debug Runtime
-        run: make test-ci-core config=debug
+        run: make test-ci-core config=debug flight_recorder_ci=yes
       - name: Build Release Runtime
         run: |
-          make configure arch=armv8 config=release
+          make configure arch=armv8 config=release use=runtime_tracing
           make build config=release
       - name: Test with Release Runtime
-        run: make test-ci-core config=release
+        run: make test-ci-core config=release flight_recorder_ci=yes
 
   ponyc-x86_64-windows:
     needs: [changes, maybe-build-windows]
@@ -217,16 +217,16 @@ jobs:
         run: python .ci-scripts/libs-cache/pr_libs_cache.py --platform windows-2025-vs2026 --tag "$env:LIBS_TAG" --pr "$env:LIBS_PR" '--' pwsh -File make.ps1 -Command libs -LlvmTools false
       - name: Build Debug Runtime
         run: |
-          .\make.ps1 -Command configure -Config Debug
+          .\make.ps1 -Command configure -Config Debug -Use runtime_tracing
           .\make.ps1 -Command build -Config Debug
       - name: Test with Debug Runtime
-        run: .\make.ps1 -Command test -Config Debug -Uselldb yes
+        run: .\make.ps1 -Command test -Config Debug -Uselldb yes -FlightRecorderCi yes
       - name: Build Release Runtime
         run: |
-          .\make.ps1 -Command configure -Config Release
+          .\make.ps1 -Command configure -Config Release -Use runtime_tracing
           .\make.ps1 -Command build -Config Release
       - name: Test with Release Runtime
-        run: .\make.ps1 -Command test -Config Release -Uselldb yes
+        run: .\make.ps1 -Command test -Config Release -Uselldb yes -FlightRecorderCi yes
       - name: Build examples
         run: .\make.ps1 -Command build-examples
 

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -73,10 +73,10 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Run Stress Test
-        run: make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}'
+        run: make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}' flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
@@ -174,7 +174,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            bash -c "make configure arch=armv8-a config=debug && make build config=debug"
+            bash -c "make configure arch=armv8-a config=debug use=runtime_tracing && make build config=debug"
       - name: Run Stress Test
         run: |
           docker run --rm \
@@ -184,7 +184,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}'
+            make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}' flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/stress-test-tcp-open-close-macos.yml
+++ b/.github/workflows/stress-test-tcp-open-close-macos.yml
@@ -44,7 +44,7 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --platform x86-macos-15-intel --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug
+          make configure arch=x86-64 config=debug use=runtime_tracing
           make build config=debug
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
@@ -91,12 +91,12 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --platform arm64-macos-26 --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j3
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Run Stress Test
-        run: make ${{ matrix.target }} config=debug usedebugger=lldb
+        run: make ${{ matrix.target }} config=debug usedebugger=lldb flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/stress-test-tcp-open-close-windows.yml
+++ b/.github/workflows/stress-test-tcp-open-close-windows.yml
@@ -75,11 +75,11 @@ jobs:
           LIBS_TAG: ${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
         run: python .ci-scripts/libs-cache/resolve_libs_cache.py --platform windows-2025-vs2026 --tag $env:LIBS_TAG '--' pwsh -File make.ps1 -Command libs -LlvmTools false
       - name: Configure
-        run: .\make.ps1 -Command configure -Config Debug
+        run: .\make.ps1 -Command configure -Config Debug -Use runtime_tracing
       - name: Build Debug Runtime
         run: .\make.ps1 -Command build -Config Debug
       - name: Run Stress Test
-        run: .\make.ps1 -Command ${{ matrix.target }} -Config Debug
+        run: .\make.ps1 -Command ${{ matrix.target }} -Config Debug -FlightRecorderCi yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -73,10 +73,10 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Run Stress Test
-        run: make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}'
+        run: make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}' flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
@@ -173,7 +173,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            bash -c "make configure arch=armv8-a config=debug && make build config=debug"
+            bash -c "make configure arch=armv8-a config=debug use=runtime_tracing && make build config=debug"
       - name: Run Stress Test
         run: |
           docker run --rm \
@@ -183,7 +183,7 @@ jobs:
             -v ${{ github.workspace }}:/home/pony/project \
             -w /home/pony/project \
             ${{ matrix.image }} \
-            make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}'
+            make ${{ matrix.target }} config=debug usedebugger='${{ matrix.debugger }}' flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/stress-test-ubench-macos.yml
+++ b/.github/workflows/stress-test-ubench-macos.yml
@@ -44,12 +44,12 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --platform x86-macos-15-intel --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
       - name: Build Debug Runtime
         run: |
-          make configure arch=x86-64 config=debug
+          make configure arch=x86-64 config=debug use=runtime_tracing
           make build config=debug
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Run Stress Test
-        run: make ${{ matrix.target }} config=debug usedebugger=lldb
+        run: make ${{ matrix.target }} config=debug usedebugger=lldb flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
@@ -91,12 +91,12 @@ jobs:
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --platform arm64-macos-26 --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j3
       - name: Build Debug Runtime
         run: |
-          make configure config=debug
+          make configure config=debug use=runtime_tracing
           make build config=debug
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Run Stress Test
-        run: make ${{ matrix.target }} config=debug usedebugger=lldb
+        run: make ${{ matrix.target }} config=debug usedebugger=lldb flight_recorder_ci=yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/.github/workflows/stress-test-ubench-windows.yml
+++ b/.github/workflows/stress-test-ubench-windows.yml
@@ -75,11 +75,11 @@ jobs:
           LIBS_TAG: ${{ hashFiles('make.ps1', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
         run: python .ci-scripts/libs-cache/resolve_libs_cache.py --platform windows-2025-vs2026 --tag $env:LIBS_TAG '--' pwsh -File make.ps1 -Command libs -LlvmTools false
       - name: Configure
-        run: .\make.ps1 -Command configure -Config Debug
+        run: .\make.ps1 -Command configure -Config Debug -Use runtime_tracing
       - name: Build Debug Runtime
         run: .\make.ps1 -Command build -Config Debug
       - name: Run Stress Test
-        run: .\make.ps1 -Command ${{ matrix.target }} -Config Debug
+        run: .\make.ps1 -Command ${{ matrix.target }} -Config Debug -FlightRecorderCi yes
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,19 @@ llc_arch ?= x86-64
 pic_flag ?=
 open_close_stress_connections ?= 10000000
 test_full_program_timeout ?= 60
+pony_test_args ?=
+flight_recorder_ci ?=
+
+# Runtime flags for flight recorder in CI Pony test executables. ~ is a runtime
+# sentinel for stderr (src/libponyrt/tracing/tracing.c); = form avoids shell
+# tilde expansion when passed through make on the command line.
+flight_recorder_pony_test_args := --ponytracingmode flight_recorder --ponytracingoutput=~ --ponytracingcategories actor,actor_behavior,actor_gc,actor_state_change,scheduler,scheduler_messaging --ponytracingflightrecorderhandletermint
+
+ifeq ($(flight_recorder_ci),yes)
+  ifeq ($(pony_test_args),)
+    pony_test_args := $(flight_recorder_pony_test_args)
+  endif
+endif
 
 ifndef version
   version := $(shell cat VERSION)
@@ -293,10 +306,10 @@ test-full-programs-debug: all
 # tests on a specific CI leg without affecting any other leg. See the riscv64
 # job in .github/workflows/ponyc-tier3.yml.
 test-stdlib-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) $(debuggercmd) ./stdlib-release --sequential $(stdlib_test_excludes)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b stdlib-release --pic --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-release && $(cross_runner) $(debuggercmd) ./stdlib-release --sequential $(stdlib_test_excludes) $(pony_test_args)
 
 test-stdlib-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b stdlib-debug --pic --strip --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-debug && $(cross_runner) $(debuggercmd) ./stdlib-debug --sequential $(stdlib_test_excludes)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b stdlib-debug --pic --strip --checktree $(cross_args) ../../packages/stdlib && echo Built `pwd`/stdlib-debug && $(cross_runner) $(debuggercmd) ./stdlib-debug --sequential $(stdlib_test_excludes) $(pony_test_args)
 
 test-examples: all
 	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) find ../../examples/*/* -name '*.pony' -print | xargs -n 1 dirname | sort -u | grep -v ffi- | xargs -n 1 -I {} ./ponyc -d -s --checktree -o {} {}
@@ -415,33 +428,33 @@ test-cross-stress-release: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu
 test-cross-stress-release: debuggercmd=
 test-cross-stress-release: test-stress-release
 test-stress-ubench-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoblock --ponynoscale
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoblock --ponynoscale $(pony_test_args)
 test-stress-tcp-open-close-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close --ponynoblock $(open_close_stress_connections)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close --ponynoblock $(open_close_stress_connections) $(pony_test_args)
 
 test-cross-stress-debug: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-debug: debuggercmd=
 test-cross-stress-debug: test-stress-debug
 test-stress-ubench-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoblock --ponynoscale
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoblock --ponynoscale $(pony_test_args)
 test-stress-tcp-open-close-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close --ponynoblock $(open_close_stress_connections)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close --ponynoblock $(open_close_stress_connections) $(pony_test_args)
 
 test-cross-stress-with-cd-release: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-with-cd-release: debuggercmd=
 test-cross-stress-with-cd-release: test-stress-with-cd-release
 test-stress-ubench-with-cd-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale $(pony_test_args)
 test-stress-tcp-open-close-with-cd-release: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close $(open_close_stress_connections)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close $(open_close_stress_connections) $(pony_test_args)
 
 test-cross-stress-with-cd-debug: cross_args=--triple=$(cross_triple) --cpu=$(cross_cpu) --link-arch=$(cross_arch) $(if $(cross_sysroot),--sysroot='$(cross_sysroot)') $(cross_ponyc_args)
 test-cross-stress-with-cd-debug: debuggercmd=
 test-cross-stress-with-cd-debug: test-stress-with-cd-debug
 test-stress-ubench-with-cd-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b ubench --pic $(cross_args) ../../test/rt-stress/string-message-ubench && echo Built `pwd`/ubench && $(cross_runner) $(debuggercmd) ./ubench --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale $(pony_test_args)
 test-stress-tcp-open-close-with-cd-debug: all
-	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close $(open_close_stress_connections)
+	$(SILENT)cd '$(outDir)' && PONYPATH=.:$(PONYPATH) ./ponyc -d -b open-close --pic $(cross_args) ../../test/rt-stress/tcp-open-close && echo Built `pwd`/open-close && $(cross_runner) $(debuggercmd) ./open-close $(open_close_stress_connections) $(pony_test_args)
 
 clean:
 	$(SILENT)([ -d '$(buildDir)' ] && cd '$(buildDir)' && cmake --build '$(buildDir)' --config $(config) --target clean) || true

--- a/make.ps1
+++ b/make.ps1
@@ -38,7 +38,21 @@
 
     [Parameter(HelpMessage="Tests to run")]
     [string]
-    $TestsToRun = 'libponyrt.tests,libponyc.tests,libponyc.run.tests.debug,libponyc.run.tests.release,stdlib-debug,stdlib-release,grammar'
+    $TestsToRun = 'libponyrt.tests,libponyc.tests,libponyc.run.tests.debug,libponyc.run.tests.release,stdlib-debug,stdlib-release,grammar',
+
+    [Parameter(HelpMessage="Extra runtime args to pass to Pony test executables")]
+    [string]
+    $PonyTestArgs = "",
+
+    [Parameter(HelpMessage="Enable flight recorder runtime flags for Pony test executables")]
+    [ValidateSet("yes", "no")]
+    [string]
+    $FlightRecorderCi = "no",
+
+    [Parameter(HelpMessage="use= directive for configure (e.g. runtime_tracing)")]
+    [ValidateSet("", "runtime_tracing")]
+    [string]
+    $Use = ""
 )
 
 # Function to extract process exit code from LLDB output
@@ -56,7 +70,15 @@ function Get-ProcessExitCodeFromLLDB {
     }
 }
 
+$FlightRecorderPonyTestArgs = '--ponytracingmode flight_recorder --ponytracingoutput=~ --ponytracingcategories actor,actor_behavior,actor_gc,actor_state_change,scheduler,scheduler_messaging --ponytracingflightrecorderhandletermint'
+
+if ($FlightRecorderCi -eq "yes" -and [string]::IsNullOrEmpty($PonyTestArgs))
+{
+    $PonyTestArgs = $FlightRecorderPonyTestArgs
+}
+
 $srcDir = Split-Path $script:MyInvocation.MyCommand.Path
+$ponyTestArgv = $PonyTestArgs.Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
 
 switch ($Version)
 {
@@ -209,6 +231,12 @@ switch ($Command.ToLower())
             $lto_flag = "-DPONY_USE_LTO=true"
         }
 
+        $use_flags = @()
+        if ($Use -eq "runtime_tracing")
+        {
+            $use_flags = @("-DPONY_USE_RUNTIME_TRACING=true")
+        }
+
         $PonyCpu = switch ($Arch.ToLower()) {
             "x64"   { "x86-64" }
             "arm64" { "generic" }
@@ -218,12 +246,12 @@ switch ($Command.ToLower())
         if ($Arch.Length -gt 0)
         {
             Write-Output "cmake.exe -B `"$buildDir`" -S `"$srcDir`" -G `"$Generator`" -A $Arch -Thost="$Thost" -DCMAKE_INSTALL_PREFIX=`"$Prefix`" -DCMAKE_BUILD_TYPE=`"$Config`" -DPONYC_VERSION=`"$Version`" -DPONY_CPU=`"$PonyCpu`""
-            & cmake.exe -B "$buildDir" -S "$srcDir" -G "$Generator" -A $Arch -Thost="$Thost" -DCMAKE_INSTALL_PREFIX="$Prefix" -DCMAKE_BUILD_TYPE="$Config" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPONYC_VERSION="$Version" -DPONY_CPU="$PonyCpu" $lto_flag --no-warn-unused-cli
+            & cmake.exe -B "$buildDir" -S "$srcDir" -G "$Generator" -A $Arch -Thost="$Thost" -DCMAKE_INSTALL_PREFIX="$Prefix" -DCMAKE_BUILD_TYPE="$Config" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPONYC_VERSION="$Version" -DPONY_CPU="$PonyCpu" $lto_flag @use_flags --no-warn-unused-cli
         }
         else
         {
             Write-Output "cmake.exe -B `"$buildDir`" -S `"$srcDir`" -G `"$Generator`" -Thost="$Thost" -DCMAKE_INSTALL_PREFIX=`"$Prefix`" -DCMAKE_BUILD_TYPE=`"$Config`" -DPONYC_VERSION=`"$Version`" -DPONY_CPU=`"$PonyCpu`""
-            & cmake.exe -B "$buildDir" -S "$srcDir" -G "$Generator" -Thost="$Thost" -DCMAKE_INSTALL_PREFIX="$Prefix" -DCMAKE_BUILD_TYPE="$Config" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPONYC_VERSION="$Version" -DPONY_CPU="$PonyCpu" $lto_flag --no-warn-unused-cli
+            & cmake.exe -B "$buildDir" -S "$srcDir" -G "$Generator" -Thost="$Thost" -DCMAKE_INSTALL_PREFIX="$Prefix" -DCMAKE_BUILD_TYPE="$Config" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPONYC_VERSION="$Version" -DPONY_CPU="$PonyCpu" $lto_flag @use_flags --no-warn-unused-cli
         }
         $err = $LastExitCode
         if ($err -ne 0) { throw "Error: exit code $err" }
@@ -370,15 +398,15 @@ switch ($Command.ToLower())
                 {
                     if ($Uselldb -eq "yes")
                     {
-                        Write-Output "$lldbcmd $lldbargs $outDir\stdlib-debug.exe --sequential"
-                        $lldboutput = & $lldbcmd $lldbargs $outDir\stdlib-debug.exe --sequential
+                        Write-Output "$lldbcmd $lldbargs $outDir\stdlib-debug.exe --sequential $ponyTestArgv"
+                        $lldboutput = & $lldbcmd $lldbargs $outDir\stdlib-debug.exe --sequential $ponyTestArgv
                         Write-Output $lldboutput
                         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
                     }
                     else
                     {
-                        Write-Output "$outDir\stdlib-debug.exe --sequential"
-                        & $outDir\stdlib-debug.exe --sequential
+                        Write-Output "$outDir\stdlib-debug.exe --sequential $ponyTestArgv"
+                        & $outDir\stdlib-debug.exe --sequential $ponyTestArgv
                         $err = $LastExitCode
                     }
                 }
@@ -406,15 +434,15 @@ switch ($Command.ToLower())
                 {
                     if ($Uselldb -eq "yes")
                     {
-                        Write-Output "$lldbcmd $lldbargs $outDir\stdlib-release.exe --sequential"
-                        $lldboutput = & $lldbcmd $lldbargs $outDir\stdlib-release.exe --sequential
+                        Write-Output "$lldbcmd $lldbargs $outDir\stdlib-release.exe --sequential $ponyTestArgv"
+                        $lldboutput = & $lldbcmd $lldbargs $outDir\stdlib-release.exe --sequential $ponyTestArgv
                         Write-Output $lldboutput
                         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
                     }
                     else
                     {
-                        Write-Output "$outDir\stdlib-release.exe --sequential"
-                        & $outDir\stdlib-release.exe --sequential
+                        Write-Output "$outDir\stdlib-release.exe --sequential $ponyTestArgv"
+                        & $outDir\stdlib-release.exe --sequential $ponyTestArgv
                         $err = $LastExitCode
                     }
                 }
@@ -610,7 +638,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --bin-name=ubench --output=$outDir test\rt-stress\string-message-ubench
-        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale --ponynoblock
+        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale --ponynoblock $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -622,7 +650,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --bin-name=ubench --output=$outDir test\rt-stress\string-message-ubench
-        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -634,7 +662,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --debug --bin-name=ubench --output=$outDir test\rt-stress\string-message-ubench
-        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale --ponynoblock
+        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale --ponynoblock $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -646,7 +674,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --debug --bin-name=ubench --output=$outDir test\rt-stress\string-message-ubench
-        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale
+        $lldboutput = & $lldbcmd $lldbargs $outDir\ubench.exe --pingers 320 --initial-pings 5 --report-count 40 --report-interval 300 --ponynoscale $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -658,7 +686,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --bin-name=open-close --output=$outDir test\rt-stress\tcp-open-close
-        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe --ponynoblock 1000
+        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe --ponynoblock 1000 $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -670,7 +698,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --bin-name=open-close --output=$outDir test\rt-stress\tcp-open-close
-        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe 1000
+        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe 1000 $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -682,7 +710,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --debug --bin-name=open-close --output=$outDir test\rt-stress\tcp-open-close
-        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe --ponynoblock 1000
+        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe --ponynoblock 1000 $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err
@@ -694,7 +722,7 @@ switch ($Command.ToLower())
         $lldbargs = @('--batch', '--one-line', 'run', '--one-line-on-crash', '"frame variable"', '--one-line-on-crash', '"register read"', '--one-line-on-crash', '"bt all"', '--one-line-on-crash', '"quit 1"', '--')
 
         & $outDir\ponyc.exe --debug --bin-name=open-close --output=$outDir test\rt-stress\tcp-open-close
-        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe 1000
+        $lldboutput = & $lldbcmd $lldbargs $outDir\open-close.exe 1000 $ponyTestArgv
         Write-Output $lldboutput
         $err = Get-ProcessExitCodeFromLLDB -LLDBOutput $lldboutput
         exit $err


### PR DESCRIPTION
## Summary

- Add `flight_recorder_ci=yes` / `-FlightRecorderCi yes` and `pony_test_args` plumbing in `Makefile` and `make.ps1`; flight recorder runtime flags are defined once in the Makefile (not copy-pasted across workflows).
- Build PR ponyc, tier2, tier3, and stress CI jobs with `use=runtime_tracing`; Pony stdlib/stress executables get flight recorder flags that dump to stderr (`--ponytracingoutput=~` is a runtime sentinel, not a shell path).
- Replace the weekly `runtime_tracing` use-matrix entry with `vanilla` (configure without `use=`).

This supersedes the earlier draft: AI-assisted, reviewed against project conventions, and DRY.

Closes #4705

## Test plan

- [ ] PR CI: x86-64 Linux musl debug/release legs show flight recorder dump in logs on normal exit
- [ ] Windows/macOS PR legs pass with LLDB unchanged
- [ ] Weekly `vanilla` use job configures without `use=` and compiles
- [ ] Tier2/tier3 and stress workflows unchanged aside from flight recorder flags