### PR TITLE
Stop disabling Windows Defender in CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -218,8 +218,6 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
@@ -294,8 +292,6 @@ jobs:
 
     name: arm64-pc-windows-msvc
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/ponyc-tier2.yml
+++ b/.github/workflows/ponyc-tier2.yml
@@ -325,8 +325,6 @@ jobs:
 
     name: arm64 Windows MSVC
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -150,8 +150,6 @@ jobs:
           - directives: runtime_tracing,runtimestats
     name: 'use ${{ matrix.directives }} (Windows)'
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,8 +118,6 @@ jobs:
         shell: pwsh
     name: maybe-build libs (x86-64 Windows)
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Ensure libs
@@ -216,8 +214,6 @@ jobs:
         shell: pwsh
     name: 'ponyc: x86-64 Windows MSVC'
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
@@ -320,8 +316,6 @@ jobs:
         shell: pwsh
     name: 'pony-compiler: Windows'
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Build libs
@@ -429,8 +423,6 @@ jobs:
         shell: pwsh
     name: 'Tools: Windows'
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Build libs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,8 +224,6 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies
@@ -295,8 +293,6 @@ jobs:
 
     name: arm64-pc-windows-msvc
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/stress-test-generative-normal-windows.yml
+++ b/.github/workflows/stress-test-generative-normal-windows.yml
@@ -28,8 +28,6 @@ jobs:
 
     name: x86-64 Windows generative normal [debug]
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/stress-test-generative-systematic-windows.yml
+++ b/.github/workflows/stress-test-generative-systematic-windows.yml
@@ -31,8 +31,6 @@ jobs:
 
     name: x86-64 Windows generative systematic [debug]
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/stress-test-tcp-swarm-windows.yml
+++ b/.github/workflows/stress-test-tcp-swarm-windows.yml
@@ -28,8 +28,6 @@ jobs:
 
     name: x86-64 Windows tcp swarm [debug]
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:

--- a/.github/workflows/test-windows-nightly.yml
+++ b/.github/workflows/test-windows-nightly.yml
@@ -15,8 +15,6 @@ jobs:
 
     name: x86-64-pc-windows-msvc
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install Dependencies

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -215,8 +215,6 @@ jobs:
 
     name: x86-64 Windows MSVC
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Build and push libs
@@ -234,8 +232,6 @@ jobs:
 
     name: arm64 Windows MSVC
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Build and push libs


### PR DESCRIPTION
We turned off real-time monitoring on the Windows runners expecting the builds and tests to get faster. They didn't. The step itself, meanwhile, sometimes fails, which fails the job for a reason that has nothing to do with the code being tested.

Removes the `Disable Windows Defender` step from all 16 Windows jobs it appears in, across 10 workflows. Pure deletion; nothing else changes.