### PR TITLE
Build DragonFly warmer libs with gcc13, not the preset's clang

### DIFF
--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -426,7 +426,7 @@ jobs:
           cd /build/ponyc
           export CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13 LD_LIBRARY_PATH=/usr/local/lib/gcc13 SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
           export GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GITHUB_REPOSITORY='${{ github.repository }}' GITHUB_ACTOR='${{ github.actor }}'
-          cmake -DTOOLS=false -DJOBS=4 -P lib/build-libs.cmake
+          cmake -DTOOLS=false -DJOBS=4 -DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13 -P lib/build-libs.cmake
           rm -rf build/build_libs
           python3 .ci-scripts/libs-cache/oci_libs_cache.py push --platform dragonfly-6.4.2 --tag '${LIBS_TAG}'
           EOF


### PR DESCRIPTION
The lib-cache warmer's DragonFly "Build and push libs" step ran `cmake -DTOOLS=false -DJOBS=4 -P lib/build-libs.cmake` without `-DCC`/`-DCXX`, so the libs CMake preset's hard-coded `clang`/`clang++` won. DragonFly ships no clang, so the configure failed at compiler identification ("The C compiler identification is unknown ... clang is not full path and was not found in the PATH").

Exporting `CC`/`CXX` in the environment doesn't help here: the `libs` preset sets `CMAKE_C_COMPILER` as a cache variable, which overrides the environment. `build-libs.cmake` turns `-DCC`/`-DCXX` into command-line `-DCMAKE_C_COMPILER`, which does override the preset.

`ponyc-tier3.yml`'s DragonFly "Build libs" step already passes `-DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13`; the warmer's DragonFly step was missed when the build system moved to CMake (#5633). This makes the two match.