### PR TITLE
Unify the two copies of the method-partiality test

### DIFF
--- a/.known-couplings/partiality-marker-mangle-collision.md
+++ b/.known-couplings/partiality-marker-mangle-collision.md
@@ -1,0 +1,22 @@
+# The `_p` partiality marker's collision-freedom depends on no type mangle ending in `'p'`
+
+`make_mangled_name` (`src/libponyc/reach/reach.c`) appends a trailing `_p` to a
+partial method's mangled name, so the painter assigns it a vtable slot separate
+from the matching non-partial method. This matters because partiality is part of
+a method's calling convention — a partial method's slot returns `{T, i1}` while a
+non-partial one returns `T` — so the two must never share a slot, or a method
+lands in a slot whose ABI doesn't match its body, a silent calling-convention bug
+in generated code.
+
+That segregation is collision-free only because no type mangle (`t->mangle`,
+assigned later in `reach.c`) is, or ends in, `'p'`: a non-internal method's base
+mangle ends in its result type's mangle, and `'p'` is not in the type-mangle
+character set, so a non-partial method's mangle never ends in `'p'` while a
+partial one always ends in the `_p` marker. Add a `t->mangle` value ending in
+`'p'`, or change the marker to a character that IS a type mangle, and a
+non-partial method can collide with a partial one in the same slot, reviving the
+ABI crash the segregation prevents. Both ends carry comments pointing at each
+other (the collision-free note in `make_mangled_name` and the reciprocal note at
+the `t->mangle` assignments).
+
+Run: `ctest --preset debug -R 'libponyc\.tests|libponyrt\.tests|full-programs'`.

--- a/.known-couplings/partiality-vtable-slot.md
+++ b/.known-couplings/partiality-vtable-slot.md
@@ -1,3 +1,0 @@
-# Partiality determines a method's vtable slot AND its calling convention
-
-Two predicates must stay byte-identical: the partiality test in `make_mangled_name` (`src/libponyc/reach/reach.c`), which puts partial and non-partial methods in separate vtable slots, and the `c_m->is_partial` test in `make_function_type` (`src/libponyc/codegen/genfun.c`), which sets a slot's LLVM return convention (`{T, i1}` vs `T`). If they diverge, a method lands in a slot whose ABI doesn't match its body, a silent calling-convention bug in generated code. Relatedly, the `_p` partiality marker is collision-free only because no type mangle (`t->mangle` in `reach.c`) ends in `'p'`; don't add one that does. Run: `ctest --preset debug -R 'libponyc\.tests|libponyrt\.tests|full-programs'`.

--- a/src/libponyc/codegen/genfun.c
+++ b/src/libponyc/codegen/genfun.c
@@ -131,18 +131,11 @@ static void make_signature(compile_t* c, reach_type_t* t,
       mparams[i + offset + 2] = p_c_t->mem_type;
   }
 
-  // Detect if the method is partial. This decides the LLVM calling convention
-  // of the method's vtable slot (`{T, i1}` for partial, `T` for non-partial).
-  // Bare functions are excluded: they are called from C code that doesn't
-  // understand error-flag returns, so they abort on unhandled error instead.
-  //
-  // COUPLING: this test MUST stay byte-identical to the partiality test in
-  // make_mangled_name (reach/reach.c), which decides WHICH slot a method lands
-  // in. If they diverge, a method's slot and its ABI disagree — the calling-
-  // convention crash that partial/non-partial slot segregation exists to
-  // prevent.
-  ast_t* can_error = ast_childidx(m->fun->ast, 5);
-  c_m->is_partial = (m->cap != TK_AT) && (ast_id(can_error) == TK_QUESTION);
+  // Partiality decides this method's LLVM calling convention: a partial
+  // method's vtable slot returns `{T, i1}`, a non-partial one returns `T`.
+  // reach_method_is_partial is the shared definition, so this ABI choice and
+  // the slot assignment in make_mangled_name (reach/reach.c) cannot diverge.
+  c_m->is_partial = reach_method_is_partial(m);
 
   // Generate the function type.
   // Bare methods returning None return void to maintain compatibility with C.

--- a/src/libponyc/codegen/genheader.c
+++ b/src/libponyc/codegen/genheader.c
@@ -129,6 +129,10 @@ static bool should_emit_fun(reach_method_t* m)
   if(m->internal)
     return false;
 
