### PR TITLE
Fix ProcessMonitor never reporting a child's exit status when stdin is open

### DIFF
--- a/.release-notes/fix-process-exit-status-stdin-open.md
+++ b/.release-notes/fix-process-exit-status-stdin-open.md
@@ -1,0 +1,7 @@
+## Fix ProcessMonitor never reporting a child's exit status when stdin is open
+
+`ProcessMonitor` did not report a child process's exit status while the parent still held the child's stdin open. A child that exited on its own — on a quit command, on bad input, or by crashing — never triggered a `ProcessNotify.dispose` call, and the program could hang.
+
+This ruled out keeping a long-running child that you write to and that exits on its own. Calling `done_writing()` to close stdin was the only way to receive the exit status, and that meant giving up writing to the child.
+
+`ProcessMonitor` now calls `ProcessNotify.dispose` with the child's exit status once the child exits, whether or not you have closed its stdin.

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -16,6 +16,8 @@ actor \nodoc\ Main is TestList
     test(_TestBadChdir)
     test(_TestBadExec)
     test(_TestChdir)
+    test(_TestChildExitsWhileStdinOpen)
+    test(_TestChildWritesThenExitsWhileStdinOpen)
     test(_TestExpect)
     test(_TestFileExecCapabilityIsRequired)
     test(_TestKillLongRunningChild)
@@ -26,6 +28,7 @@ actor \nodoc\ Main is TestList
     test(_TestStdinStdout)
     test(_TestStdinWriteBuf)
     test(_TestWaitingOnClosedProcessTwice)
+    test(_TestWriteAfterChildExitsWhileStdinOpen)
     test(_TestWritevOrdering)
 
 class \nodoc\ _PathResolver
@@ -118,6 +121,21 @@ primitive \nodoc\ _PwdArgs
       ["cmd"; "/c"; "cd"]
     else
       ["pwd"]
+    end
+
+primitive \nodoc\ _ExitCommand
+  fun path(path_resolver: _PathResolver): String ? =>
+    ifdef windows then
+      "C:\\Windows\\System32\\cmd.exe"
+    else
+      path_resolver.resolve("sh")?.path
+    end
+
+  fun args(code: I32): Array[String] val =>
+    ifdef windows then
+      ["cmd"; "/c"; "exit " + code.string()]
+    else
+      ["sh"; "-c"; "exit " + code.string()]
     end
 
 class \nodoc\ iso _TestFileExecCapabilityIsRequired is UnitTest
@@ -579,6 +597,167 @@ class \nodoc\ _TestBadExec is UnitTest
       h.long_test(30_000_000_000)
     else
       h.fail("bad_exec_path not set!")
