### PR TITLE
Raise tcp-swarm stress-test memory cap to 14 GiB

### DIFF
--- a/.known-couplings/tcp-swarm-memory-budget.md
+++ b/.known-couplings/tcp-swarm-memory-budget.md
@@ -1,14 +1,14 @@
 # The tcp-swarm memory budget's cost model tracks the engine's per-object and per-read-buffer allocation
 
-The tcp-swarm orchestrator (`test/rt-stress/tcp-swarm/orchestrate_tcp.py`) draws
-each workload against a memory budget (`MEM_BUDGET_BYTES`) so no draw exceeds the
-`RLIMIT_AS` cap the run is launched under. A draw over the cap is killed by the
-runtime's own out-of-memory abort (`ponyint_virt_alloc`), which reads like a runtime
-crash but is really the test asking for more memory than its cap allows -- a false
-failure. The budget is what prevents it.
+The tcp-swarm orchestrator (`test/rt-stress/tcp-swarm/orchestrate_tcp.py`) draws each
+workload against a memory budget (`MEM_BUDGET_BYTES`) that trims the memory-driving
+levers, aiming to keep a run under the `RLIMIT_AS` cap each seed launches under. A draw
+over the cap is killed by the runtime's own out-of-memory abort (`ponyint_virt_alloc`),
+which reads like a runtime crash but is really the test asking for more address space than
+its cap allows -- a false failure.
 
-The budget uses `est_peak_bytes`, which estimates the engine's peak memory from a few
-measured coefficients:
+The budget does NOT bound the quantity the cap limits. `RLIMIT_AS` caps VIRTUAL address
+space; `est_peak_bytes` estimates peak LIVE workload bytes:
 
 - `MEM_OBJ_BYTES * concurrency * messages * writev_chunks` -- the pending vectored-write
   buffer objects. `_Keystream.make_chunks` (`main.pony`) allocates `writev_chunks`
@@ -20,20 +20,32 @@ measured coefficients:
   read buffers, one per live connection (both endpoints) plus a conservative churn
   term. Sized by `--read-buffer-size`.
 
-If the engine's per-object cost, the read buffer, or `TCPConnection`'s buffering
-changes -- e.g. `make_chunks` starts coalescing empty chunks, or the read path changes
-how much it holds -- the coefficients drift. Under-estimating lets an over-cap draw
-through (the false OOM this exists to prevent); over-estimating silently over-trims and
-loses swarm coverage. The coupling is silent: `orchestrate_tcp_test.py` checks that
-`est_peak_bytes` stays within budget, NOT that `est_peak_bytes` matches the engine's
-real memory -- so a drift passes the unit test and only shows up as a CI OOM (or as
-quietly shrunken draws). The constants are first-CI-run calibration items; the churn
-term's shape (`connections * read_buffer`) is an unvalidated hypothesis (the CI OOM
-seeds with huge connection counts could not be reproduced on the slow local loopback).
+Measured (perf-tester, ponyc `net` stack): the pool allocator reserves virtual in large
+`MAP_NORESERVE` arenas and holds the high-water mark under the in-flight connection
+backlog, so peak virtual runs ~4-7x over these live-byte terms -- and grows as the run is
+CPU-starved (the deeper the backlog, the more the pool reserves). The failing 53k-connection
+seed the budget estimated at ~1.2 GiB peaked ~5 GiB virtual on fast cores but ~8.4 GiB pinned
+to 2 cores (~120 MiB RSS throughout); the 2-core run reproduces the CI OOM exactly, and the
+old 8 GiB cap sat just under CI's ~8.4 GiB need. The churn term (`connections * read_buffer`)
+is the weak one: it does not capture the backlog's pool reservation at all.
 
