### PR TITLE
Fail the full-program run when a test directory can't be read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,12 @@ else()
             -DWORKDIR=${PONY_OUTPUT_DIR} -DDEBUG=OFF
             -P ${CMAKE_SOURCE_DIR}/cmake/RunFullPrograms.cmake)
 
+    add_test(NAME full-program-runner-rejects-broken-config
+        COMMAND ${CMAKE_COMMAND}
+            -DRUNNER=${_full_program_runner}
+            -DWORKDIR=${PONY_OUTPUT_DIR}
+            -P ${CMAKE_SOURCE_DIR}/cmake/RunBrokenConfig.cmake)
+
     add_test(NAME stdlib-debug
         COMMAND ${CMAKE_COMMAND}
             -DPONYC=$<TARGET_FILE:ponyc>
@@ -834,6 +840,7 @@ else()
             -P ${CMAKE_SOURCE_DIR}/cmake/CheckGrammar.cmake)
 
     set_tests_properties(full-programs-debug full-programs-release
+        full-program-runner-rejects-broken-config
         stdlib-debug stdlib-release examples validate-grammar
         PROPERTIES LABELS ci-core)
 

--- a/cmake/RunBrokenConfig.cmake
+++ b/cmake/RunBrokenConfig.cmake
@@ -1,0 +1,59 @@
+# ctest wrapper: assert the full-program runner fails the run when a test's
+# configuration cannot be read (issue #5749). A test directory that has Pony
+# sources but an unreadable configuration file must fail the run, not be dropped
+# while the run still exits 0. A directory with no Pony sources is not a test and
+# must still be skipped, even when it holds an unreadable configuration file.
+#
+# The fixture is generated here rather than checked in so a deliberately broken
+# configuration file never sits in the source tree where the real full-program
+# suite would scan it.
+#
+# Args (passed with -D): RUNNER (the runner binary), WORKDIR (a scratch dir the
+# fixture is generated under).
+
+set(_fixture "${WORKDIR}/full-program-runner-broken-config")
+set(_tests "${_fixture}/tests")
+file(REMOVE_RECURSE "${_fixture}")
+file(MAKE_DIRECTORY "${_tests}/broken")
+file(MAKE_DIRECTORY "${_tests}/notatest")
+file(MAKE_DIRECTORY "${_fixture}/out")
+# A test directory: Pony sources plus an unreadable configuration.
+file(WRITE "${_tests}/broken/main.pony"
+    "actor Main\n  new create(env: Env) => None\n")
+file(WRITE "${_tests}/broken/expected-exit-code.txt" "not-a-number\n")
+# Not a test directory: an unreadable configuration but no Pony sources.
+file(WRITE "${_tests}/notatest/expected-exit-code.txt" "not-a-number\n")
+
+# The runner rejects the broken configuration during discovery, before it builds
+# anything, so no compiler is needed here.
+execute_process(
+    COMMAND "${RUNNER}" --max_parallel=1 "--output=${_fixture}/out" "${_tests}"
+    WORKING_DIRECTORY "${WORKDIR}"
+    RESULT_VARIABLE _rc
+    OUTPUT_VARIABLE _out
+    ERROR_VARIABLE _err)
+set(_output "${_out}${_err}")
+
+if(_rc EQUAL 0)
+    message(FATAL_ERROR
+        "runner exited 0 with an unreadable test configuration; it must fail "
+        "the run (issue #5749).\nOutput:\n${_output}")
+endif()
+
+# The fixture path contains "broken", so a non-zero exit for the wrong reason
+# (e.g. a missing output directory) echoes a path that would match the test
+# name. Match a phrase only the broken-configuration report emits, to confirm
+# the runner failed for the right reason.
+if(NOT "${_output}" MATCHES "could not be configured")
+    message(FATAL_ERROR
+        "runner failed but did not report the broken configuration; it may have "
+        "failed for the wrong reason.\nOutput:\n${_output}")
+endif()
+
+# The directory with no Pony sources is not a test and must be skipped, not
+# reported as broken, even though it holds an unreadable configuration.
+if("${_output}" MATCHES "notatest")
+    message(FATAL_ERROR
+        "runner reported a directory with no Pony sources as a broken test; a "
+        "non-test directory must be skipped.\nOutput:\n${_output}")
+endif()

