### PR TITLE
Fix delivery of zero-byte UDP datagrams

### DIFF
--- a/.known-couplings/udp-empty-datagram-read-budget.md
+++ b/.known-couplings/udp-empty-datagram-read-budget.md
@@ -1,0 +1,23 @@
+# UDP empty-datagram delivery depends on the read loop charging 1 byte per read
+
+`pony_os_recvfrom` in `src/libponyrt/lang/socket.c` returns `PONY_SOCKET_OK`
+with `*count_out == 0` for a zero-length UDP datagram (valid per RFC 768). The
+stdlib read loop `UDPSocket._pending_reads` in `packages/net/udp_socket.pony`
+relies on that: it delivers the empty datagram, then charges its read budget
+`count.max(1)` rather than `count`.
+
+The two are coupled. The runtime side makes a zero-count `OK` a normal,
+repeatable result. The stdlib side must charge at least 1 byte per read, or the
+`sum > (1 << 12)` yield threshold is never reached under a sustained flood of
+empty datagrams: `sum` stays 0, the `while _readable` loop never calls
+`_read_again`, and the actor spins inside a single behavior run, starving the
+other actors on its scheduler thread. Simplifying `count.max(1)` back to
+`count`, or changing the runtime so recvfrom no longer returns a zero-count
+`OK`, reintroduces the starvation.
+
+No automated test guards this. The failure is a scheduler-fairness property,
+not an output: reproducing it needs thousands of empty datagrams resident in
+the socket buffer and arriving faster than they drain, and a "blast N datagrams
+and assert the test finishes" check passes with or without the guard. The
+guard is verified by reasoning, so this file is the record. If a test seam is
+ever added over the read accumulator, cover it there.

--- a/.release-notes/fix-zero-byte-udp-datagrams.md
+++ b/.release-notes/fix-zero-byte-udp-datagrams.md
@@ -1,0 +1,3 @@
+## Fix delivery of zero-byte UDP datagrams
+
+UDP sockets now deliver zero-byte datagrams to `UDPNotify.received` with an empty payload instead of treating them as an error and tearing the socket down. A zero-length datagram is valid per RFC 768, and applications that use them as heartbeats, keepalives, or presence pings will now receive them like any other datagram. TCP zero-byte read handling, where a zero-byte read means the peer closed, is unchanged.

--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -48,9 +48,11 @@ actor \nodoc\ Main is TestList
     test(_TestTCPThrottle)
     test(_TestTCPUnmute)
     test(_TestTCPWritev)
+    test(_TestUDPEmptyDatagramDelivered)
     test(_TestUDPListenFailure)
     test(_TestUDPOversizedDatagramTruncated)
     test(_TestUDPUndersizedDatagramDelivered)
+    test(_TestUDPZeroSizeReadBufferDelivers)
     test(_TestUnicastIP6Loopback)
 
     // The deterministic send-failure trigger (send to broadcast without
@@ -1741,6 +1743,69 @@ class \nodoc\ iso _TestUDPUndersizedDatagramDelivered is UnitTest
             _AscendingBytes(20))
         end,
         "127.0.0.1", "0", 64))
