### PR TITLE
Fix linking of Pony programs on 32-bit ARM Linux

### DIFF
--- a/.release-notes/fix-arm32-linux-linking.md
+++ b/.release-notes/fix-arm32-linux-linking.md
@@ -1,0 +1,3 @@
+## Fix linking of Pony programs on 32-bit ARM Linux
+
+Pony programs failed to link on 32-bit ARM Linux systems, such as a Raspberry Pi running a 32-bit OS. They now build and run correctly.

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -428,10 +428,31 @@ static const char* dynamic_linker_path(compile_t* c)
   }
 }
 
+// The GNU/Debian-family multiarch architecture component for a target.
+// LLVM spells 32-bit little-endian ARM as the raw triple arch — "armv7l",
+// "armv6", "armv7", etc. — but Debian/Ubuntu/Raspbian multiarch directories
+// (/usr/lib/<tuple>, /usr/lib/gcc/<tuple>/) and GNU cross-toolchain triples
+// normalize all of them to "arm"; the EABI float variant is carried in the
+// environment (gnueabihf vs gnueabi), not the arch. The other architectures
+// this embedded linker supports (see expected_elf_machine: x86_64, aarch64,
+// riscv64, riscv32) already match LLVM's spelling, so fall back to
+// getArchName() there.
+static std::string gnu_multiarch_arch(const llvm::Triple& triple)
+{
+  switch(triple.getArch())
+  {
+    case llvm::Triple::arm:
+    case llvm::Triple::thumb:
+      return "arm";
+    default:
+      return std::string(triple.getArchName());
+  }
+}
+
 static const char* system_triple(compile_t* c)
 {
   llvm::Triple triple(c->opt->triple);
-  std::string result = std::string(triple.getArchName()) + "-"
+  std::string result = gnu_multiarch_arch(triple) + "-"
     + std::string(triple.getOSName()) + "-"
     + std::string(triple.getEnvironmentName());
   return stringtab(c->opt->strtab, result.c_str());
@@ -983,7 +1004,7 @@ static bool link_exe_lld_elf(compile_t* c, ast_t* program,
   // — source from libc_crt_dir. ponyc_crt_dir stays NULL on the BSDs; the
   // libponyrt block below handles that.
   llvm::Triple target_triple(c->opt->triple);
-  std::string arch_prefix = std::string(target_triple.getArchName()) + "-";
+  std::string arch_prefix = gnu_multiarch_arch(target_triple) + "-";
 
   const char* ponyc_crt_dir = NULL;
   const char* compiler_crt_dir;


### PR DESCRIPTION
Compiling a Pony program natively on a 32-bit ARM Linux host — for example, running ponyc on a 32-bit Raspberry Pi — failed at link time. ponyc's embedded linker builds the GNU/Debian multiarch tuple, and the prefix it uses to find the GCC runtime, from LLVM's target arch name. On a native 32-bit ARM host the default triple is `armv7l-unknown-linux-gnueabihf`, so that yielded `armv7l-linux-gnueabihf`. But Debian/Ubuntu/Raspbian multiarch normalizes 32-bit ARM to `arm` (`arm-linux-gnueabihf`; the EABI float variant lives in the environment), so ponyc searched `/usr/lib/armv7l-linux-gnueabihf`, which doesn't exist, and never found the system `crt1.o`/`crti.o`/`crtn.o`, libc, or libgcc.

This normalizes the ARM arch component to `arm` at the two places that build it. Cross-compilation already worked because it is driven by an explicit `arm-*` triple — which is also why CI never caught this: the ARM legs cross-compile with an explicit `arm-unknown-linux-gnueabi[hf]` triple and never exercise the native default.

Verified on a 32-bit Raspberry Pi (Raspbian, ponyc built with clang against LLVM 22): with the change the full build and the full-program test suites (release and debug) build, link, and pass; before it, the build failed at this exact link.

Found while confirming that #3849 (the old stack-unwinding/`posix_except` blocker, since removed) no longer prevents building on 32-bit ARM. That issue is unrelated to this fix.
