### PR TITLE
Fix two incorrect comments

### DIFF
--- a/packages/net/_test.pony
+++ b/packages/net/_test.pony
@@ -2293,9 +2293,9 @@ class \nodoc\ iso _TestTCPMutePeerCloseUndetected is UnitTest
   """
   A muted connection must not learn that its peer has closed until it is
   unmuted. Peer close is detected by reading, and a muted connection does not
-  read, so `closed` must not fire while muted. This holds on every platform now;
-  the test pins it on Windows, which previously surfaced a peer close to a muted
-  connection via a queued read.
+  read, so `closed` must not fire while muted. This holds on every platform; the
+  test pins it on Windows, which previously surfaced a peer close to a muted
+  connection.
 
   The receiver accepts, mutes, then asks the sender to close its side (writing
   is unaffected by muting). The sender closes only in response, so the receiver

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -164,9 +164,11 @@ PONY_API uint64_t pony_asio_event_nsec(asio_event_t* ev)
 PONY_API void pony_asio_event_send(asio_event_t* ev, uint32_t flags,
   uint32_t arg)
 {
-  // Every backend, including the Windows readiness backend, sends events only
-  // from the asio thread (already registered via ponyint_register_asio_thread),
-  // so there is no foreign thread to register.
+  // Every caller is a thread the runtime has registered: the asio thread, and
+  // the scheduler thread running the owning actor, which reaches here through
+  // the backends' PONY_API entry points. ponyint_sendv_inject and
+  // pony_scheduler_index below both need a pony_ctx, and only a registered
+  // thread has one, so there is nothing to register.
   asio_msg_t* m = (asio_msg_t*)pony_alloc_msg(POOL_INDEX(sizeof(asio_msg_t)),
     ev->msg_id);
   m->event = ev;


### PR DESCRIPTION
Two comments state things that are not true.

`pony_asio_event_send` in `src/libponyrt/asio/event.c` was documented as being called only from the asio thread. It is also called from the scheduler thread running the owning actor: the backends' PONY_API entry points (`pony_asio_event_subscribe`, `_resubscribe`, `_setnsec`) run on that thread and send from their error arms. The requirement the function actually has is a registered thread, since `ponyint_sendv_inject` and `pony_scheduler_index` both need a `pony_ctx`; the asio thread and the scheduler threads both qualify.

The `_TestTCPMutePeerCloseUndetected` docstring in `packages/net/_test.pony` said Windows had previously surfaced a peer close to a muted connection "via a queued read". There is no queued read anywhere in the tree — the phrase named IOCP machinery that #5556 deleted.