### PR TITLE
Add a streaming JSON parser

### DIFF
--- a/.release-notes/add-streaming-json-parser.md
+++ b/.release-notes/add-streaming-json-parser.md
@@ -1,0 +1,17 @@
+## Add a streaming JSON parser
+
+`JsonStreamParser` parses JSON incrementally: feed it bytes as they arrive with `feed()` and call `pull()` to take complete top-level values one at a time, without buffering the whole input first. It returns the same `JsonValue` as `JsonParser`, so streamed values work with `JsonNav`, `JsonLens`, `JsonPath`, and `JsonPrinter` unchanged.
+
+```pony
+use "json"
+
+let parser = JsonStreamParser
+parser.feed(chunk)
+match parser.pull()
+| let v: JsonValue      => // a complete top-level value
+| JsonNeedMore          => // feed more bytes, then pull() again
+| let e: JsonParseError => // malformed input
+end
+```
+
+It handles a stream of top-level object/array values: a single document yields one value, while a sequence (object-per-line newline-delimited JSON, concatenated values, a socket delivering messages) yields each value as it completes, with no per-document setup. Each top-level value must be an object or array; a bare scalar (including a scalar NDJSON line) is not supported. `JsonNeedMore` is the explicit "incomplete, not yet malformed" outcome — a value split across a chunk boundary yields `JsonNeedMore` rather than an error, so feeding the rest later completes it. For untrusted input, `JsonStreamLimits` caps per-value nesting depth, string length, number length, and total size.

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -1,7 +1,8 @@
 # json
 
 Demonstrates the standard library JSON package: building JSON documents,
-parsing JSON text, reading values with `JsonNav`, composable paths with
+parsing JSON text, incremental parsing of a chunked stream with
+`JsonStreamParser`, reading values with `JsonNav`, composable paths with
 `JsonLens`, string-based queries with `JsonPath` (including filters and
 function extensions), and serialization.
 

--- a/examples/json/main.pony
+++ b/examples/json/main.pony
@@ -14,6 +14,10 @@ actor Main
     _parse_example(env)
     env.out.print("")
 
+    env.out.print("=== Streaming Parse (JsonStreamParser) ===")
+    _stream_example(env)
+    env.out.print("")
+
     env.out.print("=== Navigation (JsonNav) ===")
     _nav_example(env)
     env.out.print("")
@@ -92,6 +96,39 @@ actor Main
     | let err: json.JsonParseError =>
       env.out.print("Parse error: " + err.string())
     end
+
+  fun _stream_example(env: Env) =>
+    // JsonStreamParser parses a stream of top-level values incrementally: feed
+    // bytes as they arrive and pull complete JsonValues as they finish. Here a
+    // two-document stream is split into chunks to simulate arrival over a
+    // network — the parser holds position across the chunk boundaries, and the
+    // values it returns are ordinary JsonValues usable with the rest of the API.
+    let chunks =
+      [ """{"user":"Bo"""
+        """b","age":3"""
+        """0,"roles":["adm"""
+        """in","dev"]} {"user":"Carol","age":35,"roles":[]}""" ]
+
+    let parser = json.JsonStreamParser
+    var count: USize = 0
+    for chunk in chunks.values() do
+      parser.feed(chunk)
+      var draining = true
+      while draining do
+        match parser.pull()
+        | let v: json.JsonValue =>
+          count = count + 1
+          env.out.print("  value " + count.string() + ": "
+            + json.JsonPrinter.print(v))
+        | json.JsonNeedMore =>
+          draining = false // need more bytes; feed the next chunk
+        | let e: json.JsonParseError =>
+          env.out.print("  parse error: " + e.string())
+          draining = false
+        end
+      end
+    end
+    env.out.print("Parsed " + count.string() + " values from the stream")
 
   fun _nav_example(env: Env) =>
     let source =

