### PR TITLE
Remove the rest of the library-mode runtime surface

### DIFF
--- a/.release-notes/remove-library-mode-runtime-surface.md
+++ b/.release-notes/remove-library-mode-runtime-surface.md
@@ -1,0 +1,7 @@
+## Remove the rest of the library-mode runtime surface
+
+Pony's library mode — embedding the runtime in a C host and stepping it by hand — was removed in earlier releases. This release removes the runtime C API functions that were left behind and that only library mode used.
+
+These functions are gone: `pony_poll`, `pony_alloc_msg_size`, `pony_gc_acquire`, `pony_gc_release`, `pony_acquire_done`, `pony_release_done`, `pony_send`, `pony_sendp`, `pony_sendi`, `pony_register_thread`, and `pony_unregister_thread`.
+
+Normal Pony programs are unaffected; the compiler never generated calls to any of these functions. Only C code that linked the runtime directly and called them is affected, and that code was using library mode, which is no longer supported.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -519,12 +519,11 @@ static bool maybe_should_mute(pony_actor_t* actor)
   return false;
 }
 
-static bool batch_limit_reached(pony_actor_t* actor, bool polling)
+static bool batch_limit_reached(pony_actor_t* actor)
 {
-  if(!has_sync_flag(actor, ACTOR_SYNC_FLAG_OVERLOADED) && !polling)
+  if(!has_sync_flag(actor, ACTOR_SYNC_FLAG_OVERLOADED))
   {
-    // If we hit our batch size, consider this actor to be overloaded
-    // only if we're not polling from C code.
+    // If we hit our batch size, consider this actor to be overloaded.
     // Overloaded actors are allowed to send to other overloaded actors
     // and to muted actors without being muted themselves.
     actor_setoverloaded(actor);
@@ -533,7 +532,7 @@ static bool batch_limit_reached(pony_actor_t* actor, bool polling)
   return true;
 }
 
-bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
+bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   TRACING_THREAD_ACTOR_RUN_START(actor);
   pony_assert(!has_sync_flag(actor, ACTOR_SYNC_FLAG_MUTED));
@@ -603,11 +602,10 @@ bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling)
       }
 
       // if we've reached our batch limit
-      // or if we're polling where we want to stop after one app message
-      if(app == batch || polling)
+      if(app == batch)
       {
         TRACING_THREAD_ACTOR_RUN_STOP(actor);
-        return batch_limit_reached(actor, polling);
+        return batch_limit_reached(actor);
       }
     }
     else
@@ -952,11 +950,6 @@ PONY_API pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id)
   return msg;
 }
 
-PONY_API pony_msg_t* pony_alloc_msg_size(size_t size, uint32_t id)
-{
-  return pony_alloc_msg((uint32_t)ponyint_pool_index(size), id);
-}
-
 PONY_API void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* first,
   pony_msg_t* last, bool has_app_msg)
 {
@@ -1079,7 +1072,7 @@ PONY_API void pony_chain(pony_msg_t* prev, pony_msg_t* next)
   atomic_store_explicit(&prev->next, next, memory_order_relaxed);
 }
 
-PONY_API void pony_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id)
+void ponyint_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id)
 {
 #ifdef USE_RUNTIMESTATS_MESSAGES
   ctx->schedulerstats.mem_used_inflight_messages += sizeof(pony_msg_t);
@@ -1090,8 +1083,7 @@ PONY_API void pony_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id)
   pony_sendv(ctx, to, m, m, id <= ACTORMSG_APPLICATION_START);
 }
 
-PONY_API void pony_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
-  void* p)
+void ponyint_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id, void* p)
 {
 #ifdef USE_RUNTIMESTATS_MESSAGES
   ctx->schedulerstats.mem_used_inflight_messages += sizeof(pony_msgp_t);
@@ -1105,8 +1097,7 @@ PONY_API void pony_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
   pony_sendv(ctx, to, &m->msg, &m->msg, id <= ACTORMSG_APPLICATION_START);
 }
 
-PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
-  intptr_t i)
+void ponyint_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id, intptr_t i)
 {
 #ifdef USE_RUNTIMESTATS_MESSAGES
   ctx->schedulerstats.mem_used_inflight_messages += sizeof(pony_msgi_t);
@@ -1264,14 +1255,6 @@ PONY_API void pony_actor_unset_pinned()
 void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   ctx->current = actor;
-}
-
-PONY_API void pony_poll(pony_ctx_t* ctx)
-{
-  // TODO: this seems like it could allow muted actors to get `ponyint_actor_run`
-  // which shouldn't be allowed. Fixing might require API changes.
-  pony_assert(ctx->current != NULL);
-  ponyint_actor_run(ctx, ctx->current, true);
 }
 
 #ifdef USE_RUNTIME_TRACING

