### PR TITLE
Add a backpressure workload to the generative stress harness

### DIFF
--- a/.known-couplings/backpressure-workload-muting.md
+++ b/.known-couplings/backpressure-workload-muting.md
@@ -1,0 +1,37 @@
+# Generative backpressure workload depends on the runtime's muting semantics
+
+The `backpressure` workload in `test/rt-stress/generative/main.pony` (the
+`Producer`/`Consumer` star) is deadlock-free and terminating only because of three
+properties of the runtime's actor muting, in `src/libponyrt/actor/actor.c` and
+`src/libponyrt/sched/scheduler.c`. A change to any of them breaks the workload as a
+**soak hang** (the orchestrator's liveness timeout), not as a local failure near the
+runtime change — and the runtime's own tests do not exercise this combination.
+
+1. **Self-send immunity.** `maybe_mark_should_mute` (actor.c) only mutes a sender
+   when `ctx->current != to` — a self-send never mutes the sender. The Consumer's
+   `lift` is a self-send, so it is always delivered even while the Consumer is
+   UNDER_PRESSURE. If self-sends could mute, the `lift` could be starved and the
+   Consumer would never release, hanging the flood.
+
+2. **Explicit release is the sole guaranteed unmute for a pressure-mute.** A producer
+   muted for sending to the UNDER_PRESSURE Consumer is unmuted only when the Consumer
+   calls `pony_release_backpressure` (via `Backpressure.release` in `lift`/`_finish`).
+   The automatic overload-clear path (`actor_unsetoverloaded`) broadcasts its unmute
+   only `if (!UNDER_PRESSURE)`, so it is subordinate: draining the Consumer's mailbox
+   does NOT unmute its pressure-muted producers while pressure is held. The workload
+   relies single-threaded on the explicit release. This is also why the Consumer must
+   never do a foreign send (it could be muted itself, with no path to release) — see
+   the DEADLOCK-FREEDOM INVARIANT comment at the `Backpressure.apply` site.
+
+3. **A held mute defers quiescence.** A scheduler holding a muted actor does not let
+   the program quiesce, so a never-released mute manifests as a hang rather than a
+   wrong result.
+
+This is distinct from `systematic-testing-park-sites.md`, which covers a different
+mechanism (systematic-testing thread handoff at shutdown), not normal-mode muting.
+
+Run: the normal-mode generative soak — `orchestrate_normal.py` drawing the
+`backpressure` workload (`.github/workflows/stress-test-generative-normal-*.yml`, or
+locally `python3 test/rt-stress/generative/orchestrate_normal.py --ponyc <debug
+ponyc> --count <N>`). A muting-semantics regression surfaces as a backpressure run
+timing out.

--- a/test/rt-stress/generative/README.md
+++ b/test/rt-stress/generative/README.md
@@ -25,7 +25,7 @@ them lives in the two driver scripts, not behind a flag.
 ## The engine
 
 **`main.pony`** — the workload engine, identical in both modes. It draws one of
-two closed, count-driven workloads (`--workload`):
+three closed, count-driven workloads (`--workload`):
 
 - **`mesh`** — a closed mesh of `Pinger` actors: a fixed number of chains are
   injected, each with a hop count (TTL); a pinger forwards exactly one ping per
@@ -46,22 +46,39 @@ two closed, count-driven workloads (`--workload`):
   this is the deliberate narrowing of the cyclic oracle.) This is the proven shape
   of `test/rt-systematic/cycle-collection-order-signature`, parameterized for the
   swarm.
+- **`backpressure`** — a star of `Producer` actors flooding one `Consumer`. The
+  consumer explicitly participates in runtime backpressure via the stdlib
+  `backpressure` package: after every `apply_every` received messages it calls
+  `Backpressure.apply` (marking itself UNDER_PRESSURE, so its producers are muted)
+  and self-sends a `lift` that calls `Backpressure.release`. The self-send is never
+  muted, so apply is always paired with release and the closed flood cannot
+  deadlock. This drives the explicit UNDER_PRESSURE muting path that the `mesh`
+  never reaches — the mesh drives only the runtime's *automatic* OVERLOAD muting
+  (which the swarm already exercises incidentally at high message volume). Each
+  producer sends `messages` work messages then a `finished` report; completion
+  triggers on `finished_count == producers` (independent of the received count) and
+  then asserts `received == sent == producers * messages` from the producers' own
+  send tallies — so conservation here is the mesh's strength, not the cyclic's
+  weakness: a lost work is caught as a conservation failure, not merely a timeout.
 
 The traced payload is a `val String` or a `U64` no-GC control (`--payload`),
-either forwarded as one object down a chain or re-allocated at each hop
-(`--payload-mode forward|fresh`) — the swarm draws both. On success the engine
-prints its result and lets the program reach **natural quiescence** (no forced
-exit), so the `cyclic` workload's garbage is actually collected and the runtime's
-clean shutdown is itself exercised; only a conservation *failure* forces a
-non-zero exit. The engine holds no configuration logic and no
-`@runtime_override_defaults`; every knob is a CLI flag set by the orchestrator.
+either reused as one object (forwarded down a chain, or re-sent by a producer) or
+re-allocated at each send (`--payload-mode forward|fresh`) — the swarm draws both.
+On success the engine prints its result and lets the program reach **natural
+quiescence** (no forced exit), so the `cyclic` workload's garbage is actually
+collected and the runtime's clean shutdown is itself exercised; only a
+conservation *failure* forces a non-zero exit. The engine holds no configuration
+logic and no `@runtime_override_defaults`; every knob is a CLI flag set by the
+orchestrator.
 
-The systematic mode draws only the `mesh` workload today; the `cyclic` workload
-runs under the normal mode, where real-parallel collection catches concurrent
-collection races the serialized systematic mode can't. (Running `cyclic` under
-systematic with the determinism oracle is a deferred follow-up — it reproduces
-with the detector on post-#5569, but needs the systematic driver's forced
-`--ponynoblock` relaxed.)
+The systematic mode draws only the `mesh` workload today; the `cyclic` and
+`backpressure` workloads run under the normal mode, where real parallelism catches
+the concurrent collection and mute/unmute races the serialized systematic mode
+can't. (Running `cyclic` under systematic with the determinism oracle is a deferred
+follow-up — it reproduces with the detector on post-#5569, but needs the systematic
+driver's forced `--ponynoblock` relaxed. A systematic `backpressure` leg is also a
+follow-up — muting is cycle-detector-independent, so it is *not* blocked by that
+forced `--ponynoblock`, but its determinism under systematic is unverified.)
 
 ## Running it
 
@@ -105,15 +122,29 @@ non-deterministic, so a replay won't necessarily reproduce a failure).
 
 - **Conservation** — for the `mesh` workload, messages sent == received == the
   expected total (an independent per-pinger tally); a mismatch is a lost or
-  duplicated message. The `cyclic` workload's actors are garbage by quiescence and
-  can't be polled, so its conservation is *completion-count only*: exactly
-  `generations * chains` terminal completions must arrive — weaker than the mesh's
-  tally. The engine checks this itself and exits non-zero on a detected failure, so
-  it holds in **both** modes.
-- **Late message** — for `mesh`, anything arriving after a pinger has reported is a
-  leak; for `cyclic`, a completion beyond the expected total is a duplicate. Both
-  trip the engine's fatal-fault path. (A *lost* `cyclic` message instead leaves the
-  completion count short forever — caught by liveness, not here.)
+  duplicated message. The `backpressure` workload is just as strong: completion
+  triggers on all producers reporting `finished` (independent of the received
+  count), then asserts received == the producers' own send tally == the expected
+  total, so a lost work is a conservation failure, not just a timeout. The `cyclic`
+  workload's actors are garbage by quiescence and can't be polled, so its
+  conservation is *completion-count only*: exactly `generations * chains` terminal
+  completions must arrive — weaker than the other two. The engine checks this itself
+  and exits non-zero on a detected failure, so it holds in **both** modes.
+- **Late / duplicate message** — for `mesh`, anything arriving after a pinger has
+  reported is a leak; for `backpressure`, a work or `finished` after completion, or
+  more `finished` reports than producers, is a duplicate; for `cyclic`, a completion
+  beyond the expected total is a duplicate. All trip the engine's fatal-fault path.
+  (A *lost* `cyclic` message instead leaves the completion count short forever —
+  caught by liveness, not here.)
+- **Backpressure / muting** (`backpressure` workload) — the consumer explicitly
+  applies and releases runtime backpressure, driving the UNDER_PRESSURE mute/unmute
+  reschedule path (the stdlib `backpressure` FFI, the `triggers_muting` /
+  global-unmute machinery) that nothing else in the harness reaches; the mesh only
+  ever triggers *automatic* OVERLOAD muting. Under the normal mode's real
+  parallelism the mute/unmute races the live flood. (Muting actually firing is a
+  calibrated property of the drawn shape — like `test/rt-systematic/`
+  `mute-order-signature`, the per-run oracles are conservation/crash/liveness, not a
+  muting assertion.)
 - **Cycle-detector collection** (`cyclic` workload) — the groups are genuine
   garbage cycles, so the detector must reclaim them; natural quiescence makes that
   collection run on every config, so a collection-path crash regression is reliably
@@ -152,19 +183,20 @@ or GC corruption (wrong bytes, truncation) would pass every oracle above —
 conservation counts messages and `ORDER_SIG` mixes ids and counts. A
 payload-integrity check is deferred to a later round, alongside richer
 allocation-diversity work, an exact spawned == finalized count for the `cyclic`
-workload, and running `cyclic` under the systematic determinism oracle.
+workload, running `cyclic` under the systematic determinism oracle, and a
+systematic `backpressure` leg.
 
 ## Tests
 
 Three self-contained test files (no pytest), run in CI via `lint-python.yml`:
 
 - `stress_common_test.py` — the shared pure pieces (seed derivation, the workload
-  draws including `draw_cyclic`, output parsing, command building).
+  draws including `draw_workload`, output parsing, command building).
 - `orchestrate_systematic_test.py` — the systematic config draw (pinned golden;
-  always the `mesh` workload, unchanged by the cyclic work).
+  always the `mesh` workload, unchanged by the cyclic/backpressure work).
 - `orchestrate_normal_test.py` — the normal config draw (no systematic seed,
-  `ponynoblock` as a swarm knob, both workload kinds drawn, the cyclic memory
-  ceiling, pinned golden).
+  `ponynoblock` as a swarm knob, all three workload kinds drawn, the cyclic memory
+  ceiling and the backpressure message ceiling, pinned per-kind goldens).
 
 Run one directly:
 

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -2,8 +2,9 @@
 Generative runtime stress harness.
 
 A swarm-driven Pony program that exercises the runtime's message passing, ORCA
