### PR TITLE
Fault on a late or duplicate completion in the mesh stress workload

### DIFF
--- a/test/rt-stress/generative/README.md
+++ b/test/rt-stress/generative/README.md
@@ -157,12 +157,13 @@ non-deterministic, so a replay won't necessarily reproduce a failure).
   *completion-count only* (exactly `generations * chains` completions) — weaker than
   the `mesh`/`iso` exact tally. The engine checks this itself and exits non-zero on a
   detected failure, so it holds in **both** modes.
-- **Late / duplicate message** — for `mesh`, anything arriving after a pinger has
-  reported is a leak; for `backpressure`, a work or `finished` after completion, or
-  more `finished` reports than producers, is a duplicate; for `cyclic`, a completion
-  beyond the expected total is a duplicate; for `iso`, a handoff arriving after a
-  `Carrier` has reported, or a completion beyond `chains`, is a duplicate. All trip
-  the engine's fatal-fault path. (A *lost* mesh/cyclic/iso message instead leaves
+- **Late / duplicate message** — for `mesh`, a ping arriving after a pinger has
+  reported is a leak, or a completion beyond `chains` is a duplicate; for
+  `backpressure`, a work or `finished` after completion, or more `finished`
+  reports than producers, is a duplicate; for `cyclic`, a completion beyond the
+  expected total is a duplicate; for `iso`, a handoff arriving after a `Carrier`
+  has reported, or a completion beyond `chains`, is a duplicate. All trip the
+  engine's fatal-fault path. (A *lost* mesh/cyclic/iso message instead leaves
   its chain incomplete forever — caught by the liveness timeout, not here; only
   `backpressure` catches a lost message as a conservation failure.)
 - **Parcel integrity** (`iso` workload) — the only oracle in the harness that

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -275,7 +275,8 @@ actor Coordinator
     A chain reached its terminal (hops == 0) ping. Fold the arrival into the
     order signature; once every chain has terminated the system is quiesced (see
     `Pinger.set_neighbors` and the module docstring), so ask every `Pinger` for
-    its final counts.
+    its final counts. A completion beyond `chains` is a duplicate or late message
+    -- a real fault -- so it trips `_Fatal`.
     """
     _mix(chain.u64())
     _mix(terminal_id.u64())
@@ -286,6 +287,8 @@ actor Coordinator
       for p in _pingers.values() do
         p.report()
       end
+    elseif _completions > _mesh.chains then
+      _Fatal("late/duplicate completion (completions > chains)")
     end
 
   be report_counts(sent: U64, received: U64) =>
@@ -985,8 +988,7 @@ actor Dispatcher
     A parcel reached its terminal (hops == 0) carrier. Fold the arrival into the
     order signature; once every parcel has terminated the system is quiesced, so
     ask every `Carrier` for its final counts. A completion beyond the expected
-    total is a duplicate or late message -- a real fault -- so it trips `_Fatal`
-    (the cyclic collector's overshoot guard, which the mesh `Coordinator` lacks).
+    total is a duplicate or late message -- a real fault -- so it trips `_Fatal`.
     """
     if _done then _Fatal("completion after done (leaked/late message)") end
     _mix(chain.u64())
@@ -1293,13 +1295,13 @@ primitive _Fatal
   """
   The harness's runtime-fault detector: print a diagnostic to stderr and exit
   non-zero. Used by the late/duplicate-message oracles across all workloads -- a
-  ping or `iso` handoff arriving after its node has reported, a cyclic or `iso`
-  completion beyond the expected total, or a backpressure `work`/`finished` after
-  the `Consumer` is done (or more `finished` reports than producers) -- and by the
-  `iso` workload's parcel-integrity oracle (a sentinel-byte mismatch in a delivered
-  graph). Each is a real runtime fault -- a duplicated or delayed message, or a
-  silently corrupted one -- so the stress run fails loudly with a location rather
-  than passing.
+  ping or `iso` handoff arriving after its node has reported, a mesh, cyclic, or
+  `iso` completion beyond the expected total, or a backpressure `work`/`finished`
+  after the `Consumer` is done (or more `finished` reports than producers) -- and
+  by the `iso` workload's parcel-integrity oracle (a sentinel-byte mismatch in a
+  delivered graph). Each is a real runtime fault -- a duplicated or delayed
+  message, or a silently corrupted one -- so the stress run fails loudly with a
+  location rather than passing.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "FATAL: " + msg + " (" + loc.file() + ":"


### PR DESCRIPTION
The `mesh` stress workload's `Coordinator` had no guard against its completion count running past `chains`, so a duplicate or late terminal completion was silently absorbed (exit 0) — the one oracle that should catch it. The `Pinger._reported` guard only catches a stray ping (a different message class), and the conservation tally never counts `completed`. The `cyclic` and `iso` collectors already fault on this overshoot; this brings the mesh to parity.

Design: #5560