### PR TITLE
Fix json package emitting invalid JSON for non-finite floating-point values

### DIFF
--- a/.release-notes/fix-json-non-finite-floats.md
+++ b/.release-notes/fix-json-non-finite-floats.md
@@ -1,0 +1,20 @@
+## Fix json package emitting invalid JSON for non-finite floating-point values
+
+The `json` package serialized a non-finite floating-point number — infinity or NaN — as the bare word `inf`, `-inf`, `nan`, or `-nan`. None of those are valid JSON, so the output could not be parsed back, including by the package's own parser. A non-finite value now serializes as `null`.
+
+```pony
+let inf = F64(1e308) * F64(10)
+JsonPrinter.print(JsonObject.update("v", inf))
+// before: {"v":inf}   (not valid JSON)
+// after:  {"v":null}
+```
+
+Relatedly, parsing a numeric literal outside `F64` range — such as `1e999`, or an integer of several hundred digits — used to succeed, producing one of these non-finite values. Such a literal is now rejected as a parse error.
+
+```pony
+JsonParser.parse("1e999")
+// before: a non-finite F64 that cannot be serialized back to valid JSON
+// after:  a JsonParseError, "Number out of range"
+```
+
+Number parsing is also more accurate at the extremes: a literal that is mathematically zero but written with a large exponent (`0e309`) previously parsed to NaN, and some in-range literals with very long digit runs parsed to infinity or a slightly wrong value — these now parse correctly.

--- a/packages/json/_json_print.pony
+++ b/packages/json/_json_print.pony
@@ -196,14 +196,23 @@ primitive _JsonPrint
     consume b
 
   fun _float(buf: String iso, n: F64): String iso^ =>
+    // RFC 8259 has no representation for infinity or NaN, so emit `null`: the
+    // printer must always produce parseable JSON. `JsonParser` rejects
+    // out-of-range literals, so a non-finite value reaches here only when one
+    // is constructed directly.
+    if not n.finite() then
+      buf.append("null")
+      return consume buf
+    end
     let s: String = n.string()
     buf.append(s)
+    // A whole-number float prints without `.`/`e`/`E`; add `.0` so it re-parses
+    // as a float, not an integer. `s` is finite here, so it never contains
+    // `inf`/`nan`.
     if
       (not s.contains("."))
         and (not s.contains("e"))
         and (not s.contains("E"))
-        and (not s.contains("inf"))
-        and (not s.contains("nan"))
     then
       buf.append(".0")
     end

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -62,15 +62,18 @@ actor \nodoc\ Main is TestList
     test(_TestParseErrorLoneSurrogates)
     test(_TestParseErrors)
     test(_TestParseKeywords)
+    test(_TestParseNumberOutOfRange)
     test(_TestParseNumbers)
     test(_TestParseStrings)
     test(_TestParseWholeDocument)
     test(_TestPrintCompact)
     test(_TestPrintFloats)
+    test(_TestPrintNonFinite)
     test(_TestPrintPretty)
     test(_TestPrinterPretty)
     test(_TestPrinterScalars)
     test(_TestTokenParserAbort)
+    test(_TestTokenParserReuseAfterError)
     // Regression tests — stack-safe JSON walks (issue #5557)
     test(_TestParseDeeplyNested)
     test(_TestPrintDeeplyNested)
@@ -544,6 +547,18 @@ class \nodoc\ iso _TestParseNumbers is UnitTest
     else h.fail("large integer failed")
     end
 
+    // The I64/F64 promotion boundary: 18 digits stays an integer, 19 becomes a
+    // float even though it would still fit I64.
+    match JsonParser.parse("999999999999999999") // 18 nines
+    | let j: JsonValue => h.assert_eq[I64](999999999999999999, j as I64)
+    else h.fail("18-digit integer failed")
+    end
+
+    match JsonParser.parse("1000000000000000000") // 19 digits
+    | let j: JsonValue => h.assert_true((j as F64).finite())
+    else h.fail("19-digit integer failed")
+    end
+
     // Zero alone is valid
     match JsonParser.parse("0")
     | let j: JsonValue => h.assert_eq[I64](0, j as I64)
