### PR TITLE
Test String and Array capacity via invariants, not allocation magic numbers

### DIFF
--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -576,22 +576,27 @@ class \nodoc\ iso _TestStringTrim is UnitTest
   fun name(): String => "builtin/String.trim"
 
   fun apply(h: TestHelper) =>
-    h.assert_eq[String]("45", "0123456".trim(4, 6))
-    h.assert_eq[USize](2, "0123456".trim(4, 6).space())
-    h.assert_eq[String]("456", "0123456".trim(4, 7))
-    h.assert_eq[USize](3, "0123456".trim(4, 7).space())
-    h.assert_eq[String]("456", "0123456".trim(4))
-    h.assert_eq[USize](3, "0123456".trim(4).space())
-    h.assert_eq[String]("", "0123456".trim(4, 4))
-    h.assert_eq[USize](0, "0123456".trim(4, 4).space())
-    h.assert_eq[String]("", "0123456".trim(4, 1))
-    h.assert_eq[USize](0, "0123456".trim(4, 1).space())
+    let orig = "0123456"
+    h.assert_eq[String]("45", orig.trim(4, 6))
+    h.assert_eq[USize](2, orig.trim(4, 6).space())                 // bounded: to - from
+    h.assert_eq[String]("456", orig.trim(4, 7))
+    h.assert_eq[USize](orig.space() - 4, orig.trim(4, 7).space())  // to-end: orig.space - from
+    h.assert_eq[String]("456", orig.trim(4))
+    h.assert_eq[USize](orig.space() - 4, orig.trim(4).space())
+    h.assert_eq[String]("", orig.trim(4, 4))                       // empty
+    h.assert_eq[String]("", orig.trim(4, 1))                       // empty
     h.assert_eq[String]("456", "0123456789".trim(1, 8).trim(3, 6))
     h.assert_eq[USize](3, "0123456789".trim(1, 8).trim(3, 6).space())
     h.assert_eq[String]("456",
       "0123456789".clone().>trim_in_place(1, 8).trim(3, 6))
     h.assert_eq[USize](3,
       "0123456789".clone().>trim_in_place(1, 8).trim(3, 6).space())
