### PR TITLE
Build the self-hosted tools through add_pony_binary

### DIFF
--- a/cmake/PonyBinary.cmake
+++ b/cmake/PonyBinary.cmake
@@ -7,7 +7,8 @@
 #
 # Compiles a Pony program with the just-built ponyc into the output directory, as
 # a custom target (built under ALL only when the ALL option is passed). Used by
-# the pony-*-tests binaries.
+# the self-hosted tool binaries (pony-lint/doc/lsp, which pass ALL) and the
+# pony-*-tests binaries.
 #
 # Rebuilds when any watched .pony source changes, when the shared tool libraries
 # change (TOOLS_LIB_STAMP), or when ponyc itself is rebuilt.

--- a/tools/pony-doc/CMakeLists.txt
+++ b/tools/pony-doc/CMakeLists.txt
@@ -1,22 +1,11 @@
 project(tools.pony-doc)
 
-set(PONY_DOC_EXECUTABLE "pony-doc${CMAKE_EXECUTABLE_SUFFIX}")
-
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
-add_custom_target(tools.pony-doc ALL DEPENDS ${PONY_OUTPUT_DIR}/${PONY_DOC_EXECUTABLE})
-add_dependencies(tools.pony-doc libponyc-standalone tools_lib_stamp)
-
-file(GLOB_RECURSE DOC_SOURCES CONFIGURE_DEPENDS "*.pony")
-add_custom_command(OUTPUT ${PONY_OUTPUT_DIR}/${PONY_DOC_EXECUTABLE}
-  COMMAND_EXPAND_LISTS
-  COMMAND echo "Building pony-doc..."
-  COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${PONY_OUTPUT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS
-    ${DOC_SOURCES}
-    ${TOOLS_LIB_STAMP}
-    $<TARGET_FILE:ponyc>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+add_pony_binary(tools.pony-doc ALL
+    NAME pony-doc
+    SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
+    PATHS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler
+    WATCH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/pony-lint/CMakeLists.txt
+++ b/tools/pony-lint/CMakeLists.txt
@@ -1,22 +1,11 @@
 project(tools.pony-lint)
 
-set(PONY_LINT_EXECUTABLE "pony-lint${CMAKE_EXECUTABLE_SUFFIX}")
-
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
-add_custom_target(tools.pony-lint ALL DEPENDS ${PONY_OUTPUT_DIR}/${PONY_LINT_EXECUTABLE})
-add_dependencies(tools.pony-lint libponyc-standalone tools_lib_stamp)
-
-file(GLOB_RECURSE LINT_SOURCES CONFIGURE_DEPENDS "*.pony")
-add_custom_command(OUTPUT ${PONY_OUTPUT_DIR}/${PONY_LINT_EXECUTABLE}
-  COMMAND_EXPAND_LISTS
-  COMMAND echo "Building pony-lint..."
-  COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${PONY_OUTPUT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS
-    ${LINT_SOURCES}
-    ${TOOLS_LIB_STAMP}
-    $<TARGET_FILE:ponyc>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+add_pony_binary(tools.pony-lint ALL
+    NAME pony-lint
+    SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
+    PATHS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler
+    WATCH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/pony-lsp/CMakeLists.txt
+++ b/tools/pony-lsp/CMakeLists.txt
@@ -1,23 +1,12 @@
-project(tools.pony-lsp VERSION ${PONYC_PROJECT_VERSION})
-
-set(PONY_LSP_EXECUTABLE "pony-lsp${CMAKE_EXECUTABLE_SUFFIX}")
+project(tools.pony-lsp)
 
 # Generate version.pony from template
 # (.gitignore prevents version.pony from dirtying the git tree)
 configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 
-add_custom_target(tools.pony-lsp ALL DEPENDS ${PONY_OUTPUT_DIR}/${PONY_LSP_EXECUTABLE})
-add_dependencies(tools.pony-lsp libponyc-standalone tools_lib_stamp)
-
-# TODO STA: --path entries are temporary until a ponyc bug is fixed.
-file(GLOB_RECURSE LSP_SOURCES CONFIGURE_DEPENDS "*.pony")
-add_custom_command(OUTPUT ${PONY_OUTPUT_DIR}/${PONY_LSP_EXECUTABLE}
-  COMMAND_EXPAND_LISTS
-  COMMAND echo "Building pony-lsp..."
-  COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} --path ${CMAKE_CURRENT_SOURCE_DIR} --path ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler/ ${PONYC_SELFHOSTED_TOOL_PATH_ARGS} -o ${PONY_OUTPUT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
-  DEPENDS
-    ${LSP_SOURCES}
-    ${TOOLS_LIB_STAMP}
-    $<TARGET_FILE:ponyc>
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+# TODO STA: the PATHS entries are temporary until a ponyc bug is fixed.
+add_pony_binary(tools.pony-lsp ALL
+    NAME pony-lsp
+    SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
+    PATHS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../lib/ponylang/pony_compiler
+    WATCH ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
pony-lint, pony-doc, and pony-lsp each hand-rolled the ponyc-invocation block that `add_pony_binary` already provides for the `pony-*-tests` binaries. Routing them through the helper leaves the pattern in one place and gives the helper's `ALL` option its first caller.

The helper passes `-b <NAME>` where the old blocks relied on ponyc naming the binary after the source directory's basename. The basenames already equal the tool names, and a debug build confirms all three come out identically named (`pony-lint`, `pony-doc`, `pony-lsp`) and run.

pony-lsp's `project()` also set a `VERSION` that nothing reads — the tools' `version.pony` comes from the top-level `PONYC_VERSION`, not `PROJECT_VERSION` — so this drops it, matching pony-lint and pony-doc.

Closes #5753