### PR TITLE
Move test-only ACTORREF_CHAINS_CEILING into the test files

### DIFF
--- a/test/rt-stress/generative/orchestrate_normal_test.py
+++ b/test/rt-stress/generative/orchestrate_normal_test.py
@@ -41,6 +41,12 @@ BACKPRESSURE_MESSAGE_CEILING = 110_000_000
 # untested territory (the OOM cliff is non-monotonic near the edge).
 ISO_ACQUIRE_CEILING = 96000
 ISO_NODE_CEILING = 15
+# Hardcoded calibrated ceiling on actorref chains (peak RSS tracks max chains), NOT
+# derived from ACTORREF_CHAINS_BUCKETS -- bumping the chains bucket max trips this and
+# forces a memory re-measure. A looser 2x trigger than the cyclic/bp/iso ceilings above:
+# actorref's drawn max (34000 chains, ~100 MB) has ~40x headroom under the memory cap and
+# its cost is LINEAR (strict `<`, so an exact doubling of the bucket max trips too).
+ACTORREF_CHAINS_CEILING = 34000 * 2
 
 
 def check(name, condition):
@@ -384,7 +390,7 @@ def test_resolve_config_deterministic_and_bounded():
     # the chains bucket max; bumping it forces a memory re-measure on the normal build.
     check("actorref theoretical worst-case chains within the memory ceiling",
           common.ACTORREF_CHAINS_BUCKETS["large"][1]
-          < common.ACTORREF_CHAINS_CEILING)
+          < ACTORREF_CHAINS_CEILING)
     check("payload-mode covers {forward, fresh}",
           mode_seen == {"forward", "fresh"})
     check("ponymaxthreads spans the full [1, THREADS] range",

--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -372,16 +372,6 @@ ACTORREF_CHAINS_BUCKETS = {"small": (50, 2000), "medium": (2001, 15000),
 # ACTORREF_TTL_BUCKETS separately), so splitting this alias into two distinct buckets
 # later leaves each floor guard pinned to the right one.
 ACTORREF_TTL_BUCKETS = ISO_TTL_BUCKETS
-# Ceiling guard: peak RSS tracks max chains. Unlike the cyclic/backpressure/iso NORMAL
-# ceilings -- which sit ~1x above their drawn max because their cost near that max is
-# non-linear (cyclic's super-linear workers, iso's non-monotonic acquire-flood) or
-# time-bound (backpressure), so any bump past the calibrated max warrants a fresh
-# measurement -- actorref's drawn max (34000 chains, ~100MB) has ~40x headroom under
-# the 4 GB cap and its cost is linear, so this is a looser 2x re-measure trigger
-# (matching the 2x SYSTEMATIC ceilings). The tests compare with a strict `<`, so a bump
-# that REACHES it -- an exact doubling of the chains bucket max -- trips the re-measure,
-# not only a bump strictly past it.
-ACTORREF_CHAINS_CEILING = 34000 * 2
 
 
 # Systematic-mode workload-kind weights for the 5-way draw (draw_systematic_workload),

--- a/test/rt-stress/generative/stress_common_test.py
+++ b/test/rt-stress/generative/stress_common_test.py
@@ -420,6 +420,18 @@ ISO_ACQUIRE_CEILING = 96000
 ISO_NODE_CEILING = 15
 
 
+# Calibrated ceiling on actorref chains (peak RSS tracks max chains). Hardcoded, NOT
+# derived from ACTORREF_CHAINS_BUCKETS, so bumping the chains bucket max trips this and
+# forces a memory re-measure. Unlike the cyclic/backpressure/iso ceilings above -- which
+# sit ~1x above their drawn max because their cost near that max is non-linear or
+# time-bound, so any bump past the calibrated max warrants a fresh measurement --
+# actorref's drawn max (34000 chains, ~100 MB) has ~40x headroom under the memory cap
+# and its cost is LINEAR, so this is a looser 2x trigger (matching the 2x SYSTEMATIC
+# ceilings below). Strict `<`, so an exact doubling of the chains bucket max reaches the
+# ceiling and trips the re-measure, not only a bump strictly past it.
+ACTORREF_CHAINS_CEILING = 34000 * 2
+
+
 # Systematic-mode cyclic/backpressure/iso are TIME-bound: kept small so the serialized
 # double-run soak's per-seed cost stays ~= the mesh-only cost it replaces. Guard the
 # PRODUCT that drives cost (like normal's cyclic_theoretical above), so a bump to
@@ -538,7 +550,7 @@ def test_draw_workload():
     # the chains bucket max; bumping it forces a memory re-measure on the normal build.
     check("actorref theoretical worst-case chains within the memory ceiling",
           common.ACTORREF_CHAINS_BUCKETS["large"][1]
-          < common.ACTORREF_CHAINS_CEILING)
+          < ACTORREF_CHAINS_CEILING)
     # iso's ttl floor is load-bearing coverage (a ttl=0 zero-hop chain terminates
     # without a hand-off, driving none of the per-hop foreign-mutable acquire-flood,
     # while conservation still passes). Assert the bucket floor directly.


### PR DESCRIPTION
`ACTORREF_CHAINS_CEILING` was the last test-only ceiling still defined in the shared draw module `stress_common.py` and reached across the module boundary as `common.ACTORREF_CHAINS_CEILING`. The draw code never used it — it exists only for the two harness unit-test guards that check the actorref chains bucket max stays under the re-measure trigger.

Every other test-only ceiling — the normal cyclic/backpressure/iso ceilings and the SYSTEMATIC_* ceilings — already lives in the test files, duplicated across `stress_common_test.py` and `orchestrate_normal_test.py`. This moves `ACTORREF_CHAINS_CEILING` to match: defined locally in both test files (with its rationale comment, adapted per file), referenced by the bare local name. Same `34000 * 2`, same strict `<` guard — no value or behavior change.

Harness-only; no runtime or engine change.

Design: #5560
