### PR TITLE
Fix `Sig.usr2()` reporting SIGUSR2 availability backwards

### DIFF
--- a/.known-couplings/scheduler-sleep-wake-signal-signals-package.md
+++ b/.known-couplings/scheduler-sleep-wake-signal-signals-package.md
@@ -1,0 +1,9 @@
+# `PONY_SCHED_SLEEP_WAKE_SIGNAL` (`src/libponyrt/sched/scheduler.h`) ↔ `Sig.usr2()` (`packages/signals/sig.pony`)
+
+On default builds (not `scheduler_scaling_pthreads`), the runtime reserves SIGUSR2 as its scheduler sleep/wake signal: `PONY_SCHED_SLEEP_WAKE_SIGNAL` is defined to `SIGUSR2`, every runtime thread blocks it, suspended schedulers consume it via `sigwait`, and wakes are delivered with `pthread_kill`. A `SignalHandler` registered for SIGUSR2 on such a build never fires. When built with `scheduler_scaling_pthreads` (forced on macOS), the runtime uses pthread condition variables instead and leaves SIGUSR2 free, so the `signals` package may hand it out.
+
+`Sig.usr2()` mirrors this: it yields a signal number only under `ifdef "scheduler_scaling_pthreads"` and is a `compile_error` otherwise. The two must stay in step — if the runtime's choice of sleep/wake signal changes, or the gate that reserves it moves, `Sig.usr2()`'s gate must change to match, or the package will again advertise a signal the runtime has taken. Both ends carry comments pointing at each other.
+
+One residual gap is not gated: `runtime_tracing` builds reuse SIGUSR2 for the tracing thread (`PONY_TRACING_SLEEP_WAKE_SIGNAL` in `src/libponyrt/tracing/tracing.c`) regardless of `scheduler_scaling_pthreads`, but `runtime_tracing` is not exposed as a Pony `ifdef` userflag, so `sig.pony` cannot exclude it.
+
+Run: the `signals` suite in the stdlib tests (`make test-stdlib-release` / `make test-stdlib-debug`) — the `signals/USR2` test exercises SIGUSR2 delivery, but only on `scheduler_scaling_pthreads` builds (e.g. macOS CI).

--- a/.release-notes/fix-sig-usr2-availability.md
+++ b/.release-notes/fix-sig-usr2-availability.md
@@ -1,0 +1,7 @@
+## Fix `Sig.usr2()` reporting SIGUSR2 availability backwards
+
+`Sig.usr2()` in the `signals` package had its availability reversed with respect to how the Pony runtime uses SIGUSR2, so it was unusable in every configuration.
+
+On the default Linux and BSD builds, the runtime reserves SIGUSR2 for its own scheduler use, so a handler registered for it never fires — yet `Sig.usr2()` compiled and returned a signal number, silently handing you a handler that could never run. On macOS (and other `scheduler_scaling_pthreads` builds), the runtime leaves SIGUSR2 free, but `Sig.usr2()` was a compile error claiming the signal was reserved.
+
+`Sig.usr2()` now returns a signal number on `scheduler_scaling_pthreads` builds, including macOS where that mode is always on, and is a compile error on the default builds where the runtime reserves the signal — so a misuse shows up when you compile rather than as a handler that silently never fires. One configuration is still not covered: `runtime_tracing` builds use SIGUSR2 themselves regardless of scheduler mode, and `Sig.usr2()` has no way to detect that, so it should not be used on a `runtime_tracing` build.

--- a/packages/signals/_test.pony
+++ b/packages/signals/_test.pony
@@ -6,8 +6,13 @@ actor \nodoc\ Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestSignalINT)
+    // Sig.usr2() is a compile error except on scheduler_scaling_pthreads builds
+    // that have SIGUSR2 (not Windows); register the test only where it runs.
+    ifdef "scheduler_scaling_pthreads" and not windows then
+      test(_TestSignalUSR2)
+    end
 
-class \nodoc\ _TestSighupNotify is SignalNotify
+class \nodoc\ _TestSignalNotify is SignalNotify
   let _h: TestHelper
 
   new iso create(h: TestHelper) =>