-Run: re-measure the engine's peak memory across the levers and re-fit the constants --
-build the engine debug and, polling `/proc/<pid>/status` `VmPeak`/`VmHWM`, sweep e.g.
-`./tcp_swarm --write-shape writev --writev-chunks 2048 --payload-size 8 --messages 8
---concurrency {64,128} --connections 2000` and confirm `est_peak_bytes` still bounds
-the observed peak with margin. There is no automated regression test -- the engine
-run is loopback-speed and memory-heavy, so it stays a manual re-measure.
+The fix was to raise the cap (`DEFAULT_MEM_LIMIT_MB` to 14 GiB) so its slack absorbs the
+underestimate, NOT to re-fit the constants -- virtual reservation is a high-water artifact
+that varies by environment and would need re-measuring per stack (lori carries a copy of
+this whole model against its OWN TCP stack). So the coupling is now cushioned: a drift in
+the engine's per-object or per-read-buffer cost no longer immediately false-OOMs, but a
+large enough drift can still push a run's virtual past the raised cap. The coupling is
+also silent -- `orchestrate_tcp_test.py` checks that `est_peak_bytes` stays within budget,
+NOT that it matches real memory -- so drift passes the unit test and only shows up as a CI
+OOM or as quietly shrunken draws.
+
+Run: if you want the budget to be a tight bound again (rather than leaning on the cap's
+slack), re-measure the engine's peak VIRTUAL across the levers and re-fit -- build the
+engine debug and, polling `/proc/<pid>/status` `VmPeak`/`VmHWM`, run the failing seed's
+config `./tcp_swarm --connections 53268 --concurrency 8 --payload-size 1024 --messages 37
+--write-shape writev --writev-chunks 2048 --read-buffer-size 1024 --yield-after-reading 16384
+--yield-after-writing 1024 --expect 0 --close graceful --ponynoscale --ponymaxthreads 2` and
+compare `VmPeak` to `est_peak_bytes`. To see the CPU-starvation effect (and reproduce the CI
+OOM), pin it to 2 cores (`taskset -c 0,1` or a `--cpus=2` container). There is no automated
+regression test -- the engine run is loopback-speed and memory-heavy, so it stays a manual
+re-measure.

--- a/test/rt-stress/tcp-swarm/README.md
+++ b/test/rt-stress/tcp-swarm/README.md
@@ -97,23 +97,26 @@ occupies the port before any client dials, so the default `localhost` is fine.
 
 ## Memory and time bounds
 
