### PR TITLE
Update supported FreeBSD 15 to 15.1

### DIFF
--- a/.claude/skills/create-freebsd-dev-env/SKILL.md
+++ b/.claude/skills/create-freebsd-dev-env/SKILL.md
@@ -114,7 +114,7 @@ is OS-agnostic, so macOS goes through the same steps with the HVF accelerator
 
 Pick a persistent VM directory and a FreeBSD version that **matches ponyc CI** (the tier-3
 `freebsd` job in `.github/workflows/ponyc-tier3.yml` runs a matrix — currently 14.3 and
-15.0; the image URL is in `.ci-scripts/bsd/freebsd-provision.bash`). Use the same two
+15.1; the image URL is in `.ci-scripts/bsd/freebsd-provision.bash`). Use the same two
 values in every block below.
 
 ### 1. Download the image (one time; keep the `.xz` to avoid re-downloading)

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -251,8 +251,8 @@ jobs:
         include:
           - version: '14.3'
             name: x86-64 FreeBSD 14.3
-          - version: '15.0'
-            name: x86-64 FreeBSD 15.0
+          - version: '15.1'
+            name: x86-64 FreeBSD 15.1
 
     name: ${{ matrix.name }}
     steps:
@@ -306,7 +306,7 @@ jobs:
           EOF
       - name: Valgrind smoke
         # FreeBSD 14.3 only: Valgrind 3.26 there runs a Pony program to
-        # completion; 15.0 is unverified, so it doesn't gate the matrix. Its own
+        # completion; 15.1 is unverified, so it doesn't gate the matrix. Its own
         # step so the matrix-version `if` can scope it — the script does its own
         # clean+configure+build, so it's self-contained.
         if: matrix.version == '14.3'

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -250,8 +250,8 @@ jobs:
         include:
           - version: '14.3'
             name: x86-64 FreeBSD 14.3
-          - version: '15.0'
-            name: x86-64 FreeBSD 15.0
+          - version: '15.1'
+            name: x86-64 FreeBSD 15.1
 
     name: ${{ matrix.name }}
     steps:

--- a/.release-notes/freebsd-15-1.md
+++ b/.release-notes/freebsd-15-1.md
@@ -1,0 +1,3 @@
+## Update supported FreeBSD 15 to 15.1
+
+We've moved our supported FreeBSD 15 release from 15.0 to 15.1. ponyc is now built and tested against FreeBSD 15.1.


### PR DESCRIPTION
FreeBSD 15.1 is now available. This switches the tier-3 FreeBSD 15 test leg and the libs-cache warmer's FreeBSD 15 platform from 15.0 to 15.1.

They move in lockstep because the BSD legs pull per-version libs-cache labels (`freebsd-15.0`); if only the test leg moved, the 15.1 leg would pull a cache miss and cold-build LLVM on every run. The provision script is version-parameterized, so it pulls the 15.1 image automatically. The Valgrind smoke stays pinned to 14.3.

Closes #5543
