### PR TITLE
Remove vestigial library-mode runtime surface

### DIFF
--- a/.known-couplings/codegen-runtime-api-prototypes.md
+++ b/.known-couplings/codegen-runtime-api-prototypes.md
@@ -1,0 +1,25 @@
+# Codegen hand-mirrors libponyrt's PONY_API signatures
+
+The compiler does not read `pony.h`. Every runtime function a generated program
+calls is hand-declared in `src/libponyc/codegen/codegen.c` (the LLVM prototype,
+e.g. `LLVMAddFunction(c->module, "pony_start", ...)`) and called from the
+`gen*.cc` files (e.g. `gencall_runtime(c, "pony_start", args, n, "")` in
+`genexe.cc`). These prototypes and call sites must match the actual C signature
+of the function in libponyrt.
+
+Change a runtime PONY_API signature — add/remove a parameter, reorder, or change
+a type — and update only the runtime, and nothing local fails: libponyrt's own
+unit tests pass and codegen still compiles. The break surfaces only when a
+generated program runs, because the linker resolves C symbols by name without
+checking arity or types, so the generated `main` passes arguments the runtime
+reads from the wrong registers. The failure can be silent rather than a crash:
+e.g. dropping `pony_start`'s leading `library` param without re-shifting the
+codegen call would feed the language-features pointer in where `exit_code` is
+expected, so networking initialisation would quietly never happen.
+
+Keep the prototype in `codegen.c`, the call in the relevant `gen*.cc`, and the
+runtime definition in lockstep, in the same change.
+
+Run: `make test-core` (full-program tests link generated code against libponyrt)
+and `make test-stdlib-release` (exercises the runtime API breadth, including the
+network path that depends on `pony_start`'s language-features argument).

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -525,11 +525,13 @@ static void init_runtime(compile_t* c)
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex,
     inacc_or_arg_mem_attr);
 
-  // i1 pony_start(i1, i32*, i8*)
-  params[0] = c->i1;
+  // i1 pony_start(i32*, i8*)
+  // This prototype and the call emitted in genexe.cc must match libponyrt's
+  // actual pony_start signature; see
+  // .known-couplings/codegen-runtime-api-prototypes.md
+  params[0] = c->ptr;
   params[1] = c->ptr;
-  params[2] = c->ptr;
-  type = LLVMFunctionType(c->i1, params, 3, false);
+  type = LLVMFunctionType(c->i1, params, 2, false);
   value = LLVMAddFunction(c->module, "pony_start", type);
 
   LLVMAddAttributeAtIndex(value, LLVMAttributeFunctionIndex, nounwind_attr);

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -211,11 +211,12 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
   args[1] = LLVMConstNull(c->ptr);
   gencall_runtime(c, "ponyint_become", args, 2, "");
 
-  // Start the runtime.
-  args[0] = LLVMConstInt(c->i1, 0, false);
-  args[1] = LLVMConstNull(c->ptr);
-  args[2] = make_lang_features_init(c);
-  LLVMValueRef start_success = gencall_runtime(c, "pony_start", args, 3, "");
+  // Start the runtime. The arg count and types here must match libponyrt's
+  // pony_start and the prototype in codegen.c; see
+  // .known-couplings/codegen-runtime-api-prototypes.md
+  args[0] = LLVMConstNull(c->ptr);
+  args[1] = make_lang_features_init(c);
+  LLVMValueRef start_success = gencall_runtime(c, "pony_start", args, 2, "");
 
   LLVMBuildCondBr(c->builder, start_success, post_block, start_fail_block);
 

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -35,9 +35,10 @@ static bool actor_noblock = false;
 #ifdef USE_SYSTEMATIC_TESTING
 // Monotonic source of stable, creation-order actor ids
 // (pony_actor_t.systematic_testing_id). Static, so zero-initialized at process
-// load; not reset by pony_stop. That is fine: only the relative creation order
-// within a single runtime lifetime is used, and a fixed seed reproduces that
-// order because systematic testing creates actors deterministically.
+// load and never reset within the process. That is fine: only the relative
+// creation order within a single runtime lifetime is used, and a fixed seed
+// reproduces that order because systematic testing creates actors
+// deterministically.
 static PONY_ATOMIC(uint64_t) actor_systematic_testing_id_counter;
 #endif
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -374,7 +374,8 @@ PONY_API void pony_traceunknown(pony_ctx_t* ctx, void* p, int m);
  *
  * Then call pony_start().
  *
