### PR TITLE
Document the Windows extern-C linkage trap for runtime FFI functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ..
 
 The same works for `../../tools/pony-lsp/` and `../../tools/pony-doc/`.
 
+## Declaring runtime FFI functions on Windows
+
+On the Windows MSVC build, libponyrt's `.c` files compile as C++ (`src/libponyrt/CMakeLists.txt` sets `LANGUAGE CXX` on them). A `PONY_API` function whose definition is not inside a `PONY_EXTERN_C_BEGIN`/`PONY_EXTERN_C_END` region gets a C++-mangled symbol, which the stdlib FFI — referencing the plain C name — can't resolve at link (`lld-link: undefined symbol`). Linux, macOS, and BSD compile `.c` as C, so the failure is Windows-only and won't show up in a local build there. Every runtime `.c` already wraps its definitions in that region (see `lang/stat.c`, `lang/socket.c`); put any new `PONY_API` function inside it. To check a symbol's linkage, run `dumpbin /SYMBOLS <lib> | findstr <name>` from a vcvars64 shell: a C-linkage function shows the plain name, a mangled one shows the C++ form.
+
 ## Release notes
 
 Load the `/pony-release-notes` skill for the full procedure. The one thing to know without it: add a `.release-notes/<slug>.md` file for each user-facing PR — do **not** edit `next-release.md` directly, because CI aggregates the individual files.


### PR DESCRIPTION
Adds an AGENTS.md note for a Windows-only trap. libponyrt's .c files compile as C++ under MSVC, so a PONY_API function whose definition isn't inside a PONY_EXTERN_C_BEGIN/END region gets a mangled symbol the stdlib FFI can't link. It's invisible on Linux/macOS/BSD, so it only surfaces in Windows CI as a cryptic `lld-link: undefined symbol` for a function that's plainly defined. The note points a contributor at the existing wrap-the-definition pattern before they hit it.

Not user-facing (contributor doc), so no release note.