@@ -556,6 +571,92 @@ class \nodoc\ iso _TestParseNumbers is UnitTest
       let f = j as F64
       h.assert_true((f - 0.5).abs() < 1e-10)
     else h.fail("0.5 failed")
+    end
+
+    // A zero written with a large exponent is still zero.
+    match JsonParser.parse("0e309")
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true(f.finite())
+      h.assert_eq[F64](0, f)
+    else h.fail("0e309 failed")
+    end
+
+    match JsonParser.parse("0.0e999")
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true(f.finite())
+      h.assert_eq[F64](0, f)
+    else h.fail("0.0e999 failed")
+    end
+
+    match JsonParser.parse("-0e309")
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true(f.finite())
+      h.assert_eq[F64](0, f)
+    else h.fail("-0e309 failed")
+    end
+
+    // The largest power-of-ten literal that stays finite; 1e309 overflows.
+    match JsonParser.parse("1e308")
+    | let j: JsonValue => h.assert_true((j as F64).finite())
+    else h.fail("1e308 failed")
+    end
+
+    // In range, but an intermediate would over- or underflow if the value were
+    // built digit by digit, so the conversion must be correctly rounded: here
+    // 1e320 (integer part, over F64) times 1e-310 (exponent) is 1e10.
+    match JsonParser.parse("1" + "0".mul(320) + "e-310")
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true(f.finite())
+      h.assert_true((f - 1e10).abs() < 1.0)
+    else h.fail("large integer with negative exponent failed")
+    end
+
+    // A nonzero fraction whose leading zeros underflow if summed term by term,
+    // pulled back into range by the exponent.
+    match JsonParser.parse("0." + "0".mul(320) + "1e320") // ~0.1
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true((f - 0.1).abs() < 1e-9)
+    else h.fail("tiny fraction with large exponent failed")
+    end
+
+    // Below the smallest positive F64: underflows to 0 and is accepted, not
+    // rejected as out of range.
+    match JsonParser.parse("1e-400")
+    | let j: JsonValue =>
+      let f = j as F64
+      h.assert_true(f.finite())
+      h.assert_eq[F64](0, f)
+    else h.fail("1e-400 failed")
+    end
+
+class \nodoc\ iso _TestParseNumberOutOfRange is UnitTest
+  fun name(): String => "json/parse/number-out-of-range"
+
+  fun apply(h: TestHelper) =>
+    // A literal whose magnitude exceeds F64 range is rejected as a parse error,
+    // not parsed to a non-finite value the printer cannot serialize. RFC 8259
+    // permits limiting numeric range.
+    _assert_out_of_range(h, "1e999")
+    _assert_out_of_range(h, "-1e999")
+    _assert_out_of_range(h, "1e400")
+    _assert_out_of_range(h, "2e308")
+    // Nested, so the error surfaces mid-document (offset < size), not at EOF.
+    _assert_out_of_range(h, "[1e999]")
+    // A long integer with no exponent overflows F64 too (310 digits).
+    _assert_out_of_range(h, "1" + "0".mul(309))
+
+  fun _assert_out_of_range(h: TestHelper, input: String) =>
+    match \exhaustive\ JsonParser.parse(input)
+    | let e: JsonParseError =>
+      // The distinct message matters: without it the location-only fallback
+      // misreports the whole-literal case as "Unexpected end of JSON".
+      h.assert_eq[String]("Number out of range", e.message)
+    | let _: JsonValue => h.fail("Expected out-of-range error for: " + input)
     end
 
 class \nodoc\ iso _TestParseStrings is UnitTest
@@ -702,6 +803,17 @@ class \nodoc\ iso _TestParseErrors is UnitTest
     _assert_parse_error(h, "00", "double zero")
     _assert_parse_error(h, "-01", "negative leading zero")
 
