### PR TITLE
Add an iso-handoff workload to the generative stress harness

### DIFF
--- a/.known-couplings/iso-handoff-workload-ownership.md
+++ b/.known-couplings/iso-handoff-workload-ownership.md
@@ -1,0 +1,47 @@
+# Generative iso-handoff workload's coverage depends on its cargo staying iso + multi-object
+
+The `iso` workload in `test/rt-stress/generative/main.pony` (the `Dispatcher`,
+`Carrier`, and `Parcel` types) exists to exercise an ORCA trace path no
+other workload reaches: transferring ownership of a nested **mutable** object
+subgraph between actors, so the receiver acquires a foreign mutable multi-object
+graph (the `invent references and acquire` path in `src/libponyrt/gc/gc.c` taken
+with `mutability == PONY_TRACE_MUTABLE`). That coverage rests on two source
+properties, and a change to either **silently loses the coverage while every oracle
+stays green** — conservation still counts the same messages, the parcel-integrity
+check still passes, and the soak does not time out. So neither the workload's own
+oracles nor the normal-mode soak can detect the regression.
+
+1. **The cargo must be `iso`.** A `Parcel` graph is constructed `recover iso` and
+   `Carrier.carry` takes `parcel: Parcel iso` and re-forwards it with `consume`. If
+   the constructor or the behavior parameter ever becomes `val` (or anything
+   non-`iso`), the graph is traced `PONY_TRACE_IMMUTABLE`, not mutable — it becomes
+   the same coverage the existing `String val` payload already gives, and the
+   workload no longer earns its keep. The type system enforces the *move* (an iso
+   parameter cannot be aliased), but it does NOT stop someone changing the cap.
+
+2. **The graph must stay multi-object — `let`, not `embed`.** `Parcel.kids:
+   Array[Parcel]` and the `bytes` arrays are `let` (separate heap allocations) on
+   purpose, so the receiver acquires each node as a distinct foreign mutable object.
+   pony-ref gotcha #11 ("prefer embed for class-typed fields") points a maintainer
+   straight at changing them to `embed` — which keeps the cargo `iso` (so property
+   1's check would not fire) but co-allocates the child nodes into their parent,
+   collapsing the multi-object subgraph. The node-by-node mutable acquire the
+   workload targets shrinks, again with every oracle still green. The comments at
+   the field declarations flag this; do not "optimize" them to `embed`. (The graph's
+   depth/breadth is a swarm-drawn knob, so the node count varies per run, but a
+   single node still has its byte array as a separate allocation — the multi-object
+   property must hold even at the smallest drawn shape.)
+
+This was verified by instrumenting `gc.c` (counting `PONY_TRACE_MUTABLE` sends and
+the foreign-acquire branches) and comparing the `let`/iso nested graph against a
+`val`/`embed` equivalent: the iso multi-object graph drove the mutable-acquire path
+heavily (invent_mut high, invent_immut zero) while the alternatives did not.
+
+Run: re-run that instrumentation, NOT the soak. Add the mut/immut/invent_mut
+counters to `ponyint_gc_sendobject`/`ponyint_gc_recvobject` and `send_remote_object`
+in `src/libponyrt/gc/gc.c`, build a debug ponyc, compile and run the engine
+`--workload iso` at a small and a large drawn shape, and confirm typed structs are
+traced mutable and the receiver hits the mutable invent-and-acquire branch
+(`invent_mut > 0`, `invent_immut ~= 0`). Revert the instrumentation afterward. The
+normal-mode soak (`orchestrate_normal.py` drawing `iso`) canNOT catch either
+regression, so it is the wrong check here.

--- a/.known-couplings/stress-heartbeat-watchdog.md
+++ b/.known-couplings/stress-heartbeat-watchdog.md
@@ -26,6 +26,14 @@ messages they receive. The two numbers are a pair:
   needs one. If a future cyclic-bucket bump pushed its worst-case runtime toward
   `DEFAULT_NORMAL_NO_PROGRESS_SECONDS`, it would need a heartbeat (the persistent
   `CyclicCollector` is the place — its workers are ephemeral) or a larger window.
+- The `iso` workload likewise emits no heartbeat: its `chains` are clamped to the
+  acquire-flood budget (`ISO_ACQUIRE_BUDGET`), so its total message count is capped
+  near ~100k (well below `_Heartbeat._min`) and its worst-case run finishes in well
+  under a second (measured ~0.2s, 16 threads, at the calibrated budget across every
+  drawn graph shape). Like cyclic it never approaches the window; if the acquire
+  budget were ever raised enough to push its runtime toward
+  `DEFAULT_NORMAL_NO_PROGRESS_SECONDS`, the `Carrier` would need a heartbeat (the
+  persistent `Dispatcher` is the place — its carriers stay live, so either works).
 - The heartbeat is gated OFF for small runs (`_Heartbeat._min`), which keeps
   SYSTEMATIC runs (all far below it) heartbeat-free; systematic also keeps the flat
   total-time watchdog (`no_progress_seconds=None`), not this one — see

--- a/test/rt-stress/generative/README.md
+++ b/test/rt-stress/generative/README.md
@@ -25,7 +25,7 @@ them lives in the two driver scripts, not behind a flag.
 ## The engine
 
 **`main.pony`** — the workload engine, identical in both modes. It draws one of
-three closed, count-driven workloads (`--workload`):
+four closed, count-driven workloads (`--workload`):
 
 - **`mesh`** — a closed mesh of `Pinger` actors: a fixed number of chains are
   injected, each with a hop count (TTL); a pinger forwards exactly one ping per
@@ -60,25 +60,49 @@ three closed, count-driven workloads (`--workload`):
   then asserts `received == sent == producers * messages` from the producers' own
   send tallies — so conservation here is the mesh's strength, not the cyclic's
   weakness: a lost work is caught as a conservation failure, not merely a timeout.
+- **`iso`** — the `mesh` topology, but the shared `val` payload is replaced by a
+  freshly built nested `iso` object graph — a `Parcel` tree of `--node-depth`
+  levels with `--node-breadth` children per node, every node separately allocated
+  and holding its own byte array — that is `consume`d hop-to-hop. Each hop moves
+  ownership of the whole mutable subgraph to the next actor, so the receiver
+  acquires a foreign *mutable* multi-object graph node by node — the ORCA trace path
+  no other workload reaches (the others only ever make a raw byte buffer mutable,
+  never a typed object struct, and never transfer a mutable subgraph). The swarm
+  draws the graph shape, so runs span a single flat node through a 15-node tree. At
+  the terminal hop the graph is consumed into a `ref` and every node's sentinel
+  bytes are verified, so a silent GC corruption or premature free of the moved
+  subgraph is caught, not just a crash. Conservation is the mesh's full send/receive
+  tally (`sent == received == chains * (ttl + 1)`); the `Carrier`s are live at
+  quiescence (the `Dispatcher` holds them), so they are polled exactly like the
+  mesh.
 
-The traced payload is a `val String` or a `U64` no-GC control (`--payload`),
-either reused as one object (forwarded down a chain, or re-sent by a producer) or
-re-allocated at each send (`--payload-mode forward|fresh`) — the swarm draws both.
-On success the engine prints its result and lets the program reach **natural
+For the mesh/cyclic/backpressure workloads the traced payload is a `val String` or
+a `U64` no-GC control (`--payload`), either reused as one object (forwarded down a
+chain, or re-sent by a producer) or re-allocated at each send
+(`--payload-mode forward|fresh`) — the swarm draws both. The `iso` workload has its
+OWN cargo knobs (`--node-size`/`--node-depth`/`--node-breadth` shape the iso graph)
+and does not draw the val payload at all: an `iso` is single-owner, so it can't ride
+the shared `(String val | U64)` payload union and can't be reused, only moved. On
+success the engine prints its result and lets the
+program reach **natural
 quiescence** (no forced exit), so the `cyclic` workload's garbage is actually
 collected and the runtime's clean shutdown is itself exercised; only a
 conservation *failure* forces a non-zero exit. The engine holds no configuration
 logic and no `@runtime_override_defaults`; every knob is a CLI flag set by the
 orchestrator.
 
-The systematic mode draws only the `mesh` workload today; the `cyclic` and
-`backpressure` workloads run under the normal mode, where real parallelism catches
-the concurrent collection and mute/unmute races the serialized systematic mode
-can't. (Running `cyclic` under systematic with the determinism oracle is a deferred
-follow-up — it reproduces with the detector on post-#5569, but needs the systematic
-driver's forced `--ponynoblock` relaxed. A systematic `backpressure` leg is also a
-follow-up — muting is cycle-detector-independent, so it is *not* blocked by that
-forced `--ponynoblock`, but its determinism under systematic is unverified.)
+The systematic mode draws only the `mesh` workload today; the `cyclic`,
+`backpressure`, and `iso` workloads run under the normal mode, where real
+parallelism catches the concurrent collection, mute/unmute, and mutable-subgraph
+acquire races the serialized systematic mode can't. (Running `cyclic` under
+systematic with the determinism oracle is a deferred follow-up — it reproduces with
+the detector on post-#5569, but needs the systematic driver's forced `--ponynoblock`
+relaxed. A systematic `backpressure` leg is also a follow-up — muting is
+cycle-detector-independent, so it is *not* blocked by that forced `--ponynoblock`,
+but its determinism under systematic is unverified. A systematic `iso` leg is a
+follow-up too — its `ORDER_SIG` is a real interleaving fingerprint, like the mesh's,
+so it is the most directly portable, but its determinism under systematic is
+likewise unverified.)
 
 ## Running it
 
@@ -120,22 +144,37 @@ non-deterministic, so a replay won't necessarily reproduce a failure).
 
 ## Oracles
 
-- **Conservation** — for the `mesh` workload, messages sent == received == the
-  expected total (an independent per-pinger tally); a mismatch is a lost or
-  duplicated message. The `backpressure` workload is just as strong: completion
-  triggers on all producers reporting `finished` (independent of the received
-  count), then asserts received == the producers' own send tally == the expected
-  total, so a lost work is a conservation failure, not just a timeout. The `cyclic`
-  workload's actors are garbage by quiescence and can't be polled, so its
-  conservation is *completion-count only*: exactly `generations * chains` terminal
-  completions must arrive — weaker than the other two. The engine checks this itself
-  and exits non-zero on a detected failure, so it holds in **both** modes.
+- **Conservation** — the `mesh` and `iso` workloads poll an exact, independent
+  per-actor send/receive tally from the live pingers/carriers (`sent == received ==
+  chains * (ttl + 1)`); a duplicate or miscounted message shows as a tally mismatch.
+  A *lost* mesh/iso message does NOT show here — the chain never completes, so the
+  tally is never polled — it surfaces as a liveness timeout instead. The
+  `backpressure` workload is the strongest on *lost* messages: its `finished`
+  reports are sent independently of work delivery, so a lost work still lets
+  `_finish` run and assert received == the producers' send tally == the expected
+  total — a conservation failure, not just a timeout. The `cyclic` workload's actors
+  are garbage by quiescence and can't be polled, so its conservation is
+  *completion-count only* (exactly `generations * chains` completions) — weaker than
+  the `mesh`/`iso` exact tally. The engine checks this itself and exits non-zero on a
+  detected failure, so it holds in **both** modes.
 - **Late / duplicate message** — for `mesh`, anything arriving after a pinger has
   reported is a leak; for `backpressure`, a work or `finished` after completion, or
   more `finished` reports than producers, is a duplicate; for `cyclic`, a completion
