### PR TITLE
Parallelize the Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,12 +534,16 @@ if(MSVC)
     set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
     # Disable some warnings for Windows, and compile Debug builds with the regular CRT.
+    # /MP lets cl.exe compile the many source files within a single project (e.g.
+    # libponyc) concurrently; without it MSBuild's project-level --parallel only
+    # parallelizes across projects, leaving big single-target compiles serial.
     add_compile_options(
         /wd4142
         /wd4996
         $<$<CONFIG:Debug>:/MD>
         /WX
         /EHa
+        /MP
     )
     add_compile_definitions(
         _MBCS

--- a/make.ps1
+++ b/make.ps1
@@ -218,6 +218,9 @@ switch ($Command.ToLower())
         if ($err -ne 0) { throw "Error: exit code $err" }
 
         # Write-Output "Building libraries..."
+        # Capped at 4 (not NUMBER_OF_PROCESSORS like the `build` command) because
+        # LLVM translation units are memory-hungry; a higher count risks
+        # exhausting a CI runner's RAM.
         Write-Output "cmake.exe --build `"$libsBuildDir`" --target install --config Release --parallel 4"
         & cmake.exe --build "$libsBuildDir" --target install --config Release --parallel 4
         $err = $LastExitCode
@@ -277,8 +280,17 @@ switch ($Command.ToLower())
     }
     "build"
     {
-        Write-Output "cmake.exe --build `"$buildDir`" --config $Config --target ALL_BUILD"
-        & cmake.exe --build "$buildDir" --config $Config --target ALL_BUILD
+        # `--parallel` drives MSBuild's project-level parallelism (/m); the
+        # per-source parallelism within a project comes from the /MP flag set in
+        # CMakeLists.txt. Without both, the Windows build compiles serially.
+        # The two combined can oversubscribe (up to jobs x cores cl.exe
+        # processes); left uncapped because ponyc translation units are small
+        # and the memory-heavy LLVM build is a separate, capped step (libs).
+        # Cap this if a smaller CI runner shows memory pressure.
+        $jobs = $env:NUMBER_OF_PROCESSORS
+        if ([string]::IsNullOrEmpty($jobs)) { $jobs = [Environment]::ProcessorCount }
+        Write-Output "cmake.exe --build `"$buildDir`" --config $Config --target ALL_BUILD --parallel $jobs"
+        & cmake.exe --build "$buildDir" --config $Config --target ALL_BUILD --parallel $jobs
         $err = $LastExitCode
         if ($err -ne 0) { throw "Error: exit code $err" }
         break


### PR DESCRIPTION
The Windows CI build compiled serially while Linux and macOS build in parallel. `make.ps1`'s `build` step passed no `--parallel` to `cmake`, and the MSVC config set no `/MP`.

The Visual Studio generator splits parallelism across two axes, so closing the gap takes both flags:

- `--parallel $env:NUMBER_OF_PROCESSORS` drives MSBuild's project-level concurrency (`/m`).
- `/MP` (added to the MSVC `add_compile_options`) drives `cl.exe`'s per-source concurrency within a project. The long-pole `libponyc` compile is a single project, so it only benefits from `/MP`.

Measured locally on a 16-core machine: a clean Debug build dropped from 278s to 168s (~1.65x). The ceiling is structural -- the large LLVM link steps are single-threaded and gated behind the `libponyc` compile -- not a misconfiguration.