### PR TITLE
Unify the from-source build's compiler and PIC overrides

### DIFF
--- a/.claude/skills/create-dragonfly-dev-env/SKILL.md
+++ b/.claude/skills/create-dragonfly-dev-env/SKILL.md
@@ -300,7 +300,7 @@ cat > /build/run-libs.sh <<'S'
 export CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13
 export LD_LIBRARY_PATH=/usr/local/lib/gcc13
 export SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
-cd /build/ponyc && cmake -DTOOLS=false -DJOBS=8 -DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13 -P lib/build-libs.cmake
+cd /build/ponyc && cmake -DTOOLS=false -DJOBS=8 -DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13 -P lib/build-libs.cmake
 echo "libs DONE rc=$?"
 S
 chmod +x /build/run-libs.sh

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -664,7 +664,7 @@ jobs:
           set -e
           cd /build/ponyc
           export GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GITHUB_REPOSITORY='${{ github.repository }}' GITHUB_ACTOR='${{ github.actor }}' CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13 LD_LIBRARY_PATH=/usr/local/lib/gcc13 SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
-          cmake -DTOOLS=false -DJOBS=4 -DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13 -P lib/build-libs.cmake
+          cmake -DTOOLS=false -DJOBS=4 -DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13 -P lib/build-libs.cmake
           rm -rf build/build_libs
           python3 .ci-scripts/libs-cache/branch_libs_cache.py push --platform dragonfly-6.4.2 --tag '${LIBS_TAG}' || echo '::warning::dragonfly branch libs cache push failed, will rebuild next run'
           EOF

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -426,7 +426,7 @@ jobs:
           cd /build/ponyc
           export CC=/usr/local/bin/gcc13 CXX=/usr/local/bin/g++13 LD_LIBRARY_PATH=/usr/local/lib/gcc13 SSL_CERT_FILE=/usr/local/share/certs/ca-root-nss.crt
           export GITHUB_TOKEN='${{ secrets.GITHUB_TOKEN }}' GITHUB_REPOSITORY='${{ github.repository }}' GITHUB_ACTOR='${{ github.actor }}'
-          cmake -DTOOLS=false -DJOBS=4 -DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13 -P lib/build-libs.cmake
+          cmake -DTOOLS=false -DJOBS=4 -DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13 -P lib/build-libs.cmake
           rm -rf build/build_libs
           python3 .ci-scripts/libs-cache/oci_libs_cache.py push --platform dragonfly-6.4.2 --tag '${LIBS_TAG}'
           EOF

--- a/BUILD.md
+++ b/BUILD.md
@@ -29,7 +29,13 @@ The build is divided into several stages:
 - Removing a configuration's build directory (`rm -rf build/build_release build/release`) cleans your ponyc build without touching the libraries.
 - `rm -rf build` will delete the entire `build` directory, including the libraries.
 
-The presets default to using Clang on Unix.  To use GCC, override the compiler in the configure step: `cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++`.
+The presets default to using Clang on Unix. To build ponyc with GCC, override the compiler at the configure step:
+
+```bash
+cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+```
+
+The libs build (`cmake -P lib/build-libs.cmake`) takes the same `-DCMAKE_C_COMPILER`/`-DCMAKE_CXX_COMPILER` flags — one spelling overrides the compiler for either step. You don't need to rebuild the libraries to switch the ponyc compiler; the ones built by the default (Clang) libs build work with a GCC ponyc build. You only pass the override to the libs build on platforms that need a non-default compiler for the vendored LLVM (32-bit Raspbian and DragonFly BSD — see those sections).
 
 ## FreeBSD
 
@@ -73,7 +79,7 @@ DragonFly BSD's base compiler (GCC 8.3) cannot build the vendored LLVM. Install 
 
 ```bash
 pkg install -y cmake gmake git python3 cxx_atomics gcc13
-cmake -DCC=/usr/local/bin/gcc13 -DCXX=/usr/local/bin/g++13 -P lib/build-libs.cmake
+cmake -DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13 -P lib/build-libs.cmake
 cmake --preset release -DCMAKE_C_COMPILER=/usr/local/bin/gcc13 -DCMAKE_CXX_COMPILER=/usr/local/bin/g++13
 cmake --build --preset release
 sudo cmake --install build/build_release
@@ -132,7 +138,7 @@ Operating Systems. There are two important things to note:
 - you'll need to override the CPU tuning (the presets default to `-mtune=generic`).
 
 ```bash
