### PR TITLE
Fix `ANSITerm` not fully cleaning up on dispose

### DIFF
--- a/.release-notes/fix-term-dispose-cleanup.md
+++ b/.release-notes/fix-term-dispose-cleanup.md
@@ -1,0 +1,3 @@
+## Fix `ANSITerm` not fully cleaning up on dispose
+
+Disposing an `ANSITerm` did not fully shut it down: its `prompt` and `size` behaviors still called the notifier afterward, and the terminal-resize handler it installs was never removed, so it kept calling the closed notifier on a resize and held its signal subscription. A disposed `ANSITerm` now ignores `prompt` and `size` and removes its resize handler.

--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -182,6 +182,42 @@ class \nodoc\ _FlushNotify is ANSINotify
       _h.complete(true)
     end
 
+class \nodoc\ _DisposeNotify is ANSINotify
+  """
+  Checks dispose semantics by failing on any forbidden callback: input,
+  `prompt`, or `size` after `closed()`, or a second `closed()`. `closed()`
+  completes the "closed" action so a test can require that it fired. The
+  constructor's initial `size` arrives before `closed()`, so it is allowed.
+  """
+  let _h: TestHelper
+  var _closed: Bool = false
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref apply(term: ANSITerm ref, input: U8) =>
+    if _closed then
+      _h.fail("input forwarded after close: " + input.string())
+    end
+
+  fun ref prompt(term: ANSITerm ref, value: String) =>
+    if _closed then
+      _h.fail("prompt forwarded after close")
+    end
+
+  fun ref size(rows: U16, cols: U16) =>
+    if _closed then
+      _h.fail("size forwarded after close")
+    end
+
+  fun ref closed() =>
+    if _closed then
+      _h.fail("closed fired twice")
+    else
+      _closed = true
+      _h.complete_action("closed")
+    end
+
 // ---------------------------------------------------------------------------
 // ANSITerm: escape-sequence decoding.
 // ---------------------------------------------------------------------------
@@ -480,26 +516,40 @@ class \nodoc\ iso _TestANSITermRealTimerFlush is UnitTest
 
 class \nodoc\ iso _TestANSITermDispose is UnitTest
   """
-  dispose notifies the notifier of closure exactly once (a second dispose is a
-  no-op) and input received after dispose is ignored.
+  dispose notifies the notifier of closure exactly once, and no callback (input,
+  prompt, or size) reaches the notifier afterward.
   """
   fun name(): String => "term/ANSITerm.dispose"
 
   fun ref apply(h: TestHelper) =>
-    // "Z" passes through; dispose closes once; the post-dispose "a" is ignored;
-    // the second dispose is guarded. closed() and the source disposal share the
-    // same guard, so one closed event implies one source disposal.
-    let expected = recover val ["byte 90"; "closed"] end
     let timers = Timers
-    let term = ANSITerm(_RecordNotify(h, expected), _NullSource, timers)
+    let term = ANSITerm(_DisposeNotify(h), _NullSource, timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
-    term.apply(_Bytes("Z"))
+    // "closed" must fire, or the test times out. A callback after close fails
+    // the test via _DisposeNotify.
+    h.expect_action("closed")
+    h.expect_action("done")
     term.dispose()
-    term.apply(_Bytes("a"))
-    term.dispose()
-    term.prompt("")
+    term.apply(_Bytes("a")) // input after close is ignored
+    term.dispose()          // a second dispose does not close again
+    term.prompt("x")        // prompt after close is ignored
+    term.size()             // size after close is ignored
+    // Complete via a 100ms timer, not a notifier callback (nothing forwards
+    // after close). The term drains the near-instant calls above long before
+    // the timer fires, so any forbidden callback has already failed the test by
+    // then: a timing margin, not a strict happens-before.
+    let done =
+      recover
+        object is TimerNotify
+          let _h: TestHelper = h
+          fun ref apply(timer: Timer, count: U64): Bool =>
+            _h.complete_action("done")
+            false
+        end
+      end
+    timers(Timer(consume done, 100_000_000))
 
 class \nodoc\ iso _TestANSITermPromptForward is UnitTest
   """

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -50,6 +50,7 @@ actor ANSITerm
   var _timer: (Timer tag | None) = None
   let _notify: ANSINotify
   let _source: DisposableActor
+  var _signal: (SignalHandler | None) = None
   var _escape: _EscapeState = _EscapeNone
   var _esc_num: U8 = 0
   var _esc_mod: U8 = 0
@@ -70,7 +71,7 @@ actor ANSITerm
     _source = source
 
     ifdef not windows then
-      SignalHandler(recover _TermResizeNotify(this) end, Sig.winch())
+      _signal = SignalHandler(recover _TermResizeNotify(this) end, Sig.winch())
     end
 
     _size()
@@ -172,9 +173,17 @@ actor ANSITerm
     """
     Pass a prompt along to the notifier.
     """
+    if _closed then
+      return
+    end
+
     _notify.prompt(this, value)
 
   be size() =>
+    if _closed then
+      return
+    end
+
     _size()
 
   fun ref _size() =>
@@ -189,21 +198,31 @@ actor ANSITerm
 
   be dispose() =>
     """
-    Stop accepting input, inform the notifier we have closed, and dispose of
-    our source.
+    Stop accepting input, inform the notifier we have closed, dispose of our
+    source, and remove our terminal-resize handler.
     """
     if not _closed then
       _esc_clear()
       _notify.closed()
       _source.dispose()
+      // Unregister the SIGWINCH handler installed in the constructor so it
+      // stops delivering resize callbacks and frees its subscription.
+      match _signal
+      | let s: SignalHandler => s.dispose()
+      end
       _closed = true
     end
 
   be _timeout() =>
     """
     Our timer since receiving an ESC has expired. Send the buffered data as if
-    it was not an escape sequence.
+    it was not an escape sequence. Guarded like the other notifier-forwarding
+    behaviors so a timer that fires after dispose delivers nothing.
     """
+    if _closed then
+      return
+    end
+
     _timer = None
     _esc_flush()
 


### PR DESCRIPTION
Disposing an `ANSITerm` did not fully shut it down: its `prompt` and `size` behaviors still called the notifier afterward, and the terminal-resize handler it installs was never removed, so it kept calling the closed notifier on a resize and held its signal subscription. A disposed `ANSITerm` now ignores `prompt` and `size` (and a late escape timeout) and removes its resize handler.