-tracing, and -- via the `cyclic` workload -- the cycle detector's collection
-path. One run draws one of two closed, count-driven workloads (`--workload`):
+tracing, the cycle detector's collection path (via the `cyclic` workload), and the
+explicit backpressure / muting path (via the `backpressure` workload). One run
+draws one of three closed, count-driven workloads (`--workload`):
 
 * `mesh` (M0): a closed mesh of `Pinger` actors. A fixed number of chains are
   injected, each carrying a hop counter (TTL); a `Pinger` receiving a ping with
@@ -34,7 +35,21 @@ path. One run draws one of two closed, count-driven workloads (`--workload`):
   `_Fatal`. This is strictly weaker than the mesh's independent send/receive
   tally; it is the strongest oracle available once the actors are garbage.
 
-Both workloads are closed, unlike an open cascade stopped by a wall-clock timer:
+* `backpressure` (M1): a star of `Producer` actors flooding one `Consumer`. Each
+  producer sends `messages` work messages then a `finished` report; the consumer
+  explicitly participates in runtime backpressure via the stdlib `backpressure`
+  package -- after every `apply_every` messages it calls `Backpressure.apply`
+  (marking itself UNDER_PRESSURE, so its producers are muted) and self-sends a
+  `lift` that calls `Backpressure.release`. The self-send is never muted, so apply
+  is always paired with release and the closed flood cannot deadlock. This drives
+  the explicit UNDER_PRESSURE muting path that the `mesh` never reaches -- the mesh
+  drives only the runtime's *automatic* OVERLOAD muting. Conservation is the mesh's
+  strength, not the cyclic's weakness: completion triggers on
+  `finished_count == producers` (independent of the received count), then asserts
+  `received == sent == producers * messages` from the producers' own send tallies,
+  so a lost work is caught as a conservation failure here, not merely as a timeout.
+
+The workloads are closed, unlike an open cascade stopped by a wall-clock timer:
 a fixed amount of work is injected and the run terminates when it drains. The
 closed shape is a deliberate constraint, not the end goal -- a continuous, open
 workload is the better stress model, but closed is what's feasible under
@@ -56,19 +71,21 @@ is not a function of `--seed` alone, though: which draw lands on which ping depe
 on the order an actor processes its mailbox, so the routing -- and the run --
 reproduce only when the interleaving does: a fixed `--ponysystematictestingseed`
 under a systematic build. (#5566/#5570 made that replay independent of memory
-layout, so disabling ASLR is no longer needed.) The coordinator/collector folds
-chain-completion arrivals into an FNV-1a `ORDER_SIG` -- a pure function of the
-scheduler interleaving -- as the observable for the determinism oracle.
+layout, so disabling ASLR is no longer needed.) Each workload's driver/collector
+folds its terminal arrivals (chain completions, or producer `finished` reports)
+into an FNV-1a `ORDER_SIG` -- a pure function of the scheduler interleaving -- as
+the observable for the determinism oracle.
 
 This program holds no `@runtime_override_defaults`: every runtime knob (scaling,
 cycle detector, GC, thread count, the systematic seed) is a `--pony*` flag set by
 the orchestrator, and every workload parameter is a `--flag value` arg parsed
 here. Two orchestrators in this directory drive it: `orchestrate_systematic.py`
 (serialized, reproducible -- draws only the `mesh` workload today) and
-`orchestrate_normal.py` (a normal, real-parallel runtime -- draws both workloads;
-the conservation invariant holds there too, but `ORDER_SIG` does not reproduce, so
-that mode runs each seed once).
+`orchestrate_normal.py` (a normal, real-parallel runtime -- draws all three
+workloads; the conservation invariant holds there too, but `ORDER_SIG` does not
+reproduce, so that mode runs each seed once).
 """
+use "backpressure"
 use "cli"
 use "random"
 use @printf[I32](fmt: Pointer[U8] tag, ...)
@@ -78,18 +95,19 @@ use @exit[None](status: I32)
 
 type Payload is (String val | U64)
   """
-  A ping's traced cargo: a heap-allocated `String val` (gives ORCA something to
+  A message's traced cargo: a heap-allocated `String val` (gives ORCA something to
   trace across the actor boundary) or a `U64` primitive (a no-GC control). The
   kind is fixed for a whole run by `--payload`; `--payload-mode` then decides
-  whether one payload object is forwarded the whole chain or a fresh one is
-  allocated at each hop. Shared by both workloads.
+  whether one payload object is reused (forwarded the whole chain, or re-sent by a
+  producer) or a fresh one is allocated at each send. Shared by all workloads.
   """
 
 primitive _Payloads
   """
-  Builds a ping payload of the configured kind. `--payload-mode forward` reuses
-  one object down a chain (exercising ORCA's shared-`val` refcounting); `fresh`
-  calls this at every hop (exercising allocation + tracing + collection churn).
+  Builds a message payload of the configured kind. `--payload-mode forward` reuses
+  one object across a sender's sends (exercising ORCA's shared-`val` refcounting);
+  `fresh` calls this at every send (exercising allocation + tracing + collection
+  churn). Used by all three workloads.
   """
   fun make(config: _Config): Payload =>
     if config.payload_string then
@@ -123,6 +141,10 @@ actor Main
         match config.workload
         | let mesh: _Mesh => Coordinator(config, mesh)
         | let cyclic: _Cyclic => Churner(config, cyclic)
+        | let bp: _Backpressure =>
+          // Only this workload needs the backpressure auth token, built from the
+          // root authority here and threaded into the Consumer.
+          Consumer(config, bp, ApplyReleaseBackpressureAuth(env.root))
         end
       | let err: String =>
         env.err.print(err)
@@ -144,6 +166,7 @@ actor Coordinator
   returns and lets the program quiesce.
   """
   let _config: _Config
+  let _mesh: _Mesh
   let _pingers: Array[Pinger] val
   var _completions: USize = 0
   var _reports_outstanding: USize = 0
@@ -153,6 +176,7 @@ actor Coordinator
 
   new create(config: _Config, mesh: _Mesh) =>
     _config = config
+    _mesh = mesh
 
     // Create the mesh. Pingers are built outside the `recover` block (so we can
     // pass `this`) and pushed into the iso array via automatic receiver
@@ -175,10 +199,10 @@ actor Coordinator
     // Each injected ping is one coordinator send (added back in `_finish`).
     let r = Rand(config.seed)
     var chain: USize = 0
-    while chain < config.chains do
+    while chain < mesh.chains do
       let start = r.int(pingers.size().u64()).usize()
       try
-        pingers(start)?.ping(_Payloads.make(config), config.ttl, chain)
+        pingers(start)?.ping(_Payloads.make(config), mesh.ttl, chain)
       else
         _Unreachable("injection start index out of range")
       end
@@ -196,7 +220,7 @@ actor Coordinator
     _mix(terminal_id.u64())
     _mix(received_snapshot)
     _completions = _completions + 1
-    if _completions == _config.chains then
+    if _completions == _mesh.chains then
       _reports_outstanding = _pingers.size()
       for p in _pingers.values() do
         p.report()
@@ -218,8 +242,8 @@ actor Coordinator
   fun ref _finish() =>
     // The coordinator itself performed `chains` initial sends (the injected
     // pings); every `Pinger` forward is already in `_total_sent`.
-    let total_sent = _total_sent + _config.chains.u64()
-    let expected = _config.chains.u64() * (_config.ttl.u64() + 1)
+    let total_sent = _total_sent + _mesh.chains.u64()
+    let expected = _mesh.chains.u64() * (_mesh.ttl.u64() + 1)
     let conserved =
       (total_sent == _total_received) and (_total_received == expected)
 
@@ -333,15 +357,19 @@ actor Churner
   let _config: _Config
   let _generations: USize
   let _group: USize
+  let _chains: USize
+  let _ttl: USize
   let _collector: CyclicCollector
 
   new create(config: _Config, cyclic: _Cyclic) =>
     _config = config
     _generations = cyclic.generations
     _group = cyclic.group
+    _chains = cyclic.chains
+    _ttl = cyclic.ttl
     // Exactly one chain terminates per injected chain, so the collector expects
     // generations * chains completions before it folds the signature.
-    _collector = CyclicCollector(cyclic.generations * config.chains)
+    _collector = CyclicCollector(cyclic.generations * cyclic.chains)
     tick(0)
 
   be tick(gen: USize) =>
@@ -385,11 +413,11 @@ actor Churner
     // pure function of the interleaving.
     let r = Rand(_config.seed, gen.u64())
     var c: USize = 0
-    while c < _config.chains do
+    while c < _chains do
       let start = r.int(k.u64()).usize()
       try
-        members(start)?.ping(_Payloads.make(_config), _config.ttl,
-          (gen * _config.chains) + c)
+        members(start)?.ping(_Payloads.make(_config), _ttl,
+          (gen * _chains) + c)
       else
         _Unreachable("cyclic injection start index out of range")
       end
@@ -499,51 +527,275 @@ actor CyclicCollector
   fun ref _mix(v: U64) =>
     _sig = (_sig xor v) * 1099511628211 // FNV-1a 64-bit prime
 
