### PR TITLE
Keep the TCP swarm draw under its memory cap

### DIFF
--- a/.known-couplings/tcp-swarm-memory-budget.md
+++ b/.known-couplings/tcp-swarm-memory-budget.md
@@ -1,0 +1,39 @@
+# The tcp-swarm memory budget's cost model tracks the engine's per-object and per-read-buffer allocation
+
+The tcp-swarm orchestrator (`test/rt-stress/tcp-swarm/orchestrate_tcp.py`) draws
+each workload against a memory budget (`MEM_BUDGET_BYTES`) so no draw exceeds the
+`RLIMIT_AS` cap the run is launched under. A draw over the cap is killed by the
+runtime's own out-of-memory abort (`ponyint_virt_alloc`), which reads like a runtime
+crash but is really the test asking for more memory than its cap allows -- a false
+failure. The budget is what prevents it.
+
+The budget uses `est_peak_bytes`, which estimates the engine's peak memory from a few
+measured coefficients:
+
+- `MEM_OBJ_BYTES * concurrency * messages * writev_chunks` -- the pending vectored-write
+  buffer objects. `_Keystream.make_chunks` (`main.pony`) allocates `writev_chunks`
+  `Array[U8]` objects per message, *regardless of payload* (the extras are zero-length
+  when the chunk count exceeds the payload), and the `Spawner` keeps `concurrency`
+  connections in flight. The term assumes exactly that object count and that live-set
+  size.
+- `MEM_RB_FACTOR * concurrency * read_buffer` and `connections * read_buffer` -- the
+  read buffers, one per live connection (both endpoints) plus a conservative churn
+  term. Sized by `--read-buffer-size`.
+
+If the engine's per-object cost, the read buffer, or `TCPConnection`'s buffering
+changes -- e.g. `make_chunks` starts coalescing empty chunks, or the read path changes
+how much it holds -- the coefficients drift. Under-estimating lets an over-cap draw
+through (the false OOM this exists to prevent); over-estimating silently over-trims and
+loses swarm coverage. The coupling is silent: `orchestrate_tcp_test.py` checks that
+`est_peak_bytes` stays within budget, NOT that `est_peak_bytes` matches the engine's
+real memory -- so a drift passes the unit test and only shows up as a CI OOM (or as
+quietly shrunken draws). The constants are first-CI-run calibration items; the churn
+term's shape (`connections * read_buffer`) is an unvalidated hypothesis (the CI OOM
+seeds with huge connection counts could not be reproduced on the slow local loopback).
+
+Run: re-measure the engine's peak memory across the levers and re-fit the constants --
+build the engine debug and, polling `/proc/<pid>/status` `VmPeak`/`VmHWM`, sweep e.g.
+`./tcp_swarm --write-shape writev --writev-chunks 2048 --payload-size 8 --messages 8
+--concurrency {64,128} --connections 2000` and confirm `est_peak_bytes` still bounds
+the observed peak with margin. There is no automated regression test -- the engine
+run is loopback-speed and memory-heavy, so it stays a manual re-measure.

--- a/test/rt-stress/tcp-swarm/README.md
+++ b/test/rt-stress/tcp-swarm/README.md
@@ -95,13 +95,22 @@ occupies the port before any client dials, so the default `localhost` is fine.
 ## Memory and time bounds
 
 - **Memory** — the orchestrator caps each run at 8 GiB of address space
