### PR TITLE
Drop the library-mode framing from pony_init's docstring

### DIFF
--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -311,9 +311,7 @@ PONY_API void pony_traceunknown(pony_ctx_t* ctx, void* p, int m);
 /** Initialize the runtime.
  *
  * Call this first. It will strip out command line arguments that you should
- * ignore and will return the remaining argc. Then create an actor and send it
- * a message, so that some initial work exists. Use ponyint_become() if you need
- * to send messages that require allocation and tracing.
+ * ignore and will return the remaining argc.
  *
  * Then call pony_start().
  *


### PR DESCRIPTION
The `pony_init` docstring told a C host to create an actor, send it a message, and use `ponyint_become()` between `pony_init` and `pony_start`. That is the bootstrap the compiler generates for a normal program, `ponyint_become` is not public, and driving the runtime by hand is library mode, which is no longer supported. What remains is `pony_init`'s own contract.

Follow-up to #5729, which removed the same framing from the other runtime docstrings.