### PR TITLE
Fix generative stress test crash on macOS

### DIFF
--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -17,8 +17,10 @@ an `if systematic` branch in shared code.
 Cross-platform: this runs on Linux, macOS, AND Windows. Both modes target all
 three TIER1 platforms (on Windows the systematic build uses
 `use=systematic_testing` alone -- Windows scales the scheduler with native
-primitives, not pthreads). POSIX-only facilities (the RLIMIT_AS memory cap) are
-gated here; the wall-clock watchdog is portable.
+primitives, not pthreads). The RLIMIT_AS memory cap is applied only where the OS
+honors it (Linux): Windows lacks the `resource` module and macOS rejects the
+limit, so both fall back to host OOM handling. The wall-clock watchdog is
+portable.
 
 The pure pieces (derive_seed / resolve_workload / draw_* / build_argv /
 run_command / parse_result / lldb_argv / lldb_exit_code) are unit-tested in
@@ -274,8 +276,29 @@ class RunResult:
         self.stderr = stderr
 
 
+def _rlimit_as_supported(platform, resource_available):
+    """Whether to install the RLIMIT_AS address-space cap on this platform.
+
+    An allowlist, not a denylist: the cap is applied only on Linux, the one
+    TIER1 platform validated to honor RLIMIT_AS. Windows lacks the POSIX
+    `resource` module entirely; macOS HAS it but Darwin does not honor
+    RLIMIT_AS, and `setrlimit` raises there -- inside `preexec_fn` (post-fork,
+    pre-exec) that aborts the spawn with `SubprocessError`, crashing every run
+    before the engine starts rather than capping anything.
+
+    Allowlisting is deliberate: that macOS crash is the failure mode of applying
+    the cap on an unvalidated platform, so any platform we have not confirmed
+    falls back to the host's OOM handling (as Windows already did) instead of
+    risking the same crash. A new platform that honors RLIMIT_AS is added here
+    explicitly once validated.
+
+    Pure (platform + resource-availability in, bool out) so it is testable from
+    any host regardless of where the suite runs."""
+    return resource_available and (platform == "linux")
+
+
 def _capture(argv, timeout, mem_limit_bytes):
-    """Run argv under a wall-clock watchdog and (on POSIX) an RLIMIT_AS cap;
+    """Run argv under a wall-clock watchdog and (on Linux) an RLIMIT_AS cap;
     return (timed_out, returncode, stdout, stderr). Mechanism only -- the caller
     classifies the outcome.
 
@@ -287,10 +310,12 @@ def _capture(argv, timeout, mem_limit_bytes):
     `start_new_session` puts the child in its own group so killpg reaps the tree.
 
     The address-space cap (== `ulimit -v`, covering the pool allocator's mmap'd
-    regions) is POSIX-only; on Windows the `resource` module is absent, so
-    preexec_fn stays None and the job relies on the CI host's OOM handling."""
+    regions) is applied only where the OS honors it -- see _rlimit_as_supported
+    for why Windows and macOS are excluded; there preexec_fn stays None and the
+    job relies on the host's OOM handling."""
     preexec = None
-    if (resource is not None) and (mem_limit_bytes is not None):
+    if (mem_limit_bytes is not None) and _rlimit_as_supported(
+            sys.platform, resource is not None):
         def set_limits():
             resource.setrlimit(resource.RLIMIT_AS,
                                (mem_limit_bytes, mem_limit_bytes))

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -318,6 +318,24 @@ def test_run_under_lldb():
         common._capture = real
 
 
+def test_rlimit_as_supported():
+    # Linux honors RLIMIT_AS and ships the resource module: cap applies.
+    check("rlimit_as_supported: linux with resource -> True",
+          common._rlimit_as_supported("linux", True) is True)
+    # macOS has the resource module but setrlimit(RLIMIT_AS) raises there, so
+    # the cap must be skipped even when resource is available.
+    check("rlimit_as_supported: darwin with resource -> False",
+          common._rlimit_as_supported("darwin", True) is False)
+    # Windows lacks the resource module (resource_available is False).
+    check("rlimit_as_supported: windows without resource -> False",
+          common._rlimit_as_supported("win32", False) is False)
+    # Allowlist, not denylist: an unvalidated POSIX platform (e.g. a BSD) is
+    # skipped even with resource available -- fail safe rather than risk the
+    # macOS-style preexec_fn crash on a platform we have not confirmed.
+    check("rlimit_as_supported: unvalidated posix with resource -> False",
+          common._rlimit_as_supported("freebsd14", True) is False)
+
+
 def test_bundle_for():
     result = common.RunResult("fail", 1, None, "out", "err")
     limits = {"timeout_seconds": 60, "mem_limit_bytes": None}
@@ -393,6 +411,7 @@ def main():
     test_lldb_exit_code()
     test_run_once()
     test_run_under_lldb()
+    test_rlimit_as_supported()
     test_bundle_for()
     test_resolve_seeds()
     test_parse_result()


### PR DESCRIPTION
The macOS systematic generative stress job crashed before the engine ran. The harness caps each run's address space with an RLIMIT_AS limit set in a subprocess preexec_fn, and macOS does not honor RLIMIT_AS: setrlimit raises there, which Python reports as `SubprocessError: Exception occurred in preexec_fn`, failing every run.

The cap is a soft guardrail that already falls back to host OOM handling where it can't be applied (Windows, which has no `resource` module). This applies it only on Linux, the one TIER1 platform validated to honor RLIMIT_AS. The gate is an allowlist, not a denylist, so an unvalidated platform skips the cap and falls back rather than hitting the same preexec_fn crash.

The normal-mode macOS job runs through the same code and would have failed the same way once its schedule fired. Both modes are fixed.
