### PR TITLE
Rename run_once's local so it stops shadowing the signal module

### DIFF
--- a/test/rt-stress/generative/stress_common.py
+++ b/test/rt-stress/generative/stress_common.py
@@ -969,9 +969,9 @@ def run_once(binary, config, timeout, mem_limit_bytes):
         run_command(binary, config), timeout, mem_limit_bytes)
     if timed_out:
         return RunResult("timeout", None, None, stdout, stderr)
-    signal = -returncode if returncode < 0 else None
+    terminating_signal = -returncode if returncode < 0 else None
     outcome = "pass" if returncode == 0 else "fail"
-    return RunResult(outcome, returncode, signal, stdout, stderr)
+    return RunResult(outcome, returncode, terminating_signal, stdout, stderr)
 
 
 def lldb_argv(lldb, engine_argv):


### PR DESCRIPTION
The local variable made the `signal` module unreachable throughout `run_once`; a future edit reaching for `signal.SIGKILL` inside it would hit an `UnboundLocalError` instead of the module. Rename it to `terminating_signal` (the value it feeds is `RunResult.signal`, a terminating signal number). No behavior change.