### PR TITLE
Stop a socket write on a blocking file descriptor from hanging a program

### DIFF
--- a/.ci-scripts/test-debugger.sh
+++ b/.ci-scripts/test-debugger.sh
@@ -9,14 +9,19 @@
 # cmake's test wrappers read PONY_TEST_DEBUGGER and split it with shell quoting
 # rules, so the quoted sub-commands below survive as single arguments. lldb ends
 # with `--` and gdb with `--args`, so the test binary and its arguments follow.
+#
+# The signals below are ones a Pony program takes in normal operation, so a
+# debugger that stops on them turns a passing run into a reported crash. SIGPIPE
+# is on the list even though the runtime sets it to SIG_IGN: a debugger stops on
+# an ignored signal too, seeing it before the process's disposition applies.
 set -euo pipefail
 
 case "${1:-}" in
   lldb)
-    echo 'lldb --batch --one-line "breakpoint set --name main" --one-line run --one-line "process handle SIGINT --pass true --stop false" --one-line "process handle SIGUSR2 --pass true --stop false" --one-line "thread continue" --one-line-on-crash "frame variable" --one-line-on-crash "register read" --one-line-on-crash "bt all" --one-line-on-crash "quit 1" --'
+    echo 'lldb --batch --one-line "breakpoint set --name main" --one-line run --one-line "process handle SIGINT --pass true --stop false" --one-line "process handle SIGUSR2 --pass true --stop false" --one-line "process handle SIGPIPE --pass true --stop false" --one-line "thread continue" --one-line-on-crash "frame variable" --one-line-on-crash "register read" --one-line-on-crash "bt all" --one-line-on-crash "quit 1" --'
     ;;
   gdb)
-    echo 'gdb --quiet --batch --return-child-result --eval-command="set confirm off" --eval-command="set pagination off" --eval-command="handle SIGINT nostop pass" --eval-command="handle SIGUSR2 nostop pass" --eval-command=run --eval-command="info args" --eval-command="info locals" --eval-command="info registers" --eval-command="thread apply all bt full" --eval-command=quit --args'
+    echo 'gdb --quiet --batch --return-child-result --eval-command="set confirm off" --eval-command="set pagination off" --eval-command="handle SIGINT nostop pass" --eval-command="handle SIGUSR2 nostop pass" --eval-command="handle SIGPIPE nostop pass" --eval-command=run --eval-command="info args" --eval-command="info locals" --eval-command="info registers" --eval-command="thread apply all bt full" --eval-command=quit --args'
     ;;
   *)
     echo "usage: ${0} {lldb|gdb}" >&2

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -198,3 +198,25 @@ The sockets `TCPConnection` and `UDPSocket` create are never in blocking mode, s
 
 On Linux, macOS, and the BSDs, a socket read no longer waits for data to arrive, whatever mode the file descriptor is in. Windows offers no way to ask for that per read, so reads there still depend on the socket being non-blocking.
 
