### PR TITLE
Fix an intermittent hang when using systematic testing

### DIFF
--- a/.release-notes/fix-systematic-testing-intermittent-hang.md
+++ b/.release-notes/fix-systematic-testing-intermittent-hang.md
@@ -1,0 +1,6 @@
+## Fix an intermittent hang when using systematic testing
+
+Programs run under systematic testing (`--ponysystematictestingseed`) could
+intermittently hang instead of running to completion. The hang was timing
+sensitive: the same seed might hang on one run and finish normally on another.
+This has been fixed.

--- a/src/libponyrt/sched/systematic_testing.c
+++ b/src/libponyrt/sched/systematic_testing.c
@@ -269,11 +269,20 @@ void ponyint_systematic_testing_yield()
 
     if(!current_thread->stopped)
     {
+      // Park until it is genuinely this thread's turn again. The underlying
+      // wait can return without a matching wake -- pthread_cond_wait is allowed
+      // to wake spuriously (POSIX), and a stray wake is more likely under load.
+      // Returning here while active_thread still points at another thread would
+      // let this thread run out of turn and desync the single-runner handoff,
+      // deadlocking every thread. Re-check and re-park, as wait_start does.
+      while(active_thread != current_thread)
+      {
 #if defined(USE_SCHEDULER_SCALING_PTHREADS)
-      ponyint_thread_suspend(current_thread->sleep_object, &systematic_testing_mut);
+        ponyint_thread_suspend(current_thread->sleep_object, &systematic_testing_mut);
 #else
-      ponyint_thread_suspend(current_thread->sleep_object);
+        ponyint_thread_suspend(current_thread->sleep_object);
 #endif
+      }
       TRACING_SYSTEMATIC_TESTING_TIMESLICE_BEGIN();
     }
     else


### PR DESCRIPTION
Programs run under systematic testing (`--ponysystematictestingseed`) could intermittently deadlock instead of running to completion. Because the trigger is timing sensitive, the same seed might hang on one run and finish normally on another.

The systematic-testing scheduler runs one thread at a time and hands off the work by waking the next thread and parking the current one. The yield handoff parked the current thread with a single condition-variable wait and no predicate loop. `pthread_cond_wait` is allowed to return spuriously (POSIX), and a stray wake is likelier under load; a spurious return there let a thread resume out of turn while the baton still pointed at another thread, desyncing the single-runner handoff and parking every thread. `wait_start` in the same file already used the correct re-check-and-re-park pattern, so the yield handoff now does too.

This is confined to systematic testing; the production scheduler's suspend already re-checks its condition in a loop.

Surfaced by the generative runtime stress harness. Reproduced locally by injecting simulated spurious wakeups, which turned otherwise-deterministic seeds into intermittent deadlocks; the predicate loop eliminates them.