-  beyond the expected total is a duplicate. All trip the engine's fatal-fault path.
-  (A *lost* `cyclic` message instead leaves the completion count short forever —
-  caught by liveness, not here.)
+  beyond the expected total is a duplicate; for `iso`, a handoff arriving after a
+  `Carrier` has reported, or a completion beyond `chains`, is a duplicate. All trip
+  the engine's fatal-fault path. (A *lost* mesh/cyclic/iso message instead leaves
+  its chain incomplete forever — caught by the liveness timeout, not here; only
+  `backpressure` catches a lost message as a conservation failure.)
+- **Parcel integrity** (`iso` workload) — the only oracle in the harness that
+  checks message *contents*, not just counts. Every node of the graph is built with
+  sentinel bytes; at the terminal hop the `Carrier` consumes the graph into a `ref`
+  and walks the whole tree, checking the first and last byte of each node's array,
+  so a silent GC corruption or premature free that disturbs an endpoint sentinel —
+  which the message-counting oracles cannot see — trips the fatal-fault path. This
+  is endpoint sampling, not a full scan: it *narrows* the payload-integrity gap
+  (below) for `iso` rather than closing it (interior-only corruption, or a premature
+  free whose memory is not yet reused, still slips through); the other three
+  workloads check no bytes at all.
 - **Backpressure / muting** (`backpressure` workload) — the consumer explicitly
   applies and releases runtime backpressure, driving the UNDER_PRESSURE mute/unmute
   reschedule path (the stdlib `backpressure` FFI, the `triggers_muting` /
@@ -183,13 +222,17 @@ actor pointer values, which ASLR randomizes per run.
 creation-order keyed instead, so replay is now layout-independent on every
 platform and no ASLR wrapper is needed.)
 
-Not yet checked: the payload's bytes at the end of a chain. A non-crashing trace
-or GC corruption (wrong bytes, truncation) would pass every oracle above —
-conservation counts messages and `ORDER_SIG` mixes ids and counts. A
-payload-integrity check is deferred to a later round, alongside richer
-allocation-diversity work, an exact spawned == finalized count for the `cyclic`
-workload, running `cyclic` under the systematic determinism oracle, and a
-systematic `backpressure` leg.
+Not yet checked: the payload's bytes for the mesh/cyclic/backpressure workloads. A
+non-crashing trace or GC corruption (wrong bytes, truncation) on one of those would
+pass every oracle above — conservation counts messages and `ORDER_SIG` mixes ids
+and counts. (The `iso` workload *narrows* this for itself — its terminal `Carrier`
+checks the endpoint sentinel bytes of the parcel; see Parcel integrity above — but
+interior corruption still slips through there too, and the other three check no
+bytes. A full byte-integrity check is deferred.) Also deferred to a later round:
+richer allocation-diversity work, the `iso` graph carrying `tag` actor references
+(dynamic cross-actor edges that can form cycles) rather than only byte arrays, an
+exact spawned == finalized count for the `cyclic` workload, and running `cyclic`,
+`backpressure`, and `iso` under the systematic determinism oracle.
 
 ## Tests
 
@@ -198,10 +241,11 @@ Three self-contained test files (no pytest), run in CI via `lint-python.yml`:
 - `stress_common_test.py` — the shared pure pieces (seed derivation, the workload
   draws including `draw_workload`, output parsing, command building).
 - `orchestrate_systematic_test.py` — the systematic config draw (pinned golden;
-  always the `mesh` workload, unchanged by the cyclic/backpressure work).
+  always the `mesh` workload, unchanged by the cyclic/backpressure/iso work).
 - `orchestrate_normal_test.py` — the normal config draw (no systematic seed,
-  `ponynoblock` as a swarm knob, all three workload kinds drawn, the cyclic memory
-  ceiling and the backpressure message ceiling, pinned per-kind goldens).
+  `ponynoblock` as a swarm knob, all four workload kinds drawn, the cyclic memory
+  ceiling, the backpressure message ceiling, the iso chains/ttl burst ceilings,
+  pinned per-kind goldens).
 
 Run one directly:
 

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -2,9 +2,11 @@
 Generative runtime stress harness.
 
 A swarm-driven Pony program that exercises the runtime's message passing, ORCA
-tracing, the cycle detector's collection path (via the `cyclic` workload), and the
-explicit backpressure / muting path (via the `backpressure` workload). One run
-draws one of three closed, count-driven workloads (`--workload`):
+tracing, the cycle detector's collection path (via the `cyclic` workload), the
+explicit backpressure / muting path (via the `backpressure` workload), and ORCA's
+transfer of ownership of a nested mutable object subgraph between actors (via the
+`iso` workload). One run draws one of four closed, count-driven workloads
+(`--workload`):
 
 * `mesh` (M0): a closed mesh of `Pinger` actors. A fixed number of chains are
   injected, each carrying a hop counter (TTL); a `Pinger` receiving a ping with
@@ -49,6 +51,21 @@ draws one of three closed, count-driven workloads (`--workload`):
   `received == sent == producers * messages` from the producers' own send tallies,
   so a lost work is caught as a conservation failure here, not merely as a timeout.
 
+* `iso` (M1): the `mesh` topology, but the shared `val` payload is replaced by a
+  freshly built nested `iso` object graph -- a `Parcel` tree of `--node-depth`
+  levels with `--node-breadth` children per node, every node a separate allocation
+  holding its own byte array -- `consume`d hop-to-hop. Each hop moves ownership of
+  the whole mutable subgraph to the next actor, so the receiver acquires a foreign
+  *mutable* multi-object graph node by node -- a trace path no other workload
+  reaches (the others only ever make a raw byte buffer mutable, never a typed
+  object struct, and never transfer a mutable subgraph). The swarm draws the graph
+  shape, so runs span a single flat node through a 15-node tree. At the terminal
+  hop the graph is consumed into a `ref` and every node's sentinel bytes are
+  verified, so a silent GC corruption or premature free of the moved subgraph is
+  caught, not just a crash. Conservation is the mesh's full send/receive tally
+  (`sent == received == chains * (ttl + 1)`); the `Carrier`s are live at quiescence
+  (the `Dispatcher` holds them), so they are polled exactly like the mesh.
+
 The workloads are closed, unlike an open cascade stopped by a wall-clock timer:
 a fixed amount of work is injected and the run terminates when it drains. The
 closed shape is a deliberate constraint, not the end goal -- a continuous, open
@@ -81,7 +98,7 @@ cycle detector, GC, thread count, the systematic seed) is a `--pony*` flag set b
 the orchestrator, and every workload parameter is a `--flag value` arg parsed
 here. Two orchestrators in this directory drive it: `orchestrate_systematic.py`
 (serialized, reproducible -- draws only the `mesh` workload today) and
