### PR TITLE
Fix the start position reported for a JSON String or Key token

### DIFF
--- a/.release-notes/fix-json-string-key-token-start-position.md
+++ b/.release-notes/fix-json-string-key-token-start-position.md
@@ -1,0 +1,3 @@
+## Fix the start position reported for a JSON String or Key token
+
+`JsonTokenParser` reports a `token_start()` and `token_end()` byte offset for each token it emits. For a `String` or `Key` token, `token_start()` now marks the opening `"`, so the reported span covers the whole quoted token. Previously it pointed one byte past the opening quote, so the span dropped the opening quote — inconsistent with every other token, which already reported its first byte.

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -79,6 +79,7 @@ actor \nodoc\ Main is TestList
     test(_TestJsonPathFilterDeeplyNested)
     test(_TestTokenParserPositions)
     test(_TestTokenParserEndPosition)
+    test(_TestTokenParserStringPosition)
 
 // ===================================================================
 // Generators
@@ -2561,15 +2562,15 @@ class \nodoc\ iso _TestTokenParserPositions is UnitTest
     // ArrayEnd at 23 (its `]`), the closing-bracket positions.
     let expected: Array[(String, USize, USize)] = [
       ("ObjectStart", 0, 1)
-      ("Key", 2, 4)
+      ("Key", 1, 4)
       ("ArrayStart", 5, 6)
       ("Number", 6, 7)
       ("ObjectStart", 8, 9)
       ("ObjectEnd", 9, 10)
       ("ArrayEnd", 10, 11)
-      ("Key", 13, 15)
+      ("Key", 12, 15)
       ("Number", 16, 17)
-      ("Key", 19, 21)
+      ("Key", 18, 21)
       ("ArrayStart", 22, 23)
       ("ArrayEnd", 23, 24)
       ("ObjectEnd", 24, 25)
@@ -2624,6 +2625,41 @@ class \nodoc\ iso _TestTokenParserEndPosition is UnitTest
     else
       h.fail("no tokens recorded for " + input)
     end
+
+class \nodoc\ iso _TestTokenParserStringPosition is UnitTest
+  """
+  A String or Key token's token_start marks the opening quote, so its span
+  covers the whole quoted token — the same anchoring every other token uses.
+  Previously token_start pointed one byte past the opening quote, dropping the
+  opening quote from the span.
+  """
+  fun name(): String => "json/tokenparser/stringposition"
+
+  fun apply(h: TestHelper) =>
+    // (input, label, token_start, token_end) for the first String/Key token.
+    // The span covers the opening quote, the content, and the closing quote.
+    _check(h, "\"abc\"", "String", 0, 5)
+    _check(h, "\"\"", "String", 0, 2)
+    _check(h, """{"k":1}""", "Key", 1, 4)
+    _check(h, "[\"x\"]", "String", 1, 4)
+
+  fun _check(h: TestHelper, input: String, label: String,
+    expected_start: USize, expected_end: USize)
+  =>
+    let events = Array[(String, USize, USize)]
+    let parser = JsonTokenParser(_TokenRecorder(events))
+    try parser.parse(input)?
+    else h.fail("token parse raised unexpectedly for " + input); return
+    end
+    for ev in events.values() do
+      if (ev._1 == "String") or (ev._1 == "Key") then
+        h.assert_eq[String](label, ev._1)
+        h.assert_eq[USize](expected_start, ev._2)
+        h.assert_eq[USize](expected_end, ev._3)
+        return
+      end
+    end
+    h.fail("no String/Key token recorded for " + input)
 
 class \nodoc\ _TokenRecorder is JsonTokenNotify
   """Records (label, token_start, token_end) into a caller-owned array."""

--- a/packages/json/json_token_parser.pony
+++ b/packages/json/json_token_parser.pony
@@ -297,8 +297,11 @@ class ref JsonTokenParser
     result
 
   fun ref _parse_string(is_key: Bool) ? =>
+    // token_start is already anchored at the opening '"' by the caller
+    // (_read_value for a string value, _parse_value for a key). Don't
+    // re-anchor it after _eat — that would drop the opening quote from the
+    // String/Key token's span.
     _eat('"')?
-    _token_start = _offset
     var buf = recover String end
     while true do
       match \exhaustive\ _next()?


### PR DESCRIPTION
`JsonTokenParser` reported `token_start()` one byte past the opening quote for `String` and `Key` tokens (at the first content byte), so the reported span dropped the opening quote — unlike every other token, which anchors `token_start` at its first source byte. `_parse_string` re-anchored `token_start` after consuming the opening quote; both callers already set it to the opening quote, so the re-anchor is removed. `token_end` was already correct and is unchanged.
