### PR TITLE
Add generative + swarm runtime stress harness

### DIFF
--- a/.ci-scripts/AGENTS.md
+++ b/.ci-scripts/AGENTS.md
@@ -9,16 +9,20 @@ when you want to exercise them).
 - **Stdlib only.** CI runners have no `pip install` step, so scripts must not
   import third-party packages. Use `urllib`, `json`, `subprocess`, `tarfile`,
   etc. — never `requests`, `pyyaml`, `pytest`, …
-- **ruff lints everything here on every PR** (`.github/workflows/lint-python.yml`,
-  `ruff check .ci-scripts`). There is no ruff config file, so the defaults apply.
+- **ruff lints everything here on every PR** (`.github/workflows/lint-python.yml`).
+  There is no ruff config file, so the defaults apply. A `lint` job runs
+  `ruff check .ci-scripts`; a separate `lint-rt-stress` job runs
+  `ruff check test/rt-stress` — these conventions also cover `test/rt-stress/`,
+  whose generative stress harness carries Python (an orchestrator) under the same
+  rules even though it lives with a test rather than in `.ci-scripts/`.
 - **Tests are `*_test.py` files, self-contained, no pytest.** Each is runnable as
-  `python3 .ci-scripts/<path>/<name>_test.py`, exits 0 on pass / 1 on fail, and
-  prints a one-line summary (see `pr_changed_suites_test.py` for the shape). The
-  **`test` job in `lint-python.yml` discovers every `.ci-scripts/**/*_test.py`
-  (via `find … -name '*_test.py'`) and runs each one**, so a new `*_test.py` is
-  picked up automatically — you do not register it
-  anywhere. When you add or change a script, add or update its `*_test.py`; it
-  will run in CI on the next PR.
+  `python3 <path>/<name>_test.py`, exits 0 on pass / 1 on fail, and prints a
+  one-line summary (see `pr_changed_suites_test.py` for the shape). The **`test`
+  job in `lint-python.yml` discovers every `*_test.py` under `.ci-scripts/` (via
+  `find … -name '*_test.py'`) and runs each one; a parallel `test-rt-stress` job
+  does the same for `test/rt-stress/`** — so a new `*_test.py` is picked up
+  automatically — you do not register it anywhere. When you add or change a
+  script, add or update its `*_test.py`; it will run in CI on the next PR.
 - After writing a test, break each assertion once to confirm it actually fires
   (counterfactual check) before trusting it.
 

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -43,3 +43,37 @@ jobs:
             echo "== $t =="
             python3 "$t"
           done
+
+  lint-rt-stress:
+    name: Lint rt-stress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Check Python files under test/rt-stress/
+        # ruff 0.15.12
+        uses: docker://ghcr.io/astral-sh/ruff@sha256:e42f3866bb9f701dbc459cdec3f5aca06511e6a38e6e04bfd4d04a2be26d4fd4
+        with:
+          args: check test/rt-stress
+
+  test-rt-stress:
+    name: Test rt-stress
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Run test/rt-stress tests
+        # Every `*_test.py` under test/rt-stress/ is self-contained (no pytest):
+        # python3-runnable, exits non-zero on failure. New tests are picked up
+        # automatically by this glob -- no registration needed.
+        run: |
+          set -e
+          tests=$(find test/rt-stress -name '*_test.py' | sort)
+          if [ -z "$tests" ]; then
+            echo "No test/rt-stress/**/*_test.py found -- glob or path broken?" >&2
+            exit 1
+          fi
+          for t in $tests; do
+            echo "== $t =="
+            python3 "$t"
+          done