+actor Producer
+  """
+  A `backpressure`-workload producer. Sends `messages` work messages to the single
+  consumer, then one `finished` report carrying its id and send tally, and stops.
+  Each foreign `work` send is a muting point: while the consumer is UNDER_PRESSURE
+  the producer is muted, so its self-sent `produce` is deferred until the consumer
+  releases -- that deferral IS the backpressure. Many producers flood one consumer
+  (a star), so every muted producer concentrates in that one receiver's muteset.
+  """
+  let _consumer: Consumer
+  let _config: _Config
+  let _id: USize
+  var _remaining: USize
+  var _sent: U64 = 0
+  let _payload: Payload
+
+  new create(consumer: Consumer, config: _Config, id: USize, messages: USize) =>
+    _consumer = consumer
+    _config = config
+    _id = id
+    _remaining = messages
+    // `forward` mode reuses this one payload object for every send (a muted
+    // producer then holds a shared `val` ref -- ORCA under backpressure); `fresh`
+    // mode allocates a new one at each send (allocation churn). Built once here so
+    // forward mode has an object to reuse.
+    _payload = _Payloads.make(config)
+    produce()
+
+  be produce() =>
+    """
+    Send exactly one work message, then self-send to continue; after `messages`
+    have been sent, report `finished` and stop. The self-send is deferred while
+    this producer is muted, so production pauses under backpressure and resumes on
+    release -- without any explicit rate logic here.
+    """
+    if _remaining == 0 then
+      _consumer.finished(_id, _sent)
+      return
+    end
+    let outgoing: Payload =
+      if _config.payload_fresh then _Payloads.make(_config) else _payload end
+    _consumer.work(outgoing)
+    _sent = _sent + 1
+    _remaining = _remaining - 1
+    produce()
+
+actor Consumer
+  """
+  The `backpressure` workload's driver, sink, and conservation oracle in one actor
+  (mirroring how the mesh's `Coordinator` both drives and evaluates). It spawns the
+  producers, counts received work, participates in runtime backpressure, and on
+  completion checks conservation.
+
+  Backpressure: after every `apply_every` received work messages it calls
+  `Backpressure.apply` (marking itself UNDER_PRESSURE, so producers sending to it
+  are muted) and self-sends `lift`; processing the `lift` calls
+  `Backpressure.release` (unmuting them). The `lift` self-send is immune to muting
+  (a self-send never mutes -- the `ctx->current != to` rule in actor.c
+  `maybe_mark_should_mute`), so every apply is followed by a release: the closed
+  flood cannot deadlock. This drives the explicit UNDER_PRESSURE muting path that
+  the mesh's automatic OVERLOAD muting never reaches.
+
+  Conservation: each producer sends `finished(id, sent)` after its last work; by
+  same-sender FIFO that report follows all of its work, so when all `producers`
+  have reported, all work has been received. The oracle then asserts
+  received == total_sent == expected (producers * messages): a lost work shows as
+  received < total_sent (a conservation failure caught here, not just a timeout), a
+  duplicate trips `_Fatal`. On success it returns and the program quiesces.
+  """
+  let _auth: ApplyReleaseBackpressureAuth
+  let _producers: USize
+  let _apply_every: USize
+  let _expected: U64
+  var _received: U64 = 0
+  var _since_apply: USize = 0
+  var _pressured: Bool = false
+  var _total_sent: U64 = 0
+  var _finished: USize = 0
+  var _done: Bool = false
+  var _sig: U64 = 14695981039346656037 // FNV-1a 64-bit offset basis
+
+  new create(config: _Config, bp: _Backpressure,
+    auth: ApplyReleaseBackpressureAuth)
+  =>
+    _auth = auth
+    _producers = bp.producers
+    _apply_every = bp.apply_every
+    _expected = bp.producers.u64() * bp.messages.u64()
+
+    // Spawn the producers pointing at this consumer (the Coordinator pattern: the
+    // driver creates the workers with `this`). Each floods `messages` work
+    // messages and then reports `finished`.
+    var id: USize = 0
+    while id < bp.producers do
+      Producer(this, config, id, bp.messages)
+      id = id + 1
+    end
+
+  be work(payload: Payload) =>
+    """
+    Count one received work message and run the backpressure hysteresis. The
+    payload is traced by ORCA across the send/receive crossing and then dropped
+    (the consumer doesn't retain it). A work after completion is a leaked/late
+    message -- a real fault -- so it trips `_Fatal`.
+    """
+    if _done then
+      _Fatal("work after done (leaked/late message)")
+    end
+    _received = _received + 1
+    if not _pressured then
+      _since_apply = _since_apply + 1
+      if _since_apply >= _apply_every then
+        // DEADLOCK-FREEDOM INVARIANT: this Consumer must never do a foreign send.
+        // While UNDER_PRESSURE, a foreign send could mute this Consumer itself, and
+        // the explicit Backpressure.release is the SOLE guaranteed unmute for a
+        // pressure-mute (the runtime's automatic overload-clear is subordinate --
+        // gated by !UNDER_PRESSURE), so a muted Consumer could never release and the
+        // flood would hang. Its only send is the `lift` self-send below, which is
+        // immune to muting. See .known-couplings/backpressure-workload-muting.md.
+        Backpressure.apply(_auth)
+        _pressured = true
+        lift()
+      end
+    end
+
+  be lift() =>
+    """
+    Release backpressure. Reached only via the self-send queued when pressure was
+    applied; a self-send is never muted, so this always runs and always releases --
+    the apply/release pairing that makes the closed flood deadlock-free.
+    """
+    if _pressured then
+      Backpressure.release(_auth)
+      _pressured = false
+      _since_apply = 0
+    end
+
+  be finished(producer_id: USize, sent: U64) =>
+    """
+    Fold one producer's terminal report into `ORDER_SIG` (one fold per producer,
+    matching the mesh/cyclic fold-at-completion convention) and accumulate its send
+    tally. When all producers have reported, evaluate conservation. A duplicate or
+    late `finished` arrives after `_finish` has set `_done` (the report that reaches
+    `_producers` triggers `_finish` synchronously), so the `_done` guard catches it.
+    A *lost* `finished` instead leaves `_finished` short forever -- caught by the
+    orchestrator's liveness timeout, not here (the symmetric case to a lost `work`,
+    which conservation catches; mirrors the cyclic workload's lost-completion note).
+    """
+    if _done then
+      _Fatal("finished after done (duplicate/late report)")
+    end
+    _mix(producer_id.u64())
+    _mix(sent)
+    _total_sent = _total_sent + sent
+    _finished = _finished + 1
+    if _finished == _producers then
+      _finish()
+    end
+
+  fun ref _finish() =>
+    _done = true
+    // All producers have reported, so by same-sender FIFO all work has been
+    // received. SENT is the independent per-producer tally (as strong as the
+    // mesh's); a lost work shows here as received < total_sent.
+    let conserved = (_received == _total_sent) and (_total_sent == _expected)
+
+    // Release if still under pressure so the program quiesces cleanly rather than
+    // depending on a pending `lift` running first. Idempotent: `lift` guards on
+    // `_pressured`, so a queued `lift` then no-ops.
+    if _pressured then
+      Backpressure.release(_auth)
+      _pressured = false
+    end
+
+    // Synchronous print so the result survives natural quiescence (env.out.print
+    // is async and could be lost if a later exit raced it).
+    let line = "RECEIVED=" + _received.string()
+      + " SENT=" + _total_sent.string()
+      + " EXPECTED=" + _expected.string()
+      + " ORDER_SIG=" + _sig.string() + "\n"
+    @printf("%s".cstring(), line.cstring())
+
+    // On success: return and let the program reach natural quiescence (no forced
+    // exit), same as the mesh/cyclic. Only a conservation FAILURE forces a
+    // non-zero exit: fail fast once a bug is detected.
+    if not conserved then
+      let diag = "CONSERVATION FAILURE: received=" + _received.string()
+        + " sent=" + _total_sent.string()
+        + " expected=" + _expected.string() + "\n"
+      @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
+      @exit(I32(1))
+    end
+
+  fun ref _mix(v: U64) =>
+    _sig = (_sig xor v) * 1099511628211 // FNV-1a 64-bit prime
+
 class val _Mesh
   """
   The `mesh` workload's shape. Built only by `_Cli.config` (after validation), so
-  `pingers >= 1` can be trusted. A `cyclic` config has no `pingers` field, so an
-  illegal mesh/cyclic field mix is unrepresentable.
+  `pingers >= 1` and `chains >= 1` can be trusted. Carries the chain count and hop
+  count itself (rather than sharing them through `_Config`) so a `backpressure`
+  config -- which has no chains/ttl -- cannot carry those fields at all; an illegal
+  cross-workload field mix is unrepresentable.
   """
   let pingers: USize
+  let chains: USize
+  let ttl: USize
 