--- a/src/libponyrt/actor/actor.h
+++ b/src/libponyrt/actor/actor.h
@@ -133,6 +133,24 @@ typedef struct pony_actor_pad_t
  */
 void ponyint_become(pony_ctx_t* ctx, pony_actor_t* actor);
 
+/** Convenience function to send a message with no arguments.
+ *
+ * The dispatch function receives a pony_msg_t.
+ */
+void ponyint_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id);
+
+/** Convenience function to send a pointer argument in a message.
+ *
+ * The dispatch function receives a pony_msgp_t.
+ */
+void ponyint_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id, void* p);
+
+/** Convenience function to send an integer argument in a message.
+ *
+ * The dispatch function receives a pony_msgi_t.
+ */
+void ponyint_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id, intptr_t i);
+
 /** Send a message to an actor and add to the inject queue if it is not currently
  * scheduled.
  */
@@ -159,7 +177,7 @@ void ponyint_sendp_inject(pony_actor_t* to, uint32_t id, void* p);
  */
 void ponyint_sendi_inject(pony_actor_t* to, uint32_t id, intptr_t i);
 
-bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor, bool polling);
+bool ponyint_actor_run(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_actor_destroy(pony_actor_t* actor, actor_destroyed_reason_t reason);
 

--- a/src/libponyrt/asio/emscripten.c
+++ b/src/libponyrt/asio/emscripten.c
@@ -107,7 +107,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   ponyint_messageq_destroy(&b->q, true);
   POOL_FREE(asio_backend_t, b);
-  pony_unregister_thread();
+  ponyint_unregister_thread();
   return NULL;
 }
 

--- a/src/libponyrt/asio/epoll.c
+++ b/src/libponyrt/asio/epoll.c
@@ -330,7 +330,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   TRACING_THREAD_STOP();
 
-  pony_unregister_thread();
+  ponyint_unregister_thread();
   return NULL;
 }
 

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -318,7 +318,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   TRACING_THREAD_STOP();
 
-  pony_unregister_thread();
+  ponyint_unregister_thread();
   return NULL;
 }
 

--- a/src/libponyrt/asio/sock_notify.c
+++ b/src/libponyrt/asio/sock_notify.c
@@ -481,7 +481,7 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
   TRACING_THREAD_STOP();
 
-  pony_unregister_thread();
+  ponyint_unregister_thread();
   return NULL;
 }
 

--- a/src/libponyrt/gc/actormap.c
+++ b/src/libponyrt/gc/actormap.c
@@ -114,7 +114,7 @@ static void send_release(pony_ctx_t* ctx, actorref_t* aref)
     return;
   }
 
-  pony_sendp(ctx, aref->actor, ACTORMSG_RELEASE, aref);
+  ponyint_sendp(ctx, aref->actor, ACTORMSG_RELEASE, aref);
 }
 
 actorref_t* ponyint_actormap_getactor(actormap_t* map, pony_actor_t* actor, size_t* index)
@@ -144,8 +144,7 @@ actorref_t* ponyint_actormap_getorput(actormap_t* map, pony_actor_t* actor,
 // RELEASE sends in ponyint_actormap_sweep happen in a layout-independent order
 // rather than in the map's pointer-hash iteration order. ids are unique, so
 // there are no ties (see pony_actor_t.systematic_testing_id and gc.c's
-// gc_drain_acquire_ordered, which sorts the acquire/release sends the same
-// way).
+// gc_drain_acquire_ordered, which sorts the ACQUIRE sends the same way).
 static int actormap_sweep_systematic_testing_id_cmp(const void* a,
   const void* b)
 {

--- a/src/libponyrt/gc/cycle.c
+++ b/src/libponyrt/gc/cycle.c
@@ -679,7 +679,7 @@ static void send_conf(pony_ctx_t* ctx, perceived_t* per)
     qsort(views, size, sizeof(view_t*), view_systematic_testing_id_cmp);
 
     for(k = 0; k < size; k++)
-      pony_sendi(ctx, views[k]->actor, ACTORMSG_CONF, per->token);
+      ponyint_sendi(ctx, views[k]->actor, ACTORMSG_CONF, per->token);
 
     ponyint_pool_free_size(size * sizeof(view_t*), views);
   }
@@ -689,7 +689,7 @@ static void send_conf(pony_ctx_t* ctx, perceived_t* per)
 
   while((view = ponyint_viewmap_next(&per->map, &i)) != NULL)
   {
-    pony_sendi(ctx, view->actor, ACTORMSG_CONF, per->token);
+    ponyint_sendi(ctx, view->actor, ACTORMSG_CONF, per->token);
   }
 #endif
 }
