### PR TITLE
Require the build configuration to be debug or release

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build
         run: cmake --build --preset windows-x86-64-release
       - name: Install
-        run: cmake --install build/build --config Release --prefix build\install\release
+        run: cmake --install build/build --config release --prefix build\install\release
       - name: Package
         run: Compress-Archive -Path "build\install\release\lib\pony\nightly\bin", "build\install\release\lib\pony\nightly\lib", "build\install\release\lib\pony\nightly\packages" -DestinationPath "build\ponyc-x86-64-pc-windows-msvc.zip" -Force
       - name: Upload
@@ -287,7 +287,7 @@ jobs:
       - name: Build
         run: cmake --build --preset windows-arm64-release
       - name: Install
-        run: cmake --install build/build --config Release --prefix build\install\release
+        run: cmake --install build/build --config release --prefix build\install\release
       - name: Package
         run: Compress-Archive -Path "build\install\release\lib\pony\nightly\bin", "build\install\release\lib\pony\nightly\lib", "build\install\release\lib\pony\nightly\packages" -DestinationPath "build\ponyc-arm64-pc-windows-msvc.zip" -Force
       - name: Upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Build
         run: cmake --build --preset windows-x86-64-release
       - name: Install
-        run: cmake --install build/build --config Release --prefix build\install\release
+        run: cmake --install build/build --config release --prefix build\install\release
       - name: Package
         run: |
           $version = (Get-Content .\VERSION)
@@ -290,7 +290,7 @@ jobs:
       - name: Build
         run: cmake --build --preset windows-arm64-release
       - name: Install
-        run: cmake --install build/build --config Release --prefix build\install\release
+        run: cmake --install build/build --config release --prefix build\install\release
       - name: Package
         run: |
           $version = (Get-Content .\VERSION)

--- a/BUILD.md
+++ b/BUILD.md
@@ -29,6 +29,8 @@ The build is divided into several stages:
 - Removing a configuration's build directory (`rm -rf build/build_release build/release`) cleans your ponyc build without touching the libraries.
 - `rm -rf build` will delete the entire `build` directory, including the libraries.
 