-  new val create(pingers': USize) =>
+  new val create(pingers': USize, chains': USize, ttl': USize) =>
     pingers = pingers'
+    chains = chains'
+    ttl = ttl'
 
 class val _Cyclic
   """
   The `cyclic` workload's shape. Built only by `_Cli.config` (after validation),
-  so `generations >= 1` and `group >= 2` (a group needs at least two members to be
-  a non-trivial cycle) can be trusted.
+  so `generations >= 1`, `group >= 2` (a group needs at least two members to be a
+  non-trivial cycle), and `chains >= 1` can be trusted. Carries chains/ttl itself
+  for the same reason as `_Mesh`.
   """
   let generations: USize
   let group: USize
+  let chains: USize
+  let ttl: USize
 
-  new val create(generations': USize, group': USize) =>
+  new val create(generations': USize, group': USize, chains': USize,
+    ttl': USize)
+  =>
     generations = generations'
     group = group'
+    chains = chains'
+    ttl = ttl'
+
+class val _Backpressure
+  """
+  The `backpressure` workload's shape. Built only by `_Cli.config` (after
+  validation), so `producers >= 1`, `messages >= 1`, and `apply_every >= 1` can be
+  trusted. Has no chains/ttl: a flood is not a chain of hops, so those fields are
+  structurally absent here (the reason chains/ttl live on `_Mesh`/`_Cyclic` rather
+  than on the shared `_Config`).
+  """
+  let producers: USize
+  let messages: USize
+  let apply_every: USize
+
+  new val create(producers': USize, messages': USize, apply_every': USize) =>
+    producers = producers'
+    messages = messages'
+    apply_every = apply_every'
 
 class val _Config
   """
-  A validated workload configuration: the fields shared by both workloads plus the
-  workload-specific shape (`_Mesh` or `_Cyclic`). Built only by `_Cli.config`, so
-  the rest of the program can trust its invariants (chains >= 1, payload_size >= 1
-  when payload_string, and the per-shape invariants on the variant).
+  A validated workload configuration: the fields shared by all workloads (seed and
+  payload kind/size/mode) plus the workload-specific shape (`_Mesh`, `_Cyclic`, or
+  `_Backpressure`). The chain/hop counts are NOT here -- only the two chain-based
+  workloads have them, so they live on those variants. Built only by `_Cli.config`,
+  so the rest of the program can trust its invariants (payload_size >= 1 when
+  payload_string, plus the per-shape invariants on the variant).
   """
   let seed: U64
-  let chains: USize
-  let ttl: USize
   let payload_string: Bool
   let payload_size: USize
   let payload_fresh: Bool
-  let workload: (_Mesh | _Cyclic)
+  let workload: (_Mesh | _Cyclic | _Backpressure)
 
-  new val create(seed': U64, chains': USize, ttl': USize, payload_string': Bool,
-    payload_size': USize, payload_fresh': Bool, workload': (_Mesh | _Cyclic))
+  new val create(seed': U64, payload_string': Bool, payload_size': USize,
+    payload_fresh': Bool, workload': (_Mesh | _Cyclic | _Backpressure))
   =>
     seed = seed'
-    chains = chains'
-    ttl = ttl'
     payload_string = payload_string'
     payload_size = payload_size'
     payload_fresh = payload_fresh'
@@ -556,8 +808,11 @@ primitive _Cli
   numbers, and `--help`; this adds the value-set and lower-bound checks it can't
   express. Runtime `--pony*` flags are stripped by the runtime before `Main` sees
   `env.args`, so they never reach the parser. Every option carries a default, so a
-  caller (e.g. the systematic orchestrator) that omits the cyclic-only flags still
-  parses cleanly as a `mesh` run.
+  caller (e.g. the systematic orchestrator) that omits a workload's specific flags
+  still parses cleanly as a `mesh` run. The CLI spec is deliberately flat -- every
+  flag is accepted for every run, with "ignored for ..." help text -- while the
+  validated `_Config` it builds is a per-kind union; only the union enforces that a
+  workload carries only its own shape fields.
   """
   fun spec(): CommandSpec ? =>
     CommandSpec.leaf("generative",
@@ -567,22 +822,32 @@ primitive _Cli
           "engine RNG seed"
           where default' = 1)
         OptionSpec.string("workload",
-          "workload kind: mesh | cyclic"
+          "workload kind: mesh | cyclic | backpressure"
           where default' = "mesh")
         OptionSpec.u64("pingers",
-          "mesh only (ignored for cyclic): number of mesh actors (>= 1)"
+          "mesh only (ignored otherwise): number of mesh actors (>= 1)"
           where default' = 8)
         OptionSpec.u64("generations",
-          "cyclic only (ignored for mesh): garbage-group generations (>= 1)"
+          "cyclic only (ignored otherwise): garbage-group generations (>= 1)"
           where default' = 1)
         OptionSpec.u64("group",
-          "cyclic only (ignored for mesh): actors per garbage group (>= 2)"
+          "cyclic only (ignored otherwise): actors per garbage group (>= 2)"
           where default' = 2)
+        OptionSpec.u64("producers",
+          "backpressure only (ignored otherwise): flooding producers (>= 1)"
+          where default' = 64)
+        OptionSpec.u64("messages",
+          "backpressure only (ignored otherwise): work msgs per producer (>= 1)"
+          where default' = 1000)
+        OptionSpec.u64("apply-every",
+          "backpressure only (ignored otherwise): received msgs between "
+          + "apply/release toggles (>= 1)"
+          where default' = 200)
         OptionSpec.u64("chains",
-          "chains to inject (>= 1)"
+          "mesh/cyclic only (ignored for backpressure): chains to inject (>= 1)"
           where default' = 8)
         OptionSpec.u64("ttl",
-          "hops per chain"
+          "mesh/cyclic only (ignored for backpressure): hops per chain"
           where default' = 16)
         OptionSpec.string("payload",
           "traced payload kind: string | u64"
@@ -591,7 +856,7 @@ primitive _Cli
           "string payload size in bytes (>= 1)"
           where default' = 64)
         OptionSpec.string("payload-mode",
-          "per-hop payload allocation: forward | fresh"
+          "per-send payload allocation: forward | fresh"
           where default' = "forward")
       ])?.>add_help()?
 
@@ -606,6 +871,9 @@ primitive _Cli
     let pingers = cmd.option("pingers").u64().usize()
     let generations = cmd.option("generations").u64().usize()
     let group = cmd.option("group").u64().usize()
+    let producers = cmd.option("producers").u64().usize()
+    let messages = cmd.option("messages").u64().usize()
+    let apply_every = cmd.option("apply-every").u64().usize()
 
     let payload_string =
       if payload == "string" then
@@ -625,33 +893,42 @@ primitive _Cli
         return "bad --payload-mode (expected 'forward' or 'fresh')"
       end
 
-    if chains < 1 then return "--chains must be >= 1" end
     if payload_string and (payload_size < 1) then
       return "--payload-size must be >= 1 for string payload"
     end
 
-    let workload: (_Mesh | _Cyclic) =
+    // chains is validated only where it is used (the two chain-based workloads);
+    // backpressure has no chains, so it carries none.
+    let workload: (_Mesh | _Cyclic | _Backpressure) =
       if workload_name == "mesh" then
         if pingers < 1 then return "--pingers must be >= 1" end
-        _Mesh(pingers)
+        if chains < 1 then return "--chains must be >= 1" end
+        _Mesh(pingers, chains, ttl)
       elseif workload_name == "cyclic" then
         if generations < 1 then return "--generations must be >= 1" end
         if group < 2 then return "--group must be >= 2" end
-        _Cyclic(generations, group)
+        if chains < 1 then return "--chains must be >= 1" end
+        _Cyclic(generations, group, chains, ttl)
+      elseif workload_name == "backpressure" then
+        if producers < 1 then return "--producers must be >= 1" end
+        if messages < 1 then return "--messages must be >= 1" end
+        if apply_every < 1 then return "--apply-every must be >= 1" end
+        _Backpressure(producers, messages, apply_every)
       else
-        return "bad --workload (expected 'mesh' or 'cyclic')"
+        return "bad --workload (expected 'mesh', 'cyclic' or 'backpressure')"
       end
 
-    _Config(seed, chains, ttl, payload_string, payload_size, payload_fresh,
-      workload)
+    _Config(seed, payload_string, payload_size, payload_fresh, workload)
 
 primitive _Fatal
   """
   The harness's runtime-fault detector: print a diagnostic to stderr and exit
-  non-zero. Used by the late/duplicate-message oracles -- a ping arriving after a
-  `Pinger` has reported, or a completion beyond the expected total, is a
-  duplicated or delayed message, a real runtime fault, so the stress run fails
-  loudly with a location rather than passing.
+  non-zero. Used by the late/duplicate-message oracles across all workloads -- a
+  ping arriving after a `Pinger` has reported, a cyclic completion beyond the
+  expected total, or a backpressure `work`/`finished` after the `Consumer` is done
+  (or more `finished` reports than producers) -- each is a duplicated or delayed
+  message, a real runtime fault, so the stress run fails loudly with a location
+  rather than passing.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "FATAL: " + msg + " (" + loc.file() + ":"

--- a/test/rt-stress/generative/orchestrate_normal.py
+++ b/test/rt-stress/generative/orchestrate_normal.py
@@ -59,34 +59,39 @@ def resolve_config(master_seed, max_threads):
     not forced), so both the cycle-detector-on and -off paths are exercised --
     this is where the cycle detector gets its stress coverage.
 
-    Normal mode draws one of two workloads (draw_cyclic): `mesh` (the static M0
-    mesh) or `cyclic` (successive groups of strongly-connected actors that drop
-    their external reference, so the cycle detector must reclaim them). A `mesh`
-    run draws a deliberate small->large magnitude in chains/ttl (the magnitude
-    buckets, reaching ~1.16B messages); a `cyclic` run draws the magnitude in
-    GENERATIONS instead and keeps chains/ttl small (total messages =
-    generations*chains*(ttl+1)). The payload is drawn with its string SIZE limited
-    by the message count (draw_payload).
+    Normal mode draws one of three workloads (draw_workload): `mesh` (the static M0
+    mesh), `cyclic` (successive groups of strongly-connected actors that drop their
+    external reference, so the cycle detector must reclaim them), or `backpressure`
+    (a star of producers flooding one consumer that explicitly applies/releases
+    runtime backpressure, driving the UNDER_PRESSURE muting path). A `mesh` run draws
+    a small->large magnitude in chains/ttl (the magnitude buckets, reaching ~1.16B
+    messages); a `cyclic` run draws the magnitude in GENERATIONS and keeps chains/ttl
+    small (total = generations*chains*(ttl+1)); a `backpressure` run draws the
+    magnitude in MESSAGES per producer (total = producers*messages) and has no
+    chains/ttl. The payload is drawn with its string SIZE limited by the total
+    message count (draw_payload).
 
     This mode is non-reproducible (real parallelism), so a seed maps to a
     *configuration* deterministically but not to an *execution*. The draw order is
     pinned (orchestrate_normal_test.py) so a seed yields a stable config:
-    draw_cyclic (kind + generations + group, a fixed 4 rng) -> pingers (always
-    drawn; used only by a mesh run) -> chains (bucketed, the kind's own buckets) ->
-    ttl (bucketed) -> payload (kind, mode, size) -> ponynoblock -> the four shared
-    swarm knobs -> ponymaxthreads last. Drawing the workload kind first lets the
-    shared chains/ttl/payload draws pick the kind's bucket ranges while making the
-    same sequence of draws either way. This contract is independent of the systematic
-    driver's, and it intentionally differs from the pre-cyclic draw, so historical
-    normal-mode seeds remap.
+    draw_workload (kind + cyclic shape + backpressure shape, fixed consumption) ->
+    pingers (always drawn; used only by a mesh run) -> chains (bucketed, the kind's
+    own buckets) -> ttl (bucketed) -> payload (kind, mode, size) -> ponynoblock ->
+    the four shared swarm knobs -> ponymaxthreads last. Drawing the workload kind
+    first lets the shared chains/ttl/payload draws pick the kind's bucket ranges
+    while making the same sequence of draws regardless of kind. This contract is
+    independent of the systematic driver's, and it intentionally differs from the
+    two-kind draw, so historical normal-mode seeds remap.
     """
     program_seed = common.derive_seed(master_seed, "program")
     rng = random.Random(master_seed)
 
-    kind, generations, group = common.draw_cyclic(rng)
+    (kind, generations, group, producers, messages, apply_every) = \
+        common.draw_workload(rng)
     pingers = rng.choice(common.NORMAL_PINGERS)
-    # chains/ttl come from the kind's own buckets; both kinds make the same two
-    # draw_bucketed calls, so the kind picks the bucket ranges (the value) without
+    # chains/ttl come from the kind's own buckets; mesh and cyclic both use them and
+    # backpressure draws-then-ignores them, so all three make the same two
+    # draw_bucketed calls -- the kind picks the bucket ranges (the value) without
     # changing the draw sequence.
     chains_buckets = (common.CYCLIC_CHAINS_BUCKETS if kind == "cyclic"
                       else common.NORMAL_SIZE_BUCKETS)
@@ -94,21 +99,33 @@ def resolve_config(master_seed, max_threads):
                    else common.NORMAL_SIZE_BUCKETS)
     chains = common.draw_bucketed(rng, chains_buckets)
     ttl = common.draw_bucketed(rng, ttl_buckets)
-    msgs = (generations * chains * (ttl + 1) if kind == "cyclic"
-            else chains * (ttl + 1))
+    # Total message count per kind, fed to draw_payload's fresh-string size cap.
+    if kind == "cyclic":
+        msgs = generations * chains * (ttl + 1)
+    elif kind == "backpressure":
+        msgs = producers * messages
+    else:
+        msgs = chains * (ttl + 1)
     payload, size, mode = common.draw_payload(rng, msgs)
 
-    # Emit only the shape fields the kind uses (a cyclic config has no `pingers`,
-    # a mesh config no `generations`/`group`), so a contradictory pair is never
-    # passed to the engine.
+    # Emit only the shape fields the kind uses, so a contradictory field is never
+    # passed to the engine: mesh has pingers+chains+ttl, cyclic has
+    # generations+group+chains+ttl, backpressure has producers+messages+apply-every
+    # (and NO chains/ttl -- they live on the variants, not the shared _Config).
     workload = {"seed": program_seed, "workload": kind}
     if kind == "cyclic":
         workload["generations"] = generations
         workload["group"] = group
+        workload["chains"] = chains
+        workload["ttl"] = ttl
+    elif kind == "backpressure":
+        workload["producers"] = producers
+        workload["messages"] = messages
+        workload["apply-every"] = apply_every
     else:
         workload["pingers"] = pingers
-    workload["chains"] = chains
-    workload["ttl"] = ttl
+        workload["chains"] = chains
+        workload["ttl"] = ttl
     workload["payload"] = payload
     workload["payload-size"] = size
     workload["payload-mode"] = mode

--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -3,11 +3,12 @@
 draw). Self-contained (no pytest): `python3 ..._test.py`, exits 0/1.
 
 Normal mode is non-reproducible at runtime, but a seed still maps to a stable
-*config* -- the golden below pins that draw order. The two things that distinguish
-normal from systematic are asserted explicitly: no systematic seed is ever set,
-and ponynoblock is a swarm knob (drawn, not forced). Normal mode draws one of two
-workload kinds (`mesh` or `cyclic`); the per-kind shape and the memory ceiling on
-the cyclic workload are checked here too.
+*config* -- the per-kind goldens below pin that draw order. The two things that
+distinguish normal from systematic are asserted explicitly: no systematic seed is
+ever set, and ponynoblock is a swarm knob (drawn, not forced). Normal mode draws
+one of three workload kinds (`mesh`, `cyclic`, or `backpressure`); the per-kind
+shape, the cyclic memory ceiling, and the backpressure message ceiling are checked
+here too.
 """
 import sys
 
@@ -24,6 +25,11 @@ SIZE_ALLOWED = {1, 8, 64, 256, 1024, 4096}
 # run), NOT derived from the CYCLIC_* constants -- bumping a bucket or adding a
 # bigger group trips this. Real max today is 8000*16 = 128000 (see CYCLIC_* docs).
 CYCLIC_WORKER_CEILING = 130000
+# Hardcoded calibrated ceiling on producers*messages (total backpressure work),
+# NOT derived from the BACKPRESSURE_* constants -- bumping a producer count or a
+# message bucket trips this and forces a time re-measure. Real max today is
+# 256*400000 = 102_400_000 (see BACKPRESSURE_* docs).
+BACKPRESSURE_MESSAGE_CEILING = 110_000_000
 
 
 def check(name, condition):
@@ -34,59 +40,90 @@ def check(name, condition):
         FAILURES.append(name)
 
 
-def test_resolve_config_golden():
-    # Pin resolve_config(0, 8): the normal-mode seed-stability guard. Distinct from
-    # the systematic golden -- normal draws the workload kind first, then bucketed
-    # chains/ttl, a payload whose string size is limited by the message count, and
-    # ponynoblock as a swarm knob, and carries no systematic seed.
-    # (This intentionally differs from the pre-cyclic normal golden -- drawing the
-    # workload kind first remaps every historical seed.)
-    expected = {
-        "master_seed": 0,
-        "runtime": {
-            "ponygcinitial": 10,
-            "ponymaxthreads": 5,
-            "ponynoscale": True,
-        },
-        "workload": {
-            "chains": 30981,
-            "payload": "u64",
-            "payload-mode": "fresh",
-            "payload-size": 64,
-            "pingers": 4,
-            "seed": 2686188150644990173,
-            "ttl": 26842,
-            "workload": "mesh",
-        },
-    }
-    check("resolve_config(0, 8) matches the pinned normal golden config",
-          normal.resolve_config(0, THREADS) == expected)
-
-
-def test_resolve_config_cyclic_golden():
-    # Pin a CYCLIC config too (seed 0 rolls mesh, so the mesh golden alone never
-    # checks the cyclic emit-block shape: generations/group present, no pingers).
-    # Seed 1 rolls cyclic.
+def test_resolve_config_mesh_golden():
+    # Pin a MESH config: the normal-mode seed-stability guard for the mesh emit
+    # shape (pingers + chains + ttl, no generations/group/producers). Distinct from
+    # the systematic golden -- normal draws the workload kind first (now 3-way), then
+    # bucketed chains/ttl, a payload whose string size is limited by the total
+    # message count, and ponynoblock as a swarm knob, and carries no systematic seed.
+    # (This intentionally differs from the two-kind normal golden -- the 3-way kind
+    # roll and the extra backpressure-shape draws remap every historical seed.)
+    # Seed 1 rolls mesh.
     expected = {
         "master_seed": 1,
         "runtime": {
-            "ponymaxthreads": 5,
+            "ponycdinterval": 100,
+            "ponygcinitial": 10,
+            "ponymaxthreads": 1,
+        },
+        "workload": {
+            "chains": 17440,
+            "payload": "u64",
+            "payload-mode": "fresh",
+            "payload-size": 256,
+            "pingers": 32,
+            "seed": 2570779959355939992,
+            "ttl": 1964,
+            "workload": "mesh",
+        },
+    }
+    check("resolve_config(1, 8) matches the pinned mesh golden config",
+          normal.resolve_config(1, THREADS) == expected)
+
+
+def test_resolve_config_cyclic_golden():
+    # Pin a CYCLIC config too (the mesh golden alone never checks the cyclic emit
+    # shape: generations/group/chains/ttl present, no pingers/producers). Seed 5
+    # rolls cyclic.
+    expected = {
+        "master_seed": 5,
+        "runtime": {
+            "ponycdinterval": 1000,
+            "ponygcfactor": 1.05,
+            "ponygcinitial": 16,
+            "ponymaxthreads": 8,
+            "ponynoblock": True,
             "ponynoscale": True,
         },
         "workload": {
-            "chains": 4,
-            "generations": 3517,
-            "group": 8,
-            "payload": "string",
+            "chains": 6,
+            "generations": 2972,
+            "group": 2,
+            "payload": "u64",
             "payload-mode": "forward",
-            "payload-size": 64,
-            "seed": 2570779959355939992,
-            "ttl": 8,
+            "payload-size": 256,
+            "seed": 1674455568713221789,
+            "ttl": 6,
             "workload": "cyclic",
         },
     }
-    check("resolve_config(1, 8) matches the pinned cyclic golden config",
-          normal.resolve_config(1, THREADS) == expected)
+    check("resolve_config(5, 8) matches the pinned cyclic golden config",
+          normal.resolve_config(5, THREADS) == expected)
+
+
+def test_resolve_config_backpressure_golden():
+    # Pin a BACKPRESSURE config: it has producers/messages/apply-every and NO
+    # chains/ttl/pingers/generations/group -- the emit shape that proves the new
+    # variant carries only its own fields. Seed 0 rolls backpressure.
+    expected = {
+        "master_seed": 0,
+        "runtime": {
+            "ponymaxthreads": 3,
+            "ponynoblock": True,
+        },
+        "workload": {
+            "apply-every": 200,
+            "messages": 354767,
+            "payload": "string",
+            "payload-mode": "fresh",
+            "payload-size": 1,
+            "producers": 64,
+            "seed": 2686188150644990173,
+            "workload": "backpressure",
+        },
+    }
+    check("resolve_config(0, 8) matches the pinned backpressure golden config",
+          normal.resolve_config(0, THREADS) == expected)
 
 
 def test_resolve_config_never_sets_systematic_seed():
@@ -120,24 +157,29 @@ def test_resolve_config_deterministic_and_bounded():
           normal.resolve_config(7, THREADS)
           == normal.resolve_config(7, THREADS))
 
-    # Invariants over both workload kinds: a mesh config carries `pingers` and no
-    # `generations`/`group`; a cyclic config the reverse. chains/ttl/payload are
-    # shared but draw from the kind's own ranges.
+    # Invariants over all three workload kinds: each carries ONLY its own shape
+    # fields (mesh: pingers+chains+ttl; cyclic: generations+group+chains+ttl;
+    # backpressure: producers+messages+apply-every and NO chains/ttl). Payload is
+    # shared. This is the structural check that the per-kind emit never leaks a
+    # field from another kind.
     cyclic_gen_lo = common.CYCLIC_GENERATION_BUCKETS["small"][0]
     cyclic_gen_hi = common.CYCLIC_GENERATION_BUCKETS["large"][1]
     cyclic_chains_hi = common.CYCLIC_CHAINS_BUCKETS["large"][1]
     cyclic_ttl_hi = common.CYCLIC_TTL_BUCKETS["large"][1]
+    bp_msg_lo = common.BACKPRESSURE_MESSAGE_BUCKETS["small"][0]
+    bp_msg_hi = common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1]
     invariants_hold = True
     maxthreads_seen = set()
     mode_seen = set()
-    worst_workers = 0
     for master in range(0, 300):
         config = normal.resolve_config(master, THREADS)
         work = config["workload"]
         runtime = config["runtime"]
         kind = work["workload"]
         if kind == "mesh":
-            if ("generations" in work) or ("group" in work):
+            if any(k in work for k in
+                   ("generations", "group", "producers", "messages",
+                    "apply-every")):
                 invariants_hold = False
             if work["pingers"] not in PINGERS_ALLOWED:
                 invariants_hold = False
@@ -147,7 +189,8 @@ def test_resolve_config_deterministic_and_bounded():
             if not (1500 <= work["ttl"] <= 34000):
                 invariants_hold = False
         elif kind == "cyclic":
-            if "pingers" in work:
+            if any(k in work for k in
+                   ("pingers", "producers", "messages", "apply-every")):
                 invariants_hold = False
             if not (cyclic_gen_lo <= work["generations"] <= cyclic_gen_hi):
                 invariants_hold = False
@@ -157,8 +200,18 @@ def test_resolve_config_deterministic_and_bounded():
                 invariants_hold = False
             if not (1 <= work["ttl"] <= cyclic_ttl_hi):
                 invariants_hold = False
-            worst_workers = max(worst_workers,
-                                work["generations"] * work["group"])
+        elif kind == "backpressure":
+            # No chains/ttl (they live on the chain-based variants) and no
+            # pingers/generations/group.
+            if any(k in work for k in
+                   ("pingers", "generations", "group", "chains", "ttl")):
+                invariants_hold = False
+            if work["producers"] not in common.BACKPRESSURE_PRODUCERS:
+                invariants_hold = False
+            if not (bp_msg_lo <= work["messages"] <= bp_msg_hi):
+                invariants_hold = False
+            if work["apply-every"] not in common.BACKPRESSURE_APPLY_EVERY:
+                invariants_hold = False
         else:
             invariants_hold = False
         if work["payload"] not in ("string", "u64"):
@@ -172,21 +225,33 @@ def test_resolve_config_deterministic_and_bounded():
         else:
             maxthreads_seen.add(mt)
     check("normal per-kind invariants hold over 300 seeds", invariants_hold)
-    check("cyclic worst-case workers within the calibrated memory ceiling",
-          worst_workers <= CYCLIC_WORKER_CEILING)
+    # Ceiling guard: assert the THEORETICAL worst case (the product of the bound
+    # maxima), NOT the sampled worst over the 300 seeds -- a narrow bucket bump can
+    # push the theoretical max over a ceiling without any sample reaching it (the
+    # largest producers and largest messages need not co-occur), so a sampled check
+    # would miss it. The product of the constants always trips on an unsafe bump.
+    cyclic_theoretical = (max(common.CYCLIC_GROUPS)
+                          * common.CYCLIC_GENERATION_BUCKETS["large"][1])
+    bp_theoretical = (max(common.BACKPRESSURE_PRODUCERS)
+                      * common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1])
+    check("cyclic theoretical worst-case workers within the memory ceiling",
+          cyclic_theoretical <= CYCLIC_WORKER_CEILING)
+    check("backpressure theoretical worst-case messages within the ceiling",
+          bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
     check("payload-mode covers {forward, fresh}",
           mode_seen == {"forward", "fresh"})
     check("ponymaxthreads spans the full [1, THREADS] range",
           maxthreads_seen == set(range(1, THREADS + 1)))
 
 
-def test_resolve_config_draws_both_workloads():
-    # Swarm coverage: over many seeds both workload kinds must appear, or the
-    # cyclic path (or the mesh path) would go entirely untested in the soak.
+def test_resolve_config_draws_all_workloads():
+    # Swarm coverage: over many seeds all three workload kinds must appear, or one
+    # of the cycle-detector / backpressure / mesh paths would go untested in a soak.
     kinds = set()
     for master in range(0, 300):
         kinds.add(normal.resolve_config(master, THREADS)["workload"]["workload"])
-    check("normal mode draws both mesh and cyclic", kinds == {"mesh", "cyclic"})
+    check("normal mode draws all of mesh, cyclic, backpressure",
+          kinds == {"mesh", "cyclic", "backpressure"})
 
 
 def test_resolve_config_swarm_omission():
@@ -204,14 +269,16 @@ def test_resolve_config_swarm_omission():
 
 def test_resolve_config_magnitude_buckets():
     # The deliberate small->large distribution. A MESH run draws chains/ttl from the
-    # magnitude buckets; a CYCLIC run draws generations from its own buckets (and
-    # keeps chains/ttl small). Over many seeds each magnitude knob must reach all
-    # three of its buckets.
+    # magnitude buckets; a CYCLIC run draws generations from its own buckets; a
+    # BACKPRESSURE run draws messages from its own buckets. Over many seeds each
+    # magnitude knob must reach all three of its buckets.
     nb = common.NORMAL_SIZE_BUCKETS
     gb = common.CYCLIC_GENERATION_BUCKETS
+    mb = common.BACKPRESSURE_MESSAGE_BUCKETS
     mesh_chains = {"small": 0, "medium": 0, "large": 0}
     mesh_ttl = {"small": 0, "medium": 0, "large": 0}
     cyclic_gen = {"small": 0, "medium": 0, "large": 0}
+    bp_messages = {"small": 0, "medium": 0, "large": 0}
 
     def bucket_of(val, buckets):
         if val <= buckets["small"][1]:
@@ -225,14 +292,18 @@ def test_resolve_config_magnitude_buckets():
         if w["workload"] == "mesh":
             mesh_chains[bucket_of(w["chains"], nb)] += 1
             mesh_ttl[bucket_of(w["ttl"], nb)] += 1
-        else:
+        elif w["workload"] == "cyclic":
             cyclic_gen[bucket_of(w["generations"], gb)] += 1
+        else:
+            bp_messages[bucket_of(w["messages"], mb)] += 1
     check("mesh chains reaches all three magnitude buckets",
           all(c > 0 for c in mesh_chains.values()))
     check("mesh ttl reaches all three magnitude buckets",
           all(c > 0 for c in mesh_ttl.values()))
     check("cyclic generations reaches all three magnitude buckets",
           all(c > 0 for c in cyclic_gen.values()))
+    check("backpressure messages reaches all three magnitude buckets",
+          all(c > 0 for c in bp_messages.values()))
 
 
 def test_resolve_config_draws_single_pinger():
@@ -255,14 +326,19 @@ def test_resolve_config_fresh_string_size_fits_run():
     small = set(common.STRING_SIZE_TABLES[0][1])
     small_medium = small | set(common.STRING_SIZE_TABLES[1][1])
     holds = True
-    fresh_seen = False
+    fresh_seen = {"mesh": False, "cyclic": False, "backpressure": False}
     for master in range(0, 400):
         w = normal.resolve_config(master, THREADS)["workload"]
         if not (w["payload"] == "string" and w["payload-mode"] == "fresh"):
             continue
-        fresh_seen = True
-        if w["workload"] == "cyclic":
+        kind = w["workload"]
+        fresh_seen[kind] = True
+        # The total message count drives the fresh-string size cap, computed per
+        # kind (cyclic multiplies by generations; backpressure by producers).
+        if kind == "cyclic":
             msgs = w["generations"] * w["chains"] * (w["ttl"] + 1)
+        elif kind == "backpressure":
+            msgs = w["producers"] * w["messages"]
         else:
             msgs = w["chains"] * (w["ttl"] + 1)
         if msgs > caps["medium"] and w["payload-size"] not in small:
@@ -270,16 +346,23 @@ def test_resolve_config_fresh_string_size_fits_run():
         elif msgs > caps["large"] and w["payload-size"] not in small_medium:
             holds = False
     check("fresh-string size fits the run's message count", holds)
-    check("fresh-string configs were actually drawn to check", fresh_seen)
+    # Every kind contributes a fresh-string config, so the per-kind msgs formula runs
+    # without error for each. NOTE: only mesh's totals actually reach the size caps
+    # (medium 520M / large 300M) over the sampled seeds, so for cyclic and
+    # backpressure this confirms the formula RUNS, not that the size-limiting bites
+    # (their totals stay under the caps -- same as the pre-existing cyclic behavior).
+    check("fresh-string configs drawn for all three kinds",
+          all(fresh_seen.values()))
 
 
 def main():
-    test_resolve_config_golden()
+    test_resolve_config_mesh_golden()
     test_resolve_config_cyclic_golden()
+    test_resolve_config_backpressure_golden()
     test_resolve_config_never_sets_systematic_seed()
     test_ponynoblock_is_a_swarm_knob()
     test_resolve_config_deterministic_and_bounded()
-    test_resolve_config_draws_both_workloads()
+    test_resolve_config_draws_all_workloads()
     test_resolve_config_swarm_omission()
     test_resolve_config_magnitude_buckets()
     test_resolve_config_draws_single_pinger()

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -201,10 +201,17 @@ ALL_STRING_SIZES = [s for _name, _sizes, _cap in STRING_SIZE_TABLES for s in _si
 # as the same blowup.
 NORMAL_PINGERS = [1, 2, 4, 8, 16, 32, 64]
 
-# Normal-mode cyclic-garbage draws (the `cyclic` workload). A run draws this
-# workload with probability CYCLIC_PROBABILITY; otherwise it is a `mesh` run. The
-# cyclic workload spawns `generations` successive groups of `group` actors, each
-# group a strongly connected reference cycle the detector must reclaim.
+# Normal-mode workload-kind weights for the 3-way draw (draw_workload). mesh is the
+# baseline (the widest runtime surface); cyclic and backpressure each target one
+# otherwise-untouched subsystem (the cycle detector; the explicit UNDER_PRESSURE
+# muting path). A run rolls mesh below MESH_P, cyclic below MESH_P + CYCLIC_P, else
+# backpressure. The tests assert all three appear over the sampled seed range.
+WORKLOAD_MESH_P = 0.4
+WORKLOAD_CYCLIC_P = 0.3   # backpressure gets the remaining 1 - MESH_P - CYCLIC_P
+
+# Normal-mode cyclic-garbage draws (the `cyclic` workload). The cyclic workload
+# spawns `generations` successive groups of `group` actors, each group a strongly
+# connected reference cycle the detector must reclaim.
 #
 # Memory bound (calibrated on the engine, CD-OFF worst case -- the leak case, since
 # normal draws ponynoblock ~50%): the Churner front-loads generations with no
@@ -222,7 +229,6 @@ NORMAL_PINGERS = [1, 2, 4, 8, 16, 32, 64]
 # races creation rather than piling up. COUPLING: these bounds are a property of the
 # engine's per-worker footprint and the front-loading Churner -- re-measure if the
 # cyclic actor's fields or the Churner's pacing change.
-CYCLIC_PROBABILITY = 0.5
 CYCLIC_GROUPS = [2, 4, 8, 16]
 CYCLIC_GENERATION_BUCKETS = {
     "small": (10, 800),
@@ -231,6 +237,38 @@ CYCLIC_GENERATION_BUCKETS = {
 }
 CYCLIC_CHAINS_BUCKETS = {"small": (1, 2), "medium": (3, 5), "large": (6, 8)}
 CYCLIC_TTL_BUCKETS = {"small": (1, 4), "medium": (5, 10), "large": (11, 16)}
+
+# Normal-mode backpressure draws (the `backpressure` workload). A star of
+# `producers` actors floods one consumer that explicitly applies/releases runtime
+# backpressure every `apply_every` received messages, muting its producers via the
+# UNDER_PRESSURE path the mesh's automatic OVERLOAD muting never reaches.
+#
+# Memory is NOT a governing bound here -- the opposite of cyclic. The consumer's
+# mailbox stays bounded by the runtime's automatic OVERLOAD muting irrespective of
+# whether explicit backpressure engages or how `apply_every` is set (measured ~11 MB
+# peak RSS even in a pure-flood config where explicit BP never fires). The producer
+# cap is for muteset-depth stress (one receiver's muteset up to `producers` deep)
+# and pre-flood actor-creation cost, NOT mailbox memory; RLIMIT_AS stays the free
+# backstop.
+#
+# Time governs the bounds: total messages = producers * messages, so `messages` is
+# bucketed small->large for magnitude variety (the #5601 philosophy). The worst
+# drawn case -- 256 producers * 400000 messages = 102.4M messages, fresh 4096-byte
+# string, apply_every 50 -- measures ~6 min wall and ~404 MB peak RSS on the
+# calibration host: under the 100-min per-run cap (~17x margin) and ~10x under the
+# 4 GB RLIMIT_AS, and shorter than the mesh's ~15-20 min worst case. Most draws are
+# far shorter (small/medium buckets dominate). `apply_every` is a set: smaller =
+# more frequent apply/release toggling = more mute/unmute churn (the worst case
+# above logged ~32M mutes / ~299k explicit applies). COUPLING: the time bound is a
+# property of the engine's per-message cost -- re-measure if the Producer/Consumer
+# per-message work changes. Calibrated, not provisional.
+BACKPRESSURE_PRODUCERS = [16, 32, 64, 128, 256]
+BACKPRESSURE_MESSAGE_BUCKETS = {
+    "small": (1000, 20000),
+    "medium": (20001, 100000),
+    "large": (100001, 400000),
+}
+BACKPRESSURE_APPLY_EVERY = [50, 200, 1000]
 
 
 def draw_bucketed(rng, buckets):
@@ -274,20 +312,31 @@ def draw_payload(rng, msgs):
     return kind, size, mode
 
 
-def draw_cyclic(rng):
-    """Draw the workload kind plus the cyclic-only shape, returning
-    (workload, generations, group). ALWAYS the same fixed sequence of four logical
-    draws -- the kind roll, the bucketed generations (a roll + a value), and the
-    group choice -- with no branch on the rolled kind, so the kind changes which
-    keys the config later emits but not how many draws this makes (mirrors
-    draw_payload's fixed-consumption discipline; "logical draws" because a randint's
-    underlying bit consumption varies with its value, but the call sequence does
-    not). generations and group are drawn even for a mesh run (and then ignored) to
-    keep that sequence fixed."""
-    workload = "cyclic" if rng.random() < CYCLIC_PROBABILITY else "mesh"
+def draw_workload(rng):
+    """Draw the workload kind plus EVERY kind's specific shape, returning
+    (workload, generations, group, producers, messages, apply_every). ALWAYS the
+    same fixed sequence of logical draws regardless of the rolled kind -- the kind
+    roll, then the cyclic shape (bucketed generations + group choice), then the
+    backpressure shape (producers choice + bucketed messages + apply_every choice).
+    No branch on the rolled kind, so the kind changes which keys the config later
+    emits, never how many draws this makes (the fixed-consumption discipline;
+    "logical draws" because a randint's underlying bit consumption varies with its
+    value, but the call sequence does not). The mesh `pingers` field is drawn
+    separately in resolve_config, as before. Every kind's params are drawn even when
+    another kind is rolled (and then ignored) to keep that sequence fixed."""
+    roll = rng.random()
+    if roll < WORKLOAD_MESH_P:
+        workload = "mesh"
+    elif roll < (WORKLOAD_MESH_P + WORKLOAD_CYCLIC_P):
+        workload = "cyclic"
+    else:
+        workload = "backpressure"
     generations = draw_bucketed(rng, CYCLIC_GENERATION_BUCKETS)
     group = rng.choice(CYCLIC_GROUPS)
-    return workload, generations, group
+    producers = rng.choice(BACKPRESSURE_PRODUCERS)
+    messages = draw_bucketed(rng, BACKPRESSURE_MESSAGE_BUCKETS)
+    apply_every = rng.choice(BACKPRESSURE_APPLY_EVERY)
+    return workload, generations, group, producers, messages, apply_every
 
 
 def build_argv(binary, config):
@@ -625,17 +674,24 @@ def summary_line(config, result):
     detail = "received=%s expected=%s sig=%s" % (
         parsed.get("received", "?"), parsed.get("expected", "?"),
         parsed.get("order_sig", "?"))
-    # The cyclic and mesh workloads carry different shape fields (a cyclic config
-    # has no `pingers`); chains/ttl/payload are shared. A systematic config has no
-    # `workload` key (always mesh, by the engine default), so default to mesh.
-    if shape.get("workload") == "cyclic":
-        kind = "cyclic generations=%d group=%d" % (
-            shape["generations"], shape["group"])
+    # Each workload carries different shape fields: mesh/cyclic have chains/ttl,
+    # backpressure has producers/messages/apply-every instead (no chains/ttl). Only
+    # payload is shared. A systematic config has no `workload` key (always mesh, by
+    # the engine default), so default to mesh. Fold chains/ttl into the per-kind
+    # string so the backpressure branch never reads a field it lacks.
+    wl = shape.get("workload", "mesh")
+    if wl == "cyclic":
+        kind = "cyclic generations=%d group=%d chains=%d ttl=%d" % (
+            shape["generations"], shape["group"], shape["chains"], shape["ttl"])
+    elif wl == "backpressure":
+        kind = "backpressure producers=%d messages=%d apply_every=%d" % (
+            shape["producers"], shape["messages"], shape["apply-every"])
     else:
-        kind = "mesh pingers=%d" % shape["pingers"]
-    return "[seed %d] %s (%s chains=%d ttl=%d payload=%s) %s" % (
+        kind = "mesh pingers=%d chains=%d ttl=%d" % (
+            shape["pingers"], shape["chains"], shape["ttl"])
+    return "[seed %d] %s (%s payload=%s) %s" % (
         config["master_seed"], result.outcome.upper(), kind,
-        shape["chains"], shape["ttl"], shape["payload"], detail)
+        shape["payload"], detail)
 
 
 def execute(binary, config, version, use_flags, out_dir, timeout,

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -305,10 +305,17 @@ def test_draw_payload():
 CYCLIC_WORKER_CEILING = 130000
 
 
+# The calibrated ceiling on producers*messages (total backpressure work).
+# Hardcoded, NOT derived from the BACKPRESSURE_* constants, so bumping a producer
+# count or a message bucket trips this guard and forces a time re-measure. Real max
+# today is 256*400000 = 102_400_000.
+BACKPRESSURE_MESSAGE_CEILING = 110_000_000
+
+
 class _CallCountingRandom(random.Random):
     """A Random that counts the high-level draw calls (random/randint/choice) made
     on it, delegating to the real implementation so the produced values are
-    unchanged. Used to verify draw_cyclic makes the same number of calls whichever
+    unchanged. Used to verify draw_workload makes the same number of calls whichever
     kind it rolls."""
 
     def __init__(self, seed):
@@ -328,51 +335,69 @@ class _CallCountingRandom(random.Random):
         return super().choice(seq)
 
 
-def test_draw_cyclic():
-    check("draw_cyclic is deterministic",
-          common.draw_cyclic(random.Random(7))
-          == common.draw_cyclic(random.Random(7)))
+def test_draw_workload():
+    check("draw_workload is deterministic",
+          common.draw_workload(random.Random(7))
+          == common.draw_workload(random.Random(7)))
 
     kinds = set()
     bounds_ok = True
-    worst_workers = 0
     gen_lo = common.CYCLIC_GENERATION_BUCKETS["small"][0]
     gen_hi = common.CYCLIC_GENERATION_BUCKETS["large"][1]
+    bp_msg_lo = common.BACKPRESSURE_MESSAGE_BUCKETS["small"][0]
+    bp_msg_hi = common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1]
     for master in range(0, 500):
-        workload, generations, group = common.draw_cyclic(random.Random(master))
+        (workload, generations, group, producers, messages, apply_every) = \
+            common.draw_workload(random.Random(master))
         kinds.add(workload)
-        if workload not in ("mesh", "cyclic"):
+        if workload not in ("mesh", "cyclic", "backpressure"):
             bounds_ok = False
-        # generations and group are drawn for BOTH kinds (fixed rng consumption),
-        # so they are always valid numbers in range -- checking them over all
-        # seeds, mesh and cyclic alike, is the evidence the draw never skips them.
+        # EVERY kind's params are drawn for every roll (fixed rng consumption), so
+        # they are always valid numbers in range regardless of the rolled kind --
+        # checking them over all seeds is the evidence the draw never skips any.
         if not (gen_lo <= generations <= gen_hi):
             bounds_ok = False
         if group not in common.CYCLIC_GROUPS:
             bounds_ok = False
-        worst_workers = max(worst_workers, generations * group)
-    check("draw_cyclic covers both workload kinds", kinds == {"mesh", "cyclic"})
-    check("draw_cyclic generations/group always in range (drawn for both kinds)",
+        if producers not in common.BACKPRESSURE_PRODUCERS:
+            bounds_ok = False
+        if not (bp_msg_lo <= messages <= bp_msg_hi):
+            bounds_ok = False
+        if apply_every not in common.BACKPRESSURE_APPLY_EVERY:
+            bounds_ok = False
+    check("draw_workload covers all three workload kinds",
+          kinds == {"mesh", "cyclic", "backpressure"})
+    check("draw_workload all shape params always in range (drawn for every kind)",
           bounds_ok)
-    check("draw_cyclic worst-case workers within the calibrated memory ceiling",
-          worst_workers <= CYCLIC_WORKER_CEILING)
+    # Ceiling guard: assert the THEORETICAL worst case (the product of the bound
+    # maxima), NOT the sampled worst over the seeds. A narrow bucket bump can push
+    # the theoretical max over a ceiling without any 500-seed sample reaching it
+    # (the largest producers and the largest messages need not co-occur in a draw),
+    # so a sampled check would miss it. The product of the constants always trips.
+    cyclic_theoretical = (max(common.CYCLIC_GROUPS)
+                          * common.CYCLIC_GENERATION_BUCKETS["large"][1])
+    bp_theoretical = (max(common.BACKPRESSURE_PRODUCERS)
+                      * common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1])
+    check("cyclic theoretical worst-case workers within the memory ceiling",
+          cyclic_theoretical <= CYCLIC_WORKER_CEILING)
+    check("backpressure theoretical worst-case messages within the ceiling",
+          bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
 
-    # Fixed-consumption contract: draw_cyclic must make the SAME sequence of rng
-    # calls whether it rolls mesh or cyclic (it draws generations + group
-    # unconditionally), so a future kind-dependent extra draw -- which would remap
-    # seeds -- is caught. Compare the call COUNT across a mesh-rolling and a
-    # cyclic-rolling seed; comparing rng state would not work, because a randint's
-    # underlying bit consumption varies with its value (see the draw_cyclic doc).
-    mesh_seed = next(s for s in range(0, 500)
-                     if common.draw_cyclic(random.Random(s))[0] == "mesh")
-    cyclic_seed = next(s for s in range(0, 500)
-                       if common.draw_cyclic(random.Random(s))[0] == "cyclic")
-    mesh_counter = _CallCountingRandom(mesh_seed)
-    cyclic_counter = _CallCountingRandom(cyclic_seed)
-    common.draw_cyclic(mesh_counter)
-    common.draw_cyclic(cyclic_counter)
-    check("draw_cyclic makes the same number of rng calls for mesh and cyclic",
-          (mesh_counter.calls == cyclic_counter.calls) and (mesh_counter.calls > 0))
+    # Fixed-consumption contract: draw_workload must make the SAME sequence of rng
+    # calls whichever kind it rolls (it draws every kind's shape unconditionally),
+    # so a future kind-dependent extra draw -- which would remap seeds -- is caught.
+    # Compare the call COUNT across a seed of each kind; comparing rng state would
+    # not work, because a randint's underlying bit consumption varies with its value
+    # (see the draw_workload doc).
+    counts = []
+    for kind in ("mesh", "cyclic", "backpressure"):
+        seed = next(s for s in range(0, 500)
+                    if common.draw_workload(random.Random(s))[0] == kind)
+        counter = _CallCountingRandom(seed)
+        common.draw_workload(counter)
+        counts.append(counter.calls)
+    check("draw_workload makes the same number of rng calls for every kind",
+          (len(set(counts)) == 1) and (counts[0] > 0))
 
 
 def test_build_argv():
@@ -602,6 +627,55 @@ def test_parse_result():
                               "expected=6") == {})
 
 
+def test_summary_line():
+    # summary_line reads DIFFERENT shape fields per kind (mesh/cyclic have
+    # chains/ttl, backpressure has producers/messages/apply-every). If its read keys
+    # ever drift from resolve_config's emit keys, it raises an unguarded KeyError --
+    # at soak time, never in CI -- so exercise every branch here. The shape dicts
+    # mirror what the orchestrators emit (see orchestrate_normal.resolve_config and
+    # resolve_systematic_workload).
+    result = common.RunResult(
+        "pass", 0, None,
+        "RECEIVED=10 SENT=10 EXPECTED=10 ORDER_SIG=42", "")
+
+    mesh = {"master_seed": 1, "runtime": {},
+            "workload": {"seed": 9, "workload": "mesh", "pingers": 8,
+                         "chains": 8, "ttl": 16, "payload": "u64",
+                         "payload-size": 1, "payload-mode": "forward"}}
+    cyclic = {"master_seed": 2, "runtime": {},
+              "workload": {"seed": 9, "workload": "cyclic", "generations": 50,
+                           "group": 4, "chains": 2, "ttl": 8, "payload": "string",
+                           "payload-size": 64, "payload-mode": "fresh"}}
+    bp = {"master_seed": 3, "runtime": {},
+          "workload": {"seed": 9, "workload": "backpressure", "producers": 64,
+                       "messages": 1000, "apply-every": 200, "payload": "string",
+                       "payload-size": 64, "payload-mode": "forward"}}
+    # A systematic config has NO `workload` key (always mesh by the engine default)
+    # and must default to the mesh branch.
+    systematic = {"master_seed": 4, "runtime": {},
+                  "workload": {"seed": 9, "pingers": 16, "chains": 100, "ttl": 4,
+                               "payload": "u64", "payload-size": 8,
+                               "payload-mode": "fresh"}}
+
+    # Each kind must render without KeyError and name its kind + its own fields.
+    ms = common.summary_line(mesh, result)
+    check("summary_line mesh: names kind and pingers/chains",
+          ("mesh pingers=8" in ms) and ("chains=8" in ms) and ("PASS" in ms))
+    cs = common.summary_line(cyclic, result)
+    check("summary_line cyclic: names generations/group/chains",
+          ("cyclic generations=50 group=4" in cs) and ("chains=2" in cs))
+    bs = common.summary_line(bp, result)
+    check("summary_line backpressure: names producers/messages/apply_every",
+          ("backpressure producers=64 messages=1000 apply_every=200" in bs)
+          and ("chains" not in bs))   # backpressure has no chains/ttl
+    ss = common.summary_line(systematic, result)
+    check("summary_line defaults a no-workload-key config to mesh",
+          "mesh pingers=16" in ss)
+    # The detail suffix carries the parsed result on every kind.
+    check("summary_line carries the parsed detail",
+          "received=10 expected=10 sig=42" in bs)
+
+
 def main():
     test_derive_seed()
     test_derive_seed_zero_floor()
@@ -612,7 +686,7 @@ def main():
     test_draw_max_threads()
     test_draw_bucketed()
     test_draw_payload()
-    test_draw_cyclic()
+    test_draw_workload()
     test_build_argv()
     test_run_command()
     test_lldb_argv()
@@ -623,6 +697,7 @@ def main():
     test_bundle_for()
     test_resolve_seeds()
     test_parse_result()
+    test_summary_line()
     if FAILURES:
         print("%d failure(s): %s" % (len(FAILURES), ", ".join(FAILURES)))
         sys.exit(1)


### PR DESCRIPTION
Adds a `backpressure` workload to the generative runtime stress harness — the next
M1 primitive after cyclic garbage (#5605).

The mesh already drives the runtime's automatic overload muting heavily (measured:
up to ~228k mute events at high message volume), and the rt-systematic
`mute-order-signature` fixture covers its determinism. So a slow-consumer overload
workload would mostly duplicate coverage we already have. The uncovered slice is
the explicit backpressure path — an actor calling `Backpressure.apply`/`release`
from the stdlib package to mark itself UNDER_PRESSURE, the way `TCPConnection` does.
The mesh never reaches it (measured: 0 explicit applications); the new workload
drives it reliably (790–2969 per run).

The workload is a star of `Producer` actors flooding one `Consumer` that applies
and releases runtime backpressure every `apply_every` received messages. A
self-sent `lift` (immune to muting) guarantees the release, so the closed flood
can't deadlock. Conservation is the mesh's strength, not the cyclic workload's
weaker completion count: completion triggers on all producers reporting, then
asserts received == the producers' own send tally == expected, so a lost message is
a conservation failure, not just a timeout.

Normal mode only this cycle, mirroring cyclic. A systematic leg is a follow-up —
unlike cyclic it isn't blocked by the forced `--ponynoblock` (muting is
cycle-detector-independent), but its determinism under systematic is unverified.

`chains`/`ttl` move out of the shared `_Config` onto the `_Mesh`/`_Cyclic` variants,
since a backpressure run has neither — a backpressure config then can't carry them
at all, keeping illegal field combinations unrepresentable.

Calibrated on the engine: muting fires on every drawn config (even the weakest
applies backpressure); the worst-case run is ~6 min / ~404 MB, under the 100-min
and 4 GB caps and shorter than the mesh's worst. Adversarial review ran ~350
watchdog-wrapped runs, including 300 that force backpressure onto the last received
message, with zero hangs.

Design: #5560
