### PR TITLE
Make the normal stress watchdog fire on no progress, not total time

### DIFF
--- a/.known-couplings/stress-heartbeat-watchdog.md
+++ b/.known-couplings/stress-heartbeat-watchdog.md
@@ -1,0 +1,39 @@
+# The generative engine's heartbeat cadence is coupled to the orchestrator's no-progress watchdog
+
+The normal-mode stress orchestrator
+(`test/rt-stress/generative/stress_common.py`) kills a run when it produces NO
+output for `DEFAULT_NORMAL_NO_PROGRESS_SECONDS` (the `_watch_for_progress`
+watchdog), instead of on total wall-clock length. That only tells a hang from a
+slow run because the engine (`test/rt-stress/generative/main.pony`) emits a
+flushed `HEARTBEAT` line as it makes progress: the mesh `Pinger` and the
+backpressure `Consumer` call `_Heartbeat.emit()` every `_Heartbeat.interval(...)`
+messages they receive. The two numbers are a pair:
+
+- The worst gap between heartbeats on a live run MUST stay well under
+  `DEFAULT_NORMAL_NO_PROGRESS_SECONDS`, or the watchdog false-fires on a healthy
+  run. The cadence is set by `_Heartbeat._target` (heartbeats per emitter) and
+  `_Heartbeat._min` (the gate below which a run is too small to bother) in
+  `main.pony`; the threshold is in `stress_common.py`. Change either — the engine's
+  cadence/gate, or the threshold — and re-check that the slowest drawable live run
+  still heartbeats comfortably inside the window.
+- The heartbeat MUST be flushed (`@fflush(@pony_os_stdout())`). A bare `@printf`
+  to a piped stdout is block-buffered, so the line would not reach the watchdog
+  until the buffer fills or the program exits — the watchdog would then false-fire
+  on every healthy long run. Verified: a flushed heartbeat arrives in real time
+  both directly and under lldb (normal mode runs the engine under lldb).
+- The `cyclic` workload emits NO heartbeat on purpose: its largest draw finishes
+  in well under the no-progress window (~8s measured, single thread), so it never
+  needs one. If a future cyclic-bucket bump pushed its worst-case runtime toward
+  `DEFAULT_NORMAL_NO_PROGRESS_SECONDS`, it would need a heartbeat (the persistent
+  `CyclicCollector` is the place — its workers are ephemeral) or a larger window.
+- The heartbeat is gated OFF for small runs (`_Heartbeat._min`), which keeps
+  SYSTEMATIC runs (all far below it) heartbeat-free; systematic also keeps the flat
+  total-time watchdog (`no_progress_seconds=None`), not this one — see
+  `systematic-testing-park-sites.md`, whose hang-detection-via-timeout property
+  this change must not weaken.
+
+Run: the orchestrator unit tests
+(`python test/rt-stress/generative/stress_common_test.py` —
+`test_watchdog_should_kill`, `test_watch_for_progress`) plus, for the engine side,
+a large mesh or backpressure run, confirming `HEARTBEAT` lines stream during the
+run (not bunched at exit).

--- a/test/rt-stress/generative/README.md
+++ b/test/rt-stress/generative/README.md
@@ -159,9 +159,14 @@ non-deterministic, so a replay won't necessarily reproduce a failure).
   each seed under lldb so even a raw crash with no assert is captured with a
   `bt all` (the systematic mode reproduces from its seed, so it re-runs under a
   debugger locally instead).
-- **Liveness** — the orchestrator's wall-clock watchdog; a hang is a failure
-  (including a `cyclic` chain that never completes, or a runtime that fails to
-  shut down cleanly once the engine quiesces).
+- **Liveness** — the orchestrator's watchdog; a hang is a failure (including a
+  `cyclic` chain that never completes, or a runtime that fails to shut down
+  cleanly once the engine quiesces). In **normal** mode the watchdog fires on **no
+  progress** — the engine emits a flushed heartbeat as it advances, and a run that
+  stays silent too long is hung — so a slow-but-progressing run finishes rather
+  than being false-failed for taking a long time. **Systematic** mode keeps a flat
+  total-time watchdog (its runs are short and reproducible, and its park-site hangs
+  must still surface as a timeout).
 - **Determinism** (systematic mode only) — every seed runs twice and the two
   runs' `ORDER_SIG` must match; a divergence is a real race. This needs the
   serialized, reproducible runtime, so it is the systematic driver's oracle

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -90,6 +90,8 @@ use "cli"
 use "random"
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @fflush[I32](stream: Pointer[U8] tag)
+use @pony_os_stdout[Pointer[U8]]()
 use @pony_os_stderr[Pointer[U8]]()
 use @exit[None](status: I32)
 
