### PR TITLE
Fix compiler crash when compiling very long expression sequences

### DIFF
--- a/.release-notes/fix-long-sequence-stack-overflow.md
+++ b/.release-notes/fix-long-sequence-stack-overflow.md
@@ -1,0 +1,3 @@
+## Fix compiler crash when compiling very long expression sequences
+
+The compiler could crash when compiling a very long sequence of expressions, such as a large array or tuple literal, a long argument list, or a long function or method body — the kind of thing code generators often produce. Sequences of this kind now compile without crashing, regardless of how many expressions they contain.

--- a/pony.g
+++ b/pony.g
@@ -38,29 +38,20 @@ method
   ;
 
 annotatedrawseq
-  : ('\\' ID (',' ID)* '\\')? (exprseq | jump)
+  : ('\\' ID (',' ID)* '\\')? (assignment | jump) antlr_0*
   ;
 
 rawseq
-  : exprseq
-  | jump
-  ;
-
-exprseq
-  : assignment (semiexpr | nosemi)?
-  ;
-
-nextexprseq
-  : nextassignment (semiexpr | nosemi)?
+  : (assignment | jump) antlr_1*
   ;
 
 nosemi
-  : nextexprseq
+  : nextassignment
   | jump
   ;
 
 semiexpr
-  : ';' (exprseq | jump)
+  : ';' (assignment | jump)
   ;
 
 jump
@@ -76,11 +67,11 @@ assignment
   ;
 
 nextinfix
-  : nextterm antlr_0*
+  : nextterm antlr_2*
   ;
 
 infix
-  : term antlr_1*
+  : term antlr_3*
   ;
 
 isop
@@ -188,15 +179,15 @@ parampattern
   ;
 
 nextpostfix
-  : nextatom antlr_2*
+  : nextatom antlr_4*
   ;
 
 casepostfix
-  : caseatom antlr_3*
+  : caseatom antlr_5*
   ;
 
 postfix
-  : atom antlr_4*
+  : atom antlr_6*
   ;
 
 call
@@ -320,7 +311,7 @@ tupletype
   ;
 
 infixtype
-  : type antlr_5*
+  : type antlr_7*
   ;
 
 isecttype
@@ -387,31 +378,25 @@ param
   ;
 
 antlr_0
-  : binop
-  | isop
-  | 'as' type
+  : semiexpr
+  | nosemi
   ;
 
 antlr_1
+  : semiexpr
+  | nosemi
+  ;
+
+antlr_2
   : binop
   | isop
   | 'as' type
   ;
 
-antlr_2
-  : dot
-  | tilde
-  | chain
-  | typeargs
-  | call
-  ;
-
 antlr_3
-  : dot
-  | tilde
-  | chain
-  | typeargs
-  | call
+  : binop
+  | isop
+  | 'as' type
   ;
 
 antlr_4
@@ -423,6 +408,22 @@ antlr_4
   ;
 
 antlr_5
+  : dot
+  | tilde
+  | chain
+  | typeargs
+  | call
+  ;
+
+antlr_6
+  : dot
+  | tilde
+  | chain
+  | typeargs
+  | call
+  ;
+
+antlr_7
   : uniontype
   | isecttype
   ;

--- a/src/libponyc/ast/bnfprint.c
+++ b/src/libponyc/ast/bnfprint.c
@@ -12,7 +12,11 @@
  * readable and ANTLR file form. This is intended as a form of documentation,
  * as well as allowing us to use ANTLR to check for grammar errors (such as
  * ambiguities). Since the printed grammar is generated from the actual parse
- * macros we are guaranteed that it is accurate and up to date.
+ * macros it stays up to date with them. It can however be an over-
+ * approximation of the accepted language: a macro may enforce a constraint at
+ * parse time that has no grammar form (e.g. SEQ_STOP_AFTER_CHILD stops a repetition
+ * once a particular statement is seen, which the generated `*` does not
+ * express), so the grammar may admit input the parser rejects.
  *
  * We generate a BNF tree structure from the parser source. To do this we
  * define an alternative set of the parse macros defined in parserapi.h, and
