### PR TITLE
Fix TCP connections hanging on Windows

### DIFF
--- a/.known-couplings/asio-oneshot-shared-read-write-arm.md
+++ b/.known-couplings/asio-oneshot-shared-read-write-arm.md
@@ -1,0 +1,39 @@
+# TCPConnection's read re-arm depends on epoll/Windows sharing one read+write registration
+
+The epoll and Windows readiness backends (`src/libponyrt/asio/epoll.c`,
+`sock_notify.c`) register a socket for read and write on ONE one-shot registration
+(`EPOLLONESHOT`; `SOCK_NOTIFY_TRIGGER_ONESHOT`). One-shot disables the WHOLE
+registration after ONE delivered event, so delivering a *writeable* event disarms
+the *read* arm too (and vice versa). `pony_asio_event_resubscribe` re-arms both
+directions together (IN if `!readable`, OUT if `!writeable`). kqueue
+(`kqueue.c`) is DIFFERENT: it registers `EVFILT_READ` and `EVFILT_WRITE` as two
+independent one-shot kevents, so a write event disarms only the write filter and
+the read arm survives -- the bug below cannot occur there.
+
+`packages/net/tcp_connection.pony` relies on the epoll/Windows shared-registration
+model. Its `_pending_reads` (read would-block) and `_apply_backpressure` (write
+would-block) re-arm on would-block, which normally re-arms both arms. But a
+*writeable* event that drains fully (no backpressure) returns through neither, so
+it never re-arms the read arm the writeable delivery just consumed. Without a fix,
+a later readable is never delivered and the connection hangs with the runtime idle
+-- observed on Windows, where the slow loopback makes read and write readiness
+arrive at separate times so the write event consumes the read arm (latent on
+epoll, where fast loopback usually delivers them together; impossible on kqueue).
+So `_event_notify`'s writeable branch re-arms reads explicitly, gated on
+`_writeable` (true only when NOT backpressured, which also makes the combined
+resubscribe touch only the read arm). On kqueue that re-arm is a harmless,
+idempotent no-op.
+
+The coupling: this re-arm is load-bearing ONLY while epoll and Windows deliver
+read and write on one shared one-shot registration. If either backend is changed
+to give each direction its own independent one-shot (as kqueue already does), the
+explicit read re-arm in `_event_notify` becomes an inert no-op there and its
+rationale changes; if a backend drops one-shot for edge/level-triggered
+persistent, the whole re-arm dance changes. A change to the one-shot model in
+`epoll.c` or `sock_notify.c` must be checked against `_event_notify`'s writeable
+branch in `tcp_connection.pony`.
+
+Run: the TCP tests in `packages/net/_test.pony`, and the tcp-swarm stress test
+(`test/rt-stress/tcp-swarm/`) on Windows -- the swarm is what surfaced the hang,
+and a moderate write-heavy workload (many queued writes per connection) reproduces
+it probabilistically when the re-arm is missing.

--- a/.release-notes/fix-windows-tcp-connection-hang.md
+++ b/.release-notes/fix-windows-tcp-connection-hang.md
@@ -1,0 +1,3 @@
+## Fix TCP connections hanging on Windows
+
+On Windows, a busy TCP connection could hang: one that had several writes queued up would, after sending its data, stop receiving and never finish -- the connection stayed stuck and the program sat idle. This was most likely on connections moving a lot of data at once. Affected connections now continue and complete normally.

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -619,6 +619,22 @@ actor TCPConnection is AsioEventNotify
           // Sent all data. Release backpressure.
           _release_backpressure()
         end
+        // On the epoll and Windows readiness backends read and write share ONE
+        // one-shot registration, so this writeable event disarmed the read side
+        // too. Unless we hit write backpressure (`_apply_backpressure` re-arms
+        // both and owns the write arm), nothing re-arms reads after a full drain
+        // -- a later readable is silently lost and the connection hangs. Re-arm
+        // reads here, gated on `_writeable` (true only when NOT backpressured,
+        // which also keeps the combined resubscribe from touching the write arm).
+        // Skip if this event also carried a readable (handled below), reads are
+        // muted, or the peer has closed. (kqueue arms read and write on separate
+        // one-shots, so it never loses the read arm and this is an inert no-op.)
+        // COUPLING: .known-couplings/asio-oneshot-shared-read-write-arm.md.
+        if _writeable and not AsioEvent.readable(flags) and _connected
+          and not _readable and not _muted and not _shutdown_peer
+        then
+          @pony_asio_event_resubscribe_read(_event)
+        end
       end
 
       if AsioEvent.readable(flags) then


### PR DESCRIPTION
The nightly Windows TCP swarm stress test caught this: TCP connections could hang under load. A connection that had several writes queued would, after sending them, stop receiving and never finish, sitting idle with the runtime doing no work.

The cause is in how `TCPConnection` re-arms readiness. On the epoll and Windows readiness backends, a socket's read and write are one shared one-shot registration, so a delivered readiness event disarms both directions. `TCPConnection` re-arms lazily on would-block, which covers the usual paths — but a writeable event that drains all pending writes returns through neither would-block path, so the read arm that the writeable delivery just consumed is never re-armed. The next readable is never delivered and the connection hangs.

It shows up on Windows because its loopback is slow enough that read and write readiness arrive at separate times, so the write event consumes the read arm; on Linux they usually arrive together in one event and both get handled. kqueue registers the two directions as independent one-shots, so it's unaffected.

The fix re-arms reads after a fully-drained writeable event, gated on `_writeable` so it never re-arms the write arm (the backpressure path owns that).

Reproduced locally on Windows down to a minimal case (a handful of connections, a few queued 64 KB writes) that hung ~40% of runs; with the fix it passes every run, along with the full set of failing stress-test workloads and the `net` package's TCP tests.