-  (`RLIMIT_AS`). Real RSS is tiny (~124 MiB worst case at concurrency 256, 64 KiB
-  payload), but the Pony runtime reserves a flat ~3.5 GiB of *virtual* address space
-  regardless of config, and `RLIMIT_AS` caps virtual — a 4 GiB cap sat ~86% full at
-  baseline and risked a false OOM on a high-thread run. That RSS figure was measured
-  before the `--writev-chunks` lever; a heavy multi-batch draw (2048 chunks) builds
-  many more small buffer objects at once, so the peak there is not re-validated —
-  treat it as a first-CI-run calibration item.
+  (`RLIMIT_AS`), and the *draw itself* is bounded so no config can reach that cap. A
+  config that did would be killed by the runtime's own out-of-memory abort — which
+  reads like a runtime crash but is really the draw asking for more memory than the
+  cap allows, a false failure. So the memory-driving levers (connections, concurrency,
+  messages, payload, writev-chunks, read-buffer) are drawn against a shared memory
+  budget (`MEM_BUDGET_BYTES`, 2 GiB of workload under the cap): the draw spends the
+  budget, and once it is spent the remaining levers are trimmed to fit. The levers are
+  drawn in a per-seed *random order*, so the trimmed lever rotates — on one seed a big
+  `--writev-chunks` squeezes concurrency and messages, on another a big connection
+  count squeezes `--writev-chunks` — and every lever still reaches large on some
+  seeds, keeping the swarm a swarm. Why 8 GiB and not 4: the Pony runtime reserves a
+  flat ~3.5 GiB of *virtual* address space regardless of config and `RLIMIT_AS` caps
+  virtual, so a 4 GiB cap sat ~86% full at baseline and risked a false OOM on a
+  high-thread run. The budget's cost constants (used by `est_peak_bytes`) are
+  calibrated from local measurement with a margin and are first-CI-run calibration
+  items; see `.known-couplings/tcp-swarm-memory-budget.md`.
 - **Time** — the per-run clamp (`clamp_run`) bounds round-trips
   (`connections * messages`) and total bytes (`connections * messages * payload`),
   so an outsized draw (e.g. 100k conns × 64 msgs × 64 KiB ≈ 400 GB) is trimmed.

