### PR TITLE
Tighten stress-harness ceiling and floor test guards

### DIFF
--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -24,12 +24,13 @@ PINGERS_ALLOWED = {1, 2, 4, 8, 16, 32, 64}
 SIZE_ALLOWED = {1, 8, 64, 256, 1024, 4096}
 # Hardcoded calibrated ceiling on generations*group (leaked actors in a CD-off
 # run), NOT derived from the CYCLIC_* constants -- bumping a bucket or adding a
-# bigger group trips this. Real max today is 8000*16 = 128000 (see CYCLIC_* docs).
+# bigger group trips this (strict `<`, so an exact bump to the ceiling trips too).
+# Real max today is 8000*16 = 128000 (see CYCLIC_* docs).
 CYCLIC_WORKER_CEILING = 130000
 # Hardcoded calibrated ceiling on producers*messages (total backpressure work),
 # NOT derived from the BACKPRESSURE_* constants -- bumping a producer count or a
-# message bucket trips this and forces a time re-measure. Real max today is
-# 256*400000 = 102_400_000 (see BACKPRESSURE_* docs).
+# message bucket trips this and forces a time re-measure (strict `<`, as with cyclic
+# above). Real max today is 256*400000 = 102_400_000 (see BACKPRESSURE_* docs).
 BACKPRESSURE_MESSAGE_CEILING = 110_000_000
 # Hardcoded calibrated ceilings for the iso workload. Its memory bound is the
 # ACQUIRE-FLOOD = chains * ttl * node_count; the per-run chains draw is CLAMPED so
@@ -367,9 +368,9 @@ def test_resolve_config_deterministic_and_bounded():
     bp_theoretical = (max(common.BACKPRESSURE_PRODUCERS)
                       * common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1])
     check("cyclic theoretical worst-case workers within the memory ceiling",
-          cyclic_theoretical <= CYCLIC_WORKER_CEILING)
+          cyclic_theoretical < CYCLIC_WORKER_CEILING)
     check("backpressure theoretical worst-case messages within the ceiling",
-          bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
+          bp_theoretical < BACKPRESSURE_MESSAGE_CEILING)
     # iso's memory bound is the acquire-flood budget (the chains clamp keeps every
     # run within it -- asserted per-config above). Pin the calibrated budget and the
     # max graph node count; bumping either forces a memory re-measure.
