### PR TITLE
Add missing break in multicast_change's AF_INET6 case

### DIFF
--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -1488,6 +1488,7 @@ static void multicast_change(int fd, const char* group, const char* to,
       else
         setsockopt(s, IPPROTO_IPV6, IPV6_LEAVE_GROUP, (const char*)&req,
           sizeof(req));
+      break;
     }
 
     default: {}


### PR DESCRIPTION
In `src/libponyrt/lang/socket.c`, `multicast_change`'s `AF_INET` case ends with a `break`, but the `AF_INET6` case fell through into the empty `default: {}`. It's harmless today because `default:` does nothing, but anything later added to `default:` would silently run after the IPv6 join/leave path. Adding the `break` makes the two arms consistent and closes the gap.

Closes #5546