### PR TITLE
Fix executables failing to start on Linux systems with both glibc and musl

### DIFF
--- a/.known-couplings/pass-opt-struct-mirror.md
+++ b/.known-couplings/pass-opt-struct-mirror.md
@@ -1,0 +1,7 @@
+# `pass_opt_t` struct layout (`src/libponyc/pass/pass.h`)
+
+The Pony tools (`pony-compiler`, `pony-lint`, `pony-lsp`, `pony-doc`) reach libponyc's options through an FFI struct `_PassOpt` in `tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony`, which must have the same memory layout as the C `pass_opt_t`. Adding, removing, or reordering a field in `pass_opt_t` — even a bool that currently lands in existing padding — must be mirrored in `_PassOpt`, or a later field addition shifts every offset below it and the tools read garbage. `_PassOpt` keeps `strtab` last and `llvm_args` unconditional for exactly this reason (see the comments there).
+
+This is the struct-layout sibling of the `pass_id` enum coupling in `pass-id-enum.md`; both live in `pass.h` and both mirror into `pass.pony`.
+
+Run: `make test-pony-compiler`, `make test-pony-lint`, `make test-pony-lsp`, `make test-pony-doc`.

--- a/.release-notes/fix-libc-loader-detection.md
+++ b/.release-notes/fix-libc-loader-detection.md
@@ -1,0 +1,5 @@
+## Fix executables failing to start on Linux systems with both glibc and musl
+
+On Linux systems that have both the GNU (glibc) and musl C libraries installed, `ponyc` could build a program that was linked against one C library but set up to load the other at startup. Compilation succeeded, but the program failed the moment you ran it, printing messages such as `Error loading shared library` or `symbol not found`.
+
+`ponyc` now selects the startup loader that matches the C library your program is linked against. If you pass an explicit `--triple`, `ponyc` honors your choice instead of guessing from what is installed on the build machine.

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -757,6 +757,10 @@ bool codegen_pass_init(pass_opt_t* opt)
   // Default triple, cpu and features.
   if(opt->triple != NULL)
   {
+    // The user provided a target triple; treat it as authoritative for libc
+    // detection (see target_libc_is_musl). A defaulted triple (else branch)
+    // leaves user_triple false via pass_opt_init's zeroing.
+    opt->user_triple = true;
     triple = LLVMCreateMessage(opt->triple);
   } else {
 #if defined(PLATFORM_IS_MACOSX) && defined(PLATFORM_IS_ARM)

--- a/src/libponyc/codegen/gencshim.cc
+++ b/src/libponyc/codegen/gencshim.cc
@@ -849,11 +849,16 @@ bool gencshim(ast_t* program, pass_opt_t* opt)
   // headers, and the vendored driver does the same (clang's
   // ToolChains/Linux.cpp). Diverging here would give Alpine shims
   // different headers than every other clang compile on that platform.
-  bool builtin_include_last;
-  {
-    llvm::Triple target_triple(opt->triple);
-    builtin_include_last = target_triple.isMusl() || host_is_musl(opt);
-  }
+  // Detect musl the same way the ELF linker does, so a shim's header ordering
+  // and the executable's dynamic linker never disagree about the target libc.
+  // target_libc_is_musl is part of genexe's ELF-linking surface (POSIX only);
+  // on non-POSIX targets the libc is never musl, so the triple's own view is
+  // all that is needed.
+#ifdef PLATFORM_IS_POSIX_BASED
+  bool builtin_include_last = target_libc_is_musl(opt);
+#else
+  bool builtin_include_last = llvm::Triple(opt->triple).isMusl();
+#endif
 
   int written = snprintf(buf, sizeof(buf), "%s%cinclude", resource_dir,
     PATH_SLASH);

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -261,8 +261,11 @@ LLVMValueRef gen_main(compile_t* c, reach_type_t* t_main, reach_type_t* t_env)
 }
 
 #ifdef PLATFORM_IS_POSIX_BASED