@@ -23,10 +28,34 @@ class \nodoc\ iso _TestSignalINT is UnitTest
   fun name(): String => "signals/INT"
 
   fun ref apply(h: TestHelper) =>
-    let signal = SignalHandler(_TestSighupNotify(h), Sig.int())
+    let signal = SignalHandler(_TestSignalNotify(h), Sig.int())
     signal.raise()
     _signal = signal
     h.long_test(2_000_000_000) // 2 second timeout
+
+  fun timed_out(h: TestHelper) =>
+    try
+      (_signal as SignalHandler).dispose()
+    end
+
+    h.fail("timeout")
+    h.complete(false)
+
+class \nodoc\ iso _TestSignalUSR2 is UnitTest
+  var _signal: (SignalHandler | None) = None
+
+  fun name(): String => "signals/USR2"
+
+  fun ref apply(h: TestHelper) =>
+    // Gated to match the registration in tests(): the runtime leaves SIGUSR2
+    // free only on scheduler_scaling_pthreads builds, and it exists only off
+    // Windows, so that is where Sig.usr2() yields a usable signal number.
+    ifdef "scheduler_scaling_pthreads" and not windows then
+      let signal = SignalHandler(_TestSignalNotify(h), Sig.usr2())
+      signal.raise()
+      _signal = signal
+      h.long_test(2_000_000_000) // 2 second timeout
+    end
 
   fun timed_out(h: TestHelper) =>
     try

--- a/packages/signals/sig.pony
+++ b/packages/signals/sig.pony
@@ -149,7 +149,14 @@ primitive Sig
     end
 
   fun usr2(): U32 =>
-    ifdef not "scheduler_scaling_pthreads" then
+    // The runtime reserves SIGUSR2 as its scheduler sleep/wake signal
+    // (PONY_SCHED_SLEEP_WAKE_SIGNAL in src/libponyrt/sched/scheduler.h) on
+    // default builds, and frees it when built with scheduler_scaling_pthreads
+    // (forced on macOS). So SIGUSR2 is available to this package only on
+    // scheduler_scaling_pthreads builds. Caveat: runtime_tracing builds reuse
+    // SIGUSR2 for the tracing thread regardless, but that flag is not visible
+    // to `ifdef`, so it cannot be gated on here.
+    ifdef "scheduler_scaling_pthreads" then
       ifdef bsd or osx then 31
       elseif linux then 12
       else compile_error "no SIGUSR2"

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -25,7 +25,8 @@ typedef struct scheduler_t scheduler_t;
 
 #if !defined(PLATFORM_IS_WINDOWS) && !defined(USE_SCHEDULER_SCALING_PTHREADS)
 // Signal to use for suspending/resuming threads via `sigwait`/`pthread_kill`
-// If you change this, remember to change `signals` package accordingly
+// If you change this, change the `signals` package (Sig.usr2()) accordingly;
+// see .known-couplings/scheduler-sleep-wake-signal-signals-package.md
 #define PONY_SCHED_SLEEP_WAKE_SIGNAL SIGUSR2
 #endif
 


### PR DESCRIPTION
`Sig.usr2()` gated on the `scheduler_scaling_pthreads` build flag in the wrong direction, so it was unusable everywhere. On default Linux and BSD builds the runtime reserves SIGUSR2 for scheduler sleep/wake, yet `Sig.usr2()` compiled and returned the signal number — a handler registered for it silently never fired. On `scheduler_scaling_pthreads` builds (macOS always, opt-in elsewhere) the runtime leaves SIGUSR2 free, but `Sig.usr2()` was a compile error claiming it was reserved.

This flips the gate to match the runtime: a signal number where SIGUSR2 is free, a compile error where it is reserved. A gated end-to-end test registers and raises SIGUSR2 on `scheduler_scaling_pthreads` builds, exercised by macOS CI, and the runtime-to-package coupling is now recorded in `.known-couplings/`.

One case remains uncovered: `runtime_tracing` builds reuse SIGUSR2 for the tracing thread regardless of scheduler mode, and that flag is not visible to `ifdef`, so the package cannot gate on it. This is documented at the gate and in the coupling file; closing it would mean exposing a new build userflag, which is a separate change.

Closes #5641