### PR TITLE
Cover the multi-batch write path in the TCP swarm stress test

### DIFF
--- a/.known-couplings/tcp-swarm-writev-chunks-iov-max.md
+++ b/.known-couplings/tcp-swarm-writev-chunks-iov-max.md
@@ -1,0 +1,32 @@
+# The tcp-swarm multi-batch write coverage depends on pony_os_writev_max()'s POSIX value
+
+The tcp-swarm stress test's `--writev-chunks` lever
+(`test/rt-stress/tcp-swarm/`) exists to exercise `TCPConnection`'s multi-batch
+send path and its mid-write yield (`--yield-after-writing`). Those only run when a
+single `writev` queues more buffers than one `@pony_os_writev_max()` syscall sends
+-- `IOV_MAX` (1024 on Linux and macOS) on POSIX, `1` on Windows (defined in
+`src/libponyrt/lang/io.c`). The orchestrator picks
+`WRITEV_CHUNKS = [4, 64, 2048]`; the `2048` is chosen to exceed the POSIX
+`IOV_MAX` so that, with a payload at least that large, the multi-batch path is
+reached on POSIX.
+
+The coupling is silent: `orchestrate_tcp_test.py`'s "multi-batch writev is
+reachable" assertion checks the *draw* (writev-chunks > 1024 and payload >= it),
+not the runtime's actual batch size. The multi-batch path needs a `writev` to
+queue *strictly more* buffers than one syscall sends, so it needs
+`WRITEV_CHUNKS`'s large value to stay strictly above `pony_os_writev_max()`. If
+that value on POSIX ever rose **to 2048 or higher**, or `WRITEV_CHUNKS`'s large
+value were lowered to at or below the POSIX `IOV_MAX`, the swarm would still pass
+its unit test but would stop exercising the multi-batch send path and the
+mid-write yield on the POSIX CI runs, and no test would catch it. Keep the large
+`WRITEV_CHUNKS` value
+comfortably above `pony_os_writev_max()`'s POSIX return. (Windows is unaffected:
+its `writev_max` of 1 makes any multi-chunk writev multi-batch -- see
+`writev-max-net-files.md` for the separate reason that value must stay 1.)
+
+Run: the tcp-swarm engine with a multi-batch config on POSIX, confirming the
+multi-batch branch is taken -- e.g. instrument `_pending_writes`'s
+`num_to_send = writev_batch_size` branch, build the engine debug, and run
+`./tcp_swarm --write-shape writev --writev-chunks 2048 --payload-size 4096
+--yield-after-writing 64 --connections 40 --concurrency 8`; the branch (and the
+mid-write yield) should fire.

--- a/test/rt-stress/tcp-swarm/README.md
+++ b/test/rt-stress/tcp-swarm/README.md
@@ -16,6 +16,13 @@ on top and swarm dimensions each tied to a distinct code path in
 - `--payload-size` / `--messages` — how much each connection sends, and in how many
   messages (chatty vs single).
 - `--write-shape` (`write` | `writev`) — single vs vectored writes.
+- `--writev-chunks` (`N`, writev only) — how many buffers a `writev` splits its
+  payload into. Above `@pony_os_writev_max()` (IOV_MAX — 1024 on Linux/macOS — on
+  POSIX, 1 on Windows) a single writev queues more buffers than one syscall sends,
+  so
+  `TCPConnection` takes its multi-batch send path. That path is the only one that
+  re-checks `--yield-after-writing`, so on POSIX the mid-write yield needs a
+  chunk count above IOV_MAX to fire at all.
 - `--expect` (`0` = off, `N` = frame size) — fixed-size framed reads vs
   whole-buffer, on both endpoints.
 - `--close` (`graceful` | `hard`) — a graceful `dispose()` (FIN, drains) vs a muted
@@ -24,8 +31,10 @@ on top and swarm dimensions each tied to a distinct code path in
   drops no data here — it exercises the distinct teardown/unsubscribe code.
 - `--read-buffer-size` / `--yield-after-reading` / `--yield-after-writing` — the
   TCPConnection read-buffer size and the byte counts at which it yields back to the
