### PR TITLE
Fix pooltrack build option on Windows

### DIFF
--- a/.release-notes/fix-pooltrack-build-option-on-windows.md
+++ b/.release-notes/fix-pooltrack-build-option-on-windows.md
@@ -1,0 +1,3 @@
+## Fix pooltrack build option on Windows
+
+The `pooltrack` build option failed to compile on Windows, so you couldn't build the runtime with pool allocation tracking enabled there. It now builds on Windows.

--- a/src/libponyrt/mem/pool.c
+++ b/src/libponyrt/mem/pool.c
@@ -158,22 +158,22 @@ static void pool_event_print(int thread, void* op, size_t event, size_t tsc,
   void* addr, size_t size)
 {
   if(op == POOL_TRACK_ALLOC)
-    printf("%d ALLOC "__zu" ("__zu"): %p, "__zu"\n",
+    printf("%d ALLOC " __zu " (" __zu "): %p, " __zu "\n",
       thread, event, tsc, addr, size);
   else if(op == POOL_TRACK_FREE)
-    printf("%d FREE "__zu" ("__zu"): %p, "__zu"\n",
+    printf("%d FREE " __zu " (" __zu "): %p, " __zu "\n",
       thread, event, tsc, addr, size);
   else if(op == POOL_TRACK_PUSH)
-    printf("%d PUSH "__zu" ("__zu"): %p, "__zu"\n",
+    printf("%d PUSH " __zu " (" __zu "): %p, " __zu "\n",
       thread, event, tsc, addr, size);
   else if(op == POOL_TRACK_PULL)
-    printf("%d PULL "__zu" ("__zu"): %p, "__zu"\n",
+    printf("%d PULL " __zu " (" __zu "): %p, " __zu "\n",
       thread, event, tsc, addr, size);
   else if(op == POOL_TRACK_PUSH_LIST)
-    printf("%d PUSH LIST "__zu" ("__zu"): "__zu", "__zu"\n",
+    printf("%d PUSH LIST " __zu " (" __zu "): " __zu ", " __zu "\n",
       thread, event, tsc, (size_t)addr, size);
   else if(op == POOL_TRACK_PULL_LIST)
-    printf("%d PULL LIST "__zu" ("__zu"): "__zu", "__zu"\n",
+    printf("%d PULL LIST " __zu " (" __zu "): " __zu ", " __zu "\n",
       thread, event, tsc, (size_t)addr, size);
 }
 
@@ -233,7 +233,7 @@ static void pool_track(int thread_filter, void* addr_filter, size_t op_filter,
               print = false;
 
             if((addr_filter != NULL) &&
-              ((addr > addr_filter) || ((addr + size) <= addr_filter)))
+              ((addr > addr_filter) || (((char*)addr + size) <= addr_filter)))
             {
               print = false;
             }


### PR DESCRIPTION
The `pooltrack` build option fails to compile on Windows. MSVC builds the runtime's `.c` files as C++, and the pooltrack-only debug code in `pool.c` hits two constructs that are valid C but not C++:

- The format strings write `"..."__zu` with no space. Under C++11 that lexes as a user-defined string literal with suffix `__zu`, so the `__zu` macro is never expanded. Adding spaces around `__zu` (as the rest of the codebase already does) fixes it.
- It does pointer arithmetic on a `void*`, which C++ doesn't allow. Casting to `char*` for the arithmetic fixes it.

Both are behavior-preserving on the platforms where pooltrack already builds. Verified building on Windows/MSVC with the option enabled.
