### PR TITLE
Give pony-lsp standard command-line handling

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -81,3 +81,27 @@ JsonParser.parse("1e999")
 
 Number parsing is also more accurate at the extremes: a literal that is mathematically zero but written with a large exponent (`0e309`) previously parsed to NaN, and some in-range literals with very long digit runs parsed to infinity or a slightly wrong value — these now parse correctly.
 
+## Add `--version` and `--help` support to pony-lsp
+
+`pony-lsp --version` used to print nothing and hang: it ignored the flag, started the language server, and waited for input that never came. `pony-lsp` now handles `--version` and `--help` and exits, the same as `ponyc`, `pony-doc`, and `pony-lint`.
+
+## pony-lsp now rejects unrecognized command-line arguments
+
+`pony-lsp` used to ignore everything on its command line and start the language server regardless. It now parses its arguments the same way `ponyc`, `pony-doc`, and `pony-lint` do — it recognizes `--version` and `--help` — and rejects anything else instead of ignoring it.
+
+This means an editor configured to launch `pony-lsp` with an argument will now fail to start the server. The Helix configuration previously published on the Pony website passed a single empty-string argument:
+
+```toml
+[language-server.pony-lsp]
+command = "pony-lsp"
+args = [""]
+```
+
+Remove the argument so `args` is an empty list:
+
+```toml
+[language-server.pony-lsp]
+command = "pony-lsp"
+args = []
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- Add --version and --help support to pony-lsp ([PR #5668](https://github.com/ponylang/ponyc/pull/5668))
 
 ### Changed
 
 - Stop installing the Pony runtime's C headers and static libraries ([PR #5620](https://github.com/ponylang/ponyc/pull/5620))
 - Don't run the ASIO thread under systematic testing ([PR #5647](https://github.com/ponylang/ponyc/pull/5647))
+- pony-lsp now rejects unrecognized command-line arguments ([PR #5668](https://github.com/ponylang/ponyc/pull/5668))
 
 ## [0.66.0] - 2026-06-29
 

--- a/tools/pony-lsp/main.pony
+++ b/tools/pony-lsp/main.pony
@@ -1,3 +1,4 @@
+use "cli"
 use "path:../lib/ponylang/pony_compiler/"
 use "files"
 use "pony_compiler"
@@ -10,7 +11,47 @@ use @_fileno[I32](stream: Pointer[None] tag) if windows
 use @_setmode[I32](fd: I32, mode: I32) if windows
 
 actor Main
+  """
+  CLI entry point for pony-lsp. Parses command-line arguments, then starts the
+  language server, which communicates with the editor over stdin/stdout.
+  """
   new create(env: Env) =>
+    let cs =
+      try
+        CommandSpec.leaf(
+          "pony-lsp",
+          "The Pony language server",
+          [
+            OptionSpec.bool(
+              "version",
+              "Print version and exit"
+              where short' = 'V', default' = false)
+          ])? .> add_help()?
+      else
+        env.err.print("internal error: invalid command spec")
+        env.exitcode(1)
+        return
+      end
+
+    let cmd =
+      match \exhaustive\ CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command => c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+    // Handle --version
+    if cmd.option("version").bool() then
+      env.out.print("pony-lsp " + Version())
+      return
+    end
+
+    // No CLI action requested: start the language server.
     ifdef windows then
       @_setmode(@_fileno(@pony_os_stdout()), 0x8000)
     end


### PR DESCRIPTION
`pony-lsp` did no command-line parsing. It read `argv0` and ignored everything else, so `pony-lsp --version` was silently dropped: the process started the language server and blocked on stdin, printing nothing and never exiting. `pony-lsp` now parses its arguments the same way `ponyc`, `pony-doc`, and `pony-lint` do — it recognizes `--version` and `--help` and rejects anything else.

Rejecting unrecognized arguments is a behavior change. An editor that launches `pony-lsp` with an argument will now fail to start the server instead of ignoring the argument. The Helix configuration previously published on the Pony website passed a single empty-string argument (`args = [""]`), so Helix users following those docs need to change it to `args = []`. That is covered by a Changed release note here and by a companion fix to the website docs.

Because this PR is both an addition (`--version`/`--help`) and a behavior change (argument rejection), each needing its own description, the CHANGELOG and release notes are updated by hand rather than by a changelog label.

Closes #5646