@@ -383,7 +384,7 @@ def test_resolve_config_deterministic_and_bounded():
     # the chains bucket max; bumping it forces a memory re-measure on the normal build.
     check("actorref theoretical worst-case chains within the memory ceiling",
           common.ACTORREF_CHAINS_BUCKETS["large"][1]
-          <= common.ACTORREF_CHAINS_CEILING)
+          < common.ACTORREF_CHAINS_CEILING)
     check("payload-mode covers {forward, fresh}",
           mode_seen == {"forward", "fresh"})
     check("ponymaxthreads spans the full [1, THREADS] range",

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -366,13 +366,21 @@ ISO_ACQUIRE_BUDGET = 96000
 # re-measure if either changes. Calibrated.
 ACTORREF_CHAINS_BUCKETS = {"small": (50, 2000), "medium": (2001, 15000),
                            "large": (15001, 34000)}
+# actorref reuses iso's ttl envelope. This is an ALIAS, not a copy: editing
+# ISO_TTL_BUCKETS moves actorref's ttl floor/range too. Each workload asserts its own
+# `>= 1` ttl floor through its own name (the tests read ISO_TTL_BUCKETS and
+# ACTORREF_TTL_BUCKETS separately), so splitting this alias into two distinct buckets
+# later leaves each floor guard pinned to the right one.
 ACTORREF_TTL_BUCKETS = ISO_TTL_BUCKETS
 # Ceiling guard: peak RSS tracks max chains. Unlike the cyclic/backpressure/iso NORMAL
-# ceilings -- which sit ~1x above their drawn max because those buckets are calibrated
-# right up against their measured memory limit -- actorref's drawn max (34000 chains,
-# ~100MB) has ~40x headroom under the 4 GB cap, so this is a conservative 2x re-measure
-# trigger (matching the 2x SYSTEMATIC ceilings), not a tight memory bound. A bump past
-# it forces a re-measure.
+# ceilings -- which sit ~1x above their drawn max because their cost near that max is
+# non-linear (cyclic's super-linear workers, iso's non-monotonic acquire-flood) or
+# time-bound (backpressure), so any bump past the calibrated max warrants a fresh
+# measurement -- actorref's drawn max (34000 chains, ~100MB) has ~40x headroom under
+# the 4 GB cap and its cost is linear, so this is a looser 2x re-measure trigger
+# (matching the 2x SYSTEMATIC ceilings). The tests compare with a strict `<`, so a bump
+# that REACHES it -- an exact doubling of the chains bucket max -- trips the re-measure,
+# not only a bump strictly past it.
 ACTORREF_CHAINS_CEILING = 34000 * 2
 
 

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -214,17 +214,24 @@ def test_draw_systematic_workload_coverage():
     # iso acquire-flood (the 15-node corner) is asserted in the loop above.
     check("systematic cyclic worst-case workers within the ceiling",
           (common.SYSTEMATIC_CYCLIC_GENERATION_MAX * max(common.CYCLIC_GROUPS))
-          <= SYSTEMATIC_CYCLIC_WORKER_CEILING)
+          < SYSTEMATIC_CYCLIC_WORKER_CEILING)
     check("systematic iso worst-case 1-node messages within the ceiling",
           (common.SYSTEMATIC_ISO_CHAINS_MAX * common.ISO_TTL_MAX)
-          <= SYSTEMATIC_ISO_MESSAGE_CEILING)
+          < SYSTEMATIC_ISO_MESSAGE_CEILING)
     check("systematic backpressure worst-case messages within the ceiling",
           (max(common.SYSTEMATIC_BACKPRESSURE_PRODUCERS)
            * common.SYSTEMATIC_BACKPRESSURE_MESSAGES_MAX)
-          <= SYSTEMATIC_BACKPRESSURE_MESSAGE_CEILING)
+          < SYSTEMATIC_BACKPRESSURE_MESSAGE_CEILING)
     check("systematic actorref worst-case hops within the ceiling",
           (common.SYSTEMATIC_ACTORREF_CHAINS_MAX * (common.ISO_TTL_MAX + 1))
-          <= SYSTEMATIC_ACTORREF_MESSAGE_CEILING)
+          < SYSTEMATIC_ACTORREF_MESSAGE_CEILING)
+    # iso's ttl floor is load-bearing coverage: a ttl=0 (zero-hop) chain is delivered
+    # once and terminates without a hand-off, so it drives none of the per-hop
+    # foreign-mutable acquire-flood (chains*ttl*node_count) the workload exists to
+    # exercise, while conservation still passes. Same reasoning as actorref below;
+    # assert the floor directly.
+    check("systematic iso ttl floor is >= 1 (ttl 0 = zero-hop = no acquire)",
+          common.SYSTEMATIC_WORKLOAD_RANGES["iso"][1][0] >= 1)
     # actorref's ttl floor is load-bearing coverage: a ttl=0 (zero-hop) chain injects
     # but never forwards, so it drives ZERO acquire_actor -- the workload's whole point
     # -- while conservation still passes (expected == chains). The engine sets no CLI
@@ -232,6 +239,14 @@ def test_draw_systematic_workload_coverage():
     # a drawn value, which would be tautological against the range under test).
     check("systematic actorref ttl floor is >= 1 (ttl 0 = zero-hop = no acquire)",
           common.SYSTEMATIC_WORKLOAD_RANGES["actorref"][1][0] >= 1)
+    # chains=0 is silent uselessness: a run that injects zero chains still conserves
+    # (received == sent == expected == 0), so it scores green while testing nothing --
+    # the soak's pass/fail can't tell it from a real run. Every chains-bearing kind
+    # (mesh/cyclic/iso/actorref; backpressure draws chains but ignores them) must floor
+    # chains at >= 1. Assert the range floors directly (a drawn value is tautological).
+    check("systematic chains floor is >= 1 for every chains-bearing kind",
+          all(common.SYSTEMATIC_WORKLOAD_RANGES[k][0][0] >= 1
+              for k in ("mesh", "cyclic", "iso", "actorref")))
 
 
 def test_draw_swarm_knobs():
