### PR TITLE
Add normal-mode magnitude distribution to the generative stress harness

### DIFF
--- a/.github/workflows/stress-test-generative-normal-linux.yml
+++ b/.github/workflows/stress-test-generative-normal-linux.yml
@@ -28,10 +28,14 @@ concurrency:
 jobs:
   x86_64-linux-glibc:
     runs-on: ubuntu-latest
-    # Generous ceiling (matches the systematic jobs): the ponyc debug build, then
-    # a 30-minute wall-clock soak (--budget-seconds) plus a final-seed watchdog
-    # overshoot. The orchestrator caps each seed too.
-    timeout-minutes: 90
+    # Whole-job ceiling: ponyc debug build + a 90-min wall-clock soak
+    # (--budget-seconds) + a final-seed overshoot. A large run is ~15-20 min, but the
+    # orchestrator's flat per-run timeout (~100 min) bounds a HUNG final run, so the
+    # worst case is build + 90 + 100. This must stay under the gap to the next
+    # generative cron: the six generative workflows share one concurrency group, so
+    # a still-running job would silently drop the next scheduled run -- the normal
+    # cron slots are spaced >=4h apart for this.
+    timeout-minutes: 210
 
     name: x86-64-unknown-linux-ubuntu26.04 generative normal [debug]
     container:
@@ -68,7 +72,7 @@ jobs:
         run: |
           python3 test/rt-stress/generative/orchestrate_normal.py \
             --ponyc build/debug/ponyc \
-            --start ${{ github.run_id }} --budget-seconds 1800 \
+            --start ${{ github.run_id }} --budget-seconds 5400 \
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() && hashFiles('.libs-cache-miss') == '' }}

--- a/.github/workflows/stress-test-generative-normal-macos.yml
+++ b/.github/workflows/stress-test-generative-normal-macos.yml
@@ -2,7 +2,7 @@ name: "Stress Test: macOS Generative (Normal)"
 
 on:
   schedule:
-    - cron: "30 21 * * *"
+    - cron: "0 22 * * *"
   workflow_dispatch:
     inputs:
       sha:
@@ -28,10 +28,14 @@ concurrency:
 jobs:
   arm64-macos:
     runs-on: macos-26
-    # Generous ceiling (matches the systematic jobs): the ponyc debug build, then
-    # a 30-minute wall-clock soak (--budget-seconds) plus a final-seed watchdog
-    # overshoot. The orchestrator caps each seed too.
-    timeout-minutes: 90
+    # Whole-job ceiling: ponyc debug build + a 90-min wall-clock soak
+    # (--budget-seconds) + a final-seed overshoot. A large run is ~15-20 min, but the
+    # orchestrator's flat per-run timeout (~100 min) bounds a HUNG final run, so the
+    # worst case is build + 90 + 100. This must stay under the gap to the next
+    # generative cron: the six generative workflows share one concurrency group, so
+    # a still-running job would silently drop the next scheduled run -- the normal
+    # cron slots are spaced >=4h apart for this.
+    timeout-minutes: 210
 
     name: arm64 macOS generative normal [debug]
     steps:
@@ -60,7 +64,7 @@ jobs:
         run: |
           python3 test/rt-stress/generative/orchestrate_normal.py \
             --ponyc build/debug/ponyc \
-            --start ${{ github.run_id }} --budget-seconds 1800 \
+            --start ${{ github.run_id }} --budget-seconds 5400 \
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() && hashFiles('.libs-cache-miss') == '' }}

--- a/.github/workflows/stress-test-generative-normal-windows.yml
+++ b/.github/workflows/stress-test-generative-normal-windows.yml
@@ -2,7 +2,7 @@ name: "Stress Test: Windows Generative (Normal)"
 
 on:
   schedule:
-    - cron: "15 23 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       sha:
@@ -31,10 +31,14 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    # Generous ceiling (matches the systematic jobs): the ponyc debug build, then
-    # a 30-minute wall-clock soak (--budget-seconds) plus a final-seed watchdog
-    # overshoot. The orchestrator caps each seed too.
-    timeout-minutes: 90
+    # Whole-job ceiling: ponyc debug build + a 90-min wall-clock soak
+    # (--budget-seconds) + a final-seed overshoot. A large run is ~15-20 min, but the
+    # orchestrator's flat per-run timeout (~100 min) bounds a HUNG final run, so the
+    # worst case is build + 90 + 100. This must stay under the gap to the next
+    # generative cron: the six generative workflows share one concurrency group, so
+    # a still-running job would silently drop the next scheduled run -- the normal
+    # cron slots are spaced >=4h apart for this.
+    timeout-minutes: 210
 
     name: x86-64 Windows generative normal [debug]
     steps:
@@ -86,7 +90,7 @@ jobs:
           python test/rt-stress/generative/orchestrate_normal.py `
             --ponyc build/debug/ponyc.exe `
             --lldb 'C:\msys64\mingw64\bin\lldb.exe' `
-            --start ${{ github.run_id }} --budget-seconds 1800 `
+            --start ${{ github.run_id }} --budget-seconds 5400 `
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() && hashFiles('.libs-cache-miss') == '' }}

--- a/test/rt-stress/generative/orchestrate_normal.py
+++ b/test/rt-stress/generative/orchestrate_normal.py
@@ -60,22 +60,41 @@ def resolve_config(master_seed, max_threads):
     this is where the cycle detector gets its stress coverage now that
     string-message-ubench is retired.
 
+    Normal mode draws a deliberate small->large magnitude: chains and ttl each pick
+    a small/medium/large bucket at 25/50/25 (draw_bucketed), reaching ~1.16B messages
+    (~15-20 min on the calibration host) at the top, versus systematic's fixed tiny
+    range. The payload is then drawn with its string SIZE limited by the message count
+    (draw_payload): a big run may draw only a cheap size, so no run blows the flat
+    per-run timeout, while a small run may draw any size.
+
     This mode is non-reproducible (real parallelism), so a seed maps to a
     *configuration* deterministically but not to an *execution*. The draw order is
-    still pinned (orchestrate_normal_test.py) so a given seed yields a stable
-    config: workload (five fields) -> ponynoblock -> the four shared swarm knobs
-    -> payload-mode -> ponymaxthreads last. This contract is independent of the
-    systematic driver's (a seed need not mean the same config across modes).
+    pinned (orchestrate_normal_test.py) so a seed yields a stable config: pingers ->
+    chains (bucketed) -> ttl (bucketed) -> payload (kind, mode, size) ->
+    ponynoblock -> the four shared swarm knobs -> ponymaxthreads last. This contract
+    is independent of the systematic driver's, and it intentionally differs from the
+    pre-magnitude draw, so historical normal-mode seeds remap.
     """
     program_seed = common.derive_seed(master_seed, "program")
     rng = random.Random(master_seed)
 
-    workload = common.resolve_workload(rng, program_seed)
+    pingers = rng.choice(common.NORMAL_PINGERS)
+    chains = common.draw_bucketed(rng, common.NORMAL_SIZE_BUCKETS)
+    ttl = common.draw_bucketed(rng, common.NORMAL_SIZE_BUCKETS)
+    payload, size, mode = common.draw_payload(rng, chains * (ttl + 1))
+    workload = {
+        "seed": program_seed,
+        "pingers": pingers,
+        "chains": chains,
+        "ttl": ttl,
+        "payload": payload,
+        "payload-size": size,
+        "payload-mode": mode,
+    }
     runtime = {}
     if rng.random() < 0.5:
         runtime["ponynoblock"] = True
     common.draw_swarm_knobs(rng, runtime)
-    workload["payload-mode"] = common.draw_payload_mode(rng)
     runtime["ponymaxthreads"] = common.draw_max_threads(rng, max_threads)
 
     return {"master_seed": master_seed, "workload": workload, "runtime": runtime}
@@ -96,10 +115,11 @@ def main(argv):
                         "normal-mode crash does not reproduce")
     parser.add_argument("--out", help="output dir for the binary and bundles")
     parser.add_argument("--timeout", type=int,
-                        default=common.DEFAULT_TIMEOUT_SECONDS,
-                        help="per-run wall-clock watchdog, seconds (default %d); "
-                        "set to ~2x the slowest legitimate run"
-                        % common.DEFAULT_TIMEOUT_SECONDS)
+                        default=common.DEFAULT_NORMAL_TIMEOUT_SECONDS,
+                        help="per-run wall-clock watchdog, seconds (default %d); a "
+                        "flat ~2x the longest plausible large run with slow-CI "
+                        "margin -- a single hung run, not its true length, is the "
+                        "worst case" % common.DEFAULT_NORMAL_TIMEOUT_SECONDS)
     parser.add_argument("--mem-limit-mb", type=int,
                         default=common.DEFAULT_MEM_LIMIT_MB,
                         help="per-run address-space cap, MB (POSIX only; on "

--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -10,6 +10,7 @@ and ponynoblock is a swarm knob (drawn, not forced).
 import sys
 
 import orchestrate_normal as normal
+import stress_common as common
 
 FAILURES = []
 
@@ -26,25 +27,26 @@ def check(name, condition):
 
 def test_resolve_config_golden():
     # Pin resolve_config(0, 8): the normal-mode seed-stability guard. Distinct from
-    # the systematic golden -- normal draws ponynoblock as an extra swarm knob,
-    # which shifts every subsequent draw (hence different ponymaxthreads /
-    # payload-mode), and carries no systematic seed.
+    # the systematic golden -- normal draws bucketed chains/ttl, a payload whose string
+    # size is limited by the message count, and ponynoblock as a swarm knob, and
+    # carries no systematic seed.
+    # (This intentionally differs from the pre-magnitude normal golden -- the new
+    # draw remaps every historical seed.)
     expected = {
         "master_seed": 0,
         "runtime": {
             "ponycdinterval": 10,
-            "ponygcinitial": 65536,
+            "ponygcinitial": 1024,
             "ponymaxthreads": 5,
-            "ponynoblock": True,
         },
         "workload": {
-            "chains": 198,
+            "chains": 20891,
             "payload": "u64",
-            "payload-mode": "forward",
-            "payload-size": 1,
+            "payload-mode": "fresh",
+            "payload-size": 4096,
             "pingers": 64,
             "seed": 2686188150644990173,
-            "ttl": 48,
+            "ttl": 9876,
         },
     }
     check("resolve_config(0, 8) matches the pinned normal golden config",
@@ -83,6 +85,8 @@ def test_resolve_config_deterministic_and_bounded():
           normal.resolve_config(7, THREADS)
           == normal.resolve_config(7, THREADS))
 
+    # pingers=1 is drawn in normal mode -- it exercises the ORCA self-send path
+    # (bounded since PR #5594; see NORMAL_PINGERS).
     pingers_allowed = {1, 2, 4, 8, 16, 32, 64}
     size_allowed = {1, 8, 64, 256, 1024, 4096}
     invariants_hold = True
@@ -94,9 +98,10 @@ def test_resolve_config_deterministic_and_bounded():
         runtime = config["runtime"]
         if work["pingers"] not in pingers_allowed:
             invariants_hold = False
-        if not (1 <= work["chains"] <= 400):
+        # chains/ttl now span the magnitude buckets' union (small low .. large high).
+        if not (1500 <= work["chains"] <= 34000):
             invariants_hold = False
-        if not (0 <= work["ttl"] <= 48):
+        if not (1500 <= work["ttl"] <= 34000):
             invariants_hold = False
         if work["payload"] not in ("string", "u64"):
             invariants_hold = False
@@ -128,12 +133,68 @@ def test_resolve_config_swarm_omission():
         check("swarm omission: %s sometimes absent" % knob, counts[knob] < 300)
 
 
+def test_resolve_config_magnitude_buckets():
+    # The deliberate small->large distribution: chains and ttl each draw a
+    # small/medium/large bucket, and over many seeds BOTH knobs must reach all three.
+    b = common.NORMAL_SIZE_BUCKETS
+    chains_buckets = {"small": 0, "medium": 0, "large": 0}
+    ttl_buckets = {"small": 0, "medium": 0, "large": 0}
+    for master in range(0, 300):
+        w = normal.resolve_config(master, THREADS)["workload"]
+        for val, seen in ((w["chains"], chains_buckets), (w["ttl"], ttl_buckets)):
+            if val <= b["small"][1]:
+                seen["small"] += 1
+            elif val <= b["medium"][1]:
+                seen["medium"] += 1
+            else:
+                seen["large"] += 1
+    check("chains reaches all three magnitude buckets",
+          all(c > 0 for c in chains_buckets.values()))
+    check("ttl reaches all three magnitude buckets",
+          all(c > 0 for c in ttl_buckets.values()))
+
+
+def test_resolve_config_draws_single_pinger():
+    # pingers=1 must be drawn in normal mode: it exercises the ORCA self-send path
+    # (bounded since PR #5594), so the soak keeps a standing stress on that fix.
+    one_seen = False
+    for master in range(0, 500):
+        if normal.resolve_config(master, THREADS)["workload"]["pingers"] == 1:
+            one_seen = True
+    check("normal mode draws pingers=1", one_seen)
+
+
+def test_resolve_config_fresh_string_size_fits_run():
+    # A fresh-string config's size must fit its run: above the medium table's cap a
+    # fresh string may only be a small size; above the large table's cap, never 4096.
+    caps = {name: cap for name, _t, cap in common.STRING_SIZE_TABLES}
+    small = set(common.STRING_SIZE_TABLES[0][1])
+    small_medium = small | set(common.STRING_SIZE_TABLES[1][1])
+    holds = True
+    fresh_seen = False
+    for master in range(0, 400):
+        w = normal.resolve_config(master, THREADS)["workload"]
+        if not (w["payload"] == "string" and w["payload-mode"] == "fresh"):
+            continue
+        fresh_seen = True
+        msgs = w["chains"] * (w["ttl"] + 1)
+        if msgs > caps["medium"] and w["payload-size"] not in small:
+            holds = False
+        elif msgs > caps["large"] and w["payload-size"] not in small_medium:
+            holds = False
+    check("fresh-string size fits the run's message count", holds)
+    check("fresh-string configs were actually drawn to check", fresh_seen)
+
+
 def main():
     test_resolve_config_golden()
     test_resolve_config_never_sets_systematic_seed()
     test_ponynoblock_is_a_swarm_knob()
     test_resolve_config_deterministic_and_bounded()
     test_resolve_config_swarm_omission()
+    test_resolve_config_magnitude_buckets()
+    test_resolve_config_draws_single_pinger()
+    test_resolve_config_fresh_string_size_fits_run()
     if FAILURES:
         print("%d failure(s): %s" % (len(FAILURES), ", ".join(FAILURES)))
         sys.exit(1)

--- a/test/rt-stress/generative/orchestrate_systematic.py
+++ b/test/rt-stress/generative/orchestrate_systematic.py
@@ -66,7 +66,7 @@ def resolve_config(master_seed, max_threads):
     systematic_seed = common.derive_seed(master_seed, "systematic")
     rng = random.Random(master_seed)
 
-    workload = common.resolve_workload(rng, program_seed)
+    workload = common.resolve_systematic_workload(rng, program_seed)
     runtime = {
         "ponynoblock": True,
         "ponysystematictestingseed": systematic_seed,

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -22,7 +22,7 @@ honors it (Linux): Windows lacks the `resource` module and macOS rejects the
 limit, so both fall back to host OOM handling. The wall-clock watchdog is
 portable.
 
-The pure pieces (derive_seed / resolve_workload / draw_* / build_argv /
+The pure pieces (derive_seed / resolve_systematic_workload / draw_* / build_argv /
 run_command / parse_result / lldb_argv / lldb_exit_code) are unit-tested in
 stress_common_test.py; the run classifiers (run_once / run_under_lldb) are tested
 by injecting a fake _capture.
@@ -52,6 +52,12 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SOURCE_DIR)))
 
 U64_MASK = (1 << 64) - 1
 DEFAULT_TIMEOUT_SECONDS = 120
+# Normal mode's per-run watchdog: a flat ~100 min, ~2x the longest plausible large
+# run with slow-CI margin (a hung run, not its true length, is the worst case). Big
+# enough that host-speed variance never false-positives a legitimate run, so the
+# bucket and size-table numbers can stay hardcoded with no startup calibration. Systematic
+# keeps DEFAULT_TIMEOUT_SECONDS -- its runs stay ~10ms.
+DEFAULT_NORMAL_TIMEOUT_SECONDS = 6000
 DEFAULT_MEM_LIMIT_MB = 4096
 
 
@@ -73,21 +79,22 @@ def derive_seed(master_seed, label):
     return (int.from_bytes(digest[:8], "big") & U64_MASK) or 1
 
 
-def resolve_workload(rng, program_seed):
-    """The workload shape: the program seed (passed, not drawn) plus the five
-    swarm-drawn fields, in the dict-insertion and rng-draw order that is the
+def resolve_systematic_workload(rng, program_seed):
+    """The systematic-mode workload shape: the program seed (passed, not drawn) plus
+    the five swarm-drawn fields, in the dict-insertion and rng-draw order that is the
     seed-stability contract.
 
-    `payload-mode` is deliberately NOT here -- each driver draws it via
-    draw_payload_mode() AFTER its runtime-knob draws and BEFORE draw_max_threads().
-    The interleaving of these draws in each driver's resolve_config is the
-    contract: move any draw and every seed remaps (breaking historical --replay).
-    resolve_config(0, 8) is pinned in the per-driver tests to guard it.
+    Normal mode does NOT use this -- it composes its own bucketed draw plus a
+    payload whose string size is limited by the message count (draw_bucketed /
+    draw_payload); see orchestrate_normal.resolve_config. Systematic stays small and
+    fixed-range on purpose: it serializes the scheduler, so a billion-message run's
+    interleaving space is intractable.
 
-    These ranges are a starting point, not tuned. The choice() knobs sample every
-    listed value equally; the randint() ranges (chains, ttl) under-sample their
-    edges. When tuned, bias toward allocator size-class boundaries and reach past
-    the current max of 64 pingers (contention bugs intensify with scale).
+    `payload-mode` is deliberately NOT here -- the systematic driver draws it via
+    draw_payload_mode() AFTER its runtime-knob draws and BEFORE draw_max_threads().
+    The interleaving of these draws in resolve_config is the contract: move any draw
+    and every seed remaps (breaking historical --replay). resolve_config(0, 8) is
+    pinned in orchestrate_systematic_test.py to guard it.
     """
     return {
         "seed": program_seed,
@@ -123,9 +130,11 @@ def draw_swarm_knobs(rng, runtime):
 def draw_payload_mode(rng):
     """`forward` re-sends one payload object down a chain (shared-val
     refcounting); `fresh` allocates a new one at each hop (allocation + collection
-    churn). COUPLING: this must be drawn AFTER the runtime-knob draws and BEFORE
-    draw_max_threads(), in BOTH drivers -- that position is the seed-stability
-    contract. A driver that reorders it remaps every seed."""
+    churn). Used only by the SYSTEMATIC driver now -- normal mode draws kind, size,
+    and mode together in draw_payload. COUPLING: in the systematic driver this
+    must be drawn AFTER the runtime-knob draws and BEFORE draw_max_threads() -- that
+    position is its seed-stability contract; reordering it remaps every systematic
+    seed."""
     return rng.choice(["forward", "fresh"])
 
 
@@ -137,6 +146,93 @@ def draw_max_threads(rng, max_threads):
     different core counts. The runtime REJECTS --ponymaxthreads > physical cores,
     so max_threads is the probed physical count (see probe_max_threads)."""
     return rng.randint(1, max_threads)
+
+
+# Normal-mode magnitude buckets. Each of chains and ttl draws a bucket
+# (small/medium/large at 25/50/25), then a uniform value within it. Ranges are
+# (lo, hi) inclusive and tuned on the calibration host (WSL2, 2 threads, debug,
+# ~1M msg/s at scale) so same-bucket pairs land near the time yardstick: S*S
+# ~secs-3min, M*M ~3-12min, L*L ~12-19min (top ~1.16B messages ~ 15-20 min).
+# chains and ttl share these ranges. Systematic mode does NOT use them -- it stays
+# small/fixed-range (see resolve_systematic_workload). Locked, not provisional.
+NORMAL_SIZE_BUCKETS = {
+    "small": (1500, 14000),
+    "medium": (14001, 27000),
+    "large": (27001, 34000),
+}
+
+# String-payload sizes grouped by per-hop cost into small/medium/large tables. A
+# fresh string's run cost is ~ messages * per-hop-cost(size), so the costlier tables
+# are offered only to smaller runs: each table's third field is the most messages a
+# fresh run of its slowest size keeps within the ~30-min soak budget. The 4096/1024/
+# 256 figures are measured at scale on the calibration host (the per-message rate
+# decays as a run grows, so these are not short-run extrapolations); the small table's
+# cap is from the same decay curve, which reproduces the measured ones within ~3%, and
+# the 100-min per-run hard timeout backstops any drift. draw_payload limits a fresh
+# string to the sizes whose table fits the run's message count -- a big run can only
+# draw a cheap size, a small run any. Forward and u64 payloads allocate once (or
+# never), so their cost is ~flat in size and they draw from every size. COUPLING: the
+# per-table caps are a property of the engine's per-hop cost -- if that changes (e.g. a
+# payload-integrity check, per the README's deferred work), re-measure them.
+STRING_SIZE_TABLES = (
+    # (name, sizes, max fresh-string messages within the ~30-min budget)
+    ("small",  [1, 8, 64],  990_000_000),
+    ("medium", [256, 1024], 520_000_000),
+    ("large",  [4096],      300_000_000),
+)
+ALL_STRING_SIZES = [s for _name, _sizes, _cap in STRING_SIZE_TABLES for s in _sizes]
+
+# Normal-mode actor counts. pingers=1 -- a lone actor that only ever forwards to
+# itself -- is included on purpose: it exercises the ORCA self-send path. That path
+# used to flood the forwarded object's owner with acquire messages and balloon memory
+# (~4.5 GB at ~7.7M messages), so this draw once excluded pingers=1. But that was a
+# real runtime defect, fixed in PR #5594: the in-queue self-sent object is pinned so
+# the per-actor sweep no longer releases and re-borrows it every hop. With the fix a
+# pingers=1 run is bounded (~40 MB even at the 34000-chain max, conserving), so
+# drawing it here keeps a standing stress on that fix -- a regression would reappear
+# as the same blowup.
+NORMAL_PINGERS = [1, 2, 4, 8, 16, 32, 64]
+
+
+def draw_bucketed(rng, buckets):
+    """Draw a small/medium/large bucket at 25/50/25, then a uniform value within it.
+    Exactly two rng draws (the bucket roll, then the value), and that order is part
+    of the seed-stability contract. `buckets` is a name->(lo, hi) inclusive dict with
+    small/medium/large keys."""
+    roll = rng.random()
+    if roll < 0.25:
+        lo, hi = buckets["small"]
+    elif roll < 0.75:
+        lo, hi = buckets["medium"]
+    else:
+        lo, hi = buckets["large"]
+    return rng.randint(lo, hi)
+
+
+def draw_payload(rng, msgs):
+    """Draw payload kind, size, and mode. Returns (payload, size, mode).
+
+    The available string SIZE is limited by `msgs`: a fresh string's cost grows with
+    both message count and size, so a big run may draw only a cheap (small) size while
+    a small run may draw any (see STRING_SIZE_TABLES). Forward and u64 payloads are
+    flat-cost in size and draw from every size. Runs so large that even the small
+    table's budget is exceeded still draw from it (a slight, hard-timeout-bounded
+    overrun) rather than being denied a string.
+
+    Always exactly three rng draws -- kind, mode, size -- in that fixed order, so the
+    draw stream is stable: the size table changes which value the third draw lands on,
+    never how much rng it consumes."""
+    kind = rng.choice(["string", "u64"])
+    mode = rng.choice(["forward", "fresh"])
+    if kind == "string" and mode == "fresh":
+        sizes = [s for _n, table, cap in STRING_SIZE_TABLES if msgs <= cap
+                 for s in table]
+        if not sizes:                      # past even the small table's budget;
+            sizes = STRING_SIZE_TABLES[0][1]  # still allow the cheapest sizes
+    else:
+        sizes = ALL_STRING_SIZES
+    size = sizes[int(rng.random() * len(sizes))]
+    return kind, size, mode
 
 
 def build_argv(binary, config):

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -72,28 +72,29 @@ def test_derive_seed_zero_floor():
         common.hashlib.sha256 = real
 
 
-def test_resolve_workload_five_field_split():
-    # CRITICAL contract: resolve_workload returns the program seed plus EXACTLY the
-    # five swarm-drawn fields -- payload-mode is NOT here (each driver draws it
-    # after its runtime knobs). A regression that folds payload-mode back in (a
-    # contiguous-six draw) remaps every seed and breaks systematic replay; this
-    # pins against it.
+def test_resolve_systematic_workload_five_field_split():
+    # CRITICAL contract: resolve_systematic_workload returns the program seed plus
+    # EXACTLY the five swarm-drawn fields -- payload-mode is NOT here (the systematic
+    # driver draws it after its runtime knobs). A regression that folds payload-mode
+    # back in (a contiguous-six draw) remaps every seed and breaks systematic replay;
+    # this pins against it.
     rng = random.Random(0)
-    work = common.resolve_workload(rng, 999)
-    check("resolve_workload keys are seed + the five drawn fields",
+    work = common.resolve_systematic_workload(rng, 999)
+    check("resolve_systematic_workload keys are seed + the five drawn fields",
           set(work.keys()) == {"seed", "pingers", "chains", "ttl", "payload",
                                "payload-size"})
-    check("resolve_workload does NOT include payload-mode",
+    check("resolve_systematic_workload does NOT include payload-mode",
           "payload-mode" not in work)
-    check("resolve_workload carries the passed program seed", work["seed"] == 999)
+    check("resolve_systematic_workload carries the passed program seed",
+          work["seed"] == 999)
     # Pin the exact draw order/values for Random(0): a reordered or narrowed draw
     # changes this (and would silently remap historical seeds).
-    check("resolve_workload(Random(0), 999) matches the pinned draws",
+    check("resolve_systematic_workload(Random(0), 999) matches the pinned draws",
           work == {"seed": 999, "pingers": 64, "chains": 198, "ttl": 48,
                    "payload": "u64", "payload-size": 1})
 
 
-def test_resolve_workload_coverage():
+def test_resolve_systematic_workload_coverage():
     pingers_allowed = {1, 2, 4, 8, 16, 32, 64}
     size_allowed = {1, 8, 64, 256, 1024, 4096}
     pingers_seen, size_seen, payload_seen = set(), set(), set()
@@ -101,7 +102,7 @@ def test_resolve_workload_coverage():
     invariants = True
     for master in range(0, 300):
         rng = random.Random(master)
-        w = common.resolve_workload(rng, 1)
+        w = common.resolve_systematic_workload(rng, 1)
         if w["pingers"] not in pingers_allowed:
             invariants = False
         if not (1 <= w["chains"] <= 400):
@@ -117,7 +118,8 @@ def test_resolve_workload_coverage():
         payload_seen.add(w["payload"])
         chains_seen.append(w["chains"])
         ttls_seen.append(w["ttl"])
-    check("resolve_workload holds all field invariants over 300 seeds", invariants)
+    check("resolve_systematic_workload holds all field invariants over 300 seeds",
+          invariants)
     check("pingers covers the full declared set", pingers_seen == pingers_allowed)
     check("payload covers {string, u64}", payload_seen == {"string", "u64"})
     check("payload-size covers the full declared set", size_seen == size_allowed)
@@ -168,6 +170,131 @@ def test_draw_max_threads():
     check("draw_max_threads always in [1, max]", ok)
     check("draw_max_threads spans the full [1, max] range",
           seen == set(range(1, 9)))
+
+
+def test_draw_bucketed():
+    # Each draw picks a small/medium/large bucket at 25/50/25, then a uniform value
+    # within it. Values must always land in exactly one declared (non-overlapping)
+    # bucket, all three must be reachable, and the weighting must be ~25/50/25.
+    b = common.NORMAL_SIZE_BUCKETS
+    counts = {"small": 0, "medium": 0, "large": 0}
+    in_range = True
+    for master in range(0, 2000):
+        v = common.draw_bucketed(random.Random(master), b)
+        if b["small"][0] <= v <= b["small"][1]:
+            counts["small"] += 1
+        elif b["medium"][0] <= v <= b["medium"][1]:
+            counts["medium"] += 1
+        elif b["large"][0] <= v <= b["large"][1]:
+            counts["large"] += 1
+        else:
+            in_range = False
+    check("draw_bucketed values always land in one declared bucket", in_range)
+    check("draw_bucketed reaches all three buckets",
+          all(c > 0 for c in counts.values()))
+    # 2000 draws at 25/50/25: ~500/1000/500. Deterministic, loose bounds.
+    check("draw_bucketed weighting is ~25/50/25",
+          (400 <= counts["small"] <= 650)
+          and (850 <= counts["medium"] <= 1150)
+          and (400 <= counts["large"] <= 650))
+
+
+def test_draw_payload():
+    # A fresh string's available SIZE is limited by the run's message count; forward
+    # and u64 are flat-cost and draw any size. The harness's largest run has chains and
+    # ttl both at the large bucket's max -- max*(max+1) messages, ~1.16B, past even the
+    # small table's budget -- so a fresh string there may draw only small sizes. Derive
+    # it from the bucket so it can't go stale if the ranges change.
+    _max_dim = common.NORMAL_SIZE_BUCKETS["large"][1]
+    big = _max_dim * (_max_dim + 1)
+    small_sizes = set(common.STRING_SIZE_TABLES[0][1])   # {1, 8, 64}
+    larger_sizes = set(common.ALL_STRING_SIZES) - small_sizes   # {256, 1024, 4096}
+    caps = {name: cap for name, _t, cap in common.STRING_SIZE_TABLES}
+
+    big_fresh_larger = big_fresh_small = flat_larger_at_big = False
+    for master in range(0, 2000):
+        k, s, m = common.draw_payload(random.Random(master), big)
+        if k == "string" and m == "fresh":
+            big_fresh_larger |= s in larger_sizes
+            big_fresh_small |= s in small_sizes
+        else:                                 # forward string or u64
+            flat_larger_at_big |= s in larger_sizes
+    check("draw_payload: a big fresh-string run never draws a non-small size",
+          not big_fresh_larger)
+    check("draw_payload: a big fresh-string run still draws small sizes",
+          big_fresh_small)
+    check("draw_payload: forward/u64 draw any size even at the max run",
+          flat_larger_at_big)
+
+    # A big run's fresh-string sizes are a strict subset of a small run's: the table
+    # only grows as the run shrinks.
+    fresh_big, fresh_small = set(), set()
+    for master in range(0, 3000):
+        k, s, m = common.draw_payload(random.Random(master), big)
+        if k == "string" and m == "fresh":
+            fresh_big.add(s)
+        k, s, m = common.draw_payload(random.Random(master), 1)
+        if k == "string" and m == "fresh":
+            fresh_small.add(s)
+    check("draw_payload: a small run can draw a large fresh-string size",
+          larger_sizes & fresh_small)
+    check("draw_payload: a big run's fresh sizes are a strict subset of a small run's",
+          fresh_big < fresh_small)
+
+    # Cap boundary, per table: at exactly a table's cap a fresh string may still draw
+    # that table's sizes; one message above, the table drops out. The small table is
+    # the floor -- above its cap the never-deny fallback keeps its sizes -- so it is
+    # checked separately below; here we cover medium and large.
+    def fresh_sizes_at(msgs):
+        seen = set()
+        for master in range(0, 3000):
+            k, s, m = common.draw_payload(random.Random(master), msgs)
+            if k == "string" and m == "fresh":
+                seen.add(s)
+        return seen
+    for name, table_sizes, cap in common.STRING_SIZE_TABLES[1:]:   # medium, large
+        want = set(table_sizes)
+        at_cap, above_cap = fresh_sizes_at(cap), fresh_sizes_at(cap + 1)
+        check("draw_payload: fresh string AT the %s cap can draw %s sizes"
+              % (name, name), want <= at_cap)
+        check("draw_payload: fresh string ABOVE the %s cap cannot draw %s sizes"
+              % (name, name), not (want & above_cap))
+
+    # The small table is the floor: at AND above its cap a fresh string still draws its
+    # sizes (the never-deny fallback) and never a larger one.
+    small_set = set(common.STRING_SIZE_TABLES[0][1])
+    at_small, above_small = fresh_sizes_at(caps["small"]), fresh_sizes_at(caps["small"] + 1)
+    check("draw_payload: fresh string AT the small cap can draw small sizes",
+          small_set <= at_small)
+    check("draw_payload: fresh string ABOVE the small cap still draws small sizes",
+          small_set <= above_small)
+    check("draw_payload: fresh string ABOVE the small cap draws no larger size",
+          not (above_small - small_set))
+
+    # Seed-stability contract: kind and mode are drawn before the (msgs-dependent)
+    # size, and the size always costs exactly one rng draw, so draw_payload consumes
+    # the SAME rng count for any msgs -- the message count must never remap a
+    # downstream draw. Verify the rng state AFTER the call is identical across msgs
+    # spanning every cap boundary and the overrun region (msgs > the small cap, where
+    # the fallback fires), and that kind/mode never shift with msgs.
+    boundary_msgs = [1, caps["large"], caps["large"] + 1, caps["medium"],
+                     caps["medium"] + 1, caps["small"], caps["small"] + 1, big]
+    rng_stable = kind_mode_stable = True
+    for master in range(0, 300):
+        states, kinds_modes = [], []
+        for mm in boundary_msgs:
+            rng = random.Random(master)
+            k, _, m = common.draw_payload(rng, mm)
+            states.append(rng.getstate())
+            kinds_modes.append((k, m))
+        if any(st != states[0] for st in states):
+            rng_stable = False
+        if any(km != kinds_modes[0] for km in kinds_modes):
+            kind_mode_stable = False
+    check("draw_payload: rng consumption is fixed across all msgs (overrun included)",
+          rng_stable)
+    check("draw_payload: message count changes only the size, never kind/mode",
+          kind_mode_stable)
 
 
 def test_build_argv():
@@ -400,11 +527,13 @@ def test_parse_result():
 def main():
     test_derive_seed()
     test_derive_seed_zero_floor()
-    test_resolve_workload_five_field_split()
-    test_resolve_workload_coverage()
+    test_resolve_systematic_workload_five_field_split()
+    test_resolve_systematic_workload_coverage()
     test_draw_swarm_knobs()
     test_draw_payload_mode()
     test_draw_max_threads()
+    test_draw_bucketed()
+    test_draw_payload()
     test_build_argv()
     test_run_command()
     test_lldb_argv()


### PR DESCRIPTION
Normal-mode generative stress runs were all the same tiny shape — chains 1-400, ttl 0-48, a few-millisecond mesh. That's one fixed point; it barely exercises the runtime. Draw chains and ttl from small/medium/large buckets instead, so a soak spans quick startup/shutdown-dominated runs through sustained ~1.16B-message load.

A fresh-string payload's cost grows with both the message count and the string size, so a big run that drew a large fresh string could run for hours. Group the string sizes into small, medium, and large tables, each capped at the message count a fresh run of its slowest size finishes inside the soak budget, and offer a fresh string only the tables a run can afford. A big run still gets a fresh string, just a cheaper-sized one; forward and u64 payloads cost the same at any size, so they draw from all of them.

Each normal lane now soaks for 90 minutes instead of 30, to use more of the multi-hour gap before its next scheduled run. A flat 100-minute per-run timeout still bounds a hung run, the whole-job ceiling moves to 210 minutes, and the cron start times are spaced so a long job can't outrun the gap to the next scheduled generative run.

pingers=1 is drawn again. A lone actor that only forwards to itself used to flood the forwarded object's owner with acquire messages and balloon memory; that was a real runtime bug, fixed in #5594 by pinning the in-queue object against the per-actor sweep. With the fix a pingers=1 run stays bounded, so drawing it keeps a standing stress on that fix — a regression there would resurface as the same blowup.

Systematic mode keeps its small fixed-range draw — serialized runs can't afford billion-message interleaving spaces — so the draw it still shares is renamed resolve_systematic_workload. The engine (main.pony) is unchanged.