-  scheduler mid-read/mid-write; small values drive frequent yields on any payload
-  size.
+  scheduler mid-read/mid-write. A small `--yield-after-reading` yields on any
+  payload that fills the read buffer more than once; `--yield-after-writing` only
+  bites on the multi-batch write path (see `--writev-chunks`), so on POSIX it does
+  nothing unless the chunk count is above IOV_MAX.
 - `--connections` / `--concurrency` — total connections to churn, and the in-flight
   cap.
 - `--host` / `--port` — where the listener binds (default `localhost` / ephemeral).
@@ -89,7 +98,10 @@ occupies the port before any client dials, so the default `localhost` is fine.
   (`RLIMIT_AS`). Real RSS is tiny (~124 MiB worst case at concurrency 256, 64 KiB
   payload), but the Pony runtime reserves a flat ~3.5 GiB of *virtual* address space
   regardless of config, and `RLIMIT_AS` caps virtual — a 4 GiB cap sat ~86% full at
-  baseline and risked a false OOM on a high-thread run.
+  baseline and risked a false OOM on a high-thread run. That RSS figure was measured
+  before the `--writev-chunks` lever; a heavy multi-batch draw (2048 chunks) builds
+  many more small buffer objects at once, so the peak there is not re-validated —
+  treat it as a first-CI-run calibration item.
 - **Time** — the per-run clamp (`clamp_run`) bounds round-trips
   (`connections * messages`) and total bytes (`connections * messages * payload`),
   so an outsized draw (e.g. 100k conns × 64 msgs × 64 KiB ≈ 400 GB) is trimmed.

--- a/test/rt-stress/tcp-swarm/main.pony
+++ b/test/rt-stress/tcp-swarm/main.pony
@@ -13,6 +13,12 @@ The swarm dimensions are each tied to a distinct code path in
 * `--payload-size` / `--messages` -- how much each connection sends, and in how
   many messages.
 * `--write-shape` (`write` | `writev`) -- single vs vectored writes.
+* `--writev-chunks` (N, writev only) -- how many buffers a `writev` splits its
+  payload into. Above `@pony_os_writev_max()` -- IOV_MAX (1024 on Linux/macOS) on
+  POSIX, 1 on Windows -- the send takes TCPConnection's multi-batch path, sending
+  one
+  `writev_max`-sized batch per pass and re-entering the send loop, which is the
+  only thing that makes the mid-write yield below actually fire on POSIX.
 * `--expect` (0 = off, N = frame size) -- fixed-size framed reads vs whole-buffer.
 * `--close` (`graceful` | `hard`) -- a graceful `dispose()` (FIN, drains the send
   buffer) vs a muted `dispose()`, which takes TCPConnection's `hard_close` path
@@ -21,8 +27,12 @@ The swarm dimensions are each tied to a distinct code path in
   teardown/unsubscribe code, not write loss.
 * `--read-buffer-size` / `--yield-after-reading` / `--yield-after-writing` -- the
   TCPConnection read-buffer size and the byte counts at which it yields back to the
-  scheduler mid-read/mid-write; small values drive frequent yields (reschedules) on
-  any payload size.
+  scheduler mid-read/mid-write. A small `--yield-after-reading` yields on any
+  payload big enough to fill the read buffer more than once. `--yield-after-writing`
+  is different: the send loop only re-checks it when a write spans more than one
+  `writev_max` batch, so on POSIX it needs a `--writev-chunks` above IOV_MAX to
+  bite at all (on Windows, where writev_max is 1, any multi-chunk writev triggers
+  it).
 
 Oracles:
 
@@ -92,6 +102,7 @@ class val _Config
   let messages: USize
   let close_hard: Bool
   let use_writev: Bool
+  let writev_chunks: USize
   let expect_frame: USize
   let read_buffer_size: USize
   let yield_after_reading: USize
@@ -113,6 +124,13 @@ class val _Config
     messages = _usize(m, "messages", 1)
     close_hard = _str(m, "close", "graceful") == "hard"
     use_writev = _str(m, "write-shape", "write") == "writev"