+
+    h.long_test(TimeoutValue())
+
+class \nodoc\ iso _TestUDPEmptyDatagramDelivered is UnitTest
+  """
+  A zero-byte UDP datagram is a valid datagram (RFC 768) and is delivered to
+  `received` with an empty payload -- not treated as an error that tears the
+  socket down. This pins the connectionless recvfrom contract that a 0-byte
+  read is an empty datagram, distinct from stream `pony_os_recv` where 0 bytes
+  means the peer closed.
+
+  Reusing `_TestUDPReadBufferReceiver` with an empty expected payload asserts
+  the delivered array is genuinely 0 bytes, so a delivery of the wrong (stray,
+  non-empty) datagram would fail on length rather than pass silently. If the
+  runtime still errored on a 0-byte recvfrom, `_pending_reads` would `_close`
+  the socket, `received` would never fire, and the test would time out.
+  """
+  fun name(): String => "net/UDPEmptyDatagramDelivered"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver listen")
+    h.expect_action("sender listen")
+    h.expect_action("receive")
+
+    // Buffer 64, payload 0: delivered = min(64, 0) = 0, an empty datagram.
+    h.dispose_when_done(
+      UDPSocket.ip4(UDPAuth(h.env.root),
+        recover
+          _TestUDPReadBufferReceiver(h, _AscendingBytes(0), _AscendingBytes(0))
+        end,
+        "127.0.0.1", "0", 64))
+
+    h.long_test(TimeoutValue())
+
+class \nodoc\ iso _TestUDPZeroSizeReadBufferDelivers is UnitTest
+  """
+  A `UDPSocket` created with a read buffer `size` of 0 does not silently drop
+  incoming datagrams. `size` is raised to 1 at construction, so a non-empty
+  datagram is delivered truncated to its first byte instead of arriving as an
+  empty datagram. Without the clamp a 0-length buffer makes every `recvfrom`
+  return a 0 count, which -- now that a 0 count means "empty datagram" (see
+  net/UDPEmptyDatagramDelivered) -- would deliver every datagram as empty and
+  silently lose its bytes.
+
+  The sender transmits 3 bytes; the receiver's buffer (0, raised to 1) delivers
+  exactly the first byte, [0]. The size assertion (1, not 0) is what fails if
+  the clamp is removed.
+  """
+  fun name(): String => "net/UDPZeroSizeReadBufferDelivers"
+  fun exclusion_group(): String => "network"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("receiver listen")
+    h.expect_action("sender listen")
+    h.expect_action("receive")
+
+    h.dispose_when_done(
+      UDPSocket.ip4(UDPAuth(h.env.root),
+        recover
+          _TestUDPReadBufferReceiver(h, _AscendingBytes(1), _AscendingBytes(3))
+        end,
+        "127.0.0.1", "0", 0))
 
     h.long_test(TimeoutValue())
 

--- a/packages/net/udp_notify.pony
+++ b/packages/net/udp_notify.pony
@@ -40,6 +40,8 @@ interface UDPNotify
     bytes were lost. To receive whole datagrams, size the read buffer to your
     protocol's largest expected datagram (the UDP maximum is 65507 bytes for
     IPv4).
+
+    A zero-length datagram is valid and is delivered here with an empty `data`.
     """
     None
 

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -113,15 +113,16 @@ actor UDPSocket is AsioEventNotify
     `size` is the read buffer size in bytes (default 1024) and therefore the
     maximum datagram length delivered to `UDPNotify.received`; a larger datagram
     is truncated to `size` and the excess is silently discarded (see
-    `UDPNotify.received`).
+    `UDPNotify.received`). A `size` of 0 is raised to 1, so an empty delivery to
+    `received` always means an empty datagram, never a dropped one.
     """
     _notify = consume notify
     _event =
       @pony_os_listen_udp(this, host.cstring(), service.cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname(_fd, _ip)
-    _packet_size = size
-    _read_buf = recover Array[U8] .> undefined(size) end
+    _packet_size = size.max(1)
+    _read_buf = recover Array[U8] .> undefined(_packet_size) end
     _notify_listening()
 
   new ip4(
@@ -137,15 +138,16 @@ actor UDPSocket is AsioEventNotify
     `size` is the read buffer size in bytes (default 1024) and therefore the
     maximum datagram length delivered to `UDPNotify.received`; a larger datagram
     is truncated to `size` and the excess is silently discarded (see
-    `UDPNotify.received`).
+    `UDPNotify.received`). A `size` of 0 is raised to 1, so an empty delivery to
+    `received` always means an empty datagram, never a dropped one.
     """
     _notify = consume notify
     _event =
       @pony_os_listen_udp4(this, host.cstring(), service.cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname(_fd, _ip)
-    _packet_size = size
-    _read_buf = recover Array[U8] .> undefined(size) end
+    _packet_size = size.max(1)
+    _read_buf = recover Array[U8] .> undefined(_packet_size) end
     _notify_listening()
 
   new ip6(
@@ -161,15 +163,16 @@ actor UDPSocket is AsioEventNotify
     `size` is the read buffer size in bytes (default 1024) and therefore the
     maximum datagram length delivered to `UDPNotify.received`; a larger datagram
     is truncated to `size` and the excess is silently discarded (see
-    `UDPNotify.received`).
+    `UDPNotify.received`). A `size` of 0 is raised to 1, so an empty delivery to
+    `received` always means an empty datagram, never a dropped one.
     """
     _notify = consume notify
     _event =
       @pony_os_listen_udp6(this, host.cstring(), service.cstring())
     _fd = @pony_asio_event_fd(_event)
     @pony_os_sockname(_fd, _ip)
-    _packet_size = size
-    _read_buf = recover Array[U8] .> undefined(size) end
+    _packet_size = size.max(1)
+    _read_buf = recover Array[U8] .> undefined(_packet_size) end
     _notify_listening()
 
   be write(data: ByteSeq, to: NetAddress) =>
@@ -322,9 +325,10 @@ actor UDPSocket is AsioEventNotify
 
   fun ref _pending_reads() =>
     """
-    Read while data is available, guessing the next packet length as we go. If
-    we read 4 kb of data, send ourself a resume message and stop reading, to
-    avoid starving other actors.
+    Read while data is available, guessing the next packet length as we go.
+    Once about 4 kb of read work accumulates, send ourself a resume message and
+    stop reading, to avoid starving other actors. A zero-byte datagram counts
+    as 1 byte of work so a flood of empty datagrams cannot loop here forever.
     """
     try
       var sum: USize = 0
@@ -341,7 +345,10 @@ actor UDPSocket is AsioEventNotify
           data.truncate(count)
           _notify.received(this, consume data, consume from)
 
-          sum = sum + count
+          // An empty datagram is delivered as OK with count 0; charge it 1
+          // byte so a flood still advances the read budget and yields.
+          // Coupling: .known-couplings/udp-empty-datagram-read-budget.md
+          sum = sum + count.max(1)
 
           if sum > (1 << 12) then
             _read_again()

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -948,8 +948,11 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
     *count_out = 0;
     return PONY_SOCKET_ERROR;
   } else if(recvd == 0) {
+    // A 0-byte UDP recvfrom is a valid zero-length datagram (RFC 768), not a
+    // peer close as it would be for stream pony_os_recv. Deliver it, don't
+    // error (issue #5289).
     *count_out = 0;
-    return PONY_SOCKET_ERROR;
+    return PONY_SOCKET_OK;
   }
 
   *count_out = (size_t)recvd;
