### PR TITLE
Fix crash when parsing, printing, or querying deeply nested JSON

### DIFF
--- a/.release-notes/fix-deeply-nested-json-stack-overflow.md
+++ b/.release-notes/fix-deeply-nested-json-stack-overflow.md
@@ -1,0 +1,5 @@
+## Fix crash when parsing, printing, or querying deeply nested JSON
+
+Parsing, printing, or querying a deeply nested JSON value — for example a document of many thousands of nested arrays or objects — could overflow the stack and crash the program with a segfault, rather than returning a value or a catchable `JsonParseError`.
+
+The `json` package now handles arbitrarily deep nesting, limited only by available memory.

--- a/packages/json/_json_path_eval.pony
+++ b/packages/json/_json_path_eval.pony
@@ -80,13 +80,38 @@ primitive _JsonPathEval
     root: JsonValue,
     out: Array[JsonValue] ref)
   =>
-    """Depth-first pre-order: apply selectors here, then recurse."""
-    _select_all(selectors, node, root, out)
-    match node
-    | let obj: JsonObject =>
-      for v in obj.values() do _descend(selectors, v, root, out) end
-    | let arr: JsonArray =>
-      for v in arr.values() do _descend(selectors, v, root, out) end
+    """
+    Depth-first pre-order: apply selectors to a node, then to each of its
+    children in turn (array elements in index order, object members in
+    `values()` order).
+
+    Walked with an explicit work stack rather than native recursion so that
+    nesting depth is bounded by the heap, not the scheduler thread's native
+    stack, which deeply nested input would otherwise overflow. Children are
+    pushed in reverse so they pop in that forward order, preserving the
+    pre-order traversal of the recursive walk exactly.
+    """
+    let stack = Array[JsonValue]
+    stack.push(node)
+    while stack.size() > 0 do
+      let n = try stack.pop()? else _Unreachable(); return end
+      _select_all(selectors, n, root, out)
+      match n
+      | let obj: JsonObject =>
+        let kids = Array[JsonValue](obj.size())
+        for v in obj.values() do kids.push(v) end
+        var i = kids.size()
+        while i > 0 do
+          i = i - 1
+          try stack.push(kids(i)?) else _Unreachable() end
+        end
+      | let arr: JsonArray =>
+        var i = arr.size()
+        while i > 0 do
+          i = i - 1
+          try stack.push(arr(i)?) else _Unreachable() end
+        end
+      end
     end
 
   // _FilterSelector.select takes an extra `root` parameter. This is

--- a/packages/json/_json_path_filter_eval.pony
+++ b/packages/json/_json_path_filter_eval.pony
@@ -272,9 +272,9 @@ primitive _FilterCompare
 
     Nothing == Nothing is true. Nothing vs any value is false.
     Same-type primitives use value equality. Mixed I64/F64 converts
