### PR TITLE
Describe libs-cache script options by behavior, not caller

### DIFF
--- a/.ci-scripts/libs-cache/branch_libs_cache.py
+++ b/.ci-scripts/libs-cache/branch_libs_cache.py
@@ -4,8 +4,8 @@ a push/pull/exists/package-name against it.
 
 This is the BRANCH libs cache: a separate, short-lived cache from the main libs
 cache (`oci_libs_cache.py` / `ponyc-libs-cache`). It exists so a build that misses
-the main cache because it changed an LLVM-determining input -- a non-fork PR, or an
-ad-hoc `workflow_dispatch` of weekly on a branch -- builds LLVM once
+the main cache -- because it changed an LLVM-determining input the main cache does
+not have yet (the main cache is filled from main) -- builds LLVM once
 and reuses that build on later runs instead of cold-building every time. The warmer
 also reads it: on a main-cache miss it promotes a matching branch artifact into the
 main cache instead of cold-building (`promote_libs_cache.py`).
@@ -38,9 +38,8 @@ it is building for and check it with one HEAD; no per-PR partitioning is needed.
 The tag (not who built it) is what prevents a stale artifact from being served: a
 branch that changes any LLVM-determining input gets a different tag (or platform),
 so two builds that share a tag share identical content, and a build at a different
-tag is a different version -- exact hit or miss. Two PRs (or a PR and a tier
-dispatch) that produce the same tag share the one package, which is free dedup,
-not a hazard.
+tag is a different version -- exact hit or miss. Two builds that produce the same
+tag share the one package, which is free dedup, not a hazard.
 
 Usage:
     branch_libs_cache.py package-name (--image <ref> | --platform <lbl>)
@@ -49,11 +48,10 @@ Usage:
     branch_libs_cache.py push --tag <hash> (--image <ref> | --platform <lbl>)
 
 `exists` reports whether the artifact is cached (exit 0 present / 1 absent)
-without downloading the blob -- the cheap check a maybe-build job or the warmer
-gates on. `pull` restores the artifact, exiting non-zero on a miss so the caller
-can fall back to building. `push` uploads the blob before the manifest; auth uses
-GITHUB_TOKEN (needs `packages: write`, which only non-fork PR runs and
-`workflow_dispatch`/`schedule` runs get).
+without downloading the blob -- a cheap check for deciding whether to build. `pull`
+restores the artifact, exiting non-zero on a miss so the caller can fall back to
+building. `push` uploads the blob before the manifest; auth uses GITHUB_TOKEN and
+the push needs `packages: write`.
 
 Stdlib only so no pip install is required on any CI runner.
 """

--- a/.ci-scripts/libs-cache/oci_libs_cache.py
+++ b/.ci-scripts/libs-cache/oci_libs_cache.py
@@ -37,10 +37,10 @@ Usage:
 
 `package-name` prints the full package name (for debugging). `exists` reports
 whether the artifact is cached (exit 0 present / 1 absent) without downloading
-the blob -- the cheap check a maybe-build job gates on. `pull` restores the
+the blob -- a cheap check for deciding whether to build. `pull` restores the
 artifact into the working tree, exiting non-zero on a miss so the caller can fall
-back to building. `push` (warmer only) uploads the blob before the manifest;
-auth uses GITHUB_TOKEN (needs `packages: write`).
+back to building. `push` uploads the blob before the manifest; auth uses
+GITHUB_TOKEN and needs `packages: write`.
 
 Stdlib only so no pip install is required on any CI runner.
 """

--- a/.ci-scripts/libs-cache/pr_libs_cache.py
+++ b/.ci-scripts/libs-cache/pr_libs_cache.py
@@ -1,32 +1,30 @@
 #!/usr/bin/env python3
-"""Resolve the prebuilt LLVM `build/libs` for a pull-request CI job.
+"""Resolve the prebuilt LLVM `build/libs` for a PR build.
 
-The PR libs-building jobs need the prebuilt LLVM, but -- unlike a push-to-main
-consumer -- a PR branch that changes an LLVM-determining input misses the main
-cache on every push (the main cache only updates on push-to-main). So when allowed
-to (a non-fork run, which has a writable token) a PR job also uses the branch
-scratch cache (`branch_libs_cache.py`): build LLVM once on the first push that
-misses, reuse it on later pushes.
+A build that changes an LLVM-determining input misses the main cache on every push
+until that change reaches main (the main cache is filled from main).
+So, given a token that can write the branch cache, this orchestration also uses the
+branch scratch cache (`branch_libs_cache.py`): build LLVM once on the first push
+that misses, reuse it on later pushes.
 