@@ -990,7 +990,7 @@ static void check_blocked(pony_ctx_t* ctx, detector_t* d)
 #ifdef USE_SYSTEMATIC_TESTING
       views[count++] = view;
 #else
-      pony_send(ctx, view->actor, ACTORMSG_ISBLOCKED);
+      ponyint_send(ctx, view->actor, ACTORMSG_ISBLOCKED);
 #endif
     }
 
@@ -1018,7 +1018,7 @@ static void check_blocked(pony_ctx_t* ctx, detector_t* d)
     qsort(views, count, sizeof(view_t*), view_systematic_testing_id_cmp);
 
     for(size_t k = 0; k < count; k++)
-      pony_send(ctx, views[k]->actor, ACTORMSG_ISBLOCKED);
+      ponyint_send(ctx, views[k]->actor, ACTORMSG_ISBLOCKED);
 
     // The buffer was allocated to `total` (the probe upper bound), and only
     // `count <= total` of it was filled, so the free size is `total`, not

--- a/src/libponyrt/gc/gc.c
+++ b/src/libponyrt/gc/gc.c
@@ -67,17 +67,6 @@ static void recv_local_actor(gc_t* gc)
   }
 }
 
-static void acquire_local_actor(gc_t* gc)
-{
-  gc->rc++;
-}
-
-static void release_local_actor(gc_t* gc)
-{
-  pony_assert(gc->rc > 0);
-  gc->rc--;
-}
-
 static void send_remote_actor(pony_ctx_t* ctx, gc_t* gc, actorref_t* aref)
 {
   if(aref->mark == gc->mark)
@@ -138,12 +127,6 @@ static void mark_remote_actor(pony_ctx_t* ctx, gc_t* gc, actorref_t* aref)
     if(!ponyint_actor_getnoblock())
       gc->delta = ponyint_deltamap_update(gc->delta, aref->actor, aref->rc);
   }
-}
-
-static void acq_or_rel_remote_actor(pony_ctx_t* ctx, pony_actor_t* actor)
-{
-  actorref_t* aref = ponyint_actormap_getorput(&ctx->acquire, actor, 0);
-  aref->rc += 1;
 }
 
 static void send_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
@@ -214,58 +197,6 @@ static void mark_local_object(pony_ctx_t* ctx, chunk_t* chunk, void* p,
     // is not opaque, it will recurse.
     ponyint_heap_mark_shallow(chunk, p);
   }
-}
-
-static void acquire_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability)
-{
-  gc_t* gc = ponyint_actor_gc(ctx->current);
-  object_t* obj = ponyint_objectmap_getorput(&gc->local, p, t, gc->mark);
-
-  if(obj->mark == gc->mark)
-    return;
-
-  // Implicitly acquire the owner.
-  acquire_local_actor(gc);
-
-  obj->rc++;
-  obj->mark = gc->mark;
-
-  if(mutability == PONY_TRACE_OPAQUE)
-    return;
-
-  if(mutability == PONY_TRACE_IMMUTABLE)
-    obj->immutable = true;
-
-  if(!obj->immutable || might_reference_actor(t))
-    recurse(ctx, p, t->trace);
-}
-
-static void release_local_object(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability)
-{
-  size_t index = HASHMAP_UNKNOWN;
-  gc_t* gc = ponyint_actor_gc(ctx->current);
-  object_t* obj = ponyint_objectmap_getobject(&gc->local, p, &index);
-  pony_assert(obj != NULL);
-
-  if(obj->mark == gc->mark)
-    return;
-
-  // Implicitly release the owner.
-  release_local_actor(gc);
-
-  obj->rc--;
-  obj->mark = gc->mark;
-
-  if(mutability == PONY_TRACE_OPAQUE)
-    return;
-
-  if(mutability == PONY_TRACE_IMMUTABLE)
-    obj->immutable = true;
-
-  if(!obj->immutable || might_reference_actor(t))
-    recurse(ctx, p, t->trace);
 }
 
 static void send_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