-`orchestrate_normal.py` (a normal, real-parallel runtime -- draws all three
+`orchestrate_normal.py` (a normal, real-parallel runtime -- draws all four
 workloads; the conservation invariant holds there too, but `ORDER_SIG` does not
 reproduce, so that mode runs each seed once).
 """
@@ -101,7 +118,8 @@ type Payload is (String val | U64)
   trace across the actor boundary) or a `U64` primitive (a no-GC control). The
   kind is fixed for a whole run by `--payload`; `--payload-mode` then decides
   whether one payload object is reused (forwarded the whole chain, or re-sent by a
-  producer) or a fresh one is allocated at each send. Shared by all workloads.
+  producer) or a fresh one is allocated at each send. Shared by the mesh, cyclic,
+  and backpressure workloads (the `iso` workload has its own `Parcel` cargo).
   """
 
 primitive _Payloads
@@ -109,7 +127,8 @@ primitive _Payloads
   Builds a message payload of the configured kind. `--payload-mode forward` reuses
   one object across a sender's sends (exercising ORCA's shared-`val` refcounting);
   `fresh` calls this at every send (exercising allocation + tracing + collection
-  churn). Used by all three workloads.
+  churn). Used by the mesh, cyclic, and backpressure workloads (the `iso` workload
+  builds its own `Parcel` cargo instead).
   """
   fun make(config: _Config): Payload =>
     if config.payload_string then
@@ -183,6 +202,7 @@ actor Main
           // Only this workload needs the backpressure auth token, built from the
           // root authority here and threaded into the Consumer.
           Consumer(config, bp, ApplyReleaseBackpressureAuth(env.root))
+        | let iso': _Iso => Dispatcher(config, iso')
         end
       | let err: String =>
         env.err.print(err)
@@ -775,6 +795,254 @@ actor Consumer
   fun ref _mix(v: U64) =>
     _sig = (_sig xor v) * 1099511628211 // FNV-1a 64-bit prime
 
+class Parcel
+  """
+  The `iso` workload's cargo: a multi-object MUTABLE subgraph, shaped by the swarm.
+  Each node is a typed struct (traced `PONY_TRACE_MUTABLE` while owned through an
+  `iso`) holding its own byte array AND an array of child `Parcel`s, so one
+  `Parcel iso` is a tree of `depth` levels, `breadth` children per node, every node
+  separately allocated. Built fresh per injected chain and moved (`consume`d) at
+  each hop; never reused (an `iso` is single-owner). Every byte is the sentinel 'p',
+  so the terminal hop can verify the whole moved subgraph survived uncorrupted.
+
+  `bytes` and `kids` are `let`, NOT `embed`, on purpose -- separate heap
+  allocations, so a receiver acquires each node as a distinct foreign mutable
+  object. An `embed` would co-allocate them, collapsing the multi-object subgraph
+  this workload exists to trace. The workload's coverage rests on this type being
+  built and handed off as `iso` (not `val`) and staying multi-object (`let`, not
+  `embed`): changing either silently loses the coverage while every oracle stays
+  green -- see .known-couplings/iso-handoff-workload-ownership.md (pony-ref's
+  "prefer embed" guidance does not apply here).
+  """
+  let bytes: Array[U8]
+  let kids: Array[Parcel]
+
+  new create(size: USize, depth: USize, breadth: USize) =>
+    bytes = Array[U8].init('p', size)
+    // A node has `breadth` children only when it is not the last level; the last
+    // level (depth == 1) has none. `depth == 1` or `breadth == 0` is a single node.
+    let n = if depth > 1 then breadth else 0 end
+    kids = Array[Parcel](n)
+    var i: USize = 0
+    while i < n do
+      kids.push(Parcel(size, depth - 1, breadth))
+      i = i + 1
+    end
+
+actor Carrier
+  """
+  An `iso`-workload node. Mirrors `Pinger`: produces exactly one successor message
+  per received handoff and tracks how many it has sent and received. The successor
+  carries the `consume`d parcel itself -- moving ownership of the mutable subgraph
+  one hop further -- so the trace path the workload exists to drive runs on every
+  forward. At the terminal hop it verifies the parcel before dropping it.
+  """
+  let _dispatcher: Dispatcher
+  let _id: USize
+  var _neighbors: Array[Carrier] val
+  var _received: U64 = 0
+  var _sent: U64 = 0
+  var _reported: Bool = false
+  let _rand: Rand
+
+  new create(dispatcher: Dispatcher, id: USize, seed: U64) =>
+    _dispatcher = dispatcher
+    _id = id
+    _neighbors = recover val Array[Carrier] end
+    // Per-Carrier deterministic draw stream, seeded only from `--seed` + id (the
+    // same scheme as `Pinger`); which value lands on which handoff depends on
+    // mailbox arrival order, so routing is a function of the seed AND the
+    // interleaving. No `_Config` is stored: a `Carrier` needs nothing from it but
+    // the seed (it has no payload logic, unlike `Pinger`).
+    _rand = Rand(seed, id.u64())
+
+  be set_neighbors(neighbors: Array[Carrier] val) =>
+    """
+    Install the full mesh BEFORE any handoff can arrive. The `Dispatcher` sends
+    this to every `Carrier` in program order before it injects, so by Pony's
+    causal delivery every `Carrier` has its neighbors before any handoff -- the
+    same load-bearing ordering as `Pinger.set_neighbors`.
+    """
+    _neighbors = neighbors
+
+  be carry(parcel: Parcel iso, hops: USize, chain: USize) =>
+    """
+    Produce exactly one successor per received handoff: a forward of the
+    `consume`d parcel when hops > 0, otherwise verify it and signal completion.
+    This one-in/one-out invariant is what makes the dispatcher's completion count a
+    sound quiescence barrier (module docstring) -- do not make this fan out.
+    `consume` moves the parcel; it is never aliased, so the U64 tallies are
+    untouched by the move.
+    """
+    if _reported then
+      // Quiescence is proven before `report()` is sent, so no handoff should
+      // arrive afterwards. One that does is a leaked or duplicated message.
+      _Fatal("carry after report (leaked/late message)")
+    end
+    _received = _received + 1
+    if hops > 0 then
+      _sent = _sent + 1
+      let next = _rand.int(_neighbors.size().u64()).usize()
+      try
+        _neighbors(next)?.carry(consume parcel, hops - 1, chain)
+      else
+        _Unreachable("carrier neighbor index out of range")
+      end
+    else
+      // Terminal hop. Consume the parcel into a `ref` so its arrays can be read
+      // (a field read THROUGH an `iso` viewpoint-adapts to `tag` and will not
+      // compile; consuming into `ref` gives full read access, since `iso^` can
+      // become `ref`). Verify it, then drop it.
+      let p: Parcel ref = consume parcel
+      _verify(p)
+      _dispatcher.completed(chain, _id, _received)
+    end
+
+  fun _verify(parcel: Parcel box) =>
+    """
+    Integrity oracle (recursive): every byte of every node in the graph was the
+    sentinel 'p' at construction and the subgraph was only moved (never mutated)
+    since, so each node's first and last byte must still be 'p'. Walk the whole
+    tree (`node_size >= 1` is a `_Config` invariant, so the endpoint reads are in
+    range). A mismatch is a silent GC/ORCA corruption or premature free of the
+    moved subgraph -- a real fault none of the message-counting oracles can see.
+    """
+    try
+      let n = parcel.bytes.size()
+      if (parcel.bytes(0)? != 'p') or (parcel.bytes(n - 1)? != 'p') then
+        _Fatal("parcel corruption (sentinel byte mismatch)")
+      end
+    else
+      _Unreachable("parcel array empty (node_size >= 1 guaranteed)")
+    end
+    for kid in parcel.kids.values() do
+      _verify(kid)
+    end
+
+  be report() =>
+    _reported = true
+    _dispatcher.report_counts(_sent, _received)
+
+actor Dispatcher
+  """
+  The `iso` workload's driver, injector, and conservation oracle in one actor (the
+  mesh `Coordinator` pattern). Builds the `Carrier` mesh, injects the parcels,
+  counts completions to detect quiescence, collects per-`Carrier` send/receive
+  tallies, and evaluates conservation. On completion it prints `ORDER_SIG` plus the
+  tallies; on a conservation failure it forces a non-zero exit, otherwise it
+  returns and lets the program quiesce.
+  """
+  let _iso: _Iso
+  let _carriers: Array[Carrier] val
+  var _completions: USize = 0
+  var _reports_outstanding: USize = 0
+  var _total_sent: U64 = 0
+  var _total_received: U64 = 0
+  var _done: Bool = false
+  var _sig: U64 = 14695981039346656037 // FNV-1a 64-bit offset basis
+
+  new create(config: _Config, iso': _Iso) =>
+    _iso = iso'
+
+    // Build the mesh. Carriers are created outside the `recover` block (so we can
+    // pass `this`) and pushed into the iso array via automatic receiver recovery
+    // -- `push`'s argument, a `Carrier tag`, is sendable. Only `config.seed` is
+    // needed (in this constructor), so no `_Config` field is stored.
+    let cs: Array[Carrier] iso = recover Array[Carrier](iso'.pingers) end
+    var id: USize = 0
+    while id < iso'.pingers do
+      cs.push(Carrier(this, id, config.seed))
+      id = id + 1
+    end
+    let carriers: Array[Carrier] val = consume cs
+    _carriers = carriers
+
+    // Wire neighbors, THEN inject. The ordering is load-bearing -- the same
+    // reasoning as `Coordinator` (see `Carrier.set_neighbors`).
+    for c in carriers.values() do
+      c.set_neighbors(carriers)
+    end
+
+    // Each injected parcel is one dispatcher send (added back in `_finish`).
+    let r = Rand(config.seed)
+    var chain: USize = 0
+    while chain < iso'.chains do
+      let start = r.int(carriers.size().u64()).usize()
+      try
+        // Fresh graph per chain -- an `iso` is single-owner, so there is no
+        // forward-mode reuse; the graph is always newly built and moved.
+        carriers(start)?.carry(
+          recover iso Parcel(iso'.node_size, iso'.depth, iso'.breadth) end,
+          iso'.ttl, chain)
+      else
+        _Unreachable("iso injection start index out of range")
+      end
+      chain = chain + 1
+    end
+
+  be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
+    """
+    A parcel reached its terminal (hops == 0) carrier. Fold the arrival into the
+    order signature; once every parcel has terminated the system is quiesced, so
+    ask every `Carrier` for its final counts. A completion beyond the expected
+    total is a duplicate or late message -- a real fault -- so it trips `_Fatal`
+    (the cyclic collector's overshoot guard, which the mesh `Coordinator` lacks).
+    """
+    if _done then _Fatal("completion after done (leaked/late message)") end
+    _mix(chain.u64())
+    _mix(terminal_id.u64())
+    _mix(received_snapshot)
+    _completions = _completions + 1
+    if _completions == _iso.chains then
+      _reports_outstanding = _carriers.size()
+      for c in _carriers.values() do c.report() end
+    elseif _completions > _iso.chains then
+      _Fatal("late/duplicate completion (completions > chains)")
+    end
+
+  be report_counts(sent: U64, received: U64) =>
+    """
+    Accumulate one `Carrier`'s tallies. When all have reported, evaluate the
+    conservation oracle.
+    """
+    _total_sent = _total_sent + sent
+    _total_received = _total_received + received
+    _reports_outstanding = _reports_outstanding - 1
+    if _reports_outstanding == 0 then
+      _finish()
+    end
+
+  fun ref _finish() =>
+    _done = true
+    // The dispatcher itself performed `chains` initial sends (the injected
+    // parcels); every `Carrier` forward is already in `_total_sent`.
+    let total_sent = _total_sent + _iso.chains.u64()
+    let expected = _iso.chains.u64() * (_iso.ttl.u64() + 1)
+    let conserved =
+      (total_sent == _total_received) and (_total_received == expected)
+
+    // Synchronous print so the result survives natural quiescence (env.out.print
+    // is async and could be lost if a later exit raced it).
+    let line = "RECEIVED=" + _total_received.string()
+      + " SENT=" + total_sent.string()
+      + " EXPECTED=" + expected.string()
+      + " ORDER_SIG=" + _sig.string() + "\n"
+    @printf("%s".cstring(), line.cstring())
+
+    // On success: return and let the program reach natural quiescence (no forced
+    // exit), same as the other workloads. Only a conservation FAILURE forces a
+    // non-zero exit: fail fast once a bug is detected.
+    if not conserved then
+      let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
+        + " sent=" + total_sent.string()
+        + " expected=" + expected.string() + "\n"
+      @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
+      @exit(I32(1))
+    end
+
+  fun ref _mix(v: U64) =>
+    _sig = (_sig xor v) * 1099511628211 // FNV-1a 64-bit prime
+
 class val _Mesh
   """
   The `mesh` workload's shape. Built only by `_Cli.config` (after validation), so
@@ -817,8 +1085,8 @@ class val _Backpressure
   The `backpressure` workload's shape. Built only by `_Cli.config` (after
   validation), so `producers >= 1`, `messages >= 1`, and `apply_every >= 1` can be
   trusted. Has no chains/ttl: a flood is not a chain of hops, so those fields are
