### PR TITLE
Pass --ponygcinitial as an exponent in the stress harness swarm

### DIFF
--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -44,7 +44,7 @@ def test_resolve_config_golden():
     expected = {
         "master_seed": 0,
         "runtime": {
-            "ponygcinitial": 1024,
+            "ponygcinitial": 10,
             "ponymaxthreads": 5,
             "ponynoscale": True,
         },

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -122,7 +122,13 @@ def draw_swarm_knobs(rng, runtime):
     if rng.random() < 0.5:
         runtime["ponynoscale"] = True
     if rng.random() < 0.5:
-        runtime["ponygcinitial"] = rng.choice([1024, 1 << 16, 1 << 20])
+        # --ponygcinitial is a base-2 EXPONENT, not a byte count: it defers an
+        # actor's GC until it is using 2^N bytes (runtime default N=14 = 16 KiB).
+        # These draw 1 KiB / 64 KiB / 1 MiB thresholds (a spread around the
+        # default). Pass exponents, NOT byte counts -- the runtime computes
+        # `1 << N`, so a byte count like 65536 is masked (mod 64) to a 1-byte
+        # threshold on x86-64, silently forcing GC on nearly every allocation.
+        runtime["ponygcinitial"] = rng.choice([10, 16, 20])
     if rng.random() < 0.5:
         runtime["ponygcfactor"] = round(rng.choice([1.05, 1.5, 2.0, 4.0]), 2)
     if rng.random() < 0.5:


### PR DESCRIPTION
The generative stress harness's `draw_swarm_knobs` drew byte counts `[1024, 65536, 1048576]` for `--ponygcinitial`, but that flag takes a base-2 exponent: the runtime sets an actor's GC threshold to `2^N` bytes (default `N=14` = 16 KiB). All three drawn values are multiples of 64, so the runtime's `1 << N` masks (mod 64) to `1 << 0` = 1 byte on x86-64. Every draw collapsed to the same 1-byte threshold, so the swarm knob never actually varied the GC-initial threshold it was meant to exercise.

Verified empirically: passing `65536` and passing `0` produce byte-identical run rates (both a 1-byte threshold), while `16` and the runtime default run faster.

This draws exponents `[10, 16, 20]` instead, giving the intended 1 KiB / 64 KiB / 1 MiB thresholds (a spread around the 16 KiB default). The draw count is unchanged (still one `rng.choice`), so no downstream seed remapping; the one pinned golden config is updated to match.