- * It is not safe to call this again before the runtime has terminated.
+ * The runtime can only be initialised and run once per process; it is not safe
+ * to call this more than once.
  */
 PONY_API int pony_init(int argc, char** argv);
 
@@ -384,20 +385,16 @@ PONY_API int pony_init(int argc, char** argv);
  * the value pointed by exit_code set with pony_exitcode(), defaulting to 0.
  * exit_code can be NULL if you don't care about the exit code.
  *
- * If library is false, this call will return when the pony program has
- * terminated. If library is true, this call will return immediately, with an
- * exit code of 0, and the runtime won't terminate until pony_stop() is
- * called. This allows further processing to be done on the current thread.
- * The value pointed by exit_code will not be modified if library is true. Use
- * the return value of pony_stop() in that case.
+ * This call will return when the pony program has terminated.
  *
  * language_features specifies which features of the runtime specific to the
  * Pony language, such as network, should be initialised.
  * If language_features is NULL, no feature will be initialised.
  *
- * It is not safe to call this again before the runtime has terminated.
+ * The runtime can only be run once per process; it is not safe to call this
+ * more than once.
  */
-PONY_API bool pony_start(bool library, int* exit_code,
+PONY_API bool pony_start(int* exit_code,
   const pony_language_features_init_t* language_features);
 
 /**
@@ -419,14 +416,6 @@ PONY_API void pony_register_thread();
 PONY_API void pony_unregister_thread();
 
 PONY_API int32_t pony_scheduler_index();
-
-/** Signals that the pony runtime may terminate.
- *
- * This only needs to be called if pony_start() was called with library set to
- * true. This returns the exit code, defaulting to zero. This call won't return
- * until the runtime actually terminates.
- */
-PONY_API int pony_stop();
 
 /** Set the exit code.
  *

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1842,7 +1842,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
   return pony_ctx();
 }
 
-bool ponyint_sched_start(bool library)
+bool ponyint_sched_start()
 {
   pony_register_thread();
 
@@ -1852,7 +1852,7 @@ bool ponyint_sched_start(bool library)
   atomic_store_explicit(&pinned_actor_scheduler_suspended, false, memory_order_relaxed);
   atomic_store_explicit(&pinned_actor_scheduler_suspended_check, false, memory_order_relaxed);
 
-  atomic_store_explicit(&detect_quiescence, !library, memory_order_relaxed);
+  atomic_store_explicit(&detect_quiescence, true, memory_order_relaxed);
 
   DTRACE0(RT_START);
   uint32_t start = 0;
@@ -1882,10 +1882,7 @@ bool ponyint_sched_start(bool library)
   // custom run loop for pinned actors
   run_pinned_actors();
 
-  if(!library)
-  {
-    ponyint_sched_shutdown();
-  }
+  ponyint_sched_shutdown();
 
   TRACING_THREAD_STOP();
   ponyint_pool_thread_cleanup();
@@ -1900,12 +1897,6 @@ bool ponyint_sched_start(bool library)
   ponyint_mpmcq_destroy(&this_scheduler->q);
 
   return true;
-}
-
-void ponyint_sched_stop()
-{
-  atomic_store_explicit(&detect_quiescence, true, memory_order_release);
-  ponyint_sched_shutdown();
 }
 
 void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor)

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -139,9 +139,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool nopin,
 // width-sensitive conversion can be unit-tested.
 uint64_t ponyint_sched_stats_interval_cycles(uint32_t interval_seconds);
 
-bool ponyint_sched_start(bool library);
-
-void ponyint_sched_stop();
+bool ponyint_sched_start();
 
 void ponyint_sched_add(pony_ctx_t* ctx, pony_actor_t* actor);
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -15,10 +15,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#ifdef USE_VALGRIND
-#include <valgrind/helgrind.h>
-#endif
-
 typedef struct options_t
 {
   // concurrent options
@@ -55,8 +51,7 @@ typedef struct options_t
 typedef enum running_kind_t
 {
   NOT_RUNNING,
-  RUNNING_DEFAULT,
-  RUNNING_LIBRARY
+  RUNNING
 } running_kind_t;
 
 // global data
@@ -292,12 +287,6 @@ PONY_API int pony_init(int argc, char** argv)
   pony_assert(
     atomic_load_explicit(&running, memory_order_relaxed) == NOT_RUNNING);
 
-  atomic_thread_fence(memory_order_acquire);
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_AFTER(&initialised);
-  ANNOTATE_HAPPENS_AFTER(&running);
-#endif
-
   DTRACE0(RT_INIT);
   options_t opt;
   memset(&opt, 0, sizeof(options_t));
@@ -396,15 +385,19 @@ PONY_API int pony_init(int argc, char** argv)
   return argc;
 }
 
-PONY_API bool pony_start(bool library, int* exit_code,
+// Changing this signature means updating the FFI prototype and call the
+// compiler emits for pony_start; see
+// .known-couplings/codegen-runtime-api-prototypes.md
+PONY_API bool pony_start(int* exit_code,
   const pony_language_features_init_t* language_features)
 {
   pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
 
-  // Set to RUNNING_DEFAULT even if library is true so that pony_stop() isn't
-  // callable until the runtime has actually started.
+  // Guard against starting the runtime more than once. This latches to RUNNING
+  // and is never cleared: the runtime runs once per process, so neither a
+  // failed start below nor a completed run rolls it back.
   running_kind_t prev_running = atomic_exchange_explicit(&running,
-    RUNNING_DEFAULT, memory_order_relaxed);
+    RUNNING, memory_order_relaxed);
   (void)prev_running;
   pony_assert(prev_running == NOT_RUNNING);
 
@@ -414,46 +407,21 @@ PONY_API bool pony_start(bool library, int* exit_code,
       sizeof(pony_language_features_init_t));
 
     if(language_init.init_network && !ponyint_os_sockets_init())
-    {
-      atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
       return false;
-    }
   } else {
     memset(&language_init, 0, sizeof(pony_language_features_init_t));
   }
 
   if(!TRACING_START())
-  {
-    atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
     return false;
-  }
 
-  if(!ponyint_sched_start(library))
-  {
-    atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
+  if(!ponyint_sched_start())
     return false;
-  }
-
-  if(library)
-  {
-#ifdef USE_VALGRIND
-    ANNOTATE_HAPPENS_BEFORE(&running);
-#endif
-    atomic_store_explicit(&running, RUNNING_LIBRARY, memory_order_release);
-    return true;
-  }
 
   if(language_init.init_network)
     ponyint_os_sockets_final();
 
   int ec = pony_get_exitcode();
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_BEFORE(&initialised);
-  ANNOTATE_HAPPENS_BEFORE(&running);
-#endif
-  atomic_thread_fence(memory_order_acq_rel);
-  atomic_store_explicit(&initialised, false, memory_order_relaxed);
-  atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
 
   if(exit_code != NULL)
     *exit_code = ec;
@@ -462,38 +430,6 @@ PONY_API bool pony_start(bool library, int* exit_code,
   TRACING_STOP();
 
   return true;
-}
-
-PONY_API int pony_stop()
-{
-  pony_assert(atomic_load_explicit(&initialised, memory_order_relaxed));
-
-  running_kind_t loc_running = atomic_load_explicit(&running,
-    memory_order_acquire);
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_AFTER(&running);
-#endif
-  (void)loc_running;
-  pony_assert(loc_running == RUNNING_LIBRARY);
-
-  ponyint_sched_stop();
-
-  if(language_init.init_network)
-    ponyint_os_sockets_final();
-
-  int ec = pony_get_exitcode();
-#ifdef USE_VALGRIND
-  ANNOTATE_HAPPENS_BEFORE(&initialised);
-  ANNOTATE_HAPPENS_BEFORE(&running);
-#endif
-  atomic_thread_fence(memory_order_acq_rel);
-  atomic_store_explicit(&initialised, false, memory_order_relaxed);
-  atomic_store_explicit(&running, NOT_RUNNING, memory_order_relaxed);
-
-  // stop tracing as the last thing the program does
-  TRACING_STOP();
-
-  return ec;
 }
 
 PONY_API void pony_exitcode(int code)


### PR DESCRIPTION
Library mode's front door -- the `--library` build flag and the C-API library generator -- was removed in #3975. The runtime kept the pieces behind it: `pony_start`'s `library` parameter and its early-return branch, `pony_stop`, the `running_kind_t` library/default distinction, and `ponyint_sched_start`'s `library` argument. The generated `main` hardcodes `library = false`, so none of it could ever run. This removes it, along with the codegen prototype and call that mirror `pony_start`'s signature.

It also drops the runtime's re-initialization support. The `pony.h` docstrings advertised that the runtime could be re-initialized after it terminated (`pony_init` -> `pony_start` -> `pony_init` -> `pony_start`, a second run in the same process), which only ever served hand-written C embedding of libponyrt -- part of the same unsupported library-mode usage. The fences, resets, and valgrind annotations that backed reuse are gone, and the docstrings now state the one-shot-per-process contract.

Closes #5038