@@ -487,32 +418,6 @@ static void mark_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
     recurse(ctx, p, t->trace);
 }
 
-static void acq_or_rel_remote_object(pony_ctx_t* ctx, pony_actor_t* actor,
-  void* p, pony_type_t* t, int mutability)
-{
-  gc_t* gc = ponyint_actor_gc(ctx->current);
-  actorref_t* aref = ponyint_actormap_getorput(&ctx->acquire, actor, 0);
-  object_t* obj = ponyint_actorref_getorput(aref, p, t, gc->mark);
-
-  if(obj->mark == gc->mark)
-    return;
-
-  // Implicitly acquire/release the owner.
-  acq_or_rel_remote_actor(ctx, actor);
-
-  obj->rc++;
-  obj->mark = gc->mark;
-
-  if(mutability == PONY_TRACE_OPAQUE)
-    return;
-
-  if(mutability == PONY_TRACE_IMMUTABLE)
-    obj->immutable = true;
-
-  if(!obj->immutable || might_reference_actor(t))
-    recurse(ctx, p, t->trace);
-}
-
 void ponyint_gc_sendobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability)
 {
@@ -573,47 +478,6 @@ void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
     mark_remote_object(ctx, actor, p, t, mutability, chunk);
 }
 
-void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability)
-{
-  pony_actor_t* actor = NULL;
-  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
-
-  // Don't gc memory that wasn't pony_allocated, but do recurse.
-  if(chunk == NULL)
-  {
-    if(mutability != PONY_TRACE_OPAQUE)
-      recurse(ctx, p, t->trace);
-    return;
-  }
-
-  if(actor == ctx->current)
-    acquire_local_object(ctx, p, t, mutability);
-  else
-    acq_or_rel_remote_object(ctx, actor, p, t, mutability);
-}
-
-void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability)
-{
-  pony_actor_t* actor = NULL;
-  chunk_t* chunk = ponyint_pagemap_get(p, &actor);
-
-  // Don't gc memory that wasn't pony_allocated, but do recurse.
-  if(chunk == NULL)
-  {
-    if(mutability != PONY_TRACE_OPAQUE)
-      recurse(ctx, p, t->trace);
-    return;
-  }
-
-  if(actor == ctx->current)
-    release_local_object(ctx, p, t, mutability);
-  else
-    acq_or_rel_remote_object(ctx, actor, p, t, mutability);
-
-}
-
 void ponyint_gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor)
 {
   gc_t* gc = ponyint_actor_gc(ctx->current);
@@ -650,22 +514,6 @@ void ponyint_gc_markactor(pony_ctx_t* ctx, pony_actor_t* actor)
   gc_t* gc = ponyint_actor_gc(ctx->current);
   actorref_t* aref = ponyint_actormap_getorput(&gc->foreign, actor, gc->mark);
   mark_remote_actor(ctx, gc, aref);
-}
-
-void ponyint_gc_acquireactor(pony_ctx_t* ctx, pony_actor_t* actor)
-{
-  if(actor == ctx->current)
-    acquire_local_actor(ponyint_actor_gc(ctx->current));
-  else
-    acq_or_rel_remote_actor(ctx, actor);
-}
-
-void ponyint_gc_releaseactor(pony_ctx_t* ctx, pony_actor_t* actor)
-{
-  if(actor == ctx->current)
-    release_local_actor(ponyint_actor_gc(ctx->current));
-  else
-    acq_or_rel_remote_actor(ctx, actor);
 }
 
 void ponyint_gc_createactor(pony_actor_t* current, pony_actor_t* actor)
@@ -834,14 +682,12 @@ static int gc_actorref_systematic_testing_id_cmp(const void* a, const void* b)
   return (ia > ib) - (ia < ib);
 }
 