@@ -117,6 +119,42 @@ primitive _Payloads
     else
       U64(42)
     end
+
+primitive _Heartbeat
+  """
+  The no-progress watchdog's progress signal. A receiving actor calls `emit` every
+  `interval(...)` messages it handles; the normal orchestrator's watchdog reads
+  these to tell a slow-but-advancing run from a hung one, killing only on silence
+  (see stress_common.py). The line carries no data -- only its arrival matters, and
+  it adds no message and no fan-out, so the conservation and ORDER_SIG oracles are
+  untouched.
+
+  Flushing is load-bearing: a bare @printf to a piped stdout is block-buffered, so
+  the line would not reach the watchdog until the buffer fills or the program exits,
+  defeating the watchdog. @fflush forces it out per heartbeat (verified to arrive in
+  real time both directly and under lldb).
+  """
+  fun interval(total_messages: USize, emitters: USize): USize =>
+    """
+    Per-emitter message count between heartbeats, or 0 to disable. Disabled when the
+    run is small enough to finish well within the watchdog's no-progress window (so
+    it needs no heartbeat -- the cyclic workload and small mesh/backpressure draws);
+    otherwise ~`_target` heartbeats per emitter, floored at 1. COUPLING: this cadence
+    is paired with the orchestrator's no_progress threshold -- a live run must
+    heartbeat well within it; see .known-couplings/stress-heartbeat-watchdog.md.
+    """
+    if (emitters == 0) or (total_messages < _min()) then
+      0
+    else
+      (total_messages / (emitters * _target())).max(1)
+    end
+
+  fun emit() =>
+    @printf("HEARTBEAT\n".cstring())
+    @fflush(@pony_os_stdout())
+
+  fun _target(): USize => 50
+  fun _min(): USize => 1_000_000
 
 actor Main
   new create(env: Env) =>
@@ -181,10 +219,13 @@ actor Coordinator
     // Create the mesh. Pingers are built outside the `recover` block (so we can
     // pass `this`) and pushed into the iso array via automatic receiver
     // recovery -- `push`'s argument, a `Pinger tag`, is sendable.
+    // Per-Pinger heartbeat cadence: ~_target prints per Pinger over the run, off
+    // for runs too small to need a progress signal. Computed once and shared.
+    let hb = _Heartbeat.interval(mesh.chains * (mesh.ttl + 1), mesh.pingers)
     let ps: Array[Pinger] iso = recover Array[Pinger](mesh.pingers) end
     var id: USize = 0
     while id < mesh.pingers do
-      ps.push(Pinger(this, id, config))
+      ps.push(Pinger(this, id, config, hb))
       id = id + 1
     end
     let pingers: Array[Pinger] val = consume ps
@@ -281,16 +322,18 @@ actor Pinger
   let _coord: Coordinator
   let _id: USize
   let _config: _Config
+  let _hb_interval: USize
   var _neighbors: Array[Pinger] val
   var _received: U64 = 0
   var _sent: U64 = 0
   var _reported: Bool = false
   let _rand: Rand
 
-  new create(coord: Coordinator, id: USize, config: _Config) =>
+  new create(coord: Coordinator, id: USize, config: _Config, hb_interval: USize) =>
     _coord = coord
     _id = id
     _config = config
+    _hb_interval = hb_interval
     _neighbors = recover val Array[Pinger] end
     // Per-Pinger deterministic draw stream, seeded only from `--seed` + id,
     // never the clock. The stream of values is fixed by the seed; which value
@@ -322,6 +365,9 @@ actor Pinger
       _Fatal("ping after report (leaked/late message)")
     end
     _received = _received + 1
