### PR TITLE
Remove dead LL_FLAGS from the cross-compiled runtime build

### DIFF
--- a/.ci-scripts/cross-libponyrt.sh
+++ b/.ci-scripts/cross-libponyrt.sh
@@ -4,12 +4,11 @@
 # .github/workflows/ponyc-tier3.yml. The cmake cross machinery already exists
 # (PONY_CROSS_LIBPONYRT in the top-level CMakeLists.txt); this just drives it.
 #
-# Usage: cross-libponyrt.sh <config> <CC> <CXX> <arch> <cflags> <llc_flags>
+# Usage: cross-libponyrt.sh <config> <CC> <CXX> <arch> <cflags>
 #   config     debug | release
 #   CC/CXX     the cross toolchain (e.g. riscv64-linux-gnu-gcc-10)
 #   arch       PONY_ARCH / CMAKE_SYSTEM_PROCESSOR (e.g. rv64gc, armv7-a)
 #   cflags     CMAKE_C_FLAGS / CMAKE_CXX_FLAGS for the target
-#   llc_flags  LL_FLAGS (cmake ;-list) passed through to llc
 #
 # The build lands in build/<arch>/build_<config>, output in build/<arch>/<config>,
 # which the cross test picks up via PONYPATH.
@@ -20,7 +19,6 @@ cc="$2"
 cxx="$3"
 arch="$4"
 cflags="$5"
-llc_flags="$6"
 
 dir="build/$arch/build_$config"
 cmake -B "$dir" -S . \
@@ -33,6 +31,5 @@ cmake -B "$dir" -S . \
   -DCMAKE_BUILD_TYPE="$config" \
   -DCMAKE_C_FLAGS="$cflags" \
   -DCMAKE_CXX_FLAGS="$cflags" \
-  -DPONY_ARCH="$arch" \
-  -DLL_FLAGS="$llc_flags"
+  -DPONY_ARCH="$arch"
 cmake --build "$dir" --config "$config" --target libponyrt crt_objects

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -151,7 +151,7 @@ jobs:
           cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh debug riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket" "-march=riscv64"
+        run: sh .ci-scripts/cross-libponyrt.sh debug riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket"
       # net/ tests are excluded on the qemu-user cross legs. User-mode emulation
       # translates instructions faithfully -- so codegen is still exercised --
       # but does not faithfully emulate the kernel: e.g. setsockopt
@@ -169,7 +169,7 @@ jobs:
           cmake --build --preset release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh release riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket" "-march=riscv64"
+        run: sh .ci-scripts/cross-libponyrt.sh release riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket"
       # See the debug step above for why net/ tests are excluded under qemu-user.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
@@ -235,7 +235,7 @@ jobs:
           cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9" "-O3;-march=arm"
+        run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
@@ -247,7 +247,7 @@ jobs:
           cmake --build --preset release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9" "-O3;-march=arm"
+        run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
@@ -313,7 +313,7 @@ jobs:
           cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9" "-O3;-march=arm"
+        run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
@@ -325,7 +325,7 @@ jobs:
           cmake --build --preset release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9" "-O3;-march=arm"
+        run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}


### PR DESCRIPTION
The tier-3 cross jobs pass `LL_FLAGS` to CMake as a cache variable, and no
`CMakeLists.txt` reads it. Its only consumer was an `llc` invocation that compiled
the hand-written LLVM assembly for the stack-unwinding error path. We deleted that
in #5002, along with the `.ll` file and the object built from it, when we replaced
stack unwinding with error-flag returns. Since then CMake has warned on every
tier-3 cross build that the variable was manually specified but never used.
Removing it drops the `llc_flags` positional argument from
`.ci-scripts/cross-libponyrt.sh` and from its six call sites in the riscv64 and
arm tier-3 legs.

The cross runtime was never miscompiled. With the `llc` step gone there is no
LLVM-tool step left in the cross build. The cross C compiler builds `libponyrt`
and `crt_objects`: `libponyrt` is compiled with the target's `-march` flags from
`CMAKE_C_FLAGS`, and the CRT objects with the cross compiler's own target triple.
The tier-3 jobs still set the compiler and the flags.

The issue also lists `Makefile:253` and `llc_arch` at `Makefile:9`. Both went away
with the Makefile itself when we moved the build to CMake in #5633, so nothing is
left to remove there.

Tier 3 runs on a schedule and on manual dispatch, never on pull requests, so this
PR's own CI does not exercise the changed lines.

Closes #5693