--- a/test/rt-stress/tcp-swarm/main.pony
+++ b/test/rt-stress/tcp-swarm/main.pony
@@ -191,6 +191,13 @@ primitive _Keystream
     `writev` -- contiguous over `start .. start + total`, so the echo verifies
     identically regardless of write shape.
     """
+    // COUPLING: this allocates `nchunks` buffer objects per call regardless of
+    // payload size (the extras are zero-length when nchunks > total). The
+    // orchestrator's memory budget models peak memory as
+    // OBJ_BYTES * concurrency * messages * writev_chunks off exactly this count
+    // (est_peak_bytes in orchestrate_tcp.py) -- change how many objects this creates
+    // and the budget can let an OOM through. See
+    // .known-couplings/tcp-swarm-memory-budget.md.
     recover val
       let out = Array[ByteSeq]
       let n = if nchunks == 0 then 1 else nchunks end

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp.py
@@ -44,10 +44,9 @@ DEFAULT_TIMEOUT_SECONDS = 6000
 # 8 GiB, not 4: the Pony runtime reserves a flat ~3.5 GiB of VIRTUAL address space
 # (measured, constant across configs), and RLIMIT_AS caps virtual, not RSS -- so a
 # 4 GiB cap sits ~86% full before the workload runs and a high --ponymaxthreads run
-# could trip a FALSE OOM. Real RSS is tiny (~124 MiB worst case measured -- before
-# the writev-chunks lever, whose heavy multi-batch draws build many more small
-# buffer objects; that peak is a first-CI-run calibration item), so 8 GiB has no
-# downside and removes the false-kill risk.
+# could trip a FALSE OOM. 8 GiB has no downside and removes that risk. This cap is
+# the backstop, not the primary bound: the draw is separately kept under it by the
+# memory budget below (see est_peak_bytes), so a healthy workload never reaches it.
 DEFAULT_MEM_LIMIT_MB = 8192
 
 
@@ -127,13 +126,148 @@ def draw_bucketed(rng, buckets):
     return rng.randint(lo, hi)
 
 
+# --------------------------------------------------------------- memory budget
+
+# The draw must never pick a workload whose peak memory exceeds the RLIMIT_AS cap the
+# orchestrator runs each seed under (see _capture / DEFAULT_MEM_LIMIT_MB). A workload
+# that does is killed by the runtime's own out-of-memory abort (ponyint_virt_alloc) --
+# which reads like a runtime crash but is really the test asking for more memory than
+# its own cap allows, a false failure. So every memory-driving lever is drawn against
+# a shared budget: the draw spends it, and once it is spent the remaining levers are
+# trimmed to fit.
+#
+# The levers are drawn in a per-seed RANDOM order (see _draw_memory_levers), and that
+# is the point. A fixed trim order would always shave the same lever -- we would never
+# test a large writev-chunks, because it would always be the first cut -- throwing away
+# swarm coverage. With a random order the trimmed lever rotates: on one seed
+# writev-chunks wins the budget and concurrency/messages shrink, on another connections
+# wins and writev-chunks is forced to 4. Every lever still reaches large on some
+# fraction of seeds. This mirrors the generative harness's clamp_ttl (big chains force
+# ttl small), generalized so the sacrificed lever is not always the same one.
+#
+# est_peak_bytes estimates peak WORKLOAD bytes on top of the runtime's flat virtual
+# reservation. Terms and constants are calibrated from local measurement with a fat
+# margin (measured: writev-chunks=2048 at concurrency 64 / 8 messages peaks ~460 MiB
+# RSS; a write-shape run stays ~15 MiB flat regardless of connection count). They are
+# BEST GUESSES to confirm from the first CI run, like clamp_run's ceilings. The churn
+# term (connections * read_buffer) is the least certain: the CI out-of-memory seeds
+# with huge connection counts (36902, 72178) could not be reproduced locally (WSL2
+# loopback is too slow to build the queue depth CI builds), so its SHAPE is a
+# hypothesis -- it covers the one such seed we saw (which had a large read buffer) but
+# does not bound a small-buffer / huge-connections draw, which we have no evidence
+# OOMs. Validate with a raised-cap CI run.
+# COUPLING: the constants track the engine's per-object and per-read-buffer memory --
+# re-measure if make_chunks, the read buffer, or TCPConnection buffering changes. See
+# .known-couplings/tcp-swarm-memory-budget.md.
+MEM_BUDGET_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB workload, well under the 8 GiB cap
+MEM_OBJ_BYTES = 2048        # per pending writev buffer object (margin over ~832 B virt)
+MEM_RB_FACTOR = 4           # live read buffers: client + server, plus headroom
+
+# The memory-driving levers, drawn in a shuffled order against MEM_BUDGET_BYTES.
+# payload is here (concurrency * messages * payload reaches ~1 GiB); write-shape is
+# NOT (it carries no magnitude, but it is drawn before these so chunks_eff is known).
+MEM_LEVERS = ["connections", "concurrency", "messages", "payload",
+              "writev_chunks", "read_buffer"]
+
+
+def est_peak_bytes(concurrency, messages, payload, use_writev, writev_chunks,
+                   read_buffer, connections):
+    """Estimated peak workload memory (bytes) for a drawn config. Monotonic
+    non-decreasing in each lever (flat in writev_chunks for a plain write), which is
+    what makes the fit helpers below a simple clamp. See the block comment above."""
+    chunks_eff = writev_chunks if use_writev else 1
+    return (MEM_OBJ_BYTES * concurrency * messages * chunks_eff  # pending write bufs
+            + MEM_RB_FACTOR * concurrency * read_buffer          # live read buffers
+            + concurrency * messages * payload                   # bytes in flight
+            + connections * read_buffer)                         # conservative churn
+
+
+def _fit_discrete(key, drawn, chosen, values):
+    """Largest value in `values` (ascending) that is <= `drawn` and keeps est_peak
+    within budget, with the other levers at their `chosen` values. Precondition:
+    `drawn` is a member of `values` (every caller draws it from the same list), so
+    values[0] (the minimum) always fits and a fit always exists. Consumes no rng."""
+    best = values[0]
+    for v in values:
+        if v > drawn:
+            break
+        trial = dict(chosen)
+        trial[key] = v
+        if est_peak_bytes(**trial) <= MEM_BUDGET_BYTES:
+            best = v
+    return best
+
+
+def _fit_continuous(key, drawn, chosen, floor):
+    """Largest integer in [floor, drawn] that keeps est_peak within budget, with the
+    other levers at their `chosen` values. `floor` always fits, so a fit exists.
+    Consumes no rng."""
+    trial = dict(chosen)
+    trial[key] = drawn
+    if est_peak_bytes(**trial) <= MEM_BUDGET_BYTES:
+        return drawn
+    lo, hi, best = floor, drawn, floor
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        trial[key] = mid
+        if est_peak_bytes(**trial) <= MEM_BUDGET_BYTES:
+            best, lo = mid, mid + 1
+        else:
+            hi = mid - 1
+    return best
+
+
+def _draw_memory_levers(rng, use_writev):
+    """Draw the memory levers in a per-seed random order against MEM_BUDGET_BYTES.
+    Undrawn levers reserve their minimum, so every pick leaves room for the rest and
+    the draw can never wedge (all-minimums is ~80 KB, far under budget). Each lever
+    consumes its usual draw once; the fit is a no-rng clamp, so total rng consumption
+    is fixed per seed. Returns the chosen values under internal keys."""
+    chosen = {
+        "connections": MIN_CONNECTIONS,
+        "concurrency": min(CONCURRENCY),
+        "messages": MESSAGE_BUCKETS["small"][0],
+        "payload": min(PAYLOAD_SIZES),
+        "writev_chunks": min(WRITEV_CHUNKS),
+        "read_buffer": min(READ_BUFFER_SIZES),
+        "use_writev": use_writev,
+    }
+    order = list(MEM_LEVERS)
+    rng.shuffle(order)
+    for lever in order:
+        if lever == "connections":
+            chosen[lever] = _fit_continuous(
+                lever, draw_bucketed(rng, CONNECTION_BUCKETS), chosen,
+                MIN_CONNECTIONS)
+        elif lever == "messages":
+            chosen[lever] = _fit_continuous(
+                lever, draw_bucketed(rng, MESSAGE_BUCKETS), chosen,
+                MESSAGE_BUCKETS["small"][0])
+        elif lever == "concurrency":
+            chosen[lever] = _fit_discrete(
+                lever, rng.choice(CONCURRENCY), chosen, CONCURRENCY)
+        elif lever == "payload":
+            chosen[lever] = _fit_discrete(
+                lever, rng.choice(PAYLOAD_SIZES), chosen, PAYLOAD_SIZES)
+        elif lever == "writev_chunks":
+            chosen[lever] = _fit_discrete(
+                lever, rng.choice(WRITEV_CHUNKS), chosen, WRITEV_CHUNKS)
+        elif lever == "read_buffer":
+            chosen[lever] = _fit_discrete(
+                lever, rng.choice(READ_BUFFER_SIZES), chosen, READ_BUFFER_SIZES)
+    return chosen
+
+
 def resolve_config(master_seed, max_threads, max_connections=None):
-    """Draw one TCP workload from a master seed. The draw ORDER is the
-    seed-stability contract: reorder any draw and every seed remaps (breaking a
-    historical --replay). --ponymaxthreads is drawn LAST because it is the only
-    host-dependent field (its randint width depends on the core count), so any
-    draw after it would remap across hosts. resolve_config(0, 8) is pinned in
-    orchestrate_tcp_test.py.
+    """Draw one TCP workload from a master seed. The draw is the seed-stability
+    contract: change it and every seed remaps (breaking a historical --replay), so
+    change it deliberately and regenerate the pinned goldens in orchestrate_tcp_test.py
+    (resolve_config(0, 8) etc.). It stays deterministic per seed, so --replay holds.
+    The memory levers are drawn in a per-seed SHUFFLED order against a memory budget
+    (see _draw_memory_levers) -- that shuffle is seeded only from master_seed, so it is
+    host-independent. --ponymaxthreads is drawn LAST because it is the only
+    host-dependent field (its randint width depends on the core count), so any draw
+    after it would remap across hosts.
 
     max_connections, if set, caps the drawn connection count after the draw (no rng
     consumed, so within-host seed stability holds). Windows CI passes a small value
@@ -142,14 +276,20 @@ def resolve_config(master_seed, max_threads, max_connections=None):
     rng = random.Random(master_seed)
 
     workload = {}
-    workload["connections"] = draw_bucketed(rng, CONNECTION_BUCKETS)
-    workload["concurrency"] = rng.choice(CONCURRENCY)
-    payload = rng.choice(PAYLOAD_SIZES)
+    # write-shape is drawn BEFORE the memory levers: it carries no magnitude, but the
+    # memory budget needs to know whether a writev-chunks draw counts (chunks_eff is 1
+    # for a plain write). The memory levers then draw in a shuffled order against the
+    # budget so no config can exceed the RLIMIT_AS cap; see _draw_memory_levers.
+    use_writev = rng.choice(WRITE_SHAPES) == "writev"
+    mem = _draw_memory_levers(rng, use_writev)
+    payload = mem["payload"]
+    read_buffer = mem["read_buffer"]
+    workload["connections"] = mem["connections"]
+    workload["concurrency"] = mem["concurrency"]
     workload["payload-size"] = payload
-    workload["messages"] = draw_bucketed(rng, MESSAGE_BUCKETS)
-    workload["write-shape"] = rng.choice(WRITE_SHAPES)
-    workload["writev-chunks"] = rng.choice(WRITEV_CHUNKS)
-    read_buffer = rng.choice(READ_BUFFER_SIZES)
+    workload["messages"] = mem["messages"]
+    workload["write-shape"] = "writev" if use_writev else "write"
+    workload["writev-chunks"] = mem["writev_chunks"]
     workload["read-buffer-size"] = read_buffer
     workload["yield-after-reading"] = rng.choice(YIELD_SIZES)
     workload["yield-after-writing"] = rng.choice(YIELD_SIZES)

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
@@ -21,54 +21,55 @@ def check(name, condition):
 
 
 def test_resolve_config_golden():
-    # Pinned draws: a reordered/narrowed/added draw changes these and would
-    # silently remap every seed (breaking --replay). Regenerate deliberately if
-    # the draw is intended to change. Three seeds spanning both write shapes, so a
-    # change is unlikely to leave all untouched by luck AND a regression that
-    # touched only one write-shape branch can't hide. Seed 0 is a plain writev;
-    # seed 5 is write-shape=write (payload 1, hard close); seed 16 exercises the
-    # multi-batch writev path (writev, writev-chunks 2048 > IOV_MAX, payload >=
-    # chunks) plus expect > 0 and a hard close.
+    # Pinned draws: any change to the draw -- a reordered/narrowed/added draw, or a
+    # budget/cost-model change -- changes these pinned configs, which is the visible
+    # signal that every seed's draw has silently remapped (breaking --replay).
+    # Regenerate deliberately if the draw is meant to change. The seeds are chosen to
+    # span the draw's branches so a change can't leave all three untouched by luck:
+    # seed 0 is a plain writev; seed 6 is write-shape=write AND lands on the memory
+    # budget (its connections, messages, and payload are all trimmed to fit, so a
+    # cost-model change remaps it, not only a draw-order change); seed 23 exercises the
+    # multi-batch writev path (writev-chunks 2048 > IOV_MAX, payload >= chunks) with
+    # expect on and a hard close.
     golden0 = {
         "master_seed": 0,
-        "runtime": {"ponymaxthreads": 5, "ponypin": True},
+        "runtime": {"ponymaxthreads": 6, "ponynoscale": True},
         "workload": {
-            "close": "graceful", "concurrency": 8, "connections": 75126,
-            "expect": 0, "messages": 26, "payload-size": 1024,
+            "close": "graceful", "concurrency": 32, "connections": 11236,
+            "expect": 0, "messages": 6, "payload-size": 64,
             "read-buffer-size": 65536, "write-shape": "writev",
             "writev-chunks": 64,
-            "yield-after-reading": 1024, "yield-after-writing": 16384,
-        },
-    }
-    golden5 = {
-        "master_seed": 5,
-        "runtime": {"ponymaxthreads": 4, "ponynoblock": True},
-        "workload": {
-            "close": "hard", "concurrency": 256, "connections": 13749,
-            "expect": 0, "messages": 32, "payload-size": 1,
-            "read-buffer-size": 128, "write-shape": "write",
-            "writev-chunks": 4,
-            "yield-after-reading": 1024, "yield-after-writing": 1024,
-        },
-    }
-    golden16 = {
-        "master_seed": 16,
-        "runtime": {"ponymaxthreads": 5, "ponynoblock": True,
-                    "ponynoscale": True},
-        "workload": {
-            "close": "hard", "concurrency": 32, "connections": 17745,
-            "expect": 16384, "messages": 1, "payload-size": 16384,
-            "read-buffer-size": 16384, "write-shape": "writev",
-            "writev-chunks": 2048,
             "yield-after-reading": 64, "yield-after-writing": 16384,
+        },
+    }
+    golden6 = {
+        "master_seed": 6,
+        "runtime": {"ponymaxthreads": 5, "ponynoblock": True},
+        "workload": {
+            "close": "hard", "concurrency": 256, "connections": 31735,
+            "expect": 0, "messages": 1, "payload-size": 256,
+            "read-buffer-size": 65536, "write-shape": "write",
+            "writev-chunks": 2048,
+            "yield-after-reading": 1024, "yield-after-writing": 64,
+        },
+    }
+    golden23 = {
+        "master_seed": 23,
+        "runtime": {"ponymaxthreads": 6, "ponynoscale": True},
+        "workload": {
+            "close": "hard", "concurrency": 16, "connections": 1370,
+            "expect": 4096, "messages": 7, "payload-size": 4096,
+            "read-buffer-size": 65536, "write-shape": "writev",
+            "writev-chunks": 2048,
+            "yield-after-reading": 1024, "yield-after-writing": 64,
         },
     }
     check("resolve_config(0, 8) matches the pinned draw",
           o.resolve_config(0, 8) == golden0)
-    check("resolve_config(5, 8) matches the pinned draw",
-          o.resolve_config(5, 8) == golden5)
-    check("resolve_config(16, 8) matches the pinned draw",
-          o.resolve_config(16, 8) == golden16)
+    check("resolve_config(6, 8) matches the pinned draw",
+          o.resolve_config(6, 8) == golden6)
+    check("resolve_config(23, 8) matches the pinned draw",
+          o.resolve_config(23, 8) == golden23)
     check("resolve_config is deterministic",
           o.resolve_config(7, 8) == o.resolve_config(7, 8))
 
@@ -109,6 +110,143 @@ def test_clamp_run():
         if (c * m > o.RUN_MAX_EXCHANGES) or (c * m * p > o.RUN_MAX_BYTES):
             over += 1
     check("clamp: no drawn seed exceeds the ceilings", over == 0)
+
+
+def test_memory_budget():
+    # No drawn config may exceed the memory budget. A draw over the RLIMIT_AS cap gets
+    # killed by the runtime's own out-of-memory abort -- a false failure that reads
+    # like a runtime crash. Also confirm the budget isn't vacuous: some draws land near
+    # the ceiling, so it is a tight bound, not a ceiling nothing reaches.
+    over = 0
+    binds = 0
+    for seed in range(5000):
+        w = o.resolve_config(seed, 8)["workload"]
+        peak = o.est_peak_bytes(
+            w["concurrency"], w["messages"], w["payload-size"],
+            w["write-shape"] == "writev", w["writev-chunks"],
+            w["read-buffer-size"], w["connections"])
+        if peak > o.MEM_BUDGET_BYTES:
+            over += 1
+        if peak > (o.MEM_BUDGET_BYTES * 9) // 10:
+            binds += 1
+    check("memory: no drawn config exceeds the budget", over == 0)
+    check("memory: the budget binds (some draws land near the ceiling)", binds > 0)
+
+
+def test_memory_budget_trims():
+    # The fit helpers -- the building block of the rotating draw -- trim a value that
+    # would break the budget down to the largest one that fits (never below the
+    # minimum) and leave a fitting value alone.
+    mins = {"connections": o.MIN_CONNECTIONS, "concurrency": min(o.CONCURRENCY),
+            "messages": o.MESSAGE_BUCKETS["small"][0], "payload": min(o.PAYLOAD_SIZES),
+            "writev_chunks": min(o.WRITEV_CHUNKS),
+            "read_buffer": min(o.READ_BUFFER_SIZES), "use_writev": True}
+    check("fit_discrete: a fitting value passes through unchanged",
+          o._fit_discrete("read_buffer", 65536, mins, o.READ_BUFFER_SIZES) == 65536)
+    # With connections at the max, a 64 KiB read buffer blows the budget -> trimmed to
+    # a smaller listed value. Boundary: the trimmed value fits and the NEXT larger
+    # listed value would not (so the helper returns the largest that fits, not any).
+    loaded = dict(mins, connections=100000)
+    trimmed = o._fit_discrete("read_buffer", 65536, loaded, o.READ_BUFFER_SIZES)
+    nxt = o.READ_BUFFER_SIZES[o.READ_BUFFER_SIZES.index(trimmed) + 1]
+    check("fit_discrete: trims to the largest listed value that fits (next would not)",
+          trimmed < 65536
+          and o.est_peak_bytes(**dict(loaded, read_buffer=trimmed))
+          <= o.MEM_BUDGET_BYTES < o.est_peak_bytes(**dict(loaded, read_buffer=nxt)))
+    # Continuous: a huge connection count is trimmed when the read buffer is large,
+    # never below the MIN_CONNECTIONS floor. Boundary: fc fits and fc+1 does not, so
+    # the binary search returns the exact largest fitting integer (catches an off-by-one
+    # in the comparison).
+    big_rb = dict(mins, read_buffer=65536)
+    fc = o._fit_continuous("connections", 100000, big_rb, o.MIN_CONNECTIONS)
+    check("fit_continuous: trims to the exact budget boundary (fc fits, fc+1 doesn't)",
+          o.MIN_CONNECTIONS <= fc < 100000
+          and o.est_peak_bytes(**dict(big_rb, connections=fc))
+          <= o.MEM_BUDGET_BYTES < o.est_peak_bytes(**dict(big_rb, connections=fc + 1)))
+
+
+def test_est_peak_bytes_monotonic():
+    # The fit helpers' binary search / list scan are correct only if est_peak_bytes is
+    # non-decreasing in the swept lever. Guard that: a future non-monotonic cost term
+    # would break the search silently. Sweep each lever across its domain with the
+    # others fixed at a mid value.
+    base = {"connections": 10000, "concurrency": 32, "messages": 8, "payload": 1024,
+            "writev_chunks": 64, "read_buffer": 16384, "use_writev": True}
+    domains = {"connections": range(100, 100001, 2500),
+               "concurrency": o.CONCURRENCY,
+               "messages": range(1, 65),
+               "payload": o.PAYLOAD_SIZES,
+               "writev_chunks": o.WRITEV_CHUNKS,
+               "read_buffer": o.READ_BUFFER_SIZES}
+    non_monotone = []
+    for lever, values in domains.items():
+        prev = None
+        for v in values:
+            e = o.est_peak_bytes(**dict(base, **{lever: v}))
+            if prev is not None and e < prev:
+                non_monotone.append(lever)
+            prev = e
+    check("est_peak_bytes is non-decreasing in every lever: "
+          + (", ".join(sorted(set(non_monotone))) if non_monotone else "all monotone"),
+          not non_monotone)
+
+
+def test_memory_budget_rotates_the_trimmed_lever():
+    # Two properties, together the rotation:
+    #   (a) every memory lever reaches its largest value on some seed -- so a large
+    #       draw is never impossible for any of them (the swarm stays a swarm).
+    #   (b) every memory lever is trimmed below its rolled value on some seed.
+    # (b) is the rotation, and it holds for all six levers ONLY because the draw order
+    # is shuffled per seed. Under a fixed order only the LAST levers drawn ever trim --
+    # connections/concurrency/messages/payload would never trim -- so replacing the
+    # shuffle with identity fails this test. Trims are observed by wrapping the two fit
+    # helpers (they are where a value gets clamped down); the wrappers consume no rng,
+    # so the draw is unchanged.
+    levers = ("connections", "concurrency", "messages", "payload",
+              "writev_chunks", "read_buffer")
+    reached = {k: False for k in levers}
+    trimmed = {k: False for k in levers}
+    orig_d, orig_c = o._fit_discrete, o._fit_continuous
+
+    def wrap_d(key, drawn, chosen, values):
+        got = orig_d(key, drawn, chosen, values)
+        if got != drawn:
+            trimmed[key] = True
+        return got
+
+    def wrap_c(key, drawn, chosen, floor):
+        got = orig_c(key, drawn, chosen, floor)
+        if got != drawn:
+            trimmed[key] = True
+        return got
+
+    o._fit_discrete, o._fit_continuous = wrap_d, wrap_c
+    try:
+        for seed in range(4000):
+            w = o.resolve_config(seed, 8)["workload"]
+            if w["concurrency"] == max(o.CONCURRENCY):
+                reached["concurrency"] = True
+            if w["payload-size"] == max(o.PAYLOAD_SIZES):
+                reached["payload"] = True
+            if w["writev-chunks"] == max(o.WRITEV_CHUNKS):
+                reached["writev_chunks"] = True
+            if w["read-buffer-size"] == max(o.READ_BUFFER_SIZES):
+                reached["read_buffer"] = True
+            if w["connections"] > o.CONNECTION_BUCKETS["medium"][1]:
+                reached["connections"] = True   # into the large connection bucket
+            if w["messages"] == o.MESSAGE_BUCKETS["large"][1]:
+                reached["messages"] = True
+    finally:
+        o._fit_discrete, o._fit_continuous = orig_d, orig_c
+    never_large = [k for k, v in reached.items() if not v]
+    never_trimmed = [k for k, v in trimmed.items() if not v]
+    check("memory: every lever reaches large on some seed: "
+          + (", ".join(never_large) + " never do" if never_large else "all do"),
+          not never_large)
+    check("memory: every lever is trimmed on some seed (the shuffle rotates the "
+          "trim): " + (", ".join(never_trimmed) + " never trim" if never_trimmed
+                       else "all trim"),
+          not never_trimmed)
 
 
 def test_resolve_config_coverage_and_invariants():
@@ -333,6 +471,9 @@ def test_rlimit_as_supported():
 
 def main():
     for fn in (test_resolve_config_golden, test_clamp_run,
+               test_memory_budget, test_memory_budget_trims,
+               test_est_peak_bytes_monotonic,
+               test_memory_budget_rotates_the_trimmed_lever,
                test_max_connections_cap,
                test_resolve_config_coverage_and_invariants,
                test_ponymaxthreads_is_last_and_host_dependent,


### PR DESCRIPTION
The scheduled Linux TCP swarm stress job aborted on main. Three seeds drew workloads whose peak memory exceeded the 8 GiB `RLIMIT_AS` cap each run is launched under, so the runtime's out-of-memory abort fired -- which looks like a runtime crash but is really the draw asking for more memory than its own cap allows, a false failure. The dominant driver was the writev-chunks lever: `make_chunks` allocates one buffer object per chunk regardless of payload, so a large chunk count builds a huge number of objects.

The memory-driving levers (connections, concurrency, messages, payload, writev-chunks, read-buffer) are now drawn against a shared memory budget. The draw spends the budget, and once it is spent the remaining levers are trimmed to fit, so no config can reach the cap. The levers are drawn in a per-seed random order, so the lever that gets trimmed rotates seed to seed -- a fixed trim order would always shave the same one and gut the swarm's coverage. Every lever still reaches its largest value on some seed.

The churn term of the cost model (`connections * read_buffer`) is an unvalidated hypothesis: the huge-connection OOM seeds couldn't be reproduced on the slow local loopback, so the constants are first-CI-run calibration items, documented in `.known-couplings/tcp-swarm-memory-budget.md`. The `RLIMIT_AS` cap stays as the backstop.
