### PR TITLE
Make systematic testing reproducible with multiple scheduler threads when scheduler scaling is disabled

### DIFF
--- a/.ci-scripts/systematic-testing/determinism_smoke.py
+++ b/.ci-scripts/systematic-testing/determinism_smoke.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Weekly regression guard for systematic-testing reproducibility (#5560).
+
+Systematic testing (`use=systematic_testing`) exists so a runtime interleaving
+can be replayed from a seed. The reproducibility half of that only holds above
+one scheduler thread once the scheduler's clock-gated decisions run off a
+deterministic logical clock instead of the wall clock. Nothing in the normal CI
+builds with `use=systematic_testing`, so a regression that reintroduced a
+wall-clock read on the scheduler's control path -- or that broke the systematic
+build outright -- would pass every PR and only surface when someone next tried to
+replay a seed. This guards against that.
+
+What it does, from the ponyc source root, in a container that has already built
+build/libs:
+
+  1. Builds a systematic-testing ponyc
+     (`use=scheduler_scaling_pthreads,systematic_testing`). The build itself is
+     the first assertion -- it is the only thing in CI that compiles that code
+     path.
+  2. Compiles test/rt-systematic/order-signature with it. That program folds the
+     message arrival order into an order-sensitive hash, ORDER_SIG, which is a
+     pure function of the scheduler interleaving.
+  3. Asserts the property the fix guarantees, scoped to `--ponynoscale` (dynamic
+     scheduler scaling off), with more than one scheduler thread:
+       - reproducible: one seed, many runs, all the same ORDER_SIG;
+       - still exploring: several seeds produce more than one distinct ORDER_SIG.
+
+It asserts the *property*, never a specific ORDER_SIG value. The value is
+platform-dependent (the scheduler draws from rand()/srand(), whose stream differs
+by platform), so a hardcoded value would false-fail off this machine; the
+property holds on any platform with more than one scheduler thread.
+
+Scope is deliberately `--ponynoscale`. Making dynamic scheduler scaling itself
+reproducible is follow-up work and is not checked here.
+
+The pure pieces (parse_order_sig / is_reproducible / explores) are unit-tested in
+determinism_smoke_test.py.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# A fixed seed must replay the same interleaving across this many runs.
+REPRODUCIBILITY_RUNS = 8
+# Distinct seeds that must, between them, produce more than one interleaving
+# (so we know pinning the seed didn't flatten the search to a single ordering).
+EXPLORATION_SEEDS = [12345, 111, 222, 333, 444, 555, 98765, 24680]
+REPRODUCIBILITY_SEED = 12345
+# Each run is serialized to one thread at a time; a healthy run finishes well
+# under this. A run that exceeds it is a hang, which is itself a failure.
+RUN_TIMEOUT_SECONDS = 120
+
+ORDER_SIG_RE = re.compile(rb"ORDER_SIG=(\d+)")
+REPRO_PACKAGE = "test/rt-systematic/order-signature"
+# The output suffix order (scheduler_scaling_pthreads then systematic_testing)
+# comes from the block order of the PONY_USE_* `if()`s in the top-level
+# CMakeLists.txt, NOT from the order passed to `use=`. If those blocks are
+# reordered this path goes stale; the os.access check below then fails loudly.
+PONYC_REL = "build/debug-scheduler_scaling_pthreads-systematic_testing/ponyc"
+
+
+def parse_order_sig(output):
+    """Return the ORDER_SIG value from a run's stdout, or None if absent."""
+    match = ORDER_SIG_RE.search(output)
+    return match.group(1).decode() if match is not None else None
+
+
+def is_reproducible(sigs):
+    """True if every run produced the same (non-empty) signature."""
+    return len(sigs) > 0 and len(set(sigs)) == 1
+
+
+def explores(sigs):
+    """True if the signatures span more than one ordering (search not collapsed)."""
+    return len(set(sigs)) >= 2
+
+
+def run(cmd, **kwargs):
+    print("+ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd, **kwargs)
+
+
+def fail(message):
+    print("FAIL: " + message, file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def build_systematic_ponyc(root):
+    # The build is itself an assertion: this is the only place CI compiles the
+    # systematic-testing code path. A failure here is a real regression.
+    #
+    # No arch= is passed, so the Makefile default (native) is used. The check
+    # asserts a property and builds + runs on the same machine, so native is
+    # self-consistent, and leaving arch out keeps the script usable as-is if the
+    # job grows to other architectures.
+    if run(["make", "configure", "config=debug",
+            "use=scheduler_scaling_pthreads,systematic_testing"],
+           cwd=root).returncode != 0:
+        fail("`make configure` for the systematic-testing build failed")
+    if run(["make", "build", "config=debug"], cwd=root).returncode != 0:
+        fail("`make build` for the systematic-testing build failed")
+
+    ponyc = os.path.join(root, PONYC_REL)
+    if not os.access(ponyc, os.X_OK):
+        fail("systematic-testing ponyc not found at " + PONYC_REL)
+    return ponyc
+
+
+def compile_reproducer(root, ponyc, out_dir):
+    env = dict(os.environ, PONYPATH=os.path.join(root, "packages"))
+    result = run([ponyc, "-b", "probe", "--pic", "-o", out_dir,
+                  os.path.join(root, REPRO_PACKAGE)],
+                 cwd=root, env=env)
+    if result.returncode != 0:
+        fail("compiling the reproducer with the systematic-testing ponyc failed")
+    probe = os.path.join(out_dir, "probe")
+    if not os.access(probe, os.X_OK):
+        fail("reproducer binary not produced at " + probe)
+    return probe
+
+
+def order_sig(probe, seed):
+    """Run the reproducer once and return its ORDER_SIG, or fail loudly.
+
+    stderr is captured (not discarded) so it can be surfaced on failure -- the
+    systematic-testing banner goes to stderr, but so would any crash diagnostic.
+    """
+    cmd = [probe, "--ponysystematictestingseed", str(seed), "--ponynoscale"]
+    try:
+        result = run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                     timeout=RUN_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        fail("run hung (>%ds) at seed %d -- a hang is a regression"
+             % (RUN_TIMEOUT_SECONDS, seed))
+    if result.returncode != 0:
+        fail("reproducer exited %d at seed %d; stderr:\n%s"
+             % (result.returncode, seed,
+                result.stderr.decode(errors="replace")))
+    sig = parse_order_sig(result.stdout)
+    if sig is None:
+        fail("no ORDER_SIG in output at seed %d; stdout: %r; stderr:\n%s"
+             % (seed, result.stdout, result.stderr.decode(errors="replace")))
+    return sig
+
+
+def main():
+    root = os.getcwd()
+
+    # The whole point is reproducibility across more than one scheduler thread.
+    # --ponynoscale keeps the started thread count (CPU count) but turns dynamic
+    # scaling off; with one CPU there is only one thread and nothing to check, so
+    # skip rather than emit a misleading pass or a false failure. os.cpu_count()
+    # is a host-side proxy for the count the runtime detects; they agree on the
+    # GitHub-hosted runners this job uses (no cgroup pinning to a single CPU).
+    cpus = os.cpu_count() or 1
+    if cpus < 2:
+        print("SKIP: only %d CPU available; the multi-thread reproducibility "
+              "property needs more than one scheduler thread." % cpus)
+        return
+
+    ponyc = build_systematic_ponyc(root)
+
+    with tempfile.TemporaryDirectory(prefix="systematic-repro-") as out_dir:
+        probe = compile_reproducer(root, ponyc, out_dir)
+
+        # Reproducible: one seed, many runs, all identical.
+        repro_sigs = [order_sig(probe, REPRODUCIBILITY_SEED)
+                      for _ in range(REPRODUCIBILITY_RUNS)]
+        if not is_reproducible(repro_sigs):
+            fail("seed %d gave %d distinct ORDER_SIG over %d runs (expected 1, "
+                 "so the interleaving is not reproducible): %s"
+                 % (REPRODUCIBILITY_SEED, len(set(repro_sigs)),
+                    REPRODUCIBILITY_RUNS, sorted(set(repro_sigs))))
+        print("reproducible: seed %d gave one ORDER_SIG (%s) over %d runs"
+              % (REPRODUCIBILITY_SEED, repro_sigs[0], REPRODUCIBILITY_RUNS))
+
+        # Still exploring: several seeds must not collapse to one ordering.
+        seed_sigs = [order_sig(probe, seed) for seed in EXPLORATION_SEEDS]
+        if not explores(seed_sigs):
+            fail("all %d seeds produced the same ORDER_SIG (%s); seed no longer "
+                 "drives the interleaving -- exploration has collapsed"
+                 % (len(EXPLORATION_SEEDS), seed_sigs[0]))
+        print("still exploring: %d seeds produced %d distinct ORDER_SIG"
+              % (len(EXPLORATION_SEEDS), len(set(seed_sigs))))
+
+    print("systematic-testing reproducibility smoke test passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.ci-scripts/systematic-testing/determinism_smoke_test.py
+++ b/.ci-scripts/systematic-testing/determinism_smoke_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for determinism_smoke.py.
+
+Self-contained (no pytest); run as
+`python3 .ci-scripts/systematic-testing/determinism_smoke_test.py`. Exits 0 on
+pass, 1 on failure, and prints a one-line summary. Covers the pure helpers
+(parse_order_sig / is_reproducible / explores), including the counterfactual
+cases that must read False; the build/run orchestration needs a built ponyc and
+is exercised end-to-end by the weekly job.
+"""
+
+import determinism_smoke as smoke
+
+CASES = [
+    # parse_order_sig
+    ("parse: well-formed line",
+     smoke.parse_order_sig(b"RECEIVED=512 ORDER_SIG=15143612403306820233\n"),
+     "15143612403306820233"),
+    ("parse: amid other output",
+     smoke.parse_order_sig(b"junk\nRECEIVED=1 ORDER_SIG=42\nmore\n"), "42"),
+    ("parse: first match wins",
+     smoke.parse_order_sig(b"ORDER_SIG=111\nORDER_SIG=222\n"), "111"),
+    ("parse: absent -> None", smoke.parse_order_sig(b"no signature here"), None),
+    ("parse: empty -> None", smoke.parse_order_sig(b""), None),
+
+    # is_reproducible
+    ("reproducible: all identical", smoke.is_reproducible(["a", "a", "a"]), True),
+    ("reproducible: single run", smoke.is_reproducible(["a"]), True),
+    # counterfactual: a differing run must NOT read as reproducible
+    ("reproducible: a differing run -> False",
+     smoke.is_reproducible(["a", "b", "a"]), False),
+    ("reproducible: no runs -> False", smoke.is_reproducible([]), False),
+
+    # explores
+    ("explores: distinct signatures", smoke.explores(["a", "b", "c"]), True),
+    ("explores: two distinct", smoke.explores(["a", "b"]), True),
+    # counterfactual: a collapsed search (all same) must NOT read as exploring
+    ("explores: all identical -> False", smoke.explores(["a", "a", "a"]), False),
+    ("explores: single seed -> False", smoke.explores(["a"]), False),
+    ("explores: no seeds -> False", smoke.explores([]), False),
+]
+
+
+def run():
+    failures = ["%s: expected %r, got %r" % (desc, expected, actual)
+                for desc, actual, expected in CASES if actual != expected]
+    for f in failures:
+        print("FAIL: " + f)
+    print("%d/%d checks passed" % (len(CASES) - len(failures), len(CASES)))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -164,6 +164,53 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  systematic_testing_tests:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+
+    # Tests that the systematic-testing feature still works (currently the
+    # reproducibility smoke; more systematic-testing checks can be added here).
+    # Single config for now (x86-64 Linux, debug); the smoke script asserts a
+    # property, not a platform-specific signature value, so it can be extended to
+    # more images/configs by adding matrix rows. This image is already a warmer
+    # platform (shared with the other Linux jobs here), so it needs no new entry
+    # in update-lib-cache.yml.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+
+    name: systematic testing tests
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_IMAGE: ${{ matrix.image }}
+          LIBS_TAG: ${{ hashFiles('Makefile', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/llvm/patches/*') }}
+        run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- make libs llvm_tools=false build_flags=-j4
+      - name: Determinism smoke test
+        run: python3 .ci-scripts/systematic-testing/determinism_smoke.py
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   with_sanitizers:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'

--- a/.release-notes/systematic-testing-multithread-noscale.md
+++ b/.release-notes/systematic-testing-multithread-noscale.md
@@ -1,0 +1,5 @@
+## Make systematic testing reproducible with multiple scheduler threads when scheduler scaling is disabled
+
+Systematic testing (`use=systematic_testing`) lets you replay a runtime interleaving from a seed: run until an intermittent bug shows up, then re-run with `--ponysystematictestingseed <seed>` to replay the same interleaving and chase it down. Previously this only held with a single scheduler thread (`--ponymaxthreads 1`), and a single thread explores no interleavings at all, so reproducibility and interleaving exploration were mutually exclusive.
+
+With scheduler scaling disabled (`--ponynoscale`), a fixed seed now replays the same interleaving across runs with more than one scheduler thread, while different seeds still produce different interleavings. The cycle detector can stay enabled. Making dynamic scheduler scaling itself reproducible under systematic testing is not yet covered; use `--ponynoscale` for reproducible multi-threaded replay until then.

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -585,6 +585,22 @@ static bool read_msg(scheduler_t* sched, pony_actor_t* actor)
  * terminate.
  */
 
+// Clock source for the scheduler's clock-gated control flow (block/suspend
+// thresholds and the cycle-detector cadence). Under systematic testing we read
+// the deterministic logical clock instead of the wall clock so those decisions
+// — and therefore the seeded thread-selection stream — reproduce run to run.
+// The matching ponyint_cpu_tick_diff() calls are left as-is: on x86-64 and
+// Windows (the only platforms systematic testing builds on) PONY_CPU_TICK_BITS
+// is 64, so tick_diff(a, b) is exactly b - a, correct for a monotonic clock.
+static uint64_t sched_clock(void)
+{
+#if defined(USE_SYSTEMATIC_TESTING)
+  return SYSTEMATIC_TESTING_CLOCK();
+#else
+  return ponyint_cpu_tick();
+#endif
+}
+
 static bool quiescent(scheduler_t* sched, uint64_t tsc, uint64_t tsc2)
 {
   if(sched->terminate)
@@ -919,7 +935,7 @@ static pony_actor_t* steal(scheduler_t* sched)
   bool block_sent = false;
   bool suspend_eligible = false;
   uint32_t steal_attempts = 0;
-  uint64_t tsc = ponyint_cpu_tick();
+  uint64_t tsc = sched_clock();
   pony_actor_t* actor;
   scheduler_t* victim = NULL;
 
@@ -931,7 +947,7 @@ static pony_actor_t* steal(scheduler_t* sched)
     if(actor != NULL)
       break;
 
-    uint64_t tsc2 = ponyint_cpu_tick();
+    uint64_t tsc2 = sched_clock();
 
     if(read_msg(sched, actor))
     {
@@ -1053,7 +1069,7 @@ static pony_actor_t* steal(scheduler_t* sched)
     if(!ponyint_actor_getnoblock() && (sched->index == 0))
     {
       // trigger cycle detector by sending it a message if it is time
-      uint64_t current_tsc = ponyint_cpu_tick();
+      uint64_t current_tsc = sched_clock();
       if(ponyint_cycle_check_blocked(last_cd_tsc, current_tsc))
       {
         last_cd_tsc = current_tsc;
@@ -1180,7 +1196,7 @@ static void run(scheduler_t* sched)
       if(!ponyint_actor_getnoblock())
       {
         // trigger cycle detector by sending it a message if it is time
-        uint64_t current_tsc = ponyint_cpu_tick();
+        uint64_t current_tsc = sched_clock();
         if(ponyint_cycle_check_blocked(last_cd_tsc, current_tsc))
         {
           last_cd_tsc = current_tsc;
@@ -1451,7 +1467,7 @@ static void run_pinned_actors()
 #endif
 
   pony_actor_t* actor = NULL;
-  uint64_t tsc = ponyint_cpu_tick();
+  uint64_t tsc = sched_clock();
   bool suspend_eligible = false;
 
   while(true)
@@ -1512,7 +1528,7 @@ static void run_pinned_actors()
 
     if(actor == NULL)
     {
-      uint64_t tsc2 = ponyint_cpu_tick();
+      uint64_t tsc2 = sched_clock();
       uint64_t clocks_elapsed = ponyint_cpu_tick_diff(tsc, tsc2);
 
       // Latch suspend-eligibility, as in steal(). tsc here is the last time we
@@ -1556,7 +1572,7 @@ static void run_pinned_actors()
       // update the last time the scheduler did meaningful work (used for
       // deciding when to suspend the thread); this also clears the
       // suspend-eligibility latch so we wait idle again before suspending
-      tsc = ponyint_cpu_tick();
+      tsc = sched_clock();
       suspend_eligible = false;
 
       if(reschedule)

--- a/src/libponyrt/sched/systematic_testing.c
+++ b/src/libponyrt/sched/systematic_testing.c
@@ -21,6 +21,26 @@ static uint32_t total_threads = 0;
 static uint32_t stopped_threads = 0;
 static PONY_ATOMIC(uint32_t) waiting_to_start_count;
 
+// Logical clock for systematic testing.
+//
+// Under systematic testing the wall clock is meaningless because execution is
+// serialized to one thread at a time; a thread sits parked waiting its turn
+// while real time keeps advancing. The scheduler's clock-gated decisions (when
+// to send SCHED_BLOCK, when a thread becomes suspend-eligible, the cycle
+// detector cadence) must therefore run off this deterministic step counter
+// instead of ponyint_cpu_tick(), or the spin where a threshold trips moves run
+// to run and desyncs the seeded rand() stream that picks the next thread.
+//
+// The clock advances by a fixed number of pseudo-cycles once per yield (one
+// "scheduling step"). The increment scales logical steps onto the existing
+// cycle-scale thresholds (block/suspend at 2,000,000; cycle detector at
+// detect_interval * 2,000,000) so those thresholds keep their meaning and CLI
+// configurability, now measured in scheduling steps rather than CPU cycles.
+//
+// Only the active thread runs at any moment, so no synchronization is needed.
+#define SYSTEMATIC_TESTING_TICK_PER_YIELD 20000
+static uint64_t logical_clock = 0;
+
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
 static pthread_mutex_t systematic_testing_mut;
 
@@ -60,6 +80,12 @@ void ponyint_systematic_testing_init(uint64_t random_seed, uint32_t max_threads)
 
   atomic_store_explicit(&waiting_to_start_count, 0, memory_order_relaxed);
 
+  logical_clock = 0;
+
+  // NB: when no seed is given (random_seed == 0) we intentionally read the real
+  // wall clock for entropy. The logical clock is 0 here and would make the
+  // auto-chosen seed always 0; reproducibility is moot when no seed was asked
+  // for. A given seed never reaches this branch, so determinism is unaffected.
   if(0 == random_seed)
     random_seed = ponyint_cpu_tick();
 
@@ -161,6 +187,11 @@ void ponyint_systematic_testing_start(scheduler_t* schedulers, pony_thread_id_t 
   TRACING_SYSTEMATIC_TESTING_TIMESLICE_BEGIN();
 }
 
+uint64_t ponyint_systematic_testing_clock()
+{
+  return logical_clock;
+}
+
 static uint32_t get_next_index()
 {
   uint32_t active_scheduler_count = pony_active_schedulers();
@@ -189,6 +220,10 @@ static uint32_t get_next_index()
 
 void ponyint_systematic_testing_yield()
 {
+  // Advance the logical clock once per scheduling step. This is the single
+  // choke point every yield flows through, so it is the natural place to tick.
+  logical_clock += SYSTEMATIC_TESTING_TICK_PER_YIELD;
+
   if(stopped_threads == total_threads)
   {
     size_t mem_needed = total_threads * sizeof(systematic_testing_thread_t);
@@ -201,6 +236,7 @@ void ponyint_systematic_testing_yield()
     threads_to_track = NULL;
     total_threads = 0;
     stopped_threads = 0;
+    logical_clock = 0;
     atomic_store_explicit(&waiting_to_start_count, 0, memory_order_relaxed);
 
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)

--- a/src/libponyrt/sched/systematic_testing.h
+++ b/src/libponyrt/sched/systematic_testing.h
@@ -27,6 +27,10 @@ void ponyint_systematic_testing_init(uint64_t random_seed, uint32_t max_threads)
 void ponyint_systematic_testing_start(scheduler_t* schedulers, pony_thread_id_t asio_thread, pony_signal_event_t asio_signal, pony_thread_id_t pinned_actor_thread, pony_signal_event_t pinned_actor_signal);
 void ponyint_systematic_testing_wait_start(pony_thread_id_t thread, pony_signal_event_t signal);
 void ponyint_systematic_testing_yield();
+// Current value of the systematic-testing logical clock (see the .c file). Used
+// by the scheduler in place of ponyint_cpu_tick() on the clock-gated control
+// paths so those decisions are a deterministic function of the seed.
+uint64_t ponyint_systematic_testing_clock();
 bool ponyint_systematic_testing_asio_stopped();
 void ponyint_systematic_testing_stop_thread();
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
@@ -41,6 +45,7 @@ void ponyint_systematic_testing_suspend();
 #define SYSTEMATIC_TESTING_START(SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT, PINNED_ACTOR_THREAD, PINNED_ACTOR_SLEEP_OBJECT) ponyint_systematic_testing_start(SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT, PINNED_ACTOR_THREAD, PINNED_ACTOR_SLEEP_OBJECT)
 #define SYSTEMATIC_TESTING_WAIT_START(THREAD, SIGNAL) ponyint_systematic_testing_wait_start(THREAD, SIGNAL)
 #define SYSTEMATIC_TESTING_YIELD() ponyint_systematic_testing_yield()
+#define SYSTEMATIC_TESTING_CLOCK() ponyint_systematic_testing_clock()
 #define SYSTEMATIC_TESTING_ASIO_STOPPED() ponyint_systematic_testing_asio_stopped()
 #define SYSTEMATIC_TESTING_STOP_THREAD() ponyint_systematic_testing_stop_thread()
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
@@ -58,6 +63,7 @@ PONY_EXTERN_C_END
 #define SYSTEMATIC_TESTING_START(SCHEDULERS, ASIO_THREAD, ASIO_SLEEP_OBJECT, PINNED_ACTOR_THREAD, PINNED_ACTOR_SLEEP_OBJECT)
 #define SYSTEMATIC_TESTING_WAIT_START(THREAD, SIGNAL)
 #define SYSTEMATIC_TESTING_YIELD()
+#define SYSTEMATIC_TESTING_CLOCK() (0)
 #define SYSTEMATIC_TESTING_ASIO_STOPPED()
 #define SYSTEMATIC_TESTING_STOP_THREAD()
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)

--- a/test/rt-systematic/README.md
+++ b/test/rt-systematic/README.md
@@ -1,0 +1,14 @@
+# Runtime systematic-testing fixtures
+
+Standalone Pony programs used to check the runtime's `use=systematic_testing`
+behavior. They are not part of the normal test suites; they are compiled and run
+by a dedicated CI script.
+
+- `order-signature/` — eight senders fan messages into one collector, which
+  folds the arrival order into an order-sensitive hash printed as `ORDER_SIG`.
+  The signature is a pure function of the scheduler interleaving, so it is the
+  observable used to check that a fixed `--ponysystematictestingseed` replays the
+  same interleaving across runs (with `--ponynoscale`), while different seeds
+  still produce different ones. Driven by
+  `.ci-scripts/systematic-testing/determinism_smoke.py`, run weekly from
+  `.github/workflows/ponyc-weekly-checks.yml`.

--- a/test/rt-systematic/order-signature/main.pony
+++ b/test/rt-systematic/order-signature/main.pony
@@ -1,0 +1,77 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility check (#5560).
+
+Eight Sender actors each send 64 messages to a single Collector. The arrival
+order is a pure function of the scheduler's interleaving; the Collector folds
+(sender_id, seq) of every arrival into an order-sensitive hash and prints it as
+ORDER_SIG. There is no randomness and no clock reads in the program itself, so
+under systematic testing a seed-deterministic scheduler must print the same
+ORDER_SIG for two runs at the same --ponysystematictestingseed, and different
+seeds must be free to produce different ones.
+
+Driven by .ci-scripts/systematic-testing/determinism_smoke.py, which builds
+a systematic-testing ponyc, compiles this program with it, and asserts that
+property under --ponynoscale. It is not part of the normal test suites.
+"""
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+use @exit[None](status: I32)
+
+actor Main
+  new create(env: Env) =>
+    let num_senders: USize = 8
+    let per_sender: USize = 64
+    let collector = Collector(num_senders * per_sender)
+    var i: USize = 0
+    while i < num_senders do
+      Sender(collector, i, per_sender).start()
+      i = i + 1
+    end
+
+actor Sender
+  let _collector: Collector
+  let _id: USize
+  let _total: USize
+  var _sent: USize = 0
+
+  new create(collector: Collector, id: USize, total: USize) =>
+    _collector = collector
+    _id = id
+    _total = total
+
+  be start() =>
+    tick()
+
+  be tick() =>
+    if _sent < _total then
+      _collector.recv(_id, _sent)
+      _sent = _sent + 1
+      // self-send: a fresh behavior run, i.e. a scheduler interleaving point
+      tick()
+    end
+
+actor Collector
+  let _expected: USize
+  var _received: USize = 0
+  // FNV-1a-style rolling hash of the arrival order: an interleaving signature
+  var _sig: U64 = 14695981039346656037
+
+  new create(expected: USize) =>
+    _expected = expected
+
+  be recv(sender_id: USize, seq: USize) =>
+    _mix(sender_id.u64())
+    _mix(seq.u64())
+    _received = _received + 1
+    if _received == _expected then
+      // Synchronous printf then forced exit. env.out.print is async and would be
+      // lost on @exit. The forced exit also sidesteps the separate shutdown-hang
+      // symptom under systematic testing. The signature is fully computed before
+      // we exit, so the determinism result is unaffected.
+      let line = "RECEIVED=" + _received.string()
+        + " ORDER_SIG=" + _sig.string() + "\n"
+      @printf("%s".cstring(), line.cstring())
+      @exit(0)
+    end
+
+  fun ref _mix(v: U64) =>
+    _sig = (_sig xor v) * 1099511628211


### PR DESCRIPTION
Routes the scheduler's wall-clock control-flow reads — the work-stealing block/suspend gates and the cycle-detector cadence — through a deterministic logical clock under `USE_SYSTEMATIC_TESTING`, so a fixed `--ponysystematictestingseed` replays the same interleaving with more than one scheduler thread. Previously only `--ponymaxthreads 1` was reproducible, and a single thread explores no interleavings at all.

Scope: validated for reproducible multi-threaded replay with scheduler scaling disabled (`--ponynoscale`) — the same seed reproduces across runs while different seeds still diverge. The cycle detector can stay enabled. Making dynamic scheduler scaling itself deterministic, and the ASIO/shutdown-quiescence paths, is follow-up work.

The non-systematic runtime is unchanged: the new `sched_clock()` helper compiles to `ponyint_cpu_tick()` when systematic testing is off.

Design: #5560