@@ -971,8 +974,11 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
     *count_out = 0;
     return PONY_SOCKET_ERROR;
   } else if(recvd == 0) {
+    // A 0-byte UDP recvfrom is a valid zero-length datagram (RFC 768), not a
+    // peer close as it would be for stream pony_os_recv. Deliver it, don't
+    // error (issue #5289).
     *count_out = 0;
-    return PONY_SOCKET_ERROR;
+    return PONY_SOCKET_OK;
   }
 
   *count_out = (size_t)recvd;

--- a/src/libponyrt/lang/socket.h
+++ b/src/libponyrt/lang/socket.h
@@ -16,6 +16,10 @@ PONY_EXTERN_C_BEGIN
 //                          every platform (the Windows backend uses readiness
 //                          notifications, not overlapped IOCP), so the count
 //                          is always the bytes transferred by this call.
+//                          A datagram pony_os_recvfrom may return OK with a 0
+//                          count: an empty UDP datagram (RFC 768) is a valid
+//                          read, unlike stream pony_os_recv where a 0-byte read
+//                          means the peer closed (ERROR, below).
 //   PONY_SOCKET_RETRY = 1  transient condition (POSIX EWOULDBLOCK/EAGAIN,
 //                          Windows WSAEWOULDBLOCK on send/writev). Caller
 //                          should retry later. *count_out is 0.


### PR DESCRIPTION
UDP sockets now deliver zero-byte datagrams to `UDPNotify.received` with an empty payload instead of treating them as an error and closing the socket.

A zero-length UDP datagram is valid per RFC 768. The runtime was erroring on a 0-byte `recvfrom`, which is right for a stream `recv` — 0 bytes means the peer closed — but wrong for connectionless UDP, where it has no such meaning. Applications using empty datagrams as heartbeats, keepalives, or presence pings had the socket torn down under them.

`pony_os_recvfrom` now returns `PONY_SOCKET_OK` with a 0 count for an empty datagram on both POSIX and Windows; TCP `pony_os_recv` is unchanged. Because empty datagrams now deliver, the UDP read loop charges each read at least one byte against its yield budget so a flood of them can't keep one actor on its scheduler thread.

A read buffer `size` of 0 is now raised to 1 at construction. Otherwise a 0-length buffer would make `recvfrom` return a 0 count for every datagram, empty or not, so a non-empty datagram would be delivered as empty and its bytes lost — a 0 count now unambiguously means an empty datagram.

Closes #5289