@@ -381,16 +396,18 @@ def test_clamp_ttl():
 
 # The calibrated ceiling on generations*group (leaked actors in a CD-off run).
 # Hardcoded, NOT derived from the CYCLIC_* constants, so bumping a generation
-# bucket or adding a bigger group trips this guard and forces a re-measure. The
-# real max today is 8000*16 = 128000 (~1.2 GB peak, fits under DEFAULT_MEM_LIMIT_MB
-# with margin -- see the decision log / CYCLIC_* docstring).
+# bucket or adding a bigger group trips this guard and forces a re-measure (strict
+# `<`, so an exact bump to the ceiling trips too). The real max today is 8000*16 =
+# 128000 (~1.2 GB peak, fits under DEFAULT_MEM_LIMIT_MB with margin -- see the
+# decision log / CYCLIC_* docstring).
 CYCLIC_WORKER_CEILING = 130000
 
 
 # The calibrated ceiling on producers*messages (total backpressure work).
 # Hardcoded, NOT derived from the BACKPRESSURE_* constants, so bumping a producer
-# count or a message bucket trips this guard and forces a time re-measure. Real max
-# today is 256*400000 = 102_400_000.
+# count or a message bucket trips this guard and forces a time re-measure. Strict `<`
+# (as with cyclic above), so an exact bump to the ceiling trips too. Real max today is
+# 256*400000 = 102_400_000.
 BACKPRESSURE_MESSAGE_CEILING = 110_000_000
 
 
@@ -411,9 +428,12 @@ ISO_NODE_CEILING = 15
 # chains*ttl messages (the 15-node acquire-flood corner is separately bounded by
 # ISO_ACQUIRE_BUDGET, asserted per-config in test_draw_systematic_workload_coverage);
 # backpressure cost ~ producers*messages total work. Each ceiling is 2x the drawn-worst
-# product -- the re-measure trigger. Calibrated single-run: cyclic gen 100 * group 16
-# ~1.18s, iso chains 800 * ttl 16 ~0.77s, backpressure 64 * 600 ~1.0s -- all well under
-# the systematic watchdog even run twice (each kind's drawn worst is ~half its ceiling).
+# product, compared with a strict `<` -- the worst must stay UNDER 2x, so an exact
+# doubling of a cap (e.g. generations 50->100) trips the re-measure trigger; a plain
+# `<=` would let that exact-2x bump slip through. Calibrated single-run: cyclic gen 100
+# * group 16 ~1.18s, iso chains 800 * ttl 16 ~0.77s, backpressure 64 * 600 ~1.0s -- all
+# well under the systematic watchdog even run twice (each kind's drawn worst is ~half
+# its ceiling).
 SYSTEMATIC_CYCLIC_WORKER_CEILING = 100 * 16
 SYSTEMATIC_ISO_MESSAGE_CEILING = 800 * 16
 SYSTEMATIC_BACKPRESSURE_MESSAGE_CEILING = 64 * 600
@@ -497,9 +517,9 @@ def test_draw_workload():
     bp_theoretical = (max(common.BACKPRESSURE_PRODUCERS)
                       * common.BACKPRESSURE_MESSAGE_BUCKETS["large"][1])
     check("cyclic theoretical worst-case workers within the memory ceiling",
-          cyclic_theoretical <= CYCLIC_WORKER_CEILING)
+          cyclic_theoretical < CYCLIC_WORKER_CEILING)
     check("backpressure theoretical worst-case messages within the ceiling",
-          bp_theoretical <= BACKPRESSURE_MESSAGE_CEILING)
+          bp_theoretical < BACKPRESSURE_MESSAGE_CEILING)
     # iso is governed by the acquire-flood budget (chains * ttl * node_count); the
     # per-run chains clamp (resolve_config) keeps every run within it. Pin the
     # calibrated budget and the max graph node count; bumping either forces a memory
