### PR TITLE
Bound mesh stress-run time by trimming ttl to a per-run ceiling

### DIFF
--- a/test/rt-stress/generative/orchestrate_normal.py
+++ b/test/rt-stress/generative/orchestrate_normal.py
@@ -68,8 +68,9 @@ def resolve_config(master_seed, max_threads):
     messages); a `cyclic` run draws the magnitude in GENERATIONS and keeps chains/ttl
     small (total = generations*chains*(ttl+1)); a `backpressure` run draws the
     magnitude in MESSAGES per producer (total = producers*messages) and has no
-    chains/ttl. The payload is drawn with its string SIZE limited by the total
-    message count (draw_payload).
+    chains/ttl. The payload (kind/size/mode) is drawn freely; a `mesh` run's ttl is
+    then trimmed to a run-time ceiling (clamp_ttl), since a forward run's cost grows
+    with chains^2 and a high-chains/high-ttl draw would otherwise run for hours.
 
     This mode is non-reproducible (real parallelism), so a seed maps to a
     *configuration* deterministically but not to an *execution*. The draw order is
@@ -99,14 +100,14 @@ def resolve_config(master_seed, max_threads):
                    else common.NORMAL_SIZE_BUCKETS)
     chains = common.draw_bucketed(rng, chains_buckets)
     ttl = common.draw_bucketed(rng, ttl_buckets)
-    # Total message count per kind, fed to draw_payload's fresh-string size cap.
-    if kind == "cyclic":
-        msgs = generations * chains * (ttl + 1)
-    elif kind == "backpressure":
-        msgs = producers * messages
-    else:
-        msgs = chains * (ttl + 1)
-    payload, size, mode = common.draw_payload(rng, msgs)
+    payload, size, mode = common.draw_payload(rng)
+    # Mesh run time is bounded by trimming ttl to fit the per-run ceiling (a
+    # forward run's cost grows with chains^2, so a high-chains/high-ttl draw would
+    # take hours). The clamp consumes no rng, so only an over-budget mesh ttl
+    # changes -- cyclic/backpressure draws are untouched. Cyclic keeps its own tiny
+    # ttl range and backpressure ignores ttl, so neither needs the mesh clamp.
+    if kind == "mesh":
+        ttl = common.clamp_ttl(chains, ttl, mode, payload, size)
 
     # Emit only the shape fields the kind uses, so a contradictory field is never
     # passed to the engine: mesh has pingers+chains+ttl, cyclic has

--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -44,8 +44,9 @@ def test_resolve_config_mesh_golden():
     # Pin a MESH config: the normal-mode seed-stability guard for the mesh emit
     # shape (pingers + chains + ttl, no generations/group/producers). Distinct from
     # the systematic golden -- normal draws the workload kind first (now 3-way), then
-    # bucketed chains/ttl, a payload whose string size is limited by the total
-    # message count, and ponynoblock as a swarm knob, and carries no systematic seed.
+    # bucketed chains/ttl (a mesh run's ttl then trimmed to the run-time ceiling), a
+    # freely-drawn payload, and ponynoblock as a swarm knob, and carries no
+    # systematic seed.
     # (This intentionally differs from the two-kind normal golden -- the 3-way kind
     # roll and the extra backpressure-shape draws remap every historical seed.)
     # Seed 1 rolls mesh.
@@ -183,10 +184,14 @@ def test_resolve_config_deterministic_and_bounded():
                 invariants_hold = False
             if work["pingers"] not in PINGERS_ALLOWED:
                 invariants_hold = False
-            # mesh chains/ttl span the magnitude buckets (small low .. large high).
+            # mesh chains spans the magnitude buckets (small low .. large high).
+            # ttl is drawn from the same range but then trimmed by clamp_ttl to
+            # keep the run within the time ceiling, so a high-chains config can land
+            # below the bucket floor (down to 0) -- only its upper bound is the
+            # bucket max.
             if not (1500 <= work["chains"] <= 34000):
                 invariants_hold = False