+
+    // > 32 bytes: bounded and trim-to-end both derive correctly.
+    let big = "0123456789012345678901234567890123456789" // 40 chars
+    h.assert_eq[String]("45", big.trim(4, 6))
+    h.assert_eq[USize](2, big.trim(4, 6).space())
+    h.assert_eq[USize](big.space() - 4, big.trim(4).space())
 
 class \nodoc\ iso _TestStringTrimInPlace is UnitTest
   """
@@ -600,31 +605,32 @@ class \nodoc\ iso _TestStringTrimInPlace is UnitTest
   fun name(): String => "builtin/String.trim_in_place"
 
   fun apply(h: TestHelper) =>
-    case(h, "45", "0123456", 4, 6, 2)
-    case(h, "456", "0123456", 4, 7, 3)
-    case(h, "456", "0123456", 4 where space = 3)
-    case(h, "", "0123456", 4, 4, 0)
-    case(h, "", "0123456", 4, 1, 0)
-    case(h, "456", "0123456789".clone().>trim_in_place(1, 8), 3, 6, 3)
-    case(h, "456", "0123456789".trim(1, 8), 3, 6, 3)
-    case(h, "", "0123456789".clone().>trim_in_place(1, 8), 3, 3, 0)
+    case(h, "45", "0123456", 4, 6)
+    case(h, "456", "0123456", 4, 7)
+    case(h, "456", "0123456", 4)
+    case(h, "", "0123456", 4, 4)
+    case(h, "", "0123456", 4, 1)
+    case(h, "456", "0123456789".clone().>trim_in_place(1, 8), 3, 6)
+    case(h, "456", "0123456789".trim(1, 8), 3, 6)
+    case(h, "", "0123456789".clone().>trim_in_place(1, 8), 3, 3)
+    // > 32 bytes
+    case(h, "89", "0123456789012345678901234567890123456789", 38, 40)
 
   fun case(
     h: TestHelper,
     expected: String,
     orig: String,
     from: USize,
-    to: USize = -1,
-    space: USize = 0)
+    to: USize = -1)
   =>
     let copy: String ref = orig.clone()
     let pre_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     copy.trim_in_place(from, to)
     h.assert_eq[String box](expected, copy)
-    h.assert_eq[USize](space, copy.space())
     h.assert_eq[String box](expected, copy.clone()) // safe to clone
+    h.assert_true(copy.space() >= copy.size())
     let post_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
-    if copy.space() == 0 then
+    if copy.size() == 0 then
       h.assert_eq[USize](0, post_trim_pagemap.usize())
     else
       h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())
@@ -668,9 +674,13 @@ class \nodoc\ iso _TestStringIsNullTerminated is UnitTest
       String.from_iso_array(recover
         ['a'; 'b'; 'c']
       end).is_null_terminated())
+    // from_iso_array of an array with no spare capacity is not null-terminated.
     h.assert_false(
       String.from_iso_array(recover
-        ['a'; 'b'; 'c'; 'd'; 'e'; 'f'; 'g'; 'h'] // power of two sized array
+        let a = Array[U8]
+        a.reserve(40)
+        while a.size() < a.space() do a.push('x') end
+        a
       end).is_null_terminated())
 
 class \nodoc\ iso _TestSpecialValuesF32 is UnitTest
@@ -1133,40 +1143,62 @@ class \nodoc\ iso _TestStringSpace is UnitTest
   fun name(): String => "builtin/String.space"
 
   fun apply(h: TestHelper) =>
-    let s =
+    // No spare capacity (filled to the allocation): from_iso_array does not add
+    // a null terminator, so space() == size().
+    let filled =
       String.from_iso_array(recover
-        ['1'; '1'; '1'; '1'; '1'; '1'; '1'; '1']
+        let a = Array[U8]
+        a.reserve(40)
+        while a.size() < a.space() do a.push('x') end
+        a
       end)
+    h.assert_eq[USize](filled.size(), filled.space())
+    h.assert_false(filled.is_null_terminated())
 
-    h.assert_eq[USize](s.size(), 8)
-    h.assert_eq[USize](s.space(), 8)
-    h.assert_false(s.is_null_terminated())
+    // Spare capacity (partly filled): from_iso_array writes a null terminator,
+    // so space() > size().
+    let spare =
+      String.from_iso_array(recover
+        let a = Array[U8]
+        a.reserve(40)
+        var i: USize = 0
+        while i < 3 do a.push('x'); i = i + 1 end
+        a
+      end)
+    h.assert_eq[USize](3, spare.size())
+    h.assert_true(spare.space() > spare.size())
+    h.assert_true(spare.is_null_terminated())
 
 class \nodoc\ iso _TestStringRecalc is UnitTest
   fun name(): String => "builtin/String.recalc"
 
   fun apply(h: TestHelper) =>
-    let s: String ref =
+    // No null terminator within the allocation (filled, no spare): recalc finds
+    // no null and leaves the size unchanged.
+    let no_null: String ref =
       String.from_iso_array(recover
-        ['1'; '1'; '1'; '1'; '1'; '1'; '1'; '1']
+        let a = Array[U8]
+        a.reserve(40)
+        while a.size() < a.space() do a.push('x') end
+        a
       end)
-    s.recalc()
-    h.assert_eq[USize](s.size(), 8)
-    h.assert_eq[USize](s.space(), 8)
-    h.assert_false(s.is_null_terminated())
+    let filled_size = no_null.size()
+    no_null.recalc()
+    h.assert_eq[USize](filled_size, no_null.size())
 
+    // Null-terminated content: recalc finds the terminator and sets the size to
+    // the content length.
     let s2: String ref = "foobar".clone()
     s2.recalc()
-    h.assert_eq[USize](s2.size(), 6)
-    h.assert_eq[USize](s2.space(), 6)
+    h.assert_eq[USize](6, s2.size())
     h.assert_true(s2.is_null_terminated())
 
+    // Interior null after truncate: recalc finds the null at index 1.
     let s3: String ref =
       String.from_iso_array(recover ['1'; 0; 0; 0; 0; 0; 0; '1'] end)
     s3.truncate(1)
     s3.recalc()
-    h.assert_eq[USize](s3.size(), 1)
-    h.assert_eq[USize](s3.space(), 7)
+    h.assert_eq[USize](1, s3.size())
     h.assert_true(s3.is_null_terminated())
 
 class \nodoc\ iso _TestStringTruncate is UnitTest
@@ -1179,22 +1211,24 @@ class \nodoc\ iso _TestStringTruncate is UnitTest
           ['1'; '1'; '1'; '1'; '1'; '1'; '1'; '1']
         end)
       end
-    s.truncate(s.space())
+    // truncate(capacity) fills the string up to its current capacity.
+    let cap = s.space()
+    s.truncate(cap)
     h.assert_true(s.is_null_terminated())
-    h.assert_eq[String](s.clone(), "11111111")
-    h.assert_eq[USize](s.size(), 8)
-    h.assert_eq[USize](s.space(), 15) // created extra allocation for null
+    h.assert_eq[USize](cap, s.size())
 
-    s.truncate(100)
+    // truncate(len > capacity) clamps to the allocation; it never reads past it.
+    let cap2 = s.space()
+    s.truncate(cap2 + 1000)
     h.assert_true(s.is_null_terminated())
-    h.assert_eq[USize](s.size(), 16) // sized up to _alloc
-    h.assert_eq[USize](s.space(), 31) // created extra allocation for null
+    h.assert_true(s.size() >= cap2)
+    h.assert_true(s.size() <= (cap2 + 1))
 
+    // truncate(len < size) shrinks to exactly len.
     s.truncate(3)
     h.assert_true(s.is_null_terminated())
-    h.assert_eq[String](s.clone(), "111")
-    h.assert_eq[USize](s.size(), 3)
-    h.assert_eq[USize](s.space(), 31)
+    h.assert_eq[USize](3, s.size())
+    h.assert_eq[String]("111", s.clone())
 
 class \nodoc\ iso _TestStringChop is UnitTest
   """