-This is the orchestration that ties the two caches together for a PR job. It is
+This is the orchestration that ties the two caches together for a PR build. It is
 CI-only logic -- it pushes scratch artifacts -- so it lives here, in a script the
 workflow calls, NOT in the Makefile / make.ps1 (which are the developer-facing
 build files and know only how to *build* libs). It does not reimplement any
 caching itself: it sequences the existing `oci_libs_cache.py` and
-`branch_libs_cache.py` primitives and shells out to the build command the workflow
-hands it.
+`branch_libs_cache.py` primitives and shells out to the build command it is handed.
 
 Flow (per platform, per job):
   1. check the main cache              -> hit -> done, no build, no push.
   2. (if --branch-cache) check the branch -> hit -> done, no build, no push.
   3. miss -> run the build command -> (if --branch-cache) push to the branch cache.
 
-`--branch-cache` is the non-fork signal: it says "this run may read and write the
-branch scratch cache" (the push needs `packages: write`, which only non-fork PR
-runs get). The workflow passes it for non-fork runs and omits it for forks; a fork
-then behaves exactly like the plain pull-main-or-build -- no branch pull, no push.
-The branch cache is tag-addressable (`branch_libs_cache.py`), so no PR identifier
-is needed: the platform+arch+tag fully name the artifact.
+`--branch-cache` enables the branch scratch cache: read it when the main cache
+misses, and push to it after a build. The push needs `packages: write`, so pass the
+flag only on a run that has it; omit it and the run just pulls the main cache or
+builds -- no branch read, no push. The branch cache is tag-addressable
+(`branch_libs_cache.py`): the platform+arch+tag fully name the artifact, so the flag
+carries no identifier -- it is just on or off.
 
 Two modes select how "check" and "push failure" behave:
 
@@ -34,20 +32,22 @@ Two modes select how "check" and "push failure" behave:
     tree on a hit) and the branch push is best-effort -- the libs are already
     built, so a cache-write hiccup degrades to "rebuild next push" rather than
     failing the job.
-  - maybe-build mode (`--ensure`): step 1/2 `exists` (no download -- the job only
-    needs to know whether to build, not the blob itself, so a hit is seconds) and a
-    branch push failure HARD-fails the job, so a registry write problem surfaces
-    instead of silently leaving consumers to each cold-build. `--ensure` requires
+  - ensure mode (`--ensure`): step 1/2 `exists` (no download -- this job only needs
+    to know whether to build, not the blob itself, so a hit is seconds) and a
+    branch push failure HARD-fails the job. Use it for a job whose purpose is to
+    guarantee the branch cache is populated so later consumers can rely on a hit; a
+    silent push failure would leave each of them to cold-build. `--ensure` requires
     `--branch-cache`.
 
-The sibling `resolve_libs_cache.py` (the non-PR consumer/warmer orchestration)
-spells its warmer build-and-push mode `--warm`, not these flags, on purpose: it
-pushes the *main* cache, where a push failure is fatal differently. Its own
-`--branch-cache` consumer flag matches this one (participate in the branch cache),
-but the warmer/main-push path is distinct -- don't assume the flags interchange.
+The sibling `resolve_libs_cache.py` (the consumer/warmer orchestration for non-PR
+builds) spells its main-cache build-and-push mode `--warm`, not these flags, on
+purpose: it pushes the *main* cache, where a push failure is fatal differently. Its
+own `--branch-cache` consumer flag matches this one (participate in the branch
+cache), but the warmer/main-push path is distinct -- don't assume the flags
+interchange.
 
-A main-cache hit short-circuits before any push, so a PR job never writes the main
-cache (the warmer stays its only writer).
+A main-cache hit short-circuits before any push, so this orchestration never writes
+the main cache.
 
 Stdlib only. Usage:
     pr_libs_cache.py [--ensure] [--branch-cache] (--image <ref> | --platform <lbl>) \
@@ -56,8 +56,7 @@ Stdlib only. Usage:
 Everything after `--` is the build command, run as-is on a cache miss (e.g.
 `make libs llvm_tools=false build_flags=-j4`, or on Windows
 `pwsh -File make.ps1 -Command libs -LlvmTools false`). Auth for the pulls/pushes
