### PR TITLE
Stop a socket read on a blocking file descriptor from hanging a program

### DIFF
--- a/.known-couplings/udp-empty-datagram-read-budget.md
+++ b/.known-couplings/udp-empty-datagram-read-budget.md
@@ -15,9 +15,17 @@ other actors on its scheduler thread. Simplifying `count.max(1)` back to
 `count`, or changing the runtime so recvfrom no longer returns a zero-count
 `OK`, reintroduces the starvation.
 
-No automated test guards this. The failure is a scheduler-fairness property,
+Only the runtime end is guarded by a test.
+`SocketRecvTest.RecvFromOnEmptyDatagramReturnsOk` in
+`test/libponyrt/lang/socket.cc` fails if `pony_os_recvfrom` stops returning a
+zero-count `OK` for an empty datagram.
+
+Nothing guards the stdlib end. That failure is a scheduler-fairness property,
 not an output: reproducing it needs thousands of empty datagrams resident in
 the socket buffer and arriving faster than they drain, and a "blast N datagrams
 and assert the test finishes" check passes with or without the guard. The
-guard is verified by reasoning, so this file is the record. If a test seam is
-ever added over the read accumulator, cover it there.
+`count.max(1)` charge is verified by reasoning, so this file is the record. If a
+test seam is ever added over the read accumulator, cover it there.
+
+Run: `ctest --preset debug -R libponyrt.tests` (catches a regression on the
+runtime end only)

--- a/.release-notes/stop-socket-read-hanging-on-blocking-fd.md
+++ b/.release-notes/stop-socket-read-hanging-on-blocking-fd.md
@@ -1,0 +1,7 @@
+## Stop a socket read on a blocking file descriptor from hanging a program
+
+A read on a socket could park a scheduler thread inside the read call, waiting for data that might never arrive. The runtime then never went idle and the program never exited.
+
+The sockets `TCPConnection` and `UDPSocket` create are never in blocking mode, so this took a file descriptor from somewhere else: one opened over the C FFI, or one belonging to a library that closes and reuses descriptors itself, where a read for a closed connection can land on a descriptor number that a blocking socket has since taken over.
+
+On Linux, macOS, and the BSDs, a socket read no longer waits for data to arrive, whatever mode the file descriptor is in. Windows offers no way to ask for that per read, so reads there still depend on the socket being non-blocking.

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -91,13 +91,6 @@ PONY_EXTERN_C_BEGIN
 
 PONY_API void pony_os_socket_close(int fd);
 