+    end
+
+class \nodoc\ iso _TestChildExitsWhileStdinOpen is UnitTest
+  """
+  A child that exits on its own has its exit status reported even when the
+  parent never closes stdin. Regression test for
+  https://github.com/ponylang/ponyc/issues/5748.
+  """
+  fun name(): String => "process/child-exits-while-stdin-open"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun apply(h: TestHelper) =>
+    let notifier =
+      object iso is ProcessNotify
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          h.fail("process failed: " + err.string())
+          h.complete(false)
+
+        fun ref dispose(
+          process: ProcessMonitor ref,
+          child_exit_status: ProcessExitStatus)
+        =>
+          match child_exit_status
+          | Exited(7) => h.complete(true)
+          else
+            h.fail("child exited with " + child_exit_status.string())
+            h.complete(false)
+          end
+      end
+
+    try
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+
+      let path_resolver = _PathResolver(h.env.vars, file_auth)
+      let path = FilePath(file_auth, _ExitCommand.path(path_resolver)?)
+      let args = _ExitCommand.args(7)
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      let pm = ProcessMonitor(process_auth, backpressure_auth,
+        consume notifier, path, args, vars)
+      // Intentionally do not call done_writing(): the child exits on its own
+      // while the parent still holds stdin open.
+      h.dispose_when_done(pm)
+      h.long_test(30_000_000_000)
+    else
+      h.fail("Could not set up child process.")
+    end
+
+class \nodoc\ iso _TestChildWritesThenExitsWhileStdinOpen is UnitTest
+  """
+  A child that writes output and then exits on its own has that output
+  delivered and its exit status reported, even when the parent never closes
+  stdin. Regression test for https://github.com/ponylang/ponyc/issues/5748.
+  """
+  fun name(): String => "process/child-writes-then-exits-while-stdin-open"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun apply(h: TestHelper) =>
+    let notifier =
+      recover object is ProcessNotify
+        let _h: TestHelper = h
+        let _expected: String = ifdef windows then "hello\r\n" else "hello\n" end
+        let _out: String ref = String
+
+        fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
+          _out.append(consume data)
+
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          _h.fail("process failed: " + err.string())
+          _h.complete(false)
+
+        fun ref dispose(
+          process: ProcessMonitor ref,
+          child_exit_status: ProcessExitStatus)
+        =>
+          _h.assert_eq[String box](_expected, _out)
+          match child_exit_status
+          | Exited(7) => _h.complete(true)
+          else
+            _h.fail("child exited with " + child_exit_status.string())
+            _h.complete(false)
+          end
+      end end
+
+    try
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+
+      let path_resolver = _PathResolver(h.env.vars, file_auth)
+      let path = FilePath(file_auth, _ExitCommand.path(path_resolver)?)
+      let args: Array[String] val = ifdef windows then
+        ["cmd"; "/c"; "echo hello&exit 7"]
+      else
+        ["sh"; "-c"; "echo hello; exit 7"]
+      end
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      let pm = ProcessMonitor(process_auth, backpressure_auth,
+        consume notifier, path, args, vars)
+      // Intentionally do not call done_writing(): the child exits on its own
+      // while the parent still holds stdin open.
+      h.dispose_when_done(pm)
+      h.long_test(30_000_000_000)
+    else
+      h.fail("Could not set up child process.")
+    end
+
+class \nodoc\ iso _TestWriteAfterChildExitsWhileStdinOpen is UnitTest
+  """
+  Writing to a child that has already exited on its own, while the parent still
+  holds stdin open, must not stall the writer. Once the child's stdin is gone
+  the writes are dropped rather than queued behind backpressure that is never
+  released. Regression test for
+  https://github.com/ponylang/ponyc/issues/5748.
+  """
+  fun name(): String => "process/write-after-child-exits-while-stdin-open"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun apply(h: TestHelper) =>
+    try
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+
+      let path_resolver = _PathResolver(h.env.vars, file_auth)
+      let path = FilePath(file_auth, _ExitCommand.path(path_resolver)?)
+      let args = _ExitCommand.args(0)
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      let pm = ProcessMonitor(process_auth, backpressure_auth,
+        object iso is ProcessNotify end, path, args, vars)
+      // Keep writing after the child has exited, without calling done_writing().
+      // If a write stalled the writer under unreleased backpressure, this test
+      // would time out.
+      _StdinFlooder(h, pm)
+      h.dispose_when_done(pm)
+      h.long_test(30_000_000_000)
+    else
+      h.fail("Could not set up child process.")
+    end
+
+actor \nodoc\ _StdinFlooder
+  let _h: TestHelper
+  let _pm: ProcessMonitor
+  var _remaining: USize = 200_000
+
+  new create(h: TestHelper, pm: ProcessMonitor) =>
+    _h = h
+    _pm = pm
+    _flood()
+
+  be _flood() =>
+    if _remaining == 0 then
+      _h.complete(true)
+    else
+      _pm.write("x")
+      _remaining = _remaining - 1
+      _flood()
     end
 
 class \nodoc\ iso _TestLongRunningChild is UnitTest

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -204,7 +204,6 @@ actor ProcessMonitor is AsioEventNotify
       // a child (or haven't started one yet).
       return
     else