+    if (_hb_interval > 0) and ((_received % _hb_interval.u64()) == 0) then
+      _Heartbeat.emit()
+    end
     if hops > 0 then
       _sent = _sent + 1
       // In `fresh` mode allocate a new payload each hop (allocation +
@@ -600,6 +646,7 @@ actor Consumer
   let _producers: USize
   let _apply_every: USize
   let _expected: U64
+  let _hb_interval: USize
   var _received: U64 = 0
   var _since_apply: USize = 0
   var _pressured: Bool = false
@@ -615,6 +662,8 @@ actor Consumer
     _producers = bp.producers
     _apply_every = bp.apply_every
     _expected = bp.producers.u64() * bp.messages.u64()
+    // Single consumer, so it is the sole heartbeat emitter for this workload.
+    _hb_interval = _Heartbeat.interval(bp.producers * bp.messages, 1)
 
     // Spawn the producers pointing at this consumer (the Coordinator pattern: the
     // driver creates the workers with `this`). Each floods `messages` work
@@ -636,6 +685,9 @@ actor Consumer
       _Fatal("work after done (leaked/late message)")
     end
     _received = _received + 1
+    if (_hb_interval > 0) and ((_received % _hb_interval.u64()) == 0) then
+      _Heartbeat.emit()
+    end
     if not _pressured then
       _since_apply = _since_apply + 1
       if _since_apply >= _apply_every then

--- a/test/rt-stress/generative/orchestrate_normal.py
+++ b/test/rt-stress/generative/orchestrate_normal.py
@@ -8,8 +8,9 @@ real lock-free contention) the serialized systematic mode cannot. The cost: runs
 are NOT reproducible -- two runs of the same seed differ -- so there is no
 determinism oracle here (that is orchestrate_systematic.py's job). What survives:
 the conservation invariant (the engine itself exits non-zero on
-sent != received != expected), crash detection, and the wall-clock liveness
-watchdog. Because a normal-mode crash does NOT reproduce, the engine runs under
+sent != received != expected), crash detection, and the liveness watchdog (here it
+fires on no progress -- engine silence -- so a slow run that keeps advancing is not
+false-failed). Because a normal-mode crash does NOT reproduce, the engine runs under
 lldb so the crash backtrace is captured in the moment -- it is the only artifact
 you will get for a raced memory-corruption crash.
 
@@ -156,10 +157,12 @@ def main(argv):
     parser.add_argument("--out", help="output dir for the binary and bundles")
     parser.add_argument("--timeout", type=int,
                         default=common.DEFAULT_NORMAL_TIMEOUT_SECONDS,
-                        help="per-run wall-clock watchdog, seconds (default %d); a "
-                        "flat ~2x the longest plausible large run with slow-CI "
-                        "margin -- a single hung run, not its true length, is the "
-                        "worst case" % common.DEFAULT_NORMAL_TIMEOUT_SECONDS)
+                        help="absolute per-run backstop, seconds (default %d). A "
+                        "hang is caught sooner by the no-progress watchdog (%ds of "
+                        "silence); this only bounds a run whose real time runs far "
+                        "past its estimate, so it can't eat the whole CI job."
+                        % (common.DEFAULT_NORMAL_TIMEOUT_SECONDS,
+                           common.DEFAULT_NORMAL_NO_PROGRESS_SECONDS))
     parser.add_argument("--mem-limit-mb", type=int,
                         default=common.DEFAULT_MEM_LIMIT_MB,
                         help="per-run address-space cap, MB (POSIX only; on "
@@ -219,8 +222,13 @@ def main(argv):
     # crashed seed under lldb later would not recapture it -- it is lldb-now or
     # never. Don't "optimize" this to a direct run without solving crash capture
     # another way (e.g. core dump + post-mortem lldb).
+    # The watchdog fires on NO PROGRESS (a hang), not on total length: the engine
+    # heartbeats as it advances, so a slow-but-progressing run finishes instead of
+    # false-failing. `t` (the per-run timeout) is the absolute backstop.
     def runner(b, c, t, m):
-        return common.run_under_lldb(b, c, args.lldb, t, m)
+        return common.run_under_lldb(
+            b, c, args.lldb, t, m,
+            no_progress_seconds=common.DEFAULT_NORMAL_NO_PROGRESS_SECONDS)
 
     failures = 0
     if args.budget_seconds is not None:

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -19,8 +19,9 @@ three TIER1 platforms (on Windows the systematic build uses
 `use=systematic_testing` alone -- Windows scales the scheduler with native
 primitives, not pthreads). The RLIMIT_AS memory cap is applied only where the OS
 honors it (Linux): Windows lacks the `resource` module and macOS rejects the
-limit, so both fall back to host OOM handling. The wall-clock watchdog is
-portable.
+limit, so both fall back to host OOM handling. Both watchdogs are portable -- the
+systematic mode's flat wall-clock timeout and the normal mode's no-progress
+watchdog (threads + blocking reads, no `select`, so it runs on Windows too).
 
 The pure pieces (derive_seed / resolve_systematic_workload / draw_* / build_argv /
 run_command / parse_result / lldb_argv / lldb_exit_code) are unit-tested in
@@ -35,6 +36,8 @@ import shlex
 import signal
 import subprocess
 import sys
+import threading
+import time
 
 try:
     import resource  # POSIX only; absent on Windows
@@ -52,13 +55,19 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(SOURCE_DIR)))
 
 U64_MASK = (1 << 64) - 1
 DEFAULT_TIMEOUT_SECONDS = 120