+    // Malformed numbers: a fraction or exponent needs at least one digit, and a
+    // sign needs digits after it.
+    _assert_parse_error(h, "1.", "trailing dot")
+    _assert_parse_error(h, "1.e5", "dot with no fraction digit")
+    _assert_parse_error(h, "1e", "exponent with no digit")
+    _assert_parse_error(h, "1E", "capital exponent with no digit")
+    _assert_parse_error(h, "1e+", "exponent sign with no digit")
+    _assert_parse_error(h, "1e-", "negative exponent with no digit")
+    _assert_parse_error(h, "1..2", "double dot")
+    _assert_parse_error(h, "-", "lone minus")
+
     // Raw control char (byte < 0x20)
     let ctrl = recover val
       let s = String(3)
@@ -824,6 +936,41 @@ class \nodoc\ iso _TestPrintFloats is UnitTest
     let zero = JsonArray.push(F64(0))
     let zero_s: String val = zero.print()
     h.assert_eq[String]("[0.0]", zero_s)
+
+class \nodoc\ iso _TestPrintNonFinite is UnitTest
+  fun name(): String => "json/print/non-finite"
+
+  fun apply(h: TestHelper) =>
+    // A non-finite F64 (infinity or NaN) has no JSON representation, so it
+    // serializes as `null` — the printer must always produce valid JSON.
+    let inf: F64 = F64(1e308) * F64(10)
+    let neg_inf: F64 = -inf
+    let nan: F64 = inf - inf
+
+    // Guard: confirm the inputs really are non-finite.
+    h.assert_false(inf.finite())
+    h.assert_false(neg_inf.finite())
+    h.assert_false(nan.finite())
+
+    h.assert_eq[String]("null", JsonPrinter.print(inf))
+    h.assert_eq[String]("null", JsonPrinter.print(neg_inf))
+    h.assert_eq[String]("null", JsonPrinter.print(nan))
+
+    // Inside a container, compact and pretty.
+    h.assert_eq[String]("""{"v":null}""",
+      JsonPrinter.print(JsonObject.update("v", inf)))
+    h.assert_eq[String]("[null,null]",
+      JsonPrinter.print(JsonArray.push(inf).push(nan)))
+    h.assert_eq[String]("[\n  null\n]",
+      JsonPrinter.pretty(JsonArray.push(neg_inf)))
+
+    // The direct print methods on JsonArray/JsonObject route through the same
+    // path, so they coerce too.
+    h.assert_eq[String]("[null]", JsonArray.push(inf).print())
+
+    // A finite float is unaffected — whole numbers still keep a `.0`.
+    h.assert_eq[String]("1.0", JsonPrinter.print(F64(1)))
+    h.assert_eq[String]("2.5", JsonPrinter.print(F64(2.5)))
 
 class \nodoc\ iso _TestPrinterPretty is UnitTest
   fun name(): String => "json/printer/pretty"
@@ -1536,6 +1683,34 @@ class \nodoc\ iso _TestTokenParserAbort is UnitTest
       raised = true
     end
     h.assert_true(raised)
