### PR TITLE
Drop tier 3's libs-cache permission to read-only

### DIFF
--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -15,11 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  # write (not read) so a non-`main` workflow_dispatch can push its libs build to
-  # the branch scratch cache (`--branch-cache`), to reuse across dispatches and to
-  # let the warmer promote it after merge. workflow_dispatch/schedule are non-fork,
-  # so the write token is only ever available to repo-authorized actors.
-  packages: write
+  # read, not write: tier3 requires a pre-warmed libs cache (`--require-cache-hit`)
+  # and never builds, so it only pulls the main/branch cache -- it never pushes.
+  packages: read
 
 jobs:
   check-for-changes:


### PR DESCRIPTION
tier 3 requires a pre-warmed libs cache (`--require-cache-hit`) and never builds, so it only pulls the main and branch caches — it never pushes. The `packages: write` it carried, and the comment claiming it pushes its build to the branch scratch cache, predate the switch to require-cache-hit. Nothing in tier 3 writes a package anymore: the container and cross legs pull with `--require-cache-hit`, and the BSD legs do read-only `exists` checks plus an in-VM pull. The stress workflows, the closest precedent, already run with `packages: read`.

Surfaced while reviewing #5622, which makes the same read-only switch for tier 2.