+
+## Stop a socket write on a blocking file descriptor from hanging a program
+
+A write to a socket could park a scheduler thread inside the write call, waiting for room in a send buffer that might never drain. The runtime then never went idle and the program never exited.
+
+The sockets `TCPConnection` and `UDPSocket` create are never in blocking mode, so this took a file descriptor from somewhere else: one opened over the C FFI, or one belonging to a library that closes and reuses descriptors itself, where a write for a closed connection can land on a descriptor number that a blocking socket has since taken over.
+
+On Linux, FreeBSD, OpenBSD, and DragonFly BSD, a socket write no longer waits for room in the send buffer, whatever mode the file descriptor is in. macOS and Windows offer no way to ask for that per write: macOS ignores the flag that asks for it on a write, though not on a read, and Windows has no such flag at all. Writes on those two still depend on the socket being non-blocking, as every socket the runtime creates is.
+
+## Add `pony_os_sendv` for writing to a socket
+
+`pony_os_sendv` sends an array of buffers over a socket in a single call. It is what `TCPConnection` now uses to write.
+
+```pony
+use @pony_os_sendv[U8](ev: AsioEventID,
+  iov: Pointer[(Pointer[U8] tag, USize)] tag, iovcnt: I32,
+  count_out: Pointer[USize])
+```
+
+It returns the same three values `pony_os_writev` does — 0 when the write completed, 1 to retry later, 2 on an error — and writes the number of bytes sent through `count_out`.
+
+If you call `pony_os_writev` over the FFI to write to a socket, switch to `pony_os_sendv`. `pony_os_writev` is unchanged and still exported, but on Linux, macOS, and the BSDs it calls `writev`, which takes no flags argument, so nothing can request a non-blocking write: on a blocking file descriptor it parks the calling thread. `pony_os_sendv` passes `MSG_DONTWAIT` and returns a retry instead, on every platform whose kernel honors that flag on a write. In exchange it takes a socket and nothing else, where `pony_os_writev` on those platforms takes any file descriptor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,14 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix `Readline` nudging the cursor right on an empty line ([PR #5688](https://github.com/ponylang/ponyc/pull/5688))
 - Fix `Readline.down` underflow on empty history ([PR #5689](https://github.com/ponylang/ponyc/pull/5689))
 - Stop a socket read on a blocking file descriptor from hanging a program ([PR #5718](https://github.com/ponylang/ponyc/pull/5718))
+- Stop a socket write on a blocking file descriptor from hanging a program ([PR #5726](https://github.com/ponylang/ponyc/pull/5726))
 
 ### Added
 
 - Add --version and --help support to pony-lsp ([PR #5668](https://github.com/ponylang/ponyc/pull/5668))
 - Support runtime tracing on Windows ([PR #5676](https://github.com/ponylang/ponyc/pull/5676))
 - Add `rewind()` to ArrayKeys and ArrayPairs ([PR #5645](https://github.com/ponylang/ponyc/pull/5645))
+- Add `pony_os_sendv` for writing to a socket ([PR #5726](https://github.com/ponylang/ponyc/pull/5726))
 
 ### Changed
 

--- a/packages/net/_socket_result.pony
+++ b/packages/net/_socket_result.pony
@@ -1,7 +1,7 @@
 // Pony-side dual of `pony_socket_result_t` defined in
 // `src/libponyrt/lang/socket.h`. The integer values returned from `apply()`
 // must match the C-side `PONY_SOCKET_OK`/`PONY_SOCKET_RETRY`/`PONY_SOCKET_ERROR`
-// constants, which are part of the FFI ABI for the five `pony_os_*` socket
+// constants, which are part of the FFI ABI for the six `pony_os_*` socket
 // runtime functions. Keep both files in sync.
 //
 // `_SocketResultDecoder` collapses any out-of-range U8 to `_SocketResultError`

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -12,8 +12,9 @@ use @pony_asio_event_set_writeable[None](event: AsioEventID, writeable: Bool)
 use @pony_asio_event_set_readable[None](event: AsioEventID, readable: Bool)
 use @pony_os_recv[U8](event: AsioEventID, buffer: Pointer[U8] tag,
   size: USize, count_out: Pointer[USize])
-use @pony_os_writev[U8](ev: AsioEventID, iov: Pointer[(Pointer[U8] tag, USize)] tag,
-  iovcnt: I32, count_out: Pointer[USize])
+use @pony_os_sendv[U8](ev: AsioEventID,
+  iov: Pointer[(Pointer[U8] tag, USize)] tag, iovcnt: I32,
+  count_out: Pointer[USize])
 use @pony_os_writev_max[I32]()
 use @pony_os_keepalive[None](fd: U32, secs: U32)
 use @pony_os_socket_close[None](fd: U32)
@@ -718,7 +719,7 @@ actor TCPConnection is AsioEventNotify
           num_to_send = _pending_writev.size()
           bytes_to_send = _pending_writev_total
         else
-          // Have more buffers than a single writev can handle.
+          // Have more buffers than a single send can handle.
           // Iterate over buffers being sent to add up total.
           num_to_send = writev_batch_size
           bytes_to_send = 0
@@ -730,7 +731,7 @@ actor TCPConnection is AsioEventNotify
         // Write as much data as possible.
         var count: USize = 0
         match \exhaustive\ _SocketResultDecoder(
-          @pony_os_writev(_event,
+          @pony_os_sendv(_event,
             _pending_writev.cpointer(), num_to_send.i32(),
             addressof count))
         | _SocketResultOk =>

--- a/src/libponyrt/lang/io.c
+++ b/src/libponyrt/lang/io.c
@@ -14,7 +14,7 @@ PONY_EXTERN_C_BEGIN
 
 
 // How many buffers a single gather-write may carry. Read by both packages/net
-// (TCPConnection) and packages/files (File). On Windows net's pony_os_writev
+// (TCPConnection) and packages/files (File). On Windows net's pony_os_sendv
 // does a real WSASend over a WSABUF array, but file.pony's Windows write branch
 // does a single-buffer write keyed off this same cap: raising it above 1 there
 // would hand file.pony a multi-buffer total and it would over-read past the

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -179,16 +179,6 @@ static int set_nonblocking(int s)
 #define SIO_UDP_CONNRESET _WSAIOW(IOC_VENDOR, 12)
 #endif
 
-// Pony passes writev buffers as an array of (Pointer[U8], USize) tuples, the
-// same memory layout as a POSIX struct iovec. Windows has no struct iovec, so
-// we mirror it here; pony_os_writev builds a WSABUF array from it internally
-// (WSABUF orders its fields differently and uses u_long, not size_t).
-typedef struct pony_iovec_t
-{
-  void* iov_base;
-  size_t iov_len;
-} pony_iovec_t;
-
 static int set_nonblocking(SOCKET s)
 {
   u_long nonblocking = 1;
@@ -677,7 +667,7 @@ PONY_API bool pony_os_host_ip6(const char* host)
 }
 
 #ifdef PLATFORM_IS_WINDOWS
-PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
+PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
   const pony_iovec_t* iov, int iovcnt, size_t* count_out)
 {
   SOCKET s = (SOCKET)ev->fd;
@@ -726,7 +716,46 @@ PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
   *count_out = (size_t)sent;
   return PONY_SOCKET_OK;
 }
+
+PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
+  const pony_iovec_t* iov, int iovcnt, size_t* count_out)
+{
+  // Winsock has no gather-write outside of the socket API, so there is nothing
+  // for this to do that pony_os_sendv doesn't already do.
+  return pony_os_sendv(ev, iov, iovcnt, count_out);
+}
 #else
+PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
+  const struct iovec* iov, int iovcnt, size_t* count_out)
+{
+  struct msghdr msg;
+  memset(&msg, 0, sizeof(msg));
+
+  msg.msg_iov = (struct iovec*)iov;
+
+  // msg_iovlen is a size_t on Linux, an int on macOS, FreeBSD, and DragonFly,
+  // and an unsigned int on OpenBSD. Let each platform convert from int itself;
+  // a cast naming one of those types is wrong on the others.
+  msg.msg_iovlen = iovcnt;
+
+  ssize_t sent = sendmsg(ev->fd, &msg, MSG_DONTWAIT);
+
+  if(sent < 0)
+  {
+    if(errno == EWOULDBLOCK || errno == EAGAIN)
+    {
+      *count_out = 0;
+      return PONY_SOCKET_RETRY;
+    }
+
+    *count_out = 0;
+    return PONY_SOCKET_ERROR;
+  }
+
+  *count_out = (size_t)sent;
+  return PONY_SOCKET_OK;
+}
+
 PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
   const struct iovec *iov, int iovcnt, size_t* count_out)
 {
@@ -770,7 +799,7 @@ PONY_API pony_socket_result_t pony_os_send(asio_event_t* ev, const char* buf,
   *count_out = (size_t)sent;
   return PONY_SOCKET_OK;
 #else
-  ssize_t sent = send(ev->fd, buf, len, 0);
+  ssize_t sent = send(ev->fd, buf, len, MSG_DONTWAIT);
 
   if(sent < 0)
   {
@@ -793,13 +822,9 @@ PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
   size_t len, size_t* count_out)
 {
 #ifdef PLATFORM_IS_WINDOWS
-  // Synchronous non-blocking recv, like POSIX. OK paths must write a non-zero
-  // count (the stdlib read loop advances by it and would spin on a 0-byte OK);
-  // received == 0 (peer closed) is surfaced as ERROR for that reason.
-  //
-  // Winsock has no MSG_DONTWAIT, so unlike the POSIX branch below this call
-  // depends on the socket being in non-blocking mode, which every socket the
-  // runtime hands out has been put in by set_nonblocking (ioctlsocket FIONBIO).
+  // OK paths must write a non-zero count (the stdlib read loop advances by it
+  // and would spin on a 0-byte OK); received == 0 (peer closed) is surfaced as
+  // ERROR for that reason.
   int received = recv((SOCKET)ev->fd, buf, (int)len, 0);
 
   if(received == SOCKET_ERROR)
@@ -825,16 +850,6 @@ PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
   // `_read_buf_offset` and `sum` by the count and would loop forever
   // if OK ever carried 0 bytes. `received == 0` (peer closed) is
   // surfaced as ERROR for that reason.
-  //
-  // Pass MSG_DONTWAIT rather than trust the socket to be in non-blocking mode.
-  // The runtime only ever creates non-blocking sockets, but a read can arrive
-  // for a connection whose fd was already closed and whose number has since
-  // been reused by a blocking socket. Without the flag, that read parks this
-  // scheduler thread inside recv until data arrives, which may be never: the
-  // runtime cannot reach quiescence and the program cannot exit. The flag does
-  // not make such a read correct -- if the reused fd has data, it still lands
-  // in the wrong connection's buffer -- it only stops the read from parking
-  // the thread.
   ssize_t received = recv(ev->fd, buf, len, MSG_DONTWAIT);
 
   if(received < 0)
@@ -897,8 +912,8 @@ PONY_API pony_socket_result_t pony_os_sendto(int fd, const char* buf,
     return PONY_SOCKET_ERROR;
   }
 
-  ssize_t sent = sendto(fd, buf, len, 0, (struct sockaddr*)&ipaddr->addr,
-    addrlen);
+  ssize_t sent = sendto(fd, buf, len, MSG_DONTWAIT,
+    (struct sockaddr*)&ipaddr->addr, addrlen);
 
   if(sent < 0)
   {
@@ -931,7 +946,6 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
 
   int addrlen = sizeof(struct sockaddr_storage);
 
-  // No MSG_DONTWAIT on Winsock; see the comment in pony_os_recv.
   int recvd = recvfrom((SOCKET)ev->fd, buf, (int)len, 0,
     (struct sockaddr*)&ipaddr->addr, &addrlen);
 
@@ -968,8 +982,6 @@ PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
 #else
   socklen_t addrlen = sizeof(struct sockaddr_storage);
 
-  // MSG_DONTWAIT for the same reason as pony_os_recv above: a read on a
-  // blocking fd must not park the scheduler thread.
   ssize_t recvd = recvfrom(ev->fd, (char*)buf, len, MSG_DONTWAIT,
     (struct sockaddr*)&ipaddr->addr, &addrlen);
 

--- a/src/libponyrt/lang/socket.h
+++ b/src/libponyrt/lang/socket.h
@@ -8,6 +8,7 @@
 #include <winsock2.h>
 #else
 #include <sys/socket.h>
+#include <sys/uio.h>
 #endif
 
 #include "../asio/event.h"
@@ -15,16 +16,17 @@
 
 PONY_EXTERN_C_BEGIN
 
-// Wire-level result for the five PONY_API socket runtime functions
-// (pony_os_writev, pony_os_send, pony_os_recv, pony_os_sendto,
+// Wire-level result for the six PONY_API socket runtime functions
+// (pony_os_writev, pony_os_sendv, pony_os_send, pony_os_recv, pony_os_sendto,
 // pony_os_recvfrom). The integer values are part of the ABI:
 //
 //   PONY_SOCKET_OK    = 0  operation completed; *count_out holds the byte
 //                          count read/written for the caller to act on.
-//                          These calls are synchronous and non-blocking on
-//                          every platform (the Windows backend uses readiness
-//                          notifications, not overlapped IOCP), so the count
-//                          is always the bytes transferred by this call.
+//                          These calls transfer data themselves rather than
+//                          queue it for later on every platform (the Windows
+//                          backend uses readiness notifications, not overlapped
+//                          IOCP), so the count is always the bytes transferred
+//                          by this call.
 //                          A datagram pony_os_recvfrom may return OK with a 0
 //                          count: an empty UDP datagram (RFC 768) is a valid
 //                          read, unlike stream pony_os_recv where a 0-byte read
@@ -41,6 +43,10 @@ PONY_EXTERN_C_BEGIN
 //
 // On RETRY and ERROR, pony_os_recvfrom does not write *ipaddr; treat its
 // contents as unspecified.
+//
+// These calls do not wait on a non-blocking descriptor, which every socket the
+// runtime creates is. On any other descriptor, whether a call waits varies by
+// platform and by direction; nothing may depend on it.
 //
 // Pony stdlib decodes these values in packages/net/_socket_result.pony.
 // Keep the integer values in sync with the _SocketResult* primitives'
@@ -60,11 +66,47 @@ typedef struct
   struct sockaddr_storage addr;
 } ipaddress_t;
 
+#ifdef PLATFORM_IS_WINDOWS
+// Pony passes gather-write buffers as an array of (Pointer[U8], USize) tuples,
+// the same memory layout as a POSIX struct iovec. Windows has no struct iovec,
+// so we mirror it here; pony_os_sendv builds a WSABUF array from it internally
+// (WSABUF orders its fields differently and uses u_long, not size_t).
+typedef struct pony_iovec_t
+{
+  void* iov_base;
+  size_t iov_len;
+} pony_iovec_t;
+#endif
+
 PONY_API pony_socket_result_t pony_os_recv(asio_event_t* ev, char* buf,
   size_t len, size_t* count_out);
 
 PONY_API pony_socket_result_t pony_os_recvfrom(asio_event_t* ev, char* buf,
   size_t len, ipaddress_t* ipaddr, size_t* count_out);
+
+PONY_API pony_socket_result_t pony_os_send(asio_event_t* ev, const char* buf,
+  size_t len, size_t* count_out);
+
+PONY_API pony_socket_result_t pony_os_sendto(int fd, const char* buf,
+  size_t len, ipaddress_t* ipaddr, size_t* count_out);
+
+#ifdef PLATFORM_IS_WINDOWS
+PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
+  const pony_iovec_t* iov, int iovcnt, size_t* count_out);
+#else
+PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
+  const struct iovec* iov, int iovcnt, size_t* count_out);
+#endif
+
+// For use with non-socket file descriptors. If you have a socket, use
+// pony_os_sendv.
+#ifdef PLATFORM_IS_WINDOWS
+PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
+  const pony_iovec_t* iov, int iovcnt, size_t* count_out);
+#else
+PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
+  const struct iovec* iov, int iovcnt, size_t* count_out);
+#endif
 
 bool ponyint_os_sockets_init();
 

--- a/test/libponyrt/lang/socket.cc
+++ b/test/libponyrt/lang/socket.cc
@@ -6,39 +6,35 @@
 #include <asio/event.h>
 #include <lang/socket.h>
 
+#include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include <chrono>
 #include <cstring>
+#include <vector>
 
-/** pony_os_recv and pony_os_recvfrom pass MSG_DONTWAIT so that a read never
- * blocks, whatever mode the fd is in. The runtime only ever creates
- * non-blocking sockets, so these tests hand it a blocking one -- the state a
- * reused fd number can put it in -- and check that the call still returns
- * without waiting for data.
- *
- * SO_RCVTIMEO bounds the failure: were MSG_DONTWAIT dropped, the recv would
- * block until that timeout rather than forever, so the test fails on the
- * elapsed-time assertion instead of hanging the suite. The result assertions
- * pass either way; the elapsed time is what tells the two apart.
- */
-
-static const int RECV_TIMEOUT_SECS = 5;
+static const int SOCKET_TIMEOUT_SECS = 5;
 static const int MAX_ELAPSED_MS = 2000;
 
-static_assert((RECV_TIMEOUT_SECS * 1000) > MAX_ELAPSED_MS,
-  "the receive timeout has to be longer than the elapsed-time bound, or a read "
+static_assert((SOCKET_TIMEOUT_SECS * 1000) > MAX_ELAPSED_MS,
+  "the socket timeout has to be longer than the elapsed-time bound, or a call "
   "that blocks finishes inside the bound and the tests pass without the flag");
 
-class SocketRecvTest : public testing::Test
+class SocketTest : public testing::Test
 {
 protected:
   void SetUp() override
   {
+    // Puts SIGPIPE on SIG_IGN for the rest of the process, the disposition
+    // every Pony program runs with. A send to a closed peer has to come back as
+    // an error rather than kill the test binary.
+    ASSERT_TRUE(ponyint_os_sockets_init());
+
     memset(&_ev, 0, sizeof(_ev));
     memset(&_dgram_addr, 0, sizeof(_dgram_addr));
     _stream[0] = -1;
@@ -66,17 +62,28 @@ protected:
       close(_pipe[1]);
   }
 
-  // A blocking stream socket with a receive timeout, and its peer.
-  void make_blocking_stream_pair()
+  // A blocking stream socket with timeouts, and its peer. A non-zero bufsize
+  // shrinks the socket buffers so that a test can fill or overrun them; zero
+  // leaves the kernel's defaults.
+  void make_blocking_stream_pair(int bufsize = 0)
   {
     ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, _stream));
-    ASSERT_NO_FATAL_FAILURE(set_recv_timeout(_stream[0]));
+
+    if(bufsize > 0)
+    {
+      ASSERT_EQ(0, setsockopt(_stream[0], SOL_SOCKET, SO_SNDBUF, &bufsize,
+        sizeof(bufsize)));
+      ASSERT_EQ(0, setsockopt(_stream[1], SOL_SOCKET, SO_RCVBUF, &bufsize,
+        sizeof(bufsize)));
+    }
+
+    ASSERT_NO_FATAL_FAILURE(set_timeouts(_stream[0]));
     ASSERT_FALSE(is_nonblocking(_stream[0]));
     _ev.fd = _stream[0];
   }
 
-  // A blocking datagram socket with a receive timeout, bound to a loopback
-  // port. Its own address goes in _dgram_addr so a test can send to it.
+  // A blocking datagram socket with timeouts, bound to a loopback port. Its own
+  // address goes in _dgram_addr so a test can send to it.
   void make_blocking_datagram_socket()
   {
     _dgram = socket(AF_INET, SOCK_DGRAM, 0);
@@ -92,7 +99,7 @@ protected:
     socklen_t addrlen = sizeof(_dgram_addr);
     ASSERT_EQ(0, getsockname(_dgram, (struct sockaddr*)&_dgram_addr, &addrlen));
 
-    ASSERT_NO_FATAL_FAILURE(set_recv_timeout(_dgram));
+    ASSERT_NO_FATAL_FAILURE(set_timeouts(_dgram));
     ASSERT_FALSE(is_nonblocking(_dgram));
     _ev.fd = _dgram;
   }
@@ -106,19 +113,20 @@ protected:
     pfd.fd = fd;
     pfd.events = POLLIN;
     pfd.revents = 0;
-    ASSERT_EQ(1, poll(&pfd, 1, RECV_TIMEOUT_SECS * 1000));
+    ASSERT_EQ(1, poll(&pfd, 1, SOCKET_TIMEOUT_SECS * 1000));
   }
 
-  static void set_recv_timeout(int fd)
+  static void set_timeouts(int fd)
   {
     struct timeval tv;
-    tv.tv_sec = RECV_TIMEOUT_SECS;
+    tv.tv_sec = SOCKET_TIMEOUT_SECS;
     tv.tv_usec = 0;
     ASSERT_EQ(0, setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)));
+    ASSERT_EQ(0, setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)));
   }
 
   // Guards the tests against passing for the wrong reason: if the fd were
-  // non-blocking, the reads would return without waiting even with the flag
+  // non-blocking, the calls would return without waiting even with the flag
   // removed.
   static bool is_nonblocking(int fd)
   {
@@ -131,6 +139,8 @@ protected:
   int _pipe[2];
   struct sockaddr_storage _dgram_addr;
 };
+
+class SocketRecvTest : public SocketTest {};
 
 /** A read on a blocking stream socket with nothing to read returns RETRY
  * without waiting for data.
@@ -295,6 +305,353 @@ TEST_F(SocketRecvTest, RecvFromOnNonSocketFdReturnsError)
   ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_recvfrom(&_ev, buf, sizeof(buf), &ipaddr,
     &count));
   ASSERT_EQ((size_t)0, count);
+}
+
+// Small enough that filling the send buffer, or overrunning it with one write,
+// takes a handful of kilobytes rather than megabytes. Kernels round it, so the
+// tests that care about the real capacity read it back with getsockopt.
+static const int SMALL_BUFSIZE = 8192;
+
+class SocketSendTest : public SocketTest
+{
+protected:
+  // A macOS send waits for buffer space whatever flags it is given. Its reads
+  // honor MSG_DONTWAIT, so only the send tests have to step around this.
+  static bool sends_honor_dontwait()
+  {
+#ifdef PLATFORM_IS_MACOSX
+    return false;
+#else
+    return true;
+#endif
+  }
+
+  // Put the stream pair's own descriptor in non-blocking mode, the mode every
+  // socket the runtime creates is in.
+  void make_stream_pair_nonblocking()
+  {
+    int flags = fcntl(_stream[0], F_GETFL, 0);
+    ASSERT_NE(-1, flags);
+    ASSERT_NE(-1, fcntl(_stream[0], F_SETFL, flags | O_NONBLOCK));
+  }
+
+  // Leave the stream pair's send buffer with no room in it. The fd goes
+  // non-blocking for the fill so that a full buffer announces itself with
+  // EAGAIN, and blocking again afterwards, which is the state under test.
+  void fill_send_buffer()
+  {
+    int flags = fcntl(_stream[0], F_GETFL, 0);
+    ASSERT_NE(-1, flags);
+    ASSERT_NE(-1, fcntl(_stream[0], F_SETFL, flags | O_NONBLOCK));
+
+    std::vector<char> chunk(SMALL_BUFSIZE, 'x');
+    bool full = false;
+
+    for(int i = 0; !full && (i < 1024); i++)
+    {
+      ssize_t w = write(_stream[0], chunk.data(), chunk.size());
+
+      if(w < 0)
+      {
+        ASSERT_TRUE((errno == EWOULDBLOCK) || (errno == EAGAIN));
+        full = true;
+      }
+    }
+
+    ASSERT_TRUE(full);
+    ASSERT_NE(-1, fcntl(_stream[0], F_SETFL, flags));
+    ASSERT_FALSE(is_nonblocking(_stream[0]));
+  }
+
+  // What the kernel actually gave us, which is not what we asked for: the two
+  // buffers together bound how much one write can put into an empty socket.
+  size_t effective_capacity()
+  {
+    int sndbuf = 0;
+    int rcvbuf = 0;
+    socklen_t len = sizeof(sndbuf);
+    EXPECT_EQ(0, getsockopt(_stream[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, &len));
+    len = sizeof(rcvbuf);
+    EXPECT_EQ(0, getsockopt(_stream[1], SOL_SOCKET, SO_RCVBUF, &rcvbuf, &len));
+    return (size_t)sndbuf + (size_t)rcvbuf;
+  }
+
+  // An address pointing at the datagram socket this test made.
+  void datagram_address(ipaddress_t* ipaddr)
+  {
+    memset(ipaddr, 0, sizeof(ipaddress_t));
+    memcpy(&ipaddr->addr, &_dgram_addr, sizeof(struct sockaddr_in));
+  }
+
+  // An address whose family the runtime recognizes. pony_os_sendto rejects one
+  // it doesn't before it ever looks at the descriptor, so a test that wants to
+  // reach the descriptor has to hand it a real address.
+  static void loopback_address(ipaddress_t* ipaddr)
+  {
+    memset(ipaddr, 0, sizeof(ipaddress_t));
+    struct sockaddr_in* addr = (struct sockaddr_in*)&ipaddr->addr;
+    addr->sin_family = AF_INET;
+    addr->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr->sin_port = htons(9);
+  }
+};
+
+TEST_F(SocketSendTest, SendvOnFullBlockingSocketDoesNotWait)
+{
+  if(!sends_honor_dontwait())
+    GTEST_SKIP() << "a send ignores MSG_DONTWAIT on this platform";
+
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair(SMALL_BUFSIZE));
+  ASSERT_NO_FATAL_FAILURE(fill_send_buffer());
+
+  char data[] = "hello";
+  struct iovec iov[1];
+  iov[0].iov_base = data;
+  iov[0].iov_len = 5;
+  size_t count = 1;
+
+  auto start = std::chrono::steady_clock::now();
+  pony_socket_result_t r = pony_os_sendv(&_ev, iov, 1, &count);
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - start).count();
+
+  ASSERT_EQ(PONY_SOCKET_RETRY, r);
+  ASSERT_EQ((size_t)0, count);
+  ASSERT_LT(elapsed, MAX_ELAPSED_MS);
+}
+
+TEST_F(SocketSendTest, SendOnFullBlockingSocketDoesNotWait)
+{
+  if(!sends_honor_dontwait())
+    GTEST_SKIP() << "a send ignores MSG_DONTWAIT on this platform";
+
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair(SMALL_BUFSIZE));
+  ASSERT_NO_FATAL_FAILURE(fill_send_buffer());
+
+  size_t count = 1;
+
+  auto start = std::chrono::steady_clock::now();
+  pony_socket_result_t r = pony_os_send(&_ev, "hello", 5, &count);
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - start).count();
+
+  ASSERT_EQ(PONY_SOCKET_RETRY, r);
+  ASSERT_EQ((size_t)0, count);
+  ASSERT_LT(elapsed, MAX_ELAPSED_MS);
+}
+
+TEST_F(SocketSendTest, SendvOnBlockingSocketWritesAllBuffers)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  char first[] = "hello";
+  char second[] = ", world";
+  struct iovec iov[2];
+  iov[0].iov_base = first;
+  iov[0].iov_len = 5;
+  iov[1].iov_base = second;
+  iov[1].iov_len = 7;
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_sendv(&_ev, iov, 2, &count));
+  ASSERT_EQ((size_t)12, count);
+
+  char buf[64];
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_stream[1]));
+  ASSERT_EQ((ssize_t)12, read(_stream[1], buf, sizeof(buf)));
+  ASSERT_EQ(0, memcmp(buf, "hello, world", 12));
+}
+
+/** TCPConnection._manage_pending_buffer advances its iovecs by the count an OK
+ * carries, so a partial write must stay an OK with a short count rather than
+ * become a retry.
+ */
+TEST_F(SocketSendTest, SendvWithOversizedPayloadWritesPartially)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair(SMALL_BUFSIZE));
+  ASSERT_NO_FATAL_FAILURE(make_stream_pair_nonblocking());
+
+  // Past what the socket can hold, however the kernel rounded the request.
+  size_t total = effective_capacity() * 4;
+  std::vector<char> data(total, 'x');
+  struct iovec iov[1];
+  iov[0].iov_base = data.data();
+  iov[0].iov_len = total;
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_sendv(&_ev, iov, 1, &count));
+  ASSERT_LT((size_t)0, count);
+  ASSERT_LT(count, total);
+}
+
+TEST_F(SocketSendTest, SendWithOversizedPayloadWritesPartially)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair(SMALL_BUFSIZE));
+  ASSERT_NO_FATAL_FAILURE(make_stream_pair_nonblocking());
+
+  size_t total = effective_capacity() * 4;
+  std::vector<char> data(total, 'x');
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_send(&_ev, data.data(), total, &count));
+  ASSERT_LT((size_t)0, count);
+  ASSERT_LT(count, total);
+}
+
+TEST_F(SocketSendTest, SendOnBlockingSocketWritesData)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  size_t count = 0;
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_send(&_ev, "hello", 5, &count));
+  ASSERT_EQ((size_t)5, count);
+
+  char buf[64];
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_stream[1]));
+  ASSERT_EQ((ssize_t)5, read(_stream[1], buf, sizeof(buf)));
+  ASSERT_EQ(0, memcmp(buf, "hello", 5));
+}
+
+/** A closed peer must not report RETRY: the stdlib write loop would answer a
+ * retry by writing to the dead socket again.
+ */
+TEST_F(SocketSendTest, SendvOnPeerClosedSocketReturnsError)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  ASSERT_EQ(0, close(_stream[1]));
+  _stream[1] = -1;
+
+  char data[] = "hello";
+  struct iovec iov[1];
+  iov[0].iov_base = data;
+  iov[0].iov_len = 5;
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_sendv(&_ev, iov, 1, &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+TEST_F(SocketSendTest, SendOnPeerClosedSocketReturnsError)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  ASSERT_EQ(0, close(_stream[1]));
+  _stream[1] = -1;
+
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_send(&_ev, "hello", 5, &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+/** Only EAGAIN becomes a retry. Were ENOTSOCK to become one, the stdlib write
+ * loop would retry a dead descriptor forever.
+ */
+TEST_F(SocketSendTest, SendvOnNonSocketFdReturnsError)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+  _ev.fd = _pipe[1];
+
+  char data[] = "hello";
+  struct iovec iov[1];
+  iov[0].iov_base = data;
+  iov[0].iov_len = 5;
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_sendv(&_ev, iov, 1, &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+TEST_F(SocketSendTest, SendOnNonSocketFdReturnsError)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+  _ev.fd = _pipe[1];
+
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_send(&_ev, "hello", 5, &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+TEST_F(SocketSendTest, SendToOnBlockingSocketSendsDatagram)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_datagram_socket());
+
+  ipaddress_t ipaddr;
+  datagram_address(&ipaddr);
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_sendto(_dgram, "hello", 5, &ipaddr,
+    &count));
+  ASSERT_EQ((size_t)5, count);
+
+  // The socket sent to itself, so the datagram comes back to it.
+  char buf[64];
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_dgram));
+  ASSERT_EQ((ssize_t)5, recv(_dgram, buf, sizeof(buf), 0));
+  ASSERT_EQ(0, memcmp(buf, "hello", 5));
+}
+
+TEST_F(SocketSendTest, SendToOnNonSocketFdReturnsError)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+
+  ipaddress_t ipaddr;
+  loopback_address(&ipaddr);
+  size_t count = 1;
+
+  ASSERT_EQ(PONY_SOCKET_ERROR, pony_os_sendto(_pipe[1], "hello", 5, &ipaddr,
+    &count));
+  ASSERT_EQ((size_t)0, count);
+}
+
+TEST_F(SocketSendTest, WritevOnBlockingSocketWritesAllBuffers)
+{
+  ASSERT_NO_FATAL_FAILURE(make_blocking_stream_pair());
+
+  char first[] = "hello";
+  char second[] = ", world";
+  struct iovec iov[2];
+  iov[0].iov_base = first;
+  iov[0].iov_len = 5;
+  iov[1].iov_base = second;
+  iov[1].iov_len = 7;
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_writev(&_ev, iov, 2, &count));
+  ASSERT_EQ((size_t)12, count);
+
+  char buf[64];
+  ASSERT_NO_FATAL_FAILURE(wait_readable(_stream[1]));
+  ASSERT_EQ((ssize_t)12, read(_stream[1], buf, sizeof(buf)));
+  ASSERT_EQ(0, memcmp(buf, "hello, world", 12));
+}
+
+/** pony_os_writev takes any descriptor and pony_os_sendv takes a socket, which
+ * is why the runtime carries both. A sendmsg behind this name would return
+ * ERROR here.
+ */
+TEST_F(SocketSendTest, WritevOnNonSocketFdWritesData)
+{
+  ASSERT_EQ(0, pipe(_pipe));
+  _ev.fd = _pipe[1];
+
+  char first[] = "hello";
+  char second[] = ", world";
+  struct iovec iov[2];
+  iov[0].iov_base = first;
+  iov[0].iov_len = 5;
+  iov[1].iov_base = second;
+  iov[1].iov_len = 7;
+  size_t count = 0;
+
+  ASSERT_EQ(PONY_SOCKET_OK, pony_os_writev(&_ev, iov, 2, &count));
+  ASSERT_EQ((size_t)12, count);
+
+  char buf[64];
+  ASSERT_EQ((ssize_t)12, read(_pipe[0], buf, sizeof(buf)));
+  ASSERT_EQ(0, memcmp(buf, "hello, world", 12));
 }
 
 #endif