-// Drain ctx->acquire and send `msg_id` to each referenced actor, ordered by the
-// target actor's stable creation-order id rather than by the actormap's
-// pointer-hash iteration order. Each send schedules its recipient, so sending
-// in a layout-independent order is what keeps a fixed seed's interleaving
-// reproducible under ASLR (see pony_actor_t.systematic_testing_id). Both
-// ACTORMSG_ACQUIRE (ponyint_gc_sendacquire) and ACTORMSG_RELEASE
-// (ponyint_gc_sendrelease_manual) drain ctx->acquire this way.
-static void gc_drain_acquire_ordered(pony_ctx_t* ctx, uint32_t msg_id)
+// Drain ctx->acquire and send each referenced actor an ACTORMSG_ACQUIRE,
+// ordered by the target actor's stable creation-order id rather than by the
+// actormap's pointer-hash iteration order. Each send schedules its recipient,
+// so sending in a layout-independent order is what keeps a fixed seed's
+// interleaving reproducible under ASLR. See pony_actor_t.systematic_testing_id.
+static void gc_drain_acquire_ordered(pony_ctx_t* ctx)
 {
   size_t n = ponyint_actormap_size(&ctx->acquire);
 
@@ -871,7 +717,7 @@ static void gc_drain_acquire_ordered(pony_ctx_t* ctx, uint32_t msg_id)
       ctx->schedulerstats.mem_allocated_actors += (POOL_ALLOC_SIZE(actorref_t)
         + ponyint_objectmap_total_alloc_size(&aref->map));
 #endif
-      pony_sendp(ctx, aref->actor, msg_id, aref);
+      ponyint_sendp(ctx, aref->actor, ACTORMSG_ACQUIRE, aref);
     }
 
     ponyint_pool_free_size(n * sizeof(actorref_t*), refs);
@@ -884,7 +730,7 @@ static void gc_drain_acquire_ordered(pony_ctx_t* ctx, uint32_t msg_id)
 void ponyint_gc_sendacquire(pony_ctx_t* ctx)
 {
 #ifdef USE_SYSTEMATIC_TESTING
-  gc_drain_acquire_ordered(ctx, ACTORMSG_ACQUIRE);
+  gc_drain_acquire_ordered(ctx);
 #else
   size_t i = HASHMAP_BEGIN;
   actorref_t* aref;
@@ -899,7 +745,7 @@ void ponyint_gc_sendacquire(pony_ctx_t* ctx)
 #endif
 
     ponyint_actormap_clearindex(&ctx->acquire, i);
-    pony_sendp(ctx, aref->actor, ACTORMSG_ACQUIRE, aref);
+    ponyint_sendp(ctx, aref->actor, ACTORMSG_ACQUIRE, aref);
   }
 
   pony_assert(ponyint_actormap_size(&ctx->acquire) == 0);
@@ -924,31 +770,6 @@ void ponyint_gc_sendrelease(pony_ctx_t* ctx, gc_t* gc)
 #ifdef USE_RUNTIMESTATS
   ctx->current->actorstats.foreign_actormap_objectmap_mem_used -= objectmap_mem_used_freed;
   ctx->current->actorstats.foreign_actormap_objectmap_mem_allocated -= objectmap_mem_allocated_freed;
-#endif
-}
-
-void ponyint_gc_sendrelease_manual(pony_ctx_t* ctx)
-{
-#ifdef USE_SYSTEMATIC_TESTING
-  gc_drain_acquire_ordered(ctx, ACTORMSG_RELEASE);
-#else
-  size_t i = HASHMAP_BEGIN;
-  actorref_t* aref;
-
-  while((aref = ponyint_actormap_next(&ctx->acquire, &i)) != NULL)
-  {
-#ifdef USE_RUNTIMESTATS
-    ctx->schedulerstats.mem_used_actors += (sizeof(actorref_t)
-      + ponyint_objectmap_total_mem_size(&aref->map));
-    ctx->schedulerstats.mem_allocated_actors += (POOL_ALLOC_SIZE(actorref_t)
-      + ponyint_objectmap_total_alloc_size(&aref->map));
-#endif
-
-    ponyint_actormap_clearindex(&ctx->acquire, i);
-    pony_sendp(ctx, aref->actor, ACTORMSG_RELEASE, aref);
-  }
-
-  pony_assert(ponyint_actormap_size(&ctx->acquire) == 0);
 #endif
 }
 

--- a/src/libponyrt/gc/gc.h
+++ b/src/libponyrt/gc/gc.h
@@ -36,21 +36,11 @@ void ponyint_gc_recvobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
 void ponyint_gc_markobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
   int mutability);
 
-void ponyint_gc_acquireobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability);
-
-void ponyint_gc_releaseobject(pony_ctx_t* ctx, void* p, pony_type_t* t,
-  int mutability);
-
 void ponyint_gc_sendactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_recvactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_markactor(pony_ctx_t* ctx, pony_actor_t* actor);
