### PR TITLE
Add docstring to Randomness.shuffle

### DIFF
--- a/packages/pony_check/randomness.pony
+++ b/packages/pony_check/randomness.pony
@@ -251,6 +251,9 @@ class ref Randomness
     (_random.next() % 2) == 0
 
   fun ref shuffle[T](array: Array[T] ref) =>
+    """
+    Shuffle the elements of the array into a random order, mutating the array.
+    """
     _random.shuffle[T](array)
 
 


### PR DESCRIPTION
`Randomness.shuffle` was the only public method on `Randomness` without a docstring. It delegates to `Random.shuffle`, so it takes that method's docstring: "Shuffle the elements of the array into a random order, mutating the array."

No release note: this matches the precedent of #5674, the sibling docstring-only change to the same file, which shipped without one — there's no functional difference a library user would notice.

Closes #5675