### PR DESCRIPTION
On POSIX, `pony_os_send` and `pony_os_sendto` passed a flags argument of `0`, and `pony_os_writev` called `writev(2)`, which takes no flags argument. All three left a write blocking or not depending on the socket's own mode. The runtime always creates non-blocking sockets, but a descriptor number can be closed and recycled by code the runtime doesn't own. A stray write on the recycled number reaches whatever socket the kernel gave that number to, and if that socket is blocking with a full send buffer, the write parks a scheduler thread. The runtime never goes idle and the program never exits.

`send` and `sendto` now pass `MSG_DONTWAIT`, the same one-word change made for reads in #5718. `writev` has no flag to pass, and the call that does, `sendmsg`, accepts a socket and nothing else. `pony_os_writev` is exported and code outside this repo links against it, so changing the syscall under that name would hand a caller with a non-socket descriptor `ENOTSOCK`, with no compile error and no warning. `pony_os_sendv` is new instead, `TCPConnection` calls it, and `pony_os_writev` is left alone. #5719 has the argument in full. On Windows both are the same `WSASend`, and `pony_os_writev` calls `pony_os_sendv`.

The flag does not reach every platform, which is a correction to what #5719 assumed. Linux, FreeBSD, OpenBSD, and DragonFly check `MSG_DONTWAIT` on the send path and return `EWOULDBLOCK`. macOS does not: its kernel tests an internal `MSG_NBIO` there and no header exposes it, so a send on a blocking socket parks whatever flags it is given (xnu, `bsd/kern/uipc_socket.c`, in `sosendcheck`). macOS honors the flag on a receive, which is why #5718 covers it and this doesn't. Winsock has no `MSG_DONTWAIT` at all. So macOS and Windows join `pony_os_writev` in depending on the descriptor's own mode, and `socket.h` carries the table. The macOS CI leg caught this; the two tests that assert a send doesn't wait now skip there.

Nothing in `packages/net` can hand the runtime a blocking descriptor, so the new tests are C++ against the runtime rather than Pony. They surfaced one more thing: a write to a closed peer raises `SIGPIPE`, and while the runtime sets it to `SIG_IGN`, a debugger stops on an ignored signal all the same. `.ci-scripts/test-debugger.sh` now passes `SIGPIPE` through, next to `SIGINT` and `SIGUSR2`.

Closes #5719