### PR TITLE
Fix `term` mishandling of unrecognized escape sequences

### DIFF
--- a/.release-notes/fix-term-unrecognized-escape-sequences.md
+++ b/.release-notes/fix-term-unrecognized-escape-sequences.md
@@ -1,0 +1,5 @@
+## Fix `term` mishandling of unrecognized escape sequences
+
+The `term` package's input decoder mishandled terminal escape sequences it didn't recognize. An unrecognized sequence such as Shift-Tab (`ESC[Z`) leaked stray characters into the input; an unknown keypad code stalled the decoder so following keystrokes were dropped or garbled; and an out-of-range numeric parameter could be read as a different, valid key.
+
+The decoder now reads each escape sequence through to its end and discards it when it isn't recognized, so an unrecognized key no longer inserts stray text, stalls input, or fires the wrong key. Recognized keys are unaffected.

--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -24,6 +24,10 @@ actor \nodoc\ Main is TestList
     test(_TestANSITermModifiers)
     test(_TestANSITermAltWord)
     test(_TestANSITermUnrecognizedEscape)
+    test(_TestANSITermUnknownKeypad)
+    test(_TestANSITermParamOverflow)
+    test(_TestANSITermPrivateParam)
+    test(_TestANSITermControlAbort)
     test(_TestANSITermTimeoutFlush)
     test(_TestANSITermRealTimerFlush)
     test(_TestANSITermDispose)
@@ -329,24 +333,20 @@ class \nodoc\ iso _TestANSITermAltWord is UnitTest
 
 class \nodoc\ iso _TestANSITermUnrecognizedEscape is UnitTest
   """
-  An unrecognised escape sequence flushes its buffered bytes back to the
-  notifier as plain input.
-
-  Current behaviour, pinned here: the byte that terminates the unrecognised
-  sequence is dropped rather than flushed (the `x`, `Z`, and `z` below never
-  reach the notifier). Whether that byte should be preserved is an open
-  question.
+  A complete but unrecognised escape sequence, or an unreportable Alt+char, is
+  discarded; nothing from it reaches the notifier. A plain byte after it still
+  passes through.
   """
   fun name(): String => "term/ANSITerm.unrecognized-escape"
 
   fun ref apply(h: TestHelper) =>
     let expected = recover val
-      // ESC x      -> flush [ESC];             x dropped
-      // ESC [ Z    -> flush [ESC, '['];        Z dropped; Y passes through
-      // ESC O z    -> flush [ESC, 'O'];        z dropped
-      // ESC [1;2 Z -> flush [ESC, '[', '1', '2']; Z dropped (modifier state)
-      [ "byte 27"; "byte 27"; "byte 91"; "byte 89"; "byte 27"; "byte 79"
-        "byte 27"; "byte 91"; "byte 49"; "byte 50" ]
+      // ESC x      -> Alt+x, no way to report -> discarded
+      // ESC [ Z    -> unrecognised CSI final   -> discarded; Y passes through
+      // ESC O z    -> unrecognised SS3 final   -> discarded
+      // ESC [1;2 Z -> unrecognised CSI final   -> discarded
+      // Only the plain Y survives.
+      [ "byte 89" ]
     end
     let timers = Timers
     let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
@@ -354,6 +354,90 @@ class \nodoc\ iso _TestANSITermUnrecognizedEscape is UnitTest
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
     term.apply(_Bytes("\x1Bx\x1B[ZY\x1BOz\x1B[1;2Z"))
