### PR TITLE
Fix stale alpine version in stress test job labels

### DIFF
--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -39,19 +39,19 @@ jobs:
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [release]
+            name: x86-64-unknown-linux-alpine3.23 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [debug]
+            name: x86-64-unknown-linux-alpine3.23 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [cd] [release]
+            name: x86-64-unknown-linux-alpine3.23 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [cd] [debug]
+            name: x86-64-unknown-linux-alpine3.23 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
 
@@ -122,19 +122,19 @@ jobs:
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [release]
+            name: arm64-unknown-linux-alpine3.23 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [debug]
+            name: arm64-unknown-linux-alpine3.23 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [cd] [release]
+            name: arm64-unknown-linux-alpine3.23 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [cd] [debug]
+            name: arm64-unknown-linux-alpine3.23 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
 

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -39,19 +39,19 @@ jobs:
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [release]
+            name: x86-64-unknown-linux-alpine3.23 [release]
             target: test-stress-ubench-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [debug]
+            name: x86-64-unknown-linux-alpine3.23 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [cd] [release]
+            name: x86-64-unknown-linux-alpine3.23 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: x86-64-unknown-linux-alpine3.21 [cd] [debug]
+            name: x86-64-unknown-linux-alpine3.23 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
 
@@ -122,19 +122,19 @@ jobs:
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [release]
+            name: arm64-unknown-linux-alpine3.23 [release]
             target: test-stress-ubench-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [debug]
+            name: arm64-unknown-linux-alpine3.23 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [cd] [release]
+            name: arm64-unknown-linux-alpine3.23 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
-            name: arm64-unknown-linux-alpine3.21 [cd] [debug]
+            name: arm64-unknown-linux-alpine3.23 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
     name: ${{matrix.target}}:${{ matrix.name }}


### PR DESCRIPTION
The Linux stress test jobs run on `ponyc-ci-alpine3.23-builder`, but their matrix `name:` labels still say `alpine3.21`, a leftover from before the image was bumped. Nothing functional depends on the label (the image and the libs cache key come from `image:`), so this is cosmetic, but a failing job reports an alpine version it isn't running on. Every other workflow on that image already labels it `alpine3.23`. This corrects the 16 labels to match.

`nightlies.yml` and `release.yml` keep their `alpine3.21` entries untouched: those are paired with a real `alpine3.21-builder` image and distribute for alpine 3.21.

Follow-on to #5507.
