### PR TITLE
Fix Sig.ill() compile error naming SIGINT instead of SIGILL

### DIFF
--- a/packages/signals/sig.pony
+++ b/packages/signals/sig.pony
@@ -9,7 +9,7 @@ primitive Sig
 
   fun ill(): U32 =>
     ifdef linux or bsd or osx then 4
-    else compile_error "no SIGINT"
+    else compile_error "no SIGILL"
     end
 
   fun trap(): U32 =>


### PR DESCRIPTION
The `else` branch of `Sig.ill()` raised `compile_error "no SIGINT"`, but `ill()` is the SIGILL accessor. On a platform without SIGILL (Windows), code using `Sig.ill()` failed to compile with a message claiming SIGINT was unavailable — even though SIGINT exists there and `Sig.int()` works. The message now names SIGILL, matching every other platform-gated accessor in the file.

Closes #5640