-  structurally absent here (the reason chains/ttl live on `_Mesh`/`_Cyclic` rather
-  than on the shared `_Config`).
+  structurally absent here (the reason chains/ttl live on `_Mesh`/`_Cyclic`/`_Iso`
+  rather than on the shared `_Config`).
   """
   let producers: USize
   let messages: USize
@@ -829,23 +1097,52 @@ class val _Backpressure
     messages = messages'
     apply_every = apply_every'
 
+class val _Iso
+  """
+  The `iso` workload's shape. Built only by `_Cli.config` (after validation), so
+  `pingers >= 1`, `chains >= 1`, `node_size >= 1`, and `depth >= 1` can be trusted
+  (`ttl` and `breadth` have no lower bound -- breadth 0 or depth 1 is a single-node
+  graph). Carries its own shape for the same reason as `_Mesh`/`_Cyclic`: a
+  `backpressure` config cannot carry it, so an illegal cross-workload field mix is
+  unrepresentable. Has its OWN cargo knobs (node_size/depth/breadth shape the iso
+  graph), NOT the shared String-payload knobs -- an `iso` can't ride the
+  `(String val | U64)` Payload.
+  """
+  let pingers: USize
+  let chains: USize
+  let ttl: USize
+  let node_size: USize
+  let depth: USize
+  let breadth: USize
+
+  new val create(pingers': USize, chains': USize, ttl': USize,
+    node_size': USize, depth': USize, breadth': USize)
+  =>
+    pingers = pingers'
+    chains = chains'
+    ttl = ttl'
+    node_size = node_size'
+    depth = depth'
+    breadth = breadth'
+
 class val _Config
   """
   A validated workload configuration: the fields shared by all workloads (seed and
-  payload kind/size/mode) plus the workload-specific shape (`_Mesh`, `_Cyclic`, or
-  `_Backpressure`). The chain/hop counts are NOT here -- only the two chain-based
-  workloads have them, so they live on those variants. Built only by `_Cli.config`,
-  so the rest of the program can trust its invariants (payload_size >= 1 when
-  payload_string, plus the per-shape invariants on the variant).
+  payload kind/size/mode) plus the workload-specific shape (`_Mesh`, `_Cyclic`,
+  `_Backpressure`, or `_Iso`). The chain/hop counts are NOT here -- only the three
+  chain-based workloads (mesh/cyclic/iso) have them, so they live on those variants.
+  Built only by `_Cli.config`, so the rest of the program can trust its invariants
+  (payload_size >= 1 when payload_string, plus the per-shape invariants on the
+  variant).
   """
   let seed: U64
   let payload_string: Bool
   let payload_size: USize
   let payload_fresh: Bool
-  let workload: (_Mesh | _Cyclic | _Backpressure)
+  let workload: (_Mesh | _Cyclic | _Backpressure | _Iso)
 
   new val create(seed': U64, payload_string': Bool, payload_size': USize,
-    payload_fresh': Bool, workload': (_Mesh | _Cyclic | _Backpressure))
+    payload_fresh': Bool, workload': (_Mesh | _Cyclic | _Backpressure | _Iso))
   =>
     seed = seed'
     payload_string = payload_string'
@@ -874,10 +1171,10 @@ primitive _Cli
           "engine RNG seed"
           where default' = 1)
         OptionSpec.string("workload",
-          "workload kind: mesh | cyclic | backpressure"
+          "workload kind: mesh | cyclic | backpressure | iso"
           where default' = "mesh")
         OptionSpec.u64("pingers",
-          "mesh only (ignored otherwise): number of mesh actors (>= 1)"
+          "mesh/iso only (ignored otherwise): number of mesh actors (>= 1)"
           where default' = 8)
         OptionSpec.u64("generations",
           "cyclic only (ignored otherwise): garbage-group generations (>= 1)"
@@ -895,11 +1192,21 @@ primitive _Cli
           "backpressure only (ignored otherwise): received msgs between "
           + "apply/release toggles (>= 1)"
           where default' = 200)
+        OptionSpec.u64("node-size",
+          "iso only (ignored otherwise): bytes per graph node array (>= 1)"
+          where default' = 64)
+        OptionSpec.u64("node-depth",
+          "iso only (ignored otherwise): graph nesting levels (>= 1)"
+          where default' = 2)
+        OptionSpec.u64("node-breadth",
+          "iso only (ignored otherwise): child nodes per graph node"
+          where default' = 1)
         OptionSpec.u64("chains",
-          "mesh/cyclic only (ignored for backpressure): chains to inject (>= 1)"
+          "mesh/cyclic/iso only (ignored for backpressure): chains to inject "
+          + "(>= 1)"
           where default' = 8)
         OptionSpec.u64("ttl",
-          "mesh/cyclic only (ignored for backpressure): hops per chain"
+          "mesh/cyclic/iso only (ignored for backpressure): hops per chain"
           where default' = 16)
         OptionSpec.string("payload",
           "traced payload kind: string | u64"
@@ -926,6 +1233,9 @@ primitive _Cli
     let producers = cmd.option("producers").u64().usize()
     let messages = cmd.option("messages").u64().usize()
     let apply_every = cmd.option("apply-every").u64().usize()
+    let node_size = cmd.option("node-size").u64().usize()
+    let node_depth = cmd.option("node-depth").u64().usize()
+    let node_breadth = cmd.option("node-breadth").u64().usize()
 
     let payload_string =
       if payload == "string" then
@@ -949,9 +1259,9 @@ primitive _Cli
       return "--payload-size must be >= 1 for string payload"
     end
 
-    // chains is validated only where it is used (the two chain-based workloads);
-    // backpressure has no chains, so it carries none.
-    let workload: (_Mesh | _Cyclic | _Backpressure) =
+    // chains is validated only where it is used (the chain-based workloads:
+    // mesh/cyclic/iso); backpressure has no chains, so it carries none.
+    let workload: (_Mesh | _Cyclic | _Backpressure | _Iso) =
       if workload_name == "mesh" then
         if pingers < 1 then return "--pingers must be >= 1" end
         if chains < 1 then return "--chains must be >= 1" end
@@ -966,8 +1276,15 @@ primitive _Cli
         if messages < 1 then return "--messages must be >= 1" end
         if apply_every < 1 then return "--apply-every must be >= 1" end
         _Backpressure(producers, messages, apply_every)
+      elseif workload_name == "iso" then
+        if pingers < 1 then return "--pingers must be >= 1" end
+        if chains < 1 then return "--chains must be >= 1" end
+        if node_size < 1 then return "--node-size must be >= 1" end
+        if node_depth < 1 then return "--node-depth must be >= 1" end
+        _Iso(pingers, chains, ttl, node_size, node_depth, node_breadth)
       else
-        return "bad --workload (expected 'mesh', 'cyclic' or 'backpressure')"
+        return "bad --workload (expected 'mesh', 'cyclic', 'backpressure' or "
+          + "'iso')"
       end
 
     _Config(seed, payload_string, payload_size, payload_fresh, workload)
@@ -976,11 +1293,13 @@ primitive _Fatal
   """
   The harness's runtime-fault detector: print a diagnostic to stderr and exit
   non-zero. Used by the late/duplicate-message oracles across all workloads -- a
-  ping arriving after a `Pinger` has reported, a cyclic completion beyond the
-  expected total, or a backpressure `work`/`finished` after the `Consumer` is done
-  (or more `finished` reports than producers) -- each is a duplicated or delayed
-  message, a real runtime fault, so the stress run fails loudly with a location
-  rather than passing.
+  ping or `iso` handoff arriving after its node has reported, a cyclic or `iso`
+  completion beyond the expected total, or a backpressure `work`/`finished` after
+  the `Consumer` is done (or more `finished` reports than producers) -- and by the
+  `iso` workload's parcel-integrity oracle (a sentinel-byte mismatch in a delivered
+  graph). Each is a real runtime fault -- a duplicated or delayed message, or a
+  silently corrupted one -- so the stress run fails loudly with a location rather
+  than passing.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "FATAL: " + msg + " (" + loc.file() + ":"
@@ -991,11 +1310,12 @@ primitive _Fatal
 primitive _Unreachable
   """
   A branch the compiler can't prove is dead but we know is: every guarded array
-  access here is indexed by `Rand.int(size)` with `size >= 1`, so the index is in
-  range by construction. If one ever fires it is a real bug, so crash with a
-  location rather than continue with corrupt state (the "unreachable try/else"
-  rule). Distinct from `_Fatal`: this flags a fault that should be impossible,
-  not one the harness is built to catch.
+  access here is in range by construction -- a neighbor or injection-start index
+  from `Rand.int(size)` with `size >= 1`, or an `iso`-parcel array index guarded by
+  the `node_size >= 1` invariant. If one ever fires it is a real bug, so crash with
+  a location rather than continue with corrupt state (the "unreachable try/else"
+  rule). Distinct from `_Fatal`: this flags a fault that should be impossible, not
+  one the harness is built to catch.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "UNREACHABLE: " + msg + " (" + loc.file() + ":"

--- a/test/rt-stress/generative/orchestrate_normal.py
+++ b/test/rt-stress/generative/orchestrate_normal.py
@@ -60,60 +60,82 @@ def resolve_config(master_seed, max_threads):
     not forced), so both the cycle-detector-on and -off paths are exercised --
     this is where the cycle detector gets its stress coverage.
 
-    Normal mode draws one of three workloads (draw_workload): `mesh` (the static M0
+    Normal mode draws one of four workloads (draw_workload): `mesh` (the static M0
     mesh), `cyclic` (successive groups of strongly-connected actors that drop their
-    external reference, so the cycle detector must reclaim them), or `backpressure`
+    external reference, so the cycle detector must reclaim them), `backpressure`
     (a star of producers flooding one consumer that explicitly applies/releases
-    runtime backpressure, driving the UNDER_PRESSURE muting path). A `mesh` run draws
-    a small->large magnitude in chains/ttl (the magnitude buckets, reaching ~1.16B
-    messages); a `cyclic` run draws the magnitude in GENERATIONS and keeps chains/ttl
-    small (total = generations*chains*(ttl+1)); a `backpressure` run draws the
-    magnitude in MESSAGES per producer (total = producers*messages) and has no
-    chains/ttl. The payload (kind/size/mode) is drawn freely; a `mesh` run's ttl is
-    then trimmed to a run-time ceiling (clamp_ttl), since a forward run's cost grows
-    with chains^2 and a high-chains/high-ttl draw would otherwise run for hours.
+    runtime backpressure, driving the UNDER_PRESSURE muting path), or `iso` (the mesh
+    topology handing a nested `iso` object graph hop-to-hop by `consume`, so the
+    receiver acquires a foreign mutable subgraph). A `mesh` run draws a small->large
+    magnitude in chains/ttl (the magnitude buckets, reaching ~1.16B messages); a
+    `cyclic` run draws the magnitude in GENERATIONS and keeps chains/ttl small
+    (total = generations*chains*(ttl+1)); a `backpressure` run draws the magnitude in
+    MESSAGES per producer (total = producers*messages) and has no chains/ttl; an
+    `iso` run reuses pingers and draws its graph shape (node-size/depth/breadth) plus
+    small chains/ttl from its own buckets, then clamps chains to the acquire budget
+    (the injection burst, not raw volume, governs its memory). The payload
+    (kind/size/mode) is drawn freely; a `mesh` run's ttl is then trimmed to a run-time
+    ceiling (clamp_ttl), since a forward run's cost grows with chains^2 and a
+    high-chains/high-ttl draw would otherwise run for hours; an `iso` run draws then
+    ignores the payload, since its cargo is the iso graph.
 
     This mode is non-reproducible (real parallelism), so a seed maps to a
     *configuration* deterministically but not to an *execution*. The draw order is
     pinned (orchestrate_normal_test.py) so a seed yields a stable config:
-    draw_workload (kind + cyclic shape + backpressure shape, fixed consumption) ->
-    pingers (always drawn; used only by a mesh run) -> chains (bucketed, the kind's
-    own buckets) -> ttl (bucketed) -> payload (kind, mode, size) -> ponynoblock ->
-    the four shared swarm knobs -> ponymaxthreads last. Drawing the workload kind
-    first lets the shared chains/ttl/payload draws pick the kind's bucket ranges
-    while making the same sequence of draws regardless of kind. This contract is
-    independent of the systematic driver's, and it intentionally differs from the
-    two-kind draw, so historical normal-mode seeds remap.
+    draw_workload (kind + cyclic shape + backpressure shape + iso cargo shape, fixed
+    consumption) -> pingers (always drawn; used by a mesh or iso run) -> chains
+    (bucketed, the kind's own buckets) -> ttl (bucketed) -> payload (kind, mode,
+    size) -> ponynoblock -> the four shared swarm knobs -> ponymaxthreads last.
+    Drawing the workload kind first lets the shared chains/ttl/payload draws pick the
+    kind's bucket ranges while making the same sequence of draws regardless of kind.
+    This contract is independent of the systematic driver's, and it intentionally
+    differs from the three-kind draw, so historical normal-mode seeds remap.
     """
     program_seed = common.derive_seed(master_seed, "program")
     rng = random.Random(master_seed)
 
