### PR TITLE
Don't resurrect TCPConnection readiness flags after a hard close

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -41,6 +41,7 @@ actor \nodoc\ Main is TestList
     test(_TestTCPExpect)
     test(_TestTCPExpectOverBufferSize)
     test(_TestTCPExpectSetToZero)
+    test(_TestTCPGracefulClose)
     test(_TestTCPMute)
     test(_TestTCPMutePeerCloseUndetected)
     test(_TestTCPProxy)
@@ -2314,6 +2315,69 @@ class \nodoc\ _TestTCPMuteClosePeerNotify is TCPConnectionNotify
 
   fun ref connect_failed(conn: TCPConnection ref) =>
     _h.fail_action("sender connect failed")
+
+class \nodoc\ iso _TestTCPGracefulClose is UnitTest
+  """
+  Test that a graceful `close` on an established, unmuted connection runs to
+  completion. `close` sets `_closed` but leaves `_connected` true, so the
+  connection must keep reacting to readiness while it drains: it reads the
+  peer's close and then fires `closed`. This pins the `_event_notify` readiness
+  gate to `_connected` -- gating it on `_closed` as well would drop the draining
+  read, and the initiator's `closed` would never fire.
+
+  The client closes its side as soon as it connects; the server reads that close
+  and hard closes in turn, which gives the client a peer close to read. The
+  client reads it and completes. A timeout means the client never saw the peer
+  close -- failure.
+  """
+  fun name(): String => "net/TCPGracefulClose"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("client connected")
+    h.expect_action("client closed")
+
+    _TestTCP(h)(_TestTCPGracefulCloseClientNotify(h),
+      _TestTCPGracefulCloseServerNotify(h))
+
+class \nodoc\ _TestTCPGracefulCloseClientNotify is TCPConnectionNotify
+  """
+  Client side: close gracefully as soon as we connect, then expect `closed` to
+  fire once we have read the server's close. That read happens while `_closed`
+  is set but `_connected` is still true -- the drain the readiness gate must
+  keep allowing.
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: TCPConnection ref) =>
+    _h.complete_action("client connected")
+    conn.close()
+
+  fun ref closed(conn: TCPConnection ref) =>
+    _h.complete_action("client closed")
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("client connect failed")
+
+class \nodoc\ _TestTCPGracefulCloseServerNotify is TCPConnectionNotify
+  """
+  Server side: accept and let the runtime react to the client's close. Reading
+  the client's close (a zero-length read) hard closes this side, which closes
+  its socket and so gives the client a peer close to read.
+  """
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    _h.dispose_when_done(conn)
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    _h.fail_action("server connect failed")
 
 class \nodoc\ iso _TestTCPThrottle is UnitTest
   """

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -603,7 +603,18 @@ actor TCPConnection is AsioEventNotify
       end
 
       if AsioEvent.writeable(flags) then
-        _writeable = true
+        // Only set the flag while still connected. A readiness event for our
+        // own event can still be in our queue after `hard_close` unsubscribed
+        // and set the flags false; without this gate it would resurrect
+        // `_writeable` and break `hard_close`'s post-condition. Gate on
+        // `_connected` (not `_closed`): a graceful `close` sets `_closed` while
+        // the connection is still draining and must keep reacting to readiness;
+        // only `hard_close` clears `_connected`. Re-checking per block (rather
+        // than once around both) also covers `_pending_writes` calling
+        // `hard_close` on a write error before the readable block runs.
+        if _connected then
+          _writeable = true
+        end
         if _pending_writes() then
           // Sent all data. Release backpressure.
           _release_backpressure()
@@ -611,7 +622,11 @@ actor TCPConnection is AsioEventNotify
       end
 
       if AsioEvent.readable(flags) then
-        _readable = true
+        // Gated on `_connected` for the same reason as the writeable block
+        // above.
+        if _connected then
+          _readable = true
+        end
         _pending_reads()
       end
 
@@ -932,6 +947,11 @@ actor TCPConnection is AsioEventNotify
     _writeable = false
     @pony_asio_event_set_readable(_event, false)
     @pony_asio_event_set_writeable(_event, false)
+
+    // `_event` is not nulled here (the later disposable event clears it), so a
+    // readiness event already queued for it can still reach `_event_notify`
+    // after this returns. The `_connected = false` set above is what makes that
+    // handler skip resurrecting `_readable`/`_writeable`.
 
     // POSIX closes the fd here; on Windows the readiness backend owns the close
     // (when it sees the deferred REMOVE from the unsubscribe above), so we must


### PR DESCRIPTION
A readiness event for our own asio event can already be queued in the actor's mailbox when `hard_close` runs — `unsubscribe` stops new notifications but doesn't recall a message that's already enqueued. When the actor ran that message, `_event_notify` set `_writeable`/`_readable` back to true with no check on connection state, breaking `hard_close`'s post-condition that a dead connection is neither readable nor writeable. It's latent today — nothing reads either flag after close — but a trap for any future change that does.

The fix gates both assignments on `_connected`, which is true while the connection is live or gracefully draining and false only after `hard_close`.

The issue suggested gating on `_connected and not _closed`. That turns out to be wrong: a graceful `close` sets `_closed` while the connection is still draining and must keep reacting to readiness to finish closing, so gating on `not _closed` drops the drain read and the close hangs. Gating on `_connected` alone fixes the resurrection without touching graceful close.

Adds `net/TCPGracefulClose`, which exercises the drain path the gate must keep allowing — a graceful close on the initiator completing after it reads the peer's close. It fails by timeout under the rejected `not _closed` gate.

Closes #5590
