### PR TITLE
Make systematic testing replay independent of memory layout

### DIFF
--- a/.ci-scripts/systematic-testing/determinism_smoke.py
+++ b/.ci-scripts/systematic-testing/determinism_smoke.py
@@ -17,11 +17,14 @@ build/libs:
      (`use=scheduler_scaling_pthreads,systematic_testing`). The build itself is
      the first assertion -- it is the only thing in CI that compiles that code
      path.
-  2. Compiles test/rt-systematic/order-signature with it. That program folds the
-     message arrival order into an order-sensitive hash, ORDER_SIG, which is a
-     pure function of the scheduler interleaving.
-  3. Asserts the property the fix guarantees, scoped to `--ponynoscale` (dynamic
-     scheduler scaling off), with more than one scheduler thread:
+  2. Compiles the test/rt-systematic fixtures with it. Each folds the message
+     arrival order into an order-sensitive hash, ORDER_SIG, which is a pure
+     function of the scheduler interleaving. order-signature exercises the base
+     scheduler path; mute-order-signature additionally drives the actor
+     muting/unmuting reschedule path (its foreign-send volume overloads actors).
+  3. Asserts the property, scoped to `--ponynoscale` (dynamic scheduler scaling
+     off), at the runtime's default thread count (the host's physical cores),
+     for each fixture:
        - reproducible: one seed, many runs, all the same ORDER_SIG;
        - still exploring: several seeds produce more than one distinct ORDER_SIG.
 
@@ -30,8 +33,19 @@ platform-dependent (the scheduler draws from rand()/srand(), whose stream differ
 by platform), so a hardcoded value would false-fail off this machine; the
 property holds on any platform with more than one scheduler thread.
 
-Scope is deliberately `--ponynoscale`. Making dynamic scheduler scaling itself
-reproducible is follow-up work and is not checked here.
+Scope and limits:
+  - `--ponynoscale`: making dynamic scheduler scaling itself reproducible is
+    follow-up work and is not checked here.
+  - mute-order-signature only catches a muting-reschedule regression when actors
+    actually overload, which needs load and thread count in balance. It is sized
+    for the 2-4 physical cores a CI runner typically has; on a host with many
+    more cores the per-thread load is too light to mute and that fixture degrades
+    to a plain reproducibility check (still correct, just no longer guarding the
+    muting path).
+  - These fixtures do not cover every source of layout- or timing-dependence in
+    the systematic scheduler. Other paths -- e.g. the ORCA reference-message
+    (ACQUIRE/RELEASE) send ordering, which is also actor-pointer ordered -- have
+    not been exhaustively explored.
 
 The pure pieces (parse_order_sig / is_reproducible / explores) are unit-tested in
 determinism_smoke_test.py.
@@ -54,7 +68,16 @@ REPRODUCIBILITY_SEED = 12345
 RUN_TIMEOUT_SECONDS = 120
 
 ORDER_SIG_RE = re.compile(rb"ORDER_SIG=(\d+)")
-REPRO_PACKAGE = "test/rt-systematic/order-signature"
+
+# (package, binary name) for each fixture. order-signature covers the base
+# scheduler path; mute-order-signature additionally exercises the actor
+# muting/unmuting reschedule path. Both run at the runtime's default thread
+# count (physical cores); see the module docstring for the muting fixture's
+# coverage ceiling.
+FIXTURES = [
+    ("test/rt-systematic/order-signature", "order-signature"),
+    ("test/rt-systematic/mute-order-signature", "mute-order-signature"),
+]
 # The output suffix order (scheduler_scaling_pthreads then systematic_testing)
 # comes from the block order of the PONY_USE_* `if()`s in the top-level
 # CMakeLists.txt, NOT from the order passed to `use=`. If those blocks are
@@ -109,26 +132,26 @@ def build_systematic_ponyc(root):
     return ponyc
 
 
-def compile_reproducer(root, ponyc, out_dir):
+def compile_reproducer(root, ponyc, out_dir, package, name):
     env = dict(os.environ, PONYPATH=os.path.join(root, "packages"))