-// This must match the pony NetAddress type in packages/net.
-typedef struct
-{
-  pony_type_t* type;
-  struct sockaddr_storage addr;
-} ipaddress_t;
-
 PONY_API socklen_t ponyint_address_length(ipaddress_t* ipaddr)
 {
   switch(ipaddr->addr.ss_family)
@@ -803,6 +796,10 @@ PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
   // Synchronous non-blocking recv, like POSIX. OK paths must write a non-zero
   // count (the stdlib read loop advances by it and would spin on a 0-byte OK);
   // received == 0 (peer closed) is surfaced as ERROR for that reason.
+  //
+  // Winsock has no MSG_DONTWAIT, so unlike the POSIX branch below this call
+  // depends on the socket being in non-blocking mode, which every socket the
+  // runtime hands out has been put in by set_nonblocking (ioctlsocket FIONBIO).
   int received = recv((SOCKET)ev->fd, buf, (int)len, 0);
 
   if(received == SOCKET_ERROR)
@@ -828,7 +825,17 @@ PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
   // `_read_buf_offset` and `sum` by the count and would loop forever
   // if OK ever carried 0 bytes. `received == 0` (peer closed) is
   // surfaced as ERROR for that reason.
-  ssize_t received = recv(ev->fd, buf, len, 0);
+  //
+  // Pass MSG_DONTWAIT rather than trust the socket to be in non-blocking mode.
+  // The runtime only ever creates non-blocking sockets, but a read can arrive
+  // for a connection whose fd was already closed and whose number has since
+  // been reused by a blocking socket. Without the flag, that read parks this
+  // scheduler thread inside recv until data arrives, which may be never: the
+  // runtime cannot reach quiescence and the program cannot exit. The flag does
+  // not make such a read correct -- if the reused fd has data, it still lands
+  // in the wrong connection's buffer -- it only stops the read from parking
+  // the thread.
+  ssize_t received = recv(ev->fd, buf, len, MSG_DONTWAIT);
 
   if(received < 0)
   {
@@ -924,6 +931,7 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
 
   int addrlen = sizeof(struct sockaddr_storage);
 
+  // No MSG_DONTWAIT on Winsock; see the comment in pony_os_recv.
   int recvd = recvfrom((SOCKET)ev->fd, buf, (int)len, 0,
     (struct sockaddr*)&ipaddr->addr, &addrlen);
 
@@ -960,7 +968,9 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
 #else
   socklen_t addrlen = sizeof(struct sockaddr_storage);
 
-  ssize_t recvd = recvfrom(ev->fd, (char*)buf, len, 0,
+  // MSG_DONTWAIT for the same reason as pony_os_recv above: a read on a
+  // blocking fd must not park the scheduler thread.
+  ssize_t recvd = recvfrom(ev->fd, (char*)buf, len, MSG_DONTWAIT,
     (struct sockaddr*)&ipaddr->addr, &addrlen);
 
   if(recvd < 0)

--- a/src/libponyrt/lang/socket.h
+++ b/src/libponyrt/lang/socket.h
@@ -4,6 +4,15 @@
 #include <platform.h>
 #include <stdint.h>
 
+#ifdef PLATFORM_IS_WINDOWS
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
+
+#include "../asio/event.h"
+#include "../pony.h"
+
 PONY_EXTERN_C_BEGIN
 
 // Wire-level result for the five PONY_API socket runtime functions
@@ -21,14 +30,17 @@ PONY_EXTERN_C_BEGIN
 //                          read, unlike stream pony_os_recv where a 0-byte read
 //                          means the peer closed (ERROR, below).
 //   PONY_SOCKET_RETRY = 1  transient condition (POSIX EWOULDBLOCK/EAGAIN,
-//                          Windows WSAEWOULDBLOCK on send/writev). Caller
-//                          should retry later. *count_out is 0.
+//                          Windows WSAEWOULDBLOCK). Caller should retry later.
+//                          *count_out is 0.
 //   PONY_SOCKET_ERROR = 2  unrecoverable error or peer closed (POSIX recv
 //                          returning 0). *count_out is 0.
 //
 // The functions ALWAYS write *count_out before returning; callers MUST
 // pass a non-NULL pointer to a writable size_t. Passing NULL will
 // segfault.
+//
+// On RETRY and ERROR, pony_os_recvfrom does not write *ipaddr; treat its
+// contents as unspecified.
 //
 // Pony stdlib decodes these values in packages/net/_socket_result.pony.
 // Keep the integer values in sync with the _SocketResult* primitives'
@@ -40,6 +52,19 @@ typedef uint8_t pony_socket_result_t;
 #define PONY_SOCKET_OK    ((pony_socket_result_t)0)
 #define PONY_SOCKET_RETRY ((pony_socket_result_t)1)
 #define PONY_SOCKET_ERROR ((pony_socket_result_t)2)
+
+// This must match the pony NetAddress type in packages/net.
+typedef struct
+{
+  pony_type_t* type;
+  struct sockaddr_storage addr;
+} ipaddress_t;
+
+PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
+  size_t len, size_t* count_out);
+
+PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
+  size_t len, ipaddress_t* ipaddr, size_t* count_out);
 
 bool ponyint_os_sockets_init();
 

--- a/test/libponyrt/CMakeLists.txt
+++ b/test/libponyrt/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(libponyrt.tests
     ds/fun.cc
     ds/hash.cc
     ds/list.cc
+    lang/socket.cc
     mem/heap.cc
     mem/pagemap.cc
     mem/pool.cc

--- a/test/libponyrt/lang/socket.cc
+++ b/test/libponyrt/lang/socket.cc
@@ -1,0 +1,300 @@
+#include <platform.h>
+#include <gtest/gtest.h>
+
+#ifndef PLATFORM_IS_WINDOWS
+
+#include <asio/event.h>
+#include <lang/socket.h>
+
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstring>
+
+/** pony_os_recv and pony_os_recvfrom pass MSG_DONTWAIT so that a read never
+ * blocks, whatever mode the fd is in. The runtime only ever creates
+ * non-blocking sockets, so these tests hand it a blocking one -- the state a
+ * reused fd number can put it in -- and check that the call still returns
+ * without waiting for data.
+ *
+ * SO_RCVTIMEO bounds the failure: were MSG_DONTWAIT dropped, the recv would
+ * block until that timeout rather than forever, so the test fails on the
+ * elapsed-time assertion instead of hanging the suite. The result assertions
+ * pass either way; the elapsed time is what tells the two apart.
+ */
+
+static const int RECV_TIMEOUT_SECS = 5;
+static const int MAX_ELAPSED_MS = 2000;
+
+static_assert((RECV_TIMEOUT_SECS * 1000) > MAX_ELAPSED_MS,
+  "the receive timeout has to be longer than the elapsed-time bound, or a read "
+  "that blocks finishes inside the bound and the tests pass without the flag");
+
+class SocketRecvTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    memset(&_ev, 0, sizeof(_ev));
+    memset(&_dgram_addr, 0, sizeof(_dgram_addr));
+    _stream[0] = -1;
+    _stream[1] = -1;
+    _dgram = -1;
+    _pipe[0] = -1;
+    _pipe[1] = -1;
+  }
+
+  void TearDown() override
+  {
+    if(_stream[0] >= 0)
+      close(_stream[0]);
+
+    if(_stream[1] >= 0)
+      close(_stream[1]);
+
+    if(_dgram >= 0)
+      close(_dgram);
+
+    if(_pipe[0] >= 0)
+      close(_pipe[0]);
+
+    if(_pipe[1] >= 0)
+      close(_pipe[1]);
+  }
+
+  // A blocking stream socket with a receive timeout, and its peer.
+  void make_blocking_stream_pair()
+  {
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, _stream));
+    ASSERT_NO_FATAL_FAILURE(set_recv_timeout(_stream[0]));
+    ASSERT_FALSE(is_nonblocking(_stream[0]));
+    _ev.fd = _stream[0];
+  }
+
+  // A blocking datagram socket with a receive timeout, bound to a loopback
+  // port. Its own address goes in _dgram_addr so a test can send to it.
+  void make_blocking_datagram_socket()
+  {
+    _dgram = socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_LE(0, _dgram);
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    ASSERT_EQ(0, bind(_dgram, (struct sockaddr*)&addr, sizeof(addr)));
+
+    socklen_t addrlen = sizeof(_dgram_addr);
+    ASSERT_EQ(0, getsockname(_dgram, (struct sockaddr*)&_dgram_addr, &addrlen));
+
+    ASSERT_NO_FATAL_FAILURE(set_recv_timeout(_dgram));
+    ASSERT_FALSE(is_nonblocking(_dgram));
+    _ev.fd = _dgram;
+  }
+
+  // Wait for the fd to have data, so that a non-blocking read can't outrun the
+  // kernel's loopback delivery. This is also the state the asio backend has a
+  // socket in when it calls these functions.
+  static void wait_readable(int fd)
+  {
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+    ASSERT_EQ(1, poll(&pfd, 1, RECV_TIMEOUT_SECS * 1000));
+  }
+
+  static void set_recv_timeout(int fd)
+  {
+    struct timeval tv;
+    tv.tv_sec = RECV_TIMEOUT_SECS;
+    tv.tv_usec = 0;
+    ASSERT_EQ(0, setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)));
+  }
+
+  // Guards the tests against passing for the wrong reason: if the fd were
+  // non-blocking, the reads would return without waiting even with the flag
+  // removed.
+  static bool is_nonblocking(int fd)
+  {
+    return (fcntl(fd, F_GETFL, 0) & O_NONBLOCK) != 0;
+  }
+
+  asio_event_t _ev;
+  int _stream[2];
+  int _dgram;
+  int _pipe[2];
+  struct sockaddr_storage _dgram_addr;
+};
+
+/** A read on a blocking stream socket with nothing to read returns RETRY
+ * without waiting for data.
+ */
+TEST_F(SocketRecvTest, RecvOnEmptyBlockingSocketDoesNotWait)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  char buf[64];
+  size_t count = 1;
+
+  auto start = std::chrono::steady_clock::now();
+  pony_socket_result_t r = pony_os_recv(&_ev, buf, sizeof(buf), &count);
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - start).count();
+
+  ASSERT_EQ(PONY_SOCKET_RETRY, r);
+  ASSERT_EQ((size_t)0, count);
+  ASSERT_LT(elapsed, MAX_ELAPSED_MS);
+}
+
+/** A read on a blocking datagram socket with nothing to read returns RETRY
+ * without waiting for a datagram.
+ */
+TEST_F(SocketRecvTest, RecvFromOnEmptyBlockingSocketDoesNotWait)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_datagram_socket());
+
+  char buf[64];
+  size_t count = 1;
+  ipaddress_t ipaddr;
+  memset(&ipaddr, 0, sizeof(ipaddr));
+
+  auto start = std::chrono::steady_clock::now();
+  pony_socket_result_t r = pony_os_recvfrom(&_ev, buf, sizeof(buf), &ipaddr,
+    &count);
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - start).count();
+
+  ASSERT_EQ(PONY_SOCKET_RETRY, r);
+  ASSERT_EQ((size_t)0, count);
+  ASSERT_LT(elapsed, MAX_ELAPSED_MS);
+}
+
+/** MSG_DONTWAIT doesn't stop a blocking stream socket from delivering data
+ * that is already there.
+ */
+TEST_F(SocketRecvTest, RecvOnBlockingSocketReadsAvailableData)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  ASSERT_EQ((ssize_t)5, write(_stream[1], "hello", 5));
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_stream[0]));
+
+  char buf[64];
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_recv(&_ev, buf, sizeof(buf), &count));
+  ASSERT_EQ((size_t)5, count);
+  ASSERT_EQ(0, memcmp(buf, "hello", 5));
+}
+
+/** MSG_DONTWAIT doesn't stop a blocking datagram socket from delivering a
+ * datagram that is already there, or from reporting the sender's address.
+ */
+TEST_F(SocketRecvTest, RecvFromOnBlockingSocketReadsAvailableDatagram)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_datagram_socket());
+
+  ASSERT_EQ((ssize_t)5, sendto(_dgram, "hello", 5, 0,
+    (struct sockaddr*)&_dgram_addr, sizeof(struct sockaddr_in)));
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_dgram));
+
+  char buf[64];
+  size_t count = 0;
+  ipaddress_t ipaddr;
+  memset(&ipaddr, 0, sizeof(ipaddr));
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_recvfrom(&_ev, buf, sizeof(buf), &ipaddr,
+    &count));
+  ASSERT_EQ((size_t)5, count);
+  ASSERT_EQ(0, memcmp(buf, "hello", 5));
+
+  // The socket sent to itself, so the sender's address is its own.
+  const struct sockaddr_in* from = (const struct sockaddr_in*)&ipaddr.addr;
+  const struct sockaddr_in* self = (const struct sockaddr_in*)&_dgram_addr;
+  ASSERT_EQ(AF_INET, ipaddr.addr.ss_family);
+  ASSERT_EQ(self->sin_port, from->sin_port);
+  ASSERT_EQ(self->sin_addr.s_addr, from->sin_addr.s_addr);
+}
+
+/** An empty datagram is a valid read, so recvfrom reports a zero-byte OK.
+ * MSG_DONTWAIT does not turn it into a retry, which the caller could not tell
+ * apart from an empty socket.
+ */
+TEST_F(SocketRecvTest, RecvFromOnEmptyDatagramReturnsOk)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_datagram_socket());
+
+  ASSERT_EQ((ssize_t)0, sendto(_dgram, "", 0, 0,
+    (struct sockaddr*)&_dgram_addr, sizeof(struct sockaddr_in)));
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_dgram));
+
+  char buf[64];
+  size_t count = 1;
+  ipaddress_t ipaddr;
+  memset(&ipaddr, 0, sizeof(ipaddr));
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_recvfrom(&_ev, buf, sizeof(buf), &ipaddr,
+    &count));
+  ASSERT_EQ((size_t)0, count);
+  ASSERT_EQ(AF_INET, ipaddr.addr.ss_family);
+}
+
+/** A read on a stream socket whose peer has closed reports ERROR, not a
+ * zero-byte OK. MSG_DONTWAIT does not turn the peer's close into a retry.
+ */
+TEST_F(SocketRecvTest, RecvOnPeerClosedSocketReturnsError)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  ASSERT_EQ(0, close(_stream[1]));
+  _stream[1] = -1;
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_stream[0]));
+
+  char buf[64];
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_recv(&_ev, buf, sizeof(buf), &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+/** A read on a descriptor that isn't a socket reports ERROR. Only EAGAIN
+ * becomes a retry; were any other error to become one, the stdlib read loop
+ * would retry a dead descriptor forever.
+ */
+TEST_F(SocketRecvTest, RecvOnNonSocketFdReturnsError)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+  _ev.fd = _pipe[0];
+
+  char buf[64];
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_recv(&_ev, buf, sizeof(buf), &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+/** As for pony_os_recv: a descriptor that isn't a socket is an error, not a
+ * retry.
+ */
+TEST_F(SocketRecvTest, RecvFromOnNonSocketFdReturnsError)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+  _ev.fd = _pipe[0];
+
+  char buf[64];
+  size_t count = 1;
+  ipaddress_t ipaddr;
+  memset(&ipaddr, 0, sizeof(ipaddr));
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_recvfrom(&_ev, buf, sizeof(buf), &ipaddr,
+    &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+#endif


### PR DESCRIPTION
On POSIX, `pony_os_recv` and `pony_os_recvfrom` passed a flags argument of `0`, which left a read blocking or not depending on the socket's own mode. The runtime always creates non-blocking sockets, but a descriptor number can be closed and recycled by code the runtime doesn't own: code called over the C FFI, or a library that manages descriptors itself. A stray read on the recycled number reaches whatever socket the kernel gave that number to, and if that socket is blocking, the read parks a scheduler thread. The runtime never reaches quiescence and the program never exits.

Both calls now pass `MSG_DONTWAIT`, so a read with no data returns `PONY_SOCKET_RETRY` instead of blocking, whatever mode the descriptor is in. On the sockets the runtime creates, the flag is a no-op, so nothing on the normal read path changes. `MSG_DONTWAIT` is not a fix for the reuse itself: the runtime still reads data on a recycled descriptor into the wrong connection's buffer. All it does is keep that read from parking a scheduler thread. Winsock has no `MSG_DONTWAIT`, so the Windows branches still depend on the socket's non-blocking mode.

Nothing in `packages/net` can hand the runtime a blocking descriptor, so the new tests are C++ against the runtime rather than Pony. They need a header to include. `ipaddress_t` therefore lives in `socket.h` now, alongside prototypes for the two functions, neither of which had a declaration in any header before.

Closes #5715
