### PR TITLE
Reject an out-of-range --ponygcinitial exponent

### DIFF
--- a/.release-notes/reject-out-of-range-ponygcinitial-exponent.md
+++ b/.release-notes/reject-out-of-range-ponygcinitial-exponent.md
@@ -1,0 +1,3 @@
+## Reject an out-of-range `--ponygcinitial` exponent
+
+`--ponygcinitial` sets the heap size at which an actor first garbage collects, given as the exponent `N` in a `2^N` byte threshold (the default is `2^14`, or 16 KiB). Passing a value of 64 or greater on a 64-bit platform — for instance mistaking the flag for a byte count and passing `--ponygcinitial 65536` — used to silently wrap around to a 1-byte threshold, making the actor garbage collect on nearly every allocation: the exact opposite of the large threshold the value implied. The runtime now rejects such a value with an error at startup instead of running with a wildly wrong threshold.

--- a/src/libponyrt/options/options.h
+++ b/src/libponyrt/options/options.h
@@ -84,7 +84,9 @@
   "  --ponycdinterval Run cycle detection every N ms (max 1000 ms, min 10 ms).\n" \
   "                   Defaults to 100 ms.\n" \
   "  --ponygcinitial  Defer garbage collection until an actor is using at\n" \
-  "                   least 2^N bytes. Defaults to 2^14.\n" \
+  "                   least 2^N bytes, where N is less than the machine's\n" \
+  "                   pointer width in bits (at most 63 on 64-bit).\n" \
+  "                   Defaults to 2^14.\n" \
   "  --ponygcfactor   After GC, an actor will next be GC'd at a heap memory\n" \
   "                   usage N times its current value. This is a floating\n" \
   "                   point value. Defaults to 2.0.\n" \

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -218,7 +218,23 @@ static int parse_opts(int argc, char** argv, options_t* opt)
         if(opt->cd_detect_interval > 1000)
           err_out(id, "can't be more than 1000");
         break;
-      case OPT_GCINITIAL: if(parse_size(&opt->gc_initial, 0, s.arg_val)) err_out(id, "can't be less than 0"); break;
+      case OPT_GCINITIAL:
+        if(parse_size(&opt->gc_initial, 0, s.arg_val))
+          err_out(id, "can't be less than 0");
+        // gc_initial is the exponent N in a 2^N byte GC threshold; the runtime
+        // computes `(size_t)1 << N`, which is undefined once N reaches the bit
+        // width of size_t. Reject an out-of-range exponent rather than let the
+        // shift wrap -- on a 64-bit host `--ponygcinitial 64` would otherwise
+        // mask to `1 << 0`, a 1-byte threshold (GC on nearly every allocation),
+        // the opposite of the "defer GC" the flag promises.
+        if(opt->gc_initial >= (sizeof(size_t) * 8))
+        {
+          char msg[64];
+          snprintf(msg, sizeof(msg), "can't be %d or greater",
+            (int)(sizeof(size_t) * 8));
+          err_out(id, msg);
+        }
+        break;
       case OPT_GCFACTOR: if(parse_udouble(&opt->gc_factor, 1.0, s.arg_val)) err_out(id, "can't be less than 1.0"); break;
       case OPT_NOYIELD: opt->noyield = true; break;
       case OPT_NOBLOCK: opt->noblock = true; break;


### PR DESCRIPTION
`--ponygcinitial` is the exponent `N` in a `2^N` byte GC threshold (default `N=14` = 16 KiB). The runtime computes `(size_t)1 << N`, which is undefined behavior once `N` reaches the bit width of `size_t`. On x86-64 that shift masks `N` mod 64, so `--ponygcinitial 64` silently collapsed to `1 << 0` — a 1-byte threshold that garbage collects on nearly every allocation, the exact opposite of the deferral the value implies. A user mistaking the flag for a byte count (`--ponygcinitial 65536`) hit the same wraparound.

The runtime now rejects an exponent at or beyond the pointer width at startup, matching the upper-bound checks `--ponysuspendthreshold` and `--ponycdinterval` already perform. The largest valid value is one less than the pointer width (63 on a 64-bit platform); the help text now documents the bound.

Verified: `--ponygcinitial 63` runs, `64`/`65`/`65536` exit with `--ponygcinitial can't be 64 or greater`, and the libponyrt unit tests pass.