-      Backpressure.release(_backpressure_auth)
       _child.kill()
       _close()
     end
@@ -269,6 +268,7 @@ actor ProcessMonitor is AsioEventNotify
     """
     if not _closed then
       _closed = true
+      Backpressure.release(_backpressure_auth)
       _stdin.close()
       _stdout.close()
       _stderr.close()
@@ -339,10 +339,7 @@ actor ProcessMonitor is AsioEventNotify
     """
     If neither stdout nor stderr are open we close down and exit.
     """
-    if _stdin.is_closed() and
-      _stdout.is_closed() and
-      _stderr.is_closed()
-    then
+    if _stdout.is_closed() and _stderr.is_closed() then
        _close()
     end
 
@@ -430,7 +427,14 @@ actor ProcessMonitor is AsioEventNotify
     pending writes. Save everything unwritten into _pending and apply
     backpressure.
     """
-    if (not _closed) and not _stdin.is_closed() and (_pending.size() == 0) then
+    if _closed or _stdin.is_closed() then
+      // The child's stdin is gone, so this data can never be sent. Drop it
+      // rather than queue it and apply backpressure that nothing would ever
+      // release.
+      return
+    end
+
+    if _pending.size() == 0 then
       // Send as much data as possible.
       (let len, let errno) = _stdin.write(data, 0)
 


### PR DESCRIPTION
`ProcessMonitor` reaped the child and called `ProcessNotify.dispose` only once the parent had closed the child's stdin. A child that exits on its own while the parent still holds stdin open — on a quit command, on bad input, or by crashing — was never reaped: no exit status arrived, and the program hung.

`_try_shutdown` required stdin, stdout, and stderr all closed before calling `_close()`, and `_close()` is what starts the wait for the child. When the child exits, stdout and stderr reach EOF and close, but nothing closes the parent's write end of stdin outside of `done_writing()`, a write error, or `dispose()`. The function's own docstring — "If neither stdout nor stderr are open we close down and exit" — describes the correct behavior; the code had diverged from it. This gates reaping on stdout and stderr alone.

Removing the stdin requirement means `_close()` can now run while the client is still writing (the child exited on its own and the client never called `done_writing()`). Two follow-on changes keep that path correct:

- `_close()` releases backpressure, so a child that exits with data still queued does not leave the monitor's backpressure applied. The release moved out of `dispose()`, which already routes through `_close()`.
- `_write_final` drops writes once the child's stdin is gone instead of queueing them and applying backpressure that nothing would release. Without this, a client that keeps writing after the child exits was muted by unreleased backpressure and the program hung — the same kind of hang this fixes, reached by a different route.

Three regression tests cover a child that exits on its own with stdin held open, a child that writes output and then exits the same way, and a client that keeps writing after the child has exited. Each hangs or fails on the unfixed code and passes with the fix.

## Divergences

- A child that closes its own stdout and stderr but keeps running now has its stdin closed and is reaped once both output streams reach EOF. Before this change, such a child was never reaped while the parent held stdin open, so the program hung until the child exited on its own. The fix turns that hang into a clean shutdown. The behavior change to note: a program that deliberately closes the child's stdout and stderr but keeps writing to its stdin will now have that stdin closed once both output streams close; before, it could keep writing. This is an unusual pattern, and the prior behavior for the common case — a child that exits on its own — was a hang.

## Parked for review

- This uses "stdout and stderr both at EOF" as the signal that the child is done, matching the docstring and the issue. An alternative is to drive reaping off an independent `waitpid` poll, so that closing the parent's stdin is tied to the child actually exiting rather than to its output streams closing. That would also address two pre-existing limitations: a grandchild that inherits stdout/stderr keeps the child from being detected as exited (now filed as #5764), and the divergence above. It is a larger change than this fix, so I have left it as a design question rather than folding it in.

Closes #5748