-    (kind, generations, group, producers, messages, apply_every) = \
-        common.draw_workload(rng)
+    (kind, generations, group, producers, messages, apply_every, node_size,
+     depth, breadth) = common.draw_workload(rng)
     pingers = rng.choice(common.NORMAL_PINGERS)
-    # chains/ttl come from the kind's own buckets; mesh and cyclic both use them and
-    # backpressure draws-then-ignores them, so all three make the same two
-    # draw_bucketed calls -- the kind picks the bucket ranges (the value) without
-    # changing the draw sequence.
-    chains_buckets = (common.CYCLIC_CHAINS_BUCKETS if kind == "cyclic"
-                      else common.NORMAL_SIZE_BUCKETS)
-    ttl_buckets = (common.CYCLIC_TTL_BUCKETS if kind == "cyclic"
-                   else common.NORMAL_SIZE_BUCKETS)
+    # chains/ttl come from the kind's own buckets; mesh/iso use the magnitude/iso
+    # ranges, cyclic uses its small ranges, and backpressure draws-then-ignores
+    # them. All kinds make the same two draw_bucketed calls (each exactly two rng
+    # draws), so the kind picks the bucket ranges (the values) without changing the
+    # draw sequence -- the fixed-consumption contract.
+    if kind == "cyclic":
+        chains_buckets = common.CYCLIC_CHAINS_BUCKETS
+        ttl_buckets = common.CYCLIC_TTL_BUCKETS
+    elif kind == "iso":
+        chains_buckets = common.ISO_CHAINS_BUCKETS
+        ttl_buckets = common.ISO_TTL_BUCKETS
+    else:                          # mesh; backpressure draws-then-ignores
+        chains_buckets = common.NORMAL_SIZE_BUCKETS
+        ttl_buckets = common.NORMAL_SIZE_BUCKETS
     chains = common.draw_bucketed(rng, chains_buckets)
     ttl = common.draw_bucketed(rng, ttl_buckets)
+    if kind == "iso":
+        # Clamp chains to the safe acquire-flood budget for the drawn graph shape:
+        # bigger graphs acquire more objects per hop, so they get fewer chains,
+        # keeping chains * ttl * node_count <= ISO_ACQUIRE_BUDGET (the memory bound).
+        # The chains draw above still happens unchanged (fixed consumption); this
+        # only caps the value -- like clamp_ttl below trims a mesh run's ttl, no rng.
+        chains = min(chains, common.iso_chains_cap(depth, breadth))
     payload, size, mode = common.draw_payload(rng)
     # Mesh run time is bounded by trimming ttl to fit the per-run ceiling (a
     # forward run's cost grows with chains^2, so a high-chains/high-ttl draw would
     # take hours). The clamp consumes no rng, so only an over-budget mesh ttl
-    # changes -- cyclic/backpressure draws are untouched. Cyclic keeps its own tiny
-    # ttl range and backpressure ignores ttl, so neither needs the mesh clamp.
+    # changes -- cyclic/backpressure/iso draws are untouched. Cyclic keeps its own
+    # tiny ttl range, backpressure ignores ttl, and iso draws from its own small ttl
+    # buckets and caps chains above, so none needs the mesh clamp.
     if kind == "mesh":
         ttl = common.clamp_ttl(chains, ttl, mode, payload, size)
 
     # Emit only the shape fields the kind uses, so a contradictory field is never
     # passed to the engine: mesh has pingers+chains+ttl, cyclic has
     # generations+group+chains+ttl, backpressure has producers+messages+apply-every
-    # (and NO chains/ttl -- they live on the variants, not the shared _Config).
+    # (and NO chains/ttl), iso has pingers+chains+ttl+node-size/depth/breadth and its
+    # OWN cargo knobs INSTEAD of the val payload. They live on the variants, not the
+    # shared _Config.
     workload = {"seed": program_seed, "workload": kind}
     if kind == "cyclic":
         workload["generations"] = generations
@@ -124,13 +146,25 @@ def resolve_config(master_seed, max_threads):
         workload["producers"] = producers
         workload["messages"] = messages
         workload["apply-every"] = apply_every
+    elif kind == "iso":
+        workload["pingers"] = pingers
+        workload["chains"] = chains
+        workload["ttl"] = ttl
+        workload["node-size"] = node_size
+        workload["node-depth"] = depth
+        workload["node-breadth"] = breadth
     else:
         workload["pingers"] = pingers
         workload["chains"] = chains
         workload["ttl"] = ttl
-    workload["payload"] = payload
-    workload["payload-size"] = size
-    workload["payload-mode"] = mode
+    # The val payload is emitted for every kind EXCEPT iso: an iso run picks from its
+    # own cargo knobs above (node-size/depth/breadth), so the engine never receives a
+    # payload flag it would ignore. The draw still happened (fixed consumption); only
+    # the emit is per-kind.
+    if kind != "iso":
+        workload["payload"] = payload
+        workload["payload-size"] = size
+        workload["payload-mode"] = mode
 
     runtime = {}
     if rng.random() < 0.5:

--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -6,9 +6,9 @@ Normal mode is non-reproducible at runtime, but a seed still maps to a stable
 *config* -- the per-kind goldens below pin that draw order. The two things that
 distinguish normal from systematic are asserted explicitly: no systematic seed is
 ever set, and ponynoblock is a swarm knob (drawn, not forced). Normal mode draws