-
-void ponyint_gc_acquireactor(pony_ctx_t* ctx, pony_actor_t* actor);
-
-void ponyint_gc_releaseactor(pony_ctx_t* ctx, pony_actor_t* actor);
 
 void ponyint_gc_createactor(pony_actor_t* current, pony_actor_t* actor);
 
@@ -65,8 +55,6 @@ void ponyint_gc_sweep(pony_ctx_t* ctx, gc_t* gc);
 void ponyint_gc_sendacquire(pony_ctx_t* ctx);
 
 void ponyint_gc_sendrelease(pony_ctx_t* ctx, gc_t* gc);
-
-void ponyint_gc_sendrelease_manual(pony_ctx_t* ctx);
 
 bool ponyint_gc_acquire(gc_t* gc, actorref_t* aref);
 

--- a/src/libponyrt/gc/trace.c
+++ b/src/libponyrt/gc/trace.c
@@ -43,22 +43,6 @@ void ponyint_gc_mark(pony_ctx_t* ctx)
   ctx->trace_actor = ponyint_gc_markactor;
 }
 
-PONY_API void pony_gc_acquire(pony_ctx_t* ctx)
-{
-  pony_assert(ctx->current != NULL);
-  pony_assert(ctx->stack == NULL);
-  ctx->trace_object = ponyint_gc_acquireobject;
-  ctx->trace_actor = ponyint_gc_acquireactor;
-}
-
-PONY_API void pony_gc_release(pony_ctx_t* ctx)
-{
-  pony_assert(ctx->current != NULL);
-  pony_assert(ctx->stack == NULL);
-  ctx->trace_object = ponyint_gc_releaseobject;
-  ctx->trace_actor = ponyint_gc_releaseactor;
-}
-
 PONY_API void pony_send_done(pony_ctx_t* ctx)
 {
   pony_assert(ctx->current != NULL);
@@ -98,22 +82,6 @@ void ponyint_mark_done(pony_ctx_t* ctx)
   ponyint_gc_sendacquire(ctx);
   TRACING_ACTOR_GC_SWEEP_START(ctx->current);
   ponyint_gc_sweep(ctx, ponyint_actor_gc(ctx->current));
-  ponyint_gc_done(ponyint_actor_gc(ctx->current));
-}
-
-PONY_API void pony_acquire_done(pony_ctx_t* ctx)
-{
-  pony_assert(ctx->current != NULL);
-  ponyint_gc_handlestack(ctx);
-  ponyint_gc_sendacquire(ctx);
-  ponyint_gc_done(ponyint_actor_gc(ctx->current));
-}
-
-PONY_API void pony_release_done(pony_ctx_t* ctx)
-{
-  pony_assert(ctx->current != NULL);
-  ponyint_gc_handlestack(ctx);
-  ponyint_gc_sendrelease_manual(ctx);
   ponyint_gc_done(ponyint_actor_gc(ctx->current));
 }
 

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -148,9 +148,6 @@ PONY_API ATTRIBUTE_MALLOC pony_actor_t* pony_create(pony_ctx_t* ctx,
 /// Allocate a message and set up the header. The index is a POOL_INDEX.
 PONY_API pony_msg_t* pony_alloc_msg(uint32_t index, uint32_t id);
 
-/// Allocate a message and set up the header. The size is in bytes.
-PONY_API pony_msg_t* pony_alloc_msg_size(size_t size, uint32_t id);
-
 /** Send a chain of messages to an actor.
  *
  * The first and last messages must either be the same message or the two ends
@@ -186,26 +183,6 @@ PONY_API void pony_sendv_single(pony_ctx_t* ctx, pony_actor_t* to,
  * next must either be an unchained message or the start of an existing chain.
  */
 PONY_API void pony_chain(pony_msg_t* prev, pony_msg_t* next);
-
-/** Convenience function to send a message with no arguments.
- *
- * The dispatch function receives a pony_msg_t.
- */
-PONY_API void pony_send(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id);
-
-/** Convenience function to send a pointer argument in a message
- *
- * The dispatch function receives a pony_msgp_t.
- */
-PONY_API void pony_sendp(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
-  void* p);
-
-/** Convenience function to send an integer argument in a message
- *
- * The dispatch function receives a pony_msgi_t.
- */
-PONY_API void pony_sendi(pony_ctx_t* ctx, pony_actor_t* to, uint32_t id,
-  intptr_t i);
 
 /** Allocate memory on the current actor's heap.
  *
@@ -265,28 +242,6 @@ PONY_API void pony_gc_send(pony_ctx_t* ctx, pony_actor_t* to);
  */
 PONY_API void pony_gc_recv(pony_ctx_t* ctx);
 
-/** Start gc tracing for acquiring.
- *
- * Call this when acquiring objects. Then trace the objects you want to
- * acquire, then call pony_acquire_done. Acquired objects will not be GCed
- * until released even if they are not reachable from Pony code anymore.
- * Acquiring an object will also acquire all objects reachable from it as well
- * as their respective owners. When adding or removing objects from an acquired
- * object graph, you must acquire anything added and release anything removed.
- * A given object (excluding actors) cannot be acquired more than once in a
- * single pony_gc_acquire/pony_acquire_done round. The same restriction applies
- * to release functions.
- */
-PONY_API void pony_gc_acquire(pony_ctx_t* ctx);
-
-/** Start gc tracing for releasing.
- *
- * Call this when releasing acquired objects. Then trace the objects you want
- * to release, then call pony_release_done. If an object was acquired multiple
- * times, it must be released as many times before being GCed.
- */
-PONY_API void pony_gc_release(pony_ctx_t* ctx);
-
 /** Finish gc tracing for sending.
  *
  * Call this after tracing the GCable contents.
@@ -298,18 +253,6 @@ PONY_API void pony_send_done(pony_ctx_t* ctx);
  * Call this after tracing the GCable contents.
  */
 PONY_API void pony_recv_done(pony_ctx_t* ctx);
-
-/** Finish gc tracing for acquiring.
- *
- * Call this after tracing objects you want to acquire.
- */
-PONY_API void pony_acquire_done(pony_ctx_t* ctx);
-
-/** Finish gc tracing for releasing.
- *
- * Call this after tracing objects you want to release.
- */
-PONY_API void pony_release_done(pony_ctx_t* ctx);
 
 /** Continue gc tracing with another message.
  *
@@ -397,24 +340,6 @@ PONY_API int pony_init(int argc, char** argv);
 PONY_API bool pony_start(int* exit_code,
   const pony_language_features_init_t* language_features);
 
-/**
- * Call this to create a pony_ctx_t for a non-scheduler thread. This has to be
- * done before calling pony_ctx(), and before calling any Pony code from the
- * thread.
- *
- * Threads that call pony_init() or pony_start() are automatically registered.
- * It's safe, but not necessary, to call this more than once.
- */
-PONY_API void pony_register_thread();
-
-/** Unregisters a non-scheduler thread.
- *
- * Clean up the runtime context allocated when registering a thread with
- * pony_register_thread(). This should never be called from a thread owned by
- * the Pony runtime.
- */
-PONY_API void pony_unregister_thread();
-
 PONY_API int32_t pony_scheduler_index();
 
 /** Set the exit code.
@@ -429,15 +354,6 @@ PONY_API void pony_exitcode(int code);
  * Get the value of the last pony_exitcode() call.
  */
 PONY_API int pony_get_exitcode();
-
-/**
- * Call this to handle an application message on an actor. This will do two
- * things: first, it will possibly gc, and second it will possibly handle a
- * pending application message.
- *
- * A thread must ponyint_become an actor before it can pony_poll.
- */
-PONY_API void pony_poll(pony_ctx_t* ctx);
 
 #if defined(__cplusplus)
 }

