### PR TITLE
Make `ArrayKeys.next()` partial

### DIFF
--- a/.release-notes/5714.md
+++ b/.release-notes/5714.md
@@ -1,0 +1,37 @@
+## Make `ArrayKeys.next()` partial
+
+Change the `next()` function of `ArrayKeys` to partial, so it behaves the same as `next()?` of
+`ArrayValues` and `ArrayPairs`.
+
+This change is breaking, and will require code previously using `ArrayKeys.next()` to convert those calls to partial.
+
+Before:
+
+```ponyc
+...
+let keys = array.keys()
+let first_key = keys.next()
+...
+```
+
+After:
+
+```ponyc
+...
+let keys = array.keys()
+try
+  let first_key = keys.next()?
+  ...
+end
+...
+
+
+Note that iteration based access remains unchanged and does not require any code changes:
+
+```ponyc
+...
+let keys = array.keys()
+for key in keys do
+  // your code using each key
+end
+```

--- a/packages/builtin/array.pony
+++ b/packages/builtin/array.pony
@@ -962,11 +962,11 @@ class ArrayKeys[A, B: Array[A] #read] is Iterator[USize]
   fun has_next(): Bool =>
     _i < _array.size()
 
-  fun ref next(): USize =>
+  fun ref next(): USize ? =>
     if _i < _array.size() then
       _i = _i + 1
     else
-      _i
+      error
     end
 
   fun ref rewind(): ArrayKeys[A, B] =>

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -1733,22 +1733,22 @@ class \nodoc\ iso _TestArrayKeysRewind is UnitTest
   """
   fun name(): String => "builtin/ArrayKeys.rewind"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let av = [as U32: 1; 2; 3; 4].keys()
 
-    h.assert_eq[USize](0, av.next())
-    h.assert_eq[USize](1, av.next())
-    h.assert_eq[USize](2, av.next())
-    h.assert_eq[USize](3, av.next())
+    h.assert_eq[USize](0, av.next()?)
+    h.assert_eq[USize](1, av.next()?)
+    h.assert_eq[USize](2, av.next()?)
+    h.assert_eq[USize](3, av.next()?)
     h.assert_eq[Bool](false, av.has_next())
 
     av.rewind()
 
     h.assert_eq[Bool](true, av.has_next())
-    h.assert_eq[USize](0, av.next())
-    h.assert_eq[USize](1, av.next())
-    h.assert_eq[USize](2, av.next())
-    h.assert_eq[USize](3, av.next())
+    h.assert_eq[USize](0, av.next()?)
+    h.assert_eq[USize](1, av.next()?)
+    h.assert_eq[USize](2, av.next()?)
+    h.assert_eq[USize](3, av.next()?)
     h.assert_eq[Bool](false, av.has_next())
 
 class \nodoc\ iso _TestArrayValuesRewind is UnitTest


### PR DESCRIPTION
`next()` in an Iterator is typically partial. This is what users generally expect from `next()` in an Iterator. This change makes `next()` in `ArrayKeys` partial so it has the same behaviour as other Iterators.

This is a breaking change, as any code previously using `ArrayKeys.next()` will need to update to `ArrayKeys.next()?` and possibly wrap it in a try block.