### PR TITLE
Run the testing workflows on the Ubuntu 26.04 builder image

### DIFF
--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             name: x86-64 Linux glibc deb
           - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-fedora44-builder:20260614
             name: x86-64 Linux glibc rpm
@@ -166,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             name: arm64 Linux glibc
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
             name: arm64 Linux musl

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -52,19 +52,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: dtrace
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: pool_memalign
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: pool_retain
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: runtimestats
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: runtime_tracing
 
@@ -125,10 +125,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             cc: clang
             cxx: clang++
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             cc: gcc
             cxx: g++
 
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
             debugger: lldb
             directives: pool_memalign,address_sanitizer,undefined_behavior_sanitizer
 

--- a/.github/workflows/stress-test-tcp-open-close-linux.yml
+++ b/.github/workflows/stress-test-tcp-open-close-linux.yml
@@ -22,20 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [cd] [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [cd] [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
@@ -105,20 +105,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [release]
             target: test-stress-tcp-open-close-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [debug]
             target: test-stress-tcp-open-close-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [cd] [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [cd] [release]
             target: test-stress-tcp-open-close-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [cd] [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [cd] [debug]
             target: test-stress-tcp-open-close-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201

--- a/.github/workflows/stress-test-ubench-linux.yml
+++ b/.github/workflows/stress-test-ubench-linux.yml
@@ -22,20 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [release]
             target: test-stress-ubench-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [cd] [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-x86-64-unknown-linux-ubuntu24.04-builder:20250115
-            name: x86-64-unknown-linux-ubuntu24.04 [cd] [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: x86-64-unknown-linux-ubuntu26.04 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201
@@ -105,20 +105,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [release]
             target: test-stress-ubench-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [debug]
             target: test-stress-ubench-debug
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [cd] [release]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [cd] [release]
             target: test-stress-ubench-with-cd-release
             debugger: lldb
-          - image: ghcr.io/ponylang/ponyc-ci-arm64-unknown-linux-ubuntu24.04-builder:20250510
-            name: arm64-unknown-linux-ubuntu24.04 [cd] [debug]
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+            name: arm64-unknown-linux-ubuntu26.04 [cd] [debug]
             target: test-stress-ubench-with-cd-debug
             debugger: lldb
           - image: ghcr.io/ponylang/ponyc-ci-alpine3.23-builder:20260201


### PR DESCRIPTION
tier2, the weekly checks, and the Linux stress tests were building and testing against the Ubuntu 24.04 builder image. We now ship an Ubuntu 26.04 release target, so this moves those test suites onto its builder image.

Nightly, release, and libs-cache workflows stay on 24.04 since it's still a supported release target. No runner labels change — the multi-arch 26.04 image runs on the existing `ubuntu-24.04-arm` runner, exactly as the 26.04 nightly and release jobs already do.