### PR TITLE
Fix dtrace heading level in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -218,7 +218,7 @@ make configure arch=arm7
 make build
 ```
 
-## dtrace
+### dtrace
 
 Linux, FreeBSD, and macOS support collecting Pony runtime events, through SystemTap on Linux and DTrace on FreeBSD and macOS. DTrace isn't supported on DragonFly BSD or OpenBSD.
 


### PR DESCRIPTION
Under "Additional Build Options on Unix", every option is an h3 except `dtrace`, which was an h2. That popped it out of the section in the rendered table of contents, as if it were a top-level heading rather than one of the build options. This makes it an h3 like its siblings.
