### PR TITLE
Add `rewind()` to ArrayKeys and ArrayPairs

### DIFF
--- a/.release-notes/5645.md
+++ b/.release-notes/5645.md
@@ -1,0 +1,24 @@
+## Add `rewind()` to `ArrayKeys` and `ArrayPairs`
+
+Replicate the `fun ref rewind()` functionality from `ArrayValues` to `ArrayKeys` and `ArrayPairs`.
+This enables reuse of the same `ArrayKeys` or `ArrayPairs` iterator without creating a new one.
+The main use case is when an iterator is passed down to other scopes, and you don't want to pass around
+references to the source array just to rewind the iterator.
+
+Example:
+
+```ponyc
+let array: Array[USize] = recover [as F32: 1;2;3;4;5] end
+let keys = array.keys()
+for key in keys do
+  // your code here
+end
+
+// rewind the keys iterator
+keys.rewind()
+
+// perform another iteration
+for key in keys do
+  // your code here
+end
+```

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -969,6 +969,10 @@ class ArrayKeys[A, B: Array[A] #read] is Iterator[USize]
       _i
     end
 
+  fun ref rewind(): ArrayKeys[A, B] =>
+    _i = 0
+    this
+
 class ArrayValues[A, B: Array[A] #read] is Iterator[B->A]
   let _array: B
   var _i: USize
@@ -1000,3 +1004,7 @@ class ArrayPairs[A, B: Array[A] #read] is Iterator[(USize, B->A)]
 
   fun ref next(): (USize, B->A) ? =>
     (_i, _array(_i = _i + 1)?)
+
+  fun ref rewind(): ArrayPairs[A, B] =>
+    _i = 0
+    this

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -42,6 +42,8 @@ actor \nodoc\ Main is TestList
     test(_TestArrayTrimInPlaceWithAppend)
     test(_TestArrayUnchop)
     test(_TestArrayValuesRewind)
+    test(_TestArrayKeysRewind)
+    test(_TestArrayPairsRewind)
     test(_TestDivc)
     test(_TestFld)
     test(_TestFldc)
@@ -1725,6 +1727,30 @@ class \nodoc\ iso _TestArrayInsert is UnitTest
 
     h.assert_error({() ? => ["one"; "three"].insert(3, "invalid")? })
 
+class \nodoc\ iso _TestArrayKeysRewind is UnitTest
+  """
+  Test rewinding an ArrayKeys object
+  """
+  fun name(): String => "builtin/ArrayKeys.rewind"
+
+  fun apply(h: TestHelper) =>
+    let av = [as U32: 1; 2; 3; 4].keys()
+
+    h.assert_eq[USize](0, av.next())
+    h.assert_eq[USize](1, av.next())
+    h.assert_eq[USize](2, av.next())
+    h.assert_eq[USize](3, av.next())
+    h.assert_eq[Bool](false, av.has_next())
+
+    av.rewind()
+
+    h.assert_eq[Bool](true, av.has_next())
+    h.assert_eq[USize](0, av.next())
+    h.assert_eq[USize](1, av.next())
+    h.assert_eq[USize](2, av.next())
+    h.assert_eq[USize](3, av.next())
+    h.assert_eq[Bool](false, av.has_next())
+
 class \nodoc\ iso _TestArrayValuesRewind is UnitTest
   """
   Test rewinding an ArrayValues object
@@ -1748,6 +1774,41 @@ class \nodoc\ iso _TestArrayValuesRewind is UnitTest
     h.assert_eq[U32](3, av.next()?)
     h.assert_eq[U32](4, av.next()?)
     h.assert_eq[Bool](false, av.has_next())
+
+class \nodoc\ iso _TestArrayPairsRewind is UnitTest
+  """
+  Test rewinding an ArrayPairs object
+  """
+  fun name(): String => "builtin/ArrayPairs.rewind"
+
+  fun apply(h: TestHelper) ? =>
+    let av = [as U32: 1; 2; 3; 4].pairs()
+
+    var idx: USize = 0
+    var v: U32 = 1
+    while av.has_next() do
+      (let idx': USize, let v': U32) = av.next()?
+      h.assert_eq[USize](idx, idx')
+      h.assert_eq[U32](v, v')
+      idx = idx + 1
+      v = v + 1
+    end
+    h.assert_eq[Bool](false, av.has_next())
+    h.assert_eq[USize](4, idx)
+
+    av.rewind()
+    idx = 0
+    v = 1
+
+    while av.has_next() do
+      (let idx': USize, let v': U32) = av.next()?
+      h.assert_eq[USize](idx, idx')
+      h.assert_eq[U32](v, v')
+      idx = idx + 1
+      v = v + 1
+    end
+    h.assert_eq[Bool](false, av.has_next())
+    h.assert_eq[USize](4, idx)
 
 class \nodoc\ _FindTestCls
   let i: ISize


### PR DESCRIPTION
ArrayValues has `fun ref rewind()` which resets the internal pointer `_i = 0`. This is useful, but sometimes you want the same for `ArrayKeys` and `ArrayPairs` which do not have this method, requiring the iterator itself to be recreated each time.

- This PR adds the rewind() function to ArrayPairs and ArrayKeys, as well as tests in the `builtin_test` test package.
