### PR TITLE
Fix Windows link failure for `ProcessSocketNotifications`

### DIFF
--- a/.release-notes/fix-windows-processsocketnotifications-link.md
+++ b/.release-notes/fix-windows-processsocketnotifications-link.md
@@ -1,0 +1,5 @@
+## Fix Windows link failure for `ProcessSocketNotifications`
+
+On Windows, compiling a program could fail at link time with `undefined symbol: __declspec(dllimport) ProcessSocketNotifications`, even a program that does no networking. The runtime's socket backend calls that Winsock function, and some Windows SDKs do not provide it from the system libraries ponyc was linking. ponyc now also links `mswsock.lib`, the import library for that symbol, so it resolves.
+
+`ProcessSocketNotifications` was introduced in the Windows SDK for build 20348 (Windows 11 / Windows Server 2022) and does not exist in older SDKs. The runtime requires it, so ponyc now checks the installed SDK version and, if it is older than 10.0.20348.0, stops with a clear message telling you to install a newer SDK — instead of failing later with a confusing linker error.

--- a/src/libponyc/platform/vcvars.c
+++ b/src/libponyc/platform/vcvars.c
@@ -237,16 +237,40 @@ static bool find_kernel32(vcvars_t* vcvars, errors_t* errors)
   }
 
   vcvars->ucrt[0] = '\0';
+  // mswsock.lib is linked for ProcessSocketNotifications, which the Windows
+  // asio backend (src/libponyrt/asio/sock_notify.c) calls. That symbol lives in
+  // MSWSOCK.dll, and mswsock.lib is its import library. The SDK-version check
+  // below guarantees the symbol exists; the already-listed Ws2_32.lib provides
+  // it on recent SDKs, but not all do — a user reported "undefined symbol:
+  // ProcessSocketNotifications" at link time on an SDK whose Ws2_32.lib lacked
+  // it. Don't remove mswsock.lib as unused; it is here for that symbol.
   strcpy(vcvars->default_libs,
     "kernel32.lib "
     "msvcrt.lib "
-    "Ws2_32.lib advapi32.lib vcruntime.lib "
+    "Ws2_32.lib mswsock.lib advapi32.lib vcruntime.lib "
     "legacy_stdio_definitions.lib dbghelp.lib ntdll.lib");
 
   strcpy(vcvars->kernel32, sdk.path);
   strcat(vcvars->kernel32, "Lib\\");
   if(strcmp("v10.0", sdk.name) == 0)
   {
+    // ProcessSocketNotifications, which the runtime's Windows socket backend
+    // calls (src/libponyrt/asio/sock_notify.c), was introduced in the Windows
+    // SDK for build 20348 (Windows 11 / Server 2022). An SDK older than that
+    // cannot provide the symbol from any library, so linking any program would
+    // fail with a confusing "undefined symbol" error. Reject it up front with a
+    // clear message; the runtime requires that API regardless. All candidates
+    // here are 10.0.<build>.<rev>, so comparing the packed version is a build
+    // comparison. get_version packs the build into bits 16-31.
+    uint64_t min_sdk_version = ((uint64_t)10 << 48) | ((uint64_t)20348 << 16);
+    if(sdk.latest_ver < min_sdk_version)
+    {
+      errorf(errors, NULL, "the newest installed Windows SDK (%s) is older than "
+        "10.0.20348.0; ponyc requires that version or newer. Install a more "
+        "recent Windows SDK.", sdk.version);
+      return false;
+    }
+
     strcat(vcvars->kernel32, sdk.version);
 
     // recent Windows 10 kits have the correct 4-place version


### PR DESCRIPTION
The runtime's Windows socket backend calls `ProcessSocketNotifications`, but ponyc's default link libraries did not include a library that reliably exports it. On a Windows SDK whose `Ws2_32.lib` does not carry the symbol, linking any program — even one that does no networking — fails with `undefined symbol: __declspec(dllimport) ProcessSocketNotifications`. This links `mswsock.lib`, the import library for that symbol, so it resolves.

`ProcessSocketNotifications` was introduced in the Windows SDK for build 20348 (Windows 11 / Windows Server 2022) and does not exist in older SDKs. The runtime requires it, so this also adds a check: if the newest installed SDK is older than 10.0.20348.0, ponyc stops with a clear message telling you to install a newer SDK, instead of failing later with a confusing linker error.

Reported in #5684.

Verified on a current SDK (10.0.26100): ponyc rebuilds clean, the `circle` example compiles, links, and runs, and building ponyc itself re-links all the bundled Pony tools through this code path. I confirmed the SDK-version check actually fires by temporarily raising the threshold above the installed SDK and observing ponyc stop with the version message. At runtime the symbol lives in `mswsock.dll` (`ws2_32.dll` forwards to it), so importing it from `mswsock.lib` is safe.

Not verified: the reporter's exact environment. I don't have an SDK whose `Ws2_32.lib` lacks the symbol, so I could not reproduce their link failure with the `mswsock.lib` fix in place — I reproduced the failure only by removing the symbol's library from the real link command. What is now certain either way: if their SDK is 20348 or newer, `mswsock.lib` supplies the symbol; if it is older, they get the clear SDK-version error instead of a cryptic linker failure. The discussion doesn't state their SDK version.