### PR TITLE
Add a constant-GC threshold to the stress harness swarm draw

### DIFF
--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -124,11 +124,12 @@ def draw_swarm_knobs(rng, runtime):
     if rng.random() < 0.5:
         # --ponygcinitial is a base-2 EXPONENT, not a byte count: it defers an
         # actor's GC until it is using 2^N bytes (runtime default N=14 = 16 KiB).
-        # These draw 1 KiB / 64 KiB / 1 MiB thresholds (a spread around the
-        # default). Pass exponents, NOT byte counts -- the runtime computes
-        # `1 << N`, so a byte count like 65536 is masked (mod 64) to a 1-byte
-        # threshold on x86-64, silently forcing GC on nearly every allocation.
-        runtime["ponygcinitial"] = rng.choice([10, 16, 20])
+        # 0 is a deliberate stress point -- a 1-byte threshold that forces GC on
+        # nearly every allocation; 10/16/20 are 1 KiB / 64 KiB / 1 MiB, a spread
+        # around the default. Pass exponents, NOT byte counts -- the runtime
+        # computes `1 << N`, so a byte count like 65536 is masked (mod 64) to a
+        # 1-byte threshold on x86-64.
+        runtime["ponygcinitial"] = rng.choice([0, 10, 16, 20])
     if rng.random() < 0.5:
         runtime["ponygcfactor"] = round(rng.choice([1.05, 1.5, 2.0, 4.0]), 2)
     if rng.random() < 0.5:

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -137,11 +137,14 @@ def test_draw_swarm_knobs():
     omittable = ["ponynoscale", "ponygcinitial", "ponygcfactor", "ponycdinterval"]
     counts = dict.fromkeys(omittable, 0)
     ponynoblock_added = False
+    gcinitial_values = set()
     for master in range(0, 300):
         runtime = {}
         common.draw_swarm_knobs(random.Random(master), runtime)
         if "ponynoblock" in runtime:
             ponynoblock_added = True
+        if "ponygcinitial" in runtime:
+            gcinitial_values.add(runtime["ponygcinitial"])
         for knob in omittable:
             if knob in runtime:
                 counts[knob] += 1
@@ -149,6 +152,11 @@ def test_draw_swarm_knobs():
         check("swarm omission: %s sometimes present" % knob, counts[knob] > 0)
         check("swarm omission: %s sometimes absent" % knob, counts[knob] < 300)
     check("draw_swarm_knobs never adds ponynoblock", not ponynoblock_added)
+    # 0 is the deliberate constant-GC stress point (a 1-byte threshold). Unlike
+    # the other swarm knobs we pin its presence in the draw -- without this a
+    # refactor could silently drop the regime the value exists to exercise.
+    check("swarm draws the gcinitial=0 constant-GC stress point",
+          0 in gcinitial_values)
 
 
 def test_draw_payload_mode():


### PR DESCRIPTION
The `--ponygcinitial` swarm knob drew exponents `[10, 16, 20]` (1 KiB / 64 KiB / 1 MiB thresholds). This adds `0` — a `2^0` = 1-byte threshold — so the swarm deliberately exercises the constant-GC regime, where an actor garbage collects on nearly every allocation. That's the stress condition the old byte-count values created by accident (before #5608); now it's a chosen draw rather than a side effect of a bug.

A coverage check in `test_draw_swarm_knobs` pins that `0` is actually drawn over the sampled seeds, so a later refactor can't silently drop the regime this value exists to exercise. The other swarm knobs are only checked for presence/absence, but `0` carries deliberate intent the spread values don't, so it gets its own assertion.

Widening the draw list remaps the swarm seeds (Python's `random.choice` consumes different entropy for a 4-element list), the same kind of intentional remap earlier draw-content changes made (#5601, #5605). The pinned golden configs (seeds 0 and 1) are unaffected.