### PR TITLE
Fix crash when a directory is named like a Pony source file

### DIFF
--- a/.release-notes/fix-directory-named-like-source-file.md
+++ b/.release-notes/fix-directory-named-like-source-file.md
@@ -1,0 +1,3 @@
+## Fix crash when a directory is named like a Pony source file
+
+Previously, if a directory inside a package was named like a Pony source file — that is, with a name ending in `.pony` — ponyc would abort with an out-of-memory error instead of compiling your program. Such directories are now ignored, like any other non-source entry in a package directory, and compilation proceeds normally.

--- a/src/libponyc/ast/source.c
+++ b/src/libponyc/ast/source.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 source_t* source_open(const char* file, const char** error_msgp,
   strtable_t* strtab)
@@ -14,6 +15,20 @@ source_t* source_open(const char* file, const char** error_msgp,
   if(fp == NULL)
   {
     *error_msgp = "can't open file";
+    return NULL;
+  }
+
+  // fopen("dir", "rb") succeeds on some platforms; the size logic below then
+  // reads a meaningless length from ftell. On common Linux filesystems that
+  // value is SSIZE_MAX, which overflows `size + 1` into a huge allocation that
+  // aborts the compiler. Reject a directory here with a clear error. Source
+  // discovery already skips directories; this is the backstop for any other
+  // caller.
+  struct stat s;
+  if((stat(file, &s) == 0) && S_ISDIR(s.st_mode))
+  {
+    *error_msgp = "is a directory";
+    fclose(fp);
     return NULL;
   }
 

--- a/src/libponyc/pkg/package.c
+++ b/src/libponyc/pkg/package.c
@@ -232,6 +232,18 @@ static bool parse_files_in_dir(ast_t* package, const char* dir_path,
     if(name[0] == '.')
       continue;
 
+    // A directory is never a source file, whatever its name. Skip it before
+    // classifying by extension: otherwise a directory named like a source
+    // file (e.g. foo.pony) reaches source_open, which on some filesystems
+    // opens it, misreads its length via ftell, and aborts the compiler with a
+    // huge allocation. Filtering here covers every source extension.
+    char fullpath[FILENAME_MAX];
+    path_cat(dir_path, name, fullpath);
+
+    struct stat s;
+    if((stat(fullpath, &s) == 0) && S_ISDIR(s.st_mode))
+      continue;
+
     const char* p = strrchr(name, '.');
 
     if((p != NULL) && (strcmp(p, EXTENSION) == 0))

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(libponyc.tests
     recursive_type_alias.cc
     refer.cc
     scope.cc
+    source.cc
     stable_type.cc
     subtype_cache.cc
     sugar.cc

--- a/test/libponyc/source.cc
+++ b/test/libponyc/source.cc
@@ -139,7 +139,11 @@ TEST_F(SourceTest, SourceOpenRejectsDirectory)
   const char* error_msg = NULL;
   source_t* source = source_open(".", &error_msg, opt.strtab);
 
+  // Rejected with an error, not aborted. The exact message is platform-
+  // dependent, so don't assert it: where fopen opens a directory
+  // (Linux/macOS) source_open's own check reports "is a directory"; on Windows
+  // fopen refuses the directory first, so the failure is "can't open file".
+  // Either way it is a clean error rather than the misread-length abort.
   ASSERT_EQ((void*)NULL, source);
   ASSERT_NE((void*)NULL, (void*)error_msg);
-  ASSERT_STREQ("is a directory", error_msg);
 }

--- a/test/libponyc/source.cc
+++ b/test/libponyc/source.cc
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include <ast/source.h>
+#include <pkg/package.h>
+
+#include "util.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <string>
+#include <vector>
+
+#ifdef PLATFORM_IS_WINDOWS
+#  include <direct.h>
+#endif
+
+/** Tests for loading Pony source from disk. A directory whose name ends in
+ * .pony must not be treated as a source file: before the fix it reached
+ * source_open, which on some filesystems opens a directory successfully and
+ * then reads a meaningless length from ftell, aborting the compiler with a
+ * huge allocation. parse_files_in_dir now skips such directories; source_open
+ * rejects them as a backstop.
+ */
+
+#define TEST_COMPILE(src, pass) DO(test_compile(src, pass))
+
+
+class SourceTest : public PassTest
+{
+protected:
+  // Paths a test created, removed in TearDown in reverse order (a directory's
+  // contents before the directory). TearDown runs even when a test fails
+  // partway, which an inline cleanup at the end of the test body would not.
+  std::vector<std::string> _created;
+
+  void TearDown() override
+  {
+    for(size_t i = _created.size(); i > 0; i--)
+    {
+      const char* p = _created[i - 1].c_str();
+      remove(p); // files, and empty directories on POSIX
+#ifdef PLATFORM_IS_WINDOWS
+      _rmdir(p); // the Windows CRT needs _rmdir for directories
+#endif
+    }
+    _created.clear();
+    PassTest::TearDown();
+  }
+
+  // mkdir, treating "already exists" as success. gtest-fatal on other
+  // failures; call through DO().
+  void make_dir(const char* path)
+  {
+#ifdef PLATFORM_IS_WINDOWS
+    int r = _mkdir(path);
+#else
+    int r = mkdir(path, 0755);
+#endif
+    ASSERT_TRUE((r == 0) || (errno == EEXIST)) << "couldn't mkdir " << path;
+    _created.push_back(path);
+  }
+
+  void write_file(const char* path, const char* contents)
+  {
+    FILE* f = fopen(path, "w");
+    ASSERT_NE((void*)NULL, (void*)f) << "couldn't write " << path;
+    fputs(contents, f);
+    fclose(f);
+    _created.push_back(path);
+  }
+};
+
+
+// A directory whose name ends in .pony, sitting alongside a real source file,
+// is skipped; the package still loads from its real .pony files. Before the
+// fix, loading this package aborted (or, on some filesystems, silently
+// mishandled the directory).
+TEST_F(SourceTest, DirectoryNamedLikeSourceFileIsSkipped)
+{
+  const char* pkg = "source_test_pkg";
+  char thing[FILENAME_MAX];
+  char weird[FILENAME_MAX];
+  snprintf(thing, sizeof(thing), "%s/thing.pony", pkg);
+  snprintf(weird, sizeof(weird), "%s/weird.pony", pkg);
+
+  DO(make_dir(pkg));
+  DO(write_file(thing, "primitive Thing\n"));
+  DO(make_dir(weird)); // a DIRECTORY named like a source file
+
+  package_add_magic_path(pkg, pkg, &opt);
+
+  const char* src =
+    "use \"source_test_pkg\"\n"
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  // Succeeds: weird.pony is skipped and thing.pony loads. A crash or an error
+  // here is the bug.
+  TEST_COMPILE(src, "scope");
+}
+
+
+// A package whose only .pony-named entry is a directory has no source files:
+// the directory is skipped, leaving the package empty, so loading it produces
+// the ordinary empty-package error rather than aborting. This pins the skip's
+// effect on a dimension that holds on every filesystem -- remove the skip and
+// the directory instead reaches source_open, yielding a different error ("is
+// a directory") or a crash, never this one.
+TEST_F(SourceTest, DirectoryOnlyPackageHasNoSourceFiles)
+{
+  const char* pkg = "source_test_empty_pkg";
+  char weird[FILENAME_MAX];
+  snprintf(weird, sizeof(weird), "%s/weird.pony", pkg);
+
+  DO(make_dir(pkg));
+  DO(make_dir(weird)); // the only .pony-named entry is a directory
+
+  package_add_magic_path(pkg, pkg, &opt);
+
+  const char* src =
+    "use \"source_test_empty_pkg\"\n"
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  const char* errs[] =
+    { "no source files in package", "can't load package", NULL };
+  DO(test_expected_errors(src, "scope", errs));
+}
+
+
+// source_open's backstop: opening a directory fails with a clear error rather
+// than aborting. Discovery already skips directories; this guards any other
+// caller from the same allocation abort.
+TEST_F(SourceTest, SourceOpenRejectsDirectory)
+{
+  const char* error_msg = NULL;
+  source_t* source = source_open(".", &error_msg, opt.strtab);
+
+  ASSERT_EQ((void*)NULL, source);
+  ASSERT_NE((void*)NULL, (void*)error_msg);
+  ASSERT_STREQ("is a directory", error_msg);
+}


### PR DESCRIPTION
A directory inside a package whose name ends in `.pony` was treated as a source file: it was handed to the source reader, which opened it, misread its length, and aborted ponyc with a huge allocation instead of compiling. Such directories are now skipped during source discovery, with a backstop in the source reader that rejects a directory with a clear error.

Pre-existing on main; found while reviewing an unrelated branch.

Closes #5513