+ponyc builds in two configurations, `release` and `debug`. The presets set this for you. If you configure without a preset, set it yourself: `cmake -B mybuild -S . -DCMAKE_BUILD_TYPE=release` (or `debug`). The name is lowercase because it is also the name of the output directory (`build/release`, `build/debug`); any other value, including CMake's usual `Release`, `RelWithDebInfo`, and `MinSizeRel`, is rejected at configure time.
+
 The presets default to using Clang on Unix. To build ponyc with GCC, override the compiler at the configure step:
 
 ```bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,38 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # See cmake/PonyUses.cmake.
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PonyUses.cmake)
 
+# ponyc builds in exactly two configurations, "debug" and "release", and the
+# configuration name is also the name of the output directory (build/<config>).
+# Two things depend on getting that name right, so reject anything else here,
+# where the message is clear, rather than let it fail later:
+#  - The name is used as a path segment in lowercase throughout the tree
+#    (build/debug, build/release), so a capitalized "Release" would build into
+#    build/Release, which none of those lowercase paths point at.
+#  - The per-config compile flags and the PONY_BUILD_CONFIG / DEBUG / NDEBUG /
+#    PONY_VERSION_STR definitions are gated on $<CONFIG:Debug>/$<CONFIG:Release>.
+#    A name CMake doesn't recognize matches neither, so those definitions are
+#    dropped and the runtime fails to compile ("PONY_BUILD_CONFIG undeclared")
+#    partway through, far from the cause.
+# Placed after the PonyUses include so the BSD reject probes (which configure
+# without a build type) hit that validation first, not this one.
+get_property(_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_multi_config)
+    # On a multi-config generator the configuration is chosen at build time and
+    # CMAKE_BUILD_TYPE is empty, so constrain the set on offer instead.
+    set(CMAKE_CONFIGURATION_TYPES "debug;release" CACHE STRING
+        "ponyc build configurations" FORCE)
+elseif(NOT CMAKE_BUILD_TYPE)
+    message(FATAL_ERROR
+        "CMAKE_BUILD_TYPE is not set. ponyc builds as \"debug\" or \"release\". "
+        "Use a preset (cmake --preset release) or set it directly "
+        "(-DCMAKE_BUILD_TYPE=release).")
+elseif(NOT CMAKE_BUILD_TYPE STREQUAL "debug" AND NOT CMAKE_BUILD_TYPE STREQUAL "release")
+    message(FATAL_ERROR
+        "CMAKE_BUILD_TYPE must be \"debug\" or \"release\", not \"${CMAKE_BUILD_TYPE}\". "
+        "Use a preset (cmake --preset release) or set it directly "
+        "(-DCMAKE_BUILD_TYPE=release).")
+endif()
+
 # We require LLVM, Google Test and Google Benchmark
 if(NOT PONY_CROSS_LIBPONYRT)
     find_package(LLVM REQUIRED CONFIG PATHS "build/libs/lib/cmake/llvm" "build/libs/lib64/cmake/llvm" NO_DEFAULT_PATH)
@@ -140,30 +172,22 @@ if(PONY_USE_RUNTIME_TRACING)
     add_compile_options(-DUSE_RUNTIME_TRACING)
 endif()
 
-# LibPonyC tests assume that our outputs are two directories above the root directory.
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/../${CMAKE_BUILD_TYPE}${PONY_OUTPUT_SUFFIX}")
-
-# Per-config output directory for ponyc-compiled binaries and the ctest wrappers.
-# On the Windows Visual Studio multi-config generator CMAKE_RUNTIME_OUTPUT_DIRECTORY
-# above is config-less (CMAKE_BUILD_TYPE is empty there), so the per-config dir must
-# be derived from $<CONFIG> as a generator expression. On a single-config generator
-# (the non-Windows presets) CMAKE_RUNTIME_OUTPUT_DIRECTORY already carries the
-# config, so use it verbatim -- this keeps the non-Windows build byte-for-byte
-# unchanged (no genex on that path). $<LOWER_CASE:$<CONFIG>> matches the lowercase
-# debug/release dirs the _DEBUG/_RELEASE vars above use; ${PONY_OUTPUT_SUFFIX} keeps
-# use= builds aligned. Everything that locates a ponyc-compiled binary, sets a ctest
-# working dir, or tells ponyc where to write must use PONY_OUTPUT_DIR rather than
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY: on the single-config generators the two are equal,
-# so a site that reverts to the latter passes every Unix job and breaks only Windows.
-if(CMAKE_CONFIGURATION_TYPES)
-    set(PONY_OUTPUT_DIR "${CMAKE_BINARY_DIR}/../$<LOWER_CASE:$<CONFIG>>${PONY_OUTPUT_SUFFIX}")
-else()
-    set(PONY_OUTPUT_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
-endif()
+# The build's output directory, a sibling of the CMake binary directory. CMake
+# places the executables via CMAKE_RUNTIME_OUTPUT_DIRECTORY, set here from
+# PONY_OUTPUT_DIR; the static libraries and other artifacts are copied into the
+# same directory by POST_BUILD commands, and install() reads it. One definition
+# keeps all of those pointing at the same place.
+#
+# The depth matters: a ponyc run out of the build tree finds the standard library
+# by adding ../../packages to its own executable's path (see
+# add_pony_installation_dir in src/libponyc/pkg/package.c), so build/<config>/ponyc
+# sits two directories below the source root.
+#
+# Both names hold a $<CONFIG> generator expression, usable only where CMake
+# evaluates one (add_custom_command, add_test, target properties, install()); a
+# configure-time file() or if(EXISTS) on either gets the literal "$<CONFIG>".
+set(PONY_OUTPUT_DIR "${CMAKE_BINARY_DIR}/../$<CONFIG>${PONY_OUTPUT_SUFFIX}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PONY_OUTPUT_DIR}")
 
 # Libs are now always built in release mode.
 set(PONY_LLVM_BUILD_MODE "1")
@@ -546,18 +570,12 @@ add_compile_definitions(
     PONY_DEFAULT_PIC=true
     $<$<CONFIG:Debug>:PONY_BUILD_CONFIG="debug">
     $<$<CONFIG:Release>:PONY_BUILD_CONFIG="release">
-    $<$<CONFIG:RelWithDebInfo>:PONY_BUILD_CONFIG="release">
-    $<$<CONFIG:MinSizeRel>:PONY_BUILD_CONFIG="release">
     PONY_USE_BIGINT
     PONY_VERSION="${PONYC_VERSION}"
     $<$<CONFIG:Debug>:DEBUG>
     $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:RelWithDebInfo>:NDEBUG>
-    $<$<CONFIG:MinSizeRel>:NDEBUG>
     $<$<CONFIG:Debug>:PONY_VERSION_STR="${PONYC_VERSION} [debug]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     $<$<CONFIG:Release>:PONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:RelWithDebInfo>:PONY_VERSION_STR="${PONYC_VERSION} [relwithdebinfo]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:MinSizeRel>:PONY_VERSION_STR="${PONYC_VERSION} [minsizerel]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM}
 )
 
@@ -728,6 +746,11 @@ else()
     enable_testing()
 
     add_test(NAME check-version COMMAND $<TARGET_FILE:ponyc> --version)
+    add_test(NAME output-layout
+        COMMAND ${CMAKE_COMMAND}
+            -DDIR=$<TARGET_FILE_DIR:ponyc>
+            -DSUFFIX=${CMAKE_EXECUTABLE_SUFFIX}
+            -P ${CMAKE_SOURCE_DIR}/cmake/CheckOutputLayout.cmake)
     add_test(NAME libponyrt.tests
         COMMAND ${CMAKE_COMMAND} -DBIN=$<TARGET_FILE:libponyrt.tests>
             -DARGS=--gtest_shuffle -DGTEST=ON
@@ -738,7 +761,7 @@ else()
             -DARGS=--gtest_shuffle -DGTEST=ON
             -DWORKDIR=${PONY_OUTPUT_DIR}
             -P ${CMAKE_SOURCE_DIR}/cmake/RunTest.cmake)
-    set_tests_properties(check-version libponyrt.tests libponyc.tests
+    set_tests_properties(check-version output-layout libponyrt.tests libponyc.tests
         PROPERTIES LABELS ci-core)
 
     add_test(NAME pony-doc-tests
@@ -781,9 +804,9 @@ else()
 
     set(_full_program_runner
         ${CMAKE_BINARY_DIR}/test/full-program-runner/full-program-runner${CMAKE_EXECUTABLE_SUFFIX})
-    # The per-config full-program-tests output dirs can't be created here on the
-    # multi-config generator (the path is config-dependent); RunFullPrograms.cmake
-    # creates its --output dir at test time instead.
+    # The full-program-tests output dirs can't be created here: PONY_OUTPUT_DIR is
+    # a $<CONFIG> genex, so the path isn't known at configure time.
+    # RunFullPrograms.cmake creates its --output dir at test time instead.
 
     add_test(NAME full-programs-debug
         COMMAND ${CMAKE_COMMAND}
@@ -842,9 +865,9 @@ else()
     # PROGRAMS. Test and benchmark binaries are not installed.
     install(TARGETS ponyc DESTINATION ${PONY_VERSIONED_DIR}/bin)
     install(PROGRAMS
-        $<TARGET_FILE_DIR:ponyc>/pony-lsp${CMAKE_EXECUTABLE_SUFFIX}
-        $<TARGET_FILE_DIR:ponyc>/pony-lint${CMAKE_EXECUTABLE_SUFFIX}
-        $<TARGET_FILE_DIR:ponyc>/pony-doc${CMAKE_EXECUTABLE_SUFFIX}
+        ${PONY_OUTPUT_DIR}/pony-lsp${CMAKE_EXECUTABLE_SUFFIX}
+        ${PONY_OUTPUT_DIR}/pony-lint${CMAKE_EXECUTABLE_SUFFIX}
+        ${PONY_OUTPUT_DIR}/pony-doc${CMAKE_EXECUTABLE_SUFFIX}
         DESTINATION ${PONY_VERSIONED_DIR}/bin)
 
     # Runtime + compiler static libs, into the lib dir ponyc searches at run time
@@ -856,13 +879,13 @@ else()
     # doesn't produce one doesn't fail the install.
     install(TARGETS libponyrt libponyc DESTINATION ${PONY_INSTALL_LIBDIR})
     install(FILES
-        $<TARGET_FILE_DIR:ponyc>/libponyc-standalone.a
-        $<TARGET_FILE_DIR:ponyc>/libponyrt-pic.a
-        $<TARGET_FILE_DIR:ponyc>/libdtrace_probes.a
-        $<TARGET_FILE_DIR:ponyc>/crtbeginS.o
-        $<TARGET_FILE_DIR:ponyc>/crtendS.o
-        $<TARGET_FILE_DIR:ponyc>/crtbeginT.o
-        $<TARGET_FILE_DIR:ponyc>/crtend.o
+        ${PONY_OUTPUT_DIR}/libponyc-standalone.a
+        ${PONY_OUTPUT_DIR}/libponyrt-pic.a
+        ${PONY_OUTPUT_DIR}/libdtrace_probes.a
+        ${PONY_OUTPUT_DIR}/crtbeginS.o
+        ${PONY_OUTPUT_DIR}/crtendS.o
+        ${PONY_OUTPUT_DIR}/crtbeginT.o
+        ${PONY_OUTPUT_DIR}/crtend.o
         DESTINATION ${PONY_INSTALL_LIBDIR} OPTIONAL)
 
     # The stdlib packages.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -152,10 +152,10 @@
     { "name": "armv8-a-release", "configurePreset": "armv8-a-release" },
     { "name": "debug-asan", "configurePreset": "debug-asan" },
     { "name": "release-asan", "configurePreset": "release-asan" },
-    { "name": "windows-x86-64-debug", "configurePreset": "windows-x86-64", "configuration": "Debug" },
-    { "name": "windows-x86-64-release", "configurePreset": "windows-x86-64", "configuration": "Release" },
-    { "name": "windows-arm64-debug", "configurePreset": "windows-arm64", "configuration": "Debug" },
-    { "name": "windows-arm64-release", "configurePreset": "windows-arm64", "configuration": "Release" }
+    { "name": "windows-x86-64-debug", "configurePreset": "windows-x86-64", "configuration": "debug" },
+    { "name": "windows-x86-64-release", "configurePreset": "windows-x86-64", "configuration": "release" },
+    { "name": "windows-arm64-debug", "configurePreset": "windows-arm64", "configuration": "debug" },
+    { "name": "windows-arm64-release", "configurePreset": "windows-arm64", "configuration": "release" }
   ],
   "testPresets": [
     { "name": "debug", "configurePreset": "debug", "output": { "outputOnFailure": true } },
@@ -166,9 +166,9 @@
     { "name": "armv8-release", "configurePreset": "armv8-release", "output": { "outputOnFailure": true } },
     { "name": "armv8-a-debug", "configurePreset": "armv8-a-debug", "output": { "outputOnFailure": true } },
     { "name": "armv8-a-release", "configurePreset": "armv8-a-release", "output": { "outputOnFailure": true } },
-    { "name": "windows-x86-64-debug", "configurePreset": "windows-x86-64", "configuration": "Debug", "output": { "outputOnFailure": true } },
-    { "name": "windows-x86-64-release", "configurePreset": "windows-x86-64", "configuration": "Release", "output": { "outputOnFailure": true } },
-    { "name": "windows-arm64-debug", "configurePreset": "windows-arm64", "configuration": "Debug", "output": { "outputOnFailure": true } },
-    { "name": "windows-arm64-release", "configurePreset": "windows-arm64", "configuration": "Release", "output": { "outputOnFailure": true } }
+    { "name": "windows-x86-64-debug", "configurePreset": "windows-x86-64", "configuration": "debug", "output": { "outputOnFailure": true } },
+    { "name": "windows-x86-64-release", "configurePreset": "windows-x86-64", "configuration": "release", "output": { "outputOnFailure": true } },
+    { "name": "windows-arm64-debug", "configurePreset": "windows-arm64", "configuration": "debug", "output": { "outputOnFailure": true } },
+    { "name": "windows-arm64-release", "configurePreset": "windows-arm64", "configuration": "release", "output": { "outputOnFailure": true } }
   ]
 }

--- a/cmake/CheckOutputLayout.cmake
+++ b/cmake/CheckOutputLayout.cmake
@@ -1,0 +1,11 @@
+# Assert the ponyc-compiled tools sit in the same directory as the ponyc binary.
+# install() reads them from ponyc's directory (the install(PROGRAMS ...) rules in
+# the top-level CMakeLists), so a build that writes them anywhere else installs a
+# tree with no tools. DIR is ponyc's directory; SUFFIX is the platform executable
+# suffix.
+foreach(_tool pony-lsp pony-lint pony-doc)
+    if(NOT EXISTS "${DIR}/${_tool}${SUFFIX}")
+        message(FATAL_ERROR
+            "${_tool}${SUFFIX} is not in ${DIR}, where ponyc is and install() reads it")
+    endif()
+endforeach()

--- a/cmake/PonyBinary.cmake
+++ b/cmake/PonyBinary.cmake
@@ -5,23 +5,17 @@
 #   [PATHS <dir> ...]        # extra --path arguments for use resolution
 #   [WATCH <dir> ...])       # directories whose *.pony files are build inputs
 #
-# Compiles a Pony program with the just-built ponyc into the runtime output
-# directory, as a custom target that builds under ALL. This is the one place the
-# ponyc-invocation pattern lives: the tool binaries (pony-lint/doc/lsp) and the
-# test binaries (pony-*-tests) all go through it, so they share one dependency-
-# tracking path.
+# Compiles a Pony program with the just-built ponyc into the output directory, as
+# a custom target (built under ALL only when the ALL option is passed). Used by
+# the pony-*-tests binaries.
 #
 # Rebuilds when any watched .pony source changes, when the shared tool libraries
 # change (TOOLS_LIB_STAMP), or when ponyc itself is rebuilt.
 function(add_pony_binary _target)
     cmake_parse_arguments(_pb "ALL" "NAME;SOURCE" "PATHS;WATCH" ${ARGN})
 
-    # Per-config output directory. PONY_OUTPUT_DIR (defined in the top-level
-    # CMakeLists) is a $<CONFIG> generator expression on the Windows multi-config
-    # generator (where the plain CMAKE_RUNTIME_OUTPUT_DIRECTORY is config-less) and
-    # the plain CMAKE_RUNTIME_OUTPUT_DIRECTORY on a single-config generator.
-    # $<TARGET_FILE_DIR:ponyc> can't be used here because a target genex is invalid
-    # in add_custom_command(OUTPUT).
+    # $<TARGET_FILE_DIR:ponyc> can't be used here because a target genex is
+    # invalid in add_custom_command(OUTPUT).
     set(_out "${PONY_OUTPUT_DIR}")
     set(_exe "${_out}/${_pb_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
 

--- a/src/crt/CMakeLists.txt
+++ b/src/crt/CMakeLists.txt
@@ -51,10 +51,7 @@ set(CRT_FILES
 
 foreach(CRT_FILE ${CRT_FILES})
     add_custom_command(TARGET crt_objects POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${CRT_FILE} ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy ${CRT_FILE} ${PONY_OUTPUT_DIR}/
     )
 endforeach()
 

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -129,10 +129,7 @@ endif (MSVC)
 
 if (NOT MSVC)
     add_custom_command(TARGET libponyc POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_BINARY_DIR}/libponyc.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_BINARY_DIR}/libponyc.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_BINARY_DIR}/libponyc.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_BINARY_DIR}/libponyc.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy ${libponyc_BINARY_DIR}/libponyc.a ${PONY_OUTPUT_DIR}/
     )
 endif (NOT MSVC)
 
@@ -150,10 +147,7 @@ if (MSVC)
         COMMAND ${CMAKE_AR} /NOLOGO /VERBOSE /OUT:${libponyc_standalone_path} "$<TARGET_FILE:libponyc>" ${LLVM_OBJS} ${LLD_OBJS} ${CLANG_OBJS}
         DEPENDS libponyc)
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG}/${libponyc_standalone_file}
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE}/${libponyc_standalone_file}
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO}/${libponyc_standalone_file}
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyc_standalone_path} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL}/${libponyc_standalone_file}
+        COMMAND ${CMAKE_COMMAND} -E copy ${libponyc_standalone_path} ${PONY_OUTPUT_DIR}/${libponyc_standalone_file}
     )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     # on macos we dont have no static libc++
@@ -168,10 +162,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     )
     # copy the generated file after it is built
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy libponyc-standalone.a ${PONY_OUTPUT_DIR}/
     )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
     # add a rule to generate the standalone library if needed
@@ -195,10 +186,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "FreeBSD")
     )
     # copy the generated file after it is built
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy libponyc-standalone.a ${PONY_OUTPUT_DIR}/
     )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
     # add a rule to generate the standalone library if needed
@@ -222,10 +210,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "OpenBSD")
     )
     # copy the generated file after it is built
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy libponyc-standalone.a ${PONY_OUTPUT_DIR}/
     )
 elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
     # add a rule to generate the standalone library if needed
@@ -249,10 +234,7 @@ elseif(${CMAKE_HOST_SYSTEM_NAME} MATCHES "DragonFly")
     )
     # copy the generated file after it is built
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy libponyc-standalone.a ${PONY_OUTPUT_DIR}/
     )
 else()
     execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libstdc++.a
@@ -294,9 +276,6 @@ else()
     )
     # copy the generated file after it is built
     add_custom_command(TARGET libponyc-standalone POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy libponyc-standalone.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy libponyc-standalone.a ${PONY_OUTPUT_DIR}/
     )
 endif (MSVC)

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -171,10 +171,7 @@ if (MSVC)
 
     # copy libponyrt to the ponyc directory for use when linking pony programs
     add_custom_command(TARGET libponyrt POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/debug/libponyrt.lib ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/libponyrt.lib
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/release/libponyrt.lib ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/libponyrt.lib
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/relwithdebinfo/libponyrt.lib ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/libponyrt.lib
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/minsizerel/libponyrt.lib ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/libponyrt.lib
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:libponyrt> ${PONY_OUTPUT_DIR}/libponyrt.lib
     )
 else()
     target_include_directories(libponyrt
@@ -191,10 +188,7 @@ else()
 
     # copy libponyrt to the ponyc directory for use when linking pony programs
     add_custom_command(TARGET libponyrt POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/${LIBPONYRT_ARCHIVE}
+        COMMAND ${CMAKE_COMMAND} -E copy ${libponyrt_BINARY_DIR}/libponyrt.a ${PONY_OUTPUT_DIR}/${LIBPONYRT_ARCHIVE}
     )
 
     # On FreeBSD the DOF object lives in its own archive built by the POST_BUILD
@@ -203,10 +197,7 @@ else()
     # (both are POST_BUILD on libponyrt, run in order), so the archive exists.
     if(PONY_USE_DTRACE AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
         add_custom_command(TARGET libponyrt POST_BUILD
-            COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
-            COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
-            COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
-            COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/libdtrace_probes.a
+            COMMAND ${CMAKE_COMMAND} -E copy ${libponyrt_BINARY_DIR}/libdtrace_probes.a ${PONY_OUTPUT_DIR}/libdtrace_probes.a
         )
     endif()
 endif (MSVC)
@@ -242,9 +233,6 @@ if(PONY_RUNTIME_BITCODE)
     )
 
     add_custom_command(TARGET libponyrt_bc POST_BUILD
-        COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/
-        COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/
+        COMMAND ${CMAKE_COMMAND} -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${PONY_OUTPUT_DIR}/
     )
 endif()

--- a/test/full-program-tests/CMakeLists.txt
+++ b/test/full-program-tests/CMakeLists.txt
@@ -28,14 +28,7 @@ foreach(test_c_source ${test_c_sources})
   endif()
 
   add_custom_command(TARGET ${test_lib_name} POST_BUILD
-    COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E make_directory ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E make_directory ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E make_directory ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E make_directory ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/test_lib
-
-    COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> ARGS -E copy $<TARGET_FILE:${test_lib_name}> ${CMAKE_BINARY_DIR}/../debug${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> ARGS -E copy $<TARGET_FILE:${test_lib_name}> ${CMAKE_BINARY_DIR}/../release${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:RelWithDebInfo>:${CMAKE_COMMAND}> ARGS -E copy $<TARGET_FILE:${test_lib_name}> ${CMAKE_BINARY_DIR}/../relwithdebinfo${PONY_OUTPUT_SUFFIX}/test_lib
-    COMMAND $<$<CONFIG:MinSizeRel>:${CMAKE_COMMAND}> ARGS -E copy $<TARGET_FILE:${test_lib_name}> ${CMAKE_BINARY_DIR}/../minsizerel${PONY_OUTPUT_SUFFIX}/test_lib
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PONY_OUTPUT_DIR}/test_lib
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${test_lib_name}> ${PONY_OUTPUT_DIR}/test_lib
   )
 endforeach()

--- a/tools/pony-doc/CMakeLists.txt
+++ b/tools/pony-doc/CMakeLists.txt
@@ -2,12 +2,6 @@ project(tools.pony-doc)
 
 set(PONY_DOC_EXECUTABLE "pony-doc${CMAKE_EXECUTABLE_SUFFIX}")
 
-# Build into the same per-config output directory ponyc and the C/C++ executables
-# use. PONY_OUTPUT_DIR (defined in the top-level CMakeLists) is a $<CONFIG>
-# generator expression on the Windows multi-config generator (where
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY is config-less) and the plain
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY on a single-config generator.
-
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)

--- a/tools/pony-lint/CMakeLists.txt
+++ b/tools/pony-lint/CMakeLists.txt
@@ -2,12 +2,6 @@ project(tools.pony-lint)
 
 set(PONY_LINT_EXECUTABLE "pony-lint${CMAKE_EXECUTABLE_SUFFIX}")
 
-# Build into the same per-config output directory ponyc and the C/C++ executables
-# use. PONY_OUTPUT_DIR (defined in the top-level CMakeLists) is a $<CONFIG>
-# generator expression on the Windows multi-config generator (where
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY is config-less) and the plain
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY on a single-config generator.
-
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)

--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -2,12 +2,6 @@ project(tools.pony-lsp VERSION ${PONYC_PROJECT_VERSION})
 
 set(PONY_LSP_EXECUTABLE "pony-lsp${CMAKE_EXECUTABLE_SUFFIX}")
 
-# Build into the same per-config output directory ponyc and the C/C++ executables
-# use. PONY_OUTPUT_DIR (defined in the top-level CMakeLists) is a $<CONFIG>
-# generator expression on the Windows multi-config generator (where
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY is config-less) and the plain
-# CMAKE_RUNTIME_OUTPUT_DIRECTORY on a single-config generator.
-
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)


### PR DESCRIPTION
ponyc's CMake build used `CMAKE_BUILD_TYPE` verbatim as the name of the output directory while the per-config variables beside it hardcoded lowercase. Configuring with `-DCMAKE_BUILD_TYPE=Release` therefore wrote the ponyc-compiled tools to `build/Release` while `install()` read them from `build/release`, so `cmake --install` failed on a case-sensitive filesystem.

The configuration name doubles as a directory name, and that directory is spelled in lowercase everywhere else. So require the name to be `debug` or `release`, and derive the output directory from it in one place. That also rejects a name CMake doesn't recognize -- a typo, or an empty `CMAKE_BUILD_TYPE` -- which used to drop the per-config compile definitions, so compiling the runtime failed partway through, far from the cause.

`-DCMAKE_BUILD_TYPE=Release`, `RelWithDebInfo`, and `MinSizeRel` now error at configure. Every documented build path uses a preset, which sets the configuration.

Supersedes #5750.
