### PR TITLE
Describe the Windows socket code, not the IOCP model it replaced

### DIFF
--- a/packages/net/tcp_listener.pony
+++ b/packages/net/tcp_listener.pony
@@ -190,9 +190,7 @@ actor TCPListener is AsioEventNotify
       match fd
       | -1 =>
         // Something other than EWOULDBLOCK (a failed accept). Bail out; the
-        // ASIO event will re-notify when the socket is readable again. On
-        // Windows this path is now reachable too, closing the old
-        // one-accept-at-a-time liveness gap.
+        // ASIO event will re-notify when the socket is readable again.
         return
       | 0 =>
         // EWOULDBLOCK, don't try again.

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -371,8 +371,7 @@ actor UDPSocket is AsioEventNotify
       // `count` (bytes sent on Ok) is discarded: UDP is unreliable, so we
       // don't track partial-send progress. The local is required by the FFI
       // shape. `_SocketResultRetry` (EWOULDBLOCK/EAGAIN) silently drops the
-      // datagram on every platform. A send Error now surfaces and closes the
-      // socket -- on Windows too, where it was previously discarded.
+      // datagram on every platform. A send Error closes the socket.
       var count: USize = 0
       match \exhaustive\ _SocketResultDecoder(
         @pony_os_sendto(_fd, data.cpointer(), data.size(), to,

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -166,7 +166,7 @@ PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
 {
   // Every backend, including the Windows readiness backend, sends events only
   // from the asio thread (already registered via ponyint_register_asio_thread),
-  // so there is no foreign thread to register and no liveness token to hold.
+  // so there is no foreign thread to register.
   asio_msg_t* m = (asio_msg_t*)pony_alloc_msg(POOL_INDEX(sizeof(asio_msg_t)),
     ev->msg_id);
   m->event = ev;

--- a/src/libponyrt/asio/sock_notify.c
+++ b/src/libponyrt/asio/sock_notify.c
@@ -23,9 +23,9 @@
 // a completion port, blocks on it, and turns "socket became ready" packets into
 // ASIO_READ/ASIO_WRITE events with one-shot + readable/writeable gating. recv/
 // send are then synchronous non-blocking calls with our own buffers (no kernel-
-// retained buffers), so there is no foreign-thread completion delivery and no
-// liveness token. The completion port here is only the notification queue
-// (epoll-fd's role), not an overlapped-completion port.
+// retained buffers), so there is no foreign-thread completion delivery. The
+// completion port here is only the notification queue (epoll-fd's role), not
+// an overlapped-completion port.
 //
 // PSN is gated in <winsock2.h> on NTDDI_VERSION >= NTDDI_WIN10_MN. We rely on
 // the SDK's default version (which exceeds the floor; forcing the macro lower
@@ -98,10 +98,9 @@ static void signal_handler(int sig)
 
   // POSIX (epoll.c) routes signals through the asio thread: the handler only
   // wakes that thread, which then sends the event. We mirror that so the asio
-  // thread is the ONLY thread that ever sends events -- the property that makes
-  // the old foreign-thread liveness token unnecessary. PostQueuedCompletionStatus
-  // is thread-safe and touches no event state; the signal number rides in the
-  // bytes-transferred field.
+  // thread is the ONLY thread that ever sends events.
+  // PostQueuedCompletionStatus is thread-safe and touches no event state; the
+  // signal number rides in the bytes-transferred field.
   asio_backend_t* b = ponyint_asio_get_backend();
 
   if(b != NULL)
@@ -634,7 +633,7 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
     }
   } else if(ev->fd == 0) {
     // Unsubscribe from stdin. These paths are driven from the asio thread and
-    // never had foreign-thread races, so dispose synchronously (as before).
+    // have no foreign-thread races, so dispose synchronously.
     send_request(NULL, ASIO_STDIN_NOTIFY);
 
     ev->flags = ASIO_DISPOSABLE;

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -482,8 +482,7 @@ PONY_API int pony_os_accept(asio_event_t* ev)
 {
 #if defined(PLATFORM_IS_WINDOWS)
   // Plain accept on read-readiness, like POSIX. Return the new fd, 0 for
-  // "would block" (don't retry), or -1 for a real failure (the listener
-  // surfaces this -- the latent liveness gap the old one-AcceptEx model had).
+  // "would block" (don't retry), or -1 for a real failure.
   SOCKET skt = accept((SOCKET)ev->fd, NULL, NULL);
   int ns;
 
@@ -876,8 +875,8 @@ PONY_API pony_socket_result_t pony_os_sendto(int fd, const char* buf,
   size_t len, ipaddress_t* ipaddr, size_t* count_out)
 {
 #ifdef PLATFORM_IS_WINDOWS
-  // Synchronous sendto, like POSIX. Send errors now surface (and close the
-  // socket via the ERROR arm) instead of being discarded fire-and-forget.
+  // Synchronous sendto, like POSIX. A send error closes the socket via the
+  // PONY_SOCKET_ERROR return.
   socklen_t addrlen = ponyint_address_length(ipaddr);
 
   if(addrlen == (socklen_t)-1)
@@ -1082,7 +1081,7 @@ bool ponyint_os_sockets_init()
   WSADATA data;
 
   // Load the winsock library. The readiness backend uses plain connect/accept,
-  // so the ConnectEx/AcceptEx extension function pointers are no longer needed.
+  // so WSAStartup is all the winsock setup there is.
   int r = WSAStartup(ver, &data);
 
   if(r != 0)


### PR DESCRIPTION
Comments introduced by #5556, the Windows IOCP-to-readiness migration, describe the new socket code by contrast with the removed IOCP model, in phrases like "no longer needed" and "the old ... liveness token" that name mechanisms a reader today has nothing to match against. This rewrites them to state what the code does, keeping the durable facts and dropping the history.

#5727 named two comments in socket.c. The same defect, from the same PR, appears in seven more across the runtime socket code and the net package; all are rewritten here.

Closes #5727