--- a/test/full-program-runner/_test_definitions.pony
+++ b/test/full-program-runner/_test_definitions.pony
@@ -59,6 +59,20 @@ class val _TestDefinition
     stdin = stdin'
     program_args = program_args'
 
+class val _BrokenTest
+  """
+  A directory the runner could not turn into a test: it could not be opened or
+  listed, or it has Pony sources but a configuration file could not be read.
+  Unlike an entry that is not a test directory (None), the runner fails the run
+  on one of these instead of dropping it.
+  """
+  let name: String
+  let reason: String
+
+  new val create(name': String, reason': String) =>
+    name = name'
+    reason = reason'
+
 class _TestDefinitions
   let _verbose: Bool
   let _exclude: Set[String] val
@@ -125,39 +139,56 @@ class _TestDefinitions
         return
       end
 
-    recover
-      let definitions = Array[_TestDefinition]
-      for entry in (consume entries).values() do
-        if _exclude.contains(entry) then continue end
+    let definitions = recover iso Array[_TestDefinition] end
+    let broken = Array[_BrokenTest]
+    for entry in (consume entries).values() do
+      if _exclude.contains(entry) then continue end
 
-        match _get_definition(auth, dir.path.path, entry)
-        | let def: _TestDefinition => definitions.push(def)
-        end
+      match _get_definition(auth, dir.path.path, entry)
+      | let def: _TestDefinition => definitions.push(def)
+      | let bt: _BrokenTest => broken.push(bt)
       end
-      if _verbose then
-        _out.print("Found " + definitions.size().string()
-          + " test definitions.")
-      end
-      definitions
     end
 
+    if broken.size() > 0 then
+      _err.print(_Colors.red() + broken.size().string()
+        + " test(s) could not be configured; failing the run:" + _Colors.none())
+      for bt in broken.values() do
+        _err.print(_Colors.red() + "  " + bt.name + ": " + bt.reason
+          + _Colors.none())
+      end
+      return
+    end
+
+    let result: Array[_TestDefinition] val = consume definitions
+    if _verbose then
+      _out.print("Found " + result.size().string() + " test definitions.")
+    end
+    result
+
   fun _get_definition(auth: FileAuth, parent: String,
-    child: String): (_TestDefinition | None)
+    child: String): (_TestDefinition | _BrokenTest | None)
   =>
+    let fp = FilePath(auth, Path.join(parent, child))
+
+    // An entry that is not a directory is not a test; skip it. A directory the
+    // runner cannot open or list is a broken test, not a skip.
+    if not (try FileInfo(fp)?.directory else false end) then
+      return None
+    end
+
     let dir =
       try
-        Directory(FilePath(auth, Path.join(parent, child)))?
+        Directory(fp)?
       else
-        return None
+        return _BrokenTest(child, "unable to open directory")
       end
 
     let entries =
       try
         dir.entries()?
       else
-        _err.print(_Colors.red() + child
-          + ": unable to get directory entries for" + child + _Colors.none())
-        return None
+        return _BrokenTest(child, "unable to read directory entries")
       end
 
     var has_pony_sources = false
@@ -165,6 +196,7 @@ class _TestDefinitions
     var stdin_data: (String val | None) = None
     var delay_seconds: (U64 | None) = None
     var program_args = recover val Array[String] end
+    var config_error: (String | None) = None
     let ext_size = ISize.from[USize](_str_pony_extension().size())
     for entry in (consume entries).values() do
       let entry_lower = entry.lower()
@@ -178,12 +210,13 @@ class _TestDefinitions
 
       if entry_lower == _str_expected_exit_code() then
         try
-          expected_exit_code =
-            _get_expected_exit_code(FilePath.from(dir.path, entry)?)?
+          let exit_code_fp = FilePath.from(dir.path, entry)?
+          match \exhaustive\ _get_expected_exit_code(exit_code_fp)
+          | let code: I32 => expected_exit_code = code
+          | let reason: String => config_error = reason
+          end
         else