-    result = run([ponyc, "-b", "probe", "--pic", "-o", out_dir,
-                  os.path.join(root, REPRO_PACKAGE)],
+    result = run([ponyc, "-b", name, "--pic", "-o", out_dir,
+                  os.path.join(root, package)],
                  cwd=root, env=env)
     if result.returncode != 0:
-        fail("compiling the reproducer with the systematic-testing ponyc failed")
-    probe = os.path.join(out_dir, "probe")
-    if not os.access(probe, os.X_OK):
-        fail("reproducer binary not produced at " + probe)
-    return probe
+        fail("compiling %s with the systematic-testing ponyc failed" % name)
+    binary = os.path.join(out_dir, name)
+    if not os.access(binary, os.X_OK):
+        fail("reproducer binary not produced at " + binary)
+    return binary
 
 
-def order_sig(probe, seed):
+def order_sig(binary, seed):
     """Run the reproducer once and return its ORDER_SIG, or fail loudly.
 
     stderr is captured (not discarded) so it can be surfaced on failure -- the
     systematic-testing banner goes to stderr, but so would any crash diagnostic.
     """
-    cmd = [probe, "--ponysystematictestingseed", str(seed), "--ponynoscale"]
+    cmd = [binary, "--ponysystematictestingseed", str(seed), "--ponynoscale"]
     try:
         result = run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                      timeout=RUN_TIMEOUT_SECONDS)
@@ -144,6 +167,29 @@ def order_sig(probe, seed):
         fail("no ORDER_SIG in output at seed %d; stdout: %r; stderr:\n%s"
              % (seed, result.stdout, result.stderr.decode(errors="replace")))
     return sig
+
+
+def check_fixture(binary, name):
+    """Assert the reproducibility property for one compiled fixture."""
+    # Reproducible: one seed, many runs, all identical.
+    repro_sigs = [order_sig(binary, REPRODUCIBILITY_SEED)
+                  for _ in range(REPRODUCIBILITY_RUNS)]
+    if not is_reproducible(repro_sigs):
+        fail("%s: seed %d gave %d distinct ORDER_SIG over %d runs (expected 1, "
+             "so the interleaving is not reproducible): %s"
+             % (name, REPRODUCIBILITY_SEED, len(set(repro_sigs)),
+                REPRODUCIBILITY_RUNS, sorted(set(repro_sigs))))
+    print("%s reproducible: seed %d gave one ORDER_SIG (%s) over %d runs"
+          % (name, REPRODUCIBILITY_SEED, repro_sigs[0], REPRODUCIBILITY_RUNS))
+
+    # Still exploring: several seeds must not collapse to one ordering.
+    seed_sigs = [order_sig(binary, seed) for seed in EXPLORATION_SEEDS]
+    if not explores(seed_sigs):
+        fail("%s: all %d seeds produced the same ORDER_SIG (%s); seed no longer "
+             "drives the interleaving -- exploration has collapsed"
+             % (name, len(EXPLORATION_SEEDS), seed_sigs[0]))
+    print("%s still exploring: %d seeds produced %d distinct ORDER_SIG"
+          % (name, len(EXPLORATION_SEEDS), len(set(seed_sigs))))
 
 
 def main():
@@ -164,27 +210,9 @@ def main():
     ponyc = build_systematic_ponyc(root)
 
     with tempfile.TemporaryDirectory(prefix="systematic-repro-") as out_dir:
-        probe = compile_reproducer(root, ponyc, out_dir)
-
-        # Reproducible: one seed, many runs, all identical.
-        repro_sigs = [order_sig(probe, REPRODUCIBILITY_SEED)
-                      for _ in range(REPRODUCIBILITY_RUNS)]
-        if not is_reproducible(repro_sigs):
-            fail("seed %d gave %d distinct ORDER_SIG over %d runs (expected 1, "
-                 "so the interleaving is not reproducible): %s"
-                 % (REPRODUCIBILITY_SEED, len(set(repro_sigs)),
-                    REPRODUCIBILITY_RUNS, sorted(set(repro_sigs))))
-        print("reproducible: seed %d gave one ORDER_SIG (%s) over %d runs"
-              % (REPRODUCIBILITY_SEED, repro_sigs[0], REPRODUCIBILITY_RUNS))
-
-        # Still exploring: several seeds must not collapse to one ordering.
-        seed_sigs = [order_sig(probe, seed) for seed in EXPLORATION_SEEDS]
-        if not explores(seed_sigs):
-            fail("all %d seeds produced the same ORDER_SIG (%s); seed no longer "
-                 "drives the interleaving -- exploration has collapsed"
-                 % (len(EXPLORATION_SEEDS), seed_sigs[0]))
-        print("still exploring: %d seeds produced %d distinct ORDER_SIG"
-              % (len(EXPLORATION_SEEDS), len(set(seed_sigs))))
+        for package, name in FIXTURES:
+            binary = compile_reproducer(root, ponyc, out_dir, package, name)
+            check_fixture(binary, name)
 
     print("systematic-testing reproducibility smoke test passed")
 

--- a/.release-notes/systematic-testing-layout-independent.md
+++ b/.release-notes/systematic-testing-layout-independent.md
@@ -1,0 +1,3 @@
+## Make systematic testing replay independent of memory layout
+
+Under `use=systematic_testing`, replaying a run from a fixed `--ponysystematictestingseed` is meant to reproduce the same scheduler interleaving. Previously this could fail for programs with enough actor-to-actor messaging to trigger backpressure: the replay depended on the process's memory layout, so address-space layout randomization (ASLR) made the same seed produce different interleavings from one run to the next, even with `--ponynoscale` and a fixed thread count. A fixed seed now replays the same interleaving regardless of memory layout.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -32,6 +32,15 @@ pony_static_assert((offsetof(pony_actor_t, gc) + sizeof(gc_t)) ==
 
 static bool actor_noblock = false;
 