+    // How many buffers a single `writev` splits its payload into. Above
+    // `@pony_os_writev_max()` -- IOV_MAX (1024 on Linux/macOS) on POSIX, 1 on
+    // Windows -- it drives TCPConnection's multi-batch send and the mid-write
+    // yield, so on POSIX it bites only when payload_size >= writev_chunks > 1024.
+    // Default 4; writev only. Coupling:
+    // .known-couplings/tcp-swarm-writev-chunks-iov-max.md.
+    writev_chunks = _usize(m, "writev-chunks", 4).max(1)
     read_buffer_size = _usize(m, "read-buffer-size", 16384)
     // Clamp expect to the read buffer: TCPConnection.expect() errors when the frame
     // exceeds it, so clamping here keeps the call from erroring (the call sites then
@@ -395,11 +413,12 @@ class SwarmClient is TCPConnectionNotify
     var m: USize = 0
     while m < _config.messages do
       if _config.use_writev then
-        // Split across 4 buffers to drive the vectored-write path (multiple
-        // iovecs). A payload under 4 bytes leaves some buffers empty, but writev
-        // still sees several iovecs, which is the point.
-        conn.writev(
-          _Keystream.make_chunks(_seed, _sent_total, _config.payload_size, 4))
+        // Split across `writev_chunks` buffers to drive the vectored-write path.
+        // Several non-empty iovecs need payload_size >= writev_chunks; a chunk
+        // count above the payload collapses to a single iovec (writev skips the
+        // empty buffers). A chunk count above IOV_MAX drives the multi-batch send.
+        conn.writev(_Keystream.make_chunks(
+          _seed, _sent_total, _config.payload_size, _config.writev_chunks))
       else
         conn.write(_Keystream.make(_seed, _sent_total, _config.payload_size))
       end

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp.py
@@ -44,8 +44,10 @@ DEFAULT_TIMEOUT_SECONDS = 6000
 # 8 GiB, not 4: the Pony runtime reserves a flat ~3.5 GiB of VIRTUAL address space
 # (measured, constant across configs), and RLIMIT_AS caps virtual, not RSS -- so a
 # 4 GiB cap sits ~86% full before the workload runs and a high --ponymaxthreads run
-# could trip a FALSE OOM. Real RSS is tiny (~124 MiB worst case measured), so 8 GiB
-# has no downside and removes the false-kill risk.
+# could trip a FALSE OOM. Real RSS is tiny (~124 MiB worst case measured -- before
+# the writev-chunks lever, whose heavy multi-batch draws build many more small
+# buffer objects; that peak is a first-CI-run calibration item), so 8 GiB has no
+# downside and removes the false-kill risk.
 DEFAULT_MEM_LIMIT_MB = 8192
 
 
@@ -63,6 +65,14 @@ def die(message):
 # Feature levers (each drawn independently -- omission is the swarm). Magnitudes
 # are bucketed small/medium/large at 25/50/25 then uniform within the bucket.
 WRITE_SHAPES = ["write", "writev"]
+# writev buffer counts (writev only). 2048 exceeds POSIX IOV_MAX (1024): drawn
+# with a payload at least that large, a single writev then queues more buffers
+# than one writev() syscall can send, so TCPConnection takes its multi-batch send
+# path -- the only path on which the mid-write yield (--yield-after-writing) fires
+# on POSIX. 4 and 64 are ordinary small vector writes. COUPLING: the large value
+# must stay above pony_os_writev_max()'s POSIX return, or the multi-batch coverage
+# silently vanishes -- see .known-couplings/tcp-swarm-writev-chunks-iov-max.md.
+WRITEV_CHUNKS = [4, 64, 2048]
 CLOSE_KINDS = ["graceful", "hard"]
 # Payload sizes span the runtime's 16384-byte default read buffer: below, at, and
 # above it, so runs straddle the read-chunk boundary rather than clustering small.
@@ -138,6 +148,7 @@ def resolve_config(master_seed, max_threads, max_connections=None):
     workload["payload-size"] = payload
     workload["messages"] = draw_bucketed(rng, MESSAGE_BUCKETS)
     workload["write-shape"] = rng.choice(WRITE_SHAPES)