--- a/packages/json/_json_stream.pony
+++ b/packages/json/_json_stream.pony
@@ -1,0 +1,204 @@
+// Internal support types for JsonStreamParser: the grammar frame stack, the
+// suspendable leaf-scan state, and a standalone number parser.
+
+primitive _StepGo
+  """Dispatch made progress within a value; keep looping in pull()."""
+
+primitive _ScanComplete
+primitive _ScanNeedMore
+type _ScanOutcome is (_ScanComplete | _ScanNeedMore | JsonParseError)
+
+// --- grammar frames ------------------------------------------------------
+//
+// One frame per open container, holding the grammar sub-position. The position
+// is split so that a post-comma state forbids the closing delimiter, which is
+// how trailing commas (`[1,]`, `{"a":1,}`) are rejected.
+
+primitive _ArrValueOrEnd  // after '['; a value or ']'
+primitive _ArrValue       // after ','; a value is required, ']' is illegal
+primitive _ArrCommaOrEnd  // after a value; ',' or ']'
+type _ArrPos is (_ArrValueOrEnd | _ArrValue | _ArrCommaOrEnd)
+
+primitive _ObjKeyOrEnd    // after '{'; a key or '}'
+primitive _ObjKey         // after ','; a key is required, '}' is illegal
+primitive _ObjColon       // after a key; ':'
+primitive _ObjValue       // after ':'; a value
+primitive _ObjCommaOrEnd  // after a value; ',' or '}'
+type _ObjPos is
+  (_ObjKeyOrEnd | _ObjKey | _ObjColon | _ObjValue | _ObjCommaOrEnd)
+
+class _ArrayFrame
+  var pos: _ArrPos
+  new create(pos': _ArrPos) => pos = pos'
+
+class _ObjectFrame
+  var pos: _ObjPos
+  new create(pos': _ObjPos) => pos = pos'
+
+type _StreamFrame is (_ArrayFrame | _ObjectFrame)
+
+// --- leaf scans ----------------------------------------------------------
+//
+// State held across pull() calls while a scalar is being scanned, so a value
+// split across a chunk boundary resumes exactly where it stopped.
+
+primitive _StrNormal
+primitive _StrEscape
+primitive _StrUnicode
+type _StrPhase is (_StrNormal | _StrEscape | _StrUnicode)
+
+class _StringScan
+  let is_key: Bool
+  var buf: String iso
+  var phase: _StrPhase
+  var hex_value: U32
+  var hex_count: U8
+  var pending_high: (U32 | None)
+
+  new create(is_key': Bool) =>
+    is_key = is_key'
+    buf = recover iso String end
+    phase = _StrNormal
+    hex_value = 0
+    hex_count = 0
+    pending_high = None
+
+class _NumberScan
+  let buf: String ref
+
+  new create() =>
+    buf = String
+
+class _KeywordScan
+  let word: String
+  let value: JsonValue
+  var matched: USize
+
+  new create(word': String, value': JsonValue) =>
+    word = word'
+    value = value'
+    matched = 0
+
+type _LeafScan is (_StringScan | _NumberScan | _KeywordScan)
+
+// --- number parsing ------------------------------------------------------
+
+primitive _NumberMalformed
+
+primitive _NumberParse
+  """
+  Parse a number from its complete text, applying the same RFC 8259 rules as the
+  batch JsonTokenParser (leading-zero rejection, >18 integer digits force F64,
+  fraction and exponent handling) so streaming and batch agree on every number.
+  """
+  fun apply(s: String box): (I64 | F64 | _NumberMalformed) =>
+    let n = s.size()
+    if n == 0 then return _NumberMalformed end
+
+    var i: USize = 0
+    var sign: I64 = 1
+    if try s(0)? == '-' else false end then
+      sign = -1
+      i = 1
+    end
+
+    // integer part
+    let int_start = i
+    var integer: I64 = 0
+    var int_digits: USize = 0
+    try
+      while i < n do
+        let c = s(i)?
+        if (c >= '0') and (c <= '9') then
+          integer = (integer * 10) + (c - '0').i64()
+          i = i + 1
+          int_digits = int_digits + 1
+        else
+          break
+        end
+      end
+    end
+    if int_digits == 0 then return _NumberMalformed end
+    if (int_digits > 1) and (try s(int_start)? == '0' else false end) then
+      return _NumberMalformed // leading zero
+    end
+    let force_float = int_digits > 18
+
+    // fractional part
+    var has_dot = false
+    var frac: F64 = 0
+    if (i < n) and (try s(i)? == '.' else false end) then
+      has_dot = true
+      i = i + 1
+      var divisor: F64 = 10
+      var frac_digits: USize = 0
+      try
+        while i < n do
+          let c = s(i)?
+          if (c >= '0') and (c <= '9') then
+            frac = frac + ((c - '0').f64() / divisor)
+            divisor = divisor * 10
+            i = i + 1
+            frac_digits = frac_digits + 1
+          else
+            break
+          end
+        end
+      end
+      if frac_digits == 0 then return _NumberMalformed end
+    end
+
+    // exponent part
+    var has_exp = false
+    var exp: I64 = 0
+    if (i < n)
+      and (try (s(i)? == 'e') or (s(i)? == 'E') else false end)
+    then
+      has_exp = true
+      i = i + 1
+      var exp_sign: I64 = 1
+      if i < n then
+        match try s(i)? else U8(0) end
+        | '+' => i = i + 1
+        | '-' => exp_sign = -1; i = i + 1
+        end
+      end
+      var exp_digits: USize = 0
+      try
+        while i < n do
+          let c = s(i)?
+          if (c >= '0') and (c <= '9') then
+            exp = (exp * 10) + (c - '0').i64()
+            i = i + 1
+            exp_digits = exp_digits + 1
+          else
+            break
+          end
+        end
+      end
+      if exp_digits == 0 then return _NumberMalformed end
+      exp = exp * exp_sign
+    end
+
+    // any leftover bytes mean the text was not a valid number
+    if i != n then return _NumberMalformed end
+
+    if has_dot or has_exp or force_float then
+      let integer_f64 =
+        if force_float then
+          var r: F64 = 0
+          try
+            var j = int_start
+            while j < (int_start + int_digits) do
+              r = (r * 10) + (s(j)? - '0').f64()
+              j = j + 1
+            end
+          end
+          r
+        else
+          integer.f64()
+        end
+      sign.f64() * (integer_f64 + frac) * F64(10).pow(exp.f64())
+    else
+      sign * integer
+    end

--- a/packages/json/_stream_test.pony
+++ b/packages/json/_stream_test.pony
@@ -338,7 +338,7 @@ class \nodoc\ iso _TestStreamLimits is UnitTest
     _reject(h, JsonStreamLimits(where max_value_bytes' = 4), "[1,2,3]")
     _accept(h, JsonStreamLimits(where max_value_bytes' = 7), "[1,2,3]")
     // a raised max_depth lifts the default bound: 9000-deep nesting exceeds the
-    // default max_depth (8192), so the default rejects it while max_depth'=10000
+    // default max_depth (1024), so the default rejects it while max_depth'=10000
     // accepts it.
     let s = String
     var i: USize = 0

--- a/packages/json/_stream_test.pony
+++ b/packages/json/_stream_test.pony
@@ -1,0 +1,580 @@
+use "pony_test"
+use "pony_check"
+
+primitive \nodoc\ _StreamHelp
+  """Test helpers for driving JsonStreamParser."""
+  fun drain(p: JsonStreamParser, out: Array[JsonValue]): (None | JsonParseError)
+  =>
+    var go = true
+    var err: (None | JsonParseError) = None
+    while go do
+      match p.pull()
+      | let v: JsonValue => out.push(v)
+      | JsonNeedMore => go = false
+      | let e: JsonParseError => err = e; go = false
+      end
+    end
+    err
+
+  fun all(input: String): (Array[JsonValue] | JsonParseError) =>
+    """Feed `input` as a single chunk and collect all complete values."""
+    let p = JsonStreamParser
+    p.feed(input)
+    let out = Array[JsonValue]
+    match drain(p, out)
+    | let e: JsonParseError => e
+    else out
+    end
+
+  fun split(input: String, n: USize): (Array[JsonValue] | JsonParseError) =>
+    """Feed `input` in chunks of `n` bytes, collecting values as they complete."""
+    let p = JsonStreamParser
+    let out = Array[JsonValue]
+    var i: USize = 0
+    while i < input.size() do
+      let upper = (i + n).min(input.size())
+      p.feed(input.trim(i, upper))
+      match drain(p, out)
+      | let e: JsonParseError => return e
+      end
+      i = upper
+    end
+    out
+
+  fun render(values: Array[JsonValue] box): String =>
+    """Canonical text of a value list, for structural equality comparison."""
+    let s = String
+    for v in values.values() do
+      s.append(JsonPrinter.print(v))
+      s.push('\n')
+    end
+    s.clone()
+
+class \nodoc\ iso _TestStreamObject is UnitTest
+  fun name(): String => "json/stream/object"
+
+  fun apply(h: TestHelper) ? =>
+    match _StreamHelp.all("""{"a":1,"b":true,"c":null,"d":"hi"}""")
+    | let vs: Array[JsonValue] =>
+      h.assert_eq[USize](1, vs.size())
+      let nav = JsonNav(vs(0)?)
+      h.assert_eq[I64](1, nav("a").as_i64()?)
+      h.assert_eq[Bool](true, nav("b").as_bool()?)
+      nav("c").as_null()? // a JSON null (raises if not null)
+      h.assert_eq[String]("hi", nav("d").as_string()?)
+    | let e: JsonParseError => h.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamArray is UnitTest
+  fun name(): String => "json/stream/array"
+
+  fun apply(h: TestHelper) ? =>
+    match _StreamHelp.all("[1,2,3]")
+    | let vs: Array[JsonValue] =>
+      h.assert_eq[USize](1, vs.size())
+      let arr = JsonNav(vs(0)?).as_array()?
+      h.assert_eq[USize](3, arr.size())
+      h.assert_eq[I64](2, JsonNav(arr(1)?).as_i64()?)
+    | let e: JsonParseError => h.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamEmptyContainers is UnitTest
+  fun name(): String => "json/stream/empty-containers"
+
+  fun apply(h: TestHelper) ? =>
+    match _StreamHelp.all("""{} [] [[]] {"a":{}}""")
+    | let vs: Array[JsonValue] =>
+      h.assert_eq[USize](4, vs.size())
+      h.assert_eq[USize](0, JsonNav(vs(0)?).as_object()?.size())
+      h.assert_eq[USize](0, JsonNav(vs(1)?).as_array()?.size())
+      h.assert_eq[USize](1, JsonNav(vs(2)?).as_array()?.size())
+      h.assert_eq[USize](0, JsonNav(vs(3)?)("a").as_object()?.size())
+    | let e: JsonParseError => h.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamMultiValue is UnitTest
+  fun name(): String => "json/stream/multi-value"
+
+  fun apply(h: TestHelper) ? =>
+    match _StreamHelp.all("""{"a":1} {"b":2} [3]""")
+    | let vs: Array[JsonValue] =>
+      h.assert_eq[USize](3, vs.size())
+      h.assert_eq[I64](1, JsonNav(vs(0)?)("a").as_i64()?)
+      h.assert_eq[I64](2, JsonNav(vs(1)?)("b").as_i64()?)
+      h.assert_eq[I64](3, JsonNav(vs(2)?)(USize(0)).as_i64()?)
+    | let e: JsonParseError => h.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamNeedMore is UnitTest
+  fun name(): String => "json/stream/need-more"
+
+  fun apply(h: TestHelper) ? =>
+    let p = JsonStreamParser
+    p.feed("""{"a":""")
+    match p.pull()
+    | JsonNeedMore => None
+    else h.fail("expected JsonNeedMore on incomplete value")
+    end
+    p.feed("1}")
+    match p.pull()
+    | let v: JsonValue => h.assert_eq[I64](1, JsonNav(v)("a").as_i64()?)
+    else h.fail("expected a value after the rest arrived")
+    end
+
+class \nodoc\ iso _TestStreamSplitInvariance is UnitTest
+  """The token stream must be identical regardless of where chunks are split."""
+  fun name(): String => "json/stream/split-invariance"
+
+  fun apply(h: TestHelper) =>
+    let input =
+      """{"name":"alice","tags":["x","y"],"n":-12.5e3,"nested":{"deep":[true,null]},"u":"sm😀ile\n\t"} [1,2,{"k":false}]"""
+    let whole =
+      match _StreamHelp.all(input)
+      | let vs: Array[JsonValue] => _StreamHelp.render(vs)
+      | let e: JsonParseError => h.fail("whole parse failed: " + e.string()); ""
+      end
+    for n in [as USize: 1; 2; 3; 5; 7; 13].values() do
+      match _StreamHelp.split(input, n)
+      | let vs: Array[JsonValue] =>
+        h.assert_eq[String](whole, _StreamHelp.render(vs)
+          where msg = "mismatch at chunk size " + n.string())
+      | let e: JsonParseError =>
+        h.fail("split parse failed at chunk size " + n.string()
+          + ": " + e.string())
+      end
+    end
+
+class \nodoc\ iso _TestStreamEscapes is UnitTest
+  fun name(): String => "json/stream/escapes"
+
+  fun apply(h: TestHelper) ? =>
+    // Every C-style escape, a BMP \uXXXX escape, and a \uXXXX surrogate pair —
+    // decoded the same as the batch parser. (The triple-quoted literal is not
+    // escape-processed by Pony, so \", \uD83D, etc. reach the parser verbatim.)
+    let input = """{"s":"q\"b\\s\/f\b\f\n\r\t\u00E9-\uD83D\uDE00"}"""
+    let expected =
+      match JsonParser.parse(input)
+      | let v: JsonValue => JsonNav(v)("s").as_string()?
+      | let e: JsonParseError => h.fail("batch failed: " + e.string()); ""
+      end
+    // Split at size 1 forces the scanner to suspend mid-escape, mid-\uXXXX hex,
+    // and between the two \u of the surrogate pair.
+    match _StreamHelp.split(input, 1)
+    | let vs: Array[JsonValue] =>
+      h.assert_eq[String](expected, JsonNav(vs(0)?)("s").as_string()?)
+    | let e: JsonParseError => h.fail("stream failed: " + e.string())
+    end
+
+    // Invalid/lone surrogates are rejected by the streaming parser too.
+    for bad in
+      [ """["\uD800"]"""; """["\uDC00"]"""; """["\uD800A"]""" ].values()
+    do
+      match _StreamHelp.all(bad)
+      | let v2: Array[JsonValue] => h.fail("expected a surrogate error: " + bad)
+      | let e2: JsonParseError => None
+      end
+    end
+
+class \nodoc\ iso _TestStreamNumbers is UnitTest
+  fun name(): String => "json/stream/numbers"
+
+  fun apply(h: TestHelper) ? =>
+    match _StreamHelp.all("[0,-1,42,3.14,-2.5e-3,1E10,123456789012345678901]")
+    | let vs: Array[JsonValue] =>
+      let a = JsonNav(vs(0)?).as_array()?
+      h.assert_eq[I64](0, JsonNav(a(0)?).as_i64()?)
+      h.assert_eq[I64](-1, JsonNav(a(1)?).as_i64()?)
+      h.assert_eq[I64](42, JsonNav(a(2)?).as_i64()?)
+      h.assert_eq[F64](3.14, JsonNav(a(3)?).as_f64()?)
+      h.assert_eq[F64](-2.5e-3, JsonNav(a(4)?).as_f64()?) // negative exponent
+      h.assert_eq[F64](1e10, JsonNav(a(5)?).as_f64()?)    // uppercase E
+      // >18 digit integer is forced to F64
+      h.assert_true(JsonNav(a(6)?).as_f64()? > 1.0e20)
+    | let e: JsonParseError => h.fail("unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamNumberForms is UnitTest
+  """Streaming numbers decode to the exact expected value, and rejects hold."""
+  fun name(): String => "json/stream/number-forms"
+
+  fun apply(h: TestHelper) ? =>
+    // Assert the exact decoded value (not a printed form), so a divergence
+    // below printer precision cannot hide.
+    h.assert_eq[I64](0, _i64(h, "[0]")?)
+    h.assert_eq[I64](0, _i64(h, "[-0]")?)
+    // 18 integer digits stay I64 (max 18-digit < I64.max)
+    h.assert_eq[I64](123456789012345678, _i64(h, "[123456789012345678]")?)
+    h.assert_eq[F64](0.0, _f64(h, "[0e0]")?)
+    h.assert_eq[F64](1e10, _f64(h, "[1E10]")?)   // uppercase E
+    h.assert_eq[F64](-2.5e-3, _f64(h, "[-2.5e-3]")?) // signed exponent
+    // 19 digits force F64 — assert stream agrees with the batch parse
+    _agree(h, "[1234567890123456789]")
+
+    // malformed numbers (the over-consume-then-validate path) must be rejected
+    for bad in
+      [ "[1-2]"; "[1.2.3]"; "[1e]"; "[.5]"; "[+5]"; "[--1]"; "[1.]"; "[01]"
+        "[1e+e1]" ].values()
+    do
+      match _StreamHelp.all(bad)
+      | let vs: Array[JsonValue] => h.fail("expected a number error: " + bad)
+      | let e: JsonParseError => None
+      end
+    end
+
+  fun _i64(h: TestHelper, doc: String): I64 ? =>
+    match _StreamHelp.all(doc)
+    | let vs: Array[JsonValue] => JsonNav(vs(0)?)(USize(0)).as_i64()?
+    | let e: JsonParseError => h.fail(doc + ": " + e.string()); error
+    end
+
+  fun _f64(h: TestHelper, doc: String): F64 ? =>
+    match _StreamHelp.all(doc)
+    | let vs: Array[JsonValue] => JsonNav(vs(0)?)(USize(0)).as_f64()?
+    | let e: JsonParseError => h.fail(doc + ": " + e.string()); error
+    end
+
+  fun _agree(h: TestHelper, doc: String) =>
+    let batch =
+      match JsonParser.parse(doc)
+      | let v: JsonValue => JsonPrinter.print(v)
+      | let e: JsonParseError => h.fail("batch failed on " + doc); ""
+      end
+    match _StreamHelp.all(doc)
+    | let vs: Array[JsonValue] =>
+      if vs.size() == 1 then
+        try h.assert_eq[String](batch, JsonPrinter.print(vs(0)?)) end
+      else
+        h.fail("expected exactly one value for " + doc)
+      end
+    | let e: JsonParseError => h.fail("stream failed on " + doc)
+    end
+
+class \nodoc\ iso _TestStreamTrailingComma is UnitTest
+  fun name(): String => "json/stream/trailing-comma"
+
+  fun apply(h: TestHelper) =>
+    _expect_error(h, "[1,]")
+    _expect_error(h, """{"a":1,}""")
+    _expect_error(h, "[1,2,]")
+
+  fun _expect_error(h: TestHelper, input: String) =>
+    match _StreamHelp.all(input)
+    | let vs: Array[JsonValue] =>
+      h.fail("expected error for: " + input)
+    | let e: JsonParseError => None
+    end
+
+class \nodoc\ iso _TestStreamMalformed is UnitTest
+  fun name(): String => "json/stream/malformed"
+
+  fun apply(h: TestHelper) =>
+    for bad in
+      [ """{"a":}"""; """{,}"""; """{"a" 1}"""; """[1 2]"""; """{"a":1 "b":2}"""
+        """[treu]"""; """[nul]"""; """[1,,2]"""; """{"a":1]""" ].values()
+    do
+      match _StreamHelp.all(bad)
+      | let vs: Array[JsonValue] => h.fail("expected error for: " + bad)
+      | let e: JsonParseError => None
+      end
+    end
+
+class \nodoc\ iso _TestStreamScalarRootRejected is UnitTest
+  """Top-level values must be containers; bare scalars are out of scope."""
+  fun name(): String => "json/stream/scalar-root-rejected"
+
+  fun apply(h: TestHelper) =>
+    for bad in ["42"; """"hi"""" ; "true"; "null"; "  3.14  "].values() do
+      match _StreamHelp.all(bad)
+      | let vs: Array[JsonValue] => h.fail("expected error for scalar: " + bad)
+      | let e: JsonParseError => None
+      end
+    end
+
+class \nodoc\ iso _TestStreamErrorLatches is UnitTest
+  fun name(): String => "json/stream/error-latches"
+
+  fun apply(h: TestHelper) =>
+    let p = JsonStreamParser
+    p.feed("""{"a":}""")
+    match p.pull()
+    | let e: JsonParseError => None
+    else h.fail("expected an error")
+    end
+    // latched: further pulls keep returning the error, even after feeding more
+    p.feed("""{"b":2}""")
+    match p.pull()
+    | let e: JsonParseError => None
+    else h.fail("error did not latch")
+    end
+
+class \nodoc\ iso _TestStreamLimitDepth is UnitTest
+  fun name(): String => "json/stream/limit-depth"
+
+  fun apply(h: TestHelper) =>
+    let limits = JsonStreamLimits(where max_depth' = 3)
+    let p = JsonStreamParser(limits)
+    p.feed("[[[[1]]]]") // depth 4 > 3
+    match p.pull()
+    | let e: JsonParseError => None
+    else h.fail("expected a depth-limit error")
+    end
+    // depth exactly at the limit is fine
+    match _StreamHelp.all("[[[1]]]")
+    | let vs: Array[JsonValue] => h.assert_eq[USize](1, vs.size())
+    | let e: JsonParseError => h.fail("depth 3 should be allowed: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamLimits is UnitTest
+  fun name(): String => "json/stream/limits"
+
+  fun apply(h: TestHelper) =>
+    // max_string_len (tight: a string of exactly the limit is accepted, +1 not)
+    _accept(h, JsonStreamLimits(where max_string_len' = 4), """["abcd"]""")
+    _reject(h, JsonStreamLimits(where max_string_len' = 4), """["abcde"]""")
+    // max_number_len (tight: a number of exactly the limit is accepted, +1 not)
+    _accept(h, JsonStreamLimits(where max_number_len' = 5), "[12345]")
+    _reject(h, JsonStreamLimits(where max_number_len' = 5), "[123456]")
+    // max_value_bytes (whole value is 7 bytes)
+    _reject(h, JsonStreamLimits(where max_value_bytes' = 4), "[1,2,3]")
+    _accept(h, JsonStreamLimits(where max_value_bytes' = 7), "[1,2,3]")
+    // a raised max_depth lifts the default bound: 9000-deep nesting exceeds the
+    // default max_depth (8192), so the default rejects it while max_depth'=10000
+    // accepts it.
+    let s = String
+    var i: USize = 0
+    while i < 9000 do s.push('['); i = i + 1 end
+    i = 0
+    while i < 9000 do s.push(']'); i = i + 1 end
+    let deep: String = s.clone()
+    _reject(h, JsonStreamLimits, deep)
+    _accept(h, JsonStreamLimits(where max_depth' = 10000), deep)
+
+    // whitespace before/between values must not count toward the value budget
+    let p = JsonStreamParser(JsonStreamLimits(where max_value_bytes' = 3))
+    p.feed("   [1]      [2]") // each value 3 bytes; spaces around/between
+    let out = Array[JsonValue]
+    match _StreamHelp.drain(p, out)
+    | let e: JsonParseError =>
+      h.fail("whitespace counted against the value budget: " + e.string())
+    end
+    h.assert_eq[USize](2, out.size())
+
+    // a limit is enforced even when the value is split across chunks, with no
+    // single chunk exceeding the cap
+    let cp = JsonStreamParser(JsonStreamLimits(where max_string_len' = 6))
+    cp.feed("[\"abc")  // 3 string bytes so far
+    cp.feed("defg\"]") // "abcdefg" is 7 > 6
+    match _StreamHelp.drain(cp, Array[JsonValue])
+    | None => h.fail("max_string_len not enforced across a chunk boundary")
+    end
+
+  fun _reject(h: TestHelper, limits: JsonStreamLimits, input: String) =>
+    let p = JsonStreamParser(limits)
+    p.feed(input)
+    match _StreamHelp.drain(p, Array[JsonValue])
+    | None => h.fail("expected a limit error for: " + input)
+    end
+
+  fun _accept(h: TestHelper, limits: JsonStreamLimits, input: String) =>
+    let p = JsonStreamParser(limits)
+    p.feed(input)
+    let out = Array[JsonValue]
+    match _StreamHelp.drain(p, out)
+    | let e: JsonParseError =>
+      h.fail("unexpected error for " + input + ": " + e.string())
+    end
+    h.assert_true(out.size() >= 1, "expected a value for: " + input)
+
+class \nodoc\ iso _TestStreamDefaultDepthPrintable is UnitTest
+  """
+  A value nested at the default max_depth must survive the recursive consumers.
+
+  The parser is iterative (an explicit frame stack), so it never overflows the
+  native stack no matter how deep the input. But `JsonPrinter` and `JsonNav`
+  recurse over the assembled tree, and the native stack is finite. The default
+  `max_depth` exists to keep a streamed value safe to hand to those APIs, so
+  this round-trips a doc nested exactly at the default cap through the parser
+  and back out through the compact printer (which recurses the full depth). If
+  a platform's scheduler-thread stack can't take the default depth, this is the
+  test that fails — loudly — rather than a user's program crashing in the field.
+  """
+  fun name(): String => "json/stream/default_depth_printable"
+
+  fun apply(h: TestHelper) =>
+    let limits: JsonStreamLimits = JsonStreamLimits
+    let depth = limits.max_depth
+    let doc = String((depth * 2) + 1)
+    var i: USize = 0
+    while i < depth do doc.push('['); i = i + 1 end
+    i = 0
+    while i < depth do doc.push(']'); i = i + 1 end
+    let input: String val = doc.clone()
+
+    let p = JsonStreamParser // default limits
+    p.feed(input)
+    match p.pull()
+    | let v: JsonValue =>
+      // A deep array of empty arrays prints back to its exact source, so an
+      // exact round-trip confirms both the parse and the recursive descent
+      // survived the full depth.
+      h.assert_eq[String val](input, JsonPrinter.print(v))
+    | JsonNeedMore =>
+      h.fail("a doc at the default max_depth should parse, got JsonNeedMore")
+    | let e: JsonParseError =>
+      h.fail("a doc at the default max_depth errored: " + e.string())
+    end
+
+class \nodoc\ iso _TestStreamProtocol is UnitTest
+  """feed/pull lifecycle edges."""
+  fun name(): String => "json/stream/protocol"
+
+  fun apply(h: TestHelper) ? =>
+    // pull() before any feed() is JsonNeedMore, not an error
+    match JsonStreamParser.pull()
+    | JsonNeedMore => None
+    else h.fail("pull() before feed() should be JsonNeedMore")
+    end
+
+    // empty feeds are harmless no-ops; a real chunk still parses
+    let q = JsonStreamParser
+    q.feed("")
+    q.feed("[1]")
+    q.feed("")
+    match q.pull()
+    | let v: JsonValue => h.assert_eq[USize](1, JsonNav(v).as_array()?.size())
+    else h.fail("empty feeds should not disturb parsing")
+    end
+
+    // a complete value followed by garbage: the value is returned, then the
+    // next pull() latches an error (the design's named example)
+    let p = JsonStreamParser
+    p.feed("[1,2,3] x")
+    match p.pull()
+    | let v: JsonValue => h.assert_eq[USize](3, JsonNav(v).as_array()?.size())
+    else h.fail("expected the leading value")
+    end
+    match p.pull()
+    | let e: JsonParseError => None
+    else h.fail("expected an error on the trailing garbage")
+    end
+
+class \nodoc\ iso _TestStreamErrorLocation is UnitTest
+  """A parse error reports byte offset and line absolute across all fed chunks."""
+  fun name(): String => "json/stream/error-location"
+
+  fun apply(h: TestHelper) =>
+    // The malformed byte ('9' where ':' is expected) is in the SECOND chunk,
+    // on the second line. The reported offset must be at least the first
+    // chunk's length — proving offsets accumulate across chunks, not reset.
+    let first = "{\n  \"a\" "
+    let p = JsonStreamParser
+    p.feed(first)
+    p.feed("9}")
+    match p.pull()
+    | let e: JsonParseError =>
+      h.assert_true(e.offset >= first.size(),
+        "error offset " + e.offset.string() + " is not absolute across chunks")
+      h.assert_eq[USize](2, e.line)
+    else
+      h.fail("expected a parse error")
+    end
+
+class \nodoc\ iso _TestStreamDifferential is UnitTest
+  """Streaming and batch parsing agree on the resulting value."""
+  fun name(): String => "json/stream/differential"
+
+  fun apply(h: TestHelper) =>
+    let docs =
+      [ """{"a":1,"b":[2,3.5,-4],"c":{"d":"e","f":null,"g":true}}"""
+        """[{"x":1},{"y":[]},{"z":{}}]"""
+        """{"unicode":"café 😀","esc":"a\tb\nc"}""" ]
+    for doc in docs.values() do
+      let batch =
+        match JsonParser.parse(doc)
+        | let v: JsonValue => JsonPrinter.print(v)
+        | let e: JsonParseError =>
+          h.fail("batch failed on " + doc + ": " + e.string()); ""
+        end
+      match _StreamHelp.all(doc)
+      | let vs: Array[JsonValue] =>
+        if vs.size() == 1 then
+          try h.assert_eq[String](batch, JsonPrinter.print(vs(0)?)) end
+        else
+          h.fail("expected exactly one value for " + doc)
+        end
+      | let e: JsonParseError =>
+        h.fail("stream failed on " + doc + ": " + e.string())
+      end
+    end
+
+// ===================================================================
+// Property tests
+// ===================================================================
+
+primitive \nodoc\ _JsonDocStringGen
+  """
+  Generates a JSON document whose root is an object or array — the form the
+  streaming parser accepts — reusing the package's value-string generator.
+  """
+  fun apply(max_depth: USize = 3): Generator[String] =>
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String =>
+          if rnd.bool() then
+            _JsonValueStringGen._gen_array(rnd, max_depth)
+          else
+            _JsonValueStringGen._gen_object(rnd, max_depth)
+          end
+      end)
+
+class \nodoc\ iso _StreamMatchesBatchProperty is Property1[String]
+  """Feeding a whole document to the stream parser yields the batch value."""
+  fun name(): String => "json/stream/property/matches-batch"
+
+  fun gen(): Generator[String] => _JsonDocStringGen(3)
+
+  fun ref property(doc: String, ph: PropertyHelper) =>
+    match JsonParser.parse(doc)
+    | let bv: JsonValue =>
+      let batch: String val = JsonPrinter.print(bv)
+      let p = JsonStreamParser
+      p.feed(doc)
+      match p.pull()
+      | let sv: JsonValue =>
+        ph.assert_eq[String val](batch, JsonPrinter.print(sv))
+        // a single document leaves the stream drained
+        match p.pull()
+        | JsonNeedMore => None
+        else ph.fail("stream not drained after one document: " + doc)
+        end
+      | JsonNeedMore =>
+        ph.fail("stream returned NeedMore on a complete document: " + doc)
+      | let e: JsonParseError =>
+        ph.fail("stream failed on " + doc + ": " + e.string())
+      end
+    | let e: JsonParseError =>
+      ph.fail("batch failed on generated doc " + doc + ": " + e.string())
+    end
+
+class \nodoc\ iso _StreamSplitInvariantProperty is Property1[String]
+  """The result is identical no matter where the document is split into chunks."""
+  fun name(): String => "json/stream/property/split-invariant"
+
+  fun gen(): Generator[String] => _JsonDocStringGen(3)
+
+  fun ref property(doc: String, ph: PropertyHelper) =>
+    match _StreamHelp.all(doc)
+    | let whole_vs: Array[JsonValue] =>
+      let whole: String val = _StreamHelp.render(whole_vs)
+      for n in [as USize: 1; 2; 3].values() do
+        match _StreamHelp.split(doc, n)
+        | let vs: Array[JsonValue] =>
+          ph.assert_eq[String val](whole, _StreamHelp.render(vs))
+        | let e: JsonParseError =>
+          ph.fail("split at " + n.string() + " failed on " + doc + ": "
+            + e.string())
+        end
+      end
+    | let e: JsonParseError =>
+      ph.fail("whole-feed failed on generated doc " + doc + ": " + e.string())
+    end

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -80,6 +80,28 @@ actor \nodoc\ Main is TestList
     test(_TestTokenParserPositions)
     test(_TestTokenParserEndPosition)
     test(_TestTokenParserStringPosition)
+    // Streaming parser
+    test(_TestStreamObject)
+    test(_TestStreamArray)
+    test(_TestStreamEmptyContainers)
+    test(_TestStreamMultiValue)
+    test(_TestStreamNeedMore)
+    test(_TestStreamSplitInvariance)
+    test(_TestStreamEscapes)
+    test(_TestStreamNumbers)
+    test(_TestStreamNumberForms)
+    test(_TestStreamTrailingComma)
+    test(_TestStreamMalformed)
+    test(_TestStreamScalarRootRejected)
+    test(_TestStreamErrorLatches)
+    test(_TestStreamProtocol)
+    test(_TestStreamErrorLocation)
+    test(_TestStreamLimitDepth)
+    test(_TestStreamLimits)
+    test(_TestStreamDefaultDepthPrintable)
+    test(_TestStreamDifferential)
+    test(Property1UnitTest[String](_StreamMatchesBatchProperty))
+    test(Property1UnitTest[String](_StreamSplitInvariantProperty))
 
 // ===================================================================
 // Generators

--- a/packages/json/_tree_assembler.pony
+++ b/packages/json/_tree_assembler.pony
@@ -1,0 +1,101 @@
+use pc = "collections/persistent"
+
+primitive _NoResult
+
+class ref _ObjectInProgress
+  var map: pc.Map[String, JsonValue]
+  var pending_key: (String | None)
+
+  new ref create() =>
+    map = pc.Map[String, JsonValue]
+    pending_key = None
+
+class ref _ArrayInProgress
+  var vec: pc.Vec[JsonValue]
+
+  new ref create() =>
+    vec = pc.Vec[JsonValue]
+
+class ref _TreeAssembler
+  """
+  Folds a JsonValue tree from a sequence of structural and scalar events.
+
+  Shared by _TreeBuilder (which drives it from the batch JsonTokenParser's
+  token callback) and JsonStreamParser (which drives it directly as it scans).
+  It knows nothing about tokens, parsers, or readers — only how to assemble
+  objects, arrays, and scalars into a `JsonValue`. This is the single place the
+  tree shape is built, so the batch and streaming parsers cannot drift in how
+  they assemble results.
+  """
+  embed _stack: Array[(_ObjectInProgress | _ArrayInProgress)]
+  var _result: (JsonValue | _NoResult)
+
+  new ref create() =>
+    _stack = Array[(_ObjectInProgress | _ArrayInProgress)]
+    _result = _NoResult
+
+  fun ref begin_object() =>
+    """Open a new object; subsequent key/value pairs fold into it."""
+    _stack.push(_ObjectInProgress)
+
+  fun ref begin_array() =>
+    """Open a new array; subsequent values fold into it."""
+    _stack.push(_ArrayInProgress)
+
+  fun ref key(name: String) =>
+    """Set the pending key for the next value added to the current object."""
+    try
+      match _stack(_stack.size() - 1)?
+      | let obj: _ObjectInProgress => obj.pending_key = name
+      else _Unreachable() // key() is only called with an object on top
+      end
+    else _Unreachable()
+    end
+
+  fun ref value(v: JsonValue) =>
+    """Add a completed scalar (or nested) value at the current position."""
+    _add_value(v)
+
+  fun ref end_object() =>
+    """Close the current object and fold it into its parent (or the result)."""
+    try
+      let obj = _stack.pop()? as _ObjectInProgress
+      _add_value(JsonObject(obj.map))
+    else _Unreachable()
+    end
+
+  fun ref end_array() =>
+    """Close the current array and fold it into its parent (or the result)."""
+    try
+      let arr = _stack.pop()? as _ArrayInProgress
+      _add_value(JsonArray(arr.vec))
+    else _Unreachable()
+    end
+
+  fun result(): (JsonValue | _NoResult) =>
+    """The assembled top-level value, or _NoResult if none completed yet."""
+    _result
+
+  fun ref reset() =>
+    """Clear all state to assemble a fresh top-level value."""
+    _stack.clear()
+    _result = _NoResult
+
+  fun ref _add_value(v: JsonValue) =>
+    if _stack.size() == 0 then
+      _result = v
+    else
+      try
+        match \exhaustive\ _stack(_stack.size() - 1)?
+        | let obj: _ObjectInProgress =>
+          match obj.pending_key
+          | let k: String =>
+            obj.map = obj.map(k) = v
+            obj.pending_key = None
+          end
+        | let arr: _ArrayInProgress =>
+          arr.vec = arr.vec.push(v)
+        end
+      else _Unreachable()
+      end
+    end

--- a/packages/json/_tree_builder.pony
+++ b/packages/json/_tree_builder.pony
@@ -1,89 +1,33 @@
-use pc = "collections/persistent"
-
-primitive _NoResult
-
-class ref _ObjectInProgress
-  var map: pc.Map[String, JsonValue]
-  var pending_key: (String | None)
-
-  new ref create() =>
-    map = pc.Map[String, JsonValue]
-    pending_key = None
-
-class ref _ArrayInProgress
-  var vec: pc.Vec[JsonValue]
-
-  new ref create() =>
-    vec = pc.Vec[JsonValue]
-
 class ref _TreeBuilder is JsonTokenNotify
   """
   Internal token consumer that assembles a JsonValue tree from token events.
-  Used by JsonParser to build the full parse result.
+  Used by JsonParser to build the full parse result. The actual tree assembly
+  is delegated to a shared _TreeAssembler (also used by JsonStreamParser), so
+  this type is only the adapter from the batch token callback — reading the
+  parser's last_string/last_number side-channel — to assembler calls.
   """
-
-  var _stack: Array[(_ObjectInProgress | _ArrayInProgress)]
-  var _result: (JsonValue | _NoResult)
+  embed _assembler: _TreeAssembler
 
   new ref create() =>
-    _stack = Array[(_ObjectInProgress | _ArrayInProgress)]
-    _result = _NoResult
+    _assembler = _TreeAssembler
 
   fun ref apply(parser: JsonTokenParser, token: JsonToken) =>
     match \exhaustive\ token
-    | JsonTokenObjectStart =>
-      _stack.push(_ObjectInProgress)
-    | JsonTokenArrayStart =>
-      _stack.push(_ArrayInProgress)
-    | JsonTokenKey =>
-      try
-        match _stack(_stack.size() - 1)?
-        | let obj: _ObjectInProgress =>
-          obj.pending_key = parser.last_string
-        end
-      end
-    | JsonTokenString =>
-      _add_value(parser.last_string)
+    | JsonTokenObjectStart => _assembler.begin_object()
+    | JsonTokenArrayStart => _assembler.begin_array()
+    | JsonTokenKey => _assembler.key(parser.last_string)
+    | JsonTokenString => _assembler.value(parser.last_string)
     | JsonTokenNumber =>
       match \exhaustive\ parser.last_number
-      | let n: I64 => _add_value(n)
-      | let n: F64 => _add_value(n)
+      | let n: I64 => _assembler.value(n)
+      | let n: F64 => _assembler.value(n)
       end
-    | JsonTokenTrue =>
-      _add_value(true)
-    | JsonTokenFalse =>
-      _add_value(false)
-    | JsonTokenNull =>
-      _add_value(None)
-    | JsonTokenObjectEnd =>
-      try
-        let obj = _stack.pop()? as _ObjectInProgress
-        _add_value(JsonObject(obj.map))
-      end
-    | JsonTokenArrayEnd =>
-      try
-        let arr = _stack.pop()? as _ArrayInProgress
-        _add_value(JsonArray(arr.vec))
-      end
-    end
-
-  fun ref _add_value(value: JsonValue) =>
-    if _stack.size() == 0 then
-      _result = value
-    else
-      try
-        match \exhaustive\ _stack(_stack.size() - 1)?
-        | let obj: _ObjectInProgress =>
-          match obj.pending_key
-          | let key: String =>
-            obj.map = obj.map(key) = value
-            obj.pending_key = None
-          end
-        | let arr: _ArrayInProgress =>
-          arr.vec = arr.vec.push(value)
-        end
-      end
+    | JsonTokenTrue => _assembler.value(true)
+    | JsonTokenFalse => _assembler.value(false)
+    | JsonTokenNull => _assembler.value(None)
+    | JsonTokenObjectEnd => _assembler.end_object()
+    | JsonTokenArrayEnd => _assembler.end_array()
     end
 
   fun result(): (JsonValue | _NoResult) =>
-    _result
+    _assembler.result()

--- a/packages/json/json.pony
+++ b/packages/json/json.pony
@@ -28,6 +28,48 @@ match json.JsonParser.parse(source)
 end
 ```
 
+## Streaming Parsing
+
+`JsonStreamParser` parses JSON incrementally. Feed it bytes as they arrive with
+`feed()`, then call `pull()` to take complete top-level values one at a time. It
+returns the same `JsonValue` as `JsonParser`, so streamed values flow into
+`JsonNav`, `JsonLens`, `JsonPath`, and `JsonPrinter` unchanged:
+
+```pony
+let parser = json.JsonStreamParser
+parser.feed(chunk)
+// One fed chunk may complete several values (or none): loop until JsonNeedMore.
+var draining = true
+while draining do
+  match parser.pull()
+  | let v: json.JsonValue      => // a complete top-level value
+  | json.JsonNeedMore          => draining = false // feed more bytes, pull again
+  | let e: json.JsonParseError => draining = false // malformed; parser latched
+  end
+end
+```
+
+Reach for it when JSON arrives a piece at a time — over a socket, or a large
+file read in chunks — and you don't want to buffer the whole input before
+parsing. It handles a *stream* of object/array values: a single document yields
+one value; a sequence (object-per-line NDJSON, concatenated values, a socket of
+messages) yields each value as it completes, with no per-document setup. Each
+top-level value must be an object or array — its closing `}`/`]` is what signals
+completion — so, unlike `JsonParser`, a bare scalar document (or a scalar line in
+an NDJSON stream) is not supported, and a scalar where a value is expected
+latches the parser.
+
+Unlike `JsonTokenParser` (which streams *tokens* from a single in-memory
+source), `JsonStreamParser` streams whole *values* and never needs the whole
+input at once.
+
+`JsonNeedMore` is the explicit "incomplete, not yet malformed" outcome: a
+truncated value yields `JsonNeedMore`, never an error, so feeding the rest later
+completes it. The parser materializes each value into a full `JsonValue` tree,
+which bounds the *source* (you feed chunks) but not a single value's size; over
+untrusted input, `JsonStreamLimits` caps per-value depth, string length, number
+length, and total bytes.
+
 ## Serializing JSON
 
 `JsonPrinter` is the dual of `JsonParser`: it encodes any `JsonValue` —

--- a/packages/json/json_stream_limits.pony
+++ b/packages/json/json_stream_limits.pony
@@ -43,7 +43,7 @@ class val JsonStreamLimits
     """Maximum total source bytes consumed for a single top-level value."""
 
   new val create(
-    max_depth': USize = 8192,
+    max_depth': USize = 1024,
     max_string_len': USize = 1_048_576,
     max_number_len': USize = 256,
     max_value_bytes': USize = 8_388_608)

--- a/packages/json/json_stream_limits.pony
+++ b/packages/json/json_stream_limits.pony
@@ -1,0 +1,54 @@
+class val JsonStreamLimits
+  """
+  Resource bounds for `JsonStreamParser`.
+
+  Streaming parsers are typically fed from untrusted sources (a socket, a file
+  of unknown origin), and each value is materialized into a `JsonValue` tree
+  whose size the producer controls. These limits cap what a single value can
+  consume so a malicious or malformed input cannot exhaust memory. Each limit is
+  checked *during* parsing, so an oversized or unterminated value is rejected
+  near the moment it crosses the bound rather than only at the end. Enforcement
+  is approximate: a value may exceed a limit by a small, bounded amount — a
+  trailing `}`/`]`, or a final multi-byte `\uXXXX` expansion — before the next
+  check rejects it.
+
+  The default constructor applies conservative limits; raise a specific bound
+  when a trusted source legitimately has a large value or deep nesting.
+
+  ```pony
+  // Default conservative limits:
+  let parser = JsonStreamParser
+
+  // Custom limits:
+  let parser = JsonStreamParser(JsonStreamLimits(where max_depth' = 32))
+  ```
+  """
+  let max_depth: USize
+    """
+    Maximum container nesting depth. This also protects *downstream* consumers:
+    `JsonPrinter` and JSONPath recursive descent (`..`) walk the tree with
+    native recursion, so a value nested tens of thousands of levels deep can
+    overflow the native stack when they process it. The default bound stays well
+    under that, keeping streamed values safe to hand to those APIs; raising it
+    erodes that margin.
+    """
+
+  let max_string_len: USize
+    """Maximum decoded length, in bytes, of a single string."""
+
+  let max_number_len: USize
+    """Maximum length, in bytes, of a single number's text."""
+
+  let max_value_bytes: USize
+    """Maximum total source bytes consumed for a single top-level value."""
+
+  new val create(
+    max_depth': USize = 8192,
+    max_string_len': USize = 1_048_576,
+    max_number_len': USize = 256,
+    max_value_bytes': USize = 8_388_608)
+  =>
+    max_depth = max_depth'
+    max_string_len = max_string_len'
+    max_number_len = max_number_len'
+    max_value_bytes = max_value_bytes'

--- a/packages/json/json_stream_parser.pony
+++ b/packages/json/json_stream_parser.pony
@@ -1,0 +1,465 @@
+use "buffered"
+
+primitive JsonNeedMore
+  """
+  Returned by `JsonStreamParser.pull()` when no complete top-level value is
+  available yet: the bytes fed so far are valid JSON but incomplete. Feed more
+  bytes with `feed()` and call `pull()` again. Expected at every chunk boundary
+  that falls inside a value.
+  """
+
+type JsonStreamResult is (JsonValue | JsonNeedMore | JsonParseError)
+  """
+  The outcome of a `JsonStreamParser.pull()`: a completed top-level `JsonValue`,
+  `JsonNeedMore` (feed more bytes), or a `JsonParseError` (the input is
+  malformed; the parser latches into the error state).
+  """
+
+class ref JsonStreamParser
+  """
+  Incremental, pull-based JSON parser.
+
+  Feed bytes with `feed()` as they arrive, then call `pull()` to take complete
+  top-level values one at a time. `pull()` returns the same `JsonValue` the
+  batch `JsonParser` returns, so a streamed value flows into `JsonNav`,
+  `JsonLens`, `JsonPath`, and `JsonPrinter` unchanged.
+
+  ```pony
+  let parser = JsonStreamParser
+  parser.feed(chunk)
+  // Drain every value the fed bytes completed; one chunk may yield zero, one,
+  // or several values, so loop until pull() returns JsonNeedMore.
+  var draining = true
+  while draining do
+    match parser.pull()
+    | let v: JsonValue      => // a complete top-level value
+    | JsonNeedMore          => draining = false // feed more bytes, pull() again
+    | let e: JsonParseError => draining = false // malformed; parser now latched
+    end
+  end
+  ```
+
+  It parses a *stream* of top-level values, each of which must be an object or
+  array: a single document yields one value; a sequence of object/array values
+  (newline-delimited JSON whose lines are objects or arrays, concatenated values,
+  a socket delivering messages) yields each value as it completes, with no
+  per-document setup. A bare scalar top-level value (`42`, `"hi"`) is not
+  supported — a top-level value must be a container, because its closing `}`/`]`
+  is what signals completion. This differs from `JsonParser`, which accepts a
+  scalar document. (A bare-scalar element in a stream — a `42` line in otherwise
+  object-per-line NDJSON — is rejected and latches the parser; see below.)
+
+  Completion is structural: a value is done when its root container closes. There
+  is intentionally no end-of-stream call. If a producer feeds an incomplete value
+  and then stops, `pull()` simply keeps returning `JsonNeedMore` — noticing a
+  truncated feed is the consumer's concern, not the parser's.
+
+  Malformed input latches: once `pull()` returns a `JsonParseError`, the stream
+  is considered corrupt and every later `pull()` returns that same error. Recover
+  by constructing a new parser.
+  """
+  embed _reader: Reader
+  embed _assembler: _TreeAssembler
+  embed _frames: Array[_StreamFrame]
+  var _scan: (_LeafScan | None)
+  let _limits: JsonStreamLimits val
+  var _error: (JsonParseError | None)
+  var _value_bytes: USize
+  var _line: USize
+  var _offset: USize
+
+  new ref create(limits: JsonStreamLimits val = JsonStreamLimits) =>
+    _reader = Reader
+    _assembler = _TreeAssembler
+    _frames = Array[_StreamFrame]
+    _scan = None
+    _limits = limits
+    _error = None
+    _value_bytes = 0
+    _line = 1
+    _offset = 0
+
+  fun ref feed(data: ByteSeq) =>
+    """
+    Append a chunk of bytes to be parsed. `ByteSeq` is `(String | Array[U8]
+    val)`; an `Array[U8] iso` from a socket moves to `val` with no copy via
+    `consume`. After the parser has latched an error, `feed()` is a no-op.
+    """
+    // Drop empty chunks: a producer that loops feeding zero-byte reads would
+    // otherwise accumulate buffer nodes that never drain.
+    if (_error is None) and (data.size() > 0) then
+      _reader.append(data)
+    end
+
+  fun ref pull(): JsonStreamResult =>
+    """
+    Take the next complete top-level value, or `JsonNeedMore` if more bytes are
+    needed, or a latched `JsonParseError`. Call `pull()` repeatedly until it
+    returns `JsonNeedMore`: a single fed chunk can complete several values (or
+    none), so a one-pull-per-feed loop would silently drop values.
+    """
+    match _error
+    | let e: JsonParseError => return e
+    end
+
+    var result: JsonStreamResult = JsonNeedMore
+    var looping = true
+    while looping do
+      match _scan
+      | let ss: _StringScan =>
+        match _resume_string(ss)
+        | _ScanNeedMore => result = JsonNeedMore; looping = false
+        | let e: JsonParseError => result = _fail(e); looping = false
+        | _ScanComplete =>
+          // Move the decoded buffer out as an immutable value (no copy),
+          // matching the batch parser's `consume buf`.
+          let decoded: String iso = ss.buf = recover iso String end
+          if ss.is_key then
+            _assembler.key(consume decoded)
+            _set_object_pos(_ObjColon)
+          else
+            _assembler.value(consume decoded)
+          end
+          _scan = None
+        end
+      | let ns: _NumberScan =>
+        match _resume_number(ns)
+        | _ScanNeedMore => result = JsonNeedMore; looping = false
+        | let e: JsonParseError => result = _fail(e); looping = false
+        | _ScanComplete =>
+          match _NumberParse(ns.buf)
+          | let v: I64 => _assembler.value(v); _scan = None
+          | let v: F64 => _assembler.value(v); _scan = None
+          | _NumberMalformed =>
+            result = _fail(_err("invalid number")); looping = false
+          end
+        end
+      | let ks: _KeywordScan =>
+        match _resume_keyword(ks)
+        | _ScanNeedMore => result = JsonNeedMore; looping = false
+        | let e: JsonParseError => result = _fail(e); looping = false
+        | _ScanComplete => _assembler.value(ks.value); _scan = None
+        end
+      | None =>
+        match _dispatch()
+        | _StepGo => None
+        | let r: JsonStreamResult => result = r; looping = false
+        end
+      end
+    end
+    result
+
+  // --- dispatch between tokens --------------------------------------------
+
+  fun ref _dispatch(): (_StepGo | JsonStreamResult) =>
+    _skip_whitespace()
+    // Whitespace before/between top-level values belongs to no value, so it
+    // does not count against the next value's max_value_bytes budget.
+    if _frames.size() == 0 then _value_bytes = 0 end
+    let b = try _reader.peek_u8()? else return JsonNeedMore end
+    if _value_bytes > _limits.max_value_bytes then
+      return _fail(_err("value exceeds maximum size"))
+    end
+    if _frames.size() == 0 then
+      _dispatch_root(b)
+    else
+      match _top_frame()
+      | let f: _ArrayFrame => _dispatch_array(f, b)
+      | let f: _ObjectFrame => _dispatch_object(f, b)
+      end
+    end
+
+  fun ref _top_frame(): _StreamFrame =>
+    // Only called when _frames is non-empty.
+    try _frames(_frames.size() - 1)?
+    else _Unreachable(); _ArrayFrame(_ArrValueOrEnd)
+    end
+
+  fun ref _dispatch_root(b: U8): (_StepGo | JsonStreamResult) =>
+    match b
+    | '{' => _open_object()
+    | '[' => _open_array()
+    else
+      _fail(_err("expected an object or array at the top level"))
+    end
+
+  fun ref _dispatch_array(f: _ArrayFrame, b: U8): (_StepGo | JsonStreamResult) =>
+    match f.pos
+    | _ArrValueOrEnd =>
+      if b == ']' then _close_array()
+      else f.pos = _ArrCommaOrEnd; _begin_value(b) end
+    | _ArrValue =>
+      if b == ']' then _fail(_err("trailing comma in array"))
+      else f.pos = _ArrCommaOrEnd; _begin_value(b) end
+    | _ArrCommaOrEnd =>
+      if b == ',' then _consume(); f.pos = _ArrValue; _StepGo
+      elseif b == ']' then _close_array()
+      else _fail(_err("expected ',' or ']' in array")) end
+    end
+
+  fun ref _dispatch_object(f: _ObjectFrame, b: U8): (_StepGo | JsonStreamResult)
+  =>
+    match f.pos
+    | _ObjKeyOrEnd =>
+      if b == '}' then _close_object()
+      elseif b == '"' then _begin_key()
+      else _fail(_err("expected a key or '}' in object")) end
+    | _ObjKey =>
+      if b == '"' then _begin_key()
+      else _fail(_err("expected a key in object")) end
+    | _ObjColon =>
+      if b == ':' then _consume(); f.pos = _ObjValue; _StepGo
+      else _fail(_err("expected ':' in object")) end
+    | _ObjValue =>
+      f.pos = _ObjCommaOrEnd; _begin_value(b)
+    | _ObjCommaOrEnd =>
+      if b == ',' then _consume(); f.pos = _ObjKey; _StepGo
+      elseif b == '}' then _close_object()
+      else _fail(_err("expected ',' or '}' in object")) end
+    end
+
+  fun ref _begin_value(b: U8): (_StepGo | JsonStreamResult) =>
+    match b
+    | '{' => _open_object()
+    | '[' => _open_array()
+    | '"' => _consume(); _scan = _StringScan(false); _StepGo
+    | 't' => _scan = _KeywordScan("true", true); _StepGo
+    | 'f' => _scan = _KeywordScan("false", false); _StepGo
+    | 'n' => _scan = _KeywordScan("null", None); _StepGo
+    else
+      if (b == '-') or ((b >= '0') and (b <= '9')) then
+        _scan = _NumberScan
+        _StepGo
+      else
+        _fail(_err("expected a value"))
+      end
+    end
+
+  fun ref _begin_key(): (_StepGo | JsonStreamResult) =>
+    _consume() // opening '"'
+    _scan = _StringScan(true)
+    _StepGo
+
+  fun ref _open_object(): (_StepGo | JsonStreamResult) =>
+    if _frames.size() >= _limits.max_depth then
+      return _fail(_err("maximum nesting depth exceeded"))
+    end
+    _consume() // '{'
+    _assembler.begin_object()
+    _frames.push(_ObjectFrame(_ObjKeyOrEnd))
+    _StepGo
+
+  fun ref _open_array(): (_StepGo | JsonStreamResult) =>
+    if _frames.size() >= _limits.max_depth then
+      return _fail(_err("maximum nesting depth exceeded"))
+    end
+    _consume() // '['
+    _assembler.begin_array()
+    _frames.push(_ArrayFrame(_ArrValueOrEnd))
+    _StepGo
+
+  fun ref _close_object(): (_StepGo | JsonStreamResult) =>
+    _consume() // '}'
+    _assembler.end_object()
+    try _frames.pop()? else _Unreachable() end
+    _maybe_complete()
+
+  fun ref _close_array(): (_StepGo | JsonStreamResult) =>
+    _consume() // ']'
+    _assembler.end_array()
+    try _frames.pop()? else _Unreachable() end
+    _maybe_complete()
+
+  fun ref _maybe_complete(): (_StepGo | JsonStreamResult) =>
+    if _frames.size() == 0 then
+      // top-level value complete; hand it back and reset for the next one
+      match _assembler.result()
+      | let v: JsonValue =>
+        // _value_bytes is reset by _dispatch when it next sees the root frame,
+        // so it is not reset here (single owner).
+        _assembler.reset()
+        v
+      | _NoResult => _Unreachable(); JsonNeedMore
+      end
+    else
+      _StepGo
+    end
+
+  fun ref _set_object_pos(pos: _ObjPos) =>
+    match _top_frame()
+    | let f: _ObjectFrame => f.pos = pos
+    else _Unreachable()
+    end
+
+  // --- leaf scanners (suspendable) ----------------------------------------
+
+  fun ref _resume_string(s: _StringScan): _ScanOutcome =>
+    while _reader.size() > 0 do
+      if s.buf.size() > _limits.max_string_len then
+        return _err("string exceeds maximum length")
+      end
+      if _value_bytes > _limits.max_value_bytes then
+        return _err("value exceeds maximum size")
+      end
+      let c = _take()
+      match s.phase
+      | _StrNormal =>
+        if (s.pending_high isnt None) and (c != '\\') then
+          return _err("unpaired high surrogate")
+        end
+        if c == '"' then
+          return _ScanComplete
+        elseif c == '\\' then
+          s.phase = _StrEscape
+        elseif c < 0x20 then
+          return _err("control character in string")
+        else
+          s.buf.push(c)
+        end
+      | _StrEscape =>
+        if (s.pending_high isnt None) and (c != 'u') then
+          return _err("unpaired high surrogate")
+        end
+        match c
+        | '"' => s.buf.push('"'); s.phase = _StrNormal
+        | '\\' => s.buf.push('\\'); s.phase = _StrNormal
+        | '/' => s.buf.push('/'); s.phase = _StrNormal
+        | 'b' => s.buf.push(0x08); s.phase = _StrNormal
+        | 'f' => s.buf.push(0x0C); s.phase = _StrNormal
+        | 'n' => s.buf.push('\n'); s.phase = _StrNormal
+        | 'r' => s.buf.push('\r'); s.phase = _StrNormal
+        | 't' => s.buf.push('\t'); s.phase = _StrNormal
+        | 'u' => s.phase = _StrUnicode; s.hex_value = 0; s.hex_count = 0
+        else return _err("invalid escape sequence")
+        end
+      | _StrUnicode =>
+        match _hex_digit(c)
+        | let hd: U32 =>
+          s.hex_value = (s.hex_value << 4) or hd
+          s.hex_count = s.hex_count + 1
+          if s.hex_count == 4 then
+            match _apply_unicode(s)
+            | let e: JsonParseError => return e
+            end
+          end
+        | None => return _err("invalid unicode escape")
+        end
+      end
+    end
+    _ScanNeedMore
+
+  fun ref _apply_unicode(s: _StringScan): (None | JsonParseError) =>
+    let value = s.hex_value
+    match s.pending_high
+    | let high: U32 =>
+      if (value >= 0xDC00) and (value < 0xE000) then
+        let combined: U32 =
+          0x10000 + (((high and 0x3FF) << 10) or (value and 0x3FF))
+        s.buf.append(recover val String.from_utf32(combined) end)
+        s.pending_high = None
+        s.phase = _StrNormal
+        None
+      else
+        _err("expected a low surrogate")
+      end
+    | None =>
+      if (value >= 0xD800) and (value < 0xDC00) then
+        // High surrogate: a low-surrogate `\u` escape must follow immediately.
+        // That invariant is enforced by the `pending_high isnt None` guards in
+        // _resume_string's _StrNormal/_StrEscape arms (which reject any byte
+        // other than `\` then `u` while a high surrogate is pending).
+        s.pending_high = value
+        s.phase = _StrNormal
+        None
+      elseif (value >= 0xDC00) and (value < 0xE000) then
+        _err("unexpected low surrogate")
+      else
+        s.buf.append(recover val String.from_utf32(value) end)
+        s.phase = _StrNormal
+        None
+      end
+    end
+
+  fun ref _resume_number(s: _NumberScan): _ScanOutcome =>
+    while _reader.size() > 0 do
+      let c = try _reader.peek_u8()? else return _ScanNeedMore end
+      if not _is_number_byte(c) then
+        // a following non-number byte terminates the number; leave it in the
+        // reader for dispatch. A number is never completed on exhaustion.
+        return _ScanComplete
+      end
+      // `>=` (vs the string scanner's `>`) keeps the bound tight: a number's
+      // terminator is peeked, not consumed in the loop, so we must reject the
+      // byte that *would* exceed the limit before pushing it.
+      if s.buf.size() >= _limits.max_number_len then
+        return _err("number exceeds maximum length")
+      end
+      if _value_bytes > _limits.max_value_bytes then
+        return _err("value exceeds maximum size")
+      end
+      _consume()
+      s.buf.push(c)
+    end
+    _ScanNeedMore
+
+  fun ref _resume_keyword(s: _KeywordScan): _ScanOutcome =>
+    // No length limit is needed: a keyword is at most 5 bytes (`false`), and
+    // max_value_bytes still bounds the enclosing value.
+    while s.matched < s.word.size() do
+      if _reader.size() == 0 then return _ScanNeedMore end
+      let c = _take()
+      let expected = try s.word(s.matched)? else _Unreachable(); U8(0) end
+      if c != expected then return _err("invalid literal") end
+      s.matched = s.matched + 1
+    end
+    _ScanComplete
+
+  // --- byte primitives ----------------------------------------------------
+
+  fun ref _skip_whitespace() =>
+    while _reader.size() > 0 do
+      match try _reader.peek_u8()? else return end
+      | ' ' | '\t' | '\r' | '\n' => _consume()
+      else return
+      end
+    end
+
+  fun ref _consume() =>
+    try
+      let c = _reader.u8()?
+      _offset = _offset + 1
+      _value_bytes = _value_bytes + 1
+      if c == '\n' then _line = _line + 1 end
+    else
+      _Unreachable()
+    end
+
+  fun ref _take(): U8 =>
+    try
+      let c = _reader.u8()?
+      _offset = _offset + 1
+      _value_bytes = _value_bytes + 1
+      if c == '\n' then _line = _line + 1 end
+      c
+    else
+      _Unreachable()
+      U8(0)
+    end
+
+  fun _hex_digit(c: U8): (U32 | None) =>
+    if (c >= '0') and (c <= '9') then (c - '0').u32()
+    elseif (c >= 'a') and (c <= 'f') then ((c - 'a') + 10).u32()
+    elseif (c >= 'A') and (c <= 'F') then ((c - 'A') + 10).u32()
+    else None
+    end
+
+  fun _is_number_byte(c: U8): Bool =>
+    ((c >= '0') and (c <= '9')) or (c == '-') or (c == '+') or (c == '.')
+      or (c == 'e') or (c == 'E')
+
+  fun _err(message: String): JsonParseError =>
+    JsonParseError(message, _offset, _line)
+
+  fun ref _fail(e: JsonParseError): JsonStreamResult =>
+    _error = e
+    e

--- a/packages/json/json_token_parser.pony
+++ b/packages/json/json_token_parser.pony
@@ -194,6 +194,10 @@ class ref JsonTokenParser
     _eat('n')?; _eat('u')?; _eat('l')?; _eat('l')?
     _emit(JsonTokenNull)?
 
+  // COUPLING: the RFC 8259 number rules here (leading-zero rejection, >18
+  // integer digits force F64, fraction/exponent handling) are mirrored by
+  // `_NumberParse` in `_json_stream.pony` for the streaming parser. Keep the two
+  // in sync; `_TestStreamDifferential` guards that they agree.
   fun ref _parse_number() ? =>
     let sign: I64 = if _peek_safe() == '-' then _next()?; -1 else 1 end
     let int_start = _offset
@@ -296,6 +300,9 @@ class ref JsonTokenParser
     if count == 0 then error end
     result
 
+  // COUPLING: the string escape and `\uXXXX`/surrogate rules here are mirrored
+  // by `_resume_string`/`_apply_unicode` in `json_stream_parser.pony` for the
+  // streaming parser. Keep the two in sync.
   fun ref _parse_string(is_key: Bool) ? =>
     // token_start is already anchored at the opening '"' by the caller
     // (_read_value for a string value, _parse_value for a key). Don't


### PR DESCRIPTION
The json package only parsed whole documents: you had to have all the bytes before `JsonParser` would return anything. `JsonStreamParser` parses incrementally instead. Feed it bytes as they arrive with `feed()`, pull complete top-level values one at a time with `pull()`, and get back the same `JsonValue` the rest of the package already consumes, so streamed values work with `JsonNav`, `JsonLens`, `JsonPath`, and `JsonPrinter` unchanged. A value split across a chunk boundary returns `JsonNeedMore` rather than an error, so feeding the rest later finishes it. `JsonStreamLimits` caps per-value depth, string length, number length, and total size for untrusted input.

Opening this as `do not merge` to get a CI run across every platform before it's merge-ready. RFC 7464 (JSON text sequences) support is still under design discussion and will land on top.

The default depth cap (1024) keeps streamed values shallow enough to hand to the recursive printer and JSONPath descent safely. The native-recursion stack overflow those have on deeply nested values is a separate, pre-existing bug, tracked in #5557.