@@ -838,6 +842,18 @@ static void bnf_mark_used_rules(bnf_t* tree)
 #define SEQ(desc, ...)  \
   { \
     static const char* const tokens[] = { FOREACH(STRINGIFY, __VA_ARGS__) NULL }; \
+    bnf_t* p = bnf_add(bnf_create(BNF_REPEAT), parent); \
+    p = bnf_add(bnf_create(BNF_OR), p); \
+    bnf_rule_set(p, tokens); \
+  }
+
+// The runtime terminator-token stop has no grammar analogue; render as the
+// repetition of the two rules (the trailing token args are not part of the
+// grammar).
+#define SEQ_STOP_AFTER_CHILD(desc, rule1, rule2, ...)  \
+  { \
+    static const char* const tokens[] = \
+      { STRINGIFY(rule1) STRINGIFY(rule2) NULL }; \
     bnf_t* p = bnf_add(bnf_create(BNF_REPEAT), parent); \
     p = bnf_add(bnf_create(BNF_OR), p); \
     bnf_rule_set(p, tokens); \

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -18,8 +18,6 @@ DECL(rawseq);
 DECL(seq);
 DECL(annotatedrawseq);
 DECL(annotatedseq);
-DECL(exprseq);
-DECL(nextexprseq);
 DECL(jump);
 DECL(assignment);
 DECL(term);
@@ -1090,10 +1088,16 @@ DEF(nextassignment);
   OPT_NO_DFLT RULE("value", assignop);
   DONE();
 
+// The statements that terminate a sequence: nothing may follow a jump in its
+// sequence. Shared by the jump rule and the SEQ_STOP_AFTER_CHILD loops in
+// rawseq/annotatedrawseq so the two cannot drift apart.
+#define JUMP_TOKENS \
+  TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR, TK_COMPILE_INTRINSIC, \
+  TK_COMPILE_ERROR
+
 // RETURN | BREAK | CONTINUE | ERROR | COMPILE_INTRINSIC | COMPILE_ERROR
 DEF(jump);
-  TOKEN("statement", TK_RETURN, TK_BREAK, TK_CONTINUE, TK_ERROR,
-    TK_COMPILE_INTRINSIC, TK_COMPILE_ERROR);
+  TOKEN("statement", JUMP_TOKENS);
   OPT RULE("return value", rawseq);
   DONE();
 
@@ -1104,39 +1108,42 @@ DEF(semi);
   IF(TK_NEWLINE, SET_FLAG(AST_FLAG_BAD_SEMI));
   DONE();
 
-// semi (exprseq | jump)
+// semi (assignment | jump)
+// One continuation of a statement sequence, introduced by an explicit
+// semicolon. Parses a single statement; the enclosing seq loop handles
+// repetition (see rawseq), so this is not recursive. The statement
+// (assignment | jump) must remain the last node this rule adds, because
+// rawseq's SEQ_STOP_AFTER_CHILD tests it to decide whether a jump ended the sequence.
 DEF(semiexpr);
   AST_NODE(TK_FLATTEN);
   RULE("semicolon", semi);
-  RULE("value", exprseq, jump);
+  RULE("value", assignment, jump);
   DONE();
 
-// nextexprseq | jump
+// nextassignment | jump
+// One continuation of a statement sequence with no semicolon (a newline, or an
+// illegal same-line break flagged as a missing semicolon). Parses a single
+// statement; repetition is handled by the enclosing seq loop (see rawseq). As
+// in semiexpr, the statement must remain this rule's last node for
+// SEQ_STOP_AFTER_CHILD's jump check.
 DEF(nosemi);
   IFELSE(TK_NEWLINE, NEXT_FLAGS(0), NEXT_FLAGS(AST_FLAG_MISSING_SEMI));
-  RULE("value", nextexprseq, jump);
+  RULE("value", nextassignment, jump);
   DONE();
 
-// nextassignment (semiexpr | nosemi)
-DEF(nextexprseq);
-  AST_NODE(TK_FLATTEN);
-  RULE("value", nextassignment);
-  OPT_NO_DFLT RULE("value", semiexpr, nosemi);
-  NEXT_FLAGS(0);
-  DONE();
-
-// assignment (semiexpr | nosemi)
-DEF(exprseq);
-  AST_NODE(TK_FLATTEN);
-  RULE("value", assignment);
-  OPT_NO_DFLT RULE("value", semiexpr, nosemi);
-  NEXT_FLAGS(0);
-  DONE();
-
-// (exprseq | jump)
+// (assignment | jump) {semiexpr | nosemi}
+// The sequence is parsed iteratively: a first statement followed by a loop of
+// continuations. The loop stops after a jump statement, because a jump always
+// terminates its sequence (anything after it is a syntax error). Parsing this
+// way (rather than right-recursively) keeps parser stack depth independent of
+// the number of statements (issue #3660).
 DEF(rawseq);
   AST_NODE(TK_SEQ);
-  RULE("value", exprseq, jump);
+  RULE("value", assignment, jump);
+  SEQ_STOP_AFTER_CHILD("value", semiexpr, nosemi, JUMP_TOKENS);
+  // Clear any missing-semicolon flag left pending by a final unmatched nosemi
+  // so it cannot attach to a token consumed by an enclosing rule.
+  NEXT_FLAGS(0);
   DONE();
 
 // rawseq
@@ -1145,11 +1152,14 @@ DEF(seq);
   SCOPE();
   DONE();
 
-// [annotations] (exprseq | jump)
+// [annotations] (assignment | jump) {semiexpr | nosemi}
 DEF(annotatedrawseq);
   AST_NODE(TK_SEQ);
   ANNOTATE(annotations);
-  RULE("value", exprseq, jump);
+  RULE("value", assignment, jump);
+  SEQ_STOP_AFTER_CHILD("value", semiexpr, nosemi, JUMP_TOKENS);
+  // Clear the pending missing-semicolon flag as in rawseq.
+  NEXT_FLAGS(0);
   DONE();
 
 // annotatedrawseq

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -387,6 +387,18 @@ static ast_t* handle_not_found(parser_t* parser, rule_state_t* state,
 }
 
 
+bool token_id_in_set(token_id id, const token_id* set)
+{
+  for(const token_id* p = set; *p != TK_NONE; p++)
+  {
+    if(*p == id)
+      return true;
+  }
+
+  return false;
+}
+
+
 /* Check if current token matches any in given set and consume on match.
  * Args:
  *    terminating is the description of the structure this token terminates,

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -122,6 +122,9 @@ ast_t* parse_token_set(parser_t* parser, rule_state_t* state, const char* desc,
 ast_t* parse_rule_set(parser_t* parser, rule_state_t* state, const char* desc,
   const rule_t* rule_set, bool* out_found, bool annotate);
 
+// True if id is a member of the TK_NONE-terminated set.
+bool token_id_in_set(token_id id, const token_id* set);
+
 void parse_set_next_flags(parser_t* parser, uint32_t flags);
 
 ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state);
@@ -397,6 +400,39 @@ bool parse(ast_t* package, source_t* source, rule_t start, const char* expected,
     bool found = true; \
     while(found) \
     { \
+      state.deflt_id = TK_EOF; \
+      ast_t* r = parse_rule_set(parser, &state, desc, rule_set, &found, \
+        false); \
+      if(r != PARSE_OK) return r; \
+    } \
+  }
+
+
+/** Repeatedly try to parse either of two rules, appending each result, but
+ * stop once the most recently appended child is one of the given terminator
+ * tokens. Use this to parse a list iteratively (avoiding the deep recursion of
+ * a right-recursive rule) when one kind of element must be the last in the
+ * list.
+ *
+ * The terminator check reads state.last_child, which is the element just
+ * appended. This is reliable only while each rule contributes its terminator-
+ * bearing node as the *last* node it adds to the parent (a TK_FLATTEN child is
+ * unpacked in order by default_builder, so its last grandchild wins). A rule
+ * that buries the deciding node earlier would silently defeat the stop check.
+ *
+ * Example:
+ *    SEQ_STOP_AFTER_CHILD("value", semiexpr, nosemi, TK_RETURN, TK_BREAK);
+ */
+#define SEQ_STOP_AFTER_CHILD(desc, rule1, rule2, ...) \
+  { \
+    static const token_id terminators[] = { __VA_ARGS__, TK_NONE }; \
+    static const rule_t rule_set[] = { rule1, rule2, NULL }; \
+    bool found = true; \
+    while(found) \
+    { \
+      if((state.last_child != NULL) && \
+        token_id_in_set(ast_id(state.last_child), terminators)) \
+        break; \
       state.deflt_id = TK_EOF; \
       ast_t* r = parse_rule_set(parser, &state, desc, rule_set, &found, \
         false); \

--- a/test/libponyc/parse_expr.cc
+++ b/test/libponyc/parse_expr.cc
@@ -174,3 +174,173 @@ TEST_F(ParseExprTest, BlockCommentPreservesPrecedingNewline)
 
   TEST_COMPILE(src);
 }
+
+
+// Statement sequences.
+//
+// Sequences are parsed iteratively rather than right-recursively so that parser
+// stack depth does not grow with the number of statements (issue #3660). These
+// tests pin the observable behaviour the rewrite must preserve.
+
+static bool ast_subtree_has_id(ast_t* ast, token_id id)
+{
+  if(ast == NULL)
+    return false;
+
+  if(ast_id(ast) == id)
+    return true;
+
+  for(ast_t* child = ast_child(ast); child != NULL; child = ast_sibling(child))
+  {
+    if(ast_subtree_has_id(child, id))
+      return true;
+  }
+
+  return false;
+}
+
+TEST_F(ParseExprTest, NewlineSeparatedStatements)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    let a: U64 = 1\n"
+    "    let b: U64 = 2\n"
+    "    a + b";
+
+  TEST_COMPILE(src);
+
+  // Newline-separated statements produce no semicolon node.
+  ASSERT_FALSE(ast_subtree_has_id(module, TK_SEMI));
+}
+
+TEST_F(ParseExprTest, SemicolonSeparatedStatements)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    let a: U64 = 1; let b: U64 = 2\n"
+    "    a + b";
+
+  TEST_COMPILE(src);
+
+  // An explicit semicolon is preserved as a node in the sequence.
+  ASSERT_TRUE(ast_subtree_has_id(module, TK_SEMI));
+}
+
+TEST_F(ParseExprTest, UnexpectedSemicolonBeforeNewline)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    let a: U64 = 1;\n"
+    "    a";
+
+  TEST_ERRORS_1(src,
+    "Unexpected semicolon, only use to separate expressions on the same line");
+}
+
+TEST_F(ParseExprTest, MissingSemicolonBetweenSameLineStatements)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    let a: U64 = 1 let b: U64 = 2\n"
+    "    a + b";
+
+  TEST_ERRORS_1(src,
+    "Use a semi colon to separate expressions on the same line");
+}
+
+TEST_F(ParseExprTest, JumpTerminatesSequence)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    let a: U64 = 1\n"
+    "    return a";
+
+  TEST_COMPILE(src);
+}
+
+// A jump ends its sequence, so a semicolon after one is a syntax error rather
+// than the start of another statement. The return takes no value (the
+// semicolon stops it absorbing one), so the trailing "; a" is left over.
+TEST_F(ParseExprTest, SemicolonAfterJumpRejected)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    let a: U64 = 1; return; a";
+
+  TEST_ERRORS_1(src, "unexpected token ;");
+}
+
+// Termination applies to every jump keyword, not just return. error ends its
+// sequence too, so the trailing "; a" is left over and rejected.
+TEST_F(ParseExprTest, SemicolonAfterErrorRejected)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    let a: U64 = 1; error; a";
+
+  TEST_ERRORS_1(src, "unexpected token ;");
+}
+
+// break terminates its sequence, so the trailing "; a" is left over and the
+// enclosing loop never reaches its end keyword.
+TEST_F(ParseExprTest, SemicolonAfterBreakRejected)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    while true do break; a end";
+
+  TEST_ERRORS_1(src, "unterminated while loop");
+}
+
+// The same iterative loop drives an annotated sequence (a try/match else body).
+// A jump terminates it too, so the trailing "; a" is left over and the try's
+// end keyword is never reached.
+TEST_F(ParseExprTest, JumpTerminatesAnnotatedSequence)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    try error else return; a end";
+
+  TEST_ERRORS_1(src, "unterminated try expression");
+}
+
+// A parenthesised expression is a single-statement sequence whose ')' sits on
+// the same line, so the sequence parse sets a pending missing-semicolon flag
+// that must be cleared. Without the clear the ')' (or a following token) gets
+// the flag and a spurious "use a semi colon" error fires.
+TEST_F(ParseExprTest, ParenthesisedSequenceDoesNotLeakMissingSemicolon)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m(): U64 =>\n"
+    "    (1)";
+
+  TEST_COMPILE(src);
+}
+
+// Regression test for #3660: a long statement sequence must not overflow the
+// parser stack. The old right-recursive grammar recursed once per statement; a
+// regression to it fails this test by overflowing the stack (a crash that
+// fails the run), not by a clean assertion. 50000 is well above the old
+// overflow point at the default test stack size.
+TEST_F(ParseExprTest, LongSequenceDoesNotOverflowParser)
+{
+  std::string src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    var x: U64 = 0\n";
+
+  for(size_t i = 0; i < 50000; i++)
+    src += "    x = x + 1\n";
+
+  TEST_COMPILE(src.c_str());
+}


### PR DESCRIPTION
The parser built statement sequences with a right-recursive grammar, so a long sequence -- a large array or tuple literal, a long argument list, or a big generated function body -- grew the parser's call stack one frame per expression and eventually overflowed it, crashing the compiler.

This reworks statement-sequence parsing to be iterative, so parser stack depth no longer grows with the number of expressions in a sequence. The accepted language and the produced AST are unchanged -- verified by comparing the parse output across the whole standard library against the previous compiler -- and the change is covered by new parser tests, including a long-sequence regression guard.

Closes #3660