-- **Memory** — the orchestrator caps each run at 8 GiB of address space
-  (`RLIMIT_AS`), and the *draw itself* is bounded so no config can reach that cap. A
-  config that did would be killed by the runtime's own out-of-memory abort — which
-  reads like a runtime crash but is really the draw asking for more memory than the
-  cap allows, a false failure. So the memory-driving levers (connections, concurrency,
+- **Memory** — the orchestrator caps each run at 14 GiB of address space
+  (`RLIMIT_AS`), and the *draw itself* is trimmed to keep well under that cap. A config
+  over the cap is killed by the runtime's own out-of-memory abort — which reads like a
+  runtime crash but is really the draw asking for more address space than the cap
+  allows, a false failure. So the memory-driving levers (connections, concurrency,
   messages, payload, writev-chunks, read-buffer) are drawn against a shared memory
-  budget (`MEM_BUDGET_BYTES`, 2 GiB of workload under the cap): the draw spends the
-  budget, and once it is spent the remaining levers are trimmed to fit. The levers are
-  drawn in a per-seed *random order*, so the trimmed lever rotates — on one seed a big
-  `--writev-chunks` squeezes concurrency and messages, on another a big connection
-  count squeezes `--writev-chunks` — and every lever still reaches large on some
-  seeds, keeping the swarm a swarm. Why 8 GiB and not 4: the Pony runtime reserves a
-  flat ~3.5 GiB of *virtual* address space regardless of config and `RLIMIT_AS` caps
-  virtual, so a 4 GiB cap sat ~86% full at baseline and risked a false OOM on a
-  high-thread run. The budget's cost constants (used by `est_peak_bytes`) are
-  calibrated from local measurement with a margin and are first-CI-run calibration
-  items; see `.known-couplings/tcp-swarm-memory-budget.md`.
+  budget (`MEM_BUDGET_BYTES`, 2 GiB): the draw spends the budget, and once it is spent
+  the remaining levers are trimmed to fit. The levers are drawn in a per-seed *random
+  order*, so the trimmed lever rotates — on one seed a big `--writev-chunks` squeezes
+  concurrency and messages, on another a big connection count squeezes `--writev-chunks`
+  — and every lever still reaches large on some seeds, keeping the swarm a swarm. Why
+  14 GiB: the cap is on *virtual* address space, but the budget estimates *live* bytes,
+  which measured ~4-7x under the pool allocator's virtual high-water mark. That peak grows
+  as the run is CPU-starved (the deeper the in-flight backlog, the more the pool reserves)
+  — the failing 53k-connection seed the budget put at ~1.2 GiB peaked ~5 GiB virtual on
+  fast cores but ~8.4 GiB pinned to 2 cores, and the 2-core run reproduces the CI OOM
+  exactly (RSS stayed ~120 MiB throughout). CI's slow 4-vCPU runner builds that backlog and
+  the old 8 GiB cap sat just under it. Virtual is nearly free (RSS is the scarce resource,
+  the runner has 16 GiB), so 14 GiB clears the measured ~8.4 GiB worst case with margin
+  rather than re-fitting the constants; see `.known-couplings/tcp-swarm-memory-budget.md`.
 - **Time** — the per-run clamp (`clamp_run`) bounds round-trips
   (`connections * messages`) and total bytes (`connections * messages * payload`),
   so an outsized draw (e.g. 100k conns × 64 msgs × 64 KiB ≈ 400 GB) is trimmed.

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp.py
@@ -48,13 +48,21 @@ DEFAULT_NO_PROGRESS_SECONDS = 300
 # can't run unbounded, but that is NOT a failure (outcome "incomplete") -- the run
 # was healthy, it just ran long. Only the no-progress hang above fails a seed.
 DEFAULT_TIMEOUT_SECONDS = 6000
-# 8 GiB, not 4: the Pony runtime reserves a flat ~3.5 GiB of VIRTUAL address space
-# (measured, constant across configs), and RLIMIT_AS caps virtual, not RSS -- so a
-# 4 GiB cap sits ~86% full before the workload runs and a high --ponymaxthreads run
-# could trip a FALSE OOM. 8 GiB has no downside and removes that risk. This cap is
-# the backstop, not the primary bound: the draw is separately kept under it by the
-# memory budget below (see est_peak_bytes), so a healthy workload never reaches it.
-DEFAULT_MEM_LIMIT_MB = 8192
+# 14 GiB, on VIRTUAL address space (RLIMIT_AS caps virtual, not RSS). Pony's pool
+# allocator reserves virtual in large MAP_NORESERVE arenas and holds the high-water mark
+# under the in-flight connection backlog, so a run's virtual footprint runs far ahead of
+# the RAM it touches -- RSS stayed ~120 MiB in every measurement below. The peak scales
+# with how deep that backlog gets, which scales with how CPU-starved the run is: the
+# failing 53k-connection seed measured ~5 GiB virtual on many fast cores but ~8.4 GiB
+# pinned to 2 cores -- and the 2-core run reproduces the CI OOM exactly (same
+# ponyint_virt_alloc abort). CI's slow 4-vCPU runner builds that deep backlog, and the old
+# 8 GiB cap sat just below the ~8.4 GiB it needed. est_peak_bytes below estimates live
+# WORKLOAD bytes (~1.2 GiB for this seed), ~4-7x under the real virtual peak, so the budget
+# did not keep the run under the cap. Virtual is nearly free (RSS is the scarce resource and
+# the runner has 16 GiB), so 14 clears the measured ~8.4 GiB worst case with margin at no RAM
+# cost; a genuine runaway still trips it (virtual >= RSS) and the runner's own OOM-killer
+# backstops. See the memory budget block below and .known-couplings/tcp-swarm-memory-budget.md.
+DEFAULT_MEM_LIMIT_MB = 14336
 
 
 def info(message):
@@ -139,13 +147,15 @@ def draw_bucketed(rng, buckets):
 
 # --------------------------------------------------------------- memory budget
 
-# The draw must never pick a workload whose peak memory exceeds the RLIMIT_AS cap the
-# orchestrator runs each seed under (see _capture / DEFAULT_MEM_LIMIT_MB). A workload
-# that does is killed by the runtime's own out-of-memory abort (ponyint_virt_alloc) --
-# which reads like a runtime crash but is really the test asking for more memory than
-# its own cap allows, a false failure. So every memory-driving lever is drawn against
-# a shared budget: the draw spends it, and once it is spent the remaining levers are
-# trimmed to fit.
+# The draw is trimmed to keep a workload's peak well under the RLIMIT_AS cap each seed
+# runs under (see _capture / DEFAULT_MEM_LIMIT_MB). A workload over the cap is killed by
+# the runtime's own out-of-memory abort (ponyint_virt_alloc) -- which reads like a runtime
+# crash but is really the test asking for more address space than its cap allows, a false
+# failure. Every memory-driving lever is drawn against a shared budget: the draw spends it,
+# and once it is spent the remaining levers trim to fit. The budget bounds LIVE bytes,
+# though, which runs well under the pool allocator's virtual high-water mark -- so it is a
+# coverage-shaping trim, not a hard guarantee; the cap's slack (see DEFAULT_MEM_LIMIT_MB)
+# is what actually absorbs the gap.
 #
 # The levers are drawn in a per-seed RANDOM order (see _draw_memory_levers), and that
 # is the point. A fixed trim order would always shave the same lever -- we would never
@@ -156,21 +166,21 @@ def draw_bucketed(rng, buckets):
 # fraction of seeds. This mirrors the generative harness's clamp_ttl (big chains force
 # ttl small), generalized so the sacrificed lever is not always the same one.
 #
-# est_peak_bytes estimates peak WORKLOAD bytes on top of the runtime's flat virtual
-# reservation. Terms and constants are calibrated from local measurement with a fat
-# margin (measured: writev-chunks=2048 at concurrency 64 / 8 messages peaks ~460 MiB
-# RSS; a write-shape run stays ~15 MiB flat regardless of connection count). They are
-# BEST GUESSES to confirm from the first CI run, like clamp_run's ceilings. The churn
-# term (connections * read_buffer) is the least certain: the CI out-of-memory seeds
-# with huge connection counts (36902, 72178) could not be reproduced locally (WSL2
-# loopback is too slow to build the queue depth CI builds), so its SHAPE is a
-# hypothesis -- it covers the one such seed we saw (which had a large read buffer) but
-# does not bound a small-buffer / huge-connections draw, which we have no evidence
-# OOMs. Validate with a raised-cap CI run.
+# est_peak_bytes estimates peak live WORKLOAD bytes (pending write buffers, read buffers,
+# bytes in flight, churn). This is NOT what the cap bounds: RLIMIT_AS caps virtual, and the
+# pool allocator's virtual high-water mark under the in-flight backlog runs ~4-7x over these
+# live-byte terms and grows as the run is CPU-starved -- a 53k-connection draw the budget put
+# at ~1.2 GiB measured ~5 GiB virtual on fast cores and ~8.4 GiB pinned to 2 cores (~120 MiB
+# RSS throughout), the 2-core run reproducing the CI OOM. The churn is what the budget misses;
+# the term (connections * read_buffer) does not capture the backlog's pool reservation. We
+# chose not to re-fit the constants to virtual -- pool reservation is a high-water artifact
+# that varies with core count and stack, and would need re-measuring per stack (lori copies
+# this model) -- and raised the cap to carry the slack instead. Re-fit only if you need the
+# budget to be a tight bound.
 # COUPLING: the constants track the engine's per-object and per-read-buffer memory --
 # re-measure if make_chunks, the read buffer, or TCPConnection buffering changes. See
 # .known-couplings/tcp-swarm-memory-budget.md.
-MEM_BUDGET_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB workload, well under the 8 GiB cap
+MEM_BUDGET_BYTES = 2 * 1024 * 1024 * 1024   # 2 GiB workload, well under the 14 GiB cap
 MEM_OBJ_BYTES = 2048        # per pending writev buffer object (margin over ~832 B virt)
 MEM_RB_FACTOR = 4           # live read buffers: client + server, plus headroom
 


### PR DESCRIPTION
The tcp-swarm stress test caps each run's virtual address space at 8 GiB to catch runaway memory. A healthy seed false-OOMed in a scheduled CI run: under the slow 4-vCPU runner the in-flight connection backlog deepens, Pony's pool allocator reserves virtual (MAP_NORESERVE) to match, and the run's virtual peak reached ~8.4 GiB — just over the cap. That memory is nearly free; RSS stayed ~120 MiB, so the cap was killing a run that was no threat to the runner's 16 GiB.

Reproduced on a local box by pinning the same seed to 2 cores: it OOMs at the 8 GiB cap and peaks ~8.4 GiB under a higher cap, matching the CI abort exactly. On many fast cores the same seed peaks ~5 GiB — the peak scales with how CPU-starved the run is, because that governs how deep the backlog gets.

Raising the cap to 14 GiB clears the measured worst case with margin at no real memory cost. The draw's own budget (est_peak_bytes) estimates live workload bytes, which run ~4-7x under the virtual high-water mark, so it can't be relied on to keep a draw under the cap; giving the cap slack beats re-fitting a per-stack virtual model. The comments, README, and memory-budget coupling doc are updated to match.