-one of three workload kinds (`mesh`, `cyclic`, or `backpressure`); the per-kind
-shape, the cyclic memory ceiling, and the backpressure message ceiling are checked
-here too.
+one of four workload kinds (`mesh`, `cyclic`, `backpressure`, or `iso`); the
+per-kind shape, the cyclic memory ceiling, the backpressure message ceiling, and
+the iso chains/ttl burst ceilings are checked here too.
 """
 import sys
 
@@ -30,6 +30,15 @@ CYCLIC_WORKER_CEILING = 130000
 # message bucket trips this and forces a time re-measure. Real max today is
 # 256*400000 = 102_400_000 (see BACKPRESSURE_* docs).
 BACKPRESSURE_MESSAGE_CEILING = 110_000_000
+# Hardcoded calibrated ceilings for the iso workload. Its memory bound is the
+# ACQUIRE-FLOOD = chains * ttl * node_count; the per-run chains draw is CLAMPED so
+# this stays <= ISO_ACQUIRE_BUDGET (see stress_common). These ceilings pin the
+# calibrated safe limits: the budget itself (worst ~160 MB at K=96000), and the max
+# graph node count (the depth/breadth maxima -- the per-hop acquire multiplier).
+# Bumping either past these forces a memory re-measure rather than slipping into
+# untested territory (the OOM cliff is non-monotonic near the edge).
+ISO_ACQUIRE_CEILING = 96000
+ISO_NODE_CEILING = 15
 
 
 def check(name, condition):
@@ -43,28 +52,28 @@ def check(name, condition):
 def test_resolve_config_mesh_golden():
     # Pin a MESH config: the normal-mode seed-stability guard for the mesh emit
     # shape (pingers + chains + ttl, no generations/group/producers). Distinct from
-    # the systematic golden -- normal draws the workload kind first (now 3-way), then
+    # the systematic golden -- normal draws the workload kind first (now 4-way), then
     # bucketed chains/ttl (a mesh run's ttl then trimmed to the run-time ceiling), a
     # freely-drawn payload, and ponynoblock as a swarm knob, and carries no
     # systematic seed.
-    # (This intentionally differs from the two-kind normal golden -- the 3-way kind
-    # roll and the extra backpressure-shape draws remap every historical seed.)
-    # Seed 1 rolls mesh.
+    # (This intentionally differs from the three-kind normal golden -- the 4-way kind
+    # roll and the extra iso cargo-shape draws remap every historical seed, and the
+    # weight change remaps which seed rolls which kind.) Seed 1 rolls mesh.
     expected = {
         "master_seed": 1,
         "runtime": {
-            "ponycdinterval": 100,
-            "ponygcinitial": 10,
+            "ponygcfactor": 1.05,
+            "ponygcinitial": 16,
             "ponymaxthreads": 1,
         },
         "workload": {
-            "chains": 17440,
-            "payload": "u64",
+            "chains": 7886,
+            "payload": "string",
             "payload-mode": "fresh",
-            "payload-size": 256,
-            "pingers": 32,
+            "payload-size": 8,
+            "pingers": 8,
             "seed": 2570779959355939992,
-            "ttl": 1964,
+            "ttl": 19020,
             "workload": "mesh",
         },
     }
@@ -74,56 +83,84 @@ def test_resolve_config_mesh_golden():
 
 def test_resolve_config_cyclic_golden():
     # Pin a CYCLIC config too (the mesh golden alone never checks the cyclic emit
-    # shape: generations/group/chains/ttl present, no pingers/producers). Seed 5
-    # rolls cyclic.
+    # shape: generations/group/chains/ttl present, no pingers/producers). Seed 9
+    # rolls cyclic (the 4-way weight change remapped it from seed 5).
+    expected = {
+        "master_seed": 9,
+        "runtime": {
+            "ponymaxthreads": 7,
+            "ponynoblock": True,
+            "ponynoscale": True,
+        },
+        "workload": {
+            "chains": 5,
+            "generations": 1368,
+            "group": 4,
+            "payload": "u64",
+            "payload-mode": "fresh",
+            "payload-size": 1,
+            "seed": 7931586630182256735,
+            "ttl": 10,
+            "workload": "cyclic",
+        },
+    }
+    check("resolve_config(9, 8) matches the pinned cyclic golden config",
+          normal.resolve_config(9, THREADS) == expected)
+
+
+def test_resolve_config_backpressure_golden():
+    # Pin a BACKPRESSURE config: it has producers/messages/apply-every and NO
+    # chains/ttl/pingers/generations/group -- the emit shape that proves the variant
+    # carries only its own fields. Seed 5 rolls backpressure (remapped from seed 0).
     expected = {
         "master_seed": 5,
         "runtime": {
             "ponycdinterval": 1000,
             "ponygcfactor": 1.05,
-            "ponygcinitial": 20,
             "ponymaxthreads": 8,
             "ponynoblock": True,
             "ponynoscale": True,
         },
         "workload": {
-            "chains": 6,
-            "generations": 2972,
-            "group": 2,
-            "payload": "u64",
-            "payload-mode": "forward",
-            "payload-size": 256,
-            "seed": 1674455568713221789,
-            "ttl": 6,
-            "workload": "cyclic",
-        },
-    }
-    check("resolve_config(5, 8) matches the pinned cyclic golden config",
-          normal.resolve_config(5, THREADS) == expected)
-
-
-def test_resolve_config_backpressure_golden():
-    # Pin a BACKPRESSURE config: it has producers/messages/apply-every and NO
-    # chains/ttl/pingers/generations/group -- the emit shape that proves the new
-    # variant carries only its own fields. Seed 0 rolls backpressure.
-    expected = {
-        "master_seed": 0,
-        "runtime": {
-            "ponymaxthreads": 3,
-            "ponynoblock": True,
-        },
-        "workload": {
-            "apply-every": 200,
-            "messages": 354767,
+            "apply-every": 1000,
+            "messages": 230576,
             "payload": "string",
-            "payload-mode": "fresh",
-            "payload-size": 1,
-            "producers": 64,
-            "seed": 2686188150644990173,
+            "payload-mode": "forward",
+            "payload-size": 1024,
+            "producers": 128,
+            "seed": 1674455568713221789,
             "workload": "backpressure",
         },
     }
-    check("resolve_config(0, 8) matches the pinned backpressure golden config",
+    check("resolve_config(5, 8) matches the pinned backpressure golden config",
+          normal.resolve_config(5, THREADS) == expected)
+
+
+def test_resolve_config_iso_golden():
+    # Pin an ISO config: it has pingers/chains/ttl + its OWN cargo knobs
+    # (node-size/node-depth/node-breadth) and NO val payload and NO
+    # generations/group/producers/messages/apply-every -- the emit shape that proves
+    # the variant carries only its own fields and picks its own cargo set instead of
+    # the shared payload. Seed 0 rolls iso; chains is clamped to the graph's
+    # acquire-flood cap (depth 4, breadth 1 = 4 nodes, cap 1500).
+    expected = {
+        "master_seed": 0,
+        "runtime": {
+            "ponymaxthreads": 5,
+            "ponynoblock": True,
+        },
+        "workload": {
+            "chains": 1500,
+            "node-breadth": 1,
+            "node-depth": 4,
+            "node-size": 64,
+            "pingers": 16,
+            "seed": 2686188150644990173,
+            "ttl": 7,
+            "workload": "iso",
+        },
+    }
+    check("resolve_config(0, 8) matches the pinned iso golden config",
           normal.resolve_config(0, THREADS) == expected)
 
 
@@ -158,17 +195,24 @@ def test_resolve_config_deterministic_and_bounded():
           normal.resolve_config(7, THREADS)
           == normal.resolve_config(7, THREADS))
 
-    # Invariants over all three workload kinds: each carries ONLY its own shape
+    # Invariants over all four workload kinds: each carries ONLY its own shape
     # fields (mesh: pingers+chains+ttl; cyclic: generations+group+chains+ttl;
-    # backpressure: producers+messages+apply-every and NO chains/ttl). Payload is
-    # shared. This is the structural check that the per-kind emit never leaks a
-    # field from another kind.
+    # backpressure: producers+messages+apply-every and NO chains/ttl; iso:
+    # pingers+chains+ttl + its OWN cargo knobs node-size/node-depth/node-breadth and
+    # NO val payload). This is the structural check that the per-kind emit never
+    # leaks a field from another kind. (iso's lack of payload is itself checked: the
+    # shared payload reads below are guarded for iso.)
     cyclic_gen_lo = common.CYCLIC_GENERATION_BUCKETS["small"][0]
     cyclic_gen_hi = common.CYCLIC_GENERATION_BUCKETS["large"][1]
     cyclic_chains_hi = common.CYCLIC_CHAINS_BUCKETS["large"][1]
     cyclic_ttl_hi = common.CYCLIC_TTL_BUCKETS["large"][1]
     bp_msg_lo = common.BACKPRESSURE_MESSAGE_BUCKETS["small"][0]
     bp_msg_hi = common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1]
+    iso_ttl_lo = common.ISO_TTL_BUCKETS["small"][0]
+    iso_ttl_hi = common.ISO_TTL_BUCKETS["large"][1]
+    # Every other kind's unique fields, which the iso emit must never carry, and the
+    # iso cargo knobs, which the OTHER kinds must never carry.
+    iso_cargo = ("node-size", "node-depth", "node-breadth")
     invariants_hold = True
     maxthreads_seen = set()
     mode_seen = set()
@@ -180,7 +224,7 @@ def test_resolve_config_deterministic_and_bounded():
         if kind == "mesh":
             if any(k in work for k in
                    ("generations", "group", "producers", "messages",
-                    "apply-every")):
+                    "apply-every") + iso_cargo):
                 invariants_hold = False
             if work["pingers"] not in PINGERS_ALLOWED:
                 invariants_hold = False
@@ -195,7 +239,8 @@ def test_resolve_config_deterministic_and_bounded():
                 invariants_hold = False
         elif kind == "cyclic":
             if any(k in work for k in
-                   ("pingers", "producers", "messages", "apply-every")):
+                   ("pingers", "producers", "messages", "apply-every")
+                   + iso_cargo):
                 invariants_hold = False
             if not (cyclic_gen_lo <= work["generations"] <= cyclic_gen_hi):
                 invariants_hold = False
@@ -207,9 +252,10 @@ def test_resolve_config_deterministic_and_bounded():
                 invariants_hold = False
         elif kind == "backpressure":
             # No chains/ttl (they live on the chain-based variants) and no
-            # pingers/generations/group.
+            # pingers/generations/group and no iso cargo knobs.
             if any(k in work for k in
-                   ("pingers", "generations", "group", "chains", "ttl")):
+                   ("pingers", "generations", "group", "chains", "ttl")
+                   + iso_cargo):
                 invariants_hold = False
             if work["producers"] not in common.BACKPRESSURE_PRODUCERS:
                 invariants_hold = False
@@ -217,13 +263,45 @@ def test_resolve_config_deterministic_and_bounded():
                 invariants_hold = False
             if work["apply-every"] not in common.BACKPRESSURE_APPLY_EVERY:
                 invariants_hold = False
+        elif kind == "iso":
+            # pingers+chains+ttl + node-size/depth/breadth; NO val payload and no
+            # other kind's fields.
+            if any(k in work for k in
+                   ("generations", "group", "producers", "messages",
+                    "apply-every", "payload", "payload-size", "payload-mode")):
+                invariants_hold = False
+            if work["pingers"] not in PINGERS_ALLOWED:
+                invariants_hold = False
+            if work["node-size"] not in common.ISO_NODE_SIZES:
+                invariants_hold = False
+            if work["node-depth"] not in common.ISO_DEPTHS:
+                invariants_hold = False
+            if work["node-breadth"] not in common.ISO_BREADTHS:
+                invariants_hold = False
+            if not (iso_ttl_lo <= work["ttl"] <= iso_ttl_hi):
+                invariants_hold = False
+            # chains is clamped to the graph's acquire-flood cap, so every iso run
+            # must satisfy chains <= cap AND the budget (chains * ttl_max *
+            # node_count <= ISO_ACQUIRE_BUDGET) -- the memory-safe envelope.
+            nd = work["node-depth"]
+            nb = work["node-breadth"]
+            cap = common.iso_chains_cap(nd, nb)
+            nodes = common.iso_node_count(nd, nb)
+            if not (1 <= work["chains"] <= cap):
+                invariants_hold = False
+            if (work["chains"] * common.ISO_TTL_MAX * nodes
+                    > common.ISO_ACQUIRE_BUDGET):
+                invariants_hold = False
         else:
             invariants_hold = False
-        if work["payload"] not in ("string", "u64"):
-            invariants_hold = False
-        if work["payload-size"] not in SIZE_ALLOWED:
-            invariants_hold = False
-        mode_seen.add(work["payload-mode"])
+        # Payload is shared by mesh/cyclic/backpressure but NOT iso (iso picks its
+        # own cargo set), so guard the shared reads for iso.
+        if kind != "iso":
+            if work["payload"] not in ("string", "u64"):
+                invariants_hold = False
+            if work["payload-size"] not in SIZE_ALLOWED:
+                invariants_hold = False
+            mode_seen.add(work["payload-mode"])
         mt = runtime.get("ponymaxthreads")
         if (mt is None) or not (1 <= mt <= THREADS):
             invariants_hold = False
@@ -243,6 +321,15 @@ def test_resolve_config_deterministic_and_bounded():
           cyclic_theoretical <= CYCLIC_WORKER_CEILING)
     check("backpressure theoretical worst-case messages within the ceiling",
           bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
+    # iso's memory bound is the acquire-flood budget (the chains clamp keeps every
+    # run within it -- asserted per-config above). Pin the calibrated budget and the
+    # max graph node count; bumping either forces a memory re-measure.
+    iso_max_nodes = max(common.iso_node_count(d, b)
+                        for d in common.ISO_DEPTHS for b in common.ISO_BREADTHS)
+    check("iso calibrated acquire budget within the ceiling",
+          common.ISO_ACQUIRE_BUDGET <= ISO_ACQUIRE_CEILING)
+    check("iso max graph node count within the ceiling",
+          iso_max_nodes <= ISO_NODE_CEILING)
     check("payload-mode covers {forward, fresh}",
           mode_seen == {"forward", "fresh"})
     check("ponymaxthreads spans the full [1, THREADS] range",
@@ -250,13 +337,14 @@ def test_resolve_config_deterministic_and_bounded():
 
 
 def test_resolve_config_draws_all_workloads():
-    # Swarm coverage: over many seeds all three workload kinds must appear, or one
-    # of the cycle-detector / backpressure / mesh paths would go untested in a soak.
+    # Swarm coverage: over many seeds all four workload kinds must appear, or one of
+    # the cycle-detector / backpressure / iso / mesh paths would go untested in a
+    # soak.
     kinds = set()
     for master in range(0, 300):
         kinds.add(normal.resolve_config(master, THREADS)["workload"]["workload"])
-    check("normal mode draws all of mesh, cyclic, backpressure",
-          kinds == {"mesh", "cyclic", "backpressure"})
+    check("normal mode draws all of mesh, cyclic, backpressure, iso",
+          kinds == {"mesh", "cyclic", "backpressure", "iso"})
 
 
 def test_resolve_config_swarm_omission():
@@ -275,15 +363,22 @@ def test_resolve_config_swarm_omission():
 def test_resolve_config_magnitude_buckets():
     # The deliberate small->large distribution. A MESH run draws chains/ttl from the
     # magnitude buckets; a CYCLIC run draws generations from its own buckets; a
-    # BACKPRESSURE run draws messages from its own buckets. Over many seeds each
-    # magnitude knob must reach all three of its buckets.
+    # BACKPRESSURE run draws messages from its own buckets. ISO's magnitude is in its
+    # ttl (bucketed) AND its GRAPH SHAPE (node count): its chains is clamped to the
+    # graph's acquire cap, so chains is not an independent magnitude knob (a large
+    # draw on a big graph clamps down) -- the graph node count is the iso magnitude
+    # dimension instead. Each branch reads only its own kind's field, so iso needs
+    # its own arm (the backpressure `messages` it lacks would KeyError).
     nb = common.NORMAL_SIZE_BUCKETS
     gb = common.CYCLIC_GENERATION_BUCKETS
     mb = common.BACKPRESSURE_MESSAGE_BUCKETS
+    itb = common.ISO_TTL_BUCKETS
     mesh_chains = {"small": 0, "medium": 0, "large": 0}
     mesh_ttl = {"small": 0, "medium": 0, "large": 0}
     cyclic_gen = {"small": 0, "medium": 0, "large": 0}
     bp_messages = {"small": 0, "medium": 0, "large": 0}
+    iso_ttl = {"small": 0, "medium": 0, "large": 0}
+    iso_node_counts = set()
 
     def bucket_of(val, buckets):
         if val <= buckets["small"][1]:
@@ -294,13 +389,18 @@ def test_resolve_config_magnitude_buckets():
 
     for master in range(0, 400):
         w = normal.resolve_config(master, THREADS)["workload"]
-        if w["workload"] == "mesh":
+        wl = w["workload"]
+        if wl == "mesh":
             mesh_chains[bucket_of(w["chains"], nb)] += 1
             mesh_ttl[bucket_of(w["ttl"], nb)] += 1
-        elif w["workload"] == "cyclic":
+        elif wl == "cyclic":
             cyclic_gen[bucket_of(w["generations"], gb)] += 1
-        else:
+        elif wl == "backpressure":
             bp_messages[bucket_of(w["messages"], mb)] += 1
+        else:  # iso
+            iso_ttl[bucket_of(w["ttl"], itb)] += 1
+            iso_node_counts.add(
+                common.iso_node_count(w["node-depth"], w["node-breadth"]))
     check("mesh chains reaches all three magnitude buckets",
           all(c > 0 for c in mesh_chains.values()))
     check("mesh ttl reaches all three magnitude buckets",
@@ -309,17 +409,32 @@ def test_resolve_config_magnitude_buckets():
           all(c > 0 for c in cyclic_gen.values()))
     check("backpressure messages reaches all three magnitude buckets",
           all(c > 0 for c in bp_messages.values()))
+    check("iso ttl reaches all three magnitude buckets",
+          all(c > 0 for c in iso_ttl.values()))
+    # iso graph shape spans flat (1 node) through the max tree (15 nodes).
+    iso_max_nodes = max(common.iso_node_count(d, b)
+                        for d in common.ISO_DEPTHS for b in common.ISO_BREADTHS)
+    check("iso graph reaches both the single node and the max tree",
+          (1 in iso_node_counts) and (iso_max_nodes in iso_node_counts))
 
 
 def test_resolve_config_draws_single_pinger():
-    # pingers=1 must be drawn for some MESH run: it exercises the ORCA self-send
-    # path (bounded since PR #5594), so the soak keeps a standing stress on that fix.
-    one_seen = False
+    # pingers=1 must be drawn for some MESH run AND some ISO run: it exercises the
+    # ORCA self-send path (bounded since PR #5594), so the soak keeps a standing
+    # stress on that fix -- the iso run additionally self-sends an iso nested graph,
+    # exercising the pin with a moved mutable subgraph (see self-send-object-pinning).
+    mesh_one_seen = False
+    iso_one_seen = False
     for master in range(0, 500):
         w = normal.resolve_config(master, THREADS)["workload"]
-        if (w["workload"] == "mesh") and (w["pingers"] == 1):
-            one_seen = True
-    check("normal mode draws a mesh run with pingers=1", one_seen)
+        # cyclic/backpressure have no `pingers`, so .get() guards the read.
+        if w.get("pingers") == 1:
+            if w["workload"] == "mesh":
+                mesh_one_seen = True
+            elif w["workload"] == "iso":
+                iso_one_seen = True
+    check("normal mode draws a mesh run with pingers=1", mesh_one_seen)
+    check("normal mode draws an iso run with pingers=1", iso_one_seen)
 
 
 def test_resolve_config_mesh_run_time_bounded():
@@ -356,6 +471,7 @@ def main():
     test_resolve_config_mesh_golden()
     test_resolve_config_cyclic_golden()
     test_resolve_config_backpressure_golden()
+    test_resolve_config_iso_golden()
     test_resolve_config_never_sets_systematic_seed()
     test_ponynoblock_is_a_swarm_knob()
     test_resolve_config_deterministic_and_bounded()

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -256,13 +256,16 @@ def clamp_ttl(chains, ttl, mode, payload, size):
 # as the same blowup.
 NORMAL_PINGERS = [1, 2, 4, 8, 16, 32, 64]
 
-# Normal-mode workload-kind weights for the 3-way draw (draw_workload). mesh is the
-# baseline (the widest runtime surface); cyclic and backpressure each target one
-# otherwise-untouched subsystem (the cycle detector; the explicit UNDER_PRESSURE
-# muting path). A run rolls mesh below MESH_P, cyclic below MESH_P + CYCLIC_P, else
-# backpressure. The tests assert all three appear over the sampled seed range.
+# Normal-mode workload-kind weights for the 4-way draw (draw_workload). mesh is the
+# baseline (the widest runtime surface); cyclic, backpressure, and iso each target
+# one otherwise-untouched subsystem (the cycle detector; the explicit UNDER_PRESSURE
+# muting path; ORCA's transfer of a nested mutable subgraph between actors). A run
+# rolls mesh below MESH_P, cyclic below MESH_P + CYCLIC_P, backpressure below
+# MESH_P + CYCLIC_P + BP_P, else iso. The tests assert all four appear over the
+# sampled seed range.
 WORKLOAD_MESH_P = 0.4
-WORKLOAD_CYCLIC_P = 0.3   # backpressure gets the remaining 1 - MESH_P - CYCLIC_P
+WORKLOAD_CYCLIC_P = 0.2
+WORKLOAD_BP_P = 0.2   # iso gets the remaining 1 - MESH_P - CYCLIC_P - BP_P
 
 # Normal-mode cyclic-garbage draws (the `cyclic` workload). The cyclic workload
 # spawns `generations` successive groups of `group` actors, each group a strongly
@@ -325,6 +328,59 @@ BACKPRESSURE_MESSAGE_BUCKETS = {
 }
 BACKPRESSURE_APPLY_EVERY = [50, 200, 1000]
 
+# Normal-mode iso-handoff draws (the `iso` workload). The `mesh` topology, but the
+# val payload is replaced by a freshly built nested `iso` graph and consumed
+# hop-to-hop; the receiver acquires a foreign MUTABLE multi-object subgraph -- the
+# new ORCA coverage. iso has its OWN cargo knobs (it does NOT draw the val payload):
+# a `Parcel` tree of `depth` levels with `breadth` children per node, each node a
+# separate allocation holding a `node_size`-byte array. iso reuses NORMAL_PINGERS
+# for its actor count (pingers=1 is the self-handoff, bounded by PR #5594's
+# self-send pin).
+#
+# Graph shape: ISO_DEPTHS x ISO_BREADTHS gives node counts in {1,2,3,4,7,15} (a flat
+# node through a 15-node tree), so the swarm spans flat/chain/tree. depth is capped
+# at 4 to keep the GC-trace recursion shallow.
+#
+# Memory bound (CALIBRATED on the engine, 4 GB RLIMIT_AS, real-parallel, ~16
+# threads): each parcel is owned by the Dispatcher and acquired by every carrier it
+# passes, so the owner's GC-acquire backlog scales with the ACQUIRE-FLOOD =
+# chains * ttl * node_count. The OOM cliff is non-monotonic near the edge (7 nodes
+# at 2285 chains crashed at the same ~256k acquire events where other shapes were
+# safe), so the budget is set CONSERVATIVELY: at K=96000 the worst measured is
+# ~160 MB (pingers=16, 15-node tree), every shape/pinger combo is safe, and 2x the
+# budget still did not crash -- ~25x margin under 4 GB. The per-run `chains` draw is
+# CLAMPED to K/(ISO_TTL_MAX*node_count) (iso_chains_cap), so a 1-node run goes high-
+# volume (up to ~6000 chains) and a 15-node run stays low-volume (~400), both safe.
+# COUPLING: the budget is a property of the Dispatcher's front-loaded injection and
+# the per-node acquire footprint -- re-measure if either changes. Calibrated.
+ISO_NODE_SIZES = [1, 8, 64, 256, 1024]
+ISO_DEPTHS = [1, 2, 3, 4]
+ISO_BREADTHS = [0, 1, 2]
+ISO_TTL_BUCKETS = {"small": (1, 4), "medium": (5, 10), "large": (11, 16)}
+ISO_TTL_MAX = 16
+# Pre-clamp chains magnitude buckets (max = the 1-node cap K/ISO_TTL_MAX = 6000);
+# iso_chains_cap then clamps per run to the drawn graph's safe limit.
+ISO_CHAINS_BUCKETS = {"small": (50, 1000), "medium": (1001, 3000),
+                      "large": (3001, 6000)}
+ISO_ACQUIRE_BUDGET = 96000
+
+
+def iso_node_count(depth, breadth):
+    """Total nodes in a `Parcel` tree of `depth` levels and `breadth` children per
+    node: 1 + breadth + breadth^2 + ... + breadth^(depth-1). depth 1 or breadth 0 is
+    a single node. Matches the engine's recursive `Parcel` constructor."""
+    if depth <= 1 or breadth == 0:
+        return 1
+    return sum(breadth ** level for level in range(depth))
+
+
+def iso_chains_cap(depth, breadth):
+    """The safe `chains` ceiling for a drawn graph shape: the acquire-flood budget
+    divided by (ISO_TTL_MAX * node_count). Used to CLAMP the drawn chains so no run
+    exceeds chains * ttl * node_count <= ISO_ACQUIRE_BUDGET (ttl <= ISO_TTL_MAX), the
+    calibrated memory-safe envelope. node_count==1 gives the max, 6000."""
+    return ISO_ACQUIRE_BUDGET // (ISO_TTL_MAX * iso_node_count(depth, breadth))
+
 
 def draw_bucketed(rng, buckets):
     """Draw a small/medium/large bucket at 25/50/25, then a uniform value within it.
@@ -356,29 +412,37 @@ def draw_payload(rng):
 
 def draw_workload(rng):
     """Draw the workload kind plus EVERY kind's specific shape, returning
