### PR TITLE
Resolve shellcheck findings in the warmer's BSD VM scripts

### DIFF
--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -335,7 +335,6 @@ jobs:
       - name: Install build dependencies
         if: steps.check.outputs.hit != 'true'
         run: |
-          export PUB_KEY=$(cat vm_key.pub)
           expect <<'EXPECT'
           set timeout 600
           spawn ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 -t freebsd@localhost su -m root
@@ -728,6 +727,9 @@ jobs:
         env:
           LIBS_TAG: ${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
         run: |
+          # Unquoted heredoc on purpose: ${LIBS_TAG} must expand on the runner
+          # (it is not set inside the VM), so EOF must stay unquoted.
+          # shellcheck disable=SC2087
           ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i vm_key -p 2222 root@localhost /bin/sh <<EOF
           set -e
           cd /build/ponyc


### PR DESCRIPTION
Two shellcheck findings sat in embedded `run:` scripts in `update-lib-cache.yml`. They never showed in CI because our actionlint image ships no shellcheck and file-based shellcheck can't see scripts embedded in workflow YAML, but they turn up for anyone running actionlint with shellcheck locally.

The FreeBSD "Install build dependencies" step exported `PUB_KEY` from a command substitution and never used it (SC2155); dead, so it's gone. The DragonFly "Build and push libs" heredoc is unquoted on purpose so `${LIBS_TAG}` expands on the runner rather than in the VM, where it isn't set (SC2087); quoting `EOF` as shellcheck suggests would push an empty tag, so the intent is marked with a `# shellcheck disable=SC2087` and a comment instead.

CI-only, no user-visible effect.

Closes #5504
