### PR TITLE
Bump actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/stress-test-generative-normal-linux.yml
+++ b/.github/workflows/stress-test-generative-normal-linux.yml
@@ -64,7 +64,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-normal-bundles-linux-glibc
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-generative-normal-macos.yml
+++ b/.github/workflows/stress-test-generative-normal-macos.yml
@@ -56,7 +56,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-normal-bundles-macos-arm
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-generative-normal-windows.yml
+++ b/.github/workflows/stress-test-generative-normal-windows.yml
@@ -72,7 +72,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-normal-bundles-windows
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-generative-systematic-linux.yml
+++ b/.github/workflows/stress-test-generative-systematic-linux.yml
@@ -69,7 +69,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-systematic-bundles-linux-glibc
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-generative-systematic-macos.yml
+++ b/.github/workflows/stress-test-generative-systematic-macos.yml
@@ -69,7 +69,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-systematic-bundles-macos-arm
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-generative-systematic-windows.yml
+++ b/.github/workflows/stress-test-generative-systematic-windows.yml
@@ -89,7 +89,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: generative-systematic-bundles-windows
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-tcp-swarm-linux.yml
+++ b/.github/workflows/stress-test-tcp-swarm-linux.yml
@@ -64,7 +64,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-linux-glibc
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-tcp-swarm-macos.yml
+++ b/.github/workflows/stress-test-tcp-swarm-macos.yml
@@ -63,7 +63,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-macos-arm
           path: rt-stress-out/*.json

--- a/.github/workflows/stress-test-tcp-swarm-windows.yml
+++ b/.github/workflows/stress-test-tcp-swarm-windows.yml
@@ -71,7 +71,7 @@ jobs:
       # cancelled() too: keep bundles from seeds that ran before a cancel.
       - name: Upload failure bundles
         if: ${{ (failure() || cancelled()) && hashFiles('.libs-cache-miss') == '' }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-windows
           path: rt-stress-out/*.json


### PR DESCRIPTION
The nine stress-test workflows pinned `actions/upload-artifact@v4.6.2`, three majors behind current.

v6 moved the action to Node 24 and v7 to ESM. Both are fine here: every stress-test job runs on a GitHub-hosted runner (`ubuntu-latest`, `macos-26`, `windows-2025-vs2026`), and the Linux jobs container on Ubuntu 26.04, well past the glibc floor Node 24 needs. The three inputs these jobs pass — `name`, `path`, `if-no-files-found` — are unchanged in v7, and v7's new `archive` input defaults to the existing zip-on-upload behavior, so no call site changes.