-    (workload, generations, group, producers, messages, apply_every). ALWAYS the
-    same fixed sequence of logical draws regardless of the rolled kind -- the kind
-    roll, then the cyclic shape (bucketed generations + group choice), then the
-    backpressure shape (producers choice + bucketed messages + apply_every choice).
-    No branch on the rolled kind, so the kind changes which keys the config later
-    emits, never how many draws this makes (the fixed-consumption discipline;
+    (workload, generations, group, producers, messages, apply_every, node_size,
+    depth, breadth). ALWAYS the same fixed sequence of logical draws regardless of
+    the rolled kind -- the kind roll, then the cyclic shape (bucketed generations +
+    group choice), then the backpressure shape (producers choice + bucketed messages
+    + apply_every choice), then the iso cargo shape (node_size + depth + breadth
+    choices). No branch on the rolled kind, so the kind changes which keys the config
+    later emits, never how many draws this makes (the fixed-consumption discipline;
     "logical draws" because a randint's underlying bit consumption varies with its
-    value, but the call sequence does not). The mesh `pingers` field is drawn
-    separately in resolve_config, as before. Every kind's params are drawn even when
-    another kind is rolled (and then ignored) to keep that sequence fixed."""
+    value, but the call sequence does not). The mesh/iso `pingers` field and the
+    per-kind bucketed chains/ttl are drawn separately in resolve_config, as before.
+    Every kind's params are drawn even when another kind is rolled (and then ignored)
+    to keep that sequence fixed."""
     roll = rng.random()
     if roll < WORKLOAD_MESH_P:
         workload = "mesh"
     elif roll < (WORKLOAD_MESH_P + WORKLOAD_CYCLIC_P):
         workload = "cyclic"
-    else:
+    elif roll < (WORKLOAD_MESH_P + WORKLOAD_CYCLIC_P + WORKLOAD_BP_P):
         workload = "backpressure"
+    else:
+        workload = "iso"
     generations = draw_bucketed(rng, CYCLIC_GENERATION_BUCKETS)
     group = rng.choice(CYCLIC_GROUPS)
     producers = rng.choice(BACKPRESSURE_PRODUCERS)
     messages = draw_bucketed(rng, BACKPRESSURE_MESSAGE_BUCKETS)
     apply_every = rng.choice(BACKPRESSURE_APPLY_EVERY)
-    return workload, generations, group, producers, messages, apply_every
+    node_size = rng.choice(ISO_NODE_SIZES)
+    depth = rng.choice(ISO_DEPTHS)
+    breadth = rng.choice(ISO_BREADTHS)
+    return (workload, generations, group, producers, messages, apply_every,
+            node_size, depth, breadth)
 
 
 def build_argv(binary, config):
@@ -786,10 +850,12 @@ def summary_line(config, result):
         parsed.get("received", "?"), parsed.get("expected", "?"),
         parsed.get("order_sig", "?"))
     # Each workload carries different shape fields: mesh/cyclic have chains/ttl,
