### PR TITLE
Add use=coverage smoke tests to CI

### DIFF
--- a/.ci-scripts/dragonfly-coverage-smoke.sh
+++ b/.ci-scripts/dragonfly-coverage-smoke.sh
@@ -1,25 +1,26 @@
 #!/bin/sh
-# Coverage link smoke test for the DragonFly tier-3 job. Runs inside the
+# Coverage smoke test for the DragonFly tier-3 job. Runs inside the
 # DragonFly VM, invoked from .github/workflows/ponyc-tier3.yml. POSIX sh (no
 # bash in the DragonFly base system). Expects to run from the ponyc source root
 # with the gcc13 build env already exported (CC/CXX/LD_LIBRARY_PATH/SSL_CERT_FILE).
 #
-# DragonFly only builds ponyc with gcc, so it is the platform where the gcc
-# coverage path (-fprofile-arcs) is exercised by default. That path was broken
-# (#5434): -fprofile-arcs instruments libponyrt with gcov constructors that
-# reference __gcov_init/__gcov_exit from libgcov, but ponyc links Pony programs
-# via embedded LLD (not the compiler driver), so libgcov never reached the link
-# line and every Pony program failed to link. The fix captures the driver's
-# coverage link fragment (-lgcov) at configure time and splices it into the
-# embedded LLD link (see the coverage capture in the top-level CMakeLists.txt and
-# the PONY_COVERAGE block in genexe.cc). This test is the primary guard for that
-# fix: a coverage ponyc that can't link is caught here, at build + link time.
+# use=coverage is for working on ponyc itself: a coverage-instrumented ponyc
+# records which parts of the compiler each run exercises. DragonFly builds ponyc
+# only with gcc (the -fprofile-arcs path). gcc's -fprofile-arcs instruments
+# libponyrt with gcov constructors referencing __gcov_init/__gcov_exit from
+# libgcov; ponyc links Pony programs via embedded LLD (not the driver), so libgcov
+# is spliced onto the link line (#5434; see the coverage capture in the top-level
+# CMakeLists.txt and the PONY_COVERAGE block in genexe.cc) — without it the build
+# can't link the self-hosted tools at all.
 #
-# The `gmake build` below is itself the first assertion: before the fix it dies
-# linking the self-hosted tools / full-program-runner with undefined __gcov_init.
-# Then we link AND run a standalone Pony program: running proves the spliced
-# libgcov actually satisfies the gcov init/fini constructors at runtime, not just
-# that the symbols resolved at link time.
+# This smoke guards two things:
+#   1. use=coverage still builds and links on gcc — `gmake build` (which links the
+#      self-hosted tools via embedded LLD) is the first assertion; before #5434 it
+#      died with undefined __gcov_init. Compiling and running a standalone program
+#      then confirms the spliced libgcov satisfies the gcov constructors at
+#      runtime, not just at link time.
+#   2. the coverage-instrumented ponyc emits profile data when it runs (.gcda) —
+#      the point of use=coverage, measuring ponyc's own coverage.
 set -eu
 
 # Clean + reconfigure debug from scratch with coverage. `clean` is config-scoped
@@ -49,15 +50,35 @@ actor Main
     env.out.print("coverage smoke ok")
 PONY
 
-# Link via embedded LLD (the captured -lgcov fragment is spliced here) and run.
-# A broken splice fails at link time with undefined __gcov_init/__gcov_exit.
-PONYPATH="$PWD/packages" "$out/ponyc" --debug -o "$smoke" "$smoke"
-out_text=$("$smoke/coverage-smoke")
+# Compile a program (link via embedded LLD — the captured -lgcov fragment is
+# spliced here; a broken splice fails at link time with undefined __gcov_init) and
+# run it. The same ponyc invocation is real work for the instrumented compiler, so
+# capture its .gcda with a per-invocation GCOV_PREFIX (not exported) to assert
+# ponyc's own coverage below.
+gcov_dir="$smoke/gcov"
+rm -rf "$gcov_dir"
+mkdir -p "$gcov_dir"
+PONYPATH="$PWD/packages" GCOV_PREFIX="$gcov_dir" "$out/ponyc" --debug -o "$smoke" "$smoke"
+# Run from $smoke so any stray profile file the program might drop lands in the
+# scratch dir, not the source tree. We don't assert on it — this is the
+# build/link/run check.
+out_text=$(cd "$smoke" && "$smoke/coverage-smoke")
 echo "$out_text"
 echo "$out_text" | grep -q "coverage smoke ok"