-# Normal mode's per-run watchdog: a flat ~100 min, ~2x the longest plausible large
-# run with slow-CI margin (a hung run, not its true length, is the worst case). Big
-# enough that host-speed variance never false-positives a legitimate run, so the
-# bucket and cost-model numbers can stay hardcoded with no startup calibration. Systematic
-# keeps DEFAULT_TIMEOUT_SECONDS -- its runs are seconds (the engine now reaches natural
-# quiescence through full shutdown rather than forcing an exit, so a large drawn config
-# can take ~10s, still well inside the 120s cap).
+# Normal mode kills a run on NO PROGRESS, not on total length: the engine emits a
+# flushed heartbeat as it advances, and a run that stays silent this long is hung
+# (a deadlock, a lost message, or a shutdown that never completes). A slow-but-
+# advancing run keeps heartbeating, so it is NOT killed -- it finishes, however
+# long it legitimately takes. ~5 min is far above the worst inter-heartbeat gap
+# (the engine targets ~tens of heartbeats per emitter over a run) yet catches a
+# hang in minutes. COUPLING: paired with the engine's heartbeat cadence -- see
+# .known-couplings/stress-heartbeat-watchdog.md.
+DEFAULT_NORMAL_NO_PROGRESS_SECONDS = 300
+# Absolute backstop for the normal mode: even a steadily-progressing run is capped
+# here, bounding a config whose real time runs far past its estimate (a cost-model
+# miss) so a single run can't eat the whole CI job. The magnitude draw (clamp_ttl)
+# targets ~20 min, so this ~100 min leaves wide margin and rarely fires.
 DEFAULT_NORMAL_TIMEOUT_SECONDS = 6000
 DEFAULT_MEM_LIMIT_MB = 4096
 
@@ -530,22 +539,26 @@ def _rlimit_as_supported(platform, resource_available):
     return resource_available and (platform == "linux")
 
 
-def _capture(argv, timeout, mem_limit_bytes):
-    """Run argv under a wall-clock watchdog and (on Linux) an RLIMIT_AS cap;
-    return (timed_out, returncode, stdout, stderr). Mechanism only -- the caller
-    classifies the outcome.
+def _capture(argv, timeout, mem_limit_bytes, no_progress_seconds=None):
+    """Run argv under a watchdog and (on Linux) an RLIMIT_AS cap; return
+    (timed_out, returncode, stdout, stderr). Mechanism only -- the caller classifies.
 
