### PR TITLE
Fix systematic testing build failure under gcc

### DIFF
--- a/.release-notes/fix-systematic-testing-gcc-build.md
+++ b/.release-notes/fix-systematic-testing-gcc-build.md
@@ -1,0 +1,3 @@
+## Fix systematic testing build failure under gcc
+
+Building with `use=systematic_testing` under gcc failed to compile with a spurious compiler error. The build now compiles cleanly under gcc.

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -166,7 +166,7 @@ static int parse_uint64(uint64_t* target, uint64_t min, const char *value) {
   uint64_t v = strtoull(value, NULL, 10);
 #endif
 
-  if (v < (min < 0 ? 0 : min)) {
+  if (v < min) {
     return 1;
   }
   *target = v;


### PR DESCRIPTION
Building with `use=systematic_testing` under gcc fails to compile: `parse_uint64` guards its lower bound with `if (v < (min < 0 ? 0 : min))`, but `min` is a `uint64_t`, so `min < 0` is always false and gcc's `-Werror=type-limits` turns it into a hard error. The guard collapses to `min` anyway, so the fix is `if (v < min)`. The function is gated behind `USE_SYSTEMATIC_TESTING` and clang doesn't flag it, so only a gcc build of the systematic config saw it.

Verified by building the `debug` + `scheduler_scaling_pthreads,systematic_testing` config from scratch under gcc; it now compiles cleanly.

Closes #5563