### PR TITLE
List VM's ponyc directory at the end of *BSD provisioning (#5709)

### DIFF
--- a/.ci-scripts/bsd/dragonfly-provision.bash
+++ b/.ci-scripts/bsd/dragonfly-provision.bash
@@ -123,3 +123,9 @@ echo "::group::Copy source to VM"
 rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
   "$GITHUB_WORKSPACE/" root@localhost:/build/ponyc/
 echo "::endgroup::"
+
+echo "::group::List files in VM"
+ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 root@localhost /bin/sh <<'EOF'
+ls -la /build/ponyc/
+EOF
+echo "::endgroup::"

--- a/.ci-scripts/bsd/freebsd-provision.bash
+++ b/.ci-scripts/bsd/freebsd-provision.bash
@@ -109,3 +109,9 @@ echo "::group::Copy source to VM"
 rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
   "$GITHUB_WORKSPACE/" freebsd@localhost:/home/freebsd/ponyc/
 echo "::endgroup::"
+
+echo "::group::List files in VM"
+ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 freebsd@localhost <<'EOF'
+ls -la /home/freebsd/ponyc/
+EOF
+echo "::endgroup::"

--- a/.ci-scripts/bsd/openbsd-provision.bash
+++ b/.ci-scripts/bsd/openbsd-provision.bash
@@ -107,3 +107,9 @@ echo "::group::Copy source to VM"
 rsync -az -e "ssh -o StrictHostKeyChecking=no -i vm_key -p 2222" \
   "$GITHUB_WORKSPACE/" openbsd@localhost:/build/ponyc/
 echo "::endgroup::"
+
+echo "::group::List files in VM"
+ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 openbsd@localhost <<'EOF'
+ls -la /build/ponyc/
+EOF
+echo "::endgroup::"


### PR DESCRIPTION
WIP on Haiku provisioning showed up that qcow images created in current directory (which is GITHUB_WORKSPACE) end up being rsynced into the VM.

This does not fix the problem (#5709), but helps to show what ends up in the VM, and hopefully can help with the problem and similar ones in the future.