-    The timeout is the primary guardrail on every platform -- a real-parallel or
-    deterministic run can still deadlock. On timeout we kill the whole process
-    GROUP, not just the direct child: the normal mode's direct child is lldb and
-    the engine is its grandchild, so SIGKILLing only lldb would orphan a hung
-    engine (it reparents to init and keeps consuming the host across the soak).
-    `start_new_session` puts the child in its own group so killpg reaps the tree.
+    Two watchdog modes:
+      * no_progress_seconds is None (SYSTEMATIC): `timeout` is a single total
+        wall-clock limit -- the original behavior. Systematic runs are short and
+        reproducible, and a systematic hang must still surface as a timeout (see
+        .known-couplings/systematic-testing-park-sites.md), so this stays unchanged.
+      * no_progress_seconds is set (NORMAL): the run is killed when it produces NO
+        output for that long (a hang); a slow-but-advancing run -- which the engine's
+        heartbeats keep printing through -- is NOT killed, so a legitimately long run
+        finishes instead of false-failing. `timeout` is then an absolute backstop.
+        Both kills return timed_out=True -- a no-progress kill IS a hang/timeout.
 
-    The address-space cap (== `ulimit -v`, covering the pool allocator's mmap'd
-    regions) is applied only where the OS honors it -- see _rlimit_as_supported
-    for why Windows and macOS are excluded; there preexec_fn stays None and the
-    job relies on the host's OOM handling."""
+    On any kill we reap the whole process GROUP, not just the direct child: normal
+    mode's direct child is lldb and the engine is its grandchild, so SIGKILLing only
+    lldb would orphan a hung engine. `start_new_session` puts the child in its own
+    group so killpg reaps the tree. The RLIMIT_AS cap is applied only where the OS
+    honors it -- see _rlimit_as_supported (Windows/macOS fall back to host OOM)."""
     preexec = None
     if (mem_limit_bytes is not None) and _rlimit_as_supported(
             sys.platform, resource is not None):
@@ -558,13 +571,72 @@ def _capture(argv, timeout, mem_limit_bytes):
     proc = subprocess.Popen(argv, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, preexec_fn=preexec,
                             start_new_session=(os.name == "posix"))
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-        return (False, proc.returncode, _decode(stdout), _decode(stderr))
-    except subprocess.TimeoutExpired:
-        _kill_process_tree(proc)
-        stdout, stderr = proc.communicate()
-        return (True, None, _decode(stdout), _decode(stderr))
+    if no_progress_seconds is None:
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+            return (False, proc.returncode, _decode(stdout), _decode(stderr))
+        except subprocess.TimeoutExpired:
+            _kill_process_tree(proc)
+            stdout, stderr = proc.communicate()
+            return (True, None, _decode(stdout), _decode(stderr))
+    return _watch_for_progress(proc, timeout, no_progress_seconds)
+
+
+def _watchdog_should_kill(now, start, last_output, timeout, no_progress_seconds):
+    """The normal-mode watchdog decision: kill if the run has been silent past the
+    no-progress window (a hang) OR has run past the absolute backstop. A run that
+    keeps producing output (last_output recent) survives indefinitely up to the
+    backstop -- that is the "slow but progressing is not a hang" property."""
+    return ((now - last_output) > no_progress_seconds) or ((now - start) > timeout)
+
+
+def _watch_for_progress(proc, timeout, no_progress_seconds,
+                        poll=time.monotonic, sleep=time.sleep):
+    """Drain BOTH of proc's streams in reader threads -- concurrently, so a full
+    stderr pipe (lldb is chatty) can't deadlock the child the way a single deferred
+    reader would -- updating a last-output time on every line. Kill the process
+    group on a no-progress gap (a hang) or the absolute `timeout` backstop;
+    otherwise let the run finish. Returns (timed_out, returncode, stdout, stderr).
+    `poll`/`sleep` are injectable so the watchdog logic is testable without real
+    time."""
+    last_output = [poll()]
+    lock = threading.Lock()
+    chunks = {"out": [], "err": []}
+
+    def drain(stream, key):
+        try:
+            for line in iter(stream.readline, b""):
+                chunks[key].append(line)
+                with lock:
+                    last_output[0] = poll()
+        finally:
+            stream.close()
+
+    readers = [
+        threading.Thread(target=drain, args=(proc.stdout, "out"), daemon=True),
+        threading.Thread(target=drain, args=(proc.stderr, "err"), daemon=True),
+    ]
+    for t in readers:
+        t.start()
+
+    start = poll()
+    timed_out = False
+    while proc.poll() is None:
+        now = poll()
+        with lock:
+            last = last_output[0]
+        if _watchdog_should_kill(now, start, last, timeout, no_progress_seconds):
+            _kill_process_tree(proc)
+            timed_out = True
+            break
+        sleep(0.5)
+    proc.wait()
+    for t in readers:
+        t.join(timeout=5)
+    stdout = _decode(b"".join(chunks["out"]))
+    stderr = _decode(b"".join(chunks["err"]))
+    returncode = None if timed_out else proc.returncode
+    return (timed_out, returncode, stdout, stderr)
 
 
 def _kill_process_tree(proc):
@@ -636,15 +708,21 @@ def lldb_exit_code(output):
     return int(match.group(1)) if match is not None else None
 
 
-def run_under_lldb(binary, config, lldb, timeout, mem_limit_bytes):
+def run_under_lldb(binary, config, lldb, timeout, mem_limit_bytes,
+                   no_progress_seconds=None):
     """Run the engine under lldb so a crash leaves a backtrace in the captured
     output. The normal mode is non-reproducible (real parallelism), so an
     in-the-moment stack is the only crash artifact -- re-running the seed need not
     crash again. The engine's real exit code comes from lldb's exit-status line
     (conservation failures exit 1, a clean run exits 0); no such line means the