-uses GITHUB_TOKEN; the branch push needs `packages: write`, which only non-fork PR
-runs get.
+uses GITHUB_TOKEN; the branch push needs `packages: write`.
 """
 
 import argparse
@@ -75,18 +74,19 @@ def main(argv):
     sel.add_argument('--platform', help='literal platform label')
     parser.add_argument('--tag', required=True, help='hashFiles content hash')
     parser.add_argument('--branch-cache', action='store_true',
-                        help='this run may read/write the branch scratch cache '
-                             '(non-fork only: the push needs packages: write). '
-                             'Omitted for forks, which then pull-main-or-build.')
+                        help='use the branch scratch cache: read it on a '
+                             'main-cache miss, push to it after a build. The push '
+                             'needs packages: write. Omit it to only pull main or '
+                             'build.')
     parser.add_argument('--ensure', action='store_true',
-                        help='maybe-build mode: check existence (no download); on '
-                             'a miss build and HARD-push the branch cache. '
-                             'Requires --branch-cache.')
+                        help='ensure mode: check existence (no download); on a miss '
+                             'build and HARD-push the branch cache, failing the job '
+                             'if that push fails. Requires --branch-cache.')
     args = parser.parse_args(ours)
     if not build_cmd:
         die("no build command after '--'.")
     if args.ensure and not args.branch_cache:
-        die("--ensure requires --branch-cache (non-fork only).")
+        die("--ensure requires --branch-cache.")
 
     base = cache_args(args)
     verb = 'exists' if args.ensure else 'pull'

--- a/.ci-scripts/libs-cache/pr_libs_cache_test.py
+++ b/.ci-scripts/libs-cache/pr_libs_cache_test.py
@@ -12,7 +12,7 @@ any subprocess or network. Load-bearing invariants:
     now; a stray `--pr` would make branch_libs_cache.py argparse-reject and break
     every non-fork PR job -- this is the regression guard for the rename);
   - `--branch-cache` (non-fork) does main -> branch -> build -> push-branch; a fork
-    (no `--branch-cache`) skips all branch ops and just pull-main-or-builds;
+    (no `--branch-cache`) skips all branch ops and just pulls main or builds;
   - default (non-`--ensure`) branch push is best-effort (a failure warns, exit 0);
     `--ensure` HARD-fails on a branch push failure; `--ensure` requires
     `--branch-cache`.

--- a/.ci-scripts/libs-cache/promote_libs_cache.py
+++ b/.ci-scripts/libs-cache/promote_libs_cache.py
@@ -1,19 +1,18 @@
 #!/usr/bin/env python3
 """Promote a branch libs-cache artifact into the main libs cache (same tag).
 