-          _err.print(_Colors.red() + child + "/" + entry
-            + ": unable to open file" + _Colors.none())
-          return None
+          config_error = "unable to read " + _str_expected_exit_code()
         end
       end
 
@@ -191,20 +224,15 @@ class _TestDefinitions
         try
           stdin_data = _get_stdin(FilePath.from(dir.path, entry)?)?
         else
-          _err.print(_Colors.red() + child + "/" + entry
-            + ": unable to open file" + _Colors.none())
-          return None
+          config_error = "unable to read " + _str_stdin()
         end
       end
 
       if entry_lower == _str_stdin_delay_seconds() then
         try
-          delay_seconds =
-            _get_delay_seconds(FilePath.from(dir.path, entry)?)?
+          delay_seconds = _get_delay_seconds(FilePath.from(dir.path, entry)?)?
         else
-          _err.print(_Colors.red() + child + "/" + entry
-            + ": unable to read a number of seconds" + _Colors.none())
-          return None
+          config_error = "unable to read " + _str_stdin_delay_seconds()
         end
       end
 
@@ -212,9 +240,7 @@ class _TestDefinitions
         try
           program_args = _get_program_args(FilePath.from(dir.path, entry)?)?
         else
-          _err.print(_Colors.red() + child + "/" + entry
-            + ": unable to open file" + _Colors.none())
-          return None
+          config_error = "unable to read " + _str_program_args()
         end
       end
     end
@@ -228,9 +254,15 @@ class _TestDefinitions
         _StdinClose
       end
 
-    if has_pony_sources then
-      _TestDefinition(child, dir.path.path, expected_exit_code, stdin,
-        program_args)
+    if not has_pony_sources then
+      None
+    else
+      match \exhaustive\ config_error
+      | let reason: String => _BrokenTest(child, reason)
+      | None =>
+        _TestDefinition(child, dir.path.path, expected_exit_code, stdin,
+          program_args)
+      end
     end
 
   fun _get_stdin(fp: FilePath): String val ? =>
@@ -273,18 +305,22 @@ class _TestDefinitions
       error
     end
 
-  fun _get_expected_exit_code(fp: FilePath): I32 ? =>
+  fun _get_expected_exit_code(fp: FilePath): (I32 | String) =>
+    """
+    The expected exit code from a test's expected-exit-code.txt, or a reason it
+    could not be read. The reason is returned rather than printed so that a
+    directory that turns out not to be a test stays quiet.
+    """
     match OpenFile(fp)
     | let f: File =>
       for line in FileLines(f) do
         try
           return line.i32()?
         else
-          _err.print(_Colors.red() + fp.path
-            + ": unable to parse expected error code: '" + line.clone() + "'"
-            + _Colors.none())
+          return "unable to parse expected exit code: '" + line.clone() + "'"
         end
-        break
       end
+      _str_expected_exit_code() + " is empty"
+    else
+      "unable to read " + _str_expected_exit_code()
     end
-    error


### PR DESCRIPTION
The full-program test runner dropped a test directory it could not read and
still exited 0, so a directory that stopped running was indistinguishable from a
test that passed. `_get_definition` returned `None` both for an entry that is
not a test directory (correctly skipped) and for a directory the runner could
not read — one that could not be opened or listed, or one with Pony sources
whose configuration file could not be read. `find` drops a `None` without
counting it, so the dropped directory never reached the coordinator and the run
exited 0 when the rest passed.

Such a directory now becomes a `_BrokenTest` instead of a `None`. `find` reports
each one and fails the run rather than dropping it. An entry that is not a
directory is still skipped, and a directory with no Pony sources is still a
non-test that is skipped silently, even when it holds an unreadable
configuration file.

The runner has no unit-test harness of its own, and the bug is about the exit
code, so the regression test is a ctest: `full-program-runner-rejects-broken-config`
generates a fixture with a malformed `expected-exit-code.txt` in a directory
with Pony sources, plus a second directory that holds the same malformed file
but no Pony sources, and checks that the runner exits non-zero, names the broken
directory, and stays silent about the non-test one.

Closes #5749