+    term.prompt("")
+
+class \nodoc\ iso _TestANSITermUnknownKeypad is UnitTest
+  """
+  An unrecognised keypad code is discarded without stalling the decoder: a
+  following recognised sequence still decodes.
+  """
+  fun name(): String => "term/ANSITerm.unknown-keypad"
+
+  fun ref apply(h: TestHelper) =>
+    // ESC[16~ has no keypad mapping -> discarded. A stalled decoder would then
+    // swallow the plain 'x' as a sequence byte; here it passes through, and the
+    // following ESC[3~ decodes cleanly.
+    let expected = recover val ["byte 120"; "delete 000"] end
+    let timers = Timers
+    let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(2_000_000_000)
+    term.apply(_Bytes("\x1B[16~x\x1B[3~"))
+    term.prompt("")
+
+class \nodoc\ iso _TestANSITermParamOverflow is UnitTest
+  """
+  An oversized numeric parameter is clamped so it cannot wrap into a different
+  valid key or modifier: the keypad code is discarded, and the modifier decodes
+  as no modifiers rather than aliasing to a real one.
+  """
+  fun name(): String => "term/ANSITerm.param-overflow"
+
+  fun ref apply(h: TestHelper) =>
+    // ESC[289~: 289 would wrap a U8 to 33 (F19); clamped, it is discarded.
+    // ESC[1;258A: 258 would wrap to 2 (shift); clamped, it is no modifiers.
+    let expected = recover val ["up 000"] end
+    let timers = Timers
+    let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(2_000_000_000)
+    term.apply(_Bytes("\x1B[289~\x1B[1;258A"))
+    term.prompt("")
+
+class \nodoc\ iso _TestANSITermPrivateParam is UnitTest
+  """
+  A CSI sequence that carries a private parameter marker (such as `?`) is
+  discarded even when it ends in an otherwise-recognised final byte, rather than
+  firing that key.
+  """
+  fun name(): String => "term/ANSITerm.private-param"
+
+  fun ref apply(h: TestHelper) =>
+    // ESC[?A: '?' marks the sequence non-standard, so the 'A' final does not
+    // fire up; the sequence is discarded and the trailing 'x' passes through.
+    let expected = recover val ["byte 120"] end
+    let timers = Timers
+    let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(2_000_000_000)
+    term.apply(_Bytes("\x1B[?Ax"))
+    term.prompt("")
+
+class \nodoc\ iso _TestANSITermControlAbort is UnitTest
+  """
+  A control byte in the middle of an escape sequence aborts it and is still
+  delivered; a second ESC restarts a fresh sequence rather than leaking the
+  rest as text.
+  """
+  fun name(): String => "term/ANSITerm.control-abort"
+
+  fun ref apply(h: TestHelper) =>
+    // ESC[3 then CR     -> sequence aborted, CR delivered (byte 13).
+    // ESC O then ESC[A  -> mid-SS3 ESC restarts; up decodes, nothing leaks.
+    // ESC then CR       -> aborted at the start, CR delivered.
+    // ESC[1 then ESC[A  -> mid-CSI ESC restarts; up decodes, nothing leaks.
+    let expected = recover val
+      ["byte 13"; "up 000"; "byte 13"; "up 000"]
+    end
+    let timers = Timers
+    let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(2_000_000_000)
+    term.apply(_Bytes("\x1B[3\r\x1BO\x1B[A\x1B\r\x1B[1\x1B[A"))
     term.prompt("")
 
 class \nodoc\ iso _TestANSITermTimeoutFlush is UnitTest

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -53,6 +53,7 @@ actor ANSITerm
   var _escape: _EscapeState = _EscapeNone
   var _esc_num: U8 = 0
   var _esc_mod: U8 = 0
+  var _esc_private: Bool = false
   embed _esc_buf: Array[U8] = Array[U8]
   var _closed: Bool = false
 
@@ -108,57 +109,40 @@ actor ANSITerm
           _escape = _EscapeCSI
           _esc_buf.push(c)
         else
-          _esc_flush()
+          // ESC then some other byte. A control byte (a second ESC restarts) or
+          // a high byte (a byte of a multi-byte character) is re-handled and
+          // delivered; a printable ASCII byte is an unreportable Alt+<char>, so
+          // it is discarded.
+          if (c < 0x20) or (c >= 0x7F) then
+            _abort_and_rehandle(c)
+          else
+            _esc_clear()
+          end
         end
       | _EscapeSS3 =>
-        match c
-        | 'A' => _up()
-        | 'B' => _down()
-        | 'C' => _right()
-        | 'D' => _left()
-        | 'H' => _home()
-        | 'F' => _end()
-        | 'P' => _fn_key(1)
-        | 'Q' => _fn_key(2)
-        | 'R' => _fn_key(3)
-        | 'S' => _fn_key(4)
+        if (c < 0x20) or (c >= 0x7F) then
+          _abort_and_rehandle(c)
         else
-          _esc_flush()
+          match c
+          | 'A' => _up()
+          | 'B' => _down()
+          | 'C' => _right()
+          | 'D' => _left()
+          | 'H' => _home()
+          | 'F' => _end()
+          | 'P' => _fn_key(1)
+          | 'Q' => _fn_key(2)
+          | 'R' => _fn_key(3)
+          | 'S' => _fn_key(4)
+          else
+            // Unrecognised SS3 final byte: discard the sequence.
+            _esc_clear()
+          end
         end
       | _EscapeCSI =>
-        match \exhaustive\ c
-        | 'A' => _up()
-        | 'B' => _down()
-        | 'C' => _right()
-        | 'D' => _left()
-        | 'H' => _home()
-        | 'F' => _end()
-        | '~' => _keypad()
-        | ';' =>
-          _escape = _EscapeMod
-        | if (c >= '0') and (c <= '9') =>
-          // Escape number.
-          _esc_num = (_esc_num * 10) + (c - '0')
-          _esc_buf.push(c)
-        else
-          _esc_flush()
-        end
+        _csi(c, false)
       | _EscapeMod =>