@@ -518,11 +538,23 @@ def test_draw_workload():
     # the chains bucket max; bumping it forces a memory re-measure on the normal build.
     check("actorref theoretical worst-case chains within the memory ceiling",
           common.ACTORREF_CHAINS_BUCKETS["large"][1]
-          <= common.ACTORREF_CHAINS_CEILING)
+          < common.ACTORREF_CHAINS_CEILING)
+    # iso's ttl floor is load-bearing coverage (a ttl=0 zero-hop chain terminates
+    # without a hand-off, driving none of the per-hop foreign-mutable acquire-flood,
+    # while conservation still passes). Assert the bucket floor directly.
+    check("normal iso ttl floor is >= 1 (ttl 0 = zero-hop = no acquire)",
+          common.ISO_TTL_BUCKETS["small"][0] >= 1)
     # actorref's ttl floor is load-bearing coverage (a ttl=0 zero-hop chain drives zero
     # acquire_actor while conservation still passes). Assert the bucket floor directly.
     check("normal actorref ttl floor is >= 1 (ttl 0 = zero-hop = no acquire)",
           common.ACTORREF_TTL_BUCKETS["small"][0] >= 1)
+    # chains=0 is silent uselessness (see the systematic test): a zero-chain run
+    # conserves and scores green while testing nothing. Each chains-bearing normal
+    # bucket floors chains at >= 1 (backpressure has none). Assert the floors directly.
+    check("normal chains floor is >= 1 for every chains-bearing bucket",
+          all(b["small"][0] >= 1 for b in (
+              common.NORMAL_SIZE_BUCKETS, common.CYCLIC_CHAINS_BUCKETS,
+              common.ISO_CHAINS_BUCKETS, common.ACTORREF_CHAINS_BUCKETS)))
 
     # Fixed-consumption contract: draw_workload must make the SAME sequence of rng
     # calls whichever kind it rolls (it draws every kind's shape unconditionally),


### PR DESCRIPTION
Two vetted follow-ups from the #5638 (actorref workload) code review, both
tightening guards in the generative stress harness's Python unit tests. Harness-only
(`test/rt-stress/generative/`); no engine, runtime, or draw-logic changes, so no
release note and no changelog label.

**iso ttl-floor asserted directly.** The iso workload's coverage — a receiver
acquiring a foreign mutable subgraph — only happens on a hop; a `ttl=0` chain is
zero-hop (the engine's `Carrier.carry` forwards only when `hops > 0`), so it drives
none of that acquire-flood while conservation still passes. The ttl floor of 1 is
therefore load-bearing, but it was only checked indirectly, by asserting a drawn value
fell within the range it was drawn from — tautological against the range under test, so
it couldn't catch the floor being lowered to 0. actorref got direct floor assertions in
#5638; iso now gets the parallel ones, one per mode.

**chains=0 guarded against.** A run drawn with `chains=0` injects nothing, so
`received == sent == expected == 0`, conservation passes, and the soak scores it green
while testing nothing — the same silent-uselessness case as `ttl=0` (in an automated
soak, nobody reads a single run's `received=0`). Pin every chains-bearing workload's
chains floor (mesh, cyclic, iso, actorref — backpressure has no chains) at `>= 1`
directly, in both modes, so a floor lowered to 0 fires a test.

**Ceiling guards use strict `<`.** The re-measure-trigger ceilings compared the
worst-case product with `<=`, so a bump landing exactly on the ceiling passed without
forcing the re-measure the guard exists to force. Strict `<` closes that. This covers
every re-measure trigger — the four `SYSTEMATIC_*_CEILING`s, the normal
`ACTORREF_CHAINS_CEILING`, and the normal `CYCLIC_WORKER_CEILING` and
`BACKPRESSURE_MESSAGE_CEILING` (the last two were caught by the review — they're
just-above-max triggers with the same hole, not tight memory bounds as first thought).
The only ceilings left `<=` are the two exact-equality pins — the iso acquire budget
(`96000 == 96000`) and max node count (`15 == 15`) — where the value must equal the
pin and `<` would fail today.

Design: #5560
