### PR TITLE
Run the pony-compiler CI suite when the CMake build system changes

### DIFF
--- a/.ci-scripts/pr_changed_suites.py
+++ b/.ci-scripts/pr_changed_suites.py
@@ -8,19 +8,30 @@ PR's changed paths on stdin (one per line) and writes `<suite>=true|false` for
 each suite to stdout in `$GITHUB_OUTPUT` (`name=value`) format.
 
 The rules are the three suites' original `paths:` blocks, transcribed as plain
-prefix/suffix/exact tests -- no glob engine -- plus a deliberate addition not in
-those blocks: `test/rt-stress/` and `test/rt-systematic/` are excluded from every
-suite. They hold test workloads the PR suites build nothing of -- their Pony is
-compiled and run only by scheduled workflows (`stress-test-*` and
-`ponyc-weekly-checks.yml`). The stress harness's Python orchestration is linted
-by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
+prefix/suffix/exact tests -- no glob engine -- plus two deliberate departures
+from those blocks. First, `test/rt-stress/` and `test/rt-systematic/` are
+excluded from every suite. They hold test workloads the PR suites build nothing
+of -- their Pony is compiled and run only by scheduled workflows (`stress-test-*`
+and `ponyc-weekly-checks.yml`). The stress harness's Python orchestration is
+linted by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
 `test/rt-systematic/` carries no Python (its orchestrator lives under
-`.ci-scripts/`). So a PR touching only these
-needs none of these suites. The rules must stay in sync with the union `paths:`
-filter at the top of `pr.yml`: a file that triggers any suite here must also
-match the workflow-level filter, or the workflow never starts and that suite
-silently never runs. (`ponyc` is a subset of `tools`, so the union is exactly
-`tools` plus `pony_compiler`.)
+`.ci-scripts/`). So a PR touching only these needs none of these suites.
+
+Second, the shared CMake build system -- the top-level `CMakeLists.txt`,
+`CMakePresets.json`, and `cmake/` -- triggers `pony_compiler`. That suite builds
+`pony-compiler-tests`, a target that `add_pony_binary` (in
+`cmake/PonyBinary.cmake`) defines and `cmake --build --preset debug --target
+pony-compiler-tests` compiles, so a build-system change can break its build.
+`ponyc` and `tools` already match these files through their broad rules; only
+`pony_compiler`'s allowlist would otherwise skip them. Build-system doc and yaml
+files stay excluded, so this stays in sync with the union filter (below) without
+a re-include.
+
+The rules must stay in sync with the union `paths:` filter at the top of
+`pr.yml`: a file that triggers any suite here must also match the workflow-level
+filter, or the workflow never starts and that suite silently never runs.
+(`ponyc` is a subset of `tools`, so the union is exactly `tools` plus
+`pony_compiler`.)
 
 Editing `pr.yml` itself re-triggers every suite: each suite's original filter
 re-included its own workflow file, and now there is one shared file.
@@ -51,9 +62,17 @@ def matches_ponyc(path):
         or path == WORKFLOW_FILE
 
 
+def matches_build_system(path):
+    return not excluded(path) and (
+        path == 'CMakeLists.txt'
+        or path == 'CMakePresets.json'
+        or path.startswith('cmake/'))
+
+
 def matches_pony_compiler(path):
     return (path.startswith('src/libponyc/')
             or path.startswith('tools/lib/ponylang/pony_compiler/')
+            or matches_build_system(path)
             or path == WORKFLOW_FILE)
 
 

--- a/.ci-scripts/pr_changed_suites_test.py
+++ b/.ci-scripts/pr_changed_suites_test.py
@@ -35,6 +35,20 @@ SINGLE_PATH_TABLE = [
     ('tools/lib/ponylang/pony_compiler/pass.pony', (False, True, True)),
     # plain stdlib code: ponyc + tools.
     ('packages/json/json.pony', (True, False, True)),
+    # the shared CMake build system builds pony-compiler-tests, so it triggers
+    # pony_compiler too (as well as ponyc and tools via their broad rules).
+    ('cmake/PonyBinary.cmake', (True, True, True)),
+    ('CMakeLists.txt', (True, True, True)),
+    ('CMakePresets.json', (True, True, True)),
+    # boundary guards for the build-system rule. Exact-match, not endswith: a
+    # tool's own CMakeLists and the vendored-LLVM (lib/) presets are NOT the
+    # top-level files. Prefix needs the slash: a `cmakefoo/` sibling must not
+    # match `cmake/`. And a build-system doc stays excluded everywhere, keeping
+    # the classifier in sync with the union filter (which drops **/*.md).
+    ('tools/pony-lint/CMakeLists.txt', (False, False, True)),
+    ('lib/CMakePresets.json', (True, False, True)),
+    ('cmakefoo/build.cmake', (True, False, True)),
+    ('cmake/notes.md', (False, False, False)),
     # scheduled-only test workloads trigger no suite: nothing under
     # test/rt-stress/ or test/rt-systematic/ feeds test-ci-core or the tools
     # build, so the whole directory is excluded -- a .py orchestration file and


### PR DESCRIPTION
`pr_changed_suites.py` classifies a PR into the `ponyc`, `pony_compiler`, and `tools` CI suites. Its `pony_compiler` rule matched only the compiler library source, not the CMake build system that builds `pony-compiler-tests`. So a change to `cmake/` (including `add_pony_binary` in `cmake/PonyBinary.cmake`, which compiles `pony-compiler-tests`), the top-level `CMakeLists.txt`, or `CMakePresets.json` classified as `pony_compiler=false`, and the suite that builds and runs those tests skipped. No other suite builds `pony-compiler-tests`, so the break would go untested. This surfaced on #5755, whose `cmake/PonyBinary.cmake` edit skipped the `pony-compiler` suite.

The fix adds a `matches_build_system` predicate — `cmake/`, top-level `CMakeLists.txt`, `CMakePresets.json` — to the `pony_compiler` rule. `ponyc` and `tools` already match those files through their broad rules, and the workflow-level `paths:` filter in `pr.yml` already includes them, so only the classifier needed changing.

Scope: the rule deliberately leaves out `lib/` (vendored LLVM) and `src/libponyrt/`. Those affect runtime behavior, which the `ponyc` suite already tests comprehensively, and they don't change how `pony-compiler-tests` is built.