### PR TITLE
Fix ARMV6 detection on 32-bit ARMv8 targets

### DIFF
--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -130,10 +130,21 @@
 
 /** ARM architecture flags.
  *
+ * Detects the ARM architecture version on 32-bit ARM (AArch32). The runtime
+ * consumes ARMV6 (cpu.c: hardware cycle counter), ARMV7 (NEON-detection macro
+ * below), and ARMV5 (fun.c: clz handling of zero); the cascade keeps lower
+ * tiers defined once a higher one is. Detection prefers the ACLE __ARM_ARCH
+ * version macro so v8 and later are covered: the legacy __ARM_ARCH_Nx__ macros
+ * stop at v7, so a 32-bit ARMv8 target (e.g. a Raspberry Pi 4 on a 32-bit OS)
+ * would otherwise match none of these and lose the cycle counter. The
+ * __ARM_ARCH checks are gated on __arm__ so AArch64 -- which also defines
+ * __ARM_ARCH -- is excluded; its cycle counter uses different registers, so
+ * the AArch32-only CP15 code in cpu.c must not be enabled there.
  */
 #if defined(__ARM_ARCH_7__) || \
     defined(__ARM_ARCH_7R__) || \
-    defined(__ARM_ARCH_7A__)
+    defined(__ARM_ARCH_7A__) || \
+    (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
 # define ARMV7 1
 #endif
 
@@ -143,7 +154,8 @@
     defined(__ARM_ARCH_6K__) || \
     defined(__ARM_ARCH_6Z__) || \
     defined(__ARM_ARCH_6T2__) || \
-    defined(__ARM_ARCH_6ZK__)
+    defined(__ARM_ARCH_6ZK__) || \
+    (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 6))
 # define ARMV6 1
 #endif
 


### PR DESCRIPTION
`platform.h`'s ARM version cascade enumerated only the legacy `__ARM_ARCH_Nx__` macros, which stop at v7. A 32-bit ARMv8 build — a Raspberry Pi 4 on a 32-bit OS, or any `-march=armv8-a` / `-march=native` 32-bit build — therefore matched no tier and never defined `ARMV6`, so `cpu.c` compiled out the hardware cycle-counter path.

Detection now also uses the ACLE `__ARM_ARCH` numeric macro, which covers v8 and later, gated on `__arm__` so AArch64 — which also defines `__ARM_ARCH`, but whose cycle counter uses different registers — is unaffected.

Closes #3855