+  // Any error-raising method is excluded, bare ones included (a C signature
+  // can't carry Pony's error flag). This is deliberately NOT
+  // reach_method_is_partial (reach.h), which excludes bare methods — using it
+  // here would wrongly emit a header for a bare partial function.
   ast_t* can_error = ast_childidx(m->fun->ast, 5);
 
   if(ast_id(can_error) == TK_QUESTION)

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -498,16 +498,7 @@ static const char* make_mangled_name(reach_method_t* m, pass_opt_t* opt)
     token_id fun_id = ast_id(m->fun->ast);
     include_trace_kind = (fun_id == TK_BE) || (fun_id == TK_NEW);
 
-    // COUPLING: this partiality test decides which vtable slot a method lands
-    // in. It MUST stay byte-identical to the `c_m->is_partial` test in
-    // make_function_type (codegen/genfun.c), which decides that slot's LLVM
-    // calling convention (`{T, i1}` for partial, `T` for non-partial). If the
-    // two diverge, a method lands in a slot whose ABI doesn't match its body —
-    // silently reintroducing the calling-convention crash this segregation
-    // exists to prevent. Child index 5 is the error/partial token (fixed by
-    // the parser's method REORDER).
-    ast_t* can_error = ast_childidx(m->fun->ast, 5);
-    is_partial = (m->cap != TK_AT) && (ast_id(can_error) == TK_QUESTION);
+    is_partial = reach_method_is_partial(m);
   }
 
   printbuf_t* buf = printbuf_new();
@@ -1931,6 +1922,16 @@ uint32_t reach_vtable_index(reach_type_t* t, const char* name, pass_opt_t* opt)
     return (uint32_t)-1;
 
   return m->vtable_index;
+}
+
+bool reach_method_is_partial(reach_method_t* m)
+{
+  // Child index 5 of a method's AST is its error/partial token (fixed by the
+  // parser's method REORDER). Requires m->fun != NULL (internal methods have
+  // none); see the reach.h docstring for the bare-method exclusion rationale.
+  pony_assert(m->fun != NULL);
+  ast_t* can_error = ast_childidx(m->fun->ast, 5);
+  return (m->cap != TK_AT) && (ast_id(can_error) == TK_QUESTION);
 }
 
 bool reach_limit_exceeded(reach_t* r)

--- a/src/libponyc/reach/reach.h
+++ b/src/libponyc/reach/reach.h
@@ -150,6 +150,19 @@ reach_method_name_t* reach_method_name(reach_type_t* t,
 
 uint32_t reach_vtable_index(reach_type_t* t, const char* name, pass_opt_t* opt);
 
+/** Return true if a method is partial for calling-convention purposes.
+ *
+ * Partiality changes a method's ABI: a partial method returns `{T, i1}` (value
+ * plus error flag), a non-partial one returns `T`. The vtable slot a method
+ * lands in (make_mangled_name) and that slot's LLVM return type
+ * (make_signature in codegen/genfun.c) must agree on this, so both call
+ * here rather than each testing it separately. Bare methods (cap TK_AT) are
+ * never partial in this sense — a bare partial function aborts on error
+ * instead of returning the flag. Requires m->fun to be set (internal methods
+ * have none and are never partial).
+ */
+bool reach_method_is_partial(reach_method_t* m);
+
 /** Return true if reachability analysis aborted because a generic instantiation
  * exceeded the maximum type depth or size.
  *


### PR DESCRIPTION
`make_mangled_name` (reach.c) and `make_signature` (genfun.c) each computed whether a method is partial from the same AST, and the two copies had to be kept byte-identical: one decides which vtable slot a method gets, the other decides that slot's LLVM calling convention, so a divergence is a silent ABI mismatch in generated code — a hazard recorded as a known coupling. This extracts the test into a single `reach_method_is_partial` that both sites call, so they can't diverge.

`genheader.c`'s `should_emit_fun` keeps its own, deliberately different test (it excludes bare partial methods from C headers too); a comment there warns against folding it into the shared helper.

The known-couplings file is rewritten to drop the now-removed two-predicates coupling, keeping only the separate invariant it also documented: the `_p` marker is collision-free only because no type mangle ends in `'p'`.