-        match \exhaustive\ c
-        | 'A' => _up()
-        | 'B' => _down()
-        | 'C' => _right()
-        | 'D' => _left()
-        | 'H' => _home()
-        | 'F' => _end()
-        | '~' => _keypad()
-        | if (c >= '0') and (c <= '9') =>
-          // Escape modifier.
-          _esc_mod = (_esc_mod * 10) + (c - '0')
-          _esc_buf.push(c)
-        else
-          _esc_flush()
-        end
+        _csi(c, true)
       end
     end
 
@@ -223,6 +207,75 @@ actor ANSITerm
     _timer = None
     _esc_flush()
 
+  fun ref _csi(c: U8, in_mod: Bool) =>
+    """
+    Handle one byte of a CSI sequence (ESC [ ...), reading parameter and
+    intermediate bytes until a final byte ends the sequence. A recognised final
+    byte dispatches its key; an unrecognised one, or one reached through a
+    non-standard parameter, discards the sequence. `in_mod` is true once a `;`
+    has been seen, so digits accumulate the modifier rather than the key number.
+    """
+    if (c >= '0') and (c <= '9') then
+      // Accumulate a parameter, clamping on every digit so an oversized value
+      // can't wrap a U8 into a different valid key or modifier.
+      let d = (c - '0').u16()
+      if in_mod then
+        _esc_mod = (((_esc_mod.u16() * 10) + d).min(255)).u8()
+      else
+        _esc_num = (((_esc_num.u16() * 10) + d).min(255)).u8()
+      end
+      _esc_buf.push(c)
+    elseif c == ';' then
+      // A parameter separator. The first one moves us into modifier parameters;
+      // any later ones are consumed as we read on to the final byte.
+      if not in_mod then
+        _escape = _EscapeMod
+      end
+      _esc_buf.push(c)
+    elseif (c >= 0x20) and (c <= 0x3F) then
+      // A parameter or intermediate byte we don't use (a private marker like
+      // `?`, a sub-parameter `:`, an intermediate). Keep reading to the final
+      // byte, but mark the sequence non-standard so it is discarded, not
+      // dispatched as if it were a plain key.
+      _esc_private = true
+      _esc_buf.push(c)
+    elseif (c >= 0x40) and (c <= 0x7E) then
+      // A final byte ends the sequence.
+      if _esc_private then
+        _esc_clear()
+      else
+        match c
+        | 'A' => _up()
+        | 'B' => _down()
+        | 'C' => _right()
+        | 'D' => _left()
+        | 'H' => _home()
+        | 'F' => _end()
+        | '~' => _keypad()
+        else
+          // Unrecognised final byte: discard the sequence.
+          _esc_clear()
+        end
+      end
+    else
+      // Control byte (< 0x20 or >= 0x7F): abort.
+      _abort_and_rehandle(c)
+    end
+
+  fun ref _abort_and_rehandle(c: U8) =>
+    """
+    Abort the escape sequence in progress. A new ESC starts a fresh sequence;
+    any other byte is passed straight to the notifier, so a control key pressed
+    mid-sequence still registers.
+    """
+    _esc_clear()
+    if c == 0x1B then
+      _escape = _EscapeStart
+      _esc_buf.push(0x1B)
+    else
+      _notify(this, c)
+    end
+
   fun ref _mod(): (Bool, Bool, Bool) =>
     """
     Set the modifier bools.
@@ -272,6 +325,10 @@ actor ANSITerm
     | 32 => _fn_key(18)
     | 33 => _fn_key(19)
     | 34 => _fn_key(20)
+    else
+      // Unrecognised keypad code: discard the sequence rather than leaving the
+      // decoder stalled in its escape state.
+      _esc_clear()
     end
 
   fun ref _up() =>
@@ -364,7 +421,8 @@ actor ANSITerm
 
   fun ref _esc_flush() =>
     """
-    Pass a partial or unrecognised escape sequence to the notifier.
+    Pass a partial escape sequence that timed out to the notifier as plain
+    input.
     """
     for c in _esc_buf.values() do
       _notify(this, c)
@@ -385,3 +443,4 @@ actor ANSITerm
     _esc_buf.clear()
     _esc_num = 0
     _esc_mod = 0
+    _esc_private = false


### PR DESCRIPTION
The `term` package's escape-sequence decoder mishandled terminal input it didn't recognize. An unrecognized sequence such as Shift-Tab (`ESC[Z`) leaked stray characters into the input; an unknown keypad code stalled the decoder so following keystrokes were dropped or garbled; and an out-of-range numeric parameter could be read as a different, valid key.

The decoder now reads each escape sequence through to its final byte and discards it when it isn't recognized, so an unrecognized key no longer inserts stray text, stalls input, or fires the wrong key. Recognized keys are unaffected, and a partial sequence that times out still passes through.