--- a/test/rt-stress/generative/README.md
+++ b/test/rt-stress/generative/README.md
@@ -1,0 +1,82 @@
+# Generative runtime stress harness
+
+A generative + swarm message-passing stress test for the Pony runtime. Where
+`string-message-ubench` runs one fixed workload, this draws a different workload
+and runtime configuration from each master seed, so a single failure replays
+from one number.
+
+Two pieces:
+
+- **`orchestrate.py`** — the harness. Owns *how to run*: it derives two seeds
+  from a master seed (the program's RNG and the scheduler interleaving), draws a
+  swarm configuration (workload shape plus a random subset of the non-timing
+  runtime knobs), compiles the engine once with a provided `ponyc`, runs it under
+  a wall-clock watchdog and an address-space cap, decides pass/fail, and writes a
+  failure bundle. It can loop over many seeds, replay one, or run the determinism
+  oracle.
+- **`main.pony`** — the workload engine. A closed mesh of `Pinger` actors: a
+  fixed number of chains are injected, each with a hop count (TTL); a pinger
+  forwards exactly one ping per received ping until the TTL expires. The run
+  terminates deterministically when every chain has, and `sent == received ==
+  chains * (ttl + 1)` is an exact conservation invariant. The traced payload is a
+  `val String` or a `U64` no-GC control (`--payload`), either forwarded as one
+  object down a chain or re-allocated at each hop (`--payload-mode forward|fresh`)
+  — the swarm draws both. It holds no configuration logic and no
+  `@runtime_override_defaults`; every knob is a CLI flag set by the harness.
+
+## Running it
+
+The harness needs a **debug + systematic** ponyc:
+
+```bash
+make configure config=debug use=scheduler_scaling_pthreads,systematic_testing
+make build config=debug
+```
+
+Build it with clang. gcc currently fails to compile the systematic-testing
+runtime ([#5563](https://github.com/ponylang/ponyc/issues/5563)); pass
+`CC=clang CXX=clang++` to both `make` commands if gcc is your default.
+
+Then drive it from a master seed (or a range):
+
+```bash
+python3 test/rt-stress/generative/orchestrate.py \
+  --ponyc build/debug-scheduler_scaling_pthreads-systematic_testing/ponyc \
+  --use-flags scheduler_scaling_pthreads,systematic_testing \
+  --count 50 --out ~/tmp/rt-stress-out
+```
+
+Other seed selectors: `--master-seed N` (one seed), `--seeds A,B,C`, and
+`--replay N` (reconstruct one run's exact config and CLI). Every seed runs twice
+and its observable `ORDER_SIG` must match (the determinism check is always on; a
+divergence is a race).
+
+## Oracles
+
+- **Conservation** — messages sent == received == the expected total; a mismatch
+  is a lost or duplicated message.
+- **Late message** — anything arriving after a pinger has reported is a leak.
+- **Crash / `pony_assert`** — debug build, asserts on.
+- **Liveness** — the harness's wall-clock watchdog; a hang is a failure.
+- **Determinism** (always on) — every seed runs twice and the two runs'
+  `ORDER_SIG` must match. The harness disables ASLR (`setarch -R` on Linux) for
+  every run: systematic-testing replay is otherwise address-dependent (the runtime
+  orders some work by actor pointer values, which ASLR randomizes per run), so
+  without it this oracle would report false races. A runtime fix to make the
+  systematic build layout-independent is in progress; once it lands the wrapper
+  becomes a harmless no-op.
+
+Not yet checked: the payload's bytes at the end of a chain. A non-crashing trace
+or GC corruption (wrong bytes, truncation) would pass every oracle above —
+conservation counts messages, `ORDER_SIG` mixes ids and counts, and the
+late-message check keys on a flag. A payload-integrity check is deferred to the
+next round, alongside the richer allocation-diversity work.
+
+## Tests
+
+`orchestrate_test.py` covers the harness's pure pieces (seed derivation, swarm
+config, output parsing) and runs in CI via `lint-python.yml`. Run it directly:
+
+```bash
+python3 test/rt-stress/generative/orchestrate_test.py
+```

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -1,0 +1,407 @@
+"""
+Generative runtime stress harness (M0 -- plumbing).
+
+A closed, count-driven mesh of `Pinger` actors that exercises the Pony runtime's
+message passing and -- for the `String` payload kind -- ORCA tracing, with a
+*provable* conservation oracle.
+
+Unlike `string-message-ubench` (an open cascade stopped by a wall-clock timer),
+this workload is closed: a fixed number of chains are injected, each carrying a
+hop counter (TTL). A `Pinger` receiving a ping with hops > 0 forwards exactly
+one ping (hops - 1) to a random neighbor; a ping with hops == 0 terminates and
+signals the coordinator. Because each ping produces exactly one successor
+message, the run terminates deterministically once every chain has terminated
+-- no timer is needed (time is not virtualized under systematic testing) -- and
+
+    sent == received == chains * (ttl + 1)
+
+is an exact, checkable invariant.
+
+The closed shape is a deliberate constraint, not the end goal. A continuous,
+open workload -- always running, never quiescing -- is the better stress model:
+continuous beats epochal, keeping the runtime under sustained, varied load
+rather than in repeated run-to-quiescence epochs. We use a closed workload here
+because it is what's feasible under systematic testing today: it yields the
+exact conservation invariant above, and it needs no timer (time is not
+virtualized under systematic testing, so a timer-driven open cascade like
+ubench's would not reproduce). When open becomes feasible -- virtualized logical
+time under systematic testing, or a non-systematic continuous mode -- revisit
+this and switch.
+
+All randomness is seeded only from `--seed` (never the clock). The routing graph
+is not a function of `--seed` alone, though: which draw lands on which ping
+depends on the order a Pinger processes its mailbox, so the routing — and the
+run — reproduce only when the interleaving does (a fixed
+`--ponysystematictestingseed` AND ASLR disabled; the orchestrator disables it).
+The coordinator folds chain-completion arrivals into an FNV-1a `ORDER_SIG` -- a
+pure function of the scheduler interleaving -- as the observable for the
+determinism oracle.
+
+This program holds no `@runtime_override_defaults`: every runtime knob (scaling,
+cycle detector, GC, thread count, the systematic seed) is a `--pony*` flag set
+by the orchestrator, and every workload parameter is a `--flag value` arg parsed
+here. It is driven by `orchestrate.py` in this directory.
+"""
+use "cli"
+use "random"
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](status: I32)
+
+type Payload is (String val | U64)
+  """
+  A ping's traced cargo: a heap-allocated `String val` (gives ORCA something to
+  trace across the actor boundary) or a `U64` primitive (a no-GC control). The
+  kind is fixed for a whole run by `--payload`; `--payload-mode` then decides
+  whether one payload object is forwarded the whole chain or a fresh one is
+  allocated at each hop.
+  """
+
+primitive _Payloads
+  """
+  Builds a ping payload of the configured kind. `--payload-mode forward` reuses
+  one object down a chain (exercising ORCA's shared-`val` refcounting); `fresh`
+  calls this at every hop (exercising allocation + tracing + collection churn).
+  """
+  fun make(config: _Config): Payload =>
+    if config.payload_string then
+      let s: String val =
+        String.from_array(recover val Array[U8].init('p', config.payload_size) end)
+      s
+    else
+      U64(42)
+    end
+
+actor Main
+  new create(env: Env) =>
+    """
+    Parse the workload args with the `cli` package and hand a validated config to
+    the coordinator. `--help` prints usage and exits 0; a syntax error (unknown
+    flag, missing value, bad number) or a failed value check exits non-zero
+    without starting the workload.
+    """
+    let spec =
+      try
+        _Cli.spec()?
+      else
+        env.err.print("internal error: malformed command spec")
+        env.exitcode(1)
+        return
+      end
+    match \exhaustive\ CommandParser(spec).parse(env.args)
+    | let cmd: Command =>
+      match _Cli.config(cmd)
+      | let config: _Config => Coordinator(config)
+      | let err: String =>
+        env.err.print(err)
+        env.exitcode(1)
+      end
+    | let help: CommandHelp =>
+      help.print_help(env.out)
+    | let se: SyntaxError =>
+      env.err.print(se.string())
+      env.exitcode(1)
+    end
+
+actor Coordinator
+  """
+  Builds the mesh, injects the chains, counts completions to detect quiescence,
+  collects per-`Pinger` send/receive tallies, and evaluates the conservation
+  oracle. On completion it prints `ORDER_SIG` plus the tallies and forces exit.
+  """
+  let _config: _Config
+  let _pingers: Array[Pinger] val
+  var _completions: USize = 0
+  var _reports_outstanding: USize = 0
+  var _total_sent: U64 = 0
+  var _total_received: U64 = 0
+  var _sig: U64 = 14695981039346656037 // FNV-1a 64-bit offset basis
+
+  new create(config: _Config) =>
+    _config = config
+
+    // Create the mesh. Pingers are built outside the `recover` block (so we can
+    // pass `this`) and pushed into the iso array via automatic receiver
+    // recovery -- `push`'s argument, a `Pinger tag`, is sendable.
+    let ps: Array[Pinger] iso = recover Array[Pinger](config.pingers) end
+    var id: USize = 0
+    while id < config.pingers do
+      ps.push(Pinger(this, id, config))
+      id = id + 1
+    end
+    let pingers: Array[Pinger] val = consume ps
+    _pingers = pingers
+
+    // Wire neighbors, THEN inject. The ordering is load-bearing -- see the
+    // comment on `Pinger.set_neighbors`.
+    for p in pingers.values() do
+      p.set_neighbors(pingers)
+    end
+
+    // Each injected ping is one coordinator send (added back in `_finish`).
+    let r = Rand(config.seed)
+    var chain: USize = 0
+    while chain < config.chains do
+      let start = r.int(pingers.size().u64()).usize()
+      try
+        pingers(start)?.ping(_Payloads.make(config), config.ttl, chain)
+      else
+        _Unreachable("injection start index out of range")
+      end
+      chain = chain + 1
+    end
+
+  be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
+    """
+    A chain reached its terminal (hops == 0) ping. Fold the arrival into the
+    order signature; once every chain has terminated the system is quiesced (see
+    `Pinger.set_neighbors` and the module docstring), so ask every `Pinger` for
+    its final counts.
+    """
+    _mix(chain.u64())
+    _mix(terminal_id.u64())
+    _mix(received_snapshot)
+    _completions = _completions + 1
+    if _completions == _config.chains then
+      _reports_outstanding = _pingers.size()
+      for p in _pingers.values() do
+        p.report()
+      end
+    end
+
+  be report_counts(sent: U64, received: U64) =>
+    """
+    Accumulate one `Pinger`'s tallies. When all have reported, evaluate the
+    conservation oracle.
+    """
+    _total_sent = _total_sent + sent
+    _total_received = _total_received + received
+    _reports_outstanding = _reports_outstanding - 1
+    if _reports_outstanding == 0 then
+      _finish()
+    end
+
+  fun ref _finish() =>
+    // The coordinator itself performed `chains` initial sends (the injected
+    // pings); every `Pinger` forward is already in `_total_sent`.
+    let total_sent = _total_sent + _config.chains.u64()
+    let expected = _config.chains.u64() * (_config.ttl.u64() + 1)
+    let conserved =
+      (total_sent == _total_received) and (_total_received == expected)
+
+    // Synchronous print + forced exit: `env.out.print` is async and would be
+    // lost on `@exit`, and the forced exit sidesteps the shutdown-hang symptom
+    // seen under systematic testing (see test/rt-systematic/order-signature).
+    let line = "RECEIVED=" + _total_received.string()
+      + " SENT=" + total_sent.string()
+      + " EXPECTED=" + expected.string()
+      + " ORDER_SIG=" + _sig.string() + "\n"
+    @printf("%s".cstring(), line.cstring())
+
+    if conserved then
+      @exit(I32(0))
+    else
+      let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
+        + " sent=" + total_sent.string()
+        + " expected=" + expected.string() + "\n"
+      @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
+      @exit(I32(1))
+    end
+
+  fun ref _mix(v: U64) =>
+    _sig = (_sig xor v) * 1099511628211 // FNV-1a 64-bit prime
+
+actor Pinger
+  """
+  A mesh node. Forwards exactly one successor message per received ping and
+  tracks how many pings it has sent and received.
+  """
+  let _coord: Coordinator
+  let _id: USize
+  let _config: _Config
+  var _neighbors: Array[Pinger] val
+  var _received: U64 = 0
+  var _sent: U64 = 0
+  var _reported: Bool = false
+  let _rand: Rand
+
+  new create(coord: Coordinator, id: USize, config: _Config) =>
+    _coord = coord
+    _id = id
+    _config = config
+    _neighbors = recover val Array[Pinger] end
+    // Per-Pinger deterministic draw stream, seeded only from `--seed` + id,
+    // never the clock. The stream of values is fixed by the seed; which value
+    // lands on which ping depends on mailbox arrival order, so the resulting
+    // routing is a function of the seed AND the interleaving (see module docs).
+    _rand = Rand(config.seed, id.u64())
+
+  be set_neighbors(neighbors: Array[Pinger] val) =>
+    """
+    Install the full mesh. The coordinator sends this to every `Pinger` BEFORE
+    it injects any chain (program order in the coordinator's constructor), so by
+    Pony's causal message delivery every `Pinger` has its neighbors before any
+    ping -- the coordinator's injected ping or any forward descended from one --
+    can converge on it. Injecting before wiring would let a `Pinger` forward
+    before it knows its neighbors.
+    """
+    _neighbors = neighbors
+
+  be ping(payload: Payload, hops: USize, chain: USize) =>
+    """
+    Produce exactly one successor message per received ping: a forward when
+    hops > 0, otherwise one completion signal. This one-in/one-out invariant is
+    what makes the coordinator's completion count a sound quiescence barrier
+    (module docstring) -- do not make this fan out.
+    """
+    if _reported then
+      // Quiescence is proven before `report()` is sent, so no ping should
+      // arrive afterwards. One that does is a leaked or duplicated message.
+      _Fatal("ping after report (leaked/late message)")
+    end
+    _received = _received + 1
+    if hops > 0 then
+      _sent = _sent + 1
+      // In `fresh` mode allocate a new payload each hop (allocation +
+      // collection churn); in `forward` mode re-send the received object
+      // (shared-`val` refcounting). Either way exactly one message goes out.
+      let outgoing: Payload =
+        if _config.payload_fresh then _Payloads.make(_config) else payload end
+      let next = _rand.int(_neighbors.size().u64()).usize()
+      try
+        _neighbors(next)?.ping(outgoing, hops - 1, chain)
+      else
+        _Unreachable("neighbor index out of range")
+      end
+    else
+      _coord.completed(chain, _id, _received)
+    end
+
+  be report() =>
+    _reported = true
+    _coord.report_counts(_sent, _received)
+
+class val _Config
+  """
+  A validated workload configuration. Built only by `_Cli.config`, so the rest
+  of the program can trust its invariants (pingers >= 1, chains >= 1, and
+  payload_size >= 1 when payload_string).
+  """
+  let seed: U64
+  let pingers: USize
+  let chains: USize
+  let ttl: USize
+  let payload_string: Bool
+  let payload_size: USize
+  let payload_fresh: Bool
+
+  new val create(seed': U64, pingers': USize, chains': USize, ttl': USize,
+    payload_string': Bool, payload_size': USize, payload_fresh': Bool)
+  =>
+    seed = seed'
+    pingers = pingers'
+    chains = chains'
+    ttl = ttl'
+    payload_string = payload_string'
+    payload_size = payload_size'
+    payload_fresh = payload_fresh'
+
+primitive _Cli
+  """
+  Builds the workload command spec and extracts a validated `_Config` from a
+  parsed command. The `cli` package handles unknown flags, missing values, bad
+  numbers, and `--help`; this adds the value-set and lower-bound checks it
+  can't express. Runtime `--pony*` flags are stripped by the runtime before
+  `Main` sees `env.args`, so they never reach the parser.
+  """
+  fun spec(): CommandSpec ? =>
+    CommandSpec.leaf("generative",
+      "Generative runtime stress workload (driven by orchestrate.py)",
+      [
+        OptionSpec.u64("seed",
+          "engine RNG seed"
+          where default' = 1)
+        OptionSpec.u64("pingers",
+          "number of mesh actors (>= 1)"
+          where default' = 8)
+        OptionSpec.u64("chains",
+          "chains to inject (>= 1)"
+          where default' = 8)
+        OptionSpec.u64("ttl",
+          "hops per chain"
+          where default' = 16)
+        OptionSpec.string("payload",
+          "traced payload kind: string | u64"
+          where default' = "string")
+        OptionSpec.u64("payload-size",
+          "string payload size in bytes (>= 1)"
+          where default' = 64)
+        OptionSpec.string("payload-mode",
+          "per-hop payload allocation: forward | fresh"
+          where default' = "forward")
+      ])?.>add_help()?
+
+  fun config(cmd: Command): (_Config | String) =>
+    let seed = cmd.option("seed").u64()
+    let pingers = cmd.option("pingers").u64().usize()
+    let chains = cmd.option("chains").u64().usize()
+    let ttl = cmd.option("ttl").u64().usize()
+    let payload_size = cmd.option("payload-size").u64().usize()
+    let payload = cmd.option("payload").string()
+    let mode = cmd.option("payload-mode").string()
+
+    let payload_string =
+      if payload == "string" then
+        true
+      elseif payload == "u64" then
+        false
+      else
+        return "bad --payload (expected 'string' or 'u64')"
+      end
+
+    let payload_fresh =
+      if mode == "forward" then
+        false
+      elseif mode == "fresh" then
+        true
+      else
+        return "bad --payload-mode (expected 'forward' or 'fresh')"
+      end
+
+    if pingers < 1 then return "--pingers must be >= 1" end
+    if chains < 1 then return "--chains must be >= 1" end
+    if payload_string and (payload_size < 1) then
+      return "--payload-size must be >= 1 for string payload"
+    end
+
+    _Config(seed, pingers, chains, ttl, payload_string, payload_size,
+      payload_fresh)
+
+primitive _Fatal
+  """
+  The harness's runtime-fault detector: print a diagnostic to stderr and exit
+  non-zero. Used by the late/leaked-message oracle -- a ping arriving after a
+  `Pinger` has reported is a duplicated or delayed message, a real runtime fault,
+  so the stress run fails loudly with a location rather than passing.
+  """
+  fun apply(msg: String, loc: SourceLoc = __loc) =>
+    let line = "FATAL: " + msg + " (" + loc.file() + ":"
+      + loc.line().string() + ")\n"
+    @fprintf(@pony_os_stderr(), "%s".cstring(), line.cstring())
+    @exit(I32(1))
+
+primitive _Unreachable
+  """
+  A branch the compiler can't prove is dead but we know is: every guarded array
+  access here is indexed by `Rand.int(size)` with `size >= 1`, so the index is in
+  range by construction. If one ever fires it is a real bug, so crash with a
+  location rather than continue with corrupt state (the "unreachable try/else"
+  rule). Distinct from `_Fatal`: this flags a fault that should be impossible,
+  not one the harness is built to catch.
+  """
+  fun apply(msg: String, loc: SourceLoc = __loc) =>
+    let line = "UNREACHABLE: " + msg + " (" + loc.file() + ":"
+      + loc.line().string() + ")\n"
+    @fprintf(@pony_os_stderr(), "%s".cstring(), line.cstring())
+    @exit(I32(1))

--- a/test/rt-stress/generative/orchestrate.py
+++ b/test/rt-stress/generative/orchestrate.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Generative + swarm stress orchestrator for the Pony runtime (M0).
+
+This is the harness for test/rt-stress/generative/main.pony. It owns everything
+about *how to run* the workload; the Pony program owns *what the workload does*
+and holds no configuration logic. The split keeps every run a function of a
+master seed (and the host's core count), so any failure replays from one number
+on the same host.
+
+From a master seed it:
+  1. derives two seeds -- the program's RNG (`--seed`) and the scheduler
+     interleaving (`--ponysystematictestingseed`, forced >= 1);
+  2. draws a swarm configuration -- workload shape plus a random subset of the
+     non-timing runtime knobs, always with `--ponynoscale` (the Wave-0
+     reproducibility constraint) and `--ponymaxthreads` across [1, the host's
+     probed physical core count];
+  3. compiles the program once with a provided `--ponyc` (the binary is
+     invariant across seeds -- all configuration is CLI/runtime);
+  4. runs each seed TWICE under a wall-clock watchdog and an address-space cap
+     so a deadlock or a pathological draw can't hang or OOM the host;
+  5. requires the two runs' observable ORDER_SIG to match (the determinism
+     oracle, always on -- a divergence is a race), decides pass/fail from that
+     plus exit code + timeout, and writes a failure bundle. A seed replays from
+     its number.
+
+The ponyc passed in must be a debug + systematic build:
+
+    make configure config=debug use=scheduler_scaling_pthreads,systematic_testing
+    make build config=debug
+    python3 test/rt-stress/generative/orchestrate.py \\
+      --ponyc build/debug-scheduler_scaling_pthreads-systematic_testing/ponyc \\
+      --use-flags scheduler_scaling_pthreads,systematic_testing \\
+      --count 50 --out ~/tmp/rt-stress-out
+
+`--version` does not echo the build's `use=` flags (a systematic build still
+reports a bare `[debug]`), so the bundle records `--use-flags` separately.
+
+The pure pieces (derive_seeds / resolve_config / build_argv / parse_result) are
+unit-tested in orchestrate_test.py.
+"""
+import argparse
+import hashlib
+import json
+import os
+import platform
+import random
+import re
+import resource
+import shlex
+import shutil
+import subprocess
+import sys
+
+# The program name passed to `ponyc -b`, and the source package this script
+# sits in (compile its own directory).
+BINARY_NAME = "generative"
+SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
+# Repo root is four levels up: test/rt-stress/generative/orchestrate.py. If this
+# script moves to a different depth, update the count (orchestrate_test.py pins
+# that packages/ resolves from here).
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SOURCE_DIR)))
+
+U64_MASK = (1 << 64) - 1
+DEFAULT_TIMEOUT_SECONDS = 120
+DEFAULT_MEM_LIMIT_MB = 4096
+
+
+def info(message):
+    print(message, flush=True)
+
+
+def die(message):
+    print("FATAL: " + message, file=sys.stderr, flush=True)
+    sys.exit(1)
+
+
+def derive_seeds(master_seed):
+    """Derive (program_seed, systematic_seed) from a master seed.
+
+    Deterministic and stdlib-only. Both land in the U64 range. The program seed
+    is forced >= 1 so the engine's `Rand(seed, 0)` can't hit the all-zero
+    xoroshiro state, and the systematic seed >= 1 because the runtime rejects 0.
+    """
+    def mixed(label):
+        digest = hashlib.sha256(("%d:%s" % (master_seed, label)).encode()).digest()
+        return int.from_bytes(digest[:8], "big") & U64_MASK
+
+    program_seed = mixed("program") or 1
+    systematic_seed = mixed("systematic") or 1
+    return program_seed, systematic_seed
+
+
+def resolve_config(master_seed, max_threads):
+    """Fully resolve a run from a master seed and the host's physical core count.
+
+    Returns derived seeds, workload shape, and the runtime flag set. Every field
+    is a pure function of master_seed alone EXCEPT `--ponymaxthreads`, which is
+    drawn last across [1, max_threads] and is the only host-dependent value -- so
+    --replay and the determinism check reconstruct an identical configuration on
+    the same host (and an identical one bar the thread count on any host). Swarm
+    testing: each non-timing runtime knob is independently present or absent
+    (omission is the mechanism), and `--ponynoscale` is always on (Wave-0
+    reproducibility constraint).
+
+    The ORDER of the rng draws below is the seed-stability contract: a master
+    seed maps to a config only as long as that draw sequence is unchanged. Add a
+    new host-independent knob by appending its draw just BEFORE the final
+    `ponymaxthreads` draw -- never insert mid-sequence (it remaps every seed and
+    breaks historical --replay), and never after `ponymaxthreads` (its randint
+    width is host-dependent, so a later draw would remap across hosts).
+    orchestrate_test.py pins resolve_config(0, 8) to guard this.
+    """
+    program_seed, systematic_seed = derive_seeds(master_seed)
+    rng = random.Random(master_seed)
+
+    # These draws are a starting point, not tuned. The choice() knobs sample
+    # every listed value equally, so their extremes are well covered; the
+    # randint() ranges (chains, ttl) under-sample their edges (uniform rarely
+    # draws 0/48 or 1/400). When this is tuned (M1, with allocation diversity),
+    # bias toward important values where bugs cluster: edge-weight the ranges,
+    # favor allocator size-class boundaries and occasional-large payload sizes,
+    # and reach past the current max of 64 actors (contention/interleaving bugs
+    # intensify with scale; the ASLR repro needed 32+).
+    workload = {
+        "seed": program_seed,
+        "pingers": rng.choice([1, 2, 4, 8, 16, 32, 64]),
+        "chains": rng.randint(1, 400),
+        "ttl": rng.randint(0, 48),
+        "payload": rng.choice(["string", "u64"]),
+        "payload-size": rng.choice([1, 8, 64, 256, 1024, 4096]),
+    }
+
+    runtime = {
+        "ponynoscale": True,
+        "ponysystematictestingseed": systematic_seed,
+    }
+    if rng.random() < 0.5:
+        runtime["ponynoblock"] = True
+    if rng.random() < 0.5:
+        runtime["ponygcinitial"] = rng.choice([1024, 1 << 16, 1 << 20])
+    if rng.random() < 0.5:
+        runtime["ponygcfactor"] = round(rng.choice([1.05, 1.5, 2.0, 4.0]), 2)
+    if rng.random() < 0.5:
+        runtime["ponycdinterval"] = rng.choice([10, 100, 1000])
+    # Per-run allocation mode: `forward` re-sends one payload object down a chain
+    # (shared-val refcounting), `fresh` allocates a new one at each hop
+    # (allocation + collection churn).
+    workload["payload-mode"] = rng.choice(["forward", "fresh"])
+
+    # ponymaxthreads is drawn LAST and is the ONLY host-dependent field. Always
+    # set, across [1, max_threads] so the swarm spans serial (1) through all
+    # physical cores. The runtime REJECTS --ponymaxthreads > physical cores and
+    # exits (src/libponyrt/sched/start.c; ponyint_cpu_count() collapses SMT
+    # siblings, so "cores" is physical), so max_threads is the probed physical
+    # count. It MUST stay last: randint() consumes a variable number of rng steps
+    # (its width depends on max_threads), so any draw after it would remap across
+    # hosts with different core counts. Last => every other field is a function
+    # of master_seed alone (host-independent); only this one varies by host.
+    runtime["ponymaxthreads"] = rng.randint(1, max_threads)
+
+    return {"master_seed": master_seed, "workload": workload, "runtime": runtime}
+
+
+def build_argv(binary, config):
+    """Build the full command line for a resolved config.
+
+    Workload args first, then runtime flags. A flag whose value is True is bare
+    (`--ponynoscale`); anything else is `--key value`.
+    """
+    argv = [binary]
+    for key, value in config["workload"].items():
+        argv += ["--" + key, str(value)]
+    for key, value in config["runtime"].items():
+        if value is True:
+            argv.append("--" + key)
+        else:
+            argv += ["--" + key, str(value)]
+    return argv
+
+
+def aslr_prefix():
+    """Command prefix that disables ASLR for the run (Linux).
+
+    Systematic-testing replay is reproducible only with address-space layout
+    randomization off. The runtime orders some work by actor pointer values
+    (hash_ptr-keyed GC maps iterated in bucket order), which ASLR randomizes per
+    run -- a per-run input the `--ponysystematictestingseed` does not control.
+    `setarch -R` (ADDR_NO_RANDOMIZE) removes it, restoring the
+    same-seed-same-interleaving contract. Non-Linux hosts need their own
+    equivalent; without one, replay and the determinism oracle are best-effort.
+    """
+    if (platform.system() == "Linux") and (shutil.which("setarch") is not None):
+        return ["setarch", platform.machine(), "-R"]
+    return []
+
+
+def run_command(binary, config):
+    """The full run command: the ASLR-disable prefix plus the engine argv."""
+    return aslr_prefix() + build_argv(binary, config)
+
+
+def parse_result(stdout):
+    """Extract the engine's RECEIVED/SENT/EXPECTED/ORDER_SIG line, or {}."""
+    result = {}
+    for key in ("RECEIVED", "SENT", "EXPECTED", "ORDER_SIG"):
+        match = re.search(key + r"=(\d+)", stdout)
+        if match is not None:
+            result[key.lower()] = match.group(1)
+    return result
+
+
+def run(cmd, **kwargs):
+    info("+ " + " ".join(shlex.quote(c) for c in cmd))
+    return subprocess.run(cmd, **kwargs)
+
+
+def probe_max_threads(binary):
+    """Probe the runtime's physical core count -- the ceiling `--ponymaxthreads`
+    is checked against. Ask the engine for an impossible thread count and parse
+    the count the runtime rejects with, so we match the runtime's own
+    (SMT-collapsing) definition exactly rather than guessing from
+    `os.cpu_count()`, which is logical and would over-count on an SMT host (and
+    re-introduce the spurious-reject bug). Falls back to `os.cpu_count()` if the
+    rejection can't be parsed.
+    """
+    cmd = aslr_prefix() + [binary, "--ponymaxthreads", "1000000",
+                           "--ponynoscale", "--ponysystematictestingseed", "1"]
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE, timeout=30)
+        text = (result.stdout.decode(errors="replace")
+                + result.stderr.decode(errors="replace"))
+        match = re.search(r"> (\d+)\)", text)
+        if match is not None:
+            return int(match.group(1))
+    except subprocess.TimeoutExpired:
+        pass
+    fallback = os.cpu_count() or 1
+    info("note: could not probe physical cores from the runtime; using "
+         "os.cpu_count()=%d" % fallback)
+    return fallback
+
+
+def ponyc_version(ponyc):
+    """Capture `ponyc --version` verbatim and in full (it is the primary
+    provenance; the embedded git SHA is authoritative even past a tree move)."""
+    result = subprocess.run([ponyc, "--version"], stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT)
+    return result.stdout.decode(errors="replace").strip()
+
+
+def compile_engine(ponyc, out_dir):
+    """Compile the engine once with the provided ponyc. stdlib resolves from
+    REPO_ROOT/packages, matching .ci-scripts/systematic-testing."""
+    env = dict(os.environ, PONYPATH=os.path.join(REPO_ROOT, "packages"))
+    result = run([ponyc, "-d", "-b", BINARY_NAME, "--pic", "-o", out_dir,
+                  SOURCE_DIR], env=env)
+    if result.returncode != 0:
+        die("compiling the engine failed")
+    binary = os.path.join(out_dir, BINARY_NAME)
+    if not os.access(binary, os.X_OK):
+        die("engine binary not produced at " + binary)
+    return binary
+
+
+class RunResult:
+    """How a single run ended: outcome, exit status, and captured streams."""
+
+    def __init__(self, outcome, returncode, signal, stdout, stderr):
+        self.outcome = outcome  # "pass" | "fail" | "timeout"
+        self.returncode = returncode
+        self.signal = signal
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def run_once(binary, config, timeout, mem_limit_bytes):
+    """Run the binary under a wall-clock watchdog and an RLIMIT_AS cap.
+
+    A deterministic schedule can still deadlock, so the timeout is real; the
+    address-space cap (== `ulimit -v`, covering the pool allocator's mmap'd
+    regions) keeps a pathological draw from taking down the host. Near the cap
+    the runtime hits allocation failure and aborts rather than exiting cleanly,
+    so a signal is recorded for the bundle to make that legible.
+    """
+    argv = run_command(binary, config)
+
+    def set_limits():
+        resource.setrlimit(resource.RLIMIT_AS,
+                           (mem_limit_bytes, mem_limit_bytes))
+
+    info("+ " + " ".join(shlex.quote(a) for a in argv))
+    try:
+        completed = subprocess.run(argv, stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE, timeout=timeout,
+                                   preexec_fn=set_limits)
+    except subprocess.TimeoutExpired as expired:
+        return RunResult("timeout", None, None,
+                         _decode(expired.stdout), _decode(expired.stderr))
+
+    returncode = completed.returncode
+    signal = -returncode if returncode < 0 else None
+    outcome = "pass" if returncode == 0 else "fail"
+    return RunResult(outcome, returncode, signal,
+                     completed.stdout.decode(errors="replace"),
+                     completed.stderr.decode(errors="replace"))
+
+
+def _decode(raw):
+    return raw.decode(errors="replace") if raw else ""
+
+
+def bundle_for(config, version, use_flags, argv, limits, result):
+    """Assemble the failure-bundle dict: everything needed to reproduce and
+    attribute a run from the record alone."""
+    return {
+        "master_seed": config["master_seed"],
+        "program_seed": config["workload"]["seed"],
+        "systematic_seed": config["runtime"]["ponysystematictestingseed"],
+        "workload": config["workload"],
+        "runtime_flags": config["runtime"],
+        "cli": " ".join(shlex.quote(a) for a in argv),
+        "ponyc_version": version,
+        "use_flags": use_flags,
+        "limits": limits,
+        "outcome": result.outcome,
+        "returncode": result.returncode,
+        "signal": result.signal,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def write_bundle(out_dir, bundle):
+    path = os.path.join(out_dir, "bundle-%d.json" % bundle["master_seed"])
+    with open(path, "w") as handle:
+        json.dump(bundle, handle, indent=2, sort_keys=True)
+    return path
+
+
+def summary_line(config, result):
+    parsed = parse_result(result.stdout)
+    shape = config["workload"]
+    detail = "received=%s expected=%s sig=%s" % (
+        parsed.get("received", "?"), parsed.get("expected", "?"),
+        parsed.get("order_sig", "?"))
+    return "[seed %d] %s (pingers=%d chains=%d ttl=%d payload=%s) %s" % (
+        config["master_seed"], result.outcome.upper(), shape["pingers"],
+        shape["chains"], shape["ttl"], shape["payload"], detail)
+
+
+def execute(binary, config, version, use_flags, out_dir, timeout,
+            mem_limit_bytes):
+    """Run one seed once; tee output, write a bundle on non-pass, return the
+    RunResult."""
+    result = run_once(binary, config, timeout, mem_limit_bytes)
+    info(summary_line(config, result))
+    if result.stdout:
+        info(result.stdout.rstrip("\n"))
+    if result.stderr:
+        info(result.stderr.rstrip("\n"))
+    if result.outcome != "pass":
+        argv = run_command(binary, config)
+        limits = {"timeout_seconds": timeout,
+                  "mem_limit_bytes": mem_limit_bytes}
+        path = write_bundle(out_dir,
+                            bundle_for(config, version, use_flags, argv, limits,
+                                       result))
+        info("wrote failure bundle: " + path)
+    return result
+
+
+def check_determinism(binary, config, version, use_flags, out_dir, timeout,
+                      mem_limit_bytes):
+    """Run one seed twice and compare the observable ORDER_SIG. Divergence at a
+    fixed seed pair (with ASLR disabled) is a race. A non-pass run is a failure
+    in its own right. On any determinism failure a `determinism-<seed>.json`
+    bundle is written capturing both runs, so the divergence -- the headline
+    oracle failure, which otherwise leaves no on-disk artifact since both runs
+    exit 0 -- reproduces from the record, not just from stdout."""
+    seed = config["master_seed"]
+    first = execute(binary, config, version, use_flags, out_dir, timeout,
+                    mem_limit_bytes)
+    second = execute(binary, config, version, use_flags, out_dir, timeout,
+                     mem_limit_bytes)
+    sig_a = parse_result(first.stdout).get("order_sig")
+    sig_b = parse_result(second.stdout).get("order_sig")
+    runs_ok = (first.outcome == "pass") and (second.outcome == "pass")
+    have_sigs = (sig_a is not None) and (sig_b is not None)
+
+    if runs_ok and have_sigs and (sig_a == sig_b):
+        info("[seed %d] determinism ok: ORDER_SIG=%s reproduced" % (seed, sig_a))
+        return True
+
+    if not runs_ok:
+        verdict = "a run did not pass (cannot compare ORDER_SIG)"
+    elif not have_sigs:
+        verdict = "a run exited 0 without an ORDER_SIG (cannot compare)"
+    elif not aslr_prefix():
+        # ASLR was not disabled, so a divergence is INCONCLUSIVE rather than a
+        # race: systematic replay is address-dependent without ASLR off (the
+        # runtime orders work by actor pointer values).
+        verdict = "INCONCLUSIVE: ORDER_SIG %s vs %s but ASLR was not disabled" \
+            % (sig_a, sig_b)
+    else:
+        verdict = "DETERMINISM FAILURE: %s != %s (a race)" % (sig_a, sig_b)
+    info("[seed %d] %s" % (seed, verdict))
+
+    # Build the top-level bundle from the failing run when one failed (otherwise
+    # the headline outcome would describe a passing run); the determinism block
+    # below carries both runs regardless.
+    failed = first if first.outcome != "pass" else second
+    bundle = bundle_for(config, version, use_flags, run_command(binary, config),
+                        {"timeout_seconds": timeout,
+                         "mem_limit_bytes": mem_limit_bytes}, failed)
+    bundle["determinism"] = {"verdict": verdict, "sig_run1": sig_a,
+                             "sig_run2": sig_b, "outcome_run1": first.outcome,
+                             "outcome_run2": second.outcome}
+    path = os.path.join(out_dir, "determinism-%d.json" % seed)
+    with open(path, "w") as handle:
+        json.dump(bundle, handle, indent=2, sort_keys=True)
+    info("wrote determinism bundle: " + path)
+    return False
+
+
+def resolve_seeds(args):
+    if args.master_seed is not None:
+        return [args.master_seed]
+    if args.replay is not None:
+        return [args.replay]
+    if args.count is not None:
+        return list(range(args.start, args.start + args.count))
+    try:
+        return [int(token) for token in args.seeds.split(",")]
+    except ValueError:
+        die("bad --seeds (expected comma-separated integers): " + args.seeds)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--ponyc", required=True,
+                        help="path to a debug + systematic ponyc")
+    parser.add_argument("--use-flags", required=True,
+                        help="use= flags the ponyc was built with (provenance)")
+    parser.add_argument("--out", help="output dir for the binary and bundles")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS,
+                        help="per-run wall-clock watchdog, seconds (default %d)"
+                        % DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--mem-limit-mb", type=int,
+                        default=DEFAULT_MEM_LIMIT_MB,
+                        help="per-run address-space cap, MB (default %d); a cap "
+                        "below the runtime's startup need reports as a FAIL"
+                        % DEFAULT_MEM_LIMIT_MB)
+    parser.add_argument("--start", type=int, default=1,
+                        help="first master seed for --count (ignored otherwise)")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--master-seed", type=int, help="run one master seed")
+    source.add_argument("--count", type=int, help="run --start .. --start+N-1")
+    source.add_argument("--seeds", help="comma-separated master seeds")
+    source.add_argument("--replay", type=int,
+                        help="re-run one master seed verbosely")
+    args = parser.parse_args(argv)
+
+    ponyc = os.path.abspath(args.ponyc)
+    if not os.access(ponyc, os.X_OK):
+        die("ponyc not executable at " + ponyc)
+    if "systematic_testing" not in args.use_flags:
+        die("--use-flags must include systematic_testing: the engine passes "
+            "--ponysystematictestingseed, which a non-systematic runtime rejects "
+            "(every seed would 'fail')")
+
+    out_dir = os.path.abspath(args.out) if args.out else os.path.join(
+        REPO_ROOT, "rt-stress-out")
+    os.makedirs(out_dir, exist_ok=True)
+    mem_limit_bytes = args.mem_limit_mb * 1024 * 1024
+
+    version = ponyc_version(ponyc)
+    info("ponyc: " + version.replace("\n", " | "))
+    info("use-flags: " + args.use_flags)
+    if not aslr_prefix():
+        info("note: setarch -R unavailable (non-Linux or no setarch) -- "
+             "systematic replay needs ASLR disabled, so replay and the "
+             "determinism oracle are best-effort here")
+    binary = compile_engine(ponyc, out_dir)
+    max_threads = probe_max_threads(binary)
+    info("physical cores (--ponymaxthreads ceiling): %d" % max_threads)
+
+    seeds = resolve_seeds(args)
+    if not seeds:
+        die("no seeds to run -- --count must be >= 1 (a 0/negative --count or "
+            "empty --seeds runs nothing and would exit 0)")
+    replay = args.replay is not None
+    if replay:
+        config = resolve_config(seeds[0], max_threads)
+        info("replay config: " + json.dumps(config, sort_keys=True))
+        info("replay cli: " + " ".join(
+            shlex.quote(a) for a in run_command(binary, config)))
+
+    failures = 0
+    for seed in seeds:
+        config = resolve_config(seed, max_threads)
+        # Determinism is checked on every seed (always-on): each runs twice and
+        # the observable ORDER_SIG must match. The second run is also a full
+        # conservation/crash/liveness run, so it is not wasted.
+        if not check_determinism(binary, config, version, args.use_flags,
+                                 out_dir, args.timeout, mem_limit_bytes):
+            failures += 1
+
+    info("ran %d seed(s), %d failure(s)" % (len(seeds), failures))
+    if failures != 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/test/rt-stress/generative/orchestrate_test.py
+++ b/test/rt-stress/generative/orchestrate_test.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure pieces of orchestrate.py.
+
+Self-contained (no pytest): runnable as
+`python3 test/rt-stress/generative/orchestrate_test.py`, exits 0 on pass / 1 on
+failure, prints a one-line summary. Picked up automatically by lint-python.yml's
+`*_test.py` discovery once that workflow covers test/rt-stress/.
+"""
+import sys
+
+import orchestrate
+
+FAILURES = []
+
+U64_MAX = (1 << 64) - 1
+# A fixed physical-core count so resolve_config is deterministic in tests (the
+# real orchestrator probes it from the runtime).
+THREADS = 8
+
+
+def check(name, condition):
+    if condition:
+        print("ok   - " + name)
+    else:
+        print("FAIL - " + name)
+        FAILURES.append(name)
+
+
+def test_derive_seeds():
+    check("derive_seeds is deterministic",
+          orchestrate.derive_seeds(42) == orchestrate.derive_seeds(42))
+
+    # Both seeds stay in U64 and >= 1 across a spread of master seeds. The
+    # systematic seed >= 1 is load-bearing -- the runtime rejects 0.
+    all_in_range = True
+    program_seen = set()
+    for master in range(0, 300):
+        program, systematic = orchestrate.derive_seeds(master)
+        program_seen.add(program)
+        if not (1 <= program <= U64_MAX and 1 <= systematic <= U64_MAX):
+            all_in_range = False
+    check("derive_seeds keeps both seeds in [1, U64_MAX]", all_in_range)
+
+    # The two derived seeds are independent (different labels), and the program
+    # seed varies with the master seed rather than being constant.
+    program0, systematic0 = orchestrate.derive_seeds(0)
+    check("derive_seeds: program != systematic", program0 != systematic0)
+    check("derive_seeds: program seed varies with master",
+          len(program_seen) > 250)
+
+
+def test_resolve_config_deterministic_and_bounded():
+    check("resolve_config is deterministic",
+          orchestrate.resolve_config(7, THREADS)
+          == orchestrate.resolve_config(7, THREADS))
+
+    pingers_allowed = {1, 2, 4, 8, 16, 32, 64}
+    size_allowed = {1, 8, 64, 256, 1024, 4096}
+    invariants_hold = True
+    pingers_seen = set()
+    size_seen = set()
+    chains_seen = []
+    ttls_seen = []
+    payload_seen = set()
+    mode_seen = set()
+    maxthreads_ok = True
+    maxthreads_seen = set()
+    for master in range(0, 300):
+        config = orchestrate.resolve_config(master, THREADS)
+        work = config["workload"]
+        runtime = config["runtime"]
+        if runtime.get("ponynoscale") is not True:
+            invariants_hold = False
+        if runtime["ponysystematictestingseed"] < 1:
+            invariants_hold = False
+        if work["pingers"] not in pingers_allowed:
+            invariants_hold = False
+        if not (1 <= work["chains"] <= 400):
+            invariants_hold = False
+        if not (0 <= work["ttl"] <= 48):
+            invariants_hold = False
+        if work["payload"] not in ("string", "u64"):
+            invariants_hold = False
+        if work["payload-size"] not in size_allowed:
+            invariants_hold = False
+        mt = runtime.get("ponymaxthreads")
+        if (mt is None) or not (1 <= mt <= THREADS):
+            maxthreads_ok = False
+        else:
+            maxthreads_seen.add(mt)
+        pingers_seen.add(work["pingers"])
+        payload_seen.add(work["payload"])
+        mode_seen.add(work["payload-mode"])
+        size_seen.add(work["payload-size"])
+        chains_seen.append(work["chains"])
+        ttls_seen.append(work["ttl"])
+    check("resolve_config holds all invariants over 300 seeds", invariants_hold)
+    # Edge/coverage, not just membership: the choice knobs must produce their
+    # FULL declared set (catches a dropped choice), the randint ranges must span
+    # widely (catches a narrowing), and ponymaxthreads must always be set and
+    # cover the full [1, max_threads] range (the probed-core-count draw).
+    check("pingers covers the full declared set", pingers_seen == pingers_allowed)
+    check("payload covers both kinds {string, u64}",
+          payload_seen == {"string", "u64"})
+    check("payload-mode covers {forward, fresh}",
+          mode_seen == {"forward", "fresh"})
+    check("payload-size covers the full declared set", size_seen == size_allowed)
+    check("ttl reaches both declared edges 0 and 48",
+          (min(ttls_seen) == 0) and (max(ttls_seen) == 48))
+    check("chains spans most of [1,400]",
+          (max(chains_seen) - min(chains_seen)) >= 380)
+    check("ponymaxthreads always set and in [1, THREADS]", maxthreads_ok)
+    check("ponymaxthreads spans the full [1, THREADS] range",
+          maxthreads_seen == set(range(1, THREADS + 1)))
+
+
+def test_resolve_config_swarm_omission():
+    # Swarm testing's mechanism is omission: EACH optional knob must appear in
+    # some runs and be absent in others, not pinned one way. Check all four --
+    # they share identical `if rng.random() < 0.5` logic, so testing only the
+    # first would let a regression in any of the others pass silently.
+    # (ponymaxthreads is always set now, so it isn't an omittable knob.)
+    omittable = ["ponynoblock", "ponygcinitial", "ponygcfactor",
+                 "ponycdinterval"]
+    counts = dict.fromkeys(omittable, 0)
+    for master in range(0, 300):
+        runtime = orchestrate.resolve_config(master, THREADS)["runtime"]
+        for knob in omittable:
+            if knob in runtime:
+                counts[knob] += 1
+    for knob in omittable:
+        check("swarm omission: %s sometimes present" % knob, counts[knob] > 0)
+        check("swarm omission: %s sometimes absent" % knob, counts[knob] < 300)
+
+
+def test_build_argv():
+    config = orchestrate.resolve_config(1, THREADS)
+    argv = orchestrate.build_argv("/bin/generative", config)
+
+    check("build_argv: binary is first", argv[0] == "/bin/generative")
+    check("build_argv: includes --ponynoscale bare", "--ponynoscale" in argv)
+    # A bare flag must not leak its Python True as a literal token.
+    check("build_argv: no literal True token", "True" not in argv)
+
+    # Guard the index lookups so a regression that drops a flag yields a clean
+    # FAIL line rather than an uncaught ValueError traceback.
+    program_seed = str(config["workload"]["seed"])
+    check("build_argv: --seed present", "--seed" in argv)
+    if "--seed" in argv:
+        check("build_argv: --seed carries the program seed",
+              argv[argv.index("--seed") + 1] == program_seed)
+
+    check("build_argv: --ponysystematictestingseed present",
+          "--ponysystematictestingseed" in argv)
+    if "--ponysystematictestingseed" in argv:
+        check("build_argv: systematic seed value present",
+              argv[argv.index("--ponysystematictestingseed") + 1] ==
+              str(config["runtime"]["ponysystematictestingseed"]))
+
+
+def test_run_command():
+    config = orchestrate.resolve_config(1, THREADS)
+    engine = orchestrate.build_argv("/bin/generative", config)
+    full = orchestrate.run_command("/bin/generative", config)
+    prefix = orchestrate.aslr_prefix()
+
+    check("run_command: engine argv is the suffix",
+          full[len(full) - len(engine):] == engine)
+    check("run_command: length is prefix + engine",
+          len(full) == len(prefix) + len(engine))
+    # The ASLR prefix is either absent or a `setarch ... -R` invocation.
+    check("aslr_prefix: empty or setarch -R",
+          (prefix == []) or ((prefix[0] == "setarch") and (prefix[-1] == "-R")))
+
+
+def test_derive_seeds_zero_floor():
+    # The `or 1` floor on both derived seeds is load-bearing: the runtime rejects
+    # systematic seed 0, and Rand(0, 0) is the degenerate all-zero xoroshiro
+    # state. No real SHA-256 prefix is zero in the seed ranges used, so force a
+    # zero digest to exercise the floor directly (otherwise it is never hit).
+    class _ZeroDigest:
+        def digest(self):
+            return b"\x00" * 32
+
+    def _zero_sha(*args, **kwargs):
+        return _ZeroDigest()
+
+    real = orchestrate.hashlib.sha256
+    try:
+        orchestrate.hashlib.sha256 = _zero_sha
+        program, systematic = orchestrate.derive_seeds(123)
+        check("derive_seeds floors a zero program digest to 1", program == 1)
+        check("derive_seeds floors a zero systematic digest to 1",
+              systematic == 1)
+    finally:
+        orchestrate.hashlib.sha256 = real
+
+
+def test_build_argv_numeric_knob():
+    # Numeric runtime-knob values must render as their string form (e.g. a float
+    # gcfactor), not be dropped or mangled.
+    config = {
+        "master_seed": 0,
+        "workload": {"seed": 5, "pingers": 8, "chains": 8, "ttl": 16,
+                     "payload": "string", "payload-size": 64},
+        "runtime": {"ponynoscale": True, "ponysystematictestingseed": 7,
+                    "ponygcfactor": 1.05, "ponymaxthreads": 2},
+    }
+    argv = orchestrate.build_argv("/bin/generative", config)
+    check("build_argv renders a float knob value",
+          ("--ponygcfactor" in argv)
+          and (argv[argv.index("--ponygcfactor") + 1] == "1.05"))
+    check("build_argv renders an int knob value",
+          ("--ponymaxthreads" in argv)
+          and (argv[argv.index("--ponymaxthreads") + 1] == "2"))
+
+
+def test_resolve_config_golden():
+    # Pin resolve_config(0)'s EXACT output: the seed-stability guard. Any change
+    # to the draw sequence (a narrowed range, an inserted/reordered draw, a
+    # dropped choice, a removed seed floor) changes this and fails here -- which
+    # also flags that historical --replay for this seed has been broken.
+    expected = {
+        "master_seed": 0,
+        "runtime": {
+            "ponygcfactor": 2.0,
+            "ponymaxthreads": 4,
+            "ponynoblock": True,
+            "ponynoscale": True,
+            "ponysystematictestingseed": 6974751086576699578,
+        },
+        "workload": {
+            "chains": 198,
+            "payload": "u64",
+            "payload-mode": "fresh",
+            "payload-size": 1,
+            "pingers": 64,
+            "seed": 2686188150644990173,
+            "ttl": 48,
+        },
+    }
+    check("resolve_config(0, 8) matches the pinned golden config",
+          orchestrate.resolve_config(0, THREADS) == expected)
+
+
+def test_parse_result():
+    line = "RECEIVED=136 SENT=136 EXPECTED=136 ORDER_SIG=13652540024091563273"
+    parsed = orchestrate.parse_result(line)
+    check("parse_result: received", parsed.get("received") == "136")
+    check("parse_result: sent", parsed.get("sent") == "136")
+    check("parse_result: expected", parsed.get("expected") == "136")
+    check("parse_result: order_sig",
+          parsed.get("order_sig") == "13652540024091563273")
+    check("parse_result: empty on garbage",
+          orchestrate.parse_result("no result here") == {})
+
+
+def main():
+    test_derive_seeds()
+    test_derive_seeds_zero_floor()
+    test_resolve_config_deterministic_and_bounded()
+    test_resolve_config_golden()
+    test_resolve_config_swarm_omission()
+    test_build_argv()
+    test_build_argv_numeric_knob()
+    test_run_command()
+    test_parse_result()
+    if FAILURES:
+        print("%d failure(s): %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("all orchestrate_test checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`string-message-ubench` exercises one fixed point in the space of runtime
workloads: a full mesh of N actors forwarding `String`s with scaling and the
cycle detector off. A bug that needs a different actor count, a different
message-size distribution, scaling on, or an aggressive `gcfactor` isn't unlikely
to be found there: it's unreachable.

This adds a generative harness alongside it that draws a different workload and
runtime configuration from each master seed, so coverage spans the space instead
of repeating one point, and any failure replays from a single number. It's the
first ("M0") milestone: the whole loop from a seed to a pass/fail verdict and a
reproducible failure bundle, on a workload simple enough that a red flag means a
harness bug rather than noise. The GC, backpressure, and topology primitives that
exercise ORCA and the cycle detector come next (M1).

`orchestrate.py` derives the program's RNG seed and the scheduler-interleaving
seed from one master seed, draws the swarm configuration (workload shape plus a
random subset of the non-timing runtime knobs, always `--ponynoscale`), compiles
the engine once with a provided `ponyc`, runs it under a wall-clock watchdog and
an address-space cap, decides pass/fail, and writes a failure bundle; it also
loops over seeds, replays one, and has an opt-in determinism oracle. `main.pony`
is the closed TTL-chain mesh: a fixed number of chains, each forwarded one hop at
a time until its TTL runs out, which makes `sent == received == chains * (ttl + 1)`
an exact conservation invariant and ends the run without a timer.
`lint-python.yml` is extended to lint and run the harness's Python under the
`.ci-scripts` conventions.

Runs disable ASLR with `setarch -R`. Systematic-testing replay is otherwise
address-dependent (the runtime orders some work by actor pointer values that ASLR
randomizes per run), so without it the determinism oracle reports false races. A
runtime fix to make the systematic build layout-independent is in progress; once
it lands the wrapper is a no-op.

Reviewed with the full `pony-code-review` ensemble plus re-reviews. The three
design questions raised during review are resolved here: payload allocation is a
per-run `--payload-mode forward|fresh` swarm knob (re-send one object down a
chain, or allocate a fresh one each hop; the swarm draws both); the
payload-integrity check is deferred to the next round, where it pairs with the M1
allocation-diversity work (documented); and `_Fatal` is split into `_Unreachable`
(the unreachable index guards) and `_Fatal` (the late-message oracle).
