### PR TITLE
Fix `Readline.down` underflow on empty history

### DIFF
--- a/.release-notes/fix-term-down-empty-history.md
+++ b/.release-notes/fix-term-down-empty-history.md
@@ -1,0 +1,3 @@
+## Fix `Readline.down` underflow on empty history
+
+Pressing down in a `Readline` with no history triggered an integer underflow and an out-of-bounds history access. Both are now avoided.

--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -46,6 +46,7 @@ actor \nodoc\ Main is TestList
     test(_TestReadlineCtrlDEmptyDisposes)
     test(_TestReadlineRejectDisposes)
     test(_TestReadlineHistoryNavigation)
+    test(_TestReadlineDownEmptyHistory)
     test(_TestReadlineHistoryDedup)
     test(_TestReadlineHistoryMaxlen)
     test(_TestReadlineHistoryMissingFile)
@@ -1135,6 +1136,30 @@ class \nodoc\ iso _TestReadlineHistoryNavigation is UnitTest
 
   fun ref tear_down(h: TestHelper) =>
     try (_dir as FilePath).remove() end
+
+class \nodoc\ iso _TestReadlineDownEmptyHistory is UnitTest
+  """
+  Pressing down (ctrl-n) with an empty history leaves the edit line and cursor
+  untouched. An empty history makes _history.size() - 1 underflow; the guard
+  makes down a clean no-op, matching up when there is no previous line. The
+  underflow was swallowed by a try, so down is an observable no-op either way —
+  the test pins that down never disturbs the line on an empty history. Typing
+  "abc", pressing down, typing "d", then dispatching yields "abcd": down neither
+  changed the buffer nor moved the cursor off the end.
+  """
+  fun name(): String => "term/Readline.down-empty-history"
+
+  fun ref apply(h: TestHelper) =>
+    let timers = Timers
+    let term = ANSITerm(Readline(_LineNotify(h, "abcd"), _NullOut), _NullSource,
+      timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(5_000_000_000)
+    term.prompt("")
+    // ctrl-n (down) with no history must not move the cursor or change the
+    // buffer, so the trailing "d" appends at the end.
+    term.apply(_Bytes("abc\x0Ed\n"))
 
 class \nodoc\ iso _TestReadlineHistoryDedup is UnitTest
   """

--- a/packages/term/readline.pony
+++ b/packages/term/readline.pony
@@ -119,6 +119,12 @@ class Readline is ANSINotify
     """
     Next line.
     """
+    // With no history there is no next line, and _history.size() - 1 would
+    // underflow. Do nothing, as up does when there is no previous line.
+    if _history.size() == 0 then
+      return
+    end
+
     try
       if _cur_line < (_history.size() - 1) then
         _cur_line = _cur_line + 1


### PR DESCRIPTION
`down` underflowed on an empty history: `_history.size() - 1` wrapped around, so `down` tried to index past the end of the history. The enclosing `try` swallowed the error, so there was no visible effect, but it left the internal line index in a bad state. `down` now returns early on an empty history and does nothing, the same as `up` when there is no previous line.

Because the error was swallowed, `down` on an empty history was already a no-op on screen, so there is no visible behavior change. The added test pins that `down` leaves the line and cursor untouched; it cannot fail on the unfixed code, since the bad state it removes is not observable.
