### PR TITLE
Fix the stale cyclic golden in the normal-mode stress test

### DIFF
--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -80,7 +80,7 @@ def test_resolve_config_cyclic_golden():
         "runtime": {
             "ponycdinterval": 1000,
             "ponygcfactor": 1.05,
-            "ponygcinitial": 16,
+            "ponygcinitial": 20,
             "ponymaxthreads": 8,
             "ponynoblock": True,
             "ponynoscale": True,


### PR DESCRIPTION
`test_resolve_config_cyclic_golden` currently fails on main. #5612 added `0` to the swarm's `--ponygcinitial` draw, which remapped seed 5's drawn gcinitial from 16 to 20, but the cyclic golden pinned in #5614 still expects 16. Each PR was green against main as it stood when its CI ran, so the skew only surfaced once both had landed.

The drawn config is correct — only the pinned expectation is stale. This refreshes it to 20.