### PR TITLE
Narrow per-PR lint/test workflows to run only when their inputs change

### DIFF
--- a/.ci-scripts/AGENTS.md
+++ b/.ci-scripts/AGENTS.md
@@ -9,7 +9,7 @@ when you want to exercise them).
 - **Stdlib only.** CI runners have no `pip install` step, so scripts must not
   import third-party packages. Use `urllib`, `json`, `subprocess`, `tarfile`,
   etc. — never `requests`, `pyyaml`, `pytest`, …
-- **ruff lints everything here on every PR** (`.github/workflows/lint-python.yml`,
+- **ruff lints everything here** (`.github/workflows/lint-python.yml`,
   which now only lints — the tests live in `test-ci-scripts.yml` and
   `test-rt-stress.yml`). There is no ruff config file, so the defaults apply. A
   `lint` job runs `ruff check .ci-scripts`; a separate `lint-rt-stress` job runs
@@ -66,6 +66,6 @@ when you want to exercise them).
 - `windows-install-deps.ps1` installs the pinned msys2 lldb and the libraries it
   loads against. It holds the only copy of that pin, and every Windows job
   needing lldb calls it. Don't inline the `pacman` block into a workflow: the
-  per-PR job that checks lldb's behavior has to install the same lldb the
+  PR job that checks lldb's behavior has to install the same lldb the
   scheduled lanes do, or it guards a version nothing runs. The script's header
   carries the pin history.

--- a/.ci-scripts/pr_changed_suites.py
+++ b/.ci-scripts/pr_changed_suites.py
@@ -13,7 +13,7 @@ those blocks: `test/rt-stress/` and `test/rt-systematic/` are excluded from ever
 suite. They hold test workloads the PR suites build nothing of -- their Pony is
 compiled and run only by scheduled workflows (`stress-test-*` and
 `ponyc-weekly-checks.yml`). The stress harness's Python orchestration is linted
-by `lint-python.yml` and tested by `test-rt-stress.yml` on every PR;
+by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
 `test/rt-systematic/` carries no Python (its orchestrator lives under
 `.ci-scripts/`). So a PR touching only these
 needs none of these suites. The rules must stay in sync with the union `paths:`

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -1,6 +1,13 @@
 name: Lint GitHub Action Workflows
 
-on: pull_request
+on:
+  pull_request:
+    # actionlint reads the workflow files plus its own config
+    # (.github/actionlint.yaml, which holds the self-hosted runner labels), so a
+    # PR editing only that config still needs a lint pass.
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
 
 concurrency:
   group: lint-actions-${{ github.ref }}

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,6 +1,15 @@
 name: Lint Python Scripts
 
-on: pull_request
+on:
+  pull_request:
+    # Both jobs (`lint` for .ci-scripts, `lint-rt-stress` for test/rt-stress)
+    # run whenever either tree changes. A PR touching only one still runs the
+    # other's ruff pass over an unchanged tree -- a couple of seconds, not
+    # worth splitting the workflow to avoid.
+    paths:
+      - '.ci-scripts/**'
+      - 'test/rt-stress/**'
+      - '.github/workflows/lint-python.yml'
 
 concurrency:
   group: lint-python-${{ github.ref }}

--- a/.github/workflows/test-ci-scripts.yml
+++ b/.github/workflows/test-ci-scripts.yml
@@ -1,6 +1,10 @@
 name: Test .ci-scripts
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '.ci-scripts/**'
+      - '.github/workflows/test-ci-scripts.yml'
 
 concurrency:
   group: test-ci-scripts-${{ github.ref }}

--- a/.github/workflows/test-rt-stress.yml
+++ b/.github/workflows/test-rt-stress.yml
@@ -10,7 +10,14 @@ name: Test rt-stress
 # The Pony workloads these scripts drive are NOT run here. They run in the
 # scheduled `stress-test-*` workflows.
 
-on: pull_request
+on:
+  pull_request:
+    # windows-install-deps.ps1 is here because the Windows job runs it to
+    # install the pinned lldb.
+    paths:
+      - 'test/rt-stress/**'
+      - '.ci-scripts/windows-install-deps.ps1'
+      - '.github/workflows/test-rt-stress.yml'
 
 concurrency:
   group: test-rt-stress-${{ github.ref }}
@@ -28,8 +35,8 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Install lldb
         # The stock runner ships no lldb. Installing it keeps the real-lldb
-        # integration test running per-PR, where it guards behavior only a real
-        # lldb can: the inferior process-tree walk and the stop-on-SIGABRT
+        # integration test running in PR CI, where it guards behavior only a
+        # real lldb can: the inferior process-tree walk and the stop-on-SIGABRT
         # capture.
         run: |
           sudo apt-get update


### PR DESCRIPTION
Four per-PR workflows triggered on bare `on: pull_request`, so they ran on every PR regardless of what changed. Each now filters on the paths it actually exercises:

- `test-rt-stress` — `test/rt-stress/**`, `.ci-scripts/windows-install-deps.ps1` (its Windows job runs that script to install the pinned lldb), and its own file.
- `test-ci-scripts` — `.ci-scripts/**` and its own file.
- `lint-python` — `.ci-scripts/**`, `test/rt-stress/**`, and its own file. One union filter; both ruff jobs run when either tree changes.
- `lint-action-workflows` — `.github/workflows/**` and `.github/actionlint.yaml`. actionlint reads that config, so a PR editing only it still needs a lint pass.

Also rewords the comments and docs that called these "on every PR" / "per-PR", which the filters make false.

This is safe because ponylang repos carry no required status checks, so a path-filtered skip leaves no pending check blocking a merge.