-    # backpressure has producers/messages/apply-every instead (no chains/ttl). Only
-    # payload is shared. A systematic config has no `workload` key (always mesh, by
-    # the engine default), so default to mesh. Fold chains/ttl into the per-kind
-    # string so the backpressure branch never reads a field it lacks.
+    # backpressure has producers/messages/apply-every instead (no chains/ttl), iso
+    # has pingers/chains/ttl + its own cargo knobs and NO payload. A systematic
+    # config has no `workload` key (always mesh, by the engine default), so default
+    # to mesh. Each branch reads only the fields its kind carries -- iso needs its
+    # own arm so an iso run is not mislabeled `mesh` by the fall-through, and the
+    # shared `payload` read is guarded (iso has none).
     wl = shape.get("workload", "mesh")
     if wl == "cyclic":
         kind = "cyclic generations=%d group=%d chains=%d ttl=%d" % (
@@ -797,12 +863,16 @@ def summary_line(config, result):
     elif wl == "backpressure":
         kind = "backpressure producers=%d messages=%d apply_every=%d" % (
             shape["producers"], shape["messages"], shape["apply-every"])
+    elif wl == "iso":
+        kind = ("iso pingers=%d chains=%d ttl=%d node_size=%d depth=%d breadth=%d"
+                % (shape["pingers"], shape["chains"], shape["ttl"],
+                   shape["node-size"], shape["node-depth"], shape["node-breadth"]))
     else:
         kind = "mesh pingers=%d chains=%d ttl=%d" % (
             shape["pingers"], shape["chains"], shape["ttl"])
     return "[seed %d] %s (%s payload=%s) %s" % (
         config["master_seed"], result.outcome.upper(), kind,
-        shape["payload"], detail)
+        shape.get("payload", "none"), detail)
 
 
 def execute(binary, config, version, use_flags, out_dir, timeout,

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -289,6 +289,15 @@ CYCLIC_WORKER_CEILING = 130000
 BACKPRESSURE_MESSAGE_CEILING = 110_000_000
 
 
+# Calibrated iso ceilings. iso's memory bound is the ACQUIRE-FLOOD =
+# chains * ttl * node_count; the per-run chains draw is CLAMPED so this stays within
+# ISO_ACQUIRE_BUDGET (see stress_common). These pin the calibrated budget (worst
+# ~160 MB at K=96000) and the max graph node count; bumping either forces a memory
+# re-measure (the OOM cliff is non-monotonic near the edge).
+ISO_ACQUIRE_CEILING = 96000
+ISO_NODE_CEILING = 15
+
+
 class _CallCountingRandom(random.Random):
     """A Random that counts the high-level draw calls (random/randint/choice) made
     on it, delegating to the real implementation so the produced values are
@@ -324,10 +333,11 @@ def test_draw_workload():
     bp_msg_lo = common.BACKPRESSURE_MESSAGE_BUCKETS["small"][0]
     bp_msg_hi = common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1]
     for master in range(0, 500):
-        (workload, generations, group, producers, messages, apply_every) = \
+        (workload, generations, group, producers, messages, apply_every,
+         node_size, depth, breadth) = \
             common.draw_workload(random.Random(master))
         kinds.add(workload)
-        if workload not in ("mesh", "cyclic", "backpressure"):
+        if workload not in ("mesh", "cyclic", "backpressure", "iso"):
             bounds_ok = False
         # EVERY kind's params are drawn for every roll (fixed rng consumption), so
         # they are always valid numbers in range regardless of the rolled kind --
@@ -342,8 +352,14 @@ def test_draw_workload():
             bounds_ok = False
         if apply_every not in common.BACKPRESSURE_APPLY_EVERY:
             bounds_ok = False
-    check("draw_workload covers all three workload kinds",
-          kinds == {"mesh", "cyclic", "backpressure"})
+        if node_size not in common.ISO_NODE_SIZES:
+            bounds_ok = False
+        if depth not in common.ISO_DEPTHS:
+            bounds_ok = False
+        if breadth not in common.ISO_BREADTHS:
+            bounds_ok = False
+    check("draw_workload covers all four workload kinds",
+          kinds == {"mesh", "cyclic", "backpressure", "iso"})
     check("draw_workload all shape params always in range (drawn for every kind)",
           bounds_ok)
     # Ceiling guard: assert the THEORETICAL worst case (the product of the bound
@@ -359,6 +375,20 @@ def test_draw_workload():
           cyclic_theoretical <= CYCLIC_WORKER_CEILING)
     check("backpressure theoretical worst-case messages within the ceiling",
           bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
+    # iso is governed by the acquire-flood budget (chains * ttl * node_count); the
+    # per-run chains clamp (resolve_config) keeps every run within it. Pin the
+    # calibrated budget and the max graph node count; bumping either forces a memory
+    # re-measure. Also verify the clamp's max output (the 1-node cap) never exceeds
+    # the pre-clamp chains bucket max, i.e. the cap is the binding limit.
+    iso_max_nodes = max(common.iso_node_count(d, b)
+                        for d in common.ISO_DEPTHS for b in common.ISO_BREADTHS)
+    check("iso calibrated acquire budget within the ceiling",
+          common.ISO_ACQUIRE_BUDGET <= ISO_ACQUIRE_CEILING)
+    check("iso max graph node count within the ceiling",
+          iso_max_nodes <= ISO_NODE_CEILING)
+    check("iso 1-node chains cap stays within the acquire budget",
+          (common.iso_chains_cap(1, 0) * common.ISO_TTL_MAX
+           * common.iso_node_count(1, 0)) <= common.ISO_ACQUIRE_BUDGET)
 
     # Fixed-consumption contract: draw_workload must make the SAME sequence of rng
     # calls whichever kind it rolls (it draws every kind's shape unconditionally),
@@ -367,7 +397,7 @@ def test_draw_workload():
     # not work, because a randint's underlying bit consumption varies with its value
     # (see the draw_workload doc).
     counts = []
-    for kind in ("mesh", "cyclic", "backpressure"):
+    for kind in ("mesh", "cyclic", "backpressure", "iso"):
         seed = next(s for s in range(0, 500)
                     if common.draw_workload(random.Random(s))[0] == kind)
         counter = _CallCountingRandom(seed)
@@ -699,10 +729,11 @@ def test_parse_result():
 
 def test_summary_line():
     # summary_line reads DIFFERENT shape fields per kind (mesh/cyclic have
-    # chains/ttl, backpressure has producers/messages/apply-every). If its read keys
-    # ever drift from resolve_config's emit keys, it raises an unguarded KeyError --
-    # at soak time, never in CI -- so exercise every branch here. The shape dicts
-    # mirror what the orchestrators emit (see orchestrate_normal.resolve_config and
+    # chains/ttl, backpressure has producers/messages/apply-every, iso has
+    # pingers/chains/ttl/node-size). If its read keys ever drift from
+    # resolve_config's emit keys, it raises an unguarded KeyError -- at soak time,
+    # never in CI -- so exercise every branch here. The shape dicts mirror what the
+    # orchestrators emit (see orchestrate_normal.resolve_config and
     # resolve_systematic_workload).
     result = common.RunResult(
         "pass", 0, None,
@@ -720,6 +751,10 @@ def test_summary_line():
           "workload": {"seed": 9, "workload": "backpressure", "producers": 64,
                        "messages": 1000, "apply-every": 200, "payload": "string",
                        "payload-size": 64, "payload-mode": "forward"}}
+    iso = {"master_seed": 6, "runtime": {},
+           "workload": {"seed": 9, "workload": "iso", "pingers": 8,
+                        "chains": 100, "ttl": 8, "node-size": 64,
+                        "node-depth": 3, "node-breadth": 2}}
     # A systematic config has NO `workload` key (always mesh by the engine default)
     # and must default to the mesh branch.
     systematic = {"master_seed": 4, "runtime": {},
@@ -738,6 +773,10 @@ def test_summary_line():
     check("summary_line backpressure: names producers/messages/apply_every",
           ("backpressure producers=64 messages=1000 apply_every=200" in bs)
           and ("chains" not in bs))   # backpressure has no chains/ttl
+    isos = common.summary_line(iso, result)
+    check("summary_line iso: names its cargo knobs + payload=none (not 'mesh')",
+          ("iso pingers=8 chains=100 ttl=8 node_size=64 depth=3 breadth=2" in isos)
+          and ("payload=none" in isos) and ("mesh" not in isos))
     ss = common.summary_line(systematic, result)
     check("summary_line defaults a no-workload-key config to mesh",
           "mesh pingers=16" in ss)


### PR DESCRIPTION
The mesh, cyclic, and backpressure workloads all send a shared `val` payload or a
primitive, so no workload moved a mutable object graph between actors. ORCA's path
for that, where the receiver acquires a foreign mutable subgraph node by node, went
untested. The iso workload exercises it: the mesh topology with the payload
replaced by a nested `iso` graph consumed at each hop.

It has to be a nested graph, not a flat one. A `String`'s byte buffer is already
traced as mutable on every send, so a flat `iso` scalar exercises nothing the
existing `val` String doesn't. Only a multi-object `iso` graph makes the typed
structs themselves mutable and forces the receiver to acquire the whole subgraph. I
measured that against the runtime before building, to confirm it drives the path
the existing payloads don't.

iso draws from its own set of cargo options rather than the val payload, which it
can't use anyway: an iso can't ride the `(String val | U64)` union and can't be
reused, only moved. The swarm draws the graph's shape — depth and breadth and node
size — so runs span a single flat node through a 15-node tree, and the memory cost
(each node is acquired on every hop) is bounded by clamping the chain count to the
drawn shape.

The terminal `Carrier` walks the delivered graph and checks each node's sentinel
bytes, so this is also the harness's only oracle that checks message contents
instead of counting them. A silent GC corruption of the moved subgraph trips a
fault instead of passing.

Design: #5560