+
+class \nodoc\ iso _TestTokenParserReuseAfterError is UnitTest
+  fun name(): String => "json/tokenparser/reuse-after-error"
+
+  fun apply(h: TestHelper) =>
+    // Reusing a JsonTokenParser after an out-of-range error must not leak the
+    // stale "Number out of range" message into a later document's error. This
+    // guards the _error_message reset in parse().
+    let parser = JsonTokenParser(
+      object ref is JsonTokenNotify
+        fun ref apply(parser': JsonTokenParser, token: JsonToken) => None
+      end)
+
+    try
+      parser.parse("1e999")?
+      h.fail("1e999 should have raised")
+    else
+      h.assert_eq[String]("Number out of range", parser.describe_error())
+    end
+
+    // A later, different error on the same instance reports its own message,
+    // not the stale one.
+    try
+      parser.parse("[")?
+      h.fail("unterminated array should have raised")
+    else
+      h.assert_true(parser.describe_error() != "Number out of range")
+    end
 
 // ===================================================================
 // Property Tests — JSONPath Filter Safety

--- a/packages/json/json_parser.pony
+++ b/packages/json/json_parser.pony
@@ -11,6 +11,10 @@ primitive JsonParser
 
   Built on top of JsonTokenParser — the token parser handles all parsing
   logic, and an internal tree builder assembles the result.
+
+  A numeric literal outside `F64` range — for example `1e999`, or an integer of
+  several hundred digits — is rejected as a parse error rather than parsed to a
+  non-finite value. RFC 8259 permits an implementation to limit numeric range.
   """
 
   fun parse(source: String): (JsonValue | JsonParseError) =>

--- a/packages/json/json_printer.pony
+++ b/packages/json/json_printer.pony
@@ -24,6 +24,9 @@ primitive JsonPrinter
   JsonPrinter.print(true)   // true
   JsonPrinter.print("hi")   // "hi"
   ```
+
+  A non-finite `F64` — infinity or NaN — has no JSON representation (RFC 8259
+  numbers are finite), so it serializes as `null`.
   """
 
   fun print(value: JsonValue): String iso^ =>

--- a/packages/json/json_token_parser.pony
+++ b/packages/json/json_token_parser.pony
@@ -1,3 +1,5 @@
+use @strtod[F64](nptr: Pointer[U8] tag, endptr: Pointer[Pointer[U8] box] ref)
+
 class ref JsonTokenParser
   """
   Streaming JSON token parser.
@@ -14,6 +16,13 @@ class ref JsonTokenParser
   var _token_start: USize = 0
   var _line: USize = 1
   var _abort: Bool = false
+  var _error_message: String = ""
+  // Null-terminated view of _source, computed once per parse() so `_read_float`
+  // can hand strtod a pointer into it without re-terminating the whole source
+  // on every number. For a non-null-terminated source this is a temporary copy
+  // held only by this raw pointer, alive only for the synchronous parse() that
+  // set it — never dereference it outside the current parse().
+  var _source_cstr: Pointer[U8] tag = Pointer[U8]
 
   var last_number: (I64 | F64) = I64(0)
     """The most recently parsed number value."""
@@ -25,12 +34,17 @@ class ref JsonTokenParser
     _notify = notify'
 
   fun ref parse(source': String box) ? =>
-    """Parse a JSON document, emitting tokens to the notify callback."""
+    """
+    Parse a JSON document, emitting tokens to the notify callback. Raises on
+    malformed input and on a numeric literal outside `F64` range.
+    """
     _source = source'
+    _source_cstr = source'.cstring()
     _offset = 0
     _token_start = 0
     _line = 1
     _abort = false
+    _error_message = ""
     last_number = I64(0)
     last_string = ""
 
@@ -57,8 +71,14 @@ class ref JsonTokenParser
     _line
 
   fun describe_error(): String =>
-    """Human-readable description of the error location."""
-    if _offset < _source.size() then
+    """
+    Human-readable description of the most recent error: a specific reason (such
+    as an out-of-range number) when one has been recorded, otherwise the error's
+    byte-offset location.
+    """
+    if _error_message != "" then
+      _error_message
+    elseif _offset < _source.size() then
       "Invalid JSON at byte offset " + _offset.string()
         + ", line " + _line.string()
     else
@@ -195,6 +215,9 @@ class ref JsonTokenParser
     _emit(JsonTokenNull)?
 
   fun ref _parse_number() ? =>
+    // The whole literal, including any sign, starts here; the float path hands
+    // this span to strtod, the integer path accumulates directly.
+    let num_start = _offset
     let sign: I64 = if _peek_safe() == '-' then _next()?; -1 else 1 end
     let int_start = _offset
     let integer = _read_digits()?
@@ -206,41 +229,36 @@ class ref JsonTokenParser
       error
     end
 
-    // For large integers, re-read as F64 to get the correct value
-    // (_read_digits accumulates into I64 which silently wraps on overflow)
-    let force_float = int_digits > 18
-    let integer_f64: F64 = if force_float then
-      _offset = int_start
-      _read_digits_f64()?
-    else
-      integer.f64()
-    end
+    // An integer of more than 18 digits can exceed I64, so it is read as an F64
+    // even with no fraction or exponent.
+    var is_float = int_digits > 18
 
-    var has_dot = false
-    var frac: F64 = 0
     if _peek_safe() == '.' then
       _next()?
-      has_dot = true
-      frac = _read_fractional()?
+      _read_digits()? // require at least one fraction digit
+      is_float = true
     end
 
-    var has_exp = false
-    var exp: I64 = 0
     match _peek_safe()
     | 'e' | 'E' =>
       _next()?
-      has_exp = true
-      let exp_sign: I64 = match _peek()?
-      | '+' => _next()?; 1
-      | '-' => _next()?; -1
-      else 1
-      end
-      exp = _read_digits()? * exp_sign
+      let c = _peek()?
+      if (c == '+') or (c == '-') then _next()? end
+      _read_digits()? // require at least one exponent digit
+      is_float = true
     end
 
-    if has_dot or has_exp or force_float then
-      last_number = sign.f64() * (integer_f64 + frac)
-        * F64(10).pow(exp.f64())
+    if is_float then
+      let value = _read_float(num_start)?
+      // An out-of-range literal (1e999, or a very long integer) overflows to
+      // ±inf; carrying a non-finite value would hand the printer something it
+      // cannot serialize to valid JSON. Underflow rounds to a finite 0 and is
+      // kept. RFC 8259 permits limiting numeric range.
+      if not value.finite() then
+        _error_message = "Number out of range"
+        error
+      end
+      last_number = value
     else
       last_number = sign * integer
     end
@@ -262,39 +280,22 @@ class ref JsonTokenParser
     if count == 0 then error end
     result
 
-  fun ref _read_digits_f64(): F64 ? =>
-    var result: F64 = 0
-    var count: USize = 0
-    while _offset < _source.size() do
-      let c = _source(_offset)?
-      if (c >= '0') and (c <= '9') then
-        result = (result * 10) + (c - '0').f64()
-        _offset = _offset + 1
-        count = count + 1
-      else
-        break
-      end
+  fun ref _read_float(num_start: USize): F64 ? =>
+    // Correctly-rounded value of the validated number text [num_start, _offset)
+    // via strtod — no intermediate over/underflow, unlike a hand-rolled
+    // mantissa*10^exp. _source_cstr is the null-terminated source (set once in
+    // parse()); strtod stops at the delimiter or end of input. The caller's
+    // finite() check judges range (overflow is ±inf, underflow rounds to a
+    // finite 0); errno is not used because it conflates the two.
+    var endp: Pointer[U8] box = Pointer[U8]
+    let value = @strtod(_source_cstr.offset(num_start), addressof endp)
+    // strtod must consume the whole validated span; reject a shortfall rather
+    // than accept a partial value.
+    if endp != _source_cstr.offset(_offset) then
+      _error_message = "Invalid number"
+      error
     end
-    if count == 0 then error end
-    result
-
-  fun ref _read_fractional(): F64 ? =>
-    var result: F64 = 0
-    var divisor: F64 = 10
-    var count: USize = 0
-    while _offset < _source.size() do
-      let c = _source(_offset)?
-      if (c >= '0') and (c <= '9') then
-        result = result + ((c - '0').f64() / divisor)
-        divisor = divisor * 10
-        _offset = _offset + 1
-        count = count + 1
-      else
-        break
-      end
-    end
-    if count == 0 then error end
-    result
+    value
 
   fun ref _parse_string(is_key: Bool) ? =>
     // token_start is already anchored at the opening '"' by the caller


### PR DESCRIPTION
A non-finite `F64` — infinity or NaN — has no JSON representation, so serializing one produced the invalid bare words `inf`/`-inf`/`nan`/`-nan`, which could not be parsed back. The printer now emits `null` for a non-finite value. Emitting `null` rather than raising keeps the printer total, so no public serialize signature changes.

A non-finite value also reached the printer through parsing: a numeric literal outside `F64` range, such as `1e999` or an integer of several hundred digits, parsed to a non-finite value. The parser now rejects such a literal as a parse error, matching Pony's own `String.f64()`. Separately, a literal that is mathematically zero but written with a large exponent (`0e309`) parsed to NaN through `0 * 10^exp`; it now parses to `0`.

Closes #5659