-    program crashed, which is a failure with the backtrace already captured."""
+    program crashed, which is a failure with the backtrace already captured.
+
+    `no_progress_seconds` (the normal driver sets it) makes the watchdog fire on a
+    hang -- silence -- rather than on total length, so a slow run finishes; see
+    _capture."""
     timed_out, _lldb_rc, stdout, stderr = _capture(
-        lldb_argv(lldb, run_command(binary, config)), timeout, mem_limit_bytes)
+        lldb_argv(lldb, run_command(binary, config)), timeout, mem_limit_bytes,
+        no_progress_seconds=no_progress_seconds)
     if timed_out:
         return RunResult("timeout", None, None, stdout, stderr)
     combined = stdout + "\n" + stderr

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -525,6 +525,99 @@ def test_run_under_lldb():
         common._capture = real
 
 
+def test_watchdog_should_kill():
+    # The pure no-progress decision: kill on a silence gap OR the absolute backstop;
+    # spare a run that keeps producing output, however long it legitimately takes.
+    decide = common._watchdog_should_kill
+    check("watchdog kills on a no-progress gap (a hang)",
+          decide(400, 0, 0, 6000, 300))
+    check("watchdog spares a slow-but-progressing run",
+          not decide(5000, 0, 4990, 6000, 300))
+    check("watchdog kills at the absolute backstop despite recent progress",
+          decide(6001, 0, 6000, 6000, 300))
+
+
+class _FakeStream:
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+    def close(self):
+        pass
+
+
+class _FakeProc:
+    """A subprocess stand-in for _watch_for_progress: poll() returns None while
+    `alive_polls` remain (the run is going), then the exit code."""
+    def __init__(self, out, err, alive_polls, returncode=0):
+        self.stdout = _FakeStream(out)
+        self.stderr = _FakeStream(err)
+        self._alive = alive_polls
+        self.returncode = returncode
+
+    def poll(self):
+        if self._alive > 0:
+            self._alive -= 1
+            return None
+        return self.returncode
+
+    def wait(self):
+        self._alive = 0
+        return self.returncode
+
+
+def test_watch_for_progress():
+    real_kill = common._kill_process_tree
+    killed = []
+    common._kill_process_tree = lambda p: killed.append(p)
+    try:
+        # Clean completion: the process exits, both streams are drained, the exit
+        # code passes through, and nothing is killed.
+        proc = _FakeProc([b"HEARTBEAT\n", b"RECEIVED=1 SENT=1 EXPECTED=1\n"],
+                         [b"(lldb) run\n"], alive_polls=0, returncode=0)
+        timed_out, rc, out, err = common._watch_for_progress(
+            proc, 6000, 300, poll=lambda: 0.0, sleep=lambda _s: None)
+        check("watch_for_progress: clean run is not timed out", timed_out is False)
+        check("watch_for_progress: exit code passes through", rc == 0)
+        check("watch_for_progress: stdout is drained", "RECEIVED=1" in out)
+        check("watch_for_progress: stderr is drained", "lldb" in err)
+        check("watch_for_progress: a clean run is not killed", not killed)
+
+        # Hang: the process stays alive and emits nothing -> killed on no-progress,
+        # reported as timed out with no returncode. The injected sleep advances the
+        # clock past the no-progress window without real waiting.
+        clock = [0.0]
+
+        def advance(_s):
+            clock[0] += 1000.0
+
+        proc2 = _FakeProc([], [], alive_polls=1000, returncode=0)
+        timed_out2, rc2, _o, _e = common._watch_for_progress(
+            proc2, 6000, 300, poll=lambda: clock[0], sleep=advance)
+        check("watch_for_progress: a hang is timed out", timed_out2 is True)
+        check("watch_for_progress: a hung run is killed", len(killed) == 1)
+        check("watch_for_progress: a timed-out run has no returncode", rc2 is None)
+
+        # Alive across several poll iterations, but the clock stays inside the
+        # no-progress window each step -> the loop runs, the watchdog spares the run,
+        # and it completes cleanly (not killed).
+        clock3 = [0.0]
+
+        def small_advance(_s):
+            clock3[0] += 100.0  # < the 300s no-progress window per step
+
+        proc3 = _FakeProc([b"HEARTBEAT\n"], [], alive_polls=2, returncode=0)
+        timed_out3, rc3, _o3, _e3 = common._watch_for_progress(
+            proc3, 6000, 300, poll=lambda: clock3[0], sleep=small_advance)
+        check("watch_for_progress: an advancing run within the window completes",
+              (timed_out3 is False) and (rc3 == 0))
+        check("watch_for_progress: an advancing run is not killed", len(killed) == 1)
+    finally:
+        common._kill_process_tree = real_kill
+
+
 def test_rlimit_as_supported():
     # Linux honors RLIMIT_AS and ships the resource module: cap applies.
     check("rlimit_as_supported: linux with resource -> True",
@@ -671,6 +764,8 @@ def main():
     test_lldb_exit_code()
     test_run_once()
     test_run_under_lldb()
+    test_watchdog_should_kill()
+    test_watch_for_progress()
     test_rlimit_as_supported()
     test_bundle_for()
     test_resolve_seeds()


### PR DESCRIPTION
The normal-mode stress orchestrator killed a run on total wall-clock time, which false-fails a legitimately slow but progressing run (a forward-mode mesh run is slow, not hung). This makes the watchdog fire on *no progress* instead.

The engine now emits a flushed `HEARTBEAT` line as it advances — the mesh `Pinger` and the backpressure `Consumer` emit every ~N messages received, scaled so a run produces ~tens of heartbeats; cyclic finishes fast enough (~8s) to need none, and small runs are gated off. The heartbeat is a pure flushed print: no message, no fan-out, and it never touches the conservation tallies or `ORDER_SIG`, so both oracles are unchanged. Flushing is load-bearing — a bare `@printf` to a piped stdout is block-buffered and wouldn't reach the watchdog until exit.

The normal orchestrator now kills a run only when it has produced no output for 5 minutes (a hang), keeping the old 100-minute timeout as an absolute backstop for a cost-model miss. It drains stdout and stderr in two reader threads so lldb's chatter can't deadlock the pipe. A slow-but-progressing run finishes instead of being killed for taking a long time.

Systematic mode is untouched: its runs are short and below the heartbeat gate, and its park-site hangs must still surface as a flat timeout, so it keeps the total-time watchdog.

Verified locally: heartbeats arrive in real time directly and under lldb (msys2 lldb 22.1.4, the CI build); conservation passes for every workload; a 20s run under lldb with a 5s no-progress threshold ran to completion (not killed); a hang is killed; counterfactual on the watchdog logic fires the tests.

A known-coupling file records the pairing between the engine's heartbeat cadence and the orchestrator's no-progress threshold.