-cmake -DCC=gcc -DCXX=g++ -P lib/build-libs.cmake
+cmake -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -P lib/build-libs.cmake
 cmake --preset release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_FLAGS="-march=native -mtune=native" -DCMAKE_CXX_FLAGS="-march=native -mtune=native"
 cmake --build --preset release
 sudo cmake --install build/build_release
@@ -144,7 +150,7 @@ Installing on a 64-bit Raspbian is slightly different from other Linux based
 Operating Systems, you'll need to build for the `armv8-a` architecture, but otherwise, everything is the same.
 
 ```bash
-cmake -DPIC=-fPIC -P lib/build-libs.cmake
+cmake -DPONY_PIC_FLAG=-fPIC -P lib/build-libs.cmake
 cmake --preset armv8-a-release -DPONY_PIC_FLAG=-fPIC
 cmake --build --preset armv8-a-release
 sudo cmake --install build/build_armv8-a-release

--- a/lib/build-libs.cmake
+++ b/lib/build-libs.cmake
@@ -17,10 +17,13 @@
 #                    false to keep the cached libs small).
 #   -DJOBS=<n>       parallel build jobs (default: 4; keep it low -- LLVM is
 #                    memory-hungry).
-#   -DCC=<path> -DCXX=<path>  override the compiler (DragonFly builds LLVM with
-#                    gcc, not the preset's clang).
-#   -DPIC=<flag>     PONY_PIC_FLAG value (default -fpic; some 64-bit ARM targets
-#                    need -fPIC).
+#   -DCMAKE_C_COMPILER=<path> -DCMAKE_CXX_COMPILER=<path>  override the compiler
+#                    (DragonFly builds LLVM with gcc, not the preset's clang).
+#                    Same flag names the ponyc configure step uses, so one
+#                    spelling overrides the compiler at either step.
+#   -DPONY_PIC_FLAG=<flag>  position-independent-code flag (default -fpic; some
+#                    64-bit ARM targets need -fPIC). Same flag name the ponyc
+#                    configure step uses.
 
 if(NOT DEFINED PRESET)
     set(PRESET "libs")
@@ -36,11 +39,11 @@ set(_src "${CMAKE_CURRENT_LIST_DIR}")
 set(_build "${CMAKE_CURRENT_LIST_DIR}/../build/build_libs")
 
 set(_configure cmake --preset "${PRESET}" -S "${_src}" "-DPONY_LLVM_TOOLS=${TOOLS}")
-if(DEFINED CC)
-    list(APPEND _configure "-DCMAKE_C_COMPILER=${CC}" "-DCMAKE_CXX_COMPILER=${CXX}")
+if(DEFINED CMAKE_C_COMPILER)
+    list(APPEND _configure "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}" "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
 endif()
-if(DEFINED PIC)
-    list(APPEND _configure "-DPONY_PIC_FLAG=${PIC}")
+if(DEFINED PONY_PIC_FLAG)
+    list(APPEND _configure "-DPONY_PIC_FLAG=${PONY_PIC_FLAG}")
 endif()
 
 execute_process(COMMAND ${_configure} RESULT_VARIABLE _rc)


### PR DESCRIPTION
The from-source build overrides the compiler in two places — the vendored-LLVM/libs build (`cmake -P lib/build-libs.cmake`) and the ponyc configure step (`cmake --preset ...`) — because both default to Clang. The configure step took the standard `-DCMAKE_C_COMPILER`/`-DCMAKE_CXX_COMPILER`, but `lib/build-libs.cmake` exposed its own `-DCC`/`-DCXX` alias for the same thing, translating it internally. Position-independent code had the identical split: `-DPIC` at the libs step, `-DPONY_PIC_FLAG` at the configure step.

Two spellings for one intent is error-prone — it is what caused #5695, where the DragonFly libs warmer passed no override and silently kept Clang, which DragonFly does not ship.

This makes `lib/build-libs.cmake` read the standard `CMAKE_C_COMPILER`/`CMAKE_CXX_COMPILER` and `PONY_PIC_FLAG` directly and drops the `-DCC`/`-DCXX`/`-DPIC` aliases. One spelling now overrides the compiler (and the PIC flag) at both steps. The tier3 and lib-cache-warmer DragonFly steps and the from-source build docs are updated to match.

The aliases were introduced by the unreleased CMake build-system migration (#5633), so nothing user-facing changes.

Docs on the website are updated in the companion PR ponylang/ponylang-website#1396.