+    workload["writev-chunks"] = rng.choice(WRITEV_CHUNKS)
     read_buffer = rng.choice(READ_BUFFER_SIZES)
     workload["read-buffer-size"] = read_buffer
     workload["yield-after-reading"] = rng.choice(YIELD_SIZES)

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
@@ -23,33 +23,52 @@ def check(name, condition):
 def test_resolve_config_golden():
     # Pinned draws: a reordered/narrowed/added draw changes these and would
     # silently remap every seed (breaking --replay). Regenerate deliberately if
-    # the draw is intended to change. Two seeds so a change is unlikely to leave
-    # both untouched by luck. Seed 5 also exercises expect > 0.
+    # the draw is intended to change. Three seeds spanning both write shapes, so a
+    # change is unlikely to leave all untouched by luck AND a regression that
+    # touched only one write-shape branch can't hide. Seed 0 is a plain writev;
+    # seed 5 is write-shape=write (payload 1, hard close); seed 16 exercises the
+    # multi-batch writev path (writev, writev-chunks 2048 > IOV_MAX, payload >=
+    # chunks) plus expect > 0 and a hard close.
     golden0 = {
         "master_seed": 0,
         "runtime": {"ponymaxthreads": 5, "ponypin": True},
         "workload": {
             "close": "graceful", "concurrency": 8, "connections": 75126,
             "expect": 0, "messages": 26, "payload-size": 1024,
-            "read-buffer-size": 16384, "write-shape": "writev",
-            "yield-after-reading": 1024, "yield-after-writing": 1024,
+            "read-buffer-size": 65536, "write-shape": "writev",
+            "writev-chunks": 64,
+            "yield-after-reading": 1024, "yield-after-writing": 16384,
         },
     }
     golden5 = {
         "master_seed": 5,
-        "runtime": {"ponymaxthreads": 7, "ponynoscale": True, "ponypin": True,
-                    "ponypinasio": True},
+        "runtime": {"ponymaxthreads": 4, "ponynoblock": True},
         "workload": {
-            "close": "graceful", "concurrency": 256, "connections": 13749,
-            "expect": 1, "messages": 32, "payload-size": 1,
-            "read-buffer-size": 1024, "write-shape": "write",
-            "yield-after-reading": 64, "yield-after-writing": 1024,
+            "close": "hard", "concurrency": 256, "connections": 13749,
+            "expect": 0, "messages": 32, "payload-size": 1,
+            "read-buffer-size": 128, "write-shape": "write",
+            "writev-chunks": 4,
+            "yield-after-reading": 1024, "yield-after-writing": 1024,
+        },
+    }
+    golden16 = {
+        "master_seed": 16,
+        "runtime": {"ponymaxthreads": 5, "ponynoblock": True,
+                    "ponynoscale": True},
+        "workload": {
+            "close": "hard", "concurrency": 32, "connections": 17745,
+            "expect": 16384, "messages": 1, "payload-size": 16384,
+            "read-buffer-size": 16384, "write-shape": "writev",
+            "writev-chunks": 2048,
+            "yield-after-reading": 64, "yield-after-writing": 16384,
         },
     }
     check("resolve_config(0, 8) matches the pinned draw",
           o.resolve_config(0, 8) == golden0)
     check("resolve_config(5, 8) matches the pinned draw",
           o.resolve_config(5, 8) == golden5)
+    check("resolve_config(16, 8) matches the pinned draw",
+          o.resolve_config(16, 8) == golden16)
     check("resolve_config is deterministic",
           o.resolve_config(7, 8) == o.resolve_config(7, 8))
 
@@ -96,6 +115,9 @@ def test_resolve_config_coverage_and_invariants():
     write_shapes = set()
     closes = set()
     expect_states = set()
+    chunk_vals = set()
+    multibatch_seeds = 0
+    yield_fires_seeds = 0
     noscale = pin = pinasio = noblock = 0
     invariants = True
     for seed in range(500):
@@ -104,6 +126,23 @@ def test_resolve_config_coverage_and_invariants():
         write_shapes.add(w["write-shape"])
         closes.add(w["close"])
         expect_states.add(w["expect"] > 0)