-    I64 to F64. Arrays compare element-wise recursively. Objects
-    compare by same key set with recursively equal values (iteration
-    order doesn't matter). Cross-type is false.
+    I64 to F64. Arrays compare element-wise; objects compare by same key
+    set with equal values (iteration order doesn't matter) — both via the
+    structural `_deep_eq` walk. Cross-type is false.
     """
     match (left, right)
     | (_Nothing, _Nothing) => true
@@ -287,8 +287,8 @@ primitive _FilterCompare
     | (let a: String, let b: String) => a == b
     | (let a: Bool, let b: Bool) => a == b
     | (None, None) => true
-    | (let a: JsonArray, let b: JsonArray) => _array_eq(a, b)
-    | (let a: JsonObject, let b: JsonObject) => _object_eq(a, b)
+    | (let a: JsonArray, let b: JsonArray) => _deep_eq(a, b)
+    | (let a: JsonObject, let b: JsonObject) => _deep_eq(a, b)
     else
       false
     end
@@ -314,51 +314,46 @@ primitive _FilterCompare
       false
     end
 
-  fun _array_eq(a: JsonArray, b: JsonArray): Bool =>
-    """Element-wise recursive equality for arrays."""
-    if a.size() != b.size() then return false end
-    var i: USize = 0
-    while i < a.size() do
-      try
-        if not _deep_eq(a(i)?, b(i)?) then return false end
-      else
-        return false
-      end
-      i = i + 1
-    end
-    true
-
-  fun _object_eq(a: JsonObject, b: JsonObject): Bool =>
-    """
-    Key/value recursive equality for objects.
-
-    Checks that both objects have the same number of keys, then verifies
-    every key in `a` exists in `b` with a recursively equal value.
-    Iteration order doesn't matter (JsonObject is backed by CHAMP map).
-    """
-    if a.size() != b.size() then return false end
-    for (key, a_val) in a.pairs() do
-      try
-        let b_val = b(key)?
-        if not _deep_eq(a_val, b_val) then return false end
-      else
-        return false
-      end
-    end
-    true
-
   fun _deep_eq(a: JsonValue, b: JsonValue): Bool =>
-    """Recursive equality for JsonValue values."""
-    match (a, b)
-    | (let x: I64, let y: I64) => x == y
-    | (let x: F64, let y: F64) => x == y
-    | (let x: I64, let y: F64) => x.f64() == y
-    | (let x: F64, let y: I64) => x == y.f64()
-    | (let x: String, let y: String) => x == y
-    | (let x: Bool, let y: Bool) => x == y
-    | (None, None) => true
-    | (let x: JsonArray, let y: JsonArray) => _array_eq(x, y)
-    | (let x: JsonObject, let y: JsonObject) => _object_eq(x, y)
-    else
-      false
+    """
+    Structural equality for JsonValue values.
+
+    Arrays compare element-wise; objects compare by same key set with equal
+    values (iteration order doesn't matter — JsonObject is backed by a CHAMP
+    map). Walked with an explicit work stack rather than native recursion so
+    that nesting depth is bounded by the heap, not the scheduler thread's
+    native stack, which deeply nested input would otherwise overflow.
+    """
+    let stack = Array[(JsonValue, JsonValue)]
+    stack.push((a, b))
+    while stack.size() > 0 do
+      (let x, let y) = try stack.pop()? else _Unreachable(); return false end
+      match (x, y)
+      | (let p: I64, let q: I64) => if p != q then return false end
+      | (let p: F64, let q: F64) => if p != q then return false end
+      | (let p: I64, let q: F64) => if p.f64() != q then return false end
+      | (let p: F64, let q: I64) => if p != q.f64() then return false end
+      | (let p: String, let q: String) => if p != q then return false end
+      | (let p: Bool, let q: Bool) => if p != q then return false end
+      | (None, None) => None
+      | (let p: JsonArray, let q: JsonArray) =>
+        if p.size() != q.size() then return false end
+        var i: USize = 0
+        while i < p.size() do
+          let xv = try p(i)? else _Unreachable(); return false end
+          let yv = try q(i)? else _Unreachable(); return false end
+          stack.push((xv, yv))
+          i = i + 1
+        end
+      | (let p: JsonObject, let q: JsonObject) =>
+        if p.size() != q.size() then return false end
+        for (key, pv) in p.pairs() do
+          // A missing key means the objects differ — not an impossible path.
+          let qv = try q(key)? else return false end
+          stack.push((pv, qv))
+        end
+      else
+        return false
+      end
     end
+    true

--- a/packages/json/_json_print.pony
+++ b/packages/json/_json_print.pony
@@ -1,43 +1,130 @@
 primitive _JsonPrint
-  """Private serialization helper. Handles all JsonValue members."""
+  """
+  Private serialization helper. Handles all JsonValue members.
+
+  Serialization is iterative, not recursive: an explicit stack of container
+  frames bounds nesting depth by the heap instead of the scheduler thread's
+  native stack, which deeply nested input would otherwise overflow. The output
+  buffer is a single `String iso` threaded through the walk.
+  """
 
   fun compact(value: JsonValue): String iso^ =>
     """Compact serialization of any JSON value."""
-    _value(recover iso String(256) end, value, "", 0, false)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_open(recover iso String(256) end, value, 0, stack), "", false, stack)
 
   fun pretty(value: JsonValue, indent: String = "  "): String iso^ =>
     """Pretty-printed serialization of any JSON value."""
-    _value(recover iso String(256) end, value, indent, 0, true)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_open(recover iso String(256) end, value, 0, stack), indent, true,
+      stack)
 
   fun compact_object(obj: JsonObject box): String iso^ =>
     """Compact serialization from a box reference (backs JsonObject.print)."""
-    _object(recover iso String(256) end, obj, "", 0, false)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_seed_object(recover iso String(256) end, obj, 0, stack), "", false,
+      stack)
 
   fun pretty_object(obj: JsonObject box, indent: String = "  "): String iso^ =>
     """Pretty-printed serialization from a box reference."""
-    _object(recover iso String(256) end, obj, indent, 0, true)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_seed_object(recover iso String(256) end, obj, 0, stack), indent, true,
+      stack)
 
   fun compact_array(arr: JsonArray box): String iso^ =>
     """Compact serialization from a box reference (backs JsonArray.print)."""
-    _array(recover iso String(256) end, arr, "", 0, false)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_seed_array(recover iso String(256) end, arr, 0, stack), "", false,
+      stack)
 
   fun pretty_array(arr: JsonArray box, indent: String = "  "): String iso^ =>
     """Pretty-printed serialization from a box reference."""
-    _array(recover iso String(256) end, arr, indent, 0, true)
+    let stack = Array[(_PrintObjectFrame | _PrintArrayFrame)]
+    _run(_seed_array(recover iso String(256) end, arr, 0, stack), indent, true,
+      stack)
 
-  fun _value(
+  fun _run(
     buf: String iso,
-    value: JsonValue,
     indent: String,
-    level: USize,
-    is_pretty: Bool)
+    is_pretty: Bool,
+    stack: Array[(_PrintObjectFrame | _PrintArrayFrame)])
     : String iso^
   =>
-    match value
-    | let obj: JsonObject =>
-      _object(consume buf, obj, indent, level, is_pretty)
-    | let arr: JsonArray =>
-      _array(consume buf, arr, indent, level, is_pretty)
+    """
+    Drive the work stack until every open container is closed. Each iteration
+    advances the top frame by one element (opening any child container, which
+    pushes a new top frame — depth-first) or, when the frame is exhausted,
+    writes its closing bracket and pops it.
+    """
+    var b = consume buf
+    while stack.size() > 0 do
+      let frame =
+        try
+          stack(stack.size() - 1)?
+        else
+          _Unreachable()
+          return recover iso String end
+        end
+      match \exhaustive\ frame
+      | let f: _PrintObjectFrame =>
+        if f.iter.has_next() then
+          (let k, let v) =
+            try f.iter.next()? else _Unreachable(); ("", None) end
+          if not f.first then b.push(',') end
+          f.first = false
+          if is_pretty then
+            b.push('\n')
+            b = _indent(consume b, indent, f.level + 1)
+          end
+          b = _escaped_string(consume b, k)
+          b.push(':')
+          if is_pretty then b.push(' ') end
+          b = _open(consume b, v, f.level + 1, stack)
+        else
+          if is_pretty then
+            b.push('\n')
+            b = _indent(consume b, indent, f.level)
+          end
+          b.push('}')
+          try stack.pop()? else _Unreachable() end
+        end
+      | let f: _PrintArrayFrame =>
+        if f.iter.has_next() then
+          let v = try f.iter.next()? else _Unreachable(); None end
+          if not f.first then b.push(',') end
+          f.first = false
+          if is_pretty then
+            b.push('\n')
+            b = _indent(consume b, indent, f.level + 1)
+          end
+          b = _open(consume b, v, f.level + 1, stack)
+        else
+          if is_pretty then
+            b.push('\n')
+            b = _indent(consume b, indent, f.level)
+          end
+          b.push(']')
+          try stack.pop()? else _Unreachable() end
+        end
+      end
+    end
+    consume b
+
+  fun _open(
+    buf: String iso,
+    value: JsonValue,
+    level: USize,
+    stack: Array[(_PrintObjectFrame | _PrintArrayFrame)])
+    : String iso^
+  =>
+    """
+    Append a scalar, or open a container: write its opening bracket and, when
+    non-empty, push a frame for `_run` to fill. Empty containers are closed
+    inline and never push a frame.
+    """
+    match \exhaustive\ value
+    | let obj: JsonObject => _seed_object(consume buf, obj, level, stack)
+    | let arr: JsonArray => _seed_array(consume buf, arr, level, stack)
     | let s: String => _escaped_string(consume buf, s)
     | let n: I64 =>
       buf.append(n.string())
@@ -51,73 +138,38 @@ primitive _JsonPrint
       consume buf
     end
 
-  fun _object(
+  fun _seed_object(
     buf: String iso,
     obj: JsonObject box,
-    indent: String,
     level: USize,
-    is_pretty: Bool)
+    stack: Array[(_PrintObjectFrame | _PrintArrayFrame)])
     : String iso^
   =>
+    """Write `{`; close an empty object inline, else push a frame for `_run`."""
     var b = consume buf
     b.push('{')
     if obj.size() == 0 then
       b.push('}')
-      return consume b
+    else
+      stack.push(_PrintObjectFrame(obj, level))
     end
-
-    var first = true
-    for (k, v) in obj.pairs() do
-      if not first then b.push(',') end
-      first = false
-      if is_pretty then
-        b.push('\n')
-        b = _indent(consume b, indent, level + 1)
-      end
-      b = _escaped_string(consume b, k)
-      b.push(':')
-      if is_pretty then b.push(' ') end
-      b = _value(consume b, v, indent, level + 1, is_pretty)
-    end
-
-    if is_pretty then
-      b.push('\n')
-      b = _indent(consume b, indent, level)
-    end
-    b.push('}')
     consume b
 
-  fun _array(
+  fun _seed_array(
     buf: String iso,
     arr: JsonArray box,
-    indent: String,
     level: USize,
-    is_pretty: Bool)
+    stack: Array[(_PrintObjectFrame | _PrintArrayFrame)])
     : String iso^
   =>
+    """Write `[`; close an empty array inline, else push a frame for `_run`."""
     var b = consume buf
     b.push('[')
     if arr.size() == 0 then
       b.push(']')
-      return consume b
+    else
+      stack.push(_PrintArrayFrame(arr, level))
     end
-
-    var first = true
-    for v in arr.values() do
-      if not first then b.push(',') end
-      first = false
-      if is_pretty then
-        b.push('\n')
-        b = _indent(consume b, indent, level + 1)
-      end
-      b = _value(consume b, v, indent, level + 1, is_pretty)
-    end
-
-    if is_pretty then
-      b.push('\n')
-      b = _indent(consume b, indent, level)
-    end
-    b.push(']')
     consume b
 
   fun _escaped_string(buf: String iso, s: String box): String iso^ =>
@@ -169,3 +221,29 @@ primitive _JsonPrint
     if nibble < 10 then '0' + nibble
     else 'a' + (nibble - 10)
     end
+
+class _PrintObjectFrame
+  """
+  A JSON object being serialized: its pair iterator, indent level, and
+  whether its first entry has been written yet.
+  """
+  let iter: Iterator[(String, JsonValue)]
+  let level: USize
+  var first: Bool = true
+
+  new create(obj: JsonObject box, level': USize) =>
+    iter = obj.pairs()
+    level = level'
+
+class _PrintArrayFrame
+  """
+  A JSON array being serialized: its value iterator, indent level, and
+  whether its first element has been written yet.
+  """
+  let iter: Iterator[JsonValue]
+  let level: USize
+  var first: Bool = true
+
+  new create(arr: JsonArray box, level': USize) =>
+    iter = arr.values()
+    level = level'

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -71,6 +71,13 @@ actor \nodoc\ Main is TestList
     test(_TestPrinterPretty)
     test(_TestPrinterScalars)
     test(_TestTokenParserAbort)
+    // Regression tests — stack-safe JSON walks (issue #5557)
+    test(_TestParseDeeplyNested)
+    test(_TestPrintDeeplyNested)
+    test(_TestJsonPathDescendDeeplyNested)
+    test(_TestJsonPathDescendOrder)
+    test(_TestJsonPathFilterDeeplyNested)
+    test(_TestTokenParserPositions)
 
 // ===================================================================
 // Generators
@@ -680,6 +687,8 @@ class \nodoc\ iso _TestParseErrors is UnitTest
     _assert_parse_error(h, "[1,]", "trailing comma in array")
     _assert_parse_error(h, """{"a":1""", "unclosed object")
     _assert_parse_error(h, "[1", "unclosed array")
+    _assert_parse_error(h, "[1}", "array closed by brace")
+    _assert_parse_error(h, """{"a":1]""", "object closed by bracket")
     _assert_parse_error(h, "\"hello", "unterminated string")
     _assert_parse_error(h, "\"\\x\"", "bad escape")
     _assert_parse_error(h, "1 2", "trailing content")
@@ -2021,6 +2030,26 @@ class \nodoc\ iso _TestJsonPathFilterDeepEquality is UnitTest
     let r = p.query(doc)
     h.assert_eq[USize](2, r.size())
 
+    // Object equality: only an object with the same keys and equal values
+    // matches. The three unequal cases each hit a different rejection path in
+    // the iterative deep-equality walk: an unequal value; a smaller object
+    // (caught by the size check); and a same-size object whose key is absent in
+    // the target (caught by the key lookup).
+    let odoc = JsonObject
+      .update("target", JsonObject.update("a", I64(1)).update("b", I64(2)))
+      .update("items", JsonArray
+        .push(JsonObject.update("v",
+          JsonObject.update("a", I64(1)).update("b", I64(2))))  // equal
+        .push(JsonObject.update("v",
+          JsonObject.update("a", I64(1)).update("b", I64(9))))  // value differs
+        .push(JsonObject.update("v",
+          JsonObject.update("a", I64(1))))                      // size differs
+        .push(JsonObject.update("v",
+          JsonObject.update("a", I64(1)).update("c", I64(2))))) // key absent
+    let op = JsonPathParser.compile("$.items[?@.v == $.target]")?
+    let or' = op.query(odoc)
+    h.assert_eq[USize](1, or'.size())
+
 class \nodoc\ iso _TestJsonPathFilterNumbers is UnitTest
   fun name(): String => "json/jsonpath/filter/numbers"
 
@@ -2368,4 +2397,215 @@ class \nodoc\ iso _TestJsonPathFilterFunctionValue is UnitTest
       """$[?value(@.tags[0]) == "urgent"]""")?
     let r4 = p4.query(doc2)
     h.assert_eq[USize](1, r4.size())
+
+// ===================================================================
+// Regression Tests — stack-safe JSON walks (issue #5557)
+// ===================================================================
+//
+// Every value-depth walk in the package (parse, print, JSONPath recursive
+// descent, and filter `==` equality) is driven by an explicit work stack
+// rather than native recursion, so nesting depth is bounded by the heap, not
+// the scheduler thread's native stack. These tests drive each walk far past
+// any practical input depth and assert it returns the correct result, so a
+// logic error in the work-stack management surfaces here. They also guard
+// against reintroducing native recursion, which on a build/platform that does
+// not optimize the recursion's stack growth away crashes the process with an
+// uncatchable stack overflow on deeply nested input — the bug in #5557. (Where
+// the toolchain does elide that stack growth, recursion survives this depth, so
+// these are not a universal crash-counterfactual.) See
+// https://github.com/ponylang/ponyc/issues/5557.
+
+primitive \nodoc\ _DeepNestingDepth
+  """
+  Nesting depth for the stack-safety regression tests: deep enough to overflow
+  a native-recursion walk on a standard scheduler-thread stack (~8 MB) on
+  builds and platforms that don't optimize the recursion's stack growth away,
+  yet small enough to stay fast. The iterative walks handle it with depth
+  bounded by the heap.
+  """
+  fun apply(): USize => 200_000
+
+class \nodoc\ iso _TestParseDeeplyNested is UnitTest
+  """
+  Parsing deeply nested JSON completes (no native-stack overflow) and returns
+  the right structure. Reaching past `parse` proves the walk finished; the
+  root-array shape is checked too.
+  """
+  fun name(): String => "json/parse/deeply-nested"
+
+  fun apply(h: TestHelper) =>
+    let depth = _DeepNestingDepth()
+    var s = recover iso String(depth * 2) end
+    var i: USize = 0
+    while i < depth do s.push('['); i = i + 1 end
+    i = 0
+    while i < depth do s.push(']'); i = i + 1 end
+    match \exhaustive\ JsonParser.parse(consume s)
+    | let a: JsonArray => h.assert_eq[USize](1, a.size())
+    | let _: JsonValue => h.fail("expected a JsonArray at the root")
+    | let e: JsonParseError => h.fail("deep parse failed: " + e.string())
+    end
+
+class \nodoc\ iso _TestPrintDeeplyNested is UnitTest
+  """
+  Serializing a deeply nested value completes (no native-stack overflow) and
+  produces the right bytes. The value alternates object and array wrappers so
+  both the object and array printer frames are driven at depth; the expected
+  compact length is accumulated as the value is built.
+  """
+  fun name(): String => "json/print/deeply-nested"
+
+  fun apply(h: TestHelper) =>
+    let depth = _DeepNestingDepth()
+    var v: JsonValue = JsonObject
+    var expected_len: USize = 2 // innermost "{}"
+    var i: USize = 0
+    while i < depth do
+      if (i % 2) == 0 then
+        v = JsonArray.push(v)
+        expected_len = expected_len + 2 // "[" ... "]"
+      else
+        v = JsonObject.update("a", v)
+        expected_len = expected_len + 6 // {"a": ... }
+      end
+      i = i + 1
+    end
+    let s: String val = JsonPrinter.print(v)
+    h.assert_eq[USize](expected_len, s.size())
+
+class \nodoc\ iso _TestJsonPathDescendDeeplyNested is UnitTest
+  """
+  JSONPath recursive descent (`..`) over a deeply nested value completes (no
+  native-stack overflow) and visits every node. `depth` nested objects each
+  carry one "a", so `$..a` matches exactly `depth` values.
+  """
+  fun name(): String => "json/jsonpath/descend/deeply-nested"
+
+  fun apply(h: TestHelper) ? =>
+    let depth = _DeepNestingDepth()
+    var v: JsonValue = JsonObject
+    var i: USize = 0
+    while i < depth do
+      v = JsonObject.update("a", v)
+      i = i + 1
+    end
+    let p = JsonPathParser.compile("$..a")?
+    let r = p.query(v)
+    h.assert_eq[USize](depth, r.size())
+
+class \nodoc\ iso _TestJsonPathDescendOrder is UnitTest
+  """
+  Recursive descent must keep its pre-order, left-to-right traversal after the
+  switch from native recursion to an explicit work stack (children are pushed
+  in reverse so they pop in forward order). Built from arrays so child order is
+  positional and predictable.
+  """
+  fun name(): String => "json/jsonpath/descend/order"
+
+  fun apply(h: TestHelper) ? =>
+    // [ {"a": 1}, {"a": [ {"a": 2}, {"a": 3} ]} ]
+    let doc = JsonArray
+      .push(JsonObject.update("a", I64(1)))
+      .push(JsonObject.update("a", JsonArray
+        .push(JsonObject.update("a", I64(2)))
+        .push(JsonObject.update("a", I64(3)))))
+    let r = JsonPathParser.compile("$..a")?.query(doc)
+    // pre-order, left-to-right: 1, then the inner array, then 2, then 3.
+    h.assert_eq[USize](4, r.size())
+    h.assert_eq[I64](1, r(0)? as I64)
+    h.assert_eq[USize](2, (r(1)? as JsonArray).size())
+    h.assert_eq[I64](2, r(2)? as I64)
+    h.assert_eq[I64](3, r(3)? as I64)
+
+class \nodoc\ iso _TestJsonPathFilterDeeplyNested is UnitTest
+  """
+  Filter equality (`==`) over deeply nested values completes (no native-stack
+  overflow) and compares correctly. The document's single element is the deep
+  value; `@ == @` forces a full structural comparison of it against itself
+  (equality has no early-out when equal), which matches, giving one result.
+  """
+  fun name(): String => "json/jsonpath/filter/deeply-nested"
+
+  fun apply(h: TestHelper) ? =>
+    let depth = _DeepNestingDepth()
+    var deep: JsonValue = JsonArray
+    var i: USize = 0
+    while i < depth do
+      deep = JsonArray.push(deep)
+      i = i + 1
+    end
+    let doc = JsonArray.push(deep)
+    let p = JsonPathParser.compile("$[?@ == @]")?
+    let r = p.query(doc)
+    h.assert_eq[USize](1, r.size())
+
+class \nodoc\ iso _TestTokenParserPositions is UnitTest
+  """
+  The streaming token parser reports the same token sequence and byte offsets
+  after the iterative rewrite. In particular, an empty container's end token
+  keeps the start offset of its opening bracket — a detail a naive rewrite
+  drops — checked for both `{}` and `[]`. Guards token_start/token_end
+  bookkeeping.
+  """
+  fun name(): String => "json/tokenparser/positions"
+
+  fun apply(h: TestHelper) =>
+    let events = Array[(String, USize, USize)]
+    let parser = JsonTokenParser(_TokenRecorder(events))
+    try parser.parse("""{"a":[1,{}],"b":2,"c":[]}""")?
+    else h.fail("token parse raised unexpectedly")
+    end
+
+    // (label, token_start, token_end) for {"a":[1,{}],"b":2,"c":[]}. The empty
+    // {}'s ObjectEnd keeps token_start 8 (its `{`) and the empty []'s ArrayEnd
+    // keeps token_start 22 (its `[`), not the closing-bracket positions.
+    let expected: Array[(String, USize, USize)] = [
+      ("ObjectStart", 0, 1)
+      ("Key", 2, 4)
+      ("ArrayStart", 5, 6)
+      ("Number", 6, 7)
+      ("ObjectStart", 8, 9)
+      ("ObjectEnd", 8, 10)
+      ("ArrayEnd", 10, 11)
+      ("Key", 13, 15)
+      ("Number", 16, 17)
+      ("Key", 19, 21)
+      ("ArrayStart", 22, 23)
+      ("ArrayEnd", 22, 24)
+      ("ObjectEnd", 24, 25)
+    ]
+    h.assert_eq[USize](expected.size(), events.size())
+    for (idx, exp) in expected.pairs() do
+      try
+        let got = events(idx)?
+        h.assert_eq[String](exp._1, got._1)
+        h.assert_eq[USize](exp._2, got._2)
+        h.assert_eq[USize](exp._3, got._3)
+      else
+        h.fail("missing token event at index " + idx.string())
+      end
+    end
+
+class \nodoc\ _TokenRecorder is JsonTokenNotify
+  """Records (label, token_start, token_end) into a caller-owned array."""
+  let _events: Array[(String, USize, USize)]
+
+  new create(events: Array[(String, USize, USize)]) =>
+    _events = events
+
+  fun ref apply(parser: JsonTokenParser, token: JsonToken) =>
+    let label =
+      match \exhaustive\ token
+      | JsonTokenNull => "Null"
+      | JsonTokenTrue => "True"
+      | JsonTokenFalse => "False"
+      | JsonTokenNumber => "Number"
+      | JsonTokenString => "String"
+      | JsonTokenKey => "Key"
+      | JsonTokenObjectStart => "ObjectStart"
+      | JsonTokenObjectEnd => "ObjectEnd"
+      | JsonTokenArrayStart => "ArrayStart"
+      | JsonTokenArrayEnd => "ArrayEnd"
+      end
+    _events.push((label, parser.token_start(), parser.token_end()))
 

--- a/packages/json/json_token_parser.pony
+++ b/packages/json/json_token_parser.pony
@@ -74,72 +74,104 @@ class ref JsonTokenParser
     if _abort then error end
 
   fun ref _parse_value() ? =>
+    """
+    Parse one JSON value and all its descendants, emitting tokens.
+
+    Iterative rather than recursive: an explicit stack of container contexts
+    bounds nesting depth by the heap instead of the scheduler thread's native
+    stack, which deeply nested input would otherwise overflow. The token
+    sequence, token-offset bookkeeping, and abort/error behavior match a
+    straightforward recursive descent exactly.
+    """
+    let stack = Array[_ParseCtx]
+    match \exhaustive\ _read_value()?
+    | _ReadComplete => return
+    | _ReadOpenObject => stack.push(_ParseCtx(true))
+    | _ReadOpenArray => stack.push(_ParseCtx(false))
+    end
+
+    while stack.size() > 0 do
+      let ctx = try stack(stack.size() - 1)? else _Unreachable(); return end
+      if ctx.expect_separator then
+        _skip_whitespace()
+        _token_start = _offset
+        match _next()?
+        | ',' => ctx.expect_separator = false
+        | '}' if ctx.is_object =>
+          _emit(JsonTokenObjectEnd)?
+          try stack.pop()? else _Unreachable() end
+        | ']' if not ctx.is_object =>
+          _emit(JsonTokenArrayEnd)?
+          try stack.pop()? else _Unreachable() end
+        else
+          error
+        end
+      else
+        if ctx.is_object then
+          _skip_whitespace()
+          _token_start = _offset
+          _parse_string(true)? // parse key
+          _skip_whitespace()
+          _eat(':')?
+        end
+        // The current element's value follows. A container value sets this
+        // context to the separator phase before its own context is pushed,
+        // so when the child closes we resume looking for ',' or the bracket.
+        match \exhaustive\ _read_value()?
+        | _ReadComplete => ctx.expect_separator = true
+        | _ReadOpenObject =>
+          ctx.expect_separator = true
+          stack.push(_ParseCtx(true))
+        | _ReadOpenArray =>
+          ctx.expect_separator = true
+          stack.push(_ParseCtx(false))
+        end
+      end
+    end
+
+  fun ref _read_value(): _ReadResult ? =>
+    """
+    Read a single value at the current position.
+
+    Scalars emit their token and return _ReadComplete. A container emits its
+    start token; an empty one also emits its end token and returns
+    _ReadComplete, while a non-empty one returns _ReadOpenObject or
+    _ReadOpenArray for the caller to track on the work stack.
+    """
     _skip_whitespace()
     _token_start = _offset
     match _peek()?
-    | '{' => _parse_object()?
-    | '[' => _parse_array()?
-    | '"' => _parse_string(false)?
-    | 't' => _parse_true()?
-    | 'f' => _parse_false()?
-    | 'n' => _parse_null()?
+    | '{' =>
+      _next()? // consume '{'
+      _emit(JsonTokenObjectStart)?
+      _skip_whitespace()
+      if _peek()? == '}' then
+        _next()?
+        _emit(JsonTokenObjectEnd)?
+        _ReadComplete
+      else
+        _ReadOpenObject
+      end
+    | '[' =>
+      _next()? // consume '['
+      _emit(JsonTokenArrayStart)?
+      _skip_whitespace()
+      if _peek()? == ']' then
+        _next()?
+        _emit(JsonTokenArrayEnd)?
+        _ReadComplete
+      else
+        _ReadOpenArray
+      end
+    | '"' => _parse_string(false)?; _ReadComplete
+    | 't' => _parse_true()?; _ReadComplete
+    | 'f' => _parse_false()?; _ReadComplete
+    | 'n' => _parse_null()?; _ReadComplete
     | let c: U8 if (c == '-') or ((c >= '0') and (c <= '9')) =>
       _parse_number()?
+      _ReadComplete
     else
       error
-    end
-
-  fun ref _parse_object() ? =>
-    _next()? // consume '{'
-    _emit(JsonTokenObjectStart)?
-    _skip_whitespace()
-
-    if _peek()? == '}' then
-      _next()?
-      _emit(JsonTokenObjectEnd)?
-      return
-    end
-
-    while true do
-      _skip_whitespace()
-      _token_start = _offset
-      _parse_string(true)? // parse key
-      _skip_whitespace()
-      _eat(':')?
-      _parse_value()? // parse value
-      _skip_whitespace()
-      _token_start = _offset
-      match _next()?
-      | ',' => None
-      | '}' =>
-        _emit(JsonTokenObjectEnd)?
-        return
-      else error
-      end
-    end
-
-  fun ref _parse_array() ? =>
-    _next()? // consume '['
-    _emit(JsonTokenArrayStart)?
-    _skip_whitespace()
-
-    if _peek()? == ']' then
-      _next()?
-      _emit(JsonTokenArrayEnd)?
-      return
-    end
-
-    while true do
-      _parse_value()?
-      _skip_whitespace()
-      _token_start = _offset
-      match _next()?
-      | ',' => None
-      | ']' =>
-        _emit(JsonTokenArrayEnd)?
-        return
-      else error
-      end
     end
 
   fun ref _parse_true() ? =>
@@ -350,3 +382,29 @@ class ref JsonTokenParser
       else return
       end
     end
+
+primitive _ReadComplete
+  """`_read_value` read a complete value (a scalar or an empty container)."""
+primitive _ReadOpenObject
+  """`_read_value` opened a non-empty object; its context must be tracked."""
+primitive _ReadOpenArray
+  """`_read_value` opened a non-empty array; its context must be tracked."""
+
+type _ReadResult is (_ReadComplete | _ReadOpenObject | _ReadOpenArray)
+  """What `_read_value` did: completed a value, or opened a container."""
+
+class _ParseCtx
+  """
+  One open container on the parser's work stack.
+
+  `is_object` distinguishes `{}` from `[]`. `expect_separator` is the phase
+  toggle: `false` means the next thing to read is an element (a key/value pair
+  for an object, a value for an array); `true` means it is a separator (`,`) or
+  the closing bracket.
+  """
+  let is_object: Bool
+  var expect_separator: Bool
+
+  new create(is_object': Bool) =>
+    is_object = is_object'
+    expect_separator = false


### PR DESCRIPTION
The json package walked JSON structure with native recursion in several places — the token parser, the printer, JSONPath recursive descent (`..`), and structural `==` equality in JSONPath filters. None of them capped depth, so deeply nested input ran a scheduler thread's native stack into the ground: an uncatchable SIGSEGV, not a `JsonParseError`.

Each of those walks now uses an explicit heap work stack instead of native recursion, so nesting depth is bounded by available memory rather than the thread stack. No depth limit is imposed, and observable behavior — token sequence and offsets, serialized bytes, query result ordering, equality semantics — is unchanged.

Issue #5557 enumerated three of these walks (parse, print, descend). The fourth, filter equality (`_deep_eq`), is the same bug class — reachable by a query like `$[?@ == @]` against a deeply nested value — so it is fixed here as well.

The regression tests drive each walk well past any practical input depth and check the result. One caveat worth stating plainly: on at least some builds and platforms the toolchain optimizes the old recursion's stack growth away, so the old code survives these depths and the tests do not act as a crash-counterfactual there. They guard correct iterative behavior at depth and catch a reintroduction of native recursion on the builds and platforms where the stack growth is not elided — which is where the crash actually happens.

Closes #5557