+
+# The point of use=coverage: the instrumented ponyc emits profile data when it
+# runs. gcc writes a .gcda per instrumented TU at exit, redirected above into
+# $gcov_dir, so a real compile must have written some. Assert at least one landed;
+# none means coverage isn't actually capturing data.
+gcda_count=$(find "$gcov_dir" -name '*.gcda' | wc -l | tr -dc '0-9')
+if [ "$gcda_count" -eq 0 ]; then
+  echo "FAIL: coverage-instrumented ponyc produced no .gcda profile data"
+  exit 1
+fi
+echo "ponyc dropped profile data: $gcda_count .gcda files"
 
 # The self-hosted tools are themselves Pony programs the coverage ponyc linked
 # during `gmake build`; confirm one runs, proving the tool link path works under
 # coverage and not just that a minimal program does.
 "$out/pony-lint" --version
-echo "coverage link smoke test passed"
+echo "coverage smoke test passed"

--- a/.ci-scripts/freebsd-coverage-smoke.sh
+++ b/.ci-scripts/freebsd-coverage-smoke.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Coverage smoke test for the FreeBSD tier-3 job. Runs inside the FreeBSD VM,
+# invoked from .github/workflows/ponyc-tier3.yml. POSIX sh, not bash: FreeBSD's
+# base system has no bash. Expects to run from the ponyc source root.
+#
+# use=coverage is for working on ponyc itself: a coverage-instrumented ponyc
+# records which parts of the compiler each run exercises. FreeBSD builds ponyc
+# with its base clang (the -fprofile-instr-generate path). This smoke guards two
+# things:
+#   1. use=coverage still builds — it compiles the instrumented ponyc and links
+#      the self-hosted tools (pony-lsp/pony-lint/pony-doc) plus a standalone
+#      program, so a coverage build that can't link is caught here.
+#   2. the coverage-instrumented ponyc actually emits profile data when it runs
+#      (a .profraw) — the point of use=coverage, measuring ponyc's own coverage.
+set -eu
+
+# Clean + reconfigure debug from scratch with coverage. `clean` is config-scoped
+# (pass config=debug so it removes the debug build/output dirs); the prebuilt
+# LLVM in build/libs is untouched, so this does not rebuild LLVM. A from-scratch
+# configure is required because the coverage instrumentation flags differ from
+# the plain debug build the job already made. This runs after the sanitizer and
+# dtrace smokes, which perform the same clean+reconfigure, so the order is
+# deliberate.
+gmake clean config=debug
+gmake configure config=debug use=coverage
+# The `gmake build` below is itself the first assertion: it compiles the
+# instrumented ponyc and links the self-hosted tools (pony-lsp/pony-lint/
+# pony-doc). A coverage build that can't link them fails here, at build time.
+gmake build config=debug
+
+# use=coverage sets PONY_OUTPUT_SUFFIX to -coverage, so the build output lands in
+# build/debug-coverage. Derive it rather than hardcoding (the suffix is
+# CMake-determined and could grow more segments in a combined build).
+out=$(find build -maxdepth 1 -type d -name 'debug-coverage' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: coverage build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/coverage-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    env.out.print("coverage smoke ok")
+PONY
+
+# Compile a program and run it — confirms the coverage ponyc produces a working
+# binary. That ponyc invocation is real work for the instrumented compiler, so it
+# also exercises ponyc's own coverage; capture this run's profile data with a
+# per-invocation LLVM_PROFILE_FILE (not exported, so it captures only this run,
+# not the many ponyc runs `gmake build` already made).
+prof="$smoke/ponyc.profraw"
+rm -f "$prof"
+PONYPATH="$PWD/packages" LLVM_PROFILE_FILE="$prof" "$out/ponyc" --debug -o "$smoke" "$smoke"
+# Run from $smoke so any stray profile file the program might drop (e.g. a clang
+# default.profraw, written relative to the cwd) lands in the scratch dir, not the
+# source tree. We don't assert on it — this is the build/link/run check.
+out_text=$(cd "$smoke" && "$smoke/coverage-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "coverage smoke ok"
+
+# The point of use=coverage: the instrumented ponyc emits profile data when it
+# runs. The driver-linked ponyc binary carries clang's profile runtime, so a real
+# compile drops a non-empty .profraw. A non-empty file proves the runtime is
+# linked and ran; an empty/missing one means coverage isn't actually capturing.
+if [ ! -s "$prof" ]; then
+  echo "FAIL: coverage-instrumented ponyc produced no profile data"
+  exit 1
+fi
+echo "ponyc dropped profile data: $(wc -c < "$prof") bytes"
+
+# The self-hosted tools are themselves Pony programs the coverage ponyc linked
+# during `gmake build`; confirm one runs, proving the tool link path works under
+# coverage and not just that a minimal program does.
+"$out/pony-lint" --version
+echo "coverage smoke test passed"

--- a/.ci-scripts/linux-coverage-smoke.sh
+++ b/.ci-scripts/linux-coverage-smoke.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# Coverage smoke test for the Linux weekly-checks job. Invoked from
+# .github/workflows/ponyc-weekly-checks.yml. Expects to run from the ponyc source
+# root, in a container that has built libs, with CC/CXX selecting the toolchain to
+# exercise (gcc or clang — the weekly job runs it once with each).
+#
+# use=coverage is for working on ponyc itself: a coverage-instrumented ponyc
+# records which parts of the compiler each run exercises. The instrumentation and
+# the data files differ by toolchain:
+#   - gcc (-fprofile-arcs): data lands as .gcda files, one per instrumented TU,
+#     redirected by GCOV_PREFIX to a scratch dir. gcc instruments libponyrt with
+#     gcov constructors referencing __gcov_init/__gcov_exit from libgcov; ponyc
+#     links Pony programs via embedded LLD (not the driver), so libgcov is spliced
+#     onto the link line (#5434; see the coverage capture in the top-level
+#     CMakeLists.txt and the PONY_COVERAGE block in genexe.cc) — without it the
+#     build can't link the self-hosted tools.
+#   - clang (-fprofile-instr-generate): data lands as a single .profraw selected by
+#     LLVM_PROFILE_FILE.
+#
+# This guards, for whichever toolchain CC/CXX selects, two things:
+#   1. use=coverage builds and links the Pony programs ponyc compiles (the
+#      self-hosted tools during `make build`, plus the standalone program below)
+#      via embedded LLD.
+#   2. the coverage-instrumented ponyc emits profile data when it runs — the point
+#      of use=coverage, measuring ponyc's own coverage.
+set -eu
+
+# CC/CXX must be set — they select the toolchain to exercise, and the coverage
+# data format (clang .profraw vs gcc .gcda) is chosen below from CXX, so it has
+# to match the compiler the build actually used. Fail loudly if unset rather than
+# defaulting and risking a format mismatch (e.g. the Makefile prefers clang when
+# CC/CXX are unset, which would disagree with a gcc-style assertion).
+: "${CC:?set CC and CXX (gcc/g++ or clang/clang++)}"
+: "${CXX:?set CC and CXX (gcc/g++ or clang/clang++)}"
+
+# Clean + reconfigure debug from scratch with coverage. `clean` is config-scoped
+# (pass config=debug); the prebuilt LLVM in build/libs is untouched, so this does
+# not rebuild LLVM.
+make clean config=debug
+make configure config=debug use=coverage
+# The `make build` below is itself the first assertion: it compiles the
+# instrumented ponyc and links the self-hosted tools (pony-lsp/pony-lint/
+# pony-doc), Pony programs ponyc links via embedded LLD.
+make build config=debug
+
+# use=coverage sets PONY_OUTPUT_SUFFIX to -coverage. Derive the output dir.
+out=$(find build -maxdepth 1 -type d -name 'debug-coverage' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: coverage build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/coverage-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    env.out.print("coverage smoke ok")
+PONY
+
+# The coverage data format follows the toolchain libponyrt was instrumented with,
+# which CMake selects from the C++ compiler id (clang -> profraw, else gcov). Pick
+# the matching capture/assertion path from the same compiler CC/CXX selected. The
+# program compile below links via embedded LLD (on gcc the spliced libgcov is what
+# lets it link); running it confirms the coverage ponyc produces a working binary,
+# and the same compile is real work for the instrumented compiler, so it also
+# exercises ponyc's own coverage — captured per-invocation and asserted below.
+if "$CXX" --version 2>/dev/null | grep -qi clang; then
+  # clang: LLVM_PROFILE_FILE selects a per-invocation .profraw, asserted non-empty.
+  ponyc_data="$smoke/ponyc.profraw"
+  rm -f "$ponyc_data"
+  PONYPATH="$PWD/packages" LLVM_PROFILE_FILE="$ponyc_data" "$out/ponyc" --debug -o "$smoke" "$smoke"
+  # Run from $smoke so a stray clang default.profraw lands in scratch, not the tree.
+  out_text=$(cd "$smoke" && "$smoke/coverage-smoke")
+  echo "$out_text"
+  echo "$out_text" | grep -q "coverage smoke ok"
+  if [ ! -s "$ponyc_data" ]; then
+    echo "FAIL: coverage-instrumented ponyc produced no profile data"
+    exit 1
+  fi
+  echo "ponyc dropped profile data: $(wc -c < "$ponyc_data") bytes"
+else
+  # gcc: GCOV_PREFIX redirects the per-TU .gcda files; assert at least one lands.
+  ponyc_gcov="$smoke/gcov-ponyc"
+  rm -rf "$ponyc_gcov"
+  mkdir -p "$ponyc_gcov"
+  PONYPATH="$PWD/packages" GCOV_PREFIX="$ponyc_gcov" "$out/ponyc" --debug -o "$smoke" "$smoke"
+  # Run from $smoke so any stray profile file lands in scratch, not the tree.
+  out_text=$(cd "$smoke" && "$smoke/coverage-smoke")
+  echo "$out_text"
+  echo "$out_text" | grep -q "coverage smoke ok"
+  ponyc_gcda=$(find "$ponyc_gcov" -name '*.gcda' | wc -l | tr -dc '0-9')
+  if [ "$ponyc_gcda" -eq 0 ]; then
+    echo "FAIL: coverage-instrumented ponyc produced no .gcda profile data"
+    exit 1
+  fi
+  echo "ponyc dropped profile data: $ponyc_gcda .gcda files"
+fi
+
+# The self-hosted tools are themselves Pony programs the coverage ponyc linked
+# during `make build`; confirm one runs, proving the tool link path works under
+# coverage and not just that a minimal program does.
+"$out/pony-lint" --version
+echo "coverage smoke test passed"

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -292,6 +292,10 @@ jobs:
           sh .ci-scripts/freebsd-sanitizer-smoke.sh
           # use=dtrace smoke test — see the script for details.
           sh .ci-scripts/freebsd-dtrace-smoke.sh
+          # use=coverage smoke test — see the script for details. Runs last; it
+          # does the same clean+reconfigure of the debug build as the smokes
+          # above.
+          sh .ci-scripts/freebsd-coverage-smoke.sh
           EOF
       - name: Shutdown VM
         if: always()
@@ -438,9 +442,9 @@ jobs:
           gmake configure config=release
           gmake build config=release
           gmake test-ci-core config=release
-          # gcc coverage link smoke test (#5434) — see the script for details. It
-          # does a clean + reconfigure of the debug build with use=coverage, so it
-          # runs last, after the release tests that depend on the prior builds.
+          # gcc use=coverage smoke test — see the script for details. It does a
+          # clean + reconfigure of the debug build with use=coverage, so it runs
+          # last, after the release tests that depend on the prior builds.
           sh .ci-scripts/dragonfly-coverage-smoke.sh
           EOF
       - name: Shutdown VM

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -112,6 +112,58 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  coverage:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+
+    # use=coverage takes a different runtime path per toolchain: clang's
+    # -fprofile-instr-generate (libclang_rt.profile / .profraw) and gcc's
+    # -fprofile-arcs (libgcov / .gcda). The embedded LLD link splices each in (see
+    # genexe.cc + the top-level CMakeLists.txt), so exercise both compilers.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+            cc: clang
+            cxx: clang++
+          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+            cc: gcc
+            cxx: g++
+
+    name: use coverage (${{ matrix.cc }})
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_IMAGE: ${{ matrix.image }}
+          LIBS_TAG: ${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+        run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
+      - name: Coverage smoke test
+        env:
+          CC: ${{ matrix.cc }}
+          CXX: ${{ matrix.cxx }}
+        run: sh .ci-scripts/linux-coverage-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   with_sanitizers:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -294,12 +294,6 @@ Previously, if a directory inside a package was named like a Pony source file â€
 
 `scope()` now returns the zone identifier correctly. Big-endian platforms were unaffected and are unchanged.
 
-## Fix `use=coverage` builds failing to link with gcc
-
-Building ponyc with `use=coverage` under a gcc toolchain produced a compiler that couldn't link the Pony programs it compiled: every link failed with `undefined symbol: __gcov_init` (and `__gcov_exit`). Because DragonFly BSD only builds ponyc with gcc, coverage builds were unusable there entirely.
-
-Coverage builds under gcc now link correctly on every platform where coverage is supported.
-
 ## Fix crash when tracing actor behaviors without forced actor tracing
 
 A runtime built with `runtime_tracing` enabled would crash when the `actor_behavior` tracing category was active without `--ponytracingforceactortracing` also being set:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to the Pony compiler and standard library will be documented
 - Make `UDPSocket.set_broadcast` a no-op on IPv6 sockets ([PR #5497](https://github.com/ponylang/ponyc/pull/5497))
 - Fix crash when a directory is named like a Pony source file ([PR #5514](https://github.com/ponylang/ponyc/pull/5514))
 - Fix NetAddress.scope() returning a byte-swapped value on little-endian platforms ([PR #5511](https://github.com/ponylang/ponyc/pull/5511))
-- Fix `use=coverage` builds failing to link with gcc ([PR #5515](https://github.com/ponylang/ponyc/pull/5515))
 - Fix crash when tracing actor behaviors without forced actor tracing ([PR #5522](https://github.com/ponylang/ponyc/pull/5522))
 
 ### Added


### PR DESCRIPTION
use=coverage is an internal build option for working on ponyc itself: a coverage-instrumented ponyc reports which parts of the compiler and runtime C code a run exercises. Nothing in CI exercised it, so a broken coverage build or embedded-LLD link splice would go unnoticed until someone reached for it.

These smokes build with use=coverage, link the self-hosted tools, and confirm the instrumented ponyc emits profile data — FreeBSD (clang) and DragonFly (gcc) in tier 3, both toolchains on Linux in the weekly checks, covering the distinct clang (.profraw) and gcc (.gcda) paths. The DragonFly smoke already existed as a build/link guard for the gcc coverage splice (#5434/#5515); this extends it to also assert profile emission.

This also drops PR #5515's release note and CHANGELOG entry. That fix was to this same internal coverage build, so it has no user-visible effect and doesn't belong in user-facing release notes.

Closes #5436