--- a/src/libponyrt/sched/scheduler.c
+++ b/src/libponyrt/sched/scheduler.c
@@ -1093,7 +1093,7 @@ static pony_actor_t* steal(scheduler_t* sched)
           {
             // Run the cycle detector and get the next actor
             DTRACE2(ACTOR_SCHEDULED, (uintptr_t)sched, (uintptr_t)actor);
-            bool reschedule = ponyint_actor_run(&sched->ctx, actor, false);
+            bool reschedule = ponyint_actor_run(&sched->ctx, actor);
             sched->ctx.current = NULL;
             pony_actor_t* next = pop_global(sched);
 
@@ -1294,7 +1294,7 @@ static void run(scheduler_t* sched)
     pony_assert(!ponyint_actor_is_pinned(actor));
 
     // Run the current actor and get the next actor.
-    bool reschedule = ponyint_actor_run(&sched->ctx, actor, false);
+    bool reschedule = ponyint_actor_run(&sched->ctx, actor);
     sched->ctx.current = NULL;
     SYSTEMATIC_TESTING_YIELD();
     pony_actor_t* next = pop_global(sched);
@@ -1563,7 +1563,7 @@ static void run_pinned_actors()
       pony_assert(ponyint_actor_is_pinned(actor));
 
       // Run the current actor and get the next actor.
-      bool reschedule = ponyint_actor_run(&sched->ctx, actor, false);
+      bool reschedule = ponyint_actor_run(&sched->ctx, actor);
       sched->ctx.current = NULL;
       SYSTEMATIC_TESTING_YIELD();
 
@@ -1694,7 +1694,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
   )
 #endif
 {
-  pony_register_thread();
+  ponyint_register_thread();
 
 #ifdef USE_RUNTIMESTATS
   if(stats_interval != UINT32_MAX)
@@ -1848,7 +1848,7 @@ pony_ctx_t* ponyint_sched_init(uint32_t threads, bool noyield, bool pin,
 
 bool ponyint_sched_start()
 {
-  pony_register_thread();
+  ponyint_register_thread();
 
   if(!ponyint_asio_start())
     return false;
@@ -1953,7 +1953,7 @@ PONY_API bool pony_scheduler_yield()
   return use_yield;
 }
 
-PONY_API void pony_register_thread()
+void ponyint_register_thread()
 {
   if(this_scheduler != NULL)
     return;
@@ -1966,7 +1966,7 @@ PONY_API void pony_register_thread()
   this_scheduler->ctx.scheduler = this_scheduler;
 }
 
-PONY_API void pony_unregister_thread()
+void ponyint_unregister_thread()
 {
   if(this_scheduler == NULL)
     return;
@@ -1993,7 +1993,7 @@ bool ponyint_get_pinned_actor_scheduler_suspended()
 
 void ponyint_register_asio_thread()
 {
-  pony_register_thread();
+  ponyint_register_thread();
   this_scheduler->index = PONY_ASIO_SCHEDULER_INDEX;
   TRACING_THREAD_START(this_scheduler);
 }

--- a/src/libponyrt/sched/scheduler.h
+++ b/src/libponyrt/sched/scheduler.h
@@ -81,7 +81,7 @@ typedef struct pony_ctx_t
   trace_actor_fn trace_actor;
   // Temporary stack for GC tracing; empty when GC not running
   gcstack_t* stack;
-  // Temporary storage for acquire/release of actors/objects for GC;
+  // Temporary storage for acquiring actors/objects for GC;
   // empty when GC not running
   actormap_t acquire;
   // Destination of the message currently being traced for send. Set from the
@@ -158,6 +158,20 @@ PONY_API uint32_t pony_active_schedulers();
 PONY_API int32_t pony_scheduler_index();
 
 PONY_API schedulerstats_t* pony_scheduler_stats();
+
+/** Create a pony_ctx_t for a thread that the runtime uses but that is not a
+ * normal scheduler thread, such as the ASIO thread or the thread that
+ * bootstraps the runtime. Do this before the thread calls pony_ctx() or runs
+ * any Pony code. It is safe, but unnecessary, to call it more than once on the
+ * same thread.
+ */
+void ponyint_register_thread();
+
+/** Release the pony_ctx_t that ponyint_register_thread() created for a thread, as
+ * that thread shuts down. Only call this on a thread that was registered with
+ * ponyint_register_thread(); never on a scheduler thread.
+ */
+void ponyint_unregister_thread();
 
 void ponyint_register_asio_thread();
 

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -312,7 +312,7 @@ PONY_API int pony_init(int argc, char** argv)
   opt.pintracing = false;
 #endif
 
-  pony_register_thread();
+  ponyint_register_thread();
 
   // Allow override via bare function on Main actor
   Main_runtime_override_defaults_oo(&opt);


### PR DESCRIPTION
Removes the runtime C API functions left over from library mode, which was removed in earlier releases. Six functions that nothing calls are deleted, along with the internal GC acquire/release-tracing code only they reached. Five functions that only the runtime itself calls are renamed to the `ponyint_` internal prefix and moved to internal headers.

Removing `pony_poll` makes `ponyint_actor_run`'s `polling` parameter always false, so it goes too. Removing the manual release protocol leaves the systematic-testing acquire drain sending only `ACTORMSG_ACQUIRE`, so its message-id parameter goes with it.

Normal Pony programs are unaffected — the compiler never generated calls to any of these. Only C code that linked the runtime directly and called them is affected, and that code relied on library mode, which is no longer supported.

Closes #5728