### PR TITLE
Ignore coverage instrumentation artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,12 @@ tools/pony-doc/version.pony
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Coverage instrumentation artifacts (use=coverage). clang writes default.profraw
+# relative to each instrumented binary's cwd — the tracked test dirs when the
+# test suite runs; gcc writes .gcda/.gcno per translation unit.
+*.profraw
+*.profdata
+*.gcda
+*.gcno
+*.gcov


### PR DESCRIPTION
A `use=coverage` build writes profile data into the working tree: clang drops `default.profraw` in each instrumented binary's cwd — for the test suite that's the tracked `test/full-program-tests/*/` and `tools/` directories — and gcc writes `.gcda`/`.gcno` per translation unit. None of these were gitignored, so running the coverage test suite leaves a couple hundred untracked files that a `git add -A` can sweep into a commit.

This ignores the clang (`.profraw`, `.profdata`) and gcc (`.gcda`, `.gcno`, `.gcov`) coverage artifacts. No tracked file uses these extensions.