+        chunk_vals.add(w["writev-chunks"])
+        # A writev whose non-empty buffer count exceeds POSIX IOV_MAX (1024)
+        # reaches TCPConnection's multi-batch send path. That needs writev,
+        # writev-chunks > 1024, and payload >= chunks (so no buffer is empty). The
+        # mid-write yield fires only on that path, and only once one IOV_MAX-buffer
+        # batch's bytes reach --yield-after-writing. Since the yield is the whole
+        # point of the writev-chunks lever, both must stay reachable or those paths
+        # go untested. (IOV_MAX here is the POSIX value; see
+        # .known-couplings/tcp-swarm-writev-chunks-iov-max.md.)
+        iov_max = 1024
+        chunks = w["writev-chunks"]
+        if (w["write-shape"] == "writev" and chunks > iov_max
+                and w["payload-size"] >= chunks):
+            multibatch_seeds += 1
+            first_batch_bytes = iov_max * (w["payload-size"] // chunks)
+            if first_batch_bytes >= w["yield-after-writing"]:
+                yield_fires_seeds += 1
         noscale += 1 if r.get("ponynoscale") else 0
         pin += 1 if r.get("ponypin") else 0
         pinasio += 1 if r.get("ponypinasio") else 0
@@ -128,6 +167,8 @@ def test_resolve_config_coverage_and_invariants():
             invariants = False
         if w["write-shape"] not in o.WRITE_SHAPES:
             invariants = False
+        if w["writev-chunks"] not in o.WRITEV_CHUNKS:
+            invariants = False
         if w["close"] not in o.CLOSE_KINDS:
             invariants = False
         if not (1 <= r["ponymaxthreads"] <= 8):
@@ -138,6 +179,11 @@ def test_resolve_config_coverage_and_invariants():
         if r.get("ponypinasio") and not r.get("ponypin"):
             invariants = False           # pinasio requires pin
     check("both write shapes appear", write_shapes == {"write", "writev"})
+    # Hardcoded literal (not set(o.WRITEV_CHUNKS)) so narrowing the constant is
+    # caught here, matching the sibling write-shape/close checks.
+    check("all writev-chunk counts appear", chunk_vals == {4, 64, 2048})
+    check("multi-batch writev is reachable by the draw", multibatch_seeds > 0)
+    check("mid-write yield is reachable via writev-chunks", yield_fires_seeds > 0)
     check("both close kinds appear", closes == {"graceful", "hard"})
     check("expect appears both on and off", expect_states == {True, False})
     check("ponynoscale is drawn sometimes and not always",


### PR DESCRIPTION
The mid-write yield (`--yield-after-writing`) was dead on Linux and macOS. On
POSIX the send loop only re-checks the yield when a single `writev` queues more
buffers than one syscall sends (IOV_MAX, 1024), and the swarm's client only ever
queued a handful — so the yield and `TCPConnection`'s multi-batch send path went
unexercised on two of the three CI backends. (On Windows they fire, since
`pony_os_writev_max()` is 1 there.)

This makes the writev chunk count a lever (`--writev-chunks`), drawn from
`[4, 64, 2048]`. When a seed draws 2048 with a payload at least that large, the
client's `writev` queues more than IOV_MAX buffers, so the multi-batch send path
and the mid-write yield both run on POSIX. The docstring and README claim that the
yield fired "on any payload size" was wrong and is corrected. A `.known-couplings/`
doc records that this coverage depends on `pony_os_writev_max()`'s POSIX value
staying below the drawn chunk count.

Watch-items for the first scheduled runs (not blockers):

- **Memory** — the ~124 MiB worst-case RSS figure in the notes predates this lever.
  A heavy multi-batch draw (2048 chunks) builds many more small buffer objects at
  once; that peak has not been re-measured. The 8 GiB address-space cap should
  absorb it, and a false OOM would surface as a reproducible failure from the seed.
- **Buffer liveness** — the multi-batch + yield path leaves `writev` data pending
  across a scheduler yield boundary, which the swarm did not exercise before. A
  multi-batch, yield-firing seed passes the byte-for-byte echo oracle locally, so
  this holds in practice; a first CI/soak run confirms it across backends. If a run
  ever goes red here, suspect the runtime's buffer-liveness handling, not the test.
