### PR TITLE
Fix `use=coverage` builds failing to link with gcc

### DIFF
--- a/.ci-scripts/dragonfly-coverage-smoke.sh
+++ b/.ci-scripts/dragonfly-coverage-smoke.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Coverage link smoke test for the DragonFly tier-3 job. Runs inside the
+# DragonFly VM, invoked from .github/workflows/ponyc-tier3.yml. POSIX sh (no
+# bash in the DragonFly base system). Expects to run from the ponyc source root
+# with the gcc13 build env already exported (CC/CXX/LD_LIBRARY_PATH/SSL_CERT_FILE).
+#
+# DragonFly only builds ponyc with gcc, so it is the platform where the gcc
+# coverage path (-fprofile-arcs) is exercised by default. That path was broken
+# (#5434): -fprofile-arcs instruments libponyrt with gcov constructors that
+# reference __gcov_init/__gcov_exit from libgcov, but ponyc links Pony programs
+# via embedded LLD (not the compiler driver), so libgcov never reached the link
+# line and every Pony program failed to link. The fix captures the driver's
+# coverage link fragment (-lgcov) at configure time and splices it into the
+# embedded LLD link (see the coverage capture in the top-level CMakeLists.txt and
+# the PONY_COVERAGE block in genexe.cc). This test is the primary guard for that
+# fix: a coverage ponyc that can't link is caught here, at build + link time.
+#
+# The `gmake build` below is itself the first assertion: before the fix it dies
+# linking the self-hosted tools / full-program-runner with undefined __gcov_init.
+# Then we link AND run a standalone Pony program: running proves the spliced
+# libgcov actually satisfies the gcov init/fini constructors at runtime, not just
+# that the symbols resolved at link time.
+set -eu
+
+# Clean + reconfigure debug from scratch with coverage. `clean` is config-scoped
+# (pass config=debug so it removes the debug build/output dirs); the prebuilt
+# LLVM in build/libs is untouched, so this does not rebuild LLVM. A from-scratch
+# configure is required because the coverage capture and instrumentation flags
+# differ from the plain debug build the job already made.
+gmake clean config=debug
+gmake configure config=debug use=coverage
+gmake build config=debug
+
+# use=coverage sets PONY_OUTPUT_SUFFIX to -coverage, so the build output lands in
+# build/debug-coverage. Derive it rather than hardcoding (the suffix is
+# CMake-determined and could grow more segments in a combined build).
+out=$(find build -maxdepth 1 -type d -name 'debug-coverage' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: coverage build output directory not found"
+  exit 1
+fi
+
+smoke=/build/coverage-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    env.out.print("coverage smoke ok")
+PONY
+
+# Link via embedded LLD (the captured -lgcov fragment is spliced here) and run.
+# A broken splice fails at link time with undefined __gcov_init/__gcov_exit.
+PONYPATH="$PWD/packages" "$out/ponyc" --debug -o "$smoke" "$smoke"
+out_text=$("$smoke/coverage-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "coverage smoke ok"
+
+# The self-hosted tools are themselves Pony programs the coverage ponyc linked
+# during `gmake build`; confirm one runs, proving the tool link path works under
+# coverage and not just that a minimal program does.
+"$out/pony-lint" --version
+echo "coverage link smoke test passed"

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -434,6 +434,10 @@ jobs:
           gmake configure config=release
           gmake build config=release
           gmake test-ci-core config=release
+          # gcc coverage link smoke test (#5434) — see the script for details. It
+          # does a clean + reconfigure of the debug build with use=coverage, so it
+          # runs last, after the release tests that depend on the prior builds.
+          sh .ci-scripts/dragonfly-coverage-smoke.sh
           EOF
       - name: Shutdown VM
         if: always()

--- a/.release-notes/fix-coverage-link-gcc.md
+++ b/.release-notes/fix-coverage-link-gcc.md
@@ -1,0 +1,5 @@
+## Fix `use=coverage` builds failing to link with gcc
+
+Building ponyc with `use=coverage` under a gcc toolchain produced a compiler that couldn't link the Pony programs it compiled: every link failed with `undefined symbol: __gcov_init` (and `__gcov_exit`). Because DragonFly BSD only builds ponyc with gcc, coverage builds were unusable there entirely.
+
+Coverage builds under gcc now link correctly on every platform where coverage is supported.

--- a/BUILD.md
+++ b/BUILD.md
@@ -93,10 +93,9 @@ The sanitizer `use=` build options aren't supported on DragonFly, because the `g
 
 `use=dtrace` isn't supported on DragonFly either, and `gmake configure` rejects it.
 
-`use=coverage` and `use=valgrind` aren't rejected, but neither currently works on DragonFly:
+`use=coverage` works on DragonFly: ponyc splices the gcc coverage runtime (`libgcov`) into the Pony programs it links, so coverage-instrumented programs build and run.
 
-- `use=coverage` — the coverage-instrumented runtime needs `libgcov`, which ponyc's embedded linker doesn't supply, so linking any Pony program fails ([#5434](https://github.com/ponylang/ponyc/issues/5434)).
-- `use=valgrind` — builds, and the Pony programs it compiles link, but DragonFly ships Valgrind 3.15, which is too old to run a Pony program ([#5435](https://github.com/ponylang/ponyc/issues/5435)).
+`use=valgrind` isn't rejected but doesn't work on DragonFly: it builds, and the Pony programs it compiles link, but DragonFly ships Valgrind 3.15, which is too old to run a Pony program ([#5435](https://github.com/ponylang/ponyc/issues/5435)).
 
 ## Linux
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,29 +129,29 @@ if(NOT DEFINED PONY_ARCH)
     set(PONY_ARCH "native")
 endif()
 
-# Sanitizer link fragment capture.
+# Driver link-fragment capture (used by sanitizer and coverage builds).
 #
-# When ponyc is built with sanitizers, libponyrt's C code is instrumented, so
-# every executable ponyc links references the sanitizer runtime (__asan_* etc.)
-# and must link it. ponyc links natively via embedded LLD, which does not go
-# through the compiler driver, so it cannot rely on -fsanitize= to pull the
+# Some build options instrument libponyrt's C code so that every executable
+# ponyc links references a runtime library the compiler driver would normally
+# pull in: the sanitizer runtime for -fsanitize=, or libgcov (__gcov_init etc.)
+# for gcc's -fprofile-arcs. ponyc links natively via embedded LLD, which does
+# NOT go through the driver, so it cannot rely on those flags to pull the
 # runtime in. Instead we ask the driver, at configure time, for the exact link
-# fragment it emits for -fsanitize=${PONY_SANITIZERS_VALUE} and embed it as a
-# generated header that the embedded linker splices in (genexe.cc).
+# fragment it emits for the flag and embed it as a generated header the embedded
+# linker splices in (genexe.cc).
 #
 # Asking the driver (rather than locating the runtime libraries ourselves)
-# avoids re-implementing its per-compiler library selection, ubsan-folding, and
-# wrapping rules, and avoids depending on a compiler's runtime-directory layout
-# (clang's libclang_rt.asan-<arch>.a vs per-target lib/<triple>/libclang_rt.asan.a
-# vs gcc's libasan_preinit.o + shared libasan): the driver emits whatever paths
-# and flags are correct for itself. This works for both clang (whole-archived
-# clang_rt static archives + --dynamic-list) and gcc (preinit object + shared
-# -lasan/-lubsan). On macOS, Apple clang emits the clang_rt dylib by absolute
-# path plus -rpath entries (and folds UBSan into ASan when both are enabled).
-# The fragment's library paths are absolute on the build machine, which is fine:
-# a sanitizer ponyc is a developer/CI artifact that runs where it was built.
-# Native Linux, FreeBSD, and macOS sanitizer builds consume this (see
-# genexe.cc); the splice is gated on !is_cross_compiling.
+# avoids re-implementing its per-compiler library selection and wrapping rules,
+# and avoids depending on a compiler's runtime-directory layout: the driver
+# emits whatever paths and flags are correct for itself. A fragment's library
+# paths may be absolute on the build machine, which is fine: such a ponyc is a
+# developer/CI artifact that runs where it was built. The splice is gated on
+# !is_cross_compiling (see genexe.cc).
+#
+# The capture is the same algorithm for every flag (probe the driver with and
+# without the flag via -###, then take the ordered set difference); only the
+# flag, the sanity-check pattern, and the output names vary. It lives in one
+# function so a fix to the (subtle) supersequence diff covers every caller.
 
 # Extract the linker subcommand's arguments from a compiler "-###" stderr dump.
 # The link subcommand is the line naming the probe object (clang emits a direct
@@ -160,9 +160,9 @@ endif()
 # leaves most bare, and separate_arguments handles both. Drop volatile tokens:
 # gcc's LTO plugin injects "-plugin-opt=-fresolution=<tmp>.res" with a fresh
 # temp path on every invocation, which otherwise differs between the baseline
-# and sanitized probe runs and desyncs the ordered diff below.
-function(_pony_sanitizer_link_tokens raw outvar)
-    string(REGEX MATCH "[^\n]*pony_sanitizer_probe\\.o[^\n]*" _line "${raw}")
+# and flagged probe runs and desyncs the ordered diff below.
+function(_pony_driver_link_tokens raw marker outvar)
+    string(REGEX MATCH "[^\n]*${marker}[^\n]*" _line "${raw}")
     separate_arguments(_toks UNIX_COMMAND "${_line}")
     set(_out "")
     foreach(_t IN LISTS _toks)
@@ -173,123 +173,186 @@ function(_pony_sanitizer_link_tokens raw outvar)
     set(${outvar} "${_out}" PARENT_SCOPE)
 endfunction()
 
-if(PONY_SANITIZERS_ENABLED)
-    set(_san_probe_c "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.c")
-    set(_san_probe_o "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.o")
-    set(_san_probe_bin "${CMAKE_BINARY_DIR}/pony_sanitizer_probe.bin")
-    file(WRITE "${_san_probe_c}" "int main(void){return 0;}\n")
+# Capture the link fragment the driver inserts for `flag` and write it as a
+# generated C header. Args:
+#   flag         - the compiler flag to probe (e.g. -fsanitize=address,undefined
+#                  or -fprofile-arcs).
+#   sanity_regex - a regex the captured fragment must match, else FATAL_ERROR
+#                  (guards against the extraction silently producing nothing).
+#   header_name  - output header filename, written under pony_generated/.
+#   sym_prefix   - C symbol prefix: emits ${sym_prefix}_LINK_ARGS[] and
+#                  ${sym_prefix}_LINK_ARGS_COUNT.
+#   what         - short noun for diagnostics (e.g. "sanitizer", "coverage").
+function(_pony_capture_driver_link_fragment flag sanity_regex header_name sym_prefix what)
+    # Scratch files are named from `what` (a lowercase, regex/path-safe noun),
+    # not `sym_prefix` (a C identifier), so the names stay clean and distinct
+    # per caller (pony_sanitizer_probe.* vs pony_coverage_probe.*).
+    set(_probe_c "${CMAKE_BINARY_DIR}/pony_${what}_probe.c")
+    set(_probe_o "${CMAKE_BINARY_DIR}/pony_${what}_probe.o")
+    set(_probe_bin "${CMAKE_BINARY_DIR}/pony_${what}_probe.bin")
+    # The marker is matched as a regex in _pony_driver_link_tokens; escape the
+    # '.' before the extension so it matches literally (as the old hardcoded
+    # pattern did). `what` itself contains no regex metacharacters.
+    get_filename_component(_marker "${_probe_o}" NAME)
+    string(REPLACE "." "\\." _marker "${_marker}")
+    file(WRITE "${_probe_c}" "int main(void){return 0;}\n")
 
     # -### prints the link command without running it, but only for an input
     # that exists, so compile a real (uninstrumented) object first. No -march or
-    # other arch flag is passed to any probe: the sanitizer runtime the driver
-    # selects depends on the target (the driver's default target == this native
-    # host, which is what we link for), not on -march, so an arch flag would only
-    # add an unrelated way for the probe to fail.
+    # other arch flag is passed to any probe: the runtime the driver selects
+    # depends on the target (the driver's default target == this native host,
+    # which is what we link for), not on -march, so an arch flag would only add
+    # an unrelated way for the probe to fail.
     execute_process(
-        COMMAND ${CMAKE_C_COMPILER} -c ${_san_probe_c} -o ${_san_probe_o}
-        RESULT_VARIABLE _san_probe_rc
+        COMMAND ${CMAKE_C_COMPILER} -c ${_probe_c} -o ${_probe_o}
+        RESULT_VARIABLE _probe_rc
         OUTPUT_QUIET ERROR_QUIET)
-    if(NOT _san_probe_rc EQUAL 0)
-        message(FATAL_ERROR "sanitizer link capture: failed to compile probe object")
+    if(NOT _probe_rc EQUAL 0)
+        message(FATAL_ERROR "${what} link capture: failed to compile probe object")
     endif()
 
-    # Capture the driver's link line with and without -fsanitize=. -### writes
-    # the subcommands to stderr. Check the exit codes: if the driver can't emit
-    # a link line at all (e.g. an unrecognized -fsanitize= value), fail here with
-    # the real cause rather than letting it surface downstream as a confusing
-    # "not a supersequence" error. (A mutually-exclusive combo like
+    # Capture the driver's link line with and without the flag. -### writes the
+    # subcommands to stderr. Check the exit codes: if the driver can't emit a
+    # link line at all (e.g. an unrecognized flag value), fail here with the real
+    # cause rather than letting it surface downstream as a confusing "not a
+    # supersequence" error. (A mutually-exclusive combo like -fsanitize=
     # thread,address is accepted by -### but rejected later when libponyrt
     # compiles with those flags, so it fails loudly there - not caught here.)
     execute_process(
-        COMMAND ${CMAKE_C_COMPILER} "-###" ${_san_probe_o} -o ${_san_probe_bin}
-        RESULT_VARIABLE _san_baseline_rc
-        ERROR_VARIABLE _san_baseline_raw OUTPUT_QUIET)
+        COMMAND ${CMAKE_C_COMPILER} "-###" ${_probe_o} -o ${_probe_bin}
+        RESULT_VARIABLE _baseline_rc
+        ERROR_VARIABLE _baseline_raw OUTPUT_QUIET)
     execute_process(
-        COMMAND ${CMAKE_C_COMPILER} -fsanitize=${PONY_SANITIZERS_VALUE} "-###" ${_san_probe_o} -o ${_san_probe_bin}
-        RESULT_VARIABLE _san_sanitized_rc
-        ERROR_VARIABLE _san_sanitized_raw OUTPUT_QUIET)
-    if(NOT _san_baseline_rc EQUAL 0 OR NOT _san_sanitized_rc EQUAL 0)
+        COMMAND ${CMAKE_C_COMPILER} ${flag} "-###" ${_probe_o} -o ${_probe_bin}
+        RESULT_VARIABLE _flagged_rc
+        ERROR_VARIABLE _flagged_raw OUTPUT_QUIET)
+    if(NOT _baseline_rc EQUAL 0 OR NOT _flagged_rc EQUAL 0)
         message(FATAL_ERROR
-            "sanitizer link capture: ${CMAKE_C_COMPILER} failed to emit a link "
-            "line for -fsanitize=${PONY_SANITIZERS_VALUE} (-### exited non-zero)")
+            "${what} link capture: ${CMAKE_C_COMPILER} failed to emit a link "
+            "line for ${flag} (-### exited non-zero)")
     endif()
 
-    _pony_sanitizer_link_tokens("${_san_baseline_raw}" _san_base_toks)
-    _pony_sanitizer_link_tokens("${_san_sanitized_raw}" _san_san_toks)
+    _pony_driver_link_tokens("${_baseline_raw}" "${_marker}" _base_toks)
+    _pony_driver_link_tokens("${_flagged_raw}" "${_marker}" _flag_toks)
 
-    # Ordered diff. The sanitized link line is a supersequence of the baseline
-    # (-fsanitize only inserts arguments, never removes or reorders existing
-    # ones, once the volatile LTO token is filtered out). A two-pointer scan
-    # over the sanitized tokens, advancing the baseline pointer on each match,
-    # collects exactly the inserted arguments in driver order: clang's
-    # whole-archive/clang_rt/--dynamic-list block plus extra syslibs, or gcc's
-    # libasan_preinit.o + -lasan/-lubsan. Nothing is hardcoded. If the baseline
-    # is not fully consumed in order the supersequence assumption is violated (a
-    # new volatile token, or a driver that reorders existing args); we stop with
-    # a clear error rather than emit a fragment we can't trust.
-    list(LENGTH _san_base_toks _san_base_len)
-    set(_san_j 0)
-    set(_san_fragment "")
-    foreach(_t IN LISTS _san_san_toks)
-        set(_san_matched FALSE)
-        if(_san_j LESS _san_base_len)
-            list(GET _san_base_toks ${_san_j} _san_bt)
-            if(_t STREQUAL _san_bt)
-                math(EXPR _san_j "${_san_j} + 1")
-                set(_san_matched TRUE)
+    # Ordered diff. The flagged link line is a supersequence of the baseline (the
+    # flag only inserts arguments, never removes or reorders existing ones, once
+    # the volatile LTO token is filtered out). A two-pointer scan over the
+    # flagged tokens, advancing the baseline pointer on each match, collects
+    # exactly the inserted arguments in driver order (e.g. for sanitizers clang's
+    # whole-archive/clang_rt/--dynamic-list block, or gcc's libasan_preinit.o +
+    # -lasan/-lubsan; for coverage gcc's -lgcov). Nothing is hardcoded. If the
+    # baseline is not fully consumed in order the supersequence assumption is
+    # violated (a new volatile token, or a driver that reorders existing args);
+    # we stop with a clear error rather than emit a fragment we can't trust.
+    list(LENGTH _base_toks _base_len)
+    set(_j 0)
+    set(_fragment "")
+    foreach(_t IN LISTS _flag_toks)
+        set(_matched FALSE)
+        if(_j LESS _base_len)
+            list(GET _base_toks ${_j} _bt)
+            if(_t STREQUAL _bt)
+                math(EXPR _j "${_j} + 1")
+                set(_matched TRUE)
             endif()
         endif()
-        if(NOT _san_matched)
-            list(APPEND _san_fragment "${_t}")
+        if(NOT _matched)
+            list(APPEND _fragment "${_t}")
         endif()
     endforeach()
 
-    if(NOT _san_j EQUAL _san_base_len)
+    if(NOT _j EQUAL _base_len)
         message(FATAL_ERROR
-            "sanitizer link capture: the -fsanitize link line is not a "
+            "${what} link capture: the ${flag} link line is not a "
             "supersequence of the baseline after filtering volatile tokens "
             "(a new non-deterministic token, or a driver that reorders existing "
             "arguments). See discussion ponylang/ponyc#5399.")
     endif()
 
-    # Sanity: the captured fragment must reference a sanitizer runtime, or the
-    # extraction silently produced nothing useful. clang names it libclang_rt.*,
-    # gcc names it libasan/-lasan/libubsan/libtsan; matching the sanitizer
-    # substrings covers both.
-    string(REGEX MATCH "asan|ubsan|tsan" _san_has_rt "${_san_fragment}")
-    if(_san_has_rt STREQUAL "")
+    # Sanity: the captured fragment must reference the expected runtime, or the
+    # extraction silently produced nothing useful (e.g. for sanitizers clang's
+    # libclang_rt.* / gcc's -lasan; for coverage gcc's -lgcov).
+    string(REGEX MATCH "${sanity_regex}" _has_rt "${_fragment}")
+    if(_has_rt STREQUAL "")
         message(FATAL_ERROR
-            "sanitizer link capture: no sanitizer runtime (asan/ubsan/tsan) "
-            "found in the captured fragment for -fsanitize=${PONY_SANITIZERS_VALUE}")
+            "${what} link capture: no expected runtime (matching '${sanity_regex}') "
+            "found in the captured fragment for ${flag}")
     endif()
 
     # Emit each token as a C string literal, escaping backslash then quote so a
     # toolchain path containing either can't break out of the literal. (Linux
     # toolchain paths don't normally contain these, but a malformed header is a
     # confusing failure mode worth closing off.)
-    set(_san_array "")
-    foreach(_a IN LISTS _san_fragment)
+    set(_array "")
+    foreach(_a IN LISTS _fragment)
         string(REPLACE "\\" "\\\\" _a_esc "${_a}")
         string(REPLACE "\"" "\\\"" _a_esc "${_a_esc}")
-        string(APPEND _san_array "  \"${_a_esc}\",\n")
+        string(APPEND _array "  \"${_a_esc}\",\n")
     endforeach()
 
-    set(_san_gen_dir "${CMAKE_BINARY_DIR}/pony_generated")
-    file(MAKE_DIRECTORY "${_san_gen_dir}")
-    file(WRITE "${_san_gen_dir}/sanitizer_link_args.h"
-"// Generated by CMake (PONY_SANITIZERS_ENABLED block in the top-level\n"
-"// CMakeLists.txt). Do not edit. The sanitizer runtime link fragment captured\n"
-"// from the compiler driver for -fsanitize=${PONY_SANITIZERS_VALUE}.\n"
+    set(_gen_dir "${CMAKE_BINARY_DIR}/pony_generated")
+    file(MAKE_DIRECTORY "${_gen_dir}")
+    file(WRITE "${_gen_dir}/${header_name}"
+"// Generated by CMake (top-level CMakeLists.txt). Do not edit. The ${what}\n"
+"// runtime link fragment captured from the compiler driver for ${flag}.\n"
 "#pragma once\n"
 "#include <stddef.h>\n"
-"static const char* const PONY_SANITIZER_LINK_ARGS[] = {\n${_san_array}};\n"
-"static const size_t PONY_SANITIZER_LINK_ARGS_COUNT =\n"
-"  sizeof(PONY_SANITIZER_LINK_ARGS) / sizeof(PONY_SANITIZER_LINK_ARGS[0]);\n")
-    message("-- Captured sanitizer link fragment for "
-        "-fsanitize=${PONY_SANITIZERS_VALUE}")
+"static const char* const ${sym_prefix}_LINK_ARGS[] = {\n${_array}};\n"
+"static const size_t ${sym_prefix}_LINK_ARGS_COUNT =\n"
+"  sizeof(${sym_prefix}_LINK_ARGS) / sizeof(${sym_prefix}_LINK_ARGS[0]);\n")
+    message("-- Captured ${what} link fragment for ${flag}")
 
     # The probe scratch files have served their purpose at configure time.
-    file(REMOVE "${_san_probe_c}" "${_san_probe_o}" "${_san_probe_bin}")
+    file(REMOVE "${_probe_c}" "${_probe_o}" "${_probe_bin}")
+endfunction()
+
+# Sanitizer build: ponyc links references the sanitizer runtime (__asan_* etc.).
+# The driver fragment differs per compiler — clang emits whole-archived clang_rt
+# static archives + --dynamic-list, gcc a libasan_preinit.o + shared
+# -lasan/-lubsan, Apple clang the clang_rt dylib by absolute path + -rpath (and
+# folds UBSan into ASan). Native Linux, FreeBSD, and macOS sanitizer builds
+# consume this (see genexe.cc); DragonFly/OpenBSD sanitizer builds are rejected
+# at configure time. The matching include dir is wired in below via
+# PONY_GENERATED_INCLUDE_NEEDED, and the splice lives in genexe.cc under
+# #if defined(PONY_SANITIZER).
+if(PONY_SANITIZERS_ENABLED)
+    _pony_capture_driver_link_fragment(
+        "-fsanitize=${PONY_SANITIZERS_VALUE}"
+        "asan|ubsan|tsan"
+        "sanitizer_link_args.h"
+        "PONY_SANITIZER"
+        "sanitizer")
+    set(PONY_GENERATED_INCLUDE_NEEDED TRUE)
+endif()
+
+# Coverage build with gcc: -fprofile-arcs instruments libponyrt's C objects with
+# gcov constructors that reference __gcov_init/__gcov_exit from gcc's libgcov, so
+# every Pony program ponyc links needs libgcov (issue #5434). Capture the
+# driver's coverage fragment (just -lgcov) and splice it in genexe.cc under
+# #if defined(PONY_COVERAGE). Only real gcc needs this: -lgcov is gcc's coverage
+# runtime specifically. clang's -fprofile-instr-generate (the PONY_USE_COVERAGE
+# clang branch above) links fine without a splice, and a non-GNU compiler that
+# takes the -fprofile-arcs instrumentation branch instead — e.g. Apple clang on
+# macOS, which CMake reports as "AppleClang" — emits its own profile runtime
+# (clang_rt.profile), NOT libgcov, so -lgcov would be wrong for it. Gating on
+# CMAKE_C_COMPILER_ID == GNU restricts the capture to gcc, where libgcov is the
+# correct runtime (the instrumented code needing it is libponyrt's C). Since
+# PONY_COVERAGE is defined only here, no other compiler or platform pulls in the
+# spliced fragment.
+if(PONY_USE_COVERAGE AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    _pony_capture_driver_link_fragment(
+        "-fprofile-arcs"
+        "gcov"
+        "coverage_link_args.h"
+        "PONY_COVERAGE"
+        "coverage")
+    # -DPONY_COVERAGE gates the genexe.cc include + splice; it is a compile-time
+    # preprocessor define with no link-time meaning, so it goes on compile
+    # options only (unlike the sanitizer block's -fsanitize=, which the linker
+    # genuinely needs).
+    add_compile_options(-DPONY_COVERAGE)
+    set(PONY_GENERATED_INCLUDE_NEEDED TRUE)
 endif()
 
 if(DEFINED PONY_CPU AND NOT PONY_CPU STREQUAL "")

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -108,10 +108,12 @@ target_include_directories(libponyc
     PRIVATE ../../build/libs/include
 )
 
-# In sanitizer builds, genexe.cc includes the generated sanitizer_link_args.h
-# (the captured sanitizer runtime link fragment; see the PONY_SANITIZERS_ENABLED
-# block in the top-level CMakeLists.txt).
-if(PONY_SANITIZERS_ENABLED)
+# In sanitizer builds (and gcc coverage builds), genexe.cc includes a generated
+# header from pony_generated/ (sanitizer_link_args.h / coverage_link_args.h —
+# the captured runtime link fragment; see the driver link-fragment capture in
+# the top-level CMakeLists.txt). PONY_GENERATED_INCLUDE_NEEDED is set there when
+# either capture runs, so both builds get the dir on the include path.
+if(PONY_GENERATED_INCLUDE_NEEDED)
     target_include_directories(libponyc PRIVATE ${CMAKE_BINARY_DIR}/pony_generated)
 endif()
 

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -45,6 +45,13 @@ LLD_HAS_DRIVER(wasm)
 #  include "sanitizer_link_args.h"
 #endif
 
+#if defined(PONY_COVERAGE)
+// Generated at configure time (top-level CMakeLists.txt, coverage capture block):
+// the coverage runtime (libgcov) link fragment captured from the compiler
+// driver. Exists only in gcc coverage builds, so the include is guarded to match.
+#  include "coverage_link_args.h"
+#endif
+
 #define STR(x) STR2(x)
 #define STR2(x) #x
 
@@ -1340,6 +1347,39 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   }
 #endif
 
+#if defined(PONY_COVERAGE)
+  // Coverage runtime (libgcov). When ponyc is built with gcc coverage
+  // (-fprofile-arcs), libponyrt's C objects carry gcov constructors that
+  // reference __gcov_init/__gcov_exit from gcc's libgcov, so every Pony program
+  // ponyc links needs libgcov on the link line (issue #5434).
+  // PONY_COVERAGE_LINK_ARGS is the fragment the gcc driver emits for
+  // -fprofile-arcs — just -lgcov — captured at ponyc build time (see the
+  // coverage capture block in the top-level CMakeLists.txt). It is defined only
+  // in gcc coverage builds; clang coverage (-fprofile-instr-generate) links
+  // fine without a splice, so this code is absent there.
+  //
+  // Gated to the native ELF targets where gcc coverage is allowed and reaches
+  // embedded LLD: Linux, FreeBSD, and DragonFly. Unlike the sanitizer gate
+  // above, DragonFly is INCLUDED — coverage is allowed there (sanitizers are
+  // not), and DragonFly only builds ponyc with gcc, so it is the platform that
+  // needs this most. OpenBSD coverage is rejected at configure time; macOS and
+  // Windows are not gcc-coverage paths. !is_cross_compiling keeps the host
+  // fragment out of any cross link routed here.
+  //
+  // -lgcov is a bare archive reference, resolved via the gcc lib -L path ponyc
+  // already emits earlier in this function (the same dir libgcov.a and the gcc
+  // sanitizer libs live in). Position is immaterial: LLD resolves __gcov_init
+  // from libgcov.a whether -lgcov precedes or follows the instrumented libponyrt
+  // archive, so splicing here (before file_o, alongside the sanitizer fragment)
+  // is fine.
+  if((target_is_linux(c->opt->triple) || target_is_freebsd(c->opt->triple)
+    || target_is_dragonfly(c->opt->triple)) && !is_cross_compiling(c))
+  {
+    for(size_t i = 0; i < PONY_COVERAGE_LINK_ARGS_COUNT; i++)
+      args.push_back(PONY_COVERAGE_LINK_ARGS[i]);
+  }
+#endif
+
   // Object file.
   args.push_back(file_o);
 
@@ -2114,7 +2154,10 @@ static bool link_exe(compile_t* c, ast_t* program,
   // FreeBSD, and macOS, native sanitizer builds use embedded LLD too: the ELF
   // and Mach-O link functions splice the sanitizer runtime from a fragment
   // captured at ponyc build time. DragonFly and OpenBSD native sanitizer
-  // builds are rejected at configure time. Cross-compilation always uses LLD.
+  // builds are rejected at configure time. Native gcc coverage builds
+  // (Linux/FreeBSD/DragonFly) likewise splice the libgcov fragment in
+  // link_exe_lld_elf (see its PONY_COVERAGE block). Cross-compilation always
+  // uses LLD.
 #ifdef PLATFORM_IS_POSIX_BASED
   if(target_is_linux(c->opt->triple))
     return link_exe_lld_elf(c, program, file_o);


### PR DESCRIPTION
gcc's `-fprofile-arcs` instruments libponyrt with gcov constructors that reference `__gcov_init`/`__gcov_exit` from libgcov, but ponyc links the Pony programs it compiles through embedded LLD rather than the compiler driver, so libgcov never reached the link line. Every link failed with `undefined symbol: __gcov_init`, which made `use=coverage` unusable under gcc and left it dead on DragonFly, which only builds ponyc with gcc.

The fix captures the link fragment the driver emits for `-fprofile-arcs` (just `-lgcov`) at configure time and splices it into the embedded LLD link, the same approach already used for the sanitizer runtime. The two captures are the same driver-probe algorithm, so it is now a shared CMake function. A DragonFly tier3 smoke test guards the gcc coverage link path.

Closes #5434