-The warmer (`update-lib-cache.yml`, via `resolve_libs_cache.py --warm` or the BSD
-jobs' host-side check) calls this on a main-cache MISS: instead of cold-building
-LLVM, copy the artifact a PR or an ad-hoc tier dispatch already built and pushed to
-the branch scratch cache (`branch_libs_cache.py` / `ponyc-branch-libs-cache`) into
-the main cache (`oci_libs_cache.py` / `ponyc-libs-cache`).
+The main cache's warmer calls this on a main-cache MISS: instead of cold-building
+LLVM, copy an artifact already built and pushed to the branch scratch cache
+(`branch_libs_cache.py` / `ponyc-branch-libs-cache`) into the main cache
+(`oci_libs_cache.py` / `ponyc-libs-cache`).
 
 This is the one script that spans both namespaces. The two package names are the
 same `<platform>-<arch>` string under different namespace prefixes and share the
 same content-hash tag, so the branch artifact is a valid main artifact -- the only
 work is a registry-to-registry copy (`registry.copy`), which downloads the source
 archive blob and re-uploads it under the main package with a fresh manifest. No
-`build/libs` is needed on disk, so the warmer's BSD jobs can promote host-side
-without booting their VM.
+`build/libs` is needed on disk, so a promote can run host-side without booting a
+build VM.
 
 The caller checks `branch_libs_cache.py exists` first and only invokes this on a
 hit; `registry.copy` still re-checks (and dies if the source is absent), so a

--- a/.ci-scripts/libs-cache/prune_branch_libs_cache.py
+++ b/.ci-scripts/libs-cache/prune_branch_libs_cache.py
@@ -2,12 +2,12 @@
 """Age-based retention for the branch libs cache (`ponyc-branch-libs-cache/*`).
 
 The branch libs cache (`branch_libs_cache.py`) holds a tag-addressable scratch copy
-of the prebuilt LLVM, one package per `<platform>-<arch>`, so a changed-libs build
-(a non-fork PR, or an ad-hoc tier dispatch) doesn't rebuild LLVM on every run. The
-versions accumulate as branches come and go, so this sweep, run daily, deletes
-anything older than the cutoff: stale versions individually, and a package outright
-once all of its versions are stale (a platform nobody has pushed to in the window,
-e.g. a retired builder image).
+of the prebuilt LLVM, one package per `<platform>-<arch>`, so a build that changes
+an LLVM-determining input doesn't rebuild LLVM on every run. The versions
+accumulate as branches come and go, so this sweep, run daily, deletes anything
+older than the cutoff: stale versions individually, and a package outright once all
+of its versions are stale (a platform nobody has pushed to in the window, e.g. a
+retired builder image).
 
 This is the branch cache's OWN retention -- deliberately different from the main
 cache's `prune_libs_cache.py` (which keeps the N newest versions per package and

--- a/.ci-scripts/libs-cache/resolve_libs_cache.py
+++ b/.ci-scripts/libs-cache/resolve_libs_cache.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Resolve the prebuilt LLVM `build/libs` for a non-PR CI job (consumer or warmer).
+"""Resolve the prebuilt LLVM `build/libs` for a non-PR build (consumer, warmer, or
+require-cache-hit).
 
-This is the orchestration the build/warmer jobs call instead of building LLVM
-directly. It sequences the `oci_libs_cache.py` / `branch_libs_cache.py` /
-`promote_libs_cache.py` primitives around the build command the workflow hands it
-after `--`; it does not reimplement any caching itself. It is CI-only logic, so it
-lives here, in a script the workflows call, NOT in the Makefile / make.ps1 (which
-are the developer-facing build files and know only how to *build* libs). The PR
-jobs have their own orchestration (`pr_libs_cache.py`).
+This orchestration sequences the `oci_libs_cache.py` / `branch_libs_cache.py` /
+`promote_libs_cache.py` primitives around the build command it is handed after
+`--`, instead of building LLVM directly; it does not reimplement any caching
+itself. It is CI-only logic, so it lives here, in a script the workflows call, NOT
+in the Makefile / make.ps1 (which are the developer-facing build files and know
+only how to *build* libs). PR builds have their own orchestration
+(`pr_libs_cache.py`).
 
 Modes:
 

--- a/.ci-scripts/libs-cache/resolve_libs_cache_test.py
+++ b/.ci-scripts/libs-cache/resolve_libs_cache_test.py
@@ -11,8 +11,9 @@ through `run()`, so monkeypatching `run` lets us assert the exact primitive
 sequence and exit code for every mode/path without any subprocess or network. The
 load-bearing invariants pinned here:
   - consumer mode never pushes the MAIN cache (the warmer is its only writer);
-  - the warmer promotes a branch artifact on a main miss before cold-building, and
-    a failed promote falls through to build+push rather than failing the job;
+  - the warmer promotes a branch artifact on a main-cache miss before
+    cold-building, and a failed promote falls through to build+push rather than
+    failing the job;
   - `--branch-cache` consumer mode pulls the branch cache for reuse and pushes it
     best-effort (a push failure does NOT fail the job), and a MAIN hit short-circuits
     before any branch op (so the flag self-gates on a warm main cache);
@@ -134,7 +135,7 @@ def test_branch_cache_main_hit_short_circuits():
 
 
 def test_branch_cache_reuse_on_main_miss():
-    # main miss -> branch hit -> reuse, no build, no push.
+    # main-cache miss -> branch hit -> reuse, no build, no push.
     calls, code = run_main(BRANCH, {'main:pull': 1, 'branch:pull': 0})
     check('branch reuse calls', calls, ['main:pull', 'branch:pull'])
     check('branch reuse code', code, 0)
@@ -175,7 +176,7 @@ def test_warm_hit():
 
 
 def test_warm_promotes_on_branch_hit():
-    # main miss -> branch hit -> promote -> done. No build, no main push.
+    # main-cache miss -> branch hit -> promote -> done. No build, no main push.
     calls, code = run_main(WARM, {'main:exists': 1, 'branch:exists': 0,
                                   'promote': 0})
     check('warm promote calls', calls,
@@ -257,7 +258,7 @@ def test_require_hit_branch_main_hit_short_circuits():
 
 
 def test_require_hit_branch_reuse_on_main_miss():
-    # main miss -> branch hit -> run against the branch-built libs, no fail.
+    # main-cache miss -> branch hit -> run against the branch-built libs, no fail.
     calls, code = run_main(REQUIRE_HIT_BRANCH, {'main:pull': 1, 'branch:pull': 0})
     check('require-hit branch reuse calls', calls, ['main:pull', 'branch:pull'])
     check('require-hit branch reuse code', code, 0)


### PR DESCRIPTION
The scripts in `.ci-scripts/libs-cache/` described their options and behavior by naming the specific workflows and jobs that call them: `branch_libs_cache.py` named "weekly," `pr_libs_cache.py` and `oci_libs_cache.py` named "a maybe-build job," and several enumerated "non-fork PR runs" to explain when a push has `packages: write`. Naming the caller couples a reusable script to its callers, so the description goes stale when a workflow changes which options it passes, and the fix would land in a different file that nobody thinks to touch.

This rewrites the docstrings and argparse help across the entry scripts (`branch`, `oci`, `pr`, `resolve`, `promote`) and the branch-cache pruner to describe what each option does. Which workflow depends on what already lives in `.known-couplings/`, so nothing is lost. Design-role words ("warmer," "consumer") and sibling-script references stay — those aren't the callers the issue is about.

It also replaces coined jargon the issue calls out ("main miss," "pull-main-or-build," "changed-libs build," "maybe-build mode") with plain language, including in a couple of test-file comments.

Closes #5654
