### PR TITLE
Fix crash when tracing actor behaviors without forced actor tracing

### DIFF
--- a/.release-notes/fix-runtime-tracing-crash-on-actor-behavior-tracing.md
+++ b/.release-notes/fix-runtime-tracing-crash-on-actor-behavior-tracing.md
@@ -1,0 +1,11 @@
+## Fix crash when tracing actor behaviors without forced actor tracing
+
+A runtime built with `runtime_tracing` enabled would crash when the `actor_behavior` tracing category was active without `--ponytracingforceactortracing` also being set:
+
+```
+program --ponytracingcategories actor_behavior
+```
+
+The crash occurred whenever a message was scheduled from a thread that was not running an actor, such as the ASIO thread delivering a network event or the cycle detector. Programs that perform any I/O or run long enough to trigger cycle detection would reliably crash. Setting `--ponytracingforceactortracing all` avoided the crash.
+
+This has been fixed. Actor behavior tracing now works without forcing actor tracing on.

--- a/src/libponyrt/tracing/tracing.c
+++ b/src/libponyrt/tracing/tracing.c
@@ -1351,7 +1351,13 @@ void ponyint_tracing_actor_behavior_run_schedule(pony_actor_t* actor, pony_actor
   if(!tracing_category_enabled(TRACING_CATEGORY_ACTOR_BEHAVIOR))
     return;
 
-  if(!force_actor_tracing_enabled && !ponyint_actor_tracing_enabled(actor))
+  // The sending actor is NULL when a schedule originates from a thread that is
+  // not running an actor: the ASIO thread delivering an event, or a message
+  // injected (e.g. a cycle detector check) from a scheduler thread between
+  // actor runs. In that case there is no per-actor trace flag to consult, so
+  // we only emit the trace when tracing is forced on.
+  if(!force_actor_tracing_enabled
+    && ((actor == NULL) || !ponyint_actor_tracing_enabled(actor)))
     return;
 
   tracing_actor_behavior_run_schedule_t* m = (tracing_actor_behavior_run_schedule_t*)pony_alloc_msg(


### PR DESCRIPTION
In a runtime built with `runtime_tracing`, running a program with `--ponytracingcategories actor_behavior` (without `--ponytracingforceactortracing`) crashed with a NULL-pointer dereference whenever a message was scheduled from a thread not running an actor — the ASIO thread delivering an event, or the cycle detector.

`ponyint_tracing_actor_behavior_run_schedule` receives the sending actor (`ctx->current`), which is NULL on those inject paths. Its body already handles a NULL actor, but the early-return gate called `ponyint_actor_tracing_enabled(actor)`, which dereferences it. With force actor tracing on, `&&` short-circuited before the deref, which is why forcing tracing avoided the crash.

Reproduced the crash on unmodified code with the `net` example and confirmed the fix resolves it (clean across repeated runs); the force-tracing path is unchanged.

Closes #5516