+#ifdef USE_SYSTEMATIC_TESTING
+// Monotonic source of stable, creation-order actor ids
+// (pony_actor_t.systematic_testing_id). Static, so zero-initialized at process
+// load; not reset by pony_stop. That is fine: only the relative creation order
+// within a single runtime lifetime is used, and a fixed seed reproduces that
+// order because systematic testing creates actors deterministically.
+static PONY_ATOMIC(uint64_t) actor_systematic_testing_id_counter;
+#endif
+
 #ifdef USE_RUNTIMESTATS
 void print_actor_stats(pony_actor_t* actor)
 {
@@ -888,6 +897,15 @@ PONY_API pony_actor_t* pony_create(pony_ctx_t* ctx, pony_type_t* type,
   pony_actor_t* actor = (pony_actor_t*)ponyint_pool_alloc_size(type->size);
   memset(actor, 0, type->size);
   actor->type = type;
+
+#ifdef USE_SYSTEMATIC_TESTING
+  // Assign a stable, monotonic creation-order id (ids start at 1; 0 is never a
+  // valid actor id). Used to order otherwise pointer-ordered scheduling
+  // decisions deterministically (see pony_actor_t.systematic_testing_id).
+  actor->systematic_testing_id =
+    atomic_fetch_add_explicit(&actor_systematic_testing_id_counter, 1,
+      memory_order_relaxed) + 1;
+#endif
 
 #ifdef USE_RUNTIMESTATS
   ctx->schedulerstats.mem_used_actors += type->size;

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -96,6 +96,14 @@ typedef struct pony_actor_t
 #ifdef USE_RUNTIMESTATS
   actorstats_t actorstats; // 64/128 bytes
 #endif
+#ifdef USE_SYSTEMATIC_TESTING
+  // Stable, monotonic creation-order id. Under systematic testing the runtime
+  // orders otherwise pointer-ordered scheduling decisions (e.g. rescheduling
+  // unmuted actors) by this id instead of by actor address, so a fixed seed
+  // replays the same interleaving regardless of ASLR. Not present in
+  // non-systematic builds.
+  uint64_t systematic_testing_id;
+#endif
   gc_t gc; // 48/88 bytes
   // if you add more members here, you need to update the PONY_ACTOR_PAD_SIZE
   // calculation below and the pony_static_assert at the top of actor.c, to

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -15,6 +15,9 @@
 #include <string.h>
 #include "mutemap.h"
 #include "../tracing/tracing.h"
+#ifdef USE_SYSTEMATIC_TESTING
+#include <stdlib.h>
+#endif
 
 #ifdef USE_RUNTIMESTATS
 #include <stdio.h>
@@ -2183,6 +2186,31 @@ void ponyint_sched_start_global_unmute(uint32_t from, pony_actor_t* actor)
 DECLARE_STACK(ponyint_actorstack, actorstack_t, pony_actor_t);
 DEFINE_STACK(ponyint_actorstack, actorstack_t, pony_actor_t);
 
+#ifdef USE_SYSTEMATIC_TESTING
+// Order two actors by their stable creation-order id so unmuted actors are
+// rescheduled in a layout-independent order rather than in the muteset's
+// pointer-hash iteration order (which depends on ASLR). ids are unique, so
+// there are no ties and qsort's instability cannot reintroduce a layout
+// dependence.
+static int sched_actor_systematic_testing_id_cmp(const void* a, const void* b)
+{
+  uint64_t ia = (*(pony_actor_t* const*)a)->systematic_testing_id;
+  uint64_t ib = (*(pony_actor_t* const*)b)->systematic_testing_id;
+  return (ia > ib) - (ia < ib);
+}
+#endif
+
+// Reschedule one no-longer-muted actor. Both unmute arms in
+// ponyint_sched_unmute_senders go through this so they stay behaviorally
+// identical; they differ only in the order they walk the actors.
+static void sched_reschedule_unmuted(pony_ctx_t* ctx, pony_actor_t* actor)
+{
+  ponyint_unmute_actor(actor);
+  ponyint_sched_add(ctx, actor);
+  DTRACE2(ACTOR_SCHEDULED, (uintptr_t)ctx->scheduler, (uintptr_t)actor);
+  ponyint_sched_start_global_unmute(ctx->scheduler->index, actor);
+}
+
 bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   size_t actors_rescheduled = 0;
@@ -2198,6 +2226,9 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
     size_t i = HASHMAP_UNKNOWN;
     pony_actor_t* muted = NULL;
     actorstack_t* needs_unmuting = NULL;
+#ifdef USE_SYSTEMATIC_TESTING
+    size_t needs_unmuting_count = 0;
+#endif
 
 #ifdef USE_RUNTIMESTATS
     ctx->schedulerstats.mem_used -= sizeof(muteref_t);
@@ -2221,26 +2252,52 @@ bool ponyint_sched_unmute_senders(pony_ctx_t* ctx, pony_actor_t* actor)
       if(muted->muted == 0)
       {
         needs_unmuting = ponyint_actorstack_push(needs_unmuting, muted);
+#ifdef USE_SYSTEMATIC_TESTING
+        needs_unmuting_count++;
+#endif
       }
     }
 
     ponyint_mutemap_removeindex(&sched->mute_mapping, index);
     ponyint_muteref_free(mref);
 
-    // Unmute any actors that need to be unmuted
+    // Reschedule the actors that are no longer muted. Under systematic testing
+    // we sort them by stable creation-order id so the run-queue order (and thus
+    // the replayed interleaving) does not depend on the muteset's pointer-hash
+    // iteration order, i.e. on memory layout; otherwise we walk the stack
+    // directly. Both arms reschedule via sched_reschedule_unmuted.
+#ifdef USE_SYSTEMATIC_TESTING
+    if(needs_unmuting_count > 0)
+    {
+      pony_actor_t** unmuting = (pony_actor_t**)ponyint_pool_alloc_size(
+        needs_unmuting_count * sizeof(pony_actor_t*));
+      size_t k = 0;
+
+      while(needs_unmuting != NULL)
+        needs_unmuting = ponyint_actorstack_pop(needs_unmuting, &unmuting[k++]);
+
+      qsort(unmuting, needs_unmuting_count, sizeof(pony_actor_t*),
+        sched_actor_systematic_testing_id_cmp);
+
+      for(k = 0; k < needs_unmuting_count; k++)
+      {
+        sched_reschedule_unmuted(ctx, unmuting[k]);
+        actors_rescheduled++;
+      }
+
+      ponyint_pool_free_size(needs_unmuting_count * sizeof(pony_actor_t*),
+        unmuting);
+    }
+#else
     pony_actor_t* to_unmute;
 
     while(needs_unmuting != NULL)
     {
       needs_unmuting = ponyint_actorstack_pop(needs_unmuting, &to_unmute);
-
-      ponyint_unmute_actor(to_unmute);
-      ponyint_sched_add(ctx, to_unmute);
-      DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)to_unmute);
+      sched_reschedule_unmuted(ctx, to_unmute);
       actors_rescheduled++;