-            if not (1500 <= work["ttl"] <= 34000):
+            if not (0 <= work["ttl"] <= 34000):
                 invariants_hold = False
         elif kind == "cyclic":
             if any(k in work for k in
@@ -317,42 +322,34 @@ def test_resolve_config_draws_single_pinger():
     check("normal mode draws a mesh run with pingers=1", one_seen)
 
 
-def test_resolve_config_fresh_string_size_fits_run():
-    # A fresh-string config's size must fit its run: above the medium table's cap a
-    # fresh string may only be a small size; above the large table's cap, never
-    # 4096. The run's message count depends on the kind (cyclic multiplies by
-    # generations).
-    caps = {name: cap for name, _t, cap in common.STRING_SIZE_TABLES}
-    small = set(common.STRING_SIZE_TABLES[0][1])
-    small_medium = small | set(common.STRING_SIZE_TABLES[1][1])
-    holds = True
-    fresh_seen = {"mesh": False, "cyclic": False, "backpressure": False}
-    for master in range(0, 400):
+def test_resolve_config_mesh_run_time_bounded():
+    # Run time is bounded by trimming a mesh config's ttl: no mesh config's estimated
+    # single-thread time may exceed the ceiling, and a high-chains FORWARD run (the
+    # shape that used to take hours) must still be drawn -- just with its ttl trimmed
+    # so it fits. Coverage of the dimension is preserved; only the can't-finish corner
+    # (high chains AND high ttl together) is dropped.
+    ceiling = common.RUN_TIME_CEILING_SECONDS
+    large_lo = common.NORMAL_SIZE_BUCKETS["large"][0]
+    small_lo = common.NORMAL_SIZE_BUCKETS["small"][0]
+    over = high_chains_forward = bound_bit = False
+    for master in range(0, 600):
         w = normal.resolve_config(master, THREADS)["workload"]
-        if not (w["payload"] == "string" and w["payload-mode"] == "fresh"):
+        if w["workload"] != "mesh":
             continue
-        kind = w["workload"]
-        fresh_seen[kind] = True
-        # The total message count drives the fresh-string size cap, computed per
-        # kind (cyclic multiplies by generations; backpressure by producers).
-        if kind == "cyclic":
-            msgs = w["generations"] * w["chains"] * (w["ttl"] + 1)
-        elif kind == "backpressure":
-            msgs = w["producers"] * w["messages"]
-        else:
-            msgs = w["chains"] * (w["ttl"] + 1)
-        if msgs > caps["medium"] and w["payload-size"] not in small:
-            holds = False
-        elif msgs > caps["large"] and w["payload-size"] not in small_medium:
-            holds = False
-    check("fresh-string size fits the run's message count", holds)
-    # Every kind contributes a fresh-string config, so the per-kind msgs formula runs
-    # without error for each. NOTE: only mesh's totals actually reach the size caps
-    # (medium 520M / large 300M) over the sampled seeds, so for cyclic and
-    # backpressure this confirms the formula RUNS, not that the size-limiting bites
-    # (their totals stay under the caps -- same as the pre-existing cyclic behavior).
-    check("fresh-string configs drawn for all three kinds",
-          all(fresh_seen.values()))
+        if common.est_mesh_seconds(w["chains"], w["ttl"], w["payload-mode"],
+                                   w["payload"], w["payload-size"]) > ceiling:
+            over = True
+        if w["payload-mode"] == "forward" and w["chains"] >= large_lo:
+            high_chains_forward = True
+            # At large chains the forward budget caps ttl well below the small
+            # bucket's floor, so a clamped run lands below it -- evidence the bound
+            # actually bit, not just that high chains happened to draw a small ttl.
+            if w["ttl"] < small_lo:
+                bound_bit = True
+    check("no mesh config's estimated run time exceeds the ceiling", not over)
+    check("high-chains forward mesh runs are still drawn (coverage preserved)",
+          high_chains_forward)
+    check("the run-time bound actually trims a high-chains forward run", bound_bit)
 
 
 def main():
@@ -366,7 +363,7 @@ def main():
     test_resolve_config_swarm_omission()
     test_resolve_config_magnitude_buckets()
     test_resolve_config_draws_single_pinger()
-    test_resolve_config_fresh_string_size_fits_run()
+    test_resolve_config_mesh_run_time_bounded()
     if FAILURES:
         print("%d failure(s): %s" % (len(FAILURES), ", ".join(FAILURES)))
         sys.exit(1)

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -55,7 +55,7 @@ DEFAULT_TIMEOUT_SECONDS = 120
 # Normal mode's per-run watchdog: a flat ~100 min, ~2x the longest plausible large
 # run with slow-CI margin (a hung run, not its true length, is the worst case). Big
 # enough that host-speed variance never false-positives a legitimate run, so the
-# bucket and size-table numbers can stay hardcoded with no startup calibration. Systematic
+# bucket and cost-model numbers can stay hardcoded with no startup calibration. Systematic
 # keeps DEFAULT_TIMEOUT_SECONDS -- its runs are seconds (the engine now reaches natural
 # quiescence through full shutdown rather than forcing an exit, so a large drawn config
 # can take ~10s, still well inside the 120s cap).
@@ -86,9 +86,9 @@ def resolve_systematic_workload(rng, program_seed):
     the five swarm-drawn fields, in the dict-insertion and rng-draw order that is the
     seed-stability contract.
 
-    Normal mode does NOT use this -- it composes its own bucketed draw plus a
-    payload whose string size is limited by the message count (draw_bucketed /
-    draw_payload); see orchestrate_normal.resolve_config. Systematic stays small and
+    Normal mode does NOT use this -- it composes its own bucketed draw, then trims
+    a mesh config's ttl to a run-time ceiling (draw_bucketed / draw_payload /
+    clamp_ttl); see orchestrate_normal.resolve_config. Systematic stays small and
     fixed-range on purpose: it serializes the scheduler, so a billion-message run's
     interleaving space is intractable.
 