-// is_cross_compiling, host_is_musl, and system_triple are shared with gencshim
-// and live in genopt (declared in genopt.h); both take pass_opt_t.
+// is_cross_compiling and system_triple are shared with gencshim and live in
+// genopt (declared in genopt.h); both take pass_opt_t.
+// target_libc_is_musl (defined below, declared in genexe.h) is likewise shared
+// with gencshim: the interpreter choice and the shim header ordering both call
+// it so they can never disagree about the target libc.
 
 static const char* elf_emulation(compile_t* c)
 {
@@ -357,7 +360,7 @@ static const char* dynamic_linker_path(compile_t* c)
   if(target_is_openbsd(c->opt->triple))
     return "/usr/libexec/ld.so";
 
-  bool is_musl = triple.isMusl() || host_is_musl(c->opt);
+  bool is_musl = target_libc_is_musl(c->opt);
 
   switch(triple.getArch())
   {
@@ -460,25 +463,16 @@ static bool elf_matches_target(const char* path, uint16_t target_machine)
   return machine == target_machine;
 }
 
-static const char* find_libc_crt_dir(const char* sysroot,
-  const char* sys_triple, uint16_t target_machine, strtable_t* strtab)
+// The standard sysroot library directories, in search order, where a target's
+// libc startup objects and shared libraries live. Shared by find_libc_crt_dir
+// (which looks for crt1.o/crt0.o) and target_libc_is_musl (which looks for
+// libc.so.6) so both search the same set -- including non-usr-merged layouts
+// where /lib/<triple> and /usr/lib/<triple> are distinct directories. The lib64
+// entries cover Fedora/RHEL and other distros that place 64-bit objects in
+// /usr/lib64 rather than /usr/lib/<triple> or /usr/lib.
+static void libc_lib_dirs(const char* sysroot, const char* sys_triple,
+  strtable_t* strtab, const char* candidates[6])
 {
-  // Search candidate paths for libc CRT objects.
-  // The lib64 candidates cover Fedora, RHEL, and other distros that
-  // place 64-bit libc startup objects in /usr/lib64 rather than
-  // /usr/lib/<triple> or /usr/lib.
-  //
-  // Per candidate, try crt1.o first (Linux/FreeBSD/DragonFly), then
-  // crt0.o (OpenBSD, which has no crt1.o at all). The sentinel is
-  // validated against the target architecture via elf_matches_target.
-  // On multilib hosts (e.g. an x86_64 system with glibc-devel.i686
-  // installed) /usr/lib/crt1.o is the 32-bit object while
-  // /usr/lib64/crt1.o is the 64-bit one — without arch validation the
-  // search would return /usr/lib and the link would fail later inside
-  // LLD with an arch-mismatch error. Validating the sentinel alone is
-  // sufficient because the multilib/per-OS layouts ship matched sets of
-  // startup objects in each directory.
-  const char* candidates[6];
   char buf[PATH_MAX];
 
   snprintf(buf, sizeof(buf), "%s/usr/lib/%s", sysroot, sys_triple);
@@ -498,8 +492,25 @@ static const char* find_libc_crt_dir(const char* sysroot,
 
   snprintf(buf, sizeof(buf), "%s/lib64", sysroot);
   candidates[5] = stringtab(strtab, buf);
+}
+
+static const char* find_libc_crt_dir(const char* sysroot,
+  const char* sys_triple, uint16_t target_machine, strtable_t* strtab)
+{
+  // Per candidate directory, try crt1.o first (Linux/FreeBSD/DragonFly), then
+  // crt0.o (OpenBSD, which has no crt1.o at all). The sentinel is validated
+  // against the target architecture via elf_matches_target. On multilib hosts
+  // (e.g. an x86_64 system with glibc-devel.i686 installed) /usr/lib/crt1.o is
+  // the 32-bit object while /usr/lib64/crt1.o is the 64-bit one -- without arch
+  // validation the search would return /usr/lib and the link would fail later
+  // inside LLD with an arch-mismatch error. Validating the sentinel alone is
+  // sufficient because the multilib/per-OS layouts ship matched sets of startup
+  // objects in each directory.
+  const char* candidates[6];
+  libc_lib_dirs(sysroot, sys_triple, strtab, candidates);
 
   static const char* sentinels[] = { "crt1.o", "crt0.o" };
+  char buf[PATH_MAX];
 
   for(size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
   {
@@ -512,6 +523,51 @@ static const char* find_libc_crt_dir(const char* sysroot,
   }
 
   return NULL;
+}
+
+bool target_libc_is_musl(pass_opt_t* opt)
+{
+  // Musl is a Linux-only libc. On the BSDs, macOS, and Windows the target is
+  // never musl -- and their libc has no libc.so.6, so the glibc fingerprint
+  // below must not run there or it would misread every non-glibc libc as musl.
+  if(!target_is_linux(opt->triple))
+    return false;
+
+  llvm::Triple triple(opt->triple);
+
+  // An explicit --triple is the user's declaration of the target libc. Honor
+  // it exactly; a host probe must never override what the user asked for.
+  if(opt->user_triple)
+    return triple.isMusl();
+
+  // A default triple can occasionally name musl correctly; trust that. When it
+  // claims gnu we cannot -- the vendored LLVM reports "gnu" even on musl hosts
+  // -- so identify the libc we will actually link instead of trusting it.
+  if(triple.isMusl())
+    return true;
+
+  // Fingerprint the libc we are about to link. glibc always ships libc.so.6 in
+  // one of the standard lib directories; musl never does (its libc is the
+  // dynamic loader itself). Probe the same directories find_libc_crt_dir
+  // searches -- not just the one holding the crt objects -- so a non-usr-merged
+  // layout that splits libc.so.6 (/lib/<triple>) from crt1.o (/usr/lib/<triple>)
+  // still reads as glibc. Found anywhere -> glibc; absent everywhere -> musl.
+  const char* sys_triple = system_triple(opt);
+  const char* sysroot =
+    (opt->sysroot != NULL && opt->sysroot[0] != '\0') ? opt->sysroot : "";
+
+  const char* candidates[6];
+  libc_lib_dirs(sysroot, sys_triple, opt->strtab, candidates);
+
+  char buf[PATH_MAX];
+  for(size_t i = 0; i < sizeof(candidates) / sizeof(candidates[0]); i++)
+  {
+    snprintf(buf, sizeof(buf), "%s/libc.so.6", candidates[i]);
+    if(file_exists(buf))
+      return false;
+  }
+
+  return true;
 }
 
 static const char* find_ponyc_crt_dir(ast_t* program, compile_t* c)

--- a/src/libponyc/codegen/genexe.h
+++ b/src/libponyc/codegen/genexe.h
@@ -19,6 +19,19 @@ bool genexe(compile_t* c, ast_t* program);
  * emitting the "requires --sysroot" error when none is found.
  */
 const char* find_cross_toolchain_sysroot(pass_opt_t* opt, errors_t* errors);
+
+/** Whether the target C library is musl.
+ *
+ * Musl exists only on Linux; the result is false for every other target. An
+ * explicit --triple is authoritative and is never overridden. Otherwise the
+ * libc that will actually be linked is identified directly: glibc ships
+ * libc.so.6 alongside its crt startup objects and musl never does, so the
+ * dynamic linker stamped into the executable stays consistent with the libc
+ * it is linked against. Shared with the C shim compiler (gencshim) so a
+ * build's interpreter choice and its shim header ordering agree. Not
+ * memoized -- a handful of stat() calls, recomputed at each call site.
+ */
+bool target_libc_is_musl(pass_opt_t* opt);
 #endif
 
 PONY_EXTERN_C_END

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -1319,35 +1319,6 @@ bool is_cross_compiling(pass_opt_t* opt)
     || target.getEnvironment() != host.getEnvironment();
 }
 
-bool host_is_musl(pass_opt_t* opt)
-{
-  if(is_cross_compiling(opt))
-    return false;
-
-  Triple triple(opt->triple);
-  const char* musl_linker = NULL;
-
-  switch(triple.getArch())
-  {
-    case Triple::x86_64:  musl_linker = "/lib/ld-musl-x86_64.so.1"; break;
-    case Triple::aarch64: musl_linker = "/lib/ld-musl-aarch64.so.1"; break;
-    case Triple::riscv64: musl_linker = "/lib/ld-musl-riscv64.so.1"; break;
-
-    case Triple::arm:
-    case Triple::thumb:
-    {
-      struct stat st;
-      return (stat("/lib/ld-musl-armhf.so.1", &st) == 0)
-        || (stat("/lib/ld-musl-arm.so.1", &st) == 0);
-    }
-
-    default: return false;
-  }
-
-  struct stat st;
-  return stat(musl_linker, &st) == 0;
-}
-
 // Twin of genexe.cc's gnu_multiarch_arch (keep the two in sync): LLVM reports
 // 32-bit little-endian ARM as the raw triple arch ("armv7l", "armv6", etc.),
 // but Debian/Ubuntu/Raspbian multiarch directories normalize all of them to

--- a/src/libponyc/codegen/genopt.h
+++ b/src/libponyc/codegen/genopt.h
@@ -37,11 +37,6 @@ bool target_is_littleendian(char* triple);
 // triple says "darwin" and the target says "macosx".
 bool is_cross_compiling(pass_opt_t* opt);
 
-// True if the native host is actually musl. The vendored LLVM's default
-// triple may claim "gnu" on musl systems, so for native builds this probes
-// the filesystem for the musl loader instead of trusting the triple.
-bool host_is_musl(pass_opt_t* opt);
-
 // The arch-os-environment form distros use for multiarch directories
 // (e.g. x86_64-linux-gnu), interned in opt->strtab.
 const char* system_triple(pass_opt_t* opt);

--- a/src/libponyc/pass/pass.h
+++ b/src/libponyc/pass/pass.h
@@ -299,6 +299,15 @@ typedef struct pass_opt_t
   bool allow_test_symbols;
   bool parse_trace;
 
+  // True when the target triple was explicitly provided (via --triple or set
+  // programmatically) rather than defaulted from the host. An explicit triple
+  // is authoritative for libc detection and must never be overridden by a
+  // host probe. See target_libc_is_musl (genexe).
+  //
+  // Any field change to this struct must be mirrored in _PassOpt (pass.pony);
+  // see .known-couplings/pass-opt-struct-mirror.md.
+  bool user_triple;
+
   strlist_t* package_search_paths;
   strlist_t* safe_packages;
   magic_package_t* magic_packages;

--- a/test/libponyc/codegen.cc
+++ b/test/libponyc/codegen.cc
@@ -5,6 +5,21 @@
 
 #include "util.h"
 
+#include <codegen/genexe.h>
+
+#ifdef PLATFORM_IS_LINUX
+#include <codegen/genopt.h>
+#include <llvm-c/Core.h>
+#include <string>
+#include <vector>
+#include <cstdio>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <cstdlib>
+#endif
+
 #include "llvm_config_begin.h"
 
 #include <llvm/IR/Constants.h>
@@ -326,3 +341,158 @@ TEST_F(CodegenTest, LifetimeIntrinsicsHaveSinglePointerArgument)
   // lifetime markers, or the per-call assertion never runs.
   ASSERT_GT(lifetime_calls, 0u);
 }
+
+// codegen_pass_init marks an explicitly provided triple as user_triple so libc
+// detection treats it as authoritative (see target_libc_is_musl); a defaulted
+// triple leaves it clear.
+extern const char* test_argv0;  // the gtest main's argv[0], defined in util.cc
+
+TEST(CodegenPassInitTest, ExplicitTripleSetsUserTriple)
+{
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+  opt.argv0 = test_argv0;
+  opt.triple = const_cast<char*>("x86_64-unknown-linux-gnu");
+  ASSERT_TRUE(codegen_pass_init(&opt));
+  EXPECT_TRUE(opt.user_triple);
+  codegen_pass_cleanup(&opt);
+  pass_opt_done(&opt);
+}
+
+TEST(CodegenPassInitTest, DefaultTripleLeavesUserTripleClear)
+{
+  pass_opt_t opt;
+  pass_opt_init(&opt);
+  opt.argv0 = test_argv0;
+  ASSERT_TRUE(codegen_pass_init(&opt));
+  EXPECT_FALSE(opt.user_triple);
+  codegen_pass_cleanup(&opt);
+  pass_opt_done(&opt);
+}
+
+#ifdef PLATFORM_IS_LINUX
+
+namespace
+{
+  // Create dir and any missing parents (mkdir -p). Errors (including EEXIST)
+  // are ignored: the file operations that follow fail loudly if a dir is
+  // missing, so a real failure surfaces there.
+  void mkdir_p(const std::string& dir)
+  {
+    for(size_t i = 1; i <= dir.size(); i++)
+    {
+      if((i == dir.size()) || (dir[i] == '/'))
+        mkdir(dir.substr(0, i).c_str(), 0700);
+    }
+  }
+
+  // Create an empty libc.so.6 under <base><subdir> -- the glibc marker the
+  // fingerprint looks for. Its contents are never read, only its presence.
+  bool put_libc_so_6(const std::string& base, const char* subdir)
+  {
+    std::string dir = base + subdir;
+    mkdir_p(dir);
+    int fd = open((dir + "/libc.so.6").c_str(), O_CREAT | O_WRONLY, 0644);
+    if(fd < 0)
+      return false;
+    close(fd);
+    return true;
+  }
+
+  int rm_entry(const char* path, const struct stat*, int, struct FTW*)
+  {
+    remove(path);
+    return 0;
+  }
+
+  void remove_tree(const std::string& base)
+  {
+    nftw(base.c_str(), rm_entry, 16, FTW_DEPTH | FTW_PHYS);
+  }
+
+  // Replace opt->triple, keeping it an LLVM-owned string so TearDown's codegen
+  // cleanup frees it exactly once however the test exits.
+  void set_triple(pass_opt_t* opt, const char* triple)
+  {
+    LLVMDisposeMessage(opt->triple);
+    opt->triple = LLVMCreateMessage(triple);
+  }
+}
+
+// target_libc_is_musl decides the target C library. With no explicit triple it
+// fingerprints the sysroot -- glibc ships libc.so.6 in a standard lib
+// directory, musl never does. An explicit triple, a musl-named default triple,
+// and a non-Linux target each short-circuit that probe.
+TEST_F(CodegenTest, TargetLibcMuslDetection)
+{
+  // Reset opt.sysroot and remove the temp sysroots on every exit path,
+  // including a fatal ASSERT_* (which returns from the test body). opt.triple
+  // is left LLVM-owned throughout, so TearDown frees it independently.
+  std::vector<std::string> roots;
+  struct Cleanup
+  {
+    pass_opt_t* opt;
+    std::vector<std::string>* roots;
+    ~Cleanup()
+    {
+      opt->sysroot = NULL;
+      for(const std::string& root : *roots)
+        remove_tree(root);
+    }
+  } cleanup{&opt, &roots};
+
+  char glibc_tmpl[] = "/tmp/ponyc_libc_glibc_XXXXXX";
+  char musl_tmpl[] = "/tmp/ponyc_libc_musl_XXXXXX";
+  char split_tmpl[] = "/tmp/ponyc_libc_split_XXXXXX";
+  ASSERT_NE(mkdtemp(glibc_tmpl), nullptr);
+  ASSERT_NE(mkdtemp(musl_tmpl), nullptr);
+  ASSERT_NE(mkdtemp(split_tmpl), nullptr);
+  std::string glibc_root = glibc_tmpl;
+  std::string musl_root = musl_tmpl;
+  std::string split_root = split_tmpl;
+  roots.push_back(glibc_root);
+  roots.push_back(musl_root);
+  roots.push_back(split_root);
+
+  // usr-merged glibc: libc.so.6 in /usr/lib. musl: none anywhere. Non-usr-
+  // merged glibc: libc.so.6 in /lib, where crt1.o would sit in /usr/lib.
+  ASSERT_TRUE(put_libc_so_6(glibc_root, "/usr/lib"));
+  ASSERT_TRUE(put_libc_so_6(split_root, "/lib"));
+
+  // A gnu, non-musl Linux triple so the fingerprint runs. It tests for
+  // libc.so.6 by path with no ELF/arch validation, so a fixed triple keeps the
+  // test host-independent. opt.triple stays LLVM-owned (see set_triple).
+  set_triple(&opt, "x86_64-unknown-linux-gnu");
+  opt.user_triple = false;
+
+  // libc.so.6 present in a standard lib dir -> glibc.
+  opt.sysroot = const_cast<char*>(glibc_root.c_str());
+  ASSERT_FALSE(target_libc_is_musl(&opt));
+
+  // libc.so.6 absent everywhere -> musl.
+  opt.sysroot = const_cast<char*>(musl_root.c_str());
+  ASSERT_TRUE(target_libc_is_musl(&opt));
+
+  // Non-usr-merged split (libc.so.6 in /lib, not beside the crt dir) -> glibc.
+  opt.sysroot = const_cast<char*>(split_root.c_str());
+  ASSERT_FALSE(target_libc_is_musl(&opt));
+
+  // An explicit --triple wins over the fingerprint: musl-looking sysroot, gnu
+  // triple -> glibc.
+  opt.sysroot = const_cast<char*>(musl_root.c_str());
+  opt.user_triple = true;
+  ASSERT_FALSE(target_libc_is_musl(&opt));
+
+  // A non-Linux target is never musl, whatever the host filesystem holds.
+  opt.user_triple = false;
+  set_triple(&opt, "x86_64-unknown-freebsd");
+  ASSERT_FALSE(target_libc_is_musl(&opt));
+
+  // A default triple that already names musl is trusted without probing -- the
+  // glibc-looking sysroot must not flip it back.
+  set_triple(&opt, "x86_64-unknown-linux-musl");
+  opt.sysroot = const_cast<char*>(glibc_root.c_str());
+  ASSERT_TRUE(target_libc_is_musl(&opt));
+}
+
+#endif

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/pass.pony
@@ -68,6 +68,9 @@ struct _PassOpt
   var ast_print_width: USize = 0
   var allow_test_symbols: Bool = false
   var parse_trace: Bool = false
+  // Mirrors pass_opt_t.user_triple (pass.h). See
+  // .known-couplings/pass-opt-struct-mirror.md.
+  var user_triple: Bool = false
 
   var package_search_paths: Pointer[_StrList] = package_search_paths.create()
   var safe_packages: Pointer[_StrList] = safe_packages.create()


### PR DESCRIPTION
On a Linux host that uses glibc but also has the musl dynamic loader installed, ponyc stamped musl's linker into executables that were linked against glibc. They compiled, but failed to start with errors like `Error loading shared library` or `symbol not found`. Passing an explicit `--triple=...-gnu` did not help: ponyc probed the filesystem for the musl loader and let that probe override the triple.

The target C library is now determined explicitly. An explicit `--triple` is authoritative. Otherwise the libc is whichever one the sysroot actually has: glibc ships `libc.so.6` in a standard lib directory, musl never does. The same detection drives both the executable's dynamic linker and the C-shim header ordering, so they can't disagree, and the old musl-loader probe is gone.
