### PR TITLE
Fix scheduler threads suspending after half the configured idle time

### DIFF
--- a/.release-notes/fix-suspend-threshold-half-timing.md
+++ b/.release-notes/fix-suspend-threshold-half-timing.md
@@ -1,0 +1,11 @@
+## Fix scheduler threads suspending after half the configured idle time
+
+The `--ponysuspendthreshold` runtime option controls how long a scheduler thread waits, while it has no work to do, before suspending itself to reduce CPU usage. It is documented in milliseconds and defaults to 1 ms.
+
+On the most common platforms, including all x86 systems, the threshold was being applied at half its intended scale, so threads started suspending after about half the idle time you asked for. Passing `--ponysuspendthreshold 100` caused threads to begin suspending after roughly 50 ms instead of 100 ms, and the 1 ms default behaved like 0.5 ms.
+
+The threshold now uses the same timing scale as the runtime's other interval options, such as `--ponycdinterval`, rather than half of it.
+
+As a result, idle scheduler threads now stay awake roughly twice as long before suspending compared to previous releases. Programs that depend on scheduler threads suspending quickly when idle (for example, to keep CPU usage low on an otherwise idle process) may see threads remain active a little longer, while programs sensitive to the cost of waking a suspended thread when new work arrives may benefit. If you previously tuned `--ponysuspendthreshold`, halve your value to keep the same timing as before.
+
+The same calibration error affected an internal threshold the runtime uses to decide a scheduler thread has gone idle, which doubled along with the suspend threshold. As a side effect, a program that goes idle may take a fraction of a millisecond longer to be detected as ready to terminate than in previous releases.

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #endif
 
-#define PONY_SCHED_BLOCK_THRESHOLD 1000000
+#define PONY_SCHED_BLOCK_THRESHOLD 2000000
 
 PONY_EXTERN_C_BEGIN
 
@@ -974,13 +974,13 @@ static pony_actor_t* steal(scheduler_t* sched)
     //    we will have also tried getting work off the ASIO inject queue
     //    multiple times
     // 4. We've been trying to steal for at least PONY_SCHED_BLOCK_THRESHOLD
-    //    cycles (currently 1000000).
+    //    cycles (currently 2000000).
     //    In many work stealing scenarios, we immediately get steal an actor.
     //    Sending a block/unblock pair in that scenario is very wasteful.
     //    Same applies to other "quick" steal scenarios.
-    //    1 million cycles is roughly 1 millisecond, depending on clock speed.
-    //    By waiting 1 millisecond before sending a block message, we are going to
-    //    delay quiescence by a small amount of time but also optimize work
+    //    2 million cycles is roughly 1 millisecond, depending on clock speed.
+    //    By waiting 1 millisecond before sending a block message, we are going
+    //    to delay quiescence by a small amount of time but also optimize work
     //    stealing for generating far fewer block/unblock messages.
     uint32_t current_active_scheduler_count = get_active_scheduler_count();
     uint64_t clocks_elapsed = tsc2 - tsc;
@@ -1675,7 +1675,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
   // convert to cycles for use with ponyint_cpu_tick()
   // 1 second = 2000000000 cycles (approx.)
   // based on same scale as ponyint_cpu_core_pause() uses
-  scheduler_suspend_threshold = (uint64_t)thread_suspend_threshold * 1000000;
+  scheduler_suspend_threshold = (uint64_t)thread_suspend_threshold * 2000000;
 
   scheduler_count = threads;
   min_scheduler_count = min_threads;


### PR DESCRIPTION
`--ponysuspendthreshold` is documented in milliseconds, but the runtime converted it to a cycle count using `* 1000000` while its sibling interval knobs (`print_stats_interval`, `detect_interval`) and the `ponyint_cpu_core_pause()` calibration anchor all use `* 2000000` (2,000,000,000 cycles ≈ 1 second). On platforms where `ponyint_cpu_tick()` returns real cycles — x86, RISC-V, and ARM with a hardware counter — scheduler threads started trying to suspend after half the configured idle time.

This switches the suspend threshold to the same `* 2000000` scale as the other interval knobs and the calibration anchor, so the code matches its own comment.

`PONY_SCHED_BLOCK_THRESHOLD` was introduced in the same commit (`a44cfafd4`) with the same documented intent — "wait 1 millisecond before sending a block message" — and the same 1 GHz slip: `1000000` cycles is ~0.5 ms at the 2 GHz scale, not 1 ms. This bumps it to `2000000` so the work-stealing block debounce is actually ~1 ms, restoring its intended coincidence with the now-corrected 1 ms default suspend threshold. The debounce doubles (~0.5 ms → ~1 ms), so a program going idle may take a fraction of a millisecond longer to be detected as ready to terminate.

Because both thresholds' cycle counts double, idle scheduler threads now stay awake roughly twice as long before suspending, and idle programs reach quiescence detection slightly later, on every platform; the release note covers the user-facing impact.

Closes #5531.