@@ -159,10 +159,15 @@ def draw_max_threads(rng, max_threads):
 
 # Normal-mode magnitude buckets. Each of chains and ttl draws a bucket
 # (small/medium/large at 25/50/25), then a uniform value within it. Ranges are
-# (lo, hi) inclusive and tuned on the calibration host (WSL2, 2 threads, debug,
-# ~1M msg/s at scale) so same-bucket pairs land near the time yardstick: S*S
-# ~secs-3min, M*M ~3-12min, L*L ~12-19min (top ~1.16B messages ~ 15-20 min).
-# chains and ttl share these ranges. Systematic mode does NOT use them -- it stays
+# (lo, hi) inclusive. These set the magnitude RANGE only; run TIME is governed
+# separately by clamp_ttl (below), which trims ttl so a config's estimated
+# single-thread time stays within RUN_TIME_CEILING_SECONDS. The two are split
+# because per-message cost is NOT flat: a forward-mode run's cost grows with
+# chains^2 (the shared payload's per-hop trace cost scales with the number of
+# concurrent live chains), so a high-chains forward run at high ttl would take
+# hours -- the clamp pairs high chains with a low ttl (and vice versa), keeping
+# both dimensions covered and dropping only the can't-finish corner. chains and
+# ttl share these ranges. Systematic mode does NOT use them -- it stays
 # small/fixed-range (see resolve_systematic_workload). Locked, not provisional.
 NORMAL_SIZE_BUCKETS = {
     "small": (1500, 14000),
@@ -170,26 +175,66 @@ NORMAL_SIZE_BUCKETS = {
     "large": (27001, 34000),
 }
 
-# String-payload sizes grouped by per-hop cost into small/medium/large tables. A
-# fresh string's run cost is ~ messages * per-hop-cost(size), so the costlier tables
-# are offered only to smaller runs: each table's third field is the most messages a
-# fresh run of its slowest size keeps within the ~30-min soak budget. The 4096/1024/
-# 256 figures are measured at scale on the calibration host (the per-message rate
-# decays as a run grows, so these are not short-run extrapolations); the small table's
-# cap is from the same decay curve, which reproduces the measured ones within ~3%, and
-# the 100-min per-run hard timeout backstops any drift. draw_payload limits a fresh
-# string to the sizes whose table fits the run's message count -- a big run can only
-# draw a cheap size, a small run any. Forward and u64 payloads allocate once (or
-# never), so their cost is ~flat in size and they draw from every size. COUPLING: the
-# per-table caps are a property of the engine's per-hop cost -- if that changes (e.g. a
-# payload-integrity check, per the README's deferred work), re-measure them.
-STRING_SIZE_TABLES = (
-    # (name, sizes, max fresh-string messages within the ~30-min budget)
-    ("small",  [1, 8, 64],  990_000_000),
-    ("medium", [256, 1024], 520_000_000),
-    ("large",  [4096],      300_000_000),
-)
-ALL_STRING_SIZES = [s for _name, _sizes, _cap in STRING_SIZE_TABLES for s in _sizes]
+# String-payload byte sizes. Drawn freely; run time is governed by clamp_ttl, not
+# by restricting which sizes a big run may pick.
+STRING_SIZES = [1, 8, 64, 256, 1024, 4096]
+
+# Per-run time ceiling (estimated single-thread seconds on the slow path). The
+# largest mesh run targets ~this; smaller draws finish faster. ~20 min keeps the
+# soak getting through many configs while no single run dominates the window, and
+# matches the original "largest run ~15-20 min" intent. Tunable.
+RUN_TIME_CEILING_SECONDS = 1200
+
+# Mesh run-time cost model: estimated SINGLE-THREAD seconds on the slow CI path,
+# measured on the engine (debug, under lldb on a 2-core runner is the worst TIER1
+# path). Two shapes:
+#   forward: time ~ K_fwd[payload] * chains^2 * (ttl+1). The one payload object is
+#     forwarded the whole chain, so each hop re-traces it across an actor boundary;
+#     that per-hop trace cost scales with the number of concurrent live chains, so
+#     cost is quadratic in chains. It depends on payload KIND (a String traces more
+#     than a boxed U64) but ~not its byte size (forwarding doesn't copy the bytes).
+#   fresh:   time ~ K_fresh[payload][size] * chains * (ttl+1). A new payload is
+#     allocated every hop, so cost is linear in chains and grows with the string's
+#     byte size (allocation + tracing of the bytes).
+# Constants are seconds-per-(unit of the shape above) and fold in a ~2x slow-CI
+# margin over the local measurement. Bounding for 1 thread is deliberately the
+# worst case: a multi-thread run finishes faster, so more seeds run -> more
+# coverage. COUPLING: these are a property of the engine's per-hop cost -- re-measure
+# (test/rt-stress/generative, sweep chains for each mode/payload/size) if the payload
+# handling or the forwarding/trace path changes.
+_MESH_FWD_COST = {"u64": 1.5e-9, "string": 6.0e-9}
+_MESH_FRESH_COST_U64 = 4.0e-6
+_MESH_FRESH_COST_STRING = {1: 8e-6, 8: 8e-6, 64: 9e-6, 256: 10e-6,
+                           1024: 14e-6, 4096: 22e-6}
+
+
+def est_mesh_seconds(chains, ttl, mode, payload, size):
+    """Estimated single-thread slow-path run time (seconds) for a mesh config.
+    See the cost-model comment above for the two shapes."""
+    hops = chains * (ttl + 1)
+    if mode == "forward":
+        return _MESH_FWD_COST[payload] * chains * hops
+    per_msg = (_MESH_FRESH_COST_U64 if payload == "u64"
+               else _MESH_FRESH_COST_STRING[size])
+    return per_msg * hops
+
+
+def clamp_ttl(chains, ttl, mode, payload, size):
+    """Trim ttl so a mesh config's estimated run time stays within
+    RUN_TIME_CEILING_SECONDS, returning the (possibly unchanged) ttl. The estimate
+    is linear in (ttl+1), so the per-(ttl+1) coefficient is est at ttl=0; the
+    largest ttl that fits is ceiling/coefficient - 1, floored at 0. High chains in
+    forward mode -> low ttl_max; low chains -> ttl unchanged. The 0 floor stays
+    within the ceiling only while a single hop (the coefficient) does -- true for
+    every drawable config (the max coefficient is ~7s, far under the ceiling); a
+    bucket bump that broke that would fail test_clamp_ttl's max-chains case.
+    Consumes no rng (a post-draw clamp), so only an over-budget ttl VALUE changes
+    -- no draw remap."""
+    if est_mesh_seconds(chains, ttl, mode, payload, size) <= RUN_TIME_CEILING_SECONDS:
+        return ttl
+    coefficient = est_mesh_seconds(chains, 0, mode, payload, size)
+    ttl_max = int(RUN_TIME_CEILING_SECONDS / coefficient) - 1
+    return max(0, min(ttl, ttl_max))
 
 # Normal-mode actor counts. pingers=1 -- a lone actor that only ever forwards to
 # itself -- is included on purpose: it exercises the ORCA self-send path. That path
@@ -287,29 +332,16 @@ def draw_bucketed(rng, buckets):
     return rng.randint(lo, hi)
 
 
-def draw_payload(rng, msgs):
+def draw_payload(rng):
     """Draw payload kind, size, and mode. Returns (payload, size, mode).
 
-    The available string SIZE is limited by `msgs`: a fresh string's cost grows with
-    both message count and size, so a big run may draw only a cheap (small) size while
-    a small run may draw any (see STRING_SIZE_TABLES). Forward and u64 payloads are
-    flat-cost in size and draw from every size. Runs so large that even the small
-    table's budget is exceeded still draw from it (a slight, hard-timeout-bounded
-    overrun) rather than being denied a string.
-
-    Always exactly three rng draws -- kind, mode, size -- in that fixed order, so the
-    draw stream is stable: the size table changes which value the third draw lands on,
-    never how much rng it consumes."""
+    Size is drawn freely from the full set -- a big run is no longer denied a large
+    string size, because run time is bounded by clamp_ttl (which trims ttl) rather
+    than by restricting size. Exactly three rng draws -- kind, mode, size -- in that
+    fixed order, so the draw stream is stable."""
     kind = rng.choice(["string", "u64"])
     mode = rng.choice(["forward", "fresh"])
-    if kind == "string" and mode == "fresh":
-        sizes = [s for _n, table, cap in STRING_SIZE_TABLES if msgs <= cap
-                 for s in table]
-        if not sizes:                      # past even the small table's budget;
-            sizes = STRING_SIZE_TABLES[0][1]  # still allow the cheapest sizes
-    else:
-        sizes = ALL_STRING_SIZES
-    size = sizes[int(rng.random() * len(sizes))]
+    size = STRING_SIZES[int(rng.random() * len(STRING_SIZES))]
     return kind, size, mode
 
 

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -208,101 +208,70 @@ def test_draw_bucketed():
 
 
 def test_draw_payload():
-    # A fresh string's available SIZE is limited by the run's message count; forward
-    # and u64 are flat-cost and draw any size. The harness's largest run has chains and
-    # ttl both at the large bucket's max -- max*(max+1) messages, ~1.16B, past even the
-    # small table's budget -- so a fresh string there may draw only small sizes. Derive
-    # it from the bucket so it can't go stale if the ranges change.
-    _max_dim = common.NORMAL_SIZE_BUCKETS["large"][1]
-    big = _max_dim * (_max_dim + 1)
-    small_sizes = set(common.STRING_SIZE_TABLES[0][1])   # {1, 8, 64}
-    larger_sizes = set(common.ALL_STRING_SIZES) - small_sizes   # {256, 1024, 4096}
-    caps = {name: cap for name, _t, cap in common.STRING_SIZE_TABLES}
-
-    big_fresh_larger = big_fresh_small = flat_larger_at_big = False
+    # Size is drawn freely from the full set now -- run time is bounded by clamp_ttl
+    # (which trims ttl), not by restricting which sizes a big run may pick. Every
+    # size, kind, and mode must be reachable across seeds.
+    sizes, kinds, modes = set(), set(), set()
     for master in range(0, 2000):
-        k, s, m = common.draw_payload(random.Random(master), big)
-        if k == "string" and m == "fresh":
-            big_fresh_larger |= s in larger_sizes
-            big_fresh_small |= s in small_sizes
-        else:                                 # forward string or u64
-            flat_larger_at_big |= s in larger_sizes
-    check("draw_payload: a big fresh-string run never draws a non-small size",
-          not big_fresh_larger)
-    check("draw_payload: a big fresh-string run still draws small sizes",
-          big_fresh_small)
-    check("draw_payload: forward/u64 draw any size even at the max run",
-          flat_larger_at_big)
+        k, s, m = common.draw_payload(random.Random(master))
+        sizes.add(s)
+        kinds.add(k)
+        modes.add(m)
+    check("draw_payload covers every string size", sizes == set(common.STRING_SIZES))
+    check("draw_payload covers {string, u64}", kinds == {"string", "u64"})
+    check("draw_payload covers {forward, fresh}", modes == {"forward", "fresh"})
 
-    # A big run's fresh-string sizes are a strict subset of a small run's: the table
-    # only grows as the run shrinks.
-    fresh_big, fresh_small = set(), set()
-    for master in range(0, 3000):
-        k, s, m = common.draw_payload(random.Random(master), big)
-        if k == "string" and m == "fresh":
-            fresh_big.add(s)
-        k, s, m = common.draw_payload(random.Random(master), 1)
-        if k == "string" and m == "fresh":
-            fresh_small.add(s)
-    check("draw_payload: a small run can draw a large fresh-string size",
-          larger_sizes & fresh_small)
-    check("draw_payload: a big run's fresh sizes are a strict subset of a small run's",
-          fresh_big < fresh_small)
-
-    # Cap boundary, per table: at exactly a table's cap a fresh string may still draw
-    # that table's sizes; one message above, the table drops out. The small table is
-    # the floor -- above its cap the never-deny fallback keeps its sizes -- so it is
-    # checked separately below; here we cover medium and large.
-    def fresh_sizes_at(msgs):
-        seen = set()
-        for master in range(0, 3000):
-            k, s, m = common.draw_payload(random.Random(master), msgs)
-            if k == "string" and m == "fresh":
-                seen.add(s)
-        return seen
-    for name, table_sizes, cap in common.STRING_SIZE_TABLES[1:]:   # medium, large
-        want = set(table_sizes)
-        at_cap, above_cap = fresh_sizes_at(cap), fresh_sizes_at(cap + 1)
-        check("draw_payload: fresh string AT the %s cap can draw %s sizes"
-              % (name, name), want <= at_cap)
-        check("draw_payload: fresh string ABOVE the %s cap cannot draw %s sizes"
-              % (name, name), not (want & above_cap))
-
-    # The small table is the floor: at AND above its cap a fresh string still draws its
-    # sizes (the never-deny fallback) and never a larger one.
-    small_set = set(common.STRING_SIZE_TABLES[0][1])
-    at_small, above_small = fresh_sizes_at(caps["small"]), fresh_sizes_at(caps["small"] + 1)
-    check("draw_payload: fresh string AT the small cap can draw small sizes",
-          small_set <= at_small)
-    check("draw_payload: fresh string ABOVE the small cap still draws small sizes",
-          small_set <= above_small)
-    check("draw_payload: fresh string ABOVE the small cap draws no larger size",
-          not (above_small - small_set))
-
-    # Seed-stability contract: kind and mode are drawn before the (msgs-dependent)
-    # size, and the size always costs exactly one rng draw, so draw_payload consumes
-    # the SAME rng count for any msgs -- the message count must never remap a
-    # downstream draw. Verify the rng state AFTER the call is identical across msgs
-    # spanning every cap boundary and the overrun region (msgs > the small cap, where
-    # the fallback fires), and that kind/mode never shift with msgs.
-    boundary_msgs = [1, caps["large"], caps["large"] + 1, caps["medium"],
-                     caps["medium"] + 1, caps["small"], caps["small"] + 1, big]
-    rng_stable = kind_mode_stable = True
+    # Seed-stability contract: exactly three rng draws -- kind, mode, size -- in that
+    # order, so draw_payload never remaps a downstream draw. Compare the rng state
+    # after the call to a hand-rolled three-draw reference.
+    stable = True
     for master in range(0, 300):
-        states, kinds_modes = [], []
-        for mm in boundary_msgs:
-            rng = random.Random(master)
-            k, _, m = common.draw_payload(rng, mm)
-            states.append(rng.getstate())
-            kinds_modes.append((k, m))
-        if any(st != states[0] for st in states):
-            rng_stable = False
-        if any(km != kinds_modes[0] for km in kinds_modes):
-            kind_mode_stable = False
-    check("draw_payload: rng consumption is fixed across all msgs (overrun included)",
-          rng_stable)
-    check("draw_payload: message count changes only the size, never kind/mode",
-          kind_mode_stable)
+        rng = random.Random(master)
+        common.draw_payload(rng)
+        ref = random.Random(master)
+        ref.choice(["string", "u64"])
+        ref.choice(["forward", "fresh"])
+        ref.random()
+        if rng.getstate() != ref.getstate():
+            stable = False
+    check("draw_payload consumes exactly three rng draws (kind, mode, size)", stable)
+
+
+def test_clamp_ttl():
+    # The mesh run-time bound. Forward cost is quadratic in chains, fresh linear, so
+    # est must separate them; clamp_ttl trims ttl so the estimate fits the ceiling.
+    C = common.RUN_TIME_CEILING_SECONDS
+    check("est: forward cost is >>(10x) fresh at high chains",
+          common.est_mesh_seconds(30000, 1000, "forward", "u64", 1)
+          > 10 * common.est_mesh_seconds(30000, 1000, "fresh", "u64", 1))
+
+    # An in-budget config is returned unchanged.
+    check("clamp_ttl leaves an in-budget config alone",
+          common.clamp_ttl(2000, 1000, "fresh", "u64", 1) == 1000)
+
+    # The original failing seed: forward u64, chains=31178, ttl=30244 (hours of run
+    # time). It must clamp to a large-but-finite ttl whose estimate fits the ceiling.
+    ct = common.clamp_ttl(31178, 30244, "forward", "u64", 256)
+    check("clamp_ttl bounds the failing forward seed", ct < 30244)
+    check("clamp_ttl leaves a usable ttl for the failing seed", ct > 0)
+    check("clamp_ttl keeps the failing seed's estimate within the ceiling",
+          common.est_mesh_seconds(31178, ct, "forward", "u64", 256) <= C)
+
+    # Never raises ttl; floors at 0 (never negative) even at the most extreme config.
+    over = common.clamp_ttl(34000, 34000, "forward", "string", 4096)
+    check("clamp_ttl never raises ttl", over <= 34000)
+    check("clamp_ttl floors at 0 (never negative)", over >= 0)
+
+    # Every (mode, payload, size) at max chains AND max ttl clamps within the ceiling.
+    worst_ok = True
+    max_dim = common.NORMAL_SIZE_BUCKETS["large"][1]
+    for mode in ("forward", "fresh"):
+        for payload in ("u64", "string"):
+            for size in common.STRING_SIZES:
+                t = common.clamp_ttl(max_dim, max_dim, mode, payload, size)
+                if common.est_mesh_seconds(max_dim, t, mode, payload, size) > C:
+                    worst_ok = False
+    check("clamp_ttl bounds every payload/size at max chains+ttl", worst_ok)
 
 
 # The calibrated ceiling on generations*group (leaked actors in a CD-off run).
@@ -694,6 +663,7 @@ def main():
     test_draw_max_threads()
     test_draw_bucketed()
     test_draw_payload()
+    test_clamp_ttl()
     test_draw_workload()
     test_build_argv()
     test_run_command()


### PR DESCRIPTION
A forward-mode mesh run's cost grows with `chains²`: the one forwarded payload is re-traced across an actor boundary every hop, and that per-hop cost scales with the number of concurrent live chains. So a high-`chains`, high-`ttl` forward config runs for hours and trips the per-seed timeout — a false positive, since the run is slow, not hung. (This is what failed the Windows generative-normal soak.) The magnitude buckets drew `chains` and `ttl` independently up to the same max, so that corner was reachable.

This bounds each mesh config's estimated single-thread run time instead: draw `chains` across the full range, then trim `ttl` so the estimate stays within a ~20-minute ceiling. High `chains` pairs with low `ttl` and vice versa, so both dimensions stay covered and only the can't-finish corner drops. The estimate is a measured cost model (forward ≈ `chains²·ttl`, fresh ≈ `chains·ttl`, payload- and size-aware), bounding for the single-thread worst case (a multi-thread run finishes faster, so more seeds run).

The clamp is applied after the draw and consumes no rng, so no seed remaps — only an over-budget mesh `ttl` (or a previously size-capped fresh-string size) changes. It replaces `STRING_SIZE_TABLES`, which capped fresh-string size by message count on a now-wrong 2-thread basis, with the unified time bound.

Follow-ups (separate): a no-progress watchdog so the timeout fires on real hangs rather than slow runs (which would let this bound be more generous), and an investigation into why single-thread forward mode is ~9× slower than two-thread (a possible runtime perf issue this surfaced).