### PR TITLE
Add a use=valgrind smoke test to the FreeBSD tier-3 job

### DIFF
--- a/.ci-scripts/bsd/freebsd-provision.bash
+++ b/.ci-scripts/bsd/freebsd-provision.bash
@@ -88,7 +88,7 @@ expect {
   "su: Sorry" { puts "su failed - wrong password or nuageinit didn't set it"; exit 1 }
   timeout { puts "Timeout waiting for root shell"; exit 1 }
 }
-send "pkg install -y cmake gmake libunwind git python3 rsync doas\r"
+send "pkg install -y cmake gmake libunwind git python3 rsync doas valgrind\r"
 expect {
   "#" {}
   timeout { puts "Timeout during pkg install"; exit 1 }

--- a/.ci-scripts/freebsd-valgrind-smoke.sh
+++ b/.ci-scripts/freebsd-valgrind-smoke.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Valgrind smoke test for the FreeBSD tier-3 job. Runs inside the FreeBSD VM,
+# invoked from .github/workflows/ponyc-tier3.yml. POSIX sh, not bash: FreeBSD's
+# base system has no bash. Expects to run from the ponyc source root.
+#
+# use=valgrind annotates the Pony runtime so Valgrind can understand its custom
+# allocator. FreeBSD ships a modern Valgrind port, so this is the one BSD where
+# running a Pony program under Valgrind actually works — unlike DragonFly, whose
+# Valgrind 3.15 is too old and hangs on the runtime's memory arena
+# (https://github.com/ponylang/ponyc/issues/5435). This smoke guards two things:
+#   1. use=valgrind still builds — `gmake build` compiles the annotated runtime
+#      into ponyc; a build that can't compile or link is caught here.
+#   2. a Pony program compiled with it runs to completion *under Valgrind*
+#      without hanging — the DragonFly failure mode.
+# It deliberately does NOT assert that Memcheck comes back clean: Pony's custom
+# allocator isn't fully Valgrind-clean (Valgrind flags the pool allocator's
+# intrusive free-list reuse at thread teardown), and getting there is a separate
+# concern from "the build works and runs".
+set -eu
+
+# Clean + reconfigure debug from scratch with valgrind. `clean` is config-scoped
+# (pass config=debug so it removes the debug build/output dirs); the prebuilt
+# LLVM in build/libs is untouched, so this does not rebuild LLVM. A from-scratch
+# configure is required because the valgrind annotations differ from any plain
+# debug build already present (the tier-3 job builds one, and the earlier smokes
+# leave their own). This script is self-contained: it rebuilds from scratch, so
+# it can run as its own CI step regardless of what came before.
+gmake clean config=debug
+gmake configure config=debug use=valgrind
+# The `gmake build` below is itself the first assertion: it compiles ponyc with
+# the Valgrind-annotated runtime. A use=valgrind build that can't compile or
+# link fails here, at build time.
+gmake build config=debug
+
+# use=valgrind sets PONY_OUTPUT_SUFFIX to -valgrind, so the build output lands in
+# build/debug-valgrind. Derive it rather than hardcoding (the suffix is
+# CMake-determined and could grow more segments in a combined build).
+out=$(find build -maxdepth 1 -type d -name 'debug-valgrind' | head -1)
+if [ -z "$out" ] || [ ! -x "$out/ponyc" ]; then
+  echo "FAIL: valgrind build output directory not found"
+  exit 1
+fi
+
+smoke=/tmp/valgrind-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    env.out.print("valgrind smoke ok")
+PONY
+
+# Compile a program with the Valgrind-annotated ponyc — confirms it produces a
+# working binary.
+PONYPATH="$PWD/packages" "$out/ponyc" --debug -o "$smoke" "$smoke"
+
+# Run the program UNDER Valgrind. The whole point: a Pony program runs to
+# completion under Valgrind on FreeBSD, where DragonFly's older Valgrind hangs on
+# the runtime's memory arena (#5435). `timeout` is the real assertion here — a
+# hang surfaces as a non-zero (124) exit, not as missing output. We do not pass
+# --error-exitcode or inspect Memcheck's error/leak summary on purpose (see the
+# header): this checks that it builds and runs, not that it's Memcheck-clean.
+log="$smoke/valgrind.log"
+rc=0
+timeout 300 valgrind "$smoke/valgrind-smoke" >"$smoke/out.txt" 2>"$log" || rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "FAIL: program did not run to completion under Valgrind (rc=$rc)"
+  [ "$rc" -eq 124 ] && echo "(rc=124 = timed out: a DragonFly-style hang)"
+  cat "$log"
+  exit 1
+fi
+
+# The program ran to completion: assert its output.
+if ! grep -q "valgrind smoke ok" "$smoke/out.txt"; then
+  echo "FAIL: expected program output missing"
+  cat "$smoke/out.txt"
+  exit 1
+fi
+
+# Assert Valgrind actually instrumented the run (its summary always prints), so
+# the smoke can't pass by accidentally running the binary outside Valgrind.
+if ! grep -q "ERROR SUMMARY" "$log"; then
+  echo "FAIL: no Valgrind ERROR SUMMARY — did the program run under Valgrind?"
+  cat "$log"
+  exit 1
+fi
+
+echo "valgrind smoke test passed"

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -292,10 +292,23 @@ jobs:
           sh .ci-scripts/freebsd-sanitizer-smoke.sh
           # use=dtrace smoke test — see the script for details.
           sh .ci-scripts/freebsd-dtrace-smoke.sh
-          # use=coverage smoke test — see the script for details. Runs last; it
-          # does the same clean+reconfigure of the debug build as the smokes
-          # above.
+          # use=coverage smoke test — see the script for details. Runs last of
+          # the smokes in this step; it does the same clean+reconfigure of the
+          # debug build as the smokes above. (The use=valgrind smoke runs after,
+          # in its own step, so it can be gated to FreeBSD 14.3.)
           sh .ci-scripts/freebsd-coverage-smoke.sh
+          EOF
+      - name: Valgrind smoke
+        # FreeBSD 14.3 only: Valgrind 3.26 there runs a Pony program to
+        # completion; 15.0 is unverified, so it doesn't gate the matrix. Its own
+        # step so the matrix-version `if` can scope it — the script does its own
+        # clean+configure+build, so it's self-contained.
+        if: matrix.version == '14.3'
+        run: |
+          ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 freebsd@localhost <<'EOF'
+          set -e
+          cd /home/freebsd/ponyc
+          sh .ci-scripts/freebsd-valgrind-smoke.sh
           EOF
       - name: Shutdown VM
         if: always()


### PR DESCRIPTION
FreeBSD ships a modern Valgrind, so unlike DragonFly (#5435) a Pony program built with use=valgrind actually runs to completion under it. Nothing in CI exercised that, so use=valgrind could rot unnoticed on the one BSD where it works.

The new smoke builds use=valgrind, compiles a small program, and runs it under Valgrind with a timeout. A build that won't compile or link fails at build time; a runtime hang like DragonFly's shows up as the timeout. It does not check that Memcheck comes back clean: Pony's allocator isn't fully Valgrind-clean, and getting it there is a separate job.

I validated it on FreeBSD 14.3 (Valgrind 3.26, runs in about twelve seconds). 15.0 isn't validated, so the smoke is gated to 14.3 in the matrix.

One choice to flag: the test program is deliberately trivial, where the dtrace and sanitizer smokes allocate. The #5435 hang happens at runtime startup, so any program triggers it, and since this smoke doesn't check Memcheck output, allocation churn would only add runtime and noise. Easy to beef up if you'd rather it match the siblings.

Closes #5437