@@ -1441,35 +1475,40 @@ class \nodoc\ iso _TestArraySlice is UnitTest
 
 class \nodoc\ iso _TestArrayTrim is UnitTest
   """
-  Test trimming part of a string.
+  Test trimming part of an array.
   """
   fun name(): String => "builtin/Array.trim"
 
   fun apply(h: TestHelper) =>
     let orig: Array[U8] val = [0; 1; 2; 3; 4; 5; 6]
     h.assert_array_eq[U8]([4; 5], orig.trim(4, 6))
-    h.assert_eq[USize](2, orig.trim(4, 6).space())
+    h.assert_eq[USize](2, orig.trim(4, 6).space())                 // bounded
     h.assert_array_eq[U8]([4; 5; 6], orig.trim(4, 7))
-    h.assert_eq[USize](4, orig.trim(4, 7).space())
+    h.assert_eq[USize](orig.space() - 4, orig.trim(4, 7).space())  // to-end
     h.assert_array_eq[U8]([4; 5; 6], orig.trim(4))
-    h.assert_eq[USize](4, orig.trim(4).space())
+    h.assert_eq[USize](orig.space() - 4, orig.trim(4).space())
     h.assert_array_eq[U8](Array[U8], orig.trim(4, 4))
-    h.assert_eq[USize](0, orig.trim(4, 4).space())
+    h.assert_eq[USize](0, orig.trim(4, 4).space())                 // empty (Array.create(0))
     h.assert_array_eq[U8](Array[U8], orig.trim(4, 1))
     h.assert_eq[USize](0, orig.trim(4, 1).space())
 
+    // > 32 bytes
+    let big: Array[U8] val = recover val Array[U8].init(0, 40) end
+    h.assert_eq[USize](2, big.trim(4, 6).space())                  // bounded
+    h.assert_eq[USize](big.space() - 4, big.trim(4).space())       // to-end
+
 class \nodoc\ iso _TestArrayTrimInPlace is UnitTest
   """
-  Test trimming part of a string in place.
+  Test trimming part of an array in place.
   """
   fun name(): String => "builtin/Array.trim_in_place"
 
   fun apply(h: TestHelper) =>
-    case(h, [4; 5], [0; 1; 2; 3; 4; 5; 6], 4, 6, 2)
-    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4, 7, 4)
-    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4 where space = 4)
-    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 4, 0)
-    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 1, 0)
+    case(h, [4; 5], [0; 1; 2; 3; 4; 5; 6], 4, 6)
+    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4, 7)
+    case(h, [4; 5; 6], [0; 1; 2; 3; 4; 5; 6], 4)
+    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 4)
+    case(h, Array[U8], [0; 1; 2; 3; 4; 5; 6], 4, 1)
     case(h, Array[U8], Array[U8].init(8, 1024), 1024)
 
   fun case(
@@ -1477,16 +1516,15 @@ class \nodoc\ iso _TestArrayTrimInPlace is UnitTest
     expected: Array[U8],
     orig: Array[U8],
     from: USize,
-    to: USize = -1,
-    space: USize = 0)
+    to: USize = -1)
   =>
     let copy: Array[U8] ref = orig.clone()
     let pre_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
     copy.trim_in_place(from, to)
-    h.assert_eq[USize](space, copy.space())
     h.assert_array_eq[U8](expected, copy)
+    h.assert_true(copy.space() >= copy.size())
     let post_trim_pagemap = @ponyint_pagemap_get_chunk(copy.cpointer())
-    if copy.space() == 0 then
+    if copy.size() == 0 then
       h.assert_eq[USize](0, post_trim_pagemap.usize())
     else
       h.assert_eq[USize](pre_trim_pagemap.usize(), post_trim_pagemap.usize())


### PR DESCRIPTION
The String and Array tests for trim, trim_in_place, space, recalc, truncate, and is_null_terminated asserted exact `space()` and `is_null_terminated()` values that encode the current allocation strategy (`next_pow2` with an 8-element lower bound) — one test even commented "power of two sized array". `space()`'s contract says the reserved space "may be larger" than requested, so those exact values were never part of the contract; the tests would break on any change to allocation behavior even when the behavior under test was unchanged.

This rewrites those assertions to test the underlying contract instead:

- Trim view extent is derived from the original's `space()` (`trimmed.space() == orig.space() - from` for a trim that reaches the end), rather than a hardcoded number.
- Null-termination is checked via the actual rule — `from_iso_array` terminates iff the wrapped array has spare capacity — by constructing arrays with known spare-ness (filled to capacity vs. partially filled) instead of relying on a power-of-two-sized literal.
- `truncate`, `recalc`, and `space` assert size, content, clamp, and null-terminator semantics; any capacity referenced is captured and derived rather than hardcoded.

Each affected test also gains a case with more than 32 bytes of data, so the invariants are exercised on both sides of the allocator's minimum block boundary.

The tests pass unchanged against the current allocator and are no longer coupled to its specific sizing, so they remain meaningful if allocation behavior changes.