-
-      ponyint_sched_start_global_unmute(ctx->scheduler->index, to_unmute);
     }
+#endif
   }
 
 #ifdef USE_RUNTIMESTATS

--- a/test/rt-systematic/README.md
+++ b/test/rt-systematic/README.md
@@ -12,3 +12,11 @@ by a dedicated CI script.
   still produce different ones. Driven by
   `.ci-scripts/systematic-testing/determinism_smoke.py`, run weekly from
   `.github/workflows/ponyc-weekly-checks.yml`.
+- `mute-order-signature/` — a ring of nodes forwards tokens with deterministic
+  `(id + 1) % n` routing, then reports arrivals into the same `ORDER_SIG` hash.
+  Unlike `order-signature`, the volume of foreign actor-to-actor sends overloads
+  actors and exercises the muting/unmuting reschedule path, so it guards a
+  different slice of the same replay property. Same driver, run at the runtime's
+  default thread count; its node/token counts are sized so actors overload at the
+  small physical-core counts a CI runner typically has (the muting-driven
+  reordering only appears when thread count and load are balanced).

--- a/test/rt-systematic/mute-order-signature/main.pony
+++ b/test/rt-systematic/mute-order-signature/main.pony
@@ -1,0 +1,103 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility check (#5560),
+covering the actor muting / unmuting scheduling path.
+
+A ring of 48 Node actors each forwards a token to the next node a fixed number
+of times (deterministic `(id + 1) % n` routing -- no randomness, no clock), then
+reports the token's arrival to a single Collector. The Collector folds
+(token_id, node_id) of every arrival into an order-sensitive hash printed as
+ORDER_SIG, a pure function of the scheduler interleaving.
+
+Unlike order-signature (whose senders only self-send and fan into the collector,
+so no actor ever overloads another), the volume of foreign actor-to-actor sends
+here drives backpressure: nodes overload, their senders get muted, and are later
+rescheduled when the overloaded node drains. That unmute-rescheduling step is a
+distinct part of the scheduler that order-signature does not exercise, so this
+fixture guards a different slice of the "fixed seed replays one interleaving"
+property.
+
+The muting-driven reordering only manifests when scheduler-thread count and load
+are in balance, so the node and token counts here are sized to overload actors
+at the handful of physical cores a CI runner typically has (the runtime defaults
+to one scheduler thread per physical core). See
+.ci-scripts/systematic-testing/determinism_smoke.py, which builds a
+systematic-testing ponyc, compiles this program with it, and asserts the
+property under --ponynoscale. It is not part of the normal test suites.
+"""
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+use @exit[None](status: I32)
+
+actor Main
+  new create(env: Env) =>
+    let nodes: USize = 48
+    let tokens: USize = 600
+    let ttl: USize = 16
+    let collector = Collector(tokens)
+    let ring: Array[Node] iso = recover Array[Node](nodes) end
+    var i: USize = 0
+    while i < nodes do
+      ring.push(Node(collector, i))
+      i = i + 1
+    end
+    let ring': Array[Node] val = consume ring
+    for node in ring'.values() do
+      node.wire(ring')
+    end
+    // Wire every node before injecting tokens; causal messaging then delivers
+    // each node's wire() ahead of any token() that can reach it, so _ring is
+    // always set when token() runs.
+    var t: USize = 0
+    while t < tokens do
+      try ring'(t % nodes)?.token(ttl, t) end
+      t = t + 1
+    end
+
+actor Node
+  let _collector: Collector
+  let _id: USize
+  var _ring: Array[Node] val = recover val Array[Node] end
+
+  new create(collector: Collector, id: USize) =>
+    _collector = collector
+    _id = id
+
+  be wire(ring: Array[Node] val) =>
+    _ring = ring
+
+  be token(ttl: USize, id: USize) =>
+    if ttl > 0 then
+      // Deterministic next hop: a foreign send that, in volume, overloads the
+      // receiver and triggers the muting path. `next` is always in
+      // [0, _ring.size()), so the indexed access cannot error.
+      let next = (_id + 1) % _ring.size()
+      try _ring(next)?.token(ttl - 1, id) end
+    else
+      _collector.recv(id, _id)
+    end
+
+actor Collector
+  let _expected: USize
+  var _received: USize = 0
+  // FNV-1a-style rolling hash of the arrival order: an interleaving signature
+  var _sig: U64 = 14695981039346656037
+
+  new create(expected: USize) =>
+    _expected = expected
+
+  be recv(token_id: USize, node_id: USize) =>
+    _mix(token_id.u64())
+    _mix(node_id.u64())
+    _received = _received + 1
+    if _received == _expected then
+      // Synchronous printf then forced exit, as in order-signature:
+      // env.out.print is async and would be lost on @exit, and the forced exit
+      // sidesteps the separate shutdown-hang symptom. The signature is fully
+      // computed first, so the determinism result is unaffected.
+      let line = "RECEIVED=" + _received.string()
+        + " ORDER_SIG=" + _sig.string() + "\n"
+      @printf("%s".cstring(), line.cstring())
+      @exit(0)
+    end
+
+  fun ref _mix(v: U64) =>
+    _sig = (_sig xor v) * 1099511628211


### PR DESCRIPTION
Under `use=systematic_testing`, replaying a run from a fixed `--ponysystematictestingseed` is meant to reproduce the same scheduler interleaving. It did not for workloads with enough actor-to-actor messaging to trigger backpressure: when an overloaded actor drained, the scheduler rescheduled its muted senders in the muteset's `hash_ptr(actor)` iteration order, which depends on actor addresses. ASLR then made the same seed produce different interleavings from run to run, even with `--ponynoscale` and a fixed thread count.

This gives each actor a stable creation-order id (`systematic_testing_id`, gated to `USE_SYSTEMATIC_TESTING`, so normal builds are unaffected) and reschedules the unmuted actors in that order instead of by address.

The weekly determinism smoke test never caught this because its `order-signature` fixture only self-sends and so never mutes. A new `test/rt-systematic/mute-order-signature` fixture, wired into the smoke test, overloads actors via foreign sends and guards the muting reschedule path.

This addresses the demonstrated muting reschedule path. Other actor-pointer-ordered scheduling paths exist — notably the ORCA ACQUIRE/RELEASE send ordering — verified pointer-ordered by inspection but not shown to change observable ordering by any reproducer; they are not changed here. A tracking issue will follow.

The `mute-order-signature` fixture only guards the muting path when actors actually overload, which needs load and thread count balanced; it is sized for the handful of physical cores a CI runner has. On a much larger runner it degrades to a plain reproducibility check (still correct, just no longer guarding muting) — documented in the smoke script.

Design: #5560
